### PR TITLE
The new-session picker is a dialog over the dashboard, not the chat blown up

### DIFF
--- a/ui/webview/picker-host-list.test.ts
+++ b/ui/webview/picker-host-list.test.ts
@@ -70,3 +70,22 @@ test("a reachable host with no sessions says so, instead of looking like a faile
   assert.match(RENDER, /if \(!list\.children\.length && pickerListHost\)/);
   assert.match(RENDER, /no sessions on \$\{pickerListHost\} in the last 30 days/);
 });
+
+// ── the picker is a dialog over the dashboard, not the chat pane blown up (the user 2026-07-29) ──────
+// The shell lifts this iframe full-window so the session list gets the whole height, but the iframe is
+// opaque, so the picker read as the chat expanded to fill the screen. While lifted the page steps aside
+// and only the picker draws, leaving the timeline, feed and chat visible behind it.
+test("the page steps aside while the shell has it lifted", () => {
+  const STYLES = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+  assert.match(RENDER, /document\.body\.classList\.toggle\("picker-lifted", on\);/);
+  assert.match(RENDER, /window\.parent\.postMessage\(\{ romp: "picker", on \}, "\*"\);/, "the shell still lifts it");
+  assert.match(STYLES, /body\.picker-lifted \{ background: transparent !important; \}/);
+  assert.match(STYLES, /body\.picker-lifted > \* \{ visibility: hidden; \}/);
+  assert.match(STYLES, /body\.picker-lifted > #picker \{ visibility: visible; \}/);
+  // visibility, not display: nothing reflows, so the chat is exactly where it was when the picker closes
+  assert.doesNotMatch(STYLES, /body\.picker-lifted > \* \{ display: none/);
+  // …and it centres like a modal instead of hugging the top edge
+  assert.match(STYLES, /body\.picker-lifted > #picker \{ align-items: center;/);
+  // two thirds of the window: the list is what you came to read
+  assert.match(STYLES, /width: min\(66vw, 900px\); min-width: min\(560px, 96vw\);/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3790,7 +3790,17 @@ function cancelOpening() {
 // the picker is up, so the overlay fills the screen and the list gets the full viewport height. Standalone
 // (no parent) is a no-op.
 function signalPickerOverlay(on: boolean) {
-  try { if (window.parent && window.parent !== window) window.parent.postMessage({ romp: "picker", on }, "*"); } catch (e) { /* standalone: no shell to lift */ }
+  try {
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage({ romp: "picker", on }, "*");
+      // …and get out of the way while lifted (the user 2026-07-29). The shell lifts this iframe over the
+      // whole window, and the iframe is OPAQUE, so the picker read as the chat pane blown up to full
+      // screen rather than as a dialog over the dashboard. Dropping this page's background and hiding
+      // its own content leaves only the picker drawn, so the timeline, feed and chat stay visible
+      // (dimmed by the picker's own backdrop) behind a modal that floats over all of them.
+      document.body.classList.toggle("picker-lifted", on);
+    }
+  } catch (e) { /* standalone: no shell to lift */ }
 }
 
 // ── new-session directory: inline completer ────────────────────────────────────────────────────────

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1681,8 +1681,23 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
 .opening-dots span:nth-child(3) { animation-delay: 0.3s; }
 @keyframes opening-bounce { 0%, 80%, 100% { opacity: 0.3; transform: translateY(0); } 40% { opacity: 1; transform: translateY(-5px); } }
 
+/* LIFTED over the dashboard (the user 2026-07-29): while the shell has this iframe full-window, the page
+   itself steps aside — no background, and its own content hidden — so what remains on screen is the
+   picker alone, floating over the panes behind it. Without this the opaque chat page covered the
+   timeline and feed, which is why the picker read as the chat expanded to full screen instead of as a
+   dialog. `visibility` (not display) so nothing reflows: layout is untouched, and the chat is exactly
+   where it was when the picker closes. */
+body.picker-lifted { background: transparent !important; }
+body.picker-lifted > * { visibility: hidden; }
+body.picker-lifted > #picker { visibility: visible; }
+/* centred, like every other modal. Top-aligned made sense when this filled the screen and the list
+   wanted every pixel of height; as a dialog over the dashboard it should sit in the middle. */
+body.picker-lifted > #picker { align-items: center; padding: 24px 16px; }
+
 .picker-box {
-  width: min(560px, 96%);
+  /* two thirds of the window, not a narrow column: it is a dialog over the whole dashboard now, and the
+     session list is the thing you came to read (the user 2026-07-29) */
+  width: min(66vw, 900px); min-width: min(560px, 96vw);
   /* The picker is lifted full-window while open (shell body.picker-open lifts #f-chat), so this vh now
      measures the FULL viewport, not the chat pane. Cap it to the viewport minus the overlay's top+bottom
      padding so the actions row is always on screen and .picker-list scrolls the rest (the user 2026-07-05,


### PR DESCRIPTION
Opening the picker looked like the chat expanding to fill the screen. The shell *does* lift the chat iframe full-window on purpose (so the session list gets the whole height to scroll), but the iframe is opaque, so the timeline and feed were covered by a chat page nobody wanted to look at.

While lifted, that page now steps aside: no background, its own content hidden, so the only thing drawn is the picker and the panes stay visible behind it under the picker's own backdrop. `visibility`, not `display`, so nothing reflows and the chat is exactly where it was when the picker closes.

The dialog also centres instead of hugging the top edge, and takes two thirds of the window rather than a 560px column. Top-aligned and narrow made sense while this *was* the whole screen.

No kernel change: the existing lift bridge is unchanged, so this is pane-side and a browser reload picks it up.

Tests: appended to `ui/webview/picker-host-list.test.ts`, including that it stays `visibility` (a `display:none` variant would reflow the chat). Both suites green (3638 python, 1479 node), tsc clean, verified with a headless render at 1200x700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)