### PR TITLE
Federation: trust-by-origin without a tunnel + via-relay reach in the popover

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4275,6 +4275,71 @@ def _notify_bus_peer(host, port, up, peer_token="", trust="directed"):
         return False
 
 
+def _notify_bus_origin_trust(host, trust):
+    """Origin-only trust row → the local bus: no port, no dialer — just the tier the inbound gate
+    reads when mail from `host` arrives RELAYED through a hub (trust is judged by true origin, never
+    by the tunnel it rode in on — the user 2026-07-25). Guarded like _notify_bus_peer: postal being
+    down never breaks the caller; the supervisor re-pushes, and a restarted bus re-seeds from
+    /tunnels' `known` rows."""
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", BUS_PORT, timeout=2)
+        conn.request("POST", "/peer", json.dumps({"host": host, "trust": trust or "directed",
+                                                  "originOnly": True}),
+                     {"Content-Type": "application/json", "X-Romp-Token": TOKEN})
+        ok = conn.getresponse().status == 200
+        conn.close()
+        return ok
+    except Exception:
+        return False
+
+
+_origin_trust_pushed = {}   # host -> level the bus last acked (supervisor re-push memo)
+
+
+def _push_origin_trust_rows():
+    """Supervisor helper: push every remembered-but-unattached host's trust to the bus as an
+    origin-only row, once per (host, level). Attached hosts are the (up, trust)-keyed notify's job;
+    a host that attaches later drops out of this memo so the full notify owns it again."""
+    with _remotes_lock:
+        attached = set(_remotes)
+    for k in list_known():
+        h, tr = k.get("host"), k.get("trust") or "directed"
+        if not h:
+            continue
+        if h in attached:
+            _origin_trust_pushed.pop(h, None)
+            continue
+        if _origin_trust_pushed.get(h) != tr and _notify_bus_origin_trust(h, tr):
+            _origin_trust_pushed[h] = tr
+
+
+_via_cache = {"t": 0.0, "rows": []}
+
+
+def _bus_via_reach():
+    """The bus's via-reach summary for the popover: hosts with no tunnel here whose sessions a hub
+    gossips one hop (postal via_reach). Cached ~3s — it rides every /tunnels poll. Empty when the
+    bus is down or peering is off: the popover simply shows no relay section (display-only; the
+    trust GATE itself lives in the bus and fails safe to directed)."""
+    if not _postal_peers_on():
+        return []
+    now = time.time()
+    if now - _via_cache["t"] < 3.0:
+        return _via_cache["rows"]
+    rows = []
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", BUS_PORT, timeout=2)
+        conn.request("GET", "/peers", None, {"X-Romp-Token": TOKEN})
+        r = conn.getresponse()
+        if r.status == 200:
+            rows = (json.loads(r.read().decode() or "{}") or {}).get("viaReach") or []
+        conn.close()
+    except Exception:
+        rows = []
+    _via_cache["t"], _via_cache["rows"] = now, rows
+    return rows
+
+
 def _bus_quarantine_act(body):
     """Proxy a quarantine verdict (approve/deny, optional edited text) to the bus, which OWNS postal
     delivery and the held-message store. On approve the bus re-runs the peer's deliver(), so an approved
@@ -4338,19 +4403,31 @@ TRUST_LEVELS = ("trusted", "directed", "isolated")
 
 
 def set_trust(host, level):
-    """Set an attached host's federation trust level (the popover's per-host selector drives this).
+    """Set a host's federation trust level (the popover's per-host selector drives this).
     trusted = full bidirectional postal (a box you control); directed = its mail is HELD for human
     approval, never auto-injected (the safe default for rented/shared compute); isolated = no postal at
-    all, dashboard aggregation only. Persists and wakes the supervisor, which re-notifies the bus with
-    the new level on its next pass (the notify is keyed on (up, trust), so even a trusted<->directed
-    switch propagates). Returns (public_row, None) or (None, error)."""
+    all, dashboard aggregation only.
+
+    Trust is judged BY ORIGIN at delivery time, so the host does NOT have to be attached (the user
+    2026-07-25): mail from a machine you have no tunnel to arrives relayed one hop through a hub, and
+    the receiving bus still gates it by its true origin. An attached host's level lives on its remotes
+    row (the supervisor re-notifies the bus, keyed on (up, trust)); an unattached one lands in the
+    remembered-hosts table and reaches the bus as an ORIGIN-ONLY row — pushed now, re-pushed by the
+    supervisor, and re-seeded by a restarted bus from /tunnels' `known`. Returns (public_row, None)
+    or (None, error)."""
     if level not in TRUST_LEVELS:
         return None, "trust must be one of %s" % ", ".join(TRUST_LEVELS)
+    host = (host or "").strip()
+    if not host:
+        return None, "host required"
     with _remotes_lock:
         r = _remotes.get(host)
-        if r is None:
-            return None, "no attached host '%s'" % host
-        r["trust"] = level
+        if r is not None:
+            r["trust"] = level
+    if r is None:
+        _known_note(host, level)           # the remembered entry IS the origin-trust store
+        _notify_bus_origin_trust(host, level)   # best-effort now; the supervisor pass retries
+        return {"host": host, "trust": level, "originOnly": True}, None
     _remotes_save()
     _known_note(host, level)               # the remembered entry tracks the level, so a re-attach keeps it
     _tunnel_wake.set()                     # a prompt supervisor pass pushes the new level to the bus
@@ -5298,6 +5375,11 @@ def _tunnel_supervisor():
                         with _remotes_lock:
                             if r["host"] in _remotes:
                                 r["_handshook"] = pid
+            if _postal_peers_on():
+                # Trust-by-origin (the user 2026-07-25): remembered-but-unattached hosts carry a
+                # tier too — their mail arrives relayed through a hub and is judged by true origin.
+                # Once per (host, level); a failed push retries next pass.
+                _push_origin_trust_rows()
         except Exception:
             sys.stderr.write("tunnel-supervisor: %s\n" % traceback.format_exc())
         _tunnel_wake.wait(15)
@@ -13938,7 +14020,7 @@ paintIcon(ts.some(function(t){return t.status==='up';}),busy||!!pushing.length);
 icon.title=ts.length?('Remote kernels\\n'+ts.map(function(t){var n=(t.sids&&t.sids.length)||0;
 var ap=t.autoPush?('\\n    auto-update: '+(t.autoPush.detail||t.autoPush.phase)):'';
 return '\\u2022 '+t.host+': '+(LBL[t.status]||t.status)+' ('+n+' session'+(n===1?'':'s')+')'+(t.token?'':' \\u00b7 no token')+ap;}).join('\\n')):'Remote kernels \\u2014 none attached (click to connect)';
-if(!back.hidden)render(ts,(d&&d.known)||[],pmode);   // pmode is refresh-local — render must be GIVEN it
+if(!back.hidden)render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[]);   // pmode is refresh-local — render must be GIVEN it
 // while any tunnel is mid-attach, poll fast so the phase words (authorizing -> connecting -> connected)
 // are actually visible in the couple seconds it takes; settle to a slow keep-alive once all up/down.
 schedule((busy||pushing.length)?600:3000);   // poll fast while an auto-push runs, so its progress reads live
@@ -13954,7 +14036,13 @@ schedule(3000);});}
 // as a free variable threw ReferenceError on EVERY render, after list.innerHTML='' had already cleared the
 // list and before any row was appended. The panel therefore showed an empty host list no matter how many
 // hosts were attached, and the bare catch swallowed the error (the user 2026-07-22). Take it as a param.
-function render(ts,known,pmode){list.innerHTML='';known=known||[];
+function render(ts,known,pmode,via){list.innerHTML='';known=known||[];via=via||[];
+// Attached rows win; a via/known row for an attached host would be a duplicate.
+var live={};ts.forEach(function(t){live[t.host]=1;});
+via=via.filter(function(v){return !live[v.host];});
+var viaHosts={};via.forEach(function(v){viaHosts[v.host]=1;});
+known=known.filter(function(k){return !viaHosts[k.host];});   // a relay row shows the SAME trust select, plus live reach
+var TRUSTW={trusted:'trusted (auto-accept)',directed:'directed (held for you)',isolated:'isolated (no mail)'};
 // Every host romp knows about feeds the add box's completions, so a machine you typed in once is a
 // couple of keystrokes the next time even after you forget its exact spelling.
 _seen=ts.map(function(t){return t.host;}).concat(known.map(function(k){return k.host;}));fillHosts();
@@ -13998,7 +14086,6 @@ var keep=(pmode&&!t.checkinPeer)?'<label class=rnet-keep title=\"Publish this ma
 // your approval, never auto-injected; isolated = dashboard only, no postal. The gate lives in the bus.
 // Each option carries its own plain gloss: the bare words are romp's vocabulary, not English, and a
 // dropdown whose meaning only appears on hover makes you uncover every option before you can choose.
-var TRUSTW={trusted:'trusted (auto-accept)',directed:'directed (held for you)',isolated:'isolated (no mail)'};
 var tcur=t.trust||'directed';
 var trust='<span class=rnet-set><span class=rnet-lbl>Their mail</span><select class=rnet-trust data-t=\"'+t.host+'\" title=\"What happens to postal mail from '+t.host+'. trusted: delivered straight to your sessions. directed: held for your approval. isolated: none, dashboard only.\">'+
 ['trusted','directed','isolated'].map(function(v){return '<option value='+v+(tcur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select></span>';
@@ -14027,11 +14114,30 @@ if(known.length){var hd=document.createElement('div');hd.className='rnet-khead';
 hd.textContent='Previously attached';hd.title='Hosts you have attached before. They keep the trust level you last chose, so re-attaching restores it. Forget removes a host from this list.';
 list.appendChild(hd);
 known.forEach(function(k){var kr=document.createElement('div');kr.className='rnet-row rnet-known';
+var kcur=k.trust||'directed';
+// The SAME trust select as an attached row (data-t → /tunnels/trust): trust is judged by ORIGIN at
+// delivery, so the level applies to this host's mail even when it arrives relayed through a hub —
+// no tunnel required to set it (the user 2026-07-25).
+var ktrust='<select class=rnet-trust data-t=\"'+k.host+'\" title=\"What happens to postal mail from '+k.host+', however it arrives (a direct tunnel later, or relayed through a hub now): trusted = delivered straight to your sessions; directed = held for your approval; isolated = none.\">'+
+['trusted','directed','isolated'].map(function(v){return '<option value='+v+(kcur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select>';
 kr.innerHTML='<span class=rnet-dot style=\"background:transparent;box-shadow:inset 0 0 0 1.5px #5a5a5a\" title=\"Not attached right now.\"></span>'+
-'<span class=nm><b>'+k.host+'</b> <span class=st title=\"Trust level remembered from the last time this host was attached; re-attaching restores it.\">not attached \\u00b7 '+(k.trust||'directed')+'</span></span>'+
+'<span class=nm><b>'+k.host+'</b> <span class=st title=\"Not attached; the trust level applies to its mail by origin, and re-attaching keeps it.\">not attached</span></span>'+ktrust+
 '<button data-ra=\"'+k.host+'\" title=\"Open the ssh tunnel to '+k.host+' again, restoring its remembered trust level.\">Re-attach</button>'+
 '<button data-fg=\"'+k.host+'\" title=\"Remove '+k.host+' from this list. It does not touch the host itself; attaching again will re-add it.\">Forget</button>';
 list.appendChild(kr);});}
+// REACHABLE VIA RELAY (the user 2026-07-25): machines with no direct tunnel from here, one relay hop
+// away through an attached hub. Their mail is judged by ORIGIN, so the same trust select applies —
+// this is where the laptop tiers the remote server without ever holding ssh credentials for it.
+if(via.length){var vh=document.createElement('div');vh.className='rnet-khead';
+vh.textContent='Reachable via relay';vh.title='Machines you have no direct tunnel to; a hub you are attached to relays their mail one hop. Trust is judged by origin, so the level you set here applies to their mail even though it arrives through the hub.';
+list.appendChild(vh);
+via.forEach(function(v){var vr=document.createElement('div');vr.className='rnet-row rnet-known';
+var vcur=v.trust||'directed';
+var vtrust='<select class=rnet-trust data-t=\"'+v.host+'\" title=\"What happens to postal mail from '+v.host+' (it arrives relayed through '+v.via+'; trust is judged by its true origin): trusted = delivered straight to your sessions; directed = held for your approval; isolated = none.\">'+
+['trusted','directed','isolated'].map(function(w){return '<option value='+w+(vcur===w?' selected':'')+'>'+TRUSTW[w]+'</option>';}).join('')+'</select>';
+vr.innerHTML='<span class=rnet-dot style=\"background:transparent;box-shadow:inset 0 0 0 1.5px #7a6a3a\" title=\"No direct tunnel; reachable one hop through '+v.via+'.\"></span>'+
+'<span class=nm><b>'+v.host+'</b> <span class=st title=\"Its sessions are gossiped one hop by '+v.via+'; attach it directly for full control.\">via '+v.via+' \\u00b7 '+(v.agents||0)+' session'+((v.agents||0)===1?'':'s')+'</span></span>'+vtrust;
+list.appendChild(vr);});}
 list.querySelectorAll('select[data-t]').forEach(function(s){s.onchange=function(){var h=s.getAttribute('data-t');
 s.disabled=true;fetch('/tunnels/trust',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h,trust:s.value})}).then(function(r){return r.json();}).then(function(d){
 if(!(d&&d.ok)){alert('trust change on '+h+' failed: '+((d&&d.error)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
@@ -15046,6 +15152,7 @@ class Handler(BaseHTTPRequestHandler):
                 # re-attach rows instead of making you retype them.
                 return self._send(200, json.dumps({"tunnels": list_remotes(),
                                                    "known": list_known(),
+                                                   "viaReach": _bus_via_reach(),   # hosts one relay hop away (trust-by-origin rows hang here)
                                                    "autoUpdate": _auto_update_remotes_on(),   # the popover checkbox reflects the KERNEL, not this tab
                                                    "peersMode": _postal_peers_on()}),
                                   "application/json", cache="no-cache")

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1261,8 +1261,24 @@ def peer_update(data):
     """Apply one kernel notify. Returns (payload, status). `token` is the PEER machine's serve token
     (the kernel learned it at attach/checkin) — the dialer needs it because the peer's bus is
     token-gated too. `trust` is the per-host federation level (trusted|directed|isolated) the inbound
