### PR TITLE
Renumber the default ports: kernel 7433 -> 29855, postal bus 47100 -> 25302

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ history); Romp runs the same either way. Drop it if you want the whole history.
 
 Run `romp launch`. It opens the dashboard in your browser and prints the link
 too — the link carries a one-time access token, and after that first open plain
-`http://127.0.0.1:7433/` works (a cookie remembers you). Start a session.
+`http://127.0.0.1:29855/` works (a cookie remembers you). Start a session.
 
 ## Docs
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ assumes, what that means on a shared machine, and how to report a vulnerability.
 
 Two local services run on your machine:
 
-- the **kernel** (dashboard/API) on `127.0.0.1:7433`, and
+- the **kernel** (dashboard/API) on `127.0.0.1:29855`, and
 - the **postal bus** (inter-session messaging) on `127.0.0.1` (a fixed local port).
 
 Both bind **loopback only** (`127.0.0.1`); neither is exposed to your network by

--- a/bin/README.md
+++ b/bin/README.md
@@ -29,7 +29,7 @@ no separate implementation to point at.
 
 | Command | Source | What it is |
 |---|---|---|
-| `romp-kernel` | `kernel/kernel.py` | **The** kernel: parses transcripts into the event tree, runs the judges, serves chat/feed/fleet/timeline over HTTP+WebSocket on `127.0.0.1:7433`. Spawned by `romp-serve`. |
+| `romp-kernel` | `kernel/kernel.py` | **The** kernel: parses transcripts into the event tree, runs the judges, serves chat/feed/fleet/timeline over HTTP+WebSocket on `127.0.0.1:29855`. Spawned by `romp-serve`. |
 | `romp-event-model` | `kernel/event_model.py` | Layer 1: transcript → event tree (atoms/segments/turns). Loaded by the kernel and the judges. |
 | `romp-judge` | `kernel/judge.py` | Layer 2: the judge engine + all judge prompts (captioner, archiver, planner, …). `docs/judges.md`. |
 | `romp-askparse` | `kernel/askparse.py` | Parses the AskUserQuestion picker out of a captured tmux pane (tmux backend only; SDK sessions get the picker natively). |

--- a/bin/romp
+++ b/bin/romp
@@ -676,7 +676,7 @@ if [[ "${1:-}" == "--url" ]]; then
     if [[ -z "$_tok" ]]; then
         echo "romp --url: no serve token yet (start romp first — the kernel mints it)" >&2; exit 1
     fi
-    echo "http://127.0.0.1:${ROMP_KERNEL_PORT:-7433}/?token=$_tok"
+    echo "http://127.0.0.1:${ROMP_KERNEL_PORT:-29855}/?token=$_tok"
     exit 0
 fi
 
@@ -687,7 +687,7 @@ fi
 # doesn't pretend: it prints the URL plus the two ways to actually reach it from your laptop.
 if [[ "${1:-}" =~ ^(--)?(launch|open)$ ]]; then
     _tok="$(_romp_token)"
-    _kport="${ROMP_KERNEL_PORT:-7433}"
+    _kport="${ROMP_KERNEL_PORT:-29855}"
     if [[ -z "$_tok" ]]; then
         echo "romp launch: no serve token yet — start romp first (\`romp --on\`), then re-run." >&2
         exit 1
@@ -741,7 +741,7 @@ if [[ "${1:-}" =~ ^(--)?(checkin|checkout)$ ]]; then
     _verb="${1#--}"; shift
     _host="${1:-}"
     if [[ -z "$_host" ]]; then echo "usage: romp $_verb <host>" >&2; exit 2; fi
-    _kport="${ROMP_KERNEL_PORT:-7433}"
+    _kport="${ROMP_KERNEL_PORT:-29855}"
     _on="false"; [[ "$_verb" == "checkin" ]] && _on="true"
     _resp="$(curl -sf -m 10 -X POST "http://127.0.0.1:$_kport/tunnels/checkin" \
                   -H "X-Romp-Token: $(_romp_token)" \
@@ -765,7 +765,7 @@ if [[ "${1:-}" =~ ^(--)?(send|interrupt|end)$ ]]; then
     _who="${1:-}"
     if [[ -z "$_who" ]]; then echo "usage: romp $_verb <session> $([[ "$_verb" == send ]] && echo '<text>')" >&2; exit 2; fi
     shift
-    _kport="${ROMP_KERNEL_PORT:-7433}"
+    _kport="${ROMP_KERNEL_PORT:-29855}"
     if [[ "$_verb" == "send" ]]; then
         _text="$*"
         if [[ -z "$_text" ]]; then echo "usage: romp send <session> <text>" >&2; exit 2; fi

--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -30,7 +30,7 @@ const fs = require('fs');
 
 const HOST = '127.0.0.1';
 const CONTROL_PORT = Number(process.env.ROMP_MANAGER_PORT) || 7432;
-const KERNEL_PORT = Number(process.env.ROMP_SERVE_PORT) || 7433;
+const KERNEL_PORT = Number(process.env.ROMP_SERVE_PORT) || 29855;
 
 // $TMUX scrub (2026-07-20): a manager launched by hand from INSIDE a tmux session leaks $TMUX to
 // its kernels and their SDK-session children — whose tmux-status hooks then resolve `#S` to

--- a/cli/judge_monitor.py
+++ b/cli/judge_monitor.py
@@ -36,7 +36,7 @@ from pathlib import Path
 
 REFRESH_SECS = 3
 ACTIVE_WINDOW_SECS = 2 * 3600     # headless fallback: a session is "active" if its cache changed this recently
