### PR TITLE
Fix two confusing readings: one commit two versions, and a drag that would not stick

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -331,38 +331,48 @@ def _kernel_sha():
     return _SHA or None
 
 
-_VER = None                                  # lazily-resolved release tag the running code descends from
+_VER = None                                  # lazily-resolved release the running code descends from
 
 
 def _kernel_ver():
-    """The RELEASE this kernel's code descends from — the nearest tag behind HEAD ('v0.2.0'), plus a '+'
-    when HEAD has moved past it. A bare sha means nothing without your own sha to compare it to (the
-    user 2026-07-30), and on a fleet that is exactly the reading you can't do in your head; a tag is a
-    number both machines already agree on. `git describe --tags --abbrev=0` names the tag; the VERSION
-    file is the fallback for a clone with no tags fetched. Resolved once, like _kernel_sha."""
+    """The RELEASE this kernel's code descends from — 'v0.3.0', plus a '+' when HEAD has moved past the
+    commit that cut it. A bare sha means nothing without your own sha to compare it to (the user
+    2026-07-30), and across machines that is exactly the reading you can't do in your head; a release is
+    a number both machines already agree on. Resolved once, like _kernel_sha.
+
+    Derived ENTIRELY from the commit — the tracked VERSION file, and the commit that last wrote it — and
+    NOT from `git describe`, because tags are refs and refs do not travel with the code. `romp update`
+    ships COMMITS (`_update_remote` pushes HEAD to a scratch ref over ssh), so a machine romp has updated
+    holds the new commit and none of the new tags: describing there names whatever OLDER tag that clone
+    happens to have fetched. That is how two machines sitting on the SAME commit reported different
+    versions in the network panel — same code, two numbers, and no way to tell which was lying (the user
+    2026-08-02). The VERSION file and the history behind it are part of the tree that gets pushed, so
+    every machine at one commit now derives one answer.
+
+    The '+' means HEAD is past the release BUMP (the commit that last set VERSION), which is the release
+    boundary the commit graph actually carries; the tag naming that release is usually placed on or just
+    after it, so a machine sitting exactly on the tag reads 'v0.3.0+' rather than 'v0.3.0'. That is the
+    price of a number every machine agrees on, and the sha beside it says precisely where you are."""
     global _VER
     if _VER is None:
-        tag = ""
+        ver = ""
         try:
-            r = subprocess.run(["git", "-C", str(ROOT), "describe", "--tags", "--abbrev=0"],
-                               capture_output=True, text=True, timeout=2)
-            tag = (r.stdout.strip() or "") if r.returncode == 0 else ""
-            if tag:
-                # exact-match tells a tagged release apart from "somewhere after it", so a machine sitting
-                # 27 commits past v0.2.0 never reports itself as v0.2.0 flat
-                e = subprocess.run(["git", "-C", str(ROOT), "describe", "--tags", "--exact-match"],
-                                   capture_output=True, text=True, timeout=2)
-                if e.returncode != 0:
-                    tag += "+"
-        except Exception:
-            tag = ""
-        if not tag:
+            v = (ROOT / "VERSION").read_text().strip()
+            ver = ("v" + v) if v and not v.startswith("v") else v
+        except OSError:
+            ver = ""
+        if ver:
             try:
-                v = (ROOT / "VERSION").read_text().strip()
-                tag = ("v" + v) if v and not v.startswith("v") else v
-            except OSError:
-                tag = ""
-        _VER = tag
+                # the release-bump commit, reachable from HEAD → identical on every clone at this commit
+                b = subprocess.run(["git", "-C", str(ROOT), "log", "-1", "--format=%H", "HEAD", "--", "VERSION"],
+                                   capture_output=True, text=True, timeout=2)
+                bump = (b.stdout.strip() or "") if b.returncode == 0 else ""
+                head = _local_head() or ""
+                if bump and head and bump != head:
+                    ver += "+"
+            except Exception:
+                pass
+        _VER = ver
     return _VER or None
 
 
@@ -5835,6 +5845,15 @@ def _remote_public(r):
     ood = _remote_out_of_date(r)
     drift = _behind_info(r.get("kernel_sha") or "") if ood else {"behind": 0, "ahead": 0, "date": ""}
     stale = (r.get("status") or "down") != "up"
