### PR TITLE
Bell panel: per-kind filter toggles + recency-coloured timestamps

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14687,35 +14687,60 @@ setTimeout(hide,5000);})();
 _LANDING_ERRS_JS = """
 (function(){var icon=document.getElementById('rail-errs'),micon=document.getElementById('merr'),
 back=document.getElementById('rerr-back'),list=document.getElementById('rerr-list'),
-clearBtn=document.getElementById('rerr-clear'),x=document.getElementById('rerr-x');
+clearBtn=document.getElementById('rerr-clear'),x=document.getElementById('rerr-x'),
+filtBar=document.getElementById('rerr-filters');
 if(!icon||!back||!list)return;
-var KEY='romp:notices',MAX=100;
+var KEY='romp:notices',MAX=100,FKEY='romp:errFilters';
 function load(){try{var v=JSON.parse(localStorage.getItem(KEY)||'[]');return Array.isArray(v)?v:[];}catch(e){return[];}}
 var NOTES=load();
 function save(){try{localStorage.setItem(KEY,JSON.stringify(NOTES));}catch(e){}}
 function ago(t){var dt=Math.max(0,Math.floor(Date.now()/1000)-t);if(dt<90)return 'just now';
 var m=Math.round(dt/60);if(m<60)return m+'m ago';var h=Math.floor(m/60);
 return h<24?h+'h ago':Math.floor(h/24)+'d ago';}
-function unseen(){var n=0;for(var i=0;i<NOTES.length;i++)if(!NOTES[i].seen)n++;return n;}
-// The bell: red while anything is unread OR a visible pane's socket is DOWN right now (the live
-// problem keeps the cue up even after the entry is read; it clears the moment the pane reconnects).
+// Per-kind FILTERS (the user 2026-07-28: offline fires so often it drowns the rest — every high-level
+// category gets a toggle). FILT holds the kinds turned OFF, persisted so the choice sticks; a muted
+// kind neither renders, counts as unread, nor (for offline) keeps the live red cue up. Entries are
+// still STORED — re-enabling the kind shows what happened while it was muted. Unknown kinds always show.
+function loadFilt(){try{var v=JSON.parse(localStorage.getItem(FKEY)||'{}');return v&&typeof v==='object'?v:{};}catch(e){return{};}}
+var FILT=loadFilt();
+function saveFilt(){try{localStorage.setItem(FKEY,JSON.stringify(FILT));}catch(e){}}
+function kindOn(k){return !FILT[k];}
+function unseen(){var n=0;for(var i=0;i<NOTES.length;i++)if(!NOTES[i].seen&&kindOn(NOTES[i].kind))n++;return n;}
+// The bell: red while anything unmuted is unread OR a visible pane's socket is DOWN right now (the live
+// problem keeps the cue up even after the entry is read; it clears the moment the pane reconnects —
+// and stays dark entirely while the offline kind is muted).
 // No count badge — it clipped against the bar edge and the number added nothing (the user 2026-07-27).
 function paint(){var n=unseen();
-[icon,micon].forEach(function(el){if(el)el.classList.toggle('has',n>0||liveDown());});
+[icon,micon].forEach(function(el){if(el)el.classList.toggle('has',n>0||(kindOn('conn')&&liveDown()));});
 if(!back.hidden)renderList();}
 // each entry leads with the chip its card wears in the feed, so the vocabulary matches across surfaces
+var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror'];
 var KINDLBL={conn:'offline',limit:'limit',judge:'judge',warn:'warning',stalled:'stalled',
 nudge:'follow-up failed',retry:'retrying',apierror:'api error'};
-function renderList(){list.innerHTML='';
-if(!NOTES.length){var e=document.createElement('div');e.className='rerr-empty';e.textContent='No errors';list.appendChild(e);return;}
-for(var i=NOTES.length-1;i>=0;i--)(function(n,i){var row=document.createElement('div');row.className='rerr-row';
+// the toggles ARE the chips (same pill, same colours) — lit = shown, dimmed = muted. Built once on a
+// STABLE container; only classes flip on click, so the buttons stay click-safe.
+if(filtBar)KINDS.forEach(function(k){var b=document.createElement('span');
+b.className='rerr-chip rerr-fbtn k-'+k+(kindOn(k)?'':' off');b.textContent=KINDLBL[k];
+b.title='Show / hide '+KINDLBL[k]+' entries';
+b.addEventListener('click',function(ev){ev.stopPropagation();
+if(kindOn(k)){FILT[k]=1;}else{delete FILT[k];}saveFilt();
+b.classList.toggle('off',!kindOn(k));renderList();paint();});
+filtBar.appendChild(b);});
+function renderList(){list.innerHTML='';var shown=0;
+for(var i=NOTES.length-1;i>=0;i--)(function(n,i){if(!kindOn(n.kind))return;shown++;
+var row=document.createElement('div');row.className='rerr-row';
 if(KINDLBL[n.kind]){var ch=document.createElement('span');ch.className='rerr-chip k-'+n.kind;
 ch.textContent=KINDLBL[n.kind];row.appendChild(ch);}
 var tx=document.createElement('span');tx.className='rerr-msg';tx.textContent=n.text+(n.n>1?' (x'+n.n+')':'');
 var tm=document.createElement('span');tm.className='rerr-t';tm.textContent=ago(n.t);
+// the timestamp wears the SAME recency colour every other "(Xm ago)" wears (window.__rompAgeColor,
+// published by dist/age-color-global.js from the shared ramp; dim default if the bundle is stale)
+if(window.__rompAgeColor)tm.style.color=window.__rompAgeColor(Math.max(0,Math.floor(Date.now()/1000)-n.t));
 var del=document.createElement('span');del.className='rerr-del';del.textContent='\\u00d7';del.title='Clear';
 del.addEventListener('click',function(ev){ev.stopPropagation();NOTES.splice(i,1);save();renderList();paint();});
-row.appendChild(tx);row.appendChild(tm);row.appendChild(del);list.appendChild(row);})(NOTES[i],i);}
+row.appendChild(tx);row.appendChild(tm);row.appendChild(del);list.appendChild(row);})(NOTES[i],i);
+if(!shown){var e=document.createElement('div');e.className='rerr-empty';
+e.textContent=NOTES.length?'Nothing to show \\u2014 hidden by the filters above':'No errors';list.appendChild(e);}}
 // One write path. A repeat of the NEWEST entry (same kind+text — e.g. a reconnect loop dropping over and
 // over) coalesces into it with a count instead of flooding the feed: event-exact, no time window.
 window.__rompNotify=function(kind,text){if(!text)return;
@@ -14742,7 +14767,9 @@ if(s==='down'&&prev!=='down'&&shown(m.app))
 window.__rompNotify('conn','Kernel connection lost \\u2014 '+(PN[m.app]||m.app)+' pane (reconnecting)');
 else paint();});
 window.addEventListener('romp-panes',paint);
-function open(){for(var i=0;i<NOTES.length;i++)NOTES[i].seen=true;save();back.hidden=false;renderList();paint();}
+// opening marks seen only what the filters let you SEE — a muted kind's entries stay unread, so
+// re-enabling its toggle re-reddens the bell if something happened while it was muted
+function open(){for(var i=0;i<NOTES.length;i++)if(kindOn(NOTES[i].kind))NOTES[i].seen=true;save();back.hidden=false;renderList();paint();}
 function close(){back.hidden=true;}
 icon.addEventListener('click',function(){back.hidden?open():close();});
 back.addEventListener('click',function(e){if(e.target===back)close();});
@@ -15837,6 +15864,12 @@ def _landing():
             ".rerr-del{flex:0 0 auto;cursor:pointer;opacity:.5;font-weight:700}"
             ".rerr-del:hover{opacity:1}"
             ".rerr-empty{padding:16px 12px;color:#6e7681;text-align:center;font-size:11.5px}"
+            # The per-kind filter bar (the user 2026-07-28): the toggles ARE the chips — lit means shown,
+            # dimmed (with a dashed edge, a second cue beyond opacity) means muted.
+            "#rerr-filters{display:flex;flex-wrap:wrap;gap:5px;padding:8px 12px;border-bottom:1px solid #2a2a2a;flex:0 0 auto}"
+            ".rerr-fbtn{cursor:pointer;user-select:none}"
+            ".rerr-fbtn.off{opacity:0.35;border-style:dashed}"
+            ".rerr-fbtn:hover{opacity:1}"
             # Each entry leads with the SAME chip the card wears in the feed — same pill shape, colours and
             # weight as the .fask-* chip family (feed.css), so "stalled" here looks like "stalled" there.
             ".rerr-chip{flex:0 0 auto;font-size:9px;font-weight:700;letter-spacing:.04em;padding:1px 6px;"
@@ -15855,6 +15888,7 @@ def _landing():
             "<div class=rerr-top>Errors<span class=sp></span>"
             "<button id=rerr-clear title='Clear all entries'>Clear all</button>"
             "<button id=rerr-x aria-label=Close>×</button></div>"
+            "<div id=rerr-filters></div>"
             "<div id=rerr-list></div>"
             "</div></div>"
             "<div class=col>"
@@ -16018,6 +16052,11 @@ def _landing():
             # the mobile tab bar. (The splitter used to query a stale id=t for the timeline iframe and
             # throw on every load — fixed above by giving that iframe id=f-timeline.)
             "<script>" + _LANDING_BOOT_JS + "</script>"
+            # the shared recency colour ramp (ui/webview/age-color.ts), published as window.__rompAgeColor
+            # by a tiny standalone dist bundle — the shell page loads no webview bundle of its own, and the
+            # bell panel's timestamps wear the same recency colours as every other "(Xm ago)" (the user
+            # 2026-07-28). Loaded BEFORE the errs script, which reads it (with a dim fallback if absent).
+            + ("<script src=/dist/age-color-global.js?v=%d></script>" % v) +
             "<script>" + _LANDING_ERRS_JS + "</script>"
             "<script>" + _LANDING_USAGE_JS + "</script>"
             "<script>" + _LANDING_JS + "</script>"

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -58,7 +58,7 @@ function withCls(el) {
   return el;
 }
 const EL = {};
-['rail-errs', 'merr', 'rerr-back', 'rerr-list', 'rerr-clear', 'rerr-x'].forEach((id) => {
+['rail-errs', 'merr', 'rerr-back', 'rerr-list', 'rerr-clear', 'rerr-x', 'rerr-filters'].forEach((id) => {
   EL[id] = withCls(mkEl(id));
 });
 const BODY = new Set(['po-chat', 'po-feed', 'po-timeline']);   // fleet pane hidden, like the real default
@@ -110,6 +110,20 @@ out.afterClearAll = { n: notes().length, rows: EL['rerr-list'].children.length,
 // 8) once the pane reconnects, the live red cue clears too
 post({ romp: 'wsState', app: 'chat', state: 'up' });
 out.afterReconnect = { red: EL['rail-errs']._cls.has('has') };
+// 9) the filter bar built one toggle chip per kind, in order, conn ("offline") first
+out.filterBar = { n: EL['rerr-filters'].children.length,
+  first: EL['rerr-filters'].children[0].textContent,
+  labels: EL['rerr-filters'].children.map((c) => c.textContent).join('|') };
+// 10) muting offline: its entries stop rendering, stop counting, and the live-down cue stays dark
+EL['rerr-filters'].children[0].fire('click');
+post({ romp: 'wsState', app: 'chat', state: 'down' });
+out.afterMute = { stored: STORE['romp:errFilters'], n: notes().length,
+  red: EL['rail-errs']._cls.has('has'),
+  emptyText: EL['rerr-list'].children[0].textContent };
+// 11) unmuting shows what happened while muted, and the unread entry re-reddens the bell
+EL['rerr-filters'].children[0].fire('click');
+out.afterUnmute = { red: EL['rail-errs']._cls.has('has'), rows: EL['rerr-list'].children.length,
+  chip: EL['rerr-list'].children[0].children[0].textContent };
 console.log(JSON.stringify(out));
 """
 
