### PR TITLE
Peer waits: delegate handoffs make edges, answers end stamps, divergence tripwire

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1448,7 +1448,7 @@ def _mark_auto_nudged(gid, turn_id, count, arm_atoms=None, at=None):
     _write_auto_nudge(d)
 
 
-def _goal_awaiting_stamp(nodes, top, children=None):
+def _goal_awaiting_stamp(nodes, top, children=None, answered_at=0):
     """The freshest live ⏳ stamp in `top`'s subtree — the JUDGE's durable awaiting verdict (the closer's
     `awaiting` annotation, kernel/judge.py: the goal's latest audited turn ended waiting on async work it
     set in motion, with intent to act when it lands). Returns the stamp's why, or None.
@@ -1457,7 +1457,12 @@ def _goal_awaiting_stamp(nodes, top, children=None):
     in-memory subagent/bgTask sets die with the backend, which is how a genuinely-waiting session read as
     'stalled' after a restart), and it needs no time checks — the fold/lift machinery ends it on exact
     events (the goal's next audited turn, a landing done/block, a clear, a user reply). rolledUp nodes are
-    skipped: their flag cache is tree-derived display state, not verdicts."""
+    skipped: their flag cache is tree-derived display state, not verdicts.
+
+    `answered_at` (pass _peer_answered_at(sid)) adds one more exact ending event: a stamp whose awaitingAt
+    predates a peer's answer to this session's ask/handoff is SUPERSEDED — the wait it described was met,
+    and waiting for the closer's own lift left a card awaiting 5h after the reply (the user 2026-07-25).
+    A stamp with no awaitingAt can't be ordered against the reply and is kept as before."""
     if children is None:
         children = {}
         for nid, nd in nodes.items():
@@ -1469,8 +1474,10 @@ def _goal_awaiting_stamp(nodes, top, children=None):
         if not nd:
             continue
         if nd.get("awaitingWhy") and not nd.get("rolledUp"):
-            cand = (nd.get("awaitingAt") or 0, nd["awaitingWhy"])
-            best = cand if best is None else max(best, cand)
+            at = nd.get("awaitingAt") or 0
+            if not (at and answered_at and at < answered_at):
+                cand = (at, nd["awaitingWhy"])
+                best = cand if best is None else max(best, cand)
         stack.extend(children.get(x, []))
     return best[1] if best else None
 
@@ -1494,7 +1501,8 @@ def _mark_nudge_failed(gid, ev_t=None):
         _sid = gid.rsplit(":", 1)[0]
         if _session_awaiting(_sid, _path_of(_sid) or "", True):
             return
-        if _goal_awaiting_stamp(jd.load_goals(_sid).get("nodes", {}), gid):
+        if _goal_awaiting_stamp(jd.load_goals(_sid).get("nodes", {}), gid,
+                                answered_at=_peer_answered_at(_sid)):
             return                                     # the judge's durable ⏳ stamp says the goal waits on
             #                                            async work — same rule as above, restart-proof
     except Exception:
@@ -2392,12 +2400,13 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor):
             continue                                 # all open work handed to peers → nothing for THIS session
         if sid in waitfor and nd.get("t", 0) <= waitfor[sid]["since"]:
             continue                                 # awaiting a live peer's reply to a question this goal predates
-        if _goal_awaiting_stamp(nodes, gid, _kids):
+        if _goal_awaiting_stamp(nodes, gid, _kids, answered_at=_peer_answered_at(sid)):
             continue                                 # the judge's durable ⏳ stamp (closer awaiting verdict):
             #                                          the goal's latest audited turn ended waiting on async
             #                                          work it dispatched — not a stall. Restart-proof, unlike
             #                                          the session-level live gate above; lifted by exact
-            #                                          events (next audited turn / done / block / user reply)
+            #                                          events (next audited turn / done / block / user reply /
+            #                                          a peer's answer superseding the stamp)
         # LAST-RESORT GATE (the user 2026-07-22): every OTHER mechanism that could still move this card
         # off 'working' must be exhausted first. This is what the 2026-07-22 false interrupt needed: the
         # card's 'working' came from a STALE agent-to-do mirror, and the nudge fired before the sync that
@@ -5941,8 +5950,10 @@ def _session_stamp_read(sid):
     twin of _goal_awaiting_stamp, so the rail chip and timeline lane (which read _session_awaiting, not the
     per-goal stamp) light up the same restart-proof awaiting the feed card already shows off the stamp (the
     user 2026-07-22); the top set is the bg-task classifier's judge-affirmed-wait test (_bg_split). mtime-
