### PR TITLE
CLI: every dashless word names a session; commands live behind dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/romp-on/romp/main/bootstrap.sh | ba
 
 This clones Romp to `~/romp`, checks out the newest release, installs it, and adds `bin/` to your shell rc. Open a new terminal afterwards. [Installing by hand](docs/install.md#installing-by-hand) works too.
 
-Run `romp launch`. It opens the dashboard in your browser and prints the link
+Run `romp -l`. It opens the dashboard in your browser and prints the link
 too — the link carries a one-time access token, and after that first open plain
 `http://127.0.0.1:29855/` works (a cookie remembers you). Start a session.
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -50,7 +50,7 @@ no separate implementation to point at.
 |---|---|---|
 | `romp-feed` | `cli/feed.py` | Terminal mirror of the feed (`romp -f`). Backend-agnostic. |
 | `romp-judge-monitor` | `cli/judge_monitor.py` | Terminal health view of the judges (`romp -j`). |
-| `romp-update` | `cli/update.py` | Pushes this machine's committed romp to attached remote kernels and restarts them (`romp update [host]`). |
+| `romp-update` | `cli/update.py` | Pushes this machine's committed romp to attached remote kernels and restarts them (`romp --update [host]`). |
 | `romp-version` | `cli/version.py` | Version report across the moving parts (`romp --version`). |
 | `romp-idle-dots` | `cli/idle_dots.py` | tmux backend only: heals stranded `working` state / fades idle tab dots by inspecting tmux panes. Fired from `hooks/tmux-status.sh`. |
 

--- a/bin/romp
+++ b/bin/romp
@@ -4,14 +4,15 @@
 # Usage (see `romp -h`):
 #   romp                 # session named after the launch folder
 #   romp my-task         # named session "my-task"
+#   romp -l              # open the dashboard in your browser (--launch)
 #   romp -r              # resume a past conversation (full-screen picker, by name)
-#   romp -d              # live session monitor (dashboard)
-#   romp -l              # ledger — live "what is each session doing" view
+#   romp -d              # live session monitor (terminal dashboard)
 #   romp -h              # help
 # Scripting / agent entrypoints (double-dash):
 #   romp --resume <id>   # resume a specific conversation by its UUID
 #   romp ... --detach    # create the session but don't attach (prints attach cmd)
 #   romp --mail ...      # Romp Postal Service (send/inbox/agents/remote)
+# Every word WITHOUT a leading dash names a session — no bare-word commands.
 #
 # romp sessions are tagged with a tmux user option (@romp 1), so the dashboard
 # and the tmux-status hook find them by that flag — not by a naming convention.
@@ -572,7 +573,7 @@ romp — launch & manage persistent Claude Code tmux sessions
 
 Usage:
 EOF
-    _romp_cmd "romp launch"                -            "Open the dashboard in your browser (prints the link too)"
+    _romp_cmd "romp -l"                    -            "Open the dashboard in your browser (prints the link too)"
     _romp_cmd "romp"                       -            "Start a session named after the current folder"
     _romp_cmd "romp <name>"                -            "Start a session with the given name"
     _romp_cmd "romp -r"                    -            "Resume a past conversation (full-screen picker, by name)"
@@ -586,8 +587,8 @@ EOF
     _romp_cmd "romp -h"                    -            "Show this help"
     cat <<'EOF'
 
-Any name is fine — sessions are tagged with the tmux @romp flag, not a naming
-convention, so "dashboard", "help", etc. don't collide with the flags above.
+Any dashless word names a session — "dashboard", "help", "launch", "send" are
+all fine; sessions are tagged with the tmux @romp flag, not a naming convention.
 Rename from inside tmux (prefix-$ or :rename-session); it auto-syncs. Attach
 with `tmux a`. Quitting Claude ends the session (it's exec'd; no shell lingers).
 
@@ -596,8 +597,9 @@ EOF
     _romp_cmd "romp --resume <id>"         -            "Resume a specific conversation by its UUID"
     _romp_cmd "romp --detach"              -            "Create the session without attaching (prints attach cmd)"
     _romp_cmd "romp --mail ..."            romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
-    _romp_cmd "romp --url"                 -            "Print ONLY the tokened dashboard URL (for scripts; humans want \`romp launch\`)"
-    _romp_cmd "romp checkin <host>"        -            "Publish this machine to an attached hub (peer-bus check-in; checkout withdraws)"
+    _romp_cmd "romp --url"                 -            "Print ONLY the tokened dashboard URL (for scripts; humans want \`romp -l\`)"
+    _romp_cmd "romp --update [host]"       romp-update  "Push this machine's committed romp to attached remotes and restart them"
+    _romp_cmd "romp --checkin <host>"      -            "Publish this machine to an attached hub (peer-bus check-in; --checkout withdraws)"
     exit 0
 fi
 
@@ -651,12 +653,13 @@ if [[ "${1:-}" == "--version" ]]; then
     exec romp-version
 fi
 
-# `romp update [host...]` — PUSH this machine's committed romp to attached REMOTE kernels + restart them, so
-# they run exactly the local code (the user 2026-07-04: peer-to-peer, no GitHub). No host → every out-of-date
-# attached remote. Delegates to romp-update (python), which asks the LOCAL kernel to git-push local HEAD over
-# ssh + restart. Both `update` and `--update` work (`update` reserves that bare word — a session literally
-# named "update" is not a real case). To update THIS machine: `git pull`/checkout then `romp --refresh`.
-if [[ "${1:-}" == "update" || "${1:-}" == "--update" ]]; then
+# `romp --update [host...]` — PUSH this machine's committed romp to attached REMOTE kernels + restart them,
+# so they run exactly the local code (the user 2026-07-04: peer-to-peer, no GitHub). No host → every
+# out-of-date attached remote. Delegates to romp-update (python), which asks the LOCAL kernel to git-push
+# local HEAD over ssh + restart. Dash-only since 2026-07-25: the bare word names a session like any other
+# (the retired-word notice below the dispatches covers the old spelling). To update THIS machine:
+# `git pull`/checkout then `romp --refresh`.
+if [[ "${1:-}" == "--update" ]]; then
     shift
     exec romp-update "$@"
 fi
@@ -669,7 +672,7 @@ _romp_token() {
     cat "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/serve-token" 2>/dev/null || true
 }
 
-# `romp --url` — print the tokened dashboard URL, nothing else (scripting/piping; `romp launch` is the
+# `romp --url` — print the tokened dashboard URL, nothing else (scripting/piping; `romp -l` is the
 # human entry point). The first open seeds a year-long cookie; after that the bare URL works.
 if [[ "${1:-}" == "--url" ]]; then
     _tok="$(_romp_token)"
@@ -680,16 +683,17 @@ if [[ "${1:-}" == "--url" ]]; then
     exit 0
 fi
 
-# `romp launch` — THE first-run entry point (the user 2026-07-22, who wanted one command instead of
-# copying a token by hand). Jupyter's flow: print the tokened URL, then TRY to open a browser on it.
-# Both, always — the print is the contract (it always works, and you can copy it), the open is the
-# convenience (it may not be possible). On a remote/headless box (ssh, no DISPLAY, no opener) it
-# doesn't pretend: it prints the URL plus the two ways to actually reach it from your laptop.
-if [[ "${1:-}" =~ ^(--)?(launch|open)$ ]]; then
+# `romp -l` / `--launch` — THE first-run entry point (the user 2026-07-22, who wanted one command
+# instead of copying a token by hand). Jupyter's flow: print the tokened URL, then TRY to open a
+# browser on it. Both, always — the print is the contract (it always works, and you can copy it), the
+# open is the convenience (it may not be possible). On a remote/headless box (ssh, no DISPLAY, no
+# opener) it doesn't pretend: it prints the URL plus the two ways to actually reach it from your
+# laptop. Dash-only since 2026-07-25 (`romp launch` names a session; the bare `open` alias is gone).
+if [[ "${1:-}" == "-l" || "${1:-}" == "--launch" ]]; then
     _tok="$(_romp_token)"
     _kport="${ROMP_KERNEL_PORT:-29855}"
     if [[ -z "$_tok" ]]; then
-        echo "romp launch: no serve token yet — start romp first (\`romp --on\`), then re-run." >&2
+        echo "romp -l: no serve token yet; start romp first (\`romp --on\`), then re-run." >&2
         exit 1
     fi
     _url="http://127.0.0.1:$_kport/?token=$_tok"
@@ -734,41 +738,42 @@ if [[ "${1:-}" =~ ^(--)?(launch|open)$ ]]; then
     exit 0
 fi
 
-# `romp checkin <host>` / `romp checkout <host>` — publish THIS machine to an attached hub over our
-# own outbound ssh (peer-bus check-in, plans/postal-peer-buses.md stage 3), or withdraw it. The
+# `romp --checkin <host>` / `romp --checkout <host>` — publish THIS machine to an attached hub over
+# our own outbound ssh (peer-bus check-in, plans/postal-peer-buses.md stage 3), or withdraw it. The
 # plumbing behind the network popover's keep-connected checkbox; the host must be attached first.
-if [[ "${1:-}" =~ ^(--)?(checkin|checkout)$ ]]; then
+# Dash-only since 2026-07-25: the bare words name sessions like any other.
+if [[ "${1:-}" =~ ^--(checkin|checkout)$ ]]; then
     _verb="${1#--}"; shift
     _host="${1:-}"
-    if [[ -z "$_host" ]]; then echo "usage: romp $_verb <host>" >&2; exit 2; fi
+    if [[ -z "$_host" ]]; then echo "usage: romp --$_verb <host>" >&2; exit 2; fi
     _kport="${ROMP_KERNEL_PORT:-29855}"
     _on="false"; [[ "$_verb" == "checkin" ]] && _on="true"
     _resp="$(curl -sf -m 10 -X POST "http://127.0.0.1:$_kport/tunnels/checkin" \
                   -H "X-Romp-Token: $(_romp_token)" \
                   -H 'Content-Type: application/json' -d "{\"host\": \"$_host\", \"on\": $_on}")" \
-        || { echo "romp $_verb: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+        || { echo "romp --$_verb: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
-        echo "romp $_verb: ok ($_host)"
+        echo "romp --$_verb: ok ($_host)"
         exit 0
     fi
-    echo "romp $_verb: kernel refused: $_resp" >&2
+    echo "romp --$_verb: kernel refused: $_resp" >&2
     exit 1
 fi
 
-# `romp send|interrupt|end <session> [text]` — headless session control through the kernel HTTP API
-# (the kernel owns the transport and routes to whichever backend drives the session, tmux or SDK).
+# `romp --send|--interrupt|--end <session> [text]` — headless session control through the kernel HTTP
+# API (the kernel owns the transport and routes to whichever backend drives the session, tmux or SDK).
 # Before this, interrupt/end existed only as browser WS ops: a session could be FED headlessly but
-# never STOPPED (2026-07-05). Both bare and double-dash forms work, like `update`. Exit 0 only when
-# the kernel acked ok — a dead kernel or unknown session fails LOUDLY, never silently.
-if [[ "${1:-}" =~ ^(--)?(send|interrupt|end)$ ]]; then
+# never STOPPED (2026-07-05). Dash-only since 2026-07-25: the bare words name sessions like any other.
+# Exit 0 only when the kernel acked ok — a dead kernel or unknown session fails LOUDLY, never silently.
+if [[ "${1:-}" =~ ^--(send|interrupt|end)$ ]]; then
     _verb="${1#--}"; shift
     _who="${1:-}"
-    if [[ -z "$_who" ]]; then echo "usage: romp $_verb <session> $([[ "$_verb" == send ]] && echo '<text>')" >&2; exit 2; fi
+    if [[ -z "$_who" ]]; then echo "usage: romp --$_verb <session> $([[ "$_verb" == send ]] && echo '<text>')" >&2; exit 2; fi
     shift
     _kport="${ROMP_KERNEL_PORT:-29855}"
     if [[ "$_verb" == "send" ]]; then
         _text="$*"
-        if [[ -z "$_text" ]]; then echo "usage: romp send <session> <text>" >&2; exit 2; fi
+        if [[ -z "$_text" ]]; then echo "usage: romp --send <session> <text>" >&2; exit 2; fi
         _payload="$(python3 -c 'import json,sys; print(json.dumps({"name": sys.argv[1], "text": sys.argv[2]}))' "$_who" "$_text")"
     else
         _payload="$(python3 -c 'import json,sys; print(json.dumps({"name": sys.argv[1]}))' "$_who")"
@@ -776,12 +781,12 @@ if [[ "${1:-}" =~ ^(--)?(send|interrupt|end)$ ]]; then
     _resp="$(curl -sf -m 10 -X POST "http://127.0.0.1:$_kport/$_verb" \
                   -H "X-Romp-Token: $(_romp_token)" \
                   -H 'Content-Type: application/json' -d "$_payload")" \
-        || { echo "romp $_verb: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+        || { echo "romp --$_verb: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
-        echo "romp $_verb: ok ($_who)"
+        echo "romp --$_verb: ok ($_who)"
         exit 0
     fi
-    echo "romp $_verb: kernel refused: $_resp" >&2
+    echo "romp --$_verb: kernel refused: $_resp" >&2
     exit 1
 fi
 
@@ -896,6 +901,35 @@ esac
 # `romp _renamed` (above), which resyncs the picker map + Claude's pill. Attach
 # with plain `tmux a`.
 
+# --- Retired bare commands (2026-07-25) ---
+# These eight words used to dispatch commands, which silently broke the CLI's one
+# rule: `romp <word>` with no leading dash names a session (the user 2026-07-24).
+# They are session names now. Because fingers and old scripts still type the old
+# spellings, say where each command went: with no other args, one stderr line and
+# then proceed per the rule; with args (an old command invocation, never a valid
+# session launch), fail loudly naming the new spelling. Permanent and exact-match,
+# not a deprecation window. `_renamed`/`_color` stay reserved: internal tmux-hook
+# entrypoints (a live tmux server holds the old hook string until it restarts).
+_romp_retired_hint() {
+    case "$1" in
+        launch|open) echo "the dashboard is now: romp -l" ;;
+        update)      echo "the remote update is now: romp --update [host]" ;;
+        checkin)     echo "the check-in is now: romp --checkin <host>" ;;
+        checkout)    echo "the checkout is now: romp --checkout <host>" ;;
+        send)        echo "the command is now: romp --send <session> <text>" ;;
+        interrupt)   echo "the command is now: romp --interrupt <session>" ;;
+        end)         echo "the command is now: romp --end <session>" ;;
+        *)           return 1 ;;
+    esac
+}
+if _retired_hint="$(_romp_retired_hint "${1:-}")"; then
+    if [[ $# -gt 1 ]]; then
+        echo "romp: \"$1\" is a session name now; $_retired_hint" >&2
+        exit 2
+    fi
+    echo "romp: starting a session named \"$1\"; $_retired_hint" >&2
+fi
+
 # --- Argument parsing ---
 # Optional positional session name; an optional resume directive (-r for humans,
 # --resume for scripts/agents) optionally followed by a session id (UUID) to
@@ -939,7 +973,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # --- Custom name-based resume picker ----------------------------------------
-# `romp resume` (without an explicit session id) shows OUR full-screen picker of
+# `romp -r` (without an explicit session id) shows OUR full-screen picker of
 # resumable named sessions instead of Claude's auto-summary picker. Picking one
 # sets the conversation id to resume, the session name to reuse, and the
 # directory to resume it in. Cancelling (Esc / q / Ctrl-C) or having nothing to

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -86,4 +86,4 @@ fi
 
 echo
 echo "romp is installed at $DIR"
-echo "Open a new terminal (or 'source' your shell rc), then run:  romp launch"
+echo "Open a new terminal (or 'source' your shell rc), then run:  romp -l"

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,7 +1,7 @@
 # cli/ — terminal tools
 
 Python implementations of the terminal-facing romp commands. Run them via
-their `bin/` symlinks (`romp -f`, `romp -j`, `romp --version`, `romp update`)
+their `bin/` symlinks (`romp -f`, `romp -j`, `romp --version`, `romp --update`)
 — see `bin/README.md` for the command surface.
 
 | File | Command | What it is |
@@ -9,5 +9,5 @@ their `bin/` symlinks (`romp -f`, `romp -j`, `romp --version`, `romp update`)
 | `feed.py` | `romp -f` | Terminal mirror of the feed. Deliberately does NOT import the kernel/judge: it re-reads the same raw stores from scratch as an independent cross-check. |
 | `judge_monitor.py` | `romp -j` | Terminal health view of the judges. |
 | `version.py` | `romp --version` | Version report across the moving parts (working tree vs running kernel vs built bundles). |
-| `update.py` | `romp update [host]` | Pushes this machine's committed romp to attached remote kernels over ssh and restarts them. |
+| `update.py` | `romp --update [host]` | Pushes this machine's committed romp to attached remote kernels over ssh and restarts them. |
 | `idle_dots.py` | (hook-fired) | tmux backend only: heals stranded `working` state by inspecting tmux panes. Fired from `hooks/tmux-status.sh`. |

--- a/cli/update.py
+++ b/cli/update.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """romp-update — push THIS machine's committed romp to attached REMOTE kernels + restart them
-(`romp update [host...]`).
+(`romp --update [host...]`).
 
 Peer-to-peer, no GitHub (the user 2026-07-04): the local kernel pushes its committed HEAD straight to each
 host over ssh and restarts it, so the remote runs exactly the local code — no `git pull` from origin, no round
@@ -69,21 +69,21 @@ def _post(u, path, body):
 def main(argv):
     u = _kernel()
     if not u:
-        sys.stderr.write("romp update: no running kernel found (is romp on? try `romp --status`)\n")
+        sys.stderr.write("romp --update: no running kernel found (is romp on? try `romp --status`)\n")
         return 2
     hosts = [a for a in argv if not a.startswith("-")]
     if not hosts:                                                   # no host → the out-of-date attached remotes
         try:
             tuns = _get(u, "/tunnels").get("tunnels", [])
         except Exception as e:
-            sys.stderr.write("romp update: couldn't list remotes: %s\n" % e)
+            sys.stderr.write("romp --update: couldn't list remotes: %s\n" % e)
             return 2
         if not tuns:
-            sys.stdout.write("romp update: no remotes attached (attach one from the rail's network popover).\n")
+            sys.stdout.write("romp --update: no remotes attached (attach one from the rail's network popover).\n")
             return 0
         hosts = [t["host"] for t in tuns if t.get("outOfDate")]
         if not hosts:
-            sys.stdout.write("romp update: all attached remotes are up to date.\n")
+            sys.stdout.write("romp --update: all attached remotes are up to date.\n")
             return 0
     rc = 0
     for h in hosts:

--- a/docs/install.md
+++ b/docs/install.md
@@ -51,13 +51,13 @@ connect to it, open the user interface in your browser or in your editor.
 ### In a browser
 
 ```bash
-romp launch
+romp -l
 ```
 
 This opens Romp using an access token. The first open trades the token
 for a cookie, so `http://127.0.0.1:29855/` works from then on.
 
-On a remote machine, `romp launch` prints the link rather than opening a
+On a remote machine, `romp -l` prints the link rather than opening a
 browser, along with how to reach it from your laptop.
 
 ### In VS Code or Cursor

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -276,7 +276,7 @@ The Python kernel (`kernel/kernel.py`) closes it.
   the cookie, and `X-Romp-Token` (CLI/hooks/daemons, read from the file). The
   token is baked into how the kernel launches (env/autostart), never a manual
   per-launch flag; a bare browser open of `/` gets a paste-the-token login page
-  (`romp launch` prints the link + opens a browser). Only the no-side-effect liveness
+  (`romp -l` prints the link + opens a browser). Only the no-side-effect liveness
   probes are exempt (`/healthz`, `/version`, `/busy`; bus `/ping`) so liveness
   never breaks token-less monitors. `tailscale serve` traffic needs the token
   once per device like any browser — and funnel (public internet through the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -10,12 +10,18 @@ runs on the machine that hosts the kernel.
 | Command | What it does |
 |---|---|
 | `romp <name>` | Start or re-attach the terminal (tmux-backend) session `<name>` |
+| `romp -l` | Open the dashboard in your browser and print the tokened link (`--launch`) |
 | `romp -d` / `-f` / `-j` | Terminal views: dashboard, feed mirror, judge monitor |
 | `romp --on` / `--status` | Start the kernel manager / report its status |
 | `romp --refresh` | Restart the kernels (every machine; running sessions reconnect) |
 | `romp --mail …` | The postal service from the shell (below) |
-| `romp update [host]` | Push this machine's committed romp to an attached remote kernel and restart it |
+| `romp --update [host]` | Push this machine's committed romp to an attached remote kernel and restart it |
+| `romp --checkin <host>` / `--checkout` | Publish this machine to an attached hub, or withdraw it |
+| `romp --send <session> <text>` | Feed a session headlessly (`--interrupt` and `--end` stop one) |
 | `romp --version` | Version report across the moving parts |
+
+Every word without a leading dash names a session: `romp launch`, `romp send`
+and the rest start sessions with those names, and commands live behind dashes.
 
 ## The Romp Postal Service
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -381,7 +381,7 @@ border-radius:6px;background:#0c1117;color:#dfe7ee">
   <button style="margin-top:.9em;padding:.5em 1.4em;border:0;border-radius:6px;\
 background:#9cd2ff;color:#0c1a2e;font-weight:600;cursor:pointer">Open</button>
   <div style="opacity:.6;margin-top:1.2em;font-size:.9em">Get a ready-made link with
-  <code>romp launch</code>, or read <code>~/.local/state/romp/serve-token</code>.</div>
+  <code>romp -l</code>, or read <code>~/.local/state/romp/serve-token</code>.</div>
 </form>
 """
 
@@ -4836,7 +4836,7 @@ _HEAD_CACHE = {"ts": 0.0, "full": None, "short": None}   # ~2s TTL: HEAD is read
 
 def _local_head(short=False):
     """This kernel's committed HEAD sha (FULL, or --short when short=True), or None outside a checkout — the
-    commit `romp update` PUSHES to a remote AND the reference the drift is measured against, so the push and
+    commit `romp --update` PUSHES to a remote AND the reference the drift is measured against, so the push and
     the drift check AGREE. (The old drift compared the remote to _kernel_sha()'s cached STARTUP sha while the
     push sent live HEAD; once HEAD moved ahead of the running kernel they never reconciled and the "behind"
     banner never cleared — the user 2026-07-04.) Cached ~2s since it's read on every /tunnels poll but HEAD
@@ -15865,7 +15865,7 @@ def main():
     sys.stderr.write("romp-kernel: serving the ported UI at %s  (Ctrl-C to stop)\n" % url)
     sys.stderr.write("romp-kernel: records under %s ; bundles from %s\n" % (jd.STATE, DIST))
     sys.stderr.write("romp-kernel: every request needs the serve token (loopback included) — "
-                     "browser entry: `romp launch`\n")
+                     "browser entry: `romp -l`\n")
     if BIND != "127.0.0.1":
         # reachable off-box (tailnet/phone): the Origin gate blocks cross-site browsers token-free,
         # and the token is required everywhere. Open from the phone:

--- a/tests/romp-headless.bats
+++ b/tests/romp-headless.bats
@@ -1,9 +1,10 @@
 #!/usr/bin/env bats
 
-# `romp send|interrupt|end <session> [text]` — headless session control through the kernel HTTP
-# API (2026-07-05: interrupt/end existed only as browser WS ops, so a runaway session had no
-# headless stop). A tiny one-shot python server stands in for the kernel; failures must be LOUD
-# (non-zero exit + a message), never a silent curl swallow.
+# `romp --send|--interrupt|--end <session> [text]` — headless session control through the kernel
+# HTTP API (2026-07-05: interrupt/end existed only as browser WS ops, so a runaway session had no
+# headless stop; dash-only since 2026-07-25 — the bare words name sessions). A tiny one-shot python
+# server stands in for the kernel; failures must be LOUD (non-zero exit + a message), never a
+# silent curl swallow.
 
 ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
 
@@ -42,25 +43,37 @@ PY
     export ROMP_KERNEL_PORT="$(cat "$TEST_DIR/port")"
 }
 
-@test "romp interrupt <name> POSTs /interrupt and exits 0 on ok" {
+@test "romp --interrupt <name> POSTs /interrupt and exits 0 on ok" {
     start_fake_kernel '{"ok": true}'
-    run "$ROMP_SCRIPT" interrupt runaway
+    run "$ROMP_SCRIPT" --interrupt runaway
     [ "$status" -eq 0 ]
     [[ "$output" == *"ok (runaway)"* ]]
     grep -q "^/interrupt$" <(head -1 "$TEST_DIR/req")
     grep -q '"name": "runaway"' "$TEST_DIR/req"
 }
 
-@test "romp end works with the --end form too" {
+@test "romp --end stops a session through /end" {
     start_fake_kernel '{"ok": true}'
     run "$ROMP_SCRIPT" --end done-with-it
     [ "$status" -eq 0 ]
     grep -q "^/end$" <(head -1 "$TEST_DIR/req")
 }
 
-@test "romp send ships JSON-safe text" {
+@test "the bare spellings are retired: an old command invocation fails naming the new one" {
+    # `romp send <name> <text>` is the pre-2026-07-25 spelling; the bare word names a
+    # session now, so the old form must exit 2 with the fix, never reach the kernel.
+    run "$ROMP_SCRIPT" send helper "hello"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"romp --send <session> <text>"* ]]
+    run "$ROMP_SCRIPT" interrupt runaway
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"romp --interrupt <session>"* ]]
+    [ ! -e "$TEST_DIR/req" ]
+}
+
+@test "romp --send ships JSON-safe text" {
     start_fake_kernel '{"ok": true}'
-    run "$ROMP_SCRIPT" send helper 'fix the "thing" \ and this'
+    run "$ROMP_SCRIPT" --send helper 'fix the "thing" \ and this'
     [ "$status" -eq 0 ]
     grep -q "^/send$" <(head -1 "$TEST_DIR/req")
     python3 - "$TEST_DIR/req" <<'PY'
@@ -72,21 +85,21 @@ PY
 
 @test "a kernel refusal is loud: non-zero exit + the kernel's answer" {
     start_fake_kernel '{"ok": false, "error": "id or name required"}'
-    run "$ROMP_SCRIPT" interrupt ghost
+    run "$ROMP_SCRIPT" --interrupt ghost
     [ "$status" -eq 1 ]
     [[ "$output" == *"kernel refused"* ]]
 }
 
 @test "an unreachable kernel is loud, not a silent curl swallow" {
-    ROMP_KERNEL_PORT=1 run "$ROMP_SCRIPT" interrupt anyone
+    ROMP_KERNEL_PORT=1 run "$ROMP_SCRIPT" --interrupt anyone
     [ "$status" -eq 1 ]
     [[ "$output" == *"kernel not reachable"* ]]
 }
 
 @test "usage errors exit 2: missing session name, send without text" {
-    run "$ROMP_SCRIPT" interrupt
+    run "$ROMP_SCRIPT" --interrupt
     [ "$status" -eq 2 ]
-    run "$ROMP_SCRIPT" send lonely
+    run "$ROMP_SCRIPT" --send lonely
     [ "$status" -eq 2 ]
-    [[ "$output" == *"usage: romp send"* ]]
+    [[ "$output" == *"usage: romp --send"* ]]
 }

--- a/tests/romp-launch.bats
+++ b/tests/romp-launch.bats
@@ -1,10 +1,11 @@
 #!/usr/bin/env bats
 
-# `romp launch` — the first-run entry point (2026-07-22): print the tokened dashboard URL AND try to
-# open a browser on it (Jupyter's flow). The PRINT is the contract — it must always happen, even when
-# no browser can be opened — because it is the user's guaranteed way in. On a remote/headless box it
-# must NOT pretend to open anything, and must say how to reach the dashboard from a laptop instead.
-# `romp --url` stays the print-only variant for scripting.
+# `romp -l` / `--launch` — the first-run entry point (2026-07-22; dash-only since 2026-07-25, when
+# bare `launch` became a session name like every dashless word): print the tokened dashboard URL AND
+# try to open a browser on it (Jupyter's flow). The PRINT is the contract — it must always happen,
+# even when no browser can be opened — because it is the user's guaranteed way in. On a
+# remote/headless box it must NOT pretend to open anything, and must say how to reach the dashboard
+# from a laptop instead. `romp --url` stays the print-only variant for scripting.
 
 ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
 
@@ -30,21 +31,27 @@ MOCK
 
 teardown() { rm -rf "$TEST_DIR"; }
 
-@test "romp launch prints the tokened URL" {
-    run "$ROMP_SCRIPT" launch
+@test "romp -l prints the tokened URL" {
+    run "$ROMP_SCRIPT" -l
     [ "$status" -eq 0 ]
     [[ "$output" == *"http://127.0.0.1:29855/?token=TESTTOKEN123"* ]]
 }
 
-@test "romp launch opens a browser on a local machine" {
-    run "$ROMP_SCRIPT" launch
+@test "romp --launch is the long spelling of -l" {
+    run "$ROMP_SCRIPT" --launch
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"http://127.0.0.1:29855/?token=TESTTOKEN123"* ]]
+}
+
+@test "romp -l opens a browser on a local machine" {
+    run "$ROMP_SCRIPT" -l
     [ "$status" -eq 0 ]
     [ -s "$OPEN_LOG" ]
     grep -q "token=TESTTOKEN123" "$OPEN_LOG"
 }
 
-@test "romp launch on a remote/ssh box prints the URL but opens nothing" {
-    SSH_CONNECTION="10.0.0.1 1 10.0.0.2 22" run "$ROMP_SCRIPT" launch
+@test "romp -l on a remote/ssh box prints the URL but opens nothing" {
+    SSH_CONNECTION="10.0.0.1 1 10.0.0.2 22" run "$ROMP_SCRIPT" -l
     [ "$status" -eq 0 ]
     [[ "$output" == *"http://127.0.0.1:29855/?token=TESTTOKEN123"* ]]   # the link is ALWAYS printed
     [[ "$output" == *"remote/headless"* ]]
@@ -52,40 +59,40 @@ teardown() { rm -rf "$TEST_DIR"; }
     [ ! -s "$OPEN_LOG" ] || false                                       # never opened a browser
 }
 
-@test "romp launch still prints the URL when no opener exists" {
+@test "romp -l still prints the URL when no opener exists" {
     # ROMP_OPENER= (set, empty) means "no opener", which PATH alone CANNOT express:
     # macOS ships /usr/bin/open, so the previous `rm $MOCK/open` + PATH=...:/usr/bin
     # form fell through to the REAL opener and launched an actual browser on every
     # macOS run. Linux has no `open`, which is why only macOS was affected.
     rm "$MOCK/open"
-    ROMP_OPENER= run "$ROMP_SCRIPT" launch
+    ROMP_OPENER= run "$ROMP_SCRIPT" -l
     [ "$status" -eq 0 ]
     [[ "$output" == *"http://127.0.0.1:29855/?token=TESTTOKEN123"* ]]
     [[ "$output" == *"couldn't open a browser automatically"* ]]
 }
 
-@test "romp launch opens nothing when no opener exists, even where a real one is on PATH" {
+@test "romp -l opens nothing when no opener exists, even where a real one is on PATH" {
     # The regression guard for the above: assert the real opener was never reached.
     # $MOCK/open stays in place and must NOT be called.
-    ROMP_OPENER= run "$ROMP_SCRIPT" launch
+    ROMP_OPENER= run "$ROMP_SCRIPT" -l
     [ "$status" -eq 0 ]
     [ ! -s "$OPEN_LOG" ] || false
 }
 
-@test "romp launch honours a custom ROMP_OPENER" {
+@test "romp -l honours a custom ROMP_OPENER" {
     cat > "$MOCK/mybrowser" <<'MOCK'
 #!/bin/sh
 echo "$@" >> "$OPEN_LOG"
 MOCK
     chmod +x "$MOCK/mybrowser"
-    ROMP_OPENER=mybrowser run "$ROMP_SCRIPT" launch
+    ROMP_OPENER=mybrowser run "$ROMP_SCRIPT" -l
     [ "$status" -eq 0 ]
     [[ "$(cat "$OPEN_LOG")" == *"token=TESTTOKEN123"* ]]
 }
 
-@test "romp launch fails loudly when no token has been minted yet" {
+@test "romp -l fails loudly when no token has been minted yet" {
     rm "$XDG_STATE_HOME/romp/serve-token"
-    run "$ROMP_SCRIPT" launch
+    run "$ROMP_SCRIPT" -l
     [ "$status" -ne 0 ]
     [[ "$output" == *"no serve token"* ]]
 }

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -553,6 +553,38 @@ MOCK
     grep -q 'tmux new-session -d -s down' "$MOCK_LOG"
 }
 
+@test "retired bare words are session names now, with a one-line notice naming the new spelling" {
+    # 2026-07-25 dash-ification of the last eight bare commands: `romp <word>` with no
+    # leading dash ALWAYS names a session. Argless, each word starts its session and a
+    # single stderr line says where the command went, so old muscle memory self-corrects.
+    for word in launch open update checkin checkout send interrupt end; do
+        : > "$MOCK_LOG"
+        run run_romp "$word"
+        [ "$status" -eq 0 ]
+        grep -q "tmux new-session -d -s ${word}" "$MOCK_LOG"
+        [[ "$output" == *"starting a session named \"${word}\""* ]]
+    done
+    # the notice names the new spelling (spot-check the dashboard one)
+    run run_romp launch
+    [[ "$output" == *"romp -l"* ]]
+}
+
+@test "a retired bare word WITH args is an old command invocation: loud exit 2, session untouched" {
+    # `romp send api "hi"` can only be the old command (a session launch takes one
+    # positional), so it must fail naming the new spelling, never guess.
+    run run_romp send api "hello there"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'"send" is a session name now'* ]]
+    [[ "$output" == *"romp --send <session> <text>"* ]]
+    ! grep -q 'tmux new-session' "$MOCK_LOG"
+    run run_romp update somehost
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"romp --update"* ]]
+    run run_romp launch --detach
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"romp -l"* ]]
+}
+
 @test "romp-manager: control verbs error cleanly when no manager is running" {
     command -v node >/dev/null 2>&1 || skip "node not available"
     local mgr; mgr="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp-manager"
@@ -841,14 +873,14 @@ MOCK
     grep -q 'tmux new-session -d -s j' "$MOCK_LOG"
 }
 
-@test "romp checkin/checkout: usage without a host, loud failure with no kernel" {
-    run "$ROMP_SCRIPT" checkin
+@test "romp --checkin/--checkout: usage without a host, loud failure with no kernel" {
+    run "$ROMP_SCRIPT" --checkin
     [ "$status" -eq 2 ]
-    [[ "$output" == *"usage: romp checkin <host>"* ]]
-    run "$ROMP_SCRIPT" checkout
+    [[ "$output" == *"usage: romp --checkin <host>"* ]]
+    run "$ROMP_SCRIPT" --checkout
     [ "$status" -eq 2 ]
     # port 1 refuses instantly → the CLI must fail LOUDLY, never pretend the checkout happened
-    ROMP_KERNEL_PORT=1 run "$ROMP_SCRIPT" checkout somehost
+    ROMP_KERNEL_PORT=1 run "$ROMP_SCRIPT" --checkout somehost
     [ "$status" -eq 1 ]
     [[ "$output" == *"kernel not reachable"* ]]
 }

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6107,7 +6107,7 @@ class ServeSecurity(unittest.TestCase):
         with urllib.request.urlopen("http://127.0.0.1:%d/" % self.port, timeout=5) as r:
             self.assertEqual(r.status, 200)
             body = r.read().decode("utf-8", "replace")
-        self.assertIn("romp launch", body)                 # names the CLI that opens/prints the tokened link
+        self.assertIn("romp -l", body)                     # names the CLI that opens/prints the tokened link
         self.assertNotIn("testtok", body)                  # never echoes the token itself
         self.assertNotIn("src=/chat", body)                # none of the real shell is served
 

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -276,8 +276,11 @@ class RompUpdateCLI(unittest.TestCase):
         ru._kernel, ru._get, ru._post = self._k, self._g, self._p
 
     def test_dispatch_routes_update_in_the_bash_cli(self):
+        # Dash-only since 2026-07-25: bare `update` names a session (the retired-word
+        # notice covers the old spelling); only `--update` routes to romp-update.
         src = open(os.path.join(BIN, "romp")).read()
-        self.assertIn('"${1:-}" == "update" || "${1:-}" == "--update"', src, "both `update` and `--update` route")
+        self.assertIn('"${1:-}" == "--update"', src, "--update routes to romp-update")
+        self.assertNotIn('"${1:-}" == "update"', src, "bare `update` must stay free to name a session")
         self.assertIn("exec romp-update", src)
 
     def test_no_kernel_errors_cleanly(self):


### PR DESCRIPTION
Delegated audit + fix of the `romp` CLI argument grammar. The invariant: `romp <word>` with no leading dash always starts/attaches a session named `<word>`.

## What changed
- Eight bare words stopped being commands and became ordinary session names: `launch`, `open`, `update`, `checkin`, `checkout`, `send`, `interrupt`, `end`.
- The commands are dash-only now: `--launch` (new `-l` short form), `--update`, `--checkin`, `--checkout`, `--send`, `--interrupt`, `--end`. Every dashed form already worked, so scripts using them are untouched. The undocumented `open` alias is dropped.
- Muscle-memory rescue, permanent and exact-match: an argless retired word prints one stderr line naming the new spelling and proceeds per the invariant; a retired word with args (an old command invocation) exits 2 naming the fix. Nothing silently does the wrong thing.
- `_renamed`/`_color` stay reserved: internal tmux-hook entrypoints; a live tmux server holds the old hook string until restart.
- Docs/help/hints updated everywhere but `docs/guide.md` (owned by another session, updates after this lands): help table, reference.md, install.md, README, bootstrap.sh, kernel login/startup hints, cli/update.py messages, bin/ and cli/ READMEs. Stale header `-l` ledger line and `romp resume` comment retired.

## Tests
- bats: retired words create sessions with the notice; with-args exits 2 naming the new spelling; `--checkin`/`--send`/`--interrupt`/`--end`/`-l`/`--launch` behavior pinned. 236/236 pass.
- Python: dispatch source pin updated (bare `update` must NOT route). 3071 passed, 25 skipped.
- node: 1328/1328, tsc clean (no webview changes; kernel string edits only).

CI on this org is currently failing all jobs instantly with a billing error, so this was merged on local green, same as #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)