### PR TITLE
Keep a scroll-back history load from stealing the jump you just made

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19415,6 +19415,11 @@ class Handler(BaseHTTPRequestHandler):
                        "ok": bool(msg.get("ok")), "sid": str(msg.get("id") or ""),
                        "anchor": msg.get("anchor"), "anchorT": msg.get("anchorT"),
                        "kind": msg.get("kind"),
+                       # keep=True ⇒ NOT a user navigation: a scroll-back loadOlder putting the reader's own
+                       # row back at its captured offset. The two were indistinguishable in the audit before,
+                       # so a scroll-restore row read as a second click the user never made (the user
+                       # 2026-08-02, diagnosing exactly such a pair of rows a second apart).
+                       "keep": bool(msg.get("keep")),
                        "trail": msg.get("trail") if isinstance(msg.get("trail"), list) else []}
                 with open(jd.STATE / "locate-audit.jsonl", "a", encoding="utf-8") as f:
                     f.write(json.dumps(rec) + "\n")

--- a/ui/webview/chat-older-restore.test.ts
+++ b/ui/webview/chat-older-restore.test.ts
@@ -1,0 +1,108 @@
+// Scroll-back history loading must be INVISIBLE — it must never move what the reader is looking at
+// (the user 2026-08-02).
+//
+// The reported bug: clicking a card's distilled summary landed on the summary, then a second later the chat
+// jumped to an unrelated old Bash tool card; clicking the summary again then worked. The locate audit caught
+// it exactly — two rows a second apart, the first the user's click (pointer-exact, with an anchorT), the
+// second a jump to a different uuid with anchorT null that no click produced.
+//
+// The chain: the click lands pointer-exact → landOn top-aligns the summary → when that summary sits within
+// WINDOW_RADIUS of the resident head and older history is still on the server, the resulting scrollTop trips
+// virtualizeToViewport's "at the top of the resident events" branch → requestOlder fetches the previous chunk
+// → chatHead lands its re-anchor as a DEEP-LINK (top-align + flash) onto the FIRST TURN IN THE DOM, a whole
+// window-radius above what the reader was reading. Merely scrolling up after the click did the same thing.
+//
+// Two things were wrong and both are pinned here: requestOlder anchored on the wrong row (first-in-DOM, not
+// the row at the viewport top), and chatHead landed a position-restore as if it were a navigation.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+function bodyOf(name: string): string {
+  const at = RENDER.indexOf("function " + name + "(");
+  assert.ok(at > 0, name + " must exist");
+  const end = RENDER.indexOf("\n}", at);
+  return RENDER.slice(at, end);
+}
+
+test("requestOlder anchors on the row at the VIEWPORT TOP, not the first turn in the DOM", () => {
+  const body = bodyOf("requestOlder");
+  assert.match(body, /captureScrollAnchor\(content, v\)/,
+    "the re-anchor row is the one the reader is looking at (captureScrollAnchor), not v.el's first child");
+  assert.ok(!/const firstTurn = v\.el\.querySelector\(["'`]\.turn\[data-uuid\]/.test(body),
+    "first-in-DOM must not be the PRIMARY anchor — after a deep-link it is a window-radius off-screen");
+});
+
+test("requestOlder records a keep-offset, so the arrival restores rather than jumps", () => {
+  const body = bodyOf("requestOlder");
+  assert.match(body, /pendingOlderKeepY\.set\(sid, keep\?\.y \?\? 0\)/,
+    "a scroll-back stashes the row's on-screen offset (0 when nothing was capturable — still never a jump)");
+});
+
+test("a deep-link fetch stays a deep-link: no keep-offset, so it top-aligns and flashes", () => {
+  const body = bodyOf("fetchOlderForAnchor");
+  assert.match(body, /pendingOlderKeepY\.delete\(sid\)/,
+    "fetchOlderForAnchor is a real navigation — it must clear any stale keep-offset for that session");
+  // The short-circuit branch matters just as much: when a fetch is ALREADY in flight fetchOlderForAnchor
+  // returns false without running, and that in-flight fetch may be a requestOlder whose keep-offset would
+  // silently demote this click to a position restore. scrollToAnchor clears it at the re-point.
+  const sca = bodyOf("scrollToAnchor");
+  assert.match(sca, /pendingOlderAnchor\.set\(activeId, uuid\);\s*pendingOlderKeepY\.delete\(activeId\);/,
+    "re-pointing the arrival at a clicked uuid also drops the scroll-back offset");
+});
+
+test("chatHead never overwrites a deep-link that is still waiting to land", () => {
+  const body = bodyOf("chatHead");
+  assert.match(body, /if \(anchorUuid && !pendingAnchor\)/,
+    "a pending deep-link (where the user asked to GO) outranks a scroll-back re-anchor (where they WERE)");
+  assert.match(body, /pendingAnchorKeepY = keepY \?\? null/,
+    "the arrival carries the keep-offset through to the landing");
+});
+
+test("scrollToAnchor restores a keep-offset instead of landing on it", () => {
+  const body = bodyOf("scrollToAnchor");
+  assert.match(body, /if \(pendingAnchorKeepY != null\) \{/, "the keep-offset branch exists");
+  const at = body.indexOf("if (pendingAnchorKeepY != null) {");
+  const branch = body.slice(at, body.indexOf('landTrail.push("pointer-exact")', at));   // the keep branch alone
+  assert.match(branch, /landTrail\.push\("pointer-keep-offset"\)/,
+    "the audit trail names the restore, so it is never mistaken for a click again");
+  assert.match(branch, /content\.scrollTop = yNow - keepY/,
+    "the row comes back at its captured offset");
+  assert.ok(!/landOn\(/.test(branch), "a restore must NOT top-align + flash the row like a jump");
+  // …and the ordinary path still does land properly.
+  assert.match(body, /landTrail\.push\("pointer-exact"\);\s*\n\s*landOn\(target\);/,
+    "a genuine deep-link still lands via landOn");
+});
+
+test("a keep-offset restore that misses does not toast the reader 'couldn't locate'", () => {
+  // Nobody asked to locate anything — they scrolled. The audit row still records it.
+  assert.match(RENDER, /if \(!scrolled && !anchorPendingOlder && !att\.keep\) \{/,
+    "the couldn't-locate toast + error-center entry are for user navigations only");
+  assert.match(RENDER, /keep: att\.keep \|\| undefined,/, "…but the audit row still carries the flag");
+});
+
+test("the kernel persists the keep flag, so click and scroll-restore stay distinguishable in the audit", () => {
+  const kernel = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
+  const at = kernel.indexOf('elif msg and msg.get("type") == "locateDiag":');
+  assert.ok(at > 0, "the locateDiag handler must exist");
+  assert.match(kernel.slice(at, at + 1600), /"keep": bool\(msg\.get\("keep"\)\)/,
+    "locate-audit.jsonl rows say whether a landing was a user navigation");
+});
+
+// executed: the offset restore itself — the arithmetic that keeps the reader still.
+test("restoring by offset keeps the anchored row exactly where it was on screen", () => {
+  // Model: content scrolled to `scrollTop`; the anchor row sits `y` px below the viewport top. Older history
+  // is prepended ABOVE it, growing everything above by `prependH`. Restoring must put it back at the same y.
+  const restore = (scrollTopNow: number, rowTopInScrollSpace: number, keepY: number) => rowTopInScrollSpace - keepY;
+  const keepY = 12;                       // the row was 12px below the viewport top when the fetch went out
+  const rowAfter = 4000 + 300;            // 4000px of older history prepended above a row that was at 300
+  const st = restore(0, rowAfter, keepY);
+  assert.equal(st, 4288, "scrollTop lands so the row is 12px below the viewport top again");
+  assert.equal(rowAfter - st, keepY, "…i.e. its on-screen offset is unchanged");
+  // The old behaviour (landOn → scrollIntoView block:"start") would have forced offset 0, and on the WRONG
+  // row at that: the first turn in the DOM rather than the reader's own.
+  assert.notEqual(0, keepY, "top-aligning is a visible jump for any reader not already flush at the top");
+});

--- a/ui/webview/render-scroll.test.ts
+++ b/ui/webview/render-scroll.test.ts
@@ -95,8 +95,9 @@ test("the kind guard accepts a peer's postal card as a valid PROMPT target (reco
 });
 
 test("honest-fail fires whenever the deep-link can't resolve by id (the turn is genuinely gone)", () => {
-  // now gated on !anchorPendingOlder so it doesn't fire while we're fetching older history for the anchor
-  assert.match(RENDER, /if \(!scrolled && !anchorPendingOlder\) \{\s*\n\s*landToast\("couldn't locate this in the transcript"\)/);
+  // now gated on !anchorPendingOlder so it doesn't fire while we're fetching older history for the anchor —
+  // and on !att.keep, since a scroll-back position restore is nobody's navigation (chat-older-restore.test.ts)
+  assert.match(RENDER, /if \(!scrolled && !anchorPendingOlder && !att\.keep\) \{\s*\n\s*landToast\("couldn't locate this in the transcript"\)/);
   // 2026-07-28: the same failure ALSO files an error-center entry — a transient toast left nothing the
   // user could point at once it faded (the full bridge is pinned in chat-delta-resync.test.ts).
   assert.match(RENDER, /notifyShell\("locate",/);
@@ -109,7 +110,9 @@ test("a deep-link to an anchor OLDER than the resident tail fetches older histor
   assert.match(RENDER, /else if \(s && \(s\.headFrom \?\? 0\) > 0\) \{/, "older-than-tail branch in scrollToAnchor");
   // 2026-07-20: an in-flight fetch counts as pending too (loadingOlder), and the arrival re-land is
   // re-pointed at THIS uuid — a push re-render mid-fetch used to fall through to a false "couldn't locate"
-  assert.match(RENDER, /if \(fetchOlderForAnchor\(activeId, uuid\) \|\| loadingOlder\.has\(activeId\)\) \{\s*pendingOlderAnchor\.set\(activeId, uuid\);\s*pendingAnchor = uuid; anchorPendingOlder = true;/);
+  // 2026-08-02: …and it drops any keep-offset the in-flight fetch left, so a click can't be demoted to a
+  // scroll-back position restore (chat-older-restore.test.ts).
+  assert.match(RENDER, /if \(fetchOlderForAnchor\(activeId, uuid\) \|\| loadingOlder\.has\(activeId\)\) \{\s*pendingOlderAnchor\.set\(activeId, uuid\);\s*pendingOlderKeepY\.delete\(activeId\);\s*pendingAnchor = uuid; anchorPendingOlder = true;/);
   // the helper stashes the TARGET uuid (not the current top row) so chatHead lands on it
   assert.match(RENDER, /function fetchOlderForAnchor\(sid: string, uuid: string\): boolean/);
   assert.match(RENDER, /pendingOlderAnchor\.set\(sid, uuid\)/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -380,6 +380,12 @@ let pendingAnchorIntent: string | null = null; // kind the uuid anchor must hono
 let pendingAnchorT: number | null = null; // time fallback (epoch s) when the uuid can't resolve
 let pendingAnchorKind: string | null = null; // intent for the time fallback: "user" = land on the user's own turn
 let anchorPendingOlder = false; // scrollToAnchor kicked off a loadOlder fetch for an anchor past the resident tail → don't toast "couldn't locate"; chatHead re-lands when the chunk arrives (the user 2026-06-27)
+// KEEP-OFFSET landing (the user 2026-08-02). A scroll-back loadOlder re-anchors on the row the reader was
+// on — that is POSITION PRESERVATION, not a deep-link: the row must come back at the SAME on-screen offset,
+// with no top-align and no flash. Non-null ⇒ resolve pendingAnchor by id as usual (which renders the window
+// around it), then restore it to this y instead of calling landOn. Sticks with pendingAnchor across
+// render-pass retries, like pendingAnchorIntent.
+let pendingAnchorKeepY: number | null = null;
 // Landing diagnostics (the user's ask, 2026-06-10): record HOW each deep-link
 // landing resolved — exact pointer / refused wrong-kind pointer / time-nearby
 // / gave up. The trail is posted to the host (→ ~/.local/state/romp/
@@ -4750,8 +4756,12 @@ function scrollToAnchor(uuid: string): boolean {
       // run on every push re-render (0.5–3s), so a mid-fetch attempt used to fall through to
       // "pointer-not-rendered" and toast a false "couldn't locate" while the chunk that would land it was
       // still on the wire. Re-point the arrival re-land at THIS uuid and keep waiting.
+      // …and the arrival becomes a DEEP-LINK land, so drop any keep-offset a scroll-back fetch left behind:
+      // in the short-circuit branch the in-flight fetch may well BE a requestOlder, whose stale offset would
+      // otherwise silently demote this click to a position restore.
       if (fetchOlderForAnchor(activeId, uuid) || loadingOlder.has(activeId)) {
         pendingOlderAnchor.set(activeId, uuid);
+        pendingOlderKeepY.delete(activeId);
         pendingAnchor = uuid; anchorPendingOlder = true; landTrail.push("pointer-fetch-older"); return false;
       }
     }
@@ -4771,6 +4781,21 @@ function scrollToAnchor(uuid: string): boolean {
     pendingAnchor = null; pendingAnchorIntent = null; landTrail.push("pointer-wrong-kind"); return false;
   }
   pendingAnchor = null; pendingAnchorIntent = null;
+  // POSITION PRESERVATION, not a jump (the user 2026-08-02): a scroll-back loadOlder re-anchors on the row
+  // the reader was already on, so it must land back at its captured offset — never top-aligned and flashed
+  // like a deep-link. Routing it through landOn was what yanked a reader off the summary they had just
+  // jumped to and onto the head of the resident tail (an old Bash card); see chatHead.
+  if (pendingAnchorKeepY != null) {
+    const keepY = pendingAnchorKeepY;
+    pendingAnchorKeepY = null;
+    landTrail.push("pointer-keep-offset");
+    const content = document.getElementById("content");
+    if (content) {
+      const yNow = target.getBoundingClientRect().top - content.getBoundingClientRect().top + content.scrollTop;
+      content.scrollTop = yNow - keepY;
+    }
+    return true;
+  }
   landTrail.push("pointer-exact");
   landOn(target);
   return true;
@@ -5409,7 +5434,7 @@ function landActive(content: HTMLElement | null, v: View): void {
   }
   sizeSpacers(v);  // the view is now VISIBLE (display set in showActive), so the spacers get a real height
                    // measurement — a tab pre-built while display:none could only fall back until now
-  const att = { anchor: pendingAnchor, t: pendingAnchorT, kind: pendingAnchorKind };   // this pass's landing attempt, for diagnostics
+  const att = { anchor: pendingAnchor, t: pendingAnchorT, kind: pendingAnchorKind, keep: pendingAnchorKeepY != null };   // this pass's landing attempt, for diagnostics
   if (att.anchor || att.t != null) landTrail = [];
   let scrolled = pendingAnchor ? scrollToAnchor(pendingAnchor) : false;
   // BY-ID landing ONLY (the user 2026-06-20, who wanted to shrink the 29%, then remove the time fallback). TIER 1, by id:
@@ -5420,15 +5445,19 @@ function landActive(content: HTMLElement | null, v: View): void {
   // unanchorable — so they honest-fail with a toast rather than a clock-nearest guess (which often landed on
   // an unrelated turn anyway — the 'retry'-message bug). The old time tier-2 (scrollToNearestT) is GONE: the
   // last time-based navigation removed, per "no time heuristics". WORK/REPLY intent never had a tier-2 either.
-  pendingAnchor = null; pendingAnchorIntent = null; pendingAnchorT = null; pendingAnchorKind = null;
+  pendingAnchor = null; pendingAnchorIntent = null; pendingAnchorT = null; pendingAnchorKind = null; pendingAnchorKeepY = null;
   // Diagnostics: log every landing attempt; a deep-link that couldn't resolve announces itself loudly
   // instead of impersonating a successful jump.
   if (att.anchor || att.t != null) {
     vscodeApi?.postMessage({
       type: "locateDiag", id: activeId, ok: scrolled, trail: landTrail.slice(),
       anchor: att.anchor ?? undefined, anchorT: att.t ?? undefined, kind: att.kind ?? undefined,
+      keep: att.keep || undefined,
     });
-    if (!scrolled && !anchorPendingOlder) {
+    // A keep-offset restore is NOT a user navigation — nobody asked to locate anything, so a failed one must
+    // not raise "couldn't locate this in the transcript" at a reader who only scrolled. It still gets its
+    // audit row above (trail + keep), which is where a lost position is diagnosed from.
+    if (!scrolled && !anchorPendingOlder && !att.keep) {
       landToast("couldn't locate this in the transcript");  // fetching older history → chatHead re-lands, no false "couldn't locate"
       // …and file it in the error center. The toast is transient and the locate-audit.jsonl row is invisible
       // from the UI, so a failed jump left NOTHING the user could point at afterwards — it read as the click
@@ -7224,24 +7253,37 @@ function chatTail(msg: any) {
 // anchor on the row the user was at, so the older content appears ABOVE without the view jumping.
 const loadingOlder = new Set<string>();                 // sessions with a loadOlder in flight
 const pendingOlderAnchor = new Map<string, string>();   // sid → the uuid to re-anchor on when the chunk lands
+// sid → the on-screen y that uuid must come back to. PRESENT ⇒ the fetch was a scroll-back (requestOlder) and
+// the arrival is POSITION PRESERVATION; ABSENT ⇒ it was a deep-link (fetchOlderForAnchor) and the arrival is a
+// real jump that top-aligns + flashes. The two were indistinguishable before, so every scroll-back arrival
+// jumped (the user 2026-08-02).
+const pendingOlderKeepY = new Map<string, number>();
 function chatHead(msg: any) {
   loadingOlder.delete(msg.id);
   hideLoadingPill();
+  const forget = (sid: string) => { pendingOlderAnchor.delete(sid); pendingOlderKeepY.delete(sid); };
   const s = sessions.get(msg.id);
-  if (!s) { pendingOlderAnchor.delete(msg.id); return; }
+  if (!s) { forget(msg.id); return; }
   const before = msg.before | 0, from = msg.from | 0;
-  if (before !== (s.headFrom ?? 0)) { pendingOlderAnchor.delete(msg.id); return; }   // stale / overlapping → ignore
+  if (before !== (s.headFrom ?? 0)) { forget(msg.id); return; }   // stale / overlapping → ignore
   const older = (msg.events || []) as ChatEvent[];
   if (older.length) s.events = older.concat(s.events);
   s.headFrom = from;
   const v = views.get(msg.id);
-  if (msg.id !== activeId) { pendingOlderAnchor.delete(msg.id); if (v) v.stale = true; return; }
+  if (msg.id !== activeId) { forget(msg.id); if (v) v.stale = true; return; }
   // re-anchor: reset the active view so it re-windows around the saved row (now further down s.events), and
-  // land on it (deep-link path) — the prepended older content sits above, off-screen, ready to scroll into.
+  // put that row back where it was — the prepended older content sits above, off-screen, ready to scroll into.
   if (v) { v.rendered = 0; v.winStart = 0; v.winEnd = 0; v.avgTurnH = undefined; v.spacerCount = undefined; v.spacerCountBot = undefined; v.unitTotal = undefined; }
   const anchorUuid = pendingOlderAnchor.get(msg.id);
-  pendingOlderAnchor.delete(msg.id);
-  if (anchorUuid) { pendingAnchor = anchorUuid; pendingAnchorIntent = null; pendingAnchorT = null; pendingAnchorKind = null; }
+  const keepY = pendingOlderKeepY.get(msg.id);
+  forget(msg.id);
+  // A DEEP-LINK STILL WAITING TO LAND WINS (the user 2026-08-02). A scroll-back re-anchor is about where the
+  // reader was; a pending deep-link is about where they asked to GO. Letting the arrival overwrite it sent
+  // the click somewhere the user never named.
+  if (anchorUuid && !pendingAnchor) {
+    pendingAnchor = anchorUuid; pendingAnchorIntent = null; pendingAnchorT = null; pendingAnchorKind = null;
+    pendingAnchorKeepY = keepY ?? null;
+  }
   showActive();
 }
 
@@ -7253,20 +7295,36 @@ function fetchOlderForAnchor(sid: string, uuid: string): boolean {
   const s = sessions.get(sid);
   if (!s || (s.headFrom ?? 0) <= 0 || loadingOlder.has(sid)) return false;
   pendingOlderAnchor.set(sid, uuid);
+  pendingOlderKeepY.delete(sid);   // a DEEP-LINK: land it properly (top-align + flash), not offset-preserved
   loadingOlder.add(sid);
   showLoadingPill();
   vscodeApi?.postMessage({ type: "loadOlder", id: sid, before: s.headFrom });
   return true;
 }
 
-// Ask the kernel for the chunk of history just before the resident tail. Anchors on the current top row so
-// chatHead can land the user back on it after prepending.
-function requestOlder(sid: string, v: View, _content: HTMLElement): void {
+// Ask the kernel for the chunk of history just before the resident tail. Anchors on the row the reader is
+// actually LOOKING AT — the first turn still visible at the viewport top, with its on-screen offset — so
+// chatHead can put it back exactly there once the older chunk is prepended above it.
+//
+// It used to anchor on `v.el.querySelector(".turn[data-uuid]")`: the first turn in the DOM, which after a
+// deep-link is a whole window-radius above what the reader is reading. Paired with chatHead landing it as a
+// deep-link (top-align + flash), that produced the reported bug (the user 2026-08-02): click a card's
+// distilled summary → it lands pointer-exact → landOn top-aligns it, which (when the summary sits within
+// WINDOW_RADIUS of the resident head and older history is still on the server) trips this very fetch → the
+// arrival yanks the reader off the summary and onto the head of the resident tail, an unrelated old Bash
+// card. Clicking the summary a second time then "worked" because the chunk was resident by then. Same
+// mechanism when the reader merely scrolls up after the click. Anchor on the reader's own row, restore it to
+// its own offset, and the fetch becomes invisible again — which is all it was ever supposed to be.
+function requestOlder(sid: string, v: View, content: HTMLElement): void {
   const s = sessions.get(sid);
   if (!s || (s.headFrom ?? 0) <= 0 || loadingOlder.has(sid)) return;
-  const firstTurn = v.el.querySelector(".turn[data-uuid]") as HTMLElement | null;
-  const anchor = firstTurn?.dataset.uuid || (s.events[0] as { uuid?: string } | undefined)?.uuid;
-  if (anchor) pendingOlderAnchor.set(sid, anchor);
+  const keep = captureScrollAnchor(content, v);
+  const anchor = keep?.uuid
+    || (v.el.querySelector(".turn[data-uuid]") as HTMLElement | null)?.dataset.uuid
+    || (s.events[0] as { uuid?: string } | undefined)?.uuid;
+  // keepY on EITHER branch: this arrival must never jump. With no capture (nothing visible at the viewport
+  // top) 0 restores the fallback row to the top, which is where it already is.
+  if (anchor) { pendingOlderAnchor.set(sid, anchor); pendingOlderKeepY.set(sid, keep?.y ?? 0); }
   loadingOlder.add(sid);
   showLoadingPill();
   vscodeApi?.postMessage({ type: "loadOlder", id: sid, before: s.headFrom });


### PR DESCRIPTION
## The bug

Clicking a card's distilled summary landed on the summary, then a second later the chat jumped to an unrelated old Bash tool card; clicking the summary again worked. Merely scrolling up after the click did the same thing.

`locate-audit.jsonl` recorded it exactly — two rows a second apart, the first the user's click (`pointer-exact`, with an `anchorT`), the second a jump to a *different* uuid with `anchorT: null` that no click produced.

## The chain

1. The click lands `pointer-exact` → `landOn` top-aligns the summary.
2. When that summary sits within `WINDOW_RADIUS` of the resident head and older history is still on the server, the resulting `scrollTop` trips `virtualizeToViewport`'s "at the top of the resident events" branch.
3. `requestOlder` fetches the previous chunk anchored on **the first turn in the DOM** — a whole window-radius above what the reader is reading.
4. `chatHead` lands that re-anchor as a **deep-link**: top-aligned and flashed.

So a fetch that is supposed to be invisible became a navigation to a row nobody named. The second click "worked" only because the chunk was resident by then.

## The fix

Both halves:

- `requestOlder` anchors on the row at the **viewport top** (`captureScrollAnchor`) and records its on-screen offset.
- `chatHead` **restores** that row to that offset instead of landing on it, and stands down entirely when a deep-link is still pending — where the user asked to *go* outranks where they *were*.
- A deep-link fetch clears the offset so it still lands properly, including in the already-in-flight short-circuit (where the in-flight fetch may itself be a scroll-back).

Also: the audit now records `keep`, so a position restore is never again mistaken for a click the user never made, and a restore that misses no longer toasts "couldn't locate" at a reader who only scrolled.

## Tests

`ui/webview/chat-older-restore.test.ts` (new, 7 tests incl. an executed offset-arithmetic check), plus two updated assertions in `render-scroll.test.ts`. Full suites green: 1602 node tests, 3860 pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)