### PR TITLE
Chat: a delta gap now re-syncs instead of freezing the tab

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8169,11 +8169,21 @@ def _chat_build_sig(sess):
     except OSError:
         return None
     fsid = os.path.basename(path).rsplit(".", 1)[0]   # transcript filename stem == the fsid
-    try:
-        ss = os.stat(jd.STATESDIR / (fsid + ".jsonl"))
-        sig += [ss.st_mtime, ss.st_size]
-    except OSError:
-        sig += [0, 0]
+    # Fold in EVERY states file that can change this payload. The fsid is not always the key the state
+    # transitions are written under: a session that forked (a resume/clear mints a new transcript) keeps
+    # writing states/<anchor>.jsonl while its lane is keyed by the new fsid, so a states/<fsid>.jsonl stat
+    # silently fell to [0,0] and no settle EVER busted that lane's cache. Since a settle writes only to
+    # states/ (never the transcript), a forked lane's chat could latch "working" until the next transcript
+    # write (the user 2026-07-28; verified live: two live sessions had a states file under their identity
+    # id and none under the fsid their lane was keyed by). Stat both and keep the pair.
+    for _k in dict.fromkeys([fsid, str(sess.get("anchor") or "")]):
+        if not _k:
+            continue
+        try:
+            ss = os.stat(jd.STATESDIR / (_k + ".jsonl"))
+            sig += [ss.st_mtime, ss.st_size]
+        except OSError:
+            sig += [0, 0]
     sig.append(_judge_gen[0])     # a judge pass (goal/caption change) busts every tab's cache once
     sig.append(_task_store_fp(fsid))   # a store update (incl. a subagent completing a task) refreshes the to-do card
     # a pending DELETE rollback changes the payload with NO transcript write (the parse-cache lesson,
@@ -13942,8 +13952,17 @@ def _push(targets, connect=False):
                 # drops from the whole events array to just what changed.
                 change_from = _chat_diff(_prev_chat_events.get(m["id"]), m.get("events") or [])
                 led_changed = m.get("ledger") != _prev_chat_ledger.get(m["id"])
-                _prev_chat_events[m["id"]] = m.get("events") or []
-                _prev_chat_ledger[m["id"]] = m.get("ledger")
+                # The baseline is SHARED by every client, so only a push that reaches them all may advance it.
+                # A connect push targets ONE client (_push_one → _push([client], connect=True)); when it moved
+                # the baseline, everything written since the last full push fell BELOW the next diff's
+                # change_from and the already-connected clients never got it — they rejected the too-far-ahead
+                # delta and froze (the user 2026-07-28: opening or reloading any pane could silently strand the
+                # others). Leaving the baseline alone costs only a slightly longer next suffix, which every
+                # client — including the one that just connected — applies idempotently (truncate at `from`,
+                # re-append). The fresh client is already served its own full session directly below.
+                if not connect:
+                    _prev_chat_events[m["id"]] = m.get("events") or []
+                    _prev_chat_ledger[m["id"]] = m.get("ledger")
                 for c in chat_clients:
                     _send_chat(c, m, ms, change_from, led_changed)   # flush as built → the active tab lands first
             shown_sids = {s["sid"] for s in chat_list}
@@ -14968,9 +14987,9 @@ el.classList.toggle('has',n>0||(kindOn('conn')&&liveDown()));
 var t=el.querySelector('.rerr-n');if(t)t.textContent=n<=0?'!':(n>9?'+':String(n));});
 if(!back.hidden)renderList();}
 // each entry leads with the chip its card wears in the feed, so the vocabulary matches across surfaces
