### PR TITLE
An undeliverable op fails loudly instead of typing into thin air

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3642,6 +3642,72 @@ def _picker_mid_series(sid):
     return isinstance(i, int) and isinstance(n, int) and i < n
 
 
+def _kernel_knows(sid):
+    """Does THIS kernel have a session by this id at all? The names registry is the authority: it is sid-keyed
+    and written at launch by BOTH backends, and the entry outlives the session, so a dormant or long-dead
+    session still answers True and can be sent to (that revives it). The SDK's own view is checked too, so a
+    session mid-launch — spawned but not yet named — is never called foreign. So is the LIVE set, which both
+    backends report from their own view: a session this kernel can see running right now is ours whatever the
+    registry says, and that ordering keeps an unreadable names file from ever turning a live session away.
+    False means exactly one thing: no session with this id exists here, so nothing local can act on it."""
+    sid = str(sid or "")
+    if not sid:
+        return False
+    if _name_of(sid):
+        return True
+    be = _sdk()
+    try:
+        if be and be.owns(sid):
+            return True
+    except Exception:
+        pass
+    try:
+        return sid in Sessions.live()
+    except Exception:
+        return False
+
+
+# What the user is told when an op names a session this kernel doesn't have. Written for the ONE case that
+# actually produces it — a federated board whose panes address several kernels — and phrased as what was lost
+# and what to do, not as an internal fault.
+_FOREIGN_OP_VERB = {"sendMessage": "message", "askFollowUp": "reply", "askText": "answer",
+                    "addCustomAsk": "answer", "answerAsk": "answer", "submitAsk": "answer",
+                    "rewindSend": "edited message", "sendCommand": "command", "renameSession": "rename",
+                    "endSession": "end", "interrupt": "interrupt", "compactSession": "compact"}
+
+
+def _refuse_drive(client, op, sid, msg):
+    """Refuse an op for a session this kernel doesn't have — and make the refusal impossible to miss. THREE
+    places, because a silent drop here costs the user typed work they cannot get back (the user 2026-07-29):
+      1. a MODAL in the pane that fired it — not the `warn` toast, which fades in 12s and can be missed
+         entirely; losing a message you typed deserves a dialog you have to dismiss.
+      2. `undelivered.jsonl` in the state dir, carrying the text VERBATIM, so anything typed survives the
+         refusal and can be copied back out. This is the whole point: the old path lost the words.
+      3. stderr → the kernel log, for the case where the browser is gone by the time it happens.
+    Text is capped for the log line, never for the user's own copy of it."""
+    text = ""
+    for k in ("text", "cmd", "name"):
+        if isinstance(msg.get(k), str) and msg[k]:
+            text = msg[k]
+            break
+    what = _FOREIGN_OP_VERB.get(op, "action")
+    try:
+        with (jd.STATE / "undelivered.jsonl").open("a") as fh:
+            fh.write(json.dumps({"at": int(time.time()), "op": op, "sid": sid, "what": what,
+                                 "itemId": msg.get("itemId") or "", "text": text}) + "\n")
+    except OSError:
+        pass
+    sys.stderr.write("undeliverable %s: this kernel has no session %s — %r\n" % (op, sid, text[:200]))
+    detail = ("Nothing was sent. This romp kernel has no session with id %s, so it could not deliver your %s "
+              "— on a board showing more than one machine, that means the pane addressed the wrong kernel. "
+              "Your text is saved verbatim in undelivered.jsonl under romp's state directory." % (sid, what))
+    try:
+        client["send"](json.dumps({"type": "err", "title": "That %s was not delivered" % what,
+                                   "text": detail, "copy": text}))
+    except Exception:
+        pass
+
+
 def _drive(msg, client):
     """Route a per-session DRIVE op — send / interrupt / compact / ask picker / model·effort·mode / rename /
     end / follow-up — to whichever backend OWNS the sid (Sessions.backend_for(sid)), and return True. UI /
@@ -3663,6 +3729,17 @@ def _drive(msg, client):
         sid = str(msg["itemId"]).rsplit(":", 1)[0] if msg.get("itemId") else str(msg["id"])
     else:
         return False                                      # not a drive op (UI/nav) → _dispatch_ws handles it
+    # A drive op for a session THIS kernel has never heard of is undeliverable — refuse it here, loudly.
+    # backend_for() falls through to tmux for any unrecognized sid, and TmuxBackend.send then types at a pane
+    # named after the sid; when no such pane exists the keystrokes evaporate with nothing raised and nothing
+    # logged. That silence swallowed real user messages (the user 2026-07-29): a federated dashboard sent a
+    # card reply here that belonged to another machine's kernel, and it simply ceased to exist — no bubble,
+    # no error, no record. Per the fail-loudly rule, an op we cannot deliver must SAY so instead of degrading
+    # into a no-op. `_kernel_knows` is the registry, not liveness: a dead-but-ours session still resolves, so
+    # reviving sends keep working — only a genuinely foreign sid lands here.
+    if not _kernel_knows(sid):
+        _refuse_drive(client, t, sid, msg)
+        return True                                       # consumed: refused, reported, and recorded
     be = Sessions.backend_for(sid)
     if t == "sendMessage" and msg.get("text"):
 

--- a/tests/test_drive_foreign_sid.py
+++ b/tests/test_drive_foreign_sid.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""A drive op naming a session this kernel doesn't have must FAIL LOUDLY, never degrade into a no-op.
+
+The user 2026-07-29: on a board merging two kernels, a reply addressed to the wrong one reached a kernel
+that owns no such session. Sessions.backend_for() falls through to tmux for any unrecognized sid, and
+TmuxBackend.send then types at a pane named after the sid — with no such pane, the keystrokes evaporate
+with nothing raised and nothing logged, so typed messages simply ceased to exist. Per the repo's
+fail-loudly rule, an op we cannot deliver has to say so: a modal in the pane that fired it, the text kept
+verbatim on disk so nothing typed is lost, and a line in the kernel log.
+"""
+import json
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_foreign", os.path.join(BIN, "romp-kernel")).load_module()
+
+OURS = "11111111-2222-3333-4444-555555555555"
+THEIRS = "99999999-8888-7777-6666-555555555555"   # lives on another machine's kernel
+
+
+class KernelKnows(unittest.TestCase):
+    """The names registry is the authority, and it OUTLIVES the session — so 'we don't have it' means
+    never created here, not merely 'not running'."""
+
+    def setUp(self):
+        self._name_of, self._sdk = km._name_of, km._sdk
+        km._name_of = lambda sid: "web" if sid == OURS else None
+        km._sdk = lambda: None
+
+    def tearDown(self):
+        km._name_of, km._sdk = self._name_of, self._sdk
+
+    def test_a_named_session_is_ours_even_when_long_dead(self):
+        # the registry entry survives the session, so a send that REVIVES a dormant tab still goes through
+        self.assertTrue(km._kernel_knows(OURS))
+
+    def test_a_foreign_sid_is_not_ours(self):
+        self.assertFalse(km._kernel_knows(THEIRS))
+
+    def test_empty_is_not_ours(self):
+        self.assertFalse(km._kernel_knows(""))
+        self.assertFalse(km._kernel_knows(None))
+
+    def test_a_session_mid_launch_is_ours_via_the_sdk(self):
+        # spawned but not yet written to the registry — never call that foreign
+        km._name_of = lambda sid: None
+        km._sdk = lambda: type("B", (), {"owns": staticmethod(lambda s: s == OURS)})()
+        self.assertTrue(km._kernel_knows(OURS))
+        self.assertFalse(km._kernel_knows(THEIRS))
+
+
+class RefusesForeignDriveOps(unittest.TestCase):
+    def setUp(self):
+        self.sent = []
+        self.client = {"send": lambda s: self.sent.append(json.loads(s))}
+        self._name_of, self._sdk = km._name_of, km._sdk
+        km._name_of = lambda sid: "web" if sid == OURS else None
+        km._sdk = lambda: None
+        self._backend_for = km.Sessions.backend_for
+        self.reached = []
+        km.Sessions.backend_for = staticmethod(
+            lambda sid: type("B", (), {"send": lambda _s, s, t: self.reached.append((s, t))})())
+
+    def tearDown(self):
+        km._name_of, km._sdk = self._name_of, self._sdk
+        km.Sessions.backend_for = staticmethod(self._backend_for)
+
+    def test_a_send_to_a_foreign_session_never_reaches_a_backend(self):
+        handled = km._drive({"type": "sendMessage", "id": THEIRS, "text": "did you get this?"}, self.client)
+        self.assertTrue(handled, "the op is CONSUMED — refused, not passed on to be silently retried")
+        self.assertEqual(self.reached, [], "nothing was handed to a backend")
+
+    def test_the_refusal_reaches_the_pane_that_fired_it_as_an_err_not_a_warn(self):
+        km._drive({"type": "sendMessage", "id": THEIRS, "text": "did you get this?"}, self.client)
+        self.assertEqual(len(self.sent), 1)
+        msg = self.sent[0]
+        # `err` (a modal you must dismiss), NOT `warn` (a toast that fades in 12s and can be missed)
+        self.assertEqual(msg["type"], "err")
+        self.assertIn("not delivered", msg["title"])
+        self.assertIn("Nothing was sent", msg["text"])
+        self.assertIn(THEIRS, msg["text"], "names the session it could not find, so the cause is diagnosable")
+        # the typed text rides back so the user can recover it — the composer cleared it on Enter
+        self.assertEqual(msg["copy"], "did you get this?")
+
+    def test_a_card_reply_is_refused_the_same_way(self):
+        # the exact shape that lost real messages: askFollowUp derives its sid from the itemId
+        km._drive({"type": "askFollowUp", "itemId": THEIRS + ":g4", "text": "and the fix?"}, self.client)
+        self.assertEqual(self.reached, [])
+        self.assertEqual(self.sent[0]["type"], "err")
+        self.assertEqual(self.sent[0]["copy"], "and the fix?")
+        self.assertIn("reply", self.sent[0]["title"])
+
+    def test_our_own_session_is_untouched(self):
+        km._drive({"type": "sendMessage", "id": OURS, "text": "hello"}, self.client)
+        self.assertEqual(self.reached, [(OURS, "hello")], "a session we own still gets its message")
+        self.assertEqual(self.sent, [], "and no error is raised for it")
+
+    def test_a_non_drive_op_still_falls_through_untouched(self):
+        # UI/nav ops carry no session to own — they must keep reaching _dispatch_ws
+        self.assertFalse(km._drive({"type": "setColormap", "name": "viridis"}, self.client))
+        self.assertEqual(self.sent, [])
+
+    def test_the_text_is_kept_verbatim_on_disk_so_nothing_typed_is_lost(self):
+        import tempfile
+        import pathlib
+        with tempfile.TemporaryDirectory() as d:
+            saved = km.jd.STATE
+            km.jd.STATE = pathlib.Path(d)
+            try:
+                km._drive({"type": "sendMessage", "id": THEIRS, "text": "a paragraph I do not want to retype"},
+                          self.client)
+                rows = [json.loads(x) for x in (pathlib.Path(d) / "undelivered.jsonl").read_text().splitlines()]
+            finally:
+                km.jd.STATE = saved
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["text"], "a paragraph I do not want to retype")
+        self.assertEqual(rows[0]["sid"], THEIRS)
+        self.assertEqual(rows[0]["op"], "sendMessage")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_apiretry.py
+++ b/tests/test_kernel_apiretry.py
@@ -69,9 +69,11 @@ class ApiRetryRendersAsRomp(unittest.TestCase):
 class ApiRetryIdempotency(unittest.TestCase):
     """Drive _drive({type:'apiRetry'}) with a stubbed backend + gate globals and observe what gets sent."""
     def setUp(self):
