### PR TITLE
Distill at the done verdict, re-brief each new prompt, and a done-confirming cue

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2662,6 +2662,7 @@ def rollup_status(store, session_closed, now=None):
     # (setdefault) so it freezes the entry order; cleared by _reopen so a re-completion re-stamps.
     latest_t = max((max(nd.get("mt", 0) or 0, nd.get("t", 0) or 0) for nd in nodes.values()), default=0)
     status = {}
+    confirming = []                                   # done verdict landed, settle pending — see the export below
     for nid in children.get(None, []):                # precedence: cleared > blocked > followup-pending > complete+settled > working
         settled = (nid != focus) or session_closed
         if nodes[nid].get("cleared"):
@@ -2685,6 +2686,16 @@ def rollup_status(store, session_closed, now=None):
             status[nid] = "completed"
         else:
             status[nid] = "working"
+            # DONE-BUT-UNSETTLED (the user 2026-07-24): the done verdict is in; only the settle event
+            # (focus moving on) is pending. The COLUMN stays Working — the settle gate above is what
+            # stops premature completion — but a done goal is frozen for the user's review, so two
+            # consumers need the fact NOW rather than at settle: the feed's "done, confirming" cue on
+            # the card, and the distiller, which starts the takeaway at the done verdict instead of
+            # leaving the card summary-less until focus moves (the 76-minute card). Exported on the
+            # store (authoritative rollup product) so neither consumer re-derives it from the raw
+            # nodeComplete flag, which lies for agent-open umbrellas is_complete refuses.
+            if is_complete(nid):
+                confirming.append(nid)
 
     # Heal ORPHANED open descendants: when a TOP rolls up to completed/cleared, its sub-steps are discharged
     # (done) or dismissed (cleared) WITH it — the planner's top-done verdict discharges the whole ask even with
@@ -2774,6 +2785,7 @@ def rollup_status(store, session_closed, now=None):
             else:
                 nd.pop("warns", None)
     store["status"] = status
+    store["confirming"] = confirming
 
 
 def _sync_declared_plan(store, session, seg_id, seg_t, prompt_uuid=None):
@@ -6911,13 +6923,20 @@ def stalled_facts(fsid):
     return out
 
 
-def _last_state_value(fsid):
-    """The most-recent STATE transition in states/<fsid>.jsonl ('working'/'waiting'/'picker'/…), ignoring the
-    interleaved awaiting overlays; '' when there's no state file. Mirrors the kernel's _last_state_value — the
-    distiller uses it to spot a session parked RIGHT NOW on a live picker/permission prompt (a transient live
-    state the planner hasn't classified into the goal store), so it can brief that focus goal too."""
+def _live_prompt_since(fsid):
+    """The `t` of the transition INTO the current trailing picker/permission run of states/<fsid>.jsonl —
+    None when the latest state is anything else, or there's no state file. Only "state"-bearing records
+    count (the log interleaves awaiting overlays and other markers). The distiller uses it to spot a
+    session parked RIGHT NOW on a live prompt (a transient live state the planner hasn't classified into
+    the goal store) AND to name that park's own event: the value is stable for as long as one park lasts,
+    and a NEW prompt after any other state is a NEW episode with a fresh t. That per-episode identity is
+    what the live-brief gate keys on (see _distill_session) — node `mt`, the old key, is stable across
+    EPISODES too (nothing lands in the store mid-turn), so a second prompt in the same open turn kept the
+    first prompt's stale brief (the user 2026-07-24: a reply answered the parked question, the session
+    asked a NEW one, and the card still briefed the answered one). Consecutive prompt states
+    (picker→permission) are ONE run — the episode starts where the run does."""
     p = STATESDIR / (fsid + ".jsonl")
-    val = ""
+    since, prev = None, ""
     try:
         with open(p, errors="replace") as f:
             for line in f:
@@ -6927,20 +6946,27 @@ def _last_state_value(fsid):
                     rec = json.loads(line)
                 except ValueError:
                     continue
-                if isinstance(rec, dict) and isinstance(rec.get("state"), str):
-                    val = rec["state"]
+                if not (isinstance(rec, dict) and isinstance(rec.get("state"), str)):
+                    continue
+                s = rec["state"]
+                if s in ("picker", "permission"):
+                    if prev not in ("picker", "permission"):
+                        since = rec.get("t") or 0      # entered a prompt run → the episode's own event
+                else:
+                    since = None                       # left the prompt → that episode is over
+                prev = s
     except OSError:
-        return ""
-    return val
+        return None
+    return since
 
 
 def _distill_due_t(store, nid, blocked):
     """The authoritative "this goal (re)resolved" time the distiller/brief gate compares against —
     never `mt` (the user 2026-07-08, the Proton-card regression): since the diary flip an event-only
     reopen→settle cycle bumps no cache stamp, so an mt-keyed gate slept through re-completions and the
-    card kept its stale pre-follow-up summary. Completed side = the settle event (settledAt); blocked
-    side = the newest block event among the nodes STILL blocked (the block that owes the brief can sit
-    on a descendant). Falls back to mt only when the store predates those events entirely.
+    card kept its stale pre-follow-up summary. Completed side = the newest DONE event in the subtree;
+    blocked side = the newest block event among the nodes STILL blocked (the block that owes the brief
+    can sit on a descendant). Falls back to mt only when the store predates those events entirely.
 
     STILL blocked, not ever blocked (the user 2026-07-23, the launch-prep card again): a block the fold
     has since closed is dead history, and counting it pinned `due` to the newest DEAD block. A mid-turn
@@ -6949,11 +6975,18 @@ def _distill_due_t(store, nid, blocked):
     forever, so the card never re-entered the distiller and sat in Blocked saying nothing. Reading only
     open blocks keys `due` to the same set the brief's owed question comes from (`blkd`), which is the
     invariant that broke. `blocked` is the materialized fold, so an unblock closes the episode by
-    history, not by flag-poking."""
+    history, not by flag-poking.
+
+    Completed side: the newest DONE event in the SUBTREE, not settledAt (the user 2026-07-24, the
+    76-minute card): a done verdict means the goal is frozen for the user's review, so its takeaway
+    should be ready THEN — keyed on settle, the card sat nodeComplete-but-focus in Working with no
+    distill under way while the settle event was still pending. Settle alone moves nothing now (the
+    summary written at done is already right); only a reopen→re-done lands a NEWER done event and
+    re-fires — the worst case the user accepted is one re-distill when work actually resumes. Subtree,
+    not the top's own log: a bottom-up-completed umbrella carries no done verdict of its own — its
+    children's do. settledAt stays as the fallback for stores whose diary predates done events."""
     nodes = store["nodes"]
     nd = nodes.get(nid) or {}
