### PR TITLE
The bottom-bar panel is the Log, and transient stalls no longer flood it

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15952,7 +15952,8 @@ window.addEventListener('message',function(e){if(e&&e.data&&e.data.romp==='ready
 setTimeout(hide,5000);})();
 """
 
-# The shell's NOTIFICATION CENTER (the user 2026-07-27): errors used to drop as fixed banners from the top
+# The shell's LOG (the user 2026-07-27; named "Log" 2026-07-29 — "Errors" was a misnomer once quiet
+# informational kinds joined the error-ish ones): errors used to drop as fixed banners from the top
 # of the screen ("Disconnected — reconnecting…", usage-limit reached, judge degraded) and got in the way.
 # They now land as entries in a sequential feed behind a bell in the bottom bar's action cluster (next to
 # ↻ / network / gear): the bell goes red when something arrives (no count badge — it clipped and the
@@ -16047,7 +16048,7 @@ var f=document.getElementById('f-feed');
 try{f&&f.contentWindow&&f.contentWindow.postMessage({romp:'revealCard',itemId:n.tgt.itemId||'',sid:n.tgt.sid||''},'*');}catch(e){}});}
 row.appendChild(tx);row.appendChild(tm);row.appendChild(del);list.appendChild(row);})(NOTES[i],i);
 if(!shown){var e=document.createElement('div');e.className='rerr-empty';
-e.textContent=NOTES.length?'Nothing to show \\u2014 hidden by the filters above':'No errors';list.appendChild(e);}}
+e.textContent=NOTES.length?'Nothing to show \\u2014 hidden by the filters above':'Nothing logged';list.appendChild(e);}}
 // One write path. A repeat of the NEWEST entry (same kind+text — e.g. a reconnect loop dropping over and
 // over) coalesces into it with a count instead of flooding the feed: event-exact, no time window.
 window.__rompNotify=function(kind,text,tgt){if(!text)return;
@@ -17402,7 +17403,7 @@ def _landing():
             # Reload button (the user 2026-07-27: redundant next to the rail's own restart/refresh —
             # and a dead page is one browser-refresh away regardless).
             "<div id=rerr-back hidden><div id=rerr-panel>"
-            "<div class=rerr-top>Errors<span class=sp></span>"
+            "<div class=rerr-top>Log<span class=sp></span>"
             "<button id=rerr-clear title='Clear all entries'>Clear all</button>"
             "<button id=rerr-x aria-label=Close>×</button></div>"
             "<div id=rerr-filters><span class=rerr-flabel>show</span><div id=rerr-fgrid></div></div>"
@@ -17437,10 +17438,10 @@ def _landing():
             "</div>"   # /.rail-scroll
             # refresh + network + settings, pinned to the far RIGHT (settings last), always visible:
             "<div class=rail-acts>"
-            # the error center's warning triangle (a bell until 2026-07-28 — the bell now means the
+            # the log's warning triangle (a bell until 2026-07-28 — the bell now means the
             # notification toggles): monochrome outline like its neighbors; goes red with the unread
-            # count drawn INSIDE the triangle when an error lands (see _ERRS_SVG + _LANDING_ERRS_JS).
-            "<div class=rail-act id=rail-errs title='Errors — click to open' aria-label=Errors>"
+            # count drawn INSIDE the triangle when an entry lands (see _ERRS_SVG + _LANDING_ERRS_JS).
+            "<div class=rail-act id=rail-errs title='Log — click to open' aria-label=Log>"
             + _ERRS_SVG +
             "</div>"
             # the refresh glyph is a REAL browser-style reload icon now (the user 2026-07-27: the ↻ text
@@ -17495,8 +17496,8 @@ def _landing():
             # restart the kernel (the user 2026-07-22): the rail's ↻ is hidden on mobile, so mirror it here.
             # Same glyph as the rail; wired to window.__rompRestart (POST /restart, poll /healthz, reload).
             "<button class=mact data-act=restart aria-label='Restart kernel' title='Restart kernel'>" + _REFRESH_SVG + "</button>"
-            # the error triangle on mobile too (same glyph + in-body count; opens the same popover)
-            "<button class=mact id=merr data-act=errs aria-label=Errors title='Errors — click to open'>"
+            # the log triangle on mobile too (same glyph + in-body count; opens the same popover)
+            "<button class=mact id=merr data-act=errs aria-label=Log title='Log — click to open'>"
             + _ERRS_SVG +
             "</button>"
             # settings wears the desktop rail's OWN gear glyph, ⛭ (U+26ED), not the outlined star it had.

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -206,7 +206,7 @@ class ErrorCenterExecutes(unittest.TestCase):
         self.assertEqual(self.out["afterRowClear"]["rows"], 1)
         self.assertEqual(self.out["afterClearAll"]["n"], 0)
         self.assertEqual(self.out["afterClearAll"]["rows"], 1)
-        self.assertEqual(self.out["afterClearAll"]["empty"], "No errors")
+        self.assertEqual(self.out["afterClearAll"]["empty"], "Nothing logged")
 
     def test_reconnect_clears_the_live_cue(self):
         self.assertFalse(self.out["afterReconnect"]["red"])
@@ -275,7 +275,12 @@ class ErrorCenterWiring(unittest.TestCase):
         self.assertIn("M8 2.2 L14.6 13.4 L1.4 13.4 Z", html)
         self.assertIn("n<=0?'!'", html)
         self.assertNotIn("M8 2 C5.8 2 4.5 3.7", html, "the old bell path left the shell entirely")
-        self.assertIn("title='Errors — click to open'", html)   # the glyph says what it is
+        # "Log", not "Errors" (the user 2026-07-29): quiet informational kinds live here too, so the
+        # old name oversold every entry as a problem. BOTH glyphs (rail + mobile) say what it is.
+        self.assertIn("title='Log — click to open'", html)
+        self.assertEqual(html.count("title='Log — click to open'"), 2)
+        self.assertIn("<div class=rerr-top>Log<span class=sp></span>", html)
+        self.assertNotIn("aria-label=Errors", html)
         # the panel speaks the shared modal vocabulary (network panel / settings card), never the
         # undefined --vscode-font-family shorthand that rendered oversized in the browser shell
         self.assertIn("font:13px/1.6 system-ui,-apple-system,'Segoe UI',sans-serif}#rerr-panel .rerr-top", html)

--- a/ui/webview/badge-mirror.test.ts
+++ b/ui/webview/badge-mirror.test.ts
@@ -15,23 +15,31 @@ const base = (over: Partial<BadgeItem>): BadgeItem =>
 test("every trouble chip becomes one entry, in the session's name", () => {
   const items = [base({
     warns: [{ kind: "distill", t: 100, msg: "the summarizer gave up" }],
-    stalled: { why: "reviver not retiring", since: 200, note: "romp is holding this" },
     nudgeFailed: true,
     retrying: { since: 300 },
     blocked: { state: "apiError", status: 529 },
   })];
   const { notices } = badgeNotices(items, new Set());
-  assert.deepEqual(notices.map((n) => n.kind), ["warn", "stalled", "nudge", "retry", "apierror"]);
+  assert.deepEqual(notices.map((n) => n.kind), ["warn", "nudge", "retry", "apierror"]);
   assert.ok(notices.every((n) => n.text.startsWith("api — ")), "each entry names the session");
   // every notice carries its jump target so the bell entry can lead back to the card (2026-07-28)
   assert.ok(notices.every((n) => n.sid === "TESTSID" && n.itemId === "TESTSID:g1"));
   assert.match(notices[0].text, /warning: the summarizer gave up/);
-  assert.match(notices[1].text, /stalled: romp is holding this/, "the staller's note beats the mechanical why");
-  assert.match(notices[4].text, /API error 529/);
+  assert.match(notices[3].text, /API error 529/);
+});
+
+test("a stalled hold mints NO log entry — the card chip is its only surface", () => {
+  // The user 2026-07-29: the log filled with "stalled" rows for holds that resolved in seconds
+  // (the judge ruled, or the nudge fired and worked) — the mechanism doing its job, not a problem.
+  // A stall that defeats the nudge escalates to nudgeFailed, which does log.
+  const it = { ...base({}), stalled: { why: "reviver not retiring", since: 200, note: "romp is holding this" } };
+  const { notices, active } = badgeNotices([it], new Set());
+  assert.equal(notices.length, 0);
+  assert.equal(active.size, 0, "no sig either — nothing for the seen-set to hold");
 });
 
 test("a seen signature stays quiet; the SAME badge next push logs nothing", () => {
-  const items = [base({ stalled: { why: "w", since: 200 } })];
+  const items = [base({ warns: [{ kind: "distill", t: 200, msg: "w" }] })];
   const first = badgeNotices(items, new Set());
   assert.equal(first.notices.length, 1);
   const second = badgeNotices(items, new Set(first.active));
@@ -39,9 +47,9 @@ test("a seen signature stays quiet; the SAME badge next push logs nothing", () =
 });
 
 test("a NEW episode (different since/t) is a new entry; a cleared badge leaves the active set", () => {
-  const s1 = badgeNotices([base({ stalled: { why: "w", since: 200 } })], new Set());
-  const s2 = badgeNotices([base({ stalled: { why: "w", since: 999 } })], new Set(s1.active));
-  assert.equal(s2.notices.length, 1, "a fresh stall episode logs again");
+  const s1 = badgeNotices([base({ warns: [{ kind: "distill", t: 200, msg: "w" }] })], new Set());
+  const s2 = badgeNotices([base({ warns: [{ kind: "distill", t: 999, msg: "w" }] })], new Set(s1.active));
+  assert.equal(s2.notices.length, 1, "a fresh warn episode logs again");
   const gone = badgeNotices([base({})], new Set(s2.active));
   assert.equal(gone.active.size, 0, "no badge → no active sigs → the next occurrence re-logs");
 });

--- a/ui/webview/badge-mirror.ts
+++ b/ui/webview/badge-mirror.ts
@@ -1,8 +1,15 @@
 // Card trouble badges mirror into the shell's notification bell (the user 2026-07-27): anything that
-// shows as a problem chip on a card — a judge warning, a stalled hold, a failed follow-up, an
-// API-error block, a retry storm — ALSO logs one entry in the bell, so problems are findable in one
-// place after the fact. The chip on the card stays exactly as it was; the bell entry is the durable
-// copy of the moment it appeared.
+// shows as a problem chip on a card — a judge warning, a failed follow-up, an API-error block, a
+// retry storm — ALSO logs one entry in the bell, so problems are findable in one place after the
+// fact. The chip on the card stays exactly as it was; the bell entry is the durable copy of the
+// moment it appeared.
+//
+// DELIBERATELY NOT MIRRORED: the stalled hold. A stall is romp's nudge gate waiting out one of its
+// own revivers (a judge call mid-flight, a reply still being judged), and almost every episode ends
+// in seconds — the judge rules, or the auto-nudge fires and the session picks the work back up.
+// That is the machinery working, not a problem, and mirroring it filled the log with "stalled" rows
+// for holds nobody ever saw on a card (the user 2026-07-29). The chip on the card is the live
+// surface; a stall that actually defeats the nudge escalates to nudgeFailed, which logs below.
 //
 // Pure: the caller passes the previously-notified signature set and gets back fresh notices + the
 // now-active set. A signature keys the EPISODE (card + kind + the badge's own since/t), the same
@@ -14,7 +21,6 @@ import { apiErrorReason } from "./api-error-reason";
 
 export interface BadgeItem {
   itemId: string; sid: string; name: string; text: string;
-  stalled?: { why: string; since: number; note?: string | null } | null;
   nudgeFailed?: boolean;
   retrying?: { since?: number | null; count?: number; max?: number | null; status?: number | string | null; networkDown?: boolean | null; rateLimitType?: string | null } | null;
   warns?: { kind: string; t: number; msg: string }[] | null;
@@ -36,10 +42,6 @@ export function badgeNotices(items: BadgeItem[], seen: Set<string>): { notices: 
     };
     for (const w of it.warns ?? []) {
       add("w|" + it.itemId + "|" + w.t + "|" + w.kind, "warn", it.name + " — warning: " + cap(w.msg, 100));
-    }
-    if (it.stalled) {
-      add("s|" + it.itemId + "|" + it.stalled.since, "stalled",
-        it.name + " — stalled: " + cap(it.stalled.note || it.stalled.why, 100));
     }
     if (it.nudgeFailed) {
       add("n|" + it.itemId, "nudge", it.name + " — follow-up failed on “" + cap(it.text, 50) + "”");


### PR DESCRIPTION
## What

Two changes to the bottom-bar notification panel (the warning-triangle popover):

1. **Renamed Errors to Log** on every user-visible string: the panel header, the rail and mobile glyph tooltips and aria-labels, and the empty state ("Nothing logged"). Informational kinds (cleared, retrying) live here alongside real errors, so the old name oversold every entry as a problem. Internal ids and localStorage keys are unchanged.

2. **A transient stalled hold no longer mints a log row.** The nudge gate re-runs about twice a second and a hold calls itself stalled after two consecutive runs with the same reviver reason, so a card could wear "stalled" roughly one second into an ordinary judge pass and shed it seconds later when the judge ruled or the auto-nudge fired and worked. Every one of those blinks minted a durable log row (and a lingering deferral record could re-log the same hold on every judge pass, because a cleared badge leaves the mirror's seen-set). Live state on the maintainer's fleet: 560 goals ever nudged, 458 resolved after a single fire, 85 ever escalated - the holds are the machinery working, not a problem. The chip on the card remains the live surface; a stall that defeats the nudge still logs via the follow-up-failed kind, and stored stalled rows keep their label and filter.

## Tests

- `tests/test_error_center.py`: asserts the Log title on both glyphs, the header, the new empty state, and that no aria-label says Errors.
- `ui/webview/badge-mirror.test.ts`: a stalled hold mints no entry and no signature; episode-identity tests now ride the warn kind.
- Full suites green locally: pytest 3638 passed, node 1479 passed, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)