### PR TITLE
The docs preview restarts on git changes, which mkdocs' watcher sleeps through

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -178,9 +178,10 @@ the LLM calls in Romp's judge pipeline.
 
 ### Linking kernels on other machines
 
-Link the Romp kernels running on several machines, a laptop and a server say:
-you drive them all from one interface, and their agents talk to each other
-across the machines. A linked machine's sessions appear as
+Romp kernels can connect and communicate across multiple machines, e.g. a laptop
+and a server. This lets you control them all from one user interface, and lets
+their agents communicate across the machines. A linked machine's sessions appear
+as
 <span class="romp-sid"><span class="host">server:</span>api</span> tabs and
 timeline lanes beside your local ones, its cards share the feed, and its
 sessions message yours, so an agent on your desktop can hand work to one on the
@@ -203,7 +204,7 @@ sit down at it and drive the fleet from there too.
 Attach any machine you can `ssh` to, such as a server or a desktop that stays
 on. Your kernel opens the connection.
 
-1. **Install Romp on that machine**, the same way you installed it on this one
+1. **Install Romp on that machine**, the same way you installed it on your own
    (see [Install](install.md)).
 2. **Check that `ssh <host>` connects without prompting you for anything.** Romp
    opens the connection in the background, so a password or passphrase prompt

--- a/scripts/docs-serve.sh
+++ b/scripts/docs-serve.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Serve the docs site so a browser refresh ALWAYS shows the current tree.
+#
+# `mkdocs serve` watches the filesystem, and that watcher reliably catches your
+# own saves but misses changes that arrive through git: a merge, a checkout, a
+# rebase replaces files wholesale and the rebuild never fires, so the page you
+# refresh is whatever was true when the server started. That has fooled us into
+# re-reporting fixed text as broken more than once.
+#
+# So: run mkdocs serve, and watch the one thing its watcher misses. Whenever
+# HEAD or the working tree moves, restart it. Event-based on git state, not a
+# rebuild timer (CLAUDE.md's design rule).
+#
+#   scripts/docs-serve.sh [port]        # default 8000
+set -euo pipefail
+
+PORT="${1:-8000}"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+# HEAD plus the hash of every tracked+untracked doc input: catches merges,
+# checkouts, and stashes, which are exactly what the mkdocs watcher sleeps through.
+tree_id() {
+  {
+    git rev-parse HEAD 2>/dev/null || true
+    git status --porcelain -- docs mkdocs.yml overrides 2>/dev/null || true
+  } | shasum | cut -d' ' -f1
+}
+
+MKDOCS="${ROMP_MKDOCS:-mkdocs}"     # stubbable, so the test never runs a real server
+POLL="${ROMP_DOCS_POLL:-2}"
+
+SERVER=""
+start() {
+  "$MKDOCS" serve -a "127.0.0.1:$PORT" &
+  SERVER=$!
+}
+stop() { [ -n "$SERVER" ] && kill "$SERVER" 2>/dev/null || true; }
+trap 'stop; exit 0' INT TERM
+
+start
+LAST="$(tree_id)"
+echo "docs on http://127.0.0.1:$PORT/romp/ — restarting on any git change"
+
+while true; do
+  sleep "$POLL"
+  NOW="$(tree_id)"
+  if [ "$NOW" != "$LAST" ]; then
+    echo "[docs-serve] tree moved; restarting mkdocs"
+    LAST="$NOW"
+    stop
+    wait "$SERVER" 2>/dev/null || true
+    start
+  fi
+  # A crashed mkdocs (a bad config, a port grab) must not leave a dead port
+  # answering nothing: bring it back rather than looping over a corpse.
+  if ! kill -0 "$SERVER" 2>/dev/null; then
+    echo "[docs-serve] mkdocs exited; restarting"
+    start
+  fi
+done

