### PR TITLE
A closed tab stays gone: stop dismissSession from erasing the close record it was just handed

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7338,21 +7338,32 @@ function statusOnly(msg: any) {
   if (msg.id === activeId) updateStatusline();
 }
 
-// The ✕'s own path: remember the close (see closingTabs), then drop the tab now. (dismissSession is ALSO how
-// a session dying on its own arrives — that one must not be recorded as a close of ours.)
+// The ✕'s own path: drop the tab now, THEN remember the close (see closingTabs). The order matters and
+// regressed the whole mechanism once (the user 2026-08-02, closed tabs lingering as the spinning swirl):
+// dismissSession used to open with closingTabs.delete(id), so set-then-dismiss erased the record the
+// instant it was written — the suppression the optimistic close depends on never survived the click, the
+// next push re-added the id, and with the session already dropped it rendered as the loader placeholder
+// until the kernel caught up. (dismissSession is ALSO how a session dying on its own arrives — that one
+// must not be recorded as a close of ours, which is why the record is written HERE, not in there.)
 function closeTabLocally(id: string): void {
   // A provisional tab has no session to close — closing it means "never mind", so it cancels the spawn
   // the kernel may still be running, the way the old cue's ✕ did.
   if (isProvisionalId(id)) { cancelProvisional(); return; }
-  closingTabs.set(id, Date.now());
   dismissSession(id);
+  closingTabs.set(id, Date.now());
 }
 
 // Drop a session from the panel + reselect another tab, NOW (the user 2026-06-24): used both by the kernel's
 // `closed` event AND optimistically the instant you Close tab / End session — otherwise the reselect waited on
 // that round-trip while the tab bar already updated, leaving you on the CLOSED session's stale content.
