### PR TITLE
Send is sized like the primary action it is, and a thumb can hit it

### DIFF
--- a/tests/test_shell_mobile_composer_pad.py
+++ b/tests/test_shell_mobile_composer_pad.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""The mobile shell's composer padding is load-bearing for the send button's position (2026-07-29).
+
+The Send and Attach buttons are absolutely positioned inside #composer, so their `right` offsets are
+measured from ITS padding edge. The kernel's mobile CSS narrows that padding from 24px to 10px, and
+styles.css carries a second set of offsets under the SAME media query to match. Change the padding here
+and the buttons move relative to the box they are supposed to sit inside — which is exactly the class of
+breakage this pins, since the two live in different files and the coupling is otherwise invisible.
+
+(A landscape iPad is a coarse pointer WIDER than 1024, so it keeps the desktop padding: that is why the
+query carries a max-width at all, and why the offsets cannot simply live in the coarse block.)
+"""
+import os
+import re
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_mcomp", os.path.join(BIN, "romp-kernel")).load_module()
+STYLES = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "styles.css")).read()
+
+
+class MobileComposerPadding(unittest.TestCase):
+    def test_the_mobile_shell_narrows_the_composer_padding_to_10px(self):
+        self.assertIn("#composer{padding:8px 10px 6px}", km._CHAT_MOBILE_CSS)
+
+    def test_it_is_scoped_to_coarse_pointers_up_to_1024px(self):
+        self.assertIn("@media (pointer:coarse) and (max-width:1024px)", km._CHAT_MOBILE_CSS)
+
+    def test_the_button_offsets_carry_a_matching_query(self):
+        self.assertIn("@media (pointer: coarse) and (max-width: 1024px) {", STYLES)
+        block = STYLES.split("@media (pointer: coarse) and (max-width: 1024px) {")[1].split("}")[0]
+        self.assertIn("right: 14px", block, "send sits 4px inside the narrowed 10px padding")
+
+    def test_the_offsets_keep_both_buttons_inside_the_box_at_both_paddings(self):
+        """Arithmetic, so a future nudge to one number cannot quietly overlap the two buttons."""
+        def px(pattern, where=STYLES):
+            m = re.search(pattern, where)
+            self.assertIsNotNone(m, "missing rule: %s" % pattern)
+            return int(m.group(1))
+
+        coarse = STYLES[STYLES.index("/* TOUCH (the user 2026-07-29"):]
+        narrow = STYLES.split("@media (pointer: coarse) and (max-width: 1024px) {")[1].split("\n}")[0]
+        send_w = px(r"#composer-send \{ right: 28px; width: (\d+)px", coarse)
+        att_w = px(r"#composer-attach \{ right: 136px; width: (\d+)px", coarse)
+        for label, send_right, att_right, pad in (
+                ("wide (iPad landscape, 24px padding)", 28, 136, 24),
+                ("narrow (mobile shell, 10px padding)", px(r"#composer-send \{ right: (\d+)px; \}", narrow),
+                 px(r"#composer-attach \{ right: (\d+)px; \}", narrow), 10)):
+            with self.subTest(label):
+                self.assertGreaterEqual(send_right, pad, "send would hang outside the box's right edge")
+                self.assertGreaterEqual(att_right, send_right + send_w,
+                                        "the paperclip would overlap the send button")
+                self.assertGreaterEqual(att_right, pad)
+                # and neither is so far left that it lands under the text's own inset
+                self.assertLess(att_right + att_w, 400, "the pair would eat a phone's whole box width")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/composer-buttons.test.ts
+++ b/ui/webview/composer-buttons.test.ts
@@ -1,0 +1,62 @@
+// Send and Attach are sized to be hit (the user 2026-07-29, on an iPad). They were 26px squares tucked
+// in the corner of the message box: passable with a mouse, a poor target for a thumb, and on a touch
+// layout — where the resting box is already two lines tall — they read as a stray row under the
+// placeholder rather than as the pane's controls.
+//
+// Send is the primary action of the whole chat, so it gets real width instead of matching the paperclip
+// beside it, and on a coarse pointer both become a 44px row along the bottom of the box with the text
+// running full width above them.
+//
+// The offsets are measured from #composer, so they depend on ITS padding — which the kernel's mobile
+// shell narrows from 24px to 10px. That coupling is what the paired media queries below are about, and
+// tests/test_shell_mobile_composer_pad.py pins the kernel end of it.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const coarse = CSS.slice(CSS.indexOf("/* TOUCH (the user 2026-07-29"));
+
+test("the old 26px squares are gone", () => {
+  assert.doesNotMatch(CSS, /#composer-attach, #composer-send \{[^}]*width: 26px; height: 26px/);
+  assert.match(CSS, /#composer-attach, #composer-send \{ bottom: 10px; height: 30px; \}/);
+});
+
+test("send is the widest control in the corner, not a twin of the paperclip", () => {
+  assert.match(CSS, /#composer-send \{ right: 28px; width: 46px; font-size: 16px; \}/);
+  assert.match(CSS, /#composer-attach \{ right: 82px; width: 34px; font-size: 16px; \}/);
+  // 28 + 46 = 74, so the paperclip at 82 clears it with room; the text stops clear of both
+  assert.match(CSS, /#composer-input \{ padding-right: 92px; \}/);
+});
+
+test("a coarse pointer gets a 44px row: the tap target a finger expects", () => {
+  assert.match(coarse, /#composer-attach, #composer-send \{ bottom: 12px; height: 44px; border-radius: 8px; \}/);
+  assert.match(coarse, /#composer-send \{ right: 28px; width: 96px; font-size: 21px; \}/);
+  assert.match(coarse, /#composer-attach \{ right: 136px; width: 60px; font-size: 19px; \}/);
+  // 28 + 96 = 124, so 136 clears the send button by 12px
+});
+
+test("on touch, send wears the accent as a FILL and the glyph flips to the on-accent colour", () => {
+  assert.match(coarse, /background: var\(--accent\); color: var\(--accent-fg\); opacity: 1;/);
+  // hover is included on purpose: a touch device can leave a sticky :hover that would otherwise
+  // repaint the fill with the toolbar hover grey
+  assert.match(coarse, /#composer-send, #composer-send:not\(:disabled\), #composer-send:hover:not\(:disabled\)/);
+});
+
+test("disabled is a muted fill, not a ghost", () => {
+  // 0.3 opacity on a 96px button reads as a rendering fault rather than a disabled control
+  assert.match(coarse, /#composer-send:disabled \{ background: rgba\(255, 255, 255, 0\.10\); color: var\(--dim\); opacity: 1; \}/);
+});
+
+test("on touch the text runs full width, with the button row's height reserved under it", () => {
+  assert.match(coarse, /#composer-input \{ padding-right: 12px; padding-bottom: 62px; min-height: calc\(2\.8em \+ 62px\); \}/);
+});
+
+test("the narrow offsets are matched to the query that narrows #composer's padding", () => {
+  // A landscape iPad is coarse but WIDER than 1024, so it keeps desktop padding. Phone offsets applied
+  // there would hang both buttons outside the box — hence the second, narrower query rather than
+  // folding these into the coarse block above.
+  assert.match(CSS, /@media \(pointer: coarse\) and \(max-width: 1024px\) \{\s*\n\s*#composer-send \{ right: 14px; \}\s*\n\s*#composer-attach \{ right: 122px; \}/);
+  // 14 + 96 = 110, so 122 clears send by 12px at the narrow padding too
+});

--- a/ui/webview/composer-icons.test.ts
+++ b/ui/webview/composer-icons.test.ts
@@ -33,6 +33,6 @@ test("the statusline directory shows a monochrome folder icon (folderIcon), not 
 test("the paperclip and send glyphs wear the romp accent blue (the user 2026-07-15)", () => {
   // action affordances (not status), so var(--accent) is the intended use — currentColor on the paperclip SVG
   // then picks up the accent tint from the button color
-  assert.match(CSS, /#composer-attach \{ right: 58px; color: var\(--accent\)/);
+  assert.match(CSS, /#composer-attach \{ color: var\(--accent\)/);   // the offset moved to the sizing block (2026-07-29)
   assert.match(CSS, /#composer-send:not\(:disabled\) \{ color: var\(--accent\)/);
 });

--- a/ui/webview/composer-send.test.ts
+++ b/ui/webview/composer-send.test.ts
@@ -61,9 +61,12 @@ test("the send button is disabled on a closed (read-only) session", () => {
 });
 
 test("the send button is styled to the right of 📎 and the textarea reserves room for both", () => {
-  assert.match(CSS, /#composer-send\s+\{ right: 30px/);
-  assert.match(CSS, /#composer-attach \{ right: 58px/);
+  // resized 2026-07-29 (send is the primary action, so it is the wider of the two); the touch layout and
+  // the arithmetic that keeps the pair inside the box live in composer-buttons.test.ts
+  assert.match(CSS, /#composer-send \{ right: 28px; width: 46px/);
+  assert.match(CSS, /#composer-attach \{ right: 82px; width: 34px/);
   assert.match(CSS, /#composer-input \{[\s\S]*padding: 8px 64px 8px 10px/);
+  assert.match(CSS, /#composer-input \{ padding-right: 92px; \}/, "…widened for the bigger pair");
 });
 
 test("the composer sits tight to the bottom — no wasted gap below it (the user 2026-06-23)", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -516,19 +516,27 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 @keyframes slash-spin { to { transform: rotate(-360deg); } }
 @media (prefers-reduced-motion: reduce) { .slash-spin { animation: none; } }
 #composer-attach, #composer-send {
-  position: absolute; bottom: 12px;
-  width: 26px; height: 26px; padding: 0; line-height: 1;
+  position: absolute;   /* size + offsets: the sizing block below (they differ per button now) */
+  padding: 0; line-height: 1;
   display: flex; align-items: center; justify-content: center;
   background: transparent; border: none; border-radius: 5px;
   font-size: 15px; opacity: 0.55; cursor: pointer;
 }
 /* the paperclip + send glyphs wear the romp accent blue (the user 2026-07-15) — action affordances, not
    status, so var(--accent) is the intended use; resting a touch dim, full on hover */
-#composer-attach { right: 58px; color: var(--accent); opacity: 0.8; }   /* clip sits LEFT of the send button */
-#composer-send   { right: 30px; font-size: 13px; }   /* the explicit ⏎ send button, rightmost */
+#composer-attach { color: var(--accent); opacity: 0.8; }   /* clip sits LEFT of the send button */
 #composer-attach:hover, #composer-send:hover { opacity: 1; background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.08)); }
 #composer-send:not(:disabled) { color: var(--accent); opacity: 0.85; }   /* romp-blue send affordance */
 #composer-send:disabled { opacity: 0.3; cursor: not-allowed; }
+/* SIZE (the user 2026-07-29). Both were 26px squares tucked in the corner: passable for a mouse, a poor
+   target for a thumb. Send is the primary action of the whole pane, so it gets real width — the widest
+   thing in the corner rather than the same square as the paperclip beside it. Offsets are measured from
+   #composer, whose own right padding (24px here) is what puts the textarea's edge at 24: 28 is 4px
+   inside the box. */
+#composer-attach, #composer-send { bottom: 10px; height: 30px; }
+#composer-send { right: 28px; width: 46px; font-size: 16px; }
+#composer-attach { right: 82px; width: 34px; font-size: 16px; }
+#composer-input { padding-right: 92px; }   /* text stops clear of both buttons */
 #composer-input {
   width: 100%; resize: none; box-sizing: border-box;
   /* Floor at one line + padding + border, so the box can never collapse to a
@@ -549,6 +557,34 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    full hint is visible; growComposer's inline height still floors on this, and a real message grows past it. */
 @media (pointer: coarse) {
   #composer-input { min-height: calc(2.8em + 18px); }
+}
+/* TOUCH (the user 2026-07-29, on an iPad): the two buttons sat in the corner of a two-line resting box,
+   which read as a stray row under the placeholder AND gave a thumb two 26px squares to hit. Here they
+   become a real button ROW along the bottom of the box: 44px tall (the tap target a finger expects),
+   send filled in the accent because it is the primary action, and the text runs the FULL width above
+   them instead of being squeezed into a column beside them. Same two elements, same corner — they are
+   simply big enough to be the controls they are. */
+@media (pointer: coarse) {
+  #composer-attach, #composer-send { bottom: 12px; height: 44px; border-radius: 8px; }
+  #composer-send { right: 28px; width: 96px; font-size: 21px; }
+  #composer-attach { right: 136px; width: 60px; font-size: 19px; }
+  /* the fill is the accent itself, so the glyph flips to the on-accent colour (--accent-fg) */
+  #composer-send, #composer-send:not(:disabled), #composer-send:hover:not(:disabled) {
+    background: var(--accent); color: var(--accent-fg); opacity: 1;
+  }
+  /* disabled reads as a muted FILL, not a ghost: at 0.3 opacity a 96px button looked like a render bug */
+  #composer-send:disabled { background: rgba(255, 255, 255, 0.10); color: var(--dim); opacity: 1; }
+  #composer-attach { background: rgba(255, 255, 255, 0.07); }
+  /* full-width text, with the button row's height reserved underneath it */
+  #composer-input { padding-right: 12px; padding-bottom: 62px; min-height: calc(2.8em + 62px); }
+}
+/* The mobile shell narrows #composer's own padding to 10px (kernel _CHAT_MOBILE_CSS), so the offsets
+   that put a button 4px inside the box change with it. Matched to the SAME query the padding uses, or a
+   landscape iPad — coarse but wider than 1024 — would take phone offsets against desktop padding and
+   hang both buttons outside the box. */
+@media (pointer: coarse) and (max-width: 1024px) {
+  #composer-send { right: 14px; }
+  #composer-attach { right: 122px; }
 }
 /* Cursor in the message box → a thin romp-blue border, exactly on the box edge — the same accent blue that
    marks the focused panel (the user 2026-06-26). It only fills in the existing 1px border (no glow, no layout


### PR DESCRIPTION
Send and Attach were 26px squares in the corner of the message box: passable with a mouse, a poor target for a thumb, and on a touch layout — where the resting box is already two lines tall — they read as a stray row under the placeholder rather than as the pane's controls.

- **Desktop**: send 46×30, attach 34×30. Send stops being a twin of the paperclip, since it is the primary action of the pane.
- **Coarse pointer**: both become a 44px row along the bottom of the box (the tap target a finger expects). Send is 96 wide and wears the accent as a *fill*; the text runs the full width above them rather than squeezing into a column beside them. Disabled became a muted fill, because 0.3 opacity on a button that size reads as a rendering fault.
- The offsets are measured from `#composer`, whose padding the mobile shell narrows from 24px to 10px, so the narrow offsets carry the **same media query** as that override. A landscape iPad is coarse but wider than 1024, keeps desktop padding, and phone offsets there would hang both buttons outside the box.

CSS only, so a browser reload picks it up — no kernel restart.

Verified by measuring in a real browser at both paddings: 44px tall, 4px inside the box's right edge, 12px clearance between the two, no overlap either way. Chrome headless does not report `pointer: coarse`, so the touch branch was measured by applying the same declarations unconditionally at each padding; the query pairing itself is pinned in tests.

Tests: `ui/webview/composer-buttons.test.ts` and `tests/test_shell_mobile_composer_pad.py` (the cross-file coupling, including arithmetic that fails if a future nudge overlaps the pair), plus two stale pins updated. Both suites green (3598 python, 1455 node), tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)