### PR TITLE
Document the two traps in romp sessions --json: waiting is at rest, id is the key

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -709,6 +709,20 @@ fi
 # --json emits the kernel's rows verbatim (id, name, state, dir, bg, fg, backend, working, lastSid);
 # bare prints one aligned line per session. A dead kernel fails LOUDLY rather than printing an empty
 # list, which would read as "no sessions" and hide the breakage this command exists to end.
+#
+# TWO TRAPS for a consumer, both found the hard way (2026-07-27, the downstream editor extension):
+#
+#   * `waiting` is AT REST, not attention-needed. It is the ordinary state of a session sitting
+#     there having finished its turn, and it is what most of the fleet reads most of the time.
+#     Substring-matching /wait/ into an alert paints a "needs you" badge on every idle session,
+#     which is worse than the blank it replaced. The states that DO want the user are `awaiting`
+#     (a permission prompt) and `blocked`. See bin/romp-dashboard, which groups
+#     waiting|idle as at rest.
+#   * `id` is the durable key, NOT `lastSid`. Every per-session store romp keeps (states/,
+#     captions/, goals/, episodes/) is filed under `id`. `lastSid` is the live Claude Code
+#     transcript's fsid, which FORKS on /clear — it is what the old tmux @romp-session-id
+#     tracked, being re-anchored per fork, so it is the natural guess and the wrong one. On a
+#     fleet of 11 here, all 11 had records under `id` and only 6 under `lastSid`.
 if [[ "${1:-}" == "sessions" ]]; then
     shift
     _json=false

--- a/bin/romp
+++ b/bin/romp
@@ -722,7 +722,10 @@ fi
 #     captions/, goals/, episodes/) is filed under `id`. `lastSid` is the live Claude Code
 #     transcript's fsid, which FORKS on /clear — it is what the old tmux @romp-session-id
 #     tracked, being re-anchored per fork, so it is the natural guess and the wrong one. On a
-#     fleet of 11 here, all 11 had records under `id` and only 6 under `lastSid`.
+#     fleet of 11 here, all 11 had records under `id` and only 6 under `lastSid`. That key opens
+#     the per-turn one-liners at captions/<id>.jsonl, text under `caption` (the record's OWN `id`
+#     is the turn's, not the session's). There is no summaries/ any more — the old path returns
+#     nothing rather than erroring, so a consumer on it shows blank text and mtime 0 forever.
 if [[ "${1:-}" == "sessions" ]]; then
     shift
     _json=false

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -53,6 +53,13 @@ that want a person are `awaiting`, a permission prompt, and `blocked`. And
 keyed by `id`, while `lastSid` is the live transcript's id and forks on
 `/clear`.
 
+That key opens the per-session records under `~/.local/state/romp/`. The
+per-turn one-liners live in `captions/<id>.jsonl`, one JSON record a line, with
+the text under `caption`. A record's own `id` field is not the session's: it
+identifies the turn within it. There is no `summaries/` directory; an older
+layout had one, and reading it fails silently, since a missing directory just
+yields nothing rather than an error.
+
 ## The Romp Postal Service
 
 How sessions message each other, from either side. Inside a session it is an MCP

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -45,6 +45,14 @@ These are for scripting and for agents rather than daily use:
 | `romp resume <id> [--name <n>] [--detach]` | Resume one exact conversation by UUID |
 | `romp refresh --now` | Refresh without waiting for sessions to finish their turns |
 
+Two things to know before building on `romp sessions --json`. **`waiting` means
+at rest**, the ordinary state of a session that has finished its turn, so
+matching it as an alert badges the whole idle fleet as needing you; the states
+that want a person are `awaiting`, a permission prompt, and `blocked`. And
+**`id` is the durable key**, not `lastSid`: everything Romp files per session is
+keyed by `id`, while `lastSid` is the live transcript's id and forks on
+`/clear`.
+
 ## The Romp Postal Service
 
 How sessions message each other, from either side. Inside a session it is an MCP


### PR DESCRIPTION
A downstream consumer hit both of these within an hour of #81 landing, so
they belong next to the command rather than in a merged PR's description.

**`waiting` is at rest, not attention-needed.** It is the ordinary state of a
session that has finished its turn, and most of the fleet sits in it most of the
time. A consumer substring-matching `/wait/` into an alert painted the red
"needs you" dot on all 11 idle sessions, strictly worse than the blank dots it
replaced. The states that do want a person are `awaiting` (a permission prompt)
and `blocked`. `bin/romp-dashboard:343` already groups `waiting|idle` as at
rest, which is how they caught it.

**`id` is the durable key, not `lastSid`.** Measured on the local fleet: all 11
sessions have records under `id` in `states/`, `captions/`, `goals/` and
`episodes/`; only 6 do under `lastSid`, and those are exactly the 6 where the
two happen to be equal. `lastSid` is the live Claude Code transcript's fsid and
forks on `/clear`. It is a natural guess precisely because the old tmux
`@romp-session-id` tracked that fsid, re-anchored per fork
(`hooks/tmux-status.sh:106`), so anyone porting from the tmux vars will reach
for it.

Both go in the `bin/romp` comment block and, in shorter form, in
`docs/reference.md`.

Strict build clean; `tests/romp-sessions.bats` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)