### PR TITLE
A moot prompt-run is retired, not skipped: auto-nudge stops reading it forever

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4953,7 +4953,18 @@ def _plan_session(fsid, path, now):
         if _placed_key(store["placements"], key, live):   # drift-safe: a recorded key whose parse t has since
             continue                                  # shifted still dedups (this phase already placed)
         if phase in ("prompt", "live") and _placed_key(store["placements"], seg_id, live):
-            continue                                  # work already placed (legacy/fast segment) → the run is moot
+            # Work already placed (legacy/fast segment) → this phase is moot, a FINAL ruling like the
+            # courier's "fyi" below. RETIRE it rather than skipping: a bare `continue` left the key
+            # ABSENT, and auto-nudge's placement gate (kernel `_auto_nudge_session`, `_unplanned`) asks
+            # `_placed_key` of EVERY unit plan_units yields — so an un-retired moot phase read as pending
+            # on every tick and silenced nudges for the WHOLE session, forever, with no visible symptom
+            # beyond a card stuck 'working' (the user 2026-07-27). The shape that hits this: a turn that
+            # ended with no assistant work earns a `#p` prompt-run (the 2026-07-25 API-error fix), while
+            # every store written BEFORE that fix already carries its bare work key. Retiring heals those
+            # stores in one pass and reopens the gate without the gate needing to know about mootness.
+            store["placements"][key] = None
+            retired = True
+            continue
         if phase == "delegation":
             tgt = _placement_of(store["placements"], seg_id, live)   # the COURIER's verdict for this peer segment
             if _placed_key(store["placements"], seg_id, live) and not (isinstance(tgt, str) and tgt in store["nodes"]):

