### PR TITLE
Which tab you are looking at is yours, not the fleet's

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4006,15 +4006,19 @@ def _drive(msg, client):
     return True
 
 
-def _reveal_or_confirm(sid, focus_msg):
+def _reveal_or_confirm(sid, focus_msg, client=None):
     """Bring the chat to `sid`. LIVE → the focus message. DEAD → never silently reveal; pop the chat's
     confirmRevive modal (Revive / View read-only), bringing the chat forward (the user 2026-06-17: dead
     = timeline-only, reopen on demand). Routing the prompt through _reveal_chat means a feed/timeline tap
-    lands the modal in the chat, which owns it — even though the tap came from another pane."""
+    lands the modal in the chat, which owns it — even though the tap came from another pane.
+
+    Where a CLIENT is in scope (every WS op that calls this), the reveal is aimed at that dashboard
+    alone: a jump into a transcript is one viewer's navigation, and broadcasting it dragged every open
+    dashboard to the same turn (the user 2026-07-29). No client → the old broadcast."""
     if sid and sid not in _tmux_sessions():
-        _reveal_chat({"type": "confirmRevive", "id": sid, "name": _name_of(sid) or sid})
+        _reveal_chat_for(client, {"type": "confirmRevive", "id": sid, "name": _name_of(sid) or sid})
     else:
-        _reveal_chat(focus_msg)
+        _reveal_chat_for(client, focus_msg)
 
 
 def _folder_opener():
@@ -14360,6 +14364,32 @@ def _reveal_chat(focus_msg):
     _send_to_app("shell", {"type": "reveal", "pane": "chat"})
 
 
+def _send_to_view(app, msg, wid):
+    """Push to the clients of `app` belonging to ONE dashboard — the one whose `wid` this is. Which tab a
+    viewer is looking at, and where in a transcript they jumped, is theirs alone: broadcasting it made two
+    open dashboards yank each other around (the user 2026-07-29). An EMPTY wid falls back to the broadcast,
+    so a client that reports none (an older build, a surface that supplies no id) keeps today's behaviour
+    rather than silently receiving nothing."""
+    if not wid:
+        return _send_to_app(app, msg)
+    s = json.dumps(msg)
+    with _clients_lock:
+        targets = [c for c in _clients if c["app"] == app and (c.get("wid") or "") == wid]
+    for c in targets:
+        try:
+            c["send"](s)
+        except Exception:
+            c["alive"] = False
+
+
+def _reveal_chat_for(client, focus_msg):
+    """_reveal_chat, aimed at the dashboard that asked. Use this wherever a WS op is being handled: the
+    client IS the asker, so its wid names the one window that should follow the click."""
+    wid = (client or {}).get("wid") or ""
+    _send_to_view("chat", focus_msg, wid)
+    _send_to_view("shell", {"type": "reveal", "pane": "chat"}, wid)
+
+
 def _focus_kind(anchor):
     """showOnTimeline's `anchor` → the chat focus land-on intent: "prompt" = the user's typed MESSAGE
     (a user turn), "work"/absent = the work that was done (the assistant reply turn). Used only to pick the
@@ -15385,7 +15415,14 @@ def _shim(app, v=0):
     # "newer build" prompt, not just the dashboard landing's /version poll (the user 2026-07-13: a standalone
     # pane sat silent through rebuilds).
     return """
-(function(){var queue=[],ws=null,everConnected=false;var wid=new URLSearchParams(location.search).get("wid")||"";
+(function(){var queue=[],ws=null,everConnected=false;
+// This pane's DASHBOARD id. ?wid= when the host supplies one (the VS Code extension builds its own pane
+// URLs); otherwise the shell's per-tab id from sessionStorage, which is scoped to the browsing context and
+// shared with same-origin iframes — so every pane of one window agrees, a second window differs, and no
+// iframe has to reload to learn it. It rides the WS connect so the kernel can aim a per-viewer message
+// (a focus, a jump) at the dashboard that asked instead of at every one that is open (the user 2026-07-29).
+var wid=new URLSearchParams(location.search).get("wid")||"";
+try{if(!wid)wid=window.sessionStorage.getItem("romp:wid")||"";}catch(e){}
 var APP="%s";var LOADEDV=%d;var lastRecv=0;var STALE_MS=30000;   // watchdog: no frame (incl. keepalive) for this long → the socket is dead → reconnect
 var connT=0;   // when the current socket's connect() attempt started — the progress watchdog's reference point
 // Tell the shell this pane's WS state so it can show ONE "disconnected" banner (the user 2026-06-27): a real
@@ -16237,6 +16274,11 @@ _LANDING_SETTINGS_JS = """
 if(m.romp==='settings')document.body.classList.toggle('settings-open',!!m.on);
 // the /chat iframe's new-session picker asks the shell to lift it full-window (see body.picker-open CSS)
 if(m.romp==='picker')document.body.classList.toggle('picker-open',!!m.on);});
