### PR TITLE
Trust pairs: show both directions, Match mirrors through the tunnel

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4445,6 +4445,18 @@ def _bus_remote_holds():
     return _bus_peers_snap().get("remoteHolds") or []
 
 
+def _bus_peer_tiers():
+    """{host: tier} — how each peer bus holds THIS machine's mail, from its exchange declaration
+    (bus my_tier_of, gossiped every exchange). Display-only: lets the popover show both directions
+    of a trust pair, so a half-open pair is visible before mail quarantines (the user 2026-07-26).
+    Empty when the bus is down, peering is off, or a peer predates the tier field."""
+    out = {}
+    for h, p in (_bus_peers_snap().get("peers") or {}).items():
+        if isinstance(p, dict) and p.get("theirTier"):
+            out[h] = p["theirTier"]
+    return out
+
+
 def _bus_quarantine_act(body):
     """Proxy a quarantine verdict (approve/deny, optional edited text) to the bus, which OWNS postal
     delivery and the held-message store. On approve the bus re-runs the peer's deliver(), so an approved
@@ -4538,6 +4550,40 @@ def set_trust(host, level):
     _tunnel_wake.set()                     # a prompt supervisor pass pushes the new level to the bus
     with _remotes_lock:
         return (_remote_public(_remotes[host]) if host in _remotes else None), None
+
+
+def mirror_trust(host):
+    """Set OUR current trust level for `host` as ITS trust level for US — through the admin access the
+    user already holds on that machine (the attached tunnel's local forward + that machine's serve
+    token, the same-user trust boundary). This is the deliberate alternative to protocol-level
+    reciprocity (the user 2026-07-26): a peer must NEVER be able to open our gate by declaring trust,
+    so the only mirror is the human with both tokens acting on both kernels. The remote's own
+    /tunnels/trust route does the persisting there (remotes row or origin-trust known entry), so the
+    mirrored level survives that machine's restarts exactly like a locally-set one.
+    Returns ({host, trust}, None) or (None, error)."""
+    host = (host or "").strip()
+    with _remotes_lock:
+        r = dict(_remotes.get(host) or {})
+    if not r:
+        return None, "no attached tunnel to '%s' — set trust from that machine's own dashboard" % host
+    level = r.get("trust") or "directed"
+    port, tok = r.get("local_port") or 0, r.get("token") or ""
+    if not port or not tok:
+        return None, "no admin path to '%s' (missing forward or token) — set trust from its dashboard" % host
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", int(port), timeout=8)
+        conn.request("POST", "/tunnels/trust",
+                     json.dumps({"host": _self_host(), "trust": level}),
+                     {"Content-Type": "application/json", "X-Romp-Token": tok})
+        resp = conn.getresponse()
+        data = resp.read()
+        conn.close()
+        j = json.loads(data.decode() or "{}")
+    except Exception as e:
+        return None, "could not reach %s's kernel: %s" % (host, e)
+    if not j.get("ok"):
+        return None, j.get("error") or ("HTTP %s from %s" % (resp.status, host))
+    return {"host": host, "trust": level}, None
 
 
 def _checkin_payload(r):
@@ -14325,7 +14371,7 @@ paintIcon(ts.some(function(t){return t.status==='up';}),busy||!!pushing.length);
 icon.title=ts.length?('Remote kernels\\n'+ts.map(function(t){var n=(t.sids&&t.sids.length)||0;
 var ap=t.autoPush?('\\n    auto-update: '+(t.autoPush.detail||t.autoPush.phase)):'';
 return '\\u2022 '+t.host+': '+(LBL[t.status]||t.status)+' ('+n+' session'+(n===1?'':'s')+')'+(t.token?'':' \\u00b7 no token')+ap;}).join('\\n')):'Remote kernels \\u2014 none attached (click to connect)';
-if(!back.hidden)render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[],(d&&d.remoteHolds)||[]);   // pmode is refresh-local — render must be GIVEN it
+if(!back.hidden)render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[],(d&&d.remoteHolds)||[],(d&&d.peerTiers)||{});   // pmode is refresh-local — render must be GIVEN it
 // while any tunnel is mid-attach, poll fast so the phase words (authorizing -> connecting -> connected)
 // are actually visible in the couple seconds it takes; settle to a slow keep-alive once all up/down.
 schedule((busy||pushing.length)?600:3000);   // poll fast while an auto-push runs, so its progress reads live
@@ -14341,7 +14387,7 @@ schedule(3000);});}
 // as a free variable threw ReferenceError on EVERY render, after list.innerHTML='' had already cleared the
 // list and before any row was appended. The panel therefore showed an empty host list no matter how many
 // hosts were attached, and the bare catch swallowed the error (the user 2026-07-22). Take it as a param.
-function render(ts,known,pmode,via,rholds){list.innerHTML='';known=known||[];via=via||[];rholds=rholds||[];
+function render(ts,known,pmode,via,rholds,tiers){list.innerHTML='';known=known||[];via=via||[];rholds=rholds||[];tiers=tiers||{};
 // Attached rows win; a via/known row for an attached host would be a duplicate.
 var live={};ts.forEach(function(t){live[t.host]=1;});
 // "connect from" (attach-on-behalf, the user 2026-07-25): offer every CONNECTED host as a tunnel
@@ -14400,6 +14446,15 @@ var keep=(pmode&&!t.checkinPeer)?'<label class=rnet-keep title=\"Publish this ma
 var tcur=t.trust||'directed';
 var trust='<span class=rnet-set><span class=rnet-lbl>Their mail</span><select class=rnet-trust data-t=\"'+t.host+'\" title=\"What happens to postal mail from '+t.host+'. trusted: delivered straight to your sessions. directed: held for your approval. isolated: none, dashboard only.\">'+
 ['trusted','directed','isolated'].map(function(v){return '<option value='+v+(tcur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select></span>';
+// The OTHER direction of the pair (how that host holds mail FROM this machine, declared by its bus on
+// the last exchange). Trust is receiver-evaluated on purpose, so a half-open pair is legal — but it
+// used to be invisible until mail quarantined over there (the user 2026-07-26). A mismatch offers
+// Match: done by YOU on that kernel through the tunnel + its own serve token; a peer can never set
+// your trust, and this machine never lets one.
+var theirs=tiers[t.host]||'';
+if(theirs){var mm=theirs!==tcur;
+trust+='<span class=\"rnet-back'+(mm?' rnet-mismatch':'')+'\" title=\"How '+t.host+' holds mail from this machine, as its bus declared on the last exchange. Each side owns its own gate.\">'+t.host+' holds yours: '+theirs+'</span>';
+if(mm){trust+='<button class=rnet-mirror data-m=\"'+t.host+'\" title=\"Set '+t.host+'\\u2019s level for this machine to '+tcur+' too. This is your admin access (the tunnel + that machine\\u2019s own token) acting on its kernel \\u2014 a peer can never set your trust, and this never lets one.\">Match ('+tcur+')</button>';}}
 // Line 1 is what this host is doing right now plus the acts you perform on it; line 2 is the pair of
 // settings you set once and leave. They shared a single flat row before, which gave Detach the same
 // weight as a dropdown, and on a phone pushed it off the edge entirely.
@@ -14467,6 +14522,10 @@ list.querySelectorAll('select[data-t]').forEach(function(s){s.onchange=function(
 s.disabled=true;fetch('/tunnels/trust',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h,trust:s.value})}).then(function(r){return r.json();}).then(function(d){
 if(!(d&&d.ok)){alert('trust change on '+h+' failed: '+((d&&d.error)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
 s.disabled=false;refresh();}).catch(function(){s.disabled=false;alert('trust change on '+h+' failed to reach the kernel.');});};});
+list.querySelectorAll('button[data-m]').forEach(function(b){b.onclick=function(){var h=b.getAttribute('data-m');
+b.disabled=true;b.textContent='Matching\\u2026';fetch('/tunnels/trust-mirror',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h})}).then(function(r){return r.json();}).then(function(d){
+if(!(d&&d.ok)){alert('trust match on '+h+' failed: '+((d&&d.error)||'unknown'));b.disabled=false;b.textContent='Match';return;}   // fail LOUDLY (CLAUDE.md)
+b.textContent='Matched';refresh();}).catch(function(){b.disabled=false;b.textContent='Match';alert('trust match on '+h+' failed to reach the kernel.');});};});
 list.querySelectorAll('input[data-k]').forEach(function(c){c.onchange=function(){var h=c.getAttribute('data-k');
 c.disabled=true;fetch('/tunnels/checkin',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h,on:c.checked})}).then(function(r){return r.json();}).then(function(d){
 if(!(d&&d.ok)){c.checked=!c.checked;alert('keep-connected on '+h+' failed: '+((d&&d.error)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
@@ -14884,6 +14943,13 @@ def _landing():
             ".rnet-row2{display:flex;align-items:center;flex-wrap:wrap;gap:8px 14px;margin:4px 0 0 14px}"
             ".rnet-set{display:flex;align-items:center;gap:5px;color:#6e7681;font-size:11px;white-space:nowrap}"
             ".rnet-lbl{color:#6e7681;font-size:11px}"
+            # The reverse trust direction (how THAT host holds this machine's mail) + the Match button.
+            # A mismatched pair is the state that used to be invisible until mail quarantined, so it
+            # wears a warm tint; matched reads as quiet metadata.
+            ".rnet-back{color:#6e7681;font-size:11px;white-space:nowrap}"
+            ".rnet-back.rnet-mismatch{color:#d29922}"
+            ".rnet-mirror{background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:6px;padding:1px 7px;font-size:11px;cursor:pointer}"
+            ".rnet-mirror:disabled{opacity:0.55;cursor:default}"
             ".rnet-dot{width:7px;height:7px;border-radius:50%;flex:0 0 auto}"
             ".rnet-row .nm{flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}"
             ".rnet-row .st{color:#999;font-size:11px}"
@@ -15492,6 +15558,7 @@ class Handler(BaseHTTPRequestHandler):
                                                    "viaReach": _bus_via_reach(),   # hosts one relay hop away (trust-by-origin rows hang here)
                                                    "remoteHolds": _bus_remote_holds(),   # quarantine holds on OTHER machines (direct peers + one relay hop)
                                                    "autoUpdate": _auto_update_remotes_on(),   # the popover checkbox reflects the KERNEL, not this tab
+                                                   "peerTiers": _bus_peer_tiers(),   # host → how IT holds OUR mail (both-direction display)
                                                    "peersMode": _postal_peers_on()}),
                                   "application/json", cache="no-cache")
             # HTML pages are served no-cache so a reload always gets the freshest markup — which carries
@@ -15857,6 +15924,22 @@ class Handler(BaseHTTPRequestHandler):
                     code = 404 if err.startswith("no attached") else 400
                     return self._send(code, json.dumps({"ok": False, "error": err}), "application/json")
                 return self._send(200, json.dumps({"ok": True, "tunnel": pub}), "application/json")
+            if u.path == "/tunnels/trust-mirror":
+                # Mirror OUR trust level for a host onto THAT host (its trust of us), via the tunnel +
+                # its serve token — the human with both tokens acting on both kernels, never the peer
+                # asking (the user 2026-07-26). Body: {"host"}.
+                try:
+                    body = json.loads(raw_body or b"{}")
+                except Exception:
+                    body = None
+                host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
+                if not host:
+                    return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
+                res, err = mirror_trust(host)
+                if err:
+                    code = 404 if err.startswith("no attached") else 502
+                    return self._send(code, json.dumps({"ok": False, "error": err}), "application/json")
+                return self._send(200, json.dumps({"ok": True, "mirrored": res}), "application/json")
             if u.path == "/checkin":
                 # A mobile machine's check-in handshake arriving through its own reverse forward.
                 try:

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1362,9 +1362,28 @@ def remote_holds():
             out.append(dict(hd, atHost=hd.get("via") or h))
     return out
 
+def my_tier_of(host):
+    """The trust tier THIS bus applies to `host`'s direct mail — what _relay_in resolves for a
+    token-proven direct relay (an exchange partner has, by definition, shown our serve token): an
+    explicit row wins; a row without a level reads directed; no row at all reads trusted (the
+    token-proven default). Declared to the peer in every exchange so each side can SHOW how the other
+    holds it (the user 2026-07-26: a half-open pair was invisible until mail quarantined) — display
+    and mirroring ride this; the GATE itself stays _relay_in's, receiver-evaluated, always."""
+    row = PEERS.get(host)
+    if row is None:
+        return "trusted"
+    return row.get("trust") or "directed"
+
+
 def peers_snapshot():
