### PR TITLE
fix: stale-transcript live sessions + port stashed chat-view features

### DIFF
--- a/bin/romp-askparse
+++ b/bin/romp-askparse
@@ -45,6 +45,17 @@ FOOTER_RE = re.compile(r"to navigate|Enter to select|Esc to (cancel|exit)")
 # the message box, NOT a pending footer-less confirmation (PATH C below).
 COMPOSER_RE = re.compile(r"⏵⏵|shift\s*\+\s*tab to cycle|auto mode (on|off)|\bctx:\s*\d+%")
 
+# The diff frame in an Edit/Write/MultiEdit permission prompt is fenced by a row
+# of ╌ (U+254C) / ┄ (U+2504) dashes — distinct from the ─ box border above. The
+# diff body sits between two such fences; each line is `<lineno> <marker><text>`
+# (marker: '-' deleted, '+' added, ' ' context).
+DIFF_FENCE_RE = re.compile(r"^\s*[╌┄]{3,}\s*$")
+# A numbered diff line: "<lineno> <rest>". Group 1 is everything after the line
+# number + its single separator space, right-trimmed of the TUI's width padding.
+DIFF_NUM_RE = re.compile(r"^\s*\d+\s(.*?)\s*$")
+BOX_TOP_RE = re.compile(r"^\s*╭")
+BOX_BOT_RE = re.compile(r"^\s*╰")
+
 # Side-by-side preview: match VERTICAL and CORNER box glyphs ONLY — never
 # horizontals (─━═) or the em/en dashes that legitimately appear in a diagram.
 BOX_EDGE_RE = re.compile(r"[│┃┆┇┊┋╎╏║▏▕╭╮╯╰┌┐┘└┏┓┛┗╔╗╝╚├┤┣┫╠╣]")
@@ -74,6 +85,189 @@ def is_indented(line):
 # The `←  ☒ Header  ✔ Submit  →` tab bar (multi-select AND the wizard).
 def is_tab_bar(line):
     return _TABBAR_ARROW_RE.search(line) is not None and _TABBAR_KIND_RE.search(line) is not None
+
+
+def is_diff_fence(line):
+    return DIFF_FENCE_RE.match(line) is not None
+
+
+def is_box_edge(line):
+    return BOX_TOP_RE.match(line) is not None or BOX_BOT_RE.match(line) is not None or re.match(r"^\s*│", line) is not None
+
+
+def _strip_box(s):
+    """Remove │-border from a boxed line."""
+    return re.sub(r"\s*│\s*$", "", re.sub(r"^\s*│\s?", "", s))
+
+
+def _lead_ws(s):
+    m = re.match(r"^(\s*)", s)
+    return len(m.group(1)) if m else 0
+
+
+def find_diff_region(lines, end_idx):
+    """Find a ╌-fenced or ╭-boxed diff region before end_idx.
+
+    Returns (frame_top, start, end, strip_fn) or None. strip_fn maps a raw line
+    to its inner content (identity for ╌-fences, border-strip for boxes).
+    """
+    fences = [i for i in range(end_idx) if is_diff_fence(lines[i])]
+    if len(fences) >= 2:
+        return (fences[0], fences[0] + 1, fences[-1], lambda s: s)
+    top = -1
+    bot = -1
+    for i in range(end_idx):
+        if top < 0:
+            if BOX_TOP_RE.match(lines[i]):
+                top = i
+        elif BOX_BOT_RE.match(lines[i]):
+            bot = i
+            break
+    if top >= 0 and bot > top:
+        return (top, top + 1, bot, _strip_box)
+    return None
+
+
+def extract_diff_block(lines, end_idx):
+    """Pull the framed diff (and file header) out of a permission pane.
+
+    Returns a dict with optional keys: diff, fileHead, planBody.
+
+    Each diff line is `<lineno> <marker><text>` -> emit "-text" / "+text" / "  text"
+    (a unified diff the webview colors). A line with NO line number is a soft-wrap
+    continuation and folds into the previous.
+
+    New-file Writes have NO marker column -- line numbers sit directly before
+    content -- so `- item` (a markdown bullet) would be misread as a deletion.
+    The marker column exists ONLY when EVERY numbered line begins with "+", "-",
+    or space.
+
+    When a rounded box holds no numbered diff lines, its content is plan markdown
+    (ExitPlanMode) -- returned as planBody, not as a diff.
+    """
+    region = find_diff_region(lines, end_idx)
+    if not region:
+        return {}
+    frame_top, start, end, strip_fn = region
+    # header ABOVE the frame: from the nearest ─ rule down to the frame.
+    h_start = 0
+    for i in range(frame_top - 1, -1, -1):
+        if is_rule(lines[i]):
+            h_start = i + 1
+            break
+    above = []
+    for i in range(h_start, frame_top):
+        t = lines[i]
+        if not is_blank(t) and not is_rule(t) and not is_diff_fence(t):
+            above.append(t.strip())
+    # inner lines: numbered lines are the diff; non-numbered lines BEFORE the
+    # first diff row are the in-box header (NotebookEdit's path + subtitle).
+    rows = []         # list of rest strings (content after "<lineno> ")
+    in_box_head = []
+    inner_raw = []
+    for i in range(start, end):
+        t = strip_fn(lines[i])
+        inner_raw.append(t.rstrip())
+        if is_diff_fence(t):
+            continue
+        m = DIFF_NUM_RE.match(t)
+        if m:
+            rows.append(m.group(1))  # rest (marker column kept)
+        elif rows and t.strip():
+            rows[-1] += " " + t.strip()  # soft-wrap continuation
+        elif not rows and t.strip():
+            in_box_head.append(t.strip())  # in-box header line
+    above_head = "\n".join(above) if above else None
+    # No numbered lines -> the box is markdown (a plan), not a diff.
+    if not rows:
+        plan_body = "\n".join(inner_raw).strip()
+        result = {}
+        if above_head:
+            result["fileHead"] = above_head
+        if plan_body:
+            result["planBody"] = plan_body
+        return result
+    file_head_parts = above + in_box_head
+    file_head = "\n".join(file_head_parts) if file_head_parts else None
+    marked = [r for r in rows if r != ""]
+    has_marker_col = len(marked) > 0 and all(r[0] in ("+", "-", " ") for r in marked)
+    out = []
+    for r in rows:
+        if not has_marker_col:
+            out.append("+" + r)  # new file: whole line is an addition
+        elif r == "":
+            out.append("  ")     # blank context line
+        else:
+            mk = r[0]
+            if mk in ("+", "-"):
+                out.append(mk + r[1:])
+            else:
+                out.append("  " + r[1:])
+    result = {}
+    result["diff"] = "\n".join(out)
+    if file_head:
+        result["fileHead"] = file_head
+    return result
+
+
+def split_above(lines, first_opt_idx):
+    """Split the lines above the option block into header, question, body, and diff fields.
+
+    Blank lines break the region into blocks; the block nearest the options seeds
+    the QUESTION. A block above it that's indented DEEPER than the question is the
+    detail BODY (WebFetch url+prompt, Bash command, MCP call); a same-or-less-
+    indented block is more question text and folds in.
+    """
+    header = None
+    blocks = []  # bottom-up; lines bottom-up within a block
+    cur = None
+    floor = max(0, first_opt_idx - 40)
+    for k in range(first_opt_idx - 1, floor - 1, -1):
+        t = lines[k]
+        if is_rule(t) or is_diff_fence(t) or is_box_edge(t):
+            break
+        if is_blank(t):
+            if cur:
+                blocks.append(cur)
+                cur = None
+            continue
+        if is_tab_bar(t):
+            h = re.search(r"☐\s*([^☐☒✔✓→]+?)\s+[☐☒✔✓]", t) or \
+                re.search(r"[☐☒]\s*([^☐☒✔✓→]+?)\s+[☐☒✔✓]", t)
+            if h and not header:
+                header = h.group(1).strip()
+            continue
+        hm = HEADER_RE.match(t)
+        if hm and not header:
+            header = hm.group(1).strip()
+            continue
+        if not cur:
+            cur = {"lines": [t.strip()], "indent": _lead_ws(t)}
+        else:
+            cur["lines"].append(t.strip())
+            cur["indent"] = min(cur["indent"], _lead_ws(t))
+    if cur:
+        blocks.append(cur)
+
+    question_lines = []
+    body = None
+    if blocks:
+        q_indent = blocks[0]["indent"]
+        question_lines = list(reversed(blocks[0]["lines"]))  # top-down
+        for i in range(1, len(blocks)):
+            if blocks[i]["indent"] > q_indent:
+                body = "\n".join(reversed(blocks[i]["lines"]))
+                break
+            question_lines = list(reversed(blocks[i]["lines"])) + question_lines
+    diff_result = extract_diff_block(lines, first_opt_idx)
+    return {
+        "header": header,
+        "question": " ".join(question_lines) if question_lines else None,
+        "body": body,
+        "diff": diff_result.get("diff"),
+        "fileHead": diff_result.get("fileHead"),
+        "planBody": diff_result.get("planBody"),
+    }
 
 
 def preview_border_col(lines):
@@ -164,7 +358,8 @@ def parse_options(lines, block, end_idx):
     return {"options": options, "cursor": cursor, "cursorFound": cursor_found, "hasCheckbox": has_checkbox}
 
 
-def _mk(kind, header, question, opts, preview=None, chosen=None, pairs=None):
+def _mk(kind, header, question, opts, preview=None, chosen=None, pairs=None,
+         diff=None, body=None, file_head=None, plan_body=None):
     sig_opts = "|".join(
         "%s:%s:%s" % (o["n"], o["label"], "" if o.get("checked") is None else ("x" if o["checked"] else "o"))
         for o in opts["options"]
@@ -176,6 +371,10 @@ def _mk(kind, header, question, opts, preview=None, chosen=None, pairs=None):
         ",".join(chosen or []),
         ";".join("%s=%s" % (p["q"], p["a"]) for p in (pairs or [])),
         ("pv%d:%s" % (len(preview), preview)) if preview else "",
+        ("diff:%d" % len(diff)) if diff else "",
+        ("body:%d" % len(body)) if body else "",
+        ("fh:%d" % len(file_head)) if file_head else "",
+        ("plan:%d" % len(plan_body)) if plan_body else "",
     ])
     result = {
         "kind": kind,
@@ -190,6 +389,14 @@ def _mk(kind, header, question, opts, preview=None, chosen=None, pairs=None):
         "preview": preview,
         "sig": sig,
     }
+    if diff is not None:
+        result["diff"] = diff
+    if file_head is not None:
+        result["fileHead"] = file_head
+    if body is not None:
+        result["body"] = body
+    if plan_body is not None:
+        result["planBody"] = plan_body
     return result
 
 
@@ -228,40 +435,16 @@ def parse_ask_pane(pane, cols=None):
         block = option_block(lines, foot_idx)
         if block:
             first_opt_idx = block[0]
-            header = None
-            q_lines = []
-            k = first_opt_idx - 1
-            while k >= 0 and len(q_lines) + (1 if header else 0) < 8:
-                t = lines[k]
-                if is_rule(t):
-                    break
-                if is_blank(t):
-                    k -= 1
-                    continue
-                if is_tab_bar(t):
-                    # Best-effort tab name: the first unanswered ☐ tab (the active
-                    # one in forward flow), else the first tab.
-                    h = re.search(r"☐\s*([^☐☒✔✓→]+?)\s+[☐☒✔✓]", t) or \
-                        re.search(r"[☐☒]\s*([^☐☒✔✓→]+?)\s+[☐☒✔✓]", t)
-                    if h and not header:
-                        header = h.group(1).strip()
-                    k -= 1
-                    continue
-                hm = HEADER_RE.match(t)
-                if hm and not header:
-                    header = hm.group(1).strip()
-                    k -= 1
-                    continue
-                q_lines.append(t.strip())
-                k -= 1
-            question = " ".join(reversed(q_lines)) if q_lines else None
+            sa = split_above(lines, first_opt_idx)
             opts = parse_options(lines, block, foot_idx)
             if opts["options"]:
                 # ONLY checkbox rows mean multi-select — the ✔ Submit tab bar also
                 # tops the multi-question wizard, whose per-question screens are
                 # single-select.
                 kind = "multi" if opts["hasCheckbox"] else "single"
-                return _mk(kind, header, question, opts, preview)
+                return _mk(kind, sa["header"], sa["question"], opts, preview,
+                           diff=sa["diff"], body=sa["body"],
+                           file_head=sa["fileHead"], plan_body=sa["planBody"])
 
     # PATH B — the multi-select SUBMIT/review screen (no footer; "Submit answers").
     end = len(lines)
@@ -313,25 +496,10 @@ def parse_ask_pane(pane, cols=None):
             opts = parse_options(lines, block, end)
             if len(opts["options"]) >= 2 and opts["cursorFound"] and not opts["hasCheckbox"]:
                 first_opt_idx = block[0]
