### PR TITLE
The loader a dropped socket puts up can come back down

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14755,7 +14755,11 @@ ws=new WebSocket(proto+location.host+"/ws?app=%s"+(wid?"&wid="+encodeURIComponen
 // onopen: flush the queue; a RECONNECT (after a drop) also PROMPTS a reload — the fresh socket resyncs live via
 // the kernel's next push, and the banner offers a full reload for anything a live push doesn't cover. This
 // replaces the old silent location.reload() (the user: don't foist a reload; let me click — [[prefer-reload-banner-not-auto]]).
-ws.onopen=function(){lastRecv=Date.now();netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];if(wasReconn)raiseStale();};
+// A RECONNECT also fires `romp:wsup`, the counterpart to the `romp:wsdown` below: whatever went up when the
+// socket dropped (the pane's romp loader) needs the socket's RETURN as its event to come back down. The
+// first connect deliberately doesn't fire it — nothing is waiting on it, and the loader must stay up until
+// real content lands.
+ws.onopen=function(){lastRecv=Date.now();netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];if(wasReconn){raiseStale();try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
 ws.onmessage=function(ev){lastRecv=Date.now();var msg;try{msg=JSON.parse(ev.data);}catch(e){return;}
 if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();return;}   // keepalive: stamped lastRecv above; carries the build token (drift → reload banner); nothing for the bundle to render
 if(window.__rompFed){window.__rompFed.inbound("",msg);}else{window.dispatchEvent(new MessageEvent("message",{data:msg}));}};
@@ -14946,9 +14950,23 @@ def _pane_spin(cid, ignore_id=""):
     wsdown), never in the load path.
 
     It RE-SHOWS on a kernel restart / WS drop (the user 2026-06-29): the shim fires `romp:wsdown` on
-    ws.onclose, and the loader un-fades over the stale pane — "romp is reconnecting" — until fresh content
-    arrives after the reconnect-reload. Event-based (the WS close), not a timer. Kept in the DOM (never
-    removeChild) precisely so it can be shown again.
+    ws.onclose, and the loader un-fades over the stale pane — "romp is reconnecting" — until the socket is
+    back. Event-based (the WS close), not a timer. Kept in the DOM (never removeChild) precisely so it can
+    be shown again.
+
+    That re-show needs its own way DOWN, which it did not have (the user 2026-07-28: every few seconds the
+    dashboard said it had lost the connection and the chat then sat under the romp loader until a manual
+    reload). Neither exit worked a second time:
+      - The MutationObserver can't fire on a reconnect. render.ts's ensureView inserts one `.thread` div per
+        session ONCE and keeps it in a map for the life of the page, so a post-reconnect push mutates nodes
+        that are already there — the container's direct children never change again, and a childList
+        observer is deaf to that.
+      - The 30s failsafe was armed once at page load, i.e. it only ever covered the FIRST show. By the time
+        a drop re-showed the loader that timer had long since fired.
+    So the loader went up on the drop and nothing could take it down. Both exits are now repeatable: the
+    failsafe re-arms on every show, and `romp:wsup` (the shim's reconnect) hides it — the socket being back
+    IS the event that ends "romp is reconnecting", and the shell's own reload prompt covers the staleness
+    of what's on screen until the next push lands.
 
     ignore_id: a permanent child of `cid` that does NOT count as content (the user 2026-06-27) — the chat's
     #content always holds a hidden #live-ask picker host, so without this the loader hid instantly over a blank
@@ -14958,11 +14976,16 @@ def _pane_spin(cid, ignore_id=""):
             "#pane-spin.gone{opacity:0;pointer-events:none}" + _LOADER_CSS + "</style>"
             "<div id=pane-spin>" + _loader_inner() + "</div>"
             "<script>(function(){var o=document.getElementById('pane-spin'),c=document.getElementById('" + cid + "'),IGN='" + ignore_id + "';"
-            "if(!o)return;function show(){o.classList.remove('gone');}function hide(){o.classList.add('gone');}"
+            "if(!o)return;var fail=0;"
+            "function arm(){clearTimeout(fail);fail=setTimeout(hide,30000);}"   # per SHOW, not per page load
+            "function show(){o.classList.remove('gone');arm();}"
+            "function hide(){clearTimeout(fail);o.classList.add('gone');}"
             "function ready(){if(!c)return false;for(var i=0;i<c.children.length;i++){if(!IGN||c.children[i].id!==IGN)return true;}return false;}"
+            "arm();"
             "if(c){try{new MutationObserver(function(){if(ready())hide();}).observe(c,{childList:true});}catch(e){}"
-            "if(ready())hide();}setTimeout(hide,30000);"
-            "window.addEventListener('romp:wsdown',show);})();</script>")
+            "if(ready())hide();}"
+            "window.addEventListener('romp:wsdown',show);"
+            "window.addEventListener('romp:wsup',hide);})();</script>")
 
 
 def _chat_page():

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -30,7 +30,9 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn("ws.onerror=function(){try{ws.close();}catch(e){}};", js)
         # a RECONNECT no longer silently reloads (the user 2026-07-05): it PROMPTS via raiseStale, and the fresh
         # socket resyncs live. The old auto-reload-on-reopen is gone.
