### PR TITLE
A refused op is filed in the error center, not just flashed

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3702,8 +3702,11 @@ def _refuse_drive(client, op, sid, msg):
               "— on a board showing more than one machine, that means the pane addressed the wrong kernel. "
               "Your text is saved verbatim in undelivered.jsonl under romp's state directory." % (sid, what))
     try:
+        # `sid` rides along so the shell's error-center entry carries the session it was meant for, the way
+        # every card-badge entry does — the bell is a log you read later, and "which one?" is the first thing
+        # you ask of it.
         client["send"](json.dumps({"type": "err", "title": "That %s was not delivered" % what,
-                                   "text": detail, "copy": text}))
+                                   "text": detail, "copy": text, "sid": sid}))
     except Exception:
         pass
 
@@ -15670,10 +15673,10 @@ el.classList.toggle('has',n>0||(kindOn('conn')&&liveDown()));
 var t=el.querySelector('.rerr-n');if(t)t.textContent=n<=0?'!':(n>9?'+':String(n));});
 if(!back.hidden)renderList();}
 // each entry leads with the chip its card wears in the feed, so the vocabulary matches across surfaces
-var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror','sdk','locate','cleared'];
+var KINDS=['conn','limit','judge','warn','stalled','nudge','retry','apierror','sdk','locate','cleared','undelivered'];
 var KINDLBL={conn:'offline',limit:'limit',judge:'judge',warn:'warning',stalled:'stalled',
 nudge:'follow-up failed',retry:'retrying',apierror:'api error',sdk:'sdk',
-locate:'jump failed',cleared:'cleared'};
+locate:'jump failed',cleared:'cleared',undelivered:'not sent'};
 // what each kind MEANS (the user 2026-07-28: the tooltip should explain the badge, not just say
 // show/hide) — worn by the filter toggles AND every entry's chip
 var DESC={conn:"the dashboard lost its live connection to the kernel for a visible pane; it reconnects on its own",
@@ -15686,7 +15689,8 @@ retry:"a session is inside an API-error retry storm; auto-retry is already worki
 apierror:"a session stopped on an API error (rate limit, spend cap, or prompt too long) and its card is blocked",
 sdk:"romp's SDK backend, the machinery that actually runs your sessions, hit an error: a session thread that died, a stream that dropped, a setting the CLI refused. The session usually recovers on its own, and the full traceback is in the kernel log under ~/.local/state/romp",
 locate:"a click that should have jumped to a message in the chat couldn't find it. Usually the chat is missing part of its history; reload the pane if it keeps happening",
-cleared:"a /clear in a session dropped still-open cards at the boundary; Undo clear on the feed restores them"};
+cleared:"a /clear in a session dropped still-open cards at the boundary; Undo clear on the feed restores them",
+undelivered:"something you sent never reached a session — the kernel it was addressed to has no session by that id, which on a board showing more than one machine means the pane addressed the wrong one. Nothing was delivered. Your text is kept verbatim in undelivered.jsonl under ~/.local/state/romp"};
 // the toggles ARE the chips (same pill, same colours) — lit = shown, dimmed = muted. Built once on a
 // STABLE container; only classes flip on click, so the buttons stay click-safe.
 if(filtBar)KINDS.forEach(function(k){var b=document.createElement('span');
@@ -17006,7 +17010,9 @@ def _landing():
             ".rerr-chip{flex:0 0 auto;font-size:9px;font-weight:700;letter-spacing:.04em;padding:1px 6px;"
             "border-radius:999px;line-height:1.4;white-space:nowrap;border:1px solid transparent}"
             ".rerr-chip.k-stalled,.rerr-chip.k-warn{color:#ffd166;border-color:rgba(255,209,102,0.6)}"
-            ".rerr-chip.k-nudge{color:#ff6a6a;border-color:rgba(255,106,106,0.6)}"
+            # "not sent" rides with the follow-up-failed red: both mean a message of yours didn't land, and
+            # this one is the harder loss of the two — nothing was delivered at all (the user 2026-07-29)
+            ".rerr-chip.k-nudge,.rerr-chip.k-undelivered{color:#ff6a6a;border-color:rgba(255,106,106,0.6)}"
             ".rerr-chip.k-retry,.rerr-chip.k-apierror,.rerr-chip.k-sdk{color:#e5484d;border-color:rgba(229,72,77,0.6)}"
             ".rerr-chip.k-conn{color:#ff6b6b;border-color:rgba(255,107,107,0.6)}"
             ".rerr-chip.k-limit,.rerr-chip.k-judge,.rerr-chip.k-locate{color:#e0a030;border-color:rgba(224,160,48,0.6)}"

--- a/tests/test_drive_foreign_sid.py
+++ b/tests/test_drive_foreign_sid.py
@@ -85,6 +85,8 @@ class RefusesForeignDriveOps(unittest.TestCase):
         self.assertIn(THEIRS, msg["text"], "names the session it could not find, so the cause is diagnosable")
         # the typed text rides back so the user can recover it — the composer cleared it on Enter
         self.assertEqual(msg["copy"], "did you get this?")
+        # …and the sid rides along, so the shell's error-center entry says WHICH session it was meant for
+        self.assertEqual(msg["sid"], THEIRS)
 
     def test_a_card_reply_is_refused_the_same_way(self):
         # the exact shape that lost real messages: askFollowUp derives its sid from the itemId

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -218,12 +218,15 @@ class ErrorCenterExecutes(unittest.TestCase):
         # an entry now, rather than only flashing a toast that leaves nothing to point at afterwards.
         # 'sdk' joined on 2026-07-28: SDK-backend failures used to live only in the kernel
         # log, so a session whose thread died just looked odd with nothing to look at.
+        # 'not sent' joined on 2026-07-29: an op the kernel can't deliver (no session by that id — on a
+        # multi-machine board, the pane addressed the wrong kernel) used to vanish into a tmux send at a
+        # pane that wasn't there, losing whatever had been typed with nothing anywhere to show for it.
         a = self.out["filterBar"]
-        self.assertEqual(a["n"], 11)
+        self.assertEqual(a["n"], 12)
         self.assertEqual(a["first"], "offline")
         self.assertEqual(a["labels"],
                          "offline|limit|judge|warning|stalled|follow-up failed|retrying|api error|"
-                         "sdk|jump failed|cleared")
+                         "sdk|jump failed|cleared|not sent")
 
     def test_muting_a_kind_hides_counts_and_live_cue_but_keeps_the_entries(self):
         a = self.out["afterMute"]
@@ -278,7 +281,8 @@ class ErrorCenterWiring(unittest.TestCase):
         self.assertIn("font:13px/1.6 system-ui,-apple-system,'Segoe UI',sans-serif}#rerr-panel .rerr-top", html)
         # the chip family mirrors feed.css's .fask-* colours
         self.assertIn(".rerr-chip.k-stalled,.rerr-chip.k-warn{color:#ffd166", html)
-        self.assertIn(".rerr-chip.k-nudge{color:#ff6a6a", html)
+        # 'not sent' shares the follow-up-failed red: both mean a message of yours didn't land
+        self.assertIn(".rerr-chip.k-nudge,.rerr-chip.k-undelivered{color:#ff6a6a", html)
         # the per-kind filter bar sits between header and list, chips doubling as the toggles: a
         # vertical white "show" label, then an even 4-column grid (8 kinds -> the minimum 2 rows,
         # every chip the same cell width) instead of one ragged wrapping row (the user 2026-07-28)

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3349,8 +3349,14 @@ window.addEventListener("message", (e: MessageEvent) => {
     applyExtHover();
     if (extHoverEid) document.querySelector(".dot-hl[data-eid]")?.scrollIntoView({ block: "center" });
   } else if (m.type === "err" && typeof m.text === "string" && m.text) {
-    showErrDialog(typeof m.title === "string" && m.title ? m.title : "That action was not delivered",
-                  m.text, typeof m.copy === "string" ? m.copy : "");
+    // the dialog interrupts; the bell KEEPS it (the user 2026-07-29) — dismissing the modal must not erase
+    // the fact that a message never landed. Same {romp:'notify'} bridge the card-badge mirror below uses.
+    const title = typeof m.title === "string" && m.title ? m.title : "That action was not delivered";
+    const copy = typeof m.copy === "string" ? m.copy : "";
+    window.parent?.postMessage({ romp: "notify", kind: "undelivered",
+                                 text: copy ? title + ": " + copy : title,
+                                 sid: typeof m.sid === "string" ? m.sid : "" }, "*");
+    showErrDialog(title, m.text, copy);
   } else if (m.type === "pickerOptions" && typeof m.name === "string") {
     // the host read the blocked session's live resume-picker screen — show the
     // same options in-page; a choice goes back as keystrokes (transport only,

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7048,9 +7048,15 @@ window.addEventListener("message", (e: MessageEvent) => {
   // after 12s, which is right for "that name has a bad character" and wrong for "the message you just typed
   // was never sent." This one takes the confirm modal — it has to be dismissed — and hands the text back,
   // since the composer cleared on Enter and the kernel's record is the only place it survives.
+  // …and it ALSO files an entry in the shell's error center, the bell in the bottom bar (the user
+  // 2026-07-29). A modal is the interrupt; the bell is the durable record you can come back to — the same
+  // split the card-badge mirror already makes. Dismissing the dialog must not erase the fact that a message
+  // of yours never landed.
   else if (m.type === "err" && typeof m.text === "string" && m.text) {
     const copy = typeof m.copy === "string" ? m.copy : "";
-    showConfirm(typeof m.title === "string" && m.title ? m.title : "That action was not delivered", m.text,
+    const title = typeof m.title === "string" && m.title ? m.title : "That action was not delivered";
+    notifyShell("undelivered", copy ? title + ": " + copy : title, typeof m.sid === "string" ? m.sid : "");
+    showConfirm(title, m.text,
                 copy ? [{ label: "Copy my text", value: "copy" }, { label: "Dismiss", value: "ok" }]
                      : [{ label: "Dismiss", value: "ok" }],
                 (v) => { if (v === "copy") navigator.clipboard?.writeText(copy); });

--- a/ui/webview/undelivered-err.test.ts
+++ b/ui/webview/undelivered-err.test.ts
@@ -16,7 +16,8 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("chat: an `err` takes the confirm MODAL, not the warn toast", () => {
   assert.match(RENDER, /else if \(m\.type === "err" && typeof m\.text === "string" && m\.text\) \{/);
-  assert.match(RENDER, /showConfirm\(typeof m\.title === "string" && m\.title \? m\.title : "That action was not delivered", m\.text,/);
+  assert.match(RENDER, /const title = typeof m\.title === "string" && m\.title \? m\.title : "That action was not delivered";/);
+  assert.match(RENDER, /showConfirm\(title, m\.text,/);
   // the fading toast stays for the soft cases it was written for
   assert.match(RENDER, /m\.type === "warn" && typeof m\.text === "string" && m\.text\) warnToast\(m\.text\);/);
 });
@@ -34,7 +35,8 @@ test("feed: the pane that fires card ops gets an error dialog of its own", () =>
   assert.doesNotMatch(FEED, /m\.type === "warn"/);
   assert.match(FEED, /function showErrDialog\(title: string, text: string, copy: string\)/);
   assert.match(FEED, /\} else if \(m\.type === "err" && typeof m\.text === "string" && m\.text\) \{/);
-  assert.match(FEED, /showErrDialog\(typeof m\.title === "string" && m\.title \? m\.title : "That action was not delivered",/);
+  assert.match(FEED, /const title = typeof m\.title === "string" && m\.title \? m\.title : "That action was not delivered";/);
+  assert.match(FEED, /showErrDialog\(title, m\.text, copy\);/);
 });
 
 test("feed: the dialog reuses the resume-picker chrome rather than inventing another look", () => {
@@ -53,4 +55,27 @@ test("feed: the dialog reuses the resume-picker chrome rather than inventing ano
 test("feed: copying acknowledges the click, per the always-acknowledge rule", () => {
   const dlg = FEED.split("function showErrDialog(")[1].split("\n}")[0];
   assert.match(dlg, /c\.onclick = \(\) => \{ navigator\.clipboard\?\.writeText\(copy\); c\.textContent = "Copied"; \};/);
+});
+
+// …and it is also FILED, not just flashed (the user 2026-07-29). romp's error center — the bell in the
+// shell's bottom bar, opening a newest-first panel with per-kind filters — is where a problem is findable
+// after the fact. A dismissed modal must not erase the fact that a message never landed, so `err` writes an
+// entry there too, through the same {romp:'notify'} bridge the card-badge mirror uses.
+test("both panes file the refusal in the error center, not only in the modal", () => {
+  assert.match(RENDER, /notifyShell\("undelivered", copy \? title \+ ": " \+ copy : title, typeof m\.sid === "string" \? m\.sid : ""\);/);
+  assert.match(FEED, /window\.parent\?\.postMessage\(\{ romp: "notify", kind: "undelivered",/);
+  // the entry carries the text and the session, so the log answers "what did I lose, and where to?"
+  assert.match(FEED, /text: copy \? title \+ ": " \+ copy : title,/);
+  assert.match(FEED, /sid: typeof m\.sid === "string" \? m\.sid : "" \}, "\*"\);/);
+});
+
+test("the error center knows the new kind: chip label, description and filter toggle", () => {
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  // KINDS drives the filter row, KINDLBL the chip, DESC the tooltip — a kind missing from any of the three
+  // renders as an unlabelled entry with no way to mute it
+  assert.match(KERNEL, /var KINDS=\[[^\]]*'undelivered'\]/);
+  assert.match(KERNEL, /undelivered:'not sent'/);
+  assert.match(KERNEL, /undelivered:"something you sent never reached a session/);
+  // and it wears the follow-up-failed red: both mean a message of yours didn't land
+  assert.match(KERNEL, /\.rerr-chip\.k-nudge,\.rerr-chip\.k-undelivered\{color:#ff6a6a/);
 });


### PR DESCRIPTION
Follow-on to #118. That PR gave an undeliverable op a modal and a jsonl, but stopped there on the mistaken belief that romp had no general error surface. It does — the bell in the shell's bottom bar, opening a newest-first panel with per-kind chips, filters and per-row clear. That is exactly where a problem is meant to be findable after the fact, and a dismissed modal left nothing behind.

## Change

`err` now files an entry there too, through the same `{romp:'notify'}` bridge the card-badge mirror uses — from **both** panes, since either can fire a card op. The modal interrupts; the bell keeps it.

The new kind is `undelivered`, chip **"not sent"**, riding the follow-up-failed red: both mean a message of yours didn't land, and this one is the harder loss (nothing was delivered at all). It joins `KINDS` / `KINDLBL` / `DESC` together — a kind missing from any of the three renders as an unlabelled entry with no way to mute it.

The entry carries the text and the `sid` the op was addressed to, so the log answers both "what did I lose" and "where was it going" — the same reason card-badge entries carry their sid.

## Tests

- `test_error_center.py` drives the real panel headlessly: the filter bar is now 12 toggles ending in "not sent", and the chip colour rule is pinned.
- `undelivered-err.test.ts`: both panes file the entry with text + sid, and the kind is complete across all three tables.

Green: 3543 Python, 1432 node, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)