@@ -171,6 +185,28 @@ class ErrorCenterExecutes(unittest.TestCase):
     def test_reconnect_clears_the_live_cue(self):
         self.assertFalse(self.out["afterReconnect"]["red"])
 
+    def test_the_filter_bar_has_one_toggle_per_kind(self):
+        # the user 2026-07-28: every high-level category gets a toggle (offline fires so often it
+        # drowns the rest). The toggles ARE the chips, in the same order entries wear them.
+        a = self.out["filterBar"]
+        self.assertEqual(a["n"], 8)
+        self.assertEqual(a["first"], "offline")
+        self.assertEqual(a["labels"],
+                         "offline|limit|judge|warning|stalled|follow-up failed|retrying|api error")
+
+    def test_muting_a_kind_hides_counts_and_live_cue_but_keeps_the_entries(self):
+        a = self.out["afterMute"]
+        self.assertEqual(a["stored"], '{"conn":1}', "the choice persists")
+        self.assertEqual(a["n"], 1, "the entry is still STORED while muted")
+        self.assertFalse(a["red"], "a muted kind neither counts unread nor holds the live-down cue")
+        self.assertIn("hidden by the filters", a["emptyText"])
+
+    def test_unmuting_shows_what_happened_and_re_reddens(self):
+        a = self.out["afterUnmute"]
+        self.assertTrue(a["red"], "the entry logged while muted was never seen")
+        self.assertEqual(a["rows"], 1)
+        self.assertEqual(a["chip"], "offline")
+
 
 class ErrorCenterWiring(unittest.TestCase):
     def test_the_shell_mounts_bell_popover_and_script(self):
