### PR TITLE
Loading cues: swirl placeholder for tunnel-slow previews, busy dots on Undo clear

### DIFF
--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -783,6 +783,19 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 #feed-clearall { order: 10; margin-left: auto; }   /* accent hover like every action button */
 #feed-undoclear { order: 11; }                     /* restorative — far right */
 #feed-foot .fdismiss { font-size: 10.5px; padding: 1px 9px; opacity: 0.95; }
+
+/* Undo clear, WORKING (the user 2026-07-31): when the cleared batch isn't in this page's cache the
+   restore is a full kernel round-trip and the button read dead for a beat. Accent border + three
+   pulsing accent dots say "on it" — WITHOUT disabling: each further click keeps popping older
+   batches. Cleared by the next feed payload (feed.ts clearUndoBusy — event-based, timeout backstop). */
+#feed-undoclear.undo-busy { border-color: var(--accent); }
+#feed-undoclear .undo-dots { display: inline-flex; gap: 3px; margin-left: 6px; vertical-align: 1px; }
+#feed-undoclear .undo-dots i { width: 4px; height: 4px; border-radius: 50%; background: var(--accent);
+  animation: undo-dot 1s ease-in-out infinite; }
+#feed-undoclear .undo-dots i:nth-child(2) { animation-delay: 0.18s; }
+#feed-undoclear .undo-dots i:nth-child(3) { animation-delay: 0.36s; }
+@keyframes undo-dot { 0%, 100% { opacity: 0.25; } 40% { opacity: 1; } }
+@media (prefers-reduced-motion: reduce) { #feed-undoclear .undo-dots i { animation: none; opacity: 0.8; } }
 /* the "Newest first" / "Collapsed" MODE toggles: pressed (.on) wears the accent language (blue text + border
    + faint wash), the same selected-state look the card section toggles use (the user 2026-07-07) */
 #feed-foot .feed-modetoggle.on { color: var(--accent); border-color: var(--accent);
@@ -992,6 +1005,16 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   border: 1px solid rgba(255, 255, 255, 0.14); overflow: hidden; background: rgba(0, 0, 0, 0.25); }
 .path-thumb:hover { border-color: var(--accent); }
 .path-thumb-img { display: block; max-width: 220px; max-height: 140px; object-fit: contain; }
+
+/* the preview's LOADING cue (the user 2026-07-31): the mini romp swirl holds a mentioned image's spot
+   until its load event lands (preview.ts withLoadCue) — a remote file rides the ssh tunnel, and the
+   picture used to pop in with nothing saying it was on the way. First load of a URL only, so re-renders
+   never re-flash it. Both sheets carry it (each page loads only its own — the .romp-acted precedent). */
+.path-load-spin { display: block; width: 20px; height: 20px; margin: 8px 10px;
+  animation: path-load-spin 2.4s linear infinite; }   /* the calm mini-swirl spin, same as the awaiting glyphs */
+@keyframes path-load-spin { to { transform: rotate(-360deg); } }
+.path-img-loading { display: none; }   /* the <img> takes the spot the instant it has pixels */
+@media (prefers-reduced-motion: reduce) { .path-load-spin { animation: none; } }
 .path-thumb.pdf { padding: 5px 9px; cursor: pointer; }
 .path-thumb-tag { font-size: 0.72em; font-weight: 700; letter-spacing: 0.04em; color: var(--accent); flex: 0 0 auto; }
 .path-thumb-name { font-size: 0.72em; color: var(--fg); overflow: hidden; text-overflow: ellipsis;

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -2781,10 +2781,31 @@ function makeUndoClearBtn(): HTMLElement {
       render();
     } else {
       pendingCleared.clear();   // nothing cached (e.g. cleared in another session) → fall back to the round-trip
+      // WORKING cue (the user 2026-07-31): with nothing in this page's cache the restore is a full
+      // kernel round-trip and the button read dead for a beat (the optimistic branch above needs no
+      // cue — its card appears instantly). Three pulsing accent dots + an accent border say "on it"
+      // WITHOUT disabling: each further click keeps popping older batches. Cleared by the NEXT feed
+      // payload (the push undoClear triggers — the event this cue is waiting for), with a timeout
+      // backstop so a lost push can never trap it.
+      b.classList.add("undo-busy");
+      if (!b.querySelector(".undo-dots")) {
+        const d = el("span", "undo-dots");
+        d.append(el("i"), el("i"), el("i"));
+        b.appendChild(d);
+      }
+      window.clearTimeout(undoBusyBackstop);
+      undoBusyBackstop = window.setTimeout(clearUndoBusy, 6000);
     }
     vscodeApi?.postMessage({ type: "undoClear" });
   };
   return b;
