### PR TITLE
A /clear that drops open cards is visible and consented, never silent

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3270,12 +3270,19 @@ def episode_last(sid):
     return rows[-1] if rows else None
 
 
-def append_episode(sid, head, fsid, t):
+def append_episode(sid, head, fsid, t, settled=None):
     """Record an observed episode head for `sid` (append-only; the caller has already established
-    this head is NEW — see the kernel's boundary tick)."""
+    this head is NEW — see the kernel's boundary tick). `settled` is the boundary's own settle
+    record (the user 2026-07-27, who found the drop invisible): the open cards dropped with the
+    cleared conversation, [{"id","text"}, ...]. It rides the row so every later surface — the
+    feed's bell notice, the chat boundary card — can say what the clear took with it, instead of
+    the cards leaving the board with nothing shown anywhere."""
     EPIDIR.mkdir(parents=True, exist_ok=True)
+    row = {"head": head, "fsid": fsid, "t": t}
+    if settled:
+        row["settled"] = settled
     with (EPIDIR / (sid + ".jsonl")).open("a") as fh:
-        fh.write(json.dumps({"head": head, "fsid": fsid, "t": t}) + "\n")
+        fh.write(json.dumps(row) + "\n")
     _episode_memo.pop(sid, None)
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9817,7 +9817,11 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
         if boundary:
             events.insert(0, {"kind": "clear", "uuid": "clear:%s" % (boundary.get("head") or boundary.get("t")),
                               "ts": iso(boundary["t"]) if boundary.get("t") else None,
-                              "clearedAt": boundary.get("t"), "episodes": len(_epi_rows)})
+                              "clearedAt": boundary.get("t"), "episodes": len(_epi_rows),
+                              # the open cards the boundary settle dropped (the episode row's own
+                              # settle record) — the card names them so the drop is visible in the
+                              # chat too, not only in the feed's bell (the user 2026-07-27)
+                              "dropped": [d.get("text") or "" for d in (boundary.get("settled") or [])] or None})
     return {"type": "session", "id": sid, "name": sess["name"], "color": _name_color(sid),
             "cwd": _tilde(_cwd_of(sid) or meta.get("cwd") or ""),   # fixed-at-creation dir; lane tab shows it (the user 2026-06-22)
             # git branch as a TOP-LEVEL session field, NOT just inside the head system event: the status-bar
@@ -9998,15 +10002,20 @@ def _episode_boundary_check(sid, path, now):
     last = jd.episode_last(sid)      # either way the recorded episode is still the current one
     if last is not None and last.get("head") == head["uuid"]:
         return
-    jd.append_episode(sid, head["uuid"], Path(path).stem, head["t"] or int(now))
+    tops, nodes = [], {}
+    if last is not None:             # a real boundary (not the seeding first look): what dies with it?
+        store = jd.load_goals(sid)
+        nodes, status = store.get("nodes", {}), store.get("status", {})
+        tops = [nid for nid, nd in nodes.items()
+                if nd.get("parentId") is None and not nd.get("cleared") and status.get(nid) != "cleared"
+                and not (nd.get("nodeComplete") or status.get(nid) == "completed")]
+    # The settle summary rides the episode row itself, so the drop is never silent (the user
+    # 2026-07-27): the feed's bell notice and the chat boundary card both read it back from here.
+    settled = [{"id": nid, "text": (nodes[nid].get("text") or "")[:120]} for nid in tops]
+    jd.append_episode(sid, head["uuid"], Path(path).stem, head["t"] or int(now), settled=settled or None)
     if last is None:
         return                       # first observation SEEDS the log; a boundary needs a prior recorded
     #                                  episode (so deploying this never mass-settles existing sessions)
-    store = jd.load_goals(sid)
-    nodes, status = store.get("nodes", {}), store.get("status", {})
-    tops = [nid for nid, nd in nodes.items()
-            if nd.get("parentId") is None and not nd.get("cleared") and status.get(nid) != "cleared"
-            and not (nd.get("nodeComplete") or status.get(nid) == "completed")]
     if not tops:
         return
     p = jd.STATE / "cleared.jsonl"
@@ -10773,6 +10782,27 @@ def _card_warn_rows(rows, fsid, subtree, placements, cap=20):
     return out[-cap:]
 
 
+def _boundary_clear_notices(alive):
+    """The newest /clear boundary that SETTLED cards, per living session — read straight from the
+    episodes log's own settle record (the authoritative row, written at the boundary). The feed
+    mirrors each into the shell's notification bell exactly once (client seen-set), so a clear that
+    dropped open cards is always visible after the fact instead of the cards silently leaving the
+    board (the user 2026-07-27). Newest-only bounds the payload; episode_rows is an mtime memo, so
+    this is cheap per push."""
+    out = []
+    for s in alive:
+        try:
+            rows = jd.episode_rows(s["sid"])
+        except Exception:
+            continue
+        for r in reversed(rows):
+            if r.get("settled"):
+                out.append({"sid": s["sid"], "name": s["name"], "t": r.get("t") or 0,
+                            "titles": [str(d.get("text") or "") for d in r["settled"]]})
+                break
+    return out
+
+
 def build_feed(now, tmux=None):
     """The {type:"feed"} message the tuned feed.js bundle consumes (ui-parity.md: feed = ADAPT).
     Goals map onto the AskItem/AskTreeNode shape the render already speaks: the goal tree IS the