-    gate reads. A token-less/trust-less notify (e.g. a down transition) keeps the last known values."""
+    gate reads. A token-less/trust-less notify (e.g. a down transition) keeps the last known values.
+
+    ORIGIN-ONLY rows (the user 2026-07-25): {"host", "trust", "originOnly": true} with NO port sets a
+    tier for a host this machine has no tunnel to — its mail arrives RELAYED through a hub, and the
+    inbound gate judges by TRUE ORIGIN, so the tier needs a row here with nothing to dial. Portless,
+    never given a dialer; applied to a CONNECTED row it touches only the trust."""
     host = str(data.get("host") or "").strip()
+    if data.get("originOnly"):
+        trust = str(data.get("trust") or "").strip()
+        if not host or trust not in ("trusted", "directed", "isolated"):
+            return {"error": "host and trust (trusted|directed|isolated) required"}, 400
+        prev = PEERS.get(host) or {}
+        row = {"port": prev.get("port"), "up": bool(prev.get("up")), "at": int(time.time()),
+               "token": prev.get("token") or "", "trust": trust}
+        if not prev.get("port"):
+            row["originOnly"] = True
+        PEERS[host] = row
+        return {"ok": True, "originOnly": True}, 200
     port = data.get("port")
     if not host or not isinstance(port, int) or isinstance(port, bool) or not (0 < port < 65536):
         return {"error": "host and port required"}, 400