-    if not blocked:
-        return nd.get("settledAt") or nd.get("mt")
     kids = {}
     for x, d in nodes.items():
         kids.setdefault(d.get("parentId"), []).append(x)
@@ -6961,13 +6994,15 @@ def _distill_due_t(store, nid, blocked):
     stack = [nid]
     while stack:
         x = stack.pop()
-        if nodes.get(x, {}).get("blocked"):
+        if not blocked or nodes.get(x, {}).get("blocked"):
             for e in (nodes.get(x, {}).get("log") or []):
-                if e.get("kind") == "block":
+                if e.get("kind") == ("block" if blocked else "done"):
                     t = e.get("ev_t") or e.get("at") or 0
                     if best is None or t > best:
                         best = t
         stack.extend(kids.get(x, []))
+    if not blocked:
+        return best or nd.get("settledAt") or nd.get("mt")
     return best or nd.get("mt")
 
 
@@ -6985,31 +7020,61 @@ def _distill_session(fsid, path, now):
     _judge_ctx.fsid = fsid                            # usage logging: attribute this session's judge calls
     store = load_goals(fsid)
     status, nodes = store.get("status", {}), store.get("nodes", {})
-    # Event-gated: (re)distill when the goal (re)completed (distilledMt != mt). ALSO re-enter a completed goal
-    # whose summary is still null even at the current mt — that is the no-work give-up below having stamped
-    # distilledMt without a summary, leaving the card stuck on "(generating…)" forever; reprocessing settles it
-    # to the "" sentinel (or a real summary if work has since appeared). The "" sentinel is NON-null, so a
-    # settled goal never re-enters — this self-heals existing stuck cards without a migration. Same for
-    # blocked/blockSummary.
+    # Event-gated: (re)distill when the goal (re)completed (distilledMt != the done event). ALSO re-enter a
+    # completed goal whose summary is still null even at the current due — that is the no-work give-up below
+    # having stamped distilledMt without a summary, leaving the card stuck on "(generating…)" forever;
+    # reprocessing settles it to the "" sentinel (or a real summary if work has since appeared). The ""
+    # sentinel is NON-null, so a settled goal never re-enters — this self-heals existing stuck cards without
+    # a migration. Same for blocked/blockSummary.
+    #
+    # AT THE DONE VERDICT, not at settle (the user 2026-07-24, the 76-minute card): a done goal is frozen
+    # for the user's review, so its takeaway is owed THEN — the rollup's `confirming` export (done verdict
+    # in, settle pending, status still 'working') enters here alongside 'completed'. Settle alone then
+    # changes nothing; only a reopen→re-done moves the due and re-fires (the one-re-distill worst case the
+    # user accepted).
+    confirming = set(store.get("confirming") or ())
+
+    def _done_owed(nid):
+        if nodes[nid].get("summary") is None:
+            return True
+        _dmt = nodes[nid].get("distilledMt")
+        # A stamp equal to the goal's settle time is ALSO current: pre-07-24 stamps were the settle event,
+        # and re-keying the due on the done event must not re-enter every already-distilled card in the
+        # fleet at once (a deploy-wide re-distill storm). Match the settledAt cache OR any settle event in
+        # the diary (the stamp materializes from the event, so either form may be the one on disk). Self-
+        # retiring: new-era stamps are done-event times, and a reopen undoes the settle, so any later
+        # re-completion is judged by the done event alone.
+        if _dmt is not None and (_dmt == nodes[nid].get("settledAt")
+                                 or any(_dmt == (e.get("ev_t") or e.get("at") or 0)
+                                        for e in (nodes[nid].get("log") or [])
+                                        if e.get("kind") == "settle")):
+            return False
+        return _dmt != _distill_due_t(store, nid, False)
+
     todo = [nid for nid, st in status.items() if nodes.get(nid) and (
-            (st == "completed" and (nodes[nid].get("distilledMt") != _distill_due_t(store, nid, False)
-                                    or nodes[nid].get("summary") is None)) or
+            ((st == "completed" or nid in confirming) and _done_owed(nid)) or
             (st == "blocked" and (nodes[nid].get("briefedMt") != _distill_due_t(store, nid, True)
                                   or nodes[nid].get("blockSummary") is None)))]
     # LIVE picker/permission floor (the user 2026-06-29): a session parked RIGHT NOW on a live prompt is
     # blocked-on-you, but the planner hasn't classified its focus goal — its stored status is still 'working',
     # so the loop above never briefs it and the card shows no distiller line. Detect it from the state log and
