### PR TITLE
Treat a spent model allowance as on-you, not a transient API error

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8699,6 +8699,26 @@ def _is_spend_limit(text):
             or ("spending" in low and "limit" in low))
 
 
+# A MODEL-SCOPED allowance is exhausted (the user 2026-08-01): "You've reached your Fable 5 limit. Run
+# /usage-credits to continue or switch models with /model". This is on YOU like the two above — the account
+# keeps serving every OTHER model, so nothing clears it but switching model, buying credits, or waiting out
+# a window that can be hours away. Until this landed it fell through as a TRANSIENT error, which is the
+# worst of both: the card stayed in Working, the auto-nudge was suppressed (a session sitting on an API
+# error is deliberately not "orphaned"), the badge said "stopped on an API error — Retry to resume" when
+# Retry could not possibly work, and the auto-retry ladder re-failed for 80 minutes while the user's
+# message sat unanswered in the transcript. romp had the fact the whole time: usage.json carried the
+# model's window at 100%. Matched on the CLI's own REMEDY phrasing — it is the only error that offers
+# "switch models" or the credits top-up — so an account-wide 5h/weekly error (no such remedy, a real
+# countdown, _auto_pause_on_limit's job) still keeps its retry-and-wait path.
+#
+# Deliberately NOT a global retry-pause: that was tried for fable=100% on 2026-07-03 and was pathological
+# (the account keeps serving, so _auto_resume_retry cleared the pause every tick and this re-engaged it —
+# a flap that starved the judges). Per-session, on the card, which is where a model-scoped limit belongs.
+def _is_model_limit(text):
+    low = (text or "").lower()
+    return "limit" in low and ("/usage-credits" in low or "switch models" in low)
+
+
 def _spend_dialog_showing(pane):
     """Is the CLI's spend-cap MODAL currently up in this pane capture? When a tmux session hits the
     monthly cap MID-TURN the CLI drops into an interactive menu ("What do you want to do? / Adjust
@@ -8756,7 +8776,11 @@ def _api_error(path):
                                "tooLong": "too long" in text.lower(),
                                # a spend cap is on YOU (raise it), like tooLong — but ALSO stops the
                                # auto-retry entirely (no reset to wait out); see _auto_pause_on_spend_limit
-                               "spendLimit": _is_spend_limit(text)}
+                               "spendLimit": _is_spend_limit(text),
+                               # a model's own allowance is spent — on YOU too (switch model / add
+                               # credits), and the auto-retry keeps running only because the window does
+                               # eventually reset; see _is_model_limit
+                               "modelLimit": _is_model_limit(text)}
                     elif (isinstance(c, list) and any(isinstance(b, dict)
                             and b.get("type") in ("text", "tool_use", "thinking") for b in c)) \
                             or (isinstance(c, str) and c.strip()):
@@ -11523,6 +11547,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   # a spend cap is on-you like tooLong (red tab, "raise your cap") AND never auto-retried:
                   # the client's apiRetryTick skips it, and the global pause it engages stops the loop too
                   "apiSpendLimit": bool(aerr and aerr.get("spendLimit")),
+                  # a model-scoped allowance is spent — on-you like the two above (red tab), and the
+                  # client's retry-all skips it: nothing retries into it until the model changes or its
+                  # window resets, and an amber "retrying" tab said the opposite (the user 2026-08-01)
+                  "apiModelLimit": bool(aerr and aerr.get("modelLimit")),
                   # user interrupted this thread's retry/API-error storm → romp's auto-retry stays OFF for it
                   # until a successful turn re-arms (the user 2026-07-06); the card + retry loop read this
                   "retrySuppressed": _session_retry_suppressed(sid),
@@ -13054,7 +13082,12 @@ def build_feed(now, tmux=None):
             # auto-retry recovers it, so the card STAYS in Working with the "⚠ API error" chip. But a "prompt
             # is too long" error IS on you (compact needed) → it floors to needs-input like a real block. So
             # only api_top WHEN tooLong, or a genuine soft block (col blocked & not recheck), keeps needs_input.
-            api_block = (nid == api_top and bool(aerr and (aerr.get("tooLong") or aerr.get("spendLimit"))))
+            # A MODEL-scoped usage limit joins them (the user 2026-08-01): the session cannot run another
+            # turn until you switch model or top up, so leaving the card in Working left a working card on
+            # a session nothing could move — not nudged (the api-error gate suppresses it), not blocked,
+            # not awaiting, for 80 minutes.
+            api_block = (nid == api_top and bool(aerr and (aerr.get("tooLong") or aerr.get("spendLimit")
+                                                          or aerr.get("modelLimit"))))
             # NUDGE FAILED (plans/stalled-open-todos-nudge.md, the user 2026-07-01): the tick stamped
             # `failed` on this goal's nudge record — the nudge-response turn completed (judged) and the goal
             # was still working-stalled; per the anti-loop rule it is never re-nudged, so the card carries
@@ -13216,8 +13249,12 @@ def build_feed(now, tmux=None):
                              "status": aerr.get("status"),
                              "text": aerr.get("text"), "tooLong": bool(aerr.get("tooLong")),
                              "spendLimit": bool(aerr.get("spendLimit")),
+                             "modelLimit": bool(aerr.get("modelLimit")),
                              "what": ("this account hit its monthly spend limit — raise it at claude.ai/settings/usage to continue" if aerr.get("spendLimit")
                                       else "this session's prompt is too long — compact it to continue" if aerr.get("tooLong")
+                                      # the CLI's own text names the model and the two remedies; the card
+                                      # states them, because "Retry to resume" is false here (the user 2026-08-01)
+                                      else "this session's model is out of allowance — switch its model or add credits to continue" if aerr.get("modelLimit")
                                       else "this session stopped on an API error — Retry to resume")} if nid == api_top
                             else {"state": perm_state,
                                   "what": ("this session is stopped awaiting your input" if perm_state == "picker"

--- a/tests/test_kernel_apierror_working.py
+++ b/tests/test_kernel_apierror_working.py
@@ -1,7 +1,9 @@
 """API errors (the user 2026-06-29): a TRANSIENT API error is not blocking — its card stays in Working with the
 ⚠ chip and auto-retry recovers it. BUT an ON-YOU error floors the focus card to needs-input and gets the
