### PR TITLE
/clear is an episode boundary, not a silent hole

### DIFF
--- a/docs/goal-state.md
+++ b/docs/goal-state.md
@@ -178,3 +178,11 @@ within a beat it reverts with a toast, never silently.
     no diary is frozen, never derived-and-wiped, and surfaces loudly in
     judge-errors.jsonl. Retired flags (`everDone`, `logBorn`) are popped
     by the sweep.
+11. `/clear` is an episode boundary, not a deletion. A new null-rooted
+    transcript head (vs the episodes log) settles the session's still-open
+    tops — a romp-authored clear ("dropped when the conversation was
+    cleared"), sealed like the mute path: no agent notify, no delegation
+    cascade; completed cards stay. Placement fuzzy-matching is scoped to
+    the current episode (a retyped prompt plans again; exact hits still
+    dedup, so archived nodes never re-mint). The timeline draws a seam
+    per boundary; `plans/clear-episodes.md` has the full design.

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -41,6 +41,10 @@ GOALDIR  = STATE / "goals"               # per-session goal tree (the inbox), ke
                                          # (the user-override journal lives beside it — _overrides_dir())
 GOALARCHDIR = STATE / "goals-archive"    # CLEARED (dismissed) goal subtrees moved out of the live tree, keyed by rompUuid:
                                          #   keeps the live store flat so build_feed stops re-deriving dismissed cards every push
+EPIDIR   = STATE / "episodes"            # per-session append-only episode log, keyed by rompUuid: one row per observed
+                                         #   /clear-style fork head ({head, fsid, t}) — the durable record of where each
+                                         #   conversation episode began (the SDK registry's lastSid is OVERWRITTEN per fork,
+                                         #   so without this log a multi-/clear session's past transcripts are unattributable)
 STATESDIR = STATE / "states"             # per-session real idle/compacting transitions → idle atoms (settled gate)
 PCACHE   = STATE / "judge-units-cache"   # (mtime,size) cache of a transcript's ready units
 MESSAGES = STATE / "timeline" / "messages.jsonl"
@@ -61,14 +65,17 @@ def _rebind_state(path):
     save_goals wrote synthetic fixtures into the live goals/ and the triage pass then stormed
     judge-errors.jsonl over those orphans every pass forever (the user 2026-06-24). A test must call this
     instead of assigning jd.STATE alone. Not used in production (STATE is bound once at import)."""
-    global STATE, NAMES, CAPDIR, ARCHDIR, GOALDIR, GOALARCHDIR, STATESDIR, PCACHE, MESSAGES, ERRORS, USAGE, SDKDIR
+    global STATE, NAMES, CAPDIR, ARCHDIR, GOALDIR, GOALARCHDIR, STATESDIR, PCACHE, MESSAGES, ERRORS, USAGE, SDKDIR, EPIDIR
     STATE = path
     NAMES, CAPDIR, ARCHDIR, GOALDIR = STATE / "names", STATE / "captions", STATE / "archive", STATE / "goals"
     GOALARCHDIR = STATE / "goals-archive"
     STATESDIR, PCACHE = STATE / "states", STATE / "judge-units-cache"
     MESSAGES, ERRORS, USAGE = STATE / "timeline" / "messages.jsonl", STATE / "judge-errors.jsonl", STATE / "judge-usage.jsonl"
     SDKDIR = STATE / "sdk"
+    EPIDIR = STATE / "episodes"
     _lastsid_memo.clear()   # sdk-registry reads are mtime-memoized per sid — a rebind must not serve the old root's values
+    _episode_memo.clear()   # ...and so are the episode-log reads
+    _head_memo.clear()      # transcript heads are immutable per path, but a rebind swaps the whole world of paths
     # (the override journal needs no rebinding: _overrides_dir() derives from GOALDIR at call time, so
     #  ANY isolation style — _rebind_state OR a bare GOALDIR reassignment — scopes it automatically)
 
@@ -3139,6 +3146,110 @@ def _sdk_last_sid(sid):
     return ls
 
 
+# ── Episodes: /clear is a boundary, not a deletion (the user 2026-07-26) ─────────────────────────
+# A `/clear` mints a new transcript whose head record has NO parent link, while a resume-style fork
+# chains parentUuid into the prior file — so "the session's current transcript starts at a null-rooted
+# head we have not seen before" is the exact, event-based signal that a conversation episode ended.
+# episodes/<sid>.jsonl records each observed episode head, append-only: the first row is whatever
+# episode was current when the session was first observed; every LATER row is a /clear boundary. The
+# kernel keys its boundary settle (open cards die with their episode) and the timeline's clear seams
+# on this log, and it is the only durable map from a session to its past episodes' transcript files.
+
+_head_memo = {}      # transcript path -> {"uuid","root","t"} — a file's head record is immutable
+_episode_memo = {}   # sid -> (log mtime, last row or None)
+
+
+def transcript_head(path):
+    """The first uuid-bearing record of `path`: {"uuid", "root": <no parent link>, "t": <epoch>} — or
+    None (empty/unreadable file, or no uuid-bearing row yet). `root` follows the same rule as the
+    FileAdapter walk: parentUuid OR logicalParentUuid (the compaction stitch) counts as a parent, so
+    only a genuine `/clear`-style head reads as an episode start. Cached per path once a head exists
+    (a transcript is append-only; its head never changes)."""
+    key = str(path)
+    hit = _head_memo.get(key)
+    if hit is not None:
+        return hit
+    head = None
+    try:
+        with open(path, "r", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    r = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(r, dict) or not r.get("uuid"):
+                    continue    # summary/meta rows before the first real record
+                t = em.parse_z(r.get("timestamp")) or 0
+                head = {"uuid": r["uuid"],
+                        "root": (r.get("parentUuid") or r.get("logicalParentUuid")) is None,
+                        "t": t}
+                break
+    except OSError:
+        return None
+    if head is not None:
+        if len(_head_memo) > 4096:   # backstop: bounded by transcripts-seen, but never unbounded
+            _head_memo.clear()
+        _head_memo[key] = head
+    return head
+
+
+def episode_rows(sid):
+    """Every recorded episode row of `sid` ([{"head","fsid","t"}, ...], oldest first; [] if none).
+    Row 0 is the episode current at first observation; every later row is a /clear boundary.
+    mtime-memoized like _sdk_last_sid — the log only grows at a /clear, so per-pass reads are a stat."""
+    p = EPIDIR / (sid + ".jsonl")
+    try:
+        mt = p.stat().st_mtime
+    except OSError:
+        _episode_memo.pop(sid, None)
+        return []
+    hit = _episode_memo.get(sid)
+    if hit is not None and hit[0] == mt:
+        return hit[1]
+    rows = []
+    try:
+        for line in p.read_text(errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                r = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(r, dict) and r.get("head"):
+                rows.append(r)
+    except OSError:
+        pass
+    _episode_memo[sid] = (mt, rows)
+    return rows
+
+
+def episode_last(sid):
+    """The last recorded episode row of `sid` ({"head","fsid","t"}) or None."""
+    rows = episode_rows(sid)
+    return rows[-1] if rows else None
+
+
+def append_episode(sid, head, fsid, t):
+    """Record an observed episode head for `sid` (append-only; the caller has already established
+    this head is NEW — see the kernel's boundary tick)."""
+    EPIDIR.mkdir(parents=True, exist_ok=True)
+    with (EPIDIR / (sid + ".jsonl")).open("a") as fh:
+        fh.write(json.dumps({"head": head, "fsid": fsid, "t": t}) + "\n")
+    _episode_memo.pop(sid, None)
+
+
+def episode_floor(sid):
+    """The current episode's start time for `sid`, or None if no episode was ever recorded. The
+    placement fuzzy-match scope (see _placed_key): evidence recorded before this instant belongs to
+    a conversation the agent can no longer see."""
+    row = episode_last(sid)
+    return row.get("t") if row else None
+
+
 _discover_lock = threading.Lock()
 _discover_cache = {}     # window seconds → {"fp", "result"}: the cached discover() list for THAT horizon (see
 #                          _discover_fingerprint). Keyed by window because the picker asks for a wider one
@@ -4599,19 +4710,46 @@ def _placed_key(placements, key, live=None):
     resumes), so the first placed twin swallowed every later twin's work-run forever — whole turns of
     real work never reached the goal tree (the user 2026-07-06, the stuck 'drag' card). Drift is exactly
     the orphan case (a drifted old id no longer parses out), so the double-mint protection is intact —
-    event-based, no time window."""
+    event-based, no time window.
+
+    Episode scope (the user 2026-07-26): a fuzzy hit must also come from the CURRENT episode. After a
+    `/clear`, every pre-clear placement is orphaned, so a byte-identical prompt retyped in the fresh
+    conversation fuzzy-matched its dead twin and was silently deduped — no card, ever. A recorded key
+    whose embedded t predates episode_floor() is evidence from a conversation the agent can no longer
+    see, so it dedups nothing (exact hits are untouched: pre-clear segment ids can only re-enter the
+    parse as-written, and then the exact match is precisely the anti-re-mint guard)."""
     if key in placements:
         return True
     want = _seg_key(key)
     kb = key.split("#")[0]
+    floor = None
     for k in placements:
         if _seg_key(k) != want:
             continue
         rb = k.split("#")[0]
-        if live is not None and rb != kb and rb in live:
-            continue                                   # the recorded key IS another live segment (a twin), not our drift
+        if rb != kb:
+            if live is not None and rb in live:
+                continue                               # the recorded key IS another live segment (a twin), not our drift
+            if floor is None:                          # sid = everything before the volatile t + texthash
+                parts = key.split(":")                 # (a federated sid itself carries a colon)
+                floor = (episode_floor(":".join(parts[:-2])) if len(parts) >= 3 else None) or 0
+            rt = _key_t(rb)
+            if rt is not None and rt < floor:
+                continue                               # recorded in a PRIOR episode (pre-/clear) — not our drift
         return True
     return False
+
+
+def _key_t(seg_id):
+    """The volatile middle `seg.t` of a seg id as written (`rompuuid:t:texthash`), or None for a
+    non-conforming/legacy id — those stay un-scoped rather than guessed at."""
+    parts = seg_id.split(":")
+    if len(parts) < 3:
+        return None
+    try:
+        return float(parts[-2])
+    except ValueError:
+        return None
 
 
 def _placement_of(placements, seg_id, live=None):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9521,14 +9521,18 @@ def _cleared_ids():
     return cur
 
 
-def _mark_nodes_cleared(item_ids, value):
+def _mark_nodes_cleared(item_ids, value, src="user", why=None):
     """Set the DURABLE node-level `cleared` flag on each cleared/restored top goal node, so a Clear is
     immune to status recompute AND the grouper. The view-level cleared.jsonl only hid the CARD; the
     node stayed 'open', so two paths resurfaced it (the user 2026-06-18): (1) the grouper's _group_tops
     re-wraps an open top under a FRESH umbrella whose new id is NOT in cleared.jsonl → the umbrella card
     reappears; (2) rollup_status keeps flipping a nodeComplete focus top working↔completed, so the card
     bounces between columns. Both keys read nd['cleared'] — set it and rollup gives 'cleared' (which the
-    grouper skips and the feed filter hides), durably. Re-rolls each touched session's status."""
+    grouper skips and the feed filter hides), durably. Re-rolls each touched session's status.
+
+    `src`/`why` apply to the CLEAR direction only (an undo is always the user's gesture): the episode
+    boundary settle records its clears as romp-authored with an honest why, so the card's log says the
+    conversation was cleared rather than claiming the user crossed it off the feed."""
     by_sid = {}
     for iid in item_ids:
         sid = iid.rsplit(":", 1)[0]
@@ -9550,8 +9554,9 @@ def _mark_nodes_cleared(item_ids, value):
                 # gate passes because _undo_clear appends the cleared.jsonl undo rows BEFORE this runs)
                 was_done = nd.get("parentId") is None and (
                     store.get("status", {}).get(iid) == "completed" or nd.get("nodeComplete"))
-                applied = jd.record_verdict(store, nd, "user", "clear" if value else "reopen", now,
-                                            why="cleared from the feed" if value else "undo clear",
+                applied = jd.record_verdict(store, nd, src if value else "user",
+                                            "clear" if value else "reopen", now,
+                                            why=(why or "cleared from the feed") if value else "undo clear",
                                             undo=not value)   # an undo-restore asserts nothing about doneness
                 if not value and applied:
                     # Journal the UN-CLEAR (the user 2026-07-23, the restore-then-reply flicker): the
@@ -9585,6 +9590,62 @@ def _mark_nodes_cleared(item_ids, value):
             _note_user_goal_write(sid)
     if not value:
         _mark_views_dirty()
+
+
+# ── /clear is an episode boundary, not a deletion (the user 2026-07-26) ──────────────────────────
+# A `/clear` mints a new transcript whose head record has no parent link; romp's goal layer used to be
+# blind to it, so a session's open cards outlived the conversation that was their only evidence. Four
+# machines then carried them into the fresh, unrelated conversation: the closer's history-nominated
+# candidates, the unblocker's per-turn re-examines, the auto-nudge (quoting pre-clear goals at an agent
+# with no memory of them, then recording a "nudge failed" block when its reply couldn't resolve them),
+# and the awaiting backstop. The boundary tick makes the clear visible: it records each observed
+# episode head in jd's episodes/<sid>.jsonl (also the durable map to past episodes' transcripts —
+# lastSid is overwritten per fork, so this log is the only attribution of old files to their session),
+# and settles the open cards that died with their episode — sealed like the mute path (cleared.jsonl +
+# the durable node flag; no clear-wrap notify: the agent that knew this work is gone, and messaging the
+# fresh one is exactly the confusion this exists to stop; no delegation cascade: a handed-off piece
+# lives on in the peer). Completed cards stay — the Completed column is history and needs no evidence.
+# Cards remain undoable (Undo restores the batch) and archive/searchable via goal-store compaction.
+
+def _episode_boundary_tick(now):
+    """Detect `/clear` boundaries across the fleet and settle each cleared episode's open cards. Runs
+    in the producer thread BEFORE the judge tiers and the pre-pass goals snapshot, so the same pass's
+    planner/closer/nudge already see the settled store. Cheap when nothing changed: _sessions() is the
+    cached discover, the episode log read is an mtime memo, and a transcript's head record is cached
+    per path (immutable once written)."""
+    for s in _sessions(now):
+        try:
+            _episode_boundary_check(s["sid"], s["path"], now)
+        except Exception:
+            sys.stderr.write("episode boundary: %s\n" % traceback.format_exc())
+
+
+def _episode_boundary_check(sid, path, now):
+    head = jd.transcript_head(path)
+    if not head or not head["root"]:
+        return                       # no head yet, or a resume-style leaf (chains into a prior file):
+    last = jd.episode_last(sid)      # either way the recorded episode is still the current one
+    if last is not None and last.get("head") == head["uuid"]:
+        return
+    jd.append_episode(sid, head["uuid"], Path(path).stem, head["t"] or int(now))
+    if last is None:
+        return                       # first observation SEEDS the log; a boundary needs a prior recorded
+    #                                  episode (so deploying this never mass-settles existing sessions)
+    store = jd.load_goals(sid)
+    nodes, status = store.get("nodes", {}), store.get("status", {})
+    tops = [nid for nid, nd in nodes.items()
+            if nd.get("parentId") is None and not nd.get("cleared") and status.get(nid) != "cleared"
+            and not (nd.get("nodeComplete") or status.get(nid) == "completed")]
+    if not tops:
+        return
+    p = jd.STATE / "cleared.jsonl"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    t = time.time()                  # one shared batch t → a single Undo restores the whole boundary batch
+    with p.open("a") as fh:
+        for nid in tops:
+            fh.write(json.dumps({"id": nid, "t": t, "op": "clear"}) + "\n")
+    _mark_nodes_cleared(tops, True, src="romp", why="dropped when the conversation was cleared")
+    sys.stderr.write("episode boundary: %s cleared -> settled %d open card(s)\n" % (sid[:8], len(tops)))
 
 
 def _clear_ask(item_id):
@@ -12288,6 +12349,9 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
             "awaiting": _state_intervals(sid, _NEEDS_INPUT_STATES, now),
             "compacting": _state_intervals(sid, "compacting", now),
             "compactions": compactions,
+            # /clear seams: every episode boundary (row 0 of the log is the FIRST observed episode, not
+            # a clear) — the lane marks where a conversation ended and a blank one began
+            "clears": [{"t": r["t"]} for r in jd.episode_rows(sid)[1:] if r.get("t")],
             "faded": faded,
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),    # lane checkbox → mute from feed (timeline-only)
             "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff")})  # lane mailbox → isolate from the Romp Postal Service (bin/romp-postal-service)
@@ -13216,6 +13280,10 @@ def _producer():
             if _tmux_sessions() and not _retry_paused_on():
                 tiers.append(threading.Thread(target=_run_tier, args=(jd.run_index,), name="index"))
                 tiers.append(threading.Thread(target=_run_tier, args=(jd.run_triage,), name="triage"))
+            try:                                       # /clear boundaries FIRST (before the snapshot + tiers), so
+                _episode_boundary_tick(time.time())    # this same pass's planner/closer/nudge see a settled store
+            except Exception:                          # instead of carrying dead cards into the fresh conversation
+                sys.stderr.write("episode: %s\n" % traceback.format_exc())
             _begin_goals_pass()                        # snapshot PRE-pass goal stores → the feed serves them for the
                                                        # whole pass, so no half-applied intermediate ever shows
             _own_frame = jd.begin_pass_frame()         # ONE evidence frame for BOTH tiers and their worker pools:

--- a/plans/clear-episodes.md
+++ b/plans/clear-episodes.md
@@ -1,0 +1,123 @@
+# `/clear` is an episode boundary, not a deletion
+
+Direction picked by the user (2026-07-26): when a session's conversation is
+cleared, keep the session — its name, tab slot, mailbox, worktree naming, and
+timeline lane all persist — and treat the cleared conversation as a **closed
+episode**: settled on the board, visible as a seam on the timeline, and (future
+work) browsable read-only. Explicitly rejected: minting a literal new session
+with a duplicate name (breaks postal addressing, session-order, and
+worktree-per-session conventions).
+
+## The problem (traced 2026-07-26, before the fix)
+
+Nothing in romp knew a `/clear` happened. The transcript layer is fully
+fork-aware — discover re-points the sid at the new `lastSid` file, the parse
+drops the pre-clear branch (`kept_uuids`'s "clear" classification) — but the
+goal layer was not. A session's open cards outlived the only conversation that
+was their evidence, and four machines carried them into the fresh one:
+
+- the **closer**'s history-nominated candidates (`_subtree_done_candidates`,
+  `_starved_candidates`) re-judged pre-clear cards against unrelated new turns
+  with an empty `<goal-history>` block;
+- the **unblocker** re-examined every pre-clear blocked card on each new ended
+  turn (an LLM call per turn, false-lift risk);
+- the **auto-nudge** quoted pre-clear goals at an agent with no memory of them,
+  then recorded a manufactured "nudge failed" block when its reply couldn't
+  resolve them — escalating dead cards into Needs-you;
+- the **awaiting backstop** pinged 6h later about background work from a
+  conversation that no longer exists (`_lift_spent_awaiting` can never pair a
+  launch it can't see, so the stamp never lifted).
+
+Two quieter defects: the distiller/briefer emitted empty summaries with a
+misleading "heals itself" warning for boundary-orphaned cards, and a
+byte-identical prompt retyped after a `/clear` was silently deduped against its
+dead twin's placement (`_placed_key`'s t-invariant fuzzy match — the recorded
+key is orphaned post-clear, which is exactly the state the fuzzy path treats as
+benign drift), so the new ask never got a card.
+
+## What shipped (this plan's first commit)
+
+**Detection — exact and event-based.** A `/clear` fork's transcript head has no
+parent link; a resume-style fork chains `parentUuid` (or the compaction
+stitch's `logicalParentUuid`) into the prior file. So "the session's current
+transcript starts at a null-rooted head we have not recorded" is precisely the
+boundary event — no heuristics, no time windows. `jd.transcript_head(path)`
+reads (and caches — a transcript head is immutable) the first uuid-bearing
+record; the kernel's `_episode_boundary_tick` compares it against the last row
+of the new append-only **episodes log** (`state/episodes/<sid>.jsonl`, rows
+`{head, fsid, t}`, mtime-memoized reads). First observation seeds the log
+without settling, so deploying this never mass-clears an existing fleet.
+
+**The boundary settle.** On a boundary, still-open tops (not cleared, not
+completed) are settled exactly like the mute path: rows in `cleared.jsonl`
+(one shared batch `t`, so a single Undo restores the whole batch) plus the
+durable node flag via `_mark_nodes_cleared`, now recording a **romp-authored**
+clear with the honest why — "dropped when the conversation was cleared" — so
+the Fleet ledger reads dismissal, not completion. Deliberately absent: the
+clear-wrap notify (the agent that knew this work is gone; messaging the fresh
+one is exactly the confusion this exists to stop) and the delegation cascade
+(a handed-off piece lives on in the peer's session). Completed cards stay —
+the Completed column is history and needs no live evidence; rollup rolls the
+clear down to open sub-steps as usual. All four carry-forward machines go
+quiet automatically because every one of them already skips cleared nodes.
+The tick runs in the producer thread before the pre-pass snapshot and the
+judge tiers, so the same pass's planner/closer/nudge already see the settled
+store.
+
+**Placement scoping.** `_placed_key`'s fuzzy (t-dropped) match now requires
+the recorded key to belong to the **current episode** (`jd.episode_floor`,
+keyed off the seg id's embedded t). Exact hits are untouched on purpose:
+pre-clear segment ids can only re-enter a parse as-written (the broken-chain
+re-admission edge case), and then the exact match is exactly the anti-re-mint
+guard that keeps archived nodes from flooding back.
+
+**Timeline seam.** The kernel ships `clears: [{t}]` per lane (episodes rows
+after the first); `ui/romp-timeline-view.js` draws a film-splice cut through
+the lane at each boundary — quiet by default, "conversation cleared · a fresh
+one starts here" on hover. The lane stays continuous: same session, same slot.
+
+**The episodes log doubles as the missing attribution record.** The SDK
+registry's `lastSid` is overwritten on every fork, so before this log there
+was no durable map from a session to its past episodes' transcript files (SDK
+transcripts carry no custom-title either). Every future episode surface hangs
+off this file.
+
+## Deferred — the read-only episode browser
+
+The pieces exist; none are wired. When built:
+
+- **Entry point**: the episodes log enumerates a session's past episode heads
+  and their starting fsids. `build_session` gains an optional transcript
+  override (it is the single `sid → path` resolution point); the parse cache
+  is already keyed by leaf path, and `bin/romp-event-model --test` proves an
+  arbitrary-path parse works.
+- **Rendering**: reuse the `viewReadOnly` / `_kept_open` struck, composer-
+  disabled tab, with a real entry point (e.g. the timeline seam's hover, or a
+  "previous conversations" item in the tab context menu) instead of the
+  `confirmRevive` fork — and WITHOUT offering Revive on a bare fsid.
+- **Hazards mapped in advance**: never feed raw fsids through `_ordered`/
+  `session-order.json` (fsid churn polluted it once); `_reveal_or_confirm`
+  must be bypassed or it offers a nonsense Revive; a fork-lane fsid has no
+  goal store, so the ledger/TOC panel should hide rather than render empty.
+- **Search** (the user's "searchable rather than deleted"): today no surface
+  searches transcript text — the Fleet box matches names + goal trees, the
+  picker matches the one-line archive headline. Cleared boundary cards are
+  already searchable through the Fleet's archived-goals path once compaction
+  moves them; transcript-text search over past episodes is its own project.
+
+## Known gaps, accepted
+
+- **tmux backend**: a TUI `/clear` there surfaces as a separate fork lane
+  (the anchor sid keeps pointing at the old file), so no boundary fires for
+  the anchor. The stale-card harassment this plan fixes is an SDK-path
+  phenomenon (discover re-points the sid); the tmux shape is different and
+  untouched.
+- **A session first observed on a resume-fork leaf** (kernel down across the
+  session's birth) has no seeded episode until its next `/clear`, which then
+  seeds without settling — one missed boundary, never a false one.
+- **Multi-`/clear` between kernel passes** records only the newest head; the
+  intermediate episode's transcript is recoverable by project-dir scan but
+  unattributed in the log.
+- Pre-existing sessions cleared **before** this shipped keep their stale open
+  cards (the seed-don't-settle rule); they settle by hand or by the next
+  boundary.

--- a/tests/test_episode_boundary.py
+++ b/tests/test_episode_boundary.py
@@ -1,0 +1,222 @@
+"""/clear is an episode boundary, not a deletion (the user 2026-07-26).
+
+A `/clear` mints a new transcript whose head record has NO parent link; the goal layer used to be
+blind to it, so a session's open cards outlived the conversation that was their only evidence and
+four machines (closer candidates, unblocker, auto-nudge, awaiting backstop) carried them into the
+fresh, unrelated conversation. The kernel's episode boundary tick records each observed episode head
+in episodes/<sid>.jsonl and settles the open cards that died with their episode: sealed like the
+mute path (cleared.jsonl + the durable node flag, romp-authored verdict), no agent notify, completed
+cards untouched. The judge's _placed_key fuzzy match is scoped to the current episode so a retyped
+identical prompt plans again instead of deduping against its dead twin. Synthetic data only.
+"""
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-555555555555"
+NOW = 1750000000
+
+
+def _rec(uuid, parent=None, logical=None, ts="2026-01-01T00:00:00Z", typ="user"):
+    r = {"type": typ, "uuid": uuid, "parentUuid": parent, "timestamp": ts}
+    if logical is not None:
+        r["logicalParentUuid"] = logical
+    return r
+
+
+def _write_jsonl(path, rows):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text("".join(json.dumps(r) + "\n" for r in rows))
+
+
+def _node(nid, parent, **kw):
+    n = {"id": nid, "text": nid, "parentId": parent, "nodeComplete": False,
+         "blocked": False, "cleared": False, "trail": [], "t": 1, "mt": 1, "log": []}
+    n.update(kw)
+    return n
+
+
+class EpisodeBoundaryTest(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        self.proj = Path(self._td) / "proj"
+        self.proj.mkdir()
+        self.g = lambda n: "%s:%s" % (SID, n)
+
+    def tearDown(self):
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _store(self):
+        g = self.g
+        nodes = {
+            g("g1"): _node(g("g1"), None),                        # open working top -> settled at boundary
+            g("g1a"): _node(g("g1a"), g("g1")),                   # sub-goal -> untouched (cleared rolls down in views)
+            g("g2"): _node(g("g2"), None, nodeComplete=True),     # completed top -> stays (history needs no evidence)
+            g("g3"): _node(g("g3"), None, blocked=True),          # blocked top -> open; dies with its episode too
+            g("g4"): _node(g("g4"), None, cleared=True),          # already cleared -> not re-cleared
+        }
+        store = {"rompUuid": SID, "seq": 5, "nodes": nodes,
+                 "status": {self.g("g1"): "working", self.g("g2"): "completed",
+                            self.g("g3"): "blocked", self.g("g4"): "cleared"},
+                 "placements": {}}
+        jd.save_goals(SID, store)
+
+    def _cleared_rows(self):
+        p = jd.STATE / "cleared.jsonl"
+        if not p.exists():
+            return []
+        return [json.loads(l) for l in p.read_text().splitlines() if l.strip()]
+
+    # ── transcript_head ──────────────────────────────────────────────────────────────────────────
+
+    def test_head_null_root(self):
+        p = self.proj / "a.jsonl"
+        _write_jsonl(p, [{"type": "summary", "summary": "x"},        # no uuid -> skipped
+                         _rec("u1", ts="2026-01-01T01:00:00Z")])
+        h = jd.transcript_head(p)
+        self.assertEqual(h["uuid"], "u1")
+        self.assertTrue(h["root"])
+        self.assertGreater(h["t"], 0)
+
+    def test_head_resume_fork_is_not_root(self):
+        p = self.proj / "b.jsonl"
+        _write_jsonl(p, [_rec("u2", parent="u1")])
+        self.assertFalse(jd.transcript_head(p)["root"])
+
+    def test_head_compaction_stitch_is_not_root(self):
+        p = self.proj / "c.jsonl"
+        _write_jsonl(p, [_rec("u3", parent=None, logical="u2", typ="system")])
+        self.assertFalse(jd.transcript_head(p)["root"])
+
+    def test_head_missing_or_empty(self):
+        self.assertIsNone(jd.transcript_head(self.proj / "nope.jsonl"))
+        p = self.proj / "empty.jsonl"
+        p.write_text("")
+        self.assertIsNone(jd.transcript_head(p))
+
+    # ── the boundary tick ────────────────────────────────────────────────────────────────────────
+
+    def test_first_observation_seeds_without_settling(self):
+        self._store()
+        p = self.proj / (SID + ".jsonl")
+        _write_jsonl(p, [_rec("root1")])
+        km._episode_boundary_check(SID, str(p), NOW)
+        rows = jd.episode_rows(SID)
+        self.assertEqual([r["head"] for r in rows], ["root1"])
+        self.assertEqual(self._cleared_rows(), [])                   # deploy never mass-settles existing fleets
+        store = jd.load_goals(SID)
+        self.assertFalse(store["nodes"][self.g("g1")].get("cleared"))
+
+    def test_clear_boundary_settles_open_tops(self):
+        self._store()
+        anchor = self.proj / (SID + ".jsonl")
+        _write_jsonl(anchor, [_rec("root1")])
+        km._episode_boundary_check(SID, str(anchor), NOW)
+        # /clear: the session's path re-points at a NEW null-rooted transcript
+        fork = self.proj / "aaaaaaaa-0000-0000-0000-000000000001.jsonl"
+        _write_jsonl(fork, [_rec("root2", ts="2026-01-02T00:00:00Z")])
+        km._episode_boundary_check(SID, str(fork), NOW)
+
+        rows = jd.episode_rows(SID)
+        self.assertEqual([r["head"] for r in rows], ["root1", "root2"])
+        self.assertEqual(rows[1]["fsid"], "aaaaaaaa-0000-0000-0000-000000000001")
+
+        store = jd.load_goals(SID)
+        g = self.g
+        self.assertTrue(store["nodes"][g("g1")].get("cleared"))      # open working top: settled
+        self.assertTrue(store["nodes"][g("g3")].get("cleared"))      # blocked top: settled too
+        self.assertFalse(store["nodes"][g("g2")].get("cleared"))     # completed top: stays
+        self.assertTrue(store["nodes"][g("g1a")].get("cleared"))     # sub-goal: rollup rolls the clear down
+        #                                                              (a cleared card takes its sub-steps with it)
+        # the verdict log says WHO and WHY -- romp-authored, honest reason
+        ev = [e for e in store["nodes"][g("g1")]["log"] if e.get("kind") == "clear"]
+        self.assertEqual(ev[-1]["src"], "romp")
+        self.assertIn("conversation was cleared", ev[-1]["why"])
+        # cleared.jsonl: one row per settled top, ONE shared batch t (a single Undo restores the batch)
+        rows = self._cleared_rows()
+        self.assertEqual({r["id"] for r in rows}, {g("g1"), g("g3")})
+        self.assertEqual(len({r["t"] for r in rows}), 1)
+
+    def test_resume_fork_is_not_a_boundary(self):
+        self._store()
+        anchor = self.proj / (SID + ".jsonl")
+        _write_jsonl(anchor, [_rec("root1")])
+        km._episode_boundary_check(SID, str(anchor), NOW)
+        fork = self.proj / "aaaaaaaa-0000-0000-0000-000000000002.jsonl"
+        _write_jsonl(fork, [_rec("u5", parent="root1")])              # resume: chains into the prior file
+        km._episode_boundary_check(SID, str(fork), NOW)
+        self.assertEqual(len(jd.episode_rows(SID)), 1)               # recorded episode unchanged
+        self.assertEqual(self._cleared_rows(), [])
+
+    def test_same_head_is_idempotent(self):
+        self._store()
+        p = self.proj / (SID + ".jsonl")
+        _write_jsonl(p, [_rec("root1")])
+        km._episode_boundary_check(SID, str(p), NOW)
+        km._episode_boundary_check(SID, str(p), NOW)
+        self.assertEqual(len(jd.episode_rows(SID)), 1)
+
+    def test_boundary_with_no_open_tops_records_only(self):
+        g = self.g
+        store = {"rompUuid": SID, "seq": 1,
+                 "nodes": {g("g2"): _node(g("g2"), None, nodeComplete=True)},
+                 "status": {g("g2"): "completed"}, "placements": {}}
+        jd.save_goals(SID, store)
+        anchor = self.proj / (SID + ".jsonl")
+        _write_jsonl(anchor, [_rec("root1")])
+        km._episode_boundary_check(SID, str(anchor), NOW)
+        fork = self.proj / "aaaaaaaa-0000-0000-0000-000000000003.jsonl"
+        _write_jsonl(fork, [_rec("root2")])
+        km._episode_boundary_check(SID, str(fork), NOW)
+        self.assertEqual(len(jd.episode_rows(SID)), 2)
+        self.assertEqual(self._cleared_rows(), [])
+
+    # ── _placed_key episode scoping ──────────────────────────────────────────────────────────────
+
+    def test_fuzzy_match_rejects_prior_episode_twin(self):
+        # episode 2 starts at t=2000; a placement recorded in episode 1 (t=1000) must not dedup a
+        # byte-identical prompt retyped in the fresh conversation (t=3000)
+        jd.append_episode(SID, "root1", SID, 1)
+        jd.append_episode(SID, "root2", "fork1", 2000)
+        placements = {"%s:1000:abcd#p" % SID: self.g("g1")}
+        self.assertFalse(jd._placed_key(placements, "%s:3000:abcd#p" % SID, live={"%s:3000:abcd" % SID}))
+
+    def test_fuzzy_match_keeps_same_episode_drift(self):
+        jd.append_episode(SID, "root1", SID, 1)
+        jd.append_episode(SID, "root2", "fork1", 2000)
+        placements = {"%s:2500:abcd#p" % SID: self.g("g1")}           # recorded IN episode 2, t drifted
+        self.assertTrue(jd._placed_key(placements, "%s:2600:abcd#p" % SID, live={"%s:2600:abcd" % SID}))
+
+    def test_exact_match_survives_across_episodes(self):
+        # pre-clear segment ids can only re-enter the parse as-written; the exact hit is the
+        # anti-re-mint guard and must NOT be episode-scoped
+        jd.append_episode(SID, "root2", "fork1", 2000)
+        key = "%s:1000:abcd#p" % SID
+        self.assertTrue(jd._placed_key({key: self.g("g1")}, key))
+
+    def test_no_episode_recorded_keeps_old_behavior(self):
+        placements = {"%s:1000:abcd#p" % SID: self.g("g1")}
+        self.assertTrue(jd._placed_key(placements, "%s:3000:abcd#p" % SID, live={"%s:3000:abcd" % SID}))
+
+    def test_live_twin_guard_still_wins(self):
+        # the recorded key IS another live segment (a twin) -> still no dedup, episode or not
+        jd.append_episode(SID, "root1", SID, 1)
+        placements = {"%s:2500:abcd" % SID: self.g("g1")}
+        self.assertFalse(jd._placed_key(placements, "%s:2600:abcd" % SID,
+                                        live={"%s:2500:abcd" % SID, "%s:2600:abcd" % SID}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2551,6 +2551,24 @@ class TimelinePanel {
         ch.addEventListener('click', () => { this._select(s.id); this.openChat(this._laneTid(s), null, true); });
         svg.appendChild(ch);
       }
+      // A /CLEAR SEAM — an episode boundary: the conversation ended here and a blank one began. Drawn
+      // as a film-splice cut through the lane (two short slanted strokes), quiet by default with the
+      // mechanics on hover — the lane stays CONTINUOUS across it (same session, same slot); only the
+      // conversation restarted. Fed by the kernel's episodes log (row 0 = first observation, not a clear).
+      for (const cl of (s.clears || [])) {
+        if (cl.t < t0 || cl.t > t1) continue;
+        const sx = x(cl.t), sh = BAR_H + 6;
+        for (const dx of [-1.6, 1.6]) {
+          svg.appendChild(el('line', { x1: sx + dx - 2, y1: y + sh / 2, x2: sx + dx + 2, y2: y - sh / 2,
+                                       stroke: '#ffffff', 'stroke-width': 1.2, opacity: 0.55, 'pointer-events': 'none' }));
+        }
+        const hh = el('rect', { x: sx - 6, y: y - 10, width: 12, height: 20, fill: 'transparent' });
+        const html = () => '<div class="r"><span class="chip" style="background:#9cd2ff"></span><span class="who" style="color:' + s.color + '">' + esc(s.name) + '</span><span class="k">cleared</span></div><div class="b">conversation cleared · a fresh one starts here · ' + clock(cl.t) + '</div>';
+        hh.addEventListener('mouseenter', (e) => this.showTip(html(), e));
+        hh.addEventListener('mousemove', (e) => this.moveTip(e));
+        hh.addEventListener('mouseleave', () => this.hideTip());
+        svg.appendChild(hh);
+      }
       // name left-aligned; status chip in the shared chip column to its right. ENDED or idle >1h
       // (s.faded) → name/chip/ctx blended toward the surface bg to a uniform low luminance (perceptual
       // fade via F(), consistent across hues + with the chat tabs), instead of a flat opacity.

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "romp-chat-view",
-  "version": "0.4.331",
+  "version": "0.4.333",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "romp-chat-view",
-      "version": "0.4.331",
+      "version": "0.4.333",
       "dependencies": {
         "@types/ws": "^8.18.1",
         "dompurify": "^3.4.10",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "romp-chat-view",
   "displayName": "romp Chat View",
   "description": "Read-only, nicely-rendered live view of Claude Code (romp) sessions, styled like the official Claude Code panel.",
-  "version": "0.4.332",
+  "version": "0.4.333",
   "publisher": "romp",
   "private": true,
   "engines": {


### PR DESCRIPTION
## What

A `/clear` mints a new null-rooted transcript, but the goal layer never noticed: a session's open cards outlived the only conversation that was their evidence, and four machines carried them into the fresh one — the closer's history-nominated candidates, the unblocker's per-turn re-examines, the auto-nudge (quoting dead goals at an agent that never saw them, then recording a manufactured "nudge failed" block), and the awaiting backstop. A retyped identical prompt was also silently deduped against its dead twin's placement, so it never got a card.

## How

- **Detection is exact and event-based**: a `/clear` fork's head record has no parent link; a resume fork chains into the prior file. `jd.transcript_head` + the new append-only `episodes/<sid>.jsonl` log (which also becomes the only durable map from a session to its past transcripts — `lastSid` is overwritten per fork).
- **Boundary settle**: still-open tops seal like the mute path (`cleared.jsonl` batch + durable flag), recorded as a romp-authored clear with an honest why — "dropped when the conversation was cleared". No clear-wrap notify, no delegation cascade, completed cards stay. First observation seeds without settling, so deploying never mass-clears a fleet. Runs in the producer thread before the snapshot + tiers.
- **Placement scoping**: `_placed_key`'s fuzzy match now requires the recorded key to be from the current episode; exact hits untouched (the anti-re-mint guard).
- **Timeline**: a quiet film-splice seam per boundary; the lane stays continuous (same session, same slot).
- Spec + the deferred read-only episode browser: `plans/clear-episodes.md`; rule 11 in `docs/goal-state.md`.

## Tests

`tests/test_episode_boundary.py` (14): head classification (null root / resume chain / compaction stitch), seed-vs-boundary, settle semantics (open+blocked settle, completed stays, roll-down, shared batch t, romp-authored why), idempotence, and the placement episode scope (prior-episode twin rejected, same-episode drift kept, exact cross-episode kept, no-log fallback, live-twin guard). Full suites green: pytest 3153 passed, node 1330 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)