### PR TITLE
romp sessions: the fleet's state for scripts, from the kernel instead of tmux

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -597,6 +597,7 @@ Quitting Claude ends a terminal session (it's exec'd; no shell lingers).
 For scripts / agents:
 EOF
     _romp_cmd "romp url"                   -            "Print ONLY the tokened dashboard URL (for scripts; humans just run \`romp\`)"
+    _romp_cmd "romp sessions [--json]"     -            "List the fleet with each session's state, colours and backend"
     _romp_cmd "romp mail ..."              romp-postal-service  "Romp Postal Service: send <to> <text> | inbox | agents | remote"
     _romp_cmd "romp send <session> <text>" -            "Hand a session a message (kernel API, either backend)"
     _romp_cmd "romp interrupt <session>"   -            "Interrupt a session's current turn"
@@ -693,6 +694,45 @@ if [[ "${1:-}" == "url" || "${1:-}" == "--url" ]]; then
         echo "romp url: no serve token yet (start romp first — the kernel mints it)" >&2; exit 1
     fi
     echo "http://127.0.0.1:${ROMP_KERNEL_PORT:-29855}/?token=$_tok"
+    exit 0
+fi
+
+# `romp sessions [--json]` — the fleet's live state for SCRIPTS, read from the kernel, which owns it.
+# Before this the only machine-readable source of per-session state and identity colour was the tmux
+# table (@claude-state, @identity-bg/@identity-fg), which an external tool could read directly. That
+# stopped working the moment sessions moved to the SDK backend: they never enter tmux, so
+# `tmux list-sessions` returns nothing and every such consumer silently degraded to empty output
+# (found 2026-07-27 in a downstream editor extension whose status dots and colours just vanished).
+# Reading the authoritative store instead of a side effect of one backend is the repo's standing
+# rule, and it is the only source that covers both backends.
+#
+# --json emits the kernel's rows verbatim (id, name, state, dir, bg, fg, backend, working, lastSid);
+# bare prints one aligned line per session. A dead kernel fails LOUDLY rather than printing an empty
+# list, which would read as "no sessions" and hide the breakage this command exists to end.
+if [[ "${1:-}" == "sessions" ]]; then
+    shift
+    _json=false
+    case "${1:-}" in
+        --json) _json=true; shift ;;
+        "")     ;;
+        *)      echo "usage: romp sessions [--json]" >&2; exit 2 ;;
+    esac
+    _kport="${ROMP_KERNEL_PORT:-29855}"
+    _resp="$(curl -sf -m 10 "http://127.0.0.1:$_kport/sessions" -H "X-Romp-Token: $(_romp_token)")" \
+        || { echo "romp sessions: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+    if $_json; then
+        printf '%s\n' "$_resp"
+        exit 0
+    fi
+    printf '%s' "$_resp" | python3 -c '
+import json, sys
+rows = json.load(sys.stdin)
+rows = rows.get("sessions", rows) if isinstance(rows, dict) else rows
+w = max([len(r.get("name") or "") for r in rows] or [4])
+for r in rows:
+    print("%-*s  %-10s  %-5s  %s" % (w, r.get("name") or "", r.get("state") or "",
+                                     r.get("backend") or "", r.get("dir") or ""))
+'
     exit 0
 fi
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -34,6 +34,7 @@ These are for scripting and for agents rather than daily use:
 | Command | What it does |
 |---|---|
 | `romp url` | Print only the tokened dashboard URL, for piping |
+| `romp sessions [--json]` | The fleet with each session's state, identity colours, directory and backend |
 | `romp mail …` | The postal service from the shell (below) |
 | `romp send <session> <text>` | Hand a session a message, on either backend |
 | `romp interrupt <session>` | Interrupt whatever turn a session is taking |

--- a/tests/romp-sessions.bats
+++ b/tests/romp-sessions.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+# `romp sessions [--json]` — the fleet's live state for scripts, read from the kernel.
+#
+# It exists because the only machine-readable source of per-session state and identity colour
+# used to be the tmux table (@claude-state, @identity-bg/@identity-fg). SDK sessions never enter
+# tmux, so once they became the default `tmux list-sessions` returned nothing and every external
+# consumer silently degraded to empty output. The kernel owns this state for BOTH backends, so
+# that is what this reads — and a dead kernel must fail loudly rather than print an empty list,
+# which would read as "no sessions" and hide exactly the breakage this command ends.
+
+ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export XDG_STATE_HOME="$TEST_DIR/state"
+    mkdir -p "$XDG_STATE_HOME/romp"
+    printf 'TESTTOKEN123\n' > "$XDG_STATE_HOME/romp/serve-token"
+    export ROMP_KERNEL_PORT=29855
+
+    # Stub curl: records the request, replies with a two-session fleet. Nothing touches a real
+    # kernel, so the suite is safe to run beside a live one.
+    MOCK="$TEST_DIR/mock"; mkdir -p "$MOCK"
+    export CURL_LOG="$TEST_DIR/curl.log"
+    export FLEET_JSON="$TEST_DIR/fleet.json"
+    cat > "$FLEET_JSON" <<'JSON'
+{"sessions": [
+  {"id": "11111111-2222-3333-4444-555555555555", "name": "web", "state": "working",
+   "dir": "/tmp/notes-api", "bg": "#1EA1EB", "fg": "black", "backend": "sdk", "working": ""},
+  {"id": "66666666-7777-8888-9999-000000000000", "name": "api", "state": "waiting",
+   "dir": "/tmp/notes-api", "bg": "#54B204", "fg": "black", "backend": "tmux", "working": ""}
+]}
+JSON
+    cat > "$MOCK/curl" <<'MOCK'
+#!/usr/bin/env bash
+echo "$*" >> "$CURL_LOG"
+[ -n "${CURL_FAIL:-}" ] && exit 22
+cat "$FLEET_JSON"
+MOCK
+    chmod +x "$MOCK/curl"
+    export PATH="$MOCK:$PATH"
+}
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+@test "romp sessions: prints a line per session with state and backend" {
+    run "$ROMP_SCRIPT" sessions
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"web"* ]]
+    [[ "$output" == *"working"* ]]
+    [[ "$output" == *"api"* ]]
+    [[ "$output" == *"waiting"* ]]
+}
+
+@test "romp sessions: covers BOTH backends, which is the point of not reading tmux" {
+    run "$ROMP_SCRIPT" sessions
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"sdk"* ]]
+    [[ "$output" == *"tmux"* ]]
+}
+
+@test "romp sessions --json: emits the kernel's rows verbatim, colours included" {
+    run "$ROMP_SCRIPT" sessions --json
+    [ "$status" -eq 0 ]
+    # the identity colours an external consumer used to read from @identity-bg
+    [[ "$output" == *"#1EA1EB"* ]]
+    [[ "$output" == *"#54B204"* ]]
+    echo "$output" | python3 -c 'import json,sys; assert len(json.load(sys.stdin)["sessions"]) == 2'
+}
+
+@test "romp sessions: reads the KERNEL, authorizing with the serve token" {
+    run "$ROMP_SCRIPT" sessions
+    [ "$status" -eq 0 ]
+    grep -q "127.0.0.1:29855/sessions" "$CURL_LOG"
+    grep -q "TESTTOKEN123" "$CURL_LOG"
+}
+
+@test "romp sessions: a dead kernel fails LOUDLY, never an empty list read as no sessions" {
+    CURL_FAIL=1 run "$ROMP_SCRIPT" sessions
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"kernel not reachable"* ]]
+}
+
+@test "romp sessions: an unknown flag is refused rather than silently ignored" {
+    run "$ROMP_SCRIPT" sessions --nope
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp sessions"* ]]
+}
+
+@test "romp sessions: listed in help, under the scripting group" {
+    run "$ROMP_SCRIPT" help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"romp sessions"* ]]
+}


