### PR TITLE
Cards move on new information: the reply latch holds, and a superseded nudge stands down

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,30 @@ Prefer exact event-based mechanisms over time-based heuristics (grace periods,
 debounces, age thresholds). If a time window seems needed, find the event it is
 approximating and key on that event instead.
 
+### Cards move on new information, never on inference flaps (user rule, 2026-07-29)
+Every card move claims something changed, and the user's eye follows it — so a
+card may move only when NEW INFORMATION arrives (a judge verdict filed from fresh
+evidence, a user gesture), and must move MINIMALLY: accurate, but never
+ping-ponging without user action. Two standing corollaries:
+- **Transient states latch until the deciding event.** A state like "reply
+  pending judgment" holds its column until the judge actually rules — never
+  re-derived per build from a flapping input (an open-turn bit, a per-build
+  recomputation). The audited card flipped working↔needs-you seven times in six
+  minutes because its drop-to-Working was bounded by the open turn, a proxy that
+  toggles at every turn boundary of an active session; the fix latches on the
+  unblocker's `blockCheckT` watermark, the event the proxy was approximating.
+- **A writer whose evidence predates the diary stands down.** Any mechanism about
+  to move a card must check, at the write moment, whether a verdict was FILED
+  after the evidence it is acting on — and if so, yield (the judges already ruled
+  on a newer world). The nudge does this at both ends now (`_nudge_fire_list`
+  arm-time guard, `_mark_nudge_failed` moot retire): before it, a nudge fired
+  five seconds after the unblocker had ruled its question answered, and then
+  converted its own cut-off response turn into a false needs-you block
+  presenting a brief the user had already answered.
+When adding any mechanism that can change a card's column, name the exact event
+that justifies the move; if the trigger can flap between builds without new
+information, it is the wrong trigger.
+
 ### Progressive disclosure is the UI's organizing principle (user rule, 2026-07-17)
 Every surface defaults to its most COMPACT legible form, and you can always click
 to go one level deeper — gist → summary → full mechanics, each level a click. When

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1750,6 +1750,7 @@ def _mark_nudge_failed(gid, ev_t=None):
     planner has processed it too) and the goal is STILL working-stalled: the one ask didn't resolve it, and
     per the anti-loop rule we never re-ask. Event-based — stamped at the tick's re-arm gate, whose
     session-level gates ARE "response turn ended + judged"; cleared by the next genuine fire's fresh record.
+    Returns "failed" when the stamp landed, "moot" when the story had moved on, None when skipped.
 
     AND (the user 2026-07-07): a failed nudge IS a block — romp asked, the answer didn't resolve it, romp
     won't ask again, so by definition the goal now needs the user. Record the block verdict so the card
@@ -1763,10 +1764,10 @@ def _mark_nudge_failed(gid, ev_t=None):
     try:
         _sid = gid.rsplit(":", 1)[0]
         if _session_awaiting(_sid, _path_of(_sid) or "", True):
-            return
+            return None
         if _goal_awaiting_stamp(jd.load_goals(_sid).get("nodes", {}), gid,
                                 answered_at=_peer_answered_at(_sid)):
-            return                                     # the judge's durable ⏳ stamp says the goal waits on
+            return None                                # the judge's durable ⏳ stamp says the goal waits on
             #                                            async work — same rule as above, restart-proof
     except Exception:
         pass
@@ -1774,8 +1775,31 @@ def _mark_nudge_failed(gid, ev_t=None):
     d = dict(_auto_nudge_data())
     nudged = dict(d.get("nudged", {}))
     rec = nudged.get(gid)
