### PR TITLE
Held mail shows its route, and the rail names each host's drift

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12530,6 +12530,10 @@ def build_feed(now, tmux=None):
             "clearNotices": _boundary_clear_notices(alive),
             # SDK-backend failures → the same bell, one entry per occurrence (the user 2026-07-28)
             "sdkNotices": _sdk_problem_rows(),
+            # This machine's own name, so a card can say which SIDE of a federated exchange it is (the
+            # user 2026-07-29: held mail should read sender-host:session -> recipient-host:session). A
+            # local sid carries no host prefix, so the receiving end has no other way to name itself.
+            "selfHost": _self_host(),
             "canUndoClear": len(cleared) > 0}
 
 
@@ -16036,7 +16040,14 @@ starting:'The ssh tunnel is up; waiting for the remote kernel to answer on its p
 down:'The ssh tunnel is not up. romp keeps retrying on its own, waiting longer between tries the longer it stays down, so a machine that comes back is picked up without you doing anything. Try now dials immediately.',
 error:'The connection failed. Hover the status text for the reason romp got back. romp keeps retrying in the background.'};
 var _timer;function schedule(ms){clearTimeout(_timer);_timer=setTimeout(refresh,ms);}
-function busyStatus(s){return s!=='up'&&s!=='down'&&s!=='error'&&s!=='no-kernel';}   // mid-attach (authorizing/connecting); no-kernel is SETTLED (no marching dashes)
+function busyStatus(s){return s!=='up'&&s!=='down'&&s!=='error'&&s!=='no-kernel';}
+// HOW a host's build differs from this machine's, in words. ONE definition, worn by the panel row and
+// by the rail's hover (the user 2026-07-29, who wanted the count without opening the panel) — two
+// spellings of the same drift would eventually disagree, and the number is the whole point of it.
+function driftWord(t){var bb=t.behindBy,ab=t.aheadBy;
+if(typeof bb!=='number'||typeof ab!=='number')return 'different build';
+return (bb>0&&ab>0)?'diverged':(ab>0)?'ahead '+ab+' commit'+(ab===1?'':'s')
+:(bb>0)?'behind '+bb+' commit'+(bb===1?'':'s'):'different build';}   // mid-attach (authorizing/connecting); no-kernel is SETTLED (no marching dashes)
 // the mobile bottom bar's Net button mirrors the rail icon's connected/busy classes (it shows the same glyph)
 function mnet(){return document.querySelector('#mtabs .mact[data-act=net]');}
 // One host's contribution to the glyph (the user 2026-07-29): 'ok' connected and on this build, 'warn'
@@ -16080,7 +16091,8 @@ var _head=!ts.length?'':(_bad?(_bad+' host'+(_bad===1?'':'s')+' need'+(_bad===1?
 :(_wt?(_wt+' host'+(_wt===1?'':'s')+' disconnected (romp is retrying)'):'all hosts connected and in sync'));
 icon.title=ts.length?('Remote kernels \\u00b7 '+_head+'\\n'+ts.map(function(t){var n=(t.sids&&t.sids.length)||0;
 var ap=t.autoPush?('\\n    auto-update: '+(t.autoPush.detail||t.autoPush.phase)):'';
-return '\\u2022 '+t.host+': '+(LBL[t.status]||t.status)+' ('+n+' session'+(n===1?'':'s')+')'+(t.token?'':' \\u00b7 no token')+ap;}).join('\\n')):'Remote kernels \\u2014 none attached (click to connect)';
+var dw=t.outOfDate?(' \\u00b7 '+(t.status==='up'?'':'last known ')+driftWord(t)):'';
+return '\\u2022 '+t.host+': '+(LBL[t.status]||t.status)+' ('+n+' session'+(n===1?'':'s')+')'+dw+(t.token?'':' \\u00b7 no token')+ap;}).join('\\n')):'Remote kernels \\u2014 none attached (click to connect)';
 if(!back.hidden)render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[],(d&&d.remoteHolds)||[],(d&&d.peerTiers)||{});   // pmode is refresh-local — render must be GIVEN it
 // while any tunnel is mid-attach, poll fast so the phase words (authorizing -> connecting -> connected)
 // are actually visible in the couple seconds it takes; settle to a slow keep-alive once all up/down.
