### PR TITLE
Compact quarantine card + decision dialog; echo-backfill dry-run

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -5289,6 +5289,92 @@ def run_plan(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verb
     return placed
 
 
+def _echo_clear_targets(store, minted, now, age=86400):
+    """Maximal all-old subtrees among sweep-MINTED nodes — the one-time parse-identity backfill's clear
+    selection (the user 2026-07-26). A node is clearable iff it was minted by the sweep, its evidence
+    time `t` predates `now - age`, and every descendant is clearable too; the returned targets are the
+    HIGHEST such nodes (largest granularity), so a mixed-age top keeps its fresh outcomes and only the
+    all-old sub clears. Pre-existing nodes are never targets and never let an ancestor qualify — the
+    sweep curates only what the sweep itself re-minted. Already-cleared nodes count as clearable (they
+    are already off the board) but are not re-emitted as targets."""
+    nodes = store["nodes"]
+    children = {}
+    for nid, nd in nodes.items():
+        children.setdefault(nd.get("parentId"), []).append(nid)
+    memo = {}
+
+    def clearable(nid):
+        if nid in memo:
+            return memo[nid]
+        nd = nodes[nid]
+        ok = (nd.get("cleared") or
+              (nid in minted and (nd.get("t") or now) < now - age)) and \
+             all(clearable(c) for c in children.get(nid, []))
+        memo[nid] = ok
+        return ok
+
+    out = []
+
+    def walk(nid):
+        if clearable(nid):
+            if not nodes[nid].get("cleared"):
+                out.append(nid)
+            return                                     # the whole subtree rides this clear (roll-down)
+        for c in children.get(nid, []):
+            walk(c)
+
+    for nid, nd in nodes.items():
+        if nd.get("parentId") is None:
+            walk(nid)
+    return out
+
+
+def run_echo_backfill(now=None, age=86400, window=45 * 86400, max_passes=20, verbose=True):
+    """DRY-RUN of the one-time placement backfill for the 435d9df parse-identity echoes (the user
+    2026-07-26, delegated via session bugz): force the planner through the orphaned backlog for every
+    session whose parse changed identity (orphanReply markers in states/, dormant included, looping per
+    session until a pass places nothing), then REPORT — per session — what was minted and which minted
+    subtrees are all-old (evidence entirely older than `age`, _echo_clear_targets) and therefore due to
+    be cleared. The clear application itself is a separate, supervised step. Returns
+    {sid: {passes, placed, minted, clear_targets}} plus '_skipped' (affected sids discover() couldn't
+    resolve)."""
+    if now is None:
+        now = int(time.time())
+    affected = []
+    try:
+        for f in sorted(STATESDIR.glob("*.jsonl")):
+            try:
+                if any('"orphanReply"' in ln for ln in f.read_text(errors="replace").splitlines()):
+                    affected.append(f.stem)
+            except OSError:
+                continue
+    except OSError:
+        pass
+    lanes = {fsid: str(path) for fsid, path, anchor, name in discover(now, window, forks=False)}
+    report = {"_skipped": [s for s in affected if s not in lanes]}
+    for sid in affected:
+        path = lanes.get(sid)
+        if not path:
+            continue
+        before = set(load_goals(sid)["nodes"])
+        placed = passes = 0
+        for _ in range(max_passes):
+            n = _plan_session(sid, path, now)
+            passes += 1
+            placed += n
+            if not n:
+                break
+        store = load_goals(sid)
+        minted = set(store["nodes"]) - before
+        targets = _echo_clear_targets(store, minted, now, age)
+        report[sid] = {"passes": passes, "placed": placed, "minted": sorted(minted),
+                       "clear_targets": sorted(targets)}
+        if verbose:
+            sys.stderr.write("backfill %s: %d passes, %d placed, %d minted, %d clear targets\n"
+                             % (sid[:8], passes, placed, len(minted), len(targets)))
+    return report
+
+
 def fast_forward_placements(fsid, path=None, now=None):
     """Seal every currently-OUTSTANDING planner unit as processed-with-no-goal (the None sentinel the
     retirement path already uses), WITHOUT planning any of it — so the planner resumes from the PRESENT

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11363,10 +11363,15 @@ def _quarantine_cards(now, cleared):
             continue
         frm, to, origin = rec.get("frm") or "?", rec.get("to") or "?", rec.get("origin") or "?"
         t = int(rec.get("at") or now)
+        # COMPACT card (the user 2026-07-26): what you're approving is a delivery to THIS session, so
+        # the card reads as one line under the recipient's name — "New message" + a dim sender/gist
+        # line — and the full body lives in the click-through decision modal. The gist is the same
+        # 90-char collapse the federation gossip uses (there is no courier summary at hold time: the
+        # courier only judges mail AFTER delivery, which is exactly what hasn't happened yet).
         out.append({
             "itemId": item_id, "sid": rec.get("toId") or "", "name": to,
             "color": _name_color(rec.get("toId") or ""),
-            "text": "Held message from %s to %s" % (frm, to),
+            "text": "New message",
             "t": t, "live": False,
             "trgb": list(cm.age_rgb(now - t, _colormap())),
             "turnId": item_id, "origin": None,
@@ -11375,9 +11380,10 @@ def _quarantine_cards(now, cleared):
             "nudged": None,
             "blocked": {"state": "quarantine", "mid": mid, "frm": frm, "to": to, "origin": origin,
                         "body": rec.get("body") or "",
+                        "gist": " ".join(str(rec.get("body") or "").split())[:90],
                         "what": "an incoming postal message from %s (held because peer %s is DIRECTED) is "
-                                "waiting on you — approve to deliver it to %s, edit the text first, or deny "
-                                "to drop it. Nothing reaches %s until you approve." % (frm, origin, to, to)},
+                                "waiting on you — approve to deliver it to %s, or deny to drop it. Nothing "
+                                "reaches %s until you approve." % (frm, origin, to, to)},
             "column": "needs_input",
             "tree": []})
     out.sort(key=lambda c: c["t"])
@@ -15891,6 +15897,8 @@ class Handler(BaseHTTPRequestHandler):
             _qbody = {"mid": _qmid, "action": str(msg.get("action") or "").strip().lower()}
             if msg.get("text") is not None:
                 _qbody["text"] = str(msg["text"])
+            if msg.get("feedback"):                # deny-with-note: the bus mails it back to the sender
+                _qbody["feedback"] = str(msg["feedback"])
             _qok, _qerr = _bus_quarantine_act(_qbody)
             if _qok:
                 _mark_views_dirty()

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1054,7 +1054,7 @@ class Handler(BaseHTTPRequestHandler):
             mid = str(data.get("mid") or "")       # blocked card via the kernel; approve delivers, deny drops
             action = str(data.get("action") or "").strip().lower()
             text = data.get("text")                # optional human-edited body for approve
-            ok, err = quarantine_decide(mid, action, text)
+            ok, err = quarantine_decide(mid, action, text, feedback=data.get("feedback"))
             return self._send({"ok": ok} if ok else {"ok": False, "error": err}, 200 if ok else 400)
         self._send({"error": "not found"}, 404)
 
@@ -1557,16 +1557,31 @@ def quarantine_del(mid):
     except OSError:
         return False
 
-def quarantine_decide(mid, action, text=None):
+def quarantine_decide(mid, action, text=None, feedback=None):
     """Approve (deliver, optionally with human-edited text) or deny (drop) a held message. Returns
     (ok, error). Approve replays the deliver() the gate would have run for a trusted peer, so the
     message lands as normal postal mail (from-attribution intact). The mid was already peer_seen'd at
-    hold time, so the sender never resends regardless of the verdict."""
+    hold time, so the sender never resends regardless of the verdict.
+
+    `feedback` (the user 2026-07-26): an optional note back to the SENDER on a deny — parked in the
+    origin host's outbox as ordinary store-and-forward mail from the postal service (so the sender's
+    agent learns why instead of waiting forever), delivered on the next exchange and judged by the
+    origin host's own trust gate like any inbound mail."""
     rec = quarantine_get(mid)
     if rec is None:
         return False, "no held message '%s'" % mid
     if action == "deny":
         quarantine_del(mid)
+        note = " ".join(str(feedback or "").split())
+        if note and rec.get("origin") and rec.get("frm"):
+            gist = " ".join(str(rec.get("body") or "").split())[:60]
+            body = ('Your message to %s ("%s%s") was reviewed there and declined — it was not '
+                    "delivered. Note from the reviewer: %s"
+                    % (rec.get("to") or "?", gist, "…" if len(gist) == 60 else "", note))
+            fb_mid = _unique()
+            outbox_put(rec["origin"], {"mid": fb_mid, "to": rec["frm"], "frm": "Romp Postal Service",
+                                       "frm_id": "", "body": body, "kind": "coordinate"})
+            _peer_wake(rec["origin"]).set()
         return True, None
     if action == "approve":
         body = str(text) if (text is not None and str(text).strip()) else (rec.get("body") or "")

--- a/tests/test_echo_backfill.py
+++ b/tests/test_echo_backfill.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""_echo_clear_targets: the parse-identity backfill's clear selection (the user 2026-07-26).
+
+The one-time sweep re-mints goals for placements orphaned by the 435d9df segment-identity change;
+minted nodes whose evidence is entirely older than the age cutoff are bookkeeping echoes and get
+cleared at the LARGEST all-old-subtree granularity — a mixed-age top keeps its fresh outcomes and
+only the all-old sub clears; pre-existing nodes are never touched. Synthetic stores only."""
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+jd = SourceFileLoader("romp_judge_echobackfill", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NOW = 1785200000
+OLD = NOW - 3 * 86400          # evidence well past the 24h cutoff
+FRESH = NOW - 3600             # evidence from this afternoon
+
+
+def _store(nodes):
+    return {"rompUuid": SID, "nodes": nodes, "status": {}, "placements": {}}
+
+
+def _n(gid, t, parent=None, cleared=False):
+    return {"id": gid, "text": "x", "parentId": parent, "t": t,
+            "nodeComplete": False, "blocked": False, "cleared": cleared}
+
+
+class EchoClearTargets(unittest.TestCase):
+    def test_all_old_minted_top_clears_at_the_top(self):
+        g, s1, s2 = SID + ":g1", SID + ":g2", SID + ":g3"
+        store = _store({g: _n(g, OLD), s1: _n(s1, OLD, g), s2: _n(s2, OLD, g)})
+        self.assertEqual(jd._echo_clear_targets(store, {g, s1, s2}, NOW), [g],
+                         "largest granularity: one clear at the top, the subtree rides roll-down")
+
+    def test_mixed_age_top_keeps_fresh_and_clears_only_the_old_sub(self):
+        g, old, fresh = SID + ":g1", SID + ":g2", SID + ":g3"
+        store = _store({g: _n(g, OLD), old: _n(old, OLD, g), fresh: _n(fresh, FRESH, g)})
+        self.assertEqual(jd._echo_clear_targets(store, {g, old, fresh}, NOW), [old],
+                         "a mixed-age top keeps its fresh outcomes; only the all-old sub clears")
+
+    def test_old_minted_sub_under_a_pre_existing_top_clears_the_sub_only(self):
+        top, sub = SID + ":g1", SID + ":g2"
+        store = _store({top: _n(top, OLD), sub: _n(sub, OLD, top)})
+        self.assertEqual(jd._echo_clear_targets(store, {sub}, NOW), [sub],
+                         "a pre-existing top is never a target even when its evidence is old")
+
+    def test_fresh_mints_and_untouched_old_nodes_yield_nothing(self):
+        g, h = SID + ":g1", SID + ":g2"
+        store = _store({g: _n(g, FRESH), h: _n(h, OLD)})
+        self.assertEqual(jd._echo_clear_targets(store, {g}, NOW), [],
+                         "fresh mints stay; old nodes the sweep did not mint stay")
+
+    def test_already_cleared_descendant_lets_the_ancestor_clear_but_is_not_re_emitted(self):
+        g, done = SID + ":g1", SID + ":g2"
+        store = _store({g: _n(g, OLD), done: _n(done, OLD, g, cleared=True)})
+        self.assertEqual(jd._echo_clear_targets(store, {g}, NOW), [g],
+                         "an already-cleared sub is off the board — it neither blocks nor re-clears")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_trust.py
+++ b/tests/test_kernel_trust.py
@@ -181,6 +181,16 @@ class QuarantineCards(unittest.TestCase):
         self.assertEqual(c["blocked"]["origin"], "TESTHOST")
         self.assertEqual(c["blocked"]["body"], "ship the parser fix")
 
+    def test_card_is_compact_title_plus_gist(self):
+        """The card reads "New message" under the RECIPIENT session's name, with the bus-style 90-char
+        gist for the one-line body (the user 2026-07-26 — the full body lives in the decision modal)."""
+        self._write_held("qc-4", body="  ship   the\nparser fix  " + "x" * 200)
+        c = km._quarantine_cards(2000, set())[0]
+        self.assertEqual(c["text"], "New message")
+        gist = c["blocked"]["gist"]
+        self.assertTrue(gist.startswith("ship the parser fix"), gist)
+        self.assertEqual(len(gist), 90, "whitespace-collapsed and clamped like the federation gossip gist")
+
     def test_cleared_card_is_hidden(self):
         self._write_held("qc-2")
         self.assertEqual(km._quarantine_cards(2000, {"quarantine:qc-2"}), [])

--- a/tests/test_postal_quarantine.py
+++ b/tests/test_postal_quarantine.py
@@ -248,6 +248,27 @@ class QuarantineDecide(unittest.TestCase):
         self.assertTrue(ok, err)
         self.assertEqual(ps.quarantine_list(), [])
         self.assertEqual(ps.read_box("sess-web", consume=False), [], "deny delivers nothing")
+        self.assertEqual(list((ps.OUTBOX / "TESTHOST").glob("*.json")) if (ps.OUTBOX / "TESTHOST").is_dir() else [],
+                         [], "a bare deny sends nothing back")
+
+    def test_deny_with_feedback_mails_the_sender(self):
+        """Deny + a note (the user 2026-07-26): the note parks in the ORIGIN host's outbox as ordinary
+        store-and-forward mail addressed to the sender session, so their agent learns why instead of
+        waiting forever. The body names the recipient and quotes a gist of what was declined."""
+        ps._relay_in("TESTHOST", _relay("q-deny-2", body="please rewrite the ingest job tonight"))
+        ok, err = ps.quarantine_decide("q-deny-2", "deny", feedback="not tonight, we freeze before the demo")
+        self.assertTrue(ok, err)
+        self.assertEqual(ps.quarantine_list(), [])
+        rows = [json.loads(f.read_text()) for f in (ps.OUTBOX / "TESTHOST").glob("*.json")]
+        self.assertEqual(len(rows), 1, "exactly one note back to the sender")
+        m = rows[0]
+        self.assertEqual(m["to"], "api", "addressed to the SENDER session by name")
+        self.assertEqual(m["frm"], "Romp Postal Service")
+        self.assertIn("declined", m["body"])
+        self.assertIn("not tonight, we freeze before the demo", m["body"])
+        self.assertIn("please rewrite the ingest job", m["body"], "the gist anchors which message this was")
+        for f in (ps.OUTBOX / "TESTHOST").glob("*.json"):
+            f.unlink()
 
     def test_decide_unknown_mid_errors(self):
         ok, err = ps.quarantine_decide("no-such-mid", "approve")

--- a/ui/webview/feed-quarantine.test.ts
+++ b/ui/webview/feed-quarantine.test.ts
@@ -1,11 +1,14 @@
 // Quarantine card in the feed (per-host trust model): mail from a DIRECTED federated peer is HELD, and
-// surfaces as a needs_input card (blocked.state "quarantine") whose body shows the message IN FULL
-// (read-only prose — the human is deciding on it), with Approve / Edit / Deny. Approve/Deny post a
+// surfaces as a COMPACT needs_input card under the RECIPIENT session's name — "New message" + one dim
+// sender/gist line (the user 2026-07-26: the full-body card made the feed scroll; the delivery to that
+// session is what's being approved). Clicking the line opens the decision dialog with the whole body,
+// read-only (editing was cut from the flow); Approve delivers, Deny flips the dialog to an optional
+// note back to the sender (the bus mails it to the origin host). Approve/Deny post a
 // quarantineDecision op that carries the card's sid, so the federation manager routes the verdict to
 // the kernel that actually HOLDS the file (a remote hold's Approve used to land on the local kernel
-// and silently no-op — the user 2026-07-26). Edit opens a modal editor on document.body, outside the
-// re-rendered feed root, so a kernel push mid-edit can't eat the text. Source-pin (no jsdom for the
-// feed renderer), like the other feed-*.
+// and silently no-op — the user 2026-07-26). The dialog lives on document.body, outside the
+// re-rendered feed root, so a kernel push mid-decision can't eat the note. Source-pin (no jsdom for
+// the feed renderer), like the other feed-*.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -13,18 +16,19 @@ import * as path from "node:path";
 
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
-test("the quarantine buttons + full-message body are created and registered", () => {
+test("the quarantine card is compact: Approve/Deny buttons + a one-line sender/gist, no Edit", () => {
   assert.match(FEED, /const qApprove = el\("button", "fdismiss fq fq-ok"\)[\s\S]*?qApprove\.textContent = "Approve"/);
-  assert.match(FEED, /const qEdit = el\("button", "fdismiss fq"\)[\s\S]*?qEdit\.textContent = "Edit"/);
   assert.match(FEED, /const qDeny = el\("button", "fdismiss fq fq-no"\)[\s\S]*?qDeny\.textContent = "Deny"/);
-  // the body is a read-only prose div (the whole message), NOT a clipped inline textarea
+  assert.doesNotMatch(FEED, /qEdit/, "editing was cut from the flow (the user 2026-07-26)");
+  // the body line is a dim one-liner (sender + gist), click-through to the decision dialog
   assert.match(FEED, /const qbody = el\("div", "fask-qbody"\)/);
-  assert.doesNotMatch(FEED, /el\("textarea", "fask-qbody"\)/);
-  assert.match(FEED, /a\._qApprove = qApprove; a\._qEdit = qEdit; a\._qDeny = qDeny; a\._qBody = qbody;/);
+  assert.match(FEED, /qBody\.textContent = `from \$\{sender\} — \$\{it\.blocked\.gist \|\| it\.blocked\.body \|\| ""\}`/);
+  assert.match(FEED, /qBody\.onclick = [\s\S]*?showQuarantineDialog\(sender, it\.blocked!\.to \|\| "\?", it\.blocked!\.body \|\| "", decide, false\)/);
+  assert.match(FEED, /a\._qApprove = qApprove; a\._qDeny = qDeny; a\._qBody = qbody;/);
 });
 
-test("the blocked type carries the quarantine fields", () => {
-  assert.match(FEED, /mid\?: string; frm\?: string; to\?: string; origin\?: string; body\?: string \};\s*\/\/ quarantine/);
+test("the blocked type carries the quarantine fields (incl. the gist)", () => {
+  assert.match(FEED, /mid\?: string; frm\?: string; to\?: string; origin\?: string; body\?: string; gist\?: string \};\s*\/\/ quarantine/);
 });
 
 test("the decision carries the card's sid so a remote hold's verdict reaches the holding kernel", () => {
@@ -32,21 +36,23 @@ test("the decision carries the card's sid so a remote hold's verdict reaches the
   // the block chip is suppressed for a quarantine card — its own buttons carry the decision
   assert.match(FEED, /it\.blocked\.state !== "quarantine"/);
   // sid rides the op — federation's routeOutbound keys on it (same shape as the askClear fix, 2026-07-02)
-  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "quarantineDecision", mid, action, text, sid: it\.sid \}\)/);
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "quarantineDecision", mid, action, text, sid: it\.sid, feedback \}\)/);
   assert.match(FEED, /a\._qApprove\.onclick = [\s\S]*?decide\("approve", "Delivering…", it\.blocked!\.body \|\| ""\)/);
-  assert.match(FEED, /a\._qDeny\.onclick = [\s\S]*?decide\("deny", "Denying…", it\.blocked!\.body \|\| ""\)/);
+  // the card's Deny goes through the dialog's feedback step, never a blind drop
+  assert.match(FEED, /a\._qDeny\.onclick = [\s\S]*?showQuarantineDialog\(sender, it\.blocked!\.to \|\| "\?", it\.blocked!\.body \|\| "", decide, true\)/);
 });
 
-test("Edit opens the modal editor; the dialog lives outside the feed render root", () => {
-  assert.match(FEED, /a\._qEdit\.onclick = [\s\S]*?showQuarantineEditDialog\(/);
-  // the dialog: overlay on document.body (survives feed re-renders), textarea prefilled with the body,
-  // Approve delivers the edited text, Deny drops, Cancel keeps the message held
-  assert.match(FEED, /function showQuarantineEditDialog\(/);
-  const dlg = FEED.slice(FEED.indexOf("function showQuarantineEditDialog"));
+test("the decision dialog: read-only body, Approve/Deny, deny step offers a note to the sender", () => {
+  assert.match(FEED, /function showQuarantineDialog\(/);
+  const dlg = FEED.slice(FEED.indexOf("function showQuarantineDialog"));
   assert.match(dlg, /document\.body\.appendChild\(overlay\)/);
-  assert.match(dlg, /el\("textarea", "qdlg-text"\)/);
-  assert.match(dlg, /ta\.value = body/);
-  assert.match(dlg, /decide\("approve", "Delivering…", ta\.value\)/);
-  assert.match(dlg, /decide\("deny", "Denying…", ta\.value\)/);
-  assert.match(dlg, /cancel\.onclick = \(\) => overlay\.remove\(\)/);
+  // the body is a read-only view, not a textarea (editing was cut)
+  assert.match(dlg, /el\("div", "qdlg-view"\)/);
+  assert.match(dlg, /view\.textContent = body/);
+  assert.match(dlg, /decide\("approve", "Delivering…", body\)/);
+  // deny step: optional note back to the sender, or a bare deny; Cancel keeps the message held
+  assert.match(dlg, /el\("textarea", "qdlg-text qdlg-feedback"\)/);
+  assert.match(dlg, /decide\("deny", "Denying…", body, ta\.value\.trim\(\) \|\| undefined\)/);
+  assert.match(dlg, /decide\("deny", "Denying…", body\)/);
+  assert.match(dlg, /c\.onclick = \(\) => overlay\.remove\(\)/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -662,19 +662,29 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fdismiss.fq-ok:hover:not(:disabled) { color: var(--accent-fg); background: var(--accent); border-color: var(--accent); }
 .fdismiss.fq-no { color: #e5484d; border-color: rgba(229, 72, 77, 0.6); }
 .fdismiss.fq-no:hover:not(:disabled) { color: #fff; background: #e5484d; border-color: #e5484d; }
+/* Compact quarantine line (the user 2026-07-26): one dim sender+gist line, click opens the decision
+   modal — the full body never renders on the card. */
 .fask-qbody {
-  display: block; width: 100%; box-sizing: border-box; margin: 6px 0 2px;
-  font: inherit; font-size: 12px; line-height: 1.45; white-space: pre-wrap; overflow-wrap: anywhere;
+  display: block; width: 100%; box-sizing: border-box; margin: 4px 0 2px;
+  font: inherit; font-size: 12px; line-height: 1.45;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  color: var(--dim); cursor: pointer;
+}
+.fask-qbody:hover { color: #dfe7ee; }
+/* The quarantine decision dialog rides the pickdlg overlay/box; the body is READ-ONLY (.qdlg-view);
+   the textarea appears only on the deny step, for the optional note back to the sender. */
+.qdlg-box { width: min(640px, 96%); }
+.qdlg-view {
+  width: 100%; box-sizing: border-box; font: inherit; font-size: 12px; line-height: 1.45;
+  max-height: 50vh; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere;
   color: #dfe7ee; background: #0c1117; border: 1px solid #35414d; border-radius: 6px; padding: 6px 8px;
 }
-/* The quarantine edit dialog rides the pickdlg overlay/box; the textarea is the editing surface. */
-.qdlg-box { width: min(640px, 96%); }
 .qdlg-text {
   width: 100%; box-sizing: border-box; font: inherit; font-size: 12px; line-height: 1.45;
-  min-height: 14em; resize: vertical;
+  min-height: 5em; resize: vertical; margin-top: 8px;
   color: #dfe7ee; background: #0c1117; border: 1px solid var(--accent); border-radius: 6px; padding: 6px 8px;
 }
-.qdlg-actions { display: flex; gap: 8px; justify-content: flex-end; }
+.qdlg-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 8px; }
 
 /* ↩ answer row — the user's recorded reply to an agent question (an explicit
    child event on the card, kind:"answer"): decision blue, never dimmed — it's

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -76,7 +76,7 @@ interface AskItem {
               tooLong?: boolean;   // apiError: a "prompt is too long" error (on you → compact) vs a transient API error
               spendLimit?: boolean;   // apiError: a monthly spend cap (on you → raise it, never auto-retried; the user 2026-07-14)
               toName?: string; toSid?: string;    // parkedHandoff adds to*
-              mid?: string; frm?: string; to?: string; origin?: string; body?: string };   // quarantine (held peer mail) adds these
+              mid?: string; frm?: string; to?: string; origin?: string; body?: string; gist?: string };   // quarantine (held peer mail) adds these; gist = the bus's 90-char collapse for the compact card line
   summary?: string | null;                         // distiller's key takeaway for a COMPLETED goal → the done card's one auto-written line (kernel asks.append); null until produced
   distillState?: "completed" | "blocked" | null;   // the GENUINE resolution state the distiller line keys on, so the brief/takeaway rides the real block instead of the transient `column` (which recheck/rejudging flicker to working) — the user 2026-07-21; absent from older/remote payloads → fall back to column
   artifacts?: string[] | null;                     // files the work PRODUCED (distiller ARTIFACTS line, kernel existence-filtered at build): "N artifacts" under the summary; previewed in the modal (the user 2026-07-08)
@@ -614,8 +614,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   // Edit opens the modal to change the text before delivering, Deny drops it. Human-in-the-loop is the
   // whole point of directed trust, so nothing reaches the session until one of these is clicked.
   const qApprove = el("button", "fdismiss fq fq-ok") as HTMLButtonElement; qApprove.textContent = "Approve"; qApprove.title = "deliver this message to the recipient session"; qApprove.style.display = "none";
-  const qEdit = el("button", "fdismiss fq") as HTMLButtonElement; qEdit.textContent = "Edit"; qEdit.title = "edit the message text, then deliver"; qEdit.style.display = "none";
-  const qDeny = el("button", "fdismiss fq fq-no") as HTMLButtonElement; qDeny.textContent = "Deny"; qDeny.title = "drop this message — nothing is delivered"; qDeny.style.display = "none";
+  const qDeny = el("button", "fdismiss fq fq-no") as HTMLButtonElement; qDeny.textContent = "Deny"; qDeny.title = "drop this message — with the option of a note back to the sender"; qDeny.style.display = "none";
   // The header "awaiting" chip was REMOVED (the user 2026-07-04): it duplicated the "Awaiting background
   // agents" box in the card body, which says the same thing with room for the full "why" — so the chip was
   // pure redundancy. The awaiting state now reads only from that body box (see the awaitSpin block below).
@@ -640,7 +639,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   // COMPACTNESS (the user 2026-07-07): Clear rides the NAME row (right side, after the chips) and the
   // Background/Summary toggles ride the TIME row — freeing a whole action row. So the action row holds only
   // Retry / Revive (rare states); both rows flex-WRAP so nothing overflows or overlaps on a narrow card.
-  actions.append(apiRetry, revive, qApprove, qEdit, qDeny);
+  actions.append(apiRetry, revive, qApprove, qDeny);
   // "↪ from <peer>" provenance + the "reopened"/"↻ Followed up" chips ride the name row's right side;
   // row2 wraps them onto a new line when there isn't room, so the provenance never overlaps a chip
   // (the user 2026-06-20). origin sits left of the chips, matching the "from … · Followed up" reading order.
@@ -821,7 +820,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   a._waitOn = waitOnBadge;
   a._blocked = blkBadge;
   a._apiBadge = apiBadge; a._apiRetry = apiRetry; a._retryBadge = retryBadge; a._revive = revive; a._clr = clr;
-  a._qApprove = qApprove; a._qEdit = qEdit; a._qDeny = qDeny; a._qBody = qbody;
+  a._qApprove = qApprove; a._qDeny = qDeny; a._qBody = qbody;
   a._delegations = delegations;
   a._checklist = checklist;
   a._distill = distill; a._artline = artline;
@@ -1370,11 +1369,13 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
       a._revive.disabled = true; a._revive.textContent = "Reviving…";
     };
   }
-  // QUARANTINE (per-host trust) → Approve / Edit / Deny a held message from a DIRECTED peer. The body
-  // shows in full, read-only (peer content, never auto-run); Edit opens a modal editor (the user
-  // 2026-07-26 — inline unlock was cramped and a re-render could eat the edit); Approve delivers,
-  // Deny drops. The decision CARRIES THE CARD'S sid so the federation manager routes it to the kernel
-  // that actually holds the file — without it a remote hold's verdict landed on the local kernel and
+  // QUARANTINE (per-host trust) → a COMPACT "New message" card under the RECIPIENT session's name —
+  // that delivery is what you're approving (the user 2026-07-26; the full-body card made the feed
+  // scroll). One dim line names the sender (host:name) with the bus's 90-char gist; clicking it opens
+  // the decision modal with the whole body, read-only (peer content, never auto-run). Approve
+  // delivers; Deny opens the same modal's feedback step (optional note mailed back to the sender).
+  // The decision CARRIES THE CARD'S sid so the federation manager routes it to the kernel that
+  // actually holds the file — without it a remote hold's verdict landed on the local kernel and
   // Approve silently did nothing (same shape as the askClear routing fix, 2026-07-02). No optimistic
   // clear — the next kernel push removes the card on success, or re-renders it (buttons re-enabled)
   // if the bus refused (e.g. the recipient is no longer live; the warn toast says why).
@@ -1382,21 +1383,22 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   const isQuar = it.blocked?.state === "quarantine";
   const qBody = a._qBody as HTMLElement;
   qBody.style.display = isQuar ? "" : "none";
-  for (const b of [a._qApprove, a._qEdit, a._qDeny] as HTMLButtonElement[]) b.style.display = isQuar ? "" : "none";
+  for (const b of [a._qApprove, a._qDeny] as HTMLButtonElement[]) b.style.display = isQuar ? "" : "none";
   if (isQuar && it.blocked) {
     const mid = it.blocked.mid || "";
-    qBody.textContent = it.blocked.body || "";
+    const sender = `${it.blocked.origin || "?"}:${it.blocked.frm || "?"}`;
+    qBody.textContent = `from ${sender} — ${it.blocked.gist || it.blocked.body || ""}`;
+    qBody.title = "click to read the whole message and decide";
     a._qApprove.disabled = false; a._qApprove.textContent = "Approve";
-    a._qEdit.disabled = false; a._qEdit.textContent = "Edit";
     a._qDeny.disabled = false; a._qDeny.textContent = "Deny";
-    const decide = (action: string, busy: string, text: string) => {
-      vscodeApi?.postMessage({ type: "quarantineDecision", mid, action, text, sid: it.sid });
-      for (const b of [a._qApprove, a._qEdit, a._qDeny] as HTMLButtonElement[]) b.disabled = true;
+    const decide = (action: string, busy: string, text: string, feedback?: string) => {
+      vscodeApi?.postMessage({ type: "quarantineDecision", mid, action, text, sid: it.sid, feedback });
+      for (const b of [a._qApprove, a._qDeny] as HTMLButtonElement[]) b.disabled = true;
       (action === "deny" ? a._qDeny : a._qApprove).textContent = busy;
     };
-    a._qEdit.onclick = (ev: Event) => { ev.stopPropagation(); showQuarantineEditDialog(it.blocked!.frm || "?", it.blocked!.to || "?", it.blocked!.body || "", decide); };
+    qBody.onclick = (ev: Event) => { ev.stopPropagation(); showQuarantineDialog(sender, it.blocked!.to || "?", it.blocked!.body || "", decide, false); };
     a._qApprove.onclick = (ev: Event) => { ev.stopPropagation(); decide("approve", "Delivering…", it.blocked!.body || ""); };
-    a._qDeny.onclick = (ev: Event) => { ev.stopPropagation(); decide("deny", "Denying…", it.blocked!.body || ""); };
+    a._qDeny.onclick = (ev: Event) => { ev.stopPropagation(); showQuarantineDialog(sender, it.blocked!.to || "?", it.blocked!.body || "", decide, true); };
   }
   (a._clr as HTMLElement).style.display = isQuar ? "none" : "";
 
@@ -3129,34 +3131,58 @@ window.addEventListener("message", (e: MessageEvent) => {
   }
 });
 
-// ---- quarantine edit dialog: edit a held message's text, then Approve (deliver the edit) or Deny ----
-// Lives on document.body OUTSIDE the re-rendered feed root, so a kernel push mid-edit can't eat the
-// text (the inline-unlock textarea it replaces was clobbered exactly that way; the user 2026-07-26).
+// ---- quarantine decision dialog (the user 2026-07-26): the card is compact, so THIS is where the
+// whole held message is read and decided. Step 1: the full body, read-only (peer content, never
+// auto-run; editing was cut from the flow), with Approve / Deny / Cancel. Deny flips the SAME dialog
+// to step 2: an optional note back to the sender ("Deny & send note" / "Deny" / Cancel) — the bus
+// mails it to the origin host so the sender's agent learns why instead of waiting forever. Lives on
+// document.body OUTSIDE the re-rendered feed root, so a kernel push mid-decision can't eat the note.
 // `decide` is the owning card's decision closure — it carries the mid + sid and flips the card buttons.
-function showQuarantineEditDialog(frm: string, to: string, body: string,
-                                  decide: (action: string, busy: string, text: string) => void) {
-  document.getElementById("quar-edit-dialog")?.remove();
-  const overlay = el("div", "pickdlg-overlay"); overlay.id = "quar-edit-dialog";
+function showQuarantineDialog(sender: string, to: string, body: string,
+                              decide: (action: string, busy: string, text: string, feedback?: string) => void,
+                              denyFirst: boolean) {
+  document.getElementById("quar-dialog")?.remove();
+  const overlay = el("div", "pickdlg-overlay"); overlay.id = "quar-dialog";
   const box = el("div", "pickdlg-box qdlg-box");
   const title = el("div", "pickdlg-title");
-  title.textContent = `Held message from ${frm} to ${to} — edit, then approve to deliver your version`;
-  const ta = el("textarea", "qdlg-text") as HTMLTextAreaElement;
-  ta.value = body;
+  title.textContent = `New message from ${sender} to ${to}`;
+  const view = el("div", "qdlg-view");
+  view.textContent = body;
   const row = el("div", "qdlg-actions");
-  const ok = el("button", "fdismiss fq fq-ok") as HTMLButtonElement; ok.textContent = "Approve";
-  ok.title = "deliver the text above to the recipient session";
-  ok.onclick = () => { decide("approve", "Delivering…", ta.value); overlay.remove(); };
-  const no = el("button", "fdismiss fq fq-no") as HTMLButtonElement; no.textContent = "Deny";
-  no.title = "drop this message — nothing is delivered";
-  no.onclick = () => { decide("deny", "Denying…", ta.value); overlay.remove(); };
-  const cancel = el("button", "fdismiss fq") as HTMLButtonElement; cancel.textContent = "Cancel";
-  cancel.title = "close without deciding — the message stays held";
-  cancel.onclick = () => overlay.remove();
-  row.append(ok, no, cancel);
-  box.append(title, ta, row);
+  box.append(title, view, row);
+
+  const cancel = () => { const c = el("button", "fdismiss fq") as HTMLButtonElement; c.textContent = "Cancel";
+    c.title = "close without deciding — the message stays held"; c.onclick = () => overlay.remove(); return c; };
+
+  const denyStep = () => {
+    title.textContent = `Deny the message from ${sender} — send a note back?`;
+    const ta = el("textarea", "qdlg-text qdlg-feedback") as HTMLTextAreaElement;
+    ta.placeholder = "optional: tell the sender why (delivered to them as postal mail)";
+    row.replaceChildren();
+    const withNote = el("button", "fdismiss fq fq-no") as HTMLButtonElement; withNote.textContent = "Deny & send note";
+    withNote.title = "drop the message and mail your note back to the sender";
+    withNote.onclick = () => { decide("deny", "Denying…", body, ta.value.trim() || undefined); overlay.remove(); };
+    const bare = el("button", "fdismiss fq") as HTMLButtonElement; bare.textContent = "Deny without note";
+    bare.title = "drop the message — nothing is sent back";
+    bare.onclick = () => { decide("deny", "Denying…", body); overlay.remove(); };
+    row.append(withNote, bare, cancel());
+    box.insertBefore(ta, row);
+    ta.focus();
+  };
+
+  if (denyFirst) {
+    denyStep();
+  } else {
+    const ok = el("button", "fdismiss fq fq-ok") as HTMLButtonElement; ok.textContent = "Approve";
+    ok.title = "deliver this message to the recipient session";
+    ok.onclick = () => { decide("approve", "Delivering…", body); overlay.remove(); };
+    const no = el("button", "fdismiss fq fq-no") as HTMLButtonElement; no.textContent = "Deny";
+    no.title = "drop this message — with the option of a note back to the sender";
+    no.onclick = () => denyStep();
+    row.append(ok, no, cancel());
+  }
   overlay.onclick = (e) => { if (e.target === overlay) overlay.remove(); };
   document.body.appendChild(overlay);
-  ta.focus();
 }
 
 // ---- in-page resume-picker dialog (the answerPicker flow, no native QuickPick) ----

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "romp-chat-view",
-  "version": "0.4.334",
+  "version": "0.4.335",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "romp-chat-view",
-      "version": "0.4.334",
+      "version": "0.4.335",
       "dependencies": {
         "@types/ws": "^8.18.1",
         "dompurify": "^3.4.10",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "romp-chat-view",
   "displayName": "romp Chat View",
   "description": "Read-only, nicely-rendered live view of Claude Code (romp) sessions, styled like the official Claude Code panel.",
-  "version": "0.4.334",
+  "version": "0.4.335",
   "publisher": "romp",
   "private": true,
   "engines": {


### PR DESCRIPTION
## Quarantine card redesign (the user's ask)

The held-mail card rendered the full message body on the feed. Now: a compact card under the **recipient** session's name — "New message" + one dim `host:sender — gist` line (the bus's 90-char collapse; there is no courier summary at hold time, since the courier only judges mail after delivery). Clicking the line opens a decision dialog with the full body, read-only: **Approve** delivers; **Deny** flips to an optional note back to the sender, mailed to the origin host as store-and-forward postal mail from the postal service. The Edit flow is cut per the user's direction (the bus keeps the `text` param for API compatibility).

## Parse-identity echo backfill (dry-run scaffolding)

`run_echo_backfill` drains the planner backlog for every session with orphanReply markers (dormant included) and reports which sweep-minted subtrees are all-old via `_echo_clear_targets` (largest all-old-subtree granularity; mixed-age tops keep fresh outcomes; pre-existing nodes never targeted). The clear-application step ships separately.

## Tests

Bus: deny-with-feedback outbox note, bare-deny sends nothing. Kernel: compact card + gist. Node: rewritten quarantine source pins (compact line, dialog steps, no Edit). Echo backfill: 5 selection-granularity cases. Suites green: pytest 3171 passed, node 1332 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)