### PR TITLE
Federated hosts reach the phone: the kernel relays /remote/<host>/ws

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from datetime import datetime
 from importlib.machinery import SourceFileLoader
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs, unquote, urlencode
 
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent
@@ -4854,12 +4854,16 @@ def _tmux_sessions():
 # For the browser to reach a remote kernel — and for that machine's sessions to reach THIS laptop's
 # postal bus — the kernel manages the ssh tunnels (it's the long-lived local process, the natural owner
 # of the child ssh procs). ONE ssh per host carries both directions:
-#     -L <local_port>:127.0.0.1:<remote_kernel_port>   browser → remote kernel   (dashboard view)
+#     -L <local_port>:127.0.0.1:<remote_kernel_port>   this kernel → remote kernel  (dashboard relay)
 #     -R <bus_port>:127.0.0.1:<bus_port>               remote sessions → this bus (postal messaging)
-# The kernel is NOT a data relay — the browser talks to the remote kernel DIRECTLY through the -L
-# tunnel (authorizing with the remote's token, which a valid-token request carries past the Origin
-# gate; see _authorize). We just open the door + report state. The registry persists to
-# STATE/remotes.json so attached hosts survive a kernel restart (the supervisor re-spawns their procs).
+# The browser reaches a remote kernel via GET /remote/<host>/ws on THIS kernel, which splices the
+# connection onto the -L port byte-for-byte (_remote_ws). It has to be a relay: the forwarded port
+# lives on THIS machine's loopback, so when the browser dialed it directly, any dashboard viewed
+# from OFF this machine — the phone, through `tailscale serve` — reached its own loopback instead
+# and every remote host silently vanished, with no disconnected mark (the user 2026-07-30). The
+# kernel still reads nothing (no frame parsing; the remote enforces its own token per connection),
+# and this registry still just opens the door + reports state. It persists to STATE/remotes.json
+# so attached hosts survive a kernel restart (the supervisor re-spawns their procs).
 
 REMOTES_FILE = jd.STATE / "remotes.json"
 # Hosts you have EVER attached, kept after detach (the user 2026-07-22: the popover should list past
@@ -17916,6 +17920,9 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(403, "forbidden: " + why, "text/plain")
             if p == "/ws":
                 return self._ws()
+            if p.startswith("/remote/") and p.endswith("/ws"):
+                # federated dashboard, viewed off this machine: relay to the attached host's kernel
+                return self._remote_ws(unquote(p[len("/remote/"):-len("/ws")]), u.query)
             if p == "/analytics":                             # token-usage analytics (the settings modal's chart)
                 try:
                     w = int((q.get("window") or ["86400"])[0])
@@ -18939,6 +18946,86 @@ class Handler(BaseHTTPRequestHandler):
             with _clients_lock:
                 if client in _clients:
                     _clients.remove(client)
