### PR TITLE
A peer we can't reach is asked to fast-forward itself

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5222,7 +5222,10 @@ def _remote_public(r):
             # the rail icon's motion, so background work is never invisible (the user 2026-07-24).
             # fastPull: the mirror — the remote is strictly ahead, so pulling only ADDS commits here.
             # Drives the row's Pull button; the auto-pull additionally requires trusted + local main.
-            "fastForward": _is_fast_forward(r), "fastPull": _is_fast_pull(r),
+            # askPull: a CHECKED-IN peer that is strictly behind. No ssh runs from here, so a push can
+            # only be refused — the row offers "tell it to update itself" instead (_ask_peer_to_pull),
+            # which is the one route that exists between the two machines (the user 2026-07-28).
+            "fastForward": _is_fast_forward(r), "fastPull": _is_fast_pull(r), "askPull": _is_ask_pull(r),
             "autoPush": _auto_push_state(r["host"]),
             # reconnect budget (the user 2026-07-22): the popover has to be able to SAY that romp stopped
             # dialing, instead of a silent forever-retry that looks identical to a healthy idle row
@@ -5732,18 +5735,32 @@ def _auto_pull_remote(host):
     return ok
 
 
+def _auto_ask_peer(host):
+    """Run ONE automatic 'fast-forward yourself' ask against a checked-in peer, publishing phase as it
+    goes — the third direction of the same sync, for the host this machine cannot reach by ssh at all.
+    Ends in 'waiting' (it pulled and is restarting; the EVENT that clears it is that host coming back
+    reporting our sha) or a visible 'failed' carrying the peer's own reason."""
+    _set_auto_push(host, "asking", "asking %s to fast-forward itself over its own SSH" % host)
+    try:
+        ok, detail = _ask_peer_to_pull(host)
+    except Exception as e:
+        ok, detail = False, str(e)
+    _set_auto_push(host, "waiting" if ok else "failed",
+                   detail or ("asked; waiting for it to restart" if ok else "the ask failed"))
+    return ok
+
+
 def _maybe_auto_push(r):
     """The supervisor's per-pass hook: start an automatic sync of this remote when the setting is on —
     a PUSH when a straight fast-forward of the remote is observed, a PULL when a TRUSTED remote is
     strictly ahead and the local checkout sits clean on main (the user 2026-07-27: main syncs itself
-    across trusted machines, both directions ridden by the attaching side's own ssh). Spawns a THREAD —
-    either direction is several seconds of ssh, and the supervisor also keeps every tunnel alive, so
-    blocking it here would stall the whole fleet."""
+    across trusted machines, both directions ridden by the attaching side's own ssh), and an ASK when a
+    CHECKED-IN peer is behind — no ssh runs from here, so the fast-forward is driven through the tunnel
+    that peer holds open (the user 2026-07-28). Spawns a THREAD — every direction is several seconds of
+    network, and the supervisor also keeps every tunnel alive, so blocking it here would stall the fleet."""
     host = r.get("host") or ""
     if not host:
         return
-    if r.get("checkin_peer"):
-        return   # no ssh route from here in either direction — auto-sync would just manufacture failures
     if not _remote_out_of_date(r):
         # It matches us now. That is the EVENT that ends a push (never a timer): a 'waiting for it to
         # restart' clears the moment the restarted remote reports our sha, and a stale 'failed' clears too
@@ -5755,21 +5772,23 @@ def _maybe_auto_push(r):
         return
     if not _auto_update_remotes_on():
         return
-    push = _is_fast_forward(r)
-    pull = (not push and _is_fast_pull(r) and (r.get("trust") or "directed") == "trusted"
+    ci = bool(r.get("checkin_peer"))
+    ask = _is_ask_pull(r)          # checked in here + strictly behind → drive it from ITS side
+    push = not ci and _is_fast_forward(r)
+    pull = (not ci and not push and _is_fast_pull(r) and (r.get("trust") or "directed") == "trusted"
             and _local_branch() == "main")
-    if not push and not pull:
-        return
+    if not (push or pull or ask):
+        return                     # includes a checked-in peer we cannot prove is behind: nothing safe to drive
     key = (_sha_base(r.get("kernel_sha") or ""), _local_head() or "")
     with _auto_push_lock:
-        if _auto_push.get(host, {}).get("phase") in ("pushing", "pulling"):
+        if _auto_push.get(host, {}).get("phase") in ("pushing", "pulling", "asking"):
             return                                  # one sync per host at a time
         if _auto_push_tried.get(host) == key:
             return                                  # already attempted for this exact advance
         if len(_auto_push_tried) > 64:
             _auto_push_tried.clear()
         _auto_push_tried[host] = key
-    threading.Thread(target=_auto_push_remote if push else _auto_pull_remote,
+    threading.Thread(target=_auto_push_remote if push else (_auto_pull_remote if pull else _auto_ask_peer),
                      args=(host,), daemon=True).start()
 
 
@@ -5821,8 +5840,10 @@ def _update_remote(host):
     if _rr is not None and _rr.get("checkin_peer"):
         # A checked-in host reached US over its own outbound tunnel; there is no ssh route from here,
         # so a push can only die with a confusing "No route to host" (the user 2026-07-27). Say what
-        # is actually possible instead.
-        return False, ("no ssh path to %s from this machine (it checked in here over its own tunnel) — "
+        # is actually possible instead — since 2026-07-28 that includes Update, which asks the peer to
+        # fast-forward itself over the tunnel it holds (_ask_peer_to_pull).
+        return False, ("no ssh path to %s from this machine (it checked in here over its own tunnel). "
+                       "When it is behind this build, Update asks it to fast-forward itself; otherwise "
                        "sync from that machine's own dashboard" % host)
     kport = int((_rr or {}).get("kernel_port") or _REMOTE_KERNEL_PORT)   # for the restart's port poll
     lfull = _local_head()
@@ -6006,6 +6027,105 @@ def _pull_remote(host):
                            capture_output=True, text=True, timeout=5).stdout.strip()
     return True, "pulled %s commit%s from %s — now at %s; restart romp to run it" % (
         count, "" if count == "1" else "s", host, short or "HEAD")
+
+
+def _peer_call(r, method, path, body=None, timeout=8):
+    """One control call to a CHECKED-IN peer's kernel, through the tunnel IT holds open and authorized
+    with the serve token it handed us at check-in. Returns (status, parsed json) — status 0 with an
+    {"error"} when the call never landed. Unlike _remote_forward, which folds every failure to None, the
+    BODY of a non-200 is kept: the peer's routes report a refusal as {"ok": false, "detail": ...} with a
+    502, and passing that reason through IS the point of asking (CLAUDE.md: fail loudly, with the why)."""
+    import urllib.parse
+    try:
+        c = http.client.HTTPConnection("127.0.0.1", int(r.get("local_port") or 0), timeout=timeout)
+        p = path + (("?token=" + urllib.parse.quote(r["token"])) if r.get("token") else "")
+        if body is None:
+            c.request(method, p)
+        else:
+            c.request(method, p, json.dumps(body), {"Content-Type": "application/json"})
+        resp = c.getresponse()
+        data = resp.read()
+        c.close()
+        try:
+            j = json.loads(data.decode("utf-8") or "{}")
+        except Exception:
+            j = {}
+        return resp.status, (j if isinstance(j, dict) else {})
+    except Exception as e:
+        return 0, {"error": str(e)[:160]}
+
+
+def _peer_hub_name(r):
+    """The name a checked-in peer knows THIS machine by — the ssh destination it must be handed to pull
+    FROM here. Read from the peer's OWN /tunnels through its tunnel, the authoritative source: that row
+    carries the ssh alias it actually reaches us at, which need not be our hostname. We are the row it
+    checks IN to whose running build is the one we report; when exactly one row checks in anywhere, that
+    is us regardless of sha. Falls back to _self_host() — the same identity _push_trust_to_peer hands
+    over — when the peer answers nothing usable, so an odd answer degrades to today's behaviour rather
+    than to a confidently wrong host."""
+    me = _self_host()
+    st, j = _peer_call(r, "GET", "/tunnels", timeout=6)
+    if st != 200:
+        return me
+    rows = [t for t in (j.get("tunnels") or []) if isinstance(t, dict) and t.get("checkin")]
+    mine = [t for t in rows if _shas_agree(t.get("kernelSha") or "", _kernel_sha() or "")]
+    pick = mine[0] if len(mine) == 1 else (rows[0] if len(rows) == 1 else None)
+    return str((pick or {}).get("host") or me) or me
+
+
+_ASK_PULL_TIMEOUT = 180   # the PEER's git fetch + fast-forward over its own ssh, not a local operation
+
+
+def _ask_peer_to_pull(host):
+    """Get a CHECKED-IN peer to FAST-FORWARD ITSELF onto this machine's build (the user 2026-07-28, whose
+    laptop kept being offered a push that could never run).
+
+    A peer that checked in here owns the ONLY ssh between the two machines, so this side cannot push and
+    the drift was a dead end: the banner offered Push, _update_remote refused with "no ssh path", nothing
+    moved, and the offer came straight back. But a route does exist — the peer's own. It holds an ssh to
+    us, and its kernel already knows how to fetch a hub's HEAD and fast-forward onto it. So drive that
+    from here, through the tunnel it keeps open:
+      1. ask its kernel to pull from us (its /tunnels/pull — ff-only, refused on a dirty tree there), so
+         every guardrail stays on the side where a clobber would happen, and
+      2. ask it to restart, so it RUNS what it just pulled. Its /version reports the sha its process
+         BOOTED from, so a pull alone would leave the old kernel up still reporting the old sha — the
+         drift would never clear and this would re-offer itself forever. The push direction restarts the
+         remote for exactly the same reason; this is that step, asked instead of done.
+    Returns (ok, detail), fail-loud: the peer's own refusal is passed through verbatim."""
+    host = str(host or "").strip()
+    if not host:
+        return False, "no host"
+    with _remotes_lock:
+        r = dict(_remotes.get(host) or {})
+    if not r:
+        return False, "no attached host '%s'" % host
+    if not r.get("checkin_peer"):
+        return False, "%s is attached over this machine's own ssh — push to it instead" % host
+    if not (r.get("local_port") and r.get("token")):
+        return False, ("no admin path to %s (missing forward or token) — sync from that machine's own "
+                       "dashboard" % host)
+    if not _local_head():
+        return False, "local kernel isn't a git checkout — there is nothing for %s to pull" % host
+    st, j = _peer_call(r, "POST", "/tunnels/pull", {"host": _peer_hub_name(r)}, timeout=_ASK_PULL_TIMEOUT)
+    if st == 0:
+        return False, "couldn't reach %s's kernel: %s" % (host, j.get("error") or "no answer")
+    if st == 404:
+        return False, ("%s runs a romp too old to be asked to update itself — update it once by hand "
+                       "there" % host)
+    if not j.get("ok"):
+        return False, "%s refused: %s" % (host, j.get("detail") or j.get("error") or ("HTTP %s" % st))
+    detail = str(j.get("detail") or "pulled this machine's commits")
+    rst, _rj = _peer_call(r, "POST", "/restart", {}, timeout=10)
+    if rst != 200:
+        return True, detail + "; it took the commits but did not ack the restart — restart romp on %s" % host
+    return True, detail + "; restarting it"
+
+
+def _is_ask_pull(r):
+    """Whether this remote can be TOLD to fast-forward itself: a checked-in peer (no ssh from here) that is
+    strictly BEHIND us, so what it pulls only ADDS commits. Same provable-fast-forward bar as the push gate
+    — a diverged or unknown relationship is never driven automatically, and never offered as one click."""
+    return bool(r.get("checkin_peer")) and _is_fast_forward(r)
 
 
 def _start_remote(host):