-    return {"peers": {h: dict(p) for h, p in PEERS.items()}, "viaReach": via_reach(),
-            "remoteHolds": remote_holds()}
+    peers = {}
+    for h, p in PEERS.items():
+        d = dict(p)
+        tt = (PEER_STATE.get(h) or {}).get("theirTier")
+        if tt:
+            d["theirTier"] = tt        # how that host holds US, from its last exchange declaration
+        peers[h] = d
+    return {"peers": peers, "viaReach": via_reach(), "remoteHolds": remote_holds()}
 
 # ── peering protocol (peer-bus mode, stage 2) ───────────────────────────────────
 # One EXCHANGE carries both directions (plans/postal-peer-buses.md): the dialer POSTs
@@ -1696,6 +1715,8 @@ def peer_exchange_handle(data):
                 % ((data or {}).get("proto"), PEER_PROTO), "proto": PEER_PROTO}, 409
     PEER_STATE[host] = {"presence": data.get("presence") or [], "epoch": data.get("epoch"),
                         "holds": data.get("holds") or [], "seenAt": int(time.time())}
+    if data.get("tier"):                             # the dialer's declared tier-of-us (additive; older peers omit it)
+        PEER_STATE[host]["theirTier"] = str(data["tier"])
     for mid in data.get("acks") or []:               # the dialer confirmed relays landed — end-to-end:
         _ack_arrived(host, mid)                      # a forwarded one relays its ack back to the origin
     for b in data.get("bounces") or []:              # ...or refused them → backward, or to our sender
