### PR TITLE
Debt reminders: an owed reply is nudged like owed work

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -740,6 +740,82 @@ def _nudge_bundle_body(gids, nodes, stalled_gids):
     return msg + "\n\n" + tail
 
 
+# ── the DEBT reminder (the user 2026-07-26): the peer-wait's other end ──────────────────────────────
+# An unanswered postal QUESTION/DELEGATE paints "Awaiting <peer>" on the SENDER's cards and parks them
+# (the auto-nudge deliberately skips peer-waiting cards) — but nothing ever told the RECIPIENT it owes a
+# reply, so a mis-declared kind (a "question" whose prose said no reply was needed) or a plain forgotten
+# reply parked the sender silently for a day (logic waited 26h on a reply the recipient never knew it
+# owed). The fix is the same loop the goal nudge closes: an IDLE session sitting on unanswered inbound
+# asks from LIVE peers gets ONE reminder, in the asker's terms, and either honest exit — an answer, or
+# "nothing needed" — is the reply event that releases the asker's wait. Dedup per ask event (debtNudged
+# in auto-nudge.json, one reminder per ask ever); a NEWER ask from the same peer is a new event.
+
+
+def _debt_asks(sid, alive_ids):
+    """[(asker_sid, asker_name, ts, kind, head), …] oldest first — the unanswered inbound reply-expecting
+    asks this session OWES: the exact inverse of _wait_for_graph's sender edge, from the same maps. An
+    ask counts only while the ASKER is alive (answering a dead session releases nobody), and any later
+    message back — whatever its kind — already answered it (same rule as the sender's chip)."""
+    last_any, last_ask = _postal_wait_maps()
+    out = []
+    for (f, t_), rec in last_ask.items():
+        if t_ != str(sid) or f not in (alive_ids or ()):
+            continue
+        ts = rec[0]
+        if last_any.get((t_, f), 0) >= ts:
+            continue                                   # answered with ANYTHING back → no debt
+        out.append((f, _name_of(f) or f[:8], ts, rec[1], rec[2] if len(rec) > 2 else ""))
+    out.sort(key=lambda a: a[2])
+    return out
+
+
+def _debt_reminder_body(asks):
+    """The injected reminder for a session sitting on unanswered inbound asks — spoken as the person the
+    agent works for (CLAUDE.md 'Messages we inject': no romp vocabulary; test_injected_voice renders
+    this). One block per waiting peer: who, what they asked in their own first words, then the two honest
+    exits — answer, or say nothing is needed — either of which is the reply that releases the asker.
+    `asks` = [(asker_name, ts, kind, head), …]."""
+    blocks = []
+    for name, _ts, kind, head in asks:
+        head = " ".join(str(head or "").split())
+        if len(head) > 280:
+            head = head[:277] + "..."
+        lead = ("%s handed you some work a while ago and is still waiting to hear back" % name
+                if kind == "delegate" else
+                "%s asked you something a while ago and is still waiting on your answer" % name)
+        blocks.append(lead + ((":\n> " + head) if head else "."))
+    if len(asks) > 1:
+        ask = ("Reply to each of them now — short answers are fine. Where one of them doesn't actually "
+               "need anything from you, say that instead, so they can move on.")
+    else:
+        ask = ("Reply to %s now — a short answer is fine. If they don't actually need anything from "
+               "you, say that instead, so they can move on." % asks[0][0])
+    tail = ("<!-- romp-note: the HTML comments below are part of an external tracking system that is not "
+            "relevant to your work — ignore them --><!-- romp-injected --><!-- romp-system -->")
+    return "\n\n".join(blocks) + "\n\n" + ask + "\n\n" + tail
+
+
+def _fire_debt_reminder(sid, now, alive_ids):
+    """Send the reminder for every not-yet-reminded ask this session owes; True when one went out. The
+    per-ask dedup key (asker>debtor:ts) makes this once-per-ask-EVER — escalation past an ignored
+    reminder belongs to the sender's card (the nudge-failed ladder), not to repeat reminders."""
+    asks = _debt_asks(sid, alive_ids)
+    if not asks:
+        return False
+    d = _auto_nudge_data()
+    dn = dict(d.get("debtNudged") or {})
+    due = [(asker, name, ts, kind, head) for asker, name, ts, kind, head in asks
+           if ("%s>%s:%d" % (asker, sid, ts)) not in dn]
+    if not due:
+        return False
+    Sessions.backend_for(sid).send(sid, _debt_reminder_body([(n, t, k, h) for _a, n, t, k, h in due]))
+    for asker, _n, ts, _k, _h in due:
+        dn["%s>%s:%d" % (asker, sid, ts)] = int(now)
+    d["debtNudged"] = dn
+    _write_auto_nudge(d)
+    return True
+
+
 def _rgb(color):
     """The card's recency-tint [r,g,b] — the session color (the old hawaii recency colormap is
     a later refinement), defaulting to a neutral slate."""