@@ -15522,16 +15642,21 @@ if(t.outOfDate){var bb=t.behindBy,ab=t.aheadBy,w='different build';
 if(typeof bb==='number'&&typeof ab==='number'){
 w=(bb>0&&ab>0)?'diverged':(ab>0)?'ahead '+ab+' commit'+(ab===1?'':'s'):(bb>0)?'behind '+bb+' commit'+(bb===1?'':'s'):w;}
 var tt='running '+(t.kernelSha||'?')+(t.kernelDate?' from '+t.kernelDate:'')+'; this machine is at '+(t.localSha||'?')+(w==='diverged'?' (each has commits the other lacks)':'')
-+(t.checkinPeer?' No ssh path from this machine (it checked in over its own tunnel) \\u2014 sync from its own dashboard.':'');
++(t.checkinPeer?(t.askPull?' No ssh path from this machine (it checked in over its own tunnel), so Update asks it to fast-forward itself over the link it holds.':' No ssh path from this machine (it checked in over its own tunnel) \\u2014 sync from its own dashboard.'):'');
 ver=' \\u00b7 <span class=\"rnet-old'+(stl?' rnet-stale':'')+'\" title=\"'+tt+sq+'\">'+(stl?'last known: ':'')+w+'</span>';}
 else if(t.kernelSha){ver=' \\u00b7 <span class=\"rnet-sha'+(stl?' rnet-stale':'')+'\" title=\"'+(stl?'same build as this machine when last reached.'+sq:'same build as this machine')+'\">'+(stl?'last known: ':'')+t.kernelSha+'</span>';}
 // A push romp is ALREADY doing needs no button — offering one would just invite a duplicate of the work in
 // flight. The row shows the live phase instead (below), and the manual Push returns if it fails.
