### PR TITLE
Card bell moves to the top-right; lane toggles fold into a gear menu

### DIFF
--- a/tests/test_postal_isolation.py
+++ b/tests/test_postal_isolation.py
@@ -82,9 +82,14 @@ class WiringAcrossSurfaces(unittest.TestCase):
                       "the kernel must publish postalServiceOff in the session boot so the timeline can render it")
 
     def test_timeline_view_draws_and_toggles_the_mailbox(self):
+        # Since 2026-07-28 the mailbox lives in the lane GEAR's drop-down (LANE_TOGGLES) rather than as
+        # its own lane icon — the row still draws the mailboxIcon and toggles postalServiceOff through
+        # the same _setSessionFlag persistence.
         src = open(os.path.join(os.path.dirname(BIN), "ui", "romp-timeline-view.js")).read()
-        self.assertIn("mailboxIcon", src, "the timeline draws a (monochrome) mailbox icon")
-        self.assertIn("_setSessionFlag(s, 'postalServiceOff'", src, "clicking the mailbox toggles the postalServiceOff flag")
+        self.assertIn("mailboxIcon", src, "the gear menu draws the (monochrome) mailbox icon")
+        self.assertIn("flag: 'postalServiceOff', label: 'Postal service', icon: mailboxIcon", src,
+                      "the gear menu row toggles the postalServiceOff flag")
+        self.assertIn("this._setSessionFlag(s, t.flag, next);", src, "menu rows persist via _setSessionFlag")
 
 
 if __name__ == "__main__":

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -386,6 +386,36 @@ function bellIcon(off, cx, cy, color) {
   if (off) g.appendChild(el('line', { x1: cx - 6.5, y1: cy + 4.5, x2: cx + 6.5, y2: cy - 4.5, stroke: color, 'stroke-width': 1.4, 'stroke-linecap': 'round' }));
   return g;
 }
+// The per-lane SETTINGS GEAR (the user 2026-07-28, round 3): the three toggle icons above no longer
+// draw on the lane — three always-on icons crowded the row — so ONE gear opens them as a drop-down
+// (_openLaneMenu), each row wearing its icon, its state, and a plain-language line. Drawn like its
+// neighbors: a toothed ring + a filled hub, monochrome.
+function gearIcon(cx, cy, color) {
+  const g = el('g', { 'pointer-events': 'none' });
+  g.appendChild(el('circle', { cx: cx, cy: cy, r: 3.9, fill: 'none', stroke: color, 'stroke-width': 1.2 }));
+  g.appendChild(el('circle', { cx: cx, cy: cy, r: 1.4, fill: color, stroke: 'none' }));
+  for (let i = 0; i < 8; i++) {
+    const a = (Math.PI / 4) * i;
+    g.appendChild(el('line', { x1: cx + 4.4 * Math.cos(a), y1: cy + 4.4 * Math.sin(a),
+      x2: cx + 6.1 * Math.cos(a), y2: cy + 6.1 * Math.sin(a),
+      stroke: color, 'stroke-width': 1.5, 'stroke-linecap': 'round' }));
+  }
+  return g;
+}
+// The gear menu's rows, one per per-session flag. `enabled` reads the toggle's MEANING off the session
+// (hideFromFeed/postalServiceOff are off-flags; notify is an on-flag), `value` maps a desired
+// enabled-state back to the flag value _setSessionFlag persists.
+const LANE_TOGGLES = [
+  { flag: 'hideFromFeed', label: 'Feed cards', icon: feedCheckIcon,
+    enabled: (s) => !s.hideFromFeed, value: (enable) => !enable,
+    desc: 'its prompts make cards on the feed; off, the lane stays here but new prompts mint none' },
+  { flag: 'postalServiceOff', label: 'Postal service', icon: mailboxIcon,
+    enabled: (s) => !s.postalServiceOff, value: (enable) => !enable,
+    desc: 'visible to peer sessions, can send and receive their messages; off = fully isolated' },
+  { flag: 'notify', label: 'Notifications', icon: bellIcon,
+    enabled: (s) => !!s.notify, value: (enable) => enable,
+    desc: 'system notification when its work blocks on you or completes' },
+];
 // Model + effort choices come from the kernel's /models — the ONE list shared with the chat statusline picker
 // and the judge-tier settings (the user 2026-07-02: no hardcoded model list per surface). Populated in place
 // on load so _openMetaMenu keeps its reference; the lane picker appends its own 'Default' sentinel (not a model).
