### PR TITLE
The composer buttons match the one-line box, as rounded squares

### DIFF
--- a/tests/test_shell_mobile_composer_pad.py
+++ b/tests/test_shell_mobile_composer_pad.py
@@ -38,10 +38,11 @@ class MobileComposerPadding(unittest.TestCase):
         self.assertIsNone(re.search(r"#composer-(send|attach)[^{]*\{[^}]*\bright:", STYLES))
         self.assertIsNone(re.search(r"#composer-(send|attach)[^{]*\{[^}]*position: absolute", STYLES))
 
-    def test_the_buttons_are_in_flow_flex_circles(self):
+    def test_the_buttons_are_in_flow_flex_rounded_squares(self):
         self.assertIn(
             "#composer-attach, #composer-send {\n"
-            "  flex: 0 0 auto; width: 34px; height: 34px; border-radius: 50%;", STYLES)
+            "  flex: 0 0 auto; width: calc(1.4 * var(--fs) + 18px); "
+            "height: calc(1.4 * var(--fs) + 18px); border-radius: 10px;", STYLES)
 
 
 if __name__ == "__main__":

--- a/ui/webview/composer-buttons.test.ts
+++ b/ui/webview/composer-buttons.test.ts
@@ -27,10 +27,15 @@ test("flex order puts the paperclip LEFT of the input and send on its right", ()
   assert.match(CSS, /#composer-send \{ order: 3; \}/);
 });
 
