### PR TITLE
A session that can't start says so, instead of swallowing every message

### DIFF
--- a/bin/romp-sdk-setup
+++ b/bin/romp-sdk-setup
@@ -19,7 +19,9 @@ VENV="$STATE/sdkvenv"
 pick_python() {
     if [[ -n "${ROMP_PYTHON:-}" ]]; then echo "$ROMP_PYTHON"; return; fi
     local v c
-    for v in 3.13 3.12 3.11 3.10; do
+    # Newest first, and KEPT IN SYNC with bin/romp-serve — see the note there about why the list has to
+    # grow with each python release rather than relying on the `python3` fallback.
+    for v in 3.14 3.13 3.12 3.11 3.10; do
         for c in "python$v" "$HOME/.local/bin/python$v"; do
             if command -v "$c" >/dev/null 2>&1; then command -v "$c"; return; fi
         done

--- a/bin/romp-sdk-setup
+++ b/bin/romp-sdk-setup
@@ -19,8 +19,9 @@ VENV="$STATE/sdkvenv"
 pick_python() {
     if [[ -n "${ROMP_PYTHON:-}" ]]; then echo "$ROMP_PYTHON"; return; fi
     local v c
-    # Newest first, and KEPT IN SYNC with bin/romp-serve — see the note there about why the list has to
-    # grow with each python release rather than relying on the `python3` fallback.
+    # Newest first. The list has to GROW with each release: a machine whose only python is newer than
+    # everything named here falls through to `python3`, which is right when that IS the new one and wrong
+    # when python3 points at something ancient. Seen on a 3.14-only box, 2026-07-28.
     for v in 3.14 3.13 3.12 3.11 3.10; do
         for c in "python$v" "$HOME/.local/bin/python$v"; do
             if command -v "$c" >/dev/null 2>&1; then command -v "$c"; return; fi

--- a/bin/romp-serve
+++ b/bin/romp-serve
@@ -52,7 +52,10 @@ host="${host:-127.0.0.1}"
 pick_python() {
     if [[ -n "${ROMP_PYTHON:-}" ]]; then echo "$ROMP_PYTHON"; return; fi
     local v c
-    for v in 3.13 3.12 3.11 3.10; do
+    # Newest first. The list has to GROW with each release: a machine whose only python is newer than
+    # everything named here falls through to `python3`, which is right when that IS the new one and wrong
+    # when python3 points at something ancient. Seen on a 3.14-only box, 2026-07-28.
+    for v in 3.14 3.13 3.12 3.11 3.10; do
         for c in "python$v" "$HOME/.local/bin/python$v"; do
             if command -v "$c" >/dev/null 2>&1; then command -v "$c"; return; fi
         done

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2286,6 +2286,17 @@ def _awaiting_backstop_tick(now, tmux):
         _push_all()
 
 
+def _launch_error(sid):
+    """Why this session's CLI could not start, or None — {text, at, limit}, straight from the backend that
+    tried to start it (SessionBackend.launch_error). Guarded the same way as _backend_queued: a backend
+    hiccup reads as 'no known failure' rather than crashing the chat build."""
+    try:
+        be = Sessions.backend_for(str(sid))
+        return be.launch_error(str(sid)) if be else None
+    except Exception:
+        return None
+
+
 def _backend_queued(sid):
     """True if the session's backend holds queued-but-unstarted user turns (the SDK keeps them in _pending;
     tmux folds them from the transcript's queue-op records). Composer sends now go straight to that queue
@@ -3272,6 +3283,13 @@ def _sdk_locked():
             if not _ensure_sdk_on_path():
                 sys.stderr.write("sdk-backend: claude_agent_sdk not found — run bin/romp-sdk-setup to "
                                  "enable the non-tmux backend (tmux sessions are unaffected)\n")
+                # The backend is STILL built, deliberately: it owns the registry, the persisted queues and
+                # the chat those sessions render from, and dropping it would take the user's unsent
+                # messages off screen along with it. What it must not do is pretend to work — it detects
+                # the missing dep itself and reports every session as unable to start (launch_error), which
+                # is what puts this line in front of the user instead of only in the kernel log. Before
+                # that, a fresh install whose romp-sdk-setup had bailed looked like romp silently eating
+                # every message (the user 2026-07-28).
             sbmod = SourceFileLoader("romp_sdk_backend", str(HERE / "sdk_backend.py")).load_module()
             _sdk_backend = sbmod.SdkBackend(
                 jd.STATE, _claude_bin(), _send_to_app,
@@ -8654,6 +8672,18 @@ def _limit_hold(sid):
     The hold is never silent: it rides the `queued` event onto every parked bubble (so the chat says what
     the queue is waiting for and until when), and every bubble keeps its ✕ — whatever romp is holding, the
     user can see it and drop it."""
+    # The CLI REFUSING TO START on the limit is the first arm, because it is the case usage.json cannot
+    # see: usage.json is written from a RateLimitEvent the CLI streams once connected, so a limit that
+    # blocks the connect blocks its own reporting. On a fresh install that left the hold blind — the user
+    # sent a message, it parked in the SDK queue with nothing to explain it, and the session sat 'waiting'
+    # forever (the user 2026-07-28). The failed launch IS the event; it clears on the connect that
+    # disproves it, so the queue drains a pass after the window reopens. No readable reset stamp comes with
+    # it (the CLI reports a local wall-clock time, not an epoch), so this arm promises no countdown — the
+    # CLI's own words ride along as `detail` instead.
+    _le = _launch_error(sid)
+    if _le and _le.get("limit"):
+        return {"reason": "limit", "resetsAt": None,
+                "what": "waiting for your usage limit to reset", "detail": _le.get("text") or ""}
     try:
         u = _usage() or {}
     except Exception:
@@ -9902,6 +9932,21 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
         events = [ev for ev in events
                   if not (ev.get("kind") == "apiErrorNote" and ev.get("uuid") == aerr.get("uuid"))]
         events.append({"kind": "apiError", "text": aerr["text"], "status": aerr["status"]})
+    elif not (open_now or awaiting_why):
+        # The session's CLI could not START (SessionBackend.launch_error) — a blocked session with NO
+        # transcript atom to detect it by, since nothing ever connected to write one. It rides the same
+        # red card as an API error because it is the same thing to the reader: this session is stopped,
+        # here is why, here is Retry (the user 2026-07-28, whose message vanished into a session that
+        # silently failed to launch). The usage-limit flavor is EXCLUDED: nothing is broken there, the
+        # queue is simply parked, and the queued bubble's hold already says so with the same words —
+        # a red error card on top of it would read as damage instead of a wait.
+        _lerr = _launch_error(sid)
+        if _lerr and not _lerr.get("limit"):
+            # A missing dependency already reads as a whole sentence with its own remedy; only the raw
+            # failures need the "could not start" framing to make sense of a bare stderr line.
+            events.append({"kind": "apiError",
+                           "text": _lerr["text"] if _lerr.get("dep") else
+                           "This session's claude process could not start — %s" % _lerr["text"]})
     # TOC ledger: archiver headline (the tab tooltip's Summary; the bullets list retired 2026-07-07 —
     # its in-chat readers were deleted with the ledger box, and the tooltip reads recent/tree instead)
     arch = jd.load_archive(sid) or {}

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -715,6 +715,73 @@ CRASH_RESUME_NUDGE = (
     "the conversation and pick the work back up where it stopped.")
 
 
+# A CLI that cannot even START says so on the way out — and the ONE cause that reliably does this is the
+# account being out of usage: `claude` refuses the handshake and exits with the limit in its own words
+# ("You've hit your session limit · resets 1:10pm (America/Los_Angeles)"). romp used to swallow that
+# entirely (the user 2026-07-28, on a fresh install): the message they typed sat in the persisted queue,
+# the session settled 'waiting', and NOTHING said why — the send simply never flipped to working. The
+# limit was observable the whole time (romp's own judge calls were getting the same envelope), just never
+# read on this path. usage.json is no help here either: it is written from a RateLimitEvent the CLI streams
+# once CONNECTED, so a limit that blocks the connect blocks its own reporting — _limit_hold stayed None and
+# the queued bubble had nothing to say. This is that missing edge.
+_LAUNCH_LIMIT_RE = re.compile(
+    r"hit your (?:session|usage|weekly|5-hour) limit"      # the CLI's own phrasing
+    r"|usage limit reached"
+    r"|out of (?:usage|credits)"
+    r"|rate.?limit(?:ed)? .{0,40}(?:account|session|usage)", re.I)
+
+
+# The ONE dependency the whole SDK backend rests on. When it is absent every SDK session is a session
+# that can accept a message and never, ever run it — which is exactly what a fresh install looked like on
+# 2026-07-28: romp-sdk-setup had bailed (a python with no ensurepip), the kernel logged one stderr line
+# and BUILT THE BACKEND ANYWAY, and from the user's side sends vanished, no session flipped to working,
+# and the model/effort/usage readouts stayed blank (all three publish only AFTER a connect that could
+# never happen). tmux sessions worked the whole time, which made it read as an Anthropic outage. The
+# remedy is one command, so the error names it rather than describing the symptom.
+SDK_MISSING_TEXT = (
+    "romp's Agent SDK backend isn't installed, so this session can't run — its messages are being kept, "
+    "not sent. Install it with bin/romp-sdk-setup (it prints the OS package to add if one is missing), "
+    "then restart romp. tmux-backed sessions are unaffected.")
+
+
+def sdk_importable() -> bool:
+    """Is claude_agent_sdk actually importable RIGHT NOW? Checked at backend construction so the failure
+    is reported ONCE, up front, for every session — rather than one session at a time as each one's
+    thread dies at the lazy import inside _amain."""
+    try:
+        import importlib.util
+        return importlib.util.find_spec("claude_agent_sdk") is not None
+    except Exception:
+        return False
+
+
+def launch_failure_text(exc: BaseException) -> str:
+    """The most SPECIFIC human text a failed CLI launch carries. The SDK's ProcessError keeps the CLI's
+    own stderr on the exception (the class that actually names the cause); everything else falls back to
+    the exception's own text. Truncated, since a stderr dump can run long and this lands in a chat card."""
+    parts = []
+    for attr in ("stderr", "stdout"):
+        v = getattr(exc, attr, None)
+        if isinstance(v, bytes):
+            v = v.decode("utf-8", "replace")
+        if isinstance(v, str) and v.strip():
+            parts.append(v.strip())
+    parts.append(("%s: %s" % (type(exc).__name__, exc)).strip())
+    # prefer whichever part NAMES a limit — that's the line worth showing — else the first non-empty
+    named = next((p for p in parts if _LAUNCH_LIMIT_RE.search(p)), None)
+    text = (named or parts[0]).strip()
+    if len(text) > 600:
+        text = text[:600].rstrip() + "…"
+    return text
+
+
+def is_launch_limit(text: str) -> bool:
+    """True when a launch failure is the ACCOUNT being out of usage rather than a broken install. Drives
+    the kernel's _limit_hold (the queue parks and says what it is waiting for) instead of the plain
+    'this session could not start' card."""
+    return bool(text and _LAUNCH_LIMIT_RE.search(text))
+
+
 def task_death_notice(tasks: list) -> str:
     """The visible romp notice for BACKGROUND TASKS that died with their claude process. Bg tasks are
     the CLI's children, so a kernel restart or CLI crash silently kills a session's timers/watchers —
@@ -1315,11 +1382,18 @@ class SdkSession:
             self.backend._on_session_gone(self)
 
     async def _amain(self):
-        # Lazy SDK import — keeps the module importable without the dep.
-        from claude_agent_sdk import (
-            ClaudeSDKClient, ClaudeAgentOptions,
-            AssistantMessage, ResultMessage, SystemMessage,
-        )
+        # Lazy SDK import — keeps the module importable without the dep. RECORD a failure here before it
+        # propagates: this is the FIRST thing a session does, so with the dep missing every session dies
+        # right here, and the only trace used to be one kernel stderr line per crash while the user's
+        # messages piled up unsent (the user 2026-07-28).
+        try:
+            from claude_agent_sdk import (
+                ClaudeSDKClient, ClaudeAgentOptions,
+                AssistantMessage, ResultMessage, SystemMessage,
+            )
+        except Exception as e:
+            self.backend._record_launch_error(self, e)
+            raise
         self.loop = asyncio.get_running_loop()
         self._wake = asyncio.Event()
         with self._lock:
@@ -1404,6 +1478,11 @@ class SdkSession:
                 async with ClaudeSDKClient(options=opts) as client:
                     connected = True
                     self.client = client
+                    # The CLI is demonstrably up, so any recorded launch failure is HISTORY — clear it
+                    # here, at the proof, rather than on a timer. This is what lifts the usage-limit
+                    # hold once the window resets: the next _ensure connects, the error record goes, and
+                    # the queue the limit was holding drains on the following producer pass.
+                    self.backend._clear_launch_error(self.sid)
                     # A pending /effort switch is APPLIED the instant this (re)connect lands (--effort rode _options
                     # above) → clear the switching-dots + "Reloading session…" notice (the user 2026-07-06). Covers
                     # the immediate (idle) reconnect, the deferred (turn-end) one, and a first connect that picked up
@@ -1455,6 +1534,11 @@ class SdkSession:
                 if self._rewind_armed and not connected:
                     self._rewind_failed(e)
                     continue
+                if not connected:
+                    # The CLI never came up. RECORD why, where the user can see it: this thread is about
+                    # to die, and everything downstream of it (_on_session_gone settling 'waiting') is
+                    # silent by design. Without this the only trace is a kernel stderr line nobody reads.
+                    self.backend._record_launch_error(self, e)
                 raise
             if self.ended or not self._reconnect:
                 break        # drain ended on its own (process exit) or we're shutting down → done
@@ -2019,6 +2103,12 @@ class SdkBackend:
         self._pending_ask: dict[str, bool] = {}   # sid -> has an ask awaiting answer
         self._live: dict[str, dict] = {}          # sid -> {key -> atom}: the in-memory LIVE TAIL (ahead of disk)
         self._rl_lock = threading.Lock()          # serializes usage.json read-merge-write (_record_rate_limit)
+        # The dependency check, done ONCE here: absent → every session this backend owns reports the same
+        # launch error (launch_error), instead of each one silently dying at its own lazy import.
+        self._sdk_missing = not sdk_importable()
+        if self._sdk_missing and log:
+            log("claude_agent_sdk is NOT importable — every SDK session will report itself unable to "
+                "start (run bin/romp-sdk-setup). tmux sessions are unaffected.")
         self._heal_attempts: dict[str, int] = {}  # sid -> crash-resume attempts since its last COMPLETED turn
         #                                           (bounds _heal_cut_session to one resume per cut; a completed
         #                                           turn resets it, so a crash LOOP can't respawn forever)
@@ -2545,10 +2635,23 @@ class SdkBackend:
         """Queued-but-not-yet-started user turns for an SDK session (oldest first), or [] if the
         session isn't SDK-backed / not running. The kernel calls this to build the chat's
         kind:"queued" event for SDK sessions — the SDK keeps its queue in memory, so there are no
-        transcript queue-operation records for _pending_queued to read."""
+        transcript queue-operation records for _pending_queued to read.
+
+        A session that is NOT running falls back to the PERSISTED queue (the reg mirror _persist_queue
+        writes on every mutation). That is not a guess: it is the same list, and it is what the boot
+        reconcile re-delivers, so it is exactly what is still owed to the user. Returning [] there made
+        the message VANISH from the chat the moment the CLI died — which is how a send into an
+        out-of-usage account looked like romp had eaten it (the user 2026-07-28). While the session IS
+        running the in-memory queue stays authoritative: the mirror trails it by one write."""
         with self._lock:
             s = self.sessions.get(sid)
-        return s.pending() if s else []
+        if s:
+            return s.pending()
+        try:
+            q = (read_reg(self.state_dir, str(sid)) or {}).get("queue")
+        except Exception:
+            return []
+        return [t for t in q if isinstance(t, str) and t] if isinstance(q, list) else []
 
     def unqueue(self, sid: str, idx: int, expect: str | None = None) -> str | None:
         """Cancel the queued turn at `idx` for an SDK session (the kernel's cancelQueued route). Returns
@@ -3120,6 +3223,53 @@ class SdkBackend:
             reg = read_reg(self.state_dir, sid) or {"sid": sid}   # unserialized RMWs would drop fields
             reg.update(fields)
             write_reg(self.state_dir, sid, reg)
+
+    def _record_launch_error(self, sess: SdkSession, exc: BaseException) -> None:
+        """A session's CLI refused to start — persist WHY onto the session so the user is told, loudly,
+        on the surface they were typing into. The reg is the right home: it outlives this thread (which
+        is dying) and it is what the boot reconcile and the chat build already read, so the error
+        survives a kernel restart exactly like the queue it is holding up.
+
+        `limit` marks the account-out-of-usage flavor, which reads differently to the user: nothing is
+        broken, the queue is simply parked until the window resets (kernel _limit_hold), and the message
+        they typed is still there. Anything else is a real failure and gets the plain error card."""
+        # A missing dependency gets the REMEDY as its text, not the raw ModuleNotFoundError: "No module
+        # named 'claude_agent_sdk'" tells a user nothing about what to run.
+        dep = isinstance(exc, ImportError)
+        text = SDK_MISSING_TEXT if dep else launch_failure_text(exc)
+        rec = {"text": text, "at": int(time.time()), "limit": is_launch_limit(text), "dep": dep}
+        try:
+            self._update_reg(sess.sid, launchError=rec)
+        except Exception:
+            self._log("record launch error (%s): %s" % (sess.name, traceback.format_exc()))
+        self._log("session %s: claude CLI failed to start%s — %s"
+                  % (sess.name, " (account usage limit)" if rec["limit"] else "", text))
+        self._poke()
+
+    def _clear_launch_error(self, sid: str) -> None:
+        """Drop a recorded launch failure — called from the connect that DISPROVES it. Read-then-write so
+        a session that never failed doesn't churn the reg on every reconnect."""
+        try:
+            if not (read_reg(self.state_dir, sid) or {}).get("launchError"):
+                return
+            self._update_reg(sid, launchError=None)
+        except Exception:
+            self._log("clear launch error (%s): %s" % (sid, traceback.format_exc()))
+        self._poke()
+
+    def launch_error(self, sid: str):
+        """The reason this session's CLI could not start, or None — {text, at, limit}. The kernel reads
+        it for the chat's error card and for the usage-limit queue hold (see SessionBackend.launch_error).
+
+        A MISSING SDK outranks any per-session record: it is true of every session immediately, needs no
+        session to have died to be known, and it is the actionable one."""
+        if self._sdk_missing:
+            return {"text": SDK_MISSING_TEXT, "at": 0, "limit": False, "dep": True}
+        try:
+            rec = (read_reg(self.state_dir, str(sid)) or {}).get("launchError")
+        except Exception:
+            return None
+        return rec if isinstance(rec, dict) and rec.get("text") else None
 
     def _on_session_gone(self, sess: SdkSession):
         with self._lock:

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -82,6 +82,17 @@ class SessionBackend(ABC):
         (the known tmux gap in plans/clear-episodes.md)."""
         return None
 
+    def launch_error(self, sid: str):
+        """Why this session's CLI could NOT start — {text, at, limit} — or None when it started fine (and
+        on a backend with no such signal). A launch failure is otherwise invisible: the session settles
+        'waiting', the message the user typed stays in the queue, and nothing anywhere says why (the user
+        2026-07-28, whose send into an out-of-usage account simply never flipped to working). `limit` is
+        True when the cause is the ACCOUNT being out of usage rather than a broken session — the queue is
+        parked, not lost, and the kernel says so (_limit_hold) instead of showing a red error.
+
+        tmux keeps the None default: its CLI launches into a pane where the failure is on screen."""
+        return None
+
     def forwards_sends(self) -> bool:
         """True if this backend accepts a plain composer send at ANY time — even mid-turn — and manages its
         own delivery: forwarding the message to the model at the next tool boundary, folding several queued

--- a/tests/test_kernel_limit_queue.py
+++ b/tests/test_kernel_limit_queue.py
@@ -243,6 +243,45 @@ class LimitDrain(_Base):
             km._set_retry_paused(False)
 
 
+class LimitThatBlocksTheLaunchItself(_Base):
+    """The case usage.json structurally CANNOT see (the user 2026-07-28): usage.json is written from a
+    RateLimitEvent the CLI streams once CONNECTED, so a limit that refuses the connect blocks its own
+    reporting. With no other source the hold went blind on a fresh install — the message parked in the
+    SDK queue with nothing to explain it and the session sat 'waiting'. The refused launch IS the event."""
+
+    def _launch(self, rec):
+        km._launch_error = lambda sid: rec
+
+    def tearDown(self):
+        km._launch_error = self._saved_launch
+        super().tearDown()
+
+    def setUp(self):
+        super().setUp()
+        self._saved_launch = km._launch_error
+
+    def test_a_launch_the_limit_refused_holds_the_queue(self):
+        self._launch({"text": "You've hit your session limit · resets 4:00pm", "at": 1, "limit": True})
+        hold = km._limit_hold(SID)
+        self.assertEqual(hold["reason"], "limit")
+        self.assertIsNone(hold["resetsAt"], "the CLI reports a wall clock, not an epoch — promise no countdown")
+        self.assertIn("session limit", hold["detail"], "the CLI's own words ride along one level deeper")
+
+    def test_the_held_message_is_parked_not_sent(self):
+        self._launch({"text": "You've hit your session limit · resets 4:00pm", "at": 1, "limit": True})
+        km._send_or_park(self.be, SID, "pick the migration back up", echo="human")
+        self.assertEqual(self.be.calls, [], "sending into an account that cannot serve just buys an error")
+        self._launch(None)                     # the window reopened; the next connect cleared the record
+        km._apply_pending_ops()
+        self.assertEqual(self.be.calls, [("send", "pick the migration back up")])
+
+    def test_a_broken_install_is_not_a_hold(self):
+        # a missing dependency is damage, not a wait — it gets the error card, and must not silently
+        # park input forever behind a limit that does not exist
+        self._launch({"text": "romp's Agent SDK backend isn't installed", "at": 1, "limit": False})
+        self.assertIsNone(km._limit_hold(SID))
+
+
 class HeldQueueIsVisible(unittest.TestCase):
     """A held queue must never be silent — the bubbles say what they're waiting for."""
 

--- a/tests/test_sdk_launch_error.py
+++ b/tests/test_sdk_launch_error.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""A session that CANNOT START says why — instead of swallowing every message sent to it.
+
+The failure this closes (the user 2026-07-28, on a fresh install): romp-sdk-setup had bailed on that
+machine (a python3 with no ensurepip, so the venv was never built), the kernel logged ONE stderr line and
+built the SDK backend anyway, and every SDK session then accepted messages it could never run. From the
+user's side: a message sent to a session did nothing at all — no flip to working, no error — a brand-new
+session behaved the same, and the model/effort readouts and the usage bars stayed blank (all three publish
+only AFTER a connect that could never happen). tmux sessions worked throughout, so it read as an outage at
+Anthropic rather than a missing local dependency.
+
+What is pinned here:
+  1. the backend detects its own missing dependency ONCE, up front, and reports EVERY session as unable to
+     start — no session has to die first for the user to be told;
+  2. the text names the REMEDY (bin/romp-sdk-setup), not the symptom, and never a bare ModuleNotFoundError;
+  3. a launch failure recorded on a session survives on the registry (the thread that saw it is dying) and
+     is cleared by the connect that DISPROVES it, never by a timer;
+  4. queued messages do NOT vanish when the session's thread dies — the persisted queue answers
+     pending_queued, so what the user typed stays on screen;
+  5. the account-out-of-usage flavor is classified apart, because that queue is parked, not broken.
+
+SYNTHETIC fixtures only (placeholder ids, hostname TESTHOST).
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+sb = SourceFileLoader("romp_sdk_backend_launcherr", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+OTHER = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+class _FakeSess:
+    """The two attributes _record_launch_error reads off a session."""
+
+    def __init__(self, sid=SID, name="api"):
+        self.sid = sid
+        self.name = name
+
+
+def _backend(state, missing=False):
+    saved = sb.sdk_importable
+    sb.sdk_importable = lambda: not missing
+    try:
+        return sb.SdkBackend(state, "/bin/true", lambda *a, **k: None)
+    finally:
+        sb.sdk_importable = saved
+
+
+class MissingDependencyIsReportedForEverySession(unittest.TestCase):
+    """The dep is checked at construction, so the report needs no session to have crashed first."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.state = self.td.name
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def test_every_session_reports_unable_to_start(self):
+        be = _backend(self.state, missing=True)
+        for sid in (SID, OTHER):
+            err = be.launch_error(sid)
+            self.assertIsNotNone(err, "a session that cannot possibly run must not read as fine")
+            self.assertFalse(err["limit"], "a missing dependency is not a usage limit")
+
+    def test_the_text_names_the_remedy_not_the_symptom(self):
+        err = _backend(self.state, missing=True).launch_error(SID)
+        self.assertIn("romp-sdk-setup", err["text"],
+                      "the user needs the command to run, not the name of a python module")
+        self.assertNotIn("ModuleNotFoundError", err["text"])
+        self.assertIn("tmux", err["text"], "say what still works — tmux sessions are unaffected")
+
+    def test_a_healthy_install_reports_nothing(self):
+        self.assertIsNone(_backend(self.state, missing=False).launch_error(SID))
+
+
+class RecordedLaunchFailures(unittest.TestCase):
+    """A failure the thread saw on its way out has to outlive the thread — so it lands on the registry."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.be = _backend(self.td.name, missing=False)
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def _reg(self, sid=SID):
+        return sb.read_reg(Path(self.td.name), sid) or {}
+
+    def test_an_import_failure_records_the_remedy(self):
+        self.be._record_launch_error(_FakeSess(), ImportError("No module named 'claude_agent_sdk'"))
+        rec = self._reg()["launchError"]
+        self.assertIn("romp-sdk-setup", rec["text"])
+        self.assertTrue(rec["dep"])
+        self.assertEqual(self.be.launch_error(SID)["text"], rec["text"])
+
+    def test_an_ordinary_failure_keeps_its_own_text(self):
+        self.be._record_launch_error(_FakeSess(), RuntimeError("claude exited with code 1"))
+        rec = self._reg()["launchError"]
+        self.assertIn("claude exited with code 1", rec["text"])
+        self.assertFalse(rec["limit"], "a plain crash is not a usage limit")
+
+    def test_the_connect_that_disproves_it_clears_it(self):
+        self.be._record_launch_error(_FakeSess(), RuntimeError("transport closed"))
+        self.assertIsNotNone(self.be.launch_error(SID))
+        self.be._clear_launch_error(SID)
+        self.assertIsNone(self.be.launch_error(SID),
+                          "the record clears on the connect that disproves it, never on a timer")
+
+    def test_clearing_a_session_that_never_failed_is_a_no_op(self):
+        self.be._clear_launch_error(SID)
+        self.assertIsNone(self.be.launch_error(SID))
+
+
+class LaunchFailureText(unittest.TestCase):
+    """Pick the line that actually names the cause, and know a usage limit when the CLI states one."""
+
+    def test_the_clis_own_stderr_wins_over_the_exception_repr(self):
+        exc = RuntimeError("Command failed")
+        exc.stderr = "You've hit your session limit · resets 4:00pm (America/Los_Angeles)"
+        self.assertIn("session limit", sb.launch_failure_text(exc))
+
+    def test_a_long_stderr_dump_is_bounded(self):
+        exc = RuntimeError("boom")
+        exc.stderr = "x" * 5000
+        self.assertLessEqual(len(sb.launch_failure_text(exc)), 601, "this text lands in a chat card")
+
+    def test_a_bare_exception_still_yields_text(self):
+        self.assertIn("ValueError", sb.launch_failure_text(ValueError("no executable found")))
+
+    def test_usage_limits_are_classified_apart_from_breakage(self):
+        self.assertTrue(sb.is_launch_limit("You've hit your session limit · resets 4:00pm"))
+        self.assertTrue(sb.is_launch_limit("usage limit reached"))
+        self.assertFalse(sb.is_launch_limit("claude: command not found"))
+        self.assertFalse(sb.is_launch_limit(""))
+
+
+class QueuedMessagesSurviveTheSessionsDeath(unittest.TestCase):
+    """What the user typed must stay on screen when the CLI dies — it is still owed to them."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.be = _backend(self.td.name, missing=False)
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def test_the_persisted_queue_answers_when_no_session_is_running(self):
+        typed = "set up the deploy script for the notes-api"
+        self.be._update_reg(SID, queue=[typed])
+        self.assertEqual(self.be.pending_queued(SID), [typed],
+                         "a dead thread must not make the user's message vanish from the chat")
+
+    def test_a_session_with_no_queue_reports_nothing(self):
+        self.be._update_reg(SID, queue=[])
+        self.assertEqual(self.be.pending_queued(SID), [])
+        self.assertEqual(self.be.pending_queued(OTHER), [])
+
+    def test_a_corrupt_queue_mirror_does_not_crash_the_chat(self):
+        self.be._update_reg(SID, queue="not a list")
+        self.assertEqual(self.be.pending_queued(SID), [])
+        self.be._update_reg(OTHER, queue=[None, "", "keep me", 7])
+        self.assertEqual(self.be.pending_queued(OTHER), ["keep me"])
+
+
+class ContractConformance(unittest.TestCase):
+    """launch_error is part of the backend contract, with a None default for tmux."""
+
+    def test_the_abc_defaults_to_no_known_failure(self):
+        mod = SourceFileLoader(
+            "romp_session_backend_launcherr",
+            os.path.join(BIN, "romp_session_backend.py")).load_module()
+        self.assertIsNone(mod.SessionBackend.launch_error(object(), SID),
+                          "a backend whose CLI launches into a visible pane reports nothing here")
+
+
+class KernelSurfaces(unittest.TestCase):
+    """The kernel side: the error reaches the chat, and a usage-limit launch parks the queue instead."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.kernel_src = Path(BIN).parent.joinpath("kernel", "kernel.py").read_text()
+
+    def test_the_chat_raises_a_card_for_a_launch_failure(self):
+        self.assertIn("_lerr = _launch_error(sid)", self.kernel_src,
+                      "the chat build must ask the backend why the session could not start")
+        self.assertIn('"This session\'s claude process could not start — %s" % _lerr["text"]',
+                      self.kernel_src)
+        self.assertIn('_lerr["text"] if _lerr.get("dep")', self.kernel_src,
+                      "a missing dependency already reads as a sentence — don't wrap it in a second one")
+
+    def test_a_usage_limit_launch_parks_the_queue_instead_of_erroring(self):
+        self.assertIn('if _lerr and not _lerr.get("limit")', self.kernel_src,
+                      "a parked queue is a wait, not damage — it must not also raise a red card")
+        self.assertIn('_le = _launch_error(sid)', self.kernel_src,
+                      "_limit_hold reads the launch that the limit refused — usage.json cannot see it")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -197,7 +197,11 @@ test("the kernel parks every drive op while the account can't serve one, and dra
 });
 
 test("a held queue says WHY it isn't moving, and outranks the pending-ask note", () => {
-  assert.match(RENDER, /held\?: \{ reason: string; resetsAt\?: number \| null; what: string \}/);
+  assert.match(RENDER, /held\?: \{ reason: string; resetsAt\?: number \| null; what: string; detail\?: string \}/);
+  // `detail` carries the CLI's own sentence when the limit REFUSED THE LAUNCH (the user 2026-07-28) —
+  // that flavor reports a wall-clock reset, not an epoch, so it has no countdown to render and the exact
+  // words go one level deeper instead of into the one-line head.
+  assert.match(RENDER, /if \(held\?\.detail\) label\.title = held\.detail;/);
   assert.match(RENDER, /const askNote = \(pendingAsk \? " · sends after you answer" : ""\);/);
   assert.match(RENDER, /\? ` · \$\{held\.what\}` \+ \(held\.resetsAt \? ` · in \$\{fmtReset\(held\.resetsAt, Math\.floor\(Date\.now\(\) \/ 1000\)\)\}` : ""\)/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -121,7 +121,7 @@ type ChatEvent = (
   // `held` DOES come from the kernel (_limit_hold): the queue is stuck on the ACCOUNT rather than on this
   // session — a usage limit or a monthly spend cap holds every send — so the head names what it is waiting
   // for, and how long is left when the API reported a reset (the user 2026-07-24).
-  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string } }
+  | { kind: "queued"; texts: { md: string; followUp?: boolean; goal?: string; fuCtx?: string; idx?: number; park?: number; cancelable?: boolean; optimistic?: boolean }[]; ts?: string; uuid?: string; bare?: boolean; held?: { reason: string; resetsAt?: number | null; what: string; detail?: string } }
   // The turn stopped on an API error (event-based: transcript isApiErrorMessage). The session is BLOCKED
   // until retried — a red-dot card at the bottom with a Retry button (the user 2026-06-16).
   | { kind: "apiError"; text: string; status?: number; ts?: string; uuid?: string }
@@ -2409,6 +2409,10 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     const label = el("span", "queued-count");
     label.dataset.why = why;      // the ✕'s recount rewrites the count and keeps this suffix as-is
     label.textContent = queuedCountText(n, nCmd) + why;
+    // `detail` is the CLI's OWN sentence about the limit (it carries the reset time as a wall clock, which
+    // is why that flavor has no epoch to count down to). One level deeper on hover, per the compact-by-
+    // default rule — the head keeps its one-line reason.
+    if (held?.detail) label.title = held.detail;
     head.appendChild(label);
     turn.appendChild(head);
   }


### PR DESCRIPTION
## The bug

A fresh install where `romp-sdk-setup` had bailed (a python3 with no `ensurepip`, so the SDK venv was never built) left the kernel logging **one stderr line** and building the SDK backend anyway. Every SDK session then accepted messages it could never run.

From the user's side, nothing pointed at the cause:

- a message sent to a session did nothing — no flip to working, no error;
- a brand-new session behaved identically;
- the model/effort readouts and the usage bars stayed blank (all three publish only *after* a connect that could never happen);
- tmux sessions worked throughout, so it read as an outage at Anthropic.

The kernel journal had `ModuleNotFoundError: No module named 'claude_agent_sdk'` on every session, every boot. Nothing surfaced it.

## The fix

The backend checks its own dependency **once, at construction**, and reports every session as unable to start — no session has to die first for the user to be told. The text names the remedy (`bin/romp-sdk-setup`) rather than a bare `ModuleNotFoundError`, and says what still works (tmux).

A per-session launch failure is recorded on the **registry** — the thread that saw it is dying — and cleared by the connect that **disproves** it, never by a timer. The chat raises it on the same red card an API error uses: this session is stopped, here is why, here is Retry.

Two holes the same incident exposed:

- **Queued messages vanished from the chat when the session's thread died.** `pending_queued` only answered from memory, so a dead thread took the user's unsent message off screen. It now falls back to the persisted queue — the same list, and what the boot reconcile re-delivers.
- **A usage limit that refuses the CONNECT blocks its own reporting.** `usage.json` is written from a `RateLimitEvent` the CLI streams once *connected*, so `_limit_hold` was structurally blind to a limit that prevents connecting. The refused launch is now that arm's event: the queue parks and says what it is waiting for, with the CLI's own words one level deeper (that flavor reports a wall clock, not an epoch, so it promises no countdown).

Also: `pick_python` stopped at 3.13, so a machine whose only python is newer fell through to whatever `python3` happens to be. Kept in sync across `romp-serve` and `romp-sdk-setup`.

## Tests

New `tests/test_sdk_launch_error.py` (17 tests) pins: the dependency is reported for every session; the text names the remedy and never a bare `ModuleNotFoundError`; a recorded failure survives on the registry and clears only on a disproving connect; queued messages survive the session's death; the usage-limit flavor is classified apart from breakage. `tests/test_kernel_limit_queue.py` gains the launch-refused-by-limit arm (parks rather than sends, and a broken install is *not* a hold).

Full Python suite green; 1368 webview tests green. `bats` isn't installed on this machine, so the shell suite is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)