### PR TITLE
Render a remote session's mentioned images through a /remote/<host>/file relay

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18301,6 +18301,9 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(403, b"", "text/plain")
             if u.path == "/file":
                 return self._file_preview(q, head=True)
+            if u.path.startswith("/remote/") and u.path.endswith("/file"):
+                # a remote PDF chip's existence probe — same relay as the GET route
+                return self._remote_file(unquote(u.path[len("/remote/"):-len("/file")]), u.query, head=True)
             return self._send(404, b"", "text/plain")
         except (BrokenPipeError, ConnectionResetError):
             pass
@@ -18351,6 +18354,10 @@ class Handler(BaseHTTPRequestHandler):
             if p.startswith("/remote/") and p.endswith("/ws"):
                 # federated dashboard, viewed off this machine: relay to the attached host's kernel
                 return self._remote_ws(unquote(p[len("/remote/"):-len("/ws")]), u.query)
+            if p.startswith("/remote/") and p.endswith("/file"):
+                # preview bytes for a REMOTE session's mentioned path: relay /file to the kernel
+                # that can actually read the disk the path names (see _remote_file)
+                return self._remote_file(unquote(p[len("/remote/"):-len("/file")]), u.query)
             if p == "/analytics":                             # token-usage analytics (the settings modal's chart)
                 try:
                     w = int((q.get("window") or ["86400"])[0])
@@ -19473,6 +19480,55 @@ class Handler(BaseHTTPRequestHandler):
                 up.close()                       # ours alone — safe to close fully
             except OSError:
                 pass
+
+    def _remote_file(self, host, query, head=False):
+        """GET/HEAD /remote/<host>/file — relay ONE preview request to an attached host's kernel
+        through this kernel's own ssh -L tunnel. A remote session's chat mentions paths on the
+        REMOTE machine's disk, but a preview <img> can only dial the origin that served the page —
+        so its /file hit THIS kernel, read the local disk, 404'd, and every mentioned plot or
+        screenshot on a federated session silently hid itself (the user 2026-07-31). Same shape as
+        the /remote/…/ws splice above: the local auth gate has already run, the remote's own token
+        is rewritten into the forwarded query (so the browser only ever needs its local credential,
+        and the per-host trust boundary is unchanged — THAT kernel still runs its own allowlist,
+        size cap and path resolution), and this kernel reads nothing but the reply it mirrors.
+        Deliberately /file only — a preview relay, not a general proxy."""
+        with _remotes_lock:
+            r = _remotes.get(host)
+            port, rtok = (r or {}).get("local_port") or 0, (r or {}).get("token") or ""
+        if not port:
+            return self._send(404, b"" if head else ("no attached host %r" % host), "text/plain")
+        q = parse_qs(query or "")
+        if rtok:
+            q["token"] = [rtok]      # the remote's own credential; whatever the browser sent means nothing there
+        conn = http.client.HTTPConnection("127.0.0.1", int(port), timeout=15)
+        try:
+            conn.request("HEAD" if head else "GET", "/file?" + urlencode(q, doseq=True))
+            resp = conn.getresponse()
+            body = b"" if head else resp.read(_PREVIEW_MAX_BYTES + 1)
+            status, ctype = resp.status, resp.getheader("Content-Type") or "application/octet-stream"
+            clen = resp.getheader("Content-Length")
+        except (OSError, http.client.HTTPException):
+            return self._send(502, b"" if head else ("tunnel to %s is not answering" % host), "text/plain")
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+        if len(body) > _PREVIEW_MAX_BYTES:       # backstop only — the remote's own cap 413s long before this
+            return self._send(413, b"" if head else "too large to preview", "text/plain")
+        if head:
+            # mirror _file_preview's HEAD: the remote's verdict + real length, no body
+            self.send_response(status)
+            self.send_header("Content-Type", ctype)
+            if clen is not None:
+                self.send_header("Content-Length", clen)
+            self.send_header("Cache-Control", "no-cache")
+            if getattr(self, "_cors_origin", None):
+                self.send_header("Access-Control-Allow-Origin", self._cors_origin)
+                self.send_header("Vary", "Origin")
+            self.end_headers()
+            return
+        return self._send(status, body, ctype, cache="no-cache")
 
     def _push_one(self, client):
         _push([client], connect=True)             # full state to a fresh client (its per-client dedup is empty);

