### PR TITLE
SDK backend: drain reaps still-closing CLIs; orphan census matches the SDK's real argv

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -726,14 +726,32 @@ def task_death_notice(tasks: list) -> str:
 _SDK_CLI_MARK = "--input-format stream-json"
 
 
+def _cli_carries_sid(cmd: str, sids) -> bool:
+    """True when this CLI's argv names one of OUR conversation ids. The Agent SDK has spelled the
+    flag BOTH ways across versions — `--resume <sid>` (space) and `--resume=<sid>` (equals) — and a
+    fresh-spawned, never-resumed CLI carries its id only as `--session-id[= ]<sid>`. The space-only
+    `--resume` match went blind when the SDK moved to the equals form: every boot reconcile logged
+    'reaped 0 orphaned CLI(s)' while a real orphan kept working the repo for over an hour
+    (2026-07-25, the twin incident — the restart's drain timed out on a busy session, the kernel
+    exited, and the census that should have caught the leftover matched nothing), and the interrupt
+    escalation could not find its own child to signal. Match every spelling."""
+    for s in sids:
+        if not s:
+            continue
+        for flag in ("--resume", "--session-id"):
+            if (flag + " " + s) in cmd or (flag + "=" + s) in cmd:
+                return True
+    return False
+
+
 def find_orphan_clis(ps_lines: list[str], lastsids: list[str]) -> list[int]:
-    """PIDs of ORPHANED SDK-driven `claude` CLIs resuming one of OUR sessions (`--resume <lastSid>`
-    + the stream-json mark). Orphaned = re-parented to launchd (ppid 1): a live SDK CLI is always a
-    child of the kernel that spawned it, so only a dead kernel's leftover — a zombie writer that
-    would fight the resume for the transcript — reaches ppid 1. The parent check is load-bearing:
-    matching on the command line alone let a duplicate backend's reconcile reap freshly-resumed
-    LIVE sessions mid-turn (2026-07-06). Pure (takes `ps -axo pid=,ppid=,command=` lines) so tests
-    need no live processes."""
+    """PIDs of ORPHANED SDK-driven `claude` CLIs holding one of OUR sessions (--resume/--session-id
+    in either flag spelling, + the stream-json mark — see _cli_carries_sid). Orphaned = re-parented
+    to launchd (ppid 1): a live SDK CLI is always a child of the kernel that spawned it, so only a
+    dead kernel's leftover — a zombie writer that would fight the resume for the transcript —
+    reaches ppid 1. The parent check is load-bearing: matching on the command line alone let a
+    duplicate backend's reconcile reap freshly-resumed LIVE sessions mid-turn (2026-07-06). Pure
+    (takes `ps -axo pid=,ppid=,command=` lines) so tests need no live processes."""
     out = []
     for ln in ps_lines:
         parts = ln.strip().split(None, 2)
@@ -744,17 +762,18 @@ def find_orphan_clis(ps_lines: list[str], lastsids: list[str]) -> list[int]:
             continue
         if _SDK_CLI_MARK not in cmd:
             continue
-        if any(s and ("--resume " + s) in cmd for s in lastsids):
+        if _cli_carries_sid(cmd, lastsids):
             out.append(pid)
     return out
 
 
 def find_session_cli(ps_lines: list[str], sids: list[str], parent_pid: int) -> int | None:
-    """The LIVE CLI pid resuming one of `sids` as a child of `parent_pid` (this kernel), or None.
-    The interrupt escalation's target: same signature match as find_orphan_clis (--resume + the
-    stream-json mark) but the OPPOSITE parent check — it may only signal our own child, never a tmux
-    CLI (no mark), never another kernel's, never an orphan (ppid 1, the reaper's territory). Pure
-    (takes `ps -axo pid=,ppid=,command=` lines) so tests need no live processes."""
+    """The LIVE CLI pid holding one of `sids` as a child of `parent_pid` (this kernel), or None.
+    The interrupt escalation's (and the drain reap's) target: same signature match as
+    find_orphan_clis (_cli_carries_sid + the stream-json mark) but the OPPOSITE parent check — it
+    may only signal our own child, never a tmux CLI (no mark), never another kernel's, never an
+    orphan (ppid 1, the reaper's territory). Pure (takes `ps -axo pid=,ppid=,command=` lines) so
+    tests need no live processes."""
     for ln in ps_lines:
         parts = ln.strip().split(None, 2)
         if len(parts) < 3 or not parts[0].isdigit() or not parts[1].isdigit():
@@ -762,7 +781,7 @@ def find_session_cli(ps_lines: list[str], sids: list[str], parent_pid: int) -> i
         pid, ppid, cmd = int(parts[0]), int(parts[1]), parts[2]
         if ppid != parent_pid or _SDK_CLI_MARK not in cmd:
             continue
-        if any(s and ("--resume " + s) in cmd for s in sids):
+        if _cli_carries_sid(cmd, sids):
             return pid
     return None
 