-var apx=t.autoPush&&(t.autoPush.phase==='pushing'||t.autoPush.phase==='waiting'||t.autoPush.phase==='pulling');
-// A checked-in host has no ssh route FROM here, so Push/Pull can only fail — the tooltip above says
-// where to sync instead. A strictly-AHEAD remote gets Pull in Push's place: a push there would only
-// be refused (it has commits this machine lacks), so offering it is a dead end.
-var upd=(t.status==='up'&&t.outOfDate&&!apx&&!t.checkinPeer&&!t.fastPull)?'<button class=rnet-upd data-u=\"'+t.host+'\" title=\"Push this machine\\u2019s committed romp to '+t.host+' and restart its kernel, so it runs exactly this code. Uncommitted local edits are not sent, so commit first. It refuses if that machine has its own commits.\">Push</button>':'';
+var apx=t.autoPush&&(t.autoPush.phase==='pushing'||t.autoPush.phase==='waiting'||t.autoPush.phase==='pulling'||t.autoPush.phase==='asking');
+// Every button here is gated on the action being PROVABLY possible (the user 2026-07-28, whose laptop was
+// offered a push that could never run). Push needs an ssh route from here AND a straight fast-forward: a
+// checked-in host has no route, and a remote whose commit is diverged from — or unknown to — this repo is
+// refused by the remote's own ancestor check every single time (a commit this repo has never seen cannot be
+// an ancestor of its HEAD). Those states get the action that CAN work instead: Pull when the remote is
+// strictly ahead, Update when a checked-in peer is behind, and otherwise the drift word plus its tooltip,
+// which say what happened without dead-ending on a button.
+var upd=(t.status==='up'&&t.fastForward&&!apx&&!t.checkinPeer)?'<button class=rnet-upd data-u=\"'+t.host+'\" title=\"Push this machine\\u2019s committed romp to '+t.host+' and restart its kernel, so it runs exactly this code. Uncommitted local edits are not sent, so commit first.\">Push</button>':'';
+var ask=(t.status==='up'&&t.askPull&&!apx)?'<button class=rnet-upd data-a=\"'+t.host+'\" title=\"'+t.host+' checked in over its own tunnel, so this machine cannot push to it. This asks its romp to pull these commits from here and restart, over the link it already holds.\">Update</button>':'';
 var pull=(t.status==='up'&&t.fastPull&&!apx&&!t.checkinPeer)?'<button class=rnet-upd data-p=\"'+t.host+'\" title=\"Pull '+t.host+'\\u2019s newer commits into this machine\\u2019s romp (fast-forward only; refuses if this tree has uncommitted changes). This kernel keeps running the old build until you restart romp.\">Pull</button>':'';
 // ssh alive but no kernel answering -> the explicit ASK (the user 2026-07-10): a Start button that
 // pushes this machine's committed romp to the host FIRST, then boots its kernel. Never auto-starts —
