### PR TITLE
A path verdict never outlives the host it was about

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18733,7 +18733,10 @@ class Handler(BaseHTTPRequestHandler):
             # path on a remote machine lists THAT machine's disk (the user 2026-07-28). reqId is echoed so
             # a slow answer that lands after a newer keystroke is dropped by the client, not rendered.
             _val = str(msg.get("value") or "")
-            _reply(client, dict({"type": "dirCompletions", "reqId": msg.get("reqId"),
+            # `host` rides back so the client can tell WHICH machine answered (the user 2026-07-29, whose
+            # field kept showing the previous host's verdict after switching). federation stamps a remote
+            # reply with its own host; a local kernel answers "" and matches the local selection.
+            _reply(client, dict({"type": "dirCompletions", "reqId": msg.get("reqId"), "host": "",
                                  "value": _val, "status": _dir_status(_val)},
                                 **_dir_completions(_val)))
         elif msg and msg.get("type") == "browseDir":

--- a/ui/webview/dir-complete.test.ts
+++ b/ui/webview/dir-complete.test.ts
@@ -8,7 +8,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { dirStatusLine, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 
-const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8")
+  + fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
 const STYLES = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 const st = (over: Partial<DirStatus>): DirStatus => ({
@@ -29,20 +30,20 @@ test("the untouched default says it is the default", () => {
 test("a missing folder warns and names where it would go", () => {
   const said = dirStatusLine(st({ exists: false, isDir: false, canCreate: true, missing: 2 }));
   assert.equal(said.cls, "warn");
-  assert.match(said.text, /not there yet/);
-  assert.match(said.text, /under ~\/GitRepos$/, "the offer says where, so it isn't a blind yes");
+  assert.match(said.text, /no such folder yet/);
+  assert.match(said.text, /Starting will create it$/, "it says what happens next, not just what is wrong");
 });
 
 test("a file where a folder was typed is an error, not an offer", () => {
   const said = dirStatusLine(st({ isDir: false, isFile: true, canCreate: false }));
   assert.equal(said.cls, "bad");
-  assert.match(said.text, /file, not a folder/);
+  assert.match(said.text, /not a folder: /);
 });
 
 test("an unreachable path says so rather than offering to create it", () => {
   const said = dirStatusLine(st({ exists: false, isDir: false, canCreate: false, nearest: "" }));
   assert.equal(said.cls, "bad");
-  assert.match(said.text, /can't be reached/);
+  assert.match(said.text, /invalid path: /);
 });
 
 test("no answer yet says nothing at all", () => {
@@ -68,13 +69,14 @@ test("the create dialog names the path and how much it would make", () => {
 });
 
 test("the field asks the kernel that would OWN the session, so a remote host completes its own disk", () => {
-  assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "dirComplete", value, reqId: \+\+dirReq, host: pickerHost\(\) \}\)/);
+  assert.match(RENDER, /dirAskedHost = pickerHost\(\);/);
+  assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "dirComplete", value, reqId: \+\+dirReq, host: dirAskedHost \}\)/);
   assert.match(RENDER, /#picker \.picker-host \.picker-be-opt\.sel/, "the host comes off the picker's own selection");
 });
 
 test("pacing is the round trip, not a timer: one request in flight, the newest value queued behind it", () => {
   assert.match(RENDER, /if \(dirInFlight\) \{ dirQueued = value; return; \}/);
-  assert.match(RENDER, /dirInFlight = false;\s*\n\s*const stale = m\.reqId !== dirReq;/);
+  assert.match(RENDER, /dirInFlight = false;\s*\n\s*const stale = m\.reqId !== dirReq \|\| \(typeof m\.host === "string" \? m\.host : ""\) !== pickerHost\(\);/);
   assert.match(RENDER, /if \(dirQueued !== null\) \{ const v = dirQueued; dirQueued = null; askDirComplete\(v\); \}/);
   assert.match(RENDER, /if \(stale\) return;/, "a reply for an older keystroke never renders");
   assert.doesNotMatch(RENDER.slice(RENDER.indexOf("function askDirComplete"), RENDER.indexOf("function dirMenuOpen")),
@@ -145,4 +147,14 @@ test("a remote's prefill is what you used THERE, never this machine's default", 
   assert.match(RENDER, /if \(di\) di\.value = dirPrefill\(""\);/, "the open prefill goes through it");
   assert.match(RENDER, /if \(dirIn\) \{ dirIn\.value = dirPrefill\(h\); askDirComplete\(dirIn\.value\); \}/,
     "switching host swaps the path AND re-vets it against that host");
+});
+
+test("a new question drops the old verdict, so no answer ever describes another host's disk", () => {
+  // the user 2026-07-29: switching host left the field insisting the path was fine. The verdict is about
+  // one machine and one path, so it stops standing the moment a different question goes out — and a host
+  // whose kernel is too old to answer leaves the line saying "checking", never a borrowed verdict.
+  assert.match(RENDER, /dirStatus = null;\s*\n\s*dirItems = \[\];\s*\n\s*renderDirMenu\(false\);/);
+  assert.match(RENDER, /checking on \$\{dirAskedHost\}…/);
+  assert.match(RENDER, /if \(out\.type === "dirCompletions"\) out\.host = host;/,
+    "federation stamps a remote answer with the machine that gave it");
 });

--- a/ui/webview/dir-complete.ts
+++ b/ui/webview/dir-complete.ts
@@ -15,11 +15,12 @@ export function dirStatusLine(s: DirStatus | null): { text: string; cls: string 
   if (s.isDefault) return { text: s.path + "  (the default)", cls: "" };
   if (s.isDir) return { text: "✓ " + s.path, cls: "" };
   // a file where a folder was typed can never become one — no create offer follows, so say so plainly
-  if (s.isFile) return { text: "that's a file, not a folder", cls: "bad" };
-  if (s.canCreate) {
-    return { text: "not there yet. Starting will offer to create it, under " + s.nearest, cls: "warn" };
-  }
-  return { text: "can't be reached: " + s.path, cls: "bad" };
+  if (s.isFile) return { text: "not a folder: " + s.path, cls: "bad" };
+  // Plain words for what is wrong (the user 2026-07-29: "still not there" read as waffle). A missing
+  // folder is not INVALID, though, since starting here creates it, so it says which of the two it is
+  // rather than collapsing both into one wrong label.
+  if (s.canCreate) return { text: "no such folder yet. Starting will create it", cls: "warn" };
+  return { text: "invalid path: " + s.path, cls: "bad" };
 }
 
 /** Walk the completion list. -1 ("nothing chosen") is part of the cycle in BOTH directions, so walking

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -66,6 +66,9 @@ export function prefixInbound(host: string, msg: any): any {
   // generic passes above leave them alone — and prefixing them is what makes a click route back: the row
   // posts openSession with the id, and routeOutbound sends it to the host in the prefix. Stamped with
   // the source host too, so the picker can drop a late reply for a host it is no longer showing.
+  // the path checker's answer, stamped with the machine that gave it: the picker drops a verdict that
+  // arrives for a host it is no longer on, instead of showing one machine's answer about another's disk.
+  if (out.type === "dirCompletions") out.host = host;
   if (out.type === "sessionList" && Array.isArray(out.items)) {
     out.items = out.items.map((it: any) => (it && typeof it === "object" && typeof it.id === "string"
       ? { ...it, id: prefixId(host, it.id),

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3810,6 +3810,7 @@ let dirQueued: string | null = null;  // typed while a request was out
 let dirItems: DirItem[] = [];
 let dirActive = -1;                   // highlighted completion row (-1 = none; Enter then creates)
 let dirStatus: DirStatus | null = null;
+let dirAskedHost = "";          // the host the in-flight question was about; a reply for any other is stale
 
 // The last directory a session was actually started in, per host (the user 2026-07-29). The gear's
 // "Default directory" is ONE path on THIS machine, so it is the wrong answer for a remote: prefilling a
@@ -3861,12 +3862,21 @@ function askDirComplete(value: string): void {
   if (!vscodeApi) return;
   if (dirInFlight) { dirQueued = value; return; }
   dirInFlight = true;
-  vscodeApi.postMessage({ type: "dirComplete", value, reqId: ++dirReq, host: pickerHost() });
+  dirAskedHost = pickerHost();
+  // The old verdict belongs to whatever was asked BEFORE this (the user 2026-07-29, who switched host and
+  // watched the field keep insisting the path was fine). It is about a different machine, or a different
+  // path, so it stops standing the instant a new question goes out: the line says it is checking, and a
+  // host whose kernel never answers (an older build with no such op) leaves it saying that rather than
+  // showing a verdict from somewhere else.
+  dirStatus = null;
+  dirItems = [];
+  renderDirMenu(false);
+  vscodeApi.postMessage({ type: "dirComplete", value, reqId: ++dirReq, host: dirAskedHost });
 }
 
 function onDirCompletions(m: any): void {
   dirInFlight = false;
-  const stale = m.reqId !== dirReq;
+  const stale = m.reqId !== dirReq || (typeof m.host === "string" ? m.host : "") !== pickerHost();
   if (dirQueued !== null) { const v = dirQueued; dirQueued = null; askDirComplete(v); }
   if (stale) return;                                   // a newer keystroke already owns the field
   dirItems = Array.isArray(m.items) ? m.items : [];
@@ -3890,7 +3900,8 @@ function closeDirMenu(): void {
 // deeper level, and it only exists while there is something to choose.
 function renderDirMenu(truncated: boolean): void {
   const line = document.getElementById("picker-dir-status");
-  const said = dirStatusLine(dirStatus);
+  const said = dirStatus || !dirInFlight ? dirStatusLine(dirStatus)
+    : { text: dirAskedHost ? `checking on ${dirAskedHost}…` : "checking…", cls: "" };
   if (line) {
     line.className = "picker-dir-status" + (said.cls ? " " + said.cls : "");
     line.textContent = said.text;


### PR DESCRIPTION
Switching host left the directory field still insisting the path was valid, answering about the machine you'd just switched away from.

The switch *did* re-ask (#122). What it didn't do was **retract** the old answer, so whatever was on screen stayed until a new one arrived. And if the selected host's kernel is too old to answer at all, the stale verdict stood forever, which is likely what you were seeing: your local kernel restarted into the new op, a remote may not have.

- A verdict is about one path on one machine, so it stops standing the moment a different question goes out. The line says `checking on <host>…` until that host answers.
- The reply carries the host that gave it (kernel echoes `""`, federation stamps a remote with its own), so an answer for a host you're no longer on is dropped rather than painted over the current one.
- A silent host leaves the line saying it's checking, rather than borrowing another machine's verdict.

**Wording**, per the same report:
- `not there yet. Starting will offer to create it, under X` → `no such folder yet. Starting will create it`
- a file in the way → `not a folder: <path>`
- unreachable → `invalid path: <path>`

A missing folder still reads differently from an invalid one: starting there creates it, so calling it invalid while offering to create it would contradict itself.

Tests: `ui/webview/dir-complete.test.ts` updated for the new copy and the host-tagged replies, plus a new case for the retract-on-new-question rule. Both suites green (3638 python, 1479 node), tsc clean. The kernel echo needs a restart; the retract and the wording are pane-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)