### PR TITLE
Unread count drawn inside the bell

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14737,8 +14737,12 @@ function unseen(){var n=0;for(var i=0;i<NOTES.length;i++)if(!NOTES[i].seen&&kind
 // problem keeps the cue up even after the entry is read; it clears the moment the pane reconnects —
 // and stays dark entirely while the offline kind is muted).
 // No count badge — it clipped against the bar edge and the number added nothing (the user 2026-07-27).
+// the unread count draws INSIDE the bell (digits 1-9, '+' for many, blank when read — the user
+// 2026-07-28); it reddens with the bell via fill=currentColor.
 function paint(){var n=unseen();
-[icon,micon].forEach(function(el){if(el)el.classList.toggle('has',n>0||(kindOn('conn')&&liveDown()));});
+[icon,micon].forEach(function(el){if(!el)return;
+el.classList.toggle('has',n>0||(kindOn('conn')&&liveDown()));
+var t=el.querySelector('.rerr-n');if(t)t.textContent=n<=0?'':(n>9?'+':String(n));});
 if(!back.hidden)renderList();}
 // each entry leads with the chip its card wears in the feed, so the vocabulary matches across surfaces
 var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror'];
@@ -15517,6 +15521,20 @@ def _rdrift_block():
             + "<script>" + _RDRIFT_JS + "</script>")
 
 
+# The notification bell, shared by the desktop rail and the mobile bar. The unread COUNT lives
+# INSIDE the bell body (the user 2026-07-28 — the old corner badge clipped): an svg <text> centered
+# in the body, digits 1-9, '+' for more, empty when nothing is unread (the errs JS drives .rerr-n).
+# fill=currentColor so the digit reddens with the bell. SVG ATTRIBUTES QUOTED (the rail-net saga).
+_BELL_SVG = (
+    "<svg viewBox='0 0 16 16' width='17' height='17'>"
+    "<path d='M8 2 C5.8 2 4.5 3.7 4.5 6 L4.5 9 L3 11.5 L13 11.5 L11.5 9 L11.5 6 C11.5 3.7 10.2 2 8 2 Z'"
+    " fill='none' stroke='currentColor' stroke-width='1.1' stroke-linejoin='round'/>"
+    "<path d='M6.5 13.2 A1.6 1.6 0 0 0 9.5 13.2' fill='none' stroke='currentColor' stroke-width='1.1'/>"
+    # size 8 / baseline 10.8 chosen by headless A-B against 7/10.4: visibly fuller at the rendered
+    # 17px, still clear of the body walls (interior x 4.5-11.5, y 2-11.5)
+    "<text class='rerr-n' x='8' y='10.8' text-anchor='middle' font-size='8' font-weight='700'"
+    " fill='currentColor'></text></svg>")
+
 # The kernel-restart glyph, shared by the desktop rail and the mobile bar. A browser-style reload:
 # a circular arc sweeping clockwise from 4 o'clock the long way round to 1 o'clock, arrowhead at the
 # end (the user 2026-07-27 — the ↻ TEXT glyph stopped short at 11 o'clock and read as "weird", and its
@@ -15947,13 +15965,10 @@ def _landing():
             "</div>"   # /.rail-scroll
             # refresh + network + settings, pinned to the far RIGHT (settings last), always visible:
             "<div class=rail-acts>"
-            # the notification bell (the user 2026-07-27): monochrome outline like its neighbors, red +
-            # unread badge when an error lands (see _LANDING_ERRS_JS). ATTRIBUTES QUOTED (the rail-net saga).
+            # the notification bell (the user 2026-07-27): monochrome outline like its neighbors; goes red
+            # with the unread count drawn INSIDE the body when an error lands (see _BELL_SVG + _LANDING_ERRS_JS).
             "<div class=rail-act id=rail-errs title='Errors — click to open' aria-label=Errors>"
-            "<svg viewBox='0 0 16 16' width='17' height='17'>"
-            "<path d='M8 2 C5.8 2 4.5 3.7 4.5 6 L4.5 9 L3 11.5 L13 11.5 L11.5 9 L11.5 6 C11.5 3.7 10.2 2 8 2 Z'"
-            " fill='none' stroke='currentColor' stroke-width='1.1' stroke-linejoin='round'/>"
-            "<path d='M6.5 13.2 A1.6 1.6 0 0 0 9.5 13.2' fill='none' stroke='currentColor' stroke-width='1.1'/></svg>"
+            + _BELL_SVG +
             "</div>"
             # the refresh glyph is a REAL browser-style reload icon now (the user 2026-07-27: the ↻ text
             # glyph stopped at 11 o'clock and never read as refresh): a near-full circular arc sweeping
@@ -16004,10 +16019,7 @@ def _landing():
             "<button class=mact data-act=restart aria-label='Restart kernel' title='Restart kernel'>" + _REFRESH_SVG + "</button>"
             # the notification bell on mobile too (same glyph + badge; opens the same popover)
             "<button class=mact id=merr data-act=errs aria-label=Errors title='Errors — click to open'>"
-            "<svg viewBox='0 0 16 16' width='17' height='17'>"
-            "<path d='M8 2 C5.8 2 4.5 3.7 4.5 6 L4.5 9 L3 11.5 L13 11.5 L11.5 9 L11.5 6 C11.5 3.7 10.2 2 8 2 Z'"
-            " fill='none' stroke='currentColor' stroke-width='1.1' stroke-linejoin='round'/>"
-            "<path d='M6.5 13.2 A1.6 1.6 0 0 0 9.5 13.2' fill='none' stroke='currentColor' stroke-width='1.1'/></svg>"
+            + _BELL_SVG +
             "</button>"
             # settings wears the desktop rail's OWN gear glyph, ⛭ (U+26ED), not the outlined star it had.
             "<button class=mact data-act=settings aria-label=Settings title=Settings>⛭</button>"

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -41,7 +41,7 @@ function mkEl(id) {
     children: [], _cls: new Set(), _ls: {}, _html: '', _badge: null,
     classList: null,   // filled below (needs `this`)
     appendChild(c) { this.children.push(c); return c; },
-    querySelector(sel) { return sel === '.rerr-badge' ? this._badge : null; },
+    querySelector(sel) { return sel === '.rerr-n' ? this._num : null; },
     addEventListener(k, f) { (this._ls[k] = this._ls[k] || []).push(f); },
     fire(k, ev) { (this._ls[k] || []).forEach((f) => f(ev || { stopPropagation() {}, target: null })); },
     get innerHTML() { return this._html; },
@@ -61,6 +61,9 @@ const EL = {};
 ['rail-errs', 'merr', 'rerr-back', 'rerr-list', 'rerr-clear', 'rerr-x', 'rerr-filters'].forEach((id) => {
   EL[id] = withCls(mkEl(id));
 });
+EL['rail-errs']._num = mkEl('');   // the <text class=rerr-n> INSIDE each bell svg (the in-bell count)
+EL['merr']._num = mkEl('');
+function bellNum() { return EL['rail-errs']._num.textContent; }
 const BODY = new Set(['po-chat', 'po-feed', 'po-timeline']);   // fleet pane hidden, like the real default
 const WL = {};
 global.window = {
@@ -80,7 +83,8 @@ const out = {};
 // 1) a VISIBLE pane's drop logs an entry + reddens the bell (no count badge — it clipped, 2026-07-27)
 post({ romp: 'wsState', app: 'chat', state: 'down' });
 out.afterDrop = { n: notes().length, text: notes()[0].text,
-  red: EL['rail-errs']._cls.has('has'), mred: EL['merr']._cls.has('has') };
+  red: EL['rail-errs']._cls.has('has'), mred: EL['merr']._cls.has('has'),
+  num: bellNum(), mnum: EL['merr']._num.textContent };
 // 2) up then down again — the SAME error coalesces into one entry with a count (no flood)
 post({ romp: 'wsState', app: 'chat', state: 'up' });
 post({ romp: 'wsState', app: 'chat', state: 'down' });
@@ -90,12 +94,12 @@ post({ romp: 'wsState', app: 'fleet', state: 'down' });
 out.afterHidden = { n: notes().length };
 // 4) panes can feed the center directly
 post({ romp: 'notify', kind: 'warn', text: 'TESTHOST delivery failed' });
-out.afterNotify = { n: notes().length };
+out.afterNotify = { n: notes().length, num: bellNum() };
 // 5) opening the popover marks everything seen (red stays while chat is still down). Each row leads
 // with the feed's own chip vocabulary: [chip, message, time, clear] — newest entry first.
 EL['rail-errs'].fire('click');
 out.afterOpen = { open: !EL['rerr-back'].hidden, rows: EL['rerr-list'].children.length,
-  red: EL['rail-errs']._cls.has('has'),
+  red: EL['rail-errs']._cls.has('has'), num: bellNum(),
   newestChip: EL['rerr-list'].children[0].children[0].textContent,
   newestChipCls: EL['rerr-list'].children[0].children[0].className,
   newestFirst: EL['rerr-list'].children[0].children[1].textContent,
@@ -123,7 +127,10 @@ out.afterMute = { stored: STORE['romp:errFilters'], n: notes().length,
 // 11) unmuting shows what happened while muted, and the unread entry re-reddens the bell
 EL['rerr-filters'].children[0].fire('click');
 out.afterUnmute = { red: EL['rail-errs']._cls.has('has'), rows: EL['rerr-list'].children.length,
-  chip: EL['rerr-list'].children[0].children[0].textContent };
+  chip: EL['rerr-list'].children[0].children[0].textContent, num: bellNum() };
+// 12) past nine unread the in-bell count yields to '+' (a two-glyph "10" can't fit the body)
+for (let i = 0; i < 12; i++) post({ romp: 'notify', kind: 'warn', text: 'distinct problem ' + i });
+out.afterMany = { num: bellNum() };
 console.log(JSON.stringify(out));
 """
 
@@ -148,6 +155,8 @@ class ErrorCenterExecutes(unittest.TestCase):
         self.assertIn("Chat", a["text"])
         self.assertTrue(a["red"], "the rail bell goes red")
         self.assertTrue(a["mred"], "the mobile bell goes red too")
+        self.assertEqual(a["num"], "1", "…with the unread count drawn inside the bell")
+        self.assertEqual(a["mnum"], "1", "on the mobile bell too")
 
     def test_a_repeat_of_the_same_error_coalesces(self):
         a = self.out["afterRepeat"]
@@ -159,12 +168,14 @@ class ErrorCenterExecutes(unittest.TestCase):
 
     def test_panes_can_post_notify(self):
         self.assertEqual(self.out["afterNotify"]["n"], 2)
+        self.assertEqual(self.out["afterNotify"]["num"], "2")
 
     def test_opening_marks_seen_but_a_live_problem_keeps_the_cue(self):
         a = self.out["afterOpen"]
         self.assertTrue(a["open"])
         self.assertEqual(a["rows"], 2)
         self.assertTrue(a["red"], "chat is still down → the live cue stays")
+        self.assertEqual(a["num"], "", "everything read → the bell carries no number")
         self.assertIn("delivery failed", a["newestFirst"], "newest entry renders first")
 
     def test_rows_lead_with_the_feeds_chip_vocabulary(self):
@@ -206,6 +217,12 @@ class ErrorCenterExecutes(unittest.TestCase):
         self.assertTrue(a["red"], "the entry logged while muted was never seen")
         self.assertEqual(a["rows"], 1)
         self.assertEqual(a["chip"], "offline")
+        self.assertEqual(a["num"], "1", "the missed entry counts again once unmuted")
+
+    def test_past_nine_the_count_yields_to_plus(self):
+        # the user 2026-07-28: digits 1-9, then "something else to mean many" — a two-glyph "10"
+        # cannot fit the bell body, so '+' stands for many
+        self.assertEqual(self.out["afterMany"]["num"], "+")
 
 
 class ErrorCenterWiring(unittest.TestCase):
@@ -213,7 +230,12 @@ class ErrorCenterWiring(unittest.TestCase):
         html = km._landing()
         for pin in ("id=rail-errs", "id=rerr-back", "id=rerr-list", "id=rerr-clear", "id=merr"):
             self.assertIn(pin, html)
-        self.assertNotIn("rerr-badge", html)   # the count badge clipped and is gone (the user 2026-07-27)
+        self.assertNotIn("rerr-badge", html)   # the CORNER badge clipped and is gone (the user 2026-07-27);
+        # the count now lives INSIDE the bell body (the user 2026-07-28): an svg <text> the JS drives,
+        # reddening with the bell via fill=currentColor
+        self.assertIn("<text class='rerr-n'", html)
+        self.assertEqual(html.count("class='rerr-n'"), 2, "rail + mobile, both from the ONE _BELL_SVG")
+        self.assertIn("n>9?'+':String(n)", html)
         self.assertIn("title='Errors — click to open'", html)   # the bell says what it is
         # the panel speaks the shared modal vocabulary (network panel / settings card), never the
         # undefined --vscode-font-family shorthand that rendered oversized in the browser shell


### PR DESCRIPTION
Digits 1-9 centered in the bell body, '+' for many, blank when read; same bell size, count reddens with the bell (fill=currentColor). Rail + mobile bells consolidated into one _BELL_SVG. Size/baseline picked via headless A-B render. Executed-JS test extended (counts across the whole story incl. mute/unmute and the >9 → '+' cutover).

pytest 3315, node 1368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)