@@ -11452,6 +11482,8 @@ def build_feed(now, tmux=None):
             # the shared session order (session-order.json — the tab/lane order): grouped mode sorts each
             # column's session runs by it (the user 2026-07-13); federation prefixes + concatenates per host
             "order": _session_order(),
+            # /clear boundary settles, newest per session → the bell logs each once (the user 2026-07-27)
+            "clearNotices": _boundary_clear_notices(alive),
             "canUndoClear": len(cleared) > 0}
 
 

--- a/plans/clear-episodes.md
+++ b/plans/clear-episodes.md
@@ -82,6 +82,31 @@ was no durable map from a session to its past episodes' transcript files (SDK
 transcripts carry no custom-title either). Every future episode surface hangs
 off this file.
 
+## What shipped (second commit): the settle is visible, and consented where possible
+
+The first commit's settle was silent — one stderr line; the cards left the
+feed, the Fleet ledger, and (via compaction) the live store with nothing shown
+anywhere (the user 2026-07-27: "cards must not disappear without you seeing
+anything"). Now:
+
+- **The settle record rides the episode row.** The boundary writes
+  `settled: [{id, text}, ...]` into its own `episodes/<sid>.jsonl` row — the
+  authoritative, durable record of what the clear took with it.
+- **The bell logs the drop.** `build_feed` ships the newest settled boundary
+  per living session (`clearNotices`); the feed mirrors each into the shell's
+  notification bell exactly once (the badge-mirror seen-set), naming the
+  dropped cards and the Undo-clear way back.
+- **The chat boundary card counts and names them.** "Conversation cleared — a
+  fresh one starts here · N open cards dropped with it", titles on hover.
+- **The composer confirms first.** A `/clear` typed into the chat composer is
+  the one place romp sees the command BEFORE it runs; with open cards it now
+  puts up an explicit confirm ("Its N open cards get dropped with it: …",
+  Cancel default-focused) instead of letting Enter drop them silently. A
+  `/clear` typed into a terminal-attached TUI is still detect-after-the-fact —
+  the bell + boundary card are the guarantee there.
+- **The feed's per-node story is src-aware.** A boundary clear (src `romp`)
+  reads "dropped with the cleared conversation", no longer "you cleared it".
+
 ## Deferred — the read-only episode browser
 
 The pieces exist; none are wired. When built:
@@ -101,9 +126,13 @@ The pieces exist; none are wired. When built:
   goal store, so the ledger/TOC panel should hide rather than render empty.
 - **Search** (the user's "searchable rather than deleted"): today no surface
   searches transcript text — the Fleet box matches names + goal trees, the
-  picker matches the one-line archive headline. Cleared boundary cards are
-  already searchable through the Fleet's archived-goals path once compaction
-  moves them; transcript-text search over past episodes is its own project.
+  picker matches the one-line archive headline. NOTE (corrected 2026-07-27):
+  the Fleet's archived-goals path (`_fleet_archived_tops`) deliberately shows
+  completed-or-summarized tops only, so a bare boundary dismissal does NOT
+  surface there — after compaction the dropped cards are reachable via the
+  tab-hover Recent list (any status, newest 5), the episode row's settle
+  record, and Undo clear (newest batch only). Transcript-text search over past
+  episodes is its own project.
 
 ## Known gaps, accepted
 

--- a/tests/test_clear_chat_view.py
+++ b/tests/test_clear_chat_view.py
@@ -114,6 +114,21 @@ class ClearChatViewTest(unittest.TestCase):
         self.assertEqual(clear["uuid"], "clear:n1", "keyed on the episode head - stable across pushes")
         self.assertEqual(clear["clearedAt"], CLEAR_T)
         self.assertEqual(clear["episodes"], 2)
+        self.assertIsNone(clear["dropped"], "a boundary that settled nothing names nothing")
+
+    def test_boundary_card_names_the_dropped_cards(self):
+        # the settle record rides the episode row (the user 2026-07-27) -> the chat boundary card
+        # counts + names what the clear took, so the drop is visible in the chat, not only the bell
+        _write_jsonl(jd.STATE / "episodes" / (SID + ".jsonl"), [
+            {"head": "u1", "fsid": SID, "t": NOW - 3600},
+            {"head": "n1", "fsid": NEWFSID, "t": CLEAR_T,
+             "settled": [{"id": SID + ":g1", "text": "Ship the deployment guide"},
+                         {"id": SID + ":g2", "text": "Tune the api rate limits"}]},
+        ])
+        clear = self._events()[0]
+        self.assertEqual(clear["kind"], "clear")
+        self.assertEqual(clear["dropped"],
+                         ["Ship the deployment guide", "Tune the api rate limits"])
 
     def test_a_cleared_session_is_never_events_empty(self):
         # the exact "No messages yet." lie: the fresh transcript has NOTHING renderable yet

--- a/tests/test_episode_boundary.py
+++ b/tests/test_episode_boundary.py
@@ -132,6 +132,13 @@ class EpisodeBoundaryTest(unittest.TestCase):
         rows = jd.episode_rows(SID)
         self.assertEqual([r["head"] for r in rows], ["root1", "root2"])
         self.assertEqual(rows[1]["fsid"], "aaaaaaaa-0000-0000-0000-000000000001")
+        # the boundary row carries its OWN settle record (the user 2026-07-27): the dropped cards'
+        # ids + titles ride the episodes log, so the feed's bell notice and the chat boundary card
+        # can NAME what the clear took — the settle is never invisible
+        self.assertNotIn("settled", rows[0], "the seeding first observation settles nothing")
+        settled = rows[1].get("settled") or []
+        self.assertEqual({d["id"] for d in settled}, {self.g("g1"), self.g("g3")})
+        self.assertTrue(all(d.get("text") for d in settled), "titles ride along for the notices")
 
         store = jd.load_goals(SID)
         g = self.g
@@ -148,6 +155,26 @@ class EpisodeBoundaryTest(unittest.TestCase):
         rows = self._cleared_rows()
         self.assertEqual({r["id"] for r in rows}, {g("g1"), g("g3")})
         self.assertEqual(len({r["t"] for r in rows}), 1)
+
+    def test_boundary_settle_feeds_the_bell_notice(self):
+        # build_feed ships the newest settled boundary per living session (clearNotices) so the
+        # shell's bell logs the drop exactly once (client seen-set) — a /clear must never take
+        # cards off the board with nothing shown anywhere (the user 2026-07-27)
+        self._store()
+        anchor = self.proj / (SID + ".jsonl")
+        _write_jsonl(anchor, [_rec("root1")])
+        km._episode_boundary_check(SID, str(anchor), NOW)
+        self.assertEqual(km._boundary_clear_notices([{"sid": SID, "name": "web"}]), [],
+                         "a seeded-but-never-cleared session ships no notice")
+        fork = self.proj / "aaaaaaaa-0000-0000-0000-000000000004.jsonl"
+        _write_jsonl(fork, [_rec("root2", ts="2026-01-02T00:00:00Z")])
+        km._episode_boundary_check(SID, str(fork), NOW)
+        notices = km._boundary_clear_notices([{"sid": SID, "name": "web"}])
+        self.assertEqual(len(notices), 1)
+        n = notices[0]
+        self.assertEqual((n["sid"], n["name"]), (SID, "web"))
+        self.assertEqual(set(n["titles"]), {self.g("g1"), self.g("g3")})
+        self.assertTrue(n["t"], "the boundary's own t keys the bell's once-only signature")
 
     def test_resume_fork_is_not_a_boundary(self):
         self._store()

--- a/ui/webview/badge-mirror.test.ts
+++ b/ui/webview/badge-mirror.test.ts
@@ -5,7 +5,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { badgeNotices, type BadgeItem } from "./badge-mirror";
+import { badgeNotices, clearBoundaryNotices, type BadgeItem, type ClearNoticeRow } from "./badge-mirror";
 
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
@@ -56,8 +56,31 @@ test("spend-limit and prompt-too-long blocks say what they are", () => {
   assert.match(tl.text, /prompt too long/);
 });
 
+test("a /clear boundary that dropped cards logs once, naming them and the way back", () => {
+  // the user 2026-07-27: the boundary settle was fully silent — cards left the board with one
+  // stderr line. The bell entry is the durable "you saw it happen" record.
+  const rows: ClearNoticeRow[] = [{ sid: "TESTSID", name: "web", t: 1234,
+    titles: ["ship the notes-api", "tune the rate limits"] }];
+  const first = clearBoundaryNotices(rows, new Set());
+  assert.equal(first.notices.length, 1);
+  assert.equal(first.notices[0].kind, "cleared");
+  assert.match(first.notices[0].text, /^web — \/clear dropped 2 open cards: ship the notes-api, tune the rate limits/);
+  assert.match(first.notices[0].text, /Undo clear/, "the way back is in the entry itself");
+  const again = clearBoundaryNotices(rows, new Set(first.active));
+  assert.equal(again.notices.length, 0, "the same boundary never re-logs across pushes/reloads");
+});
+
+test("a NEWER boundary on the same session is a new entry — its own t keys the signature", () => {
+  const a = clearBoundaryNotices([{ sid: "TESTSID", name: "web", t: 1, titles: ["x"] }], new Set());
+  const b = clearBoundaryNotices([{ sid: "TESTSID", name: "web", t: 2, titles: ["y"] }], new Set(a.active));
+  assert.equal(b.notices.length, 1, "a fresh clear logs afresh");
+  assert.match(b.notices[0].text, /1 open card: y/);
+});
+
 test("the feed posts each notice to the shell and persists only the ACTIVE set", () => {
-  assert.match(FEED, /mirrorBadges\(incomingAsks\);/, "runs on every feed payload, against the FULL list");
+  assert.match(FEED, /mirrorBadges\(incomingAsks, Array\.isArray\(m\.clearNotices\) \? m\.clearNotices : \[\]\)/,
+    "runs on every feed payload, against the FULL list + the kernel's clear notices");
+  assert.match(FEED, /clearBoundaryNotices\(clears, seenSet\)/, "clear drops ride the same seen-set");
   assert.match(FEED, /window\.parent\?\.postMessage\(\{ romp: "notify", kind: n\.kind, text: n\.text \}, "\*"\)/);
   assert.match(FEED, /localStorage\.setItem\(BADGE_SEEN_KEY, JSON\.stringify\(Array\.from\(active\)\)\)/,
     "active-only persistence is what re-arms a cleared badge and bounds the store");

--- a/ui/webview/badge-mirror.ts
+++ b/ui/webview/badge-mirror.ts
@@ -55,3 +55,25 @@ export function badgeNotices(items: BadgeItem[], seen: Set<string>): { notices: 
   }
   return { notices, active };
 }
+
+// A /clear boundary that settled open cards (the kernel's clearNotices payload, read from the
+// episodes log's own settle record). Same episode-identity contract as the badges above: one bell
+// entry per boundary (sid + its t), so a clear that silently dropped cards is always findable in
+// the bell after the fact (the user 2026-07-27). The entry names the dropped cards and the way back
+// (Undo clear restores the batch).
+export interface ClearNoticeRow { sid: string; name: string; t: number; titles: string[]; }
+
+export function clearBoundaryNotices(rows: ClearNoticeRow[], seen: Set<string>): { notices: BadgeNotice[]; active: Set<string> } {
+  const notices: BadgeNotice[] = [];
+  const active = new Set<string>();
+  for (const r of rows) {
+    const sig = "c|" + r.sid + "|" + r.t;
+    active.add(sig);
+    if (seen.has(sig)) continue;
+    const n = r.titles.length;
+    notices.push({ kind: "cleared", sig,
+      text: r.name + " — /clear dropped " + n + " open card" + (n === 1 ? "" : "s") + ": "
+        + cap(r.titles.join(", "), 120) + " (Undo clear on the feed restores them)" });
+  }
+  return { notices, active };
+}

--- a/ui/webview/clear-confirm.test.ts
+++ b/ui/webview/clear-confirm.test.ts
@@ -1,0 +1,66 @@
+// A /clear typed into the composer must never silently drop the session's open cards (the user
+// 2026-07-27): the kernel's episode boundary settles open tops when the conversation clears, and
+// the composer is the one place romp sees the command before it runs. EXECUTES ./clear-confirm;
+// the sendComposer gate, the boundary card's dropped line, and the feed's src-aware clear story
+// are source-pinned (no jsdom for render.ts / feed.ts).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { isClearCmd, openTopTitles, clearConfirmDetail } from "./clear-confirm";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+
+test("isClearCmd mirrors the kernel's _is_clear_cmd truth table", () => {
+  assert.ok(isClearCmd("/clear"));
+  assert.ok(isClearCmd("  /clear  "));
+  assert.ok(isClearCmd("/clear now"));
+  assert.ok(!isClearCmd("/cleared"));
+  assert.ok(!isClearCmd("please /clear"));
+  assert.ok(!isClearCmd("/compact"));
+});
+
+test("openTopTitles counts exactly what the boundary settle takes: open tops, blocked included", () => {
+  const tree = [
+    { depth: 0, done: false, text: "Ship the deployment guide" },
+    { depth: 0, done: false, cleared: false, text: "Tune the api rate limits" },
+    { depth: 1, done: false, text: "a sub-step, not a card" },
+    { depth: 0, done: true, text: "already finished" },
+    { depth: 0, done: false, cleared: true, text: "already dismissed" },
+  ];
+  assert.deepEqual(openTopTitles(tree), ["Ship the deployment guide", "Tune the api rate limits"]);
+  assert.deepEqual(openTopTitles(undefined), [], "no ledger yet → no titles → no modal");
+});
+
+test("the confirm detail: null with nothing open; singular/plural; long lists capped", () => {
+  assert.equal(clearConfirmDetail([]), null, "no open cards → no modal, the /clear just sends");
+  assert.match(clearConfirmDetail(["one card"])!, /Its 1 open card gets dropped with it: one card/);
+  const two = clearConfirmDetail(["a", "b"])!;
+  assert.match(two, /Its 2 open cards get dropped with it: a, b/);
+  assert.match(two, /Undo clear/, "the way back is named in the same breath");
+  const long = clearConfirmDetail(Array.from({ length: 30 }, (_, i) => "card number " + i))!;
+  assert.ok(long.length < 400, "the titles list is capped so the modal stays readable");
+  assert.match(long, /…/);
+});
+
+test("sendComposer gates a /clear behind showConfirm — Cancel first (safe default), send only on confirm", () => {
+  const at = RENDER.indexOf("const dropDetail");
+  assert.ok(at > 0, "the gate exists in sendComposer");
+  const gate = RENDER.slice(at, at + 700);
+  assert.match(gate, /isClearCmd\(text\) \? clearConfirmDetail\(openTopTitles\(ledgers\.get\(sid\)\?\.tree\)\) : null/);
+  assert.match(gate, /showConfirm\("Clear this conversation\?"/);
+  assert.match(gate, /\{ label: "Cancel", value: "cancel" \}, \{ label: "Clear anyway", value: "clear", danger: true \}/);
+  assert.match(gate, /if \(v === "clear"\) deliver\(\)/);
+  // the deliver closure is pinned to the session the confirm was armed for
+  assert.match(RENDER, /if \(activeId !== sid\) return;/);
+});
+
+test("the chat boundary card counts the dropped cards, and hover names them", () => {
+  assert.match(RENDER, /" open card" \+ \(dropped\.length === 1 \? "" : "s"\) \+ " dropped with it"/);
+  assert.match(RENDER, /setAttribute\("title", "dropped: " \+ dropped\.join\(", "\)\)/);
+});
+
+test("the feed's per-node clear story is src-aware — a romp boundary clear is not blamed on the user", () => {
+  assert.match(FEED, /r\.src === "romp" \? "dropped with the cleared conversation" : "you cleared it"/);
+});

--- a/ui/webview/clear-confirm.ts
+++ b/ui/webview/clear-confirm.ts
@@ -1,0 +1,31 @@
+// A typed /clear ends the conversation, and the kernel's episode boundary then settles the
+// session's open cards with it (plans/clear-episodes.md). The chat composer is the one place romp
+// sees the command BEFORE it runs, so it must never pass silently while open cards exist (the user
+// 2026-07-27): sendComposer gates the send on an explicit confirm when clearConfirmDetail returns a
+// detail. Pure helpers here so the gate's logic is node-testable without the DOM.
+
+// mirrors the kernel's _is_clear_cmd (sdk_backend.py) — the same truth table, client-side
+export function isClearCmd(text: string): boolean {
+  const t = text.trim();
+  return t === "/clear" || t.startsWith("/clear ");
+}
+
+export interface OpenCardNode { depth: number; done: boolean; cleared?: boolean; text: string; }
+
+// The open TOP-level cards a /clear would drop — the same population the kernel's boundary settle
+// takes (open tops only; completed stay, already-cleared are gone). Blocked tops count: they are
+// open, and dropping an owed question is exactly the silent loss the gate exists to stop.
+export function openTopTitles(tree: OpenCardNode[] | undefined | null): string[] {
+  return (tree || []).filter((n) => n.depth === 0 && !n.done && !n.cleared).map((n) => n.text);
+}
+
+// The confirm modal's detail line, or null when no confirm is needed (nothing open to drop).
+export function clearConfirmDetail(titles: string[]): string | null {
+  if (!titles.length) return null;
+  const list = titles.join(", ");
+  const shown = list.length > 140 ? list.slice(0, 139) + "…" : list;
+  const n = titles.length;
+  return (n === 1 ? "Its 1 open card gets dropped with it: " : "Its " + n + " open cards get dropped with it: ")
+    + shown
+    + ". Undo clear on the feed restores the cards, but the agent will no longer remember the work behind them.";
+}

--- a/ui/webview/clear-divider.test.ts
+++ b/ui/webview/clear-divider.test.ts
@@ -21,7 +21,7 @@ const SDK = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_bac
 const TL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
 
 test("the ChatEvent union carries both /clear kinds, dispatched to their renderers", () => {
-  assert.match(RENDER, /\| \{ kind: "clear"; clearedAt\?: number; episodes\?: number; ts\?: string; uuid\?: string \}/);
+  assert.match(RENDER, /\| \{ kind: "clear"; clearedAt\?: number; episodes\?: number; ts\?: string; uuid\?: string; dropped\?: string\[\] \}/);
   assert.match(RENDER, /\| \{ kind: "clearing"; ts\?: string; uuid\?: string \}/);
   assert.match(RENDER, /if \(ev\.kind === "clearing"\) return renderClearing\(\);/);
   assert.match(RENDER, /if \(ev\.kind === "clear"\) return renderClear\(ev\);/);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -13,7 +13,7 @@ import { hostNameNodes, hostPartsNodes } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
 import { provenanceRows, provenanceGroupRows, rootStart, type ProvFmt, type ProvRow } from "./provenance";
 import { ageColorReadable } from "./age-color";
-import { badgeNotices } from "./badge-mirror";
+import { badgeNotices, clearBoundaryNotices, type ClearNoticeRow } from "./badge-mirror";
 import { initStrip } from "./strip";
 import { installSettingsSync } from "./settings";
 import { previewThumb, previewKind } from "./preview";
@@ -1682,7 +1682,9 @@ function logPhrase(r: NodeLogRow): string {
   if (r.kind === "unblock") return r.src === "user" ? "you answered" : "unblocked";
   if (r.kind === "done") return r.src === "user" ? "you checked it off" : "marked done";
   if (r.kind === "reopen") return "reopened";
-  if (r.kind === "clear") return "you cleared it";
+  // a clear is only "you" when the user did it — the episode boundary clears with src "romp"
+  // when a /clear drops the conversation's open cards (the user 2026-07-27)
+  if (r.kind === "clear") return r.src === "romp" ? "dropped with the cleared conversation" : "you cleared it";
   if (r.kind === "dismiss") return "dismissed";
   if (r.kind === "settle") return "settled";
   return r.kind || "updated";
@@ -3085,13 +3087,18 @@ function pipeBanner(up: boolean, queued: number): void {
 // the {romp:'notify'} post the shell's bell listens for. Storing only the ACTIVE set is what re-arms a
 // cleared badge and keeps the store from growing: a card that left the payload takes its sigs with it.
 const BADGE_SEEN_KEY = "romp:cardNotified";
-function mirrorBadges(items: AskItem[]): void {
+function mirrorBadges(items: AskItem[], clears: ClearNoticeRow[]): void {
   let seen: string[] = [];
   try { seen = JSON.parse(localStorage.getItem(BADGE_SEEN_KEY) || "[]"); } catch { /* fresh */ }
-  const { notices, active } = badgeNotices(items, new Set(seen));
-  for (const n of notices) {
+  const seenSet = new Set(seen);
+  const badges = badgeNotices(items, seenSet);
+  // /clear boundary settles share the same seen-set + bell (the user 2026-07-27): a clear that
+  // dropped open cards logs one durable entry naming them, so the drop is never silent.
+  const boundary = clearBoundaryNotices(clears, seenSet);
+  for (const n of [...badges.notices, ...boundary.notices]) {
     try { window.parent?.postMessage({ romp: "notify", kind: n.kind, text: n.text }, "*"); } catch { /* no shell (VS Code view) */ }
   }
+  const active = new Set([...badges.active, ...boundary.active]);
   try { localStorage.setItem(BADGE_SEEN_KEY, JSON.stringify(Array.from(active))); } catch { /* storage full */ }
 }
 
@@ -3133,7 +3140,7 @@ window.addEventListener("message", (e: MessageEvent) => {
     bgServicesMap = m.bgServices && typeof m.bgServices === "object" ? m.bgServices : {};   // session name -> judge-classified service descs → the session-header chip (2026-07-24)
     if (Array.isArray(m.order)) sessionOrder = m.order.filter((x: any) => typeof x === "string");   // grouped-mode session rank (tab/lane order)
     hostNow = typeof m.now === "number" ? m.now : Math.floor(Date.now() / 1000);
-    mirrorBadges(incomingAsks);   // card trouble chips also log in the shell's bell (chips stay on the cards)
+    mirrorBadges(incomingAsks, Array.isArray(m.clearNotices) ? m.clearNotices : []);   // card trouble chips + /clear drops also log in the shell's bell (chips stay on the cards)
     if (typeof m.dismissedCount === "number") dismissedCount = m.dismissedCount;
     if (typeof m.showDismissed === "boolean") showDismissed = m.showDismissed;
     if (typeof m.canUndoClear === "boolean") canUndoClear = m.canUndoClear;

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -17,6 +17,7 @@ import { markerLabel } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
 import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompSettings } from "./settings";
 import { delegate } from "./actions";
+import { isClearCmd, openTopTitles, clearConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
 import { reconcileTabOrder } from "./tab-order";
 import { onlyTag, matchesOnly } from "./only-filter";
@@ -130,7 +131,7 @@ type ChatEvent = (
   // chat twin of the timeline's film-splice seam. Its body lazy-loads the PRE-CLEAR conversation on first
   // expand (loadEpisode → chatEpisode, cached per boundary), so the cleared history stays one click away
   // instead of vanishing. `uuid` is "clear:<episode head>" — stable across pushes (the fold key).
-  | { kind: "clear"; clearedAt?: number; episodes?: number; ts?: string; uuid?: string }
+  | { kind: "clear"; clearedAt?: number; episodes?: number; ts?: string; uuid?: string; dropped?: string[] }
   // LIVE /clear in progress (kernel-driven, event-based off the SDK backend's clearing bracket): an
   // animated "Clearing conversation…" element between the /clear delivery and the fresh transcript
   // landing — a stretch that otherwise has NO observable state and used to render as a dead gap, then
@@ -2023,7 +2024,11 @@ function fillClearBody(body: HTMLElement, got: { events: ChatEvent[]; truncated?
 function renderClear(ev: Extract<ChatEvent, { kind: "clear" }>): HTMLElement {
   const sid = renderingSid || "";
   const key = "clear:" + (ev.uuid || sid);
-  const head = "Conversation cleared — a fresh one starts here";
+  // the boundary settle's own record rides the event: the head counts the dropped cards, hover
+  // names them — the drop is visible in the chat too, never only in the feed (the user 2026-07-27)
+  const dropped = ev.dropped || [];
+  const head = "Conversation cleared — a fresh one starts here"
+    + (dropped.length ? " · " + dropped.length + " open card" + (dropped.length === 1 ? "" : "s") + " dropped with it" : "");
   const body = el("div", "clear-body");
   body.dataset.clearKey = key;
   const cached = episodeCache.get(key);
@@ -2037,6 +2042,7 @@ function renderClear(ev: Extract<ChatEvent, { kind: "clear" }>): HTMLElement {
     body.appendChild(p);
   }
   const turn = noticeCard({ variant: "clear", chip: "cleared", head, body, collapsible: true, key });
+  if (dropped.length) turn.querySelector(".notice-head")?.setAttribute("title", "dropped: " + dropped.join(", "));
   // Fetch on FIRST expand (ride the same head click that toggles the fold — noticeCard owns the toggle):
   // one request per boundary, deduped by the pending map; re-renders hit the cache instead.
   const headEl = turn.querySelector(".notice-head");
@@ -6902,27 +6908,43 @@ function setupComposer() {
       ta.value = ""; composerManualH = null; ta.style.height = "";
       return;
     }
-    lastSent.set(activeId, text);   // remembered for a possible Ctrl+C restore
-    // A pending citation chip → send as a FOLLOW-UP on that goal (the user 2026-07-01): askFollowUp wraps the
-    // text with the goal's context + the romp-goal-id marker (kernel side), so the goal reopens (done→working,
-    // unless cleared) and the chat renders the ↩ Follow-up header — the same path the Follow-up button uses,
-    // just seeded by the click. A QUOTE chip (highlighted transcript text, the user 2026-07-13) has no goal:
-    // it wraps client-side (quoteReplyBody) into a plain message. No chip → plain sendMessage.
-    const cite = composerCitations.get(activeId);
-    if (vscodeApi) {
-      if (cite?.itemId) vscodeApi.postMessage({ type: "askFollowUp", itemId: cite.itemId, text });
-      else if (cite?.quote) vscodeApi.postMessage({ type: "sendMessage", id: activeId, text: quoteReplyBody(cite.quote, text, cite.src) });
-      else { vscodeApi.postMessage({ type: "sendMessage", id: activeId, text }); registerOptimistic(activeId, text); }
-      // (a citation follow-up/quote has its own kernel-side echo path; the optimistic bubble covers the plain send)
+    const sid = activeId;   // the session this send (and any confirm below) was armed for
+    const deliver = () => {
+      if (activeId !== sid) return;   // a confirm outlived a tab switch — never send into the wrong session
+      lastSent.set(activeId, text);   // remembered for a possible Ctrl+C restore
+      // A pending citation chip → send as a FOLLOW-UP on that goal (the user 2026-07-01): askFollowUp wraps the
+      // text with the goal's context + the romp-goal-id marker (kernel side), so the goal reopens (done→working,
+      // unless cleared) and the chat renders the ↩ Follow-up header — the same path the Follow-up button uses,
+      // just seeded by the click. A QUOTE chip (highlighted transcript text, the user 2026-07-13) has no goal:
+      // it wraps client-side (quoteReplyBody) into a plain message. No chip → plain sendMessage.
+      const cite = composerCitations.get(activeId);
+      if (vscodeApi) {
+        if (cite?.itemId) vscodeApi.postMessage({ type: "askFollowUp", itemId: cite.itemId, text });
+        else if (cite?.quote) vscodeApi.postMessage({ type: "sendMessage", id: activeId, text: quoteReplyBody(cite.quote, text, cite.src) });
+        else { vscodeApi.postMessage({ type: "sendMessage", id: activeId, text }); registerOptimistic(activeId, text); }
+        // (a citation follow-up/quote has its own kernel-side echo path; the optimistic bubble covers the plain send)
+      }
+      if (cite) { composerCitations.delete(activeId); renderComposerChips(activeId); }   // consumed on send
+      drafts.delete(activeId); draftStartedAt.delete(activeId); persistDrafts();   // sent — no draft to restore on a later switch-back
+      ta.value = "";
+      composerManualH = null;   // a drag-expanded box snaps back to one line after a send (the user 2026-07-07)
+      ta.style.height = "";
+      // The box is empty again, so a live picker re-takes it: send your pre-question draft, then just type the
+      // answer (the user 2026-07-16). Repaints the "answering" tint that draftPredatesAsk had suppressed.
+      setComposerAskMode();
+    };
+    // A typed /clear ends the conversation, and the kernel's episode boundary then settles the
+    // session's open cards with it. The composer sees the command BEFORE it runs — the one
+    // interception point — so open cards put an explicit confirm between Enter and the drop
+    // (the user 2026-07-27). Cancel keeps the text in the box; no open cards → no modal.
+    const dropDetail = isClearCmd(text) ? clearConfirmDetail(openTopTitles(ledgers.get(sid)?.tree)) : null;
+    if (dropDetail) {
+      showConfirm("Clear this conversation?", dropDetail,
+        [{ label: "Cancel", value: "cancel" }, { label: "Clear anyway", value: "clear", danger: true }],
+        (v) => { if (v === "clear") deliver(); });
+      return;
     }
-    if (cite) { composerCitations.delete(activeId); renderComposerChips(activeId); }   // consumed on send
-    drafts.delete(activeId); draftStartedAt.delete(activeId); persistDrafts();   // sent — no draft to restore on a later switch-back
-    ta.value = "";
-    composerManualH = null;   // a drag-expanded box snaps back to one line after a send (the user 2026-07-07)
-    ta.style.height = "";
-    // The box is empty again, so a live picker re-takes it: send your pre-question draft, then just type the
-    // answer (the user 2026-07-16). Repaints the "answering" tint that draftPredatesAsk had suppressed.
-    setComposerAskMode();
+    deliver();
   };
   // an explicit send button on the right of the box (touch devices have no easy ⏎; desktop gets a click
   // affordance too). mousedown, not click, so the textarea keeps focus and a follow-up keeps typing.


### PR DESCRIPTION
Since the episode-boundary commit, a /clear settled the session's open cards off the board with one stderr line: no UI trace, the feed attributed the romp-authored clear to the user ("you cleared it"), and a /clear typed into the composer sailed through with no warning.

- **The settle record rides the episode row**: the boundary writes `settled [{id, text}]` into its own `episodes/<sid>.jsonl` row — the durable, authoritative record of what the clear took.
- **The bell logs the drop once**: `build_feed` ships the newest settled boundary per living session (`clearNotices`); the feed mirrors each into the shell's notification bell through the badge-mirror seen-set, naming the dropped cards and the Undo-clear way back.
- **The chat boundary card counts and names them**: "Conversation cleared … N open cards dropped with it", titles on hover.
- **The composer confirms first**: /clear typed into the chat composer — the one place romp sees the command before it runs — now raises an explicit confirm when open cards exist (Cancel default-focused, "Clear anyway" danger). Pure helpers in `ui/webview/clear-confirm.ts` mirror the kernel's `_is_clear_cmd` truth table and the settle's open-tops population; the deliver closure is pinned to the session the confirm was armed for.
- **Src-aware clear story**: a boundary clear reads "dropped with the cleared conversation", no longer "you cleared it".
- `plans/clear-episodes.md` gains the visibility section and corrects its archived-search claim (`_fleet_archived_tops` deliberately excludes bare dismissals; the settle record + tab-hover Recent + Undo are the recovery surfaces).

Tests: the boundary row's settle record, the `clearNotices` helper, the boundary card's dropped titles, `clearBoundaryNotices` once-only bell entries, and source pins for the composer gate + src-aware story. Both suites green (3258 py, 1363 node) + tsc typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)