### PR TITLE
A dropped host flashes the network glyph instead of covering your sessions

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,7 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
-import json, os, queue, re, signal, socket, sys, time, threading, traceback, base64, bisect, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid
+import json, os, queue, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid
 from pathlib import Path
 from datetime import datetime
 from importlib.machinery import SourceFileLoader
@@ -4784,6 +4784,59 @@ TUNNEL_BACKOFF_MAX = 300         # steady ceiling for a fresh outage (5 min)
 TUNNEL_BACKOFF_LONG = 900        # relaxed to 15 min once the outage is clearly not a blip
 TUNNEL_LONG_AFTER = 12           # consecutive failures before the long ceiling applies (~38 min of trying)
 
+# Every dial, death and probe verdict, on the record (the user 2026-07-29, after a morning lost to a host
+# that would not come back while plain `ssh <host>` worked throughout). _spawn_tunnel used to send ssh's
+# stdout AND stderr to DEVNULL, so the one line that names the cause — "Address already in use",
+# "remote port forwarding failed for listen port …", "Permission denied", "Timeout, server not
+# responding" — was destroyed at the moment it was printed, and afterwards NOTHING on this machine
+# could say why a single dial had failed. The reason is the whole diagnosis, so it is kept: ssh's stderr
+# goes to a per-host file (truncated each dial, so it always holds the LAST attempt verbatim) and is
+# copied into an append-only jsonl next to it, with the argv, the exit code and the probe verdict.
+#   jq 'select(.host=="…")' ~/.local/state/romp/tunnel-dials.jsonl
+TUNNEL_LOG = jd.STATE / "tunnel-dials.jsonl"
+TUNNEL_ERR_DIR = jd.STATE / "tunnel-err"
+TUNNEL_LOG_MAX = 2_000_000       # rotate at ~2MB; one dial is a few hundred bytes, so this is months
+
+
+def _tunnel_log(host, event, **kw):
+    """Append one record to the dial log. Best-effort and never raises: logging must not be able to break
+    the supervisor that is trying to reconnect you."""
+    try:
+        TUNNEL_LOG.parent.mkdir(parents=True, exist_ok=True)
+        if TUNNEL_LOG.exists() and TUNNEL_LOG.stat().st_size > TUNNEL_LOG_MAX:
+            TUNNEL_LOG.replace(TUNNEL_LOG.with_suffix(".jsonl.1"))     # keep exactly one generation back
+        rec = {"t": round(time.time(), 3), "host": host, "event": event}
+        rec.update(kw)
+        with open(TUNNEL_LOG, "a") as f:
+            f.write(json.dumps(rec, default=str) + "\n")
+    except Exception:
+        pass
+
+
+def _tunnel_err_path(host):
+    return TUNNEL_ERR_DIR / ("%s.log" % re.sub(r"[^A-Za-z0-9_.-]", "_", str(host)))
+
+
+def _tunnel_stderr(host, limit=4000):
+    """What the LAST dial for this host printed, minus benign chatter. '' when it said nothing."""
+    try:
+        return _ssh_err(_tunnel_err_path(host).read_text(errors="replace"))[-limit:]
+    except Exception:
+        return ""
+
+
+# An ssh whose forward cannot bind is a PERMANENT wedge, not a transient failure: ExitOnForwardFailure=yes
+# (which we want — a tunnel with a silently missing forward is worse) means the dial dies instantly, and
+# since the ports are minted once by _free_port and then persisted forever, the NEXT dial rebuilds exactly
+# the same doomed argv. That loops until whatever holds the port lets go, which for an ssh corpse on either
+# end can be tens of minutes. Detected off ssh's own words, then healed by re-minting the ports.
+_FWD_BIND_FAIL = ("Address already in use", "cannot listen to port", "remote port forwarding failed",
+                  "bind: ", "Error: remote port forwarding failed")
+
+
+def _forward_bind_failed(err):
+    return any(s in (err or "") for s in _FWD_BIND_FAIL)
+
 
 def _tunnel_backoff(fails):
     """Seconds before the next dial, after `fails` consecutive failures. There is no "stop" answer: the
@@ -5354,14 +5407,50 @@ def _reap_stray_tunnels(host):
 
 
 def _spawn_tunnel(r):
-    """(Re)spawn the ssh tunnel proc for one remote. Caller holds _remotes_lock."""
+    """(Re)spawn the ssh tunnel proc for one remote. Caller holds _remotes_lock.
+
+    ssh's stderr is CAPTURED, not discarded (see TUNNEL_LOG): it is the only place the reason for a failed
+    dial is ever stated, and throwing it away is what made a real outage undiagnosable after the fact."""
     _reap_stray_tunnels(r["host"])   # clear any orphan on this host's ports first, so we never leak a 2nd tunnel
+    argv = _tunnel_argv(r)
     try:
-        r["proc"] = subprocess.Popen(_tunnel_argv(r), stdin=subprocess.DEVNULL,
-                                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        TUNNEL_ERR_DIR.mkdir(parents=True, exist_ok=True)
+        # truncated per dial, so the file always holds THIS attempt's words; the jsonl keeps the history
+        errf = open(_tunnel_err_path(r["host"]), "w+b")
+    except Exception:
+        errf = None
+    try:
+        r["proc"] = subprocess.Popen(argv, stdin=subprocess.DEVNULL,
+                                     stdout=subprocess.DEVNULL,
+                                     stderr=(errf or subprocess.DEVNULL))
         r["status"], r["detail"] = "starting", ""
+        r["_death_logged"] = False
+        _tunnel_log(r["host"], "dial", pid=r["proc"].pid, fails=r.get("fails", 0), argv=argv)
     except Exception as e:
         r["proc"], r["status"], r["detail"] = None, "error", str(e)
+        _tunnel_log(r["host"], "spawn-failed", error=str(e), argv=argv)
+    finally:
+        if errf:
+            try:
+                errf.close()      # the child holds its own dup of the fd; we only needed it to hand over
+            except Exception:
+                pass
+
+
+def _remint_forward_ports(r):
+    """Give this row fresh local/reverse forward ports after a bind failure, so the next dial is not the
+    same doomed argv (the user 2026-07-29). The ports were minted ONCE by _free_port and then persisted,
+    so a collision — a corpse of ours, another kernel, or an unrelated process that grabbed the number out
+    of the ephemeral range — wedged every future dial identically and forever. Caller holds _remotes_lock."""
+    old = {k: r.get(k) for k in ("local_port", "bus_port", "rk_port", "rb_port") if r.get(k)}
+    r["local_port"] = _free_port()
+    r["bus_port"] = _free_port()
+    if r.get("checkin"):
+        r["rk_port"], r["rb_port"] = _free_port(), _free_port()
+        r.pop("_handshook", None)        # the hub must be re-told the new ports
+    r["_peer_notified"] = None           # bus_port moved: the local bus is holding a stale endpoint
+    new = {k: r.get(k) for k in ("local_port", "bus_port", "rk_port", "rb_port") if r.get(k)}
+    _tunnel_log(r["host"], "ports-reminted", old=old, new=new)
 
 
 def _tunnel_proc_alive(r):
@@ -5591,6 +5680,20 @@ def attach_remote(host, kernel_port=None):
             r["token"] = token
         if not _tunnel_proc_alive(r):
             _spawn_tunnel(r)
+        elif r.get("status") != "up":
+            # An attach gesture on a row that is NOT up means "dial again, now" — that is what the panel's
+            # Try now sends. It used to do NOTHING here, because a live ssh proc satisfied the check above:
+            # the one wedge the button existed to break — a tunnel whose proc is fine and whose transport
+            # is gone — was the exact case it declined to act on (the user 2026-07-29). Drop the old ssh
+            # and dial fresh. Waiting for the process to actually exit is what frees the forwarded ports,
+            # so the new dial does not die on its predecessor's listener.
+            _tunnel_log(host, "forced-redial", pid=r["proc"].pid, status=r.get("status"))
+            try:
+                r["proc"].terminate()
+                r["proc"].wait(timeout=3)
+            except Exception:
+                pass
+            _spawn_tunnel(r)
         if boot_detail and not token:
             r["detail"] = boot_detail              # the popover's next step (e.g. "run bin/romp-host-setup")
         pub = _remote_public(r)
@@ -5695,7 +5798,17 @@ def list_remotes():
 
 def _poll_remote_sids(r):
     """GET the remote kernel's /sessions THROUGH the -L tunnel; return its session ids (for the wake-router's