-KERNEL_URLS = ["http://127.0.0.1:7433", "http://127.0.0.1:7878", "http://127.0.0.1:7432"]
+KERNEL_URLS = ["http://127.0.0.1:29855", "http://127.0.0.1:7878", "http://127.0.0.1:7432"]
 
 
 # ───────────────────────── raw readers (independent of the kernel) ─────────────────────────

--- a/cli/update.py
+++ b/cli/update.py
@@ -15,7 +15,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-KPORTS = ["http://127.0.0.1:7433", "http://127.0.0.1:7878", "http://127.0.0.1:7432"]
+KPORTS = ["http://127.0.0.1:29855", "http://127.0.0.1:7878", "http://127.0.0.1:7432"]
 
 
 def _token():

--- a/cli/version.py
+++ b/cli/version.py
@@ -51,7 +51,7 @@ def _probe_kernel():
     ('stale', url) when only /healthz answers (a kernel predating /version → restart it), or
     ('down', None) when nothing is listening."""
     import urllib.request
-    for u in ["http://127.0.0.1:7433", "http://127.0.0.1:7878", "http://127.0.0.1:7432"]:
+    for u in ["http://127.0.0.1:29855", "http://127.0.0.1:7878", "http://127.0.0.1:7432"]:
         try:
             with urllib.request.urlopen(u + "/version", timeout=1.5) as resp:
                 d = json.loads(resp.read().decode())

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -159,7 +159,7 @@ Which backend a session runs on (Agent SDK or tmux) is a per-session choice;
 ## Self-hosted and remote access
 
 You run Romp on your own machine; there is no hosted service in between. The
-kernel runs there and serves the dashboard on `127.0.0.1:7433`, to a browser
+kernel runs there and serves the dashboard on `127.0.0.1:29855`, to a browser
 tab or the VS Code / Cursor extension. Everything Romp stores stays local; the
 only traffic that leaves your machine is `claude` itself, both the agents' own
 model calls and the LLM calls in Romp's judge pipeline.
@@ -253,7 +253,7 @@ HTTPS at your machine's tailnet name to the loopback port, on the machine
 itself.
 
 ```bash
-tailscale serve --bg 7433     # https://<machine>.<tailnet>.ts.net -> 127.0.0.1:7433
+tailscale serve --bg 29855     # https://<machine>.<tailnet>.ts.net -> 127.0.0.1:29855
 tailscale serve status        # show the active proxy
 tailscale serve reset         # back to local-only
 ```
@@ -286,7 +286,7 @@ that file and send it automatically; you never type it. Only liveness probes
 
 **Getting in.** Run `romp launch`: it prints the tokened link *and* opens your
 browser. The first visit exchanges the token for a year-long `HttpOnly` cookie,
-so afterwards plain `http://127.0.0.1:7433/` just works. Opening that bare URL
+so afterwards plain `http://127.0.0.1:29855/` just works. Opening that bare URL
 without a cookie shows a paste-the-token page rather than a dead error.
 
 **Remote machines.** Every machine mints its **own** token. When you attach a

--- a/docs/install.md
+++ b/docs/install.md
@@ -49,7 +49,7 @@ romp launch
 
 It opens the dashboard in your browser and prints the link as well: the link
 carries the one-time access token. After that first open a cookie remembers you
-and plain `http://127.0.0.1:7433/` works. Type a name into the picker and start
+and plain `http://127.0.0.1:29855/` works. Type a name into the picker and start
 a session.
 
 On a remote or headless box `romp launch` won't try to open a browser — it

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -23,13 +23,13 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
   `romp-serve` → `romp-kernel`) and stays up across kernel restarts. Front ends
   (browser, phone, VS Code) ATTACH to the kernel; they never spawn it.
   `romp-serve` points at the Python kernel, so `romp --on` supervises it on the
-  manager's port (7433), and the front ends and tailscale serve attach unchanged.
+  manager's port (29855), and the front ends and tailscale serve attach unchanged.
 - **The UI is served by the kernel.** The front-end (the three panes) is `ui/`. A
   browser hits the kernel's port and gets it.
 - **`romp --on` starts the supervisor.** It runs `romp-manager` in the foreground
   (like `jupyter lab`); `romp --refresh` restarts the kernel(s), `romp --status`
   reports them. The kernel binds loopback only; tailnet/phone reach is
-  `tailscale serve` proxying to `127.0.0.1:7433` (there is no `0.0.0.0` opt-in
+  `tailscale serve` proxying to `127.0.0.1:29855` (there is no `0.0.0.0` opt-in
   door; the tailscale proxy carries the phone path). The UI itself is just a URL
   the kernel serves.
 - **Session discovery keys on the rompUuid birth stamp, not a time window.** The

--- a/hooks/romp-wake.sh
+++ b/hooks/romp-wake.sh
@@ -17,7 +17,7 @@ set -uo pipefail
 # exist", and a wake is cheap + idempotent on the kernel side.
 cat >/dev/null 2>&1 || true
 
-port="${ROMP_SERVE_PORT:-7433}"
+port="${ROMP_SERVE_PORT:-29855}"
 # The kernel gates every request on the serve token, loopback included (Jupyter's model) — read it
 # the way the kernel resolves it: env override, else the 0600 state file. Missing token → the poke
 # 403s silently, same posture as no kernel at all (the 20s backstop covers it).

--- a/install.sh
+++ b/install.sh
@@ -150,7 +150,7 @@ if [[ -z "${ROMP_NO_SERVICE:-}" ]]; then
     if [[ -x "$_svc" ]]; then
         # Don't tear down a HEALTHY manager just to ship a webview dist/VSIX change. `romp-service
         # install` boots the running romp-manager OUT (SIGTERM, drains every kernel) then re-bootstraps;
-        # a bootstrap that loses the drain-race exits 1 and leaves the dashboard dead on :7433. A routine
+        # a bootstrap that loses the drain-race exits 1 and leaves the dashboard dead on :29855. A routine
         # webview deploy needs NO manager restart (the kernel serves the rebuilt dist live), so skip the
         # whole bootout when the manager already reports `running`. Only (re)install when it is NOT
         # running — and then FAIL LOUDLY on a non-zero exit rather than `|| echo`-swallowing it, so a
@@ -160,7 +160,7 @@ if [[ -z "${ROMP_NO_SERVICE:-}" ]]; then
         else
             echo "  Installing the romp login service (romp-manager)..."
             if ! "$_svc" install; then
-                echo "install.sh: romp-service install FAILED — romp-manager is NOT running; the dashboard will be dead on :7433." >&2
+                echo "install.sh: romp-service install FAILED — romp-manager is NOT running; the dashboard will be dead on :29855." >&2
                 echo "  Retry by hand:  $_svc install" >&2
                 exit 1
             fi

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -2,7 +2,7 @@
 
 The Python backend: one process (`kernel.py`) that reads every session's Claude
 Code transcript, builds the event tree, runs the judges, drives the session
-backends, and serves the four panes over HTTP + WebSocket on `127.0.0.1:7433`.
+backends, and serves the four panes over HTTP + WebSocket on `127.0.0.1:29855`.
 Spawned by `bin/romp-serve` (the `bin/romp-kernel` symlink points here); see
 `docs/architecture.md` for the data-flow picture.
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9,7 +9,7 @@ Transport is the SAME WebSocket postMessage protocol the bundles already speak (
 `shimJs` bridge is reused verbatim), so the VS Code extension repoints to this kernel with
 zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no dependency).
 
-Run:  bin/romp-kernel   → opens http://127.0.0.1:7433
+Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
 import json, os, re, signal, sys, time, threading, traceback, base64, bisect, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid
 from pathlib import Path
@@ -32,7 +32,7 @@ DIST = CHAT_VIEW / "dist"                    # bundles built from ui/webview sou
 MEDIA = CHAT_VIEW / "media"
 UI = ROOT / "ui"                             # the browser UI: timeline view + webview sources (served/built from here)
 NAMES = jd.STATE / "names"
-PORT = int(os.environ.get("ROMP_KERNEL_PORT", "7433"))   # 7433 = the manager/extension default (the user 2026-06-16); env still overrides
+PORT = int(os.environ.get("ROMP_KERNEL_PORT", "29855"))   # the manager/extension default; env still overrides. Renumbered from 7433 (the user 2026-07-24), which an LLM had picked — so a twin-prompted project plausibly binds it — and whose nearest IANA neighbour is 7443. 29855 was drawn at random from the ports absent from /etc/services, minus common dev defaults, below the 49152 ephemeral floor.
 BIND = os.environ.get("ROMP_SERVE_HOST", "127.0.0.1")   # loopback only; tailnet/phone reach = `tailscale serve` proxying to loopback (docs/guide/remote-access.md). Env override is a test seam, not a user knob.
 
 
@@ -4064,7 +4064,7 @@ KNOWN_FILE = jd.STATE / "remotes-known.json"
 # so a machine that was simply off sat there re-dialing all day with nothing in the UI saying so. The
 # budget resets on each boot (_remotes_load) and on a manual attach, so "try again" is always one click.
 TUNNEL_MAX_TRIES = 5
-BUS_PORT = int(os.environ.get("ROMP_POSTAL_PORT", "47100"))      # this laptop's postal bus (reverse-forwarded)
+BUS_PORT = int(os.environ.get("ROMP_POSTAL_PORT", "25302"))      # this laptop's postal bus (reverse-forwarded)
 SSH_BIN = os.environ.get("ROMP_SSH_BIN", "ssh")                  # overridable for tests
 SSH_CONFIG = Path(os.environ.get("ROMP_SSH_CONFIG") or (Path.home() / ".ssh" / "config"))
 _REMOTE_KERNEL_PORT = int(os.environ.get("ROMP_REMOTE_KERNEL_PORT", str(PORT)))   # remote kernels default to our port

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -57,9 +57,9 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 HOST = "127.0.0.1"
-PORT = int(os.environ.get("ROMP_POSTAL_PORT", "47100"))
+PORT = int(os.environ.get("ROMP_POSTAL_PORT", "25302"))   # renumbered from 47100 alongside the kernel's port (the user 2026-07-24), same random draw. A bus that cannot bind degrades fleet messaging silently, rather than failing a URL someone is looking at, so a collision here is worth avoiding more, not less.
 BASE = f"http://{HOST}:{PORT}"
-KERNEL_BASE = "http://127.0.0.1:%s" % os.environ.get("ROMP_KERNEL_PORT", "7433")  # the dashboard kernel — it owns the backend session query (tmux + SDK)
+KERNEL_BASE = "http://127.0.0.1:%s" % os.environ.get("ROMP_KERNEL_PORT", "29855")  # the dashboard kernel — it owns the backend session query (tmux + SDK)
 
 STATE = Path(os.environ.get("XDG_STATE_HOME", str(Path.home() / ".local/state"))) / "romp" / "postal"
 MAILROOT = STATE / "mail"

--- a/tests/install-sh.bats
+++ b/tests/install-sh.bats
@@ -75,7 +75,7 @@ PY
 
 # The login-service step (the user's rescue_me, 2026-07-21): a webview deploy must never bootout a
 # HEALTHY romp-manager, and must FAIL LOUDLY (not `|| echo`-swallow) if an install it DID attempt fails —
-# the swallowed failure is what left the dashboard dead on :7433. ROMP_SERVICE_BIN stubs romp-service.
+# the swallowed failure is what left the dashboard dead on :29855. ROMP_SERVICE_BIN stubs romp-service.
 _svc_stub() {   # write a fake romp-service to $1; behavior toggled by ROMP_SVC_RUNNING / ROMP_SVC_FAIL
     cat > "$1" <<'SH'
 #!/usr/bin/env bash

--- a/tests/romp-launch.bats
+++ b/tests/romp-launch.bats
@@ -13,7 +13,7 @@ setup() {
     export XDG_STATE_HOME="$TEST_DIR/state"
     mkdir -p "$XDG_STATE_HOME/romp"
     printf 'TESTTOKEN123\n' > "$XDG_STATE_HOME/romp/serve-token"
-    export ROMP_KERNEL_PORT=7433
+    export ROMP_KERNEL_PORT=29855
     # a fake opener on PATH that records that it was called, instead of opening a real browser
     MOCK="$TEST_DIR/mock"; mkdir -p "$MOCK"
     export OPEN_LOG="$TEST_DIR/open.log"
@@ -33,7 +33,7 @@ teardown() { rm -rf "$TEST_DIR"; }
 @test "romp launch prints the tokened URL" {
     run "$ROMP_SCRIPT" launch
     [ "$status" -eq 0 ]
-    [[ "$output" == *"http://127.0.0.1:7433/?token=TESTTOKEN123"* ]]
+    [[ "$output" == *"http://127.0.0.1:29855/?token=TESTTOKEN123"* ]]
 }
 
 @test "romp launch opens a browser on a local machine" {
@@ -46,7 +46,7 @@ teardown() { rm -rf "$TEST_DIR"; }
 @test "romp launch on a remote/ssh box prints the URL but opens nothing" {
     SSH_CONNECTION="10.0.0.1 1 10.0.0.2 22" run "$ROMP_SCRIPT" launch
     [ "$status" -eq 0 ]
-    [[ "$output" == *"http://127.0.0.1:7433/?token=TESTTOKEN123"* ]]   # the link is ALWAYS printed
+    [[ "$output" == *"http://127.0.0.1:29855/?token=TESTTOKEN123"* ]]   # the link is ALWAYS printed
     [[ "$output" == *"remote/headless"* ]]
     [[ "$output" == *"ssh -N -L"* ]]                                    # tells you how to reach it
     [ ! -s "$OPEN_LOG" ] || false                                       # never opened a browser
@@ -60,7 +60,7 @@ teardown() { rm -rf "$TEST_DIR"; }
     rm "$MOCK/open"
     ROMP_OPENER= run "$ROMP_SCRIPT" launch
     [ "$status" -eq 0 ]
-    [[ "$output" == *"http://127.0.0.1:7433/?token=TESTTOKEN123"* ]]
+    [[ "$output" == *"http://127.0.0.1:29855/?token=TESTTOKEN123"* ]]
     [[ "$output" == *"couldn't open a browser automatically"* ]]
 }
 
@@ -93,6 +93,6 @@ MOCK
 @test "romp --url stays print-only (no browser, bare URL for scripts)" {
     run "$ROMP_SCRIPT" --url
     [ "$status" -eq 0 ]
-    [ "$output" = "http://127.0.0.1:7433/?token=TESTTOKEN123" ]         # exactly the URL, nothing else
+    [ "$output" = "http://127.0.0.1:29855/?token=TESTTOKEN123" ]         # exactly the URL, nothing else
     [ ! -s "$OPEN_LOG" ] || false
 }

--- a/tests/romp-serve.bats
+++ b/tests/romp-serve.bats
@@ -62,8 +62,8 @@ teardown() { rm -rf "$TEST_DIR"; }
 }
 
 @test "romp-serve: ROMP_SERVE_PORT fallback + forwards ROMP_MANAGER_PID" {
-    ROMP_MANAGER_PID=4242 ROMP_SERVE_PORT=7433 run "$ROMP_SERVE"
-    [[ "$output" == *"PORT=7433"* ]]
+    ROMP_MANAGER_PID=4242 ROMP_SERVE_PORT=29855 run "$ROMP_SERVE"
+    [[ "$output" == *"PORT=29855"* ]]
     [[ "$output" == *"MGRPID=4242"* ]]
 }
 

--- a/tests/romp-wake-hook.bats
+++ b/tests/romp-wake-hook.bats
@@ -17,6 +17,11 @@ echo "curl $*" >> "$CURL_LOG"
 MOCK
     chmod +x "$MOCK/curl"
     export PATH="$MOCK:$PATH"
+    # Clear the port env so the default-port test asserts the hook's OWN default.
+    # Run the suite from inside a romp session and it inherits that kernel's
+    # ROMP_SERVE_PORT, which silently turns the default case into an override
+    # case — a green CI and a red local run (2026-07-24).
+    unset ROMP_SERVE_PORT
     HOOK="$(cd "$(dirname "$BATS_TEST_FILENAME")/../hooks" && pwd)/romp-wake.sh"
 }
 
@@ -31,11 +36,11 @@ teardown() { rm -rf "$TEST_DIR"; }
     grep -q 'http://127.0.0.1:7777/tick' "$CURL_LOG"
 }
 
-@test "romp-wake defaults to port 7433 when ROMP_SERVE_PORT is unset" {
+@test "romp-wake defaults to port 29855 when ROMP_SERVE_PORT is unset" {
     run bash -c 'echo "{}" | "'"$HOOK"'"'
     [ "$status" -eq 0 ]
     for _ in $(seq 1 40); do [ -s "$CURL_LOG" ] && break; sleep 0.05; done
-    grep -q 'http://127.0.0.1:7433/tick' "$CURL_LOG"
+    grep -q 'http://127.0.0.1:29855/tick' "$CURL_LOG"
 }
 
 @test "romp-wake sends the serve token header (env override form)" {

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6524,7 +6524,7 @@ class PostalPeerTunnels(unittest.TestCase):
     ExitOnForwardFailure would kill the whole tunnel) for a second ephemeral -L that dials the
     remote's bus — stage 2's peering protocol is duplex over that one connection."""
 
