### PR TITLE
Bell panel: click-to-jump, labelled filter grid, aligned rows, wider panel

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14730,7 +14730,7 @@ _LANDING_ERRS_JS = """
 (function(){var icon=document.getElementById('rail-errs'),micon=document.getElementById('merr'),
 back=document.getElementById('rerr-back'),list=document.getElementById('rerr-list'),
 clearBtn=document.getElementById('rerr-clear'),x=document.getElementById('rerr-x'),
-filtBar=document.getElementById('rerr-filters');
+filtBar=document.getElementById('rerr-fgrid');
 if(!icon||!back||!list)return;
 var KEY='romp:notices',MAX=100,FKEY='romp:errFilters';
 function load(){try{var v=JSON.parse(localStorage.getItem(KEY)||'[]');return Array.isArray(v)?v:[];}catch(e){return[];}}
@@ -14760,14 +14760,25 @@ el.classList.toggle('has',n>0||(kindOn('conn')&&liveDown()));
 var t=el.querySelector('.rerr-n');if(t)t.textContent=n<=0?'':(n>9?'+':String(n));});
 if(!back.hidden)renderList();}
 // each entry leads with the chip its card wears in the feed, so the vocabulary matches across surfaces
-var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror'];
+var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror','cleared'];
 var KINDLBL={conn:'offline',limit:'limit',judge:'judge',warn:'warning',stalled:'stalled',
-nudge:'follow-up failed',retry:'retrying',apierror:'api error'};
+nudge:'follow-up failed',retry:'retrying',apierror:'api error',cleared:'cleared'};
+// what each kind MEANS (the user 2026-07-28: the tooltip should explain the badge, not just say
+// show/hide) — worn by the filter toggles AND every entry's chip
+var DESC={conn:"the dashboard lost its live connection to the kernel for a visible pane; it reconnects on its own",
+limit:"an account-wide Claude usage window (5h session or 7d weekly) hit 100% \u2014 retries and background judging pause until it resets",
+judge:"romp's summarizer gave up on one or more cards \u2014 open a flagged card to see what happened",
+warn:"romp's judge stamped an anomaly on a card; the card wears the same yellow chip with the detail",
+stalled:"romp itself is holding a working thread and nothing is moving it \u2014 not waiting on you",
+nudge:"romp's one automatic follow-up on a stalled thread didn't resolve it; the thread now needs you",
+retry:"a session is inside an API-error retry storm; auto-retry is already working on it",
+apierror:"a session stopped on an API error (rate limit, spend cap, or prompt too long) and its card is blocked",
+cleared:"a /clear in a session dropped still-open cards at the boundary; Undo clear on the feed restores them"};
 // the toggles ARE the chips (same pill, same colours) — lit = shown, dimmed = muted. Built once on a
 // STABLE container; only classes flip on click, so the buttons stay click-safe.
 if(filtBar)KINDS.forEach(function(k){var b=document.createElement('span');
 b.className='rerr-chip rerr-fbtn k-'+k+(kindOn(k)?'':' off');b.textContent=KINDLBL[k];
-b.title='Show / hide '+KINDLBL[k]+' entries';
+b.title='Show or hide these entries. '+KINDLBL[k]+': '+DESC[k];
 b.addEventListener('click',function(ev){ev.stopPropagation();
 if(kindOn(k)){FILT[k]=1;}else{delete FILT[k];}saveFilt();
 b.classList.toggle('off',!kindOn(k));renderList();paint();});
@@ -14775,8 +14786,10 @@ filtBar.appendChild(b);});
 function renderList(){list.innerHTML='';var shown=0;
 for(var i=NOTES.length-1;i>=0;i--)(function(n,i){if(!kindOn(n.kind))return;shown++;
 var row=document.createElement('div');row.className='rerr-row';
-if(KINDLBL[n.kind]){var ch=document.createElement('span');ch.className='rerr-chip k-'+n.kind;
-ch.textContent=KINDLBL[n.kind];row.appendChild(ch);}
+// the chip cell ALWAYS exists (grid column 1), empty for an unknown kind, so messages stay aligned
+var ch=document.createElement('span');
+if(KINDLBL[n.kind]){ch.className='rerr-chip k-'+n.kind;ch.textContent=KINDLBL[n.kind];ch.title=DESC[n.kind]||'';}
+row.appendChild(ch);
 var tx=document.createElement('span');tx.className='rerr-msg';tx.textContent=n.text+(n.n>1?' (x'+n.n+')':'');
 var tm=document.createElement('span');tm.className='rerr-t';tm.textContent=ago(n.t);
 // the timestamp wears the SAME recency colour every other "(Xm ago)" wears (window.__rompAgeColor,
@@ -14784,20 +14797,29 @@ var tm=document.createElement('span');tm.className='rerr-t';tm.textContent=ago(n
 if(window.__rompAgeColor)tm.style.color=window.__rompAgeColor(Math.max(0,Math.floor(Date.now()/1000)-n.t));
 var del=document.createElement('span');del.className='rerr-del';del.textContent='\\u00d7';del.title='Clear';
 del.addEventListener('click',function(ev){ev.stopPropagation();NOTES.splice(i,1);save();renderList();paint();});
+// entries minted from a feed card carry a jump target (the user 2026-07-28): clicking the row closes
+// the popover, reveals the feed pane, and asks the feed to scroll to + pulse that card (it falls back
+// to opening the session if the card is gone). The x keeps its own handler (stopPropagation above).
+if(n.tgt&&(n.tgt.itemId||n.tgt.sid)){row.className+=' link';row.title='Jump to this card';
+row.addEventListener('click',function(){close();
+try{window.__rompPaneToggle&&window.__rompPaneToggle('feed',true);}catch(e){}
+var f=document.getElementById('f-feed');
+try{f&&f.contentWindow&&f.contentWindow.postMessage({romp:'revealCard',itemId:n.tgt.itemId||'',sid:n.tgt.sid||''},'*');}catch(e){}});}
 row.appendChild(tx);row.appendChild(tm);row.appendChild(del);list.appendChild(row);})(NOTES[i],i);
 if(!shown){var e=document.createElement('div');e.className='rerr-empty';
 e.textContent=NOTES.length?'Nothing to show \\u2014 hidden by the filters above':'No errors';list.appendChild(e);}}
 // One write path. A repeat of the NEWEST entry (same kind+text — e.g. a reconnect loop dropping over and
 // over) coalesces into it with a count instead of flooding the feed: event-exact, no time window.
-window.__rompNotify=function(kind,text){if(!text)return;
+window.__rompNotify=function(kind,text,tgt){if(!text)return;
 var last=NOTES[NOTES.length-1];
-if(last&&last.kind===kind&&last.text===String(text)){last.n=(last.n||1)+1;last.t=Math.floor(Date.now()/1000);last.seen=false;}
-else{NOTES.push({kind:String(kind||'error'),text:String(text),t:Math.floor(Date.now()/1000),n:1,seen:false});
+if(last&&last.kind===kind&&last.text===String(text)){last.n=(last.n||1)+1;last.t=Math.floor(Date.now()/1000);last.seen=false;if(tgt)last.tgt=tgt;}
+else{NOTES.push({kind:String(kind||'error'),text:String(text),t:Math.floor(Date.now()/1000),n:1,seen:false,tgt:tgt||null});
 if(NOTES.length>MAX)NOTES=NOTES.slice(-MAX);}
 save();paint();};
-// pane iframes can feed the center too
+// pane iframes can feed the center too; sid/itemId ride along as the entry's jump target
 window.addEventListener('message',function(e){var m=e&&e.data;
-if(m&&m.romp==='notify'&&m.text)window.__rompNotify(m.kind||'error',m.text);});
+if(m&&m.romp==='notify'&&m.text)window.__rompNotify(m.kind||'error',m.text,
+(m.sid||m.itemId)?{sid:String(m.sid||''),itemId:String(m.itemId||'')}:null);});
 // Connection tracking (was the #romp-offline top banner). Only a VISIBLE pane counts (the user 2026-07-06):
 // a pane toggled OFF still holds a live socket (the Fleet pane is hidden by default, its iframe always
 // loaded), so a blip on a pane you can't even see shouldn't cry wolf while the chat pane you interact
@@ -15545,9 +15567,9 @@ _BELL_SVG = (
     "<path d='M8 2 C5.8 2 4.5 3.7 4.5 6 L4.5 9 L3 11.5 L13 11.5 L11.5 9 L11.5 6 C11.5 3.7 10.2 2 8 2 Z'"
     " fill='none' stroke='currentColor' stroke-width='1.1' stroke-linejoin='round'/>"
     "<path d='M6.5 13.2 A1.6 1.6 0 0 0 9.5 13.2' fill='none' stroke='currentColor' stroke-width='1.1'/>"
-    # size 8 / baseline 10.8 chosen by headless A-B against 7/10.4: visibly fuller at the rendered
-    # 17px, still clear of the body walls (interior x 4.5-11.5, y 2-11.5)
-    "<text class='rerr-n' x='8' y='10.8' text-anchor='middle' font-size='8' font-weight='700'"
+    # size 7.5 / baseline 10.2 (the user 2026-07-28: at 8/10.8 the digit melded into the bell's mouth
+    # line at y=11.5 — a pixel up and a touch smaller keeps a clear gap; re-checked headlessly)
+    "<text class='rerr-n' x='8' y='10.2' text-anchor='middle' font-size='7.5' font-weight='700'"
     " fill='currentColor'></text></svg>")
 
 # The kernel-restart glyph, shared by the desktop rail and the mobile bar. A browser-style reload:
@@ -15905,7 +15927,7 @@ def _landing():
             # shell never defines, so the whole shorthand was invalid and the text rendered oversized in
             # the page default): #252526 card, 13px system-ui body, 14px/600 header, 11.5px rows + 11px
             # dim times (the network panel's information-type sizes), rnet-style action button + close.
-            "#rerr-panel{position:absolute;right:10px;bottom:44px;width:min(440px,94vw);max-height:min(60vh,480px);"
+            "#rerr-panel{position:absolute;right:10px;bottom:44px;width:min(700px,94vw);max-height:min(60vh,480px);"   # 60% wider (the user 2026-07-28)
             "display:flex;flex-direction:column;background:#252526;border:1px solid #3a3a3a;border-radius:10px;"
             "box-shadow:0 12px 36px #000000aa;color:#ccc;font:13px/1.6 system-ui,-apple-system,'Segoe UI',sans-serif}"
             "#rerr-panel .rerr-top{display:flex;align-items:center;gap:8px;font-size:14px;font-weight:600;color:#e8eaed;"
@@ -15917,17 +15939,28 @@ def _landing():
             "#rerr-x{background:none;border:none;color:#9aa0a6;font-size:16px;line-height:1;cursor:pointer;padding:0 2px}"
             "#rerr-x:hover{color:#fff}"
             "#rerr-list{overflow-y:auto;padding:4px 0;flex:1 1 auto}"
-            ".rerr-row{display:flex;align-items:baseline;gap:7px;padding:6px 12px;color:#ccc;font-size:11.5px;line-height:1.45}"
+            # grid rows (the user 2026-07-28): a fixed 96px chip column — wider than the widest chip
+            # ("follow-up failed") — so every message starts at the SAME x, left-aligned past the chips.
+            ".rerr-row{display:grid;grid-template-columns:96px 1fr auto auto;align-items:baseline;"
+            "column-gap:8px;padding:6px 12px;color:#ccc;font-size:11.5px;line-height:1.45}"
+            ".rerr-row .rerr-chip{justify-self:start}"
+            ".rerr-row.link{cursor:pointer}"
+            ".rerr-row.link:hover{background:rgba(255,255,255,0.05)}"
             ".rerr-row+.rerr-row{border-top:1px solid #2a2a2a}"
             ".rerr-msg{flex:1;min-width:0;overflow-wrap:anywhere}"
             ".rerr-t{flex:0 0 auto;color:#6e7681;font-size:11px;white-space:nowrap;font-variant-numeric:tabular-nums}"
             ".rerr-del{flex:0 0 auto;cursor:pointer;opacity:.5;font-weight:700}"
             ".rerr-del:hover{opacity:1}"
             ".rerr-empty{padding:16px 12px;color:#6e7681;text-align:center;font-size:11.5px}"
-            # The per-kind filter bar (the user 2026-07-28): the toggles ARE the chips — lit means shown,
-            # dimmed (with a dashed edge, a second cue beyond opacity) means muted.
-            "#rerr-filters{display:flex;flex-wrap:wrap;gap:5px;padding:8px 12px;border-bottom:1px solid #2a2a2a;flex:0 0 auto}"
-            ".rerr-fbtn{cursor:pointer;user-select:none}"
+            # The per-kind filter bar (the user 2026-07-28): a vertical white "show" label on the left, then
+            # the toggles in an even GRID — 8 kinds over the minimum 2 rows x 4 equal columns, every chip the
+            # same cell width, instead of one ragged wrapping row. The toggles ARE the chips — lit means
+            # shown, dimmed (with a dashed edge, a second cue beyond opacity) means muted.
+            "#rerr-filters{display:flex;align-items:stretch;gap:9px;padding:8px 12px;border-bottom:1px solid #2a2a2a;flex:0 0 auto}"
+            ".rerr-flabel{writing-mode:vertical-rl;transform:rotate(180deg);text-align:center;color:#e8eaed;"
+            "font-size:9px;font-weight:700;letter-spacing:.10em;text-transform:uppercase;user-select:none}"
+            "#rerr-fgrid{flex:1;display:grid;grid-template-columns:repeat(5,1fr);gap:5px}"   # 9 kinds -> 2 rows (5+4), the minimum
+            ".rerr-fbtn{cursor:pointer;user-select:none;text-align:center}"
             ".rerr-fbtn.off{opacity:0.35;border-style:dashed}"
             ".rerr-fbtn:hover{opacity:1}"
             # Each entry leads with the SAME chip the card wears in the feed — same pill shape, colours and
@@ -15939,6 +15972,7 @@ def _landing():
             ".rerr-chip.k-retry,.rerr-chip.k-apierror{color:#e5484d;border-color:rgba(229,72,77,0.6)}"
             ".rerr-chip.k-conn{color:#ff6b6b;border-color:rgba(255,107,107,0.6)}"
             ".rerr-chip.k-limit,.rerr-chip.k-judge{color:#e0a030;border-color:rgba(224,160,48,0.6)}"
+            ".rerr-chip.k-cleared{color:#9aa0a6;border-color:rgba(154,160,166,0.6)}"   # not an error — quiet gray
             "</style></head><body class='po-chat po-feed po-timeline'>"
             "<div id=romp-boot>" + _loader_inner() + "</div>"
             # the notification popover (hidden until the bell is clicked; backdrop click closes). No
@@ -15948,7 +15982,7 @@ def _landing():
             "<div class=rerr-top>Errors<span class=sp></span>"
             "<button id=rerr-clear title='Clear all entries'>Clear all</button>"
             "<button id=rerr-x aria-label=Close>×</button></div>"
-            "<div id=rerr-filters></div>"
+            "<div id=rerr-filters><span class=rerr-flabel>show</span><div id=rerr-fgrid></div></div>"
             "<div id=rerr-list></div>"
             "</div></div>"
             "<div class=col>"

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -58,9 +58,12 @@ function withCls(el) {
   return el;
 }
 const EL = {};
-['rail-errs', 'merr', 'rerr-back', 'rerr-list', 'rerr-clear', 'rerr-x', 'rerr-filters'].forEach((id) => {
+['rail-errs', 'merr', 'rerr-back', 'rerr-list', 'rerr-clear', 'rerr-x', 'rerr-fgrid', 'f-feed'].forEach((id) => {
   EL[id] = withCls(mkEl(id));
 });
+const POSTED = [];   // what the shell posts into the feed iframe (revealCard)
+EL['f-feed'].contentWindow = { postMessage: (msg) => POSTED.push(msg) };
+const TOGGLES = [];  // window.__rompPaneToggle calls (revealing the feed pane on a jump)
 EL['rail-errs']._num = mkEl('');   // the <text class=rerr-n> INSIDE each bell svg (the in-bell count)
 EL['merr']._num = mkEl('');
 function bellNum() { return EL['rail-errs']._num.textContent; }
@@ -68,6 +71,7 @@ const BODY = new Set(['po-chat', 'po-feed', 'po-timeline']);   // fleet pane hid
 const WL = {};
 global.window = {
   addEventListener: (k, f) => { (WL[k] = WL[k] || []).push(f); },
+  __rompPaneToggle: (k, to) => TOGGLES.push(k + ':' + to),
 };
 global.document = {
   getElementById: (id) => EL[id] || null,
@@ -115,22 +119,33 @@ out.afterClearAll = { n: notes().length, rows: EL['rerr-list'].children.length,
 post({ romp: 'wsState', app: 'chat', state: 'up' });
 out.afterReconnect = { red: EL['rail-errs']._cls.has('has') };
 // 9) the filter bar built one toggle chip per kind, in order, conn ("offline") first
-out.filterBar = { n: EL['rerr-filters'].children.length,
-  first: EL['rerr-filters'].children[0].textContent,
-  labels: EL['rerr-filters'].children.map((c) => c.textContent).join('|') };
+out.filterBar = { n: EL['rerr-fgrid'].children.length,
+  first: EL['rerr-fgrid'].children[0].textContent,
+  labels: EL['rerr-fgrid'].children.map((c) => c.textContent).join('|') };
 // 10) muting offline: its entries stop rendering, stop counting, and the live-down cue stays dark
-EL['rerr-filters'].children[0].fire('click');
+EL['rerr-fgrid'].children[0].fire('click');
 post({ romp: 'wsState', app: 'chat', state: 'down' });
 out.afterMute = { stored: STORE['romp:errFilters'], n: notes().length,
   red: EL['rail-errs']._cls.has('has'),
   emptyText: EL['rerr-list'].children[0].textContent };
 // 11) unmuting shows what happened while muted, and the unread entry re-reddens the bell
-EL['rerr-filters'].children[0].fire('click');
+EL['rerr-fgrid'].children[0].fire('click');
 out.afterUnmute = { red: EL['rail-errs']._cls.has('has'), rows: EL['rerr-list'].children.length,
   chip: EL['rerr-list'].children[0].children[0].textContent, num: bellNum() };
 // 12) past nine unread the in-bell count yields to '+' (a two-glyph "10" can't fit the body)
 for (let i = 0; i < 12; i++) post({ romp: 'notify', kind: 'warn', text: 'distinct problem ' + i });
 out.afterMany = { num: bellNum() };
+// 13) an entry minted from a feed card carries a jump target: clicking the row closes the popover,
+// reveals the feed pane, and posts revealCard into the feed iframe
+post({ romp: 'notify', kind: 'stalled', text: 'api \u2014 stalled: held', sid: 'TESTSID', itemId: 'TESTSID:g9' });
+const jumpRow = EL['rerr-list'].children[0];
+out.jump = { linky: jumpRow.className.indexOf('link') >= 0 };
+jumpRow.fire('click');
+out.jump.closed = EL['rerr-back'].hidden;
+out.jump.posted = POSTED[POSTED.length - 1] || null;
+out.jump.toggles = TOGGLES.join('|');
+// …while a kernel-minted entry (no target) is not clickable
+out.plainRowLinky = EL['rerr-list'].children[1].className.indexOf('link') >= 0;
 console.log(JSON.stringify(out));
 """
 
