### PR TITLE
A textless disk twin never lands streamed reply text, so the salvage can save it

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -765,7 +765,14 @@ def synthesize_orphans(states, atoms):
     hold that noise, and it must not resurface as work."""
     if not atoms:
         return []
-    seen_uuids = {a.get("uuid") for a in atoms if a.get("uuid")}
+    # TEXT-BEARING uuids only (the user 2026-07-28): a marker whose uuid the disk knows solely as a
+    # TEXTLESS record must still interleave. On some model+tool combinations (observed: fable-5 replying
+    # before an AskUserQuestion) the CLI persists the streamed reply text as an EMPTY thinking record
+    # under the same uuid — the very loss the marker salvages — so counting that twin as "seen" ate the
+    # salvage. A retry that DID re-reply carries its text and still dedups, as does a re-orphaned marker
+    # (the add below); the prefix check against disk_texts guards every remaining double.
+    seen_uuids = {a.get("uuid") for a in atoms
+                  if a.get("uuid") and _text_of(_content(a.get("message"))).strip()}
     disk_texts = [t for a in atoms if a.get("type") == "assistant"
                   if (t := _text_of(_content(a.get("message"))).strip())]
     sid = atoms[0]["session_id"]

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9237,6 +9237,20 @@ def _merge_live_atoms(session, sid, shown_texts=()):
     if not live:
         return session
     tx_uuids = {a.get("uuid") for turn in session["turns"] for a in turn["atoms"] if a.get("uuid")}
+    # A TEXTLESS disk twin must not land a texty live atom (the user 2026-07-28): on some model+tool
+    # combinations (observed: fable-5 replying before an AskUserQuestion) the CLI persists the reply
+    # text that streamed before the tool call as an EMPTY thinking record under the SAME uuid. The
+    # uuid-only prune then retired the live text mid-turn, the settle salvage (retire_live_work) never
+    # saw it, and the explanation the user watched stream vanished from the chat everywhere. Withhold
+    # those uuids: the live text stays visible until settle, where the orphan-reply salvage makes it
+    # durable (event_model._orphan_replies interleaves it back; its dedup is text-aware for the same
+    # reason). Self-neutralizing: a twin that DOES carry the text lands the atom exactly as before.
+    tx_text_uuids = {a.get("uuid") for turn in session["turns"] for a in turn["atoms"]
+                     if a.get("uuid") and _atom_prose_chars(a) > 0}
+    live_text_uuids = {a.get("uuid") for a in live
+                       if not a.get("_echo_text") and not a.get("command")
+                       and _atom_prose_chars(a) > 0}
+    tx_uuids -= (live_text_uuids - tx_text_uuids)
     tx_texts = {t for turn in session["turns"] for a in turn["atoms"] for t in _atom_user_texts(a)}
     # FIFO floor: the newest GENUINE-HUMAN turn the transcript has — retires an input echo whose text can't
     # match because the transcript extracted an image path out of it (screenshots piling up at the bottom, the

--- a/tests/test_judge_orphan_replies.py
+++ b/tests/test_judge_orphan_replies.py
@@ -72,6 +72,20 @@ class SynthesizeOrphans(unittest.TestCase):
             [_marker(160, "e1", "API Error: 529 Overloaded. This is a server-side issue.")], atoms)
         self.assertEqual(got, [], "pre-tagging markers hold the CLI's error text — noise, not work")
 
+    def test_a_textless_disk_twin_does_not_eat_the_salvage(self):
+        """(the user 2026-07-28): on some model+tool combinations (observed: fable-5 replying before an
+        AskUserQuestion) the CLI persists the streamed reply text as an EMPTY thinking record under the
+        SAME uuid — the very loss the marker salvages. The uuid dedup counted that twin as 'the disk
+        kept it' and dropped the marker; a textless record must not dedup a texty marker."""
+        atoms = [_atom("u1", 100, "the ask", typ="user"),
+                 {"type": "assistant", "uuid": "a5", "session_id": SID, "t": 150, "fsid": "f",
+                  "parentUuid": None, "_seq": 150,
+                  "message": {"role": "assistant",
+                              "content": [{"type": "thinking", "thinking": ""}]}}]
+        got = em.synthesize_orphans([_marker(160, "a5", "the explanation before the picker")], atoms)
+        self.assertEqual([g["uuid"] for g in got], ["a5"])
+        self.assertEqual(got[0]["message"]["content"][0]["text"], "the explanation before the picker")
+
 
 def iso(t):
     return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")