-    cached on the goal-store + override-journal files so an ordinary idle session — which falls through
-    every live source to here every render — does not reparse the store each tick."""
+    cached on the goal-store + override-journal + postal-log files so an ordinary idle session — which falls
+    through every live source to here every render — does not reparse the store each tick. (The postal log
+    is in the key because a peer's answer SUPERSEDES older stamps — see _peer_answered_at — so mail landing
+    must re-read the view, the user 2026-07-25.)"""
     sid = str(sid)
     try:
         gs = (jd.GOALDIR / (sid + ".json")).stat()
@@ -5954,7 +5965,12 @@ def _session_stamp_read(sid):
         okey = (ostt.st_mtime, ostt.st_size)
     except Exception:
         okey = None                                    # no override journal is normal
-    key = (gkey, okey)
+    try:
+        mst = jd.MESSAGES.stat()
+        mkey = (mst.st_mtime_ns, mst.st_size)
+    except OSError:
+        mkey = None                                    # no postal log yet is normal
+    key = (gkey, okey, mkey)
     hit = _SESSION_STAMP_CACHE.get(sid)
     if hit and hit[0] == key:
         return hit[1]
@@ -5962,9 +5978,13 @@ def _session_stamp_read(sid):
     try:                                               # load_goals (not a raw read) so overrides replay —
         nodes = jd.load_goals(sid).get("nodes", {})    # the same view _goal_awaiting_stamp sees on the card
         best = None
+        answered = _peer_answered_at(sid)              # a peer's later answer supersedes older stamps
         for nid, nd in nodes.items():
             if nd.get("awaitingWhy") and not nd.get("rolledUp"):
-                cand = (nd.get("awaitingAt") or 0, nid, nd["awaitingWhy"])
+                at = nd.get("awaitingAt") or 0
+                if at and answered and at < answered:
+                    continue                           # the awaited answer landed after this stamp — superseded
+                cand = (at, nid, nd["awaitingWhy"])
                 best = cand if best is None else max(best, cand)
                 top, seen = nid, set()                 # stamped node → its TOP ancestor (cycle-guarded)
                 while top in nodes and nodes[top].get("parentId") is not None and top not in seen:
@@ -10156,17 +10176,26 @@ def _blocked_placeholder(s, name, color, fsid, live, now, perm_state, since):
 # word). Rows that CARRY a kind use it directly — the sender's declared intent is the designed source; the
 # body regex is only the fallback for old log rows (the user 2026-06-22 / the 2026-07-22 unification).
 _WAIT_Q_RE = re.compile(r"^\s*(?:QUESTION|ASK|Q)\b", re.I)
+_POSTAL_WAIT_CACHE = [None, None]   # (mtime_ns, size) , (last_any, last_ask) — one log scan per file change
 
 
-def _wait_for_graph(now, alive_sids):
-    """The fleet's WAIT-FOR graph from the postal log (the user 2026-06-22): a session X 'waits on' peer Y
-    when X's latest REPLY-REQUIRED message to Y (a postal QUESTION/ASK — NOT a COORDINATE/FYI heads-up, which
-    expects no reply) has no answer back since (any later Y→X record answers it) AND Y is ALIVE (a dead peer
-    won't reply). Each X points to its single most-recent such Y (a functional graph), so following the edges
-    detects CYCLES (X→Y→…→X = a mutual-wait deadlock). Only QUESTIONs count — an actively-coordinating session
-    isn't falsely shown 'waiting' for every FYI it sent. Returns {sid: {peerSid, name, color, inCycle}} for
-    every waiting session — the goal card's chip + the auto-nudge gate read it. Best-effort {}."""
-    last_any, last_q = {}, {}                            # (from,to) -> latest t of: ANY msg / a QUESTION-intent msg
+def _postal_wait_maps():
+    """(last_any, last_ask) from the postal log, cached on the file's (mtime, size): per ordered pair
+    (from_id, to_id), last_any holds the latest t of ANY message, last_ask the latest (t, kind) of a
+    reply-EXPECTING ask — a QUESTION (an answer is required) or a DELEGATE (the recipient owns work whose
+    result comes back to the sender; the user 2026-07-25, whose handoff to a peer wore the generic
+    "background agents" box because only questions counted). COORDINATE/FYI rows never make last_ask.
+    Rows carrying the schema `kind` use it; kindless legacy rows fall back to the QUESTION/ASK body
+    prefix. Shared by _wait_for_graph (twice per push) and _peer_answered_at (the stamp readers), which
+    each re-scanned the log per call before this cache."""
+    try:
+        st = jd.MESSAGES.stat()
+        key = (st.st_mtime_ns, st.st_size)
+    except OSError:
+        return {}, {}
+    if _POSTAL_WAIT_CACHE[0] == key:
+        return _POSTAL_WAIT_CACHE[1]
+    last_any, last_ask = {}, {}
     try:
         for line in jd.MESSAGES.read_text(errors="replace").splitlines():
             try:
