### PR TITLE
Stamp the interrupt block and its lift with the event, not the clock

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -169,21 +169,12 @@ def _interrupt_cause(nxt_atom):
     return None
 
 
-def _interrupt_suppresses_nudge(turns):
-    """True while the session's most recent USER action is a GENUINE user INTERRUPT: the user stopped
-    the agent and hasn't spoken since, so they're at the controls — auto-nudge stays suppressed until
-    their NEXT message (the user 2026-07-05, refined via ui: re-engage on the user-message EVENT, never
-    a timer or merely "a newer turn ended"). Concretely: the newest genuine-stop interrupt record
-    outranks the newest genuine HUMAN prompt. A peer postal message or romp injection opening a turn in
-    between does NOT lift it — only the user speaking does. The interrupt record itself authors 'human',
-    so it's classified FIRST. Also drives the feed's "interrupted" badge: the card's quiet is user-chosen.
-
-    A MACHINE cut — a kernel restart or the session's own process dying mid-turn — mints the SAME stop
-    record, but romp (not the user) caused it and immediately queued a resume notice to CONTINUE the
-    work, so it must never suppress the nudge nor paint "you stopped this — romp won't follow up" (the
-    user 2026-07-14: restart-cut SDK sessions sat inertly in Working wearing that false badge, and
-    auto-nudge stayed off so a genuine RE-stall was never caught). Such a cut is identified by the romp
-    resume notice that FOLLOWS its record (_interrupt_cause) and is EXCLUDED from the user-stop tally."""
+def _interrupt_marks(turns):
+    """(newest genuine user STOP, newest genuine human PROMPT) on this thread, in transcript time —
+    the one place the two are tallied, so the predicate below and the interrupt block's EVIDENCE stamp
+    read the same events. A MACHINE cut (kernel restart / process death) mints the same stop record but
+    is romp's own, so it never counts as a stop (_interrupt_cause, via the resume notice that follows
+    it). The interrupt record itself authors 'human', so it's classified FIRST."""
     users = [a for turn in turns for a in (turn.get("atoms") or []) if a.get("type") == "user"]
     last_intr = last_human = 0
     for i, a in enumerate(users):
@@ -194,6 +185,25 @@ def _interrupt_suppresses_nudge(turns):
             last_intr = max(last_intr, t)
         elif a.get("author") == "human":
             last_human = max(last_human, t)
+    return last_intr, last_human
+
+
+def _interrupt_suppresses_nudge(turns):
+    """True while the session's most recent USER action is a GENUINE user INTERRUPT: the user stopped
+    the agent and hasn't spoken since, so they're at the controls — auto-nudge stays suppressed until
+    their NEXT message (the user 2026-07-05, refined via ui: re-engage on the user-message EVENT, never
+    a timer or merely "a newer turn ended"). Concretely: the newest genuine-stop interrupt record
+    outranks the newest genuine HUMAN prompt. A peer postal message or romp injection opening a turn in
+    between does NOT lift it — only the user speaking does. Also drives the feed's "interrupted" badge:
+    the card's quiet is user-chosen.
+
+    A MACHINE cut — a kernel restart or the session's own process dying mid-turn — mints the SAME stop
+    record, but romp (not the user) caused it and immediately queued a resume notice to CONTINUE the
+    work, so it must never suppress the nudge nor paint "you stopped this — romp won't follow up" (the
+    user 2026-07-14: restart-cut SDK sessions sat inertly in Working wearing that false badge, and
+    auto-nudge stayed off so a genuine RE-stall was never caught). Such a cut is identified by the romp
+    resume notice that FOLLOWS its record (_interrupt_cause) and is EXCLUDED from the user-stop tally."""
+    last_intr, last_human = _interrupt_marks(turns)
     return last_intr > last_human
 
 
@@ -1883,42 +1893,64 @@ def _interrupt_focus_top(store):
     return None
 
 
