### PR TITLE
Provenance recency colours, rail icon sizing, network-panel consistency

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15145,8 +15145,10 @@ def _landing():
             ".rail-act svg{display:block}"
             # the ↻ is a narrow TEXT glyph whose rendered size rides the browser's fallback font — at the
             # shared 15px it drew visibly smaller than its 18px-svg network neighbor (the user 2026-07-20:
-            # "the restart kernel button got much smaller"). Size it to optically match the icon row.
-            "#rail-refresh{font-size:19px}"
+            # "the restart kernel button got much smaller"; 2026-07-27: still short next to the bell —
+            # span the full 18px icon-row height like the svg neighbors, line-height pinned so the taller
+            # glyph can't grow the bar).
+            "#rail-refresh{font-size:22px;line-height:18px;height:18px}"
             # the rail's network (⧉) action opens a shell-native popover anchored by the rail to manage
             # federated remote kernels (attach a host from ~/.ssh/config, see status, detach).
             ".rail-act.on{color:var(--accent)}"   # the network icon glows accent-blue while a remote is connected
@@ -15221,8 +15223,14 @@ def _landing():
             ".rnet-dot{width:7px;height:7px;border-radius:50%;flex:0 0 auto}"
             ".rnet-row .nm{flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}"
             ".rnet-row .st{color:#999;font-size:11px}"
-            ".rnet-row button{flex:0 0 auto;background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:6px;padding:2px 8px;cursor:pointer}"
+            # Buttons wear the settings modal's action-button vocabulary (the user 2026-07-27: sizes and button
+            # styles must match the rest of romp): 12px like the analytics-modal buttons — they inherited the
+            # panel's 13px body size before, the one size in the panel that matched nothing — with that
+            # family's hover (bg #333, text lightens). The trust dropdown + Match button stay at the 11px
+            # per-row-settings size they sit amongst.
+            ".rnet-row button{flex:0 0 auto;background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:6px;padding:2px 8px;font-size:12px;cursor:pointer}"
             ".rnet-row button:disabled{opacity:0.55;cursor:default}"
+            ".rnet-row button:hover:not(:disabled),.rnet-mirror:hover:not(:disabled),.rnet-trust:hover:not(:disabled){background:#333;color:#ddd}"
             # On a phone the panel is ~360px. Splitting the settings onto their own line already takes the
             # squeeze off line 1, but keep the wrap as a backstop: a host row previously packed trust +
             # keep + Push + Start + Detach as flex:0 0 auto, overflowed, and put Detach off the right edge,
@@ -15239,14 +15247,15 @@ def _landing():
             # "Previously attached": a quiet section header + dimmed rows, so remembered hosts read as
             # history you can act on and never as something currently connected. Hover restores full
             # opacity (they're interactive, not decoration).
-            ".rnet-khead{color:#6e7681;font-size:10.5px;letter-spacing:.04em;text-transform:uppercase;"
+            # same treatment as the settings modal's .rs-sec section headers (10.5px/700/.08em uppercase)
+            ".rnet-khead{color:#6e7681;font-size:10.5px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;"
             "margin:10px 0 2px;padding-top:8px;border-top:1px solid #2a2a2a}"
             ".rnet-known{opacity:0.62}"
             ".rnet-known:hover{opacity:1}"
             ".rnet-sha{color:#6e7681;font-variant-numeric:tabular-nums}"
             ".rnet-old{color:var(--accent)}"   # accent-blue "update available" cue (highlight chrome, not a status color)
             ".rnet-upd{color:var(--accent-fg)!important;background:var(--accent)!important;border-color:var(--accent)!important;font-weight:600}"
-            ".rnet-empty{color:#777;font-size:11px}"
+            ".rnet-empty{color:#6e7681;font-size:11px}"   # the one dim gray the panel already uses, not a fourth
             # "Automatically update" — a panel-wide setting, so it wears the same muted label treatment as the
             # per-host settings row (.rnet-keep) rather than inventing a third size
             ".rnet-auto{display:flex;align-items:center;gap:5px;color:#6e7681;font-size:11px;cursor:pointer;"