@@ -713,9 +743,10 @@ class TimelinePanel {
 
     // model/effort drop-down pickers: the open menu element + per-lane optimistic "pending" cues
     // ('sid:kind' → {was, until}) that dim a word until the tmux var actually flips (or 20s elapses).
-    this._metaMenu = null; this._metaPending = {};
-    this._onDocClick = () => this._closeMetaMenu();
-    this._onDocKey = (e) => { if (e.key === 'Escape') this._closeMetaMenu(); };
+    // _laneMenu = the per-lane GEAR drop-down (feed/postal/notify toggles — the user 2026-07-28).
+    this._metaMenu = null; this._metaPending = {}; this._laneMenu = null;
+    this._onDocClick = () => { this._closeMetaMenu(); this._closeLaneMenu(); };
+    this._onDocKey = (e) => { if (e.key === 'Escape') { this._closeMetaMenu(); this._closeLaneMenu(); } };
     document.addEventListener('click', this._onDocClick);
     document.addEventListener('keydown', this._onDocKey);
 
@@ -823,6 +854,7 @@ class TimelinePanel {
     document.removeEventListener('click', this._onDocClick);
     document.removeEventListener('keydown', this._onDocKey);
     this._closeMetaMenu();
+    this._closeLaneMenu();
     if (this.tip) this.tip.remove();
   }
 
@@ -2093,9 +2125,62 @@ class TimelinePanel {
     this._metaMenu = menu;
   }
 
-  // (The old per-lane settings drop-down + its flag list were removed (the user 2026-06-22): with a single
-  // flag, the lane EYE toggles hideFromFeed DIRECTLY on click — no menu. See the render below; the flag is
-  // still persisted by _setSessionFlag.)
+  _closeLaneMenu() { if (this._laneMenu) { this._laneMenu.remove(); this._laneMenu = null; } }
+
+  // The per-lane settings drop-down is BACK (the user 2026-07-28, superseding their 2026-06-22 removal:
+  // that rule held for ONE flag, where a direct icon beat a menu — at THREE flags the icons crowded the
+  // lane). The gear opens one row per LANE_TOGGLES entry: the toggle's own icon (blue = on, slashed
+  // gray = off), its label + state word, and a plain-language line on what it does. Clicking a row
+  // toggles that flag with the SAME optimistic + sticky treatment as the old direct icons, and the menu
+  // stays open, repainting in place — it's a settings panel, not a command.
+  _openLaneMenu(s, anchorEl) {
+    const reopen = this._laneMenu && this._laneMenu._sid === s.id;
+    this._closeLaneMenu(); this._closeMetaMenu();
+    if (reopen) return;
+    // Styled inline like the meta menu (injectStyles can't add rules after a plugin reload).
+    const menu = document.body.createDiv();
+    menu.setAttribute('style', 'position:fixed;z-index:1001;width:280px;padding:4px;background:#1c2430;'
+      + 'border:1px solid #ffffff1f;border-radius:8px;box-shadow:0 8px 24px #00000066;font-size:12px;'
+      + 'color:#e6edf3;user-select:none;');
+    menu._sid = s.id;
+    menu.addEventListener('click', (e) => e.stopPropagation());   // inside clicks must not reach the doc closer
+    const build = () => {
+      menu.textContent = '';
+      for (const t of LANE_TOGGLES) {
+        const on = t.enabled(s);
+        const row = menu.createDiv();
+        row.setAttribute('style', 'display:flex;gap:9px;align-items:flex-start;padding:6px 9px;border-radius:5px;cursor:pointer;');
+        const ic = el('svg', { viewBox: '0 0 17 17', width: 15, height: 15 });
+        ic.setAttribute('style', 'flex:0 0 auto;margin-top:1px;' + (on ? '' : 'opacity:0.55;'));
+        ic.appendChild(t.icon(!on, 8.5, 8.5, on ? ROMP_BLUE : MODEL_FG));
+        row.appendChild(ic);
+        const body = row.createDiv();
+        body.setAttribute('style', 'display:flex;flex-direction:column;line-height:1.35;min-width:0;');
+        const lab = body.createDiv({ text: t.label + ' — ' + (on ? 'on' : 'off') });
+        lab.setAttribute('style', on ? '' : 'opacity:0.75;');
+        const sub = body.createDiv({ text: t.desc });
+        sub.setAttribute('style', 'opacity:0.55;font-size:11px;');
+        row.addEventListener('mouseenter', () => { row.style.background = '#ffffff14'; });
+        row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });
+        row.addEventListener('click', (e) => {
+          e.stopPropagation();
+          const next = t.value(!on);                 // the flag value that flips this toggle
+          s[t.flag] = next;                          // optimistic …
+          (this._pendingFlags[s.id] = this._pendingFlags[s.id] || {})[t.flag] = next;   // … sticky until the kernel confirms
+          this._setSessionFlag(s, t.flag, next);
+          this._reconcilePendingFlags();
+          this.draw();
+          build();                                   // repaint states in place; the panel stays open
+        });
+      }
+    };
+    build();
+    const r = anchorEl.getBoundingClientRect();
+    const left = Math.min(Math.round(r.left), (window.innerWidth || 9999) - 300);   // clamp on-screen
+    menu.style.left = Math.max(6, left) + 'px';
+    menu.style.top = Math.round(r.bottom + 4) + 'px';
+    this._laneMenu = menu;
+  }
 
   // Optimistic per-session view flags (the feed checkbox → hideFromFeed). A click flips the flag locally AND
   // fires _setSessionFlag, but the kernel's confirming rebuild takes ~1s and ANY routine push that lands in
