### PR TITLE
SDK failures reach the error center; hollow lane gear, bigger rail gear

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3374,8 +3374,74 @@ def _sdk_locked():
                 reconcile=True)   # boot reconcile: reap orphaned CLIs, resume cut turns, deliver persisted queues
         except Exception:
             sys.stderr.write("sdk-backend unavailable: %s\n" % traceback.format_exc())
+            _sdk_problem("the SDK backend could not be built: %s" % traceback.format_exc())
             _sdk_backend = False
     return _sdk_backend or None
+
+
+# ── SDK problems → the dashboard's error center (the user 2026-07-28) ─────────────────────────────────────
+# The backend keeps a ring of everything that went wrong (SdkBackend._log, problem=True). Those used to
+# live only in the kernel log, so a stream that died or a model switch the CLI refused was invisible: the
+# session just behaved oddly. The feed payload carries the ring and the feed mirrors it into the bell,
+# the same path card badges and /clear boundaries already take (badge-mirror.ts).
+# _SDK_BOOT_PROBLEMS covers the window where there is no backend to hold a ring — the construction itself
+# failed — which is exactly when the user most needs to be told.
+_SDK_BOOT_PROBLEMS = []
+
+
+def _sdk_problem(text):
+    _SDK_BOOT_PROBLEMS.append({"seq": len(_SDK_BOOT_PROBLEMS) + 1, "t": time.time(), "text": str(text)})
+    del _SDK_BOOT_PROBLEMS[:-20]
+
+
+def _sdk_problem_count():
+    """Total problems recorded so far (boot + backend). The view-cache key: it changes only when
+    something actually failed, so a failure lands in the payload on its own event."""
+    n = len(_SDK_BOOT_PROBLEMS)
+    be = _sdk_backend if _sdk_backend else None
+    if be is not None and hasattr(be, "problem_seq"):
+        try:
+            n += int(be.problem_seq())
+        except Exception:
+            pass
+    return n
+
+
+def _sdk_problem_text(text, cap=400):
+    """One line naming what broke, out of a message that may be a whole traceback. The head says what
+    romp was doing ("boot reconcile failed"), the LAST line says what actually raised ("KeyError: 'x'"),
+    and the frames in between are the kernel log's business — so the entry reads as a cause, not as
+    "Traceback (most recent call last):". Deterministic slicing, no parsing of the frames."""
+    lines = [ln.strip() for ln in str(text or "").strip().splitlines() if ln.strip()]
+    if not lines:
+        return ""
+    head = lines[0]
+    if head.endswith("Traceback (most recent call last):"):
+        head = head[:-len("Traceback (most recent call last):")].rstrip(" :")
+    out = head if len(lines) == 1 or lines[-1] == head else ((head + " … " if head else "") + lines[-1])
+    return out[:cap - 1] + "…" if len(out) > cap else out
+
+
+def _sdk_problem_rows(limit=20, cap=400):
+    """Recent SDK-backend problems for the feed payload, oldest first. The signature keys the OCCURRENCE
+    (this kernel's start + the ring's own sequence number), so a re-render or a page reload never re-logs
+    and a repeat of the same failure DOES log again — the bell coalesces a flood into one counted row.
+    Bodies are capped: a full traceback stays in the kernel log, the entry names what broke."""
+    rows = [("boot", r) for r in _SDK_BOOT_PROBLEMS]
+    be = _sdk_backend if _sdk_backend else None
+    if be is not None and hasattr(be, "problems"):
+        try:
+            rows += [("be", r) for r in be.problems(limit)]
+        except Exception:
+            pass   # a fake/older backend without a usable ring: the boot problems still ride
+    out = []
+    for src, r in rows[-limit:]:
+        txt = _sdk_problem_text(r.get("text"), cap)
+        if not txt:
+            continue
+        out.append({"sig": "sdk|%d|%s|%d" % (int(_STARTED), src, int(r.get("seq") or 0)),
+                    "t": float(r.get("t") or 0), "text": txt})
+    return out
 
 
 # ── slash-command list for the composer's "/" autocomplete (the user 2026-06-29) ──────────────────────────────
@@ -12025,6 +12091,8 @@ def build_feed(now, tmux=None):
             "order": _session_order(),
             # /clear boundary settles, newest per session → the bell logs each once (the user 2026-07-27)
             "clearNotices": _boundary_clear_notices(alive),
+            # SDK-backend failures → the same bell, one entry per occurrence (the user 2026-07-28)
+            "sdkNotices": _sdk_problem_rows(),
             "canUndoClear": len(cleared) > 0}
 
 
@@ -14194,6 +14262,7 @@ def _fleet_view_sig(now, tmux):
     sig = _producer_sig(True)
     sig["__judge__"] = _judge_gen[0]
     sig["__bucket__"] = now // 5
+    sig["__sdkp__"] = _sdk_problem_count()   # a fresh SDK failure is its own event → rebuild now, don't wait
     for p, k in ((jd.STATE / "colormap", "__cmap__"), (jd.STATE / "session-flags.json", "__flags__"),
                  (jd.STATE / "session-order.json", "__order__"),
                  (jd.STATE / "notify-cards.json", "__ncards__")):   # per-card bell arming → the card's menu state
@@ -15038,9 +15107,10 @@ el.classList.toggle('has',n>0||(kindOn('conn')&&liveDown()));
 var t=el.querySelector('.rerr-n');if(t)t.textContent=n<=0?'!':(n>9?'+':String(n));});
 if(!back.hidden)renderList();}
 // each entry leads with the chip its card wears in the feed, so the vocabulary matches across surfaces