@@ -1727,6 +1748,7 @@ def peer_exchange_handle(data):
         acks, bounces = acks + a2, bounces + b2
     return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO,
             "presence": fleet_presence(host), "holds": holds_payload(host),
+            "tier": my_tier_of(host),                # how WE hold the dialer's mail (display/mirror, never the gate)
             "relays": rel, "acks": acks, "bounces": bounces}, 200
 
 def build_exchange_request(host, wait=True):
@@ -1735,6 +1757,7 @@ def build_exchange_request(host, wait=True):
         acks, bounces = list(p["acks"]), list(p["bounces"])
     return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO,
             "presence": fleet_presence(host), "holds": holds_payload(host),
+            "tier": my_tier_of(host),                # how WE hold the dialed host's mail
             "relays": outbox_list(host),
             "acks": acks, "bounces": bounces, "wait": bool(wait)}
 
@@ -1747,6 +1770,8 @@ def peer_exchange_apply(host, req_sent, resp):
         p["bounces"] = [b for b in p["bounces"] if b not in (req_sent.get("bounces") or [])]
     PEER_STATE[host] = {"presence": resp.get("presence") or [], "epoch": resp.get("epoch"),
                         "holds": resp.get("holds") or [], "seenAt": int(time.time())}
+    if resp.get("tier"):                             # the dialed side's declared tier-of-us
+        PEER_STATE[host]["theirTier"] = str(resp["tier"])
     for mid in resp.get("acks") or []:
         _ack_arrived(host, mid)
     for b in resp.get("bounces") or []:

