### PR TITLE
Move the chat date onto a day divider so "Yesterday" is never clipped

### DIFF
--- a/ui/webview/clear-divider.test.ts
+++ b/ui/webview/clear-divider.test.ts
@@ -42,7 +42,8 @@ test("the pre-clear history lazy-loads once per boundary and renders through the
   assert.match(RENDER, /else if \(m\.type === "chatEpisode"\) chatEpisode\(m\);/);
   assert.match(RENDER, /episodeCache\.set\(key, got\)/);
   // the folded episode reuses renderEvent — the SAME renderers as the live transcript, not a text dump
-  assert.match(RENDER, /wrap\.appendChild\(renderEvent\(e\)\)/);
+  // (it passes the chained prior epoch, so the fold's rail marks day boundaries the same way too)
+  assert.match(RENDER, /wrap\.appendChild\(renderEvent\(e, prior\)\)/);
   // a bounded render says what it cut (no silent truncation)
   assert.match(RENDER, /earlier event.*of the cleared conversation not shown/);
 });

--- a/ui/webview/day-divider.test.ts
+++ b/ui/webview/day-divider.test.ts
@@ -1,0 +1,79 @@
+// The day divider (the user 2026-08-01). A day boundary used to stack its date on its own row
+// INSIDE the 47px-wide rail marker; "Yesterday" measures 52.6px bold at the default 13px, so the
+// pane's overflow:hidden ate its leading "Y". Sizing the label to fit that gutter is not a fix —
+// `--fs` follows --vscode-chat-font-size, so a larger chat font re-clips whatever just fit at 13px.
+// The date moved to a full-width divider in the prose column, where no date string can be cut off.
+//
+// Two invariants worth pinning, both of which a refactor could quietly break:
+//   - the divider is a SIBLING before the turn, never a child of it. .dot and .time-marker are
+//     absolutely positioned against the TURN's top edge, so a divider inside the turn would push
+//     the message down and strand the dot up beside the rule.
+//   - every append path emits it. The windowed rebuild and the incremental tail append are separate
+//     code paths; when only one had it, scrolling back rebuilt dividers that live appends had dropped.
+// The chat renderer has no jsdom harness, so — like render-rail.test.ts — pin at the source.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("dayDividerFor returns a divider only on the first turn of a past day", () => {
+  const fn = RENDER.slice(RENDER.indexOf("function dayDividerFor"));
+  assert.match(fn.slice(0, 400), /if \(!day \|\| !date\) return null/, "every other turn gets nothing");
+  assert.match(fn.slice(0, 400), /markerLabel\(epoch, prevEpoch, Date\.now\(\)\)/, "same day-boundary rule as the marker");
+});
+
+test("the divider is a sibling of the turn, never a child (the dot anchors to the turn's top)", () => {
+  // a turn.insertBefore/appendChild of the divider would displace the absolutely-positioned dot
+  assert.doesNotMatch(RENDER, /turn\.(insertBefore|appendChild)\(\s*(dv|dayDivider)/);
+  // it is appended to the thread/fold container instead
+  assert.match(RENDER, /v\.el\.appendChild\(tag\(dv\)\)/, "windowed path appends to the thread");
+  assert.match(RENDER, /wrap\.appendChild\(dv\)/, "cleared-episode fold appends to the fold body");
+});
+
+test("every append path emits the divider, so scrolling back can't disagree with the live tail", () => {
+  // three call sites: windowed rebuild, incremental tail append, cleared-episode fold
+  // (the `function dayDividerFor(` definition is excluded, hence the negative lookbehind)
+  const calls = RENDER.match(/(?<!function )dayDividerFor\(/g) ?? [];
+  assert.equal(calls.length, 3, `expected 3 dayDividerFor() call sites, found ${calls.length}`);
+});
+
+test("the windowed divider carries data-unit so the scroll-to-unit map still resolves it", () => {
+  // appendItem tags via tag(); the tail path sets it explicitly
+  assert.match(RENDER, /dv\.dataset\.unit = String\(i\)/);
+});
+
+test("the incremental tail trim goes by data-unit, not by child count", () => {
+  // THE subtle break this feature could cause: the hot append path used to keep
+  // `spacer + (from - winStart)` CHILDREN, one per unit. A day divider makes a unit own two
+  // nodes, so that count trimmed one real turn off the tail per divider in the kept range —
+  // and the re-render started at `from`, so those turns were gone until a full rebuild.
+  assert.doesNotMatch(RENDER, /while \(v\.el\.childNodes\.length > keep\)/, "count-based trim is gone");
+  assert.match(RENDER, /while \(v\.el\.lastChild && unitOf\(v\.el\.lastChild\) >= from\)/);
+  // the spacer has no data-unit, so it must map to a sentinel BELOW any real unit and end the walk
+  assert.match(RENDER, /n\.dataset\.unit != null \? Number\(n\.dataset\.unit\) : -1/);
+});
+
+test("the divider label is never constrained to a fixed width", () => {
+  const rule = CSS.slice(CSS.indexOf(".day-divider-label"));
+  assert.doesNotMatch(rule.slice(0, 200), /\bwidth:|max-width:/, "a fixed width is the bug being closed");
+  // the hairline fills the leftover room, so the label takes exactly what it needs
+  assert.match(CSS, /\.day-divider::after \{[^}]*flex: 1 1 auto/);
+  assert.match(CSS, /\.day-divider-label \{[^}]*flex: 0 0 auto/);
+});
+
+test("the divider label matches the rail marker's type size", () => {
+  // one size for one kind of label — no new font-size on this surface.
+  // Anchor each rule at the START of a line: a bare indexOf(".time-marker {") hits the compound
+  // `.turn-compacting .dot, .turn-compacting .time-marker {` rule first and reads the wrong size.
+  const rule = (sel: string): string => {
+    const m = CSS.match(new RegExp("^\\" + sel + " \\{[^}]*\\}", "m"));
+    assert.ok(m, `no top-level ${sel} rule`);
+    return m[0];
+  };
+  const size = (s: string): string | null => (s.match(/font-size: ([\d.]+em)/) ?? [])[1] ?? null;
+  assert.equal(size(rule(".day-divider")), size(rule(".time-marker")));
+  assert.equal(size(rule(".day-divider")), "0.76em");
+});

--- a/ui/webview/render-rail.test.ts
+++ b/ui/webview/render-rail.test.ts
@@ -1,8 +1,8 @@
 // Chat rail rendering (the user 2026-06-13/14). Two changes, both about the left rail:
 //   1. Tool outcome lives ONLY on the left dot now — green ✓ disc on success, red ✗ disc on
 //      error. The duplicate right-side in-head ✓/✗ (`.tool-status`) was removed.
-//   2. A day boundary's marker stacks the date on its OWN line above the time, so a combined
-//      "Yesterday · 21:24" no longer overruns the narrow gutter into the dot.
+//   2. A day boundary shows its date on a full-width divider above the day's first turn, NOT in
+//      the rail — the gutter is 47px and "Yesterday" measures 52.6px, so it used to be clipped.
 // The chat renderer has no jsdom harness, so — like the feed-*.test.ts files — pin at the source.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -20,9 +20,20 @@ test("the redundant right-side tool-status ✓/✗ is gone; the dot carries the 
   assert.match(CSS, /\.dot\.green::before \{[^}]*content: "✓"/);
 });
 
