### PR TITLE
A repeated message is not a compaction replay

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -545,6 +545,7 @@ class FileAdapter:
         # already-done (even CLEARED) goal. Identify replays in CHRONOLOGICAL order (the main emit loop below
         # is leaf-first) so we keep the ORIGINAL and drop the later replay — then placements dedup still holds.
         replay_uuids, _seen_text, _compacted = set(), set(), False
+        _seen_exact, _restoring = set(), False   # (second, text) ever seen; inside a restore burst?
         summaries, last_boundary = {}, None   # boundary_uuid -> the compaction SUMMARY text (the isCompactSummary
         #   user record that FOLLOWS each compact_boundary — Claude's "what it kept"; captured here to attach to
         #   the boundary atom, so the chat can show it in a collapsible box, the user 2026-07-07).
@@ -555,7 +556,10 @@ class FileAdapter:
                 continue
             if r.get("type") == "system" and r.get("subtype") == "compact_boundary":
                 _compacted = True
+                _restoring = True          # the restore burst starts here and ends at the next assistant
                 last_boundary = u
+            elif r.get("type") == "assistant":
+                _restoring = False         # work resumed → anything later is new, not restored context
             elif r.get("type") == "user" and r.get("isCompactSummary") is True:
                 stext = _text_of(_content(r.get("message")))
                 if last_boundary and stext:            # attach to the boundary just seen; cap for transport
@@ -564,7 +568,31 @@ class FileAdapter:
             elif r.get("type") == "user" and not r.get("isMeta"):
                 txt = _text_of(_content(r.get("message")))
                 if txt:
-                    replay_uuids.add(u) if (_compacted and txt in _seen_text) else _seen_text.add(txt)
+                    # A REPLAY is one of two measured shapes, and neither is "this text was said before"
+                    # (the user 2026-08-01). Text alone identified something else entirely: any message a
+                    # person ever repeats. Once a session had compacted, the SECOND "Now?", "retry",
+                    # "[Request interrupted by user]" or romp notice was read as a replay of the first and
+                    # dropped from the chat outright, however many days apart — the live case was a
+                    # one-word question whose ANSWER rendered while the question itself did not, in a
+                    # session that had compacted two days earlier. Over 22 compacted transcripts, 179
+                    # duplicate texts differ in timestamp (genuine repeats, all being eaten) against 90
+                    # that share one. So:
+                    #   * a VERBATIM re-write — same text at the same SECOND — is the same record written
+                    #     twice (resume/compaction re-splice; the absorbed-send dedupe below has keyed on
+                    #     exactly this pair all along, and its comment records x2 as common, x24 once);
+                    #   * a RESTORED TAIL — duplicate text inside the burst that follows a boundary, before
+                    #     any assistant work resumes — is the shape this guard was written for.
+                    # Outside those, a repeat is a message the person actually sent, and it renders.
+                    # The exact-pair case needs NO compaction gate: a re-write carries the original's
+                    # timestamp, so this chronological walk meets it right beside the original — before
+                    # the boundary that produced it — and gating on _compacted would never fire. It is
+                    # the same record either way. Only the restore-burst case is compaction-scoped.
+                    key = (int(parse_z(r.get("timestamp")) or 0), txt)
+                    if key in _seen_exact or (_compacted and _restoring and txt in _seen_text):
+                        replay_uuids.add(u)
+                    else:
+                        _seen_exact.add(key)
+                        _seen_text.add(txt)
         # Skill tool_use block ids: the anchor for the NEW skill-instructions shape (2026-07-10). Newer
         # CLIs inject the payload as an isMeta user record whose sourceToolUseID names the invoking Skill
         # tool_use — the text no longer starts with the "Base directory for this skill:" preamble

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -139,7 +139,7 @@ JUDGE_FAIL_CAP = 3                       # the same rule for every other retryin
 #                                          model actually wrote. Closer / grouper / consolidator / courier; the
 #                                          planner (PLAN_PARSE_RETRIES) and distiller/briefer (DISTILL_FAIL_CAP)
 #                                          already had their own.
-PLACEMENTS_V = 6                         # placements-identity schema version (plan P2, the user 2026-07-06).
+PLACEMENTS_V = 7                         # placements-identity schema version (plan P2, the user 2026-07-06).
 #                                          v2 (2026-07-09): a 07-07/07-08 change to segment-text derivation
 #                                          stepped the text hash without this bump — dormant segments' old-hash
 #                                          placements stopped matching, and every restart/touch replayed them as
