### PR TITLE
Arm the stale-connection prompt for a second instead of raising it at once

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15960,9 +15960,20 @@ function selfStale(){selfBar("romp lost the live connection, so what you see may
 // the kernel's connect-time push has landed, which IS the resync the banner offers a reload for. Fires on
 // the first non-keepalive frame after a reconnect — the event, not a timer. A BUILD prompt is untouched:
 // new code is not delivered by a resync, so only a reload can answer that one.
-function clearStale(){if(window.parent!==window){try{window.parent.postMessage({romp:"wsFresh"},"*");}catch(e){}}
+function clearStale(){if(staleTimer){clearTimeout(staleTimer);staleTimer=0;}   // armed but never shown → nothing to see
+if(window.parent!==window){try{window.parent.postMessage({romp:"wsFresh"},"*");}catch(e){}}
 else{var b=document.getElementById("romp-stale-self");if(b&&b.dataset.kind==="conn")b.remove();}}
 function raiseStale(){if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale"},"*");}catch(e){}}else{selfStale();}}
+// ARM it rather than show it (the user 2026-08-01): the resync almost always lands within a beat of the
+// reconnect, so raising immediately made the prompt FLASH up and straight back down on nearly every
+// dashboard open — visual noise for a problem that fixed itself. A short arming window lets the common
+// case pass in silence, and clearStale below disarms it the moment the resync frame arrives.
+// Why a timer here, against the standing preference for events: the prompt asserts "your view MAY be
+// stale", and the only proof it is NOT is the resync landing — an event we key on. The only proof it IS
+// is that resync FAILING to arrive, which has no event to key on at all. So the window is exactly the
+// unavoidable minimum, and the event still wins whenever it exists.
+var staleTimer=0;
+function armStale(){if(staleTimer)return;staleTimer=setTimeout(function(){staleTimer=0;raiseStale();},1000);}
 // BUILD drift (the user 2026-07-13): the keepalive carries the kernel's current dist token (dv); a page whose
 // baked LOADEDV is older is running outdated code against newer kernel state — prompt a reload (never auto).
 // In the dashboard the raise routes to the shell's #rstale banner (build:1 → its BUILDMSG); standalone pages
@@ -15982,7 +15993,7 @@ ws=new WebSocket(proto+location.host+"/ws?app=%s"+(wid?"&wid="+encodeURIComponen
 // socket dropped (the pane's romp loader) needs the socket's RETURN as its event to come back down. The
 // first connect deliberately doesn't fire it — nothing is waiting on it, and the loader must stay up until
 // real content lands.
-ws.onopen=function(){lastRecv=Date.now();netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];if(wasReconn){raiseStale();freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
+ws.onopen=function(){lastRecv=Date.now();netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];if(wasReconn){armStale();freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
 ws.onmessage=function(ev){lastRecv=Date.now();var msg;try{msg=JSON.parse(ev.data);}catch(e){return;}
 if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();return;}   // keepalive: stamped lastRecv above; carries the build token (drift → reload banner); nothing for the bundle to render
 // the first REAL frame after a reconnect is the kernel's connect-time push — the resync itself, so the
@@ -16014,7 +16025,7 @@ if(ws.readyState===3&&Date.now()-connT>8000){connect();}},5000);
 // foregrounded, if the socket isn't open or has gone quiet past the watchdog window, treat the view as stale —
 // prompt at once AND force a reconnect (which resyncs live), rather than leaving the user on a frozen frame.
 document.addEventListener("visibilitychange",function(){if(document.visibilityState!=="visible"||!everConnected)return;
-if(!ws||ws.readyState!==1||Date.now()-lastRecv>STALE_MS){raiseStale();
+if(!ws||ws.readyState!==1||Date.now()-lastRecv>STALE_MS){armStale();freshPending=true;
 try{if(ws&&ws.readyState<=1)ws.close();}catch(e){}   // OPEN or stuck-CONNECTING both die here → onclose retries
 if(!ws||ws.readyState===3)connect();}});})();
 """ % (app, int(v), app, app)

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -34,7 +34,7 @@ class DisconnectBanner(unittest.TestCase):
         # (test_pane_loader_reconnect.py owns that half)
         # …and ARMS the retire (freshPending) so the prompt clears itself when the resync frame lands
         # (the user 2026-08-01) — see test_the_connection_prompt_retires_when_the_resync_lands
-        self.assertIn('if(wasReconn){raiseStale();freshPending=true;'
+        self.assertIn('if(wasReconn){armStale();freshPending=true;'
                       'try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}', js)
         self.assertNotIn("if(everConnected){location.reload();return;}", js,
                          "the silent auto-reload-on-reconnect is replaced by a reload PROMPT")
@@ -47,10 +47,11 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn('window.parent.postMessage({romp:"wsStale"}', js, "embedded pane hands off to the shell banner")
         self.assertIn("function selfStale()", js, "standalone page (no shell) gets its own reload bar")
         self.assertIn("romp-stale-self", js)
-        # visibility fast-path: a foregrounded tab whose socket is dead/quiet prompts at once (not after the
-        # throttled 5s watchdog), and forces a reconnect to resync.
+        # visibility fast-path: a foregrounded tab whose socket is dead/quiet ARMS the prompt at once (not
+        # after the throttled 5s watchdog), and forces a reconnect to resync — which disarms it again if the
+        # resync lands inside the arming window (the user 2026-08-01).
         self.assertIn('document.addEventListener("visibilitychange"', js)
-        self.assertIn("Date.now()-lastRecv>STALE_MS){raiseStale();", js)
+        self.assertIn("Date.now()-lastRecv>STALE_MS){armStale();freshPending=true;", js)
 
     def test_shim_reconnect_loop_cannot_die(self):
         # The retry chain used to hang entirely off onclose, and the watchdog only ever closed OPEN
@@ -103,6 +104,14 @@ class DisconnectBanner(unittest.TestCase):
         auto-reload — the reload prompt still stands whenever the resync genuinely never arrives."""
         js = km._shim("feed", 7777)
         self.assertIn("freshPending=true", js, "a reconnect arms the retire")
+        # …and the prompt is ARMED, not shown (the user 2026-08-01): raising it at once made it flash up
+        # and straight back down on nearly every dashboard open, since the resync lands within a beat.
+        self.assertIn("staleTimer=setTimeout(function(){staleTimer=0;raiseStale();},1000)", js,
+                      "a one-second arming window, not an immediate raise")
+        self.assertIn("if(wasReconn){armStale();", js, "the reconnect ARMS it")
+        self.assertNotIn("if(wasReconn){raiseStale();", js, "…and never raises it outright")
+        self.assertIn("if(staleTimer){clearTimeout(staleTimer);staleTimer=0;}", js,
+                      "a resync inside the window disarms it, so it never appears at all")
         self.assertIn("if(freshPending){freshPending=false;clearStale();}", js,
                       "the first real frame after it fires the retire")
         # keepalives must NOT count as a resync — the ka branch returns before the retire line
@@ -114,6 +123,13 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn("m.romp==='wsFresh'", km._STALE_JS)
         self.assertIn("connStale=false;if(buildStale)show(BUILDMSG);else box.classList.remove('show');",
                       km._STALE_JS)
+
+    def test_the_foregrounded_tab_path_arms_the_same_way(self):
+        # a tab foregrounded onto a dead socket forces a reconnect and used to prompt immediately; that
+        # reconnect resyncs like any other, so it arms the same window and disarms on the same frame
+        js = km._shim("chat", 7777)
+        self.assertIn("Date.now()-lastRecv>STALE_MS){armStale();freshPending=true;", js)
+        self.assertNotIn("STALE_MS){raiseStale();", js)
 
     def test_a_standalone_page_retires_only_its_connection_bar(self):
         # the shell-less case (feed/timeline opened directly) self-injects the same prompt; the retire must

--- a/tests/test_pane_loader_reconnect.py
+++ b/tests/test_pane_loader_reconnect.py
@@ -64,7 +64,7 @@ class PaneLoaderReconnect(unittest.TestCase):
         """A first connect must NOT fire it: the loader is legitimately up during a cold load and has to
         stay there until real content lands (an 8s timer that hid it early was the 2026-07-03 bug)."""
         shim = km._shim("chat")
-        self.assertIn('if(wasReconn){raiseStale();freshPending=true;'
+        self.assertIn('if(wasReconn){armStale();freshPending=true;'
                       'try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}',
                       shim, "wsup rides the same wasReconn gate as the reload prompt (which now also arms "
                             "its own retire — the user 2026-08-01)")


### PR DESCRIPTION
Follow-up to #174. Retiring the prompt when the resync lands stopped it *sitting* there, but it still **flashed**: raised the instant the socket reconnected, gone a beat later when the kernel's connect-time push arrived. On nearly every dashboard open that's a box appearing and vanishing for a problem that fixed itself.

It's now **armed for one second** rather than shown. The resync frame disarms it, so the common case passes in silence and the prompt appears only when the resync genuinely doesn't arrive — exactly when a reload is the answer. Both raise paths arm identically: the reconnect, and a tab foregrounded onto a dead socket (which forces a reconnect and so resyncs like any other).

**On the timer**, against the repo's standing preference for events: the prompt asserts the view *may* be stale. The proof it is **not** is the resync landing — an event, and the one that disarms it. The proof it **is** is that resync *failing* to arrive, which has no event to key on at all. So the window is the unavoidable minimum, and the event wins whenever it exists.

Tests: the arming window, that neither path raises outright, and that a resync inside the window disarms it (red on the old code). Three pre-existing pins updated. Python 3799 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)