### PR TITLE
The courier demotes a declared message kind but never promotes it

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -7949,8 +7949,9 @@ def _seg_peer(seg):
 def _seg_peer_kind(seg):
     """The sender-declared postal kind (delegate|coordinate|question) riding the delivered message's
     romp-msg-kind marker (2026-07-08 — send_message requires it in the schema), or '' for legacy/CLI
-    mail with no declaration. The courier treats it as a strong prior, never the verdict. Mirrors
-    _seg_peer's trigger lookup."""
+    mail with no declaration. coordinate/question are BINDING (filed fyi, no courier call); a declared
+    delegate is a strong prior the courier may demote but never invert (demote-only, the user
+    2026-07-27). Mirrors _seg_peer's trigger lookup."""
     atoms = seg.get("atoms") or []
     trig = next((a for a in atoms if a.get("uuid") == seg.get("trigger")), None) or (atoms[0] if atoms else None)
     if not trig:
@@ -8133,13 +8134,14 @@ def _parse_courier(raw, menu_len):
 def courier_llm(message_text, menu_text, declared=""):
     """One courier verdict line from the TRIAGE-tier model (Sonnet) over a postal message + the
     sender's open goals. '' on failure. `declared` = the sender's own kind declaration from the
-    send_message schema (2026-07-08) — a strong prior the model may override when the body clearly
-    shows otherwise (a "coordinate" that hands over work, a "delegate" that transfers nothing)."""
+    send_message schema (2026-07-08). Only a declared DELEGATE (or undeclared legacy mail) reaches
+    this call — run_courier files coordinate/question as fyi without asking (demote-only, the user
+    2026-07-27) — so the model's one open question on declared mail is whether the delegate really
+    hands work over."""
     user = "<message>\n%s\n</message>\n<sender-open-goals>\n%s\n</sender-open-goals>" % (message_text, menu_text)
     if declared:
-        user += ("\n<note>The sender declared this message kind=%s when sending it. That declaration is a "
-                 "strong prior, not the verdict: delegate usually means delegating; coordinate or question "
-                 "usually means coordinating. Override it only when the body clearly shows otherwise.</note>"
+        user += ("\n<note>The sender declared this message kind=%s when sending it. That is a strong "
+                 "prior, not the verdict: file it as coordinating if the body hands no work over.</note>"
                  % declared)
     return _judge_run(_triage_model(), COURIER_SYS, user, judge="courier").strip()[:300]
 
@@ -8255,7 +8257,9 @@ def run_propagate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY,
 def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
     """One TRIAGE-TIER courier pass: place peer-message (postal) segments as delegations, GLOBAL
     oldest-first across sessions. Idempotent (msgId + seg_id). COORDINATING segments are marked processed
-    without a goal-edit. (Sender goals are read as-of-NOW for the MVP; true as-of-send is a refinement.)"""
+    without a goal-edit; a declared coordinate/question files that way outright, no model call (demote-
+    only, the user 2026-07-27). (Sender goals are read as-of-NOW for the MVP; true as-of-send is a
+    refinement.)"""
     if now is None:
         now = int(time.time())
     fleet = discover(now)[:sessions_cap]
