### PR TITLE
A disconnected remote says what it REMEMBERS, and recoveries reach disk

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5128,9 +5128,18 @@ def _tunnel_status(proc_alive, port_up, remote_answered):
 def _remote_public(r):
     """The API view of a remote row — everything the browser needs to open its own WS, minus the Popen.
     kernelSha/localSha/outOfDate let the dashboard flag a remote running older code + offer to update it;
-    behindBy/aheadBy/kernelDate say HOW it drifted (computed only when it actually did)."""
+    behindBy/aheadBy/kernelDate say HOW it drifted (computed only when it actually did).
+
+    stale/lastOk (the user 2026-07-28): kernelSha, the drift counts and the mail-tier mirror are all the
+    LAST SUCCESSFUL poll's answer, never a live one — only an `up` row polled this pass. A disconnected row
+    kept shipping them as current, so a peer unreachable for hours still reported "behind 2 commits" and a
+    mail tier it could not possibly know, a readout that contradicted the row's own "disconnected" label.
+    Keep sending the cached values (they remain the best available answer, and the row should not go blank)
+    but SAY they are remembered and when they were last confirmed, so the UI can mark them instead of
+    passing memory off as fact."""
     ood = _remote_out_of_date(r)
     drift = _behind_info(r.get("kernel_sha") or "") if ood else {"behind": 0, "ahead": 0, "date": ""}
+    stale = (r.get("status") or "down") != "up"
     return {"host": r["host"], "kernelPort": r["kernel_port"], "localPort": r["local_port"],
             "busPort": r.get("bus_port") or 0,   # peer-bus mode: a restarted bus reseeds its peer table from this
             "checkin": bool(r.get("checkin")),           # we publish ourselves to this hub (stage 3)
@@ -5152,7 +5161,28 @@ def _remote_public(r):
             # reconnect budget (the user 2026-07-22): the popover has to be able to SAY that romp stopped
             # dialing, instead of a silent forever-retry that looks identical to a healthy idle row
             "gaveUp": bool(r.get("gave_up")), "fails": int(r.get("fails") or 0),
-            "maxTries": TUNNEL_MAX_TRIES}
+            "maxTries": TUNNEL_MAX_TRIES,
+            # not live: everything above derived from kernel_sha / the peer's declared tier is a memory of
+            # the last successful exchange. lastOk is when that was (0 = never seen up this process).
+            "stale": stale, "lastOk": int(r.get("last_ok") or 0)}
+
+
+_remotes_saved_sig = None   # signature of the last blob written — lets the supervisor save ONLY on a real
+#                             change instead of rewriting a 0600 credential file every pass forever.
+
+
+def _remotes_rows_for_save():
+    with _remotes_lock:
+        return [{k: v for k, v in r.items() if k != "proc"} for r in _remotes.values()]
+
+
+def _remotes_sig(rows):
+    """Change signature for the periodic save. EXCLUDES last_ok on purpose: the supervisor restamps it
+    every pass a host answers, so counting it would make every tick look like a change. It is still
+    WRITTEN — when a real change (a status flip, a new sha, a fail) triggers the save, the current last_ok
+    rides along, which is exactly the moment the stamp earns its keep: the save fired BY a drop carries
+    the last time that host was actually seen up."""
+    return json.dumps([{k: v for k, v in r.items() if k != "last_ok"} for r in rows], sort_keys=True)
 
 
 def _remotes_save():
@@ -5160,12 +5190,27 @@ def _remotes_save():
     0600: every row carries that host's SERVE TOKEN (fetched over ssh at attach), so this file is a
     credential store — at the default 0644 any other local user could lift a remote's token and drive
     that machine's kernel through the tunnel, which would defeat the loopback token gate for federation."""
-    with _remotes_lock:
-        rows = [{k: v for k, v in r.items() if k != "proc"} for r in _remotes.values()]
+    global _remotes_saved_sig
+    rows = _remotes_rows_for_save()
     try:
         _atomic_write(REMOTES_FILE, json.dumps(rows), mode=0o600)
