### PR TITLE
Romp reviewing is romp working: the judging hold stops minting the Stalled chip

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -246,11 +246,15 @@ STALLER_ON = os.environ.get("ROMP_STALLER", "1") != "0"   # the stall note (2026
 STALL_SEEN = 2
 # The nudge gate's "the judge itself could still move this card" reason — same one-definition rule as
 # STALL_SEEN: the kernel mints it (_revivers_pending) and both stall readers (kernel _stalled_goals,
-# stalled_facts below) verify it through stall_why_stands. The LEGACY string is the pre-2026-07-25 GLOBAL
-# form, deferred on ANY judge activity anywhere — but the producer opens a fleet-wide pass every ~3s, so
-# that was cadence, not a reviver: adjacent gate ticks routinely both landed inside (different) routine
-# passes, the string-keyed seen counter read them as one non-retiring wedge, and false "stalled" cards
-# minted fleet-wide. A legacy record names no session, so its claim is unverifiable and never stands.
+# stalled_facts below) screen it out through stall_why_stands. Neither string EVER presents as a stall
+# (the user 2026-07-31): a goal held only because romp's own review is mid-flight is a goal romp is
+# WORKING, and the card already says so — the Analyzing… swirl (spin-caption.ts) covers exactly this
+# beat, its tip naming the nudge hold. The hold itself stays real in the gate (with its backstop); only
+# the yellow chip is retired, so "stalled" keeps meaning "nothing romp does is moving this". The LEGACY
+# string is the pre-2026-07-25 GLOBAL form, deferred on ANY judge activity anywhere — but the producer
+# opens a fleet-wide pass every ~3s, so that was cadence, not a reviver, and false "stalled" cards
+# minted fleet-wide. Screening both strings also ends the frozen-record problem the 2026-07-25
+# live-verify existed for: a record that freezes holding a judging claim now simply says nothing.
 WHY_JUDGING = "romp's own review of this session is mid-flight"
 _WHY_JUDGING_LEGACY = "a judge pass is mid-flight"
 # The CONSOLIDATOR (the user 2026-06-19): the grouper's twin for the COMPLETED column. The working grouper
@@ -7560,19 +7564,16 @@ def stall_llm(goal_text, work_text, holding):
 
 
 def stall_why_stands(why, fsid):
-    """True when a recorded stall reason still holds RIGHT NOW. A deferral record is a cache of the gate's
-    last run, and the gate only re-runs (and pops it) while its session stays idle-and-due — a session that
-    resumes work, or goes awaiting, freezes the record with whatever reason it last held, and by 2026-07-25
-    the live file held records frozen for days presenting a present-tense claim. The judging reason is
-    live-verifiable (active_runs IS the authority for "is a judge call on this session in flight"), so both
-    stall readers verify it here instead of presenting the frozen claim; a legacy global record named no
-    session and can never be verified, so it never stands. Other reasons pass through: their truth lives in
-    stores this predicate can't reach, and their own passes reconcile the records that carry them."""
-    if why == WHY_JUDGING:
-        return bool(fsid) and any(r.get("fsid") == fsid for r in active_runs())
-    if why == _WHY_JUDGING_LEGACY:
-        return False
-    return True
+    """True when a recorded stall reason is one the card should PRESENT. The judging reasons never are
+    (the user 2026-07-31, superseding the 2026-07-25 live-verify): a goal the gate holds because romp's
+    own review is mid-flight is a goal romp is actively working, and calling that "stalled" drew the
+    user's eye to a state nobody needs to act on — the Analyzing… swirl already tells that story, with
+    the nudge hold in its tip (spin-caption.ts). The hold itself is untouched; this predicate only
+    decides what the stall surfaces say. Other reasons pass through: their truth lives in stores this
+    predicate can't reach, and their own passes reconcile the records that carry them. `fsid` is the
+    record's session, kept for the next reason that needs live verification against it (the retired
+    judging branch checked active_runs here)."""
+    return why not in (WHY_JUDGING, _WHY_JUDGING_LEGACY)
 
 
 def stalled_facts(fsid):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2538,7 +2538,9 @@ def _revivers_pending(sid, store, turns, gid):
             # (29 live records, median age 45h, when caught). A call in flight for THIS fsid is the
             # event-true signal that a verdict for this store may be about to land; the small window
             # between that call returning and its save is covered by the fire path's last-moment store
