### PR TITLE
Linking names the three trust levels instead of only pointing at them

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -222,7 +222,15 @@ is one click and it returns with the trust level you last gave it.
 
 #### Mail across linked machines
 
-Each linked machine carries a trust level that governs its mail; see
+Each linked machine carries a trust level, set on its row, that decides what
+happens to mail arriving from it:
+
+- **trusted** — delivered straight to your sessions.
+- **directed**, the default — held for your approval as a needs-you card.
+- **isolated** — no mail either way; its sessions still appear in your
+  interface.
+
+Which to choose, and what each one guards against, is in
 [Security and trust](#security-and-trust).
 
 Machines that a linked machine can reach appear to you too, under **Reachable


### PR DESCRIPTION
"Each linked machine carries a trust level that governs its mail; see Security
and trust" left a reader with three unexplained words on a dropdown and a link
to follow before they could set a host.

Three one-line glosses now sit inline, matching the popover's own labels
(`kernel.py` `TRUSTW`: auto-accept / held for you / no mail), so the level can
be chosen without leaving the section. Security and trust keeps the reasoning,
the needs-you card mechanics, and the guidance on which to pick for what.

Strict build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)