### PR TITLE
Write down the rule: injected messages speak as the user, not as romp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,40 @@ can't, rather than quietly folding. There is no SDK API for the to-do checklist 
 verified, not assumed.) This is the same spirit as the event-vs-heuristic rule
 below: don't approximate when the real thing is available; when it isn't, be loud.
 
+## Messages we inject into a session: the agent does not know romp exists (user rule, 2026-07-24)
+Every message romp puts into a session — a nudge, a follow-up, a clear wrap-up, a
+canned status ask — is read by an agent with NO idea it is being tracked. It has
+never seen the feed, has no concept of a card, a goal, a board, or a column, and
+cannot act on any of it. So write these as **the person it works for asking for
+something**, in their words:
+- **No romp nouns in the prose**: card, board, goal, column, cleared, dismissal,
+  nudge, status check. Say the thing instead. "Status check on this card" → "Where
+  does each of these stand?"; "the goal above was cleared off the board — a
+  dismissal, not a completion" → "I'm dropping this one."
+- **No taxonomy handed over as reply slots.** romp's planner files four verdicts
+  (done / in progress / blocked-on-you / obsolete), but naming them at the agent
+  turns a question into a form. Ask like a person — "what shipped, what's next, or
+  exactly what you need from me if you're stuck" — and the same four answers come
+  back for the planner to file.
+- **Short.** A long directive reads as a system notice however it is worded. The
+  clear wrap-up carries the same content in about half the words it started with.
+- Draft this copy with the `jld` skill, the way any user-facing writing is drafted.
+
+TWO deliberate exceptions, both fine, neither a licence to widen:
+- **The SessionStart instruction** that asks a session to report what it finished
+  and what it is blocked on. That asks for ordinary self-reporting; it names no
+  romp machinery and needs none.
+- **The marker tail** (`<!-- romp-note: … an external tracking system that is not
+  relevant to your work — ignore them -->`). It describes the markers WITHOUT
+  naming romp, on purpose: naming it would explain nothing to a model that has
+  never heard of it.
+- Also fine: the `[romp] The kernel restarted…` notices in `sdk_backend.py`. Those
+  are genuinely ABOUT romp — they tell a session why its turn was cut — so they
+  name it.
+
+`tests/test_injected_voice.py` renders every injected body and fails on romp
+vocabulary in the prose, so this holds without anyone remembering it.
+
 ## Design
 Prefer exact event-based mechanisms over time-based heuristics (grace periods,
 debounces, age thresholds). If a time window seems needed, find the event it is

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -719,7 +719,7 @@ def _nudge_bundle_body(gids, nodes, stalled_gids):
     quote, stall_nums = [], []
     for i, gid in enumerate(gids, 1):
         nd = nodes.get(str(gid)) or {}
-        head = str(nd.get("text", "")).strip() or "(unnamed goal)"
+        head = str(nd.get("text", "")).strip() or "(untitled)"
         why = str(nd.get("why") or "").strip()
         quote.append("%d. %s" % (i, head) + ((" — " + why) if why else ""))
         # CAP 6, tighter than the single-goal 12: N goals share one message
@@ -9535,7 +9535,7 @@ def _clear_wrap_body(gids, nodes):
     quote = []
     for i, gid in enumerate(gids, 1):
         nd = nodes.get(str(gid)) or {}
