### PR TITLE
The mobile picker keeps a host prefix quiet, and drift says ahead/behind

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15949,16 +15949,28 @@ function realTab(id){return tabs.querySelector('.tab[data-id="'+id+'"]');}
 function hide(){list.classList.remove('open');}
 function read(){return [].map.call(tabs.querySelectorAll('.tab[data-id]'),function(t){
 var lab=t.querySelector('.tab-label');
-return {id:t.getAttribute('data-id'),name:(lab?lab.textContent:t.getAttribute('data-id')),
+return {id:t.getAttribute('data-id'),name:(lab?lab.textContent:t.getAttribute('data-id')),lab:lab,
 bg:t.style.getPropertyValue('--chip-bg').trim(),fg:t.style.getPropertyValue('--chip-fg').trim(),
 working:t.classList.contains('tab-working'),awaitbg:!!t.querySelector('.tab-dot.await'),active:t.classList.contains('active')};});}
+// A name is filled from the desktop label's own CHILD NODES, cloned — not from its flattened text. A
+// federated session's name carries a <span class="host-prefix"> that renders the "host:" as quiet
+// metadata (host-prefix.ts: dim, italic, never bold, a step smaller), and textContent threw that span
+// away, so the mobile picker painted the host in the session's identity colour at full weight (the user
+// 2026-07-30). Cloning keeps ONE definition of the treatment: the span brings its own class, and
+// styles.css (which this page loads) does the rest — including the disconnected-host cue.
+// slice FIRST: childNodes is a LIVE NodeList, so appending straight off it removes each node from the
+// clone as we go and the walk skips every second one — which dropped the session name and left a row
+// reading just "host:" (caught in a browser; a source-pinned test cannot see it).
+function fillName(elm,s){elm.textContent='';
+if(s.lab&&s.lab.childNodes.length)[].slice.call(s.lab.cloneNode(true).childNodes).forEach(function(n){elm.appendChild(n);});
+else elm.textContent=s.name;}
 function sync(){var ts=read(),act=null;
 for(var i=0;i<ts.length;i++){if(ts[i].active){act=ts[i];break;}}
 if(!act&&ts.length)act=ts[0];
 var nm=cur.querySelector('.nm');
 var wd=cur.querySelector('.wd');wd.style.display=(act&&(act.working||act.awaitbg))?'':'none';   // gold working / green awaiting dot, matching desktop
 wd.classList.toggle('await',!!(act&&act.awaitbg&&!act.working));
-if(act){nm.textContent=act.name;
+if(act){fillName(nm,act);
 if(act.bg){cur.classList.add('colored');cur.style.setProperty('--cbg',act.bg);cur.style.setProperty('--cfg',act.fg||'#ffffff');}
 else{cur.classList.remove('colored');cur.style.removeProperty('--cbg');cur.style.removeProperty('--cfg');}}
 else{nm.textContent='no sessions';cur.classList.remove('colored');}
@@ -15968,7 +15980,7 @@ ts.forEach(function(s){var row=document.createElement('div');row.className='mrow
 // tab's own dot — gold when working, green (awaitbg) when idle-waiting-on-bg-work, none otherwise.
 if(s.working){var wd=document.createElement('span');wd.className='workdot';row.appendChild(wd);}
 else if(s.awaitbg){var wd=document.createElement('span');wd.className='workdot await';row.appendChild(wd);}
-var lbl=document.createElement('span');lbl.className='nm';lbl.textContent=s.name;if(s.bg)lbl.style.color=s.bg;
+var lbl=document.createElement('span');lbl.className='nm';fillName(lbl,s);if(s.bg)lbl.style.color=s.bg;
 row.appendChild(lbl);
 // End-session x: clicks the hidden desktop tab's own .tab-close, reusing its confirm dialog (Close tab /
 // End session / Cancel) + endSession/closeTab plumbing — the mobile picker's only way to end a session
@@ -16832,16 +16844,18 @@ function busyStatus(s){return s!=='up'&&s!=='down'&&s!=='error'&&s!=='no-kernel'
 // HOW a host's build differs from this machine's, in words. ONE definition, worn by the panel row and
 // by the rail's hover (the user 2026-07-29, who wanted the count without opening the panel) — two
 // spellings of the same drift would eventually disagree, and the number is the whole point of it.
-// git's own shorthand (the user 2026-07-29): the counts read at a glance as arrows, and a diverged host
-// shows BOTH rather than collapsing to one word that hides how much is on each side. '' when either count
-// is unknown (the remote's commit isn't in this repo at all) — the caller says so in words instead.
-function driftArrows(t){var bb=t.behindBy,ab=t.aheadBy;
+// Drift says AHEAD and BEHIND in words (the user 2026-07-30, replacing the 07-29 arrows): an arrow only
+// reads as a direction if you already know which way romp points it, and this is the one place a reader
+// is deciding whether to push or pull. The count stays — it is the whole point — and a diverged host
+// shows BOTH sides rather than collapsing to one word that hides how much sits on each. '' when either
+// count is unknown (the remote's commit isn't in this repo at all): the caller says so in words instead.
+function driftCounts(t){var bb=t.behindBy,ab=t.aheadBy;
 if(typeof bb!=='number'||typeof ab!=='number')return '';
-var up=ab>0?('\\u2191'+ab):'',down=bb>0?('\\u2193'+bb):'';
-return (up&&down)?(up+' '+down):(up||down);}
-function driftWord(t){var a=driftArrows(t);
+var up=ab>0?('ahead '+ab):'',down=bb>0?('behind '+bb):'';
+return (up&&down)?(up+', '+down):(up||down);}
+function driftWord(t){var a=driftCounts(t);
 if(!a)return 'different build';
-return (t.aheadBy>0&&t.behindBy>0)?('diverged '+a):a;}
+return (t.aheadBy>0&&t.behindBy>0)?('diverged: '+a):a;}
 // WHAT a host is running, in the two names that mean something together: the release it descends from
 // and the commit (the user 2026-07-30 — a bare sha says nothing unless you happen to know your own).
 // Either half alone if that is all there is; a kernel older than the version field reports no tag.
@@ -16974,11 +16988,11 @@ var dot=t.status==='up'?'background:var(--accent)':(t.status==='error'||t.status
 var stl=!!t.stale;
 var sw=stl?(t.lastOk?('last confirmed '+new Date(t.lastOk*1000).toLocaleTimeString()):'never confirmed since this kernel started'):'';
 var sq=stl?(' \\u2014 '+sw+'; not re-checked while '+(LBL[t.status]||t.status)+'.'):'';
-// The build reads as a NAME plus a distance: "v0.2.0+ 682d232 (↓3)" — the release and commit it is on,
-// then how far that sits from here in git's arrows (the user 2026-07-30). A remote whose commit this repo
-// has never seen has no distance to report, so it says "different build" where the arrows would go.
+// The build reads as a NAME plus a distance: "v0.2.0+ 682d232 (behind 3)" — the release and commit it is
+// on, then how far that sits from here, said in words (the user 2026-07-30). A remote whose commit this
+// repo has never seen has no distance to report, so it says "different build" where the count would go.
 var ver='',bw=buildWord(t.kernelVer,t.kernelSha);
-if(t.outOfDate){var w=driftWord(t),ar=driftArrows(t);
+if(t.outOfDate){var w=driftWord(t),ar=driftCounts(t);
 var tt='running '+(buildWord(t.kernelVer,t.kernelSha)||'?')+(t.kernelDate?' from '+t.kernelDate:'')+'; this machine is at '+(buildWord(t.localVer,t.localSha)||'?')+((t.aheadBy>0&&t.behindBy>0)?' (each has commits the other lacks)':'')
 +(t.checkinPeer?(t.askPull?' No ssh path from this machine (it checked in over its own tunnel), so Update asks it to fast-forward itself over the link it holds.':' No ssh path from this machine (it checked in over its own tunnel) \\u2014 sync from its own dashboard.'):'');
 ver=' \\u00b7 <span class=\"rnet-old'+(stl?' rnet-stale':'')+'\" title=\"'+tt+sq+'\">'+(stl?'last known: ':'')+(bw?bw+' ':'')+(ar?'('+ar+')':w)+'</span>';}

--- a/tests/test_fleet_sync_log.py
+++ b/tests/test_fleet_sync_log.py
@@ -122,11 +122,15 @@ class VersionTag(unittest.TestCase):
         self.assertIn("rnet-me", js, "the panel says what THIS machine is on")
         self.assertIn("rnet-mybuild", km._landing())
 
-    def test_the_drift_still_reads_as_gits_arrows(self):
+    def test_the_drift_says_ahead_and_behind_in_words(self):
+        # an arrow only reads as a direction if you already know which way romp points it, and this is
+        # where a reader decides whether to push or pull (the user 2026-07-30, replacing the arrows)
         js = km._LANDING_REMOTES_JS
-        self.assertIn("up=ab>0?(", js)
-        self.assertIn("down=bb>0?(", js)
-        self.assertIn("function driftArrows(t)", js)
+        self.assertIn("up=ab>0?('ahead '+ab):''", js)
+        self.assertIn("down=bb>0?('behind '+bb):''", js)
+        self.assertIn("function driftCounts(t)", js)
+        self.assertNotIn("\\u2191", js, "no arrow spelling may survive alongside the words")
+        self.assertNotIn("\\u2193", js)
 
 
 class SpinWhileWorking(unittest.TestCase):

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -253,6 +253,28 @@ class ChatSessionPicker(unittest.TestCase):
         self.assertIn("--chip-bg", js)                    # reads each session's identity color
         self.assertIn("#mcur.colored", css)               # the current button wears that color
 
+    def test_a_remote_sessions_host_prefix_stays_quiet_metadata(self):
+        # the user 2026-07-30, on a phone: "host:name" came through the picker painted whole in the
+        # session's identity colour at full weight, where desktop renders the "host:" as quiet metadata
+        # (host-prefix.ts: dim, italic, never bold, a step smaller). The cause was textContent flattening
+        # the desktop label — which already carries a <span class="host-prefix"> — so the fix CLONES the
+        # label's child nodes instead of re-deriving the split, keeping ONE definition of the treatment.
+        js = km._CHAT_MOBILE_JS
+        self.assertIn("function fillName(elm,s){", js)
+        self.assertIn("s.lab.cloneNode(true).childNodes", js, "the nodes are cloned, not flattened")
+        # ...and the clone's childNodes are SLICED before the walk: appending straight off that live
+        # NodeList removes each node as it goes and skips every second one, which dropped the session
+        # name and left a row reading just "host:" (caught in a browser, not by a source pin)
+        self.assertIn("[].slice.call(s.lab.cloneNode(true).childNodes).forEach(", js)
+        self.assertIn("lab:lab,", js, "read() carries the label element through")
+        self.assertIn("fillName(nm,act);", js, "the current-session button too, not just the rows")
+        self.assertNotIn("nm.textContent=act.name", js)
+        self.assertNotIn("lbl.textContent=s.name", js)
+        # the treatment itself is NOT re-declared here: the cloned span brings its class, and the chat
+        # page loads the sheet that styles it (a second spelling would eventually disagree with desktop)
+        self.assertNotIn("host-prefix", km._CHAT_MOBILE_CSS)
+        self.assertIn("<link href=/dist/styles.css", km._chat_page())
+
     def test_picker_rows_match_desktop_colored_name_plus_status_dot(self):
         # the user 2026-07-22: on mobile the picker painted a per-session identity DOT (grey #666 when the
         # session had no color, and confusingly the identity color when it did) — desktop has no such dot.
@@ -260,7 +282,7 @@ class ChatSessionPicker(unittest.TestCase):
         # label), and the dot MIRRORS the tab's own status dot — gold when working, GREEN when awaitingBg
         # (idle-waiting-on-bg-work, the .tab-dot.await), none otherwise.
         js, css = km._CHAT_MOBILE_JS, km._CHAT_MOBILE_CSS
-        self.assertIn("lbl.textContent=s.name;if(s.bg)lbl.style.color=s.bg;", js)   # identity color on the NAME
+        self.assertIn("fillName(lbl,s);if(s.bg)lbl.style.color=s.bg;", js)   # identity color on the NAME
         self.assertIn("if(s.working){var wd=document.createElement('span');wd.className='workdot';", js)  # gold dot when working
         # awaitingBg is read off the desktop tab's own green dot (no tab-working class on an awaiting tab)
         self.assertIn("awaitbg:!!t.querySelector('.tab-dot.await')", js)

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -132,14 +132,14 @@ class PaneRailTest(unittest.TestCase):
         # host (the user 2026-07-29). ONE definition of the wording, worn by the panel row and the
         # tooltip alike — two spellings of the same drift would eventually disagree.
         self.assertIn("function driftWord(t){", self.html)
-        self.assertIn("down=bb>0?(", self.html)   # git-style arrows since 2026-07-29
-        self.assertIn("up=ab>0?(", self.html)
+        self.assertIn("down=bb>0?('behind '+bb):''", self.html)   # said in words since 2026-07-30
+        self.assertIn("up=ab>0?('ahead '+ab):''", self.html)
         self.assertIn("var dw=t.outOfDate?(' \\u00b7 '+(t.status==='up'?'':'last known ')+driftWord(t)):''", self.html)
         self.assertIn("+dw+", self.html, "the per-host tooltip line carries it")
         # the panel row reads the same functions rather than re-deriving the words. Since 2026-07-30 it
         # leads with the BUILD (release + commit) and puts the distance in parentheses after it — a bare
-        # sha meant nothing without the reader's own sha memorised — so it takes the arrows directly.
-        self.assertIn("if(t.outOfDate){var w=driftWord(t),ar=driftArrows(t);", self.html)
+        # sha meant nothing without the reader's own sha memorised — so it takes the counts directly.
+        self.assertIn("if(t.outOfDate){var w=driftWord(t),ar=driftCounts(t);", self.html)
         self.assertIn("function buildWord(v,s)", self.html)
 
     def test_network_icon_lights_accent_when_a_remote_is_connected(self):

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -399,9 +399,9 @@ class DriftWordingUI(unittest.TestCase):
 
     def test_row_names_how_the_remote_differs(self):
         js = km._LANDING_REMOTES_JS
-        self.assertIn("down=bb>0?(", js)   # git-style arrows since 2026-07-29
-        self.assertIn("up=ab>0?(", js)
-        self.assertIn("'diverged'", js)
+        self.assertIn("down=bb>0?('behind '+bb):''", js)   # said in words since 2026-07-30
+        self.assertIn("up=ab>0?('ahead '+ab):''", js)
+        self.assertIn("'diverged: '", js)
         self.assertIn("'different build'", js, "an unknown sha says so instead of guessing")
 
     def test_tooltip_carries_the_shas_and_date(self):

--- a/tests/test_remotes_panel_render.py
+++ b/tests/test_remotes_panel_render.py
@@ -190,7 +190,7 @@ class RemotesPanelRender(unittest.TestCase):
         # The control: an `up` row DID just poll, so its drift is fact and wears no hedge.
         out = self._run(tunnels=self._drifted(status="up", stale=False))
         html = out.get("html", "")
-        self.assertIn("(\u21932)", html)   # git-style arrows (2026-07-29), in parens after the build (2026-07-30)
+        self.assertIn("(behind 2)", html)   # said in words (2026-07-30), in parens after the build
         self.assertIn("v0.1.3 abc1234", html, "the build it is actually on, named so a human can read it")
         self.assertNotIn("last known", html)
         self.assertNotIn("rnet-stale", html)
@@ -199,7 +199,7 @@ class RemotesPanelRender(unittest.TestCase):
         out = self._run(tunnels=self._drifted(status="down", stale=True, last_ok=1785272930))
         html = out.get("html", "")
         self.assertIn("disconnected", html, "the row still reports its live state")
-        self.assertIn("last known: v0.1.3 abc1234 (\u21932)", html,
+        self.assertIn("last known: v0.1.3 abc1234 (behind 2)", html,
                       "a drift count from an unreachable host must read as memory, not as a finding")
         self.assertIn("rnet-stale", html, "and must carry the muted cue that overrides the accent")
         self.assertIn("last confirmed", html, "hover says WHEN it was true (progressive disclosure)")


### PR DESCRIPTION
Two asks from the phone (the user 2026-07-30):

**A remote session's "host:" reads as metadata in the mobile session picker**, matching desktop. It was painted whole in the session's identity colour at full weight, because the picker read the desktop tab's label with `textContent` — flattening away the `.host-prefix` span that carries the treatment. It clones the label's child nodes now, so one definition of that look serves both surfaces (including the disconnected-host cue the same span wears).

Worth noting: the first cut appended straight off the clone's `childNodes`, a live NodeList — each append removed a node and the walk skipped every second one, so rows rendered as a bare "host:" with no session name. Caught in a browser repro, not by the source pin; the test now pins the `slice` as well as the clone.

**The network panel says the words instead of git's arrows**: "behind 3", "ahead 2", and a diverged host "diverged: ahead 2, behind 3". An arrow only reads as a direction if you already know which way romp points it, and this is where a reader decides whether to push or pull. The counts stay, and one definition still feeds the panel row and the rail tooltip alike.

Verified with a headless-Chrome repro driving the real mobile picker JS against a synthetic federated tab DOM; pytest 3768 pass, node 1525 pass.

Generated with [Claude Code](https://claude.com/claude-code)