-    if not rec or rec.get("failed"):
-        return
+    if not rec or rec.get("failed") or rec.get("moot"):
+        return None
+    # MOOT, NOT FAILED (the user 2026-07-29): if a real judge FILED a verdict on this node after the
+    # response turn — an unblock ("answered in passing"), a fresh planner/closer block, a completion —
+    # then the judges have already ruled on evidence at least as new as ours, and "the response didn't
+    # resolve this" is a stale claim. Filing our procedural block anyway would overwrite that ruling AND
+    # resurface the node's LAST decision brief, which the later verdict may have just answered — the
+    # audited card sat in Needs-you presenting a question the user had answered and the unblocker had
+    # ruled answered, five minutes after the fact. Retire the record instead (`moot`, no `failed`, no
+    # block): the anti-loop gate keeps this arm from ever re-firing, and a genuinely still-stalled goal
+    # re-arms on the next GENUINE ended turn, judged against the post-verdict world. The verdict's
+    # FILING time (`at`; ev_t for legacy rows) is the event — same discipline as _nudge_fire_list's
+    # arm-time guard, applied at the eval end of the race.
+    _ev = int(ev_t or now)
+    try:
+        _nd0 = jd.load_goals(gid.rsplit(":", 1)[0]).get("nodes", {}).get(gid)
+        if _nd0 is not None and any((e.get("at") or e.get("ev_t") or 0) > _ev
+                                    and e.get("src") != "nudge"
+                                    for e in _nd0.get("log") or []):
+            nudged[gid] = dict(rec, moot=True)
+            d["nudged"] = nudged
+            _write_auto_nudge(d)
+            return "moot"
+    except Exception:
+        pass
     # failedAt: the build_feed chip's retire fallback when the block row below goes missing — the two
     # writes land in different files and only this one is guaranteed (g52, 2026-07-16: a planner pass's
     # stale save erased the row, and the row-keyed retire left the chip saying "waiting on you" through
@@ -1789,11 +1813,11 @@ def _mark_nudge_failed(gid, ev_t=None):
         nd = store.get("nodes", {}).get(gid)
         why = jd.NUDGE_BLOCK_WHY          # shared constant: the briefer recognizes it as PROCEDURAL and
         #                                   writes no decision brief, rather than inventing one from <work>
-        # EVIDENCE TIME = the nudge RESPONSE turn, not wall-clock `now` (the user 2026-07-22). The block's
-        # evidence IS that response; claiming `now` made the stamp structurally outrank the user's own
-        # reply floor (_block_is_stale voids a block only when ev_t <= followupAt), so a reply could NEVER
-        # void a nudge block — the one mechanism built to stop a judge re-blocking a just-answered card.
-        _ev = int(ev_t or now)
+        # EVIDENCE TIME (_ev, hoisted above for the moot check) = the nudge RESPONSE turn, not wall-clock
+        # `now` (the user 2026-07-22). The block's evidence IS that response; claiming `now` made the stamp
+        # structurally outrank the user's own reply floor (_block_is_stale voids a block only when
+        # ev_t <= followupAt), so a reply could NEVER void a nudge block — the one mechanism built to stop
+        # a judge re-blocking a just-answered card.
         if nd is not None and jd.record_verdict(store, nd, "nudge", "block", _ev, why=why):
             nd["mt"] = _ev                            # the event materialized blocked + blockWhy
             jd.append_block(sid, gid, "nudge", why, _ev)  # journal before the save it protects: a judge
@@ -1804,6 +1828,7 @@ def _mark_nudge_failed(gid, ev_t=None):
             _mark_views_dirty()
     except Exception:
         sys.stderr.write("nudge-failed block: %s\n" % traceback.format_exc())
+    return "failed"
 
 
 def _interrupt_focus_top(store):
@@ -2806,7 +2831,9 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
             # settled), yet the goal is STILL 'working' (the per-goal status gate above). The one ask
             # didn't resolve it and we never re-ask — surface it to the human instead: stamp the record
             # so build_feed shows the "nudge failed" chip (a FORK nudge also floors to needs-you).
-            if rec and not rec.get("failed"):
+            # A `moot` record is one the judges superseded mid-flight (see _mark_nudge_failed) — settled,
+            # like `failed`, but with no chip and no block; skip it without re-running the ready gates.
+            if rec and not rec.get("failed") and not rec.get("moot"):
                 ready, resp = _nudge_response_ready(turns, store, rec, gid, now)
                 if not ready:
                     continue                           # the response hasn't arrived / hasn't been ruled /
@@ -2822,9 +2849,12 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
                 _sdefer = _revivers_pending(sid, store, turns, gid)
                 if _sdefer and not _nudge_deferred_ok(gid, _sdefer, now, sid):
                     continue                           # something else can still move it → not needs-you
