### PR TITLE
Restart button: reload only when the new kernel answers, splash while waiting

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14391,10 +14391,23 @@ if(m.romp==='picker')document.body.classList.toggle('picker-open',!!m.on);});
 var gear=document.getElementById('rail-gear');
 if(gear)gear.onclick=function(){var f=document.getElementById('f-feed');
 try{f&&f.contentWindow&&f.contentWindow.postMessage({romp:'openSettings'},'*');}catch(e){}};
-// the rail's ↻ restarts the kernel (POST /restart), then polls /healthz and reloads once it's back up.
+// the rail's ↻ restarts the kernel (POST /restart), puts the romp boot splash back up, and reloads only
+// when /healthz answers from the NEW kernel — its X-Romp-Boot differs from the id this page was served
+// under (__ROMP_BOOT__, spliced in by _landing). Polling for a bare 200 raced: the OLD kernel keeps
+// answering for a beat after the /restart ack, so the reload landed on a dying server and the browser
+// showed its connection-error page until a manual refresh (the user 2026-07-27). The splash element was
+// removed from the DOM after boot, so this rebuilds it from the same server-rendered loader markup
+// (__ROMP_LOADER__). 120s backstop reload so the splash can never trap the user.
 // Factored to window.__rompRestart so the mobile bottom bar (no rail there) can trigger the same thing.
-window.__rompRestart=function(){try{fetch('/restart',{method:'POST'}).catch(function(){});}catch(e){}
-var n=0;(function again(){setTimeout(function(){n++;fetch('/healthz',{cache:'no-store'}).then(function(r){if(r&&r.ok)location.reload();else if(n<40)again();}).catch(function(){if(n<40)again();});},500);})();};
+window.__rompRestart=function(){
+var boot=document.getElementById('romp-boot');
+if(!boot){boot=document.createElement('div');boot.id='romp-boot';boot.innerHTML=__ROMP_LOADER__;document.body.appendChild(boot);}
+boot.classList.remove('gone');
+try{fetch('/restart',{method:'POST'}).catch(function(){});}catch(e){}
+var n=0;(function again(){setTimeout(function(){n++;
+fetch('/healthz',{cache:'no-store'}).then(function(r){var b=(r&&r.ok)?r.headers.get('X-Romp-Boot'):null;
+if(b&&b!==__ROMP_BOOT__)location.reload();else if(n<240)again();else location.reload();})
+.catch(function(){if(n<240)again();else location.reload();});},500);})();};
 var rf=document.getElementById('rail-refresh');
 if(rf)rf.onclick=function(){rf.style.pointerEvents='none';rf.style.opacity='0.5';window.__rompRestart();};
 })();
@@ -15423,12 +15436,23 @@ def _landing():
             "<script>" + _LANDING_JS + "</script>"
             "<script>" + _LANDING_FOCUS_JS + "</script>"
             "<script>" + _LANDING_FLEET_JS + "</script>"
-            "<script>" + _LANDING_SETTINGS_JS + "</script>"
+            # the restart flow needs this kernel's boot id (to detect the NEW kernel answering /healthz)
+            # and the loader markup (to rebuild the boot splash the boot JS removed) — spliced, not
+            # %-formatted, so the JS never fights Python's % escaping.
+            "<script>" + _LANDING_SETTINGS_JS
+                         .replace("__ROMP_BOOT__", json.dumps(_BOOT_ID))
+                         .replace("__ROMP_LOADER__", json.dumps(_loader_inner())) + "</script>"
             "<script>" + _LANDING_REMOTES_JS + "</script>"
             "<script>" + _LANDING_MOBILE_JS + "</script>"
             "<script>" + _LANDING_COLLAPSE_JS + "</script>"
             + _stale_block(v) + _rdrift_block() +
             "</body></html>")