+// One id per dashboard (per browser tab/window), minted here so every pane in it reports the same one.
+// sessionStorage, deliberately: it survives a reload (the panes keep their identity) and a second window
+// gets its own, which is what makes "the dashboard that asked" a thing the kernel can address.
+try{if(!sessionStorage.getItem('romp:wid'))sessionStorage.setItem('romp:wid',
+  (crypto.randomUUID?crypto.randomUUID():String(Math.random()).slice(2)));}catch(e){}
 // the rail's ⛭ opens the feed iframe's settings modal (the feed owns the modal); the CSS lifts the iframe
 // full-window while body.settings-open, so it works even when the feed pane is toggled off (the user 2026-06-25).
 var gear=document.getElementById('rail-gear');
@@ -18564,7 +18606,7 @@ class Handler(BaseHTTPRequestHandler):
                         client["send"](json.dumps({"type": "warn", "text": derr}))
                 elif nm in live:                 # already running → just (re)open it, don't re-spawn
                     _set_hidden_tab(live[nm], False)
-                    _reveal_chat({"type": "focus", "id": live[nm]})
+                    _reveal_chat_for(client, {"type": "focus", "id": live[nm]})
                     _mark_views_dirty()          # pusher ships the tab; never a synchronous fleet build here
                 elif msg.get("backend") == "sdk":   # non-tmux: drive via the Agent SDK
                     # _sdk_ready(), not _sdk(): the backend object exists even with the dependency
@@ -18601,7 +18643,7 @@ class Handler(BaseHTTPRequestHandler):
             sid = msg.get("id") or _live_names(_tmux_sessions()).get(str(msg.get("name")))
             if sid:
                 _set_hidden_tab(sid, False); _push_all()
-                _reveal_chat({"type": "focus", "id": sid})
+                _reveal_chat_for(client, {"type": "focus", "id": sid})
         elif msg and msg.get("type") == "openAll":
             for s in _alive_sessions(int(time.time()), _tmux_sessions()):
                 _set_hidden_tab(s["sid"], False)
@@ -18637,12 +18679,12 @@ class Handler(BaseHTTPRequestHandler):
             _kept_open.add(msg["id"])            # confirmRevive → "View read-only": this dead session
             _set_hidden_tab(msg["id"], False)    # gets a (struck) read-only tab now, without resuming it
             _push_all()
-            _reveal_chat({"type": "focus", "id": msg["id"]})
+            _reveal_chat_for(client, {"type": "focus", "id": msg["id"]})
         elif msg and msg.get("type") == "deepLink" and msg.get("session"):
             _reveal_or_confirm(msg["session"], {"type": "focus", "id": msg["session"], "anchor": msg.get("anchor"),
-                          "anchorT": msg.get("anchorT"), "anchorKind": msg.get("anchorKind")})
+                          "anchorT": msg.get("anchorT"), "anchorKind": msg.get("anchorKind")}, client)
         elif msg and msg.get("type") == "showOnTimeline" and msg.get("sid"):
-            _reveal_or_confirm(msg["sid"], _show_on_timeline_focus(msg))
+            _reveal_or_confirm(msg["sid"], _show_on_timeline_focus(msg), client)
         elif msg and msg.get("type") == "expand" and msg.get("itemId"):
             _request_feed_detail(str(msg["itemId"]), bool(msg.get("generate")))
         elif msg and msg.get("type") == "hoverHighlight":

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4859,9 +4859,12 @@ class ViewBuilder(unittest.TestCase):
         # opening a DEAD session pops the chat's confirmRevive modal — no silent reopen — and now from
         # ANY pane (feed/timeline included), since dead = timeline-only (the user 2026-06-17). A LIVE
         # session just reopens/focuses, no prompt.
-        cap, orig_rc, orig_tx, orig_pa = [], km._reveal_chat, km._tmux_sessions, km._push_all
+        # _reveal_chat_for since 2026-07-29: the reveal is aimed at the dashboard that asked (its wid),
+        # so a jump in one window no longer drags every other open one to the same turn. With no client
+        # in scope it still broadcasts, which is the path this exercises.
+        cap, orig_rc, orig_tx, orig_pa = [], km._reveal_chat_for, km._tmux_sessions, km._push_all
         try:
-            km._reveal_chat = lambda m: cap.append(m)
+            km._reveal_chat_for = lambda c, m: cap.append(m)
             km._push_all = lambda: None
             km._tmux_sessions = lambda: {SID: {}}            # SID alive; deadsid000 dead
             cap.clear(); km._open_or_revive("deadsid000")
@@ -4876,7 +4879,7 @@ class ViewBuilder(unittest.TestCase):
             live_focus = next(m for m in cap if m.get("type") == "focus" and m.get("id") == SID)
             self.assertTrue(live_focus.get("live"), "live open lands the chat on its live tail (the picker prompt)")
         finally:
-            km._reveal_chat = orig_rc; km._tmux_sessions = orig_tx; km._push_all = orig_pa
+            km._reveal_chat_for = orig_rc; km._tmux_sessions = orig_tx; km._push_all = orig_pa
 
     def test_revive_session_resumes_and_unhides_tab(self):
         # confirming the modal's "Revive" must actually resume the session AND un-hide its tab. The