@@ -2138,14 +2157,22 @@ class SdkBackend:
         except Exception:
             self._log("boot reconcile failed: %s" % traceback.format_exc())
 
-    def drain(self, timeout: float = 2.0) -> dict:
+    def drain(self, timeout: float = 2.0, kill=os.kill) -> dict:
         """Graceful-shutdown drain (the kernel's SIGTERM handler): stop every running session cleanly
         within `timeout` — interrupt any in-flight turn and close the SDK clients so the claude
         subprocesses exit with us instead of being orphaned to launchd as zombie transcript-writers.
         Queued turns are already mirrored to the registry (_persist_queue). A cut turn's state log
         keeps its trailing 'working' (shutdown() writes no idle/waiting; _on_session_gone skips the
         settle when ended is set) — exactly the marker the NEXT kernel's boot reconcile resumes by.
-        Bounded so a routine `romp refresh` stays snappy."""
+        Bounded so a routine `romp refresh` stays snappy.
+
+        A session STILL CLOSING when the bound expires gets its CLI process reaped before we exit —
+        the bound alone orphaned a busy session's CLI (2026-07-25: 'still closing: logic', the
+        kernel exited, and the leftover CLI kept executing its turn — tools run in the CLI, so it
+        needs nothing from us — for over an hour while the next boot resumed the same conversation
+        into a second process). The turn is already marked working, so the reap loses nothing the
+        resume does not restore. SIGTERM first, a short existence poll, then SIGKILL; `kill` is the
+        test seam."""
         with self._lock:
             sessions = list(self.sessions.values())
         inflight = sum(1 for s in sessions if s.inflight)
@@ -2157,12 +2184,35 @@ class SdkBackend:
         deadline = time.time() + timeout
         for s in sessions:
             s.thread.join(max(0.05, deadline - time.time()))
-        unjoined = [s.name for s in sessions if s.thread.is_alive()]
+        unjoined = [s for s in sessions if s.thread.is_alive()]
+        reaped = []
+        for s in unjoined:
+            try:
+                pid = self._session_cli_pid(s)
+                if pid is None:
+                    continue
+                kill(pid, signal.SIGTERM)
+                for _ in range(20):                      # ~1s for the TERM to land
+                    time.sleep(0.05)
+                    try:
+                        kill(pid, 0)
+                    except ProcessLookupError:
+                        break
+                else:
+                    kill(pid, signal.SIGKILL)            # a wedged CLI still never outlives us
+                reaped.append("%s(pid %d)" % (s.name, pid))
+            except ProcessLookupError:
+                pass                                     # exited between the join and the reap — fine
+            except Exception:
+                self._log("drain: reap failed for %s: %s" % (s.name, traceback.format_exc()))
         if sessions:
-            self._log("drain: stopped %d session(s), %d in-flight turn(s) interrupted%s"
+            names = [s.name for s in unjoined]
+            self._log("drain: stopped %d session(s), %d in-flight turn(s) interrupted%s%s"
                       % (len(sessions), inflight,
-                         "; still closing: " + ", ".join(unjoined) if unjoined else ""))
-        return {"stopped": len(sessions), "inflight": inflight, "unjoined": len(unjoined)}
+                         "; still closing: " + ", ".join(names) if names else "",
+                         "; reaped: " + ", ".join(reaped) if reaped else ""))
+        return {"stopped": len(sessions), "inflight": inflight, "unjoined": len(unjoined),
+                "reaped": len(reaped)}
 
     def busy_count(self) -> int:
         """How many SDK sessions have a turn IN FLIGHT right now — the manager's quiet-window gate

--- a/tests/test_sdk_interrupt_escalation.py
+++ b/tests/test_sdk_interrupt_escalation.py
@@ -65,6 +65,12 @@ class FindSessionCli(unittest.TestCase):
     def test_junk_lines_are_skipped(self):
         self.assertIsNone(sb.find_session_cli(["", "not a ps line", "x y"], [SID], KERNEL))
 