-    R = {"host": "TESTHOST", "kernel_port": 7433, "local_port": 50001, "bus_port": 50002}
+    R = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 50001, "bus_port": 50002}
 
     def test_flag_off_keeps_the_reverse_forward(self):
         os.environ["ROMP_POSTAL_PEERS"] = "0"          # peer mode is the DEFAULT now; 0 = legacy scheme
@@ -6540,7 +6540,7 @@ class PostalPeerTunnels(unittest.TestCase):
             os.environ.pop("ROMP_POSTAL_PEERS", None)
         self.assertNotIn("-R", argv, "no fixed-port reverse forward in peer mode")
         self.assertIn("50002:127.0.0.1:%d" % km.BUS_PORT, argv, "the ephemeral -L dials the remote's bus")
-        self.assertIn("50001:127.0.0.1:7433", argv, "the kernel forward is unchanged")
+        self.assertIn("50001:127.0.0.1:29855", argv, "the kernel forward is unchanged")
 
     def test_notify_bus_peer_is_guarded(self):
         saved = km.BUS_PORT
@@ -6566,7 +6566,7 @@ class CheckinMechanics(unittest.TestCase):
 
     def test_checkin_argv_adds_the_reverse_forwards(self):
         os.environ["ROMP_POSTAL_PEERS"] = "1"