--- a/tests/test_per_viewer_focus.py
+++ b/tests/test_per_viewer_focus.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Which tab you are looking at is YOURS (the user 2026-07-29).
+
+Two dashboards on one kernel are two pairs of eyes, and one should not move the other. But every
+cross-pane reveal went through _send_to_app, which pushes to EVERY client of an app, so opening a session
+in one window switched tabs in the other, and clicking a distilled summary jumped both to the same turn.
+
+Each dashboard now reports a `wid` (the shell mints one per browser tab in sessionStorage, shared with its
+same-origin pane iframes and passed on the WS connect), and a reveal handled inside a WS op is aimed at
+the asker's wid alone. An empty wid keeps the broadcast, so a client that reports none behaves as before.
+
+Synthetic clients only; no sockets.
+"""
+import inspect
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_pvf", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _client(app, wid, sink):
+    return {"app": app, "wid": wid, "alive": True, "send": lambda s: sink.append((wid, s))}
+
+
+class TargetedSend(unittest.TestCase):
+    def setUp(self):
+        self.sink = []
+        self._saved = list(km._clients)
+        km._clients[:] = [_client("chat", "win-A", self.sink), _client("chat", "win-B", self.sink),
+                          _client("feed", "win-A", self.sink)]
+
+    def tearDown(self):
+        km._clients[:] = self._saved
+
+    def test_only_the_asking_dashboard_hears_it(self):
+        km._send_to_view("chat", {"type": "focus", "id": "s1"}, "win-A")
+        self.assertEqual([w for w, _ in self.sink], ["win-A"], "the other window is left where it was")
+
+    def test_a_wid_names_a_dashboard_not_a_pane(self):
+        # every pane of one window shares the wid, so a shell reveal reaches that window's shell only
+        km._send_to_view("feed", {"type": "x"}, "win-A")
+        self.assertEqual(len(self.sink), 1)
+        self.sink.clear()
+        km._send_to_view("feed", {"type": "x"}, "win-B")
+        self.assertEqual(self.sink, [], "win-B has no feed pane open")
+
+    def test_no_wid_still_broadcasts(self):
+        # an older client, or a surface that supplies no id, must not silently receive nothing
+        km._send_to_view("chat", {"type": "focus", "id": "s1"}, "")
+        self.assertEqual(sorted(w for w, _ in self.sink), ["win-A", "win-B"])
+
+
+class Wiring(unittest.TestCase):
+    def test_the_ops_a_user_clicks_are_aimed_at_the_asker(self):
+        src = inspect.getsource(km.Handler)
+        # openByName/pickResult, openSession, deepLink and showOnTimeline all have the client in hand
+        self.assertGreaterEqual(src.count("_reveal_chat_for(client,"), 3)
+        self.assertIn("_reveal_or_confirm(msg[\"sid\"], _show_on_timeline_focus(msg), client)", src,
+                      "the distilled-summary jump is one viewer's navigation")
+        self.assertIn("\"anchorKind\": msg.get(\"anchorKind\")}, client)", src, "…and so is a deep link")
+
+    def test_the_shell_mints_one_id_per_tab_and_the_panes_read_it(self):
+        html = km._landing()
+        self.assertIn("sessionStorage.getItem('romp:wid')", html)
+        self.assertIn("sessionStorage.setItem('romp:wid'", html)
+        # the pane's own shim prefers ?wid= (the VS Code host supplies one) then the shell's per-tab id
+        shim = km._shim("chat", 1)
+        self.assertIn('get("wid")', shim)
+        self.assertIn('window.sessionStorage.getItem("romp:wid")', shim)
+
+    def test_an_empty_wid_falls_through_to_the_broadcast(self):
+        self.assertIn("if not wid:\n        return _send_to_app(app, msg)",
+                      inspect.getsource(km._send_to_view))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two dashboards on one kernel are two pairs of eyes, and one was moving the other: opening a session in one window switched tabs in the other, and clicking a distilled summary jumped both to the same turn. Every cross-pane reveal went through `_send_to_app`, which pushes to **every** client of an app.

**Each dashboard now has an id.** The shell mints one per browser tab into `sessionStorage` — scoped to the browsing context and shared with its same-origin pane iframes, so every pane of one window agrees, a second window differs, and no iframe has to reload or handshake to learn it. It rides the WS connect, where the client record already carried a `wid` field used only for diagnostics.

**Reveals handled inside a WS op are aimed at the asker alone**, since the client *is* the asker: open-by-name, open-by-id, deep links, and the feed's jump into a transcript. Cross-pane reveal still works *within* a window, which was always the point. An empty id falls through to the broadcast, so a client that reports none (an older build, a surface supplying no id) behaves exactly as before.

**Not yet per-viewer, and left for its own change:** the reveals with no client in scope, a session spawning and a revive completing. Those fire from threads and helpers that would each need the asking window threaded through them.

Tests: `tests/test_per_viewer_focus.py` (targeted send, wid names a dashboard not a pane, empty-wid broadcast, the op wiring, and that the shell mints the id while the pane shim reads it). One existing harness updated for the renamed helper. Python suite green (3661). Kernel + shell, so it needs a kernel restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)