### PR TITLE
The per-card bell becomes a corner button on every goal card

### DIFF
--- a/ui/webview/card-notify.test.ts
+++ b/ui/webview/card-notify.test.ts
@@ -1,6 +1,7 @@
-// The per-card notification bell (the user 2026-07-28): right-click a feed card → a one-item context
-// menu whose "Notify me" arms an OS notification for when THIS card enters needs_input or completed
-// (kernel notify-cards.json; the session-wide bell rides session-flags "notify" on the lane/tab menu).
+// The per-card notification bell (the user 2026-07-28): every goal card wears a bell BUTTON in its
+// bottom-right corner (round 2 — promoted from right-click-only) that arms an OS notification for
+// when THIS card enters needs_input or completed (kernel notify-cards.json; the session-wide bell
+// rides session-flags "notify" on the lane/tab menu). Right-click still opens the labelled menu.
 // Source pins against feed.ts + feed.css (the render path has no jsdom harness), like badge-mirror's.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -10,40 +11,47 @@ import * as path from "node:path";
 const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
 
-test("right-click opens the card menu; a provisional placeholder (no stable identity) gets none", () => {
+test("every card carries the corner bell button, riding the CARD (absolute), not the flex rows", () => {
+  assert.match(SRC, /const bellBtn = el\("button", "fask-bellbtn"\);/);
+  assert.match(SRC, /card\.append\(main, bellBtn\);/);
+  assert.match(CSS, /\.fitem\.ask \{ cursor: pointer; position: relative; \}/);   // the corner's anchor
+  assert.match(CSS, /\.fask-bellbtn \{\s*\n\s*position: absolute; right: 4px; bottom: 3px;/);
+});
+
+test("off = hover-revealed slashed dim bell; armed (.on) = accent, always visible (mechanics, not status)", () => {
+  assert.match(CSS, /\.fask-bellbtn[\s\S]{0,400}opacity: 0;/);                    // quiet feed stays quiet
+  assert.match(CSS, /\.fitem\.ask:hover \.fask-bellbtn \{ opacity: 0\.55; \}/);   // the tab-close idiom
+  assert.match(CSS, /\.fask-bellbtn\.on \{ opacity: 0\.85; color: var\(--accent\); \}/);
+});
+
+test("the bell click toggles without opening the modal, off the FRESHEST payload copy", () => {
+  assert.match(SRC, /bellBtn\.onclick = \(ev: Event\) => \{\s*\n\s*ev\.stopPropagation\(\);/);
+  assert.match(SRC, /const cur = \(card as any\)\._it as AskItem \| undefined;/);
+  assert.match(SRC, /setCardNotify\(card, live, !cardNotifyOn\(live\)\);/);
+});
+
+test("right-click still opens the labelled menu; both paths land on the ONE setCardNotify", () => {
   assert.match(SRC, /card\.addEventListener\("contextmenu", \(ev\) => \{\s*\n\s*if \(it\.provisional\) return;/);
-  assert.match(SRC, /ev\.preventDefault\(\); ev\.stopPropagation\(\);\s*\n\s*showCardMenu\(ev, card\);/);
-});
-
-test("the menu reads the FRESHEST payload copy off the card, never the make-time closure", () => {
-  // updateAskCard restashes a._it every push; the closure's `it` goes stale after the first one
-  assert.match(SRC, /a\._it = it;/);
-  assert.match(SRC, /const it = \(card as any\)\._it as AskItem \| undefined;/);
-});
-
-test("the toggle posts cardNotify with the card's id + owning session", () => {
-  assert.match(SRC, /vscodeApi\?\.postMessage\(\{ type: "cardNotify", itemId: it\.itemId, sid: it\.sid, value: !on \}\)/);
+  assert.match(SRC, /showCardMenu\(ev, card\);/);
+  assert.match(SRC, /function setCardNotify\(card: HTMLElement, it: AskItem, value: boolean\): void \{/);
+  assert.match(SRC, /vscodeApi\?\.postMessage\(\{ type: "cardNotify", itemId: it\.itemId, sid: it\.sid, value \}\)/);
   assert.match(SRC, /notify\?: boolean \| null;/);   // the kernel echoes the armed state back on the ask
 });
 
-test("optimism is sticky until the kernel confirms — the lane toggles' pattern, not a timer", () => {
+test("optimism is sticky until the kernel confirms, and the click acknowledges instantly", () => {
   assert.match(SRC, /const pendingNotify = new Map<string, boolean>\(\);/);
-  assert.match(SRC, /pendingNotify\.set\(it\.itemId, !on\);/);
+  assert.match(SRC, /pendingNotify\.set\(it\.itemId, value\);/);
+  assert.match(SRC, /paintCardBell\(card, value\);\s*\/\/ acknowledge instantly/);
   // retired the moment the payload agrees (event-based), then whichever value stands renders
   assert.match(SRC, /if \(pendingNotify\.has\(it\.itemId\) && !!it\.notify === pendingNotify\.get\(it\.itemId\)\) pendingNotify\.delete\(it\.itemId\);/);
 });
 
-test("the click acknowledges instantly: the armed bell shows before the kernel round-trip", () => {
-  assert.match(SRC, /if \(bell\) bell\.style\.display = !on \? "" : "none";\s*\/\/ acknowledge instantly/);
+test("repaints are state-gated so a routine push never churns the svg under a press (click-safety)", () => {
+  assert.match(SRC, /if \(\(btn as any\)\._bellOn === on\) return;/);
 });
 
-test("an armed card wears a quiet accent bell beside Clear; labels are state-dependent", () => {
-  assert.match(SRC, /const bellOnBadge = el\("span", "fask-bellon"\);/);
-  assert.match(SRC, /waitOnBadge, bellOnBadge, clr\);/);
-  assert.match(SRC, /on \? "Stop notifying" : "Notify me"/);
-  assert.match(SRC, /system notification when this card blocks on you or completes/);
-  // accent = mechanics chrome (CLAUDE.md: never a status colour)
-  assert.match(CSS, /\.fask-bellon \{ flex: 0 0 auto; display: flex; align-items: center; color: var\(--accent\)/);
+test("a provisional placeholder hides its bell (no stable identity to arm)", () => {
+  assert.match(SRC, /\.style\.display = it\.provisional \? "none" : "";/);
 });
 
 test("the menu wears the tab menu's chrome (feed.css has its own copy — the feed page loads only feed.css)", () => {

--- a/ui/webview/done-confirming.test.ts
+++ b/ui/webview/done-confirming.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const dcBadge = el\("span", "fask-doneconfirming"\)/);
   assert.match(FEED, /dcBadge\.textContent = "done, confirming"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   assert.match(FEED, /a\._doneConfirming = dcBadge;/);
 });
 

--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -18,7 +18,7 @@ test("COMPACTNESS (the user 2026-07-07): time trails the title; Clear on the nam
   assert.match(FEED, /row3\.append\(bgBtn, takeBtn, stallBtn, subBtn, taskBtn, actions\)/, "ask card: row3 is Background/Summary/Stalled/Sub-goals/Waiting-on-task (+ rare Retry/Revive)");
   assert.match(FEED, /actions\.append\(apiRetry, revive,/, "…so the action row is Retry/Revive (+ resume-gate) only (Clear + toggles moved up)");
   // Clear is the rightmost control on the NAME row now (both ask + group cards)
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/, "ask card: Clear on the name row");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "ask card: Clear on the name row");
   // its tooltip is plain-spoken (the user 2026-07-13): "clear this task", not the inbox-zero jargon
   assert.match(FEED, /clr\.title = "clear this task";/);
   assert.match(FEED, /row2\.append\(idwrap, clr\)/, "group card: Clear on the name row");
@@ -57,7 +57,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
   assert.match(FEED, /const origin = el\("a", "fask-origin"\); origin\.style\.display = "none"/);
   // it's a direct child of the wrapping row2 (NOT nested in idwrap) so a narrow card wraps it under the
   // name instead of overlapping the chips (the user 2026-06-20)
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/, "the origin marker rides the name row beside the chips");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "the origin marker rides the name row beside the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested inside idwrap");
   // populated from it.origin in the update path: a dim gray "↪ from" + the peer in the bold session-name
   // style (its own identity colour); click opens the sender (the user 2026-06-16)
@@ -74,7 +74,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
 test("the follow-up badge serves ONLY '↩ re-judging' now — the '↻ Followed up' chip was removed (the user 2026-07-01)", () => {
   assert.match(FEED, /el\("span", "fask-followedup"\); fupBadge\.textContent = "↩ re-judging"/);
   // the badge rides the SESSION-NAME row (right-justified), NOT the bottom action row
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   // the CARD badge block is now recheck-only: recheck → "↩ re-judging", else hidden. No followupPending branch.
   // (The modal tree's per-node "↻ Followed up" chip, ftree-followedup, is a separate thing and stays.)
   assert.match(FEED, /if \(it\.recheck\) \{\s*\n\s*a\._followedup\.style\.display = "";\s*\n\s*a\._followedup\.textContent = "↩ re-judging";[\s\S]*?\} else \{\s*\n\s*a\._followedup\.style\.display = "none";\s*\n\s*\}/);

--- a/ui/webview/feed-delegation.test.ts
+++ b/ui/webview/feed-delegation.test.ts
@@ -45,7 +45,7 @@ test("a narrow card WRAPS the '↪ from' provenance under the name instead of ov
   // chip. Fix: row2 wraps, and origin is a direct row2 child (sibling of the chips) so it drops to a
   // second line rather than overlapping when name + provenance + chips don't all fit.
   assert.match(CSS, /\.fask-row2 \{[^}]*flex-wrap: wrap/, "the name row wraps so trailing items never overlap");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/, "origin is a row2 sibling of the chips");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "origin is a row2 sibling of the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested in the shrinking idwrap");
   // the old overflow mechanism is gone — flex-grow on idwrap right-aligns it instead of an auto margin
   assert.doesNotMatch(CSS, /\.fask-origin \{[^}]*margin-left: auto/);

--- a/ui/webview/feed-interrupted.test.ts
+++ b/ui/webview/feed-interrupted.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the interrupted badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const intBadge = el\("span", "fask-interrupted"\)/);
   assert.match(FEED, /intBadge\.textContent = "interrupted"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   assert.match(FEED, /a\._interrupted = intBadge;/);
 });
 

--- a/ui/webview/feed-interrupting.test.ts
+++ b/ui/webview/feed-interrupting.test.ts
@@ -15,7 +15,7 @@ test("the interrupting badge is built once and rides the wrapping chip row", () 
   assert.match(FEED, /const intingBadge = el\("span", "fask-interrupting"\)/);
   assert.match(FEED, /intingBadge\.textContent = "interrupting…"/, "text label, no emoji/glyph");
   // sits immediately left of the past-tense interrupted badge on the same wrapping row
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   assert.match(FEED, /a\._interrupting = intingBadge;/);
 });
 

--- a/ui/webview/feed-nudge-failed.test.ts
+++ b/ui/webview/feed-nudge-failed.test.ts
@@ -16,7 +16,7 @@ test("the follow-up-failed chip is built once and rides the wrapping chip row", 
   assert.match(FEED, /const nfBadge = el\("span", "fask-nudgefailed"\)/);
   assert.match(FEED, /nfBadge\.textContent = "follow-up failed"/,
     "the label is 'follow-up failed' (the user 2026-07-23) — 'stalled' is the yellow section's word; no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   assert.match(FEED, /a\._nudgeFailed = nfBadge;/);
 });
 

--- a/ui/webview/feed-waiton.test.ts
+++ b/ui/webview/feed-waiton.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("a waiting-on chip is built and rides the wrapping chip row (its own line when it doesn't fit)", () => {
   assert.match(FEED, /const waitOnBadge = el\("span", "fask-waiton"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   assert.match(FEED, /a\._waitOn = waitOnBadge;/);
 });
 

--- a/ui/webview/feed-warn-chip.test.ts
+++ b/ui/webview/feed-warn-chip.test.ts
@@ -15,7 +15,7 @@ test("the warning chip is a button built once, riding the wrapping chip row", ()
   assert.match(FEED, /const warnChip = el\("button", "fask-warnchip"\)/,
     "a BUTTON (focusable), not a span — it has a click action");
   assert.match(FEED, /warnChip\.textContent = "warning"/, "plain text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
   assert.match(FEED, /a\._warnChip = warnChip;/);
 });
 

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -211,7 +211,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    the card's own session-colour border (the user 2026-07-15): that colour at 0.5α at rest (--card-r/g/b set
    inline per card), 0.8α when pinned, full opacity when focused/hovered. Order matters: .focused after .pinned
    so a pinned-AND-focused card shows the bright (full) border. */
-.fitem.ask { cursor: pointer; }
+.fitem.ask { cursor: pointer; position: relative; }   /* relative: anchors the corner bell button */
 .fitem.ask, .fitem.fgroup { border-color: rgba(var(--card-r, 255), var(--card-g, 255), var(--card-b, 255), 0.5); }
 .fitem.ask.pinned  { border-color: rgba(var(--card-r, 255), var(--card-g, 255), var(--card-b, 255), 0.85); }   /* pinned: bolded, persistent */
 /* effective focus: full-opacity same colour, thickened a touch by a 1px same-colour ring (a bolder highlight
@@ -1040,5 +1040,18 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .ctx-item-toggle .ctx-icon.off { color: var(--dim); }
 .ctx-item-body { display: flex; flex-direction: column; line-height: 1.25; }
 .ctx-item-sub { font-size: 0.82em; opacity: 0.6; }
-/* the armed marker on the card: mechanics chrome (accent), deliberately not a status colour */
-.fask-bellon { flex: 0 0 auto; display: flex; align-items: center; color: var(--accent); opacity: 0.75; }
+/* the corner bell BUTTON (the user 2026-07-28, round 2): pinned bottom-right in the card's own padding.
+   Off = slashed dim bell, hidden until the card is hovered (the tab-close idiom — a quiet feed stays
+   quiet); armed (.on) = accent bell, always visible. Accent = mechanics chrome, never a status colour. */
+.fask-bellbtn {
+  position: absolute; right: 4px; bottom: 3px; z-index: 1;
+  display: flex; align-items: center; justify-content: center;
+  width: 20px; height: 20px; padding: 0; border: 0; border-radius: 5px;
+  background: transparent; color: var(--dim); cursor: pointer; opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.fitem.ask:hover .fask-bellbtn { opacity: 0.55; }
+.fitem.ask .fask-bellbtn:hover { opacity: 1; background: rgba(255, 255, 255, 0.10); }
+.fask-bellbtn.on { opacity: 0.85; color: var(--accent); }
+.fitem.ask:hover .fask-bellbtn.on { opacity: 0.85; }
+.fitem.ask .fask-bellbtn.on:hover { opacity: 1; }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -556,11 +556,14 @@ function ensureHeader() {
 // Expanded body = the request DAG as a tree of NODES (state machine only); each
 // node clicks to reveal its OWN reply history; ? nodes carry a decision sub-card.
 // ── per-card notification bell (the user 2026-07-28) ─────────────────────────────────────────────
-// Right-click a card → a small context menu (the tab menu's chrome) with one toggle: "Notify me" arms
-// an OS notification for when THIS card blocks on you or completes (kernel notify-cards.json; the
-// session-wide version lives on the timeline lane / tab menu). The armed state shows as a quiet bell
-// beside Clear. Optimism mirrors the lane toggles: pendingNotify holds the clicked value sticky across
-// pushes until the kernel's payload agrees, so the bell never flickers back while the rebuild lands.
+// Every card wears a small bell BUTTON in its bottom-right corner (the user 2026-07-28, round 2 —
+// promoted from a right-click-only toggle): click it to arm/disarm an OS notification for when THIS
+// card blocks on you or completes (kernel notify-cards.json; the session-wide version lives on the
+// timeline lane / tab menu). Armed = accent bell, always visible; off = slashed dim bell, revealed on
+// card hover (the tab-close idiom — no clutter on a quiet feed). Right-clicking the card still opens
+// the labelled menu for the same toggle. Optimism mirrors the lane toggles: pendingNotify holds the
+// clicked value sticky across pushes until the kernel's payload agrees, so the bell never flickers
+// back while the rebuild lands.
 const pendingNotify = new Map<string, boolean>();   // itemId -> clicked value, until the payload confirms
 let cardMenuEl: HTMLElement | null = null;
 
@@ -583,6 +586,26 @@ function cardNotifyOn(it: AskItem): boolean {
   return pendingNotify.has(it.itemId) ? !!pendingNotify.get(it.itemId) : !!it.notify;
 }
 
+// paint the corner bell to a state: armed = accent + unslashed (always visible via .on), off = slashed
+// dim (hover-revealed). The title explains the CLICK, so it always describes the opposite state.
+function paintCardBell(card: HTMLElement, on: boolean): void {
+  const btn = (card as any)._bell as HTMLElement | undefined;
+  if (!btn) return;
+  if ((btn as any)._bellOn === on) return;   // steady state: never churn the svg under a press (click-safety)
+  (btn as any)._bellOn = on;
+  btn.classList.toggle("on", on);
+  btn.innerHTML = cardBellSvg(!on);
+  btn.title = on ? "system notifications on for this task — click to stop"
+    : "notify me when this task blocks on you or completes";
+}
+
+// the ONE toggle path — the corner bell click and the right-click menu both land here
+function setCardNotify(card: HTMLElement, it: AskItem, value: boolean): void {
+  pendingNotify.set(it.itemId, value);               // sticky until the kernel's payload carries it
+  paintCardBell(card, value);                        // acknowledge instantly, before the round-trip
+  vscodeApi?.postMessage({ type: "cardNotify", itemId: it.itemId, sid: it.sid, value });
+}
+
 function showCardMenu(e: MouseEvent, card: HTMLElement): void {
   dismissCardMenu();
   const it = (card as any)._it as AskItem | undefined;   // the freshest payload copy (updateAskCard stashes it)
@@ -602,10 +625,7 @@ function showCardMenu(e: MouseEvent, card: HTMLElement): void {
   item.addEventListener("click", (ev) => {
     ev.stopPropagation();
     dismissCardMenu();
-    pendingNotify.set(it.itemId, !on);               // sticky until the kernel's payload carries it
-    const bell = (card as any)._bell as HTMLElement | undefined;
-    if (bell) bell.style.display = !on ? "" : "none";   // acknowledge instantly, before the round-trip
-    vscodeApi?.postMessage({ type: "cardNotify", itemId: it.itemId, sid: it.sid, value: !on });
+    setCardNotify(card, it, !on);
   });
   menu.appendChild(item);
   document.body.appendChild(menu);
@@ -733,14 +753,17 @@ function makeAskCard(it: AskItem): HTMLElement {
   // row2 wraps them onto a new line when there isn't room, so the provenance never overlaps a chip
   // (the user 2026-06-20). origin sits left of the chips, matching the "from … · Followed up" reading order.
   // Clear is the rightmost, always-present control on this row (idwrap flex:1 pushes it to the edge).
-  // armed per-card bell (the user 2026-07-28): a quiet accent bell just left of Clear while this card's
-  // right-click "Notify me" is on — mechanics marker, not a status (session-level arming shows on the
-  // lane/tab instead, so an armed SESSION doesn't stamp every card).
-  const bellOnBadge = el("span", "fask-bellon");
-  bellOnBadge.title = "system notifications on for this card — right-click to change";
-  bellOnBadge.innerHTML = cardBellSvg(false);
-  bellOnBadge.style.display = "none";
-  row2.append(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, bellOnBadge, clr);
+  row2.append(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr);
+  // the corner bell BUTTON (the user 2026-07-28, round 2): bottom-right of the card, per-task arming.
+  // Session-level arming shows on the lane/tab instead, so an armed SESSION doesn't stamp every card.
+  // Absolutely positioned in the card's own padding — it never shoves the rows around.
+  const bellBtn = el("button", "fask-bellbtn");
+  bellBtn.onclick = (ev: Event) => {
+    ev.stopPropagation();                            // never open the modal under the toggle
+    const cur = (card as any)._it as AskItem | undefined;   // freshest payload copy, not this closure
+    const live = cur || it;
+    setCardNotify(card, live, !cardNotifyOn(live));
+  };
   // ROW 3 — Background (left) · Summary (right), always one line, opposite sides. Populated below, once the
   // toggle buttons exist (they're declared with the distiller sections). The time now trails the title (row1).
   const row3 = el("div", "fask-row3");
@@ -813,7 +836,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   const qbody = el("div", "fask-qbody");
   qbody.style.display = "none";
   main.append(row1, row2, row3, secs, qbody, awaitSpin, checklist, delegations);   // no expand button — body click opens the modal
-  card.append(main);
+  card.append(main, bellBtn);   // the bell rides the CARD (absolute, bottom-right corner), outside the flex rows
   // Follow-up lives in the modal now (the user 2026-06-10), not on the card.
 
   // title → locate the turn the card stands for. A normal card anchors on "prompt" (the originating
@@ -915,7 +938,7 @@ function makeAskCard(it: AskItem): HTMLElement {
 
   const a = card as any;
   a._title = title; a._name = name; a._time = time; a._followedup = fupBadge;
-  a._bell = bellOnBadge;
+  a._bell = bellBtn;
   a._row1 = row1; a._row2 = row2;   // grouped mode re-homes Clear between these (the user 2026-07-13)
   a._doneConfirming = dcBadge;
   a._nudgeFailed = nfBadge;
@@ -1198,7 +1221,8 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // per-card bell: retire the optimistic value once the kernel's payload agrees (event-based, no timer),
   // then render whichever stands. Same sticky-optimism shape as the timeline lane's _pendingFlags.
   if (pendingNotify.has(it.itemId) && !!it.notify === pendingNotify.get(it.itemId)) pendingNotify.delete(it.itemId);
-  if (a._bell) (a._bell as HTMLElement).style.display = cardNotifyOn(it) ? "" : "none";
+  if (a._bell) (a._bell as HTMLElement).style.display = it.provisional ? "none" : "";   // no stable identity to arm
+  paintCardBell(card, cardNotifyOn(it));
   card.className = "fitem ask" + (it.live ? " live" : " dead") + (it.itemId === (hoverAskId ?? pinnedAskId) ? " focused" : "") + (it.itemId === pinnedAskId ? " pinned" : "") + (it.provisional ? " provisional" : "");
   // PROVISIONAL placeholder: a dim, italic, non-interactive card from the live prompt while the planner
   // hasn't classified the in-progress turn yet. No Clear/Nudge (nothing to curate), no auto-line, no tree.


### PR DESCRIPTION
Follow-up to #97: the per-card notification toggle is now a visible bell button in the bottom-right corner of every goal card, not just a right-click menu item.

- Armed: accent bell, always visible — the button is also the armed indicator (the small marker beside Clear is gone).
- Off: slashed dim bell, revealed on card hover (tab-close idiom), full brightness on button hover.
- Click toggles that card's notification (stopPropagation, so it never opens the modal); the right-click menu remains and both paths share one `setCardNotify` with sticky optimism until the kernel's payload confirms.
- Repaints are state-gated so routine feed pushes never rebuild the svg mid-press (click-safety rule); provisional placeholders hide the bell.

Verified with a headless render of mock cards in both states. Node suite 1382 green, tsc clean, Python suite 3362 green (no kernel changes this round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)