@@ -15371,6 +15380,8 @@ def _landing():
             # action buttons: dimmer + fixed-width so the four pane tabs keep the room; thin divider between
             "#mtabs .mtabs-div{flex:0 0 1px;background:#303031;margin:5px 0}"
             "#mtabs button.mact{flex:0 0 auto;padding:6px 10px;color:#7d848b;font-size:17px;line-height:1}"
+            # the mobile ↻ is the same narrow text glyph as the rail one — same optical-match treatment
+            "#mtabs .mact[data-act=restart]{font-size:21px;line-height:18px}"
             "#mtabs button.mact svg{display:block}"
             "}"
             # default Chat + Feed + Timeline shown, Fleet off (the user 2026-06-25); the rail toggles + ?panes=
@@ -15459,10 +15470,10 @@ def _landing():
             # the notification bell (the user 2026-07-27): monochrome outline like its neighbors, red +
             # unread badge when an error lands (see _LANDING_ERRS_JS). ATTRIBUTES QUOTED (the rail-net saga).
             "<div class=rail-act id=rail-errs title=Errors aria-label=Errors>"
-            "<svg viewBox='0 0 16 16' width='18' height='18'>"
+            "<svg viewBox='0 0 16 16' width='17' height='17'>"
             "<path d='M8 2 C5.8 2 4.5 3.7 4.5 6 L4.5 9 L3 11.5 L13 11.5 L11.5 9 L11.5 6 C11.5 3.7 10.2 2 8 2 Z'"
-            " fill='none' stroke='currentColor' stroke-width='1.2' stroke-linejoin='round'/>"
-            "<path d='M6.5 13.2 A1.6 1.6 0 0 0 9.5 13.2' fill='none' stroke='currentColor' stroke-width='1.2'/></svg>"
+            " fill='none' stroke='currentColor' stroke-width='1.1' stroke-linejoin='round'/>"
+            "<path d='M6.5 13.2 A1.6 1.6 0 0 0 9.5 13.2' fill='none' stroke='currentColor' stroke-width='1.1'/></svg>"
             "<span class=rerr-badge hidden></span></div>"
             "<div class=rail-act id=rail-refresh title='Restart the romp kernel' aria-label=Refresh>↻</div>"
             # remote-kernels (federation): a LAN glyph — one device wired down a bus to two below. Goes
@@ -15509,10 +15520,10 @@ def _landing():
             "<button class=mact data-act=restart aria-label='Restart kernel' title='Restart kernel'>↻</button>"
             # the notification bell on mobile too (same glyph + badge; opens the same popover)
             "<button class=mact id=merr data-act=errs aria-label=Errors title=Errors>"
-            "<svg viewBox='0 0 16 16' width='18' height='18'>"
+            "<svg viewBox='0 0 16 16' width='17' height='17'>"
             "<path d='M8 2 C5.8 2 4.5 3.7 4.5 6 L4.5 9 L3 11.5 L13 11.5 L11.5 9 L11.5 6 C11.5 3.7 10.2 2 8 2 Z'"
-            " fill='none' stroke='currentColor' stroke-width='1.2' stroke-linejoin='round'/>"
-            "<path d='M6.5 13.2 A1.6 1.6 0 0 0 9.5 13.2' fill='none' stroke='currentColor' stroke-width='1.2'/></svg>"
+            " fill='none' stroke='currentColor' stroke-width='1.1' stroke-linejoin='round'/>"
+            "<path d='M6.5 13.2 A1.6 1.6 0 0 0 9.5 13.2' fill='none' stroke='currentColor' stroke-width='1.1'/></svg>"
             "<span class=rerr-badge hidden></span></button>"
             # settings wears the desktop rail's OWN gear glyph, ⛭ (U+26ED), not the outlined star it had.
             "<button class=mact data-act=settings aria-label=Settings title=Settings>⛭</button>"

--- a/tests/test_kernel_refresh_button.py
+++ b/tests/test_kernel_refresh_button.py
@@ -23,9 +23,10 @@ class RefreshButtonDecoupledTest(unittest.TestCase):
         self.assertIn("id=rail-refresh", html)
         self.assertIn("fetch('/restart',{method:'POST'})", html)
         self.assertNotIn("id=rrefresh", _gear_src())   # gone from the feed gear