+    # ONE commit, ONE version (the user 2026-08-02, reading "v0.3.0 4a0beaa" here and "v0.2.0+ 4a0beaa"
+    # for a host on that same commit). The release is a property of the CODE, so two machines at one
+    # commit cannot honestly be on two releases: the remote is simply naming it from a tag graph its
+    # clone never received (see _kernel_ver — tags don't travel with a pushed commit, and a remote
+    # running a kernel from before that fix keeps reporting the old way forever). When the shas agree,
+    # this machine's name for that commit is the one both rows wear.
+    ver = r.get("kernel_ver") or ""
+    if _shas_agree(r.get("kernel_sha"), _local_head(short=True)):
+        ver = _kernel_ver() or ver
     return {"host": r["host"], "kernelPort": r["kernel_port"], "localPort": r["local_port"],
             "busPort": r.get("bus_port") or 0,   # peer-bus mode: a restarted bus reseeds its peer table from this
             "checkin": bool(r.get("checkin")),           # we publish ourselves to this hub (stage 3)
@@ -5846,7 +5865,7 @@ def _remote_public(r):
             # The RELEASE each side descends from (the user 2026-07-30): a sha alone says nothing without
             # your own sha in your head, and the whole point of the row is a comparison. "" when the remote
             # kernel predates the field — the row then shows the sha alone rather than guessing a version.
-            "kernelVer": r.get("kernel_ver") or "", "localVer": (_kernel_ver() or ""),
+            "kernelVer": ver, "localVer": (_kernel_ver() or ""),
             "outOfDate": ood, "behindBy": drift["behind"], "aheadBy": drift["ahead"],
             "kernelDate": drift["date"],
             # fastForward: a push here would only ADD commits (the remote's is an ancestor of ours) — the

--- a/tests/test_fleet_sync_log.py
+++ b/tests/test_fleet_sync_log.py
@@ -133,6 +133,46 @@ class VersionTag(unittest.TestCase):
         self.assertNotIn("\\u2193", js)
 
 
+class OneCommitOneVersion(unittest.TestCase):
+    """Two machines on the SAME commit read as two different releases in the network panel (the user
+    2026-08-02: this machine v0.3.0 at 4a0beaa, the host beside it v0.2.0+ at 4a0beaa). The release is a
+    property of the code, so that pairing cannot both be true — and the sha said which reading was the
+    artifact: `romp update` pushes COMMITS over ssh, never tags, so the far clone was naming the release
+    off whatever older tag it had ever fetched."""
+
+    def test_the_release_is_read_off_the_committed_tree_not_the_local_tags(self):
+        body = inspect.getsource(km._kernel_ver).split('"""')[2]   # past the docstring, which says why
+        self.assertIn('"VERSION"', body, "the release name has to travel with the commit")
+        self.assertNotIn("describe", body,
+                         "tags are refs; a pushed commit arrives without them, so describing is a "
+                         "per-clone answer to a per-commit question")
+
+    def test_the_version_matches_the_file_every_machine_gets(self):
+        v = km._kernel_ver()
+        if v is None:
+            return                      # not a git checkout / no VERSION file — nothing to agree on
+        root = os.path.dirname(HERE)
+        with open(os.path.join(root, "VERSION")) as f:
+            want = "v" + f.read().strip()
+        self.assertEqual(v.rstrip("+"), want, "the number both machines can see in their own tree")
+
+    def test_a_host_on_this_commit_wears_this_machines_release(self):
+        row = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 51000, "token": "tok",
+               "status": "up", "sids": [], "kernel_sha": (km._local_head(short=True) or "abc1234"),
+               "kernel_ver": "v0.1.0+", "proc": None}
+        pub = km._remote_public(row)
+        self.assertFalse(pub["outOfDate"], "same commit — nothing to push")
+        self.assertEqual(pub["kernelVer"], pub["localVer"],
+                         "one commit cannot be two releases; the stale tag graph doesn't get a vote")
+
+    def test_a_host_on_another_commit_keeps_its_own_release(self):
+        row = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 51000, "token": "tok",
+               "status": "up", "sids": [], "kernel_sha": "0000000", "kernel_ver": "v0.1.0", "proc": None}
+        pub = km._remote_public(row)
+        self.assertEqual(pub["kernelVer"], "v0.1.0",
+                         "a genuinely different build must still say what IT is running")
+
+
 class SpinWhileWorking(unittest.TestCase):
     """The romp loader shows wherever the panel is WAITING on work (the user 2026-07-30)."""
 

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -425,6 +425,15 @@ export class FederationManager {
     // A drag in ANY pane rewrites the arrangement; every other pane hears it through `storage` (which fires
     // only in other same-origin contexts) and this one through the writer's own CustomEvent. Both land here,
     // and re-emitting all three merged payloads is what moves the tabs, lanes and feed groups together.
+    // ...and it RE-EMITS ONLY: reacting to an arrangement by rewriting it is what made a drag fail to
+    // stick. gcView (below) drops ids the reporting hosts no longer list, judged against THIS context's
+    // session lists — so any pane holding a stale list (a dashboard window whose socket died, a surface
+    // that never got the newest session's push) answered another pane's drag by pruning the very tab
+    // that had just moved, and the writer obeyed the write-back. On the audited drag the strip permuted
+    // correctly and reverted in the same second, twice per attempt, so the tab looked like it never
+    // moved at all — and it was always the NEWEST tab, the one a stale list is most likely to be missing
+    // (the user 2026-08-02). A view arrangement is not new information about what exists; only a host's
+    // own report is, so only an inbound tabOrder push may gc (see emitMergedOrder's `gc`).
     const reorder = () => { this.emitMergedOrder(); this.emitMergedFeed(); this.emitMergedTimeline(false); };
     w.addEventListener("storage", (e: StorageEvent) => { if (!e.key || e.key === VIEW_ORDER_KEY) reorder(); });
     w.addEventListener(VIEW_ORDER_EVENT, reorder);
@@ -446,7 +455,7 @@ export class FederationManager {
       this.perHostOrder[host] = Array.isArray(m.order) ? m.order.filter((x: any) => typeof x === "string") : [];
       this.perHostTabs[host] = Array.isArray(m.tabs) ? m.tabs : [];
       this.ensureHost(host);
-      this.emitMergedOrder();
+      this.emitMergedOrder(true);   // a host just reported its sessions → the one moment gc has fresh evidence
       return;
     }
     if (m && m.type === "feed") {
@@ -511,8 +520,12 @@ export class FederationManager {
     window.dispatchEvent(new MessageEvent("message", { data }));
   }
 
-  private emitMergedOrder(): void {
-    this.gcView();
+  // `gc` is the caller's answer to "did a host just tell me what it has?" — true only on an inbound
+  // tabOrder push, which carries a fresh, complete list for that host. Every other caller (a drag
+  // landing here through the storage / CustomEvent path) re-emits without touching the stored
+  // arrangement, so no pane can prune away what another pane just arranged.
+  private emitMergedOrder(gc = false): void {
+    if (gc) this.gcView();
     const order = mergeHostOrder(this.perHostOrder, this.hostSeq, this.view());
     const tabs = this.hostSeq.flatMap((h) => this.perHostTabs[h] || []);
     window.dispatchEvent(new MessageEvent("message", { data: { type: "tabOrder", order, tabs } }));

--- a/ui/webview/view-order-wiring.test.ts
+++ b/ui/webview/view-order-wiring.test.ts
@@ -45,6 +45,18 @@ test("the timeline's lane drag writes the same store", () => {
   assert.doesNotMatch(BOOT, /type: "writeOrder"/);
 });
 
+test("a pane answers another pane's drag by re-emitting, never by rewriting the arrangement", () => {
+  // The audited failure (the user 2026-08-02): dragging the last tab up between two others permuted the
+  // strip and reverted it in the same second, twice per attempt, so it read as a drag that never took.
+  // Every revert arrived through the `storage` listener — another context answering the write by running
+  // its own gc, which prunes ids ITS session lists don't name and so dropped the tab that had just moved
+  // (the newest tab is the one a stale list is likeliest to be missing). An arrangement is not evidence
+  // about what exists; only a host's own report is, and that is the one caller allowed to gc.
+  assert.match(FED, /this\.emitMergedOrder\(true\);\s+\/\/ a host just reported/, "inbound tabOrder gc's");
+  assert.match(FED, /private emitMergedOrder\(gc = false\): void \{\s*\n\s*if \(gc\) this\.gcView\(\);/,
+    "every other caller — both drag paths included — re-emits without touching the stored order");
+});
+
 test("the stale arrangement self-cleans on the host's own report, not on a clock", () => {
   assert.match(FED, /const reporting = new Set\(Object\.keys\(this\.perHostOrder\)\);/);
   assert.match(FED, /if \(!reporting\.size\) return;/, "no report in hand → prune nothing");


### PR DESCRIPTION
Two independent bugs the user hit in the same sitting.

## One commit reported two versions

The network panel showed this machine on `v0.3.0` at a commit and a host on `v0.2.0+` at the same commit. Both came from `git describe`, which reads the LOCAL tag graph. `romp update` pushes commits over ssh (HEAD to a scratch ref) and never tags, so an updated machine holds the new commit and none of the new tags, and keeps naming whatever older release its clone once fetched.

The release is now derived entirely from the commit: the tracked `VERSION` file for the name, and the commit that last wrote it for the `+`. Both travel with the tree, so every machine at one commit derives one answer. `_remote_public` additionally gives a host on this machine's commit this machine's release, so the panel reads right now rather than after every remote has been updated.

Trade-off, stated in the docstring: `+` now means "past the release bump commit" rather than "not exactly at the tag", so a machine sitting exactly on a tag reads `v0.3.0+`. That is the price of a number every machine agrees on.

## A tab drag that would not stick

Dragging the last tab up between two others drew the drop marker and then did nothing. `order-audit.jsonl` shows the drop landing and reverting within the same second, twice per attempt.

Every revert arrived through federation's `storage` listener: another dashboard context answering the arrangement write by re-running `gcView`, which prunes ids the reporting hosts no longer list, judged against THAT context's session lists. A pane holding a stale list therefore pruned the tab that had just moved, and the writer obeyed the write-back. The newest tab is the one a stale list is likeliest to be missing, which is why the last tab specifically would not move.

An arrangement is not evidence about what exists; only a host's own report is. An inbound `tabOrder` push is now the only caller that may gc.

## Tests

- `tests/test_fleet_sync_log.py::OneCommitOneVersion` (4 tests)
- `ui/webview/view-order-wiring.test.ts` (the gc gate)
- Full suites green: 3854 python passed, 1588 node passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)