### PR TITLE
Held mail: no hold on a token-proven dialer's own mail; card verdicts route + modal edit

### DIFF
--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1573,12 +1573,22 @@ def quarantine_decide(mid, action, text=None):
     return False, "unknown action '%s' (approve|deny)" % action
 
 
-def _relay_in(host, m):
+def _relay_in(host, m, token_proven=False):
     """One incoming relay: deliver locally, FORWARD one hop to a peer that owns the recipient, or
     bounce. Returns (verdict, bounce): 'ack' (delivered/held/deduped), 'hold' (forwarded — the
     END-TO-END ack comes back through us later; the sender keeps it parked meanwhile), 'bounce'
     (definitive refusal), or 'drop' (unidentifiable: no mid to ack or bounce). Per-host trust gates the
-    local-delivery branch: trusted injects, directed holds for approval, isolated silently drops."""
+    local-delivery branch: trusted injects, directed holds for approval, isolated silently drops.
+
+    `token_proven` — True on the DIALED side (peer_exchange_handle): every request past the HTTP gate
+    presented THIS machine's serve token, and token possession already means full control here (the
+    kernel is gated by the same token — a holder can inject into any session directly). So holding the
+    dialer's OWN mail protects nothing and only strands the user's outgoing mail on a machine they
+    attached (the user 2026-07-26, whose delegation to a fresh box sat quarantined on it). The proof
+    covers only the direct dialer: mail it FORWARDED (origin-stamped) is still judged by the origin's
+    tier, and an EXPLICIT tier the user set for the dialer (directed/isolated) still wins — the
+    exemption replaces only the unknown-origin default. The dialer side (peer_exchange_apply) proves
+    nothing: whatever answers the tunnel port never showed our token, so tiers gate it as before."""
     mid = m.get("mid") or ""
     if not mid:
         return "drop", None
@@ -1590,7 +1600,10 @@ def _relay_in(host, m):
         # Trust key = the true ORIGIN (the forwarding host stamps m["origin"]; else the direct peer).
         # Unknown host (a race before the kernel's notify lands) defaults to directed — never auto-inject.
         origin = m.get("origin") or host
-        trust = (PEERS.get(origin) or {}).get("trust") or "directed"
+        prow = PEERS.get(origin)
+        trust = (prow or {}).get("trust") or "directed"
+        if prow is None and token_proven and not m.get("origin"):
+            trust = "trusted"                        # token-proven direct dialer, no explicit tier → deliver (see docstring)
         if trust == "trusted":
             deliver(match[0]["id"], m.get("frm") or "?", m.get("frm_id") or "", m.get("body") or "",
                     kind=m.get("kind") or "")
@@ -1663,7 +1676,7 @@ def peer_exchange_handle(data):
         _bounce_arrived(host, b)
     acks, bounces = [], []
     for m in data.get("relays") or []:
-        verdict, bounce = _relay_in(host, m)
+        verdict, bounce = _relay_in(host, m, token_proven=True)   # past the HTTP gate = showed OUR serve token
         if verdict == "ack":
             acks.append(m.get("mid"))
         elif verdict == "bounce" and bounce:

--- a/tests/test_postal_quarantine.py
+++ b/tests/test_postal_quarantine.py
@@ -102,6 +102,91 @@ class InboundTrustGate(unittest.TestCase):
         self.assertEqual(len(ps.quarantine_list()), 1, "the ORIGIN's directed level must hold it")
 
 
+class TokenProvenDialerGate(InboundTrustGate):
+    """The DIALED side of an exchange (token_proven=True): the dialer showed OUR serve token, which
+    already grants full control of this machine, so holding its own mail protects nothing — the user's
+    outgoing delegation to a machine they attached used to sit quarantined THERE (2026-07-26). The
+    proof exempts only the unknown-origin default: an explicit tier still wins, and forwarded mail is
+    still judged by its origin's tier. Inherits InboundTrustGate so every explicit-tier test above
+    reruns with token_proven=True — trusted/directed/isolated rows must gate identically."""
+
+    def setUp(self):
+        super().setUp()
+        ps._seen_ids = None                          # the inherited tests reuse their mids — reset the
+        try:                                         # dedupe window so the rerun isn't swallowed as dupes
+            ps.PEER_SEEN.unlink()
+        except OSError:
+            pass
+        self._orig_relay_in = ps._relay_in
+        ps._relay_in = lambda host, m, token_proven=False: self._orig_relay_in(host, m, token_proven=True)
+
+    def tearDown(self):
+        ps._relay_in = self._orig_relay_in
+
+    def test_unknown_origin_defaults_to_directed(self):
+        # OVERRIDES the inherited default-hold test: with the dialer token-proven, unknown-origin
+        # DIRECT mail delivers instead of holding — that is the point of this gate.
+        verdict, _ = ps._relay_in("MYSTERY", _relay("q-tok-1", body="from the attacher"))
+        self.assertEqual(verdict, "ack")
+        self.assertEqual(ps.quarantine_list(), [], "a token-proven dialer's own mail is not held")
+        box = ps.read_box("sess-web", consume=False)
+        self.assertTrue(any("from the attacher" in (m.get("body") or "") for m in box),
+                        "it is delivered like trusted mail")
+
+    def test_forwarded_unknown_origin_still_held(self):
+        # The token proof covers the DIALER only: mail it forwarded from an unknown third machine
+        # keeps the safe default — the third machine never proved anything.
+        verdict, _ = ps._relay_in("MYSTERY", _relay("q-tok-2", origin="FARBOX"))
+        self.assertEqual(verdict, "ack")
+        self.assertEqual(len(ps.quarantine_list()), 1, "forwarded mail is judged by its origin's tier")
+        self.assertEqual(ps.read_box("sess-web", consume=False), [])
+
+    def test_explicit_directed_row_still_holds(self):
+        # A tier the user SET for the dialer outranks the token proof — an explicit hold is a choice.
+        self._set_trust("MYSTERY", "directed")
+        verdict, _ = ps._relay_in("MYSTERY", _relay("q-tok-3"))
+        self.assertEqual(verdict, "ack")
+        self.assertEqual(len(ps.quarantine_list()), 1)
+        self.assertEqual(ps.read_box("sess-web", consume=False), [])
+
+
+class ExchangeHandleIsTokenProven(unittest.TestCase):
+    """peer_exchange_handle passes token_proven=True — it only runs for requests past the HTTP serve-token
+    gate — so an attached machine's own relays deliver instead of quarantining on the dialed side."""
+
+    def setUp(self):
+        os.environ["ROMP_SESSIONS_FILE"] = _SESS
+        os.environ["ROMP_POSTAL_PEERS"] = "1"
+        ps.PEERS.clear()
+        ps.PEER_STATE.clear()
+        ps._seen_ids = None
+        for d in (ps.QUARANTINE, ps.MAILROOT / "sess-web" / "new"):
+            try:
+                for f in d.glob("*"):
+                    f.unlink()
+            except OSError:
+                pass
+        try:
+            ps.PEER_SEEN.unlink()
+        except OSError:
+            pass
+
+    def tearDown(self):
+        os.environ.pop("ROMP_POSTAL_PEERS", None)
+
+    def test_handle_delivers_unknown_dialers_direct_relay(self):
+        req = {"host": "MYSTERY", "epoch": 1, "proto": ps.PEER_PROTO, "presence": [], "holds": [],
+               "relays": [{"mid": "q-hx-1", "to": "web", "frm": "api", "frm_id": "id-api",
+                           "body": "checking the deploy", "kind": "coordinate"}],
+               "acks": [], "bounces": [], "wait": False}
+        resp, status = ps.peer_exchange_handle(req)
+        self.assertEqual(status, 200)
+        self.assertIn("q-hx-1", resp["acks"])
+        self.assertEqual(ps.quarantine_list(), [], "the dialed side does not hold the dialer's own mail")
+        box = ps.read_box("sess-web", consume=False)
+        self.assertTrue(any("checking the deploy" in (m.get("body") or "") for m in box))
+
+
 class QuarantineDecide(unittest.TestCase):
     def setUp(self):
         os.environ["ROMP_SESSIONS_FILE"] = _SESS   # pin OUR sessions seam (see InboundTrustGate.setUp)