--- a/tests/test_kernel_picker_text_salvage.py
+++ b/tests/test_kernel_picker_text_salvage.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""A textless disk twin must not land a texty live atom (the user 2026-07-28).
+
+On some model+tool combinations (observed: fable-5 replying before an AskUserQuestion) the CLI
+persists the reply text that streamed before the tool call as an EMPTY thinking record under the
+SAME uuid. _merge_live_atoms pruned the live text by that uuid alone, so the explanation the user
+watched stream vanished mid-turn, the settle salvage (retire_live_work) never saw the atom, and no
+orphan marker was ever written. The merge now withholds a uuid from the prune/fresh sets when the
+live atom carries prose the disk twin lacks — the text stays visible until settle makes it durable.
+SYNTHETIC only."""
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_pts", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = 1781100000
+
+
+def _session(atoms):
+    return {"turns": [{"id": "t", "trigger": None, "t": T0, "end": T0, "ended": True, "atoms": atoms}]}
+
+
+def _disk(uuid, blocks):
+    return {"type": "assistant", "uuid": uuid, "t": T0 + 1,
+            "message": {"role": "assistant", "content": blocks}}
+
+
+def _live_text(uuid, text):
+    return {"type": "assistant", "uuid": uuid, "session_id": SID, "t": T0 + 1,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}]}}
+
+
+class _FakeBackend:
+    def __init__(self, live):
+        self._atoms = {a["uuid"]: a for a in live}
+        self.pruned_with = None                     # the tx_uuids set the kernel handed prune_live
+
+    def live_atoms(self, sid):
+        return sorted(self._atoms.values(), key=lambda a: a.get("t", 0))
+
+    def prune_live(self, sid, tx_uuids, tx_user_texts=(), human_floor=0):
+        self.pruned_with = set(tx_uuids)
+        for k in list(self._atoms):
+            if k in tx_uuids:
+                del self._atoms[k]
+
+
+class PickerTextSalvage(unittest.TestCase):
+    def setUp(self):
+        self._saved = km.Sessions.backend_for
+
+    def tearDown(self):
+        km.Sessions.backend_for = self._saved
+
+    def _merge(self, disk_atoms, live):
+        fake = _FakeBackend(live)
+        km.Sessions.backend_for = staticmethod(lambda sid: fake)
+        merged = km._merge_live_atoms(_session(disk_atoms), SID)
+        return merged, fake
+
+    def test_textless_twin_does_not_prune_the_live_text(self):
+        # the buggy shape: thinking, then the text's EMPTY-thinking twin, then the picker tool_use
+        disk = [_disk("th1", [{"type": "thinking", "thinking": ""}]),
+                _disk("tx1", [{"type": "thinking", "thinking": ""}]),
+                _disk("tu1", [{"type": "tool_use", "name": "AskUserQuestion", "input": {}}])]
+        merged, fake = self._merge(disk, [_live_text("tx1", "the explanation before the picker")])
+        self.assertNotIn("tx1", fake.pruned_with, "a textless twin must not land the live text")
+        self.assertIn("th1", fake.pruned_with, "atoms without live prose still prune by uuid")
+        self.assertIn("tu1", fake.pruned_with)
+        texts = [t for a in merged["turns"][-1]["atoms"]
+                 for t in ([b.get("text") for b in (a.get("message") or {}).get("content", [])
+                            if isinstance(b, dict) and b.get("type") == "text"])]
+        self.assertIn("the explanation before the picker", texts,
+                      "the streamed text stays visible instead of vanishing mid-turn")
+
+    def test_twin_that_kept_the_text_lands_the_atom_as_before(self):
+        # self-neutralizing: a CLI that persists the text correctly gets the exact old behavior
+        disk = [_disk("tx1", [{"type": "text", "text": "the explanation before the picker"}])]
+        merged, fake = self._merge(disk, [_live_text("tx1", "the explanation before the picker")])
+        self.assertIn("tx1", fake.pruned_with, "a twin carrying the text retires the live copy")
+        texts = [t for a in merged["turns"][-1]["atoms"]
+                 for t in ([b.get("text") for b in (a.get("message") or {}).get("content", [])
+                            if isinstance(b, dict) and b.get("type") == "text"])]
+        self.assertEqual(texts.count("the explanation before the picker"), 1, "never doubled")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_kernel.py
+++ b/tests/test_sdk_kernel.py
@@ -303,7 +303,12 @@ class LiveTailAndOpen(unittest.TestCase):
     def test_merge_dedups_by_uuid(self):
         self.be._live = {"sid-sdk": [{"type": "assistant", "uuid": "dup", "t": 50,
                                       "message": {"role": "assistant", "content": [{"type": "text", "text": "x"}]}}]}
-        session = {"turns": [{"id": "t", "atoms": [{"uuid": "dup", "t": 10}], "ended": True}]}
+        # the disk twin CARRIES the streamed text (the normal case — same record, same uuid). A twin
+        # that kept the uuid but LOST the text no longer dedups: see test_kernel_picker_text_salvage.
+        session = {"turns": [{"id": "t", "atoms": [{"uuid": "dup", "t": 10, "type": "assistant",
+                                                    "message": {"role": "assistant",
+                                                                "content": [{"type": "text", "text": "x"}]}}],
+                              "ended": True}]}
         out = km._merge_live_atoms(session, "sid-sdk")
         self.assertEqual(len(out["turns"][-1]["atoms"]), 1)              # transcript already has it → not re-added
 


### PR DESCRIPTION
## The incident

Twice in one session, an assistant explanation streamed into the chat, an AskUserQuestion picker followed it, and after answering the picker the user found the explanation gone — it had never been anywhere durable.

## Root cause (two layers)

**CLI layer (not ours to fix):** on `claude-fable-5`, the reply text that streams immediately before an AskUserQuestion tool call is persisted to the transcript as an **empty thinking record under the same uuid** (verified across sessions: every broken picker turn is fable with the `think:0, think:0, tool_use` shape; every healthy one is an Opus model with `think:0, text:N, tool_use`; 34/34 text atoms before other tool types persist fine on fable).

**Romp layer (fixed here):** the uuid-only prune in `_merge_live_atoms` took that textless twin as proof the text had landed — the live copy was retired mid-turn (the user watched it vanish), `retire_live_work`'s orphan salvage never saw the atom, and even a hand-written marker would have been eaten by `synthesize_orphans`' uuid dedup against the same twin.

## The fix

Two text-aware checks, both self-neutralizing (a twin that carries its text behaves exactly as before):

- `_merge_live_atoms` withholds a uuid from the prune/fresh sets while the live atom carries prose its disk twin lacks — the streamed text stays visible through the turn, and at settle the **existing** orphan-reply salvage writes the durable marker.
- `synthesize_orphans` (parse side, chat + judge) counts only **text-bearing** disk uuids as "seen", so the salvaged marker interleaves instead of being deduped by the record that lost the text. (The chat build's own dedup was already text-based and needs no change.)

## Tests

- `tests/test_kernel_picker_text_salvage.py` (new): the buggy shape keeps the live text and still prunes everything else; the healthy shape dedups exactly as before.
- `tests/test_judge_orphan_replies.py`: a textless twin no longer eats the salvage.
- `tests/test_sdk_kernel.py`: the uuid-dedup case now models the real twin (carries its text).
- Suites green: pytest 3365 passed, node 1382 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)