### PR TITLE
A lost send says "never delivered" instead of posing as history

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3762,7 +3762,7 @@ def _drive(msg, client):
         return False
     t = msg.get("type")
     ID_OPS = ("sendMessage", "rewindSend", "rewindDelete", "interrupt", "compactSession", "dismissDialog", "answerAsk", "navAsk", "toggleAsk", "submitAsk",
-              "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "apiRetry", "setModel", "setEffort", "setMode",
+              "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "setModel", "setEffort", "setMode",
               "endSession", "renameSession")
     if t in ID_OPS and msg.get("id"):
         sid = str(msg["id"])
@@ -3920,6 +3920,15 @@ def _drive(msg, client):
         err = _cancel_backend_queued(be, sid, int(msg["idx"]), str(msg.get("md") or ""))
         client["send"](json.dumps({"type": "cancelResult", "ok": not err, "id": sid,
                                    "md": str(msg.get("md") or ""), "text": err or ""}))
+        _push_soon()
+    elif t == "dismissEcho" and hasattr(be, "dismiss_echo"):
+        # ✕ on a never-delivered bubble (a send whose CLI died holding it — the backend's dropped-echo
+        # marking): the user has seen the loss, so retire the echo. Idempotent: a miss means it is
+        # already gone, and the next push simply paints without it (the client removed its node
+        # optimistically, per the acknowledge-the-click rule).
+        _et = msg.get("t")
+        be.dismiss_echo(sid, uuid=str(msg.get("uuid") or "") or None,
+                        t=int(_et) if isinstance(_et, (int, float)) and not isinstance(_et, bool) else None)
         _push_soon()
     elif t == "dismissDialog":
         # Dismiss the CLI's spend-cap modal (the chat card's tmux-only affordance): the backend VERIFIES
@@ -10658,6 +10667,14 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                             # interrupt marker on the rail instead of a person-blue bubble (the user 2026-07-02).
                             if prompt.strip().startswith("[Request interrupted by user"):
                                 ev["interruptMarker"] = True
+                            # A provably-LOST send (a live echo whose CLI died holding it — the backend's
+                            # dropped-echo marking): the client renders "never delivered" with restore/
+                            # dismiss instead of a sent-looking bubble that poses as history (the user
+                            # 2026-07-29). echoT is the dismiss handle that survives kernel restarts —
+                            # the echo uuid regenerates on every boot reseed; its send time does not.
+                            if a.get("dropped") and a.get("_echo_text"):
+                                ev["undelivered"] = True
+                                ev["echoT"] = a.get("t")
                             if fu_goal is not None or (author == "human" and "romp-goal-id" in text):
                                 ev["followUp"] = True
                                 if fu_goal:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1389,6 +1389,10 @@ class SdkSession:
             # waiting displays that read as a wedged session (nimbus, the user 2026-07-10).
             self.backend._update_reg(self.sid, spawnedAt=int(time.time()))
             self.backend._heal_stale_awaiting(self.sid)
+            # The SPAWN half of the dropped-echo marking (boot half: _reseed_echoes): a fresh CLI means
+            # whatever held any earlier send is gone. An echo neither in self._pending (delivered to the
+            # new CLI) nor landed has no holder left — flag it so the chat says "never delivered".
+            self.backend._mark_dropped_echoes(self.sid, self.pending())
             asyncio.run(self._amain())
         except Exception as e:                       # surfaced for debugging; never crash kernel
             # The TRACEBACK too, not just the type and message: a bare "KeyError: <uuid>" names no line,
@@ -2871,7 +2875,7 @@ class SdkBackend:
         after a restart would assert something that may no longer be true."""
         d = self._live.get(sid) or {}
         snap = [{"t": a.get("t", 0), "text": a["_echo_text"], "author": a.get("author") or "human",
-                 "rompAuto": bool(a.get("rompAuto"))}
+                 "rompAuto": bool(a.get("rompAuto")), "dropped": bool(a.get("dropped"))}
                 for a in d.values() if a.get("_echo_text") and not a.get("command")]
         try:
             self._update_reg(sid, echoes=snap)
@@ -2881,7 +2885,10 @@ class SdkBackend:
     def _reseed_echoes(self, regs: list[dict]) -> None:
         """Kernel boot: re-create each alive session's persisted unlanded echoes in the live store, so a
         send in flight across the restart stays visible until its real record lands (then the normal
-        text-prune retires it and the mirror empties)."""
+        text-prune retires it and the mirror empties). Reseeding is also the BOOT half of the dropped
+        marking: whatever process held these sends died with the previous kernel, so any echo whose text
+        is not in the persisted queue (which _boot_reconcile is about to re-deliver) has provably lost
+        its message — _mark_dropped_echoes flags it so the chat can say so."""
         for reg in regs:
             if not (reg.get("alive") and reg.get("sid")):
                 continue
