### PR TITLE
A session whose card is awaiting must not read READY

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7984,7 +7984,13 @@ def _session_awaiting(sid, path, idle, stamp=False):
     # scopes it itself. This is what carries a genuinely-awaiting session's rail chip + timeline lane across a
     # restart, the same read the feed card floors to per goal via _goal_awaiting_stamp.
     if live is not None and stamp:
-        return _session_stamp_cached(sid)
+        # Source 1.75 — the blocked-yield's OWNED dispatch, the same evidence the feed card uses to put
+        # this session's card in Working (the user 2026-08-01: the card said "waiting on a background
+        # task: <GPU batch>" while every session surface read READY). LIVE evidence, so it outranks the
+        # durable stamp below. Same stamp=True gate: the session-scoped surfaces want one summary answer,
+        # while the FEED keeps scoping per goal — a session-wide _await_ok would floor every sibling card
+        # to awaiting, which is exactly what that gate has always prevented.
+        return _owned_yield_why(sid, path) or _session_stamp_cached(sid)
     return None
 
 
@@ -8170,6 +8176,67 @@ def _bg_owner_tops(fsid, path, tasks):
         rec["since"] = max(rec["since"], int(t.get("t") or 0))
         rec["descs"].append(t["desc"] or "background task")
     return out
+
+
+def _owned_yield_why(sid, path):
+    """The SESSION-level twin of the feed card's BLOCKED-YIELD (the user 2026-08-01): a top goal whose
+    rolled-up state is blocked, but whose own thread DISPATCHED a live background task AFTER that block,
+    so the card yields blocked → awaiting (build_feed's `_owned_why`). Returns that why, else None.
+
+    Why this exists as its own source: the card and the session surfaces were reading different
+    evidence and disagreeing out loud. A GPU batch dispatched from a blocked thread put the card in
+    Working saying "waiting on a background task: <desc>", while the timeline lane, rail chip and chat
+    chip all read plain READY — the session looked idle-with-nothing-happening next to its own card
+    saying otherwise. Neither of the session-level sources could see it: the live set counts only
+    launches the judge has NOT placed (a placed one is a SERVICE unless a stamp affirms it, the
+    mkdocs-serve rule), and the durable ⏳ stamps here sat on nodes the judge had since marked done,
+    which the stamp reader skips as rolled-up display state. The card's own rule was the only one
+    looking at the right thing.
+
+    Deliberately as NARROW as that card rule: it needs a live BLOCK that a dispatch from the same
+    subtree has outrun. A service under a working goal — the case the 2026-07-24 split exists to keep
+    quiet — has no block to outrun and stays furniture."""
+    tasks = _bg_live_norm(sid, path)
+    if not tasks:
+        return None
+    owned = _bg_owner_tops(sid, path, tasks)
+    if not owned:
+        return None
+    try:
+        store = jd.load_goals(sid)
+        nodes = store.get("nodes", {})
+        status = store.get("status", {}) or {}
+    except Exception:
+        return None
+    kids = {}
+    for nid, nd in nodes.items():
+        kids.setdefault(nd.get("parentId"), []).append(nid)
+
+    def _sub(top):                                  # the top's subtree (cycle-guarded, like _subtree)
+        out, stack, seen = [], [top], set()
+        while stack:
+            x = stack.pop()
+            if x in seen or x not in nodes:
+                continue
+            seen.add(x)
+            out.append(x)
+            stack.extend(kids.get(x, []))
+        return out
+
+    best = None
+    for top, own in owned.items():
+        if top not in nodes or status.get(top) != "blocked":
+            continue                                # only a BLOCKED top can yield — see the docstring
+        blk = max([nodes[x].get("mt", nodes[x].get("t", 0)) for x in _sub(top)
+                   if nodes[x].get("blocked") and not nodes[x].get("nodeComplete")
+                   and not nodes[x].get("cleared")] or [0])
+        if not blk or int(own.get("since") or 0) < blk:
+            continue                                # the dispatch predates the block → proves nothing
+        cand = (int(own["since"]), (own.get("descs") or [None])[0])
+        best = cand if best is None else max(best, cand)
+    if best is None:
+        return None
+    return "waiting on a background task%s" % ((": " + best[1]) if best[1] else "")
 
 
 def _states_awaiting_overlay(sid):