+        _remotes_saved_sig = _remotes_sig(rows)
     except Exception:
         sys.stderr.write("remotes save: %s\n" % traceback.format_exc())
+
+
+def _remotes_save_if_changed():
+    """Persist what the SUPERVISOR owns (the user 2026-07-28). _remotes_save() was called only by the act
+    routes — attach/detach/trust/checkin — so status, fails, gave_up, kernel_sha and detail lived in memory
+    alone. A host that failed, got persisted mid-failure by some unrelated act, then quietly recovered left
+    the file frozen on the failure: hours after the tunnel was healthily up, the on-disk row still read
+    `starting`, with a stale sha and a by-then-unreachable hostname parked in `detail`. Nothing consumes it
+    wrongly today (a boot resets the retry budget anyway), but this file is the record of last known state
+    and it was lying about it. Signature-gated, so an idle healthy fleet writes nothing at all."""
+    if _remotes_sig(_remotes_rows_for_save()) == _remotes_saved_sig:
+        return False
+    _remotes_save()
+    return True
 
 
 def _remotes_load():
@@ -6009,6 +6054,8 @@ def _tunnel_supervisor():
                     if st == "up":
                         r["fails"], r["next_try"] = 0, 0   # healthy end-to-end → clear the backoff
                         r.pop("gave_up", None)             # ...and re-arm the budget for a later drop
+                        r["last_ok"] = time.time()         # the moment the cached sha/tier below were TRUE,
+                        #                                    so a later down row can date what it remembers
                         if r.get("detail"):
                             r["detail"] = ""               # any parked error/hint is moot once it answers
                     elif st == "no-kernel" and not r.get("booting"):
@@ -6061,6 +6108,10 @@ def _tunnel_supervisor():
                 # tier too — their mail arrives relayed through a hub and is judged by true origin.
                 # Once per (host, level); a failed push retries next pass.
                 _push_origin_trust_rows()
+            # Everything above is the supervisor's own state (status, fails, gave_up, kernel_sha, detail).
+            # None of it used to reach disk — only the act routes saved — so the file could sit frozen on a
+            # failure long after the row recovered. Signature-gated: a steady fleet writes nothing.
+            _remotes_save_if_changed()
         except Exception:
             sys.stderr.write("tunnel-supervisor: %s\n" % traceback.format_exc())
         _tunnel_wake.wait(15)
@@ -15367,14 +15418,22 @@ var dot=t.status==='up'?'background:var(--accent)':(t.status==='error'||t.status
 // commits' (a push delivers exactly those), 'ahead N commits'/'diverged' (it has commits this repo lacks — a
 // push would clobber them, and the kernel refuses), or 'different build' (its sha is unknown here, e.g. it was
 // updated from another machine). Shas + the remote commit's date ride the tooltip. Else its sha.
+// STALE (the user 2026-07-28): only an `up` row was polled this pass, so a sha, a drift count and the mail
+// tier below are all a MEMORY of the last exchange. A disconnected row used to draw them as fact — it would
+// report 'behind 2 commits' and a peer's mail tier for a host it had not reached in hours, flatly
+// contradicting the 'disconnected' word sitting beside it. Keep the value (a blank row is worse) but say it
+// is remembered, and date it on hover: glanceable mark, mechanics one hover away.
+var stl=!!t.stale;
+var sw=stl?(t.lastOk?('last confirmed '+new Date(t.lastOk*1000).toLocaleTimeString()):'never confirmed since this kernel started'):'';
+var sq=stl?(' \\u2014 '+sw+'; not re-checked while '+(LBL[t.status]||t.status)+'.'):'';
 var ver='';
 if(t.outOfDate){var bb=t.behindBy,ab=t.aheadBy,w='different build';
 if(typeof bb==='number'&&typeof ab==='number'){
 w=(bb>0&&ab>0)?'diverged':(ab>0)?'ahead '+ab+' commit'+(ab===1?'':'s'):(bb>0)?'behind '+bb+' commit'+(bb===1?'':'s'):w;}
 var tt='running '+(t.kernelSha||'?')+(t.kernelDate?' from '+t.kernelDate:'')+'; this machine is at '+(t.localSha||'?')+(w==='diverged'?' (each has commits the other lacks)':'')
 +(t.checkinPeer?' No ssh path from this machine (it checked in over its own tunnel) \\u2014 sync from its own dashboard.':'');
-ver=' \\u00b7 <span class=rnet-old title=\"'+tt+'\">'+w+'</span>';}
-else if(t.kernelSha){ver=' \\u00b7 <span class=rnet-sha title=\"same build as this machine\">'+t.kernelSha+'</span>';}
+ver=' \\u00b7 <span class=\"rnet-old'+(stl?' rnet-stale':'')+'\" title=\"'+tt+sq+'\">'+(stl?'last known: ':'')+w+'</span>';}
+else if(t.kernelSha){ver=' \\u00b7 <span class=\"rnet-sha'+(stl?' rnet-stale':'')+'\" title=\"'+(stl?'same build as this machine when last reached.'+sq:'same build as this machine')+'\">'+(stl?'last known: ':'')+t.kernelSha+'</span>';}
 // A push romp is ALREADY doing needs no button — offering one would just invite a duplicate of the work in
 // flight. The row shows the live phase instead (below), and the manual Push returns if it fails.
 var apx=t.autoPush&&(t.autoPush.phase==='pushing'||t.autoPush.phase==='waiting'||t.autoPush.phase==='pulling');