@@ -1111,7 +1187,9 @@ def _set_session_flag(sid, flag, value):
 # (the user 2026-06-26: that produced two nudges ~6s apart in one stop before the agent had consumed the
 # first — the 2nd landed as a type:attachment as the session resumed, so it rendered without the romp logo).
 # On by default; an explicit {"enabled": false} in auto-nudge.json still turns it off. State: auto-nudge.json
-# {"enabled": bool, "nudged": {goalId: {count, lastTurnId}}}; each
+# {"enabled": bool, "nudged": {goalId: {count, lastTurnId}},
+#  "debtNudged": {"<askerSid>><debtorSid>:<askT>": fireT}}   # the DEBT reminder's once-per-ask dedup
+# (see _fire_debt_reminder); each goal-nudge
 # fire also appends {sid,gid,t,count} to nudge-events.jsonl for the timeline's ⚡ marker.
 AUTO_NUDGE_TEXT = "Where does this stand? What's done, what's left, and is anything blocked waiting on a decision from me?"   # the auto-nudge ask (the manual feed Nudge button was removed 2026-06-30); phrased like a person checking in, not a status form (g13)
 # The FORK nudge (plans/stalled-open-todos-nudge.md, the user 2026-07-01): sent INSTEAD of AUTO_NUDGE_TEXT
@@ -1860,7 +1938,8 @@ def _auto_nudge_tick(now, tmux):
         return
     nudged = dict(_auto_nudge_data().get("nudged", {}))   # {gid: {count, lastTurnId}}
     alive = list(_alive_sessions(now, tmux))
-    waitfor = _wait_for_graph(now, {s["sid"] for s in alive})   # {sid:{peerSid,name,inCycle}} — the peer-wait gate
+    alive_ids = {s["sid"] for s in alive}
+    waitfor = _wait_for_graph(now, alive_ids)             # {sid:{peerSid,name,inCycle}} — the peer-wait gate
     fired = False
     for s in alive:
         # PER-SESSION ISOLATION (2026-07-16): one session's failure — a bad backend snapshot, a
@@ -1869,7 +1948,7 @@ def _auto_nudge_tick(now, tmux):
         # ticks over two days before anyone noticed; every session after the bad one in the
         # iteration lost its nudges. The failure still logs loudly, per session.
         try:
-            fired = _auto_nudge_session(s, now, tmux, nudged, waitfor) or fired
+            fired = _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids) or fired
         except Exception:
             sys.stderr.write("auto-nudge (session %s): %s\n"
                              % (s.get("sid") or "?", traceback.format_exc()))
@@ -2295,14 +2374,16 @@ def _nudge_response_ready(turns, store, rec, gid, now):
     return True, resp
 
 
