### PR TITLE
A /clear never mints a card, never skips its settle, never re-judges the dead episode

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -777,7 +777,13 @@ def synthesize_orphans(states, atoms):
         if not isinstance(orq, dict):
             continue
         txt = (orq.get("text") or "").strip()
-        if not txt or txt.startswith("API Error:"):
+        if not txt or txt.startswith("API Error:") or txt == "(no content)":
+            # "(no content)" is the CLI's own placeholder for a contentless command-feedback message
+            # (an SDK /clear streams one; its transcript record is a system/local_command row). Salvaged
+            # as a real assistant atom it read as MODEL WORK: _seg_command_worked turned True for the
+            # bare /clear turn and the planner minted a "clearing conversation history" card (the user
+            # 2026-07-27). Every such marker in the live corpus rides a command turn, which plans no
+            # units at all once skipped — so this drops no real work and needs no PLACEMENTS_V bump.
             continue
         u = orq.get("uuid") or ""
         if u and u in seen_uuids:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4952,6 +4952,18 @@ def _plan_session(fsid, path, now):
         #                                               LLM call and file its own duplicate node (2026-07-06)
         if _placed_key(store["placements"], key, live):   # drift-safe: a recorded key whose parse t has since
             continue                                  # shifted still dedups (this phase already placed)
+        if u[2] and u[2] < (episode_floor(fsid) or 0):
+            # PRE-EPISODE unit (the user 2026-07-27): its segment predates the current episode's head —
+            # evidence from a conversation the agent can no longer see (_placed_key's own scoping rule),
+            # reachable because the parse stitches the anchor transcript behind a /clear fork. Planning
+            # it re-judges the DEAD conversation: an old unplaced turn re-planned 40s after a /clear
+            # filed done-verdicts on three-day-old cards, resurfacing them as freshly completed. The
+            # boundary settle usually hides this (verdicts on cleared nodes stay dark), but the planner
+            # must not depend on it. RETIRE, not skip, for the same reason as the moot branch below —
+            # an un-retired unit wedges auto-nudge's `_unplanned` gate forever.
+            store["placements"][key] = None
+            retired = True
+            continue
         if phase in ("prompt", "live") and _placed_key(store["placements"], seg_id, live):
             # Work already placed (legacy/fast segment) → this phase is moot, a FINAL ruling like the
             # courier's "fyi" below. RETIRE it rather than skipping: a bare `continue` left the key

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9968,13 +9968,25 @@ def _episode_boundary_check(sid, path, now):
     head = jd.transcript_head(path)
     if not head or not head["root"]:
         return                       # no head yet, or a resume-style leaf (chains into a prior file):
-    last = jd.episode_last(sid)      # either way the recorded episode is still the current one
-    if last is not None and last.get("head") == head["uuid"]:
-        return
+    #                                  either way the recorded episode is still the current one
+    if any(r.get("head") == head["uuid"] for r in jd.episode_rows(sid)):
+        return                       # this head is already recorded — the current episode, or a
+    #                                  HISTORICAL one re-sighted through a stale path (a peer writer
+    #                                  mid-transition). A re-sighting is never a new boundary, and
+    #                                  skipping its append keeps the race below from growing the log.
     jd.append_episode(sid, head["uuid"], Path(path).stem, head["t"] or int(now))