-def _record_interrupt_block(sid):
+def _record_interrupt_block(sid, ev):
     """Interrupted → Blocked (the user 2026-07-07, extending the stalled rule): the user stopped the
     session mid-turn and nothing will move until they speak, so by definition the focus goal needs
     them. Record a block verdict (src "interrupt") in the goal's diary — the same normal ladder every
     block rides — and remember the gid in auto-nudge.json so the LIFT on re-engage is cheap (only
-    sessions we blocked get their store re-checked). Returns the gid blocked, or None."""
+    sessions we blocked get their store re-checked). Returns the gid blocked, or None.
+
+    `ev` = the STOP's own transcript time (_interrupt_marks), never wall-clock now: the diary is an
+    evidence-time ledger, and a wall-clock stamp on a store the judges also write is what deadlocked
+    the lift below."""
     store = jd.load_goals(sid)
     gid = _interrupt_focus_top(store)
     if not gid:
         return None
     nd = store["nodes"][gid]
     why = jd.INTERRUPT_BLOCK_WHY      # shared constant, PROCEDURAL (see judge.procedural_block_why)
-    now = int(time.time())
-    if not jd.record_verdict(store, nd, "interrupt", "block", now, why=why):
+    ev = int(ev or 0)
+    if not jd.record_verdict(store, nd, "interrupt", "block", ev, why=why):
         return None
-    nd["mt"] = now                                    # the event materialized blocked + blockWhy
-    jd.append_block(sid, gid, "interrupt", why, now)  # journal before the save it protects (a judge
-    #                                                   pass's stale save erases out-of-band rows)
+    nd["mt"] = max(nd.get("mt") or 0, ev)            # the event materialized blocked + blockWhy (never
+    #                                                  backwards: mt is a display stamp the brief keys on)
+    jd.append_block(sid, gid, "interrupt", why, ev)  # journal before the save it protects (a judge
+    #                                                  pass's stale save erases out-of-band rows)
     jd.rollup_status(store, False)
     jd.save_goals(sid, store)
     _mark_views_dirty()
     return gid
 
 
-def _lift_interrupt_block(sid, gid):
-    """The user re-engaged (their next message — the same event that re-arms auto-nudge): the interrupt
-    block is lifted with an explicit unblock event, so the diary stays the authority (an eventless flag
-    clear would be re-blocked by the next materialize). Only lifts a block WE placed (the diary's latest
-    block has src "interrupt") — a real judge verdict recorded since then owns the card and stays."""
+def _lift_interrupt_block(sid, gid, ev):
+    """The session re-engaged (the user's next message, or romp continuing a machine cut — the same
+    event that re-arms auto-nudge): the interrupt block is lifted with an explicit unblock event, so
+    the diary stays the authority (an eventless flag clear would be re-blocked by the next
+    materialize). Only lifts a block WE placed (the diary's latest block has src "interrupt") — a real
+    judge verdict recorded since then owns the card and stays.
+
+    `ev` = the EVIDENCE time of that re-engagement — the trigger of the turn it opened — and NOT
+    wall-clock now (the user 2026-08-01). Every judge verdict stamps the TRIGGER of the segment it
+    ruled on, so a lift stamped `now` while that segment is still running sorts after it forever: the
+    fold, which orders by ev_t, then replayed the lift AFTER the planner's and closer's block about
+    that very segment and erased both. The audited card: a restart cut a session mid-turn, romp's
+    resume notice opened the next turn, the lift fired 2m into it stamped `now`, the session finished
+    by asking the user a question — and the block the judges filed on it never took. The card sat in
+    Working on an idle session for six minutes with no block, no waiting chip, no nudge (that same row
+    read as "evidence newer than the last turn romp saw end", so _nudge_fire_list held the nudge under
+    a why the stall surface screens), until a peer's message opened a fresh turn whose verdict finally
+    outranked it. Floored at the block's own stamp so the lift can never sort BEFORE what it lifts —
+    the same guard rollup_status's moot-unblock uses."""
     store = jd.load_goals(sid)
     nd = store.get("nodes", {}).get(gid)
     if nd is None:
         return
-    lastblk = next((e.get("src") for e in reversed(nd.get("log") or []) if e.get("kind") == "block"), None)
+    log = nd.get("log") or []
+    lastblk = next((e.get("src") for e in reversed(log) if e.get("kind") == "block"), None)
     if lastblk == "interrupt" and nd.get("blocked"):
-        jd.record_verdict(store, nd, "user", "unblock", int(time.time()), why="you re-engaged")
+        ev = max(int(ev or 0), max((e.get("ev_t") or 0 for e in log if e.get("kind") == "block"),
+                                   default=0))
+        jd.record_verdict(store, nd, "user", "unblock", ev, why="you re-engaged")
         jd.rollup_status(store, False)
         jd.save_goals(sid, store)
         _mark_views_dirty()
@@ -1946,9 +1978,10 @@ def _interrupt_block_tick(now, tmux):
     it belongs in the Blocked (needs-you) column — never sitting quietly in Working. This flip used to
     live inside _auto_nudge_tick, so it only happened with auto-nudge ON; it is a needs-you rule, not a
     nudge feature, so it runs every push regardless of the toggle. A MACHINE cut (kernel restart /
-    process death) is NOT a user stop — _interrupt_suppresses_nudge already excludes it — so those are
-    continued, never blocked. On re-engage (the user's next message, or once a machine cut is no longer
-    the latest action) the block WE placed is lifted; a real judge verdict recorded since then stays."""
+    process death) is NOT a user stop — _interrupt_marks already excludes it — so those are continued,
+    never blocked. On re-engage (the user's next message, or once a machine cut is no longer the latest
+    action) the block WE placed is lifted; a real judge verdict recorded since then stays. Both writes
+    are stamped with the EVENT they are about, never wall-clock now — see _lift_interrupt_block."""
     changed = False
     for s in _alive_sessions(now, tmux):
         sid = s["sid"]
@@ -1963,16 +1996,20 @@ def _interrupt_block_tick(now, tmux):
             turns = jd.parsed_session(sid, [s["path"]], now)["turns"]
         except Exception:
             continue
-        block_it = bool(turns) and not _session_working(turns) and _interrupt_suppresses_nudge(turns)
+        stop_t, human_t = _interrupt_marks(turns)        # the two EVENTS this tick reasons about — and the
+        #                                                  evidence times both writes are stamped with
+        block_it = bool(turns) and not _session_working(turns) and stop_t > human_t
         if block_it:                                     # a GENUINE user stop → block the focus goal on them,
             if not _intr_blocked(sid):                   # once per interrupt episode (the intrBlocked marker)
-                g = _record_interrupt_block(sid)
+                g = _record_interrupt_block(sid, stop_t)
                 if g:
                     _set_intr_blocked(sid, g); changed = True
         else:                                            # working / re-engaged / machine cut → lift OUR block if any
             ib = _intr_blocked(sid)
             if ib:
-                _lift_interrupt_block(sid, ib)
+                # the re-engagement IS the newest turn's trigger — the same stamp the judges will put on
+                # every verdict about that turn, so their ruling outranks this lift on arrival order
+                _lift_interrupt_block(sid, ib, turns[-1].get("t") if turns else 0)
                 _set_intr_blocked(sid, None); changed = True
     if changed:                                          # a needs-you flip should reach the feed at once
         _push_all()

--- a/tests/test_interrupt_lift_evidence_time.py
+++ b/tests/test_interrupt_lift_evidence_time.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""romp's interrupt block and its LIFT are stamped with the EVENT they are about, never wall-clock now.
+
+The diary is an evidence-time ledger: every judge verdict carries the TRIGGER of the segment it ruled
+on, and the fold replays rows in that order. So a lift stamped `now` while that segment is still
+running sorts after every verdict about it — permanently — and the fold erases them.
+
+The audited card (the user 2026-08-01): a kernel restart cut a session mid-turn; romp's resume notice
+opened the next turn; two minutes in, the interrupt-block lift fired stamped `now`; the session worked
+on and ended that turn by asking the user a question. The planner and the closer both filed a block
+about it — and both were replayed BEFORE the lift and wiped. The card sat in Working on an idle session
+with no block, no waiting chip, no nudge (that same row also read as "evidence newer than the last turn romp
+saw end", so _nudge_fire_list held the nudge under a why the stall surface screens), until a peer's
+message six minutes later opened a fresh turn whose verdict finally outranked it.
+
+Synthetic fixtures only.
+"""
+import json
+import os
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+_STATE_TMP = tempfile.mkdtemp()
+os.environ["XDG_STATE_HOME"] = _STATE_TMP
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+sb = SourceFileLoader("romp_sdk_backend_ile", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+km = SourceFileLoader("romp_kernel_ile", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+# A SID of this file's own: the judge module is process-shared across every kernel test copy, so the
+# append-only overrides journal is shared too — a same-SID block journaled elsewhere would replay here.
+SID = "11111111-2222-3333-4444-666666666666"
+GID = SID + ":g1"
+NOW = 1781100000
+CUT_T = NOW - 900          # the restart cut the turn here
+RESUME_T = NOW - 890       # romp's resume notice opened the next turn (its TRIGGER: what judges stamp)
+LIFT_WALL_T = NOW - 750    # …and the lift fired two minutes into it — the wall-clock stamp that broke
+FILED_T = NOW - 600        # the judges ruled on that turn once it ended
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent, stop):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+def _seed():
+    store = {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "lastNode": GID,
+             "nodes": {GID: {"id": GID, "text": "Ship the reconnect banner", "parentId": None,
+                             "nodeComplete": False, "blocked": False, "cleared": False,
+                             "trail": [], "t": NOW - 3600, "mt": CUT_T}}}
+    jd.rollup_status(store, False)
+    jd.save_goals(SID, store)
+    return store
+
+
+def _row(nd, kind, src=None):
+    return next((e for e in reversed(nd.get("log") or [])
+                 if e["kind"] == kind and (src is None or e["src"] == src)), None)
+
+
+class TheStampsAreEvidenceTimes(unittest.TestCase):
+    """Both writers carry the moment they are ABOUT — the stop's own transcript time, and the trigger
+    of the turn the re-engagement opened."""
+
+    def setUp(self):
+        km._write_auto_nudge({"enabled": True, "nudged": {}})
+        fp = jd._overrides_dir() / (SID + ".jsonl")
+        if fp.exists():
+            fp.unlink()
+        _seed()
+
+    def test_the_block_carries_the_stops_own_time(self):
+        km._record_interrupt_block(SID, CUT_T)
+        nd = jd.load_goals(SID)["nodes"][GID]
+        self.assertEqual(_row(nd, "block")["ev_t"], CUT_T)
+        self.assertEqual(nd["mt"], CUT_T, "the display stamp rides the same event")
+
+    def test_the_lift_carries_the_reengagement_not_wall_clock(self):
+        km._record_interrupt_block(SID, CUT_T)
+        km._lift_interrupt_block(SID, GID, RESUME_T)
+        nd = jd.load_goals(SID)["nodes"][GID]
+        self.assertEqual(_row(nd, "unblock")["ev_t"], RESUME_T,
+                         "the lift is stamped with the turn it re-engaged into, not when the tick noticed")
+        self.assertLess(_row(nd, "unblock")["ev_t"], int(time.time()) - 600,
+                        "a wall-clock stamp would outrank every verdict about that turn, forever")
+        self.assertEqual(jd.load_goals(SID)["status"][GID], "working", "and the block still lifts")
+
+    def test_the_lift_never_sorts_before_the_block_it_lifts(self):
+        # a re-engagement whose turn PREDATES the stop (a stale parse, a clock skew) would fold ahead of
+        # the block and leave the card stuck blocked — floored, the same guard the moot-unblock uses
+        km._record_interrupt_block(SID, CUT_T)
+        km._lift_interrupt_block(SID, GID, CUT_T - 300)
+        nd = jd.load_goals(SID)["nodes"][GID]
+        self.assertEqual(_row(nd, "unblock")["ev_t"], CUT_T)
+        self.assertEqual(jd.load_goals(SID)["status"][GID], "working")
+
+    def test_a_real_verdict_since_still_owns_the_card(self):
+        km._record_interrupt_block(SID, CUT_T)
+        st = jd.load_goals(SID)
+        jd.record_verdict(st, st["nodes"][GID], "closer", "block", RESUME_T, why="which host?")
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+        km._lift_interrupt_block(SID, GID, RESUME_T)
+        self.assertEqual(jd.load_goals(SID)["status"][GID], "blocked",
+                         "the lift only ever clears a block WE placed")
+
+
+class TheFoldReplaysTheVerdictAfterTheLift(unittest.TestCase):
+    """The incident, at the fold: the judges' block about the resumed turn must survive a lift that
+    fired while that turn was still running."""
+
+    def _log(self, lift_ev):
+        return [{"ev_t": CUT_T, "src": "interrupt", "kind": "block", "at": CUT_T,
+                 "why": jd.INTERRUPT_BLOCK_WHY},
+                {"ev_t": lift_ev, "src": "user", "kind": "unblock", "at": LIFT_WALL_T,
+                 "why": "you re-engaged"},
+                {"ev_t": RESUME_T, "src": "planner", "kind": "block", "at": FILED_T,
+                 "why": "needs the staging host name"},
+                {"ev_t": RESUME_T, "src": "closer", "kind": "block", "at": FILED_T + 13,
+                 "why": "needs the staging host name"}]
+
+    def test_an_evidence_time_lift_lets_the_verdict_land(self):
+        self.assertEqual(jd._fold_node_state({"id": GID, "log": self._log(RESUME_T)}), "blocked",
+                         "the judges ruled on the turn the lift re-engaged into — newer information")
+
+    def test_a_wall_clock_lift_erases_it(self):
+        # the defect, pinned: nothing about these rows changes except the lift's stamp
+        self.assertEqual(jd._fold_node_state({"id": GID, "log": self._log(LIFT_WALL_T)}), "open",
+                         "a mid-segment wall-clock stamp replays after the verdicts about that segment")
+
+    def test_a_verdict_about_an_OLDER_turn_is_still_superseded(self):
+        rows = self._log(RESUME_T)
+        rows.append({"ev_t": CUT_T - 60, "src": "closer", "kind": "block", "at": FILED_T + 40,
+                     "why": "a replayed pre-cut segment"})
+        self.assertEqual(jd._fold_node_state({"id": GID, "log": rows}), "blocked")
+        rows = [r for r in rows if r["src"] not in ("planner", "closer")] + [rows[-1]]
+        self.assertEqual(jd._fold_node_state({"id": GID, "log": rows}), "open",
+                         "a catch-up ruling on a turn that predates the re-engagement stays stale")
+
+
+class TheNudgeIsNotHeldByTheLift(unittest.TestCase):
+    """The second half of the silence: _nudge_fire_list drops a goal whose diary holds evidence NEWER
+    than the last turn romp watched end, and records the hold under a why the stall surface screens. A
+    wall-clock lift is exactly such a row — so the card showed no nudge and no stalled chip either."""
+
+    def _fresh(self, lift_ev):
+        return {"nodes": {GID: {"id": GID, "log": [
+                    {"ev_t": CUT_T, "src": "interrupt", "kind": "block", "at": CUT_T},
+                    {"ev_t": lift_ev, "src": "user", "kind": "unblock", "at": LIFT_WALL_T}]}},
+                "status": {GID: "working"}}
+
+    def test_an_evidence_time_lift_leaves_the_nudge_free_to_fire(self):
+        held = []
+        keep = km._nudge_fire_list(self._fresh(RESUME_T), [(GID, 0, True)],
+                                   arm_t=CUT_T, seen_t=RESUME_T, held=held)
+        self.assertEqual([f[0] for f in keep], [GID])
+        self.assertEqual(held, [], "nothing in the diary postdates the turn romp saw end")
+
+    def test_a_wall_clock_lift_holds_it_invisibly(self):
+        held = []
+        keep = km._nudge_fire_list(self._fresh(LIFT_WALL_T), [(GID, 0, True)],
+                                   arm_t=CUT_T, seen_t=RESUME_T, held=held)
+        self.assertEqual(keep, [])
+        self.assertEqual([f[0] for f in held], [GID])
+        self.assertFalse(jd.stall_why_stands(jd.WHY_TURN_IN_FLIGHT, SID),
+                         "and the hold's why is screened off the stall surface — hence a silent card")
+
+
+class EndToEndThroughTheTick(unittest.TestCase):
+    """Through the parse: a genuine stop blocks the focus goal, the user's next message lifts it — and
+    the closer's verdict about THAT message's turn puts the card back in needs-you, where the six-minute
+    silent Working card should have been."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        self.tpath = pdir / (SID + ".jsonl")
+        names = td / "names"; names.mkdir()
+        (names / SID).write_text("api\t%s\t#abcdef\n" % str(cdir))
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE, km.NAMES, jd.CLOSER_ON)
+        jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE = names, proj, td / "goals", td
+        km.NAMES = names
+        jd.CLOSER_ON = False
+        jd.GOALDIR.mkdir(parents=True)
+        km._downtime[:] = []
+        km._parse_cache.clear()
+        km._autonudge_cache.clear()
+        km._pending_ops.clear()
+        km._write_auto_nudge({"enabled": True, "nudged": {}, "intrBlocked": {}})
+        self.tmux = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+                           "context": None, "compactPct": None, "color": None}}
+        recs = [uline(NOW - 3600, "wire up the reconnect banner", "u1"),
+                aline(NOW - 3580, "on it", "a1", "u1", "tool_use"),
+                uline(CUT_T, "[Request interrupted by user]", "u2", "a1")]
+        self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        g = {"id": GID, "text": "Ship the reconnect banner", "parentId": None, "nodeComplete": False,
+             "blocked": False, "cleared": False, "trail": [], "t": NOW - 3600}
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            {"rompUuid": SID, "seq": 1, "lastNode": GID, "closedTurns": [], "nodes": {GID: g},
+             "placements": {}, "status": {GID: "working"}}))
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE, km.NAMES, jd.CLOSER_ON) = self.saved
+        km._pending_ops.clear()
+        km._parse_cache.clear()
+        km._autonudge_cache.clear()
+        self.td.cleanup()
+
+    def _reengage(self):
+        with open(self.tpath, "a") as f:
+            f.write(json.dumps(uline(RESUME_T, "use the staging host for now", "u3", "u2")) + "\n")
+            f.write(json.dumps(aline(RESUME_T + 40, "done — which host do you want for prod?",
+                                     "a2", "u3", "end_turn")) + "\n")
+        km._parse_cache.clear()
+
+    def test_the_lift_records_the_reengagement_turns_trigger(self):
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(jd.load_goals(SID)["status"][GID], "blocked")
+        self._reengage()
+        km._interrupt_block_tick(NOW, self.tmux)
+        nd = jd.load_goals(SID)["nodes"][GID]
+        self.assertEqual(jd.load_goals(SID)["status"][GID], "working")
+        self.assertEqual(_row(nd, "unblock")["ev_t"], RESUME_T,
+                         "the message's own turn trigger — the stamp the judges will use for it too")
+
+    def test_the_verdict_on_the_reengaged_turn_puts_the_card_back_in_needs_you(self):
+        km._interrupt_block_tick(NOW, self.tmux)
+        self._reengage()
+        km._interrupt_block_tick(NOW, self.tmux)
+        st = jd.load_goals(SID)                       # the judges audit that turn once it ends
+        self.assertTrue(jd.record_verdict(st, st["nodes"][GID], "closer", "block", RESUME_T,
+                                          why="which host for prod?"))
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+        self.assertEqual(jd.load_goals(SID)["status"][GID], "blocked",
+                         "the turn ended by asking the user — the card belongs in needs-you, not Working")
+
+    def test_a_machine_cut_lift_is_stamped_the_same_way(self):
+        # the audited shape: romp's own resume notice is the re-engagement, and the tick lifts on it
+        km._interrupt_block_tick(NOW, self.tmux)
+        with open(self.tpath, "a") as f:
+            f.write(json.dumps(uline(RESUME_T, sb.BOOT_RESUME_NUDGE, "u3", "u2")) + "\n")
+            f.write(json.dumps(aline(RESUME_T + 40, "picked it up; which host for prod?",
+                                     "a2", "u3", "end_turn")) + "\n")
+        km._parse_cache.clear()
+        km._interrupt_block_tick(NOW, self.tmux)
+        nd = jd.load_goals(SID)["nodes"][GID]
+        self.assertEqual(_row(nd, "unblock")["ev_t"], RESUME_T)
+        st = jd.load_goals(SID)
+        jd.record_verdict(st, st["nodes"][GID], "planner", "block", RESUME_T, why="which host for prod?")
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+        self.assertEqual(jd.load_goals(SID)["status"][GID], "blocked",
+                         "a restart-cut session that comes back and asks a question still reaches the user")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_interrupt_blocks.py
+++ b/tests/test_kernel_interrupt_blocks.py
@@ -24,6 +24,8 @@ jd = kern.jd
 SID = "11111111-2222-3333-4444-777777777777"
 GID = SID + ":g1"
 NOW = int(time.time())
