### PR TITLE
A first install works on a host with no editor, no tmux, and no pip

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -584,6 +584,7 @@ EOF
     _romp_cmd "romp update [host]"         romp-update  "Push this machine's committed romp to attached remotes and restart them"
     _romp_cmd "romp up"                    romp-manager "Run the kernel manager in the foreground (rare — the login service runs it)"
     _romp_cmd "romp version"               romp-version "Versions across the parts (tree, kernel, served vs built bundles)"
+    _romp_cmd "romp uninstall"             romp-uninstall "Remove romp's installed footprint (--purge also deletes recorded state)"
     _romp_cmd "romp help"                  -            "Show this help"
     cat <<'EOF'
 
@@ -655,6 +656,15 @@ fi
 # `--version` stays as an alias: it's the one flag every CLI answers.
 if [[ "${1:-}" == "version" || "${1:-}" == "--version" ]]; then
     exec romp-version
+fi
+
+# `romp uninstall` — undo install.sh (service, ~/.claude wiring, venv, build artifacts, PATH line).
+# A verb rather than a README section because the footprint spans five places and reconstructing it
+# by hand is how a "from scratch" reinstall ends up landing on leftovers. Delegates to
+# romp-uninstall, which prompts before doing anything and needs --purge to touch recorded state.
+if [[ "${1:-}" == "uninstall" ]]; then
+    shift
+    exec "$(dirname "$(readlink -f "$0")")/romp-uninstall" "$@"
 fi
 
 # `romp update [host...]` — PUSH this machine's committed romp to attached REMOTE kernels + restart them,
@@ -1065,6 +1075,46 @@ if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
     exit 1
 fi
 
+# A lowercase v4 uuid for --session-id, from whichever source this host actually has.
+# uuidgen is NOT universal: on Debian/Ubuntu it ships in uuid-runtime, which a minimal
+# install omits — and there it failed to an EMPTY sid, so claude launched with a bare
+# `--session-id` and the session broke with nothing pointing at the cause (the user
+# 2026-07-27, first Linux install). python3 is already a hard romp dependency (install.sh
+# preflights it), so the fallback can never be the missing one; the kernel's random uuid
+# source is the last resort for a stripped container.
+_romp_uuid() {
+    if command -v uuidgen >/dev/null 2>&1; then
+        uuidgen | tr 'A-Z' 'a-z'
+    elif command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import uuid; print(uuid.uuid4())'
+    elif [[ -r /proc/sys/kernel/random/uuid ]]; then
+        cat /proc/sys/kernel/random/uuid
+    else
+        echo "romp: no way to generate a session id (install uuid-runtime, or python3)" >&2
+        return 1
+    fi
+}
+
+# --- Everything below here IS the tmux launcher: require tmux, loudly ---------
+# Only `romp new -t` and `romp resume` reach this point (plain `romp new` returned
+# above, over the kernel API, needing no tmux). tmux is OPTIONAL for romp as a whole
+# — a host without it runs SDK sessions fine and the kernel keeps its tmux backend
+# disabled — but these two paths cannot work without it, so say the remedy instead
+# of letting a bare "tmux: command not found" fall out of the launcher (a fresh
+# Linux box with no tmux, the user 2026-07-27). Same no-silent-fallback rule as the
+# SDK branch above: name the fix, don't quietly do something else.
+if ! command -v tmux >/dev/null 2>&1; then
+    echo "romp: tmux isn't installed — terminal sessions need it." >&2
+    echo "  Linux: your distro's tmux package (e.g. sudo apt install tmux)    macOS: brew install tmux" >&2
+    if $resume; then
+        echo "  Without it, resume the session from the dashboard instead: romp" >&2
+    else
+        echo "  Or start it without a terminal (runs in the kernel, drive it from the dashboard):" >&2
+        echo "      romp new ${session_arg:-<name>}" >&2
+    fi
+    exit 1
+fi
+
 # --- Custom name-based resume picker ----------------------------------------
 # `romp resume` (without an explicit session id) shows OUR full-screen picker of
 # resumable named sessions instead of Claude's auto-summary picker. Picking one
@@ -1165,7 +1215,7 @@ if $resume; then
     fi
     claude_cmd="claude --resume $resume_id --name \"$display\""
 else
-    sid="$(uuidgen | tr 'A-Z' 'a-z')"
+    sid="$(_romp_uuid)"
     claude_cmd="claude --name \"$display\" --session-id $sid"
 fi
 

--- a/bin/romp
+++ b/bin/romp
@@ -1103,7 +1103,15 @@ _romp_uuid() {
 # of letting a bare "tmux: command not found" fall out of the launcher (a fresh
 # Linux box with no tmux, the user 2026-07-27). Same no-silent-fallback rule as the
 # SDK branch above: name the fix, don't quietly do something else.
-if ! command -v tmux >/dev/null 2>&1; then
+# ROMP_TMUX_AVAILABLE overrides the probe, matching install.sh and TmuxBackend.available().
+_romp_tmux_available() {
+    case "${ROMP_TMUX_AVAILABLE-unset}" in
+        unset) command -v tmux >/dev/null 2>&1 ;;
+        ""|0)  return 1 ;;
+        *)     return 0 ;;
+    esac
+}
+if ! _romp_tmux_available; then
     echo "romp: tmux isn't installed — terminal sessions need it." >&2
     echo "  Linux: your distro's tmux package (e.g. sudo apt install tmux)    macOS: brew install tmux" >&2
     if $resume; then

--- a/bin/romp-sdk-setup
+++ b/bin/romp-sdk-setup
@@ -35,6 +35,20 @@ if ! "$PY" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)'; t
   exit 1
 fi
 
+# Debian/Ubuntu ship a python3 whose venv module cannot bootstrap pip: ensurepip is split into a
+# separate python3-venv package. `python3 -m venv` there still creates bin/python symlinks and THEN
+# fails, leaving a pip-less husk — so the naive "does bin/python exist" check below would sail past a
+# broken venv and die at the pip line with a bare "No such file or directory". Check the capability up
+# front and name the package (a fresh Ubuntu box, the user 2026-07-27, where this failed silently and
+# left the SDK backend — what plain `romp new` uses — dead with no visible reason).
+if ! "$PY" -c 'import ensurepip' >/dev/null 2>&1; then
+  echo "romp-sdk-setup: $PY has no 'ensurepip' — it cannot create a venv with pip in it." >&2
+  echo "  Debian/Ubuntu: sudo apt install python$(pyver "$PY")-venv   (or: sudo apt install python3-venv)" >&2
+  echo "  Then re-run: $0" >&2
+  echo "  romp still runs without this; only the SDK backend (plain \`romp new\`) is disabled." >&2
+  exit 1
+fi
+
 mkdir -p "$STATE"
 # a venv built with a DIFFERENT python than the kernel will run is worse than none — the kernel
 # imports its site-packages in-process. Rebuild on mismatch.