@@ -1274,8 +1290,28 @@ def peer_update(data):
     _peer_threads_reconcile(host)                    # an up peer gets its dialer; a down one is woken to exit
     return {"ok": True, "up": sum(1 for p in PEERS.values() if p["up"])}, 200
 
+def via_reach():
+    """Hosts reachable only THROUGH a directly-peered hub: the far spokes whose sessions a hub
+    gossips with `via` labels (fleet_presence — one hop, never re-gossiped). One row per far host:
+    {"host", "via", "agents", "seenAgo", "trust"} — the popover's "reachable via relay" section, and
+    the hook a trust-by-origin tier hangs on even though no tunnel to that host exists here."""
+    now, out = int(time.time()), {}
+    for hub, st in PEER_STATE.items():
+        age = int(now - (st.get("seenAt") or 0))
+        for pa in st.get("presence") or []:
+            far = pa.get("via")
+            if not far:      # a hub's exchange never gossips OUR sessions back (fleet_presence
+                continue     # excludes the asking host), so no self-row can appear here
+            if (PEERS.get(far) or {}).get("port"):    # directly peered here → its own row, not via
+                continue
+            e = out.setdefault(far, {"host": far, "via": hub, "agents": 0, "seenAgo": age,
+                                     "trust": (PEERS.get(far) or {}).get("trust") or "directed"})
+            e["agents"] += 1
+            e["seenAgo"] = min(e["seenAgo"], age)
+    return sorted(out.values(), key=lambda e: e["host"])
+
 def peers_snapshot():
