### PR TITLE
Fresh-install federation: start the bus at kernel boot, put repo bin on spawned sessions' PATH

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4490,6 +4490,21 @@ _remotes_lock = threading.Lock()
 _tunnel_wake = threading.Event()
 
 
+def _ensure_postal_bus():
+    """Start the local postal bus if nothing has yet (best-effort, off the boot path). The bus used to
+    start only LAZILY — a session's postal MCP server runs `ensure` — so a freshly attach-bootstrapped
+    machine with no sessions ran a kernel but no bus: invisible to fleet presence, no mail in or out,
+    silently (the 2026-07-27 federation shakedown: the new box answered /sessions while every message
+    to it sat parked). The postal service's own `ensure` is idempotent, respects client-only mode, and
+    no-ops when the bus is already up, so the kernel can insist at every boot. Absolute paths: a
+    bootstrap-started kernel's non-login shell has neither the repo's bin/ nor a guaranteed PATH."""
+    try:
+        subprocess.run([sys.executable, str(BIN / "romp-postal-service"), "ensure"],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30)
+    except Exception:
+        sys.stderr.write("postal bus ensure failed:\n%s" % traceback.format_exc())
+
+
 def _ssh_config_hosts():
     """Host aliases declared in ~/.ssh/config (the 'find the things' for the attach UI). Concrete 'Host'
     patterns only — wildcards/negations are skipped (not connectable targets). Best-effort: a missing or
@@ -17307,6 +17322,7 @@ def main():
     threading.Thread(target=_parent_watch, daemon=True).start()
     _known_load()                                              # remembered past hosts (popover's re-attach rows)
     _remotes_load()                                            # re-attach remote kernels from a prior run
+    threading.Thread(target=_ensure_postal_bus, daemon=True).start()   # a sessionless machine still needs its bus
     threading.Thread(target=_tunnel_supervisor, daemon=True).start()   # keep ssh tunnels alive + poll host↔sid map
     srv = ThreadingHTTPServer((BIND, PORT), Handler)
     url = "http://127.0.0.1:%d" % PORT

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -43,6 +43,17 @@ from importlib.machinery import SourceFileLoader as _SFL
 _pal = _SFL("romp_palette", str(Path(__file__).resolve().parent / "palette.py")).load_module()
 
 
+def _bin_on_path_env(environ) -> dict:
+    """The env overlay for a spawned CLI: the repo's bin/ prepended to PATH, or {} when it is already
+    there. Pure on its input for tests; _options passes os.environ. Kept additive on purpose — the SDK
+    merges options.env over the inherited environment, so returning only PATH changes nothing else."""
+    rbin = str(Path(__file__).resolve().parent.parent / "bin")
+    cur = environ.get("PATH", "")
+    if rbin in cur.split(os.pathsep):
+        return {}
+    return {"PATH": (rbin + os.pathsep + cur) if cur else rbin}
+
+
 def pick_identity_color(sid: str, state_dir=None) -> tuple[str, str]:
     """A stable (bg, fg) for a session, hashed from its sid into the ACTIVE identity palette
     (STATE/palette, the gear's Session-colors pick; the default set when state_dir is unknown)."""
@@ -2413,6 +2424,13 @@ class SdkBackend:
         kw = dict(
             cli_path=self.claude_bin,
             cwd=sess.cwd,
+            # The repo's bin/ on the CLI's PATH — the postal MCP command (`romp-postal-service`) and
+            # the mail CLI the inbox footer suggests both resolve from it, and a kernel started from a
+            # non-login shell (the attach bootstrap's ssh) hands down a PATH with neither (the
+            # 2026-07-27 federation shakedown: a remote session's `romp mail send` died
+            # command-not-found and re-prompted for permission on the absolute-path retry). options.env
+            # merges OVER the inherited environment in the SDK's transport, so this is additive.
+            env=_bin_on_path_env(os.environ),
             can_use_tool=sess._can_use_tool,
             hooks={"Stop": [HookMatcher(matcher=None, hooks=[sess._stop_hook])],          # awaiting overlay producer
                    "SubagentStart": [HookMatcher(matcher=None, hooks=[sess._subagent_start_hook])],  # live subagent

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -2225,11 +2225,15 @@ def cli_send(argv):
         sys.stderr.write("[romp mail] %s\n" % _unreachable_hint()); return 1
     me, mid = my_name(), my_id()
     try:
-        _http("POST", "/send", {"to": to, "from": me or "unknown", "from_id": mid or "", "body": body,
-                                "kind": kind})
+        resp = _http("POST", "/send", {"to": to, "from": me or "unknown", "from_id": mid or "", "body": body,
+                                       "kind": kind})
     except BusError as e:
         sys.stderr.write("[romp mail] %s\n" % e); return 1
-    print("[romp mail] delivered to '%s'" % to)
+    # Echo what actually happened, not a blanket "delivered": a cross-host send is only RELAYING (or
+    # parked for an unreachable host), and the receiving bus may still hold it for the human's
+    # approval — the 2026-07-27 shakedown had this print "delivered" for a quarantined message.
+    note = (resp or {}).get("note")
+    print("[romp mail] %s" % (note or ("delivered to '%s'" % to)))
     return 0
 
 def cli_inbox(peek=False):

--- a/tests/test_fresh_install_federation.py
+++ b/tests/test_fresh_install_federation.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Three gaps a fresh attach-bootstrapped machine showed in the 2026-07-27 federation shakedown:
+  1. Nothing started its postal bus — only a session's MCP server does, lazily, so a sessionless box
+     ran a kernel while staying postal-invisible. The kernel now insists at every boot.
+  2. Sessions spawned by that kernel inherited its non-login PATH, without the repo's bin/ — the
+     postal MCP command and `romp mail send` died command-not-found. The SDK options now overlay PATH.
+  3. `romp mail send` printed "delivered" for a cross-host message that was merely relaying (and may
+     be quarantined at the receiver). The CLI now echoes the bus's own routing note.
+
+Synthetic only — hermetic temp STATE, placeholder hosts, no processes actually spawned."""
+import io
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_freshfed", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_freshfed",
+                      os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).load_module()
+ps = SourceFileLoader("romp_postal_freshfed", os.path.join(BIN, "romp-postal-service")).load_module()
+
+
+class KernelEnsuresBus(unittest.TestCase):
+    def test_boot_runs_postal_ensure_by_absolute_path(self):
+        calls = []
+        saved = km.subprocess.run
+        km.subprocess.run = lambda argv, **kw: calls.append(argv)
+        try:
+            km._ensure_postal_bus()
+        finally:
+            km.subprocess.run = saved
+        self.assertEqual(len(calls), 1)
+        argv = [str(a) for a in calls[0]]
+        self.assertTrue(argv[1].endswith("bin/romp-postal-service"),
+                        "absolute path — a bootstrap-started kernel's PATH has no repo bin/: %s" % argv)
+        self.assertEqual(argv[2], "ensure")
+
+    def test_a_failing_ensure_never_raises(self):
+        saved = km.subprocess.run
+        km.subprocess.run = lambda *a, **kw: (_ for _ in ()).throw(OSError("no python"))
+        try:
+            km._ensure_postal_bus()   # must swallow and log, not kill the boot thread
+        finally:
+            km.subprocess.run = saved
+
+    def test_main_starts_the_ensure_thread(self):
+        src = Path(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read_text()
+        self.assertIn("threading.Thread(target=_ensure_postal_bus, daemon=True).start()", src,
+                      "boot wires the ensure — the function alone fixes nothing")
+
+
+class SpawnedSessionPath(unittest.TestCase):
+    def setUp(self):
+        self.rbin = str(Path(os.path.dirname(HERE)) / "bin")
+
+    def test_a_binless_path_gains_the_repo_bin_first(self):
+        env = sb._bin_on_path_env({"PATH": "/usr/bin:/bin"})
+        self.assertEqual(env["PATH"], self.rbin + os.pathsep + "/usr/bin:/bin",
+                         "prepended, so the repo's own tools win")
+
+    def test_a_path_already_carrying_bin_is_left_alone(self):
+        cur = self.rbin + os.pathsep + "/usr/bin"
+        self.assertEqual(sb._bin_on_path_env({"PATH": cur}), {},
+                         "no overlay at all — nothing to change")
+
+    def test_an_empty_environment_still_yields_the_bin(self):
+        self.assertEqual(sb._bin_on_path_env({}), {"PATH": self.rbin})
+
+    def test_options_pass_the_overlay(self):
+        src = Path(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read_text()
+        self.assertIn("env=_bin_on_path_env(os.environ)", src,
+                      "_options wires the overlay through the SDK's designed env field")
+
+
+class CliSendEchoesRouting(unittest.TestCase):
+    def _send(self, resp):
+        saved_http, saved_ensure = ps._http, ps.ensure
+        ps.ensure = lambda: True
+        ps._http = lambda method, path, payload=None: resp
+        out = io.StringIO()
+        saved_out = ps.sys.stdout
+        ps.sys.stdout = out
+        try:
+            rc = ps.cli_send(["--kind", "coordinate", "web", "synthetic test body"])
+        finally:
+            ps.sys.stdout = saved_out
+            ps._http, ps.ensure = saved_http, saved_ensure
+        return rc, out.getvalue()
+
+    def test_local_delivery_still_reads_delivered(self):
+        rc, out = self._send({"ok": True, "id": "m1"})
+        self.assertEqual(rc, 0)
+        self.assertIn("delivered to 'web'", out)
+
+    def test_a_cross_host_relay_says_relaying_not_delivered(self):
+        rc, out = self._send({"ok": True, "id": "px-1", "note": "relaying to 'web' on boxalias"})
+        self.assertEqual(rc, 0)
+        self.assertIn("relaying to 'web' on boxalias", out)
+        self.assertNotIn("delivered", out, "the receiving bus may still hold it — never claim delivery")
+
+    def test_a_parked_send_says_parked(self):
+        rc, out = self._send({"ok": True, "id": "px-2", "parked": "boxalias",
+                              "note": "parked for boxalias (unreachable) — delivers on reconnect, "
+                                      "or bounces back to you"})
+        self.assertEqual(rc, 0)
+        self.assertIn("parked for boxalias", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the gaps found when a freshly attach-bootstrapped machine joined the fleet in the 2026-07-27 two-machine shakedown (follow-up to #83):

- **The postal bus never started on a sessionless machine.** It only started lazily, from a session's MCP server — so an attach-bootstrapped box ran a kernel while staying postal-invisible: no presence, every inbound message parked, silently. The kernel now runs `romp-postal-service ensure` (absolute path) in a boot thread; `ensure` is idempotent, client-only-aware, and no-ops when the bus is already up.

- **Spawned sessions inherited a PATH without the repo's `bin/`.** The kernel itself was started from a non-login ssh shell, so its sessions couldn't resolve the postal MCP command, and the `romp mail send` the inbox footer suggests died command-not-found — doubling permission prompts on the absolute-path retry. `_options` now overlays PATH via `ClaudeAgentOptions.env` (the SDK's designed field, merged additively over the inherited environment), with the logic in a pure helper for tests.

- **`romp mail send` claimed "delivered" for cross-host mail.** A relayed message may be parked for an unreachable host or quarantined at the receiver; the CLI now echoes the bus's own routing note (relaying/parked) and says "delivered" only for a local delivery.

Tests in `tests/test_fresh_install_federation.py`; full Python (3321) and Node (1368) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)