### PR TITLE
Forked sessions self-identify: postal name, mailbox, and working note follow the stable sid

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5660,6 +5660,11 @@ def _session_rows():
         bg, fg = _identity_of(sid)
         out.append({"id": sid, "name": _name_of(sid) or sid[:8], "state": meta.get("state", ""),
                     "dir": _cwd_of(sid), "bg": bg, "fg": fg,
+                    # lastSid: the session's CURRENT transcript fsid (SDK registry join, mtime-memoized).
+                    # CLAUDE_CODE_SESSION_ID inside a forked session carries THIS id, not the stable sid,
+                    # so the postal bus resolves self-identity through it (the user 2026-07-27: a
+                    # post-/clear session mailed as "unknown" and read an empty mailbox).
+                    "lastSid": jd._sdk_last_sid(sid) or sid,
                     "working": notes.get(sid, ""), "backend": meta.get("backend", "")})
     return out
 
@@ -7248,6 +7253,7 @@ def _postal_index():
             continue
         if o.get("ev") == "sent" and o.get("id"):
             idx[o["id"]] = {"id": o["id"], "from": o.get("from", "?"), "fromId": o.get("from_id", ""),
+                            "fromHost": o.get("from_host", ""),
                             "toId": o.get("to_id", ""), "body": o.get("body", ""), "kind": o.get("kind", ""),
                             "t": o["t"] if isinstance(o.get("t"), (int, float)) else 0, "park": bool(o.get("park"))}
     return idx
@@ -7361,7 +7367,15 @@ def _hydrate_postal(events, index):
             for mid in ids:
                 rec = index.get(mid)
                 if rec:
