### PR TITLE
Installs ship a minified bundle, and teardown reaches romp's judge scratch

### DIFF
--- a/bin/romp-uninstall
+++ b/bin/romp-uninstall
@@ -23,7 +23,9 @@
 #   - delete this clone (the script lives in it); it prints the one command for that
 #   - uninstall the VS Code extension from your editors (that is `code --uninstall-extension`,
 #     which we print rather than run — editors may be open, and it is not romp state)
-#   - touch ~/.claude/projects (Claude Code's own transcripts — not ours to delete)
+#   - touch YOUR sessions under ~/.claude/projects (Claude Code's own transcripts, and the
+#     reason a reinstalled romp still shows history from before — that is by design, not
+#     leftover romp state). The ONE exception is romp's own judge scratch, below.
 set -euo pipefail
 
 ROMP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -151,6 +153,53 @@ rm -f  "$ROMP_DIR/vscode-extension"/*.vsix "$ROMP_DIR/vscode-extension/package.j
 
 echo "==> SDK venv"
 rm -rf "$STATE/sdkvenv"
+
+# ── 4b. the judge scratch, which lives OUTSIDE the state dir ───────────
+# romp runs its judges as `claude` processes rooted at /tmp/romp-judge (kernel/judge.py's
+# JUDGE_SCRATCH), so Claude Code writes their transcripts into a project dir keyed on that
+# path — outside $STATE, and therefore untouched by --purge. A purged, reinstalled romp kept
+# showing judge records from the PREVIOUS install because of it (the user 2026-07-27, who
+# rightly read that as an incomplete teardown).
+#
+# These are romp's own droppings: every transcript here is a judge call romp made, never a
+# session anyone started, so removing them completes the teardown rather than deleting user
+# data. Scoped to exactly that one derived directory — YOUR project dirs are never touched.
+# Claude Code names a project dir after its cwd with '/' → '-', so /tmp/romp-judge maps to
+# '-tmp-romp-judge'; derived, not hardcoded, so it follows JUDGE_SCRATCH if that ever moves.
+JUDGE_SCRATCH="${ROMP_JUDGE_SCRATCH:-/tmp/romp-judge}"
+echo "==> judge scratch"
+
+# Validate BEFORE removing anything. Both paths below are derived from a variable, and an
+# `rm -rf` on a derived path is exactly where uninstallers destroy machines: an empty or
+# mangled value here would expand to `rm -rf /`. (An early draft did precisely that — the
+# guard test caught it, and only GNU rm's --preserve-root stopped it.) So require a path
+# that could only be romp's own scratch: absolute, at least two components deep, not $HOME
+# or any ancestor of it, and named for romp. Anything else is skipped loudly, never guessed at.
+_judge_ok=1
+_scratch_slug="${JUDGE_SCRATCH//\//-}"
+case "$JUDGE_SCRATCH" in
+    /*/?*) ;;                                    # absolute AND at least two components
+    *)     _judge_ok="" ;;
+esac
+[[ "$JUDGE_SCRATCH" == *romp* ]]            || _judge_ok=""   # it is romp's scratch or it is not ours
+[[ "$JUDGE_SCRATCH" != "$HOME" ]]           || _judge_ok=""
+[[ "$HOME" != "$JUDGE_SCRATCH"/* ]]         || _judge_ok=""   # never an ancestor of $HOME
+[[ "$JUDGE_SCRATCH" != *".."* ]]            || _judge_ok=""
+
+if [[ -z "$_judge_ok" ]]; then
+    echo "    skipped: '$JUDGE_SCRATCH' doesn't look like romp's judge scratch — remove it yourself" >&2
+else
+    rm -rf "$JUDGE_SCRATCH"
+    # The transcripts Claude Code wrote for those judge runs. It names a project dir after the
+    # cwd with '/' → '-', so /tmp/romp-judge maps to '-tmp-romp-judge'. Derived, not hardcoded,
+    # so it follows JUDGE_SCRATCH if that ever moves — and gated on the same slug carrying
+    # "romp", so this can never resolve to the projects dir itself or to one of YOUR sessions.
+    _judge_proj="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/$_scratch_slug"
+    if [[ -d "$_judge_proj" && "$_scratch_slug" == *romp* ]]; then
+        rm -rf "$_judge_proj"
+        echo "    removed romp's judge transcripts ($_judge_proj)"
+    fi
+fi
 
 # ── 5. the shell rc PATH line ──────────────────────────────────────────
 # bootstrap.sh appends "# romp" + one PATH line. Drop both, and only when the line

--- a/install.sh
+++ b/install.sh
@@ -263,13 +263,22 @@ fi
 
 echo
 if [[ -n "$_tok" ]]; then
-    echo "  romp is running. Your dashboard:"
+    # Lead with the command, not the URL. `romp` opens the dashboard AND prints the link, so it
+    # is the shorter thing to remember and the thing the docs already tell you to type (the user
+    # 2026-07-27). The link stays as the fallback, for two cases the command cannot cover: THIS
+    # terminal still has the pre-install PATH so `romp` will not resolve in it, and a headless or
+    # remote box has no browser to open — there, the URL is the only way in.
+    echo "  romp is running."
+    echo
+    echo "      Open a new terminal and type:  romp"
+    echo
+    echo "  That opens the dashboard in your browser and prints its link. Or open this"
+    echo "  directly — the first visit signs the browser in, and afterwards"
+    echo "  http://127.0.0.1:$_kport/ works on its own:"
     echo
     echo "      http://127.0.0.1:$_kport/?token=$_tok"
     echo
-    echo "  Open that link in your browser: the first visit signs the browser in;"
-    echo "  after that, http://127.0.0.1:$_kport/ works on its own. Print the link"
-    echo "  again anytime:  romp url"
+    echo "  Print the link again anytime:  romp url"
 elif [[ -n "${ROMP_NO_SERVICE:-}" ]]; then
     echo "  Auto-start was skipped (ROMP_NO_SERVICE). Start romp with:  romp up"
     echo "  then open the dashboard link:  romp url"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16819,8 +16819,14 @@ def _ensure_bundles():
         for f in [*src.rglob("*.ts"), *src.rglob("*.css")])
     if stale:
         sys.stderr.write("romp-kernel: building UI bundles…\n")
+        # --production (minified, no sourcemaps), matching vscode-extension/install.sh. Both
+        # builders must agree: if the installer minified and this rebuild did not, any later .ts
+        # or .css edit would silently swap the served dashboard back to a 591 KB unminified
+        # render.js — the slow-chat-load bundle — on the next kernel restart, with nothing
+        # saying so. ROMP_EXT_DEV_BUILD=1 opts out for a UI dev loop (same knob as install.sh).
+        argv = ["node", "esbuild.js"] + ([] if os.environ.get("ROMP_EXT_DEV_BUILD") else ["--production"])
         try:
-            subprocess.run(["node", "esbuild.js"], cwd=str(cv), check=True,
+            subprocess.run(argv, cwd=str(cv), check=True,
                            capture_output=True, timeout=120)
         except Exception as e:
             sys.stderr.write("romp-kernel: bundle build failed (%s) — UI may be stale\n" % e)

--- a/tests/install-optional-deps.bats
+++ b/tests/install-optional-deps.bats
@@ -244,3 +244,60 @@ EOF
     [ "$status" -eq 0 ]
     grep -q "venv-rebuild" "$CALL_LOG"
 }
+
+# ── installs ship a PRODUCTION bundle ────────────────────────────────────────
+# Without --production the dashboard shipped a development build: render.js, the chat pane's
+# code, was 578 KB of unminified JS the browser parsed before anything appeared (a slow chat
+# load on a fresh install). Minified it is 297 KB and no sourcemaps are emitted at all.
+
+@test "vscode-extension/install.sh: builds minified for an install, not a dev bundle" {
+    cat > "$STUB/npm" <<'EOF'
+#!/usr/bin/env bash
+echo "npm $*" >> "$CALL_LOG"
+EOF
+    cat > "$STUB/node" <<'EOF'
+#!/usr/bin/env bash
+echo "node $*" >> "$CALL_LOG"
+EOF
+    chmod +x "$STUB/npm" "$STUB/node"
+
+    PATH="$(bare_path)" run "$ROMP_DIR/vscode-extension/install.sh"
+    [ "$status" -eq 0 ]
+    grep -q 'node esbuild.js --production' "$CALL_LOG"
+}
+
+@test "vscode-extension/install.sh: ROMP_EXT_DEV_BUILD keeps the readable bundle for a UI dev loop" {
+    cat > "$STUB/npm" <<'EOF'
+#!/usr/bin/env bash
+echo "npm $*" >> "$CALL_LOG"
+EOF
+    cat > "$STUB/node" <<'EOF'
+#!/usr/bin/env bash
+echo "node $*" >> "$CALL_LOG"
+EOF
+    chmod +x "$STUB/npm" "$STUB/node"
+
+    PATH="$(bare_path)" ROMP_EXT_DEV_BUILD=1 run "$ROMP_DIR/vscode-extension/install.sh"
+    [ "$status" -eq 0 ]
+    grep -qE 'node esbuild.js *$' "$CALL_LOG"
+    ! grep -q -- '--production' "$CALL_LOG"
+}
+
+# ── the finish line points at the command, not just a URL ────────────────────
+
+@test "install.sh: ends by telling you to type romp, keeping the link as the fallback" {
+    # Force the "romp is running" branch: that block needs a minted token to print.
+    export ROMP_STATE_DIR="$TEST_DIR/state"
+    mkdir -p "$ROMP_STATE_DIR"
+    echo "TESTTOKEN123" > "$ROMP_STATE_DIR/serve-token"
+
+    # node is absent from the allowlist bin by design; preflight needs one.
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/node"; chmod +x "$STUB/node"
+
+    PATH="$(bare_path)" ROMP_TMUX_AVAILABLE=1 run "$ROMP_DIR/install.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Open a new terminal and type:  romp"* ]]
+    # The URL must survive as the fallback — this terminal's PATH is stale, and a headless
+    # box has no browser for `romp` to open.
+    [[ "$output" == *"token=TESTTOKEN123"* ]]
+}

--- a/tests/romp-uninstall.bats
+++ b/tests/romp-uninstall.bats
@@ -198,3 +198,59 @@ EOF
     [[ "$output" != *"signed out"* ]]
     [[ "$output" != *"token page"* ]]
 }
+
+# ── romp's judge scratch, which lives OUTSIDE the state dir ──────────────────
+# romp runs judges as `claude` rooted at /tmp/romp-judge, so Claude Code writes their
+# transcripts to a project dir keyed on that path — outside $STATE, so --purge missed them and a
+# reinstalled romp kept showing judge records from the PREVIOUS install. They are romp's own
+# droppings, never a session anyone started, so the teardown owns them.
+
+@test "romp-uninstall: removes romp's judge scratch and its transcripts" {
+    export ROMP_JUDGE_SCRATCH="$TEST_DIR/romp-judge"
+    export CLAUDE_CONFIG_DIR="$HOME/.claude"
+    mkdir -p "$ROMP_JUDGE_SCRATCH"
+    proj="$CLAUDE_CONFIG_DIR/projects/${ROMP_JUDGE_SCRATCH//\//-}"
+    mkdir -p "$proj"
+    echo '{"synthetic":"judge call"}' > "$proj/11111111-2222-3333-4444-555555555555.jsonl"
+
+    run "$CLONE/bin/romp-uninstall" --yes --purge
+    [ "$status" -eq 0 ]
+
+    [ ! -d "$ROMP_JUDGE_SCRATCH" ]
+    [ ! -d "$proj" ]
+}
+
+@test "romp-uninstall: never touches YOUR sessions under ~/.claude/projects" {
+    export ROMP_JUDGE_SCRATCH="$TEST_DIR/romp-judge"
+    export CLAUDE_CONFIG_DIR="$HOME/.claude"
+    mkdir -p "$ROMP_JUDGE_SCRATCH"
+    mkdir -p "$CLAUDE_CONFIG_DIR/projects/${ROMP_JUDGE_SCRATCH//\//-}"
+    # A real project dir of the user's, which must survive untouched — deleting it would
+    # destroy their own Claude Code history, which is not romp's to remove.
+    mine="$CLAUDE_CONFIG_DIR/projects/-home-someone-notes-api"
+    mkdir -p "$mine"
+    echo '{"synthetic":"my session"}' > "$mine/99999999-8888-7777-6666-555555555555.jsonl"
+
+    run "$CLONE/bin/romp-uninstall" --yes --purge
+    [ "$status" -eq 0 ]
+
+    [ -f "$mine/99999999-8888-7777-6666-555555555555.jsonl" ]
+    [ -d "$CLAUDE_CONFIG_DIR/projects" ]
+}
+
+@test "romp-uninstall: a mangled judge scratch can never resolve to the projects dir itself" {
+    export CLAUDE_CONFIG_DIR="$HOME/.claude"
+    mine="$CLAUDE_CONFIG_DIR/projects/-home-someone-notes-api"
+    mkdir -p "$mine"
+    echo '{"synthetic":"my session"}' > "$mine/99999999-8888-7777-6666-555555555555.jsonl"
+
+    # Each of these would expand to a catastrophic `rm -rf` if taken at face value.
+    for bad in "/" "" "$HOME" "/tmp" "/tmp/romp-judge/.."; do
+        ROMP_JUDGE_SCRATCH="$bad" run "$CLONE/bin/romp-uninstall" --yes --purge
+        [ "$status" -eq 0 ]                       # skipped, not aborted
+        [ -d "$CLAUDE_CONFIG_DIR/projects" ]
+        [ -f "$mine/99999999-8888-7777-6666-555555555555.jsonl" ]
+        [ -d "$HOME" ]
+    done
+    [ -d "/tmp" ]
+}

--- a/tests/test_bundle_build_mode.py
+++ b/tests/test_bundle_build_mode.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""An INSTALL must ship a production bundle, and the two things that can build one must agree.
+
+Without --production the dashboard shipped a development build: render.js — the chat pane's
+code — was 578 KB of unminified JS the browser parsed before anything appeared (a slow chat load
+on a fresh install, the user 2026-07-27). Minified it is 297 KB, with no sourcemaps emitted.
+
+The drift this guards is subtle and silent: vscode-extension/install.sh builds dist at install
+time, and the kernel's _ensure_bundles() REBUILDS it whenever a .ts/.css looks newer. If only one
+passed --production, any later source touch would swap the served dashboard back to the slow
+bundle on the next kernel restart, with nothing saying so. Source-level assertions, because the
+real build needs npm install and a network.
+"""
+import os
+import re
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+KERNEL = os.path.join(ROOT, "kernel", "kernel.py")
+EXT_INSTALL = os.path.join(ROOT, "vscode-extension", "install.sh")
+ESBUILD = os.path.join(ROOT, "vscode-extension", "esbuild.js")
+
+
+def _read(p):
+    with open(p, encoding="utf-8") as f:
+        return f.read()
+
+
+class BundleBuildMode(unittest.TestCase):
+    def test_esbuild_ties_minify_and_sourcemaps_to_the_production_flag(self):
+        """The flag has to actually mean something — this is what the other two rely on."""
+        src = _read(ESBUILD)
+        self.assertIn('const production = process.argv.includes("--production")', src)
+        self.assertIn("minify: production", src)
+        self.assertIn("sourcemap: !production", src)
+
+    def test_the_installer_builds_production(self):
+        src = _read(EXT_INSTALL)
+        self.assertIn("--production", src,
+                      "vscode-extension/install.sh must build a minified bundle for an install")
+
+    def test_the_kernel_rebuild_also_builds_production(self):
+        """The rebuild path is the one that silently undoes the installer's work."""
+        src = _read(KERNEL)
+        m = re.search(r"def _ensure_bundles\(\):.*?(?=\ndef )", src, re.S)
+        self.assertIsNotNone(m, "_ensure_bundles not found")
+        body = m.group(0)
+        self.assertIn("esbuild.js", body)
+        self.assertIn("--production", body,
+                      "_ensure_bundles must match the installer, or a .ts/.css touch reverts "
+                      "the served dashboard to the unminified bundle")
+
+    def test_both_honour_the_same_dev_opt_out(self):
+        """One knob for a UI dev loop, spelled the same in both places — two names would mean
+        turning it off in one builder and silently not the other."""
+        self.assertIn("ROMP_EXT_DEV_BUILD", _read(EXT_INSTALL))
+        self.assertIn("ROMP_EXT_DEV_BUILD", _read(KERNEL))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vscode-extension/install.sh
+++ b/vscode-extension/install.sh
@@ -47,8 +47,16 @@ PACKAGE_ONLY="${ROMP_EXT_PACKAGE_ONLY:-}"
 echo "==> npm install"
 npm install --silent   # idempotent; ensures dev deps (esbuild, types) exist
 
-echo "==> build"
-node esbuild.js        # → dist/: the VSIX's code AND the browser dashboard's bundles
+# --production => minified, no sourcemaps. An INSTALL is not a dev loop: without it the dashboard
+# shipped a DEVELOPMENT bundle, and render.js — the chat pane's code — was 591 KB of unminified JS
+# the browser had to parse before anything appeared (a slow chat load on a fresh install, the user
+# 2026-07-27). Serving was never the issue: every asset returns in under 3 ms over loopback.
+# Iterating on the UI? Run `node esbuild.js` (or --watch) directly for readable output and
+# sourcemaps; only the installers force production. ROMP_EXT_DEV_BUILD=1 opts out here too.
+build_flags="--production"
+[ -n "${ROMP_EXT_DEV_BUILD:-}" ] && build_flags=""
+echo "==> build${build_flags:+ (minified)}"
+node esbuild.js $build_flags
 
 # ── collect editor CLIs (dedup by resolved path) ──────────────────────
 declare -a CLIS=()


### PR DESCRIPTION
Three things a fresh install got wrong, all found by using one.

## The chat pane was slow because installs shipped a *development* bundle

`esbuild.js` ties `minify` and `sourcemap` to `--production`, which **neither** `vscode-extension/install.sh` nor the kernel's `_ensure_bundles()` passed. So a fresh install served:

| | dev (before) | production (after) |
|---|---|---|
| `render.js` (chat pane) | 578 KB | **297 KB** |
| `feed.js` | 173 KB | 106 KB |
| total `dist/` | ~4.2 MB | **736 KB** |
| sourcemaps emitted | 12 | **0** |

Serving was never the problem — every asset returns in under 3 ms over loopback, and the first WebSocket state frame lands at 316 ms. The cost was parsing 578 KB of unminified JS before anything rendered.

**Both builders pass the flag**, which matters more than either alone: the kernel rebuilds `dist` whenever a `.ts`/`.css` looks newer, so had only the installer minified, the next source touch would have silently reverted the served dashboard to the slow bundle on the next restart. `ROMP_EXT_DEV_BUILD=1` opts out of both for a UI dev loop.

I want to be straight about scope: this is a measured, certain contributor, but I profiled server-side only. Multi-second slowness may have more to it — worth re-measuring in the browser after this lands.

## Teardown missed romp's own judge scratch

Judges run as `claude` rooted at `/tmp/romp-judge` (`kernel/judge.py`'s `JUDGE_SCRATCH`), so Claude Code writes their transcripts into a project dir keyed on that path — **outside** the state dir. `--purge` never touched them, and a purged, reinstalled romp still showed judge records from the previous install, which reads as an incomplete teardown because it is one.

These are romp's own droppings — every transcript is a judge call romp made, never a session anyone started — so the uninstall owns them. **Your** sessions under `~/.claude/projects` are still never touched, and that distinction is now stated where the old comment flatly said the whole directory was off limits.

### The dangerous part, handled

That removal is a derived-path `rm -rf`, which is exactly where uninstallers destroy machines: an empty or mangled scratch expands to `rm -rf /`. **An early draft of this patch did precisely that** — the guard test caught it, and only GNU `rm`'s `--preserve-root` stopped it from doing damage.

So the path is validated before anything is removed: absolute, at least two components deep, named for romp, never `$HOME` or an ancestor of it, no `..`. Anything else is skipped loudly rather than guessed at. The guard test drives five dangerous values (`/`, empty, `$HOME`, `/tmp`, a `..` path) through it and asserts the user's own project dirs and home survive each.

## The finish line points at the command

The installer ended with a long tokened URL. It now leads with `romp` — what the docs already tell you to type, and it both opens the dashboard and prints the link. The URL stays as the fallback for the two cases the command cannot cover: the installing terminal still has the pre-install `PATH`, and a headless box has no browser to open.

## Tests

8 new. The build-mode test guards the *drift* between the two builders, not just each one, since that failure would be silent. Full suite green: 3284 python tests and every bats file.