### PR TITLE
Reserve the card bell's slot so hovering never re-wraps the card

### DIFF
--- a/ui/webview/card-notify.test.ts
+++ b/ui/webview/card-notify.test.ts
@@ -11,21 +11,28 @@ import * as path from "node:path";
 const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
 
-test("the bell rides row1's metadata cluster inline, after the time — an off bell costs ZERO space (round 4)", () => {
+test("the bell rides row1's metadata cluster inline, after the time (never the corner, never a float)", () => {
   // round 2's absolute corner overlapped grouped-mode Clear; round 3's float fixed the overlap but
-  // reserved a first-line notch even while invisible, wrapping titles early (the user wants compact).
-  // Inline after the timestamp + display:none until hovered/armed = no reserved space at all, and the
-  // materialization lands in the last line's slack, in-flow, so it still can't overlap the floats.
+  // reserved a first-line notch on every card, wrapping titles early. Inline after the timestamp puts it
+  // in the last line's tail, in-flow, so it can neither overlap the floats nor shove the title.
   assert.match(SRC, /const bellBtn = el\("button", "fask-bellbtn"\);/);
   assert.match(SRC, /row1\.append\(bellBtn\);/);
-  assert.match(CSS, /\.fask-bellbtn \{\s*\n\s*display: none;/);
   assert.doesNotMatch(CSS, /\.fask-bellbtn \{\s*\n\s*float: right;/, "the title-notch float is gone");
   assert.doesNotMatch(CSS, /\.fask-bellbtn \{\s*\n\s*position: absolute/, "the overlapping absolute corner is gone");
 });
 
+test("hovering a card moves NOTHING: the bell's slot is reserved in both states (the user 2026-07-31)", () => {
+  // round 4 hid it with display:none, so hovering materialized 22px into the last line, re-wrapped the
+  // title and pushed everything below the card down — layout moving because the mouse moved. visibility
+  // keeps the box and its margin in flow at rest, so revealing it changes pixels and not one line box.
+  assert.match(CSS, /\.fask-bellbtn \{\s*\n\s*display: inline-flex; visibility: hidden;/);
+  assert.doesNotMatch(CSS, /\.fask-bellbtn \{\s*\n\s*display: none;/, "display:none un-reserves the slot");
+  assert.doesNotMatch(CSS, /\.fitem\.ask:hover \.fask-bellbtn \{ display:/, "hover may change visibility, never the box");
+});
+
 test("off = shown only on card hover (dim, slashed); armed (.on) = accent, always visible (mechanics, not status)", () => {
-  assert.match(CSS, /\.fitem\.ask:hover \.fask-bellbtn \{ display: inline-flex; \}/);
-  assert.match(CSS, /\.fask-bellbtn\.on \{ display: inline-flex; opacity: 0\.85; color: var\(--accent\); \}/);
+  assert.match(CSS, /\.fitem\.ask:hover \.fask-bellbtn \{ visibility: visible; \}/);
+  assert.match(CSS, /\.fask-bellbtn\.on \{ visibility: visible; opacity: 0\.85; color: var\(--accent\); \}/);
 });
 
 test("the bell click toggles without opening the modal, off the FRESHEST payload copy", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1078,17 +1078,22 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .ctx-item-body { display: flex; flex-direction: column; line-height: 1.25; }
 .ctx-item-sub { font-size: 0.82em; opacity: 0.6; }
 /* the bell BUTTON (the user 2026-07-28, round 4): inline in row1's metadata cluster, right after the
-   timestamp, and display:none until the card is hovered or it's armed — an off bell costs ZERO space
-   (round 3's float reserved a first-line notch even while invisible, wrapping titles early; the user
-   wants compact). Materializing on hover lands in the slack after "Nm ago", so nothing shifts. Off =
-   slashed dim bell; armed (.on) = accent bell, always visible. Accent = mechanics chrome, never a
-   status colour. */
+   timestamp — shown only once the card is hovered or it's armed. Off = slashed dim bell; armed (.on) =
+   accent bell, always visible. Accent = mechanics chrome, never a status colour.
+   Round 5 (the user 2026-07-31): it hides with VISIBILITY, not display, so its slot is reserved whether
+   or not the pointer is over the card. display:none made the bell cost zero space, but then hovering
+   materialized 22px into the tail of the last line and re-wrapped the title, shoving everything below
+   the card down — layout moving because the mouse moved. Reserving the slot costs at worst one wrapped
+   word, paid identically in both states, and it is nothing like round 3's float (which notched every
+   card's FIRST line): the reservation sits at the metadata cluster's tail, after "Nm ago". There is no
+   whitespace text node between the title, the time and the bell, so the three have no break opportunity
+   between them and the reserved bell can never wrap onto a line of its own. */
 .fask-bellbtn {
-  display: none; vertical-align: -4px; margin: 0 0 0 5px;
+  display: inline-flex; visibility: hidden; vertical-align: -4px; margin: 0 0 0 5px;
   align-items: center; justify-content: center;
   width: 17px; height: 17px; padding: 0; border: 0; border-radius: 4px;
   background: transparent; color: var(--dim); cursor: pointer; opacity: 0.55;
 }
-.fitem.ask:hover .fask-bellbtn { display: inline-flex; }
+.fitem.ask:hover .fask-bellbtn { visibility: visible; }
 .fitem.ask .fask-bellbtn:hover { opacity: 1; background: rgba(255, 255, 255, 0.10); }
-.fask-bellbtn.on { display: inline-flex; opacity: 0.85; color: var(--accent); }
+.fask-bellbtn.on { visibility: visible; opacity: 0.85; color: var(--accent); }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -767,13 +767,13 @@ function makeAskCard(it: AskItem): HTMLElement {
   // (the user 2026-06-20). origin sits left of the chips, matching the "from … · Followed up" reading order.
   // Clear is the rightmost, always-present control on this row (idwrap flex:1 pushes it to the edge).
   row2.append(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr);
-  // the bell BUTTON (the user 2026-07-28, round 4): INLINE in row1's metadata cluster, right after
-  // the timestamp — and display:none until the card is hovered or it's armed, so an off bell costs
-  // ZERO space (round 3's float reserved a ~26px notch on the title's first line even while
-  // invisible, wrapping titles a word early and growing cards — the user wants compact). When it
-  // does show, it materializes into the slack after "Nm ago" (the last line's tail), the one spot
-  // that never shoves the title. In-flow, so it still cannot overlap the floated Clear. Session-level
-  // arming shows on the lane/tab instead, so an armed SESSION doesn't stamp every card.
+  // the bell BUTTON (the user 2026-07-28): INLINE in row1's metadata cluster, right after the
+  // timestamp (the last line's tail), the one spot that never shoves the title — and in-flow, so it
+  // cannot overlap the floated Clear. It hides with VISIBILITY, so its slot is reserved whether or
+  // not the pointer is over the card (the user 2026-07-31): round 4's display:none made an off bell
+  // cost zero space, but then hovering materialized it into that line and re-wrapped the title,
+  // moving everything below it — layout must not shift because the mouse moved. Session-level arming
+  // shows on the lane/tab instead, so an armed SESSION doesn't stamp every card.
   const bellBtn = el("button", "fask-bellbtn");
   bellBtn.onclick = (ev: Event) => {
     ev.stopPropagation();                            // never open the modal under the toggle


### PR DESCRIPTION
Hovering a goal card made the notification bell appear, and on cards whose title line was near full that 22px materialized mid-line, re-wrapped the title and pushed everything below the card down. Layout moved because the mouse moved.

The bell now hides with `visibility: hidden` instead of `display: none`, so its box and margin stay in flow at rest and revealing it changes pixels only. The reservation is inline at the metadata cluster's tail (after the timestamp), not the old `float: right` that notched every card's first line; with no whitespace text node between title, time and bell there is no break opportunity for the reserved bell to wrap onto a line of its own.

`ui/webview/card-notify.test.ts` gains a test pinning the reserved slot in both states (and rejecting a hover rule that changes the box). Full node suite: 1558 pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)