@@ -42,8 +56,11 @@ if [ -x "$VENV/bin/python" ] && [ "$(pyver "$VENV/bin/python")" != "$(pyver "$PY
   echo "romp-sdk-setup: venv python $(pyver "$VENV/bin/python") != kernel python $(pyver "$PY") — rebuilding"
   rm -rf "$VENV"
 fi
-if [ ! -x "$VENV/bin/python" ]; then
+# Gate on pip, not just python: a previous run that died mid-bootstrap (see ensurepip above) leaves
+# bin/python present but bin/pip absent, and gating on python alone would skip the rebuild forever.
+if [ ! -x "$VENV/bin/python" ] || [ ! -x "$VENV/bin/pip" ]; then
   echo "romp-sdk-setup: creating venv at $VENV (python: $PY)"
+  rm -rf "$VENV"
   "$PY" -m venv "$VENV"
 fi
 "$VENV/bin/pip" install -q --upgrade pip >/dev/null

--- a/bin/romp-uninstall
+++ b/bin/romp-uninstall
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# romp-uninstall — undo install.sh, so the next install is a genuine from-scratch install.
+#
+# WHY this exists: testing the installer needs a machine that looks untouched, and romp's
+# footprint is spread over five places (a login service, ~/.claude wiring, a state dir, a
+# venv, build artifacts) that no single `rm` covers. Reconstructing that list by hand before
+# each test is how you end up "reinstalling" onto leftovers and testing nothing.
+#
+# What it removes, mirroring install.sh + bootstrap.sh step for step:
+#   - the login service           (romp-service uninstall: systemd --user / launchd)
+#   - ~/.claude/hooks/*.sh        (the romp hook symlinks only)
+#   - ~/.claude/settings.json     (ONLY the romp hook entries; your other hooks are untouched)
+#   - ~/.claude/skills/romp*      (skill symlinks)
+#   - ~/.claude/romp-postal.mcp.json
+#   - the git pre-push hook symlink
+#   - vscode-extension/node_modules, dist, *.vsix   (build artifacts)
+#   - the SDK venv under the state dir
+#   - the PATH line in your shell rc
+# With --purge it also removes the STATE DIR — every recorded session, summary and message.
+# That is the only destructive step, so it is opt-in and confirmed separately.
+#
+# What it deliberately does NOT do:
+#   - delete this clone (the script lives in it); it prints the one command for that
+#   - uninstall the VS Code extension from your editors (that is `code --uninstall-extension`,
+#     which we print rather than run — editors may be open, and it is not romp state)
+#   - touch ~/.claude/projects (Claude Code's own transcripts — not ours to delete)
+set -euo pipefail
+
+ROMP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+STATE="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}"
+
+ASSUME_YES=""
+PURGE=""
+for a in "$@"; do
+    case "$a" in
+        -y|--yes)   ASSUME_YES=1 ;;
+        --purge)    PURGE=1 ;;
+        -h|--help)
+            echo "usage: romp-uninstall [--yes] [--purge]"
+            echo "  --yes     don't prompt for confirmation"
+            echo "  --purge   ALSO delete $STATE (all recorded sessions/summaries/messages)"
+            exit 0 ;;
+        *) echo "romp-uninstall: unknown option: $a" >&2; exit 2 ;;
+    esac
+done
+
+echo "romp-uninstall — removing romp's installed footprint."
+echo "  clone:  $ROMP_DIR   (kept; delete it yourself when you're done)"
+echo "  state:  $STATE"
+if [[ -n "$PURGE" ]]; then
+    echo "  --purge: the state dir WILL be deleted (recorded sessions, summaries, messages)."
+else
+    echo "  state dir is KEPT (pass --purge to delete it too)."
+fi
+if [[ -z "$ASSUME_YES" ]]; then
+    printf 'Proceed? [y/N] '
+    read -r reply </dev/tty || reply=""
+    case "$reply" in [yY]*) ;; *) echo "Aborted."; exit 0 ;; esac
+fi
+
+# ── 1. the login service ───────────────────────────────────────────────
+# First, so nothing respawns a kernel underneath the rest of the teardown.
+if [[ -x "$ROMP_DIR/bin/romp-service" ]]; then
+    echo "==> login service"
+    "$ROMP_DIR/bin/romp-service" uninstall || echo "    (romp-service uninstall reported a problem — continuing)"
+fi
+
+# Any kernel/manager still up (started by hand rather than the service) is now unowned.
+# Matched by THIS clone's absolute path, never the bare name: several romp clones/worktrees
+# coexist on a dev machine, and a bare `pkill -f bin/romp-manager` would take down a manager
+# this uninstall has no business touching (it killed the live one during a test run, 2026-07-27).
+pkill -f "$ROMP_DIR/bin/romp-manager" 2>/dev/null || true
+pkill -f "$ROMP_DIR/bin/romp-kernel"  2>/dev/null || true
+
+# ── 2. ~/.claude wiring ────────────────────────────────────────────────
+echo "==> ~/.claude hook + skill symlinks"
+for h in romp-summarize.sh romp-postal-drain.sh romp-postal-ensure.sh \
+         romp-postal-revive.sh romp-postal-context.sh romp-wake.sh tmux-status.sh; do
+    rm -f "$HOME/.claude/hooks/$h"
+done
+rm -f "$HOME/.claude/skills/romp" "$HOME/.claude/skills/romp-postal"
+rm -f "$HOME/.claude/romp-postal.mcp.json"
+
+# De-register from settings.json. Mirrors install.sh's merge in reverse: match on the SAME
+# "~/.claude/hooks/<name>" command strings it registers, drop only those, and leave every other
+# hook (and every non-hook setting) exactly as found. Empty groups/events are pruned so we don't
+# leave `"PostToolUse": [{"hooks": []}]` litter behind.
+echo "==> ~/.claude/settings.json"
+python3 - <<'PYEOF'
+import json, os
+
+SETTINGS = os.path.expanduser("~/.claude/settings.json")
+OURS = {"tmux-status.sh", "romp-summarize.sh", "romp-postal-drain.sh", "romp-postal-ensure.sh",
+        "romp-postal-revive.sh", "romp-postal-context.sh", "romp-wake.sh"}
+
+try:
+    with open(SETTINGS) as f:
+        settings = json.load(f)
+except (FileNotFoundError, ValueError):
+    print("    no settings.json to clean")
+    raise SystemExit(0)
+
+hooks = settings.get("hooks") or {}
+removed = []
+for event in list(hooks):
+    groups = hooks.get(event) or []
+    for g in groups:
+        keep = []
+        for h in g.get("hooks", []):
+            cmd = h.get("command", "")
+            if cmd.startswith("~/.claude/hooks/") and cmd.rsplit("/", 1)[-1] in OURS:
+                removed.append(event + ":" + cmd.rsplit("/", 1)[-1])
+            else:
+                keep.append(h)
+        g["hooks"] = keep
+    groups = [g for g in groups if g.get("hooks")]      # drop groups we emptied
+    if groups:
+        hooks[event] = groups
+    else:
+        hooks.pop(event, None)                          # drop events we emptied
+if not hooks:
+    settings.pop("hooks", None)
+elif "hooks" in settings:
+    settings["hooks"] = hooks
+
+if removed:
+    with open(SETTINGS, "w") as f:
+        json.dump(settings, f, indent=2)
+        f.write("\n")
+    print("    de-registered %d romp hook entries" % len(removed))
+else:
+    print("    no romp hook entries registered")
+PYEOF
+
+# ── 3. the git pre-push hook ───────────────────────────────────────────
+echo "==> git pre-push hook"
+_gitdir="$(git -C "$ROMP_DIR" rev-parse --git-common-dir 2>/dev/null || true)"
+if [[ -n "$_gitdir" ]]; then
+    # Relative (".git") when the cwd is the repo root — resolve against ROMP_DIR, not $PWD.
+    [[ "$_gitdir" = /* ]] || _gitdir="$ROMP_DIR/$_gitdir"
+    # Only ours: install.sh symlinks it, so a real file here is the user's own hook.
+    if [[ -L "$_gitdir/hooks/pre-push" ]]; then
+        rm -f "$_gitdir/hooks/pre-push"
+    fi
+fi
+
+# ── 4. build artifacts + the SDK venv ──────────────────────────────────
+echo "==> build artifacts"
+rm -rf "$ROMP_DIR/vscode-extension/node_modules" "$ROMP_DIR/vscode-extension/dist"
+rm -f  "$ROMP_DIR/vscode-extension"/*.vsix "$ROMP_DIR/vscode-extension/package.json.orig"
+
+echo "==> SDK venv"
+rm -rf "$STATE/sdkvenv"
+
+# ── 5. the shell rc PATH line ──────────────────────────────────────────
+# bootstrap.sh appends "# romp" + one PATH line. Drop both, and only when the line
+# actually points at THIS clone's bin — never a blanket edit of the user's rc.
+echo "==> shell rc PATH entry"
+for rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.config/fish/config.fish"; do
+    [[ -f "$rc" ]] || continue
+    grep -qF "$ROMP_DIR/bin" "$rc" || continue
+    python3 - "$rc" "$ROMP_DIR/bin" <<'PYEOF'
+import sys
+path, needle = sys.argv[1], sys.argv[2]
+lines = open(path).read().splitlines(True)
+out = []
+for i, ln in enumerate(lines):
+    if needle in ln and ("PATH" in ln or "fish_add_path" in ln):
+        # also drop the "# romp" marker bootstrap.sh wrote right above it
+        while out and out[-1].strip() in ("# romp", ""):
+            out.pop()
+        continue
+    out.append(ln)
+open(path, "w").writelines(out)
+PYEOF
+    echo "    cleaned $rc"
+done
+
+# ── 6. the state dir (opt-in) ──────────────────────────────────────────
+if [[ -n "$PURGE" ]]; then
+    if [[ -z "$ASSUME_YES" ]]; then
+        printf 'Delete ALL recorded romp state in %s? [y/N] ' "$STATE"
+        read -r reply </dev/tty || reply=""
+        case "$reply" in [yY]*) ;; *) echo "    kept $STATE"; PURGE="" ;; esac
+    fi
+fi
+if [[ -n "$PURGE" ]]; then
+    echo "==> state dir"
+    rm -rf "$STATE"
+    echo "    removed $STATE"
+else
+    echo "==> state dir kept: $STATE"
+fi
+
+echo
+echo "Done. romp's installed footprint is gone."
+echo
+echo "Remaining, if you want a totally clean slate:"
+echo "  - this clone:        rm -rf $ROMP_DIR"
+echo "  - the editor extension, where you have one:"
+echo "        code --uninstall-extension romp.romp-chat-view"
+[[ -n "$PURGE" ]] || echo "  - recorded state:    rm -rf $STATE   (or re-run with --purge)"
+echo
+echo "Reinstall from scratch with:"
+echo "  curl -fsSL https://raw.githubusercontent.com/romp-on/romp/main/bootstrap.sh | bash"
+echo "Open a NEW terminal afterwards (this one still has the old PATH)."

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,16 @@ if [[ -z "${ROMP_SKIP_PREFLIGHT:-}" ]]; then
     [[ "$preflight_missing" -eq 0 ]] || exit 1
 fi
 
+# Optional capabilities. NOT preflight failures — romp is fully usable without either,
+# so we record what's missing and say so once, at the end, next to the dashboard link
+# (a mid-install warning scrolls away under the hook/symlink chatter).
+#   tmux  — only `romp new -t` / `romp resume` need it. Plain `romp new` runs an SDK
+#           session inside the kernel, and the kernel leaves its tmux backend disabled
+#           until a tmux appears on PATH (picked up live, no restart).
+# Set by the SDK/extension steps below when they fail: ROMP_SDK_MISSING.
+ROMP_TMUX_MISSING=""
+command -v tmux >/dev/null 2>&1 || ROMP_TMUX_MISSING=1
+
 mkdir -p "$HOME/.claude/hooks" "$HOME/.claude/skills"
 
 for h in romp-summarize.sh romp-postal-drain.sh romp-postal-ensure.sh \
@@ -142,15 +152,24 @@ ln -sfn "$ROMP_DIR/claude/skills/romp" "$HOME/.claude/skills/romp"
 ln -sfn "$ROMP_DIR/claude/skills/romp-postal" "$HOME/.claude/skills/romp-postal"
 echo "  Symlinked romp + romp-postal skills"
 
-# The Agent SDK venv — romp's non-tmux backend. Best-effort: a host without python >= 3.10 still
-# works fully for tmux sessions (romp-sdk-setup says what to install). Opt out with ROMP_NO_SDK=1.
+# The Agent SDK venv — the backend plain `romp new` uses. Best-effort: a host missing python >= 3.10
+# or Debian's python3-venv still runs tmux sessions (romp-sdk-setup says exactly what to install).
+# Opt out with ROMP_NO_SDK=1. The failure is REMEMBERED, not just echoed past: this is the backend
+# `romp new` defaults to, so losing it silently leaves the user with no way to start a session at all
+# (that is precisely what happened on a fresh Ubuntu box, the user 2026-07-27 — an apt python3 with no
+# ensurepip, one swallowed `|| echo`, and romp looked installed but could start nothing).
+ROMP_SDK_MISSING=""
 if [[ -z "${ROMP_NO_SDK:-}" && -x "$ROMP_DIR/bin/romp-sdk-setup" ]]; then
-    "$ROMP_DIR/bin/romp-sdk-setup" || echo "  (SDK backend not provisioned — tmux sessions unaffected)"
+    "$ROMP_DIR/bin/romp-sdk-setup" || ROMP_SDK_MISSING=1
 fi
 
+# The webview bundles live here too — this step builds vscode-extension/dist, which the KERNEL serves
+# to the browser dashboard, editor or no editor. A failure here means a blank dashboard, so it is
+# remembered and reported at the end rather than echoed past.
+ROMP_EXT_FAILED=""
 if [[ -z "${ROMP_NO_EXT:-}" && -x "$ROMP_DIR/vscode-extension/install.sh" ]]; then
-    echo "  Installing romp-chat-view extension..."
-    "$ROMP_DIR/vscode-extension/install.sh" || echo "  (romp-chat-view install skipped/failed)"
+    echo "  Building the dashboard UI (and installing romp-chat-view where an editor is present)..."
+    "$ROMP_DIR/vscode-extension/install.sh" || ROMP_EXT_FAILED=1
 fi
 
 # Auto-start: install the login service so the kernel supervisor (romp-manager) is
@@ -211,6 +230,30 @@ if [[ -z "$_tok" && -z "${ROMP_NO_SERVICE:-}" ]]; then
         [[ -n "$_tok" ]] && break
     done
 fi
+# What is NOT working, said once, right before the link — the only place the user reliably
+# looks. Each line names the capability in the user's terms, what it costs them, and the exact
+# command that fixes it; romp is usable in every one of these states, which is why none of them
+# aborted the install. (Before this, all three failures were `|| echo` one-liners buried in the
+# scroll or, worse, a kernel stderr line that only reached the system journal.)
+if [[ -n "$ROMP_TMUX_MISSING$ROMP_SDK_MISSING$ROMP_EXT_FAILED" ]]; then
+    echo
+    echo "  Some optional pieces aren't set up:"
+    if [[ -n "$ROMP_EXT_FAILED" ]]; then
+        echo "   ! The dashboard UI failed to build — the browser dashboard will come up blank."
+        echo "     Retry:  (cd $ROMP_DIR/vscode-extension && npm install && node esbuild.js)"
+    fi
+    if [[ -n "$ROMP_SDK_MISSING" ]]; then
+        echo "   ! The Agent SDK backend isn't provisioned, so \`romp new\` can't start a session."
+        echo "     See the romp-sdk-setup message above for the package to install, then:"
+        echo "         $ROMP_DIR/bin/romp-sdk-setup"
+    fi
+    if [[ -n "$ROMP_TMUX_MISSING" ]]; then
+        echo "   - tmux isn't installed, so terminal sessions (\`romp new -t\`, \`romp resume\`) are off."
+        echo "     Everything else works; \`romp new\` runs sessions you drive from the dashboard."
+        echo "     Enable:  sudo apt install tmux   (macOS: brew install tmux) — no reinstall needed."
+    fi
+fi
+
 echo
 if [[ -n "$_tok" ]]; then
     echo "  romp is running. Your dashboard:"

--- a/install.sh
+++ b/install.sh
@@ -49,8 +49,15 @@ fi
 #           session inside the kernel, and the kernel leaves its tmux backend disabled
 #           until a tmux appears on PATH (picked up live, no restart).
 # Set by the SDK/extension steps below when they fail: ROMP_SDK_MISSING.
+# ROMP_TMUX_AVAILABLE overrides the probe ("0"/"" → treat as absent, anything else → present),
+# the same seam TmuxBackend.available() and bin/romp honour, so all three agree. Mainly for tests:
+# a suite that asserts the no-tmux path must not depend on whether the machine running it has tmux
+# installed — PATH cannot hide a /usr/bin/tmux, so the override is the only honest way to say it.
 ROMP_TMUX_MISSING=""
-command -v tmux >/dev/null 2>&1 || ROMP_TMUX_MISSING=1
+case "${ROMP_TMUX_AVAILABLE-unset}" in
+    unset) command -v tmux >/dev/null 2>&1 || ROMP_TMUX_MISSING=1 ;;
+    ""|0)  ROMP_TMUX_MISSING=1 ;;
+esac
 
 mkdir -p "$HOME/.claude/hooks" "$HOME/.claude/skills"
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3773,13 +3773,38 @@ class TmuxBackend(sb.SessionBackend):
         sock = os.environ.get("ROMP_TMUX_SOCKET")
         return (["tmux", "-L", sock] if sock else ["tmux"]) + list(args)
 
+    @staticmethod
+    def available():
+        """Is the tmux backend usable on this host — i.e. is there a tmux to shell? A machine with no
+        tmux installed (a fresh Linux box, the user 2026-07-27) is a supported configuration: the SDK
+        backend is what `romp new` uses, so romp runs fully without tmux and the terminal backend just
+        stays DISABLED until tmux appears. Every primitive below short-circuits on this, so a
+        tmux-less host spends no subprocess spawns per producer tick and logs no failures.
+
+        Deliberately NOT cached: shutil.which is a PATH stat, far cheaper than the spawn it replaces,
+        and re-probing per call means `apt install tmux` goes live on the next tick with no kernel
+        restart and no expiry timer (the repo's event-over-time-heuristic rule).
+
+        ROMP_TMUX_AVAILABLE overrides the probe ("0"/"" → off, anything else → on). It is mainly a
+        TEST SEAM: the tmux-behaviour tests stub subprocess.run to record argv, and without this they
+        would pass or fail on whether the machine running them happens to have tmux installed. It
+        doubles as the way to force the backend off on a host that has tmux but shouldn't use it."""
+        ov = os.environ.get("ROMP_TMUX_AVAILABLE")
+        if ov is not None:
+            return ov not in ("", "0")
+        return shutil.which("tmux") is not None
+
     def _run(self, args, t=3):
+        if not self.available():
+            return None
         try:
             return subprocess.run(self._tmux_argv(args), capture_output=True, text=True, timeout=t)
         except Exception:
             return None
 
     def _fire(self, args, t=3):                          # fire-and-forget (no captured output needed)
+        if not self.available():
+            return
         try:
             subprocess.run(self._tmux_argv(args), timeout=t)
         except Exception:
@@ -3830,6 +3855,8 @@ class TmuxBackend(sb.SessionBackend):
         self._fire(["kill-session", "-t", name], t)
 
     def rename_by_name(self, old, new, t=5):
+        if not self.available():          # no tmux → nothing to rename; stay inert like every primitive above
+            return
         try:
             subprocess.run(["tmux", "rename-session", "-t", old, new], timeout=t,
                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/tests/install-optional-deps.bats
+++ b/tests/install-optional-deps.bats
@@ -1,0 +1,209 @@
+#!/usr/bin/env bats
+
+# A first install on a machine that has neither a VS Code-family editor, nor tmux, nor a pip-capable
+# python must still produce a WORKING romp — and must SAY what it turned off. Regression cover for a
+# fresh Linux install (the user 2026-07-27) where all three were absent and each failure was swallowed
+# by a `|| echo`, leaving a dashboard that served 404s for every bundle and no way to start a session.
+#
+# Hermetic: HOME is a temp dir, and each test puts stubs ahead of the real tools on PATH.
+
+ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export HOME="$TEST_DIR/home"
+    STUB="$TEST_DIR/stub"
+    mkdir -p "$HOME" "$STUB"
+    export CALL_LOG="$TEST_DIR/calls.log"
+    export ROMP_NO_SERVICE=1 ROMP_NO_SDK=1 ROMP_NO_EXT=1
+    export ROMP_INSTALL_TOKEN_TRIES=1
+    export ROMP_GITHOOK_DIR="$TEST_DIR/githooks"
+}
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+# A PATH with the stub dir first and every editor CLI + tmux scrubbed out, so these tests
+# behave the same on a dev laptop (which has all of them) as on a bare box.
+bare_path() { echo "$STUB:/usr/bin:/bin"; }
+
+# ── the bug that blanked the dashboard ────────────────────────────────────────
+# vscode-extension/install.sh used to check for an editor CLI FIRST and exit 0, so on an
+# editor-less machine npm install and esbuild never ran — and the kernel serves that same
+# dist/ to the browser. The build must happen before, and regardless of, the editor check.
+
+@test "vscode-extension/install.sh: builds dist even with no editor CLI on the machine" {
+    # node/npm stubs that only record what they were asked to do.
+    cat > "$STUB/npm" <<'EOF'
+#!/usr/bin/env bash
+echo "npm $*" >> "$CALL_LOG"
+EOF
+    cat > "$STUB/node" <<'EOF'
+#!/usr/bin/env bash
+echo "node $*" >> "$CALL_LOG"
+EOF
+    chmod +x "$STUB/npm" "$STUB/node"
+
+    # No code/cursor/codium anywhere on this PATH, and no macOS app bundles in a temp HOME.
+    PATH="$(bare_path)" run "$ROMP_DIR/vscode-extension/install.sh"
+
+    [ "$status" -eq 0 ]
+    # The two steps the browser dashboard depends on both ran...
+    grep -q "npm install" "$CALL_LOG"
+    grep -q "node esbuild.js" "$CALL_LOG"
+    # ...and it said so honestly, instead of the old "built dist/ is ready" on a path that built nothing.
+    [[ "$output" == *"dist/ built"* ]]
+    [[ "$output" == *"No VS Code-family editor CLI found"* ]]
+}
+
+@test "vscode-extension/install.sh: builds BEFORE it looks for an editor (ordering, not just presence)" {
+    cat > "$STUB/npm" <<'EOF'
+#!/usr/bin/env bash
+echo "npm $*" >> "$CALL_LOG"
+EOF
+    cat > "$STUB/node" <<'EOF'
+#!/usr/bin/env bash
+echo "node $*" >> "$CALL_LOG"
+EOF
+    # An editor CLI that records when IT was consulted. If the editor gate ever moves back
+    # above the build, this line lands before the npm/esbuild lines and the test fails.
+    cat > "$STUB/code" <<'EOF'
+#!/usr/bin/env bash
+echo "code $*" >> "$CALL_LOG"
+EOF
+    chmod +x "$STUB/npm" "$STUB/node" "$STUB/code"
+
+    # PACKAGE_ONLY stops before the install-into-editor loop, so the run stays hermetic.
+    PATH="$(bare_path)" ROMP_EXT_PACKAGE_ONLY=1 run "$ROMP_DIR/vscode-extension/install.sh"
+
+    npm_line="$(grep -n 'npm install' "$CALL_LOG" | head -1 | cut -d: -f1)"
+    build_line="$(grep -n 'node esbuild.js' "$CALL_LOG" | head -1 | cut -d: -f1)"
+    [ -n "$npm_line" ] && [ -n "$build_line" ]
+    [ "$npm_line" -lt "$build_line" ]
+}
+
+# ── tmux is optional, and its absence is advisory (never fatal) ───────────────
+
+@test "install.sh: succeeds with no tmux, and names it as a disabled optional piece" {
+    PATH="$(bare_path)" run "$ROMP_DIR/install.sh"
+    [ "$status" -eq 0 ]                       # NOT a preflight failure
+    [[ "$output" == *"tmux isn't installed"* ]]
+    [[ "$output" == *"romp new"* ]]           # points at the backend that still works
+    [[ "$output" == *"install tmux"* ]]       # and the exact remedy
+}
+
+@test "install.sh: says nothing about tmux when tmux is present" {
+    cat > "$STUB/tmux" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$STUB/tmux"
+    PATH="$(bare_path)" run "$ROMP_DIR/install.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"tmux isn't installed"* ]]
+}
+
+@test "romp new -t: without tmux, fails naming the remedy and the SDK alternative" {
+    PATH="$(bare_path)" run "$ROMP_DIR/bin/romp" new -t notes-api
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tmux isn't installed"* ]]
+    [[ "$output" == *"install tmux"* ]]
+    # It must offer the path that still works, with the session name carried through.
+    [[ "$output" == *"romp new notes-api"* ]]
+    # And never leak the raw shell error the launcher would otherwise produce.
+    [[ "$output" != *"command not found"* ]]
+}
+
+# ── uuidgen is not universal ─────────────────────────────────────────────────
+# Debian/Ubuntu ship it in uuid-runtime, which a minimal install omits. It used to fail to an
+# EMPTY --session-id rather than to an error, so the session broke with nothing naming the cause.
+
+@test "romp new -t: generates a session id without uuidgen installed" {
+    cat > "$STUB/tmux" <<'EOF'
+#!/usr/bin/env bash
+echo "tmux $*" >> "$CALL_LOG"
+case "$1" in
+  has-session) exit 1 ;;
+  show|show-hooks|list-keys|list-sessions) exit 0 ;;
+esac
+exit 0
+EOF
+    cat > "$STUB/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$STUB/tmux" "$STUB/claude"
+    # No uuidgen on this PATH — python3 (a hard romp dependency) must cover for it.
+    [ ! -x "$STUB/uuidgen" ]
+
+    PATH="$(bare_path)" run "$ROMP_DIR/bin/romp" new -t notes-api --detach
+
+    # A real lowercase v4 uuid reached the launch line, not an empty string.
+    grep -qE 'session-id [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' "$CALL_LOG"
+    ! grep -qE 'session-id *$' "$CALL_LOG"
+}
+
+# ── a python that cannot bootstrap pip (Debian without python3-venv) ─────────
+
+@test "romp-sdk-setup: names the venv package when ensurepip is missing, instead of dying at pip" {
+    # A python that satisfies the >= 3.10 gate but has no ensurepip — exactly Debian/Ubuntu's
+    # split-out python3-venv. Real python3 for everything except `import ensurepip`.
+    cat > "$STUB/python3.12" <<'EOF'
+#!/usr/bin/env bash
+for a in "$@"; do
+  case "$a" in
+    "import ensurepip") exit 1 ;;
+  esac
+done
+exec /usr/bin/python3 "$@"
+EOF
+    chmod +x "$STUB/python3.12"
+
+    export ROMP_STATE_DIR="$TEST_DIR/state"
+    PATH="$(bare_path)" ROMP_PYTHON="$STUB/python3.12" run "$ROMP_DIR/bin/romp-sdk-setup"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ensurepip"* ]]
+    [[ "$output" == *"venv"* ]]               # names the package to install
+    # Says romp still works without it — this backend being down is not a dead install.
+    [[ "$output" == *"romp still runs without this"* ]]
+    # And it must NOT have left a pip-less husk behind for the next run to trip over.
+    [ ! -x "$TEST_DIR/state/sdkvenv/bin/python" ]
+}
+
+@test "romp-sdk-setup: rebuilds a venv that has python but no pip" {
+    # Simulate the husk a pre-fix run left behind: bin/python present, bin/pip absent.
+    # Gating on python alone (the old check) would skip creation and die at the pip line.
+    export ROMP_STATE_DIR="$TEST_DIR/state"
+    mkdir -p "$TEST_DIR/state/sdkvenv/bin"
+    ln -s "$(command -v python3)" "$TEST_DIR/state/sdkvenv/bin/python"
+
+    # Stub `python3 -m venv` so the test never builds a real venv or hits the network:
+    # record that a rebuild was attempted, which is the behaviour under test.
+    # ensurepip is answered explicitly rather than delegated — the host running these tests
+    # may itself be a Debian box without it, and this test is about the pip-less-husk rebuild,
+    # not the ensurepip gate (which test 6 covers).
+    # The stub stands in for the whole venv: it records the rebuild, then lays down a bin/pip and
+    # bin/python so the rest of romp-sdk-setup runs to a clean exit instead of dying at the pip line
+    # (which would leave the test asserting on a crash rather than on the rebuild).
+    cat > "$STUB/python3.12" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-m" ] && [ "${2:-}" = "venv" ]; then
+  echo "venv-rebuild $3" >> "$CALL_LOG"
+  mkdir -p "$3/bin"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$3/bin/pip"
+  printf '#!/usr/bin/env bash\ncat >/dev/null\nexit 0\n' > "$3/bin/python"
+  chmod +x "$3/bin/pip" "$3/bin/python"
+  exit 0
+fi
+for a in "$@"; do
+  [ "$a" = "import ensurepip" ] && exit 0
+done
+exec /usr/bin/python3 "$@"
+EOF
+    chmod +x "$STUB/python3.12"
+
+    PATH="$(bare_path)" ROMP_PYTHON="$STUB/python3.12" run "$ROMP_DIR/bin/romp-sdk-setup"
+
+    [ "$status" -eq 0 ]
+    grep -q "venv-rebuild" "$CALL_LOG"
+}

--- a/tests/install-optional-deps.bats
+++ b/tests/install-optional-deps.bats
@@ -22,8 +22,12 @@ setup() {
 
 teardown() { rm -rf "$TEST_DIR"; }
 
-# A PATH with the stub dir first and every editor CLI + tmux scrubbed out, so these tests
-# behave the same on a dev laptop (which has all of them) as on a bare box.
+# A PATH with the stub dir first, so stubs shadow anything real. NOTE this cannot hide a
+# /usr/bin/tmux: PATH ordering only shadows names the stub dir also defines. Tests that need
+# tmux to look ABSENT say so with ROMP_TMUX_AVAILABLE=0 (the seam install.sh, bin/romp and
+# TmuxBackend all honour) rather than hoping the host has no tmux — these very tests passed
+# until tmux was installed on the dev box, then started failing for a reason unrelated to
+# the code under test.
 bare_path() { echo "$STUB:/usr/bin:/bin"; }
 
 # ── the bug that blanked the dashboard ────────────────────────────────────────
@@ -84,7 +88,7 @@ EOF
 # ── tmux is optional, and its absence is advisory (never fatal) ───────────────
 
 @test "install.sh: succeeds with no tmux, and names it as a disabled optional piece" {
-    PATH="$(bare_path)" run "$ROMP_DIR/install.sh"
+    PATH="$(bare_path)" ROMP_TMUX_AVAILABLE=0 run "$ROMP_DIR/install.sh"
     [ "$status" -eq 0 ]                       # NOT a preflight failure
     [[ "$output" == *"tmux isn't installed"* ]]
     [[ "$output" == *"romp new"* ]]           # points at the backend that still works
@@ -97,13 +101,13 @@ EOF
 exit 0
 EOF
     chmod +x "$STUB/tmux"
-    PATH="$(bare_path)" run "$ROMP_DIR/install.sh"
+    PATH="$(bare_path)" ROMP_TMUX_AVAILABLE=1 run "$ROMP_DIR/install.sh"
     [ "$status" -eq 0 ]
     [[ "$output" != *"tmux isn't installed"* ]]
 }
 
 @test "romp new -t: without tmux, fails naming the remedy and the SDK alternative" {
-    PATH="$(bare_path)" run "$ROMP_DIR/bin/romp" new -t notes-api
+    PATH="$(bare_path)" ROMP_TMUX_AVAILABLE=0 run "$ROMP_DIR/bin/romp" new -t notes-api
     [ "$status" -eq 1 ]
     [[ "$output" == *"tmux isn't installed"* ]]
     [[ "$output" == *"install tmux"* ]]
@@ -135,7 +139,7 @@ EOF
     # No uuidgen on this PATH — python3 (a hard romp dependency) must cover for it.
     [ ! -x "$STUB/uuidgen" ]
 
-    PATH="$(bare_path)" run "$ROMP_DIR/bin/romp" new -t notes-api --detach
+    PATH="$(bare_path)" ROMP_TMUX_AVAILABLE=1 run "$ROMP_DIR/bin/romp" new -t notes-api --detach
 
     # A real lowercase v4 uuid reached the launch line, not an empty string.
     grep -qE 'session-id [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' "$CALL_LOG"

--- a/tests/install-optional-deps.bats
+++ b/tests/install-optional-deps.bats
@@ -18,13 +18,32 @@ setup() {
     export ROMP_NO_SERVICE=1 ROMP_NO_SDK=1 ROMP_NO_EXT=1
     export ROMP_INSTALL_TOKEN_TRIES=1
     export ROMP_GITHOOK_DIR="$TEST_DIR/githooks"
+    # Keep vscode-extension/install.sh's app-bundle probe inside the sandbox: on a
+    # dev mac, /Applications really contains editors, and finding one would send
+    # the "no editor" tests down the package-and-install path.
+    export ROMP_EDITOR_APPS="$TEST_DIR/no-apps"
+
+    # An ALLOWLIST bin instead of the machine's /usr/bin — "tmux absent" must mean
+    # the same thing on every machine, and with a real /usr/bin it doesn't: CI's
+    # apt puts tmux there, Debian puts node there, and a mac keeps both in
+    # /opt/homebrew. So a PATH of "$STUB:/usr/bin:/bin" is bare on one box and
+    # fully equipped on the next (exactly how these tests passed on the box that
+    # wrote them and failed on the runner). Symlink only the tools the scripts
+    # under test legitimately need; everything else is absent, everywhere.
+    BAREBIN="$TEST_DIR/barebin"; mkdir -p "$BAREBIN"
+    local t p
+    for t in bash sh env dirname basename realpath readlink mktemp mkdir ln cp mv rm \
+             cat echo printf grep sed awk tr sort head tail cut wc date chmod touch \
+             sleep find xargs uname hostname python3 git curl; do
+        p="$(command -v "$t" 2>/dev/null || true)"
+        [ -n "$p" ] && ln -s "$p" "$BAREBIN/$t"
+    done
 }
 
 teardown() { rm -rf "$TEST_DIR"; }
 
-# A PATH with the stub dir first and every editor CLI + tmux scrubbed out, so these tests
-# behave the same on a dev laptop (which has all of them) as on a bare box.
-bare_path() { echo "$STUB:/usr/bin:/bin"; }
+# Stubs first, then the allowlist. Nothing from the host machine leaks in.
+bare_path() { echo "$STUB:$BAREBIN"; }
 
 # ── the bug that blanked the dashboard ────────────────────────────────────────
 # vscode-extension/install.sh used to check for an editor CLI FIRST and exit 0, so on an
@@ -70,7 +89,13 @@ EOF
 #!/usr/bin/env bash
 echo "code $*" >> "$CALL_LOG"
 EOF
-    chmod +x "$STUB/npm" "$STUB/node" "$STUB/code"
+    # The PACKAGE_ONLY path reaches `npx @vscode/vsce package`; a real npx would
+    # hit the network (or, on the allowlist PATH, not exist at all).
+    cat > "$STUB/npx" <<'EOF'
+#!/usr/bin/env bash
+echo "npx $*" >> "$CALL_LOG"
+EOF
+    chmod +x "$STUB/npm" "$STUB/node" "$STUB/code" "$STUB/npx"
 
     # PACKAGE_ONLY stops before the install-into-editor loop, so the run stays hermetic.
     PATH="$(bare_path)" ROMP_EXT_PACKAGE_ONLY=1 run "$ROMP_DIR/vscode-extension/install.sh"
@@ -84,6 +109,8 @@ EOF
 # ── tmux is optional, and its absence is advisory (never fatal) ───────────────
 
 @test "install.sh: succeeds with no tmux, and names it as a disabled optional piece" {
+    # node exists (preflight needs it) — ONLY tmux is missing, which is the point.
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/node"; chmod +x "$STUB/node"
     PATH="$(bare_path)" run "$ROMP_DIR/install.sh"
     [ "$status" -eq 0 ]                       # NOT a preflight failure
     [[ "$output" == *"tmux isn't installed"* ]]
@@ -92,6 +119,7 @@ EOF
 }
 
 @test "install.sh: says nothing about tmux when tmux is present" {
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/node"; chmod +x "$STUB/node"
     cat > "$STUB/tmux" <<'EOF'
 #!/usr/bin/env bash
 exit 0
@@ -146,15 +174,18 @@ EOF
 
 @test "romp-sdk-setup: names the venv package when ensurepip is missing, instead of dying at pip" {
     # A python that satisfies the >= 3.10 gate but has no ensurepip — exactly Debian/Ubuntu's
-    # split-out python3-venv. Real python3 for everything except `import ensurepip`.
+    # split-out python3-venv. Fully self-contained: it answers romp-sdk-setup's probes itself
+    # rather than delegating to the host python3, whose version differs per machine (a mac's
+    # /usr/bin/python3 is the 3.9 xcode shim, which dies at the version gate and never reaches
+    # the ensurepip branch this test is about).
     cat > "$STUB/python3.12" <<'EOF'
 #!/usr/bin/env bash
-for a in "$@"; do
-  case "$a" in
-    "import ensurepip") exit 1 ;;
-  esac
-done
-exec /usr/bin/python3 "$@"
+case "$*" in
+  *"version_info >= (3, 10)"*) exit 0 ;;
+  *'print("%d.%d"'*)           echo "3.12"; exit 0 ;;
+  *"import ensurepip"*)        exit 1 ;;
+esac
+exit 0
 EOF
     chmod +x "$STUB/python3.12"
 
@@ -195,10 +226,12 @@ if [ "${1:-}" = "-m" ] && [ "${2:-}" = "venv" ]; then
   chmod +x "$3/bin/pip" "$3/bin/python"
   exit 0
 fi
-for a in "$@"; do
-  [ "$a" = "import ensurepip" ] && exit 0
-done
-exec /usr/bin/python3 "$@"
+case "$*" in
+  *"version_info >= (3, 10)"*) exit 0 ;;
+  *'print("%d.%d"'*)           echo "3.12"; exit 0 ;;
+  *"import ensurepip"*)        exit 0 ;;
+esac
+exit 0
 EOF
     chmod +x "$STUB/python3.12"
 

--- a/tests/romp-uninstall.bats
+++ b/tests/romp-uninstall.bats
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+
+# romp-uninstall must leave the machine looking un-installed, so a from-scratch reinstall really is
+# from scratch — and must do it WITHOUT collateral damage to the user's own Claude Code config.
+# Hermetic: HOME is a temp dir; the login service and network steps are opted out.
+
+ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+# The uninstaller is NEVER run from the real clone here. It tears down the login service and kills
+# the manager, and its ROMP_DIR comes from its own $0 — so running the repo copy would take down the
+# developer's live romp mid-test-suite (it did, 2026-07-27). Instead each test gets a THROWAWAY clone:
+# the real script, a stubbed romp-service, and disposable build artifacts. Everything the uninstaller
+# does to $HOME is still exercised for real, because HOME is a temp dir too.
+fake_clone() {
+    CLONE="$TEST_DIR/clone"
+    mkdir -p "$CLONE/bin" "$CLONE/vscode-extension"
+    cp "$ROMP_DIR/bin/romp-uninstall" "$CLONE/bin/romp-uninstall"
+    chmod +x "$CLONE/bin/romp-uninstall"
+    cat > "$CLONE/bin/romp-service" <<EOF
+#!/usr/bin/env bash
+echo "romp-service \$* (stub)" >> "$TEST_DIR/service.log"
+EOF
+    chmod +x "$CLONE/bin/romp-service"
+}
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export HOME="$TEST_DIR/home"
+    mkdir -p "$HOME"
+    export ROMP_NO_SERVICE=1 ROMP_NO_EXT=1 ROMP_NO_SDK=1
+    export ROMP_INSTALL_TOKEN_TRIES=1
+    export ROMP_GITHOOK_DIR="$TEST_DIR/githooks"
+    export ROMP_STATE_DIR="$TEST_DIR/state"
+    mkdir -p "$ROMP_STATE_DIR"
+    fake_clone
+}
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+hook_count() {   # how many romp hook commands are left registered across all events
+    python3 - "$HOME/.claude/settings.json" <<'PY'
+import json, sys, os
+try:
+    s = json.load(open(sys.argv[1]))
+except (IOError, OSError, ValueError):
+    print(0); raise SystemExit
+OURS = ("tmux-status.sh", "romp-summarize.sh", "romp-postal-drain.sh", "romp-postal-ensure.sh",
+        "romp-postal-revive.sh", "romp-postal-context.sh", "romp-wake.sh")
+n = sum(1 for rules in (s.get("hooks") or {}).values() for r in rules for h in r.get("hooks", [])
+        if h.get("command", "").rsplit("/", 1)[-1] in OURS)
+print(n)
+PY
+}
+
+@test "romp-uninstall: removes the hook symlinks, skills and MCP config that install.sh created" {
+    run "$ROMP_DIR/install.sh"
+    [ "$status" -eq 0 ]
+    [ -L "$HOME/.claude/hooks/tmux-status.sh" ]
+    [ -L "$HOME/.claude/romp-postal.mcp.json" ]
+    [ "$(hook_count)" -gt 0 ]
+
+    run "$CLONE/bin/romp-uninstall" --yes
+    [ "$status" -eq 0 ]
+
+    [ ! -e "$HOME/.claude/hooks/tmux-status.sh" ]
+    [ ! -e "$HOME/.claude/hooks/romp-summarize.sh" ]
+    [ ! -e "$HOME/.claude/hooks/romp-postal-drain.sh" ]
+    [ ! -e "$HOME/.claude/skills/romp" ]
+    [ ! -e "$HOME/.claude/skills/romp-postal" ]
+    [ ! -e "$HOME/.claude/romp-postal.mcp.json" ]
+    [ "$(hook_count)" -eq 0 ]
+}
+
+@test "romp-uninstall: leaves the user's OWN hooks in settings.json untouched" {
+    run "$ROMP_DIR/install.sh"
+    [ "$status" -eq 0 ]
+
+    # A hook of the user's own, in an event romp also writes to.
+    python3 - "$HOME/.claude/settings.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+s = json.load(open(p))
+s["hooks"].setdefault("Stop", []).append(
+    {"hooks": [{"type": "command", "command": "~/.claude/hooks/my-own-notify.sh", "timeout": 5}]})
+s["permissions"] = {"allow": ["Bash(ls:*)"]}      # a non-hook setting, must also survive
+json.dump(s, open(p, "w"), indent=2)
+PY
+
+    run "$CLONE/bin/romp-uninstall" --yes
+    [ "$status" -eq 0 ]
+
+    run python3 -c "
+import json; s = json.load(open('$HOME/.claude/settings.json'))
+cmds = [h['command'] for rules in (s.get('hooks') or {}).values() for r in rules for h in r.get('hooks', [])]
+assert '~/.claude/hooks/my-own-notify.sh' in cmds, cmds
+assert s['permissions'] == {'allow': ['Bash(ls:*)']}, s.get('permissions')
+print('preserved')
+"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"preserved"* ]]
+}
+
+@test "romp-uninstall: keeps recorded state by default, deletes it only with --purge" {
+    echo '{"synthetic": "record"}' > "$ROMP_STATE_DIR/serve-token"
+    mkdir -p "$ROMP_STATE_DIR/sdkvenv/bin"
+
+    run "$CLONE/bin/romp-uninstall" --yes
+    [ "$status" -eq 0 ]
+    [ -f "$ROMP_STATE_DIR/serve-token" ]          # records survive a plain uninstall...
+    [ ! -d "$ROMP_STATE_DIR/sdkvenv" ]            # ...but the venv is an install artifact, so it goes
+    [[ "$output" == *"state dir kept"* ]]
+
+    run "$CLONE/bin/romp-uninstall" --yes --purge
+    [ "$status" -eq 0 ]
+    [ ! -d "$ROMP_STATE_DIR" ]
+}
+
+@test "romp-uninstall: strips the PATH line bootstrap.sh added, and nothing else" {
+    cat > "$HOME/.bashrc" <<EOF
+export EDITOR=vim
+
+# romp
+export PATH="\$PATH:$CLONE/bin"
+alias ll='ls -la'
+EOF
+
+    run "$CLONE/bin/romp-uninstall" --yes
+    [ "$status" -eq 0 ]
+
+    ! grep -qF "$CLONE/bin" "$HOME/.bashrc"
+    ! grep -q '^# romp$' "$HOME/.bashrc"
+    grep -q 'EDITOR=vim' "$HOME/.bashrc"          # the user's own lines are untouched
+    grep -q "alias ll=" "$HOME/.bashrc"
+}
+
+@test "romp-uninstall: removes the build artifacts a reinstall must rebuild" {
+    # Stand-ins for what vscode-extension/install.sh produces, in the throwaway clone — never the
+    # real one, whose dist/ is what the running kernel is serving to the browser right now.
+    mkdir -p "$CLONE/vscode-extension/node_modules" "$CLONE/vscode-extension/dist"
+    touch "$CLONE/vscode-extension/dist/render.js" "$CLONE/vscode-extension/romp-chat-view.vsix"
+
+    run "$CLONE/bin/romp-uninstall" --yes
+    [ "$status" -eq 0 ]
+
+    [ ! -d "$CLONE/vscode-extension/node_modules" ]
+    [ ! -d "$CLONE/vscode-extension/dist" ]
+    [ ! -f "$CLONE/vscode-extension/romp-chat-view.vsix" ]
+}
+
+@test "romp-uninstall: never touches a DIFFERENT clone's install (kills only its own manager)" {
+    # Two clones coexist on a dev machine (worktrees are the norm here). Uninstalling one must
+    # leave the other's build artifacts — and, by the same path-scoped match, its manager — alone.
+    other="$TEST_DIR/other-clone"
+    mkdir -p "$other/vscode-extension/dist"
+    touch "$other/vscode-extension/dist/render.js"
+
+    run "$CLONE/bin/romp-uninstall" --yes
+    [ "$status" -eq 0 ]
+
+    [ -f "$other/vscode-extension/dist/render.js" ]
+    # The pkill pattern must be this clone's absolute path, not a bare 'bin/romp-manager'.
+    grep -q 'pkill -f "\$ROMP_DIR/bin/romp-manager"' "$CLONE/bin/romp-uninstall"
+}
+
+@test "romp-uninstall: is idempotent — a second run on a clean machine still exits 0" {
+    run "$ROMP_DIR/install.sh"
+    [ "$status" -eq 0 ]
+    run "$CLONE/bin/romp-uninstall" --yes
+    [ "$status" -eq 0 ]
+    run "$CLONE/bin/romp-uninstall" --yes
+    [ "$status" -eq 0 ]
+}
+
+@test "romp uninstall: reachable as a verb and listed in help" {
+    run "$ROMP_DIR/bin/romp" help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"romp uninstall"* ]]
+}

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -20,6 +20,10 @@ BIN = os.path.join(os.path.dirname(HERE), "bin")
 em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# These exercise tmux BEHAVIOUR (they stub subprocess.run and assert on the argv). Declare a tmux
+# host explicitly so they assert the same thing on a machine without tmux installed, where the
+# backend is otherwise inert by design (see TmuxBackend.available).
+os.environ["ROMP_TMUX_AVAILABLE"] = "1"
 os.environ["ROMP_SERVE_TOKEN"] = "testtok"            # known token for the serve-security test
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_kernel_inject.py
+++ b/tests/test_kernel_inject.py
@@ -12,6 +12,10 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# These exercise tmux BEHAVIOUR (they stub subprocess.run and assert on the argv). Declare a tmux
+# host explicitly so they assert the same thing on a machine without tmux installed, where the
+# backend is otherwise inert by design (see TmuxBackend.available).
+os.environ["ROMP_TMUX_AVAILABLE"] = "1"
 km = SourceFileLoader("romp_kernel_inj", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_tmux_optional.py
+++ b/tests/test_tmux_optional.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""tmux is an OPTIONAL dependency: a host without it runs romp fully on the SDK backend, and the tmux
+backend simply stays disabled until a tmux appears on PATH (the user 2026-07-27, first Linux install,
+which had no tmux). "Disabled" has to mean genuinely inert — no subprocess spawned per producer tick,
+no error spam — and it has to come back BY ITSELF once tmux is installed, with no kernel restart.
+
+Synthetic only: no real session data; the fake tmux is a stub path.
+"""
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_tmuxopt", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class _SpawnCounter:
+    """Stands in for subprocess.run and RECORDS what it was asked to spawn.
+
+    It must not raise to signal the failure: every tmux primitive wraps its spawn in a bare
+    `except Exception`, so an assertion thrown from in here would be swallowed by the very code
+    under test and the test would pass against the unfixed backend. Record, return a plausible
+    result, and assert on the log afterwards."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, argv, *a, **kw):
+        self.calls.append(argv)
+        return _FakeCompleted()
+
+
+class _FakeCompleted:
+    returncode = 0
+    stdout = ""
+    stderr = ""
+
+
+class TmuxOptional(unittest.TestCase):
+    def setUp(self):
+        self.tb = km.TmuxBackend()
+        self._real_which = km.shutil.which
+        self._real_run = km.subprocess.run
+        # Sibling test modules set ROMP_TMUX_AVAILABLE=1 at import to declare a tmux host, and
+        # os.environ is process-wide — so clear it here or a full-suite run would mask the probe
+        # these tests exist to check.
+        self._real_env = os.environ.pop("ROMP_TMUX_AVAILABLE", None)
+
+    def tearDown(self):
+        km.shutil.which = self._real_which
+        km.subprocess.run = self._real_run
+        if self._real_env is None:
+            os.environ.pop("ROMP_TMUX_AVAILABLE", None)
+        else:
+            os.environ["ROMP_TMUX_AVAILABLE"] = self._real_env
+
+    def _no_tmux(self):
+        km.shutil.which = lambda name, *a, **k: None
+
+    def _has_tmux(self):
+        km.shutil.which = lambda name, *a, **k: "/usr/bin/tmux" if name == "tmux" else None
+
+    # ── availability tracks PATH ──────────────────────────────────────────────
+    def test_available_false_without_tmux(self):
+        self._no_tmux()
+        self.assertFalse(self.tb.available())
+
+    def test_available_true_with_tmux(self):
+        self._has_tmux()
+        self.assertTrue(self.tb.available())
+
+    # ── disabled means inert, not "failing quietly" ───────────────────────────
+    def test_no_subprocess_spawned_when_tmux_is_absent(self):
+        """The producer loop calls list_lines on every tick. Without tmux that must cost nothing —
+        the old code spawned, caught FileNotFoundError, and returned None, once per tick forever."""
+        self._no_tmux()
+        spawn = _SpawnCounter()
+        km.subprocess.run = spawn
+
+        self.assertEqual(self.tb.list_lines(km.TmuxBackend.NAME_FMT), [])
+        self.assertIsNone(self.tb._run(["list-sessions"]))
+        self.tb._fire(["set", "-t", "web", "@romp", "1"])       # must not raise
+        self.tb.send_keys("web", "hello")
+        self.tb.kill_by_name("web")
+        self.tb.rename_by_name("web", "api")
+
+        self.assertEqual(spawn.calls, [], "no tmux on PATH, yet the backend still shelled out")
+
+    def test_live_sessions_is_empty_not_broken_without_tmux(self):
+        """An empty fleet, not an exception: the dashboard shows the SDK sessions and nothing else."""
+        self._no_tmux()
+        spawn = _SpawnCounter()
+        km.subprocess.run = spawn
+        self.assertEqual(self.tb.list_lines(km.TmuxBackend.LANE_FMT), [])
+        self.assertEqual(spawn.calls, [])
+
+    # ── the explicit override ─────────────────────────────────────────────────
+    def test_env_override_forces_the_backend_on_or_off(self):
+        """ROMP_TMUX_AVAILABLE beats the PATH probe in both directions: it is how the tmux-behaviour
+        tests declare a tmux host, and how a host that HAS tmux can be told not to use it."""
+        self._no_tmux()
+        os.environ["ROMP_TMUX_AVAILABLE"] = "1"
+        self.assertTrue(self.tb.available())
+
+        self._has_tmux()
+        for off in ("0", ""):
+            os.environ["ROMP_TMUX_AVAILABLE"] = off
+            self.assertFalse(self.tb.available(), "%r should force the backend off" % off)
+
+    # ── and it heals the moment tmux is installed ─────────────────────────────
+    def test_reprobes_so_installing_tmux_needs_no_restart(self):
+        """available() must not be cached at import or first call: `apt install tmux` has to go live
+        on the next tick. Caching would strand a freshly-installed tmux behind a kernel restart."""
+        self._no_tmux()
+        self.assertFalse(self.tb.available())
+
+        self._has_tmux()
+        self.assertTrue(self.tb.available())        # same instance, no restart, no expiry wait
+
+        seen = []
+        km.subprocess.run = lambda argv, *a, **k: seen.append(argv)
+        self.tb._fire(["set", "-t", "web", "@romp", "1"])
+        self.assertTrue(seen, "with tmux present the backend must actually shell out again")
+        self.assertEqual(seen[0][0], "tmux")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vscode-extension/install.sh
+++ b/vscode-extension/install.sh
@@ -60,9 +60,12 @@ add_cli() {
   CLIS+=("$real")
 }
 # macOS app bundles
-add_cli "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
-add_cli "/Applications/Cursor.app/Contents/Resources/app/bin/code"
-add_cli "/Applications/VSCodium.app/Contents/Resources/app/bin/codium"
+# ROMP_EDITOR_APPS: test seam so a dev mac's real /Applications doesn't leak
+# editors into a test that is about having none.
+APPS_DIR="${ROMP_EDITOR_APPS:-/Applications}"
+add_cli "$APPS_DIR/Visual Studio Code.app/Contents/Resources/app/bin/code"
+add_cli "$APPS_DIR/Cursor.app/Contents/Resources/app/bin/code"
+add_cli "$APPS_DIR/VSCodium.app/Contents/Resources/app/bin/codium"
 # anything on PATH (covers Linux / remote / server installs)
 for c in code code-insiders cursor codium; do
   p="$(command -v "$c" 2>/dev/null || true)"; [ -n "$p" ] && add_cli "$p"

--- a/vscode-extension/install.sh
+++ b/vscode-extension/install.sh
@@ -34,6 +34,22 @@ fi
 # without touching the editors on the machine running it.
 PACKAGE_ONLY="${ROMP_EXT_PACKAGE_ONLY:-}"
 
+# ── deps + bundles: ALWAYS, before any editor check ───────────────────
+# dist/ is NOT just the extension's — the kernel serves these same bundles to the
+# BROWSER dashboard (kernel.py's DIST/_ensure_bundles point at vscode-extension/dist).
+# So the build must never be gated on an editor being present. It used to be: the
+# editor-CLI check below sat here, above `npm install`, and exited 0 on a machine with
+# no VS Code family installed — leaving node_modules AND dist absent, so every dashboard
+# pane fetched /dist/*.js and got a 404 and the UI came up blank (a browser-only Linux
+# box, the user 2026-07-27). The old skip message even claimed "built dist/ is ready",
+# which was never true on that path. Editor presence gates only the PACKAGE + INSTALL
+# steps at the bottom, which is all it ever meant.
+echo "==> npm install"
+npm install --silent   # idempotent; ensures dev deps (esbuild, types) exist
+
+echo "==> build"
+node esbuild.js        # → dist/: the VSIX's code AND the browser dashboard's bundles
+
 # ── collect editor CLIs (dedup by resolved path) ──────────────────────
 declare -a CLIS=()
 add_cli() {
@@ -53,12 +69,10 @@ for c in code code-insiders cursor codium; do
 done
 
 if [ "${#CLIS[@]}" -eq 0 ] && [ -z "$PACKAGE_ONLY" ]; then
-  echo "!! No VS Code-family editor CLI found — skipping install (built dist/ is ready for F5)."
+  echo "==> dist/ built — the browser dashboard is ready."
+  echo "    No VS Code-family editor CLI found, so nothing to install into; skipping the .vsix."
   exit 0
 fi
-
-echo "==> npm install"
-npm install --silent   # idempotent; ensures dev deps (esbuild, types) exist
 
 # Set the packaged version WITHOUT committing it (see the header note for why).
 # Patch = epoch seconds: monotonic by construction, so every install is strictly
@@ -74,9 +88,6 @@ cp package.json package.json.orig
 
 echo "==> stamp build version"
 node -e 'const fs=require("fs"),f="package.json",p=JSON.parse(fs.readFileSync(f));const v=p.version.split(".");v[2]=String(Math.floor(Date.now()/1000));p.version=v.join(".");fs.writeFileSync(f,JSON.stringify(p,null,2)+"\n");console.log("    build version -> "+p.version+" (not committed)");'
-
-echo "==> build"
-node esbuild.js
 
 # Fixed output name (overwritten each run) so .vsix artifacts don't pile up.
 echo "==> package .vsix"


### PR DESCRIPTION
Installing on a bare Linux box left romp looking installed but unable to do anything, and every cause was swallowed by a `|| echo` or a stderr line that only reached the system journal. The installer still printed its success banner and a dashboard link.

Found while investigating a first install on Pop!_OS 24.04 that came up blank and unresponsive in the browser.

## The dashboard came up blank

`vscode-extension/install.sh` checked for a VS Code-family CLI and exited 0 **before** `npm install` and `esbuild`. That `dist/` is not only the extension's — the kernel serves it to the browser dashboard — so on a machine with no editor, `node_modules` and `dist` were never created and every pane fetched `/dist/*.js` and got a 404. `/version` reporting `dist_ver: 0` was the tell.

The build now runs first and unconditionally; editor presence gates only the package and install-into-editor steps, which is all it ever meant. Its old skip message claimed "built dist/ is ready for F5" on the one path that built nothing.

Not Linux-specific — it hits any machine without a VS Code-family CLI on PATH.

## tmux is now genuinely optional

`TmuxBackend` short-circuits every primitive on a `shutil.which` probe, so a tmux-less host spends no subprocess spawns per producer tick and logs no failures. The probe is deliberately uncached: `apt install tmux` goes live on the next tick with no kernel restart and no expiry timer.

`romp new -t` and `romp resume` now name the remedy and the SDK alternative instead of leaking `tmux: command not found`, and `install.sh` reports tmux as a disabled optional piece rather than failing preflight.

## The SDK venv was a pip-less husk

Debian splits `ensurepip` into `python3-venv`, so `python3 -m venv` built `bin/python` symlinks and *then* failed, and the script died at the pip line. The venv gate checked `bin/python` alone, so a retry after installing the package would skip the rebuild forever. It checks `ensurepip` up front, names the package, and gates on `pip`.

This is the backend plain `romp new` defaults to, so losing it silently left no way to start a session at all.

## uuidgen is not universal either

Debian ships it in `uuid-runtime`. It failed to an **empty** `--session-id`, so the session broke with nothing naming the cause. Falls back to python3, already a hard dependency. This was also causing 22 pre-existing `romp.bats` failures on a machine without it — all now pass.

## Failures are reported, once, where they're read

`install.sh` ends with what is *not* working, next to the dashboard link, each line naming the capability in the user's terms, what it costs them, and the exact command that fixes it. romp is usable in every one of these states, which is why none of them aborts the install.

## `romp uninstall`

New `bin/romp-uninstall`, so a from-scratch reinstall really is from scratch. The footprint spans the login service, `~/.claude` wiring, the state dir, a venv, build artifacts and the shell rc line; reconstructing that by hand before each install test is how you end up testing on leftovers.

It de-registers only romp's own hooks from `settings.json` (other hooks and non-hook settings are untouched), keeps recorded state unless `--purge`, and scopes its `pkill` to its own clone's path — a bare `bin/romp-manager` pattern killed the live manager during a test run, which is also why the new bats suites run it from a throwaway clone with a stubbed service rather than the real one.

## Tests

22 new (8 + 8 bats, 6 python), each verified to **fail against the unfixed code**, not merely pass against the fixed.

The tmux-behaviour tests in `test_kernel*` stub `subprocess.run` and assert on argv, so they would otherwise pass or fail on whether the machine running them happens to have tmux. They now declare a tmux host via `ROMP_TMUX_AVAILABLE`, which doubles as the way to force the backend off on a host that has tmux but shouldn't use it.

Full suite green: 3253 python tests (baseline 3247), all bats except two pre-existing failures in `romp-postal.bats` and `romp-serve.bats` that are stale text assertions unrelated to this work.