@@ -12810,6 +12877,7 @@ def build_feed(now, tmux=None):
                 api_top = f
         plain_user_t = _last_plain_user_turn_t(ps["turns"]) if ps else 0   # re-check: a plain reply after a soft block de-urgents it
         had_working = False                          # does this session show ANY working card? → drives the provisional placeholder
+        had_awaiting = False                         # …and does any of them read AWAITING? → the session's straw dot (below)
         # The live background-task set, once per session: OWNERSHIP for the blocked-yield below (any live
         # task counts there — the yield keys on the dispatch event, not on classification), and the
         # judge-classified SERVICES for the neutral per-session chip (the user 2026-07-24). Idle-gated
@@ -13036,6 +13104,7 @@ def build_feed(now, tmux=None):
                                         or (col == "blocked" and not recheck and not rejudging))
                       else "completed" if col == "completed" else "working")
             had_working = had_working or column == "working"
+            had_awaiting = had_awaiting or col == "awaiting"   # the FLAVOR, not the column: awaiting rides Working
             # distillState (the user 2026-07-21): which distilled line the CARD should show — keyed on the
             # GENUINE resolution state, NOT the transient `column`. recheck/rejudging drop a still-blocked
             # card to Working the moment its session takes a turn (de-urgent smoothing), and `column`, keyed
@@ -13178,6 +13247,15 @@ def build_feed(now, tmux=None):
         # A session actively working a brand-new ask shows NO card until the planner classifies the held
         # segment at turn-end — surface a live-prompt placeholder so it isn't invisible. Only when nothing
         # already covers it (no working card); replaced by the real card once the planner places it.
+        # THE INVARIANT (the user 2026-08-01): a card sitting in Working must be explained by something —
+        # an actively working session, a judgment in flight, an awaiting, or an error. A session whose only
+        # explanation is "one of my cards is awaiting" was reading READY at the session level while that
+        # very card said "waiting on a background task", because this dot lit ONLY from the session-wide
+        # sources (`sess_awaiting_why`), which deliberately ignore a judge-placed launch. The cards are the
+        # per-goal answer this build already computed — so take it from them. Scoped to the session's own
+        # verdicts, so no sibling card is floored by it (what the session-wide _await_ok would have done).
+        if had_awaiting and not who_working and name not in awaiting:
+            awaiting.append(name)
         if not had_working and perm_top is None and ps:   # cache-only: the live-prompt placeholder needs the parse → after the warm
             # perm_top excluded: a live-blocked focus card no longer counts as "working" (it reports needs_input
             # now), so without this guard a session whose ONLY card is the picker-blocked one would ALSO get a

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -529,6 +529,40 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(card["column"], "working", "awaiting is a flavor of working, not a new column")
         self.assertEqual((card["awaiting"] or {}).get("why"), why, "the badge carries the stamp's why")
 
