### PR TITLE
An unknown usage window draws no bars at all, just a question mark

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16655,13 +16655,18 @@ det[w[0]]={name:w[3],span:w[2],pct:pct,col:col,tp:tp,unk:rolled,ago:(rolled?fmtA
 // Horizontal fill bars (the user 2026-07-05): an expanded label, then TWO stacked horizontal tracks \u2014 the
 // used-% bar (colormap colour) ON TOP of the elapsed-% bar (slate) so you can compare pace at a glance (used
 // ahead of elapsed = burning too fast) \u2014 then the used-% readout. All inline (label \u00b7 bars \u00b7 %).
+// An UNKNOWN window draws NO BARS (the user 2026-07-31, round 2): a faded last-known fill still
+// asserts a value we do not have \u2014 the length itself is the lie. Its slot holds a single '?' so the
+// rows stay aligned, and the last-known number moves to the hover, labelled as such.
 html+='<div class="ru-w'+(rolled?' ru-unk':'')+'" data-w="'+w[0]+'">'
 +'<div class=ru-name>'+w[4]+'</div>'
-+'<div class=ru-bars>'
++(rolled?'<div class=ru-bars><div class=ru-qmark>?</div></div>'
+:('<div class=ru-bars>'
 +'<div class=ru-track><i class=ru-fill style="width:'+pct+'%;background:'+col+'"></i></div>'
 +'<div class=ru-track><i class=ru-fill style="width:'+(tp||0)+'%;background:#6b7a8c"></i></div>'
 +'</div>'
-+'<div class=ru-pct>'+(rolled?'?':pct+'%')+'</div></div>';});
++'<div class=ru-pct>'+pct+'%</div>'))
++'</div>';});
 return html;}
 // ONE SET PER CLAUDE ACCOUNT (the user 2026-07-30). These windows are ACCOUNT-wide, so a fleet signed into
 // one login has one allowance and drawing it per host would repeat the same number \u2014 that is the common
@@ -16688,9 +16693,13 @@ var rest=ROWS.filter(function(r){return r.host;});
 renderRows([{host:'',acct:(u&&u.acct)||'',usage:u}].concat(rest),SELF);}
 // ONE shared tooltip for BOTH windows: per window, the used bar (colormap) over the elapsed bar (slate) +
 // the % + reset — the exact set of bars that used to sit under the timeline, nothing more.