@@ -2896,7 +2903,58 @@ class SdkBackend:
                         "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
                 if e.get("rompAuto"):
                     atom["rompAuto"] = True
+                if e.get("dropped"):
+                    atom["dropped"] = True
                 self._live.setdefault(reg["sid"], {})[key] = atom
+            if self._live.get(reg["sid"]):
+                self._mark_dropped_echoes(reg["sid"], reg.get("queue") or [])
+
+    def _mark_dropped_echoes(self, sid: str, queued_texts) -> None:
+        """A fresh CLI is spawning for this sid, or the kernel just booted: whatever process held any
+        earlier send is gone. An input echo whose text is neither in the surviving queue (about to be
+        delivered to the new CLI) nor landed in the transcript has no holder left — its send is provably
+        LOST. Flag it `dropped`, so the chat renders "never delivered" with restore/dismiss instead of a
+        sent-looking bubble that rides the live tail with a stale timestamp forever (the user 2026-07-29:
+        a two-day-old lost send kept resurfacing mid-chat, hopping turns as new ones landed, posing as
+        history). Event-based — keyed on the spawn/boot that orphaned the send, never on age — and
+        self-correcting: an echo whose text actually LANDED still prunes by text on the next build, so a
+        premature flag can never stick to a delivered message. The flag rides the registry mirror
+        (_persist_echoes), so it survives further restarts."""
+        d = self._live.get(sid)
+        if not d:
+            return
+        qs = {q for q in queued_texts if isinstance(q, str)}
+        newly = [a for a in d.values()
+                 if a.get("_echo_text") and not a.get("command") and not a.get("dropped")
+                 and a["_echo_text"] not in qs]
+        if not newly:
+            return
+        for a in newly:
+            a["dropped"] = True
+            self._log("%s: a send never reached its CLI (the process died holding it) — kept in the chat "
+                      "as never-delivered: %.80r" % (sid[:8], a["_echo_text"]), problem=True)
+        self._persist_echoes(sid)
+        self._wake_push()
+
+    def dismiss_echo(self, sid: str, uuid: str | None = None, t: int | None = None) -> str | None:
+        """✕ on a never-delivered bubble: retire a DROPPED echo the user has acknowledged. Matched by the
+        live-store key first (the uuid this kernel painted), falling back to the echo's send time — the
+        key regenerates on every boot reseed, so a click racing a kernel restart still lands. DROPPED
+        only: a live (pending) echo is the sole visible record of an in-flight send and must stay until
+        it lands or its loss is proven. Returns the retired text, or None on a miss (already gone —
+        idempotent; the next push simply paints without it)."""
+        live = self._live.get(sid) or {}
+        for k, a in list(live.items()):                    # snapshot: the live-tail thread may mutate concurrently
+            if not (a.get("_echo_text") and a.get("dropped")):
+                continue
+            if (uuid is not None and k == uuid) or (t is not None and int(a.get("t") or 0) == t):
+                live.pop(k, None)
+                if not live:
+                    self._live.pop(sid, None)
+                self._persist_echoes(sid)
+                self._wake_push()
+                return a.get("_echo_text")
+        return None
 
     def rewind(self, sid: str, target_uuid: str, text: str) -> "tuple[bool, str]":
         """Rewind the conversation to `target_uuid` (a transcript record uuid the KERNEL has validated:

--- a/tests/test_sdk_echo_durability.py
+++ b/tests/test_sdk_echo_durability.py
@@ -2,14 +2,17 @@
 """An SDK input echo is the ONLY visible record of a send the transcript hasn't caught up on — since
 queued sends forward into the CLI mid-turn (2026-07-17) there is a window where a message is neither
 queued nor landed, and the echo must own it (the user 2026-07-20: a reply sat invisible in the chat,
-and one message was silently LOST across a kernel restart with no trace anywhere). Three durability
+and one message was silently LOST across a kernel restart with no trace anywhere). Four durability
 guarantees, each pinned here:
   1. the live-tail overflow cap never evicts an echo (work atoms are disposable; echoes aren't),
   2. the genuine-human-turn floor retires only PATH-BEARING echoes (the image-extraction case whose
      text-match structurally fails) — a plain-text echo prunes only by its own text landing, and a
      dropped send's echo PERSISTS so the loss shows (the tmux echo's semantics),
   3. unlanded echoes mirror to the registry (reg['echoes']) and reseed on backend construction, so a
