### PR TITLE
One command cuts a release, and VERSION is the only place the number is typed

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,90 +1,213 @@
 #!/usr/bin/env bash
-# scripts/release.sh vX.Y.Z — cut a romp release, with the macOS check as a HARD GATE.
+# scripts/release.sh [major|minor|patch|X.Y.Z] [flags] — cut a romp release, end to end.
 #
-# Why a script rather than `git tag`: two release rules are easy to get wrong by hand
-# and expensive to get wrong in public.
+# ONE SOURCE OF TRUTH: the VERSION file. The tag is DERIVED from it, always as
+# "v$(cat VERSION)", and this script does not accept a tag argument at all. That is
+# deliberate: the old interface took the tag and then checked it against VERSION, so the
+# two could disagree and the only thing standing between you and a mismatched release was
+# a comparison you had to remember to trust. Removing the second input removes the whole
+# class of error — there is now exactly one place a human types the number, and everything
+# downstream is computed (the user 2026-07-29, who wanted one script that does everything
+# and keeps the version in sync with the tags).
 #
-#   1. The tag MUST be v-prefixed. bootstrap.sh picks the release with
-#      `git tag -l 'v*' --sort=-v:refname | head -n1`. A tag like "0.1.0" matches
-#      NOTHING, so the one-line installer silently falls back to main instead of
-#      installing the release — no error, just the wrong thing. This refuses a
-#      non-v tag outright.
-#   2. macOS CI does not run on pushes (it is billed even on public repos, ~10x,
-#      so it is workflow_dispatch-only). That means a macOS-only breakage can sit
-#      undetected until a user hits it. Releasing is exactly when that matters, so
-#      this triggers the macOS run and REFUSES to tag unless it goes green.
+# It runs the whole sequence, because the steps between "bump the number" and "users can
+# install it" were a chain of by-hand commands that were easy to half-finish. Leaving
+# VERSION merged but untagged is the worst of those states: main claims a version that
+# bootstrap.sh will not install, since bootstrap picks the newest v* TAG.
 #
-# --skip-macos exists for the case where you must ship anyway; it is deliberately
-# an explicit flag (never an env default) and it says so loudly.
+#   1. resolve the target version (a bump level, an explicit number, or whatever VERSION
+#      already says) and refuse it if that tag already exists
+#   2. if VERSION needs to change: branch, commit, push, open a PR, auto-merge it, and wait
+#      for it to land on main  (skipped entirely when VERSION is already correct)
+#   3. run the test suites
+#   4. the macOS gate (see below)
+#   5. tag, push the tag, and publish the GitHub release
+#
+# Two rules it has always existed to enforce, both easy to get wrong by hand and expensive
+# to get wrong in public:
+#
+#   * The tag MUST be v-prefixed. bootstrap.sh picks the release with
+#     `git tag -l 'v*' --sort=-v:refname | head -n1`. A tag like "0.1.0" matches NOTHING, so
+#     the one-line installer silently falls back to main instead of installing the release —
+#     no error, just the wrong thing. Deriving the tag guarantees the prefix.
+#   * macOS CI does not run on pushes (it is billed even on public repos, ~10x, so it is
+#     workflow_dispatch-only). A macOS-only breakage can therefore sit undetected until a
+#     user hits it. Releasing is exactly when that matters, so this triggers the macOS run
+#     and REFUSES to tag unless it goes green.
+#
+# --skip-macos exists for the case where you must ship anyway; it is deliberately an
+# explicit flag (never an env default) and it says so loudly.
 set -euo pipefail
 
 GH="${ROMP_GH:-gh}"                       # overridable so tests can stub the GitHub CLI
 POLL="${ROMP_RELEASE_POLL:-5}"            # seconds between checks while the run starts
 REF="${ROMP_RELEASE_REF:-main}"
+UPSTREAM="${ROMP_RELEASE_UPSTREAM:-romp-on/romp}"
 skip_macos=0
+skip_tests=0
+dry_run=0
+bump=""
 
