### PR TITLE
Closing a session clears its reply context; Enter on a selection replies

### DIFF
--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -106,15 +106,40 @@ test("highlighting transcript text seeds a QUOTE chip — the same chip, reply-c
   // two flavors on one Citation: a goal chip (itemId) or a quote chip (quote [+ the turn's uuid])
   assert.match(RENDER, /interface Citation \{ itemId\?: string; title: string; quote\?: string; uuid\?: string \| null; src\?: string \}/);
   // event-based on selectionchange; BOTH endpoints must sit inside transcript turns, so composer/tab
-  // selections never seed; a collapse never clears (clicking into the composer must not eat the chip)
-  assert.match(RENDER, /document\.addEventListener\("selectionchange", \(\) => \{/);
-  assert.match(RENDER, /if \(!sel \|\| !sel\.rangeCount \|\| sel\.isCollapsed\) return;\s*\/\/ never clear on collapse/);
+  // selections never seed; a collapse never clears (clicking into the composer must not eat the chip).
+  // The qualification lives in transcriptSelection(), shared with the Enter-to-reply shortcut so the
+  // two can never disagree on what counts as a transcript selection.
+  assert.match(RENDER, /function transcriptSelection\(\): \{ text: string; uuid: string \| null \} \| null/);
+  assert.match(RENDER, /if \(!sel \|\| !sel\.rangeCount \|\| sel\.isCollapsed\) return null;/);
   assert.match(RENDER, /const a = turnOf\(sel\.anchorNode\), f = turnOf\(sel\.focusNode\);/);
-  assert.match(RENDER, /if \(!a \|\| !f\) return;/);
+  assert.match(RENDER, /if \(!a \|\| !f\) return null;/);
+  assert.match(RENDER, /document\.addEventListener\("selectionchange", \(\) => \{/);
+  assert.match(RENDER, /if \(!q\) return;\s*\/\/ never clear on collapse/);
   // seeding NEVER focuses the composer — a focus steal would collapse the selection mid-drag
   const seeder = RENDER.split("function setQuoteCitation(")[1].split("\n}")[0];
   assert.doesNotMatch(seeder, /focusComposer/);
   assert.match(seeder, /quote: quote\.slice\(0, QUOTE_CAP\)/);
+});
+
+test("Enter with a live transcript selection drops into the message box with the quote as context (the user 2026-08-04)", () => {
+  // the window Enter handler checks the selection BEFORE the bare-area gate: the mousedown that made the
+  // selection may have landed focus on a fold head or a button, which the ae===body gate below refuses —
+  // and re-seeding at Enter makes the chip exactly what's selected at that moment
+  assert.match(RENDER, /const q = transcriptSelection\(\);\s*\n\s*if \(q && activeId\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*setQuoteCitation\(activeId, q\.text, q\.uuid\);\s*\n\s*focusComposer\(\);\s*\n\s*return;/);
+  // the bare-area fallback (Enter with no selection — the user 2026-06-26) survives untouched below it
+  assert.match(RENDER, /if \(ae && ae !== document\.body\) return;\s*\n\s*if \(focusComposerOrAsk\(\)\) e\.preventDefault\(\);/);
+});
+
+test("closing a session clears its composer reply context — chip, draft, and edit pill (the user 2026-08-04)", () => {
+  const body = RENDER.match(/function dismissSession\(id: string\): void \{[\s\S]*?\n\}/);
+  assert.ok(body, "dismissSession not found");
+  // the maps: the draft, the citation chip, and any pending edit mode all die with the session
+  assert.match(body![0], /drafts\.delete\(id\); composerCitations\.delete\(id\); composerEdits\.delete\(id\); persistDrafts\(\);/);
+  // …and when the CLOSED session was the active one, the shared chip strip is repainted for the newly
+  // selected tab. Without this the dead session's chip lingered in the strip — and its ✕, bound to the
+  // dead id whose map entry is already gone, early-returned in removeCitation, so the stale chip could
+  // not even be dismissed by hand.
+  assert.match(body![0], /renderComposerChips\(activeId\);[\s\S]*?showActive\(\);/);
 });
 
 test("a quote chip sends a plain message wrapped by quoteReplyBody — never askFollowUp (no goal to reopen)", () => {

--- a/ui/webview/composer-draft-persist.test.ts
+++ b/ui/webview/composer-draft-persist.test.ts
@@ -37,6 +37,6 @@ test("every draft mutation keeps the persisted copy in sync (switch / send / clo
   assert.match(RENDER, /ta\.value = drafts\.get\(id\) \?\? "";\s*\n\s*growComposer\(ta\);\s*\n\s*renderComposerChips\(id\);[\s\S]*?persistDrafts\(\);/);
   // sending clears the draft (and ends its start-stamp) → persist
   assert.match(RENDER, /drafts\.delete\(activeId\); draftStartedAt\.delete\(activeId\); persistDrafts\(\);\s*\/\/ sent/);
-  // closing a tab drops its draft AND its citation → persist
-  assert.match(RENDER, /drafts\.delete\(id\); composerCitations\.delete\(id\); persistDrafts\(\);/);
+  // closing a tab drops its draft AND its citation AND its edit pill → persist (the user 2026-08-04)
+  assert.match(RENDER, /drafts\.delete\(id\); composerCitations\.delete\(id\); composerEdits\.delete\(id\); persistDrafts\(\);/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3828,6 +3828,20 @@ window.addEventListener("keydown", (e) => {
     e.preventDefault();
     content.scrollBy({ top: e.key === "ArrowDown" ? NAV_SCROLL_STEP : -NAV_SCROLL_STEP });
   } else if (e.key === "Enter") {
+    // A live transcript selection outranks everything below (the user 2026-08-04): the selection already
+    // seeded the reply chip (selectionchange), and Enter is the natural "now type the reply" — so drop
+    // straight into the message box with that context attached, even when the mousedown that made the
+    // selection happened to land focus on a fold head or button (which the bare-area gate below would
+    // refuse). Re-seeding here is what makes the chip exactly what's selected at the moment of Enter.
+    // Focusing the box collapses the selection, and the chip survives — a collapse never clears it.
+    // A focused tab and the live-ask card still win: both preventDefault before this bubbles to window.
+    const q = transcriptSelection();
+    if (q && activeId) {
+      e.preventDefault();
+      setQuoteCitation(activeId, q.text, q.uuid);
+      focusComposer();
+      return;
+    }
     // Enter from the bare chat AREA → drop the cursor into the message box, so after clicking in the
     // transcript to read/select you can just hit Enter to type (the user 2026-06-26). Gated on
     // activeElement being the body (no focused control), so it never steals Enter from a focused tab
@@ -6984,19 +6998,27 @@ function setQuoteCitation(id: string, quote: string, uuid: string | null, src?: 
   persistDrafts();
   if (id === activeId) renderComposerChips(id);
 }
-document.addEventListener("selectionchange", () => {
-  if (!activeId) return;
+// The current selection when (and only when) it qualifies as transcript text — both endpoints inside
+// `.turn` elements, non-collapsed, non-empty. Shared by the selectionchange seeding below and the
+// Enter-to-reply shortcut (window keydown), so the two can never disagree on what counts.
+function transcriptSelection(): { text: string; uuid: string | null } | null {
   const sel = window.getSelection();
-  if (!sel || !sel.rangeCount || sel.isCollapsed) return;   // never clear on collapse
+  if (!sel || !sel.rangeCount || sel.isCollapsed) return null;
   const turnOf = (n: Node | null) => {
     const e = n instanceof Element ? n : n?.parentElement;
     return e?.closest?.(".turn") ?? null;
   };
   const a = turnOf(sel.anchorNode), f = turnOf(sel.focusNode);
-  if (!a || !f) return;                                     // both endpoints must be transcript turns
+  if (!a || !f) return null;                                // both endpoints must be transcript turns
   const text = sel.toString().trim();
-  if (!text) return;
-  setQuoteCitation(activeId, text, a.getAttribute("data-uuid"));
+  if (!text) return null;
+  return { text, uuid: a.getAttribute("data-uuid") };
+}
+document.addEventListener("selectionchange", () => {
+  if (!activeId) return;
+  const q = transcriptSelection();
+  if (!q) return;                                           // never clear on collapse
+  setQuoteCitation(activeId, q.text, q.uuid);
 });
 
 // Dismiss the citation — via the chip ✕ or Backspace at the very start of an empty composer (so it deletes
@@ -7406,7 +7428,12 @@ function dismissSession(id: string): void {
   sessions.delete(id);
   liveAsks.delete(id);
   ledgers.delete(id);
-  drafts.delete(id); composerCitations.delete(id); persistDrafts();
+  // ALL of the closed session's composer context goes with it — the draft, the reply-context citation
+  // chip, and any pending edit pill (the user 2026-08-04). Deleting from the maps is not enough when the
+  // closed session was ACTIVE: the shared chip strip above the composer still shows its chip until
+  // someone repaints it, and that stale chip's ✕ targets the dead id (whose map entry is gone), so the
+  // click early-returns and the chip can't even be dismissed — hence the repaint below.
+  drafts.delete(id); composerCitations.delete(id); composerEdits.delete(id); persistDrafts();
   const v = views.get(id);
   if (v) { v.el.remove(); views.delete(id); }
   const oi = order.indexOf(id); if (oi >= 0) order.splice(oi, 1);
@@ -7416,6 +7443,7 @@ function dismissSession(id: string): void {
     activeId = mru[0] || null; // MRU: return to the previously-active tab, not the positional neighbor
     const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
     if (ta) { ta.value = (activeId && drafts.get(activeId)) || ""; growComposer(ta); }
+    renderComposerChips(activeId);   // the strip was showing the CLOSED session's chip — swap in the new active tab's (usually none)
     showActive();
   }
 }


### PR DESCRIPTION
Two composer reply-context fixes in the chat webview.

**Closing a session clears its reply context.** `dismissSession` (shared by the tab ✕, End session, and the kernel's `closed` event) deleted the closed session's citation from the map but never repainted the shared chip strip. When the closed session was the active tab, its reply-context chip lingered above the composer — and the chip's dismiss button targeted the dead session id, whose map entry was already gone, so `removeCitation` early-returned and the stale chip could not even be dismissed by hand. The close path now also drops the pending edit pill, and repaints the strip for the newly selected tab.

**Enter with a transcript selection drops into the message box with that as context.** Selecting transcript text already seeds the quote chip (selectionchange), but the Enter-from-the-chat-area shortcut was gated on `activeElement === body`, so it refused whenever the mousedown that made the selection had landed focus on a fold head or a button. The Enter handler now checks for a qualifying transcript selection first: if one exists, it re-seeds the chip (so the context is exactly what is selected at that moment) and focuses the composer. The selection qualification is factored into `transcriptSelection()`, shared by both the seeding path and the shortcut so the two can never disagree. The bare-area fallback and the focused-tab / live-ask precedence (both preventDefault before the event reaches window) are unchanged.

Tests: pins updated in `composer-citation.test.ts` and `composer-draft-persist.test.ts`, plus two new tests covering the close-clears-context path and the Enter-to-reply shortcut. Both suites green locally (1635 node, 3878 pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)