### PR TITLE
Error bell popover, model-label unify fix, card-age provenance tooltip

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4148,30 +4148,30 @@ _TMUX = TmuxBackend()
 
 
 def _unify_model_labels(rows):
-    """Make every session in the fleet's live map show the SAME display name for the SAME model — so a
-    session on the version-less best-effort label ("Opus", from a /model switch that hasn't run a turn
-    yet, incl. a stale-badge heal) borrows the fleet's real versioned name ("Opus 4.8") when another live
-    session is already reporting it (the user 2026-07-03, who asked why some say Opus and others Opus 4.8).
-    Family = the model's first word (Opus/Opus 4.8 → 'opus'); the VERSIONED variant (has a space) wins.
-    Display-only + in place; a family no live session runs a versioned variant of just keeps its short
-    label. Never merges across families, so it can't relabel one model as another."""
-    best = {}                                         # family -> the richest (versioned) display name seen
+    """Give a version-less best-effort label ("Opus", from a /model switch or new session that hasn't run
+    a turn yet, incl. a stale-badge heal) the fleet's real versioned name ("Opus 5") when the fleet knows
+    it unambiguously (the user 2026-07-03, who asked why some say Opus and others Opus 4.8).
+    Family = the model's first word (Opus/Opus 5 → 'opus'). Display-only + in place. Two hard rules
+    (the user 2026-07-27, during the Opus 4.8 → 5 transition):
+    - A VERSIONED label is ground truth (that session's own turns reported it) and is NEVER rewritten.
+      The old code relabeled everything to the family's "richest" name, its tiebreak preferred the longer
+      string, and "Opus 4.8" beats "Opus 5" — so sessions genuinely on Opus 5 displayed as 4.8.
+    - A bare label borrows only when the fleet runs exactly ONE versioned variant of that family. During
+      a version transition the fleet runs two, a bare "Opus" is genuinely ambiguous (a fresh session
+      resolves the alias to the NEW version, not the fleet's dominant one), so it stays bare rather than
+      guessing wrong."""
+    variants = {}                                     # family -> set of versioned display names seen live
     for r in rows.values():
         m = (r.get("model") or "").strip()
-        if not m:
-            continue
-        fam = m.split()[0].lower()
-        cur = best.get(fam)
-        # prefer a versioned name (has a space, e.g. "Opus 4.8") over a bare family word ("Opus")
-        if cur is None or (" " in m and " " not in cur) or (" " in m and len(m) > len(cur)):
-            best[fam] = m
+        if " " in m:
+            variants.setdefault(m.split()[0].lower(), set()).add(m)
     for r in rows.values():
         m = (r.get("model") or "").strip()
-        if not m:
+        if not m or " " in m:                         # versioned = that session's own report; keep it
             continue