+
+    def _remote_ws(self, host, query):
+        """GET /remote/<host>/ws — relay a federated-dashboard WebSocket to an attached host's
+        kernel through this kernel's own ssh -L tunnel. The federated merge happens in the
+        browser (one WS per kernel), and the remote dial used to go straight to
+        127.0.0.1:<forwarded port> — an address that only exists on THIS machine, so a dashboard
+        viewed from anywhere else (the phone, through `tailscale serve`) reached its own loopback
+        and every remote host's sessions silently vanished (the user 2026-07-30). Relaying under
+        the kernel's own origin gives any client that can reach this kernel the whole fleet, with
+        no per-host setup. The kernel stays a dumb pipe: after do_GET's local auth gate the two
+        sockets are spliced byte-for-byte (no frame parsing), and the REMOTE kernel still enforces
+        its own token — rewritten into the forwarded query here, so the browser only ever needs
+        its local credential — keeping the per-host trust boundary unchanged."""
+        with _remotes_lock:
+            r = _remotes.get(host)
+            port, rtok = (r or {}).get("local_port") or 0, (r or {}).get("token") or ""
+        if not port:
+            return self._send(404, "no attached host %r" % host, "text/plain")
+        if not self.headers.get("Sec-WebSocket-Key"):
+            return self._send(400, "expected websocket", "text/plain")
+        q = parse_qs(query or "")
+        if rtok:
+            q["token"] = [rtok]      # the remote's own credential; whatever the browser sent means nothing there
+        try:
+            up = socket.create_connection(("127.0.0.1", int(port)), timeout=6)
+        except OSError:
+            return self._send(502, "tunnel to %s is not answering" % host, "text/plain")
+        up.settimeout(None)          # create_connection's timeout would otherwise cut the long-lived splice
+        lines = ["GET /ws?%s HTTP/1.1" % urlencode(q, doseq=True),
+                 "Host: 127.0.0.1:%d" % int(port)]
+        for hn in ("Upgrade", "Connection", "Sec-WebSocket-Key", "Sec-WebSocket-Version",
+                   "Sec-WebSocket-Protocol", "Sec-WebSocket-Extensions"):
+            v = self.headers.get(hn)
+            if v:
+                lines.append("%s: %s" % (hn, v))
+        try:
+            up.sendall(("\r\n".join(lines) + "\r\n\r\n").encode("latin-1", "replace"))
+        except OSError:
+            up.close()
+            return self._send(502, "tunnel to %s dropped" % host, "text/plain")
+        self.close_connection = True             # hijacked socket — no keep-alive after the splice
+        down = self.connection
+
+        def _quiet_shutdown(s):
+            # shutdown only, never close: `down` still belongs to the base handler (its finish()
+            # flushes wfile over this socket and must find a socket object, not a closed one).
+            try:
+                s.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+
+        def _pump_remote_to_client():
+            try:
+                while True:
+                    b = up.recv(65536)
+                    if not b:
+                        break
+                    down.sendall(b)
+            except OSError:
+                pass
+            finally:
+                _quiet_shutdown(down)            # unblock the rfile read below → both halves die together
+
+        threading.Thread(target=_pump_remote_to_client, daemon=True, name="remote-ws").start()
+        try:
+            while True:
+                # rfile, not the raw socket: the buffered reader may already hold client bytes
+                # that arrived on the heels of the upgrade request
+                b = self.rfile.read1(65536)
+                if not b:
+                    break
+                up.sendall(b)
+        except (OSError, ValueError):
+            pass
+        finally:
+            _quiet_shutdown(up)
+            try:
+                up.close()                       # ours alone — safe to close fully
+            except OSError:
+                pass
 
     def _push_one(self, client):
         _push([client], connect=True)             # full state to a fresh client (its per-client dedup is empty);

