### PR TITLE
Floor-minted titles heal from the landed caption; judge calls get a permissive alarm

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -342,6 +342,16 @@ def _judge_claude_bin():
             or os.path.expanduser("~/.local/bin/claude"))
 
 
+# Hard wall-clock cap on ONE judge call (perl alarm → SIGALRM, logged as "empty stdout (exit -14)").
+# Was 45s until 2026-07-27, when an API slow patch killed a burst of healthy-but-slow calls across four
+# sessions in one morning and the coerce floor minted a card titled with the user's raw message head from
+# the wreckage. A slow call that lands beats a killed one on both cost and heal latency (the kill burns
+# the tokens AND leaves the pass to re-run next tick), so be permissive (the user 2026-07-27): the alarm
+# guards a truly hung exec, not a slow model. The subprocess timeout below it is the backstop for a perl
+# that never ran; it tracks this constant so the two can't drift apart.
+CALL_ALARM_S = 120
+
+
 def _judge_cmd(model, sys_prompt, effort=None):
     """The `claude -p` argv for ONE judge call, isolated so the model sees ONLY its own prompt. Three
     flags do it (verified by token count: a probe call drops 8334 -> ~165 input tokens):
@@ -351,7 +361,7 @@ def _judge_cmd(model, sys_prompt, effort=None):
         CLAUDE.md was otherwise still injected — privacy rules, the Romp Postal section, etc., all
         noise for a zero-tool classifier). --safe-mode keeps auth + model, so subscription billing is
         unchanged. (NOT --bare: that drops the login too.) (the user, 2026-06-16.)"""
-    cmd = ["perl", "-e", "alarm 45; exec @ARGV", _judge_claude_bin(), "-p", "--safe-mode", "--model", model,
+    cmd = ["perl", "-e", "alarm %d; exec @ARGV" % CALL_ALARM_S, _judge_claude_bin(), "-p", "--safe-mode", "--model", model,
            "--tools", "", "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}',
            "--system-prompt", sys_prompt, "--exclude-dynamic-system-prompt-sections",
            "--output-format", "json"]                 # stdout = {"result", "usage", "duration_ms", "total_cost_usd"}
@@ -573,7 +583,8 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage"):
         try:
             os.makedirs(JUDGE_SCRATCH, exist_ok=True)   # tmpfiles-cleaned /tmp: recreate per call
             p = subprocess.run(_judge_cmd(model, sys_prompt, effort), input=user,
-                               capture_output=True, text=True, cwd=JUDGE_SCRATCH, env=env, timeout=50)
+                               capture_output=True, text=True, cwd=JUDGE_SCRATCH, env=env,
+                               timeout=CALL_ALARM_S + 5)
         except Exception as e:
             # _judge_run owns ALL call-level logging (this, the error envelope below, the rate gate above)
             # so callers never double-log: to a caller every failed call is just "", and "call" rows always
@@ -3817,6 +3828,33 @@ def _heal_quote_titles(store):
     return n
 
 
+def _heal_floor_titles(fsid, store):
+    """Deterministic title heal for the coerce floor's OTHER failure shape (the user 2026-07-27): a
+    judge outage at mint time (the gister timed out too, so _prompt_gist was empty) leaves a
+    _coerce_place node wearing the verbatim message head (_seg_label) as its title — and the real
+    gist that lands in captions/ minutes later never reaches it, because nothing retitles an
+    existing node. Retitle from the persisted prompt caption once it exists: the same phrase the
+    timeline dot and the Analyzing card wear, so every surface tells one story, and no LLM call.
+    No age limit, deliberately (the user 2026-07-27: damage heals whenever the missing piece shows
+    up; only a cleared card is past caring — and a cleared node is skipped here). Recognized by the
+    coerce diary why (_COERCE_WHY, stamped on every coerced node) so pre-heal stores qualify with no
+    migration, and gated on the node STILL wearing its floor label (text == _seg_label(quote)) — a
+    planner retitle, or this heal itself, closes the gate for good. Returns the number healed."""
+    n = 0
+    for nd in store.get("nodes", {}).values():
+        if nd.get("cleared") or nd.get("why") != _COERCE_WHY:
+            continue
+        q = (nd.get("quote") or "").strip()
+        if not q or (nd.get("text") or "") != _seg_label(q):
+            continue
+        seg = (nd.get("trail") or [""])[0]              # trail[0] = the minting segment (append-only)
+        gist = _prompt_gist(fsid, seg) if seg else ""
+        if gist and gist != nd["text"]:
+            nd["text"] = gist
+            n += 1
+    return n
+
+
 def _prompt_gist(fsid, seg_id):
     """The persisted INDEX-tier gist of this segment's user message (captions/<fsid>.jsonl, id
     '<seg_id>#p', last-wins) — the same phrase the timeline dot and the Analyzing card show. '' when
@@ -3844,6 +3882,12 @@ def _followup_title(fsid, seg_id, text):
     return _prompt_gist(fsid, seg_id) or gist_llm(text) or _seg_label(text)
 
 
+# The coerce diary line, shared with _heal_floor_titles: the heal recognizes floor-minted nodes in
+# EXISTING stores by this `why` (every coerced node carries it), so old damage heals with no
+# migration and no new node marker.
+_COERCE_WHY = "kept on the board: a user message the planner tried to skip"
+
+
 def _coerce_place(menu, text, title=None):
     """Hard-guard floor: the planner returned skip for a segment carrying a real user message, which
     must never silently vanish. Place it deterministically — a step under the most recent open CARD
