### PR TITLE
A /clear never renders as a dead gap: live indicator, boundary card, lazy pre-clear fold

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -76,6 +76,9 @@ def _rebind_state(path):
     _lastsid_memo.clear()   # sdk-registry reads are mtime-memoized per sid — a rebind must not serve the old root's values
     _episode_memo.clear()   # ...and so are the episode-log reads
     _head_memo.clear()      # transcript heads are immutable per path, but a rebind swaps the whole world of paths
+    _namefp_memo.clear()    # names-entry content is memoized per SID against same-second mtimes — across a
+    #                         rebind that collides and serves the OLD root's project dir (found 2026-07-27:
+    #                         the second test in a run discovered nothing, its fleet resolved into an rm'd tmpdir)
     # (the override journal needs no rebinding: _overrides_dir() derives from GOALDIR at call time, so
     #  ANY isolation style — _rebind_state OR a bare GOALDIR reassignment — scopes it automatically)
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7954,7 +7954,8 @@ def _session_chip(sid, path, session, tm, now):
     aerr = _api_error(path) if not (open_now or awaiting_why) else None
     st = (tm or {}).get("state", "") or ""
     compacting = _compacting(sid, st, session, now, (tm or {}).get("since"))
-    return ("compacting" if compacting else
+    return ("clearing" if _clearing_now(sid) else   # a /clear in flight — a context operation, like compacting
+            "compacting" if compacting else
             "interrupting" if _interrupting(sid, session, now, tm) else   # stop dispatched, not yet settled
             "blocked" if aerr else
             "awaiting" if st in _NEEDS_INPUT_STATES else               # a live permission/picker prompt
@@ -8015,6 +8016,18 @@ def _compacting_now(sid):
     path = _path_of(sid)
     session = (_parse_cached(path) if path else None) or {"turns": []}
     return _compacting(sid, (tm or {}).get("state", ""), session, int(time.time()), (tm or {}).get("since"))
+
+
+def _clearing_now(sid):
+    """Is this session mid-/clear RIGHT NOW — the backend's authoritative bracket (SDK: set on /clear
+    delivery, cleared by the lastSid-flipping init / the turn's settle). No optimistic/tmux derivation
+    exists: a tmux TUI /clear surfaces as a fork lane with no observable bracket (the accepted gap in
+    plans/clear-episodes.md), so None reads False."""
+    try:
+        be = Sessions.backend_for(str(sid))
+        return bool(be.clearing(str(sid))) if be is not None else False
+    except Exception:
+        return False
 
 
 def _working_now(sid):
@@ -8849,9 +8862,16 @@ def _stamp_interrupt_causes(events):
     return events
 
 
-def build_session(sid, now, tmux=None):
+def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     """A {type:"session"} message the render.js bundle consumes: the event tree reshaped to
-    ChatEvent[], plus the TOC ledger (archiver headline + turn captions) and a status chip."""
+    ChatEvent[], plus the TOC ledger (archiver headline + turn captions) and a status chip.
+
+    path_override (build_episode, the user 2026-07-27): parse THAT transcript instead of the session's
+    current one — the single sid→path resolution point the episode plan reserved (plans/clear-episodes.md).
+    Override mode is a READ-ONLY historical render: no live-atom merge, no queue/compacting/todo overlays,
+    and it returns early with just {type:"session", id, events}. tail_cap_t bounds the final durable-note
+    flush (orphan replies / retry notes are sid-keyed and span episodes — without the cap, notes from AFTER
+    the /clear would dump into the old episode's tail)."""
     if tmux is None:
         tmux = _tmux_sessions()
     sess = next((s for s in _sessions(now) if s["sid"] == sid), None)
@@ -8872,13 +8892,16 @@ def build_session(sid, now, tmux=None):
                 "path": str(jd.STATE / "boot-stub" / (sid + ".jsonl")), "mtime": now}
     if not sess:
         return None
+    if path_override:
+        sess = dict(sess)
+        sess["path"] = str(path_override)
     # Messages QUEUED in the TUI (submitted while busy/compacting) — folded EVENT-BASED by the owning backend:
     # the transcript's queue-operation records (tmux) or the SDK's in-memory queue. Computed HERE, before the
     # live-atom merge, so the optimistic input echo can SUPPRESS any text already shown as queued — the
     # event-based queued indicator owns that case, so no double-show. The kind:"queued" event is appended at
     # the bottom later.
     be = Sessions.backend_for(sid)
-    queued = be.pending_queued(sid)
+    queued = [] if path_override else be.pending_queued(sid)   # override = a closed episode; nothing is live
     parsed = _parse(sess["path"], sid, now)
     # Optimistic queued echo (TMUX only): a composer send while the session is BUSY (a working turn OR a
     # compaction in progress) gets queued by Claude Code, but its queue-operation record only lands in the
@@ -8892,8 +8915,9 @@ def build_session(sid, now, tmux=None):
     # discriminator.) Keys on the EVENT MODEL (_session_working / _compacting), never the tmux pane state — and
     # an echo-only merge keeps the turn's real ended state.
     tm0 = tmux.get(sid)
-    compacting_now = _compacting(sid, (tm0 or {}).get("state", ""), parsed, now, (tm0 or {}).get("since"))
-    busy = _session_working(parsed["turns"]) or compacting_now
+    compacting_now = (False if path_override else
+                      _compacting(sid, (tm0 or {}).get("state", ""), parsed, now, (tm0 or {}).get("since")))
+    busy = not path_override and (_session_working(parsed["turns"]) or compacting_now)
     if not hasattr(be, "unqueue") and busy:
         already = {q.strip() for q in queued}
         tx_user = {t for turn in parsed["turns"] for a in turn["atoms"] for t in _atom_user_texts(a)}
@@ -8901,7 +8925,7 @@ def build_session(sid, now, tmux=None):
             et = (a.get("_echo_text") or "").strip()
             if et and et not in already and et not in tx_user:
                 queued = queued + [et]; already.add(et)
-    session = _merge_live_atoms(parsed, sid, shown_texts=queued)
+    session = parsed if path_override else _merge_live_atoms(parsed, sid, shown_texts=queued)
     caps = _captions(sid)
     events, by_tool = [], {}                  # by_tool: tool_use_id → its tool event (fill output later)
     uuid2seg, seg_anchors = {}, {}            # atom uuid → seg id; seg id → (promptId, workId) for the dot/bar split
@@ -9135,7 +9159,8 @@ def build_session(sid, now, tmux=None):
                 events.append({"kind": "compact", "uuid": a.get("uuid"), "ts": ts,
                                "trigger": cmeta.get("trigger"), "preTokens": cmeta.get("pre_tokens"),
                                "postTokens": cmeta.get("post_tokens"), "summary": a.get("summary")})
-    _flush_recoveries(None)                             # a recovery on the still-open tail turn (t past the last atom) → bottom of the flow
+    _flush_recoveries(tail_cap_t)                       # a recovery on the still-open tail turn (t past the last atom) → bottom of the flow
+    #                                                     (tail_cap_t: an episode render stops at its /clear — later notes belong to the next episode)
     events = _hydrate_postal(events, _postal_index())   # swap postal traffic for clean in/out cards (no boilerplate)
     _stamp_interrupt_causes(events)                     # a restart/crash resume notice names the seam's cause
     for ev in events:
@@ -9147,6 +9172,11 @@ def build_session(sid, now, tmux=None):
         ev["tlId"] = ((anchors[0] if is_prompt else anchors[1]) or seg) if anchors else seg
         if ev.get("askAnswer"):                       # AskUserQuestion → fill chosen now the answer's in
             _ask_fill_chosen(ev["askAnswer"], ev.get("output") or "")
+    if path_override:
+        # Historical episode render: the transcript events only — none of the LIVE overlays below (todo,
+        # queued, compacting, api-error, status chip) describe a closed episode, and the boundary/system
+        # inserts belong to the CURRENT conversation's frame.
+        return {"type": "session", "id": sid, "events": events}
     # Claude Code Task to-do list: ONE checklist event (renderTodo), appended last (bottom, by the
     # composer), from the AUTHORITATIVE live task store (updated by every writer incl. subagents — the
     # transcript fold misses subagent completions; see _read_task_store, the user via `track` 2026-07-03).
@@ -9176,6 +9206,14 @@ def build_session(sid, now, tmux=None):
     # visually becomes. Corroborated `_compacting` signal (same one the chip/timeline use), never raw tmux.
     if compacting_now:
         events.append({"kind": "compacting"})
+    # Live CLEARING indicator (the user 2026-07-27): while a /clear is in flight — from the delivery until
+    # the CLI mints the fresh transcript — the chat used to show a dead gap and then flash "No messages
+    # yet.". An animated inline element, sibling of the compacting one; event-based off the backend's
+    # authoritative bracket (SdkSession._clearing), it vanishes the instant the fork lands and the
+    # "Conversation cleared" boundary card (kind:"clear") takes over as the durable record.
+    clearing_now = _clearing_now(sid)
+    if clearing_now:
+        events.append({"kind": "clearing"})
     # Live RECONNECT indicator (the user 2026-07-06): an /effort switch has no SDK runtime control, so romp
     # applies it by RECONNECTING the session (resume = the CLI re-reads the transcript) — which otherwise
     # leaves NO record in the chat. While that reconnect is pending, show an animated "Reloading session…"
@@ -9242,6 +9280,12 @@ def build_session(sid, now, tmux=None):
         if compacting_now:
             for i, m in enumerate(qmsgs):
                 if (m.get("md") or "").strip() == "/compact":
+                    del qmsgs[i]
+                    break
+        # Same fold for a running /clear: the live "Clearing conversation…" element already represents it.
+        if clearing_now:
+            for i, m in enumerate(qmsgs):
+                if (m.get("md") or "").strip() == "/clear":
                     del qmsgs[i]
                     break
         if qmsgs:                                         # don't emit an empty "queued" (folding the running /compact could empty it)
@@ -9479,8 +9523,21 @@ def build_session(sid, now, tmux=None):
                # open (the user 2026-06-24) — works for a never-run session of EITHER backend.
                "gitBranch": meta.get("gitBranch") or _git_branch(scwd), "version": meta.get("version") or "",
                "mode": meta.get("permissionMode") or "", "claudemd": docs}
-    if events and (docs or any(sysinfo[k] for k in ("model", "cwd", "gitBranch", "version", "mode"))):
-        events.insert(0, sysinfo)
+    # The /clear boundary card (the user 2026-07-27): a session whose episodes log records ≥2 episodes had
+    # its conversation cleared — the chat's fresh episode opens with a collapsed "Conversation cleared"
+    # notice (the durable twin of the timeline's film-splice seam) whose body lazy-loads the pre-clear
+    # conversation on expand (loadEpisode → build_episode). It also guarantees a just-cleared session is
+    # never events-empty, so the "No messages yet." placeholder can't lie about a conversation that DID
+    # exist. Ordered ABOVE the system card: the cleared history predates the current conversation's frame.
+    _epi_rows = jd.episode_rows(sid)
+    boundary = _epi_rows[-1] if len(_epi_rows) >= 2 else None
+    if events or boundary:
+        if docs or any(sysinfo[k] for k in ("model", "cwd", "gitBranch", "version", "mode")):
+            events.insert(0, sysinfo)
+        if boundary:
+            events.insert(0, {"kind": "clear", "uuid": "clear:%s" % (boundary.get("head") or boundary.get("t")),
+                              "ts": iso(boundary["t"]) if boundary.get("t") else None,
+                              "clearedAt": boundary.get("t"), "episodes": len(_epi_rows)})
     return {"type": "session", "id": sid, "name": sess["name"], "color": _name_color(sid),
             "cwd": _tilde(_cwd_of(sid) or meta.get("cwd") or ""),   # fixed-at-creation dir; lane tab shows it (the user 2026-06-22)
             # git branch as a TOP-LEVEL session field, NOT just inside the head system event: the status-bar
@@ -9499,6 +9556,36 @@ def build_session(sid, now, tmux=None):
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),
             "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"),
             "firstSeen": session["turns"][0]["t"] if session["turns"] else now}