-var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror','locate','cleared'];
+var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror','sdk','locate','cleared'];
 var KINDLBL={conn:'offline',limit:'limit',judge:'judge',warn:'warning',stalled:'stalled',
-nudge:'follow-up failed',retry:'retrying',apierror:'api error',locate:'jump failed',cleared:'cleared'};
+nudge:'follow-up failed',retry:'retrying',apierror:'api error',sdk:'sdk',
+locate:'jump failed',cleared:'cleared'};
 // what each kind MEANS (the user 2026-07-28: the tooltip should explain the badge, not just say
 // show/hide) — worn by the filter toggles AND every entry's chip
 var DESC={conn:"the dashboard lost its live connection to the kernel for a visible pane; it reconnects on its own",
@@ -15051,6 +15121,7 @@ stalled:"romp itself is holding a working thread and nothing is moving it \u2014
 nudge:"romp's one automatic follow-up on a stalled thread didn't resolve it; the thread now needs you",
 retry:"a session is inside an API-error retry storm; auto-retry is already working on it",
 apierror:"a session stopped on an API error (rate limit, spend cap, or prompt too long) and its card is blocked",
+sdk:"romp's SDK backend, the machinery that actually runs your sessions, hit an error: a session thread that died, a stream that dropped, a setting the CLI refused. The session usually recovers on its own, and the full traceback is in the kernel log under ~/.local/state/romp",
 locate:"a click that should have jumped to a message in the chat couldn't find it. Usually the chat is missing part of its history; reload the pane if it keeps happening",
 cleared:"a /clear in a session dropped still-open cards at the boundary; Undo clear on the feed restores them"};
 // the toggles ARE the chips (same pill, same colours) — lit = shown, dimmed = muted. Built once on a
@@ -15951,6 +16022,11 @@ def _landing():
             # wrapper) of the bottom bar and ALWAYS visible — settings (⛭, last in the DOM) at the far right.
             ".rail-act{flex:0 0 auto;display:flex;align-items:center;justify-content:center;margin:1px 4px;padding:4px 0;"
             "border-radius:5px;cursor:pointer;color:#8a8a8a;font-size:15px;line-height:1;user-select:none;transition:color .1s,background .1s}"
+            # the settings gear is a text glyph among 18px svg siblings, so at the shared 15px it drew
+            # visibly smaller than the triangle / reload / network icons beside it — sized up on its own
+            # to match them (the user 2026-07-28). Font sizes stay few: this is one glyph matched to the
+            # icon row it sits in, not a new size for text.
+            "#rail-gear{font-size:19px}"
             ".rail-act:hover{color:#fff;background:rgba(255,255,255,0.06)}"
             ".rail-act:active{transform:scale(0.92)}"
             ".rail-act svg{display:block}"
@@ -16262,7 +16338,7 @@ def _landing():
             "border-radius:999px;line-height:1.4;white-space:nowrap;border:1px solid transparent}"
             ".rerr-chip.k-stalled,.rerr-chip.k-warn{color:#ffd166;border-color:rgba(255,209,102,0.6)}"
             ".rerr-chip.k-nudge{color:#ff6a6a;border-color:rgba(255,106,106,0.6)}"
-            ".rerr-chip.k-retry,.rerr-chip.k-apierror{color:#e5484d;border-color:rgba(229,72,77,0.6)}"
+            ".rerr-chip.k-retry,.rerr-chip.k-apierror,.rerr-chip.k-sdk{color:#e5484d;border-color:rgba(229,72,77,0.6)}"
             ".rerr-chip.k-conn{color:#ff6b6b;border-color:rgba(255,107,107,0.6)}"
             ".rerr-chip.k-limit,.rerr-chip.k-judge,.rerr-chip.k-locate{color:#e0a030;border-color:rgba(224,160,48,0.6)}"
             ".rerr-chip.k-cleared{color:#9aa0a6;border-color:rgba(154,160,166,0.6)}"   # not an error — quiet gray

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -24,6 +24,7 @@ import os
 import re
 import signal
 import subprocess
+import sys
 import threading
 import time
 import traceback
@@ -1085,8 +1086,8 @@ class SdkSession:
         if cb:
             try:
                 cb()
-            except Exception:
-                pass
+            except Exception as e:
+                self.backend._log("boot-settled callback (%s) failed: %s" % (self.name, e))
 
     def enqueue(self, text: str):
         """Deliver a user turn (called from the kernel thread). Held in self._pending —
@@ -1280,8 +1281,8 @@ class SdkSession:
     async def _do_set_model(self, model):
         try:
             await self.client.set_model(model)
-        except Exception:
-            pass
+        except Exception as e:
+            self.backend._log("set_model (%s -> %s) refused by the SDK: %s: %s" % (self.name, model, type(e).__name__, e))
         # Pull the real new name NOW rather than waiting for the next turn's assistant message — an idle
         # session the user switched but doesn't drive again would otherwise sit on the switching-dots
         # indefinitely (the user 2026-07-03). get_context_usage reports the current model, so this
@@ -1292,8 +1293,8 @@ class SdkSession:
     async def _do_set_mode(self, mode):
         try:
             await self.client.set_permission_mode(mode)
-        except Exception:
-            pass
+        except Exception as e:
+            self.backend._log("set_permission_mode (%s -> %s) refused by the SDK: %s: %s" % (self.name, mode, type(e).__name__, e))
 
     async def _do_refresh_context(self):
         """Pull authoritative context-window usage from the SDK — the DESIGNED source. `get_context_usage()` is
@@ -1333,8 +1334,8 @@ class SdkSession:
         if upd:
             try:
                 self.backend._update_reg(self.sid, **upd)
