### PR TITLE
A remote card's jump had no shell to ask, so the chat pane asks for itself

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14733,7 +14733,13 @@ def _heartbeat():
 def _reveal_chat(focus_msg):
     """A cross-pane action that brings the chat forward (a feed/timeline session tap): focus the chat
     clients AND tell the mobile shell (app=shell) to switch to its Chat tab. On desktop the shell
-    ignores the reveal (all three panes are visible at once), so this is a no-op there."""
+    ignores the reveal (all three panes are visible at once), so this is a no-op there.
+
+    The shell half only ever reaches THIS kernel's own dashboards: a federated dashboard opens a socket
+    per host for each PANE, never for the shell, so a click on a remote host's session routes to that
+    host's kernel and its reveal lands nowhere. The chat pane therefore asks for the switch itself when
+    it takes a focus (render.ts revealSelfPane) — which covers every kernel, local included, and makes
+    this line a harmless duplicate rather than the only mover."""
     _send_to_app("chat", focus_msg)
     _send_to_app("shell", {"type": "reveal", "pane": "chat"})
 
@@ -19319,6 +19325,7 @@ class Handler(BaseHTTPRequestHandler):
             return self._send(400, "expected websocket", "text/plain")
         q = parse_qs(urlparse(self.path).query)
         app = (q.get("app") or ["chat"])[0]
+        wid = (q.get("wid") or [""])[0]         # which DASHBOARD this pane belongs to → _send_to_view aims at one
         active = (q.get("active") or [""])[0]   # the tab this client is looking at → _push builds it FIRST
         self.send_response(101)
         self.send_header("Upgrade", "websocket")
@@ -19332,7 +19339,7 @@ class Handler(BaseHTTPRequestHandler):
         # push/heartbeat loops (see _ws_sender). Pongs still ride self.wfile — they are ≤125-byte control
         # frames answered on this client's own handler thread, and both paths serialise on the same `lock`.
         q = queue.Queue()
-        client = {"app": app, "alive": True, "qbytes": 0, "qlock": threading.Lock()}
+        client = {"app": app, "wid": wid, "alive": True, "qbytes": 0, "qlock": threading.Lock()}
         client["send"] = _mk_ws_send(q, self.connection, client)
         threading.Thread(target=_ws_sender, args=(q, self.connection, lock, client),
                          daemon=True, name="ws-send").start()

--- a/tests/test_per_viewer_focus.py
+++ b/tests/test_per_viewer_focus.py
@@ -79,6 +79,49 @@ class Wiring(unittest.TestCase):
         self.assertIn("if not wid:\n        return _send_to_app(app, msg)",
                       inspect.getsource(km._send_to_view))
 
+    def test_the_socket_actually_puts_the_reported_wid_ON_the_client(self):
+        # The half that was missing (found 2026-07-30): the shell minted the id, the panes sent it and
+        # _send_to_view filtered on it, but the WS handler never read it off the query — so every client
+        # carried no wid, every wid resolved to "", and the targeted send fell through to the broadcast
+        # it was written to replace. The tests above all hand-build clients WITH a wid, so none saw it.
+        src = inspect.getsource(km.Handler)
+        self.assertIn('wid = (q.get("wid") or [""])[0]', src, "the connect query is where a dashboard names itself")
+        self.assertIn('client = {"app": app, "wid": wid,', src, "…and it has to reach the client dict")
+
+    def test_a_federated_pane_names_its_dashboard_to_the_REMOTE_kernel_too(self):
+        # A remote kernel sees one anonymous client per federated pane unless the wid rides the relay
+        # dial, so its per-viewer sends would broadcast and one window's jump would move every other.
+        fed = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "federation.ts"), encoding="utf-8").read()
+        self.assertIn("&wid=${encodeURIComponent(w)}", fed)
+        # the relay forwards the whole query verbatim (only `token` is rewritten), so the wid survives
+        self.assertIn('q["token"] = [rtok]', inspect.getsource(km.Handler._remote_ws))
+
+
+class RemoteRevealReachesTheShell(unittest.TestCase):
+    """A remote host's session must jump the same way a local one does (the user 2026-07-30, on a phone).
+
+    On mobile ONE pane is on screen, so a jump is invisible unless the shell switches to Chat. The kernel
+    sends that switch to its app=shell clients — but a federated dashboard opens a socket per host for
+    each PANE and never for the shell, so a click on a remote card routes to that host's kernel and its
+    reveal reaches nobody: the distilled summaries of remote sessions read as dead text. The chat pane
+    knows it took the focus whichever kernel sent it, so it asks the shell for itself.
+    """
+
+    def setUp(self):
+        self.render = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "render.ts"), encoding="utf-8").read()
+
+    def test_the_chat_pane_asks_the_shell_to_come_forward_when_it_takes_a_focus(self):
+        self.assertIn('window.parent.postMessage({ romp: "reveal", pane: "chat" }, "*")', self.render)
+        self.assertIn('else if (m.type === "focus") {\n    revealSelfPane();', self.render)
+
+    def test_the_dead_session_prompt_comes_forward_too(self):
+        # confirmRevive is DRAWN in the chat pane — a modal on a pane you can't see is no modal at all
+        self.assertIn('else if (m.type === "confirmRevive" && m.id) {\n    revealSelfPane();', self.render)
+
+    def test_the_mobile_shell_switches_tabs_on_that_window_message(self):
+        # the receiving half already existed (the Fleet pill posts the same shape); this pins the contract
+        self.assertIn("if(m.romp==='reveal'&&m.pane)show(m.pane);", km._LANDING_MOBILE_JS)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -34,6 +34,23 @@ export function bareId(id: string): string {
   return i > 0 ? id.slice(i + 1) : id;
 }
 
+/** This dashboard's window id, resolved exactly as the pane shim resolves it (the kernel's `_shim`): the
+ *  host's `?wid=` when it supplies one, else the shell's per-tab sessionStorage id, which same-origin
+ *  iframes share. It rides every REMOTE connect too, so a remote kernel can aim a per-viewer message at
+ *  the dashboard that asked. "" when neither exists — the kernel falls back to broadcasting, which is the
+ *  pre-wid behaviour, so an older shell or a storage-blocked context degrades to what it did before. */
+export function pickWid(search: string, stored: string): string {
+  let q = "";
+  try { q = new URLSearchParams(search || "").get("wid") || ""; } catch (e) { /* malformed query */ }
+  return q || stored || "";
+}
+
+function dashboardWid(): string {
+  let stored = "";
+  try { stored = window.sessionStorage.getItem("romp:wid") || ""; } catch (e) { /* storage blocked */ }
+  return pickWid(location.search, stored);
+}
+
 // The shapes a kernel→browser message can carry a session id in. Kept generic (by field name, not by
 // message type) so a new message type that reuses these field names is covered automatically:
 const SCALAR_ID = ["id", "sid"]; //               a single session id
@@ -539,7 +556,13 @@ export class FederationManager {
     // Same-origin also means the local auth cookie rides the upgrade; the ?token (the remote
     // kernel's credential, from /tunnels) is re-checked and rewritten by the relay either way.
     const proto = location.protocol === "https:" ? "wss://" : "ws://";
-    const url = `${proto}${location.host}/remote/${encodeURIComponent(host)}/ws?app=${encodeURIComponent(this.app)}&token=${encodeURIComponent(token)}`;
+    // …carrying this dashboard's `wid`, exactly as the pane's own local socket does. Without it a remote
+    // kernel sees every federated viewer as one anonymous client and BROADCASTS its per-viewer messages,
+    // so one dashboard's jump to a remote session yanked every other open dashboard to that tab — the
+    // very cross-window yank the local path fixed (the user 2026-07-29).
+    const w = dashboardWid();
+    const url = `${proto}${location.host}/remote/${encodeURIComponent(host)}/ws?app=${encodeURIComponent(this.app)}&token=${encodeURIComponent(token)}`
+      + (w ? `&wid=${encodeURIComponent(w)}` : "");
     const conn: Conn = { host, ws: null, url, closed: false, live };
     this.conns.set(host, conn);
     this.ensureHost(host);

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -6,7 +6,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { prefixId, hostOf, bareId, prefixInbound, routeOutbound, mergeHostOrder, mergeHostFeeds,
          prefixTimelineData, mergeHostTimelines, mergeHostBars, stitchMessages,
-         FederationManager } from "./federation";
+         FederationManager, pickWid } from "./federation";
 
 const U = "11111111-2222-3333-4444-555555555555";
 const V = "99999999-8888-7777-6666-555555555555";
@@ -421,4 +421,17 @@ test("manager: merged timeline emits HOLD until the local lanes snapshot arrives
   } finally {
     if (hadWindow) g.window = prevWindow; else delete g.window;
   }
+});
+
+// ── pickWid: which DASHBOARD a federated socket belongs to ────────────────────────────────────────────
+// The remote dial has to name the viewer the same way the pane's local socket does, or the remote kernel
+// treats every federated window as one anonymous client and broadcasts what it means for one of them.
+test("pickWid prefers the host-supplied ?wid=, then the shell's per-tab id", () => {
+  assert.equal(pickWid("?app=chat&wid=from-host", "from-storage"), "from-host");
+  assert.equal(pickWid("?app=chat", "from-storage"), "from-storage");
+  assert.equal(pickWid("", ""), "", "neither → empty, and the kernel falls back to broadcasting");
+});
+
+test("pickWid survives a malformed query instead of throwing the connect away", () => {
+  assert.equal(pickWid("%", "from-storage"), "from-storage");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3869,6 +3869,19 @@ function cancelProvisional(): void {
   if (name && vscodeApi) vscodeApi.postMessage({ type: "cancelCreate", name });
 }
 
+// Bring this pane FORWARD in the shell. On mobile only one pane is on screen at a time, so a jump the
+// chat just took is invisible unless the shell switches to the chat tab; on desktop all panes are up at
+// once and the shell ignores it. The kernel asks for that switch itself — but only of ITS OWN shell
+// clients, and the shell socket is local-only, so a click on a REMOTE host's card routes to that host's
+// kernel and its reveal reaches nobody: on a phone, a remote session's distilled summary looked like dead
+// text (the user 2026-07-30). The pane knows it took the focus whichever kernel sent it, so it asks for
+// itself, and the local path keeps its (now duplicate, idempotent) kernel-side reveal.
+function revealSelfPane(): void {
+  try {
+    if (window.parent && window.parent !== window) window.parent.postMessage({ romp: "reveal", pane: "chat" }, "*");
+  } catch (e) { /* standalone page — no shell to ask */ }
+}
+
 // Full-screen bridge (the user 2026-07-05): the picker is rendered inside the /chat iframe, so its
 // position:fixed;inset:0 only covered the chat PANE — on a short pane the session list couldn't scroll.
 // Mirror the settings bridge: tell the shell to lift #f-chat over the whole window (body.picker-open) while
@@ -7273,6 +7286,7 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "update") update(m);
   else if (m.type === "status") statusOnly(m);
   else if (m.type === "focus") {
+    revealSelfPane();   // every focus is someone jumping HERE — on mobile, come forward (incl. from a remote kernel)
     if (revivePending && m.id === revivePending) clearReviveLoader();   // the revive landed — the loader's success event
     // `live` (the user 2026-07-08): land on the LIVE TAIL. A blocked card's picker/permission prompt IS the
     // live bottom of the chat, so its feed chip drops the user right on it. Stick the target view to bottom so
@@ -7385,6 +7399,7 @@ window.addEventListener("message", (e: MessageEvent) => {
       });
   }
   else if (m.type === "confirmRevive" && m.id) {
+    revealSelfPane();   // the dead-session prompt is drawn in THIS pane — useless if the pane isn't showing
     const nm = String(m.name || "");
     showConfirm(`“${nm}” is closed — revive it?`,
       "Revive restarts the session and resumes its conversation. Read-only just shows the transcript.",


### PR DESCRIPTION
Reported from a phone: distilled summaries on a remote host's sessions could not be clicked through to the chat, while local ones worked.

## What was wrong

On mobile the dashboard shows ONE pane at a time, so following a summary is only visible if the shell switches to the Chat tab. The kernel sends that switch itself (`_reveal_chat_for` → `app=shell`). But a federated dashboard opens a socket per host **for each pane and never for the shell**, so a click on a remote card routes to that host's kernel and its reveal reaches nobody. The chat had scrolled to the right turn behind a pane you could not see.

## The fix

The chat pane knows it took the focus whichever kernel sent it, so it asks the shell to come forward itself, on every `focus` and on `confirmRevive` (a modal drawn in this pane, useless while the pane is hidden). Keying on that event covers every host; the kernel-side reveal stays as a harmless duplicate for the local path. Desktop shows all panes at once and ignores it.

## A second bug found on the way

Doing that safely needed per-viewer targeting to work, and it did not. The shell minted a dashboard id, the panes reported it on connect, and `_send_to_view` filtered on it — but the WS handler never read `wid` off the query string, so every client carried none and every targeted send fell through to the broadcast it was written to replace. Without this, self-revealing would have yanked every open dashboard.

The handler reads it now, and federated sockets carry it to remote kernels too (the relay already forwards the query verbatim). Its existing tests all hand-built clients *with* a wid, which is why the gap survived; the new pin asserts the connect query reaches the client dict.

## Tests

`tests/test_per_viewer_focus.py` (+5) and `ui/webview/multi-kernel-merge.test.ts` (+2). Full suites green: 3772 Python, 1527 node, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)