@@ -200,10 +215,10 @@ class ErrorCenterExecutes(unittest.TestCase):
         # the user 2026-07-28: every high-level category gets a toggle (offline fires so often it
         # drowns the rest). The toggles ARE the chips, in the same order entries wear them.
         a = self.out["filterBar"]
-        self.assertEqual(a["n"], 8)
+        self.assertEqual(a["n"], 9)
         self.assertEqual(a["first"], "offline")
         self.assertEqual(a["labels"],
-                         "offline|limit|judge|warning|stalled|follow-up failed|retrying|api error")
+                         "offline|limit|judge|warning|stalled|follow-up failed|retrying|api error|cleared")
 
     def test_muting_a_kind_hides_counts_and_live_cue_but_keeps_the_entries(self):
         a = self.out["afterMute"]
@@ -218,6 +233,16 @@ class ErrorCenterExecutes(unittest.TestCase):
         self.assertEqual(a["rows"], 1)
         self.assertEqual(a["chip"], "offline")
         self.assertEqual(a["num"], "1", "the missed entry counts again once unmuted")
+
+    def test_an_entry_click_jumps_to_its_card(self):
+        # the user 2026-07-28: click the chip or the text to jump to the thing — the popover closes,
+        # the feed pane is revealed, and the feed scrolls to + pulses the card (revealCard).
+        a = self.out["jump"]
+        self.assertTrue(a["linky"], "a targeted entry renders as a link row")
+        self.assertTrue(a["closed"], "the popover closes on jump")
+        self.assertEqual(a["posted"], {"romp": "revealCard", "itemId": "TESTSID:g9", "sid": "TESTSID"})
+        self.assertIn("feed:true", a["toggles"], "the feed pane is revealed for the jump")
+        self.assertFalse(self.out["plainRowLinky"], "a kernel-minted entry with no target is not a link")
 
     def test_past_nine_the_count_yields_to_plus(self):
         # the user 2026-07-28: digits 1-9, then "something else to mean many" — a two-glyph "10"