-        r = {"host": "TESTHOST", "kernel_port": 7433, "local_port": 50001, "bus_port": 50002,
+        r = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 50001, "bus_port": 50002,
              "checkin": True, "rk_port": 50003, "rb_port": 50004}
         argv = km._tunnel_argv(r)
         self.assertIn("50003:127.0.0.1:%d" % km.PORT, argv, "-R publishes our kernel on the hub")
@@ -6575,7 +6575,7 @@ class CheckinMechanics(unittest.TestCase):
 
     def test_plain_peer_attach_argv_has_no_reverse_forwards(self):
         os.environ["ROMP_POSTAL_PEERS"] = "1"
-        r = {"host": "TESTHOST", "kernel_port": 7433, "local_port": 50001, "bus_port": 50002}
+        r = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 50001, "bus_port": 50002}
         self.assertNotIn("-R", km._tunnel_argv(r))
 
     def test_checkin_payload_pushes_ports_and_token(self):
@@ -6599,12 +6599,12 @@ class CheckinMechanics(unittest.TestCase):
                     {"host": "x", "kernelPort": True, "busPort": 5}):
             payload, status = km.checkin_apply(bad)
             self.assertEqual(status, 400, repr(bad))
-        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 7433, "local_port": 1, "proc": None}
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 1, "proc": None}
         payload, status = km.checkin_apply({"host": "TESTHOST", "kernelPort": 50003, "busPort": 50004})
         self.assertEqual(status, 409, "an ssh-attached row is never silently converted")
 
     def test_checkin_set_flags_ports_and_checkout_clears(self):
