### PR TITLE
Debt escalation: an ignored reminder flips the asker's card to needs-you

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -7137,13 +7137,28 @@ NUDGE_BLOCK_WHY = ("romp followed up once and the response didn't resolve this; 
                    "it won't be re-asked — it needs your direction")
 INTERRUPT_BLOCK_WHY = "you stopped this session mid-turn — it's waiting on your next instruction"
 _PROCEDURAL_BLOCK_WHYS = (NUDGE_BLOCK_WHY, INTERRUPT_BLOCK_WHY)
+# The DEBT escalation's why (the user 2026-07-26) carries the unresponsive PEER'S NAME, so it can't be an
+# exact constant: the fixed head is the recognizer (kernel debt_block_why builds it; procedural_block_why
+# prefix-matches it). Still kernel-authored bookkeeping — the variable tail is a session name, never
+# user-question text, so the exact-match rationale above holds in spirit: nothing fuzzy, one known shape.
+DEBT_BLOCK_WHY_PREFIX = "No answer from "
+
+
+def debt_block_why(peer):
+    """The block why for a wait whose debtor was reminded and still didn't reply — the whole decision
+    rides the why (ping / reclaim / drop), so the briefer's procedural path applies and no invented
+    decision brief is written."""
+    return ("%s%s despite a reminder — your message to them is still unanswered. "
+            "Ping them again, take the work back, or drop the wait." % (DEBT_BLOCK_WHY_PREFIX, peer))
 
 
 def procedural_block_why(why):
     """True if `why` is romp's own procedural block bookkeeping rather than a decision the user was asked
-    for. EXACT match on the kernel-authored constants: a real question that merely resembles one of these
-    is still a real question, so nothing fuzzy belongs here."""
-    return (why or "").strip() in _PROCEDURAL_BLOCK_WHYS
+    for. EXACT match on the kernel-authored constants — plus the ONE prefix-recognized shape above (its
+    tail is a peer name, not question text): a real question that merely resembles one of these is still
+    a real question, so nothing fuzzy belongs here."""
+    w = (why or "").strip()
+    return w in _PROCEDURAL_BLOCK_WHYS or w.startswith(DEBT_BLOCK_WHY_PREFIX)
 
 
 # The BLOCK-DISTILLER (the user 2026-06-18, via business): the done-distiller's twin for a BLOCKED top.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -816,6 +816,104 @@ def _fire_debt_reminder(sid, now, alive_ids):
     return True
 
 
+def _debt_key_parse(key):
+    """(asker, debtor, ask_ts) from a debtNudged key ("asker>debtor:ts"), or None on a malformed one."""
+    try:
+        pair, ts = str(key).rsplit(":", 1)
+        asker, debtor = pair.split(">", 1)
+        return asker, debtor, int(ts)
+    except ValueError:
+        return None
+
+
+def _debt_escalate(asker, debtor, ask_ts, now):
+    """The reminder FAILED — the debtor had its say (or never came back) and the ask is still unanswered,
+    so the wait now genuinely needs the USER: flip the ASKER's newest still-waiting card to blocked
+    through the normal ladder (the _mark_nudge_failed precedent: verdict + journal + rollup; the why is
+    the whole decision — ping / reclaim / drop — and its fixed head reads as procedural to the briefer,
+    so no decision brief is invented). The card chosen is the newest open working TOP minted at/before
+    the ask — the same population the peer-wait chip paints. True when a block landed."""
+    try:
+        store = jd.load_goals(asker)
+        nodes, status = store.get("nodes", {}), store.get("status", {})
+        cands = [nd for gid, nd in nodes.items()
+                 if nd.get("parentId") is None and status.get(gid) == "working"
+                 and not nd.get("blocked") and not nd.get("cleared") and not nd.get("nodeComplete")
+                 and (nd.get("t") or 0) <= ask_ts]
+        if not cands:
+            return False
+        nd = max(cands, key=lambda n: n.get("t") or 0)
+        why = jd.debt_block_why(_name_of(debtor) or str(debtor)[:8])
+        if jd.record_verdict(store, nd, "nudge", "block", int(now), why=why):
+            nd["mt"] = int(now)                        # the event materialized blocked + blockWhy
+            jd.append_block(asker, nd["id"], "nudge", why, int(now))   # journal outlives judge-pass saves
+            jd.rollup_status(store, False)
+            jd.save_goals(asker, store)
+            _mark_views_dirty()
+            return True
+    except Exception:
+        sys.stderr.write("debt-escalate (%s waiting on %s): %s\n" % (asker, debtor, traceback.format_exc()))
+    return False
+
+
+def _debt_reminder_outcomes(sid, lt, now):
+    """Judge this DEBTOR's past reminders at their exact outcome events, both once-ever: an ANSWERED ask
+    retires its record silently (the reminder worked), and an ask still unanswered after a turn of the
+    debtor's ENDED past the reminder's fire escalates to the asker's card and retires — the debtor had
+    its chance and moved on without replying (the reminder's own response turn included: both honest
+    exits it offered were postal replies, so a reply-less end IS the failure). A debtor that never turns
+    again is the backstop's case (_debt_backstop_tick)."""
+    d = _auto_nudge_data()
+    dn = dict(d.get("debtNudged") or {})
+    if not dn:
+        return
+    last_any, _ask = _postal_wait_maps()
+    lt_end = (lt.get("end", lt.get("t", 0)) or 0) if lt else 0
+    changed = False
+    for key, fire_t in list(dn.items()):
+        parsed = _debt_key_parse(key)
+        if not parsed or parsed[1] != sid:
+            continue
+        asker, _debtor, ts = parsed
+        if last_any.get((sid, asker), 0) >= ts:        # answered → the reminder worked
+            dn.pop(key); changed = True
+            continue
+        if isinstance(fire_t, (int, float)) and lt_end > fire_t:
+            _debt_escalate(asker, sid, ts, now)        # moved on without replying → the user's turn
+            dn.pop(key); changed = True
+    if changed:
+        d["debtNudged"] = dn
+        _write_auto_nudge(d)
+
+
+def _debt_backstop_tick(now):
+    """The reminder-outcome sweep for debtors the per-session walk can't reach — dead sessions, or one
+    idling forever on its reminder: past the same backstop the awaiting/deferral machinery uses, an
+    unanswered reminder escalates (or, if answered meanwhile, retires) regardless. Mirrors
+    AWAITING_BACKSTOP_SECS' rationale: a missing event, surfaced rather than waited on forever."""
+    d = _auto_nudge_data()
+    dn = dict(d.get("debtNudged") or {})
+    if not dn:
+        return
+    last_any, _ask = _postal_wait_maps()
+    changed = False
+    for key, fire_t in list(dn.items()):
+        parsed = _debt_key_parse(key)
+        if not parsed:
+            dn.pop(key); changed = True                # malformed → drop rather than loop on it forever
+            continue
+        asker, debtor, ts = parsed
+        if last_any.get((debtor, asker), 0) >= ts:
+            dn.pop(key); changed = True
+            continue
+        if isinstance(fire_t, (int, float)) and now - fire_t > NUDGE_DEFER_BACKSTOP_SECS:
+            _debt_escalate(asker, debtor, ts, now)
+            dn.pop(key); changed = True
+    if changed:
+        d["debtNudged"] = dn
+        _write_auto_nudge(d)
+
+
 def _rgb(color):
     """The card's recency-tint [r,g,b] — the session color (the old hawaii recency colormap is
     a later refinement), defaulting to a neutral slate."""
