### PR TITLE
CLI grammar round 3: bare-word commands, SDK-default romp new, tokened install finish

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/romp-on/romp/main/bootstrap.sh | ba
 
 This clones Romp to `~/romp`, checks out the newest release, installs it, and adds `bin/` to your shell rc. Open a new terminal afterwards. [Installing by hand](docs/install.md#installing-by-hand) works too.
 
-Run `romp -l`. It opens the dashboard in your browser and prints the link
+Run `romp`. It opens the dashboard in your browser and prints the link
 too — the link carries a one-time access token, and after that first open plain
 `http://127.0.0.1:29855/` works (a cookie remembers you). Start a session.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ The token (`~/.local/state/romp/serve-token`) is 144-bit random, stored at mode
 `0600`, and compared with a constant-time check — **file permissions are the
 same-user gate**. Same-user clients (the CLI, hooks, the bus, the VS Code
 extension) read the file and send it as an `X-Romp-Token` header; the browser
-presents it once as `?token=` (print the ready-made link with `romp --url`, or
+presents it once as `?token=` (print the ready-made link with `romp url`, or
 paste the token into the login page a bare open of the dashboard serves) and
 rides an `HttpOnly` cookie afterwards. An Origin check additionally protects
 the browser surfaces against cross-site requests, including the WebSocket

--- a/bin/README.md
+++ b/bin/README.md
@@ -21,7 +21,7 @@ no separate implementation to point at.
 | `romp` | Bash | The launcher/dispatcher: start/resume/attach sessions, `-d`/`-f`/`-j` terminal views, `--on/--refresh/--status`, `--mail`, `update`, `--version`. Also provisions the tmux server glue when using the tmux backend. |
 | `romp-service` | Bash | Installs/removes the launchd (macOS) / systemd-user (Linux) login agent. Run by `install.sh`. |
 | `romp-node-launch` | POSIX sh | Runs the manager under a romp-owned copy of node (`romp-node`) so macOS TCC permissions can be granted to romp alone. |
-| `romp-manager` | Node | The kernel **supervisor**: spawns kernels via `romp-serve`, respawns on crash, `up/ensure/restart-all/status/down`. Reached via `romp --on/--refresh/--status`. |
+| `romp-manager` | Node | The kernel **supervisor**: spawns kernels via `romp-serve`, respawns on crash, `up/ensure/restart-all/status/down`. Reached via `romp up` / `romp refresh` / `romp status`. |
 | `romp-serve` | Bash | The manager→kernel seam: maps the manager's spawn contract onto the kernel's env, picks the python, then `exec`s the kernel (PID preserved for the supervisor; the kernel self-builds stale UI bundles). |
 | `romp-sdk-setup` | Bash | Provisions the Agent SDK venv for the SDK backend. Run by `install.sh`. |
 
@@ -42,16 +42,16 @@ no separate implementation to point at.
 
 | Command | Source | What it is |
 |---|---|---|
-| `romp-postal-service` | `postal/postal_service.py` | Inter-session mail: MCP server + CLI (`romp --mail`). `romp-postal` is a symlink alias. |
+| `romp-postal-service` | `postal/postal_service.py` | Inter-session mail: MCP server + CLI (`romp mail`). `romp-postal` is a symlink alias. |
 
 ## Symlinks → `cli/` (terminal tools)
 
 | Command | Source | What it is |
 |---|---|---|
-| `romp-feed` | `cli/feed.py` | Terminal mirror of the feed (`romp -f`). Backend-agnostic. |
-| `romp-judge-monitor` | `cli/judge_monitor.py` | Terminal health view of the judges (`romp -j`). |
-| `romp-update` | `cli/update.py` | Pushes this machine's committed romp to attached remote kernels and restarts them (`romp --update [host]`). |
-| `romp-version` | `cli/version.py` | Version report across the moving parts (`romp --version`). |
+| `romp-feed` | `cli/feed.py` | Terminal mirror of the feed (`romp feed`). Backend-agnostic. |
+| `romp-judge-monitor` | `cli/judge_monitor.py` | Terminal health view of the judges (`romp judges`). |
+| `romp-update` | `cli/update.py` | Pushes this machine's committed romp to attached remote kernels and restarts them (`romp update [host]`). |
+| `romp-version` | `cli/version.py` | Version report across the moving parts (`romp version`). |
 | `romp-idle-dots` | `cli/idle_dots.py` | tmux backend only: heals stranded `working` state / fades idle tab dots by inspecting tmux panes. Fired from `hooks/tmux-status.sh`. |
 
 ## tmux backend only (real files)
@@ -62,6 +62,6 @@ dropped, these (plus `romp-askparse`, `romp-idle-dots`, and the tmux glue in
 
 | File | Lang | What it is |
 |---|---|---|
-| `romp-dashboard` | Bash | Terminal dashboard over `tmux list-sessions` (`romp -d`). The web kernel is the modern equivalent. |
+| `romp-dashboard` | Bash | Terminal dashboard over `tmux list-sessions` (`romp monitor`). The web kernel is the modern equivalent. |
 | `romp-interrupt-reset` | Bash | tmux Ctrl-C/Esc bind: resets a stuck `working` state (Claude fires no interrupt hook). |
 | `romp-mail-clear` | Bash | Clears the postal badge in the tmux status bar on session switch. |

--- a/bin/romp
+++ b/bin/romp
@@ -1,18 +1,17 @@
 #!/usr/bin/env bash
-# romp — Launch Claude Code in a persistent tmux session
+# romp — direct a fleet of Claude Code sessions; the dashboard is the front door
 #
-# Usage (see `romp -h`):
-#   romp                 # session named after the launch folder
-#   romp my-task         # named session "my-task"
-#   romp -l              # open the dashboard in your browser (--launch)
-#   romp -r              # resume a past conversation (full-screen picker, by name)
-#   romp -d              # live session monitor (terminal dashboard)
-#   romp -h              # help
-# Scripting / agent entrypoints (double-dash):
-#   romp --resume <id>   # resume a specific conversation by its UUID
-#   romp ... --detach    # create the session but don't attach (prints attach cmd)
-#   romp --mail ...      # Romp Postal Service (send/inbox/agents/remote)
-# Every word WITHOUT a leading dash names a session — no bare-word commands.
+# Usage (see `romp help`):
+#   romp                     # open the dashboard in your browser
+#   romp new api             # start a session named "api" (SDK; lives in the kernel)
+#   romp new -t api          # ...as a terminal (tmux) session, attached
+#   romp resume              # resume a past conversation (full-screen picker)
+#   romp monitor             # live session monitor (terminal dashboard)
+#   romp send api "text"     # scripts/agents: message a session (also: interrupt, end)
+#   romp help                # the full command list
+# Commands are bare words, git-style; options are dashed and belong to their
+# command. A bare word that isn't a command fails loudly naming the fix
+# (`romp foo` → `romp new foo`) — nothing silently becomes a session.
 #
 # romp sessions are tagged with a tmux user option (@romp 1), so the dashboard
 # and the tmux-status hook find them by that flag — not by a naming convention.
@@ -556,9 +555,8 @@ if [[ "${1:-}" == "_color" ]]; then
     exit 0
 fi
 
-# Help. Only the flags `-h` / `--help` (not a bare `help` word), so `romp help`
-# stays free to name a session — same rule as `-d` for the dashboard.
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+# Help. The bare word plus the conventional flags.
+if [[ "${1:-}" == "help" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     # The command list is GENERATED with a presence check per command, so it can't drift from what's
     # actually installed: a command whose backing romp-* binary is missing is hidden, and adding a new
     # romp-* front end (+ a line here) makes it appear (the user 2026-06-16). "-" = built into this
@@ -569,44 +567,48 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
         printf '  %-28s %s\n' "$inv" "$*"
     }
     cat <<'EOF'
-romp — launch & manage persistent Claude Code tmux sessions
+romp — direct a fleet of Claude Code sessions; the dashboard is the front door
 
 Usage:
 EOF
-    _romp_cmd "romp -l"                    -            "Open the dashboard in your browser (prints the link too)"
-    _romp_cmd "romp"                       -            "Start a session named after the current folder"
-    _romp_cmd "romp <name>"                -            "Start a session with the given name"
-    _romp_cmd "romp -r"                    -            "Resume a past conversation (full-screen picker, by name)"
-    _romp_cmd "romp -d"                    romp-dashboard "Live session monitor (dashboard)"
-    _romp_cmd "romp -f"                    romp-feed    "Feed — terminal Working/Blocked/Completed board (mirrors the web feed)"
-    _romp_cmd "romp -j"                    romp-judge-monitor "Judges health monitor — are they keeping up, any exceptions"
-    _romp_cmd "romp --on"                  romp-manager "Start the kernel manager (foreground — Ctrl+C stops it and its kernels)"
-    _romp_cmd "romp --refresh"             romp-manager "Restart the postal bus + all romp kernels (picks up new code — run after an update)"
-    _romp_cmd "romp --status"              romp-manager "Show manager + kernel status"
-    _romp_cmd "romp --version"             romp-version "Versions across the parts (tree, kernel, served vs built bundles)"
-    _romp_cmd "romp -h"                    -            "Show this help"
+    _romp_cmd "romp"                       -            "Open the dashboard in your browser (prints the link too)"
+    _romp_cmd "romp new <name>"            -            "Start a session (SDK; lives in the kernel, watch it on the dashboard)"
+    _romp_cmd "romp new -t <name>"         -            "Start it as a terminal (tmux) session and attach (--detach: don't attach)"
+    _romp_cmd "romp new -d <dir> <name>"   -            "Working directory for the new session (default: the current folder)"
+    _romp_cmd "romp resume [<id>]"         -            "Resume a past conversation (full-screen picker; or an exact UUID)"
+    _romp_cmd "romp monitor"               romp-dashboard "Live session monitor (terminal dashboard)"
+    _romp_cmd "romp feed"                  romp-feed    "Terminal Working/Blocked/Completed board (mirrors the web feed)"
+    _romp_cmd "romp judges"                romp-judge-monitor "Judges health monitor — are they keeping up, any exceptions"
+    _romp_cmd "romp status"                romp-manager "Show manager + kernel status"
+    _romp_cmd "romp refresh"               romp-manager "Restart the postal bus + all romp kernels (picks up new code — run after an update)"
+    _romp_cmd "romp update [host]"         romp-update  "Push this machine's committed romp to attached remotes and restart them"
+    _romp_cmd "romp up"                    romp-manager "Run the kernel manager in the foreground (rare — the login service runs it)"
+    _romp_cmd "romp version"               romp-version "Versions across the parts (tree, kernel, served vs built bundles)"
+    _romp_cmd "romp help"                  -            "Show this help"
     cat <<'EOF'
 
-Any dashless word names a session — "dashboard", "help", "launch", "send" are
-all fine; sessions are tagged with the tmux @romp flag, not a naming convention.
-Rename from inside tmux (prefix-$ or :rename-session); it auto-syncs. Attach
-with `tmux a`. Quitting Claude ends the session (it's exec'd; no shell lingers).
+Session names never collide with commands: the name is always an argument, so
+`romp new update` starts a session named "update". tmux sessions are tagged
+with the @romp flag, not a naming convention — rename from inside tmux
+(prefix-$ or :rename-session; it auto-syncs) and attach with `tmux a`.
+Quitting Claude ends a terminal session (it's exec'd; no shell lingers).
 
-For scripts / agents (double-dash = not for everyday use):
+For scripts / agents:
 EOF
-    _romp_cmd "romp --resume <id>"         -            "Resume a specific conversation by its UUID"
-    _romp_cmd "romp --detach"              -            "Create the session without attaching (prints attach cmd)"
-    _romp_cmd "romp --mail ..."            romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
-    _romp_cmd "romp --url"                 -            "Print ONLY the tokened dashboard URL (for scripts; humans want \`romp -l\`)"
-    _romp_cmd "romp --update [host]"       romp-update  "Push this machine's committed romp to attached remotes and restart them"
-    _romp_cmd "romp --checkin <host>"      -            "Publish this machine to an attached hub (peer-bus check-in; --checkout withdraws)"
+    _romp_cmd "romp url"                   -            "Print ONLY the tokened dashboard URL (for scripts; humans just run \`romp\`)"
+    _romp_cmd "romp mail ..."              romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
+    _romp_cmd "romp send <session> <text>" -            "Hand a session a message (kernel API, either backend)"
+    _romp_cmd "romp interrupt <session>"   -            "Interrupt a session's current turn"
+    _romp_cmd "romp end <session>"         -            "End a session"
+    _romp_cmd "romp checkin <host>"        -            "Publish this machine to an attached hub (romp checkout withdraws)"
+    _romp_cmd "romp default-dir [PATH]"    -            "Default working dir for new sessions (no arg prints; \"\" clears)"
+    _romp_cmd "romp debug [on|off|status]" -            "Judge debug mode (rejection rows carry full input+reply)"
     exit 0
 fi
 
-# Live session monitor. Spelled `-d` (not a `dashboard` subcommand) so the word
-# "dashboard" stays free as a session name — `romp dashboard` makes a session
-# called dashboard. Matched only as the FIRST arg, like the other dispatches.
-if [[ "${1:-}" == "-d" ]]; then
+# Live session monitor, `romp monitor` — the terminal one; the browser dashboard
+# is bare `romp`. Matched only as the FIRST arg, like the other dispatches.
+if [[ "${1:-}" == "monitor" ]]; then
     # ROMP_DASHBOARD_BIN: test seam (same pattern as the kernel's
     # ROMP_FEED_DETAIL_BIN) — the sibling-dir PATH prepend above otherwise
     # shadows any mock, and the real dashboard is an infinite watch loop
@@ -619,47 +621,47 @@ fi
 
 # Feed — terminal Working/Blocked/Completed board: a lightweight, kernel-independent
 # mirror of the web feed. It re-reads the goal stores and re-implements the rollup
-# itself, so it doubles as a cross-check on the kernel/judge render path. Spelled
-# `-f` for the same reason as `-d`. Flags pass through (e.g. `romp -f --all`,
-# `romp -f --session NAME`, `romp -f --no-color`). ^C to stop.
-if [[ "${1:-}" == "-f" ]]; then
+# itself, so it doubles as a cross-check on the kernel/judge render path. Flags pass
+# through (e.g. `romp feed --all`, `romp feed --session NAME`, `romp feed --no-color`).
+# ^C to stop.
+if [[ "${1:-}" == "feed" ]]; then
     shift
     exec romp-feed "$@"
 fi
 
 # Judges health monitor — live "are the judges keeping up + are they throwing
 # exceptions" view. Independent of the kernel (re-reads the judge state files +
-# manager.log + a /version probe), same cross-check spirit as `-f`. Spelled `-j`
-# for the same reason as `-d`/`-f`. Flags pass through (`romp -j --once|--json`).
+# manager.log + a /version probe), same cross-check spirit as the feed. Flags pass
+# through (`romp judges --once|--json`).
 # ROMP_JUDGE_MONITOR_BIN is the test seam (the live TUI is an infinite loop — same
 # pattern as ROMP_DASHBOARD_BIN, so romp.bats can mock it without hanging).
-if [[ "${1:-}" == "-j" ]]; then
+if [[ "${1:-}" == "judges" ]]; then
     shift
     exec "${ROMP_JUDGE_MONITOR_BIN:-romp-judge-monitor}" "$@"
 fi
 
-# Romp Postal Service — peer messaging between romp sessions. Double-dash because
-# it's a scripting/agent entrypoint, not an everyday command (and agents usually
-# use the MCP tools). Delegates to romp-postal-service, same pattern as `-d` -> dashboard.
-if [[ "${1:-}" == "--mail" ]]; then
+# Romp Postal Service — peer messaging between romp sessions. A scripting/agent
+# entrypoint (agents usually use the MCP tools). Delegates to romp-postal-service.
+# `--mail` stays as a SILENT alias: reply footers in already-delivered mail name
+# it, and delivered text can't be re-issued.
+if [[ "${1:-}" == "mail" || "${1:-}" == "--mail" ]]; then
     shift
-    # ROMP_POSTAL_BIN: test seam — see the -d dispatch above.
+    # ROMP_POSTAL_BIN: test seam — see the monitor dispatch above.
     exec "${ROMP_POSTAL_BIN:-romp-postal-service}" "$@"
 fi
 
-# `romp --version` — what's running across the moving parts (working tree, kernel /version, bundles
+# `romp version` — what's running across the moving parts (working tree, kernel /version, bundles
 # served vs on disk). Delegates to romp-version (python); quick, non-watch, so no test seam needed.
-if [[ "${1:-}" == "--version" ]]; then
+# `--version` stays as an alias: it's the one flag every CLI answers.
+if [[ "${1:-}" == "version" || "${1:-}" == "--version" ]]; then
     exec romp-version
 fi
 
-# `romp --update [host...]` — PUSH this machine's committed romp to attached REMOTE kernels + restart them,
+# `romp update [host...]` — PUSH this machine's committed romp to attached REMOTE kernels + restart them,
 # so they run exactly the local code (the user 2026-07-04: peer-to-peer, no GitHub). No host → every
 # out-of-date attached remote. Delegates to romp-update (python), which asks the LOCAL kernel to git-push
-# local HEAD over ssh + restart. Dash-only since 2026-07-25: the bare word names a session like any other
-# (the retired-word notice below the dispatches covers the old spelling). To update THIS machine:
-# `git pull`/checkout then `romp --refresh`.
-if [[ "${1:-}" == "--update" ]]; then
+# local HEAD over ssh + restart. To update THIS machine: `git pull`/checkout then `romp refresh`.
+if [[ "${1:-}" == "update" ]]; then
     shift
     exec romp-update "$@"
 fi
@@ -672,28 +674,28 @@ _romp_token() {
     cat "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/serve-token" 2>/dev/null || true
 }
 
-# `romp --url` — print the tokened dashboard URL, nothing else (scripting/piping; `romp -l` is the
+# `romp url` — print the tokened dashboard URL, nothing else (scripting/piping; bare `romp` is the
 # human entry point). The first open seeds a year-long cookie; after that the bare URL works.
-if [[ "${1:-}" == "--url" ]]; then
+# `--url` stays as a silent alias (agent-facing text names it).
+if [[ "${1:-}" == "url" || "${1:-}" == "--url" ]]; then
     _tok="$(_romp_token)"
     if [[ -z "$_tok" ]]; then
-        echo "romp --url: no serve token yet (start romp first — the kernel mints it)" >&2; exit 1
+        echo "romp url: no serve token yet (start romp first — the kernel mints it)" >&2; exit 1
     fi
     echo "http://127.0.0.1:${ROMP_KERNEL_PORT:-29855}/?token=$_tok"
     exit 0
 fi
 
-# `romp -l` / `--launch` — THE first-run entry point (the user 2026-07-22, who wanted one command
-# instead of copying a token by hand). Jupyter's flow: print the tokened URL, then TRY to open a
-# browser on it. Both, always — the print is the contract (it always works, and you can copy it), the
-# open is the convenience (it may not be possible). On a remote/headless box (ssh, no DISPLAY, no
-# opener) it doesn't pretend: it prints the URL plus the two ways to actually reach it from your
-# laptop. Dash-only since 2026-07-25 (`romp launch` names a session; the bare `open` alias is gone).
-if [[ "${1:-}" == "-l" || "${1:-}" == "--launch" ]]; then
+# Bare `romp` — THE front door (the user 2026-07-25: the shortest command does the most common
+# thing). Jupyter's flow: print the tokened URL, then TRY to open a browser on it. Both, always —
+# the print is the contract (it always works, and you can copy it), the open is the convenience
+# (it may not be possible). On a remote/headless box (ssh, no DISPLAY, no opener) it doesn't
+# pretend: it prints the URL plus the two ways to actually reach it from your laptop.
+if [[ $# -eq 0 ]]; then
     _tok="$(_romp_token)"
     _kport="${ROMP_KERNEL_PORT:-29855}"
     if [[ -z "$_tok" ]]; then
-        echo "romp -l: no serve token yet; start romp first (\`romp --on\`), then re-run." >&2
+        echo "romp: no serve token yet; the kernel mints it. Is romp running? (the login service starts it; \`romp up\` runs it by hand)" >&2
         exit 1
     fi
     _url="http://127.0.0.1:$_kport/?token=$_tok"
@@ -738,42 +740,42 @@ if [[ "${1:-}" == "-l" || "${1:-}" == "--launch" ]]; then
     exit 0
 fi
 
-# `romp --checkin <host>` / `romp --checkout <host>` — publish THIS machine to an attached hub over
+# `romp checkin <host>` / `romp checkout <host>` — publish THIS machine to an attached hub over
 # our own outbound ssh (peer-bus check-in, plans/postal-peer-buses.md stage 3), or withdraw it. The
 # plumbing behind the network popover's keep-connected checkbox; the host must be attached first.
-# Dash-only since 2026-07-25: the bare words name sessions like any other.
-if [[ "${1:-}" =~ ^--(checkin|checkout)$ ]]; then
-    _verb="${1#--}"; shift
+if [[ "${1:-}" =~ ^(checkin|checkout)$ ]]; then
+    _verb="$1"; shift
     _host="${1:-}"
-    if [[ -z "$_host" ]]; then echo "usage: romp --$_verb <host>" >&2; exit 2; fi
+    if [[ -z "$_host" ]]; then echo "usage: romp $_verb <host>" >&2; exit 2; fi
     _kport="${ROMP_KERNEL_PORT:-29855}"
     _on="false"; [[ "$_verb" == "checkin" ]] && _on="true"
     _resp="$(curl -sf -m 10 -X POST "http://127.0.0.1:$_kport/tunnels/checkin" \
                   -H "X-Romp-Token: $(_romp_token)" \
                   -H 'Content-Type: application/json' -d "{\"host\": \"$_host\", \"on\": $_on}")" \
-        || { echo "romp --$_verb: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+        || { echo "romp $_verb: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
-        echo "romp --$_verb: ok ($_host)"
+        echo "romp $_verb: ok ($_host)"
         exit 0
     fi
-    echo "romp --$_verb: kernel refused: $_resp" >&2
+    echo "romp $_verb: kernel refused: $_resp" >&2
     exit 1
 fi
 
-# `romp --send|--interrupt|--end <session> [text]` — headless session control through the kernel HTTP
+# `romp send|interrupt|end <session> [text]` — headless session control through the kernel HTTP
 # API (the kernel owns the transport and routes to whichever backend drives the session, tmux or SDK).
 # Before this, interrupt/end existed only as browser WS ops: a session could be FED headlessly but
-# never STOPPED (2026-07-05). Dash-only since 2026-07-25: the bare words name sessions like any other.
-# Exit 0 only when the kernel acked ok — a dead kernel or unknown session fails LOUDLY, never silently.
-if [[ "${1:-}" =~ ^--(send|interrupt|end)$ ]]; then
+# never STOPPED (2026-07-05). The dashed spellings stay as SILENT aliases (agent-facing text
+# delivered before 2026-07-25 names them). Exit 0 only when the kernel acked ok — a dead kernel or
+# unknown session fails LOUDLY, never silently.
+if [[ "${1:-}" =~ ^(--)?(send|interrupt|end)$ ]]; then
     _verb="${1#--}"; shift
     _who="${1:-}"
-    if [[ -z "$_who" ]]; then echo "usage: romp --$_verb <session> $([[ "$_verb" == send ]] && echo '<text>')" >&2; exit 2; fi
+    if [[ -z "$_who" ]]; then echo "usage: romp $_verb <session> $([[ "$_verb" == send ]] && echo '<text>')" >&2; exit 2; fi
     shift
     _kport="${ROMP_KERNEL_PORT:-29855}"
     if [[ "$_verb" == "send" ]]; then
         _text="$*"
-        if [[ -z "$_text" ]]; then echo "usage: romp --send <session> <text>" >&2; exit 2; fi
+        if [[ -z "$_text" ]]; then echo "usage: romp send <session> <text>" >&2; exit 2; fi
         _payload="$(python3 -c 'import json,sys; print(json.dumps({"name": sys.argv[1], "text": sys.argv[2]}))' "$_who" "$_text")"
     else
         _payload="$(python3 -c 'import json,sys; print(json.dumps({"name": sys.argv[1]}))' "$_who")"
@@ -781,20 +783,20 @@ if [[ "${1:-}" =~ ^--(send|interrupt|end)$ ]]; then
     _resp="$(curl -sf -m 10 -X POST "http://127.0.0.1:$_kport/$_verb" \
                   -H "X-Romp-Token: $(_romp_token)" \
                   -H 'Content-Type: application/json' -d "$_payload")" \
-        || { echo "romp --$_verb: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+        || { echo "romp $_verb: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
-        echo "romp --$_verb: ok ($_who)"
+        echo "romp $_verb: ok ($_who)"
         exit 0
     fi
-    echo "romp --$_verb: kernel refused: $_resp" >&2
+    echo "romp $_verb: kernel refused: $_resp" >&2
     exit 1
 fi
 
-# `romp --default-dir [PATH]` — the default working directory for NEW sessions (what the picker prefills).
+# `romp default-dir [PATH]` — the default working directory for NEW sessions (what the picker prefills).
 # Persisted to ~/.config/romp/default-dir, read FIRST by the kernel's _default_create_dir() (before the
 # install/serve default), so the gear dialog and this CLI share one source of truth. No arg prints the
 # current value; an empty arg ("") clears it (revert to the install/serve default). Read live — no restart.
-if [[ "${1:-}" == "--default-dir" ]]; then
+if [[ "${1:-}" == "default-dir" ]]; then
     _dd_file="$HOME/.config/romp/default-dir"
     if [[ $# -lt 2 ]]; then
         if [[ -s "$_dd_file" ]]; then cat "$_dd_file"; else echo "(unset — using the install/serve default)"; fi
@@ -805,7 +807,7 @@ if [[ "${1:-}" == "--default-dir" ]]; then
         exit 0
     fi
     _dd="${2/#\~/$HOME}"
-    _dd="$(cd "$_dd" 2>/dev/null && pwd -P)" || { echo "romp --default-dir: not a directory: $2" >&2; exit 1; }
+    _dd="$(cd "$_dd" 2>/dev/null && pwd -P)" || { echo "romp default-dir: not a directory: $2" >&2; exit 1; }
     mkdir -p "$(dirname "$_dd_file")"
     printf '%s\n' "$_dd" > "$_dd_file"
     echo "default new-session dir set to: $_dd"
@@ -818,12 +820,12 @@ fi
 # access rides tailnet device auth + TLS rather than a token in a URL.
 # See docs/guide/remote-access.md.
 
-# ── romp --debug [on|off|status]: judge debug mode ──────────────────────────────
+# ── romp debug [on|off|status]: judge debug mode ────────────────────────────────
 # When on, every judge-failure row in judge-errors.jsonl carries the failing call's
 # full input + reply, and the feed joins those rows onto each card: the card modal
 # grows a "Warnings (debug)" section showing every rejection as it happens (the user
 # 2026-07-09). Read live by the kernel + judge (mtime-cached) — no restart needed.
-if [[ "${1:-}" == "--debug" ]]; then
+if [[ "${1:-}" == "debug" ]]; then
     shift
     _dbg_conf="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/debug-mode.json"
     case "${1:-status}" in
@@ -841,25 +843,24 @@ if [[ "${1:-}" == "--debug" ]]; then
                 echo "debug mode: off"
             fi ;;
         *)
-            echo "usage: romp --debug [on|off|status]" >&2; exit 2 ;;
+            echo "usage: romp debug [on|off|status]" >&2; exit 2 ;;
     esac
     exit 0
 fi
 
-# Kernel-MANAGER control flags. The manager (bin/romp-manager) is the thin, durable supervisor you
-# launch yourself, à la `jupyter lab`: it owns + supervises the romp kernel(s); front ends (VS Code,
-# the web dashboard, Obsidian) ATTACH rather than spawn. `romp --on` is PURELY "start the manager" — the
-# actions are their OWN flags, none hidden under `romp --on` (the user 2026-06-13):
-#   romp --on        run the manager in the foreground (Ctrl+C stops it AND its kernels)
-#   romp --refresh   restart EVERYTHING — the postal bus AND every kernel (picks up new code after an update)
-#   romp --status    manager + kernel status
-# No `romp --down`: `romp --on` is foreground, so Ctrl+C stops it (the user 2026-06-13). The manager still
-# honors SIGINT/SIGTERM + a direct /stop for that path — there's just no romp flag for it.
-# GNU-style long flags, NOT bare words, so every bare argument stays free to name a session (the user
-# 2026-06-16). ROMP_MANAGER_BIN is the test seam (same pattern as ROMP_DASHBOARD_BIN / ROMP_POSTAL_BIN).
+# Kernel-MANAGER commands. The manager (bin/romp-manager) is the thin, durable supervisor — normally
+# the login service runs it (romp-service; installed by install.sh), and front ends (VS Code, the web
+# dashboard, Obsidian) ATTACH rather than spawn. `romp up` is PURELY "run the manager, foreground" —
+# the actions are their OWN commands, none hidden under it (the user 2026-06-13):
+#   romp up          run the manager in the foreground (Ctrl+C stops it AND its kernels; rare — the login service owns this)
+#   romp refresh     restart EVERYTHING — the postal bus AND every kernel (picks up new code after an update)
+#   romp status      manager + kernel status
+# No `romp down`: `romp up` is foreground, so Ctrl+C stops it (the user 2026-06-13). The manager still
+# honors SIGINT/SIGTERM + a direct /stop for that path — there's just no romp command for it.
+# ROMP_MANAGER_BIN is the test seam (same pattern as ROMP_DASHBOARD_BIN / ROMP_POSTAL_BIN).
 case "${1:-}" in
-    --on)      exec "${ROMP_MANAGER_BIN:-romp-manager}" up ;;
-    --refresh) # restart EVERYTHING (the user 2026-06-29): the postal bus too, not just the kernels — the bus
+    up)        exec "${ROMP_MANAGER_BIN:-romp-manager}" up ;;
+    refresh)   # restart EVERYTHING (the user 2026-06-29): the postal bus too, not just the kernels — the bus
                # is a separate long-lived singleton the manager doesn't own, so a kernel-only refresh left it
                # serving stale code. Bounce the bus first (best-effort), then exec the kernel restart.
                #
@@ -890,10 +891,10 @@ PYEOF
                } 2>/dev/null || true
                "${ROMP_POSTAL_BIN:-romp-postal-service}" restart >/dev/null 2>&1 || true
                # Deploys defer to the next quiet window (no SDK turn in flight) so a peer's
-               # refresh never cuts another session's turn; `romp --refresh --now` forces the
+               # refresh never cuts another session's turn; `romp refresh --now` forces the
                # old immediate bounce (the manager coalesces everything queued meanwhile).
                exec "${ROMP_MANAGER_BIN:-romp-manager}" restart-all "${2:-}" ;;
-    --status)  exec "${ROMP_MANAGER_BIN:-romp-manager}" status ;;
+    status)    exec "${ROMP_MANAGER_BIN:-romp-manager}" status ;;
 esac
 
 # NB: there's no `romp rename` / `romp a` command. Rename from inside tmux
