### PR TITLE
Session order belongs to the viewer, so hosts can finally interleave

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16185,7 +16185,7 @@ else if(m.type==="revealEvent"&&panel.revealEvent)panel.revealEvent(m.sid,m.t,m.
 window.__rompTimelineOpenExternal=function(url){try{var u=new URL(url);if(u.protocol==="vscode:"){var q=u.searchParams;
 post({type:"deepLink",session:q.get("session"),anchor:q.get("anchor")||undefined,anchorT:Number(q.get("anchorT"))||undefined,anchorKind:q.get("anchorKind")||undefined,compose:q.get("compose")==="1"});
 if(window.parent!==window)window.parent.postMessage({romp:"reveal",pane:"chat"},"*");return;}}catch(e){}window.open(url,"_blank");};
-window.__rompTimelineWriteOrder=function(order){post({type:"writeOrder",order:order});};
+window.__rompTimelineWriteOrder=function(order){if(window.__rompWriteOrder)window.__rompWriteOrder(order);};
 window.__rompTimelineCompact=function(name){post({type:"compact",name:name});};
 window.__rompTimelineSendCommand=function(name,cmd){post({type:"sendCommand",name:name,cmd:cmd});};
 window.__rompTimelineSetFlag=function(id,flag,value){post({type:"setSessionFlag",id:id,flag:flag,value:!!value});};

--- a/tests/test_browser_owned_order.py
+++ b/tests/test_browser_owned_order.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Session order belongs to the VIEWER, not to a kernel (the user 2026-07-31).
+
+Each kernel used to own the order of its own sessions and the browser concatenated the per-host lists, so
+hosts always drew as blocks and a drag that mixed them was undone on the next merge — no kernel can record
+an order over sids belonging to another one. The arrangement now lives in the browser (ui/webview/
+view-order.ts), and each kernel's list is only the arrival-order SEED it starts from.
+
+This pins the kernel-side half: the timeline page's inline boot must hand a lane drag to the browser store
+rather than posting it back here. Synthetic ids only.
+"""
+import inspect
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_bwo", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class TimelineBootWritesTheBrowser(unittest.TestCase):
+    def test_a_lane_drag_goes_to_the_browser_store_not_back_to_the_kernel(self):
+        boot = km._TIMELINE_BOOT
+        self.assertIn("window.__rompTimelineWriteOrder=function(order){"
+                      "if(window.__rompWriteOrder)window.__rompWriteOrder(order);};", boot)
+        self.assertNotIn('post({type:"writeOrder"', boot,
+                         "posting it here would put a kernel back in charge of a per-viewer choice")
+
+    def test_the_write_helper_comes_from_the_federation_bundle_the_page_already_loads(self):
+        # the inline boot cannot import a module, so federation.js publishes the ONE implementation — and
+        # the page has to load it BEFORE the boot, or the drag would find no helper to call
+        src = inspect.getsource(km._timeline_page)
+        self.assertIn("federation.js", src)
+        self.assertLess(src.index("federation.js"), src.index("_TIMELINE_BOOT"),
+                        "the bundle defining __rompWriteOrder loads ahead of the boot that calls it")
+        fed = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "federation.ts"), encoding="utf-8").read()
+        self.assertIn("w.__rompWriteOrder =", fed)
+
+
+class TheKernelListIsNowOnlyASeed(unittest.TestCase):
+    def test_the_kernel_still_orders_and_gc_s_its_own_sessions(self):
+        # unchanged on purpose: it is what a viewer with no arrangement sees, and where a NEW session
+        # enters the list. Only the browser's overlay decides the rest.
+        self.assertTrue(callable(km._session_order))
+        self.assertTrue(callable(km._merge_session_order))
+        self.assertTrue(callable(km._gc_session_order))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -11,6 +11,9 @@
 // local kernel is just connection #0 with the empty-string host key, so its messages pass through
 // unprefixed and the single-kernel path is byte-for-byte unchanged.
 
+import { applyViewOrder, applyViewOrderTo, pruneViewOrder, readViewOrder, writeViewOrder,
+         VIEW_ORDER_KEY, VIEW_ORDER_EVENT } from "./view-order";
+
 export const SEP = ":";
 export const LOCAL = ""; // the local kernel's host key — no prefix, so the single-kernel path is untouched
 
@@ -243,10 +246,16 @@ export function routeOutbound(msg: any, knownHosts?: ReadonlySet<string>): Route
   return [{ host: LOCAL, msg }];
 }
 
-/** Merge per-host tab orders into ONE list for the merged strip: each host's order VERBATIM (the kernel is
- *  authoritative within a host — never re-sort across hosts), concatenated in `hostSeq` order (local first,
- *  then attach order). Values are already prefixed by prefixInbound. Deduped; non-strings dropped. */
-export function mergeHostOrder(perHost: Record<string, readonly string[]>, hostSeq: readonly string[]): string[] {
+/** Merge per-host tab orders into ONE list for the merged strip: each host's order verbatim, concatenated in
+ *  `hostSeq` order (local first, then attach order), and then arranged by the VIEWER's own order (the user
+ *  2026-07-31 — see ./view-order for why that moved out of the kernel). Values are already prefixed by
+ *  prefixInbound. Deduped; non-strings dropped.
+ *
+ *  The concatenation is the SEED, not the answer: it decides where a session the viewer has never arranged
+ *  goes, and nothing more. With no arrangement stored, `applyViewOrder` is the identity and this returns the
+ *  host-blocked concatenation that shipped before — the single-kernel path is untouched either way. */
+export function mergeHostOrder(perHost: Record<string, readonly string[]>, hostSeq: readonly string[],
+                               view: readonly string[] = []): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
   for (const h of hostSeq) {
@@ -257,7 +266,7 @@ export function mergeHostOrder(perHost: Record<string, readonly string[]>, hostS
       }
     }
   }
-  return out;
+  return applyViewOrder(out, view);
 }
 
 /** Merge per-host feed snapshots into ONE payload. The `feed` message is a WHOLE-feed snapshot that the
@@ -266,7 +275,8 @@ export function mergeHostOrder(perHost: Record<string, readonly string[]>, hostS
  *  back and forth ("repeatedly reloading"). Concatenate the arrays (items/asks/working) in hostSeq order
  *  (local first); keep the scalar chrome fields (now, dismissedCount, flags) from the LOCAL host, since the
  *  dashboard's own controls are local-authoritative. Ids are already prefixed by prefixInbound. */
-export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly string[]): any {
+export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly string[],
+                               view: readonly string[] = []): any {
   const local = perHost[LOCAL] || {};
   const merged: any = { ...local, type: "feed", items: [], asks: [], working: [], awaiting: [], order: [] };
   // `ledgers` drives the FLEET pane (it rides the same feed message). Only include it once at least one host
@@ -289,6 +299,9 @@ export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly s
     if (typeof f.dismissedCount === "number") { anyDismissed = true; dismissed += f.dismissedCount; }
     if (f.canUndoClear) canUndo = true;
   }
+  // the grouped feed ranks its session runs off `order`, so it takes the viewer's arrangement like the tab
+  // strip does — the two surfaces have to agree or the feed's groups and the tabs read in different orders.
+  merged.order = applyViewOrder(merged.order, view);
   if (anyLedgers) merged.ledgers = ledgers;
   else delete merged.ledgers;
   if (anyDismissed) merged.dismissedCount = dismissed;
@@ -336,7 +349,8 @@ export function stitchMessages(messages: any[], sessions: readonly any[]): any[]
  *  union; the marks arrays concatenate, with cross-host connectors stitched onto the merged lanes.
  *  Scalar chrome (now/usage/focus/hover/cmapGrad…) stays LOCAL — the browser's own kernel is the
  *  clock + chrome authority, same as the feed merge. */
-export function mergeHostTimelines(perHost: Record<string, any>, hostSeq: readonly string[]): any {
+export function mergeHostTimelines(perHost: Record<string, any>, hostSeq: readonly string[],
+                                   view: readonly string[] = []): any {
   const local = perHost[LOCAL] || {};
   const merged: any = { ...local, sessions: [], turns: {}, messages: [], judging: [] };
   for (const h of hostSeq) {
@@ -346,6 +360,9 @@ export function mergeHostTimelines(perHost: Record<string, any>, hostSeq: readon
     if (d.turns && typeof d.turns === "object") Object.assign(merged.turns, d.turns);
     for (const k of ["messages", "judging"]) if (Array.isArray(d[k])) merged[k].push(...d[k]);
   }
+  // lanes are the third surface reading this order (chat strip, feed groups, timeline lanes): arrange them
+  // the same way, before the message stitch, which pairs postal arrows against the lane list.
+  merged.sessions = applyViewOrderTo(merged.sessions, view, (x: any) => String((x && x.id) || ""));
   merged.messages = stitchMessages(merged.messages, merged.sessions);
   return merged;
 }
@@ -412,6 +429,16 @@ export class FederationManager {
       down: () => [...this.downHosts],
       lastSeen: (h: string) => this.lastSeen[h] || 0,
     };
+    // A drag in ANY pane rewrites the arrangement; every other pane hears it through `storage` (which fires
+    // only in other same-origin contexts) and this one through the writer's own CustomEvent. Both land here,
+    // and re-emitting all three merged payloads is what moves the tabs, lanes and feed groups together.
+    const reorder = () => { this.emitMergedOrder(); this.emitMergedFeed(); this.emitMergedTimeline(false); };
+    w.addEventListener("storage", (e: StorageEvent) => { if (!e.key || e.key === VIEW_ORDER_KEY) reorder(); });
+    w.addEventListener(VIEW_ORDER_EVENT, reorder);
+    // The kernel-served timeline page boots from an inline script that cannot import this module, so the
+    // one implementation of the write is published here for it (its VS Code twin imports it directly).
+    w.__rompWriteOrder = (order: unknown) =>
+      writeViewOrder(Array.isArray(order) ? order.filter((x: unknown): x is string => typeof x === "string") : []);
     this.poll();
     setInterval(() => this.poll(), 4000); // converge on attach/detach made from the shell's network panel
   }
@@ -451,8 +478,15 @@ export class FederationManager {
     window.dispatchEvent(new MessageEvent("message", { data: m }));
   }
 
+  // The viewer's own session order, re-read per emit. It is a handful of strings out of localStorage and
+  // it must never be cached: another PANE of this dashboard writes the same key when you drag a tab there,
+  // and the storage event below re-emits — reading fresh is what makes all three surfaces agree.
+  private view(): string[] {
+    return readViewOrder();
+  }
+
   private emitMergedFeed(): void {
-    window.dispatchEvent(new MessageEvent("message", { data: mergeHostFeeds(this.perHostFeed, this.hostSeq) }));
+    window.dispatchEvent(new MessageEvent("message", { data: mergeHostFeeds(this.perHostFeed, this.hostSeq, this.view()) }));
   }
 
   private emitMergedTimeline(bars: boolean): void {
@@ -464,15 +498,31 @@ export class FederationManager {
     if (!(LOCAL in this.perHostTl)) return;
     const data = bars
       // the bars message carries no lanes — hand the merged lane list in for the connector stitch
-      ? mergeHostBars(this.perHostTlBars, this.hostSeq, mergeHostTimelines(this.perHostTl, this.hostSeq).sessions)
-      : { type: "data", data: mergeHostTimelines(this.perHostTl, this.hostSeq) };
+      ? mergeHostBars(this.perHostTlBars, this.hostSeq, mergeHostTimelines(this.perHostTl, this.hostSeq, this.view()).sessions)
+      : { type: "data", data: mergeHostTimelines(this.perHostTl, this.hostSeq, this.view()) };
     window.dispatchEvent(new MessageEvent("message", { data }));
   }
 
   private emitMergedOrder(): void {
-    const order = mergeHostOrder(this.perHostOrder, this.hostSeq);
+    this.gcView();
+    const order = mergeHostOrder(this.perHostOrder, this.hostSeq, this.view());
     const tabs = this.hostSeq.flatMap((h) => this.perHostTabs[h] || []);
     window.dispatchEvent(new MessageEvent("message", { data: { type: "tabOrder", order, tabs } }));
+  }
+
+  // Self-clean the stored arrangement, event-based: a host that has just reported its sessions is telling
+  // us exactly which of its ids still exist, so any of ITS ids missing from that report is gone for good and
+  // can be dropped. A host that is detached or unreachable reports nothing and is left entirely alone —
+  // pruning against a tunnel blip would flatten every remote session's placement and stack them all at the
+  // end of the strip when the host came back. Rewritten only when it actually changes.
+  private gcView(): void {
+    const reporting = new Set(Object.keys(this.perHostOrder));
+    if (!reporting.size) return;
+    const live = new Set<string>();
+    for (const h of reporting) for (const id of this.perHostOrder[h] || []) live.add(id);
+    const cur = this.view();
+    const kept = pruneViewOrder(cur, hostOf, reporting, live);
+    if (kept.length !== cur.length) writeViewOrder(kept);
   }
 
   private lastClearHost = LOCAL; // where the most recent askClear routed — undoClear follows it

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -20,6 +20,7 @@ import { delegate } from "./actions";
 import { isClearCmd, openTopTitles, clearConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
 import { reconcileTabOrder } from "./tab-order";
+import { writeViewOrder } from "./view-order";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
@@ -3061,10 +3062,16 @@ function fadedColor(hex: string): string {
 // (./tab-order). This replaced a parallel client sort (effIdx + a firstSeen tiebreaker) that diverged from
 // the kernel and made tabs jump on ordinary activity — invisible to the kernel's own (passing) order tests.
 
-// Persist the current full tab order to the shared store (host writes session-order.json → the timeline reads
-// the same file). Called only after a drag — the one client action that changes the order.
+// Persist the current full tab order. Called only after a drag — the one client action that changes it.
+//
+// This writes to THIS BROWSER, not to the kernel (the user 2026-07-31): order is a property of how you are
+// looking at the fleet, so arranging tabs on the laptop has no business moving them on the desktop — and
+// only a browser-side list can interleave hosts at all, since no single kernel can record an order over
+// sids it does not know about. Each kernel keeps its own list as the arrival-order SEED; ./view-order
+// layers this over it, and federation re-emits the tab strip, the timeline lanes and the feed's groups
+// together so all three surfaces read the same way.
 function commitTabOrder() {
-  if (vscodeApi) vscodeApi.postMessage({ type: "reorderTabs", order: order.slice() });
+  writeViewOrder(order.slice());
 }
 // Settle the just-closed tabs against the kernel's authoritative list. Gone from it → the close landed, stop
 // suppressing. STILL in it past the backstop → it didn't land; say so plainly (a session left open while its

--- a/ui/webview/timeline-boot.test.ts
+++ b/ui/webview/timeline-boot.test.ts
@@ -81,7 +81,6 @@ test("openExternalMessage hands other URLs (and junk) to the host as openLink", 
 test("bridges post the same kernel ops as the web boot", () => {
   const { sent, post } = posts();
   const b = bridgeFunctions(post);
-  b.__rompTimelineWriteOrder(["a", "b"]);
   b.__rompTimelineCompact("sess");
   b.__rompTimelineSendCommand("sess", "/model");
   b.__rompTimelineSetFlag("id1", "eye", 1);
@@ -89,7 +88,6 @@ test("bridges post the same kernel ops as the web boot", () => {
   b.__rompTimelineHover("s1", ["g1"], 5, 9);
   b.__rompTimelineHover();
   assert.deepEqual(sent, [
-    { type: "writeOrder", order: ["a", "b"] },
     { type: "compact", name: "sess" },
     { type: "sendCommand", name: "sess", cmd: "/model" },
     { type: "setSessionFlag", id: "id1", flag: "eye", value: true },
@@ -97,6 +95,16 @@ test("bridges post the same kernel ops as the web boot", () => {
     { type: "timelineHover", sid: "s1", segIds: ["g1"], t0: 5, t1: 9 },
     { type: "timelineHover", off: true },
   ]);
+});
+
+test("a lane drag posts NOTHING to a kernel — it arranges this browser's own view", () => {
+  // Order moved out of the kernel (the user 2026-07-31, ./view-order): a kernel can only record an order
+  // over its OWN sids, which is exactly why hosts could never interleave. The drag writes localStorage and
+  // federation re-emits; sending a `writeOrder` op alongside would put the kernel back in charge of a
+  // per-viewer choice and make a drag here move the tabs on another machine.
+  const { sent, post } = posts();
+  bridgeFunctions(post).__rompTimelineWriteOrder(["a", "TESTHOST:b"]);
+  assert.deepEqual(sent, []);
 });
 
 test("installDomHelpers supplies the 3 Obsidian helpers", () => {

--- a/ui/webview/timeline-boot.ts
+++ b/ui/webview/timeline-boot.ts
@@ -12,6 +12,8 @@
 // headlessly; timeline-main.ts is the thin entry that wires it to the real
 // window.
 
+import { writeViewOrder } from "./view-order";
+
 export type Post = (m: Record<string, unknown>) => void;
 
 // The 3 Obsidian DOM helpers TimelinePanel expects on every element.
@@ -72,7 +74,11 @@ export function openExternalMessage(url: string): Record<string, unknown> {
 export function bridgeFunctions(post: Post): Record<string, (...a: any[]) => void> {
   return {
     __rompTimelineOpenExternal: (url: string) => post(openExternalMessage(String(url))),
-    __rompTimelineWriteOrder: (order: unknown) => post({ type: "writeOrder", order }),
+    // A lane drag writes the VIEWER's arrangement (the user 2026-07-31), the same store the chat strip
+    // writes — not the kernel's session-order.json, which is only the arrival-order seed now. Sending it
+    // to a kernel could never interleave hosts anyway: each one can only record its own sids.
+    __rompTimelineWriteOrder: (order: unknown) =>
+      writeViewOrder(Array.isArray(order) ? order.filter((x): x is string => typeof x === "string") : []),
     __rompTimelineCompact: (name: string) => post({ type: "compact", name }),
     __rompTimelineSendCommand: (name: string, cmd: string) => post({ type: "sendCommand", name, cmd }),
     __rompTimelineSetFlag: (id: string, flag: string, value: unknown) => post({ type: "setSessionFlag", id, flag, value: !!value }),

--- a/ui/webview/view-order-wiring.test.ts
+++ b/ui/webview/view-order-wiring.test.ts
@@ -1,0 +1,53 @@
+// Where the viewer's order is READ and WRITTEN (the user 2026-07-31). view-order.test.ts executes the rule;
+// this pins that all three surfaces actually go through it and that nothing writes order back to a kernel.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const p = (f: string) => path.resolve(process.cwd(), "..", "ui", "webview", f);
+const FED = fs.readFileSync(p("federation.ts"), "utf8");
+const RENDER = fs.readFileSync(p("render.ts"), "utf8");
+const BOOT = fs.readFileSync(p("timeline-boot.ts"), "utf8");
+
+test("all THREE surfaces arrange by the same stored order", () => {
+  // chat tab strip, feed grouped-mode ranks, timeline lanes — they must agree or the dashboard reads in
+  // three different orders at once
+  assert.match(FED, /return applyViewOrder\(out, view\);/, "tab strip");
+  assert.match(FED, /merged\.order = applyViewOrder\(merged\.order, view\);/, "feed groups");
+  assert.match(FED, /merged\.sessions = applyViewOrderTo\(merged\.sessions, view, /, "timeline lanes");
+});
+
+test("the arrangement is re-read per emit, never cached", () => {
+  // another PANE writes the same key when you drag a tab there; a cached copy would leave that pane's
+  // surfaces arranged one way and this one's another until a reload
+  assert.match(FED, /private view\(\): string\[\] \{\s*\n\s*return readViewOrder\(\);\s*\n\s*\}/);
+  assert.match(FED, /mergeHostOrder\(this\.perHostOrder, this\.hostSeq, this\.view\(\)\)/);
+  assert.match(FED, /mergeHostFeeds\(this\.perHostFeed, this\.hostSeq, this\.view\(\)\)/);
+  assert.match(FED, /mergeHostTimelines\(this\.perHostTl, this\.hostSeq, this\.view\(\)\)/);
+});
+
+test("a drag in any pane moves every pane, through both notification paths", () => {
+  // `storage` fires only in OTHER same-origin contexts, so the writer needs its own event
+  assert.match(FED, /w\.addEventListener\("storage", \(e: StorageEvent\) => \{ if \(!e\.key \|\| e\.key === VIEW_ORDER_KEY\) reorder\(\); \}\);/);
+  assert.match(FED, /w\.addEventListener\(VIEW_ORDER_EVENT, reorder\);/);
+  assert.match(FED, /const reorder = \(\) => \{ this\.emitMergedOrder\(\); this\.emitMergedFeed\(\); this\.emitMergedTimeline\(false\); \};/);
+});
+
+test("the chat strip's drag writes the BROWSER, not a kernel", () => {
+  assert.match(RENDER, /function commitTabOrder\(\) \{\s*\n\s*writeViewOrder\(order\.slice\(\)\);\s*\n\s*\}/);
+  assert.doesNotMatch(RENDER, /type: "reorderTabs"/,
+    "a kernel can only record an order over its own sids — writing there is what blocked interleaving");
+});
+
+test("the timeline's lane drag writes the same store", () => {
+  assert.match(BOOT, /__rompTimelineWriteOrder: \(order: unknown\) =>\s*\n\s*writeViewOrder\(/);
+  assert.doesNotMatch(BOOT, /type: "writeOrder"/);
+});
+
+test("the stale arrangement self-cleans on the host's own report, not on a clock", () => {
+  assert.match(FED, /const reporting = new Set\(Object\.keys\(this\.perHostOrder\)\);/);
+  assert.match(FED, /if \(!reporting\.size\) return;/, "no report in hand → prune nothing");
+  assert.match(FED, /const kept = pruneViewOrder\(cur, hostOf, reporting, live\);/);
+  assert.match(FED, /if \(kept\.length !== cur\.length\) writeViewOrder\(kept\);/, "written only when it changed");
+});

--- a/ui/webview/view-order.test.ts
+++ b/ui/webview/view-order.test.ts
@@ -1,0 +1,89 @@
+// The VIEWER's session order (the user 2026-07-31): order became a property of how you are LOOKING at the
+// fleet rather than of the fleet, so it lives in the browser and can interleave hosts — which no kernel can
+// do, since none of them knows another's sids. SYNTHETIC ids only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  applyViewOrder, applyViewOrderTo, pruneViewOrder, parseViewOrder,
+  VIEW_ORDER_KEY, VIEW_ORDER_CAP,
+} from "./view-order";
+
+const hostOf = (id: string) => { const i = id.indexOf(":"); return i > 0 ? id.slice(0, i) : ""; };
+
+// ── applyViewOrder: the layering rule, executed ──────────────────────────────────────────────────────
+test("no arrangement is the IDENTITY — nothing moves until the viewer moves it", () => {
+  const seed = ["a", "b", "TESTHOST:c"];
+  assert.deepEqual(applyViewOrder(seed, []), seed);
+});
+
+test("local and remote sessions INTERLEAVE — the whole point of moving this off the kernel", () => {
+  // seed is the old per-host concatenation: both local sessions, then the host's block
+  const seed = ["a", "b", "TESTHOST:c", "TESTHOST:d"];
+  const view = ["a", "TESTHOST:c", "b", "TESTHOST:d"];
+  assert.deepEqual(applyViewOrder(seed, view), ["a", "TESTHOST:c", "b", "TESTHOST:d"],
+    "a local tab can sit between two of a server's");
+});
+
+test("a session the arrangement has never seen lands at the END, not somewhere arbitrary", () => {
+  const view = ["b", "a"];
+  assert.deepEqual(applyViewOrder(["a", "b", "new1", "new2"], view), ["b", "a", "new1", "new2"]);
+  // …and the newcomers keep their SEED order among themselves (the kernel's arrival order)
+  assert.deepEqual(applyViewOrder(["new2", "new1", "a"], ["a"]), ["a", "new2", "new1"]);
+});
+
+test("an arranged id that is no longer in the seed simply isn't drawn", () => {
+  // its session was cleared, or its host detached — the entry stays in storage (prune decides that), but it
+  // cannot conjure a tab that the merge doesn't carry
+  assert.deepEqual(applyViewOrder(["a"], ["gone", "a", "TESTHOST:x"]), ["a"]);
+});
+
+test("duplicates and non-strings never reach the strip", () => {
+  const seed = ["a", "a", null as any, "b"];
+  assert.deepEqual(applyViewOrder(seed, ["b", "b", 7 as any]), ["b", "a"]);
+});
+
+// ── applyViewOrderTo: the same rule over the timeline's lane OBJECTS ─────────────────────────────────
+test("lanes arrange by the same order the tabs do", () => {
+  const lanes = [{ id: "a" }, { id: "b" }, { id: "TESTHOST:c" }];
+  assert.deepEqual(applyViewOrderTo(lanes, ["TESTHOST:c", "a", "b"], (r) => r.id).map((r) => r.id),
+    ["TESTHOST:c", "a", "b"]);
+});
+
+test("lanes the arrangement doesn't name keep their arrival order, at the end", () => {
+  const lanes = [{ id: "x" }, { id: "a" }, { id: "y" }];
+  assert.deepEqual(applyViewOrderTo(lanes, ["a"], (r) => r.id).map((r) => r.id), ["a", "x", "y"]);
+});
+
+// ── pruneViewOrder: event-based self-clean ───────────────────────────────────────────────────────────
+test("an id its own host has stopped listing is dropped", () => {
+  const view = ["a", "b", "TESTHOST:c"];
+  const kept = pruneViewOrder(view, hostOf, new Set(["", "TESTHOST"]), new Set(["a", "TESTHOST:c"]));
+  assert.deepEqual(kept, ["a", "TESTHOST:c"], "b is gone from the local kernel's list, so it goes");
+});
+
+test("a host that ISN'T reporting keeps every one of its placements", () => {
+  // the tunnel is down / the host is detached. Pruning here would flatten the arrangement of every remote
+  // session and stack them all at the end of the strip the moment the host came back.
+  const view = ["a", "TESTHOST:c", "TESTHOST:d"];
+  const kept = pruneViewOrder(view, hostOf, new Set([""]), new Set(["a"]));
+  assert.deepEqual(kept, view);
+});
+
+test("the cap is a backstop that keeps the MOST RECENT arrangement, not the oldest", () => {
+  const view = Array.from({ length: VIEW_ORDER_CAP + 10 }, (_, i) => `s${i}`);
+  const kept = pruneViewOrder(view, hostOf, new Set<string>(), new Set<string>());
+  assert.equal(kept.length, VIEW_ORDER_CAP);
+  assert.equal(kept[kept.length - 1], `s${VIEW_ORDER_CAP + 9}`);
+});
+
+// ── storage ──────────────────────────────────────────────────────────────────────────────────────────
+test("a corrupt or foreign stored value reads as no arrangement, never throws", () => {
+  for (const raw of [null, undefined, "", "{", "{}", '"nope"', "7", '[1,2]']) {
+    assert.ok(Array.isArray(parseViewOrder(raw as any)), `${String(raw)} parses to a list`);
+  }
+  assert.deepEqual(parseViewOrder('["a",2,"b"]'), ["a", "b"], "non-strings are filtered, the rest survives");
+});
+
+test("the key is namespaced alongside the feed's other browser-owned state", () => {
+  assert.match(VIEW_ORDER_KEY, /^romp:/);
+});

--- a/ui/webview/view-order.ts
+++ b/ui/webview/view-order.ts
@@ -1,0 +1,126 @@
+// THE VIEWER'S OWN session order (the user 2026-07-31), replacing the kernel's as the thing that decides
+// what sits where.
+//
+// Until now each kernel owned the order of its own sessions (session-order.json) and the browser
+// CONCATENATED the per-host lists, local first. That made host blocks: a local session could never sit
+// between two of a server's, and a drag that mixed them was undone on the next merge, because no single
+// kernel can record an order over sids it does not know about.
+//
+// The user's ruling is that order is a property of how you are LOOKING at the fleet, not of the fleet: two
+// machines reading the same sessions should be free to arrange them differently, and dragging a tab on the
+// laptop has no business moving it on the desktop. So the arrangement lives in the browser, keyed by
+// host-prefixed id, and each kernel's list becomes a SEED — the arrival order new sessions come in on.
+//
+// The layering is deliberately one-way and lossless:
+//   seed  = the per-host concatenation, exactly what shipped before this module
+//   view  = the ids this viewer has arranged, in their arranged order
+//   shown = every id the view names, in view order, then everything else in SEED order
+// An empty view is the identity transform, so a viewer who has never dragged sees precisely the old
+// behaviour, and the first drag is what takes ownership.
+//
+// The three surfaces that must agree on this (chat tab strip, timeline lanes, feed grouped mode) read the
+// same key out of the same origin's localStorage, so they cannot drift; federation.ts applies this at all
+// three merge points and re-emits when the key changes under it.
+
+export const VIEW_ORDER_KEY = "romp:vieworder";
+// Backstop only — the prune below is the real bound (it drops ids the owning host has stopped listing).
+// This exists so a bug in that rule can never grow the entry without limit.
+export const VIEW_ORDER_CAP = 2000;
+
+/** Fired on the writing window, since `storage` events reach only OTHER contexts. Panes listen to both. */
+export const VIEW_ORDER_EVENT = "romp-vieworder";
+
+/** Order `seed` by this viewer's arrangement. Ids `view` names come first, in view order; everything else
+ *  keeps its SEED order behind them — so a session that arrives after the last drag lands at the end rather
+ *  than in an arbitrary spot. Ids in `view` that are not in `seed` (a cleared session, a detached host) are
+ *  simply absent from the result; they stay in storage, because a detached host's sessions come back.
+ *
+ *  An EMPTY view returns the seed unchanged: this is the identity transform, not a re-sort, so nothing moves
+ *  until the viewer moves it. Non-strings and duplicates are dropped from both inputs. */
+export function applyViewOrder(seed: readonly string[], view: readonly string[]): string[] {
+  const clean = (xs: readonly string[]) => {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const x of xs) if (typeof x === "string" && !seen.has(x)) { seen.add(x); out.push(x); }
+    return out;
+  };
+  const s = clean(seed);
+  if (!view || !view.length) return s;
+  const want = new Set(s);
+  const placed = new Set<string>();
+  const out: string[] = [];
+  for (const id of clean(view)) if (want.has(id)) { placed.add(id); out.push(id); }
+  for (const id of s) if (!placed.has(id)) out.push(id);
+  return out;
+}
+
+/** Sort `rows` (session-ish objects carrying `idKey`) into the same order applyViewOrder would put their
+ *  ids in. Used for the timeline's lanes, which are objects rather than a bare id list. Rows whose id the
+ *  merge doesn't name keep their relative position at the end. */
+export function applyViewOrderTo<T>(rows: readonly T[], view: readonly string[], idOf: (r: T) => string): T[] {
+  const seed = rows.map(idOf);
+  const rank = new Map(applyViewOrder(seed, view).map((id, i) => [id, i] as const));
+  // index-carrying decorate/sort/undecorate: Array#sort is stable in every engine romp runs on, but being
+  // explicit costs nothing and keeps ties (two rows with the same id) in their arrival order.
+  return rows
+    .map((r, i) => ({ r, i, k: rank.has(idOf(r)) ? rank.get(idOf(r))! : Number.MAX_SAFE_INTEGER }))
+    .sort((a, b) => (a.k - b.k) || (a.i - b.i))
+    .map((x) => x.r);
+}
+
+/** Drop arrangement entries for sessions that are GONE, and only those.
+ *
+ *  Event-based, not aged out: an id is dropped only when the host that OWNS it is currently reporting its
+ *  sessions and that report does not contain it. A host that is detached or unreachable reports nothing, so
+ *  its ids are untouched — otherwise a tunnel blip would silently flatten the arrangement of every remote
+ *  session, and they would all come back at the end of the list.
+ *
+ *  @param hostOf   the host key an id belongs to ("" for local) — federation's own hostOf
+ *  @param reporting hosts whose session list is in hand this merge
+ *  @param live     every id those hosts are currently listing */
+export function pruneViewOrder(
+  view: readonly string[],
+  hostOf: (id: string) => string,
+  reporting: ReadonlySet<string>,
+  live: ReadonlySet<string>,
+): string[] {
+  const kept = view.filter((id) => typeof id === "string" && (!reporting.has(hostOf(id)) || live.has(id)));
+  return kept.length > VIEW_ORDER_CAP ? kept.slice(kept.length - VIEW_ORDER_CAP) : kept;
+}
+
+/** Parse a stored blob. Anything malformed reads as "no arrangement" rather than throwing — a corrupt entry
+ *  must cost you your ordering, never the dashboard. */
+export function parseViewOrder(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const o = JSON.parse(raw);
+    if (!Array.isArray(o)) return [];
+    return o.filter((x): x is string => typeof x === "string");
+  } catch {
+    return [];
+  }
+}
+
+export function readViewOrder(): string[] {
+  try {
+    return parseViewOrder(localStorage.getItem(VIEW_ORDER_KEY));
+  } catch {
+    return [];   // private mode / blocked storage → the seed order, exactly as before this module
+  }
+}
+
+/** Persist an arrangement and tell every pane. `storage` fires only in OTHER same-origin contexts, so the
+ *  writing window gets the same news through a CustomEvent — one notification path, two deliveries. */
+export function writeViewOrder(order: readonly string[]): void {
+  const list = order.filter((x) => typeof x === "string");
+  try {
+    localStorage.setItem(VIEW_ORDER_KEY, JSON.stringify(list));
+  } catch {
+    /* quota / private mode → this drag just doesn't outlive the page; the strip still shows it */
+  }
+  try {
+    window.dispatchEvent(new CustomEvent(VIEW_ORDER_EVENT));
+  } catch {
+    /* no window (node test) */
+  }
+}


### PR DESCRIPTION
Requested: interleave local and remote tabs, with order living in the browser — "this is just a property of how you view it and reordering stuff on one machine shouldn't affect how it's reordered on another."

## Why it couldn't work before

Each kernel owned the order of its own sessions (`session-order.json`) and the browser concatenated the per-host lists, local first. Hosts always drew as blocks, and a drag that mixed them was undone on the next merge. That wasn't a missing feature so much as an impossible one at that layer: **no kernel can record an order over sids belonging to another kernel.**

## The change

New `ui/webview/view-order.ts` holds one pure rule. The per-host concatenation becomes a **seed**; the viewer's own arrangement decides what actually sits where:

- ids the arrangement names come first, in its order
- everything else follows in seed order — so a session arriving after the last drag lands at the end, not somewhere arbitrary
- **an empty arrangement is the identity transform**, so a viewer who has never dragged sees exactly what shipped before, and the first drag is what takes ownership

**Both drags write it, all three surfaces read it.** The chat strip and the timeline lanes write localStorage instead of posting to a kernel. The strip, the lanes and the feed's grouped runs are all arranged at the three federation merge points, so they cannot drift into three different orders. A drag in one pane reaches the others via the `storage` event and its own window via a `CustomEvent` (storage fires only in *other* contexts).

**Self-cleaning is event-based.** An id is dropped only when the host that owns it is currently listing its sessions and doesn't name it. A detached or unreachable host reports nothing and is left alone — otherwise a tunnel blip would flatten every remote session's placement and stack them all at the end of the strip on reconnect.

The kernels keep their lists unchanged, as the arrival order new sessions enter on and as what a fresh browser starts from.

## Tests

`view-order.test.ts` (12) executes the rule, including the interleave case and the detached-host prune exemption. `view-order-wiring.test.ts` (6) pins that all three surfaces go through it and that nothing writes order back to a kernel. `tests/test_browser_owned_order.py` (3) pins the kernel-side inline timeline boot. `timeline-boot.test.ts` updated: a lane drag now posts nothing.

Full suites green: 3776 Python, 1557 node, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)