### PR TITLE
The delegation chip names the sender host:name, never a bare sid

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -7970,6 +7970,38 @@ def courier_llm(message_text, menu_text, declared=""):
     return _judge_run(_triage_model(), COURIER_SYS, user, judge="courier").strip()[:300]
 
 
+_postal_from_memo = {"key": None, "map": {}}   # messages.jsonl (mtime,size) -> {mid: (from, from_host)}
+
+
+def _postal_from(mid):
+    """(from_name, from_host) for a delivered postal message id, from the messages log's "sent" row —
+    the AUTHORITATIVE record of who sent it. The sender may be a session of ANOTHER kernel (federated
+    mail), so the local names registry cannot resolve it; the log row carries the name the sender
+    wore and, since 2026-07-26, the origin host the postal bus stamped on cross-host delivery.
+    ("", "") for None/unknown mids. Memoized on the log file's (mtime, size)."""
+    if not mid:
+        return ("", "")
+    try:
+        st = os.stat(MESSAGES)
+        key = (st.st_mtime, st.st_size)
+    except OSError:
+        return ("", "")
+    if _postal_from_memo["key"] != key:
+        mp = {}
+        try:
+            for line in MESSAGES.read_text(errors="replace").splitlines():
+                try:
+                    r = json.loads(line)
+                except Exception:
+                    continue
+                if r.get("ev") == "sent" and r.get("id"):
+                    mp[r["id"]] = (r.get("from") or "", r.get("from_host") or "")
+        except OSError:
+            return ("", "")
+        _postal_from_memo["key"], _postal_from_memo["map"] = key, mp
+    return _postal_from_memo["map"].get(mid, ("", ""))
+
+
 def apply_courier(store, seg_id, seg_t, text, origin, prompt_uuid=None):
     """Plant a top-level goal in the recipient's tree for a delegating message, with origin
     provenance. Idempotent by seg_id and origin.msgId (one planted goal per message). Returns nid.
@@ -8134,8 +8166,17 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             track_id = _plant_handoff_track(sender_store, link_id, edit["text"], fsid, id2name.get(fsid), seg_t, mid)
             rollup_status(sender_store, False)
             save_goals(sender, sender_store)
-            apply_courier(store, seg_id, seg_t, edit["text"],
-                          {"peer": sender, "goalId": track_id, "msgId": mid}, prompt_uuid=anchor_uuid)
+            # Origin provenance snapshots the sender's NAME (and, for federated mail, HOST) at plant
+            # time: a cross-host sender's sid resolves to nothing in this kernel's names registry, and
+            # without the snapshot the "from" chip degrades to a bare sid prefix (the user 2026-07-26).
+            origin = {"peer": sender, "goalId": track_id, "msgId": mid}
+            frm_name, frm_host = _postal_from(mid)
+            pn = id2name.get(sender) or frm_name       # live local name first; else the log's snapshot
+            if pn:
+                origin["peerName"] = pn
+            if frm_host:                               # stamped only on cross-host delivery
+                origin["peerHost"] = frm_host
+            apply_courier(store, seg_id, seg_t, edit["text"], origin, prompt_uuid=anchor_uuid)
         else:
             store["placements"][seg_id] = "fyi"        # coordinating: no goal, but mark processed
         rollup_status(store, closed.get(fsid, False))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10746,7 +10746,15 @@ def build_feed(now, tmux=None):
                 psid, gid = o["peer"], o.get("goalId")
                 sgoal = jd.load_goals(psid).get("nodes", {}).get(gid) if gid else None
                 if sgoal and not sgoal.get("nodeComplete") and not sgoal.get("cleared") and gid not in cleared:
-                    origin = {"peer": _name_of(psid) or psid[:8], "peerSid": psid, "color": _name_color(psid)}
+                    # Name resolution: the live names registry first (a local sender may have been
+                    # renamed), then the courier's plant-time snapshot (the only source for a
+                    # FEDERATED sender, whose sid this kernel can't resolve), then the sid stub.
+                    # peerHost renders as the same quiet "host:" prefix remote sessions wear on the
+                    # timeline (host-prefix.ts) — a local resolve means a local sender, no host.
+                    pname = _name_of(psid)
+                    origin = {"peer": pname or o.get("peerName") or psid[:8],
+                              "peerHost": ("" if pname else o.get("peerHost") or ""),
+                              "peerSid": psid, "color": _name_color(psid)}
             await_why = (sess_awaiting_why or _stamp_why or _deleg_why or _owned_why) if col == "awaiting" else None   # the ⏳ awaiting badge's "why": live snapshot, then the judge's durable stamp, then the delegation graph, then the blocked-yield's owned dispatch (None for the postal-only case → the waitingOn chip names the peer)
             # The card's TIME reflects its CURRENT STATE, not when the goal was minted: a COMPLETED card
             # shows when it was completed, a BLOCKED card when it was blocked — the mt of the most-recent

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -216,12 +216,16 @@ def _tl_append(fname, obj):
     except Exception:
         pass
 
-def deliver(to_id, from_name, from_id, body, park=False, kind=""):
+def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host=""):
     # park=True marks a HANDOFF parked for a session that's currently dead. The
     # maildir is keyed by the session UUID (which `romp resume` reuses), so the
     # message simply waits on disk until that session is revived — delivered then,
     # ignored forever if it never returns. Parked mail is also exempt from the
     # orphan sweep (see _sweep_orphans), so it persists indefinitely.
+    # from_host: the sender's ORIGIN host for cross-host (federated) mail, "" for local. A foreign
+    # from_id resolves to nothing in the recipient kernel's names registry, so this is the only
+    # durable record of where the sender lives — the courier snapshots it into a planted goal's
+    # origin so the "from" chip can say host:name instead of a bare sid prefix (the user 2026-07-26).
     mb = _mailbox(to_id)
     name = _unique()
     tmp = mb / "tmp" / name
@@ -230,6 +234,8 @@ def deliver(to_id, from_name, from_id, body, park=False, kind=""):
         hdr += "X-Park: 1\n"
     if kind:
         hdr += "X-Kind: %s\n" % kind                # sender-declared delegate|coordinate|question (2026-07-08)
+    if from_host:
+        hdr += "X-From-Host: %s\n" % from_host
     tmp.write_text(hdr + "\n" + body + "\n")
     tmp.rename(mb / "new" / name)   # atomic within the same filesystem
     _mark_pending(to_id)            # new/ is now non-empty -> raise the marker (covers park + live)
@@ -241,6 +247,8 @@ def deliver(to_id, from_name, from_id, body, park=False, kind=""):
         ev["park"] = True
     if kind:
         ev["kind"] = kind                            # additive (consumer contract above)
+    if from_host:
+        ev["from_host"] = from_host                  # additive (consumer contract above)
     _tl_append("messages.jsonl", ev)
     return name   # the message id (maildir filename); joins to the log + status-bar prefix
 
@@ -267,7 +275,8 @@ def read_box(sid, consume):
             meta[k.lower()] = v
         out.append({"from": meta.get("from", "?"), "from_id": meta.get("from-id", ""),
                     "date": meta.get("date", ""), "body": body.rstrip("\n"), "id": f.name,
-                    "park": bool(meta.get("x-park")), "kind": meta.get("x-kind", "")})
+                    "park": bool(meta.get("x-park")), "kind": meta.get("x-kind", ""),
+                    "from_host": meta.get("x-from-host", "")})
         if consume:
             f.rename(mb / "cur" / f.name)
             _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "exec", "id": f.name})
@@ -837,7 +846,8 @@ def _push(sid, agent):
         for m in msgs:
             if not restore(sid, m.get("id", "")):
                 deliver(sid, m.get("from", "?"), m.get("from_id", ""), m.get("body", ""),
-                        park=m.get("park", False), kind=m.get("kind", ""))
+                        park=m.get("park", False), kind=m.get("kind", ""),
+                        from_host=m.get("from_host", ""))
         _log("push to %s deferred; %d msg(s) restored for the drain backstop" % (sid, len(msgs)))
         return False
     except Exception as e:
@@ -1567,7 +1577,8 @@ def quarantine_decide(mid, action, text=None):
             if not match:
                 return False, "recipient '%s' is no longer a live local session" % (rec.get("to") or "?")
             to_id = match[0]["id"]
-        deliver(to_id, rec.get("frm") or "?", rec.get("frmId") or "", body, kind=rec.get("kind") or "")
+        deliver(to_id, rec.get("frm") or "?", rec.get("frmId") or "", body, kind=rec.get("kind") or "",
+                from_host=rec.get("origin") or "")
         quarantine_del(mid)
         return True, None
     return False, "unknown action '%s' (approve|deny)" % action
@@ -1606,7 +1617,7 @@ def _relay_in(host, m, token_proven=False):
             trust = "trusted"                        # token-proven direct dialer, no explicit tier → deliver (see docstring)
         if trust == "trusted":
             deliver(match[0]["id"], m.get("frm") or "?", m.get("frm_id") or "", m.get("body") or "",
-                    kind=m.get("kind") or "")
+                    kind=m.get("kind") or "", from_host=origin)
         elif trust == "directed":
             _quarantine_put(origin, m, match[0]["id"])   # HELD for human approve/deny/edit; never injects
         # else isolated → drop: ack so the sender stops resending, but deliver nothing (no communication).

--- a/tests/test_courier_origin_host.py
+++ b/tests/test_courier_origin_host.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Courier origin provenance snapshots the sender's name + host at plant time (the user 2026-07-26).
+
+A goal planted from a FEDERATED peer's message carries origin.peer = the sender's sid — which the
+recipient kernel's names registry can never resolve (the sender lives on another host), so the feed's
+"↪ from" chip degraded to a bare sid prefix. The postal bus now stamps the origin host on cross-host
+delivery (messages.jsonl `from_host`), and run_courier snapshots {peerName, peerHost} into the planted
+goal's origin: the live local name when the sender is a session of THIS kernel (no host), else the
+message log's name + host.
+
+Synthetic fixtures only (placeholder UUIDs, invented text, hostname TESTHOST)."""
+import json
+import os
+import re
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+jd = SourceFileLoader("romp_judge_courierorigin", os.path.join(BIN, "romp-judge")).load_module()
+
+RECIP = "11111111-2222-3333-4444-555555555555"
+SENDER = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+MID = "1781100000.11111_22222.TESTHOST"
+T0 = 1781100000
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": text}, "promptSource": "typed"}
+
+
+def aline(t, text, uuid, parent):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+class CourierOriginHost(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        munged = re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        (proj / munged).mkdir(parents=True)
+        self.proj_dir = proj / munged
+        recip_recs = [uline(T0, "DELEGATE: wire up the export button\nromp-msg-id: %s" % MID, "u1"),
+                      aline(T0 + 30, "On it.", "a1", "u1")]
+        (self.proj_dir / (RECIP + ".jsonl")).write_text(
+            "\n".join(json.dumps(r) for r in recip_recs) + "\n")
+        names = td / "names"; names.mkdir()
+        (names / RECIP).write_text("recip\t%s\t#abcdef\n" % str(cdir))
+        self.names, self.cdir, self.tl = names, cdir, td / "timeline"
+        self.tl.mkdir()
+
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+                      jd.MESSAGES, jd.ERRORS, jd.courier_llm)
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.GOALDIR = td / "goals"
+        jd.CAPDIR, jd.ARCHDIR, jd.PCACHE = td / "captions", td / "archive", td / "pcache"
+        jd.MESSAGES = self.tl / "messages.jsonl"
+        jd.ERRORS = td / "judge-errors.jsonl"
+        jd.courier_llm = lambda *a, **k: '{"verdict": "delegating", "goal": 0, "text": "wire up the export button"}'
+        jd._PARSE_CACHE.clear()
+        jd._discover_cache["fp"] = None
+        jd._discover_cache["result"] = None
+        jd._postal_from_memo["key"] = None
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+         jd.MESSAGES, jd.ERRORS, jd.courier_llm) = self.saved
+        jd._postal_from_memo["key"] = None
+        self.td.cleanup()
+
+    def _planted_origin(self):
+        jd.run_courier(now=T0 + 100)
+        store = jd.load_goals(RECIP)
+        planted = [nd for nd in store["nodes"].values() if isinstance(nd.get("origin"), dict)]
+        self.assertEqual(len(planted), 1, "the delegating message plants exactly one goal")
+        return planted[0]["origin"]
+
+    def test_federated_sender_origin_carries_log_name_and_host(self):
+        """A cross-host sender has no local names entry and no local transcript; the origin snapshots
+        the message log's `from` + `from_host` so the chip can say host:name, never a sid stub."""
+        jd.MESSAGES.write_text(json.dumps(
+            {"t": T0 - 5, "ev": "sent", "id": MID, "from": "api", "from_id": SENDER,
+             "to_id": RECIP, "from_host": "TESTHOST2", "body": "DELEGATE: wire up the export button"}) + "\n")
+        origin = self._planted_origin()
+        self.assertEqual(origin["peer"], SENDER)
+        self.assertEqual(origin["peerName"], "api")
+        self.assertEqual(origin["peerHost"], "TESTHOST2")
+
+    def test_local_sender_prefers_live_name_and_carries_no_host(self):
+        """A sender that is a session of THIS kernel resolves through discover's id2name (the live
+        registry name, which tracks renames) and gets NO peerHost — local mail is never host-stamped."""
+        (self.proj_dir / (SENDER + ".jsonl")).write_text(
+            json.dumps(uline(T0 - 10, "start the export work", "s1")) + "\n")
+        (self.names / SENDER).write_text("sender\t%s\t#fedcba\n" % str(self.cdir))
+        jd.MESSAGES.write_text(json.dumps(
+            {"t": T0 - 5, "ev": "sent", "id": MID, "from": "sender", "from_id": SENDER,
+             "to_id": RECIP, "body": "DELEGATE: wire up the export button"}) + "\n")
+        jd._discover_cache["fp"] = None
+        origin = self._planted_origin()
+        self.assertEqual(origin["peerName"], "sender")
+        self.assertNotIn("peerHost", origin)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4679,7 +4679,7 @@ class ViewBuilder(unittest.TestCase):
                           "origin": {"peer": sender, "goalId": sender + ":g1", "msgId": "m-abc.123"}}},
             "placements": {}, "status": {g: "working"}}))
         card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
