### PR TITLE
The shell measures itself against the box that clips it, not against 100vh

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16359,7 +16359,13 @@ _LANDING_MOBILE_JS = """
 function fit(){try{var h=(window.visualViewport&&window.visualViewport.height)||window.innerHeight;
 if(h)document.documentElement.style.setProperty('--app-h',h+'px');}catch(e){}}
 fit();window.addEventListener('resize',fit);window.addEventListener('orientationchange',fit);
-if(window.visualViewport){window.visualViewport.addEventListener('resize',fit);}
+// iOS Safari collapses/expands its toolbars AS YOU SCROLL, and the visible height changes with them
+// without a window resize; the visual viewport's own scroll event is where that settles. pageshow covers
+// a restore from the back/forward cache, which hands back the height the page had when it was frozen.
+// (the user 2026-07-29, whose iPad clipped the bottom off with the toolbars showing.)
+window.addEventListener('pageshow',fit);
+if(window.visualViewport){window.visualViewport.addEventListener('resize',fit);
+window.visualViewport.addEventListener('scroll',fit);}
 var bar=document.getElementById('mtabs');if(!bar)return;
 // The bar is position:fixed (glued to the viewport bottom), so it's out of flow — reserve its real
 // rendered height (button text + padding) on .col as --mtabs-h so the iframes tile above it and the
@@ -16625,7 +16631,17 @@ def _landing():
             "<meta name=viewport content='width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no'>"
             "<link rel=icon type=image/svg+xml href=/media/romp-swirl-glyph.svg><title>Romp</title><style>"
             ":root{--accent:#9cd2ff;--accent-fg:#0c1a2e}"
-            "html,body{margin:0;height:100%;background:#1e1e1e;overflow:hidden}"
+            # The chain, widest support last-wins: 100% (always right where the viewport is static), then
+            # 100dvh (tracks browser chrome appearing/collapsing), then --app-h, the live
+            # visualViewport.height _LANDING_MOBILE_JS publishes. This used to be a mobile-only rule, so a
+            # LANDSCAPE TABLET — too wide for both mobile breakpoints — took this branch and threw the
+            # accurate measurement away (the user 2026-07-29, on an iPad).
+            "html,body{margin:0;height:100%;height:100dvh;height:var(--app-h,100dvh);"
+            "background:#1e1e1e;overflow:hidden}"
+            # A pane whose document has not painted yet is a WHITE rectangle in the shell's dark frame
+            # (Firefox shows it plainly). Give the frames the shell's own background so a slow or blank
+            # pane reads as empty romp rather than as a white strip torn out of the UI.
+            "iframe{background:#1e1e1e}"
             # A hair of breathing room down the right edge (the user 2026-07-23). The panes tiled flush to
             # the window, so whatever sits hard right inside them — a feed card's controls, the timeline's
             # lock padlock at the now-edge, the rail's own right-pinned actions — was pressed against the
@@ -16633,7 +16649,13 @@ def _landing():
             # and the bottom rail alike. border-box so the strip comes OUT of the 100vh box instead of
             # adding to it and overflowing. Deliberately tiny — a visible margin would read as a design
             # element rather than as slack.
-            ".col{display:flex;flex-direction:column;height:100vh;box-sizing:border-box;padding-right:3px}"
+            # height:100% — of the BODY, deliberately not 100vh (the user 2026-07-29, whose iPad clipped
+            # the whole bottom off and whose Firefox showed a strip over the bottom bar). body is what
+            # CLIPS (overflow:hidden) and it measures the real viewport; 100vh on iOS Safari is the LARGE
+            # viewport, the one you get with the address bar collapsed, so while any browser chrome is on
+            # screen this box was taller than the body containing it and the rail fell out of the bottom.
+            # Two height bases for the same box is the bug; there is now one, and it is the body's.
+            ".col{display:flex;flex-direction:column;height:100%;box-sizing:border-box;padding-right:3px}"
             # the shell is a single flex row: far-left pane rail, then up to FOUR independently-toggled panes
             # (chat | fleet | feed | timeline, fixed order) separated by draggable gutters (the user 2026-06-24).
             # The timeline is just the 4th pane now — no more bottom band / minimize button.
@@ -16649,14 +16671,16 @@ def _landing():
             # iframe must render + lift over the whole window EVEN WHEN the feed pane is toggled off (the user
             # 2026-06-25) — un-hide the pane and pin the iframe full-screen while the modal is open.
             "body.settings-open #feed-pane{display:block!important}"
-            "body.settings-open #f-feed{display:block;position:fixed;inset:0;z-index:200;width:100vw;height:100vh}"
+            # inset:0 alone sizes a fixed box to the viewport; the explicit 100vw/100vh OVERRODE it and
+            # overshot on iOS, hanging the modal's own actions below the fold (the user 2026-07-29).
+            "body.settings-open #f-feed{display:block;position:fixed;inset:0;z-index:200}"
             # New-session PICKER full-screen (the user 2026-07-05): the picker lives INSIDE the /chat iframe, so
             # its position:fixed;inset:0 only covered the chat PANE — a short pane couldn't scroll the session
             # list. Same bridge as settings: render.ts posts {romp:'picker',on} and the shell lifts the chat
             # iframe over the whole window (body.picker-open) so the overlay fills the screen and the list gets
             # the full height to scroll. Restored on close.
             "body.picker-open #chat-pane{display:block!important}"
-            "body.picker-open #f-chat{display:block;position:fixed;inset:0;z-index:200;width:100vw;height:100vh}"
+            "body.picker-open #f-chat{display:block;position:fixed;inset:0;z-index:200}"
             # ── pane rail (the user 2026-06-24; rotated to a BOTTOM BAR the user 2026-07-05): a thin toolbar with
             # Chat / Timeline / Outline / Feed toggles. It used to be a vertical strip on the far LEFT; it now runs
             # HORIZONTALLY across the bottom of .col, BELOW the timeline band (last child of .col). Each toggle is

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -113,7 +113,9 @@ class LandingShell(unittest.TestCase):
         # pressed against the frame or clipped by it (the user 2026-07-23). .col is the one wrapper that
         # covers the pane row, the timeline band and the bottom rail together.
         html = km._landing()
-        self.assertIn(".col{display:flex;flex-direction:column;height:100vh;box-sizing:border-box;padding-right:3px}", html)
+        # height:100%, not 100vh: the body is what clips, and on iOS 100vh is the address-bar-collapsed
+        # viewport, which pushed the rail out of the bottom (the user 2026-07-29)
+        self.assertIn(".col{display:flex;flex-direction:column;height:100%;box-sizing:border-box;padding-right:3px}", html)
         # border-box, or the strip ADDS to the 100vh box and the shell overflows instead of insetting
         self.assertIn("box-sizing:border-box;padding-right:3px", html)
 

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -101,7 +101,7 @@ class PaneRailTest(unittest.TestCase):
         # Pinned as the flex-column STRUCTURE this test is about, not as the whole declaration list: it
         # broke on an unrelated right-edge padding (the user 2026-07-23) that says nothing about where the
         # band sits. test_kernel_mobile owns that strip.
-        self.assertIn(".col{display:flex;flex-direction:column;height:100vh", self.html)
+        self.assertIn(".col{display:flex;flex-direction:column;height:100%", self.html)
         self.assertIn("#tl-pane{flex:0 0 var(--tl,200px)}", self.html)          # a fixed-height bottom band
         self.assertIn("body:not(.po-timeline) #gh,body:not(.po-timeline) #tl-pane{display:none}", self.html)
         self.assertIn("<div class=gh id=gh></div>", self.html)                  # the row-resize gutter is back

--- a/tests/test_shell_viewport_fit.py
+++ b/tests/test_shell_viewport_fit.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""The shell fits the VISIBLE viewport, on every browser (the user 2026-07-29).
+
+Two reports, one root cause. On an iPad the whole bottom of the UI was cut off; in Firefox a strip along
+the bottom sat over the rail. The shell sized its column with `100vh` while the body that CLIPS it
+(overflow:hidden) was sized `height:100%`. Those are the same number only when no browser chrome is
+moving: on iOS Safari `100vh` is the LARGE viewport, the one you get with the address bar collapsed, so
+whenever a toolbar is on screen the column was taller than the box containing it and the rail fell out of
+the bottom. Two height bases for one box is the bug.
+
+Worse, the accurate measurement already existed and was thrown away: _LANDING_MOBILE_JS publishes the
+live visualViewport height as --app-h, but only the MOBILE media query consumed it, and a landscape
+tablet is too wide for both mobile breakpoints, so it took the desktop branch.
+
+Verified in real Firefox before/after by forcing --app-h shorter than 100vh (the iOS toolbar case): the
+rail measured 870..900 inside a 600px-tall body before, and 570..600 after.
+"""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_vhfit", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class OneHeightBasis(unittest.TestCase):
+    def setUp(self):
+        self.html = km._landing()
+
+    def test_the_column_is_measured_against_the_body_that_clips_it(self):
+        self.assertIn(".col{display:flex;flex-direction:column;height:100%;box-sizing:border-box;", self.html)
+        self.assertNotIn("height:100vh;box-sizing:border-box", self.html,
+                         "the column must not carry a viewport unit of its own")
+
+    def test_the_shell_height_chain_applies_at_every_width(self):
+        # 100% → 100dvh → --app-h, last-wins, so an old browser still gets a full-height shell and a
+        # modern one tracks chrome appearing and collapsing. NOT inside a media query any more: a
+        # landscape tablet matches neither mobile breakpoint.
+        self.assertIn("html,body{margin:0;height:100%;height:100dvh;height:var(--app-h,100dvh);"
+                      "background:#1e1e1e;overflow:hidden}", self.html)
+
+    def test_no_full_height_box_is_left_on_a_raw_viewport_unit(self):
+        # every remaining 100vh in the shell would be a box that ignores the toolbars
+        shell = self.html
+        for frag in ("width:100vw;height:100vh", ".col{display:flex;flex-direction:column;height:100vh"):
+            self.assertNotIn(frag, shell, frag)
+
+    def test_a_lifted_pane_is_sized_by_its_insets_not_by_viewport_units(self):
+        # inset:0 already IS the viewport box for a fixed element; the explicit 100vw/100vh overrode it
+        self.assertIn("body.settings-open #f-feed{display:block;position:fixed;inset:0;z-index:200}", self.html)
+        self.assertIn("body.picker-open #f-chat{display:block;position:fixed;inset:0;z-index:200}", self.html)
+
+    def test_an_unpainted_pane_is_dark_not_white(self):
+        # a pane whose document has not painted is a white rectangle in a dark frame (Firefox shows it
+        # plainly) — which is exactly what "a white strip at the bottom" looks like
+        self.assertIn("iframe{background:#1e1e1e}", self.html)
+
+
+class RefitsWhenTheVisibleHeightChanges(unittest.TestCase):
+    def setUp(self):
+        self.js = km._LANDING_MOBILE_JS
+
+    def test_it_drives_app_h_off_the_live_visual_viewport(self):
+        self.assertIn("var h=(window.visualViewport&&window.visualViewport.height)||window.innerHeight;", self.js)
+        self.assertIn("setProperty('--app-h',h+'px')", self.js)
+
+    def test_it_refits_on_the_events_ios_actually_changes_the_height_on(self):
+        # iOS collapses its toolbars AS YOU SCROLL, with no window resize; the visual viewport's own
+        # scroll event is where that settles. pageshow covers a back/forward-cache restore.
+        for ev in ("'resize',fit", "'orientationchange',fit", "'pageshow',fit"):
+            self.assertIn("window.addEventListener(" + ev, self.js)
+        self.assertIn("window.visualViewport.addEventListener('scroll',fit)", self.js)
+        self.assertIn("window.visualViewport.addEventListener('resize',fit)", self.js)
+
+    def test_the_fit_runs_even_with_no_mobile_tab_bar(self):
+        # it must apply on a desktop/tablet layout too, so the fit and its listeners come BEFORE the
+        # #mtabs early return — that ordering is the whole reason a landscape tablet gets a real height
+        fit_at = self.js.index("fit();window.addEventListener('resize',fit)")
+        bar_at = self.js.index("var bar=document.getElementById('mtabs');if(!bar)return;")
+        self.assertLess(fit_at, bar_at)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two reports, one root cause: an iPad cut the whole bottom of the UI off, and Firefox showed a strip along the bottom over the rail.

