### PR TITLE
Auto-retry backs off instead of hammering a limit that hasn't lifted

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3590,6 +3590,46 @@ RETRY_MSG = "retry\n\n<!-- romp-injected -->"
 # sid → the error-record uuid its last retry was sent FOR (the one-retry-per-error-episode gate in the
 # apiRetry route). A new error record = a new episode = one more retry; recovery = no key = no retries.
 _auto_retried = {}
+# ...and how long to WAIT before that next episode's retry (the user 2026-07-29, whose usage-limited thread
+# collected a ridiculous number of attempts). One-per-episode alone slows nothing down when every attempt
+# fails instantly: each failure writes a new error record, which is a new episode, so a blocked session
+# re-tried on the client's 10s tick indefinitely. A usage limit lasts minutes to hours, and hammering it
+# changes nothing.
+#
+# So the attempts back off: 1s, 5s, 15s, 45s, then 2, 5, 15 and 30 minutes, staying at 30. Roughly x3 per
+# step, which reaches the half-hour cadence about 23 minutes in, so a blip still recovers in seconds while
+# a real limit costs a handful of attempts instead of hundreds. The ladder is the KERNEL's, not each open
+# view's: the tick runs per client, so client-side spacing would multiply by the number of dashboards.
+# sid -> {"n": attempts this outage, "next": epoch before which no auto-retry fires}
+_auto_retry_state = {}
+RETRY_BACKOFF = (1, 5, 15, 45, 120, 300, 900, 1800)
+
+
+def _retry_backoff(n):
+    """Seconds to wait after `n` consecutive failed auto-retries (n=1 is the wait after the first).
+    Clamped to the last rung, so it never stops trying, it just stops hurrying (the tunnel dialer's
+    shape)."""
+    return RETRY_BACKOFF[min(max(int(n) - 1, 0), len(RETRY_BACKOFF) - 1)]
+
+
+def _retry_gate_state(sid):
+    st = _auto_retry_state.get(sid) or {}
+    return int(st.get("n") or 0), float(st.get("next") or 0)
+
+
+def _note_retry_sent(sid, manual=False):
+    """Record an attempt and when the next may fire. A MANUAL Retry-now resets the ladder, since the user
+    asked for this one and the following automatic attempt should not inherit a half-hour wait, but it
+    still sets a deadline so the auto loop cannot stack an attempt behind it."""
+    n, _ = _retry_gate_state(sid)
+    nxt = 1 if manual else n + 1
+    if len(_auto_retry_state) > 256:
+        _auto_retry_state.clear()
+    _auto_retry_state[sid] = {"n": 0 if manual else nxt, "next": time.time() + _retry_backoff(nxt)}
+
+
+def _clear_retry_backoff(sid):
+    _auto_retry_state.pop(sid, None)   # recovered: the next outage starts at the bottom rung again
 
 
 def _predict_working(flavor, ids=None, sid=None):
@@ -3925,11 +3965,15 @@ def _drive(msg, client):
             _rk = (_rerr.get("uuid") or _rerr.get("text") or "") if _rerr else None
         except Exception:
             pass                                              # unreadable state → manual still fires below
+        if _rk is None:
+            _clear_retry_backoff(sid)                         # recovered (or never blocked): reset the ladder
         if not msg.get("manual"):
             if _rk is None:
                 return                                        # not api-blocked right now → nothing to retry
             if _auto_retried.get(sid) == _rk:
                 return                                        # this episode already got its retry
+            if time.time() < _retry_gate_state(sid)[1]:
+                return                                        # backing off: this outage's next rung isn't due
         if _rk is not None:
             if len(_auto_retried) > 256:
                 _auto_retried.clear()
@@ -3941,6 +3985,7 @@ def _drive(msg, client):
         # board…", 71 of them in one API-error storm). The marker makes author_of return 'romp' (ROMP_INJECT_RE)
         # so the echo + transcript render gray and the planner skips a work-less retry instead of minting a goal.
         be.send(sid, RETRY_MSG)