-        self.assertEqual(card["origin"], {"peer": "sendersess", "peerSid": sender,
+        self.assertEqual(card["origin"], {"peer": "sendersess", "peerHost": "", "peerSid": sender,
                                           "color": {"bg": "#ff8800", "fg": "#ffffff"}},
                          "origin.peer (a sid) resolves to the sender's name + color")
 
@@ -4697,6 +4697,42 @@ class ViewBuilder(unittest.TestCase):
         card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
         self.assertEqual(card["origin"]["peer"], sender[:8])
         self.assertIsNone(card["origin"]["color"])
+
+    def test_feed_handoff_origin_uses_couriers_name_host_snapshot_for_federated_sender(self):
+        """A FEDERATED sender's sid resolves to nothing locally; the courier's plant-time snapshot
+        (peerName + peerHost) carries the chip instead — host:name, never a bare sid stub (the user
+        2026-07-26, after a delegation chip read as an 8-char sid prefix)."""
+        sender = "abcdef00-1111-0000-0000-000000000000"
+        self._sender_goal(sender, sender + ":g1")                 # OPEN linked goal → badge shows
+        g = "%s:g21" % SID
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 21, "lastNode": g,
+            "nodes": {g: {"id": g, "text": "Handoff from a federated peer", "parentId": None,
+                          "nodeComplete": False, "blocked": False, "cleared": False, "trail": [], "t": NOW - 50,
+                          "origin": {"peer": sender, "goalId": sender + ":g1", "msgId": "m-x.2",
+                                     "peerName": "api", "peerHost": "TESTHOST2"}}},
+            "placements": {}, "status": {g: "working"}}))
+        card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
+        self.assertEqual(card["origin"]["peer"], "api")
+        self.assertEqual(card["origin"]["peerHost"], "TESTHOST2")
+
+    def test_feed_handoff_origin_live_local_name_beats_stale_snapshot(self):
+        """A LOCAL sender resolves through the live names registry (which tracks renames), and a local
+        resolve means no host qualifier — even if the origin carries an old peerName/peerHost snapshot."""
+        sender = "abcdef00-2222-0000-0000-000000000000"
+        (jd.NAMES / sender).write_text("renamedsess\t/elsewhere\t#ff8800\n")
+        self._sender_goal(sender, sender + ":g1")
+        g = "%s:g22" % SID
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 22, "lastNode": g,
+            "nodes": {g: {"id": g, "text": "Handoff with a stale snapshot", "parentId": None,
+                          "nodeComplete": False, "blocked": False, "cleared": False, "trail": [], "t": NOW - 50,
+                          "origin": {"peer": sender, "goalId": sender + ":g1", "msgId": "m-x.3",
+                                     "peerName": "oldname", "peerHost": "elsewhere"}}},
+            "placements": {}, "status": {g: "working"}}))
+        card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
+        self.assertEqual(card["origin"]["peer"], "renamedsess")
+        self.assertEqual(card["origin"]["peerHost"], "")
 
     def test_feed_handoff_origin_hidden_when_fully_absorbed(self):
         """Once the sender's linked goal is done/cleared/gone (or there was no link), the handoff is fully

--- a/tests/test_postal_quarantine.py
+++ b/tests/test_postal_quarantine.py
@@ -186,6 +186,28 @@ class ExchangeHandleIsTokenProven(unittest.TestCase):
         box = ps.read_box("sess-web", consume=False)
         self.assertTrue(any("checking the deploy" in (m.get("body") or "") for m in box))
 
+    def test_handle_stamps_senders_origin_host_on_delivered_mail(self):
+        """Cross-host delivery stamps from_host = the sender's ORIGIN host (the forwarder's stamp when
+        the mail hopped, else the dialing peer) — the only durable record of where a federated sender
+        lives; the courier snapshots it into a planted goal's origin (the user 2026-07-26). It rides
+        the maildir header AND the messages.jsonl "sent" row."""
+        req = {"host": "MYSTERY", "epoch": 1, "proto": ps.PEER_PROTO, "presence": [], "holds": [],
+               "relays": [{"mid": "q-hx-2", "to": "web", "frm": "signal", "frm_id": "id-signal",
+                           "body": "apply the fix", "kind": "delegate"},
+                          {"mid": "q-hx-3", "to": "web", "frm": "api", "frm_id": "id-api",
+                           "body": "forwarded along", "kind": "coordinate", "origin": "FARHOST"}],
+               "acks": [], "bounces": [], "wait": False}
+        ps.peer_update({"host": "FARHOST", "port": 47102, "up": True, "trust": "trusted"})
+        resp, status = ps.peer_exchange_handle(req)
+        self.assertEqual(status, 200)
+        box = {m["body"]: m for m in ps.read_box("sess-web", consume=False)}
+        self.assertEqual(box["apply the fix"]["from_host"], "MYSTERY", "direct relay → the dialer's host")
+        self.assertEqual(box["forwarded along"]["from_host"], "FARHOST", "hopped mail → the TRUE origin")
+        rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
+        sent = {r["from"]: r for r in rows if r.get("ev") == "sent" and r.get("from_host")}
+        self.assertEqual(sent["signal"]["from_host"], "MYSTERY")
+        self.assertEqual(sent["api"]["from_host"], "FARHOST")
+
 
 class QuarantineDecide(unittest.TestCase):
     def setUp(self):
@@ -207,6 +229,9 @@ class QuarantineDecide(unittest.TestCase):
         box = ps.read_box("sess-web", consume=False)
         self.assertTrue(any("original text" in (m.get("body") or "") for m in box),
                         "approve delivers the held message")
+        approved = next(m for m in box if "original text" in (m.get("body") or ""))
+        self.assertEqual(approved["from_host"], "TESTHOST",
+                         "approve replays the trusted deliver, origin-host stamp included")
 
     def test_approve_with_edited_text(self):
         ps._relay_in("TESTHOST", _relay("q-appr-2", body="raw peer text"))

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -74,6 +74,12 @@ function _prefixIdBearing(host: string, o: any, idKey: string): any {
   if (!o || typeof o !== "object" || typeof o[idKey] !== "string") return o;
   const out: any = { ...o, [idKey]: prefixId(host, o[idKey]) };
   if (typeof out.name === "string") out.name = prefixId(host, out.name);
+  // A feed card's delegation origin (asks[].origin): peerHost empty means the SENDER is local to the
+  // card's own kernel — attribute it to that host, and prefix peerSid so the click routes there. A
+  // set peerHost means the sender lives on some OTHER host (that kernel recorded which); keep it,
+  // and keep peerSid bare — the viewer may be that very host, where the bare uuid opens directly.
+  if (out.origin && typeof out.origin === "object" && typeof out.origin.peerSid === "string" && !out.origin.peerHost)
+    out.origin = { ...out.origin, peerHost: host, peerSid: prefixId(host, out.origin.peerSid) };
   return out;
 }
 

--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -62,7 +62,9 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
   // populated from it.origin in the update path: a dim gray "↪ from" + the peer in the bold session-name
   // style (its own identity colour); click opens the sender (the user 2026-06-16)
   assert.match(FEED, /pre\.textContent = "↪ from "/);
-  assert.match(FEED, /peer\.textContent = it\.origin\.peer/);
+  // the peer renders through hostPartsNodes so a FEDERATED sender wears the quiet "host:" prefix,
+  // same treatment as remote session names everywhere else (the user 2026-07-26)
+  assert.match(FEED, /peer\.replaceChildren\(\.\.\.hostPartsNodes\(it\.origin\.peerHost, it\.origin\.peer\)\)/);
   assert.match(FEED, /if \(it\.origin\.color\) peer\.style\.color = it\.origin\.color\.bg/);
   assert.match(FEED, /type: "openSession", id: it\.origin!\.peerSid/, "clicking the marker opens the sender");
   assert.match(CSS, /\.fask-origin-pre \{[^}]*var\(--dim\)/);     // "↪ from" dim gray

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -9,7 +9,7 @@
 import { distillText, distillInputs, applyDistillLine, distillPending } from "./distiller-line";
 import { spinFor } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
-import { hostNameNodes } from "./host-prefix";
+import { hostNameNodes, hostPartsNodes } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
 import { initStrip } from "./strip";
 import { installSettingsSync } from "./settings";
@@ -88,7 +88,7 @@ interface AskItem {
   warns?: { kind: string; t: number; msg: string; detail: string }[] | null;   // judge-stamped anomalies (judge _node_warn → kernel build_feed): yellow "warning" chip; click opens the detail modal (the user 2026-07-02)
   nudged?: { count: number; times: number[] } | null;   // auto-nudge HISTORY (kernel _nudge_times): how many times romp followed up + when — the stalled chip's evidence (tooltip + modal line, the user 2026-07-02)
   warnRows?: { t: number; judge: string; err: string; note?: string; debug?: { input?: string; reply?: string } }[] | null;   // DEBUG MODE only (romp debug on): every judge failure touching this card (kernel _card_warn_rows) → "Warnings (debug)" modal section; rows captured in debug carry the failing call's input + reply (the user 2026-07-09)
-  origin?: { peer: string; peerSid: string; color: { bg: string; fg: string } | null } | null;  // courier handoff: planted by a peer's message → "↪ from <peer>"
+  origin?: { peer: string; peerSid: string; peerHost?: string; color: { bg: string; fg: string } | null } | null;  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders)
   waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean; kind?: string } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip, or "Handed off to <peer>" when kind is "delegate" (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22 / 2026-07-25)
   awaiting?: { why?: string | null; tasks?: string[] | null } | null;   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Waiting on task" pill (expands the list, like Sub-goals) replaces the boxed why.
   groupTitle?: string;                             // host: this ask shares a typed turn with siblings → the group's title
@@ -1134,7 +1134,10 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     og.replaceChildren();
     og.style.color = "";
     const pre = el("span", "fask-origin-pre"); pre.textContent = "↪ from ";
-    const peer = el("span", "fask-origin-peer"); peer.textContent = it.origin.peer;
+    // A federated sender wears the same quiet "host:" prefix as remote session names on the
+    // timeline/tabs (.host-prefix keeps its own dim color under the peer's identity color).
+    const peer = el("span", "fask-origin-peer");
+    peer.replaceChildren(...hostPartsNodes(it.origin.peerHost, it.origin.peer));
     if (it.origin.color) peer.style.color = it.origin.color.bg;
     og.append(pre, peer);
     og.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: it.origin!.peerSid }); };

--- a/ui/webview/host-prefix.test.ts
+++ b/ui/webview/host-prefix.test.ts
@@ -36,6 +36,11 @@ test("every surface renders the prefix through the shared treatment", () => {
   assert.match(FEED, /a\._name\.replaceChildren\(\.\.\.hostNameNodes\(g\.name, g\.sid\)\)/);
   assert.match(FEED, /agent\.replaceChildren\(\.\.\.hostNameNodes\(grp\.name, grp\.sid\)\)/);
   assert.match(FEED, /agent\.replaceChildren\(\.\.\.hostNameNodes\(it\.name, it\.sid\)\)/);
+  // the feed card's "↪ from" chip: the host rides origin.peerHost (its own field — peerSid stays a
+  // bare uuid), rendered through the same .host-prefix treatment (the user 2026-07-26)
+  assert.match(FEED, /peer\.replaceChildren\(\.\.\.hostPartsNodes\(it\.origin\.peerHost, it\.origin\.peer\)\)/);
+  const HP = read("host-prefix.ts");
+  assert.match(HP, /export function hostPartsNodes\(host: string \| null \| undefined, name: string\): Node\[\]/);
   // fleet: the prefix stays OUT of the search highlight (metadata never highlights)
   assert.match(FLEET, /function nameInto\(elm: HTMLElement, name: string, sid: string, q: string\)/);
   assert.match(FLEET, /nameInto\(tnm, s\.name, s\.sid, curSearch\)/);

--- a/ui/webview/host-prefix.ts
+++ b/ui/webview/host-prefix.ts
@@ -23,3 +23,14 @@ export function hostNameNodes(name: string, sid: string | null | undefined): Nod
   h.textContent = p.host;
   return [h, document.createTextNode(p.rest)];
 }
+
+/** Same rendering when the host rides its OWN field instead of a sid prefix — the feed card's
+ *  "↪ from" chip, whose peerSid stays a bare uuid (the sender may live on a third host neither
+ *  the viewer nor the card's kernel can address). No host → plain text, identical to a local name. */
+export function hostPartsNodes(host: string | null | undefined, name: string): Node[] {
+  if (!host) return [document.createTextNode(name)];
+  const h = document.createElement("span");
+  h.className = "host-prefix";
+  h.textContent = host + ":";
+  return [h, document.createTextNode(name)];
+}

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -42,6 +42,18 @@ test("prefixInbound: tabOrder order[] and tabs[].id (+ display name)", () => {
   assert.equal(out.tabs[0].name, "gpu1:a", "the tab's display name is host-prefixed too (host:name)");
 });
 
+test("prefixInbound: asks[].origin attributes the delegating sender's host (the user 2026-07-26)", () => {
+  // peerHost empty (or absent, an older kernel) → the sender is local to the card's own kernel:
+  // attribute that host and prefix peerSid so the "↪ from" click routes there.
+  const out = prefixInbound("gpu1", { type: "feed",
+    asks: [{ sid: U, name: "web", origin: { peer: "api", peerSid: V, peerHost: "" } },
+           { sid: U, name: "web", origin: { peer: "signal", peerSid: V, peerHost: "farhost" } }] });
+  assert.deepEqual(out.asks[0].origin, { peer: "api", peerSid: "gpu1:" + V, peerHost: "gpu1" });
+  // a recorded peerHost means the sender lives on some THIRD host that kernel named: keep it, and keep
+  // peerSid bare — the viewer may be that very host, where the bare uuid opens directly.
+  assert.deepEqual(out.asks[1].origin, { peer: "signal", peerSid: V, peerHost: "farhost" });
+});
+
 test("prefixInbound: display name is host-prefixed on session-bearing messages", () => {
   // a session's tab + chat header should read "gpu1:foo" so a remote session never collides visually with a
   // local same-named one. Only prefixed when a co-present id/sid marks it as a session name.

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "romp-chat-view",
-  "version": "0.4.333",
+  "version": "0.4.334",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "romp-chat-view",
-      "version": "0.4.333",
+      "version": "0.4.334",
       "dependencies": {
         "@types/ws": "^8.18.1",
         "dompurify": "^3.4.10",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "romp-chat-view",
   "displayName": "romp Chat View",
   "description": "Read-only, nicely-rendered live view of Claude Code (romp) sessions, styled like the official Claude Code panel.",
-  "version": "0.4.333",
+  "version": "0.4.334",
   "publisher": "romp",
   "private": true,
   "engines": {


### PR DESCRIPTION
## What

A feed card delegated from a federated peer showed an "↪ from" chip with a raw sid prefix, because the sender lives on another machine and the recipient kernel's names registry can never resolve it. The chip now reads `host:name` with the same quiet host-prefix treatment remote sessions wear on the timeline and tabs.

## How

- **Postal bus**: cross-host delivery stamps the sender's origin host (`X-From-Host` maildir header + `from_host` on the `messages.jsonl` "sent" row). The forwarder's origin stamp wins over the direct dialer for hopped mail; quarantine approve replays it.
- **Courier**: snapshots `{peerName, peerHost}` into the planted goal's origin at plant time, from the message log (the only durable source for a federated sender).
- **build_feed**: live local name first (tracks renames, no host qualifier), then the snapshot, then the sid stub as last resort.
- **Feed chip**: renders through a new `hostPartsNodes` sibling of `hostNameNodes` — same `.host-prefix` class; the host rides its own field because `peerSid` deliberately stays a bare uuid.
- **Federation**: a remote card's origin with no recorded host is attributed to that card's own kernel (and `peerSid` gets the host prefix so the click routes there); a recorded third-host origin passes through untouched.

## Tests

New `tests/test_courier_origin_host.py` (plant-time snapshot, federated vs local), postal host-stamp tests (direct, forwarded, quarantine-approve), feed fallback-ordering tests in `test_kernel.py`, and prefixInbound origin cases + source pins on the Node side. Full suites green: pytest 3164 passed, node 1332 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)