@@ -901,79 +902,171 @@ esac
 # `romp _renamed` (above), which resyncs the picker map + Claude's pill. Attach
 # with plain `tmux a`.
 
-# --- Retired bare commands (2026-07-25) ---
-# These eight words used to dispatch commands, which silently broke the CLI's one
-# rule: `romp <word>` with no leading dash names a session (the user 2026-07-24).
-# They are session names now. Because fingers and old scripts still type the old
-# spellings, say where each command went: with no other args, one stderr line and
-# then proceed per the rule; with args (an old command invocation, never a valid
-# session launch), fail loudly naming the new spelling. Permanent and exact-match,
-# not a deprecation window. `_renamed`/`_color` stay reserved: internal tmux-hook
-# entrypoints (a live tmux server holds the old hook string until it restarts).
-_romp_retired_hint() {
+# --- Retired spellings (2026-07-25): commands are bare words now ---
+# Two grammar flips inside one day: PR #20 made every dashless word a session
+# name (commands moved behind dashes); the user then flipped the priority — the
+# most-typed things deserve the bare words, git-style, and session names moved
+# behind `romp new` where they can never collide with a command. The dashed
+# command spellings from that brief era (and the old short view flags) fail
+# loudly naming today's word. Exception, handled in the dispatches above:
+# agent-facing spellings (--mail/--url/--send/--interrupt/--end/--resume and
+# --version) keep working silently — reply footers in already-delivered postal
+# mail name them, and delivered text can't be re-issued. `_renamed`/`_color`
+# stay reserved: internal tmux-hook entrypoints (a live tmux server holds the
+# old hook string until it restarts).
+_romp_retired_flag_hint() {
     case "$1" in
-        launch|open) echo "the dashboard is now: romp -l" ;;
-        update)      echo "the remote update is now: romp --update [host]" ;;
-        checkin)     echo "the check-in is now: romp --checkin <host>" ;;
-        checkout)    echo "the checkout is now: romp --checkout <host>" ;;
-        send)        echo "the command is now: romp --send <session> <text>" ;;
-        interrupt)   echo "the command is now: romp --interrupt <session>" ;;
-        end)         echo "the command is now: romp --end <session>" ;;
-        *)           return 1 ;;
+        -l|--launch)   echo "the dashboard is now just: romp" ;;
+        -d)            echo "the terminal monitor is now: romp monitor (-d is romp new's directory option)" ;;
+        -f)            echo "the feed is now: romp feed" ;;
+        -j)            echo "the judge monitor is now: romp judges" ;;
+        -r)            echo "the resume picker is now: romp resume" ;;
+        --on)          echo "the foreground manager is now: romp up" ;;
+        --refresh)     echo "the fleet restart is now: romp refresh" ;;
+        --status)      echo "the status report is now: romp status" ;;
+        --update)      echo "the remote update is now: romp update [host]" ;;
+        --checkin)     echo "the check-in is now: romp checkin <host>" ;;
+        --checkout)    echo "the checkout is now: romp checkout <host>" ;;
+        --default-dir) echo "the setting is now: romp default-dir [PATH]" ;;
+        --debug)       echo "debug mode is now: romp debug [on|off|status]" ;;
+        *)             return 1 ;;
     esac
 }
-if _retired_hint="$(_romp_retired_hint "${1:-}")"; then
-    if [[ $# -gt 1 ]]; then
-        echo "romp: \"$1\" is a session name now; $_retired_hint" >&2
-        exit 2
-    fi
-    echo "romp: starting a session named \"$1\"; $_retired_hint" >&2
+if _retired="$(_romp_retired_flag_hint "${1:-}")"; then
+    echo "romp: \"$1\" was retired; $_retired" >&2
+    exit 2
 fi
 
-# --- Argument parsing ---
-# Optional positional session name; an optional resume directive (-r for humans,
-# --resume for scripts/agents) optionally followed by a session id (UUID) to
-# resume that specific conversation; and --detach to create the session without
-# attaching (prints how to attach instead). NB: --detach has no `-d` short form
-# — `-d` is the dashboard (see dispatch above).
+# --- new / resume: the two commands that reach the launcher below ---
+# Everything else either dispatched above or is an error here: an unknown bare
+# word is NEVER silently a session (nor a typo'd command doing nothing) — it
+# fails naming both readings.
 session_arg=""
 resume=false
 resume_id=""
 detach=false
+dir_arg=""
+use_tmux=false
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        -r|--resume)
+case "${1:-}" in
+    new)
+        shift
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                -t|--tmux) use_tmux=true; shift ;;
+                --detach)  detach=true; shift ;;
+                -d)        shift
+                           if [[ $# -eq 0 || "$1" == -* ]]; then
+                               echo "usage: romp new [-t] [-d <dir>] <name>" >&2; exit 2
+                           fi
+                           dir_arg="$1"; shift ;;
+                -*)        echo "romp new: unknown option: $1" >&2; exit 2 ;;
+                *)         if [[ -n "$session_arg" ]]; then
+                               echo "usage: romp new [-t] [-d <dir>] <name>" >&2; exit 2
+                           fi
+                           session_arg="$1"; shift ;;
+            esac
+        done
+        if [[ -z "$session_arg" ]]; then
+            echo "usage: romp new [-t] [-d <dir>] <name>" >&2; exit 2
+        fi
+        ;;
+    resume|--resume)
+        # `romp resume` — our full-screen picker; `romp resume <id>` — an exact
+        # conversation UUID (scripts/agents; also the postal revive path).
+        # --name pins the session name (the kernel's reviver passes the recorded
+        # one; without it an explicit-id resume is named after the folder).
+        shift
+        resume=true
+        if [[ $# -gt 0 && "$1" != -* ]]; then
+            resume_id="$1"; shift
+        fi
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --detach) detach=true; shift ;;
+                --name)   shift
+                          if [[ $# -eq 0 || "$1" == -* ]]; then
+                              echo "usage: romp resume [<conversation-id>] [--name <name>] [--detach]" >&2; exit 2
+                          fi
+                          session_arg="$1"; shift ;;
+                *)        echo "usage: romp resume [<conversation-id>] [--name <name>] [--detach]" >&2; exit 2 ;;
+            esac
+        done
+        ;;
+    --detach)
+        # Old-kernel compat shim (SILENT): a kernel on pre-round-3 code spawns
+        # dashboard tmux sessions as `romp --detach <name>` (and its spawn path
+        # swallows stderr, so a loud error here would fail INVISIBLY). Keep the
+        # shape working until every kernel restarts onto new code.
+        if [[ -n "${2:-}" && "${2:-}" != -* && $# -eq 2 ]]; then
+            use_tmux=true; detach=true; session_arg="$2"; shift 2
+        else
+            echo "romp: \"--detach\" is an option of new/resume now: romp new -t --detach <name>" >&2
+            exit 2
+        fi
+        ;;
+    -*)
+        echo "romp: unknown option: $1" >&2
+        exit 2
+        ;;
+    *)
+        # Old-kernel compat shim (SILENT), before the unknown-command error: the
+        # pre-round-3 reviver runs `romp <name> --resume <sid> --detach` — a bare
+        # positional name. Only that exact shape passes; anything else without
+        # `--resume` in its arguments is an unknown command.
+        if [[ " ${*:2} " == *" --resume "* ]]; then
+            session_arg="$1"; shift
             resume=true