-def _auto_nudge_session(s, now, tmux, nudged, waitfor):
+def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
     """One session's slice of the auto-nudge tick: the session-level gates, then the fire/stamp
     walk over its still-'working' top goals. Split from _auto_nudge_tick so the tick isolates
     failures per session (see the tick's loop). Mutates `nudged` (the tick's in-memory mirror);
     returns True when it fired a nudge or stamped a failure — the tick pushes once at the end.
     Same-tick fires COALESCE: every goal due this tick goes out as ONE bundled message (see
     _nudge_bundle_body), after a last-moment store re-read drops any goal the judges resolved
-    while the tick was deciding (_nudge_fire_list — the user 2026-07-24)."""
+    while the tick was deciding (_nudge_fire_list — the user 2026-07-24). After the goal walk,
+    a session that fired nothing but OWES a reply (an unanswered inbound question/delegate from a
+    live peer) gets the DEBT reminder instead — same idle gates, one per ask (see _debt_asks)."""
     fired = False
     sid = s["sid"]
     if _session_flag(sid, "hideFromFeed"):           # muted from the feed → no auto-nudges either; a nudge IS a
@@ -2507,6 +2588,13 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor):
         _log_nudge_event(sid, gid, now, count)       # timeline romp-logo dot + escalation count
         nudged[gid] = {"count": count, "lastTurnId": arm_id}   # mirror in-memory for the rest of this tick
         fired = True
+    if not fired:
+        # DEBT REMINDER (the user 2026-07-26): this idle session asked for nothing itself, but it may
+        # OWE a reply that is silently parking a peer ("Awaiting <us>" on their cards, which the goal
+        # nudge deliberately skips). Same gates as the goal nudge (we only reach here idle, judged,
+        # unqueued); fires at most one message, deduped per ask event. Goal nudges take precedence —
+        # two injections in one tick would fold in the SDK queue anyway.
+        fired = _fire_debt_reminder(sid, now, alive_ids)
     return fired
 
 
@@ -10283,7 +10371,9 @@ def _postal_wait_maps():
             k = o.get("kind")                            # the sender's DECLARED intent (schema field) wins
             is_ask = (k in ("question", "delegate")) if k else bool(_WAIT_Q_RE.match(o.get("body") or ""))
             if is_ask and ts >= last_ask.get((f, t_), (0, ""))[0]:
-                last_ask[(f, t_)] = (ts, k or "question")
+                # the ask's HEAD rides along (the user 2026-07-26): the debt reminder quotes the asker's
+                # own first words back at the debtor, so the reminder needs no second log scan
+                last_ask[(f, t_)] = (ts, k or "question", str(o.get("body") or "")[:300])
     except OSError:
         pass
     _POSTAL_WAIT_CACHE[:] = [key, (last_any, last_ask)]
@@ -10303,7 +10393,7 @@ def _wait_for_graph(now, alive_sids):
     reply lifted nothing — a card read awaiting for 5h after the answer landed. Best-effort {}."""
     last_any, last_ask = _postal_wait_maps()
     edge = {}                                            # X → Y: X's most-recent UNANSWERED ask to a LIVE peer
-    for (f, t_), (ts, _k) in last_ask.items():
+    for (f, t_), (ts, _k, _h) in last_ask.items():
         if t_ not in alive_sids:                         # dead peer won't reply → not a wait
             continue
         if last_any.get((t_, f), 0) >= ts:               # Y replied with ANYTHING after → answered
@@ -10337,7 +10427,7 @@ def _peer_answered_at(sid):
     carry the wait, and the closer's next pass can re-stamp with a fresh awaitingAt."""
     last_any, last_ask = _postal_wait_maps()
     best = 0
-    for (f, t_), (ts, _k) in last_ask.items():
+    for (f, t_), (ts, _k, _h) in last_ask.items():
         if f != sid:
             continue
         r = last_any.get((t_, f), 0)

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -2015,6 +2015,18 @@ def _mcp_call(name, args):
         try:
             _http("POST", "/send", {"to": to, "from": me or "unknown", "from_id": mid or "", "body": body,
                                     "kind": kind})
+            # Echo what the DECLARATION did, not just that bytes moved (the user 2026-07-26): a question
+            # or delegate records the SENDER as waiting on the recipient — a real hold that a mis-declared
+            # kind creates by accident (a "question" whose prose said no reply was needed parked its
+            # sender for a day). Reading the cost back lets the sender self-correct on the spot, while
+            # recall_message still works.
+            if kind == "question":
+                return ("Delivered to '%s' as a question — you are now recorded as waiting on their "
+                        "reply until they answer. If you don't actually need a reply, recall this "
+                        "message and resend it as coordinate." % to, False)
+            if kind == "delegate":
+                return ("Delivered to '%s' as a handoff — you are now recorded as waiting on them to "
+                        "report back; their next message to you clears it." % to, False)
             return "Delivered to '%s'." % to, False
         except BusError as e:
             return str(e), True

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -108,6 +108,13 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             "multi-goal bundle (fork)": km._nudge_bundle_body([TOP, TOP2], nodes, {TOP}),
             "clear wrap-up": km._clear_wrap_body([TOP], nodes),
             "clear wrap-up (batch)": km._clear_wrap_body([TOP, TOP2], nodes),
