### PR TITLE
Docs: fix the guide's dead anchor into the Reference mail section

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -183,7 +183,7 @@ romp --mail inbox                                                              #
 ```
 
 The full mail surface, shell and in-session, is in the
-[Reference](reference.md#mail-from-the-shell). Names resolve against the
+[Reference](reference.md#mail-from-the-terminal). Names resolve against the
 currently live sessions; sending to a dead session's name errors instead of
 silently parking mail.
 


### PR DESCRIPTION
The Reference heading 'Mail from the shell' was renamed to 'Mail from the terminal', but docs/guide.md still linked `#mail-from-the-shell`, so the link landed at the top of the page. `mkdocs build --strict` reports it as a broken anchor.

One-word fix; strict build is clean after it (verified locally — CI is currently billing-blocked for everyone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)