@@ -3860,7 +3904,7 @@ def _coerce_place(menu, text, title=None):
     card that is not waiting on the user (its whole on-menu subtree unblocked), or as its own top
     when every card is."""
     label = title or _seg_label(text)
-    why = "kept on the board: a user message the planner tried to skip"
+    why = _COERCE_WHY
     if menu:
         ids = {nd["id"] for nd in menu}
         by_id = {nd["id"]: nd for nd in menu}
@@ -4884,8 +4928,9 @@ def _plan_session(fsid, path, now):
     _judge_ctx.fsid = fsid                            # usage logging: attribute this session's judge calls
     session = parsed_session(fsid, [path], now)
     store = load_goals(fsid)
-    if _heal_quote_titles(store):                     # quote-leaked floor titles → the user's own words (no LLM)
-        save_goals(fsid, store)                       # persist even if no new units land this pass
+    if _heal_quote_titles(store) + _heal_floor_titles(fsid, store):   # floor titles (quote-leak → the user's
+        save_goals(fsid, store)                       # own words; raw-head → the landed prompt caption), both
+    #                                                   no-LLM; persist even if no new units land this pass
     # Built once, used only by the KNOWN-target branches below (delegation/nudge/followup) to hand the
     # planner that one goal's own raw history alongside its menu title (the user 2026-07-01) — no LLM
     # call, just an index over already-parsed atoms. Seam-aware (_segs) so a settle-split tail resolves.

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -5994,6 +5994,78 @@ class QuoteTitleHeal(unittest.TestCase):
         self.assertEqual(jd._heal_quote_titles(store), 0, "healed titles never re-enter (event-gated)")
 
 
+class FloorTitleHeal(unittest.TestCase):
+    """Raw-head floor titles (the user 2026-07-27): a judge timeout burst at mint time left a
+    _coerce_place card titled with the verbatim head of the user's message, and the prompt caption
+    that landed minutes later never reached it — nothing retitles an existing node. _heal_floor_titles
+    retitles from the landed caption deterministically (no LLM, no age limit; cleared cards excepted),
+    wired into every planner pass beside _heal_quote_titles."""
+
+    SEG = SID + ":1781099000:aabbccdd"
+    QUOTE = "the deploy script keeps wiping the staging config how do I stop that from happening"
+    GIST = "stopping the deploy script from wiping the staging config"
+
+    def setUp(self):
+        self._saved_state = jd.STATE
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+
+    def tearDown(self):
+        jd._rebind_state(self._saved_state)
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _node(self, **kw):
+        nd = {"id": SID + ":g1", "text": jd._seg_label(self.QUOTE), "quote": self.QUOTE,
+              "why": jd._COERCE_WHY, "trail": [self.SEG]}
+        nd.update(kw)
+        return nd
+
+    def _land_caption(self):
+        jd.CAPDIR.mkdir(parents=True, exist_ok=True)
+        (jd.CAPDIR / (SID + ".jsonl")).write_text(
+            json.dumps({"id": self.SEG + "#p", "grain": "prompt", "caption": self.GIST}) + "\n")
+
+    def test_coerced_mint_carries_the_shared_why_and_floor_label(self):
+        op = jd._coerce_place([], "USER ASKED: " + self.QUOTE)[0]
+        self.assertEqual(op["why"], jd._COERCE_WHY, "mint and heal share ONE why definition")
+        self.assertEqual(op["text"], jd._seg_label(self.QUOTE), "no gist at mint time → the floor label")
+        self.assertEqual(jd._coerce_place([], "USER ASKED: " + self.QUOTE, title=self.GIST)[0]["text"],
+                         self.GIST, "a gist already landed at mint time is used directly — nothing to heal")
+
+    def test_heal_retitles_once_the_caption_lands(self):
+        store = {"nodes": {SID + ":g1": self._node()}}
+        self.assertEqual(jd._heal_floor_titles(SID, store), 0, "no caption yet → nothing to do, no crash")
+        self._land_caption()
+        self.assertEqual(jd._heal_floor_titles(SID, store), 1)
+        self.assertEqual(store["nodes"][SID + ":g1"]["text"], self.GIST,
+                         "the card wears the same gist the timeline dot and Analyzing card show")
+        self.assertEqual(jd._heal_floor_titles(SID, store), 0, "healed once — the gate is closed for good")
+
+    def test_heal_leaves_cleared_retitled_and_uncoerced_nodes_alone(self):
+        self._land_caption()
+        cleared = self._node(id=SID + ":g1", cleared=True)
+        retitled = self._node(id=SID + ":g2", text="A title the planner chose later")
+        uncoerced = self._node(id=SID + ":g3", why="filed under the release card")
+        store = {"nodes": {n["id"]: n for n in (cleared, retitled, uncoerced)}}
+        self.assertEqual(jd._heal_floor_titles(SID, store), 0)
+        self.assertEqual(store["nodes"][SID + ":g1"]["text"], jd._seg_label(self.QUOTE),
+                         "a cleared card is past caring — never rewritten")
+        self.assertEqual(store["nodes"][SID + ":g2"]["text"], "A title the planner chose later",
+                         "a planner retitle outranks the heal, permanently")
+
+
+class JudgeCallAlarm(unittest.TestCase):
+    """The judge-call wall clock (the user 2026-07-27): 45s proved trigger-happy — an API slow patch
+    killed a burst of healthy-but-slow calls and the coerce floor minted raw-titled cards from the
+    wreckage. One permissive constant, wired into the perl alarm the CLI runs under."""
+
+    def test_alarm_is_permissive_and_wired_into_the_cmd(self):
+        self.assertGreaterEqual(jd.CALL_ALARM_S, 120, "a slow call that lands beats a killed one")
+        cmd = jd._judge_cmd("some-model", "a system prompt")
+        self.assertEqual(cmd[:3], ["perl", "-e", "alarm %d; exec @ARGV" % jd.CALL_ALARM_S],
+                         "the alarm the CLI runs under IS the constant — the two can't drift")
+
+
 class SeamRegrowth(unittest.TestCase):
     """Settle-time seam (plans/segment-regrowth.md): a top goal that settles while its placed segment
     keeps GROWING splits that segment at the settle moment — the post-close tail becomes a fresh,


### PR DESCRIPTION
Two recovery fixes from the 2026-07-27 morning judge-timeout burst (an API slow patch killed healthy-but-slow judge calls; the never-vanish coerce floor then minted a card titled with the verbatim head of the user's message, and nothing ever retitled it even after the proper gist landed in captions/).

- **`_heal_floor_titles`** — a coerced node still wearing its floor label (`text == _seg_label(quote)`, recognized by the coerce diary `why`, so existing stores qualify with no migration) is retitled from the segment's persisted `#p` prompt caption once that lands. Deterministic, no LLM call, no age limit; cleared cards and planner retitles are never touched. Wired into every planner pass beside `_heal_quote_titles`.
- **`CALL_ALARM_S = 120`** (was a literal `alarm 45`) — a slow call that lands beats a killed one on both cost and heal latency, so the alarm now only guards a truly hung exec. The `subprocess.run` timeout backstop is derived from the constant so the two can't drift.

Tests: `FloorTitleHeal` (mint/heal share one `why`; heals once the caption lands; gate closes for good; cleared/retitled/uncoerced nodes untouched) and `JudgeCallAlarm` (constant wired into the perl alarm, floor of 120). Both suites green: Python 3238 passed, Node 1355 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)