### PR TITLE
Nudges speak as the user, and a follow-up carries the whole card

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -567,6 +567,23 @@ def _session_backend(sid, tm):
     return "sdk" if (be and be.owns(sid)) else "tmux"
 
 
+def _open_leaf_bullets(nodes, subs, cap=12, indent="  "):
+    """The '• sub-goal (blocked) — why' lines for a run of still-open sub-goals, capped with an
+    '…and N more' tail. Shared by the NUDGE enumeration, the multi-goal bundle and the TYPED follow-up's
+    context quote, so the three renderings can't drift apart. A blocked leaf shows its blockWhy (the
+    thing it is stuck ON), an open one the planner's why."""
+    out = []
+    for lid in subs[:cap]:
+        ld = nodes.get(lid, {})
+        lt = str(ld.get("text", "")).strip() or "(unnamed)"
+        why = (ld.get("blockWhy") if ld.get("blocked") else ld.get("why")) or ""
+        why = (" — " + why.strip()) if why.strip() else ""
+        out.append(indent + "• " + lt + (" (blocked)" if ld.get("blocked") else "") + why)
+    if len(subs) > cap:
+        out.append(indent + "• …and %d more" % (len(subs) - cap))
+    return out
+
+
 def _followup_body(iid, title, text, injected=False, auto=False, stalled=False):
     """Pane message for a feed follow-up: QUOTE the ask being followed up ('> <ask>') above the user's
     text, so the recipient session knows what the reply answers. An explicit `title` (the group modal) is
@@ -611,27 +628,17 @@ def _followup_body(iid, title, text, injected=False, auto=False, stalled=False):
                 if (injected and head and not nd.get("parentId")) else [])
         if subs:
             quote.append(head)
-            quote.append("Unfinished pieces under this goal — give me a status on each:")
-            CAP = 12
-            for lid in subs[:CAP]:
-                ld = nodes.get(lid, {})
-                lt = str(ld.get("text", "")).strip() or "(unnamed)"
-                why = (ld.get("blockWhy") if ld.get("blocked") else ld.get("why")) or ""
-                why = (" — " + why.strip()) if why.strip() else ""
-                quote.append("  • " + lt + (" (blocked)" if ld.get("blocked") else "") + why)
-            if len(subs) > CAP:
-                quote.append("  • …and %d more" % (len(subs) - CAP))
+            quote.append("Still open on this:")
+            quote.extend(_open_leaf_bullets(nodes, subs))
             # `stalled` = the FORK nudge (plans/stalled-open-todos-nudge.md): the goal has items the
             # agent's OWN to-do list still marks open, so instead of a per-piece status report the body asks
             # the agent to pick a branch — continue, or name the blockers (which the planner then applies as
             # blocks). The enumerated quote above already names the open pieces.
-            body = (("These are still open on your own to-do list. For each one: where does it stand, and "
-                     "if you don't need anything from me, please continue with it now. If any is blocked, "
-                     "tell me which one and exactly what you need from me to finish it. If one is no "
-                     "longer needed, say so and why.") if stalled else
-                    ("For each unfinished piece above: what's done, what's left, and is anything blocked "
-                     "waiting on a decision from me? If a piece is obsolete and no longer needed, say so "
-                     "and why. Keep the overall goal in mind, but report per piece."))
+            body = (("Those are still open on your own to-do list. Where does each one stand? Keep going "
+                     "on anything you can. If something's blocked, tell me which one and exactly what you "
+                     "need from me. If one is no longer needed, just say so.") if stalled else
+                    ("Where does each of those stand? What's done, what's left, and is anything blocked "
+                     "waiting on a decision from me? If one is no longer needed, just say so."))
         elif not injected and str(nd.get("summary") or nd.get("blockSummary") or "").strip():
             # A TYPED follow-up quotes the card's DISTILLED SUMMARY — the takeaway (completed) or decision brief
             # (blocked) that is the card's visible HEADLINE, the thing you're reading + clicked to follow up on
@@ -640,6 +647,16 @@ def _followup_body(iid, title, text, injected=False, auto=False, stalled=False):
             # session pulls the full thread from its own history. Falls back to the minting quote below when
             # there's no summary yet (a still-working card). Nudges (injected) keep their own context.
             quote.append(str(nd.get("summary") or nd.get("blockSummary")).strip())
+            # …plus the card's still-OPEN sub-goals (the user 2026-07-24). The summary alone is a LOSSY
+            # headline: reply to it and the session sees that ONE line, so a takeaway that got the emphasis
+            # wrong propagates unchallenged, and nothing points the session at the rest of the card — a
+            # BLOCKED sub-goal in particular just goes unmentioned, which is the piece most likely to be
+            # what the reply should be about. Same bullets the nudge enumerates, so the two agree on what
+            # "still open" means; a flat card (no open sub-goals) adds nothing and keeps the bare summary.
+            sub_open = _open_leaves_for_nudge(nodes, str(iid)) if not nd.get("parentId") else []
+            if sub_open:
+                quote.append("Also still open on this:")
+                quote.extend(_open_leaf_bullets(nodes, sub_open))
         elif not injected and str(nd.get("quote") or "").strip():
             # No distilled summary yet → the node's cached minting-message VERBATIM head (judge _mint_quote; the
             # user 2026-07-01, g13): quote the user's OWN WORDS back — how a person re-raises a thread — instead
@@ -705,25 +722,16 @@ def _nudge_bundle_body(gids, nodes, stalled_gids):
         head = str(nd.get("text", "")).strip() or "(unnamed goal)"
         why = str(nd.get("why") or "").strip()
         quote.append("%d. %s" % (i, head) + ((" — " + why) if why else ""))
-        subs = _open_leaves_for_nudge(nodes, str(gid))
-        CAP = 6                                        # tighter than the single-goal 12: N goals share one message
-        for lid in subs[:CAP]:
-            ld = nodes.get(lid, {})
-            lt = str(ld.get("text", "")).strip() or "(unnamed)"
-            lw = (ld.get("blockWhy") if ld.get("blocked") else ld.get("why")) or ""
-            lw = (" — " + lw.strip()) if lw.strip() else ""
-            quote.append("   • " + lt + (" (blocked)" if ld.get("blocked") else "") + lw)
-        if len(subs) > CAP:
-            quote.append("   • …and %d more" % (len(subs) - CAP))
+        # CAP 6, tighter than the single-goal 12: N goals share one message
+        quote.extend(_open_leaf_bullets(nodes, _open_leaves_for_nudge(nodes, str(gid)), cap=6, indent="   "))
         if gid in stalled_gids:
             stall_nums.append(i)
-    body = ("Status check on the %d separate goals above, each still open. For each numbered goal: "
-            "what's done, what's left, and is anything blocked waiting on a decision from me? If one is "
-            "already finished or no longer needed, say so and why." % len(gids))
+    body = ("Where do these %d stand? For each one: what's done, what's left, and is anything blocked "
+            "waiting on a decision from me? If one is already finished or no longer needed, just say so."
+            % len(gids))
     if stall_nums:
-        body += ("\n\nUnder %s there are items still open on your own to-do list: if you don't need "
-                 "anything from me, please continue that work now; if any item is blocked, tell me which "
-                 "one and exactly what you need from me to finish it."
+        body += ("\n\nOn %s you've still got open items on your to-do list. Keep going on those unless "
+                 "you need something from me. If you do, tell me which item and exactly what you need."
                  % ", ".join("#%d" % n for n in stall_nums))
     msg = "> " + "\n".join(quote).replace("\n", "\n> ") + "\n\n" + body
     tail = ("<!-- romp-note: the HTML comments below are part of an external tracking system that is not "
@@ -1111,10 +1119,9 @@ AUTO_NUDGE_TEXT = "Where does this stand? What's done, what's left, and is anyth
 # Code's to-do system has no "blocked" state, so a session routinely stops with open items and can't say why —
 # this asks the agent to pick a branch: continue the work, or name what it needs from the user (which the
 # planner's nudge-mode note then turns into a block + blockWhy → the block-distiller's decision brief).
-AUTO_NUDGE_STALLED_TEXT = ("You stopped with items on your own to-do list still open. For each open item: "
-                           "where does it stand, and if you don't need anything from me, please continue "
-                           "with it now. If any is blocked, tell me which one and exactly what you need "
-                           "from me to finish it. If one is no longer needed, say so and why.")
+AUTO_NUDGE_STALLED_TEXT = ("You've still got open items on your to-do list. Where does each one stand? "
+                           "Keep going on anything you can. If something's blocked, tell me which one and "
+                           "exactly what you need from me. If one is no longer needed, just say so.")
 _autonudge_cache = {}   # str(path) -> ((mtime_ns,size), dict)
 
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -2388,9 +2388,9 @@ class ViewBuilder(unittest.TestCase):
             self.assertEqual(len(sent), 1, "the stalled goal is nudged")
             # the fork ask (both the flat and the hierarchical-enumeration form carry these sentences):
             # per-item progress + the continue-or-name-the-blocker fork (the user 2026-07-02)
-            self.assertIn("please continue with it now", sent[0][1],
+            self.assertIn("Keep going on anything you can", sent[0][1],
                           "the FORK text, not the plain status check")
-            self.assertIn("where does it stand", sent[0][1], "asks for per-item progress")
+            self.assertIn("Where does each one stand?", sent[0][1], "asks for per-item progress")
             self.assertIn("tell me which one and exactly what you need from me", sent[0][1])
             self.assertIn("hook up the adapter", sent[0][1], "the open item is named in the quote")
             self.assertNotIn(km.AUTO_NUDGE_TEXT, sent[0][1])
@@ -2422,7 +2422,7 @@ class ViewBuilder(unittest.TestCase):
         self.assertIn("migrate stores and land the branch", body, "open to-do #2 is named")
         self.assertNotIn("a genuinely done step", body, "a done step is not")
         self.assertIn("still open on your own to-do list", body, "the fork body rides the enumeration")
-        self.assertIn("where does it stand", body, "and asks for per-item progress")
+        self.assertIn("Where does each one stand?", body, "and asks for per-item progress")
 
     def test_auto_nudge_stamps_failed_when_its_response_leaves_the_goal_stalled(self):
         # plans/stalled-open-todos-nudge.md: after the ONE nudge, the agent's response turn ends (judged —
@@ -3168,6 +3168,44 @@ class ViewBuilder(unittest.TestCase):
         self.assertNotIn("Need you to choose", out, "no planner why line")
         self.assertTrue(out.endswith("<!-- romp-goal-id: " + sub + " -->"), "the reopen marker still rides")
 
+    def test_typed_followup_on_a_summary_carries_the_still_open_pieces(self):
+        # The distilled summary is a LOSSY headline of the card (the user 2026-07-24): reply to it and the
+        # session used to see that ONE line, so a takeaway that got the emphasis wrong propagated
+        # unchallenged and nothing pointed the session at the rest — a BLOCKED sub-goal in particular went
+        # unmentioned, which is the piece the reply is most likely to be about. The open pieces now ride
+        # under the summary, the same bullets the nudge enumerates.
+        top, done, open_, blk = SID + ":g1", SID + ":g3", SID + ":g4", SID + ":g5"
+        store = {"rompUuid": SID, "seq": 5, "nodes": {
+            top: {"id": top, "text": "Ship the notes API", "parentId": None, "nodeComplete": False,
+                  "blocked": False, "summary": "Endpoints are live and the client is wired up.", "t": T0},
+            done: {"id": done, "text": "Write the handlers", "parentId": top, "nodeComplete": True,
+                   "blocked": False, "t": T0},
+            open_: {"id": open_, "text": "Backfill the fixtures", "parentId": top, "nodeComplete": False,
+                    "blocked": False, "why": "Needed before the load test.", "t": T0},
+            blk: {"id": blk, "text": "Pick the rate-limit ceiling", "parentId": top, "nodeComplete": False,
+                  "blocked": True, "blockWhy": "Need you to choose a number.", "t": T0}},
+            "placements": {}, "status": {}}
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(store))
+        out = km._followup_body(top, None, "ship it")
+        self.assertIn("> Endpoints are live and the client is wired up.", out, "the summary still leads")
+        self.assertIn("Also still open on this:", out)
+        self.assertIn("• Backfill the fixtures — Needed before the load test.", out)
+        self.assertIn("• Pick the rate-limit ceiling (blocked) — Need you to choose a number.", out,
+                      "the blocked piece is exactly what a reply to a wrong summary must not miss")
+        self.assertNotIn("Write the handlers", out, "finished pieces are not still-open work")
+
+    def test_a_flat_card_keeps_the_bare_summary_quote(self):
+        # nothing open under it → nothing to add; the quote stays the one line it always was
+        top = SID + ":g1"
+        store = {"rompUuid": SID, "seq": 1, "nodes": {
+            top: {"id": top, "text": "Ship the notes API", "parentId": None, "nodeComplete": True,
+                  "blocked": False, "summary": "Shipped and verified.", "t": T0}},
+            "placements": {}, "status": {}}
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(store))
+        out = km._followup_body(top, None, "nice")
+        self.assertIn("> Shipped and verified.", out)
+        self.assertNotIn("Also still open", out)
+
     def test_hierarchical_nudge_enumeration_wins_over_the_quote(self):
         # a NUDGE on a hierarchical top still enumerates the unfinished pieces (the user 2026-06-24) even
         # when the top carries a verbatim quote — the checklist is the more useful nudge form (g13 scope:
@@ -3177,7 +3215,7 @@ class ViewBuilder(unittest.TestCase):
         st["nodes"][top]["quote"] = "please ship the auth refactor end to end"
         (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(st))
         out = km._followup_body(top, None, km.AUTO_NUDGE_TEXT, injected=True)
-        self.assertIn("Unfinished pieces under this goal", out)
+        self.assertIn("Still open on this:", out)
         self.assertNotIn("please ship the auth refactor", out)
 
     def test_followup_body_enriches_with_path_status_and_why(self):
@@ -3224,13 +3262,14 @@ class ViewBuilder(unittest.TestCase):
         top = self._hier_goal_store()
         out = km._followup_body(top, None, km.AUTO_NUDGE_TEXT, injected=True)   # the Nudge button
         self.assertIn("> Ship the auth refactor", out, "the high-level goal is the heading/context")
-        self.assertIn("Unfinished pieces under this goal", out)
+        self.assertIn("Still open on this:", out)
         self.assertIn("• Migrate the session store to Redis", out, "an open own-work leaf is listed")
         self.assertIn("• Add CSRF tokens (blocked) — Need you to pick the token TTL.", out,
                       "a blocked leaf carries its tag + the planner's why")
         self.assertNotIn("Update the login tests", out, "a DONE leaf is not an unfinished piece")
         self.assertNotIn("Peer is porting the client", out, "a DELEGATED leaf is peer work, not this session's")
-        self.assertIn("report per piece", out, "the body asks for a status on each piece, not the whole goal")
+        self.assertIn("Where does each of those stand?", out,
+                      "the body asks for a status on each piece, not the whole goal")
         self.assertNotIn(km.AUTO_NUDGE_TEXT, out, "the single-line 'status on the goal above' body is replaced")
         # still a proper nudge: gray-bubble marker + the reopen goal-id, targeting the TOP goal
         self.assertTrue(out.endswith("<!-- romp-injected --><!-- romp-goal-id: " + top + " -->"))
@@ -3239,7 +3278,7 @@ class ViewBuilder(unittest.TestCase):
         # the auto-nudge (injected + auto) refines IDENTICALLY to the manual button (the user 2026-06-24).
         top = self._hier_goal_store()
         auto = km._followup_body(top, None, km.AUTO_NUDGE_TEXT, injected=True, auto=True)
-        self.assertIn("Unfinished pieces under this goal", auto)
+        self.assertIn("Still open on this:", auto)
         self.assertIn("• Migrate the session store to Redis", auto)
         self.assertTrue(auto.endswith("<!-- romp-injected --><!-- romp-auto --><!-- romp-goal-id: " + top + " -->"))
 
@@ -3253,7 +3292,7 @@ class ViewBuilder(unittest.TestCase):
         (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(store))
         out = km._followup_body(top, None, km.AUTO_NUDGE_TEXT, injected=True)
         self.assertIn("> Wire up the thing", out)
-        self.assertNotIn("Unfinished pieces under this goal", out, "nothing to enumerate on a flat goal")
+        self.assertNotIn("Still open on this:", out, "nothing to enumerate on a flat goal")
         self.assertIn(km.AUTO_NUDGE_TEXT, out, "the single-line nudge body is preserved verbatim")
 
     def test_typed_followup_on_a_hierarchical_top_is_not_enumerated(self):
@@ -3261,7 +3300,7 @@ class ViewBuilder(unittest.TestCase):
         # keeps the existing single-node quote, so we don't expand their reply into a per-sub status request.
         top = self._hier_goal_store()
         out = km._followup_body(top, None, "use Redis, TTL 1h")   # injected defaults False (the user typed it)
-        self.assertNotIn("Unfinished pieces under this goal", out)
+        self.assertNotIn("Still open on this:", out)
         self.assertIn("> Ship the auth refactor", out)
         self.assertIn("use Redis, TTL 1h", out)
 

--- a/tests/test_nudge_bundle.py
+++ b/tests/test_nudge_bundle.py
@@ -129,7 +129,7 @@ class NudgeBundleBody(unittest.TestCase):
         self.assertIn("> 1. Ship the auth refactor — End-to-end auth revamp.", out)
         self.assertIn("> 2. Write the migration guide", out)
         self.assertIn("> 3. Fix the flaky login test", out)
-        self.assertIn("Status check on the 3 separate goals above", out)
+        self.assertIn("Where do these 3 stand?", out)
         for g in (G1, G2, G3):
             self.assertIn("<!-- romp-goal-id: %s -->" % g, out, "every bundled goal id must ride the tail")
         self.assertIn("<!-- romp-injected -->", out)
@@ -141,7 +141,7 @@ class NudgeBundleBody(unittest.TestCase):
 
     def test_stalled_goals_get_the_fork_line_by_number(self):
         out = km._nudge_bundle_body([G1, G3], self._nodes(), {G3})
-        self.assertIn("Under #2 there are items still open on your own to-do list", out)
+        self.assertIn("On #2 you've still got open items on your to-do list", out)
         out2 = km._nudge_bundle_body([G1, G2], self._nodes(), set())
         self.assertNotIn("to-do list", out2, "no fork line when nothing is agent-open")
 

--- a/tests/test_reply_bulk_unblock.py
+++ b/tests/test_reply_bulk_unblock.py
@@ -120,8 +120,8 @@ class WiringPins(unittest.TestCase):
         # judge side: the nudge planner resolves each reported piece on its own item, obsolete included
         self.assertIn("also resolve each reported piece on its **own** listed item", self.SRC)
         # kernel side: both nudge bodies invite the drop shape, so the reply can actually say it
-        self.assertIn("If a piece is obsolete and no longer needed, say so", self.KSRC)
-        self.assertIn("If one is no longer needed, say so and why.", self.KSRC)
+        self.assertIn("If one is no longer needed, just say so", self.KSRC)
+        self.assertIn("If one is no longer needed, just say so.", self.KSRC)
 
 
 if __name__ == "__main__":

--- a/ui/webview/feed-blocked-actions.test.ts
+++ b/ui/webview/feed-blocked-actions.test.ts
@@ -67,8 +67,13 @@ test("(A) the per-sub-goal 'Check status' is a ONE-CLICK targeted ask — askFol
   assert.match(FEED, /stat\.textContent = "Check status"/);
   assert.doesNotMatch(FEED, /stat\.textContent = "Status\?"/);
   assert.match(FEED, /function statusAskOne\(title: string\): string/);
-  // the canned ask names the four reply shapes the judge's planner files: done / in progress / blocked-on-me / obsolete
-  assert.match(FEED, /done \(say what shipped\), in progress \(say what's next\), /);
+  // The canned ask still elicits the four reply shapes the judge's planner files (done / in progress /
+  // blocked-on-me / obsolete) but no longer NAMES that taxonomy at the session (the user 2026-07-24): the
+  // recipient has never heard of romp, so four labeled reply slots read as a form to fill in rather than a
+  // question. A person asking "what shipped, what's next, or what do you need from me" gets the same four
+  // answers back. Same rule as the clear-wrap message.
+  assert.match(FEED, /what shipped, what's next, or exactly what you/);
+  assert.doesNotMatch(FEED, /Status check on this card/, "'card' is romp's word, not one the session knows");
   assert.match(FEED, /text: statusAskOne\(node\.text \|\| "this sub-goal"\), sid: it\.sid/);
   // instant ack: disable + relabel before the round-trip (the ↻ chip takes over on the next push)
   assert.match(FEED, /stat\.disabled = true; stat\.textContent = "Asked";/);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -1696,18 +1696,24 @@ function navSidOf(it: AskItem, node: AskTreeNode): string {
 // Canned one-click status asks (the user 2026-07-20). The reply shapes are exactly the verdicts the
 // judge's planner files off a nudge reply — done / in progress / blocked-on-you / obsolete — so the
 // session's answer heals the card without any new ingestion machinery.
+//
+// VOICE (the user 2026-07-24): the session has no idea romp is tracking it, so these read as the person
+// it works for asking, in their words. The old opener announced a status check on "this card", naming a
+// romp OBJECT the recipient has never heard of, and the four labeled reply slots read as a form. The
+// same four answers still come back — a person asking "what shipped, what's next, or what do you need
+// from me" gets them without naming the taxonomy. Same rule as the clear-wrap message.
 function statusAskOne(title: string): string {
-  return "Where does \"" + title + "\" stand? One line: done (say what shipped), in progress (say what's next), "
-       + "blocked on me (restate exactly what you need from me), or obsolete (say to drop it).";
+  return "Where does \"" + title + "\" stand? One line: what shipped, what's next, or exactly what you "
+       + "need from me if you're stuck. If it isn't worth doing anymore, say so.";
 }
 function statusSweepText(it: AskItem): { n: number; text: string } {
   const open = (it.tree || []).filter((n) => n.status !== "done" && !n.cleared && n.kind !== "handoff" && n.id !== it.itemId);
   const lines = open.slice(0, 15).map((n) => "- " + (n.text || "(sub-goal)"));
-  const more = open.length > 15 ? "\n(+" + (open.length - 15) + " more on this card)" : "";
+  const more = open.length > 15 ? "\n(+" + (open.length - 15) + " more)" : "";
   return { n: open.length,
-           text: "Status check on this card. For each item below, one line each: done (say what shipped), "
-               + "in progress (say what's next), blocked on me (restate exactly what you need from me), "
-               + "or obsolete (say to drop it):\n" + lines.join("\n") + more };
+           text: "Where does each of these stand? One line each: what shipped, what's next, or exactly "
+               + "what you need from me if you're stuck. If one isn't worth doing anymore, say so:\n"
+               + lines.join("\n") + more };
 }
 // True if any DESCENDANT of `node` is itself a question. Node status is ROLLED UP
 // (a ? anywhere below makes every ancestor ?), so this distinguishes the ACTUAL


### PR DESCRIPTION
Follow-on to #11, same rule applied across the rest of the injected copy.

## Voice: no romp vocabulary at the session

The session has no idea romp is tracking it, so a message that narrates the goal machinery reads as a system notice rather than the person it works for asking for something. Five places did that:

| Where | Before | After |
|---|---|---|
| `feed.ts` sweep | "Status check on this card. For each item below, one line each: done (say what shipped), in progress (say what's next), blocked on me (restate exactly what you need from me), or obsolete (say to drop it):" | "Where does each of these stand? One line each: what shipped, what's next, or exactly what you need from me if you're stuck. If one isn't worth doing anymore, say so:" |
| `feed.ts` single | `Where does "X" stand? One line: done (say what shipped), …, or obsolete (say to drop it).` | `Where does "X" stand? One line: what shipped, what's next, or exactly what you need from me if you're stuck. If it isn't worth doing anymore, say so.` |
| bundle nudge | "Status check on the 3 separate goals above, each still open." | "Where do these 3 stand?" |
| hierarchical nudge quote | "Unfinished pieces under this goal — give me a status on each:" | "Still open on this:" |
| stalled/fork nudge | "You stopped with items on your own to-do list still open. For each open item: where does it stand, and if you don't need anything from me, please continue with it now. …" | "You've still got open items on your to-do list. Where does each one stand? Keep going on anything you can. If something's blocked, tell me which one and exactly what you need from me. …" |

The four reply shapes the planner files (done / in progress / blocked-on-me / obsolete) still come back; they are just no longer named at the recipient as a taxonomy to fill in.

**Deliberately unchanged:** `AUTO_NUDGE_TEXT` was already a person checking in. The `sdk_backend.py` "[romp] The kernel restarted…" notices name romp on purpose, since they explain why the agent's turn was cut. The marker tail already says "an external tracking system".

## A follow-up on a summary now carries the open pieces

Replying to a card's distilled summary sent the session that one line. The summary is a lossy headline, so a takeaway that got the emphasis wrong propagated unchallenged and nothing pointed the session at the rest of the card. A **blocked** sub-goal went unmentioned, which is the piece a reply is most likely to be about.

The open sub-goals now ride under the summary, using the bullets the nudge already enumerates:

```
> Endpoints are live and the client is wired up.
> Also still open on this:
>   • Backfill the fixtures — Needed before the load test.
>   • Pick the rate-limit ceiling (blocked) — Need you to choose a number.
```

Those bullets are now shared through `_open_leaf_bullets` so the single-goal nudge, the multi-goal bundle and the typed follow-up cannot drift apart. A flat card with nothing open keeps the bare summary quote.

## Tests

Two new tests for the follow-up context (open pieces ride, blocked one included, finished ones excluded; flat card unchanged). The copy pins across `test_kernel.py`, `test_nudge_bundle.py`, `test_reply_bulk_unblock.py` and `feed-blocked-actions.test.ts` now assert the new wording, and the feed one also asserts the word "card" never reaches the session.

Python 3048 passed, node 1301 passed, `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)