### PR TITLE
The create offer names the folder it would make

### DIFF
--- a/ui/webview/dir-complete.test.ts
+++ b/ui/webview/dir-complete.test.ts
@@ -31,7 +31,12 @@ test("a missing folder warns and names where it would go", () => {
   const said = dirStatusLine(st({ exists: false, isDir: false, canCreate: true, missing: 2 }));
   assert.equal(said.cls, "warn");
   assert.match(said.text, /no such folder yet/);
-  assert.match(said.text, /Starting will create it$/, "it says what happens next, not just what is wrong");
+  // it NAMES the folder it would make, and how much of the chain (the user 2026-07-29)
+  assert.match(said.text, /Starting will create ~\/GitRepos\/api and the 1 folder above it$/);
+  const one = dirStatusLine(st({ exists: false, isDir: false, canCreate: true, missing: 1 }));
+  assert.match(one.text, /Starting will create ~\/GitRepos\/api$/, "one folder needs no arithmetic");
+  const three = dirStatusLine(st({ exists: false, isDir: false, canCreate: true, missing: 3 }));
+  assert.match(three.text, /and the 2 folders above it$/, "plural when it is more than one");
 });
 
 test("a file where a folder was typed is an error, not an offer", () => {

--- a/ui/webview/dir-complete.ts
+++ b/ui/webview/dir-complete.ts
@@ -19,7 +19,13 @@ export function dirStatusLine(s: DirStatus | null): { text: string; cls: string 
   // Plain words for what is wrong (the user 2026-07-29: "still not there" read as waffle). A missing
   // folder is not INVALID, though, since starting here creates it, so it says which of the two it is
   // rather than collapsing both into one wrong label.
-  if (s.canCreate) return { text: "no such folder yet. Starting will create it", cls: "warn" };
+  if (s.canCreate) {
+    // Name what will be MADE, and where (the user 2026-07-29). "will create it" left you to work out
+    // which folder, at which path, on which machine, from a line that had just told you the path was
+    // wrong. Say the path outright, and when the parent is missing too, say how much is being made.
+    const above = s.missing > 1 ? ` and the ${s.missing - 1} folder${s.missing > 2 ? "s" : ""} above it` : "";
+    return { text: `no such folder yet. Starting will create ${s.path}${above}`, cls: "warn" };
+  }
   return { text: "invalid path: " + s.path, cls: "bad" };
 }
 


### PR DESCRIPTION
`Starting will create it` left you to work out which folder, at which path, on which machine, from a line that had just said the path was wrong.

- one level missing → `no such folder yet. Starting will create ~/GitRepos/api`
- more than one → `…will create ~/GitRepos/api and the 2 folders above it`

Kept as its own message rather than folded into `invalid path`, per your call: starting here creates the folder, so calling it invalid while offering to create it would contradict itself.

Tests in `ui/webview/dir-complete.test.ts` cover all three arities (1, 2, 3 levels missing). Both suites green (3655 python, 1482 node), tsc clean. Pane-side, so a reload picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)