### PR TITLE
The chat page holds up on a phone, and the stacked feed leads with Completed

### DIFF
--- a/tests/test_shell_mobile_composer_pad.py
+++ b/tests/test_shell_mobile_composer_pad.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
-"""The mobile shell's composer padding is load-bearing for the send button's position (2026-07-29).
+"""The composer buttons no longer couple to the mobile shell's padding (2026-07-30).
 
-The Send and Attach buttons are absolutely positioned inside #composer, so their `right` offsets are
-measured from ITS padding edge. The kernel's mobile CSS narrows that padding from 24px to 10px, and
-styles.css carries a second set of offsets under the SAME media query to match. Change the padding here
-and the buttons move relative to the box they are supposed to sit inside — which is exactly the class of
-breakage this pins, since the two live in different files and the coupling is otherwise invisible.
+From 2026-07-29 to 2026-07-30 the Send and Attach buttons were absolutely positioned inside #composer,
+with `right` offsets measured from its padding edge — and the kernel's mobile CSS narrows that padding
+from 24px to 10px, so styles.css carried a second offset set under a matching media query. Two files had
+to move in lockstep for the buttons to land inside the box at all.
 
-(A landscape iPad is a coarse pointer WIDER than 1024, so it keeps the desktop padding: that is why the
-query carries a max-width at all, and why the offsets cannot simply live in the coarse block.)
+The Signal-style compose row dissolved that: the buttons are in-flow flex items now, so the kernel's
+padding override is just padding again. This pins the DISSOLUTION — the kernel side still narrows the
+padding for phones, and no absolutely-positioned button offsets may sneak back into styles.css, because
+nothing would keep them aligned with the kernel's padding this time either.
 """
 import os
 import re
@@ -26,39 +27,21 @@ STYLES = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "styles.css")
 
 
 class MobileComposerPadding(unittest.TestCase):
-    def test_the_mobile_shell_narrows_the_composer_padding_to_10px(self):
+    def test_the_mobile_shell_still_narrows_the_composer_padding_to_10px(self):
         self.assertIn("#composer{padding:8px 10px 6px}", km._CHAT_MOBILE_CSS)
 
     def test_it_is_scoped_to_coarse_pointers_up_to_1024px(self):
         self.assertIn("@media (pointer:coarse) and (max-width:1024px)", km._CHAT_MOBILE_CSS)
 
-    def test_the_button_offsets_carry_a_matching_query(self):
-        self.assertIn("@media (pointer: coarse) and (max-width: 1024px) {", STYLES)
-        block = STYLES.split("@media (pointer: coarse) and (max-width: 1024px) {")[1].split("}")[0]
-        self.assertIn("right: 14px", block, "send sits 4px inside the narrowed 10px padding")
+    def test_no_absolute_button_offsets_may_return(self):
+        """In-flow flex items need no offsets; an offset would re-create the two-file coupling."""
+        self.assertIsNone(re.search(r"#composer-(send|attach)[^{]*\{[^}]*\bright:", STYLES))
+        self.assertIsNone(re.search(r"#composer-(send|attach)[^{]*\{[^}]*position: absolute", STYLES))
 
-    def test_the_offsets_keep_both_buttons_inside_the_box_at_both_paddings(self):
-        """Arithmetic, so a future nudge to one number cannot quietly overlap the two buttons."""
-        def px(pattern, where=STYLES):
-            m = re.search(pattern, where)
-            self.assertIsNotNone(m, "missing rule: %s" % pattern)
-            return int(m.group(1))
-
-        coarse = STYLES[STYLES.index("/* TOUCH (the user 2026-07-29"):]
-        narrow = STYLES.split("@media (pointer: coarse) and (max-width: 1024px) {")[1].split("\n}")[0]
-        send_w = px(r"#composer-send \{ right: 28px; width: (\d+)px", coarse)
-        att_w = px(r"#composer-attach \{ right: 136px; width: (\d+)px", coarse)
-        for label, send_right, att_right, pad in (
-                ("wide (iPad landscape, 24px padding)", 28, 136, 24),
-                ("narrow (mobile shell, 10px padding)", px(r"#composer-send \{ right: (\d+)px; \}", narrow),
-                 px(r"#composer-attach \{ right: (\d+)px; \}", narrow), 10)):
-            with self.subTest(label):
-                self.assertGreaterEqual(send_right, pad, "send would hang outside the box's right edge")
-                self.assertGreaterEqual(att_right, send_right + send_w,
-                                        "the paperclip would overlap the send button")
-                self.assertGreaterEqual(att_right, pad)
-                # and neither is so far left that it lands under the text's own inset
-                self.assertLess(att_right + att_w, 400, "the pair would eat a phone's whole box width")
+    def test_the_buttons_are_in_flow_flex_circles(self):
+        self.assertIn(
+            "#composer-attach, #composer-send {\n"
+            "  flex: 0 0 auto; width: 34px; height: 34px; border-radius: 50%;", STYLES)
 
 
 if __name__ == "__main__":

--- a/ui/webview/ask-option-wrap.test.ts
+++ b/ui/webview/ask-option-wrap.test.ts
@@ -1,0 +1,43 @@
+// AskUserQuestion option rows must survive a narrow screen (the user 2026-07-30, on a phone). Every row
+// was a flex line of [mark] [label] [description] with a RIGID label (flex: 0 0 auto): a label wider than
+// the card pushed past its right edge, and the description, squeezed to its one-character min width
+// BEYOND the label, wrapped a letter per line — the answered card rendered as a clipped option above a
+// screen-tall stretch of blank box.
+//
+// Two treatments, because flex can't wrap text BESIDE a sibling (a flex line breaks before a too-wide
+// item, orphaning the mark on a line of its own):
+//  - the ANSWERED transcript row (.ask-opt: mark + label + desc) is INLINE with a hanging indent — the
+//    mark hangs in the indent, the label wraps beside it like prose, the description takes its own line;
+//  - the LIVE picker rows (.ask-live-opt / .ask-check: no mark glyph) stay flex but WRAP, with labels
+//    allowed to shrink and break.
+// Source-level pin (no jsdom for the chat renderer).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("the answered row is inline with a hanging indent — the mark can never be orphaned", () => {
+  assert.match(CSS, /\.ask-opt \{ display: block; padding: 2px 0 2px 18px;/);
+  assert.match(CSS, /\.ask-opt \.ask-mark \{ display: inline-block; width: 18px; margin-left: -18px;/);
+  // the description and a free-text "Other" answer each take their own line under the label
+  assert.match(CSS, /\.ask-opt \.ask-optdesc \{ display: block; \}/);
+  assert.match(CSS, /\.ask-answer-text \{ display: block;/);
+});
+
+test("option labels may shrink and wrap instead of overflowing the card", () => {
+  // overflow-wrap breaks a long unspaced label (a path, a flag) rather than letting it push out of the
+  // card; the flex props serve the live rows, and are inert in the inline answered row
+  assert.match(CSS, /\.ask-optlabel \{ flex: 0 1 auto; min-width: 0; overflow-wrap: anywhere; \}/);
+  assert.match(CSS, /\.ask-live-opt \.ask-optlabel \{ flex: 0 1 auto; min-width: 0; overflow-wrap: anywhere; font-weight: 600; \}/);
+  assert.match(CSS, /\.ask-check \.ask-optlabel \{ flex: 0 1 auto; min-width: 0; overflow-wrap: anywhere; font-weight: 600; \}/);
+});
+
+test("the live picker rows wrap, and a description claims a readable column or a full line — never a sliver", () => {
+  assert.match(CSS, /\.ask-live-opt \{\s*\n\s*display: flex; flex-wrap: wrap;/);
+  assert.match(CSS, /\.ask-check \{ display: flex; flex-wrap: wrap;/);
+  // flex-basis 14em is the narrowest column worth reading beside the label; when even that doesn't fit,
+  // flex-wrap drops the description to its own line at full card width
+  assert.match(CSS, /\.ask-optdesc \{[^}]*flex: 1 1 14em; min-width: 0; \}/);
+});

--- a/ui/webview/composer-buttons.test.ts
+++ b/ui/webview/composer-buttons.test.ts
@@ -1,62 +1,50 @@
-// Send and Attach are sized to be hit (the user 2026-07-29, on an iPad). They were 26px squares tucked
-// in the corner of the message box: passable with a mouse, a poor target for a thumb, and on a touch
-// layout — where the resting box is already two lines tall — they read as a stray row under the
-// placeholder rather than as the pane's controls.
+// The composer is a Signal-style compose ROW (the user 2026-07-30): paperclip on the left, a pill input
+// growing in the middle, a round send on the right. The two buttons are the SAME circle — the previous
+// layout gave send double the paperclip's width on touch, which read as a bar, not the round send every
+// messenger app puts there — and both are in-flow flex items, not corner overlays, so no offset
+// arithmetic couples them to #composer's padding any more (that coupling once spanned two files; see
+// tests/test_shell_mobile_composer_pad.py for the tombstone on the kernel end).
 //
-// Send is the primary action of the whole chat, so it gets real width instead of matching the paperclip
-// beside it, and on a coarse pointer both become a 44px row along the bottom of the box with the text
-// running full width above them.
-//
-// The offsets are measured from #composer, so they depend on ITS padding — which the kernel's mobile
-// shell narrows from 24px to 10px. That coupling is what the paired media queries below are about, and
-// tests/test_shell_mobile_composer_pad.py pins the kernel end of it.
+// Flex `order` does the placement so the markup both surfaces share (input before the buttons) needn't
+// change: chips row 0 (full-width), attach 1, input 2, send 3.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
-const coarse = CSS.slice(CSS.indexOf("/* TOUCH (the user 2026-07-29"));
+const coarse = CSS.slice(CSS.indexOf("/* TOUCH (the user 2026-07-30"));
 
-test("the old 26px squares are gone", () => {
-  assert.doesNotMatch(CSS, /#composer-attach, #composer-send \{[^}]*width: 26px; height: 26px/);
-  assert.match(CSS, /#composer-attach, #composer-send \{ bottom: 10px; height: 30px; \}/);
+test("the composer is a flex row with the buttons seated at the bottom", () => {
+  assert.match(CSS, /#composer \{[^}]*display: flex; flex-wrap: wrap; align-items: flex-end; gap: 8px;/);
+  // the citation chip strip keeps a full-width row of its own above the compose row
+  assert.match(CSS, /#composer-chips \{ flex: 1 1 100%;/);
 });
 
-test("send is the wider control in the corner, and the two sit FLUSH", () => {
-  assert.match(CSS, /#composer-send \{ right: 26px; width: 36px; font-size: 16px; \}/);
-  assert.match(CSS, /#composer-attach \{ right: 62px; width: 32px; font-size: 16px; \}/);
-  assert.match(CSS, /#composer-input \{ padding-right: 78px; \}/);
+test("flex order puts the paperclip LEFT of the input and send on its right", () => {
+  assert.match(CSS, /#composer-attach \{ color: var\(--accent\); opacity: 0\.8; order: 1; \}/);
+  assert.match(CSS, /#composer-input \{\s*\n\s*order: 2; flex: 1 1 auto; min-width: 0;/);
+  assert.match(CSS, /#composer-send \{ order: 3; \}/);
 });
 
-// The gap that MATTERS is between the drawn glyphs, not the boxes (the user 2026-07-29, round 2: on a
-// desktop the pair looked "goofy", far apart). A wide button centres a small glyph, so it contributes
-// half its slack to the visible gap on each side: at 46px wide with 8px between the boxes the arrow and
-// the paperclip sat 33px apart, which reads as two unrelated controls. Flush boxes and a narrower send
-// bring that to 19px, measured in a browser — and they can only stay flush if the arithmetic holds.
-test("the boxes are adjacent by arithmetic, so the glyphs read as one pair", () => {
-  const num = (re: RegExp) => {
-    const m = CSS.match(re);
-    assert.ok(m, `missing rule: ${re}`);
-    return Number(m![1]);
-  };
-  const sendRight = num(/#composer-send \{ right: (\d+)px/);
-  const sendWidth = num(/#composer-send \{ right: \d+px; width: (\d+)px/);
-  const attachRight = num(/#composer-attach \{ right: (\d+)px/);
-  assert.equal(sendRight + sendWidth, attachRight,
-    "a gap here is doubled by each button's own centring slack — keep them touching");
-  // and the text's inset clears the pair with a little air
-  const pad = num(/#composer-input \{ padding-right: (\d+)px; \}/);
-  const attachWidth = num(/#composer-attach \{ right: \d+px; width: (\d+)px/);
-  assert.ok(pad >= attachRight + attachWidth - 24 + 4,
-    `padding-right ${pad} must clear the pair (offsets are from #composer, 24px outside the box)`);
+test("the two buttons are the SAME circle — equal aspect ratio, by arithmetic", () => {
+  const m = CSS.match(/#composer-attach, #composer-send \{\s*\n\s*flex: 0 0 auto; width: (\d+)px; height: (\d+)px; border-radius: 50%;/);
+  assert.ok(m, "the shared sizing rule is missing");
+  assert.equal(m![1], m![2], "width must equal height — a circle, not a bar");
 });
 
-test("a coarse pointer gets a 44px row: the tap target a finger expects", () => {
-  assert.match(coarse, /#composer-attach, #composer-send \{ bottom: 12px; height: 44px; border-radius: 8px; \}/);
-  assert.match(coarse, /#composer-send \{ right: 28px; width: 96px; font-size: 21px; \}/);
-  assert.match(coarse, /#composer-attach \{ right: 136px; width: 60px; font-size: 19px; \}/);
-  // 28 + 96 = 124, so 136 clears the send button by 12px
+test("the corner-overlay geometry is gone for good", () => {
+  // no absolute offsets, no per-button widths: reintroducing either resurrects the padding coupling
+  assert.doesNotMatch(CSS, /#composer-(send|attach) \{ right: \d+px/);
+  assert.doesNotMatch(CSS, /#composer-(send|attach)[^{]*\{[^}]*position: absolute/);
+  assert.doesNotMatch(CSS, /#composer-input \{ padding-right: \d+px; \}/);
+});
+
+test("a coarse pointer gets 44px circles: the tap target a finger expects, still 1:1", () => {
+  assert.match(coarse, /#composer-attach, #composer-send \{ width: 44px; height: 44px; \}/);
+  // and the resting box is ONE line — the pill — not the old two-line floor
+  assert.match(coarse, /#composer-input \{ min-height: 40px; border-radius: 20px; padding: 10px 14px; \}/);
+  assert.doesNotMatch(CSS, /min-height: calc\(2\.8em/);
 });
 
 test("on touch, send wears the accent as a FILL and the glyph flips to the on-accent colour", () => {
@@ -67,18 +55,10 @@ test("on touch, send wears the accent as a FILL and the glyph flips to the on-ac
 });
 
 test("disabled is a muted fill, not a ghost", () => {
-  // 0.3 opacity on a 96px button reads as a rendering fault rather than a disabled control
+  // 0.3 opacity on a filled 44px circle reads as a rendering fault rather than a disabled control
   assert.match(coarse, /#composer-send:disabled \{ background: rgba\(255, 255, 255, 0\.10\); color: var\(--dim\); opacity: 1; \}/);
 });
 
-test("on touch the text runs full width, with the button row's height reserved under it", () => {
-  assert.match(coarse, /#composer-input \{ padding-right: 12px; padding-bottom: 62px; min-height: calc\(2\.8em \+ 62px\); \}/);
-});
-
-test("the narrow offsets are matched to the query that narrows #composer's padding", () => {
-  // A landscape iPad is coarse but WIDER than 1024, so it keeps desktop padding. Phone offsets applied
-  // there would hang both buttons outside the box — hence the second, narrower query rather than
-  // folding these into the coarse block above.
-  assert.match(CSS, /@media \(pointer: coarse\) and \(max-width: 1024px\) \{\s*\n\s*#composer-send \{ right: 14px; \}\s*\n\s*#composer-attach \{ right: 122px; \}/);
-  // 14 + 96 = 110, so 122 clears send by 12px at the narrow padding too
+test("the input is a pill on desktop too", () => {
+  assert.match(CSS, /border-radius: 18px; padding: 8px 14px;/);
 });

--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -15,7 +15,8 @@ const SKELETON = fs.readFileSync(path.resolve(process.cwd(), "src", "page-skelet
 
 test("the composer has a chip strip above the textarea", () => {
   assert.match(SKELETON, /<div id="composer-chips" style="display:none"><\/div><textarea id="composer-input"/);
-  assert.match(CSS, /#composer-chips \{ display: flex/);
+  // flex: 1 1 100% claims a full-width row of its own above the Signal-style compose row (2026-07-30)
+  assert.match(CSS, /#composer-chips \{ flex: 1 1 100%; display: flex/);
   assert.match(CSS, /\.composer-chip \{/);
 });
 

--- a/ui/webview/composer-send.test.ts
+++ b/ui/webview/composer-send.test.ts
@@ -33,13 +33,17 @@ test("on a phone (coarse pointer) Enter is a newline, not send — the Send butt
   assert.match(RENDER, /function isCoarsePointer\(\)/);
   assert.match(RENDER, /matchMedia\("\(pointer:coarse\)"\)\.matches/);
   assert.match(RENDER, /e\.key === "Enter" && !e\.shiftKey && !isCoarsePointer\(\)/);
-  // the resting placeholder drops the ⏎/⇧⏎ hint on mobile (it's wrong there and clipped the one-line box)
+  // the resting placeholder drops every hint on mobile (⏎/⇧⏎ is wrong there, and even the "/" hint
+  // wrapped and clipped the one-line pill)
   assert.match(RENDER, /function composerRestingPlaceholder\(\)/);
-  assert.match(RENDER, /isCoarsePointer\(\)\s*\?\s*"Message this session…  \(type \/ for commands\)"/);
+  assert.match(RENDER, /isCoarsePointer\(\)\s*\?\s*"Message this session…"/);
 });
 
-test("the empty composer floors at two lines on a phone so the wrapped resting placeholder isn't clipped (the user 2026-07-15)", () => {
-  assert.match(CSS, /@media \(pointer: coarse\) \{\s*#composer-input \{ min-height: calc\(2\.8em \+ 18px\); \}/);
+test("on a phone the resting box is ONE line — the Signal-style pill — with a placeholder that fits it (the user 2026-07-30)", () => {
+  // the old two-line floor existed only to show a wrapped placeholder; the placeholder is short now, so
+  // the floor is gone and the empty composer rests as a single-line pill between the two circles
+  assert.doesNotMatch(CSS, /min-height: calc\(2\.8em/);
+  assert.match(CSS, /@media \(pointer: coarse\) \{[\s\S]*?#composer-input \{ min-height: 40px;/);
 });
 
 test("⏎ jumps focus to the tab bar after sending so ←/→ switch sessions (the user 2026-06-25)", () => {
@@ -60,20 +64,18 @@ test("the send button is disabled on a closed (read-only) session", () => {
   assert.match(RENDER, /if \(sendBtn\) sendBtn\.disabled = closed/);
 });
 
-test("the send button is styled to the right of 📎 and the textarea reserves room for both", () => {
-  // resized 2026-07-29 (send is the primary action, so it is the wider of the two); the touch layout and
-  // the arithmetic that keeps the pair inside the box live in composer-buttons.test.ts
-  assert.match(CSS, /#composer-send \{ right: 26px; width: 36px/);
-  assert.match(CSS, /#composer-attach \{ right: 62px; width: 32px/);
-  assert.match(CSS, /#composer-input \{[\s\S]*padding: 8px 64px 8px 10px/);
-  assert.match(CSS, /#composer-input \{ padding-right: 78px; \}/, "…widened for the bigger pair");
+test("send sits on the input's right, the paperclip on its left — flex order, not offsets", () => {
+  // re-laid 2026-07-30 as the Signal-style compose row; the circle sizing and the touch layout live in
+  // composer-buttons.test.ts
+  assert.match(CSS, /#composer-attach \{ color: var\(--accent\); opacity: 0\.8; order: 1; \}/);
+  assert.match(CSS, /#composer-send \{ order: 3; \}/);
 });
 
 test("the composer sits tight to the bottom — no wasted gap below it (the user 2026-06-23)", () => {
-  // the bottom padding was trimmed 12px → 6px so the box hugs the pane's bottom; the 📎/send buttons drop
-  // 18px → 12px in step so they stay vertically centred on the one-line textarea.
+  // the bottom padding was trimmed 12px → 6px so the box hugs the pane's bottom; the buttons ride the
+  // row's bottom edge by flex (align-items: flex-end), with no offsets to keep in step any more.
   assert.match(CSS, /#composer \{[^}]*padding: 8px 24px 6px;/);
-  assert.match(CSS, /#composer-attach, #composer-send \{[\s\S]*bottom: 12px;/);
+  assert.match(CSS, /#composer \{[^}]*align-items: flex-end;/);
 });
 
 test("focusing a tab (after ⏎-send) draws NO white UA focus ring around its colored border (the user 2026-06-25)", () => {

--- a/ui/webview/feed-foot.test.ts
+++ b/ui/webview/feed-foot.test.ts
@@ -31,11 +31,12 @@ test("the docked footer leaves the list a proper scroll container with no float 
   assert.match(CSS, /#feed-list \{[^}]*padding: 12px;/);          // no reserved band for a float anymore
 });
 
-test("when the feed stacks (narrow), the columns read Blocked → Completed → Working (the user 2026-07-08)", () => {
+test("when the feed stacks (narrow), the columns read Completed → Blocked → Working (the user 2026-07-30)", () => {
   // the side-by-side DOM order stays Working/Blocked/Completed; a container query stacks them and `order`
-  // re-sequences ONLY the stacked case: needs-you first, then done, then still-running.
+  // re-sequences ONLY the stacked case: done first (moved up from the middle, superseding the 2026-07-08
+  // Blocked-first order), then needs-you, then still-running.
   assert.match(CSS, /@container \(max-width: 540px\) \{[\s\S]*?\.feed-cols \{ flex-direction: column; \}/);
-  assert.match(CSS, /\.feed-col\.col-needsInput \{ order: 1; \}/);
-  assert.match(CSS, /\.feed-col\.col-completed\s+\{ order: 2; \}/);
+  assert.match(CSS, /\.feed-col\.col-completed\s+\{ order: 1; \}/);
+  assert.match(CSS, /\.feed-col\.col-needsInput \{ order: 2; \}/);
   assert.match(CSS, /\.feed-col\.col-asks\s+\{ order: 3; \}/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -144,11 +144,12 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    sit side by side — prevents thin columns that break words mid-word ("Shippe/d") */
 @container (max-width: 540px) {
   .feed-cols { flex-direction: column; }
-  /* stacked, the columns read TOP-DOWN as Blocked (needs you) → Completed → Working (the user 2026-07-08):
-     what needs you first, then what's done, then what's still running. DOM order stays Working/Blocked/
-     Completed (unchanged for the side-by-side layout); `order` only re-sequences the stacked case. */
-  .feed-col.col-needsInput { order: 1; }
-  .feed-col.col-completed  { order: 2; }
+  /* stacked, the columns read TOP-DOWN as Completed → Blocked (needs you) → Working (the user 2026-07-30,
+     moving Completed up from the middle; supersedes the 2026-07-08 Blocked-first order): what finished
+     first, then what needs you, then what's still running. DOM order stays Working/Blocked/Completed
+     (unchanged for the side-by-side layout); `order` only re-sequences the stacked case. */
+  .feed-col.col-completed  { order: 1; }
+  .feed-col.col-needsInput { order: 2; }
   .feed-col.col-asks       { order: 3; }
 }
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5719,11 +5719,12 @@ function isCoarsePointer(): boolean {
 // The composer's resting placeholder — mirrors chatBody()'s skeleton. Restored whenever no free-text
 // picker is active. (Kept here, not read from the DOM, so an "answering" placeholder never leaks back
 // as the default after a picker resolves.) On a phone (coarse pointer) Enter makes a NEWLINE and the Send
-// button sends, so the ⏎/⇧⏎ hint is both wrong there and too long for the one-line box (it wrapped and got
-// clipped) — drop it on mobile (the user 2026-07-15).
+// button sends, so the ⏎/⇧⏎ hint is wrong there — and the box is a ONE-line Signal-style pill flanked by
+// the two buttons (the user 2026-07-30), so even the "/" hint wrapped and got clipped: mobile keeps just
+// the core prompt, and slash-command discovery stays a desktop hint.
 function composerRestingPlaceholder(): string {
   return isCoarsePointer()
-    ? "Message this session…  (type / for commands)"
+    ? "Message this session…"
     : "Message this session…  (⏎ send · ⇧⏎ newline · type / for commands)";
 }
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -455,12 +455,19 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   max-width: var(--chat-col); margin: 0 auto; padding: 7px 24px 0 44px;   /* left matches .thread's 44px gutter so the controls align with the transcript column */
   display: flex; align-items: center; gap: 10px;
 }
-#composer { position: relative; max-width: var(--chat-col); margin: 0 auto; padding: 8px 24px 6px; }
+/* Signal-style compose ROW (the user 2026-07-30): paperclip · pill input · round send — the layout every
+   phone messenger trained thumbs on. Laid out by flex `order` so the shared markup (input before the two
+   buttons) needn't change on either surface; align-items flex-end keeps the buttons seated at the bottom
+   of the row while the input grows upward. */
+#composer {
+  position: relative; max-width: var(--chat-col); margin: 0 auto; padding: 8px 24px 6px;
+  display: flex; flex-wrap: wrap; align-items: flex-end; gap: 8px;
+}
 
 /* ── citation chip strip (the user 2026-07-01) ── a click on a feed card summary / sub-goal seeds a
    dismissible pill here, ABOVE the textarea: "you're following up on THIS". Accent-blue, with an ✕ to
    dismiss (Backspace-at-start dismisses too). Reads as attached context, not typed text. */
-#composer-chips { display: flex; flex-wrap: wrap; gap: 6px; padding: 0 0 6px 2px; }
+#composer-chips { flex: 1 1 100%; display: flex; flex-wrap: wrap; gap: 6px; padding: 0 0 6px 2px; }   /* full-width row of its own, above the compose row */
 .composer-chip {
   display: inline-flex; align-items: center; gap: 5px; max-width: 100%;
   background: color-mix(in srgb, var(--accent) 18%, transparent);
@@ -515,30 +522,27 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   animation: slash-spin 2.4s linear infinite; }
 @keyframes slash-spin { to { transform: rotate(-360deg); } }
 @media (prefers-reduced-motion: reduce) { .slash-spin { animation: none; } }
+/* The two buttons are the SAME circle (the user 2026-07-30: the 07-29 wide send read as a bar on a
+   phone, nothing like the round send messengers put there, and the pair's aspect ratios didn't match).
+   In-flow flex items now, not corner overlays — so no offset arithmetic couples them to the composer's
+   padding any more, and a peer's padding change can't strand them outside the box. */
 #composer-attach, #composer-send {
-  position: absolute;   /* size + offsets: the sizing block below (they differ per button now) */
+  flex: 0 0 auto; width: 34px; height: 34px; border-radius: 50%;
   padding: 0; line-height: 1;
   display: flex; align-items: center; justify-content: center;
-  background: transparent; border: none; border-radius: 5px;
-  font-size: 15px; opacity: 0.55; cursor: pointer;
+  background: transparent; border: none;
+  font-size: 16px; opacity: 0.55; cursor: pointer;
 }
 /* the paperclip + send glyphs wear the romp accent blue (the user 2026-07-15) — action affordances, not
    status, so var(--accent) is the intended use; resting a touch dim, full on hover */
-#composer-attach { color: var(--accent); opacity: 0.8; }   /* clip sits LEFT of the send button */
+#composer-attach { color: var(--accent); opacity: 0.8; order: 1; }   /* clip sits LEFT of the input */
 #composer-attach:hover, #composer-send:hover { opacity: 1; background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.08)); }
+#composer-send { order: 3; }                                         /* send on the input's right */
 #composer-send:not(:disabled) { color: var(--accent); opacity: 0.85; }   /* romp-blue send affordance */
 #composer-send:disabled { opacity: 0.3; cursor: not-allowed; }
-/* SIZE (the user 2026-07-29). Both were 26px squares tucked in the corner: passable for a mouse, a poor
-   target for a thumb. Send is the primary action of the whole pane, so it gets real width — the widest
-   thing in the corner rather than the same square as the paperclip beside it. Offsets are measured from
-   #composer, whose own right padding (24px here) is what puts the textarea's edge at 24: 28 is 4px
-   inside the box. */
-#composer-attach, #composer-send { bottom: 10px; height: 30px; }
-#composer-send { right: 26px; width: 36px; font-size: 16px; }
-#composer-attach { right: 62px; width: 32px; font-size: 16px; }
-#composer-input { padding-right: 78px; }   /* text stops clear of both buttons */
 #composer-input {
-  width: 100%; resize: none; box-sizing: border-box;
+  order: 2; flex: 1 1 auto; min-width: 0;
+  resize: none; box-sizing: border-box;
   /* Floor at one line + padding + border, so the box can never collapse to a
      sliver: growComposer() sets an inline height from scrollHeight, which reads
      ~0 when it runs mid-pane-switch (textarea momentarily unlaid-out); min-height
@@ -547,44 +551,27 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   background: var(--vscode-input-background, rgba(255, 255, 255, 0.05));
   color: var(--vscode-input-foreground, var(--fg));
   border: 1px solid var(--vscode-input-border, var(--box-border));
-  border-radius: 6px; padding: 8px 64px 8px 10px;   /* right room for the 📎 + send buttons */
+  border-radius: 18px; padding: 8px 14px;   /* pill at one line, rounded box as it grows */
   font-family: var(--sans); font-size: var(--fs); line-height: 1.4; outline: none;
 }
 #composer-input:disabled { opacity: 0.55; cursor: not-allowed; }
 #composer-input::placeholder { color: var(--dim); }
-/* On a phone (coarse pointer) the resting placeholder still wraps to two lines on a narrow screen, and a
-   one-line box clipped its second line (the user 2026-07-15). Floor the empty box at two lines there so the
-   full hint is visible; growComposer's inline height still floors on this, and a real message grows past it. */
+/* TOUCH (the user 2026-07-30): the same row, thumb-sized — 44px circles (the tap target a finger
+   expects), send FILLED with the accent like a messenger's round send, the paperclip on a faint chip
+   fill so both read as buttons. The resting box stays ONE line, like Signal's; the mobile placeholder
+   is shortened to fit it (composerRestingPlaceholder). */
 @media (pointer: coarse) {
-  #composer-input { min-height: calc(2.8em + 18px); }
-}
-/* TOUCH (the user 2026-07-29, on an iPad): the two buttons sat in the corner of a two-line resting box,
-   which read as a stray row under the placeholder AND gave a thumb two 26px squares to hit. Here they
-   become a real button ROW along the bottom of the box: 44px tall (the tap target a finger expects),
-   send filled in the accent because it is the primary action, and the text runs the FULL width above
-   them instead of being squeezed into a column beside them. Same two elements, same corner — they are
-   simply big enough to be the controls they are. */
-@media (pointer: coarse) {
-  #composer-attach, #composer-send { bottom: 12px; height: 44px; border-radius: 8px; }
-  #composer-send { right: 28px; width: 96px; font-size: 21px; }
-  #composer-attach { right: 136px; width: 60px; font-size: 19px; }
-  /* the fill is the accent itself, so the glyph flips to the on-accent colour (--accent-fg) */
+  #composer-attach, #composer-send { width: 44px; height: 44px; }
+  #composer-attach { font-size: 19px; background: rgba(255, 255, 255, 0.07); }
+  #composer-send { font-size: 21px; }
+  /* hover is included on purpose: a touch device can leave a sticky :hover that would otherwise
+     repaint the fill with the toolbar hover grey; the fill flips the glyph to the on-accent colour */
   #composer-send, #composer-send:not(:disabled), #composer-send:hover:not(:disabled) {
     background: var(--accent); color: var(--accent-fg); opacity: 1;
   }
-  /* disabled reads as a muted FILL, not a ghost: at 0.3 opacity a 96px button looked like a render bug */
+  /* disabled reads as a muted FILL, not a ghost: at 0.3 opacity a 44px filled circle looked like a render bug */
   #composer-send:disabled { background: rgba(255, 255, 255, 0.10); color: var(--dim); opacity: 1; }
-  #composer-attach { background: rgba(255, 255, 255, 0.07); }
-  /* full-width text, with the button row's height reserved underneath it */
-  #composer-input { padding-right: 12px; padding-bottom: 62px; min-height: calc(2.8em + 62px); }
-}
-/* The mobile shell narrows #composer's own padding to 10px (kernel _CHAT_MOBILE_CSS), so the offsets
-   that put a button 4px inside the box change with it. Matched to the SAME query the padding uses, or a
-   landscape iPad — coarse but wider than 1024 — would take phone offsets against desktop padding and
-   hang both buttons outside the box. */
-@media (pointer: coarse) and (max-width: 1024px) {
-  #composer-send { right: 14px; }
-  #composer-attach { right: 122px; }
+  #composer-input { min-height: 40px; border-radius: 20px; padding: 10px 14px; }
 }
 /* Cursor in the message box → a thin romp-blue border, exactly on the box edge — the same accent blue that
    marks the focused panel (the user 2026-06-26). It only fills in the existing 1px border (no glow, no layout
@@ -1207,15 +1194,24 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .ask-head { font-size: 0.72em; letter-spacing: 0.06em; text-transform: uppercase; color: var(--dim); margin-bottom: 6px; }
 .ask-q + .ask-q { margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--box-border); }
 .ask-qtext { font-weight: 600; color: var(--vscode-foreground, #fff); margin-bottom: 5px; }
-.ask-opt { display: flex; gap: 8px; align-items: baseline; padding: 2px 0; color: var(--dim); }
-.ask-opt .ask-mark { color: var(--dim); font-size: 0.8em; flex: 0 0 auto; }
+/* Option rows must survive a narrow screen (the user 2026-07-30, on a phone). The old flex row held a
+   RIGID label (flex: 0 0 auto): wider than the card, it pushed past the right edge, and the description —
+   squeezed to its one-character min width beyond it — wrapped a letter per line: an answered card
+   rendered as a clipped option atop a screen of blank box. A flex row can't fix this cleanly (a flex
+   line breaks BEFORE a too-wide item, so a long label orphans the mark on a line of its own), so the
+   answered row is INLINE with a hanging indent: the mark hangs in the indent, the label wraps beside it
+   like prose, and the description takes its own dim line(s) at the same indent. */
+.ask-opt { display: block; padding: 2px 0 2px 18px; color: var(--dim); }
+.ask-opt .ask-mark { display: inline-block; width: 18px; margin-left: -18px; color: var(--dim); font-size: 0.8em; }
 .ask-opt.chosen { color: var(--fg); }
 .ask-opt.chosen .ask-mark { color: var(--check-bg); }
 .ask-opt.chosen .ask-optlabel { font-weight: 600; }
-.ask-optlabel { flex: 0 0 auto; }
-.ask-optdesc { color: var(--dim); font-size: 0.9em; overflow-wrap: anywhere; }
-/* a free-text "Other" answer: the user's verbatim words, readable (not dimmed) */
-.ask-answer-text { flex: 1 1 auto; min-width: 0; color: var(--fg); font-style: italic; overflow-wrap: anywhere; }
+.ask-optlabel { flex: 0 1 auto; min-width: 0; overflow-wrap: anywhere; }   /* flex props serve the live rows below; inert in the inline answered row */
+.ask-optdesc { color: var(--dim); font-size: 0.9em; overflow-wrap: anywhere; flex: 1 1 14em; min-width: 0; }
+.ask-opt .ask-optdesc { display: block; }   /* answered card: the description under the label, not beside */
+/* a free-text "Other" answer: the user's verbatim words, readable (not dimmed), on their own line
+   under the "Other" label (same hanging indent as a description) */
+.ask-answer-text { display: block; min-width: 0; color: var(--fg); font-style: italic; overflow-wrap: anywhere; }
 
 /* an ANSWERED AskUserQuestion → the blue "your reply" box: right-aligned + blue-washed like a sent
    message (the #2b6cef user blue), still mirroring the dialog (question + options, chosen highlighted)
@@ -1243,11 +1239,11 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 }
 .ask-live .ask-qtext { margin-bottom: 7px; }
 .ask-live-opt {
-  display: flex; gap: 9px; align-items: baseline;
+  display: flex; flex-wrap: wrap; gap: 2px 9px; align-items: baseline;   /* wrap: same phone clipping as .ask-opt */
   border-radius: 5px; padding: 5px 9px; color: var(--fg); cursor: pointer;
 }
 .ask-live-opt.focus { background: rgba(255, 255, 255, 0.10); box-shadow: inset 2px 0 0 var(--st-awaiting-bg); }
-.ask-live-opt .ask-optlabel { flex: 0 0 auto; font-weight: 600; }
+.ask-live-opt .ask-optlabel { flex: 0 1 auto; min-width: 0; overflow-wrap: anywhere; font-weight: 600; }
 /* The focused option's side-by-side TUI preview box, reproduced verbatim (the user
    2026-06-13). Monospace + preserved whitespace so the box-drawing/ASCII aligns;
    never wraps (wrapping would shear the layout) — scroll sideways when wider than
@@ -1276,13 +1272,13 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* dim, matching an option description's weight */
 .ask-custom-hint-text { flex: 1 1 auto; min-width: 0; color: var(--dim); font-size: 0.92em; }
 .ask-live-unknown .ask-custom-hint-text { padding: 4px 9px 2px; }
-.ask-check { display: flex; gap: 9px; align-items: baseline; padding: 4px 9px; border-radius: 5px; cursor: pointer; }
+.ask-check { display: flex; flex-wrap: wrap; gap: 2px 9px; align-items: baseline; padding: 4px 9px; border-radius: 5px; cursor: pointer; }
 .ask-check:hover { background: rgba(255, 255, 255, 0.06); }
 /* keyboard focus highlight — same treatment as the single card's .ask-live-opt.focus (the user 2026-06-22) */
 .ask-check.focus { background: rgba(255, 255, 255, 0.10); box-shadow: inset 2px 0 0 var(--st-awaiting-bg); }
 .ask-live-multi:focus, .ask-live:focus { outline: none; }
 .ask-check input { margin: 0; flex: 0 0 auto; cursor: pointer; accent-color: var(--check-bg); }
-.ask-check .ask-optlabel { flex: 0 0 auto; font-weight: 600; }
+.ask-check .ask-optlabel { flex: 0 1 auto; min-width: 0; overflow-wrap: anywhere; font-weight: 600; }
 /* submit-review chosen line + action buttons (multi submit / cancel) */
 .ask-chosen { color: var(--fg); margin: 2px 0 4px; overflow-wrap: anywhere; }
 /* multi-question review: one q→a pair per question */


### PR DESCRIPTION
Three phone-driven UI asks (the user 2026-07-30, with a screenshot):

**Answered pickers wrapped unreadably on mobile.** The option row was flex with a rigid label: wider than the card, the label pushed past the right edge and the description beyond it, squeezed to its one-character min width, wrapped a letter per line, rendering the card as a clipped option above a screen of blank box. The answered row is now inline with a hanging indent (the mark hangs, the label wraps beside it like prose, the description takes its own dim line); the live picker rows keep flex but wrap.

**The send button was far too wide.** The composer is now the Signal-style row: paperclip left, pill input growing in the middle, round send right, both buttons the same circle (34px, 44px on touch, send accent-filled there). Flex `order` does the placement so the shared markup is untouched, and the in-flow buttons dissolve the two-file offset coupling to the composer's padding; `tests/test_shell_mobile_composer_pad.py` pins the dissolution. The mobile resting placeholder shortens to fit the one-line pill.

**The stacked (narrow) feed now reads Completed first**, then Blocked, then Working (superseding the 2026-07-08 Blocked-first order). Side-by-side DOM order is untouched.

Verified in headless-Chrome repros at 390px (picker card, composer resting + grown, feed stack) plus both suites: node 1501 pass, pytest 3716 pass.

Generated with [Claude Code](https://claude.com/claude-code)