--- a/ui/webview/feed-quarantine.test.ts
+++ b/ui/webview/feed-quarantine.test.ts
@@ -1,7 +1,11 @@
 // Quarantine card in the feed (per-host trust model): mail from a DIRECTED federated peer is HELD, and
-// surfaces as a needs_input card (blocked.state "quarantine") with a read-only body textarea + Approve /
-// Edit / Deny. Approve/Deny post a quarantineDecision op carrying the (possibly edited) textarea value;
-// Edit just unlocks the textarea. Source-pin (no jsdom for the feed renderer), like the other feed-*.
+// surfaces as a needs_input card (blocked.state "quarantine") whose body shows the message IN FULL
+// (read-only prose — the human is deciding on it), with Approve / Edit / Deny. Approve/Deny post a
+// quarantineDecision op that carries the card's sid, so the federation manager routes the verdict to
+// the kernel that actually HOLDS the file (a remote hold's Approve used to land on the local kernel
+// and silently no-op — the user 2026-07-26). Edit opens a modal editor on document.body, outside the
+// re-rendered feed root, so a kernel push mid-edit can't eat the text. Source-pin (no jsdom for the
+// feed renderer), like the other feed-*.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -9,11 +13,13 @@ import * as path from "node:path";
 
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
-test("the quarantine buttons + body textarea are created and registered", () => {
+test("the quarantine buttons + full-message body are created and registered", () => {
   assert.match(FEED, /const qApprove = el\("button", "fdismiss fq fq-ok"\)[\s\S]*?qApprove\.textContent = "Approve"/);
   assert.match(FEED, /const qEdit = el\("button", "fdismiss fq"\)[\s\S]*?qEdit\.textContent = "Edit"/);
   assert.match(FEED, /const qDeny = el\("button", "fdismiss fq fq-no"\)[\s\S]*?qDeny\.textContent = "Deny"/);
-  assert.match(FEED, /const qbody = el\("textarea", "fask-qbody"\)[\s\S]*?qbody\.readOnly = true/);
+  // the body is a read-only prose div (the whole message), NOT a clipped inline textarea
+  assert.match(FEED, /const qbody = el\("div", "fask-qbody"\)/);
+  assert.doesNotMatch(FEED, /el\("textarea", "fask-qbody"\)/);
   assert.match(FEED, /a\._qApprove = qApprove; a\._qEdit = qEdit; a\._qDeny = qDeny; a\._qBody = qbody;/);
 });
 
@@ -21,16 +27,26 @@ test("the blocked type carries the quarantine fields", () => {
   assert.match(FEED, /mid\?: string; frm\?: string; to\?: string; origin\?: string; body\?: string \};\s*\/\/ quarantine/);
 });
 
-test("Approve/Deny post a quarantineDecision with the textarea value; Edit unlocks the textarea", () => {
+test("the decision carries the card's sid so a remote hold's verdict reaches the holding kernel", () => {
   assert.match(FEED, /const isQuar = it\.blocked\?\.state === "quarantine"/);
   // the block chip is suppressed for a quarantine card — its own buttons carry the decision
   assert.match(FEED, /it\.blocked\.state !== "quarantine"/);
-  // the verdict carries the (possibly edited) textarea value
-  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "quarantineDecision", mid, action, text: qBody\.value \}\)/);
-  // Edit only unlocks the body — it does not deliver
-  assert.match(FEED, /a\._qEdit\.onclick = [\s\S]*?qBody\.readOnly = false; qBody\.focus\(\)/);
-  assert.match(FEED, /a\._qApprove\.onclick = [\s\S]*?decide\("approve", "Delivering…"\)/);
-  assert.match(FEED, /a\._qDeny\.onclick = [\s\S]*?decide\("deny", "Denying…"\)/);
-  // the body is refreshed from the payload only when the user isn't mid-edit (focus guard)
-  assert.match(FEED, /if \(document\.activeElement !== qBody\) qBody\.value = it\.blocked\.body \|\| ""/);
+  // sid rides the op — federation's routeOutbound keys on it (same shape as the askClear fix, 2026-07-02)
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "quarantineDecision", mid, action, text, sid: it\.sid \}\)/);
+  assert.match(FEED, /a\._qApprove\.onclick = [\s\S]*?decide\("approve", "Delivering…", it\.blocked!\.body \|\| ""\)/);
+  assert.match(FEED, /a\._qDeny\.onclick = [\s\S]*?decide\("deny", "Denying…", it\.blocked!\.body \|\| ""\)/);
+});
+
+test("Edit opens the modal editor; the dialog lives outside the feed render root", () => {
+  assert.match(FEED, /a\._qEdit\.onclick = [\s\S]*?showQuarantineEditDialog\(/);
+  // the dialog: overlay on document.body (survives feed re-renders), textarea prefilled with the body,
+  // Approve delivers the edited text, Deny drops, Cancel keeps the message held
+  assert.match(FEED, /function showQuarantineEditDialog\(/);
+  const dlg = FEED.slice(FEED.indexOf("function showQuarantineEditDialog"));
+  assert.match(dlg, /document\.body\.appendChild\(overlay\)/);
+  assert.match(dlg, /el\("textarea", "qdlg-text"\)/);
+  assert.match(dlg, /ta\.value = body/);
+  assert.match(dlg, /decide\("approve", "Delivering…", ta\.value\)/);
+  assert.match(dlg, /decide\("deny", "Denying…", ta\.value\)/);
+  assert.match(dlg, /cancel\.onclick = \(\) => overlay\.remove\(\)/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -654,8 +654,9 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fdismiss.fretry:disabled { opacity: 0.55; cursor: default; }
 
 /* Quarantine (per-host trust): a held message from a directed peer — Approve (accent, the primary
-   action), Edit (neutral), Deny (red, like the Clear/Retry family). The body rides its own read-only
-   textarea above the actions. */
+   action), Edit (neutral, opens the edit dialog), Deny (red, like the Clear/Retry family). The body is
+   a read-only prose block above the actions, shown IN FULL — the human is deciding on this text, so
+   none of it hides behind a scroll (the user 2026-07-26). */
 .fdismiss.fq:disabled { opacity: 0.55; cursor: default; }
 .fdismiss.fq-ok { color: var(--accent); border-color: rgba(156, 210, 255, 0.6); }
 .fdismiss.fq-ok:hover:not(:disabled) { color: var(--accent-fg); background: var(--accent); border-color: var(--accent); }
@@ -663,11 +664,17 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fdismiss.fq-no:hover:not(:disabled) { color: #fff; background: #e5484d; border-color: #e5484d; }
 .fask-qbody {
   display: block; width: 100%; box-sizing: border-box; margin: 6px 0 2px;
-  font: inherit; font-size: 12px; line-height: 1.45; resize: vertical; min-height: 3.2em;
+  font: inherit; font-size: 12px; line-height: 1.45; white-space: pre-wrap; overflow-wrap: anywhere;
   color: #dfe7ee; background: #0c1117; border: 1px solid #35414d; border-radius: 6px; padding: 6px 8px;
 }
-.fask-qbody:read-only { opacity: 0.85; cursor: default; }
-.fask-qbody:not(:read-only) { border-color: var(--accent); opacity: 1; }
+/* The quarantine edit dialog rides the pickdlg overlay/box; the textarea is the editing surface. */
+.qdlg-box { width: min(640px, 96%); }
+.qdlg-text {
+  width: 100%; box-sizing: border-box; font: inherit; font-size: 12px; line-height: 1.45;
+  min-height: 14em; resize: vertical;
+  color: #dfe7ee; background: #0c1117; border: 1px solid var(--accent); border-radius: 6px; padding: 6px 8px;
+}
+.qdlg-actions { display: flex; gap: 8px; justify-content: flex-end; }
 
 /* ↩ answer row — the user's recorded reply to an agent question (an explicit
    child event on the card, kind:"answer"): decision blue, never dimmed — it's

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -712,10 +712,11 @@ function makeAskCard(it: AskItem): HTMLElement {
   const awaitGlyph = el("span", "fask-awaiting-swirl"); awaitGlyph.setAttribute("aria-hidden", "true");
   const awaitWhy = el("span", "fask-awaiting-why");
   awaitSpin.append(awaitGlyph, awaitWhy);
-  // QUARANTINE body: a held message from a DIRECTED peer, shown read-only (peer content, never auto-run).
-  // Edit unlocks it; Approve delivers the textarea's value (edited or not). Only on a quarantine card.
-  const qbody = el("textarea", "fask-qbody") as HTMLTextAreaElement;
-  qbody.readOnly = true; qbody.rows = 3; qbody.style.display = "none";
+  // QUARANTINE body: a held message from a DIRECTED peer, shown IN FULL, read-only (peer content, never
+  // auto-run; the human is deciding on it, so clipping it works against the decision — the user
+  // 2026-07-26). Editing happens in the Edit modal, never inline. Only on a quarantine card.
+  const qbody = el("div", "fask-qbody");
+  qbody.style.display = "none";
   main.append(row1, row2, row3, secs, qbody, awaitSpin, checklist, delegations);   // no expand button — body click opens the modal
   card.append(main);
   // Follow-up lives in the modal now (the user 2026-06-10), not on the card.
@@ -1366,30 +1367,33 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
       a._revive.disabled = true; a._revive.textContent = "Reviving…";
     };
   }
-  // QUARANTINE (per-host trust) → Approve / Edit / Deny a held message from a DIRECTED peer. The body is
-  // read-only (peer content, never auto-run); Edit unlocks it; Approve delivers the textarea's value
-  // (edited or not), Deny drops it. No optimistic clear — the next kernel push removes the card on success,
-  // or re-renders it (buttons re-enabled) if the bus refused (e.g. the recipient is no longer live; the
-  // warn toast says why). Human-in-the-loop is the whole point of directed trust.
+  // QUARANTINE (per-host trust) → Approve / Edit / Deny a held message from a DIRECTED peer. The body
+  // shows in full, read-only (peer content, never auto-run); Edit opens a modal editor (the user
+  // 2026-07-26 — inline unlock was cramped and a re-render could eat the edit); Approve delivers,
+  // Deny drops. The decision CARRIES THE CARD'S sid so the federation manager routes it to the kernel
+  // that actually holds the file — without it a remote hold's verdict landed on the local kernel and
+  // Approve silently did nothing (same shape as the askClear routing fix, 2026-07-02). No optimistic
+  // clear — the next kernel push removes the card on success, or re-renders it (buttons re-enabled)
+  // if the bus refused (e.g. the recipient is no longer live; the warn toast says why).
+  // Human-in-the-loop is the whole point of directed trust.
   const isQuar = it.blocked?.state === "quarantine";
-  const qBody = a._qBody as HTMLTextAreaElement;
+  const qBody = a._qBody as HTMLElement;
   qBody.style.display = isQuar ? "" : "none";
   for (const b of [a._qApprove, a._qEdit, a._qDeny] as HTMLButtonElement[]) b.style.display = isQuar ? "" : "none";
   if (isQuar && it.blocked) {
     const mid = it.blocked.mid || "";
-    if (document.activeElement !== qBody) qBody.value = it.blocked.body || "";   // don't clobber an in-progress edit across a re-render
-    qBody.readOnly = true;
+    qBody.textContent = it.blocked.body || "";
     a._qApprove.disabled = false; a._qApprove.textContent = "Approve";
     a._qEdit.disabled = false; a._qEdit.textContent = "Edit";
     a._qDeny.disabled = false; a._qDeny.textContent = "Deny";
-    const decide = (action: string, busy: string) => {
-      vscodeApi?.postMessage({ type: "quarantineDecision", mid, action, text: qBody.value });
+    const decide = (action: string, busy: string, text: string) => {
+      vscodeApi?.postMessage({ type: "quarantineDecision", mid, action, text, sid: it.sid });
       for (const b of [a._qApprove, a._qEdit, a._qDeny] as HTMLButtonElement[]) b.disabled = true;
       (action === "deny" ? a._qDeny : a._qApprove).textContent = busy;
     };
-    a._qEdit.onclick = (ev: Event) => { ev.stopPropagation(); qBody.readOnly = false; qBody.focus(); a._qEdit.textContent = "Editing"; };
-    a._qApprove.onclick = (ev: Event) => { ev.stopPropagation(); decide("approve", "Delivering…"); };
-    a._qDeny.onclick = (ev: Event) => { ev.stopPropagation(); decide("deny", "Denying…"); };
+    a._qEdit.onclick = (ev: Event) => { ev.stopPropagation(); showQuarantineEditDialog(it.blocked!.frm || "?", it.blocked!.to || "?", it.blocked!.body || "", decide); };
+    a._qApprove.onclick = (ev: Event) => { ev.stopPropagation(); decide("approve", "Delivering…", it.blocked!.body || ""); };
+    a._qDeny.onclick = (ev: Event) => { ev.stopPropagation(); decide("deny", "Denying…", it.blocked!.body || ""); };
   }
   (a._clr as HTMLElement).style.display = isQuar ? "none" : "";
 
@@ -3121,6 +3125,36 @@ window.addEventListener("message", (e: MessageEvent) => {
     }
   }
 });
+
+// ---- quarantine edit dialog: edit a held message's text, then Approve (deliver the edit) or Deny ----
+// Lives on document.body OUTSIDE the re-rendered feed root, so a kernel push mid-edit can't eat the
+// text (the inline-unlock textarea it replaces was clobbered exactly that way; the user 2026-07-26).
+// `decide` is the owning card's decision closure — it carries the mid + sid and flips the card buttons.
+function showQuarantineEditDialog(frm: string, to: string, body: string,
+                                  decide: (action: string, busy: string, text: string) => void) {
+  document.getElementById("quar-edit-dialog")?.remove();
+  const overlay = el("div", "pickdlg-overlay"); overlay.id = "quar-edit-dialog";
+  const box = el("div", "pickdlg-box qdlg-box");
+  const title = el("div", "pickdlg-title");
+  title.textContent = `Held message from ${frm} to ${to} — edit, then approve to deliver your version`;
+  const ta = el("textarea", "qdlg-text") as HTMLTextAreaElement;
+  ta.value = body;
+  const row = el("div", "qdlg-actions");
+  const ok = el("button", "fdismiss fq fq-ok") as HTMLButtonElement; ok.textContent = "Approve";
+  ok.title = "deliver the text above to the recipient session";
+  ok.onclick = () => { decide("approve", "Delivering…", ta.value); overlay.remove(); };
+  const no = el("button", "fdismiss fq fq-no") as HTMLButtonElement; no.textContent = "Deny";
+  no.title = "drop this message — nothing is delivered";
+  no.onclick = () => { decide("deny", "Denying…", ta.value); overlay.remove(); };
+  const cancel = el("button", "fdismiss fq") as HTMLButtonElement; cancel.textContent = "Cancel";
+  cancel.title = "close without deciding — the message stays held";
+  cancel.onclick = () => overlay.remove();
+  row.append(ok, no, cancel);
+  box.append(title, ta, row);
+  overlay.onclick = (e) => { if (e.target === overlay) overlay.remove(); };
+  document.body.appendChild(overlay);
+  ta.focus();
+}
 
 // ---- in-page resume-picker dialog (the answerPicker flow, no native QuickPick) ----
 function showPickerDialog(name: string, options: string[]) {


### PR DESCRIPTION
Fixes the three problems from the first real federated held-mail encounter (2026-07-26):

1. **Outgoing mail no longer quarantines on a machine you attached.** The dialed bus's `/peer-exchange` only runs for requests that presented its own serve token, and token possession already grants full control of that machine (the kernel is gated by the same token). Holding the direct dialer's own mail added no security — it just stranded the user's outgoing delegation on the far box. `_relay_in` gains `token_proven`: a direct relay from an origin with no explicit tier delivers; explicit directed/isolated tiers still win; forwarded relays still judged by true origin; the dialer side unchanged (a peer answering the tunnel port proved nothing).

2. **Approve/Deny now reach the kernel that holds the file.** `quarantineDecision` carries the card's sid so federation routing sends it to the owning kernel; previously a remote hold's verdict landed on the local kernel and silently no-op'd ("Delivering…" then revert).

3. **Card shows the whole message; Edit opens a modal editor** on `document.body` (survives feed re-renders), replacing the clipped inline textarea unlock.

Tests: new `TokenProvenDialerGate` + `ExchangeHandleIsTokenProven` classes (the explicit-tier suite reruns under token_proven to prove tiers still gate), reworked `feed-quarantine.test.ts`. Both suites green: 3164 pytest + 1331 node, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)