### PR TITLE
Age-provenance hover: aligned popover in the feed's row vocabulary

### DIFF
--- a/ui/webview/feed-followup-move.test.ts
+++ b/ui/webview/feed-followup-move.test.ts
@@ -25,7 +25,9 @@ test("a predicted card is kept in Working at render, styled like the kernel's re
   // (the messageless plain move was removed with its button/drag, the user 2026-07-25)
   assert.match(FEED, /if \(\(pendingMoveKind\.get\(a\.itemId\) \?\? "followup"\) === "followup"\) \{ a\.recheck = true; a\.followupPending = true; \}/);
   // applied at the top of render so EVERY render (push, modal close) reflects the prediction
-  assert.match(FEED, /const list = document\.getElementById\("feed-list"\)!;\s*\n\s*applyFollowMove\(asks\);/);
+  // (2026-07-27: render() now hides the age-provenance popover first — a re-render can swap the hovered
+  // stamp out from under its mouseleave — so the pin allows that line between the two.)
+  assert.match(FEED, /const list = document\.getElementById\("feed-list"\)!;\s*\n(\s*hideAgeTip\(\);.*\n)?\s*applyFollowMove\(asks\);/);
   // the removed drag machinery must not creep back in front of it
   assert.doesNotMatch(FEED, /dragAskId|DRAG_CARDS_ENABLED|fdrop-slot/);
   assert.doesNotMatch(FEED, /"cardMove"/, "the messageless move op is gone from the feed");

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -988,3 +988,21 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* the VS Code pipe-down banner — see styles.css (one treatment, two sheets) */
 #rpipe { position: fixed; top: 0; left: 0; right: 0; z-index: 99999; text-align: center;
   background: #2b2d30; color: #e6e6e6; border-bottom: 1px solid #4a4d51; padding: 7px 14px; }
+
+/* Age-stamp provenance popover (the user 2026-07-27): hover a card's "Nm ago" for the thread's story.
+   Replaces the native title tooltip (dense, unaligned). Panel wears the feed-toast card look; rows are
+   the modal history-row family (0.86em, dim time cell — .ftree-log-when's vocabulary) with the times in
+   ONE right-aligned tabular column so they read as a list. The closing line (what the visible stamp
+   marks) is its own section under a hairline. pointer-events:none — it can never eat a click. */
+#age-tip {
+  position: fixed; z-index: 210; display: none; max-width: min(440px, 92vw);
+  background: var(--vscode-menu-background, #26262a); color: var(--fg);
+  border: 1px solid rgba(255, 255, 255, 0.12); border-radius: 7px; padding: 7px 10px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45); font-size: 0.86em; line-height: 1.45;
+  pointer-events: none;
+}
+.age-tip-row { display: flex; column-gap: 10px; align-items: baseline; }
+.age-tip-when { flex: 0 0 auto; min-width: 118px; text-align: right; color: var(--dim);
+  white-space: nowrap; font-variant-numeric: tabular-nums; }
+.age-tip-what { overflow-wrap: anywhere; }
+.age-tip-row.stamp { margin-top: 4px; padding-top: 4px; border-top: 1px solid rgba(255, 255, 255, 0.09); }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -11,7 +11,7 @@ import { spinFor } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { hostNameNodes, hostPartsNodes } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
-import { provenanceTitle, provenanceGroupTitle, rootStart, type ProvFmt } from "./provenance";
+import { provenanceRows, provenanceGroupRows, rootStart, type ProvFmt, type ProvRow } from "./provenance";
 import { badgeNotices } from "./badge-mirror";
 import { initStrip } from "./strip";
 import { installSettingsSync } from "./settings";
@@ -1147,9 +1147,9 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   }
   a._time.textContent = relAge(hostNow - it.t);
   // hover the stamp for provenance (the user 2026-07-27): the age marks the NEWEST event (a done card's
-  // age is its completion), so the tooltip tells where the thread came from — started when, each sub +
-  // its time, what the stamp marks. Native title: no DOM, click-safe.
-  a._time.title = provenanceTitle(it, hostNow, PROV_FMT);
+  // age is its completion), so the popover tells where the thread came from — started when, each sub +
+  // its time, what the stamp marks.
+  wireAgeTip(a._time, () => provenanceRows(it, hostNow, PROV_FMT));
   // RE-CHECK chip (the user 2026-06-27): a soft-block you answered with a TARGETED follow-up (kernel `recheck`).
   // Reads "↩ re-judging" so you know it registered and isn't on you, pending the judge's verdict. (A PLAIN reply
   // is `rejudging`, not `recheck`, and gets no chip: since 2026-07-02 it ALSO moves to Working while the reply