@@ -10178,19 +10207,35 @@ def _wait_for_graph(now, alive_sids):
                 continue
             ts = int(ts)
             last_any[(f, t_)] = max(last_any.get((f, t_), 0), ts)
-            k = o.get("kind")                            # the sender's DECLARED intent (schema field) wins;
-            is_q = (k == "question") if k else bool(_WAIT_Q_RE.match(o.get("body") or ""))
-            if is_q:                                     # a reply-REQUIRED ask creates the wait edge
-                last_q[(f, t_)] = max(last_q.get((f, t_), 0), ts)
+            k = o.get("kind")                            # the sender's DECLARED intent (schema field) wins
+            is_ask = (k in ("question", "delegate")) if k else bool(_WAIT_Q_RE.match(o.get("body") or ""))
+            if is_ask and ts >= last_ask.get((f, t_), (0, ""))[0]:
+                last_ask[(f, t_)] = (ts, k or "question")
     except OSError:
         pass
-    edge = {}                                            # X → Y: X's most-recent UNANSWERED question to a LIVE peer
-    for (f, t_), ts in last_q.items():
+    _POSTAL_WAIT_CACHE[:] = [key, (last_any, last_ask)]
+    return last_any, last_ask
+
+
+def _wait_for_graph(now, alive_sids):
+    """The fleet's WAIT-FOR graph from the postal log (the user 2026-06-22): a session X 'waits on' peer Y
+    when X's latest REPLY-EXPECTING message to Y (a postal QUESTION, or a DELEGATE handoff whose result X
+    acts on — NOT a COORDINATE/FYI heads-up) has no answer back since (any later Y→X record answers it)
+    AND Y is ALIVE (a dead peer won't reply). Each X points to its single most-recent such Y (a functional
+    graph), so following the edges detects CYCLES (X→Y→…→X = a mutual-wait deadlock). Returns
+    {sid: {peerSid, name, color, inCycle, since, kind}} for every waiting session — the goal card's chip
+    (kind picks its label: "Awaiting <peer>" vs "Handed off to <peer>") + the auto-nudge gate read it.
+    DELEGATE edges since 2026-07-25: a handoff previously made no edge, so the card fell through to the
+    judge's generic ⏳ stamp ("Awaiting background agents") and, with no edge to clear, the peer's actual
+    reply lifted nothing — a card read awaiting for 5h after the answer landed. Best-effort {}."""
+    last_any, last_ask = _postal_wait_maps()
+    edge = {}                                            # X → Y: X's most-recent UNANSWERED ask to a LIVE peer
+    for (f, t_), (ts, _k) in last_ask.items():
         if t_ not in alive_sids:                         # dead peer won't reply → not a wait
             continue
         if last_any.get((t_, f), 0) >= ts:               # Y replied with ANYTHING after → answered
             continue
-        if f not in edge or ts > last_q[(f, edge[f])]:
+        if f not in edge or ts > last_ask[(f, edge[f])][0]:
             edge[f] = t_
     in_cycle = set()                                     # follow the functional graph; a revisit = a cycle
     for start in edge:
@@ -10202,8 +10247,30 @@ def _wait_for_graph(now, alive_sids):
             in_cycle.update(seen[seen.index(node):])
     return {x: {"peerSid": y, "name": _name_of(y) or y[:8], "color": _name_color(y),
                 "inCycle": x in in_cycle,
-                "since": last_q[(x, y)]}   # when the unanswered question was sent → a goal minted AFTER it can't be awaiting it
+                "since": last_ask[(x, y)][0],   # when the unanswered ask was sent → a goal minted AFTER it can't be awaiting it
+                "kind": last_ask[(x, y)][1]}    # question | delegate → the chip's label
             for x, y in edge.items()}