@@ -15410,7 +15469,7 @@ var trust='<span class=rnet-set><span class=rnet-lbl>Their mail</span><select cl
 var theirs=tiers[t.host]||'';
 if(theirs){var mm=theirs!==tcur;
 var mpd=pendLvl(_pendMirror,t.host,theirs);   // confirmed by the peer's next tier gossip, not the POST
-trust+='<span class=\"rnet-back'+(mm&&!mpd?' rnet-mismatch':'')+'\" title=\"How '+t.host+' holds mail from this machine, as its bus declared on the last exchange. Each side owns its own gate.\">'+t.host+' holds yours: '+theirs+'</span>';
+trust+='<span class=\"rnet-back'+(mm&&!mpd?' rnet-mismatch':'')+(stl?' rnet-stale':'')+'\" title=\"How '+t.host+' holds mail from this machine, as its bus declared on the last exchange. Each side owns its own gate.'+sq+'\">'+t.host+' holds yours: '+(stl?'last known ':'')+theirs+'</span>';
 if(mpd){trust+='<button class=rnet-mirror disabled title=\"Set on '+t.host+'; waiting for its bus to confirm on the next exchange.\">Matching\\u2026</button>';}
 else if(mm){trust+='<button class=rnet-mirror data-m=\"'+t.host+'\" data-lvl=\"'+tcur+'\" title=\"Set '+t.host+'\\u2019s level for this machine to '+tcur+' too. This is your admin access (the tunnel + that machine\\u2019s own token) acting on its kernel \\u2014 a peer can never set your trust, and this never lets one.\">Match ('+tcur+')</button>';}}
 // Line 1 is what this host is doing right now plus the acts you perform on it; line 2 is the pair of
@@ -15984,6 +16043,12 @@ def _landing():
             ".rnet-known:hover{opacity:1}"
             ".rnet-sha{color:#6e7681;font-variant-numeric:tabular-nums}"
             ".rnet-old{color:var(--accent)}"   # accent-blue "update available" cue (highlight chrome, not a status color)
