### PR TITLE
A tunnel that connects and then dies is still a failing tunnel

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4983,6 +4983,55 @@ def _tunnel_backoff(fails):
     if fails >= TUNNEL_LONG_AFTER:
         return TUNNEL_BACKOFF_LONG
     return min(TUNNEL_BACKOFF_MAX, TUNNEL_BACKOFF_BASE * (2 ** min(fails, 5)))
+
+
+# ── a tunnel that connects and then dies is still a failing tunnel (the user 2026-07-30) ──────────────────
+# Two separate defects, one flap. A remote spent an afternoon cycling connect -> 30s of traffic -> torn down
+# -> reconnect, roughly twice a minute, while ssh worked every time and the far kernel answered in 5ms.
+#
+# TEARDOWN took ONE missed poll. A single 4-second timeout condemned a link that had been carrying traffic
+# milliseconds earlier — one sample, no confirmation, and the verdict was to destroy the connection. A miss
+# is now COUNTED, and the tunnel goes only when STALE_MISSES consecutive polls come back with nothing. Any
+# answer at all resets the count, so this is a run of confirming events, not a grace period: a genuinely
+# dead path still dies within a few seconds, and a single hiccup costs nothing.
+#
+# BACKOFF never engaged. It counted failed DIALS, and every dial here succeeded — the row sat at fails=0
+# forever, so the ladder built for exactly this ("keep trying, waiting longer each time") was bypassed by
+# the one failure mode that needed it most. A teardown now advances the ladder like any other failure, and
+# what CLEARS it is a run of STABLE_POLLS answered polls rather than the mere fact of connecting. A tunnel
+# that comes up and dies half a minute later never reaches that run, so it backs off; a healthy one clears
+# in well under a minute and a later drop starts from the bottom rung again.
+STALE_MISSES = 3     # consecutive silent polls before a live-looking tunnel is declared dead
+STABLE_POLLS = 8     # consecutive answered polls before a connection counts as established
+
+
+def _note_poll(r, answered):
+    """Record one end-to-end poll against a tunnel row, and say whether it has now MISSED enough in a row
+    to be considered dead. Pure bookkeeping on the row; the caller owns the teardown."""
+    if answered:
+        r["misses"] = 0
+        r["ok_polls"] = int(r.get("ok_polls") or 0) + 1
+        return False
+    r["ok_polls"] = 0
+    r["misses"] = int(r.get("misses") or 0) + 1
+    return r["misses"] >= STALE_MISSES
+
+
+def _tunnel_established(r):
+    """Whether this connection has answered enough consecutive polls to count as established — the event
+    that clears the backoff ladder. Merely being dialed is NOT it: that is what let a connect-then-die
+    loop run at full speed forever."""
+    return int(r.get("ok_polls") or 0) >= STABLE_POLLS
+
+
+def _note_tunnel_teardown(r, now):
+    """A connection we had to tear down is a FAILURE of the same kind a refused dial is, so it advances
+    the ladder and schedules the next attempt on it."""
+    r["ok_polls"] = 0
+    r["misses"] = 0
+    r["fails"] = int(r.get("fails") or 0) + 1
+    r["next_try"] = now + _tunnel_backoff(r["fails"])
+    return r["fails"]
 BUS_PORT = int(os.environ.get("ROMP_POSTAL_PORT", "25302"))      # this laptop's postal bus (reverse-forwarded)
 SSH_BIN = os.environ.get("ROMP_SSH_BIN", "ssh")                  # overridable for tests
 SSH_CONFIG = Path(os.environ.get("ROMP_SSH_CONFIG") or (Path.home() / ".ssh" / "config"))
@@ -5715,7 +5764,9 @@ _remotes_saved_sig = None   # signature of the last blob written — lets the su
 
 _NOT_SAVED = ("proc",       # the live Popen
               "usage",      # a remote's rate-limit snapshot: re-polled a minute after any boot, and
-              "_usage_at")  # persisting it would rewrite this 0600 credential file every minute forever
+              "_usage_at",  # persisting it would rewrite this 0600 credential file every minute forever
+              "misses",     # the poll run counters: they describe THIS connection, and a fresh boot
+              "ok_polls")   # dials from scratch, so carrying them across would judge a link that is gone
 
 
 def _remotes_rows_for_save():
