### PR TITLE
Copy a predicted card before styling it, so the render never edits the merged frame's cache

### DIFF
--- a/ui/webview/feed-followup-move.test.ts
+++ b/ui/webview/feed-followup-move.test.ts
@@ -22,8 +22,11 @@ test("submitting a follow-up registers the optimistic move and re-renders the fe
 test("a predicted card is kept in Working at render, styled like the kernel's re-checked follow-up", () => {
   assert.match(FEED, /function applyFollowMove\(list: AskItem\[\]\)/);
   // a follow-up prediction wears the re-check styling; an "answer" flips the column only
-  // (the messageless plain move was removed with its button/drag, the user 2026-07-25)
-  assert.match(FEED, /if \(\(pendingMoveKind\.get\(a\.itemId\) \?\? "followup"\) === "followup"\) \{ a\.recheck = true; a\.followupPending = true; \}/);
+  // (the messageless plain move was removed with its button/drag, the user 2026-07-25).
+  // Styled onto a COPY, never the payload object — the federated page serves the manager's cached
+  // frames by reference, and an in-place edit echoed back as a false kernel confirm
+  // (follow-move-cache-echo.test.ts, the user 2026-08-02)
+  assert.match(FEED, /if \(\(pendingMoveKind\.get\(a\.itemId\) \?\? "followup"\) === "followup"\) \{ c\.recheck = true; c\.followupPending = true; \}/);
   // applied at the top of render so EVERY render (push, modal close) reflects the prediction
   // (2026-07-27: render() prunes the age-provenance popover first — hiding it only when the hovered
   // stamp was torn out of the DOM — so the pin allows that line between the two.)
@@ -38,7 +41,7 @@ test("the optimistic move also bumps the card's sort key to now so it lands at t
   // the TOP, then the real work re-filed at ≈now dropped it to the bottom. Stamp now so it's at the bottom
   // from the instant of the flip; the kernel's followupAt keeps it there when this prediction clears.
   assert.match(FEED, /const nowSec = Math\.floor\(Date\.now\(\) \/ 1000\);/);
-  assert.match(FEED, /if \(a\.t < nowSec\) a\.t = nowSec;/);
+  assert.match(FEED, /if \(c\.t < nowSec\) c\.t = nowSec;/);
 });
 
 test("the kernel is authoritative: a confirming push clears the prediction, an unconfirmed one is left predicting", () => {

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -321,16 +321,30 @@ function reconcileFollowMove(incoming: AskItem[], buildId: number) {
 }
 // Render-time: keep each still-unconfirmed predicted card in Working, styled like the kernel's own re-checked
 // follow-up (recheck + followupPending), so the optimistic card matches the authoritative one with no jump.
+//
+// COPY the card, never write into it (the user 2026-08-02, who watched a just-replied card bounce
+// working → blocked → working): on the federated page the ask objects in a payload ARE the
+// FederationManager's cached per-host frames, served by reference (mergeHostFeeds concatenates the cached
+// arrays and the merged frame arrives via a same-realm MessageEvent — no structured clone). An in-place
+// `a.column = "working"` therefore wrote the prediction INTO that cache, and the next merged re-emit —
+// fired by ANY host's frame, seconds later — handed the pane its own edit back as kernel truth, which
+// reconcileFollowMove took as the kernel's confirmation and dropped the prediction. The next local build
+// already in flight when the reply landed (honestly pre-reply) then bounced the card back to Blocked with
+// no prediction left to hold it. Replacing the list SLOT with a copy keeps the render identical while the
+// cached frame stays exactly what the kernel sent, so the prediction ends only on the real events.
 function applyFollowMove(list: AskItem[]) {
   if (!pendingFollowMove.size) return;
   // now, in the server's epoch-second unit (kernel is local). Bump the predicted card's sort key to now so
   // the INSTANT optimistic move lands at the BOTTOM of Working, matching where the kernel's authoritative
   // followupAt stamp keeps it once this prediction clears — no top-flash then lurch-down (the user 2026-07-03).
   const nowSec = Math.floor(Date.now() / 1000);
-  for (const a of list) if (pendingFollowMove.has(a.itemId) && a.column !== "working") {
-    a.column = "working";
-    if ((pendingMoveKind.get(a.itemId) ?? "followup") === "followup") { a.recheck = true; a.followupPending = true; }   // plain move / answer: no chip
-    if (a.t < nowSec) a.t = nowSec;   // sort to the bottom (newest); the group's repr follows via buildGroup
+  for (let i = 0; i < list.length; i++) {
+    const a = list[i];
+    if (!pendingFollowMove.has(a.itemId) || a.column === "working") continue;
+    const c: AskItem = { ...a, column: "working" };
+    if ((pendingMoveKind.get(a.itemId) ?? "followup") === "followup") { c.recheck = true; c.followupPending = true; }   // plain move / answer: no chip
+    if (c.t < nowSec) c.t = nowSec;   // sort to the bottom (newest); the group's repr follows via buildGroup
+    list[i] = c;
   }
 }
 // (drag-to-Working and the modal's "Move to Working" button were REMOVED, the user 2026-07-25: a

--- a/ui/webview/follow-move-cache-echo.test.ts
+++ b/ui/webview/follow-move-cache-echo.test.ts
@@ -1,0 +1,79 @@
+// The optimistic follow-up move must never WRITE into the payload it renders (the user 2026-08-02, who
+// replied to a blocked card and watched it bounce working → blocked → working). On the federated page the
+// ask objects in a `feed` payload ARE the FederationManager's cached per-host frames: mergeHostFeeds
+// concatenates the cached arrays element-by-reference, and the merged frame reaches the pane through a
+// same-realm MessageEvent (window.dispatchEvent — no structured clone). So applyFollowMove's old in-place
+// `a.column = "working"` edited the manager's cache; the next merged re-emit — fired by ANY host's frame,
+// seconds later — served the pane its own edit back as kernel truth, reconcileFollowMove read it as the
+// kernel confirming the move ("confirmed") and dropped the prediction, and the next local build already in
+// flight when the reply landed (honestly pre-reply) bounced the card back to Blocked with nothing left to
+// hold it. Recorded end to end in client-diag.jsonl: predict:followup → payload flip back with
+// predicted:false three seconds later → payload flip forward nine seconds after that.
+//
+// feed.ts has import-time DOM side effects, so per the established precedent this is source pins plus an
+// executed replica of the copy-on-write decision (optimistic-send.test.ts / user-img-dedup.test.ts).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const F = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+
+// the whole applyFollowMove body, so the pins below can't be satisfied by unrelated code
+const body = (() => {
+  const m = F.match(/function applyFollowMove\(list: AskItem\[\]\) \{[\s\S]*?\n\}/);
+  assert.ok(m, "applyFollowMove not found in feed.ts");
+  return m![0];
+})();
+
+test("applyFollowMove replaces the list slot with a copy — it never mutates the payload object", () => {
+  // the copy idiom: spread into a fresh AskItem, column set on the copy, slot replaced
+  assert.match(body, /const c: AskItem = \{ \.\.\.a, column: "working" \};/);
+  assert.match(body, /list\[i\] = c;/);
+  // and no write lands on the shared object itself (assignment, not the `===` comparison in the guard)
+  assert.doesNotMatch(body, /\ba\.(column|recheck|followupPending|t)\s*=[^=]/);
+});
+
+test("the shared-reference premise holds: the merge reuses cached frame elements, delivered same-realm", () => {
+  // mergeHostFeeds concatenates the cached asks arrays by reference (no per-element copy)…
+  assert.match(FED, /if \(Array\.isArray\(f\.asks\)\) merged\.asks\.push\(\.\.\.f\.asks\);/);
+  // …and the merged frame is dispatched in-realm, so no structured clone severs the references
+  assert.match(FED, /window\.dispatchEvent\(new MessageEvent\("message", \{ data: mergeHostFeeds\(/);
+});
+
+// Executed replica: the exact scenario off the diagnosed trail. A cached host frame holds the blocked
+// card; the merge serves its elements by reference; the pane predicts and renders. The cache must still
+// read needs_input afterwards — else the next re-emit "confirms" the prediction the pane itself painted.
+test("rendering a predicted card leaves the cached frame untouched, so a re-emit cannot false-confirm", () => {
+  const pending = new Set(["s1:g1"]);
+  const kind = new Map([["s1:g1", "followup"]]);
+  const nowSec = 1000;
+  const apply = (list: any[]) => {                       // replica of the pinned copy-on-write body
+    for (let i = 0; i < list.length; i++) {
+      const a = list[i];
+      if (!pending.has(a.itemId) || a.column === "working") continue;
+      const c: any = { ...a, column: "working" };
+      if ((kind.get(a.itemId) ?? "followup") === "followup") { c.recheck = true; c.followupPending = true; }
+      if (c.t < nowSec) c.t = nowSec;
+      list[i] = c;
+    }
+  };
+  const cached: any[] = [{ itemId: "s1:g1", column: "needs_input", t: 900 }];   // the manager's stored local frame
+  const merged: any[] = [...cached];                      // mergeHostFeeds: fresh array, shared elements
+  apply(merged);
+  // the render shows the prediction…
+  assert.equal(merged[0].column, "working");
+  assert.equal(merged[0].recheck, true);
+  assert.equal(merged[0].t, nowSec);
+  // …while the cache still holds exactly what the kernel sent, so the next merged re-emit still shows the
+  // card blocked and reconcileFollowMove keeps waiting for the kernel's real answer
+  assert.equal(cached[0].column, "needs_input");
+  assert.equal(cached[0].t, 900);
+  assert.equal("recheck" in cached[0], false);
+  // and a second render pass over a re-merge of the same cache predicts again without double-copying
+  const remerged = [...cached];
+  apply(remerged);
+  assert.equal(remerged[0].column, "working");
+  assert.equal(cached[0].column, "needs_input");
+});


### PR DESCRIPTION
Replying to a blocked card on the federated feed bounced it working → blocked → working within seconds, against the standing rule that a reply latches the card in Working until the judge rules.

**Root cause** (from the recorded client-diag colflip trail): `applyFollowMove` styled the predicted card by mutating the ask object in place. On the federated page those objects are the FederationManager's cached per-host frames, served by reference — `mergeHostFeeds` concatenates the cached arrays, and the merged frame arrives via a same-realm `MessageEvent` (no structured clone). The in-place `column = "working"` write therefore edited the manager's cache; the next merged re-emit (fired by any host's frame, seconds later) served the pane its own edit back as kernel truth, and `reconcileFollowMove` took the echo as the kernel confirming the move — dropping the prediction early. The next local build already in flight when the reply landed (honestly pre-reply) then knocked the card back to Blocked with nothing left to hold it; the build after that moved it forward again. Three flips in twelve seconds, `predicted:false` on the bounce.

**Fix**: `applyFollowMove` replaces the list slot with a copy and styles that. The cached frame stays exactly what the kernel sent, so the prediction ends only on the real events (confirming payload, ack ladder, backstop) — same render, no shared-state edit.

**Tests**: `follow-move-cache-echo.test.ts` pins the copy-on-write idiom and the shared-reference premise at source, and executes a replica proving a render leaves the cached frame untouched across re-merges. `feed-followup-move.test.ts` pins updated to the copy. Node suite 1605 pass; Python suite 3863 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)