### PR TITLE
The guide states the session-identity rule instead of posing it as a paradox

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -135,9 +135,11 @@ silently parking mail.
 
 ## Sessions, revival, and search
 
-A Romp session is a name, not a conversation. The name survives `/clear`,
-relaunches, and kernel restarts, so `api` is the same `api` whenever you come
-back to it.
+A session keeps its name through anything that would otherwise end it. `/clear`
+starts the agent on a blank slate, a relaunch starts it over, the kernel
+restarts: each of those is a new conversation underneath, but Romp files them
+all under the one name. So `api` is the same `api` whenever you come back to it,
+in the same place on your board, with everything Romp knows about it intact.
 
 Closed sessions come back. Type a closed session's name into the picker and Romp
 offers to revive it, with its history intact.


### PR DESCRIPTION
`docs/guide.md` opened its Sessions section with "A Romp session is a name, not
a conversation." That reads as nonsense to a reader who is typing into one. The
real point is identity over time — the name is what persists while the
underlying Claude Code conversation is replaced by `/clear`, a relaunch, or a
kernel restart — and the sentence never said so.

Rewritten to state it plainly, and to say what the reader gets out of it (same
place on the board, everything Romp knows about it intact).

Strict build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)