### PR TITLE
Judge the nudge's stall read against the newest turn romp saw end

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -265,6 +265,14 @@ STALL_SEEN = 2
 # live-verify existed for: a record that freezes holding a judging claim now simply says nothing.
 WHY_JUDGING = "romp's own review of this session is mid-flight"
 _WHY_JUDGING_LEGACY = "a judge pass is mid-flight"
+# The fire list's own hold (2026-08-01), minted by the kernel under the same one-definition rule and
+# screened the same way: a judge has ruled on a turn romp has not yet seen END, so the "it looks stalled"
+# read describes a world one turn old and the fire stands down until that turn lands. Like the judging
+# hold it is a beat romp is working through — it clears on the turn's own end event — so it must never
+# paint a chip. It carries a why (and the backstop every deferral record rides) purely so the hold is
+# INSPECTABLE: this drop used to leave NO record anywhere, which is how a card sat in Working for half an
+# hour with nothing to read (see the kernel's _nudge_fire_list).
+WHY_TURN_IN_FLIGHT = "a judge has ruled on a turn that hasn't finished yet"
 # The CONSOLIDATOR (the user 2026-06-19): the grouper's twin for the COMPLETED column. The working grouper
 # only ever sees OPEN tops, so related goals that finish before they get
 # grouped land as separate cards. The consolidator groups related ALL-COMPLETED sibling tops under a
@@ -7573,7 +7581,8 @@ def stall_llm(goal_text, work_text, holding):
 
 def stall_why_stands(why, fsid):
     """True when a recorded stall reason is one the card should PRESENT. The judging reasons never are
-    (the user 2026-07-31, superseding the 2026-07-25 live-verify): a goal the gate holds because romp's
+    (the user 2026-07-31, superseding the 2026-07-25 live-verify), nor is the fire list's turn-in-flight
+    hold (2026-08-01, same argument — see WHY_TURN_IN_FLIGHT): a goal the gate holds because romp's
     own review is mid-flight is a goal romp is actively working, and calling that "stalled" drew the
     user's eye to a state nobody needs to act on — the Analyzing… swirl already tells that story, with
     the nudge hold in its tip (spin-caption.ts). The hold itself is untouched; this predicate only
@@ -7581,7 +7590,7 @@ def stall_why_stands(why, fsid):
     predicate can't reach, and their own passes reconcile the records that carry them. `fsid` is the
     record's session, kept for the next reason that needs live verification against it (the retired
     judging branch checked active_runs here)."""
-    return why not in (WHY_JUDGING, _WHY_JUDGING_LEGACY)
+    return why not in (WHY_JUDGING, _WHY_JUDGING_LEGACY, WHY_TURN_IN_FLIGHT)
 
 
 def stalled_facts(fsid):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2794,6 +2794,10 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
     arm = next((tn for tn in reversed(turns) if tn.get("ended") and not _turn_romp_injected(tn)), None)
     arm_id = arm.get("id") if arm else None          # None (romp-only history) → never FIRE; an already-
     #                                                  nudged goal still takes its nudge-failed stamp below
+    # The newest turn romp has SEEN END — the yardstick the fire list judges "newer evidence" against, and
+    # deliberately NOT the arm: a romp-injected turn can never become the arm, so a verdict about one is
+    # newer than the arm FOREVER (see _nudge_fire_list's deadlock note).
+    seen = next((tn for tn in reversed(turns) if tn.get("ended")), None)
     store = jd.load_goals(sid)
     # Don't nudge until the CLOSER has classified this turn AT ITS CURRENT SIZE (session-level gate). A turn
     # that ENDS by asking you a question is "working" only in the window before the closer marks its goal
@@ -2917,8 +2921,14 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
         # asked. The verdict's LANDING is the event; re-reading the store at send time keys on it and
         # closes the race to the file write itself. An unreadable re-read fires on the tick's snapshot,
         # as before — never silently drops the nudge.
