### PR TITLE
Picker: reach back 30 days, lazily, instead of only 48 hours

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3131,7 +3131,9 @@ def _sdk_last_sid(sid):
 
 
 _discover_lock = threading.Lock()
-_discover_cache = {"fp": None, "result": None}        # fingerprint → cached discover() result (see _discover_fingerprint)
+_discover_cache = {}     # window seconds → {"fp", "result"}: the cached discover() list for THAT horizon (see
+#                          _discover_fingerprint). Keyed by window because the picker asks for a wider one
+#                          than the 48h caption horizon; bounded by the number of distinct windows (2).
 _namefp_memo = {}    # names/ entry -> (its mtime, resolved project dir or None) — the fingerprint runs on
 #                      EVERY discover() call, so re-reading each entry every time was the kernel's hottest
 #                      call; keyed on the entry's own mtime, evicted when the entry goes away. Bounded by
@@ -3193,28 +3195,37 @@ def _discover_fingerprint():
     return tuple(fp)
 
 
-def discover(now):
-    """[(fsid, path, anchor_sid, name)] for every transcript of a romp session touched within WINDOW —
+def discover(now, window=None):
+    """[(fsid, path, anchor_sid, name)] for every transcript of a romp session touched within `window`
+    seconds (default WINDOW, 48h) —
     CACHED behind a directory-mtime fingerprint (the result only changes on a session add/rename/fork, not on
     a transcript append), so the feed + timeline + chat builds and both judge tiers share ONE filesystem walk
-    per change instead of re-walking every push. The cached list is read-only for all callers."""
+    per change instead of re-walking every push. The cached list is read-only for all callers.
+
+    `window` is a parameter so the + picker can reach back FURTHER than the caption horizon (the user
+    2026-07-24, who typed a 3-day-old session's name into the picker, got nothing, and had to start a new
+    session). 48h is the horizon for CAPTIONING a transcript; the picker inherited it by accident, which
+    silently hid all but the last two days of the fleet. Each window keeps its OWN entry under the same
+    fingerprint, so a picker open never invalidates or slows the hot 48h path, and the wide walk happens
+    only when the picker actually asks for it — never at boot."""
+    win = WINDOW if window is None else int(window)
     fp = _discover_fingerprint()
     if fp is not None:
         with _discover_lock:
-            if _discover_cache["fp"] == fp and _discover_cache["result"] is not None:
-                return _discover_cache["result"]
-    res = _discover_impl(now)
+            hit = _discover_cache.get(win)
+            if hit is not None and hit["fp"] == fp and hit["result"] is not None:
+                return hit["result"]
+    res = _discover_impl(now, win)
     if fp is not None:
         with _discover_lock:
-            _discover_cache["fp"] = fp
-            _discover_cache["result"] = res
+            _discover_cache[win] = {"fp": fp, "result": res}
     return res
 
 
