### PR TITLE
Picker: load the whole 30 days on open, and drop the fork lanes

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3195,7 +3195,7 @@ def _discover_fingerprint():
     return tuple(fp)
 
 
-def discover(now, window=None):
+def discover(now, window=None, forks=True):
     """[(fsid, path, anchor_sid, name)] for every transcript of a romp session touched within `window`
     seconds (default WINDOW, 48h) —
     CACHED behind a directory-mtime fingerprint (the result only changes on a session add/rename/fork, not on
@@ -3205,24 +3205,33 @@ def discover(now, window=None):
     `window` is a parameter so the + picker can reach back FURTHER than the caption horizon (the user
     2026-07-24, who typed a 3-day-old session's name into the picker, got nothing, and had to start a new
     session). 48h is the horizon for CAPTIONING a transcript; the picker inherited it by accident, which
-    silently hid all but the last two days of the fleet. Each window keeps its OWN entry under the same
-    fingerprint, so a picker open never invalidates or slows the hot 48h path, and the wide walk happens
-    only when the picker actually asks for it — never at boot."""
+    silently hid all but the last two days of the fleet.
+
+    `forks=False` drops the same-customTitle fork lanes, leaving ONE entry per registered session. The
+    picker wants exactly that — a fork lane is the same romp session listed twice, and its fsid is not a
+    romp sid, so its row pointed `openSession` at something that isn't a session. Skipping it is also what
+    makes the wide window affordable: fork detection reads the head of every candidate transcript in the
+    window, which at 30 days measured 553ms of a 640ms walk. Without it the same 30-day walk is ~78ms, so
+    the picker just loads its full list up front instead of paging it in (measured 2026-07-24).
+
+    Each (window, forks) pair keeps its OWN entry under the same fingerprint, so the picker never
+    invalidates or slows the hot 48h path the judge tiers share."""
     win = WINDOW if window is None else int(window)
+    key = (win, bool(forks))
     fp = _discover_fingerprint()
     if fp is not None:
         with _discover_lock:
-            hit = _discover_cache.get(win)
+            hit = _discover_cache.get(key)
             if hit is not None and hit["fp"] == fp and hit["result"] is not None:
                 return hit["result"]
-    res = _discover_impl(now, win)
+    res = _discover_impl(now, win, forks)
     if fp is not None:
         with _discover_lock:
-            _discover_cache[win] = {"fp": fp, "result": res}
+            _discover_cache[key] = {"fp": fp, "result": res}
     return res
 
 
-def _discover_impl(now, window=None):
+def _discover_impl(now, window=None, forks=True):
     """[(fsid, path, anchor_sid, name)] for every transcript of a romp session touched within
     `window` (default WINDOW): the session's anchor transcript plus any same-customTitle fork in its
     project dir. File-based (names/), no tmux — works for headless sessions too.
@@ -3289,7 +3298,7 @@ def _discover_impl(now, window=None):
                     if mt >= cutoff and path_str not in seen:
                         seen.add(path_str); out.append((sid, Path(path_str), sid, name))
                     break
-        if not name:
+        if not name or not forks:      # forks=False (the picker): one entry per session, and no title reads
             continue
         for stem, path_str, mt in listing:               # same-customTitle forks (each its own lane)
             if stem == sid or path_str in seen or mt < cutoff:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -750,9 +750,9 @@ def _rgb(color):
         return [112, 136, 170]
 
 
-def _sessions(now, window=None):
+def _sessions(now, window=None, forks=True):
     out = []
-    for fsid, path, anchor, name in jd.discover(now, window):
+    for fsid, path, anchor, name in jd.discover(now, window, forks):
         try:
             mtime = os.stat(path).st_mtime
         except OSError:
@@ -2657,22 +2657,21 @@ def _live_names(tmux):
     return {n: sid for sid in (tmux or {}) for n in [_name_of(sid)] if n}
 
 
