### PR TITLE
The dashboard stops losing its live connection

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,7 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
-import json, os, re, signal, sys, time, threading, traceback, base64, bisect, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid
+import json, os, queue, re, signal, socket, sys, time, threading, traceback, base64, bisect, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid
 from pathlib import Path
 from datetime import datetime
 from importlib.machinery import SourceFileLoader
@@ -13623,7 +13623,75 @@ def _ws_accept(key):
     return base64.b64encode(hashlib.sha1((key + WS_GUID).encode()).digest()).decode()
 
 
-def _ws_send(wfile, lock, text):
+# How far behind a client may fall before it is treated as wedged and dropped, measured in QUEUED BYTES.
+# Bytes, not frames: a frame count measures the PRODUCER's burst rate, not the client's health. A push
+# that enqueues several payloads back-to-back can outrun a perfectly healthy client's sender thread by a
+# dozen frames in microseconds, and a frame-count cap drops it — a false positive strictly worse than the
+# stall being fixed here (caught by test_ws_send_bounded, which overran a 32-frame cap with 40 keepalives
+# a healthy client would have drained fine). Bytes track the thing that actually matters: a client behind
+# by 16 MB of view payloads has stopped reading, while any burst of ~40-byte keepalives is noise.
+WS_QUEUE_BYTES = int(os.environ.get("ROMP_WS_QUEUE_BYTES", str(16 * 1024 * 1024)))
+
+
+# Every client OWNS a queue and a sender thread, and the shared push/heartbeat loops only ever ENQUEUE.
+#
+# They used to write to the socket directly, which is the bug this fixes: a client that stops draining — a
+# paused tab, a stalled ssh tunnel to a federated peer — fills the kernel's send buffer, and the write
+# parks the CALLING thread. That thread is shared. _keepalive_all walks every client serially, so one
+# wedged client starves every OTHER client's heartbeat; they all pass the shim's STALE_MS (30s) having
+# received nothing at all, and force-close in lockstep. The whole dashboard "loses the live connection" at
+# once, repeatedly, while the kernel itself is perfectly healthy (diagnosed 2026-07-28 from the panes' own
+# drop logs: chat, feed and timeline each dropping at IDENTICAL 35s intervals = STALE_MS plus one 5s
+# watchdog tick — three independent sockets going silent at the same instant is one shared upstream stall,
+# not three socket failures).
+#
+# A timeout on the write cannot fix this, which is worth recording so it is not "simplified" back:
+#   - settimeout() puts the socket in NON-BLOCKING mode, and this client's handler thread is parked in a
+#     blocking read on that same socket. dup() does not escape it either — a duplicate shares the
+#     file-status flags.
+#   - select()-then-send() does not bound it: on Linux a BLOCKING send() transmits the whole buffer,
+#     blocking as needed (sk_stream_wait_memory). Short writes are a non-blocking-socket behaviour, so
+#     "writable" only promises the first byte, not the frame.
+# Isolating the blocking write on a thread the shared loops never wait for is what actually holds.
+def _ws_sender(q, sock, lock, client):
+    """Drain one client's queue onto its socket. Blocking here is FINE and is the entire point — it blocks
+    only this client's own thread. A dead socket ends the thread and marks the client for reaping."""
+    while True:
+        s = q.get()
+        if s is None:                          # teardown sentinel from the handler's finally
+            return
+        try:
+            _ws_send(sock, lock, s)
+        except OSError:
+            client["alive"] = False
+            return
+        finally:
+            with client["qlock"]:              # released whether the frame landed or the socket died
+                client["qbytes"] -= len(s)
+
+
+def _mk_ws_send(q, sock, client):
+    """The client's `send`: enqueue, never block. Past WS_QUEUE_BYTES the peer has stopped draining, so the
+    client is dropped and its socket shut down — which also unblocks its sender thread, parked in a write
+    that will now fail, instead of leaking it for the life of the kernel."""
+    def send(s):
+        with client["qlock"]:
+            if client["qbytes"] + len(s) > WS_QUEUE_BYTES:
+                client["alive"] = False
+                try:
+                    sock.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+                # Raise: every caller already treats an exception from send as "mark this client dead".
+                raise OSError("ws client %s is %d bytes behind — dropping"
+                              % (client.get("app"), client["qbytes"]))
+            client["qbytes"] += len(s)
+        q.put(s)                               # unbounded; the byte budget above is the real bound
+    return send
+
+
+def _ws_send(sock, lock, text):
+    """Frame and write one text message. Called ONLY from that client's sender thread (see _ws_sender)."""
     data = text.encode("utf-8")
     n = len(data)
     hdr = bytearray([0x81])                   # FIN + text frame