@@ -1952,6 +2050,10 @@ def _auto_nudge_tick(now, tmux):
         except Exception:
             sys.stderr.write("auto-nudge (session %s): %s\n"
                              % (s.get("sid") or "?", traceback.format_exc()))
+    try:
+        _debt_backstop_tick(now)                       # reminder outcomes for debtors the walk can't reach
+    except Exception:
+        sys.stderr.write("debt-backstop: %s\n" % traceback.format_exc())
     if fired:
         _push_all()
 
@@ -2593,7 +2695,10 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
         # OWE a reply that is silently parking a peer ("Awaiting <us>" on their cards, which the goal
         # nudge deliberately skips). Same gates as the goal nudge (we only reach here idle, judged,
         # unqueued); fires at most one message, deduped per ask event. Goal nudges take precedence —
-        # two injections in one tick would fold in the SDK queue anyway.
+        # two injections in one tick would fold in the SDK queue anyway. PAST reminders are judged
+        # first at their exact outcome event (answered → retire; moved on without replying → escalate
+        # to the asker's card), so a failed reminder never just evaporates.
+        _debt_reminder_outcomes(sid, lt, now)
         fired = _fire_debt_reminder(sid, now, alive_ids)
     return fired
 

--- a/tests/test_kernel_debt_nudge.py
+++ b/tests/test_kernel_debt_nudge.py
@@ -38,7 +38,7 @@ class DebtBase(unittest.TestCase):
         self._d = {"nudged": {}}
         km._auto_nudge_data = lambda: self._d
         km._write_auto_nudge = lambda d: self._d.update(d)
