### PR TITLE
A seed episode row is no floor, so founding prompts keep their cards

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3369,11 +3369,17 @@ def append_episode_settle(sid, head, t, settled):
 
 
 def episode_floor(sid):
-    """The current episode's start time for `sid`, or None if no episode was ever recorded. The
-    placement fuzzy-match scope (see _placed_key): evidence recorded before this instant belongs to
-    a conversation the agent can no longer see."""
-    row = episode_last(sid)
-    return row.get("t") if row else None
+    """The current episode's start time for `sid`, or None until a /clear BOUNDARY is recorded. Both
+    consumers — the _placed_key fuzzy-match scope and the planner's pre-episode retirement — reason
+    about evidence from a conversation the agent can no longer see, and only a /clear creates one:
+    the log's row 0 is a SEED (whatever episode was current at first observation), never a boundary.
+    The seed's t must not serve as a floor (the user 2026-07-30): a session spawned WITH its prompt
+    stamps that founding segment at the send moment, but the CLI boots for a second or more before
+    writing the transcript head that becomes the seed's t — so the session's first ask read as
+    pre-episode and was retired, zero cards ever minted, across nine spawned-with-prompt sessions
+    in the guard's first three days."""
+    rows = episode_rows(sid)
+    return rows[-1].get("t") if len(rows) >= 2 else None
 
 
 _discover_lock = threading.Lock()
@@ -5079,7 +5085,9 @@ def _plan_session(fsid, path, now):
             # filed done-verdicts on three-day-old cards, resurfacing them as freshly completed. The
             # boundary settle usually hides this (verdicts on cleared nodes stay dark), but the planner
             # must not depend on it. RETIRE, not skip, for the same reason as the moot branch below —
-            # an un-retired unit wedges auto-nudge's `_unplanned` gate forever.
+            # an un-retired unit wedges auto-nudge's `_unplanned` gate forever. The floor is None until
+            # a /clear boundary exists (episode_floor): a founding prompt stamped at its send moment,
+            # before the CLI writes the transcript head, must never read as pre-episode (2026-07-30).
             store["placements"][key] = None
             retired = True
             continue

--- a/tests/test_planner_episode_floor.py
+++ b/tests/test_planner_episode_floor.py
@@ -7,7 +7,15 @@ LOST its placement was re-planned 40 seconds after a /clear and filed done-verdi
 cards, resurfacing them as freshly completed. The boundary settle usually masks this (verdicts on
 cleared nodes stay dark), but the planner must not depend on it: a unit whose segment predates
 episode_floor() is evidence from a conversation the agent can no longer see — RETIRED, not skipped,
-so auto-nudge's `_unplanned` gate never reads it as forever-pending. Synthetic fixtures only."""
+so auto-nudge's `_unplanned` gate never reads it as forever-pending.
+
+The floor exists only once a /clear BOUNDARY is recorded (the user 2026-07-30). The episodes log's
+row 0 is a SEED — whatever episode was current when romp first observed the session — and a session
+spawned WITH its prompt stamps that founding segment at the send moment, seconds before the CLI
+boots and writes the transcript head that becomes the seed's t. Reading the seed as a floor
+misclassified the founding ask of every spawned-with-prompt session as pre-episode and sealed it:
+zero cards ever, silently, across nine sessions in the guard's first three days. A seed-only log
+means no conversation was ever lost, so there is nothing to guard. Synthetic fixtures only."""
 import json
 import os
 import shutil
@@ -74,7 +82,8 @@ class PlannerEpisodeFloor(unittest.TestCase):
         return jd.load_goals(SID)
 
     def test_pre_floor_unit_is_retired_not_planned(self):
-        jd.append_episode(SID, "newhead", SID, T_FLOOR)
+        jd.append_episode(SID, "seedhead", SID, T_OLD - 50)   # row 0: first observation (a seed)
+        jd.append_episode(SID, "newhead", SID, T_FLOOR)       # row 1: the /clear boundary
         store = self._plan()
         self.assertEqual(len(self.calls), 1, "only the current-episode unit reaches the planner")
         self.assertIn("tidy the docs", self.calls[0].lower())
@@ -90,6 +99,18 @@ class PlannerEpisodeFloor(unittest.TestCase):
         texts = " | ".join((nd.get("text") or "") for nd in store["nodes"].values())
         self.assertIn("old-era", texts.lower() + " | " + " ".join(self.calls).lower(),
                       "the old turn is judged normally when no floor exists")
+
+    def test_a_seed_only_log_never_retires_the_founding_prompt(self):
+        # A session spawned WITH its prompt: the founding segment is stamped at the send moment
+        # (T_OLD), the CLI boots and writes the transcript head a second later, and that head's t
+        # becomes the seed row. No /clear ever happened, so nothing is pre-episode.
+        jd.append_episode(SID, "seedhead", SID, T_OLD + 1)
+        store = self._plan()
+        self.assertEqual(len(self.calls), 2, "a seed row is not a boundary -> every unit still plans")
+        self.assertTrue(any("old-era" in c.lower() for c in self.calls),
+                        "the founding ask reaches the planner")
+        sealed = [k for k, v in store["placements"].items() if v is None and (":%d:" % T_OLD) in k]
+        self.assertEqual(sealed, [], "the founding unit is placed, never sealed as pre-episode")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The bug

Every session spawned WITH an initial prompt lost its founding card, silently. The pre-episode retirement guard (shipped 2026-07-27 to stop a `/clear` from replaying dead conversations as fresh goals) compares each planner unit's segment time against `episode_floor()`, which read the episodes log's last row unconditionally.

But the log's row 0 is a **seed**, recorded at first observation, not a `/clear` boundary, and its `t` is the transcript head record's timestamp. A spawned-with-prompt session stamps its founding segment at the send moment, while the CLI takes a second or more to boot before writing that head record. The founding ask therefore sat just below the "floor", read as evidence from a conversation the agent can no longer see, and was retired: processed, no goal, no card, ever. Observed gaps ran 1s to ~136s; nine sessions were hit in the guard's first three days, several ending up with a completely empty board.

## The fix

`episode_floor()` returns `None` until a boundary row exists (rows >= 2). A seed-only log means no conversation was ever lost, so there is nothing to guard, and the guard goes inert exactly there. This heals both consumers at once, since both reason about post-`/clear` visibility: the planner's pre-episode retirement and `_placed_key`'s fuzzy-match episode scope. Sessions with a real recorded boundary keep the original protection unchanged, verified by the boundary test which now records the production two-row shape (seed + boundary).

The kernel's boundary tick only appends rows for root heads (compaction forks chain via `logicalParentUuid` and are skipped), so rows >= 2 is exactly "a /clear was observed while tracked", not a heuristic.

## Tests

- `test_a_seed_only_log_never_retires_the_founding_prompt` (new, failed before the fix): seed row stamped 1s after the founding segment; the founding unit must reach the planner and place, never seal.
- `test_pre_floor_unit_is_retired_not_planned` (updated to the two-row production shape): the original 2026-07-27 protection stands.
- `test_without_an_episode_floor_the_guard_is_inert` (unchanged).

Full suites green locally: 3761 pytest passed + 107 subtests, 1525 node tests passed.

Generated with [Claude Code](https://claude.com/claude-code)