-            except Exception:
-                pass
+            except Exception as e:
+                self.backend._log("context refresh (%s): registry write failed: %s" % (self.name, e))
 
     async def _do_refresh_usage(self):
         """Pull the EXACT account-wide /usage snapshot from the CLI — the designed data behind the /usage
@@ -1386,7 +1387,11 @@ class SdkSession:
             self.backend._heal_stale_awaiting(self.sid)
             asyncio.run(self._amain())
         except Exception as e:                       # surfaced for debugging; never crash kernel
-            self.backend._log(f"sdk session {self.name} crashed: {type(e).__name__}: {e}")
+            # The TRACEBACK too, not just the type and message: a bare "KeyError: <uuid>" names no line,
+            # so a crash that killed a session left nothing to fix it by. The error center shows the
+            # first line; the kernel log keeps the whole thing.
+            self.backend._log(f"sdk session {self.name} crashed: {type(e).__name__}: {e}\n"
+                              f"{traceback.format_exc()}")
         finally:
             self._fire_boot_settled()   # a dead thread must free its boot-stagger slot (first, so
             #                             a raising _on_session_gone can never leak the slot)
@@ -1504,7 +1509,11 @@ class SdkSession:
                         # which prunes on the next message (the user 2026-07-16). Written here, not at request
                         # time, so it pins when the new effort became REAL — turn-end for a busy session, whose
                         # in-flight turn ran at the OLD effort (recording at request would misdate it).
-                        append_effort_applied(self.state_dir, self.sid, self._effort_pending)
+                        # self.backend.state_dir, not self.state_dir: a session has no state_dir of its own,
+                        # and the typo raised straight out of the connect path — killing the session thread
+                        # on any /effort switch that applied at reconnect (found 2026-07-28 in the backend's
+                        # own crash log, which until now nothing showed the user).
+                        append_effort_applied(self.backend.state_dir, self.sid, self._effort_pending)
                         self._effort_pending = ""
                         self.backend._update_reg(self.sid, effortPending=False)
                         self.backend._poke()
@@ -1571,8 +1580,8 @@ class SdkSession:
             self._persist_queue()
         try:
             self.backend._update_reg(self.sid, rewindTo="", rewindLeaf="", rewindBare=False)
-        except Exception:
-            pass
+        except Exception as e:
+            self.backend._log("rewind (%s): registry clear failed: %s" % (self.name, e))
         self.backend._log("rewind (%s): the CLI refused --resume-session-at (%s: %s) — flag dropped, "
                           "%s" % (self.name, type(exc).__name__, exc,
                                   "the rollback did not happen" if bare else "edited message returned to the user"))
@@ -1581,8 +1590,8 @@ class SdkSession:
                 ("the rollback failed (the session's CLI refused it) — the conversation is unchanged" if bare else
                  "the rewind failed (the session's CLI refused it) — your edited message was NOT sent%s"
                  % ((": " + dropped) if dropped else ""))})
-        except Exception:
-            pass
+        except Exception as e:
+            self.backend._log("rewind (%s): could not tell the chat the rewind failed: %s" % (self.name, e))
         self.backend._poke()
 
     def _learn_model(self, pm):
@@ -1604,8 +1613,8 @@ class SdkSession:
         self.model = pm
         try:
             self.backend._update_reg(self.sid, liveModel=pm, modelPending=bool(self._model_pending))
-        except Exception:
-            pass
+        except Exception as e:
+            self.backend._log("model learn (%s): registry write failed: %s" % (self.name, e))
         self.backend._poke()
 
     def _resolve_model_pending(self, pm) -> bool:
@@ -1616,8 +1625,8 @@ class SdkSession:
         self._model_pending = ""
         try:
             self.backend._update_reg(self.sid, modelPending=False)
-        except Exception:
-            pass
+        except Exception as e:
+            self.backend._log("model-pending clear (%s): registry write failed: %s" % (self.name, e))
         return True
 
     def _ctx_pct(self):
@@ -1763,8 +1772,8 @@ class SdkSession:
                 self._rewind_armed = False
                 try:
                     self.backend._update_reg(self.sid, rewindTo="", rewindLeaf="", rewindBare=False)
-                except Exception:
-                    pass
+                except Exception as e:
+                    self.backend._log("rewind (%s): registry clear failed after the turn landed: %s" % (self.name, e))
             self.backend._turn_completed(self.sid)   # a landed result re-arms the crash-resume budget
             self._mark("waiting")
             self.backend.retire_live_work(self.sid)   # turn over → a work atom that never landed never will
@@ -2004,8 +2013,8 @@ class SdkSession:
             # normally clear here, so the mirror never false-alarms.
             try:
                 self.backend._update_reg(self.sid, bgTasks=self._live_bg_tasks())
-            except Exception:
-                pass
+            except Exception as e:
+                self.backend._log("background tasks (%s): registry mirror write failed: %s" % (self.name, e))
             self.backend._poke()
 
     def _live_bg_tasks(self) -> list:
@@ -2114,12 +2123,18 @@ class SdkBackend:
         self._pending_ask: dict[str, bool] = {}   # sid -> has an ask awaiting answer
         self._live: dict[str, dict] = {}          # sid -> {key -> atom}: the in-memory LIVE TAIL (ahead of disk)
         self._rl_lock = threading.Lock()          # serializes usage.json read-merge-write (_record_rate_limit)
+        # Backend PROBLEMS, kept in a bounded ring so the dashboard can show them (see _log): until
+        # 2026-07-28 every SDK failure went to the kernel log alone, which nobody tails, so a session
+        # whose stream died or whose model switch was refused just looked odd with no way to find out.
+        self._problems: list[dict] = []
+        self._problem_seq = 0
+        self._problem_lock = threading.Lock()
         # The dependency check, done ONCE here: absent → every session this backend owns reports the same
         # launch error (launch_error), instead of each one silently dying at its own lazy import.
         self._sdk_missing = not sdk_importable()
         if self._sdk_missing and log:
-            log("claude_agent_sdk is NOT importable — every SDK session will report itself unable to "
-                "start (run bin/romp-sdk-setup). tmux sessions are unaffected.")
+            self._log("claude_agent_sdk is NOT importable — every SDK session will report itself unable to "
+                      "start (run bin/romp-sdk-setup). tmux sessions are unaffected.", problem=True)
         self._heal_attempts: dict[str, int] = {}  # sid -> crash-resume attempts since its last COMPLETED turn
         #                                           (bounds _heal_cut_session to one resume per cut; a completed
         #                                           turn resets it, so a crash LOOP can't respawn forever)
@@ -2154,8 +2169,8 @@ class SdkBackend:
         try:
             if last_awaiting(self.state_dir, sid) is True:
                 append_awaiting(self.state_dir, sid, False)
-        except Exception:
-            pass
+        except Exception as e:
+            self._log("awaiting heal (%s): %s" % (sid[:8], e))
 
     def _session_cli_pid(self, session) -> int | None:
         """The live CLI pid for `session` — a child of THIS kernel resuming its sid (or lastSid, the
@@ -2301,8 +2316,8 @@ class SdkBackend:
         for s in sessions:
             try:
                 s.shutdown()
-            except Exception:
-                pass
+            except Exception as e:
+                self._log("drain: shutdown failed for %s: %s" % (s.name, e))
         deadline = time.time() + timeout
         for s in sessions:
             s.thread.join(max(0.05, deadline - time.time()))
@@ -2509,16 +2524,47 @@ class SdkBackend:
         self._poke()   # nudge the producer so the rail re-reads usage.json promptly, not on the next backstop
 
     # ---- logging / wakeups ----
-    def _log(self, m):
+    PROBLEM_RING = 100        # how many backend problems are kept for the dashboard (oldest dropped)
+
+    def _log(self, m, problem=None):
+        """Every backend line goes to the kernel log; the ones that report a FAILURE also land in a ring
+        the dashboard's error center reads, so an SDK problem shows up where the user is looking instead
+        of only in a file nobody tails (the user 2026-07-28, who could tell exceptions were happening and
+        was never shown any).
+
+        What counts as a problem is the exact event, not a keyword sniff on the message: a line logged
+        while an exception is being handled IS that exception's report. sys.exc_info() is live for the
+        whole dynamic extent of an `except` block — helpers called from inside one included — so the
+        classification follows the code path that produced the line. `problem=` overrides either way."""
+        if problem is None:
+            problem = sys.exc_info()[0] is not None
+        if problem:
+            with self._problem_lock:
+                self._problem_seq += 1
+                self._problems.append({"seq": self._problem_seq, "t": time.time(), "text": str(m)})
+                if len(self._problems) > self.PROBLEM_RING:
+                    del self._problems[:-self.PROBLEM_RING]
         if self._log_cb:
             self._log_cb(m)
+
+    def problem_seq(self) -> int:
+        """How many problems this backend has recorded — a cheap cache key for the view builders, so a
+        fresh failure busts the feed on the event instead of riding the next unrelated change."""
+        with self._problem_lock:
+            return self._problem_seq
+
+    def problems(self, limit: int = 0) -> list[dict]:
+        """The recorded problems, oldest first (a copy — callers must not mutate the ring)."""
+        with self._problem_lock:
+            rows = list(self._problems)
+        return rows[-limit:] if limit else rows
 
     def _poke(self):
         if self._poke_cb:
             try:
                 self._poke_cb()
-            except Exception:
-                pass
+            except Exception as e:
+                self._log("producer wake failed: %s" % e)
 
     # ---- SDK option assembly (mirrors the tmux launch flags) ----
     def _options(self, sess: SdkSession, ClaudeAgentOptions):
@@ -2551,8 +2597,8 @@ class SdkBackend:
             try:
                 kw["system_prompt"] = {"type": "preset", "preset": "claude_code",
                                        "append": Path(self.append_prompt_path).read_text()}
-            except OSError:
-                pass
+            except OSError as e:
+                self._log("system-prompt append unreadable (%s) — sessions start WITHOUT it: %s" % (self.append_prompt_path, e))
         if sess.chosen_model and sess.chosen_model != "default":
             kw["model"] = sess.chosen_model    # keep the picked model across a reconnect (runtime set_model is per-connection)
         if sess.resume_sid:
@@ -2577,8 +2623,8 @@ class SdkBackend:
             sess._rewind_bare = False
             try:
                 self._update_reg(sess.sid, rewindTo="", rewindLeaf="", rewindBare=False)
-            except Exception:
-                pass
+            except Exception as e:
+                self._log("rewind (%s): registry clear failed: %s" % (sess.name, e))
             self._log("rewind (%s): conversation moved since the request — flag spent, resuming plainly"
                       % sess.name)
         if self.mcp_config:
@@ -2634,8 +2680,8 @@ class SdkBackend:
             if on_boot_settled:
                 try:
                     on_boot_settled()
-                except Exception:
-                    pass
+                except Exception as e:
+                    self._log("boot-settled callback failed: %s" % e)
         with self._lock:
             s = self.sessions.get(sid)
             if s and s.thread.is_alive():
@@ -2780,8 +2826,8 @@ class SdkBackend:
                 for a in d.values() if a.get("_echo_text") and not a.get("command")]
         try:
             self._update_reg(sid, echoes=snap)
