### PR TITLE
A safeguards model swap is visible in the chat

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -759,6 +759,20 @@ class FileAdapter:
                                                  "post_tokens": cm.get("postTokens") or cm.get("post_tokens")},
                             "summary": summaries.get(u),   # the compaction SUMMARY captured in the pre-pass (or None)
                             "_seq": seq})
+            elif t == "system" and r.get("subtype") == "model_refusal_fallback":
+                # The model's safeguards flagged the prompt and the CLI silently retried the turn on a
+                # fallback model. That is CONVERSATION state, not harness bookkeeping — the reply that
+                # follows came from a different model, and the user must see the swap where it happened
+                # (the user 2026-08-03, after a fable→opus swap mid-turn was invisible in the chat).
+                # The record's timestamp is the retry start, so the atom sorts BEFORE the fallback
+                # model's reply. Non-opener (not a user atom), so it folds into the running turn.
+                out.append({"type": "system", "subtype": "model_refusal_fallback", "uuid": u,
+                            "session_id": rompuuid, "t": ts, "fsid": fsid,
+                            "parentUuid": self.parent_of.get(u),
+                            "content": r.get("content") or "",          # the CLI's full explanation
+                            "fallback_from": r.get("originalModel") or "",
+                            "fallback_to": r.get("fallbackModel") or "",
+                            "_seq": seq})
             # other system subtypes (turn_duration, stop_hook_summary, local_command,
             # away_summary) are harness bookkeeping, not conversational messages -> skipped.
         out += self._absorbed(kept, rompuuid, postal_index)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11320,6 +11320,13 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                 events.append({"kind": "compact", "uuid": a.get("uuid"), "ts": ts,
                                "trigger": cmeta.get("trigger"), "preTokens": cmeta.get("pre_tokens"),
                                "postTokens": cmeta.get("post_tokens"), "summary": a.get("summary")})
+            elif a["type"] == "system" and a.get("subtype") == "model_refusal_fallback":
+                # Safeguards flagged the prompt and the CLI retried the turn on a fallback model — the
+                # reply that follows came from a DIFFERENT model, and the swap must be visible in the
+                # chat, never silent (the user 2026-08-03). Raw model ids; the client prettifies.
+                events.append({"kind": "modelFallback", "uuid": a.get("uuid"), "ts": ts,
+                               "from": a.get("fallback_from") or "", "to": a.get("fallback_to") or "",
+                               "md": a.get("content") or ""})
     _flush_recoveries(tail_cap_t)                       # a recovery on the still-open tail turn (t past the last atom) → bottom of the flow
     #                                                     (tail_cap_t: an episode render stops at its /clear — later notes belong to the next episode)
     events = _hydrate_postal(events, _postal_index())   # swap postal traffic for clean in/out cards (no boilerplate)

