### PR TITLE
romp installs its own critical dependency, and refuses to fake a session

### DIFF
--- a/bin/romp-sdk-setup
+++ b/bin/romp-sdk-setup
@@ -40,17 +40,38 @@ fi
 
 # Debian/Ubuntu ship a python3 whose venv module cannot bootstrap pip: ensurepip is split into a
 # separate python3-venv package. `python3 -m venv` there still creates bin/python symlinks and THEN
-# fails, leaving a pip-less husk — so the naive "does bin/python exist" check below would sail past a
-# broken venv and die at the pip line with a bare "No such file or directory". Check the capability up
-# front and name the package (a fresh Ubuntu box, the user 2026-07-27, where this failed silently and
-# left the SDK backend — what plain `romp new` uses — dead with no visible reason).
-if ! "$PY" -c 'import ensurepip' >/dev/null 2>&1; then
-  echo "romp-sdk-setup: $PY has no 'ensurepip' — it cannot create a venv with pip in it." >&2
-  echo "  Debian/Ubuntu: sudo apt install python$(pyver "$PY")-venv   (or: sudo apt install python3-venv)" >&2
-  echo "  Then re-run: $0" >&2
-  echo "  romp still runs without this; only the SDK backend (plain \`romp new\`) is disabled." >&2
-  exit 1
-fi
+# fails, leaving a pip-less husk.
+#
+# This used to stop here and tell the user to `sudo apt install python3-venv`. But an installer cannot
+# sudo for you, so that turned romp's OWN critical dependency into homework — and the SDK backend is
+# what plain `romp new` uses, so a machine that skipped it has a romp that cannot start a session at
+# all (the user 2026-07-28, on a python3.14 box: install "succeeded", every session silently swallowed
+# its messages). So DON'T stop: build the venv without pip and bootstrap pip into it from PyPA's
+# canonical get-pip.py, which needs no root. Only when THAT fails too (offline, no fetcher) do we fall
+# back to naming the package. ROMP_GET_PIP_URL overrides the source; ROMP_NO_GET_PIP=1 opts out of the
+# fetch entirely for anyone who would rather install the OS package themselves.
+GET_PIP_URL="${ROMP_GET_PIP_URL:-https://bootstrap.pypa.io/get-pip.py}"
+
+fetch() {   # $1 url → $2 dest, with whichever fetcher the box has
+  if command -v curl >/dev/null 2>&1; then curl -fsSL --max-time 60 "$1" -o "$2"
+  elif command -v wget >/dev/null 2>&1; then wget -qO "$2" "$1"
+  else return 1; fi
+}
+
+make_venv() {
+  if "$PY" -c 'import ensurepip' >/dev/null 2>&1; then
+    "$PY" -m venv "$VENV"
+    return
+  fi
+  if [ -n "${ROMP_NO_GET_PIP:-}" ]; then return 1; fi
+  echo "romp-sdk-setup: $PY has no 'ensurepip' — bootstrapping pip from $GET_PIP_URL (no sudo needed)"
+  "$PY" -m venv --without-pip "$VENV" || return 1
+  [ -x "$VENV/bin/python" ] || return 1
+  fetch "$GET_PIP_URL" "$VENV/get-pip.py" || return 1
+  "$VENV/bin/python" "$VENV/get-pip.py" -q || return 1
+  rm -f "$VENV/get-pip.py"
+  [ -x "$VENV/bin/pip" ]
+}
 
 mkdir -p "$STATE"
 # a venv built with a DIFFERENT python than the kernel will run is worse than none — the kernel
@@ -64,7 +85,19 @@ fi
 if [ ! -x "$VENV/bin/python" ] || [ ! -x "$VENV/bin/pip" ]; then
   echo "romp-sdk-setup: creating venv at $VENV (python: $PY)"
   rm -rf "$VENV"