@@ -13634,8 +13702,7 @@ def _ws_send(wfile, lock, text):
     else:
         hdr.append(127); hdr += struct.pack(">Q", n)
     with lock:
-        wfile.write(bytes(hdr) + data)
-        wfile.flush()
+        sock.sendall(bytes(hdr) + data)
 
 
 def _ws_pong(wfile, lock, payload):
@@ -17961,7 +18028,14 @@ class Handler(BaseHTTPRequestHandler):
         self.close_connection = True              # hijacked socket — don't let the handler keep-alive after
         _client_seen[0] = time.time()
         lock = threading.Lock()
-        client = {"app": app, "send": lambda s: _ws_send(self.wfile, lock, s), "alive": True}
+        # Frames are ENQUEUED, never written by the caller: one wedged client must not stall the shared
+        # push/heartbeat loops (see _ws_sender). Pongs still ride self.wfile — they are ≤125-byte control
+        # frames answered on this client's own handler thread, and both paths serialise on the same `lock`.
+        q = queue.Queue()
+        client = {"app": app, "alive": True, "qbytes": 0, "qlock": threading.Lock()}
+        client["send"] = _mk_ws_send(q, self.connection, client)
+        threading.Thread(target=_ws_sender, args=(q, self.connection, lock, client),
+                         daemon=True, name="ws-send").start()
         if active:
             client["active"] = active                  # active-tab-first streaming (the user 2026-06-24)
         with _clients_lock:
@@ -17989,6 +18063,7 @@ class Handler(BaseHTTPRequestHandler):
             pass
         finally:
             client["alive"] = False
+            q.put(None)                        # end this client's sender thread
             with _clients_lock:
                 if client in _clients:
                     _clients.remove(client)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13887,21 +13887,57 @@ def _segment_of_uuid(sid, uuid, now):
     return (None, [])
 
 
+# Top-level payload fields that tick on every BUILD while carrying no view state of their own: the host
+# clock (`now` — the client's hostNow, used for age math) and the feed's build counter (`buildId`, which
+# sequences optimistic move acks). Comparing them defeats the dedup below outright: a payload that is
+# otherwise byte-identical looks new on every push, so the kernel re-sends the WHOLE view forever. That is
+# how app=feed came to ship ~46 KB every ~2s to every client on a fleet that wasn't changing (the user
+# 2026-07-28, whose dashboard dropped the live connection every few minutes; measured on the wire as 12 of
+# 12 consecutive frames byte-distinct, differing ONLY in these two fields). Identical failure to the chat's
+# `firstSeen` clock leak — see tests/test_payload_dedup_invariant.py, which asserts the invariant one level
+# up from the chat file's: a payload MAY carry the clock, but everything the dedup compares must not.
+_DEDUP_VOLATILE = ("now", "buildId")
+
+# A deduped view still has to FADE. The feed colors each card by age against the payload's `now`, so a
+# client that received nothing for many minutes would hold its colors frozen. The client already keeps the
+# "Xm ago" text honest from its own clock on a 15s tick; this preserves the host repost that the fade was
+# always documented to ride on (feed.ts: "host reposts ~1×/min for color fade") and nothing beyond it.
+# So an UNCHANGED view costs one repost a minute instead of ~30.
+_DEDUP_REPOST_S = 60.0
+
+
+def _dedup_sig(msg, s):
+    """The string a payload is DEDUPED on: its serialization minus the always-ticking fields above.
+    Falls back to the full serialization `s` when the payload carries none of them, so a payload that is
+    already clock-invariant (chat) keeps comparing its cached serialization with no extra work."""
+    if isinstance(msg, dict) and any(k in msg for k in _DEDUP_VOLATILE):
+        return json.dumps({k: v for k, v in msg.items() if k not in _DEDUP_VOLATILE},
+                          sort_keys=True, default=str)
+    return s
+
+
 def _send_client(c, key, msg, pre=None):
     """Send a payload to ONE client only if it differs from what that client last received (per-client
     dedup, key = the slot e.g. ("chat", sid)) — so the periodic push re-sends nothing when unchanged.
     `pre` is the already-serialized msg (json.dumps(msg)) when the caller has it cached — passing it lets
     a reused/unchanged payload skip re-serializing a large chat on every poll (the chat-build cache).
 
+    Dedup compares _dedup_sig, NOT the raw bytes: a field that ticks with the clock would otherwise make
+    every payload look new. The bytes actually sent are still the full `s`, so the client keeps receiving a
+    fresh `now`/`buildId` on every send it does get.
+
     ROMP_PERF=1 logs every send AND every dedup hit. That asymmetry is the point: a payload carrying a
     field that ticks with the clock looks perfectly normal from the outside — the UI just feels slow —
     and the only visible symptom is this dedup never hitting. Finding the last one took a hand-written
     WebSocket client; the log makes the next one obvious."""
     s = pre if pre is not None else json.dumps(msg)