+
+
+def _peer_answered_at(sid):
+    """The latest time a peer that `sid` had ASKED (question) or DELEGATED to REPLIED, over pairs with no
+    newer outstanding ask: max of last_any[(Y, sid)] where that reply is at/after sid's latest ask to Y.
+    0 when nothing qualifies. The durable ⏳ awaiting-stamp readers treat a stamp OLDER than this as
+    SUPERSEDED — the awaited answer arrived after the closer spoke, which is exactly the event the stamp
+    was waiting for (the user 2026-07-25: a stamp filed at 13:12 kept a card on "Awaiting background
+    agents" 5h after the delegated peer's 15:16 reply; the closer's own lift never came). A stamp filed
+    AFTER the reply survives — the closer's verdict is fresher than the answer it already saw. If the
+    stamp was really about non-peer work (subagents, a build), the LIVE sources that outrank it still
+    carry the wait, and the closer's next pass can re-stamp with a fresh awaitingAt."""
+    last_any, last_ask = _postal_wait_maps()
+    best = 0
+    for (f, t_), (ts, _k) in last_ask.items():
+        if f != sid:
+            continue
+        r = last_any.get((t_, f), 0)
+        if r >= ts:                                      # the pair's newest ask is answered
+            best = max(best, r)
+    return best
 
 
 # ───────────────────────── view-builder: goals → feed (parity: feed = ADAPT; minimal here) ─────────────────────────
@@ -10579,7 +10646,8 @@ def build_feed(now, tmux=None):
             # across kernel restarts — exactly where the live snapshot signals above go dark and a
             # genuinely-waiting goal used to read as plain working, then "stalled". It floors WORKING
             # only: a real needs-you (block) always outranks the annotation.
-            _stamp_why = _goal_awaiting_stamp(nodes, nid, children) if col == "working" else None
+            _stamp_why = (_goal_awaiting_stamp(nodes, nid, children, answered_at=_peer_answered_at(fsid))
+                          if col == "working" else None)
             # DELEGATION-derived awaiting (the courier's durable handoff graph, not the question-regex):
             # every OPEN leaf under this top is a handoff-tracking node → the only outstanding work lives
             # with peers, so the card reads ⏳ "delegated to <peer>" instead of plain working (which reads
@@ -12774,6 +12842,47 @@ def _pick_folder():
         return None
 
 