-    # brief that focus top too (treated as blocked below). Event-gated on briefedMt vs mt exactly like a stored
-    # block, so it briefs ONCE per episode (mt is stable while parked), not every pass.
-    live_brief = set()
-    if _last_state_value(fsid) in ("picker", "permission"):
+    # brief that focus top too (treated as blocked below). Event-gated ONCE PER PROMPT EPISODE on its OWN
+    # stamp, promptBriefedT vs _live_prompt_since (the user 2026-07-24): the old key (briefedMt vs the stored
+    # due, which falls back to mt) was stable across episodes within one open turn — a reply answered the
+    # parked question, the session asked a NEW one, and the gate stayed closed on the answered question's
+    # brief. The stamp is SEPARATE from briefedMt so this gate and the stored-block gate can each close
+    # without reopening the other (sharing one stamp with two key values would alternate forever).
+    live_brief, live_since = set(), None
+    _lp = _live_prompt_since(fsid)
+    if _lp is not None:
         f = store.get("lastNode")
         while f and nodes.get(f, {}).get("parentId") is not None:
             f = nodes[f].get("parentId")
         if (f in nodes and status.get(f) not in ("completed", "cleared")
-                and (nodes[f].get("briefedMt") != _distill_due_t(store, f, True)
+                and (nodes[f].get("promptBriefedT") != _lp
                      or nodes[f].get("blockSummary") is None)):
             live_brief.add(f)
+            live_since = _lp
             if f not in todo:
                 todo.append(f)
     # STALLED tops (the user 2026-07-23): still 'working', not blocked on the user, but romp's nudge gate is
@@ -7022,8 +7087,8 @@ def _distill_session(fsid, path, now):
         _nd = nodes.get(_gid)
         if not _nd or _nd.get("parentId") is not None or _nd.get("cleared"):
             continue                                   # top-level, live goals only (the card's own root)
-        if status.get(_gid, "working") != "working" or _gid in live_brief:
-            continue                                   # resolved, or already owed a decision brief
+        if status.get(_gid, "working") != "working" or _gid in live_brief or _gid in confirming:
+            continue                                   # resolved (or done-confirming), or already owed a decision brief
         if (_nd.get("stalledMt") != _f["since"] or _nd.get("stallSummary") is None) and _gid not in todo:
             todo.append(_gid)
     if not todo:
@@ -7037,8 +7102,9 @@ def _distill_session(fsid, path, now):
     for top in todo:
         blocked = status.get(top) == "blocked" or top in live_brief   # live-picker focus → brief it like a block
         # A STALL is the third state, and it never competes with the other two: a card owed a decision brief
-        # is blocked ON THE USER, which outranks "romp is stuck on it".
-        stalled = (not blocked) and status.get(top) == "working" and top in stalls
+        # is blocked ON THE USER, which outranks "romp is stuck on it". A done-confirming top isn't stalled
+        # either — its verdict is in; it entered todo for the takeaway.
+        stalled = (not blocked) and status.get(top) == "working" and top in stalls and top not in confirming
         due = (stalls[top]["since"] if stalled            # the stall's own start event, not a settle/block
                else _distill_due_t(store, top, blocked))  # the event time this (re)resolution stamps back
         stack, sub = [top], []                         # the top + all descendants (its whole subtree) — still
@@ -7107,6 +7173,15 @@ def _distill_session(fsid, path, now):
             n += 1; changed = True
             continue
         if blocked:
+            if top in live_brief and nodes[top].get("promptBriefedT") != live_since:
+                # Close the PROMPT-EPISODE gate now, eagerly, not on the write paths below: every branch
+                # down there ends in `continue`, and threading the stamp through all of them is exactly
+                # how one gets missed and the gate re-enters (an LLM call per pass) forever. Eager is
+                # safe: a pause-skip or failed call leaves blockSummary null, and the gate's None clause
+                # re-enters on that alone — only a NEW episode (fresh _live_prompt_since) reopens it
+                # otherwise, which is the intended once-per-prompt cadence (the user 2026-07-24).
+                nodes[top]["promptBriefedT"] = live_since
+                changed = True
             # A NEW block event since a "" settle re-opens the question (the user 2026-07-23, the launch-prep
             # card): the "" sentinel means "distilled THAT episode, nothing to say" — it must not keep muting
             # the card after a FRESH block lands (due moved), or a real owed decision shows neither line nor

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10168,6 +10168,7 @@ def build_feed(now, tmux=None):
         sess_judging = bool(live and ps and not who_working
                             and _closer_pending(fsid, s["path"], now, store))
         nodes, status = store.get("nodes", {}), store.get("status", {})
+        confirming = set(store.get("confirming") or ())   # rollup export: done verdict in, settle pending (judge rollup_status, the user 2026-07-24)
         # Exact click-to-jump anchors: map each goal segment → the work/reply uuid — the SAME anchors the
         # timeline/ledger already use — so a card click deep-links to the precise turn BY ID instead of the
         # old time-nearest heuristic. _parse is cache-backed (cheap); reply uuid preferred (the readable
@@ -10647,6 +10648,12 @@ def build_feed(now, tmux=None):
                 "trgb": list(cm.age_rgb(now - disp_t, _colormap())),
                 "turnId": nid, "origin": origin,
                 "followupPending": nodes[nid].get("followupPending"),   # optimistic reopen → "Followed up" chip until the judge catches up
+                # DONE-CONFIRMING (the user 2026-07-24): the done verdict is in; only the settle event is
+                # pending. The card STAYS in Working (the settle gate exists precisely so the column never
+                # flickers working↔done) and wears a steady "done, confirming" cue instead. From the
+                # rollup's authoritative export, never the raw nodeComplete flag (which lies for agent-open
+                # umbrellas is_complete refuses).
+                "doneConfirming": (True if (column == "working" and nid in confirming) else None),
                 "waitingOn": (wmap.get(fsid) if (column == "working" and _peer_wait) else None),   # 'waiting on <peer>' chip: unanswered outbound to a live peer, only on a goal that predates the question (the user 2026-06-22/28)
                 # awaiting flavor: held in Working with a ⏳ awaiting badge (waiting on dispatched/delegated
                 # work) — the user 2026-06-22. `tasks` = the live bg-task descriptions (the user 2026-07-13):

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -4229,6 +4229,118 @@ class DeltaScopedDistill(unittest.TestCase):
                          "a block the fold has closed is history — it must not outrank the one still owed")
 
 