+STOP_T = NOW - 120        # transcript time of the stop itself
+REENGAGE_T = NOW - 60     # trigger of the turn the re-engagement opened
 
 
 def _seed(status="working"):
@@ -48,7 +50,7 @@ class InterruptBlocks(unittest.TestCase):
 
     def test_interrupt_blocks_the_focus_goal_via_the_diary(self):
         _seed()
-        gid = kern._record_interrupt_block(SID)
+        gid = kern._record_interrupt_block(SID, STOP_T)
         self.assertEqual(gid, GID)
         st = jd.load_goals(SID)
         self.assertEqual(st["status"][GID], "blocked", "the stopped focus goal needs the user")
@@ -58,8 +60,8 @@ class InterruptBlocks(unittest.TestCase):
 
     def test_reengage_lifts_our_block_with_an_unblock_event(self):
         _seed()
-        kern._record_interrupt_block(SID)
-        kern._lift_interrupt_block(SID, GID)
+        kern._record_interrupt_block(SID, STOP_T)
+        kern._lift_interrupt_block(SID, GID, REENGAGE_T)
         st = jd.load_goals(SID)
         self.assertEqual(st["status"][GID], "working", "the user spoke → the block lifts")
         kinds = [(e["src"], e["kind"]) for e in st["nodes"][GID]["log"]]