-var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror','cleared'];
+var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror','locate','cleared'];
 var KINDLBL={conn:'offline',limit:'limit',judge:'judge',warn:'warning',stalled:'stalled',
-nudge:'follow-up failed',retry:'retrying',apierror:'api error',cleared:'cleared'};
+nudge:'follow-up failed',retry:'retrying',apierror:'api error',locate:'jump failed',cleared:'cleared'};
 // what each kind MEANS (the user 2026-07-28: the tooltip should explain the badge, not just say
 // show/hide) — worn by the filter toggles AND every entry's chip
 var DESC={conn:"the dashboard lost its live connection to the kernel for a visible pane; it reconnects on its own",
@@ -14981,6 +15000,7 @@ stalled:"romp itself is holding a working thread and nothing is moving it \u2014
 nudge:"romp's one automatic follow-up on a stalled thread didn't resolve it; the thread now needs you",
 retry:"a session is inside an API-error retry storm; auto-retry is already working on it",
 apierror:"a session stopped on an API error (rate limit, spend cap, or prompt too long) and its card is blocked",
+locate:"a click that should have jumped to a message in the chat couldn't find it. Usually the chat is missing part of its history; reload the pane if it keeps happening",
 cleared:"a /clear in a session dropped still-open cards at the boundary; Undo clear on the feed restores them"};
 // the toggles ARE the chips (same pill, same colours) — lit = shown, dimmed = muted. Built once on a
 // STABLE container; only classes flip on click, so the buttons stay click-safe.
@@ -16179,7 +16199,7 @@ def _landing():
             ".rerr-chip.k-nudge{color:#ff6a6a;border-color:rgba(255,106,106,0.6)}"
             ".rerr-chip.k-retry,.rerr-chip.k-apierror{color:#e5484d;border-color:rgba(229,72,77,0.6)}"
             ".rerr-chip.k-conn{color:#ff6b6b;border-color:rgba(255,107,107,0.6)}"
-            ".rerr-chip.k-limit,.rerr-chip.k-judge{color:#e0a030;border-color:rgba(224,160,48,0.6)}"
+            ".rerr-chip.k-limit,.rerr-chip.k-judge,.rerr-chip.k-locate{color:#e0a030;border-color:rgba(224,160,48,0.6)}"
             ".rerr-chip.k-cleared{color:#9aa0a6;border-color:rgba(154,160,166,0.6)}"   # not an error — quiet gray
             "</style></head><body class='po-chat po-feed po-timeline'>"
             "<div id=romp-boot>" + _loader_inner() + "</div>"
@@ -17090,6 +17110,19 @@ class Handler(BaseHTTPRequestHandler):
             return
         if msg and msg.get("type") == "activeTab":
             client["active"] = msg.get("id")   # tab switch → next push builds the now-active tab first
+            return
+        if msg and msg.get("type") == "needFull" and msg.get("id"):
+            # The client REJECTED a delta because it started past what it holds (render.ts chatTail's gap
+            # branch) — it is missing events and cannot self-repair. Our own per-client bookkeeping can't
+            # detect this: echat advances when we SEND, not when the client APPLIES, so we would keep
+            # sending deltas it keeps dropping and the tab would stay frozen until its socket dropped
+            # (the user 2026-07-28). Forget what we believe this client holds; the next push re-sends the
+            # whole session (_send_chat's full path fires when echat has no entry for the sid) and the
+            # delta stream re-bases from there. Per-CLIENT, so one stale pane never re-sends for the rest.
+            sid = str(msg["id"])
+            client.get("echat", {}).pop(sid, None)
+            client.get("sent", {}).pop(("chat", sid), None)   # …and drop the dedup slot, so the full send lands
+            self._push_one(client)                            # repair NOW, not on the next 0.5-3s tick
             return
         if msg and msg.get("type") == "loadOlder" and msg.get("id"):
             # Browser scrolled back to the top of the loaded tail and there's older history on disk → ship the

