### PR TITLE
release.sh: address the version PR by number, not by branch name

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -147,15 +147,26 @@ if [ "$current" != "$target" ]; then
         git add VERSION
         git commit -qm "VERSION $target" || die "nothing to commit for the version bump."
         git push -q -u "$publish" "$branch" || die "could not push $branch to $publish."
-        "$GH" pr create --repo "$UPSTREAM" --title "VERSION $target" \
-            --body "Version bump for \`$tag\`, opened by scripts/release.sh." \
+        # Address the PR by NUMBER, taken from the URL `gh pr create` prints (the user 2026-08-01).
+        # `gh pr merge <branch>` resolves the branch WITHIN --repo, and the branch lives on the FORK
+        # (rulesets block branch pushes upstream, so every PR here is fork-headed) — so it answered
+        # "no pull requests found for branch release-0.3.0" and the release died one step after
+        # opening the PR, leaving VERSION merged-but-untagged, exactly the half-finished state this
+        # script exists to prevent. A number is unambiguous in any repo.
+        pr_url="$("$GH" pr create --repo "$UPSTREAM" --title "VERSION $target" \
+            --body "Version bump for \`$tag\`, opened by scripts/release.sh.")" \
             || die "could not open the version PR."
-        "$GH" pr merge --repo "$UPSTREAM" --auto --merge "$branch" \
-            || die "could not arm auto-merge on the version PR."
+        pr="${pr_url##*/}"
+        case "$pr" in
+            ''|*[!0-9]*) die "could not read the PR number from '$pr_url'." ;;
+        esac
+        say "opened PR #$pr."
+        "$GH" pr merge "$pr" --repo "$UPSTREAM" --auto --merge \
+            || die "could not arm auto-merge on PR #$pr."
         say "waiting for the version PR to land on $REF (its CI is the first gate)..."
         state=""
         for _ in $(seq 1 120); do
-            state="$("$GH" pr view "$branch" --repo "$UPSTREAM" --json state -q .state 2>/dev/null || true)"
+            state="$("$GH" pr view "$pr" --repo "$UPSTREAM" --json state -q .state 2>/dev/null || true)"
             if [ "$state" = "MERGED" ]; then break; fi
             if [ "$state" = "CLOSED" ]; then die "the version PR was closed without merging."; fi
             if [ "$POLL" = "0" ]; then break; fi

--- a/tests/release-sh.bats
+++ b/tests/release-sh.bats
@@ -57,6 +57,9 @@ case "\$1 \$2" in
   # Auto-merge really lands the branch on origin/main, so the script's post-merge
   # fast-forward has something to pull and VERSION genuinely changes on main. Simulating
   # the merge as a no-op would let the bump path "pass" while proving nothing.
+  # `gh pr create` prints the PR URL; the script reads the NUMBER off its tail and addresses
+  # every later call by that number (a fork-headed branch is unresolvable by name — see below).
+  "pr create")  echo "https://github.com/romp-on/romp/pull/4242" ;;
   "pr merge")   if [ "\${STUB_PR_STATE:-MERGED}" = "MERGED" ]; then
                     git -C "$REPO" push -q origin HEAD:main
                 fi ;;
@@ -105,6 +108,14 @@ STUB
     [[ "$output" == *"0.1.0 → 0.2.0"* ]]
     grep -q "pr create" "$GH_LOG"
     grep -q "pr merge" "$GH_LOG"
+    # BY NUMBER, never by branch name (the user 2026-08-01): every PR here is fork-headed, because
+    # rulesets block branch pushes upstream — and `gh pr merge <branch> --repo <upstream>` cannot
+    # resolve a branch that lives on the fork. It failed with "no pull requests found for branch
+    # release-0.3.0" one step after opening the PR, leaving VERSION merged but UNTAGGED: the exact
+    # half-finished release this script exists to prevent.
+    grep -q "pr merge 4242 " "$GH_LOG"
+    grep -q "pr view 4242 " "$GH_LOG"
+    ! grep -qE "pr (merge|view) release-" "$GH_LOG"
     run git -C "$REPO" tag -l
     [ "$output" = "v0.2.0" ]
 }


### PR DESCRIPTION
Cutting **v0.3.0** died one step after opening the version PR:

```
release: VERSION 0.2.0 → 0.3.0, via a PR on release-0.3.0 (pushing to 'fork').
https://github.com/romp-on/romp/pull/171
no pull requests found for branch "release-0.3.0"
release: could not arm auto-merge on the version PR.
```

`gh pr merge <branch> --repo <upstream>` resolves the branch **within the upstream repo**, but every PR here is fork-headed — rulesets block branch pushes upstream, so push-to-fork-then-PR is the only route. So the merge never armed, and the run stopped with VERSION merged but **untagged** — precisely the half-finished state the script's header calls "the worst of those states", since `main` then claims a version `bootstrap.sh` won't install. Finishing v0.3.0 took hand-driving the PR and a re-run.

`gh pr create` prints the PR URL; the number comes off its tail and resolves in any repo regardless of where the head branch lives. The auto-merge and the state poll both use it now, and the run logs which PR it opened.

`tests/release-sh.bats`: the stub now prints a PR URL, and the bump test asserts merge/view are addressed by number and **never** by branch name. All 24 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)