-                _mark_nudge_failed(gid, ev_t=(resp or {}).get("t") or lt.get("end") or lt.get("t"))
-                nudged[gid] = dict(rec, failed=True)   # mirror in-memory for the rest of this tick
-                fired = True                           # push so the chip/floor reaches the feed now
+                _fate = _mark_nudge_failed(gid, ev_t=(resp or {}).get("t") or lt.get("end") or lt.get("t"))
+                if _fate == "failed":
+                    nudged[gid] = dict(rec, failed=True)   # mirror in-memory for the rest of this tick
+                    fired = True                           # push so the chip/floor reaches the feed now
+                elif _fate == "moot":
+                    nudged[gid] = dict(rec, moot=True)     # the judges superseded the ask — no chip, no block
             continue
         count = rec.get("count", 0) + 1
         # (the nudge-fire forensics side-log was retired with the P3.4 sweep, 2026-07-07 — the goal's
@@ -2844,7 +2874,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
         # closes the race to the file write itself. An unreadable re-read fires on the tick's snapshot,
         # as before — never silently drops the nudge.
         try:
-            to_fire = _nudge_fire_list(jd.load_goals(sid), to_fire)
+            to_fire = _nudge_fire_list(jd.load_goals(sid), to_fire, arm_t=arm.get("t") or 0)
         except Exception:
             pass
     if len(to_fire) == 1:
@@ -2874,17 +2904,29 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
     return fired
 
 
