### PR TITLE
Federation: attach-on-behalf + fleet-wide quarantine-hold visibility

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4313,31 +4313,39 @@ def _push_origin_trust_rows():
             _origin_trust_pushed[h] = tr
 
 
-_via_cache = {"t": 0.0, "rows": []}
+_via_cache = {"t": 0.0, "snap": {}}
 
 
-def _bus_via_reach():
-    """The bus's via-reach summary for the popover: hosts with no tunnel here whose sessions a hub
-    gossips one hop (postal via_reach). Cached ~3s — it rides every /tunnels poll. Empty when the
-    bus is down or peering is off: the popover simply shows no relay section (display-only; the
-    trust GATE itself lives in the bus and fails safe to directed)."""
+def _bus_peers_snap():
+    """The bus's /peers snapshot (via-reach rows + remote hold summaries), cached ~3s — it rides
+    every /tunnels poll. Empty when the bus is down or peering is off: the popover simply shows no
+    relay/holds sections (display-only; the trust GATE itself lives in the bus and fails safe to
+    directed)."""
     if not _postal_peers_on():
-        return []
+        return {}
     now = time.time()
     if now - _via_cache["t"] < 3.0:
-        return _via_cache["rows"]
-    rows = []
+        return _via_cache["snap"]
+    snap = {}
     try:
         conn = http.client.HTTPConnection("127.0.0.1", BUS_PORT, timeout=2)
         conn.request("GET", "/peers", None, {"X-Romp-Token": TOKEN})
         r = conn.getresponse()
         if r.status == 200:
-            rows = (json.loads(r.read().decode() or "{}") or {}).get("viaReach") or []
+            snap = json.loads(r.read().decode() or "{}") or {}
         conn.close()
     except Exception:
-        rows = []
-    _via_cache["t"], _via_cache["rows"] = now, rows
-    return rows
+        snap = {}
+    _via_cache["t"], _via_cache["snap"] = now, snap
+    return snap
+
+
+def _bus_via_reach():
+    return _bus_peers_snap().get("viaReach") or []
+
+
+def _bus_remote_holds():
+    return _bus_peers_snap().get("remoteHolds") or []
 
 
 def _bus_quarantine_act(body):
@@ -13951,6 +13959,7 @@ if(!icon||!back)return;
 var hostIn=document.getElementById('rnet-host'),attach=document.getElementById('rnet-attach'),
 list=document.getElementById('rnet-list'),x=document.getElementById('rnet-x'),dl=document.getElementById('rnet-hosts'),
 plus=document.getElementById('rnet-plus'),addBox=document.getElementById('rnet-add'),hint=document.getElementById('rnet-hint'),
+fromSel=document.getElementById('rnet-from'),
 more=document.getElementById('rnet-more'),sub=document.getElementById('rnet-sub'),
 autoCb=document.getElementById('rnet-auto');
 // "Automatically update" writes to the KERNEL (fleet-wide, one owner) and re-reads the kernel's answer, so
@@ -14020,7 +14029,7 @@ paintIcon(ts.some(function(t){return t.status==='up';}),busy||!!pushing.length);
 icon.title=ts.length?('Remote kernels\\n'+ts.map(function(t){var n=(t.sids&&t.sids.length)||0;
 var ap=t.autoPush?('\\n    auto-update: '+(t.autoPush.detail||t.autoPush.phase)):'';
 return '\\u2022 '+t.host+': '+(LBL[t.status]||t.status)+' ('+n+' session'+(n===1?'':'s')+')'+(t.token?'':' \\u00b7 no token')+ap;}).join('\\n')):'Remote kernels \\u2014 none attached (click to connect)';
-if(!back.hidden)render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[]);   // pmode is refresh-local — render must be GIVEN it
+if(!back.hidden)render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[],(d&&d.remoteHolds)||[]);   // pmode is refresh-local — render must be GIVEN it
 // while any tunnel is mid-attach, poll fast so the phase words (authorizing -> connecting -> connected)
 // are actually visible in the couple seconds it takes; settle to a slow keep-alive once all up/down.
 schedule((busy||pushing.length)?600:3000);   // poll fast while an auto-push runs, so its progress reads live