+        self._saved_name_of = km._name_of
         self._saved = (km.Sessions, km._retry_paused_on, km._session_retry_suppressed,
                        km._api_error, km._path_of)
         km._retry_paused_on = lambda: False
+        km._name_of = lambda sid: "web"   # these tests drive ops on a session this kernel HAS; _drive refuses one it doesn't (2026-07-29)
         km._session_retry_suppressed = lambda sid: False
         # the one-retry-per-error-episode gate (2026-07-20) reads the CURRENT error record; these tests
         # exercise the queued-idempotency layer, so give each its own live error episode (fresh uuid per
@@ -88,6 +90,7 @@ class ApiRetryIdempotency(unittest.TestCase):
     def tearDown(self):
         (km.Sessions, km._retry_paused_on, km._session_retry_suppressed,
          km._api_error, km._path_of) = self._saved
+        km._name_of = self._saved_name_of
         km._auto_retried.clear()
 
     def _drive_retry(self, be, **msg):

--- a/tests/test_kernel_card_predict.py
+++ b/tests/test_kernel_card_predict.py
@@ -54,9 +54,11 @@ class PredictWorkingFanOut(unittest.TestCase):
     def setUp(self):
         self.frames = []
         self.be = _FakeBackend()
+        self._saved_name_of = km._name_of
         self._saved = (km._send_to_app, list(km._built_feed), km.Sessions.backend_for,
                        km._send_or_park, km.jd.optimistic_followup)
         km._send_to_app = lambda app, m: self.frames.append((app, m))
