### PR TITLE
Hold a due nudge only for what the hold claims: a judge's ruling

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2997,6 +2997,15 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
     return fired
 
 
+# Diary sources whose rows can never mean "a judge ruled on a turn romp hasn't seen end" — the one thing
+# _nudge_fire_list's hold is about. romp's own bookkeeping ("romp", "interrupt") and the user's own
+# gestures ("user", "agent") stamp WALL-CLOCK now rather than a segment trigger, so on an idle session
+# such a row outranks the last ended turn permanently. Every judge — planner, closer, unblocker, courier,
+# grouper, and any added later — is counted by default; this is a denylist on purpose, because a row
+# wrongly counted wedges the nudge silently while one wrongly skipped only nudges a beat early.
+NUDGE_HOLD_EXEMPT_SRC = ("user", "agent", "romp", "interrupt")
+
+
 def _nudge_fire_list(fresh, to_fire, arm_t=None, seen_t=None, held=None):
     """The subset of this tick's due nudges still worth sending, judged against a FRESH store read
     (the closer-race guard — see the call site). A goal the judges moved off plain 'working' since the
@@ -3035,6 +3044,15 @@ def _nudge_fire_list(fresh, to_fire, arm_t=None, seen_t=None, held=None):
     Once a turn has ENDED, a verdict about it that leaves the goal working is the considered verdict —
     the same reasoning the 2026-07-30 fix made for the arm turn, which is just this turn's floor.
 
+    Only a JUDGE's row counts (NUDGE_HOLD_EXEMPT_SRC): the hold's own why is "a judge has ruled on a
+    turn that hasn't finished yet", and romp's own bookkeeping — an interrupt lift, an awaiting stamp
+    retired once the dispatches came back — is not that. Those writers stamp WALL-CLOCK now, so on an
+    idle session their row is newer than the last ended turn by construction and can never be outrun:
+    the hold stands, and because the stall surface screens this why, the card says nothing at all. That
+    is one half of the 2026-08-01 silent card (the other half was the interrupt lift's stamp, fixed at
+    the writer). A user gesture is exempt for the same reason and one more: it is the event that RE-ARMS
+    the nudge, so treating it as grounds to withhold one inverts it.
+
     `held` (optional list) collects the goals dropped for newer evidence, so the caller can record the
     hold as a DEFERRAL instead of a silent drop — every other nudge hold leaves a why and rides the 6h
     backstop, and this one leaving nothing is what made the deadlock unreadable from the state dir."""
@@ -3051,7 +3069,9 @@ def _nudge_fire_list(fresh, to_fire, arm_t=None, seen_t=None, held=None):
             #                                          status check, and nothing to hold either — a RESOLVED
             #                                          goal must never reach `held`, or the backstop below
             #                                          would eventually nudge a card that is already done
-        if cut and any((e.get("ev_t") or e.get("at") or 0) > cut for e in nd.get("log") or []):
+        if cut and any(e.get("src") not in NUDGE_HOLD_EXEMPT_SRC
+                       and (e.get("ev_t") or e.get("at") or 0) > cut
+                       for e in nd.get("log") or []):
             if held is not None:                     # a ruling on EVIDENCE from a turn romp hasn't seen end —
                 held.append(f)                       # the stall read is a world old; hold it, don't lose it
             continue

--- a/tests/test_interrupt_lift_evidence_time.py
+++ b/tests/test_interrupt_lift_evidence_time.py
@@ -155,9 +155,10 @@ class TheFoldReplaysTheVerdictAfterTheLift(unittest.TestCase):
 
 
 class TheNudgeIsNotHeldByTheLift(unittest.TestCase):