-    host↔sid map). None on any failure — leave the last-known map in place."""
+    host↔sid map). None on any failure — leave the last-known map in place.
+
+    Also files HOW it failed in r["_probe"], because the shape of the failure is the one thing that tells a
+    live tunnel with no romp behind it apart from an ssh that is still holding its listener over a transport
+    that is gone (the user 2026-07-29). ssh answers the local connect either way, so "the port accepts" says
+    nothing. But the two fail DIFFERENTLY, and exactly:
+      refused — ssh reached the far side, the far side said no. The channel-open failure comes back as a
+                reset/refusal, promptly. The tunnel is fine; romp is not running over there.
+      timeout — nothing came back at all. The far side never spoke, because there is no longer a path to
+                it. The tunnel is a corpse holding a socket open, and only a re-dial fixes it.
+    That is an exact event, not a threshold, so the supervisor can act on it without guessing."""
     import urllib.parse
     try:
         c = http.client.HTTPConnection("127.0.0.1", int(r["local_port"]), timeout=4)
@@ -5705,10 +5818,23 @@ def _poll_remote_sids(r):
         data = resp.read()
         c.close()
         if resp.status != 200:
+            r["_probe"] = "http-%d" % resp.status         # it ANSWERED — the tunnel carries traffic
             return None
         rows = json.loads(data.decode("utf-8"))
+        r["_probe"] = "ok"
         return [x.get("id") for x in rows if isinstance(x, dict) and x.get("id")]