-        # …and it draws at ICON size (the user 2026-07-20: the ↻ is a narrow text glyph that rendered
-        # visibly smaller than its 18px-svg neighbors at the shared 15px — it wears its own 19px)
-        self.assertIn("#rail-refresh{font-size:19px}", html)
+        # …and it draws at ICON size (the user 2026-07-20/27: the ↻ is a narrow text glyph that rendered
+        # visibly smaller than its 18px-svg neighbors — it now spans the full 18px icon-row height,
+        # line-height pinned so the taller glyph can't grow the bar)
+        self.assertIn("#rail-refresh{font-size:22px;line-height:18px;height:18px}", html)
 
     def test_refresh_button_is_not_gated_on_debug(self):
         # the old applyDebug() helper (which hid #rrefresh unless s.debug) is gone entirely …

--- a/ui/webview/age-color.ts
+++ b/ui/webview/age-color.ts
@@ -1,0 +1,66 @@
+// The recency colour ramp — ONE shared implementation for every "(Xm ago)" tint outside render.ts
+// (extracted 2026-07-27 from fleet.ts, which had copied it verbatim from render.ts; the feed's
+// age-provenance popover made a third copy imminent, so the copy became a module). render.ts still
+// carries its own twin, entangled with its live `settings` object — KEEP THE TWO IN SYNC, and both
+// in sync with bin/romp_colormap.py (the kernel computes trgb tints from the same stops).
+export const COLORMAPS: Record<string, Array<[number, number, number]>> = {
+  aurora: [[84, 178, 4], [0, 180, 115], [35, 175, 156], [66, 169, 176], [25, 168, 201], [14, 164, 227], [74, 155, 241], [113, 145, 244], [144, 136, 240]],   // romp green→teal→blue→purple at CONSTANT lightness — the default
+  hawaii: [[140, 2, 115], [146, 46, 85], [151, 78, 62], [155, 111, 40], [156, 150, 28], [137, 189, 74], [107, 212, 142], [103, 233, 213], [179, 242, 253]],
+  viridis: [[68, 1, 84], [72, 40, 120], [62, 74, 137], [49, 104, 142], [38, 130, 142], [31, 158, 137], [53, 183, 121], [110, 206, 88], [181, 222, 43], [253, 231, 37]],
+  magma: [[0, 0, 4], [28, 16, 68], [79, 18, 123], [129, 37, 129], [181, 54, 122], [229, 80, 100], [251, 135, 97], [254, 194, 135], [252, 253, 191]],
+  inferno: [[0, 0, 4], [40, 11, 84], [101, 21, 110], [159, 42, 99], [212, 72, 66], [245, 125, 21], [250, 193, 39], [252, 255, 164]],
+  plasma: [[13, 8, 135], [75, 3, 161], [125, 3, 168], [168, 34, 150], [203, 70, 121], [229, 107, 93], [248, 148, 65], [253, 195, 40], [240, 249, 33]],
+  cividis: [[0, 34, 78], [33, 59, 110], [76, 85, 108], [108, 110, 114], [142, 137, 120], [177, 165, 112], [217, 197, 92], [254, 232, 56]],
+};
+function selectedStops(): Array<[number, number, number]> {
+  let name = "aurora";
+  try { name = String(JSON.parse(localStorage.getItem("romp:settings") || "{}").colormap || "aurora"); } catch { /* default */ }
+  return COLORMAPS[name.toLowerCase()] || COLORMAPS.aurora;
+}
+function ramp(v: number): [number, number, number] {
+  const STOPS = selectedStops();
+  v = Math.max(0, Math.min(1, v));
+  const x = v * (STOPS.length - 1), i = Math.floor(x), fr = x - i;
+  if (i >= STOPS.length - 1) return STOPS[STOPS.length - 1];
+  const a = STOPS[i], b = STOPS[i + 1];
+  return [Math.round(a[0] + (b[0] - a[0]) * fr), Math.round(a[1] + (b[1] - a[1]) * fr), Math.round(a[2] + (b[2] - a[2]) * fr)];
+}
+function recencyV(ageSecs: number): number {
+  const LO = 120, HI = 345600;
+  const a = Math.max(LO, Math.min(HI, ageSecs));
+  return 1.0 - (Math.log(a) - Math.log(LO)) / (Math.log(HI) - Math.log(LO));
+}
+function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
+  r /= 255; g /= 255; b /= 255;
+  const mx = Math.max(r, g, b), mn = Math.min(r, g, b), d = mx - mn;
+  let h = 0; const l = (mx + mn) / 2;
+  const s = d === 0 ? 0 : l > 0.5 ? d / (2 - mx - mn) : d / (mx + mn);
+  if (d !== 0) {
+    if (mx === r) h = (g - b) / d + (g < b ? 6 : 0);
+    else if (mx === g) h = (b - r) / d + 2;
+    else h = (r - g) / d + 4;
+    h /= 6;
+  }
+  return [h, s, l];
+}
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  if (s === 0) { const v = Math.round(l * 255); return [v, v, v]; }
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s, p = 2 * l - q;
+  const hk = (t: number) => {
+    if (t < 0) t += 1; if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  return [Math.round(hk(h + 1 / 3) * 255), Math.round(hk(h) * 255), Math.round(hk(h - 1 / 3) * 255)];
+}
+export function ageColorReadable(ageSecs: number): string {
+  const v = recencyV(ageSecs);
+  const c = ramp(v);
+  const [h, s] = rgbToHsl(c[0], c[1], c[2]);
+  const L = 0.50 + 0.22 * v;
+  const S = Math.max(0.4, s) * (0.65 + 0.35 * v);
+  const o = hslToRgb(h, Math.min(1, S), L);
+  return `rgb(${o[0]}, ${o[1]}, ${o[2]})`;
+}

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -12,6 +12,7 @@ import { onlyTag, matchesOnly } from "./only-filter";
 import { hostNameNodes, hostPartsNodes } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
 import { provenanceRows, provenanceGroupRows, rootStart, type ProvFmt, type ProvRow } from "./provenance";