--- a/tests/test_chat_delta_resync.py
+++ b/tests/test_chat_delta_resync.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""The chat delta stream must never strand a connected client (the user 2026-07-28).
+
+The chat ships only the changed SUFFIX once a tab is caught up (chatTail). Two kernel-side defects let
+that stream desynchronize, after which the tab froze — a stale "working" chip, no new messages, and
+every deep-link into the missing range honest-failing "couldn't locate this in the transcript" — until
+its socket happened to drop:
+
+  1. The shared diff baseline (_prev_chat_events) was advanced by a CONNECT push, which targets a single
+     client. Everything written since the last full push then fell below the next diff's change_from and
+     the already-connected clients never received it.
+  2. _chat_build_sig stat'd states/<fsid>.jsonl, but a FORKED session writes its state transitions under
+     the anchor sid. A settle writes only to states/, so a forked lane's cached chat payload was never
+     invalidated by one.
+
+Plus the repair path: a client that rejects a too-far-ahead delta posts {"type":"needFull"}, and the
+kernel must forget what it believes that client holds so the next push re-sends the whole session.
+"""
+import inspect
+import os
+import re
+from importlib.machinery import SourceFileLoader
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_resync", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _client():
+    """A fake chat client: records what it was sent, with the same dedup/echat slots _send_chat uses."""
+    out = []
+    return {"app": "chat", "alive": True, "send": out.append, "sent": {}, "echat": {}, "_out": out}
+
+
+def _evs(n, tag=""):
+    return [{"kind": "assistant", "uuid": "u%d%s" % (i, tag), "md": "m%d" % i} for i in range(n)]
+
+
+def _sess(sid, events):
+    return {"type": "session", "id": sid, "name": "web", "events": events,
+            "status": {"state": "working", "sinceEpoch": None}}
+
+
+# ───────────────────────── the gap the client cannot self-repair ─────────────────────────
+
+def test_a_delta_past_the_clients_events_is_a_gap():
+    """The shape of the bug, stated as arithmetic: a client holding N events that is handed a delta
+    starting at >N cannot apply it without silently skipping the events in between. render.ts's chatTail
+    detects exactly this (from > s.events.length) and now asks for a full session instead of freezing."""
+    client_has, delta_from = 100, 118
+    assert delta_from > client_has, "a delta starting past the resident tail is unappliable"
+
+
+def test_needfull_clears_the_kernels_belief_about_that_client():
+    """The repair. The kernel's per-client bookkeeping advances on SEND, not on ACK, so it cannot detect
+    the desync itself — the client has to say so. Handling needFull must drop BOTH the echat entry (which
+    is what makes _send_chat take its full-session path) and the dedup slot (so the full send isn't
+    swallowed as unchanged)."""
+    c = _client()
+    sid = "11111111-2222-3333-4444-555555555555"
+    c["echat"][sid] = ("u0", 0)
+    c["sent"][("chat", sid)] = '{"type":"chatTail"}'
+
+    # what the handler does (kernel.py's needFull branch)
+    c.get("echat", {}).pop(sid, None)
+    c.get("sent", {}).pop(("chat", sid), None)
+
+    assert sid not in c["echat"], "must forget the client's tail base → next push sends a full session"
+    assert ("chat", sid) not in c["sent"], "must drop the dedup slot → the full send actually goes out"
+
+
+def test_full_send_path_fires_when_echat_has_no_entry():
+    """Pin the mechanism the repair relies on: with no echat entry, _send_chat sends a whole
+    {type:"session"}, not another delta."""
+    c = _client()
+    sid = "11111111-2222-3333-4444-555555555555"
+    m = _sess(sid, _evs(5))
+    km._send_chat(c, m, __import__("json").dumps(m), 3, False)
+    assert c["_out"], "something must be sent"
+    got = __import__("json").loads(c["_out"][-1])
+    assert got["type"] == "session", "no echat entry → full session, never a chatTail"
+
+
+# ───────────────────────── (1) a connect push must not move the shared baseline ─────────────────────────
+
+def test_connect_push_does_not_advance_the_shared_baseline():
+    """A connect push targets ONE client. If it advanced the shared diff baseline, every OTHER connected
+    client would never be sent the events in that window — the next diff would start past them.
+
+    Drives the real guard in _push's build loop: the baseline write is gated on `not connect`.
+    """
+    src = inspect.getsource(km._push)
+    # the baseline writes must be reachable ONLY when the push is not a connect push
+    assert "_prev_chat_events[m[\"id\"]]" in src, "baseline write moved — re-pin this test"
+    gate = re.search(r"if not connect:\s*\n\s*_prev_chat_events\[m\[\"id\"\]\] = .*\n\s*_prev_chat_ledger\[m\[\"id\"\]\] = ",
+                     src)
+    assert gate, "the shared diff baseline must be advanced only by a push that reaches every client"
+
+
+def test_periodic_push_still_advances_the_baseline():
+    """The gate must not disable delta-sending outright: a push that reaches ALL clients still advances
+    the baseline, or every push would re-send the whole transcript to everyone."""
+    sid = "11111111-2222-3333-4444-555555555555"
+    km._prev_chat_events.clear()
+    km._prev_chat_events[sid] = _evs(118)
+    assert km._chat_diff(km._prev_chat_events[sid], _evs(118)) == 118, "caught up → empty suffix"
+    # and a stranded client's suffix starts at the OLD baseline, which it can actually apply
+    km._prev_chat_events[sid] = _evs(100)
+    assert km._chat_diff(km._prev_chat_events[sid], _evs(130)) == 100
+
+
+def test_needfull_handler_is_wired_in_the_kernel():
+    """Source-pin the repair handler: it must drop the client's echat entry AND its dedup slot."""
+    src = inspect.getsource(km)
+    i = src.find('msg.get("type") == "needFull"')
+    assert i > 0, "the kernel must handle the client's needFull resync request"
+    body = src[i:i + 1200]
+    assert '"echat"' in body and ".pop(sid, None)" in body, "must forget the client's tail base"
+    assert '("chat", sid)' in body, "must drop the dedup slot so the full send lands"
+
+
+def test_chat_diff_append_starts_at_the_previous_total():
+    """Why a moved baseline strands clients at all: for a pure append the diff returns the PREVIOUS
+    build's total, so the baseline's length is exactly where the next suffix begins."""
+    assert km._chat_diff(_evs(100), _evs(118)) == 100
+    assert km._chat_diff(None, _evs(5)) == 0, "no prior build → full send"
+
+
+# ───────────────────────── (2) the fork-lane states key ─────────────────────────
+
+def test_build_sig_folds_in_the_anchor_states_file(tmp_path):
+    """A forked lane is keyed by a new fsid but keeps writing states/<anchor>.jsonl. The signature must
+    stat the anchor's file too, or a settle (which touches ONLY states/) never busts the cached payload
+    and the lane latches on 'working'."""
+    jd._rebind_state(tmp_path)
+    km.jd = jd
+    (tmp_path / "states").mkdir(parents=True, exist_ok=True)
+    tx = tmp_path / "fork.jsonl"
+    tx.write_text('{"type":"user"}\n')
+
+    anchor = "11111111-2222-3333-4444-555555555555"
+    states = tmp_path / "states" / (anchor + ".jsonl")
+    states.write_text('{"t":1,"state":"working"}\n')
+
+    sess = {"sid": "fork", "path": str(tx), "anchor": anchor}
+    before = km._chat_build_sig(sess)
+
+    # the settle: written to states/<anchor>.jsonl ONLY, transcript untouched
+    states.write_text('{"t":1,"state":"working"}\n{"t":2,"state":"waiting"}\n')
+    after = km._chat_build_sig(sess)
+
+    assert before is not None and after is not None
+    assert before != after, "a settle under the ANCHOR sid must bust the fork lane's chat cache"
+
+
+def test_build_sig_still_tracks_the_fsid_states_file(tmp_path):
+    """The common case (sid == fsid, no fork) must keep working."""
+    jd._rebind_state(tmp_path)
+    km.jd = jd
+    (tmp_path / "states").mkdir(parents=True, exist_ok=True)
+    sid = "11111111-2222-3333-4444-555555555555"
+    tx = tmp_path / (sid + ".jsonl")
+    tx.write_text('{"type":"user"}\n')
+    states = tmp_path / "states" / (sid + ".jsonl")
+    states.write_text('{"t":1,"state":"working"}\n')
+
+    sess = {"sid": sid, "path": str(tx), "anchor": sid}
+    before = km._chat_build_sig(sess)
+    states.write_text('{"t":1,"state":"working"}\n{"t":2,"state":"waiting"}\n')
+    assert before != km._chat_build_sig(sess)

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -214,11 +214,14 @@ class ErrorCenterExecutes(unittest.TestCase):
     def test_the_filter_bar_has_one_toggle_per_kind(self):
         # the user 2026-07-28: every high-level category gets a toggle (offline fires so often it
         # drowns the rest). The toggles ARE the chips, in the same order entries wear them.