+    except (socket.timeout, TimeoutError):
+        r["_probe"] = "timeout"
+        return None
+    except (ConnectionResetError, ConnectionRefusedError, ConnectionAbortedError, BrokenPipeError):
+        r["_probe"] = "refused"
+        return None
+    except OSError as e:
+        r["_probe"] = "refused" if e.errno in (errno.ECONNRESET, errno.ECONNREFUSED) else "error"
+        return None
     except Exception:
+        # a malformed body still proves the far side spoke, so this is never a dead transport
+        r["_probe"] = "refused"
         return None
 
 
@@ -6527,6 +6653,20 @@ def _tunnel_supervisor():
                         # (A checked-in host owns NO ssh here — the mobile machine supervises its own
                         # tunnel, so there is nothing to spawn or back off; its status comes purely
                         # from polling the reverse-forwarded port below.)
+                        # A dial that just DIED is where the reason lives: read what ssh printed before
+                        # anything overwrites it, put it on the record, and heal the one failure that
+                        # would otherwise repeat forever — a forward that cannot bind (the user
+                        # 2026-07-29). Once per death, so a row waiting out its backoff logs nothing.
+                        if r.get("proc") is not None and not r.get("_death_logged"):
+                            r["_death_logged"] = True
+                            err = _tunnel_stderr(r["host"])
+                            _tunnel_log(r["host"], "died", code=r["proc"].poll(), stderr=err,
+                                        fails=r.get("fails", 0))
+                            if _forward_bind_failed(err):
+                                r["detail"] = ("a forwarded port was already taken, so the tunnel could "
+                                               "not open — romp is retrying on fresh ports")
+                                _remint_forward_ports(r)
+                                r["fails"], r["next_try"] = 0, 0   # a NEW argv deserves a fresh ladder
                         # BACK OFF re-spawns (exponential — see _tunnel_backoff) so an unreachable host
                         # isn't hammered every tick: repeated ssh attempts can trip the remote sshd's
                         # rate-limit (the user 2026-06-30). It never stops dialing (the user 2026-07-29);
@@ -6554,6 +6694,28 @@ def _tunnel_supervisor():
                         st = "up" if (up and sids is not None) else ("no-kernel" if up else "down")
                     else:
                         st = _tunnel_status(_tunnel_proc_alive(r), up, sids is not None)
+                        # A LIVE ssh is not proof of a live tunnel (the user 2026-07-29). ssh answers the
+                        # local connect from its own listener, so a proc whose transport is gone looks
+                        # exactly like a healthy tunnel with no romp behind it — and this branch only
+                        # re-dials a DEAD proc, so that row sat at 'no-kernel' forever: no re-dial, no
+                        # backoff, no reap, and a panel offering only "Start", which says to go reboot the
+                        # REMOTE kernel. That is the dead end this outage ran into.
+                        #
+                        # The probe verdict tells the two apart exactly (see _poll_remote_sids): a far side
+                        # that REFUSED is a real no-kernel and must be left alone, while one that never
+                        # answered at all means the path is gone. Kill it and let the branch above re-dial —
+                        # once, on the transition, never on a timer.
+                        if st == "no-kernel" and r.get("_probe") == "timeout":
+                            _tunnel_log(r["host"], "stale-tunnel",
+                                        pid=(r["proc"].pid if r.get("proc") else 0),
+                                        note="local forward accepts but nothing answered through it")
+                            try:
+                                r["proc"].terminate()
+                            except Exception:
+                                pass
+                            st = "down"
+                            r["detail"] = ("the link to %s stopped carrying traffic — romp is dialing "
+                                           "again") % r["host"]
                     if not (st == "down" and r.get("status") == "error") and not r.get("booting"):
                         r["status"] = st                   # keep a richer spawn-error label over plain 'down';
                         #                                    a Start in flight (`booting`) owns the row's phase
@@ -16079,6 +16241,20 @@ if(me)me.setAttribute('class','rn-me'+(nodes?' rn-ok':''));}
 function paintIcon(up,busy,nodes){icon.classList.toggle('on',up);icon.classList.toggle('busy',busy);
 paintNodes(icon,nodes);
 var m=mnet();if(m){m.classList.toggle('on',up);m.classList.toggle('busy',busy);paintNodes(m,nodes);}}
