### PR TITLE
Add scripts/release.sh: hard-gate a version tag on the macOS run

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# scripts/release.sh vX.Y.Z — cut a romp release, with the macOS check as a HARD GATE.
+#
+# Why a script rather than `git tag`: two release rules are easy to get wrong by hand
+# and expensive to get wrong in public.
+#
+#   1. The tag MUST be v-prefixed. bootstrap.sh picks the release with
+#      `git tag -l 'v*' --sort=-v:refname | head -n1`. A tag like "0.1.0" matches
+#      NOTHING, so the one-line installer silently falls back to main instead of
+#      installing the release — no error, just the wrong thing. This refuses a
+#      non-v tag outright.
+#   2. macOS CI does not run on pushes (it is billed even on public repos, ~10x,
+#      so it is workflow_dispatch-only). That means a macOS-only breakage can sit
+#      undetected until a user hits it. Releasing is exactly when that matters, so
+#      this triggers the macOS run and REFUSES to tag unless it goes green.
+#
+# --skip-macos exists for the case where you must ship anyway; it is deliberately
+# an explicit flag (never an env default) and it says so loudly.
+set -euo pipefail
+
+GH="${ROMP_GH:-gh}"                       # overridable so tests can stub the GitHub CLI
+POLL="${ROMP_RELEASE_POLL:-5}"            # seconds between checks while the run starts
+REF="${ROMP_RELEASE_REF:-main}"
+skip_macos=0
+
+usage() { echo "usage: scripts/release.sh vX.Y.Z [--skip-macos]" >&2; exit 2; }
+
+tag=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --skip-macos) skip_macos=1 ;;
+        -h|--help)    usage ;;
+        -*)           echo "release: unknown flag $1" >&2; usage ;;
+        *)            [ -z "$tag" ] || usage; tag="$1" ;;
+    esac
+    shift
+done
+[ -n "$tag" ] || usage
+
+die() { echo "release: $*" >&2; exit 1; }
+
+# ── 1. the v-prefix rule ──────────────────────────────────────────────
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+    die "tag must be v-prefixed semver, e.g. v0.1.0 (got '$tag').
+  bootstrap.sh selects releases with \`git tag -l 'v*'\`; a non-v tag matches
+  nothing and the installer silently falls back to main."
+fi
+
+# Resolve the repo from THIS SCRIPT's location, never the caller's cwd. With
+# `git rev-parse --show-toplevel` the script would inspect — and tag — whatever
+# repo you happened to be standing in, reading that tree's cleanliness and
+# VERSION instead of the one being released.
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+# `&&` would make a MISSING tag (the normal case) the last command and exit
+# non-zero under `set -e`, so this is an explicit if.
+if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+    die "tag $tag already exists."
+fi
+
+# ── 2. the tree must be releasable ────────────────────────────────────
+[ -z "$(git status --porcelain)" ] || die "working tree is dirty — commit or stash first."
+
+# VERSION carries the number without the v; a mismatch means one of them was forgotten.
+if [ -f VERSION ]; then
+    want="${tag#v}"
+    have="$(tr -d '[:space:]' < VERSION)"
+    [ "$want" = "$have" ] || die "VERSION says '$have' but the tag is '$tag' — update VERSION first."
+fi
+
+# ── 3. the macOS gate ─────────────────────────────────────────────────
+if [ "$skip_macos" -eq 1 ]; then
+    echo "release: !! SKIPPING the macOS check at your explicit request (--skip-macos)."
+    echo "release: !! a macOS-only breakage in $tag would reach users undetected."
+else
+    echo "release: triggering the macOS CI run on $REF (it is dispatch-only, so this is the check)..."
+    before="$("$GH" run list --workflow CI --event workflow_dispatch -L 1 --json databaseId -q '.[0].databaseId // ""' 2>/dev/null || true)"
+    "$GH" workflow run CI --ref "$REF" || die "could not dispatch the CI workflow."
+
+    # Identify OUR run by waiting for the newest dispatch run to differ from the one
+    # that was newest before we dispatched — `gh workflow run` prints no run id, and
+    # taking the newest unconditionally would happily watch a PREVIOUS run and pass
+    # the gate on a stale green.
+    #
+    # Each guard is a full `if`: under `set -e`, a bare `[ x ] && y` whose test is
+    # false makes the whole list non-zero and kills the script.
+    run_id=""
+    for _ in $(seq 1 60); do
+        if [ "$POLL" != "0" ]; then sleep "$POLL"; fi
+        cur="$("$GH" run list --workflow CI --event workflow_dispatch -L 1 --json databaseId -q '.[0].databaseId // ""' 2>/dev/null || true)"
+        if [ -n "$cur" ] && [ "$cur" != "$before" ]; then run_id="$cur"; break; fi
+        if [ "$POLL" = "0" ]; then break; fi     # test mode: never spin
+    done
+    if [ -z "$run_id" ]; then
+        die "the dispatched CI run never appeared — check the Actions tab."
+    fi
+
+    echo "release: watching run $run_id (macOS bats is ~16 min; this is the wait you are paying for)..."
+    "$GH" run watch "$run_id" --exit-status \
+        || die "the macOS run did not pass — NOT tagging $tag.
+  Fix it, or re-run with --skip-macos if you have decided to ship anyway."
+    echo "release: macOS run green."
+fi
+
+# ── 4. tag ────────────────────────────────────────────────────────────
+git tag -a "$tag" -m "romp $tag"
+echo "release: created tag $tag."
+echo "release: push it with:  git push origin $tag"

--- a/tests/release-sh.bats
+++ b/tests/release-sh.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+
+# scripts/release.sh — the release gate. Two rules it exists to enforce:
+#   * the tag must be v-prefixed (bootstrap.sh's `git tag -l 'v*'` selector matches
+#     nothing otherwise, and the installer silently falls back to main), and
+#   * the macOS CI run — which is dispatch-only, since macOS is billed even on public
+#     repos — must be GREEN before a version is tagged.
+# The GitHub CLI is stubbed via ROMP_GH so none of this touches real CI.
+
+ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    REPO="$TEST_DIR/repo"
+    mkdir -p "$REPO/scripts"
+    cp "$ROMP_DIR/scripts/release.sh" "$REPO/scripts/"
+    git init -q "$REPO"
+    git -C "$REPO" config user.email t@e.invalid
+    git -C "$REPO" config user.name t
+    echo "0.1.0" > "$REPO/VERSION"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -qm init
+    export ROMP_RELEASE_POLL=0          # no sleeping in tests
+    export GH_LOG="$TEST_DIR/gh.log"
+}
+teardown() { rm -rf "$TEST_DIR"; }
+
+# $1 = conclusion the stubbed `gh run watch` should report (pass|fail)
+_stub_gh() {
+    cat > "$TEST_DIR/gh" <<STUB
+#!/usr/bin/env bash
+TEST_DIR="$TEST_DIR"
+echo "\$@" >> "$GH_LOG"
+case "\$1 \$2" in
+  # a NEW run id appears only after a dispatch, as the real API behaves
+  "run list")   if [ -f "$TEST_DIR/dispatched" ]; then echo 1000; else echo 999; fi ;;
+  "workflow run") touch "$TEST_DIR/dispatched"; exit 0 ;;
+  "run watch")  [ "\${STUB_WATCH:-pass}" = pass ] && exit 0 || exit 1 ;;
+esac
+exit 0
+STUB
+    chmod +x "$TEST_DIR/gh"
+    export ROMP_GH="$TEST_DIR/gh"
+}
+
+@test "release: refuses a tag that is not v-prefixed" {
+    _stub_gh
+    run "$REPO/scripts/release.sh" 0.1.0
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"must be v-prefixed"* ]]
+    # and it bailed BEFORE spending 16 minutes of macOS CI
+    [ ! -s "$GH_LOG" ]
+}
+
+@test "release: refuses when the macOS run fails, and does NOT tag" {
+    _stub_gh
+    STUB_WATCH=fail run "$REPO/scripts/release.sh" v0.1.0
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"macOS run did not pass"* ]]
+    run git -C "$REPO" tag -l
+    [ -z "$output" ]
+}
+
+@test "release: tags when the macOS run is green" {
+    _stub_gh
+    run "$REPO/scripts/release.sh" v0.1.0
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"macOS run green"* ]]
+    run git -C "$REPO" tag -l
+    [ "$output" = "v0.1.0" ]
+    grep -q "workflow run CI" "$GH_LOG"      # it really did dispatch
+}
+
+@test "release: --skip-macos tags without CI, but says so loudly" {
+    _stub_gh
+    run "$REPO/scripts/release.sh" v0.1.0 --skip-macos
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKIPPING the macOS check"* ]]
+    [ ! -s "$GH_LOG" ]                        # no CI was dispatched
+    run git -C "$REPO" tag -l
+    [ "$output" = "v0.1.0" ]
+}
+
+@test "release: refuses when VERSION disagrees with the tag" {
+    _stub_gh
+    run "$REPO/scripts/release.sh" v9.9.9
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"VERSION says"* ]]
+}
+
+@test "release: refuses a dirty tree" {
+    _stub_gh
+    echo dirty > "$REPO/junk.txt"
+    git -C "$REPO" add junk.txt
+    run "$REPO/scripts/release.sh" v0.1.0
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"dirty"* ]]
+}
+
+@test "release: refuses a tag that already exists" {
+    _stub_gh
+    git -C "$REPO" tag v0.1.0
+    run "$REPO/scripts/release.sh" v0.1.0
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"already exists"* ]]
+}
+
+@test "release: the v-prefix guard accepts a prerelease tag" {
+    _stub_gh
+    echo "0.2.0-rc.1" > "$REPO/VERSION"
+    git -C "$REPO" commit -qam ver
+    run "$REPO/scripts/release.sh" v0.2.0-rc.1
+    [ "$status" -eq 0 ]
+    run git -C "$REPO" tag -l
+    [ "$output" = "v0.2.0-rc.1" ]
+}


### PR DESCRIPTION
Implements the hard block the user chose for the pre-tag macOS check.

## Why

Releasing is the one moment a macOS-only breakage matters, and macOS CI no longer runs on pushes (billed even on public repos at ~10x, so it's `workflow_dispatch`-only since #3). This triggers that run and **refuses to tag unless it's green**.

It also encodes the **v-prefix rule** romp_docs flagged: `bootstrap.sh` selects a release with `git tag -l 'v*' --sort=-v:refname`, so a tag like `0.1.0` matches *nothing* and the one-line installer silently falls back to main — no error, just the wrong thing installed. Verified: the repo's only existing tag, `dual-host-baseline`, is exactly what a naive newest-tag selector picks instead.

## Guards

Non-v tag (before spending any CI), dirty tree, tag already exists, VERSION disagrees with the tag. `--skip-macos` exists for shipping anyway — explicit flag, never an env default, and it says so loudly.

## Two bugs found while testing

- **Repo resolved from cwd.** `git rev-parse --show-toplevel` read the cleanliness and VERSION of whatever repo you were standing in, and would tag *that* one. Now self-locates from the script's path.
- **Stale-green risk.** `gh workflow run` prints no run id; taking the newest run unconditionally would watch a *previous* run and pass the gate on a stale green. Now waits for the newest dispatch run to change.

## Tests

8 bats tests with a stubbed `gh`, no real CI: v-prefix refusal, fail-path doesn't tag, green-path tags, `--skip-macos`, VERSION mismatch, dirty tree, duplicate tag, prerelease tag.

Local: bats 221 passed / 0 failed, privacy check clean.

**Not proven:** the live dispatch path can't run end-to-end until the repo is public (CI billing-blocked), so that half is stubbed.

Generated with [Claude Code](https://claude.com/claude-code)