-usage() { echo "usage: scripts/release.sh vX.Y.Z [--skip-macos]" >&2; exit 2; }
+usage() {
+    cat >&2 <<'USAGE'
+usage: scripts/release.sh [major|minor|patch|X.Y.Z] [flags]
 
-tag=""
+  (no argument)       release the version VERSION already carries
+  major|minor|patch   bump VERSION by that much first, via a PR
+  X.Y.Z               set VERSION to exactly this, via a PR
+
+flags:
+  --skip-macos    tag without waiting for the dispatch-only macOS run (loud, discouraged)
+  --skip-tests    do not run the local suites before releasing
+  --dry-run       print what would happen; change nothing
+USAGE
+    exit 2
+}
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --skip-macos) skip_macos=1 ;;
+        --skip-tests) skip_tests=1 ;;
+        --dry-run)    dry_run=1 ;;
         -h|--help)    usage ;;
         -*)           echo "release: unknown flag $1" >&2; usage ;;
-        *)            [ -z "$tag" ] || usage; tag="$1" ;;
+        v[0-9]*)      echo "release: pass the version WITHOUT the leading v ('${1#v}', not '$1')." >&2
+                      echo "  The tag is derived from VERSION, so the two cannot disagree." >&2
+                      exit 2 ;;
+        *)            [ -z "$bump" ] || usage; bump="$1" ;;
     esac
     shift
 done
-[ -n "$tag" ] || usage
 
 die() { echo "release: $*" >&2; exit 1; }