-        head = str(nd.get("text", "")).strip() or "(unnamed goal)"
+        head = str(nd.get("text", "")).strip() or "(untitled)"
         why = str(nd.get("why") or "").strip()
         quote.append(("%d. %s" % (i, head)) if len(gids) > 1 else head)
         if why:

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Every message romp injects into a session is written as the USER asking, not as romp reporting
+(the user rule, 2026-07-24 — CLAUDE.md "Messages we inject into a session").
+
+The recipient is an agent with NO idea it is being tracked. It has never seen the feed, has no concept
+of a card, a goal, a board or a column, and cannot act on any of it. A message that narrates that
+machinery reads as a system notice rather than the person it works for asking for something. The
+2026-07-24 sweep found five: the two feed status asks, the multi-goal bundle, the nudge quote header,
+and the fork/stalled nudge, plus the clear wrap-up that started it.
+
+This test renders each injected body from SYNTHETIC fixtures and fails on romp vocabulary in the PROSE.
+It is the guardrail behind the CLAUDE.md rule, so the rule holds without anyone remembering it.
+
+Scope note — what is deliberately NOT checked:
+- the MARKER TAIL (everything from the first "<!--"). It names romp on purpose in `romp-goal-id` /
+  `romp-injected`, and its romp-note describes the comments as "an external tracking system" precisely
+  so it does NOT have to name romp to the model. Prose only.
+- the SessionStart instruction, which asks for ordinary self-reporting (what you finished, what you're
+  blocked on) and names no machinery.
+- sdk_backend's "[romp] The kernel restarted…" notices, which are genuinely ABOUT romp: they tell a
+  session why its turn was cut, so naming it is the point.
+
+SYNTHETIC fixtures only (placeholder ids, invented goal text).
+"""
+import json
+import os
+import re
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_voice", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-555555555555"
+TOP, SUB_OPEN, SUB_BLOCKED, TOP2 = (SID + ":g1", SID + ":g2", SID + ":g3", SID + ":g4")
+T0 = 1781100000
+
+# romp's OWN vocabulary — words that name a thing only romp knows about. A message using one of these
+# is describing the tracking system to someone who has never heard of it.
+ROMP_WORDS = [
+    ("romp", "the product name — the recipient has never heard of it"),
+    ("card", "a feed object; the agent sees no feed"),
+    ("board", "a column layout the agent cannot see"),
+    ("goal", "romp's unit of tracking, not a word the user would use to an agent"),
+    ("cleared", "a board gesture"),
+    ("dismissal", "a board gesture"),
+    ("status check", "announces a form rather than asking a question"),
+    ("nudge", "romp's name for this message"),
+]
+
+
+def _nodes():
+    return {TOP: {"id": TOP, "text": "Ship the notes API", "parentId": None, "nodeComplete": False,
+                  "blocked": False, "cleared": False, "why": "The client is waiting on it.",
+                  "summary": "Endpoints are live and the client is wired up.", "t": T0, "mt": T0},
+            SUB_OPEN: {"id": SUB_OPEN, "text": "Backfill the fixtures", "parentId": TOP,
+                       "nodeComplete": False, "blocked": False,
+                       "why": "Needed before the load test.", "t": T0, "mt": T0},
+            SUB_BLOCKED: {"id": SUB_BLOCKED, "text": "Pick the rate-limit ceiling", "parentId": TOP,
+                          "nodeComplete": False, "blocked": True,
+                          "blockWhy": "Need you to choose a number.", "t": T0, "mt": T0},
+            TOP2: {"id": TOP2, "text": "Write the migration guide", "parentId": None,
+                   "nodeComplete": False, "blocked": False, "cleared": False, "t": T0, "mt": T0}}
+
+
+def prose(body):
+    """The part a model actually reads as instruction: everything before the marker tail."""
+    return body.split("<!--")[0]
+
+
+class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_goaldir, self.saved_state = jd.GOALDIR, jd.STATE
+        jd.GOALDIR, jd.STATE = Path(self.td.name), Path(self.td.name)
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            {"rompUuid": SID, "seq": 4, "nodes": _nodes(), "placements": {}, "status": {}}))
+
+    def tearDown(self):
+        jd.GOALDIR, jd.STATE = self.saved_goaldir, self.saved_state
+        self.td.cleanup()
+
+    def _bodies(self):
+        """Every message romp injects, by name, rendered from the same synthetic store."""
+        nodes = _nodes()
+        return {
+            "auto-nudge": km.AUTO_NUDGE_TEXT,
+            "fork nudge": km.AUTO_NUDGE_STALLED_TEXT,
+            "nudge on a hierarchical goal":
+                km._followup_body(TOP, None, km.AUTO_NUDGE_TEXT, injected=True, auto=True),
+            "fork nudge on a hierarchical goal":
+                km._followup_body(TOP, None, km.AUTO_NUDGE_STALLED_TEXT, injected=True, auto=True,
+                                  stalled=True),
+            "typed follow-up on a summary": km._followup_body(TOP, None, "ship it"),
+            "multi-goal bundle": km._nudge_bundle_body([TOP, TOP2], nodes, set()),
+            "multi-goal bundle (fork)": km._nudge_bundle_body([TOP, TOP2], nodes, {TOP}),
+            "clear wrap-up": km._clear_wrap_body([TOP], nodes),
+            "clear wrap-up (batch)": km._clear_wrap_body([TOP, TOP2], nodes),
+        }
+
+    def test_no_romp_vocabulary_reaches_the_session(self):
+        for name, body in self._bodies().items():
+            text = prose(body).lower()
+            for word, why in ROMP_WORDS:
+                with self.subTest(message=name, word=word):
+                    self.assertNotIn(word, text,
+                                     "%r speaks romp at the session (%r: %s). Write it as the person "
+                                     "it works for asking — see CLAUDE.md, 'Messages we inject into a "
+                                     "session'." % (name, word, why))
+
+    def test_the_untitled_fallback_names_no_romp_object(self):
+        # a node with no text still renders SOMETHING; that placeholder must not smuggle in "goal"
+        nodes = _nodes()
+        nodes[TOP]["text"] = ""
+        for name, body in (("bundle", km._nudge_bundle_body([TOP], nodes, set())),
+                           ("clear wrap-up", km._clear_wrap_body([TOP], nodes))):
+            self.assertIn("(untitled)", prose(body), name)
+            self.assertNotIn("goal", prose(body).lower(), name)
+
+    def test_the_marker_tail_is_exempt_and_still_explains_itself(self):
+        # the tail names romp in its markers ON PURPOSE, and its note describes them WITHOUT naming
+        # romp — that split is the point, so the test must not have banned it by accident
+        body = km._followup_body(TOP, None, "ship it")
+        tail = body[body.index("<!--"):]
+        self.assertIn("romp-goal-id", tail, "the judge's marker still rides")
+        note = tail.split("romp-note:", 1)[1].split("-->", 1)[0]     # the human-readable sentence
+        self.assertIn("external tracking system", note)
+        self.assertNotIn("romp", note,
+                         "the note DESCRIBES the markers without naming the product — naming it would "
+                         "explain nothing to a model that has never heard of it")
+
+    def test_the_asks_still_elicit_the_planners_four_verdicts(self):
+        # the rule is about VOCABULARY, not content: dropping the labeled reply slots must not drop the
+        # question. Each nudge still asks for progress, for what is owed by the user, and permits "drop it".
+        for name, body in self._bodies().items():
+            # the wrap-up is a stop order, not a status ask; a TYPED follow-up carries the user's OWN
+            # words as its body, so there is no romp-authored ask in it to check
+            if name in ("clear wrap-up", "clear wrap-up (batch)", "typed follow-up on a summary"):
+                continue
+            text = prose(body).lower()
+            with self.subTest(message=name):
+                self.assertTrue("stand" in text or "what's next" in text or "keep going" in text,
+                                "%r no longer asks for progress" % name)
+                self.assertIn("from me", text, "%r no longer asks what it needs from the user" % name)
+
+
+class TheRuleIsWrittenDown(unittest.TestCase):
+    def test_claude_md_carries_the_rule_and_its_exceptions(self):
+        md = (Path(HERE).parent / "CLAUDE.md").read_text()
+        self.assertIn("the agent does not know romp exists", md)
+        self.assertIn("No romp nouns in the prose", md)
+        self.assertIn("No taxonomy handed over as reply slots", md)
+        self.assertIn("tests/test_injected_voice.py", md, "the rule points at its own guardrail")
+        # the exceptions are part of the rule: without them someone "fixes" the marker note next
+        self.assertIn("SessionStart instruction", md)
+        self.assertIn("marker tail", md)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follows #13, which fixed five messages by hand. This writes the rule down and puts a guardrail behind it.

## The rule (CLAUDE.md)

Every message romp injects into a session is read by an agent with no idea it is being tracked. It has never seen the feed and has no concept of a card, a goal, a board or a column. So: no romp nouns in the prose, no verdict taxonomy handed over as reply slots, keep it short, and draft the copy with the `jld` skill.

Two deliberate exceptions are written down as part of the rule, so nobody "fixes" them next: the SessionStart instruction (ordinary self-reporting, names no machinery) and the marker tail, which describes the comments as "an external tracking system" precisely so it never has to name romp. The `[romp] The kernel restarted…` notices are fine too, since they are genuinely about romp.

## The guardrail

`tests/test_injected_voice.py` renders all nine injected bodies from synthetic fixtures and fails on romp vocabulary in the prose (78 subtests). It also pins that dropping the labeled reply slots did not drop the question: each ask still requests progress and still asks what the session needs from the user, which is what the planner files.

Prose only. The marker tail is exempt and has its own test asserting the split still holds: the markers name romp, the human-readable note does not.

One code change: the `(unnamed goal)` placeholder for a node with no text became `(untitled)`, the last place a romp noun could reach a session.

Python 3056 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)