-    return {"peers": {h: dict(p) for h, p in PEERS.items()}}
+    return {"peers": {h: dict(p) for h, p in PEERS.items()}, "viaReach": via_reach()}
 
 # ── peering protocol (peer-bus mode, stage 2) ───────────────────────────────────
 # One EXCHANGE carries both directions (plans/postal-peer-buses.md): the dialer POSTs
@@ -1724,13 +1760,23 @@ def _seed_peers_from_kernel():
     try:
         req = urllib.request.Request(KERNEL_BASE + "/tunnels", headers={"X-Romp-Token": SERVE_TOKEN})
         with urllib.request.urlopen(req, timeout=3) as r:
-            rows = json.loads(r.read().decode() or "{}").get("tunnels") or []
+            payload = json.loads(r.read().decode() or "{}") or {}
+        rows = payload.get("tunnels") or []
         for row in rows:
             port = row.get("busPort")
             if row.get("host") and isinstance(port, int) and port:
                 peer_update({"host": row["host"], "port": port, "up": row.get("status") == "up",
                              "token": row.get("token") or "",   # the peer's serve token — its bus is gated too
                              "trust": row.get("trust") or "directed"})   # per-host trust for the inbound gate
+        # Origin-only trust heals on restart too: the kernel's remembered-hosts list (`known` in the
+        # same payload) carries the tier for every UNATTACHED host the user has set one on; without
+        # this a bus bounce would silently drop a relayed origin back to `directed` (the user
+        # 2026-07-25, trust-by-origin).
+        attached = {row.get("host") for row in rows}
+        for k in payload.get("known") or []:
+            if k.get("host") and k["host"] not in attached:
+                peer_update({"host": k["host"], "trust": k.get("trust") or "directed",
+                             "originOnly": True})
     except Exception:
         pass                                         # no kernel yet → the notify path fills the table
 