-        except Exception:
-            pass
+        except Exception as e:
+            self._log("echo mirror (%s): registry write failed: %s" % (sid[:8], e))
 
     def _reseed_echoes(self, regs: list[dict]) -> None:
         """Kernel boot: re-create each alive session's persisted unlanded echoes in the live store, so a
@@ -3150,8 +3196,8 @@ class SdkBackend:
         if self._push_cb:
             try:
                 self._push_cb()
-            except Exception:
-                pass
+            except Exception as e:
+                self._log("chat push wake failed: %s" % e)
 
     def live_atoms(self, sid: str) -> list:
         """The session's in-memory live-tail atoms (newest last), for build_session to merge ahead of disk."""
@@ -3324,14 +3370,14 @@ class SdkBackend:
             sess._model_pending = ""
             try:
                 self._update_reg(sess.sid, liveModel=_alias_label(sess.chosen_model), modelPending=False)
-            except Exception:
-                pass
+            except Exception as e:
+                self._log("session gone (%s): model-pending clear failed: %s" % (sess.name, e))
         if sess._effort_pending:          # an /effort reconnect that never landed before the thread died → clear the dots/notice
             sess._effort_pending = ""
             try:
                 self._update_reg(sess.sid, effortPending=False)
-            except Exception:
-                pass
+            except Exception as e:
+                self._log("session gone (%s): effort-pending clear failed: %s" % (sess.name, e))
         # Background tasks are the CLI's children, so they just died too. A session idle-waiting on a
         # timer/watcher would wait FOREVER for a completion that can never arrive — tell it, visibly,
         # and wake it so it can relaunch what still matters (the user 2026-07-11: nimbus's campaign

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -216,12 +216,14 @@ class ErrorCenterExecutes(unittest.TestCase):
         # drowns the rest). The toggles ARE the chips, in the same order entries wear them.
         # 'jump failed' joined on 2026-07-28: a deep-link that can't find its message in the chat files
         # an entry now, rather than only flashing a toast that leaves nothing to point at afterwards.
+        # 'sdk' joined on 2026-07-28: SDK-backend failures used to live only in the kernel
+        # log, so a session whose thread died just looked odd with nothing to look at.
         a = self.out["filterBar"]
-        self.assertEqual(a["n"], 10)
+        self.assertEqual(a["n"], 11)
         self.assertEqual(a["first"], "offline")
         self.assertEqual(a["labels"],
                          "offline|limit|judge|warning|stalled|follow-up failed|retrying|api error|"
-                         "jump failed|cleared")
+                         "sdk|jump failed|cleared")
 
     def test_muting_a_kind_hides_counts_and_live_cue_but_keeps_the_entries(self):
         a = self.out["afterMute"]

--- a/tests/test_kernel_effort_note.py
+++ b/tests/test_kernel_effort_note.py
@@ -63,8 +63,11 @@ class EffortNoteSourcePins(unittest.TestCase):
         # written inside the `if self._effort_pending:` reconnect-clear block, so the timestamp is the moment
         # the new effort became REAL — not when it was requested (a busy session's in-flight turn ran the old
         # effort). append_effort_applied is called BEFORE the pending flag is cleared, so it still has the value.