-test("a day marker stacks the date above the time so it can't overrun the gutter", () => {
-  assert.match(RENDER, /el\("span", "tm-date"\)/);
-  assert.match(RENDER, /el\("span", "tm-time"\)/);
-  // the date line floats on its own row above (absolute, bottom:100%)
-  assert.match(CSS, /\.time-marker\.day \.tm-date \{[^}]*position: absolute[^}]*bottom: 100%/);
+test("the date rides a day divider, not the 47px rail gutter it used to be clipped by", () => {
+  // the old stacked-in-the-gutter markup is GONE — that is what clipped "Yesterday"
+  assert.doesNotMatch(RENDER, /tm-date|tm-time/, "no date/time spans stacked inside the marker");
+  assert.doesNotMatch(CSS, /\.tm-date\b|\.tm-time\b/, "the stacked-marker rules are removed");
+  // the divider carries it instead, with room to spare
+  assert.match(RENDER, /el\("div", "day-divider"\)/);
+  assert.match(RENDER, /el\("span", "day-divider-label"\)/);
+  assert.match(CSS, /\.day-divider \{/);
+  // the label must never be told to fit a fixed width — that is the bug class being closed
+  assert.doesNotMatch(CSS, /\.day-divider-label \{[^}]*\bwidth:/);
+  assert.match(CSS, /\.day-divider-label \{[^}]*white-space: nowrap/);
+});
+
+test("the rail marker shows only the time on a day boundary", () => {
+  // `day ? hm : text` — never the combined "Yesterday · 21:24", which overran the gutter
+  assert.match(RENDER, /m\.textContent = day \? hm : text/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -400,8 +400,10 @@ let landTrail: string[] = [];
 // avgTurnH), so content.scrollHeight stays honest and stick-to-bottom never snaps
 // (the failure mode of the reverted content-visibility approach). winStart === 0
 // ⇒ no spacer, whole transcript rendered (short sessions, compact mode).
-// Invariant: turn children === (len − winStart); view.rendered === len (events
-// accounted), so DOM childNodes === (winStart>0 ? 1 : 0) + (len − winStart).
+// Invariant: view.rendered === len (every event accounted for). Note the DOM child
+// count is NOT len − winStart + spacer: a unit may own more than one node (the day
+// divider that opens a new day precedes its turn), so anything mapping DOM back to
+// units reads data-unit off the node rather than counting children.
 interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; }
 const views = new Map<string, View>();
 
@@ -1384,21 +1386,35 @@ function eventEpoch(ev: ChatEvent): number | null {
 // Nothing re-reveals a suppressed marker: a stamp marks a time CHANGE and nothing else
 // (the user 2026-07-23) — see paintRailSticky for why the rail no longer needs repeats.
 function timeMarker(epoch: number, prevEpoch: number | null): HTMLElement {
-  const { text, day, hm, date } = markerLabel(epoch, prevEpoch, Date.now());
+  const { text, day, hm } = markerLabel(epoch, prevEpoch, Date.now());
   const m = el("div", "time-marker");
-  if (day) m.classList.add("day");
   m.dataset.hm = hm;
-  if (text) {
-    if (day && date) {
-      // Two lines: the date floats on its own row ABOVE, the time stays on the dot's row —
-      // a combined "Yesterday · 21:24" overruns the 58px gutter and collides with the dot.
-      const dd = el("span", "tm-date"); dd.textContent = date; m.appendChild(dd);
-      const tt = el("span", "tm-time"); tt.textContent = hm; m.appendChild(tt);
-    } else {
-      m.textContent = text;
-    }
-  }
+  // The gutter shows the TIME and nothing else. The date rides a full-width day divider
+  // instead (dayDividerFor below) — no date word has to fit 47px of rail any more.
+  if (text) m.textContent = day ? hm : text;
   return m;
+}
+
+// The day boundary itself: a hairline rule across the prose column with the date on it
+// ("Yesterday" / "Mon" / "Jun 3"), emitted as a SIBLING immediately before the first turn
+// of a new (non-today) day. Returns null on every other turn.
+//
+// Why it is not in the rail (the user 2026-08-01): the date used to stack on its own row
+// inside the .time-marker, but the gutter is only 47px wide and "Yesterday" measures 52.6px
+// bold, so its "Y" was clipped by the pane's overflow. Nothing that has to FIT a fixed 47px
+// is safe — `--fs` follows --vscode-chat-font-size, so a bigger chat font re-clips whatever
+// just barely fit at 13px. Out here the label has the whole column and can never be cut off.
+//
+// It must be a SIBLING, never the turn's first child: .dot and .time-marker are absolutely
+// positioned against the TURN's top edge, so a divider inside it would shove the message down
+// and leave the dot stranded up beside the rule.
+function dayDividerFor(epoch: number, prevEpoch: number | null): HTMLElement | null {
+  const { day, date } = markerLabel(epoch, prevEpoch, Date.now());
+  if (!day || !date) return null;
+  const d = el("div", "day-divider");
+  const lbl = el("span", "day-divider-label"); lbl.textContent = date;
+  d.appendChild(lbl);
+  return d;
 }
 
 // STICKY rail stamp (the user 2026-07-22). A stamp can only sit at a TURN boundary, so a single message
@@ -2053,8 +2069,18 @@ function fillClearBody(body: HTMLElement, got: { events: ChatEvent[]; truncated?
     body.appendChild(n);
   }
   const wrap = el("div", "clear-episode");
+  let prevEp: number | null = null;
   for (const e of got.events) {
-    try { wrap.appendChild(renderEvent(e)); }
+    try {
+      const ep = eventEpoch(e);
+      const prior = prevEp;   // the PREVIOUS event's epoch — chained, so the fold divides days
+      if (ep != null) {       // rather than re-stamping the full date on every turn in it
+        const dv = dayDividerFor(ep, prior);
+        if (dv) wrap.appendChild(dv);
+        prevEp = ep;
+      }
+      wrap.appendChild(renderEvent(e, prior));
+    }
     catch { /* one malformed historical event must not blank the whole fold */ }
   }
   body.appendChild(wrap);
@@ -4906,13 +4932,25 @@ function syncView(id: string, atBottom?: boolean): View {
   }
   // Normal mode, append AT the tail (unit === event, top spacer only): the cheap incremental hot path —
   // append the new turns + re-check a trailing window, tagging data-unit so the scroll↔unit map stays valid.
-  const hasSpacer = (v.winStart ?? 0) > 0 ? 1 : 0;
   let from = Math.min(v.rendered, Math.max(0, len - TAIL_RECHECK));
   from = Math.max(from, v.winStart ?? 0);
-  const keep = hasSpacer + (from - (v.winStart ?? 0));
-  while (v.el.childNodes.length > keep) v.el.removeChild(v.el.lastChild as ChildNode);
+  // Drop every node from unit `from` onward, then re-render that span. Trim by DATA-UNIT, never by
+  // child COUNT: a unit can put more than one node in the thread (a day divider precedes the turn
+  // that opens a new day), so `keep = spacer + (from - winStart)` counted one node per unit and the
+  // extra dividers made it delete that many live turns off the tail, which then never came back.
+  // Reading the unit off the node is exact however many nodes a unit owns; the top spacer carries no
+  // data-unit, so it stops the walk on its own.
+  const unitOf = (n: ChildNode): number =>
+    n instanceof HTMLElement && n.dataset.unit != null ? Number(n.dataset.unit) : -1;
+  while (v.el.lastChild && unitOf(v.el.lastChild) >= from) v.el.removeChild(v.el.lastChild);
   for (let i = from; i < len; i++) {
-    const node = renderEvent(s.events[i], prevTimedEpoch(s.events, i), turnWorkedSecs(s.events, i, working));
+    const prev = prevTimedEpoch(s.events, i);
+    const ep = eventEpoch(s.events[i]);
+    if (ep != null) {   // a day boundary opens with its divider here too, or the tail append would drop it
+      const dv = dayDividerFor(ep, prev);
+      if (dv) { dv.dataset.unit = String(i); v.el.appendChild(dv); }
+    }
+    const node = renderEvent(s.events[i], prev, turnWorkedSecs(s.events, i, working));
     node.dataset.unit = String(i);   // unit === event in normal mode
     v.el.appendChild(node);
   }
@@ -4967,6 +5005,13 @@ function appendItem(v: View, s: Session, items: DisplayItem[], u: number, prevEp
   const it = items[u];
   const tag = (node: HTMLElement): HTMLElement => { node.dataset.unit = String(u); return node; };
   const adv = (i: number) => { const ep = eventEpoch(s.events[i]); if (ep != null) prevEpoch = ep; };
+  // A new day opens with its divider, above whatever unit starts that day (tagged with the same
+  // data-unit so the scroll↔unit map still resolves every node it walks).
+  const dayOpen = eventEpoch(s.events[itemFirstEvent(it)]);
+  if (dayOpen != null) {
+    const dv = dayDividerFor(dayOpen, prevEpoch);
+    if (dv) v.el.appendChild(tag(dv));
+  }
   if (it.kind === "toolgroup") {
     const first = s.events[it.indices[0]];
     const key = toolGroupKey(first);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -927,11 +927,19 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 }
 /* match the dot's vertical position per turn type (default dot top:15, tool/thinking top:10) */
 .turn-tool .time-marker, .turn-thinking .time-marker { top: 10px; }
-.time-marker.day { color: var(--fg); font-weight: 700; }
-/* day marker stacks two lines so the date doesn't overrun the gutter into the dot: the date
-   floats on its own row directly ABOVE, the time stays in-flow on the dot's row. */
-.time-marker.day .tm-date { position: absolute; right: 0; bottom: 100%; white-space: nowrap; }
-.time-marker.day .tm-time { color: var(--dim); font-weight: 400; }   /* time reads like any other marker */
+/* DAY DIVIDER (the user 2026-08-01) — the date on a hairline rule across the prose column,
+   above the first turn of a new day. The date used to stack inside the rail marker, but the
+   gutter is 47px wide and "Yesterday" measures 52.6px bold, so its "Y" fell off the left edge
+   of the pane; anything sized to FIT that gutter re-clips the moment --vscode-chat-font-size
+   grows. Out here the label has the whole column, so no date string can ever be cut off.
+   Left-aligned with the prose (turns pad 24px); the rule fills the rest of the line. */
+.day-divider {
+  display: flex; align-items: center; gap: 9px;
+  margin: 16px 0 6px; padding-left: 24px;
+  font-size: 0.76em; letter-spacing: 0.02em;   /* same size as .time-marker — same kind of label */
+}
+.day-divider-label { flex: 0 0 auto; color: var(--fg); font-weight: 700; white-space: nowrap; }
+.day-divider::after { content: ""; flex: 1 1 auto; height: 1px; background: var(--box-border); }
 /* "worked …" footer — how long the session ran on a finished prompt. Sits IN-FLOW
    below that prompt's last reply, left-justified under the response text (turns pad
    30px on the left, so a normal block lands at the text's left edge). It used to ride

--- a/ui/webview/time-marker.ts
+++ b/ui/webview/time-marker.ts
@@ -6,18 +6,22 @@ export const WEEKDAY = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 export const MONTH = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 export interface MarkerLabel {
-  text: string; // "" → suppressed (same minute as the previous timed turn)
-  day: boolean; // true → first turn of a past day; emphasise + show the date
+  text: string; // "" → suppressed (same minute as the previous timed turn). On a day marker this
+                // is still the combined "Yesterday · 11:03", but the rail renders only `hm` there
+                // and hands `date` to the divider, so here it mostly answers "is there a stamp?"
+  day: boolean; // true → first turn of a past day; opens a day divider carrying the date
   hm: string;   // the bare "HH:MM", ALWAYS — a suppressed turn still carries its time so the
                 // sticky rail stamp can name the time at the top of the view.
   date: string; // the date word ("Yesterday" / "Mon" / "Jun 3") on a day marker, else "".
-                // Named so the renderer can stack it on its OWN line above hm — a combined
-                // "Yesterday · 21:24" overruns the narrow rail gutter and hits the dot.
+                // Split out from `text` because the renderer puts it on a full-width DAY DIVIDER
+                // rather than in the rail (dayDividerFor in render.ts): the gutter is 47px wide
+                // and "Yesterday" measures 52.6px, so in the rail its leading "Y" was clipped.
 }
 
 // HH:MM for a turn, given the previous TIMED turn's epoch (or null) and "now".
 // Rules, in order:
-//   1. First turn of a past (non-today) day → "Yesterday · 11:03" / "Mon · …" / "Jun 3 · …", emphasised.
+//   1. First turn of a past (non-today) day → day: true, with the date word split into `date`.
+//      The rail shows just "11:03"; the date opens a divider above the turn (see dayDividerFor).
 //   2. Same minute AND same day as the previous timed turn → suppressed (""), so a run of
 //      same-minute events (11:03, 11:03, 11:03, 11:04) shows the stamp only when it changes.
 //   3. Otherwise → "HH:MM".


### PR DESCRIPTION
The day marker had no room to render: the rail gutter is **47px** wide, and `.tm-date` "Yesterday" measures **52.6px** bold at the default 13px, starting at `x = -5.6` — so the pane clipped its leading "Y".

Shrinking it to fit is not a fix. `--fs` follows `--vscode-chat-font-size`, so a larger chat font re-clips whatever just barely fit at 13px (at 16px the word needs 63.3px).

So the date leaves the rail. A day boundary now opens with a hairline divider across the prose column carrying `Yesterday` / `Mon` / `Jun 3`, and the gutter shows only `HH:MM`. Out there the label has the whole column and no date string can be cut off at any font size.

**Notes**

- The divider is a **sibling** before the turn, never a child: `.dot` and `.time-marker` are absolutely positioned against the turn's top edge, so a divider inside would push the message down and strand the dot up beside the rule.
- Emitted on all three append paths (windowed rebuild, incremental tail append, cleared-episode fold), so scrolling back cannot disagree with the live tail. The fold also chains its prev epoch now, which stops it re-stamping the full date on every turn in it.
- **Knock-on fixed in the same commit:** the hot tail-append path trimmed the DOM by child COUNT, assuming one node per unit. A day divider makes a unit own two nodes, so that arithmetic deleted a live turn per divider in the kept range and never re-rendered it. It now trims by `data-unit`, exact however many nodes a unit owns.

**Verified**

Measured before/after in a standalone repro built from the real `styles.css` and the exact DOM the renderer emits, at both 13px and 16px — every label renders fully (`x=68`, nothing clipped). `npm run typecheck` clean; node suite 1585 pass / 0 fail; pytest 3801 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)