### PR TITLE
Privacy: pre-push hook scans pushed commits; redact a session name

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,39 +1,64 @@
 #!/usr/bin/env bash
-# romp pre-push hook: refuse to push if any file carries a personal identifier.
+# romp pre-push hook: refuse to publish a commit that carries a personal identifier.
 #
-# A no-op unless you supply the scan yourself. The repo may go public and history
-# is permanent, so this runs tests/test_no_personal_identifiers.py — which scans
-# every tracked + untracked file for THIS machine's own identifiers (hostname,
-# home path, and the strings in ~/.config/romp/private-strings.txt) — to catch a
-# leak before it leaves the machine, while it can still be fixed.
+# The repo may go public and history is permanent, so this scans the COMMITS
+# BEING PUSHED (every new commit's full tree, not the working tree) for the
+# strings in ~/.config/romp/private-strings.txt — one banned string per line,
+# `#` comments and blank lines ignored, matched case-insensitively. With no such
+# file it exits 0 and stays out of your way, so on a clone that never set one up
+# (any contributor's machine) it is a no-op.
 #
-# That scan is personal and machine-specific, so it is NOT tracked in the repo:
-# one machine's hostname and home path mean nothing on anyone else's clone. Drop
-# your own copy at tests/test_no_personal_identifiers.py to arm this hook; with
-# no such file it exits 0 and stays out of your way.
+# Why pushed trees rather than a working-tree scan: the hook is symlinked into
+# the SHARED git hooks dir (by install.sh), so it fires from every worktree —
+# but a working-tree scan is only as good as the tree you happen to push from,
+# and an untracked scanner script exists in only one worktree. Reading the
+# denylist from $HOME and grepping the pushed shas arms every worktree equally,
+# and catches a string buried in an intermediate commit whose tip is clean.
 #
-# Fast (~0.1s), so it is safe on every push. Bypass a false positive with
-# `git push --no-verify`. Installed by install.sh (symlinked into the shared
-# git hooks dir, so it fires from every worktree); self-locates the worktree
-# being pushed, so one shared hook checks whichever tree you push from.
+# Bypass a false positive with `git push --no-verify`.
 set -euo pipefail
 
-root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-[ -n "$root" ] || exit 0                       # not in a work tree → nothing to scan
+strings_file="${ROMP_PRIVATE_STRINGS:-${XDG_CONFIG_HOME:-$HOME/.config}/romp/private-strings.txt}"
+[ -f "$strings_file" ] || exit 0
 