-        self.assertIn("if(wasReconn)raiseStale();", js)
+        # the reconnect ALSO fires romp:wsup, which is what takes the pane loader back down
+        # (test_pane_loader_reconnect.py owns that half)
+        self.assertIn('if(wasReconn){raiseStale();try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}', js)
         self.assertNotIn("if(everConnected){location.reload();return;}", js,
                          "the silent auto-reload-on-reconnect is replaced by a reload PROMPT")
         self.assertNotIn("ws.onclose=function(){setTimeout(function(){location.reload();},1500);};", js,

--- a/tests/test_pane_loader_reconnect.py
+++ b/tests/test_pane_loader_reconnect.py
@@ -1,0 +1,86 @@
+"""The pane loader that a WS drop puts up must be able to come back DOWN.
+
+The user 2026-07-28: the dashboard announced it had lost the connection every few seconds, and after each
+one the chat pane sat under the romp loader until a manual reload.
+
+_pane_spin's loader has exactly two ways down, and on a RE-show — the one `romp:wsdown` triggers — neither
+of them worked:
+
+  MutationObserver   fires when the content container gains a child. render.ts's ensureView inserts one
+                     `.thread` div per session ONCE and keeps it in a map for the life of the page, so
+                     after the first load the container's direct children never change again. Every
+                     post-reconnect push mutates nodes that are already there, and a childList observer
+                     is deaf to that. Right on a cold load, unreachable on a reconnect.
+  30s failsafe       was armed once at page load, so it only ever covered the FIRST show. By the time a
+                     drop re-showed the loader, that timer had fired long ago.
+
+So the loader went up on the drop with nothing left that could take it down — a pane frozen behind an
+overlay while the socket underneath had already reconnected and was streaming fine.
+
+The fix keeps both exits but makes them repeatable: the failsafe re-arms on every show, and the shim
+fires `romp:wsup` on a reconnect, which hides the loader — the socket being back is precisely the event
+that ends "romp is reconnecting". Staleness of what's on screen is the shell's reload prompt's job
+(raiseStale, same onopen), not the loader's.
+
+Source-pinning, like the other _pane_spin tests (this JS has no jsdom harness).
+"""
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class PaneLoaderReconnect(unittest.TestCase):
+    def setUp(self):
+        self.js = km._pane_spin("content", "live-ask")
+
+    def test_the_failsafe_is_armed_per_show_not_once_per_page_load(self):
+        """The regression itself. A timer set in the load path cannot cover a show that happens minutes
+        later, which is every show after the first one."""
+        self.assertIn("function arm(){clearTimeout(fail);fail=setTimeout(hide,30000);}", self.js)
+        self.assertIn("function show(){o.classList.remove('gone');arm();}", self.js,
+                      "showing the loader must (re-)arm its own failsafe")
+        self.assertNotIn("if(ready())hide();}setTimeout(hide,30000);", self.js,
+                         "the old load-time-only arming is gone")
+
+    def test_hiding_cancels_the_failsafe(self):
+        """Otherwise a stale timer from an earlier show fires over a pane that is already live, and the
+        next show inherits a shortened window."""
+        self.assertIn("function hide(){clearTimeout(fail);o.classList.add('gone');}", self.js)
+
+    def test_the_loader_comes_down_when_the_socket_comes_back(self):
+        """The event-based exit for the re-show path. Without it the only way down is the failsafe, i.e.
+        30 seconds of romp logo over a pane whose socket reconnected in under two."""
+        self.assertIn("window.addEventListener('romp:wsup',hide);", self.js)
+        self.assertIn("window.addEventListener('romp:wsdown',show);", self.js,
+                      "the drop still raises it — this is a matched pair")
+
+    def test_the_shim_fires_wsup_on_a_reconnect_only(self):
+        """A first connect must NOT fire it: the loader is legitimately up during a cold load and has to
+        stay there until real content lands (an 8s timer that hid it early was the 2026-07-03 bug)."""
+        shim = km._shim("chat")
+        self.assertIn('if(wasReconn){raiseStale();try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}',
+                      shim, "wsup rides the same wasReconn gate as the reload prompt")
+        self.assertIn("var wasReconn=everConnected;everConnected=true;", shim,
+                      "and wasReconn still means 'this socket had connected before'")
+
+    def test_every_pane_that_carries_the_loader_gets_both_halves(self):
+        """The chat is only where it was noticed: the same loader ships on the feed and fleet pages, and
+        they drop and reconnect the same way. The timeline deliberately has no _pane_spin (it owns a
+        bars-area loader instead, the user 2026-06-26) — it still carries the shim, so it gets the event
+        whether or not anything listens today."""
+        for page in (km._chat_page(), km._feed_page(), km._fleet_page()):
+            self.assertIn("window.addEventListener('romp:wsup',hide);", page)
+            self.assertIn('new Event("romp:wsup")', page)
+        self.assertIn('new Event("romp:wsup")', km._timeline_page())
+        self.assertNotIn("window.addEventListener('romp:wsup',hide);", km._timeline_page(),
+                         "the timeline still owns no _pane_spin overlay")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A pane that lost its WebSocket raised the romp loader and then had no way to lower it. The chat sat under the logo until a manual reload, while the socket underneath had already reconnected and was streaming fine.

Both of the loader's exits were one-shot:

- **The MutationObserver** fires when the content container gains a child. `render.ts`'s `ensureView` inserts one `.thread` div per session ONCE and keeps it in a map for the life of the page, so after the first load the container's direct children never change again — every later push mutates nodes that are already there, and a `childList` observer is deaf to that.
- **The 30s failsafe** was armed in the load path, so it only ever covered the FIRST show. By the time a drop re-showed the loader, that timer had fired long ago.

So the loader went up on the drop with nothing left that could take it down.

The fix keeps both exits and makes them repeatable: the failsafe re-arms on every `show()`, and the shim fires `romp:wsup` on a reconnect — the counterpart to the `romp:wsdown` that raised the loader — which hides it. The socket being back is exactly the event that ends "romp is reconnecting". A first connect deliberately does not fire it, since the loader must stay up through a cold load until real content lands; staleness of what is on screen remains the shell's reload prompt's job, raised from the same `onopen`.

Tests: `tests/test_pane_loader_reconnect.py` covers per-show arming, the cancel on hide, the wsup/wsdown pair, the reconnect-only gate, and that every page carrying `_pane_spin` gets both halves (the timeline has no overlay by design). The one pinned line in `test_kernel_disconnect_banner.py` is updated to the new `onopen`.

The drop that made this visible is a separate fault, fixed in parallel on another branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)