@@ -7072,6 +7123,9 @@ def _tunnel_supervisor():
                         # the reverse forward IS the liveness: answering → up; port open but silent →
                         # no-kernel; closed → down (the mobile left; its next handshake heals the row)
                         st = "up" if (up and sids is not None) else ("no-kernel" if up else "down")
+                        # same run bookkeeping (no teardown — this side owns no ssh to tear down), so a
+                        # checked-in peer still reaches "established" and clears its ladder
+                        _note_poll(r, st == "up")
                     else:
                         st = _tunnel_status(_tunnel_proc_alive(r), up, sids is not None)
                         # A LIVE ssh is not proof of a live tunnel (the user 2026-07-29). ssh answers the
@@ -7085,17 +7139,25 @@ def _tunnel_supervisor():
                         # that REFUSED is a real no-kernel and must be left alone, while one that never
                         # answered at all means the path is gone. Kill it and let the branch above re-dial —
                         # once, on the transition, never on a timer.
-                        if st == "no-kernel" and r.get("_probe") == "timeout":
+                        silent = (st == "no-kernel" and r.get("_probe") == "timeout")
+                        if _note_poll(r, not silent):
                             _tunnel_log(r["host"], "stale-tunnel",
                                         pid=(r["proc"].pid if r.get("proc") else 0),
+                                        misses=int(r.get("misses") or 0),
                                         note="local forward accepts but nothing answered through it")
                             try:
                                 r["proc"].terminate()
                             except Exception:
                                 pass
                             st = "down"
-                            r["detail"] = ("the link to %s stopped carrying traffic — romp is dialing "
-                                           "again") % r["host"]
+                            # …and this counts as a FAILURE, so the next dial waits. Without it the row
+                            # sat at fails=0 through an afternoon of connect-and-die and never backed off.
+                            n = _note_tunnel_teardown(r, now)
+                            r["detail"] = ("the link to %s keeps dropping after it connects — romp is "
+                                           "waiting %ds before dialing again") % (r["host"], _tunnel_backoff(n))
+                        elif silent:
+                            # a miss, but not yet a run of them: say so and leave the link alone
+                            st = r.get("status") or st
                     if not (st == "down" and r.get("status") == "error") and not r.get("booting"):
                         # Every status CHANGE on the record, so an outage leaves a timeline instead of a
                         # single end-state to reason backwards from: when it flipped, what the end-to-end
@@ -7108,8 +7170,13 @@ def _tunnel_supervisor():
                         r["status"] = st                   # keep a richer spawn-error label over plain 'down';
                         #                                    a Start in flight (`booting`) owns the row's phase
                     if st == "up":
-                        r["fails"], r["next_try"] = 0, 0   # healthy end-to-end → clear the backoff, so a
-                        r.pop("gave_up", None)             #   later drop starts its ladder from 15s again
+                        # Clearing the ladder is earned by a RUN of answered polls, not by the mere fact of
+                        # connecting (the user 2026-07-30): a tunnel that comes up and dies thirty seconds
+                        # later used to reset `fails` on every single cycle, which is precisely why it
+                        # flapped at full speed for hours instead of backing off.
+                        if _tunnel_established(r):
+                            r["fails"], r["next_try"] = 0, 0   # healthy end-to-end → clear the backoff, so a
+                            r.pop("gave_up", None)             #   later drop starts its ladder from 15s again
                         r["last_ok"] = time.time()         # the moment the cached sha/tier below were TRUE,
                         #                                    so a later down row can date what it remembers
                         if r.get("detail"):