--- a/tests/test_kernel_trust.py
+++ b/tests/test_kernel_trust.py
@@ -200,5 +200,63 @@ class QuarantineCards(unittest.TestCase):
         self.assertEqual(km._quarantine_cards(2000, set()), [])
 
 
+class MirrorTrust(unittest.TestCase):
+    """mirror_trust (the user 2026-07-26): sets OUR level for a host as ITS level for US, through the
+    tunnel forward + that machine's serve token — the human with both tokens acting on both kernels.
+    Deliberately the ONLY reciprocity: a peer can never open our gate by declaring trust."""
+
+    def tearDown(self):
+        with km._remotes_lock:
+            km._remotes.pop("boxa", None)
+
+    def _stub_remote(self, seen):
+        from http.server import BaseHTTPRequestHandler
+
+        class H(BaseHTTPRequestHandler):
+            def do_POST(self):
+                seen["path"] = self.path
+                seen["token"] = self.headers.get("X-Romp-Token")
+                seen["body"] = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
+                out = json.dumps({"ok": True}).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(out)))
+                self.end_headers()
+                self.wfile.write(out)
+
+            def log_message(self, *a):
+                pass
+
+        srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        self.addCleanup(srv.shutdown)
+        return srv.server_address[1]
+
+    def test_mirror_posts_our_level_through_the_tunnel_with_the_remote_token(self):
+        seen = {}
+        port = self._stub_remote(seen)
+        with km._remotes_lock:
+            km._remotes["boxa"] = _row("boxa", local_port=port, token="remote-tok", trust="trusted")
+        res, err = km.mirror_trust("boxa")
+        self.assertIsNone(err)
+        self.assertEqual(res, {"host": "boxa", "trust": "trusted"})
+        self.assertEqual(seen["path"], "/tunnels/trust", "the remote's own persisting route does the write")
+        self.assertEqual(seen["token"], "remote-tok", "authorized with THAT machine's serve token")
+        self.assertEqual(seen["body"], {"host": km._self_host(), "trust": "trusted"},
+                         "the remote is told to hold THIS machine at our current level")
+
+    def test_mirror_without_a_tunnel_errors_plainly(self):
+        res, err = km.mirror_trust("nosuchhost")
+        self.assertIsNone(res)
+        self.assertTrue(err.startswith("no attached"), err)
+
+    def test_mirror_without_a_token_errors_plainly(self):
+        with km._remotes_lock:
+            km._remotes["boxa"] = _row("boxa", local_port=1, token="", trust="trusted")
+        res, err = km.mirror_trust("boxa")
+        self.assertIsNone(res)
+        self.assertIn("no admin path", err)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_postal_peer_tier.py
+++ b/tests/test_postal_peer_tier.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""The exchange declares each side's trust tier (the user 2026-07-26): every peer-bus exchange carries
+`tier` = how the sender holds the OTHER side's direct mail (bus `my_tier_of`), and each side stores the
+peer's declaration as PEER_STATE theirTier — surfaced by peers_snapshot so the popover can show BOTH
+directions of a trust pair (a half-open pair used to be invisible until mail quarantined). Display and
+mirroring only: the delivery gate stays _relay_in's, receiver-evaluated, always.
+
+Synthetic only — hermetic temp state dir, placeholder hostnames, invented notes-domain sessions."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+_SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
+Path(_SESS).write_text(json.dumps([{"id": "sess-web", "name": "web", "dir": "/tmp/notes-api",
+                                    "state": "waiting", "working": ""}]))
+os.environ["ROMP_SESSIONS_FILE"] = _SESS
+ps = SourceFileLoader("romp_postal_tier", os.path.join(BIN, "romp-postal-service")).load_module()
+
+
+def _req(host, tier=None):
+    r = {"host": host, "epoch": 1, "proto": ps.PEER_PROTO, "presence": [], "holds": [],
+         "relays": [], "acks": [], "bounces": [], "wait": False}
+    if tier:
+        r["tier"] = tier
+    return r
+
+
+class TierDeclaration(unittest.TestCase):
+    def setUp(self):
+        os.environ["ROMP_POSTAL_PEERS"] = "1"
+        ps.PEERS.clear()
+        ps.PEER_STATE.clear()
+
+    def tearDown(self):
+        os.environ.pop("ROMP_POSTAL_PEERS", None)
+
+    def test_my_tier_of_matches_the_gate_resolution(self):
+        self.assertEqual(ps.my_tier_of("STRANGER"), "trusted",
+                         "no row + token-proven exchange partner = the gate's trusted default")
+        ps.peer_update({"host": "HELD", "port": 1, "up": True, "trust": "directed"})
+        self.assertEqual(ps.my_tier_of("HELD"), "directed")
+        ps.peer_update({"host": "OPEN", "port": 2, "up": True, "trust": "trusted"})
+        self.assertEqual(ps.my_tier_of("OPEN"), "trusted")
+
+    def test_exchange_response_declares_our_tier_and_stores_theirs(self):
+        ps.peer_update({"host": "BOXA", "port": 1, "up": True, "trust": "directed"})
+        resp, status = ps.peer_exchange_handle(_req("BOXA", tier="trusted"))
+        self.assertEqual(status, 200)
+        self.assertEqual(resp["tier"], "directed", "the dialed side declares how it holds the dialer")
+        self.assertEqual(ps.PEER_STATE["BOXA"]["theirTier"], "trusted",
+                         "the dialer's declaration of how it holds US is stored")
+
+    def test_request_carries_tier_and_apply_stores_the_responders(self):
+        ps.peer_update({"host": "BOXB", "port": 1, "up": True, "trust": "trusted"})
+        req = ps.build_exchange_request("BOXB", wait=False)
+        self.assertEqual(req["tier"], "trusted")
+        ps.peer_exchange_apply("BOXB", req, dict(_req("BOXB"), tier="directed", relays=[]))
+        self.assertEqual(ps.PEER_STATE["BOXB"]["theirTier"], "directed")
+
+    def test_older_peer_without_the_field_stores_nothing(self):
+        ps.peer_update({"host": "OLDPEER", "port": 1, "up": True, "trust": "trusted"})
+        ps.peer_exchange_handle(_req("OLDPEER"))
+        self.assertNotIn("theirTier", ps.PEER_STATE["OLDPEER"])
+
+    def test_peers_snapshot_merges_their_tier(self):
+        ps.peer_update({"host": "BOXC", "port": 1, "up": True, "trust": "trusted"})
+        ps.peer_exchange_handle(_req("BOXC", tier="directed"))
+        snap = ps.peers_snapshot()
+        self.assertEqual(snap["peers"]["BOXC"]["theirTier"], "directed")
+        self.assertEqual(snap["peers"]["BOXC"]["trust"], "trusted",
+                         "both directions ride one row: ours from PEERS, theirs from the exchange")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_remotes_panel_render.py
+++ b/tests/test_remotes_panel_render.py
@@ -134,8 +134,38 @@ class RemotesPanelRender(unittest.TestCase):
 
     def test_render_is_given_pmode_rather_than_reading_it_free(self):
         js = km._LANDING_REMOTES_JS