--- a/tests/test_kernel_trust.py
+++ b/tests/test_kernel_trust.py
@@ -58,10 +58,42 @@ class SetTrust(unittest.TestCase):
         self.assertIsNone(pub)
         self.assertIn("trust must be one of", err)
 
-    def test_set_trust_unknown_host(self):
-        pub, err = km.set_trust("NOPE", "trusted")
-        self.assertIsNone(pub)
-        self.assertTrue(err.startswith("no attached"))
+    def test_set_trust_unattached_host_is_origin_only(self):
+        # Trust is judged BY ORIGIN at delivery (the user 2026-07-25): a host with no tunnel here —
+        # its mail arrives relayed through a hub — can carry a tier. The level lands in the
+        # remembered-hosts table and reaches the bus as an origin-only row.
+        calls = []
+        saved = km._notify_bus_origin_trust
+        km._notify_bus_origin_trust = lambda h, t: calls.append((h, t)) or True
+        try:
+            pub, err = km.set_trust("FARBOX", "trusted")
+        finally:
+            km._notify_bus_origin_trust = saved
+        self.assertIsNone(err)
+        self.assertEqual(pub, {"host": "FARBOX", "trust": "trusted", "originOnly": True})
+        self.assertEqual(km.known_trust("FARBOX"), "trusted", "the remembered table IS the store")
+        self.assertEqual(calls, [("FARBOX", "trusted")], "the bus learns the origin row now")
+
+    def test_push_origin_trust_rows_covers_only_unattached(self):
+        # The supervisor pushes remembered-but-unattached tiers once per (host, level); attached
+        # hosts stay the (up, trust)-keyed full notify's job.
+        km._remotes.clear()
+        km._remotes["TESTHOST"] = _row("TESTHOST")
+        km._known.clear()                         # order-independent: other tests seed this table
+        km._known_note("TESTHOST", "trusted")     # attached → not this path's job
+        km._known_note("FARBOX", "isolated")      # unattached → pushed
+        km._origin_trust_pushed.clear()
+        calls = []
+        saved = km._notify_bus_origin_trust
+        km._notify_bus_origin_trust = lambda h, t: calls.append((h, t)) or True
+        try:
+            km._push_origin_trust_rows()
+            km._push_origin_trust_rows()          # memoized: no duplicate push
+            km._known_note("FARBOX", "directed")  # a level CHANGE re-pushes
+            km._push_origin_trust_rows()
+        finally:
+            km._notify_bus_origin_trust = saved
+        self.assertEqual(calls, [("FARBOX", "isolated"), ("FARBOX", "directed")])
 
     def test_load_defaults_missing_trust_to_directed(self):
         # a pre-trust remotes.json row (no "trust" key) reads back as directed