-function barRows(d){return '<div class="ru-tip-row'+(d.unk?' ru-unk':'')+'"><span class=ru-tip-k>used</span>'
-+'<span class=ru-tip-track><i style="width:'+d.pct+'%;background:'+d.col+'"></i></span>'
-+'<span class=ru-tip-v>'+(d.unk?'?':d.pct+'%')+'</span></div>'
+function barRows(d){return (d.unk
+? '<div class="ru-tip-row ru-unk"><span class=ru-tip-k>last known</span>'
+ +'<span class=ru-tip-track><i style="width:'+d.pct+'%;background:'+d.col+'"></i></span>'
+ +'<span class=ru-tip-v>'+d.pct+'%</span></div>'
+: '<div class=ru-tip-row><span class=ru-tip-k>used</span>'
+ +'<span class=ru-tip-track><i style="width:'+d.pct+'%;background:'+d.col+'"></i></span>'
+ +'<span class=ru-tip-v>'+d.pct+'%</span></div>')
 +(d.tp!=null?'<div class=ru-tip-row><span class=ru-tip-k>elapsed</span>'
 +'<span class=ru-tip-track><i style="width:'+d.tp+'%;background:#6b7a8c"></i></span>'
 +'<span class=ru-tip-v>'+d.tp+'%</span></div>':'');}
@@ -17807,9 +17816,12 @@ def _landing():
             ".ru-bars{display:flex;flex-direction:column;gap:2px;flex:0 0 auto}"   # used bar stacked over elapsed bar
             ".ru-track{position:relative;width:54px;height:5px;background:rgba(255,255,255,0.12);border-radius:3px;overflow:hidden;flex:0 0 auto}"
             ".ru-fill{position:absolute;left:0;top:0;height:100%;border-radius:3px;transition:width .3s ease}"
-            # UNKNOWN (the user 2026-07-31): a rolled window's last-known bars fade and read '?' — never a confident 0%
-            ".ru-unk .ru-fill{opacity:.3}.ru-unk .ru-pct,.ru-tip-row.ru-unk .ru-tip-v{color:#8a97a6}"
-            ".ru-tip-row.ru-unk i{opacity:.3}"
+            # UNKNOWN (the user 2026-07-31): a rolled window draws NO bars at all — a fill of any length
+            # asserts a value we do not have — only a '?' in the bars' slot. The last-known reading survives
+            # in the tooltip, labelled "last known" and faded, which is honest because it says what it is.
+            ".ru-qmark{width:54px;display:flex;align-items:center;justify-content:center;"
+            "font:600 11px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#8a97a6}"
+            ".ru-tip-row.ru-unk i{opacity:.3}.ru-tip-row.ru-unk .ru-tip-k,.ru-tip-row.ru-unk .ru-tip-v{color:#8a97a6}"
             ".ru-pct{font:600 10px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#cfe6ff;font-variant-numeric:tabular-nums;white-space:nowrap}"
             # ONE shared hover panel for BOTH windows (the user 2026-06-26): it reproduces exactly the used/
             # elapsed bars that used to sit under the timeline — per window, a "used" bar (selected colormap)

--- a/tests/test_kernel_rail_usage.py
+++ b/tests/test_kernel_rail_usage.py
@@ -108,17 +108,24 @@ class RailUsage(unittest.TestCase):
         # '?', the elapsed (pace) bar is withheld, and the tooltip dates the gap.
         self.assertIn("var rolled=!!(seg.resetsAt&&nowS>seg.resetsAt),pct=Math.max(0,Math.min(100,seg.pct||0));",
                       self.html, "the reading survives the roll — it is last-known, not zeroed")
-        self.assertIn("(rolled?'?':pct+'%')", self.html, "the readout says unknown, never 0%")
         self.assertIn("var tp=(!rolled&&seg.resetsAt&&w[1])", self.html,
                       "no pace bar against a window that already ended")
-        self.assertIn(".ru-unk .ru-fill{opacity:.3}", self.html, "the last-known bars fade")
+        # NO BARS at all (round 2): a fill of any length asserts a value we do not have, so the bars'
+        # slot holds only a '?'. The last-known number survives in the tooltip, labelled as such.
+        self.assertIn("rolled?'<div class=ru-bars><div class=ru-qmark>?</div></div>'", self.html,
+                      "an unknown window draws a '?' where its bars would be")
+        self.assertIn(".ru-qmark{width:54px", self.html, "the mark takes the bars' width, so rows stay aligned")
+        self.assertNotIn(".ru-unk .ru-fill{opacity:.3}", self.html, "no faded fill on the face any more")
+        self.assertIn("<span class=ru-tip-k>last known</span>", self.html,
+                      "the hover is the ONE place the stale number appears, and it says what it is")
         self.assertIn("window reset '+esc(v.ago)", self.html, "the tooltip dates how stale the reading is")
         self.assertIn("current usage unknown", self.html)
         # the STANDALONE timeline copy (Obsidian) says the same thing — one rule, every surface
         tv = (pathlib.Path(BIN).parent / "ui" / "romp-timeline-view.js").read_text()
         self.assertIn("const rolled = !!(seg.resetsAt && nowS > seg.resetsAt);", tv)
         self.assertIn("b.usage.txt.textContent = rolled ? '?' : pct + '%';", tv)
-        self.assertIn("b.usage.fill.style.opacity = rolled ? '0.3' : '';", tv)
+        self.assertIn("if (track) track.style.display = rolled ? 'none' : '';", tv,
+                      "the bar itself is hidden, not faded")
         self.assertIn("current usage unknown (last known ", tv)
 
     def test_the_timeline_forwards_usage_to_the_shell_and_hides_its_own_copy_when_embedded(self):

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -1239,9 +1239,13 @@ class TimelinePanel {
       // account). Last-known fill stays, FADED, and the readout is '?'; the title dates the gap.
       const rolled = !!(seg.resetsAt && nowS > seg.resetsAt);
       const pct = Math.max(0, Math.min(100, seg.pct || 0));
+      // No BAR at all when the window is unknown (the user 2026-07-31, round 2): a fill of any length —
+      // even faded — asserts a value we do not have. The track is hidden and the readout is '?'; the
+      // last-known number stays in the hover title, said in words.
+      const track = b.usage.fill.parentElement;
+      if (track) track.style.display = rolled ? 'none' : '';
       b.usage.fill.style.width = pct + '%';
       b.usage.fill.style.background = pct >= 90 ? '#c0392b' : (pct >= 70 ? '#e0b020' : '#54B204');
-      b.usage.fill.style.opacity = rolled ? '0.3' : '';
       b.usage.txt.textContent = rolled ? '?' : pct + '%';
       // TIME through the window: 0% at the window start (resets_at − winSec), 100% at the reset. Meaningless
       // once the window has rolled — that pace would describe a window nobody is in any more.

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -48,9 +48,11 @@
   border-radius: 3px; overflow: hidden; flex: 0 0 auto; display: block; }
 .ru-fill { position: absolute; left: 0; top: 0; height: 100%; border-radius: 3px; transition: width .3s ease; }
 /* UNKNOWN (the user 2026-07-31): the window reset since the last report, so the reading no longer
-   describes the present — last-known bars fade and the readout is "?", never a confident 0%. */
-.ru-w.ru-unk .ru-fill { opacity: 0.3; }
-.ru-w.ru-unk .ru-pct { color: #8a97a6; }
+   describes the present. NO BARS are drawn — a fill of any length asserts a value we do not have —
+   just a "?" in the bars' slot, which keeps the rows aligned and survives the narrow tiers where the
+   % readout is hidden. The last-known number lives in the hover, labelled as such. */
+.ru-qmark { display: flex; align-items: center; justify-content: center; width: 100%;
+  color: #8a97a6; font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
 .ru-pct { font: 600 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #cfe6ff;
   font-variant-numeric: tabular-nums; white-space: nowrap; }
 

--- a/ui/webview/strip.test.ts
+++ b/ui/webview/strip.test.ts
@@ -146,3 +146,16 @@ test("both bundles init the strip; the web pages never opt in", () => {
   const kernel = fs.readFileSync(path.join(ROOT, "bin", "romp-kernel"), "utf8");
   assert.ok(!kernel.includes("__rompShowStrip"), "the web shell keeps its own rail — no strip opt-in kernel-side");
 });
+
+test("an unknown window draws NO bars — just a '?' in their slot (the user 2026-07-31, round 2)", () => {
+  // a faded last-known fill still asserts a value we do not have: the length itself is the lie. The
+  // mark takes the bars' slot (so rows stay aligned, and it survives the narrow tiers where the %
+  // readout is hidden), and the % readout is dropped — the "?" IS the readout.
+  const ROOT = path.resolve(process.cwd(), "..");
+  const src = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
+  const css = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.css"), "utf8");
+  assert.match(src, /if \(w\.unknown\) \{[\s\S]{0,700}q\.className = "ru-qmark";\s*\n\s*q\.textContent = "\?";/);
+  assert.match(src, /bars\.appendChild\(q\);\s*\n\s*box\.append\(name, bars\);/, "no .ru-pct on an unknown row");
+  assert.doesNotMatch(css, /\.ru-w\.ru-unk \.ru-fill \{ opacity: 0\.3; \}/, "the faded fill is gone");
+  assert.match(css, /\.ru-qmark \{ display: flex; align-items: center; justify-content: center; width: 100%;/);
+});

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -219,12 +219,25 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
         track.appendChild(fill);
         return track;
       };
-      bars.appendChild(mkTrack(w.pct, usageColor(w.pct)));
-      if (w.elapsedPct != null) bars.appendChild(mkTrack(w.elapsedPct, "#6b7a8c"));
-      const pct = document.createElement("span");
-      pct.className = "ru-pct";
-      pct.textContent = w.unknown ? "?" : `${w.pct}%`;   // unknown ≠ 0 — the fade + ? say "no current reading"
-      box.append(name, bars, pct);
+      if (w.unknown) {
+        // NO BARS AT ALL for an unknown window (the user 2026-07-31, round 2): a faded last-known fill
+        // still draws a value, and we do not have one — the length itself is the lie. The bars' slot
+        // holds a single "?" instead, keeping the row's alignment; the last-known number stays in the
+        // hover, explicitly labelled. The % readout is dropped too — the "?" IS the readout, and it
+        // survives the narrow tiers, where .ru-pct is hidden but the bars slot is always drawn.
+        const q = document.createElement("span");
+        q.className = "ru-qmark";
+        q.textContent = "?";
+        bars.appendChild(q);
+        box.append(name, bars);
+      } else {
+        bars.appendChild(mkTrack(w.pct, usageColor(w.pct)));
+        if (w.elapsedPct != null) bars.appendChild(mkTrack(w.elapsedPct, "#6b7a8c"));
+        const pct = document.createElement("span");
+        pct.className = "ru-pct";
+        pct.textContent = `${w.pct}%`;
+        box.append(name, bars, pct);
+      }
       usageWrap.appendChild(box);
     }
     fit();


### PR DESCRIPTION
Follow-up to #169. That round faded the last-known fill and swapped the readout for `?`, but as the user put it: we don't know what the value is — and a fill of any length still asserts one. The bar's **length is the claim**; fading it only makes the claim quieter.

An unknown window (its `resetsAt` already passed, so no reading has arrived for the current window) now draws:
- **no bars at all** — a single `?` occupies the bars' slot, which keeps rows aligned and survives the narrow strip tiers where the `%` readout is hidden anyway;
- **no percentage** — the `?` is the readout;
- **no pace bar** (already the case).

The last-known number isn't lost: it moves to the hover, on a row labelled `last known`, where naming it makes it honest instead of misleading. The tooltip header still dates the gap ("window reset 4d 2h ago — no reading since; current usage unknown").

All three surfaces: web rail (`_landing` JS + CSS), VS Code strip (`strip.ts`/`strip.css`), standalone timeline (`romp-timeline-view.js` — its track is hidden, not faded).

Tests updated to pin the no-bars contract on every surface (and to reject the old faded-fill CSS). Python 3786 passed; node suite green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)