+}
+
+let undoBusyBackstop = 0;
+function clearUndoBusy(): void {
+  window.clearTimeout(undoBusyBackstop);
+  const b = document.getElementById("feed-undoclear");
+  if (b) { b.classList.remove("undo-busy"); b.querySelector(".undo-dots")?.remove(); }
 }
 
 // Clear-all + UndoClear live in #feed-foot — a footer bar in normal flow BELOW the scrolling card
@@ -3429,6 +3450,7 @@ window.addEventListener("message", (e: MessageEvent) => {
       Array.isArray(m.sdkNotices) ? m.sdkNotices : [],
       Array.isArray(m.syncNotices) ? m.syncNotices : []);   // card trouble chips + /clear drops + SDK failures + fleet syncs also log in the shell's bell (chips stay on the cards)
     if (typeof m.dismissedCount === "number") dismissedCount = m.dismissedCount;
+    clearUndoBusy();   // the push the undo was waiting on has landed (or any fresher one) — cue off
     if (typeof m.showDismissed === "boolean") showDismissed = m.showDismissed;
     if (typeof m.canUndoClear === "boolean") canUndoClear = m.canUndoClear;
     render();

--- a/ui/webview/loading-cues.test.ts
+++ b/ui/webview/loading-cues.test.ts
@@ -1,0 +1,58 @@
+// Two waiting states got the romp loader treatment (the user 2026-07-31):
+//   1. A mentioned image whose bytes ride the ssh tunnel showed only its path for a beat, then the
+//      picture "popped in" — now a mini spinning romp swirl holds the spot until the <img> load
+//      event lands (event-based), memoized per URL so chat re-renders never re-flash it.
+//   2. Undo clear with no cached batch is a full kernel round-trip and the button read dead — now
+//      it wears an accent border + three pulsing accent dots, WITHOUT disabling (each further click
+//      pops an older batch), cleared by the next feed payload with a timeout backstop.
+// Source pins (no jsdom harness for these paths), like the other loader/tripwire tests.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const PREVIEW = fs.readFileSync(path.join(UI, "preview.ts"), "utf8");
+const FEED = fs.readFileSync(path.join(UI, "feed.ts"), "utf8");
+const FEED_CSS = fs.readFileSync(path.join(UI, "feed.css"), "utf8");
+const CHAT_CSS = fs.readFileSync(path.join(UI, "styles.css"), "utf8");
+
+test("previews: the mini swirl holds the spot until the load EVENT; first load of a URL only", () => {
+  assert.match(PREVIEW, /const loadedOnce = new Set<string>\(\);/);
+  assert.match(PREVIEW, /if \(loadedOnce\.has\(url\)\) return;/, "a URL that already loaded never re-spins");
+  assert.match(PREVIEW, /spin\.src = mediaSrc\("romp-swirl-glyph\.svg"\);/, "mediaSrc — resolves on BOTH surfaces");
+  assert.match(PREVIEW, /img\.addEventListener\("load", \(\) => \{\s*\n\s*loadedOnce\.add\(url\);\s*\n\s*spin\.remove\(\);/,
+               "the cue clears on the load event, never a timer");
+  // both builders wear it — the chat's full-size render and the feed modal's thumb
+  const cues = PREVIEW.match(/withLoadCue\(box, img, url\);/g) || [];
+  assert.equal(cues.length, 2, "previewThumb AND previewFull");
+});
+
+test("previews: the cue CSS lives in BOTH sheets (each page loads only its own — the .romp-acted precedent)", () => {
+  for (const css of [FEED_CSS, CHAT_CSS]) {
+    assert.match(css, /\.path-load-spin \{ display: block; width: 20px; height: 20px;/);
+    assert.match(css, /@keyframes path-load-spin \{ to \{ transform: rotate\(-360deg\); \} \}/, "the reverse romp spin");
+    assert.match(css, /\.path-img-loading \{ display: none; \}/, "the <img> takes the spot the instant it has pixels");
+    assert.match(css, /prefers-reduced-motion: reduce\) \{ \.path-load-spin \{ animation: none; \} \}/);
+  }
+});
+
+test("undo clear: the round-trip branch arms a busy cue that never disables the button", () => {
+  // armed ONLY on the cache-miss branch — the optimistic restore's card appearing IS its feedback
+  assert.match(FEED, /pendingCleared\.clear\(\);[\s\S]{0,700}b\.classList\.add\("undo-busy"\);/);
+  assert.doesNotMatch(FEED, /feed-undoclear[\s\S]{0,2000}\.disabled = true/, "repeat clicks must keep popping older batches");
+  assert.match(FEED, /undoBusyBackstop = window\.setTimeout\(clearUndoBusy, 6000\);/, "backstop — a lost push can't trap the cue");
+});
+
+test("undo clear: the cue clears on the NEXT feed payload (the event it waits for)", () => {
+  assert.match(FEED, /if \(typeof m\.dismissedCount === "number"\) dismissedCount = m\.dismissedCount;\s*\n\s*clearUndoBusy\(\);/);
+  assert.match(FEED, /function clearUndoBusy\(\): void \{/);
+  assert.match(FEED, /b\.querySelector\("\.undo-dots"\)\?\.remove\(\);/);
+});
+
+test("undo clear: accent dots + accent border, reduced-motion safe (feed.css — the feed page's own sheet)", () => {
+  assert.match(FEED_CSS, /#feed-undoclear\.undo-busy \{ border-color: var\(--accent\); \}/);
+  assert.match(FEED_CSS, /#feed-undoclear \.undo-dots i \{ width: 4px; height: 4px; border-radius: 50%; background: var\(--accent\);/);
+  assert.match(FEED_CSS, /@keyframes undo-dot \{ 0%, 100% \{ opacity: 0\.25; \} 40% \{ opacity: 1; \} \}/);
+  assert.match(FEED_CSS, /prefers-reduced-motion: reduce\) \{ #feed-undoclear \.undo-dots i \{ animation: none; opacity: 0\.8; \} \}/);
+});

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -7,6 +7,7 @@
 // kernel origin from an <img>, so callers gate on canPreview() and keep the plain click-to-open link.
 
 import { hostOf, bareId } from "./host-prefix";
+import { mediaSrc } from "./media";
 
 // Extensions the kernel's _PREVIEW_MIME serves — keep the two lists in step (tests pin both).
 const IMG_EXT = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"]);
@@ -25,6 +26,30 @@ export function previewKind(path: string): PreviewKind | null {
 // resolves nowhere — callers keep the existing openFile behavior there.
 export function canPreview(): boolean {
   return location.protocol === "http:" || location.protocol === "https:";
+}
+
+// LOADING CUE (the user 2026-07-31): a remote image's bytes arrive over the ssh tunnel, so for a
+// beat the message showed only the path text and the picture "popped in" with nothing saying it was
+// on the way. Per the loading-state rule the first thing up is the romp swirl: a mini spinning glyph
+// holds the image's spot until its `load` event lands (event-based; an error still removes the whole
+// box, spinner included — no backstop needed because the cue dies with its box either way). Memoized
+// per URL for this page life: chat re-renders rebuild these elements constantly, and re-flashing a
+// spinner over bytes the browser just painted would itself be flicker — only a URL's FIRST load spins.
+const loadedOnce = new Set<string>();
+function withLoadCue(box: HTMLElement, img: HTMLImageElement, url: string): void {
+  if (loadedOnce.has(url)) return;
+  const spin = document.createElement("img");
+  spin.className = "path-load-spin";
+  spin.src = mediaSrc("romp-swirl-glyph.svg");
+  spin.alt = "loading preview…";
+  spin.title = "loading preview…";
+  box.appendChild(spin);
+  img.classList.add("path-img-loading");
+  img.addEventListener("load", () => {
+    loadedOnce.add(url);
+    spin.remove();
+    img.classList.remove("path-img-loading");
+  });
 }
 
 // The kernel serves the bytes; sid lets it resolve a relative path against THAT session's cwd
@@ -109,10 +134,12 @@ export function previewThumb(path: string, sid?: string | null): HTMLElement | n
   } else {
     const img = document.createElement("img");
     img.className = "path-thumb-img";
-    img.src = fileUrl(path, sid);
+    const url = fileUrl(path, sid);
+    img.src = url;
     img.alt = path;
     img.loading = "lazy";
     img.onerror = () => box.remove();
+    withLoadCue(box, img, url);   // mini swirl holds the spot until the load event (first load only)
     box.appendChild(img);
   }
   box.onclick = (ev) => { ev.stopPropagation(); openLightbox(path, sid); };
@@ -153,11 +180,13 @@ export function previewFull(path: string, sid?: string | null): HTMLElement | nu
   } else {
     const img = document.createElement("img");
     img.className = "path-full-img";
-    img.src = fileUrl(path, sid);
+    const url = fileUrl(path, sid);
+    img.src = url;
     img.alt = path;
     img.loading = "lazy";
     img.onerror = () => box.remove();
     img.onclick = (ev) => { ev.stopPropagation(); openLightbox(path, sid); };
+    withLoadCue(box, img, url);   // mini swirl holds the spot until the load event (first load only)
     box.appendChild(img);
   }
   return box;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1997,6 +1997,16 @@ body.picker-lifted > #picker { align-items: center; padding: 24px 16px; }
   border: 1px solid rgba(255, 255, 255, 0.14); overflow: hidden; background: rgba(0, 0, 0, 0.25); }
 .path-thumb:hover { border-color: var(--accent); }
 .path-thumb-img { display: block; max-width: 220px; max-height: 140px; object-fit: contain; }
+
+/* the preview's LOADING cue (the user 2026-07-31): the mini romp swirl holds a mentioned image's spot
+   until its load event lands (preview.ts withLoadCue) — a remote file rides the ssh tunnel, and the
+   picture used to pop in with nothing saying it was on the way. First load of a URL only, so re-renders
+   never re-flash it. Both sheets carry it (each page loads only its own — the .romp-acted precedent). */
+.path-load-spin { display: block; width: 20px; height: 20px; margin: 8px 10px;
+  animation: path-load-spin 2.4s linear infinite; }   /* the calm mini-swirl spin, same as the awaiting glyphs */
+@keyframes path-load-spin { to { transform: rotate(-360deg); } }
+.path-img-loading { display: none; }   /* the <img> takes the spot the instant it has pixels */
+@media (prefers-reduced-motion: reduce) { .path-load-spin { animation: none; } }
 .path-thumb.pdf { padding: 5px 9px; cursor: pointer; }
 .path-thumb-tag { font-size: 0.74em; font-weight: 700; letter-spacing: 0.04em; color: var(--accent); flex: 0 0 auto; }
 .path-thumb-name { font-size: 0.74em; color: var(--fg); overflow: hidden; text-overflow: ellipsis;


### PR DESCRIPTION
Two waits with no cue (user report, 2026-07-31):

- **Mentioned images over the tunnel**: the picture showed only its path for a beat, then popped in. A mini spinning romp swirl (the `mediaSrc` glyph, reverse spin, calm 2.4s — the awaiting-glyph convention) now holds the spot until the `<img>` load event lands. Memoized per URL for the page life so chat re-renders never re-flash it; an error still removes the whole box, spinner included. CSS in both sheets (each page loads only its own).
- **Undo clear on a cache miss**: when the cleared batch isn't in this page's cache the restore is a full kernel round-trip and the button read dead. On that branch only, the button wears an accent border + three pulsing accent dots — **without disabling**, so repeated clicks keep popping older batches. Cleared by the next feed payload (the push the undo triggers), 6s backstop so a lost push can't trap it. The optimistic branch keeps its existing instant-card feedback.

Tests: `ui/webview/loading-cues.test.ts` pins the event-based clears, the per-URL memo, the never-disable rule, and both sheets' CSS. Node suite all green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)