--- a/tests/test_judge_nudge_wedge_moot_retire.py
+++ b/tests/test_judge_nudge_wedge_moot_retire.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""A MOOT prompt/live phase is RETIRED, not silently skipped — else auto-nudge wedges (the user 2026-07-27).
+
+The incident: a session's card sat `working` with no chips and no nudge, forever. `plan_units` emits a
+`#p` prompt-run for an ENDED turn that produced no assistant work (the 2026-07-25 API-error fix). When
+that segment's BARE work key was already placed — the shape every store written BEFORE that fix carries —
+`_plan_session` skipped the `#p` unit as moot with a plain `continue`, leaving the key ABSENT. auto-nudge's
+placement gate (kernel `_auto_nudge_session`, `_unplanned`) asks `_placed_key` of every unit `plan_units`
+yields, so that absent key read as PENDING on every tick and silenced nudges for the WHOLE session,
+permanently. The moot skip now retires the key (`placements[key] = None`) exactly as the delegation
+branch's "fyi" retire does, which heals the store in one pass and reopens the gate. SYNTHETIC fixtures only.
+"""
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+import os
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+jd = SourceFileLoader("romp_judge_nudge_wedge", os.path.join(BIN, "romp-judge")).load_module()
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-666666666666"
+T0 = NOW - 3600
+ASK = "Which retry backoff should the uploader use when the object store returns 503?"
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, api_error=False):
+    r = {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+         "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                     "stop_reason": "end_turn"}}
+    if api_error:
+        r["isApiErrorMessage"] = True
+        r["apiErrorStatus"] = 529
+    return r
+
+
+# the ask's turn died on an API error (no assistant work); a later real turn ends it
+RECORDS = [
+    uline(T0, ASK, "u1"),
+    aline(T0 + 360, "API Error: 529 Overloaded", "a1", "u1", api_error=True),
+    uline(T0 + 400, "separately, bump the client version", "u2", "a1"),
+    aline(T0 + 410, "Bumped it.", "a2", "u2"),
+]
+
+MINT = '{"ops":[{"why":"the ask is real","do":"mint","text":"Pick the uploader retry backoff"}]}'
+
+
+class MootPromptRetire(unittest.TestCase):
+    def _gate_is_open(self, store, path):
+        """Mirror kernel `_auto_nudge_session`'s `_unplanned` check: every unit already placed?"""
+        turns = jd.parsed_session(SID, [path], NOW)["turns"]
+        live = {sg["id"] for tn in turns for sg in jd._segs(tn, store)}
+        placements = store.get("placements") or {}
+        return all(jd._placed_key(placements, jd._unit_key(u[0], u[1]), live)
+                   for u in jd.plan_units({"turns": turns}, store))
+
+    def test_moot_prompt_run_is_retired_so_the_nudge_gate_reopens(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            tpath = td / (SID + ".jsonl")
+            tpath.write_text("\n".join(json.dumps(r) for r in RECORDS) + "\n")
+            saved = (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store)
+            jd.GOALDIR, jd.PCACHE = td / "goals", td / "pcache"
+            jd.plan_llm = jd.opener_llm = lambda *a, **k: MINT
+            jd._group_store = lambda *a, **k: None
+            try:
+                jd._PARSE_CACHE.clear()
+                jd._plan_session(SID, str(tpath), NOW)
+                store = jd.load_goals(SID)
+
+                # Rewrite the store into its PRE-2026-07-25 shape: the dead turn's work-run placed the
+                # BARE key and no `#p` ever existed. This is the exact on-disk state of every long-lived
+                # session that carries an API-error turn from before that fix.
+                pkeys = [k for k in store["placements"] if k.endswith("#p")]
+                self.assertTrue(pkeys, "the dead turn's ask was placed by a prompt-run")
+                legacy = {}
+                for k, v in store["placements"].items():
+                    legacy[k[:-2] if k.endswith("#p") else k] = v
+                store["placements"] = legacy
+                jd.save_goals(SID, store)
+
+                store = jd.load_goals(SID)
+                self.assertFalse(self._gate_is_open(store, str(tpath)),
+                                 "precondition: the legacy store leaves the moot #p unit unplaced")
+
+                jd._PARSE_CACHE.clear()
+                jd._plan_session(SID, str(tpath), NOW + 100)
+                store = jd.load_goals(SID)
+
+                for k in pkeys:
+                    self.assertIn(k, store["placements"],
+                                  "the moot prompt-run is RETIRED (recorded as processed), not skipped")
+                    self.assertIsNone(store["placements"][k],
+                                      "retired = marked processed with no node, like the 'fyi' #d retire")
+                self.assertTrue(self._gate_is_open(store, str(tpath)),
+                                "one pass heals the store and auto-nudge's placement gate reads planned")
+            finally:
+                (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store) = saved
+
+    def test_retiring_the_moot_phase_mints_no_second_card(self):
+        """The retire is a RULING, not a placement: it must never re-plan the ask onto a new card."""
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            tpath = td / (SID + ".jsonl")
+            tpath.write_text("\n".join(json.dumps(r) for r in RECORDS) + "\n")
+            saved = (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store)
+            jd.GOALDIR, jd.PCACHE = td / "goals", td / "pcache"
+            jd.plan_llm = jd.opener_llm = lambda *a, **k: MINT
+            jd._group_store = lambda *a, **k: None
+            try:
+                jd._PARSE_CACHE.clear()
+                jd._plan_session(SID, str(tpath), NOW)
+                store = jd.load_goals(SID)
+                before = len(store["nodes"])
+                store["placements"] = {(k[:-2] if k.endswith("#p") else k): v
+                                       for k, v in store["placements"].items()}
+                jd.save_goals(SID, store)
+
+                calls = []
+                jd.plan_llm = jd.opener_llm = lambda *a, **k: (calls.append(1), MINT)[1]
+                jd._PARSE_CACHE.clear()
+                jd._plan_session(SID, str(tpath), NOW + 100)
+                store = jd.load_goals(SID)
+                self.assertEqual(calls, [], "a moot phase is retired with NO planner call")
+                self.assertEqual(len(store["nodes"]), before, "retiring mints nothing")
+            finally:
+                (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store) = saved
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the session-wide auto-nudge wedge diagnosed 2026-07-27.

## The bug

`plan_units` emits a `#p` prompt-run for a turn that ended with no assistant work (the 2026-07-25 API-error fix). When that segment's **bare work key** was already placed, which is the shape every store written *before* that fix carries, `_plan_session` skipped the `#p` unit as moot with a plain `continue` and left the key **absent**.

auto-nudge's placement gate (`_auto_nudge_session`'s `_unplanned`) asks `_placed_key` of every unit `plan_units` yields, so that absent key read as pending on every tick and silenced nudges for the **whole session, permanently**. The only symptom was a card stuck `working` with no chips and no nudge, so any long-lived session carrying a pre-07-25 API-error turn was silently un-nudgeable.

## The fix

One retire in the moot skip branch (`kernel/judge.py`), mirroring the delegation branch's "fyi" retire directly below it:

```python
store["placements"][key] = None
retired = True
continue
```

That heals affected stores in one pass and reopens the gate without teaching the gate about mootness.

## Why it is safe

Every reader of a `#p` placement already guards with `isinstance(v, str)` (`judge.py` 2231/2527/4909/5245, `kernel.py` 6488/10739), so a `None` behaves exactly as an absent key. `_live_anchor_gone` short-circuits on the bare work key before it ever consults `#p`, and its line 4005 already documents a `None`-valued `#p` as "a ruling, not an anchor". `kernel.py:11844`'s membership test is already True via the bare key in this scenario.

## Tests

New `tests/test_judge_nudge_wedge_moot_retire.py` (synthetic fixtures) reproduces the wedge: it builds the legacy store shape, asserts the gate is closed as a precondition, runs one pass, then asserts the key is retired and the gate reads planned. A second test pins that retiring is a ruling, not a placement, so it makes no planner call and mints no card. Verified failing before the change and passing after.

Full suites green: 3246 Python passed / 25 skipped, 1355 node passed / 0 failed.