### PR TITLE
Moving between networks re-dials at once, and a failed dial says whose fault it is

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4959,6 +4959,52 @@ def _port_open(port):
         s.close()
 
 
+def _primary_addr():
+    """The local address this machine would send from to reach the outside world, or "" when it has no
+    route at all.
+
+    This is romp's handle on THE NETWORK UNDER US MOVED (the user 2026-07-29, who pulled an ethernet cord
+    and moved to Wi-Fi). That is a real event with an exact signature — the source address the routing
+    table picks changes — and it is the event two separate time-based behaviours were approximating: a
+    backoff ladder waiting out up to 15 minutes before its next dial, and every live ssh sitting on a
+    transport that died the instant the interface went away. Both should key on the move itself.
+
+    A UDP `connect` sends no packets; it only asks the kernel which route and source address it would use.
+    The target is TEST-NET-1 (RFC 5737), reserved for documentation and never routed anywhere, so this
+    cannot touch a real host even by accident. No subprocess, no new thread, no dependency."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("192.0.2.1", 9))
+        return s.getsockname()[0] or ""
+    except OSError:
+        return ""                       # no route: unplugged, asleep, or between networks
+    finally:
+        s.close()
+
+
+def _host_reachable(host):
+    """Does a PLAIN ssh to this host work right now? Returns (ok, reason).
+
+    "I could ssh in the whole time" was the one fact that made this morning's outage obvious to a human
+    and invisible to romp (the user 2026-07-29). It is the discriminator that matters: an ssh that
+    succeeds while our tunnel dial fails means the host, the network and sshd are all fine and the fault
+    is ours — the opposite of what a row reading "no kernel answering" tells you. So romp asks the same
+    question the user did, and puts the answer next to the failure.
+
+    Deliberately carries NO forwards: this must test the host and nothing else, so it cannot fail for the
+    same reason the tunnel did. Only ever run on the death of a dial, never on a poll."""
+    if not _safe_ssh_host(host):
+        return False, "invalid host"
+    try:
+        p = subprocess.run([SSH_BIN, "-n", "-T"] + _SSH_OPTS + ["--", host, "true"],
+                           stdin=subprocess.DEVNULL, capture_output=True, text=True, timeout=20)
+        return p.returncode == 0, _ssh_err(p.stderr)
+    except subprocess.TimeoutExpired:
+        return False, "ssh did not answer within 20s"
+    except Exception as e:
+        return False, str(e)
+
+
 def _fetch_remote_token(host):
     """Read the remote kernel's serve-token over ssh so the browser can authorize against it (the token
     bypasses the Origin gate — see _authorize). Best-effort: '' if ssh fails or the file is absent (the
@@ -6638,14 +6684,41 @@ def _tunnel_supervisor():
     each host by polling its kernel's /sessions THROUGH the -L tunnel — the host↔sid map the wake-router uses
     to forward a /deliver to the owning remote kernel. Also polls each up host's /version so the dashboard can
     flag (and offer to update) a remote running older code than this local kernel (the user 2026-07-04)."""
+    last_addr = [None]                     # the route we last saw; None until the first pass reads one
     while True:
         _tunnel_wake.clear()
         try:
             with _remotes_lock:
                 rows = list(_remotes.values())
+            # THE NETWORK UNDER US MOVED (the user 2026-07-29, who pulled an ethernet cord and moved to
+            # Wi-Fi, then could not get romp back for a long stretch while plain ssh worked throughout).
+            # Two things were true the moment that cord came out and neither was acted on:
+            #   - every live ssh was riding a transport that no longer existed, and nothing here knew,
+            #     so each one had to be noticed the slow way or not at all;
+            #   - the backoff ladder kept counting, so a host whose route was restored seconds later
+            #     could still be owed up to 15 minutes of waiting before its next dial.
+            # A route change is an exact event (see _primary_addr), so both now key on it: drop every
+            # tunnel, because they are all dead by construction, and clear every ladder, because the
+            # thing they were backing off from is over. The next pass dials all of them fresh.
+            addr = _primary_addr()
+            if last_addr[0] is not None and addr != last_addr[0]:
+                _tunnel_log("-", "network-changed", was=last_addr[0] or "(no route)",
+                            now=addr or "(no route)", hosts=len(rows))
+                with _remotes_lock:
+                    for r in rows:
+                        if r["host"] not in _remotes or r.get("checkin_peer"):
+                            continue
+                        r["fails"], r["next_try"] = 0, 0
+                        if _tunnel_proc_alive(r):
+                            try:
+                                r["proc"].terminate()   # its transport went with the old address
+                            except Exception:
+                                pass
+            last_addr[0] = addr
             for r in rows:
                 now = time.time()
                 skip = False
+                probe_ssh = None            # a dial died this pass → ask whether the HOST is fine (below)
                 with _remotes_lock:
                     if r["host"] not in _remotes:
                         continue
@@ -6662,11 +6735,13 @@ def _tunnel_supervisor():
                             err = _tunnel_stderr(r["host"])
                             _tunnel_log(r["host"], "died", code=r["proc"].poll(), stderr=err,
                                         fails=r.get("fails", 0))
+                            probe_ssh = err      # the ssh probe runs below, OUTSIDE this lock
                             if _forward_bind_failed(err):
                                 r["detail"] = ("a forwarded port was already taken, so the tunnel could "
                                                "not open — romp is retrying on fresh ports")
                                 _remint_forward_ports(r)
                                 r["fails"], r["next_try"] = 0, 0   # a NEW argv deserves a fresh ladder
+                                probe_ssh = None                   # cause already known; don't ask twice
                         # BACK OFF re-spawns (exponential — see _tunnel_backoff) so an unreachable host
                         # isn't hammered every tick: repeated ssh attempts can trip the remote sshd's
                         # rate-limit (the user 2026-06-30). It never stops dialing (the user 2026-07-29);
@@ -6680,6 +6755,25 @@ def _tunnel_supervisor():
                             if r.get("status") != "error":
                                 r["status"] = "down"
                             skip = True                        # backing off — don't poll a down tunnel
+                if probe_ssh is not None:
+                    # A dial just died. Ask the question the user asks — "but can I ssh to it?" — because
+                    # the answer splits the two cases that look identical on the board and want opposite
+                    # responses. ssh works and our dial does not: the host, the network and sshd are all
+                    # fine, this is romp's bug, and the row must SAY so rather than implying the far end is
+                    # down. ssh fails too: the machine really is away, and the ladder is doing its job.
+                    # Costs one ssh per DEATH (never per poll), and deaths are already rate-limited by the
+                    # backoff. Outside _remotes_lock on purpose: it is a network round-trip, and holding
+                    # the lock across it would stall every route that reads the remote registry.
+                    ok, why = _host_reachable(r["host"])
+                    _tunnel_log(r["host"], "host-probe", sshOk=ok, sshErr=why, dialErr=probe_ssh)
+                    with _remotes_lock:
+                        if r["host"] in _remotes:
+                            if ok:
+                                _remotes[r["host"]]["detail"] = (
+                                    "ssh to %s works, but romp's tunnel would not open — this is romp's "
+                                    "end, not the host's. See tunnel-dials.jsonl." % r["host"])
+                            elif why:
+                                _remotes[r["host"]]["detail"] = "cannot reach %s: %s" % (r["host"], why)
                 if skip:
                     continue
                 up = _port_open(r["local_port"])              # outside the lock (socket round-trip)
@@ -6717,6 +6811,14 @@ def _tunnel_supervisor():
                             r["detail"] = ("the link to %s stopped carrying traffic — romp is dialing "
                                            "again") % r["host"]
                     if not (st == "down" and r.get("status") == "error") and not r.get("booting"):
+                        # Every status CHANGE on the record, so an outage leaves a timeline instead of a
+                        # single end-state to reason backwards from: when it flipped, what the end-to-end
+                        # probe said, and how many dials had failed by then. On the transition only — a
+                        # steady row writes nothing, so a healthy fleet costs no lines at all.
+                        if st != r.get("status"):
+                            _tunnel_log(r["host"], "status", was=r.get("status") or "(new)", now=st,
+                                        probe=r.get("_probe") or "", fails=r.get("fails", 0),
+                                        portOpen=bool(up))
                         r["status"] = st                   # keep a richer spawn-error label over plain 'down';
                         #                                    a Start in flight (`booting`) owns the row's phase
                     if st == "up":

--- a/tests/test_tunnel_stale_and_logging.py
+++ b/tests/test_tunnel_stale_and_logging.py
@@ -87,13 +87,16 @@ class SupervisorActsOnTheVerdict(unittest.TestCase):
         # branch that writes the row's detail.
         lines = self.src.splitlines()
         guard = [i for i, ln in enumerate(lines) if 'st == "no-kernel" and r.get("_probe") == "timeout"' in ln]
-        kills = [i for i, ln in enumerate(lines) if "terminate()" in ln]
         self.assertEqual(len(guard), 1, "one guard")
-        self.assertEqual(len(kills), 1, "one kill")
-        self.assertLess(guard[0], kills[0], "the kill is inside the guard")
-        self.assertLess(kills[0] - guard[0], 6, "and directly under it, not in some later branch")
+        # the only kill in the STATUS-handling region belongs to that guard. (The route-change block near
+        # the top of the loop drops tunnels too, and legitimately so — the network moved under all of them —
+        # so this is scoped to the per-host status branch rather than counting the whole function.)
+        region = [i for i, ln in enumerate(lines) if "terminate()" in ln and i > guard[0] - 20]
+        self.assertEqual(len(region), 1, "one kill in the status branch")
+        self.assertLess(guard[0], region[0], "the kill is inside the guard")
+        self.assertLess(region[0] - guard[0], 6, "and directly under it, not in some later branch")
         plain = [i for i, ln in enumerate(lines) if 'elif st == "no-kernel"' in ln]
-        self.assertTrue(plain and plain[0] > kills[0],
+        self.assertTrue(plain and plain[0] > region[0],
                         "the detail-only no-kernel branch comes after, and kills nothing")
 
     def test_a_dead_dial_is_logged_once_with_what_ssh_printed(self):
@@ -176,6 +179,106 @@ class TryNowActuallyDials(unittest.TestCase):
         self.assertIn("forced-redial", src)
         self.assertIn('r["proc"].wait(timeout=3)', src,
                       "wait for the old ssh to exit, or the new dial dies on its listener")
+
+
+class TheNetworkMoved(unittest.TestCase):
+    """Pulling the cord is an EVENT, and both the dead tunnels and the ladder key on it.
+
+    Waiting out a backoff that is counting down from an outage which has already ended is the exact shape
+    the design rule warns about: a time window standing in for an event that exists. The event is the
+    route changing, and _primary_addr reads it.
+    """
+
+    def test_the_route_probe_names_this_machine_s_source_address_without_sending_anything(self):
+        addr = km._primary_addr()
+        self.assertIsInstance(addr, str)
+        if addr:                                   # "" is legitimate: a machine with no route at all
+            self.assertRegex(addr, r"^\d+\.\d+\.\d+\.\d+$")
+
+    def test_it_targets_reserved_documentation_space_so_it_can_never_touch_a_real_host(self):
+        import inspect as _i
+        src = _i.getsource(km._primary_addr)
+        self.assertIn('s.connect(("192.0.2.1", 9))', src, "TEST-NET-1, RFC 5737 — never routed")
+        self.assertIn("SOCK_DGRAM", src, "a UDP connect only consults the routing table")
+
+    def test_it_is_stable_when_the_network_has_not_moved(self):
+        # the whole mechanism rests on this: a re-read must not look like a change
+        self.assertEqual(km._primary_addr(), km._primary_addr())
+
+    def test_no_route_at_all_reads_as_empty_rather_than_raising(self):
+        import inspect as _i
+        src = _i.getsource(km._primary_addr)
+        self.assertIn("except OSError:", src)
+        self.assertIn('return ""', src, "unplugged is a value, not an exception")
+
+    def test_a_route_change_drops_every_tunnel_and_clears_every_ladder(self):
+        import inspect as _i
+        src = _i.getsource(km._tunnel_supervisor)
+        self.assertIn("if last_addr[0] is not None and addr != last_addr[0]:", src)
+        self.assertIn('_tunnel_log("-", "network-changed"', src)
+        i = src.index("network-changed")
+        after = src[i:i + 900]
+        self.assertIn('r["fails"], r["next_try"] = 0, 0', after,
+                      "the ladder was backing off from something that is over")
+        self.assertIn('r["proc"].terminate()', after,
+                      "every live ssh is riding a transport that went with the old address")
+        self.assertIn('r.get("checkin_peer")', after, "a checked-in peer owns no ssh here to drop")
+
+    def test_the_first_pass_is_not_a_change(self):
+        import inspect as _i
+        src = _i.getsource(km._tunnel_supervisor)
+        self.assertIn("last_addr = [None]", src)
+        # None means "we have not looked yet" — boot already dials everything, and a spurious
+        # network-changed at startup would log a move that never happened
+        self.assertIn("last_addr[0] is not None", src)
+
+
+class AskingWhetherSshWorks(unittest.TestCase):
+    """The one fact that made this obvious to a human and invisible to romp."""
+
+    def test_the_probe_carries_no_forwards_so_it_cannot_fail_for_the_tunnel_s_reason(self):
+        import inspect as _i
+        src = _i.getsource(km._host_reachable)
+        self.assertIn('["--", host, "true"]', src)
+        self.assertNotIn('"-L"', src)
+        self.assertNotIn('"-R"', src)
+
+    def test_a_host_ssh_could_parse_as_an_option_is_refused_before_it_is_run(self):
+        ok, why = km._host_reachable("-oProxyCommand=touch /tmp/pwned")
+        self.assertFalse(ok)
+        self.assertEqual(why, "invalid host")
+
+    def test_it_runs_on_a_DEATH_and_outside_the_registry_lock(self):
+        import inspect as _i
+        src = _i.getsource(km._tunnel_supervisor)
+        self.assertIn("probe_ssh = err", src, "armed where the dial's death is logged")
+        call = src.index("_host_reachable(r[\"host\"])")
+        # the probe is a network round-trip; holding _remotes_lock across it would stall every route
+        # that reads the remote registry
+        guard = src.index("if probe_ssh is not None:")
+        self.assertLess(guard, call)
+        self.assertNotIn("with _remotes_lock", src[guard:call])
+
+    def test_a_known_cause_does_not_get_asked_twice(self):
+        import inspect as _i
+        src = _i.getsource(km._tunnel_supervisor)
+        self.assertIn("probe_ssh = None                   # cause already known", src,
+                      "a bind failure already names itself; no ssh needed to confirm it")
+
+    def test_the_verdict_reaches_the_row_so_the_panel_stops_blaming_the_far_end(self):
+        import inspect as _i
+        src = _i.getsource(km._tunnel_supervisor)
+        self.assertIn("end, not the host's", src)
+        self.assertIn('_tunnel_log(r["host"], "host-probe", sshOk=ok', src)
+
+
+class StatusTimeline(unittest.TestCase):
+    def test_a_status_change_is_logged_and_a_steady_row_is_not(self):
+        import inspect as _i
+        src = _i.getsource(km._tunnel_supervisor)
+        self.assertIn('if st != r.get("status"):', src, "on the transition, never every pass")
+        self.assertIn('_tunnel_log(r["host"], "status", was=r.get("status") or "(new)", now=st', src)
+        self.assertIn("probe=r.get(\"_probe\")", src, "the timeline carries WHY, not just the flip")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #124, which fixed the wedge and added the dial log. This adds the things that would have stopped the outage happening at all, and the one signal that would have named it in seconds.

**A route change is an event; it was being answered by waiting.** The moment the ethernet cord came out, every live ssh was riding a transport that no longer existed and nothing knew it, so each had to be noticed the slow way; and the backoff ladder kept counting, so a host whose route was restored seconds later could still be owed up to 15 minutes before its next dial. The change has an exact signature — the source address the routing table picks to reach the outside world — so both now key on it: drop every tunnel (they are all dead by construction) and clear every ladder (the thing it was backing off from is over). Read with a UDP `connect` to TEST-NET-1 (RFC 5737): sends no packets, only consults the routing table, no subprocess or new thread.

**"But ssh works" is now romp's question too.** That single fact made the outage obvious to a human and invisible to romp, and it splits the two cases that look identical on the board and want opposite responses. On the death of a dial, romp runs a plain ssh carrying no forwards — so it cannot fail for the reason the tunnel did — and records the verdict. If ssh reaches the host, the row says the fault is at romp's end instead of implying the far machine is down, which is what sent a morning into restarting kernels that were never down. One ssh per death, never per poll; deaths are already rate-limited by the backoff. Runs outside `_remotes_lock`, since it is a network round-trip.

**Status changes leave a timeline.** Each flip logs the old and new status, the end-to-end probe verdict, the failed-dial count and whether the local forward was accepting — so a future outage can be read forwards rather than reasoned backwards from one end state. On the transition only; a steady fleet writes nothing.

Tests: 12 new cases in `tests/test_tunnel_stale_and_logging.py` — the route probe is exercised for real (stability, shape, reserved target), the ssh probe for its forward-free argv and its rejection of a host ssh could parse as an option, and the supervisor wiring is pinned at source including that the probe runs outside the lock. Suites green: 3610 Python, 1455 node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)