### PR TITLE
New-session directory: inline completion, live status, and a create-it offer

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3154,18 +3154,104 @@ def _true_case(path):
     return out
 
 
-def _resolve_create_dir(raw):
+def _expand_dir(raw):
+    """A typed directory as an absolute path: ~ and $VAR expanded, a relative path resolved against the
+    kernel's default new-session dir (what the field is prefilled with, so `../peer` means what it looks
+    like) rather than the kernel process's own cwd, which the user can't see."""
+    p = os.path.expanduser(os.path.expandvars(str(raw or "").strip()))
+    if not p:
+        return ""
+    return p if os.path.isabs(p) else os.path.normpath(os.path.join(_default_create_dir(), p))
+
+
+def _resolve_create_dir(raw, create=False):
     """Resolve a UI-supplied new-session directory → (path, error). ~ and $VAR are expanded; the path must
     be an existing directory (the session's cwd is fixed at creation, so a bad path can't be fixed later —
     reject it up front), and it is canonicalized — symlinks and trailing slash via realpath, on-disk
     casing via _true_case — because the string, not just the directory, is load-bearing (see
-    _true_case). Empty/None → the kernel default, no error."""
+    _true_case). Empty/None → the kernel default, no error.
+
+    create=True makes the missing directory instead of refusing (the user 2026-07-28, who wanted the
+    choice offered rather than the create silently failing). The UI only offers it after _dir_status
+    says it CAN be made; this re-checks anyway, because the answer is only as fresh as the filesystem."""
     if not raw or not str(raw).strip():
         return _default_create_dir(), None
-    p = os.path.expanduser(os.path.expandvars(str(raw).strip()))
+    p = _expand_dir(raw)
     if not os.path.isdir(p):
-        return None, "directory not found: %s" % str(raw).strip()
+        if os.path.exists(p):
+            return None, "not a directory: %s" % str(raw).strip()
+        if not create:
+            return None, "directory not found: %s" % str(raw).strip()
+        try:
+            os.makedirs(p)
+        except OSError as e:
+            return None, "could not create %s: %s" % (str(raw).strip(), e)
     return _true_case(os.path.realpath(p)), None
+
+
+def _dir_status(raw):
+    """What THIS kernel's filesystem says about a candidate new-session directory — the authoritative
+    answer, which is why the picker asks over the wire instead of guessing in the browser: for a remote
+    host the question is about the REMOTE machine's disk, and only its kernel can answer (the user
+    2026-07-28, whose new sessions have to work over SSH too).
+
+    `nearest` is the deepest ancestor that does exist, so the create offer can say how much it is about
+    to make rather than just "create it"."""
+    s = str(raw or "").strip()
+    if not s:
+        d = _default_create_dir()
+        return {"value": "", "path": _tilde(d), "exists": True, "isDir": True, "isFile": False,
+                "canCreate": False, "nearest": _tilde(d), "missing": 0, "isDefault": True}
+    p = _expand_dir(s)
+    is_dir = os.path.isdir(p)
+    exists = os.path.exists(p)
+    nearest, missing = p, 0
+    while nearest and nearest != "/" and not os.path.isdir(nearest):
+        nearest = os.path.dirname(nearest)
+        missing += 1
+    return {"value": s, "path": _tilde(p), "exists": exists, "isDir": is_dir,
+            "isFile": exists and not is_dir,
+            # a file (or anything non-directory) in the way can't be made into one — the UI offers Edit only
+            "canCreate": not exists and bool(nearest),
+            "nearest": _tilde(nearest or "/"), "missing": missing, "isDefault": False}
+
+
+DIR_COMPLETE_MAX = 50            # completion rows per reply — a big /usr/lib must not ship thousands
+
+
+def _dir_completions(raw, limit=DIR_COMPLETE_MAX):
+    """Child directories of what's typed so far → the picker's inline completer. `foo/bar` completes
+    `bar` among the children of `foo`; a trailing slash lists that directory's children. Directories
+    only (a session cwd is a directory), hidden ones only once the fragment asks for them by typing the
+    dot, and always capped — this answers a keystroke, so it must stay cheap.
+
+    Runs on the kernel that will OWN the session, so the same op serves a remote host over its tunnel;
+    no shelling out and no second source of truth (see _dir_status)."""
+    s = str(raw or "").strip()
+    p = _expand_dir(s) if s else _default_create_dir()
+    if s.endswith("/") or not s:
+        base, frag = p, ""
+    else:
+        base, frag = os.path.dirname(p), os.path.basename(p)
+    names = []
+    try:
+        with os.scandir(base or "/") as it:
+            for e in it:
+                if e.name.startswith(".") and not frag.startswith("."):
+                    continue
+                if frag and not e.name.lower().startswith(frag.lower()):
+                    continue
+                try:
+                    if e.is_dir():                      # follows symlinks: a symlinked repo is a real choice
+                        names.append(e.name)
+                except OSError:
+                    continue
+    except OSError:
+        return {"base": _tilde(base or "/"), "items": [], "truncated": False}
+    names.sort(key=lambda n: (n.lower(), n))
+    return {"base": _tilde(base or "/"),
+            "items": [{"name": n, "path": _tilde(os.path.join(base, n))} for n in names[:limit]],
+            "truncated": len(names) > limit}
 
 
 def _session_has_history(sid):
@@ -16959,9 +17045,12 @@ class Handler(BaseHTTPRequestHandler):
                 if not nm or not NAME_RE.match(nm):
                     return self._send(400, json.dumps({"ok": False, "error":
                         "session names use letters, digits, . _ - only"}), "application/json")
-                cwd, derr = _resolve_create_dir(b.get("dir"))
+                # mkdir:true makes a missing dir (the WS op's "create it" answer, available headlessly too)
+                cwd, derr = _resolve_create_dir(b.get("dir"), create=bool(b.get("mkdir")))
                 if derr:
-                    return self._send(200, json.dumps({"ok": False, "error": derr}), "application/json")
+                    return self._send(200, json.dumps({"ok": False, "error": derr,
+                                                       "dirStatus": _dir_status(b.get("dir"))}),
+                                      "application/json")
                 live = _live_names(_tmux_sessions())
                 if nm in live:
                     return self._send(200, json.dumps({"ok": True, "id": live[nm], "existing": True}),
@@ -17446,10 +17535,22 @@ class Handler(BaseHTTPRequestHandler):
             if not NAME_RE.match(nm):
                 client["send"](json.dumps({"type": "warn", "text": "session names use letters, digits, . _ - only."}))
             else:
-                cwd, derr = _resolve_create_dir(msg.get("dir"))   # the session dir is fixed at creation — validate now
+                # the session dir is fixed at creation — validate now. mkdir: the user already saw the
+                # "that folder doesn't exist" dialog and chose to make it (see createDirMissing below).
+                cwd, derr = _resolve_create_dir(msg.get("dir"), create=bool(msg.get("mkdir")))
                 live = _live_names(_tmux_sessions())
                 if derr:
-                    client["send"](json.dumps({"type": "warn", "text": derr}))
+                    st = _dir_status(msg.get("dir"))
+                    if st["canCreate"] and not msg.get("mkdir"):
+                        # A missing directory is a QUESTION, not a failure: the client raises "create it or
+                        # edit it" and comes back with mkdir set. Before this the create just warned and the
+                        # "Opening…" cue span for 30s over a session that was never going to exist (the user
+                        # 2026-07-28). Everything else (a file in the way, an unreadable parent) has no
+                        # second option, so it stays a plain warning.
+                        client["send"](json.dumps({"type": "createDirMissing", "name": nm,
+                                                   "dir": str(msg.get("dir") or ""), "status": st}))
+                    else:
+                        client["send"](json.dumps({"type": "warn", "text": derr}))
                 elif nm in live:                 # already running → just (re)open it, don't re-spawn
                     _set_hidden_tab(live[nm], False)
                     _reveal_chat({"type": "focus", "id": live[nm]})
@@ -17616,6 +17717,15 @@ class Handler(BaseHTTPRequestHandler):
                 if fp:
                     _reply(c, {"type": "droppedPath", "path": fp})
             threading.Thread(target=_pf, daemon=True).start()
+        elif msg and msg.get("type") == "dirComplete":
+            # Inline path completion for the new-session directory field. Answered by the kernel that will
+            # own the session — federation routes this by the picker's Host selection — so completing a
+            # path on a remote machine lists THAT machine's disk (the user 2026-07-28). reqId is echoed so
+            # a slow answer that lands after a newer keystroke is dropped by the client, not rendered.
+            _val = str(msg.get("value") or "")
+            _reply(client, dict({"type": "dirCompletions", "reqId": msg.get("reqId"),
+                                 "value": _val, "status": _dir_status(_val)},
+                                **_dir_completions(_val)))
         elif msg and msg.get("type") == "browseDir":
             tgt = str(msg.get("target") or "picker")          # which dir field to fill: the new-session picker or the gear
             def _bd(c=client, t=tgt):                          # Browse → native FOLDER dialog (blocks) → fill that field

--- a/tests/test_new_session_dir.py
+++ b/tests/test_new_session_dir.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""The new-session directory: completion, status, and the create-it-or-edit-it fork (the user 2026-07-28).
+
+A session's cwd is fixed at creation, so a wrong path can't be fixed later — it was already rejected up
+front. What was missing is everything around that rejection: the picker typed paths blind (a datalist of
+past dirs and a native dialog that only ever showed the LOCAL machine), and a missing directory came back
+as a toast the "Opening…" cue was covering, so the create looked like it silently did nothing.
+
+Now the kernel that will OWN the session answers three questions over the wire — what does this path
+complete to, what IS it, and shall I make it — which is also what makes the field work for a session on a
+remote host: federation routes the same ops to that host's kernel, and it reads its own disk.
+
+Synthetic paths in a temp dir only.
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_newdir", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class _Dirs(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(lambda: None)   # the temp tree is the OS's to reap; nothing here is precious
+
+
+class ResolveCreateDir(_Dirs):
+    def test_an_existing_directory_resolves(self):
+        p, err = km._resolve_create_dir(self.tmp)
+        self.assertIsNone(err)
+        self.assertEqual(os.path.realpath(p), os.path.realpath(self.tmp))
+
+    def test_blank_is_the_kernel_default(self):
+        self.assertEqual(km._resolve_create_dir("")[0], km._default_create_dir())
+        self.assertEqual(km._resolve_create_dir(None)[1], None)
+
+    def test_a_missing_directory_is_refused_without_create(self):
+        p, err = km._resolve_create_dir(os.path.join(self.tmp, "nope"))
+        self.assertIsNone(p)
+        self.assertIn("directory not found", err)
+
+    def test_create_makes_the_whole_missing_chain(self):
+        target = os.path.join(self.tmp, "a", "b", "c")
+        p, err = km._resolve_create_dir(target, create=True)
+        self.assertIsNone(err)
+        self.assertTrue(os.path.isdir(target))
+        self.assertEqual(os.path.realpath(p), os.path.realpath(target))
+
+    def test_a_file_in_the_way_is_never_created_over(self):
+        f = os.path.join(self.tmp, "afile")
+        open(f, "w").close()
+        for create in (False, True):
+            p, err = km._resolve_create_dir(f, create=create)
+            self.assertIsNone(p)
+            self.assertIn("not a directory", err)
+        self.assertTrue(os.path.isfile(f), "the file is untouched")
+
+    @unittest.skipIf(hasattr(os, "geteuid") and os.geteuid() == 0, "root ignores the mode bits")
+    def test_a_creation_that_fails_reports_instead_of_pretending(self):
+        blocked = os.path.join(self.tmp, "ro")
+        os.makedirs(blocked)
+        os.chmod(blocked, 0o500)
+        self.addCleanup(os.chmod, blocked, 0o700)
+        p, err = km._resolve_create_dir(os.path.join(blocked, "child"), create=True)
+        self.assertIsNone(p)
+        self.assertIn("could not create", err)
+
+
+class DirStatus(_Dirs):
+    def test_blank_reports_the_default_and_offers_nothing_to_create(self):
+        st = km._dir_status("")
+        self.assertTrue(st["isDefault"])
+        self.assertTrue(st["isDir"])
+        self.assertFalse(st["canCreate"])
+
+    def test_an_existing_directory(self):
+        st = km._dir_status(self.tmp)
+        self.assertTrue(st["exists"])
+        self.assertTrue(st["isDir"])
+        self.assertFalse(st["isFile"])
+        self.assertFalse(st["canCreate"])
+        self.assertEqual(st["missing"], 0)
+
+    def test_a_missing_path_names_the_deepest_ancestor_and_how_much_is_missing(self):
+        st = km._dir_status(os.path.join(self.tmp, "x", "y", "z"))
+        self.assertFalse(st["exists"])
+        self.assertTrue(st["canCreate"])
+        self.assertEqual(st["missing"], 3)
+        self.assertEqual(os.path.realpath(os.path.expanduser(st["nearest"])), os.path.realpath(self.tmp))
+
+    def test_a_file_can_never_be_created_into_a_directory(self):
+        f = os.path.join(self.tmp, "afile")
+        open(f, "w").close()
+        st = km._dir_status(f)
+        self.assertTrue(st["isFile"])
+        self.assertFalse(st["canCreate"], "no create offer for a path that is already something else")
+
+    def test_tilde_and_vars_expand(self):
+        st = km._dir_status("~")
+        self.assertTrue(st["isDir"])
+        os.environ["ROMP_TEST_DIR"] = self.tmp
+        self.addCleanup(os.environ.pop, "ROMP_TEST_DIR", None)
+        self.assertTrue(km._dir_status("$ROMP_TEST_DIR")["isDir"])
+
+
+class DirCompletions(_Dirs):
+    def setUp(self):
+        super().setUp()
+        for d in ("alpha", "album", "beta", ".hidden"):
+            os.makedirs(os.path.join(self.tmp, d))
+        open(os.path.join(self.tmp, "alfile"), "w").close()
+
+    def names(self, raw, **kw):
+        return [i["name"] for i in km._dir_completions(raw, **kw)["items"]]
+
+    def test_a_trailing_slash_lists_the_children(self):
+        self.assertEqual(self.names(self.tmp + "/"), ["album", "alpha", "beta"])
+
+    def test_a_fragment_narrows_by_prefix(self):
+        self.assertEqual(self.names(os.path.join(self.tmp, "al")), ["album", "alpha"])
+
+    def test_files_are_never_offered(self):
+        # a session cwd is a directory; "alfile" matches the prefix and must still not appear
+        self.assertNotIn("alfile", self.names(os.path.join(self.tmp, "al")))
+
+    def test_hidden_directories_appear_only_once_the_dot_is_typed(self):
+        self.assertNotIn(".hidden", self.names(self.tmp + "/"))
+        self.assertEqual(self.names(os.path.join(self.tmp, ".")), [".hidden"])
+
+    def test_matching_is_case_insensitive(self):
+        self.assertEqual(self.names(os.path.join(self.tmp, "AL")), ["album", "alpha"])
+
+    def test_the_reply_is_capped_and_says_so(self):
+        big = os.path.join(self.tmp, "many")
+        for i in range(8):
+            os.makedirs(os.path.join(big, "d%d" % i))
+        out = km._dir_completions(big + "/", limit=3)
+        self.assertEqual(len(out["items"]), 3)
+        self.assertTrue(out["truncated"])
+        self.assertFalse(km._dir_completions(big + "/", limit=50)["truncated"])
+
+    def test_an_unreadable_or_absent_base_answers_empty_rather_than_raising(self):
+        out = km._dir_completions(os.path.join(self.tmp, "nothing-here", "x"))
+        self.assertEqual(out["items"], [])
+        self.assertFalse(out["truncated"])
+
+    def test_paths_come_back_home_collapsed(self):
+        out = km._dir_completions("~/")
+        self.assertTrue(out["base"].startswith("~"), out["base"])
+        for it in out["items"]:
+            self.assertTrue(it["path"].startswith("~/"), it["path"])
+
+
+class _Wire(_Dirs):
+    """The two WS ops, driven through the real dispatcher with a fake client."""
+
+    def setUp(self):
+        super().setUp()
+        self.sent = []
+        self.client = {"app": "chat", "alive": True,
+                       "send": lambda s: self.sent.append(json.loads(s))}
+        self.handler = object.__new__(km.Handler)
+
+    def send(self, msg):
+        km.Handler._dispatch_ws(self.handler, msg, self.client)
+        return self.sent[-1] if self.sent else None
+
+
+class DirCompleteOp(_Wire):
+    def test_the_reply_carries_the_completions_the_status_and_the_request_id(self):
+        r = self.send({"type": "dirComplete", "value": self.tmp + "/", "reqId": 12})
+        self.assertEqual(r["type"], "dirCompletions")
+        self.assertEqual(r["reqId"], 12, "echoed so a late reply for an older keystroke can be dropped")
+        self.assertEqual(r["value"], self.tmp + "/")
+        self.assertIn("items", r)
+        self.assertTrue(r["status"]["isDir"])
+
+
+class CreateSessionDirFork(_Wire):
+    def setUp(self):
+        super().setUp()
+        self.spawned = []
+        self._real_sdk = km._create_sdk_session
+        self._real_ready = km._sdk_ready
+        km._create_sdk_session = lambda nm, cwd: self.spawned.append((nm, cwd)) or "TESTSID"
+        km._sdk_ready = lambda: True
+        self.addCleanup(setattr, km, "_create_sdk_session", self._real_sdk)
+        self.addCleanup(setattr, km, "_sdk_ready", self._real_ready)
+
+    def test_a_missing_directory_asks_instead_of_warning_into_the_void(self):
+        target = os.path.join(self.tmp, "not", "yet")
+        r = self.send({"type": "createSession", "name": "web", "dir": target, "backend": "sdk"})
+        self.assertEqual(r["type"], "createDirMissing")
+        self.assertEqual(r["name"], "web")
+        self.assertTrue(r["status"]["canCreate"])
+        self.assertEqual(r["status"]["missing"], 2)
+        self.assertEqual(self.spawned, [], "nothing is created until the user answers")
+        self.assertFalse(os.path.exists(target))
+
+    def test_answering_create_makes_the_directory_and_starts_there(self):
+        target = os.path.join(self.tmp, "not", "yet")
+        self.send({"type": "createSession", "name": "web", "dir": target, "backend": "sdk", "mkdir": True})
+        self.assertTrue(os.path.isdir(target))
+        self.assertEqual(len(self.spawned), 1)
+        self.assertEqual(os.path.realpath(self.spawned[0][1]), os.path.realpath(target))
+
+    def test_a_file_in_the_way_stays_a_plain_warning_there_is_nothing_to_offer(self):
+        f = os.path.join(self.tmp, "afile")
+        open(f, "w").close()
+        r = self.send({"type": "createSession", "name": "web", "dir": f, "backend": "sdk"})
+        self.assertEqual(r["type"], "warn")
+        self.assertIn("not a directory", r["text"])
+
+    def test_a_good_directory_still_just_starts(self):
+        self.send({"type": "createSession", "name": "web", "dir": self.tmp, "backend": "sdk"})
+        self.assertEqual(len(self.spawned), 1)
+        self.assertNotIn("createDirMissing", [m.get("type") for m in self.sent])
+
+
+class HeadlessParity(unittest.TestCase):
+    def test_the_new_route_can_create_the_directory_too(self):
+        import inspect
+        src = inspect.getsource(km.Handler)
+        self.assertIn('_resolve_create_dir(b.get("dir"), create=bool(b.get("mkdir")))', src,
+                      "`romp new` gets the same create-it answer the dashboard offers")
+        self.assertIn('"dirStatus": _dir_status(b.get("dir"))', src,
+                      "a headless caller is told WHY, in the same shape the picker reads")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/dir-complete.test.ts
+++ b/ui/webview/dir-complete.test.ts
@@ -1,0 +1,105 @@
+// The new-session directory field (the user 2026-07-28): what the status line says about a typed path,
+// how the keyboard walks the folder list, and how the "that folder isn't there" dialog reads. EXECUTES
+// ./dir-complete; the picker plumbing (the request/reply pacing, the create fork, the host routing) is
+// source-pinned against render.ts below.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { dirStatusLine, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+const st = (over: Partial<DirStatus>): DirStatus => ({
+  value: "~/GitRepos/api", path: "~/GitRepos/api", exists: true, isDir: true, isFile: false,
+  canCreate: false, nearest: "~/GitRepos", missing: 0, isDefault: false, ...over,
+});
+
+test("an existing folder reads as a plain confirmation", () => {
+  const said = dirStatusLine(st({}));
+  assert.equal(said.text, "✓ ~/GitRepos/api");
+  assert.equal(said.cls, "", "nothing is wrong, so nothing is coloured");
+});
+
+test("the untouched default says it is the default", () => {
+  assert.match(dirStatusLine(st({ isDefault: true })).text, /\(the default\)$/);
+});
+
+test("a missing folder warns and names where it would go", () => {
+  const said = dirStatusLine(st({ exists: false, isDir: false, canCreate: true, missing: 2 }));
+  assert.equal(said.cls, "warn");
+  assert.match(said.text, /not there yet/);
+  assert.match(said.text, /under ~\/GitRepos$/, "the offer says where, so it isn't a blind yes");
+});
+
+test("a file where a folder was typed is an error, not an offer", () => {
+  const said = dirStatusLine(st({ isDir: false, isFile: true, canCreate: false }));
+  assert.equal(said.cls, "bad");
+  assert.match(said.text, /file, not a folder/);
+});
+
+test("an unreachable path says so rather than offering to create it", () => {
+  const said = dirStatusLine(st({ exists: false, isDir: false, canCreate: false, nearest: "" }));
+  assert.equal(said.cls, "bad");
+  assert.match(said.text, /can't be reached/);
+});
+
+test("no answer yet says nothing at all", () => {
+  assert.deepEqual(dirStatusLine(null), { text: "", cls: "" });
+});
+
+test("walking the list passes through 'nothing chosen' at both ends", () => {
+  assert.equal(nextDirActive(-1, 1, 3), 0);
+  assert.equal(nextDirActive(0, 1, 3), 1);
+  assert.equal(nextDirActive(2, 1, 3), -1, "off the bottom hands the field back to typing");
+  assert.equal(nextDirActive(-1, -1, 3), 2, "up from nothing takes the last row");
+  assert.equal(nextDirActive(0, -1, 3), -1);
+  assert.equal(nextDirActive(-1, 1, 0), -1, "an empty list has nothing to choose");
+});
+
+test("the create dialog names the path and how much it would make", () => {
+  assert.match(createDirPrompt("api", st({ path: "~/w/a/b", missing: 2, nearest: "~/w" }), ""),
+    /~\/w\/a\/b doesn't exist \(2 new folders under ~\/w\)/);
+  // one folder needs no arithmetic in the sentence
+  assert.match(createDirPrompt("api", st({ path: "~/w/a", missing: 1, nearest: "~/w" }), ""),
+    /~\/w\/a doesn't exist\. Create it/);
+  assert.match(createDirPrompt("api", null, "/typed/path"), /^\/typed\/path doesn't exist/);
+});
+
+test("the field asks the kernel that would OWN the session, so a remote host completes its own disk", () => {
+  assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "dirComplete", value, reqId: \+\+dirReq, host: pickerHost\(\) \}\)/);
+  assert.match(RENDER, /#picker \.picker-host \.picker-be-opt\.sel/, "the host comes off the picker's own selection");
+});
+
+test("pacing is the round trip, not a timer: one request in flight, the newest value queued behind it", () => {
+  assert.match(RENDER, /if \(dirInFlight\) \{ dirQueued = value; return; \}/);
+  assert.match(RENDER, /dirInFlight = false;\s*\n\s*const stale = m\.reqId !== dirReq;/);
+  assert.match(RENDER, /if \(dirQueued !== null\) \{ const v = dirQueued; dirQueued = null; askDirComplete\(v\); \}/);
+  assert.match(RENDER, /if \(stale\) return;/, "a reply for an older keystroke never renders");
+  assert.doesNotMatch(RENDER.slice(RENDER.indexOf("function askDirComplete"), RENDER.indexOf("function dirMenuOpen")),
+    /setTimeout/, "no debounce");
+});
+
+test("a chosen completion walks INTO the folder; it never starts the session", () => {
+  assert.match(RENDER, /input\.value = it\.path \+ "\/";/);
+  assert.match(RENDER, /if \(e\.key === "Enter" && dirActive >= 0\) \{[\s\S]*?acceptDir\(dirActive\);/);
+  assert.match(RENDER, /if \(dirKey\(e\)\) return;/, "the completer gets the keys before the session list does");
+});
+
+test("a missing directory raises the create-or-edit choice, and Create re-sends the SAME create", () => {
+  assert.match(RENDER, /else if \(m\.type === "createDirMissing" && m\.name\) onCreateDirMissing\(m\)/);
+  assert.match(RENDER, /hideOpeningModal\(\);\s*\/\/ the cue would otherwise spin/);
+  assert.match(RENDER, /\{ label: "Create it and start", value: "create" \}, \{ label: "Edit the path", value: "edit" \}/);
+  assert.match(RENDER, /if \(v === "create"\) \{ startCreate\(req, true\); return; \}/);
+  assert.match(RENDER, /\.\.\.\(mkdir \? \{ mkdir: true \} : \{\}\)/, "mkdir rides the same message");
+});
+
+test("Edit reopens the picker with what was typed, cursor in the path", () => {
+  const edit = RENDER.slice(RENDER.indexOf('if (v === "edit")'), RENDER.indexOf("function openPicker"));
+  assert.match(edit, /search\.value = req\.name/);
+  assert.match(edit, /dir\.value = req\.dir; dir\.focus\(\); dir\.select\(\); askDirComplete\(dir\.value\)/);
+});
+
+test("switching host re-asks: the folders on screen belong to the host that was selected", () => {
+  assert.match(RENDER, /\/\/ the completions on screen belong to the host that just stopped being selected\s*\n\s*closeDirMenu\(\);/);
+});

--- a/ui/webview/dir-complete.ts
+++ b/ui/webview/dir-complete.ts
@@ -1,0 +1,40 @@
+// The new-session directory field's two decisions, kept out of the DOM so they can be tested:
+// what the status line SAYS about a typed path, and where the keyboard lands when you walk the
+// folder list. The kernel that will own the session supplies the status (kernel _dir_status) — for a
+// remote host that is the remote machine's own disk, which is the whole reason this is a round trip
+// rather than a guess in the browser (the user 2026-07-28).
+
+export interface DirStatus {
+  value: string; path: string; exists: boolean; isDir: boolean; isFile: boolean;
+  canCreate: boolean; nearest: string; missing: number; isDefault: boolean;
+}
+
+/** One line saying what the typed path IS, and the tone to say it in. "" = say nothing (no answer yet). */
+export function dirStatusLine(s: DirStatus | null): { text: string; cls: string } {
+  if (!s) return { text: "", cls: "" };
+  if (s.isDefault) return { text: s.path + "  (the default)", cls: "" };
+  if (s.isDir) return { text: "✓ " + s.path, cls: "" };
+  // a file where a folder was typed can never become one — no create offer follows, so say so plainly
+  if (s.isFile) return { text: "that's a file, not a folder", cls: "bad" };
+  if (s.canCreate) {
+    return { text: "not there yet. Starting will offer to create it, under " + s.nearest, cls: "warn" };
+  }
+  return { text: "can't be reached: " + s.path, cls: "bad" };
+}
+
+/** Walk the completion list. -1 ("nothing chosen") is part of the cycle in BOTH directions, so walking
+ *  off either end hands the field back to typing instead of trapping the cursor in the menu. */
+export function nextDirActive(cur: number, delta: number, count: number): number {
+  if (count <= 0) return -1;
+  const next = cur + delta;
+  if (next >= count) return -1;
+  if (next < -1) return count - 1;
+  return next;
+}
+
+/** The detail line of the "that folder isn't there" dialog: name the path, and how much would be made. */
+export function createDirPrompt(name: string, s: DirStatus | null, fallback: string): string {
+  const where = (s && s.path) || fallback;
+  const under = s && s.missing > 1 ? ` (${s.missing} new folders under ${s.nearest})` : "";
+  return `${where} doesn't exist${under}. Create it and start “${name}” there, or go back and edit the path?`;
+}

--- a/ui/webview/picker-dir.test.ts
+++ b/ui/webview/picker-dir.test.ts
@@ -20,8 +20,11 @@ test("the picker has a directory field with a recent-dirs datalist", () => {
 });
 
 test("createSession carries the chosen dir, alongside name + backend", () => {
-  // backend now comes from the + dialog's per-session toggle, falling back to the gear default (the user 2026-06-23)
-  assert.match(RENDER, /type: "createSession", name, backend: beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend, dir: dirInput\.value\.trim\(\)/);
+  // backend comes from the + dialog's per-session toggle, falling back to the gear default (the user
+  // 2026-06-23). The whole request goes through startCreate, which remembers it so a missing directory
+  // can be created and the SAME create re-sent (the user 2026-07-28).
+  assert.match(RENDER, /startCreate\(\{ name, backend: beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend,\s*\n\s*dir: dirInput\.value\.trim\(\), host: hostSel \}\)/);
+  assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "createSession", \.\.\.req/);
 });
 
 test("the dir field is prefilled with the gear default and hidden in pick-mode", () => {

--- a/ui/webview/picker-host.test.ts
+++ b/ui/webview/picker-host.test.ts
@@ -18,9 +18,9 @@ test("the + dialog builds a Host row listing local + attached hosts, hidden with
 
 test("createSession carries the picked host (empty = local) so the manager routes it to that kernel", () => {
   assert.match(RENDER, /const hostSel = \(hostWrap\.querySelector\("\.picker-be-opt\.sel"\) as HTMLElement \| null\)\?\.dataset\.host \|\| ""/);
-  assert.match(RENDER, /type: "createSession", name, backend: beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend, dir: dirInput\.value\.trim\(\), host: hostSel/);
+  assert.match(RENDER, /startCreate\(\{ name, backend: beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend,\s*\n\s*dir: dirInput\.value\.trim\(\), host: hostSel \}\)/);
   // the "Opening…" cue must match the PREFIXED tab name a remote create produces
-  assert.match(RENDER, /showOpeningModal\(hostSel \? hostSel \+ ":" \+ name : name\)/);
+  assert.match(RENDER, /showOpeningModal\(req\.host \? req\.host \+ ":" \+ req\.name : req\.name\)/);
 });
 
 test("picking a remote host disables the (host-local) Browse… dialog", () => {

--- a/ui/webview/render-settings.test.ts
+++ b/ui/webview/render-settings.test.ts
@@ -38,6 +38,6 @@ test("the chat has NO gear of its own — it only consumes the shared setting (g
 
 test("the + New session button sends the picker's backend toggle, defaulting to the gear's (the user 2026-06-23)", () => {
   // the per-session toggle wins; it RESETS to the gear default (read fresh via loadSettings()) on each open
-  assert.match(RENDER, /type: "createSession", name, backend: beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend/);
+  assert.match(RENDER, /startCreate\(\{ name, backend: beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend,/);
   assert.match(RENDER, /const def = loadSettings\(\)\.backend \|\| "tmux";/);   // toggle defaults to the gear setting
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -25,6 +25,7 @@ import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
 import { previewKind, previewFull, canPreview } from "./preview";
 import { hostNameNodes } from "./host-prefix";
+import { dirStatusLine, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
 
@@ -3762,6 +3763,170 @@ function signalPickerOverlay(on: boolean) {
   try { if (window.parent && window.parent !== window) window.parent.postMessage({ romp: "picker", on }, "*"); } catch (e) { /* standalone: no shell to lift */ }
 }
 
+// ── new-session directory: inline completer ────────────────────────────────────────────────────────
+// Typing a path used to be blind — a datalist of previously-used dirs and a native Browse… dialog that
+// only ever showed the LOCAL machine, so a session on a remote host was typed from memory and only
+// found out it was wrong after the create (the user 2026-07-28). The kernel that will own the session
+// answers instead (dirComplete → dirCompletions), so the same field completes remote paths over the
+// host's tunnel, and the status line under it says what the path IS before anything is committed.
+//
+// No debounce: a request goes out on the keystroke, and while one is in flight the newest value is
+// held and fired when the reply lands. The pacing is the round-trip itself — an event, not a timer —
+// so a fast local kernel completes per keystroke and a slow SSH hop coalesces on its own.
+interface DirItem { name: string; path: string }
+let dirReq = 0;                    // newest request id; a reply for an older one is stale
+let dirInFlight = false;
+let dirQueued: string | null = null;  // typed while a request was out
+let dirItems: DirItem[] = [];
+let dirActive = -1;                   // highlighted completion row (-1 = none; Enter then creates)
+let dirStatus: DirStatus | null = null;
+
+function pickerHost(): string {
+  const sel = document.querySelector("#picker .picker-host .picker-be-opt.sel") as HTMLElement | null;
+  return sel?.dataset.host || "";
+}
+
+function askDirComplete(value: string): void {
+  if (!vscodeApi) return;
+  if (dirInFlight) { dirQueued = value; return; }
+  dirInFlight = true;
+  vscodeApi.postMessage({ type: "dirComplete", value, reqId: ++dirReq, host: pickerHost() });
+}
+
+function onDirCompletions(m: any): void {
+  dirInFlight = false;
+  const stale = m.reqId !== dirReq;
+  if (dirQueued !== null) { const v = dirQueued; dirQueued = null; askDirComplete(v); }
+  if (stale) return;                                   // a newer keystroke already owns the field
+  dirItems = Array.isArray(m.items) ? m.items : [];
+  dirStatus = m.status || null;
+  dirActive = -1;
+  renderDirMenu(!!m.truncated);
+}
+
+function dirMenuOpen(): boolean {
+  const menu = document.getElementById("picker-dir-menu");
+  return !!menu && menu.style.display !== "none";
+}
+
+function closeDirMenu(): void {
+  const menu = document.getElementById("picker-dir-menu");
+  if (menu) { menu.style.display = "none"; menu.replaceChildren(); }
+  dirActive = -1;
+}
+
+// The status line is the one-glance version: what this path is right now. The menu underneath is the
+// deeper level, and it only exists while there is something to choose.
+function renderDirMenu(truncated: boolean): void {
+  const line = document.getElementById("picker-dir-status");
+  if (line) {
+    const said = dirStatusLine(dirStatus);
+    line.className = "picker-dir-status" + (said.cls ? " " + said.cls : "");
+    line.textContent = said.text;
+  }
+  const menu = document.getElementById("picker-dir-menu");
+  if (!menu) return;
+  menu.replaceChildren();
+  if (!dirItems.length) { menu.style.display = "none"; return; }
+  dirItems.forEach((it, i) => {
+    const row = el("div", "picker-dir-row" + (i === dirActive ? " active" : ""));
+    row.textContent = it.name;
+    row.dataset.path = it.path;
+    row.addEventListener("mousedown", (e) => { e.preventDefault(); acceptDir(i); });   // mousedown: the input keeps focus
+    menu.appendChild(row);
+  });
+  if (truncated) {
+    const more = el("div", "picker-dir-more");
+    more.textContent = "more: keep typing to narrow";
+    menu.appendChild(more);
+  }
+  menu.style.display = "";
+}
+
+// Accept a completion: the field becomes that path with a trailing slash, which immediately asks for
+// its children. Tab-tab-tab walks down a tree without a modal, and works the same on a remote host.
+function acceptDir(i: number): void {
+  const it = dirItems[i];
+  const input = document.getElementById("picker-dir") as HTMLInputElement | null;
+  if (!it || !input) return;
+  input.value = it.path + "/";
+  input.focus();
+  askDirComplete(input.value);
+}
+
+function moveDirActive(delta: number): void {
+  if (!dirItems.length) return;
+  dirActive = nextDirActive(dirActive, delta, dirItems.length);
+  renderDirMenu(false);
+  const active = document.querySelector("#picker-dir-menu .picker-dir-row.active") as HTMLElement | null;
+  active?.scrollIntoView({ block: "nearest" });
+}
+
+// Keys belong to the completer only while the dir field has focus — everywhere else in the picker
+// they still walk the session list. Returns true when it handled the key.
+function dirKey(e: KeyboardEvent): boolean {
+  const input = document.getElementById("picker-dir");
+  if (!input || document.activeElement !== input) return false;
+  if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+    if (!dirMenuOpen()) return false;
+    e.preventDefault(); e.stopPropagation();
+    moveDirActive(e.key === "ArrowDown" ? 1 : -1);
+    return true;
+  }
+  if (e.key === "Tab" && dirItems.length) {
+    e.preventDefault(); e.stopPropagation();
+    acceptDir(dirActive >= 0 ? dirActive : 0);          // Tab with nothing chosen takes the first match
+    return true;
+  }
+  if (e.key === "Enter" && dirActive >= 0) {
+    e.preventDefault(); e.stopPropagation();
+    acceptDir(dirActive);                                // a chosen row completes; it does NOT create
+    return true;
+  }
+  if (e.key === "Escape" && dirMenuOpen()) {
+    e.preventDefault(); e.stopPropagation();
+    closeDirMenu();                                      // dismiss the menu, keep the picker open
+    return true;
+  }
+  return false;
+}
+
+// ── creating a session, including the "that folder isn't there" fork ───────────────────────────────
+// The create is one round trip: the OWNING kernel checks its own disk and either starts the session or
+// says the directory is missing. A missing one is a question, not a failure — before this the kernel
+// warned into a toast the "Opening…" cue was covering, so the create looked like it silently did
+// nothing for 30 seconds (the user 2026-07-28). The request is remembered so "Create it" can re-send
+// exactly the same create with mkdir set, host and backend included.
+interface CreateReq { name: string; backend: string; dir: string; host: string }
+let lastCreate: CreateReq | null = null;
+
+function startCreate(req: CreateReq, mkdir = false): void {
+  lastCreate = req;
+  if (vscodeApi) vscodeApi.postMessage({ type: "createSession", ...req, ...(mkdir ? { mkdir: true } : {}) });
+  closePicker();
+  // a remote session's tab arrives host-prefixed — register the prefixed name so the cue dismisses
+  showOpeningModal(req.host ? req.host + ":" + req.name : req.name);
+}
+
+function onCreateDirMissing(m: any): void {
+  hideOpeningModal();                    // the cue would otherwise spin over a dialog it hides
+  const req = lastCreate;
+  showConfirm("That folder isn't there",
+    createDirPrompt(String(m.name), (m.status || null) as DirStatus | null, String(m.dir || "")),
+    [{ label: "Create it and start", value: "create" }, { label: "Edit the path", value: "edit" }],
+    (v) => {
+      if (!req) return;
+      if (v === "create") { startCreate(req, true); return; }
+      if (v === "edit") {
+        openPicker();                    // reopen with the same name and path, cursor in the dir field
+        const search = document.getElementById("picker-search") as HTMLInputElement | null;
+        if (search) search.value = req.name;
+        const dir = document.getElementById("picker-dir") as HTMLInputElement | null;
+        if (dir) { dir.value = req.dir; dir.focus(); dir.select(); askDirComplete(dir.value); }
+      }
+    });
+}
+
 function openPicker(pick = false, prompt?: string, allowNew = false) {
   pickMode = pick;
   pickAllowNew = pick && allowNew;
@@ -3789,14 +3954,22 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     dirInput.id = "picker-dir";
     dirInput.spellcheck = false;
     dirInput.placeholder = "New-session directory (blank = default)";
-    dirInput.title = "Working directory for a NEW session — fixed once it starts. Blank uses the kernel's default. ~ and $VARs expand; recent dirs autocomplete.";
+    dirInput.title = "Working directory for a NEW session — fixed once it starts. Blank uses the kernel's default. ~ and $VARs expand; type to complete folders (Tab walks into one), on this machine or the selected host.";
     dirInput.setAttribute("list", "picker-dir-list");
+    dirInput.setAttribute("autocomplete", "off");   // the browser's own dropdown would fight the completer
     const dirList = document.createElement("datalist"); dirList.id = "picker-dir-list";
     const browseBtn = el("button", "picker-browse") as HTMLButtonElement;
     browseBtn.type = "button"; browseBtn.textContent = "Browse…";
     browseBtn.title = "Pick a folder with the native macOS dialog (opens on the kernel's machine — host-local)";
     browseBtn.addEventListener("click", () => { if (vscodeApi) vscodeApi.postMessage({ type: "browseDir" }); });
+    // the completer's dropdown + the one-line status of whatever is typed, both fed by the owning kernel
+    const dirMenu = el("div", "picker-dir-menu"); dirMenu.id = "picker-dir-menu"; dirMenu.style.display = "none";
+    const dirStat = el("div", "picker-dir-status"); dirStat.id = "picker-dir-status";
+    dirInput.addEventListener("input", () => askDirComplete(dirInput.value));
+    dirInput.addEventListener("focus", () => askDirComplete(dirInput.value));
+    dirInput.addEventListener("blur", () => closeDirMenu());   // a row's mousedown preventDefaults, so it never blurs
     dirWrap.appendChild(dirInput); dirWrap.appendChild(dirList); dirWrap.appendChild(browseBtn);
+    dirWrap.appendChild(dirMenu); dirWrap.appendChild(dirStat);
     // per-session BACKEND picker (the user 2026-06-23): a tmux | SDK segmented toggle, defaulting to the
     // gear's Default backend but overridable for THIS new session. Hidden in pick-mode (like dirWrap).
     const beWrap = el("div", "picker-backend");
@@ -3829,10 +4002,8 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       const beSel = beWrap.querySelector(".picker-be-opt.sel") as HTMLElement | null;
       // host: local ("") or an attached SSH host — the federation manager routes createSession there.
       const hostSel = (hostWrap.querySelector(".picker-be-opt.sel") as HTMLElement | null)?.dataset.host || "";
-      if (vscodeApi) vscodeApi.postMessage({ type: "createSession", name, backend: beSel?.dataset.be || loadSettings().backend, dir: dirInput.value.trim(), host: hostSel });
-      closePicker();
-      // a remote session's tab arrives host-prefixed — register the prefixed name so the cue dismisses
-      showOpeningModal(hostSel ? hostSel + ":" + name : name);   // "Opening…" cue until the new tab arrives (see upsert)
+      startCreate({ name, backend: beSel?.dataset.be || loadSettings().backend,
+                    dir: dirInput.value.trim(), host: hostSel });
     });
     const openAll = el("button", "picker-action");
     openAll.textContent = "↗ Open all running sessions";
@@ -3878,11 +4049,15 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
                   : "Create the session on this machine.";
       b.addEventListener("click", () => {
         hostWrapEl.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", x === b));
-        // the Browse… dialog and dir autocomplete are LOCAL-machine paths — misleading for a remote host
+        // the native Browse… dialog opens on the LOCAL kernel's screen, so it can't stand for a remote
+        // machine's disk; the inline completer can — it asks that host's own kernel (the user 2026-07-28)
         const browse = overlay!.querySelector(".picker-browse") as HTMLButtonElement | null;
-        if (browse) { browse.disabled = !!h; browse.title = h ? "Directory browsing is host-local; type the remote path (blank = that kernel's default)." : "Pick a folder with the native macOS dialog (opens on the kernel's machine — host-local)"; }
+        if (browse) { browse.disabled = !!h; browse.title = h ? `The native dialog is local-only. Type the path on ${h} instead; it completes as you type.` : "Pick a folder with the native macOS dialog (opens on the kernel's machine — host-local)"; }
         const dirIn = document.getElementById("picker-dir") as HTMLInputElement | null;
         if (dirIn) dirIn.placeholder = h ? `New-session directory on ${h} (blank = its default)` : "New-session directory (blank = default)";
+        // the completions on screen belong to the host that just stopped being selected
+        closeDirMenu();
+        if (dirIn) askDirComplete(dirIn.value);
       });
       hostWrapEl.appendChild(b);
     }
@@ -3891,6 +4066,8 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   }
   const di = document.getElementById("picker-dir") as HTMLInputElement | null;
   if (di) di.value = kernelDefaultDir || loadSettings().defaultDir || "";   // the kernel's persisted default (file→env) wins; localStorage is a same-tab cache
+  closeDirMenu();                       // a previous open's folder list is not this one's
+  if (di && !pick) askDirComplete(di.value);   // the status line says what the prefilled path is, before anything is typed
   // In a filtered view (#only=<tag>), a new session created here would vanish from the view unless its name
   // matches. Prefill the name box with the tag so what you launch stays in view (the user 2026-07-15) —
   // editable: clear it to launch outside the filter on purpose. Only when creating is possible here (the
@@ -4067,6 +4244,9 @@ function moveActive(delta: number) {
 function pickerKey(e: KeyboardEvent) {
   const o = document.getElementById("picker");
   if (!o || o.style.display === "none") return;
+  // the directory field's completer owns the arrows / Tab / Enter while it is focused, so walking the
+  // folder list can't also walk the session list underneath it
+  if (dirKey(e)) return;
   if (e.key === "Escape") closePicker();
   else if (e.key === "ArrowDown") { e.preventDefault(); moveActive(1); }
   else if (e.key === "ArrowUp") { e.preventDefault(); moveActive(-1); }
@@ -6844,6 +7024,8 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "nextTab") cycleTab(1);
   else if (m.type === "prevTab") cycleTab(-1);
   else if (m.type === "warn" && typeof m.text === "string" && m.text) warnToast(m.text);
+  else if (m.type === "dirCompletions") onDirCompletions(m);        // the owning kernel's path completions
+  else if (m.type === "createDirMissing" && m.name) onCreateDirMissing(m);   // create it, or edit the path
   // The AUTHORITATIVE answer to a ✕ on a queued bubble (the user 2026-07-20). ok:false = the message
   // had already left romp's queue (handed to the CLI — no recall exists): toast the kernel's 'too late'
   // and UNDO the optimistic composer restore if the draft is untouched — leaving the copy there invited

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1674,7 +1674,9 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
   border-bottom: 1px solid var(--box-border);
 }
 .picker-error.show { display: block; }
-.picker-dir { display: flex; align-items: center; gap: 6px; padding: 8px 14px; border-top: 1px solid var(--box-border); }
+/* the row wraps so the completer's status line gets its own line under the field; the folder menu is
+   absolutely positioned so it lays OVER the rows below instead of shoving the dialog around */
+.picker-dir { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; padding: 8px 14px; border-top: 1px solid var(--box-border); position: relative; }
 .picker-dir::before { content: "📁"; opacity: 0.55; font-size: 0.9em; flex: 0 0 auto; }
 .picker-dir-input {
   flex: 1 1 auto; min-width: 0;
@@ -1691,6 +1693,30 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
   border: 1px solid var(--box-border); border-radius: 5px; padding: 5px 9px; font-size: 0.82em;
 }
 .picker-browse:hover { background: rgba(255, 255, 255, 0.12); }
+/* the typed path's one-line verdict from the kernel that would own the session (exists / will be
+   created / is a file), so the answer arrives before the create does (the user 2026-07-28) */
+.picker-dir-status {
+  flex: 1 0 100%; margin-top: 4px; min-width: 0;
+  color: var(--dim); font-family: var(--mono, monospace); font-size: 0.82em;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.picker-dir-status.warn { color: #e0a030; }
+.picker-dir-status.bad { color: #e5484d; }
+/* folder completions: Tab walks into one, so a path is assembled without a modal or a native dialog */
+.picker-dir-menu {
+  position: absolute; left: 14px; right: 14px; top: calc(100% - 4px); z-index: 6;
+  max-height: 216px; overflow-y: auto;
+  background: var(--vscode-editorWidget-background, #252526);
+  border: 1px solid var(--box-border); border-radius: 6px; box-shadow: 0 8px 24px #000000aa;
+}
+.picker-dir-row {
+  padding: 4px 10px; cursor: pointer;
+  color: var(--fg); font-family: var(--mono, monospace); font-size: 0.82em;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.picker-dir-row:hover { background: rgba(255, 255, 255, 0.08); }
+.picker-dir-row.active { background: rgba(156, 210, 255, 0.14); color: var(--accent); }
+.picker-dir-more { padding: 4px 10px; color: var(--dim); font-size: 0.82em; }
 /* per-session backend toggle in the + dialog (the user 2026-06-23): a tmux | SDK segmented control */
 .picker-backend { display: flex; align-items: center; gap: 6px; padding: 6px 14px 8px; }
 .picker-backend-label { flex: 0 0 auto; color: var(--dim); font-size: 0.82em; margin-right: 2px; }


### PR DESCRIPTION
Typing the directory for a new session was blind: autocomplete only knew directories romp had already seen, the native Browse… dialog could only show the local machine, and a path that did not exist came back as a toast hidden behind the "Opening…" cue, so the create looked like it silently did nothing for 30 seconds.

The kernel that will own the session answers over the wire, which is what makes this work for remote SSH hosts too. Federation already routes an explicit `host` field, so the same ops reach that host's kernel and it reads its own disk.

- `dirComplete` → `dirCompletions`: child directories of what's typed. Directories only, hidden ones only once the dot is typed, capped per reply. Tab walks into a folder and asks for its children. No debounce: one request in flight, newest value fires when the reply lands, so the pacing is the round trip.
- A status line under the field: exists / is a file / not there yet and where it would go.
- `createDirMissing`: a missing directory raises "Create it and start" or "Edit the path". Create re-sends the same create with `mkdir`, host and backend included. A file in the way has no second option, so it stays a plain warning.
- `POST /new` takes the same `mkdir` flag and returns the same `dirStatus`, so `romp new` has parity.
- A relative path resolves against the default new-session directory shown in the field, not the kernel process's cwd.

Tests: `tests/test_new_session_dir.py` (resolve/create incl. a file in the way and a failing mkdir, status shape, completion rules and cap, both WS ops driven through the real dispatcher), `ui/webview/dir-complete.test.ts` (executes the pure status/keyboard/dialog logic, plus source pins on the picker plumbing). Both suites green (3458 python, 1411 node), tsc clean. Layout verified with a headless render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)