### PR TITLE
Two names for one port, and mail that can't be addressed to yourself

### DIFF
--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -30,7 +30,11 @@ const fs = require('fs');
 
 const HOST = '127.0.0.1';
 const CONTROL_PORT = Number(process.env.ROMP_MANAGER_PORT) || 7432;
-const KERNEL_PORT = Number(process.env.ROMP_SERVE_PORT) || 29855;
+// ROMP_SERVE_PORT and ROMP_KERNEL_PORT are two spellings of the primary kernel's listen port
+// (bin/romp-serve owns that seam). Accept either, so a profile renumbered with only the
+// documented ROMP_KERNEL_PORT doesn't leave the manager defaulting to 29855 and spawning a
+// kernel straight into the other instance's port.
+const KERNEL_PORT = Number(process.env.ROMP_SERVE_PORT) || Number(process.env.ROMP_KERNEL_PORT) || 29855;
 
 // The PRIMARY kernel's state root — where the aux-kernel registry file lives (plans/multi-kernel.md
 // phase 3). Aux kernels get their OWN roots via their spec's stateDir; the registry itself is the
@@ -124,7 +128,11 @@ function loadSpecs(file, mainPort, controlPort) {
 // bus) inherit them, so one env set at spawn scopes state, sessions, and mail per kernel.
 function specEnv(spec, base, ids) {
   const env = Object.assign({}, base, {
+    // BOTH spellings of the listen port, always overwritten together: `base` is the manager's own
+    // env, which may carry the PRIMARY kernel's ROMP_KERNEL_PORT, and an aux kernel inheriting
+    // that stale copy is how one profile's sessions end up talking to another profile's kernel.
     ROMP_SERVE_PORT: String(spec.port),
+    ROMP_KERNEL_PORT: String(spec.port),
     ROMP_MANAGER_PID: String(ids.managerPid),  // → kernel's parent-death watchdog
     ROMP_MANAGER_PORT: String(ids.controlPort),
   });

--- a/bin/romp-serve
+++ b/bin/romp-serve
@@ -25,8 +25,23 @@ ROMP_DIR="$(cd "$(dirname "$src")/.." && pwd)"
 # ROMP_KERNEL_BIN is the test seam (same pattern as ROMP_*_BIN elsewhere).
 KERNEL="${ROMP_KERNEL_BIN:-$ROMP_DIR/bin/romp-kernel}"
 
-# Port: the manager passes --port; fall back to ROMP_SERVE_PORT, then the kernel default.
-port="${ROMP_SERVE_PORT:-}"
+# Port: the manager passes --port; fall back to the env, then the kernel default.
+#
+# ROMP_SERVE_PORT and ROMP_KERNEL_PORT are TWO SPELLINGS OF ONE VALUE: the port the kernel
+# listens on. The split is historical and role-based, not semantic. ROMP_SERVE_PORT is the
+# service-facing spelling (romp-manager, romp-service's unit, the wake hook, the VS Code
+# extension); ROMP_KERNEL_PORT is the process-facing one (kernel.py, the postal bus, every
+# `romp` CLI verb). This script is the seam between them, so it is where they have to agree.
+#
+# It used to read only ROMP_SERVE_PORT and then unconditionally OVERWRITE ROMP_KERNEL_PORT
+# from it. Someone renumbering a second kernel by the documented knob alone (docs/reference.md
+# names ROMP_KERNEL_PORT and not the other) got the two silently pulled apart: the unit carried
+# no port, the manager fell back to the default, this script stamped that default over the
+# inherited ROMP_KERNEL_PORT, and the second kernel bound the FIRST one's port while every
+# foreground `romp` command went on printing the renumbered one. A collision that reports
+# success is the exact shape the authoritative-sources rule exists to prevent, so now: accept
+# either spelling, and if both are set and DISAGREE with no --port to settle it, refuse.
+port=""
 host=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -35,6 +50,16 @@ while [[ $# -gt 0 ]]; do
         *) shift ;;
     esac
 done
+if [[ -z "$port" ]]; then
+    _sp="${ROMP_SERVE_PORT:-}"
+    _kp="${ROMP_KERNEL_PORT:-}"
+    if [[ -n "$_sp" && -n "$_kp" && "$_sp" != "$_kp" ]]; then
+        echo "romp-serve: ROMP_SERVE_PORT=$_sp and ROMP_KERNEL_PORT=$_kp disagree." >&2
+        echo "  They are two names for the kernel's listen port and must match. Set one, or pass --port." >&2
+        exit 1
+    fi
+    port="${_sp:-$_kp}"
+fi
 
 # Host: explicit --host wins; else local-only. A leftover serve-host state file
 # from the removed `romp --serve` opt-in is deliberately IGNORED — a stale file
@@ -70,7 +95,14 @@ PY="$(pick_python)"
 # supervised kernel from popping a browser on every (re)spawn.
 export ROMP_DIR
 export ROMP_BIN="${ROMP_BIN:-$ROMP_DIR/bin/romp}"
-[[ -n "$port" ]] && export ROMP_KERNEL_PORT="$port"
+# Export BOTH spellings from the ONE resolved port, so nothing downstream can read a stale
+# inherited copy of the other name: the kernel and the postal bus read ROMP_KERNEL_PORT, while
+# the wake hook and any `romp` CLI run inside a session of this kernel may read either. Unset
+# stays unset (the kernel applies its own default), so a bare launch is unchanged.
+if [[ -n "$port" ]]; then
+    export ROMP_KERNEL_PORT="$port"
+    export ROMP_SERVE_PORT="$port"
+fi
 export ROMP_SERVE_HOST="$host"
 export ROMP_KERNEL_NO_OPEN=1
 exec "$PY" "$KERNEL"

--- a/bin/romp-service
+++ b/bin/romp-service
@@ -52,7 +52,13 @@ UNIT="$SYSTEMD_DIR/romp-manager.service"
 # with the CLI still reporting the configured port. Bake whatever is SET at install time, and
 # nothing that isn't, so a default single-user install writes the same unit it always did.
 # (Reinstall after changing one, exactly like PATH.)
-_INSTANCE_VARS=(ROMP_SERVE_PORT ROMP_POSTAL_PORT ROMP_MANAGER_PORT ROMP_STATE_DIR CLAUDE_CONFIG_DIR ROMP_TMUX_SOCKET)
+# ROMP_KERNEL_PORT is here because it is the SAME value as ROMP_SERVE_PORT under the other name
+# (bin/romp-serve owns that seam), and it is the spelling docs/reference.md tells people to set.
+# Leaving it out meant following the docs wrote a unit with NO port: the supervised manager came
+# up on the default, romp-serve stamped that default back over the inherited ROMP_KERNEL_PORT,
+# and a second OS user's kernel bound the primary's port while their CLI kept printing the
+# renumbered one. Exactly the failure the paragraph above describes, one variable further along.
+_INSTANCE_VARS=(ROMP_SERVE_PORT ROMP_KERNEL_PORT ROMP_POSTAL_PORT ROMP_MANAGER_PORT ROMP_STATE_DIR CLAUDE_CONFIG_DIR ROMP_TMUX_SOCKET)
 
 # The SET ones, formatted for the platform: $1 = plist (EnvironmentVariables dict pairs) or
 # unit (systemd Environment= lines). Each line is newline-TERMINATED; the callers decide what

--- a/claude/skills/romp-postal/SKILL.md
+++ b/claude/skills/romp-postal/SKILL.md
@@ -14,6 +14,8 @@ Message sibling sessions with the postal MCP tools (each tool's own description 
 
 Addressing is live-only: you can message only currently-live sessions (see `list_agents`). Dead names error, with no parked mail or reviving.
 
+Names are not guaranteed unique. If more than one live session answers to the one you used, the send is refused and the candidates are listed as `host:name`: pick one and resend. Your own name is refused outright, since a message there arrives in your own inbox looking exactly like a reply from someone else. Your row in `list_agents` is the one marked `(you)`.
+
 From the shell (also how the human drives it): `romp mail send <name> "<text>"`, `romp mail inbox|agents|sent`, `romp mail working "<note>"`, `romp mail recall <name> [id]`.
 
 ## On a remote machine

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -126,12 +126,19 @@ through to `install.sh`:
 ### Ports
 
 - `ROMP_KERNEL_PORT=<port>` moves the kernel and its dashboard off the default
-  `29855`.
+  `29855`. `ROMP_SERVE_PORT` is a second name for the same port, the one the
+  manager and the supervised service use. Set either and the other follows; set
+  both to different values and the kernel refuses to start rather than picking
+  one for you.
 - `ROMP_POSTAL_PORT=<port>` moves the postal bus off the default `25302`.
 
 Set these if something else on the machine already holds the default. Both have
 to agree across everything that talks to the kernel, so export them where the
 whole environment sees them rather than for one command.
+
+Run `romp-service install` again after changing one. The service unit bakes in
+whatever is set at install time, so a renumbered port that only lives in your
+shell leaves the supervised manager on the old one, and the two collide.
 
 ## Where things live
 

--- a/hooks/romp-wake.sh
+++ b/hooks/romp-wake.sh
@@ -17,7 +17,9 @@ set -uo pipefail
 # exist", and a wake is cheap + idempotent on the kernel side.
 cat >/dev/null 2>&1 || true
 
-port="${ROMP_SERVE_PORT:-29855}"
+# Either spelling of the kernel's listen port (bin/romp-serve owns that seam and exports both);
+# ROMP_SERVE_PORT first, so a session under an aux kernel keeps poking ITS kernel.
+port="${ROMP_SERVE_PORT:-${ROMP_KERNEL_PORT:-29855}}"
 # The kernel gates every request on the serve token, loopback included (Jupyter's model) — read it
 # the way the kernel resolves it: env override, else the 0600 state file. Missing token → the poke
 # 403s silently, same posture as no kernel at all (the 20s backstop covers it).

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -380,13 +380,19 @@ def _queue_read_receipt(meta, unread=False):
 # The HUMAN-FACING prose (banner text, headers, the "⏸ parked" tag, REPLY_HINT) is
 # NOT a contract — consumers must not parse it, so it stays free to change.
 
-def format_inbox(msgs):
+def format_inbox(msgs, me_id=""):
     if not msgs:
         return ""
     out = ["\U0001F4EC New message(s) from your romp peers:"]
     for m in msgs:
         d = " (%s)" % m["date"] if m.get("date") else ""
         pk = "  ⏸ parked while you were offline — may be stale" if m.get("park") else ""
+        # Mail from yourself is indistinguishable from a peer's reply once it is rendered, and
+        # reading your own report back as an answer is worse than losing it (see
+        # resolve_recipient, which now refuses to create these). Anything already on disk, or
+        # looped in from a peer, says so.
+        if me_id and m.get("from_id") == me_id:
+            pk += "  (this is YOUR OWN message, arrived back in your inbox: not a reply)"
         mid = ("\n<!-- romp-msg-id: %s -->" % m["id"]) if m.get("id") else ""   # exact id for the timeline join
         if m.get("kind"):
             mid += "\n<!-- romp-msg-kind: %s -->" % m["kind"]   # sender-declared kind, read by the courier
@@ -394,12 +400,16 @@ def format_inbox(msgs):
     out.append("\n" + REPLY_HINT)
     return "\n".join(out)
 
-def format_agents(agents, me):
+def format_agents(agents, me, me_id=""):
     if not agents:
         return "(no live romp sessions)"
     lines = []
     for a in agents:
-        tag = " (you)" if a["name"] == me else (" [remote]" if a.get("remote") else "")
+        # '(you)' is an IDENTITY claim, so match on the session id when we have one. Matching on
+        # the name alone marks every same-named session as you, which is precisely the case where
+        # the reader most needs to know which row is theirs (see resolve_recipient).
+        mine = (a.get("id") == me_id) if me_id else (a["name"] == me)
+        tag = " (you)" if mine else (" [remote]" if a.get("remote") else "")
         br = ("  [%s]" % a["branch"]) if a.get("branch") else ""
         wk = ""
         if a.get("working"):
@@ -581,6 +591,75 @@ def _recip_id_for(to):
     if _safe_id(to) and (MAILROOT / to).is_dir():  # already an id with a mailbox (in-flight mail)
         return to
     return None
+
+def resolve_recipient(to, frm_id=""):
+    """Resolve a recipient reference to exactly ONE destination, or explain why it can't.
+
+    Returns exactly one of:
+      {"kind": "direct", "agent": row}             -> deliver into that session's mailbox here
+      {"kind": "relay", "host": h, "agent": row}   -> hand to the peer bus on `host`
+      {"kind": "error", "error": str, "status": n} -> refuse, and say why
+
+    Addressing is by unqualified session NAME, and a name is unique only by convention: two live
+    sessions can share one, on two hosts or on the same host. Taking the first match was silent,
+    and its worst tiebreak was the SENDER itself. A session that mailed its own name had three
+    substantive reports delivered straight back into its own inbox, rendered exactly like any
+    peer's message, so the loopback CONFIRMED that the peer was reachable and answering, and the
+    reports never went anywhere (reported by a session 2026-07-29). Nothing legitimate sends to
+    self, so identity is checked FIRST; after that, more than one candidate is a refusal that
+    names the alternatives rather than a pick. `host:name` is how the sender says which one.
+    """
+    if ":" in to:
+        want_host, bare = to.split(":", 1)
+    else:
+        want_host, bare = "", to
+    here = self_host()
+    # Everything this bus can deliver to itself: local sessions plus heartbeating remotes. A
+    # host qualifier naming somebody ELSE takes them all out of the running.
+    direct_all = ([] if (want_host and want_host != here)
+                  else [a for a in all_agents() if a["name"] == bare])
+
+    if frm_id and any(a["id"] == frm_id for a in direct_all):
+        return {"kind": "error", "status": 409,
+                "error": "'%s' is THIS session's own name. A message there lands in your OWN inbox "
+                         "looking exactly like a reply from someone else, so nothing was sent. Run "
+                         "list_agents: your own row is the one marked '(you)'. If you meant a peer "
+                         "that happens to share your name, address it as host:name." % bare}
+
+    direct = [a for a in direct_all if not _postal_off(a["id"])]
+    peer_cands = []
+    if peers_on():
+        ph, hit = peer_route(to)
+        peer_cands = [(ph, hit)] if ph else list(hit)
+
+    if len(direct) + len(peer_cands) > 1:
+        labels = []
+        for a in direct:
+            # Two live sessions HERE share the name: no address can separate them, so show the id
+            # rather than print the same candidate twice and call it a choice.
+            labels.append("%s:%s%s" % (here, a["name"],
+                                       (" [%s]" % a["id"][:8]) if len(direct) > 1 else ""))
+        labels += ["%s:%s" % (h, a.get("name") or bare) for h, a in peer_cands]
+        hint = ("Address it as host:name to say which one you mean." if len(direct) <= 1 else
+                "Two sessions on this host answer to that name, so no address distinguishes them. "
+                "Ask the user which they meant, or have one renamed.")
+        return {"kind": "error", "status": 409,
+                "error": "'%s' is ambiguous: %d live sessions answer to it (%s). Nothing was sent. %s"
+                         % (bare, len(direct) + len(peer_cands), ", ".join(sorted(labels)), hint)}
+
+    if direct:
+        return {"kind": "direct", "agent": direct[0]}
+    if peer_cands:
+        return {"kind": "relay", "host": peer_cands[0][0], "agent": peer_cands[0][1]}
+    if direct_all:                        # live, but every candidate has its mailbox off
+        return {"kind": "error", "status": 403,
+                "error": "isolation: the RECIPIENT '%s' has its mailbox OFF (it's in "
+                         "postal isolation — its mailbox icon is toggled off), so it can't receive "
+                         "mail right now. YOUR mailbox is fine; nothing was sent. It'll "
+                         "be reachable once the user toggles ITS mailbox back on." % to}
+    # Addressing is LIVE-only: no dead-session resurrection, so anything left is a typo.
+    return {"kind": "error", "status": 404, "error": "no live romp session named '%s'" % to}
+
 
 def _recall(from_id, to, mid):
     """Unsend UNREAD mail: delete messages still sitting in a recipient's `new/`
@@ -1045,42 +1124,33 @@ class Handler(BaseHTTPRequestHandler):
                                    "recipient is fine; nothing was sent. To fix, ask the USER to toggle THIS "
                                    "session's mailbox back on in the timeline, then retry. When you relay this, "
                                    "say it's YOUR mailbox that's off, not theirs."}, 403)
-            match = [a for a in all_agents() if a["name"] == to and not _postal_off(a["id"])]
-            if not match and peers_on():
+            # ONE resolution step for every case (self, ambiguous, isolated, relayed, unknown) —
+            # see resolve_recipient. A name that answers to more than one live session is refused
+            # here, not tiebroken.
+            res = resolve_recipient(to, frm_id)
+            if res["kind"] == "error":
+                return self._send({"error": res["error"]}, res["status"])
+            if res["kind"] == "relay":
                 # Peer-bus relay: the name lives on a peer host → park in its outbox; the exchange
                 # (or the next reconnect) carries it, and a definitive refusal bounces back to the
-                # sender. 'host:name' addresses a specific host; a bare name must be fleet-unique.
-                phost, hit = peer_route(to)
-                if phost:
-                    mid = "px-" + _unique()
-                    outbox_put(phost, {"mid": mid, "to": hit.get("name") or to, "frm": frm,
-                                       "frm_id": frm_id, "body": body, "kind": kind,
-                                       "t": int(time.time())})
-                    _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "sent", "id": mid,
-                                                  "from": frm, "from_id": frm_id,
-                                                  "to_id": "peer:%s" % phost,
-                                                  "toName": "%s:%s" % (phost, hit.get("name") or to),
-                                                  "body": body, "kind": kind})
-                    if PEERS.get(phost, {}).get("up"):
-                        return self._send({"ok": True, "id": mid,
-                                           "note": "relaying to '%s' on %s" % (hit.get("name") or to, phost)})
-                    return self._send({"ok": True, "id": mid, "parked": phost,
-                                       "note": "parked for %s (unreachable) — delivers on reconnect, "
-                                               "or bounces back to you" % phost})
-                if hit:                              # >1 candidate across hosts → make the sender choose
-                    cands = ", ".join(sorted({"%s:%s" % (h, (a.get("name") or "?")) for h, a in hit}))
-                    return self._send({"error": "ambiguous name '%s' across the fleet — address it as "
-                                       "host:name (one of: %s)" % (to, cands)}, 409)
-            if not match:
-                # Addressing is LIVE-only: no dead-session resurrection. A live-but-
-                # isolated recipient says so; anything else is a typo -> 404.
-                if any(a["name"] == to for a in all_agents()):   # live, but isolated → say so
-                    return self._send({"error": "isolation: the RECIPIENT '%s' has its mailbox OFF (it's in "
-                                       "postal isolation — its mailbox icon is toggled off), so it can't receive "
-                                       "mail right now. YOUR mailbox is fine; nothing was sent. It'll "
-                                       "be reachable once the user toggles ITS mailbox back on." % to}, 403)
-                return self._send({"error": "no live romp session named '%s'" % to}, 404)
-            a0 = match[0]
+                # sender.
+                phost, hit = res["host"], res["agent"]
+                mid = "px-" + _unique()
+                outbox_put(phost, {"mid": mid, "to": hit.get("name") or to, "frm": frm,
+                                   "frm_id": frm_id, "body": body, "kind": kind,
+                                   "t": int(time.time())})
+                _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "sent", "id": mid,
+                                              "from": frm, "from_id": frm_id,
+                                              "to_id": "peer:%s" % phost,
+                                              "toName": "%s:%s" % (phost, hit.get("name") or to),
+                                              "body": body, "kind": kind})
+                if PEERS.get(phost, {}).get("up"):
+                    return self._send({"ok": True, "id": mid,
+                                       "note": "relaying to '%s' on %s" % (hit.get("name") or to, phost)})
+                return self._send({"ok": True, "id": mid, "parked": phost,
+                                   "note": "parked for %s (unreachable) — delivers on reconnect, "
+                                           "or bounces back to you" % phost})
+            a0 = res["agent"]
             mid = deliver(a0["id"], frm, frm_id, body, kind=kind)
             if not a0.get("remote", False):
                 # All through the kernel (it owns the tmux status bar + the wake), off-thread so send latency
@@ -2182,6 +2252,8 @@ Before editing a shared repo, run list_agents and read peers' branches + working
 
 Addressing is live-only: you can message only currently-live sessions (list_agents). Dead names error, with no parked mail or reviving.
 
+A name is not guaranteed unique. When more than one live session answers to it the send is refused and the candidates are listed as `host:name`: pick one and resend rather than assuming the first. Your OWN name is refused outright, because a message there lands in your own inbox looking exactly like a reply from someone else. Your row in list_agents is the one marked `(you)`.
+
 An isolation refusal is FINAL. A mailbox toggled off is a boundary the user drew: if send_message refuses for isolation, do NOT reroute the content through any other door (the kernel's /send route, tmux keystrokes, shared files, another peer as relay). Report the refusal to the user and stop — only they lift the isolation.
 """
 
@@ -2226,8 +2298,16 @@ def _mcp_call(name, args):
             return ("Need 'kind': one of delegate (the recipient owns the work now), "
                     "coordinate (aligning/heads-up), or question (you need an answer).", True)
         try:
-            _http("POST", "/send", {"to": to, "from": me or "unknown", "from_id": mid or "", "body": body,
-                                    "kind": kind})
+            resp = _http("POST", "/send", {"to": to, "from": me or "unknown", "from_id": mid or "", "body": body,
+                                           "kind": kind})
+            # "Delivered" has to MEAN delivered. A cross-host send is only relaying (or parked for
+            # an unreachable host, or held for the human on the far side), and the bus says so in
+            # `note` — which this dropped on the floor, so every one of those read as delivered and
+            # the sender had no way to tell. cli_send has echoed the note since 2026-07-27; this is
+            # the same honesty on the tool surface.
+            note = (resp or {}).get("note")
+            if note:
+                return "Message to '%s': %s" % (to, note), False
             # Echo what the DECLARATION did, not just that bytes moved (the user 2026-07-26): a question
             # or delegate records the SENDER as waiting on the recipient — a real hold that a mis-declared
             # kind creates by accident (a "question" whose prose said no reply was needed parked its
@@ -2247,10 +2327,10 @@ def _mcp_call(name, args):
         if not mid:
             return "Not inside a romp session.", True
         msgs = _http("GET", "/inbox?id=%s" % urllib.parse.quote(mid)).get("messages", [])
-        return (format_inbox(msgs) or "No new messages."), False
+        return (format_inbox(msgs, mid) or "No new messages."), False
     if name == "list_agents":
         res = _http("GET", "/agents?me=%s" % urllib.parse.quote(me or ""))
-        return format_agents(res.get("agents", []), me), False
+        return format_agents(res.get("agents", []), me, mid), False
     if name == "set_working":
         if not mid:
             return "Not inside a romp session.", True
@@ -2369,7 +2449,7 @@ def cli_inbox(peek=False):
         res = _http("GET", "/inbox?id=%s&peek=%d" % (urllib.parse.quote(mid), 1 if peek else 0))
     except BusError as e:
         sys.stderr.write("[romp mail] %s\n" % e); return 1
-    text = format_inbox(res.get("messages", []))
+    text = format_inbox(res.get("messages", []), mid)
     if text:
         print(text)
     return 0
@@ -2377,12 +2457,12 @@ def cli_inbox(peek=False):
 def cli_agents():
     if not ensure():
         sys.stderr.write("[romp mail] %s\n" % _unreachable_hint()); return 1
-    me = my_name()
+    me, mid = my_name(), my_id()
     try:
         res = _http("GET", "/agents?me=%s" % urllib.parse.quote(me or ""))
     except BusError as e:
         sys.stderr.write("[romp mail] %s\n" % e); return 1
-    print(format_agents(res.get("agents", []), me))
+    print(format_agents(res.get("agents", []), me, mid))
     return 0
 
 def cli_working(argv):
@@ -2472,7 +2552,7 @@ def cli_drain(argv):
         res = _http("GET", "/drain?id=%s" % urllib.parse.quote(sid))
     except Exception:
         return 0
-    text = format_inbox(res.get("messages", []))
+    text = format_inbox(res.get("messages", []), sid)
     if text:
         print(text)
     return 0

--- a/tests/manager-registry.test.js
+++ b/tests/manager-registry.test.js
@@ -79,6 +79,7 @@ test('specEnv carries the whole isolation story, and only what the spec sets', (
   const full = specEnv({ id: 'alice', port: 30001, postalPort: 30002, stateDir: '/tmp/ra',
                          claudeConfigDir: '/tmp/ca', tmuxSocket: 'romp-alice' }, base, ids);
   assert.equal(full.ROMP_SERVE_PORT, '30001');
+  assert.equal(full.ROMP_KERNEL_PORT, '30001', 'both spellings of the listen port move together');
   assert.equal(full.ROMP_POSTAL_PORT, '30002');
   assert.equal(full.ROMP_STATE_DIR, '/tmp/ra');
   assert.equal(full.CLAUDE_CONFIG_DIR, '/tmp/ca');
@@ -90,6 +91,16 @@ test('specEnv carries the whole isolation story, and only what the spec sets', (
     assert.ok(!(k in bare), k + ' must not leak into an unscoped kernel (main keeps the process defaults)');
   }
   assert.ok(!('ROMP_STATE_DIR' in base), 'the base object is never mutated');
+});
+
+test('specEnv overwrites a stale inherited ROMP_KERNEL_PORT from the base env', () => {
+  // The manager's own env may carry the PRIMARY kernel's port under the other spelling. An aux
+  // kernel inheriting that copy is how one profile's sessions end up addressing another
+  // profile's kernel, so the spec's port has to win under BOTH names.
+  const base = { PATH: '/usr/bin', ROMP_KERNEL_PORT: '29855', ROMP_SERVE_PORT: '29855' };
+  const env = specEnv({ id: 'alice', port: 30001 }, base, { managerPid: 42, controlPort: CTRL });
+  assert.equal(env.ROMP_KERNEL_PORT, '30001');
+  assert.equal(env.ROMP_SERVE_PORT, '30001');
 });
 
 test('fileStamp changes when the file changes — the staleness detector', () => {

--- a/tests/romp-serve.bats
+++ b/tests/romp-serve.bats
@@ -10,6 +10,9 @@ ROMP_SERVE="$BIN/romp-serve"
 ROMP_SCRIPT="$BIN/romp"
 
 setup() {
+    # Running this suite INSIDE a romp session inherits the live kernel's port env, which would
+    # turn every "unset" case below into an override (same trap tests/romp-service.bats documents).
+    unset ROMP_SERVE_PORT ROMP_KERNEL_PORT
     TEST_DIR="$(mktemp -d)"
     export HOME="$TEST_DIR/home"
     export XDG_STATE_HOME="$HOME/.local/state"
@@ -19,6 +22,7 @@ setup() {
     cat > "$ROMP_KERNEL_BIN" << 'STUB'
 #!/usr/bin/env bash
 echo "PORT=${ROMP_KERNEL_PORT:-}"
+echo "SERVEPORT=${ROMP_SERVE_PORT:-}"
 echo "HOST=${ROMP_SERVE_HOST:-}"
 echo "NOOPEN=${ROMP_KERNEL_NO_OPEN:-}"
 echo "MGRPID=${ROMP_MANAGER_PID:-}"
@@ -65,6 +69,60 @@ teardown() { rm -rf "$TEST_DIR"; }
     ROMP_MANAGER_PID=4242 ROMP_SERVE_PORT=29855 run "$ROMP_SERVE"
     [[ "$output" == *"PORT=29855"* ]]
     [[ "$output" == *"MGRPID=4242"* ]]
+}
+
+# ─── the two spellings of the listen port ───────────────────────────────────────────────────
+# ROMP_SERVE_PORT (service-facing) and ROMP_KERNEL_PORT (process-facing) name ONE value, and
+# this script is the seam where they meet. It used to read only the first and stamp it over the
+# second, so renumbering a second kernel with the documented knob alone put the kernel on the
+# primary's port while the CLI kept printing the configured one.
+
+@test "romp-serve: ROMP_KERNEL_PORT alone (the documented knob) reaches the kernel" {
+    ROMP_KERNEL_PORT=29856 run "$ROMP_SERVE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PORT=29856"* ]]
+}
+
+@test "romp-serve: exports BOTH spellings from the one resolved port" {
+    # Nothing downstream (the postal bus, the wake hook, a `romp` verb in a session) may read a
+    # stale copy of the other name.
+    ROMP_KERNEL_PORT=29856 run "$ROMP_SERVE"
+    [[ "$output" == *"PORT=29856"* ]]
+    [[ "$output" == *"SERVEPORT=29856"* ]]
+    ROMP_SERVE_PORT=29857 run "$ROMP_SERVE"
+    [[ "$output" == *"PORT=29857"* ]]
+    [[ "$output" == *"SERVEPORT=29857"* ]]
+}
+
+@test "romp-serve: --port settles a disagreement and wins over both env spellings" {
+    # The manager always passes --port; that is the kernel's own name for itself, so a stale
+    # inherited env copy must never override it.
+    ROMP_SERVE_PORT=29855 ROMP_KERNEL_PORT=29999 run "$ROMP_SERVE" --port 30001
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PORT=30001"* ]]
+    [[ "$output" == *"SERVEPORT=30001"* ]]
+}
+
+@test "romp-serve: conflicting spellings with no --port REFUSE to start" {
+    # A silent pick here is the collision that reports success. Fail loudly instead.
+    ROMP_SERVE_PORT=29855 ROMP_KERNEL_PORT=29856 run "$ROMP_SERVE"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"29855"* ]]
+    [[ "$output" == *"29856"* ]]
+    ! printf '%s\n' "$output" | grep -q '^PORT='     # the stub kernel never ran
+}
+
+@test "romp-serve: matching spellings are not a conflict" {
+    ROMP_SERVE_PORT=29856 ROMP_KERNEL_PORT=29856 run "$ROMP_SERVE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PORT=29856"* ]]
+}
+
+@test "romp-serve: neither set and no --port leaves both unset (the kernel's own default)" {
+    run "$ROMP_SERVE"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s\n' "$output" | grep '^PORT=')" = "PORT=" ]
+    [ "$(printf '%s\n' "$output" | grep '^SERVEPORT=')" = "SERVEPORT=" ]
 }
 
 @test "romp --serve: removed — rejected as unknown, writes no state" {

--- a/tests/romp-service.bats
+++ b/tests/romp-service.bats
@@ -23,7 +23,7 @@ setup() {
     # ROMP_MANAGER_PORT, which the unit now bakes — so a default-vs-override test would be
     # reading the developer's machine instead of the code. Clear the whole instance set; the
     # tests that want them set them explicitly.
-    unset ROMP_SERVE_PORT ROMP_POSTAL_PORT ROMP_MANAGER_PORT ROMP_STATE_DIR CLAUDE_CONFIG_DIR ROMP_TMUX_SOCKET
+    unset ROMP_SERVE_PORT ROMP_KERNEL_PORT ROMP_POSTAL_PORT ROMP_MANAGER_PORT ROMP_STATE_DIR CLAUDE_CONFIG_DIR ROMP_TMUX_SOCKET
 }
 
 teardown() { rm -rf "$TEST_DIR"; }
@@ -235,6 +235,19 @@ EOF2
     grep -q "<key>ROMP_MANAGER_PORT</key><string>7433</string>" "$plist"
 }
 
+@test "install bakes ROMP_KERNEL_PORT — the spelling the docs tell people to set" {
+    # docs/reference.md names ROMP_KERNEL_PORT and not ROMP_SERVE_PORT, so someone renumbering a
+    # second instance by the book sets only this one. It used to reach no unit at all: the
+    # supervised manager came up on the default and the new kernel bound the primary's port.
+    export ROMP_KERNEL_PORT=29856
+    ROMP_OS_OVERRIDE=Linux run "$SVC" install
+    [ "$status" -eq 0 ]
+    grep -q "^Environment=ROMP_KERNEL_PORT=29856$" "$ROMP_SYSTEMD_DIR/romp-manager.service"
+    ROMP_OS_OVERRIDE=Darwin run "$SVC" install
+    [ "$status" -eq 0 ]
+    grep -q "<key>ROMP_KERNEL_PORT</key><string>29856</string>" "$ROMP_LAUNCHD_DIR/com.romp.manager.plist"
+}
+
 @test "install bakes the rest of the profile: state root, Claude config dir, tmux socket" {
     # The same set romp-manager's specEnv hands an aux kernel — a profile that is only half
     # carried is the silent-divergence bug, not a smaller version of it.
@@ -252,7 +265,7 @@ EOF2
     ROMP_OS_OVERRIDE=Linux run "$SVC" install
     [ "$status" -eq 0 ]
     local unit="$ROMP_SYSTEMD_DIR/romp-manager.service"
-    ! grep -q "ROMP_SERVE_PORT\|ROMP_POSTAL_PORT\|ROMP_MANAGER_PORT\|ROMP_STATE_DIR\|CLAUDE_CONFIG_DIR\|ROMP_TMUX_SOCKET" "$unit"
+    ! grep -q "ROMP_SERVE_PORT\|ROMP_KERNEL_PORT\|ROMP_POSTAL_PORT\|ROMP_MANAGER_PORT\|ROMP_STATE_DIR\|CLAUDE_CONFIG_DIR\|ROMP_TMUX_SOCKET" "$unit"
     # ...and the file is still well-formed around the seam: blank line, then [Install].
     grep -q "^Environment=ROMP_SUPERVISED=1$" "$unit"
     grep -q "^\[Install\]$" "$unit"

--- a/tests/romp-wake-hook.bats
+++ b/tests/romp-wake-hook.bats
@@ -21,7 +21,7 @@ MOCK
     # Run the suite from inside a romp session and it inherits that kernel's
     # ROMP_SERVE_PORT, which silently turns the default case into an override
     # case — a green CI and a red local run (2026-07-24).
-    unset ROMP_SERVE_PORT
+    unset ROMP_SERVE_PORT ROMP_KERNEL_PORT
     HOOK="$(cd "$(dirname "$BATS_TEST_FILENAME")/../hooks" && pwd)/romp-wake.sh"
 }
 
@@ -41,6 +41,15 @@ teardown() { rm -rf "$TEST_DIR"; }
     [ "$status" -eq 0 ]
     for _ in $(seq 1 40); do [ -s "$CURL_LOG" ] && break; sleep 0.05; done
     grep -q 'http://127.0.0.1:29855/tick' "$CURL_LOG"
+}
+
+@test "romp-wake accepts ROMP_KERNEL_PORT, the other spelling of the same port" {
+    # bin/romp-serve exports both, but a hook can also run under a shell that set only the
+    # documented one — poking the default kernel from an aux session is a cross-instance poke.
+    ROMP_KERNEL_PORT=7778 run bash -c 'echo "{}" | "'"$HOOK"'"'
+    [ "$status" -eq 0 ]
+    for _ in $(seq 1 40); do [ -s "$CURL_LOG" ] && break; sleep 0.05; done
+    grep -q 'http://127.0.0.1:7778/tick' "$CURL_LOG"
 }
 
 @test "romp-wake sends the serve token header (env override form)" {

--- a/tests/test_postal_self_send.py
+++ b/tests/test_postal_self_send.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Postal addressing checks IDENTITY and refuses ambiguity, instead of tiebreaking silently.
+
+A session reported (2026-07-29) that send_message to its OWN name returned "Delivered" three
+times and each report arrived back in its own inbox rendered exactly like a peer's message. The
+loopback is indistinguishable from a real reply, so it actively CONFIRMS that the peer is
+reachable and answering while the reports go nowhere. The cause is that a recipient reference is
+an unqualified session NAME, unique only by convention, and the resolver took the first match --
+whose worst possible tiebreak is the sender itself.
+
+So: self is a hard error, more than one candidate is a hard error that names the alternatives,
+'(you)' is decided by session id rather than by name, mail that did arrive from yourself says so,
+and "Delivered" is reserved for actually delivered. Synthetic ids and hostnames only.
+"""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()      # hermetic; constants resolve under here
+pm = SourceFileLoader("romp_postal_self_send", os.path.join(BIN, "romp-postal-service")).load_module()
+
+ME = "11111111-2222-3333-4444-555555555555"
+PEER = "22222222-3333-4444-5555-666666666666"
+TWIN = "33333333-4444-5555-6666-777777777777"
+
+
+class ResolverBase(unittest.TestCase):
+    """Drives resolve_recipient over a synthetic fleet. Every collaborator it reads is a
+    module-level function, so a plain attribute swap is the whole harness."""
+
+    def setUp(self):
+        self._saved = {k: getattr(pm, k) for k in
+                       ("all_agents", "self_host", "peers_on", "_postal_off")}
+        self._agents = []
+        self._isolated = set()
+        pm.all_agents = lambda: list(self._agents)
+        pm.self_host = lambda: "TESTHOST"
+        pm.peers_on = lambda: True
+        pm._postal_off = lambda sid: sid in self._isolated
+        pm.PEER_STATE.clear()
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            setattr(pm, k, v)
+        pm.PEER_STATE.clear()
+
+    def live(self, name, sid, remote=False):
+        self._agents.append({"name": name, "id": sid, "remote": remote})
+
+    def on_peer(self, host, name, sid):
+        pm.PEER_STATE.setdefault(host, {"presence": [], "seenAt": 1})
+        pm.PEER_STATE[host]["presence"].append({"name": name, "id": sid})
+
+
+class SelfSendRefused(ResolverBase):
+    def test_own_name_is_a_hard_error(self):
+        self.live("web", ME)
+        res = pm.resolve_recipient("web", ME)
+        self.assertEqual(res["kind"], "error")
+        self.assertEqual(res["status"], 409)
+        self.assertIn("THIS session's own name", res["error"])
+        self.assertIn("(you)", res["error"], "point them at the list_agents row that proves it")
+
+    def test_self_refused_even_when_a_peer_shares_the_name(self):
+        # The reported case: a peer on another host answered to the same name, so the reply the
+        # sender was waiting for could never come -- it was mailing itself.
+        self.live("web", ME)
+        self.on_peer("otherhost", "web", PEER)
+        res = pm.resolve_recipient("web", ME)
+        self.assertEqual(res["kind"], "error")
+        self.assertIn("host:name", res["error"], "tell them how to reach the peer they meant")
+
+    def test_self_by_host_qualified_own_name_is_still_self(self):
+        self.live("web", ME)
+        res = pm.resolve_recipient("TESTHOST:web", ME)
+        self.assertEqual(res["kind"], "error")
+        self.assertIn("own name", res["error"])
+
+    def test_a_peer_with_my_name_is_reachable_when_host_qualified(self):
+        self.live("web", ME)
+        self.on_peer("otherhost", "web", PEER)
+        res = pm.resolve_recipient("otherhost:web", ME)
+        self.assertEqual(res["kind"], "relay")
+        self.assertEqual(res["host"], "otherhost")
+        self.assertEqual(res["agent"]["id"], PEER)
+
+    def test_no_sender_id_still_resolves(self):
+        # CLI/legacy callers may not carry a from_id; the self check simply does not apply.
+        self.live("web", ME)
+        self.assertEqual(pm.resolve_recipient("web", "")["kind"], "direct")
+
+
+class AmbiguityRefused(ResolverBase):
+    def test_two_local_sessions_with_one_name(self):
+        self.live("web", ME)
+        self.live("web", TWIN)
+        res = pm.resolve_recipient("web", PEER)
+        self.assertEqual(res["kind"], "error")
+        self.assertEqual(res["status"], 409)
+        self.assertIn("ambiguous", res["error"])
+        self.assertIn(ME[:8], res["error"], "identify the candidates that no address can separate")
+        self.assertIn(TWIN[:8], res["error"])
+        self.assertIn("renamed", res["error"])
+
+    def test_local_and_peer_with_one_name(self):
+        # Previously the local row silently won and the peer was never considered.
+        self.live("web", ME)
+        self.on_peer("otherhost", "web", PEER)
+        res = pm.resolve_recipient("web", TWIN)
+        self.assertEqual(res["kind"], "error")
+        self.assertIn("TESTHOST:web", res["error"])
+        self.assertIn("otherhost:web", res["error"])
+
+    def test_host_qualifier_resolves_the_tie_both_ways(self):
+        self.live("web", ME)
+        self.on_peer("otherhost", "web", PEER)
+        here = pm.resolve_recipient("TESTHOST:web", TWIN)
+        self.assertEqual(here["kind"], "direct")
+        self.assertEqual(here["agent"]["id"], ME)
+        there = pm.resolve_recipient("otherhost:web", TWIN)
+        self.assertEqual(there["kind"], "relay")
+        self.assertEqual(there["host"], "otherhost")
+
+    def test_two_peer_hosts_with_one_name(self):
+        self.on_peer("hosta", "web", PEER)
+        self.on_peer("hostb", "web", TWIN)
+        res = pm.resolve_recipient("web", ME)
+        self.assertEqual(res["kind"], "error")
+        self.assertIn("hosta:web", res["error"])
+        self.assertIn("hostb:web", res["error"])
+
+    def test_an_isolated_twin_does_not_make_a_name_ambiguous(self):
+        # An isolated session can't receive at all, so it is not a candidate -- the one reachable
+        # session still resolves, exactly as before.
+        self.live("web", ME)
+        self.live("web", TWIN)
+        self._isolated.add(TWIN)
+        res = pm.resolve_recipient("web", PEER)
+        self.assertEqual(res["kind"], "direct")
+        self.assertEqual(res["agent"]["id"], ME)
+
+
+class UnchangedBehaviour(ResolverBase):
+    """The refusals above are additive: every pre-existing outcome still comes out the same."""
+
+    def test_unambiguous_local_name_resolves(self):
+        self.live("api", PEER)
+        res = pm.resolve_recipient("api", ME)
+        self.assertEqual(res["kind"], "direct")
+        self.assertEqual(res["agent"]["id"], PEER)
+
+    def test_unknown_name_is_404_live_only(self):
+        self.live("api", PEER)
+        res = pm.resolve_recipient("ghost", ME)
+        self.assertEqual(res["kind"], "error")
+        self.assertEqual(res["status"], 404)
+        self.assertIn("no live romp session named 'ghost'", res["error"])
+
+    def test_isolated_recipient_still_says_isolation(self):
+        self.live("api", PEER)
+        self._isolated.add(PEER)
+        res = pm.resolve_recipient("api", ME)
+        self.assertEqual(res["kind"], "error")
+        self.assertEqual(res["status"], 403)
+        self.assertIn("isolation: the RECIPIENT", res["error"])
+
+    def test_lone_peer_name_relays(self):
+        self.on_peer("otherhost", "api", PEER)
+        res = pm.resolve_recipient("api", ME)
+        self.assertEqual(res["kind"], "relay")
+        self.assertEqual(res["host"], "otherhost")
+
+    def test_peers_off_ignores_peer_presence(self):
+        pm.peers_on = lambda: False
+        self.on_peer("otherhost", "web", PEER)
+        self.live("web", ME)
+        res = pm.resolve_recipient("web", TWIN)
+        self.assertEqual(res["kind"], "direct", "legacy mode never consults the peer table")
+
+
+class SendRouteUsesTheResolver(unittest.TestCase):
+    def test_handler_delegates_and_never_indexes_a_match_list(self):
+        import inspect
+        src = inspect.getsource(pm.Handler.do_POST)
+        send = src.split('if u.path == "/send":', 1)[1].split('if u.path == "/recall":', 1)[0]
+        self.assertIn("resolve_recipient(to, frm_id)", send,
+                      "the send route must resolve through the one identity-checking path")
+        self.assertNotIn("match[0]", send,
+                         "picking the first name match is the bug: ambiguity is refused, not tiebroken")
+
+
+class SelfMailIsLabelled(unittest.TestCase):
+    """Rendering can't be the only defence, but mail already on disk (or looped in from a peer)
+    must never read as somebody else's reply."""
+
+    def test_own_message_is_flagged_in_the_inbox(self):
+        msgs = [{"from": "web", "from_id": ME, "body": "the survey", "id": "m1", "date": ""}]
+        self.assertIn("YOUR OWN message", pm.format_inbox(msgs, ME))
+
+    def test_a_real_peer_message_is_not_flagged(self):
+        msgs = [{"from": "api", "from_id": PEER, "body": "on it", "id": "m1", "date": ""}]
+        self.assertNotIn("YOUR OWN", pm.format_inbox(msgs, ME))
+
+    def test_no_reader_id_renders_as_before(self):
+        msgs = [{"from": "api", "from_id": PEER, "body": "on it", "id": "m1", "date": ""}]
+        self.assertNotIn("YOUR OWN", pm.format_inbox(msgs))
+
+
+class YouIsAnIdentityClaim(unittest.TestCase):
+    def test_you_is_matched_by_id_not_name(self):
+        agents = [{"name": "web", "id": ME}, {"name": "web", "id": TWIN, "remote": True}]
+        out = pm.format_agents(agents, "web", ME)
+        lines = [ln for ln in out.splitlines() if ln.strip()]
+        self.assertEqual(sum("(you)" in ln for ln in lines), 1,
+                         "exactly one row is you, however many sessions share the name")
+        self.assertIn("(you)", lines[0])
+
+    def test_name_fallback_when_no_id_is_known(self):
+        agents = [{"name": "web", "id": ME}]
+        self.assertIn("(you)", pm.format_agents(agents, "web"))
+
+
+class DeliveredMeansDelivered(unittest.TestCase):
+    """A relayed or parked message is not a delivered one, and the tool surface has to say which."""
+
+    def setUp(self):
+        self._saved = {k: getattr(pm, k) for k in ("_http", "my_name", "my_id", "_heartbeat")}
+        pm.my_name = lambda: "web"
+        pm.my_id = lambda: ME
+        pm._heartbeat = lambda *a, **k: None
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            setattr(pm, k, v)
+
+    def _send(self, resp, kind="coordinate"):
+        pm._http = lambda *a, **k: resp
+        out, err = pm._mcp_call("send_message", {"to": "api", "body": "hi", "kind": kind})
+        self.assertFalse(err)
+        return out
+
+    def test_parked_for_an_unreachable_host_does_not_claim_delivery(self):
+        out = self._send({"ok": True, "id": "px-1",
+                          "note": "parked for otherhost (unreachable) — delivers on reconnect, "
+                                  "or bounces back to you"})
+        self.assertNotIn("Delivered", out)
+        self.assertIn("parked for otherhost", out)
+
+    def test_relaying_says_relaying(self):
+        out = self._send({"ok": True, "id": "px-1", "note": "relaying to 'api' on otherhost"})
+        self.assertNotIn("Delivered", out)
+        self.assertIn("relaying", out)
+
+    def test_a_plain_local_delivery_is_unchanged(self):
+        self.assertEqual(self._send({"ok": True, "to": "api"}), "Delivered to 'api'.")
+
+    def test_the_declaration_echo_still_rides_a_real_delivery(self):
+        out = self._send({"ok": True, "to": "api"}, kind="question")
+        self.assertIn("waiting on their reply", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -147,7 +147,10 @@ function cfgPort(key: "kernelPort" | "managerPort", env: string | undefined, dfl
   if (typeof v === "number" && v > 0) return v;
   return Number(env) || dflt;
 }
-function kernelPort(): number { return cfgPort("kernelPort", process.env.ROMP_SERVE_PORT, 29855); }
+// Either spelling of the kernel's listen port (bin/romp-serve owns that seam), so a window opened
+// from a shell that exported only the documented ROMP_KERNEL_PORT attaches to that kernel instead
+// of silently trying the default one.
+function kernelPort(): number { return cfgPort("kernelPort", process.env.ROMP_SERVE_PORT || process.env.ROMP_KERNEL_PORT, 29855); }
 function managerPort(): number { return cfgPort("managerPort", process.env.ROMP_MANAGER_PORT, 7432); }
 
 let ctx: vscode.ExtensionContext;


### PR DESCRIPTION
Two defects handed over by a peer session that hit both while standing up a second romp kernel under a separate OS user. Neither was fixed there. They are the same shape: a value resolved silently where it should have been checked, so the failure reported success.

## 1. The port env-var split

`ROMP_SERVE_PORT` and `ROMP_KERNEL_PORT` are one value under two names. The split is role-based: the first is service-facing (manager, service unit, wake hook, VS Code extension), the second process-facing (`kernel.py`, the postal bus, every `romp` verb). `bin/romp-serve` is the seam, and it read only the first and then unconditionally exported it over the second.

`docs/reference.md` documents only `ROMP_KERNEL_PORT`. Following it exactly: the unit carried no port, the manager fell back to 29855, `romp-serve` stamped that over the inherited value, and the second kernel bound the primary's port while every foreground `romp` command went on printing the renumbered one.

- `bin/romp-service`: `ROMP_KERNEL_PORT` joins `_INSTANCE_VARS`, so the unit carries it.
- `bin/romp-serve`: accepts either spelling; exports **both** from the one resolved port; refuses to start when both are set and disagree with no `--port` to settle it. `--port` still wins, so the manager's spawn contract is unchanged.
- `bin/romp-manager`: `KERNEL_PORT` accepts either; `specEnv` overwrites both together so an aux kernel cannot inherit the primary's stale copy.
- `hooks/romp-wake.sh`, `vscode-extension/src/extension.ts`: accept either.
- `docs/reference.md`: documents both spellings, the refusal, and the `romp-service install` re-run.

## 2. Postal addressing never checked identity

A recipient reference is an unqualified session **name**, unique only by convention, and the bus took `match[0]`. Its worst tiebreak was the sender itself: a session that sent to its own name got "Delivered" three times, and each report arrived back in its own inbox rendered exactly like a peer's message. The loopback is indistinguishable from a real reply, so it actively confirms the peer is reachable and answering while the reports go nowhere. It was caught only because `list_agents` happened to show `(you)`.

A single `resolve_recipient()` now owns every outcome (self, ambiguous, isolated, relayed, unknown):

- **Self is a hard error**, checked before anything else, pointing at the `(you)` row.
- **More than one candidate is a hard error** that lists them as `host:name`, covering local-vs-local, local-vs-peer and peer-vs-peer. Previously only peer-vs-peer was caught, and only when no local match existed. Two sessions on one host get their ids shown, since no address separates them.
- `host:name` now selects the local host too, so the disambiguation advice is actionable.
- **`(you)` is decided by session id**, not by name, so same-named sessions can't all be marked as you.
- **Inbound mail from yourself is labelled** in `format_inbox`, so anything already on disk or looped in from a peer can't read as a reply.
- **`send_message` stops calling a relayed or parked message delivered** — it echoes the bus's `note`, which it had been discarding. `cli_send` has done this since 2026-07-27; the tool surface hadn't.

Every pre-existing outcome (unambiguous name, isolation refusal, live-only 404, peer relay, the kind-declaration echo) is unchanged and pinned.

## Tests

New `tests/test_postal_self_send.py` (25). Verified empirically: neutering the two new refusals fails 6 of them, and the full suite passes with them restored. Six new bats cases for the port seam, two service cases, one wake-hook case, one manager `specEnv` case.

3571 Python passed / 25 skipped, 281 bats passed / 0 failed, 1440 node passed / 0 failed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)