### PR TITLE
Rename a remote tab by its name, with the host left where it is

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -26,7 +26,7 @@ import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
 import { previewKind, previewFull, canPreview } from "./preview";
-import { hostNameNodes, hostIsDown, hostDownNote } from "./host-prefix";
+import { hostNameNodes, hostPrefix, hostIsDown, hostDownNote } from "./host-prefix";
 import { dirStatusLine, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
@@ -3659,26 +3659,40 @@ window.addEventListener("blur", () => dismissTabMenu());
 function startTabRename(tab: HTMLElement, label: HTMLElement, id: string) {
   const s = sessions.get(id);
   if (!s || tab.querySelector(".tab-rename")) return;
+  // A remote session displays as "host:name", where "host:" is METADATA this viewer added (see
+  // ./host-prefix) — the far kernel knows the session by the bare name alone. Seeding the editor with
+  // the whole display string handed the user the host to edit and sent it back on the other side of the
+  // rename, where the colon is not a legal session name and the write was refused (the user 2026-08-02).
+  // So the host stays put, rendered exactly as the label renders it and not editable, and the input
+  // holds the one part that is theirs to change.
+  const p = hostPrefix(s.name, id);
+  const base = p ? p.rest : s.name;
   const input = document.createElement("input") as HTMLInputElement;
   input.className = "tab-rename";
-  input.value = s.name;
+  input.value = base;
   input.spellcheck = false;
-  input.size = Math.max(s.name.length, 4);
+  input.size = Math.max(base.length, 4);
+  const fixed = p ? el("span", "host-prefix") : null;
+  if (fixed) fixed.textContent = p!.host;
   renameActive = true;
   tab.draggable = false;            // dragging would eat the text selection
   label.style.display = "none";
   label.after(input);
+  if (fixed) input.before(fixed);
   let finished = false;
   const done = (commit: boolean) => {
     if (finished) return;
     finished = true;
     const v = input.value.trim();
     input.remove();
+    fixed?.remove();
     label.style.display = "";
     tab.draggable = true;
     renameActive = false;
     if (renderPendingAfterRename) { renderPendingAfterRename = false; renderTabs(); }
-    if (commit && v && v !== s.name && vscodeApi) vscodeApi.postMessage({ type: "renameSession", id, name: v });
+    // The bare name, never the display string: the host prefix is this viewer's, and the kernel that
+    // owns the session is addressed by `id` (federation routes on the prefix there).
+    if (commit && v && v !== base && vscodeApi) vscodeApi.postMessage({ type: "renameSession", id, name: v });
   };
   input.addEventListener("keydown", (e) => {
     e.stopPropagation();

--- a/ui/webview/tab-rename-host.test.ts
+++ b/ui/webview/tab-rename-host.test.ts
@@ -1,0 +1,48 @@
+// Renaming a REMOTE session's tab (the user 2026-08-02). A federated session displays as "host:name",
+// where "host:" is metadata this viewer prepends (see host-prefix.ts) — the kernel that owns the session
+// knows it by the bare name. The editor used to open on the whole display string, so the host went into
+// the field, came back out on the other side of the rename, and the write was refused: a colon is not a
+// legal session name. The host is fixed chrome now and only the name is editable.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { hostPrefix } from "./host-prefix";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const rename = RENDER.slice(RENDER.indexOf("function startTabRename"),
+                            RENDER.indexOf("// Keyboard nav on a focused tab"));
+
+test("the editor opens on the session name alone, with the host beside it", () => {
+  assert.match(rename, /const p = hostPrefix\(s\.name, id\);/);
+  assert.match(rename, /const base = p \? p\.rest : s\.name;/);
+  assert.match(rename, /input\.value = base;/, "the field holds the part that is theirs to change");
+  assert.match(rename, /el\("span", "host-prefix"\)/, "…and the host reads exactly as the label renders it");
+  assert.match(rename, /input\.before\(fixed\)/, "sitting before the field, not inside it");
+});
+
+test("the host is never part of what is submitted", () => {
+  assert.match(rename, /name: v \}\)/);
+  assert.doesNotMatch(rename, /name: s\.name/);
+  assert.match(rename, /v !== base/, "unchanged is measured against the name, not the display string");
+});
+
+test("the fixed prefix is torn down with the editor", () => {
+  assert.match(rename, /fixed\?\.remove\(\)/, "else it outlives the rename and doubles the host on the tab");
+});
+
+test("a local session's rename is untouched", () => {
+  // hostPrefix returns null off a bare (local) sid, so base === s.name and no fixed span is built —
+  // the local path is exactly what it was.
+  assert.equal(hostPrefix("api", "11111111-2222-3333-4444-555555555555"), null);
+});
+
+test("a remote name splits into the host and the name the far kernel knows", () => {
+  const p = hostPrefix("TESTHOST:api", "TESTHOST:11111111-2222-3333-4444-555555555555");
+  assert.deepEqual(p, { host: "TESTHOST:", rest: "api" });
+});
+
+test("a local name that merely contains a colon is not split", () => {
+  // the sid is the marker, never the name: a bare uuid means every character of the name is the name
+  assert.equal(hostPrefix("odd:name", "11111111-2222-3333-4444-555555555555"), null);
+});


### PR DESCRIPTION
Renaming a federated session's tab failed. The editor opened on the whole display string, `host:name`, so the host went into the field, came back out on the other side of the rename, and the owning kernel refused the write: a colon is not a legal session name.

The `host:` token is metadata this viewer prepends (`host-prefix.ts`) — the far kernel knows the session by the bare name. So it stays chrome: a fixed, non-editable span beside the field, wearing the same `.host-prefix` styling the tab label uses, and the input holds only the part that is the user's to change. What is submitted is the bare name; the owning kernel is addressed by `id`, which is where `routeOutbound` reads the host from anyway (and it deliberately never strips `name` — see `multi-kernel-merge.test.ts`).

Local sessions are untouched: `hostPrefix` returns null off a bare uuid sid, so `base === s.name` and no fixed span is built.

## Tests

New `ui/webview/tab-rename-host.test.ts`: the editor seeds from `hostPrefix`, the fixed span is built and torn down with the editor, the submitted value is the bare name, unchanged is measured against the name rather than the display string, and a local name containing a colon is not split. Node suite 1594 passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)