-            # re-read (_nudge_fire_list).
+            # re-read (_nudge_fire_list). This reason defers the nudge but NEVER presents as a stall
+            # (the user 2026-07-31): romp reviewing the session is romp working the card, and the
+            # Analyzing… swirl already says so — see jd.stall_why_stands.
             return jd.WHY_JUDGING
         if nd.get("followupPending"):
             return "your reply to the card is still being judged"
@@ -2602,7 +2604,8 @@ def _nudge_deferred_ok(gid, reason, now, sid=None):
     second observation is the event; nothing here consults a clock (the backstop above is the one
     deliberate exception). `sid` rides the record so the stall readers can live-verify a session-scoped
     reason (jd.stall_why_stands) — the record freezes whenever the gate walk stops running for its
-    session, and a frozen claim must be verifiable or it is not presented."""
+    session, and a frozen claim must be verifiable or it is not presented. (No reason currently
+    verifies against it: the judging hold, which did, never presents at all since 2026-07-31.)"""
     d = _auto_nudge_data()
     dd = dict(d.get("deferred") or {})
     if not reason:
@@ -2639,18 +2642,20 @@ def _stalled_goals():
     is NOT here: that one is visibly in flight, and it escalates to a real block through _mark_nudge_failed,
     which carries its own decision brief.
 
-    LIVE-VERIFIED at read time (2026-07-25): a deferral record only pops when the gate walk re-runs, and the
-    walk stops the moment its session leaves idle-and-due — so a record freezes with whatever reason it last
-    held (records were found frozen for DAYS presenting "mid-flight" in the present tense). A reason whose
-    truth is checkable right now must check out, or the record is skipped (it still pops normally on the
-    next gate walk); reasons whose truth lives in the stores pass through — their own passes reconcile them."""
+    A hold on romp's OWN review (jd.WHY_JUDGING) is screened out entirely (the user 2026-07-31): that is
+    romp working the card, not a stall — the Analyzing… swirl carries it (spin-caption.ts), and a yellow
+    chip there drew the eye to a state nobody needs to act on. Reasons whose truth is checkable right now
+    must check out, or the record is skipped (it still pops normally on the next gate walk — a deferral
+    record only pops when the gate walk re-runs, and the walk stops the moment its session leaves
+    idle-and-due, so a record freezes with whatever reason it last held); reasons whose truth lives in
+    the stores pass through — their own passes reconcile them."""
     out = {}
     for gid, rec in (_auto_nudge_data().get("deferred") or {}).items():
         why, at = _deferral_why(rec), _deferral_at(rec)
         if not (why and at and _deferral_seen(rec) >= _STALL_SEEN):
             continue
         if not jd.stall_why_stands(why, rec.get("sid") if isinstance(rec, dict) else None):
-            continue                                     # frozen judging claim, live-false (or legacy/unverifiable)
+            continue                                     # a judging hold (presents as Analyzing, never a stall)
         if why.startswith("the judge tiers are paused") and not _retry_paused_on():
             continue                                     # tiers resumed while the record was frozen
         out[gid] = {"why": why, "since": at}

--- a/tests/test_kernel_nudge_last_resort.py
+++ b/tests/test_kernel_nudge_last_resort.py
@@ -301,19 +301,18 @@ class StalledGoals(Base):
         self.assertEqual(len(writes), 1,
                          "the run count stops at the threshold — a wedge is not a file write per tick")
 