@@ -109,9 +141,17 @@ class TrustRoute(unittest.TestCase):
         self.assertEqual(code, 400)
         self.assertFalse(data["ok"])
 
-    def test_route_unknown_host_404(self):
-        code, data = self._post("/tunnels/trust", {"host": "GHOST", "trust": "trusted"})
-        self.assertEqual(code, 404)
+    def test_route_unattached_host_sets_origin_trust(self):
+        km._remotes.clear()
+        saved = km._notify_bus_origin_trust
+        km._notify_bus_origin_trust = lambda h, t: True
+        try:
+            code, data = self._post("/tunnels/trust", {"host": "GHOST", "trust": "trusted"})
+        finally:
+            km._notify_bus_origin_trust = saved
+        self.assertEqual(code, 200)
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["tunnel"], {"host": "GHOST", "trust": "trusted", "originOnly": True})
 
 
 class QuarantineCards(unittest.TestCase):

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -59,6 +59,50 @@ class PeerMode(unittest.TestCase):
             self.assertEqual(status, 400, "rejected: %r" % (bad,))
         self.assertEqual(pm.PEERS, {}, "nothing recorded from rejected notifies")
 
+    def test_origin_only_row_stores_trust_without_a_port(self):
+        # Trust-by-origin (the user 2026-07-25): a tier for a host with no tunnel here. Portless,
+        # no dialer, judged at delivery by true origin.
+        payload, status = pm.peer_update({"host": "FARBOX", "trust": "trusted", "originOnly": True})
+        self.assertEqual(status, 200)
+        self.assertTrue(payload["originOnly"])
+        row = pm.peers_snapshot()["peers"]["FARBOX"]
+        self.assertEqual((row["port"], row["up"], row["trust"], row.get("originOnly")),
+                         (None, False, "trusted", True))
+        # applied to a CONNECTED row it touches only the trust — port/up/token survive
+        pm.peer_update({"host": "HUB", "port": 50007, "up": True, "token": "tk", "trust": "trusted"})
+        pm.peer_update({"host": "HUB", "trust": "directed", "originOnly": True})
+        row = pm.peers_snapshot()["peers"]["HUB"]
+        self.assertEqual((row["port"], row["up"], row["token"], row["trust"], row.get("originOnly")),
+                         (50007, True, "tk", "directed", None))
+
+    def test_origin_only_validates(self):
+        for bad in ({"originOnly": True}, {"host": "h", "originOnly": True},
+                    {"host": "h", "trust": "bogus", "originOnly": True}):
+            payload, status = pm.peer_update(bad)
+            self.assertEqual(status, 400, "rejected: %r" % (bad,))
+
+    def test_via_reach_summarizes_far_spokes(self):
+        pm.PEER_STATE.clear()
+        try:
+            import time as _t
+            pm.PEER_STATE["hub"] = {"presence": [
+                {"name": "a", "id": "1"},                       # the hub's own session — not via
+                {"name": "b", "id": "2", "via": "FARBOX"},
+                {"name": "c", "id": "3", "via": "FARBOX"},
+                {"name": "d", "id": "4", "via": "PEERED"},      # directly peered here → excluded
+            ], "seenAt": int(_t.time())}
+            pm.peer_update({"host": "PEERED", "port": 50008, "up": True})
+            pm.peer_update({"host": "FARBOX", "trust": "isolated", "originOnly": True})
+            rows = pm.via_reach()
+            self.assertEqual(len(rows), 1)
+            r = rows[0]
+            self.assertEqual((r["host"], r["via"], r["agents"], r["trust"]),
+                             ("FARBOX", "hub", 2, "isolated"))
+            self.assertEqual(pm.peers_snapshot()["viaReach"], rows,
+                             "the snapshot carries the summary for the kernel's popover proxy")
+        finally:
+            pm.PEER_STATE.clear()
+
     def test_routes_are_wired(self):
         import inspect
         src = inspect.getsource(pm)