+
+
+# This kernel PROCESS's identity, minted at import. /healthz carries it (X-Romp-Boot) and the landing
+# page embeds it, so the restart button can tell "the new kernel is up" (id flipped) from "the old
+# kernel is still answering" (id unchanged) — an exact event, not a down-then-up timing guess.
+_BOOT_ID = "%d.%d" % (os.getpid(), int(time.time()))
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -15437,11 +15461,13 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, *a):
         pass
 
-    def _send(self, code, body, ctype, cache=None):
+    def _send(self, code, body, ctype, cache=None, headers=None):
         body = body.encode("utf-8") if isinstance(body, str) else body
         self.send_response(code)
         self.send_header("Content-Type", ctype)
         self.send_header("Content-Length", str(len(body)))
+        for k, v in (headers or {}).items():
+            self.send_header(k, v)
         if cache:                                     # e.g. "no-cache" — keeps a tab from running a stale bundle
             self.send_header("Cache-Control", cache)
         if getattr(self, "_set_cookie", None):       # auto-inject the token so a client never 401-loops
@@ -15594,7 +15620,13 @@ class Handler(BaseHTTPRequestHandler):
         self._cors_origin = self.headers.get("Origin") if self._origin_ok() else None
         try:
             if p == "/healthz":
-                return self._send(200, "ok", "text/plain")   # liveness probe — exempt from auth
+                # liveness probe — exempt from auth. X-Romp-Boot identifies THIS kernel process: the
+                # restart button reloads only when the id flips (a bare 200 can still be the old kernel
+                # answering between the /restart ack and its SIGTERM). Exposed for cross-origin readers
+                # (the body stays "ok" — external probes compare it).
+                return self._send(200, "ok", "text/plain",
+                                  headers={"X-Romp-Boot": _BOOT_ID,
+                                           "Access-Control-Expose-Headers": "X-Romp-Boot"})
             if p == "/version":                               # build/version report — exempt from auth (no paths, harmless)
                 return self._send(200, json.dumps(_version_info()), "application/json", cache="no-cache")
             if p == "/busy":
@@ -15744,7 +15776,7 @@ class Handler(BaseHTTPRequestHandler):
                 # romp-manager to restart-all — it SIGTERMs this kernel and its exit handler spawns a
                 # fresh one, so new Python code loads (the button then polls /healthz and reloads).
                 # Standalone (no manager) → nothing to restart; the ack still returns.
-                self._send(200, json.dumps({"ok": True, "restarting": True}), "application/json")
+                self._send(200, json.dumps({"ok": True, "restarting": True, "boot": _BOOT_ID}), "application/json")
                 mport = os.environ.get("ROMP_MANAGER_PORT")
                 if mport:
                     try:

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6008,7 +6008,9 @@ class ServeSecurity(unittest.TestCase):
                                          method="POST", data=b"")
             with urllib.request.urlopen(req, timeout=5) as r:
                 self.assertEqual(r.status, 200)
-                self.assertEqual(_json.loads(r.read().decode()), {"ok": True, "restarting": True})
+                # the ack also names WHICH kernel acked (boot id, 2026-07-27) — see RestartReloadRaceTest
+                self.assertEqual(_json.loads(r.read().decode()),
+                                 {"ok": True, "restarting": True, "boot": km._BOOT_ID})
         finally:
             if saved is not None:
                 os.environ["ROMP_MANAGER_PORT"] = saved
@@ -6185,6 +6187,17 @@ class ServeSecurity(unittest.TestCase):
 
     def test_healthz_exempt(self):
         self.assertEqual(self._code("/healthz", {"Origin": "http://evil.example"}), 200)
+
+    def test_healthz_carries_the_boot_id(self):
+        # /healthz identifies WHICH kernel process answered (X-Romp-Boot): the restart button reloads
+        # only when the id flips, because a bare 200 can still be the OLD kernel answering between the
+        # /restart ack and its SIGTERM — reloading against it was the browser-error-page race (the user
+        # 2026-07-27). The body stays "ok" for external probes that compare it.
+        import urllib.request
+        with urllib.request.urlopen("http://127.0.0.1:%d/healthz" % self.port, timeout=5) as r:
+            self.assertEqual(r.read().decode(), "ok")
+            self.assertEqual(r.headers.get("X-Romp-Boot"), km._BOOT_ID)
+            self.assertEqual(r.headers.get("Access-Control-Expose-Headers"), "X-Romp-Boot")
 
     def test_host_header_has_no_auth_power(self):
         # The Host header must carry NO authorization weight in either direction: a forged

