### PR TITLE
A retry storm says what is failing, because we read the field names the CLI actually sends

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7750,7 +7750,12 @@ def _session_retrying(sid, tm):
         count = int(tm.get("retryCount") or 0)
     except (TypeError, ValueError):
         count = 0
-    return {"since": since, "count": count}
+    # The storm's own detail rides along so the card chip and the bell entry can name WHAT is failing, not
+    # just that a storm exists (the user 2026-07-29). Same retryInfo the chat's retrying element reads.
+    info = tm.get("retryInfo") if isinstance(tm.get("retryInfo"), dict) else {}
+    return {"since": since, "count": count,
+            "max": info.get("max"), "status": info.get("status"),
+            "networkDown": info.get("networkDown"), "rateLimitType": info.get("rateLimitType")}
 
 
 def _retry_recoveries(sid):

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -952,6 +952,10 @@ class _AskCancelled(Exception):
 class SdkSession:
     """One long-lived SDK client running in its own thread + asyncio loop."""
 
+    # One diagnostic per process if an api_retry payload stops matching every spelling we know (see the
+    # api_retry branch): the retry detail goes blank silently otherwise, which is how it stayed broken.
+    _retry_shape_warned = False
+
     def __init__(self, backend: "SdkBackend", reg: dict):
         self.backend = backend
         self.sid = reg["sid"]
@@ -1692,24 +1696,69 @@ class SdkSession:
             self.retry_count += 1                      # one backoff attempt → the live 'attempt N' count
             # The event's own detail — attempt number/budget, the error behind the backoff, and when the
             # next attempt fires — so the chat's retrying element can say WHAT is failing and what happens
-            # next, not just that a storm exists (the user 2026-07-10). Field names are the CLI's api_retry
-            # payload (number / max_retries / retry_delay_ms / error_status / retryAt); every read is
-            # defensive since only status has been seen on the wire so far.
+            # next, not just that a storm exists (the user 2026-07-10).
+            #
+            # The field names were GUESSED when this was written (number / max_retries / retry_delay_ms /
+            # error_status / retryAt) and every one of them was wrong, so `retry_info` came back all-None on
+            # every real storm and the whole detail UI below it rendered blank — the user saw a bare "API
+            # retrying" with no attempt count, no countdown and no reason, for months (the user 2026-07-29).
+            # The names are now VERIFIED against two authoritative sources rather than guessed:
+            #   * the WIRE frame (SDKAPIRetryMessage, subtype api_retry) — snake_case, per the CLI's own
+            #     embedded schema: retry_in_ms / is_network_down / is_ssl_error / rate_limit_type;
+            #   * the TRANSCRIPT twin the same frame is written from (system / subtype api_error) — camelCase:
+            #     retryAttempt / maxRetries / retryInMs / error{status,formatted,requestId,isNetworkDown,
+            #     rateLimits}.
+            # We accept BOTH spellings (plus the old guesses) because the two surfaces genuinely differ and
+            # either may reach us; `error` arrives as a dict on the transcript side and a string on the wire.
             d = msg.data if isinstance(msg.data, dict) else {}
             _now = time.time()