@@ -14036,9 +14045,15 @@ schedule(3000);});}
 // as a free variable threw ReferenceError on EVERY render, after list.innerHTML='' had already cleared the
 // list and before any row was appended. The panel therefore showed an empty host list no matter how many
 // hosts were attached, and the bare catch swallowed the error (the user 2026-07-22). Take it as a param.
-function render(ts,known,pmode,via){list.innerHTML='';known=known||[];via=via||[];
+function render(ts,known,pmode,via,rholds){list.innerHTML='';known=known||[];via=via||[];rholds=rholds||[];
 // Attached rows win; a via/known row for an attached host would be a duplicate.
 var live={};ts.forEach(function(t){live[t.host]=1;});
+// "connect from" (attach-on-behalf, the user 2026-07-25): offer every CONNECTED host as a tunnel
+// owner; hidden while this machine is the only choice. Rebuilt per render, keeping the selection.
+if(fromSel){var ups=ts.filter(function(t){return t.status==='up';}).map(function(t){return t.host;});
+var fcur=fromSel.value;
+fromSel.innerHTML="<option value=''>from: this machine</option>"+ups.map(function(h){return '<option value="'+h+'"'+(fcur===h?' selected':'')+'>from: '+h+'</option>';}).join('');
+fromSel.hidden=!ups.length;}
 via=via.filter(function(v){return !live[v.host];});
 var viaHosts={};via.forEach(function(v){viaHosts[v.host]=1;});
 known=known.filter(function(k){return !viaHosts[k.host];});   // a relay row shows the SAME trust select, plus live reach
@@ -14138,6 +14153,20 @@ var vtrust='<select class=rnet-trust data-t=\"'+v.host+'\" title=\"What happens 
 vr.innerHTML='<span class=rnet-dot style=\"background:transparent;box-shadow:inset 0 0 0 1.5px #7a6a3a\" title=\"No direct tunnel; reachable one hop through '+v.via+'.\"></span>'+
 '<span class=nm><b>'+v.host+'</b> <span class=st title=\"Its sessions are gossiped one hop by '+v.via+'; attach it directly for full control.\">via '+v.via+' \\u00b7 '+(v.agents||0)+' session'+((v.agents||0)===1?'':'s')+'</span></span>'+vtrust;
 list.appendChild(vr);});}