+        # A goal the fire list HOLDS is deferred, never dropped (the user 2026-08-01): it takes a deferral
+        # record like every other reviver, so the hold is inspectable and inherits the 6h backstop. The
+        # silent drop is what let the arm deadlock below hide — no fire, no record, nothing to read.
         try:
-            to_fire = _nudge_fire_list(jd.load_goals(sid), to_fire, arm_t=arm.get("t") or 0)
+            held = []
+            to_fire = _nudge_fire_list(jd.load_goals(sid), to_fire, arm_t=arm.get("t") or 0,
+                                       seen_t=(seen.get("t") or 0) if seen else 0, held=held)
+            to_fire += [f for f in held if _nudge_deferred_ok(f[0], jd.WHY_TURN_IN_FLIGHT, now, sid)]
         except Exception:
             pass
     if len(to_fire) == 1:
@@ -2931,6 +2941,8 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
         Sessions.backend_for(sid).send(sid, _nudge_bundle_body(
             [f[0] for f in to_fire], nodes, {f[0] for f in to_fire if f[2]}))
     for gid, count, stalled in to_fire:
+        _nudge_deferred_ok(gid, "", now, sid)        # the hold is over — drop any deferral record so a stale
+        #                                              why can never outlive the wait it described
         _mark_auto_nudged(gid, arm_id, count, len(arm.get("atoms") or []), at=now)   # {count, lastTurnId, armAtoms, at} → re-arm only on the next GENUINE ended-working turn; a fresh record resets `failed`
         _log_nudge_event(sid, gid, now, count)       # timeline romp-logo dot + escalation count
         nudged[gid] = {"count": count, "lastTurnId": arm_id}   # mirror in-memory for the rest of this tick
@@ -2948,7 +2960,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
     return fired
 
 