@@ -172,6 +172,14 @@ PLACEMENTS_V = 6                         # placements-identity schema version (p
 #                                          unplaced units SEALED (placements[key]=None) so dormant history can't
 #                                          replay as fresh work — the 2026-07-06 replay storm (4cdbe44 → 199118f),
 #                                          made structural. Mirrors the caption cache's v4→v5 bump.
+#                                          v7 (2026-08-01): the post-compaction replay guard keyed on TEXT
+#                                          ALONE, so in any session that had ever compacted, the second time
+#                                          anyone repeated a phrase — "Now?", "retry", a romp notice — it was
+#                                          dropped as restored context. Scoping it to verbatim (same second)
+#                                          re-writes and to the restore burst itself GROWS the atom set of
+#                                          every compacted transcript (one live session: 5825 → 5850 atoms,
+#                                          25 messages recovered). Exactly v3's shape — a bigger atom set,
+#                                          not a shifted hash — so it takes the same seal.
 PLAN_SESSIONS = None                     # per-pass session cap — REMOVED (the user 2026-06-30): the fairness
                                          # caps were a recurring source of confusing starvation bugs (a goal/
                                          # nudge stuck behind a full per-pass window), never clearly needed.

--- a/tests/test_event_model_golden.py
+++ b/tests/test_event_model_golden.py
@@ -602,6 +602,50 @@ class Compaction(unittest.TestCase):
         self.assertIn("u1", uuids, "the pre-compaction original survives")
         self.assertIn("u3", uuids, "genuine new work survives")
 
+    def test_a_repeat_of_an_old_message_is_not_a_replay(self):
+        """THE BUG (the user 2026-08-01): a message they sent, answered by the session, absent from the chat.
+
+        The replay guard keyed on TEXT ALONE, so once a session had compacted, the second time anyone said
+        a thing they had said before — "Now?", "retry", "[Request interrupted by user]", a romp notice —
+        it was read as restored context and dropped, however many days apart. The reply still rendered,
+        which is what made it look like the chat had lost a message rather than dropped one on purpose.
+        A repeat AFTER work resumed is a message the person actually sent."""
+        with tempfile.TemporaryDirectory() as td:
+            recs = [uline(T0, "Now?", "u1", ps="typed"),
+                    aline(T0 + 30, "not yet", "a1", "u1", stop="end_turn"),
+                    compact_line(T0 + 500, "c1", logical_parent="a1"),
+                    compact_summary_line(T0 + 505, "cs1", parent="c1"),
+                    aline(T0 + 600, "carrying on", "a2", "cs1", stop="end_turn"),
+                    uline(T0 + 90000, "Now?", "u2", "a2", ps="sdk"),        # the SAME word, a day later
+                    aline(T0 + 90030, "333/358 done", "a3", "u2", stop="end_turn")]
+            p = Path(td) / (SID + ".jsonl")
+            p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+            out = em.parse_session(str(p), rompuuid=SID, dir="/TESTDIR", candidate_files=[str(p)],
+                                   postal_log=[], now=NOW)
+        uuids = [a.get("uuid") for t in out["turns"] for a in t["atoms"]]
+        self.assertIn("u2", uuids, "the repeat is a real message and must render")
+        self.assertIn("u1", uuids, "…and so does the original")
+        self.assertIn("a3", uuids, "the reply was never in doubt — which is what made the loss confusing")
+
+    def test_a_verbatim_rewrite_at_the_same_second_is_still_deduped(self):
+        # the other measured replay shape: the SAME record written twice (resume/compaction re-splice),
+        # identical text at an identical timestamp — deduped wherever it lands, restore burst or not.
+        with tempfile.TemporaryDirectory() as td:
+            recs = [uline(T0, "do task X", "u1", ps="typed"),
+                    aline(T0 + 30, "did X", "a1", "u1", stop="end_turn"),
+                    compact_line(T0 + 500, "c1", logical_parent="a1"),
+                    compact_summary_line(T0 + 505, "cs1", parent="c1"),
+                    aline(T0 + 600, "carrying on", "a2", "cs1", stop="end_turn"),
+                    uline(T0, "do task X", "u2", "a2", ps="sdk"),          # same text AND same second as u1
+                    aline(T0 + 700, "again", "a3", "u2", stop="end_turn")]
+            p = Path(td) / (SID + ".jsonl")
+            p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+            out = em.parse_session(str(p), rompuuid=SID, dir="/TESTDIR", candidate_files=[str(p)],
+                                   postal_log=[], now=NOW)
+        uuids = [a.get("uuid") for t in out["turns"] for a in t["atoms"]]
+        self.assertNotIn("u2", uuids, "a verbatim re-write is the same record, not a second message")
+        self.assertIn("u1", uuids)
+
     def test_pre_compaction_turn_survives_via_logical_parent(self):
         out = run_scenario("compaction_atom")
         uuids = [a.get("uuid") for t in out["turns"] for a in t["atoms"]]