@@ -243,9 +268,22 @@ class ErrorCenterWiring(unittest.TestCase):
         # the chip family mirrors feed.css's .fask-* colours
         self.assertIn(".rerr-chip.k-stalled,.rerr-chip.k-warn{color:#ffd166", html)
         self.assertIn(".rerr-chip.k-nudge{color:#ff6a6a", html)
-        # the per-kind filter bar sits between header and list, chips doubling as the toggles
-        self.assertIn("id=rerr-filters", html)
+        # the per-kind filter bar sits between header and list, chips doubling as the toggles: a
+        # vertical white "show" label, then an even 4-column grid (8 kinds -> the minimum 2 rows,
+        # every chip the same cell width) instead of one ragged wrapping row (the user 2026-07-28)
+        self.assertIn("<div id=rerr-filters><span class=rerr-flabel>show</span><div id=rerr-fgrid></div></div>", html)
+        self.assertIn("writing-mode:vertical-rl", html)
+        self.assertIn("#rerr-fgrid{flex:1;display:grid;grid-template-columns:repeat(5,1fr);gap:5px}", html)
         self.assertIn(".rerr-fbtn.off{opacity:0.35;border-style:dashed}", html)
+        # the panel is 60% wider, and entry rows are a grid with a fixed chip column so every message
+        # left-aligns past the widest chip
+        self.assertIn("width:min(700px,94vw)", html)
+        self.assertIn("grid-template-columns:96px 1fr auto auto", html)
+        # every kind's toggle AND entry chip explains itself (not just show/hide)
+        self.assertIn("var DESC={conn:", html)
+        self.assertIn("b.title='Show or hide these entries. '+KINDLBL[k]+': '+DESC[k]", html)
+        # targeted entries jump: close, reveal the feed pane, post revealCard into the feed iframe
+        self.assertIn("{romp:'revealCard',itemId:n.tgt.itemId||'',sid:n.tgt.sid||''}", html)
         # timestamps wear the SHARED recency ramp: the standalone dist bundle is loaded BEFORE the
         # errs script and read behind a feature test (dim default if the bundle is stale/missing)
         self.assertLess(html.index("/dist/age-color-global.js"), html.index("window.__rompAgeColor"))

