### PR TITLE
The stale-connection prompt retires itself when the resync lands

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15946,24 +15946,31 @@ function netState(s){try{if(window.parent!==window)window.parent.postMessage({ro
 // auto-reloading (foisted, jarring) or leaving them staring at stale content. In the dashboard the pane rides
 // in an iframe, so hand it to the shell's ONE #rstale reload banner; a standalone page (feed/timeline opened
 // directly) has no shell, so self-inject a minimal top bar with the same Reload action.
-function selfBar(t){try{if(document.getElementById("romp-stale-self"))return;
-var b=document.createElement("div");b.id="romp-stale-self";
+function selfBar(t,kind){try{if(document.getElementById("romp-stale-self"))return;
+var b=document.createElement("div");b.id="romp-stale-self";b.dataset.kind=kind||"conn";
 b.style.cssText="position:fixed;top:0;left:0;right:0;z-index:99999;display:flex;gap:12px;align-items:center;justify-content:center;background:#2b2d30;color:#e6e6e6;border-bottom:1px solid #4a4d51;padding:9px 14px;font:13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif";
 var m=document.createElement("span");m.textContent=t;b.appendChild(m);
 var r=document.createElement("button");r.textContent="Reload";
 r.style.cssText="font:inherit;cursor:pointer;border-radius:6px;padding:4px 11px;font-weight:600;background:#54B204;color:#0c1a00;border:1px solid #3f8a00";
 r.onclick=function(){location.reload();};b.appendChild(r);
 (document.body||document.documentElement).appendChild(b);}catch(e){}}
-function selfStale(){selfBar("romp lost the live connection, so what you see may be stale.");}
+function selfStale(){selfBar("romp lost the live connection, so what you see may be stale.","conn");}
+// …and RETIRE that prompt the moment the thing it warns about is demonstrably over (the user 2026-08-01,
+// for whom it popped on nearly every dashboard open and then just sat there): the socket reconnected AND
+// the kernel's connect-time push has landed, which IS the resync the banner offers a reload for. Fires on
+// the first non-keepalive frame after a reconnect — the event, not a timer. A BUILD prompt is untouched:
+// new code is not delivered by a resync, so only a reload can answer that one.
+function clearStale(){if(window.parent!==window){try{window.parent.postMessage({romp:"wsFresh"},"*");}catch(e){}}
+else{var b=document.getElementById("romp-stale-self");if(b&&b.dataset.kind==="conn")b.remove();}}
 function raiseStale(){if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale"},"*");}catch(e){}}else{selfStale();}}
 // BUILD drift (the user 2026-07-13): the keepalive carries the kernel's current dist token (dv); a page whose
 // baked LOADEDV is older is running outdated code against newer kernel state — prompt a reload (never auto).
 // In the dashboard the raise routes to the shell's #rstale banner (build:1 → its BUILDMSG); standalone pages
 // self-inject the same bar. Latched: one prompt per page life, cleared only by the reload it asks for.
-var buildRaised=false;
+var buildRaised=false,freshPending=false;   // freshPending: a reconnect is awaiting its resync frame
 function raiseBuild(){if(buildRaised)return;buildRaised=true;
 if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale",build:1},"*");}catch(e){}}
-else selfBar("A newer romp build is available.");}
+else selfBar("A newer romp build is available.","build");}
 function connect(){if(ws&&(ws.readyState===0||ws.readyState===1))return;   // one live attempt at a time — a lost timer + the watchdog can both call in
 connT=Date.now();var proto=location.protocol==="https:"?"wss://":"ws://";
 var active="";try{var st0=JSON.parse(localStorage.getItem(SK)||"null");active=(st0&&st0.activeId)||"";}catch(e){}
@@ -15975,9 +15982,12 @@ ws=new WebSocket(proto+location.host+"/ws?app=%s"+(wid?"&wid="+encodeURIComponen
 // socket dropped (the pane's romp loader) needs the socket's RETURN as its event to come back down. The
 // first connect deliberately doesn't fire it — nothing is waiting on it, and the loader must stay up until
 // real content lands.
-ws.onopen=function(){lastRecv=Date.now();netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];if(wasReconn){raiseStale();try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
+ws.onopen=function(){lastRecv=Date.now();netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];if(wasReconn){raiseStale();freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
 ws.onmessage=function(ev){lastRecv=Date.now();var msg;try{msg=JSON.parse(ev.data);}catch(e){return;}
 if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();return;}   // keepalive: stamped lastRecv above; carries the build token (drift → reload banner); nothing for the bundle to render
+// the first REAL frame after a reconnect is the kernel's connect-time push — the resync itself, so the
+// "what you see may be stale" prompt is answered and retires (see clearStale). Keepalives return above.
+if(freshPending){freshPending=false;clearStale();}
 if(window.__rompFed){window.__rompFed.inbound("",msg);}else{window.dispatchEvent(new MessageEvent("message",{data:msg}));}};
 // onclose: flag the shell, RE-SHOW this pane's romp loader (the user 2026-06-29, who wanted the swirling loader on
 // kernel restart), + RETRY (don't blind-reload — on a real outage the reload just fails into a dead page).
@@ -17449,8 +17459,13 @@ _STALE_JS = (
     # the prompt out from under it; Dismiss (or a reload) clears it. A pane's BUILD-drift raise (the shim's
     # keepalive dv check, the user 2026-07-13) rides the same channel with build:1 → the BUILDMSG wording;
     # buildStale latches it identically so the poll (whose own token may be current) can't clear it.
+    # {romp:'wsFresh'} — the reconnected pane's resync LANDED (its first non-keepalive frame), so the
+    # connection prompt is moot and retires itself; the user saw it on nearly every dashboard open, offering
+    # a reload for a staleness that had already healed in the background. A latched BUILD prompt survives
+    # (and re-asserts its wording): a resync delivers state, never new code, so only a reload answers it.
     "window.addEventListener('message',function(e){var m=e&&e.data;"
-    "if(m&&m.romp==='wsStale'){if(m.build){buildStale=true;show(BUILDMSG);}else{connStale=true;show(CONNMSG);}}});"
+    "if(m&&m.romp==='wsStale'){if(m.build){buildStale=true;show(BUILDMSG);}else{connStale=true;show(CONNMSG);}}"
+    "else if(m&&m.romp==='wsFresh'){connStale=false;if(buildStale)show(BUILDMSG);else box.classList.remove('show');}});"
     "rl.onclick=function(){location.reload();};"
     "dm.onclick=function(){dismissed=served;connStale=false;buildStale=false;box.classList.remove('show');};"
     "check();setInterval(check,30000);})();")

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -32,7 +32,10 @@ class DisconnectBanner(unittest.TestCase):
         # socket resyncs live. The old auto-reload-on-reopen is gone.
         # the reconnect ALSO fires romp:wsup, which is what takes the pane loader back down
         # (test_pane_loader_reconnect.py owns that half)
-        self.assertIn('if(wasReconn){raiseStale();try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}', js)
+        # …and ARMS the retire (freshPending) so the prompt clears itself when the resync frame lands
+        # (the user 2026-08-01) — see test_the_connection_prompt_retires_when_the_resync_lands
+        self.assertIn('if(wasReconn){raiseStale();freshPending=true;'
+                      'try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}', js)
         self.assertNotIn("if(everConnected){location.reload();return;}", js,
                          "the silent auto-reload-on-reconnect is replaced by a reload PROMPT")
         self.assertNotIn("ws.onclose=function(){setTimeout(function(){location.reload();},1500);};", js,
@@ -89,6 +92,37 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn("if(m.build){buildStale=true;show(BUILDMSG);}else{connStale=true;show(CONNMSG);}", km._STALE_JS)
         self.assertIn("!connStale&&!buildStale", km._STALE_JS, "the poll's clear respects both latches")
         self.assertIn("connStale=false;buildStale=false;", km._STALE_JS, "Dismiss clears both")
+
+    def test_the_connection_prompt_retires_when_the_resync_lands(self):
+        """The prompt must go away on its own once what it warns about is over (the user 2026-08-01).
+
+        It popped on nearly every dashboard open — a pane whose socket dropped-and-reconnected raises it —
+        and then sat there offering a reload for staleness the kernel's connect-time push had already
+        healed in the background. So the retire keys on that push: the FIRST non-keepalive frame after a
+        reconnect IS the resync, and it clears the prompt. An event, not a timer, and not a silent
+        auto-reload — the reload prompt still stands whenever the resync genuinely never arrives."""
+        js = km._shim("feed", 7777)
+        self.assertIn("freshPending=true", js, "a reconnect arms the retire")
+        self.assertIn("if(freshPending){freshPending=false;clearStale();}", js,
+                      "the first real frame after it fires the retire")
+        # keepalives must NOT count as a resync — the ka branch returns before the retire line
+        self.assertLess(js.index('msg.type==="ka"'), js.index("if(freshPending)"),
+                        "the keepalive early-return sits ahead of the retire")
+        self.assertIn('window.parent.postMessage({romp:"wsFresh"}', js, "embedded pane tells the shell")
+        # …and the shell drops the connection prompt on it, while a BUILD prompt survives (a resync
+        # delivers state, never new code — only a reload answers that one)
+        self.assertIn("m.romp==='wsFresh'", km._STALE_JS)
+        self.assertIn("connStale=false;if(buildStale)show(BUILDMSG);else box.classList.remove('show');",
+                      km._STALE_JS)
+
+    def test_a_standalone_page_retires_only_its_connection_bar(self):
+        # the shell-less case (feed/timeline opened directly) self-injects the same prompt; the retire must
+        # remove ONLY the connection one, so a build-drift bar is never cleared by a mere resync
+        js = km._shim("timeline", 7777)
+        self.assertIn('b.dataset.kind=kind||"conn"', js, "the self-injected bar records which prompt it is")
+        self.assertIn('selfBar("romp lost the live connection, so what you see may be stale.","conn")', js)
+        self.assertIn('selfBar("A newer romp build is available.","build")', js)
+        self.assertIn('if(b&&b.dataset.kind==="conn")b.remove();', js, "only the conn bar retires")
 
     def test_timeline_page_uses_the_shared_shim(self):
         # The timeline used to hand-roll its own WebSocket in _TIMELINE_BOOT (a copy of _shim's

--- a/tests/test_kernel_ws_heartbeat.py
+++ b/tests/test_kernel_ws_heartbeat.py
@@ -107,9 +107,10 @@ class BuildDriftBanner(unittest.TestCase):
         js = km._shim("chat", 7)
         self.assertIn('window.parent.postMessage({romp:"wsStale",build:1}', js,
                       "embedded pane routes build drift to the shell banner, tagged so it words it as a BUILD")
-        self.assertIn('selfBar("A newer romp build is available.")', js,
+        self.assertIn('selfBar("A newer romp build is available.","build")', js,
                       "standalone page self-injects the same reload bar")
-        self.assertIn("var buildRaised=false;", js)   # latched: one prompt per page life
+        self.assertIn("var buildRaised=false,freshPending=false;", js)   # latched: one prompt per page life
+        #                                    (freshPending rides along: the CONN prompt's self-retire, 2026-08-01)
 
     def test_every_pane_page_passes_its_version_to_the_shim(self):
         for app in ("chat", "feed", "fleet", "timeline"):

--- a/tests/test_pane_loader_reconnect.py
+++ b/tests/test_pane_loader_reconnect.py
@@ -64,8 +64,10 @@ class PaneLoaderReconnect(unittest.TestCase):
         """A first connect must NOT fire it: the loader is legitimately up during a cold load and has to
         stay there until real content lands (an 8s timer that hid it early was the 2026-07-03 bug)."""
         shim = km._shim("chat")
-        self.assertIn('if(wasReconn){raiseStale();try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}',
-                      shim, "wsup rides the same wasReconn gate as the reload prompt")
+        self.assertIn('if(wasReconn){raiseStale();freshPending=true;'
+                      'try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}',
+                      shim, "wsup rides the same wasReconn gate as the reload prompt (which now also arms "
+                            "its own retire — the user 2026-08-01)")
         self.assertIn("var wasReconn=everConnected;everConnected=true;", shim,
                       "and wasReconn still means 'this socket had connected before'")
 


### PR DESCRIPTION
Opening the dashboard nearly always raised the "romp lost the live connection… what you see may be stale" box with Reload / Dismiss — and it then sat there, because the reconnect it was warning about had usually already completed in the background.

It is raised on a pane's socket dropping-and-reconnecting. But the kernel pushes **full state on connect**, so the staleness heals moments later on its own; the prompt was outliving its own cause and had to be dismissed by hand every time.

**The retire keys on the event the prompt was approximating**: the first **non-keepalive** frame after a reconnect *is* that connect-time push, so the pane posts `{romp:'wsFresh'}` and the shell drops the prompt. Keepalives return before the check, so a quiet socket never counts as a resync — and if the push genuinely never arrives, the prompt stands, which is exactly the case where a reload is the right answer. No timer, and no auto-reload: `prefer-reload-banner-not-auto` is untouched.

- A latched **BUILD** prompt survives and re-asserts its wording — a resync delivers state, never new code, so only a reload answers it.
- The shell-less pages (feed/timeline opened directly) tag their self-injected bar with which prompt it is, so the retire can never clear a build bar.

Tests: two new cases in `test_kernel_disconnect_banner.py` (both red on the old code), including the keepalive-ordering guard and the build-bar exemption. Three pre-existing source pins updated for the strings this extends. Python 3798 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)