+_CHAT_DIV_LAST = {}   # sid -> (chat_state, row_state) at the last logged transition — event-on-change, in-memory
+
+
+def _note_chat_divergence(sid, name, chat_state, row_state, now):
+    """DEBUG tripwire for the chat-says-working-while-the-state-says-settled bug class (the user
+    2026-07-25: a session's chat read "running" for minutes after its turn ended via the API-error
+    salvage, while /sessions and the timeline were correct — the kernel restart then destroyed the
+    in-memory live atoms, leaving the mechanism unprovable). When debug mode is on, log the moment a
+    session's BUILT chat state ("working") disagrees with its backend state row ("waiting"/"idle"),
+    with the live-tail atoms that are holding the chat's turn open — and log when it clears, so the
+    log shows spans. Event-on-change (never per-push spam); appends to STATE/chat-divergence.jsonl;
+    zero I/O when debug mode is off or nothing changed."""
+    diverged = chat_state == "working" and row_state in ("waiting", "idle")
+    pair = (chat_state, row_state) if diverged else None
+    if _CHAT_DIV_LAST.get(sid) == pair:
+        return
+    was = _CHAT_DIV_LAST.get(sid)
+    _CHAT_DIV_LAST[sid] = pair
+    if not jd._debug_mode():
+        return
+    if pair is None and was is None:
+        return
+    rec = {"t": int(now), "sid": sid, "name": name}
+    if diverged:
+        rec.update({"chat": chat_state, "row": row_state})
+        _be = _sdk()
+        atoms = getattr(_be, "live_atom_kinds", None)
+        if atoms:
+            try:
+                rec["live"] = atoms(sid)
+            except Exception:
+                rec["live"] = "unreadable"
+    else:
+        rec["cleared"] = True
+    try:
+        with open(jd.STATE / "chat-divergence.jsonl", "a") as f:
+            f.write(json.dumps(rec) + "\n")
+    except OSError:
+        pass
+
+
 def _push(targets, connect=False):
     """Build the payloads once (cached parses) and send each target only the pieces that CHANGED for it.
     Drives both the periodic pusher (all clients) and a fresh connect (one client): a new/reconnecting
@@ -12836,6 +12945,9 @@ def _push(targets, connect=False):
                         _built_chat[s["sid"]] = (sig, m, ms)
                 if not m:
                     continue
+                _note_chat_divergence(s["sid"], m.get("name") or "",
+                                      ((m.get("status") or {}).get("state") or ""),
+                                      ((tmux.get(s["sid"]) or {}).get("state") or ""), now)
                 chat_sessions.append(m)
                 # delta-send: diff this build's events against the previous one ONCE, then each client gets
                 # only the changed suffix (chatTail) if it's caught up, else the full session. Keeps the whole

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3059,6 +3059,23 @@ class SdkBackend:
         if not d:
             self._live.pop(sid, None)
 
+    def live_atom_kinds(self, sid: str) -> list:
+        """Read-only DEBUG summary of the sid's live-tail atoms: uuid/type + the flags that decide their
+        fate at settle (echo, command, apiError, hasText). The kernel's chat-divergence tripwire logs it
+        to pin WHICH atom held a chat turn open after the backend settled — the 2026-07-25 stale-"running"
+        chat could not be diagnosed because a restart cleared exactly this state before anyone read it."""
+        d = self._live.get(sid)
+        if not d:
+            return []
+        out = []
+        for a in list(d.values()):                 # copy: loop threads mutate the dict mid-iteration
+            if not isinstance(a, dict):
+                continue
+            out.append({"uuid": a.get("uuid") or "", "type": a.get("type") or "",
+                        "echo": bool(a.get("_echo_text")), "command": bool(a.get("command")),
+                        "apiError": bool(a.get("isApiError")), "hasText": bool(_atom_text(a).strip())})
+        return out
+
     def _update_reg(self, sid: str, **fields):
         with self._reg_lock:                       # kernel + loop threads both write (queue mirror);
             reg = read_reg(self.state_dir, sid) or {"sid": sid}   # unserialized RMWs would drop fields

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6971,3 +6971,141 @@ class CheckinSurfaces(unittest.TestCase):
             self.assertFalse(km._postal_peers_on())
         finally:
             os.environ.pop("ROMP_POSTAL_PEERS", None)
+
+
+class WaitGraphDelegatesAndStampSupersede(unittest.TestCase):
+    """DELEGATE handoffs in the wait-for graph + the peer-answer supersede on durable ⏳ stamps (the user
+    2026-07-25: a handoff to a peer wore the generic "Awaiting background agents" box because only
+    QUESTION-kind rows made edges, and the closer's stamp kept the card awaiting 5h after the delegated
+    peer had actually replied — the reply is the exact event the wait was for, so it must end the wait)."""
+
+    A, B = "aaaa1111", "bbbb2222"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd._rebind_state(Path(self.td.name))
+        (Path(self.td.name) / "timeline").mkdir(parents=True)
+        jd.GOALDIR.mkdir(parents=True)
+        km._POSTAL_WAIT_CACHE[:] = [None, None]
+        km._SESSION_STAMP_CACHE.clear()
+
+    def tearDown(self):
+        jd._rebind_state(self.saved_state)
+        km._POSTAL_WAIT_CACHE[:] = [None, None]
+        km._SESSION_STAMP_CACHE.clear()
+        self.td.cleanup()
+
+    def _log(self, *rows):
+        with open(jd.MESSAGES, "a") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+
+    def _msg(self, f, t, ts, kind, body="synthetic body"):
+        return {"ev": "sent", "id": "m%d" % ts, "from_id": f, "to_id": t, "t": ts,
+                "from": "x", "body": body, "kind": kind}
+
+    def test_delegate_creates_a_wait_edge_and_any_reply_clears_it(self):
+        self._log(self._msg(self.A, self.B, NOW - 300, "delegate"))
+        g = km._wait_for_graph(NOW, {self.A, self.B})
+        self.assertEqual((g[self.A]["peerSid"], g[self.A]["kind"], g[self.A]["since"]),
+                         (self.B, "delegate", NOW - 300),
+                         "a handoff is a reply-expecting ask: it creates the edge, labeled delegate")
+        # ANY later message back — even a coordinate — answers the handoff; the edge clears on that event
+        self._log(self._msg(self.B, self.A, NOW - 100, "coordinate", body="done, merged"))
+        self.assertEqual(km._wait_for_graph(NOW, {self.A, self.B}), {})
+
+    def test_coordinate_makes_no_edge_and_question_keeps_its_kind(self):
+        self._log(self._msg(self.A, self.B, NOW - 300, "coordinate"))
+        self.assertEqual(km._wait_for_graph(NOW, {self.A, self.B}), {})
+        self._log(self._msg(self.A, self.B, NOW - 200, "question"))
+        self.assertEqual(km._wait_for_graph(NOW, {self.A, self.B})[self.A]["kind"], "question")
+
+    def test_peer_answered_at_tracks_only_answered_pairs(self):
+        self.assertEqual(km._peer_answered_at(self.A), 0, "no traffic → nothing answered")
+        self._log(self._msg(self.A, self.B, NOW - 300, "delegate"))
+        self.assertEqual(km._peer_answered_at(self.A), 0, "outstanding ask → not answered")
+        self._log(self._msg(self.B, self.A, NOW - 200, "coordinate"))
+        self.assertEqual(km._peer_answered_at(self.A), NOW - 200, "the reply time, once it lands")
+        # a NEWER outstanding ask reopens the pair — the old answer no longer counts
+        self._log(self._msg(self.A, self.B, NOW - 100, "question"))
+        self.assertEqual(km._peer_answered_at(self.A), 0)
+
+    def test_goal_awaiting_stamp_superseded_by_a_later_answer(self):
+        g = "%s:g1" % self.A
+        nodes = {g: {"id": g, "text": "top", "parentId": None, "t": NOW - 900,
+                     "awaitingWhy": "handed to a peer", "awaitingAt": NOW - 500}}
+        self.assertEqual(km._goal_awaiting_stamp(nodes, g), "handed to a peer")
+        self.assertIsNone(km._goal_awaiting_stamp(nodes, g, answered_at=NOW - 100),
+                          "an answer AFTER the stamp supersedes it")
+        self.assertEqual(km._goal_awaiting_stamp(nodes, g, answered_at=NOW - 800), "handed to a peer",
+                         "an answer the closer already saw (before the stamp) does not")
+        nodes[g].pop("awaitingAt")
+        self.assertEqual(km._goal_awaiting_stamp(nodes, g, answered_at=NOW - 100), "handed to a peer",
+                         "a stamp with no awaitingAt can't be ordered against the reply — kept")
+
+    def test_session_stamp_read_lifts_when_the_delegated_peer_replies(self):
+        g = "%s:g1" % self.A
+        (jd.GOALDIR / (self.A + ".json")).write_text(json.dumps({
+            "rompUuid": self.A, "seq": 1, "lastNode": g,
+            "nodes": {g: {"id": g, "text": "top", "parentId": None, "t": NOW - 900,
+                          "nodeComplete": False, "blocked": False, "cleared": False, "trail": [],
+                          "awaitingWhy": "sent to a peer to build the flag parser",
+                          "awaitingAt": NOW - 500}},
+            "placements": {}, "status": {g: "working"}}))
+        self._log(self._msg(self.A, self.B, NOW - 600, "delegate"))
+        full, tops = km._session_stamp_read(self.A)
+        self.assertEqual(full[2], "sent to a peer to build the flag parser")
+        self.assertEqual(tops, frozenset({g}))
+        # the peer's reply lands (also busts the postal-key on the stamp cache) → the stamp view lifts
+        self._log(self._msg(self.B, self.A, NOW - 100, "coordinate", body="built and merged"))
+        full, tops = km._session_stamp_read(self.A)
+        self.assertEqual(full, (None, None, None), "the answered handoff supersedes the older stamp")
+        self.assertEqual(tops, frozenset())
+
+
+class ChatDivergenceTripwire(unittest.TestCase):
+    """_note_chat_divergence: the debug-mode tripwire for the chat-says-working-while-settled bug class
+    (the user 2026-07-25: the stale-"running" chat could not be diagnosed after a kernel restart cleared
+    the live atoms — next time, the log has the atoms). Event-on-change: one row entering divergence
+    (with the backend's live-atom summary), one row on clearing, nothing on repeats or when debug is off."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd._rebind_state(Path(self.td.name))
+        self.saved = (jd._debug_mode, km._sdk)
+        jd._debug_mode = lambda: True
+        km._sdk = lambda: types.SimpleNamespace(live_atom_kinds=lambda sid: [
+            {"uuid": "u1", "type": "assistant", "echo": False, "command": False,
+             "apiError": False, "hasText": True}])
+        km._CHAT_DIV_LAST.clear()
+
+    def tearDown(self):
+        jd._debug_mode, km._sdk = self.saved
+        jd._rebind_state(self.saved_state)
+        km._CHAT_DIV_LAST.clear()
+        self.td.cleanup()
+
+    def _rows(self):
+        p = jd.STATE / "chat-divergence.jsonl"
+        return [json.loads(x) for x in p.read_text().splitlines()] if p.exists() else []
+
+    def test_logs_on_entering_and_clearing_with_live_atoms(self):
+        km._note_chat_divergence(SID, "web", "working", "waiting", NOW)
+        km._note_chat_divergence(SID, "web", "working", "waiting", NOW + 3)   # same state → no new row
+        rows = self._rows()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual((rows[0]["sid"], rows[0]["chat"], rows[0]["row"]), (SID, "working", "waiting"))
+        self.assertEqual(rows[0]["live"][0]["uuid"], "u1", "the atoms holding the turn open are captured")
+        km._note_chat_divergence(SID, "web", "ready", "waiting", NOW + 6)     # divergence over → cleared row
+        rows = self._rows()
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(rows[1].get("cleared"))
+
+    def test_agreement_and_debug_off_write_nothing(self):
+        km._note_chat_divergence(SID, "web", "ready", "waiting", NOW)         # settled agreement: no row
+        self.assertEqual(self._rows(), [])
+        jd._debug_mode = lambda: False
+        km._note_chat_divergence(SID, "web", "working", "waiting", NOW)       # debug off: silent
+        self.assertEqual(self._rows(), [])

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -2253,5 +2253,28 @@ class BgTaskLifecycle(unittest.TestCase):
         self.assertEqual(s.snapshot()["bgTasks"], [])
 
 
+class LiveAtomKinds(unittest.TestCase):
+    """live_atom_kinds — the read-only DEBUG summary the kernel's chat-divergence tripwire logs (the
+    2026-07-25 stale-"running" chat: the live atoms that held the turn open were cleared by a restart
+    before anyone could read them; this accessor is how the tripwire captures them in time)."""
+
+    def test_summarizes_live_atoms_without_mutating(self):
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+        sid = "11111111-2222-3333-4444-555555555555"
+        self.assertEqual(be.live_atom_kinds(sid), [], "no live tail → empty")
+        be._live[sid] = {
+            "k1": {"uuid": "u1", "type": "assistant", "t": 10,
+                   "message": {"content": [{"type": "text", "text": "streamed reply"}]}},
+            "k2": {"uuid": "u2", "type": "user", "t": 11, "_echo_text": "hi",
+                   "message": {"content": "hi"}},
+            "k3": "not-a-dict"}
+        got = {a["uuid"]: a for a in be.live_atom_kinds(sid)}
+        self.assertEqual(set(got), {"u1", "u2"}, "non-dict entries are skipped, atoms summarized")
+        self.assertEqual((got["u1"]["type"], got["u1"]["hasText"], got["u1"]["echo"]),
+                         ("assistant", True, False))
+        self.assertTrue(got["u2"]["echo"])
+        self.assertEqual(len(be._live[sid]), 3, "read-only: the live tail is untouched")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ui/webview/feed-waiton.test.ts
+++ b/ui/webview/feed-waiton.test.ts
@@ -16,9 +16,10 @@ test("a waiting-on chip is built and rides the wrapping chip row (its own line w
   assert.match(FEED, /a\._waitOn = waitOnBadge;/);
 });
 