-            shift
-            # An explicit session id may follow the resume directive.
-            if [[ $# -gt 0 && "$1" != -* ]]; then
-                resume_id="$1"
-                shift
-            fi
-            ;;
-        --detach)
-            detach=true
-            shift
-            ;;
-        -*)
-            echo "Unknown option: $1" >&2
-            exit 1
-            ;;
-        *)
-            if [[ -z "$session_arg" ]]; then
-                session_arg="$1"
-                shift
-            else
-                echo "Unexpected argument: $1" >&2
-                exit 1
-            fi
-            ;;
-    esac
-done
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    --resume) shift
+                              if [[ $# -gt 0 && "$1" != -* ]]; then resume_id="$1"; shift; fi ;;
+                    --detach) detach=true; shift ;;
+                    *)        echo "usage: romp resume [<conversation-id>] [--name <name>] [--detach]" >&2; exit 2 ;;
+                esac
+            done
+        else
+            echo "romp: unknown command \"$1\". To start a session named \"$1\": romp new $1   (commands: romp help)" >&2
+            exit 2
+        fi
+        ;;
+esac
+
+# --- `romp new` default: an SDK session, created in the kernel ---
+# The recommended backend (docs/sdk-backend.md): the session runs inside the
+# kernel and is driven from the dashboard / VS Code, so there is no terminal to
+# attach — create it over the kernel API and say where to look. `-t` is the
+# terminal variant: the tmux launcher below, attached, exactly the old flow.
+# No silent fallback in either direction: a dead kernel or an unavailable SDK
+# backend fails loudly naming both fixes (start romp, or -t).
+if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
+    _tok="$(_romp_token)"
+    _kport="${ROMP_KERNEL_PORT:-29855}"
+    _dir="${dir_arg:-$PWD}"
+    if [[ -z "$_tok" ]]; then
+        echo "romp new: the kernel isn't running (no serve token). Start romp (the login service, or \`romp up\`), or use \`romp new -t $session_arg\` for a terminal session." >&2
+        exit 1
+    fi
+    _payload="$(python3 -c 'import json,sys; print(json.dumps({"name": sys.argv[1], "dir": sys.argv[2], "backend": "sdk"}))' "$session_arg" "$_dir")"
+    _resp="$(curl -sf -m 15 -X POST "http://127.0.0.1:$_kport/new" \
+                  -H "X-Romp-Token: $_tok" \
+                  -H 'Content-Type: application/json' -d "$_payload")" \
+        || { echo "romp new: kernel not reachable on :$_kport (is romp running?). \`romp new -t $session_arg\` starts a terminal session without it." >&2; exit 1; }
+    if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
+        if [[ "$_resp" == *'"existing"'* ]]; then
+            echo "romp new: \"$session_arg\" is already running; see the dashboard (romp)"
+        else
+            echo "romp new: started \"$session_arg\" (SDK session, working in $_dir)"
+            echo "romp new: watch it on the dashboard: romp"
+        fi
+        exit 0
+    fi
+    echo "romp new: kernel refused: $_resp" >&2
+    exit 1
+fi
 
 # --- Custom name-based resume picker ----------------------------------------
-# `romp -r` (without an explicit session id) shows OUR full-screen picker of
+# `romp resume` (without an explicit session id) shows OUR full-screen picker of
 # resumable named sessions instead of Claude's auto-summary picker. Picking one
 # sets the conversation id to resume, the session name to reuse, and the
 # directory to resume it in. Cancelling (Esc / q / Ctrl-C) or having nothing to
@@ -991,14 +1084,15 @@ fi
 # symlinked launch dir (e.g. ~/Vault → ~/GitRepos/Vault) would make every
 # path-munging consumer (summary backfill, digest) look in a dir that doesn't
 # exist — no summaries for that session. `pwd -P` gives the real path.
-work_dir="${picked_dir:-$PWD}"
+# Precedence: an explicit `-d` wins, then the picker's recorded dir, then here.
+work_dir="${dir_arg:-${picked_dir:-$PWD}}"
 work_dir="$(cd "$work_dir" 2>/dev/null && pwd -P || printf '%s' "$work_dir")"
 
 # Never launch a session in $HOME. A romp session indexes its working-directory
 # tree, and $HOME is the one cwd whose direct children include the macOS
 # TCC-protected Downloads/Desktop/Documents — so indexing them makes Claude
 # (node) trip a stream of spurious "wants to access your Downloads" OS prompts.
-# Redirect a $HOME launch (a bare `romp` from home, OR resuming a session that
+# Redirect a $HOME launch (`romp new` run from home, OR resuming a session that
 # was recorded there) to ROMPHOME, which defaults to the romp install dir.
 # Compare physical-to-physical: on macOS $HOME can sit under a symlinked mount
 # (e.g. a test $HOME under /var → /private/var), so `pwd -P` both sides.
@@ -1247,8 +1341,8 @@ fi
 # so quitting it ends the session. Signal the caller to close the terminal tab:
 # the romp zsh wrapper turns exit code 77 into a shell `exit`, so ghostty closes
 # the tab. Detaching (prefix-d) leaves the session alive, so this is skipped and
-# the tab stays open. Opt-in via ROMP_CLOSE_ON_END so a bare `romp` (or the test
-# harness) without the wrapper is unaffected.
+# the tab stays open. Opt-in via ROMP_CLOSE_ON_END so a plain `romp new -t` (or
+# the test harness) without the wrapper is unaffected.
 if [[ -n "${ROMP_CLOSE_ON_END:-}" ]] && ! $detach && [[ -z "${TMUX:-}" ]] \
    && ! tmux has-session -t "=$name" 2>/dev/null; then
     exit 77

--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -149,7 +149,7 @@ function idForPort(port) {
 }
 
 // ── manager self-staleness (the --refresh stale-manager incident, the user 2026-07-24) ────────────
-// `romp --refresh` restarts kernels but never this process, and a long-lived manager hands every
+// `romp refresh` restarts kernels but never this process, and a long-lived manager hands every
 // respawn its START-TIME defaults — after the port renumber the file on disk was right and every
 // kernel still came back on the old port, with everything REPORTING success. Detect it: stamp this
 // file at start; on a refresh, a changed stamp means the respawned kernels would inherit stale
@@ -170,7 +170,7 @@ const QUICK_CRASH_MS = 2000;
 const MAX_BACKOFF_MS = 10000;
 
 // Restart-storm guard (the user 2026-06-24): the kernel was SIGTERM'd + respawned 300+ times in a tight
-// loop because every /restart restarted 1:1 — concurrent `romp --refresh`es (heavy fleet kernel work) or a
+// loop because every /restart restarted 1:1 — concurrent `romp refresh`es (heavy fleet kernel work) or a
 // stray refresh loop translate straight into respawns, churning every webview (a full reload) + orphaning
 // SDK in-flight state. Cap it: coalesce near-simultaneous requests into ONE trailing restart, and once the
 // rate looks like a storm, hold to 1 restart per cooldown + log loudly so the trigger is visible.
@@ -179,7 +179,7 @@ const STORM_WINDOW_MS = 60000;        // sliding window for storm detection
 const STORM_MAX = 8;                  // ≥ this many restarts in the window = a storm
 const STORM_COOLDOWN_MS = 30000;      // during a storm, hold to 1 restart per this
 
-// Quiet-window deploy refreshes (the user 2026-07-20): peers deploying with `romp --refresh` bounced
+// Quiet-window deploy refreshes (the user 2026-07-20): peers deploying with `romp refresh` bounced
 // the kernel 11x in one day, and every bounce cuts whatever SDK turns are in flight (the drain
 // interrupts them; the next boot resumes them with a nudge — recoverable, but each cut costs the
 // model a full re-read and the user a working-session hiccup). A refresh is a DEPLOY, not an
@@ -268,7 +268,7 @@ function restartKernel(id) {
   rec._rs.history = g.history;
   if (g.action === 'coalesce') {     // too soon — a single trailing restart will pick up the latest code
     if (g.inStorm && !rec._stormLogged) {
-      log(`kernel '${id}': RESTART STORM — ${rec._rs.history.length}+ restarts in ${STORM_WINDOW_MS / 1000}s; holding to 1 per ${STORM_COOLDOWN_MS / 1000}s + this log. Something is spamming /restart (a refresh loop / concurrent \`romp --refresh\`?).`);
+      log(`kernel '${id}': RESTART STORM — ${rec._rs.history.length}+ restarts in ${STORM_WINDOW_MS / 1000}s; holding to 1 per ${STORM_COOLDOWN_MS / 1000}s + this log. Something is spamming /restart (a refresh loop / concurrent \`romp refresh\`?).`);
       rec._stormLogged = true;
     }
     if (!rec._pending) rec._pending = setTimeout(() => { rec._pending = null; restartKernel(id); }, Math.max(50, g.scheduleIn));
