### PR TITLE
Stalls are session-scoped and live-verified, and the stall chip is actually yellow

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -234,6 +234,15 @@ STALLER_ON = os.environ.get("ROMP_STALLER", "1") != "0"   # the stall note (2026
 # definition or the two drift. 2 = "the reason survived the next gate run", which is the EVENT that separates
 # a genuine wedge from the momentary reasons (a judge pass in flight) every working goal reports in passing.
 STALL_SEEN = 2
+# The nudge gate's "the judge itself could still move this card" reason — same one-definition rule as
+# STALL_SEEN: the kernel mints it (_revivers_pending) and both stall readers (kernel _stalled_goals,
+# stalled_facts below) verify it through stall_why_stands. The LEGACY string is the pre-2026-07-25 GLOBAL
+# form, deferred on ANY judge activity anywhere — but the producer opens a fleet-wide pass every ~3s, so
+# that was cadence, not a reviver: adjacent gate ticks routinely both landed inside (different) routine
+# passes, the string-keyed seen counter read them as one non-retiring wedge, and false "stalled" cards
+# minted fleet-wide. A legacy record names no session, so its claim is unverifiable and never stands.
+WHY_JUDGING = "romp's own review of this session is mid-flight"
+_WHY_JUDGING_LEGACY = "a judge pass is mid-flight"
 # The CONSOLIDATOR (the user 2026-06-19): the grouper's twin for the COMPLETED column. The working grouper
 # only ever sees OPEN tops, so related goals that finish before they get
 # grouped land as separate cards. The consolidator groups related ALL-COMPLETED sibling tops under a
@@ -6940,6 +6949,22 @@ def stall_llm(goal_text, work_text, holding):
     return _judge_run(_triage_model(), STALL_BRIEF_SYS, user, judge="staller").strip()   # caller splits SOURCE, then caps
 
 
+def stall_why_stands(why, fsid):
+    """True when a recorded stall reason still holds RIGHT NOW. A deferral record is a cache of the gate's
+    last run, and the gate only re-runs (and pops it) while its session stays idle-and-due — a session that
+    resumes work, or goes awaiting, freezes the record with whatever reason it last held, and by 2026-07-25
+    the live file held records frozen for days presenting a present-tense claim. The judging reason is
+    live-verifiable (active_runs IS the authority for "is a judge call on this session in flight"), so both
+    stall readers verify it here instead of presenting the frozen claim; a legacy global record named no
+    session and can never be verified, so it never stands. Other reasons pass through: their truth lives in
+    stores this predicate can't reach, and their own passes reconcile the records that carry them."""
+    if why == WHY_JUDGING:
+        return bool(fsid) and any(r.get("fsid") == fsid for r in active_runs())
+    if why == _WHY_JUDGING_LEGACY:
+        return False
+    return True
+
+
 def stalled_facts(fsid):
     """{gid: {"why", "since"}} for THIS session's goals the kernel's nudge gate is holding on a reviver that
     isn't retiring — the mechanical stall reasons it records in auto-nudge.json (kernel _stalled_goals is the
@@ -6957,7 +6982,7 @@ def stalled_facts(fsid):
             why, at, seen = rec.get("why"), int(rec.get("at") or 0), int(rec.get("seen") or 1)
         except (TypeError, ValueError):
             continue
-        if why and at and seen >= STALL_SEEN:
+        if why and at and seen >= STALL_SEEN and stall_why_stands(str(why), fsid):
             out[str(gid)] = {"why": str(why), "since": at}
     return out
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2105,8 +2105,17 @@ def _revivers_pending(sid, store, turns, gid):
     try:
         if _retry_paused_on():
             return "the judge tiers are paused (nothing could revive it)"
-        if _goals_snap[0] is not None or jd.active_runs():
-            return "a judge pass is mid-flight"
+        if any(r.get("fsid") == sid for r in jd.active_runs()):
+            # THIS session's judge call only (2026-07-25). The old form deferred on ANY pass activity
+            # (_goals_snap non-None, or any active run anywhere) — but the producer opens a fleet-wide
+            # pass every ~3s, so "a pass is mid-flight" was the CADENCE, not a reviver: adjacent gate
+            # ticks routinely both landed inside (different) routine passes, the string-keyed seen
+            # counter read them as one non-retiring wedge, and false "stalled" cards minted fleet-wide
+            # (29 live records, median age 45h, when caught). A call in flight for THIS fsid is the
+            # event-true signal that a verdict for this store may be about to land; the small window
+            # between that call returning and its save is covered by the fire path's last-moment store
+            # re-read (_nudge_fire_list).
+            return jd.WHY_JUDGING
         if nd.get("followupPending"):
             return "your reply to the card is still being judged"
         if nd.get("nodeComplete"):
@@ -2157,18 +2166,19 @@ def _deferral_seen(rec):
     return 2
 
 
-def _nudge_deferred_ok(gid, reason, now):
+def _nudge_deferred_ok(gid, reason, now, sid=None):
     """True when a deferral has run past the backstop and the nudge must go anyway. A reviver that never
     clears is a MISSING event — exactly the case the awaiting backstop exists for — and "never miss a
     nudge" outranks "wait for everything" once the wait itself looks wedged.
 
     Records WHY it deferred and how many consecutive gate runs have said the same thing, not just when it
     started (the user 2026-07-23, who wanted a stalled card to say what the wait is on). The why is what
