### PR TITLE
The + picker lists the sessions of whichever host you select

### DIFF
--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -61,6 +61,18 @@ export function prefixInbound(host: string, msg: any): any {
   // local same-named one. Guarded by a co-present id/sid so we never touch an unrelated `name` field.
   if (typeof out.name === "string" && (typeof out.id === "string" || typeof out.sid === "string"))
     out.name = prefixId(host, out.name);
+  // The + picker's session list (the user 2026-07-29: switching Host should list THAT machine's sessions,
+  // so a remote one can be reopened or revived from here). Its rows are keyed `id`, not `sid`, so the
+  // generic passes above leave them alone — and prefixing them is what makes a click route back: the row
+  // posts openSession with the id, and routeOutbound sends it to the host in the prefix. Stamped with
+  // the source host too, so the picker can drop a late reply for a host it is no longer showing.
+  if (out.type === "sessionList" && Array.isArray(out.items)) {
+    out.items = out.items.map((it: any) => (it && typeof it === "object" && typeof it.id === "string"
+      ? { ...it, id: prefixId(host, it.id),
+          name: typeof it.name === "string" ? prefixId(host, it.name) : it.name }
+      : it));
+    out.host = host;
+  }
   // timeline payloads: the lanes skeleton nests everything under `data`; the bars detail is top-level.
   if (out.type === "data" && out.data && typeof out.data === "object") out.data = prefixTimelineData(host, out.data);
   else if (out.type === "bars") return { ...out, ..._prefixTimelineDetail(host, out) };

--- a/ui/webview/picker-deep-list.test.ts
+++ b/ui/webview/picker-deep-list.test.ts
@@ -15,7 +15,7 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kern
 const JUDGE = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "judge.py"), "utf8");
 
 test("opening the picker asks for the whole list once — no lazy second fetch to wait on", () => {
-  assert.match(RENDER, /postMessage\(\{ type: "requestSessions" \}\)/);
+  assert.match(RENDER, /postMessage\(\{ type: "requestSessions", host \}\)/);   // host-addressed since 2026-07-29
   // the lazy machinery is gone: no deep flag, no pending state, no scroll trigger, no loader to strand
   assert.doesNotMatch(RENDER, /requestSessions", deep: true/);
   assert.doesNotMatch(RENDER, /pickerDeep/);

--- a/ui/webview/picker-dir.test.ts
+++ b/ui/webview/picker-dir.test.ts
@@ -28,7 +28,7 @@ test("createSession carries the chosen dir, alongside name + backend", () => {
 });
 
 test("the dir field is prefilled with the gear default and hidden in pick-mode", () => {
-  assert.match(RENDER, /di\.value = kernelDefaultDir \|\| loadSettings\(\)\.defaultDir \|\| ""/);
+  assert.match(RENDER, /return host \? "" : \(kernelDefaultDir \|\| loadSettings\(\)\.defaultDir \|\| ""\);/);
   assert.match(RENDER, /dirWrap\.style\.display = pick \? "none" : ""/);
 });
 
@@ -67,7 +67,8 @@ test("a Browse button opens the host-native folder dialog (browseDir → browseR
 });
 
 test("the dir field prefills with the kernel's real default path (not blank), still editable", () => {
-  assert.match(RENDER, /if \(typeof m\.defaultDir === "string"\) kernelDefaultDir = m\.defaultDir/);
+  // …and only from the LOCAL reply: a remote kernel's default directory is that machine's, not this one's
+  assert.match(RENDER, /if \(typeof m\.defaultDir === "string" && !from\) kernelDefaultDir = m\.defaultDir/);
   assert.match(RENDER, /di\.value = kernelDefaultDir \|\| loadSettings\(\)\.defaultDir \|\| ""/);
 });
 

--- a/ui/webview/picker-host-list.test.ts
+++ b/ui/webview/picker-host-list.test.ts
@@ -1,0 +1,72 @@
+// Switching Host in the + picker lists THAT machine's sessions (the user 2026-07-29), so a remote
+// session can be reopened — or revived, if it has aged out — without going to that machine's own
+// dashboard. Before this the list was always local, and a remote session that was not currently a tab
+// was reachable from nowhere in this UI.
+//
+// The mechanism is the prefix. The rows come back with host-prefixed ids, so the click posts
+// openSession with that id and routeOutbound sends it to the kernel that owns the session; the revive
+// confirmation rides back the same way (`id` is a generic scalar-id field). prefixInbound is EXECUTED
+// here; the picker plumbing is source-pinned, like the rest of render.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { prefixInbound, routeOutbound } from "./federation";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+const list = (items: any[]) => ({ type: "sessionList", items, defaultDir: "~/somewhere" });
+
+test("a remote session list comes back with prefixed ids and names, stamped with its host", () => {
+  const out = prefixInbound("TESTHOST", list([
+    { id: "1111-2222", name: "api", running: true, time: "running" },
+    { id: "3333-4444", name: "tests", running: false, time: "2h ago" }]));
+  assert.deepEqual(out.items.map((i: any) => i.id), ["TESTHOST:1111-2222", "TESTHOST:3333-4444"]);
+  assert.deepEqual(out.items.map((i: any) => i.name), ["TESTHOST:api", "TESTHOST:tests"]);
+  assert.equal(out.host, "TESTHOST", "so the picker can tell whose answer this is");
+  assert.equal(out.items[0].running, true, "everything else is left alone");
+});
+
+test("the LOCAL list is untouched, host and all", () => {
+  const m = list([{ id: "1111-2222", name: "web" }]);
+  assert.deepEqual(prefixInbound("", m), m, "no prefix, no host stamp, byte-identical");
+});
+
+test("a malformed row is passed through rather than mangled", () => {
+  const out = prefixInbound("TESTHOST", list([null, "nope", { name: "no id" }]));
+  assert.deepEqual(out.items, [null, "nope", { name: "no id" }]);
+});
+
+test("a click on a remote row routes to the kernel that owns the session", () => {
+  // this is the whole point of prefixing the ids: the row posts the id it was given
+  const [route] = routeOutbound({ type: "openSession", id: "TESTHOST:1111-2222" });
+  assert.equal(route.host, "TESTHOST");
+  assert.equal(route.msg.id, "1111-2222", "the kernel is host-blind — it gets its own bare id");
+  // and reviving a dead one takes the same path
+  const [rev] = routeOutbound({ type: "reviveSession", id: "TESTHOST:1111-2222" });
+  assert.deepEqual([rev.host, rev.msg.id], ["TESTHOST", "1111-2222"]);
+});
+
+test("the request names the host, and every open starts from the local list", () => {
+  assert.match(RENDER, /function requestSessionList\(host: string\): void \{\s*\n\s*pickerListHost = host;/);
+  assert.match(RENDER, /postMessage\(\{ type: "requestSessions", host \}\)/);
+  assert.match(RENDER, /requestSessionList\(""\);   \/\/ the Host row resets to local on open/);
+});
+
+test("a reply for a host the picker has moved on from is dropped, not painted", () => {
+  // two kernels answer at their own speeds, so arrival order proves nothing about which is current
+  assert.match(RENDER, /const from = typeof m\.host === "string" \? m\.host : "";/);
+  assert.match(RENDER, /if \(from !== pickerListHost\) return;/);
+  // and only the LOCAL reply's defaultDir is adopted — a remote's default belongs to that machine
+  assert.match(RENDER, /if \(typeof m\.defaultDir === "string" && !from\) kernelDefaultDir = m\.defaultDir;/);
+});
+
+test("switching host swaps the list, with something on screen while it loads", () => {
+  assert.match(RENDER, /requestSessionList\(h\);/);
+  assert.match(RENDER, /loading \$\{h\}'s sessions…/);
+});
+
+test("a reachable host with no sessions says so, instead of looking like a failed search", () => {
+  assert.match(RENDER, /if \(!list\.children\.length && pickerListHost\)/);
+  assert.match(RENDER, /no sessions on \$\{pickerListHost\} in the last 30 days/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3819,6 +3819,16 @@ function dirPrefill(host: string): string {
   return host ? "" : (kernelDefaultDir || loadSettings().defaultDir || "");
 }
 
+// Which host's sessions the picker list is currently showing ("" = this machine). The Host row picks the
+// machine a NEW session would be created on; it now also picks whose EXISTING sessions are listed, so a
+// remote session can be reopened or revived without going to that machine's own dashboard.
+let pickerListHost = "";
+
+function requestSessionList(host: string): void {
+  pickerListHost = host;
+  if (vscodeApi) vscodeApi.postMessage({ type: "requestSessions", host });
+}
+
 function pickerHost(): string {
   const sel = document.querySelector("#picker .picker-host .picker-be-opt.sel") as HTMLElement | null;
   return sel?.dataset.host || "";
@@ -4117,6 +4127,13 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
         if (browse) { browse.disabled = !!h; browse.title = h ? `The native dialog is local-only. Type the path on ${h} instead; it completes as you type.` : "Pick a folder with the native macOS dialog (opens on the kernel's machine — host-local)"; }
         const dirIn = document.getElementById("picker-dir") as HTMLInputElement | null;
         if (dirIn) dirIn.placeholder = h ? `New-session directory on ${h} (blank = its default)` : "New-session directory (blank = default)";
+        // …and the SESSIONS listed above belong to that machine now too (the user 2026-07-29): the list
+        // becomes that host's, so a remote session can be reopened or revived from here. Its rows arrive
+        // host-prefixed, so a click routes straight back to the kernel that owns them.
+        requestSessionList(h);
+        const lst = document.getElementById("picker-list");
+        if (lst) lst.replaceChildren(Object.assign(el("div", "picker-more"),
+          { textContent: h ? `loading ${h}'s sessions…` : "loading sessions…" }));
         // the completions on screen belong to the host that just stopped being selected
         closeDirMenu();
         // …and so does the PATH: this machine's default is meaningless on another box. Swap in what was
@@ -4152,7 +4169,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   }
   filterPicker(seed); // reset row visibility; arm the New-session button for the (possibly seeded) value
   pickerError(null);
-  if (vscodeApi) vscodeApi.postMessage({ type: "requestSessions" });
+  requestSessionList("");   // the Host row resets to local on open, so the list starts local too
 }
 
 // ---- revive loader (the user 2026-07-05) ----
@@ -4405,6 +4422,13 @@ function renderPicker(items: any[]) {
     const rest = avail.filter((it) => !it.running);
     if (running.length) { list.appendChild(label("Running — reopen")); for (const it of running) list.appendChild(mkRow(it)); }
     if (rest.length) { if (running.length) list.appendChild(label("Recent")); for (const it of rest) list.appendChild(mkRow(it)); }
+  }
+  if (!list.children.length && pickerListHost) {
+    // a machine romp can reach but which has no sessions in the window: say that, or an empty list reads
+    // as a search that failed or a request that never answered
+    const none = el("div", "picker-more");
+    none.textContent = `no sessions on ${pickerListHost} in the last 30 days`;
+    list.appendChild(none);
   }
   if (pickAllowNew) {
     const row = el("div", "picker-row picker-new");
@@ -7146,7 +7170,12 @@ window.addEventListener("message", (e: MessageEvent) => {
   // menu opened after the switch offers the NEW palette (the kernel remaps + repaints sessions itself).
   else if (m.type === "palette" && Array.isArray(m.colors)) paletteColors = m.colors;
   else if (m.type === "sessionList") {
-    if (typeof m.defaultDir === "string") kernelDefaultDir = m.defaultDir;
+    // Whose list is this? federation stamps the source host; a local reply carries none. A reply for a
+    // host the picker has since switched away from is dropped rather than painted over the current one
+    // (the user 2026-07-29) — two kernels answer at their own speeds, so order is not a given.
+    const from = typeof m.host === "string" ? m.host : "";
+    if (from !== pickerListHost) return;
+    if (typeof m.defaultDir === "string" && !from) kernelDefaultDir = m.defaultDir;   // the LOCAL default dir
     renderPicker(m.items || []);
   }
   else if (m.type === "browseResult" && typeof m.path === "string") {   // native Browse dialog returned a folder


### PR DESCRIPTION
The Host row picked the machine a *new* session would be created on, while the list above it always showed this machine's sessions. So a remote session that wasn't currently a tab was reachable from nowhere in this UI — not to reopen, and not to revive once it had aged out.

Switching Host now switches the list, and clicking a row reopens or revives that session on its own machine.

**The mechanism is the prefix federation already gives every remote id.** The rows come back host-prefixed, so the row's existing `openSession` carries the host, `routeOutbound` sends it to the kernel that owns the session, and the revive confirmation rides back the same way (`id` is a generic scalar-id field). No kernel change at all.

Two things the round trip demands:
- The reply is **stamped with its source host**, and a reply for a host the picker has since moved away from is dropped rather than painted over the current list. Two kernels answer at their own speeds, so arrival order proves nothing about which is current.
- Only the **local** reply's `defaultDir` is adopted; a remote kernel's default directory belongs to that machine, which is the same reason its path field prefills from what was last used there (#122).

The list also states which condition it's in: a loading line while a host's answer is in flight, and for a reachable machine with nothing in the window, that it has no sessions — rather than an empty box that reads as a failed search.

Tests: `ui/webview/picker-host-list.test.ts` — `prefixInbound`/`routeOutbound` executed (prefixing, the host stamp, malformed rows passed through, and both the open and revive routes), plus source pins for the request, the stale-reply drop, the swap and the empty case. Two stale pins updated. Both suites green (3594 python, 1456 node), tsc clean.

Pane-only, so a browser reload picks it up — no kernel restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)