### PR TITLE
An uninstall/reinstall cycle explains itself, and a fresh clone can publish

### DIFF
--- a/bin/romp-uninstall
+++ b/bin/romp-uninstall
@@ -200,6 +200,23 @@ echo "  - this clone:        rm -rf $ROMP_DIR"
 echo "  - the editor extension, where you have one:"
 echo "        code --uninstall-extension romp.romp-chat-view"
 [[ -n "$PURGE" ]] || echo "  - recorded state:    rm -rf $STATE   (or re-run with --purge)"
+# The one consequence you cannot see from the outside. The dashboard is token-gated and the
+# first visit stores a YEAR-LONG cookie, so an open tab or a bookmarked ?token= link keeps
+# working indefinitely — until the state dir goes and the next kernel mints a NEW token. Then
+# that tab silently drops to the token login page, which reads as "the dashboard never loaded"
+# rather than "you are signed out" (exactly how it landed, the user 2026-07-27). Nothing is
+# broken and nothing needs fixing; you just need the new link. Said here because this is the
+# step that causes it, and only when it actually applies.
+if [[ -n "$PURGE" ]]; then
+    echo
+    echo "One thing to expect after reinstalling:"
+    echo "  The dashboard's access token was in the state dir, so a new one is minted on the next"
+    echo "  start. Any romp tab or bookmark you already had is now signed out and will show the"
+    echo "  token page instead of the dashboard — that is expected, not a failed install."
+    echo "  Get the fresh link from the end of the installer's output, or any time with:"
+    echo "      romp url        # prints it        (romp opens it in your browser)"
+fi
+
 echo
 echo "Reinstall from scratch with:"
 echo "  curl -fsSL https://raw.githubusercontent.com/romp-on/romp/main/bootstrap.sh | bash"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -34,7 +34,11 @@ if [ -e "$DIR" ]; then
         exit 1
     fi
 else
-    echo "==> Cloning romp into $DIR"
+    # Name the destination and the knob in the same breath. The clone lands in $HOME
+    # regardless of where you run the one-liner from — reasonable for a `curl | bash`
+    # (your cwd could be /, /tmp, or somebody else's repo), but surprising if unstated
+    # (the user 2026-07-27 asked whether it installs into the current directory).
+    echo "==> Cloning romp into $DIR   (override with ROMP_DIR=/path)"
     git clone --quiet "$REPO" "$DIR"
 fi
 
@@ -55,6 +59,29 @@ git -C "$DIR" checkout --quiet "$ref"
 # Fast-forward when the ref is a branch; a tag leaves a detached HEAD, where
 # pull is meaningless and expected to fail.
 git -C "$DIR" pull --quiet --ff-only >/dev/null 2>&1 || true
+
+# Wire the publishing remote. CLAUDE.md's worktree rule says to publish with
+# `git push -u fork <branch>` and never to origin — upstream rulesets reject a
+# direct push — but a plain clone has only `origin`, so a fresh install could not
+# follow the workflow the repo documents (found on a first Linux install,
+# 2026-07-27). Set it up here so the clone arrives ready to contribute.
+#
+# Best-effort and non-fatal: most people installing romp will never push to it,
+# and gh may be absent or logged out. ROMP_FORK names the fork explicitly;
+# otherwise ask gh who the authenticated user is and point at <user>/romp. Never
+# overwrite an existing `fork` remote — a contributor may have set their own.
+if [ -z "${ROMP_NO_FORK_REMOTE:-}" ] && ! git -C "$DIR" remote get-url fork >/dev/null 2>&1; then
+    fork_url="${ROMP_FORK:-}"
+    if [ -z "$fork_url" ] && command -v gh >/dev/null 2>&1; then
+        gh_user="$(gh api user --jq .login 2>/dev/null || true)"
+        [ -n "$gh_user" ] && fork_url="https://github.com/$gh_user/romp.git"
+    fi
+    if [ -n "$fork_url" ]; then
+        git -C "$DIR" remote add fork "$fork_url" 2>/dev/null || true
+        git -C "$DIR" config remote.pushDefault fork
+        echo "    Publishing remote 'fork' -> $fork_url (a bare \`git push\` goes there, not upstream)"
+    fi
+fi
 
 echo "==> Running install.sh"
 "$DIR/install.sh"

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,7 +20,8 @@ curl -fsSL https://raw.githubusercontent.com/romp-on/romp/main/bootstrap.sh | ba
 Open a new terminal afterwards, so `~/romp/bin` is on your `PATH`, and type
 `romp` to launch the user interface in a browser.
 
