### PR TITLE
Contain the grouped-mode Clear float so it can't overlay the toggle row

### DIFF
--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -111,9 +111,12 @@ test("the footer action row WRAPS its buttons so they can NEVER run off the card
   // the section toggles GROUP left and wrap together (the user 2026-07-08) — no longer spread to opposite
   // edges; the old `margin-left:auto` on a trailing secbtn is gone.
   assert.doesNotMatch(CSS, /\.fask-row3 \.fask-secbtn ~ \.fask-secbtn \{ margin-left: auto; \}/);
-  // the title fills the full card width (block row1 + inline title, the user 2026-07-08) and the time trails
-  // it INLINE right after the last word — no reserved column, no empty space top-right.
-  assert.match(CSS, /\.fask-row1 \{ display: block; \}/);
+  // the title fills the full card width (flow-root row1 + inline title, the user 2026-07-08) and the time
+  // trails it INLINE right after the last word — no reserved column, no empty space top-right. flow-root,
+  // not block (the user 2026-07-31): row1 must CONTAIN its grouped-mode Clear float, else a Clear that
+  // drops off a full time line overlays row 3 and hangs misaligned beside the Background/Summary toggles.
+  assert.match(CSS, /\.fask-row1 \{ display: flow-root; \}/);
+  assert.doesNotMatch(CSS, /\.fask-row1 \{ display: block; \}/, "a plain block gains no height from the float");
   assert.match(CSS, /\.fask-row1 \.fcard-title \{ display: inline; \}/);
   assert.match(CSS, /\.fask-row1 \.ftime \{ margin-left: 8px; \}/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -161,12 +161,17 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    (the user 2026-07-08). The old flex row reserved the time's column on EVERY title line, so a narrow card
    wrapped the title short and left empty space top-right. As inline flow in a block, the text uses the whole
    width and the time follows wherever the text ends. The title's hit-area stays its text alone (blank space
-   isn't part of the inline element → a click there opens the modal, not locate). */
-.fask-row1 { display: block; }
+   isn't part of the inline element → a click there opens the modal, not locate).
+   flow-root, not block (the user 2026-07-31): row1 must CONTAIN its grouped-mode Clear float. A plain
+   block gains no height from a float, so when Clear didn't fit on the time line its "own line" overlay
+   ROW 3's line instead — Clear hung vertically offset against the Background/Summary toggles. flow-root
+   changes nothing for the inline title+time flow; it only makes the dropped float's line real. */
+.fask-row1 { display: flow-root; }
 .fask-row1 .fcard-title { display: inline; }
 .fask-row1 .ftime { margin-left: 8px; }
 /* GROUPED mode (the user 2026-07-13): Clear floats right on the TIME line — right-justified beside the
-   timestamp when it fits, else it drops to its own right-aligned line (the compactness ladder). */
+   timestamp when it fits, else it drops to its own right-aligned line (the compactness ladder; row1's
+   flow-root above is what makes that line take real height instead of overlaying row 3). */
 .fask-row1 .fdismiss { float: right; margin-left: 8px; }
 /* the by-session header on the column BACKDROP opening that session's run of cards: identity-colored
    name + the working dot; cards under it drop their own name row. NO font-size of its own (the user


### PR DESCRIPTION
In grouped mode the card's Clear button floats right on the time line, dropping to its own right-aligned line when the title fills the line. But `.fask-row1` was a plain `display: block`, which gains no height from a float — the dropped Clear overlaid row 3 and rendered vertically offset against the Background/Summary toggles (screenshot in the report). `display: flow-root` is identical for the inline title+time flow but contains the float, so the dropped line takes real height and row 3 starts below it.

Node suite: 1563 passed; `feed-card-layout.test.ts` pin updated to flow-root with a doesNotMatch guard on the old block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)