--- a/tests/test_kernel_remote_ws_proxy.py
+++ b/tests/test_kernel_remote_ws_proxy.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""The /remote/<host>/ws relay — how an off-machine dashboard (the phone) sees federated hosts.
+
+The federated dashboard merges hosts IN THE BROWSER: one WebSocket per kernel. The remote dial
+used to go straight to 127.0.0.1:<ssh -L forwarded port>, an address that only exists on the
+kernel's own machine — from a phone reading the dashboard through `tailscale serve`, that is the
+phone's own loopback, so every remote host's sessions silently vanished with no disconnected mark
+(2026-07-30). The kernel now relays: GET /remote/<host>/ws splices the browser's socket onto the
+host's forwarded port byte-for-byte, after the normal local auth gate, and rewrites the remote
+kernel's own token into the forwarded query so the per-host trust boundary is unchanged.
+
+These tests run the real Handler against a fake "remote kernel" (a raw loopback socket that speaks
+just enough of the WS handshake). Synthetic only: host name `gpu1`, invented tokens, no session
+state touched.
+"""
+import base64
+import os
+import re
+import socket
+import threading
+import unittest
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Mirror tests/test_kernel_ws_auth.py's load order. The token env keeps _load_token() away from
+# the real state dir; NO_OPEN keeps the import from launching a browser.
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+REMOTE_TOKEN = "remote-token-DO-NOT-USE"
+
+
+class _FakeRemoteKernel:
+    """One-connection stand-in for an attached host's kernel behind the ssh -L port: accepts a WS
+    upgrade (computing the accept from the FORWARDED key — the proof headers passed through),
+    sends one server frame, then records whatever else arrives."""
+
+    def __init__(self):
+        self.srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.srv.bind(("127.0.0.1", 0))
+        self.srv.listen(1)
+        self.port = self.srv.getsockname()[1]
+        self.request = b""          # the upgrade request the relay forwarded
+        self.post_upgrade = b""     # client bytes that arrived after the upgrade
+        self.got_client_bytes = threading.Event()
+        self.done = threading.Event()
+        threading.Thread(target=self._serve, daemon=True).start()
+
+    def _serve(self):
+        try:
+            conn, _ = self.srv.accept()
+            conn.settimeout(5)
+            while b"\r\n\r\n" not in self.request:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    return
+                self.request += chunk
+            key = re.search(rb"Sec-WebSocket-Key: *(\S+)", self.request).group(1).decode()
+            conn.sendall((
+                "HTTP/1.1 101 Switching Protocols\r\n"
+                "Upgrade: websocket\r\nConnection: Upgrade\r\n"
+                "Sec-WebSocket-Accept: %s\r\n\r\n" % km._ws_accept(key)
+            ).encode())
+            conn.sendall(b"\x81\x05hello")          # one unmasked text frame, server → client
+            head, _, tail = self.request.partition(b"\r\n\r\n")
+            self.post_upgrade += tail               # client frames that rode in with the upgrade
+            while not self.got_client_bytes.is_set():
+                try:
+                    chunk = conn.recv(4096)
+                except socket.timeout:
+                    return
+                if not chunk:
+                    return
+                self.post_upgrade += chunk
+                self.got_client_bytes.set()
+        except OSError:
+            pass
+        finally:
+            self.done.set()
+
+    def close(self):
+        try:
+            self.srv.close()
+        except OSError:
+            pass
+
+
+class RemoteWsProxy(unittest.TestCase):
+    def setUp(self):
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        self.port = self.srv.server_address[1]
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        self._saved_remotes = dict(km._remotes)
+
+    def tearDown(self):
+        with km._remotes_lock:
+            km._remotes.clear()
+            km._remotes.update(self._saved_remotes)
+        self.srv.shutdown()
+        self.srv.server_close()
+
+    def _register(self, host, local_port, token=REMOTE_TOKEN):
+        with km._remotes_lock:
+            km._remotes[host] = {"host": host, "kernel_port": 29855, "local_port": local_port,
+                                 "token": token, "status": "up"}
+
+    def _upgrade(self, path, token=True, ws_headers=True):
+        """Open a raw socket, send one upgrade request, return (socket, status, header block)."""
+        key = base64.b64encode(os.urandom(16)).decode()
+        lines = ["GET %s HTTP/1.1" % path, "Host: 127.0.0.1:%d" % self.port]
+        if token:
+            lines.append("X-Romp-Token: %s" % km.TOKEN)
+        if ws_headers:
+            lines += ["Upgrade: websocket", "Connection: Upgrade",
+                      "Sec-WebSocket-Key: %s" % key, "Sec-WebSocket-Version: 13"]
+        s = socket.create_connection(("127.0.0.1", self.port), timeout=5)
+        s.sendall(("\r\n".join(lines) + "\r\n\r\n").encode())
+        buf = b""
+        while b"\r\n\r\n" not in buf:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+        head, _, tail = buf.partition(b"\r\n\r\n")
+        first = head.split(b"\r\n", 1)[0].decode("latin-1")
+        parts = first.split(" ", 2)
+        status = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else -1
+        return s, status, head, tail, key
+
+    def test_splices_both_directions_and_rewrites_the_token(self):
+        fake = _FakeRemoteKernel()
+        self._register("gpu1", fake.port)
+        try:
+            s, status, head, tail, key = self._upgrade("/remote/gpu1/ws?app=chat&token=whatever-the-browser-sent")
+            try:
+                self.assertEqual(status, 101, "the remote's 101 must pass through the splice")
+                # the accept was computed by the FAKE REMOTE from our key — headers passed through
+                self.assertIn(km._ws_accept(key).encode(), head)
+                # server → client: the remote's frame arrives verbatim
+                buf = tail
+                s.settimeout(5)
+                while len(buf) < 7:
+                    chunk = s.recv(4096)
+                    if not chunk:
+                        break
+                    buf += chunk
+                self.assertEqual(buf[:7], b"\x81\x05hello")
+                # client → server: bytes flow back through the same splice untouched
+                s.sendall(b"\x81\x83\x01\x02\x03\x04abc")
+                self.assertTrue(fake.got_client_bytes.wait(5), "client bytes must reach the remote")
+                self.assertIn(b"\x81\x83\x01\x02\x03\x04abc", fake.post_upgrade)
+                # the forwarded request: path /ws, the REMOTE's token (not what the browser sent),
+                # and never the local serve token
+                req = fake.request.split(b"\r\n", 1)[0].decode("latin-1")
+                self.assertTrue(req.startswith("GET /ws?"), req)
+                self.assertIn("token=" + REMOTE_TOKEN, req)
+                self.assertNotIn("whatever-the-browser-sent", req)
+                self.assertNotIn(km.TOKEN, fake.request.decode("latin-1"))
+                self.assertIn("app=chat", req)
+            finally:
+                s.close()
+        finally:
+            fake.close()
+
+    def test_unknown_host_404s(self):
+        s, status, _, _, _ = self._upgrade("/remote/nosuch/ws")
+        s.close()
+        self.assertEqual(status, 404)
+
+    def test_unauthorized_403s_before_any_dial(self):
+        fake = _FakeRemoteKernel()
+        self._register("gpu1", fake.port)
+        try:
+            s, status, _, _, _ = self._upgrade("/remote/gpu1/ws", token=False)
+            s.close()
+            self.assertEqual(status, 403, "the local auth gate must run before the relay")
+            self.assertEqual(fake.request, b"", "an unauthorized request must never touch the tunnel")
+        finally:
+            fake.close()
+
+    def test_dead_tunnel_502s(self):
+        # a registered host whose forwarded port has no listener (the ssh died mid-flight)
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.bind(("127.0.0.1", 0))
+        dead_port = probe.getsockname()[1]
+        probe.close()
+        self._register("gpu1", dead_port)
+        s, status, _, _, _ = self._upgrade("/remote/gpu1/ws")
+        s.close()
+        self.assertEqual(status, 502)
+
+    def test_non_websocket_request_400s(self):
+        fake = _FakeRemoteKernel()
+        self._register("gpu1", fake.port)
+        try:
+            s, status, _, _, _ = self._upgrade("/remote/gpu1/ws", ws_headers=False)
+            s.close()
+            self.assertEqual(status, 400)
+        finally:
+            fake.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/federation-remote-gate.test.ts
+++ b/ui/webview/federation-remote-gate.test.ts
@@ -23,7 +23,17 @@ test("the /tunnels poll refreshes live from t.status and re-dials a closed conn 
   assert.match(FED, /c\.live = t\.status === "up";/);
   assert.match(FED, /if \(c\.live && \(!c\.ws \|\| c\.ws\.readyState === 3\)\) this\.connect\(c\);/);
   // openRemote seeds the flag from the same status so the first dial is gated too
-  assert.match(FED, /this\.openRemote\(host, t\.localPort, t\.token, t\.status === "up"\)/);
+  assert.match(FED, /this\.openRemote\(host, t\.token, t\.status === "up"\)/);
+});
+
+test("remotes are dialed through the kernel's /remote relay on the page origin, never a loopback port", () => {
+  // The forwarded ssh -L port only exists on the kernel's own machine. A direct dial to
+  // 127.0.0.1:<port> works from a browser ON that machine and silently reaches nothing from
+  // anywhere else (the phone, over `tailscale serve`) — every remote host just vanished, with no
+  // disconnected mark (2026-07-30). The kernel's /remote/<host>/ws route splices the connection
+  // onto the tunnel server-side, so the same-origin dial works from every client.
+  assert.match(FED, /\$\{proto\}\$\{location\.host\}\/remote\/\$\{encodeURIComponent\(host\)\}\/ws\?/);
+  assert.ok(!/\$\{proto\}127\.0\.0\.1/.test(FED), "the direct loopback dial must not come back");
 });
 
 test("the down-tunnel 2s blind-retry loop is gone (the retry rides connect()'s own gate)", () => {

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -506,7 +506,7 @@ export class FederationManager {
       return;
     }
     const want = new Map<string, any>(tunnels.filter((t) => t.token && t.localPort).map((t) => [t.host, t]));
-    for (const [host, t] of want) if (!this.conns.has(host)) this.openRemote(host, t.localPort, t.token, t.status === "up");
+    for (const [host, t] of want) if (!this.conns.has(host)) this.openRemote(host, t.token, t.status === "up");
     for (const host of [...this.conns.keys()]) if (!want.has(host)) this.closeRemote(host);
     // The kernel's tunnel state gates dialing: it health-checks its own ssh tunnels, so "up" is
     // authoritative for whether anything listens on the local port at all. Blind 2s retries against
@@ -531,9 +531,15 @@ export class FederationManager {
     if (changed) window.dispatchEvent(new Event("romp-hosts"));   // panes repaint their disconnected marks
   }
 
-  private openRemote(host: string, port: number, token: string, live: boolean): void {
+  private openRemote(host: string, token: string, live: boolean): void {
+    // Dial the remote through THIS kernel's /remote/<host>/ws relay, on the same origin that served
+    // the page — never at 127.0.0.1:<forwarded port>, which only exists on the kernel's machine:
+    // from a phone reading the dashboard over `tailscale serve`, that address is the phone itself,
+    // and every remote host silently vanished with no disconnected mark (the user 2026-07-30).
+    // Same-origin also means the local auth cookie rides the upgrade; the ?token (the remote
+    // kernel's credential, from /tunnels) is re-checked and rewritten by the relay either way.
     const proto = location.protocol === "https:" ? "wss://" : "ws://";
-    const url = `${proto}127.0.0.1:${port}/ws?app=${encodeURIComponent(this.app)}&token=${encodeURIComponent(token)}`;
+    const url = `${proto}${location.host}/remote/${encodeURIComponent(host)}/ws?app=${encodeURIComponent(this.app)}&token=${encodeURIComponent(token)}`;
     const conn: Conn = { host, ws: null, url, closed: false, live };
     this.conns.set(host, conn);
     this.ensureHost(host);


### PR DESCRIPTION
The federated dashboard merges hosts in the browser: one WebSocket per kernel, and the remote dial went straight to `127.0.0.1:<ssh -L forwarded port>` — an address that only exists on the kernel's own machine. From a phone reading the dashboard through `tailscale serve`, that is the phone's own loopback, so every remote host's sessions silently vanished, and with the kernel still reporting the tunnel "up", no disconnected mark appeared either.

**Fix: the kernel relays.** `GET /remote/<host>/ws` splices the browser's socket onto the host's forwarded port byte-for-byte after the normal local auth gate. The remote kernel's own token is rewritten into the forwarded query (from the tunnel registry), so the remote still enforces its own credential per connection and the per-host trust boundary is unchanged. `federation.ts` now dials same-origin `/remote/<host>/ws` — one code path for a browser on the kernel machine and one on a phone. Any client that can reach the kernel now gets the whole fleet, with no per-host setup.

The "kernel is NOT a data relay" design note predated off-machine viewing; it now documents the relay and why it has to be one (the kernel still reads nothing — no frame parsing).

**Tests**
- `tests/test_kernel_remote_ws_proxy.py`: real Handler against a fake remote kernel — splice both directions, upgrade headers forwarded (accept computed from the forwarded key), token rewritten (browser's token never reaches the remote, local serve token never leaks), 403 before any dial, 404 unknown host, 502 dead tunnel, 400 non-WS.
- `federation-remote-gate.test.ts`: pins the same-origin dial and that the direct loopback dial cannot come back.

Suites: 3695 Python passed, 1492 node passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)