--- a/tests/test_tunnel_flap.py
+++ b/tests/test_tunnel_flap.py
@@ -1,0 +1,148 @@
+"""A tunnel that connects and then dies is still a failing tunnel (the user 2026-07-30).
+
+A remote spent an afternoon cycling: connect, carry traffic for ~30 seconds, get torn down, reconnect —
+roughly twice a minute, for hours. ssh worked every time (the dial log's own host-probe said so on every
+death) and the far kernel answered in about 5ms. Two separate defects made that loop:
+
+TEARDOWN TOOK ONE MISSED POLL. A single 4-second timeout condemned a link that had been carrying traffic
+milliseconds earlier — one sample, no confirmation, and the verdict was to destroy the connection.
+
+BACKOFF NEVER ENGAGED. It counted failed DIALS, and every dial here succeeded, so the row sat at fails=0
+forever and the ladder built for "keep trying, waiting longer each time" was bypassed by the one failure
+mode that needed it most.
+
+Both are the repo's standing smell: a time-based heuristic standing in for an event. The fix counts
+CONFIRMING EVENTS at both ends — a run of silent polls before a teardown, a run of answered polls before
+the ladder clears.
+
+Synthetic rows only; nothing dials anything.
+"""
+import inspect
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_flap", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class MissRun(unittest.TestCase):
+    """One silent poll is a hiccup. A RUN of them is a dead path."""
+
+    def test_a_single_miss_never_tears_down_a_working_link(self):
+        r = {"host": "api"}
+        self.assertFalse(km._note_poll(r, False), "one 4-second timeout is not evidence of a dead tunnel")
+
+    def test_a_run_of_misses_does(self):
+        r = {"host": "api"}
+        verdicts = [km._note_poll(r, False) for _ in range(km.STALE_MISSES)]
+        self.assertEqual(verdicts[:-1], [False] * (km.STALE_MISSES - 1))
+        self.assertTrue(verdicts[-1], "consecutive silence IS the event that condemns the link")
+
+    def test_any_answer_at_all_resets_the_run(self):
+        r = {"host": "api"}
+        for _ in range(km.STALE_MISSES - 1):
+            km._note_poll(r, False)
+        km._note_poll(r, True)                       # it spoke → the run so far meant nothing
+        self.assertFalse(km._note_poll(r, False), "a hiccup every other poll must never accumulate")
+
+    def test_a_genuinely_dead_path_still_dies_quickly(self):
+        # the point of a RUN, not a grace period: this costs a few poll cycles, not a wall-clock window
+        self.assertLessEqual(km.STALE_MISSES, 5)
+
+
+class LadderClearing(unittest.TestCase):
+    """Connecting is not succeeding. Answering, repeatedly, is."""
+
+    def test_merely_connecting_does_not_count_as_established(self):
+        r = {"host": "api"}
+        km._note_poll(r, True)
+        self.assertFalse(km._tunnel_established(r),
+                         "one answered poll is what the flapping tunnel managed every single cycle")
+
+    def test_a_run_of_answered_polls_does(self):
+        r = {"host": "api"}
+        for _ in range(km.STABLE_POLLS):
+            km._note_poll(r, True)
+        self.assertTrue(km._tunnel_established(r))
+
+    def test_a_teardown_advances_the_ladder_and_schedules_on_it(self):
+        r = {"host": "api"}
+        n1 = km._note_tunnel_teardown(r, 1000.0)
+        self.assertEqual(n1, 1)
+        self.assertEqual(r["next_try"], 1000.0 + km._tunnel_backoff(1))
+        n2 = km._note_tunnel_teardown(r, 2000.0)
+        self.assertEqual(n2, 2, "a second connect-and-die waits longer, like any repeated failure")
+        self.assertGreater(km._tunnel_backoff(n2), km._tunnel_backoff(n1))
+
+    def test_a_teardown_clears_the_run_so_the_next_incarnation_earns_it_afresh(self):
+        r = {"host": "api"}
+        for _ in range(km.STABLE_POLLS):
+            km._note_poll(r, True)
+        km._note_tunnel_teardown(r, 1000.0)
+        self.assertFalse(km._tunnel_established(r))
+        self.assertEqual(r.get("misses"), 0)
+
+    def test_the_flap_this_was_built_for_actually_backs_off_now(self):
+        # replay the observed loop: up, a handful of answered polls, then silence, over and over. The old
+        # code reset fails to 0 on every cycle and redialed at full speed forever.
+        r = {"host": "api"}
+        waits = []
+        for cycle in range(5):
+            for _ in range(4):                      # it answered for a while — but never STABLE_POLLS
+                km._note_poll(r, True)
+                if km._tunnel_established(r):
+                    r["fails"] = 0
+            dead = False
+            while not dead:
+                dead = km._note_poll(r, False)
+            waits.append(km._tunnel_backoff(km._note_tunnel_teardown(r, 0.0)))
+        self.assertEqual(waits, sorted(waits), "each repeat waits at least as long as the last")
+        self.assertGreater(waits[-1], waits[0], "…and it genuinely climbs, rather than sitting at fails=0")
+
+    def test_a_healthy_link_still_clears_its_ladder_promptly(self):
+        # STABLE_POLLS at the supervisor's own cadence must be well under a minute, or a real recovery
+        # would carry a stale backoff into its next outage
+        self.assertLessEqual(km.STABLE_POLLS, 12)
+
+
+class Wiring(unittest.TestCase):
+    def test_the_supervisor_requires_the_run_before_it_kills_a_tunnel(self):
+        src = inspect.getsource(km._tunnel_supervisor)
+        self.assertIn('silent = (st == "no-kernel" and r.get("_probe") == "timeout")', src)
+        self.assertIn("if _note_poll(r, not silent):", src)
+        self.assertIn("_note_tunnel_teardown(r, now)", src)
+
+    def test_a_miss_short_of_the_run_leaves_the_row_where_it_was(self):
+        src = inspect.getsource(km._tunnel_supervisor)
+        self.assertIn('elif silent:\n                            # a miss, but not yet a run of them', src)
+
+    def test_up_clears_the_ladder_only_once_established(self):
+        src = inspect.getsource(km._tunnel_supervisor)
+        self.assertIn("if _tunnel_established(r):", src)
+        i = src.index("if _tunnel_established(r):")
+        self.assertIn('r["fails"], r["next_try"] = 0, 0', src[i:i + 400])
+
+    def test_a_checked_in_peer_keeps_the_same_run_bookkeeping(self):
+        # it owns no ssh here (nothing to tear down), but without the run it would never read as
+        # established and its ladder would stop clearing
+        src = inspect.getsource(km._tunnel_supervisor)
+        self.assertIn('_note_poll(r, st == "up")', src)
+
+    def test_the_counters_describe_this_connection_and_never_reach_disk(self):
+        self.assertIn("misses", km._NOT_SAVED)
+        self.assertIn("ok_polls", km._NOT_SAVED)
+
+    def test_the_row_says_what_is_actually_wrong(self):
+        src = inspect.getsource(km._tunnel_supervisor)
+        self.assertIn("keeps dropping after it connects", src,
+                      "'stopped carrying traffic' described one poll; this describes the pattern")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tunnel_stale_and_logging.py
+++ b/tests/test_tunnel_stale_and_logging.py
@@ -75,26 +75,34 @@ class SupervisorActsOnTheVerdict(unittest.TestCase):
         self.src = _i.getsource(km._tunnel_supervisor)
 
     def test_a_timed_out_no_kernel_row_is_killed_so_the_dead_proc_path_redials(self):
