### PR TITLE
Story time, not filing time: the same-trigger audit no longer gags its own goal

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4528,7 +4528,9 @@ def _fold_node(nd):
                    async work it set in motion, will act when it lands" ruling on the goal's latest
                    audited turn. The latest un-lifted assert wins; ANY later landed state event (a
                    user reopen, a done/block landing, a clear, a dismiss-restore) or an explicit lift
-                   row ends it — so the stamp can never outlive the story it annotates."""
+                   row ends it — so the stamp can never outlive the story it annotates. "Later" for a
+                   reopen means a strictly newer ev_t: a reopen sharing the stamp's trigger is the
+                   audited turn's own processing, not a fresh event (see the guard in the loop)."""
     state, floor = "open", 0
     cur_settle, prev_settle = None, None
     awaiting_why = awaiting_at = None     # the live ⏳ stamp (see docstring); None = not awaiting
@@ -4545,7 +4547,17 @@ def _fold_node(nd):
     for e in sorted(nd.get("log") or [], key=lambda e: (e.get("ev_t") or 0, e.get("at") or 0)):
         src, kind, t = e.get("src"), e.get("kind"), e.get("ev_t") or 0
         if kind == "reopen":
-            awaiting_why = awaiting_at = None          # the user spoke / an undo landed: the wait's story moved
+            if awaiting_at is None or t > awaiting_at:
+                # the user spoke / an undo landed: the wait's story moved. STRICTLY later in ev_t only
+                # (the user 2026-07-30): a reopen SHARING the stamp's trigger is the pipeline processing
+                # the same turn the closer audited — the planner's "reopened (followup)" files minutes
+                # after the closer's awaiting verdict, both riding the follow-up's ev_t — not the user
+                # speaking again. Clearing on it erased the stamp the closer had just ruled, and with it
+                # the ⏳ chip, the nudge exemption AND the 6h backstop: a session waiting on a fleet
+                # peer's postal reply sat wedged-invisible in Working. Same-trigger symmetry as the
+                # assert's own `t >= floor` equality-lands rule below: within one turn the reopen is the
+                # trigger, the wait is how the turn ENDED.
+                awaiting_why = awaiting_at = None
             if e.get("undo") and clear_snap is not None:
                 state, cur_settle, prev_settle = clear_snap      # restore what the cross-off displaced
                 clear_snap = None

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2949,23 +2949,32 @@ def _nudge_fire_list(fresh, to_fire, arm_t=None):
     tick's snapshot — completed, blocked, cleared, or status-rolled — gets no status check: the answer
     already landed. Pure and store-shaped for tests.
 
-    arm_t = the ended turn the stall was armed on. A goal whose diary gained a verdict FILED after that
-    turn is also dropped, even if it reads plain 'working' now (the user 2026-07-29): the judges have
-    already ruled on evidence at least as new as the stall's, so the "it looks stalled" inference is
-    stale by construction. The audited case: a card blocked on a question, the user answered, the
-    unblocker lifted the block — and five seconds later the nudge status-checked the freshly-unblocked
-    goal off its pre-answer arm; the response turn then got cut by a restart and the failed-nudge path
-    converted the mess into a false needs-you block. The verdict's FILING (`at`; ev_t for legacy
-    entries) is the event: filed after the arm → the story moved → no fire. The next GENUINE ended
-    turn re-arms and may nudge afresh, judged against the post-verdict world."""
+    arm_t = the ended turn the stall was armed on. A goal whose diary gained a verdict about EVIDENCE
+    newer than that turn is also dropped, even if it reads plain 'working' now (the user 2026-07-29):
+    the judges have ruled on a turn the stall inference never saw, so "it looks stalled" is stale by
+    construction. The audited case: a card blocked on a question, the user answered, the unblocker
+    lifted the block off the answer's own (still-open) turn — and five seconds later the nudge
+    status-checked the freshly-unblocked goal off its pre-answer arm; the response turn then got cut
+    by a restart and the failed-nudge path converted the mess into a false needs-you block. The
+    verdict's ev_t — the trigger of the turn it ruled on (`at` for a row missing one) — is the event:
+    evidence newer than the arm → the story moved → no fire. The next GENUINE ended turn re-arms and
+    may nudge afresh, judged against the post-verdict world.
+
+    NOT the row's FILING time (the user 2026-07-30, the day after the guard shipped on `at`): rulings
+    ABOUT the arm turn always FILE after it — the closer/planner audit a turn once it ends — so the
+    `at` comparison read the arm turn's own audit as "a newer world" and dropped the goal EVERY tick,
+    silently: no fire, no deferral, no failed-nudge escalation (the arm can't move while the session
+    idles), for any goal that audit touched. A ruling about the arm turn that leaves the goal working
+    IS the closer-gate's considered 'working' verdict — the definition of nudgeable, not staleness;
+    one that resolves the goal is caught by the status re-read below either way."""
     nodes, status = fresh.get("nodes", {}) or {}, fresh.get("status", {}) or {}
     keep = []
     for f in to_fire:
         if f[0] not in nodes:
             continue                                 # gone from the fresh store: cleared + compacted mid-tick
         nd = nodes[f[0]]
