### PR TITLE
A chat pane with no sessions says so, instead of spinning for 30 seconds

### DIFF
--- a/tests/test_chat_empty_pane.py
+++ b/tests/test_chat_empty_pane.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""A chat pane with NO sessions must show something immediately, not spin for 30 seconds.
+
+This is a contract between two files that have to agree, which is exactly why it broke:
+
+  kernel.py's _pane_spin  hides the romp loader on an EVENT — a MutationObserver that fires when the
+                          content container gains a child whose id is not the always-present
+                          #live-ask host — plus a long failsafe timeout for a genuinely dead kernel.
+  render.ts               is the only thing that ever puts children in #content.
+
+While a session is loading that is precisely right. With NO sessions there is nothing to load, so
+render.ts rendered nothing, the observer never fired, and the only escape left was the failsafe: every
+load of a fresh install sat under the loader for the full 30s. A brand-new user's first impression of
+romp was a half-minute spinner over an empty pane, identical on every refresh, because it was a timer
+rather than work (the user 2026-07-27, on a clean v0.1.1 install).
+
+The fix is not to shorten the timer — it was 8s once and that was WORSE, firing during a normal slow
+cold start and leaving the loader hidden over a still-blank pane. The fix is that "no sessions" is a
+real, renderable state, so the event path handles it and the failsafe goes back to meaning only what it
+says: the kernel died.
+
+Source-pinning, like the other chat-render tests (the renderer has no jsdom harness).
+"""
+import os
+import re
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+KERNEL = open(os.path.join(ROOT, "kernel", "kernel.py"), encoding="utf-8").read()
+RENDER = open(os.path.join(ROOT, "ui", "webview", "render.ts"), encoding="utf-8").read()
+CSS = open(os.path.join(ROOT, "ui", "webview", "styles.css"), encoding="utf-8").read()
+
+
+class ChatEmptyPane(unittest.TestCase):
+    def test_the_loader_still_hides_on_content_arriving_not_on_a_timer(self):
+        """Pin the mechanism the placeholder depends on. If the hide ever stops keying off a real
+        child of the container, the placeholder below stops being what dismisses the loader."""
+        spin = re.search(r"def _pane_spin\(.*?\n\n\ndef ", KERNEL, re.S)
+        self.assertIsNotNone(spin, "_pane_spin not found")
+        body = spin.group(0)
+        self.assertIn("MutationObserver", body, "the hide must stay event-based")
+        self.assertIn("children[i].id!==IGN", body, "hide keys off a child that is not the ignored host")
+
+    def test_the_failsafe_is_long_enough_to_only_mean_a_dead_kernel(self):
+        """It exists so the loader can never permanently stick. It must NOT be tuned down as a
+        substitute for rendering something — an 8s version used to fire mid-cold-start and hid the
+        loader over a still-blank pane."""
+        m = re.search(r"setTimeout\(hide,(\d+)\)", KERNEL)
+        self.assertIsNotNone(m, "the failsafe timeout is gone")
+        self.assertGreaterEqual(int(m.group(1)), 30000,
+                                "shortening the failsafe re-creates the blank-pane gap it was raised to fix")
+
+    def test_zero_sessions_renders_a_real_child_into_content(self):
+        """The actual regression: something must land in #content so the observer fires."""
+        self.assertIn("function syncNoSessionsPlaceholder", RENDER)
+        fn = re.search(r"function syncNoSessionsPlaceholder\(.*?\n\}", RENDER, re.S).group(0)
+        self.assertIn('getElementById("content")', fn, "the placeholder must go in the watched container")
+        self.assertIn("appendChild", fn, "it must actually add a child — that is what hides the loader")
+        self.assertNotIn("live-ask", fn, "and must not reuse the ignored host's id, which never counts")
+
+    def test_it_runs_on_every_push_and_is_idempotent(self):
+        """renderTabs runs on every kernel push (0.5-3s). Appending each time would pile up copies."""
+        self.assertRegex(RENDER, r"syncNoSessionsPlaceholder\(visibleIds\.length\)",
+                         "renderTabs must drive it from the visible session count")
+        fn = re.search(r"function syncNoSessionsPlaceholder\(.*?\n\}", RENDER, re.S).group(0)
+        self.assertIn("if (existing) return;", fn, "must not append a second placeholder per push")
+
+    def test_the_placeholder_is_removed_once_a_session_exists(self):
+        """Otherwise it lingers above the first real transcript."""
+        fn = re.search(r"function syncNoSessionsPlaceholder\(.*?\n\}", RENDER, re.S).group(0)
+        self.assertRegex(fn, r"visibleCount > 0[\s\S]*?existing\?\.remove\(\)")
+
+    def test_it_says_what_to_do_next_and_is_styled(self):
+        """A new user's first screen. 'Nothing here' is a dead end; name the way out."""
+        self.assertIn("No sessions yet", RENDER)
+        self.assertIn("romp new", RENDER)
+        self.assertRegex(CSS, r"\.tx-empty\s*\{", "reuses the existing empty-state style")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3201,6 +3201,35 @@ function makePlaceholderTab(id: string): HTMLElement {
   return tab;
 }
 