-                header = None
-                q_lines = []
-                k = first_opt_idx - 1
-                while k >= 0 and len(q_lines) < 8:
-                    t = lines[k]
-                    if is_rule(t):
-                        break
-                    if is_blank(t):
-                        k -= 1
-                        continue
-                    hm = HEADER_RE.match(t)
-                    if hm and not header:
-                        header = hm.group(1).strip()
-                        k -= 1
-                        continue
-                    q_lines.append(t.strip())
-                    k -= 1
-                return _mk("single", header,
-                           " ".join(reversed(q_lines)) if q_lines else None, opts, preview)
+                sa = split_above(lines, first_opt_idx)
+                return _mk("single", sa["header"], sa["question"], opts, preview,
+                           diff=sa["diff"], body=sa["body"],
+                           file_head=sa["fileHead"], plan_body=sa["planBody"])
 
     return None
 

--- a/bin/romp-gallery
+++ b/bin/romp-gallery
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+// Gallery dev server — serves the acceptance gallery at http://127.0.0.1:5599/gallery.html
+// with esbuild watch + SSE live-reload.
+//
+// Usage: node bin/romp-gallery [--open]
+//   --open   launch a browser after starting
+
+const http = require("http");
+const path = require("path");
+const fs = require("fs");
+const esbuild = require(path.join(__dirname, "../chat-view/node_modules/esbuild"));
+
+const PORT = 5599;
+const CHAT_VIEW = path.join(__dirname, "../chat-view");
+const UI = path.join(__dirname, "../ui");
+const DIST = path.join(CHAT_VIEW, "dist");
+const GALLERY_DIST = path.join(CHAT_VIEW, "dist-gallery");
+
+// SSE clients waiting for reload
+const sseClients = new Set();
+
+function notifyReload() {
+  for (const res of sseClients) {
+    res.write("event: reload\ndata: {}\n\n");
+  }
+}
+
+// Build the gallery driver (fixtures + gallery.ts → one browser IIFE)
+async function buildGallery(watch) {
+  const opts = {
+    entryPoints: [path.join(CHAT_VIEW, "src/dev/gallery.ts")],
+    nodePaths: [path.join(CHAT_VIEW, "node_modules")],
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    target: "es2020",
+    outfile: path.join(GALLERY_DIST, "gallery.js"),
+    sourcemap: true,
+    logLevel: "info",
+  };
+  if (watch) {
+    const ctx = await esbuild.context(opts);
+    await ctx.watch();
+    return ctx;
+  }
+  await esbuild.build(opts);
+}
+
+// Build the real webview bundle (render.ts + styles.css) — same as `npm run build`
+async function buildWebview(watch) {
+  const opts = {
+    entryPoints: [
+      path.join(UI, "webview/render.ts"),
+      path.join(UI, "webview/styles.css"),
+    ],
+    nodePaths: [path.join(CHAT_VIEW, "node_modules")],
+    bundle: true,
+    format: "iife",
+    platform: "browser",
+    target: "es2020",
+    outdir: GALLERY_DIST,
+    external: ["*.png", "*.svg"],
+    sourcemap: true,
+    logLevel: "info",
+  };
+  if (watch) {
+    const ctx = await esbuild.context(opts);
+    await ctx.watch();
+    return ctx;
+  }
+  await esbuild.build(opts);
+}
+
+// Generate gallery.html — the chat skeleton + sidebar + both bundles
+function galleryHtml() {
+  // Load the skeleton from page-skeleton.ts (already compiled to dist by npm run build)
+  // We inline a minimal version here to avoid a build dependency.
+  const chatBody = `
+  <div id="winframe"></div>
+  <div id="tabbar"><span id="tabs"></span></div>
+  <div id="ledger" style="display:none"></div>
+  <div id="content"><div id="live-ask" style="display:none"></div></div>
+  <div id="footer">
+    <div id="statusline" class="statusline"></div>
+    <div id="composer"><textarea id="composer-input" rows="1" placeholder="Message…"></textarea></div>
+  </div>`;
+
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>romp gallery</title>
+<link rel="stylesheet" href="/styles.css">
+<style>
+  :root {
+    --fg: #d4d4d4; --dim: #888; --bg: #1e1e1e;
+    --box-bg: #252526; --box-border: #3c3c3c;
+    --green: #74c991; --err: #e56e6e;
+    --mono: 'Menlo', 'Consolas', 'Courier New', monospace;
+    --rail-bg: rgba(255,255,255,0.06);
+    --accent: #9cd2ff; --accent-fg: #0c1a2e;
+    --st-working-bg: #f9d849; --st-ready-bg: #74c991;
+    --st-awaiting-bg: #9cd2ff; --st-permission-bg: #f85b5a;
+    --check-bg: #9cd2ff;
+    --vscode-input-background: rgba(255,255,255,0.05);
+    --vscode-input-foreground: #d4d4d4;
+    --vscode-input-border: #3c3c3c;
+  }
+  html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
+    font: 13px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  #gallery-layout { display: flex; height: 100%; }
+  #gallery-sidebar {
+    width: 220px; min-width: 180px; overflow-y: auto; padding: 12px 0;
+    border-right: 1px solid var(--box-border); background: #181818;
+    flex: 0 0 auto;
+  }
+  .gal-group {
+    font-size: 10px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.08em; color: var(--dim); padding: 14px 14px 4px;
+  }
+  .gal-item {
+    padding: 5px 14px; cursor: pointer; color: var(--fg); font-size: 12.5px;
+    border-left: 3px solid transparent;
+  }
+  .gal-item:hover { background: rgba(255,255,255,0.05); }
+  .gal-item.active { background: rgba(156,210,255,0.1); border-left-color: var(--accent); font-weight: 600; }
+  #gallery-main { flex: 1 1 auto; display: flex; flex-direction: column; overflow: hidden; }
+</style>
+</head>
+<body>
+<div id="gallery-layout">
+  <div id="gallery-sidebar"></div>
+  <div id="gallery-main">
+    ${chatBody}
+  </div>
+</div>
+<script>
+  // Shim acquireVsCodeApi so render.ts's postMessage calls don't throw
+  window.acquireVsCodeApi = function() {
+    return { postMessage: function() {}, getState: function() { return {}; }, setState: function() {} };
+  };
+  // Stub fetch (render.ts fetches /palette at load)
+  if (!window.fetch) window.fetch = function() { return Promise.resolve({ json: function() { return Promise.resolve({}); } }); };
+</script>
+<script src="/render.js"></script>
+<script src="/gallery.js"></script>
+</body>
+</html>`;
+}
+
+// Static file server
+const MIME = { ".js": "text/javascript", ".css": "text/css", ".html": "text/html", ".map": "application/json", ".svg": "image/svg+xml", ".png": "image/png" };
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+
+  if (url.pathname === "/sse") {
+    res.writeHead(200, { "Content-Type": "text/event-stream", "Cache-Control": "no-cache", "Connection": "keep-alive" });
+    res.write(":\n\n");
+    sseClients.add(res);
+    req.on("close", () => sseClients.delete(res));
+    return;
+  }
+
+  if (url.pathname === "/" || url.pathname === "/gallery.html") {
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(galleryHtml());
+    return;
+  }
+
+  // Serve from dist-gallery first, then dist (for media), then chat-view/media
+  const basename = path.basename(url.pathname);
+  const candidates = [
+    path.join(GALLERY_DIST, basename),
+    path.join(DIST, basename),
+    path.join(CHAT_VIEW, "media", basename),
+  ];
+  for (const fp of candidates) {
+    if (fs.existsSync(fp)) {
+      const ext = path.extname(fp);
+      res.writeHead(200, { "Content-Type": MIME[ext] || "application/octet-stream" });
+      fs.createReadStream(fp).pipe(res);
+      return;
+    }
+  }
+  res.writeHead(404);
+  res.end("not found");
+});
+
+async function main() {
+  fs.mkdirSync(GALLERY_DIST, { recursive: true });
+
+  // Watch for source changes and notify SSE clients
+  const watchPlugin = {
+    name: "gallery-reload",
+    setup(build) {
+      build.onEnd(() => notifyReload());
+    },
+  };
+
+  const galOpts = {
+    entryPoints: [path.join(CHAT_VIEW, "src/dev/gallery.ts")],
+    nodePaths: [path.join(CHAT_VIEW, "node_modules")],
+    bundle: true, format: "iife", platform: "browser", target: "es2020",
+    outfile: path.join(GALLERY_DIST, "gallery.js"),
+    sourcemap: true, logLevel: "info", plugins: [watchPlugin],
+  };
+  const webOpts = {
+    entryPoints: [
+      path.join(UI, "webview/render.ts"),
+      path.join(UI, "webview/styles.css"),
+    ],
+    nodePaths: [path.join(CHAT_VIEW, "node_modules")],
+    bundle: true, format: "iife", platform: "browser", target: "es2020",
+    outdir: GALLERY_DIST, external: ["*.png", "*.svg"],
+    sourcemap: true, logLevel: "info", plugins: [watchPlugin],
+  };
+
+  const [galCtx, webCtx] = await Promise.all([
+    esbuild.context(galOpts),
+    esbuild.context(webOpts),
+  ]);
+  await Promise.all([galCtx.watch(), webCtx.watch()]);
+
+  server.listen(PORT, () => {
+    const url = `http://127.0.0.1:${PORT}/gallery.html`;
+    console.log(`romp gallery → ${url}`);
+    if (process.argv.includes("--open")) {
+      const cmd = process.platform === "darwin" ? "open" : "xdg-open";
+      require("child_process").exec(`${cmd} ${url}`);
+    }
+  });
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/bin/romp-judge
+++ b/bin/romp-judge
@@ -64,7 +64,7 @@ def _rebind_state(path):
 # INDEXING on Haiku, judgment-heavy TRIAGE on Sonnet.
 INDEX_MODEL  = "claude-haiku-4-5-20251001"   # captioner + archiver (index tier — high volume, low stakes)
 TRIAGE_MODEL = "claude-sonnet-4-6"           # planner + courier + closer (triage tier — judgment)
-WINDOW      = 48 * 3600                  # only caption transcripts touched in the last N hours (matches the parse horizon)
+WINDOW      = int(10.5 * 24 * 3600)      # only caption transcripts touched within this window (default 1.5 weeks)
 BUDGET      = 60                         # max captions written per pass
 FAIRNESS    = 10                         # max captions per session per pass (so one busy session can't starve the rest)
 ARCH_BUDGET = 30                         # max session archives (re)built per pass

--- a/bin/romp-kernel
+++ b/bin/romp-kernel
@@ -1223,6 +1223,7 @@ def _timeline_sessions(now, tmux, live_only=False):
 # closeTab / endSession; the Python rewrite dropped them, so the webview's + picker stayed blank and
 # "New session" spun on its 30s "Opening…" modal forever. Ported here (the user 2026-06-15).
 NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+PICKER_MAX_AGE_S = int(os.environ.get("ROMP_PICKER_DAYS", "14")) * 86400
 
 
 def _rel_ago(now, t):
@@ -1244,18 +1245,42 @@ def _live_names(tmux):
 
 def _session_list(now, tmux):
     """Picker payload: recent sessions, RUNNING ones first then by recency, each
-    {id,name,color,running,time,summary} — the shape render.ts's renderPicker expects."""
+    {id,name,color,running,time,summary} — the shape render.ts's renderPicker expects.
+    Dead sessions older than PICKER_MAX_AGE_S (default 14 days) are filtered out."""
     live = set(tmux or {})
+    cutoff = now - PICKER_MAX_AGE_S
     items = []
     for s in _sessions(now)[:150]:
         sid = s["sid"]
+        running = sid in live
+        if not running and s.get("mtime", 0) < cutoff:
+            continue
         arch = jd.load_archive(sid) or {}
         items.append({"id": sid, "name": s["name"], "color": _name_color(sid),
-                      "running": sid in live, "dir": _tilde(_cwd_of(sid)),   # recent-dirs source for the new-session field
-                      "time": "running" if sid in live else _rel_ago(now, s["mtime"]),
+                      "running": running, "dir": _tilde(_cwd_of(sid)),
+                      "time": "running" if running else _rel_ago(now, s["mtime"]),
                       "summary": arch.get("headline", "")})
     items.sort(key=lambda it: 0 if it["running"] else 1)   # stable: running first, recency within
     return items
+
+
+def _forget_name(name, live_names):
+    """Drop every names-record carrying `name` so a stale session leaves the picker.
+    Refuses to forget a name that's still live. Returns how many records were removed."""
+    if name in live_names:
+        return 0
+    removed = 0
+    names_dir = jd.STATE / "names"
+    if not names_dir.is_dir():
+        return 0
+    for p in names_dir.iterdir():
+        try:
+            stored_name = p.read_text().split("\t")[0]
+            if stored_name == name:
+                p.unlink(); removed += 1
+        except Exception:
+            pass
+    return removed
 
 
 _DEFAULT_DIR_FILE = Path(os.path.expanduser("~/.config/romp/default-dir"))
@@ -1454,7 +1479,7 @@ def _drive(msg, client):
         return False
     t = msg.get("type")
     ID_OPS = ("sendMessage", "interrupt", "compactSession", "answerAsk", "navAsk", "toggleAsk", "submitAsk",
-              "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "apiRetry", "setModel", "setEffort", "setMode",
+              "addCustomAsk", "cancelAsk", "askText", "redirectAsk", "cancelQueued", "apiRetry", "setModel", "setEffort", "setMode",
               "endSession", "renameSession")
     if t in ID_OPS and msg.get("id"):
         sid = str(msg["id"])