-        self.assertIn("append_effort_applied(self.state_dir, self.sid, self._effort_pending)", BACKEND_SRC)
-        i = BACKEND_SRC.index("append_effort_applied(self.state_dir")
+        # self.backend.state_dir, not self.state_dir: a session has no state_dir of its own, and the typo
+        # raised an AttributeError straight out of the connect path — killing the session thread on any
+        # /effort switch that applied at reconnect (fixed 2026-07-28, found in the backend's crash log).
+        self.assertIn("append_effort_applied(self.backend.state_dir, self.sid, self._effort_pending)", BACKEND_SRC)
+        i = BACKEND_SRC.index("append_effort_applied(self.backend.state_dir")
         j = BACKEND_SRC.index('self._effort_pending = ""', i)
         self.assertLess(i, j, "the marker is written while _effort_pending still holds the applied value")
 

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -123,6 +123,9 @@ class PaneRailTest(unittest.TestCase):
         # the gear is the bigger ⛭ (gear-without-hub) the user restored — NOT the thinner ⚙
         self.assertIn("aria-label=Settings>⛭</div>", self.html)
         self.assertNotIn("⚙", self.html)
+        # …and it is sized UP from the shared .rail-act 15px (the user 2026-07-28): a text glyph at 15px
+        # drew visibly smaller than the 17-18px svg icons beside it, so the row looked ragged.
+        self.assertIn("#rail-gear{font-size:19px}", self.html)
 
     def test_network_icon_lights_accent_when_a_remote_is_connected(self):
         # the remote-kernels icon goes accent-blue (.on) while a tunnel is up, driven by the /tunnels poll

