### PR TITLE
A remote card's hover lights its chat and timeline again

### DIFF
--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -89,6 +89,13 @@ export function prefixInbound(host: string, msg: any): any {
       : it));
     out.host = host;
   }
+  // the cross-surface chat glow (glowTurns): its groups are keyed by sid, so a remote kernel's glow
+  // must arrive prefixed or the merged chat's views.get("host:sid") lookup misses and a remote
+  // session's rows never light (the user 2026-08-03 — feed-card hover; the timeline-bar hover took
+  // the same silent miss). The uuids stay bare: atom uuids are globally unique, like the hover ids.
+  if (out.type === "glowTurns" && Array.isArray(out.groups))
+    out.groups = out.groups.map((g: any) =>
+      (g && typeof g === "object" && typeof g.sid === "string" ? { ...g, sid: prefixId(host, g.sid) } : g));
   // timeline payloads: the lanes skeleton nests everything under `data`; the bars detail is top-level.
   if (out.type === "data" && out.data && typeof out.data === "object") out.data = prefixTimelineData(host, out.data);
   else if (out.type === "bars") return { ...out, ..._prefixTimelineDetail(host, out) };

--- a/ui/webview/feed-keynav.test.ts
+++ b/ui/webview/feed-keynav.test.ts
@@ -20,7 +20,7 @@ test("the shell's paneFocus arms card nav; blur/Escape disarms it", () => {
 test("the card cursor reuses the mouse-hover highlight path (applyFocus + showAskPath)", () => {
   assert.match(FEED, /function kbSelectCard\(el: HTMLElement \| null\): void \{/);
   assert.match(FEED, /hoverAskId = id; applyFocus\(\);/, "the SAME white .focused ring the hover shows");
-  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "showAskPath", itemId: id, locate: false \}\);/, "same lit timeline journey");
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "showAskPath", itemId: id, sid: sidOfItem\(id\), locate: false \}\);/, "same lit timeline journey");
 });
 
 test("Enter descends into a card; arrows step its elements; Enter activates via a real click", () => {

--- a/ui/webview/feed-nav-hover.test.ts
+++ b/ui/webview/feed-nav-hover.test.ts
@@ -31,8 +31,8 @@ test("a blocked/done node's mark+time deep-link to where it RESOLVED (node.mt), 
 });
 
 test("a tree-node hover lights the NODE's own segments via showAskPath(node.id)", () => {
-  assert.match(FEED, /mouseenter".*showAskPath", itemId: node\.id, locate: false/);
-  assert.match(FEED, /mouseleave".*showAskPath", itemId: it\.itemId, locate: false/, "leaving restores the card's full path");
+  assert.match(FEED, /mouseenter".*showAskPath", itemId: node\.id, sid: it\.sid, locate: false/);
+  assert.match(FEED, /mouseleave".*showAskPath", itemId: it\.itemId, sid: it\.sid, locate: false/, "leaving restores the card's full path");
 });
 
 test("the broken collectHoverIds path (emitted goal-node ids the timeline can't match) is gone", () => {

--- a/ui/webview/feed-remote-actions.test.ts
+++ b/ui/webview/feed-remote-actions.test.ts
@@ -14,6 +14,17 @@ test("every askClear send carries the card's sid (routes a remote clear to its k
   for (const s of sends) assert.match(s, /sid: (it|m|mem)\.sid/, `askClear send missing sid: ${s}`);
 });
 
+test("every showAskPath send carries a sid (a remote card's hover highlight routes to its kernel)", () => {
+  // The cross-surface hover glow (the user 2026-08-03): showAskPath carried only the itemId, which
+  // federation cannot route on (it is bare on both sides), so a remote card's hover landed on the
+  // local kernel and the timeline/chat highlight never lit. Every send now names the owning sid —
+  // from the item in scope where one is at hand, else resolved by sidOfItem (the pin-restore and
+  // keyboard paths hold only an itemId).
+  const sends = FEED.match(/type: "showAskPath"[^}]*/g) || [];
+  assert.ok(sends.length >= 16, `found ${sends.length} showAskPath sends — expected the 16 known sites`);
+  for (const s of sends) assert.match(s, /sid: (it\.sid|m\.sid|sidOfItem\()/, `showAskPath send missing sid: ${s}`);
+});
+
 test("askFollowUp carries sid too (remote follow-ups); the expand/detail channel died with FeedItem", () => {
   assert.doesNotMatch(FEED, /type: "expand"/);
   assert.match(FEED, /type: "askFollowUp"[^}]*sid: fbSid/);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -937,7 +937,7 @@ function makeAskCard(it: AskItem): HTMLElement {
     hoverTimer = window.setTimeout(() => {
       hoverTimer = undefined;
       hoverAskId = it.itemId; applyFocus();
-      vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, locate: false });
+      vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, sid: it.sid, locate: false });
     }, 120);
   });
   card.addEventListener("mouseleave", () => {
@@ -945,8 +945,8 @@ function makeAskCard(it: AskItem): HTMLElement {
     if (hoverAskId === it.itemId) {
       hoverAskId = null; applyFocus();
       const pin = focusAnchorId(pinnedAskId);
-      if (pin) vscodeApi?.postMessage({ type: "showAskPath", itemId: pin, locate: false });   // back to the pin (ask or group)
-      else vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, off: true });      // clear
+      if (pin) vscodeApi?.postMessage({ type: "showAskPath", itemId: pin, sid: sidOfItem(pin), locate: false });   // back to the pin (ask or group)
+      else vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, sid: it.sid, off: true });      // clear
     }
   });
   // card BODY single click → open the modal; double click → pin/unpin (locks the