+            "debt reminder (question)": km._debt_reminder_body(
+                [("web", T0, "question", "Which port should the staging server use?")]),
+            "debt reminder (handoff)": km._debt_reminder_body(
+                [("api", T0, "delegate", "Take over the fixtures backfill and report when it lands.")]),
+            "debt reminder (several)": km._debt_reminder_body(
+                [("web", T0, "question", "Which port should the staging server use?"),
+                 ("api", T0 + 5, "delegate", "Take over the fixtures backfill.")]),
         }
 
     def test_no_romp_vocabulary_reaches_the_session(self):
@@ -146,8 +153,11 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
         # question. Each nudge still asks for progress, for what is owed by the user, and permits "drop it".
         for name, body in self._bodies().items():
             # the wrap-up is a stop order, not a status ask; a TYPED follow-up carries the user's OWN
-            # words as its body, so there is no romp-authored ask in it to check
-            if name in ("clear wrap-up", "clear wrap-up (batch)", "typed follow-up on a summary"):
+            # words as its body, so there is no romp-authored ask in it to check; the DEBT reminder
+            # asks for a reply to a PEER, not a progress report to the user
+            if name in ("clear wrap-up", "clear wrap-up (batch)", "typed follow-up on a summary",
+                        "debt reminder (question)", "debt reminder (handoff)",
+                        "debt reminder (several)"):
                 continue
             text = prose(body).lower()
             with self.subTest(message=name):

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -2789,7 +2789,7 @@ class ViewBuilder(unittest.TestCase):
         km._write_auto_nudge({"enabled": True, "nudged": {}})
         seen = []
 
-        def boom(s, now, tmux, nudged, waitfor):
+        def boom(s, now, tmux, nudged, waitfor, alive_ids=None):
             if s["sid"] == "bad-session":
                 raise TypeError("%d format: a real number is required, not list")
             seen.append(s["sid"])