@@ -1515,6 +1540,8 @@ def _drive(msg, client):
         be.on_ask(sid, "cancel")
     elif t == "askText" and msg.get("text"):
         be.on_ask(sid, "text", str(msg["text"]))
+    elif t == "redirectAsk" and msg.get("text"):
+        be.on_ask(sid, "redirect", str(msg["text"]))
     elif t == "cancelQueued" and msg.get("idx") is not None and hasattr(be, "unqueue"):
         be.unqueue(sid, int(msg["idx"]))                  # pull a queued (not-yet-started) message back out; the
         _push_all()                                       # webview already refilled the composer with its text
@@ -1805,12 +1832,13 @@ class TmuxBackend(sb.SessionBackend):
     def on_ask(self, sid, kind, payload=None):
         name = _name_of(sid) or str(sid)
         fn = {"answer": _ask_answer, "focus": _ask_focus, "toggle": _ask_toggle, "submit": _ask_submit,
-              "custom": _ask_add_custom, "cancel": _ask_cancel, "text": _ask_send_text}.get(kind)
+              "custom": _ask_add_custom, "cancel": _ask_cancel, "text": _ask_send_text,
+              "redirect": _ask_redirect}.get(kind)
         if not fn:
             return False
         if kind in ("submit", "cancel"):
             _ask_thread(fn, name)
-        elif kind in ("custom", "text"):
+        elif kind in ("custom", "text", "redirect"):
             _ask_thread(fn, name, str(payload))
         else:                                             # answer / focus / toggle carry a target index
             _ask_thread(fn, name, payload)
@@ -2528,6 +2556,29 @@ def _ask_send_text(name, text):
         return
     _send_literal(name, text)
     time.sleep(0.12); _send_keys(name, ["Enter"])
+
+
+def _ask_redirect(name, text):
+    """Decline-and-redirect: Escape declines the tool, then type guidance into the
+    composer and Enter. Poll for the composer (transition timing varies by prompt kind)
+    and fall back to delivering anyway if it never settles."""
+    if not (text or "").strip():
+        return
+    _send_keys(name, ["Escape"])
+
+    def deliver():
+        _send_literal(name, text)
+        time.sleep(0.14); _send_keys(name, ["Enter"])
+
+    def step(left):
+        if left <= 0:
+            deliver(); return
+        cap = _capture_pane(name) or ""
+        if ap.COMPOSER_RE.search(cap):
+            deliver(); return
+        time.sleep(0.09); step(left - 1)
+
+    time.sleep(0.12); step(10)
 
 
 def _ask_thread(fn, *a):
@@ -8238,6 +8289,16 @@ class Handler(BaseHTTPRequestHandler):
             _kept_open.discard(msg["id"])        # ×-closing a read-only dead tab forgets it (timeline-only again)
             _send_to_app("chat", {"type": "closed", "id": msg["id"]})   # prune it in the live view now
             _push_all()
+        elif msg and msg.get("type") == "forgetSession" and isinstance(msg.get("name"), str):
+            name = str(msg["name"])
+            live = set(_live_names(_tmux_sessions()))
+            removed = _forget_name(name, live)
+            if removed:
+                client["send"](json.dumps({"type": "sessionList",
+                                           "items": _session_list(int(time.time()), _tmux_sessions()),
+                                           "defaultDir": _tilde(_default_create_dir())}))
+            else:
+                client["send"](json.dumps({"type": "warn", "text": 'can\'t forget "%s" — it\'s still running.' % name}))
         elif msg and msg.get("type") == "openSession" and msg.get("id"):
             # live → reopen the hidden tab + focus; dead → the chat's confirmRevive modal
             _open_or_revive(msg["id"])

--- a/bin/romp-kernel
+++ b/bin/romp-kernel
@@ -225,7 +225,8 @@ def _version_info():
     return {"kernel_sha": _kernel_sha(), "pid": os.getpid(), "started": int(_STARTED),
             "uptime_s": int(time.time() - _STARTED), "dist_ver": _dist_ver(), "bundles": bundles,
             "autoNudge": _auto_nudge_on(),   # server-side toggle state → the gear checkbox reflects the kernel
-            "defaultDir": _tilde(_default_create_dir())}   # the resolved default new-session dir → the gear "Default directory" field
+            "defaultDir": _tilde(_default_create_dir()),
+            "discoverWindow": _read_discover_window()}   # the resolved default new-session dir → the gear "Default directory" field
 
 
 def _dist_ver():
@@ -506,12 +507,30 @@ def _alive_sessions(now, tmux):
     So: tmux reachable (sessions present, or a tmux binary exists) → trust the empty result and show
     only living sessions; no tmux at all → fall back so a headless box isn't blank."""
     alive = [s for s in _sessions(now) if s["sid"] in tmux]
+    have = {s["sid"] for s in alive}
+    # Live tmux sessions whose transcript fell outside discover()'s 48h window are invisible —
+    # synthesize a session entry from the names registry so they stay on every surface. The
+    # transcript path mirrors discover()'s _proj_dir(cwd) / "<sid>.jsonl".
+    for sid in tmux:
+        if sid in have:
+            continue
+        name = _name_of(sid)
+        if not name:
+            continue
+        cwd = _cwd_of(sid)
+        proj = jd._proj_dir(cwd) if cwd else None
+        path = proj / (sid + ".jsonl") if proj else None
+        try:
+            mtime = os.stat(path).st_mtime if path and path.exists() else 0
+        except OSError:
+            mtime = 0
+        alive.append({"sid": sid, "name": name, "anchor": sid, "path": str(path or ""), "mtime": mtime})
+        have.add(sid)
     # SDK sessions that are alive (in the merged `tmux` map) but have no transcript on disk yet — a
     # just-created or never-run SDK session — aren't in discover()/_sessions, so add them here, else
     # their tab never opens (the user 2026-06-22). Once they run and write a transcript, discover takes over.
     be = _sdk()
     if be:
-        have = {s["sid"] for s in alive}
         for sid in tmux:
             if sid not in have and be.owns(sid):
                 alive.append(_sdk_sess(sid, now))
@@ -1284,6 +1303,27 @@ def _forget_name(name, live_names):
 
 
 _DEFAULT_DIR_FILE = Path(os.path.expanduser("~/.config/romp/default-dir"))
+_DISCOVER_WINDOW_FILE = Path(os.path.expanduser("~/.config/romp/discover-window"))
+_DISCOVER_WINDOW_DEFAULT = 10.5  # days
+
+
+def _read_discover_window():
+    """The user-set discover window in days, or the default (1.5 weeks). Persisted in a FILE so the
+    gear dialog can set it. The value drives jd.WINDOW (how far back dead sessions appear)."""
+    try:
+        v = float(_DISCOVER_WINDOW_FILE.read_text().strip())
+        return max(1, v)
+    except Exception:
+        return _DISCOVER_WINDOW_DEFAULT
+
+
+def _set_discover_window(days):
+    """Persist the discover window and update the live jd.WINDOW."""
+    days = max(1, float(days))
+    _DISCOVER_WINDOW_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _DISCOVER_WINDOW_FILE.write_text(str(days))
+    jd.WINDOW = int(days * 86400)
+    return days
 
 
 def _read_default_dir_file():