+        # 'jump failed' joined on 2026-07-28: a deep-link that can't find its message in the chat files
+        # an entry now, rather than only flashing a toast that leaves nothing to point at afterwards.
         a = self.out["filterBar"]
-        self.assertEqual(a["n"], 9)
+        self.assertEqual(a["n"], 10)
         self.assertEqual(a["first"], "offline")
         self.assertEqual(a["labels"],
-                         "offline|limit|judge|warning|stalled|follow-up failed|retrying|api error|cleared")
+                         "offline|limit|judge|warning|stalled|follow-up failed|retrying|api error|"
+                         "jump failed|cleared")
 
     def test_muting_a_kind_hides_counts_and_live_cue_but_keeps_the_entries(self):
         a = self.out["afterMute"]

--- a/tests/test_kernel_delta_send.py
+++ b/tests/test_kernel_delta_send.py
@@ -145,7 +145,12 @@ class RenderHandlesTheTail(unittest.TestCase):
         r = self._render()
         self.assertIn('else if (m.type === "chatTail") chatTail(m);', r)       # dispatched
         self.assertIn("const from = (msg.from | 0) - (s.headFrom || 0);", r)   # GLOBAL index → resident-tail local
-        self.assertIn("if (from < 0 || from > s.events.length) return;", r)    # below the loaded head / gap → wait for a full
+        # The two rejection cases split on 2026-07-28. Below the loaded head → still a quiet return (the
+        # resident tail is fine). A GAP (from past what we hold) → ask for a full session: "wait for the
+        # next full" was a promise nothing kept, and the tab froze there until its socket dropped.
+        self.assertIn("if (from < 0) return;", r)
+        self.assertIn("if (from > s.events.length) {", r)
+        self.assertIn("requestFullSession(msg.id);", r)
         self.assertIn("s.events.length = from;", r)                            # truncate the superseded tail
         self.assertIn("for (const e of (msg.events || [])) s.events.push(e);", r)  # append the suffix
         self.assertIn("v.rendered = Math.min(v.rendered, from);", r)           # repaint from the exact change

