### PR TITLE
Docs CI: pin mkdocs-material to the 9.x major

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install MkDocs Material
-        run: pip install mkdocs-material
+        run: pip install "mkdocs-material~=9.0"
       - name: Build (strict — fails on broken links / orphan pages)
         run: mkdocs build --strict
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
The Material build banner warns MkDocs 2.0 will be backward-incompatible with no migration path. Unpinned `pip install mkdocs-material` would adopt it on release day and break the docs build on a repo not under active maintenance. `~=9.0` holds the current major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)