**The bug.** `.col` was sized `height:100vh` while the body that clips it (`overflow:hidden`) was sized `height:100%`. Those agree only while no browser chrome is moving. On iOS Safari `100vh` is the *large* viewport — address bar collapsed — so with any toolbar on screen the column stood taller than its containing box and the rail fell out of the bottom.

**The accurate number already existed and was thrown away.** The shell publishes the live `visualViewport.height` as `--app-h`, but only the mobile media query consumed it, and a landscape tablet is too wide for both mobile breakpoints, so it took the desktop branch's plain `height:100%`.

Changes:
- `.col{height:100%}` — one height basis, the body's.
- The chain `100% → 100dvh → var(--app-h)` applies at **every** width, not just mobile.
- The fit re-runs on `visualViewport` **scroll** (where an iOS toolbar collapse settles, with no window resize) and on `pageshow` (back/forward-cache restore).
- The two lifted panes (settings, picker) were `position:fixed;inset:0` **and** `width:100vw;height:100vh`; the viewport units override the insets and overshoot on iOS, hanging a modal's own buttons below the fold. Insets alone now.
- `iframe{background:#1e1e1e}` so a pane that has not painted reads as empty romp rather than a white strip — which is what a blank frame looks like in Firefox, and matches the reported symptom.

**Verified in real Firefox, before and after**, by forcing `--app-h` shorter than `100vh` to stand in for the iOS toolbar case: the rail measured `870..900` inside a 600px-tall body before ("NO - clipped"), `570..600` after ("YES").

Tests: `tests/test_shell_viewport_fit.py` (one height basis, no raw viewport unit left on a full-height box, insets-only overlays, dark iframes, and the refit event set incl. the ordering that makes it apply on a tablet), plus two stale `.col` pins updated. Both suites green (3579 python, 1445 node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)