--- a/tests/test_postal_quarantine.py
+++ b/tests/test_postal_quarantine.py
@@ -82,6 +82,17 @@ class InboundTrustGate(unittest.TestCase):
         self.assertEqual(len(ps.quarantine_list()), 1)
         self.assertEqual(ps.read_box("sess-web", consume=False), [])
 
+    def test_origin_only_trust_row_governs_relayed_mail(self):
+        # Trust-by-origin end to end (the user 2026-07-25): the user tiers a host they have NO
+        # tunnel to (an origin-only, portless row); its mail arriving relayed through a hub is
+        # judged by that tier — trusted injects instead of holding.
+        self._set_trust("EDGE", "trusted")                      # the hub we ARE connected to
+        ps.peer_update({"host": "ORIGIN", "trust": "trusted", "originOnly": True})
+        verdict, _ = ps._relay_in("EDGE", _relay("q-origin-1", origin="ORIGIN"))
+        self.assertEqual(verdict, "ack")
+        self.assertEqual(len(list(ps.QUARANTINE.glob("*.json"))), 0,
+                         "an origin-only trusted tier delivers, no hold")
+
     def test_forwarded_origin_is_the_trust_key(self):
         # A 2-hop message carries m["origin"] = the true origin; the gate keys on it, not the direct peer.
         self._set_trust("EDGE", "trusted")       # the direct peer we received from

--- a/tests/test_remotes_panel_render.py
+++ b/tests/test_remotes_panel_render.py
@@ -134,8 +134,8 @@ class RemotesPanelRender(unittest.TestCase):
 
     def test_render_is_given_pmode_rather_than_reading_it_free(self):
         js = km._LANDING_REMOTES_JS
-        self.assertIn("function render(ts,known,pmode)", js)
-        self.assertIn("render(ts,(d&&d.known)||[],pmode)", js)
+        self.assertIn("function render(ts,known,pmode,via)", js)
+        self.assertIn("render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[])", js)
 
     def test_the_per_host_settings_sit_on_their_own_line(self):
         # Trust and check-in are set once and left; Detach is an act. Splitting them off line 1 is what

--- a/ui/webview/net-popover-known.test.ts
+++ b/ui/webview/net-popover-known.test.ts
@@ -16,8 +16,9 @@ const STRIP = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf
 test("web popover renders remembered hosts with re-attach + forget", () => {
   // pmode rides along as a PARAM: it is computed in refresh()'s callback, and reading it as a free
   // variable in render() threw ReferenceError on every draw (see tests/test_remotes_panel_render.py)
-  assert.match(KERNEL, /function render\(ts,known,pmode\)/, "render takes the known list + pmode");
-  assert.match(KERNEL, /if\(!back\.hidden\)render\(ts,\(d&&d\.known\)\|\|\[\],pmode\);/, "refresh passes them through");
+  assert.match(KERNEL, /function render\(ts,known,pmode,via\)/, "render takes the known list + pmode + via-reach");
+  assert.match(KERNEL, /if\(!back\.hidden\)render\(ts,\(d&&d\.known\)\|\|\[\],pmode,\(d&&d\.viaReach\)\|\|\[\]\);/, "refresh passes them through");
+  assert.match(KERNEL, /Reachable via relay/, "via-reach hosts get their own section (trust-by-origin rows)");
   assert.match(KERNEL, /Previously attached/);
   assert.match(KERNEL, /data-ra=/, "a Re-attach control keyed by host");
   assert.match(KERNEL, /data-fg=/, "a Forget control keyed by host");


### PR DESCRIPTION
First slice of the approved federation-UI direction (task: dual-view control, hybrid routing).

- **Trust-by-origin**: the bus takes portless origin-only peer rows; `set_trust` works for unattached hosts (remembered-hosts table is the store; supervisor re-push + bus-restart re-seed keep it in force). Trust stays per-machine, origin-judged, never gossiped.
- **Popover**: previously-attached rows get the live trust selector; a new 'Reachable via relay' section lists one-hop hosts (bus `via_reach` over gossiped presence) with the same selector — the exact laptop-tiers-the-remote-server flow from the walkthrough, no ssh credentials needed.
- End-to-end test: an origin-only trusted tier makes relayed mail deliver instead of quarantine.

Still open on this task (follow-up slices): attach-on-behalf ('connect from: this machine / home server') and two-hop quarantine-hold surfacing. Local green: pytest 3103 / node 1333 / tsc. CI still dead org-wide (billing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)