### PR TITLE
A reply landing mid-build rebuilds the feed at once, and column flips leave a trail

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13947,8 +13947,8 @@ def _producer_sig(browser):
 # every session on EVERY push (~2.7s combined, uncached) — a fresh connect waits for that, and an idle
 # dashboard re-does it every tick. Cache each payload, keyed on a fleet fingerprint; an UNCHANGED fleet (a
 # reload, an idle tick) reuses the last build instead of rebuilding.
-_built_feed = [None, None, 0.0]                   # [fleet_sig, payload, built_at]
-_built_timeline = [None, None, 0.0]               # [fleet_sig, payload, built_at]
+_built_feed = [None, None, 0.0, 0.0]              # [fleet_sig, payload, built_at, build_started_at]
+_built_timeline = [None, None, 0.0, 0.0]          # [fleet_sig, payload, built_at, build_started_at]
 # Each build is intrinsically ~1-1.6s (re-segments every session); the IDEAL is a per-session lane/card cache
 # (only the changed session rebuilds), but that's a big refactor of build_feed/build_timeline. Interim cap: a
 # minimum rebuild interval. With an ACTIVE fleet the fleet_sig busts on every push (the watched session keeps
@@ -14001,23 +14001,33 @@ def _cached_feed(now, tmux, sig, connect=False):
     # UNLESS an optimistic kernel-side mutation postdates the build (_views_dirty): that state is invisible
     # to the sig AND must not wait out REBUILD_MIN_S, or the push meant to show it serves the stale payload.
     e = _built_feed
-    dirty = not connect and _views_dirty[0] > e[2]        # connect still serves the warmed build (never rebuilds)
+    # The dirty mark compares against build START, not finish (the user 2026-07-28): a build takes
+    # ~1-1.6s and reads the stores one session at a time, so a mutation landing MID-build may or may
+    # not have been read — its payload can predate the gesture while its finish time postdates it.
+    # Comparing against the finish swallowed exactly that case: the reply's dirty mark lost to the
+    # in-flight build's completion, and the pre-reply payload (card still Completed) was re-served
+    # until the next sig bust — the window a client fallback needs to bounce a just-replied card
+    # back to Completed. REBUILD_MIN_S stays keyed on the FINISH (e[2]): it rate-limits build COST,
+    # so back-to-back starts must not shrink its window.
+    dirty = not connect and _views_dirty[0] > e[3]        # connect still serves the warmed build (never rebuilds)
     if e[1] is not None and not dirty and (connect or e[0] == sig or (time.time() - e[2]) < REBUILD_MIN_S):
         return e[1]
     bid = _next_feed_build_id()          # claimed BEFORE the read, so an ack issued during this build outranks it
-    feed = build_feed(now, tmux)
+    started = time.time()                # …and the dirty floor for the NEXT check: mutations after this
+    feed = build_feed(now, tmux)         # instant may be invisible to the build below → must rebuild
     feed["buildId"] = bid
-    _built_feed[:] = [sig, feed, time.time()]
+    _built_feed[:] = [sig, feed, time.time(), started]
     return feed
 
 
 def _cached_timeline(now, tmux, sig, connect=False):
     e = _built_timeline
-    dirty = not connect and _views_dirty[0] > e[2]
+    dirty = not connect and _views_dirty[0] > e[3]        # start-keyed, same as _cached_feed above
     if e[1] is not None and not dirty and (connect or e[0] == sig or (time.time() - e[2]) < REBUILD_MIN_S):
         return e[1]
+    started = time.time()
     tl = build_timeline(now, tmux)
