### PR TITLE
Chat was re-sending itself every second because firstSeen ticked with the clock

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -39,6 +39,42 @@ BIND = os.environ.get("ROMP_SERVE_HOST", "127.0.0.1")   # loopback only; tailnet
 _STARTED = time.time()                       # this kernel process's start (for /version uptime)
 
 
+# ── ROMP_PERF: where did the time go, and what got re-sent ────────────────────────────────────────
+# Off unless ROMP_PERF is set, so a normal kernel pays one env lookup at import and nothing after.
+# Lines go to stderr, which the login service already funnels into the journal:
+#     ROMP_PERF=1 romp refresh   →   journalctl --user -u romp-manager -f | grep romp-perf
+# Format is `romp-perf <event> k=v k=v`, greppable and awk-able on purpose.
+#
+# This exists because "the chat pane is slow" was, from the outside, indistinguishable between a slow
+# BUILD, a fat PAYLOAD, and a payload that was fine but re-sent every second because one field ticked
+# with the clock. It was the third, and pinning that down needed a hand-written WebSocket client. Two
+# numbers — build ms and per-slot deduped/sent — separate all three at a glance.
+_PERF = bool(os.environ.get("ROMP_PERF"))
+
+
+def _perf(evt, **kw):
+    """One `romp-perf` line. Never raises and never formats anything when disabled — this sits on the
+    per-push hot path, so an exception or a wasted json.dumps here would be a bug of its own."""
+    if not _PERF:
+        return
+    try:
+        sys.stderr.write("romp-perf %s %s\n" % (evt, " ".join("%s=%s" % (k, v) for k, v in sorted(kw.items()))))
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+
+def _perf_slot(key):
+    """A dedup key ("chat", "<uuid>") as a short, stable label. The sid is truncated: these lines are
+    read in a terminal, and a full uuid per line buries the numbers that matter."""
+    try:
+        if isinstance(key, tuple):
+            return "%s:%s" % (key[0], str(key[1])[:8]) if len(key) > 1 else str(key[0])
+        return str(key)
+    except Exception:
+        return "?"
+
+
 # ── host-suspend (laptop sleep) awareness ─────────────────────────────────────────────────────────
 # When the lid closes this kernel process is FROZEN: time.monotonic() stops, but time.time() keeps real
 # time — so on resume the producer loop sees wall-clock jump far past the monotonic delta. That divergence
@@ -9838,7 +9874,16 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
             # the timeline lane's feed checkbox + postal mailbox. Same flags + legacy fallback as build_timeline.
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),
             "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"),
-            "firstSeen": session["turns"][0]["t"] if session["turns"] else now}
+            # NEVER `now`. This rides the chat payload, and _send_client dedups by comparing the
+            # SERIALIZED payload against what that client last received — so a firstSeen that ticked
+            # with the wall clock made every build differ, defeated the dedup entirely, and re-sent the
+            # FULL chat to every connected client about once a second, forever, for any session with no
+            # turns yet. (Measured on an idle session: a complete `session` frame every ~1.1s, each one
+            # making the browser re-run its upsert/reconcile across the transcript — chat felt slow while
+            # every other pane, whose payloads dedup correctly, stayed instant.) The spawn time is
+            # persisted and fixed; None when genuinely unknown, which the client tolerates — render.ts
+            # keeps what it already had (`msg.firstSeen ?? prev.firstSeen`).
+            "firstSeen": session["turns"][0]["t"] if session["turns"] else _sdk_spawned_at(sid)}
 
 
 EPISODE_EVENT_CAP = 200   # events shipped per pre-clear episode expand — bounded, honest about the cut
