### PR TITLE
The new-session path field waits to be asked, and vets itself against the host

### DIFF
--- a/ui/webview/dir-complete.test.ts
+++ b/ui/webview/dir-complete.test.ts
@@ -9,6 +9,7 @@ import * as path from "node:path";
 import { dirStatusLine, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const STYLES = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 const st = (over: Partial<DirStatus>): DirStatus => ({
   value: "~/GitRepos/api", path: "~/GitRepos/api", exists: true, isDir: true, isFile: false,
@@ -102,4 +103,46 @@ test("Edit reopens the picker with what was typed, cursor in the path", () => {
 
 test("switching host re-asks: the folders on screen belong to the host that was selected", () => {
   assert.match(RENDER, /\/\/ the completions on screen belong to the host that just stopped being selected\s*\n\s*closeDirMenu\(\);/);
+});
+
+// ── round 2 (the user 2026-07-29) ────────────────────────────────────────────────────────────────
+// Three complaints, all about the field acting before it was asked to: the folder list dropped over
+// the dialog the moment the picker opened; the prefilled path was never vetted against the SERVER the
+// session would run on, so a path that cannot exist there only failed after pressing New; and this
+// machine's default was prefilled into a remote's field, where it is meaningless.
+
+test("opening the picker asks about the path but does NOT drop a folder list over the dialog", () => {
+  assert.match(RENDER, /if \(!dirItems\.length \|\| document\.activeElement !== input\) \{ menu\.style\.display = "none"; return; \}/);
+  assert.match(RENDER, /if \(di && !pick\) askDirComplete\(di\.value\);/, "the status is still fetched on open");
+});
+
+test("the field itself goes red for a path that cannot work, amber for one that isn't there yet", () => {
+  assert.match(RENDER, /box\.classList\.toggle\("bad", said\.cls === "bad"\)/);
+  assert.match(RENDER, /box\.classList\.toggle\("warn", said\.cls === "warn"\)/);
+  assert.match(STYLES, /\.picker-dir-input\.bad \{ border-color: #e5484d;/);
+  assert.match(STYLES, /\.picker-dir-input\.warn \{ border-color: #e0a030; \}/);
+});
+
+test("a path that cannot work refuses the create at the field, not after a round trip", () => {
+  assert.match(RENDER, /if \(dirStatus && dirStatus\.value === typed && !dirStatus\.isDir && !dirStatus\.canCreate && typed\)/,
+    "only when the kernel's answer is about what is typed RIGHT NOW");
+  assert.match(RENDER, /That path is a file, not a folder/);
+  assert.match(RENDER, /can't be reached on the selected host/);
+  // a missing-but-creatable path is NOT refused: that is the create-it-or-edit-it offer
+  assert.doesNotMatch(RENDER, /dirStatus\.canCreate \&\& typed\) \{\s*\n\s*pickerError\("That folder doesn't exist/);
+});
+
+test("each host remembers the directory you last started a session in there", () => {
+  assert.match(RENDER, /const DIR_BY_HOST_KEY = "romp:dirByHost"/);
+  assert.match(RENDER, /rememberDir\(req\.host, req\.dir\);/, "recorded when the create is sent");
+  assert.match(RENDER, /all\[host \|\| ""\] = d;/, "local is a host key too, so it keeps its own last path");
+});
+
+test("a remote's prefill is what you used THERE, never this machine's default", () => {
+  // the gear default is one path on this machine; prefilling it into a Linux box's field is a path
+  // that cannot exist there. Blank asks that kernel for its own default instead.
+  assert.match(RENDER, /return host \? "" : \(kernelDefaultDir \|\| loadSettings\(\)\.defaultDir \|\| ""\);/);
+  assert.match(RENDER, /if \(di\) di\.value = dirPrefill\(""\);/, "the open prefill goes through it");
+  assert.match(RENDER, /if \(dirIn\) \{ dirIn\.value = dirPrefill\(h\); askDirComplete\(dirIn\.value\); \}/,
+    "switching host swaps the path AND re-vets it against that host");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3789,6 +3789,37 @@ let dirItems: DirItem[] = [];
 let dirActive = -1;                   // highlighted completion row (-1 = none; Enter then creates)
 let dirStatus: DirStatus | null = null;
 
+// The last directory a session was actually started in, per host (the user 2026-07-29). The gear's
+// "Default directory" is ONE path on THIS machine, so it is the wrong answer for a remote: prefilling a
+// Mac's ~/GitRepos into a Linux box's field is a path that cannot exist there. What you used last on
+// that machine is the answer that is right by construction, and it overrides the gear default for that
+// host. With nothing remembered, a remote is left BLANK, which asks that kernel for its own default —
+// the honest fallback, since only that machine knows where its romp lives.
+const DIR_BY_HOST_KEY = "romp:dirByHost";
+
+function dirByHost(): Record<string, string> {
+  try {
+    const v = JSON.parse(localStorage.getItem(DIR_BY_HOST_KEY) || "{}");
+    return v && typeof v === "object" ? v : {};
+  } catch { return {}; }
+}
+
+function rememberDir(host: string, dir: string): void {
+  const d = (dir || "").trim();
+  if (!d) return;
+  const all = dirByHost();
+  all[host || ""] = d;
+  try { localStorage.setItem(DIR_BY_HOST_KEY, JSON.stringify(all)); } catch { /* storage full */ }
+}
+
+/** What the directory field should start with for `host`: what you last used there, else (local only)
+ *  the gear/kernel default, else blank so that kernel answers with its own. */
+function dirPrefill(host: string): string {
+  const remembered = dirByHost()[host || ""];
+  if (remembered) return remembered;
+  return host ? "" : (kernelDefaultDir || loadSettings().defaultDir || "");
+}
+
 function pickerHost(): string {
   const sel = document.querySelector("#picker .picker-host .picker-be-opt.sel") as HTMLElement | null;
   return sel?.dataset.host || "";
@@ -3827,15 +3858,27 @@ function closeDirMenu(): void {
 // deeper level, and it only exists while there is something to choose.
 function renderDirMenu(truncated: boolean): void {
   const line = document.getElementById("picker-dir-status");
+  const said = dirStatusLine(dirStatus);
   if (line) {
-    const said = dirStatusLine(dirStatus);
     line.className = "picker-dir-status" + (said.cls ? " " + said.cls : "");
     line.textContent = said.text;
   }
+  // and the FIELD itself carries it (the user 2026-07-29): a path that cannot work goes red where the
+  // path is, not only in a line under it, so the problem is visible without reading anything.
+  const box = document.getElementById("picker-dir");
+  if (box) {
+    box.classList.toggle("bad", said.cls === "bad");
+    box.classList.toggle("warn", said.cls === "warn");
+  }
+  const input = document.getElementById("picker-dir");
   const menu = document.getElementById("picker-dir-menu");
   if (!menu) return;
   menu.replaceChildren();
-  if (!dirItems.length) { menu.style.display = "none"; return; }
+  // Only when you are IN the field (the user 2026-07-29): opening the + picker asks the kernel about the
+  // prefilled path so the status line can vet it straight away, and that answer used to drop a folder
+  // list over the dialog before anyone had touched it. The status is the passive half; the menu is the
+  // half you asked for by putting the cursor there.
+  if (!dirItems.length || document.activeElement !== input) { menu.style.display = "none"; return; }
   dirItems.forEach((it, i) => {
     const row = el("div", "picker-dir-row" + (i === dirActive ? " active" : ""));
     row.textContent = it.name;
@@ -3910,6 +3953,7 @@ let lastCreate: CreateReq | null = null;
 
 function startCreate(req: CreateReq, mkdir = false): void {
   lastCreate = req;
+  rememberDir(req.host, req.dir);   // what you used on that machine is the right prefill for it next time
   if (vscodeApi) vscodeApi.postMessage({ type: "createSession", ...req, ...(mkdir ? { mkdir: true } : {}) });
   closePicker();
   // a remote session's tab arrives host-prefixed — register the prefixed name so the cue dismisses
@@ -4006,6 +4050,17 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       const name = search.value.trim();
       if (!name) { pickerError("Type the new session's name in the box above first."); search.focus(); return; }
       if (!/^[A-Za-z0-9._-]+$/.test(name)) { pickerError("Session names: letters, digits, . _ - only."); search.focus(); return; }
+      // A path that CANNOT work stops the create here, where the field is, instead of after a round trip
+      // (the user 2026-07-29). Only when the kernel's answer is about what is typed RIGHT NOW: a reply
+      // for older text is not evidence about this one, and the kernel re-validates anyway. A missing but
+      // creatable directory is not refused — that is the "create it or edit it" offer, deliberately.
+      const typed = dirInput.value.trim();
+      if (dirStatus && dirStatus.value === typed && !dirStatus.isDir && !dirStatus.canCreate && typed) {
+        pickerError(dirStatus.isFile ? "That path is a file, not a folder. Pick a folder for the session."
+                                     : "That folder can't be reached on the selected host. Pick another path.");
+        dirInput.focus(); dirInput.select();
+        return;
+      }
       // backend: this picker's toggle (defaults to the gear's "Default backend", overridable per session)
       const beSel = beWrap.querySelector(".picker-be-opt.sel") as HTMLElement | null;
       // host: local ("") or an attached SSH host — the federation manager routes createSession there.
@@ -4065,7 +4120,10 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
         if (dirIn) dirIn.placeholder = h ? `New-session directory on ${h} (blank = its default)` : "New-session directory (blank = default)";
         // the completions on screen belong to the host that just stopped being selected
         closeDirMenu();
-        if (dirIn) askDirComplete(dirIn.value);
+        // …and so does the PATH: this machine's default is meaningless on another box. Swap in what was
+        // last used there (blank asks that kernel for its own default) and re-vet it against that host,
+        // so a path that cannot exist there says so before anything is created (the user 2026-07-29).
+        if (dirIn) { dirIn.value = dirPrefill(h); askDirComplete(dirIn.value); }
       });
       hostWrapEl.appendChild(b);
     }
@@ -4073,7 +4131,9 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     if (browse0) browse0.disabled = false;   // fresh open defaults back to local
   }
   const di = document.getElementById("picker-dir") as HTMLInputElement | null;
-  if (di) di.value = kernelDefaultDir || loadSettings().defaultDir || "";   // the kernel's persisted default (file→env) wins; localStorage is a same-tab cache
+  // the host row resets to local on every open, so this is the local prefill: what you last used here,
+  // else the kernel's persisted default (file→env; localStorage is a same-tab cache)
+  if (di) di.value = dirPrefill("");
   closeDirMenu();                       // a previous open's folder list is not this one's
   if (di && !pick) askDirComplete(di.value);   // the status line says what the prefilled path is, before anything is typed
   // In a filtered view (#only=<tag>), a new session created here would vanish from the view unless its name

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1686,6 +1686,12 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
   padding: 5px 8px; outline: none;
 }
 .picker-dir-input:focus { border-color: var(--vscode-focusBorder, #4daafc); }
+/* the field carries the verdict too (the user 2026-07-29): red for a path that cannot work on the
+   selected host — the create refuses while it stands — amber for one that does not exist yet, which is
+   an offer to make it, not an error. These sit after :focus and beat it, on purpose: a path that cannot
+   work should read that way while you are standing in the field fixing it. */
+.picker-dir-input.bad { border-color: #e5484d; background: rgba(229, 72, 77, 0.07); }
+.picker-dir-input.warn { border-color: #e0a030; }
 .picker-dir-input::placeholder { color: var(--dim); }
 .picker-browse {
   flex: 0 0 auto; cursor: pointer; white-space: nowrap;


### PR DESCRIPTION
Three complaints about the directory field, all of it acting before it was asked to.

- **The folder list dropped over the dialog on open.** Opening the picker still asks the kernel about the prefilled path — that is what vets it — but the list only appears once the cursor is in the field.
- **A path that cannot work now says so where the path is.** The field goes red and the create refuses at the field, not after a round trip. It refuses only while the kernel's answer is about what is typed *right now* (a reply for older text is not evidence about this one, and the kernel re-validates anyway). A missing-but-creatable folder is deliberately not refused — that is the create-it-or-edit-it offer — and its field is amber.
- **The prefill is per host.** The gear's "Default directory" is one path on *this* machine, so prefilling it into a remote's field is a path that cannot exist there. Each host now remembers the directory a session was last started in on it, and that wins for that host; with nothing remembered a remote starts blank, which asks that kernel for its own default. Switching host swaps the path and re-vets it, so a bad path announces itself on the switch rather than on the create.

Tests: six cases appended to `ui/webview/dir-complete.test.ts`. Both suites green (3546 python, 1445 node), tsc clean, the three field states verified with a headless render.

Note: this is the first round of feedback on the path picker since the kernel restart that made its ops answer at all, which is why the host-side checking looked dead before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)