### PR TITLE
Card trouble chips mirror into the notification bell

### DIFF
--- a/ui/webview/badge-mirror.test.ts
+++ b/ui/webview/badge-mirror.test.ts
@@ -1,0 +1,64 @@
+// Card trouble badges mirror into the shell's bell (the user 2026-07-27) — the chip stays on the
+// card; the bell gets ONE durable entry per episode. EXECUTES ./badge-mirror; the feed plumbing
+// (seen-set persistence + the {romp:'notify'} post) is source-pinned.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { badgeNotices, type BadgeItem } from "./badge-mirror";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+
+const base = (over: Partial<BadgeItem>): BadgeItem =>
+  ({ itemId: "TESTSID:g1", name: "api", text: "ship the notes-api", ...over });
+
+test("every trouble chip becomes one entry, in the session's name", () => {
+  const items = [base({
+    warns: [{ kind: "distill", t: 100, msg: "the summarizer gave up" }],
+    stalled: { why: "reviver not retiring", since: 200, note: "romp is holding this" },
+    nudgeFailed: true,
+    retrying: { since: 300 },
+    blocked: { state: "apiError", status: 529 },
+  })];
+  const { notices } = badgeNotices(items, new Set());
+  assert.deepEqual(notices.map((n) => n.kind), ["warn", "stalled", "nudge", "retry", "apierror"]);
+  assert.ok(notices.every((n) => n.text.startsWith("api — ")), "each entry names the session");
+  assert.match(notices[0].text, /warning: the summarizer gave up/);
+  assert.match(notices[1].text, /stalled: romp is holding this/, "the staller's note beats the mechanical why");
+  assert.match(notices[4].text, /API error 529/);
+});
+
+test("a seen signature stays quiet; the SAME badge next push logs nothing", () => {
+  const items = [base({ stalled: { why: "w", since: 200 } })];
+  const first = badgeNotices(items, new Set());
+  assert.equal(first.notices.length, 1);
+  const second = badgeNotices(items, new Set(first.active));
+  assert.equal(second.notices.length, 0, "the persisted active set is exactly the next call's seen set");
+});
+
+test("a NEW episode (different since/t) is a new entry; a cleared badge leaves the active set", () => {
+  const s1 = badgeNotices([base({ stalled: { why: "w", since: 200 } })], new Set());
+  const s2 = badgeNotices([base({ stalled: { why: "w", since: 999 } })], new Set(s1.active));
+  assert.equal(s2.notices.length, 1, "a fresh stall episode logs again");
+  const gone = badgeNotices([base({})], new Set(s2.active));
+  assert.equal(gone.active.size, 0, "no badge → no active sigs → the next occurrence re-logs");
+});
+
+test("only the API-error block mirrors — an ordinary permission ask is not an error", () => {
+  const { notices } = badgeNotices([base({ blocked: { state: "ask" } })], new Set());
+  assert.equal(notices.length, 0);
+});
+
+test("spend-limit and prompt-too-long blocks say what they are", () => {
+  const sl = badgeNotices([base({ blocked: { state: "apiError", spendLimit: true } })], new Set()).notices[0];
+  const tl = badgeNotices([base({ blocked: { state: "apiError", tooLong: true } })], new Set()).notices[0];
+  assert.match(sl.text, /spend limit reached/);
+  assert.match(tl.text, /prompt too long/);
+});
+
+test("the feed posts each notice to the shell and persists only the ACTIVE set", () => {
+  assert.match(FEED, /mirrorBadges\(incomingAsks\);/, "runs on every feed payload, against the FULL list");
+  assert.match(FEED, /window\.parent\?\.postMessage\(\{ romp: "notify", kind: n\.kind, text: n\.text \}, "\*"\)/);
+  assert.match(FEED, /localStorage\.setItem\(BADGE_SEEN_KEY, JSON\.stringify\(Array\.from\(active\)\)\)/,
+    "active-only persistence is what re-arms a cleared badge and bounds the store");
+});

