### PR TITLE
Clear the rejudging latch on the blocked descendant's watermark, not the top's

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12671,6 +12671,33 @@ def build_feed(now, tmux=None):
             _qmemo[nid] = res
             return res
 
+        # The rejudging latch's CLEAR bound (the user 2026-07-31): the block a top card surfaces may
+        # live on a DESCENDANT (blocked rolls up, _closure_blocked above), and the unblocker stamps
+        # blockCheckT on the node it EXAMINES — the blocked child — never on the top. The latch used
+        # to read the top's own watermark, which for a child-held block stays None forever: every
+        # plain reply dropped the card to Working (plain_user_t > 0 is always true) and every landing
+        # turn advanced disp_t past the reply and lifted it back to Needs-You — the same strobe the
+        # watermark bound fixed for top-level blocks (PR #144), reintroduced one level down. The
+        # audited card flipped seconds-apart pairs at every conversational turn for half an hour.
+        # The bound is therefore the OLDEST watermark among the subtree's OPEN blocked nodes (the
+        # exact closure _closure_blocked walks, same done/cleared gates): the card returns to
+        # Needs-You only once EVERY block it is surfacing has been re-examined with evidence
+        # covering the reply. None when the walk finds no open block (a stale rollup) — the caller
+        # falls back to the top's own watermark, the pre-existing semantics.
+        _bcmemo = {}
+        def _block_check_floor(nid):
+            if nid in _bcmemo:
+                return _bcmemo[nid]
+            nd = nodes.get(nid)
+            if not nd or nd.get("cleared") or (_closure_done(nid) and nid not in agent_open):
+                _bcmemo[nid] = None
+                return None
+            vals = [int(nd.get("blockCheckT") or 0)] if nd.get("blocked") else []
+            vals += [v for v in (_block_check_floor(c) for c in children.get(nid, [])) if v is not None]
+            res = min(vals) if vals else None
+            _bcmemo[nid] = res
+            return res
+
         def flatten(nid, out, ancestor_done=False):  # AskTreeNode flat list, root first; nest via children ids
             nd = nodes[nid]
             kids = sorted(children.get(nid, []), key=_fsubmax, reverse=True)   # most-recent-first (matches the ledger)
@@ -12925,10 +12952,14 @@ def build_feed(now, tmux=None):
             # (which reads the still-blocked store). The latch arms only off the PARSE's plain-reply turn
             # (a real transcript atom, never the echo), and the watermark clear is judge-driven, so the
             # stranded-echo failure stays impossible.
+            # The watermark that bounds the latch is the one covering THE BLOCK THE CARD SURFACES —
+            # a descendant's, when the block rolled up (_block_check_floor above; the user 2026-07-31).
+            _bct = _block_check_floor(nid)
             rejudging = bool(col == "blocked" and nid != api_top and nid != perm_top
                              and not nodes[nid].get("followupPending")
                              and plain_user_t > disp_t
-                             and plain_user_t > (nodes[nid].get("blockCheckT") or 0))
+                             and plain_user_t > (_bct if _bct is not None
+                                                 else (nodes[nid].get("blockCheckT") or 0)))
             # awaiting is a flavor of WORKING → the working column (never needs-input), card time = mint t; the awaiting badge carries the why.
             # A RE-CHECK'd soft-block (targeted follow-up) drops to WORKING (the user 2026-06-27): once you've
             # replied to THAT card it's the agent's move, not yours, so it leaves the needs-input column entirely

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4467,6 +4467,52 @@ class ViewBuilder(unittest.TestCase):
         finally:
             km._last_plain_user_turn_t = saved
 