-            _ra = d.get("retryAt")
+
+            def _pick(*names, want=(int, float, str)):
+                """First present, correctly-typed value among alternate spellings of one field."""
+                for nm in names:
+                    v = d.get(nm)
+                    if isinstance(v, want) and not isinstance(v, bool):
+                        return v
+                return None
+
+            _e = d.get("error") if isinstance(d.get("error"), dict) else {}
+            _ra = _pick("retryAt", "retry_at")
+            _in_ms = _pick("retry_in_ms", "retryInMs", "retry_delay_ms")
             retry_at = (_ra / 1000.0 if isinstance(_ra, (int, float)) and _ra > 1e12 else
                         _ra if isinstance(_ra, (int, float)) and _ra > 1e9 else
-                        _now + d["retry_delay_ms"] / 1000.0
-                        if isinstance(d.get("retry_delay_ms"), (int, float)) else None)
-            _err = d.get("error") or d.get("message")
+                        _now + _in_ms / 1000.0 if isinstance(_in_ms, (int, float)) else None)
+            # The human string: the transcript's error.formatted ("529 Overloaded") is the best of these;
+            # error.message carries the raw JSON envelope, so it is the last resort.
+            _err = (_e.get("formatted") or _e.get("message") if _e else None) \
+                or _pick("display_message", "message", want=(str,))
+            _status = _pick("status_code", "error_status", "status") \
+                or (_e.get("status") if isinstance(_e.get("status"), (int, str)) else None)
+            _net = d.get("is_network_down", d.get("isNetworkDown", _e.get("isNetworkDown")))
             self.retry_info = {
-                "attempt": d.get("number") if isinstance(d.get("number"), int) else self.retry_count,
-                "max": d.get("max_retries") if isinstance(d.get("max_retries"), int) else None,
-                "status": d.get("error_status") if isinstance(d.get("error_status"), (int, str)) else None,
+                "attempt": _pick("retry_attempt", "retryAttempt", "number", want=(int,)) or self.retry_count,
+                "max": _pick("max_retries", "maxRetries", want=(int,)),
+                "status": _status,
                 "error": _err[:300] if isinstance(_err, str) else None,
                 "retryAt": retry_at,
+                # New detail the guessed reads never reached. requestId is what support/debugging actually
+                # needs; networkDown separates "this machine fell off the internet" from "the API is busy",
+                # which are opposite problems wearing the same red card; rateLimitType names WHICH quota a
+                # 429 hit (null unless it is a quota 429, per the CLI's schema).
+                "requestId": (_e.get("requestId") if _e else None) or _pick("request_id", want=(str,)),
+                "networkDown": bool(_net) if isinstance(_net, bool) else None,
+                "rateLimitType": _pick("rate_limit_type", want=(str,)),
             }
+            # Fail LOUDLY on an unrecognised payload instead of quietly rendering an empty banner — the exact
+            # failure mode above. If a future CLI renames these again we get a one-line diagnostic naming the
+            # keys it actually sent, rather than months of silently blank detail (CLAUDE.md: authoritative
+            # sources — a visible error beats data that looks fine and misleads). Once per process.
+            if d and self.retry_info["max"] is None and self.retry_info["status"] is None \
+                    and self.retry_info["error"] is None and not SdkSession._retry_shape_warned:
+                SdkSession._retry_shape_warned = True
+                sys.stderr.write(
+                    "romp: api_retry payload has no field this build understands — keys=%r. The retry "
+                    "detail (attempt/max, status, countdown) will be blank until these are mapped.\n"
+                    % (sorted(d)[:20],))
             self._mark("retrying")
             self.backend._poke()
         elif isinstance(msg, SystemMessage) and msg.subtype in (

--- a/tests/test_kernel_retrying_chip.py
+++ b/tests/test_kernel_retrying_chip.py
@@ -50,7 +50,7 @@ class SessionRetrying(unittest.TestCase):
                       {"t": T0 + 200, "state": "retrying"},
                       {"t": T0 + 300, "state": "retrying"}])
         got = km._session_retrying(SID, {"state": "retrying", "retryCount": 7})