@@ -16136,9 +16148,7 @@ var stl=!!t.stale;
 var sw=stl?(t.lastOk?('last confirmed '+new Date(t.lastOk*1000).toLocaleTimeString()):'never confirmed since this kernel started'):'';
 var sq=stl?(' \\u2014 '+sw+'; not re-checked while '+(LBL[t.status]||t.status)+'.'):'';
 var ver='';
-if(t.outOfDate){var bb=t.behindBy,ab=t.aheadBy,w='different build';
-if(typeof bb==='number'&&typeof ab==='number'){
-w=(bb>0&&ab>0)?'diverged':(ab>0)?'ahead '+ab+' commit'+(ab===1?'':'s'):(bb>0)?'behind '+bb+' commit'+(bb===1?'':'s'):w;}
+if(t.outOfDate){var w=driftWord(t);
 var tt='running '+(t.kernelSha||'?')+(t.kernelDate?' from '+t.kernelDate:'')+'; this machine is at '+(t.localSha||'?')+(w==='diverged'?' (each has commits the other lacks)':'')
 +(t.checkinPeer?(t.askPull?' No ssh path from this machine (it checked in over its own tunnel), so Update asks it to fast-forward itself over the link it holds.':' No ssh path from this machine (it checked in over its own tunnel) \\u2014 sync from its own dashboard.'):'');
 ver=' \\u00b7 <span class=\"rnet-old'+(stl?' rnet-stale':'')+'\" title=\"'+tt+sq+'\">'+(stl?'last known: ':'')+w+'</span>';}

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -127,6 +127,18 @@ class PaneRailTest(unittest.TestCase):
         # drew visibly smaller than the 17-18px svg icons beside it, so the row looked ragged.
         self.assertIn("#rail-gear{font-size:19px}", self.html)
 
+    def test_the_rail_hover_names_each_host_s_drift_without_opening_the_panel(self):
+        # the red node says SOMETHING is out of step; the hover says what, by how much, and for which
+        # host (the user 2026-07-29). ONE definition of the wording, worn by the panel row and the
+        # tooltip alike — two spellings of the same drift would eventually disagree.
+        self.assertIn("function driftWord(t){", self.html)
+        self.assertIn("'behind '+bb+' commit'", self.html)
+        self.assertIn("'ahead '+ab+' commit'", self.html)
+        self.assertIn("var dw=t.outOfDate?(' \\u00b7 '+(t.status==='up'?'':'last known ')+driftWord(t)):''", self.html)
+        self.assertIn("+dw+", self.html, "the per-host tooltip line carries it")
+        # the panel row reads the same function rather than re-deriving the words
+        self.assertIn("if(t.outOfDate){var w=driftWord(t);", self.html)
+
     def test_network_icon_lights_accent_when_a_remote_is_connected(self):
         # the remote-kernels icon goes accent-blue (.on) while a tunnel is up, driven by the /tunnels poll
         self.assertIn("id=rail-net", self.html)

--- a/tests/test_kernel_trust.py
+++ b/tests/test_kernel_trust.py
@@ -191,6 +191,23 @@ class QuarantineCards(unittest.TestCase):
         self.assertTrue(gist.startswith("ship the parser fix"), gist)
         self.assertEqual(len(gist), 90, "whitespace-collapsed and clamped like the federation gossip gist")
 
+    def test_the_card_carries_both_ENDS_of_the_delivery(self):
+        """The route the card draws (the user 2026-07-29): sender host + session, recipient session, and
+        the recipient's host, which for a locally-held message is THIS machine — a local sid has no host
+        prefix, so the payload has to name it or the receiving end cannot be named at all."""
+        self._write_held("qc-5")
+        c = km._quarantine_cards(2000, set())[0]
+        b = c["blocked"]
+        for k in ("origin", "frm", "to", "body", "gist"):
+            self.assertIn(k, b, "the card names %s" % k)
+        self.assertTrue(b["origin"], "the sending HOST")
+        self.assertTrue(b["frm"], "the sending SESSION")
+        self.assertEqual(c["name"], b["to"], "the card sits under the recipient session")
+
+    def test_the_feed_payload_names_this_machine(self):
+        import inspect
+        self.assertIn('"selfHost": _self_host(),', inspect.getsource(km.build_feed))
+
     def test_cleared_card_is_hidden(self):
         self._write_held("qc-2")
         self.assertEqual(km._quarantine_cards(2000, {"quarantine:qc-2"}), [])

--- a/ui/webview/feed-quarantine.test.ts
+++ b/ui/webview/feed-quarantine.test.ts
@@ -20,10 +20,16 @@ test("the quarantine card is compact: Approve/Deny buttons + a one-line sender/g
   assert.match(FEED, /const qApprove = el\("button", "fdismiss fq fq-ok"\)[\s\S]*?qApprove\.textContent = "Approve"/);
   assert.match(FEED, /const qDeny = el\("button", "fdismiss fq fq-no"\)[\s\S]*?qDeny\.textContent = "Deny"/);
   assert.doesNotMatch(FEED, /qEdit/, "editing was cut from the flow (the user 2026-07-26)");
-  // the body line is a dim one-liner (sender + gist), click-through to the decision dialog
+  // the body is the ROUTE then the gist (the user 2026-07-29): host:session -> host:session, hosts as
+  // quiet metadata, session names in their identity colours, click-through to the decision dialog
   assert.match(FEED, /const qbody = el\("div", "fask-qbody"\)/);
-  assert.match(FEED, /qBody\.textContent = `from \$\{sender\} — \$\{it\.blocked\.gist \|\| it\.blocked\.body \|\| ""\}`/);
-  assert.match(FEED, /qBody\.onclick = [\s\S]*?showQuarantineDialog\(sender, it\.blocked!\.to \|\| "\?", it\.blocked!\.body \|\| "", decide, false\)/);
+  assert.match(FEED, /qBody\.replaceChildren\(\s*\n\s*quarWho\(it\.blocked\.origin \|\| "", it\.blocked\.frm \|\| "\?"\),/);
+  assert.match(FEED, /Object\.assign\(el\("span", "fq-arrow"\), \{ textContent: "\\u2192" \}\)/);
+  assert.match(FEED, /quarWho\(toHost, it\.blocked\.to \|\| it\.name \|\| "\?", it\.color\?\.bg\)/);
+  assert.match(FEED, /Object\.assign\(el\("div", "fq-gist"\), \{ textContent: it\.blocked\.gist \|\| it\.blocked\.body \|\| "" \}\)/);
+  // the recipient's host: this card's own kernel — a remote card's sid prefix, else this machine's name
+  assert.match(FEED, /const toHost = \(it\.sid && it\.sid\.indexOf\(":"\) > 0\) \? it\.sid\.slice\(0, it\.sid\.indexOf\(":"\)\) : feedSelfHost;/);
+  assert.match(FEED, /qBody\.onclick = [\s\S]*?showQuarantineDialog\(\.\.\.ends\(\), it\.blocked!\.body \|\| "", decide, false\)/);
   assert.match(FEED, /a\._qApprove = qApprove; a\._qDeny = qDeny; a\._qBody = qbody;/);
 });
 
@@ -39,7 +45,7 @@ test("the decision carries the card's sid so a remote hold's verdict reaches the
   assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "quarantineDecision", mid, action, text, sid: it\.sid, feedback \}\)/);
   assert.match(FEED, /a\._qApprove\.onclick = [\s\S]*?decide\("approve", "Delivering…", it\.blocked!\.body \|\| ""\)/);
   // the card's Deny goes through the dialog's feedback step, never a blind drop