-
-# ── 1. the v-prefix rule ──────────────────────────────────────────────
-if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
-    die "tag must be v-prefixed semver, e.g. v0.1.0 (got '$tag').
-  bootstrap.sh selects releases with \`git tag -l 'v*'\`; a non-v tag matches
-  nothing and the installer silently falls back to main."
-fi
+say() { echo "release: $*"; }
+step() { if [ "$dry_run" -eq 1 ]; then echo "release: [dry-run] $*"; else "$@"; fi; }
 
 # Resolve the repo from THIS SCRIPT's location, never the caller's cwd. With
-# `git rev-parse --show-toplevel` the script would inspect — and tag — whatever
-# repo you happened to be standing in, reading that tree's cleanliness and
-# VERSION instead of the one being released.
+# `git rev-parse --show-toplevel` the script would inspect — and tag — whatever repo you
+# happened to be standing in, reading that tree's cleanliness and VERSION instead of the one
+# being released.
 root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$root"
 
-# `&&` would make a MISSING tag (the normal case) the last command and exit
-# non-zero under `set -e`, so this is an explicit if.
+[ -f VERSION ] || die "no VERSION file at the repo root — it is the source of truth and must exist."
+current="$(tr -d '[:space:]' < VERSION)"
+
+# ── 1. resolve the target version ─────────────────────────────────────
+# The bump arithmetic works on the X.Y.Z core, so a prerelease suffix ("0.2.0-rc.1") bumps
+# from its release number rather than tripping the parser.
+core="${current%%-*}"
+if [[ ! "$core" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    die "VERSION ('$current') is not X.Y.Z — cannot compute a bump from it."
+fi
+IFS=. read -r cur_major cur_minor cur_patch <<EOF
+$core
+EOF
+
+case "$bump" in
+    "")      target="$current" ;;
+    major)   target="$((cur_major + 1)).0.0" ;;
+    minor)   target="$cur_major.$((cur_minor + 1)).0" ;;
+    patch)   target="$cur_major.$cur_minor.$((cur_patch + 1))" ;;
+    *)       target="$bump" ;;
+esac
+
+if [[ ! "$target" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+    die "'$target' is not semver (X.Y.Z, optionally with a prerelease suffix)."
+fi
+tag="v$target"
+
 if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
     die "tag $tag already exists."
 fi
 
+say "releasing $tag (VERSION currently reads $current)."
+
 # ── 2. the tree must be releasable ────────────────────────────────────
 [ -z "$(git status --porcelain)" ] || die "working tree is dirty — commit or stash first."
 
-# VERSION carries the number without the v; a mismatch means one of them was forgotten.
-if [ -f VERSION ]; then
-    want="${tag#v}"
-    have="$(tr -d '[:space:]' < VERSION)"
-    [ "$want" = "$have" ] || die "VERSION says '$have' but the tag is '$tag' — update VERSION first."
+# ── 3. land the version bump, if there is one ─────────────────────────
+# Skipped entirely when VERSION already carries the target, which is the normal case when a
+# bump PR landed earlier. That makes a half-finished release resumable: re-running picks up
+# where it stopped instead of insisting on starting over.
+if [ "$current" != "$target" ]; then
+    # Branch pushes to the upstream are blocked by rulesets, so publishing is always
+    # push-to-a-fork then PR. remote.pushDefault is the configured answer when there is one.
+    publish="$(git config --get remote.pushDefault || true)"
+    if [ -z "$publish" ]; then
+        if git remote get-url fork >/dev/null 2>&1; then publish=fork; else publish=origin; fi
+    fi
+    branch="release-$target"
+    say "VERSION $current → $target, via a PR on $branch (pushing to '$publish')."
+    if [ "$dry_run" -eq 1 ]; then
+        say "[dry-run] would branch, commit VERSION=$target, open a PR, and auto-merge it."
+    else
+        printf '%s\n' "$target" > VERSION
+        git switch -c "$branch" >/dev/null 2>&1 || die "could not create branch $branch."
+        git add VERSION
+        git commit -qm "VERSION $target" || die "nothing to commit for the version bump."
+        git push -q -u "$publish" "$branch" || die "could not push $branch to $publish."
+        "$GH" pr create --repo "$UPSTREAM" --title "VERSION $target" \
+            --body "Version bump for \`$tag\`, opened by scripts/release.sh." \
+            || die "could not open the version PR."
+        "$GH" pr merge --repo "$UPSTREAM" --auto --merge "$branch" \
+            || die "could not arm auto-merge on the version PR."
+        say "waiting for the version PR to land on $REF (its CI is the first gate)..."
+        state=""
+        for _ in $(seq 1 120); do
+            state="$("$GH" pr view "$branch" --repo "$UPSTREAM" --json state -q .state 2>/dev/null || true)"
+            if [ "$state" = "MERGED" ]; then break; fi
+            if [ "$state" = "CLOSED" ]; then die "the version PR was closed without merging."; fi
+            if [ "$POLL" = "0" ]; then break; fi
+            sleep "$POLL"
+        done
+        [ "$state" = "MERGED" ] || die "the version PR did not merge — check $UPSTREAM."
+        git switch "$REF" >/dev/null 2>&1 || die "could not switch back to $REF."
+        git fetch -q origin
+        git merge --ff-only "origin/$REF" >/dev/null || die "could not fast-forward $REF after the merge."
+        say "version PR merged; $REF now carries $target."
+    fi
+else
+    say "VERSION already reads $target — no bump PR needed."
 fi
 
-# ── 3. the macOS gate ─────────────────────────────────────────────────
+# Re-read rather than trust the arithmetic: after the merge, the file on disk is the truth.
+if [ "$dry_run" -eq 0 ]; then
+    have="$(tr -d '[:space:]' < VERSION)"
+    [ "$have" = "$target" ] || die "VERSION says '$have' but we are releasing '$tag' — refusing to tag a mismatch."
+fi
+
+# ── 4. the tests ──────────────────────────────────────────────────────
+if [ "$skip_tests" -eq 1 ]; then
+    echo "release: !! skipping the local suites at your explicit request (--skip-tests)."
+else
+    say "running the Python suite..."
+    step python3 -m pytest tests/ -q || die "the Python suite failed — NOT releasing."
+    if [ -d vscode-extension/node_modules ]; then
+        say "running the webview suite..."
+        step sh -c 'cd vscode-extension && npm test' || die "the webview suite failed — NOT releasing."
+    else
+        say "vscode-extension/node_modules is absent — skipping the webview suite (npm install to include it)."
+    fi
+fi
+
+# ── 5. the macOS gate ─────────────────────────────────────────────────
 if [ "$skip_macos" -eq 1 ]; then
     echo "release: !! SKIPPING the macOS check at your explicit request (--skip-macos)."
     echo "release: !! a macOS-only breakage in $tag would reach users undetected."
+elif [ "$dry_run" -eq 1 ]; then
+    say "[dry-run] would dispatch the macOS CI run and wait for it."
 else
-    echo "release: triggering the macOS CI run on $REF (it is dispatch-only, so this is the check)..."
+    say "triggering the macOS CI run on $REF (it is dispatch-only, so this is the check)..."
     before="$("$GH" run list --workflow CI --event workflow_dispatch -L 1 --json databaseId -q '.[0].databaseId // ""' 2>/dev/null || true)"
     "$GH" workflow run CI --ref "$REF" || die "could not dispatch the CI workflow."
 
-    # Identify OUR run by waiting for the newest dispatch run to differ from the one
-    # that was newest before we dispatched — `gh workflow run` prints no run id, and
-    # taking the newest unconditionally would happily watch a PREVIOUS run and pass
-    # the gate on a stale green.
+    # Identify OUR run by waiting for the newest dispatch run to differ from the one that was
+    # newest before we dispatched — `gh workflow run` prints no run id, and taking the newest
+    # unconditionally would happily watch a PREVIOUS run and pass the gate on a stale green.
     #
-    # Each guard is a full `if`: under `set -e`, a bare `[ x ] && y` whose test is
-    # false makes the whole list non-zero and kills the script.
+    # Each guard is a full `if`: under `set -e`, a bare `[ x ] && y` whose test is false makes
+    # the whole list non-zero and kills the script.
     run_id=""
     for _ in $(seq 1 60); do
         if [ "$POLL" != "0" ]; then sleep "$POLL"; fi
@@ -96,12 +219,12 @@ else
         die "the dispatched CI run never appeared — check the Actions tab."
     fi
 
-    echo "release: watching run $run_id (macOS bats is ~16 min; this is the wait you are paying for)..."
-    # Poll `run view`, never `gh run watch`: watch holds one long connection and
-    # treats ANY hiccup — a GitHub 502, a local socket error — as run failure.
-    # Twice (2026-07-27) it declared a still-running, ultimately GREEN gate "did
-    # not pass". Here a transient API error just yields an empty conclusion and
-    # we poll again; only the run's own verdict ends the wait.
+    say "watching run $run_id (macOS bats is ~16 min; this is the wait you are paying for)..."
+    # Poll `run view`, never `gh run watch`: watch holds one long connection and treats ANY
+    # hiccup — a GitHub 502, a local socket error — as run failure. Twice (2026-07-27) it
+    # declared a still-running, ultimately GREEN gate "did not pass". Here a transient API
+    # error just yields an empty conclusion and we poll again; only the run's own verdict
+    # ends the wait.
     conclusion=""
     while :; do
         conclusion="$("$GH" run view "$run_id" --json conclusion -q .conclusion 2>/dev/null || true)"
@@ -113,10 +236,29 @@ else
         die "the macOS run did not pass (conclusion: ${conclusion:-none}) — NOT tagging $tag.
   Fix it, or re-run with --skip-macos if you have decided to ship anyway."
     fi
-    echo "release: macOS run green."
+    say "macOS run green."
 fi
 
-# ── 4. tag ────────────────────────────────────────────────────────────
-git tag -a "$tag" -m "romp $tag"
-echo "release: created tag $tag."
-echo "release: push it with:  git push origin $tag"
+# ── 6. tag, push, publish ─────────────────────────────────────────────
+# The previous release, for the notes range — computed BEFORE the new tag exists so it can
+# never pick itself.
+prev="$(git tag -l 'v*' --sort=-v:refname | head -n1 || true)"
+
+step git tag -a "$tag" -m "romp $tag"
+say "created tag $tag."
+
+# The tag goes to the UPSTREAM: rulesets block branch pushes there, but a tag is how a
+# release is published, and a tag that exists only locally installs for nobody.
+step git push -q origin "$tag" || die "could not push $tag to origin."
+say "pushed $tag."
+
+if [ -n "$prev" ]; then
+    step "$GH" release create "$tag" --repo "$UPSTREAM" --title "romp $tag" \
+        --generate-notes --notes-start-tag "$prev" \
+        || die "$tag is pushed, but publishing the release failed — finish with:
+  gh release create $tag --repo $UPSTREAM --generate-notes"
+else
+    step "$GH" release create "$tag" --repo "$UPSTREAM" --title "romp $tag" --generate-notes \
+        || die "$tag is pushed, but publishing the release failed."
+fi
+say "published. $tag is live — bootstrap.sh will install it."

--- a/tests/release-sh.bats
+++ b/tests/release-sh.bats
@@ -1,11 +1,14 @@
 #!/usr/bin/env bats
 
-# scripts/release.sh — the release gate. Two rules it exists to enforce:
-#   * the tag must be v-prefixed (bootstrap.sh's `git tag -l 'v*'` selector matches
-#     nothing otherwise, and the installer silently falls back to main), and
-#   * the macOS CI run — which is dispatch-only, since macOS is billed even on public
-#     repos — must be GREEN before a version is tagged.
-# The GitHub CLI is stubbed via ROMP_GH so none of this touches real CI.
+# scripts/release.sh — the release gate. What it exists to enforce:
+#   * VERSION is the ONE source of truth and the tag is DERIVED from it, so the two can
+#     never disagree — the script takes no tag argument at all (2026-07-29);
+#   * the tag is therefore always v-prefixed (bootstrap.sh's `git tag -l 'v*'` selector
+#     matches nothing otherwise, and the installer silently falls back to main);
+#   * the macOS CI run — dispatch-only, since macOS is billed even on public repos — must
+#     be GREEN before a version is tagged.
+# The GitHub CLI is stubbed via ROMP_GH so none of this touches real CI, and most tests run
+# with --skip-tests: the fixture repo has no suites of its own.
 
 ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
@@ -15,19 +18,29 @@ setup() {
     mkdir -p "$REPO/scripts"
     cp "$ROMP_DIR/scripts/release.sh" "$REPO/scripts/"
     git init -q "$REPO"
+    # `git init -b main` needs git 2.28+; setting HEAD before the first commit works on every
+    # version, which matters because this suite also runs on the CI's older shells.
+    git -C "$REPO" symbolic-ref HEAD refs/heads/main
     git -C "$REPO" config user.email t@e.invalid
     git -C "$REPO" config user.name t
     echo "0.1.0" > "$REPO/VERSION"
     git -C "$REPO" add -A
     git -C "$REPO" commit -qm init
+    # A real origin, because the script now pushes the tag and (on a bump) the branch. A
+    # bare repo is enough and keeps every test on the same footing as a real clone.
+    git init -q --bare "$TEST_DIR/origin.git"
+    git -C "$REPO" remote add origin "$TEST_DIR/origin.git"
+    git -C "$REPO" push -q origin main
+    export REPO_FOR_STUB="$REPO"
     export ROMP_RELEASE_POLL=0          # no sleeping in tests
     export GH_LOG="$TEST_DIR/gh.log"
 }
 teardown() { rm -rf "$TEST_DIR"; }
 
 # STUB_CONCLUSION = what the stubbed `gh run view` reports (default success).
-# STUB_FLAKY_VIEWS = report nothing for the first N `run view` calls, as a
-# transient API error looks to the poll loop, then the real conclusion.
+# STUB_FLAKY_VIEWS = report nothing for the first N `run view` calls, as a transient API
+# error looks to the poll loop, then the real conclusion.
+# STUB_PR_STATE = what `gh pr view` reports (default MERGED).
 _stub_gh() {
     cat > "$TEST_DIR/gh" <<STUB
 #!/usr/bin/env bash
@@ -41,6 +54,13 @@ case "\$1 \$2" in
       n=\$(( \$(cat "$TEST_DIR/views" 2>/dev/null || echo 0) + 1 )); echo "\$n" > "$TEST_DIR/views"
       if [ "\$n" -le "\${STUB_FLAKY_VIEWS:-0}" ]; then exit 1; fi
       echo "\${STUB_CONCLUSION:-success}" ;;
+  # Auto-merge really lands the branch on origin/main, so the script's post-merge
+  # fast-forward has something to pull and VERSION genuinely changes on main. Simulating
+  # the merge as a no-op would let the bump path "pass" while proving nothing.
+  "pr merge")   if [ "\${STUB_PR_STATE:-MERGED}" = "MERGED" ]; then
+                    git -C "$REPO" push -q origin HEAD:main
+                fi ;;
+  "pr view")    echo "\${STUB_PR_STATE:-MERGED}" ;;
 esac
 exit 0
 STUB
@@ -48,18 +68,105 @@ STUB
     export ROMP_GH="$TEST_DIR/gh"
 }
 
-@test "release: refuses a tag that is not v-prefixed" {
+# ── the source-of-truth contract ──────────────────────────────────────
+
+@test "release: with no argument it releases whatever VERSION says" {
     _stub_gh
-    run "$REPO/scripts/release.sh" 0.1.0
+    run "$REPO/scripts/release.sh" --skip-tests
+    [ "$status" -eq 0 ]
+    run git -C "$REPO" tag -l
+    [ "$output" = "v0.1.0" ]
+}
+
+@test "release: refuses a v-prefixed argument and names the version to pass instead" {
+    # the tag is derived, so accepting one would re-open the mismatch this design closed
+    _stub_gh
+    run "$REPO/scripts/release.sh" v0.1.0
     [ "$status" -ne 0 ]
-    [[ "$output" == *"must be v-prefixed"* ]]
-    # and it bailed BEFORE spending 16 minutes of macOS CI
+    [[ "$output" == *"WITHOUT the leading v"* ]]
+    [[ "$output" == *"'0.1.0'"* ]]
     [ ! -s "$GH_LOG" ]
 }
 
+@test "release: the derived tag is always v-prefixed" {
+    _stub_gh
+    echo "1.2.3" > "$REPO/VERSION"
+    git -C "$REPO" commit -qam ver
+    run "$REPO/scripts/release.sh" --skip-tests
+    [ "$status" -eq 0 ]
+    run git -C "$REPO" tag -l
+    [ "$output" = "v1.2.3" ]
+}
+
+@test "release: a bump level computes the next version and PRs it" {
+    _stub_gh
+    run "$REPO/scripts/release.sh" minor --skip-tests
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"0.1.0 → 0.2.0"* ]]
+    grep -q "pr create" "$GH_LOG"
+    grep -q "pr merge" "$GH_LOG"
+    run git -C "$REPO" tag -l
+    [ "$output" = "v0.2.0" ]
+}
+
+@test "release: patch and major bump the right component" {
+    _stub_gh
+    echo "1.4.7" > "$REPO/VERSION"
+    git -C "$REPO" commit -qam ver
+    run "$REPO/scripts/release.sh" patch --skip-tests --dry-run
+    [[ "$output" == *"1.4.7 → 1.4.8"* ]]
+    run "$REPO/scripts/release.sh" major --skip-tests --dry-run
+    [[ "$output" == *"1.4.7 → 2.0.0"* ]]
+}
+
+@test "release: an explicit number is taken as the target" {
+    _stub_gh
+    run "$REPO/scripts/release.sh" 3.0.0 --skip-tests --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"releasing v3.0.0"* ]]
+}
+
+@test "release: refuses a target that is not semver" {
+    _stub_gh
+    run "$REPO/scripts/release.sh" not-a-version --skip-tests
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"is not semver"* ]]
+}
+
+@test "release: VERSION already at the target needs no bump PR" {
+    # the resumable case: a bump PR landed earlier, so only the tagging half remains
+    _stub_gh
+    run "$REPO/scripts/release.sh" 0.1.0 --skip-tests
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no bump PR needed"* ]]
+    ! grep -q "pr create" "$GH_LOG"
+    run git -C "$REPO" tag -l
+    [ "$output" = "v0.1.0" ]
+}
+
+@test "release: a version PR that never merges does NOT tag" {
+    _stub_gh
+    STUB_PR_STATE=OPEN run "$REPO/scripts/release.sh" minor --skip-tests
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"did not merge"* ]]
+    run git -C "$REPO" tag -l
+    [ -z "$output" ]
+}
+
+@test "release: a version PR closed unmerged does NOT tag" {
+    _stub_gh
+    STUB_PR_STATE=CLOSED run "$REPO/scripts/release.sh" minor --skip-tests
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"closed without merging"* ]]
+    run git -C "$REPO" tag -l
+    [ -z "$output" ]
+}
+
+# ── the macOS gate ────────────────────────────────────────────────────
+
 @test "release: refuses when the macOS run fails, and does NOT tag" {
     _stub_gh
-    STUB_CONCLUSION=failure run "$REPO/scripts/release.sh" v0.1.0
+    STUB_CONCLUSION=failure run "$REPO/scripts/release.sh" --skip-tests
     [ "$status" -ne 0 ]
     [[ "$output" == *"macOS run did not pass"* ]]
     run git -C "$REPO" tag -l
@@ -67,10 +174,10 @@ STUB
 }
 
 @test "release: a transient API error while watching does not fail the gate" {
-    # `gh run watch` treated a dropped connection as a failed RUN and refused a
-    # green release twice (2026-07-27); the poll must ride out empty answers.
+    # `gh run watch` treated a dropped connection as a failed RUN and refused a green
+    # release twice (2026-07-27); the poll must ride out empty answers.
     _stub_gh
-    ROMP_RELEASE_POLL=0.01 STUB_FLAKY_VIEWS=3 run "$REPO/scripts/release.sh" v0.1.0
+    ROMP_RELEASE_POLL=0.01 STUB_FLAKY_VIEWS=3 run "$REPO/scripts/release.sh" --skip-tests
     [ "$status" -eq 0 ]
     [[ "$output" == *"macOS run green"* ]]
     run git -C "$REPO" tag -l
@@ -79,7 +186,7 @@ STUB
 
 @test "release: tags when the macOS run is green" {
     _stub_gh
-    run "$REPO/scripts/release.sh" v0.1.0
+    run "$REPO/scripts/release.sh" --skip-tests
     [ "$status" -eq 0 ]
     [[ "$output" == *"macOS run green"* ]]
     run git -C "$REPO" tag -l
@@ -89,26 +196,41 @@ STUB
 
 @test "release: --skip-macos tags without CI, but says so loudly" {
     _stub_gh
-    run "$REPO/scripts/release.sh" v0.1.0 --skip-macos
+    run "$REPO/scripts/release.sh" --skip-macos --skip-tests
     [ "$status" -eq 0 ]
     [[ "$output" == *"SKIPPING the macOS check"* ]]
-    [ ! -s "$GH_LOG" ]                        # no CI was dispatched
+    ! grep -q "workflow run CI" "$GH_LOG"     # no CI was dispatched
     run git -C "$REPO" tag -l
     [ "$output" = "v0.1.0" ]
 }
 
-@test "release: refuses when VERSION disagrees with the tag" {
+# ── publishing ────────────────────────────────────────────────────────
+
+@test "release: pushes the tag and publishes the release" {
     _stub_gh
-    run "$REPO/scripts/release.sh" v9.9.9
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"VERSION says"* ]]
+    run "$REPO/scripts/release.sh" --skip-tests
+    [ "$status" -eq 0 ]
+    grep -q "release create v0.1.0" "$GH_LOG"
+    # the tag really reached the remote — a local-only tag installs for nobody
+    run git -C "$TEST_DIR/origin.git" tag -l
+    [ "$output" = "v0.1.0" ]
 }
+
+@test "release: notes start at the PREVIOUS tag, never at the one being cut" {
+    _stub_gh
+    git -C "$REPO" tag v0.0.9
+    run "$REPO/scripts/release.sh" --skip-tests
+    [ "$status" -eq 0 ]
+    grep -q -- "--notes-start-tag v0.0.9" "$GH_LOG"
+}
+
+# ── the ordinary guards ───────────────────────────────────────────────
 
 @test "release: refuses a dirty tree" {
     _stub_gh
     echo dirty > "$REPO/junk.txt"
     git -C "$REPO" add junk.txt
-    run "$REPO/scripts/release.sh" v0.1.0
+    run "$REPO/scripts/release.sh" --skip-tests
     [ "$status" -ne 0 ]
     [[ "$output" == *"dirty"* ]]
 }
@@ -116,17 +238,67 @@ STUB
 @test "release: refuses a tag that already exists" {
     _stub_gh
     git -C "$REPO" tag v0.1.0
-    run "$REPO/scripts/release.sh" v0.1.0
+    run "$REPO/scripts/release.sh" --skip-tests
     [ "$status" -ne 0 ]
     [[ "$output" == *"already exists"* ]]
+    [ ! -s "$GH_LOG" ]                        # bailed before spending any CI
 }
 
-@test "release: the v-prefix guard accepts a prerelease tag" {
+@test "release: refuses when VERSION is missing" {
+    _stub_gh
+    rm "$REPO/VERSION"
+    git -C "$REPO" commit -qam rmver
+    run "$REPO/scripts/release.sh" --skip-tests
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"source of truth"* ]]
+}
+
+@test "release: refuses a VERSION that is not X.Y.Z" {
+    _stub_gh
+    echo "nightly" > "$REPO/VERSION"
+    git -C "$REPO" commit -qam ver
+    run "$REPO/scripts/release.sh" --skip-tests
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"is not X.Y.Z"* ]]
+}
+
+@test "release: a prerelease version tags as-is" {
     _stub_gh
     echo "0.2.0-rc.1" > "$REPO/VERSION"
     git -C "$REPO" commit -qam ver
-    run "$REPO/scripts/release.sh" v0.2.0-rc.1
+    run "$REPO/scripts/release.sh" --skip-tests
     [ "$status" -eq 0 ]
     run git -C "$REPO" tag -l
     [ "$output" = "v0.2.0-rc.1" ]
+}
+
+@test "release: a prerelease bumps from its release number" {
+    _stub_gh
+    echo "0.2.0-rc.1" > "$REPO/VERSION"
+    git -C "$REPO" commit -qam ver
+    run "$REPO/scripts/release.sh" minor --skip-tests --dry-run
+    [[ "$output" == *"0.2.0-rc.1 → 0.3.0"* ]]
+}
+
+@test "release: --dry-run changes nothing at all" {
+    _stub_gh
+    run "$REPO/scripts/release.sh" minor --skip-tests --dry-run
+    [ "$status" -eq 0 ]
+    run git -C "$REPO" tag -l
+    [ -z "$output" ]
+    run cat "$REPO/VERSION"
+    [ "$output" = "0.1.0" ]
+}
+
+@test "release: a failing suite stops the release before any tag" {
+    _stub_gh
+    # a fixture 'suite' that fails collection, so the gate is exercised for real
+    mkdir -p "$REPO/tests"
+    echo "raise SystemExit(1)" > "$REPO/tests/conftest.py"
+    git -C "$REPO" add -A && git -C "$REPO" commit -qm suite
+    run "$REPO/scripts/release.sh"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Python suite failed"* ]]
+    run git -C "$REPO" tag -l
+    [ -z "$output" ]
 }


### PR DESCRIPTION
## The problem

Releasing was a chain of by-hand steps — bump `VERSION` on a branch, PR it, merge it, sync main, run `release.sh vX.Y.Z`, push the tag, write the GitHub release. **Two of those steps each carried the version number**, so they could disagree; the script's answer was to compare them and refuse. That's a check standing in for a design.

It also left a genuinely bad half-finished state available: `VERSION` merged but untagged, where `main` claims a version `bootstrap.sh` will not install (bootstrap picks the newest `v*` **tag**). We were sitting in exactly that state when this was written.

## The design

**`VERSION` is the single source of truth. The tag is derived from it** as `v$(cat VERSION)`.

The script no longer accepts a tag argument at all — that's what actually removes the mismatch, rather than checking for it. One place a human types the number; everything downstream is computed. A v-prefixed argument now fails with the version to pass instead:

```
release: pass the version WITHOUT the leading v ('0.2.0', not 'v0.2.0').
  The tag is derived from VERSION, so the two cannot disagree.
```

## One command

```bash
scripts/release.sh              # release whatever VERSION says
scripts/release.sh minor        # bump VERSION first, via a PR
scripts/release.sh 1.2.3        # set it explicitly, via a PR
```

Then: bump via PR if needed → wait for that PR to land → run the suites → hold the macOS gate → tag → push → publish the release.

Safety properties, all tested:
- a bump whose PR never merges (or is closed) **never reaches the tag**;
- a failing suite stops before the tag;
- the macOS gate is unchanged, including the 2026-07-27 fix that rides out transient API errors instead of reading them as failure;
- **resumable** — when `VERSION` already carries the target the bump phase is skipped, so re-running after a partial release picks up where it stopped;
- `--dry-run` changes nothing;
- release notes start at the *previous* tag, computed before the new one exists so it can never pick itself.

## Tests

`tests/release-sh.bats` goes 8 → 24 cases. The `gh` stub now performs a real merge into the fixture's `origin/main` when auto-merge is armed, so the bump path is exercised end to end rather than simulated as a no-op — the fixture repo genuinely fast-forwards and `VERSION` genuinely changes. All 24 green; the fixture avoids `git init -b` for portability to older git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)