-PICKER_WINDOW = 30 * 86400      # how far back the + picker can reach, vs jd.WINDOW's 48h caption horizon.
-PICKER_DEEP_CAP = 600           # row cap for that deep list (150 stays the cap for the fast first paint)
-#   30 days, and the deep list is fetched LAZILY — only once the picker is opened AND the user either scrolls
-#   to the bottom or starts typing (the user 2026-07-24, who wanted to scroll back through everything up to a
-#   month without it choking startup). So the first paint stays the cheap 48h list it always was, and the
-#   wider walk is paid for only by someone actually looking for an older session.
+PICKER_WINDOW = 30 * 86400      # how far back the + picker reaches, vs jd.WINDOW's 48h CAPTION horizon (the
+PICKER_CAP = 600                # user 2026-07-24: scroll back through the last month, not just two days).
+#   The picker sends this whole list at once rather than paging it in. It can afford to because it asks
+#   discover() for forks=False: fork detection was 553ms of a 640ms 30-day walk, and without it the same
+#   walk is ~78ms cold and ~4ms cached — below noticing, so laziness would buy nothing and cost a spinner.
 
 
 def _session_list(now, tmux, window=None):
-    """Picker payload: recent sessions, RUNNING ones first then by recency, each
-    {id,name,color,running,time,summary} — the shape render.ts's renderPicker expects.
-    `window` None = the default 48h horizon (the fast first paint); PICKER_WINDOW = the deep list."""
+    """Picker payload: sessions from the last PICKER_WINDOW, RUNNING ones first then by recency, each
+    {id,name,color,running,time,summary} — the shape render.ts's renderPicker expects. ONE row per
+    registered session: forks are off, since a fork lane is the same session listed twice under an fsid
+    that is not a romp sid, so its row pointed openSession at something that isn't a session."""
     live = set(tmux or {})
     items = []