-    the stall brief is grounded in; `seen` is what separates a real stall from the churn. Most reasons are
-    momentary — "a judge pass is mid-flight" is true of every working goal for the length of any pass — and
-    those clear on the very next run, which pops the record. A reason still standing on the NEXT run is one
-    no mechanism is retiring, which is the wedge worth explaining. That second observation is the event;
-    nothing here consults a clock (the backstop above is the one deliberate exception)."""
+    the stall brief is grounded in; `seen` is what separates a real stall from the churn. A reason still
+    standing on the NEXT run is one no mechanism is retiring, which is the wedge worth explaining. That
+    second observation is the event; nothing here consults a clock (the backstop above is the one
+    deliberate exception). `sid` rides the record so the stall readers can live-verify a session-scoped
+    reason (jd.stall_why_stands) — the record freezes whenever the gate walk stops running for its
+    session, and a frozen claim must be verifiable or it is not presented."""
     d = _auto_nudge_data()
     dd = dict(d.get("deferred") or {})
     if not reason:
@@ -2180,19 +2190,19 @@ def _nudge_deferred_ok(gid, reason, now):
     rec = dd.get(gid)
     first = _deferral_at(rec)
     if first is None:
-        dd[gid] = {"at": int(now), "why": reason, "seen": 1}
+        dd[gid] = {"at": int(now), "why": reason, "seen": 1, "sid": sid}
         d["deferred"] = dd
         _write_auto_nudge(d)
         return False
     if _deferral_why(rec) != reason:                     # the wait moved to a DIFFERENT reviver: keep the
         # clock (the card has been stuck since `first` either way) but restart the run count, so a goal
         # bouncing between two momentary reasons never reads as wedged on either one.
-        dd[gid] = {"at": first, "why": reason, "seen": 1}
+        dd[gid] = {"at": first, "why": reason, "seen": 1, "sid": sid}
         d["deferred"] = dd
         _write_auto_nudge(d)
     elif _deferral_seen(rec) < _STALL_SEEN:              # same reason again → it is not self-clearing.
         # Stops counting at the threshold so a long wedge isn't a write per tick.
-        dd[gid] = {"at": first, "why": reason, "seen": _deferral_seen(rec) + 1}
+        dd[gid] = {"at": first, "why": reason, "seen": _deferral_seen(rec) + 1, "sid": sid}
         d["deferred"] = dd
         _write_auto_nudge(d)
     return (now - first) > NUDGE_DEFER_BACKSTOP_SECS
@@ -2203,12 +2213,23 @@ def _stalled_goals():
     romp has decided the card is stalled and is deliberately not acting on it. Read by build_feed (the card's
     Stalled section) and mirrored into the goal store for the judge's stall brief. A goal romp already nudged
     is NOT here: that one is visibly in flight, and it escalates to a real block through _mark_nudge_failed,