-    _built_timeline[:] = [sig, tl, time.time()]
+    _built_timeline[:] = [sig, tl, time.time(), started]
     return tl
 
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -197,7 +197,7 @@ class ViewBuilder(unittest.TestCase):
         'still slow' report, the user 2026-07-15). The reorder handler now _mark_views_dirty()s, and a dirty
         mark bypasses the throttle so the fresh order ships at once."""
         now = int(time.time()); tmux = km._tmux_sessions()
-        km._built_feed[:] = [None, None, 0.0]; km._views_dirty[0] = 0.0
+        km._built_feed[:] = [None, None, 0.0, 0.0]; km._views_dirty[0] = 0.0
         other = "22222222-3333-4444-5555-666666666666"
         km._write_session_order([SID])
         f1 = km._cached_feed(now, tmux, km._fleet_view_sig(now, tmux))   # warm the cache with this order
@@ -4611,7 +4611,7 @@ class ViewBuilder(unittest.TestCase):
         # hold steady on a cache hit — otherwise an acked prediction clears against a stale payload.
         km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
-        km._built_feed[:] = [None, None, 0.0]
+        km._built_feed[:] = [None, None, 0.0, 0.0]
         km._views_dirty[0] = 0.0
         first = km._cached_feed(NOW, km._tmux_sessions(), ("sig", 1))
         self.assertIsInstance(first.get("buildId"), int)

--- a/tests/test_kernel_fleet_cache.py
+++ b/tests/test_kernel_fleet_cache.py
@@ -41,10 +41,10 @@ class FleetCacheTest(unittest.TestCase):
         try:
             km._views_dirty[0] = 0.0
             f_sentinel = {"type": "feed", "cards": [], "working": []}
-            km._built_feed[:] = [("SIG",), f_sentinel, time.time()]
+            km._built_feed[:] = [("SIG",), f_sentinel, time.time(), time.time()]
             self.assertIs(km._cached_feed(0, {}, ("SIG",)), f_sentinel, "matching sig reuses, no rebuild")
             t_sentinel = {"type": "data"}
-            km._built_timeline[:] = [("SIG",), t_sentinel, time.time()]
+            km._built_timeline[:] = [("SIG",), t_sentinel, time.time(), time.time()]
             self.assertIs(km._cached_timeline(0, {}, ("SIG",)), t_sentinel)
         finally:
             km._built_feed[:] = feed_save
@@ -60,11 +60,41 @@ class FleetCacheTest(unittest.TestCase):
         dirty_save = km._views_dirty[0]
         try:
             f_stale = {"type": "feed", "cards": ["stale"]}
-            km._built_feed[:] = [("SIG",), f_stale, time.time()]   # fresh build: same sig AND inside REBUILD_MIN_S
+            km._built_feed[:] = [("SIG",), f_stale, time.time(), time.time()]   # fresh build: same sig AND inside REBUILD_MIN_S
             km._mark_views_dirty()                                 # the mutation lands after the build
             got = km._cached_feed(int(time.time()), {}, ("SIG",))
             self.assertIsNot(got, f_stale, "a dirty mark newer than the build must force a rebuild")
         finally:
+            km._built_feed[:] = feed_save
+            km._views_dirty[0] = dirty_save
+
+    def test_a_mutation_landing_mid_build_is_not_swallowed_by_that_build(self):
+        """A build takes ~1-1.6s and reads the stores one session at a time, so a mutation landing
+        MID-build may or may not have been read — its payload can predate the gesture while its finish
+        postdates it. The dirty floor therefore keys on the build's START: comparing against the finish
+        swallowed exactly that case (the user 2026-07-28: a reply landed while a build was in flight,
+        the reply's dirty mark lost to that build's completion, and the pre-reply payload — the card
+        still Completed — was re-served until the next sig bust, the window a client fallback needs to
+        bounce a just-replied card back to Completed)."""
+        feed_save = list(km._built_feed)
+        dirty_save = km._views_dirty[0]
+        real_build = km.build_feed
+        def build_with_midflight_reply(now, tmux):
+            time.sleep(0.005)                         # a real build runs ~1s; keep the mark measurably
+            km._mark_views_dirty()                    # past the start stamp, then: the reply lands while
+            return {"type": "feed", "cards": []}      # this build is mid-read. fresh dict → `is` tells builds apart
+        try:
+            km._views_dirty[0] = 0.0
+            km._built_feed[:] = [None, None, 0.0, 0.0]
+            km.build_feed = build_with_midflight_reply
+            f1 = km._cached_feed(int(time.time()), {}, ("SIG",))
+            km.build_feed = lambda now, tmux: {"type": "feed", "cards": []}
+            f2 = km._cached_feed(int(time.time()), {}, ("SIG",))
+            self.assertIsNot(f2, f1, "a mark set during the build postdates its start → must rebuild")
+            f3 = km._cached_feed(int(time.time()), {}, ("SIG",))
+            self.assertIs(f3, f2, "the mark predates the SECOND build's start → reuse, no rebuild loop")
+        finally:
+            km.build_feed = real_build
             km._built_feed[:] = feed_save
             km._views_dirty[0] = dirty_save
 
@@ -75,7 +105,7 @@ class FleetCacheTest(unittest.TestCase):
         dirty_save = km._views_dirty[0]
         try:
             f_warm = {"type": "feed", "cards": ["warm"]}
-            km._built_feed[:] = [("OLD",), f_warm, time.time()]
+            km._built_feed[:] = [("OLD",), f_warm, time.time(), time.time()]
             km._mark_views_dirty()
             self.assertIs(km._cached_feed(int(time.time()), {}, ("NEW",), connect=True), f_warm)
         finally:

--- a/ui/webview/feed-colflip.test.ts
+++ b/ui/webview/feed-colflip.test.ts
@@ -1,0 +1,74 @@
+// A card's column must not bounce through a stale payload after a reply — and when a view DOES
+// bounce, the bounce must leave a record (the user 2026-07-28).
+//
+// The incident: the user replied to a Completed card, watched it fly to Working, flash back to
+// Completed, then return to Working. Post-hoc, every layer checked out sound — the store held
+// "working" the whole window, the snapshot punch applied, the ack/buildId machinery held — and
+// nothing anywhere recorded what the view actually rendered, so the bounce could not be attributed.
+// Two fixes, pinned here:
+//
+// (1) KERNEL: the _views_dirty check compared the mark against the cached build's FINISH time, so a
+//     reply landing while a ~1-1.6s build was in flight was swallowed when that build completed —
+//     its payload predates the gesture, but its finish postdates it — and the pre-reply payload
+//     (card still Completed) was re-served until the next sig bust. The dirty floor now keys on the
+//     build's START; REBUILD_MIN_S stays on the finish (it rate-limits build cost).
+//
+// (2) CLIENT: every rendered column change posts a clientDiag breadcrumb (what moved, from/to, the
+//     input event the render reflects, the payload's buildId, whether a prediction was live), so
+//     the next bounce is read from client-diag.jsonl instead of unreproducible archaeology.
+//
+// Source-level pins (no jsdom for the feed renderer), mirroring feed-move-ack.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
+
+test("kernel: the dirty floor keys on build START, so a mid-build mutation still rebuilds", () => {
+  // the cache rows carry both stamps: finish (REBUILD_MIN_S) and start (the dirty floor)
+  assert.match(KERNEL, /_built_feed = \[None, None, 0\.0, 0\.0\]/);
+  assert.match(KERNEL, /_built_timeline = \[None, None, 0\.0, 0\.0\]/);
+  // both caches compare the dirty mark against the START slot, never the finish
+  const dirtyChecks = KERNEL.match(/_views_dirty\[0\] > e\[3\]/g) || [];
+  assert.equal(dirtyChecks.length, 2, "feed AND timeline key dirty on build start");
+  assert.ok(!/_views_dirty\[0\] > e\[2\]/.test(KERNEL), "no dirty check keys on build finish");
+  // the start stamp is taken BEFORE the build runs, in both caches
+  const feedBody = KERNEL.slice(KERNEL.indexOf("def _cached_feed"), KERNEL.indexOf("def _cached_timeline"));
+  assert.ok(feedBody.indexOf("started = time.time()") < feedBody.indexOf("build_feed(now, tmux)"),
+    "feed: start stamped before the build reads anything");
+  assert.match(feedBody, /_built_feed\[:\] = \[sig, feed, time\.time\(\), started\]/);
+  const tlBody = KERNEL.slice(KERNEL.indexOf("def _cached_timeline"), KERNEL.indexOf("def _run_tier"));
+  assert.ok(tlBody.indexOf("started = time.time()") < tlBody.indexOf("build_timeline(now, tmux)"),
+    "timeline: start stamped before the build reads anything");
+  assert.match(tlBody, /_built_timeline\[:\] = \[sig, tl, time\.time\(\), started\]/);
+  // the rebuild rate limit still keys on the finish, so back-to-back starts don't shrink its window
+  assert.match(feedBody, /\(time\.time\(\) - e\[2\]\) < REBUILD_MIN_S/);
+  assert.match(tlBody, /\(time\.time\(\) - e\[2\]\) < REBUILD_MIN_S/);
+});
+
+test("feed: every rendered column change posts a colflip breadcrumb with its cause", () => {
+  // the audit runs on what the render SHOWS: after the optimistic overlay is applied
+  const render = FEED.slice(FEED.indexOf("function render()"));
+  assert.ok(render.indexOf("applyFollowMove(asks)") < render.indexOf("auditShownColumns(asks)"),
+    "audit reads the post-prediction columns — the thing the user actually sees");
+  // a flip posts the generic clientDiag breadcrumb the kernel already persists
+  assert.match(FEED, /type: "clientDiag", surface: "feed", what: "colflip"/);
+  assert.match(FEED, /from: prev, to: a\.column, ev: lastFeedEvent,/);
+  assert.match(FEED, /buildId: lastPayloadBuildId, predicted: pendingFollowMove\.has\(a\.itemId\)/);
+  // ...and the kernel side of that channel exists (strip.test.ts pins its shape)
+  assert.ok(KERNEL.includes('"clientDiag"') && KERNEL.includes("client-diag.jsonl"));
+});
+
+test("feed: every prediction drop names WHY, so a bounce's trigger is in the trail", () => {
+  // each clearFollowMove call site attributes itself; the whys the incident needs to tell apart
+  for (const why of ["backstop-noack", "backstop-noconfirm", "ack-fail", "gone", "confirmed",
+                     "answer-yield", "outranked"]) {
+    assert.ok(FEED.includes(`"${why}"`), `clearFollowMove site tagged ${why}`);
+  }
+  // a fresh payload marks itself as the next render's input, before reconcile can re-tag
+  const payload = FEED.slice(FEED.indexOf('lastFeedEvent = "payload"'));
+  assert.ok(payload.indexOf("reconcileFollowMove(incomingAsks, lastPayloadBuildId)") > 0,
+    "payload tag set before reconcile runs");
+});

--- a/ui/webview/feed-followup-move.test.ts
+++ b/ui/webview/feed-followup-move.test.ts
@@ -44,7 +44,8 @@ test("the optimistic move also bumps the card's sort key to now so it lands at t
 test("the kernel is authoritative: a confirming push clears the prediction, an unconfirmed one is left predicting", () => {
   // reconcile runs against the authoritative incoming payload on every feed push, carrying that payload's
   // buildId so an ACKED prediction can tell a pre-click payload from the kernel's answer (feed-move-ack)
-  assert.match(FEED, /reconcileFollowMove\(incomingAsks, typeof m\.buildId === "number" \? m\.buildId : 0\);/);
+  assert.match(FEED, /lastPayloadBuildId = typeof m\.buildId === "number" \? m\.buildId : 0;/);
+  assert.match(FEED, /reconcileFollowMove\(incomingAsks, lastPayloadBuildId\);/);
   // CONFIRMED = the kernel now lists the card as working, OR no longer lists it (cleared/absorbed).
   // (An ANSWER-kind prediction additionally yields to the first payload either way — feed-card-predict.)
   assert.match(FEED, /if \(!a \|\| a\.column === "working" \|\| pendingMoveKind\.get\(id\) === "answer"\) \{/);

--- a/ui/webview/feed-move-ack.test.ts
+++ b/ui/webview/feed-move-ack.test.ts
@@ -71,7 +71,7 @@ test("client: an ACKED prediction yields only to a payload built AFTER the gestu
   // the exact race the old timer papered over: a build already in flight when the click landed cannot know
   // about the reopen, and taking it as the answer is the bounce back to Completed this replaced
   assert.match(FEED, /const acked = pendingMoveAck\.get\(id\);/);
-  assert.match(FEED, /if \(acked !== undefined && buildId > acked\) clearFollowMove\(id\);/);
+  assert.match(FEED, /if \(acked !== undefined && buildId > acked\) clearFollowMove\(id, "outranked"\);/);
   assert.match(FEED, /function reconcileFollowMove\(incoming: AskItem\[\], buildId: number\)/);
 });
 
@@ -80,7 +80,7 @@ test("client: an ack silences the toast but never lets a prediction wedge", () =
   // a prediction must not outlive the answer either if a payload goes missing
   const ack = FEED.slice(FEED.indexOf("function ackFollowMove("), FEED.indexOf("// On a fresh authoritative payload"));
   assert.match(ack, /pendingMoveAck\.set\(itemId, buildId\);/);
-  assert.match(ack, /clearFollowMove\(itemId\); render\(\);\s*\/\/ silent wedge guard/);
+  assert.match(ack, /clearFollowMove\(itemId, "backstop-noconfirm"\); render\(\);\s*\/\/ silent wedge guard/);
   assert.ok(!/feedToast/.test(ack.slice(ack.indexOf("pendingMoveAck.set"))),
     "no toast on any path after the kernel confirmed the move");
   // a fresh gesture waits on its OWN answer, never inheriting the last one's

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -215,18 +215,43 @@ function reconcilePendingDone(asks: AskItem[]) {
 }
 type MoveKind = "followup" | "answer";
 const pendingMoveKind = new Map<string, MoveKind>();
-function clearFollowMove(itemId: string) {
+// COLUMN-FLIP TRIPWIRE (the user 2026-07-28, who watched a just-replied card bounce Working →
+// Completed → Working and could not be told afterwards WHICH layer bounced it — every candidate
+// mechanism checked out sound post-hoc, and no surface records what the view actually SHOWED).
+// Every rendered column change posts a clientDiag breadcrumb (client-diag.jsonl) carrying what
+// most recently changed the render's inputs, so the next bounce is attributed from the recorded
+// trail instead of unreproducible archaeology. Ids only, no card text.
+const shownCol = new Map<string, string>();            // itemId → column as last RENDERED (post-prediction)
+let lastFeedEvent = "init";                            // the input change the next render reflects
+let lastPayloadBuildId = 0;
+function auditShownColumns(list: AskItem[]) {
+  const seen = new Set<string>();
+  for (const a of list) {
+    seen.add(a.itemId);
+    const prev = shownCol.get(a.itemId);
+    if (prev !== undefined && prev !== a.column) {
+      vscodeApi?.postMessage({ type: "clientDiag", surface: "feed", what: "colflip",
+        data: { id: a.itemId, from: prev, to: a.column, ev: lastFeedEvent,
+                buildId: lastPayloadBuildId, predicted: pendingFollowMove.has(a.itemId) } });
+    }
+    shownCol.set(a.itemId, a.column);
+  }
+  for (const id of Array.from(shownCol.keys())) if (!seen.has(id)) shownCol.delete(id);
+}
+function clearFollowMove(itemId: string, why = "") {
   const t = pendingFollowMove.get(itemId); if (t) clearTimeout(t);
   pendingFollowMove.delete(itemId); pendingMoveKind.delete(itemId); pendingMoveAck.delete(itemId);
+  if (why) lastFeedEvent = "clear:" + why;             // tripwire attribution only; behavior unchanged
 }
 function optimisticFollowMove(itemId: string, kind: MoveKind = "followup") {
   const prev = pendingFollowMove.get(itemId); if (prev) clearTimeout(prev);
   pendingMoveKind.set(itemId, kind);
   pendingMoveAck.delete(itemId);                       // a fresh gesture waits on its OWN answer, not the last one's
+  lastFeedEvent = "predict:" + kind;
   const timer = window.setTimeout(() => {
     if (!pendingFollowMove.has(itemId)) return;        // a push already confirmed the move → nothing to do
     const k = pendingMoveKind.get(itemId);
-    clearFollowMove(itemId);                           // give the kernel authority: drop the prediction
+    clearFollowMove(itemId, "backstop-noack");         // give the kernel authority: drop the prediction
     // Reaching here means the kernel never answered AT ALL (see ackFollowMove) — not that it declined the
     // move, which is what the old wording claimed on every mid-pass reply. An "answer" prediction has no
     // ack by design and always yields to the first payload, so it never gets this far.
@@ -244,7 +269,7 @@ function optimisticFollowMove(itemId: string, kind: MoveKind = "followup") {
 function ackFollowMove(itemId: string, ok: boolean, buildId: number) {
   if (!pendingFollowMove.has(itemId)) return;
   if (!ok) {
-    clearFollowMove(itemId);
+    clearFollowMove(itemId, "ack-fail");
     feedToast("Your reply was sent, but that card isn’t on the board any more to move to Working.");
     render();
     return;
@@ -253,7 +278,7 @@ function ackFollowMove(itemId: string, ok: boolean, buildId: number) {
   const prev = pendingFollowMove.get(itemId); if (prev) clearTimeout(prev);
   pendingFollowMove.set(itemId, window.setTimeout(() => {
     if (!pendingFollowMove.has(itemId)) return;
-    clearFollowMove(itemId); render();                 // silent wedge guard: no payload ever answered the ack
+    clearFollowMove(itemId, "backstop-noconfirm"); render();   // silent wedge guard: no payload ever answered the ack
   }, MOVE_ACK_MS));
 }
 // On a fresh authoritative payload: a predicted card the kernel now lists as working (or no longer lists at
@@ -266,7 +291,7 @@ function reconcileFollowMove(incoming: AskItem[], buildId: number) {
   for (const id of Array.from(pendingFollowMove.keys())) {
     const a = incoming.find((x) => x.itemId === id);
     if (!a || a.column === "working" || pendingMoveKind.get(id) === "answer") {
-      clearFollowMove(id);
+      clearFollowMove(id, !a ? "gone" : a.column === "working" ? "confirmed" : "answer-yield");
       continue;
     }
     // ACKED, yet this payload still shows the card elsewhere. Trust it ONLY if it was built after the kernel
@@ -275,7 +300,7 @@ function reconcileFollowMove(incoming: AskItem[], buildId: number) {
     // is the kernel's own state, so yield to it silently — the reply landed, the card simply moved on (the
     // work finished, a fresh block arrived), which is honest to show and never a failed move.
     const acked = pendingMoveAck.get(id);
-    if (acked !== undefined && buildId > acked) clearFollowMove(id);
+    if (acked !== undefined && buildId > acked) clearFollowMove(id, "outranked");
   }
 }
 // Render-time: keep each still-unconfirmed predicted card in Working, styled like the kernel's own re-checked
@@ -2810,6 +2835,7 @@ function render() {
   const list = document.getElementById("feed-list")!;
   pruneAgeTip();   // drop the tip only if the render tore its hovered stamp out (see pruneAgeTip)
   applyFollowMove(asks);   // keep optimistically-moved follow-up cards in Working until the kernel confirms (or reverts)
+  auditShownColumns(asks); // tripwire: what this render SHOWS is the record a bounce report needs
   const prevScroll = list.scrollTop;
   // footer pane (below the cards, no overlap): Newest first · Collapsed · Clear all · UndoClear
   const showCA = !!asks.length;
@@ -3143,7 +3169,9 @@ window.addEventListener("message", (e: MessageEvent) => {
     // payload read the store, which is what makes "the kernel has answered my click" an event and not a
     // guess (see reconcileFollowMove); a kernel too old to send one reads as 0 and simply never confirms
     // an acked prediction early, leaving the backstop to retire it.
-    reconcileFollowMove(incomingAsks, typeof m.buildId === "number" ? m.buildId : 0);
+    lastFeedEvent = "payload";                         // tripwire: this render's inputs are the fresh payload
+    lastPayloadBuildId = typeof m.buildId === "number" ? m.buildId : 0;
+    reconcileFollowMove(incomingAsks, lastPayloadBuildId);
     reconcilePendingDone(incomingAsks);   // retire an optimistic tick once the real tree carries it
     // An optimistic Undo clear is CONFIRMED once the kernel's payload carries the id again → stop forcing it.
     // Until then, keep the cached card in `asks` so the replace above can't drop the just-restored card (flicker).


### PR DESCRIPTION
## The incident

The user replied to a Completed card and watched it fly to Working, flash back to Completed, then return to Working. The investigation proved the goal store held the reopen ("working") for the entire window and the mid-pass snapshot punch applied correctly, so the bounce came from the view layer, and no surface records what a view actually rendered.

## Kernel fix

`_cached_feed`/`_cached_timeline` compared the `_views_dirty` mark against the cached build's **finish** time. A build takes ~1-1.6s and reads the stores one session at a time, so a reply landing mid-build may not have been read, yet the build's completion swallowed the mark: the pre-reply payload (card still Completed) was re-served until the next sig bust. The dirty floor now keys on the build's **start** (a fourth slot on the cache rows); `REBUILD_MIN_S` stays keyed on the finish, since it rate-limits build cost.

## Client tripwire

Every rendered column change posts a `clientDiag` breadcrumb to `client-diag.jsonl`: card id, from/to, the input event the render reflects, the payload's buildId, and whether an optimistic prediction was live. Every prediction drop now names why (`confirmed` / `gone` / `outranked` / `backstop-noack` / `backstop-noconfirm` / `ack-fail` / `answer-yield`). If a card ever bounces again, the trail attributes it in seconds.

## Tests

- `tests/test_kernel_fleet_cache.py`: new behavioral test, a mark set during a build must force the next rebuild (fails on the old finish-keyed check), plus 4-slot seed updates.
- `ui/webview/feed-colflip.test.ts`: source pins for the start-keyed dirty floor and the tripwire wiring.
- Updated stale pins in `feed-move-ack.test.ts` / `feed-followup-move.test.ts` for the tagged call shapes.
- Both suites green: pytest 3342 passed, node 1372 passed; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)