--- a/tests/test_placements_canary.py
+++ b/tests/test_placements_canary.py
@@ -79,7 +79,8 @@ RECORDS = [
     aline(T0 + 4020, "Resuming after compaction.", "a5", "cb1"),
 ]
 
-# The pinned derivation, recorded under PLACEMENTS_V = 6 (2026-07-22; the LAST id — a text-less segment
+# The pinned derivation, recorded under PLACEMENTS_V = 7 (2026-08-01; the derivation itself is unchanged
+# since v6 — v7 seals for a GROWN atom set, the replay-guard scoping. The LAST id — a text-less segment
 # — moved off the shared sha1('') hash da39a3ee onto its anchor atom's uuid, so text-less seams no longer
 # alias each other; the four text-bearing ids above are unchanged, they still key on content).
 EXPECTED_SEG_IDS = [
@@ -111,7 +112,7 @@ class PlacementIdentityCanary(unittest.TestCase):
         # without a bump) should both fail loudly.
         # v6 (2026-07-22, the uuid-anchored text-less seg id) shifted the LAST pinned id off da39a3ee;
         # text-bearing ids are unchanged. Pins and version re-recorded together.
-        self.assertEqual(jd.PLACEMENTS_V, 6, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=6 — "
+        self.assertEqual(jd.PLACEMENTS_V, 7, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=7 — "
                          "re-pin the ids and this version together, in the same commit")
 
 


### PR DESCRIPTION
**Reported as:** a message sent to a session, answered by it, and absent from the chat.

**Root cause** — `kernel/event_model.py`, the post-compaction replay pre-pass:

```python
replay_uuids.add(u) if (_compacted and txt in _seen_text) else _seen_text.add(txt)
```

Keyed on **text alone**, with no time bound and no scope. So once a session had ever compacted, the second time anyone said something they'd said before — `Now?`, `retry`, `[Request interrupted by user]`, a romp notice — it was classified as restored context and dropped from the atom stream, however many days apart. The reply still rendered, which is what made it look like the chat had *lost* a message rather than discarded one deliberately. The live case: a one-word question whose answer appeared while the question never did, in a session that had compacted two days earlier.

**Measured, not assumed** — across 22 compacted transcripts, a replay is one of two shapes, and neither is "this text was said before":
- **90** duplicate texts share a timestamp — the same record written twice by a resume/compaction re-splice (the sibling absorbed-send dedupe already keys on that pair, and its comment records ×2 as common, ×24 once);
- **179** differ — genuine repeats, every one being eaten.

**The fix** drops a duplicate only when it's a verbatim re-write (same text, same second, wherever it lands — no compaction gate, since such a record carries the *original's* timestamp and so meets the walk beside it) or when it falls inside the restore burst after a boundary, before any assistant work resumes — the shape the guard was written for. Anything later is a real message.

Verified on the reporting session: **5825 → 5850 atoms, 25 recovered messages**, and the reported message renders at its real time as `author=human`.

**`PLACEMENTS_V` 6 → 7**, per the documented deploy rule. This grows the atom set of every compacted transcript — v3's shape exactly ("a bigger atom set needs the bump just as much as a shifted hash", after two dormant sessions replayed a morning as fresh goals) — so older stores seal their ready-unplaced history instead of replaying it.

Tests: two new golden cases (the day-later repeat renders; the same-second re-write still dedupes), both red on the old code; the existing `test_post_compaction_replay_is_deduped` still passes unchanged. Python 3801, node 1577, canary re-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)