-    which carries its own decision brief."""
+    which carries its own decision brief.
+
+    LIVE-VERIFIED at read time (2026-07-25): a deferral record only pops when the gate walk re-runs, and the
+    walk stops the moment its session leaves idle-and-due — so a record freezes with whatever reason it last
+    held (records were found frozen for DAYS presenting "mid-flight" in the present tense). A reason whose
+    truth is checkable right now must check out, or the record is skipped (it still pops normally on the
+    next gate walk); reasons whose truth lives in the stores pass through — their own passes reconcile them."""
     out = {}
     for gid, rec in (_auto_nudge_data().get("deferred") or {}).items():
         why, at = _deferral_why(rec), _deferral_at(rec)
-        if why and at and _deferral_seen(rec) >= _STALL_SEEN:
-            out[gid] = {"why": why, "since": at}
+        if not (why and at and _deferral_seen(rec) >= _STALL_SEEN):
+            continue
+        if not jd.stall_why_stands(why, rec.get("sid") if isinstance(rec, dict) else None):
+            continue                                     # frozen judging claim, live-false (or legacy/unverifiable)
+        if why.startswith("the judge tiers are paused") and not _retry_paused_on():
+            continue                                     # tiers resumed while the record was frozen
+        out[gid] = {"why": why, "since": at}
     return out
 
 
@@ -2403,7 +2424,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor):
         # card's 'working' came from a STALE agent-to-do mirror, and the nudge fired before the sync that
         # would have completed it. Backstopped, so a wedged reviver defers the nudge but can never lose it.
         _defer = _revivers_pending(sid, store, turns, gid)
-        if _defer and not _nudge_deferred_ok(gid, _defer, now):
+        if _defer and not _nudge_deferred_ok(gid, _defer, now, sid):
             continue
         rec = nudged.get(gid) or {}
         # Fire at most ONCE per GENUINE stall — keyed on arm_id, the newest genuinely-triggered ended
@@ -2436,7 +2457,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor):
                 # thing to act: it may only fire once every other reviver is exhausted (_revivers_pending
                 # is re-checked here because the fire gate and this writer read different moments).
                 _sdefer = _revivers_pending(sid, store, turns, gid)
-                if _sdefer and not _nudge_deferred_ok(gid, _sdefer, now):
+                if _sdefer and not _nudge_deferred_ok(gid, _sdefer, now, sid):
                     continue                           # something else can still move it → not needs-you
                 _mark_nudge_failed(gid, ev_t=(resp or {}).get("t") or lt.get("end") or lt.get("t"))
                 nudged[gid] = dict(rec, failed=True)   # mirror in-memory for the rest of this tick

--- a/tests/test_kernel_nudge_last_resort.py
+++ b/tests/test_kernel_nudge_last_resort.py
@@ -173,9 +173,23 @@ class OtherReviverGates(Base):
         km._retry_paused_on = lambda: True
         self.assertIn("paused", km._revivers_pending(SID, _store(), _turns(), GID))
 
-    def test_a_pass_in_flight_defers(self):
+    def test_a_judge_call_for_this_session_defers(self):
+        jd.active_runs = lambda: [{"judge": "closer", "fsid": SID, "sent": 1.0}]
+        self.assertEqual(km._revivers_pending(SID, _store(), _turns(), GID), jd.WHY_JUDGING)
+
+    def test_another_sessions_judge_call_does_not_defer(self):
+        # SESSION-SCOPED (2026-07-25): another session's judging cannot revive THIS card, so it must not
+        # hold this card's nudge — the old any-run-anywhere form starved nudges fleet-wide.
+        jd.active_runs = lambda: [{"judge": "closer",
+                                   "fsid": "99999999-8888-7777-6666-555555555555", "sent": 1.0}]
+        self.assertEqual(km._revivers_pending(SID, _store(), _turns(), GID), "")
+
+    def test_the_global_pass_snapshot_does_not_defer(self):
+        # The producer opens a pass (and its feed snapshot) every ~3s for the WHOLE fleet — that is the
+        # cadence of the kernel, not a reviver for this card. Deferring on it let two adjacent gate ticks
+        # land inside two DIFFERENT routine passes and mint a false "stalled" card (2026-07-25).
         km._goals_snap[0] = {}
-        self.assertIn("mid-flight", km._revivers_pending(SID, _store(), _turns(), GID))
+        self.assertEqual(km._revivers_pending(SID, _store(), _turns(), GID), "")
 
     def test_a_reply_being_judged_defers(self):
         st = _store(followupPending=True)
@@ -206,11 +220,12 @@ class DeferBackstop(Base):
         super().tearDown()
 
     def test_first_deferral_holds_the_nudge(self):