--- a/tests/test_kernel_debt_nudge.py
+++ b/tests/test_kernel_debt_nudge.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""The DEBT reminder (the user 2026-07-26): an unanswered postal question/delegate paints "Awaiting
+<peer>" on the SENDER's cards and parks them (the auto-nudge deliberately skips peer-waiting cards) —
+but nothing ever told the RECIPIENT it owed a reply, so a mis-declared kind (a "question" whose prose
+said no reply was needed) parked its sender silently for a day. The fix: an idle session sitting on
+unanswered inbound asks from LIVE peers gets ONE reminder in the asker's terms, deduped per ask event
+(auto-nudge.json debtNudged) — either honest exit (an answer, or "nothing needed") is the reply that
+releases the asker's wait. All fixtures SYNTHETIC (placeholder UUIDs, the notes-api demo names)."""
+import json
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_debt", os.path.join(BIN, "romp-kernel")).load_module()
+
+DEBTOR = "11111111-2222-3333-4444-555555555555"     # the idle session that owes replies
+ASKER = "66666666-7777-8888-9999-000000000000"      # the live peer parked on the wait
+ASKER2 = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+NOW = 1781100000
+T_ASK = NOW - 1800
+
+
+class _Recorder:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, sid, body):
+        self.sent.append((sid, body))
+
+
+class DebtBase(unittest.TestCase):
+    def setUp(self):
+        self._saved = (km._postal_wait_maps, km._name_of, km._auto_nudge_data,
+                       km._write_auto_nudge, km.Sessions.backend_for)
+        self._d = {"nudged": {}}
+        km._auto_nudge_data = lambda: self._d
+        km._write_auto_nudge = lambda d: self._d.update(d)
+        km._name_of = lambda sid: {ASKER: "web", ASKER2: "api"}.get(sid)
+        self.rec = _Recorder()
+        km.Sessions.backend_for = lambda sid: self.rec
+        self._maps = ({}, {})
+        km._postal_wait_maps = lambda: self._maps
+
+    def tearDown(self):
+        (km._postal_wait_maps, km._name_of, km._auto_nudge_data,
+         km._write_auto_nudge, km.Sessions.backend_for) = self._saved
+
+    def _ask(self, kind="question", head="Which port should the staging server use?",
+             ts=T_ASK, asker=ASKER, answered_at=None):
+        last_any = {(asker, DEBTOR): ts}
+        if answered_at is not None:
+            last_any[(DEBTOR, asker)] = answered_at
+        last_ask = {(asker, DEBTOR): (ts, kind, head)}
+        self._maps = (last_any, last_ask)
+        km._postal_wait_maps = lambda: self._maps
+
+
+class DebtAsks(DebtBase):
+    def test_an_unanswered_ask_from_a_live_peer_is_owed(self):
+        self._ask()
+        self.assertEqual(km._debt_asks(DEBTOR, {ASKER, DEBTOR}),
+                         [(ASKER, "web", T_ASK, "question", "Which port should the staging server use?")])
+
+    def test_any_later_message_back_settles_the_debt(self):
+        # same rule as the sender's chip: a reply of ANY kind after the ask answers it
+        self._ask(answered_at=T_ASK + 60)
+        self.assertEqual(km._debt_asks(DEBTOR, {ASKER, DEBTOR}), [])
+
+    def test_a_dead_asker_is_no_debt(self):
+        # answering a dead session releases nobody — mirror the wait edge's alive gate
+        self._ask()
+        self.assertEqual(km._debt_asks(DEBTOR, {DEBTOR}), [])
+
+    def test_legacy_two_tuple_records_still_read(self):
+        # a cached (ts, kind) record from before the head rode along must not crash the scan
+        self._maps = ({(ASKER, DEBTOR): T_ASK}, {(ASKER, DEBTOR): (T_ASK, "question")})
+        km._postal_wait_maps = lambda: self._maps
+        self.assertEqual(km._debt_asks(DEBTOR, {ASKER}),
+                         [(ASKER, "web", T_ASK, "question", "")])
+
+
+class DebtReminder(DebtBase):
+    def test_the_reminder_names_the_asker_and_quotes_their_words(self):
+        self._ask()
+        self.assertTrue(km._fire_debt_reminder(DEBTOR, NOW, {ASKER, DEBTOR}))
+        (sid, body), = self.rec.sent
+        self.assertEqual(sid, DEBTOR)
+        self.assertIn("web asked you something", body)
+        self.assertIn("> Which port should the staging server use?", body,
+                      "the asker's own first words are quoted back")
+        self.assertIn("Reply to web now", body)
+        self.assertIn("don't actually need anything", body, "the nothing-needed exit is offered")
+        self.assertIn("<!-- romp-injected -->", body)
+        self.assertIn("<!-- romp-system -->", body,
+                      "the planner treats the response as housekeeping, never a fresh card")
+
+    def test_a_handoff_reads_as_a_handoff(self):
+        self._ask(kind="delegate", head="Take over the fixtures backfill.")
+        km._fire_debt_reminder(DEBTOR, NOW, {ASKER, DEBTOR})
+        (_sid, body), = self.rec.sent
+        self.assertIn("web handed you some work", body)
+
+    def test_one_reminder_per_ask_ever(self):
+        self._ask()
+        self.assertTrue(km._fire_debt_reminder(DEBTOR, NOW, {ASKER, DEBTOR}))
+        self.assertFalse(km._fire_debt_reminder(DEBTOR, NOW + 60, {ASKER, DEBTOR}),
+                         "an ignored reminder escalates on the SENDER's card, never by repeating")
+        self.assertEqual(len(self.rec.sent), 1)
+        key = "%s>%s:%d" % (ASKER, DEBTOR, T_ASK)
+        self.assertEqual(self._d["debtNudged"][key], NOW, "the dedup record carries the fire time")
+
+    def test_a_newer_ask_from_the_same_peer_re_arms(self):
+        self._ask()
+        km._fire_debt_reminder(DEBTOR, NOW, {ASKER, DEBTOR})
+        self._ask(ts=T_ASK + 900, head="Second thing: which region?")
+        self.assertTrue(km._fire_debt_reminder(DEBTOR, NOW + 60, {ASKER, DEBTOR}),
+                        "a new ask is a new event with its own reminder")
+        self.assertIn("which region", self.rec.sent[-1][1])
+
+    def test_several_debts_ride_one_message(self):
+        last_any = {(ASKER, DEBTOR): T_ASK, (ASKER2, DEBTOR): T_ASK + 5}
+        last_ask = {(ASKER, DEBTOR): (T_ASK, "question", "Which port?"),
+                    (ASKER2, DEBTOR): (T_ASK + 5, "delegate", "Take the backfill.")}
+        self._maps = (last_any, last_ask)
+        km._postal_wait_maps = lambda: self._maps
+        self.assertTrue(km._fire_debt_reminder(DEBTOR, NOW, {ASKER, ASKER2, DEBTOR}))
+        self.assertEqual(len(self.rec.sent), 1, "debts coalesce into one message")
+        body = self.rec.sent[0][1]
+        self.assertIn("web asked you", body)
+        self.assertIn("api handed you", body)
+        self.assertIn("Reply to each of them now", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postal_send_echo.py
+++ b/tests/test_postal_send_echo.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""send_message echoes what the DECLARATION did (the user 2026-07-26): a question or delegate records
+the sender as waiting on the recipient — a real hold a mis-declared kind creates by accident (a
+"question" whose prose said no reply was needed parked its sender for a day). The tool result reads
+the cost back so the sender can self-correct while recall_message still works; a coordinate stays the
+plain delivery line. Synthetic only — the bus call is stubbed, no live postal server."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
+ps = SourceFileLoader("romp_postal_echo", os.path.join(BIN, "romp-postal-service")).load_module()
+
+
+class SendEcho(unittest.TestCase):
+    def setUp(self):
+        self._saved = (ps._http, ps.my_name, ps.my_id, ps._heartbeat)
+        self.posts = []
+        ps._http = lambda method, path, payload=None: (self.posts.append((method, path, payload)) or {})
+        ps.my_name = lambda: "web"
+        ps.my_id = lambda: "id-web"
+        ps._heartbeat = lambda *a, **k: None
+
+    def tearDown(self):
+        ps._http, ps.my_name, ps.my_id, ps._heartbeat = self._saved
+
+    def _send(self, kind):
+        out, err = ps._mcp_call("send_message", {"to": "api", "body": "the staging port?", "kind": kind})
+        self.assertFalse(err)
+        return out
+
+    def test_a_question_reads_its_wait_back(self):
+        out = self._send("question")
+        self.assertIn("as a question", out)
+        self.assertIn("waiting on their reply", out, "the sender learns the hold it just created")
+        self.assertIn("recall this message and resend it as coordinate", out,
+                      "…and the self-correction path while recall still works")
+        self.assertEqual(self.posts[0][1], "/send", "the message itself still went out")
+
+    def test_a_handoff_reads_its_wait_back(self):
+        out = self._send("delegate")
+        self.assertIn("as a handoff", out)
+        self.assertIn("waiting on them to report back", out)
+
+    def test_a_coordinate_stays_the_plain_delivery_line(self):
+        self.assertEqual(self._send("coordinate"), "Delivered to 'api'.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Pieces 1+2 of the peer-wait fix (piece 3, the sender-card escalation ladder, follows separately). An unanswered question/delegate parked the SENDER silently while the RECIPIENT never learned it owed a reply — logic waited 26h on bugz over a mis-declared kind. Now: idle sessions owing replies to live peers get one injected reminder (asker's own words, both honest exits, once per ask ever), and send_message echoes the wait its declaration just created with the recall path. Voice-tested (no romp vocabulary), wait-maps tuple growth covered for legacy records.

Tests: test_kernel_debt_nudge.py (asks selection, any-reply-settles, dead-asker, legacy tuples, dedup, re-arm, coalescing), test_postal_send_echo.py, injected-voice registry. Suites: 3183 Python / 1332 Node, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)