-    cap = 150 if window is None else PICKER_DEEP_CAP
-    for s in _sessions(now, window)[:cap]:
+    for s in _sessions(now, PICKER_WINDOW if window is None else window, forks=False)[:PICKER_CAP]:
         sid = s["sid"]
         arch = jd.load_archive(sid) or {}
         items.append({"id": sid, "name": s["name"], "color": _name_color(sid),
@@ -15551,13 +15550,10 @@ class Handler(BaseHTTPRequestHandler):
                 else:
                     _cancel_pending.add(bare)
         elif msg and msg.get("type") == "requestSessions":
-            # deep=true is the picker's LAZY second fetch — the 30-day list, asked for only once the user
-            # scrolls to the bottom or types in the search box. The echoed flag tells the webview which
-            # list it got, so a late fast reply can't clobber a deep one already on screen.
-            deep = bool(msg.get("deep"))
-            client["send"](json.dumps({"type": "sessionList", "deep": deep,
-                                       "items": _session_list(int(time.time()), _tmux_sessions(),
-                                                              PICKER_WINDOW if deep else None),
+            # ONE request, the whole 30 days. It was briefly a lazy two-step, but measuring said the wide
+            # walk is ~78ms cold once forks are off, so paging it in bought nothing (the user 2026-07-24).
+            client["send"](json.dumps({"type": "sessionList",
+                                       "items": _session_list(int(time.time()), _tmux_sessions()),
                                        "defaultDir": _tilde(_default_create_dir())}))   # prefill the new-session dir field
         elif msg and msg.get("type") in ("pickResult", "openByName") and (msg.get("id") or msg.get("name")):
             sid = msg.get("id") or _live_names(_tmux_sessions()).get(str(msg.get("name")))

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -3748,33 +3748,63 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(it["summary"], "Fixing the feed")
         self.assertEqual(it["color"], {"bg": "#abcdef", "fg": "#ffffff"})
 
+    def _stale_session(self, sid, name, days):
+        """Register a session whose transcript was last touched `days` ago (past jd.WINDOW, inside the
+        picker's 30). Returns its launch dir."""
+        d = Path(self.td.name) / ("dir-" + sid[:8]); d.mkdir()
+        pdir = Path(self.td.name) / "projects" / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(d)))
+        pdir.mkdir(parents=True)
+        tp = pdir / (sid + ".jsonl")
+        tp.write_text(json.dumps(uline(NOW - int((days + 1) * 86400), "draft the reply", "u1", ps="typed")) + "\n")
+        t = NOW - int(days * 86400)
+        os.utime(tp, (t, t))
+        (jd.NAMES / sid).write_text("%s\t%s\t#9cd2ff\n" % (name, str(d)))
+        return d
+
     def test_picker_reaches_past_the_caption_window(self):
         # The user 2026-07-24: typed a 3-day-old session's name into the + picker, got nothing back, and had
         # to start a fresh session instead. The picker's payload was built from discover()'s 48h CAPTION
         # horizon, which it had inherited by accident — so every session idle longer than two days was
-        # invisible to it, and reviving one you couldn't reach by tab was impossible. The picker now has its
-        # own PICKER_WINDOW (30 days), asked for on the LAZY second fetch; the default first paint stays the
-        # cheap 48h list, so neither boot nor a picker open pays for the wider walk.
+        # invisible to it, and reviving one you couldn't reach by tab was impossible. The picker now gets
+        # PICKER_WINDOW (30 days) in ONE reply when it opens; no lazy second fetch, because with forks off
+        # the wider walk measured ~78ms cold, well under noticing.
         old_sid = "99999999-8888-7777-6666-555555555555"
-        odir = Path(self.td.name) / "olddir"; odir.mkdir()
-        opdir = Path(self.td.name) / "projects" / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(odir)))
-        opdir.mkdir(parents=True)
-        otp = opdir / (old_sid + ".jsonl")
-        otp.write_text(json.dumps(uline(NOW - 4 * 86400, "draft the reply", "u1", ps="typed")) + "\n")
-        stale = NOW - int(3.5 * 86400)          # idle 3.5 days: past the 48h window, well inside the 30 days
-        os.utime(otp, (stale, stale))
-        (jd.NAMES / old_sid).write_text("roof\t%s\t#9cd2ff\n" % str(odir))
+        self._stale_session(old_sid, "roof", 3.5)
 
-        shallow = km._session_list(NOW, {})
-        self.assertNotIn(old_sid, [i["id"] for i in shallow],
-                         "the default first paint stays the 48h list it always was")
-        deep = km._session_list(NOW, {}, km.PICKER_WINDOW)
-        it = next((i for i in deep if i["id"] == old_sid), None)
-        self.assertIsNotNone(it, "the deep list reaches a session idle 3.5 days — the bug this fixes")
+        items = km._session_list(NOW, {})
+        it = next((i for i in items if i["id"] == old_sid), None)
+        self.assertIsNotNone(it, "the picker reaches a session idle 3.5 days — the bug this fixes")
         self.assertEqual(it["name"], "roof")
         self.assertFalse(it["running"], "it is dead — the row is a revive target, not a reopen")
         self.assertEqual(it["time"], "3d ago")
-        self.assertIn(SID, [i["id"] for i in deep], "the recent session is still in the deep list too")
+        self.assertIn(SID, [i["id"] for i in items], "the recent session is still listed too")
+        # the judge/feed horizon is UNCHANGED — only the picker reaches wider
+        self.assertNotIn(old_sid, [s["sid"] for s in km._sessions(NOW)],
+                         "discover()'s default 48h window still governs every other surface")
+
+    def test_picker_lists_one_row_per_session_never_a_fork_lane(self):
+        # A fork lane (an SDK /clear mints a new fsid under the same customTitle) is the SAME romp session
+        # listed a second time, under an fsid that is NOT a romp sid — so its row pointed openSession at
+        # something that isn't a session. Skipping fork detection is also what makes the 30-day window
+        # affordable: reading each candidate's head cost 553ms of a 640ms walk (measured 2026-07-24).
+        old_sid = "99999999-8888-7777-6666-555555555555"
+        d = self._stale_session(old_sid, "roof", 3.5)
+        pdir = Path(self.td.name) / "projects" / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(d)))
+        fork_sid = "77777777-6666-5555-4444-333333333333"
+        fork = pdir / (fork_sid + ".jsonl")                           # same customTitle → a fork lane
+        fork.write_text("\n".join(json.dumps(r) for r in [
+            {"type": "custom-title", "customTitle": "roof"},
+            uline(NOW - 3 * 86400, "carry on", "u1", ps="typed")]) + "\n")
+        t = NOW - int(3.4 * 86400)
+        os.utime(fork, (t, t))
+
+        # with forks ON (what the judge/feed use) it IS a lane of its own — so the fixture really does
+        # exercise the fork path, and the picker's omission is the forks=False switch doing its job
+        self.assertIn(fork_sid, [s["sid"] for s in km._sessions(NOW, km.PICKER_WINDOW)],
+                      "fixture sanity: this is a real fork lane at the wider window")
+        ids = [i["id"] for i in km._session_list(NOW, {})]
+        self.assertEqual(ids.count(old_sid), 1, "the session appears exactly once")
+        self.assertNotIn(fork_sid, ids, "its fork lane is not a row of its own in the picker")
 
     def test_alive_filter_empty_tmux_with_tmux_present_shows_nothing(self):
         # The user 2026-06-16: after killing every session and reloading, the surfaces wrongly