-        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 7433, "local_port": 50001,
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 50001,
                                    "bus_port": 50002, "proc": None, "status": "up", "detail": "", "sids": []}
         saved = km._checkin_stop_hub
         km._checkin_stop_hub = lambda r: None
@@ -6620,7 +6620,7 @@ class CheckinMechanics(unittest.TestCase):
 
     def test_checkin_stop_only_forgets_checked_in_rows(self):
         os.environ["ROMP_POSTAL_PEERS"] = "0"          # keep detach's bus notify away from the real bus
-        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 7433, "local_port": 1, "proc": None}
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 1, "proc": None}
         self.assertFalse(km.checkin_stop("TESTHOST"), "an ssh-attached row is not checkout-able")
         km._remotes["hubhost"] = {"host": "hubhost", "checkin_peer": True, "kernel_port": 5,
                                   "local_port": 5, "bus_port": 6, "proc": None}

--- a/tests/test_kernel_auth_hardening.py
+++ b/tests/test_kernel_auth_hardening.py
@@ -70,7 +70,7 @@ class TokenRequiredEverywhere(unittest.TestCase):
 
     def test_forged_local_host_headers_do_not_authorize(self):
         # The old M3 bypass, now moot by construction: Host carries no auth weight at all.
-        for host in ("localhost", "127.0.0.1", "localhost:7433", "::1"):
+        for host in ("localhost", "127.0.0.1", "localhost:29855", "::1"):
             ok, _, _ = _auth(peer="203.0.113.9", headers={"Host": host})
             self.assertFalse(ok, "Host: %s must not authorize" % host)
         ok, _, _ = _auth(peer="127.0.0.1", headers={"Host": "localhost"})

--- a/tests/test_kernel_known_hosts.py
+++ b/tests/test_kernel_known_hosts.py
@@ -29,7 +29,7 @@ km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_modu
 
 
 def _row(host, trust="directed"):
