### PR TITLE
distiller: re-open the done gate when a re-completion lands after the stamp

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -7698,6 +7698,34 @@ def _distill_due_t(store, nid, blocked):
     return best or nd.get("mt")
 
 
+def _done_owed(store, nid):
+    """True when a completed/confirming top owes a (re)distill: no summary yet, or the goal has
+    (re)resolved since the stamp (distilledMt != the newest done event, _distill_due_t)."""
+    nd = store["nodes"][nid]
+    if nd.get("summary") is None:
+        return True
+    _dmt = nd.get("distilledMt")
+    due = _distill_due_t(store, nid, False)
+    # A stamp equal to the goal's settle time is ALSO current: pre-07-24 stamps were the settle event,
+    # and re-keying the due on the done event must not re-enter every already-distilled card in the
+    # deployment at once (a re-distill storm). Match the settledAt cache OR any settle event in the
+    # diary (the stamp materializes from the event, so either form may be the one on disk) — but ONLY
+    # while no done event NEWER than the stamp exists (the user 2026-08-03, the re-completed setup
+    # card): done and settle share one ev_t when a session finishes and idles, so a new-era stamp also
+    # matches its own cycle's settle event in the APPEND-ONLY diary — a reopen adds events, it removes
+    # none. Matched unconditionally, this escape held the gate shut forever: a follow-up reopened and
+    # re-completed the goal, and the card kept its stale summary, still raising a decision the newer
+    # work had already answered. A due past the stamp is exactly the re-completion the gate exists to
+    # catch, so it always falls through to re-distill.
+    if _dmt is not None and (due is None or due <= _dmt) \
+            and (_dmt == nd.get("settledAt")
+                 or any(_dmt == (e.get("ev_t") or e.get("at") or 0)
+                        for e in (nd.get("log") or [])
+                        if e.get("kind") == "settle")):
+        return False
+    return _dmt != due
+
+
 def _distill_session(fsid, path, now):
     """Distill each newly-(re)resolved TOP goal of ONE session, COMPLETED and BLOCKED alike (the user
     2026-06-18). Gather the goal's full WORK history — the text of every segment in its trail and its whole
@@ -7725,26 +7753,8 @@ def _distill_session(fsid, path, now):
     # changes nothing; only a reopen→re-done moves the due and re-fires (the one-re-distill worst case the
     # user accepted).
     confirming = set(store.get("confirming") or ())
-
-    def _done_owed(nid):
-        if nodes[nid].get("summary") is None:
-            return True
-        _dmt = nodes[nid].get("distilledMt")
-        # A stamp equal to the goal's settle time is ALSO current: pre-07-24 stamps were the settle event,
-        # and re-keying the due on the done event must not re-enter every already-distilled card in the
-        # fleet at once (a deploy-wide re-distill storm). Match the settledAt cache OR any settle event in
-        # the diary (the stamp materializes from the event, so either form may be the one on disk). Self-
-        # retiring: new-era stamps are done-event times, and a reopen undoes the settle, so any later
-        # re-completion is judged by the done event alone.
-        if _dmt is not None and (_dmt == nodes[nid].get("settledAt")
-                                 or any(_dmt == (e.get("ev_t") or e.get("at") or 0)
-                                        for e in (nodes[nid].get("log") or [])
-                                        if e.get("kind") == "settle")):
-            return False
-        return _dmt != _distill_due_t(store, nid, False)
-
     todo = [nid for nid, st in status.items() if nodes.get(nid) and (
-            ((st == "completed" or nid in confirming) and _done_owed(nid)) or
+            ((st == "completed" or nid in confirming) and _done_owed(store, nid)) or
             (st == "blocked" and (nodes[nid].get("briefedMt") != _distill_due_t(store, nid, True)
                                   or nodes[nid].get("blockSummary") is None)))]
     # LIVE picker/permission floor (the user 2026-06-29): a session parked RIGHT NOW on a live prompt is

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -2158,6 +2158,60 @@ class PlanRollup(unittest.TestCase):
         self.assertEqual(s["status"][g["id"]], "completed", "and it rolls up to completed, not blocked")
 
 
+class DistillDoneGate(unittest.TestCase):
+    """_done_owed — the completed side's (re)distill gate, keyed on the newest done event vs distilledMt."""
+
+    def _mint(self, s, seg, t, text):
+        jd.apply_plan(s, seg, t, [{"do": "mint", "why": "x", "text": text}], jd.open_menu(s))
+
+    def _done(self, s, seg, t, n):
+        jd.apply_plan(s, seg, t, [{"do": "done", "why": "x", "goal": n}], jd.open_menu(s))
+
+    def _completed_and_distilled(self):
+        """One full episode: G1 minted, done, settled by session idle — so the settle event lands at the
+        session's latest activity, the done turn itself, and shares the done event's ev_t (the common
+        finish-then-idle shape) — then distilled, exactly as _distill_session stamps it."""
+        s = _store()
+        self._mint(s, "s1", T0, "G1")
+        self._done(s, "s2", T0 + 10, 1)
+        jd.rollup_status(s, session_closed=True)
+        g1 = s["placements"]["s1"]
+        self.assertEqual(s["status"][g1], "completed")
+        s["nodes"][g1]["summary"] = "first takeaway"
+        s["nodes"][g1]["distilledMt"] = jd._distill_due_t(s, g1, False)
+        return s, g1
+
+    def test_current_stamp_keeps_the_gate_closed(self):
+        s, g1 = self._completed_and_distilled()
+        self.assertFalse(jd._done_owed(s, g1), "distilled at the current done event → nothing owed")
+
+    def test_a_re_completion_reopens_the_gate_despite_the_diary_settle_match(self):
+        # The stale-summary bug (the user 2026-08-03): done and settle share one ev_t when a session
+        # finishes and idles, so a stamp taken then ALSO matches that cycle's settle event in the
+        # append-only diary. The pre-07-24 settle-time escape matched unconditionally, held the gate
+        # shut forever, and a follow-up that reopened and re-completed the goal never re-distilled —
+        # the card kept raising a decision the newer work had already answered.
+        s, g1 = self._completed_and_distilled()
+        jd._reopen(s, g1)                              # a follow-up reopens it...
+        self._done(s, "s3", T0 + 40, 1)                # ...and re-completes it
+        jd.rollup_status(s, session_closed=True)       # ...and the session idles again (re-settle)
+        self.assertTrue(jd._done_owed(s, g1),
+                        "a done event newer than the stamp owes a re-distill — the first cycle's settle "
+                        "event matching the stamp must not hold the gate shut")
+
+    def test_pre_re_key_settle_stamp_with_no_newer_done_stays_closed(self):
+        # pre-07-24 stamps were the SETTLE time, which can trail the done event; with no re-completion
+        # since, such a stamp is still current — no re-distill storm across every card on upgrade.
+        s, g1 = self._completed_and_distilled()
+        s["nodes"][g1]["distilledMt"] = s["nodes"][g1]["settledAt"]
+        self.assertFalse(jd._done_owed(s, g1), "a settle-time stamp with no newer done event is current")
+
+    def test_null_summary_is_always_owed(self):
+        s, g1 = self._completed_and_distilled()
+        s["nodes"][g1]["summary"] = None
+        self.assertTrue(jd._done_owed(s, g1), "no summary yet → owed regardless of stamps")
+
+
 class Courier(unittest.TestCase):
     def test_seg_peer_extracts_sender_and_msgid(self):
         seg = {"trigger": "u1", "atoms": [{"uuid": "u1", "type": "user", "author": {"peer": "SENDERSID"},


### PR DESCRIPTION
## Problem

A completed card's distilled summary never refreshed when the goal was reopened by a follow-up and re-completed. Observed as a card whose summary kept raising a pending decision the session had, in a later exchange on that same card, already confirmed was resolved.

## Cause

`_done_owed`'s pre-07-24 compat escape treats a `distilledMt` matching the goal's settle time as current, to avoid a re-distill storm across every already-distilled card when the gate was re-keyed from settle events to done events. The escape matched **unconditionally** — and it was assumed to self-retire ("a reopen undoes the settle"). It doesn't: the diary is append-only, and when a session finishes and idles, the settle event lands at the session's latest activity — the done turn itself — so it shares the done event's `ev_t`. Every new-era stamp (`distilledMt = due` = the done `ev_t`) therefore matches its own cycle's settle event forever, and the gate never re-opens no matter how many newer done events land.

## Fix

The settle-time escape now holds only while no done event newer than the stamp exists (`due <= distilledMt`). A due past the stamp is exactly the re-completion the gate exists to catch, so it falls through and re-distills. Pre-07-24 settle-time stamps still close the gate until real new work lands (no storm on upgrade), because a settle time only trails its own cycle's done event, never a later cycle's.

The gate moves out of the `_distill_session` closure to a module-level `_done_owed(store, nid)` so tests reach it.

## Tests

New `DistillDoneGate` class in `tests/test_judge.py`, driven through the real planner/rollup path so the diary gets its authentic shape (done + settle sharing one `ev_t` via the finish-then-idle settle):
- a re-completion after the stamp re-opens the gate despite the diary settle match (fails on the old logic — the reproduction)
- a current stamp keeps the gate closed
- a pre-re-key settle-time stamp with no newer done event stays closed (storm guard preserved)
- a null summary is always owed

Full suite: 3867 passed, 25 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)