### PR TITLE
A reply to a remote card carries its sid, so it reaches that card's kernel

### DIFF
--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -54,9 +54,23 @@ test("Backspace at the start of the box deletes the citation like a character", 
 
 test("sending with a GOAL citation routes as an askFollowUp (reopen) and consumes the chip", () => {
   assert.match(RENDER, /const cite = composerCitations\.get\(activeId\);/);
-  assert.match(RENDER, /if \(cite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: cite\.itemId, text \}\);/);
+  assert.match(RENDER, /if \(cite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: cite\.itemId, text, sid: activeId \}\);/);
   assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: activeId, text \}\); registerOptimistic\(activeId, text\); \}/);
   assert.match(RENDER, /if \(cite\) \{ composerCitations\.delete\(activeId\); renderComposerChips\(activeId\); \}/);
+});
+
+test("a citation follow-up carries its SID, so a reply to a REMOTE card reaches that card's kernel", () => {
+  // The user 2026-07-29: replies typed into a remote session's chat vanished on Enter — box cleared, no
+  // provisional bubble, nothing on the far side. federation.routeOutbound picks the owning kernel from
+  // `id`/`sid` ONLY, and an itemId can never join that list: it is "‹sid›:‹goalId›", so hostOf() would read
+  // the session uuid as a host name. With no sid the message routed to the LOCAL kernel, which derives the
+  // sid from the itemId, owns no such session, and hands it to tmux by uuid — dropped in silence. The card
+  // still flashed to Working (the kernel's cardPredict fires before any of that) and snapped back on the
+  // ok:false ack, so the only visible trace was a bounce.
+  assert.match(RENDER, /if \(cite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: cite\.itemId, text, sid: activeId \}\);/);
+  // every OTHER card-addressed op already routes this way — the citation follow-up was the lone omission
+  assert.match(FEED, /type: "askClear", itemId: it\.itemId, sid: it\.sid/);
+  assert.match(FEED, /type: "askFollowUp", itemId: tgt \? tgt\.itemId : fbId, title: tgt \? tgt\.title : fbTitle, text: txt, sid: fbSid/);
 });
 
 test("a citation survives a RELOAD but is dropped on tab SWITCH (the user 2026-07-01)", () => {
@@ -103,7 +117,7 @@ test("highlighting transcript text seeds a QUOTE chip — the same chip, reply-c
 });
 
 test("a quote chip sends a plain message wrapped by quoteReplyBody — never askFollowUp (no goal to reopen)", () => {
-  assert.match(RENDER, /if \(cite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: cite\.itemId, text \}\);/);
+  assert.match(RENDER, /if \(cite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: cite\.itemId, text, sid: activeId \}\);/);
   assert.match(RENDER, /else if \(cite\?\.quote\) vscodeApi\.postMessage\(\{ type: "sendMessage", id: activeId, text: quoteReplyBody\(cite\.quote, text, cite\.src\) \}\);/);
   // the wrap: a lead-in + the highlighted text as a markdown quote block, then the typed message
   assert.match(RENDER, /return lead \+ "\\n" \+ q \+ "\\n\\n" \+ text;/);

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -105,6 +105,22 @@ test("routeOutbound: a remote id routes to its host with the prefix stripped", (
   assert.equal(routes[0].msg.text, "hello");
 });
 
+test("routeOutbound: a card op routes by its SID — an itemId alone can only go local", () => {
+  // Why every card-addressed op has to carry `sid` (the user 2026-07-29): an itemId is "‹sid›:‹goalId›", so
+  // it can never join SCALAR_ID — hostOf() splits on the FIRST colon and would read the session uuid as a
+  // host name. The sid is the routing key; the itemId is already bare on both sides and rides through
+  // untouched. A follow-up sent without the sid went to the LOCAL kernel, which owns no such session and
+  // dropped it in silence: the reply was simply lost.
+  const routes = routeOutbound({ type: "askFollowUp", itemId: U + ":g4", text: "and the fix?", sid: "gpu1:" + U });
+  assert.equal(routes.length, 1);
+  assert.equal(routes[0].host, "gpu1", "the sid picks the owning kernel");
+  assert.equal(routes[0].msg.sid, U, "sid stripped back to bare");
+  assert.equal(routes[0].msg.itemId, U + ":g4", "itemId was never prefixed, so it passes through as-is");
+  // the regression: drop the sid and the SAME message lands on the wrong kernel
+  const orphan = routeOutbound({ type: "askFollowUp", itemId: U + ":g4", text: "and the fix?" });
+  assert.equal(orphan[0].host, "", "no sid → local, whoever the card belongs to");
+});
+
 test("routeOutbound: a global message (no session id) goes local", () => {
   const routes = routeOutbound({ type: "setColormap", name: "viridis" });
   assert.deepEqual(routes, [{ host: "", msg: { type: "setColormap", name: "viridis" } }]);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7230,9 +7230,15 @@ function setupComposer() {
       // unless cleared) and the chat renders the ↩ Follow-up header — the same path the Follow-up button uses,
       // just seeded by the click. A QUOTE chip (highlighted transcript text, the user 2026-07-13) has no goal:
       // it wraps client-side (quoteReplyBody) into a plain message. No chip → plain sendMessage.
+      // `sid: activeId` is what ROUTES this to the owning kernel in a federated dashboard (the user 2026-07-29):
+      // federation keys routing off `id`/`sid` only, and an `itemId` ("‹sid›:‹goal›") can't be one — its own
+      // colon would read the session uuid as a host. Without the sid a follow-up on a REMOTE card went to the
+      // LOCAL kernel, which owns no such session and dropped it into tmux by uuid — nothing sent, no error,
+      // the card flashing to Working and back. The kernel keeps deriving its sid from itemId, so this is inert
+      // locally; every other card op (askClear/cardNotify/showOnTimeline) already carries the sid the same way.
       const cite = composerCitations.get(activeId);
       if (vscodeApi) {
-        if (cite?.itemId) vscodeApi.postMessage({ type: "askFollowUp", itemId: cite.itemId, text });
+        if (cite?.itemId) vscodeApi.postMessage({ type: "askFollowUp", itemId: cite.itemId, text, sid: activeId });
         else if (cite?.quote) vscodeApi.postMessage({ type: "sendMessage", id: activeId, text: quoteReplyBody(cite.quote, text, cite.src) });
         else { vscodeApi.postMessage({ type: "sendMessage", id: activeId, text }); registerOptimistic(activeId, text); }
         // (a citation follow-up/quote has its own kernel-side echo path; the optimistic bubble covers the plain send)


### PR DESCRIPTION
Replies typed into a remote session's chat vanished on Enter: the box cleared, no provisional bubble appeared, and nothing reached the far side. The card flashed to Working and snapped back a second later, which was the only trace.

## Cause

The composer's citation follow-up was the one card-addressed op that posted `itemId` without a `sid`.

`federation.routeOutbound` picks the owning kernel from `id`/`sid` alone, and an `itemId` can never join that list: it is `"<sid>:<goalId>"`, so `hostOf()` would split on its own colon and read the session uuid as a host name. With no sid the message routed to the **local** kernel, which derives the sid from the itemId, owns no such session, and hands it to the tmux backend by uuid — a `send-keys` at a pane that does not exist. Nothing sent, nothing logged.

The bounce came from the same call: the kernel fires `cardPredict` before it resolves any backend, so every feed view flipped the card to Working, then `optimistic_followup` against a store with no such goal answered `ok:false` and the ack put it back. The toast that followed said the reply had been sent.

## Fix

`sid: activeId` on the citation follow-up. The kernel keeps deriving its sid from the itemId, so the field is inert locally and purely a routing key — the same shape `askClear`, `cardNotify` and `showOnTimeline` have carried since 2026-07-02.

## Tests

- `composer-citation.test.ts` — the follow-up carries its sid, alongside the two sibling ops that already did.
- `multi-kernel-merge.test.ts` — `routeOutbound` sends the card op to its sid's host with the itemId passing through bare, and pins the regression: drop the sid and the same message lands local.

Both suites green: 3509 Python, 1425 node, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)