@@ -15568,7 +15693,7 @@ else if(mm){trust+='<button class=rnet-mirror data-m=\"'+t.host+'\" data-lvl=\"'
 // weight as a dropdown, and on a phone pushed it off the edge entirely.
 row.innerHTML='<span class=rnet-dot style=\"'+dot+'\" title=\"'+(TIP[t.status]||'')+'\"></span>'+
 '<span class=nm><b>'+t.host+'</b> <span class=st title=\"'+(TIP[t.status]||'')+'\">'+(LBL[t.status]||t.status)+(t.checkinPeer?' \\u00b7 checked in here':'')+(t.token?'':' \\u00b7 no token')+ver+'</span></span>'+
-retry+pull+upd+strt+'<button data-h=\"'+t.host+'\" title=\"Close the ssh tunnel to '+t.host+'. It stays in this list as a previously-attached host, keeping its trust level, so you can re-attach in one click.\">Detach</button>';
+retry+pull+ask+upd+strt+'<button data-h=\"'+t.host+'\" title=\"Close the ssh tunnel to '+t.host+'. It stays in this list as a previously-attached host, keeping its trust level, so you can re-attach in one click.\">Detach</button>';
 item.appendChild(row);
 // Live automatic-update phase, on its own line under the row — this is the whole reason the modal could
 // go away: the work still announces itself, it just does it here instead of over your screen. A FAILURE
@@ -15673,7 +15798,13 @@ b.disabled=true;b.textContent='Pushing\\u2026';
 fetch('/tunnels/update',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h})}).then(function(r){return r.json();}).then(function(d){
 if(d&&d.ok){b.textContent='Pushed';schedule(2000);}   // the remote restarts + re-polls → the flag clears itself
 else{b.disabled=false;b.textContent='Retry';alert('Push to '+h+' failed: '+((d&&d.detail)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
-}).catch(function(){b.disabled=false;b.textContent='Retry';alert('Push to '+h+' failed to reach the kernel.');});};});}
+}).catch(function(){b.disabled=false;b.textContent='Retry';alert('Push to '+h+' failed to reach the kernel.');});};});
+list.querySelectorAll('button[data-a]').forEach(function(b){b.onclick=function(){var h=b.getAttribute('data-a');
+b.disabled=true;b.textContent='Asking\\u2026';   // the work runs on the PEER, over its own ssh; this drives it through the tunnel it holds
+fetch('/tunnels/askpull',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h})}).then(function(r){return r.json();}).then(function(d){
+if(d&&d.ok){b.textContent='Updating';schedule(2000);}   // it pulled + is restarting → its next /version clears the flag
+else{b.disabled=false;b.textContent='Retry';alert('Updating '+h+' failed: '+((d&&d.detail)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
+}).catch(function(){b.disabled=false;b.textContent='Retry';alert('Updating '+h+' failed to reach the kernel.');});};});}
 attach.onclick=function(){var h=(hostIn.value||'').trim();if(!h)return;
 try{localStorage.setItem('romp:lastRemoteHost',h);}catch(e){}   // remember for MRU-first ordering next time
 attach.disabled=true;attach.textContent='Attaching\\u2026';
@@ -15867,18 +15998,20 @@ _RDRIFT_CSS = (
     "#rdrift .rd-dismiss:hover{color:#e6e6e6}")
 _RDRIFT_HTML = (
     "<div id=rdrift role=alert><span class=rd-spin aria-hidden=true></span><span class=rd-msg></span>"
-    "<button class=rd-upd id=rdrift-upd>Push</button>"
+    "<button class=rd-upd id=rdrift-upd>Update</button>"
     "<button class=rd-dismiss id=rdrift-dismiss>Dismiss</button></div>")
 _RDRIFT_JS = (
     "(function(){var box=document.getElementById('rdrift');if(!box)return;"
     "var msg=box.querySelector('.rd-msg'),up=document.getElementById('rdrift-upd'),dm=document.getElementById('rdrift-dismiss');"
-    "var stale=[],dismissed='',phase='idle',pushed=[],vtick=0;"   # phase: idle|pushing|verifying|failed|done
+    "var stale=[],route={},dismissed='',phase='idle',pushed=[],vtick=0;"   # phase: idle|pushing|verifying|failed|done
     "function key(hs){return hs.slice().sort().join(',');}"
     # ONE renderer for every state: message + spinner + which buttons show. Keeps the banner UP the whole flow.
     "function set(text,busy,showPush,showDismiss){msg.textContent=text;box.classList.toggle('rd-busy',!!busy);"
     "up.style.display=showPush?'':'none';dm.style.display=showDismiss?'':'none';box.classList.add('show');}"
-    "function prompt(hs){return hs.length===1?(hs[0]+' is on an older romp build. Push your version to it?')"
-    ":(hs.length+' remotes are on an older romp build. Push your version? ('+hs.join(', ')+')');}"
+    # One neutral word for both routes: a push we run, and an ask a checked-in peer runs for itself. What
+    # the user is agreeing to is the same either way — that machine ends up on this build.
+    "function prompt(hs){return hs.length===1?(hs[0]+' is on an older romp build. Update it to this one?')"
+    ":(hs.length+' remotes are on an older romp build. Update them to this one? ('+hs.join(', ')+')');}"
     "function check(){fetch('/tunnels',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){"
     # AUTOMATIC UPDATE ON → this banner does not exist (the user 2026-07-24). It was the modal landing
     # mid-screen on every advance, and the whole point of the setting is that romp just does the push and
@@ -15886,26 +16019,37 @@ _RDRIFT_JS = (
     # deliberately leaves alone (diverged, unknown build) still has to be raised somewhere — the popover row
     # keeps its Push button and its explanation, which is where a decision belongs.
     "if(d&&d.autoUpdate){box.classList.remove('show');phase='idle';return;}"
-    "var ts=(d&&d.tunnels)||[];stale=ts.filter(function(t){return t.status==='up'&&t.outOfDate;}).map(function(t){return t.host;});"
+    # Only raise a host romp can actually MOVE (the user 2026-07-28). This used to prompt on any drift, so a
+    # laptop that had checked in over its own tunnel — no ssh route from here at all — was offered a push
+    # every four seconds that /tunnels/update refused on sight. Same for a diverged or unknown build: the
+    # remote's own ancestor check rejects those every time. So the banner asks about exactly two states,
+    # each with a route that works: a provable fast-forward we can push, and a checked-in peer we can ask
+    # to fast-forward itself. Anything else stays on the row, where the drift word and its tooltip explain
+    # it without a button that can only produce an error.
+    "var ts=(d&&d.tunnels)||[];route={};"
+    "stale=ts.filter(function(t){return t.status==='up'&&t.outOfDate&&((t.fastForward&&!t.checkinPeer)||t.askPull);})"
+    ".map(function(t){route[t.host]=t.askPull?'/tunnels/askpull':'/tunnels/update';return t.host;});"
     "if(phase==='pushing'||phase==='failed'||phase==='done')return;"   # an active/terminal state owns the banner
     "if(phase==='verifying'){var still=pushed.filter(function(h){return stale.indexOf(h)>=0;});"
     "if(!still.length){set('\\u2713 Up to date.',false,false,false);phase='done';"
     "setTimeout(function(){if(phase==='done'){phase='idle';box.classList.remove('show');}},2500);return;}"
-    "if(++vtick>18){set('Pushed, but '+still.join(', ')+' still reports the old build \\u2014 it may still be restarting, or check it directly.',false,false,true);phase='failed';return;}"
-    "set('Pushed \\u2014 waiting for '+still.join(', ')+' to restart\\u2026',true,false,false);return;}"
-    "if(stale.length&&key(stale)!==dismissed){up.textContent='Push';up.disabled=false;set(prompt(stale),false,true,true);}"
+    "if(++vtick>18){set('Sent, but '+still.join(', ')+' still reports the old build \\u2014 it may still be restarting, or check it directly.',false,false,true);phase='failed';return;}"
+    "set('Sent \\u2014 waiting for '+still.join(', ')+' to restart\\u2026',true,false,false);return;}"
+    "if(stale.length&&key(stale)!==dismissed){up.textContent='Update';up.disabled=false;set(prompt(stale),false,true,true);}"
     "else if(!stale.length){box.classList.remove('show');}}).catch(function(){});}"
     "up.onclick=function(){var hosts=stale.slice();if(!hosts.length){box.classList.remove('show');return;}"
-    "phase='pushing';vtick=0;up.disabled=true;up.textContent='Pushing\\u2026';"
-    "set('Pushing your build to '+hosts.join(', ')+' over SSH\\u2026',true,false,false);"
+    "phase='pushing';vtick=0;up.disabled=true;up.textContent='Updating\\u2026';"
+    "set('Updating '+hosts.join(', ')+' over SSH\\u2026',true,false,false);"
     "var done=0,fails=[],oks=[];"
-    "hosts.forEach(function(h){fetch('/tunnels/update',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h})})"
+    # Per host, the route that can work: a push we run over our ssh, or the ask that a checked-in peer
+    # runs for itself over the link IT holds. One button, two mechanics — the user picks an outcome.
+    "hosts.forEach(function(h){fetch(route[h]||'/tunnels/update',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h})})"
     ".then(function(r){return r.json();}).then(function(x){if(x&&x.ok){oks.push(h);}else{fails.push(h+': '+((x&&x.detail)||'failed'));}})"
     ".catch(function(){fails.push(h+': couldn\\u2019t reach the kernel');})"
     ".then(function(){done++;if(done!==hosts.length)return;up.textContent='Retry';"
-    "if(fails.length&&!oks.length){up.disabled=false;set('Push failed \\u2014 '+fails.join('; '),false,true,true);phase='failed';}"    # fail LOUDLY (CLAUDE.md)
-    "else if(fails.length){up.disabled=false;pushed=oks;set('Pushed '+oks.join(', ')+'; failed '+fails.join('; '),false,true,true);phase='failed';}"
-    "else{pushed=oks;phase='verifying';vtick=0;set('Pushed to '+oks.join(', ')+'. Waiting for '+(oks.length===1?'it':'them')+' to restart\\u2026',true,false,false);setTimeout(check,1500);}"
+    "if(fails.length&&!oks.length){up.disabled=false;set('Update failed \\u2014 '+fails.join('; '),false,true,true);phase='failed';}"    # fail LOUDLY (CLAUDE.md)
+    "else if(fails.length){up.disabled=false;pushed=oks;set('Updated '+oks.join(', ')+'; failed '+fails.join('; '),false,true,true);phase='failed';}"
+    "else{pushed=oks;phase='verifying';vtick=0;set('Sent to '+oks.join(', ')+'. Waiting for '+(oks.length===1?'it':'them')+' to restart\\u2026',true,false,false);setTimeout(check,1500);}"
     "});});};"
     "dm.onclick=function(){dismissed=key(stale);phase='idle';box.classList.remove('show');};"
     "check();setInterval(check,4000);})();")   # 4s so progress feels live (was 30s)
@@ -17218,6 +17362,20 @@ class Handler(BaseHTTPRequestHandler):
                 if not host:
                     return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
                 ok, detail = _pull_remote(host)
+                return self._send(200 if ok else 502, json.dumps({"ok": ok, "detail": detail}), "application/json")
+            if u.path == "/tunnels/askpull":
+                # ASK a checked-in peer to fast-forward ITSELF to this machine's build — the third
+                # direction, for the host no ssh of ours can reach (it holds the only link). The work
+                # happens on the peer, over its own ssh; we drive it through the tunnel it keeps open
+                # and report its answer verbatim. Body: {"host": <checked-in peer>}.
+                try:
+                    body = json.loads(raw_body or b"{}")
+                except Exception:
+                    body = None
+                host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
+                if not host:
+                    return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
+                ok, detail = _ask_peer_to_pull(host)
                 return self._send(200 if ok else 502, json.dumps({"ok": ok, "detail": detail}), "application/json")
             if u.path == "/tunnels/start":
                 # START a downed remote kernel — the popover's explicit ASK for an ssh-reachable host

--- a/tests/test_auto_update_remotes.py
+++ b/tests/test_auto_update_remotes.py
@@ -210,8 +210,8 @@ class BannerAndPopoverWiring(unittest.TestCase):
     def test_an_in_flight_push_animates_the_icon_and_hides_the_duplicate_button(self):
         self.assertIn("paintIcon(ts.some(function(t){return t.status==='up';}),busy||!!pushing.length);",
                       km._LANDING_REMOTES_JS, "the rail icon marches while romp pushes in the background")
-        self.assertIn("t.outOfDate&&!apx", km._LANDING_REMOTES_JS,
-                      "no manual Push button for work already in flight")
+        self.assertIn("t.fastForward&&!apx", km._LANDING_REMOTES_JS,
+                      "no manual Push button for work already in flight — nor for a push that cannot succeed")
         self.assertIn("auto-update: ", km._LANDING_REMOTES_JS, "the row carries the live phase")
 
     def test_the_icon_tooltip_reports_the_live_phase(self):

--- a/tests/test_kernel_remote_pull.py
+++ b/tests/test_kernel_remote_pull.py
@@ -193,11 +193,24 @@ class AutoPullFiring(unittest.TestCase):
         self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted"})
         self.assertEqual(self.calls, [])
 
-    def test_a_checked_in_row_fires_neither_direction(self):
-        # no ssh route from here — an auto-sync could only manufacture "No route to host" failures
+    def test_a_checked_in_row_never_fires_this_machine_s_ssh(self):
+        # no ssh route from here — a push or pull of OURS could only manufacture "No route to host"
         self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted", "checkin_peer": True})
-        km._behind_info = lambda sha: {"behind": 2, "ahead": 0, "date": ""}   # …and the push side too
+        self.assertEqual(self.calls, [], "strictly ahead + no route: nothing this machine can run")
+
+    def test_a_checked_in_peer_that_is_BEHIND_is_asked_to_update_itself(self):
+        # the third direction (the user 2026-07-28): the peer owns the only ssh between the machines, so
+        # the fast-forward is driven through the tunnel IT holds instead of offered as an impossible push
+        km._behind_info = lambda sha: {"behind": 2, "ahead": 0, "date": ""}
         self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted", "checkin_peer": True})
+        self.assertEqual(self.calls, [("_auto_ask_peer", "TESTHOST")])
+
+    def test_a_checked_in_peer_is_never_driven_on_an_unproven_relationship(self):
+        # same bar as the push gate: diverged, or a build this repo has never seen, is not driven at all
+        for drift in ({"behind": 2, "ahead": 1, "date": ""}, {"behind": None, "ahead": None, "date": ""}):
+            km._auto_push_tried.clear()
+            km._behind_info = lambda sha, d=drift: d
+            self._run({"host": "TESTHOST", "kernel_sha": REMOTE, "trust": "trusted", "checkin_peer": True})
         self.assertEqual(self.calls, [])
 
     def test_the_same_advance_is_not_pulled_twice(self):

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -235,24 +235,27 @@ class UpdateEndpoint(unittest.TestCase):
 
 
 class UpdateUI(unittest.TestCase):
-    def test_drift_banner_uses_the_push_framing(self):
-        # mirrors the #rstale reload banner, but asks to PUSH the local build (the user 2026-07-04)
+    def test_drift_banner_uses_the_update_framing(self):
+        # mirrors the #rstale reload banner, but asks to bring the remote onto the local build (the user
+        # 2026-07-04). ONE neutral word since 2026-07-28: the same button covers a push we run and an ask
+        # a checked-in peer runs for itself, and what the user agrees to — that machine ends up on this
+        # build — is identical either way.
         self.assertIn("id=rdrift", km._RDRIFT_HTML)
-        self.assertIn(">Push<", km._RDRIFT_HTML, "the action button says Push")
-        self.assertIn("Push your version", km._RDRIFT_JS, "the prompt asks to push your version to the remote")
+        self.assertIn(">Update<", km._RDRIFT_HTML, "the action button says Update")
+        self.assertIn("Update it to this one?", km._RDRIFT_JS, "the prompt asks to bring the remote onto this build")
         self.assertIn("/tunnels/update", km._RDRIFT_JS)
         self.assertIn("outOfDate", km._RDRIFT_JS)
         self.assertIn("_rdrift_block()", inspect_src())
 
     def test_drift_banner_shows_live_progress_success_and_failure(self):
-        # the user 2026-07-04: the banner must stay up through the push with a spinner + status, a success
+        # the user 2026-07-04: the banner must stay up through the work with a spinner + status, a success
         # confirmation, and a persistent actionable error — not silently flip back to the prompt.
         self.assertIn("rd-spin", km._RDRIFT_HTML)
         self.assertIn("romp-swirl-glyph.svg", km._RDRIFT_CSS)   # the spinner is the romp loader glyph
-        self.assertIn("Pushing your build", km._RDRIFT_JS, "a 'pushing…' progress message")
+        self.assertIn("Updating ", km._RDRIFT_JS, "an 'updating…' progress message")
         self.assertIn("waiting for", km._RDRIFT_JS, "a 'waiting for it to restart' verify phase")
         self.assertIn("Up to date", km._RDRIFT_JS, "a success confirmation")
-        self.assertIn("Push failed", km._RDRIFT_JS, "a persistent, specific failure message")
+        self.assertIn("Update failed", km._RDRIFT_JS, "a persistent, specific failure message")
         self.assertIn("phase", km._RDRIFT_JS, "a state machine drives the flow")
 
     def test_popover_shows_behind_and_a_push_button(self):

--- a/tests/test_peer_fast_forward.py
+++ b/tests/test_peer_fast_forward.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Getting a CHECKED-IN peer to fast-forward ITSELF (the user 2026-07-28).
+
+A peer that checked in here owns the only ssh between the two machines, so this side cannot push to it.
+That used to be a dead end that still ADVERTISED itself: the drift banner offered a push every few
+seconds and _update_remote refused every one of them with "no ssh path". The route that exists is the
+peer's own — it holds an ssh to us and its kernel already knows how to fetch a hub's HEAD and
+fast-forward onto it — so romp drives that through the tunnel the peer keeps open (_ask_peer_to_pull),
+and every surface offers it only when it is a PROVABLE fast-forward.
+
+SYNTHETIC fixtures only — invented hosts and placeholder shas; every network call is stubbed.
+"""
+import json
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_peerff", os.path.join(BIN, "romp-kernel")).load_module()
+
+LOCAL = "a" * 40        # this machine's HEAD
+REMOTE = "b" * 40       # the peer's older commit
+PEER = "TESTHOST"
+
+
+def _row(**over):
+    r = {"host": PEER, "checkin_peer": True, "kernel_port": 52025, "local_port": 52025,
+         "token": "peertok", "kernel_sha": REMOTE, "status": "up", "trust": "trusted"}
+    r.update(over)
+    return r
+
+
+class _Calls(list):
+    """Stands in for _peer_call: records (method, path, body) and replays scripted answers."""
+
+    def __init__(self, answers):
+        super().__init__()
+        self.answers = list(answers)
+
+    def __call__(self, r, method, path, body=None, timeout=8):
+        self.append((method, path, body))
+        return self.answers.pop(0) if self.answers else (0, {"error": "no scripted answer"})
+
+
+class AskGate(unittest.TestCase):
+    """_is_ask_pull decides whether the row may offer this in one click, and whether the supervisor may
+    fire it. It must clear the SAME bar as the push gate — provable fast-forward, nothing less."""
+
+    def _gate(self, behind, ahead, checkin=True, ood=True):
+        saved = (km._remote_out_of_date, km._behind_info)
+        km._remote_out_of_date = lambda r: ood
+        km._behind_info = lambda sha: {"behind": behind, "ahead": ahead, "date": ""}
+        try:
+            return km._is_ask_pull(_row(checkin_peer=checkin))
+        finally:
+            km._remote_out_of_date, km._behind_info = saved
+
+    def test_a_checked_in_peer_strictly_behind_can_be_asked(self):
+        self.assertTrue(self._gate(behind=3, ahead=0), "it only ADDS commits over there")
+
+    def test_an_ssh_attached_host_is_pushed_not_asked(self):
+        self.assertFalse(self._gate(behind=3, ahead=0, checkin=False),
+                         "we own the ssh to that one — the push direction still applies")
+
+    def test_nothing_unprovable_is_ever_asked(self):
+        self.assertFalse(self._gate(behind=0, ahead=2), "it has commits we lack")
+        self.assertFalse(self._gate(behind=3, ahead=2), "diverged")
+        self.assertFalse(self._gate(behind=None, ahead=None), "a build this repo has never seen")
+        self.assertFalse(self._gate(behind=0, ahead=0, ood=False), "already on this build")
+
+    def test_the_row_publishes_the_verdict(self):
+        saved = (km._remote_out_of_date, km._behind_info)
+        km._remote_out_of_date = lambda r: True
+        km._behind_info = lambda sha: {"behind": 3, "ahead": 0, "date": "2026-07-28"}
+        try:
+            pub = km._remote_public(_row())
+        finally:
+            km._remote_out_of_date, km._behind_info = saved
+        self.assertTrue(pub["askPull"], "the row can say the peer is askable")
+        self.assertFalse(pub["fastPull"], "and that there is nothing here to pull")
+
+
+class AskingThePeer(unittest.TestCase):
+    """_ask_peer_to_pull: pull THEN restart, over the tunnel the peer holds — and a refusal comes back
+    with the peer's own reason rather than a generic failure (CLAUDE.md: fail loudly, with the why)."""
+
+    def setUp(self):
+        self._saved = (km._peer_call, km._peer_hub_name, km._local_head, dict(km._remotes))
+        km._peer_hub_name = lambda r: "hubname"
+        km._local_head = lambda short=False: (LOCAL[:8] if short else LOCAL)
+        km._remotes.clear()
+        km._remotes[PEER] = _row()
+
+    def tearDown(self):
+        km._peer_call, km._peer_hub_name, km._local_head, saved_remotes = self._saved
+        km._remotes.clear()
+        km._remotes.update(saved_remotes)
+
+    def _ask(self, answers):
+        km._peer_call = calls = _Calls(answers)
+        return km._ask_peer_to_pull(PEER), calls
+
+    def test_it_pulls_then_restarts(self):
+        (ok, detail), calls = self._ask([(200, {"ok": True, "detail": "pulled 8 commits from hubname"}),
+                                         (200, {"ok": True, "restarting": True})])
+        self.assertTrue(ok)
+        self.assertEqual([c[1] for c in calls], ["/tunnels/pull", "/restart"],
+                         "a pull alone leaves the OLD kernel running and still reporting the old sha")
+        self.assertEqual(calls[0][2], {"host": "hubname"}, "the peer is handed the name it knows us by")
+        self.assertIn("pulled 8 commits", detail)
+        self.assertIn("restarting it", detail)
+
+    def test_the_peer_s_own_refusal_is_passed_through(self):
+        (ok, detail), calls = self._ask([(502, {"ok": False, "detail": "this machine's tree has "
+                                                "uncommitted changes — commit or stash them first"})])
+        self.assertFalse(ok)
+        self.assertIn("uncommitted changes", detail, "the reason it refused, not a generic failure")
+        self.assertEqual(len(calls), 1, "a refused pull is never followed by a restart")
+
+    def test_an_unreachable_peer_kernel_says_so(self):
+        (ok, detail), _ = self._ask([(0, {"error": "connection refused"})])
+        self.assertFalse(ok)
+        self.assertIn("connection refused", detail)
+
+    def test_a_peer_too_old_to_have_the_route_names_the_fix(self):
+        (ok, detail), _ = self._ask([(404, {})])
+        self.assertFalse(ok)
+        self.assertIn("too old", detail)
+        self.assertIn("by hand", detail, "one manual update there breaks the chicken-and-egg")
+
+    def test_a_pull_that_lands_but_a_restart_that_does_not_still_reports_the_commits(self):
+        (ok, detail), _ = self._ask([(200, {"ok": True, "detail": "pulled 2 commits"}), (0, {"error": "gone"})])
+        self.assertTrue(ok, "the commits DID land — that is not a failure")
+        self.assertIn("restart romp on %s" % PEER, detail, "and it says what is left to do")
+
+    def test_an_ssh_attached_host_is_refused_with_the_direction_that_works(self):
+        km._remotes[PEER] = _row(checkin_peer=False)
+        (ok, detail), calls = self._ask([])
+        self.assertFalse(ok)
+        self.assertIn("push to it instead", detail)
+        self.assertEqual(calls, [], "nothing is sent to a host we can reach directly")
+
+    def test_a_peer_with_no_token_or_forward_is_refused_before_the_network(self):
+        km._remotes[PEER] = _row(token="")
+        (ok, detail), calls = self._ask([])
+        self.assertFalse(ok)
+        self.assertIn("no admin path", detail)
+        self.assertEqual(calls, [])
+
+
+class NamingThisMachine(unittest.TestCase):
+    """_peer_hub_name: the ssh destination the peer must be handed is read from the PEER's own tunnel
+    list — its real alias for us — not guessed from our hostname (which need not match)."""
+
+    def setUp(self):
+        self._saved = (km._peer_call, km._kernel_sha)
+        km._kernel_sha = lambda: "abc1234"
+        os.environ["ROMP_HOST_NAME"] = "myhostname"
+
+    def tearDown(self):
+        km._peer_call, km._kernel_sha = self._saved
+        os.environ.pop("ROMP_HOST_NAME", None)
+
+    def test_it_reads_the_alias_the_peer_actually_uses(self):
+        km._peer_call = lambda r, m, p, body=None, timeout=8: (200, {"tunnels": [
+            {"host": "some-other-hub", "checkin": False, "kernelSha": "999999"},
+            {"host": "linux-box-alias", "checkin": True, "kernelSha": "abc1234"},
+        ]})
+        self.assertEqual(km._peer_hub_name(_row()), "linux-box-alias")
+
+    def test_a_lone_check_in_row_is_us_whatever_the_sha_says(self):
+        # its sha of us is the last one it polled; a build that moved since must not lose the alias
+        km._peer_call = lambda r, m, p, body=None, timeout=8: (200, {"tunnels": [
+            {"host": "linux-box-alias", "checkin": True, "kernelSha": "0000000"}]})
+        self.assertEqual(km._peer_hub_name(_row()), "linux-box-alias")
+
+    def test_an_unusable_answer_falls_back_to_our_own_name(self):
+        for answer in ((0, {"error": "no route"}), (200, {"tunnels": []}),
+                       (200, {"tunnels": [{"host": "a", "checkin": True, "kernelSha": "1"},
+                                          {"host": "b", "checkin": True, "kernelSha": "2"}]})):
+            km._peer_call = lambda r, m, p, body=None, timeout=8, a=answer: a
+            self.assertEqual(km._peer_hub_name(_row()), "myhostname",
+                             "ambiguity degrades to today's identity, never to a wrong host")
+
+
+class PhaseIsPublished(unittest.TestCase):
+    """The ask announces itself on the row exactly like the push and pull it stands in for."""
+
+    def setUp(self):
+        self._saved = km._ask_peer_to_pull
+        km._auto_push.clear()
+
+    def tearDown(self):
+        km._ask_peer_to_pull = self._saved
+        km._auto_push.clear()
+
+    def test_success_parks_at_waiting_for_the_restart(self):
+        km._ask_peer_to_pull = lambda h: (True, "pulled 8 commits; restarting it")
+        self.assertTrue(km._auto_ask_peer(PEER))
+        st = km._auto_push_state(PEER)
+        self.assertEqual(st["phase"], "waiting")
+        self.assertIn("restarting it", st["detail"])
+
+    def test_a_failure_stays_visible_and_carries_the_reason(self):
+        km._ask_peer_to_pull = lambda h: (False, "TESTHOST refused: its tree has uncommitted changes")
+        self.assertFalse(km._auto_ask_peer(PEER))
+        st = km._auto_push_state(PEER)
+        self.assertEqual(st["phase"], "failed")
+        self.assertIn("uncommitted changes", st["detail"], "a silent failure looks like an up-to-date host")
+
+    def test_a_raising_ask_is_reported_not_swallowed(self):
+        def _boom(h):
+            raise RuntimeError("tunnel died")
+        km._ask_peer_to_pull = _boom
+        self.assertFalse(km._auto_ask_peer(PEER))
+        self.assertEqual(km._auto_push_state(PEER)["phase"], "failed")
+
+
+class SurfacesOnlyOfferWhatCanWork(unittest.TestCase):
+    """Source pins on both row copies and on the mid-screen drift banner — the surface that was making
+    the impossible offer over and over."""
+
+    def setUp(self):
+        self.strip = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "strip.ts")).read()
+
+    def test_the_banner_raises_only_a_host_romp_can_move(self):
+        self.assertIn("(t.fastForward&&!t.checkinPeer)||t.askPull", km._RDRIFT_JS,
+                      "no prompt for a drift with no working route — that was the every-4s dead end")
+
+    def test_the_banner_sends_each_host_down_the_route_that_works(self):
+        self.assertIn("route[t.host]=t.askPull?'/tunnels/askpull':'/tunnels/update'", km._RDRIFT_JS)
+        self.assertIn("fetch(route[h]||'/tunnels/update'", km._RDRIFT_JS)
+
+    def test_the_web_row_offers_update_to_a_checked_in_peer(self):
+        self.assertIn("t.status==='up'&&t.askPull&&!apx", km._LANDING_REMOTES_JS)
+        self.assertIn("/tunnels/askpull", km._LANDING_REMOTES_JS)
+        self.assertIn("data-a=", km._LANDING_REMOTES_JS)
+
+    def test_the_strip_row_matches(self):
+        self.assertIn('t.status === "up" && t.askPull && !apx', self.strip)
+        self.assertIn('act("/tunnels/askpull", t.host, a, "Asking…")', self.strip)
+        self.assertIn('t.status === "up" && t.fastForward && !apx && !t.checkinPeer', self.strip)
+
+    def test_an_ask_in_flight_counts_as_busy_in_both_copies(self):
+        self.assertIn("t.autoPush.phase==='asking'", km._LANDING_REMOTES_JS)
+        self.assertIn('t.autoPush.phase === "asking"', self.strip)
+
+    def test_the_route_is_wired(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn('u.path == "/tunnels/askpull"', src)
+        self.assertIn("ok, detail = _ask_peer_to_pull(host)", src)
+
+    def test_the_push_refusal_points_at_the_action_that_exists(self):
+        km._remotes[PEER] = _row()
+        try:
+            ok, detail = km._update_remote(PEER)
+        finally:
+            km._remotes.pop(PEER, None)
+        self.assertFalse(ok)
+        self.assertIn("Update asks it to fast-forward itself", detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/net-sync-row.test.ts
+++ b/ui/webview/net-sync-row.test.ts
@@ -1,8 +1,9 @@
 // The remote-kernel row says HOW a build differs and offers the action that can actually succeed
 // (the user 2026-07-27): "behind N" offers Push, "ahead N" offers Pull (fetched over THIS machine's
-// ssh — the remote has no route back, its own push died with "No route to host"), a checked-in host
-// offers neither (no ssh path from here; the tooltip says to sync from its own dashboard), and an
-// auto-sync in flight ('pulling' included) suppresses the manual buttons. Pinned in BOTH copies —
+// ssh — the remote has no route back, its own push died with "No route to host"), and an auto-sync in
+// flight ('pulling'/'asking' included) suppresses the manual buttons. A checked-in host, which no ssh
+// of ours can reach, offers Update when it is behind — the peer fast-forwards ITSELF over the link it
+// holds (the user 2026-07-28) — and nothing but an explanation otherwise. Pinned in BOTH copies —
 // web _LANDING_REMOTES_JS (kernel.py) and the VS Code strip — which must stay in step.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -17,12 +18,30 @@ test("web popover: Pull rides the attach tunnel, gated to a provable fast-forwar
   assert.match(KERNEL, /data-p=/, "a Pull control keyed by host");
   assert.match(KERNEL, /\/tunnels\/pull/, "wired to the kernel's pull route");
   assert.match(KERNEL, /t\.fastPull&&!apx&&!t\.checkinPeer/, "offered only when ff-provable, idle, ssh-reachable");
-  // a strictly-ahead remote replaces Push with Pull — a push there would only be refused
-  assert.match(KERNEL, /!t\.checkinPeer&&!t\.fastPull\)\?'<button class=rnet-upd data-u=/);
+  // Push is offered ONLY where it can succeed: our own ssh route AND a provable fast-forward. Anything
+  // else (ahead, diverged, a build this repo has never seen) is refused by the remote's ancestor check
+  // every time, so it gets Pull, Update, or an explanation — never a button that can only error.
+  assert.match(KERNEL, /t\.status==='up'&&t\.fastForward&&!apx&&!t\.checkinPeer\)\?'<button class=rnet-upd data-u=/);
   // the checked-in case explains itself instead of dead-ending
   assert.match(KERNEL, /No ssh path from this machine \(it checked in over its own tunnel\)/);
-  // an auto-pull in flight counts as busy everywhere a push does
+  // an auto-pull/ask in flight counts as busy everywhere a push does
   assert.match(KERNEL, /t\.autoPush\.phase==='pulling'/);
+  assert.match(KERNEL, /t\.autoPush\.phase==='asking'/);
+});
+
+test("web popover: a checked-in peer that is behind is asked to update itself", () => {
+  assert.match(KERNEL, /t\.status==='up'&&t\.askPull&&!apx/, "offered only on a provable fast-forward");
+  assert.match(KERNEL, /data-a=/, "an Update control keyed by host");
+  assert.match(KERNEL, /\/tunnels\/askpull/, "wired to the kernel's ask route");
+  assert.match(KERNEL, /asks it to fast-forward itself over the link it holds/, "the tooltip says who does the work");
+});
+
+test("drift banner: it prompts only for a host romp can actually move", () => {
+  // the every-4s dead end (the user 2026-07-28): a laptop with no ssh path from here was offered a push
+  // that /tunnels/update refused on sight, over and over
+  assert.match(KERNEL, /\(t\.fastForward&&!t\.checkinPeer\)\|\|t\.askPull/);
+  assert.match(KERNEL, /route\[t\.host\]=t\.askPull\?'\/tunnels\/askpull':'\/tunnels\/update'/,
+    "each host goes down the route that works for it");
 });
 
 test("VS Code strip: same row treatment", () => {
@@ -31,7 +50,11 @@ test("VS Code strip: same row treatment", () => {
   assert.match(STRIP, /" · diverged"/);
   assert.match(STRIP, /act\("\/tunnels\/pull", t\.host, pl, "Pulling…"\)/, "Pull posts the kernel route");
   assert.match(STRIP, /t\.status === "up" && t\.fastPull && !apx && !t\.checkinPeer/);
-  assert.match(STRIP, /!t\.checkinPeer && !t\.fastPull/, "Push yields to Pull on a strictly-ahead remote");
+  assert.match(STRIP, /t\.status === "up" && t\.fastForward && !apx && !t\.checkinPeer/,
+    "Push only where it can succeed — our ssh route and a provable fast-forward");
+  assert.match(STRIP, /t\.status === "up" && t\.askPull && !apx/, "Update for a checked-in peer that is behind");
+  assert.match(STRIP, /act\("\/tunnels\/askpull", t\.host, a, "Asking…"\)/);
   assert.match(STRIP, /No ssh path from this machine \(it checked in over its own tunnel\)/);
   assert.match(STRIP, /t\.autoPush\.phase === "pulling"/);
+  assert.match(STRIP, /t\.autoPush\.phase === "asking"/);
 });

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -376,7 +376,11 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       nm.title = (TIP[t.status] || "")
         + (t.outOfDate ? `\n\nRunning ${t.kernelSha || "?"}${t.kernelDate ? " from " + t.kernelDate : ""}; this machine is at ${t.localSha || "?"}.` : "")
         + (stale && t.outOfDate ? `\nLast confirmed ${seen || "not since this kernel started"}; not re-checked while ${LBL[t.status] || t.status}.` : "")
-        + (t.outOfDate && t.checkinPeer ? " No ssh path from this machine (it checked in over its own tunnel) — sync from its own dashboard." : "");
+        + (t.outOfDate && t.checkinPeer
+          ? (t.askPull
+            ? " No ssh path from this machine (it checked in over its own tunnel), so Update asks it to fast-forward itself over the link it holds."
+            : " No ssh path from this machine (it checked in over its own tunnel) — sync from its own dashboard.")
+          : "");
       r.append(dot, nm);
       // Federation trust (per-host): trusted = full two-way postal; directed (default) = its mail is
       // HELD for your approval; isolated = dashboard only, no postal. The gate lives in the bus.
@@ -417,16 +421,29 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       }
       // A push romp is ALREADY doing needs no button — it would only invite a duplicate of the work in
       // flight. The row shows the live phase instead (below); the manual Push returns if it fails.
-      const apx = !!(t.autoPush && (t.autoPush.phase === "pushing" || t.autoPush.phase === "waiting" || t.autoPush.phase === "pulling"));
-      // A checked-in host has no ssh route FROM here (Push/Pull can only fail — the tooltip says where
-      // to sync); a strictly-ahead remote gets Pull in Push's place (a push there would only be refused).
-      if (t.status === "up" && t.outOfDate && !apx && !t.checkinPeer && !t.fastPull) {
+      const apx = !!(t.autoPush && (t.autoPush.phase === "pushing" || t.autoPush.phase === "waiting"
+        || t.autoPush.phase === "pulling" || t.autoPush.phase === "asking"));
+      // Every button is gated on the action being PROVABLY possible (the user 2026-07-28, whose laptop was
+      // offered a push that could never run). Push needs an ssh route from here AND a straight fast-forward:
+      // a checked-in host has no route, and a diverged — or unknown — remote build is refused by the
+      // remote's own ancestor check every time (a commit this repo has never seen cannot be an ancestor of
+      // its HEAD). Those states get the action that CAN work instead: Pull when the remote is strictly
+      // ahead, Update when a checked-in peer is behind, else the drift word and its tooltip.
+      if (t.status === "up" && t.fastForward && !apx && !t.checkinPeer) {
         const u = document.createElement("button");
         u.textContent = "Push";
         u.title = `Push this machine's committed romp to ${t.host} and restart its kernel, so it runs exactly this code. `
-          + `Uncommitted local edits are not sent, so commit first. It refuses if that machine has its own commits.`;
+          + `Uncommitted local edits are not sent, so commit first.`;
         u.addEventListener("click", () => act("/tunnels/update", t.host, u, "Pushing…"));
         r.appendChild(u);
+      }
+      if (t.status === "up" && t.askPull && !apx) {
+        const a = document.createElement("button");
+        a.textContent = "Update";
+        a.title = `${t.host} checked in over its own tunnel, so this machine cannot push to it. This asks its romp `
+          + `to pull these commits from here and restart, over the link it already holds.`;
+        a.addEventListener("click", () => act("/tunnels/askpull", t.host, a, "Asking…"));
+        r.appendChild(a);
       }
       if (t.status === "up" && t.fastPull && !apx && !t.checkinPeer) {
         const pl = document.createElement("button");


### PR DESCRIPTION
## The bug

A machine that checks in here owns the only ssh between the two, so this side cannot push to it — and romp kept offering to anyway. The mid-screen drift banner raised **any** out-of-date remote (`status==='up' && outOfDate`), so a checked-in laptop drew a *"push your version to it?"* prompt every four seconds and `/tunnels/update` refused every single one on sight with *"no ssh path"*. An offer whose only outcome is an error is a false interrupt.

The same dead end existed for a **diverged or unknown** remote build: the remote's own ancestor check rejects those every time, because a commit this repo has never seen cannot be an ancestor of its HEAD.

## The fix, in two halves

**Only offer what can succeed.** Push now requires our own ssh route AND a provable fast-forward, on the row and in the banner. Everything else gets the action that works — Pull when the remote is strictly ahead, Update when a checked-in peer is behind — or just the drift word and its tooltip, which explain without dead-ending on a button.

**Drive the fast-forward the other way.** For the host no ssh of ours can reach, the route that does exist is its own: it holds an ssh to us, and its kernel already knows how to fetch a hub's HEAD and fast-forward onto it. `_ask_peer_to_pull` drives that through the tunnel the peer keeps open — ask it to pull, then ask it to restart, because its `/version` reports the sha its process *booted* from, so a pull alone would leave the drift standing forever. The peer's own refusals come back verbatim (dirty tree, diverged, too old to have the route).

The ssh destination it needs is read from the peer's own tunnel list — the alias it actually reaches us at — rather than guessed from our hostname, falling back to `_self_host()` when the answer is ambiguous. Same provable-fast-forward bar as the push gate, so nothing diverged or unknown is ever driven; the supervisor fires it under the existing auto-update setting and its one-attempt-per-advance gate, and the row publishes the phase like any other direction.

## Tests

New `tests/test_peer_fast_forward.py` covers the gate, the pull-then-restart sequence, pass-through of the peer's refusal, the too-old and unreachable cases, alias discovery and its fallbacks, the published phase, and source pins on both row copies plus the banner. Existing tests that asserted the old behaviour were updated: a checked-in peer that is behind now fires `_auto_ask_peer` instead of nothing, and the banner's framing is one neutral word ("Update") covering both mechanics.

Full Python suite (3458) and the extension suite (1399) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)