--- a/tests/docs-serve.bats
+++ b/tests/docs-serve.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+
+# scripts/docs-serve.sh — serve the docs so a browser refresh always shows the
+# current tree. `mkdocs serve`'s own watcher catches your saves but sleeps
+# through changes that arrive via git (a merge replaces files wholesale), which
+# is the whole reason this wrapper exists: it watches git state and restarts.
+# The real mkdocs is stubbed via ROMP_MKDOCS, so no test starts a web server.
+
+ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    REPO="$TEST_DIR/repo"
+    mkdir -p "$REPO/scripts" "$REPO/docs"
+    cp "$ROMP_DIR/scripts/docs-serve.sh" "$REPO/scripts/"
+    chmod +x "$REPO/scripts/docs-serve.sh"
+    git init -q "$REPO"
+    git -C "$REPO" config user.email t@e.invalid
+    git -C "$REPO" config user.name t
+    echo "start" > "$REPO/docs/guide.md"
+    printf 'site_name: t\n' > "$REPO/mkdocs.yml"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -qm init
+
+    # A stub that logs one line per launch and then blocks, so a restart is
+    # visible as a second line rather than inferred from a pid.
+    STUB="$TEST_DIR/mkdocs"
+    RUNS="$TEST_DIR/runs.log"
+    cat > "$STUB" <<EOF
+#!/usr/bin/env bash
+echo "serve" >> "$RUNS"
+while true; do sleep 0.2; done
+EOF
+    chmod +x "$STUB"
+    export ROMP_MKDOCS="$STUB"
+    export ROMP_DOCS_POLL=0.2
+}
+
+teardown() {
+    [ -n "${LOOP_PID:-}" ] && kill "$LOOP_PID" 2>/dev/null
+    pkill -f "$TEST_DIR/mkdocs" 2>/dev/null
+    rm -rf "$TEST_DIR"
+    return 0
+}
+
+runs() { [ -f "$RUNS" ] && wc -l < "$RUNS" | tr -d ' ' || echo 0; }
+
+@test "it starts the server once and leaves it alone while the tree is still" {
+    "$REPO/scripts/docs-serve.sh" 8099 >/dev/null 2>&1 &
+    LOOP_PID=$!
+    sleep 1.5
+    [ "$(runs)" = "1" ]
+}
+
+@test "a commit restarts the server, which the mkdocs watcher would have missed" {
+    "$REPO/scripts/docs-serve.sh" 8099 >/dev/null 2>&1 &
+    LOOP_PID=$!
+    sleep 1
+    [ "$(runs)" = "1" ]
+
+    # A merge/checkout looks like this to the tree: HEAD moves, files replaced.
+    echo "edited" > "$REPO/docs/guide.md"
+    git -C "$REPO" add -A
+    git -C "$REPO" commit -qm second
+    sleep 1.5
+
+    [ "$(runs)" -ge 2 ]
+}
+
+@test "an uncommitted doc edit restarts it too" {
+    "$REPO/scripts/docs-serve.sh" 8099 >/dev/null 2>&1 &
+    LOOP_PID=$!
+    sleep 1
+    echo "dirty" > "$REPO/docs/new.md"
+    sleep 1.5
+    [ "$(runs)" -ge 2 ]
+}
+
+@test "a crashed mkdocs is brought back, never a dead port answering nothing" {
+    "$REPO/scripts/docs-serve.sh" 8099 >/dev/null 2>&1 &
+    LOOP_PID=$!
+    sleep 1
+    [ "$(runs)" = "1" ]
+    pkill -f "$TEST_DIR/mkdocs"
+    sleep 1.5
+    [ "$(runs)" -ge 2 ]
+}


### PR DESCRIPTION
**The problem.** `mkdocs serve` watches the filesystem and reliably catches your
own saves, but misses files replaced wholesale by a merge, checkout or rebase.
So the page you refresh is whatever was true when the server started. That cost
real time twice today: already-fixed text was reported as broken because the
preview was still serving the pre-merge build.

**`scripts/docs-serve.sh`** runs `mkdocs serve` and watches the one thing its
watcher misses, restarting whenever HEAD or the docs working tree moves. Keyed
on git state rather than a rebuild timer, per CLAUDE.md's event-over-heuristic
rule. It also restarts mkdocs if it dies, so the port never answers with
nothing.

```
scripts/docs-serve.sh [port]      # default 8000
```

`tests/docs-serve.bats` covers all four behaviors with the real mkdocs stubbed
via `ROMP_MKDOCS`, so no test starts a web server. Mutation-checked: neutering
the git watcher fails tests 2 and 3, so they are not passing vacuously.

**Also in this PR**, two prose fixes from reader feedback:

- The topic sentence takes the kernels as its subject and names both things
  linking buys, not just the shared interface.
- Step 1 says to install Romp "the same way you installed it on your own"
  machine. "On this one" is ambiguous on a page the reader may be reading from
  either end of the link.

Strict build clean; bats green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)