### PR TITLE
Judge verdicts: an ending question to the user blocks the card, never completes it

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1294,7 +1294,12 @@ PLAN_SYS = (
     "to start the next step, or **your** pick between options is a block: the reported progress does not keep "
     "it working, and asking 'shall I proceed?' blocks when the go-ahead is owed by the user — but if it "
     "is waiting on work it dispatched or delegated in order to proceed (agents, a peer, a build), that is "
-    "not a block, it stays working. (Use \"ref\":<k> to block a node created in this reply.)\n"
+    "not a block, it stays working. "
+    "Separate decisions, separate cards: when the segment leaves the user more than one distinct "
+    "decision on genuinely different issues, never fold them into one blocked card's why — give each "
+    "issue its own card (a sub or mint in this same reply) and block each one, so the user can answer "
+    "and cross off each independently. One shared blocked card is right only when the asks are facets "
+    "of a single decision. (Use \"ref\":<k> to block a node created in this reply.)\n"
     '- {\"why\",\"do\":\"retitle\",\"goal\":<n>,\"text\":\"<new title ≤10 words>\"}: change the title of '
     "goal #n itself. Only valid on the **one** goal a <note> explicitly names as retitle-eligible for this segment; "
     "invalid on any other listed goal, so only emit this when such a <note> is present.\n"
@@ -1318,7 +1323,11 @@ PLAN_SYS = (
     "of…\": grammar is only the hint, the test is whether this segment's turn already **shows the "
     "outcome delivered**. Every such sub needs its "
     "paired done (or paired block, when what it delivered ends by asking the user to decide); an "
-    "unpaired past-tense sub sits on the board forever as phantom open work.\n"
+    "unpaired past-tense sub sits on the board forever as phantom open work. And the paired done never "
+    "settles the decision built on the record: a segment that delivers a finding and then ends by "
+    "asking the user what to do about it (\"diagnosed the cause — want me to implement the fix?\") "
+    "must also block the goal that owns that decision, per the block op above; doning the record while "
+    "its card goes unblocked shows the whole card finished when the user still owes the answer.\n"
     "You place each segment's work; you do not reorganize the board (a separate grouper judge nests "
     "related top goals afterward). Keep filing under the matching open goal and minting only a real new "
     "top.\n"
@@ -3026,7 +3035,9 @@ def plan_llm(segment_text, menu_text, model=None, effort=None, human=False, nudg
                  "as already finished (shipped / deployed / committed / landed / verified / 'already done'), "
                  "even if that work happened in an earlier turn or another session: that report **is** the "
                  "completion signal, so emit a done on #1, not a step. Or **block** it if it needs a decision or "
-                 "answer from the user (the why = that ask). Do **not** file a plain step that merely restates the "
+                 "answer from the user (the why = that ask); a reply that reports the work delivered but **ends** "
+                 "by asking the user to approve or pick the next step is a block, not a done — the owed decision "
+                 "outweighs the finished report. Do **not** file a plain step that merely restates the "
                  "status — a finished-and-reported goal is done. **Exception**: only if the agent has genuinely "
                  "**resumed** real, still-unfinished work on the goal, keep it working — never force a false "
                  "done/block; and in that case say so explicitly with **awaiting** on #1, the why naming what "
@@ -6165,7 +6176,11 @@ CLOSER_SYS = (
     "A sub-goal whose own title **records something already delivered** — an explanation given, a cause "
     "found, options laid out (\"Explained…\", \"Confirmed…\", \"Diagnosed…\") — is done the moment the "
     "turn shows it delivered: the record itself is its outcome, so close it rather than omit it; left "
-    "open it files finished work as still owed.\n"
+    "open it files finished work as still owed. But a done on the record never settles the decision "
+    "built on it: when the turn delivers a finding and then ends by asking the user what to do about "
+    "it (\"found the cause — want me to implement the fix?\"), the goal that owns that decision goes "
+    "in block in the same reply (see blocked); doning the record and leaving its goal unmentioned "
+    "shows the whole card finished while the user still owes the answer.\n"
     "- blocked: it now needs the user, a decision, approval, or answer owed by the user (the human) "
     "before it can proceed. Waiting on a peer, CI, build, agents it dispatched, or other external thing "
     "is not blocked; that stays open and working. A turn that **ends** by handing the decision back to the "
@@ -6223,7 +6238,9 @@ def _parse_close(raw, menu_len):
     the touched open tops now fully DONE / now BLOCKED (needs the user) / now AWAITING async work they set
     in motion; omitted goals stay open (the conservative default). Empty lists → empty maps. None on
     unparseable output or a missing/non-list "done" key (skip the turn). A goal in more than one list →
-    done wins, then block (a resolution outranks an annotation). Out-of-range and duplicate indices
+    block wins, then done (the user 2026-07-27: a hedged both-lists reply is the diagnosed-then-"want
+    me to fix it?" shape, and a wrong done silently buries the owed decision while a wrong block is
+    visible and one click to cross off). Out-of-range and duplicate indices
     dropped (first wins) — except a 0/negative index anywhere, which rejects the whole reply (see
     _zero_based_tell: an off-base reply's other indices silently done/block the wrong goals).
     Tolerant of an absent "block"/"awaiting" key (older replies)."""
@@ -6249,8 +6266,8 @@ def _parse_close(raw, menu_len):
                 out[n] = " ".join(str(it.get("why", "")).split())[:300]
         return out
 
-    done = _collect(obj.get("done"))
-    block = _collect(obj.get("block"), skip=done)                           # done wins for the same goal
+    block = _collect(obj.get("block"))
+    done = _collect(obj.get("done"), skip=block)                            # block wins for the same goal
     return {"done": done, "block": block,
             "awaiting": _collect(obj.get("awaiting"), skip=set(done) | set(block))}
 
@@ -6600,8 +6617,9 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
                       "session's work, not only the goals it was asked about. Goal%s %s %s open "
                       "elsewhere on the same board: judge %s ONLY from what the reply explicitly says "
                       "about it — done only where the reply plainly reports that goal's outcome "
-                      "delivered or nothing left to do on it. A goal the reply does not clearly cover "
-                      "is a considered omission, not a completion."
+                      "delivered or nothing left to do on it; block where the reply's account of it "
+                      "ends by asking the user for a decision or go-ahead. A goal the reply does not "
+                      "clearly cover is a considered omission, not a completion."
                       % ("s" if len(tflagged) > 1 else "",
                          ", ".join("#%d" % i for i in tflagged),
                          "are" if len(tflagged) > 1 else "is",

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -3124,6 +3124,27 @@ class BlockCompletionCorrectness(unittest.TestCase):
         for phrase in ("records something already delivered", "close it rather than omit it"):
             self.assertIn(phrase, done_clause, "closer: " + phrase)
 
+    def test_record_done_never_settles_the_owed_decision(self):
+        # the user 2026-07-27: cards kept landing in Completed off turns that diagnosed something and
+        # ended with "want me to implement the fix?" — the record-sub clause above ("Diagnosed…" is
+        # done the moment the turn shows it delivered) sits right next to the approval-ask carve-out
+        # and won. Both judges now say the done on the record never settles the decision built on it:
+        # the goal that owns the decision must be blocked in the same reply.
+        for phrase in ("never settles the decision", "want me to implement the fix?",
+                       "owns that decision"):
+            self.assertIn(phrase, jd.PLAN_SYS, "planner: " + phrase)
+        done_clause = jd.CLOSER_SYS.split("- blocked:", 1)[0]
+        for phrase in ("never settles the decision", "want me to implement the fix?",
+                       "owns that decision"):
+            self.assertIn(phrase, done_clause, "closer done side: " + phrase)
+
+    def test_distinct_blocked_decisions_split_into_their_own_cards(self):
+        # the user 2026-07-27: several unrelated decisions folded into one blocked card can only be
+        # answered and crossed off as a lump. The planner (the one judge that can mint) must give each
+        # distinct issue its own blocked card; one shared card only for facets of a single decision.
+        for phrase in ("Separate decisions, separate cards", "facets of a single decision"):
+            self.assertIn(phrase, jd.PLAN_SYS, phrase)
+
     def test_past_tense_sub_pairs_to_a_born_done_landing(self):
         # mechanics: the pairing the planner is told to emit (sub + done ref) lands the record-sub
         # already crossed off under a still-open card — never a new open task
@@ -3218,12 +3239,15 @@ class SweepParse(unittest.TestCase):
         self.assertEqual(jd._parse_close('noise {"done": [{"goal": 2, "why": "done"}]} more', 4),
                          {"done": {2: "done"}, "block": {}, "awaiting": {}}, "the outermost JSON object is isolated from prose")
 
-    def test_block_list_parsed_and_done_wins(self):
+    def test_block_list_parsed_and_block_wins(self):
         # the user 2026-06-17: the closer can now BLOCK a touched top (needs the user), not just complete it
         self.assertEqual(jd._parse_close('{"done": [], "block": [{"goal": 2, "why": "Approve the migration?"}]}', 3),
                          {"done": {}, "block": {2: "Approve the migration?"}, "awaiting": {}})
-        self.assertEqual(jd._parse_close('{"done": [{"goal": 1, "why": "shipped"}], "block": [{"goal": 1, "why": "?"}]}', 3),
-                         {"done": {1: "shipped"}, "block": {}, "awaiting": {}}, "a goal in both -> done wins, dropped from block")
+        # the user 2026-07-27: a goal the model hedges into BOTH lists is the diagnosed-then-"want me
+        # to fix it?" shape — block wins, because a wrong done silently buries the owed decision while
+        # a wrong block is visible and one click to cross off (done won until then).
+        self.assertEqual(jd._parse_close('{"done": [{"goal": 1, "why": "shipped"}], "block": [{"goal": 1, "why": "Fix it too?"}]}', 3),
+                         {"done": {}, "block": {1: "Fix it too?"}, "awaiting": {}}, "a goal in both -> block wins, dropped from done")
         self.assertEqual(jd._parse_close('{"done": [{"goal": 1, "why": "x"}]}', 3),
                          {"done": {1: "x"}, "block": {}, "awaiting": {}}, "an absent block key is tolerated")
 
@@ -3395,6 +3419,19 @@ class SweepTurn(unittest.TestCase):
         self.assertEqual(store["nodes"][g1["id"]]["mt"], self.turn["t"],
                          "mt is bumped to the turn time so the done node deep-links to where it resolved")
 
+    def test_hedged_both_lists_reply_blocks_not_completes(self):
+        # the user 2026-07-27: the diagnosed-then-"want me to implement the fix?" turn. A closer that
+        # hedges the same goal into done AND block must land it blocked — a wrong done silently buries
+        # the owed decision; a wrong block is visible and one click to cross off.
+        store = _store(); g1 = _mknode(store, "Fix the flaky login test")
+        store["placements"][self.seg["id"]] = g1["id"]
+        jd.closer_llm = lambda tt, mt, *_a: ('{"done": [{"goal": 1, "why": "found the cause"}], '
+                                             '"block": [{"goal": 1, "why": "Implement the fix?"}]}')
+        self.assertEqual(jd._close_turn(store, self.turn), [], "nothing completes off the hedged reply")
+        self.assertFalse(store["nodes"][g1["id"]].get("nodeComplete"), "the hedged goal must not complete")
+        self.assertTrue(store["nodes"][g1["id"]].get("blocked"), "the owed decision lands as blocked")
+        self.assertEqual(store["nodes"][g1["id"]]["blockWhy"], "Implement the fix?")
+
     def test_llm_failure_completes_nothing(self):
         store = _store(); g1 = _mknode(store, "Do X")
         store["placements"][self.seg["id"]] = g1["id"]
@@ -3490,6 +3527,8 @@ class StatusReportMenu(unittest.TestCase):
         self.assertTrue(store["nodes"][g2["id"]]["nodeComplete"])
         self.assertIn("Tune the api rate limits", captured["mt"], "the sibling top rode the menu")
         self.assertIn("status check", captured["mt"], "…with the status-report framing")
+        self.assertIn("decision or go-ahead", captured["mt"],
+                      "…and the framing routes an ending approval-ask to block (the user 2026-07-27)")
 
     def test_a_clear_wrap_turn_widens_too(self):
         turn, seg = self._session("<!-- romp-clear-wrap -->")

--- a/tests/test_nudge_block_prompts.py
+++ b/tests/test_nudge_block_prompts.py
@@ -63,6 +63,16 @@ class PlannerBlockRule(unittest.TestCase):
         self.assertIn("does not keep it working", sys,
                       "planner must say reported progress does not keep an awaiting-user goal working")
 
+    def test_nudge_note_done_rule_carves_out_the_owed_decision(self):
+        # the user 2026-07-27: the nudge <note>'s own done rule ("a reported-finished goal is done")
+        # was the one wording of done with NO owed-decision escape — a nudge reply that reported the
+        # work delivered but ended asking the user to approve the next step completed the card. The
+        # note now routes that shape to block.
+        import inspect
+        src = inspect.getsource(jd.plan_llm)
+        self.assertIn("outweighs the finished report", src,
+                      "the nudge note's done rule defers an ending approval-ask to block")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A turn that diagnoses something and ends with "want me to implement the fix?" kept filing its card as Completed. The user still owes the answer, so the card belongs in Blocked/Needs-you.

Four sites let done win that shape; all fixed:

- **PLAN_SYS past-tense pairing rule**: "Diagnosed..." was a named tell for done, with the block escape a trailing parenthetical. The paired done now explicitly never settles the decision built on the record; the goal that owns the decision must be blocked in the same reply.
- **CLOSER_SYS record-sub clause**: sat directly after the approval-ask carve-out and overrode it. Same fix on the done side itself.
- **Nudge note's done rule**: the one wording of done with no owed-decision escape; now routes an ending approval-ask to block.
- **_parse_close tie-break**: a model that hedges the same goal into done AND block is exactly the diagnosed-then-ask shape; block now wins (a wrong done silently buries the owed decision, a wrong block is visible and one click to cross off). The status-report framing also names the block route.

Plus the second ask: **separate decisions, separate cards** — the planner's block op now splits distinct owed decisions into their own blocked cards instead of folding them into one why.

Tests: prompt pins for each new clause, the tie-break flip at parse level, and a `_close_turn` mechanics test that a hedged both-lists reply lands blocked, not completed. Both suites green (3243 py, 1355 node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)