-  "$PY" -m venv "$VENV"
+  if ! make_venv; then
+    # Never leave a pip-less husk behind for the next run to trip over — that husk is what made the
+    # earlier failure surface as a bare "No such file or directory" at the pip line.
+    rm -rf "$VENV"
+    echo "romp-sdk-setup: could not build a venv with pip in it." >&2
+    if ! "$PY" -c 'import ensurepip' >/dev/null 2>&1; then
+      echo "  $PY has no 'ensurepip', and bootstrapping pip from $GET_PIP_URL did not work (offline?)." >&2
+      echo "  Debian/Ubuntu: sudo apt install python$(pyver "$PY")-venv   (or: sudo apt install python3-venv)" >&2
+    fi
+    echo "  Then re-run: $0" >&2
+    echo "  romp still runs without this; only the SDK backend (plain \`romp new\`) is disabled." >&2
+    exit 1
+  fi
 fi
 "$VENV/bin/pip" install -q --upgrade pip >/dev/null
 "$VENV/bin/pip" install -q --upgrade claude-agent-sdk

--- a/install.sh
+++ b/install.sh
@@ -251,17 +251,29 @@ fi
 # command that fixes it; romp is usable in every one of these states, which is why none of them
 # aborted the install. (Before this, all three failures were `|| echo` one-liners buried in the
 # scroll or, worse, a kernel stderr line that only reached the system journal.)
-if [[ -n "$ROMP_TMUX_MISSING$ROMP_SDK_MISSING$ROMP_EXT_FAILED" ]]; then
+# The SDK backend is NOT an optional piece: it is what plain `romp new` uses, so without it romp
+# starts, looks healthy, and cannot run a single session. Listing it among the optional ones let a
+# fresh install read as fine when it wasn't (the user 2026-07-28). It gets its own banner, above the
+# link, in the language of what the user can't do — and it is now rare, since romp-sdk-setup
+# bootstraps pip itself rather than sending anyone to sudo.
+if [[ -n "$ROMP_SDK_MISSING" ]]; then
+    echo
+    echo "  ══════════════════════════════════════════════════════════════════"
+    echo "   romp is installed but CANNOT START SESSIONS yet."
+    echo
+    echo "   Its Agent SDK backend — what \`romp new\` runs on — isn't provisioned."
+    echo "   Sessions you create will not run until it is."
+    echo
+    echo "   Fix it:  $ROMP_DIR/bin/romp-sdk-setup"
+    echo "            (see its message above if it needs a package installed first)"
+    echo "  ══════════════════════════════════════════════════════════════════"
+fi
+if [[ -n "$ROMP_TMUX_MISSING$ROMP_EXT_FAILED" ]]; then
     echo
     echo "  Some optional pieces aren't set up:"
     if [[ -n "$ROMP_EXT_FAILED" ]]; then
         echo "   ! The dashboard UI failed to build — the browser dashboard will come up blank."
         echo "     Retry:  (cd $ROMP_DIR/vscode-extension && npm install && node esbuild.js)"
-    fi
-    if [[ -n "$ROMP_SDK_MISSING" ]]; then
-        echo "   ! The Agent SDK backend isn't provisioned, so \`romp new\` can't start a session."
-        echo "     See the romp-sdk-setup message above for the package to install, then:"
-        echo "         $ROMP_DIR/bin/romp-sdk-setup"
     fi
     if [[ -n "$ROMP_TMUX_MISSING" ]]; then
         echo "   - tmux isn't installed, so terminal sessions (\`romp new -t\`, \`romp resume\`) are off."

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3293,6 +3293,12 @@ def _create_sdk_session(nm, cwd):
 # kernel runs unchanged when the SDK (or its dependency) is absent.
 _SDK_MCP = Path(os.path.expanduser("~/.claude/romp-postal.mcp.json"))
 _SDK_PROMPT = Path(os.path.expanduser("~/.claude/romp-session-prompt.md"))