-def _discover_impl(now):
+def _discover_impl(now, window=None):
     """[(fsid, path, anchor_sid, name)] for every transcript of a romp session touched within
-    WINDOW: the session's anchor transcript plus any same-customTitle fork in its project dir.
-    File-based (names/), no tmux — works for headless sessions too.
+    `window` (default WINDOW): the session's anchor transcript plus any same-customTitle fork in its
+    project dir. File-based (names/), no tmux — works for headless sessions too.
 
     Perf (the user 2026-07-03: cold-kernel startup is slow): this WAS a pathlib walk — `proj.iterdir()`
     re-listed each project dir ONCE PER SESSION that lives in it, and `.suffix`/`.stem`/`.stat()` re-parsed +
@@ -3224,7 +3235,7 @@ def _discover_impl(now):
     out, seen = [], set()
     if not NAMES.is_dir():
         return out
-    cutoff = now - WINDOW
+    cutoff = now - (WINDOW if window is None else int(window))
     dir_jsonl = {}      # proj-dir str -> [(stem, path_str, mtime)] for its .jsonl files — scandir'd ONCE
     title_memo = {}     # path_str -> _custom_title(path_str), memoized (a fork is title-checked once, not per session)
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -750,9 +750,9 @@ def _rgb(color):
         return [112, 136, 170]
 
 
-def _sessions(now):
+def _sessions(now, window=None):
     out = []
-    for fsid, path, anchor, name in jd.discover(now):
+    for fsid, path, anchor, name in jd.discover(now, window):
         try:
             mtime = os.stat(path).st_mtime
         except OSError:
@@ -2657,12 +2657,22 @@ def _live_names(tmux):
     return {n: sid for sid in (tmux or {}) for n in [_name_of(sid)] if n}
 
 
-def _session_list(now, tmux):
+PICKER_WINDOW = 30 * 86400      # how far back the + picker can reach, vs jd.WINDOW's 48h caption horizon.
+PICKER_DEEP_CAP = 600           # row cap for that deep list (150 stays the cap for the fast first paint)
+#   30 days, and the deep list is fetched LAZILY — only once the picker is opened AND the user either scrolls
+#   to the bottom or starts typing (the user 2026-07-24, who wanted to scroll back through everything up to a
+#   month without it choking startup). So the first paint stays the cheap 48h list it always was, and the
+#   wider walk is paid for only by someone actually looking for an older session.
+
+
+def _session_list(now, tmux, window=None):
     """Picker payload: recent sessions, RUNNING ones first then by recency, each