-    def test_a_judging_stall_shows_only_while_the_call_is_in_flight(self):
-        # LIVE-VERIFIED (2026-07-25): a deferral record only pops when the gate walk re-runs, and the walk
-        # stops the moment its session leaves idle-and-due — so a record freezes with its last reason.
-        # Records frozen for DAYS were found presenting "mid-flight" in the present tense. The judging
-        # claim is checkable against active_runs right now, so a frozen copy must check out to be shown.
-        km._nudge_deferred_ok(GID, jd.WHY_JUDGING, NOW, SID)
+    def test_a_judging_hold_defers_the_nudge_but_never_presents_as_a_stall(self):
+        # The user 2026-07-31 (superseding the 2026-07-25 live-verify): a goal held because romp's own
+        # review is mid-flight is a goal romp is WORKING — the Analyzing… swirl carries that story
+        # (spin-caption.ts, tip naming the hold), and a yellow chip there drew the eye to a state nobody
+        # needs to act on. The GATE half is untouched: the deferral still holds the nudge (backstop and
+        # all); only the presentation is gone, however live the call.
+        self.assertFalse(km._nudge_deferred_ok(GID, jd.WHY_JUDGING, NOW, SID),
+                         "the hold itself is real — the nudge stays deferred")
         km._nudge_deferred_ok(GID, jd.WHY_JUDGING, NOW + 30, SID)
         jd.active_runs = lambda: [{"judge": "closer", "fsid": SID, "sent": 1.0}]
-        self.assertEqual(km._stalled_goals()[GID]["why"], jd.WHY_JUDGING,
-                         "a genuinely wedged per-session judging shows as the stall it is")
-        jd.active_runs = lambda: ()
         self.assertEqual(km._stalled_goals(), {},
-                         "the call retired but the record froze → the claim is live-false, never shown")
+                         "romp reviewing is romp working — never a stall chip, even mid-flight")
 
     def test_a_legacy_global_pass_record_is_never_presented(self):
         # pre-2026-07-25 records carried the global "a judge pass is mid-flight" and named no session —
@@ -334,13 +333,12 @@ class StalledGoals(Base):
 
     def test_the_stands_predicate_is_shared_with_the_judge_reader(self):
         # stalled_facts (judge side, feeds the staller and the distill due-anchor) filters through the SAME
-        # jd.stall_why_stands, so the two stall surfaces can never disagree about a live-false claim.
-        jd.active_runs = lambda: ()
-        self.assertFalse(jd.stall_why_stands(jd.WHY_JUDGING, SID))
+        # jd.stall_why_stands, so the two stall surfaces can never disagree about which reasons present.
         jd.active_runs = lambda: [{"judge": "closer", "fsid": SID, "sent": 1.0}]
-        self.assertTrue(jd.stall_why_stands(jd.WHY_JUDGING, SID))
-        self.assertFalse(jd.stall_why_stands(jd.WHY_JUDGING, None),
-                         "a judging claim with no session is unverifiable and never stands")
+        self.assertFalse(jd.stall_why_stands(jd.WHY_JUDGING, SID),
+                         "a judging hold is romp working, never presented — even with the call live")
+        self.assertFalse(jd.stall_why_stands("a judge pass is mid-flight", None),
+                         "the legacy global form is screened the same way")
         self.assertTrue(jd.stall_why_stands("the agent's to-do sync is due", None),
                         "store-backed reasons pass through — their own passes reconcile them")
 

--- a/tests/test_stall_note.py
+++ b/tests/test_stall_note.py
@@ -55,18 +55,17 @@ class StalledFacts(unittest.TestCase):
         self._write({GID: NOW})
         self.assertEqual(jd.stalled_facts(FSID), {})
 
-    def test_a_judging_claim_is_live_verified(self):
-        # 2026-07-25: a deferral record freezes when the gate walk stops running for its session, so a
-        # judging claim is presented only while active_runs shows a call for this session RIGHT NOW —
-        # a frozen present-tense claim that is live-false must not reach the staller or the due-anchor.
+    def test_a_judging_hold_never_presents(self):
+        # The user 2026-07-31 (superseding the 2026-07-25 live-verify): a goal held because romp's own
+        # review is mid-flight is a goal romp is WORKING — the Analyzing… swirl carries that story, and a
+        # stalled chip there drew the eye to a state nobody needs to act on. So the staller never sees
+        # these, even while active_runs genuinely shows the call in flight.
         self._write({GID: {"at": NOW, "why": jd.WHY_JUDGING, "seen": jd.STALL_SEEN, "sid": FSID}})
         saved = jd.active_runs
         try:
             jd.active_runs = lambda: [{"judge": "closer", "fsid": FSID, "sent": 1.0}]