@@ -13058,11 +13103,18 @@ def _send_client(c, key, msg, pre=None):
     """Send a payload to ONE client only if it differs from what that client last received (per-client
     dedup, key = the slot e.g. ("chat", sid)) — so the periodic push re-sends nothing when unchanged.
     `pre` is the already-serialized msg (json.dumps(msg)) when the caller has it cached — passing it lets
-    a reused/unchanged payload skip re-serializing a large chat on every poll (the chat-build cache)."""
+    a reused/unchanged payload skip re-serializing a large chat on every poll (the chat-build cache).
+
+    ROMP_PERF=1 logs every send AND every dedup hit. That asymmetry is the point: a payload carrying a
+    field that ticks with the clock looks perfectly normal from the outside — the UI just feels slow —
+    and the only visible symptom is this dedup never hitting. Finding the last one took a hand-written
+    WebSocket client; the log makes the next one obvious."""
     s = pre if pre is not None else json.dumps(msg)
     if c.setdefault("sent", {}).get(key) == s:
+        _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=1)
         return
     c["sent"][key] = s
+    _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0)
     try:
         c["send"](s)
     except Exception:
@@ -13410,9 +13462,17 @@ def _push(targets, connect=False):
                 hit = _built_chat.get(s["sid"])
                 if not is_active and hit is not None and sig is not None and hit[0] == sig:
                     m, ms = hit[1], hit[2]               # unchanged background tab → reuse, no reshape/serialize
+                    _perf("chatbuild", sid=str(s["sid"])[:8], cached=1, ms=0, active=int(is_active))
                 else:
+                    _t0 = time.monotonic()
                     m = build_session(s["sid"], now, tmux)
                     ms = json.dumps(m) if m is not None else None
+                    # Build + serialize together: the ACTIVE tab skips the cache above by design, so this
+                    # is what the watched session pays on every single push. If chat ever feels slow again,
+                    # this number and the deduped= on the matching send say which half is at fault.
+                    _perf("chatbuild", sid=str(s["sid"])[:8], cached=0, active=int(is_active),
+                          ms=round((time.monotonic() - _t0) * 1000, 1),
+                          events=(len(m.get("events") or []) if m else 0), bytes=(len(ms) if ms else 0))
                     if m is not None and sig is not None:
                         if len(_built_chat) > 256:       # bounded by fleet size; a wholesale clear is fine
                             _built_chat.clear()

--- a/tests/test_chat_payload_clock_invariant.py
+++ b/tests/test_chat_payload_clock_invariant.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""The chat payload must not vary with the wall clock.
+
+_send_client dedups by comparing the SERIALIZED payload against what that client last received, so a
+single field that ticks with the clock silently defeats the whole mechanism: the kernel re-sends the
+FULL chat to every connected client on every push, forever, and the browser re-runs its
+upsert/reconcile over the transcript each time. Nothing errors; chat just feels slow while every other
+pane stays instant, because their payloads dedup correctly.
+
+That is exactly what `"firstSeen": ... if session["turns"] else now` did for any session with no turns
+yet — measured on an idle session as a complete `session` frame every ~1.1s, and it took a
+hand-written WebSocket client to see at all (the user 2026-07-27, who reported chat as slow).
+
+So this asserts the INVARIANT rather than the one field: build the same session at two different
+`now` values and require byte-identical payloads. Any future clock-varying field fails here instead of
+becoming another slow-chat report.
+
+Synthetic only: placeholder uuid, invented prompt text, temp dirs.
+"""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+jd = SourceFileLoader("romp_judge_clockinv", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_clockinv", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NOW = 1781100000
+T0 = NOW - 3600
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, stop="end_turn"):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+class ChatPayloadIsClockInvariant(unittest.TestCase):
+    """A deliberately minimal fixture — just enough for build_session to resolve the session. The
+    richer ViewBuilder fixture in test_kernel is not reused: importing its class would make unittest
+    collect and re-run all of its tests from this module too."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        self.tpath = pdir / (SID + ".jsonl")
+        self._write_turns()
+        names = td / "names"; names.mkdir()
+        (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
+
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+                      km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD)
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
+        jd.STATE = td
+        km.NAMES = names
+        # A dev machine's real ~/.claude/CLAUDE.md would otherwise leak a system-context card in.
+        km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+        # Alive + idle, and FIXED: a `since` derived from the real clock would itself vary between the
+        # two builds and mask the very thing under test.
+        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+                                           "effort": "", "context": None, "compactPct": None,
+                                           "color": None}}
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+         km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD) = self.saved
+        self.td.cleanup()
+
+    def _write_turns(self):
+        self.tpath.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0, "start the notes-api spike", "u1"),
+            aline(T0 + 40, "Spike is up.", "a1", "u1"),
+        ]) + "\n")
+
+    def _write_no_completed_turn(self):
+        """A prompt with no assistant reply yet: events exist, but session["turns"] is empty — the
+        branch whose `else now` fallback caused the every-push resend."""
+        self.tpath.write_text(json.dumps(uline(T0, "start the notes-api spike", "u1")) + "\n")
+
+    def _build_twice(self):
+        """Same session, two clocks ten minutes apart. Real pushes are ~1s apart; ten minutes makes any
+        clock-derived field differ unmistakably rather than by a rounding hair."""
+        a = km.build_session(SID, NOW)
+        b = km.build_session(SID, NOW + 600)
+        self.assertIsNotNone(a, "fixture session must build")
+        self.assertIsNotNone(b, "fixture session must build")
+        return a, b
+
+    def _assert_identical(self, a, b, why):
+        varying = sorted(k for k in set(list(a) + list(b))
+                         if json.dumps(a.get(k), default=str) != json.dumps(b.get(k), default=str))
+        self.assertEqual(varying, [], "%s — these fields move with the clock, so _send_client's dedup "
+                                      "can never hit and the full chat re-sends on every push" % why)
+
+    def test_a_session_with_turns_is_clock_invariant(self):
+        self._assert_identical(*self._build_twice(), why="session with turns")
+
+    def test_a_session_with_NO_turns_is_clock_invariant(self):
+        self._write_no_completed_turn()
+        self._assert_identical(*self._build_twice(), why="session with no completed turn")
+
+    def test_firstSeen_never_falls_back_to_the_current_time(self):
+        """Named directly, because this is the field that did it and the failure is otherwise silent."""
+        self._write_no_completed_turn()
+        a, b = self._build_twice()
+        self.assertEqual(a.get("firstSeen"), b.get("firstSeen"),
+                         "firstSeen must come from a persisted/fixed source, never `now`")
+        self.assertNotIn(a.get("firstSeen"), (NOW, NOW + 600),
+                         "firstSeen IS the clock here — the exact bug this guards")
+
+    def test_the_dedup_actually_suppresses_an_unchanged_payload(self):
+        """The other half of the contract: a stable payload is only useful if the dedup fires on it."""
+        sent = []
+        client = {"send": sent.append, "alive": True}
+        payload = {"type": "session", "id": SID, "events": []}
+        km._send_client(client, ("chat", SID), payload)
+        km._send_client(client, ("chat", SID), dict(payload))    # equal value, different object
+        self.assertEqual(len(sent), 1, "an unchanged chat payload must go out once, not once per push")
+        km._send_client(client, ("chat", SID), {"type": "session", "id": SID, "events": [{"uuid": "u1"}]})
+        self.assertEqual(len(sent), 2, "a genuinely changed payload must still be sent")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reported as: everything else loads instantly, chat is very slow.

## The bug

`_send_client` dedups by comparing the **serialized** payload against what that client last received. `build_session` set:

```python
"firstSeen": session["turns"][0]["t"] if session["turns"] else now
```

For any session with **no turns yet**, that fell back to `now`. So the payload differed on every build, the dedup could never hit, and the kernel re-sent the **entire chat** to every connected client on every push — measured on an idle session as a complete `session` frame every ~1.1s, indefinitely — with the browser re-running its `upsert`/`reconcile` across the transcript each time.

Nothing errored. Chat just felt slow while every other pane stayed instant, because their payloads dedup correctly. That asymmetry is exactly what made it hard to see.

## Measured, same idle session

| chat slot, over 3 minutes | before | after |
|---|---|---|
| frames sent | ~142 | **2** |
| dedup hits | 0 | **140** |

`firstSeen` now comes from the persisted spawn time, or `None` when genuinely unknown — which `render.ts` already tolerates (`msg.firstSeen ?? prev.firstSeen`), and which `tab-order.ts` notes is no longer used for client-side sorting.

## The test asserts the invariant, not the field

Building the same session at two `now` values ten minutes apart must produce **byte-identical** payloads, for both the with-turns and no-turns branches. Any *future* clock-varying field fails there instead of becoming another slow-chat report.

It also pins the other half of the contract — that an unchanged payload really is suppressed — because a stable payload is only useful if the dedup fires on it.

Verified to fail against unfixed `main` (3 of 4 failures) and pass here.

## ROMP_PERF

Off by default; one env lookup at import and nothing after.

```
ROMP_PERF=1 romp refresh
journalctl --user -u romp-manager -f | grep romp-perf
```

From the outside, "chat is slow" was indistinguishable between a slow **build**, a fat **payload**, and a payload that was fine but **re-sent every second**. Separating those took a hand-written WebSocket client. Two numbers now do it — per-build ms, and per-slot sent/deduped:

```
romp-perf chatbuild active=1 bytes=722 cached=0 events=0 ms=10.6 sid=20f4c227
romp-perf send bytes=722 deduped=0 slot=chat:20f4c227
romp-perf send bytes=722 deduped=1 slot=chat:20f4c227
```

Logging dedup **hits** as well as sends is deliberate: a payload carrying a clock-derived field looks completely normal, and the only visible symptom is that its slot never dedups.

Full suite green: 3288 python tests and every bats file.