-     kernel restart cannot wipe the only evidence of an in-flight send.
+     kernel restart cannot wipe the only evidence of an in-flight send,
+  4. an echo that survives its holder is MARKED dropped at the event that orphaned it (boot reseed /
+     fresh CLI spawn), so persistence reads as "never delivered", not as delivered history (the user
+     2026-07-29: a two-day-old lost send kept resurfacing mid-chat, posing as an ordinary bubble).
 SYNTHETIC fixtures only."""
 import os
 import tempfile
@@ -130,6 +133,119 @@ class EchoesSurviveARestart(unittest.TestCase):
         be._persist_echoes(SID)
         self.assertEqual(sb.read_reg(be.state_dir, SID).get("echoes"), [],
                          "a stale /model confirmation must not replay after a restart")
+
+
+class DroppedSendsAnnounceThemselves(unittest.TestCase):
+    """Guarantee 4 (the user 2026-07-29): an echo that survives its holder is marked `dropped` at the
+    exact event that orphaned it — the boot reseed, or a fresh CLI spawning — so the chat can render
+    "never delivered" instead of a sent-looking bubble posing as history. A two-day-old lost send kept
+    resurfacing mid-chat, hopping turns as new ones landed, its stale timestamp reading as a glitch:
+    durable BY DESIGN, but illegible. The marking is self-correcting (a landed text still prunes the
+    echo, flag and all) and rides the registry mirror across further restarts."""
+
+    def _backend(self, state=None):
+        return sb.SdkBackend(state or tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+
+    def test_boot_reseed_marks_an_unqueued_echo_dropped(self):
+        state = tempfile.mkdtemp()
+        be = self._backend(state)
+        sb.write_reg(be.state_dir, SID, {"sid": SID, "alive": True})
+        k, e = _echo("the send the dead CLI was holding")
+        be._live[SID] = dict([(k, e)])
+        be._persist_echoes(SID)
+        be2 = self._backend(state)               # "kernel restart": nothing re-delivers this text
+        atoms = be2.live_atoms(SID)
+        self.assertTrue(atoms and atoms[0].get("dropped"),
+                        "a reseeded echo with no queue entry has provably lost its message")
+        self.assertTrue((sb.read_reg(state, SID).get("echoes") or [{}])[0].get("dropped"),
+                        "the flag rides the mirror, so the NEXT restart keeps the verdict")
+
+    def test_boot_reseed_spares_an_echo_still_in_the_queue(self):
+        state = tempfile.mkdtemp()
+        be = self._backend(state)
+        sb.write_reg(be.state_dir, SID, {"sid": SID, "alive": True,
+                                         "queue": ["still queued across the restart"]})
+        k, e = _echo("still queued across the restart")
+        be._live[SID] = dict([(k, e)])
+        be._persist_echoes(SID)
+        be2 = self._backend(state)               # boot reconcile will re-deliver the queue → not lost
+        atoms = be2.live_atoms(SID)
+        self.assertTrue(atoms and not atoms[0].get("dropped"),
+                        "a queued send is in flight, not lost — it must not read as never-delivered")
+
+    def test_spawn_marking_spares_the_pending_queue(self):
+        be = self._backend()
+        sb.write_reg(be.state_dir, SID, {"sid": SID, "alive": True})
+        k1, e1 = _echo("orphaned by the respawn", key="echo:a")
+        k2, e2 = _echo("delivered to the fresh CLI", t=1001, key="echo:b")
+        be._live[SID] = {k1: e1, k2: e2}
+        be._mark_dropped_echoes(SID, ["delivered to the fresh CLI"])
+        d = be._live[SID]
+        self.assertTrue(d[k1].get("dropped"))
+        self.assertFalse(d[k2].get("dropped"))
+
+    def test_spawn_marking_ignores_command_feedback(self):
+        be = self._backend()
+        sb.write_reg(be.state_dir, SID, {"sid": SID, "alive": True})
+        be._live[SID] = {"cmd:1": {"type": "user", "uuid": "cmd:1", "t": 5, "command": "/model",
+                                   "_echo_text": "/model opus", "author": "human",
+                                   "message": {"role": "user", "content": [{"type": "text", "text": "/model opus"}]}}}
+        be._mark_dropped_echoes(SID, [])
+        self.assertFalse(be._live[SID]["cmd:1"].get("dropped"),
+                         "command feedback is not a lost message; it retires via the command floor")
+
+    def test_a_fresh_cli_spawn_runs_the_marking(self):
+        # the spawn half is a call inside Session._run (spawning a real CLI in a unit test is not
+        # practical) — pin it the way error-visibility's NoSilentSwallows pins handlers: read the source
+        import ast
+        import inspect
+        run = next(n for n in ast.walk(ast.parse(inspect.getsource(sb)))
+                   if isinstance(n, ast.FunctionDef) and n.name == "_run")
+        calls = [n.func.attr for n in ast.walk(run)
+                 if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)]
+        self.assertIn("_mark_dropped_echoes", calls,
+                      "_run no longer marks orphaned echoes when a fresh CLI spawns")
+
+    def test_landing_still_prunes_a_dropped_echo(self):
+        # the self-correcting guarantee: a premature mark can never stick to a delivered message
+        state = tempfile.mkdtemp()
+        be = self._backend(state)
+        sb.write_reg(be.state_dir, SID, {"sid": SID, "alive": True})
+        k, e = _echo("actually landed after all")
+        e["dropped"] = True
+        be._live[SID] = dict([(k, e)])
+        be._persist_echoes(SID)
+        be.prune_live(SID, tx_uuids=set(), tx_user_texts={"actually landed after all"}, human_floor=0)
+        self.assertNotIn(SID, be._live)
+        self.assertEqual(sb.read_reg(state, SID).get("echoes"), [])
+
+    def test_dismiss_retires_by_key_and_by_send_time(self):
+        state = tempfile.mkdtemp()
+        be = self._backend(state)
+        sb.write_reg(be.state_dir, SID, {"sid": SID, "alive": True})
+        k, e = _echo("seen and dismissed")
+        e["dropped"] = True
+        be._live[SID] = dict([(k, e)])
+        self.assertEqual(be.dismiss_echo(SID, uuid=k), "seen and dismissed")
+        self.assertNotIn(SID, be._live)
+        self.assertEqual(sb.read_reg(state, SID).get("echoes"), [], "dismissal empties the mirror")
+        # by send time: the uuid regenerates at every boot reseed, but t survives it
+        k2, e2 = _echo("dismissed after a restart", t=4242, key="echo:regen")
+        e2["dropped"] = True
+        be._live[SID] = dict([(k2, e2)])
+        self.assertEqual(be.dismiss_echo(SID, uuid="echo:stale-painted-key", t=4242),
+                         "dismissed after a restart")
+        self.assertIsNone(be.dismiss_echo(SID, uuid="echo:stale-painted-key", t=4242),
+                          "a second click is an idempotent miss, not an error")
+
+    def test_dismiss_never_touches_a_pending_echo(self):
+        be = self._backend()
+        sb.write_reg(be.state_dir, SID, {"sid": SID, "alive": True})
+        k, e = _echo("still in flight")
+        be._live[SID] = dict([(k, e)])
+        self.assertIsNone(be.dismiss_echo(SID, uuid=k, t=e["t"]),
+                          "an undropped echo is the send's only record — undismissable")
+        self.assertIn(k, be._live[SID])
 
 
 if __name__ == "__main__":

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -65,7 +65,7 @@ type TaskOutputs = Record<string, { command: string; output: string }>;
 type ChatEvent = (
   // mid/mids: postal message ids the kernel could NOT resolve into cards, carried on the raw turn so a
   // timeline arc into it still lands (see _hydrate_postal's unresolved path)
-  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[] }
+  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number }
   | { kind: "assistant"; md: string; uuid?: string; ts?: string }
   | { kind: "thinking"; text: string; encrypted: boolean; uuid?: string; ts?: string }
   | {
@@ -1615,6 +1615,41 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         for (const im of ev.images) bubble.appendChild(userImage(im, !!(im.path && mdText.includes(im.path))));
       }
       turn.appendChild(bubble);
+      // NEVER-DELIVERED send (kernel ev.undelivered, from the backend's dropped-echo marking): the
+      // session's process died holding this message, so it was never seen — say so instead of letting
+      // it pose as history (the user 2026-07-29: a two-day-old lost send kept resurfacing mid-chat as
+      // an ordinary sent bubble, hopping turns, with its stale timestamp reading as a glitch). The
+      // bubble stays — it is the only surviving copy of the text — and the note under it names the
+      // loss and offers the two honest moves: put the text back in the composer, or dismiss the
+      // record. Buttons ride the body delegate (data-act): the tail rebuilds every push, and a
+      // per-render listener eats a mid-press click (CLAUDE.md).
+      if (ev.undelivered) {
+        turn.classList.add("undelivered");
+        bubble.classList.add("undelivered-bubble");
+        const note = el("div", "undelivered-note");
+        note.title = "This message never reached the session: its process died holding it before it was written to the conversation.";
+        const label = el("span", "undelivered-label");
+        label.textContent = "never delivered";
+        note.appendChild(label);
+        if (!romp && !injected && ev.md) {   // restore only the user's own words, not a romp injection's
+          const re = el("button", "undelivered-act") as HTMLButtonElement;
+          re.type = "button";
+          re.textContent = "copy to composer";
+          re.title = "Put the text back in the composer to review and send again";
+          re.dataset.act = "echorestore";
+          (re as any)._etext = ev.md;
+          note.appendChild(re);
+        }
+        const dx = el("button", "undelivered-act") as HTMLButtonElement;
+        dx.type = "button";
+        dx.textContent = "dismiss";
+        dx.title = "Remove this never-delivered message";
+        dx.dataset.act = "echodismiss";
+        if (ev.uuid) dx.dataset.euuid = ev.uuid;
+        if (ev.echoT) dx.dataset.et = String(ev.echoT);
+        note.appendChild(dx);
+        turn.appendChild(note);
+      }
       // EDIT affordance (SDK sessions): rewind the conversation to just before this message and take a
       // new branch with an edited version — the cloud-UI edit semantics. Shown on genuine human bubbles
       // the backend can address (reconcileRewind's _editable set: has a transcript uuid, newer than the
@@ -7815,6 +7850,24 @@ setupSettings();
       const grp = bub?.closest(".turn-queued") as HTMLElement | null;
       bub?.remove();
       if (grp) reflowQueuedGroup(grp);
+    },
+    // "copy to composer" on a never-delivered bubble: the echo is the only surviving copy of the text —
+    // hand it back for review-and-resend (the same restore the queued ✕ uses). Delegated like qx: the
+    // tail rebuilds every push, and a per-render listener eats a mid-press click.
+    echorestore: (el) => {
+      const t = (el as any)._etext as string | undefined;
+      if (t) restoreToComposer(t);
+    },
+    // "dismiss" on a never-delivered bubble: the user has seen the loss — retire the echo. The node
+    // goes NOW (acknowledge the click); the kernel's dismiss_echo is idempotent, so a miss just means
+    // it was already gone and the next push paints without it either way.
+    echodismiss: (el) => {
+      if (!activeId || !vscodeApi) return;
+      const msg: Record<string, unknown> = { type: "dismissEcho", id: activeId };
+      if (el.dataset.euuid) msg.uuid = el.dataset.euuid;
+      if (el.dataset.et) msg.t = Number(el.dataset.et);
+      vscodeApi.postMessage(msg);
+      (el.closest(".turn-user") as HTMLElement | null)?.remove();
     },
     // gist↔full toggle on a compact nudge bubble (the user 2026-07-17: progressive disclosure) —
     // delegated for the same reason as qx: the tail rebuilds every push, and a per-render bubble

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1099,6 +1099,27 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   color: var(--dim); background: transparent; border: 0; border-radius: 6px; padding: 0;
 }
 .queued-x:hover { color: var(--vscode-errorForeground, #f48771); background: rgba(255, 255, 255, 0.08); }
+/* NEVER-DELIVERED send (ev.undelivered): a message whose CLI died holding it — kept, because the bubble
+   is the only surviving copy of the text, but marked as a LOSS instead of posing as delivered history
+   (the user 2026-07-29). Dashed like the queued family (a send that never became a turn), red-edged like
+   every "something went wrong" cue. The note + actions sit under the right-aligned bubble and are always
+   visible — a loss notice is not a hover secret. Button sizes wear .msg-edit's clothes (one size). */
+.user-bubble.undelivered-bubble { background: rgba(43, 108, 239, 0.10); }
+.user-bubble.undelivered-bubble, .romp-bubble.undelivered-bubble {
+  border: 1px dashed rgba(244, 135, 113, 0.65); opacity: 0.85;
+}
+.undelivered-note { display: flex; align-items: center; gap: 4px; align-self: flex-end; margin-top: 3px; }
+.undelivered-label {
+  font-size: 0.78em; color: var(--vscode-errorForeground, #f48771);
+  letter-spacing: 0.02em; margin-right: 4px;
+}
+.undelivered-act {
+  font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--box-border); background: var(--code-bg); color: var(--dim);
+  cursor: pointer; user-select: none;
+  transition: color 0.12s ease, border-color 0.12s ease;
+}
+.undelivered-act:hover { color: var(--fg); border-color: var(--accent); }
 /* compact "↩ Follow-up · <goal>" header above a message that resumed a goal — landed user turns AND pending
    queued messages, so the two render the same (the user 2026-06-27). Right-aligned with the outgoing bubble. */
 /* ONE font size across the whole header + its context box (the user 2026-07-02: the header was a soup of

--- a/ui/webview/undelivered-echo.test.ts
+++ b/ui/webview/undelivered-echo.test.ts
@@ -1,0 +1,75 @@
+// A NEVER-DELIVERED send (the user 2026-07-29): an optimistic input echo whose CLI died holding it is
+// durable BY DESIGN (the loss must show), but it used to render as an ordinary sent bubble — a two-day-old
+// lost message kept resurfacing mid-chat, hopping turns as new ones landed, its stale timestamp reading as
+// a glitch. The fix threads the backend's `dropped` marking through the kernel event (ev.undelivered) into
+// an explicit "never delivered" treatment with restore/dismiss. The renderer has no jsdom harness, so pin
+// the wiring at source (the romp-bubble.test.ts pattern); backend behavior lives in
+// tests/test_sdk_echo_durability.py.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("a user ChatEvent can carry the undelivered flag and its restart-stable dismiss handle", () => {
+  assert.match(RENDER, /kind: "user"; [^\n]*undelivered\?: boolean/);
+  assert.match(RENDER, /kind: "user"; [^\n]*echoT\?: number/);
+});
+
+test("the kernel threads a dropped echo into ev.undelivered + echoT", () => {
+  assert.match(KERNEL, /if a\.get\("dropped"\) and a\.get\("_echo_text"\):/);
+  assert.match(KERNEL, /ev\["undelivered"\] = True/);
+  assert.match(KERNEL, /ev\["echoT"\] = a\.get\("t"\)/);
+});
+
+test("the kernel exposes dismissEcho as a drive op routed to the backend", () => {
+  assert.match(KERNEL, /"cancelQueued", "dismissEcho", "apiRetry"/, "dismissEcho joins ID_OPS");
+  assert.match(KERNEL, /elif t == "dismissEcho" and hasattr\(be, "dismiss_echo"\):/);
+  assert.match(KERNEL, /be\.dismiss_echo\(sid, uuid=/);
+});
+
+test("an undelivered bubble is marked and carries the note, not just a plain sent bubble", () => {
+  assert.match(RENDER, /if \(ev\.undelivered\) \{/);
+  assert.match(RENDER, /turn\.classList\.add\("undelivered"\)/);
+  assert.match(RENDER, /bubble\.classList\.add\("undelivered-bubble"\)/);
+  assert.match(RENDER, /el\("div", "undelivered-note"\)/);
+  assert.match(RENDER, /label\.textContent = "never delivered"/);
+});
+
+test("both actions ride the body delegate (click-safe), never a per-render listener", () => {
+  // the buttons carry data-act; the handlers live in the delegate map next to qx/nudgetoggle
+  assert.match(RENDER, /re\.dataset\.act = "echorestore"/);
+  assert.match(RENDER, /dx\.dataset\.act = "echodismiss"/);
+  assert.match(RENDER, /echorestore: \(el\) => \{/);
+  assert.match(RENDER, /echodismiss: \(el\) => \{/);
+});
+
+test("restore hands the only surviving copy of the text back to the composer", () => {
+  assert.match(RENDER, /echorestore: \(el\) => \{[\s\S]*?restoreToComposer\(t\)/);
+});
+
+test("dismiss posts dismissEcho with the restart-stable handle and acknowledges the click", () => {
+  const m = RENDER.match(/echodismiss: \(el\) => \{[\s\S]*?\n    \},/);
+  assert.ok(m, "the echodismiss handler exists");
+  assert.match(m![0], /type: "dismissEcho", id: activeId/);
+  assert.match(m![0], /msg\.uuid = el\.dataset\.euuid/);
+  assert.match(m![0], /msg\.t = Number\(el\.dataset\.et\)/);
+  // optimistic removal = the immediate acknowledgement; the kernel's dismiss is idempotent
+  assert.match(m![0], /\.closest\(".turn-user"\)[\s\S]*?\.remove\(\)/);
+});
+
+test("restore is offered only for the user's own words, dismiss for every flavor", () => {
+  assert.match(RENDER, /if \(!romp && !injected && ev\.md\) \{[\s\S]{0,400}?echorestore/);
+});
+
+test("the loss treatment exists in CSS: dashed red-edged bubble + always-visible note", () => {
+  assert.match(CSS, /\.user-bubble\.undelivered-bubble, \.romp-bubble\.undelivered-bubble \{/);
+  assert.match(CSS, /\.undelivered-note \{[^}]*align-self: flex-end/);
+  assert.match(CSS, /\.undelivered-label \{[^}]*errorForeground/);
+  assert.match(CSS, /\.undelivered-act \{/);
+  // the note is NOT hover-gated like .msg-edit — a loss notice is not a hover secret
+  assert.doesNotMatch(CSS, /\.undelivered-note \{[^}]*opacity: 0/);
+});


### PR DESCRIPTION
## The bug

A message sent from the chat composer died with its CLI (a kernel restart caught it in flight), and its optimistic echo, which is durable by design so the loss stays visible, kept resurfacing in the chat two days later: an ordinary-looking sent bubble that hopped turns as new ones landed (the live merge targets whatever turn is currently last), appearing, vanishing, and reappearing lower, with its original stale timestamp. Nothing distinguished it from delivered history, and there was no way to act on it, so the designed visibility read as a haunting instead of a loss notice.

## The fix

- **Mark the loss at the event that proves it** (`kernel/sdk_backend.py`): `_mark_dropped_echoes` flags any echo whose text is neither in the surviving queue nor landed, at the two events that orphan a send: the boot reseed (the previous kernel's CLIs are dead) and a fresh CLI spawning inside a live kernel. The flag rides the registry mirror across restarts, files a problem-log entry, and is self-correcting: a landed text still prunes the echo, flag and all, so a premature mark can never stick to a delivered message.
- **Say it in the chat** (`kernel/kernel.py`, `ui/webview/render.ts`, `styles.css`): the flag threads into the chat event as `ev.undelivered`; the bubble goes dashed and red-edged with an always-visible "never delivered" note and two click-safe delegated actions: **copy to composer** (the echo is the only surviving copy of the text) and **dismiss** (a new `dismissEcho` drive op; retirement matches by painted key or by send time, since the key regenerates every reseed).

## Tests

- `tests/test_sdk_echo_durability.py`: guarantee 4, eight cases (both marking events, queue and command-feedback exemptions, mirror round-trip, the self-correction, dismissal by key/time, pending echoes undismissable).
- `ui/webview/undelivered-echo.test.ts`: pins the kernel threading, the op, the render wiring, and the CSS at source.

Local: 3667 python passed / 25 skipped, 1491 node passed, 296 bats passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)