+    def test_equals_flag_spelling_matches(self):
+        # The SDK's current argv spells it `--resume=<sid>`; the space-only match left the
+        # escalation unable to find its own child to signal (2026-07-25).
+        lines = ["  100 %d /x/claude --resume=%s --input-format stream-json" % (KERNEL, SID)]
+        self.assertEqual(sb.find_session_cli(lines, [SID], KERNEL), 100)
+
 
 class SourcePins(unittest.TestCase):
     """Wiring pins: the press routes through the ladder, failures are loud, episodes reset."""

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -20,6 +20,7 @@ All deterministic: no SDK import, no real claude processes (ps/os.kill are patch
 import json
 import os
 import tempfile
+import signal
 import threading
 import time
 import unittest
@@ -88,6 +89,20 @@ class FindOrphanClis(unittest.TestCase):
     def test_empty_sids_match_nothing(self):
         lines = [" 1 1 claude --resume  --input-format stream-json"]
         self.assertEqual(sb.find_orphan_clis(lines, [""]), [])
+
+    def test_equals_flag_spelling_matches(self):
+        # The Agent SDK moved to `--resume=<sid>` (equals form); the space-only match was blind to
+        # it, so every boot reconcile "reaped 0" while a real orphan kept working the repo for over
+        # an hour (2026-07-25, the twin incident). Both spellings, and --session-id for a CLI that
+        # was spawned fresh and never resumed, must match.
+        lines = [
+            " 5001 1 /x/claude --output-format stream-json --resume=%s --input-format stream-json" % self.SID,
+            " 5002 1 /x/claude --output-format stream-json --session-id=%s --input-format stream-json" % self.SID,
+            " 5003 1 /x/claude --output-format stream-json --session-id %s --input-format stream-json" % self.SID,
+            # equals form but a foreign sid → still not ours
+            " 5004 1 /x/claude --resume=ffffffff-0000-1111-2222-333333333333 --input-format stream-json",
+        ]
+        self.assertEqual(sb.find_orphan_clis(lines, [self.SID]), [5001, 5002, 5003])
 
 
 class QueuePersistence(unittest.TestCase):
@@ -389,7 +404,48 @@ class Drain(unittest.TestCase):
 
     def test_drain_with_nothing_running_is_a_quiet_noop(self):
         be = _backend()
-        self.assertEqual(be.drain(0.1), {"stopped": 0, "inflight": 0, "unjoined": 0})
+        self.assertEqual(be.drain(0.1), {"stopped": 0, "inflight": 0, "unjoined": 0, "reaped": 0})
+
+    def test_drain_reaps_the_cli_of_a_session_that_wont_close(self):
+        # The 2026-07-25 twin incident: the drain's bound expired on a busy session ("still
+        # closing: ..."), the kernel exited, and the orphaned CLI kept executing its turn for over
+        # an hour while the next boot resumed the same conversation into a second process. The
+        # drain must never exit leaving a live child: SIGTERM the unjoined session's CLI (then
+        # SIGKILL if it lingers).
+        d = tempfile.mkdtemp()
+        be = _backend(d)
+        sid = "11111111-aaaa-0000-0000-00000000000e"
+        s = sb.SdkSession(be, _reg(d, sid))
+        s.inflight = 1
+        s.thread = threading.Thread(target=lambda: time.sleep(5), daemon=True)
+        s.thread.start()                                  # outlives the drain bound → unjoined
+        be.sessions[sid] = s
+        be._session_cli_pid = lambda sess: 4242
+        calls = []
+        def fake_kill(pid, sig):
+            calls.append((pid, sig))
+            if sig == 0:
+                raise ProcessLookupError                  # the TERM landed; existence poll sees it gone
+        r = be.drain(0.1, kill=fake_kill)
+        self.assertEqual((r["unjoined"], r["reaped"]), (1, 1))
+        self.assertIn((4242, signal.SIGTERM), calls)
+        self.assertNotIn((4242, signal.SIGKILL), calls, "a TERM that lands never escalates")
+
+    def test_drain_sigkills_a_cli_that_ignores_term(self):
+        d = tempfile.mkdtemp()
+        be = _backend(d)
+        sid = "11111111-aaaa-0000-0000-00000000000f"
+        s = sb.SdkSession(be, _reg(d, sid))
+        s.thread = threading.Thread(target=lambda: time.sleep(5), daemon=True)
+        s.thread.start()
+        be.sessions[sid] = s
+        be._session_cli_pid = lambda sess: 4243
+        calls = []
+        def stubborn_kill(pid, sig):
+            calls.append((pid, sig))                      # sig 0 never raises → still alive
+        r = be.drain(0.1, kill=stubborn_kill)
+        self.assertEqual(r["reaped"], 1)
+        self.assertIn((4243, signal.SIGKILL), calls, "a wedged CLI still never outlives the kernel")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Root-cause fix for today's twin incident (an orphaned session CLI kept working the repo for an hour after a kernel restart, in parallel with its own resumed successor).

Two compounding defects:
1. **The orphan census and interrupt escalation were blind**: both matched `--resume <sid>` (space form) but the Agent SDK spawns `--resume=<sid>` (equals form) — every boot reconcile in the log's history says "reaped 0 orphaned CLI(s)". A shared `_cli_carries_sid` matcher now accepts both spellings plus `--session-id` (a fresh CLI that was never resumed).
2. **drain() never killed what wouldn't close**: at its bound it logged "still closing: ..." and let the kernel exit, orphaning a busy session's CLI. It now SIGTERMs the unjoined session's CLI (children-of-this-kernel only), polls briefly, SIGKILLs if wedged — the kernel never exits leaving a live child. The turn is already marked `working`, so boot reconcile resumes it losslessly.

Tests cover all matcher spellings and both reap paths (TERM lands / TERM ignored) over the real backend with a kill seam. Local green: pytest 3098, node 1333. CI still dead org-wide (billing). Landing code only — no restart here (holding per session ui's request until solar_battery finishes delivering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)