-        self.assertIn("function render(ts,known,pmode,via,rholds)", js)
-        self.assertIn("render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[],(d&&d.remoteHolds)||[])", js)
+        self.assertIn("function render(ts,known,pmode,via,rholds,tiers)", js)
+        self.assertIn("render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[],(d&&d.remoteHolds)||[],(d&&d.peerTiers)||{})", js)
+
+    def test_reverse_trust_mismatch_renders_the_direction_and_a_match_button(self):
+        # Both directions of the pair on one row (the user 2026-07-26): ours is the select, theirs is
+        # the bus-gossiped declaration; a mismatch wears the warm tint and offers Match.
+        tn = json.loads(json.dumps(TUNNELS))
+        tn["peerTiers"] = {"TESTHOST": "trusted"}          # ours: directed (fixture) — half-open pair
+        out = self._run(tunnels=tn)
+        html = out.get("html", "")
+        self.assertIn("TESTHOST holds yours: trusted", html)
+        self.assertIn("rnet-mismatch", html)
+        self.assertIn("Match (directed)", html)
+
+    def test_reverse_trust_matched_pair_is_quiet_metadata_no_button(self):
+        tn = json.loads(json.dumps(TUNNELS))
+        tn["peerTiers"] = {"TESTHOST": "directed"}
+        out = self._run(tunnels=tn)
+        html = out.get("html", "")
+        self.assertIn("TESTHOST holds yours: directed", html)
+        self.assertNotIn("rnet-mismatch", html)
+        self.assertNotIn("Match (", html)
+
+    def test_no_tier_gossip_renders_no_reverse_line(self):
+        # An older peer (or bus down) declares nothing — the row must not invent a direction.
+        out = self._run()
+        self.assertNotIn("holds yours", out.get("html", ""))
+
+    def test_match_binding_posts_the_mirror_route(self):
+        js = km._LANDING_REMOTES_JS
+        self.assertIn("button[data-m]", js)
+        self.assertIn("/tunnels/trust-mirror", js)
 
     def test_the_per_host_settings_sit_on_their_own_line(self):
         # Trust and check-in are set once and left; Detach is an act. Splitting them off line 1 is what

