### PR TITLE
bootstrap only wires a fork remote for someone who actually has one

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -66,15 +66,27 @@ git -C "$DIR" pull --quiet --ff-only >/dev/null 2>&1 || true
 # follow the workflow the repo documents (found on a first Linux install,
 # 2026-07-27). Set it up here so the clone arrives ready to contribute.
 #
-# Best-effort and non-fatal: most people installing romp will never push to it,
-# and gh may be absent or logged out. ROMP_FORK names the fork explicitly;
-# otherwise ask gh who the authenticated user is and point at <user>/romp. Never
-# overwrite an existing `fork` remote — a contributor may have set their own.
+# Only for someone who ACTUALLY HAS a fork. The first cut of this derived <gh-user>/romp from
+# whoever gh happened to be logged in as and wired it blind, so anyone with gh installed — the
+# overwhelming majority, who only ever want to run romp — got a `fork` remote pointing at a repo
+# that does not exist, remote.pushDefault aimed at it, and a line of confusing output in the
+# middle of a plain install (the user 2026-07-27, who asked what it was and whether it leaked
+# someone else's fork; it does not — it shows the READER's own login — but it was still wrong).
+#
+# So the auto-detected case must PROVE the fork exists before touching anything, and say nothing
+# at all when it doesn't. ROMP_FORK is the explicit escape hatch and is trusted as given (it may
+# name a fork on a host gh cannot see). Never overwrites an existing `fork` remote — a
+# contributor may have pointed it somewhere deliberately.
 if [ -z "${ROMP_NO_FORK_REMOTE:-}" ] && ! git -C "$DIR" remote get-url fork >/dev/null 2>&1; then
     fork_url="${ROMP_FORK:-}"
     if [ -z "$fork_url" ] && command -v gh >/dev/null 2>&1; then
         gh_user="$(gh api user --jq .login 2>/dev/null || true)"
-        [ -n "$gh_user" ] && fork_url="https://github.com/$gh_user/romp.git"
+        # `gh repo view` is the existence check the first version lacked. Requiring it to be a
+        # FORK too keeps us off an unrelated repo that merely happens to be called "romp".
+        if [ -n "$gh_user" ] \
+           && [ "$(gh repo view "$gh_user/romp" --json isFork --jq .isFork 2>/dev/null)" = "true" ]; then
+            fork_url="https://github.com/$gh_user/romp.git"
+        fi
     fi
     if [ -n "$fork_url" ]; then
         git -C "$DIR" remote add fork "$fork_url" 2>/dev/null || true

--- a/tests/bootstrap-sh.bats
+++ b/tests/bootstrap-sh.bats
@@ -30,6 +30,9 @@ setup() {
     git -C "$ROMP_REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m r2
     git -C "$ROMP_REPO" tag v0.2.0
     git -C "$ROMP_REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m post-release
+
+    # Stub dir for per-test fakes (a `gh` standing in for various fork situations).
+    STUB="$TEST_DIR/stub"; mkdir -p "$STUB"
 }
 
 teardown() { rm -rf "$TEST_DIR"; }
@@ -115,6 +118,59 @@ teardown() { rm -rf "$TEST_DIR"; }
         run bash "$REPO_ROOT/bootstrap.sh"
     [ "$status" -eq 0 ]
     [ "$(git -C "$HOME/romp" remote get-url fork)" = "https://example.invalid/first/romp.git" ]
