### PR TITLE
Docs: bump the type scale for a code-heavy dark site

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,6 +1,22 @@
 /* Romp brand colors, dark-only site. Links and every selected/highlighted cue use
    romp's in-app highlight blue #9cd2ff (--accent in the dashboard), so the docs
    read in the same accent the product uses for "this is selected". */
+
+/* Type scale: Material's stock sizes run small for a code-heavy dark site —
+   body .8rem (16px), nav .7rem (14px), and code .85em (~13.6px, the smallest
+   thing on a page that is mostly code). One modest bump per information type,
+   nothing else: body to 17px, nav to 15px, and code to .9em of the new body
+   (~15.3px), which is where the readability is actually won. */
+.md-typeset {
+  font-size: 0.85rem;
+}
+.md-nav {
+  font-size: 0.75rem;
+}
+.md-typeset code {
+  font-size: 0.9em;
+}
+
 :root {
   --md-primary-fg-color: #1ea1eb;
   --md-primary-fg-color--light: #56b8f1;


### PR DESCRIPTION
Material's stock scale reads small on the published site: sidebar 14px and code ~13.6px, the smallest text on pages that are mostly code. One modest bump per information type: body 17px, nav 15px, code ~15.3px.

First PR through the new required-checks gate; set to auto-merge when the six Linux checks go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)