+            # STALE: a remembered value on a row that is not currently up. Muted + dotted underline, and it
+            # OVERRIDES .rnet-old's accent (two classes beat one) — an accent-blue "behind 2 commits" reads as
+            # a live finding you should act on, which is exactly the false confidence being fixed here. A CSS
+            # cue, never a glyph.
+            ".rnet-old.rnet-stale,.rnet-sha.rnet-stale,.rnet-back.rnet-stale{color:#6e7681;font-style:italic;"
+            "text-decoration:underline dotted 1px;text-underline-offset:2px}"
             ".rnet-upd{color:var(--accent-fg)!important;background:var(--accent)!important;border-color:var(--accent)!important;font-weight:600}"
             ".rnet-empty{color:#6e7681;font-size:11px}"   # the one dim gray the panel already uses, not a fourth
             # "Automatically update" — a panel-wide setting, so it wears the same muted label treatment as the

--- a/tests/test_remotes_panel_render.py
+++ b/tests/test_remotes_panel_render.py
@@ -167,6 +167,56 @@ class RemotesPanelRender(unittest.TestCase):
         self.assertIn("button[data-m]", js)
         self.assertIn("/tunnels/trust-mirror", js)
 
+    # ---- remembered vs live (the user 2026-07-28) -------------------------------------------------
+    # kernelSha, the drift counts and the peer's mail tier are all answers from the LAST SUCCESSFUL
+    # poll — only an `up` row is polled. The panel drew them as current regardless, so a row could say
+    # "disconnected" and "behind 2 commits" and name the peer's mail tier all at once: three claims,
+    # two of which it had no way to know. The values stay (a blank row is worse); they must be MARKED.
+
+    def _drifted(self, status="up", stale=False, last_ok=0, tiers=None):
+        tn = json.loads(json.dumps(TUNNELS))
+        tn["tunnels"][0].update({"status": status, "outOfDate": True, "behindBy": 2, "aheadBy": 0,
+                                 "kernelSha": "abc1234", "localSha": "def5678",
+                                 "stale": stale, "lastOk": last_ok})
+        if tiers is not None:
+            tn["peerTiers"] = tiers
+        return tn
+
+    def test_a_live_row_states_its_drift_plainly(self):
+        # The control: an `up` row DID just poll, so its drift is fact and wears no hedge.
+        out = self._run(tunnels=self._drifted(status="up", stale=False))
+        html = out.get("html", "")
+        self.assertIn("behind 2 commits", html)
+        self.assertNotIn("last known", html)
+        self.assertNotIn("rnet-stale", html)
+
+    def test_a_disconnected_row_marks_its_drift_as_remembered_not_live(self):
+        out = self._run(tunnels=self._drifted(status="down", stale=True, last_ok=1785272930))
+        html = out.get("html", "")
+        self.assertIn("disconnected", html, "the row still reports its live state")
+        self.assertIn("last known: behind 2 commits", html,
+                      "a drift count from an unreachable host must read as memory, not as a finding")
+        self.assertIn("rnet-stale", html, "and must carry the muted cue that overrides the accent")
+        self.assertIn("last confirmed", html, "hover says WHEN it was true (progressive disclosure)")
+
+    def test_a_never_reached_row_says_so_rather_than_inventing_a_time(self):
+        # lastOk 0 = this kernel has not once seen it up; the hover must not imply a moment that never was.
+        out = self._run(tunnels=self._drifted(status="gave-up", stale=True, last_ok=0))
+        self.assertIn("never confirmed since this kernel started", out.get("html", ""))
+
+    def test_a_disconnected_row_marks_the_peers_mail_tier_as_remembered(self):
+        # The other half of the same bug: the reverse tier is gossiped by the peer's bus on an exchange,
+        # so a disconnected row is quoting an old exchange and must say so.
+        out = self._run(tunnels=self._drifted(status="down", stale=True, last_ok=1785272930,
+                                              tiers={"TESTHOST": "trusted"}))
+        self.assertIn("TESTHOST holds yours: last known trusted", out.get("html", ""))
+
+    def test_a_live_row_states_the_peers_mail_tier_plainly(self):
+        out = self._run(tunnels=self._drifted(status="up", stale=False, tiers={"TESTHOST": "trusted"}))
+        html = out.get("html", "")
+        self.assertIn("TESTHOST holds yours: trusted", html)
+        self.assertNotIn("last known", html)
+
     def test_the_per_host_settings_sit_on_their_own_line(self):
         # Trust and check-in are set once and left; Detach is an act. Splitting them off line 1 is what
         # stops a phone-width row from pushing Detach past the right edge.

