### PR TITLE
Tests: two assertions catch up with the CLI's bare-word rework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The Python and shell suites are also the CI gate, across Python 3.10 to 3.13 on
 Linux; the macOS cells run on demand from the Actions tab (they are billed even
 on a public repo, so they are not part of the per-push matrix).
 
-Two things about the test environment are worth knowing, because both have
+Three things about the test environment are worth knowing, because all have
 produced confusing failures:
 
 - The bats suite takes about a minute on Linux and about fifteen on macOS. That
@@ -30,3 +30,9 @@ produced confusing failures:
   to file-derived sessions. Tests that care now pin this explicitly; if you add
   one that calls into session liveness, pin it too rather than inheriting the
   machine's state.
+- On macOS, run the bats suite with a modern bash (`brew install bash`; bats
+  picks it up via `env bash` when `/opt/homebrew/bin` precedes `/bin` on PATH).
+  The stock `/bin/bash` 3.2 does not fail a test on a mid-test `[[ ]]`
+  assertion — only the last command's status counts — so a stale assertion can
+  pass silently for months. Linux CI runs bash 5 and is the arbiter; two
+  assertions went stale exactly this way while CI was offline.

--- a/tests/romp-postal.bats
+++ b/tests/romp-postal.bats
@@ -269,8 +269,8 @@ iso() { mkdir -p "$XDG_STATE_HOME/romp"; printf '{"%s":{"postalServiceOff":true}
     export ROMP_POSTAL_PEERS=0    # the nudge belongs to the LEGACY singleton scheme (peer mode silences it)
     export SSH_CONNECTION="1 2 3 4"
     run "$POSTAL" agents
-    [[ "$output" == *"romp --mail remote"* ]]
+    [[ "$output" == *"romp mail remote"* ]]
     mkdir -p "$HOME/.config/romp-postal"; touch "$HOME/.config/romp-postal/client-only"
     run "$POSTAL" agents
-    [[ "$output" != *"romp --mail remote"* ]]
+    [[ "$output" != *"romp mail remote"* ]]
 }

--- a/tests/romp-serve.bats
+++ b/tests/romp-serve.bats
@@ -70,7 +70,7 @@ teardown() { rm -rf "$TEST_DIR"; }
 @test "romp --serve: removed — rejected as unknown, writes no state" {
     run "$ROMP_SCRIPT" --serve on
     [ "$status" -ne 0 ]
-    [[ "$output" == *"Unknown option"* ]]
+    [[ "$output" == *"unknown option"* ]]
     [ ! -f "$XDG_STATE_HOME/romp/serve-host" ]
 }
 


### PR DESCRIPTION
Linux bats has been red since CI came back: the remote-nudge test expected the retired `romp --mail remote` spelling and the unknown-option test expected capitalized `Unknown option`. Both drifted during the CLI rework and kept passing on macOS because bash 3.2 silently ignores failing mid-test `[[ ]]` assertions (only the last command counts). Fixed the assertions; CONTRIBUTING documents the bash gotcha.

Unblocks PR #65 and the v0.1.0 release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)