@@ -67,12 +69,12 @@ class InterruptBlocks(unittest.TestCase):
 
     def test_a_real_judge_block_recorded_since_stays(self):
         _seed()
-        kern._record_interrupt_block(SID)
+        kern._record_interrupt_block(SID, STOP_T)
         st = jd.load_goals(SID)
         jd.record_verdict(st, st["nodes"][GID], "closer", "block", NOW + 10, why="pick a name")
         jd.rollup_status(st, False)
         jd.save_goals(SID, st)
-        kern._lift_interrupt_block(SID, GID)
+        kern._lift_interrupt_block(SID, GID, REENGAGE_T)
         st = jd.load_goals(SID)
         self.assertEqual(st["status"][GID], "blocked", "a genuine verdict owns the card; the lift is a no-op")
 
@@ -82,7 +84,7 @@ class InterruptBlocks(unittest.TestCase):
         store["nodes"][GID]["nodeComplete"] = True   # (a hand-flip alone would be reverted by the fold)
         jd.rollup_status(store, True)
         jd.save_goals(SID, store)
-        self.assertIsNone(kern._record_interrupt_block(SID))
+        self.assertIsNone(kern._record_interrupt_block(SID, STOP_T))
 
     def test_marker_bookkeeping(self):
         kern._set_intr_blocked(SID, GID)