-        self.assertFalse(km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW))
-        # the record carries WHY it deferred, not just when (2026-07-23) — the stall note is grounded in it
+        self.assertFalse(km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW, SID))
+        # the record carries WHY it deferred, not just when (2026-07-23) — the stall note is grounded in
+        # it — and WHOSE session it is (2026-07-25), so the stall readers can live-verify a frozen claim
         self.assertEqual(self._d["deferred"][GID],
-                         {"at": NOW, "why": "the agent's to-do sync is due", "seen": 1},
-                         "the first deferral is stamped with its reason")
+                         {"at": NOW, "why": "the agent's to-do sync is due", "seen": 1, "sid": SID},
+                         "the first deferral is stamped with its reason and session")
 
     def test_a_legacy_bare_int_deferral_still_backstops(self):
         # A live state file written before the record grew a reason still holds bare epoch ints; reading one
@@ -250,9 +265,8 @@ class StalledGoals(Base):
         super().tearDown()
 
     def test_one_deferral_is_not_yet_a_stall(self):
-        # Most reasons are momentary — "a judge pass is mid-flight" is true of every working goal for the
-        # length of any pass — and clear on the next run. Calling that a stall would light every card.
-        km._nudge_deferred_ok(GID, "a judge pass is mid-flight", NOW)
+        # Most reasons are momentary and clear on the next run. Calling one a stall would light every card.
+        km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW, SID)
         self.assertEqual(km._stalled_goals(), {}, "a reason seen ONCE is churn, not a wedge")
 
     def test_the_same_reason_twice_is_a_stall(self):
@@ -263,10 +277,10 @@ class StalledGoals(Base):
                          "a reason that survived the next gate run is a wedge, dated from when it started")
 
     def test_a_reason_that_changes_restarts_the_count_but_not_the_clock(self):
-        km._nudge_deferred_ok(GID, "a judge pass is mid-flight", NOW)
-        km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW + 30)
+        km._nudge_deferred_ok(GID, "the card is already complete and merely unsettled", NOW, SID)
+        km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW + 30, SID)
         self.assertEqual(km._stalled_goals(), {}, "bouncing between reasons is not wedged on either one")
-        km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW + 60)
+        km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW + 60, SID)
         self.assertEqual(km._stalled_goals()[GID]["since"], NOW,
                          "…but the card HAS been stuck since the first deferral, so the clock is kept")
 
@@ -286,6 +300,49 @@ class StalledGoals(Base):
             km._nudge_deferred_ok(GID, "the agent's to-do sync is due", NOW + 30 * (i + 1))
         self.assertEqual(len(writes), 1,
                          "the run count stops at the threshold — a wedge is not a file write per tick")