+    def test_an_awaiting_card_lights_its_session_dot(self):
+        """THE INVARIANT (the user 2026-08-01): a card sitting in Working must be explained — an active
+        session, a judgment in flight, an awaiting, or an error. A session whose card read "waiting on a
+        background task" showed READY at the session level, because this dot lit only from the SESSION-wide
+        sources, which deliberately ignore a judge-placed launch (the service split) and skip stamps on
+        rolled-up nodes. The cards are the per-goal answer the same build already computed, so the dot
+        comes from them: any card in the awaiting flavour lights its session."""
+        top = SID + ":gaw2"
+        why = "a batch it launched; results get filed when it lands"
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "lastNode": top,
+            "nodes": {top: {"id": top, "text": "Run the batch", "parentId": None, "nodeComplete": False,
+                            "blocked": False, "cleared": False, "trail": [], "t": T0, "mt": T0,
+                            "awaitingWhy": why, "awaitingAt": T0 + 40,
+                            "log": [{"ev_t": T0 + 40, "src": "closer", "kind": "awaiting", "why": why, "at": 1}]}},
+            "placements": {}, "status": {top: "working"}}))
+        feed = km.build_feed(NOW)
+        card = next(a for a in feed["asks"] if a["itemId"] == top)
+        self.assertEqual((card["awaiting"] or {}).get("why"), why, "the card is awaiting…")
+        self.assertIn("testsess", feed["awaiting"], "…so its session reads awaiting, never a bare READY")
+        self.assertNotIn("testsess", feed["working"], "an idle session is not 'working' — awaiting is its own read")
+
+    def test_a_plain_working_card_does_not_light_the_awaiting_dot(self):
+        """The other half of the invariant: the dot follows the CARDS, so an ordinary working goal with
+        nothing dispatched leaves it dark (no session-wide floor, no borrowed awaiting)."""
+        top = SID + ":gplain"
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "lastNode": top,
+            "nodes": {top: {"id": top, "text": "Ordinary work", "parentId": None, "nodeComplete": False,
+                            "blocked": False, "cleared": False, "trail": [], "t": T0, "mt": T0}},
+            "placements": {}, "status": {top: "working"}}))
+        feed = km.build_feed(NOW)
+        self.assertNotIn("testsess", feed["awaiting"])
+
     def test_judge_awaiting_stamp_suppresses_the_stalled_chip(self):
         """The false-'stalled' chain, reproduced end to end: a failed-nudge record exists, the live
         awaiting sources are dark, but the goal store carries the judge's stamp — the card must wear

--- a/tests/test_kernel_owned_yield_awaiting.py
+++ b/tests/test_kernel_owned_yield_awaiting.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""A session whose CARD reads awaiting must not read READY at the session level (the user 2026-08-01).
+
+The live case: a session dispatched a long GPU batch from a thread that was carrying a block. The feed
+card yielded blocked → awaiting and said so — "waiting on a background task: <desc>" — while the timeline
+lane, the rail chip and the chat chip all showed plain READY, so at a glance the session looked idle with
+nothing happening, right next to its own card saying otherwise.
+
+Neither session-level source could see it, and both were behaving as designed:
+  * the LIVE bg-task source counts only launches the judge has NOT placed yet; once placed, a task with no
+    live ⏳ stamp is a SERVICE (the mkdocs-serve rule, 2026-07-24) — furniture, not a wait;
+  * the durable stamp source skips rolled-up nodes, and every stamp this goal had sat on sub-goals the
+    judge had since marked done.
+The feed CARD's own blocked-yield was the only rule looking at the right evidence: a dispatch from the
+blocked card's own subtree, newer than the block.
+
+So that rule becomes a session-level source too (_owned_yield_why), and the feed's straw dot is taken
+from the cards the same build already produced. The user's invariant, stated in their words: a card in
+Working must be explained by an active session, a judgment in flight, an awaiting, or an error.
+
+SYNTHETIC only: placeholder UUIDs, invented task descriptions.
+"""
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_ownyield", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-888888888888"
+TOP = SID + ":g1"
+BORN, BLOCKED, DISPATCH = 100, 200, 300      # goal minted / blocked / the background task launched
+DESC = "nightly GPU batch: done-marker watch"
+
+
+class OwnedYieldAwaiting(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.saved_jd = (km.jd.STATE, km.jd.GOALDIR)
+        km.jd.STATE = td
+        km.jd.GOALDIR = td / "goals"
+        km.jd.GOALDIR.mkdir(parents=True)
+        self.path = str(td / (SID + ".jsonl"))
+        Path(self.path).write_text("")
+        self.saved = {k: getattr(km, k) for k in ("_bg_live_norm", "_bg_placed_tops", "_tmux_sessions")}
+        # one live background task, attributed by the judge to TOP's subtree
+        km._bg_live_norm = lambda sid, path: [{"tid": "t1", "desc": DESC, "t": DISPATCH, "type": ""}]
+        km._bg_placed_tops = lambda sid, path, tids: {"t1": TOP}
+        km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": DISPATCH, "model": "",
+                                           "effort": "", "context": None, "compactPct": None,
+                                           "color": None}}
+        km._SESSION_STAMP_CACHE.clear()
+
+    def tearDown(self):
+        for k, v in self.saved.items():
+            setattr(km, k, v)
+        km.jd.STATE, km.jd.GOALDIR = self.saved_jd
+        km._SESSION_STAMP_CACHE.clear()
+        self.td.cleanup()
+
+    def _store(self, status="blocked", blocked=True, blk_t=BLOCKED):
+        nd = {"id": TOP, "text": "run the batch", "parentId": None, "nodeComplete": False,
+              "blocked": blocked, "blockWhy": "need your call" if blocked else None,
+              "cleared": False, "trail": [], "t": BORN, "mt": blk_t}
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            {"rompUuid": SID, "seq": 1, "lastNode": TOP, "placements": {},
+             "status": {TOP: status}, "nodes": {TOP: nd}}))
+
+    # ---- the rule itself ----
+
+    def test_a_dispatch_that_outran_the_block_is_the_session_awaiting_why(self):
+        self._store()
+        why = km._owned_yield_why(SID, self.path)
+        self.assertEqual(why, "waiting on a background task: " + DESC,
+                         "the same why the card shows — one story, both surfaces")
+
+    def test_a_dispatch_that_predates_the_block_proves_nothing(self):
+        # the block is the NEWER event: the thread has not moved past it, so this is a genuine needs-you
+        self._store(blk_t=DISPATCH + 50)
+        self.assertIsNone(km._owned_yield_why(SID, self.path))
+
+    def test_a_service_under_a_working_goal_stays_furniture(self):
+        # THE REGRESSION GUARD for the 2026-07-24 split: a dev server (mkdocs serve) under a working goal
+        # has no block to outrun, so it must not light awaiting anywhere.
+        self._store(status="working", blocked=False)
+        self.assertIsNone(km._owned_yield_why(SID, self.path))
+
+    def test_no_live_task_no_why(self):
+        self._store()
+        km._bg_live_norm = lambda sid, path: []
+        self.assertIsNone(km._owned_yield_why(SID, self.path))
+
+    def test_an_unattributable_launch_never_masks_a_block(self):
+        # a launch the judge cannot place owns nothing — the conservative failure the ownership rule exists
+        # for (an unproven dispatch must never dress a real needs-you as awaiting)
+        self._store()
+        km._bg_placed_tops = lambda sid, path, tids: {}
+        self.assertIsNone(km._owned_yield_why(SID, self.path))
+
+    # ---- what the session-scoped surfaces (timeline lane, rail chip, chat chip) read ----
+
+    def test_the_session_surfaces_light_from_it_when_idle(self):
+        self._store()
+        self.assertEqual(km._session_awaiting(SID, self.path, True, stamp=True),
+                         "waiting on a background task: " + DESC,
+                         "the lane/chip say awaiting instead of READY")
+
+    def test_the_feed_path_is_unchanged_no_session_wide_floor(self):
+        # stamp=False is the FEED's call: it scopes awaiting per goal, so a session-wide why here would
+        # floor every sibling card of this session to awaiting. The feed lights its dot off the CARDS.
+        self._store()
+        self.assertIsNone(km._session_awaiting(SID, self.path, True, stamp=False))
+
+    def test_an_open_turn_is_just_working(self):
+        # idle=False → an actively producing session is working, never awaiting (unchanged contract)
+        self._store()
+        self.assertIsNone(km._session_awaiting(SID, self.path, False, stamp=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**The report:** a session dispatched a long GPU batch, its feed card correctly read *"waiting on a background task: …"* in Working — and the timeline lane, rail chip and chat chip all showed plain **READY**. The session looked idle with nothing happening, right next to its own card saying otherwise.

**Why both session-level sources were blind**, each behaving exactly as designed:
- the **live** bg-task source counts only launches the judge has *not placed* yet; once placed, a task with no live ⏳ stamp is a **service** (the mkdocs-serve rule, 2026-07-24) — furniture, not a wait;
- the **durable stamp** source skips rolled-up nodes, and every stamp this goal had sat on sub-goals the judge had since marked done.

The feed card's own **blocked-yield** was the only rule reading the right evidence: a dispatch from the blocked card's own subtree, newer than the block. Verified on the live session — the why the card shows comes from that path, and the string appears nowhere in the goal store.

**The fix**
- `_owned_yield_why` makes that rule a session-level source, ranked **above** the durable stamp (live evidence), gated exactly as the stamp is (`stamp=True` — the session-scoped surfaces). The feed keeps scoping awaiting per goal, so no sibling card is floored by a session-wide `_await_ok`.
- It stays as narrow as the card rule: it needs a **live block that a dispatch has outrun**. A service under a working goal has no block to outrun and remains furniture — pinned by a regression test.
- The feed's straw dot now comes from the **cards** the same build already produced: any card in the awaiting flavour lights its session.

**The invariant**, in the user's words and now in the tests: *a card in Working must be explained by an active session, a judgment in flight, an awaiting, or an error.*

Tests: `test_kernel_owned_yield_awaiting.py` (8 — the rule, the event-order guard, the service-split regression, the unattributable-launch guard, and what each surface reads) plus two `test_kernel.py` cases for the dot. All red on the old code. Python 3796 passed; node 1577 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)