+
+
+EPISODE_EVENT_CAP = 200   # events shipped per pre-clear episode expand — bounded, honest about the cut
+
+
+def build_episode(sid, now):
+    """The PREVIOUS episode's chat events, for the "Conversation cleared" card's lazy expand: parse the
+    pre-clear transcript (episodes/<sid>.jsonl row -2's starting file) through build_session's override
+    mode and ship the tail, capped at EPISODE_EVENT_CAP with an honest `truncated` count. FAIL LOUDLY
+    (the repo rule): a missing transcript returns an error string the card shows, never a silent empty.
+
+    Known gap, accepted (mirrors plans/clear-episodes.md): the episodes log records each episode's
+    STARTING fsid, so an episode that later forked mid-life (a resume fork) renders from its starting
+    file's chain only — the common single-file episode is exact."""
+    rows = jd.episode_rows(sid)
+    if len(rows) < 2:
+        return {"type": "chatEpisode", "id": sid, "events": [],
+                "error": "No earlier conversation is recorded for this session."}
+    prev, cur = rows[-2], rows[-1]
+    cur_path = _path_of(sid)
+    path = (Path(cur_path).parent / ((prev.get("fsid") or "") + ".jsonl")) if cur_path else None
+    if not path or not prev.get("fsid") or not path.exists():
+        return {"type": "chatEpisode", "id": sid, "events": [],
+                "error": "The pre-clear transcript file is missing (%s), so the cleared conversation "
+                         "can't be shown." % (path.name if path is not None else "unknown")}
+    full = build_session(sid, now, path_override=str(path), tail_cap_t=cur.get("t"))
+    evs = (full or {}).get("events") or []
+    truncated = max(0, len(evs) - EPISODE_EVENT_CAP)
+    return {"type": "chatEpisode", "id": sid, "events": evs[-EPISODE_EVENT_CAP:],
+            "truncated": truncated, "clearedAt": cur.get("t")}
 
 
 # ───────────────────────── feed clear / undo (inbox-zero) ─────────────────────────
@@ -15841,6 +15928,14 @@ class Handler(BaseHTTPRequestHandler):
                                                        "before": before, "events": evs[frm:before]}))
             except Exception:
                 sys.stderr.write("loadOlder: %s\n" % traceback.format_exc())
+            return
+        if msg and msg.get("type") == "loadEpisode" and msg.get("id"):
+            # The "Conversation cleared" card was expanded → ship the pre-clear episode's events (a one-shot
+            # direct reply, like chatHead; cached client-side per boundary so re-renders don't re-ask).
+            try:
+                client["send"](json.dumps(build_episode(str(msg["id"]), int(time.time()))))
+            except Exception:
+                sys.stderr.write("loadEpisode: %s\n" % traceback.format_exc())
             return
         if msg and msg.get("type") == "setGlobalRetryPaused":
             _set_retry_paused(msg.get("value"))

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -113,6 +113,15 @@ def _is_compact_cmd(text: str) -> bool:
     return t == "/compact" or t.startswith("/compact ")
 
 