@@ -185,6 +221,13 @@ class ErrorCenterWiring(unittest.TestCase):
         # the chip family mirrors feed.css's .fask-* colours
         self.assertIn(".rerr-chip.k-stalled,.rerr-chip.k-warn{color:#ffd166", html)
         self.assertIn(".rerr-chip.k-nudge{color:#ff6a6a", html)
+        # the per-kind filter bar sits between header and list, chips doubling as the toggles
+        self.assertIn("id=rerr-filters", html)
+        self.assertIn(".rerr-fbtn.off{opacity:0.35;border-style:dashed}", html)
+        # timestamps wear the SHARED recency ramp: the standalone dist bundle is loaded BEFORE the
+        # errs script and read behind a feature test (dim default if the bundle is stale/missing)
+        self.assertLess(html.index("/dist/age-color-global.js"), html.index("window.__rompAgeColor"))
+        self.assertIn("if(window.__rompAgeColor)tm.style.color=window.__rompAgeColor(", html)
         self.assertIn("window.__rompNotify=function", html)
         # the mobile bar routes its bell to the same popover
         self.assertIn("errs:function(){try{window.__rompOpenErrs&&window.__rompOpenErrs();}catch(e){}}", html)

--- a/ui/webview/age-color-global.ts
+++ b/ui/webview/age-color-global.ts
@@ -1,0 +1,8 @@
+// Publish the shared recency colour (./age-color) to pages that load no webview bundle — the
+// kernel's landing SHELL, whose inline scripts (the bell panel, _LANDING_ERRS_JS) want the same
+// "(Xm ago)" tints as the panes but cannot import a module. Built as its own tiny dist entry
+// (esbuild.js) and included by _landing() before the errs script; consumers must feature-test
+// (`window.__rompAgeColor`) and fall back to their dim default, so a stale dist can't break them.
+import { ageColorReadable } from "./age-color";
+
+(window as unknown as { __rompAgeColor: (ageSecs: number) => string }).__rompAgeColor = ageColorReadable;

--- a/vscode-extension/esbuild.js
+++ b/vscode-extension/esbuild.js
@@ -46,6 +46,7 @@ const webview = {
     "../ui/webview/strip.css",           // the romp strip (VS Code-only bottom rail stand-in)
     "../ui/webview/gear.css",            // the settings modal (linked by the kernel feed page + VS Code chat/feed)
     "../ui/webview/federation.ts",   // multi-kernel manager: loaded after the shim on chat/feed/fleet pages
+    "../ui/webview/age-color-global.ts",   // window.__rompAgeColor for the kernel's inline shell scripts (bell panel)
   ],
   nodePaths: [path.join(__dirname, "node_modules")],
   bundle: true,


### PR DESCRIPTION
- One toggle chip per category (offline / limit / judge / warning / stalled / follow-up failed / retrying / api error) at the top of the panel, persisted; muted kinds don't render, don't count unread, and (offline) don't hold the live red cue — but their entries are stored, and unmuting re-reddens the bell for anything missed.
- Timestamps take the shared recency ramp via a new standalone dist entry publishing window.__rompAgeColor to the shell's inline scripts (feature-tested, dim fallback).

Driven end-to-end by the executed-JS test (13 cases now); pytest 3303, node 1368, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)