--- a/ui/webview/picker-deep-list.test.ts
+++ b/ui/webview/picker-deep-list.test.ts
@@ -1,9 +1,9 @@
-// The + picker's LAZY 30-day list. The user 2026-07-24: typing a session's name into the picker found
-// nothing unless it had been touched in the last 48h (discover()'s CAPTION horizon, which the picker had
-// inherited by accident), so an older session could not be reopened at all and the only way forward was to
-// start a new one. The picker now asks for its own 30-day window, but only once the user reaches for
-// something off screen — scrolling to the bottom, or typing — so the first paint and kernel boot stay as
-// cheap as they were. Source-level pins (no jsdom for the renderer).
+// The + picker's 30-day list. The user 2026-07-24: typing a session's name into the picker found nothing
+// unless it had been touched in the last 48h (discover()'s CAPTION horizon, which the picker had inherited
+// by accident), so an older session could not be reopened at all and the only way forward was to start a
+// new one. The picker now gets the last 30 days, in ONE reply when it opens — it was briefly a lazy
+// two-step fetch, but measuring said the wide walk is ~78ms cold once fork detection is off, so paging it
+// in bought nothing and cost a spinner. Source-level pins (no jsdom for the renderer).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -12,52 +12,38 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const JUDGE = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "judge.py"), "utf8");
 