+        km._name_of = lambda sid: "web"   # these tests drive ops on a session this kernel HAS; _drive refuses one it doesn't (2026-07-29)
         km.Sessions.backend_for = lambda sid: self.be
         km._send_or_park = lambda *a, **k: None
         km.jd.optimistic_followup = lambda *a, **k: False
@@ -72,6 +74,7 @@ class PredictWorkingFanOut(unittest.TestCase):
     def tearDown(self):
         (km._send_to_app, built, km.Sessions.backend_for,
          km._send_or_park, km.jd.optimistic_followup) = self._saved
+        km._name_of = self._saved_name_of
         km._built_feed[:] = built
 
     def _feed_frames(self):

--- a/tests/test_kernel_push_responsiveness.py
+++ b/tests/test_kernel_push_responsiveness.py
@@ -62,8 +62,10 @@ class DriveOpsAckFast(unittest.TestCase):
     def setUp(self):
         self.be = _FakeBackend()
         self.pushes = []
+        self._saved_name_of = km._name_of
         self._saved = (km._push_all, km._ops_gate, km.Sessions.backend_for, km._optimistic_echo)
         km._push_all = lambda: self.pushes.append(1)
+        km._name_of = lambda sid: "web"   # these tests drive ops on a session this kernel HAS; _drive refuses one it doesn't (2026-07-29)
         km._ops_gate = lambda sid: False
         km.Sessions.backend_for = lambda sid: self.be
         km._optimistic_echo = lambda *a, **k: None