-  assert.match(FEED, /a\._qDeny\.onclick = [\s\S]*?showQuarantineDialog\(sender, it\.blocked!\.to \|\| "\?", it\.blocked!\.body \|\| "", decide, true\)/);
+  assert.match(FEED, /a\._qDeny\.onclick = [\s\S]*?showQuarantineDialog\(\.\.\.ends\(\), it\.blocked!\.body \|\| "", decide, true\)/);
 });
 
 test("the decision dialog: read-only body, Approve/Deny, deny step offers a note to the sender", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -661,15 +661,21 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fdismiss.fq-ok:hover:not(:disabled) { color: var(--accent-fg); background: var(--accent); border-color: var(--accent); }
 .fdismiss.fq-no { color: #e5484d; border-color: rgba(229, 72, 77, 0.6); }
 .fdismiss.fq-no:hover:not(:disabled) { color: #fff; background: #e5484d; border-color: #e5484d; }
-/* Compact quarantine line (the user 2026-07-26): one dim sender+gist line, click opens the decision
-   modal — the full body never renders on the card. */
+/* Compact quarantine line (the user 2026-07-26; given its route 2026-07-29): line one is WHO to WHO —
+   host:session -> host:session, hosts as quiet metadata, session names in their identity colours — and
+   line two is the gist. Click opens the decision modal; the full body never renders on the card. */
 .fask-qbody {
   display: block; width: 100%; box-sizing: border-box; margin: 4px 0 2px;
   font: inherit; font-size: 12px; line-height: 1.45;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   color: var(--dim); cursor: pointer;
 }
-.fask-qbody:hover { color: #dfe7ee; }
+.fask-qbody:hover .fq-gist { color: #dfe7ee; }
+.fq-who { white-space: nowrap; }
+.fq-name { font-weight: 600; }               /* the identity colour rides an inline style */
+.fq-arrow { margin: 0 6px; opacity: 0.6; }
+.fq-gist {                                    /* one line, whatever the message length */
+  margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--dim);
+}
 /* The quarantine decision dialog rides the pickdlg overlay/box; the body is READ-ONLY (.qdlg-view);
    the textarea appears only on the deny step, for the optional note back to the sender. */
 .qdlg-box { width: min(640px, 96%); }
@@ -901,6 +907,10 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   box-shadow: 0 10px 36px rgba(0, 0, 0, 0.55);
 }
 .pickdlg-title { font-weight: 700; color: var(--vscode-foreground, #ccc); margin-bottom: 4px; }
+/* the quarantine dialog's title IS the card's route line, so opening a held message never re-words who
+   it is between: "New message" then host:session -> host:session, same colours (the user 2026-07-29) */
+.qdlg-lead { margin-right: 8px; }
+.pickdlg-title .fq-name { font-weight: 700; }
 /* the err dialog's body sentence — the resume-picker dialog is all buttons, so its box carried no prose style */
 .pickdlg-detail { color: var(--vscode-descriptionForeground, #999); margin-bottom: 10px; line-height: 1.45; }
 .pickdlg-opt {

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -9,7 +9,7 @@
 import { distillText, distillInputs, applyDistillLine, distillPending } from "./distiller-line";
 import { spinFor } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
-import { hostNameNodes, hostPartsNodes } from "./host-prefix";
+import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
 import { provenanceRows, provenanceGroupRows, rootStart, type ProvFmt, type ProvRow } from "./provenance";
 import { ageColorReadable } from "./age-color";
@@ -406,6 +406,12 @@ let sessionOrder: string[] = [];
 // names of sessions currently WORKING → a working dot before that name everywhere
 // it renders (card titles, modal title, group name). Pushed in each feed message.
 let workingSet = new Set<string>();
+// This machine's own name (kernel _self_host, on every feed payload) and the identity colour of every
+// session the feed knows, keyed "host:name" for a remote one and plain for a local one. Held mail names
+// BOTH ends of the exchange, and a session's colour is its identity everywhere else, so the card has to
+// be able to look one up by name — the quarantine record carries names, not sids (the user 2026-07-29).
+let feedSelfHost = "";
+const sessionColors = new Map<string, string>();
 // session name -> live background-process descriptions the JUDGE classified as services (kernel bgServices:
 // a dev server the session keeps around — nobody waits on it, so it is session furniture, not a status).
 // Rendered as a neutral chip on the grouped-mode session header; flat mode has no headers (the chat view's
@@ -1541,8 +1547,17 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   for (const b of [a._qApprove, a._qDeny] as HTMLButtonElement[]) b.style.display = isQuar ? "" : "none";
   if (isQuar && it.blocked) {
     const mid = it.blocked.mid || "";
-    const sender = `${it.blocked.origin || "?"}:${it.blocked.frm || "?"}`;
-    qBody.textContent = `from ${sender} — ${it.blocked.gist || it.blocked.body || ""}`;
+    // WHO to WHO, then what it says (the user 2026-07-29). Held mail is a delivery between two named
+    // sessions on two named machines, and the card used to render that as one grey run of text with the
+    // recipient missing entirely — you could not tell which of your sessions was about to receive it.
+    // Hosts stay quiet metadata (the same .host-prefix every surface uses), session names wear their
+    // identity colours, and the gist gets its own line under the route.
+    const toHost = (it.sid && it.sid.indexOf(":") > 0) ? it.sid.slice(0, it.sid.indexOf(":")) : feedSelfHost;
+    qBody.replaceChildren(
+      quarWho(it.blocked.origin || "", it.blocked.frm || "?"),
+      Object.assign(el("span", "fq-arrow"), { textContent: "\u2192" }),
+      quarWho(toHost, it.blocked.to || it.name || "?", it.color?.bg),
+      Object.assign(el("div", "fq-gist"), { textContent: it.blocked.gist || it.blocked.body || "" }));
     qBody.title = "click to read the whole message and decide";
     a._qApprove.disabled = false; a._qApprove.textContent = "Approve";
     a._qDeny.disabled = false; a._qDeny.textContent = "Deny";
@@ -1551,9 +1566,12 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
       for (const b of [a._qApprove, a._qDeny] as HTMLButtonElement[]) b.disabled = true;
       (action === "deny" ? a._qDeny : a._qApprove).textContent = busy;
     };
-    qBody.onclick = (ev: Event) => { ev.stopPropagation(); showQuarantineDialog(sender, it.blocked!.to || "?", it.blocked!.body || "", decide, false); };
+    const ends = (): [QuarEnd, QuarEnd] => [
+      { host: it.blocked!.origin || "", name: it.blocked!.frm || "?" },
+      { host: toHost, name: it.blocked!.to || it.name || "?", color: it.color?.bg }];
+    qBody.onclick = (ev: Event) => { ev.stopPropagation(); showQuarantineDialog(...ends(), it.blocked!.body || "", decide, false); };
     a._qApprove.onclick = (ev: Event) => { ev.stopPropagation(); decide("approve", "Delivering…", it.blocked!.body || ""); };
-    a._qDeny.onclick = (ev: Event) => { ev.stopPropagation(); showQuarantineDialog(sender, it.blocked!.to || "?", it.blocked!.body || "", decide, true); };
+    a._qDeny.onclick = (ev: Event) => { ev.stopPropagation(); showQuarantineDialog(...ends(), it.blocked!.body || "", decide, true); };
   }
   (a._clr as HTMLElement).style.display = isQuar ? "none" : "";
 
@@ -1595,6 +1613,26 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   r2.style.display = gmode && !r2live ? "none" : "";
 
   // (bg / summary / sub-goals are wired above in applySections — one mutually-exclusive selection.)
+}
+
+// One end of a held message's route: "host:" as quiet metadata, the session name in its identity
+// colour. The colour is looked up by the name a peer addresses (sessionColors, filled per payload) and
+// simply absent when that session has no cards here — an invented colour would be a lie about identity.
+// A host romp cannot currently reach wears the same struck mark its tabs and lanes do.
+function quarWho(host: string, name: string, known?: string): HTMLElement {
+  const who = el("span", "fq-who");
+  if (host) {
+    const h = el("span", "host-prefix");
+    h.textContent = host + ":";
+    if (hostIsDown(host + ":x")) { h.classList.add("off"); h.title = hostDownNote(host + ":x"); }
+    who.appendChild(h);
+  }
+  const n = el("span", "fq-name");
+  n.textContent = name;
+  const color = known || sessionColors.get(host ? host + ":" + name : name) || sessionColors.get(name);
+  if (color) n.style.color = color;
+  who.appendChild(n);
+  return who;
 }
 
 // Resolve a focus key (set on hoverAskId/pinnedAskId) to the itemId the timeline
@@ -3307,6 +3345,16 @@ window.addEventListener("message", (e: MessageEvent) => {
       for (const it of pendingRestored.values()) if (!present.has(it.itemId)) asks.push(it);
     }
     workingSet = new Set(Array.isArray(m.working) ? m.working : []);
+    if (typeof m.selfHost === "string" && m.selfHost) feedSelfHost = m.selfHost;
+    // Index every session's colour by the name a peer would address it by. Federation merges the hosts'
+    // payloads, so one pass over the merged asks covers the whole fleet; a card whose session has no
+    // cards of its own simply gets no colour, which is honest rather than invented.
+    for (const a of incomingAsks) {
+      if (!a.color || !a.name) continue;
+      sessionColors.set(a.name, a.color.bg);
+      const c = a.sid ? a.sid.indexOf(":") : -1;             // remote sid → also index the bare name under its host
+      if (c > 0 && !a.name.includes(":")) sessionColors.set(a.sid.slice(0, c) + ":" + a.name, a.color.bg);
+    }
     awaitingSet = new Set(Array.isArray(m.awaiting) ? m.awaiting : []);   // straw awaiting dots (the user 2026-07-13)
     bgServicesMap = m.bgServices && typeof m.bgServices === "object" ? m.bgServices : {};   // session name -> judge-classified service descs → the session-header chip (2026-07-24)
     if (Array.isArray(m.order)) sessionOrder = m.order.filter((x: any) => typeof x === "string");   // grouped-mode session rank (tab/lane order)
@@ -3389,14 +3437,23 @@ window.addEventListener("message", (e: MessageEvent) => {
 // mails it to the origin host so the sender's agent learns why instead of waiting forever. Lives on
 // document.body OUTSIDE the re-rendered feed root, so a kernel push mid-decision can't eat the note.
 // `decide` is the owning card's decision closure — it carries the mid + sid and flips the card buttons.
-function showQuarantineDialog(sender: string, to: string, body: string,
+interface QuarEnd { host: string; name: string; color?: string }
+
+function showQuarantineDialog(from: QuarEnd, to: QuarEnd, body: string,
                               decide: (action: string, busy: string, text: string, feedback?: string) => void,
                               denyFirst: boolean) {
   document.getElementById("quar-dialog")?.remove();
   const overlay = el("div", "pickdlg-overlay"); overlay.id = "quar-dialog";
   const box = el("div", "pickdlg-box qdlg-box");
   const title = el("div", "pickdlg-title");
-  title.textContent = `New message from ${sender} to ${to}`;
+  // the SAME route the card shows, so opening the message doesn't re-word who it is between
+  const sender = `${from.host}:${from.name}`;
+  const route = () => title.replaceChildren(
+    Object.assign(el("span", "qdlg-lead"), { textContent: "New message" }),
+    quarWho(from.host, from.name, from.color),
+    Object.assign(el("span", "fq-arrow"), { textContent: "\u2192" }),
+    quarWho(to.host, to.name, to.color));
+  route();
   const view = el("div", "qdlg-view");
   view.textContent = body;
   const row = el("div", "qdlg-actions");
@@ -3406,7 +3463,7 @@ function showQuarantineDialog(sender: string, to: string, body: string,
   // catch something malicious). Clicking the backdrop still closes without deciding; the message
   // stays held either way.
   const denyStep = () => {
-    title.textContent = `Deny the message from ${sender} — send a note back?`;
+    title.replaceChildren(document.createTextNode(`Deny the message from ${sender}. Send a note back?`));
     const ta = el("textarea", "qdlg-text qdlg-feedback") as HTMLTextAreaElement;
     ta.placeholder = "optional: tell the sender why (delivered to them as postal mail)";
     row.replaceChildren();

--- a/ui/webview/quarantine-route.test.ts
+++ b/ui/webview/quarantine-route.test.ts
@@ -1,0 +1,73 @@
+// Held mail names BOTH ends of the exchange (the user 2026-07-29). The card used to read "from
+// HOST:session — <gist>" in one grey run, with the recipient missing entirely, so you could not tell
+// which of your sessions was about to receive the message. It now renders the route the way every other
+// surface renders a federated name: "host:" as quiet metadata, the session name in its identity colour,
+// an arrow between the two, and the gist on its own line. The decision dialog wears the same header, so
+// opening a message never re-words who it is between. Source-pinned (no jsdom for the feed renderer).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const FEED = fs.readFileSync(path.join(UI, "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.join(UI, "feed.css"), "utf8");
+
+test("one end of the route: quiet host, identity-coloured session name", () => {
+  assert.match(FEED, /function quarWho\(host: string, name: string, known\?: string\): HTMLElement/);
+  assert.match(FEED, /const h = el\("span", "host-prefix"\);/, "the SAME class every surface uses");
+  assert.match(FEED, /const n = el\("span", "fq-name"\);/);
+  assert.match(FEED, /n\.style\.color = color/);
+});
+
+test("the colour is looked up, never invented", () => {
+  // a session with no cards here has no known colour; leaving it uncoloured is honest, and a made-up
+  // one would be a lie about identity — colours ARE how sessions are told apart everywhere else
+  assert.match(FEED, /const color = known \|\| sessionColors\.get\(host \? host \+ ":" \+ name : name\) \|\| sessionColors\.get\(name\)/);
+  assert.match(FEED, /if \(color\) n\.style\.color = color/, "no colour → no style, not a default");
+});
+
+test("the colour index is built from the merged payload, keyed the way a peer addresses a session", () => {
+  assert.match(FEED, /const sessionColors = new Map<string, string>\(\)/);
+  assert.match(FEED, /sessionColors\.set\(a\.name, a\.color\.bg\)/);
+  assert.match(FEED, /sessionColors\.set\(a\.sid\.slice\(0, c\) \+ ":" \+ a\.name, a\.color\.bg\)/,
+    "a remote session is also indexed under its host, which is how the sender is addressed");
+});
+
+test("the recipient's host comes from the card's own kernel, falling back to this machine", () => {
+  // a card built by a remote kernel arrives with a host-prefixed sid; a local one has none, and the
+  // kernel supplies this machine's name on the payload so the receiving end can still be named
+  assert.match(FEED, /const toHost = \(it\.sid && it\.sid\.indexOf\(":"\) > 0\) \? it\.sid\.slice\(0, it\.sid\.indexOf\(":"\)\) : feedSelfHost;/);
+  assert.match(FEED, /if \(typeof m\.selfHost === "string" && m\.selfHost\) feedSelfHost = m\.selfHost;/);
+});
+
+test("a host romp cannot reach wears the same struck mark its tabs and lanes do", () => {
+  assert.match(FEED, /if \(hostIsDown\(host \+ ":x"\)\) \{ h\.classList\.add\("off"\); h\.title = hostDownNote\(host \+ ":x"\); \}/);
+});
+
+test("the dialog header IS the card's route, with the same colours", () => {
+  assert.match(FEED, /interface QuarEnd \{ host: string; name: string; color\?: string \}/);
+  assert.match(FEED, /function showQuarantineDialog\(from: QuarEnd, to: QuarEnd, body: string,/);
+  assert.match(FEED, /const route = \(\) => title\.replaceChildren\(/);
+  assert.match(FEED, /quarWho\(from\.host, from\.name, from\.color\)/);
+  assert.match(FEED, /quarWho\(to\.host, to\.name, to\.color\)/);
+  // the deny step is a question, not a route — it says who is being denied in words
+  assert.match(FEED, /Deny the message from \$\{sender\}\. Send a note back\?/);
+});
+
+test("the full body still lives in the dialog only, and both openings reach it", () => {
+  assert.match(FEED, /const ends = \(\): \[QuarEnd, QuarEnd\] => \[/);
+  assert.match(FEED, /qBody\.onclick = [\s\S]*?showQuarantineDialog\(\.\.\.ends\(\)/, "clicking the line opens it");
+  assert.match(FEED, /a\._qDeny\.onclick = [\s\S]*?showQuarantineDialog\(\.\.\.ends\(\)/, "Deny goes through it too");
+  assert.match(FEED, /view\.textContent = body/, "the whole message renders only there");
+  assert.doesNotMatch(FEED, /qBody\.textContent = `from /, "the old one-run line is gone");
+});
+
+test("the route is two lines: who to who, then the gist, each on one line", () => {
+  assert.match(CSS, /\.fq-who \{ white-space: nowrap; \}/);
+  assert.match(CSS, /\.fq-name \{ font-weight: 600; \}/);
+  assert.match(CSS, /\.fq-arrow \{ margin: 0 6px; opacity: 0\.6; \}/);
+  assert.match(CSS, /\.fq-gist \{[\s\S]*?white-space: nowrap; overflow: hidden; text-overflow: ellipsis;/);
+  // the card itself no longer clips the route away with the gist's ellipsis
+  assert.doesNotMatch(CSS, /\.fask-qbody \{[^}]*white-space: nowrap/);
+});


### PR DESCRIPTION
**The quarantine card.** It read `from HOST:session — <gist>` in one grey run, with the recipient missing entirely, so you could not tell which of your sessions was about to receive the message.

It now draws the route the way every other surface draws a federated name: `host:session → host:session`, hosts as quiet `.host-prefix` metadata, session names in their identity colours, gist on its own line beneath.

- Colours are **looked up, never invented** — a session with no cards here goes uncoloured rather than getting a default, since a made-up colour would be a lie about identity. The index is keyed the way a peer addresses a session (`host:name`), because a held record carries names, not ids.
- The recipient's host comes from the card's own kernel: a remote card's sid prefix, else this machine, which the feed payload now names (`selfHost`) since a local sid has no prefix.
- A host romp cannot currently reach wears the same struck mark its tabs and lanes got in #115.
- The full body still lives only in the decision dialog, which now wears the same route as its header, so opening a message never re-words who it is between. Both ways in reach it: clicking the line, and Deny.

**The rail's network hover** now names each host's drift, so `behind 3 commits` no longer needs the panel opened. The wording became one function shared by the panel row and the tooltip; two spellings of the same drift would eventually disagree.

Tests: `ui/webview/quarantine-route.test.ts` (route rendering, the no-invented-colour rule, host resolution, the disconnected mark, the dialog header, the two-line layout), extended `tests/test_kernel_trust.py` (both ends on the card, `selfHost` on the payload) and `tests/test_kernel_pane_rail.py` (drift in the tooltip, one shared definition), plus updated quarantine pins. Both suites green (3546 python, 1438 node), tsc clean, card verified with a headless render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)