-        self.assertIn('if st == "no-kernel" and r.get("_probe") == "timeout":', self.src,
-                      "the stale-tunnel kill keys on the probe verdict, never on a timer or a counter")
+        # The verdict is unchanged; what changed on 2026-07-30 is that it now takes a RUN of them. A
+        # single 4-second timeout used to condemn a link that had been carrying traffic milliseconds
+        # earlier, which is what made a remote flap twice a minute for hours (see test_tunnel_flap.py).
+        self.assertIn('silent = (st == "no-kernel" and r.get("_probe") == "timeout")', self.src,
+                      "the kill still keys on the probe verdict, never on a timer")
+        self.assertIn("if _note_poll(r, not silent):", self.src, "…and now on a run of them")
         self.assertIn('r["proc"].terminate()', self.src)
         self.assertIn("stale-tunnel", self.src, "and it goes on the record")
 
     def test_the_kill_is_never_reached_on_a_refusal(self):
         # A refusal proves the tunnel carries traffic — churning its ssh would be pure damage, and would
         # re-dial every 15s forever against a box whose romp is deliberately off. So the ONLY terminate()
-        # in the supervisor must sit under the timeout-qualified guard, not under the plain no-kernel
-        # branch that writes the row's detail.
+        # in the supervisor must sit under the silence-qualified guard, not under the plain no-kernel
+        # branch that writes the row's detail. `silent` is false for a refusal, so _note_poll is told the
+        # link ANSWERED and the run resets — a refusing host can never accumulate its way to a kill.
         lines = self.src.splitlines()
-        guard = [i for i, ln in enumerate(lines) if 'st == "no-kernel" and r.get("_probe") == "timeout"' in ln]
+        verdict = [i for i, ln in enumerate(lines) if 'silent = (st == "no-kernel"' in ln]
+        self.assertEqual(len(verdict), 1, "one place decides what silence is")
+        guard = [i for i, ln in enumerate(lines) if "if _note_poll(r, not silent):" in ln]
         self.assertEqual(len(guard), 1, "one guard")