@@ -73,6 +75,7 @@ class DriveOpsAckFast(unittest.TestCase):
 
     def tearDown(self):
         (km._push_all, km._ops_gate, km.Sessions.backend_for, km._optimistic_echo) = self._saved
+        km._name_of = self._saved_name_of
         km._pusher_wake.clear()
         km._pending_ops.clear()
         km._interrupt_clicked.clear()

--- a/tests/test_kernel_retry_episode.py
+++ b/tests/test_kernel_retry_episode.py
@@ -40,10 +40,12 @@ class _FakeBackend:
 class RetryPerEpisode(unittest.TestCase):
     def setUp(self):
         self.be = _FakeBackend()
+        self._saved_name_of = km._name_of
         self._saved = (km.Sessions.backend_for, km._api_error, km._path_of,
                        km._retry_paused_on, km._session_retry_suppressed, dict(km._auto_retried))
         km.Sessions.backend_for = lambda sid: self.be
         km._path_of = lambda sid, now=None: "/TESTDIR/x.jsonl"
+        km._name_of = lambda sid: "web"   # these tests drive ops on a session this kernel HAS; _drive refuses one it doesn't (2026-07-29)
         km._retry_paused_on = lambda: False
         km._session_retry_suppressed = lambda sid: False
         self.aerr = {"text": "500 server_error", "status": 500, "category": "server_error",
@@ -54,6 +56,7 @@ class RetryPerEpisode(unittest.TestCase):
     def tearDown(self):
         (km.Sessions.backend_for, km._api_error, km._path_of,
          km._retry_paused_on, km._session_retry_suppressed, saved) = self._saved
+        km._name_of = self._saved_name_of
         km._auto_retried.clear()
         km._auto_retried.update(saved)
 

--- a/tests/test_sdk_kernel.py
+++ b/tests/test_sdk_kernel.py
@@ -96,15 +96,19 @@ class KernelWiring(unittest.TestCase):
     def test_non_sdk_sid_routes_to_the_tmux_backend(self):
         # a non-SDK sid no longer "falls through" — _drive routes it to the tmux backend via
         # Sessions.backend_for (the fallback). The unified dispatch handles BOTH kinds.
+        # It must be a session this kernel HAS, though: since 2026-07-29 _drive refuses an id it has never
+        # heard of rather than letting backend_for's tmux fallback type at a pane that isn't there. The
+        # names entry is what a real tmux session would carry; test_drive_foreign_sid.py owns the refusal.
         tm = FakeBackend(); tm._owned = set()
-        saved = km._TMUX
+        saved, saved_name = km._TMUX, km._name_of
         km._TMUX = tm
+        km._name_of = lambda sid: "web"
         try:
             self.assertTrue(self._route({"type": "sendMessage", "id": "sid-tmux", "text": "hi"}))
             self.assertIn(("send", "sid-tmux", "hi"), tm.calls)   # routed to the tmux backend
             self.assertEqual(self.be.calls, [])                   # the SDK backend was untouched
         finally:
-            km._TMUX = saved
+            km._TMUX, km._name_of = saved, saved_name
             km._tmux_echo.pop("sid-tmux", None)                   # the optimistic echo wrote here — don't leak it
 
     def test_ui_op_falls_through_even_for_sdk_sid(self):

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -901,6 +901,8 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   box-shadow: 0 10px 36px rgba(0, 0, 0, 0.55);
 }
 .pickdlg-title { font-weight: 700; color: var(--vscode-foreground, #ccc); margin-bottom: 4px; }
+/* the err dialog's body sentence — the resume-picker dialog is all buttons, so its box carried no prose style */
+.pickdlg-detail { color: var(--vscode-descriptionForeground, #999); margin-bottom: 10px; line-height: 1.45; }
 .pickdlg-opt {
   padding: 8px 10px; cursor: pointer; text-align: left;
   background: rgba(255, 255, 255, 0.05); color: var(--vscode-foreground, #ccc);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3348,6 +3348,9 @@ window.addEventListener("message", (e: MessageEvent) => {
     renderModal();
     applyExtHover();
     if (extHoverEid) document.querySelector(".dot-hl[data-eid]")?.scrollIntoView({ block: "center" });
+  } else if (m.type === "err" && typeof m.text === "string" && m.text) {
+    showErrDialog(typeof m.title === "string" && m.title ? m.title : "That action was not delivered",
+                  m.text, typeof m.copy === "string" ? m.copy : "");
   } else if (m.type === "pickerOptions" && typeof m.name === "string") {
     // the host read the blocked session's live resume-picker screen — show the
     // same options in-page; a choice goes back as keystrokes (transport only,
@@ -3455,6 +3458,32 @@ function showPickerDialog(name: string, options: string[]) {
   cancel.textContent = "Cancel";
   cancel.onclick = () => overlay.remove();
   box.append(cancel);
+  overlay.onclick = (e) => { if (e.target === overlay) overlay.remove(); };
+  document.body.appendChild(overlay);
+  (box.querySelector("button") as HTMLElement | null)?.focus();
+}
+
+// The kernel's LOUD channel (the user 2026-07-29). The feed had no error surface at all: every failure here
+// went to feedToast, which fades, and a kernel `warn` had no handler on this page whatsoever — so an action
+// fired from a card could fail with the page showing nothing. A refused reply is typed work that is gone, so
+// it gets a dialog you must dismiss, reusing the resume-picker dialog's chrome rather than inventing another.
+function showErrDialog(title: string, text: string, copy: string) {
+  document.getElementById("err-dialog")?.remove();
+  const overlay = el("div", "pickdlg-overlay"); overlay.id = "err-dialog";
+  const box = el("div", "pickdlg-box");
+  const h = el("div", "pickdlg-title"); h.textContent = title;
+  const d = el("div", "pickdlg-detail"); d.textContent = text;
+  box.append(h, d);
+  if (copy) {
+    const c = el("button", "pickdlg-opt");
+    c.textContent = "Copy my text";
+    c.onclick = () => { navigator.clipboard?.writeText(copy); c.textContent = "Copied"; };
+    box.append(c);
+  }
+  const ok = el("button", "pickdlg-opt pickdlg-cancel");
+  ok.textContent = "Dismiss";
+  ok.onclick = () => overlay.remove();
+  box.append(ok);
   overlay.onclick = (e) => { if (e.target === overlay) overlay.remove(); };
   document.body.appendChild(overlay);
   (box.querySelector("button") as HTMLElement | null)?.focus();

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7044,6 +7044,17 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "nextTab") cycleTab(1);
   else if (m.type === "prevTab") cycleTab(-1);
   else if (m.type === "warn" && typeof m.text === "string" && m.text) warnToast(m.text);
+  // `err` is the LOUD channel, deliberately distinct from `warn` (the user 2026-07-29): a warn toast fades
+  // after 12s, which is right for "that name has a bad character" and wrong for "the message you just typed
+  // was never sent." This one takes the confirm modal — it has to be dismissed — and hands the text back,
+  // since the composer cleared on Enter and the kernel's record is the only place it survives.
+  else if (m.type === "err" && typeof m.text === "string" && m.text) {
+    const copy = typeof m.copy === "string" ? m.copy : "";
+    showConfirm(typeof m.title === "string" && m.title ? m.title : "That action was not delivered", m.text,
+                copy ? [{ label: "Copy my text", value: "copy" }, { label: "Dismiss", value: "ok" }]
+                     : [{ label: "Dismiss", value: "ok" }],
+                (v) => { if (v === "copy") navigator.clipboard?.writeText(copy); });
+  }
   else if (m.type === "dirCompletions") onDirCompletions(m);        // the owning kernel's path completions
   else if (m.type === "createDirMissing" && m.name) onCreateDirMissing(m);   // create it, or edit the path
   // The AUTHORITATIVE answer to a ✕ on a queued bubble (the user 2026-07-20). ok:false = the message

--- a/ui/webview/undelivered-err.test.ts
+++ b/ui/webview/undelivered-err.test.ts
@@ -1,0 +1,56 @@
+// The kernel's LOUD channel (the user 2026-07-29). An op naming a session this kernel doesn't have used to
+// degrade into a no-op — the tmux backend typed at a pane that wasn't there — so typed messages vanished with
+// no bubble, no error and no record. The kernel now refuses and emits `err`; this pins the two panes that can
+// fire such an op rendering it as a DIALOG rather than a fading toast, and handing the text back.
+//
+// `err` is deliberately a separate type from `warn`: warn is right for "that name has a bad character" and
+// wrong for "the message you just typed was never sent." No jsdom for these renderers, so pin at source.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+test("chat: an `err` takes the confirm MODAL, not the warn toast", () => {
+  assert.match(RENDER, /else if \(m\.type === "err" && typeof m\.text === "string" && m\.text\) \{/);
+  assert.match(RENDER, /showConfirm\(typeof m\.title === "string" && m\.title \? m\.title : "That action was not delivered", m\.text,/);
+  // the fading toast stays for the soft cases it was written for
+  assert.match(RENDER, /m\.type === "warn" && typeof m\.text === "string" && m\.text\) warnToast\(m\.text\);/);
+});
+
+test("chat: the refused text is offered back, because the composer already cleared it", () => {
+  assert.match(RENDER, /const copy = typeof m\.copy === "string" \? m\.copy : "";/);
+  assert.match(RENDER, /copy \? \[\{ label: "Copy my text", value: "copy" \}, \{ label: "Dismiss", value: "ok" \}\]/);
+  assert.match(RENDER, /\(v\) => \{ if \(v === "copy"\) navigator\.clipboard\?\.writeText\(copy\); \}/);
+  // no text to hand back (an interrupt, a compact) → just the dismiss
+  assert.match(RENDER, /: \[\{ label: "Dismiss", value: "ok" \}\],/);
+});
+
+test("feed: the pane that fires card ops gets an error dialog of its own", () => {
+  // it had NONE: kernel `warn` has no handler on this page at all, and feedToast fades
+  assert.doesNotMatch(FEED, /m\.type === "warn"/);
+  assert.match(FEED, /function showErrDialog\(title: string, text: string, copy: string\)/);
+  assert.match(FEED, /\} else if \(m\.type === "err" && typeof m\.text === "string" && m\.text\) \{/);
+  assert.match(FEED, /showErrDialog\(typeof m\.title === "string" && m\.title \? m\.title : "That action was not delivered",/);
+});
+
+test("feed: the dialog reuses the resume-picker chrome rather than inventing another look", () => {
+  const dlg = FEED.split("function showErrDialog(")[1].split("\n}")[0];
+  assert.match(dlg, /el\("div", "pickdlg-overlay"\)/);
+  assert.match(dlg, /el\("div", "pickdlg-box"\)/);
+  assert.match(dlg, /el\("div", "pickdlg-title"\)/);
+  // one style is added, for prose the all-buttons picker dialog never needed
+  assert.match(dlg, /el\("div", "pickdlg-detail"\)/);
+  assert.match(CSS, /\.pickdlg-detail \{/);
+  // dismissible by button OR backdrop — an error must never trap the pane
+  assert.match(dlg, /ok\.onclick = \(\) => overlay\.remove\(\);/);
+  assert.match(dlg, /overlay\.onclick = \(e\) => \{ if \(e\.target === overlay\) overlay\.remove\(\); \};/);
+});
+
+test("feed: copying acknowledges the click, per the always-acknowledge rule", () => {
+  const dlg = FEED.split("function showErrDialog(")[1].split("\n}")[0];
+  assert.match(dlg, /c\.onclick = \(\) => \{ navigator\.clipboard\?\.writeText\(copy\); c\.textContent = "Copied"; \};/);
+});


### PR DESCRIPTION
Follow-on to #116, which fixed the addressing bug. This fixes the reason it was invisible.

## The silence

`Sessions.backend_for()` falls through to tmux for any sid it doesn't recognise, and `TmuxBackend.send` then types at a pane named after that sid. With no such pane the keystrokes evaporate — nothing raised, nothing logged, nothing shown. A federated board sent a card reply to a kernel that owns no such session and the message simply ceased to exist.

## The check

`_drive` now tests ownership before dispatching. `_kernel_knows` asks, in order:

1. the **names registry** — sid-keyed, written by both backends, and it *outlives* the session, so sending to a dormant tab (which revives it) still works;
2. the **SDK's own view**, so a session spawned but not yet named is never called foreign;
3. the **live set**, so an unreadable registry can't turn away a session the kernel can see running.

False means exactly one thing: no session with this id exists here.

## Failing loudly, in three places

Because what gets lost is typed work:

- **A modal in the pane that fired it.** Not the `warn` toast, which fades after 12s — right for "that name has a bad character", wrong for "the message you just typed was never sent." The feed had *no* error surface at all: it has never handled `warn`, so an action fired from a card could fail with the page showing nothing. It reuses the resume-picker dialog's chrome; one CSS rule added for prose.
- **`undelivered.jsonl`** in the state dir, holding the text verbatim and offered back through a Copy button. The composer clears on Enter, so this is the only surviving copy.
- **stderr**, for when no browser is attached to hear it.

Only WS drive ops route through `_drive`. `POST /send` has its own path and already forwards by host, so it is untouched.

## Tests

`tests/test_drive_foreign_sid.py` (new, 10 cases): the ownership rule including the dormant and mid-launch cases; a foreign send reaching no backend; the `err` shape carrying the text back; a card reply refused the same way; our own sessions and non-drive ops untouched; and the verbatim on-disk record.

`ui/webview/undelivered-err.test.ts` (new): both panes render `err` as a dialog, the text is offered back, the feed reuses existing chrome, and the dialog is dismissible.

Four existing fixtures now stub the names registry — they drive ops on synthetic sids, which the new precondition requires them to state. `test_sdk_kernel`'s tmux-fallback test does the same: the fallback it pins is for sessions we have.

Green: 3519 Python, 1430 node, 273 bats, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)