--- a/tests/test_kernel_refresh_button.py
+++ b/tests/test_kernel_refresh_button.py
@@ -42,6 +42,46 @@ class RefreshButtonDecoupledTest(unittest.TestCase):
         self.assertNotRegex(_gear_src(), r"checked;[^\n]*applyDebug")
 
 
+class RestartReloadRaceTest(unittest.TestCase):
+    """The restart flow reloads on the NEW kernel's answer, never a bare 200 (the user 2026-07-27).
+
+    The old poll reloaded on the first /healthz 200 — but the OLD kernel keeps answering for a beat
+    after the /restart ack (the manager SIGTERMs it asynchronously), so the reload routinely landed on
+    a dying server and the browser sat on its connection-error page until a manual refresh. Now the
+    page embeds the boot id it was served under, /healthz stamps every answer with X-Romp-Boot, and
+    the poll reloads only when the id FLIPS — an exact process-identity event, not a timing guess.
+    While it waits, the romp boot splash is rebuilt over the page (the loading rule), with a reload
+    backstop so the splash can never trap the user."""
+
+    def test_reload_waits_for_the_boot_id_to_flip(self):
+        import json
+        html = km._landing()
+        # the page knows its own kernel's boot id, and the poll compares against it
+        self.assertIn("b!==" + json.dumps(km._BOOT_ID), html)
+        self.assertIn("r.headers.get('X-Romp-Boot')", html)
+        # both splice placeholders were resolved
+        self.assertNotIn("__ROMP_BOOT__", html)
+        self.assertNotIn("__ROMP_LOADER__", html)
+        # the racy first-200 reload is gone
+        self.assertNotIn("if(r&&r.ok)location.reload()", html)
+
+    def test_wait_wears_the_boot_splash(self):
+        import json
+        html = km._landing()
+        # the splash element is rebuilt (the boot JS removed it from the DOM after startup) from the
+        # SAME server-rendered loader markup the boot splash uses — one source, no drifting copy
+        self.assertIn("boot.id='romp-boot'", html)
+        self.assertIn("boot.innerHTML=" + json.dumps(km._loader_inner()), html)
+
+    def test_healthz_and_restart_carry_the_boot_id(self):
+        # source-level pins (the HTTP-level check lives in test_kernel.py's ServeSecurity): /healthz
+        # stamps X-Romp-Boot, and the /restart ack reports which kernel acked
+        import inspect
+        src = inspect.getsource(km.Handler)
+        self.assertIn('"X-Romp-Boot": _BOOT_ID', src)
+        self.assertIn('"restarting": True, "boot": _BOOT_ID', src)
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
Clicking the kernel-restart button left the browser on a connection-error page until a manual refresh. The poll reloaded on the first /healthz 200, which was routinely still the OLD kernel answering between the /restart ack and its SIGTERM — so the reload landed on a dying server.

- The kernel mints a per-process `_BOOT_ID`; `/healthz` stamps `X-Romp-Boot` (body stays `"ok"` for external probes), and the `/restart` ack reports it.
- The landing page embeds the boot id it was served under; `__rompRestart` (rail + mobile bar) reloads only when the polled id flips — the exact "new kernel is up" event.
- While waiting, the romp boot splash is rebuilt over the page from the same server-rendered loader markup, with a 120s backstop reload so it can never trap the user.

Tests: `RestartReloadRaceTest` (flip-compare, resolved splices, splash rebuild, racy reload gone), `/healthz` header check + `/restart` ack pin in `ServeSecurity`. Both suites green (pytest 3214, node 1332).

🤖 Generated with [Claude Code](https://claude.com/claude-code)