### PR TITLE
The awaiting lift bounds ownership by when the stamp was written

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2130,6 +2130,31 @@ def _last_awaiting_is_lift(nd):
     return bool(evs) and bool(evs[-1].get("lift"))
 
 
+def _stamp_written_at(nd):
+    """WHEN the awaiting stamp was written — the ownership horizon for the time-window fallback below.
+
+    `awaitingAt` is the anchor the fold materializes, and it is the audited turn's TRIGGER time (the
+    awaiting event's `ev_t`), not the moment the stamp was made. But a turn dispatches its background
+    work partway THROUGH, always after that trigger, so bounding ownership at the anchor excludes exactly
+    the launches the stamp is about — and when the goal was minted by the same turn that stamped it,
+    `born == awaitingAt` and the window is a SINGLE INSTANT that can never match anything. The fallback
+    was dead for precisely the goals it exists to serve (the user 2026-07-27: a card stamped at its
+    turn's trigger owned two watchers launched four and twenty-seven minutes later inside that same turn,
+    so its stamp could only ever come off via the 6h backstop).
+
+    The closer writes the stamp having audited the whole turn, so its WRITE time is the exact epistemic
+    boundary: every dispatch that existed when the stamp was made, and nothing from a later turn. That is
+    an event we already journal (`at` on each awaiting verdict), not a margin — no reparse, and no window
+    that could bleed forward the way a fixed slack would. Lift events are skipped (they retract a wait,
+    they don't assert one); floored at the anchor so a legacy record with no `at` keeps the old bound."""
+    best = 0
+    for e in (nd.get("log") or []):
+        if e.get("kind") != "awaiting" or e.get("lift"):
+            continue
+        best = max(best, e.get("at") or e.get("ev_t") or 0)
+    return max(best, nd.get("awaitingAt") or 0)
+
+
 def _lift_spent_awaiting(now, tmux):
     """Retire a goal's ⏳ awaiting stamp once the dispatches it was waiting on have RETURNED (the user
     2026-07-22). The closer's lift is bounded to the goals a turn actually WORKED ON (`touched`), which is
@@ -2189,14 +2214,16 @@ def _lift_spent_awaiting(now, tmux):
                     seen.add(x); x = nodes[x]["parentId"]
                 return x
             for nd in stamped:
-                at, born = nd.get("awaitingAt") or 0, nd.get("t") or 0
+                born = nd.get("t") or 0
                 top = _top_of(nd.get("id"))
                 # The dispatches this goal owns. Placement is authoritative when the judge has spoken:
                 # a task placed under ANOTHER card can never retire this stamp (the user 2026-07-27:
                 # unrelated returns were lifting CI-wait stamps — one lifted the same minute it was
                 # re-asserted). The time window survives only for placement-unknown launches (the
                 # conservative pre-verdict shape): launched during the goal's life, at or before the
-                # stamp it explains.
+                # stamp it explains — bounded by when that stamp was WRITTEN, not by its turn-trigger
+                # anchor, which the launches of that very turn all postdate (see _stamp_written_at).
+                horizon = _stamp_written_at(nd)
                 own = []
                 for t in every:
                     p = placed.get(t.get("id"))
@@ -2204,7 +2231,7 @@ def _lift_spent_awaiting(now, tmux):
                         if p == top:
                             own.append(t)             # the goal's own thread, before OR after the stamp:
                             #                           anything of its own still out keeps the wait honest
-                    elif born <= (t.get("t") or 0) <= at:
+                    elif born <= (t.get("t") or 0) <= horizon:
                         own.append(t)
                 if not own:                           # nothing dispatched → not a background wait; leave it
                     continue

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -85,11 +85,15 @@ class AwaitingLift(unittest.TestCase):
                 f.write(json.dumps(r) + "\n")
         km._bgall_cache.clear(); km._bgtasks_cache.clear()
 
-    def _seed(self, why="waiting on two dispatched investigations; will act when they return"):
+    def _seed(self, why="waiting on two dispatched investigations; will act when they return",
+              born=BORN, anchor=STAMP, written=None):
+        """`anchor` is awaitingAt (the audited turn's TRIGGER time); `written` is when the closer actually
+        wrote the verdict (its `at`), which defaults to the anchor for the pre-2026-07-27 fixture shape."""
         nd = {"id": self.gid, "text": "a goal", "parentId": None, "nodeComplete": False,
-              "blocked": False, "cleared": False, "trail": [], "t": BORN, "mt": BORN,
-              "awaitingWhy": why, "awaitingAt": STAMP,
-              "log": [{"ev_t": STAMP, "src": "closer", "kind": "awaiting", "why": why, "at": STAMP}]}
+              "blocked": False, "cleared": False, "trail": [], "t": born, "mt": born,
+              "awaitingWhy": why, "awaitingAt": anchor,
+              "log": [{"ev_t": anchor, "src": "closer", "kind": "awaiting", "why": why,
+                       "at": anchor if written is None else written}]}
         (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
             {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}))
 
@@ -219,6 +223,50 @@ class AwaitingLift(unittest.TestCase):
         log2 = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())["nodes"][self.gid]["log"]
         self.assertEqual(len([e for e in log2 if e.get("kind") == "awaiting" and e.get("lift")]), 1,
                          "diary-guarded: the sweep never re-lifts")
+
+    # ---- the collapsed window (the user 2026-07-27): mint and stamp in the SAME turn ----
+    # awaitingAt is the audited turn's TRIGGER, but a turn dispatches partway through, always after it.
+    # When that turn also MINTED the goal, born == awaitingAt and [born, awaitingAt] is a single instant:
+    # the fallback matched nothing, so this whole path was dead for the goals it exists to serve. The
+    # bound is the stamp's WRITE time, which is after every launch the closer could have audited.
+    def test_a_same_turn_mint_and_stamp_still_owns_its_mid_turn_dispatch(self):
+        self._transcript([_launch("t1", STAMP + 20), _notification("t1", STAMP + 60)])
+        self._seed(born=STAMP, anchor=STAMP, written=STAMP + 90)   # one turn: trigger STAMP, closed later
+        self.assertIsNotNone(self._stamp(), "precondition: the goal starts stamped")
+        self._tick(now=STAMP + 200)
+        self.assertIsNone(self._stamp(),
+                          "the dispatch was launched inside the very turn the stamp explains → owned, "
+                          "and it came back")
+
+    def test_a_same_turn_dispatch_still_running_keeps_the_stamp(self):
+        # the widened bound must not lift a wait that is genuinely still out
+        self._transcript([_launch("t1", STAMP + 20)])              # never reported
+        self._seed(born=STAMP, anchor=STAMP, written=STAMP + 90)
+        self._tick(now=STAMP + 200)
+        self.assertIsNotNone(self._stamp(), "its own dispatch is still in flight")
+
+    def test_a_dispatch_after_the_stamp_was_written_is_still_not_owned(self):
+        # the bound moved to the WRITE time, not to infinity: a launch the closer could not have seen
+        # belongs to a later turn and says nothing about this wait
+        self._transcript([_launch("t9", STAMP + 150), _notification("t9", STAMP + 180)])
+        self._seed(born=STAMP, anchor=STAMP, written=STAMP + 90)
+        self._tick(now=STAMP + 300)
+        self.assertIsNotNone(self._stamp(), "launched after the stamp was written → a later turn's work")
+
+    def test_written_at_prefers_the_newest_assertion_and_ignores_lifts(self):
+        why = "waiting on a dispatched investigation"
+        nd = {"awaitingAt": STAMP,
+              "log": [{"ev_t": STAMP, "kind": "awaiting", "why": why, "at": STAMP + 10},
+                      {"ev_t": STAMP, "kind": "awaiting", "why": why, "at": STAMP + 90},
+                      {"ev_t": STAMP, "kind": "awaiting", "lift": True, "at": STAMP + 500},
+                      {"ev_t": STAMP, "kind": "done", "at": STAMP + 900}]}
+        self.assertEqual(km._stamp_written_at(nd), STAMP + 90,
+                         "the newest ASSERTION bounds ownership; a lift retracts a wait, never asserts one")
+
+    def test_written_at_floors_at_the_anchor_for_a_legacy_record(self):
+        self.assertEqual(km._stamp_written_at({"awaitingAt": STAMP, "log": []}), STAMP,
+                         "no journalled write time → the old anchor bound, unchanged")
+        self.assertEqual(km._stamp_written_at({"awaitingAt": STAMP}), STAMP, "no log at all is safe")
 
     def test_running_only_scan_still_hides_returned_tasks(self):
         # the want_all split must not change the existing running-only view


### PR DESCRIPTION
`_lift_spent_awaiting` decides which background dispatches a stamped goal owns. When the judge has placed a launch, placement rules. Otherwise it falls back to a time window, `born <= launch <= awaitingAt`, and that upper bound was wrong.

`awaitingAt` is the audited turn's **trigger** time, not the moment the stamp was made. A turn dispatches its background work partway through, always after that trigger, so the window excluded exactly the launches the stamp was about. Worse: when the same turn also **minted** the goal, `born == awaitingAt` and the window collapsed to a single instant that could never match anything. For that whole class of goals (minted and stamped by one turn, the ordinary shape) the fallback was dead, and the stamp could only ever come off via the 6h backstop.

Found on a live card that had been claiming a wait for five hours after the thing it named had finished.

## The fix

The bound is now the stamp's **write time**: the newest non-lift awaiting verdict's `at`, floored at the anchor. The closer writes the stamp having audited the whole turn, so its write time is the exact epistemic boundary. Every dispatch that existed when the stamp was made is owned; nothing from a later turn is.

Chosen over the two alternatives on purpose:
- It is an event already journalled on every awaiting verdict, so there is **no reparse** and no fixed slack that could bleed forward into a later turn's dispatches.
- Widening to the stamped turn's `end` would need a `parsed_session` call and still has to reason about turn boundaries; the write time is strictly after the turn's own launches and strictly before the next turn's.

Lift events are skipped (they retract a wait rather than assert one), and a legacy record carrying no `at` keeps the old anchor bound unchanged.

## Risk

This arms a path that was previously dead for same-turn-minted goals, so the guard tests matter as much as the fix: a still-running dispatch must keep holding the stamp, and a launch past the write time must stay disowned. Both are pinned.

## Tests

- a same-turn mint+stamp owns its mid-turn dispatch and lifts when it returns (**fails without this change**)
- the same case still holds the stamp while that dispatch is in flight
- a launch after the write time is still disowned
- unit coverage for the newest-assertion pick (ignoring lifts) and the legacy floor

Full Python suite green locally: 3305 passed, 25 skipped. The node suite's only kernel-source pin is an unrelated HTML string, and CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)