### PR DESCRIPTION
## The bug

A card sat in the **Working** column of an idle session for six minutes with no block, no waiting chip, no nudge and nothing being judged — the invariant the user has repeatedly asked never to break. From the outside it was simply stalled and silent.

## Root cause

The verdict diary is an **evidence-time** ledger: every judge verdict carries the *trigger* of the segment it ruled on, and `_fold_node` replays rows in that order. romp's interrupt-block lift stamped **wall-clock `now`**, so a lift that fired while a segment was still running sorted after every verdict about that segment — permanently.

The audited sequence:

| time | event |
|---|---|
| 19:02:53 | a kernel restart cut the turn; `interrupt` block filed |
| 19:02:55 | romp's resume notice opened the next turn (its trigger) |
| 19:05:01 | the lift fired, stamped `now` — two minutes *into* that turn |
| 19:07:48 | the session ended the turn by asking the user a question |
| 19:09:08 / 19:09:21 | the planner and the closer each filed a **block** about it, `ev_t` 19:02:55 |
| 19:15:20 | a peer's message opened a fresh turn whose verdict finally outranked the lift |

Replaying the real diary confirms it: with the rows as filed the fold returns `open`; with the lift carrying the re-engagement's evidence time it returns `blocked`.

The same row produced the second half of the silence. It read as "evidence newer than the last turn romp saw end", so `_nudge_fire_list` held the nudge — and that hold's why (`WHY_TURN_IN_FLIGHT`) is deliberately screened off the stall surface, so the card said nothing at all. `auto-nudge.json` has the deferral record to prove it.

## The fix

Both writers now carry the moment they are *about*:

- `_record_interrupt_block(sid, ev)` — the stop's own transcript time.
- `_lift_interrupt_block(sid, gid, ev)` — the trigger of the turn the re-engagement opened. That is the stamp the judges will put on every verdict about that turn, so their ruling wins on arrival order, while a catch-up ruling on an *older* turn stays correctly superseded. Floored at the block's own stamp so the lift can never sort before what it lifts — the same guard `rollup_status`'s moot-unblock uses.

`_interrupt_marks` gives the tick and `_interrupt_suppresses_nudge` one definition of the two events they both read. This is the same lesson the nudge block learned on 2026-07-22 (evidence time, not `now`), applied to the one pair of writers that never got it.

## Tests

`tests/test_interrupt_lift_evidence_time.py`, 12 cases, synthetic fixtures only: the stamps themselves, the fold (including a pin on what the wall-clock stamp did, and that an older turn's ruling is still superseded), the fire-list hold, and end to end through `_interrupt_block_tick` for both a user stop and a machine cut. Seven fail against the unfixed kernel, including the incident itself.

3834 Python tests and 1587 node tests pass.