+        self.assertLess(verdict[0], guard[0], "the verdict is computed before it is counted")
         # the only kill in the STATUS-handling region belongs to that guard. (The route-change block near
         # the top of the loop drops tunnels too, and legitimately so — the network moved under all of them —
         # so this is scoped to the per-host status branch rather than counting the whole function.)
         region = [i for i, ln in enumerate(lines) if "terminate()" in ln and i > guard[0] - 20]
         self.assertEqual(len(region), 1, "one kill in the status branch")
         self.assertLess(guard[0], region[0], "the kill is inside the guard")
-        self.assertLess(region[0] - guard[0], 6, "and directly under it, not in some later branch")
+        self.assertLess(region[0] - guard[0], 8, "and directly under it, not in some later branch")
         plain = [i for i, ln in enumerate(lines) if 'elif st == "no-kernel"' in ln]
         self.assertTrue(plain and plain[0] > region[0],
                         "the detail-only no-kernel branch comes after, and kills nothing")

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -999,9 +999,14 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .host-prefix { color: var(--dim); font-weight: 400; font-style: italic; font-size: 0.88em; }
 /* DISCONNECTED host (the user 2026-07-29): its sessions keep their tabs, lanes and cards — dropping them
    would lose the thread — but the "host:" token says the link is down, so nobody reads a frozen transcript
-   thinking it is live. Struck + dimmed, the strike on the HOST only: a struck WHOLE name already means a
-   dead session, and this session may be perfectly alive on a machine we simply cannot reach. */
-.host-prefix.off { text-decoration: line-through; opacity: 0.75; }
+   thinking it is live. Marked on the HOST only: a marked WHOLE name already means a dead session, and this
+   session may be perfectly alive on a machine we simply cannot reach. The mark is the STALE treatment
+   rather than a strikethrough (2026-07-30) — what it says is "the last state romp got", not "cancelled".
+   One treatment, two sheets: keep this identical to styles.css. */
+.host-prefix.off {
+  opacity: 0.75; font-style: italic;
+  text-decoration: underline dotted 1px; text-underline-offset: 2px;
+}
 
 /* the VS Code pipe-down banner — see styles.css (one treatment, two sheets) */
 #rpipe { position: fixed; top: 0; left: 0; right: 0; z-index: 99999; text-align: center;