-                    cards.append({"kind": "postal-service", "direction": "in", "peer": rec["from"] or "?",
+                    frm = rec["from"]
+                    if not frm or frm in ("?", "unknown"):
+                        # The sender couldn't self-name at send time (pre-fix forked sessions, older
+                        # peers). Resolve locally when the sid is ours to know; else host:sid-stub —
+                        # never the literal word "unknown" wearing a name pill (the user 2026-07-27).
+                        frm = _name_of(rec["fromId"]) or (
+                            (rec.get("fromHost", "") + ":" if rec.get("fromHost") else "")
+                            + (rec["fromId"][:8] if rec["fromId"] else "?"))
+                    cards.append({"kind": "postal-service", "direction": "in", "peer": frm,
                                   "color": _name_color(rec["fromId"]) if rec["fromId"] else None,
                                   "body": rec["body"], "summary": caption_for(rec["id"]),   # incoming caption (full body on expand)
                                   "intent": _postal_intent(rec.get("kind"), rec.get("body")),

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -139,12 +139,32 @@ def _self_id():
     not in a romp session. No tmux fallback: the bus never shells tmux; the env var IS the designed identity."""
     return (os.environ.get("CLAUDE_CODE_SESSION_ID") or "").strip() or None
 
+def _self_row():
+    """THIS session's live agent row. CLAUDE_CODE_SESSION_ID is the CURRENT transcript fsid, and a
+    /clear or resume fork moves that off the stable romp sid every store is keyed by (names registry,
+    mailboxes, working notes, session flags) — so a forked session that trusted the env var mailed as
+    "unknown", published its working note under an id no peer could see, and read an EMPTY mailbox
+    (the user 2026-07-27). Resolve through the kernel's sessions seam instead: an exact id match
+    first, else the row whose lastSid is our fsid (the SDK registry's authoritative stable→current
+    join, published on every /sessions row). None when not a romp session or the kernel is down."""
+    sid = _self_id()
+    if not sid:
+        return None
+    agents = local_agents()
+    return (next((a for a in agents if a.get("id") == sid), None)
+            or next((a for a in agents if a.get("lastSid") == sid), None))
+
 def my_id():
-    return _self_id()
+    row = _self_row()
+    return row["id"] if row else _self_id()
 
 def my_name():
-    # Resolve the NAME from our real id (names registry) so name + id never disagree — same reason as
-    # _self_id. None when not in a romp session (no tmux fallback: the bus never shells tmux).
+    # The live agent row first (it tracks renames AND survives transcript forks); the names registry as
+    # the kernel-down fallback. None when not in a romp session (no tmux fallback: the bus never shells
+    # tmux).
+    row = _self_row()
+    if row and row.get("name"):
+        return row["name"]
     sid = _self_id()
     if not sid:
         return None
@@ -421,6 +441,7 @@ def local_agents():
             continue
         res.append({"name": s.get("name") or sid[:8], "id": sid, "remote": False,
                     "working": s.get("working", ""), "dir": s.get("dir", ""),
+                    "lastSid": s.get("lastSid", ""),   # the session's CURRENT transcript fsid (self-identity join)
                     "state": s.get("state", "")})   # state: working/idle/waiting/... → working-note freshness
     return res
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -701,6 +701,28 @@ class ViewBuilder(unittest.TestCase):
         finally:
             km._msg_summaries = saved
 
+    def test_postal_card_never_wears_the_literal_unknown_sender(self):
+        """A sender that couldn't self-name at send time (pre-fix forked sessions, older peers) used to
+        render a name pill reading "unknown" (the user 2026-07-27). The card resolves the sid locally
+        when it can, else falls to host:sid-stub — informative, never the bare word."""
+        saved = km._msg_summaries
+        km._msg_summaries = lambda: {}
+        try:
+            inc = [{"kind": "user", "md": "romp-msg-id: m10", "ts": T0, "uuid": "u3"}]
+            fid = "abcdef00-1234-0000-0000-000000000000"
+            idx = {"m10": {"from": "unknown", "fromId": fid, "fromHost": "TESTHOST2",
+                           "body": "the sensors are live", "id": "m10", "t": T0, "park": None}}
+            card = km._hydrate_postal(inc, idx)[0]
+            self.assertEqual(card["peer"], "TESTHOST2:abcdef00",
+                             "an unresolvable foreign sender reads host:sid-stub, not 'unknown'")
+            (jd.NAMES / fid).write_text("signalsess\t/tmp/notes-api\t#ff8800\n")
+            card = km._hydrate_postal(inc, idx)[0]
+            self.assertEqual(card["peer"], "signalsess",
+                             "a locally-resolvable sender sid wins over the stub")
+        finally:
+            km._msg_summaries = saved
+            (jd.NAMES / fid).unlink()
+
     def test_unmuting_fast_forwards_the_planner_so_it_does_not_backfill(self):
         # the user 2026-06-25: re-enabling task tracking must NOT retro-create a burst of goals for the work
         # that happened while muted. Unmuting calls jd.fast_forward_placements (seals the gap); muting must not.

--- a/tests/test_kernel_send.py
+++ b/tests/test_kernel_send.py
@@ -59,10 +59,14 @@ class SessionList(unittest.TestCase):
                    "sid-s": ("beta", "/work/b", "blue", "white")})
         rows = {r["id"]: r for r in km._session_rows()}
         self.assertEqual(set(rows), {"sid-t", "sid-s"})
+        # lastSid = the session's CURRENT transcript fsid (self-identity join, the user 2026-07-27);
+        # with no diverged SDK registry it is the sid itself.
         self.assertEqual(rows["sid-t"], {"id": "sid-t", "name": "alpha", "state": "working", "dir": "/work/a",
-                                         "bg": "#112233", "fg": "#ffffff", "working": "owns feed.ts", "backend": "tmux"})
+                                         "bg": "#112233", "fg": "#ffffff", "lastSid": "sid-t",
+                                         "working": "owns feed.ts", "backend": "tmux"})
         self.assertEqual(rows["sid-s"], {"id": "sid-s", "name": "beta", "state": "waiting", "dir": "/work/b",
-                                         "bg": "blue", "fg": "white", "working": "", "backend": "sdk"})
+                                         "bg": "blue", "fg": "white", "lastSid": "sid-s",
+                                         "working": "", "backend": "sdk"})
 
     def test_empty_when_no_live_sessions(self):
         self._stub(live={}, notes={}, names={})

--- a/tests/test_postal_self_identity.py
+++ b/tests/test_postal_self_identity.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Forked-session self-identity on the postal bus (the user 2026-07-27).
+
+CLAUDE_CODE_SESSION_ID carries the CURRENT transcript fsid; a /clear or resume fork moves it off the
+stable romp sid that every store is keyed by. A session that trusted the env var mailed as "unknown"
+(my_name read names/<fsid>, which never exists), published its working note under an invisible id, and
+read an empty mailbox. _self_row resolves through the kernel sessions seam — exact id first, then the
+row whose lastSid matches — so my_id returns the STABLE sid and my_name the live name.
+
+Synthetic only — hermetic temp state dir, placeholder UUIDs, invented notes-domain sessions."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+STABLE = "11111111-2222-3333-4444-555555555555"
+FORK = "99999999-8888-7777-6666-555555555555"
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+_SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
+Path(_SESS).write_text(json.dumps([
+    {"id": STABLE, "name": "web", "dir": "/tmp/notes-api", "state": "waiting",
+     "working": "", "lastSid": FORK}]))
+os.environ["ROMP_SESSIONS_FILE"] = _SESS
+ps = SourceFileLoader("romp_postal_selfid", os.path.join(BIN, "romp-postal-service")).load_module()
+
+
+class ForkedSelfIdentity(unittest.TestCase):
+    def setUp(self):
+        os.environ["ROMP_SESSIONS_FILE"] = _SESS
+        self._env = os.environ.get("CLAUDE_CODE_SESSION_ID")
+
+    def tearDown(self):
+        if self._env is None:
+            os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
+        else:
+            os.environ["CLAUDE_CODE_SESSION_ID"] = self._env
+
+    def test_exact_id_match_resolves_directly(self):
+        os.environ["CLAUDE_CODE_SESSION_ID"] = STABLE
+        self.assertEqual(ps.my_id(), STABLE)
+        self.assertEqual(ps.my_name(), "web")
+
+    def test_forked_fsid_resolves_to_the_stable_row(self):
+        os.environ["CLAUDE_CODE_SESSION_ID"] = FORK
+        self.assertEqual(ps.my_id(), STABLE,
+                         "the stable sid is the identity every store is keyed by — never the fork fsid")
+        self.assertEqual(ps.my_name(), "web", "the live row name, never the 'unknown' fallback")
+
+    def test_unknown_env_id_keeps_the_raw_value_and_no_name(self):
+        os.environ["CLAUDE_CODE_SESSION_ID"] = "abcdef00-0000-0000-0000-000000000000"
+        self.assertEqual(ps.my_id(), "abcdef00-0000-0000-0000-000000000000",
+                         "no row and no lastSid match → the env value passes through (mail still routes by id)")
+        self.assertIsNone(ps.my_name())
+
+    def test_no_env_means_not_a_romp_session(self):
+        os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
+        self.assertIsNone(ps.my_id())
+        self.assertIsNone(ps.my_name())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
A chat card showed a delegation note "from **unknown**". Root cause is bigger than the chip: `CLAUDE_CODE_SESSION_ID` is the current transcript fsid, and a `/clear` or resume fork moves it off the stable sid every postal store is keyed by. A forked session therefore mailed as "unknown", published an invisible working note, was never marked "(you)" in list_agents, and read an empty mailbox while its real mail sat under the stable sid.

- **Kernel**: `/sessions` rows now carry `lastSid` (`jd._sdk_last_sid`, the authoritative stable→current join; the sid itself when undiverged).
- **Bus**: `_self_row()` resolves the env id through the sessions seam — exact match, then lastSid match — and `my_id`/`my_name` ride it, so the stable sid flows into sends (`from`/`from_id`), inbox reads, working notes, and self-marking all at once. Names-registry fallback kept for kernel-down CLI use.
- **Chat display hardening**: an inbound postal card never renders the literal "unknown" — it re-resolves the sender sid locally, else `host:sid-stub` via the `from_host` stamp (covers historical rows and unfixed peers).

Tests: self-identity resolution (4 cases incl. the fork join), the never-"unknown" card fallback (foreign stub + local re-resolve), updated `_session_rows` shape. Suites green: pytest 3210, node 1332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)