--- a/ui/webview/badge-mirror.test.ts
+++ b/ui/webview/badge-mirror.test.ts
@@ -10,7 +10,7 @@ import { badgeNotices, clearBoundaryNotices, type BadgeItem, type ClearNoticeRow
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
 const base = (over: Partial<BadgeItem>): BadgeItem =>
-  ({ itemId: "TESTSID:g1", name: "api", text: "ship the notes-api", ...over });
+  ({ itemId: "TESTSID:g1", sid: "TESTSID", name: "api", text: "ship the notes-api", ...over });
 
 test("every trouble chip becomes one entry, in the session's name", () => {
   const items = [base({
@@ -23,6 +23,8 @@ test("every trouble chip becomes one entry, in the session's name", () => {
   const { notices } = badgeNotices(items, new Set());
   assert.deepEqual(notices.map((n) => n.kind), ["warn", "stalled", "nudge", "retry", "apierror"]);
   assert.ok(notices.every((n) => n.text.startsWith("api — ")), "each entry names the session");
+  // every notice carries its jump target so the bell entry can lead back to the card (2026-07-28)
+  assert.ok(notices.every((n) => n.sid === "TESTSID" && n.itemId === "TESTSID:g1"));
   assert.match(notices[0].text, /warning: the summarizer gave up/);
   assert.match(notices[1].text, /stalled: romp is holding this/, "the staller's note beats the mechanical why");
   assert.match(notices[4].text, /API error 529/);
@@ -81,7 +83,24 @@ test("the feed posts each notice to the shell and persists only the ACTIVE set",
   assert.match(FEED, /mirrorBadges\(incomingAsks, Array\.isArray\(m\.clearNotices\) \? m\.clearNotices : \[\]\)/,
     "runs on every feed payload, against the FULL list + the kernel's clear notices");
   assert.match(FEED, /clearBoundaryNotices\(clears, seenSet\)/, "clear drops ride the same seen-set");
-  assert.match(FEED, /window\.parent\?\.postMessage\(\{ romp: "notify", kind: n\.kind, text: n\.text \}, "\*"\)/);
+  assert.match(FEED,
+    /window\.parent\?\.postMessage\(\{ romp: "notify", kind: n\.kind, text: n\.text, sid: n\.sid, itemId: n\.itemId \}, "\*"\)/,
+    "each notice carries its jump target (sid + itemId) for the bell's click-through");
   assert.match(FEED, /localStorage\.setItem\(BADGE_SEEN_KEY, JSON\.stringify\(Array\.from\(active\)\)\)/,
     "active-only persistence is what re-arms a cleared badge and bounds the store");
+});
+
+
+test("the feed answers revealCard: scroll to the card, pulse it accent, session fallback", () => {
+  // the return path of the bell's jump (the user 2026-07-28): the shell posts {romp:'revealCard'};
+  // the feed finds the card by its data-key, scrolls + pulses; a gone card opens the session instead.
+  assert.match(FEED, /if \(m\.romp === "revealCard"\) \{/);
+  assert.match(FEED, /\[data-key="a:\$\{String\(m\.itemId \|\| ""\)\}"\]/);
+  assert.match(FEED, /target\.scrollIntoView\(\{ block: "center", behavior: "smooth" \}\);/);
+  assert.match(FEED, /target\.classList\.add\("reveal-pulse"\);/);
+  assert.match(FEED, /animationend.*reveal-pulse.*once: true/, "the pulse is one-shot");
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "openSession", id: String\(m\.sid\) \}\)/);
+  const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+  assert.match(CSS, /\.reveal-pulse \{ animation: revealPulse 1\.6s ease; \}/);
+  assert.match(CSS, /box-shadow: 0 0 0 2px var\(--accent\)/, "accent chrome, not a status colour");
 });

--- a/ui/webview/badge-mirror.ts
+++ b/ui/webview/badge-mirror.ts
@@ -11,25 +11,27 @@
 // of the same kind (different since/t) is a new entry.
 
 export interface BadgeItem {
-  itemId: string; name: string; text: string;
+  itemId: string; sid: string; name: string; text: string;
   stalled?: { why: string; since: number; note?: string | null } | null;
   nudgeFailed?: boolean;
   retrying?: { since?: number | null; count?: number } | null;
   warns?: { kind: string; t: number; msg: string }[] | null;
   blocked?: { state: string; status?: number; text?: string; tooLong?: boolean; spendLimit?: boolean } | null;
 }
-export interface BadgeNotice { kind: string; text: string; sig: string; }
+// sid + itemId ride along so a bell entry can JUMP back to the card it was minted from (the user
+// 2026-07-28): the shell posts them back as {romp:'revealCard'} and the feed scrolls + pulses the card.
+export interface BadgeNotice { kind: string; text: string; sig: string; sid: string; itemId: string; }
 
 const cap = (s: string, n: number) => (s.length > n ? s.slice(0, n - 1) + "…" : s);
 
 export function badgeNotices(items: BadgeItem[], seen: Set<string>): { notices: BadgeNotice[]; active: Set<string> } {
   const notices: BadgeNotice[] = [];
   const active = new Set<string>();
-  const add = (sig: string, kind: string, text: string) => {
-    active.add(sig);
-    if (!seen.has(sig)) notices.push({ kind, text, sig });
-  };
   for (const it of items) {
+    const add = (sig: string, kind: string, text: string) => {
+      active.add(sig);
+      if (!seen.has(sig)) notices.push({ kind, text, sig, sid: it.sid, itemId: it.itemId });
+    };
     for (const w of it.warns ?? []) {
       add("w|" + it.itemId + "|" + w.t + "|" + w.kind, "warn", it.name + " — warning: " + cap(w.msg, 100));
     }
@@ -71,7 +73,7 @@ export function clearBoundaryNotices(rows: ClearNoticeRow[], seen: Set<string>):
     active.add(sig);
     if (seen.has(sig)) continue;
     const n = r.titles.length;
-    notices.push({ kind: "cleared", sig,
+    notices.push({ kind: "cleared", sig, sid: r.sid, itemId: "",   // no single card — the jump opens the session
       text: r.name + " — /clear dropped " + n + " open card" + (n === 1 ? "" : "s") + ": "
         + cap(r.titles.join(", "), 120) + " (Undo clear on the feed restores them)" });
   }

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1006,3 +1006,14 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   white-space: nowrap; font-variant-numeric: tabular-nums; }
 .age-tip-what { overflow-wrap: anywhere; }
 .age-tip-row.stamp { margin-top: 4px; padding-top: 4px; border-top: 1px solid rgba(255, 255, 255, 0.09); }
+
+/* Bell-entry jump target (the user 2026-07-28): clicking an entry in the shell's error popover lands
+   here — the card pulses accent twice so the eye finds it. Runs once per jump (the class is removed on
+   animationend); accent = highlight chrome, deliberately NOT a status colour. */
+.reveal-pulse { animation: revealPulse 1.6s ease; }
+@keyframes revealPulse {
+  0%, 100% { box-shadow: none; }
+  15%, 40% { box-shadow: 0 0 0 2px var(--accent), 0 0 16px rgba(156, 210, 255, 0.5); }
+  55% { box-shadow: none; }
+  70%, 85% { box-shadow: 0 0 0 2px var(--accent), 0 0 16px rgba(156, 210, 255, 0.5); }
+}

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3096,7 +3096,9 @@ function mirrorBadges(items: AskItem[], clears: ClearNoticeRow[]): void {
   // dropped open cards logs one durable entry naming them, so the drop is never silent.
   const boundary = clearBoundaryNotices(clears, seenSet);
   for (const n of [...badges.notices, ...boundary.notices]) {
-    try { window.parent?.postMessage({ romp: "notify", kind: n.kind, text: n.text }, "*"); } catch { /* no shell (VS Code view) */ }
+    try {
+      window.parent?.postMessage({ romp: "notify", kind: n.kind, text: n.text, sid: n.sid, itemId: n.itemId }, "*");
+    } catch { /* no shell (VS Code view) */ }
   }
   const active = new Set([...badges.active, ...boundary.active]);
   try { localStorage.setItem(BADGE_SEEN_KEY, JSON.stringify(Array.from(active))); } catch { /* storage full */ }
@@ -3107,6 +3109,21 @@ window.addEventListener("message", (e: MessageEvent) => {
   if (!m) return;
   if (m.type === "pipeState") { pipeBanner(!!m.up, Number(m.queued) || 0); return; }
   if (m.romp === "paneFocus") { kbEnterCards(); return; }   // the shell handed us keyboard focus → arm card nav
+  if (m.romp === "revealCard") {
+    // a bell-entry click jumps back to the card it was minted from (the user 2026-07-28): scroll it
+    // into view and pulse it accent so the eye lands on the right card. A card that no longer exists
+    // under its own key (cleared, or folded into a group) falls back to opening the session.
+    const target = document.querySelector(`[data-key="a:${String(m.itemId || "")}"]`) as HTMLElement | null;
+    if (target) {
+      target.scrollIntoView({ block: "center", behavior: "smooth" });
+      target.classList.remove("reveal-pulse"); void target.offsetWidth;   // restart the animation on a repeat jump
+      target.classList.add("reveal-pulse");
+      target.addEventListener("animationend", () => target.classList.remove("reveal-pulse"), { once: true });
+    } else if (m.sid) {
+      vscodeApi?.postMessage({ type: "openSession", id: String(m.sid) });
+    }
+    return;
+  }
   if (m.type === "feed") {
     const incomingAsks: AskItem[] = Array.isArray(m.asks) ? m.asks : [];
     // A clear is CONFIRMED once the kernel's payload no longer lists it → stop suppressing it. Then drop


### PR DESCRIPTION
- Card-minted entries are clickable: popover closes, feed pane revealed, card scrolled into view + accent double-pulse (session fallback if the card is gone). Targets ride the existing notify channel; the /clear-boundary notices jump to their session.
- Filter bar: vertical white "show" label + even 5-column grid (9 kinds = minimum 2 rows, uniform chip widths); every toggle and entry chip carries a plain-language description of its kind on hover.
- Rows are a grid with a fixed chip column so all messages left-align past the widest chip; panel widened to 700px.
- In-bell digit moved up/slightly smaller (7.5/10.2) so it clears the bell's mouth — verified with headless A-B renders.

pytest 3326, node 1369, tsc clean; all landing scripts node-parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)