### PR TITLE
Docs: the site description carries the current tagline

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Romp
-site_description: Mission control for many AI coding agents at once.
+site_description: Manages multiple Claude Code sessions, so you don't have to.
 
 site_url: https://romp-on.github.io/romp/
 repo_url: https://github.com/romp-on/romp


### PR DESCRIPTION
A shared docs link previews with the old tagline — mkdocs.yml's site_description never caught up with the repo description. (Message apps may cache old previews for a while after this deploys.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)