--- a/ui/webview/host-offline-ux.test.ts
+++ b/ui/webview/host-offline-ux.test.ts
@@ -1,0 +1,74 @@
+// What a disconnected host looks like from inside the chat (the user 2026-07-30, watching a remote flap).
+//
+// Three changes, one complaint: the only cue was a strikethrough on the "host:" token, which said the
+// wrong thing in the wrong place and said nothing at all about the message you were about to lose.
+//
+//   1. Strikethrough reads as CANCELLED. The session is fine; the LINK is down and what is on screen is
+//      the last state romp got. That is "stale", and romp already has a treatment for stale.
+//   2. The tab mark is peripheral once you are reading. The transcript itself should say why it ends.
+//   3. Nothing stopped a send into a session whose kernel is unreachable.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const HOSTPFX = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "host-prefix.ts"), "utf8");
+
+test("an unreachable host reads as STALE, not as struck out", () => {
+  assert.doesNotMatch(CSS, /\.host-prefix\.off \{[^}]*line-through/,
+    "strikethrough claims the session is gone; it is the link that is down");
+  assert.match(CSS, /\.host-prefix\.off \{[\s\S]*?text-decoration: underline dotted 1px/);
+  assert.match(CSS, /\.host-prefix\.off \{[\s\S]*?font-style: italic/);
+});
+
+test("it is the SAME stale vocabulary the network panel already uses", () => {
+  // one language for "remembered, not live" across surfaces — .rnet-stale is the kernel-side twin
+  const rule = CSS.slice(CSS.indexOf(".host-prefix.off"));
+  assert.match(rule, /text-underline-offset: 2px/);
+});
+
+test("the mark still goes on the host token, never the session name", () => {
+  // a struck WHOLE name already means a dead session; the two claims must stay distinguishable
+  assert.match(HOSTPFX, /h\.className = off \? "host-prefix off" : "host-prefix";/);
+  assert.match(HOSTPFX, /the STALE treatment, not strikethrough/);
+});
+
+test("the transcript says why it ends, at the END, where the eye lands", () => {
+  assert.match(RENDER, /function syncHostOfflineFoot\(\): void \{/);
+  assert.match(RENDER, /is disconnected — this is the last romp got from it\. Reconnecting\./);
+  assert.match(RENDER, /note\.id = "host-offline-foot";/);
+  assert.match(CSS, /\.tx-hostoff \{/);
+});
+
+test("the foot is a SIBLING of the view, never a child of it", () => {
+  // syncView counts v.el's children to track what it has rendered — a foot inside would read as transcript
+  assert.match(RENDER, /content\.appendChild\(note\);/);
+  assert.match(RENDER, /A sibling of the view element, never a child/);
+});
+
+test("it is not a top banner — one covered the tab strip and was removed", () => {
+  assert.match(RENDER, /Deliberately NOT a top banner/);
+  assert.doesNotMatch(RENDER, /id = "rhostoff"/);
+});
+
+test("it repaints on both render paths, before the scroll maths", () => {
+  assert.match(RENDER, /syncView\(activeId, stick\);\s*\n\s*syncHostOfflineFoot\(\);/);
+  assert.match(RENDER, /syncHostOfflineFoot\(\);\s*\/\/ the tab we just switched to/);
+});
+
+test("it clears itself the moment the host is back", () => {
+  assert.match(RENDER, /if \(!activeId \|\| !hostIsDown\(activeId\)\) \{ existing\?\.remove\(\); return; \}/);
+});
+
+test("a send into a disconnected session is refused, and the text is KEPT", () => {
+  assert.match(RENDER, /if \(hostIsDown\(sid\)\) \{/);
+  assert.match(RENDER, /is disconnected, so this wasn't sent\. It's still in the box/);
+  // the refusal must come BEFORE the box is cleared, or the message is gone
+  const deliver = RENDER.slice(RENDER.indexOf("const deliver = () =>"));
+  const guard = deliver.indexOf("if (hostIsDown(sid)) {");
+  const clear = deliver.indexOf('ta.value = "";');
+  assert.ok(guard >= 0 && clear >= 0 && guard < clear,
+    "clearing the composer and delivering nothing is the one outcome to rule out");
+});

--- a/ui/webview/host-offline.test.ts
+++ b/ui/webview/host-offline.test.ts
@@ -82,8 +82,11 @@ test("the manager publishes reachability off the KERNEL's tunnel health, and onl
 test("the mark goes on the HOST token, never on the session name", () => {
   // a struck WHOLE name already means a dead session; this session may be perfectly alive
   assert.match(read("host-prefix.ts"), /h\.className = off \? "host-prefix off" : "host-prefix"/);
-  assert.match(CSS, /\.host-prefix\.off \{ text-decoration: line-through; opacity: 0\.75; \}/);
-  assert.match(FEEDCSS, /\.host-prefix\.off \{ text-decoration: line-through/, "the feed page loads only feed.css");
+  // (2026-07-30: the cue became the STALE treatment — dim italic, dotted underline — because
+  // strikethrough claimed the session was gone when it is the LINK that is down. See host-offline-ux.)
+  assert.match(CSS, /\.host-prefix\.off \{[\s\S]*?text-decoration: underline dotted 1px/);
+  assert.match(FEEDCSS, /\.host-prefix\.off \{[\s\S]*?text-decoration: underline dotted 1px/,
+    "the feed page loads only feed.css");
 });
 
 test("the tab dims as a whole and carries the why on hover", () => {

--- a/ui/webview/host-prefix.ts
+++ b/ui/webview/host-prefix.ts
@@ -20,7 +20,8 @@ export function hostPrefix(name: string | null | undefined, sid: string | null |
  *  read a remote's transcripts for a while before noticing nothing was connected). The mark goes on the
  *  "host:" token, not the session name: the LINK is what is gone, not the session — and a struck WHOLE
  *  name already means a dead session, so the two can never be confused. A CSS cue and a title, never a
- *  glyph. */
+ *  glyph. The cue itself is the STALE treatment, not strikethrough (2026-07-30): what this says is "the
+ *  last state romp got", which is what .rnet-stale already says in the network panel. */
 export function hostNameNodes(name: string, sid: string | null | undefined): Node[] {
   const p = hostPrefix(name, sid);
   if (!p) return [document.createTextNode(name)];

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5247,6 +5247,7 @@ function showActive() {
   // tint the whole-window border with the active session's identity color
   if (s.color && s.color.bg) document.body.style.setProperty("--active-accent", s.color.bg);
   else document.body.style.removeProperty("--active-accent");
+  syncHostOfflineFoot();   // the tab we just switched to may sit on an unreachable host
   touchMru(activeId!); // record activation order so close returns to the previous tab
   const v = ensureView(activeId!);
   // Bound the switch. A view the user scrolled to the top of has had its window expanded to the WHOLE
@@ -5398,6 +5399,29 @@ function restoreScrollAnchor(content: HTMLElement, v: View, a: { uuid: string; y
 // messages were jumping the view "backwards"; the compact path FULL-REBUILDS on append, clearing the DOM and
 // resetting scrollTop). Pass atBottom=false so the rebuild keeps winStart, then restore ANCHOR-relative
 // (captureScrollAnchor) — the raw scrollTop only as the eviction fallback.
+// A disconnected host's transcript SAYS SO where it ends (the user 2026-07-30). The tab mark is
+// peripheral once you are reading — you notice it after the fact, if at all — so the note goes at the
+// bottom of the conversation, which is where the eye already lands and where "nothing more is coming"
+// belongs. Deliberately NOT a top banner: one lived there for a few hours on 2026-07-29 and covered the
+// session tab strip, hiding the sessions in order to announce that a machine had gone away.
+//
+// A sibling of the view element, never a child: syncView counts v.el's children to track what it has
+// rendered, so a foot node inside it would read as transcript.
+function syncHostOfflineFoot(): void {
+  const content = document.getElementById("content");
+  if (!content) return;
+  const existing = document.getElementById("host-offline-foot");
+  if (!activeId || !hostIsDown(activeId)) { existing?.remove(); return; }
+  const host = String(activeId).slice(0, String(activeId).indexOf(":"));
+  const text = host + " is disconnected — this is the last romp got from it. Reconnecting.";
+  if (existing) { if (existing.textContent !== text) existing.textContent = text; return; }
+  const note = el("div", "tx-hostoff");
+  note.id = "host-offline-foot";
+  note.textContent = text;
+  note.title = hostDownNote(activeId);   // the one place that note is worded — host-prefix.ts
+  content.appendChild(note);
+}
+
 function appendActive() {
   const content = document.getElementById("content");
   if (!content || !activeId) { showActive(); return; }
@@ -5406,6 +5430,7 @@ function appendActive() {
   const before = content.scrollTop;
   const anchor = !stick && v ? captureScrollAnchor(content, v) : null;
   syncView(activeId, stick);
+  syncHostOfflineFoot();                 // before the scroll maths: it changes scrollHeight
   updateStatusline();
   if (stick) content.scrollTop = content.scrollHeight;
   else if (!(v && restoreScrollAnchor(content, v, anchor))) content.scrollTop = before;
@@ -7482,6 +7507,15 @@ function setupComposer() {
       // and flush it the instant the real one lands (adoptProvisional). The dashed optimistic bubble goes
       // up now, which is the honest reading — romp has your message, it has not been delivered — and it
       // carries over to the real tab rather than being redrawn there.
+      // A session on an unreachable host cannot receive this: the kernel that owns it is the far end of a
+      // link that is down. Refuse BEFORE the box is cleared, so the message stays exactly where you typed
+      // it (the user 2026-07-30) — silently accepting it would clear the composer and deliver nothing.
+      if (hostIsDown(sid)) {
+        const host = String(sid).slice(0, String(sid).indexOf(":"));
+        warnToast(host + " is disconnected, so this wasn't sent. It's still in the box — romp is "
+          + "reconnecting, and you can send it then.");
+        return;
+      }
       if (isProvisionalId(sid)) {
         provisionalQueue.push(text);
         registerOptimistic(sid, text);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2044,9 +2044,24 @@ body.picker-lifted > #picker { align-items: center; padding: 24px 16px; }
    would lose the thread — but the "host:" token says the link is down, so nobody reads a frozen transcript
    thinking it is live. Struck + dimmed, the strike on the HOST only: a struck WHOLE name already means a
    dead session, and this session may be perfectly alive on a machine we simply cannot reach. */
-.host-prefix.off { text-decoration: line-through; opacity: 0.75; }
+/* An unreachable host's prefix reads as STALE, not as gone (the user 2026-07-30). Strikethrough said
+   "cancelled/dead", which is the wrong claim: the session is fine, it is the LINK that is down and what
+   you are looking at is the last state romp got. This is the same dim-italic dotted-underline the network
+   panel already uses for a remembered-not-live value (.rnet-stale), so one vocabulary covers every
+   surface. A CSS cue and a title, never a glyph. */
+.host-prefix.off {
+  opacity: 0.75; font-style: italic;
+  text-decoration: underline dotted 1px; text-underline-offset: 2px;
+}
+/* The end of a disconnected host's transcript (the user 2026-07-30): where the conversation stops, a
+   line saying that is where it stops BECAUSE the link is down, not because nothing more happened. Quiet
+   and dim — it is a footnote on the reading, not an alarm — and it wears the same dotted-underline stale
+   vocabulary as the host token above it. */
+.tx-hostoff {
+  color: var(--dim); text-align: center; padding: 14px 28px 22px; font-size: 0.86em; font-style: italic;
+}
 /* the tab of a session on an unreachable host: dimmed as a whole, so "not connected" is glanceable and
-   the struck "host:" inside it is the detail one look further in. */
+   the marked "host:" inside it is the detail one look further in. */
 .tab.host-off { opacity: 0.62; }
 .tab.host-off:hover, .tab.host-off.active { opacity: 1; }
 


### PR DESCRIPTION
A remote spent an afternoon cycling: connect, carry traffic ~30s, get torn down, reconnect — roughly twice a minute, for hours. ssh worked on *every* probe (`sshOk: true` in `tunnel-dials.jsonl`, every death) and the far kernel answered `/sessions` in ~5ms. Two defects made that loop, and one display problem made it hard to read.

## The flap

**Teardown took one missed poll.** A single 4-second timeout condemned a link that had been carrying traffic milliseconds earlier — one sample, no confirmation, and the verdict was to destroy the connection. A miss is now counted, and the tunnel goes only after `STALE_MISSES` consecutive silent polls. Any answer at all resets the run, so this is a run of confirming *events*, not a grace period: a genuinely dead path still dies in seconds, a hiccup costs nothing. A *refusal* still never kills the tunnel — that invariant is unchanged and still pinned.

**Backoff never engaged.** This is the worse one. The ladder counted failed *dials*, and every dial here succeeded — the live row read `fails: 0` after hours of churn, so the exponential backoff built for "keep trying, waiting longer each time" was bypassed by the one failure mode that needed it most. A teardown now advances the ladder like any other failure, and what *clears* it is a run of `STABLE_POLLS` answered polls rather than the bare fact of connecting. A tunnel that comes up and dies half a minute later never reaches that run, so it backs off; a healthy one clears in well under a minute.

Both were the repo's standing smell: a time-based heuristic standing in for an event.

## The display

- **Strikethrough → the stale treatment.** A struck host token reads as *cancelled*. The session is fine; the **link** is down, and what's on screen is the last state romp got. That's "stale", and romp already has a treatment for it (`.rnet-stale` in the network panel) — dim, italic, dotted underline. One vocabulary, every surface. Changed in **both** sheets; the feed page loads only `feed.css`, and its existing pin caught that I'd missed it.
- **The transcript says why it ends**, at the end, where the eye already lands and where "nothing more is coming" belongs. Deliberately *not* a top banner — one lived there for a few hours on 07-29 and covered the session tab strip. It's a sibling of the view element, never a child, since `syncView` counts `v.el`'s children to track what it has rendered.
- **A send into a disconnected session is refused before the box is cleared**, so the message stays where it was typed. Silently accepting it cleared the composer and delivered nothing.

## Tests

`tests/test_tunnel_flap.py` (new, 16 cases): one miss never tears down, a run does, any answer resets it, a teardown advances and schedules on the ladder, and a replay of the observed connect-and-die loop that asserts the waits actually climb instead of sitting at zero. `ui/webview/host-offline-ux.test.ts` (new, 9 cases): the stale treatment in both sheets, the foot's placement and self-clearing, and that the composer guard sits *before* the clear. Three stale pins updated with the reason.

3757 Python tests and 1525 node tests pass; typecheck clean. Verified both display states visually headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)