-        if arm_t and any((e.get("at") or e.get("ev_t") or 0) > arm_t for e in nd.get("log") or []):
-            continue                                 # a verdict landed AFTER the arm — the stall read is stale
+        if arm_t and any((e.get("ev_t") or e.get("at") or 0) > arm_t for e in nd.get("log") or []):
+            continue                                 # a ruling on EVIDENCE newer than the arm — the stall read is stale
         if status.get(f[0], "working") == "working" and not nd.get("cleared") \
                 and not nd.get("nodeComplete") and not nd.get("blocked"):
             keep.append(f)

--- a/tests/test_awaiting_same_trigger_wedge.py
+++ b/tests/test_awaiting_same_trigger_wedge.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Story time vs filing time: rulings ABOUT a turn always FILE after it starts (the user 2026-07-30).
+
+The audited incident, all fixtures SYNTHETIC: the `web` session traced a missing template to a fleet
+peer on TESTHOST, sent that session a postal question for the source, and went idle to wait. The
+closer audited the follow-up turn and ruled the goal awaiting ("waiting on the TESTHOST session's
+reply with the template source"). Four seconds later the planner, placing the SAME follow-up, filed
+its bookkeeping "reopened (followup)" row. All three rows ride the follow-up's trigger (one ev_t);
+only their filing times differ. Two independent mechanisms then failed the same way, because each
+compared a row's FILING time (`at`) against a point in STORY time:
+
+- the fold's reopen handler cleared the awaiting stamp ("the user spoke — the wait's story moved")
+  because the planner's reopen SORTS after the closer's assert on the (ev_t, at) tie-break. But that
+  reopen is the pipeline processing the very trigger the closer had already audited, not the user
+  speaking again. With the stamp gone: no ⏳ chip, no awaiting nudge-exemption, no 6h backstop.
+- _nudge_fire_list's arm guard then dropped every nudge for the goal, because the diary held rows
+  FILED after the arm turn began — which is true of every row the judges file while auditing the arm
+  turn itself. The session sat idle in Working indefinitely: no nudge, no failed-nudge escalation,
+  no deferral record, nothing visible anywhere.
+
+The discipline both fixes share: compare EVIDENCE to EVIDENCE. A reopen ends an awaiting stamp only
+when its ev_t is STRICTLY newer than the stamp's; the arm guard stands down only for a verdict whose
+ev_t is strictly newer than the arm turn. A ruling about the arm turn that leaves the goal working
+IS the closer-gate's considered 'working' verdict — the definition of nudgeable, not staleness.
+"""
+import os
+import random
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+jd = SourceFileLoader("romp_judge_sametrig", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_sametrig", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+G1 = SID + ":g1"
+T = 1781100000                    # the follow-up turn's trigger — every row below is ABOUT this turn
+WHY = "waiting on the TESTHOST session's reply with the template source"
+
+
+def node(log):
+    return {"id": G1, "text": "port the export template for the api session", "parentId": None,
+            "nodeComplete": False, "blocked": False, "cleared": False, "trail": [],
+            "t": T - 500, "mt": T - 100, "log": log}
+
+
+def incident_log():
+    """The audited shape verbatim (synthetic): user follow-up reopen, closer awaiting, planner reopen —
+    one trigger, three filings."""
+    return [
+        {"ev_t": T, "src": "user", "kind": "reopen", "why": "reopened (optimistic)", "msg": True, "at": T},
+        {"ev_t": T, "src": "closer", "kind": "awaiting", "why": WHY, "at": T + 150},
+        {"ev_t": T, "src": "planner", "kind": "reopen", "why": "reopened (followup)", "at": T + 154},
+    ]
+
+
+class FoldSameTriggerReopen(unittest.TestCase):
+    """A reopen clears the ⏳ stamp only when it is STRICTLY later in story time."""
+
+    def test_the_pipelines_same_trigger_reopen_keeps_the_stamp(self):
+        f = jd._fold_node(node(incident_log()))
+        self.assertEqual(f["awaitingWhy"], WHY,
+                         "the planner's bookkeeping reopen rides the trigger the closer audited — "
+                         "it is not the user speaking, so the wait's story has not moved")
+        self.assertEqual(f["awaitingAt"], T)
+        self.assertEqual(f["state"], "open")
+
+    def test_a_genuinely_later_reopen_still_clears(self):
+        log = incident_log() + [{"ev_t": T + 600, "src": "user", "kind": "reopen",
+                                 "why": "reopened (optimistic)", "msg": True, "at": T + 600}]
+        f = jd._fold_node(node(log))
+        self.assertIsNone(f["awaitingWhy"], "the user's NEXT message is the exact event that ends the wait")
+        self.assertIsNone(f["awaitingAt"])
+
+    def test_shuffle_invariance_survives_the_guard(self):
+        want = jd._fold_node(node(incident_log()))
+        log = incident_log()
+        rng = random.Random(7)
+        for _ in range(12):
+            rng.shuffle(log)
+            self.assertEqual(jd._fold_node(node(list(log))), want,
+                             "ordering is reconstructed from (ev_t, at), never assumed")
+
+
+class FireListArmEvidence(unittest.TestCase):
+    """_nudge_fire_list stands down on newer EVIDENCE, not on newer FILINGS about the arm itself."""
+
+    def _store(self, log):
+        return {"rompUuid": SID, "seq": 1, "nodes": {G1: node(log)},
+                "placements": {}, "status": {G1: "working"}}
+
+    def test_rulings_about_the_arm_turn_keep_the_fire(self):
+        # the sibling incident: the arm turn answered its own blocker in passing ("answered in the
+        # thread"), the unblocker unblocked off that same turn, the goal stayed working and the
+        # session idled — a status check is exactly what is due, yet the late-FILED rows gagged it
+        log = [{"ev_t": T, "src": "planner", "kind": "block", "why": "which branch ships?", "at": T + 140},
+               {"ev_t": T, "src": "unblocker", "kind": "unblock", "why": "answered in the thread", "at": T + 150}]
+        self.assertEqual([f[0] for f in km._nudge_fire_list(self._store(log), [(G1, 1, False)], arm_t=T)],
+                         [G1],
+                         "a ruling about the arm turn that leaves the goal working IS the considered "
+                         "'working' verdict — the definition of nudgeable")
+
+    def test_the_incidents_awaiting_and_reopen_rows_keep_the_fire(self):
+        # the wedged goal's actual diary tail; with the fold fixed the awaiting GATE holds upstream,
+        # but the fire list itself must not read these same-trigger rows as a moved story either
+        self.assertEqual([f[0] for f in km._nudge_fire_list(self._store(incident_log()),
+                                                            [(G1, 1, False)], arm_t=T)], [G1])
+
+    def test_evidence_from_a_newer_turn_still_drops(self):
+        # the 2026-07-29 audited case, faithfully: the user's ANSWER opened a newer turn and the
+        # unblock rode it — the "it looks stalled" read predates the answer, so the nudge stands down
+        log = [{"ev_t": T - 600, "src": "planner", "kind": "block", "why": "which branch ships?", "at": T - 590},
+               {"ev_t": T + 290, "src": "unblocker", "kind": "unblock", "why": "answered in the thread",
+                "at": T + 300}]
+        self.assertEqual(km._nudge_fire_list(self._store(log), [(G1, 1, False)], arm_t=T), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nudge_moot_supersede.py
+++ b/tests/test_nudge_moot_supersede.py
@@ -9,13 +9,16 @@ that cut turn as "the response didn't resolve this" and filed a needs-you block 
 presenting the already-answered decision brief. The user re-answered a question they had answered
 five minutes earlier.
 
-The discipline, at both ends of the race: a verdict FILED (`at`; ev_t for legacy rows) after the
-evidence the nudge machinery is acting on means the judges have already ruled on a newer world, so
-the machinery stands down —
-- fire time: _nudge_fire_list drops a goal whose diary gained a verdict after the ARM turn, even if
-  the goal reads plain 'working' in the fresh store (the freshly-unblocked case above);
+The discipline, at both ends of the race: a verdict the judges based on a newer world than the one
+the nudge machinery is acting on means they have already ruled, so the machinery stands down —
+- fire time: _nudge_fire_list drops a goal whose diary gained a verdict about EVIDENCE (ev_t) newer
+  than the ARM turn, even if the goal reads plain 'working' in the fresh store (the freshly-unblocked
+  case above). Evidence time, NOT filing time: rulings about the arm turn itself always FILE after
+  it, so the original `at` comparison read the arm's own audit as a moved story and silently gagged
+  every goal that audit touched (the same-trigger wedge, tests/test_awaiting_same_trigger_wedge.py);
 - eval time: _mark_nudge_failed retires the record as `moot` (no failed chip, no block) when a
-  non-nudge verdict was filed after the RESPONSE turn.
+  non-nudge verdict was FILED (`at`) after the RESPONSE turn — there the question really is "did a
+  judge look after the reply", and moot (stand down) is the safe direction.
 A moot record keeps the anti-loop gate (lastTurnId pins the arm), and a genuinely still-stalled goal
 re-arms on the next GENUINE ended turn, judged against the post-verdict world.
 
@@ -66,14 +69,16 @@ def _store(nodes, status=None):
 class FireListArmOrdering(unittest.TestCase):
     """_nudge_fire_list's arm_t guard: the stall inference is stale once the judges filed anything newer."""
 
-    def test_a_verdict_filed_after_the_arm_drops_the_fire(self):
-        # the audited shape: unblocked moments ago → plain 'working' in the fresh store, but the
-        # unblock's filing postdates the arm — the "it looks stalled" read predates the answer
+    def test_a_verdict_on_newer_evidence_drops_the_fire(self):
+        # the audited shape: the user's ANSWER opened a turn after the arm and the unblock rode it
+        # (ev_t = the answer's trigger) → plain 'working' in the fresh store, but the "it looks
+        # stalled" read predates the answer
         log = [{"ev_t": ARM_T, "src": "planner", "kind": "block", "why": "open the PR, or hold it?", "at": ARM_T + 5},
-               {"ev_t": ARM_T, "src": "unblocker", "kind": "unblock", "why": "answered in the thread", "at": ARM_T + 300}]
+               {"ev_t": ARM_T + 290, "src": "unblocker", "kind": "unblock", "why": "answered in the thread",
+                "at": ARM_T + 300}]
         fresh = _store({G1: _node(G1, "ship the notes-api", log=log)})
         self.assertEqual(km._nudge_fire_list(fresh, [(G1, 1, False)], arm_t=ARM_T), [],
-                         "the judges ruled after the arm — the status check would ask about a moved story")
+                         "the judges ruled on the answer's turn — the status check would ask about a moved story")
 
     def test_old_history_before_the_arm_still_fires(self):
         log = [{"ev_t": ARM_T - 900, "src": "planner", "kind": "block", "why": "?", "at": ARM_T - 890},
@@ -82,7 +87,7 @@ class FireListArmOrdering(unittest.TestCase):
         self.assertEqual([f[0] for f in km._nudge_fire_list(fresh, [(G1, 1, False)], arm_t=ARM_T)], [G1],
                          "a diary that predates the arm is exactly the stalled case — the nudge stands")
 
-    def test_a_legacy_row_without_at_falls_back_to_ev_t(self):
+    def test_a_row_without_at_still_counts_on_ev_t(self):
         log = [{"ev_t": ARM_T + 60, "src": "closer", "kind": "block", "why": "?"}]   # no `at` (older writer)
         fresh = _store({G1: _node(G1, "ship the notes-api", log=log)})
         self.assertEqual(km._nudge_fire_list(fresh, [(G1, 1, False)], arm_t=ARM_T), [])


### PR DESCRIPTION
Rulings about a turn always file after it starts. Two mechanisms compared a diary row's filing time (`at`) against a point in story time (`ev_t`), and a goal whose arming turn the judges audited could wedge silently in Working with every reviver disarmed at once:

- **The fold cleared the closer's awaiting stamp on the pipeline's own same-trigger reopen.** The planner's "reopened (followup)" row files minutes after the closer's awaiting verdict but rides the same trigger; the `(ev_t, at)` tie-break sorted it later and the reopen handler cleared unconditionally. With the stamp gone: no ⏳ chip, no awaiting nudge-exemption, no 6h backstop. The audited session was waiting on a fleet peer's postal reply and showed nothing anywhere.
- **The fire list's arm guard (shipped 2026-07-29 on `at`) read the arm turn's own audit as "a newer world"** and dropped the goal from every tick's fire — silently: no nudge, no deferral record, and no failed-nudge escalation, since the arm can never move while the session idles.

Both now compare evidence to evidence:

- a reopen ends the awaiting stamp only when its `ev_t` is strictly newer than the stamp's (a same-trigger reopen is the audited turn's own processing, symmetric with the assert's equality-lands floor rule);
- the arm guard stands down on a verdict whose `ev_t` outruns the arm turn. A ruling about the arm turn that leaves the goal working is the closer-gate's considered "working" verdict — the definition of nudgeable — and one that resolves the goal is already caught by the fresh-store status re-read.

Wedged stores self-heal: the stamp re-derives from the unchanged diary on the next materialize pass, no migration. Regression tests in `tests/test_awaiting_same_trigger_wedge.py` reproduce the incident shape end to end; the two `test_nudge_moot_supersede.py` fixtures whose timestamps had been compressed onto the arm are updated to match their own narrative (the superseding answer arrived in a newer turn). `_mark_nudge_failed`'s moot check stays on filing time deliberately — there the question really is "did a judge look after the reply", and standing down is the safe direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