+// HELD ELSEWHERE (the user 2026-07-25): mail waiting for approval on OTHER machines — direct peers
+// and one relay hop — which used to be visible only on the holding machine's own dashboard. One
+// line per machine (count first, gists on hover); acting on them still happens on that machine.
+if(rholds.length){var byHost={};rholds.forEach(function(h){(byHost[h.atHost]=byHost[h.atHost]||[]).push(h);});
+var hh=document.createElement('div');hh.className='rnet-khead';
+hh.textContent='Held for approval elsewhere';
+hh.title='Postal mail quarantined on another machine (its trust for the sender is directed). Open that machine\u2019s dashboard to approve or deny; the hold itself lives there.';
+list.appendChild(hh);
+Object.keys(byHost).sort().forEach(function(hn){var rows=byHost[hn];
+var gl=rows.slice(0,6).map(function(r){return r.frm+' \\u2192 '+r.to+((r.origin&&r.origin!==hn)?' (from '+r.origin+')':'')+': '+(r.gist||'');}).join('\\n');
+var hr=document.createElement('div');hr.className='rnet-row rnet-known';
+hr.innerHTML='<span class=rnet-dot style=\"background:#b58900\" title=\"Mail is waiting for approval on '+hn+'.\"></span>'+
+'<span class=nm><b>'+hn+'</b> <span class=st title=\"'+gl.replace(/\"/g,'&quot;')+'\">'+rows.length+' message'+(rows.length===1?'':'s')+' held for your approval</span></span>';
+list.appendChild(hr);});}
 list.querySelectorAll('select[data-t]').forEach(function(s){s.onchange=function(){var h=s.getAttribute('data-t');
 s.disabled=true;fetch('/tunnels/trust',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h,trust:s.value})}).then(function(r){return r.json();}).then(function(d){
 if(!(d&&d.ok)){alert('trust change on '+h+' failed: '+((d&&d.error)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
@@ -14176,9 +14205,14 @@ icon.classList.add('busy');var mb=mnet();if(mb)mb.classList.add('busy');   // mo
 // A typed host can simply be wrong (a typo, or a string ssh cannot parse — the kernel rejects those in
 // _safe_ssh_host), which never used to be possible when the only way in was picking from a dropdown.
 // Say so instead of quietly restoring the button and leaving an unchanged list to explain itself.
-fetch('/tunnels',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h})}).then(function(r){return r.json();}).then(function(d){
+var payload={host:h};
+var frm=fromSel&&!fromSel.hidden?fromSel.value:'';   // attach-on-behalf: that machine dials + owns the tunnel
+if(frm)payload.from=frm;
+fetch('/tunnels',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)}).then(function(r){return r.json();}).then(function(d){
 attach.disabled=false;attach.textContent='Attach';
-if(d&&d.ok){hostIn.value='';showAdd(false);}   // it has a row of its own now, so the form's work is done
+if(d&&d.ok&&d.via){hostIn.value='';showAdd(false);
+alert(d.via+' is opening the tunnel to '+h+' and will own it. Watch it on '+d.via+"'s dashboard; its sessions reach yours through the relay.");}
+else if(d&&d.ok){hostIn.value='';showAdd(false);}   // it has a row of its own now, so the form's work is done
 else{alert('Could not attach '+h+': '+((d&&d.error)||'unknown'));}
 refresh();}).catch(function(){attach.disabled=false;attach.textContent='Attach';
 alert('Could not attach '+h+': the kernel did not answer.');});};
@@ -14537,6 +14571,7 @@ def _landing():
             ".rnet-add{display:flex;gap:6px;margin-top:11px;padding-top:11px;border-top:1px solid #2a2a2a}"
             ".rnet-add[hidden]{display:none}"
             "#rnet-host{flex:1 1 auto;min-width:0;background:#121212;color:#ccc;border:1px solid #3a3a3a;border-radius:6px;padding:4px 6px;font:inherit}"
+            "#rnet-from{flex:0 0 auto;max-width:44%;background:#121212;color:#ccc;border:1px solid #3a3a3a;border-radius:6px;padding:4px 6px;font:inherit}"
             "#rnet-attach{flex:0 0 auto;background:var(--accent);color:var(--accent-fg);border:none;border-radius:6px;padding:4px 12px;font-weight:600;cursor:pointer}"
             "#rnet-attach:disabled{opacity:0.5;cursor:default}"
             ".rnet-hint{color:#6e7681;font-size:11.5px;line-height:1.45;margin-top:6px}"
@@ -14888,7 +14923,13 @@ def _landing():
             "<div class=rnet-add id=rnet-add hidden>"
             "<input id=rnet-host list=rnet-hosts placeholder='hostname or user@host' "
             "autocapitalize=off autocorrect=off spellcheck=false>"
-            "<datalist id=rnet-hosts></datalist><button id=rnet-attach>Attach</button></div>"
+            "<datalist id=rnet-hosts></datalist>"
+            "<select id=rnet-from title='Which machine opens and owns the ssh tunnel. This machine: the "
+            "tunnel lives here and drops when this kernel stops. An attached host: the attach request is "
+            "forwarded to that kernel, which dials out itself; pick your always-on box so the connection "
+            "outlives this laptop. That machine needs its own ssh access to the target.' hidden>"
+            "<option value=''>from: this machine</option></select>"
+            "<button id=rnet-attach>Attach</button></div>"
             "<div class=rnet-hint id=rnet-hint hidden>Any ssh target you could type after <code>ssh</code>: a "
             "<code>~/.ssh/config</code> alias, or <code>user@host</code>. Hosts you attach are remembered here.</div>"
             "</div></div>"
@@ -15153,6 +15194,7 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, json.dumps({"tunnels": list_remotes(),
                                                    "known": list_known(),
                                                    "viaReach": _bus_via_reach(),   # hosts one relay hop away (trust-by-origin rows hang here)
+                                                   "remoteHolds": _bus_remote_holds(),   # quarantine holds on OTHER machines (direct peers + one relay hop)
                                                    "autoUpdate": _auto_update_remotes_on(),   # the popover checkbox reflects the KERNEL, not this tab
                                                    "peersMode": _postal_peers_on()}),
                                   "application/json", cache="no-cache")
@@ -15419,6 +15461,12 @@ class Handler(BaseHTTPRequestHandler):
                 # Attach a remote kernel: open its ssh tunnels + fetch its token so the browser can merge
                 # its fleet. Body: {"host": <any ssh target>, "kernelPort"?: <remote port>}. The blocking ssh
                 # round-trip (token fetch) is fine on the threaded server. Returns the public tunnel row.
+                #
+                # ATTACH ON BEHALF (the user 2026-07-25): {"from": <attached host>} forwards the attach to
+                # THAT machine's kernel over its -L tunnel, so the always-on box can OWN the tunnel while
+                # you sit at the laptop ("connect from: home server"). The far kernel runs the same
+                # attach_remote — ssh reachability and credentials are judged THERE, never here; we only
+                # relay the ask and bubble its answer. Loud when the from-host is not attached/up.
                 try:
                     body = json.loads(raw_body or b"{}")
                 except Exception:
@@ -15426,6 +15474,25 @@ class Handler(BaseHTTPRequestHandler):
                 host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
                 if not host:
                     return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
+                frm = str((body or {}).get("from") or "").strip() if isinstance(body, dict) else ""
+                if frm:
+                    with _remotes_lock:
+                        r = _remotes.get(frm)
+                        r = dict(r) if r else None
+                    if not r or r.get("status") != "up":
+                        return self._send(200, json.dumps({"ok": False, "error":
+                            "'%s' is not an attached, connected host — attach it first, then it can "
+                            "own tunnels for you" % frm}), "application/json")
+                    fwd = {"host": host}
+                    if (body or {}).get("kernelPort"):
+                        fwd["kernelPort"] = body["kernelPort"]
+                    res = _remote_forward(r, "/tunnels", fwd)
+                    if res is None:
+                        return self._send(200, json.dumps({"ok": False, "error":
+                            "the kernel on '%s' didn't answer the attach request" % frm}), "application/json")
+                    res = dict(res) if isinstance(res, dict) else {"ok": False, "error": "bad answer"}
+                    res["via"] = frm
+                    return self._send(200, json.dumps(res), "application/json")
                 try:
                     pub = attach_remote(host, (body or {}).get("kernelPort"))
                 except Exception as e:

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1310,8 +1310,51 @@ def via_reach():
             e["seenAgo"] = min(e["seenAgo"], age)
     return sorted(out.values(), key=lambda e: e["host"])
 
+def _hold_rows():
+    """This bus's OWN quarantine holds, summarized for gossip: enough for a peer's popover to say who
+    is waiting where (mid, from -> to, true origin, a one-line gist) without shipping bodies around.
+    Bounded — past 20 the COUNT is the story and the holder's own dashboard has the rest."""
+    out = []
+    try:
+        for f in sorted(QUARANTINE.glob("*.json")):
+            try:
+                m = json.loads(f.read_text())
+            except Exception:
+                continue
+            out.append({"mid": m.get("mid"), "frm": m.get("frm") or "?", "to": m.get("to") or "?",
+                        "origin": m.get("origin") or "", "at": m.get("at") or 0,
+                        "gist": " ".join(str(m.get("body") or "").split())[:90]})
+    except OSError:
+        pass
+    return out[:20]
+
+def holds_payload(exclude_host):
+    """Quarantine-hold summaries for an exchange payload: our own + ONE hop from our other peers,
+    labeled `via` and never re-gossiped — the same shape as fleet_presence, so a spoke can SEE the
+    mail held for approval on the far spoke (the user 2026-07-25: a hold two machines away used to
+    be invisible everywhere but on that machine's own dashboard)."""
+    out = list(_hold_rows())
+    for h, st in PEER_STATE.items():
+        if h == exclude_host:
+            continue
+        for hd in st.get("holds") or []:
+            if hd.get("via"):
+                continue
+            out.append(dict(hd, via=h))
+    return out
+
+def remote_holds():
+    """Every hold we know about on OTHER machines, stamped with the machine that HOLDS it (`atHost`
+    = the via label when relayed, else the direct peer). The kernel proxies this to the popover."""
+    out = []
+    for h, st in PEER_STATE.items():
+        for hd in st.get("holds") or []:
+            out.append(dict(hd, atHost=hd.get("via") or h))
+    return out
+
 def peers_snapshot():
-    return {"peers": {h: dict(p) for h, p in PEERS.items()}, "viaReach": via_reach()}
+    return {"peers": {h: dict(p) for h, p in PEERS.items()}, "viaReach": via_reach(),
+            "remoteHolds": remote_holds()}
 
 # ── peering protocol (peer-bus mode, stage 2) ───────────────────────────────────
 # One EXCHANGE carries both directions (plans/postal-peer-buses.md): the dialer POSTs
@@ -1613,7 +1656,7 @@ def peer_exchange_handle(data):
         return {"error": "peer protocol drift (theirs %r, ours %r) — update romp on one side"
                 % ((data or {}).get("proto"), PEER_PROTO), "proto": PEER_PROTO}, 409
     PEER_STATE[host] = {"presence": data.get("presence") or [], "epoch": data.get("epoch"),
-                        "seenAt": int(time.time())}
+                        "holds": data.get("holds") or [], "seenAt": int(time.time())}
     for mid in data.get("acks") or []:               # the dialer confirmed relays landed — end-to-end:
         _ack_arrived(host, mid)                      # a forwarded one relays its ack back to the origin
     for b in data.get("bounces") or []:              # ...or refused them → backward, or to our sender