--- a/tests/test_kernel_remote_file_relay.py
+++ b/tests/test_kernel_remote_file_relay.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""The /remote/<host>/file relay — previews for a FEDERATED session's mentioned paths.
+
+A remote session's chat mentions paths on the REMOTE machine's disk, but a preview <img> can only
+dial the origin that served the page — its /file hit the local kernel, read the local disk, 404'd,
+and every mentioned plot/screenshot on a federated session silently hid itself (2026-07-31). The
+kernel now relays: GET/HEAD /remote/<host>/file forwards the one request to the attached host's
+kernel through the same ssh -L tunnel the /remote/<host>/ws splice uses, after the normal local
+auth gate, rewriting the remote kernel's own token into the forwarded query so the per-host trust
+boundary is unchanged (THAT kernel still runs its allowlist, size cap and path resolution).
+
+These tests run the real Handler against a fake "remote kernel" (an HTTP server that answers
+/file and records what it was asked). Synthetic only: host name `gpu1`, invented tokens, no
+session state touched.
+"""
+import os
+import socket
+import threading
+import unittest
+import urllib.request
+import urllib.error
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Mirror tests/test_kernel_ws_auth.py's load order. The token env keeps _load_token() away from
+# the real state dir; NO_OPEN keeps the import from launching a browser.
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+REMOTE_TOKEN = "remote-token-DO-NOT-USE"
+PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-png-bytes"
+
+
+class _FakeRemoteFileHandler(BaseHTTPRequestHandler):
+    """The attached host's kernel behind the ssh -L port, /file route only: serves PNG_BYTES for
+    path=/tmp/plot.png (recording the request line), 404s anything else."""
+    requests = []               # class-level: the recorded request lines
+
+    def _serve(self, head):
+        _FakeRemoteFileHandler.requests.append(self.path)
+        if "plot.png" not in self.path:
+            self.send_response(404)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "image/png")
+        self.send_header("Content-Length", str(len(PNG_BYTES)))
+        self.end_headers()
+        if not head:
+            self.wfile.write(PNG_BYTES)
+
+    def do_GET(self):
+        self._serve(head=False)
+
+    def do_HEAD(self):
+        self._serve(head=True)
+
+    def log_message(self, *a):  # keep the test output clean
+        pass
+
+
+class RemoteFileRelay(unittest.TestCase):
+    def setUp(self):
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        self.port = self.srv.server_address[1]
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        self.fake = ThreadingHTTPServer(("127.0.0.1", 0), _FakeRemoteFileHandler)
+        threading.Thread(target=self.fake.serve_forever, daemon=True).start()
+        _FakeRemoteFileHandler.requests = []
+        self._saved_remotes = dict(km._remotes)
+
+    def tearDown(self):
+        with km._remotes_lock:
+            km._remotes.clear()
+            km._remotes.update(self._saved_remotes)
+        for s in (self.srv, self.fake):
+            s.shutdown()
+            s.server_close()
+
+    def _register(self, host, local_port, token=REMOTE_TOKEN):
+        with km._remotes_lock:
+            km._remotes[host] = {"host": host, "kernel_port": 29855, "local_port": local_port,
+                                 "token": token, "status": "up"}
+
+    def _get(self, path, token=True, method="GET"):
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path), method=method)
+        if token:
+            req.add_header("X-Romp-Token", km.TOKEN)
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, r.read(), dict(r.headers)
+        except urllib.error.HTTPError as e:
+            return e.code, e.read(), dict(e.headers)
+
+    def test_relays_the_bytes_and_rewrites_the_token(self):
+        self._register("gpu1", self.fake.server_address[1])
+        status, body, headers = self._get(
+            "/remote/gpu1/file?path=%2Ftmp%2Fplot.png&sid=11111111-2222-3333-4444-555555555555"
+            "&token=whatever-the-browser-sent")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, PNG_BYTES, "the remote's bytes must pass through unmodified")
+        self.assertEqual(headers.get("Content-Type"), "image/png")
+        # the forwarded request: path /file, the REMOTE's token (not what the browser sent, and
+        # never the local serve token), the sid + path intact
+        (req,) = _FakeRemoteFileHandler.requests
+        self.assertTrue(req.startswith("/file?"), req)
+        self.assertIn("token=" + REMOTE_TOKEN, req)
+        self.assertNotIn("whatever-the-browser-sent", req)
+        self.assertNotIn(km.TOKEN, req)
+        self.assertIn("path=%2Ftmp%2Fplot.png", req)
+        self.assertIn("sid=11111111-2222-3333-4444-555555555555", req)
+
+    def test_head_relays_the_verdict_without_a_body(self):
+        # the PDF chip's existence probe: headers only, the remote's real length
+        self._register("gpu1", self.fake.server_address[1])
+        status, body, headers = self._get("/remote/gpu1/file?path=%2Ftmp%2Fplot.png", method="HEAD")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b"")
+        self.assertEqual(headers.get("Content-Length"), str(len(PNG_BYTES)))
+        (req,) = _FakeRemoteFileHandler.requests
+        self.assertTrue(req.startswith("/file?"), req)
+
+    def test_remote_404_passes_through(self):
+        # a deleted/hallucinated path: the REMOTE's 404 reaches the <img> so it hides itself
+        self._register("gpu1", self.fake.server_address[1])
+        status, _, _ = self._get("/remote/gpu1/file?path=%2Ftmp%2Fgone.png")
+        self.assertEqual(status, 404)
+
+    def test_unknown_host_404s(self):
+        status, _, _ = self._get("/remote/nosuch/file?path=%2Ftmp%2Fplot.png")
+        self.assertEqual(status, 404)
+        self.assertEqual(_FakeRemoteFileHandler.requests, [])
+
+    def test_unauthorized_403s_before_any_dial(self):
+        self._register("gpu1", self.fake.server_address[1])
+        status, _, _ = self._get("/remote/gpu1/file?path=%2Ftmp%2Fplot.png", token=False)
+        self.assertEqual(status, 403, "the local auth gate must run before the relay")
+        self.assertEqual(_FakeRemoteFileHandler.requests, [],
+                         "an unauthorized request must never touch the tunnel")
+
+    def test_dead_tunnel_502s(self):
+        # a registered host whose forwarded port has no listener (the ssh died mid-flight)
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.bind(("127.0.0.1", 0))
+        dead_port = probe.getsockname()[1]
+        probe.close()
+        self._register("gpu1", dead_port)
+        status, _, _ = self._get("/remote/gpu1/file?path=%2Ftmp%2Fplot.png")
+        self.assertEqual(status, 502)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/feed-artifacts.test.ts
+++ b/ui/webview/feed-artifacts.test.ts
@@ -22,8 +22,11 @@ test("preview.ts: kind classification, kernel /file URL, and self-removing thumb
   assert.match(KERNEL, /_PREVIEW_MIME = dict\(_IMG_MIME, \*\*\{"\.pdf": "application\/pdf"\}\)/,
                "kernel allowlist = image mimes + pdf; the client mirrors it");
   assert.match(PREVIEW, /if \(ext === "pdf"\) return "pdf";/);
-  // bytes come from the kernel's /file endpoint, path percent-encoded, sid for cwd-relative resolution
-  assert.match(PREVIEW, /"\/file\?path=" \+ encodeURIComponent\(path\) \+ \(sid \? "&sid=" \+ encodeURIComponent\(sid\) : ""\)/);
+  // bytes come from the kernel's /file endpoint, path percent-encoded, sid for cwd-relative
+  // resolution — routed through the /remote/<host>/file relay when the sid wears a host prefix
+  // (a federated session's file lives on the remote disk; behavior pinned in preview-remote.test.ts)
+  assert.match(PREVIEW, /base \+ "\?path=" \+ encodeURIComponent\(path\) \+ \(bare \? "&sid=" \+ encodeURIComponent\(bare\) : ""\)/);
+  assert.match(PREVIEW, /"\/remote\/" \+ encodeURIComponent\(host\) \+ "\/file"/);
   // web dashboard only: the VS Code webview can't reach the kernel origin from an <img>
   assert.match(PREVIEW, /location\.protocol === "http:" \|\| location\.protocol === "https:"/);
   // a thumb the kernel can't serve REMOVES ITSELF (no dead chips): img onerror, pdf HEAD probe

--- a/ui/webview/preview-remote.test.ts
+++ b/ui/webview/preview-remote.test.ts
@@ -1,0 +1,33 @@
+// A FEDERATED session's preview bytes must come from the kernel that can read the disk the path
+// names (the user 2026-07-31: mentioned plots on a remote session's chat never rendered — the
+// <img> hit the LOCAL kernel's /file, which read the local disk and 404'd, and the thumb removed
+// itself). fileUrl routes a host-prefixed sid through the local kernel's /remote/<host>/file relay
+// (the HTTP twin of the /remote/<host>/ws splice) with the bare sid the remote kernel actually
+// knows; a bare (local) sid keeps the plain /file path byte-for-byte, so the single-kernel case is
+// untouched. Same-origin either way — viewed from the phone over `tailscale serve`, both routes
+// still resolve against the kernel that served the page.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { fileUrl } from "./preview";
+
+const UUID = "11111111-2222-3333-4444-555555555555";
+
+test("a bare (local) sid keeps the plain /file route — the single-kernel path is untouched", () => {
+  assert.equal(fileUrl("/tmp/plot.png", UUID),
+               "/file?path=%2Ftmp%2Fplot.png&sid=" + UUID);
+});
+
+test("no sid at all: /file with just the path", () => {
+  assert.equal(fileUrl("/tmp/plot.png"), "/file?path=%2Ftmp%2Fplot.png");
+  assert.equal(fileUrl("/tmp/plot.png", null), "/file?path=%2Ftmp%2Fplot.png");
+});
+
+test("a host-prefixed sid routes through /remote/<host>/file with the bare sid", () => {
+  assert.equal(fileUrl("/tmp/plot.png", "gpu1:" + UUID),
+               "/remote/gpu1/file?path=%2Ftmp%2Fplot.png&sid=" + UUID);
+});
+
+test("a relative path rides through too — the REMOTE kernel resolves it against its session's cwd", () => {
+  assert.equal(fileUrl("plots/out.png", "gpu1:" + UUID),
+               "/remote/gpu1/file?path=plots%2Fout.png&sid=" + UUID);
+});

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -6,6 +6,8 @@
 // (event-based; no stale placeholders). Web dashboard only: the VS Code webview sandbox can't reach the
 // kernel origin from an <img>, so callers gate on canPreview() and keep the plain click-to-open link.
 
+import { hostOf, bareId } from "./federation";
+
 // Extensions the kernel's _PREVIEW_MIME serves — keep the two lists in step (tests pin both).
 const IMG_EXT = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"]);
 
@@ -26,9 +28,17 @@ export function canPreview(): boolean {
 }
 
 // The kernel serves the bytes; sid lets it resolve a relative path against THAT session's cwd
-// (same resolution as click-to-open — kernel _resolve_open_path).
+// (same resolution as click-to-open — kernel _resolve_open_path). A FEDERATED session's file lives
+// on the REMOTE machine's disk, so a host-prefixed sid (`gpu1:‹uuid›` — see federation.ts) routes
+// through this kernel's /remote/<host>/file relay, the HTTP twin of the /remote/<host>/ws splice,
+// with the bare sid the remote kernel actually knows (the user 2026-07-31: mentioned plots on a
+// remote session's chat never rendered — /file read the LOCAL disk and 404'd). Still a same-origin
+// URL, so it works wherever the dashboard is viewed from (the phone over `tailscale serve` included).
 export function fileUrl(path: string, sid?: string | null): string {
-  return "/file?path=" + encodeURIComponent(path) + (sid ? "&sid=" + encodeURIComponent(sid) : "");
+  const host = sid ? hostOf(sid) : "";
+  const base = host ? "/remote/" + encodeURIComponent(host) + "/file" : "/file";
+  const bare = sid ? bareId(sid) : "";
+  return base + "?path=" + encodeURIComponent(path) + (bare ? "&sid=" + encodeURIComponent(bare) : "");
 }
 
 // Full-view lightbox: dark backdrop, the image at natural-but-capped size or the PDF in the browser's


### PR DESCRIPTION
On a federated session's chat, mentioned PNG paths never rendered: the preview `<img>` can only dial the origin that served the page, so `/file` hit the **local** kernel, read the local disk, 404'd, and the thumb removed itself. Same for feed artifact strips and the lightbox.

- **Kernel**: `GET/HEAD /remote/<host>/file` relays the one request to the attached host's kernel through the same ssh `-L` tunnel the `/remote/<host>/ws` splice uses — local auth gate first, the remote's own token rewritten into the forwarded query (per-host trust boundary unchanged: that kernel still runs its allowlist, size cap and path resolution). Deliberately `/file` only, never a general proxy.
- **Client**: `fileUrl` routes a host-prefixed sid through the relay with the bare sid; a bare (local) sid keeps the plain `/file` route byte-for-byte, so the single-kernel path is untouched.

Both routes are same-origin, so previews render wherever the dashboard is viewed from: the kernel's own machine, or a phone reading it over `tailscale serve` (the relay pattern that fixed the vanishing remote hosts on 2026-07-30).

Tests: `tests/test_kernel_remote_file_relay.py` drives the real Handler against a fake remote kernel (byte pass-through, token rewrite, HEAD probe, remote-404 pass-through, unknown-host 404, auth-before-dial, dead-tunnel 502); `ui/webview/preview-remote.test.ts` pins `fileUrl`'s routing. Python 3782 passed; node 1563 passed; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)