### PR TITLE
Read one rate-limit window as one window, however its boundary is dated

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -595,6 +595,23 @@ def append_awaiting(state_dir: Path, sid: str, awaiting: bool, why: str = "") ->
         f.write(json.dumps(rec) + "\n")
 
 
+# How far apart two readings of ONE rate-limit window's reset can sit and still be that window. The two
+# sources romp reads date the same window differently — RateLimitEvents carry the API response headers'
+# reset, the get_usage snapshot carries the /usage endpoint's — and on 2026-08-02 those were 10 minutes
+# apart for the 5h window. The windows themselves are 5 hours and 7 days wide, so a genuine roll moves the
+# stamp by hours at minimum: an hour of slack cannot swallow one, and it absorbs any skew between sources.
+WINDOW_SLACK = 3600
+
+
+def _same_window(a, b) -> bool:
+    """Whether two reset stamps name the SAME rate-limit window. Equality is the wrong test: the two
+    sources quantize the boundary differently, and reading their disagreement as a window ROLL is what
+    reset the bars to 0 seconds after an exact reading landed (see _record_rate_limit)."""
+    if not isinstance(a, (int, float)) or not isinstance(b, (int, float)):
+        return False
+    return abs(a - b) <= WINDOW_SLACK
+
+
 def last_state(state_dir: Path, sid: str) -> dict:
     p = Path(state_dir) / "states" / (sid + ".jsonl")
     try:
@@ -1365,6 +1382,12 @@ class SdkSession:
                 self.backend._update_reg(self.sid, **upd)
             except Exception as e:
                 self.backend._log("context refresh (%s): registry write failed: %s" % (self.name, e))
