### PR TITLE
An offer the user hasn't approved is not a card of its own

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1245,7 +1245,11 @@ PLAN_SYS = (
     "to read), mint it even mid-conversation while other goals are in flight, and even when it shares a "
     "project or theme with an open goal. Sharing context is not the test; sharing an outcome is. Work "
     "filed as a sub disappears into its parent's card, so burying a separate deliverable hides it from "
-    "the user — an explanation checked off as a sub of a big card is an answer the user never sees.\n"
+    "the user — an explanation checked off as a sub of a big card is an answer the user never sees. "
+    "A card born **blocked** is the tell: when all a new goal would hold is a question about work that "
+    "has not started, it is not a goal. Work the assistant merely **offers** (a fix it proposes after "
+    "diagnosing, a follow-up it volunteers) is not an ask, so block the goal that surfaced the offer, "
+    "with the offer as the why, and mint nothing. It earns a card of its own once the user says go.\n"
     '- {\"why\",\"do\":\"sub\",\"under\":<n>,\"text\":\"<step ≤10 words>\"}: a step or progress under '
     "card #n, where #n must be a **top-level card** (a flush-left line in <open-goals>; the indented "
     "sub-goals are context and done/block targets, not filing spots — where inside the card the step "

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -2957,6 +2957,32 @@ class PlanTuning(unittest.TestCase):
         self.assertIn("decide by the finish line, never by topic overlap", jd.OPENER_SYS)
         self.assertGreaterEqual(jd.open_menu.__defaults__[0], 20, "menu cap covers old goals (≥20)")
 
+    def test_an_unapproved_offer_never_mints_its_own_card(self):
+        # The diagnosis/fix SPLIT (the user 2026-07-28): with diagnose-then-ask filed as a block, one
+        # turn started minting TWO cards for one decision — the diagnosis, and a second card holding
+        # only "want me to implement the fix?". Both landed in Blocked, so answering one left the other
+        # sitting there, and clearing that leftover fires the clear wrap-up ("I'm dropping this one"),
+        # which reads as abandoning the fix the user had just approved on the first card.
+        # The tell is a card born blocked: a mint whose whole content is a question about work that
+        # has not started. Work the assistant only OFFERS belongs to the card that surfaced it.
+        for phrase in ("A card born **blocked** is the tell",
+                       "Work the assistant merely **offers**",
+                       "block the goal that surfaced the offer",
+                       "It earns a card of its own once the user says go"):
+            self.assertIn(phrase, jd.PLAN_SYS, phrase)
+        # It has to sit in the MINT bullet, where the mint decision is actually made — the rule read
+        # after the fact (down in the writing guidance) does not reach that choice.
+        mint_at = jd.PLAN_SYS.index('\"do\":\"mint\"')
+        sub_at = jd.PLAN_SYS.index('\"do\":\"sub\"')
+        self.assertLess(mint_at, jd.PLAN_SYS.index("A card born **blocked** is the tell"))
+        self.assertLess(jd.PLAN_SYS.index("A card born **blocked** is the tell"), sub_at)
+        # The ONE path that mints a blocked card on purpose keeps doing so: the clear wrap-up turns
+        # parked work into exactly one keep-or-discard card. That instruction rides in the segment's
+        # own <note>, which is local and explicit, so it still wins over the general rule above
+        # (measured, not assumed: 18/18 wrap-up replays kept minting their single blocked card).
+        import inspect
+        self.assertIn("mint exactly **one** new top-level goal", inspect.getsource(jd.plan_units))
+
     def test_menu_prompts_state_the_numbering_base(self):
         # The zero-based tell's prompt half (the user 2026-07-17): every menu-reading prompt says the
         # numbering counts from 1 and there is no 0, so an off-base reply is a model slip the parsers


### PR DESCRIPTION
Filing diagnose-then-ask as a block did stop diagnoses landing in Completed, but it started splitting one decision across two cards: the diagnosis, plus a second card whose whole content was "want me to implement the fix?". Both sat in Blocked. Answering one left the other behind, and clearing that leftover fires the clear wrap-up, which tells the session the work is being dropped and voids the go-ahead just given on the first card.

The tell is a card born blocked. A goal holding only a question about work that has not started is not a goal, it is the offer, and the offer belongs to the card that surfaced it. The planner now blocks that card and mints nothing; the work earns its own card once the user says go.

One sentence in the mint bullet of `PLAN_SYS`. No new judge, no new pass, no code path.

## How it was measured

Real planner calls replayed against the board each one actually saw: the `<open-goals>` menu is rebuilt from the goal diary and rewound on each row's *write* time rather than its evidence time, since a closer row anchored to an earlier turn is usually written later.

| | born-blocked cards |
|---|---|
| four segments where the assistant offered unapproved work, 6 replays each | **12 before, 2 after** |
| controls (real user asks, answers, already-finished work) | unchanged, 0 in every arm |
| the clear wrap-up's keep-or-discard card, the one path that mints a blocked card on purpose | 18/18 unchanged |

Both suites green: 3390 Python, 1385 Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)