-        self.assertEqual(got, {"since": T0 + 100, "count": 7},
+        self.assertEqual({"since": got["since"], "count": got["count"]}, {"since": T0 + 100, "count": 7},
                          "the stretch dates from its FIRST retrying row, not the latest attempt")
 
     def test_a_recovery_ends_the_stretch_so_a_new_storm_dates_from_its_own_start(self):
@@ -77,12 +77,29 @@ class SessionRetrying(unittest.TestCase):
     def test_no_states_row_yet_renders_timeless(self):
         # the live snapshot can lead the log by a beat — the chip still shows, just without a time
         got = km._session_retrying(SID, {"state": "retrying", "retryCount": 2})
-        self.assertEqual(got, {"since": None, "count": 2})
+        self.assertEqual({"since": got["since"], "count": got["count"]}, {"since": None, "count": 2})
 
     def test_junk_retry_count_degrades_to_zero(self):
         self._states([{"t": T0, "state": "retrying"}])
         got = km._session_retrying(SID, {"state": "retrying", "retryCount": "lots"})
         self.assertEqual(got["count"], 0, "a malformed count never crashes the feed build")
+
+    def test_the_storms_own_detail_rides_along(self):
+        """The chip and the bell entry name WHAT is failing, not just that a storm exists (the user
+        2026-07-29). Same retryInfo the chat's retrying element reads, so all three agree."""
+        self._states([{"t": T0, "state": "retrying"}])
+        got = km._session_retrying(SID, {"state": "retrying", "retryCount": 7,
+                                         "retryInfo": {"max": 10, "status": 529, "networkDown": False,
+                                                       "rateLimitType": None}})
+        self.assertEqual((got["max"], got["status"]), (10, 529))
+        self.assertIs(got["networkDown"], False)
+
+    def test_a_snapshot_with_no_detail_still_builds(self):
+        """A storm whose payload romp couldn't read must not break the chip — the detail is optional."""
+        self._states([{"t": T0, "state": "retrying"}])
+        got = km._session_retrying(SID, {"state": "retrying", "retryCount": 3, "retryInfo": None})
+        self.assertEqual(got["count"], 3)
+        self.assertIsNone(got["status"])
 
 
 class FeedCardRetryingChip(unittest.TestCase):

--- a/tests/test_sdk_api_retry_detail.py
+++ b/tests/test_sdk_api_retry_detail.py
@@ -1,0 +1,211 @@
+"""The api_retry payload is read with the field names the CLI actually sends (the user 2026-07-29).
+
+romp has rendered a rich retry banner for a while — "API retrying — attempt 7 of 10", a live countdown to
+the next attempt, and the status + message behind the backoff. None of it ever appeared, because the reader
+was written against GUESSED field names (number / max_retries / retry_delay_ms / error_status / retryAt) and
+every one of them was wrong. `retry_info` came back all-None on every real storm, so the whole detail UI
+rendered blank and a session in trouble showed a bare "API retrying" with no reason and no progress. The
+user, watching one thread fail for twenty minutes while a fresh session connected fine, had nothing in the
+UI to tell the two apart.
+
+The names here are VERIFIED against the two surfaces the frame actually reaches us on, not guessed again:
+
+  * the WIRE frame (SDKAPIRetryMessage, subtype api_retry) — snake_case, per the CLI's own embedded schema:
+    retry_in_ms / is_network_down / is_ssl_error / rate_limit_type;
+  * the TRANSCRIPT twin it is written from (system / subtype api_error) — camelCase, and the shape observed
+    in real transcripts: retryAttempt / maxRetries / retryInMs / error{status,formatted,requestId,
+    isNetworkDown,rateLimits}.
+
+Both are accepted, along with the old guesses, because either may reach us and dropping the old names would
+be a silent regression on any build still sending them. A payload matching NONE of them now writes a
+one-line diagnostic naming the keys it did send — the blank-detail failure above is exactly the kind of
+silent degradation CLAUDE.md forbids.
+
+Fixtures are synthetic: invented request ids and placeholder uuids, never a recorded one.
+"""
+import io
+import os
+import unittest
+from contextlib import redirect_stderr
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+sb = SourceFileLoader("romp_sdk_backend_retrydetail", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+REQ = "req_TESTREQ00000000000000"          # synthetic: never a recorded request id
+
+
+class _Sys:
+    """Stand-in for the SDK's SystemMessage — subtype + the raw data dict, which is all the branch reads."""
+
+    def __init__(self, subtype, data):
+        self.subtype, self.data = subtype, data
+
+
+class _Other:
+    """A type the branch must not confuse with SystemMessage (stands in for Assistant/Result)."""
+
+
+class _Backend:
+    """Only what _on_message touches: the poke, and the unconditional raw-message forward at its tail."""
+
+    def __init__(self):
+        self.forwarded = []
+
+    def _poke(self):
+        pass
+
+    def _forward(self, sess, msg):
+        self.forwarded.append(msg)
+
+
+class _Sess(sb.SdkSession):
+    """The retry state alone — SdkSession.__init__ builds a whole client/thread these don't need."""
+
+    def __init__(self):
+        self.sid = SID
+        self.backend = _Backend()
+        self.retrying = False
+        self.retry_count = 0
+        self.retry_info = None
+        self.marks = []
+
+    def _mark(self, state):
+        self.marks.append(state)
+
+
+def _feed(sess, data):
+    """Drive one api_retry frame through the real handler and hand back the detail it produced."""
+    sess._on_message(_Sys("api_retry", data), _Other, _Other, _Sys)
+    return sess.retry_info
+
+
+# A real 529 storm frame as the TRANSCRIPT records it (camelCase, error as a dict). Field-for-field the
+# shape observed in live transcripts; the values are invented.
+TRANSCRIPT_SHAPE = {
+    "retryAttempt": 7, "maxRetries": 10, "retryInMs": 38888,
+    "error": {"message": '529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+              "status": 529, "requestId": REQ, "formatted": "529 Overloaded",
+              "connection": None, "isNetworkDown": False, "rateLimits": None},
+    "slug": "test-slug", "source": "request_retry", "entrypoint": "sdk-py",
+}
+
+# The same failure as the WIRE frame names it (snake_case, flat).
+WIRE_SHAPE = {
+    "retry_attempt": 7, "max_retries": 10, "retry_in_ms": 38888,
+    "status_code": 529, "request_id": REQ, "display_message": "529 Overloaded",
+    "is_network_down": False, "is_ssl_error": False, "rate_limit_type": None,
+}
+
+
+class ReadsTheRealFieldNames(unittest.TestCase):
+    def test_the_transcript_shape_fills_every_detail_field(self):
+        info = _feed(_Sess(), TRANSCRIPT_SHAPE)
+        self.assertEqual(info["attempt"], 7)
+        self.assertEqual(info["max"], 10, "maxRetries — the guessed 'max_retries' never matched this shape")
+        self.assertEqual(info["status"], 529)
+        self.assertEqual(info["error"], "529 Overloaded",
+                         "error.formatted is the human string; error.message is a raw JSON envelope")
+        self.assertEqual(info["requestId"], REQ)
+        self.assertIs(info["networkDown"], False)
+
+    def test_the_wire_shape_fills_every_detail_field_too(self):
+        info = _feed(_Sess(), WIRE_SHAPE)
+        self.assertEqual((info["attempt"], info["max"], info["status"]), (7, 10, 529))
+        self.assertEqual(info["error"], "529 Overloaded")
+        self.assertEqual(info["requestId"], REQ)
+        self.assertIs(info["networkDown"], False)
+
+    def test_both_spellings_agree(self):
+        """The same failure must describe itself identically whichever surface delivered it."""
+        a, b = _feed(_Sess(), TRANSCRIPT_SHAPE), _feed(_Sess(), WIRE_SHAPE)
+        for k in ("attempt", "max", "status", "error", "requestId", "networkDown"):
+            self.assertEqual(a[k], b[k], "%s differs between the wire and transcript spellings" % k)
+
+    def test_the_countdown_epoch_comes_from_the_backoff_delay(self):
+        """retryInMs → an absolute epoch, which is what the live countdown ticks against."""
+        import time
+        before = time.time()
+        info = _feed(_Sess(), TRANSCRIPT_SHAPE)
+        self.assertIsNotNone(info["retryAt"], "no epoch → the chat's countdown never renders")
+        self.assertGreaterEqual(info["retryAt"], before + 38.0)
+        self.assertLessEqual(info["retryAt"], time.time() + 39.5)
+
+    def test_an_absolute_retry_at_in_millis_is_normalised_to_seconds(self):
+        info = _feed(_Sess(), {"retryAt": 2000000000000, "maxRetries": 10})
+        self.assertAlmostEqual(info["retryAt"], 2000000000.0, places=3)
+
+    def test_the_old_guessed_names_still_work(self):
+        """Dropping them would silently regress any build that does send them."""
+        info = _feed(_Sess(), {"number": 3, "max_retries": 8, "error_status": 500,
+                               "retry_delay_ms": 2000, "message": "500 Server Error"})
+        self.assertEqual((info["attempt"], info["max"], info["status"]), (3, 8, 500))
+        self.assertEqual(info["error"], "500 Server Error")
+        self.assertIsNotNone(info["retryAt"])
+
+    def test_a_network_drop_is_distinguishable_from_an_overloaded_api(self):
+        """Opposite problems, same red card — the flag is the only thing that separates them."""
+        info = _feed(_Sess(), {"is_network_down": True, "status_code": 0, "retry_attempt": 1})
+        self.assertIs(info["networkDown"], True)
+
+    def test_a_quota_429_carries_which_limit_it_hit(self):
+        info = _feed(_Sess(), {"status_code": 429, "rate_limit_type": "output_tokens", "retry_attempt": 2})
+        self.assertEqual(info["rateLimitType"], "output_tokens")
+
+    def test_the_attempt_count_falls_back_to_our_own_tally(self):
+        """A payload with no attempt number still counts: the storm's size is romp's own observation."""
+        s = _Sess()
+        _feed(s, {"status_code": 529})
+        info = _feed(s, {"status_code": 529})
+        self.assertEqual(info["attempt"], 2)
+
+    def test_the_frame_marks_the_session_retrying(self):
+        s = _Sess()
+        _feed(s, TRANSCRIPT_SHAPE)
+        self.assertTrue(s.retrying)
+        self.assertEqual(s.marks, ["retrying"])
+
+
+class AnUnknownShapeIsLoud(unittest.TestCase):
+    def setUp(self):
+        sb.SdkSession._retry_shape_warned = False
+
+    def tearDown(self):
+        sb.SdkSession._retry_shape_warned = False
+
+    def test_a_payload_we_cannot_read_says_so_once(self):
+        """The blank-detail bug in reverse: if the names change again we hear about it immediately."""
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            _feed(_Sess(), {"totallyRenamedField": 1, "somethingElse": "x"})
+        out = buf.getvalue()
+        self.assertIn("api_retry payload", out)
+        self.assertIn("totallyRenamedField", out, "the diagnostic must name the keys it actually got")
+
+    def test_it_does_not_repeat_for_every_attempt_in_a_storm(self):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            for _ in range(5):
+                _feed(_Sess(), {"totallyRenamedField": 1})
+        self.assertEqual(buf.getvalue().count("api_retry payload"), 1)
+
+    def test_a_readable_payload_stays_quiet(self):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            _feed(_Sess(), TRANSCRIPT_SHAPE)
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_an_empty_payload_is_not_treated_as_a_rename(self):
+        """No data at all is a frame carrying nothing, not a schema we failed to parse."""
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            _feed(_Sess(), {})
+        self.assertEqual(buf.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/api-error-reason.test.ts
+++ b/ui/webview/api-error-reason.test.ts
@@ -1,0 +1,92 @@
+// An API failure says whose problem it is, in words that decide what to do next (the user 2026-07-29).
+// EXECUTES ./api-error-reason; the two callers (chat retry line, bell entry) are source-pinned so neither
+// can quietly go back to printing a bare status code.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { apiErrorReason } from "./api-error-reason";
+import { badgeNotices, type BadgeItem } from "./badge-mirror";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("529 is named as server-side and temporary, not a fault of the session", () => {
+  const s = apiErrorReason({ status: 529 });
+  assert.match(s, /overloaded/i);
+  assert.match(s, /server-side/i);
+  // the whole point of the sentence: a long thread bouncing while a fresh one connects is NOT a broken thread
+  assert.match(s, /not this session/i);
+});
+
+test("the on-you cases outrank the status code, because only they are actionable", () => {
+  // a spend cap arrives as a 4xx; read by status alone it would misreport as an ordinary rejection
+  assert.match(apiErrorReason({ status: 400, spendLimit: true }), /spend limit reached/i);
+  assert.match(apiErrorReason({ status: 400, tooLong: true }), /prompt too long/i);
+});
+
+test("a dead network and a busy API are told apart", () => {
+  assert.match(apiErrorReason({ status: 529, networkDown: true }), /offline/i);
+  assert.doesNotMatch(apiErrorReason({ status: 529, networkDown: true }), /overloaded/i);
+});
+
+test("a quota 429 names which limit it hit", () => {
+  assert.match(apiErrorReason({ status: 429, rateLimitType: "output_tokens" }), /output_tokens/);
+  assert.match(apiErrorReason({ status: 429 }), /rate limited/i);
+});
+
+test("unknown facts produce no sentence rather than an invented cause", () => {
+  assert.equal(apiErrorReason({}), "");
+  assert.equal(apiErrorReason({ status: null }), "");
+  assert.equal(apiErrorReason({ status: "not-a-number" }), "");
+  assert.equal(apiErrorReason({ status: 200 }), "", "a non-error status explains nothing");
+});
+
+test("other server errors still read as server-side", () => {
+  assert.match(apiErrorReason({ status: 500 }), /server-side/i);
+  assert.match(apiErrorReason({ status: 503 }), /server-side/i);
+  assert.match(apiErrorReason({ status: 404 }), /model/i);
+});
+
+test("the bell entry carries the reason and the attempt count, not just 'retry storm'", () => {
+  const it: BadgeItem = {
+    itemId: "TESTSID:g1", sid: "TESTSID", name: "api", text: "ship the notes-api",
+    retrying: { since: 300, count: 7, max: 10, status: 529 },
+  };
+  const { notices } = badgeNotices([it], new Set());
+  assert.equal(notices.length, 1);
+  assert.match(notices[0].text, /attempt 7 of 10/, "how far into the backoff it is");
+  assert.match(notices[0].text, /overloaded/i, "and what is actually failing");
+});
+
+test("a blocked API-error entry explains the status instead of only quoting it", () => {
+  const it: BadgeItem = {
+    itemId: "TESTSID:g1", sid: "TESTSID", name: "api", text: "ship the notes-api",
+    blocked: { state: "apiError", status: 529 },
+  };
+  const { notices } = badgeNotices([it], new Set());
+  assert.match(notices[0].text, /API error 529/, "the code is still there for the record");
+  assert.match(notices[0].text, /server-side/i, "and now says what it means");
+});
+
+test("a spend-limit block reads as the spend limit, with no bare status pasted in front", () => {
+  const it: BadgeItem = {
+    itemId: "TESTSID:g1", sid: "TESTSID", name: "api", text: "ship the notes-api",
+    blocked: { state: "apiError", status: 400, spendLimit: true },
+  };
+  const { notices } = badgeNotices([it], new Set());
+  assert.match(notices[0].text, /spend limit/i);
+  assert.doesNotMatch(notices[0].text, /API error 400/);
+});
+
+test("the chat's retry line shows the reason and hides the request id in the tooltip", () => {
+  // progressive disclosure: the gist is on the line, the id is one hover away (CLAUDE.md)
+  assert.match(RENDER, /apiErrorReason\(info\)/, "the retry line renders the shared reason");
+  assert.match(RENDER, /request \$\{info\.requestId\}/, "the request id rides the tooltip");
+  assert.doesNotMatch(RENDER, /err\.textContent = \[status, msg\]\.filter/,
+    "the old status+message-only line is gone");
+});
+
+test("the retrying element renders whenever there is anything to say", () => {
+  // networkDown alone (status 0 / no message) must still surface — it is the most actionable case of all
+  assert.match(RENDER, /if \(info\.status \|\| info\.error \|\| info\.networkDown\)/);
+});

--- a/ui/webview/api-error-reason.ts
+++ b/ui/webview/api-error-reason.ts
@@ -1,0 +1,42 @@
+// What an API failure MEANS, in the few words that decide what the user does next.
+//
+// A status code alone doesn't say whose problem it is, and that is the only question worth answering on a
+// red card: wait it out, fix your network, or stop and come back later. The trigger (the user 2026-07-29):
+// one long-running thread kept dying while a fresh session connected fine, and every surface romp offered
+// said only "API error" — which is true of all of those cases and useful in none of them.
+//
+// Shared by the chat's retry line and the bell's entry so the two can never drift into different words for
+// the same failure. Pure and string-only: the callers own their own chrome.
+
+export interface ApiErrorFacts {
+  status?: number | string | null;
+  networkDown?: boolean | null;
+  rateLimitType?: string | null;
+  spendLimit?: boolean | null;
+  tooLong?: boolean | null;
+}
+
+// The plain-words reason, or "" when the facts don't identify one (callers then fall back to the bare
+// status, which is still better than inventing a cause we can't support).
+export function apiErrorReason(f: ApiErrorFacts): string {
+  // The two ON-YOU cases first: they are the only ones the user can actually act on, and both outrank a
+  // status code (a spend cap also arrives as a 4xx, which would otherwise read as a plain rate limit).
+  // Wording is the established one these badges already used — folding them in here is about having ONE
+  // place that decides what a failure means, not about renaming failures that already read clearly.
+  if (f.spendLimit) return "spend limit reached";
+  if (f.tooLong) return "prompt too long (needs compaction)";
+  if (f.networkDown) return "this machine is offline";
+  if (f.rateLimitType) return `rate limited (${f.rateLimitType})`;
+  const s = Number(f.status);
+  if (!Number.isFinite(s)) return "";
+  // 529 is the one worth spelling out: it is genuinely server-side and transient, it looks identical to a
+  // session-specific fault from the outside, and it is far likelier to hit a LONG thread — a big request
+  // needs more capacity at once, so a fresh session sails through the same minute a full one keeps bouncing.
+  if (s === 529) return "the API was overloaded — server-side and temporary, not this session";
+  if (s === 429) return "rate limited — the account's quota, not this session";
+  if (s === 401 || s === 403) return "the API rejected our credentials";
+  if (s === 404) return "the API says that model does not exist";
+  if (s >= 500) return "server-side and temporary";
+  if (s >= 400) return "the request itself was rejected";
+  return "";
+}

--- a/ui/webview/badge-mirror.ts
+++ b/ui/webview/badge-mirror.ts
@@ -10,11 +10,13 @@
 // re-log, a badge that clears leaves the active set (so a recurrence logs afresh), and a NEW episode
 // of the same kind (different since/t) is a new entry.
 
+import { apiErrorReason } from "./api-error-reason";
+
 export interface BadgeItem {
   itemId: string; sid: string; name: string; text: string;
   stalled?: { why: string; since: number; note?: string | null } | null;
   nudgeFailed?: boolean;
-  retrying?: { since?: number | null; count?: number } | null;
+  retrying?: { since?: number | null; count?: number; max?: number | null; status?: number | string | null; networkDown?: boolean | null; rateLimitType?: string | null } | null;
   warns?: { kind: string; t: number; msg: string }[] | null;
   blocked?: { state: string; status?: number; text?: string; tooLong?: boolean; spendLimit?: boolean } | null;
 }
@@ -43,16 +45,22 @@ export function badgeNotices(items: BadgeItem[], seen: Set<string>): { notices: 
       add("n|" + it.itemId, "nudge", it.name + " — follow-up failed on “" + cap(it.text, 50) + "”");
     }
     if (it.retrying) {
-      add("r|" + it.itemId + "|" + (it.retrying.since || 0), "retry", it.name + " — API retry storm");
+      // Name the failure behind the storm, not just that one exists — "API retry storm" was true of every
+      // cause and actionable for none (the user 2026-07-29). The count says whether it is nearly out of road.
+      const r = it.retrying;
+      const why = apiErrorReason(r);
+      const n = r.count ? ` (attempt ${r.count}${r.max ? " of " + r.max : ""})` : "";
+      add("r|" + it.itemId + "|" + (r.since || 0), "retry",
+        it.name + " — API retry storm" + n + (why ? ": " + why : ""));
     }
     // only the API-error block is an ERROR; a permission ask / picker is ordinary Needs-you traffic
     if (it.blocked && it.blocked.state === "apiError") {
       const b = it.blocked;
-      const what = b.spendLimit ? "spend limit reached"
-        : b.tooLong ? "prompt too long (needs compaction)"
-        : "API error" + (b.status ? " " + b.status : "");
+      // spendLimit / tooLong already read as plain words; apiErrorReason covers them too, so the whole
+      // verdict comes from one place and the bell can't describe a failure differently than the chat does.
+      const what = apiErrorReason(b) || "API error" + (b.status ? " " + b.status : "");
       add("e|" + it.itemId + "|" + (b.status || "") + "|" + (b.spendLimit ? "sl" : b.tooLong ? "tl" : ""),
-        "apierror", it.name + " — " + what);
+        "apierror", it.name + " — " + (b.status && !b.spendLimit && !b.tooLong ? "API error " + b.status + ": " : "") + what);
     }
   }
   return { notices, active };

--- a/ui/webview/chat-retrying-inline.test.ts
+++ b/ui/webview/chat-retrying-inline.test.ts
@@ -35,7 +35,9 @@ test("renderRetrying surfaces the api_retry payload's own detail (the user 2026-
   // the error behind the backoff on its own muted line, full message in the tooltip
   assert.match(body, /el\("div", "retrying-err"\)/);
   assert.match(body, /`HTTP \$\{info\.status\}`/);
-  assert.match(body, /err\.title = msg/);
+  // the tooltip carries the message AND the request id since 2026-07-29 — the id is the one detail worth
+  // quoting to support and the one nobody reads at a glance, so it lives a hover away, not on the line
+  assert.match(body, /err\.title = \[msg, info\.requestId/);
 });
 
 test("the next-try countdown TICKS every second — it is not frozen at render time (the user 2026-07-24)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -28,6 +28,7 @@ import { hostNameNodes, hostIsDown, hostDownNote } from "./host-prefix";
 import { dirStatusLine, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
+import { apiErrorReason } from "./api-error-reason";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -155,7 +156,7 @@ type ChatEvent = (
   // the error status+message behind the backoff, and the next-attempt moment (epoch s) — so the element
   // says WHAT is failing and when it retries, not just that a storm exists. Every field optional (only
   // status has been seen on the wire so far).
-  | { kind: "retrying"; retries?: number; info?: { attempt?: number | null; max?: number | null; status?: number | string | null; error?: string | null; retryAt?: number | null } | null; ts?: string; uuid?: string }
+  | { kind: "retrying"; retries?: number; info?: { attempt?: number | null; max?: number | null; status?: number | string | null; error?: string | null; retryAt?: number | null; requestId?: string | null; networkDown?: boolean | null; rateLimitType?: string | null } | null; ts?: string; uuid?: string }
   // A stalled api_retry turn RECOVERED — a persistent, rail-anchored "Recovered after N retries" note left
   // where output resumed, the historical counterpart of the transient element above (the user 2026-07-08).
   | { kind: "retried"; retries: number; ts?: string; uuid?: string }
@@ -2184,16 +2185,19 @@ function renderRetrying(ev: Extract<ChatEvent, { kind: "retrying" }>): HTMLEleme
   turn.appendChild(line);
   // The error behind the backoff, when the payload names it — status code and/or message on its own muted
   // line (same size as the retrying text: one size per information type), full message in the tooltip.
-  if (info.status || info.error) {
+  if (info.status || info.error || info.networkDown) {
     const err = el("div", "retrying-err");
     const status = info.status ? `HTTP ${info.status}` : "";
     const msg = (info.error || "").trim();
-    err.textContent = [status, msg].filter(Boolean).join(" — ");
-    if (msg) err.title = msg;
+    err.textContent = [status, msg, apiErrorReason(info)].filter(Boolean).join(" — ");
+    // The request id belongs in the tooltip, not the line: it is the one thing worth quoting to support and
+    // the one thing nobody reads at a glance (progressive disclosure — gist on the line, mechanics a hover away).
+    err.title = [msg, info.requestId ? `request ${info.requestId}` : ""].filter(Boolean).join("\n") || "";
     turn.appendChild(err);
   }
   return turn;
 }
+
 
 // The next-attempt countdown's text. Past due (the attempt is firing, or the CLI slipped its own estimate)
 // reads "retrying now…" rather than a stuck "0s" or a negative — the wait is over either way, and the loader


### PR DESCRIPTION
## The bug

romp has rendered a detailed retry banner for weeks — attempt N of M, a live countdown to the next attempt, the status and message behind the backoff. **None of it ever appeared.** The reader was written against *guessed* field names, and every one was wrong:

| romp read | the CLI actually sends |
|---|---|
| `number` | `retry_attempt` / `retryAttempt` |
| `max_retries` | `maxRetries` (transcript) |
| `retry_delay_ms` | `retry_in_ms` / `retryInMs` |
| `error_status` | `status_code`, or `error.status` |
| `error` (as a string) | `error` (a **dict**) |

So `retry_info` came back all-None on every real storm, the whole detail UI below it rendered blank, and a session in trouble showed a bare "API retrying" with no reason and no progress.

Found while diagnosing a session that kept dying on 529s while a fresh session connected fine. The UI could not tell those two situations apart, because it was showing nothing either way.

## The fix

Names verified against the two surfaces the frame actually arrives on, rather than guessed a second time:

- the **wire** frame (`SDKAPIRetryMessage`, subtype `api_retry`) — snake_case, per the CLI's own embedded schema (`retry_in_ms` / `is_network_down` / `is_ssl_error` / `rate_limit_type`);
- the **transcript** twin it is written from (`system` / subtype `api_error`) — camelCase, error as a nested dict.

Both are accepted, plus the old guesses, since either may reach us and dropping the old names would silently regress any build that sends them. A payload matching **none** of them writes one diagnostic line naming the keys it did send — blank detail is exactly the silent degradation `CLAUDE.md` forbids.

## What that unlocks

Detail romp was already carrying but could never show:

- **request id** in the tooltip — the one thing worth quoting to support, a hover away rather than cluttering the line (progressive disclosure).
- **a dropped network told apart from a busy API** — opposite problems, same red card, and only this flag separates them.
- **a quota 429 names which limit it hit.**

A shared `apiErrorReason()` turns the facts into the few words that decide what to do next, so the chat line and the bell entry can never describe the same failure differently. 529 now says it is server-side and temporary and *not* a fault of the session.

## Tests

- `tests/test_sdk_api_retry_detail.py` (new, 14 cases) — both real payload shapes fill every field and agree with each other; the countdown epoch derives from the backoff; old guesses still work; an unreadable payload is loud exactly once. **8 of these fail on `main`**, so they capture the bug rather than describing the fix.
- `ui/webview/api-error-reason.test.ts` (new, 11 cases) — the reason wording, the on-you cases outranking the status code, and both bell entries.
- `tests/test_kernel_retrying_chip.py` — two exact-dict assertions relaxed to the fields they test, plus coverage that the detail rides along.
- `ui/webview/chat-retrying-inline.test.ts` — one source pin updated for the widened tooltip.

Full suites green: 3610 Python passed / 25 skipped, 1459 node passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)