### PR TITLE
Federation: host identity dedupe, trust-change feedback, two-way sync over the attach tunnel

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14783,6 +14783,13 @@ function mruHost(){try{return localStorage.getItem('romp:lastRemoteHost')||'';}c
 // set of machines you can reach. Hosts you attached before are the other source, and that is what makes a
 // typed-in host stick: attaching records it in remotes-known.json, so it completes from then on.
 var _cfg=[],_seen=[];
+// A trust change (and a Match, which crosses the tunnel and confirms only on the peer's next tier
+// gossip) takes real time, and the popover re-renders every poll — so a snapshot fetched BEFORE the
+// change repainted the OLD level after it, which read as "didn't hold" and invited a second click
+// (the user 2026-07-27). Pending is keyed per host and survives re-renders: rows show the CHOSEN
+// level, disabled with an applying cue, until a snapshot agrees (the confirming EVENT — no timer).
+var _pendTrust={},_pendMirror={};
+function pendLvl(map,host,current){var p=map[host];if(p&&current===p){delete map[host];p=null;}return p;}
 function fillHosts(){if(!dl)return;var hs=[];
 [[mruHost()],_seen,_cfg].forEach(function(g){(g||[]).forEach(function(h){if(h&&hs.indexOf(h)<0)hs.push(h);});});   // most-recently-connected first, not just ssh-config order
 dl.innerHTML=hs.map(function(h){return '<option value=\"'+h+'\"></option>';}).join('');}
@@ -14889,9 +14896,10 @@ var keep=(pmode&&!t.checkinPeer)?'<label class=rnet-keep title=\"Publish this ma
 // your approval, never auto-injected; isolated = dashboard only, no postal. The gate lives in the bus.
 // Each option carries its own plain gloss: the bare words are romp's vocabulary, not English, and a
 // dropdown whose meaning only appears on hover makes you uncover every option before you can choose.
-var tcur=t.trust||'directed';
-var trust='<span class=rnet-set><span class=rnet-lbl>Their mail</span><select class=rnet-trust data-t=\"'+t.host+'\" title=\"What happens to postal mail from '+t.host+'. trusted: delivered straight to your sessions. directed: held for your approval. isolated: none, dashboard only.\">'+
-['trusted','directed','isolated'].map(function(v){return '<option value='+v+(tcur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select></span>';
+var tpd=pendLvl(_pendTrust,t.host,t.trust||'directed');
+var tcur=tpd||t.trust||'directed';
+var trust='<span class=rnet-set><span class=rnet-lbl>Their mail</span><select class=\"rnet-trust'+(tpd?' rnet-applying':'')+'\"'+(tpd?' disabled':'')+' data-t=\"'+t.host+'\" title=\"What happens to postal mail from '+t.host+'. trusted: delivered straight to your sessions. directed: held for your approval. isolated: none, dashboard only.\">'+
+['trusted','directed','isolated'].map(function(v){return '<option value='+v+(tcur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select>'+(tpd?'<span class=rnet-pend>applying\\u2026</span>':'')+'</span>';
 // The OTHER direction of the pair (how that host holds mail FROM this machine, declared by its bus on
 // the last exchange). Trust is receiver-evaluated on purpose, so a half-open pair is legal — but it
 // used to be invisible until mail quarantined over there (the user 2026-07-26). A mismatch offers
@@ -14899,8 +14907,10 @@ var trust='<span class=rnet-set><span class=rnet-lbl>Their mail</span><select cl
 // your trust, and this machine never lets one.
 var theirs=tiers[t.host]||'';
 if(theirs){var mm=theirs!==tcur;
-trust+='<span class=\"rnet-back'+(mm?' rnet-mismatch':'')+'\" title=\"How '+t.host+' holds mail from this machine, as its bus declared on the last exchange. Each side owns its own gate.\">'+t.host+' holds yours: '+theirs+'</span>';
-if(mm){trust+='<button class=rnet-mirror data-m=\"'+t.host+'\" title=\"Set '+t.host+'\\u2019s level for this machine to '+tcur+' too. This is your admin access (the tunnel + that machine\\u2019s own token) acting on its kernel \\u2014 a peer can never set your trust, and this never lets one.\">Match ('+tcur+')</button>';}}
+var mpd=pendLvl(_pendMirror,t.host,theirs);   // confirmed by the peer's next tier gossip, not the POST
+trust+='<span class=\"rnet-back'+(mm&&!mpd?' rnet-mismatch':'')+'\" title=\"How '+t.host+' holds mail from this machine, as its bus declared on the last exchange. Each side owns its own gate.\">'+t.host+' holds yours: '+theirs+'</span>';
+if(mpd){trust+='<button class=rnet-mirror disabled title=\"Set on '+t.host+'; waiting for its bus to confirm on the next exchange.\">Matching\\u2026</button>';}
+else if(mm){trust+='<button class=rnet-mirror data-m=\"'+t.host+'\" data-lvl=\"'+tcur+'\" title=\"Set '+t.host+'\\u2019s level for this machine to '+tcur+' too. This is your admin access (the tunnel + that machine\\u2019s own token) acting on its kernel \\u2014 a peer can never set your trust, and this never lets one.\">Match ('+tcur+')</button>';}}
 // Line 1 is what this host is doing right now plus the acts you perform on it; line 2 is the pair of
 // settings you set once and leave. They shared a single flat row before, which gave Detach the same
 // weight as a dropdown, and on a phone pushed it off the edge entirely.
@@ -14926,12 +14936,13 @@ if(known.length){var hd=document.createElement('div');hd.className='rnet-khead';
 hd.textContent='Previously attached';hd.title='Hosts you have attached before. They keep the trust level you last chose, so re-attaching restores it. Forget removes a host from this list.';
 list.appendChild(hd);
 known.forEach(function(k){var kr=document.createElement('div');kr.className='rnet-row rnet-known';
-var kcur=k.trust||'directed';
+var kpd=pendLvl(_pendTrust,k.host,k.trust||'directed');
+var kcur=kpd||k.trust||'directed';
 // The SAME trust select as an attached row (data-t → /tunnels/trust): trust is judged by ORIGIN at
 // delivery, so the level applies to this host's mail even when it arrives relayed through a hub —
 // no tunnel required to set it (the user 2026-07-25).
-var ktrust='<select class=rnet-trust data-t=\"'+k.host+'\" title=\"What happens to postal mail from '+k.host+', however it arrives (a direct tunnel later, or relayed through a hub now): trusted = delivered straight to your sessions; directed = held for your approval; isolated = none.\">'+
-['trusted','directed','isolated'].map(function(v){return '<option value='+v+(kcur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select>';
+var ktrust='<select class=\"rnet-trust'+(kpd?' rnet-applying':'')+'\"'+(kpd?' disabled':'')+' data-t=\"'+k.host+'\" title=\"What happens to postal mail from '+k.host+', however it arrives (a direct tunnel later, or relayed through a hub now): trusted = delivered straight to your sessions; directed = held for your approval; isolated = none.\">'+
+['trusted','directed','isolated'].map(function(v){return '<option value='+v+(kcur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select>'+(kpd?'<span class=rnet-pend>applying\\u2026</span>':'');
 kr.innerHTML='<span class=rnet-dot style=\"background:transparent;box-shadow:inset 0 0 0 1.5px #5a5a5a\" title=\"Not attached right now.\"></span>'+
 '<span class=nm><b>'+k.host+'</b> <span class=st title=\"Not attached; the trust level applies to its mail by origin, and re-attaching keeps it.\">not attached</span></span>'+ktrust+
 '<button data-ra=\"'+k.host+'\" title=\"Open the ssh tunnel to '+k.host+' again, restoring its remembered trust level.\">Re-attach</button>'+
@@ -14944,9 +14955,10 @@ if(via.length){var vh=document.createElement('div');vh.className='rnet-khead';
 vh.textContent='Reachable via relay';vh.title='Machines you have no direct tunnel to; a hub you are attached to relays their mail one hop. Trust is judged by origin, so the level you set here applies to their mail even though it arrives through the hub.';
 list.appendChild(vh);
 via.forEach(function(v){var vr=document.createElement('div');vr.className='rnet-row rnet-known';
-var vcur=v.trust||'directed';
-var vtrust='<select class=rnet-trust data-t=\"'+v.host+'\" title=\"What happens to postal mail from '+v.host+' (it arrives relayed through '+v.via+'; trust is judged by its true origin): trusted = delivered straight to your sessions; directed = held for your approval; isolated = none.\">'+
-['trusted','directed','isolated'].map(function(w){return '<option value='+w+(vcur===w?' selected':'')+'>'+TRUSTW[w]+'</option>';}).join('')+'</select>';
+var vpd=pendLvl(_pendTrust,v.host,v.trust||'directed');
+var vcur=vpd||v.trust||'directed';
+var vtrust='<select class=\"rnet-trust'+(vpd?' rnet-applying':'')+'\"'+(vpd?' disabled':'')+' data-t=\"'+v.host+'\" title=\"What happens to postal mail from '+v.host+' (it arrives relayed through '+v.via+'; trust is judged by its true origin): trusted = delivered straight to your sessions; directed = held for your approval; isolated = none.\">'+
+['trusted','directed','isolated'].map(function(w){return '<option value='+w+(vcur===w?' selected':'')+'>'+TRUSTW[w]+'</option>';}).join('')+'</select>'+(vpd?'<span class=rnet-pend>applying\\u2026</span>':'');
 vr.innerHTML='<span class=rnet-dot style=\"background:transparent;box-shadow:inset 0 0 0 1.5px #7a6a3a\" title=\"No direct tunnel; reachable one hop through '+v.via+'.\"></span>'+
 '<span class=nm><b>'+v.host+'</b> <span class=st title=\"Its sessions are gossiped one hop by '+v.via+'; attach it directly for full control.\">via '+v.via+' \\u00b7 '+(v.agents||0)+' session'+((v.agents||0)===1?'':'s')+'</span></span>'+vtrust;
 list.appendChild(vr);});}
@@ -14964,14 +14976,19 @@ var hr=document.createElement('div');hr.className='rnet-row rnet-known';
 hr.innerHTML='<span class=rnet-dot style=\"background:#b58900\" title=\"Mail is waiting for approval on '+hn+'.\"></span>'+
 '<span class=nm><b>'+hn+'</b> <span class=st title=\"'+gl.replace(/\"/g,'&quot;')+'\">'+rows.length+' message'+(rows.length===1?'':'s')+' held for your approval</span></span>';
 list.appendChild(hr);});}
+// Pending is recorded ON THE CLICK (ack now — the buttons rule), so any re-render in the round-trip
+// window repaints the chosen level + applying cue instead of the stale snapshot's old value. A
+// refused/failed write DELETES the pending entry, so the next render honestly reverts — plus the alert.
 list.querySelectorAll('select[data-t]').forEach(function(s){s.onchange=function(){var h=s.getAttribute('data-t');
-s.disabled=true;fetch('/tunnels/trust',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h,trust:s.value})}).then(function(r){return r.json();}).then(function(d){
-if(!(d&&d.ok)){alert('trust change on '+h+' failed: '+((d&&d.error)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
-s.disabled=false;refresh();}).catch(function(){s.disabled=false;alert('trust change on '+h+' failed to reach the kernel.');});};});
+_pendTrust[h]=s.value;s.disabled=true;s.classList.add('rnet-applying');
+fetch('/tunnels/trust',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h,trust:s.value})}).then(function(r){return r.json();}).then(function(d){
+if(!(d&&d.ok)){delete _pendTrust[h];alert('trust change on '+h+' failed: '+((d&&d.error)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
+refresh();}).catch(function(){delete _pendTrust[h];alert('trust change on '+h+' failed to reach the kernel.');refresh();});};});
 list.querySelectorAll('button[data-m]').forEach(function(b){b.onclick=function(){var h=b.getAttribute('data-m');
-b.disabled=true;b.textContent='Matching\\u2026';fetch('/tunnels/trust-mirror',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h})}).then(function(r){return r.json();}).then(function(d){
-if(!(d&&d.ok)){alert('trust match on '+h+' failed: '+((d&&d.error)||'unknown'));b.disabled=false;b.textContent='Match';return;}   // fail LOUDLY (CLAUDE.md)
-b.textContent='Matched';refresh();}).catch(function(){b.disabled=false;b.textContent='Match';alert('trust match on '+h+' failed to reach the kernel.');});};});
+_pendMirror[h]=b.getAttribute('data-lvl')||'';b.disabled=true;b.textContent='Matching\\u2026';
+fetch('/tunnels/trust-mirror',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h})}).then(function(r){return r.json();}).then(function(d){
+if(!(d&&d.ok)){delete _pendMirror[h];alert('trust match on '+h+' failed: '+((d&&d.error)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
+refresh();}).catch(function(){delete _pendMirror[h];alert('trust match on '+h+' failed to reach the kernel.');refresh();});};});
 list.querySelectorAll('input[data-k]').forEach(function(c){c.onchange=function(){var h=c.getAttribute('data-k');
 c.disabled=true;fetch('/tunnels/checkin',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h,on:c.checked})}).then(function(r){return r.json();}).then(function(d){
 if(!(d&&d.ok)){c.checked=!c.checked;alert('keep-connected on '+h+' failed: '+((d&&d.error)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
@@ -15431,6 +15448,10 @@ def _landing():
             ".rnet-keep input{margin:0;accent-color:var(--accent)}"
             ".rnet-trust{flex:0 0 auto;background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:6px;padding:2px 6px;font-size:11px;cursor:pointer}"
             ".rnet-trust:disabled{opacity:0.55;cursor:default}"
+            # applying = in-progress chrome, so it wears the accent (never a status color); the note's
+            # 11px matches every other annotation on the row (fonts: reuse, don't multiply)
+            ".rnet-trust.rnet-applying{border-color:var(--accent);opacity:0.8}"
+            ".rnet-pend{color:var(--accent);font-size:11px;margin-left:4px}"
             # "Previously attached": a quiet section header + dimmed rows, so remembered hosts read as
             # history you can act on and never as something currently connected. Hover restores full
             # opacity (they're interactive, not decoration).

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4807,7 +4807,21 @@ def checkin_apply(body):
         return not isinstance(p, int) or isinstance(p, bool) or not (0 < p < 65536)
     if not host or _bad(kp) or _bad(bp):
         return {"ok": False, "error": "host, kernelPort, busPort required"}, 400
+    tok = str((body or {}).get("token") or "")
     with _remotes_lock:
+        if tok:
+            for oh, o in list(_remotes.items()):
+                if o.get("token") != tok:
+                    continue
+                if not o.get("checkin_peer"):
+                    # Same kernel (same serve token), already ssh-attached here — usually under its
+                    # alias while the handshake declares its hostname. The ssh row is strictly more
+                    # capable (we own the tunnel, can push/start), so keep it and file NO second row.
+                    # 200, not an error: the mobile retries a failed handshake every tunnel
+                    # incarnation, and there is nothing here to fix (the user 2026-07-27).
+                    return {"ok": True, "host": oh, "alreadyAttached": True}, 200
+                if oh != host:
+                    _remotes.pop(oh, None)         # same mobile re-checking in under a new name
         r = _remotes.get(host)
         if r is not None and not r.get("checkin_peer"):
             return {"ok": False, "error": "host '%s' is already an ssh-attached remote here" % host}, 409
@@ -5009,6 +5023,7 @@ def attach_remote(host, kernel_port=None):
         raise ValueError("host required")
     if not _safe_ssh_host(host):
         raise ValueError("invalid host")
+    prior_trust = known_trust(host)   # BEFORE this attach's own _known_note files a default for the name
     with _remotes_lock:
         r = _remotes.get(host)
         if r is None:
@@ -5031,6 +5046,33 @@ def attach_remote(host, kernel_port=None):
         _attach_trust = r.get("trust")
     _known_note(host, _attach_trust)               # remember it for the popover's past-hosts list
     token = _fetch_remote_token(host)              # ssh round-trip, outside the lock
+    # SAME MACHINE, SECOND NAME (the user 2026-07-27, whose box sat in the registry as both its
+    # hostname and its ssh alias — every session listed twice, bare postal names ambiguous). The serve
+    # token IS the remote kernel's identity — one per machine, fetched from its state dir — so a
+    # fetched token that matches an existing row under a DIFFERENT name means this attach reaches a
+    # machine already registered. Absorb the old row into this one: kill its tunnel, tell the bus that
+    # peer name is gone, and carry its trust level forward when this name has none remembered — the
+    # user chose that level for the MACHINE, and a rename must not quietly drop it to directed.
+    absorbed = None
+    if token:
+        with _remotes_lock:
+            dup = next((o for oh, o in _remotes.items() if oh != host and o.get("token") == token), None)
+            if dup is not None:
+                absorbed = _remotes.pop(dup["host"])
+                r = _remotes.get(host)
+                if r is not None and prior_trust is None and absorbed.get("trust"):
+                    r["trust"] = absorbed["trust"]
+                    _attach_trust = absorbed["trust"]
+    if absorbed:
+        if absorbed.get("proc"):
+            try:
+                absorbed["proc"].terminate()
+            except Exception:
+                pass
+        if _postal_peers_on():                     # the old peer NAME is gone on purpose — tell the bus
+            _notify_bus_peer(absorbed["host"], absorbed.get("bus_port"), False, absorbed.get("token") or "")
+        known_forget(absorbed["host"])             # never re-offer the duplicate name in the popover
+        _known_note(host, _attach_trust)           # the surviving name carries the machine's trust level
     # BOOTSTRAP: no token yet (the kernel there never ran) or nothing listening on its port → start
     # romp-serve over ssh and wait for the port, so "install romp on the box, click attach" is the
     # whole story. A healthy remote costs one extra ssh probe; a romp-less host gets a next-step

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4965,7 +4965,10 @@ def _remote_public(r):
             # exact condition the automatic update fires on, so the row can say why it will or won't.
             # autoPush: that host's live phase (pushing / waiting / failed) → the popover's progress line and
             # the rail icon's motion, so background work is never invisible (the user 2026-07-24).
-            "fastForward": _is_fast_forward(r), "autoPush": _auto_push_state(r["host"]),
+            # fastPull: the mirror — the remote is strictly ahead, so pulling only ADDS commits here.
+            # Drives the row's Pull button; the auto-pull additionally requires trusted + local main.
+            "fastForward": _is_fast_forward(r), "fastPull": _is_fast_pull(r),
+            "autoPush": _auto_push_state(r["host"]),
             # reconnect budget (the user 2026-07-22): the popover has to be able to SAY that romp stopped
             # dialing, instead of a silent forever-retry that looks identical to a healthy idle row
             "gaveUp": bool(r.get("gave_up")), "fails": int(r.get("fails") or 0),
@@ -5423,36 +5426,87 @@ def _auto_push_remote(host):
     return ok
 
 
+def _auto_pull_remote(host):
+    """Run ONE automatic pull FROM `host` in the background — the mirror of _auto_push_remote for a
+    trusted remote that is strictly ahead. On success the phase parks at 'pulled' with the restart
+    hint: the drift flag clears at once (HEAD moved), but the running kernel is still the old build,
+    so the trace must outlive the clearing event — a kernel restart (fresh process, empty map) is what
+    removes it. Failures stay visible and red, exactly like a failed push."""
+    _set_auto_push(host, "pulling", "pulling %s's newer commits over SSH" % host)
+    try:
+        ok, detail = _pull_remote(host)
+    except Exception as e:
+        ok, detail = False, str(e)
+    _set_auto_push(host, "pulled" if ok else "failed", detail or ("" if ok else "pull failed"))
+    return ok
+
+
 def _maybe_auto_push(r):
-    """The supervisor's per-pass hook: start an automatic push of this remote when the setting is on and a
-    straight fast-forward is observed. Spawns a THREAD — `_update_remote` is several seconds of ssh, and the
-    supervisor also keeps every tunnel alive, so blocking it here would stall the whole fleet."""
+    """The supervisor's per-pass hook: start an automatic sync of this remote when the setting is on —
+    a PUSH when a straight fast-forward of the remote is observed, a PULL when a TRUSTED remote is
+    strictly ahead and the local checkout sits clean on main (the user 2026-07-27: main syncs itself
+    across trusted machines, both directions ridden by the attaching side's own ssh). Spawns a THREAD —
+    either direction is several seconds of ssh, and the supervisor also keeps every tunnel alive, so
+    blocking it here would stall the whole fleet."""
     host = r.get("host") or ""
     if not host:
         return
+    if r.get("checkin_peer"):
+        return   # no ssh route from here in either direction — auto-sync would just manufacture failures
     if not _remote_out_of_date(r):
         # It matches us now. That is the EVENT that ends a push (never a timer): a 'waiting for it to
         # restart' clears the moment the restarted remote reports our sha, and a stale 'failed' clears too
         # once the host is up to date by any route (a later manual Push, an update from another machine).
+        # 'pulled' deliberately survives this — its restart hint stays until the restart itself.
         with _auto_push_lock:
             if _auto_push.get(host, {}).get("phase") in ("waiting", "failed"):
                 _auto_push.pop(host, None)
         return
-    if not _auto_update_remotes_on() or not _is_fast_forward(r):
+    if not _auto_update_remotes_on():
+        return
+    push = _is_fast_forward(r)
+    pull = (not push and _is_fast_pull(r) and (r.get("trust") or "directed") == "trusted"
+            and _local_branch() == "main")
+    if not push and not pull:
         return
     key = (_sha_base(r.get("kernel_sha") or ""), _local_head() or "")
     with _auto_push_lock:
-        if _auto_push.get(host, {}).get("phase") == "pushing":
-            return                                  # one push per host at a time
+        if _auto_push.get(host, {}).get("phase") in ("pushing", "pulling"):
+            return                                  # one sync per host at a time
         if _auto_push_tried.get(host) == key:
             return                                  # already attempted for this exact advance
         if len(_auto_push_tried) > 64:
             _auto_push_tried.clear()
         _auto_push_tried[host] = key
-    threading.Thread(target=_auto_push_remote, args=(host,), daemon=True).start()
+    threading.Thread(target=_auto_push_remote if push else _auto_pull_remote,
+                     args=(host,), daemon=True).start()
 
 
 _P2P_REF = "romp-p2p-sync"   # scratch branch the local kernel force-pushes its HEAD to on the remote
+
+
+def _discover_remote_clone(host):
+    """ssh-discover the remote romp clone (conventional dirs, mirrors _start_remote_kernel) and its
+    state. Returns (dir, head, dirty, error) — error set (and the rest blank) on any failure. Shared
+    by the push (_update_remote) and pull (_pull_remote) directions."""
+    disc = (
+        'R=""; for d in "$HOME/GitRepos/romp" "$HOME/romp" "$HOME/code/romp" "$HOME/src/romp"; do '
+        'if [ -d "$d/.git" ]; then R="$d"; break; fi; done; '
+        'if [ -z "$R" ]; then echo NOROMP; exit 0; fi; '
+        'echo "DIR:$R"; echo "HEAD:$(git -C "$R" rev-parse HEAD 2>/dev/null)"; '
+        'echo "DIRTY:$(git -C "$R" status --porcelain 2>/dev/null | head -c 1)"')
+    try:
+        d = subprocess.run([SSH_BIN] + _SSH_OPTS + ["--", host, disc], capture_output=True, text=True, timeout=25)
+    except Exception as e:
+        return "", "", "", str(e)[:200]
+    out = d.stdout or ""
+    if "NOROMP" in out:
+        return "", "", "", "romp not installed on %s (looked in ~/GitRepos/romp, ~/romp, ~/code/romp, ~/src/romp)" % host
+    info = dict((l.split(":", 1) + [""])[:2] for l in out.splitlines() if ":" in l)
+    rdir, rhead, rdirty = info.get("DIR", "").strip(), info.get("HEAD", "").strip(), info.get("DIRTY", "").strip()
+    if not rdir:
+        return "", "", "", (_ssh_err(d.stderr) or "couldn't locate the remote romp clone on %s" % host).strip()[:200]
+    return rdir, rhead, rdirty, ""
 
 
 def _update_remote(host):
@@ -5473,6 +5527,12 @@ def _update_remote(host):
         return False, "no host"
     with _remotes_lock:
         _rr = _remotes.get(host)
+    if _rr is not None and _rr.get("checkin_peer"):
+        # A checked-in host reached US over its own outbound tunnel; there is no ssh route from here,
+        # so a push can only die with a confusing "No route to host" (the user 2026-07-27). Say what
+        # is actually possible instead.
+        return False, ("no ssh path to %s from this machine (it checked in here over its own tunnel) — "
+                       "sync from that machine's own dashboard" % host)
     kport = int((_rr or {}).get("kernel_port") or _REMOTE_KERNEL_PORT)   # for the restart's port poll
     lfull = _local_head()
     if not lfull:
@@ -5480,23 +5540,9 @@ def _update_remote(host):
     # We push the committed HEAD; uncommitted local edits are not sent ("just take what is committed on local"
     # — the user 2026-07-04). A dirty local tree is NOT refused: it just means HEAD, not the working tree.
     # (1) discover the remote clone + pre-check it's clean
-    disc = (
-        'R=""; for d in "$HOME/GitRepos/romp" "$HOME/romp" "$HOME/code/romp" "$HOME/src/romp"; do '
-        'if [ -d "$d/.git" ]; then R="$d"; break; fi; done; '
-        'if [ -z "$R" ]; then echo NOROMP; exit 0; fi; '
-        'echo "DIR:$R"; echo "HEAD:$(git -C "$R" rev-parse HEAD 2>/dev/null)"; '
-        'echo "DIRTY:$(git -C "$R" status --porcelain 2>/dev/null | head -c 1)"')
-    try:
-        d = subprocess.run([SSH_BIN] + _SSH_OPTS + ["--", host, disc], capture_output=True, text=True, timeout=25)
-    except Exception as e:
-        return False, str(e)[:200]
-    out = d.stdout or ""
-    if "NOROMP" in out:
-        return False, "romp not installed on %s (looked in ~/GitRepos/romp, ~/romp, ~/code/romp, ~/src/romp)" % host
-    info = dict((l.split(":", 1) + [""])[:2] for l in out.splitlines() if ":" in l)
-    rdir, rhead, rdirty = info.get("DIR", "").strip(), info.get("HEAD", "").strip(), info.get("DIRTY", "").strip()
-    if not rdir:
-        return False, (_ssh_err(d.stderr) or "couldn't locate the remote romp clone on %s" % host).strip()[:200]
+    rdir, rhead, rdirty, derr = _discover_remote_clone(host)
+    if derr:
+        return False, derr
     if rdirty:
         return False, "remote %s has uncommitted changes — commit or discard them there first (won't clobber)" % host
     if rhead and rhead == lfull:
@@ -5582,6 +5628,93 @@ def _update_remote(host):
     if tag == "NOLAUNCH":
         return False, "pushed + reset, but found no romp/romp-serve launcher to restart the kernel"
     return False, (_ssh_err(a.stderr) or aout or "remote apply failed").strip()[:180]
+
+
+def _is_fast_pull(r):
+    """Whether pulling this remote's commits would be a STRAIGHT FAST-FORWARD of the local checkout —
+    the remote is strictly AHEAD (it has commits we lack, we have none it lacks), both counts actually
+    known. The mirror of _is_fast_forward, for the other direction (the user 2026-07-27: the attaching
+    side owns BOTH directions of sync — the remote has no ssh route back). None is NOT zero, same as
+    the push gate: an unprovable relationship is exactly what must not be pulled automatically."""
+    if not _remote_out_of_date(r):
+        return False
+    d = _behind_info(r.get("kernel_sha") or "")
+    b, a = d.get("behind"), d.get("ahead")
+    return isinstance(b, int) and isinstance(a, int) and a > 0 and b == 0
+
+
+def _local_branch():
+    """The local checkout's branch name, or '' when detached/unknown — the auto-pull fires on main
+    only (the user 2026-07-27: main syncs itself across trusted machines; feature branches are
+    mid-thought and move when their owner says so)."""
+    try:
+        r = subprocess.run(["git", "-C", str(ROOT), "symbolic-ref", "--quiet", "--short", "HEAD"],
+                           capture_output=True, text=True, timeout=3)
+        return (r.stdout or "").strip() if r.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def _pull_remote(host):
+    """PEER-TO-PEER pull — the other direction of _update_remote (the user 2026-07-27, who wanted sync
+    to ride the attaching side's own ssh: the remote pushing back can only fail, connectivity is
+    one-way). Fetch the remote clone's committed HEAD over the same BatchMode ssh and FAST-FORWARD the
+    local checkout onto it. Guardrails: ff-only (never a merge/rebase on the user's behalf — diverged
+    is refused loudly), and a clean local tree for TRACKED files (the fast-forward rewrites the
+    working tree; peers' uncommitted edits are not ours to move). The local kernel is deliberately NOT
+    restarted — a kernel restart is fleet-visible, so the detail says what to run instead. Returns
+    (ok, detail), fail-loud."""
+    host = str(host or "").strip()
+    if not host:
+        return False, "no host"
+    with _remotes_lock:
+        _rr = _remotes.get(host)
+    if _rr is not None and _rr.get("checkin_peer"):
+        return False, ("no ssh path to %s from this machine (it checked in here over its own tunnel) — "
+                       "sync from that machine's own dashboard" % host)
+    lfull = _local_head()
+    if not lfull:
+        return False, "local kernel isn't a git checkout — nowhere to pull to"
+    try:
+        st = subprocess.run(["git", "-C", str(ROOT), "status", "--porcelain", "--untracked-files=no"],
+                            capture_output=True, text=True, timeout=10)
+    except Exception as e:
+        return False, str(e)[:200]
+    if (st.stdout or "").strip():
+        return False, "this machine's tree has uncommitted changes — commit or stash them first (won't clobber)"
+    rdir, rhead, _rdirty, derr = _discover_remote_clone(host)   # a DIRTY remote is fine: we take its COMMITS
+    if derr:
+        return False, derr
+    if rhead and rhead == lfull:
+        return True, "already up to date (%s)" % (_local_head(short=True) or lfull[:8])
+    env = dict(os.environ, GIT_SSH_COMMAND="%s %s" % (SSH_BIN, " ".join(_SSH_OPTS)))
+    try:
+        f = subprocess.run(["git", "-C", str(ROOT), "fetch", "%s:%s" % (host, rdir), "HEAD"],
+                           capture_output=True, text=True, timeout=120, env=env)
+    except Exception as e:
+        return False, "git fetch from %s failed: %s" % (host, str(e)[:160])
+    if f.returncode != 0:
+        return False, "git fetch from %s failed: %s" % (host, (_ssh_err(f.stderr) or f.stdout or "").strip()[:160])
+    try:
+        anc = subprocess.run(["git", "-C", str(ROOT), "merge-base", "--is-ancestor", "HEAD", "FETCH_HEAD"],
+                             capture_output=True, text=True, timeout=10)
+        if anc.returncode != 0:
+            return False, ("local and %s have diverged — a pull would need a merge, which is yours to "
+                           "do by hand" % host)
+        n = subprocess.run(["git", "-C", str(ROOT), "rev-list", "--count", "HEAD..FETCH_HEAD"],
+                           capture_output=True, text=True, timeout=10)
+        count = (n.stdout or "").strip() or "?"
+        m = subprocess.run(["git", "-C", str(ROOT), "merge", "--ff-only", "FETCH_HEAD"],
+                           capture_output=True, text=True, timeout=30)
+    except Exception as e:
+        return False, str(e)[:200]
+    if m.returncode != 0:
+        return False, "fast-forward failed: %s" % ((m.stderr or m.stdout or "").strip()[:160] or "unknown")
+    _HEAD_CACHE.update(ts=0.0)             # HEAD moved; the next poll re-reads it and the drift clears
+    short = subprocess.run(["git", "-C", str(ROOT), "rev-parse", "--short", "HEAD"],
+                           capture_output=True, text=True, timeout=5).stdout.strip()
+    return True, "pulled %s commit%s from %s — now at %s; restart romp to run it" % (
+        count, "" if count == "1" else "s", host, short or "HEAD")
 
 
 def _start_remote(host):
@@ -14817,7 +14950,7 @@ _auto=!!(d&&d.autoUpdate);
 if(autoCb&&!autoCb.disabled)autoCb.checked=_auto;   // mirror the kernel; never clobber a write in flight
 // An automatic push in flight counts as BUSY: the icon marches while romp works in the background, which is
 // the whole point of replacing the modal (the user 2026-07-24 — animate the icon so you can see it happening).
-var pushing=ts.filter(function(t){return t.autoPush&&(t.autoPush.phase==='pushing'||t.autoPush.phase==='waiting');});
+var pushing=ts.filter(function(t){return t.autoPush&&(t.autoPush.phase==='pushing'||t.autoPush.phase==='waiting'||t.autoPush.phase==='pulling');});
 paintIcon(ts.some(function(t){return t.status==='up';}),busy||!!pushing.length);
 // hover tooltip on the rail icon: which hosts are attached + their phase and session count, plus any
 // automatic update's live phase — so the progress is readable WITHOUT opening the panel.
@@ -14874,13 +15007,18 @@ var ver='';
 if(t.outOfDate){var bb=t.behindBy,ab=t.aheadBy,w='different build';
 if(typeof bb==='number'&&typeof ab==='number'){
 w=(bb>0&&ab>0)?'diverged':(ab>0)?'ahead '+ab+' commit'+(ab===1?'':'s'):(bb>0)?'behind '+bb+' commit'+(bb===1?'':'s'):w;}
-var tt='running '+(t.kernelSha||'?')+(t.kernelDate?' from '+t.kernelDate:'')+'; this machine is at '+(t.localSha||'?')+(w==='diverged'?' (each has commits the other lacks)':'');
+var tt='running '+(t.kernelSha||'?')+(t.kernelDate?' from '+t.kernelDate:'')+'; this machine is at '+(t.localSha||'?')+(w==='diverged'?' (each has commits the other lacks)':'')
++(t.checkinPeer?' No ssh path from this machine (it checked in over its own tunnel) \\u2014 sync from its own dashboard.':'');
 ver=' \\u00b7 <span class=rnet-old title=\"'+tt+'\">'+w+'</span>';}
 else if(t.kernelSha){ver=' \\u00b7 <span class=rnet-sha title=\"same build as this machine\">'+t.kernelSha+'</span>';}
 // A push romp is ALREADY doing needs no button — offering one would just invite a duplicate of the work in
 // flight. The row shows the live phase instead (below), and the manual Push returns if it fails.
-var apx=t.autoPush&&(t.autoPush.phase==='pushing'||t.autoPush.phase==='waiting');
-var upd=(t.status==='up'&&t.outOfDate&&!apx)?'<button class=rnet-upd data-u=\"'+t.host+'\" title=\"Push this machine\\u2019s committed romp to '+t.host+' and restart its kernel, so it runs exactly this code. Uncommitted local edits are not sent, so commit first. It refuses if that machine has its own commits.\">Push</button>':'';
+var apx=t.autoPush&&(t.autoPush.phase==='pushing'||t.autoPush.phase==='waiting'||t.autoPush.phase==='pulling');
+// A checked-in host has no ssh route FROM here, so Push/Pull can only fail — the tooltip above says
+// where to sync instead. A strictly-AHEAD remote gets Pull in Push's place: a push there would only
+// be refused (it has commits this machine lacks), so offering it is a dead end.
+var upd=(t.status==='up'&&t.outOfDate&&!apx&&!t.checkinPeer&&!t.fastPull)?'<button class=rnet-upd data-u=\"'+t.host+'\" title=\"Push this machine\\u2019s committed romp to '+t.host+' and restart its kernel, so it runs exactly this code. Uncommitted local edits are not sent, so commit first. It refuses if that machine has its own commits.\">Push</button>':'';
+var pull=(t.status==='up'&&t.fastPull&&!apx&&!t.checkinPeer)?'<button class=rnet-upd data-p=\"'+t.host+'\" title=\"Pull '+t.host+'\\u2019s newer commits into this machine\\u2019s romp (fast-forward only; refuses if this tree has uncommitted changes). This kernel keeps running the old build until you restart romp.\">Pull</button>':'';
 // ssh alive but no kernel answering -> the explicit ASK (the user 2026-07-10): a Start button that
 // pushes this machine's committed romp to the host FIRST, then boots its kernel. Never auto-starts —
 // a stopped kernel may be stopped on purpose; the click is the consent.
@@ -14916,7 +15054,7 @@ else if(mm){trust+='<button class=rnet-mirror data-m=\"'+t.host+'\" data-lvl=\"'
 // weight as a dropdown, and on a phone pushed it off the edge entirely.
 row.innerHTML='<span class=rnet-dot style=\"'+dot+'\" title=\"'+(TIP[t.status]||'')+'\"></span>'+
 '<span class=nm><b>'+t.host+'</b> <span class=st title=\"'+(TIP[t.status]||'')+'\">'+(LBL[t.status]||t.status)+(t.checkinPeer?' \\u00b7 checked in here':'')+(t.token?'':' \\u00b7 no token')+ver+'</span></span>'+
-retry+upd+strt+'<button data-h=\"'+t.host+'\" title=\"Close the ssh tunnel to '+t.host+'. It stays in this list as a previously-attached host, keeping its trust level, so you can re-attach in one click.\">Detach</button>';
+retry+pull+upd+strt+'<button data-h=\"'+t.host+'\" title=\"Close the ssh tunnel to '+t.host+'. It stays in this list as a previously-attached host, keeping its trust level, so you can re-attach in one click.\">Detach</button>';
 item.appendChild(row);
 // Live automatic-update phase, on its own line under the row — this is the whole reason the modal could
 // go away: the work still announces itself, it just does it here instead of over your screen. A FAILURE
@@ -15010,6 +15148,12 @@ fetch('/tunnels/start',{method:'POST',headers:{'Content-Type':'application/json'
 if(d&&d.ok){b.textContent='Started';schedule(1000);}   // the supervisor's next poll flips the row to connected
 else{b.disabled=false;b.textContent='Retry';alert('Start on '+h+' failed: '+((d&&d.detail)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
 }).catch(function(){b.disabled=false;b.textContent='Retry';alert('Start on '+h+' failed to reach the kernel.');});};});
+list.querySelectorAll('button[data-p]').forEach(function(b){b.onclick=function(){var h=b.getAttribute('data-p');
+b.disabled=true;b.textContent='Pulling\\u2026';
+fetch('/tunnels/pull',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h})}).then(function(r){return r.json();}).then(function(d){
+if(d&&d.ok){b.textContent='Pulled';alert((d.detail||'Pulled.')+'');schedule(1000);}   // the detail carries the restart hint
+else{b.disabled=false;b.textContent='Retry';alert('Pull from '+h+' failed: '+((d&&d.detail)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
+}).catch(function(){b.disabled=false;b.textContent='Retry';alert('Pull from '+h+' failed to reach the kernel.');});};});
 list.querySelectorAll('button[data-u]').forEach(function(b){b.onclick=function(){var h=b.getAttribute('data-u');
 b.disabled=true;b.textContent='Pushing\\u2026';
 fetch('/tunnels/update',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h})}).then(function(r){return r.json();}).then(function(d){
@@ -16503,6 +16647,20 @@ class Handler(BaseHTTPRequestHandler):
                 if not host:
                     return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
                 ok, detail = _update_remote(host)
+                return self._send(200 if ok else 502, json.dumps({"ok": ok, "detail": detail}), "application/json")
+            if u.path == "/tunnels/pull":
+                # PULL a remote's newer committed code into the local checkout (peer-to-peer, no
+                # GitHub) — the mirror of /tunnels/update, still over THIS machine's ssh (the remote
+                # has no route back). Fast-forward only, clean local tree required; the local kernel
+                # is not restarted (the detail says what to run). Body: {"host": <ssh alias>}.
+                try:
+                    body = json.loads(raw_body or b"{}")
+                except Exception:
+                    body = None
+                host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
+                if not host:
+                    return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
+                ok, detail = _pull_remote(host)
                 return self._send(200 if ok else 502, json.dumps({"ok": ok, "detail": detail}), "application/json")
             if u.path == "/tunnels/start":
                 # START a downed remote kernel — the popover's explicit ASK for an ssh-reachable host

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1420,6 +1420,14 @@ def peers_snapshot():
 
 PEER_PROTO = 1
 BUS_EPOCH = int(time.time())               # this bus process's boot — peers key cached presence on it
+# This bus process's IDENTITY, carried on every exchange (additive, like `tier`; older peers omit it).
+# One machine reaches a fleet under TWO names — the alias its kernel dials (the ssh-config name) and
+# the hostname the machine declares about itself (self_host on ITS inbound dials) — and name-keyed
+# PEER_STATE then holds two rows for one bus: every remote session listed twice, bare names ambiguous,
+# and inbound relays trust-judged under the self-declared name instead of the alias the user tiered
+# (the user 2026-07-27, whose box showed each session twice as <hostname>:<name> and <alias>:<name>).
+# busId lets the receiver recognize "same bus, second name" and fold onto the dialable alias.
+BUS_ID = os.urandom(16).hex()
 OUTBOX = STATE / "outbox"                  # outbox/<host>/<mid>.json — cross-host mail awaiting its ACK
 PEER_SEEN = STATE / "peer-seen.jsonl"      # append-only receipt log — the idempotence window
 _SEEN_CAP = 4000
@@ -1726,6 +1734,31 @@ def _pending(host):
             p = _peer_pending[host] = {"acks": [], "bounces": []}
         return p
 
+def _canon_peer_name(host, bus_id):
+    """The name to file a peer's exchange under: the DIALABLE alias when `bus_id` proves this is a bus
+    we already peer with under another name (see BUS_ID above). The alias row is the one the kernel
+    notifies, the dialer runs on, and the user tiered — so it wins over a self-declared hostname. No
+    bus_id (older peer) → the declared name stands, exactly as before."""
+    if not bus_id or (PEERS.get(host) or {}).get("port"):
+        return host   # a dialable name stands as itself; two dialable names is the kernel's dedupe
+    for k, st in PEER_STATE.items():
+        if k != host and st.get("busId") == bus_id and (PEERS.get(k) or {}).get("port"):
+            return k
+    return host
+
+
+def _drop_peer_name_dupes(host, bus_id):
+    """Forget PEER_STATE rows that are the SAME bus as `host` under another, non-dialable name — the
+    stale half of a fold (e.g. the self-declared hostname row left from before the alias attached).
+    Never drops a dialable row: two dialable names for one bus is a kernel-level duplicate with its
+    own fix (attach_remote's token dedupe), and dropping either here would fight the kernel."""
+    if not bus_id:
+        return
+    for k in [k for k, st in PEER_STATE.items()
+              if k != host and st.get("busId") == bus_id and not (PEERS.get(k) or {}).get("port")]:
+        PEER_STATE.pop(k, None)
+
+
 def peer_exchange_handle(data):
     """The DIALED side of one exchange. Returns (payload, status)."""
     host = str((data or {}).get("host") or "").strip()
@@ -1734,8 +1767,15 @@ def peer_exchange_handle(data):
     if (data or {}).get("proto") != PEER_PROTO:
         return {"error": "peer protocol drift (theirs %r, ours %r) — update romp on one side"
                 % ((data or {}).get("proto"), PEER_PROTO), "proto": PEER_PROTO}, 409
+    # Canonicalize BEFORE anything keys on the name: presence files under the alias (no duplicate
+    # session rows), and the relays below are trust-judged under the alias the user actually tiered.
+    bus_id = str((data or {}).get("busId") or "")
+    host = _canon_peer_name(host, bus_id)
     PEER_STATE[host] = {"presence": data.get("presence") or [], "epoch": data.get("epoch"),
                         "holds": data.get("holds") or [], "seenAt": int(time.time())}
+    if bus_id:
+        PEER_STATE[host]["busId"] = bus_id
+        _drop_peer_name_dupes(host, bus_id)
     if data.get("tier"):                             # the dialer's declared tier-of-us (additive; older peers omit it)
         PEER_STATE[host]["theirTier"] = str(data["tier"])
     for mid in data.get("acks") or []:               # the dialer confirmed relays landed — end-to-end:
@@ -1767,7 +1807,7 @@ def peer_exchange_handle(data):
         rel = outbox_list(host)
         a2, b2 = _drain_backflow()
         acks, bounces = acks + a2, bounces + b2
-    return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO,
+    return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO, "busId": BUS_ID,
             "presence": fleet_presence(host), "holds": holds_payload(host),
             "tier": my_tier_of(host),                # how WE hold the dialer's mail (display/mirror, never the gate)
             "relays": rel, "acks": acks, "bounces": bounces}, 200
@@ -1776,7 +1816,7 @@ def build_exchange_request(host, wait=True):
     p = _pending(host)
     with _peer_lock:
         acks, bounces = list(p["acks"]), list(p["bounces"])
-    return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO,
+    return {"host": self_host(), "epoch": BUS_EPOCH, "proto": PEER_PROTO, "busId": BUS_ID,
             "presence": fleet_presence(host), "holds": holds_payload(host),
             "tier": my_tier_of(host),                # how WE hold the dialed host's mail
             "relays": outbox_list(host),
@@ -1791,6 +1831,10 @@ def peer_exchange_apply(host, req_sent, resp):
         p["bounces"] = [b for b in p["bounces"] if b not in (req_sent.get("bounces") or [])]
     PEER_STATE[host] = {"presence": resp.get("presence") or [], "epoch": resp.get("epoch"),
                         "holds": resp.get("holds") or [], "seenAt": int(time.time())}
+    bus_id = str(resp.get("busId") or "")
+    if bus_id:                                       # the dialed alias is canonical for this bus: fold any
+        PEER_STATE[host]["busId"] = bus_id           # row it left under its self-declared hostname
+        _drop_peer_name_dupes(host, bus_id)
     if resp.get("tier"):                             # the dialed side's declared tier-of-us
         PEER_STATE[host]["theirTier"] = str(resp["tier"])
     for mid in resp.get("acks") or []:

--- a/tests/test_kernel_remote_identity.py
+++ b/tests/test_kernel_remote_identity.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""One machine, one registry row (the user 2026-07-27, whose box sat in the registry as both its
+hostname and its ssh alias — every remote session listed twice, bare postal names ambiguous). The
+serve token IS the remote kernel's identity, so:
+  - attach_remote absorbs an existing row under a DIFFERENT name when the fetched token matches,
+    carrying the machine's trust level onto the surviving name;
+  - checkin_apply files no second row when the handshaking machine is already ssh-attached here.
+
+Synthetic only — hermetic temp STATE, placeholder hosts/tokens, ssh fully stubbed out."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_identity", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class _Proc:
+    def __init__(self):
+        self.terminated = False
+
+    def poll(self):
+        return 1 if self.terminated else None
+
+    def terminate(self):
+        self.terminated = True
+
+
+class RemoteIdentity(unittest.TestCase):
+    def setUp(self):
+        km._remotes.clear()
+        with km._known_lock:
+            km._known.clear()
+        self.tokens = {}
+        self.bus_down = []
+        km._fetch_remote_token = lambda h: self.tokens.get(h, "")
+        km._remote_kernel_up = lambda h, p: True
+        km._spawn_tunnel = lambda r: r.update(proc=_Proc(), status="starting", detail="")
+        km._notify_bus_peer = (lambda host, port, up, tok="", trust="directed":
+                               (self.bus_down.append(host) if not up else None) or True)
+
+    def test_second_alias_absorbs_the_old_row(self):
+        self.tokens = {"box-hostname": "TOK-SAME", "boxalias": "TOK-SAME"}
+        km.attach_remote("box-hostname")
+        old_proc = km._remotes["box-hostname"]["proc"]
+        km.attach_remote("boxalias")
+        self.assertEqual(set(km._remotes), {"boxalias"}, "one machine, one row")
+        self.assertTrue(old_proc.terminated, "the absorbed row's tunnel is shut down")
+        self.assertIn("box-hostname", self.bus_down, "the bus is told the old peer name is gone")
+        self.assertNotIn("box-hostname", [k["host"] for k in km.list_known()],
+                         "the popover must not re-offer the duplicate name")
+
+    def test_absorb_carries_the_machines_trust_level(self):
+        self.tokens = {"box-hostname": "TOK-SAME", "boxalias": "TOK-SAME"}
+        km.attach_remote("box-hostname")
+        km.set_trust("box-hostname", "trusted")
+        km.attach_remote("boxalias")
+        self.assertEqual(km._remotes["boxalias"]["trust"], "trusted",
+                         "the level was chosen for the MACHINE; a rename must not drop it to directed")
+        self.assertEqual(km.known_trust("boxalias"), "trusted", "and the surviving name remembers it")
+
+    def test_an_explicitly_tiered_alias_keeps_its_own_level(self):
+        self.tokens = {"box-hostname": "TOK-SAME", "boxalias": "TOK-SAME"}
+        km.attach_remote("box-hostname")
+        km.set_trust("box-hostname", "trusted")
+        km._known_note("boxalias", "isolated")     # the user chose a level for THIS name before
+        km.attach_remote("boxalias")
+        self.assertEqual(km._remotes["boxalias"]["trust"], "isolated")
+
+    def test_different_tokens_stay_separate(self):
+        self.tokens = {"boxalias": "TOK-A", "otherbox": "TOK-B"}
+        km.attach_remote("boxalias")
+        km.attach_remote("otherbox")
+        self.assertEqual(set(km._remotes), {"boxalias", "otherbox"})
+
+    def test_checkin_from_an_ssh_attached_machine_files_no_second_row(self):
+        self.tokens = {"boxalias": "TOK-SAME"}
+        km.attach_remote("boxalias")
+        body = {"host": "box-hostname", "kernelPort": 12345, "busPort": 12346, "token": "TOK-SAME"}
+        payload, status = km.checkin_apply(body)
+        self.assertEqual(status, 200, "an error would make the mobile retry forever with nothing to fix")
+        self.assertTrue(payload.get("ok"))
+        self.assertEqual(payload.get("host"), "boxalias", "answered with the name it is known by here")
+        self.assertEqual(set(km._remotes), {"boxalias"})
+
+    def test_checkin_from_an_unknown_machine_still_lands(self):
+        self.tokens = {"boxalias": "TOK-A"}
+        km.attach_remote("boxalias")
+        payload, status = km.checkin_apply(
+            {"host": "mobile", "kernelPort": 12345, "busPort": 12346, "token": "TOK-OTHER"})
+        self.assertEqual(status, 200)
+        self.assertEqual(set(km._remotes), {"boxalias", "mobile"})
+
+    def test_checkin_rename_replaces_its_own_old_row(self):
+        payload, status = km.checkin_apply(
+            {"host": "mobile-old", "kernelPort": 12345, "busPort": 12346, "token": "TOK-M"})
+        self.assertEqual(status, 200)
+        payload, status = km.checkin_apply(
+            {"host": "mobile-new", "kernelPort": 12345, "busPort": 12346, "token": "TOK-M"})
+        self.assertEqual(status, 200)
+        self.assertEqual(set(km._remotes), {"mobile-new"}, "a renamed mobile keeps one row")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_remote_pull.py
+++ b/tests/test_kernel_remote_pull.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Peer-to-peer PULL — the other direction of `romp update` (the user 2026-07-27): sync rides the
+attaching side's own ssh in BOTH directions, because the remote has no route back (its push died with
+"No route to host"). `POST /tunnels/pull` / _pull_remote fetches the remote clone's committed HEAD
+and fast-forwards the local checkout onto it — ff-only, clean local tree required, kernel never
+auto-restarted. The automatic variant fires from the supervisor only for a TRUSTED remote strictly
+ahead while the local checkout sits on main.
+
+SYNTHETIC fixtures only — invented hosts and placeholder shas; subprocess/ssh fully stubbed."""
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_pull", os.path.join(BIN, "romp-kernel")).load_module()
+
+LOCAL = "a" * 40                     # local HEAD (full sha)
+REMOTE = "b" * 40                    # the remote's newer commit
+
+
+class _R:
+    def __init__(self, out="", err="", rc=0):
+        self.stdout, self.stderr, self.returncode = out, err, rc
+
+
+class FastPullGate(unittest.TestCase):
+    """_is_fast_pull mirrors _is_fast_forward: it must say no to anything it cannot prove is a strict
+    fast-forward of the LOCAL checkout."""
+
+    def _fp(self, behind, ahead, ood=True):
+        saved = (km._remote_out_of_date, km._behind_info)
+        km._remote_out_of_date = lambda r: ood
+        km._behind_info = lambda sha: {"behind": behind, "ahead": ahead, "date": ""}
+        try:
+            return km._is_fast_pull({"host": "TESTHOST", "kernel_sha": REMOTE})
+        finally:
+            km._remote_out_of_date, km._behind_info = saved
+
+    def test_strictly_ahead_is_a_fast_pull(self):
+        self.assertTrue(self._fp(behind=0, ahead=3), "the remote purely extends us — pulling only adds")
+
+    def test_everything_else_is_not(self):
+        self.assertFalse(self._fp(behind=0, ahead=0, ood=False), "up to date")
+        self.assertFalse(self._fp(behind=2, ahead=0), "behind is the PUSH direction")
+        self.assertFalse(self._fp(behind=1, ahead=1), "diverged: never automatic")
+        self.assertFalse(self._fp(behind=None, ahead=None), "an unknown build is unprovable — no")
+        self.assertFalse(self._fp(behind=0, ahead=None), "half-known is still unproven")
+
+
+class PullRemote(unittest.TestCase):
+    """_pull_remote drives git fetch + merge --ff-only via a dispatching subprocess mock."""
+
+    def setUp(self):
+        self._run, self._hc = km.subprocess.run, dict(km._HEAD_CACHE)
+        km._HEAD_CACHE.update(ts=9e18, full=LOCAL, short=LOCAL[:8])
+        km._remotes.clear()
+
+    def tearDown(self):
+        km.subprocess.run = self._run
+        km._HEAD_CACHE.clear(); km._HEAD_CACHE.update(self._hc)
+        km._remotes.clear()
+
+    def _wire(self, dirty="", rhead=REMOTE, ancestor_rc=0, merge_rc=0, count="3"):
+        calls = []
+
+        def fake(argv, **kw):
+            calls.append(argv)
+            if argv[0] == "git" and "status" in argv:
+                return _R(out=dirty)
+            if argv[0] == "git" and "fetch" in argv:
+                return _R()
+            if argv[0] == "git" and "merge-base" in argv:
+                return _R(rc=ancestor_rc)
+            if argv[0] == "git" and "rev-list" in argv:
+                return _R(out=count)
+            if argv[0] == "git" and "merge" in argv:
+                return _R(rc=merge_rc, err="not a fast-forward" if merge_rc else "")
+            if argv[0] == "git" and "rev-parse" in argv:
+                return _R(out="bbbbbbb")
+            cmd = argv[-1]                          # ssh: the clone discovery
+            if "for d in" in cmd:
+                return _R(out="DIR:/home/u/romp\nHEAD:%s\nDIRTY:" % rhead)
+            return _R()
+        km.subprocess.run = fake
+        return calls
+
+    def test_no_host_is_a_no_op(self):
+        self.assertEqual(km._pull_remote(""), (False, "no host"))
+
+    def test_a_checked_in_host_is_refused_with_the_honest_reason(self):
+        # This is the observed bug: a sync attempted at a host with no ssh route died with a bare
+        # "No route to host". The row knows there is no path — say so, and say where to sync instead.
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "checkin_peer": True}
+        ok, detail = km._pull_remote("TESTHOST")
+        self.assertFalse(ok)
+        self.assertIn("no ssh path", detail)
+        self.assertIn("dashboard", detail)
+
+    def test_push_refuses_a_checked_in_host_the_same_way(self):
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "checkin_peer": True}
+        ok, detail = km._update_remote("TESTHOST")
+        self.assertFalse(ok)
+        self.assertIn("no ssh path", detail)
+
+    def test_a_dirty_local_tree_is_refused(self):
+        # the fast-forward rewrites the working tree, and peers' uncommitted edits are not ours to move
+        self._wire(dirty=" M kernel/kernel.py")
+        ok, detail = km._pull_remote("TESTHOST")
+        self.assertFalse(ok)
+        self.assertIn("uncommitted", detail)
+
+    def test_a_clean_fast_forward_pulls_and_says_what_to_do_next(self):
+        calls = self._wire()
+        ok, detail = km._pull_remote("TESTHOST")
+        self.assertTrue(ok, detail)
+        self.assertIn("pulled 3 commits from TESTHOST", detail)
+        self.assertIn("restart romp", detail, "the kernel is NOT auto-restarted; the detail says the next step")
+        fetch = next(a for a in calls if a[0] == "git" and "fetch" in a)
+        self.assertIn("TESTHOST:/home/u/romp", fetch, "fetches from the discovered clone over our own ssh")
+        merge = next(a for a in calls if a[0] == "git" and "merge" in a)
+        self.assertIn("--ff-only", merge, "never a merge or rebase on the user's behalf")
+
+    def test_divergence_is_refused_loudly(self):
+        self._wire(ancestor_rc=1)
+        ok, detail = km._pull_remote("TESTHOST")
+        self.assertFalse(ok)
+        self.assertIn("diverged", detail)
+
+    def test_already_up_to_date_short_circuits(self):
+        self._wire(rhead=LOCAL)
+        ok, detail = km._pull_remote("TESTHOST")
+        self.assertTrue(ok)
+        self.assertIn("already up to date", detail)
+
+
+class AutoPullFiring(unittest.TestCase):
+    """The supervisor hook fires the pull only for a TRUSTED remote strictly ahead, local checkout on
+    main — and picks the pull worker, not the push one."""
+
+    def setUp(self):
+        self._prev = km._auto_update_remotes_on()
+        km._set_auto_update_remotes(True)
+        km._auto_push.clear()
+        km._auto_push_tried.clear()
+        self._saved = (km._remote_out_of_date, km._behind_info, km._local_head, km._local_branch)
+        km._remote_out_of_date = lambda r: True
+        km._behind_info = lambda sha: {"behind": 0, "ahead": 2, "date": ""}   # strictly ahead → pull side
+        km._local_head = lambda short=False: (LOCAL[:8] if short else LOCAL)
+        km._local_branch = lambda: "main"
+        self.calls = []
+
+    def tearDown(self):
+        (km._remote_out_of_date, km._behind_info, km._local_head, km._local_branch) = self._saved
+        km._set_auto_update_remotes(self._prev)
+        km._auto_push.clear()
+        km._auto_push_tried.clear()
+
+    def _run(self, row):
+        saved = km.threading.Thread
+        calls = self.calls
+
+        class _T:
+            def __init__(self, target=None, args=(), daemon=None):
+                self._t, self._a = target, args
+
+            def start(self):
+                calls.append((self._t.__name__, self._a[0]))
+        km.threading.Thread = _T
+        try:
+            km._maybe_auto_push(row)
+        finally:
+            km.threading.Thread = saved
+
+    def test_a_trusted_ahead_remote_fires_one_pull(self):
+        self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted"})
+        self.assertEqual(self.calls, [("_auto_pull_remote", "TESTHOST")])
+
+    def test_a_directed_remote_is_never_auto_pulled(self):
+        # pulling runs THEIR code here; that is exactly what the trusted tier means and directed does not
+        self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "directed"})
+        self._run({"host": "TESTHOST", "kernel_sha": REMOTE})
+        self.assertEqual(self.calls, [])
+
+    def test_off_main_is_never_auto_pulled(self):
+        # feature branches are mid-thought; they move when their owner says so
+        km._local_branch = lambda: "somefeature"
+        self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted"})
+        self.assertEqual(self.calls, [])
+        km._local_branch = lambda: ""              # detached HEAD (a release checkout)
+        self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted"})
+        self.assertEqual(self.calls, [])
+
+    def test_a_checked_in_row_fires_neither_direction(self):
+        # no ssh route from here — an auto-sync could only manufacture "No route to host" failures
+        self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted", "checkin_peer": True})
+        km._behind_info = lambda sha: {"behind": 2, "ahead": 0, "date": ""}   # …and the push side too
+        self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted", "checkin_peer": True})
+        self.assertEqual(self.calls, [])
+
+    def test_the_same_advance_is_not_pulled_twice(self):
+        row = {"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted"}
+        self._run(row)
+        self._run(row)
+        self.assertEqual(len(self.calls), 1, "one attempt per (remote sha, local HEAD)")
+
+    def test_a_pulled_phase_survives_the_drift_clearing(self):
+        # after a pull the drift clears at once (HEAD moved) but the RUNNING kernel is the old build —
+        # the 'pulled … restart romp' trace must outlive the clearing event, until the restart itself
+        km._set_auto_push("TESTHOST", "pulled", "pulled 2 commits from TESTHOST — restart romp to run it")
+        km._remote_out_of_date = lambda r: False
+        self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted"})
+        st = km._auto_push_state("TESTHOST")
+        self.assertEqual((st or {}).get("phase"), "pulled")
+
+    def test_the_row_publishes_the_fast_pull_verdict(self):
+        pub = km._remote_public({"host": "TESTHOST", "kernel_port": 29855, "local_port": 8801,
+                                 "token": "t", "status": "up", "sids": [], "kernel_sha": REMOTE})
+        self.assertTrue(pub["fastPull"])
+        self.assertFalse(pub["fastForward"])
+
+
+class PullRoute(unittest.TestCase):
+    def test_the_popover_wires_a_pull_button_to_the_route(self):
+        src = km._LANDING_REMOTES_JS
+        self.assertIn("data-p=", src, "a Pull control keyed by host")
+        self.assertIn("/tunnels/pull", src)
+        self.assertIn("t.fastPull", src, "offered exactly when the pull is a provable fast-forward")
+        self.assertIn("checkinPeer", src, "no Push/Pull dead-ends on a host with no ssh path")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postal_peer_identity.py
+++ b/tests/test_postal_peer_identity.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""One bus, one PEER_STATE row (the user 2026-07-27): a machine reaches a fleet under TWO names — the
+alias its kernel dials (the ssh-config name) and the hostname it declares about itself on its own
+inbound dials — and name-keyed PEER_STATE then lists every remote session twice and makes bare names
+ambiguous. Every exchange now carries `busId` (this bus process's identity, additive like `tier`);
+the receiver files a known bus under its DIALABLE alias and drops the self-declared duplicate.
+
+Synthetic only — hermetic temp state dir, placeholder hostnames, invented notes-domain sessions."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+_SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
+Path(_SESS).write_text(json.dumps([{"id": "sess-web", "name": "web", "dir": "/tmp/notes-api",
+                                    "state": "waiting", "working": ""}]))
+os.environ["ROMP_SESSIONS_FILE"] = _SESS
+ps = SourceFileLoader("romp_postal_peer_identity", os.path.join(BIN, "romp-postal-service")).load_module()
+
+REMOTE_BUS = "f" * 32   # the peer machine's busId, stable across both of its names
+
+
+def _req(host, bus_id=None, presence=None):
+    r = {"host": host, "epoch": 1, "proto": ps.PEER_PROTO,
+         "presence": presence if presence is not None else [{"name": "api", "id": "sess-api"}],
+         "holds": [], "relays": [], "acks": [], "bounces": [], "wait": False}
+    if bus_id:
+        r["busId"] = bus_id
+    return r
+
+
+class PeerIdentityFold(unittest.TestCase):
+    def setUp(self):
+        os.environ["ROMP_POSTAL_PEERS"] = "1"
+        ps.PEERS.clear()
+        ps.PEER_STATE.clear()
+
+    def tearDown(self):
+        os.environ.pop("ROMP_POSTAL_PEERS", None)
+
+    def _peer_alias(self):
+        """The kernel-notified, dialable alias row + one exchange that stamps its busId."""
+        ps.peer_update({"host": "boxalias", "port": 19999, "up": True, "trust": "trusted"})
+        req = ps.build_exchange_request("boxalias", wait=False)
+        ps.peer_exchange_apply("boxalias", req, dict(_req("boxalias", bus_id=REMOTE_BUS), tier="trusted"))
+
+    def test_inbound_dial_under_self_declared_name_files_under_the_alias(self):
+        self._peer_alias()
+        resp, status = ps.peer_exchange_handle(_req("box-hostname", bus_id=REMOTE_BUS))
+        self.assertEqual(status, 200)
+        self.assertNotIn("box-hostname", ps.PEER_STATE, "the second name must not become a second row")
+        self.assertIn("boxalias", ps.PEER_STATE)
+        self.assertEqual([a["name"] for a in ps.PEER_STATE["boxalias"]["presence"]], ["api"],
+                         "the inbound exchange's fresh presence lands on the alias row")
+
+    def test_no_duplicate_sessions_in_the_agents_view(self):
+        self._peer_alias()
+        ps.peer_exchange_handle(_req("box-hostname", bus_id=REMOTE_BUS))
+        names = [(h, a.get("name")) for h, st in ps.PEER_STATE.items() for a in st["presence"]]
+        self.assertEqual(names, [("boxalias", "api")], "one bus, one presence row per session")
+
+    def test_apply_drops_a_stale_self_declared_row(self):
+        # The self-declared name arrived FIRST (inbound dial before this side ever attached), then the
+        # user attached the alias: the dialer's next apply folds the stale hostname row away.
+        ps.peer_exchange_handle(_req("box-hostname", bus_id=REMOTE_BUS))
+        self.assertIn("box-hostname", ps.PEER_STATE, "unknown busId, no dialable twin — stands alone")
+        self._peer_alias()
+        self.assertNotIn("box-hostname", ps.PEER_STATE, "the alias attach folds the hostname row")
+        self.assertIn("boxalias", ps.PEER_STATE)
+
+    def test_relays_are_trust_judged_under_the_alias(self):
+        # The user tiered the ALIAS trusted; mail arriving on the machine's own inbound dial (declared
+        # hostname) must be judged under that alias, not quarantined under an unknown name.
+        self._peer_alias()
+        seen = {}
+        orig = ps._relay_in
+        ps._relay_in = lambda host, m, token_proven=False: (seen.setdefault("host", host), ("ack", None))[1]
+        try:
+            ps.peer_exchange_handle(dict(_req("box-hostname", bus_id=REMOTE_BUS),
+                                         relays=[{"mid": "m1", "to": "web", "frm": "api", "body": "hi"}]))
+        finally:
+            ps._relay_in = orig
+        self.assertEqual(seen.get("host"), "boxalias")
+
+    def test_older_peer_without_busid_is_untouched(self):
+        self._peer_alias()
+        ps.peer_exchange_handle(_req("box-hostname"))   # no busId — pre-fold peer
+        self.assertIn("box-hostname", ps.PEER_STATE, "no identity proof, no fold — behavior unchanged")
+        self.assertIn("boxalias", ps.PEER_STATE)
+
+    def test_two_dialable_names_are_left_to_the_kernel(self):
+        # Both names have kernel-notified ports (a kernel-level duplicate): the bus must not pick a
+        # winner — attach_remote's token dedupe owns that fix.
+        ps.peer_update({"host": "boxalias", "port": 19999, "up": True, "trust": "trusted"})
+        ps.peer_update({"host": "box-hostname", "port": 19998, "up": True, "trust": "directed"})
+        req = ps.build_exchange_request("boxalias", wait=False)
+        ps.peer_exchange_apply("boxalias", req, _req("boxalias", bus_id=REMOTE_BUS))
+        ps.peer_exchange_handle(_req("box-hostname", bus_id=REMOTE_BUS))
+        self.assertIn("boxalias", ps.PEER_STATE)
+        self.assertIn("box-hostname", ps.PEER_STATE)
+
+    def test_exchange_payloads_carry_this_bus_identity(self):
+        req = ps.build_exchange_request("boxalias", wait=False)
+        self.assertEqual(req["busId"], ps.BUS_ID)
+        resp, _ = ps.peer_exchange_handle(_req("someone"))
+        self.assertEqual(resp["busId"], ps.BUS_ID)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/net-sync-row.test.ts
+++ b/ui/webview/net-sync-row.test.ts
@@ -1,0 +1,37 @@
+// The remote-kernel row says HOW a build differs and offers the action that can actually succeed
+// (the user 2026-07-27): "behind N" offers Push, "ahead N" offers Pull (fetched over THIS machine's
+// ssh — the remote has no route back, its own push died with "No route to host"), a checked-in host
+// offers neither (no ssh path from here; the tooltip says to sync from its own dashboard), and an
+// auto-sync in flight ('pulling' included) suppresses the manual buttons. Pinned in BOTH copies —
+// web _LANDING_REMOTES_JS (kernel.py) and the VS Code strip — which must stay in step.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+const STRIP = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
+
+test("web popover: Pull rides the attach tunnel, gated to a provable fast-forward", () => {
+  assert.match(KERNEL, /data-p=/, "a Pull control keyed by host");
+  assert.match(KERNEL, /\/tunnels\/pull/, "wired to the kernel's pull route");
+  assert.match(KERNEL, /t\.fastPull&&!apx&&!t\.checkinPeer/, "offered only when ff-provable, idle, ssh-reachable");
+  // a strictly-ahead remote replaces Push with Pull — a push there would only be refused
+  assert.match(KERNEL, /!t\.checkinPeer&&!t\.fastPull\)\?'<button class=rnet-upd data-u=/);
+  // the checked-in case explains itself instead of dead-ending
+  assert.match(KERNEL, /No ssh path from this machine \(it checked in over its own tunnel\)/);
+  // an auto-pull in flight counts as busy everywhere a push does
+  assert.match(KERNEL, /t\.autoPush\.phase==='pulling'/);
+});
+
+test("VS Code strip: same row treatment", () => {
+  assert.match(STRIP, /ab > 0 \? ` · ahead \$\{ab\} commit/, "ahead/behind wording matches the web copy");
+  assert.match(STRIP, /bb > 0 \? ` · behind \$\{bb\} commit/);
+  assert.match(STRIP, /" · diverged"/);
+  assert.match(STRIP, /act\("\/tunnels\/pull", t\.host, pl, "Pulling…"\)/, "Pull posts the kernel route");
+  assert.match(STRIP, /t\.status === "up" && t\.fastPull && !apx && !t\.checkinPeer/);
+  assert.match(STRIP, /!t\.checkinPeer && !t\.fastPull/, "Push yields to Pull on a strictly-ahead remote");
+  assert.match(STRIP, /No ssh path from this machine \(it checked in over its own tunnel\)/);
+  assert.match(STRIP, /t\.autoPush\.phase === "pulling"/);
+});

--- a/ui/webview/net-trust-pending.test.ts
+++ b/ui/webview/net-trust-pending.test.ts
@@ -1,0 +1,56 @@
+// A trust change (and the web popover's Match) confirms on a LATER poll, and both popovers rebuild
+// their rows every poll — so a snapshot fetched before the change used to repaint the OLD level after
+// it, which read as "didn't hold" and invited a second click (the user 2026-07-27). Both copies now
+// hold a per-host pending map that survives re-renders: rows show the CHOSEN level, disabled with an
+// accent applying cue, until a snapshot agrees (the confirming event, never a timer); a refused write
+// deletes the entry so the next render honestly reverts. Pinned in BOTH copies (web _LANDING_REMOTES_JS
+// in kernel.py, VS Code strip.ts) — they must stay in step.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+const STRIP = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
+const STRIPCSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.css"), "utf8");
+
+test("web popover: pending trust survives re-renders until a snapshot confirms", () => {
+  assert.match(KERNEL, /var _pendTrust=\{\},_pendMirror=\{\};/, "per-host pending maps outlive render()");
+  // cleared by AGREEMENT with the snapshot, not by the POST returning or any timer
+  assert.match(KERNEL, /function pendLvl\(map,host,current\)\{var p=map\[host\];if\(p&&current===p\)\{delete map\[host\];p=null;\}return p;\}/);
+  // recorded ON the click (ack now), before the round trip
+  assert.match(KERNEL, /_pendTrust\[h\]=s\.value;s\.disabled=true;s\.classList\.add\('rnet-applying'\);/);
+  // a refused write deletes the pending entry (honest revert) AND still alerts (fail loudly)
+  assert.match(KERNEL, /delete _pendTrust\[h\];alert\('trust change on '/);
+  // all three row kinds (attached, previously-attached, via-relay) render the pending level
+  assert.match(KERNEL, /var tpd=pendLvl\(_pendTrust,t\.host,t\.trust\|\|'directed'\)/);
+  assert.match(KERNEL, /var kpd=pendLvl\(_pendTrust,k\.host,k\.trust\|\|'directed'\)/);
+  assert.match(KERNEL, /var vpd=pendLvl\(_pendTrust,v\.host,v\.trust\|\|'directed'\)/);
+  // the cue is visible, not just a disabled control
+  assert.match(KERNEL, /rnet-pend/, "an 'applying' note renders next to a pending select");
+  assert.match(KERNEL, /\.rnet-trust\.rnet-applying\{border-color:var\(--accent\)/, "accent = in-progress chrome");
+});
+
+test("web popover: Match waits for the peer's tier gossip, visibly", () => {
+  // pending Match keyed to the DESIRED level, confirmed by tiers gossip (theirs === pending)
+  assert.match(KERNEL, /var mpd=pendLvl\(_pendMirror,t\.host,theirs\)/);
+  assert.match(KERNEL, /data-lvl=/, "the button carries the level it is matching to");
+  assert.match(KERNEL, /_pendMirror\[h\]=b\.getAttribute\('data-lvl'\)/);
+  assert.match(KERNEL, /rnet-mirror disabled title=/, "the in-flight state renders disabled");
+  assert.match(KERNEL, /Matching/, "…labeled Matching");
+  assert.match(KERNEL, /waiting for its bus to confirm/, "the pending tooltip says what it waits on");
+  // while pending, the row must not scream mismatch at the user who just fixed it
+  assert.match(KERNEL, /rnet-back'\+\(mm&&!mpd\?' rnet-mismatch':''\)/);
+});
+
+test("VS Code strip: same pending-trust treatment", () => {
+  assert.match(STRIP, /const pendingTrust = new Map<string, string>\(\);/);
+  assert.match(STRIP, /if \(pend && \(t\.trust \|\| "directed"\) === pend\) \{ pendingTrust\.delete\(t\.host\); pend = undefined; \}/,
+    "cleared by agreement with the snapshot, never a timer");
+  assert.match(STRIP, /pendingTrust\.set\(t\.host, trust\.value\);/, "recorded on the click");
+  assert.match(STRIP, /if \(!\(d && d\.ok\)\) pendingTrust\.delete\(t\.host\)/, "refused write reverts honestly");
+  assert.match(STRIP, /sn-applying/, "the select wears the applying cue");
+  assert.match(STRIP, /pn\.textContent = "applying…"/, "a visible note, not just a disabled control");
+  assert.match(STRIPCSS, /\.sn-trust\.sn-applying \{ border-color: var\(--accent, #9cd2ff\)/);
+});

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -87,6 +87,10 @@
   background: var(--vscode-button-secondaryBackground, #2a2a2a); color: var(--vscode-foreground, #ccc);
   border: 1px solid var(--vscode-widget-border, #3a3a3a); cursor: pointer; }
 .sn-trust:disabled { opacity: 0.55; cursor: default; }
+/* applying (trust change awaiting the kernel's confirming snapshot) = in-progress chrome, so it wears
+   the accent, never a status color; 11px matches the row's other annotations */
+.sn-trust.sn-applying { border-color: var(--accent, #9cd2ff); opacity: 0.8; }
+.sn-pend { color: var(--accent, #9cd2ff); font-size: 11px; flex: 0 0 auto; }
 /* "Previously attached": a quiet header + dimmed rows, so remembered hosts read as history you can act
    on and never as something currently connected. Hover restores full opacity (they're interactive). */
 .sn-khead { color: #6e7681; font-size: 10.5px; letter-spacing: .04em; text-transform: uppercase;

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -323,6 +323,13 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       .catch(() => { b.disabled = false; b.textContent = prev; });
   }
 
+  // A trust change confirms on a LATER poll, and renderList rebuilds every poll — so a snapshot
+  // fetched before the change repainted the OLD level after it, which read as "didn't hold" and
+  // invited a second click (the user 2026-07-27). Pending survives re-renders: the select shows the
+  // CHOSEN level, disabled with the accent applying cue, until a snapshot agrees (the confirming
+  // event — no timer). A refused write deletes the entry, so the next render honestly reverts.
+  const pendingTrust = new Map<string, string>();
+
   function renderList(ts: any[], known: any[] = []) {
     list.textContent = "";
     button.classList.toggle("on", ts.some((t) => t.status === "up"));
@@ -361,21 +368,32 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       const TRUSTW: Record<string, string> = {
         trusted: "trusted (auto-accept)", directed: "directed (held for you)", isolated: "isolated (no mail)",
       };
+      let pend = pendingTrust.get(t.host);
+      if (pend && (t.trust || "directed") === pend) { pendingTrust.delete(t.host); pend = undefined; }
       for (const lvl of ["trusted", "directed", "isolated"]) {
         const o = document.createElement("option");
         o.value = lvl; o.textContent = TRUSTW[lvl];
-        if ((t.trust || "directed") === lvl) o.selected = true;
+        if ((pend || t.trust || "directed") === lvl) o.selected = true;
         trust.appendChild(o);
       }
+      if (pend) { trust.disabled = true; trust.classList.add("sn-applying"); }
       trust.addEventListener("change", () => {
+        pendingTrust.set(t.host, trust.value);   // ack on the click; re-renders show the chosen level
         trust.disabled = true;
+        trust.classList.add("sn-applying");
         fetch(kernelUrl("/tunnels/trust"), { method: "POST", headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ host: t.host, trust: trust.value }) })
           .then((rp) => rp.json())
-          .then((d) => { if (!(d && d.ok)) { /* the next poll re-renders the true level */ } trust.disabled = false; schedule(600); })
-          .catch(() => { trust.disabled = false; });
+          .then((d) => { if (!(d && d.ok)) pendingTrust.delete(t.host); schedule(600); })
+          .catch(() => { pendingTrust.delete(t.host); schedule(600); });
       });
       r.appendChild(trust);
+      if (pend) {
+        const pn = document.createElement("span");
+        pn.className = "sn-pend";
+        pn.textContent = "applying…";
+        r.appendChild(pn);
+      }
       // A push romp is ALREADY doing needs no button — it would only invite a duplicate of the work in
       // flight. The row shows the live phase instead (below); the manual Push returns if it fails.
       const apx = !!(t.autoPush && (t.autoPush.phase === "pushing" || t.autoPush.phase === "waiting"));

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -352,10 +352,23 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       dot.title = TIP[t.status] || "";
       const nm = document.createElement("span");
       nm.className = "sn-name";
-      nm.textContent = `${t.host} — ${LBL[t.status] || t.status}`
-        + (t.outOfDate ? " · different build" : "");
+      // Version drift names HOW it differs, matching the web popover: behind N (a push delivers
+      // exactly those), ahead N (a pull collects them), diverged, or different build (sha unknown
+      // here). Shas + the remote commit's date ride the tooltip (progressive disclosure).
+      let ver = "";
+      if (t.outOfDate) {
+        const bb = t.behindBy, ab = t.aheadBy;
+        ver = " · different build";
+        if (typeof bb === "number" && typeof ab === "number") {
+          ver = bb > 0 && ab > 0 ? " · diverged"
+            : ab > 0 ? ` · ahead ${ab} commit${ab === 1 ? "" : "s"}`
+            : bb > 0 ? ` · behind ${bb} commit${bb === 1 ? "" : "s"}` : ver;
+        }
+      }
+      nm.textContent = `${t.host} — ${LBL[t.status] || t.status}` + ver;
       nm.title = (TIP[t.status] || "")
-        + (t.outOfDate ? "\n\nThis machine is running a different commit than yours; Push sends this machine's committed romp there." : "");
+        + (t.outOfDate ? `\n\nRunning ${t.kernelSha || "?"}${t.kernelDate ? " from " + t.kernelDate : ""}; this machine is at ${t.localSha || "?"}.` : "")
+        + (t.outOfDate && t.checkinPeer ? " No ssh path from this machine (it checked in over its own tunnel) — sync from its own dashboard." : "");
       r.append(dot, nm);
       // Federation trust (per-host): trusted = full two-way postal; directed (default) = its mail is
       // HELD for your approval; isolated = dashboard only, no postal. The gate lives in the bus.
@@ -396,14 +409,24 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       }
       // A push romp is ALREADY doing needs no button — it would only invite a duplicate of the work in
       // flight. The row shows the live phase instead (below); the manual Push returns if it fails.
-      const apx = !!(t.autoPush && (t.autoPush.phase === "pushing" || t.autoPush.phase === "waiting"));
-      if (t.status === "up" && t.outOfDate && !apx) {
+      const apx = !!(t.autoPush && (t.autoPush.phase === "pushing" || t.autoPush.phase === "waiting" || t.autoPush.phase === "pulling"));
+      // A checked-in host has no ssh route FROM here (Push/Pull can only fail — the tooltip says where
+      // to sync); a strictly-ahead remote gets Pull in Push's place (a push there would only be refused).
+      if (t.status === "up" && t.outOfDate && !apx && !t.checkinPeer && !t.fastPull) {
         const u = document.createElement("button");
         u.textContent = "Push";
         u.title = `Push this machine's committed romp to ${t.host} and restart its kernel, so it runs exactly this code. `
           + `Uncommitted local edits are not sent, so commit first. It refuses if that machine has its own commits.`;
         u.addEventListener("click", () => act("/tunnels/update", t.host, u, "Pushing…"));
         r.appendChild(u);
+      }
+      if (t.status === "up" && t.fastPull && !apx && !t.checkinPeer) {
+        const pl = document.createElement("button");
+        pl.textContent = "Pull";
+        pl.title = `Pull ${t.host}'s newer commits into this machine's romp (fast-forward only; refuses if this tree `
+          + `has uncommitted changes). This kernel keeps running the old build until you restart romp.`;
+        pl.addEventListener("click", () => act("/tunnels/pull", t.host, pl, "Pulling…"));
+        r.appendChild(pl);
       }
       if (t.status === "no-kernel") {
         const s = document.createElement("button");
@@ -479,7 +502,7 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       renderList(ts, (d && d.known) || []);
       // An automatic push in flight counts as busy: the button marches while romp works in the background,
       // and the poll runs fast so the phase reads live.
-      const pushing = ts.some((t: any) => t.autoPush && (t.autoPush.phase === "pushing" || t.autoPush.phase === "waiting"));
+      const pushing = ts.some((t: any) => t.autoPush && (t.autoPush.phase === "pushing" || t.autoPush.phase === "waiting" || t.autoPush.phase === "pulling"));
       button.classList.toggle("busy", ts.some((t: any) => busy(t.status)) || pushing);
       schedule(ts.some((t: any) => busy(t.status)) || pushing ? 600 : 3000);   // fast while mid-attach/pushing, slow keep-alive after
     }).catch((err) => {


### PR DESCRIPTION
Three fixes from the first real two-machine federation shakedown, all sharing one root theme: the attaching side owns the ssh route, and every surface should reflect the machine's identity and reachability honestly.

**One machine, one registry row.** A box reached the fleet under two names — the ssh alias the kernel dials and the hostname it declares about itself on its own inbound dials — so every remote session listed twice and bare postal names errored as ambiguous. Exchanges now carry a per-process `busId` (additive, like `tier`); the receiving bus files a known bus under its dialable alias, folds stale self-declared rows, and trust-judges inbound relays under the alias the user actually tiered. Kernel side, the serve token is the machine's identity: attaching under a second name absorbs the old row (tunnel down, bus notified, trust carried), and a check-in handshake from an already-ssh-attached machine files no second row.

**Trust controls acknowledge and hold.** A trust change (and Match, confirmed only by the peer's next tier gossip) races the popover's poll-driven re-render, so the old level repainted after the click — it read as "didn't hold" and invited a second click. Both popover copies now keep a per-host pending map that survives re-renders: the chosen level shows disabled with an accent applying cue until a snapshot agrees (the confirming event, never a timer); a refused write reverts honestly and still alerts.

**Sync rides the attach tunnel in both directions.** The remote pushing its newer build back dies with "No route to host" — connectivity is one-way by design. New `_pull_remote` + `POST /tunnels/pull` fetch the remote's committed HEAD over the attaching side's own ssh and fast-forward the local checkout (ff-only, clean tracked tree, no kernel auto-restart — the result says what to run). Auto-sync gains the pull direction under the same setting, gated to trusted remotes strictly ahead while local sits clean on main. Rows now say *how* a build differs (behind N / ahead N / diverged) and offer the action that can succeed: Pull replaces Push on a strictly-ahead remote, and a checked-in host (no ssh path from here) offers neither, with the tooltip saying where to sync instead.

Tests: `test_postal_peer_identity.py`, `test_kernel_remote_identity.py`, `test_kernel_remote_pull.py`, `net-trust-pending.test.ts`, `net-sync-row.test.ts`; full Python (3313) and Node (1368) suites green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)