-    return {"host": host, "kernel_port": 7433, "local_port": 5000, "bus_port": 5001, "token": "t",
+    return {"host": host, "kernel_port": 29855, "local_port": 5000, "bus_port": 5001, "token": "t",
             "proc": None, "status": "up", "detail": "", "sids": [], "trust": trust}
 
 

--- a/tests/test_kernel_pkill_self_match.py
+++ b/tests/test_kernel_pkill_self_match.py
@@ -67,7 +67,7 @@ class ApplyScriptPkillPattern(unittest.TestCase):
         script = _apply_script()
         pat = re.search(r'pkill -f "([^"]+)"', script).group(1)
         for real in ("/usr/bin/python3 /home/u/GitRepos/romp/bin/romp-kernel",
-                     "python3.12 /home/u/romp/bin/romp-kernel --port 7433"):
+                     "python3.12 /home/u/romp/bin/romp-kernel --port 29855"):
             self.assertIsNotNone(re.search(pat, real),
                                  "pattern %r must still kill the real kernel (%r)" % (pat, real))
 

--- a/tests/test_kernel_remote_start.py
+++ b/tests/test_kernel_remote_start.py
@@ -21,7 +21,7 @@ class StartRemote(unittest.TestCase):
     def setUp(self):
         self._saved = (km._update_remote, km._remote_kernel_up, km._start_remote_kernel,
                        km._fetch_remote_token, km._BOOT_WAIT_S, km._remotes)