-test("it.waitingOn drives the chip: 'Awaiting <peer>' (native-colour name, NO emoji) / 'Deadlock' for a cycle", () => {
-  // the label is "Awaiting " / "Deadlock " — no ⏳/⟲ emoji (the user 2026-06-22)
-  assert.match(FEED, /woPre\.textContent = wo\.inCycle \? "Deadlock " : "Awaiting "/);
+test("it.waitingOn drives the chip: 'Awaiting <peer>' / 'Handed off to <peer>' (native-colour name, NO emoji) / 'Deadlock' for a cycle", () => {
+  // the label is "Awaiting " / "Handed off to " (delegate kind) / "Deadlock " — no ⏳/⟲ emoji
+  // (the user 2026-06-22 / 2026-07-25: a delegation handoff is not "awaiting background agents")
+  assert.match(FEED, /woPre\.textContent = wo\.inCycle \? "Deadlock " : wo\.kind === "delegate" \? "Handed off to " : "Awaiting "/);
   assert.doesNotMatch(FEED, /⏳ waiting on|⟲ deadlock/, "no emoji prefix anymore");
   // the peer NAME is a separate span in its OWN identity colour (like the ↪ from provenance)
   assert.match(FEED, /woName\.textContent = wo\.name/);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -89,7 +89,7 @@ interface AskItem {
   nudged?: { count: number; times: number[] } | null;   // auto-nudge HISTORY (kernel _nudge_times): how many times romp followed up + when — the stalled chip's evidence (tooltip + modal line, the user 2026-07-02)
   warnRows?: { t: number; judge: string; err: string; note?: string; debug?: { input?: string; reply?: string } }[] | null;   // DEBUG MODE only (romp debug on): every judge failure touching this card (kernel _card_warn_rows) → "Warnings (debug)" modal section; rows captured in debug carry the failing call's input + reply (the user 2026-07-09)
   origin?: { peer: string; peerSid: string; color: { bg: string; fg: string } | null } | null;  // courier handoff: planted by a peer's message → "↪ from <peer>"
-  waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22)
+  waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean; kind?: string } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip, or "Handed off to <peer>" when kind is "delegate" (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22 / 2026-07-25)
   awaiting?: { why?: string | null; tasks?: string[] | null } | null;   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Waiting on task" pill (expands the list, like Sub-goals) replaces the boxed why.
   groupTitle?: string;                             // host: this ask shares a typed turn with siblings → the group's title
   groupN?: number;                                 // host: sibling count for that turn (>1 ⇒ fold into one group card)
@@ -1241,20 +1241,25 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   } else {
     a._warnChip.style.display = "none";
   }
-  // "Awaiting <peer>" — this session has an unanswered message out to a live peer (kernel _wait_for_graph):
-  // held in Working, not stalled, so auto-nudge skips it. The peer NAME renders in its NATIVE identity colour
-  // (like the "↪ from" provenance), no emoji prefix (the user 2026-06-22). A mutual-wait CYCLE keeps the red
-  // styling + a "Deadlock" label instead of "Awaiting".
+  // "Awaiting <peer>" / "Handed off to <peer>" — this session has an unanswered message out to a live peer
+  // (kernel _wait_for_graph): held in Working, not stalled, so auto-nudge skips it. A DELEGATE handoff wears
+  // "Handed off to" (the peer owns the work now; the user 2026-07-25 — a handoff is not "awaiting background
+  // agents"); a question keeps "Awaiting". The peer NAME renders in its NATIVE identity colour (like the
+  // "↪ from" provenance), no emoji prefix (the user 2026-06-22). A mutual-wait CYCLE keeps the red styling +
+  // a "Deadlock" label over both.
   const wo = it.waitingOn;
   if (wo) {
     a._waitOn.replaceChildren();
-    const woPre = el("span", "fask-waiton-pre"); woPre.textContent = wo.inCycle ? "Deadlock " : "Awaiting ";
+    const woPre = el("span", "fask-waiton-pre");
+    woPre.textContent = wo.inCycle ? "Deadlock " : wo.kind === "delegate" ? "Handed off to " : "Awaiting ";
     const woName = el("span", "fask-waiton-name"); woName.textContent = wo.name;
     if (wo.color && wo.color.bg) woName.style.color = wo.color.bg;   // the peer's own identity colour
     a._waitOn.append(woPre, woName);
     a._waitOn.title = wo.inCycle
       ? "MUTUAL WAIT — this session and " + wo.name + " are each waiting on the other (a deadlock); auto-nudge surfaces it instead of nudging"
-      : "this session has an unanswered message out to " + wo.name + " — waiting on its reply, not stalled, so auto-nudge skips it";
+      : wo.kind === "delegate"
+        ? "this session handed work to " + wo.name + " and acts when the result comes back — not stalled, so auto-nudge skips it"
+        : "this session has an unanswered message out to " + wo.name + " — waiting on its reply, not stalled, so auto-nudge skips it";
     a._waitOn.className = "fask-waiton" + (wo.inCycle ? " fask-waiton-cycle" : "");
     a._waitOn.style.display = "";
   } else {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "romp-chat-view",
   "displayName": "romp Chat View",
   "description": "Read-only, nicely-rendered live view of Claude Code (romp) sessions, styled like the official Claude Code panel.",
-  "version": "0.4.331",
+  "version": "0.4.332",
   "publisher": "romp",
   "private": true,
   "engines": {


### PR DESCRIPTION
Fixes for tonight's two diagnosed display bugs (user-greenlit).

**Delegate handoffs get real peer-wait edges.** `_wait_for_graph` now counts `delegate`-kind postal messages as reply-expecting asks, via a new mtime-cached `_postal_wait_maps` shared scan (the graph used to re-read the log twice per push). The card chip reads **Handed off to \<peer\>** for a delegation vs **Awaiting \<peer\>** for a question, and the peer's answer clears the wait event-based. Previously a handoff made no edge, so the card fell through to the judge's generic "Awaiting background agents" box.

**A peer's answer ends the durable awaiting stamp.** `_peer_answered_at` supersedes any ⏳ stamp older than the answered ask's reply, applied in `_goal_awaiting_stamp` (feed floor, nudge gates) and `_session_stamp_read` (rail/chat/timeline chips; postal log folded into its cache key). Tonight a stamp filed at 13:12 kept a card awaiting until 20:37 when the delegated peer had replied at 15:16 — the reply is the event the stamp was waiting for.

**Debug tripwire for the stale-"running" chat.** The mechanism couldn't be pinned (the kernel restart cleared the live atoms), so with debug mode on, the push loop now logs chat-built-state vs state-row divergence (`chat-divergence.jsonl`) with the SDK backend's live-tail atom summary (`live_atom_kinds`) — one row entering, one clearing.

Tests: 8 new (wait-graph kinds, answered-at, stamp supersede unit + end-to-end, tripwire spans, live-atom accessor); full suites green post-merge with #29 (3130 py / 1335 node, tsc clean). VSIX 0.4.332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)