-    if last is None:
-        return                       # first observation SEEDS the log; a boundary needs a prior recorded
-    #                                  episode (so deploying this never mass-settles existing sessions)
+    # Seed-vs-boundary is decided by RE-READING the log AFTER the append, never from the pre-append
+    # read. Two kernel instances overlapped for about a second on 2026-07-27 (a restart-churn
+    # morning): a stale-path writer seeded row 1 between this writer's read and append, so the
+    # fresh-path writer — holding a pre-read "no rows yet" — took the seed path and a REAL /clear
+    # boundary silently skipped its settle; the judge then re-ran over the dead conversation and the
+    # pre-clear cards resurfaced. Post-append, whichever writer finds rows besides its own settles; a
+    # true first observation finds only itself and seeds (so deploying this never mass-settles
+    # existing fleets). Both interleavings are covered — a double settle is idempotent (tops come
+    # back empty) — and the seed is logged so a swallowed boundary is never invisible again.
+    if all(r.get("head") == head["uuid"] for r in jd.episode_rows(sid)):
+        sys.stderr.write("episode boundary: %s seeded (head %.8s)\n" % (sid[:8], head["uuid"]))
+        return
     store = jd.load_goals(sid)
     nodes, status = store.get("nodes", {}), store.get("status", {})
     tops = [nid for nid, nd in nodes.items()

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3085,7 +3085,11 @@ class SdkBackend:
                 # "Recovered after N retries" note remains where it was (the user 2026-07-21).
                 if a.get("type") == "assistant" and not a.get("isApiError"):
                     txt = _atom_text(a)
-                    if txt.strip():
+                    # "(no content)" is the CLI's placeholder for contentless command feedback (an SDK
+                    # /clear streams one) — nothing the user watched, nothing to salvage. Persisted, it
+                    # resurfaced as a worked reply on the bare command turn (the user 2026-07-27); the
+                    # parse-side guard in synthesize_orphans covers markers already written.
+                    if txt.strip() and txt.strip() != "(no content)":
                         try:
                             append_orphan_reply(self.state_dir, sid, a.get("uuid") or "", txt, t=a.get("t"))
                         except Exception:

--- a/tests/test_clear_turn_no_card.py
+++ b/tests/test_clear_turn_no_card.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""A /clear turn never mints a card, even through the SDK's orphan salvage (the user 2026-07-27).
+
+An SDK /clear streams the CLI's "(no content)" placeholder as command feedback; the transcript keeps
+it only as a system/local_command row, so the backend persisted it as an orphanReply marker and
+synthesize_orphans resurrected it as a real assistant atom. That atom made _seg_command_worked read
+the bare /clear turn as the MODEL having worked, and the planner minted a card literally titled from
+the /clear invocation. The placeholder is now dropped at both ends: the backend never persists it
+(test_sdk_orphan_reply) and the parse never synthesizes an atom from markers already written (here).
+Synthetic fixtures only."""
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+jd = SourceFileLoader("romp_judge_clearturn", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = 1780000000
+NOW = T0 + 600
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": text}, "promptSource": "typed"}
+
+
+def aline(t, text, uuid, parent):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+def clear_head(t):
+    """The records Claude Code writes at the head of a post-/clear transcript: the standalone
+    caveat, the <command-name> wrapper, and the system/local_command feedback row."""
+    return [
+        {"type": "user", "timestamp": iso(t), "uuid": "cv1", "parentUuid": None,
+         "message": {"role": "user",
+                     "content": "<local-command-caveat>Caveat: local commands</local-command-caveat>"}},
+        {"type": "user", "timestamp": iso(t), "uuid": "cm1", "parentUuid": "cv1",
+         "message": {"role": "user",
+                     "content": "<command-name>/clear</command-name>\n<command-message>clear</command-message>"
+                                "\n<command-args></command-args>"}},
+        {"type": "system", "subtype": "local_command", "uuid": "sy1", "parentUuid": "cm1",
+         "timestamp": iso(t), "level": "info", "isMeta": False,
+         "content": "<local-command-stdout></local-command-stdout>"},
+    ]
+
+
+class ClearTurnNoCard(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        self.proj = Path(self._td) / "proj"
+        self.proj.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _parse(self, recs, markers):
+        tpath = self.proj / (SID + ".jsonl")
+        tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+        (jd.STATESDIR / (SID + ".jsonl")).write_text(
+            "\n".join(json.dumps(m) for m in markers) + ("\n" if markers else ""))
+        jd._PARSE_CACHE.clear()
+        return jd.parsed_session(SID, [str(tpath)], NOW)
+
+    def test_no_content_marker_never_becomes_an_atom(self):
+        session = self._parse(
+            clear_head(T0) + [uline(T0 + 60, "tidy the docs page", "u2", "sy1"),
+                              aline(T0 + 90, "Done, tidied.", "a2", "u2")],
+            [{"t": T0, "orphanReply": {"uuid": "sy1", "text": "(no content)"}}])
+        atoms = [a for turn in session["turns"] for a in turn["atoms"]]
+        self.assertFalse(any(a.get("orphaned") for a in atoms),
+                         "the placeholder marker synthesizes no atom")
+
+    def test_clear_turn_is_a_bare_command_and_plans_no_unit(self):
+        session = self._parse(
+            clear_head(T0) + [uline(T0 + 60, "tidy the docs page", "u2", "sy1"),
+                              aline(T0 + 90, "Done, tidied.", "a2", "u2")],
+            [{"t": T0, "orphanReply": {"uuid": "sy1", "text": "(no content)"}}])
+        cmd_segs = [seg for turn in session["turns"] for seg in jd.em.segments(turn)
+                    if jd._seg_command(seg)]
+        self.assertEqual(len(cmd_segs), 1, "the /clear invocation parses as a command turn")
+        self.assertFalse(jd._seg_command_worked(cmd_segs[0]),
+                         "a salvaged placeholder is not the model working")
+        units = jd.plan_units(session)
+        self.assertEqual(len(units), 1, "only the real ask yields a unit")
+        self.assertIn("tidy the docs", units[0][3])
+
+    def test_a_real_orphan_reply_still_synthesizes(self):
+        # the guard drops ONLY the placeholder — a genuine salvaged reply keeps flowing to the judges
+        session = self._parse(
+            [uline(T0, "summarize the release notes", "u1")],
+            [{"t": T0 + 30, "orphanReply": {"uuid": "or1", "text": "Here is the summary you asked for."}}])
+        atoms = [a for turn in session["turns"] for a in turn["atoms"]]
+        self.assertTrue(any(a.get("orphaned") for a in atoms), "real salvage still emits")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_episode_boundary.py
+++ b/tests/test_episode_boundary.py
@@ -168,6 +168,46 @@ class EpisodeBoundaryTest(unittest.TestCase):
         km._episode_boundary_check(SID, str(p), NOW)
         self.assertEqual(len(jd.episode_rows(SID)), 1)
 
+    def test_interleaved_seed_race_still_settles(self):
+        """Two kernel instances overlapped for ~1s on 2026-07-27 (a restart-churn morning): a
+        stale-path writer SEEDED row 1 between the fresh writer's read and its append, so the fresh
+        writer — holding a pre-append "no rows yet" — took the seed path and a REAL /clear boundary
+        silently skipped its settle. Seed-vs-boundary is now decided by re-reading the log AFTER the
+        append: whichever writer finds rows besides its own settles."""
+        self._store()
+        fork = self.proj / "aaaaaaaa-0000-0000-0000-000000000004.jsonl"
+        _write_jsonl(fork, [_rec("root2", ts="2026-01-02T00:00:00Z")])
+        orig = jd.append_episode
+
+        def interleaved(sid, head, fsid, t):
+            orig(sid, "root1", SID, 1)      # the peer's seed lands FIRST, unseen by our pre-read
+            orig(sid, head, fsid, t)
+        jd.append_episode = interleaved
+        try:
+            km._episode_boundary_check(SID, str(fork), NOW)
+        finally:
+            jd.append_episode = orig
+        self.assertEqual([r["head"] for r in jd.episode_rows(SID)], ["root1", "root2"])
+        store = jd.load_goals(SID)
+        self.assertTrue(store["nodes"][self.g("g1")].get("cleared"),
+                        "the raced boundary still settles its open cards")
+        self.assertTrue(self._cleared_rows())
+
+    def test_resighted_historical_head_is_not_a_boundary(self):
+        """A stale-path writer re-sighting a HISTORICAL head (the pre-clear transcript, mid path
+        transition) must neither re-append it — the log would grow on every flip — nor settle."""
+        self._store()
+        anchor = self.proj / (SID + ".jsonl")
+        _write_jsonl(anchor, [_rec("root1")])
+        km._episode_boundary_check(SID, str(anchor), NOW)             # seed root1
+        fork = self.proj / "aaaaaaaa-0000-0000-0000-000000000005.jsonl"
+        _write_jsonl(fork, [_rec("root2", ts="2026-01-02T00:00:00Z")])
+        km._episode_boundary_check(SID, str(fork), NOW)               # real boundary: settles
+        n_rows = len(self._cleared_rows())
+        km._episode_boundary_check(SID, str(anchor), NOW)             # stale re-sighting of root1
+        self.assertEqual([r["head"] for r in jd.episode_rows(SID)], ["root1", "root2"])
+        self.assertEqual(len(self._cleared_rows()), n_rows, "a re-sighted head never settles again")
+
     def test_boundary_with_no_open_tops_records_only(self):
         g = self.g
         store = {"rompUuid": SID, "seq": 1,

--- a/tests/test_planner_episode_floor.py
+++ b/tests/test_planner_episode_floor.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""The planner never judges a unit from before the current episode (the user 2026-07-27).
+
+A /clear moves the episode floor, but pre-clear segments can still reach the parse (the anchor
+transcript is stitched behind a fork so resume chains keep their history). An old segment that had
+LOST its placement was re-planned 40 seconds after a /clear and filed done-verdicts on three-day-old
+cards, resurfacing them as freshly completed. The boundary settle usually masks this (verdicts on
+cleared nodes stay dark), but the planner must not depend on it: a unit whose segment predates
+episode_floor() is evidence from a conversation the agent can no longer see — RETIRED, not skipped,
+so auto-nudge's `_unplanned` gate never reads it as forever-pending. Synthetic fixtures only."""
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+jd = SourceFileLoader("romp_judge_epifloor", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+T_OLD = 1780000100          # a pre-clear turn
+T_FLOOR = 1780005000        # the current episode's head
+T_NEW = 1780006000          # a post-clear turn
+NOW = T_NEW + 600
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": text}, "promptSource": "typed"}
+
+
+def aline(t, text, uuid, parent):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+RECS = [uline(T_OLD, "audit the old-era notification design", "u1"),
+        aline(T_OLD + 30, "Audited it, all good.", "a1", "u1"),
+        uline(T_NEW, "tidy the docs page", "u2", "a1"),
+        aline(T_NEW + 30, "Done, tidied.", "a2", "u2")]
+
+
+class PlannerEpisodeFloor(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        self.proj = Path(self._td) / "proj"
+        self.proj.mkdir()
+        self.calls = []
+        self._saved = (jd.plan_llm, jd.opener_llm, jd._group_store)
+        jd.plan_llm = lambda text, *a, **k: (self.calls.append(text) or
+                                             '{"ops":[{"why":"finished","do":"mint","text":"Tidy the docs page"}]}')
+        jd.opener_llm = lambda *a, **k: ""
+        jd._group_store = lambda *a, **k: None
+
+    def tearDown(self):
+        (jd.plan_llm, jd.opener_llm, jd._group_store) = self._saved
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _plan(self):
+        tpath = self.proj / (SID + ".jsonl")
+        tpath.write_text("\n".join(json.dumps(r) for r in RECS) + "\n")
+        jd._PARSE_CACHE.clear()
+        jd._plan_session(SID, str(tpath), NOW)
+        return jd.load_goals(SID)
+
+    def test_pre_floor_unit_is_retired_not_planned(self):
+        jd.append_episode(SID, "newhead", SID, T_FLOOR)
+        store = self._plan()
+        self.assertEqual(len(self.calls), 1, "only the current-episode unit reaches the planner")
+        self.assertIn("tidy the docs", self.calls[0].lower())
+        self.assertFalse(any("old-era" in (nd.get("text") or "") for nd in store["nodes"].values()),
+                         "no node is minted from the dead conversation")
+        retired = [k for k, v in store["placements"].items() if v is None]
+        self.assertTrue(any((":%d:" % T_OLD) in k for k in retired),
+                        "the pre-floor unit is RETIRED (auto-nudge's gate must not read it as pending)")
+
+    def test_without_an_episode_floor_the_guard_is_inert(self):
+        store = self._plan()
+        self.assertEqual(len(self.calls), 2, "no recorded episode -> every unit still plans")
+        texts = " | ".join((nd.get("text") or "") for nd in store["nodes"].values())
+        self.assertIn("old-era", texts.lower() + " | " + " ".join(self.calls).lower(),
+                      "the old turn is judged normally when no floor exists")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_orphan_reply.py
+++ b/tests/test_sdk_orphan_reply.py
@@ -74,6 +74,16 @@ class OrphanReplyDurability(unittest.TestCase):
         orq = self._orphan_lines(be)
         self.assertEqual(len(orq[0]["orphanReply"]["text"]), sb.ORPHAN_REPLY_CAP)
 
+    def test_the_cli_no_content_placeholder_is_never_persisted(self):
+        # "(no content)" is the CLI's placeholder for contentless command feedback (an SDK /clear
+        # streams one; its transcript record is a system/local_command row). Persisted as an orphan
+        # it resurfaced as a WORKED reply on the bare command turn, and the planner minted a card
+        # for the /clear itself (the user 2026-07-27).
+        be = self._backend()
+        be._live[SID] = {"c": _atom("c", 100, [{"type": "text", "text": "(no content)"}])}
+        be.retire_live_work(SID)
+        self.assertEqual(self._orphan_lines(be), [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Three compounding fixes for the post-/clear card resurrection (root-caused 2026-07-27):

**The "(no content)" placeholder never reads as model work.** An SDK /clear streams the CLI's contentless command-feedback placeholder; the backend persisted it as an orphanReply marker and `synthesize_orphans` resurrected it as a real assistant atom, so `_seg_command_worked` read the bare /clear turn as worked and the planner minted a card titled from the invocation. The backend no longer persists the placeholder, and the parse skips markers already written. All 9 such markers in the live corpus ride command turns, which plan no units once skipped — so no `PLACEMENTS_V` bump is needed.

**The episode-boundary settle survives the two-writer race.** Seed-vs-boundary is now decided by re-reading the log after the append, not from the pre-append read: two overlapping kernel instances raced a first observation, the fresh-path writer took the seed path on a real /clear, and the settle silently skipped — the open pre-clear cards then resurfaced. A re-sighted historical head (a stale-path writer mid-transition) is also recognized and never re-appended, and the seed path logs itself so a swallowed boundary can't be invisible again.

**The planner never judges pre-episode evidence.** A unit whose segment predates `episode_floor()` is retired (not skipped — the `_unplanned`-gate wedge lesson): pre-clear segments still reach the parse through the anchor stitch, and one that had lost its placement was re-planned 40 seconds after a /clear, filing done-verdicts that resurfaced three-day-old cards as freshly completed.

Tests: two race cases in `test_episode_boundary.py`, new `test_clear_turn_no_card.py` (placeholder never becomes an atom; /clear plans no unit; real orphan replies still synthesize), new `test_planner_episode_floor.py` (pre-floor retired; guard inert without a floor), and a backend case in `test_sdk_orphan_reply.py`. Full Python suite 3254 passed; vscode-extension typecheck + 1355 node tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)