@@ -1644,14 +1687,16 @@ def peer_exchange_handle(data):
         a2, b2 = _drain_backflow()
         acks, bounces = acks + a2, bounces + b2
     return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO,
-            "presence": fleet_presence(host), "relays": rel, "acks": acks, "bounces": bounces}, 200
+            "presence": fleet_presence(host), "holds": holds_payload(host),
+            "relays": rel, "acks": acks, "bounces": bounces}, 200
 
 def build_exchange_request(host, wait=True):
     p = _pending(host)
     with _peer_lock:
         acks, bounces = list(p["acks"]), list(p["bounces"])
     return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO,
-            "presence": fleet_presence(host), "relays": outbox_list(host),
+            "presence": fleet_presence(host), "holds": holds_payload(host),
+            "relays": outbox_list(host),
             "acks": acks, "bounces": bounces, "wait": bool(wait)}
 
 def peer_exchange_apply(host, req_sent, resp):
@@ -1662,7 +1707,7 @@ def peer_exchange_apply(host, req_sent, resp):
         p["acks"] = [a for a in p["acks"] if a not in (req_sent.get("acks") or [])]
         p["bounces"] = [b for b in p["bounces"] if b not in (req_sent.get("bounces") or [])]
     PEER_STATE[host] = {"presence": resp.get("presence") or [], "epoch": resp.get("epoch"),
-                        "seenAt": int(time.time())}
+                        "holds": resp.get("holds") or [], "seenAt": int(time.time())}
     for mid in resp.get("acks") or []:
         _ack_arrived(host, mid)
     for b in resp.get("bounces") or []:

