### PR TITLE
Session prompt: pre-explain romp's artifacts to every session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ something**, in their words:
   clear wrap-up carries the same content in about half the words it started with.
 - Draft this copy with the `jld` skill, the way any user-facing writing is drafted.
 
-TWO deliberate exceptions, both fine, neither a licence to widen:
+THREE deliberate exceptions, all fine, none a licence to widen:
 - **The SessionStart instruction** that asks a session to report what it finished
   and what it is blocked on. That asks for ordinary self-reporting; it names no
   romp machinery and needs none.
@@ -129,9 +129,17 @@ TWO deliberate exceptions, both fine, neither a licence to widen:
   relevant to your work — ignore them -->`). It describes the markers WITHOUT
   naming romp, on purpose: naming it would explain nothing to a model that has
   never heard of it.
+- **The session prompt's housekeeping note** (`claude/romp-session-prompt.md`) —
+  the ONE place romp is named to a session, on purpose (the user 2026-07-25, after
+  a restart notice reached a session that had no idea what "the romp kernel" was).
+  It pre-explains the artifacts every session eventually sees: `[romp]` notices and
+  `<!-- romp-* -->` comments are an external session manager's bookkeeping, to be
+  ignored beyond any practical information they carry. It explains the ARTIFACTS
+  only; cards, boards, goals and the rest of the machinery stay unnamed, and every
+  injected message still speaks as the person the agent works for.
 - Also fine: the `[romp] The kernel restarted…` notices in `sdk_backend.py`. Those
   are genuinely ABOUT romp — they tell a session why its turn was cut — so they
-  name it.
+  name it (and the housekeeping note above gives the name meaning).
 
 `tests/test_injected_voice.py` renders every injected body and fails on romp
 vocabulary in the prose, so this holds without anyone remembering it.

--- a/claude/README.md
+++ b/claude/README.md
@@ -4,8 +4,9 @@ The Claude-side configuration romp installs for its sessions (symlinked into
 place by `install.sh`):
 
 - **`romp-session-prompt.md`** — the extra system-prompt content every
-  romp-managed session gets: how to behave inside a fleet (worktrees, postal
-  coordination, self-identification).
+  romp-managed session gets: plain done/not-done reporting the judges can read,
+  plus the housekeeping note that pre-explains romp's artifacts (`[romp]`
+  notices, `<!-- romp-* -->` comments) as bookkeeping to ignore.
 - **`romp-postal.mcp.json`** — registers the postal MCP server
   (`postal/postal_service.py`, via the `romp-postal-service` command on PATH).
 - **`skills/romp/`** — the `/romp` skill: convert the current plain terminal

--- a/claude/romp-session-prompt.md
+++ b/claude/romp-session-prompt.md
@@ -15,3 +15,11 @@ mapping, or planning — is not finishing the work it was for.
 
 If you get blocked and need a decision, approval, or information before you can
 continue, stop and state exactly what you need.
+
+# Housekeeping
+
+These sessions run under an external session manager called romp. Anything it
+leaves in the conversation, such as HTML comments like `<!-- romp-... -->` or
+lines tagged `[romp]`, is bookkeeping and not the user talking: ignore it,
+beyond taking in any practical information it carries (for example, that the
+session was restarted).

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -17,8 +17,12 @@ Scope note — what is deliberately NOT checked:
   so it does NOT have to name romp to the model. Prose only.
 - the SessionStart instruction, which asks for ordinary self-reporting (what you finished, what you're
   blocked on) and names no machinery.
+- the session prompt's housekeeping note (claude/romp-session-prompt.md), the ONE place romp is named
+  to a session on purpose: it pre-explains the [romp] / <!-- romp-* --> artifacts as an external
+  session manager's bookkeeping to ignore (the user 2026-07-25). Pinned by test_session_prompt.py.
 - sdk_backend's "[romp] The kernel restarted…" notices, which are genuinely ABOUT romp: they tell a
-  session why its turn was cut, so naming it is the point.
+  session why its turn was cut, so naming it is the point (and the housekeeping note gives the
+  name meaning).
 
 SYNTHETIC fixtures only (placeholder ids, invented goal text).
 """
@@ -162,6 +166,7 @@ class TheRuleIsWrittenDown(unittest.TestCase):
         # the exceptions are part of the rule: without them someone "fixes" the marker note next
         self.assertIn("SessionStart instruction", md)
         self.assertIn("marker tail", md)
+        self.assertIn("housekeeping note", md)
 
 
 if __name__ == "__main__":

--- a/tests/test_session_prompt.py
+++ b/tests/test_session_prompt.py
@@ -39,6 +39,17 @@ class SessionPrompt(unittest.TestCase):
         self.assertIn("preliminary step", self.flat,
                       "the prompt must say a preliminary step (reading/mapping/planning) is not finishing the work")
 
+    def test_housekeeping_note_preexplains_romp_artifacts(self):
+        # The ONE place romp is named to a session (the user 2026-07-25): pre-explain the artifacts
+        # every session eventually sees — [romp] notices and <!-- romp-* --> comments — so a kernel
+        # restart notice reads as explained information, not an unexplained system voice.
+        self.assertIn("romp", self.flat,
+                      "the housekeeping note must name romp so its artifacts have an anchor")
+        self.assertIn("[romp]", self.text, "the note must show the bracketed-notice form")
+        self.assertIn("<!-- romp-", self.text, "the note must show the HTML-comment form")
+        self.assertIn("ignore", self.flat,
+                      "the note must tell the session to ignore the bookkeeping")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A kernel-restart notice reached a session as `[romp] The romp kernel restarted...` — but nothing had ever told that session what romp is. Fix per the user's direction: the appended session prompt (`claude/romp-session-prompt.md`) gains a short housekeeping note naming romp once and telling the session its `[romp]` notices and `<!-- romp-* -->` comments are external bookkeeping to ignore, beyond any practical information they carry (e.g. a restart).

- The restart notices themselves are unchanged: their wording is load-bearing (the kernel and judge match on it), and with the note in place the `[romp]` tag now has an anchor.
- CLAUDE.md's injected-voice exception list grows from two to three; the injected-voice rule itself is untouched (no romp nouns in nudge/wrap-up prose).
- Tests: `test_session_prompt.py` pins the note's content; `test_injected_voice.py` pins the written-down exception.

Local green: 3072 Python passed + 25 skipped, node 1328/1328. CI on the org is still dead (billing), same as recent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)