-        km._name_of = lambda sid: {ASKER: "web", ASKER2: "api"}.get(sid)
+        km._name_of = lambda sid: {ASKER: "web", ASKER2: "api", DEBTOR: "tests"}.get(sid)
         self.rec = _Recorder()
         km.Sessions.backend_for = lambda sid: self.rec
         self._maps = ({}, {})
@@ -132,6 +132,121 @@ class DebtReminder(DebtBase):
         self.assertIn("web asked you", body)
         self.assertIn("api handed you", body)
         self.assertIn("Reply to each of them now", body)
+
+
+class ReminderOutcomes(DebtBase):
+    """Piece 3, the outcome side: a past reminder either WORKED (any reply back retires it silently) or
+    FAILED (the debtor ended a turn past the fire without replying → the ASKER's card escalates), each
+    judged once-ever. The debtor-never-returns case rides the backstop tick."""
+
+    def setUp(self):
+        super().setUp()
+        self._esc = []
+        self._saved_esc = km._debt_escalate
+        km._debt_escalate = lambda asker, debtor, ts, now: (self._esc.append((asker, debtor, ts)) or True)
+        self._key = "%s>%s:%d" % (ASKER, DEBTOR, T_ASK)
+
+    def tearDown(self):
+        km._debt_escalate = self._saved_esc
+        super().tearDown()
+
+    def _armed(self, fire_t=NOW - 600):
+        self._d["debtNudged"] = {self._key: fire_t}
+
+    def test_an_answered_reminder_retires_silently(self):
+        self._ask(answered_at=T_ASK + 60)
+        self._armed()
+        km._debt_reminder_outcomes(DEBTOR, {"t": NOW - 100, "end": NOW - 90}, NOW)
+        self.assertEqual(self._d["debtNudged"], {}, "the reminder worked; nothing escalates")
+        self.assertEqual(self._esc, [])
+
+    def test_moving_on_without_replying_escalates_once(self):
+        self._ask()
+        self._armed(fire_t=NOW - 600)
+        lt = {"t": NOW - 300, "end": NOW - 200}        # a turn ENDED after the fire, still no reply
+        km._debt_reminder_outcomes(DEBTOR, lt, NOW)
+        self.assertEqual(self._esc, [(ASKER, DEBTOR, T_ASK)], "the wait is now the user's")
+        self.assertEqual(self._d["debtNudged"], {}, "…and the record retires (once-ever)")
+
+    def test_no_turn_since_the_fire_keeps_waiting(self):
+        self._ask()
+        self._armed(fire_t=NOW - 600)
+        lt = {"t": NOW - 3000, "end": NOW - 2900}      # latest ended turn PREDATES the fire
+        km._debt_reminder_outcomes(DEBTOR, lt, NOW)
+        self.assertEqual(self._esc, [])
+        self.assertIn(self._key, self._d["debtNudged"], "the debtor hasn't had its say yet")
+
+    def test_the_backstop_escalates_a_debtor_that_never_returns(self):
+        self._ask()
+        self._armed(fire_t=NOW - km.NUDGE_DEFER_BACKSTOP_SECS - 60)
+        km._debt_backstop_tick(NOW)
+        self.assertEqual(self._esc, [(ASKER, DEBTOR, T_ASK)])
+        self.assertEqual(self._d["debtNudged"], {})
+
+    def test_the_backstop_leaves_a_young_reminder_alone(self):
+        self._ask()
+        self._armed(fire_t=NOW - 600)
+        km._debt_backstop_tick(NOW)
+        self.assertEqual(self._esc, [])
+        self.assertIn(self._key, self._d["debtNudged"])
+
+    def test_the_backstop_drops_a_malformed_key(self):
+        self._d["debtNudged"] = {"not-a-key": NOW - 600}
+        km._debt_backstop_tick(NOW)
+        self.assertEqual(self._d["debtNudged"], {}, "malformed records drop rather than loop forever")
+
+
+class DebtEscalate(DebtBase):
+    """The block itself, on a real (sandboxed) store: newest eligible waiting top, procedural why naming
+    the debtor, through record_verdict + journal like the nudge-failed precedent."""
+
+    def setUp(self):
+        super().setUp()
+        import tempfile
+        from pathlib import Path
+        self._td = tempfile.TemporaryDirectory()
+        jd = km.jd
+        # _rebind_state, NEVER bare GOALDIR/STATE reassignment: the override journal lives at the store
+        # tree's PARENT, so a GOALDIR pointed at a bare tmpdir root shares $TMPDIR/overrides with every
+        # other run on the machine — one test's block row then replays into all of them (found live,
+        # 2026-07-27, as a phantom pre-blocked node in this very class).
+        self._saved_state = jd.STATE
+        jd._rebind_state(Path(self._td.name))
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        top_old = {"id": ASKER + ":g1", "text": "Ship the notes API", "parentId": None, "t": T_ASK - 900,
+                   "mt": T_ASK - 900, "nodeComplete": False, "blocked": False, "cleared": False, "log": []}
+        top_new = {"id": ASKER + ":g2", "text": "Started after the ask", "parentId": None, "t": T_ASK + 60,
+                   "mt": T_ASK + 60, "nodeComplete": False, "blocked": False, "cleared": False, "log": []}
+        store = {"rompUuid": ASKER, "seq": 2, "placements": {},
+                 "status": {top_old["id"]: "working", top_new["id"]: "working"},
+                 "nodes": {top_old["id"]: top_old, top_new["id"]: top_new}}
+        (jd.GOALDIR / (ASKER + ".json")).write_text(json.dumps(store))
+
+    def tearDown(self):
+        km.jd._rebind_state(self._saved_state)
+        self._td.cleanup()
+        super().tearDown()
+
+    def test_the_newest_waiting_top_blocks_with_a_procedural_why(self):
+        self.assertTrue(km._debt_escalate(ASKER, DEBTOR, T_ASK, NOW))
+        store = km.jd.load_goals(ASKER)
+        old, new = store["nodes"][ASKER + ":g1"], store["nodes"][ASKER + ":g2"]
+        self.assertTrue(old["blocked"], "the newest top minted at/before the ask carries the block")
+        self.assertFalse(new["blocked"], "a top minted AFTER the ask can't be waiting on it")
+        why = old.get("blockWhy") or ""
+        self.assertIn("tests", why, "the unresponsive debtor is named")
+        self.assertIn("despite a reminder", why)
+        self.assertTrue(km.jd.procedural_block_why(why),
+                        "the fixed head reads as procedural — no invented decision brief")
+
+    def test_nothing_eligible_is_a_quiet_no_op(self):
+        import json as _json
+        p = km.jd.GOALDIR / (ASKER + ".json")
+        s = _json.loads(p.read_text())
+        for nd in s["nodes"].values():
+            nd["nodeComplete"] = True
+        p.write_text(_json.dumps(s))
+        self.assertFalse(km._debt_escalate(ASKER, DEBTOR, T_ASK, NOW))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Piece 3, completing the peer-wait fix. An ignored debt reminder escalates the wait to the ASKER's newest still-waiting card via the nudge-failed ladder — event-exact (debtor ended a turn past the fire without replying) with a 6h backstop for debtors that never return; answered asks retire records silently. The why names the peer, carries the full decision, and is prefix-recognized as procedural so no brief is invented.

Tests: outcome retirement/escalation/no-turn-yet, backstop young/old/malformed, the real-store block path (newest eligible top, procedural why), quiet no-op. Suites: 3193 Python / 1332 Node, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)