-    """The second half of the silence: _nudge_fire_list drops a goal whose diary holds evidence NEWER
-    than the last turn romp watched end, and records the hold under a why the stall surface screens. A
-    wall-clock lift is exactly such a row — so the card showed no nudge and no stalled chip either."""
+    """The second half of the silence: _nudge_fire_list holds a goal whose diary gained evidence NEWER
+    than the last turn romp watched end, under a why the stall surface screens — so the card showed no
+    nudge and no stalled chip either. The lift's stamp is one layer; the guard counting only JUDGE rows
+    is the other (test_nudge_hold_judge_rows.py), and the lift now clears both."""
 
     def _fresh(self, lift_ev):
         return {"nodes": {GID: {"id": GID, "log": [
@@ -172,10 +173,20 @@ class TheNudgeIsNotHeldByTheLift(unittest.TestCase):
         self.assertEqual([f[0] for f in keep], [GID])
         self.assertEqual(held, [], "nothing in the diary postdates the turn romp saw end")
 
-    def test_a_wall_clock_lift_holds_it_invisibly(self):
+    def test_not_even_a_wall_clock_lift_can_hold_it_now(self):
         held = []
         keep = km._nudge_fire_list(self._fresh(LIFT_WALL_T), [(GID, 0, True)],
                                    arm_t=CUT_T, seen_t=RESUME_T, held=held)
+        self.assertEqual([f[0] for f in keep], [GID],
+                         "a lift is romp's own bookkeeping, never a judge ruling on an unseen turn")
+        self.assertEqual(held, [])
+
+    def test_a_judge_ruling_on_an_unseen_turn_still_holds(self):
+        fresh = self._fresh(RESUME_T)
+        fresh["nodes"][GID]["log"].append(
+            {"ev_t": LIFT_WALL_T, "src": "closer", "kind": "awaiting", "at": FILED_T})
+        held = []
+        keep = km._nudge_fire_list(fresh, [(GID, 0, True)], arm_t=CUT_T, seen_t=RESUME_T, held=held)
         self.assertEqual(keep, [])
         self.assertEqual([f[0] for f in held], [GID])
         self.assertFalse(jd.stall_why_stands(jd.WHY_TURN_IN_FLIGHT, SID),

--- a/tests/test_nudge_hold_judge_rows.py
+++ b/tests/test_nudge_hold_judge_rows.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""_nudge_fire_list holds a due nudge only for what its why actually claims — "a judge has ruled on a
+turn that hasn't finished yet". romp's own bookkeeping is not that, and neither is a user gesture.
+
+Why it matters: the judges stamp a verdict with the TRIGGER of the segment it ruled on, so a verdict
+about a turn romp has seen end never outruns the cut. romp's own writers stamp WALL-CLOCK now — an
+interrupt lift, an awaiting stamp retired once the dispatched work came back — so on an idle session
+their row is newer than the last ended turn by construction, and nothing can ever move past it. The
+hold then stands forever (bar the 6h backstop), and because the stall surface screens this particular
+why, the card shows no nudge, no chip, no reason: a working card on an idle session saying nothing,
+which is the one state romp must never produce.
+
+The 2026-08-01 silent card came through exactly here, via an interrupt lift. That writer now stamps
+evidence time (test_interrupt_lift_evidence_time.py); this is the guard-side half, and it also closes
+the route the awaiting-lift writer still leaves open. Synthetic fixtures only.
+"""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_nhjr", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-888888888888"
+GID = SID + ":g1"
+NOW = 1781100000
+SEEN_T = NOW - 900        # trigger of the newest turn romp has watched END
+ENDED_T = NOW - 700       # …that turn finished here
+LATER_T = NOW - 300       # anything stamped after it reads as "newer evidence"
+
+
+def _fresh(rows, status="working", **flags):
+    nd = {"id": GID, "log": rows}
+    nd.update(flags)
+    return {"nodes": {GID: nd}, "status": {GID: status}}
+
+
+def _row(src, kind, ev_t, at=None):
+    return {"src": src, "kind": kind, "ev_t": ev_t, "at": at if at is not None else ev_t}
+
+
+def _run(rows, **kw):
+    """(kept, held) for one due nudge on GID."""
+    held = []
+    keep = km._nudge_fire_list(_fresh(rows, **kw), [(GID, 0, True)],
+                               arm_t=SEEN_T, seen_t=SEEN_T, held=held)
+    return [f[0] for f in keep], [f[0] for f in held]
+
+
+class RompsOwnBookkeepingNeverHolds(unittest.TestCase):
+    """These writers stamp wall-clock now, so their rows are permanently 'newer' on an idle session."""
+
+    def test_an_awaiting_lift_does_not_hold_the_nudge(self):
+        # the dispatched work came back and romp retired the wait — the goal is plainly idle again
+        keep, held = _run([_row("romp", "awaiting", LATER_T)])
+        self.assertEqual(keep, [GID], "nothing was judged; the stall read still stands")
+        self.assertEqual(held, [])
+
+    def test_an_interrupt_lift_does_not_hold_the_nudge(self):
+        keep, held = _run([_row("interrupt", "block", SEEN_T - 60), _row("user", "unblock", LATER_T)])
+        self.assertEqual(keep, [GID])
+        self.assertEqual(held, [])
+
+    def test_a_user_gesture_does_not_hold_the_nudge(self):
+        # a gesture is the event that RE-ARMS the nudge; withholding one on it inverts the mechanism
+        keep, held = _run([_row("user", "reopen", LATER_T)])
+        self.assertEqual(keep, [GID])
+        self.assertEqual(held, [])
+
+    def test_an_agent_row_does_not_hold_the_nudge(self):
+        keep, held = _run([_row("agent", "reopen", LATER_T)])
+        self.assertEqual(keep, [GID])
+        self.assertEqual(held, [])
+
+
+class AJudgesRulingStillHolds(unittest.TestCase):
+    """The 2026-07-29 guard, intact: a verdict about a turn romp has not watched end is newer
+    information than the stall inference, and the goal is HELD (deferred), never silently dropped."""
+
+    def test_an_unblocker_ruling_on_a_live_turn_holds(self):
+        keep, held = _run([_row("unblocker", "unblock", LATER_T)])
+        self.assertEqual(keep, [])
+        self.assertEqual(held, [GID], "held with a why, so the 6h backstop can still reach it")
+
+    def test_a_planner_ruling_on_a_live_turn_holds(self):
+        keep, held = _run([_row("planner", "done", LATER_T)])
+        self.assertEqual(held, [GID])
+
+    def test_a_judge_added_later_is_counted_by_default(self):
+        keep, held = _run([_row("triager", "block", LATER_T)])
+        self.assertEqual(held, [GID], "the exemption is a denylist — a new judge holds without a code change")
+
+    def test_a_ruling_about_the_turn_romp_SAW_end_does_not_hold(self):
+        # its ev_t is that turn's trigger; filing happens later, and filing time is not the yardstick
+        keep, held = _run([_row("closer", "done", SEEN_T, at=ENDED_T + 120)])
+        self.assertEqual(keep, [GID])
+        self.assertEqual(held, [])
+
+    def test_a_mix_holds_on_the_judge_row(self):
+        keep, held = _run([_row("romp", "awaiting", LATER_T), _row("closer", "block", LATER_T + 5)])
+        self.assertEqual(held, [GID], "one genuine judge ruling is enough")
+
+
+class ResolvedGoalsNeverReachHeld(unittest.TestCase):
+    """The status re-read runs FIRST: a goal the judges resolved mid-tick is dropped outright, so the
+    backstop can never nudge a card that is already done."""
+
+    def test_a_completed_goal_is_dropped_not_held(self):
+        keep, held = _run([_row("closer", "done", LATER_T)], status="completed", nodeComplete=True)
+        self.assertEqual(keep, [])
+        self.assertEqual(held, [])
+
+    def test_a_blocked_goal_is_dropped_not_held(self):
+        keep, held = _run([_row("closer", "block", LATER_T)], status="blocked", blocked=True)
+        self.assertEqual(keep, [])
+        self.assertEqual(held, [])
+
+
+class TheExemptionSetIsWhatTheCodeUses(unittest.TestCase):
+    def test_the_non_judge_sources_are_named(self):
+        self.assertEqual(set(km.NUDGE_HOLD_EXEMPT_SRC), {"user", "agent", "romp", "interrupt"})
+
+    def test_the_holds_why_is_still_screened_off_the_stall_surface(self):
+        # the reason a wrong hold is SILENT rather than merely wrong — the pairing this guard relies on
+        self.assertFalse(jd.stall_why_stands(jd.WHY_TURN_IN_FLIGHT, SID))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #181, on the same invariant: a working card on an idle session must never be silent.

## The hole

`_nudge_fire_list` holds a due nudge when the goal's diary gained evidence newer than the last turn romp watched end. Its why is **"a judge has ruled on a turn that hasn't finished yet"**, and `stall_why_stands` screens that reason off the stall surface on the strength of it — the card shows nothing because something is genuinely in flight and the Analyzing swirl already tells that story.

But the guard counted **every** diary row, not just a judge's. romp's own bookkeeping and the user's own gestures stamp **wall-clock now** rather than a segment trigger, so on an idle session such a row is newer than the last ended turn *by construction*, and nothing can ever outrun it: the hold stands until the 6h backstop, and the card sits in Working with no nudge, no chip and no reason.

That is how the second half of the 2026-08-01 silent card worked — the interrupt lift's row held the nudge for the whole six minutes; `auto-nudge.json` still carries the deferral record. #181 fixed that writer's stamp. This fixes the guard, and closes the route the **awaiting-lift** writer still leaves open: it retires a wait once the dispatched work comes back, stamped `now`, leaving the goal working — the same silent hold, reachable today.

## The fix

The guard skips `user`, `agent`, `romp` and `interrupt` rows. A **denylist** on purpose: every judge counts by default, including ones added later, because a row wrongly counted wedges the nudge silently while one wrongly skipped only nudges a beat early.

A user gesture is exempt for one more reason — it is the event that *re-arms* the nudge, so reading it as grounds to withhold one inverts the mechanism.

The 2026-07-29 guard is untouched: an unblocker or planner ruling on a turn romp has not seen end still holds, with its deferral record and backstop.

## Tests

`tests/test_nudge_hold_judge_rows.py`, 13 cases: each exempt source, each judge source (including an invented one, pinning the denylist), the resolved-goal drop that must still precede the hold, and the screened-why pairing that makes a wrong hold silent rather than merely wrong. Five fail against the unfixed guard. One case in #181's file is updated: the interrupt lift now clears both layers.

3848 Python tests and 1587 node tests pass.