### PR TITLE
Stalled chip matches the trouble-chip outline; selected state is a yellow wash

### DIFF
--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -281,18 +281,17 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    rail's .rail-btn.on. */
 .fask-secbtn.on { color: var(--accent); border-color: var(--accent);
   background: rgba(156, 210, 255, 0.10); font-weight: 600; }
-/* STALLED (the user 2026-07-23) — the one toggle that keeps its OWN colour in every state. The others turn
-   accent-blue when selected, which is the app's "this is the one you picked" language; a stall is not a
-   preference, it is something wrong, so it wears working-yellow (--st-working-bg, the status colour for a
-   card that is supposed to be moving). FILLED at rest, not an outline: the outline version sat as quiet as
-   its neighbours and the stall went unnoticed (the user 2026-07-23, round 2 — "so that it's noticed when
-   something is going on"). It reads like the working status chip because that is what it is: a status, not
-   a preference. Pressed adds only weight; the opened body below is the pressed cue. */
-.fask-stallbtn, .fask-stallbtn.on { color: var(--st-working-fg); background: var(--st-working-bg);
-  border-color: var(--st-working-bg); }
-.fask-stallbtn:hover, .fask-stallbtn.on:hover { color: var(--st-working-fg); background: var(--st-working-bg);
-  border-color: var(--st-working-bg); filter: brightness(1.08); }
-.fask-stallbtn.on { font-weight: 600; }
+/* STALLED — the one toggle that keeps its OWN colour in every state. The others turn accent-blue when
+   selected, which is the app's "this is the one you picked" language; a stall is not a preference, it
+   is something wrong. It wears the PROBLEM-CHIP outline the card's other trouble chips wear (yellow
+   text + translucent yellow border on transparent, the .fask-warnchip / .fask-interrupted family) —
+   the user 2026-07-27, superseding the 2026-07-23 solid fill, which broke ranks with every other
+   trouble chip. Selected (its note showing below) deepens WITHIN the same vocabulary: a yellow wash +
+   full-strength border + weight — clearly pressed, never the solid working-status fill. */
+.fask-stallbtn { color: #ffd166; background: transparent; border-color: rgba(255, 209, 102, 0.6); }
+.fask-stallbtn:hover { color: #ffd166; border-color: #ffd166; background: rgba(255, 209, 102, 0.14); }
+.fask-stallbtn.on, .fask-stallbtn.on:hover { color: #ffd166; border-color: #ffd166;
+  background: rgba(255, 209, 102, 0.18); font-weight: 600; }
 .fask-secs .fask-distill { min-width: 0; margin: 0; }
 /* the background body is typographically IDENTICAL to the summary (.fask-distill) — same font size,
    line height, color, opacity (the user 2026-07-02: one text style for both sections) */

--- a/ui/webview/stall-section.test.ts
+++ b/ui/webview/stall-section.test.ts
@@ -55,13 +55,17 @@ test("the body prefers the staller's note and falls back to the mechanical reaso
     "never '(generating…)' — there is always something true to say");
 });
 
-test("the toggle is a FILLED working-yellow status chip in BOTH states", () => {
-  // Filled at rest, not an outline: the outline version sat as quiet as its neighbours and the stall went
-  // unnoticed (the user 2026-07-23, round 2 — it should be "noticed when something is going on").
-  assert.match(CSS, /\.fask-stallbtn, \.fask-stallbtn\.on \{ color: var\(--st-working-fg\); background: var\(--st-working-bg\);/,
-    "selected or not, it wears the working status colours — a status, not a preference");
-  assert.match(CSS, /\.fask-stallbtn\.on \{ font-weight: 600; \}/,
-    "pressed adds only weight; the opened body below is the pressed cue");
+test("the toggle wears the problem-chip OUTLINE, deepening to a yellow wash when selected", () => {
+  // Outline at rest — yellow text + translucent yellow border on transparent, the same vocabulary as
+  // .fask-warnchip / .fask-interrupted (the user 2026-07-27, superseding the 2026-07-23 solid fill,
+  // which broke ranks with every other trouble chip). Selected = wash + full border + weight: clearly
+  // pressed, never the solid working-status fill.
+  assert.match(CSS, /\.fask-stallbtn \{ color: #ffd166; background: transparent; border-color: rgba\(255, 209, 102, 0\.6\); \}/,
+    "at rest it reads like the card's other trouble chips: yellow outline, never a fill");
+  assert.match(CSS, /\.fask-stallbtn\.on, \.fask-stallbtn\.on:hover \{ color: #ffd166; border-color: #ffd166;\n  background: rgba\(255, 209, 102, 0\.18\); font-weight: 600; \}/,
+    "selected deepens within the same vocabulary: wash + solid border + weight, the note below showing");
+  assert.doesNotMatch(CSS, /\.fask-stallbtn[^{]*\{[^}]*var\(--st-working-bg\)/,
+    "never the solid working-status fill again");
   assert.doesNotMatch(CSS, /\.fask-stallbtn[^{]*\{[^}]*var\(--accent\)/,
     "it must never take the accent the other selected toggles use — yellow is a STATUS colour here");
 });

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "romp-chat-view",
-  "version": "0.4.336",
+  "version": "0.4.337",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "romp-chat-view",
-      "version": "0.4.336",
+      "version": "0.4.337",
       "dependencies": {
         "@types/ws": "^8.18.1",
         "dompurify": "^3.4.10",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "romp-chat-view",
   "displayName": "romp Chat View",
   "description": "Read-only, nicely-rendered live view of Claude Code (romp) sessions, styled like the official Claude Code panel.",
-  "version": "0.4.336",
+  "version": "0.4.337",
   "publisher": "romp",
   "private": true,
   "engines": {


### PR DESCRIPTION
The solid yellow fill broke ranks with the card's other problem chips (warning, interrupted: yellow text + translucent yellow border, transparent background). The Stalled toggle now wears the same outline at rest; hover and selected deepen within that vocabulary — selected is a yellow wash + full-strength border + weight, so it reads clearly pressed while its note shows below, without ever going back to the solid fill. Pins updated in stall-section.test.ts. Suites green (pytest 3210, node 1332).

🤖 Generated with [Claude Code](https://claude.com/claude-code)