### PR TITLE
Pre-push identifier hook + shallow-clone docs

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# romp pre-push hook: refuse to push if any file carries a personal identifier.
+#
+# This repo may go public, and history is permanent. tests/test_no_personal_
+# identifiers.py scans every tracked + untracked file for this machine's own
+# identifiers (hostname, home path, and the strings in ~/.config/romp/private-
+# strings.txt). Running it here catches a leak BEFORE it leaves the machine,
+# where it can still be fixed, instead of after it is public.
+#
+# Fast (~0.1s), so it is safe on every push. Bypass a false positive with
+# `git push --no-verify`. Installed by install.sh (symlinked into the shared
+# git hooks dir, so it fires from every worktree); self-locates the worktree
+# being pushed, so one shared hook checks whichever tree you push from.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$root" ] || exit 0                       # not in a work tree → nothing to scan
+
+check="$root/tests/test_no_personal_identifiers.py"
+[ -f "$check" ] || exit 0                       # e.g. a partial checkout without tests/
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "romp pre-push: python3 not found — SKIPPING the identifier scan." >&2
+    echo "  (install python3, or 'git push --no-verify' to bypass this one push)" >&2
+    exit 0
+fi
+
+if ! ( cd "$root" && python3 "$check" ); then
+    echo "" >&2
+    echo "romp pre-push: BLOCKED — a personal identifier was found (see above)." >&2
+    echo "  Replace it with synthetic data (see CONTRIBUTING.md), then push again." >&2
+    echo "  To bypass for one push (you are sure it is fine): git push --no-verify" >&2
+    exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -55,11 +55,14 @@ You run Romp yourself, on your laptop or a server, with no hosted service in bet
 ## Quick start
 
 ```bash
-git clone https://github.com/romp-on/romp.git
+git clone --depth 1 https://github.com/romp-on/romp.git
 cd romp
 ./install.sh
 export PATH="$PATH:$(pwd)/bin"   # add this to your shell rc
 ```
+
+`--depth 1` grabs just the latest commit (a few MB instead of the full
+history); Romp runs the same either way. Drop it if you want the whole history.
 
 Run `romp launch`. It opens the dashboard in your browser and prints the link
 too — the link carries a one-time access token, and after that first open plain

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,11 +24,14 @@ sudo apt install python3 nodejs npm
 ## Install
 
 ```bash
-git clone https://github.com/romp-on/romp.git
+git clone --depth 1 https://github.com/romp-on/romp.git
 cd romp
 ./install.sh
 export PATH="$PATH:$(pwd)/bin"   # add this line to your shell rc
 ```
+
+`--depth 1` clones only the latest commit, which is a few MB rather than the
+whole history; Romp behaves identically. Omit it if you want the full history.
 
 The installer registers Romp with Claude Code (the hooks, the postal service,
 the `romp` skills, and the VS Code / Cursor extension) and keeps the kernel

--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,27 @@ for h in romp-summarize.sh romp-postal-drain.sh romp-postal-ensure.sh \
 done
 echo "  Symlinked romp hooks into ~/.claude/hooks/"
 