--- a/tests/test_remotes_stale_and_persist.py
+++ b/tests/test_remotes_stale_and_persist.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Two bugs in how a remote row reports itself (the user 2026-07-28).
+
+ONE — remembered values were served as live. kernelSha (and everything derived from it: outOfDate,
+behindBy, aheadBy) plus the peer's declared mail tier are answers from the LAST SUCCESSFUL poll; the
+supervisor only polls a row that is `up`. _remote_public() shipped them regardless of status, so a host
+that had been unreachable for hours still reported a commit count and a mail tier beside its own
+"disconnected" label — three claims, two unknowable. The values still ship (a blank row is less useful)
+but now carry `stale` + `lastOk` so the UI can mark them.
+
+TWO — recoveries never reached disk. _remotes_save() was called only from the ACT routes (attach, detach,
+set_trust, checkin), never from the supervisor. So status/fails/gave_up/kernel_sha/detail lived in memory
+alone: a row that failed, got persisted mid-failure by some unrelated act, then recovered left the file
+frozen on the failure. Observed live — hours after a tunnel was healthily up, remotes.json still read
+`starting` with a superseded sha and a by-then-unreachable hostname parked in `detail`.
+
+The periodic save must ALSO not churn: the file is 0600 because every row holds that host's serve token,
+and rewriting a credential file every 15s forever is its own defect. Hence the signature gate, which
+deliberately ignores last_ok (restamped every pass a host answers).
+
+Synthetic only — placeholder host/token, no network.
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_stale", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _row(**kw):
+    r = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 51000, "bus_port": 51001,
+         "token": "tok", "trust": "trusted", "status": "up", "detail": "", "sids": [],
+         "fails": 0, "next_try": 0, "kernel_sha": "abc1234", "proc": None}
+    r.update(kw)
+    return r
+
+
+class RememberedIsNotLive(unittest.TestCase):
+    def test_an_up_row_is_not_stale(self):
+        self.assertFalse(km._remote_public(_row(status="up"))["stale"],
+                         "an up row polled THIS pass — its sha and drift are current")
+
+    def test_every_not_up_status_marks_the_row_stale(self):
+        # down/starting/no-kernel/error/gave-up all mean "did not poll this pass" — the cached sha is
+        # a memory in every one of them, so none may present it as fact.
+        for st in ("down", "starting", "no-kernel", "error", "gave-up"):
+            with self.subTest(status=st):
+                self.assertTrue(km._remote_public(_row(status=st))["stale"],
+                                "%s did not poll — its cached sha is a memory" % st)
+
+    def test_a_missing_status_defaults_to_stale_not_live(self):
+        r = _row()
+        del r["status"]
+        self.assertTrue(km._remote_public(r)["stale"],
+                        "unknown state must fail toward 'remembered', never toward 'live'")
+
+    def test_last_ok_rides_the_public_view_so_the_ui_can_date_what_it_shows(self):
+        self.assertEqual(km._remote_public(_row(status="down", last_ok=1785272930.7))["lastOk"],
+                         1785272930)
+
+    def test_never_seen_up_reports_zero_rather_than_a_fabricated_time(self):
+        self.assertEqual(km._remote_public(_row(status="down"))["lastOk"], 0)
+
+    def test_the_cached_values_are_still_served(self):
+        # The fix is to MARK them, not to blank them: a row that goes empty on disconnect is a
+        # regression in its own right (you lose the last thing you knew).
+        pub = km._remote_public(_row(status="down"))
+        self.assertEqual(pub["kernelSha"], "abc1234")
+        self.assertEqual(pub["trust"], "trusted")
+
+    def test_the_supervisor_stamps_last_ok_when_a_host_answers(self):
+        # lastOk is only ever as good as the write that sets it: without this, `stale` is honest but
+        # undated, and the hover falls back to "never confirmed" for a host seen a minute ago.
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        body = src[src.index("def _tunnel_supervisor("):]
+        body = body[:body.index("\ndef ", 1)]
+        self.assertIn('r["last_ok"] = time.time()', body,
+                      "the up branch must record the moment the cached sha/tier were true")
+
+
+class SupervisorStatePersists(unittest.TestCase):
+    def setUp(self):
+        with km._remotes_lock:
+            km._remotes.clear()
+            km._remotes["TESTHOST"] = _row()
+        km._remotes_save()          # baseline: disk agrees with memory
+
+    def tearDown(self):
+        with km._remotes_lock:
+            km._remotes.clear()
+
+    def _disk(self):
+        return json.loads(km.REMOTES_FILE.read_text())
+
+    def test_an_idle_healthy_fleet_writes_nothing(self):
+        self.assertFalse(km._remotes_save_if_changed(),
+                         "nothing changed — a 0600 credential file must not be rewritten every pass")
+
+    def test_a_last_ok_restamp_alone_does_not_rewrite_the_file(self):
+        # The supervisor restamps last_ok every pass a host answers. Counting it as a change would
+        # defeat the whole gate and rewrite the token file every 15s forever.
+        with km._remotes_lock:
+            km._remotes["TESTHOST"]["last_ok"] = 1785272930.0
+        self.assertFalse(km._remotes_save_if_changed())
+
+    def test_a_status_change_reaches_disk(self):
+        # THE BUG: this is the drop the file used to miss entirely.
+        with km._remotes_lock:
+            km._remotes["TESTHOST"]["status"] = "down"
+            km._remotes["TESTHOST"]["detail"] = "ssh: Network is unreachable"
+        self.assertTrue(km._remotes_save_if_changed())
+        self.assertEqual(self._disk()[0]["status"], "down")
+
+    def test_a_recovery_reaches_disk_too(self):
+        # The half that was observed live: the file sat on a failure long after the row healed.
+        with km._remotes_lock:
+            km._remotes["TESTHOST"].update({"status": "starting", "fails": 1,
+                                            "detail": "ssh: Network is unreachable"})
+        km._remotes_save_if_changed()
+        self.assertEqual(self._disk()[0]["status"], "starting")
+        with km._remotes_lock:
+            km._remotes["TESTHOST"].update({"status": "up", "fails": 0, "detail": "",
+                                            "kernel_sha": "def5678"})
+        self.assertTrue(km._remotes_save_if_changed(), "a recovery is a change and must persist")
+        row = self._disk()[0]
+        self.assertEqual(row["status"], "up")
+        self.assertEqual(row["kernel_sha"], "def5678")
+        self.assertEqual(row["detail"], "", "the parked error must not outlive the failure on disk")
+
+    def test_last_ok_is_written_when_a_real_change_triggers_the_save(self):
+        # Excluded from the SIGNATURE, not from the file: the save fired by a drop carries the last
+        # moment the host answered, which is exactly when that stamp is worth having.
+        with km._remotes_lock:
+            km._remotes["TESTHOST"]["last_ok"] = 1785272930.0
+            km._remotes["TESTHOST"]["status"] = "down"
+        km._remotes_save_if_changed()
+        self.assertEqual(self._disk()[0]["last_ok"], 1785272930.0)
+
+    def test_the_saved_file_never_carries_the_live_popen(self):
+        with km._remotes_lock:
+            km._remotes["TESTHOST"]["status"] = "down"
+        km._remotes_save_if_changed()
+        self.assertNotIn("proc", self._disk()[0])
+
+    def test_the_supervisor_actually_calls_the_periodic_save(self):
+        # Source pin: the whole point is that supervisor-owned state reaches disk. Without this call
+        # every assertion above passes while the real bug is untouched.
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        body = src[src.index("def _tunnel_supervisor("):]
+        body = body[:body.index("\ndef ", 1)]
+        self.assertIn("_remotes_save_if_changed()", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -355,6 +355,12 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       // Version drift names HOW it differs, matching the web popover: behind N (a push delivers
       // exactly those), ahead N (a pull collects them), diverged, or different build (sha unknown
       // here). Shas + the remote commit's date ride the tooltip (progressive disclosure).
+      // STALE (the user 2026-07-28): drift comes from the sha of the LAST SUCCESSFUL poll, and only an `up`
+      // row polled this pass. Drawn as fact, a host unreachable for hours still announced "behind 2 commits"
+      // right beside the word "disconnected" — two claims that cannot both be current. Keep the number (a
+      // blank is less useful) but name it as remembered, and date it in the tooltip.
+      const stale = !!t.stale;
+      const seen = t.lastOk ? new Date(t.lastOk * 1000).toLocaleTimeString() : "";
       let ver = "";
       if (t.outOfDate) {
         const bb = t.behindBy, ab = t.aheadBy;
@@ -364,10 +370,12 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
             : ab > 0 ? ` · ahead ${ab} commit${ab === 1 ? "" : "s"}`
             : bb > 0 ? ` · behind ${bb} commit${bb === 1 ? "" : "s"}` : ver;
         }
+        if (stale) ver = ver.replace(" · ", " · last known: ");
       }
       nm.textContent = `${t.host} — ${LBL[t.status] || t.status}` + ver;
       nm.title = (TIP[t.status] || "")
         + (t.outOfDate ? `\n\nRunning ${t.kernelSha || "?"}${t.kernelDate ? " from " + t.kernelDate : ""}; this machine is at ${t.localSha || "?"}.` : "")
