### PR TITLE
Usage bars: a window whose reset has passed reads unknown, never 0%

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16644,20 +16644,24 @@ function hasBars(u){return !!(u&&(u.fiveHour||u.sevenDay||u.fable));}
 // One account's windows, as markup + the tooltip detail for them. Pure: the caller decides where it goes.
 function winsHTML(u,det){var nowS=Math.floor(Date.now()/1000),html='';
 WINS.forEach(function(w){var seg=u[w[0]];if(!seg)return;
-var rolled=seg.resetsAt&&nowS>seg.resetsAt,pct=rolled?0:(seg.pct||0);
+// A ROLLED window (its reset passed since the last report) is UNKNOWN, not 0 (the user 2026-07-31: a
+// remote whose kernel had no live session to ask sat on a days-old snapshot, and the rail drew a
+// confident 0% beside a live account's real bars). Last-known fill drawn FADED + a '?' readout, so
+// unknown and genuinely-empty can never be confused; the tooltip dates the gap.
+var rolled=!!(seg.resetsAt&&nowS>seg.resetsAt),pct=Math.max(0,Math.min(100,seg.pct||0));
 var col=(seg.color&&seg.color.length===3)?('rgb('+seg.color.join(',')+')'):'#54B204';   // selected colormap (server-computed)
-var tp=(seg.resetsAt&&w[1])?Math.max(0,Math.min(100,Math.round((nowS-(seg.resetsAt-w[1]))/w[1]*100))):null;
-det[w[0]]={name:w[3],span:w[2],pct:pct,col:col,tp:tp,reset:seg.resetsAt?fmtR(seg.resetsAt):null};
+var tp=(!rolled&&seg.resetsAt&&w[1])?Math.max(0,Math.min(100,Math.round((nowS-(seg.resetsAt-w[1]))/w[1]*100))):null;
+det[w[0]]={name:w[3],span:w[2],pct:pct,col:col,tp:tp,unk:rolled,ago:(rolled?fmtAgo(seg.resetsAt):null),reset:(!rolled&&seg.resetsAt)?fmtR(seg.resetsAt):null};
 // Horizontal fill bars (the user 2026-07-05): an expanded label, then TWO stacked horizontal tracks \u2014 the
 // used-% bar (colormap colour) ON TOP of the elapsed-% bar (slate) so you can compare pace at a glance (used
 // ahead of elapsed = burning too fast) \u2014 then the used-% readout. All inline (label \u00b7 bars \u00b7 %).
-html+='<div class=ru-w data-w="'+w[0]+'">'
+html+='<div class="ru-w'+(rolled?' ru-unk':'')+'" data-w="'+w[0]+'">'
 +'<div class=ru-name>'+w[4]+'</div>'
 +'<div class=ru-bars>'
 +'<div class=ru-track><i class=ru-fill style="width:'+pct+'%;background:'+col+'"></i></div>'
 +'<div class=ru-track><i class=ru-fill style="width:'+(tp||0)+'%;background:#6b7a8c"></i></div>'
 +'</div>'
-+'<div class=ru-pct>'+pct+'%</div></div>';});
++'<div class=ru-pct>'+(rolled?'?':pct+'%')+'</div></div>';});
 return html;}
 // ONE SET PER CLAUDE ACCOUNT (the user 2026-07-30). These windows are ACCOUNT-wide, so a fleet signed into
 // one login has one allowance and drawing it per host would repeat the same number \u2014 that is the common
@@ -16684,9 +16688,9 @@ var rest=ROWS.filter(function(r){return r.host;});
 renderRows([{host:'',acct:(u&&u.acct)||'',usage:u}].concat(rest),SELF);}
 // ONE shared tooltip for BOTH windows: per window, the used bar (colormap) over the elapsed bar (slate) +
 // the % + reset — the exact set of bars that used to sit under the timeline, nothing more.
