### PR TITLE
The awaiting badge comes back: a negative overlay row no longer vetoes the stamp

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2122,6 +2122,14 @@ def _mark_awaiting_backstop(gid, at):
     _write_auto_nudge(d)
 
 
+def _last_awaiting_is_lift(nd):
+    """True when the node's newest awaiting diary event is already a lift — the idempotence guard for
+    sweeping rolled-up stamps, whose fields the fold does not re-materialize (rolledUp nodes are
+    display-frozen), so the field alone cannot say whether the lift already happened."""
+    evs = [e for e in (nd.get("log") or []) if e.get("kind") == "awaiting"]
+    return bool(evs) and bool(evs[-1].get("lift"))
+
+
 def _lift_spent_awaiting(now, tmux):
     """Retire a goal's ⏳ awaiting stamp once the dispatches it was waiting on have RETURNED (the user
     2026-07-22). The closer's lift is bounded to the goals a turn actually WORKED ON (`touched`), which is
@@ -2149,17 +2157,55 @@ def _lift_spent_awaiting(now, tmux):
             nodes = store.get("nodes") or {}
             stamped = [nd for nd in nodes.values()
                        if nd.get("awaitingWhy") and nd.get("awaitingAt") and not nd.get("rolledUp")]
+            # A stamped node the roll-down folded under a RESOLVED ancestor: its card's story ended, but
+            # the stamp survives invisibly (every reader skips rolledUp) — lift it explicitly so the
+            # diary says why it went, instead of an unretired wait no surface can show (the user
+            # 2026-07-27). Guarded on the diary so an unmaterialized lift never re-fires each tick.
+            rolled = [nd for nd in nodes.values()
+                      if nd.get("awaitingWhy") and nd.get("rolledUp")
+                      and not _last_awaiting_is_lift(nd)]
+            changed = False
+            for nd in rolled:
+                if jd.record_verdict(store, nd, "romp", "awaiting", now, lift=True):
+                    changed = True
             if not stamped:
+                if changed:
+                    jd.rollup_status(store, False)
+                    jd.save_goals(sid, store)
+                    _mark_views_dirty()
                 continue
             every = _bg_scan_all_cached(s["path"])
             if not every:
+                if changed:
+                    jd.rollup_status(store, False)
+                    jd.save_goals(sid, store)
+                    _mark_views_dirty()
                 continue
             running = {t.get("id") for t in every if t.get("status") == "running"}
-            changed = False
+            placed = _bg_placed_tops(sid, s["path"], [t.get("id") for t in every])
+            def _top_of(x):
+                seen = set()
+                while x in nodes and nodes[x].get("parentId") is not None and x not in seen:
+                    seen.add(x); x = nodes[x]["parentId"]
+                return x
             for nd in stamped:
                 at, born = nd.get("awaitingAt") or 0, nd.get("t") or 0
-                # the dispatches this goal owns: launched during its life, at or before the stamp it explains
-                own = [t for t in every if born <= (t.get("t") or 0) <= at]
+                top = _top_of(nd.get("id"))
+                # The dispatches this goal owns. Placement is authoritative when the judge has spoken:
+                # a task placed under ANOTHER card can never retire this stamp (the user 2026-07-27:
+                # unrelated returns were lifting CI-wait stamps — one lifted the same minute it was
+                # re-asserted). The time window survives only for placement-unknown launches (the
+                # conservative pre-verdict shape): launched during the goal's life, at or before the
+                # stamp it explains.
+                own = []
+                for t in every:
+                    p = placed.get(t.get("id"))
+                    if p is not None:
+                        if p == top:
+                            own.append(t)             # the goal's own thread, before OR after the stamp:
+                            #                           anything of its own still out keeps the wait honest
+                    elif born <= (t.get("t") or 0) <= at:
+                        own.append(t)
                 if not own:                           # nothing dispatched → not a background wait; leave it
                     continue
                 if any(t.get("id") in running for t in own):
@@ -6537,6 +6583,8 @@ def _session_awaiting(sid, path, idle, stamp=False):
          so the death notice — not awaiting — is the truth there. Same pending-only rule as 0.5 (the
          scan rows carry the same launching tool_use id the lifecycle set does).
       1. the states/<sid>.jsonl AWAITING OVERLAY — {"awaiting":bool,"why":…} the SDK/tmux Stop hooks write.
+         POSITIVE rows only: an awaiting:false row contributes nothing and falls through (the Stop hook
+         writes false unconditionally at every turn end, so a false row is ambient, not an answer).
       2. the JUDGE's durable ⏳ stamp (_session_stamp_cached), OPT-IN via stamp=True — the closer's awaiting
          verdict, materialized in the goal store, so it OUTLIVES a kernel restart (sources 0-1 die with the
          backend, which is how a genuinely-waiting session read 'stalled'). LIVE-only: a dormant session's
@@ -6575,8 +6623,15 @@ def _session_awaiting(sid, path, idle, stamp=False):
                 return "waiting on a background task%s" % ((": " + d0) if d0 else "")
             return "waiting on %d background tasks%s" % (len(pending), (" — " + d0 + ", …") if d0 else "")
     ov = _states_awaiting_overlay(sid)
-    if ov is not None:                                # a producer is writing overlay records → trust it
-        return (ov.get("why") or "waiting on dispatched work") if ov.get("awaiting") else None
+    if ov is not None and ov.get("awaiting"):         # a producer wrote a LIVE awaiting:true → trust its why
+        return ov.get("why") or "waiting on dispatched work"
+    # An awaiting:false overlay row is NOT a veto — it says only that THIS channel has nothing to add.
+    # The SDK Stop hook has written an unconditional false at every turn end since 2026-07-07 while
+    # nothing writes true, so treating "most recent row is false" as the session's answer made source 2
+    # unreachable on every SDK session: the durable stamp never lit the rail chip, chat chip, or
+    # timeline lane, and when bf55a2f (2026-07-24) narrowed the live sources to pending-only the
+    # awaiting badge visibly vanished fleet-wide (the user 2026-07-27). A negative from one layer
+    # falls through to the next; only a POSITIVE short-circuits.
     # Source 2 — the JUDGE's durable ⏳ stamp (restart-proof), OPT-IN. Only for a LIVE CLI (`live is not None`
     # means a backend snapshot exists, tmux or SDK; a dormant session never resurrects off a stale stamp) AND
     # only when the caller asked (stamp=True): the session-scoped display surfaces want it, the per-goal feed
@@ -6598,12 +6653,13 @@ def _bg_live_norm(sid, path):
         return []
     if "bgTasks" in live:
         return [{"tid": t.get("toolUseId"), "desc": str(t.get("desc") or "").strip(),
-                 "t": int(t.get("since") or 0)}
+                 "t": int(t.get("since") or 0), "type": str(t.get("type") or "")}
                 for t in live.get("bgTasks") or [] if isinstance(t, dict)]
     if not path:
         return []
     sp = _sdk_spawned_at(sid)
-    return [{"tid": tk.get("id"), "desc": str(tk.get("summary") or "").strip(), "t": int(tk.get("t") or 0)}
+    return [{"tid": tk.get("id"), "desc": str(tk.get("summary") or "").strip(), "t": int(tk.get("t") or 0),
+             "type": str(tk.get("type") or "")}
             for tk in _bg_scan_cached(path) if not (sp and tk.get("t") and tk["t"] < sp)]
 
 
@@ -6623,13 +6679,18 @@ def _bg_split(sid, path, tasks):
       - placed under a top carrying a live ⏳ stamp → AWAITED: the closer affirmed the wait.
       - placed with NO stamp → a SERVICE: the closer audited past the launch without saying awaiting
         (its stamp/lift is exact there), so nobody is waiting on this process — it is the session's
-        furniture (a dev server), the neutral chip's territory, never the awaiting badge."""
+        furniture (a dev server), the neutral chip's territory, never the awaiting badge.
+      - EXCEPT a dispatched AGENT (task type carries 'agent'): an agent is work the session waits on
+        by construction, never furniture — only shell tasks can be services (the user 2026-07-27: a
+        background agent rode the neutral chip while its card sat plain Working, because the stamp
+        meant to affirm the wait was structurally unable to reach the surfaces)."""
     placed = _bg_placed_tops(sid, path, [t["tid"] for t in tasks])
     stamped = _session_stamped_tops(sid)
     awaited, services = [], []
     for t in tasks:
         top = placed.get(t["tid"]) if t["tid"] else None
-        (services if top and top not in stamped else awaited).append(t)
+        agent = "agent" in (t.get("type") or "")
+        (services if top and top not in stamped and not agent else awaited).append(t)
     return awaited, services
 
 

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -162,6 +162,64 @@ class AwaitingLift(unittest.TestCase):
         self.assertTrue(any(e.get("kind") == "awaiting" and e.get("lift") for e in log),
                         "the retraction is journalled like any other verdict, not a silent field wipe")
 
+    # ---- ownership scoping (the user 2026-07-27): placement is authoritative when the judge has spoken ----
+    def test_a_return_placed_under_another_card_never_lifts_this_stamp(self):
+        # unrelated returns were lifting CI-wait stamps (one lifted the same minute it was re-asserted):
+        # the bare time window claimed every task the session launched in [born, at]
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed(why="waiting on the release pipeline to go green, then will tag")
+        saved = km._bg_placed_tops
+        km._bg_placed_tops = lambda sid, path, tids: {"t1": SID + ":gOTHER"}
+        try:
+            self._tick()
+        finally:
+            km._bg_placed_tops = saved
+        self.assertIsNotNone(self._stamp(), "another card's dispatch can never retire this wait")
+
+    def test_the_goals_own_placed_dispatch_still_lifts(self):
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed()
+        saved = km._bg_placed_tops
+        km._bg_placed_tops = lambda sid, path, tids: {"t1": self.gid}
+        try:
+            self._tick()
+        finally:
+            km._bg_placed_tops = saved
+        self.assertIsNone(self._stamp(), "the goal's own thread returned everything → the wait is over")
+
+    def test_a_later_running_dispatch_on_the_same_thread_keeps_the_stamp(self):
+        # placed under the same top AFTER the stamp: its flight keeps the wait honest, so no lift
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK), _launch("t2", STAMP + 50)])
+        self._seed()
+        saved = km._bg_placed_tops
+        km._bg_placed_tops = lambda sid, path, tids: {"t1": self.gid, "t2": self.gid}
+        try:
+            self._tick()
+        finally:
+            km._bg_placed_tops = saved
+        self.assertIsNotNone(self._stamp(), "the thread's own newer dispatch is still out")
+
+    # ---- rolled-up stamps (the user 2026-07-27): frozen invisible, so retire them on the record ----
+    def test_a_rolled_up_stamp_is_lifted_and_only_once(self):
+        # the roll-down froze a stamped node under a resolved ancestor — every reader skips rolledUp,
+        # so the stamp could neither show nor retire. The sweep lifts it, diary-guarded against re-fire.
+        self._transcript([])
+        nd = {"id": self.gid, "text": "a goal", "parentId": None, "nodeComplete": True,
+              "blocked": False, "cleared": False, "rolledUp": True, "trail": [], "t": BORN, "mt": BORN,
+              "awaitingWhy": "a wait the roll-down froze", "awaitingAt": STAMP,
+              "log": [{"ev_t": STAMP, "src": "closer", "kind": "awaiting",
+                       "why": "a wait the roll-down froze", "at": STAMP}]}
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}))
+        self._tick()
+        log = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())["nodes"][self.gid]["log"]
+        self.assertEqual(len([e for e in log if e.get("kind") == "awaiting" and e.get("lift")]), 1,
+                         "the frozen stamp is retired, on the record")
+        self._tick()
+        log2 = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())["nodes"][self.gid]["log"]
+        self.assertEqual(len([e for e in log2 if e.get("kind") == "awaiting" and e.get("lift")]), 1,
+                         "diary-guarded: the sweep never re-lifts")
+
     def test_running_only_scan_still_hides_returned_tasks(self):
         # the want_all split must not change the existing running-only view
         self._transcript([_launch("t1", LAUNCH), _launch("t2", LAUNCH + 5), _notification("t1", BACK)])

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -185,6 +185,60 @@ class SessionLevelStamp(unittest.TestCase):
         self.assertEqual(km._session_stamp_cached(SID), "second wait, a different length so size differs")
 
 
+class OverlayDoesNotVeto(unittest.TestCase):
+    """The production regression (the user 2026-07-27): the SDK Stop hook writes awaiting:false at EVERY
+    turn end, and nothing has written true since 2026-07-07 — so every real SDK session carries a trailing
+    false overlay row. That row is ambient noise, not an answer: it must fall THROUGH to the durable
+    stamp, never veto it (the veto made source 2 unreachable fleet-wide; when bf55a2f narrowed the live
+    sources on 2026-07-24 the awaiting badge visibly vanished). The classes above stub
+    _states_awaiting_overlay to None — precisely the condition production never hits — so this class
+    runs the REAL reader over a real states file."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self._saved = (km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions)
+        km.jd.STATE = td
+        km.jd.GOALDIR = td / "goals"
+        km.jd.GOALDIR.mkdir(parents=True)
+        (td / "states").mkdir()
+        km._SESSION_STAMP_CACHE.clear()
+        km._tmux_sessions = lambda: {SID: {"state": "", "since": None, "subagents": [], "bgTasks": []}}
+
+    def tearDown(self):
+        km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions = self._saved
+        km._SESSION_STAMP_CACHE.clear()
+        self.td.cleanup()
+
+    def _overlay(self, *rows):
+        (km.jd.STATE / "states" / (SID + ".jsonl")).write_text(
+            "".join(json.dumps(r) + "\n" for r in rows))
+
+    def _seed(self, why="a dispatched release watch; tags when green"):
+        nodes = {"g1": _node("g1", why=why, at=200)}
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": nodes}))
+
+    def test_a_bare_false_row_falls_through_to_the_stamp(self):
+        self._overlay({"t": 100, "awaiting": False})
+        self._seed()
+        self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
+                         "a dispatched release watch; tags when green",
+                         "the Stop hook's ambient false must not hide the judge's stamp")
+
+    def test_a_live_true_row_still_wins_with_its_own_why(self):
+        self._overlay({"t": 100, "awaiting": True, "why": "a job the hook reported"})
+        self._seed()
+        self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True), "a job the hook reported",
+                         "a positive overlay row keeps its channel")
+
+    def test_false_row_and_no_stamp_is_plain_none(self):
+        self._overlay({"t": 100, "awaiting": False})
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {}}))
+        self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True))
+
+
 class _FakeBackend:
     def __init__(self): self.sent = []
     def send(self, sid, body): self.sent.append((sid, body))