@@ -6925,6 +6965,13 @@ _GEAR_HTML = ("<button id=rgear hidden aria-hidden=true></button>"
               "<span><b>Auto Nudge</b>"
               "<span class=rs-sub>When a session goes idle but its goal still shows working (not blocked, not awaiting you), automatically nudge it once for a status update.</span>"
               "</span></label>"
+              "<div class='rs-row rs-sep' style='cursor:default'><span style='flex:1 1 auto'><b>Session history window</b>"
+              "<span class=rs-sub>How far back dead sessions appear in the picker and timeline. Live sessions always show regardless. Default: 10.5 days (1.5 weeks).</span>"
+              "<div style='display:flex;gap:6px;align-items:center;margin-top:5px'>"
+              "<input id=rs-discoverwin type=number min=1 max=90 step=0.5 style='width:70px;background:#1e1e1e;color:#ccc;"
+              "border:1px solid #3a3a3a;border-radius:5px;padding:3px 6px;text-align:right'>"
+              "<span style='color:#9aa0a6;font-size:0.85em'>days</span>"
+              "</div></span></div>"
               "<div class=rs-sec>Timeline</div>"
               "<label class=rs-row><input type=checkbox id=rs-collapsegaps checked>"
               "<span><b>Collapse idle gaps</b>"
@@ -6959,7 +7006,7 @@ _GEAR_HTML = ("<button id=rgear hidden aria-hidden=true></button>"
               "</div></div>")
 _GEAR_JS = r"""(function(){var g=document.getElementById('rgear'),p=document.getElementById('rsettings'),
 b=document.getElementById('rsver'),cc=document.getElementById('rs-compact'),
-db=document.getElementById('rs-debug'),an=document.getElementById('rs-autonudge'),bk=document.getElementById('rs-backend'),dd=document.getElementById('rs-defaultdir'),gb=document.getElementById('rs-branch'),cg=document.getElementById('rs-collapsegaps');
+db=document.getElementById('rs-debug'),an=document.getElementById('rs-autonudge'),bk=document.getElementById('rs-backend'),dd=document.getElementById('rs-defaultdir'),gb=document.getElementById('rs-branch'),cg=document.getElementById('rs-collapsegaps'),dw=document.getElementById('rs-discoverwin');
 function load(){try{return Object.assign({compact:false,colormap:'aurora',subgoals:true,debug:false,backend:'tmux',defaultDir:'',showBranch:true,collapseGaps:true},JSON.parse(localStorage.getItem('romp:settings')||'null'));}catch(e){return {compact:false,colormap:'aurora',subgoals:true,debug:false,backend:'tmux',defaultDir:'',showBranch:true,collapseGaps:true};}}
 function save(s){try{localStorage.setItem('romp:settings',JSON.stringify(s));}catch(e){}}
 function emit(){try{window.dispatchEvent(new Event('romp:settings'));}catch(e){}}   // same-doc signal → the feed re-gates its cards
@@ -7000,12 +7047,15 @@ if(cmList&&!cmList.hidden&&w&&!w.contains(e.target))cmList.hidden=true;});   // 
 if(bk)bk.addEventListener('change',function(){var s=load();s.backend=bk.value;save(s);emit();});   // webview-local pref read at createSession time (render.ts); no kernel round-trip
 if(dd)dd.addEventListener('change',function(){var v=dd.value.trim();var s=load();s.defaultDir=v;save(s);   // same-tab cache for the picker prefill
 try{window.acquireVsCodeApi&&window.acquireVsCodeApi().postMessage({type:'setDefaultDir',value:v});}catch(e){}});   // persist kernel-side: _default_create_dir reads this file FIRST
+if(dw)dw.addEventListener('change',function(){var v=parseFloat(dw.value)||10.5;if(v<1)v=1;dw.value=v;
+try{window.acquireVsCodeApi&&window.acquireVsCodeApi().postMessage({type:'setDiscoverWindow',days:v});}catch(e){}});
 var ddb=document.getElementById('rs-defaultdir-browse');
 if(ddb)ddb.addEventListener('click',function(){try{window.acquireVsCodeApi&&window.acquireVsCodeApi().postMessage({type:'browseDir',target:'gear'});}catch(e){}});   // native folder dialog → render.ts fills #rs-defaultdir + fires change
 function lv(){var t=document.querySelector('script[src*="feed.js"]');
 var m=t&&t.getAttribute('src').match(/[?&]v=(\d+)/);return m?+m[1]:0;}
 function fill(){fetch('/version',{cache:'no-store'}).then(function(r){return r.json();}).then(function(v){
 if(an)an.checked=!!v.autoNudge;
+if(dw&&typeof v.discoverWindow==='number')dw.value=v.discoverWindow;
 if(dd&&typeof v.defaultDir==='string')dd.value=v.defaultDir;   // the kernel's persisted default (file → env/install) is authoritative
 var x=lv();b.innerHTML='kernel '+(v.kernel_sha||'?')+'\nserving v'+
 v.dist_ver+'\nthis tab v'+(x||'?');
@@ -8397,6 +8447,12 @@ class Handler(BaseHTTPRequestHandler):
                 client["send"](json.dumps({"type": "warn", "text": err}))
             else:
                 client["send"](json.dumps({"type": "defaultDirSaved", "value": _tilde(_default_create_dir())}))
+        elif msg and msg.get("type") == "setDiscoverWindow" and msg.get("days") is not None:
+            try:
+                days = _set_discover_window(float(msg["days"]))
+                jd._discover_cache["fp"] = None   # bust the discover cache so the new window takes effect
+            except Exception:
+                client["send"](json.dumps({"type": "warn", "text": "invalid discover window value"}))
         elif msg and msg.get("type") == "setColormap" and msg.get("name"):
             _set_colormap(str(msg["name"]))    # recency colormap chooser → recolours the feed on next push
 
@@ -8498,6 +8554,7 @@ def _parent_watch():
 
 
 def main():
+    jd.WINDOW = int(_read_discover_window() * 86400)
     _ensure_bundles()
     threading.Thread(target=_producer, daemon=True).start()
     threading.Thread(target=_pusher, daemon=True).start()

--- a/chat-view/.gitignore
+++ b/chat-view/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-gallery/
 *.vsix
 .DS_Store
 out-tests/

--- a/chat-view/README.md
+++ b/chat-view/README.md
@@ -31,5 +31,23 @@ npm run build      # or: npm run watch
 ```
 
 Then open this folder in VS Code/Cursor and press **F5** (Run romp Chat View).
-In the dev host, run the command **“romp Chat: Open Session Viewer”** and pick a
+In the dev host, run the command **”romp Chat: Open Session Viewer”** and pick a
 session.
+
+### Acceptance gallery
+
+```sh
+npm run gallery    # → http://127.0.0.1:5599/gallery.html  (--open to launch a browser)
+```
+
+A standalone page that replays one synthetic **scene per content type** —
+messages/markdown, thinking, tool calls, Edit/Write diffs, todo, postal, queued,
+and every permission popup (edit red/green diff, Bash command, single/multi/submit
+asks) — through the exact `postMessage` protocol the host uses. Editing
+`src/webview/*.ts`, `styles.css`, or the fixtures live-reloads the page (esbuild
+watch + SSE).
+
+- Fixtures: `src/dev/fixtures.ts` (synthetic only — see the repo privacy rule).
+- Coverage is pinned by `src/dev/fixtures.test.ts`: every content kind is present,
+  and the permission scenes trip the real `pendingEditDiff` / `pendingCommand`
+  matchers, so a popup regression fails `npm test`, not just the eye.

--- a/chat-view/esbuild.js
+++ b/chat-view/esbuild.js
@@ -76,6 +76,7 @@ function testBuild() {
     platform: "node",
     target: "node18",
     packages: "external",
+    external: ["jsdom", "esbuild"],
     outdir: "out-tests",
     sourcemap: "inline",
     logLevel: "info",

--- a/chat-view/esbuild.js
+++ b/chat-view/esbuild.js
@@ -59,12 +59,14 @@ function testBuild() {
   // ../ui (timeline + quote) and ../ui/webview (feed/render/etc.). out-tests/
   // keeps each tree's structure (esbuild's outbase = the common ancestor), and
   // `node --test 'out-tests/**/*.test.js'` finds them recursively.
-  const entries = ["src", "../ui", "../ui/webview"].flatMap((dir) =>
-    fs
-      .readdirSync(path.join(__dirname, dir))
+  const dirs = ["src", "src/dev", "../ui", "../ui/webview"];
+  const entries = dirs.flatMap((dir) => {
+    const abs = path.join(__dirname, dir);
+    if (!fs.existsSync(abs)) return [];
+    return fs.readdirSync(abs)
       .filter((f) => f.endsWith(".test.ts"))
-      .map((f) => dir + "/" + f),
-  );
+      .map((f) => dir + "/" + f);
+  });
   /** @type {import('esbuild').BuildOptions} */
   return {
     entryPoints: entries,
@@ -73,6 +75,7 @@ function testBuild() {
     format: "cjs",
     platform: "node",
     target: "node18",
+    packages: "external",
     outdir: "out-tests",
     sourcemap: "inline",
     logLevel: "info",

--- a/chat-view/package-lock.json
+++ b/chat-view/package-lock.json
@@ -15,13 +15,219 @@
         "ws": "^8.21.0"
       },
       "devDependencies": {
+        "@types/jsdom": "^28.0.3",
         "@types/node": "^20.11.0",
         "@types/vscode": "^1.85.0",
         "esbuild": "^0.21.5",
+        "jsdom": "^29.1.1",
         "typescript": "^5.4.5"
       },
       "engines": {
         "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -415,6 +621,44 @@
         "node": ">=12"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.3.tgz",
+      "integrity": "sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.28.0.tgz",
+      "integrity": "sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.42",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
@@ -423,6 +667,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -447,6 +698,51 @@
         "@types/node": "*"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dompurify": {
       "version": "3.4.10",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
@@ -454,6 +750,19 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/esbuild": {
@@ -504,6 +813,77 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/marked": {
       "version": "12.0.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
@@ -514,6 +894,122 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
+      "integrity": "sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.5"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
+      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/typescript": {
@@ -530,11 +1026,69 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/ws": {
       "version": "8.21.0",
@@ -556,6 +1110,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/chat-view/package.json
+++ b/chat-view/package.json
@@ -116,9 +116,11 @@
     "test": "node esbuild.js --tests && node --test 'out-tests/**/*.test.js'"
   },
   "devDependencies": {
+    "@types/jsdom": "^28.0.3",
     "@types/node": "^20.11.0",
     "@types/vscode": "^1.85.0",
     "esbuild": "^0.21.5",
+    "jsdom": "^29.1.1",
     "typescript": "^5.4.5"
   },
   "dependencies": {

--- a/chat-view/package.json
+++ b/chat-view/package.json
@@ -113,7 +113,8 @@
     "watch": "node esbuild.js --watch",
     "typecheck": "tsc --noEmit",
     "vscode:prepublish": "node esbuild.js --production",
-    "test": "node esbuild.js --tests && node --test 'out-tests/**/*.test.js'"
+    "test": "node esbuild.js --tests && node --test 'out-tests/**/*.test.js'",
+    "gallery": "node ../bin/romp-gallery"
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.3",

--- a/chat-view/src/dev/fixtures.test.ts
+++ b/chat-view/src/dev/fixtures.test.ts
@@ -1,0 +1,54 @@
+// Acceptance-fixture coverage: the gallery is visual, but these tests pin that
+// every scene is well-formed, that the transcript scenes cover every content
+// kind, and that the permission scenes actually trip the real popup matchers
+// (pendingEditDiff / pendingCommand) — so a regression there fails CI, not just
+// the eye.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { SCENES, EXPECTED_EVENT_KINDS } from "./fixtures";
+
+const sessionMsg = (scene: { messages: any[] }) => scene.messages.find((m) => m.type === "session");
+const askMsg = (scene: { messages: any[] }) => scene.messages.find((m) => m.type === "askLive");
+
+test("every scene is well-formed (unique id, title, ≥1 message, a focus)", () => {
+  const ids = new Set<string>();
+  for (const s of SCENES) {
+    assert.ok(s.id && s.title && s.group, `scene missing id/title/group: ${JSON.stringify(s)}`);
+    assert.ok(!ids.has(s.id), `duplicate scene id: ${s.id}`);
+    ids.add(s.id);
+    assert.ok(s.messages.length >= 1, `scene ${s.id} has no messages`);
+    assert.ok(s.messages.some((m) => m.type === "focus"), `scene ${s.id} never focuses a session`);
+  }
+});
+
+test("every session event carries a known kind", () => {
+  const KNOWN = new Set(["user", "assistant", "thinking", "tool", "postal", "todo", "queued"]);
+  for (const s of SCENES) {
+    const sess = sessionMsg(s);
+    if (!sess) continue;
+    for (const ev of sess.events) assert.ok(KNOWN.has(ev.kind), `scene ${s.id}: unknown event kind ${ev.kind}`);
+  }
+});
+
+test("transcript scenes cover every expected content kind", () => {
+  const seen = new Set<string>();
+  for (const s of SCENES) for (const ev of sessionMsg(s)?.events ?? []) seen.add(ev.kind);
+  for (const k of EXPECTED_EVENT_KINDS) assert.ok(seen.has(k), `no fixture covers content kind: ${k}`);
+});
+
+test("the edit-permission scene carries a red/green diff on the ask", () => {
+  const scene = SCENES.find((s) => s.id === "perm-edit")!;
+  const diff = askMsg(scene)!.ask.diff;
+  assert.ok(diff && diff.includes("+") && diff.includes("-"), "edit popup ask must carry a +/- diff");
+});
+
+test("the WebFetch scene carries a detail body on the ask", () => {
+  const scene = SCENES.find((s) => s.id === "perm-fetch")!;
+  const body = askMsg(scene)!.ask.body;
+  assert.ok(body && body.includes("example.com"), "fetch popup ask must carry a detail body");
+});
+
+test("permission popups cover single, multi, and submit asks", () => {
+  const kinds = new Set(SCENES.map((s) => askMsg(s)?.ask?.kind).filter(Boolean));
+  for (const k of ["single", "multi", "submit"]) assert.ok(kinds.has(k), `no permission scene covers ask kind: ${k}`);
+});

--- a/chat-view/src/dev/fixtures.ts
+++ b/chat-view/src/dev/fixtures.ts
@@ -1,0 +1,351 @@
+// Acceptance fixtures for the chat webview — one synthetic "scene" per content
+// type, replayed into render.ts through the exact postMessage protocol the host
+// uses (session / focus / askLive). Drives the dev gallery (bin/romp-gallery)
+// and the coverage test (fixtures.test.ts).
+//
+// PRIVACY (repo rule): everything here is invented. Placeholder UUIDs, hostname
+// TESTHOST, no real prompts/paths/identities. Never paste recorded data in.
+
+// A postMessage payload the webview understands (loosely typed — the gallery just
+// forwards these verbatim to window.postMessage).
+export type Msg = Record<string, any>;
+
+export interface Scene {
+  id: string;          // stable slug (nav key)
+  title: string;       // sidebar label
+  group: string;       // sidebar section
+  messages: Msg[];     // posted, in order, when the scene is selected
+}
+
+// ---- builders --------------------------------------------------------------
+
+const ISO = "2026-06-15T17:00:00.000Z"; // fixed timestamp → deterministic gallery
+let uid = 0;
+const uuid = () => `11111111-2222-3333-4444-${String(++uid).padStart(12, "0")}`;
+
+const READY = { state: "ready", sinceEpoch: null } as const;
+const AWAITING = { state: "awaiting", sinceEpoch: null } as const;
+
+function session(id: string, name: string, events: Msg[], status: Msg = READY): Msg {
+  return { type: "session", id, name, color: null, events, status, firstSeen: 1781000000 };
+}
+const focus = (id: string): Msg => ({ type: "focus", id });
+
+// A tool event with all the optional fields render.ts may read.
+function tool(name: string, over: Partial<Msg> = {}): Msg {
+  return { kind: "tool", name, desc: "", input: "", output: "", isError: false, uuid: uuid(), ts: ISO, ...over };
+}
+
+// The compact line diff editDiff() emits: trimmed head/tail context, +/- middle.
+const SAMPLE_DIFF = [
+  "   priority, due date, parent/epic, project key/name, issue type,",
+  "-  description.",
+  "+  description, and the issue's",
+  "+  **comments** (author, timestamp, body).",
+].join("\n");
+
+// A single-select / permission ask, mirroring askparse.ParsedAsk.
+function ask(kind: "single" | "multi" | "submit", question: string | undefined, labels: Array<string | [string, string]>, over: Partial<Msg> = {}): Msg {
+  const options = labels.map((l, i) => {
+    const [label, desc] = Array.isArray(l) ? l : [l, undefined];
+    return { n: i + 1, label, desc, selected: i === 0, checked: kind === "multi" ? false : undefined };
+  });
+  return { kind, header: undefined, question, options, cursor: 1, multiSelect: kind === "multi", ...over };
+}
+
+// ---- content-type scenes (transcript) --------------------------------------
+
+const transcript: Scene[] = [
+  {
+    id: "messages", title: "Messages & markdown", group: "Transcript",
+    messages: (() => {
+      const id = "sc-messages";
+      return [session(id, "messages", [
+        { kind: "user", md: "Can you summarize the **plan** and show a code sample?", uuid: uuid(), ts: ISO, human: true },
+        { kind: "assistant", md: [
+          "Here's the plan:",
+          "",
+          "## Steps",
+          "1. Parse the pane",
+          "2. Render the diff",
+          "3. Ship it",
+          "",
+          "> A short blockquote for emphasis.",
+          "",
+          "```ts",
+          "function add(a: number, b: number): number {",
+          "  return a + b; // inline",
+          "}",
+          "```",
+          "",
+          "| col | meaning |",
+          "| --- | ------- |",
+          "| a   | first   |",
+          "| b   | second  |",
+          "",
+          "See [the docs](https://example.com) for more.",
+        ].join("\n"), uuid: uuid(), ts: ISO },
+      ]), focus(id)];
+    })(),
+  },
+  {
+    id: "thinking", title: "Thinking (plain + encrypted)", group: "Transcript",
+    messages: (() => {
+      const id = "sc-thinking";
+      return [session(id, "thinking", [
+        { kind: "thinking", text: "Let me reason about the parser before editing.", encrypted: false, uuid: uuid(), ts: ISO },
+        { kind: "thinking", text: "", encrypted: true, uuid: uuid(), ts: ISO },
+        { kind: "assistant", md: "Done reasoning — here's the answer.", uuid: uuid(), ts: ISO },
+      ]), focus(id)];
+    })(),
+  },
+  {
+    id: "tools", title: "Tool calls (Bash/Read/Grep)", group: "Transcript",
+    messages: (() => {
+      const id = "sc-tools";
+      return [session(id, "tools", [
+        tool("Bash", { desc: "Run the build", input: "npm run build && echo done", output: "dist/kernel.js  278.9kb\n⚡ Done in 7ms" }),
+        tool("Read", { file: "/repo/src/app.ts", input: "/repo/src/app.ts", output: Array.from({ length: 40 }, (_, i) => `line ${i + 1}`).join("\n") }),
+        tool("Grep", { input: "TODO   src/", output: "src/a.ts:12: // TODO\nsrc/b.ts:30: // TODO" }),
+        tool("Bash", { desc: "Failing command", input: "exit 1", output: "boom: nonzero exit", isError: true }),
+      ]), focus(id)];
+    })(),
+  },
+  {
+    id: "edits", title: "Edit / Write diffs", group: "Transcript",
+    messages: (() => {
+      const id = "sc-edits";
+      return [session(id, "edits", [
+        tool("Edit", { file: "/repo/agents/engram-jira.md", input: "/repo/agents/engram-jira.md", diff: SAMPLE_DIFF }),
+        tool("Write", { file: "/repo/notes/new.md", input: "/repo/notes/new.md" }),
+      ]), focus(id)];
+    })(),
+  },
+  {
+    id: "todo", title: "Todo checklist", group: "Transcript",
+    messages: (() => {
+      const id = "sc-todo";
+      return [session(id, "todo", [
+        { kind: "todo", uuid: uuid(), ts: ISO, tasks: [
+          { id: "1", subject: "Parse the pane", status: "completed" },
+          { id: "2", subject: "Render the diff", activeForm: "Rendering the diff", status: "in_progress" },
+          { id: "3", subject: "Add a test", status: "pending" },
+        ] },
+      ]), focus(id)];
+    })(),
+  },
+  {
+    id: "postal", title: "Postal messages", group: "Transcript",
+    messages: (() => {
+      const id = "sc-postal";
+      return [session(id, "postal", [
+        { kind: "postal", direction: "in", peer: "peer-bravo", color: null, body: "FYI: build is green on TESTHOST.", mid: "m1", t: 1781000100, uuid: uuid(), ts: ISO },
+        { kind: "postal", direction: "out", peer: "peer-charlie", color: null, body: "HANDOFF: I own src/dev/* — stay off them.", status: "delivered", uuid: uuid(), ts: ISO },
+      ]), focus(id)];
+    })(),
+  },
+  {
+    id: "queued", title: "Queued messages", group: "Transcript",
+    messages: (() => {
+      const id = "sc-queued";
+      return [session(id, "queued", [
+        { kind: "user", md: "first ask", uuid: uuid(), ts: ISO, human: true },
+        { kind: "queued", texts: ["second queued", "third queued"], uuid: uuid(), ts: ISO },
+      ]), focus(id)];
+    })(),
+  },
+];
+
+// ---- permission / ask popups (the live #live-ask region) -------------------
+
+const popups: Scene[] = [
+  {
+    id: "perm-edit", title: "Permission: edit (red/green diff)", group: "Permission popups",
+    messages: (() => {
+      const id = "sc-perm-edit";
+      return [
+        session(id, "perm-edit", [{ kind: "assistant", md: "Editing engram-jira.md…", uuid: uuid(), ts: ISO }], AWAITING),
+        focus(id),
+        // The diff rides on the ask itself (askparse extracts it from the pane's
+        // ╌-fenced block into ParsedAsk.diff) — that's what the popup renders.
+        { type: "askLive", id, ask: ask("single", "Do you want to make this edit to engram-jira.md?",
+          ["Yes", ["Yes, allow all edits during this session", "shift+tab"], "No, and tell Claude what to do differently (esc)"],
+          { diff: SAMPLE_DIFF, fileHead: "Edit file\n../../tmp/demo/engram-jira.md\nThis will modify /tmp/demo/engram-jira.md (outside working directory) via a symlink" }) },
+      ];
+    })(),
+  },
+  {
+    id: "perm-write", title: "Permission: write (new file)", group: "Permission popups",
+    messages: (() => {
+      const id = "sc-perm-write";
+      // A new file is all additions — leading-dash lines (markdown bullets, the
+      // --- frontmatter rule) must read green, never as red deletions.
+      const NEW_FILE = [
+        "+---", "+title: Notes", "+---", "+# Heading",
+        "+- first bullet", "+- second bullet", "+Some closing prose.",
+      ].join("\n");
+      return [
+        session(id, "perm-write", [{ kind: "assistant", md: "Creating notes.md…", uuid: uuid(), ts: ISO }], AWAITING),
+        focus(id),
+        { type: "askLive", id, ask: ask("single", "Do you want to create notes.md?",
+          ["Yes", "Yes, allow all edits during this session", "No"],
+          { diff: NEW_FILE, fileHead: "Create file\nnotes.md" }) },
+      ];
+    })(),
+  },
+  {
+    id: "perm-notebook", title: "Permission: edit notebook", group: "Permission popups",
+    messages: (() => {
+      const id = "sc-perm-notebook";
+      const NB_DIFF = [
+        "-print(\"hello\")",
+        "   No newline at end of file",
+        "+import math",
+        "+",
+        "+# Edited via NotebookEdit to test the notebook diff UI",
+        "+for n in range(5):",
+        "+    print(n, math.sqrt(n))",
+        "   No newline at end of file",
+      ].join("\n");
+      return [
+        session(id, "perm-notebook", [{ kind: "assistant", md: "Editing demo.ipynb…", uuid: uuid(), ts: ISO }], AWAITING),
+        focus(id),
+        { type: "askLive", id, ask: ask("single", "Do you want to make this edit to demo.ipynb?",
+          ["Yes", ["Yes, allow all edits during this session", "shift+tab"], "No"],
+          { diff: NB_DIFF, fileHead: "Edit notebook\nThis will modify /tmp/demo/demo.ipynb (outside working directory) via a symlink\n/tmp/demo/demo.ipynb\nReplace cell contents for cell cell-0" }) },
+      ];
+    })(),
+  },
+  {
+    id: "perm-bash", title: "Permission: Bash command", group: "Permission popups",
+    messages: (() => {
+      const id = "sc-perm-bash";
+      return [
+        session(id, "perm-bash", [{ kind: "assistant", md: "Running the build…", uuid: uuid(), ts: ISO }], AWAITING),
+        focus(id),
+        // body = the pane's detail block (the command + description), extracted by askparse.
+        { type: "askLive", id, ask: ask("single", "Do you want to proceed?",
+          ["Yes", "Yes, and don't ask again for npm commands in /repo", "No"],
+          { body: "npm run build && npm test -- --reporter=dot && echo 'all green'\nBuild and test the project" }) },
+      ];
+    })(),
+  },
+  {
+    id: "perm-bash-multi", title: "Permission: Bash (multi-line)", group: "Permission popups",
+    messages: (() => {
+      const id = "sc-perm-bash-multi";
+      return [
+        session(id, "perm-bash-multi", [{ kind: "assistant", md: "Tagging the release…", uuid: uuid(), ts: ISO }], AWAITING),
+        focus(id),
+        // A heredoc-style multi-line command: every command line must stay in the
+        // code box — only the trailing prose line is peeled as the description.
+        { type: "askLive", id, ask: ask("single", "Do you want to proceed?",
+          ["Yes", "Yes, and don't ask again for git commands in /repo", "No"],
+          { body: [
+            "for f in src/*.ts; do",
+            "  echo \"checking $f\"",
+            "  grep -n TODO \"$f\" || true",
+            "done",
+            "Scan every source file for TODO markers",
+          ].join("\n") }) },
+      ];
+    })(),
+  },
+  {
+    id: "perm-fetch", title: "Permission: WebFetch (url)", group: "Permission popups",
+    messages: (() => {
+      const id = "sc-perm-fetch";
+      return [
+        session(id, "perm-fetch", [{ kind: "assistant", md: "Fetching example.com…", uuid: uuid(), ts: ISO }], AWAITING),
+        focus(id),
+        { type: "askLive", id, ask: ask("single", "Do you want to allow Claude to fetch this content?",
+          ["Yes", "Yes, and don't ask again for example.com", ["No", "tell Claude what to do differently (esc)"]],
+          { body: 'url: "https://example.com", prompt: "What is the main heading text on this page?"\nClaude wants to fetch content from example.com' }) },
+      ];
+    })(),
+  },
+  {
+    id: "perm-mcp", title: "Permission: MCP tool", group: "Permission popups",
+    messages: (() => {
+      const id = "sc-perm-mcp";
+      return [
+        session(id, "perm-mcp", [{ kind: "assistant", md: "Checking the other live sessions…", uuid: uuid(), ts: ISO }], AWAITING),
+        focus(id),
+        // body = tool line + a long description (with parentheses) that must peel
+        // off as dimmed italic context, not sit in the code box with the tool.
+        { type: "askLive", id, ask: ask("single", "Do you want to proceed?",
+          ["Yes", "Yes, and don't ask again for romp-postal commands in /repo", "No"],
+          { body: "romp-postal - list_agents (MCP)\nList the live romp sessions you can message (yours is marked), with each one's git branch and what it's working on — check this before editing shared files to avoid collisions." }) },
+      ];
+    })(),
+  },
+  {
+    id: "perm-plan", title: "Permission: plan mode", group: "Permission popups",
+    messages: (() => {
+      const id = "sc-perm-plan";
+      const PLAN = [
+        "## Plan",
+        "",
+        "1. Parse the pane into structured asks",
+        "   - handle the diff frame",
+        "   - handle the plan box",
+        "2. Render each kind cleanly",
+        "",
+        "```ts",
+        "function render(ask: ParsedAsk) { /* … */ }",
+        "```",
+      ].join("\n");
+      return [
+        session(id, "perm-plan", [{ kind: "assistant", md: "Here's the plan.", uuid: uuid(), ts: ISO }], AWAITING),
+        focus(id),
+        { type: "askLive", id, ask: ask("single", "Would you like to proceed?",
+          ["Yes, and auto-accept edits", "Yes, and manually approve edits", "No, keep planning"],
+          { planBody: PLAN, fileHead: "Ready to code?\nHere is Claude's plan:" }) },
+      ];
+    })(),
+  },
+  {
+    id: "ask-single", title: "AskUserQuestion: single", group: "Permission popups",
+    messages: (() => {
+      const id = "sc-ask-single";
+      return [
+        session(id, "ask-single", [{ kind: "assistant", md: "Which approach should I take?", uuid: uuid(), ts: ISO }], AWAITING),
+        focus(id),
+        { type: "askLive", id, ask: ask("single", "Which library should we use?",
+          [["highlight.js", "what we use today"], ["shiki", "heavier, more accurate"], "Type something"]) },
+      ];
+    })(),
+  },
+  {
+    id: "ask-multi", title: "AskUserQuestion: multi", group: "Permission popups",
+    messages: (() => {
+      const id = "sc-ask-multi";
+      return [
+        session(id, "ask-multi", [{ kind: "assistant", md: "Pick the features to enable.", uuid: uuid(), ts: ISO }], AWAITING),
+        focus(id),
+        { type: "askLive", id, ask: ask("multi", "Which features do you want?",
+          ["Line numbers", "Word-level highlight", "Auto-reload"]) },
+      ];
+    })(),
+  },
+  {
+    id: "ask-submit", title: "AskUserQuestion: review/submit", group: "Permission popups",
+    messages: (() => {
+      const id = "sc-ask-submit";
+      return [
+        session(id, "ask-submit", [{ kind: "assistant", md: "Review your answers.", uuid: uuid(), ts: ISO }], AWAITING),
+        focus(id),
+        { type: "askLive", id, ask: ask("submit", undefined, ["Submit answers", "Cancel"], {
+          chosen: ["Red", "Extra medium"],
+          pairs: [{ q: "Favorite color?", a: "Red" }, { q: "Pick a size?", a: "Extra medium" }],
+        }) },
+      ];
+    })(),
+  },
+];
+
+export const SCENES: Scene[] = [...transcript, ...popups];
+
+// The content-event kinds the transcript scenes are expected to cover (the
+// coverage test pins this so a new ChatEvent kind can't quietly go undemoed).
+export const EXPECTED_EVENT_KINDS = ["user", "assistant", "thinking", "tool", "todo", "postal", "queued"] as const;

--- a/chat-view/src/dev/gallery.ts
+++ b/chat-view/src/dev/gallery.ts
@@ -1,0 +1,43 @@
+// Gallery driver — loaded in gallery.html alongside the real render.ts bundle.
+// Builds a sidebar of scenes (from fixtures.ts), posts each scene's messages
+// into the webview via postMessage when clicked, and wires SSE live-reload.
+import { SCENES } from "./fixtures";
+
+const sidebar = document.getElementById("gallery-sidebar")!;
+const groups = new Map<string, HTMLElement>();
+
+function selectScene(id: string) {
+  document.querySelectorAll(".gal-item").forEach((el) =>
+    el.classList.toggle("active", (el as HTMLElement).dataset.id === id));
+  const scene = SCENES.find((s) => s.id === id);
+  if (!scene) return;
+  scene.messages.forEach((m) => window.postMessage(m, "*"));
+  history.replaceState(null, "", `#${id}`);
+}
+
+for (const scene of SCENES) {
+  let group = groups.get(scene.group);
+  if (!group) {
+    const h = document.createElement("div");
+    h.className = "gal-group";
+    h.textContent = scene.group;
+    sidebar.appendChild(h);
+    group = document.createElement("div");
+    sidebar.appendChild(group);
+    groups.set(scene.group, group);
+  }
+  const item = document.createElement("div");
+  item.className = "gal-item";
+  item.dataset.id = scene.id;
+  item.textContent = scene.title;
+  item.addEventListener("click", () => selectScene(scene.id));
+  group.appendChild(item);
+}
+
+// Auto-select from hash or the first scene
+const initial = location.hash.slice(1) || SCENES[0]?.id;
+if (initial) selectScene(initial);
+
+// SSE live-reload
+const es = new EventSource("/sse");
+es.addEventListener("reload", () => location.reload());

--- a/chat-view/src/dev/render-dom.test.ts
+++ b/chat-view/src/dev/render-dom.test.ts
@@ -1,0 +1,156 @@
+// DOM acceptance: bundle the REAL webview entry (render.ts) for the browser,
+// load it in jsdom against the real chatBody skeleton, then drive every fixture
+// scene through the exact postMessage protocol the host uses — asserting the
+// bundle loads with no error and actually paints. This is the test that would
+// have caught the "render.ts imported transcript.ts → Buffer in the browser
+// bundle → blank chat" regression: a Node global leaking into the webview throws
+// on load here, and every scene that fails to render trips an assertion.
+import { test, before } from "node:test";
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import * as esbuild from "esbuild";
+import { JSDOM, VirtualConsole } from "jsdom";
+import { chatBody } from "../page-skeleton";
+import { SCENES } from "./fixtures";
+
+let bundle = "";
+
+before(async () => {
+  // Bundle the source (not dist) so the test never goes stale against a build.
+  const out = await esbuild.build({
+    entryPoints: [path.resolve(process.cwd(), "../ui/webview/render.ts")],
+    nodePaths: [path.join(process.cwd(), "node_modules")],
+    bundle: true, format: "iife", platform: "browser", target: "es2020",
+    external: ["*.png", "*.svg"],
+    write: false, logLevel: "silent",
+  });
+  bundle = out.outputFiles[0].text;
+});
+
+// Fresh jsdom per scene: skeleton + the render bundle, capturing any load/runtime
+// error. Returns the window, collected errors, and a close() — render.ts has a
+// top-level setInterval that keeps jsdom's event loop alive, so each window MUST
+// be closed or the test process never exits.
+function mount() {
+  const errors: string[] = [];
+  const vc = new VirtualConsole();
+  vc.on("jsdomError", (e: any) => errors.push(String(e?.detail?.stack || e?.stack || e?.message || e)));
+  vc.on("error", (...a: any[]) => errors.push("console.error: " + a.join(" ")));
+  const fetchStub = `window.fetch = function() { return Promise.resolve({ json: function() { return Promise.resolve({}); } }); };`;
+  const dom = new JSDOM(
+    `<!doctype html><html><body>${chatBody("test")}<script>${fetchStub}<\/script><script>${bundle}<\/script></body></html>`,
+    { runScripts: "dangerously", pretendToBeVisual: true, virtualConsole: vc },
+  );
+  dom.window.addEventListener("error", (e: any) => errors.push(String(e?.error?.stack || e?.message)));
+  return { window: dom.window as any, errors, close: () => dom.window.close() };
+}
+
+const drive = (window: any, scene: { messages: any[] }) =>
+  scene.messages.forEach((m) => window.postMessage(m, "*"));
+
+const settle = () => new Promise((r) => setTimeout(r, 50));
+
+test("the webview bundle loads in a browser with no error (no Node globals leak)", async () => {
+  const { window, errors, close } = mount();
+  try {
+    await settle();
+    assert.deepEqual(errors, [], `render.ts bundle threw on load:\n${errors.join("\n")}`);
+    assert.ok(window.document.getElementById("content"), "skeleton present");
+  } finally { close(); }
+});
+
+test("every transcript scene paints into #content", async () => {
+  for (const scene of SCENES.filter((s) => s.group === "Transcript")) {
+    const { window, errors, close } = mount();
+    try {
+      await settle();
+      drive(window, scene);
+      await settle();
+      assert.deepEqual(errors, [], `scene ${scene.id} errored:\n${errors.join("\n")}`);
+      const content = window.document.getElementById("content");
+      assert.ok(content.textContent.trim().length > 0, `scene ${scene.id} rendered nothing into #content`);
+    } finally { close(); }
+  }
+});
+
+test("every permission scene paints the live-ask popup", async () => {
+  for (const scene of SCENES.filter((s) => s.group === "Permission popups")) {
+    const { window, errors, close } = mount();
+    try {
+      await settle();
+      drive(window, scene);
+      await settle();
+      assert.deepEqual(errors, [], `scene ${scene.id} errored:\n${errors.join("\n")}`);
+      const live = window.document.getElementById("live-ask");
+      assert.equal(live.style.display, "", `scene ${scene.id}: popup hidden`);
+      assert.ok(live.textContent.trim().length > 0, `scene ${scene.id}: popup empty`);
+    } finally { close(); }
+  }
+});
+
+test("MCP tool popup: the tool line is the command, the prose peels into a dimmed description", async () => {
+  const scene = SCENES.find((s) => s.id === "perm-mcp")!;
+  const { window, close } = mount();
+  try {
+    await settle();
+    drive(window, scene);
+    await settle();
+    const cmd = window.document.querySelector("#live-ask .ask-cmd");
+    const desc = window.document.querySelector("#live-ask .ask-body-desc");
+    assert.ok(cmd, "MCP popup must show a command/target line");
+    assert.ok(desc, "MCP popup must show a separate description");
+    assert.ok(cmd!.textContent!.includes("list_agents"), "tool name stays in the command box");
+    assert.ok(!cmd!.textContent!.includes("avoid collisions"), "description must NOT be in the command box");
+    assert.ok(desc!.textContent!.includes("avoid collisions"), "description text lands in .ask-body-desc");
+    assert.ok(desc!.textContent!.includes("(yours is marked)"), "parenthetical stays with the description");
+  } finally { close(); }
+});
+
+test("a permission popup with a 'tell Claude what to do differently' option shows the redirect field", async () => {
+  const scene = SCENES.find((s) => s.id === "perm-edit")!;
+  const { window, close } = mount();
+  try {
+    await settle();
+    drive(window, scene);
+    await settle();
+    const field = window.document.querySelector("#live-ask .ask-redirect-input");
+    assert.ok(field, "the decline-and-redirect input must render when the option is present");
+  } finally { close(); }
+});
+
+test("a plain-No permission popup (perm-write) STILL shows the redirect field", async () => {
+  // Real Edit/Write/Notebook prompts label the decline row just "No" — the field
+  // must appear anyway (the bug was requiring "tell Claude…" wording).
+  const scene = SCENES.find((s) => s.id === "perm-write")!; // options: Yes / allow-all / No
+  const { window, close } = mount();
+  try {
+    await settle();
+    drive(window, scene);
+    await settle();
+    assert.ok(window.document.querySelector("#live-ask .ask-redirect-input"), "plain-No permission prompt shows the field");
+  } finally { close(); }
+});
+
+test("an AskUserQuestion choice (not a permission prompt) shows NO redirect field", async () => {
+  const scene = SCENES.find((s) => s.id === "ask-single")!; // highlight.js / shiki / Type something
+  const { window, close } = mount();
+  try {
+    await settle();
+    drive(window, scene);
+    await settle();
+    assert.ok(!window.document.querySelector("#live-ask .ask-redirect-input"), "no redirect field on AskUserQuestion");
+  } finally { close(); }
+});
+
+test("the edit-permission popup actually renders a red/green diff block", async () => {
+  const scene = SCENES.find((s) => s.id === "perm-edit")!;
+  const { window, close } = mount();
+  try {
+    await settle();
+    drive(window, scene);
+    await settle();
+    const diff = window.document.querySelector("#live-ask .diff-fold");
+    assert.ok(diff, "edit popup must contain a .diff-fold block");
+    assert.ok(diff.textContent.includes("+") && diff.textContent.includes("-"), "diff shows +/- lines");
+  } finally { close(); }
+});

--- a/tests/test_askparse.py
+++ b/tests/test_askparse.py
@@ -7,6 +7,7 @@ synthetic fixtures, same expected outputs, same assertions. Synthetic only:
 invented prompt text, no real session data.
 """
 import os
+import re
 import unittest
 from importlib.machinery import SourceFileLoader
 
@@ -414,6 +415,235 @@ class TestAskParse(unittest.TestCase):
 # Queued-message detection moved OUT of this pane parser to an EVENT-BASED reader in bin/romp-kernel
 # (_pending_queued, folding the transcript's queue-operation records). Its tests live in test_kernel.py
 # (TestPendingQueued); the old pane-scrape parse_queued + its tests were removed (the user 2026-06-16).
+
+
+class TestDiffParsing(unittest.TestCase):
+    """Diff/body/planBody extraction from Edit/Write/NotebookEdit/ExitPlanMode permission panes."""
+
+    def test_edit_permission_diff_extracted_question_stays_clean(self):
+        fence = "╌" * 40
+        pane = "\n".join([
+            "─" * 40,
+            " Edit file",
+            " demo.txt",
+            fence,
+            " 1  context line stays",
+            " 2 -old line goes away",
+            " 2 +new line takes its place",
+            " 3  trailing context",
+            fence,
+            " Do you want to make this edit to demo.txt?",
+            " ❯ 1. Yes",
+            "   2. Yes, allow all edits during this session (shift+tab)",
+            "   3. No",
+            FOOTER,
+        ])
+        ask = parse(pane)
+        self.assertIsNotNone(ask)
+        self.assertEqual(ask["kind"], "single")
+        self.assertEqual(ask["question"], "Do you want to make this edit to demo.txt?",
+                         "diff must not bleed into the question")
+        self.assertEqual(ask["diff"],
+                         "  context line stays\n-old line goes away\n+new line takes its place\n  trailing context")
+        self.assertEqual(len(ask["options"]), 3)
+
+    def test_edit_file_header_captured_above_diff(self):
+        fence = "╌" * 40
+        pane = "\n".join([
+            "─" * 40,
+            " Edit file",
+            " ../../tmp/demo/notes.md",
+            " This will modify /tmp/demo/notes.md (outside working directory) via a symlink",
+            "",
+            fence,
+            " 1  context",
+            " 2 -old",
+            " 2 +new",
+            fence,
+            " Do you want to make this edit to notes.md?",
+            " ❯ 1. Yes",
+            "   2. No",
+            FOOTER,
+        ])
+        ask = parse(pane)
+        self.assertIsNotNone(ask)
+        self.assertEqual(ask["question"], "Do you want to make this edit to notes.md?")
+        self.assertEqual(
+            ask["fileHead"],
+            "Edit file\n../../tmp/demo/notes.md\n"
+            "This will modify /tmp/demo/notes.md (outside working directory) via a symlink",
+        )
+
+    def test_edit_blank_diff_lines_stay_own_rows(self):
+        fence = "╌" * 40
+        pad = " " * 30
+        pane = "\n".join([
+            fence,
+            " 3  intro paragraph." + pad,
+            " 4  ",                                  # blank line, number only
+            " 5 -## Section A" + pad,
+            " 5 +## Section A (revised)" + pad,
+            " 6  - item one",                        # leading-dash bullet = context
+            " 7 +- item three" + pad,
+            " 8  ",                                  # another blank
+            " 9  ## Section B",
+            fence,
+            " Do you want to make this edit to notes.md?",
+            " ❯ 1. Yes",
+            "   2. No",
+            FOOTER,
+        ])
+        ask = parse(pane)
+        self.assertIsNotNone(ask)
+        rows = ask["diff"].split("\n")
+        self.assertFalse(any(re.search(r"\b[0-9]\s*$", l) for l in rows),
+                         "a line number leaked into content:\n%s" % ask["diff"])
+        self.assertEqual(rows[0], "  intro paragraph.", "no trailing '4' folded in")
+        self.assertEqual(rows[1], "  ", "blank line is its own empty context row")
+        self.assertEqual(rows[2], "-## Section A")
+        self.assertEqual(rows[3], "+## Section A (revised)")
+        self.assertEqual(rows[4], "  - item one", "leading-dash bullet is context, not a deletion")
+        self.assertEqual(rows[5], "+- item three", "no trailing '8' folded in")
+
+    def test_write_new_file_no_marker_column(self):
+        fence = "╌" * 40
+        pane = "\n".join([
+            "─" * 40,
+            " Create file",
+            " notes.md",
+            fence,
+            " 1 ---",
+            " 2 title: Notes",
+            " 3 ---",
+            " 4 # Heading",
+            " 5 - first bullet",
+            " 6 - second bullet",
+            " 7 Some closing prose.",
+            fence,
+            " Do you want to create notes.md?",
+            " ❯ 1. Yes",
+            "   2. No",
+            FOOTER,
+        ])
+        ask = parse(pane)
+        self.assertIsNotNone(ask)
+        self.assertEqual(ask["question"], "Do you want to create notes.md?")
+        expected = "\n".join([
+            "+---", "+title: Notes", "+---", "+# Heading",
+            "+- first bullet", "+- second bullet", "+Some closing prose.",
+        ])
+        self.assertEqual(ask["diff"], expected,
+                         "every new-file line is an addition; leading '-' is content, not a deletion")
+        self.assertFalse(any(l.startswith("-") for l in ask["diff"].split("\n")),
+                         "no phantom deletions")
+
+    def test_notebook_edit_rounded_box_diff(self):
+        bx = lambda s: "│ " + s + "                    │"
+        pane = "\n".join([
+            "─" * 40,
+            " Edit notebook",
+            " This will modify /tmp/demo/demo.ipynb (outside working directory) via a symlink",
+            "",
+            "╭" + "─" * 40 + "╮",
+            bx("/tmp/demo/demo.ipynb"),
+            bx("Replace cell contents for cell cell-0"),
+            bx(""),
+            bx(' 1 -print("hello")'),
+            bx(" 1   No newline at end of file"),
+            bx(" 2 +import math"),
+            bx(" 3 +"),
+            bx(" 4 +for n in range(5):"),
+            "╰" + "─" * 40 + "╯",
+            " Do you want to make this edit to demo.ipynb?",
+            " ❯ 1. Yes",
+            "   2. No",
+            FOOTER,
+        ])
+        ask = parse(pane)
+        self.assertIsNotNone(ask)
+        self.assertEqual(ask["question"], "Do you want to make this edit to demo.ipynb?")
+        rows = ask["diff"].split("\n")
+        self.assertEqual(rows[0], '-print("hello")')
+        self.assertEqual(rows[2], "+import math")
+        self.assertIn("+for n in range(5):", rows)
+        # no box-drawing characters in parsed output
+        self.assertFalse(re.search(r"[│╭╮╰╯]", ask["diff"]),
+                         "box borders must be stripped from the diff")
+        self.assertFalse(re.search(r"[│╭╮╰╯]", ask["fileHead"]),
+                         "box borders must be stripped from the file header")
+        # file header carries the label, warning, in-box path and cell subtitle
+        self.assertIn("Edit notebook", ask["fileHead"])
+        self.assertIn("/tmp/demo/demo.ipynb", ask["fileHead"])
+        self.assertIn("Replace cell contents for cell cell-0", ask["fileHead"])
+
+    def test_exit_plan_mode_boxed_plan_is_markdown(self):
+        bx = lambda s: "│ " + s + "        │"
+        pane = "\n".join([
+            "─" * 40,
+            " Ready to code?",
+            " Here is Claude's plan:",
+            "╭" + "─" * 40 + "╮",
+            bx("## Plan"),
+            bx(""),
+            bx("1. First do a thing"),
+            bx("   - a nested detail"),
+            bx("2. Then the next thing"),
+            "╰" + "─" * 40 + "╯",
+            " Would you like to proceed?",
+            " ❯ 1. Yes, and auto-accept edits",
+            "   2. Yes, and manually approve edits",
+            "   3. No, keep planning",
+            FOOTER,
+        ])
+        ask = parse(pane)
+        self.assertIsNotNone(ask)
+        self.assertEqual(ask["question"], "Would you like to proceed?")
+        self.assertNotIn("diff", ask, "a plan is not a diff")
+        self.assertIn("planBody", ask)
+        self.assertIn("## Plan", ask["planBody"], "heading preserved")
+        self.assertIn("   - a nested detail", ask["planBody"], "nested-list indentation preserved")
+        self.assertFalse(re.search(r"[│╭╮╰╯]", ask["planBody"]),
+                         "box borders stripped from the plan")
+        self.assertEqual(len(ask["options"]), 3)
+        self.assertEqual(ask["options"][0]["label"], "Yes, and auto-accept edits")
+
+    def test_plain_permission_prompt_has_no_diff(self):
+        pane = "\n".join([
+            " Do you want to proceed?",
+            " ❯ 1. Yes",
+            "   2. No",
+            FOOTER,
+        ])
+        ask = parse(pane)
+        self.assertIsNotNone(ask)
+        self.assertNotIn("diff", ask)
+        self.assertEqual(ask["question"], "Do you want to proceed?")
+
+    def test_webfetch_permission_body_extracted(self):
+        pane = "\n".join([
+            "─" * 40,
+            " Fetch",
+            "",
+            '   url: "https://example.com", prompt: "What is the heading?"',
+            "   Claude wants to fetch content from example.com",
+            "",
+            " Do you want to allow Claude to fetch this content?",
+            " ❯ 1. Yes",
+            "   2. Yes, and don't ask again for example.com",
+            "   3. No, and tell Claude what to do differently (esc)",
+        ])
+        ask = parse(pane)
+        self.assertIsNotNone(ask)
+        self.assertEqual(ask["question"],
+                         "Do you want to allow Claude to fetch this content?",
+                         "detail must not bleed into question")
+        self.assertEqual(
+            ask["body"],
+            'url: "https://example.com", prompt: "What is the heading?"\n'
+            "Claude wants to fetch content from example.com",
+        )
+        self.assertNotIn("diff", ask)
+        self.assertEqual(len(ask["options"]), 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -2682,6 +2682,17 @@ class ViewBuilder(unittest.TestCase):
         alive = km._alive_sessions(NOW, {SID: {"state": "working"}})
         self.assertEqual([s["sid"] for s in alive], [SID])
 
+    def test_alive_stale_transcript_still_shown(self):
+        # a live tmux session whose transcript is outside discover()'s 48h window must still
+        # appear — _alive_sessions synthesizes an entry from the names registry
+        stale_sid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        (km.NAMES / stale_sid).write_text("stale-sess\t/tmp\t#1EA1EB\twhite")
+        tmux = {SID: {"state": "idle"}, stale_sid: {"state": "idle"}}
+        alive = km._alive_sessions(NOW, tmux)
+        sids = [s["sid"] for s in alive]
+        self.assertIn(SID, sids, "in-window session present")
+        self.assertIn(stale_sid, sids, "stale-transcript live session present")
+
     def test_clear_all_clears_blocked_too(self):
         d0 = km.build_feed(NOW)
         self.assertTrue([a for a in d0["asks"] if a["column"] == "needs_input"], "fixture has a blocked ask")

--- a/tests/test_kernel_apierror_working.py
+++ b/tests/test_kernel_apierror_working.py
@@ -22,7 +22,7 @@ class ApiErrorWorking(unittest.TestCase):
         src = inspect.getsource(km.build_feed)
         # api_block fires ONLY for a "prompt too long" api_top; a transient error does NOT move the card
         self.assertIn('api_block = (nid == api_top and bool(aerr and aerr.get("tooLong")))', src)
-        self.assertIn('column = ("needs_input" if (api_block or (col == "blocked" and not recheck))', src)
+        self.assertIn('column = ("needs_input" if (api_block or nid == perm_top or (col == "blocked" and not recheck))', src)
 
     def test_status_marks_tooLong_so_the_tab_can_color_it(self):
         src = inspect.getsource(km.build_session)

--- a/tests/test_kernel_feed_warm.py
+++ b/tests/test_kernel_feed_warm.py
@@ -27,7 +27,7 @@ class FeedCacheOnly(unittest.TestCase):
         # the parse-derived enrichments are all gated on `ps` (cached) so the cold first paint is just cards
         self.assertIn("if (ps and not who_working) else None", src)        # API-error floor
         self.assertIn("if ps else None", src)                              # awaiting badge
-        self.assertIn("if not had_working and ps:", src)                   # provisional card
+        self.assertIn("if not had_working and perm_top is None and ps:", src)   # provisional card
 
 
 class WarmerDoesNotCompeteWithChat(unittest.TestCase):

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -71,10 +71,9 @@ class LandingShell(unittest.TestCase):
         # the switcher runs in a separate <script> so a splitter throw can't disable the tab bar. Each shell
         # behaviour gets its own isolated <script>: boot-splash + connection-status banner + rail-usage +
         # splitter + focus-ring + fleet-toggle + settings-fullscreen + mobile switcher + per-pane collapse
-        # handles + the build-staleness banner = 10 (the user 2026-06-23; + boot-splash + rail-usage 2026-06-26;
-        # + connection-status banner 2026-06-27).
+        # handles + the build-staleness banner + keyboard-shortcuts = 11.
         html = km._landing()
-        self.assertEqual(html.count("<script>"), 10)
+        self.assertEqual(html.count("<script>"), 11)
 
     def test_bottom_bar_is_text_only_and_compact(self):
         html = km._landing()

--- a/ui/ask-types.ts
+++ b/ui/ask-types.ts
@@ -24,6 +24,10 @@ export interface ParsedAsk {
   cursorFound: boolean; // false when no ❯ was detected — capture unreliable, don't send blind keys
   chosen?: string[];    // submit screen: the answers under review (all questions, flattened)
   pairs?: { q: string; a: string }[]; // submit screen: every ● question / → answer pair, in order
+  diff?: string;        // Edit/Write permission: the fenced diff, normalized to +/- /context lines
+  fileHead?: string;    // Edit/Write permission: the label/path/warning block shown above the diff
+  planBody?: string;    // ExitPlanMode: the plan markdown (rendered as markdown, not a diff)
+  body?: string;        // non-diff tool permission (WebFetch/Bash/MCP/…): the detail block (url+prompt, command, …)
   multiSelect: boolean; // back-compat: kind === "multi"
   preview?: string;     // the side-by-side preview box (verbatim monospace text, with its border) the
                         // focused option draws to the RIGHT of the option list — undefined when none.

--- a/ui/webview/codeblock-wrap.test.ts
+++ b/ui/webview/codeblock-wrap.test.ts
@@ -24,6 +24,7 @@ test("wrapped code carries a subtle (faint) line-number gutter", () => {
   assert.match(RENDER, /class="cl"><span class="ct"/);
 });
 
-test("diffs skip the line-number gutter (they already carry +/- markers)", () => {
-  assert.match(RENDER, /highlight\(pre, false\)/);
+test("diffs use diffPre() with per-line +/- gutter rows (not hljs)", () => {
+  assert.match(RENDER, /function diffPre/);
+  assert.match(RENDER, /diff-gutter/);
 });

--- a/ui/webview/feed-checkstatus.test.ts
+++ b/ui/webview/feed-checkstatus.test.ts
@@ -10,7 +10,7 @@ import * as path from "node:path";
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
 test("the card builds a Nudge button in its actions row, beside Clear", () => {
-  assert.match(FEED, /const nudge = el\("button", "fdismiss ffollow fask-nudge"\); nudge\.textContent = "Nudge"/);
+  assert.match(FEED, /const nudge = el\("button", "fdismiss ffollow fask-nudge"\).*nudge\.textContent = "Nudge"/);
   // the action row is buttons only now (the state badges moved up to the name row, 2026-06-19)
   assert.match(FEED, /actions\.append\(apiRetry, revive, nudge, cardFup, clr\)/);
   assert.match(FEED, /a\._nudge = nudge;/);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -340,7 +340,7 @@ function makeCard(it: FeedItem): HTMLElement {
   clr.onclick = (ev) => {
     ev.stopPropagation();
     pendingCleared.add(it.itemId);   // suppress until the kernel confirms — no mid-dismiss pop-back
-    clearedStack.push([it]);         // cache for an instant optimistic Undo clear
+    clearedStack.push([it as unknown as AskItem]);
     card.classList.add("dismissing");
     vscodeApi?.postMessage({ type: "askClear", itemId: it.itemId });   // reply ids share cleared.jsonl
     setTimeout(() => { if (cardEls.get(it.itemId) === card && card.classList.contains("dismissing")) { card.remove(); cardEls.delete(it.itemId); } }, 180);
@@ -475,7 +475,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   // "Nudge" on the card itself (the user 2026-06-18): a one-click status follow-up for a WORKING card,
   // beside Clear, so you don't have to open the modal. Sends the canned status question down the SAME
   // follow-up path (askFollowUp → the kernel quotes the goal as context). Shown only for working cards.
-  const nudge = el("button", "fdismiss ffollow fask-nudge"); nudge.textContent = "Nudge"; nudge.title = "nudge this session for a status update on this goal"; nudge.style.display = "none";
+  const nudge = el("button", "fdismiss ffollow fask-nudge") as HTMLButtonElement; nudge.textContent = "Nudge"; nudge.title = "nudge this session for a status update on this goal"; nudge.style.display = "none";
   // "Follow up" on a BLOCKED or COMPLETED card (the user 2026-06-22): one click opens THIS goal's modal and
   // jumps straight into its follow-up composer (via openFollowUpOnRender), saving the open-modal-then-click
   // step. The modal's own Follow up button stays. Working cards get Nudge instead — the two are mutually

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1854,7 +1854,7 @@ function copyToClipboard(text: string) {
 // reflects it before the next push (the kernel reconciles).
 function setSessionFlag(id: string, flag: "hideFromFeed" | "postalServiceOff", value: boolean) {
   const s = sessions.get(id);
-  if (s) (s as Record<string, unknown>)[flag] = value;
+  if (s) (s as unknown as Record<string, unknown>)[flag] = value;
   if (vscodeApi) vscodeApi.postMessage({ type: "setSessionFlag", id, flag, value });
 }
 // Override a session's identity color from the tab menu's swatches (the user 2026-06-29). Optimistically paint

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -318,6 +318,58 @@ function preEl(text: string): HTMLElement {
   return pre;
 }
 
+/** Red/green diff renderer — each line gets its own div.diff-row with a gutter marker and colored band. */
+function diffPre(diffText: string): HTMLElement {
+  const box = el("div", "fold-pre diff-fold");
+  for (const line of diffText.split("\n")) {
+    const m = line[0];
+    const kind = m === "+" ? "add" : m === "-" ? "del" : "ctx";
+    const row = el("div", "diff-row diff-" + kind);
+    const gutter = el("span", "diff-gutter"); gutter.textContent = m === "+" || m === "-" ? m : " ";
+    const text = el("span", "diff-text"); text.textContent = m === "+" || m === "-" ? line.slice(1) : line.replace(/^ {2}/, "");
+    row.appendChild(gutter); row.appendChild(text);
+    box.appendChild(row);
+  }
+  return box;
+}
+
+/** File header for Edit/Write diffs — paths get mono styling, notes get dimmed. */
+function fileHead(text: string): HTMLElement {
+  const wrap = el("div", "ask-filehead");
+  for (const line of text.split("\n")) {
+    const isPath = /^\S+$/.test(line) && /[/.]/.test(line);
+    const row = el("div", isPath ? "ask-file-path" : "ask-file-note");
+    row.textContent = line;
+    wrap.appendChild(row);
+  }
+  return wrap;
+}
+
+/** Tool-permission detail block (Bash command, WebFetch url, MCP call). */
+function askBody(body: string): HTMLElement {
+  const wrap = el("div", "ask-body");
+  const lines = body.split("\n");
+  let descStart = -1;
+  for (let i = lines.length - 1; i >= 1; i--) {
+    const t = lines[i].trim();
+    if (/[=|&$<>{}`\\]/.test(t)) break;
+    if (/^[A-Z]/.test(t) && /\s/.test(t)) descStart = i;
+  }
+  const target = descStart >= 1 ? lines.slice(0, descStart) : lines;
+  const desc = descStart >= 1 ? lines.slice(descStart).join(" ").trim() : undefined;
+
+  let detail = target.join("\n");
+  const cmd = el("div", "ask-cmd");
+  cmd.textContent = detail;
+  wrap.appendChild(cmd);
+  if (desc) {
+    const d = el("div", "ask-body-desc");
+    d.textContent = desc;
+    wrap.appendChild(d);
+  }
+  return wrap;
+}
+
 // Links in the chat (markdown [x](url) and GFM-autolinked bare URLs alike, all rendered as <a href>
 // by md()) must actually follow on click. Two hosts, two paths:
 //   • Web dashboard (http(s): origin): open it in the user's OWN browser, on the device they're viewing
@@ -1243,10 +1295,8 @@ function renderTool(ev: Extract<ChatEvent, { kind: "tool" }>): HTMLElement {
     // Edit/MultiEdit: "+add −del" on the head line; the red/green diff hangs below, hidden.
     let add = 0, del = 0;
     for (const l of ev.diff.split("\n")) { if (l[0] === "+") add++; else if (l[0] === "-") del++; }
-    const pre = el("pre", "io-pre fold-pre diff-fold");
-    const code = el("code", "language-diff"); code.textContent = ev.diff; pre.appendChild(code);
+    const pre = diffPre(ev.diff);
     inlineFold(head, turn, `+${add} −${del}`, pre, fkey);
-    highlight(pre, false);   // diffs carry +/− markers + already wrap (io-pre); no line-number gutter
   } else if (ev.name === "Read") {
     if (ev.output) inlineFold(head, turn, `${countLines(ev.output)} lines`, preEl(ev.output), fkey);
   } else if (!ack && (ev.input || ev.output)) {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3646,6 +3646,10 @@ function singleOptions(ask: ParsedAsk) {
 // its "Type something." slot is driven by the inline custom-answer field.
 function renderSingleCard(ask: ParsedAsk) {
   const card = askCard();
+  if (ask.fileHead) card.appendChild(fileHead(ask.fileHead));
+  if (ask.diff) card.appendChild(diffPre(ask.diff));
+  if (ask.planBody) { const plan = el("div", "ask-plan"); plan.innerHTML = DOMPurify.sanitize(marked.parse(ask.planBody) as string); card.appendChild(plan); }
+  if (ask.body) card.appendChild(askBody(ask.body));
   qline(card, ask.question || ask.header);
   const opts = singleOptions(ask);
   const key = (activeId || "") + "§" + opts.map((o) => `${o.n}:${o.label}`).join("|");
@@ -3674,6 +3678,18 @@ function renderSingleCard(ask: ParsedAsk) {
     wirePasteFallback(inp);
     row.appendChild(inp);
     card.appendChild(row);
+  }
+  if (ask.diff !== undefined || ask.body !== undefined || ask.planBody !== undefined) {
+    const redir = el("div", "ask-redirect");
+    const arrow = el("span", "ask-redirect-arrow"); arrow.textContent = "↩"; redir.appendChild(arrow);
+    const rinp = document.createElement("input");
+    rinp.type = "text"; rinp.className = "ask-redirect-input"; rinp.placeholder = "tell Claude what to do differently…";
+    rinp.addEventListener("keydown", (e) => {
+      e.stopPropagation();
+      if (e.key === "Enter") { e.preventDefault(); const v = rinp.value.trim(); if (v && activeId) { if (vscodeApi) vscodeApi.postMessage({ type: "redirectAsk", id: activeId, text: v }); } }
+    });
+    redir.appendChild(rinp);
+    card.appendChild(redir);
   }
   card.tabIndex = 0;
   card.addEventListener("keydown", onSingleKey);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -935,6 +935,37 @@ body { display: flex; flex-direction: column; }
 /* the "↳ You answered Claude's question" marker line atop the box */
 .ask-answered-tag { font-size: 0.72em; letter-spacing: 0.04em; font-weight: 700; color: #6da0ff; margin-bottom: 6px; }
 
+/* ask-card sub-components: file header, plan box, diff fold, body/cmd */
+.ask-card .ask-filehead { margin: 2px 0 7px; font-family: var(--mono); font-size: 0.86em; line-height: 1.45; }
+.ask-file-path { color: var(--fg); overflow-wrap: anywhere; }
+.ask-file-note { color: var(--dim); overflow-wrap: anywhere; }
+.ask-card .ask-plan {
+  margin: 2px 0 9px; padding: 9px 13px; max-height: 360px; overflow: auto;
+  border: 1px solid var(--box-border); border-radius: 6px; background: var(--box-bg);
+}
+.ask-card .ask-plan > :first-child { margin-top: 0; }
+.ask-card .ask-plan > :last-child { margin-bottom: 0; }
+.ask-card .diff-fold { margin: 2px 0 9px; max-height: 320px; }
+.ask-card .ask-body { margin: 2px 0 9px; }
+.ask-cmd {
+  font-family: var(--mono); font-size: 0.9em; line-height: 1.5;
+  white-space: pre-wrap; overflow-wrap: anywhere; color: var(--fg);
+  border: 1px solid var(--box-border); border-radius: 6px; background: var(--box-bg);
+  padding: 8px 11px; max-height: 240px; overflow: auto;
+}
+.ask-body-desc { color: var(--dim); margin-top: 5px; font-size: 0.85em; font-style: italic; line-height: 1.45; overflow-wrap: anywhere; }
+
+/* ask-redirect: inline redirect input below a permission card */
+.ask-redirect { display: flex; gap: 8px; align-items: center; padding: 7px 9px 2px; margin-top: 5px; border-top: 1px solid var(--box-border); }
+.ask-redirect-arrow { flex: 0 0 auto; color: var(--dim); font-weight: 700; }
+.ask-redirect-input {
+  flex: 1 1 auto; box-sizing: border-box; min-width: 0;
+  background: var(--vscode-input-background, rgba(255, 255, 255, 0.05));
+  color: var(--vscode-input-foreground, var(--fg));
+  border: 1px solid var(--vscode-input-border, var(--box-border));
+  border-radius: 6px; padding: 5px 9px; font: inherit; outline: none;
+}
+
 /* ---------- live "awaiting your input" picker (pending, click-to-answer) ---------- */
 /* The picker is part of the scrolling transcript (the user 2026-06-27): it's the last child of #content and
    flows at the BOTTOM of the chat, scrolling WITH the history — no fixed region, no separate scrollbar, so a
@@ -946,10 +977,10 @@ body { display: flex; flex-direction: column; }
   box-shadow: inset 3px 0 0 var(--st-awaiting-bg);
   outline: none; /* the highlighted row is the cue, not a focus ring */
 }
-.ask-live .ask-qtext { margin-bottom: 7px; }
+.ask-live .ask-qtext { margin-bottom: 4px; }
 .ask-live-opt {
   display: flex; gap: 9px; align-items: baseline;
-  border-radius: 5px; padding: 5px 9px; color: var(--fg); cursor: pointer;
+  border-radius: 5px; padding: 2px 9px; color: var(--fg); cursor: pointer;
 }
 .ask-live-opt.focus { background: rgba(255, 255, 255, 0.10); box-shadow: inset 2px 0 0 var(--st-awaiting-bg); }
 .ask-live-opt .ask-optlabel { flex: 0 0 auto; font-weight: 600; }
@@ -1198,9 +1229,16 @@ body { display: flex; flex-direction: column; }
   border: 1px solid var(--box-border); border-radius: 6px; background: var(--box-bg);
 }
 
-/* diff (Edit/MultiEdit): collapsed by default; reuse the hljs add/del accents */
-.diff-fold .hljs-addition { color: var(--green); }
-.diff-fold .hljs-deletion { color: var(--err); }
+/* diff (Edit/MultiEdit): red/green row bands with gutter markers */
+.diff-fold { padding: 7px 0; font-family: var(--mono); font-size: 0.9em; line-height: 1.5; }
+.diff-row { display: flex; gap: 8px; padding: 0 13px; white-space: pre-wrap; overflow-wrap: anywhere; }
+.diff-gutter { flex: 0 0 auto; width: 1ch; text-align: center; opacity: 0.7; user-select: none; }
+.diff-text { flex: 1; min-width: 0; }
+.diff-ctx { color: var(--fg); }
+.diff-add { background: rgba(116, 201, 145, 0.14); }
+.diff-add .diff-text, .diff-add .diff-gutter { color: var(--green); }
+.diff-del { background: rgba(229, 110, 110, 0.14); }
+.diff-del .diff-text, .diff-del .diff-gutter { color: var(--err); }
 
 /* ---------- markdown ---------- */
 .md { overflow-wrap: anywhere; } /* wrap long unbreakable strings (tokens/base64/urls) */
@@ -1373,6 +1411,13 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
   font-family: var(--sans); font-size: 0.92em;
 }
 .picker-action:hover { background: rgba(255, 255, 255, 0.1); }
+.picker-forget {
+  flex: 0 0 auto; background: none; border: none; cursor: pointer;
+  color: var(--dim); font-size: 0.95em; line-height: 1; padding: 2px 4px;
+  border-radius: 4px; opacity: 0; transition: opacity 0.1s;
+}
+.picker-row:hover .picker-forget, .picker-row.active .picker-forget { opacity: 0.7; }
+.picker-forget:hover { opacity: 1; color: var(--st-permission-bg, #f85b5a); background: rgba(255, 255, 255, 0.10); }
 /* armed (auto-selected) when the typed name matches no session — Enter creates it;
    same focus-color accent as .picker-row.active so the highlight reads as "selected" */
 .picker-action.active {


### PR DESCRIPTION
## Summary

- **Fix: live tmux sessions with stale transcripts now always appear.** `_alive_sessions` filtered through `discover()` which has a 48h window — so sessions alive in tmux but with old transcripts (>48h) were invisible. Five of eleven sessions were missing. Now synthesizes session entries from the names registry for any live tmux session not found by discover.
- **Configurable discover window.** Default changed from 48h to 1.5 weeks (10.5 days). New gear UI control ("Session history window") persists to `~/.config/romp/discover-window`.
- **Port stashed features** from pre-kernel-rewrite to current file locations: diff rendering (red/green bands), file header display, plan body, tool permission detail blocks, ask redirect, picker forget button, askparse diff extraction.

## Test plan
- [ ] Restart the kernel and verify all 11 live sessions appear
- [ ] Open the gear → Sessions section → confirm "Session history window" input shows 10.5 days
- [ ] Change the value, restart, confirm it persists
- [ ] `python3 -m unittest discover -s tests -p "test_*.py"` (1140 pass, 3 pre-existing failures)
- [ ] `cd chat-view && npm test` (574 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)