--- a/ui/webview/chat-delta-resync.test.ts
+++ b/ui/webview/chat-delta-resync.test.ts
@@ -1,0 +1,68 @@
+// A chatTail delta that starts PAST what the tab holds is a gap: the events in between never arrived.
+// Applying it would fabricate a transcript that silently skips them, so the client used to just drop it
+// and "wait for the next full" — which never came, because the kernel's per-client bookkeeping advances
+// when it SENDS, not when the client APPLIES. The tab froze there: a stale "working" chip, no new
+// messages, and every deep-link into the missing range honest-failing "couldn't locate this in the
+// transcript", until the socket happened to drop (the user 2026-07-28 — locate-audit.jsonl recorded six
+// pointer-not-rendered misses on one session, then pointer-exact on the SAME anchor the moment a kernel
+// restart forced a reconnect). The fix: ask for the full session, and file the miss in the error center.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const RENDER = fs.readFileSync(path.join(ROOT, "ui", "webview", "render.ts"), "utf8");
+const FEED = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.join(ROOT, "bin", "romp-kernel"), "utf8");
+
+test("a delta gap asks the kernel for a full session instead of freezing", () => {
+  assert.match(RENDER, /if \(from > s\.events\.length\) \{/,
+    "chatTail must treat a too-far-ahead delta as its own case, not fold it into the silent return");
+  assert.match(RENDER, /requestFullSession\(msg\.id\);/, "…and request a re-base");
+  assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "needFull", id \}\)/,
+    "the resync request must actually reach the kernel");
+});
+
+test("the resync is asked ONCE per desync, and re-arms when the full session lands", () => {
+  // the pusher runs every 0.5-3s; without the guard every rejected delta would re-ask
+  assert.match(RENDER, /awaitingFull\.has\(id\)\) return;/, "one ask per desync");
+  assert.match(RENDER, /awaitingFull\.add\(id\);/);
+  assert.match(RENDER, /awaitingFull\.delete\(msg\.id\)/,
+    "upsert() must clear the flag so a LATER gap can ask again");
+});
+
+test("a below-the-head delta is still ignored quietly (not a desync)", () => {
+  // from < 0 means the change is in history this tab doesn't hold; its resident tail is still valid,
+  // so it must NOT trigger a resync storm.
+  assert.match(RENDER, /if \(from < 0\) return;/,
+    "the below-the-loaded-head case keeps its quiet return");
+});
+
+test("the kernel handles needFull by forgetting what that client holds", () => {
+  assert.ok(KERNEL.includes('msg.get("type") == "needFull"'), "the kernel must handle the frame");
+  const i = KERNEL.indexOf('msg.get("type") == "needFull"');
+  const body = KERNEL.slice(i, i + 1200);
+  assert.ok(body.includes('"echat"'), "drop the client's tail base → next push sends a full session");
+  assert.ok(body.includes('("chat", sid)'), "drop the dedup slot → the full send isn't swallowed");
+  assert.ok(body.includes("_push_one(client)"), "repair immediately, not on the next tick");
+});
+
+test("a failed jump is filed in the error center, not just toasted", () => {
+  // the toast is transient and locate-audit.jsonl is invisible from the UI, so a failed click left
+  // nothing the user could point at afterwards (the user 2026-07-28)
+  assert.match(RENDER, /notifyShell\("locate",/, "the chat files a locate entry on an honest failure");
+  assert.match(RENDER, /romp: "notify", kind, text, sid/, "…over the shell's notify bridge");
+  assert.match(FEED, /kind: "locate"/, "the feed's no-anchor summary click files one too");
+  // and the kind must be registered in the shell, or the entry renders chip-less and unfilterable
+  assert.ok(KERNEL.includes("'locate'"), "the error center must know the locate kind");
+  assert.ok(KERNEL.includes("locate:'jump failed'"), "…with a label");
+  assert.ok(/locate:"[^"]+"/.test(KERNEL), "…and a description for its filter tooltip");
+});
+
+test("the anchor re-query uses the same selectors as the first lookup", () => {
+  // the recovery re-render found the event, then re-queried with only 2 of the 3 selectors — so an
+  // unhydrated postal turn (ids only in data-mids) still honest-failed pointer-not-rendered
+  const both = RENDER.split("data-mids~=").length - 1;
+  assert.ok(both >= 2, "data-mids must be in BOTH the initial query and the post-re-render re-query");
+});

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -1455,7 +1455,18 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     // affordance, honest outcome: the click says why the jump can't happen.
     dl.classList.add("fask-distill-link");
     dl.title = "no anchor recorded for this card";
-    dl.onclick = (ev: Event) => { ev.stopPropagation(); feedToast("couldn't locate this in the transcript — no anchor was recorded for this card"); };
+    // Toast AND file it in the error center (the user 2026-07-28): a transient pop-up left no trace of a
+    // click that couldn't do anything, so the failure was unreportable a minute later. The entry carries
+    // the card so clicking it jumps back here.
+    dl.onclick = (ev: Event) => {
+      ev.stopPropagation();
+      feedToast("couldn't locate this in the transcript — no anchor was recorded for this card");
+      try {
+        window.parent?.postMessage({ romp: "notify", kind: "locate",
+          text: "Couldn't jump to this summary: no anchor was recorded for this card",
+          sid: it.sid, itemId: it.itemId }, "*");
+      } catch { /* no shell (VS Code view) */ }
+    };
   } else {
     dl.classList.remove("fask-distill-link");
     dl.onclick = null;

--- a/ui/webview/render-scroll.test.ts
+++ b/ui/webview/render-scroll.test.ts
@@ -96,7 +96,10 @@ test("the kind guard accepts a peer's postal card as a valid PROMPT target (reco
 
 test("honest-fail fires whenever the deep-link can't resolve by id (the turn is genuinely gone)", () => {
   // now gated on !anchorPendingOlder so it doesn't fire while we're fetching older history for the anchor
-  assert.match(RENDER, /if \(!scrolled && !anchorPendingOlder\) landToast\("couldn't locate this in the transcript"\)/);
+  assert.match(RENDER, /if \(!scrolled && !anchorPendingOlder\) \{\s*\n\s*landToast\("couldn't locate this in the transcript"\)/);
+  // 2026-07-28: the same failure ALSO files an error-center entry — a transient toast left nothing the
+  // user could point at once it faded (the full bridge is pinned in chat-delta-resync.test.ts).
+  assert.match(RENDER, /notifyShell\("locate",/);
 });
 
 test("a deep-link to an anchor OLDER than the resident tail fetches older history, then lands (the user 2026-06-27)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4265,8 +4265,12 @@ function scrollToAnchor(uuid: string): boolean {
         expandedGroups.add(toolGroupKey(s.events[hit.indices[0]]));
       const working = s.status.state === "working" || s.status.state === "compacting";
       renderWindowItems(v, s, items, Math.max(0, u - WINDOW_RADIUS), Math.min(items.length, u + WINDOW_RADIUS), working);
+      // Re-query with the SAME three selectors the first lookup used. data-mids was missing here, so an
+      // unhydrated postal turn (whose message ids live only in data-mids) could be found in the events,
+      // have its window rendered — and then still honest-fail "pointer-not-rendered" on the re-query.
       target = (v.el.querySelector(`.turn[data-uuid="${cssEscape(uuid)}"]`)
-                || v.el.querySelector(`.turn[data-mid="${cssEscape(uuid)}"]`)) as HTMLElement | null;
+                || v.el.querySelector(`.turn[data-mid="${cssEscape(uuid)}"]`)
+                || v.el.querySelector(`.turn[data-mids~="${cssEscape(uuid)}"]`)) as HTMLElement | null;
     } else if (s && (s.headFrom ?? 0) > 0) {
       // The anchor is OLDER than the resident tail — the chat ships only WIRE_TAIL events and streams older
       // history in on demand, so a deep-link to a message past the tail had nothing to match and honest-failed
@@ -4924,7 +4928,15 @@ function landActive(content: HTMLElement | null, v: View): void {
       type: "locateDiag", id: activeId, ok: scrolled, trail: landTrail.slice(),
       anchor: att.anchor ?? undefined, anchorT: att.t ?? undefined, kind: att.kind ?? undefined,
     });
-    if (!scrolled && !anchorPendingOlder) landToast("couldn't locate this in the transcript");  // fetching older history → chatHead re-lands, no false "couldn't locate"
+    if (!scrolled && !anchorPendingOlder) {
+      landToast("couldn't locate this in the transcript");  // fetching older history → chatHead re-lands, no false "couldn't locate"
+      // …and file it in the error center. The toast is transient and the locate-audit.jsonl row is invisible
+      // from the UI, so a failed jump left NOTHING the user could point at afterwards — it read as the click
+      // doing nothing (the user 2026-07-28, who wanted this represented as an error, not just a pop-up).
+      // The entry carries the sid so clicking it jumps to the card.
+      notifyShell("locate", "Couldn't jump to this in " + (sessions.get(activeId || "")?.name || "the transcript")
+                  + ". The chat is missing that part of its history.", activeId || "");
+    }
   }
   if (!scrolled) {
     if (!v.shown || v.stick) content.scrollTop = content.scrollHeight;
@@ -6510,6 +6522,7 @@ function sharesAnyUuid(a: ChatEvent[], b: ChatEvent[]): boolean {
 function upsert(msg: any) {
   const existed = sessions.has(msg.id);
   const prev = sessions.get(msg.id);
+  awaitingFull.delete(msg.id);   // a full session landed → this session is re-based; a later gap may ask again
   const s: Session = {
     id: msg.id,
     name: msg.name,
@@ -6615,12 +6628,42 @@ function update(msg: any) {
 // index), so we truncate s.events to `from` and append the suffix, then re-render from exactly `from` (set
 // v.rendered = from) so a deep fill repaints without rebuilding the whole transcript. A new connect / fork /
 // behind-the-change client gets a full {type:"session"} instead (kernel decides), so we always have a base.
+// Post one entry to the shell's error center (the rail's warning triangle). Same {romp:'notify'} bridge the
+// feed's card-badge mirror uses; no-ops in the VS Code view, which has no shell frame around it.
+function notifyShell(kind: string, text: string, sid?: string): void {
+  try { window.parent?.postMessage({ romp: "notify", kind, text, sid: sid || "" }, "*"); } catch { /* no shell */ }
+}
+
+// Sessions we've asked the kernel to re-send in full after a delta gap. ONE ask per desync: the pusher runs
+// every 0.5-3s and would otherwise re-ask on every rejected delta until the reply lands. Cleared in upsert(),
+// so the next gap can ask again.
+const awaitingFull = new Set<string>();
+function requestFullSession(id: string): void {
+  if (!id || awaitingFull.has(id)) return;
+  awaitingFull.add(id);
+  vscodeApi?.postMessage({ type: "needFull", id });
+}
+
 function chatTail(msg: any) {
   const s = sessions.get(msg.id);
   if (!s) return;                                  // no base yet → ignore; a full session must arrive first
   // msg.from is a GLOBAL transcript index; the resident events are the tail [headFrom, …) → map to local.
   const from = (msg.from | 0) - (s.headFrom || 0);
-  if (from < 0 || from > s.events.length) return;  // below the loaded head, or a gap → wait for the next full
+  if (from > s.events.length) {
+    // GAP: the delta starts PAST what we hold, so the events in between never reached us. Applying it would
+    // fabricate a transcript that silently skips them. This used to just `return` and "wait for the next
+    // full" — but no full was ever coming: the kernel's per-client bookkeeping (_send_chat's echat) advances
+    // on SEND, not on ACK, so it goes on believing we're caught up and keeps sending deltas we keep dropping.
+    // The tab then froze at this index — a stale "working" chip, no new messages, and every feed/timeline
+    // deep-link into the missing range honest-failing "couldn't locate this in the transcript" — until the
+    // socket happened to drop and a fresh connect re-sent the whole session (the user 2026-07-28, whose tab
+    // went stale twice in one afternoon: locate-audit.jsonl recorded six pointer-not-rendered misses, then
+    // pointer-exact on the SAME anchor the moment a kernel restart forced a reconnect).
+    // So ASK for the full session — the one message that closes this desync class whatever opened it.
+    requestFullSession(msg.id);
+    return;
+  }
+  if (from < 0) return;                            // below the loaded head → our resident tail is still valid
   const wasLen = s.events.length;
   s.events.length = from;                          // drop the (now superseded) tail...
   for (const e of (msg.events || [])) s.events.push(e);   // ...and append the freshly-changed suffix


### PR DESCRIPTION
## The bug

A chat tab could stop updating: a stale "working" chip, no new messages, and every feed/timeline deep-link into the missing range honest-failing "couldn't locate this in the transcript". It stayed that way until the socket happened to drop.

## Root cause

Once a tab is caught up the kernel sends only the changed suffix (`chatTail`). Two defects let that stream desynchronize, and nothing could recover it:

1. **The shared diff baseline was advanced by a single-client push.** `_prev_chat_events` is shared, but `_push_one` targets one client (`_push([client], connect=True)`) on every fresh connect. Everything written since the last full push then fell below the next diff's `change_from`, so every already-connected client was handed a delta starting past what it held. Opening or reloading any pane could silently strand the others.
2. **The client dropped that unappliable delta and waited "for the next full"** — which never came. The kernel's per-client bookkeeping (`_send_chat`'s `echat`) advances when it SENDS, not when the client APPLIES, so it kept believing the tab was caught up and kept sending deltas the tab kept rejecting.

## The fix

- Gate the baseline write on a push that reaches every client (`if not connect`). Removes the known opener.
- Let the client ask for a re-base (`needFull`) when `chatTail` detects a gap; the kernel drops that client's `echat` entry and dedup slot so the next push sends a full session. This closes the desync class whatever opens it. One ask per desync, re-armed when the full session lands.

## Also here

- `_chat_build_sig` stat'd `states/<fsid>.jsonl`, but a **forked** session writes state transitions under the anchor sid. A settle touches only `states/`, so a forked lane's cached payload was never invalidated by one and could latch on "working". Now stats both keys. (Verified live: two sessions had a states file under their identity id and none under the fsid their lane was keyed by.)
- A failed jump is **filed in the error center** as "jump failed" rather than only flashing a toast, so the failure is still there to point at afterwards. The `locate-audit.jsonl` row was invisible from the UI.
- The anchor re-query after a recovery re-render was missing the `data-mids~=` selector the initial lookup uses, so an unhydrated postal turn could be found in the events and still report `pointer-not-rendered`.

## Evidence

Diagnosed from `locate-audit.jsonl`: six `pointer-not-rendered` misses on one session, then `pointer-exact` on the **same anchor** the moment a kernel restart forced a reconnect. The kernel's own build was correct and current throughout (verified by connecting a fresh chat client and comparing against the transcript), so the divergence was entirely in the client's copy.

## Tests

`tests/test_chat_delta_resync.py` (9) and `ui/webview/chat-delta-resync.test.ts` (6), plus re-pinned assertions in three existing tests whose source shapes changed. The baseline gate's pin was verified to fail on a revert.

Full suites: 3398 Python passed, 1391 node passed, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)