--- a/tests/test_kernel_bg_tasks.py
+++ b/tests/test_kernel_bg_tasks.py
@@ -306,6 +306,50 @@ class DurableAwaitingSource(unittest.TestCase):
             os.unlink(path)
 
 
+class AgentTasksAreNeverServices(unittest.TestCase):
+    """_bg_split (the user 2026-07-27): a dispatched AGENT is work the session waits on by construction,
+    never furniture — only shell tasks can be classified as services. A background agent was riding the
+    neutral bgServices chip while its card sat plain Working, because the placed-with-no-stamp rule
+    assumed the closer's stamp would affirm agent waits and the stamp could not reach the surfaces."""
+    SID = "11111111-2222-3333-4444-555555555555"
+
+    def _split(self, tasks, placed, stamped=frozenset()):
+        saved = (km._bg_placed_tops, km._session_stamped_tops)
+        km._bg_placed_tops = lambda sid, path, tids: placed
+        km._session_stamped_tops = lambda sid: stamped
+        try:
+            return km._bg_split(self.SID, "/p", tasks)
+        finally:
+            km._bg_placed_tops, km._session_stamped_tops = saved
+
+    def test_a_placed_unstamped_agent_stays_awaited(self):
+        t = {"tid": "t1", "desc": "a dispatched research agent", "t": 100, "type": "local_agent"}
+        awaited, services = self._split([t], {"t1": self.SID + ":g1"})
+        self.assertEqual(awaited, [t], "an agent is never furniture")
+        self.assertEqual(services, [])
+
+    def test_a_placed_unstamped_shell_task_is_a_service(self):
+        t = {"tid": "t2", "desc": "mkdocs serve", "t": 100, "type": "local_shell"}
+        awaited, services = self._split([t], {"t2": self.SID + ":g1"})
+        self.assertEqual(services, [t], "a shell process with no affirmed wait is the session's furniture")
+        self.assertEqual(awaited, [])
+
+    def test_a_stamped_top_keeps_even_its_shell_tasks_awaited(self):
+        t = {"tid": "t3", "desc": "a watcher loop", "t": 100, "type": "local_shell"}
+        awaited, services = self._split([t], {"t3": self.SID + ":g1"}, stamped=frozenset({self.SID + ":g1"}))
+        self.assertEqual(awaited, [t], "the closer affirmed this thread's wait")
+
+    def test_norm_threads_the_type_through_both_sources(self):
+        saved = km._tmux_sessions
+        km._tmux_sessions = lambda: {self.SID: {"bgTasks": [
+            {"toolUseId": "t4", "desc": "an agent", "since": 5, "type": "local_agent"}]}}
+        try:
+            rows = km._bg_live_norm(self.SID, None)
+        finally:
+            km._tmux_sessions = saved
+        self.assertEqual(rows[0]["type"], "local_agent", "the lifecycle set's type survives normalization")
+
+
 class TaskOutputsForCard(unittest.TestCase):
     """_task_outputs_for joins a completed background command's notification to its shell command (from the
     launch scan) and its output-file tail, so the inline completion card can EXPAND to real detail instead of


### PR DESCRIPTION
The awaiting badge visibly vanished on 2026-07-24. Re-verified root causes, all fixed:

- **The dead veto**: since 07-07 the SDK Stop hook writes an unconditional `awaiting:false` overlay row every turn end (nothing writes `true`), and `_session_awaiting` treated the trailing false as the session's answer — so the durable ⏳ stamp wired to the rail chip / chat chip / timeline lane on 07-22 was structurally unreachable on every SDK session. A false row now falls through; only a positive short-circuits. New tests run the **real** overlay reader over a real states file (the old tests stubbed it to None — the one condition production never hits).
- **Agents are never furniture**: the 07-24 service split sent every placed-unstamped task to the neutral bgServices chip, including dispatched agents. `_bg_split` now keeps agent-typed tasks awaited unconditionally; only shell tasks can be services. `_bg_live_norm` threads the lifecycle `type` through.
- **Over-eager lifts**: `_lift_spent_awaiting` owned tasks by a bare time window, so unrelated returns retired CI-wait stamps (one lifted the same minute it was re-asserted). Placement is authoritative now; the window survives only for placement-unknown launches. A stamped node frozen by the roll-down (`rolledUp` — invisible to every reader, unretirable) is lifted on the record, diary-guarded.

Suites: 3324 py, 1368 node, all green. Kernel-only change — takes effect at the next kernel restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)