### PR TITLE
The login service carries which romp it supervises

### DIFF
--- a/bin/romp-service
+++ b/bin/romp-service
@@ -42,8 +42,40 @@ LAUNCHCTL="${ROMP_LAUNCHCTL:-launchctl}"
 PLIST="$LAUNCHD_DIR/$LABEL.plist"
 UNIT="$SYSTEMD_DIR/romp-manager.service"
 
+# The instance-scoping env: the variables that say WHICH romp this service supervises.
+# A second OS user on one machine (a kernel handed to another person) shares the machine's
+# PORT space, so their manager/kernel/bus have to be renumbered; the rest of the profile
+# (state root, Claude config dir, tmux socket) is the same set romp-manager's specEnv hands
+# an aux kernel. The installing shell has them set; the unit did NOT, so a supervised manager
+# came up on the defaults while every foreground `romp` command used the overrides — the
+# manager's control port then collides with the primary user's and the service dies at login,
+# with the CLI still reporting the configured port. Bake whatever is SET at install time, and
+# nothing that isn't, so a default single-user install writes the same unit it always did.
+# (Reinstall after changing one, exactly like PATH.)
+_INSTANCE_VARS=(ROMP_SERVE_PORT ROMP_POSTAL_PORT ROMP_MANAGER_PORT ROMP_STATE_DIR CLAUDE_CONFIG_DIR ROMP_TMUX_SOCKET)
+
+# The SET ones, formatted for the platform: $1 = plist (EnvironmentVariables dict pairs) or
+# unit (systemd Environment= lines). Each line is newline-TERMINATED; the callers decide what
+# the empty case looks like, because the two files want different things there.
+_instance_env_block() {
+    local v out=""
+    for v in "${_INSTANCE_VARS[@]}"; do
+        [[ -n "${!v:-}" ]] || continue
+        if [[ "$1" == plist ]]; then
+            out+="    <key>$v</key><string>${!v}</string>"$'\n'
+        else
+            out+="Environment=$v=${!v}"$'\n'
+        fi
+    done
+    printf '%s' "$out"
+}
+
 write_plist() {
     mkdir -p "$LAUNCHD_DIR" "$STATE"
+    # $() eats the trailing newline; put it back so </dict> keeps its own line. Empty → the
+    # dict closes exactly as it did before this existed.
+    local _plist_env; _plist_env="$(_instance_env_block plist)"
+    if [[ -n "$_plist_env" ]]; then _plist_env+=$'\n'; fi
     cat > "$PLIST" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -61,7 +93,7 @@ write_plist() {
     <key>PATH</key><string>$PATH</string>
     <key>ROMP_DIR</key><string>$ROMP_DIR</string>
     <key>ROMP_SUPERVISED</key><string>1</string>
-  </dict>
+${_plist_env}  </dict>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
   <key>StandardOutPath</key><string>$LOG</string>
@@ -73,6 +105,10 @@ EOF
 
 write_unit() {
     mkdir -p "$SYSTEMD_DIR" "$STATE"
+    # $() eats the trailing newline; put it back so the blank line before [Install] survives.
+    # Empty → the block collapses to exactly the unit this wrote before it existed.
+    local _unit_env; _unit_env="$(_instance_env_block unit)"
+    if [[ -n "$_unit_env" ]]; then _unit_env+=$'\n'; fi
     cat > "$UNIT" <<EOF
 [Unit]
 Description=romp kernel supervisor (romp-manager)
@@ -85,7 +121,7 @@ RestartSec=2
 Environment=PATH=$PATH
 Environment=ROMP_DIR=$ROMP_DIR
 Environment=ROMP_SUPERVISED=1
-
+${_unit_env}
 [Install]
 WantedBy=default.target
 EOF

--- a/tests/romp-service.bats
+++ b/tests/romp-service.bats
@@ -19,6 +19,11 @@ setup() {
     printf '#!/bin/sh\necho fake-node "$@"\n' > "$TEST_DIR/fake-node"
     chmod +x "$TEST_DIR/fake-node"
     export ROMP_NODE_SRC="$TEST_DIR/fake-node"
+    # Running this suite INSIDE a romp session inherits the live kernel's ROMP_SERVE_PORT /
+    # ROMP_MANAGER_PORT, which the unit now bakes — so a default-vs-override test would be
+    # reading the developer's machine instead of the code. Clear the whole instance set; the
+    # tests that want them set them explicitly.
+    unset ROMP_SERVE_PORT ROMP_POSTAL_PORT ROMP_MANAGER_PORT ROMP_STATE_DIR CLAUDE_CONFIG_DIR ROMP_TMUX_SOCKET
 }
 
 teardown() { rm -rf "$TEST_DIR"; }
@@ -205,4 +210,77 @@ EOF2
     ROMP_OS_OVERRIDE=Linux run "$SVC" install
     [ "$status" -eq 0 ]
     grep -q "^Environment=ROMP_SUPERVISED=1$" "$ROMP_SYSTEMD_DIR/romp-manager.service"
+}
+
+# ── the instance env: which romp does this service supervise? ──────────────────────────────
+# A second OS user on one machine (a kernel handed to another person) shares the PORT space,
+# so their manager/kernel/bus must be renumbered. The installing shell had the overrides; the
+# unit did not, so the supervised manager came up on the defaults, its control port collided
+# with the primary user's, and the service died at login while every foreground `romp` command
+# still reported the configured port.
+
+@test "install bakes the renumbered ports into the unit (Linux) and the plist (macOS)" {
+    export ROMP_SERVE_PORT=29856 ROMP_POSTAL_PORT=25303 ROMP_MANAGER_PORT=7433
+    ROMP_OS_OVERRIDE=Linux run "$SVC" install
+    [ "$status" -eq 0 ]
+    local unit="$ROMP_SYSTEMD_DIR/romp-manager.service"
+    grep -q "^Environment=ROMP_SERVE_PORT=29856$"   "$unit"
+    grep -q "^Environment=ROMP_POSTAL_PORT=25303$"  "$unit"
+    grep -q "^Environment=ROMP_MANAGER_PORT=7433$"  "$unit"
+    ROMP_OS_OVERRIDE=Darwin run "$SVC" install
+    [ "$status" -eq 0 ]
+    local plist="$ROMP_LAUNCHD_DIR/com.romp.manager.plist"
+    grep -q "<key>ROMP_SERVE_PORT</key><string>29856</string>"  "$plist"
+    grep -q "<key>ROMP_POSTAL_PORT</key><string>25303</string>" "$plist"
+    grep -q "<key>ROMP_MANAGER_PORT</key><string>7433</string>" "$plist"
+}
+
+@test "install bakes the rest of the profile: state root, Claude config dir, tmux socket" {
+    # The same set romp-manager's specEnv hands an aux kernel — a profile that is only half
+    # carried is the silent-divergence bug, not a smaller version of it.
+    export ROMP_STATE_DIR="$TEST_DIR/alt-state" CLAUDE_CONFIG_DIR="$TEST_DIR/alt-claude" ROMP_TMUX_SOCKET=romp-alt
+    ROMP_OS_OVERRIDE=Linux run "$SVC" install
+    [ "$status" -eq 0 ]
+    local unit="$ROMP_SYSTEMD_DIR/romp-manager.service"
+    grep -q "^Environment=ROMP_STATE_DIR=$TEST_DIR/alt-state$"      "$unit"
+    grep -q "^Environment=CLAUDE_CONFIG_DIR=$TEST_DIR/alt-claude$"  "$unit"
+    grep -q "^Environment=ROMP_TMUX_SOCKET=romp-alt$"               "$unit"
+}
+
+@test "a default install writes NO instance env — unchanged for everyone not doing this" {
+    # setup() cleared the set, so this is the single-user machine's install.
+    ROMP_OS_OVERRIDE=Linux run "$SVC" install
+    [ "$status" -eq 0 ]
+    local unit="$ROMP_SYSTEMD_DIR/romp-manager.service"
+    ! grep -q "ROMP_SERVE_PORT\|ROMP_POSTAL_PORT\|ROMP_MANAGER_PORT\|ROMP_STATE_DIR\|CLAUDE_CONFIG_DIR\|ROMP_TMUX_SOCKET" "$unit"
+    # ...and the file is still well-formed around the seam: blank line, then [Install].
+    grep -q "^Environment=ROMP_SUPERVISED=1$" "$unit"
+    grep -q "^\[Install\]$" "$unit"
+    [ -z "$(sed -n '/^Environment=ROMP_SUPERVISED=1$/{n;p;}' "$unit")" ]
+    ROMP_OS_OVERRIDE=Darwin run "$SVC" install
+    [ "$status" -eq 0 ]
+    ! grep -q "ROMP_SERVE_PORT\|ROMP_STATE_DIR\|ROMP_TMUX_SOCKET" "$ROMP_LAUNCHD_DIR/com.romp.manager.plist"
+}
+
+@test "the rendered unit and plist stay well-formed with the instance env present" {
+    export ROMP_SERVE_PORT=29856 ROMP_MANAGER_PORT=7433
+    ROMP_OS_OVERRIDE=Linux run "$SVC" install
+    [ "$status" -eq 0 ]
+    local unit="$ROMP_SYSTEMD_DIR/romp-manager.service"
+    # every Environment= line sits in [Service], i.e. before [Install]
+    local envlast instline
+    envlast="$(grep -n '^Environment=' "$unit" | tail -1 | cut -d: -f1)"
+    instline="$(grep -n '^\[Install\]$' "$unit" | cut -d: -f1)"
+    [ "$envlast" -lt "$instline" ]
+    ROMP_OS_OVERRIDE=Darwin run "$SVC" install
+    [ "$status" -eq 0 ]
+    local plist="$ROMP_LAUNCHD_DIR/com.romp.manager.plist"
+    # the pairs land INSIDE EnvironmentVariables, and the plist still parses
+    if command -v plutil >/dev/null 2>&1; then plutil -lint "$plist" >/dev/null; fi
+    local dictline portline closeline
+    dictline="$(grep -n '<key>EnvironmentVariables</key>' "$plist" | cut -d: -f1)"
+    portline="$(grep -n '<key>ROMP_SERVE_PORT</key>' "$plist" | cut -d: -f1)"
+    closeline="$(grep -n '<key>RunAtLoad</key>' "$plist" | cut -d: -f1)"
+    [ "$dictline" -lt "$portline" ]
+    [ "$portline" -lt "$closeline" ]
 }


### PR DESCRIPTION
Groundwork for running a second, isolated kernel for another person on one machine (`plans/multi-kernel.md`).

Ports are machine-wide while the rest of a romp instance derives from `$HOME`, so a second OS user has to renumber their manager, kernel and bus. The installing shell had those overrides; the generated unit did not. The supervised manager therefore came up on the defaults, its control port collided with the primary user's, and the service died at login while every foreground `romp` command went on reporting the configured port.

`romp-service` now bakes the instance-scoping env into both the launchd plist and the systemd unit: `ROMP_SERVE_PORT`, `ROMP_POSTAL_PORT`, `ROMP_MANAGER_PORT`, `ROMP_STATE_DIR`, `CLAUDE_CONFIG_DIR`, `ROMP_TMUX_SOCKET`. That is the same set `romp-manager`'s `specEnv` hands an aux kernel.

Only variables actually **set** at install time are written, so a default single-user install produces the unit it always did, byte for byte (asserted).

### Tests
Four added to `tests/romp-service.bats`; three fail without the change, and the fourth (the default install writes no instance env) passes both ways on purpose, as the regression guard.

`setup()` now clears the whole instance set: running this suite inside a romp session inherits the live kernel's ports, which the unit now bakes, so a default-vs-override test would read the developer's machine instead of the code. This is the hazard `plans/multi-kernel.md` flags for exactly these tests.

58 bats tests pass across `romp-service`, `install-sh`, `romp-uninstall` and `romp-manager-ensure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)