### PR TITLE
Take a salvaged reply with the message you deleted

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1139,8 +1139,21 @@ def parse_session(leaf_path, rompuuid=None, name=None, color="#888888", dir=None
     adapter.sdk_human = sdk_human            # SDK-backed session → unmarked promptSource "sdk" is the human
     atoms = adapter.atoms(rompuuid, postal_index)
     _srows = _load_states(states)
-    atoms += synthesize_orphans(_srows, atoms)   # salvaged replies FIRST: they are real atoms the turn
+    orphans = synthesize_orphans(_srows, atoms)  # salvaged replies FIRST: they are real atoms the turn
     #                                              grouping must absorb (idle spans overlay afterwards)
+    # A salvaged reply has NO position in the transcript graph — that absence is the very thing the
+    # marker exists to paper over — so the leaf_override walk cannot drop it the way it drops the
+    # abandoned chain. Unfiltered, deleting a message left its reply standing alone in the chat: the
+    # prompt vanished (it was on the chain) while the answer stayed (it was re-synthesized from
+    # states/), which reads as though the delete half-worked (the user 2026-08-01). Filter on the CUT
+    # RECORD's own timestamp — an exact event, not a window — since time is the only ordering a
+    # graph-less atom has. Idle spans are deliberately NOT filtered: they describe the session's
+    # working state NOW (an open span runs to `now`), not conversation content.
+    if leaf_override and leaf_override in adapter.by_uuid:
+        cut_t = parse_z(adapter.by_uuid[leaf_override].get("timestamp"))
+        if cut_t:
+            orphans = [a for a in orphans if a["t"] <= cut_t]
+    atoms += orphans
     atoms += synthesize_idle(_srows, atoms, now)
     turns = segment_turns(atoms, rompuuid)
     for turn in turns:

--- a/tests/test_kernel_rewind.py
+++ b/tests/test_kernel_rewind.py
@@ -197,6 +197,43 @@ class ParseCut(unittest.TestCase):
         self.assertIn("second ask", texts(full))
         self.assertIn("first reply", texts(cut))   # everything up to the cut point survives
 
+    def test_a_salvaged_reply_in_the_abandoned_tail_drops_with_the_cut(self):
+        """Deleting a message must take its REPLY with it even when that reply survives only as an
+        orphanReply marker. A salvaged reply has no position in the transcript graph — that absence
+        is exactly what the marker papers over — so the leaf_override walk cannot drop it the way it
+        drops the abandoned chain. Unfiltered, the prompt vanished (it was on the chain) while the
+        answer stayed standing alone (it was re-synthesized from states/), which reads as a delete
+        that only half worked (the user 2026-08-01)."""
+        recs = [
+            _rec("user", "u1", None, "first ask", timestamp="2026-07-16T10:00:00Z"),
+            _rec("assistant", "a1", "u1", "first reply", timestamp="2026-07-16T10:00:10Z"),
+            _rec("user", "u2", "a1", "second ask", timestamp="2026-07-16T10:00:20Z"),
+        ]
+        p = self._transcript(recs)
+        ep = lambda z: km.em.parse_z(z)
+        markers = [   # one on each side of the cut point (a1, 10:00:10)
+            {"t": ep("2026-07-16T10:00:05Z"), "orphanReply": {"uuid": "o-early", "text": "kept salvage"}},
+            {"t": ep("2026-07-16T10:00:30Z"), "orphanReply": {"uuid": "o-late", "text": "doomed salvage"}},
+        ]
+        texts = lambda s: json.dumps([a.get("message") for t in s["turns"] for a in t["atoms"]])
+        full = km.em.parse_session(p, states=markers)
+        self.assertIn("doomed salvage", texts(full))     # with no delete pending, the salvage shows
+        self.assertIn("kept salvage", texts(full))
+        cut = km.em.parse_session(p, states=markers, leaf_override="a1")
+        self.assertNotIn("second ask", texts(cut))       # the deleted prompt goes, as before
+        self.assertNotIn("doomed salvage", texts(cut))   # and now its salvaged reply goes WITH it
+        self.assertIn("kept salvage", texts(cut))        # a salvage from BEFORE the cut is untouched
+        self.assertIn("first reply", texts(cut))
+
+    def test_the_cut_never_filters_idle_spans(self):
+        """Idle atoms describe the session's working state NOW (an open span runs to `now`), not
+        conversation content — filtering them on the cut's timestamp would blank the live working
+        indicator for any session sitting on a pending delete."""
+        src = inspect.getsource(km.em.parse_session)
+        cut_block = src[src.index("if leaf_override and leaf_override in adapter.by_uuid"):]
+        self.assertNotIn("synthesize_idle", cut_block.split("atoms += orphans")[0])
+        self.assertIn("orphans = [a for a in orphans if a[\"t\"] <= cut_t]", src)
+
     def test_kernel_parse_keys_the_cache_on_the_cut(self):
         # arming and clearing both change the parse with NO file change — the cut must ride the key
         src = inspect.getsource(km._parse)


### PR DESCRIPTION
Deleting a message rolled the conversation back, but its reply could stay on screen alone — the prompt vanished and the answer stayed. That reads as a delete that only half worked, and leaves you unsure what state the thread is actually in.

**Cause.** A reply salvaged from an `orphanReply` marker has no position in the transcript graph — that absence is exactly what the marker papers over. So the `leaf_override` walk that drops the abandoned chain never saw it, and `synthesize_orphans` re-minted it from `states/` on every parse regardless of how the cut landed.

**Fix.** Filter the synthesized orphans on the cut RECORD's own timestamp — an exact event, not a window, and time is the only ordering a graph-less atom has. Idle spans are deliberately left alone: they describe the session's working state *now* (an open span runs to `now`), not conversation content, so cutting them would blank the working indicator for any session holding a pending delete.

**Verified.** Reproduced against the live parser first — deleting the owning message dropped everything else on the chain while the salvaged reply stood alone; after the fix it goes with its prompt, and with no delete pending the salvage still renders (the salvage feature is untouched). The new test fails without the fix on exactly that assertion. Full suites: 3824 pytest, 1587 node, both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)