-            self.assertEqual(jd.stalled_facts(FSID)[GID]["why"], jd.WHY_JUDGING)
-            jd.active_runs = lambda: ()
             self.assertEqual(jd.stalled_facts(FSID), {},
-                             "the call retired but the record froze → never presented")
+                             "romp reviewing is romp working — never a stall, however live the call")
         finally:
             jd.active_runs = saved
 

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -78,6 +78,16 @@ test("the SETTLE GAP (turn done, verdict pending) spins on a working card", () =
     "judging only speaks for a card sitting in Working");
 });
 
+test("the SETTLE GAP tip carries the nudge hold the retired judging-stall chip used to tell", () => {
+  // The user 2026-07-31: a goal held only because romp's own review is mid-flight is romp WORKING the
+  // card, so the yellow Stalled chip no longer minted for it (jd.stall_why_stands screens WHY_JUDGING).
+  // The story moved here, one hover deep — the tip must keep saying the hold exists and is not a stall,
+  // or dropping the chip becomes dropping the information.
+  const tip = spinFor({ judging: true, column: "working" }, false, false).tip;
+  assert.match(tip, /[Nn]udges hold off/, "the hold is named");
+  assert.match(tip, /not stuck/, "…and read as romp working, not a wedge");
+});
+
 test("DISTILLING names which line is being written", () => {
   assert.equal(spinFor({}, true, true).tip, "Writing the key takeaway…");
   assert.equal(spinFor({}, true, false).tip, "Writing the decision brief…");

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -108,10 +108,14 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
     // SETTLE GAP (the user 2026-07-13) — the session FINISHED its turn but the closer's verdict hasn't
     // landed, so the card would sit inertly in Working ("the session is done, why is its card still
     // working?"). The swirl says what's actually happening; it hands off to the column move (and then
-    // Distilling…) when the verdict files the work.
+    // Distilling…) when the verdict files the work. The tip also carries the story the retired
+    // judging-stall chip used to tell (the user 2026-07-31): auto-nudges hold off while the review
+    // runs, and that hold is romp working the card, not a stall — so it lives here, one hover deep,
+    // instead of as a yellow chip pulling the eye to a state nobody needs to act on.
     return {
       caption: "Analyzing…",
-      tip: "This stretch of work finished; the judge is deciding whether it completed or blocked this goal.",
+      tip: "This stretch of work finished; the judge is deciding whether it completed or blocked this goal. "
+         + "Nudges hold off while the review runs — romp is working this card, not stuck on it.",
       awaitingBg: false,
     };
   }


### PR DESCRIPTION
A goal the nudge gate holds because romp's own review of its session is mid-flight wore the yellow **Stalled** chip — drawing the eye to a state nobody needs to act on, on exactly the cards already wearing the Analyzing… swirl. "Stalled" should keep meaning *nothing romp does is moving this*, and a hold on romp's own verdict is the opposite of that.

- `jd.stall_why_stands` — the one predicate both stall readers (kernel `_stalled_goals`, judge `stalled_facts`) share — now screens `WHY_JUDGING` and its legacy global form outright, superseding the 2026-07-25 live-verify: a reason that never presents can never present stale either.
- The gate half is untouched: the deferral still holds the nudge (backstop and all), and the staller stops writing notes for these holds.
- The story moves one hover deep instead of a chip: the Analyzing… settle-gap tip now names the nudge hold, so dropping the chip is not dropping the information.

Tests: the two pinned expectations flipped (`test_stall_note.py`, `test_kernel_nudge_last_resort.py`), plus a new spin-caption test pinning the enriched tip. Full local run: 3,775 Python tests OK, 1,558 TS tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)