@@ -1611,7 +1611,7 @@ function updateGroupCard(card: HTMLElement, g: AskGroup) {
   if (g.color) a._name.style.color = g.color.bg;
   setWorkDot(a._name, dotFor(g.name));   // working/awaiting dot before the session name
   a._time.textContent = relAge(hostNow - g.t);
-  a._time.title = provenanceGroupTitle(g.members.map(rootStart), g.t, hostNow, PROV_FMT);
+  wireAgeTip(a._time, () => provenanceGroupRows(g.members.map(rootStart), g.t, hostNow, PROV_FMT));
   // member lines — rebuilt only when the member set or any member's status changes
   const memSig = g.members.map((m) => m.itemId + ":" + memberStatus(m)).join("|");
   if (a._memSig !== memSig) {
@@ -1687,8 +1687,36 @@ function logPhrase(r: NodeLogRow): string {
   return r.kind || "updated";
 }
 const logRowT = (r: NodeLogRow): number => r.at || r.evT || 0;
-// the provenance tooltip (hover the card's age stamp) borrows the same vocabulary the card renders with
+// the provenance popover (hover the card's age stamp) borrows the same vocabulary the card renders with
 const PROV_FMT: ProvFmt = { rel: relAge, clock: clockHM, phrase: logPhrase };
+// One shared popover element for every age stamp (the user 2026-07-27: the native title tooltip was
+// dense and unaligned). Times sit in their own right-aligned column, rows wear the modal history-row
+// look (#age-tip in feed.css). pointer-events:none + rebuilt per hover, so it is click-safe; a lazy
+// rows thunk keeps the assembly off the render path entirely.
+let ageTipEl: HTMLElement | null = null;
+function showAgeTip(anchor: HTMLElement, rows: ProvRow[]): void {
+  if (!ageTipEl) { ageTipEl = el("div", ""); ageTipEl.id = "age-tip"; document.body.appendChild(ageTipEl); }
+  const tip = ageTipEl;
+  tip.replaceChildren();
+  for (const r of rows) {
+    const row = el("div", "age-tip-row" + (r.kind === "stamp" ? " stamp" : ""));
+    const w = el("span", "age-tip-when"); w.textContent = r.when;
+    const x = el("span", "age-tip-what"); x.textContent = r.what;
+    row.append(w, x); tip.appendChild(row);
+  }
+  tip.style.display = "block";
+  // above the stamp, clamped to the viewport; below it when there is no headroom
+  const rc = anchor.getBoundingClientRect();
+  const left = Math.max(8, Math.min(rc.left, window.innerWidth - tip.offsetWidth - 8));
+  const top = rc.top - tip.offsetHeight - 6;
+  tip.style.left = left + "px";
+  tip.style.top = (top < 8 ? rc.bottom + 6 : top) + "px";
+}
+function hideAgeTip(): void { if (ageTipEl) ageTipEl.style.display = "none"; }
+function wireAgeTip(elm: HTMLElement, rows: () => ProvRow[]): void {
+  elm.onmouseenter = () => showAgeTip(elm, rows());
+  elm.onmouseleave = hideAgeTip;
+}
 // the node's owning session for navigation (a handoff node lives in the recipient's transcript) —
 // the same resolution wireNodeZones uses for its zones
 function navSidOf(it: AskItem, node: AskTreeNode): string {
@@ -2352,7 +2380,7 @@ function renderModal() {
     agent.replaceChildren(...hostNameNodes(grp.name, grp.sid)); if (grp.color) agent.style.color = grp.color.bg; setWorkDot(agent, dotFor(grp.name)); agent.classList.toggle("dead", !grp.live);
     agent.onclick = () => vscodeApi?.postMessage({ type: "openSession", id: grp.sid });
     ageEl.textContent = relAge(hostNow - grp.t);
-    ageEl.title = provenanceGroupTitle(grp.members.map(rootStart), grp.t, hostNow, PROV_FMT);
+    wireAgeTip(ageEl, () => provenanceGroupRows(grp.members.map(rootStart), grp.t, hostNow, PROV_FMT));
     ageEl.style.color = "rgb(" + grp.trgb.join(",") + ")";   // tint the age by recency (the time colour scheme)
     clrEl.onclick = () => { for (const mem of grp.members) vscodeApi?.postMessage({ type: "askClear", itemId: mem.itemId, sid: mem.sid }); fullscreenAskId = null; renderModal(); };
     // follow-up on a group goes to the session that took the typed prompt — one
@@ -2369,7 +2397,7 @@ function renderModal() {
     agent.replaceChildren(...hostNameNodes(it.name, it.sid)); if (it.color) agent.style.color = it.color.bg; setWorkDot(agent, dotFor(it.name)); agent.classList.toggle("dead", !it.live);
     agent.onclick = () => vscodeApi?.postMessage({ type: "openSession", id: it.sid });
     ageEl.textContent = relAge(hostNow - it.t);
-    ageEl.title = provenanceTitle(it, hostNow, PROV_FMT);
+    wireAgeTip(ageEl, () => provenanceRows(it, hostNow, PROV_FMT));
     ageEl.style.color = "rgb(" + it.trgb.join(",") + ")";   // tint the age by recency (the time colour scheme)
     clrEl.onclick = () => { vscodeApi?.postMessage({ type: "askClear", itemId: it.itemId, sid: it.sid }); fullscreenAskId = null; renderModal(); };
     // "Check status" (the user 2026-07-20): shown when the card has open/blocked subs to sweep and the
@@ -2767,6 +2795,7 @@ function feedToast(text: string) {
 
 function render() {
   const list = document.getElementById("feed-list")!;
+  hideAgeTip();   // a re-render can swap the hovered stamp out from under its mouseleave — never strand the tip
   applyFollowMove(asks);   // keep optimistically-moved follow-up cards in Working until the kernel confirms (or reverts)
   const prevScroll = list.scrollTop;
   // footer pane (below the cards, no overlap): Newest first · Collapsed · Clear all · UndoClear

--- a/ui/webview/provenance.test.ts
+++ b/ui/webview/provenance.test.ts
@@ -1,15 +1,17 @@
-// The card-age provenance tooltip (the user 2026-07-27): the header's "Nm ago" stamps the card's
+// The card-age provenance popover (the user 2026-07-27): the header's "Nm ago" stamps the card's
 // NEWEST event — a completed card's age is when it was marked done — so hovering it must tell where
 // the thread CAME from: started when, each sub-item with the time it landed, and what the visible
-// stamp itself marks. EXECUTES ./provenance directly; the feed wiring (titles set beside every
-// ageEl/_time write) is source-pinned below.
+// stamp itself marks. Emits structured {when, what} rows (the native-title first cut was dense and
+// unaligned — same day) that the feed renders as an aligned popover. EXECUTES ./provenance directly;
+// the feed wiring + CSS vocabulary are source-pinned below.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { provenanceTitle, provenanceGroupTitle, rootStart, type ProvItem, type ProvFmt } from "./provenance";
+import { provenanceRows, provenanceGroupRows, rootStart, type ProvItem, type ProvFmt } from "./provenance";
 
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
 
 // deterministic formatters: the real relAge/clockHM/logPhrase live in feed.ts (pinned there); this
 // module owns only the story's structure
@@ -34,39 +36,44 @@ function item(over: Partial<ProvItem> = {}): ProvItem {
 }
 
 test("the story: started at the root's mint, each sub at ITS time, the stamp explained last", () => {
-  const lines = provenanceTitle(item(), NOW, F).split("\n");
-  assert.equal(lines[0], "started 150m ago · @1000", "line 1 = the root's mint time");
-  assert.equal(lines[1], "✓ write the parser — 80m ago · @5200", "a resolved sub stamps where it RESOLVED (mt)");
-  assert.equal(lines[2], "⏸ ask about the schema — 50m ago · @7000");
-  assert.equal(lines[3], "· docs pass — 20m ago · @8800", "an open sub stamps its mint (nothing resolved yet)");
-  assert.equal(lines[4], "marked done 10m ago · @9400", "the visible age is named for what it marks");
+  const rows = provenanceRows(item(), NOW, F);
+  assert.deepEqual(rows[0], { when: "150m ago · @1000", what: "started", kind: "start" });
+  assert.deepEqual(rows[1], { when: "80m ago · @5200", what: "✓ write the parser", kind: "sub" },
+    "a resolved sub stamps where it RESOLVED (mt)");
+  assert.deepEqual(rows[2], { when: "50m ago · @7000", what: "⏸ ask about the schema", kind: "sub" });
+  assert.deepEqual(rows[3], { when: "20m ago · @8800", what: "· docs pass", kind: "sub" },
+    "an open sub stamps its mint (nothing resolved yet)");
+  assert.deepEqual(rows[4], { when: "10m ago · @9400", what: "marked done", kind: "stamp" },
+    "the visible age is named for what it marks");
 });
 
-test("the final line matches the column: blocked / last update", () => {
-  assert.match(provenanceTitle(item({ column: "needs_input" }), NOW, F), /\nblocked 10m ago · @9400$/);
-  assert.match(provenanceTitle(item({ column: "working" }), NOW, F), /\nlast update 10m ago · @9400$/);
+test("the final row matches the column: blocked / last update", () => {
+  assert.equal(provenanceRows(item({ column: "needs_input" }), NOW, F).at(-1)!.what, "blocked");
+  assert.equal(provenanceRows(item({ column: "working" }), NOW, F).at(-1)!.what, "last update");
 });
 
 test("the root's own verdict rows ride between start and subs, in the feed's outcome words", () => {
   const it = item();
   it.tree[0].log = [{ kind: "block", src: "romp", at: 3_000 }, { kind: "unblock", src: "romp", evT: 4_000 }];
-  const lines = provenanceTitle(it, NOW, F).split("\n");
-  assert.equal(lines[1], "[block] 117m ago · @3000");
-  assert.equal(lines[2], "[unblock] 100m ago · @4000", "evT is the time-nav fallback when `at` is absent");
-  assert.equal(lines[3], "✓ write the parser — 80m ago · @5200", "subs follow the root's events");
+  const rows = provenanceRows(it, NOW, F);
+  assert.deepEqual(rows[1], { when: "117m ago · @3000", what: "[block]", kind: "event" });
+  assert.deepEqual(rows[2], { when: "100m ago · @4000", what: "[unblock]", kind: "event" },
+    "evT is the time-nav fallback when `at` is absent");
+  assert.equal(rows[3].what, "✓ write the parser", "subs follow the root's events");
 });
 
 test("cleared subs stay out; a huge tree caps at 8 with an honest remainder", () => {
   const it = item();
   it.tree[1].cleared = true;
-  assert.ok(!provenanceTitle(it, NOW, F).includes("write the parser"), "a cleared sub is not provenance");
+  assert.ok(!provenanceRows(it, NOW, F).some((r) => r.what.includes("write the parser")),
+    "a cleared sub is not provenance");
   const big = item({
     tree: [{ id: "root", text: "r", status: "done", t: 1_000, last: 9_000 } as any].concat(
       Array.from({ length: 11 }, (_, i) => ({ id: "n" + i, text: "sub " + i, status: "open", t: 2_000 + i, last: 2_000 + i } as any))),
   });
-  const lines = provenanceTitle(big, NOW, F).split("\n");
-  assert.equal(lines.length, 1 + 8 + 1 + 1, "start + 8 subs + remainder + stamp line");
-  assert.equal(lines[9], "…and 3 more", "no silent truncation");
+  const rows = provenanceRows(big, NOW, F);
+  assert.equal(rows.length, 1 + 8 + 1 + 1, "start + 8 subs + remainder + stamp row");
+  assert.deepEqual(rows[9], { when: "", what: "…and 3 more", kind: "more" }, "no silent truncation");
 });
 
 test("rootStart falls back: earliest tree mint without a root row, the card's t on an empty tree", () => {
@@ -76,17 +83,28 @@ test("rootStart falls back: earliest tree mint without a root row, the card's t 
 });
 
 test("a group's story is the fold: earliest member start, the member count, the group stamp", () => {
-  const lines = provenanceGroupTitle([5_000, 3_000, 7_000], 9_000, NOW, F).split("\n");
-  assert.equal(lines[0], "started 117m ago · @3000");
-  assert.equal(lines[1], "3 cards from one prompt");
-  assert.equal(lines[2], "last update 17m ago · @9000");
+  const rows = provenanceGroupRows([5_000, 3_000, 7_000], 9_000, NOW, F);
+  assert.deepEqual(rows[0], { when: "117m ago · @3000", what: "started", kind: "start" });
+  assert.deepEqual(rows[1], { when: "", what: "3 cards from one prompt", kind: "sub" });
+  assert.deepEqual(rows[2], { when: "17m ago · @9000", what: "last update", kind: "stamp" });
 });
 
-test("the feed wires the tooltip beside every age write — card, group card, both modal headers", () => {
-  assert.match(FEED, /a\._time\.title = provenanceTitle\(it, hostNow, PROV_FMT\);/);
-  assert.match(FEED, /a\._time\.title = provenanceGroupTitle\(g\.members\.map\(rootStart\), g\.t, hostNow, PROV_FMT\);/);
-  assert.match(FEED, /ageEl\.title = provenanceTitle\(it, hostNow, PROV_FMT\);/);
-  assert.match(FEED, /ageEl\.title = provenanceGroupTitle\(grp\.members\.map\(rootStart\), grp\.t, hostNow, PROV_FMT\);/);
+test("the feed wires the popover beside every age write — card, group card, both modal headers", () => {
+  assert.match(FEED, /wireAgeTip\(a\._time, \(\) => provenanceRows\(it, hostNow, PROV_FMT\)\);/);
+  assert.match(FEED, /wireAgeTip\(a\._time, \(\) => provenanceGroupRows\(g\.members\.map\(rootStart\), g\.t, hostNow, PROV_FMT\)\);/);
+  assert.match(FEED, /wireAgeTip\(ageEl, \(\) => provenanceRows\(it, hostNow, PROV_FMT\)\);/);
+  assert.match(FEED, /wireAgeTip\(ageEl, \(\) => provenanceGroupRows\(grp\.members\.map\(rootStart\), grp\.t, hostNow, PROV_FMT\)\);/);
   // …with the same vocabulary the card itself renders in
   assert.match(FEED, /const PROV_FMT: ProvFmt = \{ rel: relAge, clock: clockHM, phrase: logPhrase \};/);
+});
+
+test("the popover is aligned, styled in the feed's own vocabulary, and can never eat a click", () => {
+  assert.match(CSS, /\.age-tip-when \{ flex: 0 0 auto; min-width: 118px; text-align: right; color: var\(--dim\);/,
+    "one right-aligned dim time column — the alignment the title tooltip couldn't give");
+  assert.match(CSS, /font-variant-numeric: tabular-nums/, "digits line up down the column");
+  assert.match(CSS, /#age-tip \{[^}]*pointer-events: none/s, "hover chrome, never a click target");
+  assert.match(CSS, /\.age-tip-row\.stamp \{ margin-top: 4px; padding-top: 4px; border-top:/,
+    "the closing stamp line is its own section under a hairline");
+  // a re-render can swap the hovered stamp out from under its mouseleave — render() hides the tip
+  assert.match(FEED, /hideAgeTip\(\);   \/\/ a re-render can swap the hovered stamp/);
 });

--- a/ui/webview/provenance.ts
+++ b/ui/webview/provenance.ts
@@ -1,12 +1,13 @@
 // Card-age provenance (the user 2026-07-27): the card header's "Nm ago" stamps the card's NEWEST
 // event — a completed card's age is when it was marked done — which hides where the thread CAME from.
-// Hovering the stamp now tells the story: when the goal was started, each sub-item with the time it
-// landed (or was asked), the root's own verdict events when shipped, and what the visible stamp itself
-// marks. Rendered as a native `title` tooltip: zero extra DOM, click-safe across re-renders.
+// Hovering the stamp tells the story: when the goal was started, the root's own verdict events, each
+// sub-item with the time it landed, and what the visible stamp itself marks.
 //
-// Pure assembly, executed directly by provenance.test.ts. The wording/format helpers stay in feed.ts
-// (relAge / clockHM / logPhrase are pinned there and used by a dozen other surfaces) and are injected,
-// so this module owns only the story's structure: what appears, in what order, with which timestamp.
+// Emits STRUCTURED rows ({when, what}) rather than a text blob (the user, same day: the native title
+// tooltip was dense and unaligned) — the feed renders them as a styled popover whose time column
+// aligns, reusing the modal history-row vocabulary. Pure assembly, executed by provenance.test.ts;
+// the wording/format helpers stay in feed.ts (relAge / clockHM / logPhrase are pinned there and used
+// by a dozen other surfaces) and are injected, so this module owns only the story's structure.
 
 export interface LogRow { kind: string; src: string; why?: string | null; at?: number | null; evT?: number | null; }
 export interface ProvNode {
@@ -19,8 +20,11 @@ export interface ProvFmt {
   clock: (t: number) => string;          // feed clockHM
   phrase: (r: LogRow) => string;         // feed logPhrase
 }
+// one popover line: `when` is the aligned time cell ("Nm ago · HH:MM"), `what` the story cell.
+// kind lets the renderer treat the closing stamp line as its own section (separator above).
+export interface ProvRow { when: string; what: string; kind: "start" | "event" | "sub" | "more" | "stamp"; }
 
-const SUB_CAP = 8;                       // a huge tree stays a glanceable tooltip, not a scroll
+const SUB_CAP = 8;                       // a huge tree stays a glanceable popover, not a scroll
 
 function stamp(t: number, now: number, f: ProvFmt): string {
   return f.rel(now - t) + " · " + f.clock(t);
@@ -34,13 +38,18 @@ export function rootStart(it: ProvItem): number {
   return it.tree.length ? Math.min(...it.tree.map((n) => n.t)) : it.t;
 }
 
-export function provenanceTitle(it: ProvItem, now: number, f: ProvFmt): string {
-  const lines = ["started " + stamp(rootStart(it), now, f)];
+// what the visible "Nm ago" itself marks, so the stamp is self-explaining
+function stampWhat(column: string): string {
+  return column === "completed" ? "marked done" : column === "needs_input" ? "blocked" : "last update";
+}
+
+export function provenanceRows(it: ProvItem, now: number, f: ProvFmt): ProvRow[] {
+  const rows: ProvRow[] = [{ when: stamp(rootStart(it), now, f), what: "started", kind: "start" }];
   // the root's own verdict rows (asked you / you answered / …) — only shipped for non-done nodes
   const root = it.tree.find((n) => n.id === it.itemId);
   for (const r of root?.log ?? []) {
     const rt = r.at || r.evT || 0;
-    if (rt) lines.push(f.phrase(r) + " " + stamp(rt, now, f));
+    if (rt) rows.push({ when: stamp(rt, now, f), what: f.phrase(r), kind: "event" });
   }
   // sub-items in mint order: a resolved sub is stamped when it RESOLVED (mt — where it landed), an
   // open one when it was minted (its resolution hasn't happened yet)
@@ -49,21 +58,18 @@ export function provenanceTitle(it: ProvItem, now: number, f: ProvFmt): string {
     const mark = n.status === "done" ? "✓" : n.status === "question" ? "⏸" : "·";
     const at = n.status === "open" ? n.t : (n.mt || n.last || n.t);
     const txt = n.text.length > 48 ? n.text.slice(0, 47) + "…" : n.text;
-    lines.push(mark + " " + txt + " — " + stamp(at, now, f));
+    rows.push({ when: stamp(at, now, f), what: mark + " " + txt, kind: "sub" });
   }
-  if (subs.length > SUB_CAP) lines.push("…and " + (subs.length - SUB_CAP) + " more");
-  // what the visible "Nm ago" itself marks, so the stamp is self-explaining
-  const what = it.column === "completed" ? "marked done"
-    : it.column === "needs_input" ? "blocked" : "last update";
-  lines.push(what + " " + stamp(it.t, now, f));
-  return lines.join("\n");
+  if (subs.length > SUB_CAP) rows.push({ when: "", what: "…and " + (subs.length - SUB_CAP) + " more", kind: "more" });
+  rows.push({ when: stamp(it.t, now, f), what: stampWhat(it.column), kind: "stamp" });
+  return rows;
 }
 
 // a GROUP card folds N sibling asks from one typed prompt — its stamp's story is the fold itself
-export function provenanceGroupTitle(memberStarts: number[], t: number, now: number, f: ProvFmt): string {
-  const lines: string[] = [];
-  if (memberStarts.length) lines.push("started " + stamp(Math.min(...memberStarts), now, f));
-  lines.push(memberStarts.length + " cards from one prompt");
-  lines.push("last update " + stamp(t, now, f));
-  return lines.join("\n");
+export function provenanceGroupRows(memberStarts: number[], t: number, now: number, f: ProvFmt): ProvRow[] {
+  const rows: ProvRow[] = [];
+  if (memberStarts.length) rows.push({ when: stamp(Math.min(...memberStarts), now, f), what: "started", kind: "start" });
+  rows.push({ when: "", what: memberStarts.length + " cards from one prompt", kind: "sub" });
+  rows.push({ when: stamp(t, now, f), what: "last update", kind: "stamp" });
+  return rows;
 }


### PR DESCRIPTION
Follow-up to PR #55's tooltip: same content, readable form. provenance.ts emits structured {when, what, kind} rows; the feed renders a shared #age-tip popover — one right-aligned dim time column (tabular numerals), rows in the modal history-row family (0.86em), feed-toast panel look, hairline-separated closing stamp line, pointer-events:none. Assembled lazily on hover; render() hides it so a mid-hover re-render can't strand it.

Tests updated to the rows shape + CSS/wiring pins; one neighboring pin in feed-followup-move.test.ts widened for the new render() first line. pytest 3234, node 1354, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)