+// With NO sessions at all, put a real element in #content — otherwise the chat pane sits under the
+// romp loader for a full THIRTY SECONDS on every load.
+//
+// The loader (kernel _pane_spin) hides on an event: a MutationObserver fires when #content gains a child
+// whose id isn't the always-present #live-ask host. That is exactly right while a session is loading, and
+// unreachable when there is nothing to load — no session means nothing ever renders, the observer never
+// fires, and the only escape is the 30s failsafe that exists for a dead kernel. A fresh install has zero
+// sessions, so the very first thing a new user sees is a half-minute spinner over an empty pane (the user
+// 2026-07-27, on a clean v0.1.1 install: "still takes 10s+ just to load an empty chat", identical on every
+// refresh — because it was a timer, not work).
+//
+// The empty transcript case was already handled with a "No messages yet." placeholder; this is its
+// missing sibling, one level up: no sessions rather than no messages. Saying so also beats a spinner —
+// it tells a new user the pane is working and what to do next.
+function syncNoSessionsPlaceholder(visibleCount: number) {
+  const content = document.getElementById("content");
+  if (!content) return;
+  const existing = document.getElementById("no-sessions");
+  if (visibleCount > 0) {
+    existing?.remove();               // a session arrived → the real view takes over
+    return;
+  }
+  if (existing) return;               // idempotent: renderTabs runs on every push
+  const ph = el("div", "tx-empty");
+  ph.id = "no-sessions";
+  ph.textContent = "No sessions yet. Start one with  romp new <name>  or the + above.";
+  content.appendChild(ph);
+}
+
 function renderTabs() {
   if (renameActive) { renderPendingAfterRename = true; return; }
   if (tabPointerHeld) { renderPendingWhilePressed = true; return; }   // don't destroy a tab mid-click (see tabPointerHeld)
@@ -3347,6 +3376,7 @@ function renderTabs() {
   bar.appendChild(add);
   // Restore tab-mode focus if a tab held it before this rebuild (see the top of renderTabs).
   if (refocusTab) focusActiveTab();
+  syncNoSessionsPlaceholder(visibleIds.length);
   // (The Fleet toggle that briefly lived here as a tab-bar pill was removed 2026-06-24: Fleet/Chat are now
   // the rotated toggles in the chat pane's vertical strip — see _LANDING_FLEET_JS — so the pill was redundant.)
   // (The collapse caret moved OFF the tab bar into the #ledger strip's title row — the strip now always


### PR DESCRIPTION
Reported as "still takes 10s+ just to load an empty chat", on a clean v0.1.1 install, identical on every refresh. It was not slow — it was a **timer**.

## The contract that broke

Two files have to agree, which is exactly why this slipped through:

- **`kernel.py`'s `_pane_spin`** hides the romp loader on an *event*: a MutationObserver that fires when `#content` gains a child whose id isn't the always-present `#live-ask` host. Plus a 30s failsafe for a dead kernel.
- **`render.ts`** is the only thing that ever puts children in `#content`.

While a session is loading, that's precisely right. With **no sessions** there is nothing to load — so `render.ts` rendered nothing, the observer never fired, and the only escape left was the failsafe.

Every load of a fresh install therefore sat under the loader for a full 30 seconds. A brand-new user's first impression of romp is a half-minute spinner over an empty pane.

## Why not just shorten the timer

It was 8s once, and that was **worse**: it fired during a normal slow cold start and left the loader hidden over a still-blank pane — the "loader stops, then blank for a bit before content shows" gap it was raised to 30s to fix.

The timer isn't the bug. The bug is that "no sessions" wasn't a renderable state. Now it is, so the existing event path dismisses the loader immediately and the failsafe goes back to meaning only what it says: the kernel died.

## The fix

`renderTabs` (which already runs on every push and knows the visible session count) drives a placeholder into `#content` when that count is zero:

> No sessions yet. Start one with `romp new <name>` or the + above.

The empty-*transcript* case already had this ("No messages yet."). This is its missing sibling one level up — no *sessions* rather than no *messages*. It also names the way out instead of dead-ending, since it's the first screen a new user sees.

Idempotent (renderTabs fires every 0.5–3s) and removed again once a session exists.

## Tests

Pinning the **contract**, not just the new function, since the break was two files disagreeing:

| test | asserts |
|---|---|
| loader hides on content, not a timer | the MutationObserver + non-ignored-child condition survives |
| failsafe stays ≥30s | it can't be tuned down as a substitute for rendering something |
| zero sessions appends to `#content` | the actual regression |
| idempotent per push | no pile-up of placeholders |
| removed once a session exists | doesn't linger above the first transcript |

Verified live: swapped the built bundle into a running install and the pane became instant.

Full suite green: 3338 python tests and every bats file.