+//
+// This deliberately does NOT touch closingTabs. Retiring the suppression belongs to its own events:
+// ackClosingTabs (a tabOrder push without the id = the kernel's confirm; the backstop past CLOSE_ACK_MS =
+// the loud failure) and an explicit focus (reopen). Retiring it here — including on the kernel's `closed`
+// event — is both the regression above (the ✕ path runs through here microseconds after recording the
+// close) and wrong under federation, where a `closed` ack can predate stale merged frames that still list
+// the id: the moment nothing suppresses it, the strip re-draws the swirl placeholder.
 function dismissSession(id: string): void {
-  closingTabs.delete(id);   // the kernel agreed (or the session died on its own) — nothing left to suppress
   sessions.delete(id);
   liveAsks.delete(id);
   ledgers.delete(id);
@@ -7415,6 +7426,8 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "status") statusOnly(m);
   else if (m.type === "focus") {
     revealSelfPane();   // every focus is someone jumping HERE — on mobile, come forward (incl. from a remote kernel)
+    closingTabs.delete(m.id);   // an explicit reveal outranks a pending close-suppression: closing a tab and
+    //                             reopening it from the picker inside the ack window must show it at once
     if (revivePending && m.id === revivePending) clearReviveLoader();   // the revive landed — the loader's success event
     // `live` (the user 2026-07-08): land on the LIVE TAIL. A blocked card's picker/permission prompt IS the
     // live bottom of the chat, so its feed chip drops the user right on it. Stick the target view to bottom so

--- a/ui/webview/tab-close-optimistic.test.ts
+++ b/ui/webview/tab-close-optimistic.test.ts
@@ -110,10 +110,15 @@ test("a session dying on its OWN is not recorded as a close of ours", () => {
 
 // ---- the wiring in render.ts -------------------------------------------------------------------------
 
-test("closeTabLocally records the close, then drops the tab", () => {
+test("closeTabLocally drops the tab, THEN records the close — in that order", () => {
   // (2026-07-30: a PROVISIONAL tab short-circuits above this — there is no session to close, so the ✕
   // means "never mind" and cancels the spawn instead. A real tab's path is unchanged.)
-  assert.match(RENDER, /if \(isProvisionalId\(id\)\) \{ cancelProvisional\(\); return; \}\s*\n\s*closingTabs\.set\(id, Date\.now\(\)\);\s*\n\s*dismissSession\(id\);/);
+  //
+  // The order is the whole mechanism (the user 2026-08-02, closed tabs lingering as the spinning swirl):
+  // this shipped as set-then-dismiss while dismissSession opened with closingTabs.delete(id), so the
+  // record was erased the instant it was written — the executed model above passed while the composed
+  // wiring was a no-op. Hence these pins hold the ORDER, and the next test holds dismissSession's hands.
+  assert.match(RENDER, /if \(isProvisionalId\(id\)\) \{ cancelProvisional\(\); return; \}\s*\n\s*dismissSession\(id\);\s*\n\s*closingTabs\.set\(id, Date\.now\(\)\);/);
   // declared beside tabMeta, NOT down by dismissSession: renderTabs reads it and can run before the module
   // finishes evaluating, which would make a `const` down there a temporal-dead-zone throw.
   assert.match(RENDER, /const tabMeta = new Map[\s\S]{0,900}?const closingTabs = new Map<string, number>\(\);/);
@@ -139,6 +144,16 @@ test("ackClosingTabs settles against the kernel's list on every tabOrder push", 
   assert.match(RENDER, /if \(!live\.has\(id\)\) \{ closingTabs\.delete\(id\); continue; \}/, "gone from the kernel = confirmed");
   assert.match(RENDER, /if \(now - ts < CLOSE_ACK_MS\) continue;/, "inside the window a slow kernel is not a failure");
   assert.match(RENDER, /warnToast\(`Couldn't close/);
-  // dismissSession clears it too, so the kernel's own `closed` event settles the close as well
-  assert.match(RENDER, /function dismissSession\(id: string\): void \{\s*\n\s*closingTabs\.delete\(id\);/);
+});
+
+test("dismissSession never touches the suppression — retiring belongs to ack, backstop, and reopen", () => {
+  // dismissSession is the shared drop path: the ✕ runs through it microseconds after recording the close,
+  // and under federation the kernel's `closed` event can predate stale merged frames that still list the
+  // id. A closingTabs.delete in its body is what disarmed the whole optimistic close (see above).
+  const body = RENDER.match(/function dismissSession\(id: string\): void \{[\s\S]*?\n\}/);
+  assert.ok(body, "dismissSession not found");
+  assert.doesNotMatch(body![0], /closingTabs\./, "dismissSession must not read or write closingTabs");
+  // …and the one legitimate early retire: an explicit reveal (reopen from the picker inside the ack
+  // window) must show the tab at once instead of waiting out the suppression
+  assert.match(RENDER, /m\.type === "focus"\) \{\s*\n\s*revealSelfPane\(\);.*\n\s*closingTabs\.delete\(m\.id\);/);
 });


### PR DESCRIPTION
Closing a tab (Close tab or End session) left it lingering with the spinning loader placeholder instead of going away immediately.

**Root cause:** the optimistic-close mechanism (7a3a43d, 2026-07-24) never actually worked. `closeTabLocally` recorded the close in `closingTabs` and then called `dismissSession` — whose first line deleted that very record. Set-then-erase, microseconds apart, on every close. With nothing suppressing the id, the next `tabOrder` push (the kernel a beat behind on a hidden-flag flip, or a stale merged remote frame on the federated page) re-added the tab; with its session already dropped client-side it rendered as the swirl placeholder until the kernel caught up. The shipped test missed it because its executed model re-implemented the intended logic instead of the real composition, and its source pins held each line separately — not the order that made them cancel out.

**Fix:** `dismissSession` no longer touches `closingTabs` at all. The suppression retires only on its designed events: `ackClosingTabs` confirms on a push without the id; the `CLOSE_ACK_MS` backstop brings the tab back loudly (a session still open behind a hidden tab is exactly the silent-wrong-state to surface); and an explicit `focus` (reopen from the picker inside the ack window) clears it so a close-then-reopen is never suppressed. `closeTabLocally` also drops first and records second, so no future `dismissSession` change can re-create the erase.

**Tests:** `tab-close-optimistic.test.ts` now pins the order, pins any `closingTabs` access inside `dismissSession` as a failure, and pins the focus-clears-it path. Node suite 1606 pass; Python suite 3863 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)