+def _is_clear_cmd(text: str) -> bool:
+    """True if `text` is a /clear invocation. Drives the authoritative SdkSession._clearing bracket, the
+    chat's live "clearing" indicator — without it the stretch between the /clear delivery and the CLI
+    minting the fresh transcript has no observable state at all (the episode boundary is detected only
+    after the fact)."""
+    t = (text or "").strip()
+    return t == "/clear" or t.startswith("/clear ")
+
+
 def _model_reflects_alias(live_pretty: str, alias: str) -> bool:
     """Does the LIVE model display name reflect the chosen ALIAS — i.e. the switch has taken effect? A
     bare alias ('opus') is a substring of its pretty name ('Opus 4.8'), case-insensitively; 'default'/''
@@ -890,6 +899,11 @@ class SdkSession:
         # kernel's optimistic _compact_clicked + 180s cap for SDK sessions — that cap held parked ops (a
         # model pick, a message) hostage for up to 3 minutes whenever /compact found nothing to compact.
         self._compacting = False
+        # AUTHORITATIVE clearing signal, the /clear twin of _compacting: set when a /clear is delivered,
+        # cleared by the init whose session_id flips lastSid (the fork landed — the fresh conversation
+        # exists) or by the turn's ResultMessage (backstop). Drives the chat's live "clearing" indicator
+        # and the "clearing" chip so a /clear never reads as a dead gap or "No messages yet.".
+        self._clearing = False
         # BUSY is an EVENT, not a count. The CLI is "working" from the moment we hand it input (or it
         # streams output) until it emits a ResultMessage; a ResultMessage means the CLI has drained
         # EVERYTHING we sent — however many messages were forwarded mid-turn — and is idle again. We
@@ -967,6 +981,8 @@ class SdkSession:
         # Same enqueue-time semantics as send(); cleared event-based by the boundary / the turn's result.
         if any(_is_compact_cmd(t) for t in self._pending):
             self._compacting = True
+        if any(_is_clear_cmd(t) for t in self._pending):   # same restored-queue rule for a queued /clear
+            self._clearing = True
         self._input_wake: asyncio.Event | None = None
         self._cur_ask_fut: asyncio.Future | None = None
         self._lock = threading.Lock()
@@ -1378,6 +1394,7 @@ class SdkSession:
                 self._interrupted = False
                 self._intr_level = 0
                 self._compacting = False   # an abandoned /compact turn can't emit its boundary/result on the dead client
+                self._clearing = False     # same: an abandoned /clear turn can't emit its init/result either
                 self._mark("waiting")
                 self.backend.retire_live_work(self.sid)   # the abandoned turn's stream is gone with its client
                 self.backend._poke()
@@ -1535,6 +1552,9 @@ class SdkSession:
             if fsid and fsid != self.resume_sid:
                 self.resume_sid = fsid
                 self.backend._update_reg(self.sid, lastSid=fsid)
+                # A lastSid flip IS a fork landing — for a /clear, the fresh conversation now exists, so the
+                # clearing bracket ends here (event-based; the ResultMessage below is only the backstop).
+                self._clearing = False
             cli_cwd = d.get("cwd")
             if isinstance(cli_cwd, str) and cli_cwd and cli_cwd != self.cwd:
                 # The CLI's own cwd is the AUTHORITATIVE string: its projects-dir/transcript encoding
@@ -1638,6 +1658,7 @@ class SdkSession:
             # A /compact that found NOTHING to compact emits no boundary — the turn just settles here. Clear
             # the authoritative flag so parked ops proceed immediately, instead of waiting out a 180s cap.
             self._compacting = False
+            self._clearing = False   # /clear backstop: the turn settled, whatever the init did or didn't flip
             if self._rewind_to:
                 # the rewind turn settled — the flag is CONSUMED (the leaf moved past the recorded one, so
                 # rewind_disposition would drop it on the next connect anyway; this just tidies the reg now).
@@ -2582,6 +2603,11 @@ class SdkBackend:
             # this send and the CLI actually starting the turn — so a drive op the producer tick checks in
             # that window still parks. Cleared event-based by the boundary / the turn's ResultMessage.
             s._compacting = True
+        if _is_clear_cmd(text):
+            # Delivering /clear: light the clearing bracket NOW, so the chat shows "Clearing conversation…"
+            # from the instant of the send. Cleared event-based by the lastSid-flipping init (the fresh
+            # conversation exists) / the turn's ResultMessage.
+            s._clearing = True
         s.enqueue(text)
         # optimistic input echo: show the user's own message INSTANTLY (neither the transcript nor the
         # stream has it yet at send time — only we know the text). Synthetic uuid; pruned by text once the
@@ -2759,6 +2785,15 @@ class SdkBackend:
         if not s:
             return None
         return s._compacting
+
+    def clearing(self, sid: str) -> "bool | None":
+        """Authoritative 'is a /clear in progress' (see SessionBackend.clearing): set when /clear is
+        delivered, cleared event-based by the lastSid-flipping init (the fork landed) or the turn's
+        ResultMessage. None when we don't run this sid (tmux has no bracket — the known fork-lane gap)."""
+        s = self.sessions.get(sid)
+        if not s:
+            return None
+        return s._clearing
 
     def kill(self, sid: str) -> bool:
         reg = read_reg(self.state_dir, sid)

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -72,6 +72,16 @@ class SessionBackend(ABC):
         or the /compact turn's settle; tmux keeps the None default (its @claude-state path is unchanged)."""
         return None
 