-def _nudge_fire_list(fresh, to_fire, arm_t=None):
+def _nudge_fire_list(fresh, to_fire, arm_t=None, seen_t=None, held=None):
     """The subset of this tick's due nudges still worth sending, judged against a FRESH store read
     (the closer-race guard — see the call site). A goal the judges moved off plain 'working' since the
     tick's snapshot — completed, blocked, cleared, or status-rolled — gets no status check: the answer
@@ -2971,18 +2983,42 @@ def _nudge_fire_list(fresh, to_fire, arm_t=None):
     silently: no fire, no deferral, no failed-nudge escalation (the arm can't move while the session
     idles), for any goal that audit touched. A ruling about the arm turn that leaves the goal working
     IS the closer-gate's considered 'working' verdict — the definition of nudgeable, not staleness;
-    one that resolves the goal is caught by the status re-read below either way."""
+    one that resolves the goal is caught by the status re-read below either way.
+
+    seen_t = the newest turn romp has watched END, which is the yardstick the guard actually wants; the
+    arm is only its floor. They differ exactly when a ROMP-INJECTED turn ended after the arm — and since
+    an injected turn can never BE the arm (that is the whole point of the arm), a verdict about one is
+    newer than the arm permanently, and keying on the arm alone deadlocked (the user 2026-08-01): a
+    kernel restart cut a session mid-turn, the resume notice romp injected opened the next turn, the
+    session answered in it, the unblocker ruled the card's question answered off that turn — and the
+    goal, back to plain 'working' on an idle session, was dropped by this guard on every tick for as
+    long as the session stayed idle. Nothing could break it: the arm moves only on a GENUINE ended
+    turn, and the only thing that would have produced one was the nudge itself. The card sat in
+    Working with no nudge, no block, no ⏳, nothing being judged, until the user noticed by eye.
+    Once a turn has ENDED, a verdict about it that leaves the goal working is the considered verdict —
+    the same reasoning the 2026-07-30 fix made for the arm turn, which is just this turn's floor.
+
+    `held` (optional list) collects the goals dropped for newer evidence, so the caller can record the
+    hold as a DEFERRAL instead of a silent drop — every other nudge hold leaves a why and rides the 6h
+    backstop, and this one leaving nothing is what made the deadlock unreadable from the state dir."""
     nodes, status = fresh.get("nodes", {}) or {}, fresh.get("status", {}) or {}
+    cut = max(arm_t or 0, seen_t or 0)
     keep = []
     for f in to_fire:
         if f[0] not in nodes:
             continue                                 # gone from the fresh store: cleared + compacted mid-tick
         nd = nodes[f[0]]
-        if arm_t and any((e.get("ev_t") or e.get("at") or 0) > arm_t for e in nd.get("log") or []):
-            continue                                 # a ruling on EVIDENCE newer than the arm — the stall read is stale
-        if status.get(f[0], "working") == "working" and not nd.get("cleared") \
-                and not nd.get("nodeComplete") and not nd.get("blocked"):
-            keep.append(f)
+        if status.get(f[0], "working") != "working" or nd.get("cleared") \
+                or nd.get("nodeComplete") or nd.get("blocked"):
+            continue                                 # the judges resolved it since the tick's snapshot: no
+            #                                          status check, and nothing to hold either — a RESOLVED
+            #                                          goal must never reach `held`, or the backstop below
+            #                                          would eventually nudge a card that is already done
+        if cut and any((e.get("ev_t") or e.get("at") or 0) > cut for e in nd.get("log") or []):
+            if held is not None:                     # a ruling on EVIDENCE from a turn romp hasn't seen end —
+                held.append(f)                       # the stall read is a world old; hold it, don't lose it
+            continue
+        keep.append(f)
     return keep
 
 

--- a/tests/test_nudge_injected_turn_arm.py
+++ b/tests/test_nudge_injected_turn_arm.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""A verdict about a ROMP-INJECTED turn must not gag the nudge forever (the user 2026-08-01).
+
+The incident, all fixtures SYNTHETIC: the `web` session's card was blocked on a question ("restart the
+service now, or should I?"). A kernel restart then cut the session mid-turn; romp injected its resume
+notice, which opened the next turn; the session answered in that turn ("already restarted and verified")
+and stopped. The unblocker read that turn and lifted the block, so the card dropped back to plain
+'working' on an idle session — exactly the stall the auto-nudge exists for.
+
+No nudge ever came. _nudge_fire_list dropped the goal on EVERY tick, because its diary held a verdict
+whose ev_t (the injected turn's trigger) was newer than the ARM turn — and an injected turn can never
+BECOME the arm (the arm is by definition the newest GENUINELY-triggered ended turn, so romp's own
+messages never re-arm a nudge). The only thing that could have moved the arm was a genuine new turn,
+and the only thing that would have produced one was the nudge itself. The card sat in Working with no
+nudge, no block, no ⏳ stamp, nothing being judged, and — because this drop wrote no deferral record —
+nothing to read anywhere in the state dir. The user found it by eye half an hour later.
+
+The fix keys the guard on the newest turn romp has SEEN END (`seen_t`), with the arm as its floor. The
+2026-07-29 guard the fix must not break stands on turns still IN FLIGHT: there, the judges have ruled on
+something romp has not watched finish, and the stall read really is a world old. Once a turn has ended,
+a verdict about it that leaves the goal working is the considered verdict — the same argument the
+2026-07-30 `at`→`ev_t` narrowing made for the arm turn, which is just this turn's floor.
+
+And a held goal is now DEFERRED, never dropped: it takes a deferral record (why + the 6h backstop) like
+every other nudge hold, so the wait is inspectable. The why is screened out of the stall surfaces the
+way the judging hold is (jd.stall_why_stands) — the turn's own end event clears it, so it is a beat romp
+is working through, not a wedge to interrupt anyone about.
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_injarm", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-555555555555"
+G1 = SID + ":g1"
+NOW = 1781100000
+ARM_T = NOW - 1200               # the genuine turn the stall armed on (the restart cut it)
+INJ_T = NOW - 600                # the resume notice romp injected — trigger of the turn that followed
+
+
+def _node(nid, text, **kw):
+    d = {"id": nid, "text": text, "parentId": None, "nodeComplete": False, "blocked": False,
+         "cleared": False, "trail": [], "t": NOW - 7200, "mt": NOW - 600, "log": []}
+    d.update(kw)
+    return d
+
+
+def _store(nodes, status=None):
+    return {"rompUuid": SID, "seq": len(nodes), "lastNode": G1, "nodes": nodes, "placements": {},
+            "status": status if status is not None else {n: "working" for n in nodes}}
+
+
+def _incident_log():
+    """The audited diary: blocked on a question, then unblocked off the INJECTED turn romp opened."""
+    return [{"ev_t": ARM_T, "src": "closer", "kind": "block",
+             "why": "restart the service now, or should I?", "at": ARM_T + 120},
+            {"ev_t": INJ_T, "src": "unblocker", "kind": "unblock",
+             "why": "answered in passing: already restarted and verified", "at": INJ_T + 70}]
+
+
+class FireListSeenTurn(unittest.TestCase):
+    """The guard's yardstick is the newest turn romp has watched END, not the arm."""
+
+    def _fresh(self):
+        return _store({G1: _node(G1, "Ship the reconnect banner", log=_incident_log())})
+
+    def test_a_verdict_about_an_ended_injected_turn_keeps_the_fire(self):
+        out = km._nudge_fire_list(self._fresh(), [(G1, 1, False)], arm_t=ARM_T, seen_t=INJ_T)
+        self.assertEqual([f[0] for f in out], [G1],
+                         "the injected turn ENDED and the goal is still working — that verdict is the "
+                         "considered 'working' one, and the arm can never advance to reach it")
+
+    def test_the_same_verdict_still_drops_while_its_turn_is_in_flight(self):
+        # the 2026-07-29 guard, intact: romp has not seen that turn end (seen_t is still the arm), so
+        # the stall read describes a world one turn old
+        self.assertEqual(km._nudge_fire_list(self._fresh(), [(G1, 1, False)],
+                                             arm_t=ARM_T, seen_t=ARM_T), [],
+                         "a ruling on a turn romp hasn't watched finish still stands the nudge down")
+
+    def test_evidence_newer_than_the_seen_turn_drops(self):
+        log = _incident_log() + [{"ev_t": INJ_T + 300, "src": "unblocker", "kind": "unblock",
+                                  "why": "answered in the thread", "at": INJ_T + 310}]
+        fresh = _store({G1: _node(G1, "Ship the reconnect banner", log=log)})
+        self.assertEqual(km._nudge_fire_list(fresh, [(G1, 1, False)], arm_t=ARM_T, seen_t=INJ_T), [],
+                         "a verdict from a turn NEWER than the newest ended one is the live race")
+
+    def test_a_held_goal_is_reported_to_the_caller(self):
+        held = []
+        self.assertEqual(km._nudge_fire_list(self._fresh(), [(G1, 1, False)],
+                                             arm_t=ARM_T, seen_t=ARM_T, held=held), [])
+        self.assertEqual([f[0] for f in held], [G1],
+                         "the hold must reach the caller so it can be recorded, not silently dropped")
+
+    def test_a_resolved_goal_is_never_held(self):
+        # the status re-read runs FIRST: a goal the judges finished mid-tick is out of the tick
+        # entirely, so the backstop can never resurrect a nudge for a card that is already done
+        fresh = _store({G1: _node(G1, "Ship the reconnect banner", log=_incident_log(),
+                                  nodeComplete=True)}, status={G1: "completed"})
+        held = []
+        self.assertEqual(km._nudge_fire_list(fresh, [(G1, 1, False)],
+                                             arm_t=ARM_T, seen_t=ARM_T, held=held), [])
+        self.assertEqual(held, [], "a finished card is dropped, never held for later")
+
+    def test_callers_that_pass_no_seen_turn_are_unchanged(self):
+        self.assertEqual(km._nudge_fire_list(self._fresh(), [(G1, 1, False)], arm_t=ARM_T), [],
+                         "the arm alone stays the floor — the pre-fix contract for existing callers")
+
+    def test_the_hold_why_never_presents_as_a_stall(self):
+        self.assertFalse(jd.stall_why_stands(jd.WHY_TURN_IN_FLIGHT, SID),
+                         "a wait that ends on the turn's own end event is not a wedge to act on")
+
+
+class InjectedTurnDeadlockEndToEnd(unittest.TestCase):
+    """Through _auto_nudge_session: the restart-resume shape must produce a nudge, and the in-flight
+    shape must produce a deferral RECORD rather than silence."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._autonudge_cache.clear()
+        self._orig_km = {n: getattr(km, n) for n in (
+            "_session_flag", "_compacting_now", "_api_error", "_session_working",
+            "_interrupt_suppresses_nudge", "_backend_queued", "_backend_rewind_pending",
+            "_last_state", "_session_awaiting", "_closer_settled", "_revivers_pending",
+            "_pending_ops")}
+        self._orig_jd = {n: getattr(jd, n) for n in ("parsed_session", "load_goals", "_segs", "plan_units")}
+        self._orig_backend = km.Sessions.backend_for
+        km._session_flag = lambda sid, flag: False
+        km._compacting_now = lambda sid: False
+        km._api_error = lambda path: None
+        km._session_working = lambda turns: False
+        km._interrupt_suppresses_nudge = lambda turns: False
+        km._backend_queued = lambda sid: False
+        km._backend_rewind_pending = lambda sid: False
+        km._last_state = lambda sid: ("", 0)
+        km._session_awaiting = lambda *a, **k: False
+        km._closer_settled = lambda *a: True
+        km._revivers_pending = lambda *a: ""          # every other reviver exhausted
+        km._pending_ops = {}
+        jd._segs = lambda tn, store: []
+        jd.plan_units = lambda session, store: []
+        # _turn_romp_injected stays REAL: the deadlock lives in its interaction with the arm scan.
+        self.turns = [self._turn("t1", ARM_T, "human", ended=True),
+                      self._turn("t2", INJ_T, "romp", ended=True)]
+        jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
+        self.store = _store({G1: _node(G1, "Ship the reconnect banner", log=_incident_log())})
+        jd.load_goals = lambda sid: self.store
+        self.sent = []
+        test = self
+
+        class FakeBackend:
+            def send(self, sid, body):
+                test.sent.append(body)
+        km.Sessions.backend_for = staticmethod(lambda sid: FakeBackend())
+
+    def tearDown(self):
+        for n, v in self._orig_km.items():
+            setattr(km, n, v)
+        for n, v in self._orig_jd.items():
+            setattr(jd, n, v)
+        km.Sessions.backend_for = self._orig_backend
+        jd.STATE = self.saved_state
+        km._autonudge_cache.clear()
+        self.td.cleanup()
+
+    @staticmethod
+    def _turn(tid, t, author, ended=True):
+        uid = "u-" + tid
+        return {"id": tid, "t": t, "end": t + 60, "ended": ended, "trigger": {"uuid": uid},
+                "atoms": [{"uuid": uid, "type": "user", "author": author, "t": t}, {}, {}]}
+
+    def _tick(self, now=NOW):
+        nudged = dict(km._auto_nudge_data().get("nudged", {}))
+        return km._auto_nudge_session({"sid": SID, "path": "/nonexistent.jsonl"}, now, {}, nudged, {})
+
+    def test_the_restart_resume_shape_gets_its_nudge(self):
+        self.assertTrue(km._turn_romp_injected(self.turns[-1]),
+                        "the fixture is the real shape: romp's resume notice opened the last turn")
+        self.assertTrue(self._tick(), "the idle session's still-working card must be status-checked")
+        self.assertEqual(len(self.sent), 1)
+        self.assertIn("<!-- romp-goal-id: %s -->" % G1, self.sent[0])
+        rec = km._auto_nudge_data()["nudged"][G1]
+        self.assertEqual(rec["lastTurnId"], "t1",
+                         "the record still pins the GENUINE arm — romp's own turn never re-arms a nudge")
+
+    def test_the_fire_leaves_no_stale_deferral_record_behind(self):
+        km._nudge_deferred_ok(G1, "the agent's to-do sync is due", NOW - 30, SID)
+        self.assertIn(G1, km._auto_nudge_data()["deferred"])
+        self._tick()
+        self.assertNotIn(G1, km._auto_nudge_data().get("deferred", {}),
+                         "the hold ended when the nudge went out — a stale why must not outlive it")
+
+    def test_a_turn_still_in_flight_holds_the_fire_and_says_so(self):
+        self.turns[-1]["ended"] = False               # the judges ruled on a turn romp hasn't seen end
+        self.assertFalse(self._tick(), "the 2026-07-29 stand-down still applies")
+        self.assertEqual(self.sent, [])
+        rec = km._auto_nudge_data()["deferred"][G1]
+        self.assertEqual(rec["why"], jd.WHY_TURN_IN_FLIGHT,
+                         "the hold is RECORDED — the silent drop is what made the deadlock unreadable")
+        self.assertEqual(rec["sid"], SID)
+
+    def test_a_wedged_hold_still_fires_on_the_backstop(self):
+        self.turns[-1]["ended"] = False
+        self._tick()
+        self.assertEqual(self.sent, [])
+        later = NOW + km.NUDGE_DEFER_BACKSTOP_SECS + 60
+        self.assertTrue(self._tick(now=later), "a hold that never clears is a missing event, not a veto")
+        self.assertEqual(len(self.sent), 1)
+
+    def test_a_resolved_card_is_never_nudged_either_way(self):
+        self.store["status"][G1] = "completed"
+        self.assertFalse(self._tick())
+        self.assertEqual(self.sent, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The breakage

A working card sat on an idle session for half an hour with **no nudge, no block, no awaiting stamp, and nothing being judged**. The standing invariant is that a working card always has something moving it, and it was broken outright. Worse, the state dir held no record of the hold at all, so there was nothing to read.

## Cause

`_nudge_fire_list`'s arm guard (PR #144, narrowed on 2026-07-30) stands a nudge down when the goal's diary holds a verdict about evidence **newer than the arm turn**. But the arm is by definition the newest *genuinely triggered* ended turn, so a **romp-injected** turn can never become it.

The audited sequence:

1. The card was blocked on a question.
2. A kernel restart cut the session mid-turn.
3. romp's resume notice opened the next turn (injected, so never an arm).
4. The session answered the question in that turn and stopped.
5. The unblocker ruled the question answered off that turn, so the card dropped back to plain `working` on an idle session.

From then on the verdict's `ev_t` was newer than the arm **forever**. The guard dropped the goal on every tick; the arm could only move on a genuine new turn; and the only thing that would have produced one was the nudge itself.

## Fix

- The guard's yardstick is now the newest turn romp has **seen end** (`seen_t`), with the arm as its floor. Once a turn has ended, a verdict about it that leaves the goal working is the considered verdict, which is exactly the argument the 2026-07-30 `at`/`ev_t` narrowing made for the arm turn. A verdict about a turn **still in flight** stands the nudge down exactly as before, so the 2026-07-29 guard is intact.
- A held goal is **deferred, not dropped**: it takes a deferral record (why + the 6h backstop) like every other nudge hold, and the record is cleared when the nudge goes out. The why is screened out of the stall surfaces the way the judging hold is, since the turn's own end event clears it.
- The status re-read runs before the hold, so a card the judges resolved mid-tick can never reach the hold list and be revived by the backstop.

Verified against the live wedged card (read-only replay through the pure fire list): drops before, fires after.

## Tests

`tests/test_nudge_injected_turn_arm.py`, all fixtures synthetic. Eight of its twelve cases fail on the pre-fix kernel, including the end-to-end restart-resume repro. Full suite: 3813 passed; node suite: 1577 passed.