### PR TITLE
A dead judge CLI is a logged call failure, never a silent empty reply

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -591,8 +591,20 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage"):
                 return wrap["result"]
         except Exception:
             pass
+        if not out.strip():
+            # DEAD CLI (2026-07-26): the subprocess ended with NOTHING on stdout — a death, not a reply.
+            # This used to fall through the raw-stdout fallback below as "", logged NOWHERE (no error
+            # row, no usage row): a briefer that died three times overnight gave up with zero forensics,
+            # and the card's warn could only GUESS its cause ("errors or timeouts"). The returncode and
+            # stderr tail are the only evidence a dead CLI leaves — record them (fail loudly; a silent
+            # fallback hides the very breakage we need to know about).
+            _log_judge_error(judge or tier, fsid, "call",
+                             note="empty stdout (exit %s): %s"
+                                  % (getattr(p, "returncode", "?"),
+                                     (getattr(p, "stderr", "") or "").strip()[-200:] or "no stderr"))
+            return ""
         _judge_ctx.last["reply"] = _mid_elide(out)
-        return out                                    # wrapper absent/unparseable → raw stdout (defensive)
+        return out                                    # wrapper unparseable but non-empty → raw stdout (defensive)
     finally:
         _active_end(rid)                              # call done (success/timeout/parse-fail) → drop the live bar
 

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -6421,6 +6421,30 @@ class FailureContract(unittest.TestCase):
         self.assertIn("API Error: 529 overloaded", row["note"], "the API's own message is the evidence")
         self.assertFalse(Path(jd.USAGE).exists(), "a zero-cost error envelope logs no usage row")
 
+    # ── a dead CLI (empty stdout) is a LOGGED call failure, never a silent "" ──
+    def test_a_dead_cli_is_a_logged_call_failure_with_its_stderr(self):
+        # 2026-07-26: a briefer died three times overnight (empty stdout, no envelope, no exception),
+        # returned "" through the raw-stdout fallback with NO error row and NO usage row, and the
+        # give-up warn could only guess its cause. The returncode + stderr tail are the only evidence
+        # a dead CLI leaves; the row must carry them.
+        import types
+        saved_sub, saved_fsid = jd.subprocess, getattr(jd._judge_ctx, "fsid", None)
+        jd.subprocess = types.SimpleNamespace(
+            run=lambda *a, **k: types.SimpleNamespace(
+                stdout="", stderr="FATAL ERROR: JS heap out of memory\n", returncode=134))
+        jd._judge_ctx.fsid = "sid-dead"
+        try:
+            out = jd._judge_run("model-x", "sys", "user", judge="briefer")
+        finally:
+            jd.subprocess = saved_sub
+            jd._judge_ctx.fsid = saved_fsid
+        self.assertEqual(out, "", "a dead CLI reads as an empty reply to every caller")
+        row = self._errors()[-1]
+        self.assertEqual((row["judge"], row["err"], row["fsid"]), ("briefer", "call", "sid-dead"))
+        self.assertIn("exit 134", row["note"], "the returncode is the evidence")
+        self.assertIn("heap out of memory", row["note"], "…with the stderr tail")
+        self.assertFalse(Path(jd.USAGE).exists(), "a dead CLI logs no usage row")
+
     # ── empty replies never count as parse rejects ──
     def test_empty_planner_reply_never_burns_retries_or_logs_parse(self):
         records = [uline(T0, "please fix the flaky test", "u1", ps="typed"),


### PR DESCRIPTION
Diagnosing a "card couldn't be summarized" warn hit a wall: the briefer's three failed calls left no error rows, no usage rows, nothing. Root cause of the wall: _judge_run handles exceptions, timeouts, and error envelopes, but a CLI that dies (nonzero exit, empty stdout, stderr message) returned "" through the raw-stdout fallback, logged nowhere. The give-up warn then guessed its cause, and the real one was unknowable.

Empty stdout now logs a "call" row with returncode + stderr tail. Test added to FailureContract. Both suites green: 3140 Python, 1330 Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)