### PR DESCRIPTION
**The breakage.** An external tool wanting per-session state or identity colour
had exactly one machine-readable source: the tmux table (`@claude-state`,
`@identity-bg`, `@identity-fg`). SDK sessions never enter tmux, so once they
became the default `tmux list-sessions` returned nothing, exit 0, and every such
consumer degraded to empty output with no error at all. Confirmed on this
machine: `romp --mail agents` lists 12 sessions, `tmux list-sessions` lists
none, with one server and one socket, so it is not a `-L`/`-S` mismatch. Found
downstream in an editor extension whose status dots and identity colours had
silently vanished.

**The fix.** The kernel owns this state for both backends, so `romp sessions`
reads it there rather than from a side effect of one backend. That is the
repo's authoritative-source rule, and it is also the only source that covers
tmux and SDK sessions alike.

```
romp sessions            # name, state, backend, dir — one aligned line each
romp sessions --json     # the kernel's rows verbatim: id, name, state, dir, bg, fg, backend, …
```

A dead kernel exits non-zero with "kernel not reachable" rather than printing an
empty list. That matters here specifically: "no sessions" is precisely the
disguise the original breakage wore, and a command introduced to end that class
of silent failure must not be able to reproduce it.

`tests/romp-sessions.bats`, 7 tests, curl stubbed so nothing touches a live
kernel. Covers both backends in one listing, colours surviving `--json`, the
token being sent, the loud failure, and an unknown flag being refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)