+# What a session-creation refusal says when the Agent SDK isn't provisioned. ONE string for the browser
+# toast and the `romp new` JSON, because they are the same sentence to the same person: nothing was
+# created, and here is the single command that fixes it. Names the remedy, not the missing module.
+SDK_SETUP_HINT = ("Session not created: romp's Agent SDK backend isn't installed. "
+                  "Run bin/romp-sdk-setup, then try again. (tmux sessions still work.)")
+
 _sdk_backend = None   # None = not built yet, False = unavailable, else the SdkBackend
 _sdk_lock = threading.Lock()   # single-flight construction: the eager boot thread races handler
                                # threads, and an unlocked check-then-act built 2-3 duplicate backends
@@ -3319,9 +3325,29 @@ def _ensure_sdk_on_path():
 
 
 def _sdk():
-    """The SdkBackend singleton, or None when the module/dependency is unavailable."""
+    """The SdkBackend singleton, or None when the MODULE is unavailable. NOTE: this returning a backend
+    is not proof the SDK can run anything — the backend is built even with the dependency missing, so it
+    can still own the registry, the persisted queues and the chat. Gate 'can we start a session' on
+    _sdk_ready(), never on this."""
     with _sdk_lock:
         return _sdk_locked()
+
+
+def _sdk_ready():
+    """Can the SDK backend actually RUN a session right now? The truthful gate for session CREATION.
+
+    Both creation paths used to ask `_sdk()` and take a live-but-dependency-less backend as a yes, so the
+    refusal each of them had written — never silently hand back something that can't work — never fired.
+    Creating a session from the browser produced no error and no working session (the user 2026-07-28).
+    getattr-guarded so a backend/test fake without the capability reads as ready (the old meaning)."""
+    be = _sdk()
+    if not be:
+        return False
+    try:
+        fn = getattr(be, "available", None)
+        return bool(fn()) if fn else True
+    except Exception:
+        return False
 
 
 def _sdk_locked():
@@ -16780,10 +16806,9 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps({"ok": True, "id": live[nm], "existing": True}),
                                       "application/json")
                 if (b.get("backend") or "sdk") == "sdk":
-                    if not _sdk():
-                        return self._send(200, json.dumps({"ok": False, "error":
-                            "SDK backend unavailable on this kernel (claude-agent-sdk not importable; "
-                            "run bin/romp-sdk-setup with Python 3.10+)"}), "application/json")
+                    if not _sdk_ready():          # see _sdk_ready — a built backend is not a working one
+                        return self._send(200, json.dumps({"ok": False, "error": SDK_SETUP_HINT}),
+                                          "application/json")
                     sid = _create_sdk_session(nm, cwd)
                     return self._send(200, json.dumps({"ok": True, "id": sid, "dir": cwd}),
                                       "application/json")
@@ -17256,14 +17281,15 @@ class Handler(BaseHTTPRequestHandler):
                     _reveal_chat({"type": "focus", "id": live[nm]})
                     _mark_views_dirty()          # pusher ships the tab; never a synchronous fleet build here
                 elif msg.get("backend") == "sdk":   # non-tmux: drive via the Agent SDK
-                    if _sdk():
+                    # _sdk_ready(), not _sdk(): the backend object exists even with the dependency
+                    # missing, so the old check took it as a yes and created a session that could never
+                    # run — silently, which is the whole failure (the user 2026-07-28).
+                    if _sdk_ready():
                         _create_sdk_session(nm, cwd)
                     else:
                         # NEVER silently fall back to tmux (the user asked for SDK and got a mystery tmux
                         # session on a remote host without the venv, 2026-07-02). Say what's missing.
-                        client["send"](json.dumps({"type": "warn", "text":
-                            "SDK backend unavailable on this kernel (claude-agent-sdk not importable — "
-                            "run bin/romp-sdk-setup with Python 3.10+). Session not created."}))
+                        client["send"](json.dumps({"type": "warn", "text": SDK_SETUP_HINT}))
                 else:
                     threading.Thread(target=_spawn_session, args=(nm, cwd), daemon=True).start()
         elif msg and msg.get("type") == "cancelCreate" and msg.get("name"):

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2336,6 +2336,18 @@ class SdkBackend:
         return {"stopped": len(sessions), "inflight": inflight, "unjoined": len(unjoined),
                 "reaped": len(reaped)}
 
