### PR TITLE
The card bell costs zero space: inline after the timestamp, shown on hover/armed

### DIFF
--- a/ui/webview/card-notify.test.ts
+++ b/ui/webview/card-notify.test.ts
@@ -11,20 +11,21 @@ import * as path from "node:path";
 const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
 
-test("every card carries the bell button at the TOP-right: floated FIRST in row1, in-flow (round 3)", () => {
-  // round 2's absolute bottom-right corner collided with grouped mode's right-floated Clear on compact
-  // cards (the user 2026-07-28, screenshot); a float ahead of the title claims the top-right corner and
-  // the text wraps around it — floats can't overlap by construction.
+test("the bell rides row1's metadata cluster inline, after the time — an off bell costs ZERO space (round 4)", () => {
+  // round 2's absolute corner overlapped grouped-mode Clear; round 3's float fixed the overlap but
+  // reserved a first-line notch even while invisible, wrapping titles early (the user wants compact).
+  // Inline after the timestamp + display:none until hovered/armed = no reserved space at all, and the
+  // materialization lands in the last line's slack, in-flow, so it still can't overlap the floats.
   assert.match(SRC, /const bellBtn = el\("button", "fask-bellbtn"\);/);
-  assert.match(SRC, /row1\.prepend\(bellBtn\);/);
-  assert.match(CSS, /\.fask-bellbtn \{\s*\n\s*float: right;/);
+  assert.match(SRC, /row1\.append\(bellBtn\);/);
+  assert.match(CSS, /\.fask-bellbtn \{\s*\n\s*display: none;/);
+  assert.doesNotMatch(CSS, /\.fask-bellbtn \{\s*\n\s*float: right;/, "the title-notch float is gone");
   assert.doesNotMatch(CSS, /\.fask-bellbtn \{\s*\n\s*position: absolute/, "the overlapping absolute corner is gone");
 });
 
-test("off = hover-revealed slashed dim bell; armed (.on) = accent, always visible (mechanics, not status)", () => {
-  assert.match(CSS, /\.fask-bellbtn[\s\S]{0,400}opacity: 0;/);                    // quiet feed stays quiet
-  assert.match(CSS, /\.fitem\.ask:hover \.fask-bellbtn \{ opacity: 0\.55; \}/);   // the tab-close idiom
-  assert.match(CSS, /\.fask-bellbtn\.on \{ opacity: 0\.85; color: var\(--accent\); \}/);
+test("off = shown only on card hover (dim, slashed); armed (.on) = accent, always visible (mechanics, not status)", () => {
+  assert.match(CSS, /\.fitem\.ask:hover \.fask-bellbtn \{ display: inline-flex; \}/);
+  assert.match(CSS, /\.fask-bellbtn\.on \{ display: inline-flex; opacity: 0\.85; color: var\(--accent\); \}/);
 });
 
 test("the bell click toggles without opening the modal, off the FRESHEST payload copy", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1040,21 +1040,18 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .ctx-item-toggle .ctx-icon.off { color: var(--dim); }
 .ctx-item-body { display: flex; flex-direction: column; line-height: 1.25; }
 .ctx-item-sub { font-size: 0.82em; opacity: 0.6; }
-/* the corner bell BUTTON (the user 2026-07-28, round 3): floated at the TOP-right of row1, ahead of
-   the title, so the text wraps around it — in-flow, never overlapping (round 2's absolute bottom-right
-   collided with grouped mode's right-floated Clear on compact cards; floats can't overlap by
-   construction). Off = slashed dim bell, hidden until the card is hovered (the tab-close idiom — a
-   quiet feed stays quiet); armed (.on) = accent bell, always visible. Accent = mechanics chrome,
-   never a status colour. */
+/* the bell BUTTON (the user 2026-07-28, round 4): inline in row1's metadata cluster, right after the
+   timestamp, and display:none until the card is hovered or it's armed — an off bell costs ZERO space
+   (round 3's float reserved a first-line notch even while invisible, wrapping titles early; the user
+   wants compact). Materializing on hover lands in the slack after "Nm ago", so nothing shifts. Off =
+   slashed dim bell; armed (.on) = accent bell, always visible. Accent = mechanics chrome, never a
+   status colour. */
 .fask-bellbtn {
-  float: right; margin: 0 0 2px 8px;
-  display: flex; align-items: center; justify-content: center;
-  width: 18px; height: 18px; padding: 0; border: 0; border-radius: 5px;
-  background: transparent; color: var(--dim); cursor: pointer; opacity: 0;
-  transition: opacity 0.12s ease;
+  display: none; vertical-align: -4px; margin: 0 0 0 5px;
+  align-items: center; justify-content: center;
+  width: 17px; height: 17px; padding: 0; border: 0; border-radius: 4px;
+  background: transparent; color: var(--dim); cursor: pointer; opacity: 0.55;
 }
-.fitem.ask:hover .fask-bellbtn { opacity: 0.55; }
+.fitem.ask:hover .fask-bellbtn { display: inline-flex; }
 .fitem.ask .fask-bellbtn:hover { opacity: 1; background: rgba(255, 255, 255, 0.10); }
-.fask-bellbtn.on { opacity: 0.85; color: var(--accent); }
-.fitem.ask:hover .fask-bellbtn.on { opacity: 0.85; }
-.fitem.ask .fask-bellbtn.on:hover { opacity: 1; }
+.fask-bellbtn.on { display: inline-flex; opacity: 0.85; color: var(--accent); }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -754,11 +754,13 @@ function makeAskCard(it: AskItem): HTMLElement {
   // (the user 2026-06-20). origin sits left of the chips, matching the "from … · Followed up" reading order.
   // Clear is the rightmost, always-present control on this row (idwrap flex:1 pushes it to the edge).
   row2.append(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr);
-  // the corner bell BUTTON (the user 2026-07-28, round 3): TOP-right, floated FIRST in row1 so the
-  // title text wraps around it — in-flow, so it can never overlap anything (round 2's absolute
-  // bottom-right corner sat exactly where grouped mode floats Clear, and they collided on compact
-  // cards). Session-level arming shows on the lane/tab instead, so an armed SESSION doesn't stamp
-  // every card.
+  // the bell BUTTON (the user 2026-07-28, round 4): INLINE in row1's metadata cluster, right after
+  // the timestamp — and display:none until the card is hovered or it's armed, so an off bell costs
+  // ZERO space (round 3's float reserved a ~26px notch on the title's first line even while
+  // invisible, wrapping titles a word early and growing cards — the user wants compact). When it
+  // does show, it materializes into the slack after "Nm ago" (the last line's tail), the one spot
+  // that never shoves the title. In-flow, so it still cannot overlap the floated Clear. Session-level
+  // arming shows on the lane/tab instead, so an armed SESSION doesn't stamp every card.
   const bellBtn = el("button", "fask-bellbtn");
   bellBtn.onclick = (ev: Event) => {
     ev.stopPropagation();                            // never open the modal under the toggle
@@ -766,7 +768,7 @@ function makeAskCard(it: AskItem): HTMLElement {
     const live = cur || it;
     setCardNotify(card, live, !cardNotifyOn(live));
   };
-  row1.prepend(bellBtn);   // float-first: it claims the top-right corner before the title flows
+  row1.append(bellBtn);   // inline after the time — the metadata cluster's tail
   // ROW 3 — Background (left) · Summary (right), always one line, opposite sides. Populated below, once the
   // toggle buttons exist (they're declared with the distiller sections). The time now trails the title (row1).
   const row3 = el("div", "fask-row3");


### PR DESCRIPTION
Compactness fix for the per-card bell: the round-3 float, though overlap-proof, reserved a first-line notch even while invisible — titles wrapped a word early and cards grew.

The bell is now inline in the title row's metadata cluster, right after the timestamp, and `display:none` until the card is hovered or the bell is armed:

- An off, unhovered card reserves **zero** space — byte-identical layout to a bell-less card.
- Hovering materializes the slashed dim bell into the slack after "Nm ago" (the last line's tail), so nothing shifts.
- Armed keeps the always-visible accent bell in the same spot.
- Still in-flow, so it cannot overlap grouped mode's floated Clear.

Verified headlessly: unhovered vs hovered cards wrap identically. 1381 node tests green, tsc clean, targeted Python suites green (no kernel changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)