### PR TITLE
The tunnel reaper learns the peer-bus signature

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4566,9 +4566,13 @@ def _start_remote_kernel(host):
 def _reap_stray_tunnels(host):
     """Kill orphaned ssh tunnel procs for `host` left by a PREVIOUS kernel or a re-attach — a kernel restart
     reparents them to init and they keep holding the -L/-R ports, so a fresh spawn would leak a second tunnel
-    (the user saw two -L ports for one host). Match our EXACT signature (our reverse-bus forward + `-N` + the
-    host as the final arg) so we never touch the user's own ssh to that host. Best-effort."""
+    (the user saw two -L ports for one host) — or worse: the respawn dies instantly on ExitOnForwardFailure
+    against the held ports, burning the whole reconnect budget and stranding the row at 'down' (a federated
+    host, 2026-07-26). Match our EXACT signature so we never touch the user's own ssh to that host: `-N` + the host
+    as the final arg + an ours-only forward — the legacy fixed-port -R to our bus, or (peer-bus mode, which
+    carries no -R) an -L whose target is our bus port. Best-effort."""
     sig_r = "-R %d:127.0.0.1:%d" % (BUS_PORT, BUS_PORT)
+    sig_l = re.compile(r"-L \d+:127\.0\.0\.1:%d\b" % BUS_PORT)
     try:
         out = subprocess.run(["ps", "-axo", "pid=,command="], capture_output=True, text=True, timeout=5).stdout
     except Exception:
@@ -4583,7 +4587,7 @@ def _reap_stray_tunnels(host):
             continue
         if pid == mypid:
             continue
-        if sig_r in cmd and "-N" in cmd and "-L " in cmd and cmd.rstrip().endswith(host):
+        if (sig_r in cmd or sig_l.search(cmd)) and "-N" in cmd and "-L " in cmd and cmd.rstrip().endswith(host):
             try:
                 os.kill(pid, 15)   # SIGTERM the orphaned tunnel
             except Exception:

--- a/tests/test_kernel_tunnels.py
+++ b/tests/test_kernel_tunnels.py
@@ -318,6 +318,32 @@ class ReapStrayTunnels(unittest.TestCase):
             km.subprocess.run, km.os.kill = saved_run, saved_kill
         self.assertEqual(killed, [(12345, 15)], "only the TESTHOST orphan tunnel is SIGTERM'd")
 
+    def test_kills_peer_bus_orphans_with_no_reverse_forward(self):
+        # Peer-bus tunnels (the default) carry NO -R — their ours-only mark is the second -L, which
+        # forwards to OUR postal bus port. An orphan from a dead kernel held the -L ports and every
+        # respawn died on ExitOnForwardFailure, sending the row to 'down' with the budget exhausted
+        # (a federated host, 2026-07-26). The reaper must match this shape too — and still spare the user's
+        # own -N port-forward to the same host.
+        BUS = km.BUS_PORT
+        fake_ps = "\n".join([
+            "  12345 ssh -N -T -o BatchMode=yes -L 63407:127.0.0.1:29855 -L 63408:127.0.0.1:%d -- TESTHOST" % BUS,  # peer-bus orphan → kill
+            "  22222 ssh -N -T -L 63407:127.0.0.1:29855 -L 63408:127.0.0.1:%d -- otherhost" % BUS,   # other host → keep
+            "  33333 ssh -N -L 8080:127.0.0.1:80 TESTHOST",                                          # user's own forward → keep
+            "  %d ssh -N -T -L 1:127.0.0.1:29855 -L 2:127.0.0.1:%d -- TESTHOST" % (os.getpid(), BUS),  # us → keep
+        ])
+
+        class _R:
+            stdout = fake_ps
+        killed = []
+        saved_run, saved_kill = km.subprocess.run, km.os.kill
+        km.subprocess.run = lambda *a, **k: _R()
+        km.os.kill = lambda pid, sig: killed.append((pid, sig))
+        try:
+            km._reap_stray_tunnels("TESTHOST")
+        finally:
+            km.subprocess.run, km.os.kill = saved_run, saved_kill
+        self.assertEqual(killed, [(12345, 15)], "the peer-bus orphan is SIGTERM'd, nothing else")
+
 
 class SshHostSafety(unittest.TestCase):
     """A remote `host` becomes ssh's first positional arg. A host beginning with `-` (e.g.


### PR DESCRIPTION
A kernel restart leaves its ssh tunnels reparented to init, still holding the -L ports. `_reap_stray_tunnels` matched only the legacy fixed-port `-R` forward, which peer-bus tunnels (the default since 2026-07-20) no longer carry. The orphan therefore survived, every respawn died instantly on `ExitOnForwardFailure` against the held ports, the reconnect budget burned to zero, and the tunnel row stranded at "down" even though the orphan tunnel underneath was healthy end to end (hit on a federated host, 2026-07-26).

The reaper now also matches an `-L` whose forward target is our own postal bus port, the ours-only mark a peer-bus tunnel does carry, alongside the legacy `-R` signature. The user's own ssh forwards to the same host remain untouched. New test covers the peer-bus orphan shape plus the keep cases (other host, user's own forward, our own pid).

Both suites green: 3140 pytest + 1330 node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)