+
+    def test_a_judging_stall_shows_only_while_the_call_is_in_flight(self):
+        # LIVE-VERIFIED (2026-07-25): a deferral record only pops when the gate walk re-runs, and the walk
+        # stops the moment its session leaves idle-and-due — so a record freezes with its last reason.
+        # Records frozen for DAYS were found presenting "mid-flight" in the present tense. The judging
+        # claim is checkable against active_runs right now, so a frozen copy must check out to be shown.
+        km._nudge_deferred_ok(GID, jd.WHY_JUDGING, NOW, SID)
+        km._nudge_deferred_ok(GID, jd.WHY_JUDGING, NOW + 30, SID)
+        jd.active_runs = lambda: [{"judge": "closer", "fsid": SID, "sent": 1.0}]
+        self.assertEqual(km._stalled_goals()[GID]["why"], jd.WHY_JUDGING,
+                         "a genuinely wedged per-session judging shows as the stall it is")
+        jd.active_runs = lambda: ()
+        self.assertEqual(km._stalled_goals(), {},
+                         "the call retired but the record froze → the claim is live-false, never shown")
+
+    def test_a_legacy_global_pass_record_is_never_presented(self):
+        # pre-2026-07-25 records carried the global "a judge pass is mid-flight" and named no session —
+        # unverifiable, and minted by the pass cadence rather than a wedge, so they are dropped on read
+        # (they still pop normally on the next gate walk). This is what heals the stale-card epidemic.
+        self._d["deferred"] = {GID: {"at": NOW, "why": "a judge pass is mid-flight", "seen": 2}}
+        jd.active_runs = lambda: [{"judge": "closer", "fsid": SID, "sent": 1.0}]
+        self.assertEqual(km._stalled_goals(), {})
+
+    def test_a_paused_tiers_record_shows_only_while_paused(self):
+        km._retry_paused_on = lambda: True
+        km._nudge_deferred_ok(GID, "the judge tiers are paused (nothing could revive it)", NOW, SID)
+        km._nudge_deferred_ok(GID, "the judge tiers are paused (nothing could revive it)", NOW + 30, SID)
+        self.assertIn(GID, km._stalled_goals())
+        km._retry_paused_on = lambda: False
+        self.assertEqual(km._stalled_goals(), {},
+                         "tiers resumed while the record was frozen → the claim no longer stands")
+
+    def test_the_stands_predicate_is_shared_with_the_judge_reader(self):
+        # stalled_facts (judge side, feeds the staller and the distill due-anchor) filters through the SAME
+        # jd.stall_why_stands, so the two stall surfaces can never disagree about a live-false claim.
+        jd.active_runs = lambda: ()
+        self.assertFalse(jd.stall_why_stands(jd.WHY_JUDGING, SID))
+        jd.active_runs = lambda: [{"judge": "closer", "fsid": SID, "sent": 1.0}]
+        self.assertTrue(jd.stall_why_stands(jd.WHY_JUDGING, SID))
+        self.assertFalse(jd.stall_why_stands(jd.WHY_JUDGING, None),
+                         "a judging claim with no session is unverifiable and never stands")
+        self.assertTrue(jd.stall_why_stands("the agent's to-do sync is due", None),
+                        "store-backed reasons pass through — their own passes reconcile them")
 
 
 class StampEvidenceTime(unittest.TestCase):

--- a/tests/test_stall_note.py
+++ b/tests/test_stall_note.py
@@ -55,6 +55,27 @@ class StalledFacts(unittest.TestCase):
         self._write({GID: NOW})
         self.assertEqual(jd.stalled_facts(FSID), {})
 
+    def test_a_judging_claim_is_live_verified(self):
+        # 2026-07-25: a deferral record freezes when the gate walk stops running for its session, so a
+        # judging claim is presented only while active_runs shows a call for this session RIGHT NOW —
+        # a frozen present-tense claim that is live-false must not reach the staller or the due-anchor.
+        self._write({GID: {"at": NOW, "why": jd.WHY_JUDGING, "seen": jd.STALL_SEEN, "sid": FSID}})
+        saved = jd.active_runs
+        try:
+            jd.active_runs = lambda: [{"judge": "closer", "fsid": FSID, "sent": 1.0}]
+            self.assertEqual(jd.stalled_facts(FSID)[GID]["why"], jd.WHY_JUDGING)
+            jd.active_runs = lambda: ()
+            self.assertEqual(jd.stalled_facts(FSID), {},
+                             "the call retired but the record froze → never presented")
+        finally:
+            jd.active_runs = saved
+
+    def test_a_legacy_global_pass_record_never_stands(self):
+        # pre-2026-07-25 records carried the GLOBAL "a judge pass is mid-flight" — minted by the fleet-wide
+        # pass cadence, naming no session, unverifiable → dropped on read however settled the count looks.
+        self._write({GID: {"at": NOW, "why": "a judge pass is mid-flight", "seen": jd.STALL_SEEN}})
+        self.assertEqual(jd.stalled_facts(FSID), {})
+
     def test_an_unreadable_store_is_not_fatal(self):
         (jd.STATE / "auto-nudge.json").write_text("{ this is not json")
         self.assertEqual(jd.stalled_facts(FSID), {}, "a stall note is an extra, never a reason to fail a pass")