+import { ageColorReadable } from "./age-color";
 import { badgeNotices } from "./badge-mirror";
 import { initStrip } from "./strip";
 import { installSettingsSync } from "./settings";
@@ -1702,6 +1703,9 @@ function showAgeTip(anchor: HTMLElement, rows: ProvRow[]): void {
     const row = el("div", "age-tip-row" + (r.kind === "stamp" ? " stamp" : ""));
     const w = el("span", "age-tip-when"); w.textContent = r.when;
     const x = el("span", "age-tip-what"); x.textContent = r.what;
+    // each line wears its own recency colour — time AND text, the chat tab-tip treatment (the user
+    // 2026-07-27); the un-timed remainder row keeps the panel's dim default
+    if (r.t > 0) { const c = ageColorReadable(hostNow - r.t); row.style.color = c; w.style.color = c; }
     row.append(w, x); tip.appendChild(row);
   }
   tip.style.display = "block";

--- a/ui/webview/fleet.test.ts
+++ b/ui/webview/fleet.test.ts
@@ -56,9 +56,13 @@ test("a session-level collapse caret folds the whole session's tree WITHOUT open
   assert.match(SRC, /if \(sessFolded\.has\(sid\)\) sessFolded\.delete\(sid\); else sessFolded\.add\(sid\);/);
 });
 