@@ -959,7 +959,7 @@ function makeAskCard(it: AskItem): HTMLElement {
     pending = window.setTimeout(() => {
       pending = undefined;
       fullscreenAskId = it.itemId;
-      vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, locate: false });
+      vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, sid: it.sid, locate: false });
       render();
     }, 220);
   });
@@ -970,8 +970,8 @@ function makeAskCard(it: AskItem): HTMLElement {
     applyFocus();
     // double-click = PIN + jump the TIMELINE to the painted DAG (the user's
     // ruling: hover/single-click only highlight; only a double pans)
-    if (pinnedAskId === it.itemId) vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, locate: false, jump: true });
-    else if (!pinnedAskId && hoverAskId !== it.itemId) vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, off: true });
+    if (pinnedAskId === it.itemId) vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, sid: it.sid, locate: false, jump: true });
+    else if (!pinnedAskId && hoverAskId !== it.itemId) vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, sid: it.sid, off: true });
   });
 
   // right-click → the per-card bell menu (the user 2026-07-28). Reads the FRESH item off the card
@@ -1700,6 +1700,15 @@ function focusAnchorId(key: string | null): string | null {
   return key;
 }
 
+// The session that owns a feed itemId — every showAskPath must carry it: federation's routeOutbound
+// keys on `sid` (an itemId alone can only go local), so without it a remote card's hover landed on
+// the LOCAL kernel, which knows nothing of that goal, and the timeline/chat highlight never lit
+// (the user 2026-08-03). Same contract as the askClear sid fix (2026-07-02).
+function sidOfItem(itemId: string | null): string | undefined {
+  if (!itemId) return undefined;
+  return asks.find((a) => a.itemId === itemId)?.sid;
+}
+
 // Liveness ANOMALY (the user's simplification, 2026-06-11): ring a card only when
 // its computed liveness DISAGREES with the column it's filed in — agreement is
 // the normal case and carries no information.