--- a/tests/test_kernel_attach_on_behalf.py
+++ b/tests/test_kernel_attach_on_behalf.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Attach-on-behalf (the user 2026-07-25): POST /tunnels with {"from": <attached host>} forwards the
+attach to THAT machine's kernel over its -L tunnel, so an always-on box can OWN a tunnel while you sit
+at the laptop. The far kernel judges ssh reachability itself; this side only relays and bubbles the
+answer, loudly when the from-host is not attached/up."""
+import http.client
+import json
+import os
+import tempfile
+import threading
+import unittest
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_aob", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _row(host, **extra):
+    r = {"host": host, "kernel_port": 29855, "local_port": 5000, "bus_port": 5001, "token": "t",
+         "proc": None, "status": "up", "detail": "", "sids": [], "trust": "directed"}
+    r.update(extra)
+    return r
+
+
+class AttachOnBehalf(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.srv.server_close()
+
+    def setUp(self):
+        km._remotes.clear()
+
+    def _post(self, body):
+        c = http.client.HTTPConnection("127.0.0.1", self.port, timeout=5)
+        c.request("POST", "/tunnels", json.dumps(body),
+                  {"Content-Type": "application/json", "X-Romp-Token": km.TOKEN})
+        r = c.getresponse()
+        data = json.loads(r.read().decode() or "{}")
+        c.close()
+        return r.status, data
+
+    def test_forwards_to_the_owning_kernel_and_bubbles_its_answer(self):
+        km._remotes["HUB"] = _row("HUB")
+        calls = []
+        saved = km._remote_forward
+        km._remote_forward = (lambda r, path, body:
+                              calls.append((r["host"], path, dict(body))) or
+                              {"ok": True, "tunnel": {"host": body["host"], "status": "starting"}})
+        try:
+            code, data = self._post({"host": "FAR", "from": "HUB"})
+        finally:
+            km._remote_forward = saved
+        self.assertEqual(code, 200)
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["via"], "HUB", "the answer names which machine owns the tunnel")
+        self.assertEqual(data["tunnel"]["host"], "FAR")
+        self.assertEqual(calls, [("HUB", "/tunnels", {"host": "FAR"})],
+                         "exactly one relay, to the from-host's kernel, attach body only")
+
+    def test_from_host_must_be_attached_and_up(self):
+        code, data = self._post({"host": "FAR", "from": "GHOST"})
+        self.assertEqual(code, 200)
+        self.assertFalse(data["ok"])
+        self.assertIn("not an attached, connected host", data["error"])
+        km._remotes["HUB"] = _row("HUB", status="down")
+        code, data = self._post({"host": "FAR", "from": "HUB"})
+        self.assertFalse(data["ok"], "a down from-host is refused loudly, never queued")
+
+    def test_far_kernel_silence_is_loud(self):
+        km._remotes["HUB"] = _row("HUB")
+        saved = km._remote_forward
+        km._remote_forward = lambda r, path, body: None
+        try:
+            code, data = self._post({"host": "FAR", "from": "HUB"})
+        finally:
+            km._remote_forward = saved
+        self.assertEqual(code, 200)
+        self.assertFalse(data["ok"])
+        self.assertIn("didn't answer", data["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -2,6 +2,7 @@
 """Peer-bus mode stage 1 (plans/postal-peer-buses.md): every machine runs its OWN bus — the
 client-only special case is retired under the flag — and the kernel feeds the bus a peer table
 over POST /peer on tunnel transitions. Synthetic only."""
+import json
 import os
 import tempfile
 import unittest
@@ -165,6 +166,34 @@ class TwoBusExchange(unittest.TestCase):
         pm.peer_exchange_apply("srv", req, resp)
         return resp
 
+    def test_quarantine_holds_cross_the_exchange_both_ways(self):
+        # Slice 4 of the federation UI (the user 2026-07-25): each side's exchange payload carries a
+        # summary of ITS held mail, so a hold is visible from the peer instead of only on the
+        # holding machine's own dashboard.
+        import shutil
+        for m in (pm, pmb):
+            shutil.rmtree(m.QUARANTINE, ignore_errors=True)
+        try:
+            pmb.QUARANTINE.mkdir(parents=True, exist_ok=True)
+            (pmb.QUARANTINE / "h1.json").write_text(json.dumps(
+                {"mid": "h1", "to": "beta", "frm": "api", "origin": "TESTHOST",
+                 "body": "please review the parser fix before it merges", "at": 1000}))
+            pm.QUARANTINE.mkdir(parents=True, exist_ok=True)
+            (pm.QUARANTINE / "h2.json").write_text(json.dumps(
+                {"mid": "h2", "to": "alpha", "frm": "web", "origin": "", "body": "ping", "at": 1001}))
+            self._exchange()
+            got = pm.PEER_STATE["srv"]["holds"]
+            self.assertEqual([(h["mid"], h["frm"], h["to"], h["origin"]) for h in got],
+                             [("h1", "api", "beta", "TESTHOST")], "B's hold arrived at A")
+            self.assertIn("please review the parser fix", got[0]["gist"])
+            self.assertEqual(pm.remote_holds()[0]["atHost"], "srv",
+                             "stamped with the machine HOLDING it")
+            got_b = pmb.PEER_STATE["hosta"]["holds"]
+            self.assertEqual([h["mid"] for h in got_b], ["h2"], "A's hold rode the request to B")
+        finally:
+            for m in (pm, pmb):
+                shutil.rmtree(m.QUARANTINE, ignore_errors=True)
+
     def test_mail_crosses_and_acks_clear_the_outbox(self):
         pm.outbox_put("srv", {"mid": "m1", "to": "beta", "frm": "alpha", "frm_id": "sid-a",
                               "body": "hello over the wire", "kind": "question", "t": 1})
@@ -280,6 +309,32 @@ class ThreeBusRelay(unittest.TestCase):
         names = {(a.get("name"), a.get("via")) for a in pm.PEER_STATE["hub"]["presence"]}
         self.assertIn(("beta", None), names)
         self.assertIn(("carol", "hostc"), names, "the far spoke arrives labeled via, one hop only")
+
+    def test_far_holds_gossip_via_the_hub_one_hop_only(self):
+        # A hold TWO machines away (on C) reaches A labeled via the hub — and never re-gossips
+        # further (the same one-hop rule as presence).
+        import shutil
+        for m in (pm, pmb, pmc):
+            shutil.rmtree(m.QUARANTINE, ignore_errors=True)
+        try:
+            pmc.QUARANTINE.mkdir(parents=True, exist_ok=True)
+            (pmc.QUARANTINE / "h9.json").write_text(json.dumps(
+                {"mid": "h9", "to": "carol", "frm": "ops", "origin": "RENTBOX",
+                 "body": "held on the far spoke", "at": 1002}))
+            self._xchg(pmc, pmb, "hub")              # B learns C's hold (direct, no via)
+            self._xchg(pm, pmb, "hub")               # A learns it via the hub
+            got = [h for h in pm.PEER_STATE["hub"]["holds"] if h["mid"] == "h9"]
+            self.assertEqual(len(got), 1)
+            self.assertEqual(got[0].get("via"), "hostc", "labeled with the machine holding it")
+            self.assertEqual([r["atHost"] for r in pm.remote_holds() if r["mid"] == "h9"],
+                             ["hostc"])
+            self.assertNotIn("via", [k for h in pmb.PEER_STATE["hostc"]["holds"] for k in h
+                                     if k == "via"], "the direct hop carries no via label")
+            # A never re-gossips the via-labeled hold onward (one hop, like presence)
+            self.assertEqual([h for h in pm.holds_payload("elsewhere") if h["mid"] == "h9"], [])
+        finally:
+            for m in (pm, pmb, pmc):
+                shutil.rmtree(m.QUARANTINE, ignore_errors=True)
 
     def test_relay_hops_once_with_end_to_end_acks(self):
         self._xchg(pmc, pmb, "hub")

--- a/tests/test_remotes_panel_render.py
+++ b/tests/test_remotes_panel_render.py
@@ -134,8 +134,8 @@ class RemotesPanelRender(unittest.TestCase):
 
     def test_render_is_given_pmode_rather_than_reading_it_free(self):
         js = km._LANDING_REMOTES_JS
-        self.assertIn("function render(ts,known,pmode,via)", js)
-        self.assertIn("render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[])", js)
+        self.assertIn("function render(ts,known,pmode,via,rholds)", js)
+        self.assertIn("render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[],(d&&d.remoteHolds)||[])", js)
 
     def test_the_per_host_settings_sit_on_their_own_line(self):
         # Trust and check-in are set once and left; Detach is an act. Splitting them off line 1 is what

--- a/ui/webview/net-popover-known.test.ts
+++ b/ui/webview/net-popover-known.test.ts
@@ -16,8 +16,10 @@ const STRIP = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf
 test("web popover renders remembered hosts with re-attach + forget", () => {
   // pmode rides along as a PARAM: it is computed in refresh()'s callback, and reading it as a free
   // variable in render() threw ReferenceError on every draw (see tests/test_remotes_panel_render.py)
-  assert.match(KERNEL, /function render\(ts,known,pmode,via\)/, "render takes the known list + pmode + via-reach");
-  assert.match(KERNEL, /if\(!back\.hidden\)render\(ts,\(d&&d\.known\)\|\|\[\],pmode,\(d&&d\.viaReach\)\|\|\[\]\);/, "refresh passes them through");
+  assert.match(KERNEL, /function render\(ts,known,pmode,via,rholds\)/, "render takes the known list + pmode + via-reach + remote holds");
+  assert.match(KERNEL, /if\(!back\.hidden\)render\(ts,\(d&&d\.known\)\|\|\[\],pmode,\(d&&d\.viaReach\)\|\|\[\],\(d&&d\.remoteHolds\)\|\|\[\]\);/, "refresh passes them through");
+  assert.match(KERNEL, /Held for approval elsewhere/, "remote holds get their own section");
+  assert.match(KERNEL, /rnet-from/, "the add box offers which machine owns the tunnel (attach-on-behalf)");
   assert.match(KERNEL, /Reachable via relay/, "via-reach hosts get their own section (trust-by-origin rows)");
   assert.match(KERNEL, /Previously attached/);
   assert.match(KERNEL, /data-ra=/, "a Re-attach control keyed by host");


### PR DESCRIPTION
Slices 3+4 of the approved federation direction, completing task #10.

- **Attach on behalf**: `POST /tunnels {host, from}` relays the attach to the from-host's kernel over its -L tunnel — the always-on box dials and owns the connection while you drive from the laptop. The add-host form gains a `from:` picker (hidden unless a connected host could own the tunnel). Loud refusals for unattached/down from-hosts and silent far kernels.
- **Quarantine holds fleet-wide**: exchange payloads carry bounded hold summaries, gossiped one hop with via labels like presence; the popover's new 'Held for approval elsewhere' section shows count-per-machine with gists on hover. Acting on a hold still happens on the holding machine (remote approve/deny is a possible future increment). Additive protocol change — proto stays 1, old buses interoperate.

Tests: forward/refusal paths, two-bus and three-bus (via-hub) hold gossip incl. the one-hop guarantee, panel-render harness + pins. Local green: pytest 3108 / node 1333 / tsc. Org CI still down (billing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)