+    def available(self) -> bool:
+        """Can this backend actually RUN a session? False when claude_agent_sdk isn't importable.
+
+        The backend object exists either way, on purpose — it owns the registry, the persisted queues and
+        the chat those sessions render from. So `_sdk()` returning something is NOT proof the SDK works,
+        and every caller gating on "is the SDK usable" must ask THIS instead. Both session-creation paths
+        already carried the right refusal ("never silently fall back — say what's missing") and both
+        tested the object, so the refusal was unreachable in precisely the case it was written for: the
+        user created a session from the browser, got no error at all, and got a session that could never
+        run (the user 2026-07-28)."""
+        return not self._sdk_missing
+
     def busy_count(self) -> int:
         """How many SDK sessions have a turn IN FLIGHT right now — the manager's quiet-window gate
         for deferred deploy restarts (the kernel's /busy route). Authoritative: the same per-session

--- a/tests/install-optional-deps.bats
+++ b/tests/install-optional-deps.bats
@@ -301,3 +301,90 @@ EOF
     # box has no browser for `romp` to open.
     [[ "$output" == *"token=TESTTOKEN123"* ]]
 }
+
+# ── romp installs its own critical dependency, rather than assigning homework ──
+# The SDK backend is what plain `romp new` runs on, so a box without it has a romp that starts,
+# looks healthy and cannot run a single session. romp-sdk-setup used to stop at Debian's missing
+# ensurepip and tell the user to sudo — which an installer cannot do for them, and which is exactly
+# where a fresh python3.14 install stalled (the user 2026-07-28). It now builds the venv without pip
+# and bootstraps pip itself; the sudo message is the LAST resort, not the first answer.
+
+# A python that passes the >= 3.10 gate, has no ensurepip, and can fake `-m venv --without-pip`
+# well enough to exercise the bootstrap. Self-contained for the same reason as the test above: the
+# host's own python3 differs per machine.
+_pipless_python() {
+    cat > "$STUB/python3.12" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"version_info >= (3, 10)"*) exit 0 ;;
+  *'print("%d.%d"'*)           echo "3.12"; exit 0 ;;
+  *"import ensurepip"*)        exit 1 ;;
+  *"-m venv --without-pip"*)
+      v="\${@: -1}"
+      mkdir -p "\$v/bin"
+      # the venv's python: running get-pip.py is what mints bin/pip
+      printf '#!/usr/bin/env bash\ncase "\$*" in *get-pip.py*) printf "#!/usr/bin/env bash\\nexit 0\\n" > "\$(dirname "\$0")/pip"; chmod +x "\$(dirname "\$0")/pip";; esac\nexit 0\n' > "\$v/bin/python"
+      chmod +x "\$v/bin/python"
+      exit 0 ;;
+esac
+exit 0
+EOF
+    chmod +x "$STUB/python3.12"
+}
+
+@test "romp-sdk-setup: bootstraps pip itself when ensurepip is missing — no sudo, no homework" {
+    _pipless_python
+    export ROMP_STATE_DIR="$TEST_DIR/state"
+    # file:// keeps the fetch hermetic — curl handles it, and no test may reach the network.
+    printf '# a stand-in for PyPA get-pip.py\n' > "$TEST_DIR/get-pip.py"
+
+    PATH="$(bare_path)" ROMP_PYTHON="$STUB/python3.12" \
+      ROMP_GET_PIP_URL="file://$TEST_DIR/get-pip.py" run "$ROMP_DIR/bin/romp-sdk-setup"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"bootstrapping pip"* ]]
+    # the whole point: it must NOT send the user to sudo when it can do the job itself
+    [[ "$output" != *"sudo apt install"* ]]
+    [ -x "$TEST_DIR/state/sdkvenv/bin/pip" ]
+    # the downloaded bootstrap script is not left lying in the venv
+    [ ! -f "$TEST_DIR/state/sdkvenv/get-pip.py" ]
+}
+
+@test "romp-sdk-setup: ROMP_NO_GET_PIP opts out, and then it names the package" {
+    _pipless_python
+    export ROMP_STATE_DIR="$TEST_DIR/state"
+
+    PATH="$(bare_path)" ROMP_PYTHON="$STUB/python3.12" ROMP_NO_GET_PIP=1 \
+      run "$ROMP_DIR/bin/romp-sdk-setup"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"sudo apt install"* ]]           # the fallback is still there for anyone who wants it
+    [[ "$output" == *"romp still runs without this"* ]]
+    [ ! -x "$TEST_DIR/state/sdkvenv/bin/python" ]     # and never a husk for the next run to trip over
+}
+
+@test "install.sh: a missing SDK backend is a BANNER, not an optional-pieces footnote" {
+    export ROMP_STATE_DIR="$TEST_DIR/state"
+    mkdir -p "$ROMP_STATE_DIR"
+    echo "TESTTOKEN123" > "$ROMP_STATE_DIR/serve-token"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/node"; chmod +x "$STUB/node"
+    # Let the real sdk step RUN (ROMP_NO_SDK cleared — that flag is what sets ROMP_SDK_MISSING) but
+    # make it fail at the VERSION gate, so this stays hermetic: no venv built, no network reached.
+    cat > "$STUB/oldpython" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"version_info >= (3, 10)"*) exit 1 ;;
+  *'print("%d.%d"'*)           echo "3.9"; exit 0 ;;
+esac
+exit 0
+EOF
+    chmod +x "$STUB/oldpython"
+
+    PATH="$(bare_path)" ROMP_TMUX_AVAILABLE=1 ROMP_NO_SDK= ROMP_PYTHON="$STUB/oldpython" \
+      run "$ROMP_DIR/install.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CANNOT START SESSIONS"* ]]
+    # it must NOT be filed under the things you can happily live without
+    [[ "$output" != *"Some optional pieces aren't set up:"*"Agent SDK"* ]]
+}

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6292,7 +6292,28 @@ class NewSessionRoute(unittest.TestCase):
             km._sdk, km._live_names = saved_sdk, saved_live
         self.assertEqual(code, 200)
         self.assertFalse(body["ok"], "no silent tmux session when the SDK is missing")
-        self.assertIn("SDK backend unavailable", body["error"])
+        # asserted by MEANING, not by the old phrasing: nothing was created, and the one command that
+        # fixes it is named (the user 2026-07-28 — "SDK backend unavailable" named nothing to do)
+        self.assertIn("not created", body["error"])
+        self.assertIn("romp-sdk-setup", body["error"])
+
+    def test_a_built_but_dependency_less_backend_is_NOT_a_yes(self):
+        """The real-world shape of the failure: _sdk() hands back a live backend whose SDK cannot
+        import (it stays built on purpose, to own the registry and the chat). The old gate read that
+        as available and created a session that could never run, with no error anywhere — which is
+        exactly what the user hit creating a session from the browser (2026-07-28)."""
+        class _Unusable:
+            def available(self):
+                return False
+
+        saved_sdk, saved_live = km._sdk, km._live_names
+        km._sdk, km._live_names = (lambda: _Unusable()), (lambda t: {})
+        try:
+            code, body = self._post({"name": "api", "dir": tempfile.gettempdir()})
+        finally:
+            km._sdk, km._live_names = saved_sdk, saved_live
+        self.assertFalse(body["ok"], "a backend that cannot import its SDK must refuse, not create")
+        self.assertIn("romp-sdk-setup", body["error"])
 
     def test_existing_live_name_is_an_idempotent_ok(self):
         saved_live = km._live_names

--- a/tests/test_sdk_launch_error.py
+++ b/tests/test_sdk_launch_error.py
@@ -205,3 +205,36 @@ class KernelSurfaces(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SessionCreationRefusesWhenTheSdkCannotRun(unittest.TestCase):
+    """The gap the user actually hit: they created a session in the BROWSER and got no error at all.
+
+    Both creation paths (the WS createSession op and POST /new for `romp new`) already carried the
+    right refusal — never silently hand back something that can't work — and both asked `_sdk()`.
+    But the backend object is built even with the dependency missing, on purpose, so it can keep
+    owning the registry and the chat. `_sdk()` therefore answered "yes" and the refusal never fired:
+    a session was created that could never run, silently (the user 2026-07-28)."""
+
+    def test_the_backend_reports_its_own_unavailability(self):
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        self.assertFalse(_backend(td.name, missing=True).available(),
+                         "a backend that cannot import its SDK must not answer 'ready'")
+        self.assertTrue(_backend(td.name, missing=False).available())
+
+    def test_both_creation_paths_gate_on_ready_not_on_the_object(self):
+        src = Path(BIN).parent.joinpath("kernel", "kernel.py").read_text()
+        self.assertIn("def _sdk_ready():", src)
+        self.assertIn("if _sdk_ready():", src, "the WS createSession op")
+        self.assertIn("if not _sdk_ready():", src, "POST /new, the `romp new` path")
+        self.assertNotIn("if _sdk():\n                        _create_sdk_session", src,
+                         "the old check took a dependency-less backend as a yes")
+
+    def test_the_refusal_names_the_remedy_and_says_nothing_was_created(self):
+        src = Path(BIN).parent.joinpath("kernel", "kernel.py").read_text()
+        self.assertIn("SDK_SETUP_HINT = ", src)
+        i = src.index("SDK_SETUP_HINT = ")
+        hint = src[i:i + 400]
+        self.assertIn("Session not created", hint, "say plainly that nothing was made")
+        self.assertIn("romp-sdk-setup", hint, "name the one command that fixes it")


### PR DESCRIPTION
Follow-up to #100, from the same incident. That PR made a session that *can't start* say so in the chat. This fixes the two things upstream of it — why the browser showed nothing at creation time, and why the dependency was missing at all.

## 1. Creating a session from the browser gave no error

Both creation paths — the WS `createSession` op and `POST /new` — already carried the right refusal:

> NEVER silently fall back to tmux… Say what's missing.

and both gated on `_sdk()`. But the backend object is built **even when `claude_agent_sdk` is unimportable**, on purpose, so it can keep owning the registry, the persisted queues, and the chat those sessions render from. So `_sdk()` answered "yes" and **the refusal was unreachable in precisely the case it was written for**: a session was created that could never run, with no error anywhere.

Both paths now gate on `_sdk_ready()` — the backend exists *and* its dependency imports — and share one refusal that says nothing was created and names the single command that fixes it.

## 2. It should never have come up

`romp-sdk-setup` stopped at Debian/Ubuntu's missing `ensurepip` and told the user to `sudo apt install python3-venv`. That's homework an installer can't do for you, for a dependency that **isn't optional**: the SDK backend is what plain `romp new` runs on, so a machine without it has a romp that starts, looks healthy, and cannot run a single session.

It now builds the venv `--without-pip` and bootstraps pip from PyPA's canonical `get-pip.py`, which needs no root. Verified end-to-end on a python3.14 box: **6.7s, no sudo**. The sudo message survives as the last resort (offline, no fetcher); `ROMP_NO_GET_PIP=1` opts out of the fetch and `ROMP_GET_PIP_URL` overrides the source.

## 3. It was filed as optional

`install.sh` listed the SDK backend under "Some optional pieces aren't set up," next to tmux. Filing it there let a broken install read as fine. It gets its own banner now, in terms of what the user can't do:

```
  ══════════════════════════════════════════════════════════════════
   romp is installed but CANNOT START SESSIONS yet.
   ...
```

## Tests

3 new bats (bootstrap succeeds with no sudo; `ROMP_NO_GET_PIP` falls back and leaves no pip-less husk; the install banner) and 4 new Python (backend self-report, both creation gates, the refusal's wording). The old `"SDK backend unavailable"` assertion now checks *meaning* rather than phrasing — that string named nothing the user could do.

Full Python suite, **269 bats**, and **1382 webview tests** green. I ran bats locally this time rather than leaving it to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)