+        + (stale && t.outOfDate ? `\nLast confirmed ${seen || "not since this kernel started"}; not re-checked while ${LBL[t.status] || t.status}.` : "")
         + (t.outOfDate && t.checkinPeer ? " No ssh path from this machine (it checked in over its own tunnel) — sync from its own dashboard." : "");
       r.append(dot, nm);
       // Federation trust (per-host): trusted = full two-way postal; directed (default) = its mail is


### PR DESCRIPTION
A peer row reported "disconnected", "behind 2 commits", and the mail tier that peer holds for us, all at once. Only the first was knowable.

## Remembered values were served as live

`kernelSha` (and `outOfDate`/`behindBy`/`aheadBy` derived from it) plus the peer's gossiped mail tier all come from the last SUCCESSFUL poll, and the supervisor polls only a row that is `up`. `_remote_public` shipped them regardless of status, so a host unreachable for hours still stated a commit count and a mail tier as fact, contradicting the "disconnected" word beside them.

The values still ship, since a blank row loses the last thing you knew, but they now carry `stale` + `lastOk` and both surfaces mark them: `last known: behind 2 commits`, muted and dotted. The stale rule overrides `.rnet-old`'s accent deliberately, because an accent-blue drift count reads as a live finding you should act on, which is the false confidence being fixed. When it was true rides the hover.

## Recoveries never reached disk

`_remotes_save` was called only from the act routes (attach, detach, `set_trust`, checkin), never from the supervisor, so `status`, `fails`, `gave_up`, `kernel_sha` and `detail` lived in memory alone. A row that failed, got persisted mid-failure by an unrelated act, then recovered left the file frozen on the failure.

Observed live: hours after a tunnel was healthily `up`, `remotes.json` still read `starting`, with a superseded sha and a by-then-unreachable hostname parked in `detail`.

The supervisor now saves behind a signature gate. The signature ignores `last_ok`, which is restamped every pass a host answers and would otherwise rewrite a 0600 credential file every 15 seconds forever. It is still written, so the save fired BY a drop carries the last moment that host answered.

## Tests

The render harness executes the real panel JS for both the live and remembered cases, on drift and on the tier mirror. The kernel side pins `stale` across every not-up status, defaults an unknown status to stale rather than live, and covers no-churn, drop, and recovery persistence, plus a source pin that the supervisor actually calls the periodic save.

Full suites green: 3408 Python, 1385 Node, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)