-check="$root/tests/test_no_personal_identifiers.py"
-[ -f "$check" ] || exit 0                       # no personal scan on this clone → nothing to do
+# Banned strings: strip comments and surrounding whitespace, drop blanks.
+grep_args=()
+while IFS= read -r line; do
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -n "$line" ] && grep_args+=(-e "$line")
+done < "$strings_file"
+[ ${#grep_args[@]} -gt 0 ] || exit 0
 
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "romp pre-push: python3 not found — SKIPPING the identifier scan." >&2
-    echo "  (install python3, or 'git push --no-verify' to bypass this one push)" >&2
-    exit 0
-fi
+zero=0000000000000000000000000000000000000000
+blocked=0
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    [ -n "${local_sha:-}" ] || continue
+    [ "$local_sha" = "$zero" ] && continue          # deleting a remote ref pushes nothing
+    # Only the commits this push actually publishes: what the remote ref lacks,
+    # or (for a new ref) what no remote-tracking ref already has.
+    if [ "$remote_sha" = "$zero" ]; then
+        revs=$(git rev-list "$local_sha" --not --remotes 2>/dev/null || git rev-list "$local_sha")
+    else
+        revs=$(git rev-list "$remote_sha..$local_sha")
+    fi
+    for rev in $revs; do
+        # -I skips binaries; -l lists files; the tree at $rev is what ships.
+        if hits=$(git grep -i -I -l -F "${grep_args[@]}" "$rev" -- 2>/dev/null) && [ -n "$hits" ]; then
+            echo "romp pre-push: commit ${rev:0:10} would publish a personal identifier in:" >&2
+            echo "$hits" | sed "s/^$rev:/  /" >&2
+            blocked=1
+        fi
+    done
+done
 
-if ! ( cd "$root" && python3 "$check" ); then
+if [ "$blocked" -ne 0 ]; then
     echo "" >&2
-    echo "romp pre-push: BLOCKED — a personal identifier was found (see above)." >&2
+    echo "romp pre-push: BLOCKED — a banned string from $strings_file is in a pushed commit." >&2
     echo "  Replace it with synthetic data (see CONTRIBUTING.md), then push again." >&2
+    echo "  If the string is only in an INTERMEDIATE commit, squash or rewrite the branch." >&2
     echo "  To bypass for one push (you are sure it is fine): git push --no-verify" >&2
     exit 1
 fi
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,14 +42,18 @@ This repo may go public; assume every commit is permanent and world-readable.
   catches it. Reuse the neutral demo domain the doc screenshots use (a
   `notes-api` with `web`/`api`/`tests` sessions) rather than inventing per-test
   worlds.
-- The maintainer's clone carries an UNTRACKED `tests/test_no_personal_identifiers.py`
-  that scans for that machine's own hostname, home path and private strings, wired
-  into the pre-push hook. It is deliberately not in the repo: those strings are
-  specific to one machine and mean nothing on anyone else's clone, so a
-  contributor's test run must never trip over it. Where it is absent, the hook and
-  its tests no-op. Either way it is a backstop, not the rule — the rule is the
-  bullets above. It also reads text only, so screenshots and recordings under
-  `docs/assets/` must be eyeballed for on-screen session content before release.
+- Two machine-local backstops enforce this, neither a substitute for the rule:
+  the `.githooks/pre-push` hook greps every PUSHED commit's tree for the strings
+  in `~/.config/romp/private-strings.txt` (absent file → no-op, so contributors
+  are unaffected; it scans pushed shas, not the working tree, so it arms every
+  worktree — a working-tree scan missed a leak pushed from a peer worktree on
+  2026-07-25); and the maintainer's clone carries an UNTRACKED
+  `tests/test_no_personal_identifiers.py` that scans the working tree for the
+  same strings plus that machine's hostname and home path. The pytest file is
+  deliberately not in the repo: one machine's identifiers mean nothing on anyone
+  else's clone, and a contributor's test run must never trip over it. Both read
+  text only, so screenshots and recordings under `docs/assets/` must be
+  eyeballed for on-screen session content before release.
 
 ## Worktrees — work on an isolated worktree by default (user rule, 2026-06-29)
 Do ALL non-trivial work on its own git worktree, not the shared main tree — concurrent

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3535,7 +3535,7 @@ def plan_units(session, store=None):
                 # (an API-error storm that exhausted; isApiError records don't count, same rule as the
                 # captioner). A work/nudge/delegation unit here hands the planner "USER ASKED: …" with no
                 # reply and frames it as a COMPLETED stretch — and a capable planner then answers the
-                # question FROM ITS OWN KNOWLEDGE and files done: solar_battery's wiring ask got a done
+                # question FROM ITS OWN KNOWLEDGE and files done: one session's wiring ask got a done
                 # verdict + a fully confabulated summary off a turn whose only record was "API Error: 529"
                 # (the user 2026-07-25). The ASK is still real: place it (mint-only prompt-run — its op
                 # filter cannot file done), so the card sits OPEN, which is the truth. Everything else

--- a/tests/install-sh.bats
+++ b/tests/install-sh.bats
@@ -240,10 +240,12 @@ PY
 
 # ── git pre-push identifier hook ──────────────────────────────────────
 # install.sh symlinks .githooks/pre-push into the shared git hooks dir. The hook
-# runs tests/test_no_personal_identifiers.py when that file is present and blocks
-# a push that would leak one of YOUR OWN identifiers. The scan is a personal,
-# machine-specific check, so it is deliberately not tracked (see .gitignore) and
-# the hook is a no-op without it. (ROMP_GITHOOK_DIR redirects the target below.)
+# reads the banned strings from ~/.config/romp/private-strings.txt (so it arms
+# EVERY worktree, not just the one holding an untracked scanner) and greps each
+# PUSHED commit's tree — the working tree is not what gets published, and a leak
+# in an intermediate commit ships even when the tip is clean. No strings file →
+# a no-op, so a contributor's clone is unaffected. (ROMP_GITHOOK_DIR redirects
+# install.sh's symlink target below; the behaviour tests copy the hook directly.)
 
 @test "install.sh: symlinks the pre-push hook into the git hooks dir" {
     run "$ROMP_DIR/install.sh"
@@ -261,24 +263,19 @@ PY
 # Behaviour of the hook itself, exercised through a real `git push` to a bare
 # remote, with a SYNTHETIC denylist (never a real identifier) via XDG_CONFIG_HOME.
 setup_hook_repo() {
-    # Nothing to exercise on a clone that carries no scan of its own.
-    [ -f "$ROMP_DIR/tests/test_no_personal_identifiers.py" ] \
-        || skip "no identifier scan present (it is a local-only check)"
     export XDG_CONFIG_HOME="$TEST_DIR/cfg"
     mkdir -p "$XDG_CONFIG_HOME/romp"
-    printf 'ZZBANNEDZZ\n' > "$XDG_CONFIG_HOME/romp/private-strings.txt"
+    printf '# synthetic denylist\n\nZZBANNEDZZ\n' > "$XDG_CONFIG_HOME/romp/private-strings.txt"
     git init -q "$TEST_DIR/remote.git" --bare
     WORK="$TEST_DIR/work"
     git init -q "$WORK"
     git -C "$WORK" config user.email t@e.invalid
     git -C "$WORK" config user.name t
-    mkdir -p "$WORK/tests"
-    cp "$ROMP_DIR/tests/test_no_personal_identifiers.py" "$WORK/tests/"
     cp "$ROMP_DIR/.githooks/pre-push" "$WORK/.git/hooks/pre-push"
     git -C "$WORK" remote add origin "$TEST_DIR/remote.git"
 }
 
-@test "pre-push hook: allows a push when the tree is clean" {
+@test "pre-push hook: allows a push when every pushed tree is clean" {
     setup_hook_repo
     echo "clean" > "$WORK/ok.txt"
     git -C "$WORK" add -A && git -C "$WORK" commit -qm clean
@@ -295,10 +292,52 @@ setup_hook_repo() {
     [[ "$output" == *"BLOCKED"* ]]
 }
 
+@test "pre-push hook: blocks a leak in an intermediate commit whose tip is clean" {
+    # The regression that motivated the pushed-tree scan: a string introduced and
+    # then removed mid-branch still ships in history even though the tip greps clean.
+    setup_hook_repo
+    printf 'leak ZZBANNEDZZ here\n' > "$WORK/leak.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm leak
+    git -C "$WORK" rm -q leak.txt && git -C "$WORK" commit -qm remove
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"BLOCKED"* ]]
+}
+
+@test "pre-push hook: only commits NEW to the remote are scanned" {
+    # A string that already escaped to the remote (before the denylist knew it)
+    # must not block every future push — only what this push publishes counts.
+    setup_hook_repo
+    printf 'old ZZBANNEDZZ\n' > "$WORK/old.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm old
+    git -C "$WORK" push --no-verify -q origin HEAD:main
+    git -C "$WORK" rm -q old.txt && git -C "$WORK" commit -qm clean-tip
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -eq 0 ]
+}
+
 @test "pre-push hook: --no-verify bypasses the block" {
     setup_hook_repo
     printf 'leak ZZBANNEDZZ here\n' > "$WORK/leak.txt"
     git -C "$WORK" add -A && git -C "$WORK" commit -qm leak
     run git -C "$WORK" push --no-verify origin HEAD:main
+    [ "$status" -eq 0 ]
+}
+
+@test "pre-push hook: no denylist file means the hook stays out of the way" {
+    setup_hook_repo
+    rm "$XDG_CONFIG_HOME/romp/private-strings.txt"
+    printf 'would leak ZZBANNEDZZ\n' > "$WORK/leak.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm leak
+    run git -C "$WORK" push origin HEAD:main
+    [ "$status" -eq 0 ]
+}
+
+@test "pre-push hook: a denylist of only comments and blanks bans nothing" {
+    setup_hook_repo
+    printf '# just a comment\n\n   \n' > "$XDG_CONFIG_HOME/romp/private-strings.txt"
+    printf 'ZZBANNEDZZ\n' > "$WORK/leak.txt"
+    git -C "$WORK" add -A && git -C "$WORK" commit -qm leak
+    run git -C "$WORK" push origin HEAD:main
     [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
A peer worktree pushed a judge comment naming a real session. The pre-push hook ran the untracked identifier scan from the worktree being pushed, and that file exists only in the shared checkout, so pushes from every other worktree were silently unscanned — which is where all the pushing happens.

The hook now reads the denylist from ~/.config/romp/private-strings.txt and greps each pushed commit's full tree: arms every worktree, and catches a string buried in an intermediate commit whose tip is clean. No denylist file = no-op, so contributor clones are unaffected and the hook's bats tests no longer skip on them (7 behaviour tests, 4 new). The leaked comment is redacted to a synthetic session.

Verified: install-sh.bats 23/23, judge.py compiles, denylist grep of the tree is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)