### PR TITLE
Attribute feed flicker: itemset/hostconn/feedmerge tripwires + restart audit

### DIFF
--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -440,6 +440,10 @@ function startManager() {
       return json(200, Object.assign({ ok: true }, ensureKernel(port)));
     }
     if (req.method === 'POST' && url.pathname === '/restart-all') {
+      // Every restart request is logged WITH its source (the user 2026-07-31): a run of anonymous
+      // SIGTERM respawns blinked every dashboard for an hour, and this handler — the one door every
+      // programmatic restart walks through — recorded nothing. The immediate path used to be silent.
+      log(`restart-all requested (${url.searchParams.get('when') === 'quiet' ? 'deferred to quiet window' : 'IMMEDIATE'}) from ${req.socket.remoteAddress || '?'}`);
       if (url.searchParams.get('when') === 'quiet') {            // deploy path: land at the next quiet window
         return json(202, { ok: true, deferred: true, coalesced: queueQuietRestart('all') });
       }
@@ -448,6 +452,7 @@ function startManager() {
       return json(200, { ok: true, restarted: r.ids, managerRestart: r.self });
     }
     if (req.method === 'POST' && url.pathname === '/restart') {
+      log(`restart '${kid}' requested (${url.searchParams.get('when') === 'quiet' ? 'deferred to quiet window' : 'IMMEDIATE'}) from ${req.socket.remoteAddress || '?'}`);
       if (url.searchParams.get('when') === 'quiet') {
         if (!kernels.has(kid)) return json(404, { ok: false, error: `no kernel '${kid}'` });
         return json(202, { ok: true, deferred: true, coalesced: queueQuietRestart(kid) });

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6956,12 +6956,29 @@ def _fleet_restart_run():
         _atomic_write(FLEET_REPORT, json.dumps(report))
     except OSError:
         sys.stderr.write("fleet-restart: could not write the report: %s\n" % traceback.format_exc())
-    _restart_this_kernel()
+    _restart_this_kernel("fleet-restart: the local half of the fleet Restart")
 
 
-def _restart_this_kernel():
+def _audit_restart_request(action, **kw):
+    """One line in restart-audit.jsonl — the same file the CLI path (bin/romp) and service install
+    write, so ONE log answers "who restarted the kernel?" whatever door the request came through
+    (the user 2026-07-31: a run of anonymous SIGTERM restarts blinked every dashboard for an hour
+    and nothing on disk could name the caller — the HTTP door and the manager hop were silent).
+    Best-effort and never raises: auditing must not be able to break the restart itself."""
+    try:
+        rec = {"t": int(time.time()), "action": action}
+        rec.update({k: v for k, v in kw.items() if v})
+        with open(jd.STATE / "restart-audit.jsonl", "a", encoding="utf-8") as f:
+            f.write(json.dumps(rec) + "\n")
+    except Exception:
+        pass
+
+
+def _restart_this_kernel(reason=""):
     """Ask the manager to restart-all (it SIGTERMs this kernel; its exit handler spawns a fresh one).
-    Standalone (no manager) → nothing to restart, which is not an error."""
+    Standalone (no manager) → nothing to restart, which is not an error. `reason` lands in
+    restart-audit.jsonl so the manager hop is never an anonymous SIGTERM (see _audit_restart_request)."""
+    _audit_restart_request("kernel-asks-manager-restart-all", reason=reason, pid=os.getpid())
     mport = os.environ.get("ROMP_MANAGER_PORT")
     if not mport:
         return
@@ -18548,12 +18565,20 @@ class Handler(BaseHTTPRequestHandler):
                     _fleet = json.loads(raw_body or b"{}").get("fleet", True)
                 except Exception:
                     pass
+                # WHO ASKED, on the record (the user 2026-07-31): a restart blinks every dashboard, and
+                # a run of them traced to this route was unattributable — the CLI path audits itself
+                # (bin/romp → restart-audit.jsonl) but the HTTP door was silent. Same file, so one log
+                # tells the whole story.
+                _audit_restart_request("http-restart", fleet=bool(_fleet),
+                                       addr=str(self.client_address[0]),
+                                       origin=str(self.headers.get("Origin") or ""),
+                                       ua=str(self.headers.get("User-Agent") or ""))
                 self._send(200, json.dumps({"ok": True, "restarting": True, "boot": _BOOT_ID,
                                             "fleet": bool(_fleet)}), "application/json")
                 if _fleet and _remotes:
                     threading.Thread(target=_fleet_restart_run, daemon=True).start()
                 else:
-                    _restart_this_kernel()
+                    _restart_this_kernel("http /restart (local-only)")
                 return
             if u.path == "/fleet-restart":
                 # What the last fleet restart did, read back by the page AFTER it reloads (the restart

--- a/tests/test_fleet_restart.py
+++ b/tests/test_fleet_restart.py
@@ -117,7 +117,7 @@ class ReportSurvivesTheRestart(unittest.TestCase):
     def test_the_run_writes_every_host_then_restarts_this_machine_last(self):
         src = inspect.getsource(km._fleet_restart_run)
         self.assertIn("_atomic_write(FLEET_REPORT", src)
-        self.assertLess(src.index("_atomic_write(FLEET_REPORT"), src.index("_restart_this_kernel()"),
+        self.assertLess(src.index("_atomic_write(FLEET_REPORT"), src.index("_restart_this_kernel("),
                         "the report must be on disk BEFORE this process is taken down")
         self.assertIn("except Exception as e:", src)   # one bad host never strands the rest of the fleet
 
@@ -126,7 +126,7 @@ class ReportSurvivesTheRestart(unittest.TestCase):
                                             "_restart_this_kernel", "_local_head", "_local_branch")}
         km._fleet_restart_plan = lambda r: ("restart", "already on this build")
         km._restart_remote_kernel = lambda h: (_ for _ in ()).throw(RuntimeError("ssh exploded"))
-        km._restart_this_kernel = lambda: None
+        km._restart_this_kernel = lambda reason="": None   # audits its reason since 2026-07-31
         km._local_head = lambda short=False: "abc1234"
         km._local_branch = lambda: "main"
         km._remotes.clear()
@@ -162,7 +162,7 @@ class ReportSurvivesTheRestart(unittest.TestCase):
     def test_a_kernel_with_no_remotes_restarts_exactly_as_before(self):
         src = inspect.getsource(km.Handler)
         self.assertIn("if _fleet and _remotes:", src)
-        self.assertIn("else:\n                    _restart_this_kernel()", src)
+        self.assertIn("else:\n                    _restart_this_kernel(\"http /restart (local-only)\")", src)
 
 
 class GlyphSaysTheFleetState(unittest.TestCase):

--- a/tests/test_restart_audit.py
+++ b/tests/test_restart_audit.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Every kernel-restart door writes WHO ASKED to restart-audit.jsonl (2026-07-31).
+
+A run of anonymous SIGTERM respawns blinked every dashboard for an hour, and nothing on disk could
+name the caller: the CLI path (bin/romp) audits itself, but the HTTP /restart route and the
+kernel→manager hop were silent. Now the route records the requester (address/origin/user-agent) and
+_restart_this_kernel records its reason, in the SAME file, so one log answers "who restarted the
+kernel?" whatever door the request came through.
+
+Synthetic only: the real Handler on an ephemeral port, no manager (ROMP_MANAGER_PORT unset → the
+restart itself is a no-op), invented tokens.
+"""
+import json
+import os
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+os.environ.pop("ROMP_MANAGER_PORT", None)   # no manager → _restart_this_kernel audits, then no-ops
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+def _audit_path():
+    return jd.STATE / "restart-audit.jsonl"   # at CALL time — peer test modules rebind jd.STATE
+
+
+def _read_audit():
+    try:
+        return [json.loads(x) for x in _audit_path().read_text().splitlines() if x.strip()]
+    except OSError:
+        return []
+
+
+class RestartAudit(unittest.TestCase):
+    def setUp(self):
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        self.port = self.srv.server_address[1]
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        try:
+            _audit_path().unlink()
+        except OSError:
+            pass
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+
+    def test_http_restart_route_records_the_requester(self):
+        req = urllib.request.Request(
+            "http://127.0.0.1:%d/restart" % self.port,
+            data=json.dumps({"fleet": False}).encode(),
+            headers={"X-Romp-Token": km.TOKEN, "Origin": "http://127.0.0.1:9",
+                     "User-Agent": "test-agent/1.0", "Content-Type": "application/json"},
+            method="POST")
+        with urllib.request.urlopen(req, timeout=10) as r:
+            body = json.loads(r.read())
+        self.assertTrue(body.get("restarting"))
+        recs = _read_audit()
+        route = [r for r in recs if r.get("action") == "http-restart"]
+        self.assertEqual(len(route), 1, "the HTTP door must write exactly one audit line: %r" % recs)
+        self.assertEqual(route[0].get("addr"), "127.0.0.1")
+        self.assertEqual(route[0].get("origin"), "http://127.0.0.1:9")
+        self.assertEqual(route[0].get("ua"), "test-agent/1.0")
+        self.assertNotIn("fleet", route[0], "fleet:false is omitted (falsy fields are dropped)")
+        # the manager hop audits its reason too — the two lines together tell the order of events
+        hop = [r for r in recs if r.get("action") == "kernel-asks-manager-restart-all"]
+        self.assertEqual(len(hop), 1, "the kernel→manager hop must record its reason: %r" % recs)
+        self.assertIn("http /restart", hop[0].get("reason") or "")
+
+    def test_restart_this_kernel_audits_even_with_no_manager(self):
+        km._restart_this_kernel("unit-test reason")
+        recs = _read_audit()
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["action"], "kernel-asks-manager-restart-all")
+        self.assertEqual(recs[0]["reason"], "unit-test reason")
+        self.assertEqual(recs[0]["pid"], os.getpid())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_restart_audit.py
+++ b/tests/test_restart_audit.py
@@ -12,6 +12,7 @@ restart itself is a no-op), invented tokens.
 """
 import json
 import os
+import time
 import threading
 import unittest
 import urllib.request
@@ -63,7 +64,14 @@ class RestartAudit(unittest.TestCase):
         with urllib.request.urlopen(req, timeout=10) as r:
             body = json.loads(r.read())
         self.assertTrue(body.get("restarting"))
-        recs = _read_audit()
+        # the route ACKS FIRST and audits the manager hop after — poll briefly so the assertion
+        # doesn't race the handler thread (CI hit this; the ack/restart order is the designed one)
+        recs = []
+        for _ in range(200):
+            recs = _read_audit()
+            if any(r.get("action") == "kernel-asks-manager-restart-all" for r in recs):
+                break
+            time.sleep(0.01)
         route = [r for r in recs if r.get("action") == "http-restart"]
         self.assertEqual(len(route), 1, "the HTTP door must write exactly one audit line: %r" % recs)
         self.assertEqual(route[0].get("addr"), "127.0.0.1")

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -485,7 +485,22 @@ export class FederationManager {
     return readViewOrder();
   }
 
+  private lastFeedCounts = "";   // last per-host ask-count signature — breadcrumb only on change
+
   private emitMergedFeed(): void {
+    // MERGE-INPUT TRIPWIRE (the user 2026-07-31): one breadcrumb whenever any host's contribution to
+    // the merged feed CHANGES SIZE — so a card blinking out is attributable to the host snapshot that
+    // shrank (a kernel push without it / a detach) vs. the render layer (the feed pane's own tripwire).
+    const counts: Record<string, number> = {};
+    for (const h of this.hostSeq) {
+      const f = this.perHostFeed[h];
+      if (f) counts[h || "local"] = Array.isArray(f.asks) ? f.asks.length : -1;   // -1 = a feed msg with NO asks array
+    }
+    const sig = JSON.stringify(counts);
+    if (sig !== this.lastFeedCounts) {
+      this.lastFeedCounts = sig;
+      this.diag("feedmerge", { counts });
+    }
     window.dispatchEvent(new MessageEvent("message", { data: mergeHostFeeds(this.perHostFeed, this.hostSeq, this.view()) }));
   }
 
@@ -619,6 +634,15 @@ export class FederationManager {
     this.connect(conn);
   }
 
+  // HOST-CONNECTION TRIPWIRE (the user 2026-07-31, remote cards blinking in and out): every remote
+  // socket open/close and every detach lands one breadcrumb in the same client-diag journal the
+  // feed's tripwires write, so a blink is attributed to the connection layer (a drop, a /tunnels
+  // flap) or ruled out of it — instead of re-guessed from pixels. Rides the LOCAL kernel socket.
+  private diag(what: string, data: any): void {
+    const s = (window as any).__rompLocalSend;
+    if (typeof s === "function") s({ type: "clientDiag", surface: "federation", what, data });
+  }
+
   private connect(conn: Conn): void {
     if (conn.closed || !conn.live) return;
     if (conn.ws && (conn.ws.readyState === 0 || conn.ws.readyState === 1)) return; // already connecting/open
@@ -630,6 +654,7 @@ export class FederationManager {
       return;
     }
     conn.ws = ws;
+    ws.onopen = () => this.diag("hostconn", { host: conn.host, ev: "open" });
     ws.onmessage = (ev: MessageEvent) => {
       let msg: any;
       try {
@@ -640,7 +665,8 @@ export class FederationManager {
       if (msg && msg.type === "ka") return;
       this.inbound(conn.host, msg);
     };
-    ws.onclose = () => {
+    ws.onclose = (ev: CloseEvent) => {
+      this.diag("hostconn", { host: conn.host, ev: "close", code: ev.code, clean: ev.wasClean, detached: conn.closed });
       if (!conn.closed) setTimeout(() => this.connect(conn), 2000); // reconnect a dropped remote
     };
     ws.onerror = () => {
@@ -653,6 +679,7 @@ export class FederationManager {
   private closeRemote(host: string): void {
     const c = this.conns.get(host);
     if (!c) return;
+    this.diag("hostconn", { host, ev: "detach" });   // /tunnels no longer lists it → its cards drop NOW
     c.closed = true;
     try {
       c.ws && c.ws.close();

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -228,9 +228,12 @@ let lastFeedEvent = "init";                            // the input change the n
 let lastPayloadBuildId = 0;
 function auditShownColumns(list: AskItem[]) {
   const seen = new Set<string>();
+  const firstRender = shownCol.size === 0;             // a fresh pane "appears" everything — not a delta
+  const appeared: string[] = [];
   for (const a of list) {
     seen.add(a.itemId);
     const prev = shownCol.get(a.itemId);
+    if (prev === undefined) appeared.push(a.itemId);
     if (prev !== undefined && prev !== a.column) {
       vscodeApi?.postMessage({ type: "clientDiag", surface: "feed", what: "colflip",
         data: { id: a.itemId, from: prev, to: a.column, ev: lastFeedEvent,
@@ -238,7 +241,17 @@ function auditShownColumns(list: AskItem[]) {
     }
     shownCol.set(a.itemId, a.column);
   }
-  for (const id of Array.from(shownCol.keys())) if (!seen.has(id)) shownCol.delete(id);
+  const gone: string[] = [];
+  for (const id of Array.from(shownCol.keys())) if (!seen.has(id)) { gone.push(id); shownCol.delete(id); }
+  // ITEM-SET TRIPWIRE (the user 2026-07-31, cards blinking in and out): the colflip trail above only
+  // records column CHANGES, so a card leaving/re-entering the render entirely — the observed flicker —
+  // was invisible to every log. Same breadcrumb channel; ids only, no card text. `ev` names the input
+  // change this render reflects, so a blink is attributed to the layer that dropped the card (a host
+  // payload, a filter, a fold) instead of re-guessed from pixels.
+  if (!firstRender && (appeared.length || gone.length)) {
+    vscodeApi?.postMessage({ type: "clientDiag", surface: "feed", what: "itemset",
+      data: { appeared, gone, total: list.length, ev: lastFeedEvent, buildId: lastPayloadBuildId } });
+  }
 }
 function clearFollowMove(itemId: string, why = "") {
   const t = pendingFollowMove.get(itemId); if (t) clearTimeout(t);

--- a/ui/webview/flicker-diag.test.ts
+++ b/ui/webview/flicker-diag.test.ts
@@ -1,0 +1,46 @@
+// The flicker tripwires (the user 2026-07-31): cards were blinking in and out of the feed and NO
+// surface recorded it — the colflip trail only logs column CHANGES, the connection layer logged
+// nothing, and the restart doors were anonymous. Three breadcrumb layers now write the same
+// client-diag journal (client-diag.jsonl), so the next blink is attributed from the recorded trail:
+//   feed itemset   — which itemIds entered/left the MODEL between renders (payload-level);
+//   feedmerge      — each host's contribution to the merged feed whenever a count changes;
+//   hostconn       — every remote socket open/close/detach.
+// Plus the manager logs every /restart request with its source. Source pins (the wiring has no
+// jsdom/ws harness here), like the colflip tripwire's own pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const FEED = fs.readFileSync(path.join(UI, "feed.ts"), "utf8");
+const FED = fs.readFileSync(path.join(UI, "federation.ts"), "utf8");
+const MGR = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-manager"), "utf8");
+
+test("feed: an item entering/leaving the model posts an itemset breadcrumb (ids only, attributed)", () => {
+  assert.match(FEED, /if \(prev === undefined\) appeared\.push\(a\.itemId\);/);
+  assert.match(FEED, /if \(!seen\.has\(id\)\) \{ gone\.push\(id\); shownCol\.delete\(id\); \}/);
+  assert.match(FEED, /what: "itemset",\s*\n\s*data: \{ appeared, gone, total: list\.length, ev: lastFeedEvent, buildId: lastPayloadBuildId \}/);
+  // a fresh pane "appears" everything — that is a reload, not a delta, and must not spam the journal
+  assert.match(FEED, /const firstRender = shownCol\.size === 0;/);
+  assert.match(FEED, /if \(!firstRender && \(appeared\.length \|\| gone\.length\)\)/);
+});
+
+test("federation: every remote socket open/close/detach posts a hostconn breadcrumb", () => {
+  assert.match(FED, /ws\.onopen = \(\) => this\.diag\("hostconn", \{ host: conn\.host, ev: "open" \}\);/);
+  assert.match(FED, /this\.diag\("hostconn", \{ host: conn\.host, ev: "close", code: ev\.code, clean: ev\.wasClean, detached: conn\.closed \}\);/);
+  assert.match(FED, /this\.diag\("hostconn", \{ host, ev: "detach" \}\);/);
+  // breadcrumbs ride the LOCAL kernel socket into the same client-diag journal the feed writes
+  assert.match(FED, /s\(\{ type: "clientDiag", surface: "federation", what, data \}\);/);
+});
+
+test("federation: a host's merged-feed contribution changing size posts a feedmerge breadcrumb", () => {
+  assert.match(FED, /counts\[h \|\| "local"\] = Array\.isArray\(f\.asks\) \? f\.asks\.length : -1;/);
+  // deduped on the count signature — steady-state pushes with unchanged counts log nothing
+  assert.match(FED, /if \(sig !== this\.lastFeedCounts\) \{\s*\n\s*this\.lastFeedCounts = sig;\s*\n\s*this\.diag\("feedmerge", \{ counts \}\);/);
+});
+
+test("manager: every /restart-all and /restart request is logged with its source (no anonymous SIGTERMs)", () => {
+  assert.match(MGR, /log\(`restart-all requested \(\$\{url\.searchParams\.get\('when'\) === 'quiet' \? 'deferred to quiet window' : 'IMMEDIATE'\}\) from \$\{req\.socket\.remoteAddress \|\| '\?'\}`\);/);
+  assert.match(MGR, /log\(`restart '\$\{kid\}' requested \(\$\{url\.searchParams\.get\('when'\) === 'quiet' \? 'deferred to quiet window' : 'IMMEDIATE'\}\) from \$\{req\.socket\.remoteAddress \|\| '\?'\}`\);/);
+});


### PR DESCRIPTION
Cards blink in and out of the feed (user report + screen recording, 2026-07-31) and no log records it: the colflip trail only covers column changes, remote-socket drops are silent, and today's run of SIGTERM kernel respawns was unattributable because the HTTP `/restart` door and the kernel→manager hop write no audit (only the CLI door does).

Live probing showed both kernels' feed payloads rock-steady while the rendered card blinked — so the drop happens client-side, and the next occurrence needs to be attributed from a recorded trail, not pixels:

- **feed `itemset`** — itemIds entering/leaving the model between renders, with colflip's `ev`/`buildId` attribution; a fresh pane's initial fill logs nothing.
- **federation `hostconn`** — every remote socket open/close (code/clean/detached) and every `/tunnels`-driven detach.
- **federation `feedmerge`** — per-host ask-count contributions to the merged feed, logged only on change.
- **restart audit** — `/restart` records the requester's address/Origin/user-agent; `_restart_this_kernel` records its reason (both into `restart-audit.jsonl`, the file `bin/romp` already writes); the manager logs each `/restart(-all)` request with source and immediate/deferred.

Tests: `tests/test_restart_audit.py` (route + hop records, driven through the real Handler), `ui/webview/flicker-diag.test.ts` (source pins for the three tripwires + manager logging); `tests/test_fleet_restart.py` pins updated for the reasoned `_restart_this_kernel` signature. Python 3785 passed; node 1567 passed; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)