### PR TITLE
The composer's two buttons read as a pair again

### DIFF
--- a/ui/webview/composer-buttons.test.ts
+++ b/ui/webview/composer-buttons.test.ts
@@ -23,11 +23,33 @@ test("the old 26px squares are gone", () => {
   assert.match(CSS, /#composer-attach, #composer-send \{ bottom: 10px; height: 30px; \}/);
 });
 
-test("send is the widest control in the corner, not a twin of the paperclip", () => {
-  assert.match(CSS, /#composer-send \{ right: 28px; width: 46px; font-size: 16px; \}/);
-  assert.match(CSS, /#composer-attach \{ right: 82px; width: 34px; font-size: 16px; \}/);
-  // 28 + 46 = 74, so the paperclip at 82 clears it with room; the text stops clear of both
-  assert.match(CSS, /#composer-input \{ padding-right: 92px; \}/);
+test("send is the wider control in the corner, and the two sit FLUSH", () => {
+  assert.match(CSS, /#composer-send \{ right: 26px; width: 36px; font-size: 16px; \}/);
+  assert.match(CSS, /#composer-attach \{ right: 62px; width: 32px; font-size: 16px; \}/);
+  assert.match(CSS, /#composer-input \{ padding-right: 78px; \}/);
+});
+
+// The gap that MATTERS is between the drawn glyphs, not the boxes (the user 2026-07-29, round 2: on a
+// desktop the pair looked "goofy", far apart). A wide button centres a small glyph, so it contributes
+// half its slack to the visible gap on each side: at 46px wide with 8px between the boxes the arrow and
+// the paperclip sat 33px apart, which reads as two unrelated controls. Flush boxes and a narrower send
+// bring that to 19px, measured in a browser — and they can only stay flush if the arithmetic holds.
+test("the boxes are adjacent by arithmetic, so the glyphs read as one pair", () => {
+  const num = (re: RegExp) => {
+    const m = CSS.match(re);
+    assert.ok(m, `missing rule: ${re}`);
+    return Number(m![1]);
+  };
+  const sendRight = num(/#composer-send \{ right: (\d+)px/);
+  const sendWidth = num(/#composer-send \{ right: \d+px; width: (\d+)px/);
+  const attachRight = num(/#composer-attach \{ right: (\d+)px/);
+  assert.equal(sendRight + sendWidth, attachRight,
+    "a gap here is doubled by each button's own centring slack — keep them touching");
+  // and the text's inset clears the pair with a little air
+  const pad = num(/#composer-input \{ padding-right: (\d+)px; \}/);
+  const attachWidth = num(/#composer-attach \{ right: \d+px; width: (\d+)px/);
+  assert.ok(pad >= attachRight + attachWidth - 24 + 4,
+    `padding-right ${pad} must clear the pair (offsets are from #composer, 24px outside the box)`);
 });
 
 test("a coarse pointer gets a 44px row: the tap target a finger expects", () => {

--- a/ui/webview/composer-send.test.ts
+++ b/ui/webview/composer-send.test.ts
@@ -63,10 +63,10 @@ test("the send button is disabled on a closed (read-only) session", () => {
 test("the send button is styled to the right of 📎 and the textarea reserves room for both", () => {
   // resized 2026-07-29 (send is the primary action, so it is the wider of the two); the touch layout and
   // the arithmetic that keeps the pair inside the box live in composer-buttons.test.ts
-  assert.match(CSS, /#composer-send \{ right: 28px; width: 46px/);
-  assert.match(CSS, /#composer-attach \{ right: 82px; width: 34px/);
+  assert.match(CSS, /#composer-send \{ right: 26px; width: 36px/);
+  assert.match(CSS, /#composer-attach \{ right: 62px; width: 32px/);
   assert.match(CSS, /#composer-input \{[\s\S]*padding: 8px 64px 8px 10px/);
-  assert.match(CSS, /#composer-input \{ padding-right: 92px; \}/, "…widened for the bigger pair");
+  assert.match(CSS, /#composer-input \{ padding-right: 78px; \}/, "…widened for the bigger pair");
 });
 
 test("the composer sits tight to the bottom — no wasted gap below it (the user 2026-06-23)", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -534,9 +534,9 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    #composer, whose own right padding (24px here) is what puts the textarea's edge at 24: 28 is 4px
    inside the box. */
 #composer-attach, #composer-send { bottom: 10px; height: 30px; }
-#composer-send { right: 28px; width: 46px; font-size: 16px; }
-#composer-attach { right: 82px; width: 34px; font-size: 16px; }
-#composer-input { padding-right: 92px; }   /* text stops clear of both buttons */
+#composer-send { right: 26px; width: 36px; font-size: 16px; }
+#composer-attach { right: 62px; width: 32px; font-size: 16px; }
+#composer-input { padding-right: 78px; }   /* text stops clear of both buttons */
 #composer-input {
   width: 100%; resize: none; box-sizing: border-box;
   /* Floor at one line + padding + border, so the box can never collapse to a


### PR DESCRIPTION
On a desktop the paperclip and the arrow looked far apart after the widening. The widening caused it, in a way worth naming: the gap the eye reads is between the drawn **glyphs**, and a wide button centres a small glyph, so it donates half its slack to that gap on each side. At 46px wide with 8px between the boxes, the two marks sat **33px** apart and stopped reading as one cluster.

- Boxes are now flush (`26 + 36 = 62`), send is 36 wide rather than 46 → glyphs **19px** apart, measured in a browser.
- Both stay comfortably clickable, and the touch layout is unchanged: a 44px row keeps its 12px separation, since adjacent targets that size invite the wrong tap.
- The adjacency is asserted as **arithmetic** (`sendRight + sendWidth === attachRight`) rather than as two literal offsets, because that's the relationship that matters and the one a future nudge to either width would quietly break.

Both suites green (3626 python, 1467 node), tsc clean. CSS only — a browser reload picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)