+        _note_retry_sent(sid, manual=bool(msg.get("manual")))
     elif t == "setModel" and msg.get("value"):
         _set_model_or_park(be, sid, str(msg["value"])); _push_soon()   # mid-compaction → parked as a queued command
     elif t == "setEffort" and msg.get("value"):
@@ -11060,6 +11105,11 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   # user interrupted this thread's retry/API-error storm → romp's auto-retry stays OFF for it
                   # until a successful turn re-arms (the user 2026-07-06); the card + retry loop read this
                   "retrySuppressed": _session_retry_suppressed(sid),
+                  # the auto-retry ladder (the user 2026-07-29): when the next attempt may fire, and how
+                  # many this outage has already spent. The kernel owns the cadence, so the card counts
+                  # down to the real thing instead of to each view's own 10s tick.
+                  "retryNextAt": int(_retry_gate_state(sid)[1]) or None,
+                  "retryTries": _retry_gate_state(sid)[0] or None,
                   "backend": _session_backend(sid, tm),
                   "model": tm["model"], "effort": tm["effort"], "mode": tm.get("mode", ""),
                   "modelPending": _model_pending_now(sid, tm),   # switching-dots on the model badge until the pick lands, from EITHER surface (the user 2026-07-03)

--- a/tests/test_api_retry_backoff.py
+++ b/tests/test_api_retry_backoff.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Auto-retry backs OFF (the user 2026-07-29): a usage-limited thread was collecting a ridiculous number
+of attempts.
+
+One-retry-per-error-episode (2026-07-20) stopped retries STACKING, but it does not slow anything down
+when every attempt fails instantly: each failure writes a new error record, which is a new episode, so a
+blocked session was re-tried on the client's 10s tick for as long as the block lasted. A usage limit
+lasts minutes to hours and hammering it changes nothing.
+
+Attempts now climb 1s, 5s, 15s, 45s, 2m, 5m, 15m, 30m and stay at 30m: a blip still recovers in seconds,
+a real limit costs a handful of attempts. The ladder lives in the KERNEL because the retry tick runs per
+open view, so any client-side spacing would divide by the number of dashboards.
+
+Synthetic ids only; no sessions, no sends.
+"""
+import inspect
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_retryb", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class Ladder(unittest.TestCase):
+    def tearDown(self):
+        km._auto_retry_state.clear()
+
+    def test_it_starts_in_a_second_and_climbs(self):
+        self.assertEqual(km._retry_backoff(1), 1, "a blip must recover in a second, not in a minute")
+        waits = [km._retry_backoff(n) for n in range(1, 9)]
+        self.assertEqual(waits, [1, 5, 15, 45, 120, 300, 900, 1800])
+
+    def test_it_never_narrows_and_never_stops(self):
+        waits = [km._retry_backoff(n) for n in range(1, 40)]
+        self.assertEqual(waits, sorted(waits), "a longer outage never retries MORE often")
+        for w in waits:
+            self.assertGreater(w, 0, "there is no 'stop' rung: it stops hurrying, not trying")
+
+    def test_it_settles_at_half_an_hour(self):
+        self.assertEqual(km._retry_backoff(50), 1800)
+        self.assertEqual(max(km.RETRY_BACKOFF), 1800)
+
+    def test_the_half_hour_cadence_is_reached_in_well_under_an_hour(self):
+        # the point of the early rungs: a real limit costs a handful of attempts, not hundreds, and the
+        # thread is not left waiting half an hour for its second try
+        to_cap = sum(km._retry_backoff(n) for n in range(1, len(km.RETRY_BACKOFF)))
+        self.assertLess(to_cap, 30 * 60, "climbing to the cap must cost less than one capped wait")
+        self.assertGreater(to_cap, 10 * 60)
+
+    def test_an_attempt_records_the_next_deadline(self):
+        km._note_retry_sent(SID)
+        n, nxt = km._retry_gate_state(SID)
+        self.assertEqual(n, 1)
+        self.assertAlmostEqual(nxt - time.time(), 1, delta=2)
+        km._note_retry_sent(SID)
+        n2, nxt2 = km._retry_gate_state(SID)
+        self.assertEqual(n2, 2)
+        self.assertAlmostEqual(nxt2 - time.time(), 5, delta=2, msg="the second failure steps up a rung")
+
+    def test_a_manual_retry_resets_the_ladder_but_still_holds_the_auto_loop_off(self):
+        for _ in range(6):
+            km._note_retry_sent(SID)
+        self.assertGreaterEqual(km._retry_gate_state(SID)[1] - time.time(), 100)
+        km._note_retry_sent(SID, manual=True)
+        n, nxt = km._retry_gate_state(SID)
+        self.assertEqual(n, 0, "you asked for this one, so the next automatic attempt starts over")
+        self.assertGreater(nxt, time.time(), "…but the auto loop cannot stack an attempt behind yours")
+        self.assertLess(nxt - time.time(), 5)
+
+    def test_recovery_resets_the_ladder(self):
+        for _ in range(4):
+            km._note_retry_sent(SID)
+        km._clear_retry_backoff(SID)
+        self.assertEqual(km._retry_gate_state(SID), (0, 0))
+        km._note_retry_sent(SID)
+        self.assertAlmostEqual(km._retry_gate_state(SID)[1] - time.time(), 1, delta=2,
+                               msg="a later outage starts at the bottom rung")
+
+    def test_the_map_cannot_grow_without_bound(self):
+        for i in range(300):
+            km._note_retry_sent("sid-%d" % i)
+        self.assertLessEqual(len(km._auto_retry_state), 300)
+
+
+class Wiring(unittest.TestCase):
+    def test_the_route_refuses_an_auto_retry_inside_the_backoff_window(self):
+        src = inspect.getsource(km._drive)
+        self.assertIn("if time.time() < _retry_gate_state(sid)[1]:", src)
+        self.assertIn("_note_retry_sent(sid, manual=bool(msg.get(\"manual\")))", src)
+        # …and the send happens BEFORE the stamp, so a refused send doesn't burn a rung
+        self.assertLess(src.index("be.send(sid, RETRY_MSG)"), src.index("_note_retry_sent(sid"))
+
+    def test_recovery_clears_the_ladder_on_the_next_tick(self):
+        src = inspect.getsource(km._drive)
+        self.assertIn("_clear_retry_backoff(sid)", src)
+
+    def test_a_manual_retry_is_never_gated_by_the_backoff(self):
+        src = inspect.getsource(km._drive)
+        gate = src[src.index("if time.time() < _retry_gate_state(sid)[1]:")]
+        self.assertTrue(gate)
+        # the whole gate block sits under `if not msg.get("manual")`
+        head = src[:src.index("if time.time() < _retry_gate_state(sid)[1]:")]
+        self.assertIn('if not msg.get("manual"):', head.split("elif t ==")[-1])
+
+    def test_the_status_payload_publishes_the_schedule(self):
+        src = inspect.getsource(km.build_session)
+        self.assertIn('"retryNextAt": int(_retry_gate_state(sid)[1]) or None,', src)
+        self.assertIn('"retryTries": _retry_gate_state(sid)[0] or None,', src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_apiretry.py
+++ b/tests/test_kernel_apiretry.py
@@ -86,12 +86,14 @@ class ApiRetryIdempotency(unittest.TestCase):
         km._api_error = _aerr
         km._path_of = lambda sid, now=None: "/TESTDIR/x.jsonl"
         km._auto_retried.clear()
+        km._auto_retry_state.clear()   # …and the backoff ladder (2026-07-29): each case starts at rung one
 
     def tearDown(self):
         (km.Sessions, km._retry_paused_on, km._session_retry_suppressed,
          km._api_error, km._path_of) = self._saved
         km._name_of = self._saved_name_of
         km._auto_retried.clear()
+        km._auto_retry_state.clear()
 
     def _drive_retry(self, be, **msg):
         km.Sessions = types.SimpleNamespace(backend_for=lambda sid: be)

--- a/tests/test_kernel_retry_episode.py
+++ b/tests/test_kernel_retry_episode.py
@@ -59,6 +59,12 @@ class RetryPerEpisode(unittest.TestCase):
         km._name_of = self._saved_name_of
         km._auto_retried.clear()
         km._auto_retried.update(saved)
+        km._auto_retry_state.clear()
+
+    def _elapse(self):
+        """Let the backoff window pass (the ladder itself is covered by test_api_retry_backoff.py). These
+        tests are about EPISODE identity, so they step over the wait rather than sleeping through it."""
+        km._auto_retry_state.pop(SID, None)
 
     def _auto(self):
         return km._drive({"type": "apiRetry", "id": SID}, {"send": lambda s: None})
@@ -77,6 +83,9 @@ class RetryPerEpisode(unittest.TestCase):
         self._auto()
         self.aerr = dict(self.aerr, uuid="err-2")   # the attempt ran and failed again → new record
         self._auto()
+        self.assertEqual(len(self.be.sent), 1, "the backoff holds the new episode until its rung is due")
+        self._elapse()
+        self._auto()
         self.assertEqual(len(self.be.sent), 2)
 
     def test_recovered_session_gets_no_auto_retry(self):
@@ -87,7 +96,7 @@ class RetryPerEpisode(unittest.TestCase):
     def test_manual_always_fires_and_owns_the_episode(self):
         self._auto()
         self._manual()                               # user override fires even though the episode is stamped
-        self.assertEqual(len(self.be.sent), 2)
+        self.assertEqual(len(self.be.sent), 2, "…and even inside the backoff window (2026-07-29)")
         self._auto()                                 # …but the auto loop won't stack behind the manual one
         self.assertEqual(len(self.be.sent), 2)
 

--- a/ui/webview/apierror-retry-now.test.ts
+++ b/ui/webview/apierror-retry-now.test.ts
@@ -37,3 +37,27 @@ test("a usage-limit pause counts down to the window reset instead of a mute labe
   // the LIVE (newest) error card ticks — older cards in the transcript are settled history
   assert.match(RENDER, /const cd = cds\.length \? \(cds\[cds\.length - 1\] as HTMLElement\) : null;/);
 });
+
+// ── the cadence is the KERNEL's (the user 2026-07-29) ───────────────────────────────────────────────
+// A usage-limited thread was collecting a ridiculous number of attempts: one-per-episode stops retries
+// stacking, but every failure writes a new error record, so a new episode, so the 10s tick retried for
+// as long as the block lasted. The kernel now backs each outage off to at most half an hour and
+// publishes when the next attempt may fire; this view follows that instead of its own tick.
+test("the tick holds off while the kernel's deadline stands, and adopts it as the countdown", () => {
+  assert.match(RENDER, /const kernelNext = sessions\.get\(id\)\?\.status\.retryNextAt;/);
+  assert.match(RENDER, /apiRetryNext\.set\(id, kernelNext \* 1000\);/, "the countdown shows the real schedule");
+  assert.match(RENDER, /if \(now < kernelNext \* 1000\) return;/, "no asking inside the window");
+  // no deadline published (a fresh block, an older kernel) → the local 10s tick still makes the first ask
+  assert.match(RENDER, /\} else if \(!apiRetryNext\.has\(id\)\) \{\s*\n\s*apiRetryNext\.set\(id, now \+ API_RETRY_MS\);/);
+});
+
+test("a long wait reads in minutes, with the attempt count explaining the gap", () => {
+  // "retrying in 1750s" is not a readable wait, and a silent 30-minute gap reads as stuck rather than
+  // as deliberate — the count is what says the backoff has stepped up
+  assert.match(RENDER, /const when = left >= 90 \? `\$\{Math\.round\(left \/ 60\)\}m` : `\$\{left\}s`;/);
+  assert.match(RENDER, /tries > 1 \? ` · \$\{tries\} tries so far` : ""/);
+});
+
+test("the status carries the schedule", () => {
+  assert.match(RENDER, /retryNextAt\?: number \| null; retryTries\?: number \| null;/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -183,7 +183,7 @@ type ChatEvent = (
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
 type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
-interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; retrySuppressed?: boolean; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03)
+interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed.
@@ -2594,7 +2594,19 @@ function apiRetryTick(): void {
     sessions.forEach((s, id) => { if (s.status.state === "blocked" && !s.status.retrySuppressed && !s.status.apiSpendLimit) blocked.add(id); });
     apiRetryNext.forEach((_, id) => { if (!blocked.has(id)) apiRetryNext.delete(id); });   // recovered / suppressed → stop
     blocked.forEach((id) => {
-      if (!apiRetryNext.has(id)) apiRetryNext.set(id, now + API_RETRY_MS);
+      // The kernel owns the cadence now (the user 2026-07-29): it backs each outage's attempts off up to
+      // half an hour, and publishes when the next may fire. While that deadline stands, this tick does
+      // not ask — asking anyway would be harmless (the kernel refuses) but it would also mean every open
+      // dashboard hammering the gate, and the countdown below would be describing a schedule that isn't
+      // the real one. With no deadline published (a fresh block, an older kernel) the local 10s tick
+      // stands in, so the first attempt is still prompt.
+      const kernelNext = sessions.get(id)?.status.retryNextAt;
+      if (kernelNext) {
+        apiRetryNext.set(id, kernelNext * 1000);
+        if (now < kernelNext * 1000) return;
+      } else if (!apiRetryNext.has(id)) {
+        apiRetryNext.set(id, now + API_RETRY_MS);
+      }
       if (now >= (apiRetryNext.get(id) as number)) {
         if (vscodeApi) vscodeApi.postMessage({ type: "apiRetry", id });
         apiRetryNext.set(id, now + API_RETRY_MS);                                          // reset the countdown
@@ -2614,7 +2626,14 @@ function apiRetryTick(): void {
       cd.textContent = "auto-retry stopped for this session — send a message to resume";
     } else {
       const at = activeId ? apiRetryNext.get(activeId) : undefined;
-      cd.textContent = at ? `retrying in ${Math.max(0, Math.ceil((at - now) / 1000))}s` : "retrying soon…";
+      const tries = active?.status.retryTries || 0;
+      if (!at) { cd.textContent = "retrying soon…"; } else {
+        const left = Math.max(0, Math.ceil((at - now) / 1000));
+        // "in 1750s" is not a readable wait; past a minute it reads in minutes, and the attempt count
+        // explains why the gap has grown (each failure steps the backoff up) rather than looking stuck
+        const when = left >= 90 ? `${Math.round(left / 60)}m` : `${left}s`;
+        cd.textContent = `retrying in ${when}` + (tries > 1 ? ` · ${tries} tries so far` : "");
+      }
     }
   }
 }


### PR DESCRIPTION
A usage-limited thread was collecting a ridiculous number of retries. One-retry-per-episode (2026-07-20) stopped them *stacking*, but it slows nothing down when every attempt fails instantly: each failure writes a new error record, which is a new episode, so the session was re-tried on the client's 10s tick for as long as the block lasted.

**The ladder**: 1s, 5s, 15s, 45s, 2m, 5m, 15m, 30m, then 30m forever. A blip still recovers in a second; a real limit costs a handful of attempts instead of hundreds. Climbing to the cap takes ~23 minutes, so nothing waits half an hour for its *second* try. No rung means "stop" — it stops hurrying, not trying.

**It lives in the kernel**, deliberately: the retry tick runs per open view, so client-side spacing would divide by the number of dashboards.

- Recovery resets it, so a later outage starts at the bottom rung.
- A manual **Retry now** resets it too (you asked for that one; the next automatic attempt shouldn't inherit a half-hour wait) but still takes a short deadline so the auto loop can't stack behind yours.
- The card follows the same schedule instead of its own tick: the kernel publishes `retryNextAt`/`retryTries`, the countdown reads in minutes once the gap is long, and the attempt count says why it grew. A silent 30-minute gap reads as stuck.

Tests: `tests/test_api_retry_backoff.py` (12 cases: ladder shape, monotonic, never zero, the cap, time-to-cap, per-attempt deadlines, manual reset, recovery reset, bounded map, plus route wiring including send-before-stamp so a refused send doesn't burn a rung) and three cases appended to `ui/webview/apierror-retry-now.test.ts`. Two existing suites updated where they encoded the old immediate cadence — they now step over the wait explicitly, since they are about episode identity, not timing.

Both suites green (3638 python, 1478 node), tsc clean. Kernel-side, so it needs a kernel restart to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)