@@ -8297,6 +8301,21 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
                              note="peer message unsummarized past the %dh retry horizon (usage-limited) — abandoned"
                                   % (COURIER_RETRY_HORIZON // 3600))
             save_goals(fsid, store)
+            continue
+        if declared in ("coordinate", "question"):
+            # DEMOTE-ONLY (the user 2026-07-27): a declared non-delegation files as fyi with NO model
+            # call — the courier may still demote a declared delegate whose body hands nothing over,
+            # but it can never PROMOTE. The old "strong prior the model may override" let a substantial
+            # question read as a delegation, planting a recipient-side card whose whole content was a
+            # judge summary of the reply — noise, since a question already rides the SENDER's cards
+            # (the owed-reply tracking) and the initiator summarizes the answer. Trusting the declared
+            # kind outright is the same resolution the parse give-up path below has always used.
+            store["placements"][seg_id] = "fyi"
+            store.get("courierDeferred", {}).pop(seg_id, None)
+            store.get("courierFails", {}).pop(seg_id, None)
+            rollup_status(store, closed.get(fsid, False))
+            save_goals(fsid, store)
+            placed += 1
             continue
         sender_store = load_goals(sender)
         menu = open_menu(sender_store)

--- a/tests/test_courier_kind_demote_only.py
+++ b/tests/test_courier_kind_demote_only.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""The courier may DEMOTE a declared message kind, never promote it (the user 2026-07-27).
+
+A sender-declared `question` was only "a strong prior" to the courier model, which promoted a
+substantial five-question ask into a delegation — planting a recipient-side card whose whole content
+was a judge summary of the reply. A question already rides the SENDER's cards (owed-reply tracking)
+and the initiator summarizes the answer, so the recipient card is pure noise. The rule now:
+
+- declared coordinate/question → filed `fyi` outright, with NO courier model call;
+- declared delegate → the model may still demote (file fyi) when the body hands nothing over;
+- undeclared legacy mail → the model's verdict stands, either way.
+
+Synthetic fixtures only (placeholder UUIDs, invented text, hostname TESTHOST)."""
+import json
+import os
+import re
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+jd = SourceFileLoader("romp_judge_kinddemote", os.path.join(BIN, "romp-judge")).load_module()
+
+RECIP = "11111111-2222-3333-4444-555555555555"
+SENDER = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+MID = "1781100000.11111_22222.TESTHOST"
+T0 = 1781100000
+DELEGATING = '{"verdict": "delegating", "goal": 0, "text": "check the subnet layout"}'
+COORDINATING = '{"verdict": "coordinating", "goal": 0, "text": ""}'
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": text}, "promptSource": "typed"}
+
+
+def aline(t, text, uuid, parent):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+class CourierKindDemoteOnly(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        munged = re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        (proj / munged).mkdir(parents=True)
+        self.proj_dir = proj / munged
+        names = td / "names"; names.mkdir()
+        (names / RECIP).write_text("recip\t%s\t#abcdef\n" % str(cdir))
+        tl = td / "timeline"; tl.mkdir()
+
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+                      jd.MESSAGES, jd.ERRORS, jd.courier_llm)
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.GOALDIR = td / "goals"
+        jd.CAPDIR, jd.ARCHDIR, jd.PCACHE = td / "captions", td / "archive", td / "pcache"
+        jd.MESSAGES = tl / "messages.jsonl"
+        jd.ERRORS = td / "judge-errors.jsonl"
+        jd.MESSAGES.write_text(json.dumps(
+            {"t": T0 - 5, "ev": "sent", "id": MID, "from": "sender", "from_id": SENDER,
+             "to_id": RECIP, "body": "what subnet is the new box on?"}) + "\n")
+        self.calls = []
+        jd.courier_llm = lambda *a, **k: self.calls.append(k.get("declared", "")) or self.reply
+        self.reply = DELEGATING
+        jd._PARSE_CACHE.clear()
+        jd._discover_cache["fp"] = None
+        jd._discover_cache["result"] = None
+        jd._postal_from_memo["key"] = None
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+         jd.MESSAGES, jd.ERRORS, jd.courier_llm) = self.saved
+        jd._postal_from_memo["key"] = None
+        self.td.cleanup()
+
+    def _deliver(self, kind):
+        kind_line = ("\nromp-msg-kind: %s" % kind) if kind else ""
+        recs = [uline(T0, "what subnet is the new box on?\nromp-msg-id: %s%s" % (MID, kind_line), "u1"),
+                aline(T0 + 30, "It's on the flat /24.", "a1", "u1")]
+        (self.proj_dir / (RECIP + ".jsonl")).write_text(
+            "\n".join(json.dumps(r) for r in recs) + "\n")
+        jd._PARSE_CACHE.clear()
+        jd._discover_cache["fp"] = None
+        jd.run_courier(now=T0 + 100)
+        store = jd.load_goals(RECIP)
+        planted = [nd for nd in store["nodes"].values() if isinstance(nd.get("origin"), dict)]
+        seg_id = next(k for k in store["placements"] if not k.endswith(("#p", "#d", "#live")))
+        return planted, store["placements"][seg_id]
+
+    def test_declared_question_files_fyi_without_a_model_call(self):
+        planted, placement = self._deliver("question")
+        self.assertEqual(planted, [], "a declared question never plants a recipient card")
+        self.assertEqual(placement, "fyi")
+        self.assertEqual(self.calls, [], "resolved from the declaration alone — no courier call")
+
+    def test_declared_coordinate_files_fyi_without_a_model_call(self):
+        planted, placement = self._deliver("coordinate")
+        self.assertEqual(planted, [])
+        self.assertEqual(placement, "fyi")
+        self.assertEqual(self.calls, [])
+
+    def test_declared_delegate_still_plants(self):
+        planted, placement = self._deliver("delegate")
+        self.assertEqual(len(planted), 1, "a real delegation still plants the recipient's goal")
+        self.assertEqual(self.calls, ["delegate"])
+
+    def test_declared_delegate_can_be_demoted(self):
+        self.reply = COORDINATING
+        planted, placement = self._deliver("delegate")
+        self.assertEqual(planted, [], "the model may still demote a delegate that hands nothing over")
+        self.assertEqual(placement, "fyi")
+
+    def test_legacy_undeclared_mail_keeps_the_model_verdict(self):
+        planted, placement = self._deliver("")
+        self.assertEqual(len(planted), 1, "no declaration → the courier's verdict stands")
+        self.assertEqual(self.calls, [""])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A sender-declared `question` was only "a strong prior" to the courier model, which promoted any substantial ask into a delegation and planted a recipient-side card whose whole content was a judge summary of the reply. A question already rides the sender's cards (owed-reply tracking) and the initiator summarizes the answer, so the recipient card was pure noise.

The rule now:

- declared `coordinate`/`question` mail files as `fyi` outright, with no courier model call, matching the resolution the parse give-up path has always used;
- a declared `delegate` is still judged and may be demoted (filed `fyi`) when its body hands nothing over;
- undeclared legacy mail keeps the model's verdict either way.

Covered by `tests/test_courier_kind_demote_only.py` (five cases: question and coordinate never plant and never call the model, delegate still plants, delegate can demote, legacy keeps the verdict). Full Python suite (3244 passed) and vscode-extension typecheck + node tests (1355 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)