@@ -2308,10 +2393,11 @@ class TimelinePanel {
     // 2026-06-19). Reserve its width only when there IS a live lane, so an all-historical view keeps the
     // tight [name][model] layout.
     const EYE_W = 13, EYE_GAP = 6, anyLive = vis.some((s) => s.live);
-    const eyeColX = PADL + Math.ceil(maxName) + COLGAP;                              // [name] [✓feed] [📫postal] [bell] [model+effort] [chip] [ctx]
-    const mailColX = eyeColX + (anyLive ? EYE_W + EYE_GAP : 0);                      // postal-isolation mailbox, just right of the feed checkbox
-    const bellColX = mailColX + (anyLive ? EYE_W + EYE_GAP : 0);                     // notification bell, just right of the mailbox (the user 2026-07-28)
-    const modelColX = bellColX + (anyLive ? EYE_W + EYE_GAP : 0);
+    const eyeColX = PADL + Math.ceil(maxName) + COLGAP;                              // [name] [gear] [model+effort] [chip] [ctx]
+    // ONE settings-gear column again (the user 2026-07-28, round 3): the feed checkbox, postal mailbox
+    // and notification bell folded into the gear's drop-down (LANE_TOGGLES), so the lane is back to a
+    // single icon column between the name and the model.
+    const modelColX = eyeColX + (anyLive ? EYE_W + EYE_GAP : 0);
     const effortColX = modelColX + Math.ceil(maxModelPiece) + effortGap;   // fixed left edge for EVERY lane's effort word
     const chipColX = modelColX + (maxModel > 0 ? Math.ceil(maxModel) + COLGAP : 0);
     const ctxColX = chipColX + (maxChip > 0 ? Math.ceil(maxChip) + COLGAP : 0);
@@ -2631,109 +2717,27 @@ class TimelinePanel {
       nhit.addEventListener('mouseenter', () => { rowHit.setAttribute('fill', '#ffffff'); rowHit.setAttribute('fill-opacity', '0.035'); for (const f of fadedEls) f.el.setAttribute('fill', f.full); });
       nhit.addEventListener('mouseleave', () => { rowHit.setAttribute('fill', 'transparent'); rowHit.removeAttribute('fill-opacity'); for (const f of fadedEls) f.el.setAttribute('fill', f.faded); });
       svg.appendChild(nhit);
-      // per-session feed show/hide CHECKBOX (live lanes only): one click toggles hideFromFeed directly —
-      // checked = on the feed (default), struck-through + more faded = off it. Always GRAY; the OFF state is
-      // de-emphasised (more faded), never highlighted (the user 2026-06-22). No menu.
+      // per-session settings GEAR (live lanes only — the user 2026-07-28, round 3): the feed checkbox,
+      // postal mailbox and notification bell no longer draw on the lane (three always-on icons crowded
+      // it) — ONE gear opens them as a drop-down with a labelled, explained row per toggle
+      // (_openLaneMenu / LANE_TOGGLES). Same hit-rect + showTip treatment as the old icons; opens on
+      // POINTERDOWN (a redraw between mousedown and mouseup would eat a plain click).
       if (s.live) {
-        const off = !!s.hideFromFeed;
-        const cx = eyeColX + 5, cy = y + 0.5;
-        // The drawn checkbox is PURELY VISUAL (pointer-events:none): thin strokes are nearly unhittable, so a
-        // generous transparent <rect> over it is the real hit target (same trick the work bars use). The
-        // tooltip uses the shared showTip/hideTip (a native SVG <title> never shows — a redraw kills the
-        // hover before it appears; showTip freezes live-follow so it stays — the user 2026-06-22).
-        const dim = off ? '0.3' : '0.9';               // off = faded; on = a confident romp-blue (the user 2026-06-24)
-        const box = feedCheckIcon(off, cx, cy, off ? MODEL_FG : ROMP_BLUE);   // ON = romp blue, OFF = struck-out gray
-        box.setAttribute('opacity', dim);
-        svg.appendChild(box);
-        const hit = el('rect', { x: eyeColX - 4, y: y - 9, width: EYE_W + 8, height: 18, fill: 'transparent', 'pointer-events': 'all' });
-        hit.style.cursor = 'pointer';
-        hit.setAttribute('aria-label', off ? 'session off the feed' : 'session on the feed'); svg.appendChild(hit);
-        const tip = off
-          ? "Off the feed — click to put it back on<div style='opacity:.65;margin-top:2px'>only new prompts make cards; past ones won’t reappear</div>"
-          : "On the feed — click to take it off<div style='opacity:.65;margin-top:2px'>its prompts stop making cards; it stays on the timeline</div>";
-        hit.addEventListener('mouseenter', (e) => { box.setAttribute('opacity', '1'); this.showTip(tip, e); });
-        hit.addEventListener('mousemove', (e) => this.moveTip(e));
-        hit.addEventListener('mouseleave', () => { box.setAttribute('opacity', dim); this.hideTip(); });
-        // Toggle on POINTERDOWN, not click (the user 2026-06-23): the lane redraws on every poll, and a
-        // redraw landing between mousedown and mouseup replaces this hit-rect so the 'click' never fires —
-        // the toggle felt "sometimes unresponsive". pointerdown fires on press, before any redraw can interrupt.
-        hit.addEventListener('pointerdown', (e) => {
+        const gcx = eyeColX + 5, gcy = y + 0.5;
+        const gbox = gearIcon(gcx, gcy, MODEL_FG);
+        gbox.setAttribute('opacity', '0.75');
+        svg.appendChild(gbox);
+        const ghit = el('rect', { x: eyeColX - 4, y: y - 9, width: EYE_W + 8, height: 18, fill: 'transparent', 'pointer-events': 'all' });
+        ghit.style.cursor = 'pointer';
+        ghit.setAttribute('aria-label', 'session settings'); svg.appendChild(ghit);
+        const gtip = "Session settings<div style='opacity:.65;margin-top:2px'>feed cards, postal service, notifications</div>";
+        ghit.addEventListener('mouseenter', (e) => { gbox.setAttribute('opacity', '1'); this.showTip(gtip, e); });
+        ghit.addEventListener('mousemove', (e) => this.moveTip(e));
+        ghit.addEventListener('mouseleave', () => { gbox.setAttribute('opacity', '0.75'); this.hideTip(); });
+        ghit.addEventListener('pointerdown', (e) => {
           e.stopPropagation();
-          const next = !s.hideFromFeed;
-          s.hideFromFeed = next;                       // optimistic …
-          (this._pendingFlags[s.id] = this._pendingFlags[s.id] || {}).hideFromFeed = next;   // … and held STICKY across pushes until the kernel confirms (no flicker-back)
-          this._setSessionFlag(s, 'hideFromFeed', next);
           this.hideTip();
-          // Apply the optimistic flip onto the CURRENT this.data.sessions before drawing (the user 2026-06-24):
-          // a poll can swap this.data for fresh objects between the last render and this press, leaving the
-          // captured `s` stale — draw() then reads the NEW object's OLD value and the toggle looks dead ("changed
-          // it, but it failed"). Reconcile re-applies _pendingFlags onto the live objects draw() reads, so the
-          // flip always shows AND the kernel still gets it. Keyed by id, so object identity no longer matters.
-          this._reconcilePendingFlags();
-          this.draw();
-        });
-      }
-      // per-session POSTAL ISOLATION toggle (live lanes only): a mailbox icon just right of the feed
-      // checkbox; one click toggles postalServiceOff. Un-slashed = on the Romp Postal Service (default: visible to peers,
-      // can send + receive); slashed + more faded = isolated (hidden from list_agents, no messages in or out
-      // — for working privately). Same draw/hit/tooltip pattern as the feed checkbox; enforced in bin/romp-postal-service.
-      if (s.live) {
-        const moff = !!s.postalServiceOff;
-        const mcx = mailColX + 5, mcy = y + 0.5;
-        const mdim = moff ? '0.3' : '0.9';             // off = faded; on = a confident romp-blue (the user 2026-06-24)
-        const mbox = mailboxIcon(moff, mcx, mcy, moff ? MODEL_FG : ROMP_BLUE);   // ON = romp blue, OFF = struck-out gray
-        mbox.setAttribute('opacity', mdim);
-        svg.appendChild(mbox);
-        const mhit = el('rect', { x: mailColX - 4, y: y - 9, width: EYE_W + 8, height: 18, fill: 'transparent', 'pointer-events': 'all' });
-        mhit.style.cursor = 'pointer';
-        mhit.setAttribute('aria-label', moff ? 'session isolated from the Romp Postal Service' : 'session on the Romp Postal Service'); svg.appendChild(mhit);
-        const mtip = moff
-          ? "Isolated from the Romp Postal Service — click to reconnect<div style='opacity:.65;margin-top:2px'>hidden from peers; can’t send or receive messages</div>"
-          : "On the Romp Postal Service — click to isolate<div style='opacity:.65;margin-top:2px'>work privately: hidden from peers, no messages in or out</div>";
-        mhit.addEventListener('mouseenter', (e) => { mbox.setAttribute('opacity', '1'); this.showTip(mtip, e); });
-        mhit.addEventListener('mousemove', (e) => this.moveTip(e));
-        mhit.addEventListener('mouseleave', () => { mbox.setAttribute('opacity', mdim); this.hideTip(); });
-        mhit.addEventListener('pointerdown', (e) => {   // pointerdown, not click: a redraw between mousedown
-          e.stopPropagation();                          // and mouseup ate the click → "sometimes unresponsive"
-          const next = !s.postalServiceOff;
-          s.postalServiceOff = next;                            // optimistic …
-          (this._pendingFlags[s.id] = this._pendingFlags[s.id] || {}).postalServiceOff = next;   // … held sticky until the kernel confirms
-          this._setSessionFlag(s, 'postalServiceOff', next);
-          this.hideTip();
-          this._reconcilePendingFlags();   // apply onto the CURRENT objects draw() reads — a poll may have swapped
-          this.draw();                     // this.data mid-press, leaving `s` stale (see the feed checkbox above)
-        });
-      }
-      // per-session NOTIFICATION toggle (live lanes only, the user 2026-07-28): a bell just right of the
-      // mailbox. ON (romp blue) = the kernel fires an OS notification when this session's work blocks on
-      // you or completes; OFF (default: slashed + faded gray) = quiet. NOTE the inverted polarity vs the
-      // other two toggles: `notify` true is the ENABLED state, so off = !s.notify. Same draw/hit/tooltip/
-      // pointerdown pattern as the checkbox + mailbox; the kernel's feed-diff notifier enforces it.
-      if (s.live) {
-        const boff = !s.notify;
-        const bcx = bellColX + 5, bcy = y + 0.5;
-        const bdim = boff ? '0.3' : '0.9';             // off = faded; on = a confident romp-blue
-        const bbox = bellIcon(boff, bcx, bcy, boff ? MODEL_FG : ROMP_BLUE);   // ON = romp blue, OFF = struck-out gray
-        bbox.setAttribute('opacity', bdim);
-        svg.appendChild(bbox);
-        const bhit = el('rect', { x: bellColX - 4, y: y - 9, width: EYE_W + 8, height: 18, fill: 'transparent', 'pointer-events': 'all' });
-        bhit.style.cursor = 'pointer';
-        bhit.setAttribute('aria-label', boff ? 'notifications off for this session' : 'notifications on for this session'); svg.appendChild(bhit);
-        const btip = boff
-          ? "Notifications off — click to turn on<div style='opacity:.65;margin-top:2px'>get a system notification when its work blocks on you or completes</div>"
-          : "Notifications on — click to turn off<div style='opacity:.65;margin-top:2px'>notifies when its work blocks on you or completes</div>";
-        bhit.addEventListener('mouseenter', (e) => { bbox.setAttribute('opacity', '1'); this.showTip(btip, e); });
-        bhit.addEventListener('mousemove', (e) => this.moveTip(e));
-        bhit.addEventListener('mouseleave', () => { bbox.setAttribute('opacity', bdim); this.hideTip(); });
-        bhit.addEventListener('pointerdown', (e) => {   // pointerdown, not click: a redraw between mousedown
-          e.stopPropagation();                          // and mouseup ate the click → "sometimes unresponsive"
-          const next = !s.notify;
-          s.notify = next;                              // optimistic …
-          (this._pendingFlags[s.id] = this._pendingFlags[s.id] || {}).notify = next;   // … held sticky until the kernel confirms
-          this._setSessionFlag(s, 'notify', next);
-          this.hideTip();
-          this._reconcilePendingFlags();   // apply onto the CURRENT objects draw() reads — a poll may have swapped
-          this.draw();                     // this.data mid-press, leaving `s` stale (see the feed checkbox above)
+          this._openLaneMenu(s, ghit);
         });
       }
       // DEAD lane → a "Clear" pill just right of the struck name (the user 2026-07-02). A dead session lingers

--- a/ui/timeline-flags.test.ts
+++ b/ui/timeline-flags.test.ts
@@ -1,9 +1,10 @@
-// Per-session feed show/hide CHECKBOX on the timeline lane (the user 2026-06-22; a circular checkbox since
-// 2026-06-23, was an eye): a small gray box+check between the session name and the model. ON the feed
-// (default) = a checked ring; OFF the feed = the SAME checkbox struck through + MORE faded (de-emphasised,
-// never a highlight colour). ONE click toggles hideFromFeed directly — no popup menu. The timeline view has
-// no headless render harness for the lane header, so — like timeline-view.test.ts — pin the wiring at the
-// source level against the shared ui/romp-timeline-view.js (the same file the web dashboard serves verbatim).
+// Per-session toggles on the timeline lane. History: an EYE (2026-06-22) became a direct-toggle
+// checkbox, gained a postal mailbox (2026-06-23) and a notification bell (2026-07-28) — and at THREE
+// toggles the icons crowded the lane, so they folded into ONE settings GEAR whose drop-down lists each
+// toggle with its icon, state, and a plain-language line (the user 2026-07-28, round 3 — superseding
+// the 2026-06-22 "no menu" rule, which held for a single flag). The timeline has no headless render
+// harness for the lane header, so — like timeline-view.test.ts — pin the wiring at the source level
+// against the shared ui/romp-timeline-view.js (the same file the web dashboard serves verbatim).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -11,81 +12,60 @@ import * as path from "node:path";
 
 const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
 
-test("a per-session feed-checkbox column sits BETWEEN the name and the model (live lanes only)", () => {
+test("ONE gear column sits between the name and the model (live lanes only)", () => {
   assert.match(SRC, /const eyeColX = PADL \+ Math\.ceil\(maxName\) \+ COLGAP;/);
-  // business inserted a postal-isolation mailColX between the feed checkbox and the model (main 56ae453),
-  // and the notification bellColX joined right of the mailbox (the user 2026-07-28) — the model column
-  // hangs off bellColX now.
-  assert.match(SRC, /const mailColX = eyeColX \+ \(anyLive \? EYE_W \+ EYE_GAP : 0\);/);
-  assert.match(SRC, /const modelColX = bellColX \+ \(anyLive \? EYE_W \+ EYE_GAP : 0\);/);
-  assert.match(SRC, /if \(s\.live\) \{[\s\S]*?feedCheckIcon\(off, cx, cy, off \? MODEL_FG : ROMP_BLUE\)/);
+  assert.match(SRC, /const modelColX = eyeColX \+ \(anyLive \? EYE_W \+ EYE_GAP : 0\);/);
+  // the three separate icon columns are gone
+  assert.doesNotMatch(SRC, /const mailColX/, "the mailbox column folded into the gear");
+  assert.doesNotMatch(SRC, /const bellColX/, "the bell column folded into the gear");
+  assert.match(SRC, /if \(s\.live\) \{[\s\S]*?gearIcon\(gcx, gcy, MODEL_FG\)/);
 });
 
-test("the checkbox is DRAWN (a gray ring + a checkmark); the OFF state adds the same strike-through slash", () => {
-  // not an emoji glyph — an SVG circle ring + a polyline check, monochrome (stroke = color, no fill), so it
-  // stays crisp everywhere; the eye's almond+pupil is gone.
+test("the gear is DRAWN (toothed ring + filled hub) and opens the menu on POINTERDOWN (redraw-proof)", () => {
+  assert.match(SRC, /function gearIcon\(cx, cy, color\)/);
+  assert.match(SRC, /const ghit = el\('rect', \{[^}]*fill: 'transparent', 'pointer-events': 'all'/);
+  // pointerdown, not click: a lane redraw between mousedown and mouseup replaced the hit-rect so a
+  // plain 'click' never fired (the original direct-toggle lesson, 2026-06-23) — the menu opens on press
+  assert.match(SRC, /ghit\.addEventListener\('pointerdown', \(e\) => \{[\s\S]*?this\._openLaneMenu\(s, ghit\);/);
+  assert.match(SRC, /Session settings<div style='opacity:\.65;margin-top:2px'>feed cards, postal service, notifications<\/div>/);
+});
+
+test("the menu lists all three toggles with icons, state words, and plain-language explanations", () => {
+  assert.match(SRC, /const LANE_TOGGLES = \[/);
+  assert.match(SRC, /\{ flag: 'hideFromFeed', label: 'Feed cards', icon: feedCheckIcon,/);
+  assert.match(SRC, /\{ flag: 'postalServiceOff', label: 'Postal service', icon: mailboxIcon,/);
+  assert.match(SRC, /\{ flag: 'notify', label: 'Notifications', icon: bellIcon,/);
+  // each row explains itself (the user asked for an explanation per toggle, not bare labels)
+  assert.match(SRC, /its prompts make cards on the feed; off, the lane stays here but new prompts mint none/);
+  assert.match(SRC, /visible to peer sessions, can send and receive their messages; off = fully isolated/);
+  assert.match(SRC, /system notification when its work blocks on you or completes/);
+  // polarity is encoded per toggle: two off-flags, one on-flag
+  assert.match(SRC, /enabled: \(s\) => !s\.hideFromFeed, value: \(enable\) => !enable,/);
+  assert.match(SRC, /enabled: \(s\) => !!s\.notify, value: \(enable\) => enable,/);
+});
+
+test("menu rows toggle with the SAME optimistic + sticky + reconcile-before-draw treatment as the old icons", () => {
+  assert.match(SRC, /const next = t\.value\(!on\);/);
+  assert.match(SRC, /\(this\._pendingFlags\[s\.id\] = this\._pendingFlags\[s\.id\] \|\| \{\}\)\[t\.flag\] = next;/);
+  assert.match(SRC, /this\._setSessionFlag\(s, t\.flag, next\);\s*\n\s*this\._reconcilePendingFlags\(\);\s*\n\s*this\.draw\(\);/);
+  // the panel STAYS OPEN and repaints in place — it's a settings panel, not a command
+  assert.match(SRC, /this\.draw\(\);\s*\n\s*build\(\);/);
+  // inside clicks must not reach the document-level closer that dismisses the menu
+  assert.match(SRC, /menu\.addEventListener\('click', \(e\) => e\.stopPropagation\(\)\);/);
+});
+
+test("the gear menu closes on outside click / Escape / teardown, alongside the meta menu", () => {
+  assert.match(SRC, /_closeLaneMenu\(\) \{ if \(this\._laneMenu\) \{ this\._laneMenu\.remove\(\); this\._laneMenu = null; \} \}/);
+  assert.match(SRC, /this\._onDocClick = \(\) => \{ this\._closeMetaMenu\(\); this\._closeLaneMenu\(\); \};/);
+  assert.match(SRC, /if \(e\.key === 'Escape'\) \{ this\._closeMetaMenu\(\); this\._closeLaneMenu\(\); \}/);
+});
+
+test("the icon drawers survive (they render inside the menu now): ON = romp blue, OFF = slashed gray", () => {
   assert.match(SRC, /function feedCheckIcon\(off, cx, cy, color\)/);
-  assert.doesNotMatch(SRC, /function eyeIcon\b/, "the old eye drawer is replaced");
-  assert.match(SRC, /el\('circle', \{ cx: cx, cy: cy, r: 6, fill: 'none', stroke: color, 'stroke-width': 1\.2 \}\)/);
-  assert.match(SRC, /el\('path', \{ d: 'M'[\s\S]*?fill: 'none', stroke: color[\s\S]*?'stroke-linejoin': 'round' \}\)/);
-  // off → the same diagonal slash through it (the "hidden" affordance, unchanged from the eye)
-  assert.match(SRC, /if \(off\) g\.appendChild\(el\('line', \{ x1: cx - 6\.5[\s\S]*?stroke: color/);
-});
-
-test("ON = the romp-blue accent; OFF = a faded, struck-out gray (the user 2026-06-24, supersedes the all-gray rule)", () => {
-  // The user's earlier "always gray, never highlighted" (2026-06-23) is reversed: an ENABLED toggle now reads
-  // as the romp accent blue, a disabled one as the muted gray (MODEL_FG) + more faded + the strike slash.
-  assert.match(SRC, /const ROMP_BLUE = '#9cd2ff';/);
-  assert.match(SRC, /const dim = off \? '0\.3' : '0\.9';/);                          // off recedes; on is confident
-  assert.match(SRC, /const box = feedCheckIcon\(off, cx, cy, off \? MODEL_FG : ROMP_BLUE\);/);
-  assert.match(SRC, /const mbox = mailboxIcon\(moff, mcx, mcy, moff \? MODEL_FG : ROMP_BLUE\);/);   // mailbox matches
-  assert.match(SRC, /const mdim = moff \? '0\.3' : '0\.9';/);
-});
-
-test("the checkbox has a generous hit RECT and toggles hideFromFeed on POINTERDOWN (redraw-proof, no menu)", () => {
-  assert.match(SRC, /const hit = el\('rect', \{[^}]*fill: 'transparent', 'pointer-events': 'all'/);
-  // toggle on POINTERDOWN, not click (the user 2026-06-23): a lane redraw between mousedown and mouseup
-  // replaced the hit-rect so the 'click' never fired — pointerdown fires on press, before any redraw.
-  assert.match(SRC, /hit\.addEventListener\('pointerdown', \(e\) => \{[\s\S]*?s\.hideFromFeed = next;[\s\S]*?this\._setSessionFlag\(s, 'hideFromFeed', next\)/);
-  assert.doesNotMatch(SRC, /_openFlagMenu/, "the popup flag menu is removed");
-  assert.doesNotMatch(SRC, /const SESSION_FLAGS = \[/, "the flag list is removed (single flag, direct toggle)");
-});
-
-test("the toggle RECONCILES the optimistic flip onto the live objects before drawing (the stale-`s` race fix, 2026-06-24)", () => {
-  // The real "changed it but it failed / sometimes unresponsive" cause: a poll swaps this.data for fresh
-  // session objects (update() line `this.data = data`) between the last render and the press, so the captured
-  // `s` is stale — draw() reads the NEW object's OLD value and the toggle looks dead. Both handlers now call
-  // _reconcilePendingFlags() (which re-applies _pendingFlags onto the CURRENT this.data.sessions, keyed by id)
-  // immediately before draw(), so the flip always shows AND the kernel still receives it.
-  assert.match(SRC, /'hideFromFeed', next\);[\s\S]*?this\._reconcilePendingFlags\(\);[^\n]*\n\s*this\.draw\(\);/);
-  assert.match(SRC, /'postalServiceOff', next\);[\s\S]*?this\._reconcilePendingFlags\(\);[^\n]*\n\s*this\.draw\(\);/);
-});
-
-test("the lane bell toggles the session-level `notify` flag — inverted polarity, same pattern (the user 2026-07-28)", () => {
-  // a bell column sits between the mailbox and the model, live lanes only
-  assert.match(SRC, /const bellColX = mailColX \+ \(anyLive \? EYE_W \+ EYE_GAP : 0\);/);
-  assert.match(SRC, /const modelColX = bellColX \+ \(anyLive \? EYE_W \+ EYE_GAP : 0\);/);
-  // drawn (not an emoji): dome+skirt path + clapper arc, same slash convention as the other toggles
+  assert.match(SRC, /function mailboxIcon\(off, cx, cy, color\)/);
   assert.match(SRC, /function bellIcon\(off, cx, cy, color\)/);
-  // `notify` true is the ENABLED state (the other two flags are off-flags), so off = !s.notify
-  assert.match(SRC, /const boff = !s\.notify;/);
-  assert.match(SRC, /const bbox = bellIcon\(boff, bcx, bcy, boff \? MODEL_FG : ROMP_BLUE\);/);
-  // pointerdown + optimistic + sticky + reconcile-before-draw, exactly like the checkbox/mailbox
-  assert.match(SRC, /\(this\._pendingFlags\[s\.id\] = this\._pendingFlags\[s\.id\] \|\| \{\}\)\.notify = next;/);
-  assert.match(SRC, /'notify', next\);[\s\S]*?this\._reconcilePendingFlags\(\);[^\n]*\n\s*this\.draw\(\);/);
-  // the tooltip says what arming does (the kernel's feed-diff notifier fires the OS notification)
-  assert.match(SRC, /Notifications off — click to turn on/);
-  assert.match(SRC, /Notifications on — click to turn off/);
-});
-
-test("the tooltip uses the shared showTip/hideTip (a native SVG <title> never shows — a redraw kills it)", () => {
-  // the bug the user hit: no tooltip appeared. showTip freezes live-follow so the tip survives the timeline's
-  // frequent redraws; a native <title> needs ~1s of stable hover that a redraw interrupts.
-  assert.match(SRC, /mouseenter', \(e\) => \{ box\.setAttribute\('opacity', '1'\); this\.showTip\(tip, e\)/);
-  assert.match(SRC, /mousemove', \(e\) => this\.moveTip\(e\)/);
-  assert.match(SRC, /mouseleave', \(\) => \{ box\.setAttribute\('opacity', dim\); this\.hideTip\(\)/);
-  assert.match(SRC, /Off the feed — click to put it back on/);
-  assert.match(SRC, /On the feed — click to take it off/);
+  assert.match(SRC, /const ROMP_BLUE = '#9cd2ff';/);
+  assert.match(SRC, /t\.icon\(!on, 8\.5, 8\.5, on \? ROMP_BLUE : MODEL_FG\)/);
 });
 
 test("setSessionFlag still posts via the web host hook, with a Node-fs fallback for Obsidian", () => {
@@ -95,14 +75,8 @@ test("setSessionFlag still posts via the web host hook, with a Node-fs fallback 
   assert.match(SRC, /session-flags\.json/, "Obsidian/headless writes the same file the kernel reads");
 });
 
-test("the eye toggle is OPTIMISTIC + STICKY: held across pushes until the kernel confirms (no flicker-back) (the user 2026-06-22)", () => {
-  // the bug: click → eye flips → a routine push with the OLD flag reverts it for ~1s before the kernel's
-  // rebuild lands. Fix: record the clicked value in _pendingFlags and re-apply it on every update() until the
-  // incoming data matches it (then drop). So the click sticks instantly and never bounces.
+test("the sticky-flag machinery survives: pendingFlags reconcile on every update (no flicker-back)", () => {
   assert.match(SRC, /this\._pendingFlags = \{\};/);
-  assert.match(SRC, /\(this\._pendingFlags\[s\.id\] = this\._pendingFlags\[s\.id\] \|\| \{\}\)\.hideFromFeed = next;/);
-  // update() reconciles right after adopting the new data, BEFORE the early-returns/draw (one benign
-  // assignment — the cmapGrad stash — may sit between, but reconcile still comes first)
   assert.match(SRC, /this\.data = data;\s*\n(?:[^\n]*\n)?\s*this\._reconcilePendingFlags\(\);/);
   assert.match(SRC, /_reconcilePendingFlags\(\) \{[\s\S]*?if \(s\[flag\] === p\[flag\]\) delete p\[flag\];[\s\S]*?else s\[flag\] = p\[flag\];/);
 });

--- a/ui/webview/card-notify.test.ts
+++ b/ui/webview/card-notify.test.ts
@@ -11,11 +11,14 @@ import * as path from "node:path";
 const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
 
-test("every card carries the corner bell button, riding the CARD (absolute), not the flex rows", () => {
+test("every card carries the bell button at the TOP-right: floated FIRST in row1, in-flow (round 3)", () => {
+  // round 2's absolute bottom-right corner collided with grouped mode's right-floated Clear on compact
+  // cards (the user 2026-07-28, screenshot); a float ahead of the title claims the top-right corner and
+  // the text wraps around it — floats can't overlap by construction.
   assert.match(SRC, /const bellBtn = el\("button", "fask-bellbtn"\);/);
-  assert.match(SRC, /card\.append\(main, bellBtn\);/);
-  assert.match(CSS, /\.fitem\.ask \{ cursor: pointer; position: relative; \}/);   // the corner's anchor
-  assert.match(CSS, /\.fask-bellbtn \{\s*\n\s*position: absolute; right: 4px; bottom: 3px;/);
+  assert.match(SRC, /row1\.prepend\(bellBtn\);/);
+  assert.match(CSS, /\.fask-bellbtn \{\s*\n\s*float: right;/);
+  assert.doesNotMatch(CSS, /\.fask-bellbtn \{\s*\n\s*position: absolute/, "the overlapping absolute corner is gone");
 });
 
 test("off = hover-revealed slashed dim bell; armed (.on) = accent, always visible (mechanics, not status)", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -211,7 +211,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    the card's own session-colour border (the user 2026-07-15): that colour at 0.5α at rest (--card-r/g/b set
    inline per card), 0.8α when pinned, full opacity when focused/hovered. Order matters: .focused after .pinned
    so a pinned-AND-focused card shows the bright (full) border. */
-.fitem.ask { cursor: pointer; position: relative; }   /* relative: anchors the corner bell button */
+.fitem.ask { cursor: pointer; }
 .fitem.ask, .fitem.fgroup { border-color: rgba(var(--card-r, 255), var(--card-g, 255), var(--card-b, 255), 0.5); }
 .fitem.ask.pinned  { border-color: rgba(var(--card-r, 255), var(--card-g, 255), var(--card-b, 255), 0.85); }   /* pinned: bolded, persistent */
 /* effective focus: full-opacity same colour, thickened a touch by a 1px same-colour ring (a bolder highlight
@@ -1040,13 +1040,16 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .ctx-item-toggle .ctx-icon.off { color: var(--dim); }
 .ctx-item-body { display: flex; flex-direction: column; line-height: 1.25; }
 .ctx-item-sub { font-size: 0.82em; opacity: 0.6; }
-/* the corner bell BUTTON (the user 2026-07-28, round 2): pinned bottom-right in the card's own padding.
-   Off = slashed dim bell, hidden until the card is hovered (the tab-close idiom — a quiet feed stays
-   quiet); armed (.on) = accent bell, always visible. Accent = mechanics chrome, never a status colour. */
+/* the corner bell BUTTON (the user 2026-07-28, round 3): floated at the TOP-right of row1, ahead of
+   the title, so the text wraps around it — in-flow, never overlapping (round 2's absolute bottom-right
+   collided with grouped mode's right-floated Clear on compact cards; floats can't overlap by
+   construction). Off = slashed dim bell, hidden until the card is hovered (the tab-close idiom — a
+   quiet feed stays quiet); armed (.on) = accent bell, always visible. Accent = mechanics chrome,
+   never a status colour. */
 .fask-bellbtn {
-  position: absolute; right: 4px; bottom: 3px; z-index: 1;
+  float: right; margin: 0 0 2px 8px;
   display: flex; align-items: center; justify-content: center;
-  width: 20px; height: 20px; padding: 0; border: 0; border-radius: 5px;
+  width: 18px; height: 18px; padding: 0; border: 0; border-radius: 5px;
   background: transparent; color: var(--dim); cursor: pointer; opacity: 0;
   transition: opacity 0.12s ease;
 }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -754,9 +754,11 @@ function makeAskCard(it: AskItem): HTMLElement {
   // (the user 2026-06-20). origin sits left of the chips, matching the "from … · Followed up" reading order.
   // Clear is the rightmost, always-present control on this row (idwrap flex:1 pushes it to the edge).
   row2.append(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr);
-  // the corner bell BUTTON (the user 2026-07-28, round 2): bottom-right of the card, per-task arming.
-  // Session-level arming shows on the lane/tab instead, so an armed SESSION doesn't stamp every card.
-  // Absolutely positioned in the card's own padding — it never shoves the rows around.
+  // the corner bell BUTTON (the user 2026-07-28, round 3): TOP-right, floated FIRST in row1 so the
+  // title text wraps around it — in-flow, so it can never overlap anything (round 2's absolute
+  // bottom-right corner sat exactly where grouped mode floats Clear, and they collided on compact
+  // cards). Session-level arming shows on the lane/tab instead, so an armed SESSION doesn't stamp
+  // every card.
   const bellBtn = el("button", "fask-bellbtn");
   bellBtn.onclick = (ev: Event) => {
     ev.stopPropagation();                            // never open the modal under the toggle
@@ -764,6 +766,7 @@ function makeAskCard(it: AskItem): HTMLElement {
     const live = cur || it;
     setCardNotify(card, live, !cardNotifyOn(live));
   };
+  row1.prepend(bellBtn);   // float-first: it claims the top-right corner before the title flows
   // ROW 3 — Background (left) · Summary (right), always one line, opposite sides. Populated below, once the
   // toggle buttons exist (they're declared with the distiller sections). The time now trails the title (row1).
   const row3 = el("div", "fask-row3");
@@ -836,7 +839,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   const qbody = el("div", "fask-qbody");
   qbody.style.display = "none";
   main.append(row1, row2, row3, secs, qbody, awaitSpin, checklist, delegations);   // no expand button — body click opens the modal
-  card.append(main, bellBtn);   // the bell rides the CARD (absolute, bottom-right corner), outside the flex rows
+  card.append(main);
   // Follow-up lives in the modal now (the user 2026-06-10), not on the card.
 
   // title → locate the turn the card stands for. A normal card anchors on "prompt" (the originating


### PR DESCRIPTION
Two placement fixes from review of the notification bells:

**Feed card bell — top-right, in-flow.** The absolute bottom-right corner sat exactly where grouped mode floats its Clear button, and they collided on compact cards (user screenshot). The bell now floats first in the title row, claiming the top-right corner with the title text wrapping around it — in-flow, so it cannot overlap anything on any card shape. Hover-reveal/armed behavior unchanged.

**Timeline lane — one gear instead of three icons.** The feed checkbox, postal mailbox, and notification bell folded into a single per-lane settings gear. Its drop-down lists each toggle as a labelled row: the toggle's own icon (blue = on, slashed gray = off), an on/off state word, and a plain-language explanation. Rows toggle with the same optimistic-sticky-reconcile treatment the direct icons had, the panel stays open and repaints in place, and it dismisses on outside click/Escape like the model/effort picker whose chrome it shares.

Tests: timeline-flags suite rewritten for the gear era; card-notify pins updated for the float; the postal-isolation timeline pin updated to the menu path. 3362 py / 1381 node green, tsc clean. Verified headlessly with card and menu mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)