### PR TITLE
Notification bells: per-session and per-card OS notifications; errors icon becomes a triangle

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1313,6 +1313,54 @@ def _set_session_flag(sid, flag, value):
             sys.stderr.write("unmute fast-forward: %s\n" % traceback.format_exc())
 
 
+# ── per-card notification subscriptions (the user 2026-07-28) ─────────────────────────────────────
+# The feed card's right-click "Notify me" toggle: {itemId: true} in notify-cards.json under STATE.
+# Session-level subscriptions ride session-flags.json (flag "notify" — the timeline lane bell / tab
+# menu); this file holds the per-card ones. An armed id gets an OS notification when its card enters
+# needs_input or completed (_feed_notifications). Same mtime+size cache as _session_flags — build_feed
+# echoes it on every push. Ids whose card left the feed are pruned on write (the card is gone; a fresh
+# card is a fresh id), so the file tracks the live feed instead of growing forever.
+_notify_cards_cache = {}   # str(path) -> ((mtime_ns,size), dict)
+
+
+def _notify_cards():
+    p = jd.STATE / "notify-cards.json"
+    try:
+        st = p.stat(); key = (st.st_mtime_ns, st.st_size)
+    except OSError:
+        return {}
+    hit = _notify_cards_cache.get(str(p))
+    if hit is not None and hit[0] == key:
+        return hit[1]
+    try:
+        d = json.loads(p.read_text())
+        if not isinstance(d, dict):
+            d = {}
+    except Exception:
+        d = {}
+    _notify_cards_cache[str(p)] = (key, d)
+    return d
+
+
+def _set_notify_card(item_id, value):
+    cur = dict(_notify_cards())                      # copy: never mutate the cached dict in place
+    if value:
+        cur[item_id] = True
+    else:
+        cur.pop(item_id, None)
+    _atomic_write(jd.STATE / "notify-cards.json", json.dumps(cur, sort_keys=True))
+
+
+def _prune_notify_cards(live_ids):
+    """Drop armed ids whose card is no longer in the feed (cleared/archived — the id never comes back).
+    Called from the feed-diff detector, so the write happens only on the event of a card leaving."""
+    cur = _notify_cards()
+    gone = [i for i in cur if i not in live_ids]
+    if gone:
+        kept = {i: True for i in cur if i in live_ids}
+        _atomic_write(jd.STATE / "notify-cards.json", json.dumps(kept, sort_keys=True))
+
+
 # ── Auto Nudge (the user 2026-06-19) ──────────────────────────────────────────────────────────────
 # When ON, a background pass follows up on an ORPHANED goal: a session that is ALIVE but went IDLE (its
 # turn ended) while its top goal still shows "working" — not blocked, not completed, not awaiting your
@@ -10157,6 +10205,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
             # the timeline lane's feed checkbox + postal mailbox. Same flags + legacy fallback as build_timeline.
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),
             "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"),
+            "notify": _session_flag(sid, "notify"),   # session-level bell: OS notification when its work blocks on you / completes (the user 2026-07-28)
             # NEVER `now`. This rides the chat payload, and _send_client dedups by comparing the
             # SERIALIZED payload against what that client last received — so a firstSeen that ticked
             # with the wall clock made every build differ, defeated the dedup entirely, and re-sent the
@@ -11813,6 +11862,12 @@ def build_feed(now, tmux=None):
     # QUARANTINED PEER MAIL (per-host trust model): mail from a DIRECTED federated host is held, never
     # auto-injected — each is a human decision (approve/deny/edit), so it surfaces as a needs-you card.
     asks.extend(_quarantine_cards(now, cleared))
+    # per-card bell (the user 2026-07-28): one pass over the FINAL ask list — goal cards, placeholders,
+    # parked handoffs and quarantine cards alike — so every card's right-click menu reflects its armed
+    # state. True/None (not False) keeps unarmed payloads byte-identical to pre-bell ones.
+    _ncards = _notify_cards()
+    for _a in asks:
+        _a["notify"] = True if _ncards.get(_a["itemId"]) else None
     return {"type": "feed", "asks": asks, "now": now,
             "working": working, "awaiting": awaiting,   # awaiting = idle-but-waiting-on-bg-work names → straw dot (the user 2026-07-13)
             # session name -> live judge-classified SERVICE descs (a dev server the session keeps around;
@@ -13114,7 +13169,8 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
             "clears": [{"t": r["t"]} for r in jd.episode_rows(sid)[1:] if r.get("t")],
             "faded": faded,
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),    # lane checkbox → mute from feed (timeline-only)
-            "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff")})  # lane mailbox → isolate from the Romp Postal Service (bin/romp-postal-service)
+            "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"),  # lane mailbox → isolate from the Romp Postal Service (bin/romp-postal-service)
+            "notify": _session_flag(sid, "notify")})   # lane bell → OS notification when this session's work blocks on you / completes (the user 2026-07-28)
     if with_bars:
         messages = _postal_messages(now, set(id2name), id2name)
         _bind_message_execs(messages, turns)             # connector exec → the recipient's process-start (real transit)
@@ -13984,7 +14040,8 @@ def _fleet_view_sig(now, tmux):
     sig["__judge__"] = _judge_gen[0]
     sig["__bucket__"] = now // 5
     for p, k in ((jd.STATE / "colormap", "__cmap__"), (jd.STATE / "session-flags.json", "__flags__"),
-                 (jd.STATE / "session-order.json", "__order__")):
+                 (jd.STATE / "session-order.json", "__order__"),
+                 (jd.STATE / "notify-cards.json", "__ncards__")):   # per-card bell arming → the card's menu state
         try:
             sig[k] = os.stat(p).st_mtime
         except OSError:
@@ -14008,7 +14065,63 @@ def _cached_feed(now, tmux, sig, connect=False):
     feed = build_feed(now, tmux)
     feed["buildId"] = bid
     _built_feed[:] = [sig, feed, time.time()]
+    for _t, _b in _feed_notifications(feed):              # armed bells: fresh builds are the transition event
+        _system_notify(_t, _b)
     return feed
+
+
+# ── system notifications: the bell toggles (the user 2026-07-28) ──────────────────────────────────
+# A session's bell (timeline lane / tab menu → session-flags "notify") or a card's bell (right-click →
+# notify-cards.json) arms OS-level notifications, fired when an armed card ENTERS needs_input (blocked
+# on you) or completed. Detection diffs each fresh feed build against the previous one — the exact event
+# the columns move on, no separate heuristic — and the FIRST build after a kernel start is a silent
+# baseline: existing state is status, not news (the same policy as extension.ts freshNeedsYou). A card
+# re-entering needs_input later (a new block after an answer) notifies again by construction.
+_NOTIFY_PREV = [None]   # itemId -> column at the last build; None = baseline pending
+
+
+def _system_notify(title, body):
+    """Best-effort OS notification (macOS osascript; notify-send elsewhere) — fire-and-forget Popen so the
+    pusher thread never blocks on it; never raises."""
+    try:
+        if sys.platform == "darwin":
+            esc = lambda s: str(s).replace("\\", "\\\\").replace('"', '\\"')
+            script = 'display notification "%s" with title "%s"' % (esc(body), esc(title))
+            cmd = ["osascript", "-e", script]
+        else:
+            cmd = ["notify-send", str(title), str(body)]
+        subprocess.Popen(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except OSError:
+        pass
+
+
+def _feed_notifications(feed):
+    """Diff this feed build against the last; return [(title, body)] for every ARMED card that newly
+    entered needs_input or completed (including a card appearing already there — work can surface
+    blocked). Also advances the prev map and prunes armed ids whose card left the feed."""
+    prev = _NOTIFY_PREV[0]
+    cur = {}
+    for a in feed.get("asks") or []:
+        if a.get("provisional"):
+            continue                                 # placeholder churn — not a stable card yet
+        cur[str(a.get("itemId"))] = a
+    _NOTIFY_PREV[0] = {i: a.get("column") for i, a in cur.items()}
+    _prune_notify_cards(set(cur))
+    if prev is None:
+        return []                                    # baseline: existing state is status, not news
+    cards = _notify_cards()
+    out = []
+    for iid, a in cur.items():
+        col = a.get("column")
+        if col not in ("needs_input", "completed") or prev.get(iid) == col:
+            continue
+        if not (cards.get(iid) or _session_flag(str(a.get("sid") or ""), "notify")):
+            continue
+        what = "Needs you" if col == "needs_input" else "Completed"
+        txt = str(a.get("text") or "").strip()
+        out.append(("romp: %s" % (a.get("name") or "session"),
+                    "%s: %s" % (what, txt[:140] if txt else "a task changed state")))
+    return out
 
 
 def _cached_timeline(now, tmux, sig, connect=False):
@@ -14748,16 +14861,16 @@ var FILT=loadFilt();
 function saveFilt(){try{localStorage.setItem(FKEY,JSON.stringify(FILT));}catch(e){}}
 function kindOn(k){return !FILT[k];}
 function unseen(){var n=0;for(var i=0;i<NOTES.length;i++)if(!NOTES[i].seen&&kindOn(NOTES[i].kind))n++;return n;}
-// The bell: red while anything unmuted is unread OR a visible pane's socket is DOWN right now (the live
-// problem keeps the cue up even after the entry is read; it clears the moment the pane reconnects —
+// The triangle: red while anything unmuted is unread OR a visible pane's socket is DOWN right now (the
+// live problem keeps the cue up even after the entry is read; it clears the moment the pane reconnects —
 // and stays dark entirely while the offline kind is muted).
 // No count badge — it clipped against the bar edge and the number added nothing (the user 2026-07-27).
-// the unread count draws INSIDE the bell (digits 1-9, '+' for many, blank when read — the user
-// 2026-07-28); it reddens with the bell via fill=currentColor.
+// the unread count draws INSIDE the triangle (digits 1-9, '+' for many; the triangle's own '!' when
+// read — a warning triangle without a glyph reads as an empty shape); currentColor reddens it too.
 function paint(){var n=unseen();
 [icon,micon].forEach(function(el){if(!el)return;
 el.classList.toggle('has',n>0||(kindOn('conn')&&liveDown()));
-var t=el.querySelector('.rerr-n');if(t)t.textContent=n<=0?'':(n>9?'+':String(n));});
+var t=el.querySelector('.rerr-n');if(t)t.textContent=n<=0?'!':(n>9?'+':String(n));});
 if(!back.hidden)renderList();}
 // each entry leads with the chip its card wears in the feed, so the vocabulary matches across surfaces
 var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror','cleared'];