@@ -1773,7 +1782,7 @@ function makeGroupCard(g: AskGroup): HTMLElement {
   card.append(main);
 
   const m0 = () => ((card as any)._g as AskGroup | undefined)?.members?.[0];
-  title.onclick = (ev) => { ev.stopPropagation(); const m = m0(); if (m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId }); };
+  title.onclick = (ev) => { ev.stopPropagation(); const m = m0(); if (m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, sid: m.sid }); };
   name.onclick = (ev) => { ev.stopPropagation(); const cur = (card as any)._g as AskGroup; if (cur?.sid) openOrReviveSession(cur.sid, cur.live, cur.name); };
   clr.onclick = (ev) => {
     ev.stopPropagation();
@@ -1793,7 +1802,7 @@ function makeGroupCard(g: AskGroup): HTMLElement {
     hoverTimer = window.setTimeout(() => {
       hoverTimer = undefined;
       hoverAskId = fkey; applyFocus();
-      const m = m0(); if (m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, locate: false });
+      const m = m0(); if (m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, sid: m.sid, locate: false });
     }, 120);
   });
   card.addEventListener("mouseleave", () => {
@@ -1801,8 +1810,8 @@ function makeGroupCard(g: AskGroup): HTMLElement {
     if (hoverAskId === fkey) {
       hoverAskId = null; applyFocus();
       const pin = focusAnchorId(pinnedAskId);
-      if (pin) vscodeApi?.postMessage({ type: "showAskPath", itemId: pin, locate: false });
-      else { const m = m0(); if (m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, off: true }); }
+      if (pin) vscodeApi?.postMessage({ type: "showAskPath", itemId: pin, sid: sidOfItem(pin), locate: false });
+      else { const m = m0(); if (m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, sid: m.sid, off: true }); }
     }
   });
   // body single-click → modal; double-click → pin/unpin (debounced ~220ms).
@@ -1812,7 +1821,7 @@ function makeGroupCard(g: AskGroup): HTMLElement {
     pending = window.setTimeout(() => {
       pending = undefined;
       fullscreenAskId = fkey;
-      const m = m0(); if (m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, locate: false });
+      const m = m0(); if (m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, sid: m.sid, locate: false });
       render();
     }, 220);
   });
@@ -1822,8 +1831,8 @@ function makeGroupCard(g: AskGroup): HTMLElement {
     applyFocus();
     const m = m0();
     // double-click = PIN + jump the TIMELINE (same contract as single cards)
-    if (pinnedAskId === fkey && m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, locate: false, jump: true });
-    else if (!pinnedAskId && hoverAskId !== fkey && m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, off: true });
+    if (pinnedAskId === fkey && m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, sid: m.sid, locate: false, jump: true });
+    else if (!pinnedAskId && hoverAskId !== fkey && m) vscodeApi?.postMessage({ type: "showAskPath", itemId: m.itemId, sid: m.sid, off: true });
   });
 
   const a = card as any;
@@ -2349,8 +2358,8 @@ function renderTreeNode(box: HTMLElement, it: AskItem, node: AskTreeNode, byId: 
   // emitted the goal-node id through hoverHighlight, which the timeline matches against SEGMENT ids,
   // so a sub-node hover never lit anything — the user 2026-06-16.)
   if (!repeat) {
-    line.addEventListener("mouseenter", () => vscodeApi?.postMessage({ type: "showAskPath", itemId: node.id, locate: false }));
-    line.addEventListener("mouseleave", () => vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, locate: false }));
+    line.addEventListener("mouseenter", () => vscodeApi?.postMessage({ type: "showAskPath", itemId: node.id, sid: it.sid, locate: false }));
+    line.addEventListener("mouseleave", () => vscodeApi?.postMessage({ type: "showAskPath", itemId: it.itemId, sid: it.sid, locate: false }));
   }
   box.appendChild(line);
   if (repeat) return;                                   // dim repeat: line only, no descent