+}
+
+@test "bootstrap.sh: a user with NO fork gets no remote and no output about one" {
+    # The overwhelming majority of installs. gh is present and logged in, but this user has never
+    # forked romp — deriving <gh-user>/romp and wiring it blind (the first cut of this) gave them a
+    # remote pointing at a nonexistent repo, pushDefault aimed at it, and a baffling line mid-install.
+    cat > "$STUB/gh" <<'EOF'
+#!/usr/bin/env bash
+# authenticated, but `gh repo view <user>/romp` fails: no such fork
+case "$*" in
+  "api user --jq .login") echo "someone" ;;
+  *"repo view"*)          exit 1 ;;
+esac
+EOF
+    chmod +x "$STUB/gh"
+
+    PATH="$STUB:$PATH" ROMP_DIR="$HOME/romp" run bash "$REPO_ROOT/bootstrap.sh"
+    [ "$status" -eq 0 ]
+    ! git -C "$HOME/romp" remote get-url fork 2>/dev/null
+    [ -z "$(git -C "$HOME/romp" config --get remote.pushDefault || true)" ]
+    [[ "$output" != *"Publishing remote"* ]]
+    [[ "$output" != *"someone/romp"* ]]
+}
+
+@test "bootstrap.sh: a user who DOES have a fork still gets it wired" {
+    cat > "$STUB/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "api user --jq .login") echo "contributor" ;;
+  *"repo view"*)          echo "true" ;;      # it exists AND is a fork
+esac
+EOF
+    chmod +x "$STUB/gh"
+
+    PATH="$STUB:$PATH" ROMP_DIR="$HOME/romp" run bash "$REPO_ROOT/bootstrap.sh"
+    [ "$status" -eq 0 ]
+    [ "$(git -C "$HOME/romp" remote get-url fork)" = "https://github.com/contributor/romp.git" ]
+    [ "$(git -C "$HOME/romp" config --get remote.pushDefault)" = "fork" ]
+}
+
+@test "bootstrap.sh: a repo named romp that is NOT a fork is left alone" {
+    cat > "$STUB/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "api user --jq .login") echo "someone" ;;
+  *"repo view"*)          echo "false" ;;     # exists, but an unrelated repo of the same name
+esac
+EOF
+    chmod +x "$STUB/gh"
+
+    PATH="$STUB:$PATH" ROMP_DIR="$HOME/romp" run bash "$REPO_ROOT/bootstrap.sh"
+    [ "$status" -eq 0 ]
+    ! git -C "$HOME/romp" remote get-url fork 2>/dev/null
 }
 
 @test "bootstrap.sh: no fork remote is not fatal — installing is not contributing" {


### PR DESCRIPTION
Fixing a rough edge I introduced in #74.

## What was wrong

The first cut derived `<gh-user>/romp` from whoever `gh` happened to be logged in as and wired it **blind**:

```bash
gh_user="$(gh api user --jq .login 2>/dev/null || true)"
[ -n "$gh_user" ] && fork_url="https://github.com/$gh_user/romp.git"
```

So anyone with `gh` installed — the overwhelming majority, who only ever want to *run* romp — got:

- a `fork` remote pointing at a repository that **does not exist**
- `remote.pushDefault` aimed at it, so a bare `git push` fails confusingly
- an unexplained line of output in the middle of a plain install

The user hit exactly this and asked what it was, and whether it had leaked somebody else's fork into their install. It had not — the line shows the *reader's own* login — but nothing about that was obvious from the output, and none of it should have been there for a non-contributor.

## The fix

The auto-detected path now proves the fork exists before touching anything, and stays **completely silent** when it doesn't:

```bash
[ "$(gh repo view "$gh_user/romp" --json isFork --jq .isFork 2>/dev/null)" = "true" ]
```

Requiring `isFork` as well as existence keeps us off an unrelated repository that merely happens to be named `romp`.

`ROMP_FORK` remains the explicit escape hatch and is still trusted as given, since it may name a fork on a host `gh` cannot see. An existing `fork` remote is still never overwritten.

## Tests

Three new, covering the three situations that differ:

| situation | outcome |
|---|---|
| logged in, **no fork** | no remote, no pushDefault, no output |
| logged in, **has a fork** | wired as before |
| repo named `romp` that **isn't a fork** | left alone |

The first and third fail against unfixed `main`; the second passes on both, pinning that contributors keep the behaviour #74 added.

Full suite green: 3321 python tests and every bats file.