### PR TITLE
Quarantine dialog: approve or deny, no Cancel

### DIFF
--- a/ui/webview/feed-quarantine.test.ts
+++ b/ui/webview/feed-quarantine.test.ts
@@ -44,7 +44,7 @@ test("the decision carries the card's sid so a remote hold's verdict reaches the
 
 test("the decision dialog: read-only body, Approve/Deny, deny step offers a note to the sender", () => {
   assert.match(FEED, /function showQuarantineDialog\(/);
-  const dlg = FEED.slice(FEED.indexOf("function showQuarantineDialog"));
+  const dlg = FEED.slice(FEED.indexOf("function showQuarantineDialog"), FEED.indexOf("function showPickerDialog"));
   assert.match(dlg, /document\.body\.appendChild\(overlay\)/);
   // the body is a read-only view, not a textarea (editing was cut)
   assert.match(dlg, /el\("div", "qdlg-view"\)/);
@@ -54,5 +54,8 @@ test("the decision dialog: read-only body, Approve/Deny, deny step offers a note
   assert.match(dlg, /el\("textarea", "qdlg-text qdlg-feedback"\)/);
   assert.match(dlg, /decide\("deny", "Denying…", body, ta\.value\.trim\(\) \|\| undefined\)/);
   assert.match(dlg, /decide\("deny", "Denying…", body\)/);
-  assert.match(dlg, /c\.onclick = \(\) => overlay\.remove\(\)/);
+  // no Cancel button (the user 2026-07-26: approve or deny, nothing else) — the backdrop click is the
+  // only no-decision exit, and the message stays held
+  assert.doesNotMatch(dlg, /"Cancel"/);
+  assert.match(dlg, /if \(e\.target === overlay\) overlay\.remove\(\)/);
 });

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3151,9 +3151,9 @@ function showQuarantineDialog(sender: string, to: string, body: string,
   const row = el("div", "qdlg-actions");
   box.append(title, view, row);
 
-  const cancel = () => { const c = el("button", "fdismiss fq") as HTMLButtonElement; c.textContent = "Cancel";
-    c.title = "close without deciding — the message stays held"; c.onclick = () => overlay.remove(); return c; };
-
+  // No Cancel button (the user 2026-07-26: two choices, approve or deny — this gate is only there to
+  // catch something malicious). Clicking the backdrop still closes without deciding; the message
+  // stays held either way.
   const denyStep = () => {
     title.textContent = `Deny the message from ${sender} — send a note back?`;
     const ta = el("textarea", "qdlg-text qdlg-feedback") as HTMLTextAreaElement;
@@ -3165,7 +3165,7 @@ function showQuarantineDialog(sender: string, to: string, body: string,
     const bare = el("button", "fdismiss fq") as HTMLButtonElement; bare.textContent = "Deny without note";
     bare.title = "drop the message — nothing is sent back";
     bare.onclick = () => { decide("deny", "Denying…", body); overlay.remove(); };
-    row.append(withNote, bare, cancel());
+    row.append(withNote, bare);
     box.insertBefore(ta, row);
     ta.focus();
   };
@@ -3179,7 +3179,7 @@ function showQuarantineDialog(sender: string, to: string, body: string,
     const no = el("button", "fdismiss fq fq-no") as HTMLButtonElement; no.textContent = "Deny";
     no.title = "drop this message — with the option of a note back to the sender";
     no.onclick = () => denyStep();
-    row.append(ok, no, cancel());
+    row.append(ok, no);
   }
   overlay.onclick = (e) => { if (e.target === overlay) overlay.remove(); };
   document.body.appendChild(overlay);

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "romp-chat-view",
-  "version": "0.4.335",
+  "version": "0.4.336",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "romp-chat-view",
-      "version": "0.4.335",
+      "version": "0.4.336",
       "dependencies": {
         "@types/ws": "^8.18.1",
         "dompurify": "^3.4.10",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "romp-chat-view",
   "displayName": "romp Chat View",
   "description": "Read-only, nicely-rendered live view of Claude Code (romp) sessions, styled like the official Claude Code panel.",
-  "version": "0.4.335",
+  "version": "0.4.336",
   "publisher": "romp",
   "private": true,
   "engines": {


### PR DESCRIPTION
Cancel duplicated the backdrop click (which still closes without deciding; the message stays held) and muddied a gate whose only job is catching something malicious. The dialog and its deny step now offer only the real verbs. Node suite green (1332).

🤖 Generated with [Claude Code](https://claude.com/claude-code)