-        rich = best.get(m.split()[0].lower())
-        if rich and rich != m:
-            r["model"] = rich
+        v = variants.get(m.lower())
+        if v and len(v) == 1:
+            r["model"] = next(iter(v))
 
 
 class Sessions:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14302,25 +14302,81 @@ window.addEventListener('message',function(e){if(e&&e.data&&e.data.romp==='ready
 setTimeout(hide,5000);})();
 """
 
-# Connection-status banner (the user 2026-06-27): each pane iframe posts {romp:'wsState',app,state} when its
-# kernel WebSocket opens/closes. The shell shows ONE "disconnected — reconnecting…" banner whenever ANY pane's
-# socket is down (the timeline/feed/etc. are pushed from the kernel, so a drop silently freezes them — the user
-# hit exactly this, network gone, timeline stopped moving, no idea why). It clears once every pane is back.
-_LANDING_NET_JS = """
-(function(){var bn=document.getElementById('romp-offline');if(!bn)return;var st={};
-// Only a VISIBLE pane raises the banner (the user 2026-07-06): a pane toggled OFF still holds a live socket
-// (the Fleet pane is hidden by default, its iframe always loaded), so a blip on a pane you can't even see
-// shouldn't cry "Disconnected" while the chat pane you interact through is up. Gate on the pane-enabled body
-// class the toggle sets (po-chat/po-feed/po-timeline/po-fleet), and re-check on toggle so hiding a down pane
-// clears the banner and showing one raises it. A genuinely-down VISIBLE pane still shows it — that pane IS
-// frozen and a reload resyncs it.
+# The shell's NOTIFICATION CENTER (the user 2026-07-27): errors used to drop as fixed banners from the top
+# of the screen ("Disconnected — reconnecting…", usage-limit reached, judge degraded) and got in the way.
+# They now land as entries in a sequential feed behind a bell in the bottom bar's action cluster (next to
+# ↻ / network / gear): the bell goes red with an unread count when something arrives, the popover lists
+# entries newest-first with per-row clear + Clear all, and opening it marks everything seen. Entries persist
+# in localStorage so a reload (kernel restart) keeps the story. Sources: pane WS drops (each pane iframe
+# posts {romp:'wsState',app,state}; the timeline/feed/etc. are pushed from the kernel, so a drop silently
+# freezes them), the usage-limit + judge-degraded signatures (see _LANDING_USAGE_JS), and any
+# {romp:'notify',kind,text} a pane posts. window.__rompNotify(kind,text) is the one write path.
+_LANDING_ERRS_JS = """
+(function(){var icon=document.getElementById('rail-errs'),micon=document.getElementById('merr'),
+back=document.getElementById('rerr-back'),list=document.getElementById('rerr-list'),
+clearBtn=document.getElementById('rerr-clear'),x=document.getElementById('rerr-x'),
+rel=document.getElementById('rerr-reload');
+if(!icon||!back||!list)return;
+var KEY='romp:notices',MAX=100;
+function load(){try{var v=JSON.parse(localStorage.getItem(KEY)||'[]');return Array.isArray(v)?v:[];}catch(e){return[];}}
+var NOTES=load();
+function save(){try{localStorage.setItem(KEY,JSON.stringify(NOTES));}catch(e){}}
+function ago(t){var dt=Math.max(0,Math.floor(Date.now()/1000)-t);if(dt<90)return 'just now';
+var m=Math.round(dt/60);if(m<60)return m+'m ago';var h=Math.floor(m/60);
+return h<24?h+'h ago':Math.floor(h/24)+'d ago';}
+function unseen(){var n=0;for(var i=0;i<NOTES.length;i++)if(!NOTES[i].seen)n++;return n;}
+// The bell + badge: red while anything is unread OR a visible pane's socket is DOWN right now (the live
+// problem keeps the cue up even after the entry is read; it clears the moment the pane reconnects).
+function paint(){var n=unseen();
+[icon,micon].forEach(function(el){if(!el)return;var b=el.querySelector('.rerr-badge');
+if(b){b.hidden=!n;b.textContent=n>99?'99+':String(n);}
+el.classList.toggle('has',n>0||liveDown());});
+if(!back.hidden)renderList();}
+function renderList(){list.innerHTML='';
+if(!NOTES.length){var e=document.createElement('div');e.className='rerr-empty';e.textContent='No errors';list.appendChild(e);return;}
+for(var i=NOTES.length-1;i>=0;i--)(function(n,i){var row=document.createElement('div');row.className='rerr-row';
+var tm=document.createElement('span');tm.className='rerr-t';tm.textContent=ago(n.t);
+var tx=document.createElement('span');tx.className='rerr-msg';tx.textContent=n.text+(n.n>1?' (x'+n.n+')':'');
+var del=document.createElement('span');del.className='rerr-del';del.textContent='\\u00d7';del.title='Clear';
+del.addEventListener('click',function(ev){ev.stopPropagation();NOTES.splice(i,1);save();renderList();paint();});
+row.appendChild(tm);row.appendChild(tx);row.appendChild(del);list.appendChild(row);})(NOTES[i],i);}
+// One write path. A repeat of the NEWEST entry (same kind+text — e.g. a reconnect loop dropping over and
+// over) coalesces into it with a count instead of flooding the feed: event-exact, no time window.
+window.__rompNotify=function(kind,text){if(!text)return;
+var last=NOTES[NOTES.length-1];
+if(last&&last.kind===kind&&last.text===String(text)){last.n=(last.n||1)+1;last.t=Math.floor(Date.now()/1000);last.seen=false;}
+else{NOTES.push({kind:String(kind||'error'),text:String(text),t:Math.floor(Date.now()/1000),n:1,seen:false});
+if(NOTES.length>MAX)NOTES=NOTES.slice(-MAX);}
+save();paint();};
+// pane iframes can feed the center too
+window.addEventListener('message',function(e){var m=e&&e.data;
+if(m&&m.romp==='notify'&&m.text)window.__rompNotify(m.kind||'error',m.text);});
+// Connection tracking (was the #romp-offline top banner). Only a VISIBLE pane counts (the user 2026-07-06):
+// a pane toggled OFF still holds a live socket (the Fleet pane is hidden by default, its iframe always
+// loaded), so a blip on a pane you can't even see shouldn't cry wolf while the chat pane you interact
+// through is up. Gate on the pane-enabled body class the toggle sets (po-chat/po-feed/po-timeline/po-fleet).
+// Only the up->down TRANSITION logs an entry; the live red cue rides the state itself.
+var st={};
 function shown(k){return document.body.classList.contains('po-'+k);}
-function refresh(){var down=false;for(var k in st){if(st[k]==='down'&&shown(k)){down=true;break;}}bn.classList.toggle('show',down);}
-window.addEventListener('message',function(e){var m=e&&e.data;if(!m||m.romp!=='wsState')return;st[m.app]=(m.state==='up')?'up':'down';refresh();});
-window.addEventListener('romp-panes',refresh);
-// never dead-end: the retries normally win, but a browser holding reconnects back (Firefox failure
-// backoff) leaves nothing to click — the user reloads by hand anyway, so put that action ON the banner.
-var rb=document.getElementById('ro-reload');if(rb)rb.addEventListener('click',function(){location.reload();});})();
+function liveDown(){for(var k in st){if(st[k]==='down'&&shown(k))return true;}return false;}
+var PN={chat:'Chat',feed:'Feed',timeline:'Timeline',fleet:'Outline'};
+window.addEventListener('message',function(e){var m=e&&e.data;if(!m||m.romp!=='wsState')return;
+var s=(m.state==='up')?'up':'down',prev=st[m.app];st[m.app]=s;
+if(s==='down'&&prev!=='down'&&shown(m.app))
+window.__rompNotify('conn','Kernel connection lost \\u2014 '+(PN[m.app]||m.app)+' pane (reconnecting)');
+else paint();});
+window.addEventListener('romp-panes',paint);
+function open(){for(var i=0;i<NOTES.length;i++)NOTES[i].seen=true;save();back.hidden=false;renderList();paint();}
+function close(){back.hidden=true;}
+icon.addEventListener('click',function(){back.hidden?open():close();});
+back.addEventListener('click',function(e){if(e.target===back)close();});
+if(x)x.addEventListener('click',close);
+if(clearBtn)clearBtn.addEventListener('click',function(){NOTES=[];save();renderList();paint();});
+// never dead-end a dead connection: the WS retries normally win, but a browser holding reconnects back
+// (Firefox failure backoff) leaves nothing to click — the reload action lives in the popover header now.
+if(rel)rel.addEventListener('click',function(){location.reload();});
+window.__rompOpenErrs=open;   // the mobile bar's bell routes here (no rail on mobile)
+paint();})();
 """
 
 
@@ -14346,47 +14402,39 @@ var WINS=[['fiveHour',5*3600,'5h','Session','5 hours'],
           ['sevenDay',7*86400,'7d','Weekly','7 days'],
           ['fable',7*86400,'F5','Fable 5','Fable 5']];
 var LAST={};
-// Banner dismissal (the user 2026-07-03): a maxed window — especially Fable 5's 7-DAY one — lingers for
-// days, and the fixed top banner overlaps the tab strip, so a ✕ must clear it. The dismissal is keyed to
-// the SIGNATURE of which windows are limited (not a timer), persisted in localStorage so it survives a
-// reload for THIS limit episode. A NEW window hitting its cap (or a reset that re-limits) changes the
-// signature → the banner returns with the new info; a full clear drops the stored signature.
-var _limSig='';
+// Limit / judge-degraded SIGNATURES (the user 2026-07-03; reshaped 2026-07-27): these used to gate fixed
+// top banners with a ✕ dismissal; the banners are gone — the same situations now log ONE entry each in
+// the shell's notification center (the bell, _LANDING_ERRS_JS). The stored signature means "this exact
+// episode is already logged", persisted in localStorage so a reload doesn't re-log it. A NEW window
+// hitting its cap (or a changed failure count/cause) changes the signature → a fresh entry; a full clear
+// drops the stored signature so a future episode logs again. Keys kept from the old banner dismissals,
+// so an episode the user already dismissed stays quiet across the upgrade.
 function _limGet(){try{return localStorage.getItem('romp:limitDismiss')||'';}catch(e){return '';}}
 function _limPut(v){try{if(v){localStorage.setItem('romp:limitDismiss',v);}else{localStorage.removeItem('romp:limitDismiss');}}catch(e){}}
-(function(){var lb=document.getElementById('romp-limit');if(!lb)return;var x=lb.querySelector('.rl-x');
-if(x){x.addEventListener('click',function(e){e.stopPropagation();_limPut(_limSig);lb.classList.remove('show');});}})();
-var _jdSig='';
 function _jdGet(){try{return localStorage.getItem('romp:judgeDegradedDismiss')||'';}catch(e){return '';}}
 function _jdPut(v){try{if(v){localStorage.setItem('romp:judgeDegradedDismiss',v);}else{localStorage.removeItem('romp:judgeDegradedDismiss');}}catch(e){}}
-(function(){var jb=document.getElementById('romp-judge-degraded');if(!jb)return;var x=jb.querySelector('.rl-x');
-if(x){x.addEventListener('click',function(e){e.stopPropagation();_jdPut(_jdSig);jb.classList.remove('show');});}})();
 function render(u){
-// JUDGE-FAILURE BANNER (the user 2026-07-03): surface at the top when the distiller/brief GAVE UP on cards
-// (kernel `judgeFailures` on the usage payload, count + cause) — like the usage-limit banner, and stacked
-// under it. Names the cause; dismissal is keyed to the count+cause SIGNATURE so a changed situation re-shows.
-// Per-card what-happened detail lives in that card's yellow warning chip → modal.
-var jb=document.getElementById('romp-judge-degraded');
-if(jb){var jf=u&&u.judgeFailures,jon=!!(jf&&jf.count>0);
+// JUDGE-FAILURE entry (the user 2026-07-03): when the distiller/brief GAVE UP on cards (kernel
+// `judgeFailures` on the usage payload, count + cause), log it to the notification center — once per
+// count+cause signature, so a changed situation logs afresh. Per-card what-happened detail lives in that
+// card's yellow warning chip → modal.
+var jf=u&&u.judgeFailures,jon=!!(jf&&jf.count>0);
 var jsig=jon?(jf.count+'|'+(jf.cause||'')):'';
-_jdSig=jsig;if(!jon){_jdPut('');}   // nothing failing → forget any dismissal so a future failure shows again
-var jshow=jon&&jsig!==_jdGet();jb.classList.toggle('show',jshow);
-if(jshow){var jmsg=jb.querySelector('.rl-msg');if(jmsg){var nc=jf.count,noun=(nc===1?'card':'cards');
-jmsg.textContent=nc+' '+noun+" couldn't be summarized — "+(jf.cause||'the summarizer hit errors')+'. Open a flagged card for what happened.';}}}
-// LIMIT BANNER (the user 2026-07-01): a top banner when an ACCOUNT-WIDE window (5h Session / 7d Weekly) is
-// maxed — those pause retries + the judges, so a proactive heads-up is warranted. Fable 5 is DELIBERATELY
-// EXCLUDED (the user 2026-07-04): its window is MODEL-scoped, so exhausting it doesn't stop the models romp
-// uses (Opus/Sonnet/Haiku) and doesn't pause anything — a "Fable limit reached" banner popping every refresh
-// for the 7-day window was pure noise for someone not on Fable. A Fable-only session that hits the wall is
-// surfaced WHEN YOU ACTUALLY USE IT (api-error → blocked on that session), and the rail's third bar still
-// shows the Fable usage passively; the proactive banner just no longer fires on it.
-var lb=document.getElementById('romp-limit');
-if(lb){var lim=u&&u.limited,on=!!(lim&&(lim.fiveHour||lim.sevenDay));
+if(!jon){_jdPut('');}   // nothing failing → forget the logged signature so a future failure logs again
+else if(jsig!==_jdGet()){_jdPut(jsig);var nc=jf.count,noun=(nc===1?'card':'cards');
+if(window.__rompNotify)window.__rompNotify('judge',nc+' '+noun+" couldn't be summarized — "+(jf.cause||'the summarizer hit errors')+'. Open a flagged card for what happened.');}
+// LIMIT entry (the user 2026-07-01): when an ACCOUNT-WIDE window (5h Session / 7d Weekly) is maxed —
+// those pause retries + the judges, so a proactive heads-up is warranted. Fable 5 is DELIBERATELY
+// EXCLUDED (the user 2026-07-04): its window is MODEL-scoped, so exhausting it doesn't stop the models
+// romp uses (Opus/Sonnet/Haiku) and doesn't pause anything — a "Fable limit reached" notice popping every
+// refresh for the 7-day window was pure noise for someone not on Fable. A Fable-only session that hits
+// the wall is surfaced WHEN YOU ACTUALLY USE IT (api-error → blocked on that session), and the rail's
+// third bar still shows the Fable usage passively.
+var lim=u&&u.limited,on=!!(lim&&(lim.fiveHour||lim.sevenDay));
 var sig=on?((lim.fiveHour?'5':'')+(lim.sevenDay?'7':'')):'';
-_limSig=sig;if(!on){_limPut('');}   // fully cleared → forget any dismissal so a future limit shows again
-var show=on&&sig!==_limGet();lb.classList.toggle('show',show);
-if(show){var msg=lb.querySelector('.rl-msg');if(msg){var names=[];if(lim.fiveHour)names.push('Session (5h)');if(lim.sevenDay)names.push('Weekly (7d)');
-msg.textContent=names.join(' and ')+' usage limit reached — retries paused until it resets';}}}
+if(!on){_limPut('');}   // fully cleared → forget the logged signature so a future limit logs again
+else if(sig!==_limGet()){_limPut(sig);var names=[];if(lim.fiveHour)names.push('Session (5h)');if(lim.sevenDay)names.push('Weekly (7d)');
+if(window.__rompNotify)window.__rompNotify('limit',names.join(' and ')+' usage limit reached — retries paused until it resets');}
 if(!u||(!u.fiveHour&&!u.sevenDay&&!u.fable)){el.innerHTML='';tip.style.display='none';return;}
 var nowS=Math.floor(Date.now()/1000),html='';LAST={};LAST._t=(typeof u.t==='number')?u.t:null;
 WINS.forEach(function(w){var seg=u[w[0]];if(!seg)return;
@@ -14836,7 +14884,8 @@ for(var i=0;i<B.length;i++)(function(b){var pk=b.getAttribute('data-pane');if(pk
 var A={settings:function(){var f=F.feed;try{f&&f.contentWindow&&f.contentWindow.postMessage({romp:'openSettings'},'*');}catch(e){}},
 net:function(){try{window.__rompOpenNet&&window.__rompOpenNet();}catch(e){}},
 usage:function(){try{window.__rompUsagePanel&&window.__rompUsagePanel();}catch(e){}},
-restart:function(){try{window.__rompRestart&&window.__rompRestart();}catch(e){}}};
+restart:function(){try{window.__rompRestart&&window.__rompRestart();}catch(e){}},
+errs:function(){try{window.__rompOpenErrs&&window.__rompOpenErrs();}catch(e){}}};
 Array.prototype.forEach.call(bar.querySelectorAll('button[data-act]'),function(b){
 b.addEventListener('click',function(){var f=A[b.getAttribute('data-act')];if(f)f();});});
 window.addEventListener('message',function(e){var m=e.data;if(!m)return;if(m.romp==='reveal'&&m.pane)show(m.pane);// the chat header's Fleet pill / the fleet's back-to-chat post toggleFleet — on mobile that IS a tab switch
@@ -15336,46 +15385,48 @@ def _landing():
             # the splash is the BIG version of the shared loader (the swirl-as-o reads large)
             "#romp-boot .rl-in{gap:30px}#romp-boot .rl-word{font-size:120px}"
             "#romp-boot .rl-dots{gap:9px}#romp-boot .rl-dots i{width:11px;height:11px}"
-            # the connection-status banner: a top-centered pill shown only while a pane's WS is down (event-based)
-            "#romp-offline{position:fixed;top:0;left:50%;transform:translateX(-50%);z-index:10000;display:none;"
-            "align-items:center;gap:8px;background:#3a1d1d;color:#ffd9d9;border:1px solid #7a3030;border-top:none;"
-            "border-radius:0 0 9px 9px;padding:5px 15px;font-size:12.5px;font-family:var(--vscode-font-family);"
-            "box-shadow:0 3px 12px rgba(0,0,0,.45)}#romp-offline.show{display:flex}"
-            "#romp-offline .ro-dot{width:8px;height:8px;border-radius:50%;background:#ff6b6b;"
-            "animation:roPulse 1.1s ease-in-out infinite}"
-            "@keyframes roPulse{0%,100%{opacity:.3}50%{opacity:1}}"
-            # the banner must not dead-end: retries normally recover on their own, but when the browser
-            # holds reconnects back (Firefox failure backoff) the user's one-click out is a reload.
-            "#ro-reload{font:inherit;cursor:pointer;border-radius:6px;padding:2px 10px;font-weight:600;"
-            "background:#7a3030;color:#ffd9d9;border:1px solid #9a4040}"
-            "#ro-reload:hover{background:#8a3838}"
-            # usage-limit banner (the user 2026-07-01): amber, sits just below the offline slot so the two never
-            # overlap; shown when a usage window hits 100% (kernel `limited`) — retries auto-pause until it resets.
-            "#romp-limit{position:fixed;top:0;left:50%;transform:translateX(-50%);z-index:9999;display:none;"
-            "align-items:center;gap:8px;background:#3a2f16;color:#ffe6b3;border:1px solid #7a5f24;border-top:none;"
-            "border-radius:0 0 9px 9px;padding:5px 15px;font-size:12.5px;font-family:var(--vscode-font-family);"
-            "box-shadow:0 3px 12px rgba(0,0,0,.45)}#romp-limit.show{display:flex}"
-            "#romp-offline.show ~ #romp-limit.show{top:34px}"   # if both are up, stack the limit banner below
-            "#romp-limit .rl-dot{width:8px;height:8px;border-radius:50%;background:#e0a030;flex:0 0 auto}"
-            "#romp-limit .rl-x{cursor:pointer;margin-left:6px;opacity:.6;font-weight:700;font-size:14px;line-height:1;flex:0 0 auto}"
-            "#romp-limit .rl-x:hover{opacity:1}"
-            # JUDGE-FAILURE banner (the user 2026-07-03): same look as the usage-limit one, stacked below it
-            "#romp-judge-degraded{position:fixed;top:0;left:50%;transform:translateX(-50%);z-index:9998;display:none;"
-            "align-items:center;gap:8px;background:#3a2f16;color:#ffe6b3;border:1px solid #7a5f24;border-top:none;"
-            "border-radius:0 0 9px 9px;padding:5px 15px;font-size:12.5px;font-family:var(--vscode-font-family);"
-            "box-shadow:0 3px 12px rgba(0,0,0,.45)}#romp-judge-degraded.show{display:flex}"
-            "#romp-offline.show ~ #romp-judge-degraded.show{top:34px}"      # offline above → drop one row
-            "#romp-limit.show ~ #romp-judge-degraded.show{top:34px}"        # limit above → drop one row
-            "#romp-offline.show ~ #romp-limit.show ~ #romp-judge-degraded.show{top:68px}"   # both above → drop two
-            "#romp-judge-degraded .rl-dot{width:8px;height:8px;border-radius:50%;background:#e0a030;flex:0 0 auto}"
-            "#romp-judge-degraded .rl-x{cursor:pointer;margin-left:6px;opacity:.6;font-weight:700;font-size:14px;line-height:1;flex:0 0 auto}"
-            "#romp-judge-degraded .rl-x:hover{opacity:1}"
+            # The notification center (the user 2026-07-27; replaces the fixed top banners — offline /
+            # usage-limit / judge-degraded — which got in the way): the bell in the bottom bar's action
+            # cluster goes RED (with an unread count) when an error lands; the popover is a panel anchored
+            # above the bell (bottom-right), newest first, per-row clear + Clear all.
+            "#rail-errs{position:relative}"
+            "#rail-errs.has,#merr.has{color:#ff6b6b}"
+            ".rerr-badge{position:absolute;top:-4px;right:-6px;background:#ff6b6b;color:#1e1e1e;"
+            "border-radius:8px;min-width:14px;height:14px;padding:0 3px;font-size:9.5px;font-weight:700;"
+            "line-height:14px;text-align:center;pointer-events:none}"
+            "#merr{position:relative}"
+            "#rerr-back{position:fixed;inset:0;z-index:210;background:rgba(0,0,0,.35)}"
+            "#rerr-panel{position:absolute;right:10px;bottom:44px;width:min(440px,94vw);max-height:min(60vh,480px);"
+            "display:flex;flex-direction:column;background:#26282b;border:1px solid #4a4d51;border-radius:10px;"
+            "box-shadow:0 10px 30px #0000008a;font:12.5px/1.45 var(--vscode-font-family)}"
+            "#rerr-panel .rerr-top{display:flex;align-items:center;gap:8px;font-size:14px;font-weight:600;color:#e8eaed;"
+            "padding:10px 12px;border-bottom:1px solid #3a3d41;flex:0 0 auto}"
+            "#rerr-panel .rerr-top .sp{flex:1}"
+            "#rerr-clear,#rerr-reload{font:inherit;font-size:12px;cursor:pointer;border-radius:6px;padding:3px 10px;"
+            "background:none;color:#9aa0a6;border:1px solid #4a4d51}"
+            "#rerr-clear:hover,#rerr-reload:hover{color:#e6e6e6;border-color:#6a6d71}"
+            "#rerr-x{cursor:pointer;opacity:.6;font-weight:700;font-size:15px;line-height:1}"
+            "#rerr-x:hover{opacity:1}"
+            "#rerr-list{overflow-y:auto;padding:4px 0;flex:1 1 auto}"
+            ".rerr-row{display:flex;align-items:baseline;gap:8px;padding:6px 12px;color:#d6d8da}"
+            ".rerr-row+.rerr-row{border-top:1px solid #2f3236}"
+            ".rerr-t{flex:0 0 auto;color:#8a9099;font-size:11px;white-space:nowrap}"
+            ".rerr-msg{flex:1;min-width:0;overflow-wrap:anywhere}"
+            ".rerr-del{flex:0 0 auto;cursor:pointer;opacity:.5;font-weight:700}"
+            ".rerr-del:hover{opacity:1}"
+            ".rerr-empty{padding:16px 12px;color:#8a9099;text-align:center}"
             "</style></head><body class='po-chat po-feed po-timeline'>"
             "<div id=romp-boot>" + _loader_inner() + "</div>"
-            "<div id=romp-offline><span class=ro-dot></span><span>Disconnected — reconnecting…</span>"
-            "<button id=ro-reload title='Reload the dashboard now instead of waiting out the retries'>Reload</button></div>"
-            "<div id=romp-limit><span class=rl-dot></span><span class=rl-msg>Usage limit reached — retries paused until it resets</span><span class=rl-x title='Dismiss until the limit changes'>×</span></div>"
-            "<div id=romp-judge-degraded><span class=rl-dot></span><span class=rl-msg>Some cards couldn't be summarized</span><span class=rl-x title='Dismiss until this changes'>×</span></div>"
+            # the notification popover (hidden until the bell is clicked; backdrop click closes). The
+            # Reload button keeps the old offline banner's one-click out for a dead connection the
+            # browser's own backoff won't retry.
+            "<div id=rerr-back hidden><div id=rerr-panel>"
+            "<div class=rerr-top>Errors<span class=sp></span>"
+            "<button id=rerr-reload title='Reload the dashboard (for a connection the retries gave up on)'>Reload</button>"
+            "<button id=rerr-clear title='Clear all entries'>Clear all</button>"
+            "<span id=rerr-x title=Close>×</span></div>"
+            "<div id=rerr-list></div>"
+            "</div></div>"
             "<div class=col>"
             "<div class=row>"
             "<div class=pane id=chat-pane><iframe id=f-chat class=m-on src=/chat></iframe></div>"
@@ -15405,6 +15456,14 @@ def _landing():
             "</div>"   # /.rail-scroll
             # refresh + network + settings, pinned to the far RIGHT (settings last), always visible:
             "<div class=rail-acts>"
+            # the notification bell (the user 2026-07-27): monochrome outline like its neighbors, red +
+            # unread badge when an error lands (see _LANDING_ERRS_JS). ATTRIBUTES QUOTED (the rail-net saga).
+            "<div class=rail-act id=rail-errs title=Errors aria-label=Errors>"
+            "<svg viewBox='0 0 16 16' width='18' height='18'>"
+            "<path d='M8 2 C5.8 2 4.5 3.7 4.5 6 L4.5 9 L3 11.5 L13 11.5 L11.5 9 L11.5 6 C11.5 3.7 10.2 2 8 2 Z'"
+            " fill='none' stroke='currentColor' stroke-width='1.2' stroke-linejoin='round'/>"
+            "<path d='M6.5 13.2 A1.6 1.6 0 0 0 9.5 13.2' fill='none' stroke='currentColor' stroke-width='1.2'/></svg>"
+            "<span class=rerr-badge hidden></span></div>"
             "<div class=rail-act id=rail-refresh title='Restart the romp kernel' aria-label=Refresh>↻</div>"
             # remote-kernels (federation): a LAN glyph — one device wired down a bus to two below. Goes
             # accent-blue (.on) while a remote is connected. Below help, above settings (the user 2026-06-30).
@@ -15448,6 +15507,13 @@ def _landing():
             # restart the kernel (the user 2026-07-22): the rail's ↻ is hidden on mobile, so mirror it here.
             # Same glyph as the rail; wired to window.__rompRestart (POST /restart, poll /healthz, reload).
             "<button class=mact data-act=restart aria-label='Restart kernel' title='Restart kernel'>↻</button>"
+            # the notification bell on mobile too (same glyph + badge; opens the same popover)
+            "<button class=mact id=merr data-act=errs aria-label=Errors title=Errors>"
+            "<svg viewBox='0 0 16 16' width='18' height='18'>"
+            "<path d='M8 2 C5.8 2 4.5 3.7 4.5 6 L4.5 9 L3 11.5 L13 11.5 L11.5 9 L11.5 6 C11.5 3.7 10.2 2 8 2 Z'"
+            " fill='none' stroke='currentColor' stroke-width='1.2' stroke-linejoin='round'/>"
+            "<path d='M6.5 13.2 A1.6 1.6 0 0 0 9.5 13.2' fill='none' stroke='currentColor' stroke-width='1.2'/></svg>"
+            "<span class=rerr-badge hidden></span></button>"
             # settings wears the desktop rail's OWN gear glyph, ⛭ (U+26ED), not the outlined star it had.
             "<button class=mact data-act=settings aria-label=Settings title=Settings>⛭</button>"
             "</nav>"
@@ -15518,7 +15584,7 @@ def _landing():
             # the mobile tab bar. (The splitter used to query a stale id=t for the timeline iframe and
             # throw on every load — fixed above by giving that iframe id=f-timeline.)
             "<script>" + _LANDING_BOOT_JS + "</script>"
-            "<script>" + _LANDING_NET_JS + "</script>"
+            "<script>" + _LANDING_ERRS_JS + "</script>"
             "<script>" + _LANDING_USAGE_JS + "</script>"
             "<script>" + _LANDING_JS + "</script>"
             "<script>" + _LANDING_FOCUS_JS + "</script>"

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""The shell's notification center (the user 2026-07-27) must actually WORK, not just parse.
+
+Errors used to drop as fixed banners from the top of the screen and got in the way; they now land as
+entries behind the bell in the bottom bar's action cluster. This EXECUTES the real injected
+_LANDING_ERRS_JS in node against a DOM stub (the test_remotes_panel_render.py pattern — source pins
+can't catch scope slips in this class of inline JS) and drives the full story:
+
+  a visible pane's WS drop logs an entry + reddens the bell with an unread count; a repeat of the same
+  drop coalesces (event-exact, no time window); a HIDDEN pane's drop logs nothing; opening the popover
+  marks everything seen; panes can post {romp:'notify'}; per-row clear and Clear all empty the store;
+  entries persist in localStorage.
+
+Synthetic only — no network, no real DOM.
+"""
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_errc", os.path.join(BIN, "romp-kernel")).load_module()
+
+HARNESS = r"""
+'use strict';
+const STORE = {};
+global.localStorage = {
+  getItem: (k) => (k in STORE ? STORE[k] : null),
+  setItem: (k, v) => { STORE[k] = String(v); },
+  removeItem: (k) => { delete STORE[k]; },
+};
+function mkEl(id) {
+  return {
+    id: id, hidden: true, textContent: '', title: '', className: '',
+    children: [], _cls: new Set(), _ls: {}, _html: '', _badge: null,
+    classList: null,   // filled below (needs `this`)
+    appendChild(c) { this.children.push(c); return c; },
+    querySelector(sel) { return sel === '.rerr-badge' ? this._badge : null; },
+    addEventListener(k, f) { (this._ls[k] = this._ls[k] || []).push(f); },
+    fire(k, ev) { (this._ls[k] || []).forEach((f) => f(ev || { stopPropagation() {}, target: null })); },
+    get innerHTML() { return this._html; },
+    set innerHTML(v) { this._html = v; this.children = []; },
+  };
+}
+function withCls(el) {
+  el._cls = new Set();
+  el.classList = {
+    add: (c) => el._cls.add(c), remove: (c) => el._cls.delete(c),
+    toggle: (c, on) => { if (on === undefined) on = !el._cls.has(c); if (on) el._cls.add(c); else el._cls.delete(c); },
+    contains: (c) => el._cls.has(c),
+  };
+  return el;
+}
+const EL = {};
+['rail-errs', 'merr', 'rerr-back', 'rerr-list', 'rerr-clear', 'rerr-x', 'rerr-reload'].forEach((id) => {
+  EL[id] = withCls(mkEl(id));
+});
+EL['rail-errs']._badge = withCls(mkEl(''));
+EL['merr']._badge = withCls(mkEl(''));
+const BODY = new Set(['po-chat', 'po-feed', 'po-timeline']);   // fleet pane hidden, like the real default
+const WL = {};
+global.window = {
+  addEventListener: (k, f) => { (WL[k] = WL[k] || []).push(f); },
+};
+global.document = {
+  getElementById: (id) => EL[id] || null,
+  createElement: () => withCls(mkEl('')),
+  body: { classList: { contains: (c) => BODY.has(c) } },
+};
+function post(data) { (WL['message'] || []).forEach((f) => f({ data: data })); }
+function notes() { return JSON.parse(STORE['romp:notices'] || '[]'); }
+"""
+
+DRIVER = r"""
+const out = {};
+// 1) a VISIBLE pane's drop logs an entry + reddens the bell with a count
+post({ romp: 'wsState', app: 'chat', state: 'down' });
+out.afterDrop = { n: notes().length, text: notes()[0].text,
+  red: EL['rail-errs']._cls.has('has'), mred: EL['merr']._cls.has('has'),
+  badge: EL['rail-errs']._badge.textContent, badgeShown: !EL['rail-errs']._badge.hidden };
+// 2) up then down again — the SAME error coalesces into one entry with a count (no flood)
+post({ romp: 'wsState', app: 'chat', state: 'up' });
+post({ romp: 'wsState', app: 'chat', state: 'down' });
+out.afterRepeat = { n: notes().length, times: notes()[0].n, badge: EL['rail-errs']._badge.textContent };
+// 3) a HIDDEN pane's drop logs nothing (fleet is toggled off)
+post({ romp: 'wsState', app: 'fleet', state: 'down' });
+out.afterHidden = { n: notes().length };
+// 4) panes can feed the center directly
+post({ romp: 'notify', kind: 'warn', text: 'TESTHOST delivery failed' });
+out.afterNotify = { n: notes().length, badge: EL['rail-errs']._badge.textContent };
+// 5) opening the popover marks everything seen (badge clears; red stays while chat is still down)
+EL['rail-errs'].fire('click');
+out.afterOpen = { open: !EL['rerr-back'].hidden, rows: EL['rerr-list'].children.length,
+  badgeShown: !EL['rail-errs']._badge.hidden, red: EL['rail-errs']._cls.has('has'),
+  newestFirst: EL['rerr-list'].children[0].children[1].textContent };
+// 6) per-row clear drops just that entry
+EL['rerr-list'].children[0].children[2].fire('click');
+out.afterRowClear = { n: notes().length, rows: EL['rerr-list'].children.length };
+// 7) Clear all empties the store and shows the empty state
+EL['rerr-clear'].fire('click');
+out.afterClearAll = { n: notes().length, rows: EL['rerr-list'].children.length,
+  empty: EL['rerr-list'].children[0].textContent };
+// 8) once the pane reconnects, the live red cue clears too
+post({ romp: 'wsState', app: 'chat', state: 'up' });
+out.afterReconnect = { red: EL['rail-errs']._cls.has('has') };
+console.log(JSON.stringify(out));
+"""
+
+
+class ErrorCenterExecutes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        script = HARNESS + km._LANDING_ERRS_JS + DRIVER
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+            f.write(script)
+            path = f.name
+        try:
+            r = subprocess.run(["node", path], capture_output=True, text=True, timeout=30)
+        finally:
+            os.unlink(path)
+        assert r.returncode == 0, "the center's JS threw: " + r.stderr[:800]
+        cls.out = json.loads(r.stdout.strip().splitlines()[-1])
+
+    def test_a_visible_pane_drop_logs_and_reddens_the_bell(self):
+        a = self.out["afterDrop"]
+        self.assertEqual(a["n"], 1)
+        self.assertIn("Chat", a["text"])
+        self.assertTrue(a["red"], "the rail bell goes red")
+        self.assertTrue(a["mred"], "the mobile bell goes red too")
+        self.assertEqual(a["badge"], "1")
+        self.assertTrue(a["badgeShown"])
+
+    def test_a_repeat_of_the_same_error_coalesces(self):
+        a = self.out["afterRepeat"]
+        self.assertEqual(a["n"], 1, "no flood: the same error is one entry")
+        self.assertEqual(a["times"], 2, "with a count")
+
+    def test_a_hidden_panes_drop_logs_nothing(self):
+        self.assertEqual(self.out["afterHidden"]["n"], 1)
+
+    def test_panes_can_post_notify(self):
+        a = self.out["afterNotify"]
+        self.assertEqual(a["n"], 2)
+        self.assertEqual(a["badge"], "2")
+
+    def test_opening_marks_seen_but_a_live_problem_keeps_the_cue(self):
+        a = self.out["afterOpen"]
+        self.assertTrue(a["open"])
+        self.assertEqual(a["rows"], 2)
+        self.assertFalse(a["badgeShown"], "opening marks everything seen")
+        self.assertTrue(a["red"], "chat is still down → the live cue stays")
+        self.assertIn("delivery failed", a["newestFirst"], "newest entry renders first")
+
+    def test_per_row_clear_and_clear_all(self):
+        self.assertEqual(self.out["afterRowClear"]["n"], 1)
+        self.assertEqual(self.out["afterRowClear"]["rows"], 1)
+        self.assertEqual(self.out["afterClearAll"]["n"], 0)
+        self.assertEqual(self.out["afterClearAll"]["rows"], 1)
+        self.assertEqual(self.out["afterClearAll"]["empty"], "No errors")
+
+    def test_reconnect_clears_the_live_cue(self):
+        self.assertFalse(self.out["afterReconnect"]["red"])
+
+
+class ErrorCenterWiring(unittest.TestCase):
+    def test_the_shell_mounts_bell_popover_and_script(self):
+        html = km._landing()
+        for pin in ("id=rail-errs", "id=rerr-back", "id=rerr-list", "id=rerr-clear",
+                    "id=merr", "class=rerr-badge"):
+            self.assertIn(pin, html)
+        self.assertIn("window.__rompNotify=function", html)
+        # the mobile bar routes its bell to the same popover
+        self.assertIn("errs:function(){try{window.__rompOpenErrs&&window.__rompOpenErrs();}catch(e){}}", html)
+
+    def test_the_old_top_banners_are_gone(self):
+        html = km._landing()
+        for gone in ("id=romp-offline", "id=romp-limit", "id=romp-judge-degraded"):
+            self.assertNotIn(gone, html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5614,6 +5614,22 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(rows["c"]["model"], "Fable", "no versioned variant in the fleet → keep the short label")
         self.assertEqual(rows["f"]["model"], "", "empty stays empty; never crashes")
 
+    def test_unify_model_labels_never_rewrites_a_versioned_name_and_stays_bare_when_ambiguous(self):
+        # the user 2026-07-27, during the Opus 4.8 → 5 default flip: the old unify relabeled EVERY row to
+        # the family's "richest" name, and its tiebreak preferred the longer string — so "Opus 4.8" beat
+        # "Opus 5" and sessions genuinely running Opus 5 (their own turns said so) DISPLAYED as 4.8, which
+        # is how a brand-new session on the new default looked stuck on the old one. A versioned label is
+        # that session's own report and must never be rewritten; a bare "Opus" amid TWO live versions is
+        # ambiguous (a fresh session resolves the alias to the NEW version, not the fleet's dominant one)
+        # and must stay bare rather than guess.
+        rows = {"old": {"model": "Opus 4.8"}, "new": {"model": "Opus 5"}, "fresh": {"model": "Opus"},
+                "s": {"model": "Sonnet"}, "s5": {"model": "Sonnet 5"}}
+        km._unify_model_labels(rows)
+        self.assertEqual(rows["new"]["model"], "Opus 5", "a session's own versioned report is ground truth")
+        self.assertEqual(rows["old"]["model"], "Opus 4.8")
+        self.assertEqual(rows["fresh"]["model"], "Opus", "two live versions → a bare label stays bare")
+        self.assertEqual(rows["s"]["model"], "Sonnet 5", "one live version → still borrows")
+
     def test_timeline_lane_survives_hidden_tab(self):
         # the user 2026-06-17 (reversing d52f69f): ×-hiding a tab is a tab-strip preference and must NOT
         # erase the lane from the timeline — the timeline is a complete activity history. So a dead AND

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -1,8 +1,12 @@
-"""Connection-status banner (the user 2026-06-27): a real network drop used to blind-reload each pane iframe
-into a dead page, so the dashboard silently froze (the timeline "stopped moving") with no explanation. Now each
-pane reports its WebSocket state to the shell, which shows ONE "Disconnected — reconnecting…" banner while any
-pane is down, and the panes RECONNECT (retry) instead of blind-reloading — reloading to resync only once the
-socket is actually back. Source pins on the kernel's injected JS/HTML."""
+"""Connection-status reporting (the user 2026-06-27): a real network drop used to blind-reload each pane
+iframe into a dead page, so the dashboard silently froze (the timeline "stopped moving") with no explanation.
+Now each pane reports its WebSocket state to the shell, and the panes RECONNECT (retry) instead of
+blind-reloading — reloading to resync only once the socket is actually back.
+
+The shell surface changed on 2026-07-27: the fixed top "Disconnected — reconnecting…" banner is gone —
+connection drops now log entries in the shell's NOTIFICATION CENTER (the bell in the bottom bar, red while
+anything is unread or a visible pane is down), whose behavioral tests live in test_error_center.py. The
+source pins here cover the pane shim (unchanged) and the shell's wiring of the center."""
 import inspect
 import os
 import unittest
@@ -60,14 +64,15 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn("if(ws&&ws.readyState<=1)ws.close();", js)
         self.assertIn("if(!ws||ws.readyState===3)connect();", js)
 
-    def test_offline_banner_has_a_reload_button(self):
+    def test_error_popover_has_a_reload_button(self):
         # never dead-end (progressive disclosure rule): when the browser holds reconnects back, the
-        # user's actual recovery action — reload — must be ON the banner, not a manual url-bar refresh.
+        # user's actual recovery action — reload — must be reachable from the error surface. It moved
+        # from the old offline banner into the notification popover's header (2026-07-27).
         land = inspect.getsource(km._landing)
-        self.assertIn("id=ro-reload", land, "the banner carries the button")
-        self.assertIn("#ro-reload{", land, "and its style")
-        self.assertIn("document.getElementById('ro-reload')", km._LANDING_NET_JS)
-        self.assertIn("location.reload();});})();", km._LANDING_NET_JS, "a click reloads — user-initiated, never automatic")
+        self.assertIn("id=rerr-reload", land, "the popover header carries the button")
+        self.assertIn("document.getElementById('rerr-reload')", km._LANDING_ERRS_JS)
+        self.assertIn("rel.addEventListener('click',function(){location.reload();})", km._LANDING_ERRS_JS,
+                      "a click reloads — user-initiated, never automatic")
 
     def test_shell_rstale_banner_shows_on_ws_stale_message(self):
         # the #rstale reload banner (formerly build-drift only) now ALSO shows on a pane's wsStale post, with a
@@ -99,31 +104,32 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn('window.addEventListener("message"', km._TIMELINE_BOOT)
         self.assertIn("panel.update(m.data)", km._TIMELINE_BOOT)
 
-    def test_shell_has_the_banner_and_its_listener(self):
-        # the net-state script: shows the banner when ANY pane is down, clears when all are up
-        self.assertIn("st[m.app]=(m.state==='up')?'up':'down'", km._LANDING_NET_JS)
-        self.assertIn("bn.classList.toggle('show',down)", km._LANDING_NET_JS)
-        # the shell mounts the banner element, its CSS, and wires the script
+    def test_shell_mounts_the_notification_center(self):
+        # the shell listens for pane wsState posts and routes drops into the notification center — the
+        # old fixed top banner is GONE (it got in the way, the user 2026-07-27)
+        self.assertIn("var s=(m.state==='up')?'up':'down',prev=st[m.app];st[m.app]=s;", km._LANDING_ERRS_JS)
         land = inspect.getsource(km._landing)
-        self.assertIn("id=romp-offline", land, "the banner element is in the shell body")
-        self.assertIn("Disconnected — reconnecting…", land)
-        self.assertIn("#romp-offline.show{display:flex}", land, "hidden until a pane drops")
-        self.assertIn("_LANDING_NET_JS", land, "the listener script is injected into the shell")
+        self.assertIn("id=rail-errs", land, "the bell sits in the bottom bar's action cluster")
+        self.assertIn("id=rerr-back", land, "the popover backdrop is in the shell body")
+        self.assertIn("_LANDING_ERRS_JS", land, "the center's script is injected into the shell")
+        self.assertNotIn("id=romp-offline", land, "the top banner element is gone")
+        self.assertNotIn("Disconnected — reconnecting…", land)
 
-    def test_only_visible_panes_raise_the_banner(self):
+    def test_only_visible_panes_count(self):
         # a pane toggled OFF still holds a live socket (the Fleet pane is hidden by default, its iframe always
-        # loaded), so a blip on a pane you can't even see must NOT raise the global "Disconnected" alarm while
-        # the chat pane you interact through is up (the user 2026-07-06). Gate on the pane-enabled body class
+        # loaded), so a blip on a pane you can't even see must NOT log an error / redden the bell while the
+        # chat pane you interact through is up (the user 2026-07-06). Gate on the pane-enabled body class
         # the toggle sets (po-chat/po-feed/po-timeline/po-fleet), and re-check when panes toggle.
-        js = km._LANDING_NET_JS
+        js = km._LANDING_ERRS_JS
         self.assertIn("function shown(k){return document.body.classList.contains('po-'+k);}", js)
-        self.assertIn("if(st[k]==='down'&&shown(k))", js, "a down pane counts only while its pane is visible")
-        self.assertIn("window.addEventListener('romp-panes',refresh)", js, "re-check the banner on pane toggle")
+        self.assertIn("if(st[k]==='down'&&shown(k))return true;", js, "a down pane counts only while visible")
+        self.assertIn("shown(m.app)", js, "and only a visible pane's drop logs an entry")
+        self.assertIn("window.addEventListener('romp-panes',paint)", js, "re-check the cue on pane toggle")
         # the pane toggle actually fires the romp-panes event this listens for, and both scripts ride the shell
         self.assertIn("new Event('romp-panes')", km._LANDING_COLLAPSE_JS)
         land = inspect.getsource(km._landing)
         self.assertIn("_LANDING_COLLAPSE_JS", land)
-        self.assertIn("_LANDING_NET_JS", land)
+        self.assertIn("_LANDING_ERRS_JS", land)
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_usage_limit.py
+++ b/tests/test_kernel_usage_limit.py
@@ -196,28 +196,24 @@ class AutoPauseOnSpendLimit(unittest.TestCase):
 
 
 class LimitBannerWiring(unittest.TestCase):
-    def test_the_shell_has_the_banner_and_the_widget_drives_it(self):
+    # 2026-07-27: the fixed top banner is GONE — a maxed window now logs ONE entry in the shell's
+    # notification center (the bell; see _LANDING_ERRS_JS + test_error_center.py), still gated on the
+    # limited-window signature so an episode logs exactly once and a NEW episode logs afresh.
+    def test_the_limit_logs_to_the_notification_center_not_a_banner(self):
         land = km._landing()
-        self.assertIn("<div id=romp-limit>", land)
-        self.assertIn("class=rl-msg", land)
-        self.assertIn("#romp-limit.show{display:flex}", land)
+        self.assertNotIn("<div id=romp-limit>", land, "the top banner element is gone")
         js = km._LANDING_USAGE_JS
-        self.assertIn("var lb=document.getElementById('romp-limit');", js)
-        self.assertIn("lb.classList.toggle('show',show);", js)
+        self.assertIn("window.__rompNotify('limit'", js)
         self.assertIn("usage limit reached", js)
 
-    def test_the_banner_has_a_dismiss_button_gated_on_the_limit_signature(self):
-        land = km._landing()
-        # a ✕ affordance is in the banner + styled
-        self.assertIn("class=rl-x", land)
-        self.assertIn("#romp-limit .rl-x", land)
+    def test_the_entry_is_gated_on_the_limit_signature(self):
         js = km._LANDING_USAGE_JS
-        # dismissal is keyed to WHICH windows are limited (a signature), persisted in localStorage
+        # logging is keyed to WHICH windows are limited (a signature), persisted in localStorage
         self.assertIn("romp:limitDismiss", js)
-        self.assertIn("_limPut(_limSig)", js)                 # ✕ stores the current signature → hides
-        self.assertIn("sig!==_limGet()", js)                  # a stored signature suppresses re-showing
-        self.assertIn("if(!on){_limPut('');}", js)            # a full clear forgets the dismissal
-        # a NEW limited-window set has a different signature → the banner returns (episode identity, not a timer)
+        self.assertIn("sig!==_limGet()", js)                  # a stored signature suppresses re-logging
+        self.assertIn("_limPut(sig)", js)                     # logging stores the signature
+        self.assertIn("if(!on){_limPut('');}", js)            # a full clear forgets it
+        # a NEW limited-window set has a different signature → a fresh entry (episode identity, not a timer)
         self.assertIn("(lim.fiveHour?'5':'')+(lim.sevenDay?'7':'')", js)
 
 
@@ -284,15 +280,17 @@ class JudgeFailureBanner(unittest.TestCase):
         finally:
             jd.judge_failure_scan = saved
 
-    def test_the_landing_has_the_banner_and_render_drives_and_dismisses_it(self):
+    def test_a_judge_failure_logs_to_the_notification_center_not_a_banner(self):
+        # 2026-07-27: the top banner is gone — the same situation logs an entry in the shell's
+        # notification center, once per count+cause signature (a changed situation logs afresh)
         land = km._landing()
-        self.assertIn("<div id=romp-judge-degraded>", land)
-        self.assertIn("#romp-judge-degraded.show{display:flex}", land)
+        self.assertNotIn("<div id=romp-judge-degraded>", land, "the top banner element is gone")
         js = km._LANDING_USAGE_JS
         self.assertIn("u.judgeFailures", js)                        # driven off the payload key
+        self.assertIn("window.__rompNotify('judge'", js)
         self.assertIn("couldn't be summarized", js)                # names the count
-        self.assertIn("romp:judgeDegradedDismiss", js)             # signature-keyed dismissal, like the limit one
-        self.assertIn("jf.count+'|'+(jf.cause||'')", js)           # signature = count + cause → re-shows on change
+        self.assertIn("romp:judgeDegradedDismiss", js)             # signature-keyed, like the limit one
+        self.assertIn("jf.count+'|'+(jf.cause||'')", js)           # signature = count + cause → logs on change
 
 
 if __name__ == "__main__":

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -11,6 +11,7 @@ import { spinFor } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { hostNameNodes, hostPartsNodes } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
+import { provenanceTitle, provenanceGroupTitle, rootStart, type ProvFmt } from "./provenance";
 import { initStrip } from "./strip";
 import { installSettingsSync } from "./settings";
 import { previewThumb, previewKind } from "./preview";
@@ -1144,6 +1145,10 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     og.style.display = "none";
   }
   a._time.textContent = relAge(hostNow - it.t);
+  // hover the stamp for provenance (the user 2026-07-27): the age marks the NEWEST event (a done card's
+  // age is its completion), so the tooltip tells where the thread came from — started when, each sub +
+  // its time, what the stamp marks. Native title: no DOM, click-safe.
+  a._time.title = provenanceTitle(it, hostNow, PROV_FMT);
   // RE-CHECK chip (the user 2026-06-27): a soft-block you answered with a TARGETED follow-up (kernel `recheck`).
   // Reads "↩ re-judging" so you know it registered and isn't on you, pending the judge's verdict. (A PLAIN reply
   // is `rejudging`, not `recheck`, and gets no chip: since 2026-07-02 it ALSO moves to Working while the reply
@@ -1605,6 +1610,7 @@ function updateGroupCard(card: HTMLElement, g: AskGroup) {
   if (g.color) a._name.style.color = g.color.bg;
   setWorkDot(a._name, dotFor(g.name));   // working/awaiting dot before the session name
   a._time.textContent = relAge(hostNow - g.t);
+  a._time.title = provenanceGroupTitle(g.members.map(rootStart), g.t, hostNow, PROV_FMT);
   // member lines — rebuilt only when the member set or any member's status changes
   const memSig = g.members.map((m) => m.itemId + ":" + memberStatus(m)).join("|");
   if (a._memSig !== memSig) {
@@ -1680,6 +1686,8 @@ function logPhrase(r: NodeLogRow): string {
   return r.kind || "updated";
 }
 const logRowT = (r: NodeLogRow): number => r.at || r.evT || 0;
+// the provenance tooltip (hover the card's age stamp) borrows the same vocabulary the card renders with
+const PROV_FMT: ProvFmt = { rel: relAge, clock: clockHM, phrase: logPhrase };
 // the node's owning session for navigation (a handoff node lives in the recipient's transcript) —
 // the same resolution wireNodeZones uses for its zones
 function navSidOf(it: AskItem, node: AskTreeNode): string {
@@ -2343,6 +2351,7 @@ function renderModal() {
     agent.replaceChildren(...hostNameNodes(grp.name, grp.sid)); if (grp.color) agent.style.color = grp.color.bg; setWorkDot(agent, dotFor(grp.name)); agent.classList.toggle("dead", !grp.live);
     agent.onclick = () => vscodeApi?.postMessage({ type: "openSession", id: grp.sid });
     ageEl.textContent = relAge(hostNow - grp.t);
+    ageEl.title = provenanceGroupTitle(grp.members.map(rootStart), grp.t, hostNow, PROV_FMT);
     ageEl.style.color = "rgb(" + grp.trgb.join(",") + ")";   // tint the age by recency (the time colour scheme)
     clrEl.onclick = () => { for (const mem of grp.members) vscodeApi?.postMessage({ type: "askClear", itemId: mem.itemId, sid: mem.sid }); fullscreenAskId = null; renderModal(); };
     // follow-up on a group goes to the session that took the typed prompt — one
@@ -2359,6 +2368,7 @@ function renderModal() {
     agent.replaceChildren(...hostNameNodes(it.name, it.sid)); if (it.color) agent.style.color = it.color.bg; setWorkDot(agent, dotFor(it.name)); agent.classList.toggle("dead", !it.live);
     agent.onclick = () => vscodeApi?.postMessage({ type: "openSession", id: it.sid });
     ageEl.textContent = relAge(hostNow - it.t);
+    ageEl.title = provenanceTitle(it, hostNow, PROV_FMT);
     ageEl.style.color = "rgb(" + it.trgb.join(",") + ")";   // tint the age by recency (the time colour scheme)
     clrEl.onclick = () => { vscodeApi?.postMessage({ type: "askClear", itemId: it.itemId, sid: it.sid }); fullscreenAskId = null; renderModal(); };
     // "Check status" (the user 2026-07-20): shown when the card has open/blocked subs to sweep and the

--- a/ui/webview/provenance.test.ts
+++ b/ui/webview/provenance.test.ts
@@ -1,0 +1,92 @@
+// The card-age provenance tooltip (the user 2026-07-27): the header's "Nm ago" stamps the card's
+// NEWEST event — a completed card's age is when it was marked done — so hovering it must tell where
+// the thread CAME from: started when, each sub-item with the time it landed, and what the visible
+// stamp itself marks. EXECUTES ./provenance directly; the feed wiring (titles set beside every
+// ageEl/_time write) is source-pinned below.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { provenanceTitle, provenanceGroupTitle, rootStart, type ProvItem, type ProvFmt } from "./provenance";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+
+// deterministic formatters: the real relAge/clockHM/logPhrase live in feed.ts (pinned there); this
+// module owns only the story's structure
+const F: ProvFmt = {
+  rel: (s) => Math.round(s / 60) + "m ago",
+  clock: (t) => "@" + t,
+  phrase: (r) => "[" + r.kind + "]",
+};
+const NOW = 10_000;
+
+function item(over: Partial<ProvItem> = {}): ProvItem {
+  return {
+    itemId: "root", t: 9_400, column: "completed",
+    tree: [
+      { id: "root", text: "ship the notes-api", status: "done", t: 1_000, last: 9_400 },
+      { id: "s1", text: "write the parser", status: "done", t: 1_600, last: 5_000, mt: 5_200 },
+      { id: "s2", text: "ask about the schema", status: "question", t: 2_200, last: 7_000, mt: 7_000 },
+      { id: "s3", text: "docs pass", status: "open", t: 8_800, last: 8_800 },
+    ],
+    ...over,
+  };
+}
+
+test("the story: started at the root's mint, each sub at ITS time, the stamp explained last", () => {
+  const lines = provenanceTitle(item(), NOW, F).split("\n");
+  assert.equal(lines[0], "started 150m ago · @1000", "line 1 = the root's mint time");
+  assert.equal(lines[1], "✓ write the parser — 80m ago · @5200", "a resolved sub stamps where it RESOLVED (mt)");
+  assert.equal(lines[2], "⏸ ask about the schema — 50m ago · @7000");
+  assert.equal(lines[3], "· docs pass — 20m ago · @8800", "an open sub stamps its mint (nothing resolved yet)");
+  assert.equal(lines[4], "marked done 10m ago · @9400", "the visible age is named for what it marks");
+});
+
+test("the final line matches the column: blocked / last update", () => {
+  assert.match(provenanceTitle(item({ column: "needs_input" }), NOW, F), /\nblocked 10m ago · @9400$/);
+  assert.match(provenanceTitle(item({ column: "working" }), NOW, F), /\nlast update 10m ago · @9400$/);
+});
+
+test("the root's own verdict rows ride between start and subs, in the feed's outcome words", () => {
+  const it = item();
+  it.tree[0].log = [{ kind: "block", src: "romp", at: 3_000 }, { kind: "unblock", src: "romp", evT: 4_000 }];
+  const lines = provenanceTitle(it, NOW, F).split("\n");
+  assert.equal(lines[1], "[block] 117m ago · @3000");
+  assert.equal(lines[2], "[unblock] 100m ago · @4000", "evT is the time-nav fallback when `at` is absent");
+  assert.equal(lines[3], "✓ write the parser — 80m ago · @5200", "subs follow the root's events");
+});
+
+test("cleared subs stay out; a huge tree caps at 8 with an honest remainder", () => {
+  const it = item();
+  it.tree[1].cleared = true;
+  assert.ok(!provenanceTitle(it, NOW, F).includes("write the parser"), "a cleared sub is not provenance");
+  const big = item({
+    tree: [{ id: "root", text: "r", status: "done", t: 1_000, last: 9_000 } as any].concat(
+      Array.from({ length: 11 }, (_, i) => ({ id: "n" + i, text: "sub " + i, status: "open", t: 2_000 + i, last: 2_000 + i } as any))),
+  });
+  const lines = provenanceTitle(big, NOW, F).split("\n");
+  assert.equal(lines.length, 1 + 8 + 1 + 1, "start + 8 subs + remainder + stamp line");
+  assert.equal(lines[9], "…and 3 more", "no silent truncation");
+});
+
+test("rootStart falls back: earliest tree mint without a root row, the card's t on an empty tree", () => {
+  assert.equal(rootStart(item()), 1_000);
+  assert.equal(rootStart(item({ itemId: "elsewhere" })), 1_000, "no root row → earliest mint");
+  assert.equal(rootStart(item({ tree: [] })), 9_400, "provisional cards have no tree at all");
+});
+
+test("a group's story is the fold: earliest member start, the member count, the group stamp", () => {
+  const lines = provenanceGroupTitle([5_000, 3_000, 7_000], 9_000, NOW, F).split("\n");
+  assert.equal(lines[0], "started 117m ago · @3000");
+  assert.equal(lines[1], "3 cards from one prompt");
+  assert.equal(lines[2], "last update 17m ago · @9000");
+});
+
+test("the feed wires the tooltip beside every age write — card, group card, both modal headers", () => {
+  assert.match(FEED, /a\._time\.title = provenanceTitle\(it, hostNow, PROV_FMT\);/);
+  assert.match(FEED, /a\._time\.title = provenanceGroupTitle\(g\.members\.map\(rootStart\), g\.t, hostNow, PROV_FMT\);/);
+  assert.match(FEED, /ageEl\.title = provenanceTitle\(it, hostNow, PROV_FMT\);/);
+  assert.match(FEED, /ageEl\.title = provenanceGroupTitle\(grp\.members\.map\(rootStart\), grp\.t, hostNow, PROV_FMT\);/);
+  // …with the same vocabulary the card itself renders in
+  assert.match(FEED, /const PROV_FMT: ProvFmt = \{ rel: relAge, clock: clockHM, phrase: logPhrase \};/);
+});

--- a/ui/webview/provenance.ts
+++ b/ui/webview/provenance.ts
@@ -1,0 +1,69 @@
+// Card-age provenance (the user 2026-07-27): the card header's "Nm ago" stamps the card's NEWEST
+// event — a completed card's age is when it was marked done — which hides where the thread CAME from.
+// Hovering the stamp now tells the story: when the goal was started, each sub-item with the time it
+// landed (or was asked), the root's own verdict events when shipped, and what the visible stamp itself
+// marks. Rendered as a native `title` tooltip: zero extra DOM, click-safe across re-renders.
+//
+// Pure assembly, executed directly by provenance.test.ts. The wording/format helpers stay in feed.ts
+// (relAge / clockHM / logPhrase are pinned there and used by a dozen other surfaces) and are injected,
+// so this module owns only the story's structure: what appears, in what order, with which timestamp.
+
+export interface LogRow { kind: string; src: string; why?: string | null; at?: number | null; evT?: number | null; }
+export interface ProvNode {
+  id: string; text: string; status: string; t: number; last: number; mt?: number;
+  cleared?: boolean; log?: LogRow[] | null;
+}
+export interface ProvItem { itemId: string; t: number; column: string; tree: ProvNode[]; }
+export interface ProvFmt {
+  rel: (sec: number) => string;          // feed relAge
+  clock: (t: number) => string;          // feed clockHM
+  phrase: (r: LogRow) => string;         // feed logPhrase
+}
+
+const SUB_CAP = 8;                       // a huge tree stays a glanceable tooltip, not a scroll
+
+function stamp(t: number, now: number, f: ProvFmt): string {
+  return f.rel(now - t) + " · " + f.clock(t);
+}
+
+// the moment the card's thread began: its root node's mint time (earliest tree mint as a fallback for
+// payloads without a root row; the card's own t as the last resort)
+export function rootStart(it: ProvItem): number {
+  const root = it.tree.find((n) => n.id === it.itemId);
+  if (root?.t) return root.t;
+  return it.tree.length ? Math.min(...it.tree.map((n) => n.t)) : it.t;
+}
+
+export function provenanceTitle(it: ProvItem, now: number, f: ProvFmt): string {
+  const lines = ["started " + stamp(rootStart(it), now, f)];
+  // the root's own verdict rows (asked you / you answered / …) — only shipped for non-done nodes
+  const root = it.tree.find((n) => n.id === it.itemId);
+  for (const r of root?.log ?? []) {
+    const rt = r.at || r.evT || 0;
+    if (rt) lines.push(f.phrase(r) + " " + stamp(rt, now, f));
+  }
+  // sub-items in mint order: a resolved sub is stamped when it RESOLVED (mt — where it landed), an
+  // open one when it was minted (its resolution hasn't happened yet)
+  const subs = it.tree.filter((n) => n.id !== it.itemId && !n.cleared);
+  for (const n of subs.slice(0, SUB_CAP)) {
+    const mark = n.status === "done" ? "✓" : n.status === "question" ? "⏸" : "·";
+    const at = n.status === "open" ? n.t : (n.mt || n.last || n.t);
+    const txt = n.text.length > 48 ? n.text.slice(0, 47) + "…" : n.text;
+    lines.push(mark + " " + txt + " — " + stamp(at, now, f));
+  }
+  if (subs.length > SUB_CAP) lines.push("…and " + (subs.length - SUB_CAP) + " more");
+  // what the visible "Nm ago" itself marks, so the stamp is self-explaining
+  const what = it.column === "completed" ? "marked done"
+    : it.column === "needs_input" ? "blocked" : "last update";
+  lines.push(what + " " + stamp(it.t, now, f));
+  return lines.join("\n");
+}
+
+// a GROUP card folds N sibling asks from one typed prompt — its stamp's story is the fold itself
+export function provenanceGroupTitle(memberStarts: number[], t: number, now: number, f: ProvFmt): string {
+  const lines: string[] = [];
+  if (memberStarts.length) lines.push("started " + stamp(Math.min(...memberStarts), now, f));
+  lines.push(memberStarts.length + " cards from one prompt");
+  lines.push("last update " + stamp(t, now, f));
+  return lines.join("\n");
+}


### PR DESCRIPTION
Three changes from today's session:

**Notification center (the bell).** The fixed top banners — "Disconnected — reconnecting…", usage-limit reached, judge degraded — got in the way. They're replaced by a monochrome bell in the bottom bar's action cluster (mirrored on mobile) that goes red with an unread count when an error lands, opening a popover of entries newest-first with per-row clear + Clear all. Entries persist in localStorage; repeats of the newest entry coalesce with a count (event-exact); a visible pane's live WS-down keeps the red cue until reconnect; the old banner's Reload escape hatch lives in the popover header. Panes can post `{romp:'notify',kind,text}`. `tests/test_error_center.py` executes the real injected JS in node and drives the whole story.

**Model-label unify.** `_unify_model_labels` relabeled every row to the family's "richest" name with a longest-string tiebreak — during the Opus 4.8 → 5 flip, sessions genuinely on Opus 5 displayed as 4.8. Now a versioned label (the session's own report) is never rewritten, and a bare label borrows only when the fleet runs exactly one versioned variant of that family.

**Card-age provenance tooltip.** Hovering a card's "Nm ago" (card, group, modal headers) shows where the thread came from: started when, the root's verdict events, each sub with the time it landed, and what the visible stamp marks. Pure assembly in `ui/webview/provenance.ts` with an executed test; wording helpers injected from feed.ts so the tooltip speaks the card's own vocabulary.

Both suites green: pytest 3234 passed, node 1347 passed, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)