-test("recency colour is copied VERBATIM from render.ts (identical to the ledger box)", () => {
-  assert.match(SRC, /function ageColorReadable\(ageSecs: number\)/);
-  assert.match(SRC, /const LO = 120, HI = 345600/);               // the same recency curve
+test("recency colour comes from the SHARED age-color module (identical to the ledger box)", () => {
+  // was a verbatim copy of render.ts's ramp; extracted 2026-07-27 into ui/webview/age-color.ts when the
+  // feed's age-provenance popover would have made a third copy — fleet now imports the one source
+  assert.match(SRC, /import \{ ageColorReadable \} from "\.\/age-color";/);
+  const AGE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "age-color.ts"), "utf8");
+  assert.match(AGE, /export function ageColorReadable\(ageSecs: number\)/);
+  assert.match(AGE, /const LO = 120, HI = 345600/);               // the same recency curve
   assert.match(SRC, /function stampSubtreeRecency/);              // the same subtree recency rollup
   assert.match(SRC, /const dt = now - nodeRecency\(n\);/);        // done text/time take the rolled-up recency…
   assert.match(SRC, /time\.style\.color = ageColorReadable\(dt\)/); // …in the shared colour

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -8,6 +8,7 @@ import { delegate } from "./actions";
 import { fleetVisibleRoots } from "./fleet-roots";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { hostPrefix } from "./host-prefix";
+import { ageColorReadable } from "./age-color";
 
 type Color = { bg: string; fg: string } | null;
 interface LedgerNode {
@@ -181,68 +182,6 @@ function fleetNavTo(el: HTMLElement, kind: "prompt" | "work") {
   backToChat();
 }
 
-// ── recency colour, copied verbatim from render.ts so Fleet's "(Xm ago)" colours match the ledger box ──
-const COLORMAPS: Record<string, Array<[number, number, number]>> = {
-  aurora: [[84, 178, 4], [0, 180, 115], [35, 175, 156], [66, 169, 176], [25, 168, 201], [14, 164, 227], [74, 155, 241], [113, 145, 244], [144, 136, 240]],   // romp green→teal→blue→purple at CONSTANT lightness — the default
-  hawaii: [[140, 2, 115], [146, 46, 85], [151, 78, 62], [155, 111, 40], [156, 150, 28], [137, 189, 74], [107, 212, 142], [103, 233, 213], [179, 242, 253]],
-  viridis: [[68, 1, 84], [72, 40, 120], [62, 74, 137], [49, 104, 142], [38, 130, 142], [31, 158, 137], [53, 183, 121], [110, 206, 88], [181, 222, 43], [253, 231, 37]],
-  magma: [[0, 0, 4], [28, 16, 68], [79, 18, 123], [129, 37, 129], [181, 54, 122], [229, 80, 100], [251, 135, 97], [254, 194, 135], [252, 253, 191]],
-  inferno: [[0, 0, 4], [40, 11, 84], [101, 21, 110], [159, 42, 99], [212, 72, 66], [245, 125, 21], [250, 193, 39], [252, 255, 164]],
-  plasma: [[13, 8, 135], [75, 3, 161], [125, 3, 168], [168, 34, 150], [203, 70, 121], [229, 107, 93], [248, 148, 65], [253, 195, 40], [240, 249, 33]],
-  cividis: [[0, 34, 78], [33, 59, 110], [76, 85, 108], [108, 110, 114], [142, 137, 120], [177, 165, 112], [217, 197, 92], [254, 232, 56]],
-};
-function selectedStops(): Array<[number, number, number]> {
-  let name = "aurora";
-  try { name = String(JSON.parse(localStorage.getItem("romp:settings") || "{}").colormap || "aurora"); } catch { /* default */ }
-  return COLORMAPS[name.toLowerCase()] || COLORMAPS.aurora;
-}
-function ramp(v: number): [number, number, number] {
-  const STOPS = selectedStops();
-  v = Math.max(0, Math.min(1, v));
-  const x = v * (STOPS.length - 1), i = Math.floor(x), fr = x - i;
-  if (i >= STOPS.length - 1) return STOPS[STOPS.length - 1];
-  const a = STOPS[i], b = STOPS[i + 1];
-  return [Math.round(a[0] + (b[0] - a[0]) * fr), Math.round(a[1] + (b[1] - a[1]) * fr), Math.round(a[2] + (b[2] - a[2]) * fr)];
-}
-function recencyV(ageSecs: number): number {
-  const LO = 120, HI = 345600;
-  const a = Math.max(LO, Math.min(HI, ageSecs));
-  return 1.0 - (Math.log(a) - Math.log(LO)) / (Math.log(HI) - Math.log(LO));
-}
-function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
-  r /= 255; g /= 255; b /= 255;
-  const mx = Math.max(r, g, b), mn = Math.min(r, g, b), d = mx - mn;
-  let h = 0; const l = (mx + mn) / 2;
-  const s = d === 0 ? 0 : l > 0.5 ? d / (2 - mx - mn) : d / (mx + mn);
-  if (d !== 0) {
-    if (mx === r) h = (g - b) / d + (g < b ? 6 : 0);
-    else if (mx === g) h = (b - r) / d + 2;
-    else h = (r - g) / d + 4;
-    h /= 6;
-  }
-  return [h, s, l];
-}
-function hslToRgb(h: number, s: number, l: number): [number, number, number] {
-  if (s === 0) { const v = Math.round(l * 255); return [v, v, v]; }
-  const q = l < 0.5 ? l * (1 + s) : l + s - l * s, p = 2 * l - q;
-  const hk = (t: number) => {
-    if (t < 0) t += 1; if (t > 1) t -= 1;
-    if (t < 1 / 6) return p + (q - p) * 6 * t;
-    if (t < 1 / 2) return q;
-    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
-    return p;
-  };
-  return [Math.round(hk(h + 1 / 3) * 255), Math.round(hk(h) * 255), Math.round(hk(h - 1 / 3) * 255)];
-}
-function ageColorReadable(ageSecs: number): string {
-  const v = recencyV(ageSecs);
-  const c = ramp(v);
-  const [h, s] = rgbToHsl(c[0], c[1], c[2]);
-  const L = 0.50 + 0.22 * v;
-  const S = Math.max(0.4, s) * (0.65 + 0.35 * v);
-  const o = hslToRgb(h, Math.min(1, S), L);
-  return `rgb(${o[0]}, ${o[1]}, ${o[2]})`;
-}
 function agehms(secs: number): string {
   secs = Math.max(0, Math.floor(secs));
   if (secs < 60) return `${secs}s`;

--- a/ui/webview/provenance.test.ts
+++ b/ui/webview/provenance.test.ts
@@ -37,13 +37,13 @@ function item(over: Partial<ProvItem> = {}): ProvItem {
 
 test("the story: started at the root's mint, each sub at ITS time, the stamp explained last", () => {
   const rows = provenanceRows(item(), NOW, F);
-  assert.deepEqual(rows[0], { when: "150m ago · @1000", what: "started", kind: "start" });
-  assert.deepEqual(rows[1], { when: "80m ago · @5200", what: "✓ write the parser", kind: "sub" },
+  assert.deepEqual(rows[0], { when: "150m ago · @1000", what: "started", t: 1_000, kind: "start" });
+  assert.deepEqual(rows[1], { when: "80m ago · @5200", what: "✓ write the parser", t: 5_200, kind: "sub" },
     "a resolved sub stamps where it RESOLVED (mt)");
-  assert.deepEqual(rows[2], { when: "50m ago · @7000", what: "⏸ ask about the schema", kind: "sub" });
-  assert.deepEqual(rows[3], { when: "20m ago · @8800", what: "· docs pass", kind: "sub" },
+  assert.deepEqual(rows[2], { when: "50m ago · @7000", what: "⏸ ask about the schema", t: 7_000, kind: "sub" });
+  assert.deepEqual(rows[3], { when: "20m ago · @8800", what: "· docs pass", t: 8_800, kind: "sub" },
     "an open sub stamps its mint (nothing resolved yet)");
-  assert.deepEqual(rows[4], { when: "10m ago · @9400", what: "marked done", kind: "stamp" },
+  assert.deepEqual(rows[4], { when: "10m ago · @9400", what: "marked done", t: 9_400, kind: "stamp" },
     "the visible age is named for what it marks");
 });
 
@@ -56,8 +56,8 @@ test("the root's own verdict rows ride between start and subs, in the feed's out
   const it = item();
   it.tree[0].log = [{ kind: "block", src: "romp", at: 3_000 }, { kind: "unblock", src: "romp", evT: 4_000 }];
   const rows = provenanceRows(it, NOW, F);
-  assert.deepEqual(rows[1], { when: "117m ago · @3000", what: "[block]", kind: "event" });
-  assert.deepEqual(rows[2], { when: "100m ago · @4000", what: "[unblock]", kind: "event" },
+  assert.deepEqual(rows[1], { when: "117m ago · @3000", what: "[block]", t: 3_000, kind: "event" });
+  assert.deepEqual(rows[2], { when: "100m ago · @4000", what: "[unblock]", t: 4_000, kind: "event" },
     "evT is the time-nav fallback when `at` is absent");
   assert.equal(rows[3].what, "✓ write the parser", "subs follow the root's events");
 });
@@ -73,7 +73,7 @@ test("cleared subs stay out; a huge tree caps at 8 with an honest remainder", ()
   });
   const rows = provenanceRows(big, NOW, F);
   assert.equal(rows.length, 1 + 8 + 1 + 1, "start + 8 subs + remainder + stamp row");
-  assert.deepEqual(rows[9], { when: "", what: "…and 3 more", kind: "more" }, "no silent truncation");
+  assert.deepEqual(rows[9], { when: "", what: "…and 3 more", t: 0, kind: "more" }, "no silent truncation");
 });
 
 test("rootStart falls back: earliest tree mint without a root row, the card's t on an empty tree", () => {
@@ -84,9 +84,9 @@ test("rootStart falls back: earliest tree mint without a root row, the card's t 
 
 test("a group's story is the fold: earliest member start, the member count, the group stamp", () => {
   const rows = provenanceGroupRows([5_000, 3_000, 7_000], 9_000, NOW, F);
-  assert.deepEqual(rows[0], { when: "117m ago · @3000", what: "started", kind: "start" });
-  assert.deepEqual(rows[1], { when: "", what: "3 cards from one prompt", kind: "sub" });
-  assert.deepEqual(rows[2], { when: "17m ago · @9000", what: "last update", kind: "stamp" });
+  assert.deepEqual(rows[0], { when: "117m ago · @3000", what: "started", t: 3_000, kind: "start" });
+  assert.deepEqual(rows[1], { when: "", what: "3 cards from one prompt", t: 0, kind: "sub" });
+  assert.deepEqual(rows[2], { when: "17m ago · @9000", what: "last update", t: 9_000, kind: "stamp" });
 });
 
 test("the feed wires the popover beside every age write — card, group card, both modal headers", () => {
@@ -96,6 +96,14 @@ test("the feed wires the popover beside every age write — card, group card, bo
   assert.match(FEED, /wireAgeTip\(ageEl, \(\) => provenanceGroupRows\(grp\.members\.map\(rootStart\), grp\.t, hostNow, PROV_FMT\)\);/);
   // …with the same vocabulary the card itself renders in
   assert.match(FEED, /const PROV_FMT: ProvFmt = \{ rel: relAge, clock: clockHM, phrase: logPhrase \};/);
+});
+
+test("every timed line wears its own recency colour — time AND text, the chat tab-tip treatment", () => {
+  // the user 2026-07-27: colour the timestamps and their items the way the chat tab hover does. The
+  // feed tints the whole row (and the when cell explicitly, beating its dim class) from the SHARED
+  // age-color ramp; the un-timed remainder row keeps the panel's dim default (t: 0 guards it).
+  assert.match(FEED, /import \{ ageColorReadable \} from "\.\/age-color";/);
+  assert.match(FEED, /if \(r\.t > 0\) \{ const c = ageColorReadable\(hostNow - r\.t\); row\.style\.color = c; w\.style\.color = c; \}/);
 });
 
 test("the popover is aligned, styled in the feed's own vocabulary, and can never eat a click", () => {

--- a/ui/webview/provenance.ts
+++ b/ui/webview/provenance.ts
@@ -20,9 +20,11 @@ export interface ProvFmt {
   clock: (t: number) => string;          // feed clockHM
   phrase: (r: LogRow) => string;         // feed logPhrase
 }
-// one popover line: `when` is the aligned time cell ("Nm ago · HH:MM"), `what` the story cell.
-// kind lets the renderer treat the closing stamp line as its own section (separator above).
-export interface ProvRow { when: string; what: string; kind: "start" | "event" | "sub" | "more" | "stamp"; }
+// one popover line: `when` is the aligned time cell ("Nm ago · HH:MM"), `what` the story cell, `t`
+// the row's own epoch so the renderer can tint the whole line by recency (the tab-tip treatment —
+// the user 2026-07-27; 0 on the un-timed remainder row). kind lets the renderer treat the closing
+// stamp line as its own section (separator above).
+export interface ProvRow { when: string; what: string; t: number; kind: "start" | "event" | "sub" | "more" | "stamp"; }
 
 const SUB_CAP = 8;                       // a huge tree stays a glanceable popover, not a scroll
 
@@ -44,12 +46,12 @@ function stampWhat(column: string): string {
 }
 
 export function provenanceRows(it: ProvItem, now: number, f: ProvFmt): ProvRow[] {
-  const rows: ProvRow[] = [{ when: stamp(rootStart(it), now, f), what: "started", kind: "start" }];
+  const rows: ProvRow[] = [{ when: stamp(rootStart(it), now, f), what: "started", t: rootStart(it), kind: "start" }];
   // the root's own verdict rows (asked you / you answered / …) — only shipped for non-done nodes
   const root = it.tree.find((n) => n.id === it.itemId);
   for (const r of root?.log ?? []) {
     const rt = r.at || r.evT || 0;
-    if (rt) rows.push({ when: stamp(rt, now, f), what: f.phrase(r), kind: "event" });
+    if (rt) rows.push({ when: stamp(rt, now, f), what: f.phrase(r), t: rt, kind: "event" });
   }
   // sub-items in mint order: a resolved sub is stamped when it RESOLVED (mt — where it landed), an
   // open one when it was minted (its resolution hasn't happened yet)
@@ -58,18 +60,18 @@ export function provenanceRows(it: ProvItem, now: number, f: ProvFmt): ProvRow[]
     const mark = n.status === "done" ? "✓" : n.status === "question" ? "⏸" : "·";
     const at = n.status === "open" ? n.t : (n.mt || n.last || n.t);
     const txt = n.text.length > 48 ? n.text.slice(0, 47) + "…" : n.text;
-    rows.push({ when: stamp(at, now, f), what: mark + " " + txt, kind: "sub" });
+    rows.push({ when: stamp(at, now, f), what: mark + " " + txt, t: at, kind: "sub" });
   }
-  if (subs.length > SUB_CAP) rows.push({ when: "", what: "…and " + (subs.length - SUB_CAP) + " more", kind: "more" });
-  rows.push({ when: stamp(it.t, now, f), what: stampWhat(it.column), kind: "stamp" });
+  if (subs.length > SUB_CAP) rows.push({ when: "", what: "…and " + (subs.length - SUB_CAP) + " more", t: 0, kind: "more" });
+  rows.push({ when: stamp(it.t, now, f), what: stampWhat(it.column), t: it.t, kind: "stamp" });
   return rows;
 }
 
 // a GROUP card folds N sibling asks from one typed prompt — its stamp's story is the fold itself
 export function provenanceGroupRows(memberStarts: number[], t: number, now: number, f: ProvFmt): ProvRow[] {
   const rows: ProvRow[] = [];
-  if (memberStarts.length) rows.push({ when: stamp(Math.min(...memberStarts), now, f), what: "started", kind: "start" });
-  rows.push({ when: "", what: memberStarts.length + " cards from one prompt", kind: "sub" });
-  rows.push({ when: stamp(t, now, f), what: "last update", kind: "stamp" });
+  if (memberStarts.length) rows.push({ when: stamp(Math.min(...memberStarts), now, f), what: "started", t: Math.min(...memberStarts), kind: "start" });
+  rows.push({ when: "", what: memberStarts.length + " cards from one prompt", t: 0, kind: "sub" });
+  rows.push({ when: stamp(t, now, f), what: "last update", t: t, kind: "stamp" });
   return rows;
 }


### PR DESCRIPTION
- Age-provenance popover lines are tinted by their own recency (time and text), matching the chat tab-hover treatment, via a new shared `ui/webview/age-color.ts` (extracted from fleet.ts's verbatim copy of render.ts's ramp; fleet now imports it).
- The rail bell draws slightly smaller (17px / 1.1 stroke) and the ↻ glyph spans the full icon-row height like the svg icons, desktop and mobile.
- Network panel: row buttons adopt the settings modal's 12px action-button vocabulary with its hover; the section header matches .rs-sec exactly; the stray empty-state gray unified.

pytest 3234, node 1355, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)