-    {id,name,color,running,time,summary} — the shape render.ts's renderPicker expects."""
+    {id,name,color,running,time,summary} — the shape render.ts's renderPicker expects.
+    `window` None = the default 48h horizon (the fast first paint); PICKER_WINDOW = the deep list."""
     live = set(tmux or {})
     items = []
-    for s in _sessions(now)[:150]:
+    cap = 150 if window is None else PICKER_DEEP_CAP
+    for s in _sessions(now, window)[:cap]:
         sid = s["sid"]
         arch = jd.load_archive(sid) or {}
         items.append({"id": sid, "name": s["name"], "color": _name_color(sid),
@@ -15541,8 +15551,13 @@ class Handler(BaseHTTPRequestHandler):
                 else:
                     _cancel_pending.add(bare)
         elif msg and msg.get("type") == "requestSessions":
-            client["send"](json.dumps({"type": "sessionList",
-                                       "items": _session_list(int(time.time()), _tmux_sessions()),
+            # deep=true is the picker's LAZY second fetch — the 30-day list, asked for only once the user
+            # scrolls to the bottom or types in the search box. The echoed flag tells the webview which
+            # list it got, so a late fast reply can't clobber a deep one already on screen.
+            deep = bool(msg.get("deep"))
+            client["send"](json.dumps({"type": "sessionList", "deep": deep,
+                                       "items": _session_list(int(time.time()), _tmux_sessions(),
+                                                              PICKER_WINDOW if deep else None),
                                        "defaultDir": _tilde(_default_create_dir())}))   # prefill the new-session dir field
         elif msg and msg.get("type") in ("pickResult", "openByName") and (msg.get("id") or msg.get("name")):
             sid = msg.get("id") or _live_names(_tmux_sessions()).get(str(msg.get("name")))

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -3748,6 +3748,34 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(it["summary"], "Fixing the feed")
         self.assertEqual(it["color"], {"bg": "#abcdef", "fg": "#ffffff"})
 
+    def test_picker_reaches_past_the_caption_window(self):
+        # The user 2026-07-24: typed a 3-day-old session's name into the + picker, got nothing back, and had
+        # to start a fresh session instead. The picker's payload was built from discover()'s 48h CAPTION
+        # horizon, which it had inherited by accident — so every session idle longer than two days was
+        # invisible to it, and reviving one you couldn't reach by tab was impossible. The picker now has its
+        # own PICKER_WINDOW (30 days), asked for on the LAZY second fetch; the default first paint stays the
+        # cheap 48h list, so neither boot nor a picker open pays for the wider walk.
+        old_sid = "99999999-8888-7777-6666-555555555555"
+        odir = Path(self.td.name) / "olddir"; odir.mkdir()
+        opdir = Path(self.td.name) / "projects" / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(odir)))
+        opdir.mkdir(parents=True)
+        otp = opdir / (old_sid + ".jsonl")
+        otp.write_text(json.dumps(uline(NOW - 4 * 86400, "draft the reply", "u1", ps="typed")) + "\n")
+        stale = NOW - int(3.5 * 86400)          # idle 3.5 days: past the 48h window, well inside the 30 days
+        os.utime(otp, (stale, stale))
+        (jd.NAMES / old_sid).write_text("roof\t%s\t#9cd2ff\n" % str(odir))
+
+        shallow = km._session_list(NOW, {})
+        self.assertNotIn(old_sid, [i["id"] for i in shallow],
+                         "the default first paint stays the 48h list it always was")
+        deep = km._session_list(NOW, {}, km.PICKER_WINDOW)
+        it = next((i for i in deep if i["id"] == old_sid), None)
+        self.assertIsNotNone(it, "the deep list reaches a session idle 3.5 days — the bug this fixes")
+        self.assertEqual(it["name"], "roof")
+        self.assertFalse(it["running"], "it is dead — the row is a revive target, not a reopen")
+        self.assertEqual(it["time"], "3d ago")
+        self.assertIn(SID, [i["id"] for i in deep], "the recent session is still in the deep list too")
+
     def test_alive_filter_empty_tmux_with_tmux_present_shows_nothing(self):
         # The user 2026-06-16: after killing every session and reloading, the surfaces wrongly
         # reopened tabs for the dead ones. Cause: an EMPTY tmux result fell back to file-derived
@@ -6161,8 +6189,14 @@ class SessionListNameCollision(unittest.TestCase):
 
     def test_picker_session_list_keeps_its_now_tmux_signature(self):
         import inspect
-        self.assertEqual(list(inspect.signature(km._session_list).parameters), ["now", "tmux"],
-                         "the picker payload builder must stay _session_list(now, tmux) — requestSessions calls it that way")
+        params = inspect.signature(km._session_list).parameters
+        self.assertEqual(list(params)[:2], ["now", "tmux"],
+                         "the picker payload builder must stay callable as _session_list(now, tmux) — requestSessions calls it that way")
+        # Anything AFTER those two must be optional (`window`, the 30-day deep list, 2026-07-24), so the
+        # bare two-arg call the handler makes can never become a TypeError again — which is what this
+        # regression is really about. A 0-arg def shadowing it still fails the first assert.
+        self.assertTrue(all(p.default is not inspect.Parameter.empty for p in list(params.values())[2:]),
+                        "extra picker params must carry defaults, so _session_list(now, tmux) keeps working")
 
     def test_session_rows_is_a_distinct_zero_arg_function(self):
         import inspect

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3527,7 +3527,9 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     search.id = "picker-search";
     search.placeholder = "Search sessions…";
     search.spellcheck = false;
-    search.addEventListener("input", () => { filterPicker(search.value); pickerError(null); });
+    // Typing is a deep-list trigger: search must reach the whole 30 days, not just the rows already on
+    // screen, or a remembered older name still comes back empty (the user 2026-07-24).
+    search.addEventListener("input", () => { requestDeepSessions(); filterPicker(search.value); pickerError(null); });
     const errLine = el("div", "picker-error"); errLine.id = "picker-error";
     const list = el("div", "picker-list"); list.id = "picker-list";
     // hover and keyboard share one "active" row
@@ -3535,6 +3537,8 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       const row = (e.target as HTMLElement).closest(".picker-row");
       if (row) setActiveRow(row as HTMLElement);
     });
+    // Scrolling to the bottom is the other deep-list trigger — scroll back and the older sessions arrive.
+    list.addEventListener("scroll", () => { if (nearBottom(list)) requestDeepSessions(); });
     // Directory for a NEW session — fixed once the session starts, so it's chosen here. Prefilled with the
     // gear's "Default directory" on open; recent dirs autocomplete from the datalist; the kernel expands
     // ~ / $VARs and validates it exists. Hidden in pick-mode (choosing an existing session).
@@ -3662,7 +3666,9 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   }
   filterPicker(seed); // reset row visibility; arm the New-session button for the (possibly seeded) value
   pickerError(null);
+  pickerDeep = "none";   // each open starts on the cheap list; the deep one is re-fetched on demand
   if (vscodeApi) vscodeApi.postMessage({ type: "requestSessions" });
+  if (seed) requestDeepSessions();   // opened already filtered (#only=<tag>) → that IS a search, so go deep now
 }
 
 // ---- revive loader (the user 2026-07-05) ----
@@ -3822,9 +3828,46 @@ function isOpenTab(id: string): boolean {
   return sessions.has(id) || order.includes(id) || tabMeta.has(id);
 }
 
+// ---- the picker's LAZY deep list (the user 2026-07-24) ----
+// First paint is the kernel's cheap 48h list, as it always was. Everything older, back to 30 days, is a
+// SECOND request fired only once the user shows they're reaching for something not on screen: scrolling to
+// the bottom, or typing in the search box. Typing is the case that failed — a name you remember well enough
+// to type is usually an OLD session, and the picker used to answer with nothing, so you had to start a new
+// session instead. Fetching it lazily keeps a picker open (and kernel boot) as cheap as before.
+let pickerDeep: "none" | "pending" | "loaded" = "none";
+
+function requestDeepSessions() {
+  if (pickerDeep !== "none" || !vscodeApi) return;
+  pickerDeep = "pending";
+  renderPickerMoreRow();     // the wait is visible BEFORE the round-trip, never a frozen-looking list
+  vscodeApi.postMessage({ type: "requestSessions", deep: true });
+}
+
+// Footer row for the deep fetch: the romp loader's three pulsing accent dots (.rl-dots, already on the
+// page) while it's in flight, then a plain note of how far back the list now reaches. Not a .picker-row,
+// so filterPicker and the keyboard row-walk both skip it.
+function renderPickerMoreRow() {
+  const list = document.getElementById("picker-list");
+  if (!list) return;
+  list.querySelector(".picker-more")?.remove();
+  if (pickerDeep === "none") return;
+  const more = el("div", "picker-more");
+  if (pickerDeep === "pending") {
+    const dots = el("div", "rl-dots");
+    dots.append(el("i", ""), el("i", ""), el("i", ""));
+    const cap = el("span", "");
+    cap.textContent = "loading older sessions…";
+    more.append(dots, cap);
+  } else {
+    more.textContent = "showing the last 30 days";
+  }
+  list.appendChild(more);
+}
+
 function renderPicker(items: any[]) {
   const list = document.getElementById("picker-list");
   if (!list) return;
+  const keepScroll = list.scrollTop;    // a deep list swaps the rows under the user mid-scroll
   list.replaceChildren();
   const mkRow = (it: any): HTMLElement => {
     const row = el("div", "picker-row" + (it.running ? " running" : ""));
@@ -3901,6 +3944,8 @@ function renderPicker(items: any[]) {
   // default) — so the actual default is written in there as an editable starting point (the user 2026-06-23).
   const di = document.getElementById("picker-dir") as HTMLInputElement | null;
   if (di && !di.value) di.value = kernelDefaultDir || loadSettings().defaultDir || "";
+  renderPickerMoreRow();          // deep-fetch footer (loading dots, or the 30-day note) below the rows
+  list.scrollTop = keepScroll;    // scrolling to the bottom is what TRIGGERS the deep fetch — don't yank them back to the top
   // Re-apply the current filter (the list may refresh while the user is mid-
   // type) — it also sets the active row / arms the New-session button.
   const s = document.getElementById("picker-search") as HTMLInputElement | null;
@@ -6528,7 +6573,14 @@ window.addEventListener("message", (e: MessageEvent) => {
   // The identity palette changed (gear → Session colors): refresh the right-click menu's swatch set so a
   // menu opened after the switch offers the NEW palette (the kernel remaps + repaints sessions itself).
   else if (m.type === "palette" && Array.isArray(m.colors)) paletteColors = m.colors;
-  else if (m.type === "sessionList") { if (typeof m.defaultDir === "string") kernelDefaultDir = m.defaultDir; renderPicker(m.items || []); }
+  else if (m.type === "sessionList") {
+    if (typeof m.defaultDir === "string") kernelDefaultDir = m.defaultDir;
+    if (m.deep) pickerDeep = "loaded";
+    // A slow FAST reply must not clobber a deep list already on screen (open, type immediately, deep wins
+    // the race) — it's a strict subset, so re-rendering it would drop the older rows the user asked for.
+    else if (pickerDeep === "loaded") return;
+    renderPicker(m.items || []);
+  }
   else if (m.type === "browseResult" && typeof m.path === "string") {   // native Browse dialog returned a folder
     if (m.target === "gear") {                                          // the gear's "Default directory" Browse
       const gd = document.getElementById("rs-defaultdir") as HTMLInputElement | null;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1698,6 +1698,13 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
   color: var(--dim); font-size: 0.85em; margin-top: 2px;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
+/* Foot of the + picker's list: the lazy 30-day fetch's wait (the romp loader's .rl-dots) and, once it
+   lands, how far back the list now reaches. Same 0.85em as .picker-summary / .picker-time so it reads as
+   list chrome rather than another row. */
+.picker-more {
+  display: flex; align-items: center; gap: 9px;
+  padding: 9px 14px; color: var(--dim); font-size: 0.85em;
+}
 .picker-actions { border-top: 1px solid var(--box-border); padding: 8px 10px; }
 .picker-action {
   width: 100%; padding: 7px 10px; cursor: pointer;


### PR DESCRIPTION
## Problem

Typing a session's name into the `+` picker found nothing unless that session had been touched in the last two days. There was no way to reopen an older one, so the only way forward was to start a new session with the same name.

The picker's payload came from `discover()`, whose `WINDOW` of 48h is the horizon for **captioning** a transcript. The picker inherited it by accident, and it hid all but the last two days of the fleet: on the reporting machine, 14 of 233 registered sessions were reachable.

Reviving was never the problem. `_session_list` already includes dead sessions and the revive path handles SDK-owned sids. Only the listing horizon was in the way.

## Change

- `jd.discover(now, window=None)` takes a horizon, cached **per window** under the same directory-mtime fingerprint, so the hot 48h path is untouched by a picker open.
- `_session_list(now, tmux, window=None)` gains the same optional parameter. `PICKER_WINDOW` is 30 days, with a 600-row cap for the deep list.
- `requestSessions` accepts `deep: true` and echoes the flag back, so a slow fast-reply cannot clobber a deep list already on screen.
- The webview fetches the deep list **lazily**, only when the user scrolls to the bottom of the picker or types in the search box. First paint is the same cheap 48h list it always was, so neither kernel boot nor opening the picker pays for the wider walk.
- The list footer shows the romp loader dots while the fetch is in flight, then notes how far back the list reaches.

## Tests

- New `test_picker_reaches_past_the_caption_window`: back-dates a session 3.5 days and asserts it is absent from the default list, present in the `PICKER_WINDOW` list, marked not-running, and timed `3d ago`.
- `test_picker_session_list_keeps_its_now_tmux_signature` now pins the first two parameters and requires any later one to carry a default, which still catches the shadowing regression it was written for.
- Full suites green: 3070 Python passed, 1315 node passed, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)