### PR TITLE
Picker: a typed name means create; Enter never reopens a fuzzy match

### DIFF
--- a/ui/webview/picker-enter-create.test.ts
+++ b/ui/webview/picker-enter-create.test.ts
@@ -1,0 +1,32 @@
+// The + picker's Enter belongs to CREATE once a name is typed (the user 2026-07-28): typing a name and
+// pressing Enter must open a NEW session with exactly that name — never reopen an existing session that
+// happens to match. Reopening a match takes an explicit ArrowDown (or hover/click) onto its row; ArrowUp
+// from the top row steps back out to the armed New-session button. Source pins against render.ts (no
+// jsdom harness for the picker), like the other picker suites.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("with a typed name in create mode, NO row auto-activates — matches are ArrowDown away", () => {
+  assert.match(SRC, /setActiveRow\(creating && q\.trim\(\) \? null : pickerRows\(\)\[0\] \?\? null\);/);
+});
+
+test("the New-session button arms whenever a name is typed and no row is explicitly active", () => {
+  assert.match(SRC, /function syncNewButton\(\)/);
+  assert.match(SRC, /btn\.classList\.toggle\("active", creating && !!q && !rowActive\);/);
+  // the arm no longer requires ZERO matches (the old rule that made Enter reopen a fuzzy match)
+  assert.doesNotMatch(SRC, /pickerRows\(\)\.length === 0\);/);
+  // setActiveRow keeps the two Enter targets mutually exclusive on every path (arrow, hover, filter)
+  assert.match(SRC, /syncNewButton\(\);\s*\/\/ an active row and an armed New-session button are mutually exclusive/);
+});
+
+test("Enter precedence: explicit active row, then the armed create button, then (empty box) the first row", () => {
+  assert.match(SRC, /if \(active\) \{ active\.click\(\); return; \}\s*\n\s*const btn = document\.getElementById\("picker-new-btn"\);\s*\n\s*if \(btn\?\.classList\.contains\("active"\)\) \{ btn\.click\(\); return; \}\s*\n\s*const first = pickerRows\(\)\[0\];\s*\n\s*if \(first\) first\.click\(\);/);
+});
+
+test("ArrowUp from the top row steps back OUT of the match list to the armed create button", () => {
+  assert.match(SRC, /if \(cur === 0 && delta < 0\) \{[\s\S]*?if \(creating && q\) \{ setActiveRow\(null\); return; \}/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4031,12 +4031,35 @@ function pickerRows(): HTMLElement[] {
 function setActiveRow(row: HTMLElement | null) {
   document.querySelectorAll("#picker-list .picker-row.active").forEach((r) => r.classList.remove("active"));
   if (row) { row.classList.add("active"); row.scrollIntoView({ block: "nearest" }); }
+  syncNewButton();   // an active row and an armed New-session button are mutually exclusive Enter targets
+}
+
+// Arm the "✛ New session" button exactly when Enter should CREATE: create mode (the + flow), a name
+// typed, and no row explicitly active. A typed name belongs to "create" (the user 2026-07-28) — it
+// must never be re-routed onto a fuzzy match — so matches don't steal the arm; stepping onto a row
+// with ArrowDown (or hovering one) is the explicit act that hands Enter to that row instead.
+function syncNewButton() {
+  const btn = document.getElementById("picker-new-btn");
+  if (!btn) return;
+  const creating = (btn.closest(".picker-actions") as HTMLElement | null)?.style.display !== "none";
+  const q = (document.getElementById("picker-search") as HTMLInputElement | null)?.value.trim() || "";
+  const rowActive = !!document.querySelector("#picker-list .picker-row.active:not(.hidden)");
+  btn.classList.toggle("active", creating && !!q && !rowActive);
 }
 
 function moveActive(delta: number) {
   const rows = pickerRows();
   if (!rows.length) return;
   const cur = rows.findIndex((r) => r.classList.contains("active"));
+  // ArrowUp from the TOP row steps back OUT of the match list: with a typed name in create mode that
+  // re-arms the New-session button (the way back to "Enter creates"), instead of wrapping to the
+  // bottom row (the user 2026-07-28).
+  if (cur === 0 && delta < 0) {
+    const btn = document.getElementById("picker-new-btn");
+    const creating = !!btn && (btn.closest(".picker-actions") as HTMLElement | null)?.style.display !== "none";
+    const q = (document.getElementById("picker-search") as HTMLInputElement | null)?.value.trim() || "";
+    if (creating && q) { setActiveRow(null); return; }
+  }
   const next = cur < 0 ? (delta > 0 ? 0 : rows.length - 1) : (cur + delta + rows.length) % rows.length;
   setActiveRow(rows[next]);
 }
@@ -4049,13 +4072,15 @@ function pickerKey(e: KeyboardEvent) {
   else if (e.key === "ArrowUp") { e.preventDefault(); moveActive(-1); }
   else if (e.key === "Enter") {
     e.preventDefault();
+    // Precedence (the user 2026-07-28): an EXPLICITLY active row (ArrowDown/hover) wins; else an armed
+    // New-session button (create mode + typed name) creates EXACTLY what was typed — never a fuzzy
+    // match; else (empty box) fall back to the first listed row.
     const active = document.querySelector("#picker-list .picker-row.active:not(.hidden)") as HTMLElement | null;
-    const target = active ?? pickerRows()[0];
-    if (target) { target.click(); return; }
-    // No matching session row — if the New-session button is armed (unique
-    // name typed), Enter creates it.
+    if (active) { active.click(); return; }
     const btn = document.getElementById("picker-new-btn");
-    if (btn?.classList.contains("active")) btn.click();
+    if (btn?.classList.contains("active")) { btn.click(); return; }
+    const first = pickerRows()[0];
+    if (first) first.click();
   }
 }
 
@@ -4179,15 +4204,14 @@ function filterPicker(q: string) {
     const hit = !query || (row.dataset.search || "").includes(query);
     row.classList.toggle("hidden", !hit);
   });
-  setActiveRow(pickerRows()[0] ?? null); // keep the highlight on the top of the filtered list
-  // A name that matches NO session is a new one: move the highlight to the
-  // "✛ New session" button so a bare Enter creates it (mirrors how the first
-  // matching row is auto-selected when there ARE matches).
+  // In the + (create) flow a TYPED name means "create this" (the user 2026-07-28): no row
+  // auto-activates, so a bare Enter lands on the armed New-session button and creates EXACTLY the
+  // typed name — reopening one of the matches shown below takes an explicit ArrowDown (or hover/click).
+  // With an empty box (or in pick mode, where creating isn't on offer) the first row still
+  // auto-highlights so Enter opens it, as before. setActiveRow syncs the button's armed state.
   const btn = document.getElementById("picker-new-btn");
-  if (btn) {
-    const actionsShown = (btn.closest(".picker-actions") as HTMLElement | null)?.style.display !== "none";
-    btn.classList.toggle("active", actionsShown && !!q.trim() && pickerRows().length === 0);
-  }
+  const creating = !!btn && (btn.closest(".picker-actions") as HTMLElement | null)?.style.display !== "none";
+  setActiveRow(creating && q.trim() ? null : pickerRows()[0] ?? null);
 }
 
 function nearBottom(c: HTMLElement): boolean {


### PR DESCRIPTION
In the + (new session) picker, typing a name and hitting Enter used to reopen the first fuzzy-matching existing session — creating only worked when the name matched nothing.

Now, in the create flow, a typed name always means create:

- Typing disarms the row auto-highlight and arms the New-session button, so Enter creates a session named exactly what you typed.
- Reopening one of the matches shown below takes an explicit ArrowDown (or hover/click) onto its row; ArrowUp from the top row steps back out to the armed create button.
- An empty search box still Enter-opens the first listed row, and pick mode (choosing an existing session as a target) keeps the old first-match auto-highlight — creating isn't on offer there.

New source-pin suite `picker-enter-create.test.ts`. 3389 py / 1385 node green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)