### PR TITLE
Drift reads as git's own arrows

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16436,8 +16436,11 @@ function busyStatus(s){return s!=='up'&&s!=='down'&&s!=='error'&&s!=='no-kernel'
 // spellings of the same drift would eventually disagree, and the number is the whole point of it.
 function driftWord(t){var bb=t.behindBy,ab=t.aheadBy;
 if(typeof bb!=='number'||typeof ab!=='number')return 'different build';
-return (bb>0&&ab>0)?'diverged':(ab>0)?'ahead '+ab+' commit'+(ab===1?'':'s')
-:(bb>0)?'behind '+bb+' commit'+(bb===1?'':'s'):'different build';}   // mid-attach (authorizing/connecting); no-kernel is SETTLED (no marching dashes)
+// git's own shorthand (the user 2026-07-29): the counts read at a glance as arrows, and a diverged host
+// shows BOTH rather than collapsing to one word that hides how much is on each side.
+var up=ab>0?('\\u2191'+ab):'',down=bb>0?('\\u2193'+bb):'';
+if(up&&down)return 'diverged '+up+' '+down;
+return up||down||'different build';}   // mid-attach (authorizing/connecting); no-kernel is SETTLED (no marching dashes)
 // the mobile bottom bar's Net button mirrors the rail icon's connected/busy classes (it shows the same glyph)
 function mnet(){return document.querySelector('#mtabs .mact[data-act=net]');}
 // One host's contribution to the glyph (the user 2026-07-29): 'ok' connected and on this build, 'warn'

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -132,8 +132,8 @@ class PaneRailTest(unittest.TestCase):
         # host (the user 2026-07-29). ONE definition of the wording, worn by the panel row and the
         # tooltip alike — two spellings of the same drift would eventually disagree.
         self.assertIn("function driftWord(t){", self.html)
-        self.assertIn("'behind '+bb+' commit'", self.html)
-        self.assertIn("'ahead '+ab+' commit'", self.html)
+        self.assertIn("down=bb>0?(", self.html)   # git-style arrows since 2026-07-29
+        self.assertIn("up=ab>0?(", self.html)
         self.assertIn("var dw=t.outOfDate?(' \\u00b7 '+(t.status==='up'?'':'last known ')+driftWord(t)):''", self.html)
         self.assertIn("+dw+", self.html, "the per-host tooltip line carries it")
         # the panel row reads the same function rather than re-deriving the words

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -399,8 +399,8 @@ class DriftWordingUI(unittest.TestCase):
 
     def test_row_names_how_the_remote_differs(self):
         js = km._LANDING_REMOTES_JS
-        self.assertIn("'behind '+bb+' commit'", js)
-        self.assertIn("'ahead '+ab+' commit'", js)
+        self.assertIn("down=bb>0?(", js)   # git-style arrows since 2026-07-29
+        self.assertIn("up=ab>0?(", js)
         self.assertIn("'diverged'", js)
         self.assertIn("'different build'", js, "an unknown sha says so instead of guessing")
 

--- a/tests/test_remotes_panel_render.py
+++ b/tests/test_remotes_panel_render.py
@@ -171,7 +171,7 @@ class RemotesPanelRender(unittest.TestCase):
     # ---- remembered vs live (the user 2026-07-28) -------------------------------------------------
     # kernelSha, the drift counts and the peer's mail tier are all answers from the LAST SUCCESSFUL
     # poll — only an `up` row is polled. The panel drew them as current regardless, so a row could say
-    # "disconnected" and "behind 2 commits" and name the peer's mail tier all at once: three claims,
+    # "disconnected" and a drift count and name the peer's mail tier all at once: three claims,
     # two of which it had no way to know. The values stay (a blank row is worse); they must be MARKED.
 
     def _drifted(self, status="up", stale=False, last_ok=0, tiers=None):
@@ -187,7 +187,7 @@ class RemotesPanelRender(unittest.TestCase):
         # The control: an `up` row DID just poll, so its drift is fact and wears no hedge.
         out = self._run(tunnels=self._drifted(status="up", stale=False))
         html = out.get("html", "")
-        self.assertIn("behind 2 commits", html)
+        self.assertIn("\u21932", html)   # git-style arrows (2026-07-29)
         self.assertNotIn("last known", html)
         self.assertNotIn("rnet-stale", html)
 
@@ -195,7 +195,7 @@ class RemotesPanelRender(unittest.TestCase):
         out = self._run(tunnels=self._drifted(status="down", stale=True, last_ok=1785272930))
         html = out.get("html", "")
         self.assertIn("disconnected", html, "the row still reports its live state")
-        self.assertIn("last known: behind 2 commits", html,
+        self.assertIn("last known: \u21932", html,
                       "a drift count from an unreachable host must read as memory, not as a finding")
         self.assertIn("rnet-stale", html, "and must carry the muted cue that overrides the accent")
         self.assertIn("last confirmed", html, "hover says WHEN it was true (progressive disclosure)")


### PR DESCRIPTION
`behind 3 commits` / `ahead 2 commits` / `diverged` becomes the shorthand you already read in git: `↓3`, `↑2`, and a diverged host shows **both** (`diverged ↑2 ↓3`) instead of collapsing to one word that hides how much sits on each side.

One definition, so the panel row and the rail tooltip can't disagree (`driftWord`, shared since #121). `different build` is unchanged for a remote whose sha this repo has never seen, since there is no count to show there.

Python suite green (3673). Kernel-inline, so it needs a kernel restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)