+// A host DROPPING is an EVENT, and it gets an event's cue: the rail's network glyph flashes red three
+// times and stops (the user 2026-07-29). This replaces a banner that dropped across the top of the pane
+// and covered the session tabs — the one strip you are actually reading — to announce a machine going
+// away. The steady state is already on the rail (a red fleet node) and on the tab (dimmed, host struck,
+// the why on hover); this only says something just CHANGED, and costs no pixels of transcript.
+var _wasUp={};
+function dropCue(ts){var fell=false,seen={};
+ts.forEach(function(t){var up=(t.status==='up');seen[t.host]=up;if(_wasUp[t.host]&&!up)fell=true;});
+_wasUp=seen;                       // a host we have never seen up cannot "drop": a page opened on an
+if(fell)flashDrop();}              // already-down fleet stays quiet, and the colours carry that state
+function flashDrop(){[icon,mnet()].forEach(function(el){if(!el)return;
+el.classList.remove('rn-drop');void el.offsetWidth;   // reflow: a second drop replays the flash
+el.classList.add('rn-drop');
+el.addEventListener('animationend',function(){el.classList.remove('rn-drop');},{once:true});});}
 function refresh(){fetch('/tunnels',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){
 var ts=(d&&d.tunnels)||[];var pmode=!!(d&&d.peersMode);var busy=ts.some(function(t){return busyStatus(t.status);});
 _auto=!!(d&&d.autoUpdate);
@@ -16087,6 +16263,7 @@ if(autoCb&&!autoCb.disabled)autoCb.checked=_auto;   // mirror the kernel; never 
 // the whole point of replacing the modal (the user 2026-07-24 — animate the icon so you can see it happening).
 var pushing=ts.filter(function(t){return t.autoPush&&(t.autoPush.phase==='pushing'||t.autoPush.phase==='waiting'||t.autoPush.phase==='pulling');});
 paintIcon(ts.some(function(t){return t.status==='up';}),busy||!!pushing.length,fleetNodes(ts));
+dropCue(ts);   // paint the new state first, then flash if this poll is where a host fell off
 // hover tooltip on the rail icon: which hosts are attached + their phase and session count, plus any
 // automatic update's live phase — so the progress is readable WITHOUT opening the panel.
 var _sv=ts.map(hostSev),_bad=_sv.filter(function(x){return x==='warn';}).length,
@@ -16179,7 +16356,11 @@ var strt=(t.status==='no-kernel')?'<button class=rnet-upd data-s=\"'+t.host+'\" 
 var wait=(t.nextTry&&(t.status==='down'||t.status==='error'))?Math.max(0,t.nextTry-Math.floor(Date.now()/1000)):0;
 var when=wait>90?('next try in '+Math.round(wait/60)+'m'):(wait>0?('next try in '+wait+'s'):'retrying\\u2026');
 var again=(t.status==='down'||t.status==='error')?'<span class=rnet-retry title=\"romp keeps dialing '+t.host+' on its own, waiting longer between tries the longer it is down ('+(t.fails||0)+' so far).\">'+when+'</span>':'';
-var retry=(t.status==='down'||t.status==='error')?'<button data-ra=\"'+t.host+'\" title=\"Dial '+t.host+' now instead of waiting out the backoff.\">Try now</button>':'';
+// Offered on EVERY row that is not up, not just down/error (the user 2026-07-29). A 'no-kernel' row used
+// to carry only Start — "this pushes this machine's romp there and boots its kernel" — so a link that had
+// quietly stopped carrying traffic read as a dead remote, and the only button on offer told you to go
+// restart the far end. That is the path that cost a morning of restarting kernels that were never down.
+var retry=(t.status!=='up'&&t.status!=='starting')?'<button data-ra=\"'+t.host+'\" title=\"Dial '+t.host+' now: drop the current ssh and open a fresh one. Use this when the link looks connected but nothing is coming through.\">Try now</button>':'';
 // The check-in publishes THIS machine TO that host, which is the opposite direction from everything else
 // in the row. Its old label, "keep connected", read as the reconnect setting so plainly that the tooltip
 // had to spend a sentence saying what it was NOT. Name it for what it does instead.
@@ -16698,6 +16879,13 @@ def _landing():
             # an outage past a blip). With nothing attached no class is set and the glyph stays exactly
             # as it was, monochrome.
             ".rn-ok{fill:var(--accent)}.rn-wait{fill:#8a8a8a}.rn-warn{fill:#e5484d}\n"
+            # A host dropping flashes the glyph red three times and stops (the user 2026-07-29). It
+            # replaces a banner that covered the session tabs to say the same thing. The flash rides
+            # background + ring, NOT color, so it composes with whatever fleet colour the glyph is
+            # already wearing instead of fighting it.
+            ".rail-act.rn-drop,#mtabs .mact.rn-drop{animation:rnet-drop 0.42s ease-in-out 3}"
+            "@keyframes rnet-drop{0%,100%{background:transparent;box-shadow:none}"
+            "50%{background:rgba(229,72,77,0.45);box-shadow:0 0 0 2px rgba(229,72,77,0.9)}}"
             # mid-attach motion cue (the user 2026-07-12): while any tunnel is authorizing/connecting/starting
             # the network glyph turns accent and its connector lines MARCH (dashes flowing down the bus) — the
             # icon visibly "does something" during the seconds an attach takes. Class-driven off the same

--- a/tests/test_tunnel_stale_and_logging.py
+++ b/tests/test_tunnel_stale_and_logging.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""A live ssh proc is not proof of a live tunnel, and every dial leaves a record (the user 2026-07-29).
+
+A morning was lost to a host that would not come back after the laptop moved from ethernet to Wi-Fi,
+while plain `ssh <host>` worked the entire time. Two things in here made that undiagnosable and then
+unrecoverable:
+
+  1. _spawn_tunnel sent ssh's stdout AND stderr to DEVNULL. The one line naming the cause of a failed
+     dial was destroyed as it was printed, so afterwards nothing on the machine could say why.
+  2. The supervisor re-dials only a DEAD proc. ssh answers a local connect from its own listener, so an
+     ssh whose transport is gone is indistinguishable from a healthy tunnel with no romp behind it —
+     the row sat at 'no-kernel' forever with no re-dial and no reap, and the panel offered only "Start",
+     which says to go restart the REMOTE kernel. Worse, Try now called attach_remote, which spawned only
+     when the proc was dead — so the button meant to break this wedge declined to act on exactly it.
+
+The fix keys on the probe's SHAPE, which separates the two exactly: a far side that refused SPOKE (the
+tunnel carries traffic, romp is genuinely absent), one that timed out never did (the path is gone).
+
+Synthetic only — hermetic temp STATE, placeholder hostnames/tokens, no real ssh.
+"""
+import json
+import os
+import socket
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_stale", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class ProbeVerdict(unittest.TestCase):
+    """_poll_remote_sids must say HOW it failed, not just that it did."""
+
+    def _poll(self, port):
+        r = {"host": "TESTHOST", "local_port": port, "token": ""}
+        sids = km._poll_remote_sids(r)
+        return sids, r.get("_probe")
+
+    def test_a_far_side_that_refuses_is_recorded_as_refused_not_as_a_dead_path(self):
+        # nothing listening → the connect is refused outright: this is what "no kernel over there" looks
+        # like, and it must never be mistaken for a tunnel that stopped carrying traffic
+        s = socket.socket()
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        s.close()
+        sids, probe = self._poll(port)
+        self.assertIsNone(sids)
+        self.assertEqual(probe, "refused")
+
+    def test_a_listener_that_never_answers_is_recorded_as_a_timeout(self):
+        # accepts the connect, then says nothing — exactly how an ssh holding a forward over a dead
+        # transport behaves, and the case that must trigger a re-dial
+        srv = socket.socket()
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        port = srv.getsockname()[1]
+        try:
+            sids, probe = self._poll(port)
+            self.assertIsNone(sids)
+            self.assertEqual(probe, "timeout", "silence is a dead path, not a missing kernel")
+        finally:
+            srv.close()
+
+
+class SupervisorActsOnTheVerdict(unittest.TestCase):
+    """The kill is gated on the verdict, so a host whose romp is simply not running keeps its tunnel."""
+
+    def setUp(self):
+        import inspect as _i
+        self.src = _i.getsource(km._tunnel_supervisor)
+
+    def test_a_timed_out_no_kernel_row_is_killed_so_the_dead_proc_path_redials(self):
+        self.assertIn('if st == "no-kernel" and r.get("_probe") == "timeout":', self.src,
+                      "the stale-tunnel kill keys on the probe verdict, never on a timer or a counter")
+        self.assertIn('r["proc"].terminate()', self.src)
+        self.assertIn("stale-tunnel", self.src, "and it goes on the record")
+
+    def test_the_kill_is_never_reached_on_a_refusal(self):
+        # A refusal proves the tunnel carries traffic — churning its ssh would be pure damage, and would
+        # re-dial every 15s forever against a box whose romp is deliberately off. So the ONLY terminate()
+        # in the supervisor must sit under the timeout-qualified guard, not under the plain no-kernel
+        # branch that writes the row's detail.
+        lines = self.src.splitlines()
+        guard = [i for i, ln in enumerate(lines) if 'st == "no-kernel" and r.get("_probe") == "timeout"' in ln]
+        kills = [i for i, ln in enumerate(lines) if "terminate()" in ln]
+        self.assertEqual(len(guard), 1, "one guard")
+        self.assertEqual(len(kills), 1, "one kill")
+        self.assertLess(guard[0], kills[0], "the kill is inside the guard")
+        self.assertLess(kills[0] - guard[0], 6, "and directly under it, not in some later branch")
+        plain = [i for i, ln in enumerate(lines) if 'elif st == "no-kernel"' in ln]
+        self.assertTrue(plain and plain[0] > kills[0],
+                        "the detail-only no-kernel branch comes after, and kills nothing")
+
+    def test_a_dead_dial_is_logged_once_with_what_ssh_printed(self):
+        self.assertIn('not r.get("_death_logged")', self.src, "once per death, not once per pass")
+        self.assertIn('_tunnel_log(r["host"], "died"', self.src)
+        self.assertIn("_forward_bind_failed(err)", self.src,
+                      "a bind failure repeats forever unless the ports move")
+
+
+class ForwardBindFailure(unittest.TestCase):
+    def test_ssh_s_own_words_for_a_port_it_cannot_bind_are_recognised(self):
+        for line in ("bind: Address already in use",
+                     "Error: remote port forwarding failed for listen port 52025",
+                     "channel_setup_fwd_listener_tcpip: cannot listen to port: 57946"):
+            self.assertTrue(km._forward_bind_failed(line), line)
+
+    def test_an_unrelated_failure_is_not_mistaken_for_one(self):
+        for line in ("", "Permission denied (publickey).", "ssh: Could not resolve hostname TESTHOST",
+                     "Timeout, server TESTHOST not responding."):
+            self.assertFalse(km._forward_bind_failed(line), line)
+
+    def test_reminting_moves_every_forwarded_port_off_the_one_that_collided(self):
+        r = {"host": "TESTHOST", "local_port": 51000, "bus_port": 51001, "_peer_notified": (True, "trusted")}
+        km._remint_forward_ports(r)
+        self.assertNotEqual(r["local_port"], 51000)
+        self.assertNotEqual(r["bus_port"], 51001)
+        self.assertIsNone(r["_peer_notified"], "the bus holds a stale endpoint until it is re-notified")
+
+    def test_reminting_a_checked_in_row_also_moves_its_reverse_ports_and_re_handshakes(self):
+        r = {"host": "TESTHOST", "local_port": 51000, "bus_port": 51001, "checkin": True,
+             "rk_port": 52025, "rb_port": 52026, "_handshook": 999}
+        km._remint_forward_ports(r)
+        self.assertNotEqual(r["rk_port"], 52025)
+        self.assertNotEqual(r["rb_port"], 52026)
+        self.assertNotIn("_handshook", r, "the hub must be told the new ports")
+
+
+class DialLog(unittest.TestCase):
+    def test_every_dial_and_death_is_appended_with_its_reason(self):
+        km._tunnel_log("TESTHOST", "dial", pid=4242, fails=0, argv=["ssh", "-N", "--", "TESTHOST"])
+        km._tunnel_log("TESTHOST", "died", code=255, stderr="bind: Address already in use", fails=1)
+        rows = [json.loads(x) for x in km.TUNNEL_LOG.read_text().splitlines() if x.strip()]
+        rows = [x for x in rows if x.get("host") == "TESTHOST"]
+        self.assertEqual([x["event"] for x in rows][-2:], ["dial", "died"])
+        self.assertEqual(rows[-1]["stderr"], "bind: Address already in use",
+                         "the REASON is the whole point of the log")
+        self.assertTrue(all("t" in x for x in rows), "each line is dated")
+
+    def test_logging_never_raises_into_the_supervisor(self):
+        # an unserialisable value must not take down the thread that is trying to reconnect you
+        km._tunnel_log("TESTHOST", "dial", proc=object(), sock=socket.socket())
+
+    def test_ssh_stderr_is_captured_to_a_file_rather_than_discarded(self):
+        import inspect as _i
+        src = _i.getsource(km._spawn_tunnel)
+        self.assertIn("stderr=(errf or subprocess.DEVNULL)", src)
+        self.assertNotIn("stderr=subprocess.DEVNULL", src,
+                         "discarding it is what made the outage undiagnosable")
+
+    def test_the_last_dial_s_words_are_readable_back_minus_ssh_s_advisory_chatter(self):
+        km.TUNNEL_ERR_DIR.mkdir(parents=True, exist_ok=True)
+        km._tunnel_err_path("TESTHOST").write_text(
+            "Warning: Permanently added 'TESTHOST' to the list of known hosts.\n"
+            "bind: Address already in use\n")
+        err = km._tunnel_stderr("TESTHOST")
+        self.assertIn("bind: Address already in use", err)
+        self.assertNotIn("Permanently added", err, "advisories are not failure reasons")
+
+    def test_a_host_name_can_never_escape_the_error_directory(self):
+        p = km._tunnel_err_path("../../etc/passwd")
+        self.assertEqual(p.parent, km.TUNNEL_ERR_DIR)
+
+
+class TryNowActuallyDials(unittest.TestCase):
+    def test_attach_redials_a_live_proc_whose_row_is_not_up(self):
+        import inspect as _i
+        src = _i.getsource(km.attach_remote)
+        self.assertIn('elif r.get("status") != "up":', src,
+                      "Try now on a wedged-but-alive tunnel used to do nothing at all")
+        self.assertIn("forced-redial", src)
+        self.assertIn('r["proc"].wait(timeout=3)', src,
+                      "wait for the old ssh to exit, or the new dial dies on its listener")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/host-offline.test.ts
+++ b/ui/webview/host-offline.test.ts
@@ -1,8 +1,12 @@
 // A DISCONNECTED remote's sessions must SAY so (the user 2026-07-29, who read a remote host's
 // transcripts for a while before realising nothing was connected). Its tabs, lanes and cards stay —
-// dropping them would lose the thread — but the "host:" token is struck, the tab dims, and the chat
-// says what it is showing and when it last updated. hostIsDown/hostDownNote are executed here against a
-// stub manager; the per-surface wiring is pinned at source.
+// dropping them would lose the thread — but the "host:" token is struck and the tab dims.
+//
+// It must say so WITHOUT taking the screen to do it (the user 2026-07-29, again): the first version put
+// a banner across the top of the pane, which landed on the session tab strip and hid the sessions. The
+// drop now flashes the rail's network glyph red three times — an event's cue for an event — and the
+// steady state stays on the tab and the glyph's own colour. hostIsDown/hostDownNote are executed here
+// against a stub manager; the per-surface wiring is pinned at source.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -16,6 +20,8 @@ const FED = read("federation.ts");
 const CSS = read("styles.css");
 const FEEDCSS = read("feed.css");
 const TL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
+// the rail (and so the drop cue) lives in the shell the kernel serves, not in the pane bundle
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
 const withFed = (fed: any, fn: () => void) => {
   const g = globalThis as any;
@@ -86,16 +92,37 @@ test("the tab dims as a whole and carries the why on hover", () => {
   assert.match(CSS, /\.tab\.host-off:hover, \.tab\.host-off\.active \{ opacity: 1; \}/, "hover still reads clearly");
 });
 
-test("the chat pane says the transcript it is showing has stopped updating", () => {
-  assert.match(RENDER, /function hostBanner\(\): void \{/);
-  assert.match(RENDER, /const off = !!activeId && hostIsDown\(activeId\)/);
-  assert.match(RENDER, /bar\.textContent = hostDownNote\(activeId\)/);
-  assert.match(RENDER, /hostBanner\(\);   \/\/ the open tab may have just become/, "repainted with the tabs");
-  assert.match(CSS, /#rhostoff \{/);
+test("no banner covers the pane — a drop flashes the rail's network glyph three times instead", () => {
+  assert.equal(RENDER.indexOf("hostBanner"), -1, "removed from the pane, not merely hidden");
+  assert.equal(RENDER.indexOf("rhostoff"), -1);
+  assert.doesNotMatch(CSS, /^#rhostoff\s*\{/m, "and its style went with it (the note recording why stays)");
+  assert.match(KERNEL, /function dropCue\(ts\)\{/);
+  assert.match(KERNEL, /if\(_wasUp\[t\.host\]&&!up\)fell=true;/,
+    "it fires on the up -> not-up TRANSITION; a steady down state must not re-flash every poll");
+  assert.match(KERNEL, /animation:rnet-drop 0\.42s ease-in-out 3\}/, "three times, then it stops");
+  assert.match(KERNEL, /dropCue\(ts\);/, "wired into the same /tunnels poll that paints the glyph");
+});
+
+test("a page opened on an already-down fleet does not flash — nothing dropped while you watched", () => {
+  // _wasUp starts empty, so a host never seen up cannot fall. The steady state is carried by the glyph's
+  // colour and the dimmed tab; a cue that fired on load would be the banner again, with extra steps.
+  assert.match(KERNEL, /var _wasUp=\{\};/);
+  assert.match(KERNEL, /_wasUp=seen;/, "replaced each poll, so a detached host cannot linger in it");
+});
+
+test("the flash rides background and ring, never colour, so it composes with the fleet state", () => {
+  // the glyph already wears accent / grey / red for fleet health — animating `color` would fight it
+  assert.match(KERNEL, /@keyframes rnet-drop\{0%,100%\{background:transparent;box-shadow:none\}/);
+  assert.match(KERNEL, /el\.classList\.remove\('rn-drop'\);void el\.offsetWidth;/, "a second drop replays it");
+});
+
+test("the note the tab carries on hover is still the one wording of it", () => {
+  // the banner is gone, but hostDownNote is not: the tab's title is where that sentence lives now
+  assert.match(RENDER, /tab\.title = hostDownNote\(id\)/);
 });
 
 test("both surfaces repaint on the reachability event", () => {
-  assert.match(RENDER, /window\.addEventListener\("romp-hosts", \(\) => \{ renderTabs\(\); hostBanner\(\); \}\)/);
+  assert.match(RENDER, /window\.addEventListener\("romp-hosts", \(\) => \{ renderTabs\(\); \}\)/);
   assert.match(TL, /window\.addEventListener\('romp-hosts', this\._onHosts\)/);
   assert.match(TL, /window\.removeEventListener\('romp-hosts', this\._onHosts\)/, "and let go on teardown");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3385,7 +3385,6 @@ function renderTabs() {
   // Restore tab-mode focus if a tab held it before this rebuild (see the top of renderTabs).
   if (refocusTab) focusActiveTab();
   syncNoSessionsPlaceholder(visibleIds.length);
-  hostBanner();   // the open tab may have just become (or stopped being) one on an unreachable host
   // (The Fleet toggle that briefly lived here as a tab-bar pill was removed 2026-06-24: Fleet/Chat are now
   // the rotated toggles in the chat pane's vertical strip — see _LANDING_FLEET_JS — so the pill was redundant.)
   // (The collapse caret moved OFF the tab bar into the #ledger strip's title row — the strip now always
@@ -3552,7 +3551,7 @@ function showTabMenu(e: MouseEvent, tab: HTMLElement, label: HTMLElement, id: st
 // A remote host coming or going flips the disconnected marks on its tabs. The federation manager fires
 // this only when the reachable set actually CHANGES (its own /tunnels poll is the event), so this is a
 // repaint per connect/drop, not per poll (the user 2026-07-29).
-window.addEventListener("romp-hosts", () => { renderTabs(); hostBanner(); });
+window.addEventListener("romp-hosts", () => { renderTabs(); });
 window.addEventListener("mousedown", (e) => { if (ctxMenuEl && !ctxMenuEl.contains(e.target as Node)) dismissTabMenu(); }, true);
 window.addEventListener("keydown", (e) => { if (e.key === "Escape") dismissTabMenu(); }, true);
 window.addEventListener("scroll", dismissTabMenu, true);
@@ -7045,17 +7044,12 @@ function pipeBanner(up: boolean, queued: number): void {
     : "romp is unreachable — reconnecting…";
 }
 
-// The open tab's own host is unreachable (the user 2026-07-29, who read a remote's transcripts for a
-// while before noticing nothing was connected). The tab dims and its "host:" is struck, but the thing
-// being READ is the transcript, so the pane it fills says so too: this stopped updating, here is when it
-// last did, and romp is still dialing. Runs on every render and on the reachable-set event.
-function hostBanner(): void {
-  const b = document.getElementById("rhostoff");
-  const off = !!activeId && hostIsDown(activeId);
-  if (!off) { if (b) b.remove(); return; }
-  const bar = b || document.body.appendChild(Object.assign(document.createElement("div"), { id: "rhostoff" }));
-  bar.textContent = hostDownNote(activeId);
-}
+// (A banner used to drop across the top of this pane when the open tab's host went away. It covered the
+// session tab strip — the thing you steer by — to report what the tabs already say themselves: the tab on
+// an unreachable host dims, its "host:" token is struck, and the note lives on hover. A host dropping now
+// flashes the rail's network glyph red three times instead (the user 2026-07-29, whose sessions the banner
+// hid). An event gets a transient cue; the steady state stays on the surfaces already carrying it; no pixel
+// of transcript is spent. hostDownNote is still the one place that note is worded — see host-prefix.ts.)
 
 window.addEventListener("message", (e: MessageEvent) => {
   const m = e.data;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1994,9 +1994,8 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
    browser shim's self-injected stale bar. Defined in feed.css too (the .romp-acted precedent). */
 #rpipe { position: fixed; top: 0; left: 0; right: 0; z-index: 99999; text-align: center;
   background: #2b2d30; color: #e6e6e6; border-bottom: 1px solid #4a4d51; padding: 7px 14px; }
-/* The open tab's HOST is unreachable (the user 2026-07-29): the transcript below is the last thing romp
-   got from that machine, and a frozen chat is otherwise indistinguishable from a quiet one. Sits in the
-   flow at the top of the pane, quieter than #rpipe — nothing here is broken locally. */
-#rhostoff { position: fixed; top: 0; left: 0; right: 0; z-index: 99998; text-align: center;
-  background: #33302a; color: #e0c48a; border-bottom: 1px solid #4a4436; padding: 6px 14px;
-  font-size: 0.86em; }
+/* (#rhostoff, an unreachable-host banner pinned to the top of the pane, lived here for a few hours on
+   2026-07-29 and was removed the same day: fixed to the top, it landed squarely on the session tab strip
+   and hid the sessions to announce that one machine had gone away. The drop now flashes the rail's
+   network glyph — .rn-drop / @keyframes rnet-drop, in the shell the kernel serves — and the steady state
+   stays on .tab.host-off and .host-prefix.off above, which cost no space to begin with.) */


### PR DESCRIPTION
The banner that announced an unreachable host was pinned to the top of the pane, which put it over the session tab strip: to say one machine had gone away, it hid the sessions you steer by. A drop is an event, so it gets an event's cue now — the rail's network glyph flashes red three times and stops, on the up-to-not-up transition only. The steady state was already on the tab (dimmed, host token struck, note on hover) and on the glyph's own fleet colour. A page opened on an already-down fleet stays quiet.

Underneath, the reason a host stayed unreachable this morning while plain `ssh` to it worked throughout. Conferred with the two sessions on the remote host; the network layer was clean after the interface switch (every dial accepted, nothing throttled, no bind failures), so this is the dialing side.

**A live ssh proc was taken as proof of a live tunnel.** ssh answers the local connect from its own listener, so an ssh whose transport is gone is indistinguishable from a healthy tunnel with no romp behind it. The supervisor re-dials only a dead proc, so the row sat at "no kernel answering" indefinitely — no re-dial, no reap, no backoff — and the panel offered only Start, which says to restart the far end. The probe's shape separates the two exactly: a far side that refused *spoke*; one that timed out never did. Only the timeout kills the proc, once, on the transition. Try now is now offered on every non-up row, and drops a live ssh rather than declining to act on the one wedge it exists for.

**Every dial failure's reason was destroyed as it was printed** — stdout and stderr both to DEVNULL. ssh's stderr is kept now, per host and per dial, copied into an append-only log with the argv, exit code and probe verdict. That also makes one failure self-healing: a forward that cannot bind repeats forever because the ports are minted once and reused, so the next dial rebuilds the same doomed command. Recognised from ssh's own words now, and the ports re-minted.

Tests: `tests/test_tunnel_stale_and_logging.py` (new, synthetic — probe verdicts exercised against real sockets, no ssh) and the rewritten banner tests in `ui/webview/host-offline.test.ts`. Full suites green: 3561 Python, 1443 node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)