-alarm-red tab: "prompt is too long" (compact needed) or a monthly spend cap (raise it, the user 2026-07-14) —
-the spend cap ALSO stops auto-retry entirely (no reset to wait out). Source pins on _api_error + build_feed."""
+alarm-red tab: "prompt is too long" (compact needed), a monthly spend cap (raise it, the user 2026-07-14), or a
+spent MODEL allowance (switch model / add credits, the user 2026-08-01) — the spend cap ALSO stops auto-retry
+entirely (no reset to wait out). Source pins on _api_error + build_feed. The model-limit case has its own
+behavioural file, tests/test_kernel_model_limit.py."""
 import inspect
 import os
 import unittest
@@ -23,7 +25,8 @@ class ApiErrorWorking(unittest.TestCase):
         src = inspect.getsource(km.build_feed)
         # api_block fires for an ON-YOU api_top — "prompt too long" (compact) OR a monthly spend cap (raise it,
         # the user 2026-07-14); a transient error does NOT move the card (it auto-retries in Working).
-        self.assertIn('api_block = (nid == api_top and bool(aerr and (aerr.get("tooLong") or aerr.get("spendLimit"))))', src)
+        self.assertIn('api_block = (nid == api_top and bool(aerr and (aerr.get("tooLong") or aerr.get("spendLimit")', src)
+        self.assertIn('or aerr.get("modelLimit"))))', src)
         self.assertIn('column = ("needs_input" if (api_block or nid == perm_top', src)   # stalled_floor retired 2026-07-07
         self.assertIn('or (col == "blocked" and not recheck and not rejudging))', src)
 