--- a/tests/test_sdk_error_visibility.py
+++ b/tests/test_sdk_error_visibility.py
@@ -1,0 +1,203 @@
+"""SDK-backend problems reach the user (the user 2026-07-28).
+
+Everything the SDK backend logs used to go to the kernel's stderr and nowhere else: a session thread
+that died, a stream that dropped, a model switch the CLI refused. The dashboard showed none of it, so a
+session that misbehaved left the user with nothing to look at. Now every line logged WHILE AN EXCEPTION
+IS BEING HANDLED is recorded in a bounded ring, the feed payload carries it, and the feed mirrors it
+into the shell's error center as a 'sdk' entry.
+
+The classification is the exact event, not a keyword sniff: sys.exc_info() is live for the whole dynamic
+extent of an except block, so a line emitted from inside one (helpers included) IS that exception's
+report.
+"""
+import ast
+import inspect
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_sdkerr", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_sdkerr", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+SB_SRC = open(os.path.join(BIN, "romp_sdk_backend.py")).read()
+
+
+class _Ring(sb.SdkBackend):
+    """The ring + _log alone — SdkBackend.__init__ touches the real state dir, which these don't need."""
+
+    def __init__(self):
+        self._problems = []
+        self._problem_seq = 0
+        import threading
+        self._problem_lock = threading.Lock()
+        self.lines = []
+        self._log_cb = self.lines.append
+
+
+class ProblemRing(unittest.TestCase):
+    def test_a_line_logged_while_handling_an_exception_is_a_problem(self):
+        r = _Ring()
+        try:
+            raise ValueError("the stream dropped")
+        except ValueError as e:
+            r._log("sdk session web crashed: %s" % e)
+        self.assertEqual(len(r.problems()), 1)
+        self.assertIn("the stream dropped", r.problems()[0]["text"])
+        self.assertEqual(r.lines, ["sdk session web crashed: the stream dropped"],
+                         "the kernel log still gets every line, unchanged")
+
+    def test_an_ordinary_line_is_not_a_problem(self):
+        r = _Ring()
+        r._log("boot reconcile: resumed 2 cut turn(s)")
+        self.assertEqual(r.problems(), [])
+        self.assertEqual(len(r.lines), 1)
+
+    def test_a_helper_called_from_inside_an_except_block_still_counts(self):
+        # the dynamic extent is the point: the report is usually written by a helper, not at the raise
+        r = _Ring()
+
+        def report():
+            r._log("rewind (web): the CLI refused --resume-session-at")
+
+        try:
+            raise RuntimeError("refused")
+        except RuntimeError:
+            report()
+        self.assertEqual(len(r.problems()), 1)
+
+    def test_problem_kwarg_overrides_in_both_directions(self):
+        r = _Ring()
+        r._log("claude_agent_sdk is NOT importable", problem=True)     # no live exception, still a problem
+        try:
+            raise OSError("expected")
+        except OSError:
+            r._log("this one is routine", problem=False)
+        texts = [p["text"] for p in r.problems()]
+        self.assertEqual(texts, ["claude_agent_sdk is NOT importable"])
+
+    def test_the_ring_is_bounded_and_keeps_the_newest(self):
+        r = _Ring()
+        for i in range(sb.SdkBackend.PROBLEM_RING + 25):
+            r._log("failure %d" % i, problem=True)
+        rows = r.problems()
+        self.assertEqual(len(rows), sb.SdkBackend.PROBLEM_RING)
+        self.assertEqual(rows[-1]["text"], "failure %d" % (sb.SdkBackend.PROBLEM_RING + 24))
+        self.assertEqual(r.problem_seq(), sb.SdkBackend.PROBLEM_RING + 25,
+                         "the sequence keeps counting past the ring — it is the occurrence id")
+
+    def test_problems_returns_a_copy_and_honours_limit(self):
+        r = _Ring()
+        for i in range(5):
+            r._log("failure %d" % i, problem=True)
+        rows = r.problems(2)
+        self.assertEqual([x["text"] for x in rows], ["failure 3", "failure 4"])
+        rows.clear()
+        self.assertEqual(len(r.problems()), 5, "the caller cannot mutate the ring")
+
+
+class NoSilentSwallows(unittest.TestCase):
+    """The failures that used to be `except Exception: pass` now log — which is what puts them in the
+    ring. Checked per-function so the test says what regressed, not just that a count moved."""
+
+    LOUD = ("_do_set_model", "_do_set_mode", "_do_refresh_context", "_learn_model",
+            "_resolve_model_pending", "_heal_stale_awaiting", "_persist_echoes", "_on_session_gone",
+            "_fire_boot_settled", "_poke", "_wake_push", "_options")
+
+    def test_named_handlers_report_instead_of_passing(self):
+        tree = ast.parse(SB_SRC)
+        fns = {n.name: n for n in ast.walk(tree)
+               if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name in self.LOUD}
+        self.assertEqual(sorted(fns), sorted(self.LOUD), "a checked function was renamed or removed")
+        for name, fn in fns.items():
+            for h in [n for n in ast.walk(fn) if isinstance(n, ast.ExceptHandler)]:
+                bare = len(h.body) == 1 and isinstance(h.body[0], ast.Pass)
+                self.assertFalse(bare, "%s swallows an exception silently again" % name)
+
+
+class SessionAttributes(unittest.TestCase):
+    def test_a_session_never_reads_a_state_dir_of_its_own(self):
+        # the AttributeError that killed a session thread on an /effort switch applied at reconnect:
+        # state_dir lives on the BACKEND. This is the class of bug the ring made visible.
+        tree = ast.parse(SB_SRC)
+        cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "SdkSession")
+        reads = [n for n in ast.walk(cls)
+                 if isinstance(n, ast.Attribute) and n.attr == "state_dir"
+                 and isinstance(n.value, ast.Name) and n.value.id == "self"]
+        self.assertEqual(reads, [], "SdkSession has no state_dir — use self.backend.state_dir")
+
+    def test_a_crashed_session_logs_its_traceback(self):
+        self.assertIn("crashed: {type(e).__name__}: {e}", SB_SRC)
+        i = SB_SRC.index("crashed: {type(e).__name__}: {e}")
+        self.assertIn("traceback.format_exc()", SB_SRC[i:i + 300],
+                      "a bare type+message names no line to fix")
+
+
+class KernelSide(unittest.TestCase):
+    def test_a_traceback_folds_to_cause_and_effect(self):
+        txt = km._sdk_problem_text("boot reconcile failed: Traceback (most recent call last):\n"
+                                   "  File \"kernel/sdk_backend.py\", line 1, in _boot_reconcile\n"
+                                   "    raise KeyError('x')\n"
+                                   "KeyError: 'x'\n")
+        self.assertEqual(txt, "boot reconcile failed … KeyError: 'x'")
+
+    def test_a_one_line_problem_is_left_alone_and_long_ones_are_capped(self):
+        self.assertEqual(km._sdk_problem_text("set_model (web -> opus) refused"),
+                         "set_model (web -> opus) refused")
+        self.assertEqual(km._sdk_problem_text(""), "")
+        long = km._sdk_problem_text("x" * 900, cap=40)
+        self.assertEqual(len(long), 40)
+        self.assertTrue(long.endswith("…"))
+
+    def test_rows_sign_each_occurrence_and_skip_blanks(self):
+        km._SDK_BOOT_PROBLEMS[:] = [{"seq": 1, "t": 100.0, "text": "the SDK backend could not be built"},
+                                    {"seq": 2, "t": 101.0, "text": "   "}]
+        try:
+            rows = km._sdk_problem_rows()
+            self.assertEqual([r["text"] for r in rows], ["the SDK backend could not be built"])
+            self.assertEqual(len({r["sig"] for r in rows}), len(rows))
+            self.assertTrue(rows[0]["sig"].startswith("sdk|"))
+            self.assertEqual(rows[0]["t"], 100.0)
+            again = km._sdk_problem_rows()
+            self.assertEqual(again[0]["sig"], rows[0]["sig"],
+                             "a rebuild re-sends the SAME signature, so the bell never re-logs it")
+        finally:
+            km._SDK_BOOT_PROBLEMS.clear()
+
+    def test_a_boot_problem_and_a_backend_problem_cannot_collide(self):
+        # both rings number from 1; the source tag is what keeps their signatures apart
+        class _Be:
+            def problems(self, limit=0):
+                return [{"seq": 1, "t": 5.0, "text": "sdk session web crashed"}]
+
+            def problem_seq(self):
+                return 1
+
+        km._SDK_BOOT_PROBLEMS[:] = [{"seq": 1, "t": 4.0, "text": "the SDK backend could not be built"}]
+        prev = km._sdk_backend
+        km._sdk_backend = _Be()
+        try:
+            rows = km._sdk_problem_rows()
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(len({r["sig"] for r in rows}), 2)
+            self.assertEqual(km._sdk_problem_count(), 2)
+        finally:
+            km._sdk_backend = prev
+            km._SDK_BOOT_PROBLEMS.clear()
+
+    def test_the_feed_payload_and_its_cache_key_carry_the_problems(self):
+        self.assertIn('"sdkNotices": _sdk_problem_rows(),', inspect.getsource(km.build_feed))
+        # a fresh failure is its own event: the view cache busts on it instead of riding the 5s bucket
+        self.assertIn('sig["__sdkp__"] = _sdk_problem_count()', inspect.getsource(km._fleet_view_sig))
+
+    def test_the_error_center_knows_the_kind(self):
+        js = km._LANDING_ERRS_JS
+        self.assertIn("'apierror','sdk'", js)
+        self.assertIn("sdk:'sdk'", js)
+        self.assertIn("sdk:\"romp's SDK backend", js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -389,11 +389,11 @@ function bellIcon(off, cx, cy, color) {
 // The per-lane SETTINGS GEAR (the user 2026-07-28, round 3): the three toggle icons above no longer
 // draw on the lane — three always-on icons crowded the row — so ONE gear opens them as a drop-down
 // (_openLaneMenu), each row wearing its icon, its state, and a plain-language line. Drawn like its
-// neighbors: a toothed ring + a filled hub, monochrome.
+// neighbors: a toothed ring, monochrome and HOLLOW — no hub dot (the user 2026-07-28), which also
+// matches the ⛭ the rail's settings button wears at the bottom right.
 function gearIcon(cx, cy, color) {
   const g = el('g', { 'pointer-events': 'none' });
   g.appendChild(el('circle', { cx: cx, cy: cy, r: 3.9, fill: 'none', stroke: color, 'stroke-width': 1.2 }));
-  g.appendChild(el('circle', { cx: cx, cy: cy, r: 1.4, fill: color, stroke: 'none' }));
   for (let i = 0; i < 8; i++) {
     const a = (Math.PI / 4) * i;
     g.appendChild(el('line', { x1: cx + 4.4 * Math.cos(a), y1: cy + 4.4 * Math.sin(a),

--- a/ui/timeline-flags.test.ts
+++ b/ui/timeline-flags.test.ts
@@ -21,8 +21,12 @@ test("ONE gear column sits between the name and the model (live lanes only)", ()
   assert.match(SRC, /if \(s\.live\) \{[\s\S]*?gearIcon\(gcx, gcy, MODEL_FG\)/);
 });
 
-test("the gear is DRAWN (toothed ring + filled hub) and opens the menu on POINTERDOWN (redraw-proof)", () => {
+test("the gear is DRAWN (hollow toothed ring) and opens the menu on POINTERDOWN (redraw-proof)", () => {
   assert.match(SRC, /function gearIcon\(cx, cy, color\)/);
+  // hollow: no hub dot (the user 2026-07-28), matching the ⛭ the rail's settings button wears
+  const gear = SRC.slice(SRC.indexOf("function gearIcon"), SRC.indexOf("const LANE_TOGGLES"));
+  assert.doesNotMatch(gear, /fill: color/, "the centre stays empty");
+  assert.match(gear, /r: 3\.9, fill: 'none'/);
   assert.match(SRC, /const ghit = el\('rect', \{[^}]*fill: 'transparent', 'pointer-events': 'all'/);
   // pointerdown, not click: a lane redraw between mousedown and mouseup replaced the hit-rect so a
   // plain 'click' never fired (the original direct-toggle lesson, 2026-06-23) — the menu opens on press

--- a/ui/webview/badge-mirror.test.ts
+++ b/ui/webview/badge-mirror.test.ts
@@ -80,7 +80,7 @@ test("a NEWER boundary on the same session is a new entry — its own t keys the
 });
 
 test("the feed posts each notice to the shell and persists only the ACTIVE set", () => {
-  assert.match(FEED, /mirrorBadges\(incomingAsks, Array\.isArray\(m\.clearNotices\) \? m\.clearNotices : \[\]\)/,
+  assert.match(FEED, /mirrorBadges\(incomingAsks, Array\.isArray\(m\.clearNotices\) \? m\.clearNotices : \[\],/,
     "runs on every feed payload, against the FULL list + the kernel's clear notices");
   assert.match(FEED, /clearBoundaryNotices\(clears, seenSet\)/, "clear drops ride the same seen-set");
   assert.match(FEED,

--- a/ui/webview/badge-mirror.ts
+++ b/ui/webview/badge-mirror.ts
@@ -79,3 +79,22 @@ export function clearBoundaryNotices(rows: ClearNoticeRow[], seen: Set<string>):
   }
   return { notices, active };
 }
+
+// SDK-backend problems (the kernel's sdkNotices payload — SdkBackend._log's problem ring). Same
+// episode-identity contract: the kernel signs each OCCURRENCE (its start + the ring's sequence), so
+// re-renders and reloads never re-log, while a repeat of the same failure is a NEW occurrence and logs
+// again (the bell's own coalescing turns a flood into one counted row). Until 2026-07-28 these went to
+// the kernel log alone, so a session whose thread died just looked odd, with nothing to look at.
+export interface SdkNoticeRow { sig: string; t: number; text: string; }
+
+export function sdkProblemNotices(rows: SdkNoticeRow[], seen: Set<string>): { notices: BadgeNotice[]; active: Set<string> } {
+  const notices: BadgeNotice[] = [];
+  const active = new Set<string>();
+  for (const r of rows ?? []) {
+    if (!r || !r.sig || !r.text) continue;   // a blank line is not an entry
+    active.add(r.sig);
+    if (seen.has(r.sig)) continue;
+    notices.push({ kind: "sdk", text: cap(r.text, 240), sig: r.sig, sid: "", itemId: "" });
+  }
+  return { notices, active };
+}

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -13,7 +13,8 @@ import { hostNameNodes, hostPartsNodes } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
 import { provenanceRows, provenanceGroupRows, rootStart, type ProvFmt, type ProvRow } from "./provenance";
 import { ageColorReadable } from "./age-color";
-import { badgeNotices, clearBoundaryNotices, type ClearNoticeRow } from "./badge-mirror";
+import { badgeNotices, clearBoundaryNotices, sdkProblemNotices,
+  type ClearNoticeRow, type SdkNoticeRow } from "./badge-mirror";
 import { initStrip } from "./strip";
 import { installSettingsSync } from "./settings";
 import { previewThumb, previewKind } from "./preview";
@@ -3235,7 +3236,7 @@ function pipeBanner(up: boolean, queued: number): void {
 // the {romp:'notify'} post the shell's bell listens for. Storing only the ACTIVE set is what re-arms a
 // cleared badge and keeps the store from growing: a card that left the payload takes its sigs with it.
 const BADGE_SEEN_KEY = "romp:cardNotified";
-function mirrorBadges(items: AskItem[], clears: ClearNoticeRow[]): void {
+function mirrorBadges(items: AskItem[], clears: ClearNoticeRow[], sdk: SdkNoticeRow[]): void {
   let seen: string[] = [];
   try { seen = JSON.parse(localStorage.getItem(BADGE_SEEN_KEY) || "[]"); } catch { /* fresh */ }
   const seenSet = new Set(seen);
@@ -3243,12 +3244,15 @@ function mirrorBadges(items: AskItem[], clears: ClearNoticeRow[]): void {
   // /clear boundary settles share the same seen-set + bell (the user 2026-07-27): a clear that
   // dropped open cards logs one durable entry naming them, so the drop is never silent.
   const boundary = clearBoundaryNotices(clears, seenSet);
-  for (const n of [...badges.notices, ...boundary.notices]) {
+  // …and so do SDK-backend failures (the user 2026-07-28): a crashed session thread, a dropped stream
+  // or a refused setting is a romp problem, and it belongs where the user's other problems are.
+  const sdkProblems = sdkProblemNotices(sdk, seenSet);
+  for (const n of [...badges.notices, ...boundary.notices, ...sdkProblems.notices]) {
     try {
       window.parent?.postMessage({ romp: "notify", kind: n.kind, text: n.text, sid: n.sid, itemId: n.itemId }, "*");
     } catch { /* no shell (VS Code view) */ }
   }
-  const active = new Set([...badges.active, ...boundary.active]);
+  const active = new Set([...badges.active, ...boundary.active, ...sdkProblems.active]);
   try { localStorage.setItem(BADGE_SEEN_KEY, JSON.stringify(Array.from(active))); } catch { /* storage full */ }
 }
 
@@ -3307,7 +3311,8 @@ window.addEventListener("message", (e: MessageEvent) => {
     bgServicesMap = m.bgServices && typeof m.bgServices === "object" ? m.bgServices : {};   // session name -> judge-classified service descs → the session-header chip (2026-07-24)
     if (Array.isArray(m.order)) sessionOrder = m.order.filter((x: any) => typeof x === "string");   // grouped-mode session rank (tab/lane order)
     hostNow = typeof m.now === "number" ? m.now : Math.floor(Date.now() / 1000);
-    mirrorBadges(incomingAsks, Array.isArray(m.clearNotices) ? m.clearNotices : []);   // card trouble chips + /clear drops also log in the shell's bell (chips stay on the cards)
+    mirrorBadges(incomingAsks, Array.isArray(m.clearNotices) ? m.clearNotices : [],
+      Array.isArray(m.sdkNotices) ? m.sdkNotices : []);   // card trouble chips + /clear drops + SDK failures also log in the shell's bell (chips stay on the cards)
     if (typeof m.dismissedCount === "number") dismissedCount = m.dismissedCount;
     if (typeof m.showDismissed === "boolean") showDismissed = m.showDismissed;
     if (typeof m.canUndoClear === "boolean") canUndoClear = m.canUndoClear;

--- a/ui/webview/sdk-notice-mirror.test.ts
+++ b/ui/webview/sdk-notice-mirror.test.ts
@@ -1,0 +1,59 @@
+// SDK-backend problems mirror into the shell's error center (the user 2026-07-28): a session thread
+// that died, a stream that dropped, a setting the CLI refused used to reach the kernel log alone, so
+// the dashboard showed nothing and the session just looked odd. The kernel signs each OCCURRENCE and
+// the feed posts it to the bell over the same {romp:'notify'} bridge card badges already use.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { sdkProblemNotices } from "./badge-mirror";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+
+const row = (sig: string, text: string) => ({ sig, t: 1000, text });
+
+test("every unseen row logs once, with the sdk kind", () => {
+  const { notices, active } = sdkProblemNotices(
+    [row("sdk|100|be|1", "sdk session web crashed: AttributeError"),
+      row("sdk|100|be|2", "set_model (api -> opus) refused by the SDK")], new Set());
+  assert.equal(notices.length, 2);
+  assert.deepEqual(notices.map((n) => n.kind), ["sdk", "sdk"]);
+  assert.equal(notices[0].text, "sdk session web crashed: AttributeError");
+  assert.deepEqual([...active].sort(), ["sdk|100|be|1", "sdk|100|be|2"]);
+});
+
+test("a re-sent row does NOT re-log — a re-render or reload is not a new failure", () => {
+  const rows = [row("sdk|100|be|1", "sdk session web crashed")];
+  const { notices, active } = sdkProblemNotices(rows, new Set(["sdk|100|be|1"]));
+  assert.equal(notices.length, 0);
+  assert.deepEqual([...active], ["sdk|100|be|1"], "still active, so the seen-set keeps holding it");
+});
+
+test("the same failure happening AGAIN is a new occurrence and logs again", () => {
+  // the kernel's sequence advances per record; the bell coalesces a flood into one counted row
+  const { notices } = sdkProblemNotices(
+    [row("sdk|100|be|7", "sdk session web crashed")], new Set(["sdk|100|be|1"]));
+  assert.equal(notices.length, 1);
+});
+
+test("blank or unsigned rows are not entries", () => {
+  const { notices, active } = sdkProblemNotices(
+    [row("", "orphaned"), row("sdk|100|be|9", ""), null as any], new Set());
+  assert.equal(notices.length, 0);
+  assert.equal(active.size, 0);
+});
+
+test("a very long problem is capped so one entry can't swallow the list", () => {
+  const { notices } = sdkProblemNotices([row("sdk|100|be|1", "x".repeat(900))], new Set());
+  assert.equal(notices[0].text.length, 240);
+  assert.ok(notices[0].text.endsWith("…"));
+});
+
+test("the feed mirrors sdkNotices through the same seen-set and bell bridge", () => {
+  assert.match(FEED, /import \{ badgeNotices, clearBoundaryNotices, sdkProblemNotices,/);
+  assert.match(FEED, /function mirrorBadges\(items: AskItem\[\], clears: ClearNoticeRow\[\], sdk: SdkNoticeRow\[\]\): void/);
+  assert.match(FEED, /const sdkProblems = sdkProblemNotices\(sdk, seenSet\);/);
+  assert.match(FEED, /\[\.\.\.badges\.notices, \.\.\.boundary\.notices, \.\.\.sdkProblems\.notices\]/);
+  assert.match(FEED, /new Set\(\[\.\.\.badges\.active, \.\.\.boundary\.active, \.\.\.sdkProblems\.active\]\)/);
+  assert.match(FEED, /Array\.isArray\(m\.sdkNotices\) \? m\.sdkNotices : \[\]/);
+});


### PR DESCRIPTION
SDK-backend failures used to go to the kernel's stderr and nowhere else, so a session thread that died, a stream that dropped or a setting the CLI refused left the dashboard showing nothing.

- `SdkBackend._log` records problems in a bounded ring. The classification is the exact event, not a keyword sniff: a line logged while an exception is being handled is that exception's report (`sys.exc_info()` is live for the whole dynamic extent of an except block).
- The feed payload carries the ring, signed per occurrence, and the feed mirrors it into the shell's error center as an `sdk` entry over the same bridge card badges take. A construction failure keeps its own kernel-side list, since there is no backend to hold a ring then.
- Twenty `except Exception: pass` handlers now say what broke, including an unreadable system-prompt append that had been silently dropping the appended prompt.
- A crashed session logs its traceback, since a bare `KeyError: <uuid>` names no line to fix.
- Found by that visibility, live: `SdkSession` read `self.state_dir`, which does not exist, so an `/effort` switch applied at reconnect killed the session thread with an AttributeError. Fixed to `self.backend.state_dir`.
- UI: the timeline's lane gear is hollow (no hub dot); the rail's settings gear is sized up from 15px so it matches the svg icons beside it.

Tests: `tests/test_sdk_error_visibility.py` (ring classification, bounds, no-silent-swallow and no-`self.state_dir` AST checks, kernel row signing and payload wiring), `ui/webview/sdk-notice-mirror.test.ts`, plus updated error-center / rail / effort-note / timeline pins. Both suites green (3432 python, 1397 node), tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)