-        km._remotes = {HOST: {"host": HOST, "kernel_port": 7433, "local_port": 8801,
+        km._remotes = {HOST: {"host": HOST, "kernel_port": 29855, "local_port": 8801,
                               "token": "", "proc": None, "status": "no-kernel", "detail": "", "sids": []}}
         km._BOOT_WAIT_S = 2
         self.kernel_up = {"v": False}
@@ -130,7 +130,7 @@ class RemotesLoadHygiene(unittest.TestCase):
             with tempfile.TemporaryDirectory() as td:
                 km.REMOTES_FILE = Path(td) / "remotes.json"
                 km.REMOTES_FILE.write_text(json.dumps([{
-                    "host": HOST, "kernel_port": 7433, "local_port": 8801, "token": "t",
+                    "host": HOST, "kernel_port": 29855, "local_port": 8801, "token": "t",
                     "status": "starting", "detail": "updating + starting the kernel",
                     "booting": True, "sids": []}]))
                 km._remotes = {}

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -53,7 +53,7 @@ class VersionDrift(unittest.TestCase):
         self.assertFalse(km._remote_out_of_date({"kernel_sha": ""}), "blank remote sha → not flagged")
 
     def test_remote_public_exposes_version_fields(self):
-        pub = km._remote_public({"host": "TESTHOST", "kernel_port": 7433, "local_port": 8801, "token": "t",
+        pub = km._remote_public({"host": "TESTHOST", "kernel_port": 29855, "local_port": 8801, "token": "t",
                                  "status": "up", "sids": [], "kernel_sha": "def5678"})
         self.assertEqual(pub["kernelSha"], "def5678")
         self.assertEqual(pub["localSha"], "abc1234", "localSha is the live HEAD short (what a push would send)")
@@ -174,13 +174,13 @@ class UpdateRemote(unittest.TestCase):
         # orphan) — kill the kernel, `romp-manager ensure` (respawns via a live manager, or STARTS one that spawns
         # a supervised kernel — upgrading an attach-bootstrapped bare host), then port-poll; bare romp-serve is a
         # LAST-RESORT fallback only when the port never returns. It must NOT rely on `romp --refresh` (the stuck bug).
-        km._remotes = {"TESTHOST": {"host": "TESTHOST", "kernel_port": 7433}}
+        km._remotes = {"TESTHOST": {"host": "TESTHOST", "kernel_port": 29855}}
         calls = self._wire()
         km._update_remote("TESTHOST")
         apply = next(a[-1] for a in calls if isinstance(a[-1], str) and "merge-base" in a[-1])
         self.assertIn("pkill -f", apply, "kills the running kernel")
         self.assertIn('"$R/bin/romp-manager" ensure', apply, "prefers the manager (ensure = idempotent supervised start)")
-        self.assertIn("/dev/tcp/127.0.0.1/7433", apply, "polls the remote's kernel port to confirm it came back")
+        self.assertIn("/dev/tcp/127.0.0.1/29855", apply, "polls the remote's kernel port to confirm it came back")
         self.assertIn('if [ "$UP" = 0 ]; then nohup "$R/bin/romp-serve"', apply, "bare romp-serve only as a last resort")
         self.assertNotIn("--refresh", apply, "does NOT rely on `romp --refresh` (needs a manager) — the stuck bug")
 
@@ -190,7 +190,7 @@ class UpdateRemote(unittest.TestCase):
         # banner Retry re-killed whatever a previous attempt had booted. The apply now runs in its
         # own session (setsid, plain-bash fallback where setsid is missing), so once started the
         # kill+boot pair always completes on the remote even if the connection dies.
-        km._remotes = {"TESTHOST": {"host": "TESTHOST", "kernel_port": 7433}}
+        km._remotes = {"TESTHOST": {"host": "TESTHOST", "kernel_port": 29855}}
         calls = self._wire()
         km._update_remote("TESTHOST")
         wrapper = next(a[-1] for a in calls if isinstance(a[-1], str) and "merge-base" in a[-1])
@@ -268,7 +268,7 @@ ru = SourceFileLoader("romp_update", os.path.join(BIN, "romp-update")).load_modu
 class RompUpdateCLI(unittest.TestCase):
     def setUp(self):
         self._k, self._g, self._p = ru._kernel, ru._get, ru._post
-        ru._kernel = lambda: "http://127.0.0.1:7433"
+        ru._kernel = lambda: "http://127.0.0.1:29855"
         self.posted = []
         ru._post = lambda u, path, body: (self.posted.append((path, body)) or {"ok": True, "detail": "updated"})
 
@@ -372,7 +372,7 @@ class BehindInfo(unittest.TestCase):
 
     def test_remote_public_carries_the_drift_fields(self):
         self._mock_git(behind="12", ahead="0", date="2026-07-08")
-        pub = km._remote_public({"host": "TESTHOST", "kernel_port": 7433, "local_port": 8801,
+        pub = km._remote_public({"host": "TESTHOST", "kernel_port": 29855, "local_port": 8801,
                                  "status": "up", "kernel_sha": "def5678"})
         self.assertTrue(pub["outOfDate"])
         self.assertEqual((pub["behindBy"], pub["aheadBy"], pub["kernelDate"]), (12, 0, "2026-07-08"))
@@ -381,7 +381,7 @@ class BehindInfo(unittest.TestCase):
         def boom(argv, **kw):
             raise AssertionError("an in-sync row must not pay for drift measurement: %s" % argv)
         km.subprocess.run = boom
-        pub = km._remote_public({"host": "TESTHOST", "kernel_port": 7433, "local_port": 8801,
+        pub = km._remote_public({"host": "TESTHOST", "kernel_port": 29855, "local_port": 8801,
                                  "status": "up", "kernel_sha": "abc1234"})
         self.assertFalse(pub["outOfDate"])
         self.assertEqual((pub["behindBy"], pub["aheadBy"], pub["kernelDate"]), (0, 0, ""))

--- a/tests/test_kernel_remotes_perms.py
+++ b/tests/test_kernel_remotes_perms.py
@@ -33,7 +33,7 @@ def _mode(p):
 class RemotesFilePermissions(unittest.TestCase):
     def setUp(self):
         km._remotes.clear()
-        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 7433, "local_port": 8801,
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 8801,
                                    "bus_port": 8802, "token": "REMOTE-SECRET-TOKEN", "proc": None,
                                    "status": "up", "detail": "", "sids": [], "trust": "directed"}
 

--- a/tests/test_kernel_trust.py
+++ b/tests/test_kernel_trust.py
@@ -27,7 +27,7 @@ km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_modu
 
 
 def _row(host, **extra):
-    r = {"host": host, "kernel_port": 7433, "local_port": 5000, "bus_port": 5001, "token": "t",
+    r = {"host": host, "kernel_port": 29855, "local_port": 5000, "bus_port": 5001, "token": "t",
          "proc": None, "status": "up", "detail": "", "sids": [], "trust": "directed"}
     r.update(extra)
     return r

--- a/tests/test_kernel_tunnels.py
+++ b/tests/test_kernel_tunnels.py
@@ -177,7 +177,7 @@ class HostForSidMap(unittest.TestCase):
         km._remotes.clear()
 
     def test_host_for_sid_resolves_remote_else_none(self):
-        km._remotes["gpu1"] = {"host": "gpu1", "kernel_port": 7433, "local_port": 9001,
+        km._remotes["gpu1"] = {"host": "gpu1", "kernel_port": 29855, "local_port": 9001,
                                "token": "t", "proc": None, "status": "up",
                                "detail": "", "sids": ["aaaa-1111"]}
         self.assertIs(km._host_for_sid("aaaa-1111"), km._remotes["gpu1"])
@@ -220,7 +220,7 @@ class WakeRouter(unittest.TestCase):
         self.port = self.srv.server_address[1]
         threading.Thread(target=self.srv.serve_forever, daemon=True).start()
         # register the remote, pointing its -L local_port at the stub, owning REMOTE_SID
-        km._remotes["gpu1"] = {"host": "gpu1", "kernel_port": 7433, "local_port": self.remote_port,
+        km._remotes["gpu1"] = {"host": "gpu1", "kernel_port": 29855, "local_port": self.remote_port,
                                "token": "", "proc": None, "status": "up", "detail": "",
                                "sids": [self.REMOTE_SID]}
 
@@ -300,10 +300,10 @@ class ReapStrayTunnels(unittest.TestCase):
     def test_kills_only_matching_orphan_tunnels(self):
         BUS = km.BUS_PORT
         fake_ps = "\n".join([
-            "  12345 /usr/bin/ssh -N -T -L 50512:127.0.0.1:7433 -R %d:127.0.0.1:%d TESTHOST" % (BUS, BUS),  # orphan → kill
-            "  22222 ssh -N -T -L 9:127.0.0.1:7433 -R %d:127.0.0.1:%d otherhost" % (BUS, BUS),           # other host → keep
+            "  12345 /usr/bin/ssh -N -T -L 50512:127.0.0.1:29855 -R %d:127.0.0.1:%d TESTHOST" % (BUS, BUS),  # orphan → kill
+            "  22222 ssh -N -T -L 9:127.0.0.1:29855 -R %d:127.0.0.1:%d otherhost" % (BUS, BUS),           # other host → keep
             "  33333 ssh TESTHOST",                                                                          # user's own ssh → keep
-            "  %d ssh -N -T -L 1:127.0.0.1:7433 -R %d:127.0.0.1:%d TESTHOST" % (os.getpid(), BUS, BUS),      # us → keep
+            "  %d ssh -N -T -L 1:127.0.0.1:29855 -R %d:127.0.0.1:%d TESTHOST" % (os.getpid(), BUS, BUS),      # us → keep
         ])
 
         class _R:

--- a/tests/test_remotes_panel_render.py
+++ b/tests/test_remotes_panel_render.py
@@ -29,7 +29,7 @@ km = SourceFileLoader("romp_kernel_rpanel", os.path.join(BIN, "romp-kernel")).lo
 
 TUNNELS = {
     "tunnels": [{
-        "host": "TESTHOST", "kernelPort": 7433, "localPort": 51000, "busPort": 51001,
+        "host": "TESTHOST", "kernelPort": 29855, "localPort": 51000, "busPort": 51001,
         "checkin": False, "checkinPeer": False, "token": "tok", "status": "up", "detail": "",
         "sids": ["11111111-2222-3333-4444-555555555555"], "trust": "directed",
         "kernelSha": "abc1234", "localSha": "abc1234", "outOfDate": False,

--- a/tests/test_romp_version.py
+++ b/tests/test_romp_version.py
@@ -14,7 +14,7 @@ def test_report_flags_stale_served_bundle(monkeypatch=None):
     ver._disk_bundles = lambda: {"feed.js": 200, "render.js": 100}
     # kernel reports it is SERVING an older feed.js (100) than what's on disk (200) → must flag it
     ver._probe_kernel = lambda: ("version", {"kernel_sha": "abc1234", "pid": 9, "uptime_s": 65,
-                                             "dist_ver": 100, "url": "http://127.0.0.1:7433",
+                                             "dist_ver": 100, "url": "http://127.0.0.1:29855",
                                              "bundles": {"feed.js": 100, "render.js": 100}})
     out = ver.report()
     assert "abc1234-dirty" in out
@@ -33,7 +33,7 @@ def test_report_handles_down_kernel():
 def test_report_handles_predating_kernel():
     ver._git_sha = lambda: "abc1234"
     ver._disk_bundles = lambda: {}
-    ver._probe_kernel = lambda: ("stale", "http://127.0.0.1:7433")
+    ver._probe_kernel = lambda: ("stale", "http://127.0.0.1:29855")
     out = ver.report()
     assert "predates /version" in out
 

--- a/tests/test_tunnel_reconnect_budget.py
+++ b/tests/test_tunnel_reconnect_budget.py
@@ -44,7 +44,7 @@ class ReconnectBudget(unittest.TestCase):
         state = km.jd.STATE
         state.mkdir(parents=True, exist_ok=True)
         km.REMOTES_FILE.write_text(json.dumps([{
-            "host": "TESTHOST", "kernel_port": 7433, "local_port": 51000, "token": "tok",
+            "host": "TESTHOST", "kernel_port": 29855, "local_port": 51000, "token": "tok",
             "fails": 99, "next_try": 9e12, "gave_up": True, "trust": "directed",
         }]))
         km._remotes.clear()

--- a/ui/webview/only-filter.ts
+++ b/ui/webview/only-filter.ts
@@ -1,6 +1,6 @@
 // Demo/recording VIEW filter (the user 2026-07-14): load the dashboard at `#only=<tag>` (or `?only=<tag>`)
 // and every pane (chat tabs, feed, fleet, timeline) shows ONLY sessions whose name starts with <tag>,
-// case-insensitive. The real sessions keep running and still show on the normal `:7433/` — they are just
+// case-insensitive. The real sessions keep running and still show on the normal `:29855/` — they are just
 // hidden from THIS view, so you get a clean frame for demo screencasts without standing up a separate
 // instance. Empty / no tag → no filter (everything shows, unchanged).
 //

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -153,7 +153,7 @@
           "type": "number",
           "minimum": 1,
           "maximum": 65535,
-          "markdownDescription": "Port of the romp kernel this VS Code window attaches to. Point different windows at different ports to view different kernels (each kernel scopes its own group of agents). If no kernel is running on this port, VS Code asks the `romp --on` manager to start one — VS Code never spawns the kernel itself. Unset → `$ROMP_SERVE_PORT` or **7433**."
+          "markdownDescription": "Port of the romp kernel this VS Code window attaches to. Point different windows at different ports to view different kernels (each kernel scopes its own group of agents). If no kernel is running on this port, VS Code asks the `romp --on` manager to start one — VS Code never spawns the kernel itself. Unset → `$ROMP_SERVE_PORT` or **29855**."
         },
         "romp.managerPort": {
           "type": "number",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -146,7 +146,7 @@ function cfgPort(key: "kernelPort" | "managerPort", env: string | undefined, dfl
   if (typeof v === "number" && v > 0) return v;
   return Number(env) || dflt;
 }
-function kernelPort(): number { return cfgPort("kernelPort", process.env.ROMP_SERVE_PORT, 7433); }
+function kernelPort(): number { return cfgPort("kernelPort", process.env.ROMP_SERVE_PORT, 29855); }
 function managerPort(): number { return cfgPort("managerPort", process.env.ROMP_MANAGER_PORT, 7432); }
 
 let ctx: vscode.ExtensionContext;


### PR DESCRIPTION
Both old defaults were picked by an LLM rather than drawn at random, so a project prompted the same way plausibly binds the same numbers. 7433 also sits one digit from 7443 (Oracle Application Server HTTPS) in the IANA registry.

Both replacements come from the same procedure: `secrets.choice` over every port in [20000,45000) absent from `/etc/services`, minus common dev defaults, below the 49152 ephemeral floor. Neither is IANA-registered, neither is in `/etc/services`, and nothing was found using either.

The bus moves alongside the kernel per the kernel owner's argument: a kernel that cannot bind fails a URL somebody is looking at, whereas a bus that cannot bind degrades fleet messaging quietly. Both stay overridable via `ROMP_KERNEL_PORT` / `ROMP_POSTAL_PORT`.

71 replacements across 35 tracked files, all bare literals, word-boundary matched with none left behind. `bin/` entries are symlinks into `kernel/`, `cli/` and `postal/`, so the edits land on the real files with the symlinks untouched.

Also makes `tests/romp-wake-hook.bats` hermetic: it asserts the hook default but never cleared `ROMP_SERVE_PORT`, so running it inside a romp session turned the default case into an override case. Green in CI, red locally.

Suites green: 2990 python, 221 bats, 1274 node.

After merge this needs an extension dist rebuild + VSIX bump, since `dist/` is gitignored but bakes the port in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)