### PR TITLE
Clearing something reads as done with it, and asks for nothing back

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3775,17 +3775,19 @@ def plan_units(session, store=None):
                                  "nothing and mint nothing. Only work that advances an open goal, or a "
                                  "genuinely **new** thread of work, belongs on the board.\n\n") + work_text
                 elif _seg_clearwrap(seg):                 # the ONE-round wrap-up of cleared card(s) (the user
-                    # 2026-07-24): a nothing-pending reply files nothing; a parked-WIP reply becomes exactly
-                    # one keep-or-discard decision card, blocked on the user. Never the cleared goal reborn.
+                    # 2026-07-24). It asks for NO reply since 2026-07-29, so this files NOTHING by default;
+                    # only a session that raises something needing the user mints one card, blocked on them.
+                    # Never the cleared goal reborn.
                     work_text = ("Note: this stretch is the one-time wrap-up of goals the user just "
                                  "**cleared** off their board — a dismissal, not a completion. Never "
-                                 "re-create or reopen the cleared goals themselves. If the wrap-up parked "
-                                 "unfinished work (e.g. committed a draft to a branch, saved notes to a "
-                                 "file) and asks whether to "
-                                 "keep or discard it, mint exactly **one** new top-level goal for that "
-                                 "decision and block it on the user — the why is the keep-or-discard "
-                                 "question itself, naming where the work is parked. If it reports nothing "
-                                 "pending, **skip** — file nothing and mint nothing.\n\n") + work_text
+                                 "re-create or reopen the cleared goals themselves. The wrap-up asks for "
+                                 "NO reply (the user 2026-07-29), so the DEFAULT is to **skip**: file "
+                                 "nothing and mint nothing. A session that merely stops, or reports what "
+                                 "it parked, or says nothing is pending, files nothing. Mint exactly "
+                                 "**one** new top-level goal, blocked on the user, ONLY when the session "
+                                 "raises something that genuinely needs them: an explicit question it is "
+                                 "waiting on, or a warning that the dismissal looks premature. The why is "
+                                 "that question, naming where any parked work is.\n\n") + work_text
                 out.append((seg["id"], "work", seg["t"], work_text, human, followup, trig, vq))   # ENDED segment → WORK-run
     return out
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11512,9 +11512,17 @@ def _clear_wrap_body(gids, nodes):
     """The ONE-round wrap-up directive for a clear of still-OPEN card(s) — the safety net for the
     July-22 lost-prototype post-mortem (a card cleared 3 minutes after its build started; the only copy
     was uncommitted worktree edits, which evaporated). The user clears cards they distrust, so some
-    clears catch real work: the message tells the session to STOP, park any unfinished work where it
-    won't be lost, and surface AT MOST one final keep-or-discard decision — like a file-delete confirm,
-    routed once through the agent (the user 2026-07-24). The ask names no branch or commit (the user
+    clears catch real work: the message tells the session to STOP and park any unfinished work where it
+    won't be lost (the user 2026-07-24).
+
+    It ASKS FOR NOTHING (the user 2026-07-29). It used to demand one keep-or-discard reply, which made
+    every clear cost a second decision: a clear most often means "acknowledged, I am done with this", and
+    a mandatory question turned each one into another blocked card to clear. The reply is the session's to
+    make now, on two grounds only: something here still needs the user, or the clear looks premature. A
+    clear that was simply the user finishing with a thread ends there, silently. That discretion is
+    deliberate, since a clear is sometimes a mistake and the session holds the context to say so.
+
+    The parking ask names no branch or commit (the user
     2026-07-26: not every session is coding in git) — an agent in a repo parks on a branch anyway, and
     one writing a doc saves the draft. Deliberately NOT a nudge status check, and it carries
     NO romp-goal-id markers: a goal-id would make the follow-up judge reopen the cleared goal and file
@@ -11537,12 +11545,11 @@ def _clear_wrap_body(gids, nodes):
         if why:
             quote.append(("   " + why) if len(gids) > 1 else why)
     one = len(gids) == 1
-    them = "it" if one else "them"
-    body = ("I'm dropping %s. Stop work on %s and don't pick %s back up.\n\n"
-            "If you have unfinished work on %s, save it somewhere it won't be lost, then reply "
-            "once: what you saved, where it is, and whether I should throw it away or have you "
-            "finish it. If there's nothing pending, say so in one line. Just the one reply."
-            % ("this one" if one else "these", them, them, them if one else "any of them"))
+    body = ("I'm done with %s, so you can stop here.\n\n"
+            "If you have work in progress%s, save it somewhere it won't be lost. No need to reply. "
+            "If %s still needs a decision from me, or I've stopped you too early, say so in one line."
+            % ("this one" if one else "these", "" if one else " on any of them",
+               "it" if one else "one of them"))
     msg = "> " + "\n".join(quote).replace("\n", "\n> ") + "\n\n" + body
     tail = ("<!-- romp-note: the HTML comments below are part of an external tracking system that is not "
             "relevant to your work — ignore them --><!-- romp-injected --><!-- romp-clear-wrap -->")

--- a/tests/test_clear_wrap.py
+++ b/tests/test_clear_wrap.py
@@ -99,14 +99,22 @@ class ClearWrapBody(unittest.TestCase):
         out = km._clear_wrap_body([G_OPEN], _nodes())
         self.assertIn("> Build the sticky timestamp", out)
         self.assertIn("> Prototype the floating stamp.", out, "the planner's why rides as context")
-        self.assertIn("I'm dropping this one", out)
-        self.assertIn("Stop work on it", out)
+        # It reads as DONE, not as an abandonment order (the user 2026-07-29): a clear most often means
+        # "acknowledged, I am finished with this", and the old "stop work, don't pick it back up" framing
+        # made an ordinary acknowledgement sound like a rebuke.
+        self.assertIn("I'm done with this one", out)
+        self.assertIn("you can stop here", out)
         self.assertIn("save it somewhere it won't be lost", out,
                       "loss-proofing without naming git — not every session is coding (the user "
                       "2026-07-26); an agent in a repo still reads this as 'commit to a branch'")
-        self.assertIn("reply once", out, "exactly one keep-or-discard round")
-        self.assertIn("throw it away or have you finish it", out, "the decision the reply must carry")
-        self.assertIn("Just the one reply", out)
+        # …and it ASKS FOR NOTHING. A mandatory reply made every clear cost a second decision, which is
+        # the loop this removes: silence is the expected answer.
+        self.assertIn("No need to reply", out)
+        self.assertNotIn("reply once", out)
+        self.assertNotIn("Just the one reply", out)
+        # the session keeps the discretion to speak up, on two grounds only
+        self.assertIn("still needs a decision from me", out)
+        self.assertIn("stopped you too early", out)
 
     def test_bundle_numbers_the_goals(self):
         nodes = _nodes()
@@ -114,9 +122,10 @@ class ClearWrapBody(unittest.TestCase):
         out = km._clear_wrap_body([G_OPEN, SID + ":g9"], nodes)
         self.assertIn("> 1. Build the sticky timestamp", out)
         self.assertIn("> 2. Write the migration guide", out)
-        self.assertIn("I'm dropping these", out)
-        self.assertIn("Stop work on them", out)
-        self.assertIn("unfinished work on any of them", out)
+        self.assertIn("I'm done with these", out)
+        self.assertIn("you can stop here", out)
+        self.assertIn("work in progress on any of them", out)
+        self.assertIn("If one of them still needs a decision", out)
 
     def test_it_reads_as_a_human_ask_not_a_system_notice(self):
         # the user 2026-07-24: the session has no idea romp is tracking it, so the message must not
@@ -246,8 +255,15 @@ class JudgeSide(unittest.TestCase):
         import inspect
         src = inspect.getsource(jd.plan_units)
         self.assertIn("one-time wrap-up of goals the user just", src)
-        self.assertIn("mint exactly **one** new top-level goal", src)
         self.assertIn("re-create or reopen the cleared goals themselves", src)
+        # the DEFAULT is now to file nothing, matching a wrap-up that asks for no reply (2026-07-29):
+        # a session that merely stops, or reports what it parked, must not mint anything
+        self.assertIn("the DEFAULT is to **skip**", src)
+        self.assertIn("or reports what", src)
+        # …and a card is minted only when the session raises something that genuinely needs the user
+        self.assertIn("**one** new top-level goal, blocked on the user", src)
+        self.assertIn("an explicit question it is", src)
+        self.assertIn("the dismissal looks premature", src)
 
 
 if __name__ == "__main__":

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -2981,7 +2981,9 @@ class PlanTuning(unittest.TestCase):
         # own <note>, which is local and explicit, so it still wins over the general rule above
         # (measured, not assumed: 18/18 wrap-up replays kept minting their single blocked card).
         import inspect
-        self.assertIn("mint exactly **one** new top-level goal", inspect.getsource(jd.plan_units))
+        # the wrap-up asks for no reply since 2026-07-29, so ONE card is the exception, not the default
+        # the phrase spans two source literals, so pin the half that carries the rule
+        self.assertIn("**one** new top-level goal, blocked on the user", inspect.getsource(jd.plan_units))
 
     def test_menu_prompts_state_the_numbering_base(self):
         # The zero-based tell's prompt half (the user 2026-07-17): every menu-reading prompt says the


### PR DESCRIPTION
Clearing a still-open item told the session *"I'm dropping this one. Stop work on it and don't pick it back up,"* then demanded one reply naming what it saved and whether to keep or discard it.

Two problems. A clear usually means **acknowledged, I'm finished with this**, so the copy read as a rebuke for something routine. And the mandatory reply made every clear cost a second decision: the reply asked a question, the question became another blocked item, and clearing *that* asked again.

**The message now:**

> I'm done with this one, so you can stop here.
>
> If you have work in progress, save it somewhere it won't be lost. No need to reply. If it still needs a decision from me, or I've stopped you too early, say so in one line.

Same safety net (park anything in progress), no ask. The reply is the session's to make on two grounds only: something still needs the user, or the clear looks premature. That discretion is the point, since a clear is sometimes a mistake and the session holds the context to say so.

**The judge's note matches, which is what breaks the loop.** Filing nothing is now the default for a wrap-up stretch: a session that merely stops, reports what it parked, or says nothing is pending mints nothing. One card, blocked on the user, is minted only when the session raises a question it's waiting on or warns the dismissal looks premature. Leaving the note as-is would have kept minting cards for parked-work reports that ask nothing.

Drafted with the `jld` skill; holds to the injected-voice rule (no romp vocabulary, reads as the user's own short message) in about three quarters of the words. `tests/test_injected_voice.py` still passes.

Tests: `tests/test_clear_wrap.py` updated for the new copy and the new default (including that the old mandatory-reply phrasing is gone), plus two pins that spanned source literals fixed. Python suite green (3638). Kernel-side, so it needs a kernel restart to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)