+    def _child_blocked_store(self, **child_extra):
+        # a top umbrella whose BLOCK lives on a DESCENDANT: blocked rolls up (the card reads blocked)
+        # but the unblocker examines — and stamps blockCheckT on — the child, never the top.
+        top, sub = "%s:gT" % SID, "%s:gS" % SID
+        tn = {"id": top, "text": "umbrella", "parentId": None, "nodeComplete": False,
+              "blocked": False, "cleared": False, "trail": [], "t": NOW - 200, "mt": NOW - 200}
+        sn = {"id": sub, "text": "the actual ask", "parentId": top, "nodeComplete": False,
+              "blocked": True, "blockWhy": "need your call", "cleared": False,
+              "trail": [], "t": NOW - 100, "mt": NOW - 100}
+        sn.update(child_extra)
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 2, "lastNode": sub,
+            "nodes": {top: tn, sub: sn}, "placements": {}, "status": {top: "blocked"}}))
+        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+                                           "effort": "", "context": None, "compactPct": None, "color": None}}
+        return top
+
+    def test_feed_rejudging_watermark_covers_a_descendant_block(self):
+        # REGRESSION (the user 2026-07-31): the latch's clear bound read the TOP node's blockCheckT,
+        # but when the block lives on a child (blocked rolls up), the unblocker stamps the CHILD's
+        # watermark — the top's stays None forever, so the latch armed on every plain reply and no
+        # judge look could ever release it: the card strobed Working↔Needs-You at every turn of an
+        # active conversation (the audited card flipped in seconds-apart pairs for half an hour).
+        # The bound is now the OLDEST watermark among the subtree's OPEN blocked nodes.
+        top = self._child_blocked_store()
+        saved_p, saved_w = km._last_plain_user_turn_t, km._session_working
+        try:
+            km._last_plain_user_turn_t = lambda turns: NOW - 10     # a plain reply AFTER the child's block
+            km._session_working = lambda turns: False
+            card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == top)
+            self.assertTrue(card["rejudging"], "reply not yet examined → the latch arms off the CHILD's block")
+            self.assertEqual(card["column"], "working")
+            # the unblocker examines THE CHILD with evidence covering the reply → released, exactly once
+            top = self._child_blocked_store(blockCheckT=NOW - 5)
+            card_ruled = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == top)
+            self.assertFalse(card_ruled["rejudging"],
+                             "the CHILD's watermark passed the reply → released (the top's own None must not pin the latch)")
+            self.assertEqual(card_ruled["column"], "needs_input")
+            # an examine that PRE-dates the reply keeps the latch armed — the judge hasn't seen the reply
+            top = self._child_blocked_store(blockCheckT=NOW - 20)
+            card_stale = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == top)
+            self.assertTrue(card_stale["rejudging"], "examined before the reply → still the judge's move")
+            self.assertEqual(card_stale["column"], "working")
+        finally:
+            km._last_plain_user_turn_t, km._session_working = saved_p, saved_w
+
     def _store_with_status(self, st):
         # one top goal in a given rolled-up status — used to simulate the judge rewriting the store mid-pass
         g = "%s:gP" % SID


### PR DESCRIPTION
A goal card was strobing Working↔Needs-You in seconds-apart pairs through half an hour of active conversation. Root cause: the block it surfaced lived on a **descendant** (blocked rolls up the tree), and the unblocker stamps `blockCheckT` on the node it examines — the blocked child — never the top. The rejudging latch read the **top's** watermark, which stays None for a child-held block, so every plain reply armed the latch and no judge examine could ever release it; each landing turn then advanced `disp_t` past the reply and lifted the card back to Needs-You. PR #144's watermark bound fixed exactly this strobe for top-level blocks; this closes the one-level-down hole.

The clear bound is now the oldest `blockCheckT` among the subtree's open blocked nodes (`_block_check_floor`, walking with the same done/cleared gates as `_closure_blocked`): the card returns to Needs-You exactly once, when every block it surfaces has been re-examined with evidence covering the reply. If the walk finds no open block (stale rollup), it falls back to the top's own watermark — the pre-existing semantics, byte-for-byte.

Test: `test_feed_rejudging_watermark_covers_a_descendant_block` (red on the old code) — arms off the child's block, releases on the child's watermark, stays armed when the examine predates the reply. Full suite: 3783 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)