+# Install the git pre-push identifier hook. Symlinked into the SHARED git hooks
+# dir (git rev-parse --git-common-dir), so it fires from every worktree; the hook
+# self-locates the tree being pushed. ROMP_GITHOOK_DIR overrides the target (the
+# test harness points it at a temp dir so it never touches a real .git). Skipped
+# with ROMP_NO_GITHOOK, or when this isn't a git checkout (e.g. a tarball).
+if [[ -z "${ROMP_NO_GITHOOK:-}" && -f "$ROMP_DIR/.githooks/pre-push" ]]; then
+    githook_dir="${ROMP_GITHOOK_DIR:-}"
+    if [[ -z "$githook_dir" ]]; then
+        common="$(git -C "$ROMP_DIR" rev-parse --git-common-dir 2>/dev/null || true)"
+        if [[ -n "$common" ]]; then
+            case "$common" in /*) ;; *) common="$ROMP_DIR/$common" ;; esac
+            githook_dir="$common/hooks"
+        fi
+    fi
+    if [[ -n "$githook_dir" ]]; then
+        mkdir -p "$githook_dir"
+        ln -sf "$ROMP_DIR/.githooks/pre-push" "$githook_dir/pre-push"
+        echo "  Installed the git pre-push identifier hook"
+    fi
+fi
+
 # Register the hooks in ~/.claude/settings.json so Claude Code actually fires
 # them. Idempotent merge: adds only missing romp entries, never touches any
 # other hooks you have registered.

--- a/tests/install-sh.bats
+++ b/tests/install-sh.bats
@@ -13,6 +13,9 @@ setup() {
     export HOME="$TEST_DIR/home"
     mkdir -p "$HOME"
     export ROMP_NO_SERVICE=1 ROMP_NO_EXT=1 ROMP_NO_SDK=1
+    # Redirect the git pre-push hook symlink into a temp dir so install.sh never
+    # writes into the REAL repo's .git/hooks while these tests run.
+    export ROMP_GITHOOK_DIR="$TEST_DIR/githooks"
 }
 
 teardown() { rm -rf "$TEST_DIR"; }
@@ -197,4 +200,65 @@ PY
     [ "$status" -ne 0 ]                            # the failure still surfaces
     [ "$(cat "$EXT/package.json")" = "$before" ]   # ...and the trap still restored
     [ ! -f "$EXT/package.json.orig" ]
+}
+
+# ── git pre-push identifier hook ──────────────────────────────────────
+# The repo may go public and history is permanent, so a personal identifier must
+# never leave the machine. install.sh symlinks .githooks/pre-push into the shared
+# git hooks dir; the hook runs tests/test_no_personal_identifiers.py and blocks a
+# push that would leak one. (ROMP_GITHOOK_DIR redirects the target in setup().)
+
+@test "install.sh: symlinks the pre-push hook into the git hooks dir" {
+    run "$ROMP_DIR/install.sh"
+    [ "$status" -eq 0 ]
+    [ -L "$ROMP_GITHOOK_DIR/pre-push" ]
+    [[ "$(readlink "$ROMP_GITHOOK_DIR/pre-push")" == *"/.githooks/pre-push" ]]
+}
+
+@test "install.sh: ROMP_NO_GITHOOK skips the pre-push hook" {
+    ROMP_NO_GITHOOK=1 run "$ROMP_DIR/install.sh"
+    [ "$status" -eq 0 ]
+    [ ! -e "$ROMP_GITHOOK_DIR/pre-push" ]
+}
+
+# Behaviour of the hook itself, exercised through a real `git push` to a bare
+# remote, with a SYNTHETIC denylist (never a real identifier) via XDG_CONFIG_HOME.
+setup_hook_repo() {
+    export XDG_CONFIG_HOME="$TEST_DIR/cfg"
+    mkdir -p "$XDG_CONFIG_HOME/romp"
+    printf 'ZZBANNEDZZ\n' > "$XDG_CONFIG_HOME/romp/private-strings.txt"
+    git init -q "$TEST_DIR/remote.git" --bare
+    WORK="$TEST_DIR/work"
+    git init -q "$WORK"
+    git -C "$WORK" config user.email t@e.invalid
+    git -C "$WORK" config user.name t
+    mkdir -p "$WORK/tests"
+    cp "$ROMP_DIR/tests/test_no_personal_identifiers.py" "$WORK/tests/"
+    cp "$ROMP_DIR/.githooks/pre-push" "$WORK/.git/hooks/pre-push"
+    git -C "$WORK" remote add origin "$TEST_DIR/remote.git"
+}
+
+@test "pre-push hook: allows a push when the tree is clean" {
+    setup_hook_repo
+    echo "clean" > "$WORK/ok.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm clean
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -eq 0 ]
+}
+
+@test "pre-push hook: blocks a push that would leak an identifier" {
+    setup_hook_repo
+    printf 'leak ZZBANNEDZZ here\n' > "$WORK/leak.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm leak
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"BLOCKED"* ]]
+}
+
+@test "pre-push hook: --no-verify bypasses the block" {
+    setup_hook_repo
+    printf 'leak ZZBANNEDZZ here\n' > "$WORK/leak.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm leak
+    run git -C "$WORK" push --no-verify origin HEAD:main
+    [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Two release-prep items.

## Pre-push identifier hook

`.githooks/pre-push` refuses to push when any file carries a personal identifier. It runs `tests/test_no_personal_identifiers.py` (scans tracked + untracked files for this machine's hostname, home path, and `~/.config/romp/private-strings.txt`). The repo may go public and history is permanent, so catching a leak **before** it leaves the machine beats catching it after. ~0.1s, safe on every push; bypass a false positive with `git push --no-verify`.

`install.sh` symlinks it into the shared git hooks dir (`git rev-parse --git-common-dir`) so it fires from every worktree, and the hook self-locates the tree being pushed. `ROMP_NO_GITHOOK` skips it; `ROMP_GITHOOK_DIR` redirects the target so tests never touch a real `.git`.

Five bats tests: install, skip, clean-push-allowed, leak-blocked, `--no-verify`-bypass — exercised through a real `git push` to a bare remote with a synthetic denylist.

## Shallow-clone docs

README and install docs now show `git clone --depth 1`: ~15MB vs ~180MB full, romp runs identically.

## Verification

Local (CI is billing-blocked until the repo is public, so local is the gate): pytest 2928 passed / 25 skipped, bats 213 passed / 0 failed. Expect Linux-only CI checks (macOS is manual-dispatch since #3).

Generated with [Claude Code](https://claude.com/claude-code)