@@ -15558,18 +15671,18 @@ def _rdrift_block():
             + "<script>" + _RDRIFT_JS + "</script>")
 
 
-# The notification bell, shared by the desktop rail and the mobile bar. The unread COUNT lives
-# INSIDE the bell body (the user 2026-07-28 — the old corner badge clipped): an svg <text> centered
-# in the body, digits 1-9, '+' for more, empty when nothing is unread (the errs JS drives .rerr-n).
-# fill=currentColor so the digit reddens with the bell. SVG ATTRIBUTES QUOTED (the rail-net saga).
-_BELL_SVG = (
+# The errors glyph, shared by the desktop rail and the mobile bar: a warning TRIANGLE (was a bell
+# until 2026-07-28 — the bell now means the session/card notification toggles, so the error center
+# wears the unambiguous trouble shape instead). The unread COUNT lives INSIDE the triangle (the user
+# 2026-07-28 — the old corner badge clipped): an svg <text> the errs JS drives (.rerr-n), digits 1-9,
+# '+' for more, and the triangle's own '!' when nothing is unread. fill=currentColor so the digit
+# reddens with the outline. SVG ATTRIBUTES QUOTED (the rail-net saga).
+_ERRS_SVG = (
     "<svg viewBox='0 0 16 16' width='17' height='17'>"
-    "<path d='M8 2 C5.8 2 4.5 3.7 4.5 6 L4.5 9 L3 11.5 L13 11.5 L11.5 9 L11.5 6 C11.5 3.7 10.2 2 8 2 Z'"
+    "<path d='M8 2.2 L14.6 13.4 L1.4 13.4 Z'"
     " fill='none' stroke='currentColor' stroke-width='1.1' stroke-linejoin='round'/>"
-    "<path d='M6.5 13.2 A1.6 1.6 0 0 0 9.5 13.2' fill='none' stroke='currentColor' stroke-width='1.1'/>"
-    # size 7.5 / baseline 10.2 (the user 2026-07-28: at 8/10.8 the digit melded into the bell's mouth
-    # line at y=11.5 — a pixel up and a touch smaller keeps a clear gap; re-checked headlessly)
-    "<text class='rerr-n' x='8' y='10.2' text-anchor='middle' font-size='7.5' font-weight='700'"
+    # size 6.5 / baseline 12 centers the glyph in the triangle's wide lower half, clear of the apex
+    "<text class='rerr-n' x='8' y='12' text-anchor='middle' font-size='6.5' font-weight='700'"
     " fill='currentColor'></text></svg>")
 
 # The kernel-restart glyph, shared by the desktop rail and the mobile bar. A browser-style reload:
@@ -16014,10 +16127,11 @@ def _landing():
             "</div>"   # /.rail-scroll
             # refresh + network + settings, pinned to the far RIGHT (settings last), always visible:
             "<div class=rail-acts>"
-            # the notification bell (the user 2026-07-27): monochrome outline like its neighbors; goes red
-            # with the unread count drawn INSIDE the body when an error lands (see _BELL_SVG + _LANDING_ERRS_JS).
+            # the error center's warning triangle (a bell until 2026-07-28 — the bell now means the
+            # notification toggles): monochrome outline like its neighbors; goes red with the unread
+            # count drawn INSIDE the triangle when an error lands (see _ERRS_SVG + _LANDING_ERRS_JS).
             "<div class=rail-act id=rail-errs title='Errors — click to open' aria-label=Errors>"
-            + _BELL_SVG +
+            + _ERRS_SVG +
             "</div>"
             # the refresh glyph is a REAL browser-style reload icon now (the user 2026-07-27: the ↻ text
             # glyph stopped at 11 o'clock and never read as refresh): a near-full circular arc sweeping
@@ -16066,9 +16180,9 @@ def _landing():
             # restart the kernel (the user 2026-07-22): the rail's ↻ is hidden on mobile, so mirror it here.
             # Same glyph as the rail; wired to window.__rompRestart (POST /restart, poll /healthz, reload).
             "<button class=mact data-act=restart aria-label='Restart kernel' title='Restart kernel'>" + _REFRESH_SVG + "</button>"
-            # the notification bell on mobile too (same glyph + badge; opens the same popover)
+            # the error triangle on mobile too (same glyph + in-body count; opens the same popover)
             "<button class=mact id=merr data-act=errs aria-label=Errors title='Errors — click to open'>"
-            + _BELL_SVG +
+            + _ERRS_SVG +
             "</button>"
             # settings wears the desktop rail's OWN gear glyph, ⛭ (U+26ED), not the outlined star it had.
             "<button class=mact data-act=settings aria-label=Settings title=Settings>⛭</button>"
@@ -16930,6 +17044,11 @@ class Handler(BaseHTTPRequestHandler):
             # timeline lane gear → toggle a per-session view flag (e.g. hideFromFeed). Persisted +
             # re-broadcast so the feed drops/restores that session's cards immediately.
             _set_session_flag(str(msg["id"]), str(msg["flag"]), bool(msg.get("value")))
+            _mark_views_dirty()
+        elif msg and msg.get("type") == "cardNotify" and msg.get("itemId"):
+            # feed card right-click → per-card bell (OS notification when THIS card blocks on you /
+            # completes). Persisted to notify-cards.json; build_feed echoes it back as ask.notify.
+            _set_notify_card(str(msg["itemId"]), bool(msg.get("value")))
             _mark_views_dirty()
         elif msg and msg.get("type") == "setSessionColor" and msg.get("id") and msg.get("bg"):
             # tab right-click color picker → override the session's identity color (persisted to the names

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -190,7 +190,7 @@ class ErrorCenterExecutes(unittest.TestCase):
         self.assertTrue(a["open"])
         self.assertEqual(a["rows"], 2)
         self.assertTrue(a["red"], "chat is still down → the live cue stays")
-        self.assertEqual(a["num"], "", "everything read → the bell carries no number")
+        self.assertEqual(a["num"], "!", "everything read → the triangle shows its own '!' glyph again")
         self.assertIn("delivery failed", a["newestFirst"], "newest entry renders first")
 
     def test_rows_lead_with_the_feeds_chip_vocabulary(self):
@@ -256,12 +256,18 @@ class ErrorCenterWiring(unittest.TestCase):
         for pin in ("id=rail-errs", "id=rerr-back", "id=rerr-list", "id=rerr-clear", "id=merr"):
             self.assertIn(pin, html)
         self.assertNotIn("rerr-badge", html)   # the CORNER badge clipped and is gone (the user 2026-07-27);
-        # the count now lives INSIDE the bell body (the user 2026-07-28): an svg <text> the JS drives,
-        # reddening with the bell via fill=currentColor
+        # the count lives INSIDE the glyph (the user 2026-07-28): an svg <text> the JS drives,
+        # reddening with the outline via fill=currentColor
         self.assertIn("<text class='rerr-n'", html)
-        self.assertEqual(html.count("class='rerr-n'"), 2, "rail + mobile, both from the ONE _BELL_SVG")
+        self.assertEqual(html.count("class='rerr-n'"), 2, "rail + mobile, both from the ONE _ERRS_SVG")
         self.assertIn("n>9?'+':String(n)", html)
-        self.assertIn("title='Errors — click to open'", html)   # the bell says what it is
+        # the errors glyph is a warning TRIANGLE since 2026-07-28 — the BELL shape now belongs to the
+        # session/card notification toggles, so the error center must not wear it; when nothing is
+        # unread the JS writes the triangle's own '!' (an empty outline reads as a blank shape)
+        self.assertIn("M8 2.2 L14.6 13.4 L1.4 13.4 Z", html)
+        self.assertIn("n<=0?'!'", html)
+        self.assertNotIn("M8 2 C5.8 2 4.5 3.7", html, "the old bell path left the shell entirely")
+        self.assertIn("title='Errors — click to open'", html)   # the glyph says what it is
         # the panel speaks the shared modal vocabulary (network panel / settings card), never the
         # undefined --vscode-font-family shorthand that rendered oversized in the browser shell
         self.assertIn("font:13px/1.6 system-ui,-apple-system,'Segoe UI',sans-serif}#rerr-panel .rerr-top", html)

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""The notification bells (the user 2026-07-28): a session-level bell (timeline lane / tab menu →
+session-flags "notify") and a per-card bell (feed card right-click → notify-cards.json) arm OS-level
+notifications, fired by the kernel when an armed card ENTERS needs_input (blocked on you) or completed.
+Detection diffs each fresh feed build against the previous one — the exact event the columns move on —
+and the first build after a kernel start is a silent baseline (existing state is status, not news).
+Synthetic ids/names only."""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_nb", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+
+def _card(iid, sid, col, text="Fix the login flow", **kw):
+    d = {"itemId": iid, "sid": sid, "name": "web", "column": col, "text": text}
+    d.update(kw)
+    return d
+
+
+def _feed(*cards):
+    return {"type": "feed", "asks": [dict(c) for c in cards]}
+
+
+class NotifyCardStore(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._notify_cards_cache.clear()
+
+    def tearDown(self):
+        jd.STATE = self.saved
+        self.td.cleanup()
+
+    def test_default_is_empty(self):
+        self.assertEqual(km._notify_cards(), {})
+
+    def test_set_get_then_unset_drops_the_entry(self):
+        km._set_notify_card("TESTSID:g1", True)
+        self.assertEqual(km._notify_cards(), {"TESTSID:g1": True})
+        km._set_notify_card("TESTSID:g1", False)
+        self.assertEqual(km._notify_cards(), {}, "disarming removes the key, not stores False")
+
+    def test_cache_invalidates_on_write(self):
+        self.assertEqual(km._notify_cards(), {})            # primes the (empty) read path
+        km._set_notify_card("TESTSID:g1", True)
+        self.assertTrue(km._notify_cards().get("TESTSID:g1"), "the (mtime_ns,size) cache key sees the write")
+
+    def test_prune_drops_only_ids_that_left_the_feed(self):
+        km._set_notify_card("TESTSID:g1", True)
+        km._set_notify_card("TESTSID:g2", True)
+        km._prune_notify_cards({"TESTSID:g2"})
+        self.assertEqual(km._notify_cards(), {"TESTSID:g2": True})
+        # nothing gone → no write (the file's mtime is the feed-cache sig; a no-op must not churn it)
+        p = jd.STATE / "notify-cards.json"
+        before = p.stat().st_mtime_ns
+        km._prune_notify_cards({"TESTSID:g2"})
+        self.assertEqual(p.stat().st_mtime_ns, before)
+
+
+class FeedNotifications(unittest.TestCase):
+    """The diff detector: [(title, body)] per armed card newly in needs_input/completed."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._notify_cards_cache.clear()
+        km._flags_cache.clear()
+        km._NOTIFY_PREV[0] = None
+
+    def tearDown(self):
+        jd.STATE = self.saved
+        self.td.cleanup()
+
+    def test_the_first_build_is_a_silent_baseline(self):
+        km._set_session_flag("TESTSID", "notify", True)
+        out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
+        self.assertEqual(out, [], "existing state on start is status, not news (freshNeedsYou policy)")
+
+    def test_a_session_armed_card_entering_needs_input_notifies(self):
+        km._set_session_flag("TESTSID", "notify", True)
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working")))
+        out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0][0], "romp: web")
+        self.assertTrue(out[0][1].startswith("Needs you: "), out[0][1])
+        self.assertIn("Fix the login flow", out[0][1])
+
+    def test_an_unarmed_transition_is_silent(self):
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working")))
+        out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
+        self.assertEqual(out, [], "no bell armed → no notification, however the card moves")
+
+    def test_a_card_armed_card_completing_notifies(self):
+        km._set_notify_card("TESTSID:g1", True)
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working")))
+        out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "completed")))
+        self.assertEqual(len(out), 1)
+        self.assertTrue(out[0][1].startswith("Completed: "), out[0][1])
+
+    def test_holding_a_column_does_not_refire(self):
+        km._set_session_flag("TESTSID", "notify", True)
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working")))
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
+        out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
+        self.assertEqual(out, [], "still blocked is not news — only the ENTRY event notifies")
+
+    def test_reblocking_after_an_answer_notifies_again(self):
+        km._set_session_flag("TESTSID", "notify", True)
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working")))
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working")))     # answered
+        out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
+        self.assertEqual(len(out), 1, "a NEW block after the answer is a new event")
+
+    def test_a_card_appearing_already_blocked_notifies(self):
+        km._set_session_flag("TESTSID", "notify", True)
+        km._feed_notifications(_feed())                     # baseline consumed on an empty feed
+        out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
+        self.assertEqual(len(out), 1, "work can SURFACE blocked — appearing there is entering there")
+
+    def test_a_provisional_placeholder_never_notifies(self):
+        km._set_session_flag("TESTSID", "notify", True)
+        km._feed_notifications(_feed())
+        out = km._feed_notifications(
+            _feed(_card("TESTSID:g1", "TESTSID", "needs_input", provisional=True)))
+        self.assertEqual(out, [], "placeholder churn is not a stable card")
+
+    def test_an_armed_card_leaving_the_feed_is_pruned(self):
+        km._set_notify_card("TESTSID:g1", True)
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working")))
+        km._feed_notifications(_feed())                     # cleared/archived → id never comes back
+        self.assertEqual(km._notify_cards(), {}, "the store tracks the live feed, not history")
+
+
+class SystemNotify(unittest.TestCase):
+    def test_darwin_shells_out_to_osascript_with_escaped_strings(self):
+        calls = []
+        saved_popen, saved_platform = km.subprocess.Popen, sys.platform
+        km.subprocess.Popen = lambda cmd, **kw: calls.append(cmd)
+        sys.platform = "darwin"
+        try:
+            km._system_notify('romp: web', 'Needs you: fix the "login" flow')
+        finally:
+            km.subprocess.Popen = saved_popen
+            sys.platform = saved_platform
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "osascript")
+        self.assertEqual(calls[0][1], "-e")
+        self.assertIn('with title "romp: web"', calls[0][2])
+        self.assertIn('\\"login\\"', calls[0][2], "quotes are escaped into the AppleScript string")
+
+    def test_a_missing_binary_never_raises(self):
+        saved = km.subprocess.Popen
+
+        def boom(cmd, **kw):
+            raise OSError("no such binary")
+        km.subprocess.Popen = boom
+        try:
+            km._system_notify("t", "b")                    # must not raise — best-effort by contract
+        finally:
+            km.subprocess.Popen = saved
+
+
+class NotifyWiring(unittest.TestCase):
+    """Source pins: the flag reaches every payload + the detector rides fresh feed builds."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = Path(os.path.join(BIN, "romp-kernel")).resolve().read_text()
+
+    def test_the_session_flag_rides_both_session_payloads(self):
+        # the timeline lane row AND the chat session payload both echo the flag (lane bell + tab menu)
+        self.assertEqual(self.src.count('"notify": _session_flag(sid, "notify")'), 2)
+
+    def test_every_ask_carries_its_card_arming(self):
+        self.assertIn('_a["notify"] = True if _ncards.get(_a["itemId"]) else None', self.src)
+
+    def test_the_ws_handler_persists_the_card_toggle(self):
+        self.assertIn('msg.get("type") == "cardNotify"', self.src)
+        self.assertIn('_set_notify_card(str(msg["itemId"]), bool(msg.get("value")))', self.src)
+
+    def test_the_store_mtime_busts_the_feed_cache(self):
+        self.assertIn('(jd.STATE / "notify-cards.json", "__ncards__")', self.src,
+                      "arming a card must reach the next build, not wait out the sig")
+
+    def test_fresh_feed_builds_drive_the_notifier(self):
+        # the detector runs where the fresh build lands — the one choke point every push shares
+        self.assertIn("for _t, _b in _feed_notifications(feed):", self.src)
+        self.assertIn("_system_notify(_t, _b)", self.src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -371,6 +371,21 @@ function mailboxIcon(off, cx, cy, color) {
   if (off) g.appendChild(el('line', { x1: cx - 6.5, y1: cy + 4.5, x2: cx + 6.5, y2: cy - 4.5, stroke: color, 'stroke-width': 1.4, 'stroke-linecap': 'round' }));
   return g;
 }
+// Per-lane NOTIFICATION toggle (the user 2026-07-28): a monochrome BELL just right of the mailbox. ON =
+// the kernel fires an OS notification when this session's work blocks on you or completes (session-flags
+// "notify", read by the kernel's feed-diff notifier); OFF (default) = the same bell struck through + more
+// faded. Same drawn-not-emoji idiom + slash convention as the checkbox/mailbox. (The error center's rail
+// icon stopped being a bell the same day, so the bell shape now means exactly this.)
+function bellIcon(off, cx, cy, color) {
+  const g = el('g', { 'pointer-events': 'none' });
+  const st = { fill: 'none', stroke: color, 'stroke-width': 1.2, 'stroke-linejoin': 'round', 'stroke-linecap': 'round' };
+  // the dome + skirt, one closed path (side profile, flared mouth)
+  g.appendChild(el('path', Object.assign({ d: 'M' + cx + ' ' + (cy - 4.6) + 'C' + (cx - 2.4) + ' ' + (cy - 4.4) + ' ' + (cx - 3.2) + ' ' + (cy - 2.6) + ' ' + (cx - 3.2) + ' ' + (cy - 0.8) + 'L' + (cx - 3.2) + ' ' + (cy + 1) + 'L' + (cx - 4.4) + ' ' + (cy + 2.8) + 'L' + (cx + 4.4) + ' ' + (cy + 2.8) + 'L' + (cx + 3.2) + ' ' + (cy + 1) + 'L' + (cx + 3.2) + ' ' + (cy - 0.8) + 'C' + (cx + 3.2) + ' ' + (cy - 2.6) + ' ' + (cx + 2.4) + ' ' + (cy - 4.4) + ' ' + cx + ' ' + (cy - 4.6) + 'Z' }, st)));
+  // the clapper: a small arc under the mouth
+  g.appendChild(el('path', Object.assign({ d: 'M' + (cx - 1.3) + ' ' + (cy + 4.2) + 'A 1.3 1.3 0 0 0 ' + (cx + 1.3) + ' ' + (cy + 4.2) }, st)));
+  if (off) g.appendChild(el('line', { x1: cx - 6.5, y1: cy + 4.5, x2: cx + 6.5, y2: cy - 4.5, stroke: color, 'stroke-width': 1.4, 'stroke-linecap': 'round' }));
+  return g;
+}
 // Model + effort choices come from the kernel's /models — the ONE list shared with the chat statusline picker
 // and the judge-tier settings (the user 2026-07-02: no hardcoded model list per surface). Populated in place
 // on load so _openMetaMenu keeps its reference; the lane picker appends its own 'Default' sentinel (not a model).
@@ -2293,9 +2308,10 @@ class TimelinePanel {
     // 2026-06-19). Reserve its width only when there IS a live lane, so an all-historical view keeps the
     // tight [name][model] layout.
     const EYE_W = 13, EYE_GAP = 6, anyLive = vis.some((s) => s.live);
-    const eyeColX = PADL + Math.ceil(maxName) + COLGAP;                              // [name] [✓feed] [📫postal] [model+effort] [chip] [ctx]
+    const eyeColX = PADL + Math.ceil(maxName) + COLGAP;                              // [name] [✓feed] [📫postal] [bell] [model+effort] [chip] [ctx]
     const mailColX = eyeColX + (anyLive ? EYE_W + EYE_GAP : 0);                      // postal-isolation mailbox, just right of the feed checkbox
-    const modelColX = mailColX + (anyLive ? EYE_W + EYE_GAP : 0);
+    const bellColX = mailColX + (anyLive ? EYE_W + EYE_GAP : 0);                     // notification bell, just right of the mailbox (the user 2026-07-28)
+    const modelColX = bellColX + (anyLive ? EYE_W + EYE_GAP : 0);
     const effortColX = modelColX + Math.ceil(maxModelPiece) + effortGap;   // fixed left edge for EVERY lane's effort word
     const chipColX = modelColX + (maxModel > 0 ? Math.ceil(maxModel) + COLGAP : 0);
     const ctxColX = chipColX + (maxChip > 0 ? Math.ceil(maxChip) + COLGAP : 0);
@@ -2683,6 +2699,38 @@ class TimelinePanel {
           s.postalServiceOff = next;                            // optimistic …
           (this._pendingFlags[s.id] = this._pendingFlags[s.id] || {}).postalServiceOff = next;   // … held sticky until the kernel confirms
           this._setSessionFlag(s, 'postalServiceOff', next);
+          this.hideTip();
+          this._reconcilePendingFlags();   // apply onto the CURRENT objects draw() reads — a poll may have swapped
+          this.draw();                     // this.data mid-press, leaving `s` stale (see the feed checkbox above)
+        });
+      }
+      // per-session NOTIFICATION toggle (live lanes only, the user 2026-07-28): a bell just right of the
+      // mailbox. ON (romp blue) = the kernel fires an OS notification when this session's work blocks on
+      // you or completes; OFF (default: slashed + faded gray) = quiet. NOTE the inverted polarity vs the
+      // other two toggles: `notify` true is the ENABLED state, so off = !s.notify. Same draw/hit/tooltip/
+      // pointerdown pattern as the checkbox + mailbox; the kernel's feed-diff notifier enforces it.
+      if (s.live) {
+        const boff = !s.notify;
+        const bcx = bellColX + 5, bcy = y + 0.5;
+        const bdim = boff ? '0.3' : '0.9';             // off = faded; on = a confident romp-blue
+        const bbox = bellIcon(boff, bcx, bcy, boff ? MODEL_FG : ROMP_BLUE);   // ON = romp blue, OFF = struck-out gray
+        bbox.setAttribute('opacity', bdim);
+        svg.appendChild(bbox);
+        const bhit = el('rect', { x: bellColX - 4, y: y - 9, width: EYE_W + 8, height: 18, fill: 'transparent', 'pointer-events': 'all' });
+        bhit.style.cursor = 'pointer';
+        bhit.setAttribute('aria-label', boff ? 'notifications off for this session' : 'notifications on for this session'); svg.appendChild(bhit);
+        const btip = boff
+          ? "Notifications off — click to turn on<div style='opacity:.65;margin-top:2px'>get a system notification when its work blocks on you or completes</div>"
+          : "Notifications on — click to turn off<div style='opacity:.65;margin-top:2px'>notifies when its work blocks on you or completes</div>";
+        bhit.addEventListener('mouseenter', (e) => { bbox.setAttribute('opacity', '1'); this.showTip(btip, e); });
+        bhit.addEventListener('mousemove', (e) => this.moveTip(e));
+        bhit.addEventListener('mouseleave', () => { bbox.setAttribute('opacity', bdim); this.hideTip(); });
+        bhit.addEventListener('pointerdown', (e) => {   // pointerdown, not click: a redraw between mousedown
+          e.stopPropagation();                          // and mouseup ate the click → "sometimes unresponsive"
+          const next = !s.notify;
+          s.notify = next;                              // optimistic …
+          (this._pendingFlags[s.id] = this._pendingFlags[s.id] || {}).notify = next;   // … held sticky until the kernel confirms
+          this._setSessionFlag(s, 'notify', next);
           this.hideTip();
           this._reconcilePendingFlags();   // apply onto the CURRENT objects draw() reads — a poll may have swapped
           this.draw();                     // this.data mid-press, leaving `s` stale (see the feed checkbox above)

--- a/ui/timeline-flags.test.ts
+++ b/ui/timeline-flags.test.ts
@@ -14,9 +14,10 @@ const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeli
 test("a per-session feed-checkbox column sits BETWEEN the name and the model (live lanes only)", () => {
   assert.match(SRC, /const eyeColX = PADL \+ Math\.ceil\(maxName\) \+ COLGAP;/);
   // business inserted a postal-isolation mailColX between the feed checkbox and the model (main 56ae453),
-  // so the model column now hangs off mailColX, not eyeColX directly.
+  // and the notification bellColX joined right of the mailbox (the user 2026-07-28) — the model column
+  // hangs off bellColX now.
   assert.match(SRC, /const mailColX = eyeColX \+ \(anyLive \? EYE_W \+ EYE_GAP : 0\);/);
-  assert.match(SRC, /const modelColX = mailColX \+ \(anyLive \? EYE_W \+ EYE_GAP : 0\);/);
+  assert.match(SRC, /const modelColX = bellColX \+ \(anyLive \? EYE_W \+ EYE_GAP : 0\);/);
   assert.match(SRC, /if \(s\.live\) \{[\s\S]*?feedCheckIcon\(off, cx, cy, off \? MODEL_FG : ROMP_BLUE\)/);
 });
 
@@ -58,6 +59,23 @@ test("the toggle RECONCILES the optimistic flip onto the live objects before dra
   // immediately before draw(), so the flip always shows AND the kernel still receives it.
   assert.match(SRC, /'hideFromFeed', next\);[\s\S]*?this\._reconcilePendingFlags\(\);[^\n]*\n\s*this\.draw\(\);/);
   assert.match(SRC, /'postalServiceOff', next\);[\s\S]*?this\._reconcilePendingFlags\(\);[^\n]*\n\s*this\.draw\(\);/);
+});
+
+test("the lane bell toggles the session-level `notify` flag — inverted polarity, same pattern (the user 2026-07-28)", () => {
+  // a bell column sits between the mailbox and the model, live lanes only
+  assert.match(SRC, /const bellColX = mailColX \+ \(anyLive \? EYE_W \+ EYE_GAP : 0\);/);
+  assert.match(SRC, /const modelColX = bellColX \+ \(anyLive \? EYE_W \+ EYE_GAP : 0\);/);
+  // drawn (not an emoji): dome+skirt path + clapper arc, same slash convention as the other toggles
+  assert.match(SRC, /function bellIcon\(off, cx, cy, color\)/);
+  // `notify` true is the ENABLED state (the other two flags are off-flags), so off = !s.notify
+  assert.match(SRC, /const boff = !s\.notify;/);
+  assert.match(SRC, /const bbox = bellIcon\(boff, bcx, bcy, boff \? MODEL_FG : ROMP_BLUE\);/);
+  // pointerdown + optimistic + sticky + reconcile-before-draw, exactly like the checkbox/mailbox
+  assert.match(SRC, /\(this\._pendingFlags\[s\.id\] = this\._pendingFlags\[s\.id\] \|\| \{\}\)\.notify = next;/);
+  assert.match(SRC, /'notify', next\);[\s\S]*?this\._reconcilePendingFlags\(\);[^\n]*\n\s*this\.draw\(\);/);
+  // the tooltip says what arming does (the kernel's feed-diff notifier fires the OS notification)
+  assert.match(SRC, /Notifications off — click to turn on/);
+  assert.match(SRC, /Notifications on — click to turn off/);
 });
 
 test("the tooltip uses the shared showTip/hideTip (a native SVG <title> never shows — a redraw kills it)", () => {

--- a/ui/webview/card-notify.test.ts
+++ b/ui/webview/card-notify.test.ts
@@ -1,0 +1,56 @@
+// The per-card notification bell (the user 2026-07-28): right-click a feed card → a one-item context
+// menu whose "Notify me" arms an OS notification for when THIS card enters needs_input or completed
+// (kernel notify-cards.json; the session-wide bell rides session-flags "notify" on the lane/tab menu).
+// Source pins against feed.ts + feed.css (the render path has no jsdom harness), like badge-mirror's.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+test("right-click opens the card menu; a provisional placeholder (no stable identity) gets none", () => {
+  assert.match(SRC, /card\.addEventListener\("contextmenu", \(ev\) => \{\s*\n\s*if \(it\.provisional\) return;/);
+  assert.match(SRC, /ev\.preventDefault\(\); ev\.stopPropagation\(\);\s*\n\s*showCardMenu\(ev, card\);/);
+});
+
+test("the menu reads the FRESHEST payload copy off the card, never the make-time closure", () => {
+  // updateAskCard restashes a._it every push; the closure's `it` goes stale after the first one
+  assert.match(SRC, /a\._it = it;/);
+  assert.match(SRC, /const it = \(card as any\)\._it as AskItem \| undefined;/);
+});
+
+test("the toggle posts cardNotify with the card's id + owning session", () => {
+  assert.match(SRC, /vscodeApi\?\.postMessage\(\{ type: "cardNotify", itemId: it\.itemId, sid: it\.sid, value: !on \}\)/);
+  assert.match(SRC, /notify\?: boolean \| null;/);   // the kernel echoes the armed state back on the ask
+});
+
+test("optimism is sticky until the kernel confirms — the lane toggles' pattern, not a timer", () => {
+  assert.match(SRC, /const pendingNotify = new Map<string, boolean>\(\);/);
+  assert.match(SRC, /pendingNotify\.set\(it\.itemId, !on\);/);
+  // retired the moment the payload agrees (event-based), then whichever value stands renders
+  assert.match(SRC, /if \(pendingNotify\.has\(it\.itemId\) && !!it\.notify === pendingNotify\.get\(it\.itemId\)\) pendingNotify\.delete\(it\.itemId\);/);
+});
+
+test("the click acknowledges instantly: the armed bell shows before the kernel round-trip", () => {
+  assert.match(SRC, /if \(bell\) bell\.style\.display = !on \? "" : "none";\s*\/\/ acknowledge instantly/);
+});
+
+test("an armed card wears a quiet accent bell beside Clear; labels are state-dependent", () => {
+  assert.match(SRC, /const bellOnBadge = el\("span", "fask-bellon"\);/);
+  assert.match(SRC, /waitOnBadge, bellOnBadge, clr\);/);
+  assert.match(SRC, /on \? "Stop notifying" : "Notify me"/);
+  assert.match(SRC, /system notification when this card blocks on you or completes/);
+  // accent = mechanics chrome (CLAUDE.md: never a status colour)
+  assert.match(CSS, /\.fask-bellon \{ flex: 0 0 auto; display: flex; align-items: center; color: var\(--accent\)/);
+});
+
+test("the menu wears the tab menu's chrome (feed.css has its own copy — the feed page loads only feed.css)", () => {
+  assert.match(CSS, /\.ctx-menu \{\s*\n\s*position: fixed; z-index: 100;/);
+  assert.match(CSS, /\.ctx-item-toggle \.ctx-icon\.off \{ color: var\(--dim\); \}/);
+  // the standard dismissers: outside mousedown (capture), Escape, scroll, blur
+  assert.match(SRC, /if \(cardMenuEl && !cardMenuEl\.contains\(e\.target as Node\)\) dismissCardMenu\(\)/);
+  assert.match(SRC, /if \(e\.key === "Escape"\) dismissCardMenu\(\)/);
+  assert.match(SRC, /window\.addEventListener\("scroll", dismissCardMenu, true\);/);
+});

--- a/ui/webview/done-confirming.test.ts
+++ b/ui/webview/done-confirming.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const dcBadge = el\("span", "fask-doneconfirming"\)/);
   assert.match(FEED, /dcBadge\.textContent = "done, confirming"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
   assert.match(FEED, /a\._doneConfirming = dcBadge;/);
 });
 

--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -18,7 +18,7 @@ test("COMPACTNESS (the user 2026-07-07): time trails the title; Clear on the nam
   assert.match(FEED, /row3\.append\(bgBtn, takeBtn, stallBtn, subBtn, taskBtn, actions\)/, "ask card: row3 is Background/Summary/Stalled/Sub-goals/Waiting-on-task (+ rare Retry/Revive)");
   assert.match(FEED, /actions\.append\(apiRetry, revive,/, "…so the action row is Retry/Revive (+ resume-gate) only (Clear + toggles moved up)");
   // Clear is the rightmost control on the NAME row now (both ask + group cards)
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "ask card: Clear on the name row");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/, "ask card: Clear on the name row");
   // its tooltip is plain-spoken (the user 2026-07-13): "clear this task", not the inbox-zero jargon
   assert.match(FEED, /clr\.title = "clear this task";/);
   assert.match(FEED, /row2\.append\(idwrap, clr\)/, "group card: Clear on the name row");
@@ -57,7 +57,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
   assert.match(FEED, /const origin = el\("a", "fask-origin"\); origin\.style\.display = "none"/);
   // it's a direct child of the wrapping row2 (NOT nested in idwrap) so a narrow card wraps it under the
   // name instead of overlapping the chips (the user 2026-06-20)
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "the origin marker rides the name row beside the chips");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/, "the origin marker rides the name row beside the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested inside idwrap");
   // populated from it.origin in the update path: a dim gray "↪ from" + the peer in the bold session-name
   // style (its own identity colour); click opens the sender (the user 2026-06-16)
@@ -74,7 +74,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
 test("the follow-up badge serves ONLY '↩ re-judging' now — the '↻ Followed up' chip was removed (the user 2026-07-01)", () => {
   assert.match(FEED, /el\("span", "fask-followedup"\); fupBadge\.textContent = "↩ re-judging"/);
   // the badge rides the SESSION-NAME row (right-justified), NOT the bottom action row
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
   // the CARD badge block is now recheck-only: recheck → "↩ re-judging", else hidden. No followupPending branch.
   // (The modal tree's per-node "↻ Followed up" chip, ftree-followedup, is a separate thing and stays.)
   assert.match(FEED, /if \(it\.recheck\) \{\s*\n\s*a\._followedup\.style\.display = "";\s*\n\s*a\._followedup\.textContent = "↩ re-judging";[\s\S]*?\} else \{\s*\n\s*a\._followedup\.style\.display = "none";\s*\n\s*\}/);

--- a/ui/webview/feed-delegation.test.ts
+++ b/ui/webview/feed-delegation.test.ts
@@ -45,7 +45,7 @@ test("a narrow card WRAPS the '↪ from' provenance under the name instead of ov
   // chip. Fix: row2 wraps, and origin is a direct row2 child (sibling of the chips) so it drops to a
   // second line rather than overlapping when name + provenance + chips don't all fit.
   assert.match(CSS, /\.fask-row2 \{[^}]*flex-wrap: wrap/, "the name row wraps so trailing items never overlap");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "origin is a row2 sibling of the chips");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/, "origin is a row2 sibling of the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested in the shrinking idwrap");
   // the old overflow mechanism is gone — flex-grow on idwrap right-aligns it instead of an auto margin
   assert.doesNotMatch(CSS, /\.fask-origin \{[^}]*margin-left: auto/);

--- a/ui/webview/feed-interrupted.test.ts
+++ b/ui/webview/feed-interrupted.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the interrupted badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const intBadge = el\("span", "fask-interrupted"\)/);
   assert.match(FEED, /intBadge\.textContent = "interrupted"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
   assert.match(FEED, /a\._interrupted = intBadge;/);
 });
 

--- a/ui/webview/feed-interrupting.test.ts
+++ b/ui/webview/feed-interrupting.test.ts
@@ -15,7 +15,7 @@ test("the interrupting badge is built once and rides the wrapping chip row", () 
   assert.match(FEED, /const intingBadge = el\("span", "fask-interrupting"\)/);
   assert.match(FEED, /intingBadge\.textContent = "interrupting…"/, "text label, no emoji/glyph");
   // sits immediately left of the past-tense interrupted badge on the same wrapping row
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
   assert.match(FEED, /a\._interrupting = intingBadge;/);
 });
 

--- a/ui/webview/feed-nudge-failed.test.ts
+++ b/ui/webview/feed-nudge-failed.test.ts
@@ -16,7 +16,7 @@ test("the follow-up-failed chip is built once and rides the wrapping chip row", 
   assert.match(FEED, /const nfBadge = el\("span", "fask-nudgefailed"\)/);
   assert.match(FEED, /nfBadge\.textContent = "follow-up failed"/,
     "the label is 'follow-up failed' (the user 2026-07-23) — 'stalled' is the yellow section's word; no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
   assert.match(FEED, /a\._nudgeFailed = nfBadge;/);
 });
 

--- a/ui/webview/feed-waiton.test.ts
+++ b/ui/webview/feed-waiton.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("a waiting-on chip is built and rides the wrapping chip row (its own line when it doesn't fit)", () => {
   assert.match(FEED, /const waitOnBadge = el\("span", "fask-waiton"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
   assert.match(FEED, /a\._waitOn = waitOnBadge;/);
 });
 

--- a/ui/webview/feed-warn-chip.test.ts
+++ b/ui/webview/feed-warn-chip.test.ts
@@ -15,7 +15,7 @@ test("the warning chip is a button built once, riding the wrapping chip row", ()
   assert.match(FEED, /const warnChip = el\("button", "fask-warnchip"\)/,
     "a BUTTON (focusable), not a span — it has a click action");
   assert.match(FEED, /warnChip\.textContent = "warning"/, "plain text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
   assert.match(FEED, /a\._warnChip = warnChip;/);
 });
 

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1017,3 +1017,28 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   55% { box-shadow: none; }
   70%, 85% { box-shadow: 0 0 0 2px var(--accent), 0 0 16px rgba(156, 210, 255, 0.5); }
 }
+
+/* ── per-card notification bell (the user 2026-07-28) ─────────────────────────────────────────────
+   Right-click a card → a one-item context menu (the chat tab menu's chrome, mirrored here because the
+   feed page loads only feed.css). "Notify me" arms an OS notification for when THIS card blocks on
+   you or completes; the armed state is the quiet accent bell beside Clear. */
+.ctx-menu {
+  position: fixed; z-index: 100; min-width: 110px; padding: 4px;
+  background: var(--vscode-menu-background, #252526);
+  color: var(--vscode-menu-foreground, var(--fg));
+  border: 1px solid var(--box-border); border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  font-size: 0.92em;
+}
+.ctx-item { padding: 4px 10px; border-radius: 4px; cursor: pointer; white-space: nowrap; }
+.ctx-item:hover {
+  background: var(--vscode-menu-selectionBackground, rgba(255, 255, 255, 0.1));
+  color: var(--vscode-menu-selectionForeground, var(--fg));
+}
+.ctx-item-toggle { display: flex; align-items: flex-start; gap: 8px; }
+.ctx-item-toggle .ctx-icon { flex: 0 0 auto; margin-top: 1px; color: var(--accent); display: flex; }
+.ctx-item-toggle .ctx-icon.off { color: var(--dim); }
+.ctx-item-body { display: flex; flex-direction: column; line-height: 1.25; }
+.ctx-item-sub { font-size: 0.82em; opacity: 0.6; }
+/* the armed marker on the card: mechanics chrome (accent), deliberately not a status colour */
+.fask-bellon { flex: 0 0 auto; display: flex; align-items: center; color: var(--accent); opacity: 0.75; }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -98,6 +98,7 @@ interface AskItem {
   groupN?: number;                                 // host: sibling count for that turn (>1 ⇒ fold into one group card)
   provisional?: boolean;                           // a LIVE-PROMPT placeholder (kernel _provisional_card): the session is working an in-progress turn the planner hasn't classified yet. No goal node (empty tree) — dim, non-interactive, no clear/nudge/modal; replaced by the real card once the planner places the segment.
   judging?: boolean;                               // the turn has SETTLED and the judge's pass is due/in flight → the swirl chip says Analyzing… — on a provisional card while the planner's classify is pending (the user 2026-07-12), and on a REAL working card while the closer's verdict is (the settle→verdict gap, the user 2026-07-13); an open turn stays the honest Working…
+  notify?: boolean | null;                         // per-card bell (the user 2026-07-28): the kernel fires an OS notification when THIS card enters needs_input/completed (kernel notify-cards.json ← the card's right-click menu). True/absent, never false
   tree: AskTreeNode[];                             // the ask's DAG, rendered as a tree in the expanded body
 }
 // A GROUP = N sibling asks minted by ONE typed turn (shared turnId), folded into a
@@ -529,6 +530,66 @@ function ensureHeader() {
 // Click the CARD → expand + light the DAG path on the timeline.
 // Expanded body = the request DAG as a tree of NODES (state machine only); each
 // node clicks to reveal its OWN reply history; ? nodes carry a decision sub-card.
+// ── per-card notification bell (the user 2026-07-28) ─────────────────────────────────────────────
+// Right-click a card → a small context menu (the tab menu's chrome) with one toggle: "Notify me" arms
+// an OS notification for when THIS card blocks on you or completes (kernel notify-cards.json; the
+// session-wide version lives on the timeline lane / tab menu). The armed state shows as a quiet bell
+// beside Clear. Optimism mirrors the lane toggles: pendingNotify holds the clicked value sticky across
+// pushes until the kernel's payload agrees, so the bell never flickers back while the rebuild lands.
+const pendingNotify = new Map<string, boolean>();   // itemId -> clicked value, until the payload confirms
+let cardMenuEl: HTMLElement | null = null;
+
+function dismissCardMenu(): void { if (cardMenuEl) { cardMenuEl.remove(); cardMenuEl = null; } }
+window.addEventListener("mousedown", (e) => { if (cardMenuEl && !cardMenuEl.contains(e.target as Node)) dismissCardMenu(); }, true);
+window.addEventListener("keydown", (e) => { if (e.key === "Escape") dismissCardMenu(); }, true);
+window.addEventListener("scroll", dismissCardMenu, true);
+window.addEventListener("blur", () => dismissCardMenu());
+
+// the same drawn bell as the chat tab menu's toggle icon (16-unit viewBox, currentColor, slash = off)
+function cardBellSvg(off: boolean): string {
+  const slash = off ? '<line x1="1.6" y1="14.4" x2="14.4" y2="1.6"/>' : "";
+  return '<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" '
+    + 'stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">'
+    + '<path d="M8 2 C5.9 2.2 4.7 3.8 4.7 5.8 L4.7 8 L3.4 9.9 L12.6 9.9 L11.3 8 L11.3 5.8 C11.3 3.8 10.1 2.2 8 2 Z"/>'
+    + '<path d="M6.6 11.6 A1.5 1.5 0 0 0 9.4 11.6"/>' + slash + "</svg>";
+}
+
+function cardNotifyOn(it: AskItem): boolean {
+  return pendingNotify.has(it.itemId) ? !!pendingNotify.get(it.itemId) : !!it.notify;
+}
+
+function showCardMenu(e: MouseEvent, card: HTMLElement): void {
+  dismissCardMenu();
+  const it = (card as any)._it as AskItem | undefined;   // the freshest payload copy (updateAskCard stashes it)
+  if (!it) return;
+  const on = cardNotifyOn(it);
+  const menu = el("div", "ctx-menu");
+  const item = el("div", "ctx-item ctx-item-toggle");
+  const icon = el("span", "ctx-icon" + (on ? "" : " off"));
+  icon.innerHTML = cardBellSvg(!on);
+  const body = el("span", "ctx-item-body");
+  const lab = el("span", "ctx-item-label"); lab.textContent = on ? "Stop notifying" : "Notify me";
+  const sub = el("span", "ctx-item-sub");
+  sub.textContent = on ? "no more system notifications for this card"
+    : "system notification when this card blocks on you or completes";
+  body.append(lab, sub);
+  item.append(icon, body);
+  item.addEventListener("click", (ev) => {
+    ev.stopPropagation();
+    dismissCardMenu();
+    pendingNotify.set(it.itemId, !on);               // sticky until the kernel's payload carries it
+    const bell = (card as any)._bell as HTMLElement | undefined;
+    if (bell) bell.style.display = !on ? "" : "none";   // acknowledge instantly, before the round-trip
+    vscodeApi?.postMessage({ type: "cardNotify", itemId: it.itemId, sid: it.sid, value: !on });
+  });
+  menu.appendChild(item);
+  document.body.appendChild(menu);
+  cardMenuEl = menu;
+  const r = menu.getBoundingClientRect();   // at the cursor, clamped inside the pane
+  menu.style.left = Math.max(0, Math.min(e.clientX, window.innerWidth - r.width - 4)) + "px";
+  menu.style.top = Math.max(0, Math.min(e.clientY, window.innerHeight - r.height - 4)) + "px";
+}
+
 function makeAskCard(it: AskItem): HTMLElement {
   const card = el("div", "fitem ask");
   card.dataset.key = "a:" + it.itemId;
@@ -647,7 +708,14 @@ function makeAskCard(it: AskItem): HTMLElement {
   // row2 wraps them onto a new line when there isn't room, so the provenance never overlaps a chip
   // (the user 2026-06-20). origin sits left of the chips, matching the "from … · Followed up" reading order.
   // Clear is the rightmost, always-present control on this row (idwrap flex:1 pushes it to the edge).
-  row2.append(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr);
+  // armed per-card bell (the user 2026-07-28): a quiet accent bell just left of Clear while this card's
+  // right-click "Notify me" is on — mechanics marker, not a status (session-level arming shows on the
+  // lane/tab instead, so an armed SESSION doesn't stamp every card).
+  const bellOnBadge = el("span", "fask-bellon");
+  bellOnBadge.title = "system notifications on for this card — right-click to change";
+  bellOnBadge.innerHTML = cardBellSvg(false);
+  bellOnBadge.style.display = "none";
+  row2.append(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr);
   // ROW 3 — Background (left) · Summary (right), always one line, opposite sides. Populated below, once the
   // toggle buttons exist (they're declared with the distiller sections). The time now trails the title (row1).
   const row3 = el("div", "fask-row3");
@@ -812,8 +880,17 @@ function makeAskCard(it: AskItem): HTMLElement {
     else if (!pinnedAskId && hoverAskId !== it.itemId) vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, off: true });
   });
 
+  // right-click → the per-card bell menu (the user 2026-07-28). Reads the FRESH item off the card
+  // (a._it, restashed every updateAskCard) — the closure's `it` goes stale after the first push.
+  card.addEventListener("contextmenu", (ev) => {
+    if (it.provisional) return;                    // a placeholder has no stable identity to arm
+    ev.preventDefault(); ev.stopPropagation();
+    showCardMenu(ev, card);
+  });
+
   const a = card as any;
   a._title = title; a._name = name; a._time = time; a._followedup = fupBadge;
+  a._bell = bellOnBadge;
   a._row1 = row1; a._row2 = row2;   // grouped mode re-homes Clear between these (the user 2026-07-13)
   a._doneConfirming = dcBadge;
   a._nudgeFailed = nfBadge;
@@ -1092,6 +1169,11 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
 
 function updateAskCard(card: HTMLElement, it: AskItem) {
   const a = card as any;
+  a._it = it;   // the freshest payload copy — the right-click bell menu reads this, never a stale closure
+  // per-card bell: retire the optimistic value once the kernel's payload agrees (event-based, no timer),
+  // then render whichever stands. Same sticky-optimism shape as the timeline lane's _pendingFlags.
+  if (pendingNotify.has(it.itemId) && !!it.notify === pendingNotify.get(it.itemId)) pendingNotify.delete(it.itemId);
+  if (a._bell) (a._bell as HTMLElement).style.display = cardNotifyOn(it) ? "" : "none";
   card.className = "fitem ask" + (it.live ? " live" : " dead") + (it.itemId === (hoverAskId ?? pinnedAskId) ? " focused" : "") + (it.itemId === pinnedAskId ? " pinned" : "") + (it.provisional ? " provisional" : "");
   // PROVISIONAL placeholder: a dim, italic, non-interactive card from the live prompt while the planner
   // hasn't classified the in-progress turn yet. No Clear/Nudge (nothing to curate), no auto-line, no tree.

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -192,7 +192,7 @@ interface BgTasks { count: number; tasks: BgTask[]; }
 // kernel ships only the last WIRE_TAIL events (headFrom > 0) to keep startup light; older history streams in
 // on scroll-back (loadOlder → chatHead prepends, lowering headFrom). headFrom 0 = the whole transcript is
 // resident. chatTail's `from` is GLOBAL and mapped through headFrom.
-interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; headFrom?: number; headTotal?: number; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; }
+interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; headFrom?: number; headTotal?: number; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; notify?: boolean; }
 
 const vscodeApi =
   typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
@@ -3445,7 +3445,7 @@ function copyToClipboard(text: string) {
 // Toggle a per-session view flag (feed mute / postal isolation) — the SAME message the timeline lane toggles
 // send, persisted + re-broadcast by the kernel. Optimistically update the local copy so reopening the menu
 // reflects it before the next push (the kernel reconciles).
-function setSessionFlag(id: string, flag: "hideFromFeed" | "postalServiceOff", value: boolean) {
+function setSessionFlag(id: string, flag: "hideFromFeed" | "postalServiceOff" | "notify", value: boolean) {
   const s = sessions.get(id);
   if (s) s[flag] = value;   // both flags are declared optional booleans on Session — no cast needed
   if (vscodeApi) vscodeApi.postMessage({ type: "setSessionFlag", id, flag, value });
@@ -3466,12 +3466,14 @@ function setSessionColor(id: string, bg: string) {
 
 // Small inline-SVG icon for the tab menu's toggle items (trusted constant markup; `off` slashes + dims it,
 // matching the timeline lane toggles). 16-unit viewBox; currentColor so .ctx-icon/.off set the tint.
-function ctxIcon(kind: "feed" | "mail", off: boolean): HTMLElement {
+function ctxIcon(kind: "feed" | "mail" | "bell", off: boolean): HTMLElement {
   const span = el("span", "ctx-icon" + (off ? " off" : ""));
   const slash = off ? '<line x1="1.6" y1="14.4" x2="14.4" y2="1.6"/>' : "";
   const body = kind === "feed"
     ? '<circle cx="8" cy="8" r="6"/><path d="M5 8.3 L7.2 10.7 L11.4 5.3"/>'              // circle + check (on the feed)
-    : '<rect x="2" y="4" width="12" height="8" rx="1.5"/><path d="M2.5 5 L8 9 L13.5 5"/>';  // envelope (on the postal service)
+    : kind === "mail"
+      ? '<rect x="2" y="4" width="12" height="8" rx="1.5"/><path d="M2.5 5 L8 9 L13.5 5"/>'  // envelope (on the postal service)
+      : '<path d="M8 2 C5.9 2.2 4.7 3.8 4.7 5.8 L4.7 8 L3.4 9.9 L12.6 9.9 L11.3 8 L11.3 5.8 C11.3 3.8 10.1 2.2 8 2 Z"/><path d="M6.6 11.6 A1.5 1.5 0 0 0 9.4 11.6"/>';  // bell (system notifications)
   span.innerHTML = '<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" '
     + 'stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">' + body + slash + "</svg>";
   return span;
@@ -3489,8 +3491,9 @@ function showTabMenu(e: MouseEvent, tab: HTMLElement, label: HTMLElement, id: st
   const s = sessions.get(id);
   const offFeed = !!(s && s.hideFromFeed);
   const offMail = !!(s && s.postalServiceOff);
+  const onBell = !!(s && s.notify);
   menu.appendChild(el("div", "ctx-sep"));
-  const toggle = (kind: "feed" | "mail", off: boolean, lab: string, sub: string, fn: () => void) => {
+  const toggle = (kind: "feed" | "mail" | "bell", off: boolean, lab: string, sub: string, fn: () => void) => {
     const item = el("div", "ctx-item ctx-item-toggle");
     item.appendChild(ctxIcon(kind, off));
     const bodyEl = el("span", "ctx-item-body");
@@ -3508,6 +3511,12 @@ function showTabMenu(e: MouseEvent, tab: HTMLElement, label: HTMLElement, id: st
     offMail ? "Rejoin mail" : "Mute mail",
     offMail ? "reconnect it to the postal service" : "hide from peers — no messages in or out",
     () => setSessionFlag(id, "postalServiceOff", !offMail));
+  // system-notification bell (the user 2026-07-28) — same flag the timeline lane bell toggles. NOTE the
+  // inverted polarity vs the two above: `notify` true is the ENABLED state, so the icon slashes on !onBell.
+  toggle("bell", !onBell,
+    onBell ? "Stop notifying" : "Notify me",
+    onBell ? "no more system notifications for this session" : "system notification when its work blocks on you or completes",
+    () => setSessionFlag(id, "notify", !onBell));
   // Color swatches (the user 2026-06-29): the romp identity palette as circles, the session's current one
   // ringed. Click one to recolor the session. Omitted until /palette has loaded (paletteColors empty).
   if (paletteColors.length) {
@@ -6491,6 +6500,7 @@ function upsert(msg: any) {
     bgTasks: ("bgTasks" in msg) ? msg.bgTasks : (prev ? prev.bgTasks : undefined),
     hideFromFeed: ("hideFromFeed" in msg) ? !!msg.hideFromFeed : (prev ? prev.hideFromFeed : undefined),
     postalServiceOff: ("postalServiceOff" in msg) ? !!msg.postalServiceOff : (prev ? prev.postalServiceOff : undefined),
+    notify: ("notify" in msg) ? !!msg.notify : (prev ? prev.notify : undefined),
   };
   sessions.set(msg.id, s);
   reconcileRewind(s);       // pending-rewind overlay + the editable-bubble set, from the fresh payload

--- a/vscode-extension/src/pipe-intent.ts
+++ b/vscode-extension/src/pipe-intent.ts
@@ -12,7 +12,7 @@ export const INTENT_OPS: ReadonlySet<string> = new Set([
   "interrupt", "apiRetry", "rewindDelete",
   "setModel", "setEffort", "setMode",
   "renameSession", "endSession", "reviveSession",
-  "nodeOverride", "askClear", "undoClear", "cardMove",
+  "nodeOverride", "askClear", "undoClear", "cardMove", "cardNotify",
   "answerAsk", "submitAsk", "toggleAsk", "navAsk", "cancelAsk",
   "setSessionFlag", "setSessionColor", "setGlobalRetryPaused",
   "reorderTabs", "closeTab",

--- a/vscode-extension/src/tab-menu-flags.test.ts
+++ b/vscode-extension/src/tab-menu-flags.test.ts
@@ -16,7 +16,7 @@ test("the flags ride on the session and are carried across pushes", () => {
 });
 
 test("setSessionFlag posts the same message the timeline lane toggles send, and updates locally", () => {
-  assert.match(SRC, /function setSessionFlag\(id: string, flag: "hideFromFeed" \| "postalServiceOff", value: boolean\)/);
+  assert.match(SRC, /function setSessionFlag\(id: string, flag: "hideFromFeed" \| "postalServiceOff" \| "notify", value: boolean\)/);
   assert.match(SRC, /vscodeApi\.postMessage\(\{ type: "setSessionFlag", id, flag, value \}\)/);
 });
 
@@ -28,9 +28,20 @@ test("the tab menu adds Feed + Mail toggle items with state-dependent labels", (
 });
 
 test("each toggle item carries an icon (slashed when off) and a sub-description", () => {
-  assert.match(SRC, /function ctxIcon\(kind: "feed" \| "mail", off: boolean\)/);
+  assert.match(SRC, /function ctxIcon\(kind: "feed" \| "mail" \| "bell", off: boolean\)/);
   assert.match(SRC, /off \? '<line /);   // slash when the flag is off
   assert.match(SRC, /ctx-item-sub/);
   assert.match(CSS, /\.ctx-item-toggle \{ display: flex;/);
   assert.match(CSS, /\.ctx-item-toggle \.ctx-icon\.off \{ color: var\(--dim\); \}/);
+});
+
+test("the menu adds the notification bell toggle — inverted polarity: `notify` true is the ENABLED state (the user 2026-07-28)", () => {
+  assert.match(SRC, /notify\?: boolean; \}/);                       // rides Session like the other two flags
+  assert.match(SRC, /notify: \("notify" in msg\) \? !!msg\.notify/);  // absorbed + carried across pushes
+  assert.match(SRC, /const onBell = !!\(s && s\.notify\);/);
+  // the icon slashes on !onBell (bell OFF), while feed/mail slash on their own off-flags being TRUE
+  assert.match(SRC, /toggle\("bell", !onBell,\s*onBell \? "Stop notifying" : "Notify me"/);
+  assert.match(SRC, /setSessionFlag\(id, "notify", !onBell\)/);
+  // what it does, in the sub-line: the kernel's feed-diff notifier fires on blocked-on-you / completed
+  assert.match(SRC, /system notification when its work blocks on you or completes/);
 });


### PR DESCRIPTION
A session's work blocking on you or completing can now raise a native system notification, armed from three places:

- **Timeline lane bell** — a new drawn bell between the mailbox and the model column (live lanes only). On = romp blue, off (default) = slashed gray, same pointerdown/optimistic-sticky pattern as the feed checkbox and mailbox. Persists as session-flags `notify`.
- **Session tab right-click** — a "Notify me" / "Stop notifying" toggle in the existing chat-tab context menu, posting the same `setSessionFlag`.
- **Feed card right-click** — a new one-item context menu on cards (tab-menu chrome, mirrored into feed.css since the feed page loads only feed.css). Per-card arming persists kernel-side in `notify-cards.json`, echoes back as `ask.notify`, shows as a quiet accent bell beside Clear, and prunes automatically when the card leaves the feed.

Delivery is kernel-side and event-based: each fresh feed build is diffed against the previous one, and an armed card entering `needs_input` fires "Needs you: <task>", entering `completed` fires "Completed: <task>" (osascript `display notification` on macOS, `notify-send` elsewhere, fire-and-forget). The first build after a kernel start is a silent baseline — existing state is status, not news, mirroring the VS Code extension's freshNeedsYou policy. Session-level arming covers every card of that session; card-level covers just that card.

Since the bell shape now means notifications, the error center's rail/mobile icon becomes a warning triangle: same in-body unread count (digits, `+` for many), and the triangle's own `!` when everything is read. Both glyphs verified headlessly at rail size.

Tests: new `tests/test_notify_bells.py` (store, diff detector incl. baseline/re-arm/prune/provisional, osascript escaping, wiring pins) and `ui/webview/card-notify.test.ts`; sibling cases added to the timeline-flags and tab-menu-flags suites; error-center pins updated for the triangle. Both suites green (3346 py / 1378 node), tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)