-def _nudge_fire_list(fresh, to_fire):
+def _nudge_fire_list(fresh, to_fire, arm_t=None):
     """The subset of this tick's due nudges still worth sending, judged against a FRESH store read
     (the closer-race guard — see the call site). A goal the judges moved off plain 'working' since the
     tick's snapshot — completed, blocked, cleared, or status-rolled — gets no status check: the answer
-    already landed. Pure and store-shaped for tests."""
+    already landed. Pure and store-shaped for tests.
+
+    arm_t = the ended turn the stall was armed on. A goal whose diary gained a verdict FILED after that
+    turn is also dropped, even if it reads plain 'working' now (the user 2026-07-29): the judges have
+    already ruled on evidence at least as new as the stall's, so the "it looks stalled" inference is
+    stale by construction. The audited case: a card blocked on a question, the user answered, the
+    unblocker lifted the block — and five seconds later the nudge status-checked the freshly-unblocked
+    goal off its pre-answer arm; the response turn then got cut by a restart and the failed-nudge path
+    converted the mess into a false needs-you block. The verdict's FILING (`at`; ev_t for legacy
+    entries) is the event: filed after the arm → the story moved → no fire. The next GENUINE ended
+    turn re-arms and may nudge afresh, judged against the post-verdict world."""
     nodes, status = fresh.get("nodes", {}) or {}, fresh.get("status", {}) or {}
     keep = []
     for f in to_fire:
         if f[0] not in nodes:
             continue                                 # gone from the fresh store: cleared + compacted mid-tick
         nd = nodes[f[0]]
+        if arm_t and any((e.get("at") or e.get("ev_t") or 0) > arm_t for e in nd.get("log") or []):
+            continue                                 # a verdict landed AFTER the arm — the stall read is stale
         if status.get(f[0], "working") == "working" and not nd.get("cleared") \
                 and not nd.get("nodeComplete") and not nd.get("blocked"):
             keep.append(f)
@@ -12568,28 +12610,34 @@ def build_feed(now, tmux=None):
             recheck = bool(col == "blocked" and nid != api_top and nid != perm_top
                            and nodes[nid].get("followupPending"))
             # RE-JUDGING (the user 2026-06-30; MOVED to Working 2026-07-02): a PLAIN reply on the thread
-            # AFTER the block moves the card to WORKING while the reply's turn runs — it's the agent's move
-            # now, and the delay before the card left Needs-You was the user's complaint (2026-07-02). This
-            # is NOT the old permanent sweep whose failure mode was an unrelated reply stranding a real
-            # block in Working forever (the 2026-06-30 regression): the move is EVENT-BOUNDED by the OPEN
-            # TURN (who_working). When the turn ends and the judge left the goal blocked, the flag drops and
-            # the card RETURNS to Needs-You on its own; if the judge resolved it, the store moves it out
-            # authoritatively. The "Re-judging…" swirl rides along in Working. Never the hard floors
-            # (api/permission).
+            # AFTER the block moves the card to WORKING — it's the agent's move now, and the delay before
+            # the card left Needs-You was the user's complaint (2026-07-02). The flag holds until the
+            # UNBLOCKER has re-examined the block with evidence covering the reply (blockCheckT, its
+            # persisted watermark, reaches the reply); then the card returns to Needs-You exactly once —
+            # or leaves authoritatively if the judge lifted the block. The "Re-judging…" swirl rides along
+            # in Working. Never the hard floors (api/permission).
+            #
+            # LATCHED ON THE WATERMARK, NOT THE OPEN TURN (the user 2026-07-29). The flag used to be
+            # bounded by who_working, which made a blocked card on an ACTIVE session strobe
+            # working↔needs-you at every turn boundary — the audited card flipped seven times in six
+            # minutes while nothing about it changed. The turn-bound was a proxy for "the judge hasn't
+            # ruled on the reply yet"; blockCheckT IS that event: the unblocker advances it on every
+            # examine AND on the parse give-up path, so the latch cannot stick past a judge look. This is
+            # the same trust the TARGETED-reply arm (followupPending) already places in the judge to
+            # clear its store-backed flag. Cards move on new information, never on activity boundaries.
             #
             # NO ECHO ARM (the user 2026-07-22): the flip used to ALSO ride the backend send-echo
             # (echo_send_t), for a sub-second flip before the turn's atom lands in the cached parse. But a
             # composer slash-command echo never retires — its expanded transcript form ("<command-name>…")
             # doesn't text-match the raw echo, and the parser skips it from the human floor — so the stale
             # echo pinned rejudging TRUE forever: the card sat in Working, idle, invisible to the nudge
-            # (which reads the still-blocked store). Bounding on the open turn alone is self-limiting — a
-            # cached parse cannot show who_working past a turn that ended — so it can never stick. A hair
-            # less instant on the very first push; the store-backed reopen (followupPending) still gives the
-            # instant flip for a TARGETED card reply.
+            # (which reads the still-blocked store). The latch arms only off the PARSE's plain-reply turn
+            # (a real transcript atom, never the echo), and the watermark clear is judge-driven, so the
+            # stranded-echo failure stays impossible.
             rejudging = bool(col == "blocked" and nid != api_top and nid != perm_top
                              and not nodes[nid].get("followupPending")
                              and plain_user_t > disp_t
-                             and who_working)
+                             and plain_user_t > (nodes[nid].get("blockCheckT") or 0))
             # awaiting is a flavor of WORKING → the working column (never needs-input), card time = mint t; the awaiting badge carries the why.
             # A RE-CHECK'd soft-block (targeted follow-up) drops to WORKING (the user 2026-06-27): once you've
             # replied to THAT card it's the agent's move, not yours, so it leaves the needs-input column entirely

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4372,10 +4372,13 @@ class ViewBuilder(unittest.TestCase):
         return g
 
     def test_feed_plain_reply_moves_block_to_working_while_in_flight(self):
-        # the user 2026-07-02 (who wanted it immediate): a PLAIN thread reply after a soft block moves the card
-        # to WORKING — but only WHILE the reply is in flight (open turn / just-sent echo), so an unrelated
-        # reply can never strand a real block in Working forever (the 2026-06-30 regression): when the turn
-        # ends and the judge left the goal blocked, the card RETURNS to Needs-You on its own.
+        # the user 2026-07-02 (who wanted it immediate) + 2026-07-29 (who wanted it to STOP strobing): a
+        # PLAIN thread reply after a soft block moves the card to WORKING, and it HOLDS there across turn
+        # boundaries until the UNBLOCKER has re-examined the block with evidence covering the reply
+        # (blockCheckT reaches it). The old bound — the open turn — made the card round-trip
+        # working↔needs-you at EVERY turn boundary of an active session (seven flips in six minutes on the
+        # audited card); the watermark is the event the turn-bound was approximating, so the card now
+        # returns exactly once, when the judge has actually re-considered and kept the block.
         g = self._blocked_store()
         saved_p, saved_w = km._last_plain_user_turn_t, km._session_working
         try:
@@ -4385,10 +4388,17 @@ class ViewBuilder(unittest.TestCase):
             self.assertEqual(card["column"], "working", "the reply moves the block to Working at once")
             self.assertFalse(card["recheck"], "a plain reply is not a TARGETED follow-up → recheck stays False")
             self.assertTrue(card["rejudging"], "the 'Re-judging…' swirl rides along in Working")
-            km._session_working = lambda turns: False                # turn ended, judge left it blocked
+            km._session_working = lambda turns: False                # turn ended — but the judge hasn't looked yet
             card_idle = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
-            self.assertEqual(card_idle["column"], "needs_input", "unresolved after the turn → back to Needs-You")
-            self.assertFalse(card_idle["rejudging"], "no turn in flight → no spinner (not a permanent spin)")
+            self.assertEqual(card_idle["column"], "working",
+                             "a turn boundary is not new information — the card HOLDS until the judge re-examines")
+            self.assertTrue(card_idle["rejudging"], "still pending the judge → the swirl stays")
+            g = self._blocked_store(blockCheckT=NOW - 5)             # the unblocker examined evidence PAST the reply
+            card_ruled = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
+            self.assertEqual(card_ruled["column"], "needs_input",
+                             "the judge re-examined and kept the block → back to Needs-You, exactly once")
+            self.assertFalse(card_ruled["rejudging"], "ruled → no spinner (the latch cannot stick past a judge look)")
+            g = self._blocked_store()
             km._last_plain_user_turn_t = lambda turns: NOW - 300     # a reply that PRE-dates the block
             km._session_working = lambda turns: True
             card_pre = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
@@ -4397,34 +4407,39 @@ class ViewBuilder(unittest.TestCase):
         finally:
             km._last_plain_user_turn_t, km._session_working = saved_p, saved_w
 
-    def test_feed_rejudging_ignores_a_stranded_echo_only_the_open_turn_drives_it(self):
+    def test_feed_rejudging_ignores_a_stranded_echo_and_cannot_stick_past_a_judge_look(self):
         # REGRESSION (the user 2026-07-22): rejudging used to ALSO ride the backend send-echo, moving a card
         # to Working the instant you hit send (before the turn opened). But a composer slash-command echo
         # NEVER retires — its expanded transcript form ("<command-name>/jld…") doesn't text-match the raw
         # echo, and the parser skips it from the human floor — so a stranded echo pinned the card in Working,
-        # idle, FOREVER, invisible to the nudge (which reads the still-blocked store). The flip is now bounded
-        # by the OPEN TURN alone: a cached parse can't show who_working past a turn that ended, so a stale
-        # echo can never strand it. (A hair less instant on the first push; a TARGETED card-reply still moves
-        # instantly via the store-backed followupPending reopen.)
+        # idle, FOREVER, invisible to the nudge (which reads the still-blocked store). The arm reads ONLY the
+        # PARSE's plain-reply floor (a real transcript atom, never the echo), and since 2026-07-29 the flag
+        # clears on the unblocker's watermark (blockCheckT) instead of the turn boundary — so the two
+        # stranding properties to pin are: the echo alone arms nothing, and the watermark always releases.
         g = self._blocked_store()
         km._tmux_echo.pop(SID, None)
         saved_p, saved_w = km._last_plain_user_turn_t, km._session_working
         try:
-            # a plain reply exists in the parse AFTER the block (mt NOW-100), but the session is now IDLE
-            km._last_plain_user_turn_t = lambda turns: NOW - 10
+            # NO plain reply since the block in the parse — only a stranded echo in the live tail (the
+            # slash-command case that never prunes). It must not arm the flip, working or idle.
+            km._last_plain_user_turn_t = lambda turns: NOW - 300
             km._session_working = lambda turns: False
-            # …and a stranded echo of a send is still sitting in the live tail (the slash-command case that
-            # never prunes). It must NOT resurrect the flip.
             km._tmux_echo_add(SID, "/jld go ahead, do option B", author="human")
             card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
-            self.assertFalse(card["rejudging"], "a stranded echo on an IDLE session no longer drives rejudging")
+            self.assertFalse(card["rejudging"], "a stranded echo can never arm rejudging — only a parsed reply can")
             self.assertEqual(card["column"], "needs_input",
                              "so the blocked card stays in Needs-You where the nudge sees it — never stuck in Working")
-            # the moment a turn actually opens, the plain reply legitimately moves it (the kept who_working arm)
-            km._session_working = lambda turns: True
+            # a REAL parsed reply after the block arms the latch even while idle (pending the judge)…
+            km._last_plain_user_turn_t = lambda turns: NOW - 10
             card2 = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
-            self.assertTrue(card2["rejudging"], "an OPEN turn after a plain reply still lights 'Re-judging…'")
+            self.assertTrue(card2["rejudging"], "a parsed plain reply arms the latch — idle or not, it's the judge's move")
             self.assertEqual(card2["column"], "working")
+            # …and the unblocker's watermark ALWAYS releases it — advanced on every examine and on the
+            # parse give-up path, so the 2026-07-22 stuck-in-Working failure has no revival route.
+            g = self._blocked_store(blockCheckT=NOW - 5)
+            card3 = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
+            self.assertFalse(card3["rejudging"], "the watermark passed the reply → released")
+            self.assertEqual(card3["column"], "needs_input")
         finally:
             km._tmux_echo.pop(SID, None)
             km._last_plain_user_turn_t, km._session_working = saved_p, saved_w

--- a/tests/test_nudge_moot_supersede.py
+++ b/tests/test_nudge_moot_supersede.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""A verdict filed after the nudge's evidence supersedes the nudge (the user 2026-07-29).
+
+The audited incident, all fixtures SYNTHETIC: a card sat blocked on a question ("open the PR for the
+notes-api branch, or hold it?"). The user answered in the thread; the unblocker ruled the question
+answered and lifted the block. Five seconds later the stall nudge fired anyway — its arm predated the
+answer — and its response turn was cut by a kernel restart. The failed-nudge evaluator then scored
+that cut turn as "the response didn't resolve this" and filed a needs-you block OVER the unblock,
+presenting the already-answered decision brief. The user re-answered a question they had answered
+five minutes earlier.
+
+The discipline, at both ends of the race: a verdict FILED (`at`; ev_t for legacy rows) after the
+evidence the nudge machinery is acting on means the judges have already ruled on a newer world, so
+the machinery stands down —
+- fire time: _nudge_fire_list drops a goal whose diary gained a verdict after the ARM turn, even if
+  the goal reads plain 'working' in the fresh store (the freshly-unblocked case above);
+- eval time: _mark_nudge_failed retires the record as `moot` (no failed chip, no block) when a
+  non-nudge verdict was filed after the RESPONSE turn.
+A moot record keeps the anti-loop gate (lastTurnId pins the arm), and a genuinely still-stalled goal
+re-arms on the next GENUINE ended turn, judged against the post-verdict world.
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_nudgemoot", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+G1 = SID + ":g1"
+NOW = 1781100000
+ARM_T = NOW - 600                # the ended turn the stall was armed on
+RESP_T = NOW - 120               # the nudge-response turn the evaluator scores
+
+
+def _node(nid, text, **kw):
+    d = {"id": nid, "text": text, "parentId": None, "nodeComplete": False,
+         "blocked": False, "cleared": False, "trail": [], "t": NOW - 3600, "mt": NOW - 3600, "log": []}
+    d.update(kw)
+    return d
+
+
+def _store(nodes, status=None):
+    return {"rompUuid": SID, "seq": len(nodes), "lastNode": G1, "nodes": nodes, "placements": {},
+            "status": status if status is not None else {n: "working" for n in nodes}}
+
+
+class FireListArmOrdering(unittest.TestCase):
+    """_nudge_fire_list's arm_t guard: the stall inference is stale once the judges filed anything newer."""
+
+    def test_a_verdict_filed_after_the_arm_drops_the_fire(self):
+        # the audited shape: unblocked moments ago → plain 'working' in the fresh store, but the
+        # unblock's filing postdates the arm — the "it looks stalled" read predates the answer
+        log = [{"ev_t": ARM_T, "src": "planner", "kind": "block", "why": "open the PR, or hold it?", "at": ARM_T + 5},
+               {"ev_t": ARM_T, "src": "unblocker", "kind": "unblock", "why": "answered in the thread", "at": ARM_T + 300}]
+        fresh = _store({G1: _node(G1, "ship the notes-api", log=log)})
+        self.assertEqual(km._nudge_fire_list(fresh, [(G1, 1, False)], arm_t=ARM_T), [],
+                         "the judges ruled after the arm — the status check would ask about a moved story")
+
+    def test_old_history_before_the_arm_still_fires(self):
+        log = [{"ev_t": ARM_T - 900, "src": "planner", "kind": "block", "why": "?", "at": ARM_T - 890},
+               {"ev_t": ARM_T - 800, "src": "unblocker", "kind": "unblock", "why": "answered", "at": ARM_T - 790}]
+        fresh = _store({G1: _node(G1, "ship the notes-api", log=log)})
+        self.assertEqual([f[0] for f in km._nudge_fire_list(fresh, [(G1, 1, False)], arm_t=ARM_T)], [G1],
+                         "a diary that predates the arm is exactly the stalled case — the nudge stands")
+
+    def test_a_legacy_row_without_at_falls_back_to_ev_t(self):
+        log = [{"ev_t": ARM_T + 60, "src": "closer", "kind": "block", "why": "?"}]   # no `at` (older writer)
+        fresh = _store({G1: _node(G1, "ship the notes-api", log=log)})
+        self.assertEqual(km._nudge_fire_list(fresh, [(G1, 1, False)], arm_t=ARM_T), [])
+
+    def test_no_arm_t_keeps_the_old_contract(self):
+        log = [{"ev_t": ARM_T + 60, "src": "unblocker", "kind": "unblock", "why": "answered", "at": ARM_T + 70}]
+        fresh = _store({G1: _node(G1, "ship the notes-api", log=log)})
+        self.assertEqual([f[0] for f in km._nudge_fire_list(fresh, [(G1, 1, False)])], [G1],
+                         "callers that pass no arm turn get the pre-guard behavior unchanged")
+
+
+class NudgeFailedMootWhenSuperseded(unittest.TestCase):
+    """_mark_nudge_failed retires (moot) instead of blocking when the diary moved past the response."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        # patch the KERNEL's own jd instance (km imports its own copy; a separately-loaded jd is a
+        # different module object and the kernel would keep reading the live state dirs)
+        self._saved = (km.jd.STATE, km.jd.GOALDIR, km._session_awaiting, km._path_of)
+        km.jd.STATE = td
+        km.jd.GOALDIR = td / "goals"
+        km.jd.GOALDIR.mkdir(parents=True)
+        km._autonudge_cache.clear()
+        km._session_awaiting = lambda sid, path, idle, stamp=False: None
+        km._path_of = lambda sid, now=None: "/nonexistent"
+        (td / "auto-nudge.json").write_text(json.dumps(
+            {"enabled": True, "nudged": {G1: {"count": 1, "lastTurnId": "t1", "at": RESP_T - 5}}}))
+
+    def tearDown(self):
+        km.jd.STATE, km.jd.GOALDIR, km._session_awaiting, km._path_of = self._saved
+        km._autonudge_cache.clear()
+        self.td.cleanup()
+
+    def _write_store(self, log):
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            _store({G1: _node(G1, "ship the notes-api", log=log)})))
+
+    def test_a_later_unblock_retires_the_record_instead_of_blocking(self):
+        # the audited shape: the unblocker ruled "answered" AFTER the response turn the evaluator
+        # is scoring — filing "the response didn't resolve this" would contradict the diary and
+        # resurface the answered brief
+        self._write_store([{"ev_t": RESP_T - 60, "src": "planner", "kind": "block", "why": "?", "at": RESP_T - 50},
+                           {"ev_t": RESP_T - 10, "src": "unblocker", "kind": "unblock",
+                            "why": "answered in the thread", "at": RESP_T + 30}])
+        self.assertEqual(km._mark_nudge_failed(G1, ev_t=RESP_T), "moot")
+        store = km.jd.load_goals(SID)
+        self.assertFalse(store["nodes"][G1]["blocked"],
+                         "no procedural block over a diary that says the question was answered")
+        rec = km._auto_nudge_data()["nudged"][G1]
+        self.assertFalse(rec.get("failed"), "no 'nudge failed' chip either — the ask was superseded, not ignored")
+        self.assertTrue(rec.get("moot"), "the episode is retired durably — the anti-loop arm stays pinned")
+
+    def test_a_diary_that_did_not_move_still_blocks(self):
+        self._write_store([{"ev_t": RESP_T - 300, "src": "planner", "kind": "block", "why": "?", "at": RESP_T - 290},
+                           {"ev_t": RESP_T - 200, "src": "unblocker", "kind": "unblock", "why": "answered",
+                            "at": RESP_T - 190}])
+        self.assertEqual(km._mark_nudge_failed(G1, ev_t=RESP_T), "failed")
+        store = km.jd.load_goals(SID)
+        self.assertTrue(store["nodes"][G1]["blocked"], "the genuine failed-nudge → block behavior stands")
+        self.assertTrue(km._auto_nudge_data()["nudged"][G1].get("failed"))
+
+    def test_a_nudge_row_after_the_response_does_not_moot(self):
+        # only REAL judges supersede; the machinery's own rows never gag its own escalation
+        self._write_store([{"ev_t": RESP_T + 5, "src": "nudge", "kind": "block",
+                            "why": "procedural", "at": RESP_T + 10}])
+        self.assertEqual(km._mark_nudge_failed(G1, ev_t=RESP_T), "failed")
+
+    def test_a_moot_record_is_settled_and_never_reevaluated(self):
+        self._write_store([{"ev_t": RESP_T - 10, "src": "unblocker", "kind": "unblock",
+                            "why": "answered", "at": RESP_T + 30}])
+        self.assertEqual(km._mark_nudge_failed(G1, ev_t=RESP_T), "moot")
+        self.assertIsNone(km._mark_nudge_failed(G1, ev_t=RESP_T),
+                          "a settled (moot) episode is skipped exactly like a failed one")
+        store = km.jd.load_goals(SID)
+        self.assertFalse(store["nodes"][G1]["blocked"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The audit

A card the user replied to kept jumping into Working and back. Its client-diag trail shows **nine authoritative column flips in eight minutes** — of which two were real state changes and seven were the same inference re-derived per build, plus one mechanism contradicting a verdict already on file:

| flips | cause |
|---|---|
| 7 | `rejudging` (blocked + plain reply + **open turn**) toggling at every turn boundary of an active session |
| 1 | the unblocker's "answered in passing" lift — legitimate, new information |
| 1 | the stall nudge filing a needs-you block over that unblock, off a response turn a kernel restart had cut |

The nudge chain in detail: the card was blocked on a question → the user answered in the thread → the unblocker ruled it answered → **five seconds later** the nudge fired anyway (its arm predated the answer) → the response turn was interrupted + cut by a restart → the evaluator scored it "the response didn't resolve this" and filed a block presenting the already-answered brief. The user was re-asked a question they'd answered five minutes earlier.

## The fixes

**The seven.** `rejudging` now latches on the unblocker's `blockCheckT` watermark instead of `who_working`. The turn-bound was a proxy for "the judge hasn't ruled on the reply yet"; the watermark *is* that event — advanced on every examine and on the parse give-up path, so the latch cannot stick past a judge look (the same trust `followupPending` already places in the judge). The card drops to Working at the reply and returns to Needs-You **exactly once**, when the block has actually been re-considered and kept. The 2026-07-22 stranded-echo regression stays impossible: the arm reads only the parse's plain-reply floor, and the watermark always releases.

**The one.** Both ends of the nudge race now yield to the diary:
- `_nudge_fire_list` gains an `arm_t` guard — a goal whose diary gained a verdict **filed** after the arm turn is dropped even if it reads plain `working` in the fresh store (the freshly-unblocked case).
- `_mark_nudge_failed` retires the record as `moot` (no chip, no block, anti-loop pin kept) when a non-nudge verdict was filed after the response turn. A genuinely still-stalled goal re-arms on the next genuine ended turn.

## The principle, recorded

New Design-section entry in `CLAUDE.md`: **Cards move on new information, never on inference flaps** — transient states latch until the deciding event; a writer whose evidence predates the diary stands down; any new column-moving mechanism must name the exact event that justifies the move.

## Tests

- `tests/test_nudge_moot_supersede.py` (new, 8 cases, synthetic fixtures) — both guards, the legacy `ev_t` fallback, the anti-gag rule (a nudge's own rows never moot it), and the settled-moot skip.
- `tests/test_kernel.py` — the two rejudging tests rewritten to pin the latch story: holds across turn boundaries, releases exactly once on the watermark, echo can never arm it.
- **9 of the tests fail on `main`**, so they capture the bugs, not the fix.

Suites: 3673 Python passed / 25 skipped, 1482 node passed, both run since node tests pin kernel source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)