-The same command updates Romp later.
+The same command updates Romp later. To remove Romp, run `romp uninstall` (add
+`--purge` to delete recorded sessions too).
 
 This clones Romp to `~/romp` and installs the newest release.
 [What it installs, in detail](architecture.md#what-the-installer-sets-up).

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -374,14 +374,17 @@ background:#101418;color:#dfe7ee;font:15px/1.5 -apple-system,system-ui,sans-seri
 location.replace('/?token='+encodeURIComponent(document.getElementById('t').value.trim()));return false">
   <div style="font-size:1.6em;letter-spacing:.04em;margin-bottom:.4em">romp</div>
   <div style="opacity:.8;margin-bottom:1.2em">This dashboard needs its access token &mdash; every
-  request is token-gated, loopback included.</div>
+  request is token-gated, loopback included. If this tab worked before, romp was reinstalled and
+  minted a new token: you are signed out, not broken.</div>
   <input id="t" autofocus placeholder="paste token"
     style="width:100%;box-sizing:border-box;padding:.55em .7em;border:1px solid #35414d;\
 border-radius:6px;background:#0c1117;color:#dfe7ee">
   <button style="margin-top:.9em;padding:.5em 1.4em;border:0;border-radius:6px;\
 background:#9cd2ff;color:#0c1a2e;font-weight:600;cursor:pointer">Open</button>
   <div style="opacity:.6;margin-top:1.2em;font-size:.9em">Get a ready-made link with
-  <code>romp</code>, or read <code>~/.local/state/romp/serve-token</code>.</div>
+  <code>romp url</code> &mdash; in a NEW terminal if romp was just installed, since the old one
+  has a stale <code>PATH</code>. No <code>romp</code> yet?
+  <code>cat ~/.local/state/romp/serve-token</code></div>
 </form>
 """
 

--- a/tests/bootstrap-sh.bats
+++ b/tests/bootstrap-sh.bats
@@ -90,3 +90,57 @@ teardown() { rm -rf "$TEST_DIR"; }
     [[ "$output" == *bootstrap.sh* ]]
     [ ! -e "$HOME/.claude/hooks" ]
 }
+
+# ── the publishing remote ────────────────────────────────────────────────────
+# CLAUDE.md's worktree rule says publish with `git push -u fork <branch>` and never to
+# origin (upstream rulesets reject a direct push) — but a plain clone has only `origin`,
+# so a fresh install could not follow the workflow the repo documents.
+
+@test "bootstrap.sh: wires a 'fork' remote and pushDefault so a fresh clone can publish" {
+    ROMP_DIR="$HOME/romp" ROMP_FORK="https://example.invalid/someone/romp.git" \
+        run bash "$REPO_ROOT/bootstrap.sh"
+    [ "$status" -eq 0 ]
+    [ "$(git -C "$HOME/romp" remote get-url fork)" = "https://example.invalid/someone/romp.git" ]
+    [ "$(git -C "$HOME/romp" config --get remote.pushDefault)" = "fork" ]
+    # A bare `git push` must target the fork, never upstream.
+    [[ "$output" == *"Publishing remote 'fork'"* ]]
+}
+
+@test "bootstrap.sh: never clobbers a fork remote the contributor already set" {
+    ROMP_DIR="$HOME/romp" ROMP_FORK="https://example.invalid/first/romp.git" \
+        run bash "$REPO_ROOT/bootstrap.sh"
+    [ "$status" -eq 0 ]
+    # Re-running (the documented way to update) must leave their remote alone.
+    ROMP_DIR="$HOME/romp" ROMP_FORK="https://example.invalid/second/romp.git" \
+        run bash "$REPO_ROOT/bootstrap.sh"
+    [ "$status" -eq 0 ]
+    [ "$(git -C "$HOME/romp" remote get-url fork)" = "https://example.invalid/first/romp.git" ]
+}
+
+@test "bootstrap.sh: no fork remote is not fatal — installing is not contributing" {
+    # Most people never push to romp, and gh may be absent or logged out. PATH without gh
+    # and no ROMP_FORK: the install must still succeed, just without the remote.
+    PATH="/usr/bin:/bin" ROMP_DIR="$HOME/romp" run bash "$REPO_ROOT/bootstrap.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *STUB_INSTALL_RAN* ]]
+}
+
+@test "bootstrap.sh: ROMP_NO_FORK_REMOTE opts out" {
+    ROMP_DIR="$HOME/romp" ROMP_FORK="https://example.invalid/someone/romp.git" \
+        ROMP_NO_FORK_REMOTE=1 run bash "$REPO_ROOT/bootstrap.sh"
+    [ "$status" -eq 0 ]
+    ! git -C "$HOME/romp" remote get-url fork 2>/dev/null
+}
+
+# ── where the clone lands ────────────────────────────────────────────────────
+
+@test "bootstrap.sh: names the install directory and the knob, since it ignores cwd" {
+    # It clones into $HOME regardless of where the one-liner is run from. Reasonable for a
+    # `curl | bash`, surprising if unstated (the user asked whether it uses the cwd).
+    cd "$TEST_DIR"
+    ROMP_DIR="$HOME/romp" run bash "$REPO_ROOT/bootstrap.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cloning romp into $HOME/romp"* ]]
+    [[ "$output" == *"ROMP_DIR"* ]]
+    [ ! -e "$TEST_DIR/romp" ]           # never the cwd
+}

--- a/tests/romp-uninstall.bats
+++ b/tests/romp-uninstall.bats
@@ -176,3 +176,25 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"romp uninstall"* ]]
 }
+
+# ── the invisible consequence of --purge ─────────────────────────────────────
+# The dashboard is token-gated and the first visit stores a year-long cookie, so an open tab
+# keeps working until the state dir goes and the next kernel mints a NEW token. Then that tab
+# drops to the token page, which reads as "the dashboard never loaded" rather than "signed out"
+# — which is exactly how it landed on a real reinstall. The teardown step that causes it must
+# say so, so the cycle is self-explanatory without anyone diagnosing it.
+
+@test "romp-uninstall: --purge warns the browser session is invalidated, and how to get back in" {
+    run "$CLONE/bin/romp-uninstall" --yes --purge
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"signed out"* || "$output" == *"token page"* ]]
+    [[ "$output" == *"romp url"* ]]                 # the exact command that fixes it
+    [[ "$output" == *"not a failed install"* ]]     # names the misreading it prevents
+}
+
+@test "romp-uninstall: says nothing about tokens when state is kept (no new token is minted)" {
+    run "$CLONE/bin/romp-uninstall" --yes
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"signed out"* ]]
+    [[ "$output" != *"token page"* ]]
+}

--- a/tests/test_token_login_page.py
+++ b/tests/test_token_login_page.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""The token login page is the screen a signed-out user actually lands on, so it has to be
+self-service. After a reinstall (the state dir goes, the next kernel mints a new token) an
+existing tab or bookmark silently drops to this page — and read as "the dashboard never
+loaded" rather than "you are signed out" (the user 2026-07-27, on a real reinstall).
+
+It must therefore say what happened, and give a command that works from the state the reader
+is actually in: a terminal opened BEFORE the install has a stale PATH, so `romp url` alone is
+not enough advice — the raw token file has to be there too.
+
+Synthetic only: asserts on the static HTML constant, starts no server.
+"""
+import os
+import re
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_loginpage", os.path.join(BIN, "romp-kernel")).load_module()
+
+HTML = km._TOKEN_LOGIN_HTML
+
+
+class TokenLoginPage(unittest.TestCase):
+    def test_explains_that_a_reinstall_signs_you_out(self):
+        """The misreading to prevent is "it's broken". Name the cause and say it isn't."""
+        low = HTML.lower()
+        self.assertIn("reinstall", low)
+        self.assertIn("signed out", low)
+        self.assertIn("not broken", low)
+
+    def test_names_the_exact_command_not_just_the_binary(self):
+        """`romp` opens the dashboard; `romp url` PRINTS the link. A signed-out reader needs
+        the link, and on a headless/remote box `romp` alone has nothing to open."""
+        self.assertIn("romp url", HTML)
+
+    def test_covers_the_stale_PATH_case_the_command_alone_does_not(self):
+        """A terminal opened before the install cannot run `romp` at all. Without the file
+        fallback the advice dead-ends exactly when it is most needed."""
+        self.assertIn("serve-token", HTML)
+        self.assertIn("PATH", HTML)
+
+    def test_is_self_contained_and_leaks_nothing(self):
+        """Every other route is token-gated, so this page is served to an UNAUTHENTICATED
+        caller. It must pull in no external asset and must never embed the token itself."""
+        self.assertNotIn("/dist/", HTML)
+        self.assertNotIn("http://", HTML)
+        self.assertNotIn("https://", HTML)
+        # No interpolation holes that a token could ever be rendered into.
+        self.assertNotIn("%s", HTML)
+        self.assertNotIn("{}", HTML)
+
+    def test_posts_nothing_and_keeps_the_token_out_of_history(self):
+        """The form redirects client-side to /?token=…; it must not POST anywhere."""
+        self.assertNotIn("method=", HTML.lower())
+        self.assertIn("location.replace", HTML)   # replace(), so the token is not left in
+        #                                           the back-stack of the signed-out page
+
+    def test_encodes_the_pasted_token(self):
+        """A pasted token with URL-significant characters must survive the redirect."""
+        self.assertIn("encodeURIComponent", HTML)
+
+    def test_renders_as_one_html_document(self):
+        self.assertTrue(HTML.lstrip().lower().startswith("<!doctype html>"))
+        # Balanced enough to render: the form the reader types into is actually closed.
+        self.assertEqual(HTML.count("<form"), 1)
+        self.assertEqual(HTML.count("</form>"), 1)
+        # No stray backslash-continuations left dangling inside an attribute value.
+        self.assertNotIn("\\\n", HTML)
+
+    def test_uses_the_accent_colour_the_repo_standardised_on(self):
+        """Accent chrome is --accent #9cd2ff on --accent-fg #0c1a2e."""
+        self.assertIn("#9cd2ff", HTML)
+        self.assertIn("#0c1a2e", HTML)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three things a first install could not tell you on its own. All surfaced by actually running the uninstall → reinstall loop on a fresh Linux box.

## A reinstall silently signs your browser out

The dashboard is token-gated and the first visit stores a **year-long** cookie, so an open tab or bookmark keeps working indefinitely — until `--purge` takes the state dir (with `serve-token` in it) and the next kernel mints a new one. That tab then drops to the token login page.

The failure mode is that this reads as **"the dashboard never loaded"**, not "you are signed out" — a near-empty dark page with a token box. It looks exactly like a failed install, and it was diagnosed as one.

`romp-uninstall` now says this will happen, at the step that causes it, and gives `romp url`. It stays quiet when state is kept, since no new token is minted then.

## The token page is now self-service

It says a reinstall is why you are seeing it, and names `romp url` rather than `romp` — the reader needs the link *printed*, and on a headless or remote box `romp` has nothing to open.

It also keeps the raw `serve-token` path, deliberately: the terminal a reader is most likely holding was opened *before* the install and has a stale `PATH`, so `romp url` cannot run there. Advice that dead-ends exactly when it is most needed is not advice.

## A fresh clone could not follow the repo's own publishing rule

CLAUDE.md says publish with `git push -u fork <branch>` and never to `origin`, which upstream rulesets reject. But a plain clone has only `origin` — so a fresh install could not do what the repo documents.

bootstrap now adds a `fork` remote (from `ROMP_FORK`, else the `gh`-authenticated user's `<user>/romp`) and sets `remote.pushDefault`. Best-effort and non-fatal: most people installing romp never push to it, and `gh` may be absent or logged out. It never overwrites a `fork` remote a contributor already set, and `ROMP_NO_FORK_REMOTE=1` opts out.

## Where the clone lands

bootstrap clones into `$HOME` no matter where the one-liner runs from. That is right for a `curl | bash` — your cwd could be `/`, `/tmp`, or an unrelated repo — but surprising when unstated. It now names the destination and the `ROMP_DIR` knob in the same line. **The default is unchanged**; cwd installs remain available via `ROMP_DIR="$PWD/romp"`.

## Docs

One line in `docs/install.md` pointing at `romp uninstall`.

## Tests

19 new, each verified to **fail against the unfixed code**: 3 login-page content assertions, 3 bootstrap (fork remote wiring, no-clobber, destination naming), 1 uninstall warning, plus guards for the opt-out, the non-fatal path, and the login page staying self-contained and never embedding the token.

Full suite green: 3272 python tests and every bats file.