-function barRows(d){return '<div class=ru-tip-row><span class=ru-tip-k>used</span>'
+function barRows(d){return '<div class="ru-tip-row'+(d.unk?' ru-unk':'')+'"><span class=ru-tip-k>used</span>'
 +'<span class=ru-tip-track><i style="width:'+d.pct+'%;background:'+d.col+'"></i></span>'
-+'<span class=ru-tip-v>'+d.pct+'%</span></div>'
++'<span class=ru-tip-v>'+(d.unk?'?':d.pct+'%')+'</span></div>'
 +(d.tp!=null?'<div class=ru-tip-row><span class=ru-tip-k>elapsed</span>'
 +'<span class=ru-tip-track><i style="width:'+d.tp+'%;background:#6b7a8c"></i></span>'
 +'<span class=ru-tip-v>'+d.tp+'%</span></div>':'');}
@@ -16698,7 +16702,8 @@ if(!keys.length)return '';
 return (many?'<div class=ru-tip-host>'+esc(e.host)+'</div>':'')
 +keys.map(function(k){var v=d[k];
 return '<div class=ru-tip-win><div class=ru-tip-name><span>'+esc(v.name)+' ('+esc(v.span)+')</span>'
-+(v.reset?'<span class=ru-tip-reset>resets in '+esc(v.reset)+'</span>':'')+'</div>'+barRows(v)+'</div>';}).join('')
++(v.unk?'<span class=ru-tip-reset>window reset '+esc(v.ago)+' \u2014 no reading since; current usage unknown</span>'
+:(v.reset?'<span class=ru-tip-reset>resets in '+esc(v.reset)+'</span>':''))+'</div>'+barRows(v)+'</div>';}).join('')
 +(d._t?'<div class=ru-tip-age>updated '+fmtAgo(d._t)+'</div>':'');}
 function tipHTML(){var sets=LAST||[];if(!sets.length)return '';
 var many=sets.length>1;
@@ -17802,6 +17807,9 @@ def _landing():
             ".ru-bars{display:flex;flex-direction:column;gap:2px;flex:0 0 auto}"   # used bar stacked over elapsed bar
             ".ru-track{position:relative;width:54px;height:5px;background:rgba(255,255,255,0.12);border-radius:3px;overflow:hidden;flex:0 0 auto}"
             ".ru-fill{position:absolute;left:0;top:0;height:100%;border-radius:3px;transition:width .3s ease}"
+            # UNKNOWN (the user 2026-07-31): a rolled window's last-known bars fade and read '?' — never a confident 0%
+            ".ru-unk .ru-fill{opacity:.3}.ru-unk .ru-pct,.ru-tip-row.ru-unk .ru-tip-v{color:#8a97a6}"
+            ".ru-tip-row.ru-unk i{opacity:.3}"
             ".ru-pct{font:600 10px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#cfe6ff;font-variant-numeric:tabular-nums;white-space:nowrap}"
             # ONE shared hover panel for BOTH windows (the user 2026-06-26): it reproduces exactly the used/
             # elapsed bars that used to sit under the timeline — per window, a "used" bar (selected colormap)

--- a/tests/test_kernel_rail_usage.py
+++ b/tests/test_kernel_rail_usage.py
@@ -100,6 +100,27 @@ class RailUsage(unittest.TestCase):
         self.assertIn("mkUsageBar('fable', 'Fable 5', 7 * 86400)", tv)
         self.assertIn("apply('fable', usage.fable, 'Fable 5 (7d)')", tv)
 
+    def test_a_rolled_window_reads_unknown_not_zero(self):
+        # the user 2026-07-31: a second account's bars sat at a confident 0% because that machine's
+        # kernel had no live session to ask, so its snapshot predated its own reset — an unreadable
+        # window drawn as an empty one. A reading whose window has already reset describes a window
+        # nobody is in any more: it is UNKNOWN. The last-known fill stays but FADES, the readout is
+        # '?', the elapsed (pace) bar is withheld, and the tooltip dates the gap.
+        self.assertIn("var rolled=!!(seg.resetsAt&&nowS>seg.resetsAt),pct=Math.max(0,Math.min(100,seg.pct||0));",
+                      self.html, "the reading survives the roll — it is last-known, not zeroed")
+        self.assertIn("(rolled?'?':pct+'%')", self.html, "the readout says unknown, never 0%")
+        self.assertIn("var tp=(!rolled&&seg.resetsAt&&w[1])", self.html,
+                      "no pace bar against a window that already ended")
+        self.assertIn(".ru-unk .ru-fill{opacity:.3}", self.html, "the last-known bars fade")
+        self.assertIn("window reset '+esc(v.ago)", self.html, "the tooltip dates how stale the reading is")
+        self.assertIn("current usage unknown", self.html)
+        # the STANDALONE timeline copy (Obsidian) says the same thing — one rule, every surface
+        tv = (pathlib.Path(BIN).parent / "ui" / "romp-timeline-view.js").read_text()
+        self.assertIn("const rolled = !!(seg.resetsAt && nowS > seg.resetsAt);", tv)
+        self.assertIn("b.usage.txt.textContent = rolled ? '?' : pct + '%';", tv)
+        self.assertIn("b.usage.fill.style.opacity = rolled ? '0.3' : '';", tv)
+        self.assertIn("current usage unknown (last known ", tv)
+
     def test_the_timeline_forwards_usage_to_the_shell_and_hides_its_own_copy_when_embedded(self):
         tv = (pathlib.Path(BIN).parent / "ui" / "romp-timeline-view.js").read_text()
         # only when embedded (window.parent !== window) — standalone/Obsidian keeps drawing them locally

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -1233,21 +1233,39 @@ class TimelinePanel {
       const b = this._usageBars[key]; if (!b) return;
       if (!seg) { b.group.style.display = 'none'; return; }
       b.group.style.display = 'inline-flex';
-      const rolled = seg.resetsAt && nowS > seg.resetsAt;            // window reset since the last report
-      const pct = rolled ? 0 : seg.pct;
+      // A ROLLED window (its reset passed since this reading was taken) is UNKNOWN, not 0 — the reading
+      // describes a window that has already ended (the user 2026-07-31: a machine with no live session to
+      // ask sits on a stale snapshot, and a confident 0% is indistinguishable from a genuinely idle
+      // account). Last-known fill stays, FADED, and the readout is '?'; the title dates the gap.
+      const rolled = !!(seg.resetsAt && nowS > seg.resetsAt);
+      const pct = Math.max(0, Math.min(100, seg.pct || 0));
       b.usage.fill.style.width = pct + '%';
       b.usage.fill.style.background = pct >= 90 ? '#c0392b' : (pct >= 70 ? '#e0b020' : '#54B204');
-      b.usage.txt.textContent = pct + '%';
-      // TIME through the window: 0% at the window start (resets_at − winSec), 100% at the reset.
+      b.usage.fill.style.opacity = rolled ? '0.3' : '';
+      b.usage.txt.textContent = rolled ? '?' : pct + '%';
+      // TIME through the window: 0% at the window start (resets_at − winSec), 100% at the reset. Meaningless
+      // once the window has rolled — that pace would describe a window nobody is in any more.
       let timePct = null;
-      if (seg.resetsAt && b.winSec) timePct = Math.max(0, Math.min(100, Math.round((nowS - (seg.resetsAt - b.winSec)) / b.winSec * 100)));
+      if (!rolled && seg.resetsAt && b.winSec) timePct = Math.max(0, Math.min(100, Math.round((nowS - (seg.resetsAt - b.winSec)) / b.winSec * 100)));
       b.time.row.style.display = (timePct == null) ? 'none' : 'inline-flex';
       if (timePct != null) { b.time.fill.style.width = timePct + '%'; b.time.txt.textContent = timePct + '%'; }
-      b.group.setAttribute('title', name + ' — usage ' + pct + '%' + (timePct != null ? ' · ' + timePct + '% through the window' : '') + (seg.resetsAt ? ' · resets in ' + this._fmtReset(seg.resetsAt) : ''));
+      b.group.setAttribute('title', rolled
+        ? name + ' — window reset ' + this._fmtAgo(seg.resetsAt) + ' and no reading has arrived since; current usage unknown (last known ' + pct + '%)'
+        : name + ' — usage ' + pct + '%' + (timePct != null ? ' · ' + timePct + '% through the window' : '') + (seg.resetsAt ? ' · resets in ' + this._fmtReset(seg.resetsAt) : ''));
     };
     apply('fiveHour', usage.fiveHour, 'Session (5h)');
     apply('sevenDay', usage.sevenDay, 'Weekly');
     apply('fable', usage.fable, 'Fable 5 (7d)');
+  }
+  // Compact "2d 3h 14m ago" for a reset that has already passed — how stale an UNKNOWN window's
+  // last reading is (the '?' bars above).
+  _fmtAgo(epoch) {
+    const nowS = (typeof Date !== 'undefined' && Date.now) ? Math.floor(Date.now() / 1000) : 0;
+    let dt = Math.max(0, nowS - epoch);
+    const d = Math.floor(dt / 86400); dt -= d * 86400;
+    const h = Math.floor(dt / 3600); dt -= h * 3600;
+    const m = Math.floor(dt / 60);
+    return ((d ? d + 'd ' : '') + ((h || d) ? h + 'h ' : '') + m + 'm').trim() + ' ago';
   }
   // Compact "2d 3h 14m" countdown to a reset epoch, for the usage-bar hover title.
   _fmtReset(epoch) {

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -47,6 +47,10 @@
 .ru-track { position: relative; width: auto; height: 5px; background: rgba(255, 255, 255, 0.12);
   border-radius: 3px; overflow: hidden; flex: 0 0 auto; display: block; }
 .ru-fill { position: absolute; left: 0; top: 0; height: 100%; border-radius: 3px; transition: width .3s ease; }
+/* UNKNOWN (the user 2026-07-31): the window reset since the last report, so the reading no longer
+   describes the present — last-known bars fade and the readout is "?", never a confident 0%. */
+.ru-w.ru-unk .ru-fill { opacity: 0.3; }
+.ru-w.ru-unk .ru-pct { color: #8a97a6; }
 .ru-pct { font: 600 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #cfe6ff;
   font-variant-numeric: tabular-nums; white-space: nowrap; }
 

--- a/ui/webview/strip.test.ts
+++ b/ui/webview/strip.test.ts
@@ -6,7 +6,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { usageColor, fmtReset, usageWindows, STRIP_PANES } from "./strip";
+import { usageColor, fmtAgo, fmtReset, usageWindows, STRIP_PANES } from "./strip";
 
 test("usageColor mirrors the rail's green/amber/red ramp", () => {
   assert.equal(usageColor(0), "#54B204");
@@ -38,9 +38,21 @@ test("usageWindows keeps only reported windows, clamps, and computes pace", () =
   assert.equal(ws[1].elapsedPct, 0);
 });
 
-test("a window that reset since the last report reads 0, not stale", () => {
+test("a window that reset since the last report is UNKNOWN — never a confident 0 (the user 2026-07-31)", () => {
+  // a remote whose kernel had no live session to ask sat on a days-old snapshot, and the rail drew
+  // 0% beside a live account's real bars — indistinguishable from a genuinely idle account. The
+  // last-known reading survives (drawn faded), the readout is "?", and the title dates the gap.
   const ws = usageWindows({ fiveHour: { pct: 91, resetsAt: 50 } }, 100);
-  assert.equal(ws[0].pct, 0);
+  assert.equal(ws[0].unknown, true);
+  assert.equal(ws[0].pct, 91, "the last-known reading survives for the faded fill");
+  assert.equal(ws[0].elapsedPct, null, "pace means nothing against a window that already ended");
+  assert.match(ws[0].title, /window reset .* — current usage unknown \(last known 91%\)/);
+});
+
+test("a live window is not unknown, and fmtAgo dates a gap", () => {
+  const ws = usageWindows({ fiveHour: { pct: 20, resetsAt: 200 } }, 100);
+  assert.equal(ws[0].unknown, false);
+  assert.equal(fmtAgo(100, 100 + 90060), "1d 1h 1m ago");
 });
 
 test("no usage → no windows (the strip stays quiet, never fakes bars)", () => {

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -20,8 +20,9 @@ export type UsageWindow = {
   key: string;
   label: string;        // the rail's expanded label
   short: string;        // the compressed tag a narrow strip swaps in ("5h" / "7d" / "F5")
-  pct: number;          // used % of the limit
+  pct: number;          // used % of the limit (the LAST-KNOWN reading when unknown — drawn faded)
   elapsedPct: number | null;  // % of the window elapsed (pace comparison)
+  unknown: boolean;     // the window reset since the last report — the reading no longer describes the present
   title: string;        // hover detail
 };
 
@@ -35,6 +36,14 @@ const WINS: Array<[string, number, string, string]> = [
 // The rail's usage color ramp: green under 70%, amber under 90%, red at 90+.
 export function usageColor(pct: number): string {
   return pct >= 90 ? "#c0392b" : pct >= 70 ? "#e0b020" : "#54B204";
+}
+
+export function fmtAgo(ep: number, nowS: number): string {
+  const dt = Math.max(0, nowS - ep);
+  const d = Math.floor(dt / 86400);
+  const h = Math.floor((dt % 86400) / 3600);
+  const m = Math.floor((dt % 3600) / 60);
+  return ((d ? `${d}d ` : "") + (h || d ? `${h}h ` : "") + `${m}m`).trim() + " ago";
 }
 
 export function fmtReset(resetsAt: number, nowS: number): string {
@@ -52,17 +61,24 @@ export function usageWindows(usage: any, nowS: number): UsageWindow[] {
   for (const [key, span, label, short] of WINS) {
     const seg = usage && usage[key];
     if (!seg || typeof seg.pct !== "number") continue;
-    const rolled = seg.resetsAt && nowS > seg.resetsAt;   // the window reset since the last report
-    const pct = rolled ? 0 : Math.max(0, Math.min(100, seg.pct));
+    const rolled = !!(seg.resetsAt && nowS > seg.resetsAt);   // the window reset since the last report
+    // A rolled window's reading no longer describes the PRESENT window — that is UNKNOWN, not 0
+    // (the user 2026-07-31: a remote whose kernel had no live session to ask sat on a days-old
+    // snapshot, and the rail drew a confident 0% beside a live account's real bars). The last-known
+    // fill still draws — FADED, with a "?" readout — so unknown and genuinely-empty can never be
+    // confused. Same fail-loudly rule as every other stale source.
+    const pct = Math.max(0, Math.min(100, seg.pct));
     let elapsedPct: number | null = null;
-    if (seg.resetsAt && span) {
+    if (!rolled && seg.resetsAt && span) {
       elapsedPct = Math.max(0, Math.min(100, Math.round(((nowS - (seg.resetsAt - span)) / span) * 100)));
     }
     out.push({
-      key, label, short, pct, elapsedPct,
-      title: `${label} — used ${pct}%`
-        + (elapsedPct != null ? ` · ${elapsedPct}% through the window` : "")
-        + (seg.resetsAt ? ` · resets in ${fmtReset(seg.resetsAt, nowS)}` : ""),
+      key, label, short, pct, elapsedPct, unknown: rolled,
+      title: rolled
+        ? `${label} — window reset ${fmtAgo(seg.resetsAt, nowS)} and no reading has arrived since — current usage unknown (last known ${pct}%)`
+        : `${label} — used ${pct}%`
+          + (elapsedPct != null ? ` · ${elapsedPct}% through the window` : "")
+          + (seg.resetsAt ? ` · resets in ${fmtReset(seg.resetsAt, nowS)}` : ""),
     });
   }
   return out;
@@ -177,7 +193,7 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
     usageWrap.textContent = "";
     for (const w of usageWindows(usage, nowS)) {
       const box = document.createElement("span");
-      box.className = "ru-w";
+      box.className = "ru-w" + (w.unknown ? " ru-unk" : "");
       box.title = w.title;
       // Both the expanded label and the compressed tag render; the [data-tier]
       // ladder in strip.css shows exactly one (or neither at the narrowest tier),
@@ -207,7 +223,7 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
       if (w.elapsedPct != null) bars.appendChild(mkTrack(w.elapsedPct, "#6b7a8c"));
       const pct = document.createElement("span");
       pct.className = "ru-pct";
-      pct.textContent = `${w.pct}%`;
+      pct.textContent = w.unknown ? "?" : `${w.pct}%`;   // unknown ≠ 0 — the fade + ? say "no current reading"
       box.append(name, bars, pct);
       usageWrap.appendChild(box);
     }


### PR DESCRIPTION
A second Claude account's bars showed a confident **0%** while that account was in fact heavily used (user screenshot, 2026-07-31).

Root cause: a usage reading is only ever produced by asking a **live session** on that machine (the SDK's `get_usage` control request — `refresh_usage` pokes one connected session). A host with nothing running can't ask, so its kernel keeps serving the last snapshot it took. That snapshot was 101 hours old, i.e. it predated its own `resetsAt` — and every surface treated a rolled window as `pct = 0`, so an *unreadable* window rendered exactly like an *empty* one.

Now a rolled window is **unknown**:
- the last-known fill still draws (the reading isn't discarded) but **faded**,
- the readout is `?` instead of `0%`,
- the elapsed/pace bar is withheld — pace against a window that already ended is meaningless,
- the tooltip says how long ago the window reset, that no reading has arrived since, and what the last known number was.

Applied on all three surfaces that draw these bars: the web rail (`_landing` JS + CSS), the VS Code strip (`strip.ts`/`strip.css`), and the standalone timeline copy (`romp-timeline-view.js`, which had the same `rolled ? 0` line).

Tests: `strip.test.ts` replaces the old "reads 0, not stale" expectation with the unknown contract (flag, surviving last-known pct, withheld pace, dated title) plus a `fmtAgo` check; `test_kernel_rail_usage.py` pins the rail JS, the fade CSS, the dated tooltip, and the timeline copy. Python 3786 passed; node suite green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)