-test("the two buttons are the SAME circle — equal aspect ratio, by arithmetic", () => {
-  const m = CSS.match(/#composer-attach, #composer-send \{\s*\n\s*flex: 0 0 auto; width: (\d+)px; height: (\d+)px; border-radius: 50%;/);
+test("the two buttons are the SAME rounded square, as tall as the one-line box — by arithmetic", () => {
+  // the size is the input's min-height formula written against var(--fs): em on the button would key on
+  // its larger glyph font and drift taller than the box (the user 2026-07-30, round 2: smaller, rounded
+  // rectangle, matching the resting box height)
+  const m = CSS.match(/#composer-attach, #composer-send \{\s*\n\s*flex: 0 0 auto; width: (calc\(1\.4 \* var\(--fs\) \+ 18px\)); height: (calc\(1\.4 \* var\(--fs\) \+ 18px\)); border-radius: 10px;/);
   assert.ok(m, "the shared sizing rule is missing");
-  assert.equal(m![1], m![2], "width must equal height — a circle, not a bar");
+  assert.equal(m![1], m![2], "width must equal height — a square, not a bar");
+  // ...and the input's own floor uses the SAME formula (1.4em at the input's font IS 1.4 * --fs)
+  assert.match(CSS, /#composer-input \{[\s\S]*?min-height: calc\(1\.4em \+ 18px\);/);
 });
 
 test("the corner-overlay geometry is gone for good", () => {
@@ -40,11 +45,16 @@ test("the corner-overlay geometry is gone for good", () => {
   assert.doesNotMatch(CSS, /#composer-input \{ padding-right: \d+px; \}/);
 });
 
-test("a coarse pointer gets 44px circles: the tap target a finger expects, still 1:1", () => {
-  assert.match(coarse, /#composer-attach, #composer-send \{ width: 44px; height: 44px; \}/);
+test("a coarse pointer gets 40px rounded squares, matching the 40px one-line box", () => {
+  assert.match(coarse, /#composer-attach, #composer-send \{ width: 40px; height: 40px; border-radius: 12px; \}/);
   // and the resting box is ONE line — the pill — not the old two-line floor
   assert.match(coarse, /#composer-input \{ min-height: 40px; border-radius: 20px; padding: 10px 14px; \}/);
   assert.doesNotMatch(CSS, /min-height: calc\(2\.8em/);
+});
+
+test("a grown box keeps its rounded right corners: thin scrollbar on a transparent track", () => {
+  // past the height cap the box scrolls, and a default scrollbar TRACK paints square into the corners
+  assert.match(CSS, /#composer-input \{ scrollbar-width: thin; scrollbar-color: rgba\(255, 255, 255, 0\.3\) transparent; \}/);
 });
 
 test("on touch, send wears the accent as a FILL and the glyph flips to the on-accent colour", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -522,12 +522,14 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   animation: slash-spin 2.4s linear infinite; }
 @keyframes slash-spin { to { transform: rotate(-360deg); } }
 @media (prefers-reduced-motion: reduce) { .slash-spin { animation: none; } }
-/* The two buttons are the SAME circle (the user 2026-07-30: the 07-29 wide send read as a bar on a
-   phone, nothing like the round send messengers put there, and the pair's aspect ratios didn't match).
-   In-flow flex items now, not corner overlays — so no offset arithmetic couples them to the composer's
-   padding any more, and a peer's padding change can't strand them outside the box. */
+/* The two buttons are the SAME rounded square, exactly as tall as the one-line message box beside them
+   (the user 2026-07-30, round 2: the first cut's circles sat taller than the resting box, and a rounded
+   rectangle reads better than a full circle). The size is the input's own min-height calc written
+   against var(--fs) — em here would key on the BUTTON's larger font and drift — so the pair tracks the
+   resting box height by construction. In-flow flex items, not corner overlays: no offset arithmetic
+   couples them to the composer's padding, and a peer's padding change can't strand them outside the box. */
 #composer-attach, #composer-send {
-  flex: 0 0 auto; width: 34px; height: 34px; border-radius: 50%;
+  flex: 0 0 auto; width: calc(1.4 * var(--fs) + 18px); height: calc(1.4 * var(--fs) + 18px); border-radius: 10px;
   padding: 0; line-height: 1;
   display: flex; align-items: center; justify-content: center;
   background: transparent; border: none;
@@ -556,12 +558,16 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 }
 #composer-input:disabled { opacity: 0.55; cursor: not-allowed; }
 #composer-input::placeholder { color: var(--dim); }
-/* TOUCH (the user 2026-07-30): the same row, thumb-sized — 44px circles (the tap target a finger
-   expects), send FILLED with the accent like a messenger's round send, the paperclip on a faint chip
-   fill so both read as buttons. The resting box stays ONE line, like Signal's; the mobile placeholder
-   is shortened to fit it (composerRestingPlaceholder). */
+/* A box grown past the height cap scrolls — and the scrollbar's TRACK paints square into the rounded
+   right corners (the user 2026-07-30, on a multi-line box). A thin bar on a transparent track keeps the
+   corners round; the thumb alone floats inside the box. */
+#composer-input { scrollbar-width: thin; scrollbar-color: rgba(255, 255, 255, 0.3) transparent; }
+/* TOUCH (the user 2026-07-30): the same row, thumb-sized — rounded squares matching the 40px one-line
+   box (down from 44px circles, round 2: they read oversized), send FILLED with the accent like a
+   messenger's send, the paperclip on a faint chip fill so both read as buttons. The resting box stays
+   ONE line, like Signal's; the mobile placeholder is shortened to fit it (composerRestingPlaceholder). */
 @media (pointer: coarse) {
-  #composer-attach, #composer-send { width: 44px; height: 44px; }
+  #composer-attach, #composer-send { width: 40px; height: 40px; border-radius: 12px; }
   #composer-attach { font-size: 19px; background: rgba(255, 255, 255, 0.07); }
   #composer-send { font-size: 21px; }
   /* hover is included on purpose: a touch device can leave a sticky :hover that would otherwise


### PR DESCRIPTION
Round 2 on the Signal-style composer row (the user 2026-07-30): attach and send shrink to exactly the height of the one-line message box — sized by the input's own min-height formula against `var(--fs)`, so the pair tracks the box by construction — and become rounded rectangles (10px radius; 40px with 12px radius on touch) instead of full circles.

Also keeps the grown box's right corners rounded: past the height cap the textarea scrolls, and the default scrollbar track painted square into the corners; a thin bar on a transparent track fixes it.

Verified in headless-Chrome repros (resting, grown, and scrolling boxes at phone and desktop widths); node suite 1502 pass + typecheck, targeted pytest pins updated and passing.

Generated with [Claude Code](https://claude.com/claude-code)