### PR TITLE
Fold a thread to its name, and it stays folded for the cards not written yet

### DIFF
--- a/ui/webview/feed-group-mode.test.ts
+++ b/ui/webview/feed-group-mode.test.ts
@@ -29,16 +29,19 @@ test("session rank = the kernel's session-order list (tab/lane order); unknown s
 });
 
 test("a name+dot header entry opens each session's run; only runs that exist get one", () => {
-  assert.match(FEED, /\{ kind: "sess"; t: number; sid: string; name: string; color: \{ bg: string; fg: string \} \| null; live: boolean \}/);
+  // `folded` joined the header entry with collapsible threads (feed-thread-fold.test.ts, 2026-07-31):
+  // it counts the cards a FOLDED header stands in for, and is 0 while the thread is open.
+  assert.match(FEED, /\{ kind: "sess"; t: number; sid: string; name: string; color: \{ bg: string; fg: string \} \| null; live: boolean; folded: number \}/);
   assert.match(FEED, /if \(s !== cur\) \{/);
-  assert.match(FEED, /withHeads\.push\(\{ kind: "sess", t: e\.t, sid: s, name: src\.name, color: src\.color \|\| null, live: !!src\.live \}\);/);
+  assert.match(FEED, /head = \{ kind: "sess", t: e\.t, sid: s, name: src\.name, color: src\.color \|\| null, live: !!src\.live, folded: 0 \};\s*\n\s*withHeads\.push\(head\);/);
   // reconcile keys headers per (column, sid) — one session can head a run in EVERY column
   assert.match(FEED, /key = "s:" \+ listEl\.id \+ ":" \+ e\.sid;/);
   // the header carries the identity: colored name, host prefix treatment, the yellow working dot
   assert.match(FEED, /nm\.replaceChildren\(\.\.\.hostNameNodes\(e\.name, e\.sid\)\);/);
   assert.match(FEED, /setWorkDot\(nm, dotFor\(e\.name\)\);/);   // work OR awaiting dot — straw when idle-but-awaiting (the user 2026-07-13)
-  // headers aren't cards: the column count chips exclude them
-  assert.match(FEED, /const nCards = \(es: Entry\[\]\) => es\.filter\(\(e\) => e\.kind !== "sess"\)\.length;/);
+  // headers aren't cards — but a FOLDED one stands in for its run, so the chip counts what it hides;
+  // the column must report the board, not what the reader happens to have open (2026-07-31)
+  assert.match(FEED, /const nCards = \(es: Entry\[\]\) => es\.reduce\(\(n, e\) => n \+ \(e\.kind === "sess" \? e\.folded : 1\), 0\);/);
   // flex-wrap: the header hosts the background-process chip's expandable list on its own full-width
   // line (feed-bg-service-chip.test.ts, the user 2026-07-24)
   assert.match(CSS, /\.feed-sess-head \{ display: flex; flex-wrap: wrap; align-items: center;/);

--- a/ui/webview/feed-thread-fold.test.ts
+++ b/ui/webview/feed-thread-fold.test.ts
@@ -1,0 +1,70 @@
+// COLLAPSIBLE THREADS in the grouped feed (the user 2026-07-31): a caret right of each session-header name
+// folds that thread away to its name alone, and it STAYS folded — including for cards that do not exist yet
+// — until you expand it again. Persisted with the rest of the feed's disclosure state.
+//
+// Keyed by SID rather than by column-run on purpose: a card's column is not knowable when you fold, so a
+// per-column fold could not honour "future cards stay folded" the moment a card moved columns.
+//
+// No jsdom for the feed renderer, so the render side is pinned at the source; the STATE side is executed in
+// feed-view-state.test.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+test("the caret sits to the RIGHT of the session name, where it was asked for", () => {
+  assert.match(FEED, /const fold = el\("button", "feed-sess-fold"\);/);
+  assert.match(FEED, /h\.append\(nm, fold, cnt, svc, svcList\);/, "name, then caret — not a leading tree triangle");
+});
+
+test("it is a caret, and it says which way it will go", () => {
+  assert.match(FEED, /fold\.textContent = shut \? "▸" : "▾";/);
+  assert.match(FEED, /fold\.setAttribute\("aria-expanded", shut \? "false" : "true"\);/);
+  assert.match(FEED, /fold\.setAttribute\("aria-label", \(shut \? "expand " : "collapse "\) \+ e\.name\);/);
+});
+
+test("folding hides that thread's cards and counts them onto the header", () => {
+  // the header stands in for the run: entries are counted, not rendered
+  assert.match(FEED, /if \(collapsedThreads\.has\(s\)\) \{ if \(head\) head\.folded\+\+; continue; \}/);
+  assert.match(FEED, /foldn\.textContent = e\.folded === 1 \? "1 card" : e\.folded \+ " cards";/);
+  assert.match(FEED, /foldn\.style\.display = shut && e\.folded \? "" : "none";/);
+});
+
+test("the column count reports the BOARD, not what you have open", () => {
+  // folding a thread must not read as its work having left the column
+  assert.match(FEED, /const nCards = \(es: Entry\[\]\) => es\.reduce\(\(n, e\) => n \+ \(e\.kind === "sess" \? e\.folded : 1\), 0\);/);
+});
+
+test("the fold is per-SESSION, so a card that does not exist yet inherits it", () => {
+  assert.match(FEED, /const collapsedThreads = new Set<string>\(\);/);
+  assert.match(FEED, /if \(collapsedThreads\.has\(e\.sid\)\) collapsedThreads\.delete\(e\.sid\); else collapsedThreads\.add\(e\.sid\);/);
+  // …and it survives a reload with the rest of the disclosure state
+  assert.match(FEED, /for \(const k of st\.threads\) collapsedThreads\.add\(k\);/);
+  assert.match(FEED, /threads: \[\.\.\.collapsedThreads\]/);
+});
+
+test("the click acknowledges immediately and cannot be lost to a re-render", () => {
+  // the header ELEMENT is reused across renders (sessHeadEls), so the button node survives; the handler is
+  // re-pointed at the current entry each update, and the fold is its own acknowledgement (local + render)
+  assert.match(FEED, /fold\.onclick = \(ev\) => \{\s*\n\s*ev\.stopPropagation\(\);[\s\S]{0,200}?render\(\);\s*\n\s*\};/);
+  assert.match(FEED, /card = sessHeadEls\.get\(key\) \|\| makeSessHead\(\);/);
+});
+
+test("a jump into a folded thread unfolds it instead of landing on nothing", () => {
+  // revealCards scrolls to a DOM element; a folded card has none, so the navigation would silently no-op
+  assert.match(FEED, /if \(collapsedThreads\.has\(a\.sid\) && extHoverMatches\("a:" \+ a\.itemId, keys\)\) \{/);
+  assert.match(FEED, /if \(opened\) render\(\);/);
+});
+
+test("the caret is a bare glyph, and a folded header keeps its group's spacing", () => {
+  // a chip outline on every header would draw a border down the whole column
+  assert.match(CSS, /\.feed-sess-fold \{[^}]*border: 0;/);
+  assert.match(CSS, /\.feed-sess-fold \{[^}]*cursor: pointer/);
+  assert.match(CSS, /\.feed-sess-fold:hover, \.feed-sess-fold:focus-visible \{ color: var\(--fg\); \}/);
+  assert.match(CSS, /\.feed-sess-head\.folded \{ margin-bottom: 7px; \}/);
+  // the count reuses the header's existing label size rather than adding one
+  assert.match(CSS, /\.feed-sess-foldn \{[^}]*font-size: 0\.74em/);
+});

--- a/ui/webview/feed-view-state.test.ts
+++ b/ui/webview/feed-view-state.test.ts
@@ -20,6 +20,7 @@ function sample(): FeedViewState {
     nodes: ["card-a:n3"],
     logs: ["card-b:n4"],
     asks: ["card-a"],
+    threads: [],   // the card-prune tests below assert on CARD state; the thread exemption has its own
   };
 }
 
@@ -60,6 +61,7 @@ test("an itemId containing a colon is not mis-attributed by the prune", () => {
   // its FIRST colon would read this card as "blocked" and prune state that is very much live.
   const s: FeedViewState = {
     v: 1, sec: { "blocked:sess-7": "bg" }, tree: ["blocked:sess-7:n1"], nodes: [], logs: [], asks: [],
+    threads: [],
   };
   const pruned = pruneViewState(s, new Set(["blocked:sess-7"]));
   assert.deepEqual(pruned.sec, { "blocked:sess-7": "bg" }, "the colon-bearing id survives");
@@ -90,11 +92,38 @@ test("the cap is a backstop that trims cheap state first and section choices las
     nodes: Array.from({ length: 10 }, (_, i) => `a:n${i}`),
     logs: Array.from({ length: 10 }, (_, i) => `a:l${i}`),
     asks: ["a"],
+    threads: ["sid-1"],
   };
   const capped = capViewState(big, 20);
   assert.equal(viewStateSize(capped), 20);
   assert.deepEqual(capped.sec, { a: "bg", b: "summary" }, "the per-card section is what you notice losing — trimmed last");
   assert.equal(capped.logs.length, 0, "per-node log expands are cheapest to re-open — trimmed first");
+  assert.deepEqual(capped.threads, ["sid-1"], "a folded thread is one entry per session and outlives the cheap state");
+});
+
+// ── collapsed THREADS (the user 2026-07-31) ───────────────────────────────────────────────────────────
+test("a folded thread SURVIVES the card prune — that is the whole point of it", () => {
+  // Every other entry describes a card, so a vanished card makes its entry meaningless. A folded thread
+  // describes a SESSION: it has to hold while that session has no cards on the board, or clearing the last
+  // card would silently re-expand the thread and the next card would arrive unfolded.
+  const s: FeedViewState = {
+    v: 1, sec: { "card-a": "bg" }, tree: [], nodes: [], logs: [], asks: [], threads: ["sid-quiet"],
+  };
+  const pruned = pruneViewState(s, new Set<string>());   // no live cards at all
+  assert.deepEqual(pruned.threads, ["sid-quiet"]);
+  assert.deepEqual(pruned.sec, {}, "…while the card state is still pruned as before");
+});
+
+test("a stored blob from before threads existed reads as nothing folded, not as corrupt", () => {
+  const old = JSON.stringify({ v: 1, sec: { a: "bg" }, tree: [], nodes: [], logs: [], asks: ["a"] });
+  const s = parseViewState(old);
+  assert.deepEqual(s.threads, []);
+  assert.deepEqual(s.sec, { a: "bg" }, "the sections the user had open survive the upgrade");
+});
+
+test("a folded thread round-trips through serialize/parse", () => {
+  const s = { ...sample(), threads: ["sid-1", "sid-2"] };
+  assert.deepEqual(parseViewState(serializeViewState(s)).threads, ["sid-1", "sid-2"]);
 });
 
 test("a state under the cap is returned untouched", () => {
@@ -103,10 +132,11 @@ test("a state under the cap is returned untouched", () => {
 });
 
 // ── wiring pins (no jsdom for feed.ts; repo convention) ──────────────────────────────────────────────
-test("feed.ts hydrates the five disclosure collections on load", () => {
+test("feed.ts hydrates every disclosure collection on load", () => {
   assert.match(FEED, /function hydrateViewState\(\)/);
   assert.match(FEED, /parseViewState\(localStorage\.getItem\(VIEW_STATE_KEY\)\)/);
-  for (const c of ["secChoice.set", "cardTreeExpanded.add", "collapsedNodes.add", "nodeLogOpen.add", "expandedAsks.add"]) {
+  for (const c of ["secChoice.set", "cardTreeExpanded.add", "collapsedNodes.add", "nodeLogOpen.add",
+                   "expandedAsks.add", "collapsedThreads.add"]) {
     assert.ok(FEED.includes(c), `hydrate restores ${c}`);
   }
 });

--- a/ui/webview/feed-view-state.ts
+++ b/ui/webview/feed-view-state.ts
@@ -24,6 +24,10 @@ export interface FeedViewState {
   nodes: string[];               // "askId:nodeId" — COLLAPSED modal tree nodes (inverted sense, see feed.ts)
   logs: string[];                // "askId:nodeId" — expanded per-node log stories
   asks: string[];                // expanded ask itemIds
+  // COLLAPSED session sids (inverted sense, like `nodes`): in grouped mode the thread shows its header
+  // alone. Keyed by SESSION, not by card, because the point is that cards which do not exist yet inherit
+  // it — see the prune exemption below.
+  threads: string[];
 }
 
 export const VIEW_STATE_KEY = "romp:feedview";
@@ -32,7 +36,7 @@ export const VIEW_STATE_KEY = "romp:feedview";
 export const VIEW_STATE_CAP = 4000;
 
 export function emptyViewState(): FeedViewState {
-  return { v: 1, sec: {}, tree: [], nodes: [], logs: [], asks: [] };
+  return { v: 1, sec: {}, tree: [], nodes: [], logs: [], asks: [], threads: [] };
 }
 
 /** Parse a stored blob. ANY malformed/foreign/old-version value reads as empty rather than throwing — a
@@ -47,7 +51,10 @@ export function parseViewState(raw: string | null | undefined): FeedViewState {
     if (o.sec && typeof o.sec === "object") {
       for (const [k, v] of Object.entries(o.sec as Record<string, unknown>)) if (typeof v === "string") sec[k] = v;
     }
-    return { v: 1, sec, tree: arr(o.tree), nodes: arr(o.nodes), logs: arr(o.logs), asks: arr(o.asks) };
+    // `threads` post-dates v1 blobs, so a stored entry without it reads as "nothing collapsed" rather
+    // than as corrupt — no version bump, and yesterday's saved sections survive the upgrade.
+    return { v: 1, sec, tree: arr(o.tree), nodes: arr(o.nodes), logs: arr(o.logs), asks: arr(o.asks),
+             threads: arr(o.threads) };
   } catch {
     return emptyViewState();
   }
@@ -83,25 +90,36 @@ export function keyIsLive(key: string, liveIds: Set<string>): boolean {
  *  ids, never a view-filtered subset (`#only=` hides cards without ending them; pruning against the filtered
  *  list would silently discard the hidden cards' state). Call only once a payload has actually arrived: an
  *  empty live set legitimately means "no cards", and pruning against it before the first push would wipe
- *  everything the user just restored. */
+ *  everything the user just restored.
+ *
+ *  `threads` is EXEMPT, deliberately. Every other entry describes a card, so a card that is gone makes its
+ *  entry meaningless; a collapsed thread describes a SESSION, and its whole purpose is to hold while that
+ *  session has no cards on the board so the next one arrives collapsed too. Pruning it against the live set
+ *  would silently re-expand a thread the moment its last card cleared — exactly the "collapse it and it
+ *  stays collapsed" the feature is for. It is bounded by the cap instead. */
 export function pruneViewState(s: FeedViewState, liveIds: Set<string>): FeedViewState {
   const sec: Record<string, string> = {};
   for (const [k, v] of Object.entries(s.sec)) if (keyIsLive(k, liveIds)) sec[k] = v;
   const keep = (xs: string[]) => xs.filter((k) => keyIsLive(k, liveIds));
-  return capViewState({ v: 1, sec, tree: keep(s.tree), nodes: keep(s.nodes), logs: keep(s.logs), asks: keep(s.asks) });
+  return capViewState({ v: 1, sec, tree: keep(s.tree), nodes: keep(s.nodes), logs: keep(s.logs),
+                        asks: keep(s.asks), threads: s.threads });
 }
 
 export function viewStateSize(s: FeedViewState): number {
-  return Object.keys(s.sec).length + s.tree.length + s.nodes.length + s.logs.length + s.asks.length;
+  return Object.keys(s.sec).length + s.tree.length + s.nodes.length + s.logs.length + s.asks.length
+    + s.threads.length;
 }
 
 /** Backstop trim. Order is deliberate: the per-card SECTION choice is the state the user notices losing, so
- *  it is trimmed last; the per-node tree/log expansions are cheap to re-open and go first. */
+ *  it is trimmed last; the per-node tree/log expansions are cheap to re-open and go first. Collapsed
+ *  THREADS sit just above sec — they are few (one per session, not per card) and the most durable choice
+ *  here, so they are the last thing to give before the sections do. */
 export function capViewState(s: FeedViewState, cap: number = VIEW_STATE_CAP): FeedViewState {
   let over = viewStateSize(s) - cap;
   if (over <= 0) return s;
-  const out: FeedViewState = { ...s, tree: [...s.tree], nodes: [...s.nodes], logs: [...s.logs], asks: [...s.asks] };
-  for (const f of ["logs", "nodes", "tree", "asks"] as const) {
+  const out: FeedViewState = { ...s, tree: [...s.tree], nodes: [...s.nodes], logs: [...s.logs],
+                               asks: [...s.asks], threads: [...s.threads] };
+  for (const f of ["logs", "nodes", "tree", "asks", "threads"] as const) {
     if (over <= 0) break;
     const drop = Math.min(over, out[f].length);
     out[f] = out[f].slice(drop);

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -174,6 +174,20 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .feed-sess-head { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin: 9px 3px 0; font-weight: 600; }
 .feed-sess-head .fname { font-size: inherit; }   /* not .fname's 0.92em — the header matches the card titles exactly */
 .feed-sess-head:first-child { margin-top: 2px; }
+/* the FOLD caret, right of the name (the user 2026-07-31). Bare glyph, no chip box: it sits on EVERY
+   header, so the .fask-secbtn outline the service chip wears would draw a border down the whole column.
+   Dim at rest, full strength on hover/focus — the same quiet-until-wanted treatment as the header's other
+   furniture — and un-bolded from the header's 600 so it never competes with the name. The hit area is
+   padded well past the glyph: this gets tapped with a thumb on the phone. */
+.feed-sess-fold { flex: none; padding: 0 5px; margin-left: -2px; color: var(--dim); background: transparent;
+  border: 0; font: inherit; font-weight: 400; line-height: 1; cursor: pointer; transition: color 0.12s ease; }
+.feed-sess-fold:hover, .feed-sess-fold:focus-visible { color: var(--fg); }
+/* what the folded row stands in for. The header's other label size (0.74em) and dim, so the name stays the
+   thing you read; drawn only while folded — expanded, the cards speak for themselves. */
+.feed-sess-foldn { flex: none; font-weight: 400; font-size: 0.74em; color: var(--dim); }
+/* a folded header IS its whole group, so it takes the bottom margin the run of cards would have had —
+   without it, consecutive folded threads jam into one unreadable stack of names. */
+.feed-sess-head.folded { margin-bottom: 7px; }
 /* the neutral background-process chip on the header (kernel bgServices): a process the session KEEPS
    (a dev server the judge classified as nobody-waits). Reuses the .fask-secbtn chip vocabulary — dim,
    0.74em, accent only while its list is open (a selected toggle, the accent's job) — and un-bolds from

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -418,6 +418,12 @@ const sessionColors = new Map<string, string>();
 // background-task box still lists the processes there).
 let bgServicesMap: Record<string, string[]> = {};
 const openBgSvc = new Set<string>();   // sids with the chip's process list expanded — survives re-renders
+// COLLAPSED threads (the user 2026-07-31): grouped mode's session header carries a caret, and folding one
+// leaves the header alone in every column that thread appears in, with a count of what is folded away.
+// Keyed by SID, not by column-run, for the reason the request turns on: cards that do not exist yet must
+// arrive collapsed too, and a card's column is not knowable when you fold the thread. Persisted across
+// reloads with the rest of the disclosure state, and deliberately NOT pruned when the cards go away.
+const collapsedThreads = new Set<string>();
 // names of sessions idle-but-AWAITING background work (the user 2026-07-13): the same dot in straw —
 // matching the chat chip's Awaiting color — so a held session reads differently from a working one.
 let awaitingSet = new Set<string>();
@@ -1011,12 +1017,14 @@ const cardTreeExpanded = new Set<string>();
   for (const k of st.nodes) collapsedNodes.add(k);
   for (const k of st.logs) nodeLogOpen.add(k);
   for (const k of st.asks) expandedAsks.add(k);
+  for (const k of st.threads) collapsedThreads.add(k);
 })();
 
 function currentViewState(): FeedViewState {
   const sec: Record<string, string> = {};
   secChoice.forEach((v, k) => { sec[k] = v; });
-  return { v: 1, sec, tree: [...cardTreeExpanded], nodes: [...collapsedNodes], logs: [...nodeLogOpen], asks: [...expandedAsks] };
+  return { v: 1, sec, tree: [...cardTreeExpanded], nodes: [...collapsedNodes], logs: [...nodeLogOpen],
+           asks: [...expandedAsks], threads: [...collapsedThreads] };
 }
 
 // Written at the END of every render rather than from each toggle handler: the feed re-renders on every
@@ -1042,6 +1050,7 @@ function pruneViewStateTo(live: Set<string>): void {
   keep(collapsedNodes, kept.nodes);
   keep(nodeLogOpen, kept.logs);
   keep(expandedAsks, kept.asks);
+  keep(collapsedThreads, kept.threads);   // pass-through: a thread stays collapsed with no cards on the board
 }
 
 // Fill + wire the card's THREE mutually-exclusive sections — Background, Summary, Sub-goals (the user
@@ -2665,7 +2674,8 @@ type Entry =
   | { kind: "group"; t: number; group: AskGroup }
   // a SESSION HEADER row in grouped mode (the user 2026-07-13): the session's name + working dot on the
   // column backdrop, heading that session's run of cards. Only emitted for runs that exist.
-  | { kind: "sess"; t: number; sid: string; name: string; color: { bg: string; fg: string } | null; live: boolean };
+  // `folded` = how many of this run's cards the header is standing in for (0 when the thread is expanded)
+  | { kind: "sess"; t: number; sid: string; name: string; color: { bg: string; fg: string } | null; live: boolean; folded: number };
 
 // Grouped-mode session headers, one reused element per (column, sid) — same keyed-incremental treatment as
 // cards so re-renders never rebuild a header mid-press. Pruned when a reconcile drops them from the DOM.
@@ -2679,8 +2689,16 @@ function makeSessHead(): HTMLElement {
   // vocabulary, dim by default. Click expands the process list (keyed expand, survives re-renders).
   const svc = el("button", "fask-secbtn feed-sess-svcbtn"); svc.style.display = "none";
   const svcList = el("div", "feed-sess-svclist"); svcList.style.display = "none";
-  h.append(nm, svc, svcList);
-  (h as any)._name = nm; (h as any)._svc = svc; (h as any)._svcList = svcList;
+  // FOLD control (the user 2026-07-31), immediately right of the name where they asked for it. A caret is
+  // the universal collapse affordance and costs one glyph, where a word chip would repeat on every header;
+  // it is the same typographic vocabulary as the sub-goal triangles, never an emoji. Always drawn rather
+  // than shown on hover: a hover-only control is invisible on the phone, which is where the feed is read
+  // most. The count beside it is what keeps the folded row from dead-ending — you can see what is under it.
+  const fold = el("button", "feed-sess-fold");
+  const cnt = el("span", "feed-sess-foldn"); cnt.style.display = "none";
+  h.append(nm, fold, cnt, svc, svcList);
+  (h as any)._name = nm; (h as any)._fold = fold; (h as any)._foldn = cnt;
+  (h as any)._svc = svc; (h as any)._svcList = svcList;
   return h;
 }
 function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
@@ -2690,6 +2708,21 @@ function updateSessHead(h: HTMLElement, e: Entry & { kind: "sess" }): void {
   nm.classList.toggle("dead", !e.live);
   nm.onclick = (ev) => { ev.stopPropagation(); openOrReviveSession(e.sid, e.live, e.name); };
   setWorkDot(nm, dotFor(e.name));   // the working/awaiting dot rides the header, not the cards
+  // the fold caret + the "n cards" stand-in for what it hides
+  const fold = (h as any)._fold as HTMLElement, foldn = (h as any)._foldn as HTMLElement;
+  const shut = collapsedThreads.has(e.sid);
+  h.classList.toggle("folded", shut);
+  fold.textContent = shut ? "▸" : "▾";           // ▸ folded / ▾ open
+  fold.title = shut ? "show this session's cards" : "collapse this session to its name — new cards stay folded too";
+  fold.setAttribute("aria-expanded", shut ? "false" : "true");
+  fold.setAttribute("aria-label", (shut ? "expand " : "collapse ") + e.name);
+  foldn.style.display = shut && e.folded ? "" : "none";
+  foldn.textContent = e.folded === 1 ? "1 card" : e.folded + " cards";
+  fold.onclick = (ev) => {
+    ev.stopPropagation();   // the fold IS the acknowledgement: local state + an immediate re-render
+    if (collapsedThreads.has(e.sid)) collapsedThreads.delete(e.sid); else collapsedThreads.add(e.sid);
+    render();
+  };
   const svc = (h as any)._svc as HTMLElement, svcList = (h as any)._svcList as HTMLElement;
   const procs = e.live ? bgServicesMap[e.name] || [] : [];
   const open = procs.length > 0 && openBgSvc.has(e.sid);
@@ -3073,13 +3106,18 @@ function render() {
       buckets[k].sort((x, y) => rk(x) - rk(y));
       const withHeads: Entry[] = [];
       let cur: string | null = null;
+      let head: (Entry & { kind: "sess" }) | null = null;
       for (const e of buckets[k]) {
         const s = eSid(e);
         if (s !== cur) {
           cur = s;
           const src: any = e.kind === "ask" ? e.ask : e.kind === "group" ? e.group : e;
-          withHeads.push({ kind: "sess", t: e.t, sid: s, name: src.name, color: src.color || null, live: !!src.live });
+          head = { kind: "sess", t: e.t, sid: s, name: src.name, color: src.color || null, live: !!src.live, folded: 0 };
+          withHeads.push(head);
         }
+        // A COLLAPSED thread contributes its header and nothing else — the run's cards are counted onto the
+        // header instead of rendered, so the folded row still says how much is under it.
+        if (collapsedThreads.has(s)) { if (head) head.folded++; continue; }
         withHeads.push(e);
       }
       buckets[k] = withHeads;
@@ -3109,7 +3147,10 @@ function render() {
   // the count chip shows the number only when there ARE cards; an empty column shows nothing — not "0"
   // (the user 2026-06-25). Empty string collapses the chip (it has no padding/background of its own).
   const setCount = (elc: HTMLElement, n: number) => { elc.textContent = n ? String(n) : ""; elc.style.display = n ? "" : "none"; };
-  const nCards = (es: Entry[]) => es.filter((e) => e.kind !== "sess").length;   // headers aren't cards
+  // Headers aren't cards — but a FOLDED header stands in for its run, so its cards count. The column chip
+  // reports what is on the board, never what you happen to have open: folding a thread must not read as
+  // work having left the column (the user 2026-07-31).
+  const nCards = (es: Entry[]) => es.reduce((n, e) => n + (e.kind === "sess" ? e.folded : 1), 0);
   setCount(cols.asksCount, nCards(buckets.asks));
   setCount(cols.needsInputCount, nCards(buckets.needsInput));
   setCount(cols.completedCount, nCards(buckets.completed));
@@ -3588,6 +3629,19 @@ function applyExtHover() {
 // reflow, or a second click on the same card would re-add a class it already has and CSS would replay
 // nothing — the "clicked again and it didn't flash" bug this shape avoids.
 function revealCards(keys: Set<string>) {
+  // A target inside a FOLDED thread has no element to scroll to, and a jump that lands on nothing is the
+  // silent no-op a collapse must never cause (the user 2026-07-31). Unfold the owning thread(s) and render
+  // before looking: the navigation wins over the disclosure, and the thread stays open afterwards so you
+  // can see where you were taken.
+  if (collapsedThreads.size) {
+    let opened = false;
+    for (const a of asks) {
+      if (collapsedThreads.has(a.sid) && extHoverMatches("a:" + a.itemId, keys)) {
+        collapsedThreads.delete(a.sid); opened = true;
+      }
+    }
+    if (opened) render();
+  }
   const hits = Array.from(document.querySelectorAll<HTMLElement>("[data-key]"))
     .filter((c) => extHoverMatches(c.dataset.key, keys));
   if (!hits.length) return;


### PR DESCRIPTION
A busy session can own most of a column, with no way to put it down without losing the rest of the board behind it.

Each grouped-mode session header now carries a caret just right of the name. Click it and that thread collapses to its name plus a count of what is under it, in every column it appears in. Everything defaults to expanded.

## Why it is keyed by session, not by the run you clicked

The request turns on cards that do not exist yet inheriting the fold — and a card's column is not knowable at the moment you fold. Keyed per column-run, a card moving from Working to Needs-you would pop out of a thread you had put away.

It rides the feed's existing disclosure state (`romp:feedview`), so it survives the reload a kernel restart brings. It is the one entry in that state **exempt from the live-card prune**: every other entry describes a card, so a vanished card makes its entry meaningless, but a folded thread describes a *session* and has to hold precisely while that session has nothing on the board. Otherwise clearing its last card would silently unfold it.

## Two things a fold must not quietly break

- **The column count** adds the folded cards back, so putting a thread away never reads as its work having left the column.
- **A jump into a folded thread unfolds it first.** `revealCards` scrolls to an element and a folded card has none, so a chat-dot or timeline jump would have landed on nothing at all.

## Tests

New `ui/webview/feed-thread-fold.test.ts` (8) pins the render side; `feed-view-state.test.ts` (+3) executes the state side, including the prune exemption and that a pre-`threads` stored blob upgrades cleanly rather than reading as corrupt. Three pins in `feed-group-mode.test.ts` updated for the changed header entry.

Full suites green: 3773 Python, 1538 node, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)