### PR TITLE
Picker: the deep-list fetch can never leave its loader spinning

### DIFF
--- a/ui/webview/picker-deep-list.test.ts
+++ b/ui/webview/picker-deep-list.test.ts
@@ -1,0 +1,63 @@
+// The + picker's LAZY 30-day list. The user 2026-07-24: typing a session's name into the picker found
+// nothing unless it had been touched in the last 48h (discover()'s CAPTION horizon, which the picker had
+// inherited by accident), so an older session could not be reopened at all and the only way forward was to
+// start a new one. The picker now asks for its own 30-day window, but only once the user reaches for
+// something off screen — scrolling to the bottom, or typing — so the first paint and kernel boot stay as
+// cheap as they were. Source-level pins (no jsdom for the renderer).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the deep list is a SECOND request, fired at most once per picker open", () => {
+  assert.match(RENDER, /function requestDeepSessions\(\) \{\s*if \(pickerDeep !== "none" \|\| !vscodeApi\) return;/);
+  assert.match(RENDER, /pickerDeep = "pending";/);
+  assert.match(RENDER, /postMessage\(\{ type: "requestSessions", deep: true \}\)/);
+  // the first paint is still the plain, cheap request — no deep flag
+  assert.match(RENDER, /postMessage\(\{ type: "requestSessions" \}\)/);
+});
+
+test("scrolling to the bottom and typing both reach for the older sessions", () => {
+  assert.match(RENDER, /list\.addEventListener\("scroll", \(\) => \{ if \(nearBottom\(list\)\) requestDeepSessions\(\); \}\)/);
+  assert.match(RENDER, /search\.addEventListener\("input", \(\) => \{ requestDeepSessions\(\);/);
+});
+
+test("each picker open starts back on the cheap list", () => {
+  assert.match(RENDER, /pickerDeep = "none"; clearPickerDeepBackstop\(\);/);
+});
+
+test("a slow fast-reply cannot clobber a deep list already on screen", () => {
+  assert.match(RENDER, /if \(m\.deep\) \{ pickerDeep = "loaded"; clearPickerDeepBackstop\(\); \}/);
+  assert.match(RENDER, /else if \(pickerDeep === "loaded"\) return;/);
+});
+
+test("the loader can never trap the user: a pending deep fetch has a backstop", () => {
+  // a kernel too old to know `deep` answers without the flag, so nothing would resolve the pending state
+  assert.match(RENDER, /pickerDeepBackstop = window\.setTimeout\(\(\) => \{\s*if \(pickerDeep === "pending"\) \{ pickerDeep = "none"; renderPickerMoreRow\(\); \}\s*\}, \d+\);/);
+  assert.match(RENDER, /function clearPickerDeepBackstop\(\) \{[\s\S]*?clearTimeout\(pickerDeepBackstop\)/);
+});
+
+test("the wait wears the romp loader dots, and the footer is not a selectable row", () => {
+  assert.match(RENDER, /const dots = el\("div", "rl-dots"\);/);
+  assert.match(RENDER, /cap\.textContent = "loading older sessions…";/);
+  assert.match(RENDER, /more\.textContent = "showing the last 30 days";/);
+  assert.match(CSS, /\.picker-more \{/);
+  // .picker-more is deliberately NOT a .picker-row, so filterPicker and the keyboard walk skip it
+  assert.doesNotMatch(RENDER, /el\("div", "picker-row picker-more"\)/);
+});
+
+test("a deep render keeps the scroll position that triggered it", () => {
+  assert.match(RENDER, /const keepScroll = list\.scrollTop;/);
+  assert.match(RENDER, /list\.scrollTop = keepScroll;/);
+});
+
+test("the kernel honors deep and echoes the flag back", () => {
+  assert.match(KERNEL, /PICKER_WINDOW = 30 \* 86400/);
+  assert.match(KERNEL, /deep = bool\(msg\.get\("deep"\)\)/);
+  assert.match(KERNEL, /"type": "sessionList", "deep": deep/);
+  assert.match(KERNEL, /PICKER_WINDOW if deep else None/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3666,7 +3666,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   }
   filterPicker(seed); // reset row visibility; arm the New-session button for the (possibly seeded) value
   pickerError(null);
-  pickerDeep = "none";   // each open starts on the cheap list; the deep one is re-fetched on demand
+  pickerDeep = "none"; clearPickerDeepBackstop();   // each open starts on the cheap list; the deep one is re-fetched on demand
   if (vscodeApi) vscodeApi.postMessage({ type: "requestSessions" });
   if (seed) requestDeepSessions();   // opened already filtered (#only=<tag>) → that IS a search, so go deep now
 }
@@ -3835,12 +3835,25 @@ function isOpenTab(id: string): boolean {
 // to type is usually an OLD session, and the picker used to answer with nothing, so you had to start a new
 // session instead. Fetching it lazily keeps a picker open (and kernel boot) as cheap as before.
 let pickerDeep: "none" | "pending" | "loaded" = "none";
+let pickerDeepBackstop: number | undefined;
+
+function clearPickerDeepBackstop() {
+  if (pickerDeepBackstop !== undefined) { clearTimeout(pickerDeepBackstop); pickerDeepBackstop = undefined; }
+}
 
 function requestDeepSessions() {
   if (pickerDeep !== "none" || !vscodeApi) return;
   pickerDeep = "pending";
   renderPickerMoreRow();     // the wait is visible BEFORE the round-trip, never a frozen-looking list
   vscodeApi.postMessage({ type: "requestSessions", deep: true });
+  // Backstop, per the repo's loading rule: a loader must never be able to trap the user. A kernel older
+  // than this change ignores `deep` and answers without the flag, so nothing would ever resolve the
+  // pending state and the dots would spin forever — exactly the window between a webview deploy and the
+  // kernel restart that follows it. Fall back to no footer and let a later scroll or keystroke retry.
+  clearPickerDeepBackstop();
+  pickerDeepBackstop = window.setTimeout(() => {
+    if (pickerDeep === "pending") { pickerDeep = "none"; renderPickerMoreRow(); }
+  }, 8000);
 }
 
 // Footer row for the deep fetch: the romp loader's three pulsing accent dots (.rl-dots, already on the
@@ -6575,7 +6588,7 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "palette" && Array.isArray(m.colors)) paletteColors = m.colors;
   else if (m.type === "sessionList") {
     if (typeof m.defaultDir === "string") kernelDefaultDir = m.defaultDir;
-    if (m.deep) pickerDeep = "loaded";
+    if (m.deep) { pickerDeep = "loaded"; clearPickerDeepBackstop(); }
     // A slow FAST reply must not clobber a deep list already on screen (open, type immediately, deep wins
     // the race) — it's a strict subset, so re-rendering it would drop the older rows the user asked for.
     else if (pickerDeep === "loaded") return;


### PR DESCRIPTION
Follow-up to #16.

## Problem

The lazy 30-day fetch put the romp loader dots in the picker's list footer and cleared them when the reply came back carrying the `deep` flag. A kernel older than #16 ignores that flag and answers without it, so nothing ever resolved the pending state and the dots spun forever.

That is precisely the window between a webview deploy and the kernel restart that follows it, and it breaks the repo's standing rule that a loader must have a backstop so it can never trap the user.

## Change

- The pending deep fetch arms a backstop that drops the footer and re-arms the trigger, so a later scroll or keystroke retries.
- The backstop is cleared when the deep reply lands, and on every picker open.

## Tests

New `ui/webview/picker-deep-list.test.ts` (8 source-level pins, matching the existing `picker-*.test.ts` style):

- the deep list is a second request, fired at most once per open, and the first paint stays the plain request
- both triggers: scroll to bottom, and typing in the search box
- each picker open starts back on the cheap list
- a slow plain reply cannot clobber a deep list already on screen
- the backstop, so the loader cannot trap the user
- the footer wears the romp loader dots and is deliberately not a selectable `.picker-row`
- a deep render keeps the scroll position that triggered it
- the kernel's half of the contract: `PICKER_WINDOW`, reading `deep`, and echoing the flag back

Node suite 1323 passed, typecheck clean. No Python changed in this PR, so the suite from #16 still stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)