--- a/tests/test_model_fallback_notice.py
+++ b/tests/test_model_fallback_notice.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""A mid-turn safeguards model swap must be visible in the chat (the user 2026-08-03).
+
+When the model's safeguards flag a prompt, the CLI retries the turn on a fallback model and writes a
+system/model_refusal_fallback record — but every system subtype except compact_boundary was dropped at
+the parse, so the swap was invisible: the user watched a turn silently change models (observed live:
+fable → opus, twice in one session). Conversation state the transcript records must be apparent to the
+user. The record now becomes a system atom (event_model) and a {kind:"modelFallback"} chat event
+(build_session), placed at the record's own timestamp — the retry start — so the notice reads BEFORE
+the fallback model's reply. SYNTHETIC only: placeholder uuids, invented notes-api prompts, temp dirs."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+em = SourceFileLoader("romp_em_mswap", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge_mswap", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_mswap", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NOW = 1781100000
+T0 = NOW - 3600
+
+NOTICE = ("The model's safeguards flagged this message. Switched to a fallback model. "
+          "Send feedback with /feedback.")
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+# The refusal-turn shape as the CLI writes it: the refused call leaves an assistant record whose only
+# content is a {"type":"fallback"} block, the fallback model then replies, and the system record —
+# stamped with the RETRY START time, parented onto the reply — carries the user-facing explanation.
+def refusal_turn_records():
+    return [
+        {"type": "user", "timestamp": iso(T0), "uuid": "u1", "parentUuid": None,
+         "promptSource": "typed",
+         "message": {"role": "user", "content": "summarize the notes-api README"}},
+        {"type": "assistant", "timestamp": iso(T0 + 5), "uuid": "afb", "parentUuid": "u1",
+         "message": {"role": "assistant", "stop_reason": "end_turn",
+                     "content": [{"type": "fallback", "from": {"model": "claude-fable-5"},
+                                  "to": {"model": "claude-opus-5"}}]}},
+        {"type": "assistant", "timestamp": iso(T0 + 45), "uuid": "a1", "parentUuid": "afb",
+         "message": {"role": "assistant", "stop_reason": "end_turn",
+                     "content": [{"type": "text", "text": "The README covers install and usage."}]}},
+        {"type": "system", "subtype": "model_refusal_fallback", "timestamp": iso(T0 + 5),
+         "uuid": "sfb", "parentUuid": "a1", "direction": "retry", "trigger": "refusal",
+         "level": "warning", "content": NOTICE,
+         "originalModel": "claude-fable-5", "fallbackModel": "claude-opus-5"},
+    ]
+
+
+class ParseEmitsTheFallbackAtom(unittest.TestCase):
+    def _parse(self):
+        td = Path(tempfile.mkdtemp())
+        tpath = td / (SID + ".jsonl")
+        tpath.write_text("\n".join(json.dumps(r) for r in refusal_turn_records()) + "\n")
+        return em.parse_session(str(tpath), now=NOW)
+
+    def test_the_record_becomes_a_system_atom_with_the_swap_facts(self):
+        parsed = self._parse()
+        atoms = [a for t in parsed["turns"] for a in t["atoms"]]
+        fb = [a for a in atoms if a.get("subtype") == "model_refusal_fallback"]
+        self.assertEqual(len(fb), 1, "the swap must survive the parse — it was silently dropped before")
+        self.assertEqual(fb[0]["fallback_from"], "claude-fable-5")
+        self.assertEqual(fb[0]["fallback_to"], "claude-opus-5")
+        self.assertEqual(fb[0]["content"], NOTICE)
+
+    def test_the_notice_sorts_before_the_fallback_models_reply(self):
+        # its timestamp is the retry START, so the atom order reads: flagged -> switched -> the reply
+        parsed = self._parse()
+        atoms = [a for t in parsed["turns"] for a in t["atoms"]]
+        i_fb = next(i for i, a in enumerate(atoms) if a.get("subtype") == "model_refusal_fallback")
+        i_reply = next(i for i, a in enumerate(atoms) if a.get("uuid") == "a1")
+        self.assertLess(i_fb, i_reply)
+
+    def test_it_folds_into_the_running_turn_and_never_opens_one(self):
+        parsed = self._parse()
+        self.assertEqual(len(parsed["turns"]), 1, "a system atom is not an opener")
+
+
+class BuildSessionEmitsTheNoticeEvent(unittest.TestCase):
+    """Fixture cribbed from test_rewind_ghost_reply; km.jd is a separate module object, so BOTH
+    copies get the temp paths."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        (pdir / (SID + ".jsonl")).write_text(
+            "\n".join(json.dumps(r) for r in refusal_turn_records()) + "\n")
+        names = td / "names"; names.mkdir()
+        (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
+        self.saved = []
+        for mod in (jd, km.jd):
+            self.saved.append((mod, mod.NAMES, mod.PROJECTS, mod.CAPDIR, mod.ARCHDIR,
+                               mod.GOALDIR, mod.STATE, mod.STATESDIR))
+            mod.NAMES, mod.PROJECTS = names, proj
+            mod.CAPDIR, mod.ARCHDIR, mod.GOALDIR = td / "captions", td / "archive", td / "goals"
+            mod.STATE, mod.STATESDIR = td, td / "states"
+        self.saved_km = (km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD)
+        km.NAMES = names
+        km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+                                           "effort": "", "context": None, "compactPct": None,
+                                           "color": None}}
+        km._parse_cache.clear()
+
+    def tearDown(self):
+        for mod, *vals in self.saved:
+            (mod.NAMES, mod.PROJECTS, mod.CAPDIR, mod.ARCHDIR,
+             mod.GOALDIR, mod.STATE, mod.STATESDIR) = vals
+        (km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD) = self.saved_km
+        km._parse_cache.clear()
+        self.td.cleanup()
+
+    def test_the_chat_carries_a_modelFallback_event_before_the_reply(self):
+        m = km.build_session(SID, NOW)
+        self.assertIsNotNone(m, "fixture session must build")
+        kinds = [e.get("kind") for e in m["events"]]
+        self.assertIn("modelFallback", kinds, "the swap must reach the chat payload")
+        ev = m["events"][kinds.index("modelFallback")]
+        self.assertEqual((ev["from"], ev["to"]), ("claude-fable-5", "claude-opus-5"))
+        self.assertEqual(ev["md"], NOTICE)
+        i_reply = next(i for i, e in enumerate(m["events"])
+                       if "README covers install" in (e.get("md") or ""))
+        self.assertLess(kinds.index("modelFallback"), i_reply,
+                        "the notice reads before the fallback model's reply")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/model-fallback.test.ts
+++ b/ui/webview/model-fallback.test.ts
@@ -1,0 +1,47 @@
+// A mid-turn safeguards model swap must be visible in the chat, never silent (the user 2026-08-03:
+// fable's safeguards flagged a message, the CLI silently retried on opus, and nothing in the chat said
+// so). The kernel emits {kind:"modelFallback"} from the transcript's system/model_refusal_fallback
+// record; render.ts wears it as the retried note's slim rail line in the warning voice, with the CLI's
+// full explanation one click away. render.ts has import-time DOM side effects → source pins
+// (rewind-delete.test.ts precedent).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(
+  path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(
+  path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("the modelFallback kind is dispatched to its renderer", () => {
+  assert.match(RENDER, /if \(ev\.kind === "modelFallback"\) return renderModelFallback\(ev\);/);
+  // and the union carries the payload the kernel sends (raw ids + the CLI's explanation)
+  assert.match(RENDER, /kind: "modelFallback"; from\?: string; to\?: string; md\?: string/);
+});
+
+test("the head line names both models via prettyModel, in the warning voice", () => {
+  const fn = RENDER.slice(RENDER.indexOf("function renderModelFallback"));
+  const body = fn.slice(0, fn.indexOf("\n}"));
+  assert.match(body, /prettyModel\(ev\.from\)/);
+  assert.match(body, /prettyModel\(ev\.to\)/);
+  assert.match(body, /safeguards flagged this message/);
+  assert.match(body, /"retried-text modelswap-text"/, "warning-voice class on the head text");
+  // never a red/blocked dress: a swap is a warning about provenance, not a failure of the turn
+  assert.doesNotMatch(body, /apierror|gaveup/);
+});
+
+test("the full CLI notice is one click away and the fold survives re-renders", () => {
+  const fn = RENDER.slice(RENDER.indexOf("function renderModelFallback"));
+  const body = fn.slice(0, fn.indexOf("\n}"));
+  assert.match(body, /body\.textContent = ev\.md;/, "verbatim notice — never paraphrased chrome");
+  assert.match(body, /applyFold\(body, "expanded", key\)/);
+  assert.match(body, /rememberFold\(body, "expanded", key\)/);
+  assert.match(body, /"mswap:" \+ ev\.uuid/, "fold keyed by the record's uuid");
+});
+
+test("the body is hidden until expanded, styled in the note family", () => {
+  assert.match(CSS, /\.modelswap-body \{ display: none;/);
+  assert.match(CSS, /\.modelswap-body\.expanded \{ display: block; \}/);
+  assert.match(CSS, /\.modelswap-text \{ color: var\(--warn/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -181,6 +181,11 @@ type ChatEvent = (
   // and the synthesized /effort chip prunes on the next message — so this rail-anchored note marks WHEN the
   // new effort took effect, and stays. Kernel-interleaved by time, like `retried`. SDK-only.
   | { kind: "effortApplied"; effort: string; ts?: string; uuid?: string }
+  // The model's safeguards flagged the prompt and the CLI retried the turn on a fallback model (the
+  // transcript's system/model_refusal_fallback record). The reply that follows came from a DIFFERENT
+  // model — conversation state that must be apparent in the chat, never silent (the user 2026-08-03).
+  // from/to are raw model ids; md is the CLI's full explanation, one click away.
+  | { kind: "modelFallback"; from?: string; to?: string; md?: string; ts?: string; uuid?: string }
   // Pinned, collapsed "system context" card at the top of the transcript (the user 2026-06-19): the
   // CLAUDE.md instructions in effect + session config. NOT the verbatim harness prompt — it's never
   // recorded, so it can't be shown (renderSystem says so). No ts/uuid → off the rail (no dot/hover).
@@ -1790,6 +1795,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
   if (ev.kind === "retryGaveUp") return renderRetryGaveUp(ev);
   if (ev.kind === "apiErrorNote") return renderApiErrorNote(ev);
   if (ev.kind === "effortApplied") return renderEffortApplied(ev);
+  if (ev.kind === "modelFallback") return renderModelFallback(ev);
   if (ev.kind === "compact") return renderCompact(ev);
   return renderTool(ev);
 }
@@ -2362,6 +2368,33 @@ function renderEffortApplied(ev: Extract<ChatEvent, { kind: "effortApplied" }>):
   line.appendChild(txt);
   line.title = "reasoning effort is a connect-time setting; the session reconnected to apply it, and this marks when the new level took effect";
   turn.appendChild(line);
+  return turn;
+}
+
+// The durable "safeguards flagged → switched model" note (the user 2026-08-03: a mid-turn model swap
+// must be apparent in the chat, never silent). Slim rail line in the warning voice, placed where the
+// retry started — i.e. just above the fallback model's reply. The CLI's full explanation (why the
+// safeguards fired, the /feedback pointer) expands on click; fold state survives re-renders via the
+// record's uuid key.
+function renderModelFallback(ev: Extract<ChatEvent, { kind: "modelFallback" }>): HTMLElement {
+  const turn = el("div", "turn turn-retried turn-modelswap");
+  turn.appendChild(dot("ring"));
+  const line = el("div", "retried-line modelswap-line");
+  const txt = el("span", "retried-text modelswap-text");
+  const from = ev.from ? prettyModel(ev.from) : "";
+  const to = ev.to ? prettyModel(ev.to) : "a fallback model";
+  txt.textContent = `${from || "The model"}'s safeguards flagged this message · switched to ${to}`;
+  line.appendChild(txt);
+  turn.appendChild(line);
+  if (ev.md) {
+    const body = el("div", "modelswap-body");
+    body.textContent = ev.md;
+    const key = ev.uuid ? "mswap:" + ev.uuid : undefined;
+    applyFold(body, "expanded", key);
+    line.title = "click for the full notice";
+    line.addEventListener("click", () => rememberFold(body, "expanded", key));
+    turn.appendChild(body);
+  }
   return turn;
 }
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -874,6 +874,15 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* the FAILED twin — "API errors — gave up after N retries": same slim line, in the blocked/red voice,
    so a storm that produced nothing never reads like a recovery (the user 2026-07-25) */
 .gaveup-text { color: var(--st-blocked-bg); font-weight: 600; }
+/* the durable "safeguards flagged → switched model" note (the user 2026-08-03: a mid-turn model swap
+   must be apparent in the chat, never silent) — the retried note's slim rail treatment in the warning
+   voice; the CLI's full explanation expands below the line on click */
+.modelswap-text { color: var(--warn, #d7a23a); font-weight: 600; }
+.modelswap-line { cursor: pointer; }
+.modelswap-line:hover .modelswap-text { filter: brightness(1.15); }
+.modelswap-body { display: none; color: var(--dim); font-size: 0.9em; margin: 4px 0 2px;
+  white-space: pre-wrap; max-width: 72ch; }
+.modelswap-body.expanded { display: block; }
 /* the durable record of a died turn — the live card's chrome without its buttons; slightly dimmer body
    so history reads calmer than the ACTIVE blocked card while staying unmistakably an error */
 .apierror-note .apierror-body { color: var(--dim); }


### PR DESCRIPTION
## Why

Follow-up to #193's investigation: the same live session hit two Fable-safeguards refusals, and the CLI silently retried each turn on Opus. The transcript records the swap (`system`/`model_refusal_fallback`), but every system subtype except `compact_boundary` was dropped at the parse, so nothing in the chat said the reply came from a different model. The user's call: any conversation state the transcript carries must be apparent in the chat.

## What

- `event_model`: the record becomes a system atom (uuid, retry-start timestamp, `content`, `originalModel`/`fallbackModel`). Non-opener, no message text, so turns, judges, and parse goldens are untouched.
- `build_session`: emits `{kind: "modelFallback", from, to, md}`; raw ids, the client prettifies.
- `render.ts` + `styles.css`: a slim rail note in the warning voice at the retry start, before the fallback model's reply: "Fable 5's safeguards flagged this message · switched to Opus 5". The CLI's full explanation (including the /feedback pointer) expands on click; fold state keyed by the record's uuid survives re-renders.

## Tests

`tests/test_model_fallback_notice.py`: the atom's fields and its placement before the reply, single-turn folding, and the `build_session` event end to end. `ui/webview/model-fallback.test.ts`: source pins on the dispatch, the prettyModel head line, the verbatim expandable body, and the hidden-until-expanded CSS (render.ts has import-time DOM side effects; established precedent). Suites: pytest 3878 passed, node suite fail 0, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)