+        # A moved context % or model is news the panes should see now, not at the next backstop. (This
+        # poke had been separated from the `changed` it reads and left sitting in refresh_usage below,
+        # where the name is undefined — so every /usage click raised NameError instead, and a context
+        # change waited for the backstop.)
+        if changed:
+            self.backend._poke()
 
     async def _do_refresh_usage(self):
         """Pull the EXACT account-wide /usage snapshot from the CLI — the designed data behind the /usage
@@ -1378,23 +1401,37 @@ class SdkSession:
         if not self.client or self._usage_refreshing:
             return
         self._usage_refreshing = True
+        r = None
         try:
             q = getattr(self.client, "_query", None)
-            r = (await q._send_control_request({"subtype": "get_usage"})) if q else None
-        except Exception:
-            r = None
+            if q is None:
+                # The control channel is the ONLY source of an exact reading; without it the bars can
+                # only creep up from the sparse event stream, which is precisely the silently-wrong
+                # number this must not become.
+                self.backend._log("usage refresh (%s): no control channel on the SDK client — the rail "
+                                  "bars will fall back to the rate-limit event stream" % self.name,
+                                  problem=True)
+            else:
+                r = await q._send_control_request({"subtype": "get_usage"})
+        except Exception as e:
+            # LOUD (the user 2026-08-02, whose 5h bar read 18% against a real 45%). This used to swallow
+            # every failure, so a refresh that never landed was indistinguishable from one that did: the
+            # file kept its event-derived floor and the rail presented it as the reading.
+            self.backend._log("usage refresh (%s) failed: %s: %s" % (self.name, type(e).__name__, e))
         finally:
             self._usage_refreshing = False
         if isinstance(r, dict):
             self.backend._record_usage_snapshot(r)
 
     def refresh_usage(self):
-        """Thread-safe trigger for _do_refresh_usage (the kernel's /usage click path)."""
+        """Thread-safe trigger for _do_refresh_usage (the kernel's /usage click path). Returns whether the
+        refresh was actually scheduled, so the backend can move on to another session when this one has no
+        live loop to run it on."""
         if self.loop and self.client:
             self.loop.call_soon_threadsafe(
                 lambda: asyncio.ensure_future(self._do_refresh_usage()))
-        if changed:
-            self.backend._poke()
+            return True
+        return False
 
     async def _next_ask_action(self):
         fut = asyncio.get_running_loop().create_future()
@@ -2477,15 +2514,23 @@ class SdkBackend:
         return sum(1 for s in sessions if s.inflight and not s.ended)
 
     def refresh_usage(self):
-        """Best-effort: ask ONE live connected session for the exact /usage snapshot (get_usage control
-        request). The kernel's /usage click calls this so the NEXT read is fresh; per-turn-end refreshes
-        keep the file current the rest of the time."""
+        """Ask a live connected session for the exact /usage snapshot (get_usage control request). The
+        kernel's /usage click calls this so the NEXT read is fresh; per-turn-end refreshes keep the file
+        current the rest of the time.
+
+        Every candidate is tried until one accepts, not just the first (the user 2026-08-02): one session
+        whose loop has gone away is enough to make a click do nothing at all, and the rail then shows a
+        stale reading with no sign that the refresh never happened. Says so in the log when none can be
+        asked, rather than returning quietly."""
         with self._lock:
             sessions = list(self.sessions.values())
-        for s in sessions:
-            if s.client and s.loop and not s.ended:
-                s.refresh_usage()
+        live = [s for s in sessions if s.client and s.loop and not s.ended]
+        for s in live:
+            if s.refresh_usage():
                 return
+        if live:
+            self._log("usage refresh: %d live session(s), none with a loop to run it on — the rail bars "
+                      "keep their last reading" % len(live), problem=True)
 
     def _record_usage_snapshot(self, r) -> None:
         """Fold a get_usage control-request snapshot into usage.json — EXACT utilization for every window,
@@ -2562,6 +2607,12 @@ class SdkBackend:
           from this backend's stale ACCUMULATOR replaying hours-old windows; the accumulator is gone — each
           event now touches only its own window — so that guard is obsolete, and across an account switch it
           was exactly what STUCK the bars: the old account's later reset beat the new account's live window.)
+          "Different window" is decided by _same_window, NOT by equality: romp's two sources date the SAME
+          window differently (the events read API response headers, the get_usage snapshot reads the /usage
+          endpoint), and on 2026-08-02 they sat 10 minutes apart on the 5h window. Under equality every
+          event after a snapshot read as a fresh roll and reset the bar to 0, so the exact 45% the snapshot
+          had just written was wiped within a second and the rail crept back up from zero on the rare
+          warning-band events — the user's bar read 18% against a real 45%.
         - `rejected` IS the limit: pct=100 even with utilization=None → the rail's limited banner + retry-pause
           engage (previously this event was dropped and romp missed the limit entirely).
         - `allowed` with unknown utilization in a brand-new window reads pct=0 (a window rolls with ~0 usage;
@@ -2600,10 +2651,16 @@ class SdkBackend:
                 cur = {}
             seg = cur.get(key) if isinstance(cur.get(key), dict) else None
             cur_ra = seg.get("resets_at") if seg and isinstance(seg.get("resets_at"), (int, float)) else None
-            if ra is not None and cur_ra != ra:
-                new = {"pct": pct if pct is not None else 0, "resets_at": ra}   # the event's window is the live one
+            if ra is not None and seg is None:
+                new = {"pct": pct if pct is not None else 0, "resets_at": ra}   # nothing on file to reconcile with
+            elif ra is not None and cur_ra is not None and not _same_window(ra, cur_ra):
+                new = {"pct": pct if pct is not None else 0, "resets_at": ra}   # a real roll: this window is new
             elif seg:
-                new = dict(seg)                       # same window (or the event carries no window identity)
+                # SAME window — either the event names no window, or its stamp is the same window said
+                # differently (see _same_window). Keep the file's stamp and let usage climb, never fall.
+                new = dict(seg)
+                if cur_ra is None and ra is not None:
+                    new["resets_at"] = ra             # the file simply had no stamp yet; adopt this one
                 if pct is not None:
                     new["pct"] = max(int(new.get("pct") or 0), pct)   # in-window usage only climbs
             elif pct is not None:

--- a/tests/test_sdk_rate_limit_usage.py
+++ b/tests/test_sdk_rate_limit_usage.py
@@ -8,6 +8,7 @@ Agent SDK's DESIGNED source is the RateLimitEvent stream — each carries one wi
 test_sdk_backend.py for the status-aware merge). SdkBackend._record_rate_limit folds each event into the
 SAME usage.json shape, so the same kernel _usage() reader lights the bars for SDK sessions too. Synthetic
 fixtures (duck-typed info)."""
+import inspect
 import json
 import os
 import tempfile
@@ -85,6 +86,41 @@ class RecordRateLimit(unittest.TestCase):
         self.be._record_rate_limit(_info("five_hour", None, None))
         self.assertFalse((self.state / "usage.json").exists(), "nothing to say -> nothing written")
 
+    def test_a_differently_dated_reading_of_the_same_window_never_resets_the_bar(self):
+        # The bug (the user 2026-08-02: the 5h bar read 18% against a real 45%). romp has TWO sources for
+        # one window and they date its boundary differently — the get_usage snapshot carries the /usage
+        # endpoint's 23:00, the event stream carries the API headers' 23:10. Equality read that 10-minute
+        # gap as a fresh window and reset the exact reading to 0 within a second of it landing, leaving
+        # the rail to creep back up from zero on the rare events that carry a number at all.
+        exact = 1785711600                                   # what the get_usage snapshot wrote
+        (self.state / "usage.json").write_text(json.dumps({
+            "t": 1, "five_hour": {"pct": 45, "resets_at": exact}, "seven_day": None, "fable": None}))
+        self.be._record_rate_limit(_info("five_hour", None, exact + 600))   # the header's reading, no utilization
+        five = self._usage()["five_hour"]
+        self.assertEqual(five["pct"], 45, "an unknown utilization may never lower a known reading")
+        self.assertEqual(five["resets_at"], exact, "the exact boundary stands; the event only refines usage")
+
+    def test_a_real_roll_still_starts_the_next_window_at_zero(self):
+        # The slack must not swallow an actual roll: a 5h window's reset moves by hours, not minutes.
+        (self.state / "usage.json").write_text(json.dumps({
+            "t": 1, "five_hour": {"pct": 96, "resets_at": 1785711600}, "seven_day": None, "fable": None}))
+        self.be._record_rate_limit(_info("five_hour", None, 1785711600 + 5 * 3600))
+        five = self._usage()["five_hour"]
+        self.assertEqual(five["pct"], 0, "a rolled window starts empty")
+        self.assertEqual(five["resets_at"], 1785711600 + 5 * 3600)
+
+    def test_same_window_is_decided_with_slack_not_equality(self):
+        self.assertTrue(sb._same_window(1785711600, 1785712200), "10 minutes apart is one window, said twice")
+        self.assertTrue(sb._same_window(1785711600, 1785711600))
+        self.assertFalse(sb._same_window(1785711600, 1785711600 + 5 * 3600), "a 5h roll is a new window")
+        self.assertFalse(sb._same_window(None, 1785711600), "an absent stamp names no window")
+
+    def test_a_higher_reading_still_climbs_within_the_window(self):
+        (self.state / "usage.json").write_text(json.dumps({
+            "t": 1, "five_hour": {"pct": 45, "resets_at": 1785711600}, "seven_day": None, "fable": None}))
+        self.be._record_rate_limit(_info("five_hour", 0.61, 1785711600 + 600))
+        self.assertEqual(self._usage()["five_hour"]["pct"], 61, "in-window usage climbs on a known number")
+
     def test_the_kernel_usage_reader_lights_the_bars_from_what_the_sdk_wrote(self):
         # End-to-end: the SDK writer + the kernel reader agree on usage.json (no statusline in the loop).
         self.be._record_rate_limit(_info("five_hour", 0.10, 1782787200))
@@ -104,6 +140,68 @@ class RecordRateLimit(unittest.TestCase):
         self.assertEqual(u["fiveHour"]["pct"], 10)
         self.assertEqual(u["sevenDay"]["pct"], 11)
         self.assertEqual(u["fiveHour"]["resetsAt"], 1782787200)
+
+
+class ExactSnapshotRefresh(unittest.TestCase):
+    """The exact get_usage snapshot is the only source that carries a true percent for every window; the
+    event stream attaches one only in the warning band. So a refresh that never happens is not a small
+    loss — it is the difference between the real number and a floor that creeps up from zero. It may
+    never fail quietly (the user 2026-08-02)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.logs = []
+        self.be = sb.SdkBackend(Path(self.td.name), "claude", lambda *a: None,
+                                log=lambda m: self.logs.append(m))
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def _session(self, scheduled, **kw):
+        s = SimpleNamespace(client=object(), loop=object(), ended=False, **kw)
+        s.refresh_usage = lambda: scheduled
+        return s
+
+    def test_every_live_session_is_tried_not_just_the_first(self):
+        # One session whose loop has gone away used to be enough to make the click do nothing at all,
+        # while the rail went on presenting its last reading as current.
+        asked = []
+        dead = self._session(False)
+        live = self._session(True)
+        for s in (dead, live):
+            s.refresh_usage = (lambda s=s: (asked.append(s), s is live)[1])
+        self.be.sessions = {"a": dead, "b": live}
+        self.be.refresh_usage()
+        self.assertEqual(asked, [dead, live], "the refusal moves on to the next candidate")
+
+    def test_it_stops_at_the_first_session_that_takes_it(self):
+        asked = []
+        a, b = self._session(True), self._session(True)
+        for s in (a, b):
+            s.refresh_usage = (lambda s=s: (asked.append(s), True)[1])
+        self.be.sessions = {"a": a, "b": b}
+        self.be.refresh_usage()
+        self.assertEqual(asked, [a], "one snapshot is enough — these windows are account-wide")
+
+    def test_nobody_able_to_run_it_is_said_out_loud(self):
+        s = self._session(False)
+        self.be.sessions = {"a": s}
+        self.be.refresh_usage()
+        self.assertTrue(any("usage refresh" in m for m in self.logs),
+                        "a refresh that could not run must not look like one that did")
+
+    def test_a_failing_control_request_is_logged_rather_than_swallowed(self):
+        src = inspect.getsource(sb.SdkSession._do_refresh_usage)
+        self.assertNotIn("except Exception:\n            r = None", src,
+                         "the bare swallow is what made a dead refresh indistinguishable from a live one")
+        self.assertIn("_log(", src)
+
+    def test_the_context_refresh_keeps_its_own_poke(self):
+        # `changed` is computed by the context refresh; the poke that reads it had been left in
+        # refresh_usage, where the name is undefined — so /usage clicks raised NameError and a moved
+        # context % waited for the backstop instead of pushing.
+        self.assertIn("if changed:", inspect.getsource(sb.SdkSession._do_refresh_context))
+        self.assertNotIn("changed", inspect.getsource(sb.SdkSession.refresh_usage))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The rail's 5h bar read **18%** while the account was really at **45%**.

## What was wrong

romp has two sources for each rate-limit window and they date the boundary differently:

| source | 5h window resets_at | carries a percent? |
|---|---|---|
| `get_usage` control request (the /usage screen's own data) | `23:00:00Z` | always, exact (`45`) |
| `RateLimitEvent` stream (API response headers) | `23:10:00Z` | only in the warning band |

`_record_rate_limit` compared the two stamps for equality and read any difference as a rolled window, resetting `pct` to 0. So every event after a snapshot wiped the exact reading within a second, and the bar crept back up from zero on the rare events that carry a number. Window identity is now decided with slack (`_same_window`): a real roll moves the stamp by hours, so an hour of tolerance cannot swallow one.

Verified against the live CLI (2.1.220 / SDK 0.2.128):

```
limits: [{"kind":"session","percent":45,"resets_at":"2026-08-02T23:00:00.933357+00:00"}, ...]
usage.json: {"five_hour":{"pct":18,"resets_at":1785712200}}   # 23:10:00Z
```

## Two silent failures alongside it

- `_do_refresh_usage` swallowed every exception, so a refresh that never landed was indistinguishable from one that did — the event-derived floor stayed on screen as the reading. It logs now (repo rule: fail loudly, never degrade quietly). Observed live: turn ends at 11:35 and 11:37 produced no `usage.json` write at all.
- `SdkBackend.refresh_usage` asked only the first live session; one session without a loop made the whole click a no-op. It now tries each and reports when none can run it.
- Restores the poke belonging to `_do_refresh_context`. It had been left in `refresh_usage`, where `changed` is undefined, so every /usage click raised `NameError` and a moved context percentage waited for the backstop.

## Tests

`tests/test_sdk_rate_limit_usage.py`: same-window-differently-dated (the regression), a real roll still zeroing, `_same_window` directly, climbing within a window, plus the refresh-path tests. Full suite green: 3863 passed, 25 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)