--- a/ui/webview/feed-css-vars.test.ts
+++ b/ui/webview/feed-css-vars.test.ts
@@ -1,0 +1,31 @@
+// The feed page loads ONLY feed.css — the kernel serves a single <link> (kernel.py) and the VS Code feed
+// webview mirrors it (extension.ts) — so styles.css and its :root never reach this surface. A var(--x) used
+// here WITHOUT a fallback must therefore be DEFINED here, or every declaration naming it is invalid at
+// computed-value time: background falls to transparent, border-color to currentColor, color to inherited.
+// That is how .fask-stallbtn — deliberately FILLED working-yellow "so the stall is noticed" — rendered as a
+// quiet white outline for two days: it referenced --st-working-bg/fg, which lived only in styles.css (the
+// user 2026-07-25). Host-injected vars (--vscode-*) and JS-set per-card channels (--card-r/g/b) are fine
+// BECAUSE every use carries a literal fallback; this test holds that line for them too.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+test("every fallback-less var() in feed.css is defined in feed.css", () => {
+  // definitions: `--name:` anywhere in the sheet (:root or a selector — both make the var resolvable)
+  const defined = new Set([...CSS.matchAll(/(--[a-zA-Z0-9-]+)\s*:/g)].map((m) => m[1]));
+  // uses with no fallback: `var(--name)` — a `var(--name, fallback)` never hits this pattern
+  const bare = [...CSS.matchAll(/var\(\s*(--[a-zA-Z0-9-]+)\s*\)/g)].map((m) => m[1]);
+  const missing = [...new Set(bare.filter((v) => !defined.has(v)))].sort();
+  assert.deepEqual(missing, [],
+    "used without a fallback but never defined in feed.css (define it in :root or add a fallback): "
+    + missing.join(", "));
+});
+
+test("the stall chip's working-yellow actually resolves on the feed page", () => {
+  // the incident pin, so a refactor that moves the definition back out of feed.css names the victim
+  assert.match(CSS, /--st-working-bg:\s*#e0b020/, "--st-working-bg is defined in feed.css (mirrors styles.css)");
+  assert.match(CSS, /--st-working-fg:\s*#332600/, "--st-working-fg is defined in feed.css (mirrors styles.css)");
+});

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -14,6 +14,11 @@
   --accent: #9cd2ff;  /* the romp accent (CLAUDE.md Design) — feed.css has its OWN :root, so selected-state
                        chrome here needs it defined locally or var(--accent) silently falls back */
   --accent-fg: #0c1a2e;  /* dark text ON the accent (CLAUDE.md) — for the reverse-highlight on a selected toggle */
+  --st-working-bg: #e0b020; --st-working-fg: #332600;  /* the WORKING yellow — mirrors styles.css, same trap
+                       as --err: .fask-stallbtn and .fask-interrupting referenced these while they lived only
+                       in styles.css, so the "filled yellow so the stall is noticed" chip rendered as a quiet
+                       white outline (background→transparent, border→currentColor, the user 2026-07-25).
+                       feed-css-vars.test.ts now holds the whole file to "define it here or carry a fallback". */
 
   /* Card background + border are set inline per card (the hawaii recency tint).
      These neutral tokens are for the chrome that frames them (header, detail box,


### PR DESCRIPTION
Three fixes from one screenshot (a white Stalled chip claiming a judge pass was running, hours after any pass touched the session). Companion to 435d9df's judge-parse orphanReply fix; together they close out tonight's stall/completion regression report.

- **The nudge gate's judging reviver was global.** It deferred on ANY judge activity anywhere, but the producer opens a fleet-wide pass every ~3s, so that reason was the kernel's cadence, not a reviver: adjacent gate ticks landed inside two different routine passes, the string-keyed seen counter read them as one non-retiring wedge, and false stalled cards minted fleet-wide (29 live records, median age 45h, when caught). The gate now defers only on a call in flight for this session's fsid.

- **Frozen records can no longer lie in the present tense.** A deferral record freezes with its last reason when the gate walk stops running for its session. Records now carry their session, and both stall readers (kernel `_stalled_goals`, judge `stalled_facts`) verify a judging claim against live `active_runs` through one shared predicate (`jd.stall_why_stands`); legacy global records never stand, which retires the stale-card backlog on rollout.

- **The Stalled chip renders its designed working-yellow.** `.fask-stallbtn` referenced `--st-working-bg/fg`, defined only in styles.css, and the feed page loads only feed.css, so the chip fell back to a white outline. The variables are now in feed.css's own :root, `.fask-interrupting` heals with them, and `feed-css-vars.test.ts` pins 'define it here or carry a fallback' for the whole sheet.

Tests: 3122 Python / 1335 Node / 18 root Node / tsc clean, rebased on 435d9df.

🤖 Generated with [Claude Code](https://claude.com/claude-code)