--- a/ui/webview/badge-mirror.ts
+++ b/ui/webview/badge-mirror.ts
@@ -1,0 +1,57 @@
+// Card trouble badges mirror into the shell's notification bell (the user 2026-07-27): anything that
+// shows as a problem chip on a card — a judge warning, a stalled hold, a failed follow-up, an
+// API-error block, a retry storm — ALSO logs one entry in the bell, so problems are findable in one
+// place after the fact. The chip on the card stays exactly as it was; the bell entry is the durable
+// copy of the moment it appeared.
+//
+// Pure: the caller passes the previously-notified signature set and gets back fresh notices + the
+// now-active set. A signature keys the EPISODE (card + kind + the badge's own since/t), the same
+// event-identity idea as the limit/judge signatures: per-push re-renders and page reloads don't
+// re-log, a badge that clears leaves the active set (so a recurrence logs afresh), and a NEW episode
+// of the same kind (different since/t) is a new entry.
+
+export interface BadgeItem {
+  itemId: string; name: string; text: string;
+  stalled?: { why: string; since: number; note?: string | null } | null;
+  nudgeFailed?: boolean;
+  retrying?: { since?: number | null; count?: number } | null;
+  warns?: { kind: string; t: number; msg: string }[] | null;
+  blocked?: { state: string; status?: number; text?: string; tooLong?: boolean; spendLimit?: boolean } | null;
+}
+export interface BadgeNotice { kind: string; text: string; sig: string; }
+
+const cap = (s: string, n: number) => (s.length > n ? s.slice(0, n - 1) + "…" : s);
+
+export function badgeNotices(items: BadgeItem[], seen: Set<string>): { notices: BadgeNotice[]; active: Set<string> } {
+  const notices: BadgeNotice[] = [];
+  const active = new Set<string>();
+  const add = (sig: string, kind: string, text: string) => {
+    active.add(sig);
+    if (!seen.has(sig)) notices.push({ kind, text, sig });
+  };
+  for (const it of items) {
+    for (const w of it.warns ?? []) {
+      add("w|" + it.itemId + "|" + w.t + "|" + w.kind, "warn", it.name + " — warning: " + cap(w.msg, 100));
+    }
+    if (it.stalled) {
+      add("s|" + it.itemId + "|" + it.stalled.since, "stalled",
+        it.name + " — stalled: " + cap(it.stalled.note || it.stalled.why, 100));
+    }
+    if (it.nudgeFailed) {
+      add("n|" + it.itemId, "nudge", it.name + " — follow-up failed on “" + cap(it.text, 50) + "”");
+    }
+    if (it.retrying) {
+      add("r|" + it.itemId + "|" + (it.retrying.since || 0), "retry", it.name + " — API retry storm");
+    }
+    // only the API-error block is an ERROR; a permission ask / picker is ordinary Needs-you traffic
+    if (it.blocked && it.blocked.state === "apiError") {
+      const b = it.blocked;
+      const what = b.spendLimit ? "spend limit reached"
+        : b.tooLong ? "prompt too long (needs compaction)"
+        : "API error" + (b.status ? " " + b.status : "");
+      add("e|" + it.itemId + "|" + (b.status || "") + "|" + (b.spendLimit ? "sl" : b.tooLong ? "tl" : ""),
+        "apierror", it.name + " — " + what);
+    }
+  }
+  return { notices, active };
+}

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -12,6 +12,7 @@ import { onlyTag, matchesOnly } from "./only-filter";
 import { hostNameNodes, hostPartsNodes } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
 import { provenanceTitle, provenanceGroupTitle, rootStart, type ProvFmt } from "./provenance";
+import { badgeNotices } from "./badge-mirror";
 import { initStrip } from "./strip";
 import { installSettingsSync } from "./settings";
 import { previewThumb, previewKind } from "./preview";
@@ -3037,6 +3038,23 @@ function pipeBanner(up: boolean, queued: number): void {
     : "romp is unreachable — reconnecting…";
 }
 
+// Card trouble badges mirror into the shell's notification bell (the user 2026-07-27): the chip on the
+// card stays exactly as it was; the bell gets ONE durable entry per episode. badge-mirror.ts owns the
+// episode identity (signature-keyed on the badge's own since/t); this wrapper owns the plumbing — the
+// persisted seen-set (shared across tabs via localStorage, so two open dashboards don't double-log) and
+// the {romp:'notify'} post the shell's bell listens for. Storing only the ACTIVE set is what re-arms a
+// cleared badge and keeps the store from growing: a card that left the payload takes its sigs with it.
+const BADGE_SEEN_KEY = "romp:cardNotified";
+function mirrorBadges(items: AskItem[]): void {
+  let seen: string[] = [];
+  try { seen = JSON.parse(localStorage.getItem(BADGE_SEEN_KEY) || "[]"); } catch { /* fresh */ }
+  const { notices, active } = badgeNotices(items, new Set(seen));
+  for (const n of notices) {
+    try { window.parent?.postMessage({ romp: "notify", kind: n.kind, text: n.text }, "*"); } catch { /* no shell (VS Code view) */ }
+  }
+  try { localStorage.setItem(BADGE_SEEN_KEY, JSON.stringify(Array.from(active))); } catch { /* storage full */ }
+}
+
 window.addEventListener("message", (e: MessageEvent) => {
   const m = e.data;
   if (!m) return;
@@ -3075,6 +3093,7 @@ window.addEventListener("message", (e: MessageEvent) => {
     bgServicesMap = m.bgServices && typeof m.bgServices === "object" ? m.bgServices : {};   // session name -> judge-classified service descs → the session-header chip (2026-07-24)
     if (Array.isArray(m.order)) sessionOrder = m.order.filter((x: any) => typeof x === "string");   // grouped-mode session rank (tab/lane order)
     hostNow = typeof m.now === "number" ? m.now : Math.floor(Date.now() / 1000);
+    mirrorBadges(incomingAsks);   // card trouble chips also log in the shell's bell (chips stay on the cards)
     if (typeof m.dismissedCount === "number") dismissedCount = m.dismissedCount;
     if (typeof m.showDismissed === "boolean") showDismissed = m.showDismissed;
     if (typeof m.canUndoClear === "boolean") canUndoClear = m.canUndoClear;


### PR DESCRIPTION
Follow-up to the bell (PR #55): every problem badge a card wears — judge warning, stalled hold, failed follow-up, API-error block (incl. spend-limit / prompt-too-long wording), retry storm — also logs one entry in the bell, named for the session. The chips on the cards stay exactly as they are.

Episode identity lives in `ui/webview/badge-mirror.ts` (pure, executed by its test): signatures key card + kind + the badge's own since/t, the seen-set persists active sigs only, so re-renders and reloads never re-log, a cleared badge re-arms, and a new episode logs afresh. The feed posts fresh notices over the existing `{romp:'notify'}` channel; ordinary permission asks are deliberately not mirrored.

pytest 3234 passed, node 1353 passed, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)