+    def clearing(self, sid: str) -> "bool | None":
+        """AUTHORITATIVE 'is a /clear in progress right now', or None when the backend has no such signal.
+        The bracket exists so the chat can show a live "clearing" indicator instead of a dead gap: between
+        the /clear delivery and the CLI minting the fresh transcript there is otherwise NO observable state
+        anywhere (the episode boundary is only detected after the fact, by the episodes tick). SDK: set on
+        /clear delivery, cleared event-based by the init that flips lastSid (the fork landing) or the turn's
+        settle. tmux keeps the None default — a TUI /clear there surfaces as a fork lane, with no bracket
+        (the known tmux gap in plans/clear-episodes.md)."""
+        return None
+
     def forwards_sends(self) -> bool:
         """True if this backend accepts a plain composer send at ANY time — even mid-turn — and manages its
         own delivery: forwarding the message to the model at the next tool boundary, folding several queued

--- a/tests/test_clear_chat_view.py
+++ b/tests/test_clear_chat_view.py
@@ -1,0 +1,202 @@
+"""The /clear chat UX (the user 2026-07-27): a cleared conversation must not render as a dead gap.
+
+Before this, the chat pane was the one surface with zero episode awareness (plans/clear-episodes.md):
+a /clear wiped the DOM to "No messages yet.", the pre-clear conversation was unreachable, and the
+stretch while the CLI minted the fresh transcript had no observable state at all. Now:
+  - build_session opens a post-clear episode with a {kind:"clear"} boundary card (above the system
+    card, both collapsed client-side), so a cleared session is never events-empty;
+  - build_episode serves the PRE-CLEAR conversation for the card's lazy expand, through
+    build_session's read-only path_override mode, capped with an honest truncated count, and FAILS
+    LOUDLY (an error string, never a silent empty) when the old transcript is missing;
+  - the SDK backend brackets the in-flight /clear (SdkSession._clearing) so the chip and the chat
+    show "clearing" while it runs (_is_clear_cmd; the tmux TUI /clear keeps its known fork-lane gap).
+Synthetic data only.
+"""
+import inspect
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_clearchat", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+sb = SourceFileLoader("romp_sdk_backend_clearchat",
+                      os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NEWFSID = "66666666-7777-8888-9999-000000000000"
+NOW = 1750000000
+CLEAR_T = NOW - 60
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _urec(t, uuid, text, parent=None, fsid=SID):
+    return {"type": "user", "uuid": uuid, "parentUuid": parent, "timestamp": iso(t),
+            "sessionId": fsid, "cwd": "/tmp/notes-api", "version": "2.0.0", "gitBranch": "main",
+            "message": {"role": "user", "content": text}}
+
+
+def _arec(t, uuid, text, parent, fsid=SID):
+    return {"type": "assistant", "uuid": uuid, "parentUuid": parent, "timestamp": iso(t),
+            "sessionId": fsid, "cwd": "/tmp/notes-api", "version": "2.0.0", "gitBranch": "main",
+            "message": {"role": "assistant", "model": "claude-opus-5",
+                        "content": [{"type": "text", "text": text}]}}
+
+
+def _write_jsonl(path, rows):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text("".join(json.dumps(r) + "\n" for r in rows))
+
+
+class ClearChatViewTest(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        jd.PROJECTS = Path(self._td) / "projects"
+        jd._discover_cache["fp"] = None
+        jd._discover_cache["result"] = None
+        # the launch cwd must round-trip _proj_dir's realpath+encode (a literal "/tmp/…" string does
+        # not on macOS, where /tmp realpaths to /private/tmp) — derive the project dir via jd itself
+        self.cwd = os.path.realpath(os.path.join(self._td, "notes-api"))
+        os.makedirs(self.cwd, exist_ok=True)
+        self.proj = jd._proj_dir(self.cwd)
+        self.proj.mkdir(parents=True)
+        # discover iterates the names registry: name + launch cwd (mapped to the project dir)
+        (jd.STATE / "names").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "names" / SID).write_text("web\t" + self.cwd)
+        # episode 1 (the anchor file): a small finished conversation, later cleared
+        _write_jsonl(self.proj / (SID + ".jsonl"), [
+            _urec(NOW - 3600, "u1", "set up the api server"),
+            _arec(NOW - 3590, "a1", "done - the notes-api server runs on port 8080", "u1"),
+        ])
+        # episode 2 (the post-/clear fork): a fresh null-rooted head in a NEW file
+        _write_jsonl(self.proj / (NEWFSID + ".jsonl"), [
+            _urec(NOW - 50, "n1", "hello again", fsid=NEWFSID),
+            _arec(NOW - 40, "n2", "fresh start - what next?", "n1", fsid=NEWFSID),
+        ])
+        # the SDK registry's lastSid points discover at the new file (the /clear re-point)
+        (jd.STATE / "sdk").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "sdk" / (SID + ".json")).write_text(json.dumps(
+            {"sid": SID, "name": "web", "alive": True, "lastSid": NEWFSID}))
+        # the episodes log records both heads; row -1 is the boundary the chat renders
+        _write_jsonl(jd.STATE / "episodes" / (SID + ".jsonl"), [
+            {"head": "u1", "fsid": SID, "t": NOW - 3600},
+            {"head": "n1", "fsid": NEWFSID, "t": CLEAR_T},
+        ])
+
+    def tearDown(self):
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _events(self):
+        m = km.build_session(SID, NOW)
+        self.assertIsNotNone(m, "the session must be discoverable")
+        return m["events"]
+
+    # ── the boundary card ────────────────────────────────────────────────────────────────────────
+
+    def test_post_clear_chat_opens_with_the_clear_boundary_then_the_system_card(self):
+        evs = self._events()
+        kinds = [e.get("kind") for e in evs]
+        self.assertEqual(kinds[0], "clear", "the boundary card leads (the cleared history predates the frame)")
+        self.assertEqual(kinds[1], "system", "the system card follows, so both folds sit at the top")
+        clear = evs[0]
+        self.assertEqual(clear["uuid"], "clear:n1", "keyed on the episode head - stable across pushes")
+        self.assertEqual(clear["clearedAt"], CLEAR_T)
+        self.assertEqual(clear["episodes"], 2)
+
+    def test_a_cleared_session_is_never_events_empty(self):
+        # the exact "No messages yet." lie: the fresh transcript has NOTHING renderable yet
+        _write_jsonl(self.proj / (NEWFSID + ".jsonl"), [])
+        jd._discover_cache["fp"] = None
+        jd._discover_cache["result"] = None
+        evs = self._events()
+        self.assertTrue(evs, "a just-cleared session shows the boundary card, not an empty placeholder")
+        self.assertIn("clear", [e.get("kind") for e in evs])
+
+    def test_a_single_episode_session_gets_no_boundary_card(self):
+        _write_jsonl(jd.STATE / "episodes" / (SID + ".jsonl"),
+                     [{"head": "u1", "fsid": SID, "t": NOW - 3600}])
+        self.assertNotIn("clear", [e.get("kind") for e in self._events()],
+                         "no /clear ever happened - nothing to mark")
+
+    # ── the lazy pre-clear expand ────────────────────────────────────────────────────────────────
+
+    def test_build_episode_serves_the_pre_clear_conversation(self):
+        ep = km.build_episode(SID, NOW)
+        self.assertEqual(ep["type"], "chatEpisode")
+        self.assertFalse(ep.get("error"))
+        self.assertEqual(ep.get("truncated"), 0)
+        self.assertEqual(ep.get("clearedAt"), CLEAR_T)
+        texts = json.dumps(ep["events"])
+        self.assertIn("notes-api server runs", texts, "the old episode's reply is in the fold")
+        self.assertNotIn("fresh start", texts, "the NEW episode's turns never leak into the old fold")
+        kinds = [e.get("kind") for e in ep["events"]]
+        self.assertNotIn("clear", kinds, "no boundary/system inserts inside the historical render")
+        self.assertNotIn("system", kinds)
+
+    def test_build_episode_missing_transcript_fails_loudly(self):
+        (self.proj / (SID + ".jsonl")).unlink()   # the pre-clear file is gone
+        jd._discover_cache["fp"] = None
+        jd._discover_cache["result"] = None
+        ep = km.build_episode(SID, NOW)
+        self.assertIn("missing", ep.get("error", ""), "an unreadable source surfaces an error, never a silent empty")
+        self.assertEqual(ep["events"], [])
+
+    def test_build_episode_caps_and_counts_the_cut(self):
+        rows = [_urec(NOW - 3600, "u1", "set up the api server")]
+        parent = "u1"
+        for i in range(km.EPISODE_EVENT_CAP + 40):
+            u = "x%d" % i
+            rows.append(_arec(NOW - 3599 + i, u, "step %d" % i, parent))
+            parent = u
+        _write_jsonl(self.proj / (SID + ".jsonl"), rows)
+        jd._discover_cache["fp"] = None
+        jd._discover_cache["result"] = None
+        ep = km.build_episode(SID, NOW)
+        self.assertEqual(len(ep["events"]), km.EPISODE_EVENT_CAP)
+        self.assertGreater(ep["truncated"], 0, "the cut is counted, never silent")
+
+    # ── the in-flight bracket ────────────────────────────────────────────────────────────────────
+
+    def test_is_clear_cmd_truth_table(self):
+        self.assertTrue(sb._is_clear_cmd("/clear"))
+        self.assertTrue(sb._is_clear_cmd("  /clear  "))
+        self.assertTrue(sb._is_clear_cmd("/clear now"))
+        self.assertFalse(sb._is_clear_cmd("/clearx"))
+        self.assertFalse(sb._is_clear_cmd("please /clear"))
+        self.assertFalse(sb._is_clear_cmd("/compact"))
+        self.assertFalse(sb._is_clear_cmd(""))
+
+    def test_clearing_bracket_sites(self):
+        src = inspect.getsource(sb)
+        # set on delivery + on a restored queue; cleared by the lastSid flip AND the turn's settle
+        self.assertIn("if _is_clear_cmd(text):", src)
+        self.assertIn("if any(_is_clear_cmd(t) for t in self._pending):", src)
+        flip = src.index("self.backend._update_reg(self.sid, lastSid=fsid)")
+        self.assertIn("self._clearing = False", src[flip:flip + 400],
+                      "the fork landing ends the bracket (event-based)")
+
+    def test_chip_says_clearing_first(self):
+        src = inspect.getsource(km._session_chip)
+        self.assertIn('"clearing" if _clearing_now(sid)', src)
+
+    def test_live_clearing_indicator_rides_build_session(self):
+        src = inspect.getsource(km.build_session)
+        self.assertIn('events.append({"kind": "clearing"})', src)
+        # a queued "/clear" folds while the live element represents it (mirror of the /compact fold)
+        self.assertIn('== "/clear"', src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_compacting_event.py
+++ b/tests/test_kernel_compacting_event.py
@@ -20,11 +20,13 @@ class CompactingEvent(unittest.TestCase):
         self.src = inspect.getsource(km.build_session)
 
     def test_compacting_signal_is_hoisted_from_the_busy_check(self):
-        # the corroborated compacting signal is computed once and reused (not the raw tmux state)
+        # the corroborated compacting signal is computed once and reused (not the raw tmux state);
+        # the path_override arm is the read-only episode render, where nothing is live by definition
         self.assertIn(
-            'compacting_now = _compacting(sid, (tm0 or {}).get("state", ""), parsed, now, (tm0 or {}).get("since"))',
+            '_compacting(sid, (tm0 or {}).get("state", ""), parsed, now, (tm0 or {}).get("since"))',
             self.src)
-        self.assertIn('busy = _session_working(parsed["turns"]) or compacting_now', self.src)
+        self.assertIn('busy = not path_override and (_session_working(parsed["turns"]) or compacting_now)',
+                      self.src)
 
     def test_a_compacting_event_is_emitted_while_compacting(self):
         self.assertIn('if compacting_now:', self.src)

--- a/tests/test_sdk_kernel.py
+++ b/tests/test_sdk_kernel.py
@@ -396,7 +396,8 @@ class SdkQueuedIndicator(unittest.TestCase):
         # in-memory queue, tmux from the transcript's queue-operation records (TmuxBackend.pending_queued →
         # _pending_queued). No backend fork in build_session anymore.
         self.assertIn("be = Sessions.backend_for(sid)", src)
-        self.assertIn("queued = be.pending_queued(sid)", src)
+        # (the path_override arm is the read-only episode render — a closed episode has no live queue)
+        self.assertIn("queued = [] if path_override else be.pending_queued(sid)", src)
         self.assertIn("return _pending_queued(p) if p else []", src)   # tmux pending_queued reads the transcript
 
 

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2267,7 +2267,9 @@ class TimelinePanel {
     const compactingNow = (s) => s.state === 'compacting' || (this._compactClicked[s.id] != null && (nowMs - this._compactClicked[s.id]) < 6000);
     // gutter = name column (left-aligned) + chip column (every chip shares an x,
     // like the dashboard's badge column). Names left-aligned, chips follow.
-    const visB = vis.map((s) => compactingNow(s)
+    const visB = vis.map((s) => s.state === 'clearing'
+      ? { label: 'Clearing', bg: BADGE.compacting.bg, fg: BADGE.compacting.fg }     // a /clear in flight — same context-op teal as compacting
+      : compactingNow(s)
       ? { label: 'Compacting', bg: BADGE.compacting.bg, fg: BADGE.compacting.fg }   // NO %: the scraped pct was laggy/inaccurate, and the SDK offers none (compact_progress events are lifecycle-only — investigated 2026-07-02); the scan-bar is the live cue
       : badgeFor(s));
     const visC = vis.map((s) => ctxInfo(s));
@@ -2417,7 +2419,7 @@ class TimelinePanel {
         const bh = lit ? eh : BAR_H;
         const bar = el('rect', { x: bx, y: y - bh / 2, width: bw, height: bh, rx: bh / 2, fill: s.color, opacity: lit ? 1 : 0.9 });
         svg.appendChild(bar);
-        const act = s.state === 'working' || s.state === 'permission' || s.state === 'awaiting' || s.state === 'awaitingBg' || s.state === 'compacting';
+        const act = s.state === 'working' || s.state === 'permission' || s.state === 'awaiting' || s.state === 'awaitingBg' || s.state === 'compacting' || s.state === 'clearing';
         const ongoing = s.live && act && t.end > t.start && (data.now - t.end) <= 5;
         const hit = el('rect', { x: bx, y: y - 7, width: bw, height: 14, fill: 'transparent' }); hit.style.cursor = 'pointer';
         const html = () => '<div class="r"><span class="chip" style="background:' + s.color + '"></span><span class="who" style="color:' + s.color + '">' + esc(s.name) + '</span><span class="t">' + clock(t.start) + '–' + clock(t.end) + '</span></div>' + this.barBody(t, ongoing);

--- a/ui/webview/clear-divider.test.ts
+++ b/ui/webview/clear-divider.test.ts
@@ -1,0 +1,106 @@
+// A /clear must not render as a dead gap (the user 2026-07-27). Three pieces, pinned at the source level
+// (no jsdom harness, like compact-divider.test.ts):
+//   1. LIVE: kind:"clearing" — an animated "Clearing conversation…" element (loader-dots motif) while the
+//      SDK backend's clearing bracket is lit; the chip/tab/statusline read "clearing" off the shared
+//      _session_chip derivation.
+//   2. DURABLE: kind:"clear" — a collapsed "Conversation cleared" notice card at the top of the fresh
+//      episode (above the system card, both auto-collapsed), so a cleared session is never events-empty
+//      and the "No messages yet." placeholder can't lie about a conversation that existed.
+//   3. LAZY: the card's body fetches the PRE-CLEAR conversation on first expand (loadEpisode →
+//      chatEpisode), rendered through the same per-event renderers, cached per boundary so the chat's
+//      per-push rebuilds never re-fetch.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const SDK = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
+const TL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
+
+test("the ChatEvent union carries both /clear kinds, dispatched to their renderers", () => {
+  assert.match(RENDER, /\| \{ kind: "clear"; clearedAt\?: number; episodes\?: number; ts\?: string; uuid\?: string \}/);
+  assert.match(RENDER, /\| \{ kind: "clearing"; ts\?: string; uuid\?: string \}/);
+  assert.match(RENDER, /if \(ev\.kind === "clearing"\) return renderClearing\(\);/);
+  assert.match(RENDER, /if \(ev\.kind === "clear"\) return renderClear\(ev\);/);
+});
+
+test("renderClear is a collapsed notice card keyed on the boundary, in the notice-card family", () => {
+  assert.match(RENDER, /const key = "clear:" \+ \(ev\.uuid \|\| sid\)/);
+  assert.match(RENDER, /noticeCard\(\{ variant: "clear", chip: "cleared", head, body, collapsible: true, key \}\)/);
+  // collapsed by DEFAULT: nothing pre-seeds openFolds for a clear key — expansion is the user's click
+  assert.doesNotMatch(RENDER, /openFolds\.add\("clear:/);
+});
+
+test("the pre-clear history lazy-loads once per boundary and renders through the shared renderers", () => {
+  // fetch on FIRST expand only: cache + pending dedup guard the postMessage
+  assert.match(RENDER, /if \(episodeCache\.has\(key\) \|\| episodePendingKey\.get\(sid\) === key\) return;/);
+  assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "loadEpisode", id: sid \}\)/);
+  // the reply fills the card body in place, and re-renders serve from the cache
+  assert.match(RENDER, /else if \(m\.type === "chatEpisode"\) chatEpisode\(m\);/);
+  assert.match(RENDER, /episodeCache\.set\(key, got\)/);
+  // the folded episode reuses renderEvent — the SAME renderers as the live transcript, not a text dump
+  assert.match(RENDER, /wrap\.appendChild\(renderEvent\(e\)\)/);
+  // a bounded render says what it cut (no silent truncation)
+  assert.match(RENDER, /earlier event.*of the cleared conversation not shown/);
+});
+
+test("renderClearing is the loader-dots in-progress element, and the chip family knows 'clearing'", () => {
+  assert.match(RENDER, /txt\.textContent = "Clearing conversation…";/);
+  assert.match(RENDER, /function renderClearing\(\): HTMLElement \{\n  const turn = el\("div", "turn turn-clearing"\);/);
+  assert.match(RENDER, /"clearing" \| "blocked"|clearing: "Clearing"/);   // ChipState + CHIP_LABEL entries
+  assert.match(RENDER, /⟳ Clearing conversation…/);                       // statusline line, like compacting's
+  assert.match(TL, /label: 'Clearing'/);                                  // timeline lane badge
+});
+
+test("the styles exist: quiet clear card, clearing line, nested episode scope", () => {
+  assert.match(CSS, /\.notice-card-clear \{ border-left-color: var\(--dim\); \}/);
+  assert.match(CSS, /\.clearing-line \{/);
+  assert.match(CSS, /\.clear-episode \{/);
+  assert.match(CSS, /\.clear-truncated \{/);
+});
+
+test("kernel: the boundary card leads the post-clear payload and the live indicator is event-based", () => {
+  // the {kind:"clear"} insert rides episode_rows (row -1 = the boundary), above the system card
+  assert.match(KERNEL, /boundary = _epi_rows\[-1\] if len\(_epi_rows\) >= 2 else None/);
+  assert.match(KERNEL, /"kind": "clear", "uuid": "clear:%s" % \(boundary\.get\("head"\)/);
+  // a cleared-but-empty fresh episode still gets events (the "No messages yet." lie is closed)
+  assert.match(KERNEL, /if events or boundary:/);
+  // the live indicator + the queued-"/clear" fold mirror the compacting pair
+  assert.match(KERNEL, /events\.append\(\{"kind": "clearing"\}\)/);
+  assert.match(KERNEL, /if clearing_now:/);
+  // the chip says clearing first (shared _session_chip derivation, chat + timeline)
+  assert.match(KERNEL, /"clearing" if _clearing_now\(sid\) else/);
+  // loadEpisode is a one-shot direct reply, and build_episode fails LOUDLY on a missing transcript
+  assert.match(KERNEL, /msg\.get\("type"\) == "loadEpisode"/);
+  assert.match(KERNEL, /build_episode\(str\(msg\["id"\]\), int\(time\.time\(\)\)\)/);
+  assert.match(KERNEL, /The pre-clear transcript file is missing/);
+});
+
+test("sdk backend: the clearing bracket is set on delivery and ends on exact events", () => {
+  assert.match(SDK, /def _is_clear_cmd\(text: str\) -> bool:/);
+  assert.match(SDK, /t == "\/clear" or t\.startswith\("\/clear "\)/);
+  assert.match(SDK, /if _is_clear_cmd\(text\):[\s\S]{0,500}s\._clearing = True/);
+  // restored-queue seed (a /clear queued when the kernel died still lights the bracket)
+  assert.match(SDK, /if any\(_is_clear_cmd\(t\) for t in self\._pending\):[^\n]*\n\s*self\._clearing = True/);
+  // ends: the lastSid-flipping init (the fork landed) + the turn's ResultMessage backstop
+  assert.match(SDK, /self\.backend\._update_reg\(self\.sid, lastSid=fsid\)[\s\S]{0,400}self\._clearing = False/);
+  assert.match(SDK, /self\._compacting = False\n\s*self\._clearing = False\s*# \/clear backstop/);
+});
+
+// executed twin of the python truth table — the command sniff is the bracket's trigger, so its shape
+// is behavior, not style
+test("_is_clear_cmd matches exactly the /clear invocations", () => {
+  const isClear = (text: string): boolean => {
+    const t = (text || "").trim();
+    return t === "/clear" || t.startsWith("/clear ");
+  };
+  assert.equal(isClear("/clear"), true);
+  assert.equal(isClear("  /clear  "), true);
+  assert.equal(isClear("/clear now"), true);
+  assert.equal(isClear("/clearx"), false);
+  assert.equal(isClear("please /clear"), false);
+  assert.equal(isClear("/compact"), false);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -125,6 +125,17 @@ type ChatEvent = (
   // until retried — a red-dot card at the bottom with a Retry button (the user 2026-06-16).
   | { kind: "apiError"; text: string; status?: number; ts?: string; uuid?: string }
   | { kind: "compact"; trigger?: string; preTokens?: number; postTokens?: number; summary?: string; ts?: string; uuid?: string }
+  // The /clear boundary (the user 2026-07-27): this session's conversation was cleared and the fresh
+  // episode starts here — a collapsed "Conversation cleared" notice card at the very top of the chat, the
+  // chat twin of the timeline's film-splice seam. Its body lazy-loads the PRE-CLEAR conversation on first
+  // expand (loadEpisode → chatEpisode, cached per boundary), so the cleared history stays one click away
+  // instead of vanishing. `uuid` is "clear:<episode head>" — stable across pushes (the fold key).
+  | { kind: "clear"; clearedAt?: number; episodes?: number; ts?: string; uuid?: string }
+  // LIVE /clear in progress (kernel-driven, event-based off the SDK backend's clearing bracket): an
+  // animated "Clearing conversation…" element between the /clear delivery and the fresh transcript
+  // landing — a stretch that otherwise has NO observable state and used to render as a dead gap, then
+  // "No messages yet." (the user 2026-07-27). No ts → off the rail (transient).
+  | { kind: "clearing"; ts?: string; uuid?: string }
   // LIVE compaction in progress (kernel-driven, event-based): an animated inline element while the session
   // compacts — sits above any queued/provisional message, and is replaced by the "compact" divider above
   // once the boundary lands and compacting clears (the user 2026-07-06). No ts → off the rail (transient).
@@ -168,7 +179,7 @@ type ChatEvent = (
 
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
-type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "blocked" | "retrying" | "interrupting";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
+type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
 interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; retrySuppressed?: boolean; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
@@ -647,7 +658,7 @@ function foldable(label: string, content: HTMLElement, key?: string): HTMLElemen
 // detached from the timeline. Nested → return the bare card; it sits in the parent turn's rail column under
 // its single dot (connected, like any in-turn card). A standalone notice (romp system) IS its own top-level
 // turn, so it keeps the .turn wrapper + dot.
-function noticeCard(o: { variant: "agent" | "romp" | "reminder" | "compact"; chip: string; logo?: boolean;
+function noticeCard(o: { variant: "agent" | "romp" | "reminder" | "compact" | "clear"; chip: string; logo?: boolean;
                         head: string; body: HTMLElement; collapsible?: boolean; key?: string;
                         nested?: boolean }): HTMLElement {
   const card = el("div", "notice-card notice-card-" + o.variant + (o.nested ? " notice-nested" : ""));
@@ -1703,6 +1714,8 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
   if (ev.kind === "queued") return renderQueued(ev);
   if (ev.kind === "apiError") return renderApiError(ev);
   if (ev.kind === "compacting") return renderCompacting();
+  if (ev.kind === "clearing") return renderClearing();
+  if (ev.kind === "clear") return renderClear(ev);
   if (ev.kind === "reconnecting") return renderReconnecting(ev);
   if (ev.kind === "retrying") return renderRetrying(ev);
   if (ev.kind === "retried") return renderRetried(ev);
@@ -1975,6 +1988,99 @@ function renderCompact(ev: Extract<ChatEvent, { kind: "compact" }>): HTMLElement
   // collapsible only when there's a summary to reveal; the "compacted" chip carries identity (no ✦ glyph)
   return noticeCard({ variant: "compact", chip: "compacted", head, body,
                       collapsible: !!summary, key: uuid ? "compact:" + uuid : undefined });
+}
+
+// The /clear boundary card (the user 2026-07-27): the fresh episode opens with a collapsed "Conversation
+// cleared" notice — the chat twin of the timeline's film-splice seam, in the same system-event family as
+// the compact divider. Progressive disclosure: the head is the one-line version; the PRE-CLEAR conversation
+// itself lazy-loads into the body on FIRST expand (loadEpisode → chatEpisode), rendered read-only through
+// the same per-event renderers as the live transcript, and cached per boundary uuid so the chat's per-push
+// rebuilds never re-fetch or re-ask the kernel. Auto-collapsed by default, like the system card beneath it.
+const episodeCache = new Map<string, { events: ChatEvent[]; truncated?: number; error?: string }>();
+const episodePendingKey = new Map<string, string>();   // sid → the fold key whose fetch is in flight
+
+function fillClearBody(body: HTMLElement, got: { events: ChatEvent[]; truncated?: number; error?: string }): void {
+  while (body.firstChild) body.removeChild(body.firstChild);
+  if (got.error) {
+    const p = el("div", "notice-plain");
+    p.textContent = got.error;
+    body.appendChild(p);
+    return;
+  }
+  if (got.truncated) {
+    const n = el("div", "clear-truncated");
+    n.textContent = `… ${got.truncated} earlier event${got.truncated === 1 ? "" : "s"} of the cleared conversation not shown`;
+    body.appendChild(n);
+  }
+  const wrap = el("div", "clear-episode");
+  for (const e of got.events) {
+    try { wrap.appendChild(renderEvent(e)); }
+    catch { /* one malformed historical event must not blank the whole fold */ }
+  }
+  body.appendChild(wrap);
+}
+
+function renderClear(ev: Extract<ChatEvent, { kind: "clear" }>): HTMLElement {
+  const sid = renderingSid || "";
+  const key = "clear:" + (ev.uuid || sid);
+  const head = "Conversation cleared — a fresh one starts here";
+  const body = el("div", "clear-body");
+  body.dataset.clearKey = key;
+  const cached = episodeCache.get(key);
+  if (cached) fillClearBody(body, cached);
+  else {
+    // placeholder until the first expand fetches — the loader motif (pulsing accent dots), per the
+    // "show the romp loader first" rule; replaced in place when chatEpisode lands
+    const p = el("div", "notice-plain clear-loading");
+    p.appendChild(metaDots());
+    p.appendChild(document.createTextNode(" Loading the cleared conversation…"));
+    body.appendChild(p);
+  }
+  const turn = noticeCard({ variant: "clear", chip: "cleared", head, body, collapsible: true, key });
+  // Fetch on FIRST expand (ride the same head click that toggles the fold — noticeCard owns the toggle):
+  // one request per boundary, deduped by the pending map; re-renders hit the cache instead.
+  const headEl = turn.querySelector(".notice-head");
+  headEl?.addEventListener("click", () => {
+    const card = turn.querySelector(".notice-card") || turn;
+    if (!card.classList.contains("notice-open")) return;                  // just collapsed — nothing to load
+    if (episodeCache.has(key) || episodePendingKey.get(sid) === key) return;
+    episodePendingKey.set(sid, key);
+    vscodeApi?.postMessage({ type: "loadEpisode", id: sid });
+  });
+  return turn;
+}
+
+// chatEpisode: the kernel's one-shot reply to loadEpisode — cache it under the key the expand recorded,
+// then fill the (possibly still-open) card body in place, wherever it currently sits in the DOM.
+function chatEpisode(m: any): void {
+  const sid = String(m.id || "");
+  const key = episodePendingKey.get(sid);
+  if (!key) return;
+  episodePendingKey.delete(sid);
+  const got = { events: (m.events || []) as ChatEvent[], truncated: m.truncated || 0,
+                error: m.error ? String(m.error) : undefined };
+  episodeCache.set(key, got);
+  document.querySelectorAll<HTMLElement>(".clear-body").forEach((b) => {
+    if (b.dataset.clearKey === key) fillClearBody(b, got);
+  });
+}
+
+// LIVE /clear in progress (the user 2026-07-27): an animated inline element between the /clear delivery
+// and the fresh transcript landing — the loader dots motif, sibling of the reconnecting element. Without
+// it that stretch showed a dead gap and then a bare "No messages yet.". Event-based off the SDK backend's
+// clearing bracket; it vanishes the instant the fork lands, when the "Conversation cleared" boundary card
+// (renderClear) takes over as the durable record.
+function renderClearing(): HTMLElement {
+  const turn = el("div", "turn turn-clearing");
+  turn.appendChild(dot("ring"));
+  const line = el("div", "clearing-line");
+  line.appendChild(metaDots());   // the pulsing accent-blue dots — "it's romp, working"
+  const txt = el("span", "clearing-text");
+  txt.textContent = "Clearing conversation…";
+  line.appendChild(txt);
+  line.title = "starting a fresh conversation — the cleared one stays one click away, behind the divider that lands here";
+  turn.appendChild(line);
+  return turn;
 }
 
 // LIVE compaction in progress (the user 2026-07-06): an animated inline element in the chat flow while the
@@ -3169,7 +3275,7 @@ function renderTabs() {
     else if (st === "blocked") tab.classList.add((s.status.apiTooLong || s.status.apiSpendLimit) ? "tab-blocked" : "tab-retrying");
     else if (st === "awaiting") tab.classList.add("tab-awaiting");
     else if (st === "retrying") tab.classList.add("tab-retrying");       // amber: soft-blocked on an API auto-retry
-    else if (st === "compacting") tab.classList.add("tab-compacting");
+    else if (st === "compacting" || st === "clearing") tab.classList.add("tab-compacting");   // both: a context op in flight
     else if (st === "closed") tab.classList.add("tab-closed");       // dead session: read-only, struck-through label
     if (s.status.faded) tab.classList.add("at-rest");
     // WORKING shows a yellow dot; AWAITING-BG the same dot in straw — matching the chip's color, so the
@@ -5877,7 +5983,7 @@ function setCtxBar(bar: HTMLElement, ctxStr: string | undefined, compacting = fa
 const CHIP_LABEL: Record<ChipState, string> = {
   working: "Working", ready: "Ready", awaiting: "Blocked",
   awaitingBg: "Awaiting",   // idle, waiting on background work it dispatched — straw, not working-yellow (the user 2026-07-13)
-  idle: "Idle", closed: "Closed", compacting: "Compacting", blocked: "API error",
+  idle: "Idle", closed: "Closed", compacting: "Compacting", clearing: "Clearing", blocked: "API error",
   retrying: "API retrying…",   // a live session stalled on an API rate-limit/overload auto-retry (api 2026-06-23)
   interrupting: "Interrupting…",   // stop sent, turn not yet settled (the user 2026-07-02) — clears to READY on its own
 };
@@ -5948,6 +6054,10 @@ function updateStatusline() {
   } else if (s.status.state === "compacting") {
     const c = el("span", "compacting-line");
     c.textContent = "⟳ Compacting context…";
+    sl.appendChild(c);
+  } else if (s.status.state === "clearing") {
+    const c = el("span", "compacting-line");   // same in-progress line treatment as compacting (one style per info type)
+    c.textContent = "⟳ Clearing conversation…";
     sl.appendChild(c);
   } else {
     const chip = el("span", `chip chip-${s.status.state}`);
@@ -6590,6 +6700,7 @@ window.addEventListener("message", (e: MessageEvent) => {
   }
   else if (m.type === "chatTail") chatTail(m);
   else if (m.type === "chatHead") chatHead(m);
+  else if (m.type === "chatEpisode") chatEpisode(m);
   else if (m.type === "update") update(m);
   else if (m.type === "status") statusOnly(m);
   else if (m.type === "focus") {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -802,6 +802,12 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .turn-reconnecting .dot, .turn-reconnecting .time-marker { top: 10px; }
 .turn-reconnecting .dot { background: var(--accent); border: none; }
 .reconnecting-line { display: inline-flex; align-items: center; gap: 8px; color: var(--dim); font-size: 0.9em; font-weight: 600; letter-spacing: 0.02em; }
+/* LIVE /clear in progress — the loader dots + a muted "Clearing conversation…" line; a transient sibling
+   of the reconnecting element (same treatment: an in-flight romp-driven session operation). */
+.turn-clearing { padding-top: 4px; padding-bottom: 4px; }
+.turn-clearing .dot, .turn-clearing .time-marker { top: 10px; }
+.turn-clearing .dot { background: var(--accent); border: none; }
+.clearing-line { display: inline-flex; align-items: center; gap: 8px; color: var(--dim); font-size: 0.9em; font-weight: 600; letter-spacing: 0.02em; }
 /* LIVE api_retry (rate-limit/overload backoff) — the loader dots + an AMBER "API retrying…" line, tinted the
    SAME retrying status color as the tab border (#e67e22 — a STATUS color, not accent chrome) so the chat
    element reads as that state; a transient sibling of the compacting/reconnecting elements. */
@@ -1461,6 +1467,15 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .notice-card-compact { border-left-color: var(--st-compacting-bg, #14b8a6); }
 .notice-chip-compact { color: var(--st-compacting-bg, #14b8a6); border-color: var(--st-compacting-bg, #14b8a6); }
 .notice-dot-compact { border-color: var(--st-compacting-bg, #14b8a6); }
+/* the /clear boundary — QUIET, like the timeline's film-splice seam: a dim frame (this is a historical
+   marker, not a live status), with the pre-clear conversation nested in the body once lazy-loaded. */
+.notice-card-clear { border-left-color: var(--dim); }
+.notice-chip-clear { color: var(--dim); border-color: var(--dim); }
+.notice-dot-clear { border-color: var(--dim); }
+.clear-loading { display: inline-flex; align-items: center; gap: 8px; }
+.clear-truncated { color: var(--dim); padding: 4px 0 6px; }
+/* the nested pre-clear transcript: same renderers as the live chat, scoped so its rail hugs the card */
+.clear-episode { border-top: 1px solid var(--box-border); margin-top: 4px; padding-top: 4px; }
 
 /* the pinned "system context" card (the user 2026-06-19): a proper bordered BOX at the very top of the
    transcript that looks complete even when collapsed (a ⚙ header + one-line summary + caret), expanding

--- a/ui/webview/timeline-awaiting.test.ts
+++ b/ui/webview/timeline-awaiting.test.ts
@@ -16,8 +16,8 @@ test("an awaitingBg lane renders an Awaiting badge in the romp brand green (the 
   assert.match(TL, /else if \(s\.state === 'awaitingBg' \|\| s\.awaitingBg\) m = \{ label: 'Awaiting', kind: 'awaitbg' \};/);
   // brand green, matching --st-awaitbg-bg in styles.css (this file loads standalone, so the hex is mirrored)
   assert.match(TL, /awaitbg: \{ bg: '#54B204', fg: '#0c1a00' \}/);
-  // an awaitingBg lane still reads ACTIVE (full opacity / ongoing treatment), like working/compacting
-  assert.match(TL, /s\.state === 'awaitingBg' \|\| s\.state === 'compacting';/);
+  // an awaitingBg lane still reads ACTIVE (full opacity / ongoing treatment), like working/compacting/clearing
+  assert.match(TL, /s\.state === 'awaitingBg' \|\| s\.state === 'compacting' \|\| s\.state === 'clearing';/);
 });
 
 test("precedence: blocked-on-you beats awaiting, awaiting beats Ready", () => {


### PR DESCRIPTION
The chat pane was the one surface with zero episode awareness (`plans/clear-episodes.md`): a `/clear` wiped the DOM to "No messages yet.", the pre-clear conversation became unreachable, and the stretch while the CLI minted the fresh transcript had no observable state anywhere.

Three pieces, all event-based:

- **Live indicator.** The SDK backend brackets an in-flight `/clear` (`SdkSession._clearing`, the `/compact` twin: set on delivery + restored-queue seed; ended by the `lastSid`-flipping init or the turn's settle). The chat shows an animated "Clearing conversation…" element, the chip/tab/statusline/timeline badge read `clearing`, and a queued `/clear` folds while the element represents it. tmux keeps its known fork-lane gap.
- **Boundary card.** `build_session` opens a post-clear episode with a collapsed `{kind:"clear"}` "Conversation cleared" notice card (from `episodes/` row −1), above the system card — both auto-collapsed at the top of the fresh conversation, so a cleared session is never events-empty.
- **Lazy pre-clear fold.** Expanding the card fetches the pre-clear conversation once (`loadEpisode` → `chatEpisode`, cached per boundary) through `build_session`'s new read-only `path_override` mode — no live overlays, durable-note flush capped at the boundary — rendered by the same per-event renderers, capped at `EPISODE_EVENT_CAP` with an honest truncated count, and failing loudly when the old transcript is missing.

Also fixes a latent test-isolation bug: `jd._rebind_state` now clears `_namefp_memo` (per-sid, same-second-mtime keying served a previous root's project dir across a rebind).

Tests: `tests/test_clear_chat_view.py` (10 functional tests over synthetic episodes) + `ui/webview/clear-divider.test.ts` (source pins both sides). Full suites green: 3174 python, 1340 node, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)