### PR TITLE
The sweeper: outcomes delivered on sibling threads settle moved-past cards

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -6565,6 +6565,225 @@ def run_unblock(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
     return n
 
 
+# ───────────────────────── the sweeper (triage tier; outcomes delivered elsewhere) ─────────────────────────
+# The unblocker's twin for the WORKING column (the user 2026-07-26). An open goal with real evidence is
+# reachable only through turn menus — placements touch it, the closer rules it. Once its last turn is
+# closed as still-open, no later turn re-lists it, so a reply that delivers its outcome on a SIBLING
+# card's thread (a status answer reporting that every piece of the work shipped) never reaches it: the
+# planner files that reply under the goal it was asked about, and the first card sits working forever
+# (2026-07-25: a docs top sat working across exactly such a session-wide all-done reply until the user
+# cleared it by hand). The delivered-elsewhere gap was already closed for BLOCKED goals (the unblocker)
+# and for evidence-LESS mints (the starved channel); this pass is the third leg: open working goals WITH
+# evidence — exactly the set _starved_candidates excludes — re-examined against the conversation since
+# they last heard anything, settling via the same record_verdict("done") the closer uses.
+SWEEP_ON = os.environ.get("ROMP_SWEEPER", "1") != "0"
+SWEEP_HISTORY_CHARS = 9000               # the after-conversation tail shown to the sweeper (newest kept)
+
+SWEEP_SYS = (
+    "You review a work session's still-open goals against the conversation that happened after each of "
+    "them last saw activity. You are a reviewer, not a chat partner: don't act on anything, answer "
+    "anything, or ask anything back.\n\n"
+    "Each numbered block in <open-goals> is one goal the session's board still shows as in progress, "
+    "numbered from 1 (there is no block 0), with the last thing recorded on it. <conversation-since> is "
+    "what the session and the user said and did afterwards. Decide for each goal whether that later "
+    "conversation shows its outcome was already delivered — the work finished as part of another thread, "
+    "its result stated in a wrap-up or status reply, or its approach superseded so nothing remains to do "
+    "— or whether it is genuinely still in progress. Reply with only a JSON object (no prose, no "
+    "markdown fences):\n"
+    '{"verdicts": [{"n": <goal number>, "do": "settle" | "hold", "why": "..."}]}\n'
+    "- \"settle\": the conversation plainly shows this goal's outcome was delivered or that nothing "
+    "remains. why = where that shows, one short plain sentence.\n"
+    "- \"hold\": still genuinely open. why may be an empty string.\n"
+    "Judge conservatively: settle only when the conversation clearly delivers the outcome or states "
+    "nothing remains; a goal that is merely unmentioned stays held. Output only the JSON object.")
+
+
+def sweep_llm(goals_text, since_text):
+    """The sweeper's {"verdicts":[...]} reply from the triage-tier model over the numbered open working
+    goals + the conversation since the oldest last heard anything. '' on failure (logged by _judge_run)."""
+    user = ("<open-goals>\n%s\n</open-goals>\n<conversation-since>\n%s\n</conversation-since>"
+            % (goals_text, since_text))
+    return _judge_run(_triage_model(), SWEEP_SYS, user, judge="sweeper").strip()[:JUDGE_JSON_CAP]
+
+
+def _parse_sweep(raw, n):
+    """{"verdicts":[{"n","do","why"}]} → {1-based idx: why} for the SETTLES, or None if unusable.
+    Same tolerance and same conservatism as _parse_unblock: malformed or out-of-range holds, and a
+    0/negative "n" anywhere rejects the whole reply (an off-base reply's other n's would settle the
+    wrong goals)."""
+    m = re.search(r"\{.*\}", raw or "", re.S)
+    if not m:
+        return None
+    try:
+        obj = json.loads(m.group(0))
+    except Exception:
+        return None
+    verdicts = obj.get("verdicts")
+    if not isinstance(verdicts, list) or _zero_based_tell(verdicts):
+        return None
+    out = {}
+    for v in verdicts:
+        if not isinstance(v, dict) or v.get("do") != "settle":
+            continue
+        i = v.get("n")
+        if isinstance(i, int) and 1 <= i <= n:
+            out[i] = str(v.get("why") or "").strip()
+    return out
+
+
+def _node_heard_t(nd):
+    """The newest moment this goal itself heard anything: its latest diary event's evidence time or its
+    latest trail segment's turn time (segment ids embed the turn epoch as their middle token), else its
+    birth. Deliberately NOT `mt` — cosmetic touches (a distilled line landing) bump mt without giving
+    the goal any new evidence, and inflating `heard` here would hide a genuinely moved-on thread."""
+    heard = nd.get("t") or 0
+    for e in (nd.get("log") or []):
+        heard = max(heard, e.get("ev_t") or 0)
+    for seg_id in (nd.get("trail") or []):
+        parts = str(seg_id).split(":")
+        if len(parts) >= 2 and parts[-2].isdigit():
+            heard = max(heard, int(parts[-2]))
+    return heard
+
+
+def _sweep_candidates(store):
+    """[(nid, nd, heard_t), …] for every open WORKING goal with real evidence — the exact complement of
+    _starved_candidates' evidence-less mints (`trail`/`log` present here, absent there), so no node is
+    ever nominated through both channels. Skips mirror the starved scan: ruled nodes (the unblocker owns
+    blocked ones), umbrellas, sealed subtrees, all-children-done branches (the subtree-done channel), and
+    agentTask-open subtrees (the authoritative tier: the agent's own list says the work is still owed)."""
+    nodes = store["nodes"]
+    children = {}
+    for nid, nd in nodes.items():
+        children.setdefault(nd.get("parentId"), []).append(nid)
+
+    def _sealed_above(nid):
+        x, seen = nodes.get(nid, {}).get("parentId"), set()
+        while x and x not in seen:
+            seen.add(x)
+            nd = nodes.get(x)
+            if not nd:
+                return False
+            if nd.get("nodeComplete") or nd.get("cleared"):
+                return True
+            x = nd.get("parentId")
+        return False
+
+    def _task_open(nid):
+        if (nodes.get(nid, {}).get("agentTask") or {}).get("status") == "open":
+            return True
+        return any(_task_open(c) for c in children.get(nid, []))
+
+    out = []
+    for nid, nd in nodes.items():
+        if nd.get("nodeComplete") or nd.get("cleared") or nd.get("blocked") or nd.get("settledDone"):
+            continue
+        if nd.get("umbrella"):
+            continue
+        if not (len(nd.get("trail") or []) > 1 or nd.get("log")):
+            continue                                   # evidence-less mint → the starved channel owns it
+        kids = children.get(nid, [])
+        if kids and all(nodes[c].get("nodeComplete") or nodes[c].get("cleared") for c in kids):
+            continue                                   # all-children-done → the subtree-done channel owns it
+        if _sealed_above(nid) or _task_open(nid):
+            continue
+        out.append((nid, nd, _node_heard_t(nd)))
+    out.sort(key=lambda c: c[2])
+    return out
+
+
+def _sweep_session(fsid, path, now):
+    """Re-examine ONE session's moved-past open goals. Event-gated per node exactly like the unblocker:
+    a goal is (re-)examined only when an ENDED turn newer than max(its heard time, its last check)
+    exists — sweepCheckT is the watermark, advanced after every examine (and on the parse give-up) so a
+    stable session costs zero calls. Returns the node ids settled.
+
+    Write discipline mirrors _unblock_session (the user 2026-07-11): the scan's load is read-only and
+    discarded, verdicts apply to a FRESH load afterwards, and a node whose state moved on during the
+    model call is skipped with a logged drift-skip, never silently."""
+    _judge_ctx.fsid = fsid                            # usage logging: attribute this session's judge calls
+    cands = _sweep_candidates(load_goals(fsid))        # read-only scan; this copy is NOT saved
+    if not cands:
+        return []
+    session = parsed_session(fsid, [path], now)
+    turns = session["turns"]
+    ended_ts = [turn.get("t") or 0 for turn in turns if not _turn_open(turn, turns)]
+    newest = max(ended_ts, default=0)
+    due = [(nid, nd, heard) for nid, nd, heard in cands
+           if newest > max(heard, nd.get("sweepCheckT") or 0)]
+    if not due:
+        return []
+    oldest_heard = min(heard for _nid, _nd, heard in due)
+    since = "\n\n".join(_unit_text(turn["atoms"]) for turn in turns
+                        if (turn.get("t") or 0) > oldest_heard and not _turn_open(turn, turns))
+    since = since[-SWEEP_HISTORY_CHARS:]
+    if not since.strip():
+        return []
+    goals_text = "\n".join("%d. %s\n   last recorded: %s" % (i, nd.get("text") or "(goal)",
+                                                             nd.get("summary") or "(no summary yet)")
+                           for i, (_nid, nd, _heard) in enumerate(due, 1))
+    raw = sweep_llm(goals_text, since)                 # ← seconds; no store copy held across this
+    if not raw:
+        return []                                      # call failed / paused (logged) → retry next pass
+    settles = _parse_sweep(raw, len(due))
+    store = load_goals(fsid)                           # FRESH load: apply onto the current store, never the
+    nodes = store["nodes"]                             #   pre-call snapshot (a stale save clobbers writers)
+    if settles is None:
+        _log_judge_error("sweeper", fsid, "parse", note="reply tail: %r" % raw[-160:],
+                         goal=[nid for nid, _nd, _heard in due])
+        fails = store.setdefault("sweepFails", 0) + 1
+        store["sweepFails"] = fails
+        if fails >= JUDGE_FAIL_CAP:                    # give up on THIS evidence: advance the watermarks —
+            store["sweepFails"] = 0                    # a NEWER ended turn re-arms every node (event re-arm)
+            for nid, _nd, _heard in due:
+                if nid in nodes:
+                    nodes[nid]["sweepCheckT"] = newest
+        save_goals(fsid, store)
+        return []
+    store["sweepFails"] = 0
+    settled = []
+    for i, (nid, _stale, _heard) in enumerate(due, 1):
+        nd = nodes.get(nid)
+        why = settles.get(i)
+        if nd is None or nd.get("nodeComplete") or nd.get("blocked") or nd.get("cleared"):
+            # the node moved on during the model call — resolved, cleared, or re-planned away. Never
+            # apply a verdict formed against the pre-call state; surface the race so it's observable.
+            if why is not None:
+                _log_judge_error("sweeper", fsid, "drift-skip", goal=nid,
+                                 note="node changed during the model call (resolved/cleared/re-planned) — settle skipped")
+            continue
+        nd["sweepCheckT"] = newest                     # examined up to here — re-ask only on newer evidence
+        if why is None:
+            continue
+        if record_verdict(store, nd, "sweeper", "done", newest,
+                          why=("delivered elsewhere: " + why) if why else "delivered elsewhere"):
+            nd["mt"] = now
+            settled.append(nid)
+    rollup_status(store, _session_closed(session))
+    save_goals(fsid, store)
+    return settled
+
+
+def run_sweep(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
+    """One SWEEPER pass (moved-past open goals re-examination), triage tier, run after run_unblock.
+    Per-session sequential (one call covers all its due goals), sessions concurrent."""
+    if now is None:
+        now = int(time.time())
+    fleet = [s for s in discover(now) if not _hidden_from_feed(s[0])][:sessions_cap]
+    n = 0
+    with ThreadPoolExecutor(max_workers=concurrency) as ex:
+        futs = {ex.submit(_sweep_session, fsid, str(path), now): fsid
+                for fsid, path, anchor, name in fleet}
+        for fut in as_completed(futs):
+            try:
+                n += len(fut.result())
+            except Exception:
+                pass
+    if verbose:
+        sys.stderr.write("romp-judge: sweeper settled %d delivered-elsewhere goals\n" % n)
+    return n
+
+
 def _ab_close_session(fsid, path, now):
     """Measure positive-only (a) vs positive+closer (b) completed-top-goal counts for ONE
     session WITHOUT mutating live state (sweeps a deep copy). Sweeps EVERY end-known turn (no cap, so a
@@ -7509,6 +7728,11 @@ def run_triage(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, ve
             # after the closer (a just-completed top's blocks are already moot) and before the distiller
             # (a lifted block's card re-rolls to working in this same pass)
             run_unblock(now=now, sessions_cap=sessions_cap, concurrency=concurrency, verbose=verbose)
+        if SWEEP_ON:
+            # after the closer AND the unblocker: a settle this pass just landed (closer) or a block just
+            # lifted (unblocker) is exactly the fresh evidence a moved-past sibling should be judged
+            # against, and before the distiller so a swept done distills in this same pass
+            run_sweep(now=now, sessions_cap=sessions_cap, concurrency=concurrency, verbose=verbose)
         run_courier(now=now, sessions_cap=sessions_cap, concurrency=concurrency, verbose=verbose)
         run_propagate(now=now, sessions_cap=sessions_cap, concurrency=concurrency, verbose=verbose)   # delegated goal done on B → check off the sender's tracking node
         if GROUPER_ON:

--- a/tests/test_judge_sweeper.py
+++ b/tests/test_judge_sweeper.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""The SWEEPER (the user 2026-07-26): an open working goal with real evidence is reachable only through
+turn menus, so once its last turn is closed as still-open, a reply that delivers its outcome on a
+sibling card's thread never reaches it — the planner files that reply under the goal it was asked
+about, and the first card sits working forever (2026-07-25: a docs top sat working across a
+session-wide all-done reply until the user cleared it by hand). The delivered-elsewhere gap was
+already closed for BLOCKED goals (the unblocker) and evidence-less mints (the starved channel); the
+sweeper is the third leg: open working goals WITH evidence, re-examined against the conversation
+since they last heard anything, settled via the same record_verdict("done") the closer uses.
+Event-gated per node (sweepCheckT vs the newest ended turn), model stubbed, conservative hold
+default. All fixtures SYNTHETIC (invented text, placeholder UUIDs, the notes-api demo domain).
+"""
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+jd = SourceFileLoader("romp_judge_sweep", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NOW = 1781100000
+T0 = NOW - 3600
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+def _node(nid, text, parent=None, trail=(), log=(), **extra):
+    """A plain-dict node BEFORE save (protected flags are diary-owned once loaded — GuardedNode)."""
+    nd = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False, "cleared": False,
+          "blocked": False, "trail": list(trail), "log": list(log), "t": T0, "mt": T0}
+    nd.update(extra)
+    return nd
+
+
+class SweeperBase(unittest.TestCase):
+    def setUp(self):
+        self._saved_state = jd.STATE
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        jd._PARSE_CACHE.clear()
+        self._saved_llm = jd.sweep_llm
+        self.calls = []
+
+    def tearDown(self):
+        jd.sweep_llm = self._saved_llm
+        jd._rebind_state(self._saved_state)
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _stub(self, reply):
+        def fake(goals_text, since_text):
+            self.calls.append((goals_text, since_text))
+            return reply
+        jd.sweep_llm = fake
+
+    def _store(self, nodes):
+        store = {"rompUuid": SID, "seq": 2, "lastNode": nodes[0]["id"], "placements": {},
+                 "status": {}, "nodes": {nd["id"]: nd for nd in nodes}}
+        jd.save_goals(SID, store)
+        return store
+
+    def _transcript(self, turns):
+        """Write a transcript of ENDED turns [(t, user_text, reply_text), ...] + return its path."""
+        recs, prev = [], None
+        for i, (t, ask, reply) in enumerate(turns):
+            u, a = "u%d" % i, "a%d" % i
+            recs.append(uline(t, ask, u, parent=prev))
+            recs.append(aline(t + 5, reply, a, parent=u))
+            prev = a
+        p = Path(self._td) / (SID + ".jsonl")
+        p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        return str(p)
+
+
+# The worked-elsewhere fixture both suites below share: goal A ("migrate the notes-api auth") settled
+# normally; goal B ("write the notes-api deployment guide") worked earlier (trail), then a later status
+# reply on A's thread reports B's outcome delivered too.
+def _trail(ts):
+    return [SID + ":%d:s%d" % (t, i) for i, t in enumerate(ts)]
+
+
+class SweepCandidates(SweeperBase):
+    def test_a_trail_bearing_open_goal_qualifies(self):
+        g = SID + ":g2"
+        self._store([_node(g, "write the deployment guide", trail=_trail([T0 + 90, T0 + 100]))])
+        cands = jd._sweep_candidates(jd.load_goals(SID))
+        self.assertEqual([c[0] for c in cands], [g])
+        self.assertEqual(cands[0][2], T0 + 100, "heard = the newest trail segment's turn time")
+
+    def test_a_diary_bearing_goal_qualifies_and_heard_reads_the_diary(self):
+        g = SID + ":g2"
+        self._store([_node(g, "tune the api rate limits",
+                           log=[{"ev_t": T0 + 200, "src": "planner", "kind": "note", "at": T0 + 200}])])
+        cands = jd._sweep_candidates(jd.load_goals(SID))
+        self.assertEqual([c[0] for c in cands], [g])
+        self.assertEqual(cands[0][2], T0 + 200, "heard = the newest diary event's evidence time")
+
+    def test_an_evidence_less_mint_is_the_starved_channels_not_ours(self):
+        # the exact complement: trail<=1 and no log → _starved_candidates territory, never nominated here
+        g = SID + ":g2"
+        self._store([_node(g, "a bare minted ask", trail=_trail([T0 + 90]))])
+        self.assertEqual(jd._sweep_candidates(jd.load_goals(SID)), [])
+
+    def test_ruled_and_owned_nodes_are_skipped(self):
+        base = _trail([T0 + 90, T0 + 100])
+        self._store([
+            _node(SID + ":g1", "done already", trail=base, nodeComplete=True),
+            _node(SID + ":g2", "blocked on the user", trail=base, blocked=True),   # the unblocker owns it
+            _node(SID + ":g3", "cleared by hand", trail=base, cleared=True),
+            _node(SID + ":g4", "agent still owes work", trail=base,
+                  agentTask={"key": "k1", "status": "open"}),
+        ])
+        self.assertEqual(jd._sweep_candidates(jd.load_goals(SID)), [])
+
+
+class Sweeper(SweeperBase):
+    def _worked_elsewhere(self):
+        a, b = SID + ":g1", SID + ":g2"
+        self._store([
+            _node(a, "migrate the notes-api auth", nodeComplete=True),
+            _node(b, "write the notes-api deployment guide", trail=_trail([T0 + 90, T0 + 100])),
+        ])
+        path = self._transcript([
+            (T0 + 50, "start the deployment guide", "drafting the guide now"),
+            (T0 + 500, "status on the migration?",
+             "Migration done, and the deployment guide shipped with it - both pages are live, nothing left on either."),
+            (T0 + 600, "thanks, wrapping up", "all wrapped"),
+        ])
+        return a, b, path
+
+    def test_an_outcome_delivered_elsewhere_settles_the_goal(self):
+        a, b, path = self._worked_elsewhere()
+        self._stub('{"verdicts": [{"n": 1, "do": "settle", "why": "the status reply says the guide shipped and is live"}]}')
+        self.assertEqual(jd._sweep_session(SID, path, NOW), [b])
+        store = jd.load_goals(SID)
+        nd = store["nodes"][b]
+        self.assertTrue(nd["nodeComplete"], "the moved-past goal is completed")
+        ev = next(e for e in reversed(nd.get("log") or [])
+                  if e.get("src") == "sweeper")        # the settle STAMP (src 'romp') rides after the verdict
+        self.assertEqual(ev.get("kind"), "done")
+        self.assertIn("delivered elsewhere", ev.get("why", ""), "provenance rides the diary")
+        self.assertIn("deployment guide", self.calls[0][0], "the goal is shown to the model")
+        self.assertIn("both pages are live", self.calls[0][1], "the after-conversation is shown")
+
+    def test_a_hold_keeps_the_goal_and_the_watermark_prevents_reasking(self):
+        a, b, path = self._worked_elsewhere()
+        self._stub('{"verdicts": [{"n": 1, "do": "hold", "why": ""}]}')
+        self.assertEqual(jd._sweep_session(SID, path, NOW), [])
+        store = jd.load_goals(SID)
+        self.assertFalse(store["nodes"][b]["nodeComplete"], "held: still genuinely open")
+        self.assertGreater(store["nodes"][b].get("sweepCheckT") or 0, T0 + 100,
+                           "the watermark advanced to the examined evidence")
+        # same evidence again → no second model call (event-gated)
+        self.assertEqual(jd._sweep_session(SID, path, NOW), [])
+        self.assertEqual(len(self.calls), 1, "no new ended turn → no re-ask")
+        # a NEWER ended turn re-arms the examination
+        path2 = self._transcript([
+            (T0 + 50, "start the deployment guide", "drafting the guide now"),
+            (T0 + 500, "status on the migration?", "migration done, guide shipped too"),
+            (T0 + 900, "one more look", "looked"),
+            (T0 + 950, "tail", "tail reply"),
+        ])
+        jd._PARSE_CACHE.clear()
+        jd._sweep_session(SID, path2, NOW)
+        self.assertEqual(len(self.calls), 2, "new evidence → examined again")
+
+    def test_a_goal_merely_unmentioned_is_never_settled_by_parse_tolerance(self):
+        # conservative-parse floor: garbage or out-of-range replies hold everything
+        a, b, path = self._worked_elsewhere()
+        self._stub('{"verdicts": [{"n": 7, "do": "settle", "why": "out of range"}]}')
+        self.assertEqual(jd._sweep_session(SID, path, NOW), [])
+        self.assertFalse(jd.load_goals(SID)["nodes"][b]["nodeComplete"])
+
+    def test_parse_failures_advance_the_watermark_only_at_the_fail_cap(self):
+        a, b, path = self._worked_elsewhere()
+        self._stub("not json at all")
+        for i in range(jd.JUDGE_FAIL_CAP):
+            self.assertEqual(jd._sweep_session(SID, path, NOW), [])
+        store = jd.load_goals(SID)
+        self.assertGreater(store["nodes"][b].get("sweepCheckT") or 0, T0 + 100,
+                           "the give-up advances the watermark so the pass is not re-asked forever")
+        self.assertEqual(store.get("sweepFails"), 0, "the counter resets with the give-up")
+
+    def test_a_node_that_moved_on_during_the_call_is_drift_skipped(self):
+        a, b, path = self._worked_elsewhere()
+
+        def fake(goals_text, since_text):
+            # the user clears the node while the model call is in flight: rewrite the RAW store file
+            # (plain dicts on disk — GuardedNode only guards loaded nodes)
+            p = jd.GOALDIR / (SID + ".json")
+            obj = json.loads(p.read_text())
+            obj["nodes"][b]["cleared"] = True
+            p.write_text(json.dumps(obj))
+            self.calls.append((goals_text, since_text))
+            return '{"verdicts": [{"n": 1, "do": "settle", "why": "shipped"}]}'
+        jd.sweep_llm = fake
+        self.assertEqual(jd._sweep_session(SID, path, NOW), [], "the stale settle is skipped, not applied")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A goal whose outcome lands on a sibling card's thread sat in Working forever: turn menus only re-list placement-touched nodes, so a session-wide "everything shipped" reply never reached the card it also settled. This adds the sweeper - the unblocker's twin for the Working column - covering the third leg of the delivered-elsewhere gap (unblocker = blocked goals, starved channel = evidence-less mints, sweeper = evidenced working goals, the exact complement of the starved filter).

Event-gated per node (sweepCheckT watermark vs newest ended turn), conservative hold default, unblocker write discipline throughout (fresh-load apply, drift-skip, fail-cap watermark advance). Wired into the triage tier after closer+unblocker, before the distiller. Kill switch ROMP_SWEEPER=0.

Tests: tests/test_judge_sweeper.py (candidates complement, settle with diary provenance, hold+watermark event re-arm, parse-tolerance floor, fail-cap give-up, drift-skip). Both suites green: 3138 Python, 1328 Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)