--- a/tests/test_kernel_model_limit.py
+++ b/tests/test_kernel_model_limit.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""A MODEL's own allowance running out is ON YOU, not a transient API error (the user 2026-08-01).
+
+The incident, all fixtures SYNTHETIC: the `api` session was running on a model whose included weekly
+allowance was spent. The user sent it a request; the CLI wrote the message to the transcript and the
+very next record was an API-error record reading "You've reached your <model> limit. Run
+/usage-credits to continue or switch models with /model". Every romp auto-retry for the next 80
+minutes got the identical error, so the turn never ran and the message sat unanswered.
+
+romp classified only two API errors as on-you: "prompt is too long" and a monthly spend cap. A spent
+model allowance fell through as TRANSIENT, and every consequence followed from that one call:
+- the card stayed in Working, so nothing said the thread was stuck;
+- the auto-nudge was suppressed (a session sitting on an API error is deliberately not "orphaned"),
+  so the working card had NOTHING that could move it — the exact invariant the fire-list deadlock
+  broke by another route (tests/test_nudge_injected_turn_arm.py);
+- the card's badge read "stopped on an API error — Retry to resume" when Retry could not work;
+- the tab rendered amber-retrying, which says "romp has this", the opposite of the truth.
+
+romp knew the whole time: usage.json carried that model's window at 100%.
+
+Classified here on the CLI's own REMEDY phrasing, because a model-scoped limit is the only failure
+that offers "switch models" or a credits top-up. An ACCOUNT-WIDE 5h/weekly window carries no such
+remedy and keeps its countdown-and-retry path (_auto_pause_on_limit reads the usage report for that),
+and a spend cap keeps its own. Deliberately NOT a global retry-pause: that was tried for a
+model-scoped limit on 2026-07-03 and flapped 262 times, starving the judges — the account keeps
+serving every other model, so this belongs on the one session's card.
+"""
+import inspect
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_modellimit", os.path.join(BIN, "romp-kernel")).load_module()
+
+T0 = 1781100000
+# The CLI's own words for a spent model allowance, model name neutralised.
+MODEL_LIMIT_TEXT = ("You've reached your Opus 5 limit. Run /usage-credits to continue or switch "
+                    "models with /model")
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def _apierr(t, uuid, parent, text, status=None, category="usage_limit"):
+    o = {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+         "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                     "stop_reason": "stop_sequence"},
+         "isApiErrorMessage": True, "error": category}
+    if status is not None:
+        o["apiErrorStatus"] = status
+    return o
+
+
+class IsModelLimitPredicate(unittest.TestCase):
+    def test_the_clis_own_phrasing_classifies(self):
+        for t in (MODEL_LIMIT_TEXT,
+                  "You've reached your Fable 5 limit. Run /usage-credits to continue.",
+                  "Model limit reached — switch models with /model to keep going."):
+            self.assertTrue(km._is_model_limit(t), t)
+
+    def test_other_failures_do_not(self):
+        for t in ("API Error: 500 Internal server error.",
+                  "Request timed out",
+                  "You've hit your monthly spend limit. Raise it at claude.ai/settings/usage.",
+                  # an ACCOUNT-WIDE rate window: a real countdown, no model/credits remedy
+                  "You've hit your session limit · resets 1:10pm (America/Los_Angeles)",
+                  "Usage limit reached. Your limit resets at 3pm.",
+                  # prose that merely mentions models must not trip it — there is no limit here
+                  "I'll switch models for the next step."):
+            self.assertFalse(km._is_model_limit(t), t)
+
+
+class ApiErrorCarriesTheFlag(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.p = os.path.join(self.td.name, "s.jsonl")
+        km._api_err_cache.clear()
+
+    def tearDown(self):
+        km._api_err_cache.clear()
+        self.td.cleanup()
+
+    def _write(self, *rows):
+        with open(self.p, "w") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+        km._api_err_cache.clear()
+
+    def test_the_error_is_classified_model_limit_and_nothing_else(self):
+        self._write(_uline(T0, "capture the frame", "u1"),
+                    _apierr(T0 + 1, "e1", "u1", MODEL_LIMIT_TEXT))
+        e = km._api_error(self.p)
+        self.assertTrue(e["modelLimit"], "a spent model allowance is classified on-you")
+        self.assertFalse(e["spendLimit"], "it is not a billing cap — the account is fine")
+        self.assertFalse(e["tooLong"])
+
+    def test_a_transient_error_is_not_a_model_limit(self):
+        self._write(_uline(T0, "capture the frame", "u1"),
+                    _apierr(T0 + 1, "e1", "u1", "API Error: 500 Internal server error.",
+                            status=500, category="server_error"))
+        self.assertFalse(km._api_error(self.p)["modelLimit"],
+                         "a 500 still auto-retries in Working — this must not widen")
+
+    def test_the_retry_storm_keeps_the_classification(self):
+        # the audited shape: romp's injected "retry" turns each get the same error back. The LATEST
+        # record stands, so the card must still read on-you at attempt 20, not just attempt 1.
+        rows = [_uline(T0, "capture the frame", "u1"), _apierr(T0 + 1, "e0", "u1", MODEL_LIMIT_TEXT)]
+        for i in range(1, 20):
+            rows.append(_uline(T0 + i * 60, "retry\n\n<!-- romp-injected -->", "u%d" % i))
+            rows.append(_apierr(T0 + i * 60 + 1, "e%d" % i, "u%d" % i, MODEL_LIMIT_TEXT))
+        self._write(*rows)
+        self.assertTrue(km._api_error(self.p)["modelLimit"])
+
+
+class SurfacesPinTheOnYouTreatment(unittest.TestCase):
+    """The flag has to reach every surface that already distinguishes on-you from transient, or the
+    card moves while the tab still says romp is handling it."""
+
+    def test_the_card_floors_to_needs_you(self):
+        src = inspect.getsource(km.build_feed)
+        self.assertIn('or aerr.get("modelLimit"))))', src,
+                      "api_block must include the model limit — otherwise the card sits in Working "
+                      "with the nudge suppressed and nothing able to move it")
+
+    def test_the_card_names_the_real_remedy(self):
+        src = inspect.getsource(km.build_feed)
+        self.assertIn('"modelLimit": bool(aerr.get("modelLimit"))', src)
+        self.assertIn("switch its model or add credits to continue", src)
+        self.assertIn("this session stopped on an API error — Retry to resume", src,
+                      "the transient wording stays for genuinely transient errors")
+
+    def test_the_status_flag_reaches_the_tab(self):
+        self.assertIn('"apiModelLimit": bool(aerr and aerr.get("modelLimit"))',
+                      inspect.getsource(km.build_session))
+
+    def test_it_does_not_engage_the_global_retry_pause(self):
+        # the 2026-07-03 flap: pausing the fleet on a model-scoped limit starved the judges, because
+        # the account keeps serving and _auto_resume_retry cleared the pause every tick
+        src = inspect.getsource(km._auto_pause_on_limit)
+        self.assertIn('k != "fable"', src, "account-wide windows only still gate the global pause")
+        self.assertNotIn("modelLimit", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/api-error-reason.test.ts
+++ b/ui/webview/api-error-reason.test.ts
@@ -24,6 +24,14 @@ test("the on-you cases outrank the status code, because only they are actionable
   assert.match(apiErrorReason({ status: 400, tooLong: true }), /prompt too long/i);
 });
 
+test("a spent MODEL allowance names the fix, not a wait (the user 2026-08-01)", () => {
+  // it arrives as a 429, which by status alone reads "rate limited — the account's quota" and sends the
+  // user off to wait out a window when the account is fine and one model switch unblocks the session
+  const s = apiErrorReason({ status: 429, modelLimit: true });
+  assert.match(s, /switch model|add credits/i);
+  assert.doesNotMatch(s, /rate limited/i);
+});
+
 test("a dead network and a busy API are told apart", () => {
   assert.match(apiErrorReason({ status: 529, networkDown: true }), /offline/i);
   assert.doesNotMatch(apiErrorReason({ status: 529, networkDown: true }), /overloaded/i);

--- a/ui/webview/api-error-reason.ts
+++ b/ui/webview/api-error-reason.ts
@@ -14,17 +14,21 @@ export interface ApiErrorFacts {
   rateLimitType?: string | null;
   spendLimit?: boolean | null;
   tooLong?: boolean | null;
+  modelLimit?: boolean | null;
 }
 
 // The plain-words reason, or "" when the facts don't identify one (callers then fall back to the bare
 // status, which is still better than inventing a cause we can't support).
 export function apiErrorReason(f: ApiErrorFacts): string {
-  // The two ON-YOU cases first: they are the only ones the user can actually act on, and both outrank a
+  // The ON-YOU cases first: they are the only ones the user can actually act on, and each outranks a
   // status code (a spend cap also arrives as a 4xx, which would otherwise read as a plain rate limit).
   // Wording is the established one these badges already used — folding them in here is about having ONE
   // place that decides what a failure means, not about renaming failures that already read clearly.
   if (f.spendLimit) return "spend limit reached";
   if (f.tooLong) return "prompt too long (needs compaction)";
+  // A MODEL's own allowance, not the account's: "rate limited" would send the user off to wait when the
+  // fix is one model switch away (the user 2026-08-01).
+  if (f.modelLimit) return "this model is out of allowance — switch model or add credits";
   if (f.networkDown) return "this machine is offline";
   if (f.rateLimitType) return `rate limited (${f.rateLimitType})`;
   const s = Number(f.status);

--- a/ui/webview/apierror-spend-limit.test.ts
+++ b/ui/webview/apierror-spend-limit.test.ts
@@ -18,11 +18,12 @@ test("Status carries the per-session apiSpendLimit flag", () => {
 });
 
 test("the auto-retry tick SKIPS a spend-capped thread (retrying can't fix a billing cap)", () => {
-  assert.match(R, /!s\.status\.retrySuppressed && !s\.status\.apiSpendLimit/);
+  // a spent MODEL allowance is skipped by the same rule (the user 2026-08-01)
+  assert.match(R, /!s\.status\.retrySuppressed && !s\.status\.apiSpendLimit && !s\.status\.apiModelLimit/);
 });
 
 test("a spend cap paints the tab alarm-red (on-you), not amber retrying", () => {
-  assert.match(R, /\(s\.status\.apiTooLong \|\| s\.status\.apiSpendLimit\) \? "tab-blocked" : "tab-retrying"/);
+  assert.match(R, /\(s\.status\.apiTooLong \|\| s\.status\.apiSpendLimit \|\| s\.status\.apiModelLimit\) \? "tab-blocked" : "tab-retrying"/);
 });
 
 test("the paused line names the spend cap and points at the settings page (no fake countdown)", () => {
@@ -36,7 +37,15 @@ test("the globalRetryPaused push reason is threaded into the client", () => {
 
 test("the feed card badges a spend cap and HIDES Retry (a useless click there)", () => {
   assert.match(F, /const spendLimit = !!\(it\.blocked && it\.blocked\.spendLimit\)/);
-  assert.match(F, /a\._apiRetry\.style\.display = \(isApiErr && !spendLimit\) \? "" : "none"/);
+  assert.match(F, /a\._apiRetry\.style\.display = \(isApiErr && !spendLimit && !modelLimit\) \? "" : "none"/);
   assert.match(F, /spendLimit \? "⚠ Spend limit"/);
   assert.match(F, /spendLimit\?: boolean/);
+});
+
+// A spent MODEL allowance is the same shape and gets the same treatment (the user 2026-08-01): Retry
+// re-fails until the model changes or its window resets, so the button goes and the badge names the fix.
+test("the feed card badges a spent model allowance and HIDES Retry too", () => {
+  assert.match(F, /const modelLimit = !!\(it\.blocked && it\.blocked\.modelLimit\)/);
+  assert.match(F, /modelLimit \? "⚠ Model limit"/);
+  assert.match(F, /modelLimit\?: boolean/);
 });

--- a/ui/webview/badge-mirror.ts
+++ b/ui/webview/badge-mirror.ts
@@ -24,7 +24,7 @@ export interface BadgeItem {
   nudgeFailed?: boolean;
   retrying?: { since?: number | null; count?: number; max?: number | null; status?: number | string | null; networkDown?: boolean | null; rateLimitType?: string | null } | null;
   warns?: { kind: string; t: number; msg: string }[] | null;
-  blocked?: { state: string; status?: number; text?: string; tooLong?: boolean; spendLimit?: boolean } | null;
+  blocked?: { state: string; status?: number; text?: string; tooLong?: boolean; spendLimit?: boolean; modelLimit?: boolean } | null;
 }
 // sid + itemId ride along so a bell entry can JUMP back to the card it was minted from (the user
 // 2026-07-28): the shell posts them back as {romp:'revealCard'} and the feed scrolls + pulses the card.
@@ -58,11 +58,12 @@ export function badgeNotices(items: BadgeItem[], seen: Set<string>): { notices: 
     // only the API-error block is an ERROR; a permission ask / picker is ordinary Needs-you traffic
     if (it.blocked && it.blocked.state === "apiError") {
       const b = it.blocked;
-      // spendLimit / tooLong already read as plain words; apiErrorReason covers them too, so the whole
-      // verdict comes from one place and the bell can't describe a failure differently than the chat does.
+      // spendLimit / tooLong / modelLimit already read as plain words; apiErrorReason covers them too, so the
+      // whole verdict comes from one place and the bell can't describe a failure differently than the chat does.
+      const onYou = b.spendLimit || b.tooLong || b.modelLimit;
       const what = apiErrorReason(b) || "API error" + (b.status ? " " + b.status : "");
-      add("e|" + it.itemId + "|" + (b.status || "") + "|" + (b.spendLimit ? "sl" : b.tooLong ? "tl" : ""),
-        "apierror", it.name + " — " + (b.status && !b.spendLimit && !b.tooLong ? "API error " + b.status + ": " : "") + what);
+      add("e|" + it.itemId + "|" + (b.status || "") + "|" + (b.spendLimit ? "sl" : b.tooLong ? "tl" : b.modelLimit ? "ml" : ""),
+        "apierror", it.name + " — " + (b.status && !onYou ? "API error " + b.status + ": " : "") + what);
     }
   }
   return { notices, active };

--- a/ui/webview/dismiss-dialog.test.ts
+++ b/ui/webview/dismiss-dialog.test.ts
@@ -15,7 +15,7 @@ const K = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py
 const apiErr = R.slice(R.indexOf("function renderApiError"), R.indexOf("// ── API-error auto-retry"));
 
 test("a spend cap suppresses the Retry button entirely", () => {
-  assert.match(apiErr, /const spendCap = !!st\?\.apiSpendLimit;/);
+  assert.match(apiErr, /const spendCap = !!st\?\.apiSpendLimit \|\| !!st\?\.apiModelLimit;/);
   assert.match(apiErr, /if \(!spendCap\) \{[\s\S]*?retry\.textContent = "Retry now";/);
 });
 

--- a/ui/webview/feed-apierror-working.test.ts
+++ b/ui/webview/feed-apierror-working.test.ts
@@ -21,6 +21,6 @@ test("the apiError chip + Retry still show (they key on blocked.state, not the c
   assert.match(FEED, /a\._apiBadge\.style\.display = isApiErr \? "" : "none";/);
   // Retry shows for a transient/on-you-compactable error but is HIDDEN for a spend cap (retrying can't lift a
   // billing limit) — the user 2026-07-14; the spend-cap wiring is pinned in apierror-spend-limit.test.ts.
-  assert.match(FEED, /a\._apiRetry\.style\.display = \(isApiErr && !spendLimit\) \? "" : "none";/);
+  assert.match(FEED, /a\._apiRetry\.style\.display = \(isApiErr && !spendLimit && !modelLimit\) \? "" : "none";/);
 });
 

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -79,6 +79,7 @@ interface AskItem {
   blocked?: { state: string; what: string; status?: number; text?: string;
               tooLong?: boolean;   // apiError: a "prompt is too long" error (on you → compact) vs a transient API error
               spendLimit?: boolean;   // apiError: a monthly spend cap (on you → raise it, never auto-retried; the user 2026-07-14)
+              modelLimit?: boolean;   // apiError: this session's MODEL is out of allowance (on you → switch model or add credits; the user 2026-08-01)
               toName?: string; toSid?: string;    // parkedHandoff adds to*
               mid?: string; frm?: string; to?: string; origin?: string; body?: string; gist?: string };   // quarantine (held peer mail) adds these; gist = the bus's 90-char collapse for the compact card line
   summary?: string | null;                         // distiller's key takeaway for a COMPLETED goal → the done card's one auto-written line (kernel asks.append); null until produced
@@ -1517,15 +1518,19 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // the stalled turn (the user 2026-06-16). The card STAYS in Working (the user 2026-06-29) — an API error is
   // a transient stall, not a block — so this badge + Retry are the only API-error cue; no column move.
   const spendLimit = !!(it.blocked && it.blocked.spendLimit);
+  const modelLimit = !!(it.blocked && it.blocked.modelLimit);
   a._apiBadge.style.display = isApiErr ? "" : "none";
   // Retry pastes "retry" to resume a stalled turn — useless against a monthly spend cap (retrying can't lift a
   // billing limit), so hide it there and let the badge tell you to raise the cap (the user 2026-07-14).
-  a._apiRetry.style.display = (isApiErr && !spendLimit) ? "" : "none";
+  // A spent MODEL allowance is the same shape: Retry re-fails until you switch model or top up, and the
+  // badge says so (the user 2026-08-01). Its window does reset on its own, which the badge title carries.
+  a._apiRetry.style.display = (isApiErr && !spendLimit && !modelLimit) ? "" : "none";
   if (isApiErr && it.blocked) {
-    // on-you errors name themselves: a spend cap (raise it) or "prompt too long" (compact); other API errors are
-    // transient and auto-retrying (the user 2026-06-29 / 2026-07-14).
+    // on-you errors name themselves: a spend cap (raise it), "prompt too long" (compact), or a spent model
+    // allowance (switch model); other API errors are transient and auto-retrying (2026-06-29 / 07-14 / 08-01).
     a._apiBadge.textContent = spendLimit ? "⚠ Spend limit"
       : it.blocked.tooLong ? "⚠ Prompt too long"
+      : modelLimit ? "⚠ Model limit"
       : it.blocked.status ? `⚠ API error · ${it.blocked.status}` : "⚠ API error";
     a._apiBadge.title = spendLimit ? it.blocked.what : (it.blocked.text || it.blocked.what);
     a._apiRetry.disabled = false; a._apiRetry.textContent = "Retry";

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -185,7 +185,7 @@ type ChatEvent = (
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
 type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
-interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03)
+interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed.
@@ -2534,7 +2534,9 @@ function renderApiError(ev: Extract<ChatEvent, { kind: "apiError" }>): HTMLEleme
   // menu is up, then sends Esc — cancel, never a billing change). An SDK spend-cap card names the fix
   // (raise the cap) with no dead button at all.
   const st = activeId ? sessions.get(activeId)?.status : undefined;
-  const spendCap = !!st?.apiSpendLimit;
+  // A spent MODEL allowance gets no Retry either (the user 2026-08-01): "retry" re-fails until the model
+  // changes or its own window resets, so the card names the fix instead of offering a button that cannot work.
+  const spendCap = !!st?.apiSpendLimit || !!st?.apiModelLimit;
   if (!spendCap) {
     const retry = el("button", "apierror-retry") as HTMLButtonElement;
     retry.textContent = "Retry now";
@@ -2628,7 +2630,9 @@ function apiRetryTick(): void {
     // one: romp won't re-fire "retry" into it until a successful turn re-arms it (the user 2026-07-06). A monthly
     // spend cap (apiSpendLimit) is left out too (the user 2026-07-14): retrying can't fix a billing cap, so it's
     // never auto-retried — the card asks you to raise it instead (the global pause it engages also gates this).
-    sessions.forEach((s, id) => { if (s.status.state === "blocked" && !s.status.retrySuppressed && !s.status.apiSpendLimit) blocked.add(id); });
+    // A spent MODEL allowance (apiModelLimit) is out for the same reason: every retry re-fails until the
+    // user switches model or tops up, and the card says exactly that (the user 2026-08-01).
+    sessions.forEach((s, id) => { if (s.status.state === "blocked" && !s.status.retrySuppressed && !s.status.apiSpendLimit && !s.status.apiModelLimit) blocked.add(id); });
     apiRetryNext.forEach((_, id) => { if (!blocked.has(id)) apiRetryNext.delete(id); });   // recovered / suppressed → stop
     blocked.forEach((id) => {
       // The kernel owns the cadence now (the user 2026-07-29): it backs each outage's attempts off up to
@@ -3375,10 +3379,10 @@ function renderTabs() {
     }
     const st = s.status.state;
     if (st === "working") tab.classList.add("tab-working");
-    // "blocked" is an API error. An on-YOU one — "prompt is too long" (compact) or a monthly spend cap (raise it,
-    // the user 2026-07-14) — is alarm-red dashed; a TRANSIENT API error is auto-retrying and needs no attention → the
+    // "blocked" is an API error. An on-YOU one — "prompt is too long" (compact), a monthly spend cap (raise it,
+    // the user 2026-07-14), or a spent model allowance (switch model, the user 2026-08-01) — is alarm-red dashed; a TRANSIENT API error is auto-retrying and needs no attention → the
     // amber retrying treatment, not red (the user 2026-06-29).
-    else if (st === "blocked") tab.classList.add((s.status.apiTooLong || s.status.apiSpendLimit) ? "tab-blocked" : "tab-retrying");
+    else if (st === "blocked") tab.classList.add((s.status.apiTooLong || s.status.apiSpendLimit || s.status.apiModelLimit) ? "tab-blocked" : "tab-retrying");
     else if (st === "awaiting") tab.classList.add("tab-awaiting");
     else if (st === "retrying") tab.classList.add("tab-retrying");       // amber: soft-blocked on an API auto-retry
     else if (st === "compacting" || st === "clearing") tab.classList.add("tab-compacting");   // both: a context op in flight


### PR DESCRIPTION
## The breakage

Found while chasing a peer session's report that romp had **lost a user message**. It hadn't: the message was delivered and written to the transcript at 12:34. What actually happened is worse in a quieter way.

The session was running a model whose own allowance was spent. The CLI returned, to that turn and to every one of ~20 romp auto-retries over the next 80 minutes:

> You've reached your \<model\> limit. Run /usage-credits to continue or switch models with /model

romp classifies exactly two API errors as **on-you**: `tooLong` and `spendLimit`. A spent model allowance fell through as **transient**, and every consequence followed from that single call:

- the card stayed in **Working** — and the auto-nudge is deliberately suppressed for a session sitting on an API error, so the working card had **nothing that could move it**. This is the same invariant PR #177 fixed by another route: a working card on a session that isn't working, isn't nudged, isn't blocked, isn't awaiting, isn't being judged.
- the badge read *"stopped on an API error — Retry to resume"* when Retry could not possibly work;
- the tab rendered **amber-retrying**, which says "romp has this" — the opposite of the truth;
- the retry ladder re-failed for 80 minutes while the user's message sat unanswered.

romp had the fact the whole time: `usage.json` carried that model's window at `pct: 100`.

## Fix

`_is_model_limit` classifies it off the CLI's own **remedy** phrasing — a model-scoped limit is the only failure that offers "switch models" or a credits top-up. An account-wide 5h/weekly window carries no such remedy and keeps its countdown-and-retry path (`_auto_pause_on_limit` reads the usage report for those); a spend cap keeps its own.

- `api_block` includes it → the card floors to **needs-you**, with `what` naming the two real remedies.
- `apiModelLimit` on the session status → alarm-red tab instead of amber-retrying.
- The client's retry-all tick and both Retry buttons skip it (same treatment as a spend cap).
- `apiErrorReason` gains it, so the bell and the chat retry line say the same thing.

**Deliberately not a global retry-pause.** That was tried for a model-scoped limit on 2026-07-03 and flapped 262 times, starving the judges — the account keeps serving every other model. This belongs on the one session's card.

## Tests

`tests/test_kernel_model_limit.py`: the predicate (including the account-wide and spend-cap phrasings it must *not* claim), the flag surviving a 20-deep retry storm, and pins on every surface. Plus a TS case in `api-error-reason.test.ts` and updated pins in three existing webview tests.

Full suite: 3810 passed. Node: 1579 passed, typecheck clean.