@@ -3300,7 +3309,7 @@ function kbSelectCard(el: HTMLElement | null): void {
   const id = el ? kbHoverId(el) : null;
   hoverAskId = id; applyFocus();                       // the SAME white .focused ring the mouse hover shows
   if (el) el.scrollIntoView({ block: "nearest" });
-  if (id && !id.startsWith("g:")) vscodeApi?.postMessage({ type: "showAskPath", itemId: id, locate: false });   // same lit timeline journey
+  if (id && !id.startsWith("g:")) vscodeApi?.postMessage({ type: "showAskPath", itemId: id, sid: sidOfItem(id), locate: false });   // same lit timeline journey
 }
 function kbEnterCards(): void {
   kbMode = "cards";

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -121,6 +121,29 @@ test("routeOutbound: a card op routes by its SID — an itemId alone can only go
   assert.equal(orphan[0].host, "", "no sid → local, whoever the card belongs to");
 });
 
+test("routeOutbound: showAskPath routes by sid — a remote card's hover glow reaches its own kernel", () => {
+  // The feed→timeline/chat highlight (the user 2026-08-03): hovering a remote session's card sent
+  // showAskPath with only the (bare, unroutable) itemId, so it always landed on the LOCAL kernel,
+  // which owns no such goal — nothing lit. The sid rides along purely as the routing key.
+  const routes = routeOutbound({ type: "showAskPath", itemId: U + ":g4", sid: "gpu1:" + U, locate: false });
+  assert.equal(routes.length, 1);
+  assert.equal(routes[0].host, "gpu1", "the sid picks the owning kernel");
+  assert.equal(routes[0].msg.sid, U, "sid stripped back to bare");
+  assert.equal(routes[0].msg.itemId, U + ":g4", "itemId was never prefixed, so it passes through as-is");
+  // a local card's hover (bare sid) keeps going local, exactly as before
+  assert.equal(routeOutbound({ type: "showAskPath", itemId: U + ":g4", sid: U, off: true })[0].host, "");
+});
+
+test("prefixInbound: glowTurns groups get sid-prefixed so the merged chat finds the remote pane", () => {
+  // The return leg of the same highlight: the owning kernel answers with glowTurns keyed by its own
+  // bare sids, but the merged chat page keys its views "host:sid" — unprefixed groups matched nothing.
+  const m = prefixInbound("gpu1", { type: "glowTurns", groups: [{ sid: U, uuids: ["a1", "b2"] }], mids: [] });
+  assert.equal(m.groups[0].sid, "gpu1:" + U);
+  assert.deepEqual(m.groups[0].uuids, ["a1", "b2"], "atom uuids are globally unique and stay bare");
+  const clear = prefixInbound("gpu1", { type: "glowTurns", groups: [], mids: [] });
+  assert.deepEqual(clear.groups, [], "an empty clear passes through");
+});
+
 test("routeOutbound: a global message (no session id) goes local", () => {
   const routes = routeOutbound({ type: "setColormap", name: "viridis" });
   assert.deepEqual(routes, [{ host: "", msg: { type: "setColormap", name: "viridis" } }]);


### PR DESCRIPTION
Hovering a feed card cross-highlights the goal's chat rows and timeline bars, but for a remote (federated) session's card nothing lit. Two gaps, one per direction:

- **Outbound:** `showAskPath` carried only the `itemId`, which federation cannot route on (an itemId is bare on both sides), so every hover landed on the LOCAL kernel, which owns no such goal and resolved zero segments. Every send now carries the owning `sid` (the same contract as the askClear sid fix of 2026-07-02), resolved via a small `sidOfItem()` helper on the two paths that hold only an itemId (pin restore, keyboard cursor).
- **Inbound:** the owning kernel's `glowTurns` reply is keyed by its own bare sids, but the merged chat page keys its views `host:sid`, so even a correctly routed reply matched nothing. `prefixInbound` now prefixes `glowTurns` groups. This also repairs the timeline-bar hover's chat glow for remote sessions, which took the same silent miss. Atom uuids and timeline hover ids stay bare by design (globally unique).

Tests: `routeOutbound`/`prefixInbound` coverage in `multi-kernel-merge.test.ts`, a source pin over every `showAskPath` send in `feed-remote-actions.test.ts`, and the two stale pins updated. Both suites green locally (node 1609, pytest 3862).

🤖 Generated with [Claude Code](https://claude.com/claude-code)