-test("the deep list is a SECOND request, fired at most once per picker open", () => {
-  assert.match(RENDER, /function requestDeepSessions\(\) \{\s*if \(pickerDeep !== "none" \|\| !vscodeApi\) return;/);
-  assert.match(RENDER, /pickerDeep = "pending";/);
-  assert.match(RENDER, /postMessage\(\{ type: "requestSessions", deep: true \}\)/);
-  // the first paint is still the plain, cheap request — no deep flag
+test("opening the picker asks for the whole list once — no lazy second fetch to wait on", () => {
   assert.match(RENDER, /postMessage\(\{ type: "requestSessions" \}\)/);
+  // the lazy machinery is gone: no deep flag, no pending state, no scroll trigger, no loader to strand
+  assert.doesNotMatch(RENDER, /requestSessions", deep: true/);
+  assert.doesNotMatch(RENDER, /pickerDeep/);
+  assert.doesNotMatch(RENDER, /loading older sessions/);
 });
 
-test("scrolling to the bottom and typing both reach for the older sessions", () => {
-  assert.match(RENDER, /list\.addEventListener\("scroll", \(\) => \{ if \(nearBottom\(list\)\) requestDeepSessions\(\); \}\)/);
-  assert.match(RENDER, /search\.addEventListener\("input", \(\) => \{ requestDeepSessions\(\);/);
+test("the kernel serves the picker 30 days, with forks off so it stays cheap", () => {
+  assert.match(KERNEL, /PICKER_WINDOW = 30 \* 86400/);
+  assert.match(KERNEL, /_sessions\(now, PICKER_WINDOW if window is None else window, forks=False\)\[:PICKER_CAP\]/);
+  assert.match(KERNEL, /"items": _session_list\(int\(time\.time\(\)\), _tmux_sessions\(\)\)/);
 });
 
-test("each picker open starts back on the cheap list", () => {
-  assert.match(RENDER, /pickerDeep = "none"; clearPickerDeepBackstop\(\);/);
+test("discover takes a window and a forks switch, cached per pair", () => {
+  assert.match(JUDGE, /def discover\(now, window=None, forks=True\):/);
+  assert.match(JUDGE, /key = \(win, bool\(forks\)\)/);
+  assert.match(JUDGE, /_discover_cache\.get\(key\)/);
+  // forks=False short-circuits before the same-customTitle scan, which is where the title reads were spent
+  assert.match(JUDGE, /if not name or not forks:/);
 });
 
-test("a slow fast-reply cannot clobber a deep list already on screen", () => {
-  assert.match(RENDER, /if \(m\.deep\) \{ pickerDeep = "loaded"; clearPickerDeepBackstop\(\); \}/);
-  assert.match(RENDER, /else if \(pickerDeep === "loaded"\) return;/);
-});
-
-test("the loader can never trap the user: a pending deep fetch has a backstop", () => {
-  // a kernel too old to know `deep` answers without the flag, so nothing would resolve the pending state
-  assert.match(RENDER, /pickerDeepBackstop = window\.setTimeout\(\(\) => \{\s*if \(pickerDeep === "pending"\) \{ pickerDeep = "none"; renderPickerMoreRow\(\); \}\s*\}, \d+\);/);
-  assert.match(RENDER, /function clearPickerDeepBackstop\(\) \{[\s\S]*?clearTimeout\(pickerDeepBackstop\)/);
-});
-
-test("the wait wears the romp loader dots, and the footer is not a selectable row", () => {
-  assert.match(RENDER, /const dots = el\("div", "rl-dots"\);/);
-  assert.match(RENDER, /cap\.textContent = "loading older sessions…";/);
+test("the list foot states the reach, so a missing older session has a stated reason", () => {
   assert.match(RENDER, /more\.textContent = "showing the last 30 days";/);
   assert.match(CSS, /\.picker-more \{/);
-  // .picker-more is deliberately NOT a .picker-row, so filterPicker and the keyboard walk skip it
+  // deliberately NOT a .picker-row, so filterPicker and the keyboard walk skip it
   assert.doesNotMatch(RENDER, /el\("div", "picker-row picker-more"\)/);
 });
 
-test("a deep render keeps the scroll position that triggered it", () => {
+test("a re-render keeps the scroll position of a user who scrolled back", () => {
   assert.match(RENDER, /const keepScroll = list\.scrollTop;/);
   assert.match(RENDER, /list\.scrollTop = keepScroll;/);
-});
-
-test("the kernel honors deep and echoes the flag back", () => {
-  assert.match(KERNEL, /PICKER_WINDOW = 30 \* 86400/);
-  assert.match(KERNEL, /deep = bool\(msg\.get\("deep"\)\)/);
-  assert.match(KERNEL, /"type": "sessionList", "deep": deep/);
-  assert.match(KERNEL, /PICKER_WINDOW if deep else None/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3527,9 +3527,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     search.id = "picker-search";
     search.placeholder = "Search sessions…";
     search.spellcheck = false;
-    // Typing is a deep-list trigger: search must reach the whole 30 days, not just the rows already on
-    // screen, or a remembered older name still comes back empty (the user 2026-07-24).
-    search.addEventListener("input", () => { requestDeepSessions(); filterPicker(search.value); pickerError(null); });
+    search.addEventListener("input", () => { filterPicker(search.value); pickerError(null); });
     const errLine = el("div", "picker-error"); errLine.id = "picker-error";
     const list = el("div", "picker-list"); list.id = "picker-list";
     // hover and keyboard share one "active" row
@@ -3537,8 +3535,6 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       const row = (e.target as HTMLElement).closest(".picker-row");
       if (row) setActiveRow(row as HTMLElement);
     });
-    // Scrolling to the bottom is the other deep-list trigger — scroll back and the older sessions arrive.
-    list.addEventListener("scroll", () => { if (nearBottom(list)) requestDeepSessions(); });
     // Directory for a NEW session — fixed once the session starts, so it's chosen here. Prefilled with the
     // gear's "Default directory" on open; recent dirs autocomplete from the datalist; the kernel expands
     // ~ / $VARs and validates it exists. Hidden in pick-mode (choosing an existing session).
@@ -3666,9 +3662,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   }
   filterPicker(seed); // reset row visibility; arm the New-session button for the (possibly seeded) value
   pickerError(null);
-  pickerDeep = "none"; clearPickerDeepBackstop();   // each open starts on the cheap list; the deep one is re-fetched on demand
   if (vscodeApi) vscodeApi.postMessage({ type: "requestSessions" });
-  if (seed) requestDeepSessions();   // opened already filtered (#only=<tag>) → that IS a search, so go deep now
 }
 
 // ---- revive loader (the user 2026-07-05) ----
@@ -3828,52 +3822,17 @@ function isOpenTab(id: string): boolean {
   return sessions.has(id) || order.includes(id) || tabMeta.has(id);
 }
 
-// ---- the picker's LAZY deep list (the user 2026-07-24) ----
-// First paint is the kernel's cheap 48h list, as it always was. Everything older, back to 30 days, is a
-// SECOND request fired only once the user shows they're reaching for something not on screen: scrolling to
-// the bottom, or typing in the search box. Typing is the case that failed — a name you remember well enough
-// to type is usually an OLD session, and the picker used to answer with nothing, so you had to start a new
-// session instead. Fetching it lazily keeps a picker open (and kernel boot) as cheap as before.
-let pickerDeep: "none" | "pending" | "loaded" = "none";
-let pickerDeepBackstop: number | undefined;
-
-function clearPickerDeepBackstop() {
-  if (pickerDeepBackstop !== undefined) { clearTimeout(pickerDeepBackstop); pickerDeepBackstop = undefined; }
-}
-
-function requestDeepSessions() {
-  if (pickerDeep !== "none" || !vscodeApi) return;
-  pickerDeep = "pending";
-  renderPickerMoreRow();     // the wait is visible BEFORE the round-trip, never a frozen-looking list
-  vscodeApi.postMessage({ type: "requestSessions", deep: true });
-  // Backstop, per the repo's loading rule: a loader must never be able to trap the user. A kernel older
-  // than this change ignores `deep` and answers without the flag, so nothing would ever resolve the
-  // pending state and the dots would spin forever — exactly the window between a webview deploy and the
-  // kernel restart that follows it. Fall back to no footer and let a later scroll or keystroke retry.
-  clearPickerDeepBackstop();
-  pickerDeepBackstop = window.setTimeout(() => {
-    if (pickerDeep === "pending") { pickerDeep = "none"; renderPickerMoreRow(); }
-  }, 8000);
-}
-
-// Footer row for the deep fetch: the romp loader's three pulsing accent dots (.rl-dots, already on the
-// page) while it's in flight, then a plain note of how far back the list now reaches. Not a .picker-row,
-// so filterPicker and the keyboard row-walk both skip it.
-function renderPickerMoreRow() {
+// Foot of the list: how far back the picker reaches, so an older session's absence has a stated reason
+// rather than looking like the search failed. Not a .picker-row, so filterPicker and the keyboard row-walk
+// both skip it. There is no loading state to show — the kernel sends the whole 30 days in one reply, which
+// measured ~78ms cold and ~4ms cached once fork detection is off (the user 2026-07-24, who asked for the
+// list to just be there rather than paged in as you scroll).
+function renderPickerFootRow() {
   const list = document.getElementById("picker-list");
   if (!list) return;
   list.querySelector(".picker-more")?.remove();
-  if (pickerDeep === "none") return;
   const more = el("div", "picker-more");
-  if (pickerDeep === "pending") {
-    const dots = el("div", "rl-dots");
-    dots.append(el("i", ""), el("i", ""), el("i", ""));
-    const cap = el("span", "");
-    cap.textContent = "loading older sessions…";
-    more.append(dots, cap);
-  } else {
-    more.textContent = "showing the last 30 days";
-  }
+  more.textContent = "showing the last 30 days";
   list.appendChild(more);
 }
 
@@ -3957,8 +3916,8 @@ function renderPicker(items: any[]) {
   // default) — so the actual default is written in there as an editable starting point (the user 2026-06-23).
   const di = document.getElementById("picker-dir") as HTMLInputElement | null;
   if (di && !di.value) di.value = kernelDefaultDir || loadSettings().defaultDir || "";
-  renderPickerMoreRow();          // deep-fetch footer (loading dots, or the 30-day note) below the rows
-  list.scrollTop = keepScroll;    // scrolling to the bottom is what TRIGGERS the deep fetch — don't yank them back to the top
+  renderPickerFootRow();          // the "last 30 days" note below the rows
+  list.scrollTop = keepScroll;    // a kernel push re-renders the list; don't yank a scrolled-back user to the top
   // Re-apply the current filter (the list may refresh while the user is mid-
   // type) — it also sets the active row / arms the New-session button.
   const s = document.getElementById("picker-search") as HTMLInputElement | null;
@@ -6588,10 +6547,6 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "palette" && Array.isArray(m.colors)) paletteColors = m.colors;
   else if (m.type === "sessionList") {
     if (typeof m.defaultDir === "string") kernelDefaultDir = m.defaultDir;
-    if (m.deep) { pickerDeep = "loaded"; clearPickerDeepBackstop(); }
-    // A slow FAST reply must not clobber a deep list already on screen (open, type immediately, deep wins
-    // the race) — it's a strict subset, so re-rendering it would drop the older rows the user asked for.
-    else if (pickerDeep === "loaded") return;
     renderPicker(m.items || []);
   }
   else if (m.type === "browseResult" && typeof m.path === "string") {   // native Browse dialog returned a folder


### PR DESCRIPTION
Follow-up to #16 / #17, on the user's correction: the older sessions should just be there when the picker opens, not appear once you scroll or type.

## What the measurement said

The lazy fetch existed because the 30-day walk looked expensive. It was, for one reason:

| | entries | cold | cached |
|---|---|---|---|
| 48h, forks on (judge/feed horizon) | 14 | 94ms | 4ms |
| 30d, forks on | 124 | 640ms | 4ms |
| **30d, forks off (what the picker needs)** | **121** | **80ms** | **4ms** |

Fork detection reads the head of every candidate transcript in the window: 14,123 `_custom_title` calls costing 553ms of that 640ms walk. With it off, the wide walk is 80ms cold and 4ms cached, which is below noticing. Laziness bought nothing and cost a spinner.

## Fork lanes were also wrong here

A fork lane (an SDK `/clear` mints a new fsid under the same customTitle) is the *same* romp session listed a second time, under an fsid that is **not** a romp sid, so its picker row pointed `openSession` at something that isn't a session. The picker wants one row per registered session.

(The repeated *names* in the list are unrelated and stay: those are genuinely distinct sessions reusing a name, like the two `roof`s. They're told apart by time and summary.)

## Change

- `jd.discover(now, window=None, forks=True)`; cache keyed on the `(window, forks)` pair.
- `_session_list` asks for `PICKER_WINDOW` with `forks=False`, and `requestSessions` sends that whole list in one reply.
- Removed: the `deep` flag, the pending state, the scroll trigger, the loader footer and its backstop. The list foot now just states the reach, so an older session's absence has a stated reason.
- Judge, feed and timeline are untouched: still 48h with forks on, and a test pins that.

## Tests

- `test_picker_reaches_past_the_caption_window` rewritten for the one-shot list, and now also asserts `_sessions(NOW)` still excludes the stale session, so the other surfaces' horizon can't drift with the picker's.
- New `test_picker_lists_one_row_per_session_never_a_fork_lane`, which first asserts the fixture really does produce a fork lane at the wider window, so it tests the switch rather than an accident.
- `picker-deep-list.test.ts` rewritten to pin the one-shot design and the absence of the lazy machinery.

Python 3071 passed, node 1320 passed, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)