+class DistillAtDone(unittest.TestCase):
+    """A DONE goal is frozen for the user's review, so its takeaway is owed at the done VERDICT, not at
+    settle (the user 2026-07-24): keyed on settle, a just-finished focus card sat 76 minutes in Working
+    with no distill under way, because the session kept landing sub-steps under it and focus never moved.
+    rollup_status exports store['confirming'] (done verdict in, settle pending, status still 'working');
+    the distiller enters those tops alongside 'completed'; the due stamp is the done EVENT, so settle
+    alone never re-fires — only a reopen→re-done (a fresh done event) does. SYNTHETIC fixtures only."""
+
+    G = SID + ":g1"
+
+    def setUp(self):
+        self._saved = (jd.STATE, jd.STATESDIR, jd.distill_llm)
+        self._td = tempfile.mkdtemp()
+        jd.STATE = Path(self._td)
+        jd.STATESDIR = Path(self._td) / "states"
+
+    def tearDown(self):
+        jd.STATE, jd.STATESDIR, jd.distill_llm = self._saved
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _write(self, status="working", confirming=True, log=None, **nd_extra):
+        records = [uline(T0, "build the widget", "u1", ps="typed"),
+                   aline(T0 + 10, "built it; tests green", "a1", "u1", stop="end_turn")]
+        segs = [sg for turn in build_session(records)["turns"] for sg in em.segments(turn)]
+        path = Path(self._td) / (SID + ".jsonl")
+        path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        node = {"id": self.G, "text": "build the widget", "parentId": None, "nodeComplete": True,
+                "blocked": False, "cleared": False, "trail": [sg["id"] for sg in segs],
+                "t": T0, "mt": T0 + 30, "summary": None,
+                "log": log if log is not None else [
+                    {"src": "planner", "kind": "done", "ev_t": T0 + 20, "at": T0 + 21}]}
+        node.update(nd_extra)
+        jd.save_goals(SID, {"rompUuid": SID, "seq": 1, "placementsV": jd.PLACEMENTS_V, "lastNode": self.G,
+                            "placements": {}, "status": {self.G: status},
+                            "confirming": [self.G] if confirming else [],
+                            "nodes": {self.G: node}})
+        return str(path)
+
+    def test_rollup_exports_the_confirming_window(self):
+        store = {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "lastNode": self.G,
+                 "nodes": {self.G: {"id": self.G, "text": "build the widget", "parentId": None,
+                                    "nodeComplete": True, "blocked": False, "cleared": False,
+                                    "trail": [], "t": T0, "mt": T0 + 30,
+                                    "log": [{"src": "planner", "kind": "done", "ev_t": T0 + 20, "at": T0 + 21}]}}}
+        jd.rollup_status(store, False)
+        self.assertEqual(store["status"][self.G], "working", "the COLUMN holds until settle — no flicker")
+        self.assertEqual(store["confirming"], [self.G], "the done-but-unsettled fact is exported alongside")
+        g2 = SID + ":g2"
+        store["nodes"][g2] = {"id": g2, "text": "the next thing", "parentId": None, "nodeComplete": False,
+                              "blocked": False, "cleared": False, "trail": [], "t": T0 + 40, "mt": T0 + 50,
+                              "log": []}
+        store["lastNode"] = g2                         # focus moved on → the settle event
+        jd.rollup_status(store, False)
+        self.assertEqual(store["status"][self.G], "completed")
+        self.assertEqual(store["confirming"], [], "settled → out of the confirming window")
+
+    def test_due_is_the_newest_subtree_done_event(self):
+        c = SID + ":g2"
+        store = {"nodes": {self.G: {"id": self.G, "parentId": None, "mt": T0,
+                                    "log": [{"kind": "done", "ev_t": T0 + 20}]},
+                           c: {"id": c, "parentId": self.G, "mt": T0,
+                               "log": [{"kind": "done", "ev_t": T0 + 90}]}}}
+        self.assertEqual(jd._distill_due_t(store, self.G, False), T0 + 90,
+                         "a bottom-up umbrella's done lives on its children — the subtree's newest counts")
+        store["nodes"][c]["log"] = []
+        store["nodes"][self.G]["log"] = []
+        store["nodes"][self.G]["settledAt"] = T0 + 300
+        self.assertEqual(jd._distill_due_t(store, self.G, False), T0 + 300,
+                         "no done events (pre-diary store) → the settle stamp, then mt")
+
+    def test_a_confirming_top_distills_before_settle(self):
+        path = self._write()
+        jd.distill_llm = lambda *a, **k: "BACKGROUND: b.\nTAKEAWAY: shipped the widget.\nSOURCE: m1"
+        n = jd._distill_session(SID, path, NOW)
+        nd = jd.load_goals(SID)["nodes"][self.G]
+        self.assertEqual(n, 1, "the takeaway is written at the done verdict, before settle")
+        self.assertEqual(nd["summary"], "shipped the widget.")
+        self.assertEqual(nd["distilledMt"], T0 + 20, "stamped with the done EVENT, not a settle time")
+
+    def test_settle_alone_does_not_redistill(self):
+        log = [{"src": "planner", "kind": "done", "ev_t": T0 + 20, "at": T0 + 21},
+               {"src": "romp", "kind": "settle", "ev_t": T0 + 300, "at": T0 + 300}]
+        path = self._write(status="completed", confirming=False, log=log,
+                           summary="shipped the widget.", distilledMt=T0 + 20)
+        jd.distill_llm = lambda *a, **k: self.fail("settle is not a distill event — the takeaway was written at done")
+        self.assertEqual(jd._distill_session(SID, path, NOW), 0)
+
+    def test_legacy_settle_stamp_stays_quiet(self):
+        # Pre-07-24 stores distilled AT settle: distilledMt == settledAt, with an older done event in the
+        # log. Re-keying the due on the done event must not re-enter every distilled card in the fleet at
+        # once (a deploy-wide re-distill storm).
+        log = [{"src": "planner", "kind": "done", "ev_t": T0 + 20, "at": T0 + 21},
+               {"src": "romp", "kind": "settle", "ev_t": T0 + 300, "at": T0 + 300}]
+        path = self._write(status="completed", confirming=False, log=log,
+                           summary="shipped the widget.", distilledMt=T0 + 300)
+        jd.distill_llm = lambda *a, **k: self.fail("a settle-era stamp is current — grandfathered, no storm")
+        self.assertEqual(jd._distill_session(SID, path, NOW), 0)
+
+    def test_a_reopen_and_fresh_done_refires(self):
+        log = [{"src": "planner", "kind": "done", "ev_t": T0 + 20, "at": T0 + 21},
+               {"src": "romp", "kind": "settle", "ev_t": T0 + 60, "at": T0 + 60},
+               {"src": "user", "kind": "reopen", "ev_t": T0 + 100, "at": T0 + 100},
+               {"src": "planner", "kind": "done", "ev_t": T0 + 250, "at": T0 + 251}]
+        path = self._write(status="completed", confirming=False, log=log,
+                           summary="the first takeaway", distilledMt=T0 + 20)
+        jd.distill_llm = lambda *a, **k: "TAKEAWAY: re-shipped after the follow-up.\nSOURCE: m1"
+        self.assertEqual(jd._distill_session(SID, path, NOW), 1,
+                         "a fresh done event after a reopen is the one re-distill worst case — it fires")
+        self.assertEqual(jd.load_goals(SID)["nodes"][self.G]["distilledMt"], T0 + 250,
+                         "the fresh done event is the new due")
+
+
 class ProceduralBlockStillSpeaks(unittest.TestCase):
     """A goal blocked ONLY by romp's own bookkeeping (a failed nudge, a mid-turn stop) still presents a
     where-this-stands line on its card (the user 2026-07-23: every card in Blocked shows a distilled
@@ -5625,7 +5737,12 @@ class LivePickerBrief(unittest.TestCase):
     goal's stored status is still 'working' (the planner hasn't classified the transient live state). The
     block-distiller briefs that focus top too, so the card carries a decision brief while you decide (the user
     2026-06-29: "when something is blocked from the picker, I still want a distiller summary on the card").
-    Gated on the live STATE log; the STORED status is left to the planner."""
+    Gated on the live STATE log; the STORED status is left to the planner.
+
+    ONCE PER PROMPT EPISODE (the user 2026-07-24): the gate keys on promptBriefedT vs the state log's
+    transition into the current picker/permission run (_live_prompt_since), NOT on briefedMt vs mt — mt
+    never moves mid-turn, so the old key slept through a SECOND prompt in the same open turn and the card
+    kept briefing a question the user had already answered."""
 
     def setUp(self):
         self._saved = (jd.GOALDIR, jd.STATESDIR, jd.STATE, jd.brief_llm, jd.distill_llm)
@@ -5681,7 +5798,7 @@ class LivePickerBrief(unittest.TestCase):
         jd.brief_llm = lambda goal, work, owed: (calls.append(1), "brief")[1]
         jd._distill_session(SID, path, NOW)
         jd._distill_session(SID, path, NOW)            # a 2nd pass while STILL parked
-        self.assertEqual(len(calls), 1, "briefed ONCE per episode (briefedMt == mt), not every producer pass")
+        self.assertEqual(len(calls), 1, "briefed ONCE per episode (promptBriefedT gate), not every producer pass")
 
     def test_not_at_a_live_prompt_is_not_briefed(self):
         path, g = self._setup("working")
@@ -5689,6 +5806,71 @@ class LivePickerBrief(unittest.TestCase):
         n = jd._distill_session(SID, path, NOW)
         self.assertEqual(n, 0, "no live picker/permission state → no live brief")
         self.assertIsNone(jd.load_goals(SID)["nodes"][g].get("blockSummary"), "blockSummary stays null")
+
+    def _append_states(self, *recs):
+        with open(jd.STATESDIR / (SID + ".jsonl"), "a") as f:
+            for t, state in recs:
+                f.write(json.dumps({"t": t, "state": state}) + "\n")
+
+    def test_a_new_prompt_episode_rebriefs_with_the_new_question(self):
+        # The stale-brief card (the user 2026-07-24, SYNTHETIC repro): the session parked on a question,
+        # was briefed, the user ANSWERED it (state → working), and the session parked on a NEW question in
+        # the SAME open turn — so the store's mt never moved. The old mt-keyed gate stayed closed and the
+        # card kept presenting the answered question; the episode gate re-briefs on the new park.
+        path, g = self._setup("picker")
+        briefs = iter(["Pick the retry budget: 3 or 5?", "Name the config key: timeout or deadline?"])
+        calls = []
+        jd.brief_llm = lambda goal, work, owed: (calls.append(1), next(briefs))[1]
+        jd._distill_session(SID, path, NOW)
+        self._append_states((NOW - 15, "working"), (NOW - 10, "picker"))   # answered → NEW question
+        jd._distill_session(SID, path, NOW)
+        nd = jd.load_goals(SID)["nodes"][g]
+        self.assertEqual(len(calls), 2, "a NEW prompt episode re-enters the gate")
+        self.assertEqual(nd["blockSummary"], "Name the config key: timeout or deadline?",
+                         "the card briefs the CURRENT question, not the answered one")
+        self.assertEqual(nd["promptBriefedT"], NOW - 10, "stamped with the new episode's own event")
+
+    def test_one_park_spanning_picker_and_permission_is_one_episode(self):
+        path, g = self._setup("picker")
+        calls = []
+        jd.brief_llm = lambda goal, work, owed: (calls.append(1), "brief")[1]
+        jd._distill_session(SID, path, NOW)
+        self._append_states((NOW - 15, "permission"))   # the same park, another prompt flavor — no exit between
+        jd._distill_session(SID, path, NOW)
+        self.assertEqual(len(calls), 1, "consecutive prompt states are ONE run — the episode starts where the run does")
+
+    def test_stored_block_plus_live_prompt_close_together(self):
+        # The two gates share the WORK but not the STAMP: one pass must close both (briefedMt for the
+        # stored block, promptBriefedT for the live episode) or they'd alternate — each pass reopening
+        # the other's gate — and burn an LLM call every producer tick.
+        path, g = self._setup("picker")
+        store = jd.load_goals(SID)
+        nd = store["nodes"][g]
+        with jd._authority():                          # test fixture writing the diary-owned cache directly
+            nd["blocked"], nd["blockWhy"] = True, "which port should the server bind?"
+            nd["log"] = [{"kind": "block", "ev_t": T0 + 60, "at": T0 + 60}]
+        store["status"][g] = "blocked"
+        jd.save_goals(SID, store)
+        calls = []
+        jd.brief_llm = lambda goal, work, owed: (calls.append(1), "Pick the port.")[1]
+        jd._distill_session(SID, path, NOW)
+        jd._distill_session(SID, path, NOW)
+        nd = jd.load_goals(SID)["nodes"][g]
+        self.assertEqual(len(calls), 1, "one pass closes BOTH gates; the second pass re-enters neither")
+        self.assertEqual(nd["briefedMt"], T0 + 60, "stored-block gate closed on the block's own event")
+        self.assertEqual(nd["promptBriefedT"], NOW - 20, "episode gate closed on the park's own event")
+
+    def test_live_prompt_since_reads_the_run_start(self):
+        (jd.STATESDIR / (SID + ".jsonl")).write_text("\n".join(json.dumps(r) for r in [
+            {"t": NOW - 90, "state": "working"},
+            {"t": NOW - 60, "awaiting": False},          # overlay rows never count as states
+            {"t": NOW - 50, "state": "picker"},
+            {"t": NOW - 40, "state": "permission"},      # still the same run
+        ]) + "\n")
+        self.assertEqual(jd._live_prompt_since(SID), NOW - 50, "the episode is the RUN's start, not its newest record")
+        (jd.STATESDIR / (SID + ".jsonl")).write_text(json.dumps({"t": NOW - 5, "state": "waiting"}) + "\n")
+        self.assertIsNone(jd._live_prompt_since(SID), "not parked → no episode")
+        self.assertIsNone(jd._live_prompt_since("no-such-fsid"), "no state file → no episode, never a crash")
 
 
 class QuoteTitleHeal(unittest.TestCase):

--- a/tests/test_kernel_done_confirming.py
+++ b/tests/test_kernel_done_confirming.py
@@ -1,0 +1,45 @@
+"""The done-confirming window on the feed (the user 2026-07-24): a top whose done verdict has landed but
+whose settle event is still pending stays in the Working COLUMN (the settle gate exists precisely so the
+column never flickers working↔done) and ships `doneConfirming` on its card, which the feed renders as a
+steady "done, confirming" chip. The fact comes from the rollup's `confirming` export on the store — the
+authoritative product of the judge's is_complete — never from the raw nodeComplete flag, which lies for
+agent-open umbrellas. Source pins on build_feed (its inputs — a live parse, states, sessions — make an
+end-to-end feed build heavy; the same convention as test_kernel_distill_state). The rollup export itself
+is behavior-tested in test_judge.py (DistillAtDone), and the chip in done-confirming.test.ts."""
+import inspect
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class DoneConfirming(unittest.TestCase):
+    def test_the_flag_reads_the_rollup_export_not_the_raw_node_flag(self):
+        src = inspect.getsource(km.build_feed)
+        self.assertIn('confirming = set(store.get("confirming") or ())', src,
+                      "the store's rollup export is the one source")
+        self.assertIn('"doneConfirming": (True if (column == "working" and nid in confirming) else None),', src,
+                      "shipped only on a Working-column card, keyed on the export")
+
+    def test_the_column_is_untouched_by_the_window(self):
+        # "I definitely don't want a working done flicker" (the user 2026-07-24): the window annotates the
+        # card; the column expression must not consult it.
+        src = inspect.getsource(km.build_feed)
+        start = src.index('column = ("needs_input"')
+        col = src[start: src.index('else "completed" if col == "completed" else "working")', start)]
+        self.assertNotIn("confirming", col, "the column expression never reads the confirming window")
+
+    def test_the_judge_exports_confirming_from_rollup(self):
+        src = inspect.getsource(km.jd.rollup_status)
+        self.assertIn('store["confirming"] = confirming', src)
+        self.assertIn("if is_complete(nid):", src,
+                      "the export reuses the rollup's own is_complete — agent-open umbrellas stay out")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/done-confirming.test.ts
+++ b/ui/webview/done-confirming.test.ts
@@ -1,0 +1,42 @@
+// The "done, confirming" cue (the user 2026-07-24): a Working card whose done verdict has landed but
+// whose settle event (the session's attention moving on) is still pending wears a steady chip instead
+// of moving columns — an early column move would flicker working↔done on any trailing touch, the exact
+// flicker the judge's settle gate exists to prevent. The fact rides the kernel payload as
+// `doneConfirming`, sourced from the rollup's `confirming` export (judge rollup_status), never the raw
+// nodeComplete flag. Source pins, like feed-interrupted.test.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+test("the badge is built once and rides the wrapping chip row", () => {
+  assert.match(FEED, /const dcBadge = el\("span", "fask-doneconfirming"\)/);
+  assert.match(FEED, /dcBadge\.textContent = "done, confirming"/, "text label, no emoji/glyph");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /a\._doneConfirming = dcBadge;/);
+});
+
+test("it.doneConfirming toggles the badge; the payload carries the kernel flag", () => {
+  assert.match(FEED, /\(a\._doneConfirming as HTMLElement\)\.style\.display = it\.doneConfirming \? "" : "none";/);
+  assert.match(FEED, /doneConfirming\?: boolean;/, "the card payload carries the kernel flag");
+});
+
+test("the cue is an indicator, never a column move", () => {
+  // the user 2026-07-24: "I definitely don't want a working done flicker" — nothing in the feed may
+  // re-route a card's column off doneConfirming; askColumn stays keyed on it.column alone.
+  assert.doesNotMatch(FEED, /doneConfirming[^\n]*column/, "the flag must not touch column routing");
+  assert.doesNotMatch(FEED, /column[^\n]*doneConfirming/, "column routing must not read the flag");
+});
+
+test("the tooltip explains what happens next in the user's terms", () => {
+  assert.match(FEED, /ruled done — it files under Completed once the session has moved on/);
+});
+
+test("the pill wears the done-check blue family, same shape as its sibling pills", () => {
+  assert.match(CSS, /\.fask-doneconfirming \{[^}]*color: var\(--check-bg\)/, "the ✓ family's blue, no new color");
+  assert.match(CSS, /\.fask-doneconfirming \{[^}]*font-size: 0\.64em/, "same size as its sibling pills");
+  assert.match(CSS, /\.fask-doneconfirming \{[^}]*border-radius: 999px/);
+});

--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -18,7 +18,7 @@ test("COMPACTNESS (the user 2026-07-07): time trails the title; Clear on the nam
   assert.match(FEED, /row3\.append\(bgBtn, takeBtn, stallBtn, subBtn, taskBtn, actions\)/, "ask card: row3 is Background/Summary/Stalled/Sub-goals/Waiting-on-task (+ rare Retry/Revive)");
   assert.match(FEED, /actions\.append\(apiRetry, revive,/, "…so the action row is Retry/Revive (+ resume-gate) only (Clear + toggles moved up)");
   // Clear is the rightmost control on the NAME row now (both ask + group cards)
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "ask card: Clear on the name row");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "ask card: Clear on the name row");
   // its tooltip is plain-spoken (the user 2026-07-13): "clear this task", not the inbox-zero jargon
   assert.match(FEED, /clr\.title = "clear this task";/);
   assert.match(FEED, /row2\.append\(idwrap, clr\)/, "group card: Clear on the name row");
@@ -57,7 +57,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
   assert.match(FEED, /const origin = el\("a", "fask-origin"\); origin\.style\.display = "none"/);
   // it's a direct child of the wrapping row2 (NOT nested in idwrap) so a narrow card wraps it under the
   // name instead of overlapping the chips (the user 2026-06-20)
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "the origin marker rides the name row beside the chips");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "the origin marker rides the name row beside the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested inside idwrap");
   // populated from it.origin in the update path: a dim gray "↪ from" + the peer in the bold session-name
   // style (its own identity colour); click opens the sender (the user 2026-06-16)
@@ -72,7 +72,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
 test("the follow-up badge serves ONLY '↩ re-judging' now — the '↻ Followed up' chip was removed (the user 2026-07-01)", () => {
   assert.match(FEED, /el\("span", "fask-followedup"\); fupBadge\.textContent = "↩ re-judging"/);
   // the badge rides the SESSION-NAME row (right-justified), NOT the bottom action row
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   // the CARD badge block is now recheck-only: recheck → "↩ re-judging", else hidden. No followupPending branch.
   // (The modal tree's per-node "↻ Followed up" chip, ftree-followedup, is a separate thing and stays.)
   assert.match(FEED, /if \(it\.recheck\) \{\s*\n\s*a\._followedup\.style\.display = "";\s*\n\s*a\._followedup\.textContent = "↩ re-judging";[\s\S]*?\} else \{\s*\n\s*a\._followedup\.style\.display = "none";\s*\n\s*\}/);

--- a/ui/webview/feed-delegation.test.ts
+++ b/ui/webview/feed-delegation.test.ts
@@ -45,7 +45,7 @@ test("a narrow card WRAPS the '↪ from' provenance under the name instead of ov
   // chip. Fix: row2 wraps, and origin is a direct row2 child (sibling of the chips) so it drops to a
   // second line rather than overlapping when name + provenance + chips don't all fit.
   assert.match(CSS, /\.fask-row2 \{[^}]*flex-wrap: wrap/, "the name row wraps so trailing items never overlap");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "origin is a row2 sibling of the chips");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "origin is a row2 sibling of the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested in the shrinking idwrap");
   // the old overflow mechanism is gone — flex-grow on idwrap right-aligns it instead of an auto margin
   assert.doesNotMatch(CSS, /\.fask-origin \{[^}]*margin-left: auto/);

--- a/ui/webview/feed-interrupted.test.ts
+++ b/ui/webview/feed-interrupted.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the interrupted badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const intBadge = el\("span", "fask-interrupted"\)/);
   assert.match(FEED, /intBadge\.textContent = "interrupted"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   assert.match(FEED, /a\._interrupted = intBadge;/);
 });
 

--- a/ui/webview/feed-interrupting.test.ts
+++ b/ui/webview/feed-interrupting.test.ts
@@ -15,7 +15,7 @@ test("the interrupting badge is built once and rides the wrapping chip row", () 
   assert.match(FEED, /const intingBadge = el\("span", "fask-interrupting"\)/);
   assert.match(FEED, /intingBadge\.textContent = "interrupting…"/, "text label, no emoji/glyph");
   // sits immediately left of the past-tense interrupted badge on the same wrapping row
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   assert.match(FEED, /a\._interrupting = intingBadge;/);
 });
 

--- a/ui/webview/feed-nudge-failed.test.ts
+++ b/ui/webview/feed-nudge-failed.test.ts
@@ -16,7 +16,7 @@ test("the follow-up-failed chip is built once and rides the wrapping chip row", 
   assert.match(FEED, /const nfBadge = el\("span", "fask-nudgefailed"\)/);
   assert.match(FEED, /nfBadge\.textContent = "follow-up failed"/,
     "the label is 'follow-up failed' (the user 2026-07-23) — 'stalled' is the yellow section's word; no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   assert.match(FEED, /a\._nudgeFailed = nfBadge;/);
 });
 

--- a/ui/webview/feed-waiton.test.ts
+++ b/ui/webview/feed-waiton.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("a waiting-on chip is built and rides the wrapping chip row (its own line when it doesn't fit)", () => {
   assert.match(FEED, /const waitOnBadge = el\("span", "fask-waiton"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   assert.match(FEED, /a\._waitOn = waitOnBadge;/);
 });
 

--- a/ui/webview/feed-warn-chip.test.ts
+++ b/ui/webview/feed-warn-chip.test.ts
@@ -15,7 +15,7 @@ test("the warning chip is a button built once, riding the wrapping chip row", ()
   assert.match(FEED, /const warnChip = el\("button", "fask-warnchip"\)/,
     "a BUTTON (focusable), not a span — it has a click action");
   assert.match(FEED, /warnChip\.textContent = "warning"/, "plain text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   assert.match(FEED, /a\._warnChip = warnChip;/);
 });
 

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -346,6 +346,12 @@ body.feed-dragging .feed-col.col-asks { outline: 1.5px dashed color-mix(in srgb,
 .fask-followedup { flex: 0 0 auto; font-size: 0.64em; font-weight: 700; letter-spacing: 0.04em;
   padding: 1px 6px; border-radius: 999px; line-height: 1.4;
   color: #5aa2ff; border: 1px solid rgba(90, 162, 255, 0.6); }
+/* "done, confirming" — the done verdict is in, only the settle event is pending (the user 2026-07-24):
+   a steady cue on the Working card, never an early column move (that flicker is what the settle gate
+   prevents). Outline pill in the done-check blue (--check-bg), the same family as the ✓ it will wear. */
+.fask-doneconfirming { flex: 0 0 auto; font-size: 0.64em; font-weight: 700; letter-spacing: 0.04em;
+  padding: 1px 6px; border-radius: 999px; line-height: 1.4;
+  color: var(--check-bg); border: 1px solid rgba(30, 161, 235, 0.55); }
 /* "nudge failed" — the one auto-nudge didn't resolve the stall and is never re-asked (design/
    stalled-open-todos-nudge.md); red pill: this thread is waiting on the human now */
 .fask-nudgefailed { flex: 0 0 auto; font-size: 0.64em; font-weight: 700; letter-spacing: 0.04em;

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -60,6 +60,7 @@ interface AskItem {
   trgb: [number, number, number];
   column: "working" | "needs_input" | "completed";   // RAW kernel value (build_feed): working/needs_input/completed. askColumn() maps it to the local Column. NOT "asks" — that was a stale lie that silently broke `it.column === "asks"` checks.
   followupPending?: boolean;                       // you followed up on a settled card → optimistically reopened, awaiting the judge's re-file (kernel)
+  doneConfirming?: boolean;                        // the done verdict is in, only the settle event is pending → steady "done, confirming" chip on the Working card; placement deliberately does NOT move early (no working↔done flicker) (kernel build_feed ← judge rollup confirming export; the user 2026-07-24)
   recheck?: boolean;                               // soft-block you answered with a TARGETED follow-up → de-urgented (dotted), moved to Working, dropped from the "need input" count, until the judge resolves or re-blocks it (kernel build_feed; the user 2026-06-27)
   rejudging?: boolean;                             // soft-block + a PLAIN thread reply after it → moves to WORKING while the reply is in flight (echo/open turn), with a "Re-judging…" swirl; returns to Needs-You on its own if the judge leaves it blocked (kernel build_feed; the user 2026-07-02, immediate)
   nudgeFailed?: boolean;                           // the ONE auto-nudge on this stalled goal didn't resolve it → red "follow-up failed" chip (renamed off "stalled" 2026-07-23 — that word is the yellow romp-holding section's now); the failure also records a BLOCK verdict, so the card reaches Needs-you via the normal ladder (kernel _mark_nudge_failed, 2026-07-07)
@@ -605,6 +606,13 @@ function makeAskCard(it: AskItem): HTMLElement {
   // was removed (the user 2026-07-01: click-to-cite makes follow-up routine, so the ack is noise). updateAskCard
   // sets the text/title when it shows for recheck.
   const fupBadge = el("span", "fask-followedup"); fupBadge.textContent = "↩ re-judging"; fupBadge.title = "you followed up — no longer waiting on you; the judge will resolve it or re-block it on the next pass"; fupBadge.style.display = "none";
+  // "done, confirming" (the user 2026-07-24): the done verdict is in; the card holds its Working spot
+  // until the settle event (the session's attention moving on) files it under Completed — moving the
+  // COLUMN at the verdict would flicker it back on any trailing touch, which is the exact flicker the
+  // settle gate exists to prevent. The takeaway is already being distilled during this window.
+  const dcBadge = el("span", "fask-doneconfirming"); dcBadge.textContent = "done, confirming";
+  dcBadge.title = "ruled done — it files under Completed once the session has moved on; a follow-up before then reopens it in place";
+  dcBadge.style.display = "none";
   // "follow-up failed" (plans/stalled-open-todos-nudge.md): romp asked this stalled goal ONCE and the
   // response didn't resolve it; per the anti-loop rule it is never re-asked, so the card says so instead.
   // RENAMED off "stalled" (the user 2026-07-23, superseding their 2026-07-02 label): that word now belongs
@@ -685,7 +693,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   // row2 wraps them onto a new line when there isn't room, so the provenance never overlaps a chip
   // (the user 2026-06-20). origin sits left of the chips, matching the "from … · Followed up" reading order.
   // Clear is the rightmost, always-present control on this row (idwrap flex:1 pushes it to the edge).
-  row2.append(idwrap, origin, fupBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr);
+  row2.append(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr);
   // ROW 3 — Background (left) · Summary (right), always one line, opposite sides. Populated below, once the
   // toggle buttons exist (they're declared with the distiller sections). The time now trails the title (row1).
   const row3 = el("div", "fask-row3");
@@ -852,6 +860,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   const a = card as any;
   a._title = title; a._name = name; a._time = time; a._followedup = fupBadge;
   a._row1 = row1; a._row2 = row2;   // grouped mode re-homes Clear between these (the user 2026-07-13)
+  a._doneConfirming = dcBadge;
   a._nudgeFailed = nfBadge;
   a._interrupting = intingBadge;
   a._interrupted = intBadge;
@@ -1199,6 +1208,9 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   } else {
     a._followedup.style.display = "none";
   }
+  // "done, confirming" — the done verdict is in, settle pending; the card stays put in Working with this
+  // steady cue instead of moving columns early (the user 2026-07-24: an indicator, never a column flicker).
+  (a._doneConfirming as HTMLElement).style.display = it.doneConfirming ? "" : "none";
   // "follow-up failed" chip (plans/stalled-open-todos-nudge.md): the one auto-nudge didn't resolve the
   // stall and it is never re-asked — the card says so. The failure also records a BLOCK verdict (2026-07-07),
   // so the card reaches Needs-you via the normal ladder; this chip rides along as the explanation.


### PR DESCRIPTION
Three approved changes from the distiller/settle thread (2026-07-24):

**Live-brief episode gate.** The picker/permission brief was gated on `briefedMt` vs a due that falls back to `mt` — stable across a whole open turn — so a session that got its parked question answered and parked on a NEW question kept the stale brief describing the answered one. The gate now keys a dedicated `promptBriefedT` stamp on the state log's transition into the current prompt run: one brief per park, a fresh brief per new park, and no stamp-sharing with the stored-block gate (which would alternate forever).

**Distill at the done verdict.** `_distill_due_t`'s completed side moves from `settledAt` to the newest done event in the subtree; `rollup_status` exports `store["confirming"]` (done verdict in, settle pending) and the distiller enters those tops alongside `completed`. Settle alone never re-fires; only a reopen→re-done does. Settle-era stamps are grandfathered, so deploying does not re-distill the fleet.

**"done, confirming" cue.** The Working card for a done-but-unsettled top wears a steady outline pill in the done-check blue. The column deliberately does not move early — tests on both sides pin that the flag annotates without re-routing (no working↔done flicker).

Tests: `test_judge.py` +10 (LivePickerBrief episode tests, DistillAtDone), `test_kernel_done_confirming.py` (new), `done-confirming.test.ts` (new), row-pin updates in 7 feed node tests. Python 3069 passed / 25 skipped, node 1311 passed, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)