--- a/ui/webview/net-popover-known.test.ts
+++ b/ui/webview/net-popover-known.test.ts
@@ -16,8 +16,8 @@ const STRIP = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf
 test("web popover renders remembered hosts with re-attach + forget", () => {
   // pmode rides along as a PARAM: it is computed in refresh()'s callback, and reading it as a free
   // variable in render() threw ReferenceError on every draw (see tests/test_remotes_panel_render.py)
-  assert.match(KERNEL, /function render\(ts,known,pmode,via,rholds\)/, "render takes the known list + pmode + via-reach + remote holds");
-  assert.match(KERNEL, /if\(!back\.hidden\)render\(ts,\(d&&d\.known\)\|\|\[\],pmode,\(d&&d\.viaReach\)\|\|\[\],\(d&&d\.remoteHolds\)\|\|\[\]\);/, "refresh passes them through");
+  assert.match(KERNEL, /function render\(ts,known,pmode,via,rholds,tiers\)/, "render takes the known list + pmode + via-reach + remote holds + peer tiers");
+  assert.match(KERNEL, /if\(!back\.hidden\)render\(ts,\(d&&d\.known\)\|\|\[\],pmode,\(d&&d\.viaReach\)\|\|\[\],\(d&&d\.remoteHolds\)\|\|\[\],\(d&&d\.peerTiers\)\|\|\{\}\);/, "refresh passes them through");
   assert.match(KERNEL, /Held for approval elsewhere/, "remote holds get their own section");
   assert.match(KERNEL, /rnet-from/, "the add box offers which machine owns the tunnel (attach-on-behalf)");
   assert.match(KERNEL, /Reachable via relay/, "via-reach hosts get their own section (trust-by-origin rows)");


### PR DESCRIPTION
Trust stays receiver-evaluated (a peer can never open your gate), but a half-open pair used to be invisible until mail quarantined on the far side.

- **Bus**: every exchange declares the sender's tier for the other side (`my_tier_of`, matching `_relay_in`'s token-proven resolution); each side stores the peer's declaration (`theirTier`), surfaced via `peers_snapshot`. Additive field — older peers simply omit it.
- **Kernel**: `/tunnels` ships `peerTiers`; new `/tunnels/trust-mirror` sets our level as that host's level for us, by calling the remote's own persisting `/tunnels/trust` through the tunnel with the remote's serve token — so the mirrored level survives its restarts like a locally-set one. Clear errors when there's no tunnel/token path.
- **Popover**: the reverse direction renders beside the trust select ("<host> holds yours: directed"); a mismatch wears a warm tint and offers "Match (<level>)". The declaration is display-only; the delivery gate is untouched.

Tests: bus tier declaration/storage/snapshot (5), kernel mirror route with a stub remote kernel (3), executed-JS popover render cases (4) plus updated pins. Suites green: pytest 3197, node 1332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)