### PR TITLE
One FederationManager per page: preview.ts must not import federation.ts

### DIFF
--- a/ui/webview/federation-single-instance.test.ts
+++ b/ui/webview/federation-single-instance.test.ts
@@ -1,0 +1,42 @@
+// federation.ts BOOTS a FederationManager when loaded in a browser (its module tail) — that is the
+// design: it ships as its own script (esbuild.js entry), loaded once per chat/feed/fleet page, after
+// the shim. Which makes IMPORTING it from any other webview module a bug, not a convenience: esbuild
+// inlines a second copy — bootstrap included — into that pane's bundle, and the twin manager, hearing
+// only the remote sockets it opens itself (the shim hands local frames to whichever manager claimed
+// __rompFed last), emits REMOTE-ONLY merged feeds in alternation with the real manager's complete
+// ones. Every local card blinked out and right back, remote cards persisting (the user 2026-07-31,
+// screen recording; introduced by preview.ts importing hostOf/bareId from it). Those helpers live in
+// host-prefix.ts, the side-effect-free module, precisely so nothing ever needs this import.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+
+test("no webview module imports federation.ts — importing it boots a second FederationManager", () => {
+  const offenders: string[] = [];
+  for (const f of fs.readdirSync(UI)) {
+    if (!f.endsWith(".ts") || f.endsWith(".test.ts") || f === "federation.ts") continue;
+    const src = fs.readFileSync(path.join(UI, f), "utf8");
+    if (/from "\.\/federation"/.test(src)) offenders.push(f);
+  }
+  assert.deepEqual(offenders, [], "these modules would bundle a second manager: " + offenders.join(", "));
+});
+
+test("hostOf/bareId live in host-prefix.ts (side-effect-free) and federation re-exports them", () => {
+  const hp = fs.readFileSync(path.join(UI, "host-prefix.ts"), "utf8");
+  assert.match(hp, /export function hostOf\(id: string\): string \{/);
+  assert.match(hp, /export function bareId\(id: string\): string \{/);
+  assert.doesNotMatch(hp, /import /, "host-prefix.ts must stay import-free — it is the safe home");
+  const fed = fs.readFileSync(path.join(UI, "federation.ts"), "utf8");
+  assert.match(fed, /import \{ hostOf, bareId \} from "\.\/host-prefix";/);
+  assert.match(fed, /export \{ hostOf, bareId \};/);
+  const pv = fs.readFileSync(path.join(UI, "preview.ts"), "utf8");
+  assert.match(pv, /import \{ hostOf, bareId \} from "\.\/host-prefix";/);
+});
+
+test("the bootstrap this guards is still there — federation.ts self-starts on a browser page", () => {
+  const fed = fs.readFileSync(path.join(UI, "federation.ts"), "utf8");
+  assert.match(fed, /new FederationManager\(\)\.start\(\);/);
+});

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -13,6 +13,7 @@
 
 import { applyViewOrder, applyViewOrderTo, pruneViewOrder, readViewOrder, writeViewOrder,
          VIEW_ORDER_KEY, VIEW_ORDER_EVENT } from "./view-order";
+import { hostOf, bareId } from "./host-prefix";
 
 export const SEP = ":";
 export const LOCAL = ""; // the local kernel's host key — no prefix, so the single-kernel path is untouched
@@ -22,20 +23,12 @@ export function prefixId(host: string, id: string): string {
   return host ? host + SEP + id : id;
 }
 
-/** The host a prefixed id belongs to, or "" (local) for a bare id. Session ids are UUIDs (no colon),
- *  so a colon unambiguously marks the host prefix. */
-export function hostOf(id: string): string {
-  if (typeof id !== "string") return "";
-  const i = id.indexOf(SEP);
-  return i > 0 ? id.slice(0, i) : "";
-}
-
-/** The bare session id with any `host:` prefix removed. */
-export function bareId(id: string): string {
-  if (typeof id !== "string") return id;
-  const i = id.indexOf(SEP);
-  return i > 0 ? id.slice(i + 1) : id;
-}
+// hostOf/bareId live in host-prefix.ts (the side-effect-free helper module) so that OTHER modules can
+// read a host prefix WITHOUT importing this file — importing federation.ts boots a FederationManager
+// (the module-tail bootstrap below), and a second copy bundled into a pane emitted remote-only merged
+// feeds in alternation with the real manager's (the user 2026-07-31: every local card blinking).
+// Re-exported here so this module's own consumers (the merge tests) keep one import surface.
+export { hostOf, bareId };
 
 /** This dashboard's window id, resolved exactly as the pane shim resolves it (the kernel's `_shim`): the
  *  host's `?wid=` when it supplies one, else the shell's per-tab sessionStorage id, which same-origin

--- a/ui/webview/host-prefix.ts
+++ b/ui/webview/host-prefix.ts
@@ -4,6 +4,28 @@
 // starts with the same prefix, the "host:" part is METADATA, not part of the name — and it renders as
 // such (quiet gray, never bold, italic, a step smaller) instead of wearing the session's identity
 // color at full weight (the user 2026-07-11). One helper + one .host-prefix class for every surface.
+/** The host a federation-prefixed id belongs to, or "" (local) for a bare id. Session ids are UUIDs
+ *  (no colon), so a colon unambiguously marks the host prefix. Lives HERE — the side-effect-free
+ *  helper module — because importing federation.ts BOOTS a FederationManager (its module tail
+ *  bootstraps one on load, by design: it is its own script, loaded once per page). preview.ts
+ *  importing it for these two helpers bundled a SECOND manager into the feed/chat pages, and the
+ *  twin — hearing only the remote sockets, never the shim's local frames — emitted remote-only merged
+ *  feeds in alternation with the real manager's complete ones: every LOCAL card blinked out and
+ *  right back, remote cards persisting (the user 2026-07-31, screen recording). Import federation.ts
+ *  from nothing; federation-single-instance.test.ts enforces it. */
+export function hostOf(id: string): string {
+  if (typeof id !== "string") return "";
+  const i = id.indexOf(":");
+  return i > 0 ? id.slice(0, i) : "";
+}
+
+/** The bare session id with any `host:` prefix removed. */
+export function bareId(id: string): string {
+  if (typeof id !== "string") return id;
+  const i = id.indexOf(":");
+  return i > 0 ? id.slice(i + 1) : id;
+}
+
 export function hostPrefix(name: string | null | undefined, sid: string | null | undefined): { host: string; rest: string } | null {
   if (!sid || !name) return null;
   const i = sid.indexOf(":");

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -6,7 +6,7 @@
 // (event-based; no stale placeholders). Web dashboard only: the VS Code webview sandbox can't reach the
 // kernel origin from an <img>, so callers gate on canPreview() and keep the plain click-to-open link.
 
-import { hostOf, bareId } from "./federation";
+import { hostOf, bareId } from "./host-prefix";
 
 // Extensions the kernel's _PREVIEW_MIME serves — keep the two lists in step (tests pin both).
 const IMG_EXT = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"]);


### PR DESCRIPTION
Root cause of the feed flicker (user screen recording, 2026-07-31): all local cards blinking out and right back every couple of seconds while remote cards persisted.

`federation.ts` boots a `FederationManager` from its module tail — by design, it ships as its own script, loaded once per chat/feed/fleet page after the shim. PR #163 made `preview.ts` import `hostOf`/`bareId` from it, so esbuild inlined a **second copy of the module, bootstrap included**, into the feed and chat bundles. The twin manager polls `/tunnels` and opens its own remote sockets, but never hears the local kernel's frames (the shim hands those to whichever manager claimed `__rompFed` last) — so on every remote push it emitted a merged feed containing **only the remote host's cards**, alternating with the real manager's complete ones. Both kernels' payloads were probed live and steady while this happened; the flicker was entirely the client-side twin.

Fix: `hostOf`/`bareId` move to `host-prefix.ts` — the side-effect-free helper module feed/render already import — and `federation.ts` re-exports them for its existing consumers (the merge tests are untouched). `preview.ts` imports the safe home.

Guard: `federation-single-instance.test.ts` scans every webview module and fails on any `from "./federation"` import, and pins that the bootstrap it guards is still present.

Python 3785 passed; node suite all green (incl. the new guard); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)