@@ -505,7 +505,7 @@ function ensureUp() {
 module.exports = { restartGate, quietGate, loadSpecs, specEnv, fileStamp };
 if (require.main === module) {
   const cmd = process.argv[2];
-  // `restart-all` (the `romp --refresh` deploy path) defers to the next quiet window by default —
+  // `restart-all` (the `romp refresh` deploy path) defers to the next quiet window by default —
   // `--now` keeps the old immediate bounce for emergencies/humans in a hurry.
   if (cmd === 'restart') control('POST', '/restart', process.argv[3]);
   else if (cmd === 'restart-all') control('POST', '/restart-all', null,

--- a/bin/romp-service
+++ b/bin/romp-service
@@ -112,7 +112,7 @@ ensure_romp_node() {
 
 # Install attribution (2026-07-20): four times in one day the agent was rewritten/unloaded and the
 # reload never landed — and the failure, though loud on the CALLER's stderr, left no trace saying
-# WHO ran the install. Append who/where/when to the same audit journal `romp --refresh` writes, so
+# WHO ran the install. Append who/where/when to the same audit journal `romp refresh` writes, so
 # "who reinstalled the service?" is one tail instead of forensics. Best-effort, never blocks.
 audit_install() {
     {

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -86,4 +86,4 @@ fi
 
 echo
 echo "romp is installed at $DIR"
-echo "Open a new terminal (or 'source' your shell rc), then run:  romp -l"
+echo "Open a new terminal (or 'source' your shell rc), then run:  romp"

--- a/claude/skills/romp-postal/SKILL.md
+++ b/claude/skills/romp-postal/SKILL.md
@@ -14,11 +14,11 @@ Message sibling sessions with the postal MCP tools (each tool's own description 
 
 Addressing is live-only: you can message only currently-live sessions (see `list_agents`). Dead names error, with no parked mail or reviving.
 
-From the shell (also how the human drives it): `romp --mail send <name> "<text>"`, `romp --mail inbox|agents|sent`, `romp --mail working "<note>"`, `romp --mail recall <name> [id]`.
+From the shell (also how the human drives it): `romp mail send <name> "<text>"`, `romp mail inbox|agents|sent`, `romp mail working "<note>"`, `romp mail recall <name> [id]`.
 
 ## On a remote machine
 
-If you SSH'd into another machine and are running romp there, run `romp --mail remote` to connect it to the laptop's bus. It configures the remote side and prints the one tunnel command to run from the laptop (an `ssh -R` reverse forward, or a `~C` escape on the open connection), then auto-detects when it connects. Messaging before this setup nudges you to run it.
+If you SSH'd into another machine and are running romp there, run `romp mail remote` to connect it to the laptop's bus. It configures the remote side and prints the one tunnel command to run from the laptop (an `ssh -R` reverse forward, or a `~C` escape on the open connection), then auto-detects when it connects. Messaging before this setup nudges you to run it.
 
 ## Norms
 

--- a/claude/skills/romp/SKILL.md
+++ b/claude/skills/romp/SKILL.md
@@ -37,9 +37,9 @@ continuation, then the user exits the original window.
 
    ```bash
    if [[ -n "${CLAUDE_CODE_SESSION_ID:-}" ]]; then
-       romp --resume "$CLAUDE_CODE_SESSION_ID" --detach
+       romp resume "$CLAUDE_CODE_SESSION_ID" --detach
    else
-       romp --resume --detach   # fall back to the picker if the id isn't set
+       romp resume --detach   # fall back to the picker if the id isn't set
    fi
    ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,13 +1,13 @@
 # cli/ — terminal tools
 
 Python implementations of the terminal-facing romp commands. Run them via
-their `bin/` symlinks (`romp -f`, `romp -j`, `romp --version`, `romp --update`)
+their `bin/` symlinks (`romp feed`, `romp judges`, `romp version`, `romp update`)
 — see `bin/README.md` for the command surface.
 
 | File | Command | What it is |
 |---|---|---|
-| `feed.py` | `romp -f` | Terminal mirror of the feed. Deliberately does NOT import the kernel/judge: it re-reads the same raw stores from scratch as an independent cross-check. |
-| `judge_monitor.py` | `romp -j` | Terminal health view of the judges. |
-| `version.py` | `romp --version` | Version report across the moving parts (working tree vs running kernel vs built bundles). |
-| `update.py` | `romp --update [host]` | Pushes this machine's committed romp to attached remote kernels over ssh and restarts them. |
+| `feed.py` | `romp feed` | Terminal mirror of the feed. Deliberately does NOT import the kernel/judge: it re-reads the same raw stores from scratch as an independent cross-check. |
+| `judge_monitor.py` | `romp judges` | Terminal health view of the judges. |
+| `version.py` | `romp version` | Version report across the moving parts (working tree vs running kernel vs built bundles). |
+| `update.py` | `romp update [host]` | Pushes this machine's committed romp to attached remote kernels over ssh and restarts them. |
 | `idle_dots.py` | (hook-fired) | tmux backend only: heals stranded `working` state by inspecting tmux panes. Fired from `hooks/tmux-status.sh`. |

--- a/cli/feed.py
+++ b/cli/feed.py
@@ -326,7 +326,7 @@ HELP = """romp-feed — live terminal mirror of the dashboard feed (independent 
 Working / blocked / completed for non-cleared goals, every node showing its raw complete/blocked
 flags + id. Prints a SINGLE scrollable snapshot by default (so you can scroll back through it); pass
 --watch for a live board that refreshes every second in the alternate screen (^C to stop). For
-build/kernel versions use `romp --version`.
+build/kernel versions use `romp version`.
 
   romp-feed                      alive sessions (one scrollable snapshot)
   romp-feed --watch              live board, refreshes every second (^C to stop)
@@ -347,14 +347,14 @@ def main(argv):
 
     def once():
         rows = build_board(state, include_dead=a["all"], session_filter=a["session"])
-        return render(rows, style, header="romp-feed · %s  (romp --version for builds)" % time.strftime("%H:%M:%S"))
+        return render(rows, style, header="romp-feed · %s  (romp version for builds)" % time.strftime("%H:%M:%S"))
 
     if not (tty and a["watch"]):                 # default (and piped): ONE scrollable snapshot.
         sys.stdout.write(once())                 # The old per-second `\033[2J\033[H` redraw fought the
         return 0                                 # terminal's own scrollback — every tick snapped the view
                                                  # back to the top. A plain print scrolls like any output.
     # --watch: live board in the ALTERNATE screen, so it owns the screen while running and restores your
-    # scrollback intact on exit (like top/htop and `romp -d`/`romp -j`) instead of clobbering the buffer.
+    # scrollback intact on exit (like top/htop and `romp monitor`/`romp judges`) instead of clobbering the buffer.
     sys.stdout.write("\033[?1049h\033[?25l")
     try:
         while True:

--- a/cli/judge_monitor.py
+++ b/cli/judge_monitor.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""romp-judge-monitor — a live terminal health view of the romp judges (`romp -j`).
+"""romp-judge-monitor — a live terminal health view of the romp judges (`romp judges`).
 
 Answers two questions at a glance, no log-spelunking:
   KEEPING UP  — is the judge producer processing units promptly, or is a backlog
@@ -21,10 +21,10 @@ recorded NOWHERE, so this view can't show them yet — only producer-level crash
 Closing that needs a small instrumentation change in romp-judge.
 
 Usage:
-  romp -j            live TUI, refreshes every few seconds (^C to quit)
-  romp -j --once     render one frame and exit (no alt-screen)
-  romp -j --json     print the computed health model as JSON and exit
-  romp -j --no-color disable ANSI colour
+  romp judges            live TUI, refreshes every few seconds (^C to quit)
+  romp judges --once     render one frame and exit (no alt-screen)
+  romp judges --json     print the computed health model as JSON and exit
+  romp judges --no-color disable ANSI colour
 """
 import json
 import os
@@ -359,7 +359,7 @@ def render(m):
             c("●", "green"), c(fmt_age(k.get("uptime_s")), "green"),
             c("sha=" + (k.get("sha") or "?"), "dim"), k.get("pid")))
     else:
-        out.append("  kernel     %s %s — is the manager up? (`romp --version` / `romp --status`)"
+        out.append("  kernel     %s %s — is the manager up? (`romp version` / `romp status`)"
                    % (c("●", "red"), c("unreachable", "red", "bold")))
 
     e = m["exceptions"]

--- a/cli/update.py
+++ b/cli/update.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """romp-update — push THIS machine's committed romp to attached REMOTE kernels + restart them
-(`romp --update [host...]`).
+(`romp update [host...]`).
 
 Peer-to-peer, no GitHub (the user 2026-07-04): the local kernel pushes its committed HEAD straight to each
 host over ssh and restarts it, so the remote runs exactly the local code — no `git pull` from origin, no round
 trip through GitHub. With NO host it updates every attached remote that is out of date (running a different
 commit than local). Uncommitted local edits are NOT sent — commit first. (To update THIS machine, use your own
-`git pull`/checkout then `romp --refresh`.)
+`git pull`/checkout then `romp refresh`.)
 """
 import json
 import os
@@ -69,21 +69,21 @@ def _post(u, path, body):
 def main(argv):
     u = _kernel()
     if not u:
-        sys.stderr.write("romp --update: no running kernel found (is romp on? try `romp --status`)\n")
+        sys.stderr.write("romp update: no running kernel found (is romp on? try `romp status`)\n")
         return 2
     hosts = [a for a in argv if not a.startswith("-")]
     if not hosts:                                                   # no host → the out-of-date attached remotes
         try:
             tuns = _get(u, "/tunnels").get("tunnels", [])
         except Exception as e:
-            sys.stderr.write("romp --update: couldn't list remotes: %s\n" % e)
+            sys.stderr.write("romp update: couldn't list remotes: %s\n" % e)
             return 2
         if not tuns:
-            sys.stdout.write("romp --update: no remotes attached (attach one from the rail's network popover).\n")
+            sys.stdout.write("romp update: no remotes attached (attach one from the rail's network popover).\n")
             return 0
         hosts = [t["host"] for t in tuns if t.get("outOfDate")]
         if not hosts:
-            sys.stdout.write("romp --update: all attached remotes are up to date.\n")
+            sys.stdout.write("romp update: all attached remotes are up to date.\n")
             return 0
     rc = 0
     for h in hosts:

--- a/cli/version.py
+++ b/cli/version.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""romp-version — what version of romp is running, across all the moving parts. `romp --version`.
+"""romp-version — what version of romp is running, across all the moving parts. `romp version`.
 
 Three things drift independently and a stale one is the usual cause of "the UI doesn't match the code":
   - the WORKING TREE (the .py/.js sources the kernel loads straight from bin/ and vscode-extension/),
   - the RUNNING KERNEL (what it last (re)started from — reported by its /version endpoint),
   - the BUILT BUNDLES on disk vs the bundle the kernel is actually serving.
-This prints all three so you can see at a glance whether a `romp --refresh` (or a browser hard-reload) is
+This prints all three so you can see at a glance whether a `romp refresh` (or a browser hard-reload) is
 owed — instead of reading restart logs. No filesystem paths are printed (privacy).
 """
 import json
@@ -77,9 +77,9 @@ def report():
                      % (k.get("kernel_sha") or "?", k.get("pid"), up // 60, up % 60,
                         k.get("dist_ver"), k.get("url")))
     elif kind == "stale":
-        lines.append("kernel   running at %s but predates /version — `romp --refresh` to populate" % k)
+        lines.append("kernel   running at %s but predates /version — `romp refresh` to populate" % k)
     else:
-        lines.append("kernel   not reachable — is the manager up? (`romp --on` / `romp --status`)")
+        lines.append("kernel   not reachable — is the manager up? (`romp up` / `romp status`)")
     served = (k.get("bundles") if kind == "version" else {}) or {}
     disk = _disk_bundles()
     lines.append("bundles  (on disk%s):" % (" / served" if served else ""))
@@ -87,7 +87,7 @@ def report():
         s = served.get(name)
         flag = ""
         if s is not None and s != mt:
-            flag = "  ⚠ disk newer than served — `romp --refresh`"
+            flag = "  ⚠ disk newer than served — `romp refresh`"
         lines.append("  %-14s %s%s" % (name, mt, flag))
     return "\n".join(lines)
 

--- a/hooks/romp-postal-context.sh
+++ b/hooks/romp-postal-context.sh
@@ -9,7 +9,7 @@
 # the postal MCP's own instructions instead. Keep this in sync with SKILL.md.
 [ "$(tmux show -v @romp 2>/dev/null)" = "1" ] || exit 0
 read -r -d '' CTX <<'TXT'
-You're in a romp session with sibling sessions you can message: use the postal MCP tools (send_message, list_agents, set_working, check_inbox, check_sent, recall_message) or `romp --mail`. Each tool's description carries its norms. Two to know up front:
+You're in a romp session with sibling sessions you can message: use the postal MCP tools (send_message, list_agents, set_working, check_inbox, check_sent, recall_message) or `romp mail`. Each tool's description carries its norms. Two to know up front:
 - Message a peer only for something substantive (it wakes them and costs a turn), leading with DELEGATE:/COORDINATE:/QUESTION: and the whole point in the first sentence.
 - BEFORE editing shared files, run list_agents and check peers' branches + working-notes to avoid collisions (overlap only collides on the same branch); publish yours with set_working.
 For the full guide (shell CLI, remote-machine tunnel setup, coordination detail), invoke the romp-postal skill.

--- a/install.sh
+++ b/install.sh
@@ -154,7 +154,7 @@ if [[ -z "${ROMP_NO_EXT:-}" && -x "$ROMP_DIR/vscode-extension/install.sh" ]]; th
 fi
 
 # Auto-start: install the login service so the kernel supervisor (romp-manager) is
-# always up — you never run `romp --on`; open the browser and you can even start
+# always up — you never run `romp up`; open the browser and you can even start
 # sessions FROM it. launchd on macOS, systemd --user on Linux. Opt out with
 # ROMP_NO_SERVICE=1; remove later with `romp-service uninstall`.
 if [[ -z "${ROMP_NO_SERVICE:-}" ]]; then
@@ -193,3 +193,36 @@ esac
 # ($ROMP_DIR) automatically; export it in your shell rc to point elsewhere.
 echo "  romp launches in ROMPHOME (default: $ROMP_DIR), never \$HOME."
 echo "  Override:  export ROMPHOME=\"/path/you/prefer\""
+
+# The finish line: the dashboard link, tokened so the first click signs this
+# browser in (the kernel token-gates every request, loopback included; the first
+# open sets a year-long cookie, after which the bare URL works). The kernel mints
+# the token moments after the login service loads, so wait for the file it
+# persists (bounded poll on the mint event's artifact; ROMP_INSTALL_TOKEN_TRIES
+# is the test seam) — and when it isn't there yet, say how to get the link
+# instead of printing one that would bounce to the login page.
+_state_dir="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}"
+_kport="${ROMP_KERNEL_PORT:-29855}"
+_tok="$(cat "$_state_dir/serve-token" 2>/dev/null || true)"
+if [[ -z "$_tok" && -z "${ROMP_NO_SERVICE:-}" ]]; then
+    for _ in $(seq 1 "${ROMP_INSTALL_TOKEN_TRIES:-40}"); do
+        sleep 0.25
+        _tok="$(cat "$_state_dir/serve-token" 2>/dev/null || true)"
+        [[ -n "$_tok" ]] && break
+    done
+fi
+echo
+if [[ -n "$_tok" ]]; then
+    echo "  romp is running. Your dashboard:"
+    echo
+    echo "      http://127.0.0.1:$_kport/?token=$_tok"
+    echo
+    echo "  Open that link in your browser: the first visit signs the browser in;"
+    echo "  after that, http://127.0.0.1:$_kport/ works on its own. Print the link"
+    echo "  again anytime:  romp url"
+elif [[ -n "${ROMP_NO_SERVICE:-}" ]]; then
+    echo "  Auto-start was skipped (ROMP_NO_SERVICE). Start romp with:  romp up"
+    echo "  then open the dashboard link:  romp url"
+else
+    echo "  romp is still starting; print the dashboard link in a moment:  romp url"
+fi

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -44,7 +44,7 @@ GOALARCHDIR = STATE / "goals-archive"    # CLEARED (dismissed) goal subtrees mov
 STATESDIR = STATE / "states"             # per-session real idle/compacting transitions → idle atoms (settled gate)
 PCACHE   = STATE / "judge-units-cache"   # (mtime,size) cache of a transcript's ready units
 MESSAGES = STATE / "timeline" / "messages.jsonl"
-ERRORS   = STATE / "judge-errors.jsonl"  # swallowed judge-call failures (parse-fails, call timeouts/exceptions) — surfaced by `romp -j`
+ERRORS   = STATE / "judge-errors.jsonl"  # swallowed judge-call failures (parse-fails, call timeouts/exceptions) — surfaced by `romp judges`
 USAGE    = STATE / "judge-usage.jsonl"   # one line per successful judge call: tokens/cost/ms — the kernel/UI roll up pipeline cost
 SDKDIR   = STATE / "sdk"                 # the SDK backend's per-session registry — lastSid tracks the CURRENT transcript fsid
 # Judge scratch cwd (the user 2026-07-20): every one-shot `claude -p` judge call writes a transcript
@@ -345,7 +345,7 @@ _DEBUG_CACHE = [None, None]                # (mtime_ns_or_None, bool) — one st
 
 
 def _debug_mode():
-    """Is debug mode on (STATE/debug-mode.json {"on": true})? Toggled by `romp --debug on|off`. When on,
+    """Is debug mode on (STATE/debug-mode.json {"on": true})? Toggled by `romp debug on|off`. When on,
     every failure row carries the failing call's full input + reply (see _log_judge_error) and the feed
     joins the rows onto each card's modal, so the user can watch rejections as they happen (the user
     2026-07-09: "error on the side of surfacing everything"). mtime-cached: one stat per check."""
@@ -373,7 +373,7 @@ def _mid_elide(s, cap=6200):
 
 
 def _log_judge_error(judge, fsid, err, note=None, goal=None, seg=None):
-    """Append one failure row to ERRORS (judge-errors.jsonl) so `romp -j` can surface it. The row contract
+    """Append one failure row to ERRORS (judge-errors.jsonl) so `romp judges` can surface it. The row contract
     (the user 2026-07-09) — every row answers who/where/what/why on its own:
       judge  who failed — the judge's own one-per-prompt name, never a tier
       fsid   where — the session it was judging ("" only for fleet-level rows like the rate gate)
@@ -6520,7 +6520,7 @@ def _unblock_session(fsid, path, now):
         if nd is None or not nd.get("blocked") or nd.get("cleared"):
             # the node moved on during the model call — resolved, cleared, or re-planned away. Never
             # apply a verdict formed against the pre-call state; surface the race so it's observable
-            # (`romp -j` / the debug feed) instead of silently dropping the lift.
+            # (`romp judges` / the debug feed) instead of silently dropping the lift.
             if why is not None:
                 _log_judge_error("unblocker", fsid, "drift-skip", goal=nid,
                                  note="node changed during the model call (resolved/cleared/re-planned) — lift skipped")

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -287,7 +287,7 @@ def _kernel_sha():
 
 def _version_info():
     """What this kernel is running — code sha + per-bundle build mtimes + pid/uptime. Lets the feed's
-    settings gear / `romp --version` / a curl tell at a glance whether the browser is on a stale bundle
+    settings gear / `romp version` / a curl tell at a glance whether the browser is on a stale bundle
     (compare the served ?v= against bundles[].mtime here). Any path here is $HOME-collapsed for privacy
     (like defaultDir/rompDir) — never a raw /Users/<name> path."""
     bundles = {}
@@ -381,7 +381,7 @@ border-radius:6px;background:#0c1117;color:#dfe7ee">
   <button style="margin-top:.9em;padding:.5em 1.4em;border:0;border-radius:6px;\
 background:#9cd2ff;color:#0c1a2e;font-weight:600;cursor:pointer">Open</button>
   <div style="opacity:.6;margin-top:1.2em;font-size:.9em">Get a ready-made link with
-  <code>romp -l</code>, or read <code>~/.local/state/romp/serve-token</code>.</div>
+  <code>romp</code>, or read <code>~/.local/state/romp/serve-token</code>.</div>
 </form>
 """
 
@@ -2686,7 +2686,7 @@ _DEFAULT_DIR_FILE = Path(os.path.expanduser("~/.config/romp/default-dir"))
 
 
 def _read_default_dir_file():
-    """The user-set default new-session dir (gear dialog or `romp --default-dir`), or "" — persisted in a
+    """The user-set default new-session dir (gear dialog or `romp default-dir`), or "" — persisted in a
     FILE because a web dialog can't set an env var. ~ / $VARs expanded; only returned if it still exists."""
     try:
         v = _DEFAULT_DIR_FILE.read_text().strip()
@@ -2699,7 +2699,7 @@ def _read_default_dir_file():
 def _default_create_dir():
     """The default working directory for a NEW session, in priority order (the user 2026-06-23):
       1. the user's persisted choice — ~/.config/romp/default-dir, set from the gear dialog or
-         `romp --default-dir`. A web/launchd kernel can't read a shell env var, so the override is a FILE.
+         `romp default-dir`. A web/launchd kernel can't read a shell env var, so the override is a FILE.
       2. else the romp install dir (ROMP_DIR — the repo root): romp-serve exports it and romp-service bakes
          it into the launchd plist, so it is reliably present however the kernel was started. A new session
          starts where romp lives, matching the CLI's own default (`romp`'s ROMPHOME also defaults there).
@@ -2830,14 +2830,14 @@ def _reap_if_cancelled(name):
 
 def _spawn_session(name, cwd=None):
     """Create a detached romp session named `name` — the same launch the old TS backend ran
-    (`romp --detach <name>`, tmux-backend.ts). Threaded so the ~seconds-long launch never blocks the WS
+    (`romp new -t --detach <name>`, tmux-backend.ts). Threaded so the ~seconds-long launch never blocks the WS
     recv loop; the 4s pusher then delivers the new tab and closes the webview's 'Opening…' modal. Scrub
     TMUX* so the child launcher never thinks it is already inside a tmux client. `cwd` is the session's
     working directory (validated by _resolve_create_dir); None falls back to the kernel default."""
     cwd = cwd or _default_create_dir()
     env = {k: v for k, v in os.environ.items() if k not in ("TMUX", "TMUX_PANE")}
     try:
-        subprocess.run([str(BIN / "romp"), "--detach", name], cwd=cwd, env=env, timeout=25,
+        subprocess.run([str(BIN / "romp"), "new", "-t", "--detach", name], cwd=cwd, env=env, timeout=25,
                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except Exception:
         sys.stderr.write("spawn '%s': %s\n" % (name, traceback.format_exc()))
@@ -3525,7 +3525,7 @@ def _revive_session(sid):
         else:
             cwd = _cwd_of(sid)
             workdir = cwd if cwd and os.path.isdir(cwd) else os.path.expanduser("~")
-            r = subprocess.run([str(BIN / "romp"), name, "--resume", sid, "--detach"],
+            r = subprocess.run([str(BIN / "romp"), "resume", sid, "--name", name, "--detach"],
                                cwd=workdir, capture_output=True, text=True, timeout=40)
             ok = r.returncode == 0
             if not ok:
@@ -4836,7 +4836,7 @@ _HEAD_CACHE = {"ts": 0.0, "full": None, "short": None}   # ~2s TTL: HEAD is read
 
 def _local_head(short=False):
     """This kernel's committed HEAD sha (FULL, or --short when short=True), or None outside a checkout — the
-    commit `romp --update` PUSHES to a remote AND the reference the drift is measured against, so the push and
+    commit `romp update` PUSHES to a remote AND the reference the drift is measured against, so the push and
     the drift check AGREE. (The old drift compared the remote to _kernel_sha()'s cached STARTUP sha while the
     push sent live HEAD; once HEAD moved ahead of the running kernel they never reconciled and the "behind"
     banner never cleared — the user 2026-07-04.) Cached ~2s since it's read on every /tunnels poll but HEAD
@@ -5020,7 +5020,7 @@ def _update_remote(host):
       2. `git push --force` local HEAD to a scratch ref on the remote (a NON-checked-out ref, so no bare-repo /
          denyCurrentBranch dance).
       3. ssh: REFUSE if the remote has DIVERGED (its own commits not in local — don't clobber), else reset the
-         remote to that ref, delete the scratch ref, and `romp --refresh` to restart.
+         remote to that ref, delete the scratch ref, and `romp refresh` to restart.
     Returns (ok, detail), fail-loud. Requires a CLEAN local tree — we push COMMITS, so uncommitted local work
     isn't sent; the caller is told to commit first."""
     host = str(host or "").strip()
@@ -6828,12 +6828,14 @@ def _injected_img_paths(text):
 
 # ───────────────────────── postal hydration ─────────────────────────
 # Postal traffic lands INSIDE the transcript: a received message as user text carrying the
-# `romp-msg-id` marker; a sent message as a send_message tool call (or a `romp --mail send` Bash). We
+# `romp-msg-id` marker; a sent message as a send_message tool call (or a `romp mail send` Bash). We
 # swap both for clean identity-coloured cards — and read the message BODY from the timeline log (not
 # the delivered text with its #### banner/footer), so a card shows the message, not the boilerplate.
 _SEND_TOOL_RE = re.compile(r"(?:^|__)send_message$")
 _CLI_SEND_RE = re.compile(   # capture the optional --kind that rides between send and the recipient (2026-07-08)
-    r"\bromp\s+--mail\s+send\s+(?:--kind\s+(delegate|coordinate|question)\s+)?([A-Za-z0-9._-]+)\s+([\s\S]+)$")
+    # (?:--)?mail: `romp mail` is the spelling since 2026-07-25, `romp --mail` its permanent silent
+    # alias — and old transcripts (whose Bash rows this matcher re-reads forever) only have the latter.
+    r"\bromp\s+(?:--)?mail\s+send\s+(?:--kind\s+(delegate|coordinate|question)\s+)?([A-Za-z0-9._-]+)\s+([\s\S]+)$")
 
 _POSTAL_KINDS = ("delegate", "coordinate", "question")
 
@@ -6917,7 +6919,7 @@ def _postal_out_card(ev):
 
 
 def _cli_send_card(ev):
-    """A Bash `romp --mail send <to> <body>` tool event → an outgoing card, only once the CLI confirmed
+    """A Bash `romp mail send <to> <body>` tool event → an outgoing card, only once the CLI confirmed
     delivery (else it stays a Bash row so a failure is visible)."""
     m = _CLI_SEND_RE.search(ev.get("input") or "")
     if not m:
@@ -6935,7 +6937,7 @@ def _cli_send_card(ev):
 
 
 def _hydrate_postal(events, index):
-    """Replace postal traffic with clean cards: a send_message tool (or `romp --mail send` Bash) → an
+    """Replace postal traffic with clean cards: a send_message tool (or `romp mail send` Bash) → an
     OUTGOING card; a user/tool event carrying romp-msg-id marker(s) → INCOMING card(s) with the clean
     body from the log. Anything not fully resolved passes through unchanged. Mirrors hydratePostal."""
     out = []
@@ -7577,7 +7579,7 @@ def _warm_fleet_bg(now):
 
 
 def _boot_warm():
-    """Warm the live fleet's parse cache at kernel STARTUP (the user 2026-07-03: after `romp --refresh`, local
+    """Warm the live fleet's parse cache at kernel STARTUP (the user 2026-07-03: after `romp refresh`, local
     sessions take a long time to load while remote ones — served by their own still-warm kernel over federation
     — appear at once). A fresh kernel has EMPTY caches, so the first connect pays the full cold serial parse
     (~2-4s: build_timeline bars + every chat tab). But between the restart and that connect there's a 1-2s gap
@@ -7719,7 +7721,7 @@ def _model_pending_now(sid, tm):
     return True
 # Dead-lane dismissals (the user 2026-07-02): a DEAD session lingers in the timeline as a faded/struck lane
 # while it's still in the activity window; its Clear button adds the sid here to drop it. DELIBERATELY in
-# memory only (never persisted) — a kernel restart forgets it, so `romp --refresh` brings a mistakenly-cleared
+# memory only (never persisted) — a kernel restart forgets it, so `romp refresh` brings a mistakenly-cleared
 # lane back. Only filters a lane while it's dead; a revived sid reappears (see build_timeline).
 _dismissed_lanes = set()      # sids the user cleared from the timeline (dead lanes only, forgotten on restart)
 
@@ -9802,7 +9804,7 @@ def _provisional_card(s, name, color, fsid, live, now, store=None):
     held = segs[-1]                                  # the latest segment — the ask the planner withholds / just got
     # A real user prompt warrants a placeholder; a settle-SEAM tail does too (it exists only because real
     # post-close work exists, plans/segment-regrowth.md); and so does a kernel RESUME (_seg_system: the
-    # romp-system restart/resume notice, the user 2026-07-09). A restart is the USER'S action (romp --refresh
+    # romp-system restart/resume notice, the user 2026-07-09). A restart is the USER'S action (romp refresh
     # / a crash heal), and the resumed turn is continued user work — leaving that actively-working session
     # cardless breaks the "a WORKING session always shows a card" invariant. Safe because plan_units PLACES a
     # system segment when it ends (the housekeeping-note 'work' unit, placed even on a skip → the placeholder
@@ -15130,6 +15132,39 @@ class Handler(BaseHTTPRequestHandler):
                     _send_to_app("chat", {"type": "closed", "id": sid})
                 _push_all()
                 return self._send(200, json.dumps({"ok": True}), "application/json")
+            if u.path == "/new":
+                # Headless session creation (`romp new`, 2026-07-25): the WS createSession op as a
+                # one-shot POST, so a terminal can start a session — SDK by default, the recommended
+                # backend — without a browser. Body: {"name": ..., "dir": ..., "backend": "sdk"|"tmux"}.
+                # Same validation and the same no-silent-fallback rule as the WS op: when the SDK
+                # backend is unavailable, say so (ok:false + reason), never hand back a mystery tmux
+                # session. An already-live name is a success (idempotent open), not an error.
+                try:
+                    b = json.loads(raw_body or b"{}")
+                except Exception:
+                    b = {}
+                nm = str((b or {}).get("name") or "").strip()
+                if not nm or not NAME_RE.match(nm):
+                    return self._send(400, json.dumps({"ok": False, "error":
+                        "session names use letters, digits, . _ - only"}), "application/json")
+                cwd, derr = _resolve_create_dir(b.get("dir"))
+                if derr:
+                    return self._send(200, json.dumps({"ok": False, "error": derr}), "application/json")
+                live = _live_names(_tmux_sessions())
+                if nm in live:
+                    return self._send(200, json.dumps({"ok": True, "id": live[nm], "existing": True}),
+                                      "application/json")
+                if (b.get("backend") or "sdk") == "sdk":
+                    if not _sdk():
+                        return self._send(200, json.dumps({"ok": False, "error":
+                            "SDK backend unavailable on this kernel (claude-agent-sdk not importable; "
+                            "run bin/romp-sdk-setup with Python 3.10+)"}), "application/json")
+                    sid = _create_sdk_session(nm, cwd)
+                    return self._send(200, json.dumps({"ok": True, "id": sid, "dir": cwd}),
+                                      "application/json")
+                threading.Thread(target=_spawn_session, args=(nm, cwd), daemon=True).start()
+                return self._send(200, json.dumps({"ok": True, "pending": True, "dir": cwd}),
+                                  "application/json")
             if u.path == "/working":
                 # Publish/clear a session's working-note in the backend-agnostic store, so the postal bus's
                 # set_working goes through the kernel (no tmux @romp-working) and an SDK session can publish a
@@ -15464,7 +15499,7 @@ class Handler(BaseHTTPRequestHandler):
             _mark_views_dirty()
         elif msg and msg.get("type") == "dismissLane" and msg.get("id"):
             # timeline: clear a DEAD lane's leftover row (the user 2026-07-02). IN-MEMORY only — a kernel
-            # restart forgets it, so a mistakenly-cleared lane comes back on `romp --refresh`. Only dead lanes
+            # restart forgets it, so a mistakenly-cleared lane comes back on `romp refresh`. Only dead lanes
             # carry the Clear button; build_timeline drops the sid only while it's dead, so a revived one returns.
             _dismissed_lanes.add(str(msg["id"]))
             _mark_views_dirty()
@@ -15815,7 +15850,7 @@ def _graceful_term(signum, frame):
     of orphaning to launchd as zombie transcript-writers, and any in-flight turn is interrupted so
     its state settles honestly. Parked ops + SDK queues are already mirrored to disk on every
     mutation, and a cut turn keeps its 'working' state tail — the NEXT kernel's boot reconcile
-    resumes exactly those. Bounded (~2s) so `romp --refresh` stays snappy. Never construct the
+    resumes exactly those. Bounded (~2s) so `romp refresh` stays snappy. Never construct the
     backend here — no SDK sessions were running if it doesn't exist."""
     try:
         sys.stderr.write("romp-kernel: SIGTERM — draining SDK sessions\n")
@@ -15865,7 +15900,7 @@ def main():
     sys.stderr.write("romp-kernel: serving the ported UI at %s  (Ctrl-C to stop)\n" % url)
     sys.stderr.write("romp-kernel: records under %s ; bundles from %s\n" % (jd.STATE, DIST))
     sys.stderr.write("romp-kernel: every request needs the serve token (loopback included) — "
-                     "browser entry: `romp -l`\n")
+                     "browser entry: `romp`\n")
     if BIND != "127.0.0.1":
         # reachable off-box (tailnet/phone): the Origin gate blocks cross-site browsers token-free,
         # and the token is required everywhere. Open from the phone:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2112,7 +2112,7 @@ class SdkBackend:
         Queued turns are already mirrored to the registry (_persist_queue). A cut turn's state log
         keeps its trailing 'working' (shutdown() writes no idle/waiting; _on_session_gone skips the
         settle when ended is set) — exactly the marker the NEXT kernel's boot reconcile resumes by.
-        Bounded so a routine `romp --refresh` stays snappy."""
+        Bounded so a routine `romp refresh` stays snappy."""
         with self._lock:
             sessions = list(self.sessions.values())
         inflight = sum(1 for s in sessions if s.inflight)

--- a/postal/README.md
+++ b/postal/README.md
@@ -3,7 +3,7 @@
 Inter-session mail: how peer sessions message each other (delegate, coordinate,
 question) without waking the human. `postal_service.py` is both the MCP server
 each session gets (`claude/romp-postal.mcp.json`) and the shell CLI
-(`romp --mail`); the `bin/romp-postal-service` symlink points here.
+(`romp mail`); the `bin/romp-postal-service` symlink points here.
 
 The bus is a port-keyed singleton that self-restarts when its source changes.
 Delivery is turn-boundary–safe: mail lands via the Stop hook

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -26,7 +26,7 @@
 # clients remain.
 #
 # Delivery has two paths. The backstop is the Stop hook: a recipient drains its
-# mailbox at the next turn boundary (also check_inbox / `romp --mail inbox`). On
+# mailbox at the next turn boundary (also check_inbox / `romp mail inbox`). On
 # top of that, push-on-deliver (see _push) auto-wakes an IDLE local session by
 # typing the mail straight into its prompt and submitting it — so a session
 # sitting idle reacts immediately instead of only at its next turn. The push is
@@ -124,7 +124,7 @@ ORPHAN_GRACE = int(os.environ.get("ROMP_POSTAL_ORPHAN_GRACE", "900"))  # bounce 
 STUCK_GRACE = int(os.environ.get("ROMP_POSTAL_STUCK_GRACE", "600"))  # warn the SENDER when a LIVE-but-idle recipient still hasn't read after N s
 
 REPLY_HINT = ('To reply (only if you have something substantive to add, not just to '
-              'acknowledge): romp --mail send --kind delegate|coordinate|question <name> "<text>" — '
+              'acknowledge): romp mail send --kind delegate|coordinate|question <name> "<text>" — '
               'put the whole point in your first sentence.')
 
 # The bus no longer shells tmux: session enumeration, the working-note, mail delivery/wake, the resume-picker
@@ -218,7 +218,7 @@ def _tl_append(fname, obj):
 
 def deliver(to_id, from_name, from_id, body, park=False, kind=""):
     # park=True marks a HANDOFF parked for a session that's currently dead. The
-    # maildir is keyed by the session UUID (which `romp --resume` reuses), so the
+    # maildir is keyed by the session UUID (which `romp resume` reuses), so the
     # message simply waits on disk until that session is revived — delivered then,
     # ignored forever if it never returns. Parked mail is also exempt from the
     # orphan sweep (see _sweep_orphans), so it persists indefinitely.
@@ -802,7 +802,7 @@ def format_push(msgs):
         if m.get("kind"):
             out.append("<!-- romp-msg-kind: %s -->" % m["kind"])   # sender-declared kind, read by the courier
         out.append(bar)
-    out.append('(to reply, only if substantive: romp --mail send --kind delegate|coordinate|question %s "...")'
+    out.append('(to reply, only if substantive: romp mail send --kind delegate|coordinate|question %s "...")'
                % msgs[0].get("from", ""))
     return "\n".join(out)
 
@@ -1057,7 +1057,7 @@ def _log(msg):
 
 # ── code-staleness self-restart ─────────────────────────────────────────────────────────────────────────
 # The bus is a long-lived SINGLETON keyed on its port: `ensure` is a no-op while the old process answers, and
-# `romp --refresh` restarts the KERNEL, not the bus. So a bus started before a code change keeps serving STALE
+# `romp refresh` restarts the KERNEL, not the bus. So a bus started before a code change keeps serving STALE
 # in-memory code indefinitely — which silently stranded mail to SDK sessions: a bus from before the "deliver
 # via the kernel, not by pasting into a tmux pane" refactor literally couldn't reach a pane-less SDK recipient,
 # and the message sat unread forever with no bounce (the user 2026-06-29). Guard: the bus fingerprints its own
@@ -1736,24 +1736,24 @@ def _seed_peers_from_kernel():
 
 def looks_remote():
     # Heuristic: this shell reached the machine over SSH. Used only for advisory
-    # nudges and `romp --mail remote` role detection — never to change delivery.
+    # nudges and `romp mail remote` role detection — never to change delivery.
     return bool(os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY"))
 
 def _unreachable_hint():
     if is_client_only() or looks_remote():
-        return "can't reach your laptop's Romp Postal Service bus — is the SSH tunnel up? run: romp --mail remote"
+        return "can't reach your laptop's Romp Postal Service bus — is the SSH tunnel up? run: romp mail remote"
     return "can't reach the Romp Postal Service bus (see ~/.local/state/romp/postal/server.log)"
 
 def _remote_nudge():
     # On a remote machine not yet pointed at the laptop's bus, the local bus is
-    # isolated; nudge toward `romp --mail remote` (advisory, on stderr only).
+    # isolated; nudge toward `romp mail remote` (advisory, on stderr only).
     # Peer mode (the default): every machine runs its own bus and peering carries
     # cross-host mail, so there is no laptop bus to point at — the nudge is moot.
     if peers_on():
         return
     if looks_remote() and not is_client_only():
         sys.stderr.write("[romp mail] you look like a remote machine on a local-only "
-                         "Romp Postal Service — run `romp --mail remote` to reach your laptop's sessions.\n")
+                         "Romp Postal Service — run `romp mail remote` to reach your laptop's sessions.\n")
 
 def ensure():
     """Make sure the bus is reachable. On a designated client-only host (remote),
@@ -1773,7 +1773,7 @@ def ensure():
     return ping()
 
 def restart():
-    """Force a FRESH bus process so 'restart everything' (`romp --refresh`) actually includes the bus, not
+    """Force a FRESH bus process so 'restart everything' (`romp refresh`) actually includes the bus, not
     just the kernels (the user 2026-06-29). The bus is a port-keyed singleton, so `ensure` alone is a no-op
     while the old one answers; SIGTERM the running pid, wait for the port to free, then re-ensure. Pending
     mail lives in the maildir, so the fresh bus just re-delivers it. On a client-only host the real bus is
@@ -1985,7 +1985,7 @@ def cli_send(argv):
         if kind not in ("delegate", "coordinate", "question"):
             sys.stderr.write("[romp mail] --kind must be delegate, coordinate, or question\n"); return 2
     if len(argv) < 2:
-        sys.stderr.write('usage: romp --mail send [--kind delegate|coordinate|question] <session> <text>\n'); return 2
+        sys.stderr.write('usage: romp mail send [--kind delegate|coordinate|question] <session> <text>\n'); return 2
     to, body = argv[0], " ".join(argv[1:])
     if not body.strip():
         sys.stderr.write("[romp mail] refusing to send an empty message\n"); return 2
@@ -2050,7 +2050,7 @@ def cli_sent():
 
 def cli_recall(argv):
     if not argv:
-        sys.stderr.write("usage: romp --mail recall <to> [id]\n"); return 2
+        sys.stderr.write("usage: romp mail recall <to> [id]\n"); return 2
     to, rid = argv[0], (argv[1] if len(argv) > 1 else "")
     if not ensure():
         sys.stderr.write("[romp mail] %s\n" % _unreachable_hint()); return 1
@@ -2126,7 +2126,7 @@ def setup_remote(force=False):
         print("This looks like your Romp Postal Service host (no SSH session detected);")
         print("the bus runs here automatically, so there's nothing to set up.")
         print("")
-        print("On a REMOTE machine, run `romp --mail remote` there instead.")
+        print("On a REMOTE machine, run `romp mail remote` there instead.")
         print("To make every SSH hop auto-tunnel, add to your ~/.ssh/config:")
         print("    Host <remote-host>      # or: Host *")
         print("        RemoteForward %d 127.0.0.1:%d" % (PORT, PORT))
@@ -2164,18 +2164,18 @@ def setup_remote(force=False):
             print("\nConnected! You can message now:")
             return cli_agents()
         time.sleep(0.5)
-    print("\nStill not connected. Open the tunnel above, then run `romp --mail remote` again.")
+    print("\nStill not connected. Open the tunnel above, then run `romp mail remote` again.")
     return 1
 
 USAGE = """romp-postal-service — the Romp Postal Service
-  romp --mail send <session> <text>   message a live romp session
-  romp --mail inbox                   read + clear messages sent to this session
-  romp --mail peek                    show messages without clearing them
-  romp --mail agents                  list romp sessions (with branch + what they're working on)
-  romp --mail working <text>          publish what you're working on (empty to clear)
-  romp --mail sent                    show your sent messages + whether each was read
-  romp --mail recall <to> [id]        unsend an unread message you sent to <to>
-  romp --mail remote                  connect this (remote) machine to your laptop's bus
+  romp mail send <session> <text>   message a live romp session
+  romp mail inbox                   read + clear messages sent to this session
+  romp mail peek                    show messages without clearing them
+  romp mail agents                  list romp sessions (with branch + what they're working on)
+  romp mail working <text>          publish what you're working on (empty to clear)
+  romp mail sent                    show your sent messages + whether each was read
+  romp mail recall <to> [id]        unsend an unread message you sent to <to>
+  romp mail remote                  connect this (remote) machine to your laptop's bus
 (internal: serve | ensure | restart | mcp | drain --id <id> | wake --id <id> | picker-check --name <n> --id <id>)"""
 
 def main(argv):
@@ -2184,7 +2184,7 @@ def main(argv):
     cmd, rest = argv[0], argv[1:]
     if cmd == "serve":   return serve()
     if cmd == "ensure":  return 0 if ensure() else 1
-    if cmd == "restart": return 0 if restart() else 1   # `romp --refresh` bounces the bus too, not just the kernels
+    if cmd == "restart": return 0 if restart() else 1   # `romp refresh` bounces the bus too, not just the kernels
     if cmd == "mcp":     return mcp()
     if cmd == "remote":  return setup_remote(force=("--force" in rest or "-f" in rest))
     if cmd == "drain":   return cli_drain(rest)

--- a/tests/install-sh.bats
+++ b/tests/install-sh.bats
@@ -13,6 +13,9 @@ setup() {
     export HOME="$TEST_DIR/home"
     mkdir -p "$HOME"
     export ROMP_NO_SERVICE=1 ROMP_NO_EXT=1 ROMP_NO_SDK=1
+    # One try only: the closing dashboard-link block polls for the kernel's token
+    # file, which never appears in this hermetic HOME — don't wait 10s for it.
+    export ROMP_INSTALL_TOKEN_TRIES=1
     # Redirect the git pre-push hook symlink into a temp dir so install.sh never
     # writes into the REAL repo's .git/hooks while these tests run.
     export ROMP_GITHOOK_DIR="$TEST_DIR/githooks"
@@ -119,6 +122,39 @@ SH
     [[ "$output" == *"romp-service install FAILED"* ]]
     [[ "$output" == *"dashboard will be dead"* ]]
     grep -qx install "$TEST_DIR/svc.log"
+}
+
+# ── The closing dashboard link (the user 2026-07-25, who wanted installing alone to be
+# enough to reach the dashboard) ── install.sh ends with the TOKENED link when the kernel
+# has minted the token, and an honest pointer when it hasn't; it must never print a bare
+# URL that bounces the first-time user to the paste-a-token login page.
+
+@test "install.sh: ends with the tokened dashboard link when the token exists" {
+    mkdir -p "$HOME/.local/state/romp"
+    printf 'tok123\n' > "$HOME/.local/state/romp/serve-token"
+    run "$ROMP_DIR/install.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"http://127.0.0.1:29855/?token=tok123"* ]]
+    [[ "$output" == *"romp url"* ]]
+}
+
+@test "install.sh: ROMP_NO_SERVICE with no token points at romp up, never a dead link" {
+    run "$ROMP_DIR/install.sh"     # setup sets ROMP_NO_SERVICE=1; no serve-token exists
+    [ "$status" -eq 0 ]
+    grep -q "romp up" <<<"$output"
+    grep -q "romp url" <<<"$output"
+    ! grep -q "?token=" <<<"$output"
+}
+
+@test "install.sh: service up but token not minted yet, says how to get the link" {
+    unset ROMP_NO_SERVICE
+    _svc_stub "$TEST_DIR/romp-service"
+    export ROMP_SVC_LOG="$TEST_DIR/svc.log" ROMP_SVC_RUNNING=1
+    ROMP_SERVICE_BIN="$TEST_DIR/romp-service" run "$ROMP_DIR/install.sh"
+    [ "$status" -eq 0 ]
+    grep -q "still starting" <<<"$output"
+    grep -q "romp url" <<<"$output"
+    ! grep -q "?token=" <<<"$output"
 }
 
 @test "install.sh: merges into an existing settings.json without clobbering the user's own config" {

--- a/tests/romp-debug.bats
+++ b/tests/romp-debug.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# `romp --debug [on|off|status]` persists judge debug mode (STATE/debug-mode.json).
+# `romp debug [on|off|status]` persists judge debug mode (STATE/debug-mode.json).
 # When on, judge-failure rows carry the failing call's input + reply and the feed
 # joins them onto each card's modal (the user 2026-07-09). The kernel + judge read
 # the file live (mtime-cached), so the toggle needs no restart.
@@ -19,28 +19,28 @@ teardown() {
     rm -rf "$TEST_DIR"
 }
 
-@test "romp --debug: on writes the flag, status reports it, off clears it" {
-    run "$ROMP_SCRIPT" --debug status
+@test "romp debug: on writes the flag, status reports it, off clears it" {
+    run "$ROMP_SCRIPT" debug status
     [ "$status" -eq 0 ]
     [[ "$output" == *"off"* ]]
 
-    run "$ROMP_SCRIPT" --debug on
+    run "$ROMP_SCRIPT" debug on
     [ "$status" -eq 0 ]
     grep -q 'true' "$XDG_STATE_HOME/romp/debug-mode.json"
 
-    run "$ROMP_SCRIPT" --debug status
+    run "$ROMP_SCRIPT" debug status
     [[ "$output" == *"debug mode: on"* ]]
 
-    run "$ROMP_SCRIPT" --debug off
+    run "$ROMP_SCRIPT" debug off
     [ "$status" -eq 0 ]
     [ ! -e "$XDG_STATE_HOME/romp/debug-mode.json" ]
 
-    run "$ROMP_SCRIPT" --debug status
+    run "$ROMP_SCRIPT" debug status
     [[ "$output" == *"debug mode: off"* ]]
 }
 
-@test "romp --debug: an unknown subcommand exits 2 with usage" {
-    run "$ROMP_SCRIPT" --debug bogus
+@test "romp debug: an unknown subcommand exits 2 with usage" {
+    run "$ROMP_SCRIPT" debug bogus
     [ "$status" -eq 2 ]
-    [[ "$output" == *"usage: romp --debug"* ]]
+    [[ "$output" == *"usage: romp debug"* ]]
 }

--- a/tests/romp-headless.bats
+++ b/tests/romp-headless.bats
@@ -1,8 +1,9 @@
 #!/usr/bin/env bats
 
-# `romp --send|--interrupt|--end <session> [text]` — headless session control through the kernel
+# `romp send|interrupt|end <session> [text]` — headless session control through the kernel
 # HTTP API (2026-07-05: interrupt/end existed only as browser WS ops, so a runaway session had no
-# headless stop; dash-only since 2026-07-25 — the bare words name sessions). A tiny one-shot python
+# headless stop). Bare words since round 3 (2026-07-25); the dashed spellings stay as SILENT
+# aliases because agent-facing text delivered before then names them. A tiny one-shot python
 # server stands in for the kernel; failures must be LOUD (non-zero exit + a message), never a
 # silent curl swallow.
 
@@ -43,37 +44,37 @@ PY
     export ROMP_KERNEL_PORT="$(cat "$TEST_DIR/port")"
 }
 
-@test "romp --interrupt <name> POSTs /interrupt and exits 0 on ok" {
+@test "romp interrupt <name> POSTs /interrupt and exits 0 on ok" {
     start_fake_kernel '{"ok": true}'
-    run "$ROMP_SCRIPT" --interrupt runaway
+    run "$ROMP_SCRIPT" interrupt runaway
     [ "$status" -eq 0 ]
     [[ "$output" == *"ok (runaway)"* ]]
     grep -q "^/interrupt$" <(head -1 "$TEST_DIR/req")
     grep -q '"name": "runaway"' "$TEST_DIR/req"
 }
 
-@test "romp --end stops a session through /end" {
+@test "romp end stops a session through /end" {
     start_fake_kernel '{"ok": true}'
-    run "$ROMP_SCRIPT" --end done-with-it
+    run "$ROMP_SCRIPT" end done-with-it
     [ "$status" -eq 0 ]
     grep -q "^/end$" <(head -1 "$TEST_DIR/req")
 }
 
-@test "the bare spellings are retired: an old command invocation fails naming the new one" {
-    # `romp send <name> <text>` is the pre-2026-07-25 spelling; the bare word names a
-    # session now, so the old form must exit 2 with the fix, never reach the kernel.
-    run "$ROMP_SCRIPT" send helper "hello"
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"romp --send <session> <text>"* ]]
-    run "$ROMP_SCRIPT" interrupt runaway
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"romp --interrupt <session>"* ]]
-    [ ! -e "$TEST_DIR/req" ]
+@test "the dashed spellings are silent aliases: --send works and says nothing about it" {
+    # Agent-facing text delivered before 2026-07-25 (postal reply footers, skill
+    # docs in old transcripts) names the dashed forms; they must keep working
+    # with no retirement noise.
+    start_fake_kernel '{"ok": true}'
+    run "$ROMP_SCRIPT" --send helper "hello"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"retired"* ]]
+    grep -q "^/send$" <(head -1 "$TEST_DIR/req")
+    grep -q '"name": "helper"' "$TEST_DIR/req"
 }
 
-@test "romp --send ships JSON-safe text" {
+@test "romp send ships JSON-safe text" {
     start_fake_kernel '{"ok": true}'
-    run "$ROMP_SCRIPT" --send helper 'fix the "thing" \ and this'
+    run "$ROMP_SCRIPT" send helper 'fix the "thing" \ and this'
     [ "$status" -eq 0 ]
     grep -q "^/send$" <(head -1 "$TEST_DIR/req")
     python3 - "$TEST_DIR/req" <<'PY'
@@ -85,21 +86,21 @@ PY
 
 @test "a kernel refusal is loud: non-zero exit + the kernel's answer" {
     start_fake_kernel '{"ok": false, "error": "id or name required"}'
-    run "$ROMP_SCRIPT" --interrupt ghost
+    run "$ROMP_SCRIPT" interrupt ghost
     [ "$status" -eq 1 ]
     [[ "$output" == *"kernel refused"* ]]
 }
 
 @test "an unreachable kernel is loud, not a silent curl swallow" {
-    ROMP_KERNEL_PORT=1 run "$ROMP_SCRIPT" --interrupt anyone
+    ROMP_KERNEL_PORT=1 run "$ROMP_SCRIPT" interrupt anyone
     [ "$status" -eq 1 ]
     [[ "$output" == *"kernel not reachable"* ]]
 }
 
 @test "usage errors exit 2: missing session name, send without text" {
-    run "$ROMP_SCRIPT" --interrupt
+    run "$ROMP_SCRIPT" interrupt
     [ "$status" -eq 2 ]
-    run "$ROMP_SCRIPT" --send lonely
+    run "$ROMP_SCRIPT" send lonely
     [ "$status" -eq 2 ]
-    [[ "$output" == *"usage: romp --send"* ]]
+    [[ "$output" == *"usage: romp send"* ]]
 }

--- a/tests/romp-launch.bats
+++ b/tests/romp-launch.bats
@@ -1,11 +1,12 @@
 #!/usr/bin/env bats
 
-# `romp -l` / `--launch` — the first-run entry point (2026-07-22; dash-only since 2026-07-25, when
-# bare `launch` became a session name like every dashless word): print the tokened dashboard URL AND
-# try to open a browser on it (Jupyter's flow). The PRINT is the contract — it must always happen,
-# even when no browser can be opened — because it is the user's guaranteed way in. On a
-# remote/headless box it must NOT pretend to open anything, and must say how to reach the dashboard
-# from a laptop instead. `romp --url` stays the print-only variant for scripting.
+# Bare `romp` — the front door (2026-07-25: the shortest command does the most common thing):
+# print the tokened dashboard URL AND try to open a browser on it (Jupyter's flow). The PRINT
+# is the contract — it must always happen, even when no browser can be opened — because it is
+# the user's guaranteed way in. On a remote/headless box it must NOT pretend to open anything,
+# and must say how to reach the dashboard from a laptop instead. `romp url` stays the
+# print-only variant for scripting (`--url` is its silent agent-facing alias), and the old
+# `-l`/`--launch` spellings fail loudly naming bare `romp`.
 
 ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
 
@@ -31,27 +32,21 @@ MOCK
 
 teardown() { rm -rf "$TEST_DIR"; }
 
-@test "romp -l prints the tokened URL" {
-    run "$ROMP_SCRIPT" -l
+@test "bare romp prints the tokened URL" {
+    run "$ROMP_SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"http://127.0.0.1:29855/?token=TESTTOKEN123"* ]]
 }
 
-@test "romp --launch is the long spelling of -l" {
-    run "$ROMP_SCRIPT" --launch
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"http://127.0.0.1:29855/?token=TESTTOKEN123"* ]]
-}
-
-@test "romp -l opens a browser on a local machine" {
-    run "$ROMP_SCRIPT" -l
+@test "bare romp opens a browser on a local machine" {
+    run "$ROMP_SCRIPT"
     [ "$status" -eq 0 ]
     [ -s "$OPEN_LOG" ]
     grep -q "token=TESTTOKEN123" "$OPEN_LOG"
 }
 
-@test "romp -l on a remote/ssh box prints the URL but opens nothing" {
-    SSH_CONNECTION="10.0.0.1 1 10.0.0.2 22" run "$ROMP_SCRIPT" -l
+@test "bare romp on a remote/ssh box prints the URL but opens nothing" {
+    SSH_CONNECTION="10.0.0.1 1 10.0.0.2 22" run "$ROMP_SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"http://127.0.0.1:29855/?token=TESTTOKEN123"* ]]   # the link is ALWAYS printed
     [[ "$output" == *"remote/headless"* ]]
@@ -59,47 +54,63 @@ teardown() { rm -rf "$TEST_DIR"; }
     [ ! -s "$OPEN_LOG" ] || false                                       # never opened a browser
 }
 
-@test "romp -l still prints the URL when no opener exists" {
+@test "bare romp still prints the URL when no opener exists" {
     # ROMP_OPENER= (set, empty) means "no opener", which PATH alone CANNOT express:
     # macOS ships /usr/bin/open, so the previous `rm $MOCK/open` + PATH=...:/usr/bin
     # form fell through to the REAL opener and launched an actual browser on every
     # macOS run. Linux has no `open`, which is why only macOS was affected.
     rm "$MOCK/open"
-    ROMP_OPENER= run "$ROMP_SCRIPT" -l
+    ROMP_OPENER= run "$ROMP_SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"http://127.0.0.1:29855/?token=TESTTOKEN123"* ]]
     [[ "$output" == *"couldn't open a browser automatically"* ]]
 }
 
-@test "romp -l opens nothing when no opener exists, even where a real one is on PATH" {
+@test "bare romp opens nothing when no opener exists, even where a real one is on PATH" {
     # The regression guard for the above: assert the real opener was never reached.
     # $MOCK/open stays in place and must NOT be called.
-    ROMP_OPENER= run "$ROMP_SCRIPT" -l
+    ROMP_OPENER= run "$ROMP_SCRIPT"
     [ "$status" -eq 0 ]
     [ ! -s "$OPEN_LOG" ] || false
 }
 
-@test "romp -l honours a custom ROMP_OPENER" {
+@test "bare romp honours a custom ROMP_OPENER" {
     cat > "$MOCK/mybrowser" <<'MOCK'
 #!/bin/sh
 echo "$@" >> "$OPEN_LOG"
 MOCK
     chmod +x "$MOCK/mybrowser"
-    ROMP_OPENER=mybrowser run "$ROMP_SCRIPT" -l
+    ROMP_OPENER=mybrowser run "$ROMP_SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$(cat "$OPEN_LOG")" == *"token=TESTTOKEN123"* ]]
 }
 
-@test "romp -l fails loudly when no token has been minted yet" {
+@test "bare romp fails loudly when no token has been minted yet" {
     rm "$XDG_STATE_HOME/romp/serve-token"
-    run "$ROMP_SCRIPT" -l
+    run "$ROMP_SCRIPT"
     [ "$status" -ne 0 ]
     [[ "$output" == *"no serve token"* ]]
 }
 
-@test "romp --url stays print-only (no browser, bare URL for scripts)" {
-    run "$ROMP_SCRIPT" --url
+@test "romp url stays print-only (no browser, bare URL for scripts)" {
+    run "$ROMP_SCRIPT" url
     [ "$status" -eq 0 ]
     [ "$output" = "http://127.0.0.1:29855/?token=TESTTOKEN123" ]         # exactly the URL, nothing else
     [ ! -s "$OPEN_LOG" ] || false
+}
+
+@test "--url is a silent alias of romp url (agent-facing text names it)" {
+    run "$ROMP_SCRIPT" --url
+    [ "$status" -eq 0 ]
+    [ "$output" = "http://127.0.0.1:29855/?token=TESTTOKEN123" ]
+}
+
+@test "the retired -l and --launch spellings fail naming bare romp" {
+    for old in -l --launch; do
+        run "$ROMP_SCRIPT" "$old"
+        [ "$status" -eq 2 ]
+        [[ "$output" == *"retired"* ]]
+        [[ "$output" == *"the dashboard is now just: romp"* ]]
+        [ ! -s "$OPEN_LOG" ] || false
+    done
 }

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -96,8 +96,18 @@ run_romp() {
 
 # ─── Launch tests ────────────────────────────────────────────────────
 
-@test "no args: session named after the folder, claude exec'd with --name + --session-id" {
+@test "bare romp is the dashboard front door: no kernel, loud error, never a session" {
+    # Round 3 (2026-07-25): the shortest command does the most common thing. In this
+    # hermetic env there is no serve token, so it must fail loudly and launch nothing.
+    touch "$MOCK_LOG"    # this path makes no tmux calls at all
     run run_romp
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no serve token"* ]]
+    [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
+}
+
+@test "new -t: terminal session named by the argument, claude exec'd with --name + --session-id" {
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     grep -q 'tmux new-session -d -s myproject' "$MOCK_LOG"
     grep -q 'tmux set -t myproject @romp 1' "$MOCK_LOG"
@@ -113,7 +123,7 @@ run_romp() {
     # keys are dropped — the launch once started `ec claude …` (the "ex" eaten).
     # The exec command must reach the pane atomically (respawn-pane), so the exec
     # line must NEVER appear on a send-keys call.
-    run run_romp
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     grep -q 'tmux respawn-pane -k -t myproject exec claude' "$MOCK_LOG"
     ! grep -q 'send-keys.*exec claude' "$MOCK_LOG"
@@ -126,14 +136,14 @@ run_romp() {
     # pane was left at a bare shell. The cosmetic set must be guarded so the session
     # still starts. Simulate the old tmux by failing exactly that option.
     export MOCK_TMUX_FAIL_OPT="copy-mode-position-style"
-    run run_romp --detach
+    run run_romp new -t --detach myproject
     [ "$status" -eq 0 ]
     grep -qE 'tmux respawn-pane -k -t myproject exec claude' "$MOCK_LOG"
 }
 
 @test "append-system-prompt: omitted when no working-style prompt is installed" {
     # Default hermetic HOME has no romp-session-prompt.md, so the -f guard skips it.
-    run run_romp
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     ! grep -q -- '--append-system-prompt' "$MOCK_LOG"
 }
@@ -141,7 +151,7 @@ run_romp() {
 @test "append-system-prompt: appended (deferred \$(cat ...)) when the prompt is installed" {
     mkdir -p "$HOME/.claude"
     printf 'Working style: be explicit.\n' > "$HOME/.claude/romp-session-prompt.md"
-    run run_romp
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     # The flag carries a deferred cat of the fixed path — the multi-line content
     # stays OUT of the exec line, so the launch shell expands it at exec time.
@@ -153,7 +163,7 @@ run_romp() {
 @test "append-system-prompt: also appended on the resume path" {
     mkdir -p "$HOME/.claude"
     printf 'Working style: be explicit.\n' > "$HOME/.claude/romp-session-prompt.md"
-    run run_romp --resume abc123-uuid
+    run run_romp resume abc123-uuid
     [ "$status" -eq 0 ]
     grep -F -- "--append-system-prompt \"\$(cat $HOME/.claude/romp-session-prompt.md)\"" "$MOCK_LOG"
 }
@@ -162,21 +172,21 @@ run_romp() {
     # tmux gotcha (2026-06-12): a session-scoped status-format[1] shadows the
     # whole inherited array — without [0] pinned to the global composition the
     # main status row (status-left + windows + status-right) renders EMPTY.
-    run run_romp
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     grep -q 'tmux set -t myproject status-format\[0\] GLOBAL_ROW0' "$MOCK_LOG"
     grep -q 'tmux set -t myproject status-format\[1\]' "$MOCK_LOG"
 }
 
-@test "named session: romp my-task → my-task" {
-    run run_romp my-task
+@test "named session: romp new -t my-task → my-task" {
+    run run_romp new -t my-task
     [ "$status" -eq 0 ]
     grep -q 'tmux new-session -d -s my-task' "$MOCK_LOG"
     grep -q 'tmux attach-session -t my-task' "$MOCK_LOG"
 }
 
 @test "session name sanitization: dots and colons replaced with dashes" {
-    run run_romp "my.task:v2"
+    run run_romp new -t "my.task:v2"
     [ "$status" -eq 0 ]
     grep -q 'tmux new-session -d -s my-task-v2' "$MOCK_LOG"
     grep -q 'exec claude --name "my-task-v2"' "$MOCK_LOG"
@@ -186,7 +196,7 @@ run_romp() {
     # A name/dir carrying $(), ;, or quotes must NOT survive into the launch
     # command the pane shell runs — every unsafe char becomes '-'. Regression for
     # the command-injection-via-session-name hole.
-    run run_romp 'pwn$(touch INJECTED);x"y'
+    run run_romp new -t 'pwn$(touch INJECTED);x"y'
     [ "$status" -eq 0 ]
     local line
     line="$(grep -F 'respawn-pane' "$MOCK_LOG" | grep -F 'exec claude')"
@@ -198,7 +208,7 @@ run_romp() {
 }
 
 @test "interrupt/escape key bindings route the session name through tmux #{q:} quoting" {
-    run run_romp myproject
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     grep -F 'bind -n C-c' "$MOCK_LOG"    | grep -qF 'romp-interrupt-reset #{q:session_name}'
     grep -F 'bind -n Escape' "$MOCK_LOG" | grep -qF 'romp-interrupt-reset #{q:session_name}'
@@ -209,14 +219,14 @@ run_romp() {
 @test "resume: a session id with shell metacharacters is refused before any launch" {
     # resume_id is typed into `claude --resume <id>`; a non-alphanumeric id must
     # be rejected before a session is created.
-    run run_romp myproject --resume 'abc;touch INJECTED' --detach
+    run run_romp resume 'abc;touch INJECTED' --name myproject --detach
     [ "$status" -ne 0 ]
     [[ "$output" == *"invalid session id"* ]]
     [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
 }
 
 @test "state dir is created private (0700)" {
-    run run_romp myproject
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     local perms
     # GNU stat (-c) first, BSD/macOS stat (-f) as fallback. The reverse order
@@ -236,49 +246,57 @@ run_romp() {
     # last command's status fails a test) — assert with simple commands
     # (grep, [ ]) so failures actually fire.
     mkdir -p "$XDG_STATE_HOME/romp/names"
-    run run_romp -r
+    run run_romp resume
     [ "$status" -eq 0 ]
     grep -q "no resumable sessions" <<<"$output"
     [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
 }
 
-@test "resume: -r and --resume are equivalent" {
+@test "resume: --resume is a silent alias of resume (agent-facing text names it)" {
     mkdir -p "$XDG_STATE_HOME/romp/names"
-    run run_romp -r
+    run run_romp resume
     [ "$status" -eq 0 ]
     grep -q "no resumable sessions" <<<"$output"
 
     run run_romp --resume
     [ "$status" -eq 0 ]
     grep -q "no resumable sessions" <<<"$output"
+    [[ "$output" != *"retired"* ]]
 }
 
 @test "resume: first run ever (no names dir) exits silently, creating nothing" {
     touch "$MOCK_LOG"    # this path may make no tmux calls at all
-    run run_romp -r
+    run run_romp resume
     [ "$status" -eq 0 ]
     [ -z "$output" ]
     [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
 }
 
-@test "resume: 'resume' is now a normal session name, not a directive" {
-    # -r/--resume replaced the bare `resume` word, so it's free to name a session.
-    run run_romp resume
-    [ "$status" -eq 0 ]
-    grep -q 'tmux new-session -d -s resume' "$MOCK_LOG"
-    ! grep -q -- '--resume' "$MOCK_LOG"
-}
-
-@test "resume: named session plus -r still goes through the picker" {
-    mkdir -p "$XDG_STATE_HOME/romp/names"
-    run run_romp my-task -r
-    [ "$status" -eq 0 ]
-    grep -q "no resumable sessions" <<<"$output"
+@test "an unknown bare word is a loud error naming both readings, never a session" {
+    # Round 3: commands are bare words, so a word that is not one gets exit 2
+    # with the `romp new` fix spelled out — nothing silently becomes a session.
+    touch "$MOCK_LOG"    # this path makes no tmux calls at all
+    run run_romp foo
+    [ "$status" -eq 2 ]
+    [[ "$output" == *'unknown command "foo"'* ]]
+    [[ "$output" == *"romp new foo"* ]]
     [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
 }
 
-@test "resume: explicit session id (--resume <id>) resumes that conversation" {
-    run run_romp --resume abc123-uuid
+@test "resume: the old-kernel revive shape (name --resume id --detach) still works, silently" {
+    # A kernel on pre-round-3 code revives tmux sessions as `romp <name> --resume
+    # <sid> --detach`; that exact shape must keep working (SILENTLY) until every
+    # kernel restarts onto new code — its spawn path swallows stderr.
+    run run_romp web --resume abc123-uuid --detach
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"retired"* ]]
+    grep -q 'tmux new-session -d -s web' "$MOCK_LOG"
+    grep -q 'tmux respawn-pane -k -t web exec claude --resume abc123-uuid --name "web"' "$MOCK_LOG"
+    ! grep -q 'tmux attach-session' "$MOCK_LOG"
+}
+
+@test "resume: explicit session id resumes that conversation" {
+    run run_romp resume abc123-uuid
     [ "$status" -eq 0 ]
     grep -q 'tmux respawn-pane -k -t myproject exec claude --resume abc123-uuid --name "myproject"' "$MOCK_LOG"
 }
@@ -286,7 +304,7 @@ run_romp() {
 @test "resume: name collision uniquifies instead of hijacking the session" {
     echo "myproject" > "$MOCK_TMUX_SESSIONS_FILE"
 
-    run run_romp --resume abc123-uuid
+    run run_romp resume abc123-uuid
     [ "$status" -eq 0 ]
     ! grep -qE 'tmux attach-session -t myproject$' "$MOCK_LOG"
     grep -q 'tmux new-session -d -s myproject-2' "$MOCK_LOG"
@@ -295,8 +313,8 @@ run_romp() {
 
 # ─── Detach tests ────────────────────────────────────────────────────
 
-@test "detach: --detach creates the session but does not attach" {
-    run run_romp --detach
+@test "detach: new -t --detach creates the session but does not attach" {
+    run run_romp new -t --detach myproject
     [ "$status" -eq 0 ]
     grep -q 'tmux new-session -d -s myproject' "$MOCK_LOG"
     grep -qE 'tmux respawn-pane -k -t myproject exec claude --name "myproject" --session-id [0-9a-f-]{36}' "$MOCK_LOG"
@@ -304,7 +322,7 @@ run_romp() {
     [[ "$output" == *"attach with: tmux attach -t myproject"* ]]
 }
 
-@test "detach: --resume + id + detach is the skill conversion path" {
+@test "detach: --resume + id + detach (the skill conversion path) still works as an alias" {
     run run_romp --resume sess-xyz --detach
     [ "$status" -eq 0 ]
     grep -q 'tmux new-session -d -s myproject' "$MOCK_LOG"
@@ -317,14 +335,36 @@ run_romp() {
 
 @test "unknown option shows error" {
     run run_romp -x
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"Unknown option: -x"* ]]
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unknown option: -x"* ]]
+}
+
+@test "old-kernel spawn shape (--detach <name>) still works, silently" {
+    # A kernel on pre-round-3 code spawns dashboard tmux sessions as `romp
+    # --detach <name>` with stderr swallowed — the shape must keep working.
+    run run_romp --detach oldk
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"retired"* ]]
+    grep -q 'tmux new-session -d -s oldk' "$MOCK_LOG"
+    ! grep -q 'tmux attach-session' "$MOCK_LOG"
+}
+
+@test "new: usage errors are loud — missing name, two names, dangling -d" {
+    touch "$MOCK_LOG"    # these paths make no tmux calls at all
+    run run_romp new
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp new"* ]]
+    run run_romp new -t alpha beta
+    [ "$status" -eq 2 ]
+    run run_romp new -t -d
+    [ "$status" -eq 2 ]
+    [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
 }
 
 @test "existing session reattaches instead of creating new" {
     echo "myproject" > "$MOCK_TMUX_SESSIONS_FILE"
 
-    run run_romp
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     ! grep -q 'tmux new-session' "$MOCK_LOG"
     grep -q 'tmux attach-session -t myproject' "$MOCK_LOG"
@@ -333,7 +373,7 @@ run_romp() {
 # ─── Identity-color tests ────────────────────────────────────────────
 
 @test "color: first session gets the first palette color + a status dot" {
-    run run_romp
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     grep -q 'tmux set -t myproject @identity-bg #1EA1EB' "$MOCK_LOG"
     # The tab dot is seeded blue (ready) at launch; the status hook drives
@@ -345,7 +385,7 @@ run_romp() {
     echo "other" > "$MOCK_TMUX_SESSIONS_FILE"
     echo "other=#1EA1EB" > "$MOCK_TMUX_IDENTITY_FILE"
 
-    run run_romp
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     grep -q 'tmux set -t myproject @identity-bg #54B204' "$MOCK_LOG"
 }
@@ -356,7 +396,7 @@ run_romp() {
     printf '%s\n' "s1" "s2" > "$MOCK_TMUX_SESSIONS_FILE"
     printf '%s\n' "s1=#1EA1EB" "s2=#54B204" > "$MOCK_TMUX_IDENTITY_FILE"
 
-    run run_romp
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     grep -q 'tmux set -t myproject @identity-bg #4EA8A9' "$MOCK_LOG"
 }
@@ -368,7 +408,7 @@ run_romp() {
     mkdir -p "$XDG_STATE_HOME/romp"
     printf '#AA0000\twhite\n#00BB00\tblack\n' > "$XDG_STATE_HOME/romp/palette-colors"
 
-    run run_romp
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     grep -q 'tmux set -t myproject @identity-bg #AA0000' "$MOCK_LOG"
     grep -q 'tmux set -t myproject @identity-fg white' "$MOCK_LOG"
@@ -383,35 +423,28 @@ run_romp() {
         echo "sess${i}=${palette[$i]}" >> "$MOCK_TMUX_IDENTITY_FILE"
     done
 
-    run run_romp
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     grep -q 'tmux set -t myproject @identity-bg #' "$MOCK_LOG"
 }
 
 # ─── No attach/rename subcommands (use tmux a / tmux rename) ─────────
 
-@test "'a' and 'attach' are now normal session names, not subcommands" {
-    # `romp a`/`attach` were removed — use plain `tmux a`. So these words just
-    # name a session now.
-    run run_romp a
-    [ "$status" -eq 0 ]
-    grep -q 'tmux new-session -d -s a' "$MOCK_LOG"
-
-    : > "$MOCK_LOG"
-    run run_romp attach
-    [ "$status" -eq 0 ]
-    grep -q 'tmux new-session -d -s attach' "$MOCK_LOG"
+@test "'a', 'attach', 'rename' are unknown commands, never sessions" {
+    # There is no attach/rename command (plain tmux does both), and round 3 made
+    # every non-command bare word a loud error pointing at `romp new`.
+    for word in a attach rename; do
+        : > "$MOCK_LOG"
+        run run_romp "$word"
+        [ "$status" -eq 2 ]
+        [[ "$output" == *"romp new ${word}"* ]]
+        [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
+    done
 }
 
-@test "'rename' is now a normal session name, not a subcommand" {
-    run run_romp rename
-    [ "$status" -eq 0 ]
-    grep -q 'tmux new-session -d -s rename' "$MOCK_LOG"
-}
+# ─── Terminal monitor (romp monitor) ─────────────────────────────────
 
-# ─── Dashboard (-d) ──────────────────────────────────────────────────
-
-@test "-d dispatches to romp-dashboard" {
+@test "monitor dispatches to romp-dashboard" {
     cat > "$MOCK_DIR/romp-dashboard" << 'MOCK'
 #!/usr/bin/env bash
 echo "romp-dashboard called" >> "$MOCK_LOG"
@@ -421,21 +454,33 @@ MOCK
     # dashboard shadows the mock — use the test seam instead
     export ROMP_DASHBOARD_BIN="$MOCK_DIR/romp-dashboard"
 
-    run run_romp -d
+    run run_romp monitor
     [ "$status" -eq 0 ]
     grep -q 'romp-dashboard called' "$MOCK_LOG"
 }
 
-@test "dashboard is a normal session name, not a subcommand" {
-    # `-d` is the dashboard, so the word "dashboard" is free to name a session.
-    run run_romp dashboard
-    [ "$status" -eq 0 ]
-    grep -q 'tmux new-session -d -s dashboard' "$MOCK_LOG"
+@test "retired human spellings fail loudly naming today's word, and start nothing" {
+    # Rounds 1-2 spellings (short view flags, dashed manager commands). The
+    # agent-facing aliases (--mail/--url/--send/--interrupt/--end/--resume,
+    # --version, first-arg --detach) are exercised elsewhere and stay SILENT.
+    for flag in -l --launch -d -f -j -r --on --refresh --status --update --checkin --checkout --default-dir --debug; do
+        : > "$MOCK_LOG"
+        run run_romp "$flag"
+        [ "$status" -eq 2 ]
+        [[ "$output" == *"retired"* ]]
+        [[ "$output" == *"is now"* || "$output" == *"just: romp"* ]]
+        [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
+    done
+    # spot-check two hints name the exact new spelling
+    run run_romp -d
+    [[ "$output" == *"romp monitor"* ]]
+    run run_romp --refresh
+    [[ "$output" == *"romp refresh"* ]]
 }
 
-# ─── kernel-manager control FLAGS (--on / --refresh / --status) ──────
+# ─── kernel-manager commands (up / refresh / status) ─────────────────
 
-@test "manager flags (--on/--refresh/--status) dispatch to romp-manager with the right sub-command" {
+@test "manager commands (up/refresh/status) dispatch to romp-manager with the right sub-command" {
     cat > "$MOCK_DIR/romp-manager" << 'MOCK'
 #!/usr/bin/env bash
 echo "romp-manager called: $*" >> "$MOCK_LOG"
@@ -450,25 +495,25 @@ MOCK
     chmod +x "$MOCK_DIR/romp-postal-service"
     export ROMP_POSTAL_BIN="$MOCK_DIR/romp-postal-service"
 
-    run run_romp --on            # `romp --on` is PURELY start-the-manager
+    run run_romp up              # `romp up` is PURELY start-the-manager
     [ "$status" -eq 0 ]
     grep -q 'romp-manager called: up' "$MOCK_LOG"
-    ! grep -q 'romp-postal-service called' "$MOCK_LOG"   # --on does not touch the bus
+    ! grep -q 'romp-postal-service called' "$MOCK_LOG"   # up does not touch the bus
 
     : > "$MOCK_LOG"
-    run run_romp --refresh       # restart EVERYTHING: the bus AND all kernels
+    run run_romp refresh         # restart EVERYTHING: the bus AND all kernels
     [ "$status" -eq 0 ]
     grep -q 'romp-postal-service called: restart' "$MOCK_LOG"   # bus bounced first
     grep -q 'romp-manager called: restart-all' "$MOCK_LOG"      # then the kernels
 
     : > "$MOCK_LOG"
-    run run_romp --status
+    run run_romp status
     [ "$status" -eq 0 ]
     grep -q 'romp-manager called: status' "$MOCK_LOG"
-    ! grep -q 'romp-postal-service called' "$MOCK_LOG"   # --status does not touch the bus
+    ! grep -q 'romp-postal-service called' "$MOCK_LOG"   # status does not touch the bus
 }
 
-@test "--refresh appends a caller-attribution line to restart-audit.jsonl before restarting" {
+@test "refresh appends a caller-attribution line to restart-audit.jsonl before restarting" {
     # 2026-07-16: three staged-demo teardowns traced back to untraceable fleet-wide refreshes —
     # kernel-downtime.jsonl records only {start,end}, and agents (Bash tool) leave no shell history.
     # The audit line answers WHO (sid -> session name, parent argv, tty) before the restart runs.
@@ -491,7 +536,7 @@ MOCK
         > "$XDG_STATE_HOME/romp/names/11111111-2222-3333-4444-555555555555"
     export CLAUDE_CODE_SESSION_ID="11111111-2222-3333-4444-555555555555"
 
-    run run_romp --refresh
+    run run_romp refresh
     [ "$status" -eq 0 ]
     audit="$XDG_STATE_HOME/romp/restart-audit.jsonl"
     [ -f "$audit" ]
@@ -501,7 +546,7 @@ MOCK
     grep -q 'romp-manager called: restart-all' "$MOCK_LOG"   # ...and the restart still ran
 }
 
-@test "--refresh survives an unwritable audit dir (attribution is best-effort, never blocks)" {
+@test "refresh survives an unwritable audit dir (attribution is best-effort, never blocks)" {
     cat > "$MOCK_DIR/romp-manager" << 'MOCK'
 #!/usr/bin/env bash
 echo "romp-manager called: $*" >> "$MOCK_LOG"
@@ -517,72 +562,35 @@ MOCK
 
     mkdir -p "$XDG_STATE_HOME/romp"
     chmod 500 "$XDG_STATE_HOME/romp"                 # audit append will fail
-    run run_romp --refresh
+    run run_romp refresh
     chmod 700 "$XDG_STATE_HOME/romp"                 # restore for teardown
     [ "$status" -eq 0 ]
     grep -q 'romp-manager called: restart-all' "$MOCK_LOG"   # the restart went through regardless
 }
 
-@test "romp --on no longer forwards a restart sub-verb (romp --refresh replaces it)" {
+@test "romp up does not forward trailing words to the manager (romp refresh is its own command)" {
     cat > "$MOCK_DIR/romp-manager" << 'MOCK'
 #!/usr/bin/env bash
 echo "romp-manager called: $*" >> "$MOCK_LOG"
 MOCK
     chmod +x "$MOCK_DIR/romp-manager"
     export ROMP_MANAGER_BIN="$MOCK_DIR/romp-manager"
-    run run_romp --on restart main
+    run run_romp up restart main
     [ "$status" -eq 0 ]
     grep -q 'romp-manager called: up' "$MOCK_LOG"   # starts the manager; trailing words are NOT forwarded
     ! grep -q 'restart' "$MOCK_LOG"
 }
 
-@test "bare on/refresh/status/serve/version are session names now, NOT commands (the verbs moved to flags)" {
-    # Dash-ification (the user 2026-06-16): every non-session word is a flag now, so these former bare
-    # verbs are free to name a session and must reach the launch path, not the manager/serve/version one.
-    for word in on refresh status serve version; do
+@test "'on', 'serve', 'down', 'launch', 'open' are unknown commands: loud exit 2, no session" {
+    # These words never became round-3 commands (up replaced on; serve was removed;
+    # there is no down; the dashboard is bare romp). Each must fail naming the fix.
+    for word in on serve down launch open; do
         : > "$MOCK_LOG"
         run run_romp "$word"
-        [ "$status" -eq 0 ]
-        grep -q "tmux new-session -d -s ${word}" "$MOCK_LOG"
+        [ "$status" -eq 2 ]
+        [[ "$output" == *"romp new ${word}"* ]]
+        [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
     done
-}
-
-@test "'down' is a normal session name (no romp --down flag — Ctrl+C the foreground romp --on)" {
-    run run_romp down
-    [ "$status" -eq 0 ]
-    grep -q 'tmux new-session -d -s down' "$MOCK_LOG"
-}
-
-@test "retired bare words are session names now, with a one-line notice naming the new spelling" {
-    # 2026-07-25 dash-ification of the last eight bare commands: `romp <word>` with no
-    # leading dash ALWAYS names a session. Argless, each word starts its session and a
-    # single stderr line says where the command went, so old muscle memory self-corrects.
-    for word in launch open update checkin checkout send interrupt end; do
-        : > "$MOCK_LOG"
-        run run_romp "$word"
-        [ "$status" -eq 0 ]
-        grep -q "tmux new-session -d -s ${word}" "$MOCK_LOG"
-        [[ "$output" == *"starting a session named \"${word}\""* ]]
-    done
-    # the notice names the new spelling (spot-check the dashboard one)
-    run run_romp launch
-    [[ "$output" == *"romp -l"* ]]
-}
-
-@test "a retired bare word WITH args is an old command invocation: loud exit 2, session untouched" {
-    # `romp send api "hi"` can only be the old command (a session launch takes one
-    # positional), so it must fail naming the new spelling, never guess.
-    run run_romp send api "hello there"
-    [ "$status" -eq 2 ]
-    [[ "$output" == *'"send" is a session name now'* ]]
-    [[ "$output" == *"romp --send <session> <text>"* ]]
-    ! grep -q 'tmux new-session' "$MOCK_LOG"
-    run run_romp update somehost
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"romp --update"* ]]
-    run run_romp launch --detach
-    [ "$status" -eq 2 ]
-    [[ "$output" == *"romp -l"* ]]
 }
 
 @test "romp-manager: control verbs error cleanly when no manager is running" {
@@ -672,23 +680,22 @@ MOCK
     run run_romp -h
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-    [[ "$output" == *"romp -d"* ]]
+    [[ "$output" == *"romp new"* ]]
     ! grep -q 'tmux new-session' "$MOCK_LOG"
 }
 
-@test "--help prints usage" {
+@test "help, -h and --help all print usage" {
+    touch "$MOCK_LOG"    # help makes no tmux calls at all
     run run_romp --help
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage:"* ]]
-}
-
-@test "help is a normal session name, not a subcommand" {
     run run_romp help
     [ "$status" -eq 0 ]
-    grep -q 'tmux new-session -d -s help' "$MOCK_LOG"
+    [[ "$output" == *"Usage:"* ]]
+    [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
 }
 
-@test "--mail dispatches to romp-postal with its args" {
+@test "mail dispatches to romp-postal with its args (--mail is its silent alias)" {
     cat > "$MOCK_DIR/romp-postal" << 'MOCK'
 #!/usr/bin/env bash
 echo "romp-postal called: $*" >> "$MOCK_LOG"
@@ -698,15 +705,15 @@ MOCK
     # exec'd the REAL romp-postal (a live mail send) instead of the mock
     export ROMP_POSTAL_BIN="$MOCK_DIR/romp-postal"
 
-    run run_romp --mail send beta "hello"
+    run run_romp mail send beta "hello"
     [ "$status" -eq 0 ]
     grep -q 'romp-postal called: send beta hello' "$MOCK_LOG"
-}
 
-@test "'mail' is now a normal session name, not a subcommand" {
-    run run_romp mail
+    : > "$MOCK_LOG"
+    run run_romp --mail send beta "hello"    # delivered postal footers name --mail forever
     [ "$status" -eq 0 ]
-    grep -q 'tmux new-session -d -s mail' "$MOCK_LOG"
+    [[ "$output" != *"retired"* ]]
+    grep -q 'romp-postal called: send beta hello' "$MOCK_LOG"
 }
 
 # _romp_resume_rows builds the resume-picker rows in ONE python pass: it walks the
@@ -797,16 +804,18 @@ _resume_rows_fn() {   # writes the extracted function to $1
     run env PATH="$td:/usr/bin:/bin:/opt/homebrew/bin" bash "$td/romp" -h
     [ "$status" -eq 0 ]
     # built-ins (no backing binary) always shown
-    [[ "$output" == *"romp --detach"* ]]
-    # `romp --serve` is removed (tailnet reach = tailscale serve to loopback) — must not resurface
-    [[ "$output" != *"romp --serve"* ]]
+    [[ "$output" == *"romp new"* ]]
+    [[ "$output" == *"romp resume"* ]]
+    # `romp serve` was removed (tailnet reach = tailscale serve to loopback) — must not resurface
+    [[ "$output" != *"romp serve"* ]]
     # present backing → shown
-    [[ "$output" == *"romp --on"* ]]
-    [[ "$output" == *"romp --version"* ]]
+    [[ "$output" == *"romp up"* ]]
+    [[ "$output" == *"romp status"* ]]
+    [[ "$output" == *"romp version"* ]]
     # absent backing → hidden
-    [[ "$output" != *"romp -d"* ]]
-    [[ "$output" != *"romp -f"* ]]
-    [[ "$output" != *"romp --mail"* ]]
+    [[ "$output" != *"romp monitor"* ]]
+    [[ "$output" != *"romp feed"* ]]
+    [[ "$output" != *"romp mail"* ]]
 }
 
 # ─── ROMPHOME — never launch a session in $HOME ──────────────────────
@@ -820,7 +829,7 @@ _resume_rows_fn() {   # writes the extracted function to $1
     local expect; expect="$(cd "$ROMPHOME" && pwd -P)"
     local home_real; home_real="$(cd "$HOME" && pwd -P)"
     cd "$HOME"
-    run run_romp box
+    run run_romp new -t box
     [ "$status" -eq 0 ]
     grep -qF "tmux new-session -d -s box -c $expect" "$MOCK_LOG"
     # the session must NOT be rooted at $HOME
@@ -829,13 +838,15 @@ _resume_rows_fn() {   # writes the extracted function to $1
     [[ "$output" == *"not launching in \$HOME"* ]]
 }
 
-@test "ROMPHOME: a bare launch from \$HOME is named after ROMPHOME, not \$HOME" {
+@test "ROMPHOME: a name-less resume from \$HOME is named after ROMPHOME, not \$HOME" {
     # Regression: basename(\$HOME) is the username — a privacy leak as a session
-    # name. The default name must come from the resolved (redirected) dir.
+    # name. `romp new` requires a name now, so the folder-name default only fires
+    # on an explicit-id resume without --name; the name must come from the
+    # resolved (redirected) dir.
     export ROMPHOME="$TEST_DIR/scratchpad"
     mkdir -p "$ROMPHOME"
     cd "$HOME"
-    run run_romp
+    run run_romp resume abc123-uuid
     [ "$status" -eq 0 ]
     grep -q 'tmux new-session -d -s scratchpad' "$MOCK_LOG"
     ! grep -qE 'tmux new-session -d -s home( |$| -)' "$MOCK_LOG"
@@ -846,41 +857,95 @@ _resume_rows_fn() {   # writes the extracted function to $1
     mkdir -p "$ROMPHOME"
     # setup() already cd'd into $WORK_DIR, a normal project dir
     local expect; expect="$(cd "$WORK_DIR" && pwd -P)"
-    run run_romp
+    run run_romp new -t myproject
     [ "$status" -eq 0 ]
     grep -qF "tmux new-session -d -s myproject -c $expect" "$MOCK_LOG"
     [[ "$output" != *"not launching in \$HOME"* ]]
 }
 
-# ─── Judges monitor (-j) ─────────────────────────────────────────────
+@test "new: -d launches in the given directory, not the cwd" {
+    local other="$TEST_DIR/elsewhere"
+    mkdir -p "$other"
+    local expect; expect="$(cd "$other" && pwd -P)"
+    run run_romp new -t -d "$other" side
+    [ "$status" -eq 0 ]
+    grep -qF "tmux new-session -d -s side -c $expect" "$MOCK_LOG"
+}
 
-@test "-j dispatches to romp-judge-monitor (honors the ROMP_JUDGE_MONITOR_BIN seam)" {
+# ─── Judges monitor (romp judges) ────────────────────────────────────
+
+@test "judges dispatches to romp-judge-monitor (honors the ROMP_JUDGE_MONITOR_BIN seam)" {
     cat > "$MOCK_DIR/romp-judge-monitor" << 'MOCK'
 #!/usr/bin/env bash
 echo "judge-monitor called: $*" >> "$MOCK_LOG"
 MOCK
     chmod +x "$MOCK_DIR/romp-judge-monitor"
     export ROMP_JUDGE_MONITOR_BIN="$MOCK_DIR/romp-judge-monitor"
-    run run_romp -j --once
+    run run_romp judges --once
     [ "$status" -eq 0 ]
     grep -q 'judge-monitor called: --once' "$MOCK_LOG"
     ! grep -q 'tmux new-session' "$MOCK_LOG"
 }
 
-@test "'j' is a normal session name, not a subcommand" {
-    run run_romp j
-    [ "$status" -eq 0 ]
-    grep -q 'tmux new-session -d -s j' "$MOCK_LOG"
-}
-
-@test "romp --checkin/--checkout: usage without a host, loud failure with no kernel" {
-    run "$ROMP_SCRIPT" --checkin
+@test "romp checkin/checkout: usage without a host, loud failure with no kernel" {
+    run "$ROMP_SCRIPT" checkin
     [ "$status" -eq 2 ]
-    [[ "$output" == *"usage: romp --checkin <host>"* ]]
-    run "$ROMP_SCRIPT" --checkout
+    [[ "$output" == *"usage: romp checkin <host>"* ]]
+    run "$ROMP_SCRIPT" checkout
     [ "$status" -eq 2 ]
     # port 1 refuses instantly → the CLI must fail LOUDLY, never pretend the checkout happened
-    ROMP_KERNEL_PORT=1 run "$ROMP_SCRIPT" --checkout somehost
+    ROMP_KERNEL_PORT=1 run "$ROMP_SCRIPT" checkout somehost
     [ "$status" -eq 1 ]
     [[ "$output" == *"kernel not reachable"* ]]
+}
+
+# ─── romp new (SDK default) ──────────────────────────────────────────
+
+@test "new (no -t): no kernel token → loud error naming both fixes, nothing launched" {
+    touch "$MOCK_LOG"    # this path makes no tmux calls at all
+    run run_romp new api
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"kernel isn't running"* ]]
+    [[ "$output" == *"romp new -t api"* ]]
+    [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
+}
+
+@test "new (no -t): POSTs the kernel /new with backend sdk, and starts no tmux session" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    touch "$MOCK_LOG"    # this path makes no tmux calls at all
+    mkdir -p "$XDG_STATE_HOME/romp"
+    printf 'tok-test' > "$XDG_STATE_HOME/romp/serve-token"
+    local port=7561
+    # One-shot fake kernel: accept a single POST, log it, answer ok:true.
+    python3 - "$port" "$TEST_DIR/req.log" <<'PY' &
+import sys, json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+port, log = int(sys.argv[1]), sys.argv[2]
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        with open(log, "w") as f:
+            json.dump({"path": self.path, "token": self.headers.get("X-Romp-Token"),
+                       "body": json.loads(body or b"{}")}, f)
+        out = json.dumps({"ok": True, "id": "11111111-2222-3333-4444-555555555555"}).encode()
+        self.send_response(200); self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(out))); self.end_headers()
+        self.wfile.write(out)
+    def log_message(self, *a): pass
+srv = HTTPServer(("127.0.0.1", port), H)
+srv.handle_request()
+PY
+    local srv=$!
+    sleep 0.3
+    ROMP_KERNEL_PORT=$port run run_romp new api
+    kill "$srv" 2>/dev/null || true
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"started \"api\""* ]]
+    [[ "$output" == *"dashboard"* ]]
+    [ -f "$TEST_DIR/req.log" ]
+    grep -q '"path": "/new"' "$TEST_DIR/req.log"
+    grep -q '"token": "tok-test"' "$TEST_DIR/req.log"
+    grep -q '"name": "api"' "$TEST_DIR/req.log"
+    grep -q '"backend": "sdk"' "$TEST_DIR/req.log"
+    [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
 }

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4810,7 +4810,8 @@ class ViewBuilder(unittest.TestCase):
         argv = calls[0]
         self.assertTrue(str(argv[0]).endswith("/romp"),
                         "the kernel owns the resume (bin/romp), never the removed postal subcommand")
-        self.assertEqual(argv[-3:], ["--resume", "deadsid000", "--detach"])
+        # --name pins the recorded name; this fixture has none, so _name_of falls back to the sid
+        self.assertEqual(argv[1:], ["resume", "deadsid000", "--name", "deadsid000", "--detach"])
         self.assertNotIn("deadsid000", km._hidden_tabs(), "the revived tab is un-hidden")
 
     def test_split_reminders(self):
@@ -5150,11 +5151,21 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(out[0]["color"], {"bg": "#0000ff", "fg": "#ffffff"}, "recipient color resolved by name")
 
     def test_hydrate_postal_out_from_cli_bash_send(self):
-        """A `romp --mail send` Bash call → an outgoing card too, once delivery is confirmed."""
+        """A `romp --mail send` Bash call → an outgoing card too, once delivery is confirmed. The
+        dashed spelling is the pre-round-3 one — old transcripts carry it forever, so it must keep
+        matching."""
         ev = {"kind": "tool", "name": "Bash", "input": 'romp --mail send beta "hi there"',
               "output": "[romp mail] delivered to beta", "isError": False, "uuid": "t2", "ts": "x"}
         out = km._hydrate_postal([ev], {})
         self.assertEqual((out[0]["direction"], out[0]["peer"], out[0]["body"]), ("out", "beta", "hi there"))
+
+    def test_hydrate_postal_out_from_cli_bash_send_bare_spelling(self):
+        """`romp mail send` (the round-3 spelling, 2026-07-25) matches the same outgoing-card path."""
+        ev = {"kind": "tool", "name": "Bash", "input": 'romp mail send --kind question beta "when?"',
+              "output": "[romp mail] delivered to beta", "isError": False, "uuid": "t3", "ts": "x"}
+        out = km._hydrate_postal([ev], {})
+        self.assertEqual((out[0]["direction"], out[0]["peer"], out[0]["body"], out[0]["intent"]),
+                         ("out", "beta", "when?", "question"))
 
     def test_hydrate_postal_passes_through_unresolved(self):
         """A marker with no matching log entry stays a plain event (never half-rendered) — but KEEPS its
@@ -6107,9 +6118,93 @@ class ServeSecurity(unittest.TestCase):
         with urllib.request.urlopen("http://127.0.0.1:%d/" % self.port, timeout=5) as r:
             self.assertEqual(r.status, 200)
             body = r.read().decode("utf-8", "replace")
-        self.assertIn("romp -l", body)                     # names the CLI that opens/prints the tokened link
+        self.assertIn("<code>romp</code>", body)           # names the CLI that opens/prints the tokened link
         self.assertNotIn("testtok", body)                  # never echoes the token itself
         self.assertNotIn("src=/chat", body)                # none of the real shell is served
+
+
+class NewSessionRoute(unittest.TestCase):
+    """POST /new — `romp new` (2026-07-25): the WS createSession op as a one-shot token-gated POST.
+    SDK is the default backend and there is NO silent fallback: an unavailable SDK answers ok:false
+    with the remedy; backend "tmux" threads the same _spawn_session the WS op uses. Runs the REAL
+    handler over loopback with the spawn/SDK seams patched (never a real session from a test)."""
+
+    @classmethod
+    def setUpClass(cls):
+        import threading
+        from http.server import ThreadingHTTPServer
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def _post(self, payload):
+        import urllib.request
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d/new" % self.port, method="POST",
+            data=json.dumps(payload).encode(),
+            headers={"X-Romp-Token": "testtok", "Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read().decode() or "{}")
+
+    def test_name_required_and_validated(self):
+        code, body = self._post({"dir": "/tmp"})
+        self.assertEqual(code, 400)
+        self.assertFalse(body["ok"])
+        code, body = self._post({"name": "bad name!"})
+        self.assertEqual(code, 400)
+        self.assertIn("letters, digits", body["error"])
+
+    def test_bad_dir_is_a_loud_refusal(self):
+        code, body = self._post({"name": "api", "dir": "/nonexistent-romp-test-dir"})
+        self.assertEqual(code, 200)
+        self.assertFalse(body["ok"])
+        self.assertIn("directory not found", body["error"])
+
+    def test_sdk_unavailable_never_falls_back_to_tmux(self):
+        saved_sdk, saved_live = km._sdk, km._live_names
+        km._sdk, km._live_names = (lambda: None), (lambda t: {})
+        try:
+            code, body = self._post({"name": "api", "dir": tempfile.gettempdir()})
+        finally:
+            km._sdk, km._live_names = saved_sdk, saved_live
+        self.assertEqual(code, 200)
+        self.assertFalse(body["ok"], "no silent tmux session when the SDK is missing")
+        self.assertIn("SDK backend unavailable", body["error"])
+
+    def test_existing_live_name_is_an_idempotent_ok(self):
+        saved_live = km._live_names
+        km._live_names = lambda t: {"api": "sid-existing"}
+        try:
+            code, body = self._post({"name": "api", "dir": tempfile.gettempdir()})
+        finally:
+            km._live_names = saved_live
+        self.assertEqual(code, 200)
+        self.assertEqual((body["ok"], body["existing"], body["id"]), (True, True, "sid-existing"))
+
+    def test_tmux_backend_threads_the_spawn(self):
+        calls = []
+        saved_spawn, saved_live = km._spawn_session, km._live_names
+        km._spawn_session, km._live_names = (lambda nm, cwd=None: calls.append((nm, cwd))), (lambda t: {})
+        try:
+            code, body = self._post({"name": "term1", "dir": tempfile.gettempdir(),
+                                     "backend": "tmux"})
+            for _ in range(100):                     # the spawn is threaded — wait for it
+                if calls:
+                    break
+                time.sleep(0.05)
+        finally:
+            km._spawn_session, km._live_names = saved_spawn, saved_live
+        self.assertEqual(code, 200)
+        self.assertTrue(body["ok"] and body.get("pending"))
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "term1")
 
 
 class HostSuspend(unittest.TestCase):

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -277,10 +277,11 @@ class RompUpdateCLI(unittest.TestCase):
 
     def test_dispatch_routes_update_in_the_bash_cli(self):
         # Dash-only since 2026-07-25: bare `update` names a session (the retired-word
-        # notice covers the old spelling); only `--update` routes to romp-update.
         src = open(os.path.join(BIN, "romp")).read()
-        self.assertIn('"${1:-}" == "--update"', src, "--update routes to romp-update")
-        self.assertNotIn('"${1:-}" == "update"', src, "bare `update` must stay free to name a session")
+        # Round 3 (2026-07-25): commands are bare words again — `update` is the
+        # spelling, and the retired `--update` flag fails naming it.
+        self.assertIn('"${1:-}" == "update"', src, "bare `update` routes to romp-update")
+        self.assertIn('--update)', src, "the retired --update spelling gets a loud hint")
         self.assertIn("exec romp-update", src)
 
     def test_no_kernel_errors_cleanly(self):

--- a/tests/test_kernel_revive.py
+++ b/tests/test_kernel_revive.py
@@ -86,8 +86,9 @@ class ReviveSession(unittest.TestCase):
         self._stub_run(returncode=0)
         km._revive_session(SID)
         cmd, kw = self.runs[0]
-        self.assertEqual(cmd, [os.path.join(BIN, "romp"), "testsess", "--resume", SID, "--detach"],
-                         "the launcher resume path the old postal revive used, now owned by the kernel")
+        self.assertEqual(cmd, [os.path.join(BIN, "romp"), "resume", SID, "--name", "testsess", "--detach"],
+                         "the launcher resume path the old postal revive used, now owned by the kernel "
+                         "(round-3 spelling, 2026-07-25: resume <id> --name <name>)")
         self.assertEqual(kw.get("cwd"), os.path.expanduser("~"),
                          "a missing recorded dir falls back to $HOME (old postal behavior)")
         self.assertEqual([m["type"] for m in self.focused], ["focus"])

--- a/tests/test_romp_version.py
+++ b/tests/test_romp_version.py
@@ -19,7 +19,7 @@ def test_report_flags_stale_served_bundle(monkeypatch=None):
     out = ver.report()
     assert "abc1234-dirty" in out
     assert "pid=9" in out
-    assert "feed.js" in out and "romp --refresh" in out    # stale flag present on the newer-on-disk bundle
+    assert "feed.js" in out and "romp refresh" in out    # stale flag present on the newer-on-disk bundle
 
 
 def test_report_handles_down_kernel():

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2140,7 +2140,7 @@ class TimelinePanel {
   }
 
   // Clear a DEAD lane's leftover row from the timeline (the Clear pill on a struck-through lane). The kernel
-  // holds the dismissal IN MEMORY only, so it does NOT survive a `romp --refresh` (the user 2026-07-02) —
+  // holds the dismissal IN MEMORY only, so it does NOT survive a `romp refresh` (the user 2026-07-02) —
   // a mistakenly-cleared lane comes back on restart. Web-shell only (no Obsidian/Node path: nothing to persist).
   _dismissLane(id) {
     try {
@@ -2672,7 +2672,7 @@ class TimelinePanel {
       // as a faded/struck lane while it's still in the activity window, with NONE of the live controls (no
       // feed/postal toggle, no model picker, no chip, no ctx battery — all empty), so the row right of the name
       // is free. The pill mirrors the feed cards' Clear button chrome (outlined, dim → red fill on hover) and
-      // dismisses the leftover lane. The kernel forgets the dismissal on restart, so `romp --refresh` brings a
+      // dismisses the leftover lane. The kernel forgets the dismissal on restart, so `romp refresh` brings a
       // mistakenly-cleared lane back. pointerdown (not click): a poll redraw between mousedown/up would eat a
       // 'click', same as the feed/postal toggles above.
       if (!s.live) {
@@ -2686,7 +2686,7 @@ class TimelinePanel {
         chit.style.cursor = 'pointer'; chit.setAttribute('aria-label', 'clear this ended session from the timeline');
         chit.addEventListener('mouseenter', (e) => {
           box.setAttribute('fill', CL_RED); box.setAttribute('stroke', CL_RED); box.setAttribute('stroke-opacity', '1'); ctx.setAttribute('fill', '#ffffff');
-          this.showTip("Clear this ended session from the timeline<div style='opacity:.65;margin-top:2px'>a kernel restart (romp --refresh) brings it back</div>", e);
+          this.showTip("Clear this ended session from the timeline<div style='opacity:.65;margin-top:2px'>a kernel restart (romp refresh) brings it back</div>", e);
         });
         chit.addEventListener('mousemove', (e) => this.moveTip(e));
         chit.addEventListener('mouseleave', () => {

--- a/ui/webview/feed-debug-warnings.test.ts
+++ b/ui/webview/feed-debug-warnings.test.ts
@@ -1,4 +1,4 @@
-// Debug-mode judge warnings (the user 2026-07-09): with `romp --debug on`, the kernel joins every
+// Debug-mode judge warnings (the user 2026-07-09): with `romp debug on`, the kernel joins every
 // judge-failure row onto the card whose goal (or placed segment) it touched, and the card modal grows a
 // "Warnings (debug)" section — one line per failure, expandable to the failing call's full input + reply.
 // Off is the default and costs nothing: the kernel emits no rows, the modal builds no section. Source pins

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -87,7 +87,7 @@ interface AskItem {
   summaryAnchorUuid?: string | null;               // click the summary line → the completion turn's wrap-up block (kernel build_feed completed pin; cited/latest-prose fallbacks — the user 2026-07-14)
   warns?: { kind: string; t: number; msg: string; detail: string }[] | null;   // judge-stamped anomalies (judge _node_warn → kernel build_feed): yellow "warning" chip; click opens the detail modal (the user 2026-07-02)
   nudged?: { count: number; times: number[] } | null;   // auto-nudge HISTORY (kernel _nudge_times): how many times romp followed up + when — the stalled chip's evidence (tooltip + modal line, the user 2026-07-02)
-  warnRows?: { t: number; judge: string; err: string; note?: string; debug?: { input?: string; reply?: string } }[] | null;   // DEBUG MODE only (romp --debug on): every judge failure touching this card (kernel _card_warn_rows) → "Warnings (debug)" modal section; rows captured in debug carry the failing call's input + reply (the user 2026-07-09)
+  warnRows?: { t: number; judge: string; err: string; note?: string; debug?: { input?: string; reply?: string } }[] | null;   // DEBUG MODE only (romp debug on): every judge failure touching this card (kernel _card_warn_rows) → "Warnings (debug)" modal section; rows captured in debug carry the failing call's input + reply (the user 2026-07-09)
   origin?: { peer: string; peerSid: string; color: { bg: string; fg: string } | null } | null;  // courier handoff: planted by a peer's message → "↪ from <peer>"
   waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22)
   awaiting?: { why?: string | null; tasks?: string[] | null } | null;   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Waiting on task" pill (expands the list, like Sub-goals) replaces the boxed why.
@@ -1834,7 +1834,7 @@ function applyModalArtifacts(host: HTMLElement, it: AskItem): void {
 }
 
 // Debug-mode judge warnings (the user 2026-07-09): every judge failure touching this card, appended
-// below the tree/artifacts. The kernel only emits warnRows while `romp --debug on`, so the section
+// below the tree/artifacts. The kernel only emits warnRows while `romp debug on`, so the section
 // simply never exists in normal mode. One line per failure (time · judge · kind — evidence); a row
 // captured in debug mode expands (native <details>) to the failing call's full input + reply, so a
 // rejection is inspectable the moment it happens, without reproducing it.

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -43,7 +43,7 @@ var GEAR_HTML =
   '<div class=rs-h>Settings</div>' +
   "<div class='rs-sec rs-sec-first'>Sessions</div>" +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Default directory</b>" +
-  '<span class=rs-sub>The default directory for NEW sessions (still editable per session). Persisted kernel-side — also settable with <code>romp --default-dir</code>. Falls back to the romp install dir until you set one; blank reverts to it. ~ and $VARs expand.</span>' +
+  '<span class=rs-sub>The default directory for NEW sessions (still editable per session). Persisted kernel-side — also settable with <code>romp default-dir</code>. Falls back to the romp install dir until you set one; blank reverts to it. ~ and $VARs expand.</span>' +
   "<div style='display:flex;gap:6px;margin-top:5px'>" +
   "<input id=rs-defaultdir type=text spellcheck=false placeholder='install/serve default' style='flex:1 1 auto;min-width:0;box-sizing:border-box;background:#1e1e1e;color:#ccc;" +
   "border:1px solid #3a3a3a;border-radius:5px;padding:3px 6px'>" +

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4888,7 +4888,7 @@ function agehms(secs: number): string {
 }
 
 // The "(age)" label is colored by recency on the SHARED romp colormap, log age scale, so the ledger
-// matches the feed and the terminal `romp -f`. The bullet TEXT stays at default brightness; only the
+// matches the feed and the terminal `romp feed`. The bullet TEXT stays at default brightness; only the
 // age label is colored.
 // The recency colormaps — KEEP IN SYNC with bin/romp_colormap.py (the kernel computes the feed's trgb
 // from the same stops). ONE global time colormap, picked in settings (the user 2026-06-17): the ledger
@@ -4974,7 +4974,7 @@ function hslToRgb(h: number, s: number, l: number): [number, number, number] {
   return [Math.round(hk(h + 1 / 3) * 255), Math.round(hk(h) * 255), Math.round(hk(h - 1 / 3) * 255)];
 }
 // Recency for the ledger: take the shared hawaii ramp color (same hue progression
-// as the terminal `romp -f` feed) but remap its LIGHTNESS into a legible band so
+// as the terminal `romp feed` board) but remap its LIGHTNESS into a legible band so
 // no bullet drops into the unreadable dark-magenta the raw ramp produces at the
 // old end. Brightness still carries recency as a secondary cue — recent bullets
 // are bright, oldest ones fade darker/muted — but the fade is floored (~L0.50) so

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -153,13 +153,13 @@
           "type": "number",
           "minimum": 1,
           "maximum": 65535,
-          "markdownDescription": "Port of the romp kernel this VS Code window attaches to. Point different windows at different ports to view different kernels (each kernel scopes its own group of agents). If no kernel is running on this port, VS Code asks the `romp --on` manager to start one — VS Code never spawns the kernel itself. Unset → `$ROMP_SERVE_PORT` or **29855**."
+          "markdownDescription": "Port of the romp kernel this VS Code window attaches to. Point different windows at different ports to view different kernels (each kernel scopes its own group of agents). If no kernel is running on this port, VS Code asks the `romp up` manager to start one — VS Code never spawns the kernel itself. Unset → `$ROMP_SERVE_PORT` or **29855**."
         },
         "romp.managerPort": {
           "type": "number",
           "minimum": 1,
           "maximum": 65535,
-          "markdownDescription": "Control-endpoint port of the `romp --on` manager, used to ensure a kernel exists on `#romp.kernelPort#`. Unset → `$ROMP_MANAGER_PORT` or **7432**."
+          "markdownDescription": "Control-endpoint port of the `romp up` manager, used to ensure a kernel exists on `#romp.kernelPort#`. Unset → `$ROMP_MANAGER_PORT` or **7432**."
         }
       }
     }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -270,7 +270,7 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
-  // Attach-only: VS Code does NOT own the kernel (the `romp --on` manager does), so there's nothing to
+  // Attach-only: VS Code does NOT own the kernel (the `romp up` manager does), so there's nothing to
   // reap here — closing/reloading VS Code just drops our attach; the kernel keeps running.
   chatPipe?.dispose();
   feedPipe?.dispose();
@@ -331,7 +331,7 @@ function broadcastSettings(settings: unknown, from?: vscode.Webview) {
 
 // ---- the kernel: ENSURE-THEN-ATTACH (the manager owns it; we never spawn) ----
 // VS Code does NOT spawn the kernel. It attaches to a manager-owned kernel on romp.kernelPort; if none
-// is there, it asks the `romp --on` manager to ENSURE one (the manager spawns + owns it), waits for it,
+// is there, it asks the `romp up` manager to ENSURE one (the manager spawns + owns it), waits for it,
 // and attaches. A second front-end spawner would fight the manager for the port and re-create the
 // invisible-orphan problem — so the only spawner is ever the manager (the user's 2026-06-13 ruling).
 // The decision sequence lives in ./kernel-attach (headless-testable); ensureKernel just supplies the
@@ -364,15 +364,15 @@ function ensureKernel(): Promise<boolean> {
     ensureFails++;
     // Point the user at the fix, once (not on every panel mount / reconnect
     // poll) — and only when the failure PERSISTS across rounds: attaching in
-    // the middle of a `romp --refresh` fails one round and self-heals on the
+    // the middle of a `romp refresh` fails one round and self-heals on the
     // pipes' retry, and that transient must not toast (the user 2026-07-13).
     if (!notRunningWarned && warnAfter(ensureFails)) {
       notRunningWarned = true;
       const port = kernelPort();
       vscode.window.showErrorMessage(
         res.reason === "no-manager"
-          ? `romp: no kernel on port ${port} and no manager on :${managerPort()} — start it with \`romp --on\` in a terminal.`
-          : `romp: the manager couldn't bring up a kernel on port ${port} — is that port already in use? Check \`romp --status\`.`,
+          ? `romp: no kernel on port ${port} and no manager on :${managerPort()} — start it with \`romp up\` in a terminal.`
+          : `romp: the manager couldn't bring up a kernel on port ${port} — is that port already in use? Check \`romp status\`.`,
       );
     }
     return false;
@@ -697,7 +697,7 @@ function paintStatus() {
   statusItem.text = r.text;
   statusItem.backgroundColor = r.warn ? new vscode.ThemeColor("statusBarItem.warningBackground") : undefined;
   if (statusOffline) {
-    statusItem.tooltip = "The romp kernel is unreachable — start it with `romp --on`.";
+    statusItem.tooltip = "The romp kernel is unreachable — start it with `romp up`.";
     return;
   }
   const lines = lastFrame ? statusTooltipLines(lastFrame) : [];
@@ -919,7 +919,7 @@ function gitIn(dir: string, args: string[]): Promise<string> {
 async function pickKernelSession(placeHolder: string): Promise<SessionInfo | undefined> {
   const sessions = await fetchSessions();
   if (!sessions.length) {
-    vscode.window.showWarningMessage("romp: no sessions (is the kernel running? `romp --on`).");
+    vscode.window.showWarningMessage("romp: no sessions (is the kernel running? `romp up`).");
     return undefined;
   }
   const folders = workspaceFolderPaths();

--- a/vscode-extension/src/kernel-attach.test.ts
+++ b/vscode-extension/src/kernel-attach.test.ts
@@ -62,7 +62,7 @@ test("manager acked but the kernel never serves → reason kernel-didnt-start (b
 });
 
 test("default poll budget covers a kernel RESTART, not just a clean spawn (>= 10s)", async () => {
-  // A `romp --refresh` respawn + cold boot can exceed the old ~5s budget; attaching mid-restart
+  // A `romp refresh` respawn + cold boot can exceed the old ~5s budget; attaching mid-restart
   // then toasted "couldn't bring up a kernel" while it came up seconds later (2026-07-13).
   let waited = 0;
   const res = await ensureThenAttach({

--- a/vscode-extension/src/kernel-attach.ts
+++ b/vscode-extension/src/kernel-attach.ts
@@ -2,7 +2,7 @@
 // tested headlessly (extension.ts can't be imported in a node test — it pulls in `vscode`).
 //
 // The rule (the user's 2026-06-13 ruling): a front end NEVER spawns the kernel itself. It attaches to
-// a manager-owned kernel on its configured port; if none is there, it asks the `romp --on` manager to
+// a manager-owned kernel on its configured port; if none is there, it asks the `romp up` manager to
 // ENSURE one (the manager spawns + owns it), then waits for it to come up and attaches. This keeps a
 // single owner (no invisible orphans, no two front ends fighting over the port) while still giving the
 // "point a front end at a port and a kernel appears" UX.
@@ -15,7 +15,7 @@ export interface AttachDeps {
   // await-able sleep (injected so tests run instantly)
   delay: (ms: number) => Promise<void>;
   // How long to wait for a freshly-ensured kernel to start serving. A RESTART
-  // (romp --refresh) also lands here — healthz is down while the manager
+  // (romp refresh) also lands here — healthz is down while the manager
   // respawns, and a cold kernel boot (reconcile + bundle check) can take well
   // over 5s — so the budget must cover a restart, not just a clean spawn
   // (the user 2026-07-13: a reload during a refresh raised the failure toast


### PR DESCRIPTION
The user's final grammar call, superseding #20's invariant: commands get the bare words (git-style); session names live behind `romp new` where they can never collide.

**Grammar**
- Bare `romp` = the dashboard. `romp new <name> [-d <dir>]` = an SDK session minted by the kernel's new token-gated **POST /new** (same validation as the webview create; loud ok:false when the SDK backend is unavailable, never a silent tmux fallback). `romp new -t` = the terminal (tmux) launcher, attached, with `--detach`. `romp resume [<id>] [--name] [--detach]` keeps the picker.
- Bare-word commands: new resume up refresh status update version monitor feed judges url mail send interrupt end checkin checkout default-dir debug help.
- Retired human spellings exit 2 naming today's word; agent-facing dashed spellings (--mail/--url/--send/--interrupt/--end/--resume/--version) and the two old-kernel invocation shapes stay silent aliases — delivered postal footers and mixed-version fleets speak them forever. Unknown bare word → exit 2 suggesting `romp new <word>`.
- install.sh ends with the tokened dashboard link (bounded wait for the token mint), making download → install → click the whole first-run story.

**Coverage**: romp.bats rewritten (58 tests: dispatch, retired flags, compat shims, fake-kernel /new POST); NewSessionRoute pytest class; both mail spellings on the postal-card matcher; revive pins updated. Local green: 239 bats / 3078 pytest / 1328 node / tsc. CI is still dead org-wide (billing).

docs/ untouched by design — romp_docs writes the reference against the merged table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)