### PR TITLE
A new session hands you the chat box, then starts behind it

### DIFF
--- a/ui/webview/dir-complete.test.ts
+++ b/ui/webview/dir-complete.test.ts
@@ -96,7 +96,11 @@ test("a chosen completion walks INTO the folder; it never starts the session", (
 
 test("a missing directory raises the create-or-edit choice, and Create re-sends the SAME create", () => {
   assert.match(RENDER, /else if \(m\.type === "createDirMissing" && m\.name\) onCreateDirMissing\(m\)/);
-  assert.match(RENDER, /hideOpeningModal\(\);\s*\/\/ the cue would otherwise spin/);
+  // (2026-07-30: the cue became a provisional TAB, so the folder question retires it and holds what was
+  // typed for the retry — "Create it and start" re-sends the same create, so the text is still that
+  // session's, not the fallback tab's.)
+  assert.match(RENDER, /const held = dropProvisional\(\);/);
+  assert.match(RENDER, /pendingCarry = \[\.\.\.held\.queued, held\.draft\]\.filter\(Boolean\)/);
   assert.match(RENDER, /\{ label: "Create it and start", value: "create" \}, \{ label: "Edit the path", value: "edit" \}/);
   assert.match(RENDER, /if \(v === "create"\) \{ startCreate\(req, true\); return; \}/);
   assert.match(RENDER, /\.\.\.\(mkdir \? \{ mkdir: true \} : \{\}\)/, "mkdir rides the same message");

--- a/ui/webview/picker-host.test.ts
+++ b/ui/webview/picker-host.test.ts
@@ -19,8 +19,9 @@ test("the + dialog builds a Host row listing local + attached hosts, hidden with
 test("createSession carries the picked host (empty = local) so the manager routes it to that kernel", () => {
   assert.match(RENDER, /const hostSel = \(hostWrap\.querySelector\("\.picker-be-opt\.sel"\) as HTMLElement \| null\)\?\.dataset\.host \|\| ""/);
   assert.match(RENDER, /startCreate\(\{ name, backend: beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend,\s*\n\s*dir: dirInput\.value\.trim\(\), host: hostSel \}\)/);
-  // the "Opening…" cue must match the PREFIXED tab name a remote create produces
-  assert.match(RENDER, /showOpeningModal\(req\.host \? req\.host \+ ":" \+ req\.name : req\.name\)/);
+  // the PROVISIONAL tab (2026-07-30, which replaced the "Opening…" cue) must be matched against the
+  // PREFIXED tab name a remote create produces — provisionalName() is where that join is spelled
+  assert.match(RENDER, /openProvisional\(req\);/);
 });
 
 test("picking a remote host disables the (host-local) Browse… dialog", () => {

--- a/ui/webview/provisional.test.ts
+++ b/ui/webview/provisional.test.ts
@@ -1,0 +1,111 @@
+// A new session shows its chat box immediately and starts behind it (the user 2026-07-30).
+//
+// Creating a session used to raise an "Opening session…" modal over the pane: the kernel resolved the
+// directory, spawned tmux or connected the SDK, and the first transcript poll came back — seconds you
+// could do nothing with, watching three bouncing dots. Now the tab is there from the first click with a
+// live composer; anything typed is HELD and flushed the moment the real session lands; and a create that
+// fails says so in a dialog carrying the kernel's own words, instead of the cue silently timing out.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional,
+  PROVISIONAL_PREFIX } from "./provisional";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("a provisional id carries NO colon — federation would read it as a host", () => {
+  // this is the trap that swallowed follow-ups on remote cards: routing keys off id/sid and takes the
+  // part before a colon as a host name, so a "pending:" form would address a machine called "pending"
+  for (const seed of ["1a2b3c", "web:api", "2026-07-30T12:00:00.000Z", "…ünïcode…"]) {
+    const id = mintProvisionalId(seed);
+    assert.ok(!id.includes(":"), `${id} must not contain a colon`);
+    assert.ok(id.startsWith(PROVISIONAL_PREFIX));
+  }
+});
+
+test("distinct seeds mint distinct ids, and every one is recognisable as provisional", () => {
+  const a = mintProvisionalId("aaa1"), b = mintProvisionalId("bbb2");
+  assert.notEqual(a, b);
+  assert.ok(isProvisionalId(a) && isProvisionalId(b));
+});
+
+test("a real session id is never mistaken for a provisional one", () => {
+  assert.ok(!isProvisionalId("11111111-2222-3333-4444-555555555555"));
+  assert.ok(!isProvisionalId("web:11111111-2222-3333-4444-555555555555"));
+  assert.ok(!isProvisionalId(null));
+  assert.ok(!isProvisionalId(undefined));
+});
+
+test("a remote create is matched against the HOST-PREFIXED name its tab arrives under", () => {
+  assert.equal(provisionalName("web", "api"), "web:api");
+  assert.equal(provisionalName("", "api"), "api", "a local one arrives bare");
+});
+
+test("only an unseen session under exactly the requested name adopts the tab", () => {
+  assert.ok(adoptsProvisional(false, "api", "api"));
+  assert.ok(!adoptsProvisional(true, "api", "api"), "a session we already had is not the one we asked for");
+  assert.ok(!adoptsProvisional(false, "tests", "api"), "…and neither is somebody else's new session");
+  assert.ok(!adoptsProvisional(false, "api", null), "nothing pending, nothing to adopt");
+  assert.ok(!adoptsProvisional(false, "web:api", "api"), "a remote arrival is not the local one we asked for");
+});
+
+// ── the wiring in render.ts ────────────────────────────────────────────────────────────────────────
+
+test("creating a session opens the provisional tab instead of a modal", () => {
+  assert.match(RENDER, /openProvisional\(req\);/);
+  assert.doesNotMatch(RENDER, /showOpeningModal/, "the modal is gone, not merely hidden");
+  assert.doesNotMatch(RENDER, /hideOpeningModal/);
+  assert.match(RENDER, /status: \{ state: "working", sinceEpoch/, "the chip is honest: romp IS starting it");
+  assert.match(RENDER, /order\.push\(id\);/, "the tab survives reconcileTabOrder as a not-yet-kernel-known extra");
+});
+
+test("a send on a provisional tab is HELD, not posted to a session that doesn't exist", () => {
+  assert.match(RENDER, /if \(isProvisionalId\(sid\)\) \{\s*\n\s*provisionalQueue\.push\(text\);/);
+  assert.match(RENDER, /provisionalQueue\.push\(text\);\s*\n\s*registerOptimistic\(sid, text\);/,
+    "the dashed bubble goes up now — romp has it, it is not delivered");
+});
+
+test("adoption flushes the held messages FOR REAL and carries the draft across", () => {
+  assert.match(RENDER, /if \(adoptsProvisional\(existed, msg\.name, pendingNewSession\)\) \{\s*\n\s*adoptProvisional\(msg\.id\);/);
+  assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "sendMessage", id: realId, text \}\);/);
+  assert.match(RENDER, /registerOptimistic\(realId, text\);/);
+  // the draft must be set BEFORE the switch — setActive fills the box from `drafts`
+  const adopt = RENDER.slice(RENDER.indexOf("function adoptProvisional"));
+  assert.ok(adopt.indexOf("drafts.set(realId, draft)") < adopt.indexOf("setActive(realId)"),
+    "setActive reads the draft map, so the carry has to be in it first");
+});
+
+test("a failed create says so in a dialog, in the kernel's own words", () => {
+  assert.match(RENDER, /if \(provisionalId\) failProvisional\(m\.text\); else warnToast\(m\.text\);/);
+  assert.match(RENDER, /showConfirm\("Couldn't start " \+ name,/);
+  assert.match(RENDER, /What you typed is back in the message box\./,
+    "losing the text would be the one unrecoverable part");
+});
+
+test("the silent-failure backstop is long, because it is no longer what you wait on", () => {
+  const m = RENDER.match(/const PROVISIONAL_WAIT_MS = ([0-9_]+);/);
+  assert.ok(m, "there is still a backstop for a spawn that dies saying nothing");
+  assert.ok(Number(m![1].replace(/_/g, "")) >= 60_000, "well past the old 30s cue");
+});
+
+test("closing a provisional tab aborts the pending spawn", () => {
+  assert.match(RENDER, /if \(isProvisionalId\(id\)\) \{ cancelProvisional\(\); return; \}/);
+  assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "cancelCreate", name \}\)/);
+});
+
+test("the folder question retires the tab and holds what was typed for the retry", () => {
+  assert.match(RENDER, /const held = dropProvisional\(\);/);
+  assert.match(RENDER, /pendingCarry = \[\.\.\.held\.queued, held\.draft\]\.filter\(Boolean\)/);
+  assert.match(RENDER, /if \(ta && pendingCarry\) \{ ta\.value = pendingCarry; growComposer\(ta\); \}/);
+});
+
+test("a starting tab shows the romp loader, not the 'No messages yet' placeholder", () => {
+  assert.match(RENDER, /if \(isProvisionalId\(id\)\) \{\s*\n\s*ph\.classList\.add\("tx-starting"\);/);
+  assert.match(RENDER, /romp-swirl-glyph\.svg/);
+  assert.match(RENDER, /"Starting " \+ s\.name \+ "… you can type now; romp sends it when it's up\."/);
+  assert.match(CSS, /\.tx-starting-swirl \{[\s\S]*?animation: tx-starting-spin/);
+  assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.tx-starting-swirl \{ animation: none/);
+  assert.doesNotMatch(CSS, /opening-dots/, "the bouncing-dots modal CSS went with it");
+});

--- a/ui/webview/provisional.ts
+++ b/ui/webview/provisional.ts
@@ -1,0 +1,44 @@
+// A new session shows its chat box IMMEDIATELY, and starts behind it (the user 2026-07-30).
+//
+// Creating a session used to raise a modal "Opening session…" over the whole pane, and you waited: the
+// kernel resolves the directory, spawns tmux or connects the SDK, and the first transcript poll comes
+// back — seconds, sometimes many. Nothing could be typed in that gap, and the only thing on screen was a
+// dialog with three dots. So the tab appears at once with a working chip and a live composer; anything
+// typed is held and flushed the moment the real session lands, and a create that FAILS says so in a
+// dialog instead of the cue quietly timing out after thirty seconds.
+//
+// The provisional id must NOT contain a colon. Federation routes on `id`/`sid` and reads the part before
+// a colon as a HOST, so a "pending:" form would send every op on this tab to a machine named "pending" —
+// the same trap that swallowed follow-ups on remote cards. A dash keeps it unroutable and obviously not
+// a uuid.
+
+export const PROVISIONAL_PREFIX = "new-";
+
+/** Mint an id for a not-yet-created session. `seed` makes it unique; any colon in it is stripped. */
+export function mintProvisionalId(seed: string): string {
+  return PROVISIONAL_PREFIX + String(seed).replace(/[^a-zA-Z0-9]/g, "").slice(0, 24);
+}
+
+export function isProvisionalId(id: string | null | undefined): boolean {
+  return typeof id === "string" && id.startsWith(PROVISIONAL_PREFIX);
+}
+
+/**
+ * The name a created session will ARRIVE under, which is what the provisional tab is matched against: a
+ * remote session's tab is host-prefixed, a local one is bare.
+ */
+export function provisionalName(host: string, name: string): string {
+  return host ? host + ":" + name : name;
+}
+
+/**
+ * Does this freshly-arrived session adopt the provisional tab? Only a session we have never seen, whose
+ * name is exactly the one we asked for. Matching on the NAME is the only join available — the id is
+ * minted by the kernel and cannot be known in advance — so a session arriving under a different name is
+ * somebody else's, and adopting it would hand the queued text to the wrong conversation.
+ */
+export function adoptsProvisional(
+  existed: boolean, arrivedName: string, pendingName: string | null,
+): boolean {
+  return !existed && !!pendingName && arrivedName === pendingName;
+}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -20,6 +20,7 @@ import { delegate } from "./actions";
 import { isClearCmd, openTopTitles, clearConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
 import { reconcileTabOrder } from "./tab-order";
+import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
@@ -3768,54 +3769,103 @@ function tabInAdjacentRow(id: string, dir: number): string | null {
 let pickMode = false;
 let pickAllowNew = false;
 
-// "Opening session…" modal — shown the instant the user creates a session and
-// dismissed when its tab actually arrives (the kernel spawn → tmux → first
-// transcript poll has a visible delay; this is the "something is happening" cue).
+// The session you just created gets its TAB AND COMPOSER IMMEDIATELY, and starts behind them (the user
+// 2026-07-30). This replaced an "Opening session…" modal that covered the pane while the kernel resolved
+// the directory, spawned tmux or connected the SDK, and the first transcript poll came back — seconds you
+// could do nothing with, watching three dots. See ./provisional.ts for why the id carries no colon.
+//
+// `pendingNewSession` is the NAME the created session will arrive under; it is the only join available,
+// since the kernel mints the id. The provisional tab carries a working chip (romp genuinely is starting
+// it), a live composer, and anything typed into it, held until the real session lands.
 let pendingNewSession: string | null = null;
-let openingTimer: ReturnType<typeof setTimeout> | undefined;
-function showOpeningModal(name: string) {
-  hideOpeningModal();
-  pendingNewSession = name;
-  const overlay = el("div", "picker-overlay opening-overlay");
-  overlay.id = "opening";
-  overlay.style.display = "flex";
-  const box = el("div", "picker-box opening-box");
-  // ✕ to abort (the user 2026-07-14): a spawn sometimes fails and the cue would otherwise hang for the
-  // full 30s backstop. The ✕ / Esc / backdrop all drop the modal AND cancel the pending spawn.
-  const cancel = el("button", "opening-cancel");
-  cancel.textContent = "✕";
-  cancel.title = "Cancel — stop waiting and abort this session";
-  cancel.addEventListener("click", (e) => { e.stopPropagation(); cancelOpening(); });
-  const title = el("div", "opening-title"); title.textContent = "Opening session";
-  const nm = el("div", "opening-name"); nm.textContent = name;
-  const dots = el("div", "opening-dots"); dots.append(el("span"), el("span"), el("span"));
-  box.append(cancel, title, nm, dots);
-  overlay.appendChild(box);
-  // Backdrop click / Esc cancel too — mirrors showConfirm, so a hung spawn never traps the user. The key
-  // handler is stored on the node and removed in hideOpeningModal (no leaked listeners across opens).
-  overlay.addEventListener("click", (e) => { if (e.target === overlay) cancelOpening(); });
-  const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.stopPropagation(); cancelOpening(); } };
-  (overlay as any)._key = onKey;
-  document.addEventListener("keydown", onKey, true);
-  document.body.appendChild(overlay);
-  // safety net: never strand the modal if the session never materializes (spawn failed)
-  openingTimer = setTimeout(hideOpeningModal, 30000);
+let provisionalId: string | null = null;
+const provisionalQueue: string[] = [];
+let provisionalTimer: ReturnType<typeof setTimeout> | undefined;
+// Text typed into a provisional tab whose create had to ask something first, waiting for the retry's tab.
+let pendingCarry = "";
+// The backstop, for a create that fails with nothing said. Every failure the kernel CAN name arrives as a
+// warn / createDirMissing and lands the dialog at once; this covers a spawn that dies silently. It is
+// deliberately long — the point is that it is no longer what you wait on, the way the old 30s cue was.
+const PROVISIONAL_WAIT_MS = 90_000;
+
+function openProvisional(req: CreateReq): void {
+  dropProvisional();                       // never two at once: a second create supersedes the first
+  const display = provisionalName(req.host, req.name);
+  pendingNewSession = display;
+  const id = mintProvisionalId(Date.now().toString(36) + Math.random().toString(36).slice(2));
+  provisionalId = id;
+  sessions.set(id, { id, name: display, color: null, events: [],
+                     status: { state: "working", sinceEpoch: Math.floor(Date.now() / 1000) } });
+  order.push(id);                          // a tab the kernel does not know yet survives reconcileTabOrder
+  renderTabs();
+  setActive(id);
+  const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  // text carried over from a create that had to ask something first (the folder question): it was typed
+  // for THIS session, so it comes back into the box the retry opens rather than being stranded on
+  // whichever tab happened to be underneath.
+  if (ta && pendingCarry) { ta.value = pendingCarry; growComposer(ta); }
+  pendingCarry = "";
+  ta?.focus();                             // the whole point: you can start typing NOW
+  provisionalTimer = setTimeout(
+    () => failProvisional("romp asked to start it, but nothing came back."), PROVISIONAL_WAIT_MS);
 }
-function hideOpeningModal() {
+
+/** Retire the provisional tab and hand back whatever was typed into it, so nothing is ever just dropped. */
+function dropProvisional(): { queued: string[]; draft: string } {
+  const id = provisionalId;
+  provisionalId = null;
   pendingNewSession = null;
-  if (openingTimer) { clearTimeout(openingTimer); openingTimer = undefined; }
-  const o = document.getElementById("opening");
-  if (o) {
-    const k = (o as any)._key;
-    if (k) document.removeEventListener("keydown", k, true);
-    o.remove();
+  if (provisionalTimer) { clearTimeout(provisionalTimer); provisionalTimer = undefined; }
+  const queued = provisionalQueue.slice();
+  provisionalQueue.length = 0;
+  let draft = "";
+  if (id) {
+    const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+    draft = (activeId === id && ta) ? ta.value : (drafts.get(id) ?? "");
+    pendingSent.delete(id);                // the optimistic bubbles belong to a tab that is going away
+    dismissSession(id);                    // drops it from sessions/order/views and reselects
+  }
+  return { queued, draft };
+}
+
+// The real session arrived: move everything the provisional tab was holding onto it and focus it. The
+// queued messages send FOR REAL here — they were never sent before, because there was no session to send
+// them to; the dashed bubbles you saw were this client saying "received", not the kernel.
+function adoptProvisional(realId: string): void {
+  const { queued, draft } = dropProvisional();
+  if (draft) drafts.set(realId, draft);    // set BEFORE the switch — setActive fills the box from drafts
+  setActive(realId);
+  for (const text of queued) {
+    vscodeApi?.postMessage({ type: "sendMessage", id: realId, text });
+    registerOptimistic(realId, text);      // …and the bubble carries over to the tab that now owns it
+  }
+  if (draft) { persistDrafts(); const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null; if (ta) growComposer(ta); }
+}
+
+// A create that FAILED. The kernel's own words are the message wherever it gave any (a bad name, an
+// unreadable parent, the SDK setup hint) — a dialog naming the reason beats the old cue, which simply
+// stopped after thirty seconds and left you to work out that nothing had happened. Whatever was typed
+// comes back in the box, because losing it would be the one unrecoverable part of this.
+function failProvisional(why: string): void {
+  if (!provisionalId) return;
+  const name = pendingNewSession || "that session";
+  const { queued, draft } = dropProvisional();
+  const held = [...queued, draft].filter(Boolean).join("\n\n");
+  showConfirm("Couldn't start " + name,
+    why + (held ? "\n\nWhat you typed is back in the message box." : ""),
+    [{ label: "OK", value: "ok" }], () => { /* nothing to undo — the tab is already gone */ });
+  if (held) {
+    const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+    if (ta) { ta.value = held; growComposer(ta); }
+    if (activeId) { drafts.set(activeId, held); persistDrafts(); }
   }
 }
-// The ✕ / Esc / backdrop on the "Opening…" cue: drop the modal AND tell the kernel to abort the pending
-// spawn, so a slow-but-successful open doesn't leave behind an orphan session the user meant to cancel.
-function cancelOpening() {
-  const name = pendingNewSession;                  // hideOpeningModal nulls it — capture first
-  hideOpeningModal();
+
+// The ✕ on a provisional tab: tell the kernel to abort the pending spawn too, so a slow-but-successful
+// create doesn't leave behind an orphan session the user meant to cancel.
+function cancelProvisional(): void {
+  const name = pendingNewSession;
+  dropProvisional();
   if (name && vscodeApi) vscodeApi.postMessage({ type: "cancelCreate", name });
 }
 
@@ -4044,12 +4094,17 @@ function startCreate(req: CreateReq, mkdir = false): void {
   rememberDir(req.host, req.dir);   // what you used on that machine is the right prefill for it next time
   if (vscodeApi) vscodeApi.postMessage({ type: "createSession", ...req, ...(mkdir ? { mkdir: true } : {}) });
   closePicker();
-  // a remote session's tab arrives host-prefixed — register the prefixed name so the cue dismisses
-  showOpeningModal(req.host ? req.host + ":" + req.name : req.name);
+  // …and the tab is THERE, with a live composer, before the kernel has answered. A remote session's tab
+  // arrives host-prefixed, so that is the name the provisional one is matched against on arrival.
+  openProvisional(req);
 }
 
 function onCreateDirMissing(m: any): void {
-  hideOpeningModal();                    // the cue would otherwise spin over a dialog it hides
+  // The folder question supersedes the provisional tab: this create is not going to land as asked. Keep
+  // what was typed — "Create it and start" re-sends the very same create, so the text belongs to the
+  // session that is about to exist, not to whatever tab we happen to fall back to.
+  const held = dropProvisional();
+  pendingCarry = [...held.queued, held.draft].filter(Boolean).join("\n\n");
   const req = lastCreate;
   showConfirm("That folder isn't there",
     createDirPrompt(String(m.name), (m.status || null) as DirStatus | null, String(m.dir || "")),
@@ -4776,7 +4831,18 @@ function syncView(id: string, atBottom?: boolean): View {
     const only = v.el.childNodes.length === 1 ? (v.el.firstChild as HTMLElement) : null;
     if (!only || !only.classList?.contains("tx-empty")) {
       while (v.el.firstChild) v.el.removeChild(v.el.firstChild);
-      const ph = el("div", "tx-empty"); ph.textContent = "No messages yet."; v.el.appendChild(ph);
+      const ph = el("div", "tx-empty"); v.el.appendChild(ph);
+      // A PROVISIONAL tab is not empty, it is STARTING — so it wears the romp loader (the repo's rule for
+      // any wait), not the placeholder that tells you to send something. The composer below it is live
+      // either way: anything typed here is held and flushed when the session lands.
+      if (isProvisionalId(id)) {
+        ph.classList.add("tx-starting");
+        const sw = el("img", "tx-starting-swirl") as HTMLImageElement;
+        sw.src = mediaSrc("romp-swirl-glyph.svg"); sw.alt = ""; sw.onerror = () => sw.remove();
+        const wm = el("div", "tx-starting-msg");
+        wm.textContent = "Starting " + s.name + "… you can type now; romp sends it when it's up.";
+        ph.append(sw, wm);
+      } else ph.textContent = "No messages yet.";
     }
     v.rendered = 0; v.stale = false; v.winStart = 0; v.winEnd = 0;
     return v;
@@ -6946,11 +7012,11 @@ function upsert(msg: any) {
     renderBgTasks();
   }
   // A non-active session's view is left to sync lazily when it's next shown.
-  // The session the user just created has arrived → drop the "Opening…" cue and
-  // focus its fresh tab (the whole point of opening it).
-  if (!existed && pendingNewSession && msg.name === pendingNewSession) {
-    hideOpeningModal();
-    setActive(msg.id);
+  // The session the user just created has ARRIVED: the provisional tab hands over its queued messages
+  // and its draft to the real one, and this is where those messages actually reach the kernel — until
+  // now there was no session to send them to.
+  if (adoptsProvisional(existed, msg.name, pendingNewSession)) {
+    adoptProvisional(msg.id);
   }
   schedulePrebuild(); // startup + new content: build the off-screen tabs in idle so they open instantly
 }
@@ -7109,6 +7175,9 @@ function statusOnly(msg: any) {
 // The ✕'s own path: remember the close (see closingTabs), then drop the tab now. (dismissSession is ALSO how
 // a session dying on its own arrives — that one must not be recorded as a close of ours.)
 function closeTabLocally(id: string): void {
+  // A provisional tab has no session to close — closing it means "never mind", so it cancels the spawn
+  // the kernel may still be running, the way the old cue's ✕ did.
+  if (isProvisionalId(id)) { cancelProvisional(); return; }
   closingTabs.set(id, Date.now());
   dismissSession(id);
 }
@@ -7201,7 +7270,12 @@ window.addEventListener("message", (e: MessageEvent) => {
   }
   else if (m.type === "nextTab") cycleTab(1);
   else if (m.type === "prevTab") cycleTab(-1);
-  else if (m.type === "warn" && typeof m.text === "string" && m.text) warnToast(m.text);
+  else if (m.type === "warn" && typeof m.text === "string" && m.text) {
+    // A warn arriving while a create is in flight IS that create's verdict (a name the kernel won't take,
+    // an unreadable parent, the SDK setup hint). It gets a dialog naming the reason and takes the
+    // provisional tab down with it; a toast would slide past the one moment it needed to be read.
+    if (provisionalId) failProvisional(m.text); else warnToast(m.text);
+  }
   // `err` is the LOUD channel, deliberately distinct from `warn` (the user 2026-07-29): a warn toast fades
   // after 12s, which is right for "that name has a bad character" and wrong for "the message you just typed
   // was never sent." This one takes the confirm modal — it has to be dismissed — and hands the text back,
@@ -7404,6 +7478,17 @@ function setupComposer() {
     const sid = activeId;   // the session this send (and any confirm below) was armed for
     const deliver = () => {
       if (activeId !== sid) return;   // a confirm outlived a tab switch — never send into the wrong session
+      // A PROVISIONAL tab has no session behind it yet, so there is nothing to send to: hold the message
+      // and flush it the instant the real one lands (adoptProvisional). The dashed optimistic bubble goes
+      // up now, which is the honest reading — romp has your message, it has not been delivered — and it
+      // carries over to the real tab rather than being redrawn there.
+      if (isProvisionalId(sid)) {
+        provisionalQueue.push(text);
+        registerOptimistic(sid, text);
+        drafts.delete(sid); draftStartedAt.delete(sid); persistDrafts();
+        ta.value = ""; composerManualH = null; ta.style.height = "";
+        return;
+      }
       lastSent.set(activeId, text);   // remembered for a possible Ctrl+C restore
       // A pending citation chip → send as a FOLLOW-UP on that goal (the user 2026-07-01): askFollowUp wraps the
       // text with the goal's context + the romp-goal-id marker (kernel side), so the goal reopens (done→working,

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1674,29 +1674,16 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
   display: none; align-items: flex-start; justify-content: center;
   z-index: 1000; padding: 56px 16px 16px;
 }
-/* "Opening session…" modal: a small centered card with bouncing dots, shown from
-   session-create until its tab arrives (the spawn has a visible delay). */
-.opening-overlay { align-items: center; padding: 16px; }
-.opening-box {
-  position: relative;   /* anchors the ✕ cancel in the corner */
-  width: auto; max-height: none; align-items: center; text-align: center;
-  padding: 22px 32px; gap: 0;
-}
-/* ✕ to abort a spawn that hangs/fails (the user 2026-07-14): same close-button treatment as .queued-x. */
-.opening-cancel {
-  position: absolute; top: 5px; right: 6px; width: 22px; height: 22px;
-  display: flex; align-items: center; justify-content: center;
-  font: inherit; font-size: 0.78em; line-height: 1; cursor: pointer;
-  color: var(--dim); background: transparent; border: 0; border-radius: 6px; padding: 0;
-}
-.opening-cancel:hover { color: var(--vscode-errorForeground, #f48771); background: rgba(255, 255, 255, 0.08); }
-.opening-title { color: var(--dim); font-size: 0.74em; letter-spacing: 0.09em; text-transform: uppercase; }
-.opening-name { color: var(--fg); font-weight: 700; font-size: 1.05em; margin: 6px 0 15px; }
-.opening-dots { display: inline-flex; gap: 7px; }
-.opening-dots span { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); animation: opening-bounce 1.1s ease-in-out infinite; }   /* accent, not the working-yellow (the user 2026-06-24) */
-.opening-dots span:nth-child(2) { animation-delay: 0.15s; }
-.opening-dots span:nth-child(3) { animation-delay: 0.3s; }
-@keyframes opening-bounce { 0%, 80%, 100% { opacity: 0.3; transform: translateY(0); } 40% { opacity: 1; transform: translateY(-5px); } }
+/* A session that is STARTING (the user 2026-07-30). This replaced an "Opening session…" modal that
+   covered the pane with three bouncing dots while the kernel spawned the session — seconds you could do
+   nothing with. The tab and its composer are there from the first click instead, and the transcript area
+   holds the romp loader (the repo's rule for any wait) plus what to do: type, and romp sends it when the
+   session is up. The composer below is live the whole time. */
+.tx-starting { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+.tx-starting-swirl { width: 26px; height: 26px; opacity: 0.9; animation: tx-starting-spin 2.4s linear infinite; }
+.tx-starting-msg { color: var(--dim); }
+@keyframes tx-starting-spin { to { transform: rotate(-360deg); } }
+@media (prefers-reduced-motion: reduce) { .tx-starting-swirl { animation: none; } }
 
 /* LIFTED over the dashboard (the user 2026-07-29): while the shell has this iframe full-window, the page
    itself steps aside — no background, and its own content hidden — so what remains on screen is the

--- a/ui/webview/tab-close-optimistic.test.ts
+++ b/ui/webview/tab-close-optimistic.test.ts
@@ -111,7 +111,9 @@ test("a session dying on its OWN is not recorded as a close of ours", () => {
 // ---- the wiring in render.ts -------------------------------------------------------------------------
 
 test("closeTabLocally records the close, then drops the tab", () => {
-  assert.match(RENDER, /function closeTabLocally\(id: string\): void \{\s*\n\s*closingTabs\.set\(id, Date\.now\(\)\);\s*\n\s*dismissSession\(id\);/);
+  // (2026-07-30: a PROVISIONAL tab short-circuits above this — there is no session to close, so the ✕
+  // means "never mind" and cancels the spawn instead. A real tab's path is unchanged.)
+  assert.match(RENDER, /if \(isProvisionalId\(id\)\) \{ cancelProvisional\(\); return; \}\s*\n\s*closingTabs\.set\(id, Date\.now\(\)\);\s*\n\s*dismissSession\(id\);/);
   // declared beside tabMeta, NOT down by dismissSession: renderTabs reads it and can run before the module
   // finishes evaluating, which would make a `const` down there a temporal-dead-zone throw.
   assert.match(RENDER, /const tabMeta = new Map[\s\S]{0,900}?const closingTabs = new Map<string, number>\(\);/);

--- a/ui/webview/transcript-empty.test.ts
+++ b/ui/webview/transcript-empty.test.ts
@@ -15,7 +15,10 @@ test("syncView shows a 'No messages yet.' placeholder for a zero-event transcrip
   // the empty branch is the FIRST thing syncView does after resolving the session, so it covers every
   // entry point (sync show, deferred build, append, compact + non-compact) uniformly.
   assert.match(RENDER, /if \(s\.events\.length === 0\) \{/);
-  assert.match(RENDER, /el\("div", "tx-empty"\); ph\.textContent = "No messages yet\.";/);
+  // (2026-07-30: a PROVISIONAL tab takes the romp loader instead — it is not empty, it is starting —
+  // so the placeholder text moved to the else branch. A real empty transcript reads exactly as before.)
+  assert.match(RENDER, /el\("div", "tx-empty"\); v\.el\.appendChild\(ph\);/);
+  assert.match(RENDER, /\} else ph\.textContent = "No messages yet\.";/);
   // idempotent: an already-present placeholder is left alone (no churn on repeated pushes that stay empty)
   assert.match(RENDER, /only\.classList\?\.contains\("tx-empty"\)/);
 });

--- a/ui/webview/undelivered-err.test.ts
+++ b/ui/webview/undelivered-err.test.ts
@@ -18,8 +18,9 @@ test("chat: an `err` takes the confirm MODAL, not the warn toast", () => {
   assert.match(RENDER, /else if \(m\.type === "err" && typeof m\.text === "string" && m\.text\) \{/);
   assert.match(RENDER, /const title = typeof m\.title === "string" && m\.title \? m\.title : "That action was not delivered";/);
   assert.match(RENDER, /showConfirm\(title, m\.text,/);
-  // the fading toast stays for the soft cases it was written for
-  assert.match(RENDER, /m\.type === "warn" && typeof m\.text === "string" && m\.text\) warnToast\(m\.text\);/);
+  // the fading toast stays for the soft cases it was written for (unless a create is in flight, in which
+  // case the warn IS that create's verdict and takes a dialog of its own — 2026-07-30)
+  assert.match(RENDER, /if \(provisionalId\) failProvisional\(m\.text\); else warnToast\(m\.text\);/);
 });
 
 test("chat: the refused text is offered back, because the composer already cleared it", () => {

--- a/ui/webview/warn-toast.test.ts
+++ b/ui/webview/warn-toast.test.ts
@@ -15,7 +15,9 @@ const FEDERATION = ui("webview", "federation.ts");
 const STYLES = ui("webview", "styles.css");
 
 test("render handles kernel warn messages with a toast", () => {
-  assert.match(RENDER, /m\.type === "warn" && typeof m\.text === "string" && m\.text\) warnToast\(m\.text\)/);
+  // (2026-07-30: a warn arriving while a create is in flight IS that create's verdict, so it takes the
+  // dialog and retires the provisional tab. Every other warn still gets the toast.)
+  assert.match(RENDER, /if \(provisionalId\) failProvisional\(m\.text\); else warnToast\(m\.text\);/);
   assert.match(RENDER, /function warnToast\(msg: string\)/);
 });
 


### PR DESCRIPTION
Creating a session raised an "Opening session…" modal over the pane, and you waited: the kernel resolved the directory, spawned tmux or connected the SDK, and the first transcript poll came back. Seconds, sometimes many, with nothing to do but watch three bouncing dots.

**The tab is there from the first click**, with a working chip (romp genuinely is starting it) and a live composer. The transcript area holds the romp loader and says what to do, rather than the "No messages yet" placeholder — it isn't empty, it's starting.

**Anything typed is held and sent for real on arrival.** The dashed optimistic bubble goes up immediately, which is the honest reading: romp has your message, it is not delivered. On adoption the queued text actually reaches the kernel (there was no session to send it to before) and the bubbles carry over to the tab that now owns them, along with the draft.

**Failure gets said out loud.** A `warn` arriving while a create is in flight *is* that create's verdict — a name the kernel won't take, an unreadable parent, the SDK setup hint — so it takes a dialog carrying the kernel's own words and retires the tab, instead of sliding past as a toast while the cue span on regardless. The folder question keeps whatever was typed for the retry, since "Create it and start" re-sends the very same create. Closing a provisional tab cancels the pending spawn the way the old ✕ did. What's left of the 30-second timeout is a 90-second backstop for a spawn that dies saying nothing at all — it is no longer what you wait on.

**This covers mobile too**: the flow lives in the chat pane's own code, which is the bundle mobile loads.

## One thing worth flagging

The provisional id carries **no colon**, deliberately. Federation routes on `id`/`sid` and reads the part before a colon as a host, so a `pending:` form would address a machine named "pending" — the same trap that once swallowed follow-ups on remote cards. `provisional.ts` holds that reasoning next to the code it constrains.

## Tests

`ui/webview/provisional.test.ts` (new, 13 cases): the colon-free id contract across awkward seeds, the host-prefixed name join, adoption refusing anything but an unseen session under exactly the requested name, and the render.ts wiring — the hold-instead-of-post branch, the flush ordering (the draft must reach `drafts` before `setActive` reads it), the failure dialog, the backstop's floor, the cancel path, and the loader. Six stale pins updated with the reason.

3716 Python tests and 1514 node tests pass; typecheck clean. Verified the starting state visually headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)