### PR TITLE
A prompt spliced into a running turn places its ask but never completes off that turn's work

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -485,6 +485,11 @@ class FileAdapter:
             "parentUuid": (self.by_uuid.get(auid) or {}).get("parentUuid"),
             "message": {"role": "user", "content": blocks},
             "author": author_of(blocks, None, postal_index, getattr(self, "sdk_human", False)),
+            "absorbed": True,   # a mid-turn splice: the turn's FOLLOWING atoms are the interrupted
+            #                     ask's continuing work, not provably a reply to this — judges must
+            #                     not read them as one (jd._seg_spliced / _strip_spliced_dones).
+            #                     Metadata only: the atom set and seg ids are unchanged (no
+            #                     PLACEMENTS_V bump).
             "_seq": seq,
         }
         if ROMP_AUTO_RE.search(full):   # an AUTO-nudge → flag it, mirroring the native user-record path

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1274,7 +1274,10 @@ PLAN_SYS = (
     "filing under one card never exempts the other cards the segment settled. "
     "An explanation or answer to a user's question "
     "counts as done: once you have fully answered, with nothing left for the user to act on, the goal "
-    "is done. But if the answer, plan, or scoping writeup ends by asking the user to approve or decide "
+    "is done. The answer must be IN the segment: a segment that shows a question with no assistant "
+    "reply to it (or only work on other matters) has NOT answered it — never supply the answer from "
+    "your own knowledge and file done; that goal simply stays open, however sure you are of the "
+    "answer. But if the answer, plan, or scoping writeup ends by asking the user to approve or decide "
     "a clear next step (\"want me to build this?\", \"which option?\", \"shall I proceed?\"), that is a "
     "block, not a done (see block): the go-ahead is still owed by the user. Being thorough is not the "
     "same as being finished. Set the \"why\" to a concise summary of the "
@@ -2291,6 +2294,40 @@ def _restrict_retitle(ops, allowed):
     it may retitle (see plan_llm). A defensive floor against the model retitling some OTHER listed goal;
     `allowed=None` drops every retitle (no eligible goal this call)."""
     return [o for o in ops if o["do"] != "retitle" or o.get("goal") == allowed]
+
+
+def _seg_spliced(seg):
+    """True when this segment's TRIGGER is an ABSORBED atom — a prompt the CLI spliced into a
+    RUNNING turn (a queued_command attachment; em._absorbed_atom marks the synthesized atom
+    `absorbed`). The atoms after such a trigger are the interrupted turn's CONTINUING work: by
+    wall-clock they follow the enqueue, but they answer the turn's ORIGINAL ask — deterministically
+    indistinguishable from a reply to the splice. So work in this segment is never proof that the
+    spliced ask, or any listed goal, was answered (see _strip_spliced_dones)."""
+    trig = (seg or {}).get("trigger")
+    if not trig:
+        return False
+    return any(a.get("uuid") == trig and a.get("absorbed") for a in seg.get("atoms") or [])
+
+
+def _strip_spliced_dones(ops, seg, fsid, seg_id):
+    """Drop planner DONE ops filed off a SPLICED-trigger segment (_seg_spliced). A capable planner,
+    handed 'USER ASKED: …' plus the interrupted turn's unrelated tail work, answers the question
+    from its OWN knowledge and files done with a confabulated summary — a queued question completed
+    as a card 30 seconds after it was typed, before the assistant's first post-splice token, off a
+    turn that then crashed without ever replying (the user 2026-07-29). Same failure family as the
+    API-error confabulation (the user 2026-07-25), but that guard keys on NO assistant work, and a
+    splice defeats it: the absorbed segment inherits the running turn's real atoms. Mint/sub/block
+    still apply — placing the ask and filing the tail work are right — and the goal stays OPEN,
+    which is the truth; the turn-level closer keeps done authority once the turn actually ends.
+    Logged (judge-errors, kind 'spliced-done'), never silent."""
+    if not ops or not _seg_spliced(seg):
+        return ops
+    kept = [o for o in ops if o.get("do") != "done"]
+    if len(kept) != len(ops):
+        _log_judge_error("planner", fsid, "spliced-done", seg=seg_id,
+                         note="dropped %d done op(s): a spliced-trigger segment cannot evidence an answer"
+                              % (len(ops) - len(kept)))
+    return kept
 
 
 def _depth(nodes, nid):
@@ -5108,6 +5145,9 @@ def _plan_session(fsid, path, now):
             hist = _goal_work_text(store, seg_by_id, target, GOAL_HISTORY_CHARS)
             ops = _parse_plan(plan_llm(text, _menu_text(store, sub), human=False,
                                        goal_history=hist, goal_num=1), len(sub)) or []
+            ops = _strip_spliced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # a peer message spliced
+            #                                           mid-turn can't evidence an answer any more than a
+            #                                           spliced human ask can — the fallback sub still files
             # Full expressivity, ROOTED under G: a delegation gets the same sub/done/block a human-minted top
             # does (over G's subtree), and a top-level MINT is re-rooted as a sub under G (#1) so a handoff is
             # never a competing top. Skips drop; an empty/skip-only reply falls back to one sub under G.
@@ -5194,6 +5234,9 @@ def _plan_session(fsid, path, now):
                 ops = [{"do": "sub", "under": 1, "text": o.get("text"), "why": o.get("why")}
                        if o["do"] == "mint" else o for o in ops if o["do"] != "skip"]
                 ops = _restrict_retitle(ops, 1)          # goal_num=1 above → retitle is only valid on #1
+                ops = _strip_spliced_dones(ops, _tseg, fsid, seg_id)   # a nudge spliced mid-turn reads the
+                #                                           interrupted turn's work as its reply — resolve
+                #                                           nothing; the goal stays open and re-nudgeable
                 apply_plan(store, seg_id, seg_t, ops, sub, place_key=_pkey, prompt_uuid=trig, quote=vq)
                 placed += 1
                 _group_store(store, fsid, now)
@@ -5227,6 +5270,10 @@ def _plan_session(fsid, path, now):
                                            goal_history=hist, goal_num=gi, followup=True,
                                            lifted_blocks=[(i, a) for i, (_n, a) in sorted(lifted_by_num.items())] or None),
                                   len(menu)) or []
+                ops = _strip_spliced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # a card reply spliced
+                #                                           mid-turn: strip BEFORE the pivot apply and before
+                #                                           the continuation lifts `res`, so a confabulated
+                #                                           done never re-completes the reopened target
                 if any(o["do"] == "mint" for o in ops):
                     # PIVOT: the model says this reply starts a new thread — honor its own placement. The
                     # cited goal is NOT reopened, and the pivot itself must drop its followupPending: this
@@ -5349,6 +5396,14 @@ def _plan_session(fsid, path, now):
             ops = _coerce_place(menu, text, title=_prompt_gist(fsid, seg_id) or None)   # HARD GUARD: a user
             #                                           message never silently vanishes
         store.get("parseFails", {}).pop(seg_id, None)  # placed → forget any earlier parse-fails on it
+        ops = _strip_spliced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # the incident path (the user
+        #                                           2026-07-29): a queued ask's work-run confabulated a done
+        if not ops:                                    # the reply was done-ONLY and stripped → same floor as a
+            if not human or p_target:                  #  skip: record processed, or hard-place the ask (a user
+                store["placements"][seg_id] = None     #  message never silently vanishes)
+                save_goals(fsid, store)
+                continue
+            ops = _coerce_place(menu, text, title=_prompt_gist(fsid, seg_id) or None)
         ops = _restrict_retitle(ops, pgi)              # only the segment's own prompt-run node is retitle-eligible
         ops = _card_route_subs(store, ops, menu)       # card-first: route subs to the card, then the placer
         apply_plan(store, seg_id, seg_t, ops, menu, prompt_uuid=trig, quote=vq,
@@ -6237,7 +6292,9 @@ CLOSER_SYS = (
     "built on it: when the turn delivers a finding and then ends by asking the user what to do about "
     "it (\"found the cause — want me to implement the fix?\"), the goal that owns that decision goes "
     "in block in the same reply (see blocked); doning the record and leaving its goal unmentioned "
-    "shows the whole card finished while the user still owes the answer.\n"
+    "shows the whole card finished while the user still owes the answer. The delivery must be in the "
+    "turn itself: a question the turn never answered is not done — never answer it yourself in the "
+    "why; that goal stays open, however sure you are of the answer.\n"
     "- blocked: it now needs the user, a decision, approval, or answer owed by the user (the human) "
     "before it can proceed. Waiting on a peer, CI, build, agents it dispatched, or other external thing "
     "is not blocked; that stays open and working. A turn that **ends** by handing the decision back to the "

--- a/tests/fixtures/event-model-golden/multi_input_absorbed.json
+++ b/tests/fixtures/event-model-golden/multi_input_absorbed.json
@@ -51,6 +51,7 @@
      "uuid": "a1"
     },
     {
+     "absorbed": true,
      "author": "human",
      "fsid": "11111111-2222-3333-4444-555555555555",
      "message": {

--- a/tests/fixtures/event-model-golden/popall.json
+++ b/tests/fixtures/event-model-golden/popall.json
@@ -51,6 +51,7 @@
      "uuid": "a1"
     },
     {
+     "absorbed": true,
      "author": "human",
      "fsid": "11111111-2222-3333-4444-555555555555",
      "message": {
@@ -69,6 +70,7 @@
      "uuid": "att1"
     },
     {
+     "absorbed": true,
      "author": "human",
      "fsid": "11111111-2222-3333-4444-555555555555",
      "message": {

--- a/tests/test_judge_followup_gist_title.py
+++ b/tests/test_judge_followup_gist_title.py
@@ -120,8 +120,8 @@ class SourcePins(unittest.TestCase):
     def test_every_coerce_place_call_passes_the_gist(self):
         calls = self.src.count("ops = _coerce_place(menu, text")
         gisted = self.src.count("ops = _coerce_place(menu, text, title=_prompt_gist(fsid, seg_id) or None)")
-        self.assertEqual(calls, 4, "a new floor site must decide its title source explicitly")
-        self.assertEqual(gisted, 4, "every floor site titles from the stored gist when one exists")
+        self.assertEqual(calls, 5, "a new floor site must decide its title source explicitly")
+        self.assertEqual(gisted, 5, "every floor site titles from the stored gist when one exists")
 
 
 if __name__ == "__main__":

--- a/tests/test_judge_spliced_done.py
+++ b/tests/test_judge_spliced_done.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""A prompt QUEUED into a running turn must never complete off that turn's unrelated work (the user 2026-07-29).
+
+The incident: the user queued a question while the session was mid-turn on other work; the CLI
+spliced it in (a queued_command attachment, stamped with its ENQUEUE time), and the process died
+before any reply. The splice's segment absorbed the running turn's CONTINUING atoms — real assistant
+work, none of it a reply to the spliced ask — so the no-work guard from the API-error fix
+(_has_asst_work, the user 2026-07-25) passed, plan_units emitted a full work unit framed
+"USER ASKED: … ASSISTANT SAID: [other work]", and a capable planner answered the question from its
+own knowledge and filed done with a confabulated summary — 30 seconds after the ask was typed,
+before the assistant's first post-splice token. Now the event model marks the synthesized splice
+atom `absorbed`, and planner DONE ops filed off a spliced-trigger segment are stripped
+(_strip_spliced_dones): work in such a segment is never proof the spliced ask — or any listed goal —
+was answered. Mint/sub still apply (the ask gets its card, the tail work files), the goal stays
+open — the truth — and the turn-level closer keeps done authority. SYNTHETIC fixtures only."""
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+import os
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+jd = SourceFileLoader("romp_judge_spliced_done", os.path.join(BIN, "romp-judge")).load_module()
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = NOW - 3600
+ASK = "Can the notes-api search endpoint run without a separate key, or does that need its own token?"
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, stop="end_turn"):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+def qline(t, text, uuid, parent):
+    """The CLI's mid-turn splice witness: a queued_command attachment, uuid-bearing, parent-chained,
+    stamped with the ENQUEUE time (earlier than its neighbours in file order — the real shape)."""
+    return {"type": "attachment", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "attachment": {"type": "queued_command", "prompt": text}}
+
+
+DONE_HAPPY = ('{"ops":[{"why":"asked about the search endpoint","do":"mint","text":"Answer the search endpoint question"},'
+              '{"why":"explained the same token covers it","do":"done","ref":1}]}')
+SKIP = '{"ops":[{"why":"nothing to file","do":"skip"}]}'
+
+
+def spliced_records():
+    """An in-flight labeling turn; the ask spliced into it at enqueue time; the turn's work
+    CONTINUES (chained through the attachment, as the CLI writes it) and never answers the ask;
+    a later unrelated turn ends things."""
+    return [
+        uline(T0, "Label the notes-api fixture batch", "u1"),
+        aline(T0 + 10, "Working through the batch now.", "a1", "u1"),
+        qline(T0 + 30, ASK, "q1", "a1"),
+        aline(T0 + 60, "Sheet seven labeled; two to go.", "a2", "q1"),
+        uline(T0 + 400, "unrelated: also bump the version", "u2", "a2"),
+        aline(T0 + 410, "Bumped.", "a3", "u2"),
+    ]
+
+
+class SplicedDone(unittest.TestCase):
+    def _run(self, records, reply_for_ask, reply_default=SKIP):
+        calls = []
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            tpath = td / (SID + ".jsonl")
+            tpath.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+            saved = (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store)
+            jd.GOALDIR, jd.PCACHE = td / "goals", td / "pcache"
+            def fake(text, *a, **k):
+                calls.append(text)
+                return reply_for_ask if ASK[:40] in text else reply_default
+            jd.plan_llm = jd.opener_llm = fake
+            jd._group_store = lambda *a, **k: None
+            try:
+                jd._PARSE_CACHE.clear()
+                jd._plan_session(SID, str(tpath), NOW)
+                store = jd.load_goals(SID)
+            finally:
+                (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store) = saved
+            return calls, store
+
+    def test_spliced_ask_places_but_cannot_complete(self):
+        calls, store = self._run(spliced_records(), DONE_HAPPY)
+        # the planner DID see the ambiguous frame (the unit still runs — the guard is at op level)
+        self.assertTrue(any(ASK[:40] in c for c in calls),
+                        "the spliced segment still gets its work unit — the tail work must still file")
+        asked = [nd for nd in store["nodes"].values()
+                 if "search endpoint" in (nd.get("text") or "").lower()]
+        self.assertTrue(asked, "the spliced ask still gets a card — it is real")
+        self.assertFalse(asked[0].get("nodeComplete"),
+                         "a done-happy planner reply must not complete a goal off a spliced segment "
+                         "whose work belongs to the interrupted turn's own ask")
+
+    def test_spliced_done_cannot_complete_other_cards_either(self):
+        # a done aimed at a PRE-EXISTING card (the in-flight work's own card, coerce-placed by the
+        # earlier segment) is confabulation off the same unreliable frame — stripped too, and the
+        # ask itself still lands via the never-vanish floor
+        done_only = '{"ops":[{"why":"the batch is finished","do":"done","goal":1}]}'
+        calls, store = self._run(spliced_records(), done_only)
+        self.assertTrue(store["nodes"], "the earlier segment's ask was placed")
+        self.assertFalse(any(nd.get("nodeComplete") for nd in store["nodes"].values()),
+                         "no goal may complete off a spliced-trigger segment")
+        placed_texts = " | ".join((nd.get("quote") or nd.get("text") or "") for nd in store["nodes"].values())
+        self.assertIn(ASK[:30], placed_texts,
+                      "a stripped-to-empty reply still hard-places the spliced ask (never vanish)")
+
+    def test_typed_ask_with_real_answer_still_completes(self):
+        # guard precision: an ordinary typed ask whose turn really answers it still dones
+        records = [
+            uline(T0, ASK, "u1"),
+            aline(T0 + 10, "No separate key: the search endpoint rides the session token.", "a1", "u1"),
+            uline(T0 + 400, "unrelated: also bump the version", "u2", "a1"),
+            aline(T0 + 410, "Bumped.", "a3", "u2"),
+        ]
+        calls, store = self._run(records, DONE_HAPPY)
+        asked = [nd for nd in store["nodes"].values()
+                 if "search endpoint" in (nd.get("text") or "").lower()]
+        self.assertTrue(asked and asked[0].get("nodeComplete"),
+                        "a genuinely delivered answer still completes")
+
+    def test_absorbed_trigger_is_marked_and_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            tpath = td / (SID + ".jsonl")
+            tpath.write_text("\n".join(json.dumps(r) for r in spliced_records()) + "\n")
+            jd._PARSE_CACHE.clear()
+            session = jd.parsed_session(SID, [str(tpath)], NOW)
+        segs = [seg for turn in session["turns"] for seg in jd.em.segments(turn)]
+        by_trig = {seg.get("trigger"): seg for seg in segs}
+        self.assertIn("q1", by_trig, "the splice opens its own segment")
+        spliced = by_trig["q1"]
+        self.assertTrue(any(a.get("uuid") == "q1" and a.get("absorbed") for a in spliced["atoms"]),
+                        "the synthesized splice atom carries the absorbed marker")
+        self.assertTrue(jd._seg_spliced(spliced))
+        self.assertFalse(jd._seg_spliced(by_trig["u1"]),
+                         "an ordinary typed trigger is not spliced")
+        # and the running turn's continuation really does land inside the splice's segment —
+        # the ambiguity this whole guard exists for
+        self.assertIn("a2", [a.get("uuid") for a in spliced["atoms"]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The incident (2026-07-29)

The user queued a question while a session was mid-turn on other work. 30 seconds later — before the assistant produced a single post-splice token, on a turn that then crashed without ever replying — the planner minted the ask's card **and completed it with a fully confabulated answer**. The card sat in Completed with a distillation of an answer that exists nowhere in the transcript.

## Why the 2026-07-25 guard didn't catch it

`a11007b0` routes an ended segment with no assistant work to a mint-only prompt-run, precisely because a capable planner otherwise answers the question from its own knowledge. But a mid-turn splice defeats that guard's predicate: the CLI's `queued_command` attachment is stamped with its **enqueue** time, so the synthesized absorbed atom sorts *before* the running turn's continuing atoms — and the splice's segment inherits them. `_has_asst_work` sees real assistant atoms (the interrupted ask's own work), `plan_units` emits a full work unit framed `USER ASKED: … ASSISTANT SAID: [unrelated work]`, and the planner files done. Verified against the incident: the work-run's planner call was sent 17 s after the enqueue, and its done landed 12 s before the assistant's first post-splice atom.

## The fix

- `event_model._absorbed_atom` marks the synthesized splice atom `absorbed` — metadata only: the atom set and seg ids are unchanged, so no `PLACEMENTS_V` bump.
- `judge._seg_spliced` / `judge._strip_spliced_dones`: every done-capable planner branch (work-run, followup pivot + continuation, nudge, delegation) strips `done` ops filed off a spliced-trigger segment, logged to judge-errors (kind `spliced-done`), never silent. Mint/sub/block still apply — the ask gets its card and the tail work files — and the goal stays **open**, which is the truth. The turn-level closer keeps done authority once the turn actually ends. A stripped-to-empty reply falls to the existing never-vanish floor.
- Planner + closer prompts now state the rule in words too: the answer must be in the segment/turn itself; a question it never answered stays open, however sure the judge is of the answer.

## Tests

`tests/test_judge_spliced_done.py` (synthetic fixtures): the spliced ask places but cannot complete; a spliced done can't complete *other* listed cards either (and the ask still hard-places when the reply was done-only); an ordinary typed ask with a real answer still completes; the absorbed marker and detection are pinned, including that the running turn's continuation really lands inside the splice's segment. Golden trees regenerated (`absorbed: true` on absorbed atoms — the only diff); the `_coerce_place` source pin bumped for the new floor site. Full suite: 3641 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)