-    if c.setdefault("sent", {}).get(key) == s:
+    sig = _dedup_sig(msg, s)
+    prev = c.setdefault("sent", {}).get(key)
+    now = time.time()
+    if prev is not None and prev[0] == sig and (now - prev[1]) < _DEDUP_REPOST_S:
         _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=1)
         return
-    c["sent"][key] = s
+    c["sent"][key] = (sig, now)
     _perf("send", slot=_perf_slot(key), bytes=len(s), deduped=0)
     try:
         c["send"](s)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6549,6 +6549,11 @@ class WsLoopResilience(unittest.TestCase):
             path = "/ws?app=chat"
             rfile = io.BytesIO()
             wfile = io.BytesIO()
+            # Frames now go out on the SOCKET: each client owns a queue + sender thread so one wedged
+            # client cannot stall the shared push/heartbeat walk (see _ws_sender). This loop exercises
+            # only the READ side, so the socket just has to absorb writes.
+            connection = type("FakeSock", (), {"sendall": lambda self, b: None,
+                                               "shutdown": lambda self, how: None})()
             close_connection = False
             def send_response(self, *a): pass
             def send_header(self, *a): pass

--- a/tests/test_payload_dedup_invariant.py
+++ b/tests/test_payload_dedup_invariant.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""No pane payload may defeat _send_client's dedup by ticking with the clock.
+
+test_chat_payload_clock_invariant.py asserts this for the CHAT payload, where the bug was first
+found (a `firstSeen` that fell back to `now`). It came straight back on the FEED, which carries the
+host clock as a deliberate top-level field: `now` (the client's hostNow, for age math) plus
+`buildId` (sequences optimistic move acks). Both tick on every build, and _send_client compared the
+whole serialization, so no feed payload ever matched the previous one and the kernel re-sent the
+entire view to every client forever.
+
+Measured on the wire before the fix (the user 2026-07-28, whose dashboard kept dropping the live
+connection): app=feed shipped ~46 KB every ~2s on a fleet that wasn't changing — 12 of 12
+consecutive frames byte-distinct, differing ONLY in `now` and `buildId`.
+
+So the invariant here is one level up from the chat file's: a payload MAY carry the clock, but
+everything the dedup actually compares must be clock-invariant. Any future field that ticks — an age
+folded into a card, a "seconds since" counter — fails here instead of becoming another silent
+firehose.
+
+Synthetic only: placeholder uuid, invented prompt text, temp dirs.
+"""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+jd = SourceFileLoader("romp_judge_dedupinv", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_dedupinv", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NOW = 1781100000
+T0 = NOW - 3600
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, stop="end_turn"):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+class DedupSuppressesAClockOnlyDifference(unittest.TestCase):
+    """The wire behaviour, asserted directly on _send_client — no fixture needed."""
+
+    def _client(self):
+        sent = []
+        return {"send": sent.append, "alive": True}, sent
+
+    def test_a_feed_payload_differing_only_in_the_clock_is_sent_once(self):
+        """The exact measured regression: same cards, new `now` + `buildId` on every build."""
+        client, sent = self._client()
+        for i in range(12):                      # 12 pushes ≈ the 12 frames captured on the wire
+            km._send_client(client, ("feed",),
+                            {"type": "feed", "asks": [{"itemId": "g1", "col": "working"}],
+                             "now": NOW + i, "buildId": 100 + i})
+        self.assertEqual(len(sent), 1,
+                         "an unchanged feed must go out ONCE; a fresh `now`/`buildId` per build is not "
+                         "a change and must not re-send the whole view")
+
+    def test_the_payload_that_IS_sent_still_carries_the_current_clock(self):
+        """Dedup compares a stripped signature; it must not strip the bytes actually sent, or the
+        client's hostNow/buildId would go stale."""
+        client, sent = self._client()
+        km._send_client(client, ("feed",), {"type": "feed", "asks": [], "now": NOW, "buildId": 1})
+        km._send_client(client, ("feed",), {"type": "feed", "asks": [{"itemId": "g1"}],
+                                            "now": NOW + 5, "buildId": 2})
+        self.assertEqual(len(sent), 2)
+        self.assertEqual(json.loads(sent[1])["now"], NOW + 5, "the sent bytes keep the fresh clock")
+        self.assertEqual(json.loads(sent[1])["buildId"], 2, "…and the fresh buildId")
+
+    def test_a_real_change_still_sends_even_when_the_clock_is_frozen(self):
+        """The other half: dedup must key on CONTENT, so a change lands even on an identical clock."""
+        client, sent = self._client()
+        km._send_client(client, ("feed",), {"type": "feed", "asks": [], "now": NOW, "buildId": 1})
+        km._send_client(client, ("feed",), {"type": "feed", "asks": [{"itemId": "g1"}],
+                                            "now": NOW, "buildId": 1})
+        self.assertEqual(len(sent), 2, "a changed card list must be sent")
+
+    def test_an_unchanged_view_is_reposted_about_once_a_minute_for_colour_fade(self):
+        """The feed fades card colour against the payload's `now`, so a view that never re-sends would
+        hold its colours frozen. feed.ts documents the contract: 'host reposts ~1x/min for color fade'."""
+        client, sent = self._client()
+        payload = {"type": "feed", "asks": [], "now": NOW, "buildId": 1}
+        km._send_client(client, ("feed",), payload)
+        self.assertEqual(len(sent), 1)
+        # Age the client's record past the repost window rather than sleeping.
+        sig, when = client["sent"][("feed",)]
+        client["sent"][("feed",)] = (sig, when - km._DEDUP_REPOST_S - 1)
+        km._send_client(client, ("feed",), dict(payload, now=NOW + 61, buildId=2))
+        self.assertEqual(len(sent), 2, "an unchanged view must still repost so the colour fade advances")
+
+    def test_a_payload_with_no_clock_field_dedups_on_its_full_serialization(self):
+        """Clock-invariant payloads (chat) must keep comparing their cached serialization untouched."""
+        client, sent = self._client()
+        km._send_client(client, ("chat", SID), {"type": "session", "id": SID, "events": []})
+        km._send_client(client, ("chat", SID), {"type": "session", "id": SID, "events": []})
+        self.assertEqual(len(sent), 1)
+
+
+class BuiltFeedIsClockInvariantApartFromTheClockItself(unittest.TestCase):
+    """Guards the BUILDER, not just the sender: build_feed at two clocks may differ in `now`/`buildId`
+    and nothing else. A future age-derived field folded into a card fails here."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        (pdir / (SID + ".jsonl")).write_text("\n".join(json.dumps(r) for r in [
+            uline(T0, "start the notes-api spike", "u1"),
+            aline(T0 + 40, "Spike is up.", "a1", "u1"),
+        ]) + "\n")
+        names = td / "names"; names.mkdir()
+        (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
+
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+                      km.NAMES, km._GLOBAL_CLAUDE_MD)
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
+        jd.STATE = td
+        km.NAMES = names
+        km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+        # Fixed so the stub itself contributes nothing clock-derived (mirrors the chat invariant test).
+        self.tmux = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+                           "context": None, "compactPct": None, "color": None}}
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+         km.NAMES, km._GLOBAL_CLAUDE_MD) = self.saved
+        self.td.cleanup()
+
+    def test_only_the_declared_volatile_fields_move_with_the_clock(self):
+        a = km.build_feed(NOW, self.tmux)
+        b = km.build_feed(NOW + 600, self.tmux)
+        varying = sorted(k for k in set(list(a) + list(b))
+                         if json.dumps(a.get(k), sort_keys=True, default=str)
+                         != json.dumps(b.get(k), sort_keys=True, default=str))
+        self.assertTrue(set(varying) <= set(km._DEDUP_VOLATILE),
+                        "these feed fields move with the clock but are not declared volatile, so the "
+                        "dedup can never hit and the whole feed re-sends on every push: %s"
+                        % [k for k in varying if k not in km._DEDUP_VOLATILE])
+
+    def test_two_builds_ten_minutes_apart_dedup_to_a_single_send(self):
+        """End to end: the builder's output, run through the real sender, must send once."""
+        sent = []
+        client = {"send": sent.append, "alive": True}
+        km._send_client(client, ("feed",), km.build_feed(NOW, self.tmux))
+        km._send_client(client, ("feed",), km.build_feed(NOW + 600, self.tmux))
+        self.assertEqual(len(sent), 1,
+                         "an unchanging fleet must not re-send the feed just because time passed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ws_send_bounded.py
+++ b/tests/test_ws_send_bounded.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""One client that stops draining must not stall the clients behind it.
+
+The kernel's send loops are SHARED and serial: _keepalive_all walks every connected client in one
+thread, handing each the ~40-byte heartbeat. When that walk wrote to sockets directly, a client whose
+buffer was full parked the whole walk, so every client after it received nothing — and the browser shim
+force-closes any socket silent for STALE_MS (30s).
+
+That is what "the dashboard keeps losing its connection" turned out to be (the user 2026-07-28),
+diagnosed from the panes' own drop logs: chat, feed and timeline dropping at IDENTICAL 35s intervals
+(STALE_MS plus one 5s watchdog tick), in lockstep. Three independent sockets falling silent at the same
+instant is one shared upstream stall, not three socket failures.
+
+Why a send timeout is NOT the fix (asserted below so it is not "simplified" back in):
+  - settimeout() puts the socket in non-blocking mode, and the client's handler thread is parked in a
+    blocking read on that same socket; dup() shares the file-status flags, so it does not escape either.
+  - select()-then-send() does not bound it: on Linux a BLOCKING send() transmits the whole buffer,
+    blocking as needed. Short writes are non-blocking-socket behaviour. This test's first version hung
+    for exactly that reason.
+The fix is structural: each client owns a queue and a sender thread, and shared loops only enqueue.
+
+Real TCP loopback throughout, matching the kernel's actual transport (AF_UNIX socketpairs behave
+differently again and would not represent it). Synthetic only: no session data.
+"""
+import os
+import queue
+import socket
+import threading
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_wsbound", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class WedgedClientCannotStallTheSendLoop(unittest.TestCase):
+    def setUp(self):
+        self.closeables = []
+
+    def tearDown(self):
+        for s in self.closeables:
+            try:
+                s.close()
+            except OSError:
+                pass
+
+    def _tcp_pair(self, sndbuf=4096):
+        """A connected loopback pair with a small send buffer, so a modest payload fills it once the peer
+        stops reading — the wedged-client condition, reproduced honestly."""
+        srv = socket.socket()
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        client = socket.socket()
+        client.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, sndbuf)
+        client.connect(srv.getsockname())
+        peer, _ = srv.accept()
+        peer.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, sndbuf)
+        srv.close()
+        self.closeables += [client, peer]
+        return client, peer
+
+    def _wire(self, sock):
+        """Build the client dict exactly as the WS handler does: queue + sender thread + enqueueing send."""
+        q = queue.Queue()
+        c = {"app": "feed", "alive": True, "qbytes": 0, "qlock": threading.Lock()}
+        c["send"] = km._mk_ws_send(q, sock, c)
+        t = threading.Thread(target=km._ws_sender, args=(q, sock, threading.Lock(), c), daemon=True)
+        t.start()
+        return c, q, t
+
+    def test_sending_to_a_wedged_client_never_blocks_the_caller(self):
+        """The core guarantee: the shared loop enqueues and returns, however stuck the peer is."""
+        sock, _peer_never_reads = self._tcp_pair()
+        c, _q, _t = self._wire(sock)
+        big = "x" * (256 * 1024)               # far past the 4 KB buffer; the sender thread will park
+        started = time.monotonic()
+        dropped = False
+        for _ in range(200):                   # 200 x 256 KB overruns the 16 MB budget
+            try:
+                c["send"](big)
+            except OSError:
+                dropped = True
+                break
+        elapsed = time.monotonic() - started
+        self.assertLess(elapsed, 5.0,
+                        "enqueueing to a wedged client must not block the shared walk (took %.1fs)" % elapsed)
+        self.assertTrue(dropped, "a client that falls far enough behind must be dropped")
+        self.assertFalse(c["alive"], "…and marked dead so the walk stops carrying it")
+
+    def test_a_healthy_client_is_NOT_dropped_by_a_burst_of_frames(self):
+        """The false positive that a frame-COUNT budget caused: a producer enqueueing faster than the
+        sender thread is scheduled looks identical to a wedged client under a count cap, and a healthy
+        pane was dropped after 40 keepalives it would have drained without noticing."""
+        sock, reader = self._tcp_pair(sndbuf=65536)
+        c, _q, _t = self._wire(sock)
+        stop = threading.Event()
+
+        def drain():
+            reader.settimeout(0.2)
+            while not stop.is_set():
+                try:
+                    if not reader.recv(65536):
+                        return
+                except (socket.timeout, TimeoutError):
+                    continue
+                except OSError:
+                    return
+
+        t = threading.Thread(target=drain, daemon=True)
+        t.start()
+        try:
+            for _ in range(500):               # a burst far past any plausible frame count
+                c["send"]("ka")
+        except OSError as e:
+            self.fail("a healthy client must survive a burst of keepalives, got: %s" % e)
+        finally:
+            stop.set()
+        self.assertTrue(c["alive"], "a burst is not a wedge — the client must stay alive")
+
+    def test_a_wedged_client_does_not_starve_the_NEXT_client_in_the_walk(self):
+        """The regression in its real shape: a serial walk over [wedged, healthy]. The healthy client
+        still gets its frame, well inside the 30s the shim would give up after."""
+        wedged, _never_reads = self._tcp_pair()
+        healthy, reader = self._tcp_pair(sndbuf=65536)
+        cw, _qw, _tw = self._wire(wedged)
+        ch, _qh, _th = self._wire(healthy)
+
+        got = []
+        stop = threading.Event()
+
+        def drain():
+            reader.settimeout(0.2)
+            while not stop.is_set():
+                try:
+                    b = reader.recv(65536)
+                except (socket.timeout, TimeoutError):
+                    continue
+                except OSError:
+                    return
+                if not b:
+                    return
+                got.append(b)
+
+        t = threading.Thread(target=drain, daemon=True)
+        t.start()
+
+        started = time.monotonic()
+        for _ in range(120):                             # the shared, serial keepalive walk, repeated
+            for c in (cw, ch):
+                try:
+                    c["send"]("x" * (256 * 1024) if c is cw else "ka")
+                except OSError:
+                    pass                                 # caller marks it dead and moves on
+        elapsed = time.monotonic() - started
+
+        deadline = time.monotonic() + 5
+        while not got and time.monotonic() < deadline:
+            time.sleep(0.01)
+        stop.set()
+
+        self.assertLess(elapsed, 30.0,
+                        "the walk must not park behind the wedged client (took %.1fs)" % elapsed)
+        self.assertTrue(got, "the healthy client must still receive its frames")
+        self.assertTrue(ch["alive"], "the healthy client must survive its neighbour being dropped")
+
+    def test_a_draining_client_receives_the_frame_intact(self):
+        """The queue must not disturb the ordinary path: header + payload arrive unaltered."""
+        sock, peer = self._tcp_pair(sndbuf=65536)
+        c, _q, _t = self._wire(sock)
+        c["send"]("hello")
+        peer.settimeout(3)
+        frame = peer.recv(64)
+        self.assertEqual(frame[0], 0x81, "FIN + text opcode")
+        self.assertEqual(frame[1], 5, "unmasked length of 'hello'")
+        self.assertEqual(frame[2:7], b"hello")
+
+    def test_a_large_frame_round_trips_byte_exact(self):
+        """Past the 126-byte and 64 KiB header boundaries, where a botched write loop would corrupt the
+        stream — the size range the feed payload actually lives in."""
+        sock, peer = self._tcp_pair(sndbuf=1 << 20)
+        c, _q, _t = self._wire(sock)
+        body = "y" * 70000
+        got = bytearray()
+
+        def drain():
+            peer.settimeout(5)
+            while len(got) < 70010:
+                try:
+                    b = peer.recv(65536)
+                except OSError:
+                    return
+                if not b:
+                    return
+                got.extend(b)
+
+        t = threading.Thread(target=drain, daemon=True)
+        t.start()
+        c["send"](body)
+        t.join(10)
+
+        self.assertEqual(got[0], 0x81)
+        self.assertEqual(got[1], 127, "70000 bytes uses the 64-bit length form")
+        self.assertEqual(bytes(got[10:70010]), body.encode(), "payload must arrive byte-exact")
+
+    def test_the_sender_thread_ends_on_the_teardown_sentinel(self):
+        """The handler's finally puts None so a closed pane does not leak its thread."""
+        sock, _peer = self._tcp_pair(sndbuf=65536)
+        _c, q, t = self._wire(sock)
+        q.put_nowait(None)
+        t.join(3)
+        self.assertFalse(t.is_alive(), "the sender thread must exit on the sentinel")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The dashboard kept dropping its live connection every few minutes. Two independent causes, each measured on the wire rather than inferred.

## 1. The feed defeated its own dedup

`_send_client` dedups by comparing the **serialized** payload, so any field that ticks with the clock disables it entirely. The feed carries two by design — `now` (the client's hostNow, for age math) and `buildId` (sequences optimistic move acks) — so no feed payload ever matched the previous one.

Measured with a hand-written WebSocket client: **12 of 12 consecutive frames byte-distinct, ~46 KB each, every ~2s** on a fleet that wasn't changing, differing only in those two fields.

Same failure as the chat's `firstSeen` clock leak, one pane over, so the guard now sits one level up from `test_chat_payload_clock_invariant`'s: a payload MAY carry the clock, but everything the dedup **compares** must not. The bytes sent still carry the fresh clock, so nothing goes stale on the client. An unchanged view still reposts ~1×/min, which is the repost `feed.ts` always documented for colour fade — so an idle fleet costs one repost a minute instead of ~30.

New test fails against the old code with `12 != 1` — the exact frame count measured on the wire.

## 2. One stuck client took every other client down with it

The send loops are shared and serial: `_keepalive_all` walks every client in one thread. Writing straight to the socket meant a client that stopped draining parked that walk on a blocking write, and every client **behind** it received nothing — each then crossed the shim's `STALE_MS` (30s) and force-closed together.

Diagnosed from the panes' own drop logs: chat, feed and timeline dropping at **identical 35s intervals** (STALE_MS + one 5s watchdog tick), in lockstep. Three independent sockets going silent at the same instant is one shared upstream stall, not three socket failures.

Each client now owns a queue and a sender thread; the shared loops only enqueue, so blocking is confined to the thread of the client responsible.

Two dead ends are recorded in the code so they aren't "simplified" back, both measured:

- `settimeout()` puts the socket in non-blocking mode, and that client's handler thread is parked in a blocking read on the same socket. `dup()` doesn't escape it — a duplicate shares the file-status flags.
- `select()`-then-`send()` bounds nothing: on Linux a **blocking** `send()` transmits the whole buffer, blocking as needed. Short writes are non-blocking-socket behaviour, so "writable" promises the first byte, not the frame. The first version of the test hung for exactly this reason.

The drop budget is **bytes, not frames**. A frame count measures the producer's burst rate rather than the client's health — the first cut dropped a healthy pane after 40 keepalives because the enqueueing loop outran its sender thread. That false positive is now its own test.

## Testing

Full suite green: **3496 tests, OK**. New: `tests/test_payload_dedup_invariant.py`, `tests/test_ws_send_bounded.py`.

Not covered here: the client-side recovery path (the loader that couldn't come back down after a drop) is a sibling change owned by another session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)