### PR TITLE
Quote contexts stack: cmd-select adds a chip below the ones held

### DIFF
--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -23,7 +23,7 @@ test("the composer has a chip strip above the textarea", () => {
 test("a focus message carrying a cite seeds the composer citation", () => {
   // the kernel attaches cite:{itemId,title} to the chat focus when a card click resolves to a live goal
   assert.match(RENDER, /if \(m\.cite && typeof m\.cite\.itemId === "string" && typeof m\.cite\.title === "string"\) setCitation\(m\.id, \{ itemId: m\.cite\.itemId, title: m\.cite\.title \}\);/);
-  assert.match(RENDER, /const composerCitations = new Map<string, Citation>\(\);/);
+  assert.match(RENDER, /const composerCitations = new Map<string, Citation\[\]>\(\);/);   // a LIST — quote chips stack (the user 2026-08-04)
   assert.match(RENDER, /function setCitation\(id: string, cite: Citation\): void/);
 });
 
@@ -33,14 +33,14 @@ test("the chip renders a pill with the cited title + a dismiss ✕", () => {
   assert.match(RENDER, /el\("span", "composer-chip-label"\); label\.textContent = cite\.title;/);
   assert.match(RENDER, /el\("button", "composer-chip-x"\)/);
   // ✕ dismisses but stops the click from also opening the audit preview
-  assert.match(RENDER, /x\.addEventListener\("click", \(e\) => \{ e\.stopPropagation\(\); if \(id\) removeCitation\(id\); \}\);/);
+  assert.match(RENDER, /x\.addEventListener\("click", \(e\) => \{ e\.stopPropagation\(\); if \(id\) removeCitation\(id, i\); \}\);/);   // each chip dismisses ITSELF
 });
 
 test("clicking the chip opens an audit preview of the exact prompt from /followup-preview (the user 2026-07-01)", () => {
   assert.match(RENDER, /chip\.addEventListener\("click", \(\) => \{ if \(id\) openCitePreview\(id, chip\); \}\);/);
   assert.match(RENDER, /function openCitePreview\(id: string, anchor: HTMLElement\): void/);
   // fetches the REAL wrapped body (kernel _followup_body) with the current draft substituted, escaped as text
-  assert.match(RENDER, /"\/followup-preview\?itemId=" \+ encodeURIComponent\(cite\.itemId\) \+ "&text=" \+ encodeURIComponent\(draft\)/);
+  assert.match(RENDER, /"\/followup-preview\?itemId=" \+ encodeURIComponent\(goalId\) \+ "&text=" \+ encodeURIComponent\(draft\)/);
   assert.match(RENDER, /el\("pre", "cite-preview-body"\)/);
   assert.match(RENDER, /body\.textContent = \(d && typeof d\.body === "string" && d\.body\)/);
   // Esc / outside-click / re-render close it
@@ -54,10 +54,10 @@ test("Backspace at the start of the box deletes the citation like a character", 
 });
 
 test("sending with a GOAL citation routes as an askFollowUp (reopen) and consumes the chip", () => {
-  assert.match(RENDER, /const cite = composerCitations\.get\(activeId\);/);
-  assert.match(RENDER, /if \(cite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: cite\.itemId, text, sid: activeId \}\);/);
+  assert.match(RENDER, /const cites = composerCitations\.get\(activeId\);/);
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid: activeId \}\);/);
   assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: activeId, text \}\); registerOptimistic\(activeId, text\); \}/);
-  assert.match(RENDER, /if \(cite\) \{ composerCitations\.delete\(activeId\); renderComposerChips\(activeId\); \}/);
+  assert.match(RENDER, /if \(cites\) \{ composerCitations\.delete\(activeId\); renderComposerChips\(activeId\); \}/);
 });
 
 test("a citation follow-up carries its SID, so a reply to a REMOTE card reaches that card's kernel", () => {
@@ -68,7 +68,7 @@ test("a citation follow-up carries its SID, so a reply to a REMOTE card reaches 
   // sid from the itemId, owns no such session, and hands it to tmux by uuid — dropped in silence. The card
   // still flashed to Working (the kernel's cardPredict fires before any of that) and snapped back on the
   // ok:false ack, so the only visible trace was a bounce.
-  assert.match(RENDER, /if \(cite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: cite\.itemId, text, sid: activeId \}\);/);
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid: activeId \}\);/);
   // every OTHER card-addressed op already routes this way — the citation follow-up was the lone omission
   assert.match(FEED, /type: "askClear", itemId: it\.itemId, sid: it\.sid/);
   assert.match(FEED, /type: "askFollowUp", itemId: tgt \? tgt\.itemId : fbId, title: tgt \? tgt\.title : fbTitle, text: txt, sid: fbSid/);
@@ -91,7 +91,7 @@ test("clearing a card drops any composer chip pointing INTO it (the user 2026-07
   // dropCitationByItem removes every chip citing the card OR any node under it
   assert.match(RENDER, /function dropCitationByItem\(itemId: string, itemIds\?: string\[\]\): void/);
   assert.match(RENDER, /const gone = new Set\(itemIds && itemIds\.length \? itemIds : \[itemId\]\);/);
-  assert.match(RENDER, /if \(c\.itemId && gone\.has\(c\.itemId\)\) \{ composerCitations\.delete\(sid\);/);   // quote chips cite no goal → never dropped by a card clear
+  assert.match(RENDER, /const kept = list\.filter\(\(c\) => !\(c\.itemId && gone\.has\(c\.itemId\)\)\)/);   // quote chips cite no goal — a card clear never drops them
 });
 
 test("a sub-goal click cites ITSELF, not the card's top goal (the user 2026-07-01)", () => {
@@ -114,18 +114,40 @@ test("highlighting transcript text seeds a QUOTE chip — the same chip, reply-c
   assert.match(RENDER, /const a = turnOf\(sel\.anchorNode\), f = turnOf\(sel\.focusNode\);/);
   assert.match(RENDER, /if \(!a \|\| !f\) return null;/);
   assert.match(RENDER, /document\.addEventListener\("selectionchange", \(\) => \{/);
-  assert.match(RENDER, /if \(!q\) return;\s*\/\/ never clear on collapse/);
+  assert.match(RENDER, /if \(!q\) \{ quoteSeedLive = false; return; \}\s*\/\/ never clear on collapse/);
   // seeding NEVER focuses the composer — a focus steal would collapse the selection mid-drag
-  const seeder = RENDER.split("function setQuoteCitation(")[1].split("\n}")[0];
+  const seeder = RENDER.split("function seedTranscriptQuote(")[1].split("\n}")[0];
   assert.doesNotMatch(seeder, /focusComposer/);
-  assert.match(seeder, /quote: quote\.slice\(0, QUOTE_CAP\)/);
+  assert.match(RENDER, /quote: quote\.slice\(0, QUOTE_CAP\)/);   // mkQuoteCitation bounds every chip
+});
+
+test("⌘-selecting another piece of text ADDS a context below the held ones (the user 2026-08-04)", () => {
+  // The deciding event is the mousedown that STARTS the selection gesture: plain → replace (the pre-stack
+  // behavior), ⌘/Ctrl → add. Shift is deliberately left to the browser (it extends the live selection, and
+  // the live gesture's chip follows), so a shift-mousedown neither resets the gesture nor re-reads the key.
+  assert.match(RENDER, /document\.addEventListener\("mousedown", \(e\) => \{\s*\n\s*if \(e\.shiftKey\) return;[\s\S]*?quoteAddHeld = e\.metaKey \|\| e\.ctrlKey;\s*\n\s*quoteSeedLive = false;\s*\n\}, true\);/);
+  // One gesture owns one chip: selectionchange fires dozens of times mid-drag, so the live gesture WRITES
+  // THROUGH to its own chip; only a new gesture appends (⌘) or replaces (plain). Without the write-through
+  // a single ⌘-drag would spray a chip per selectionchange event.
+  const seeder = RENDER.split("function seedTranscriptQuote(")[1].split("\n}")[0];
+  assert.match(seeder, /if \(quoteSeedLive && list\.length\) list\[list\.length - 1\] = chip;/);
+  assert.match(seeder, /else if \(quoteAddHeld && list\.length\) list\.push\(chip\);/);
+  assert.match(seeder, /else list\.splice\(0, list\.length, chip\);/);
+  // flavors never mix: any quote seed drops a goal chip (the send routes goal XOR quotes)
+  assert.match(seeder, /\.filter\(\(c\) => !c\.itemId\)/);
+  // the second chip sits BELOW the first: the strip stacks (flex column), one chip per row
+  assert.match(CSS, /#composer-chips \{ flex: 1 1 100%; display: flex; flex-direction: column; align-items: flex-start/);
+  // Backspace-at-start eats the NEWEST chip first, one per press
+  assert.match(RENDER, /list\.splice\(idx == null \? list\.length - 1 : idx, 1\);/);
+  // the persisted state restores a LIST, and still accepts the pre-stack single-object form
+  assert.match(RENDER, /for \(const c of \(Array\.isArray\(v\) \? v : \[v\]\) as any\[\]\)/);
 });
 
 test("Enter with a live transcript selection drops into the message box with the quote as context (the user 2026-08-04)", () => {
   // the window Enter handler checks the selection BEFORE the bare-area gate: the mousedown that made the
   // selection may have landed focus on a fold head or a button, which the ae===body gate below refuses —
   // and re-seeding at Enter makes the chip exactly what's selected at that moment
-  assert.match(RENDER, /const q = transcriptSelection\(\);\s*\n\s*if \(q && activeId\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*setQuoteCitation\(activeId, q\.text, q\.uuid\);\s*\n\s*focusComposer\(\);\s*\n\s*return;/);
+  assert.match(RENDER, /const q = transcriptSelection\(\);\s*\n\s*if \(q && activeId\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*seedTranscriptQuote\(activeId, q\.text, q\.uuid\);\s*\n\s*focusComposer\(\);\s*\n\s*return;/);
   // the bare-area fallback (Enter with no selection — the user 2026-06-26) survives untouched below it
   assert.match(RENDER, /if \(ae && ae !== document\.body\) return;\s*\n\s*if \(focusComposerOrAsk\(\)\) e\.preventDefault\(\);/);
 });
@@ -142,36 +164,37 @@ test("closing a session clears its composer reply context — chip, draft, and e
   assert.match(body![0], /renderComposerChips\(activeId\);[\s\S]*?showActive\(\);/);
 });
 
-test("a quote chip sends a plain message wrapped by quoteReplyBody — never askFollowUp (no goal to reopen)", () => {
-  assert.match(RENDER, /if \(cite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: cite\.itemId, text, sid: activeId \}\);/);
-  assert.match(RENDER, /else if \(cite\?\.quote\) vscodeApi\.postMessage\(\{ type: "sendMessage", id: activeId, text: quoteReplyBody\(cite\.quote, text, cite\.src\) \}\);/);
-  // the wrap: a lead-in + the highlighted text as a markdown quote block, then the typed message
-  assert.match(RENDER, /return lead \+ "\\n" \+ q \+ "\\n\\n" \+ text;/);
-  // the chip's audit preview shows the SAME composed body, client-side (no /followup-preview fetch)
-  assert.match(RENDER, /body\.textContent = quoteReplyBody\(cite\.quote \|\| "", draft \|\| "\(your message\)", cite\.src\);/);
+test("quote chips send a plain message wrapped by quoteReplyBody — never askFollowUp (no goal to reopen)", () => {
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid: activeId \}\);/);
+  assert.match(RENDER, /else if \(quoteCites\.length\) vscodeApi\.postMessage\(\{ type: "sendMessage", id: activeId, text: quoteReplyBody\(quoteCites, text\) \}\);/);
+  // the wrap: one section per stacked chip (lead-in + the highlighted text as a markdown quote block), in
+  // strip order, then the typed message — a single chip composes byte-identically to the pre-stack form
+  assert.match(RENDER, /return sections\.join\("\\n\\n"\) \+ "\\n\\n" \+ text;/);
+  // the chip's audit preview shows the SAME composed body — the whole outgoing message, every stacked
+  // quote, whichever chip was clicked — client-side (no /followup-preview fetch)
+  assert.match(RENDER, /body\.textContent = quoteReplyBody\(cites\.filter\(\(c\) => c\.quote\), draft \|\| "\(your message\)"\);/);
   // a quote chip wears the typographic quote mark; the goal chip keeps ↩
   assert.match(RENDER, /mark\.textContent = cite\.quote \? "“" : "↩";/);
-  // clearing a card drops only GOAL chips citing it — a quote chip cites no goal
-  assert.match(RENDER, /if \(c\.itemId && gone\.has\(c\.itemId\)\)/);
 });
 
 test("right-click Reply drops the auto-seeded quote chip — the quote is in the composer now, never sent twice", () => {
-  // the selection that opened the context menu also seeded the chip (selectionchange); quoting it into the
-  // composer text must consume the chip, or the send would wrap an already-quoted message again
-  assert.match(RENDER, /if \(c\?\.quote\) \{ composerCitations\.delete\(activeId\); renderComposerChips\(activeId\); \}/);
+  // the selection that opened the context menu also seeded a chip (selectionchange); quoting it into the
+  // composer text must consume THAT chip — the newest, the one this gesture made — or the send would wrap
+  // an already-quoted message again. Earlier stacked contexts stay.
+  assert.match(RENDER, /if \(list\?\.length && list\[list\.length - 1\]\.quote\) \{\s*\n\s*list\.pop\(\);/);
 });
 
 test("a VS Code EDITOR highlight seeds the same chip, labeled + wrapped with its file:lines origin (the user 2026-07-13)", () => {
   // the extension host posts editorSelection {text, src} on onDidChangeTextEditorSelection (see
   // vscode-extension/src editor-selection pins); the webview seeds the quote chip from it
   assert.match(RENDER, /m\.type === "editorSelection" && typeof m\.text === "string" && m\.text\.trim\(\) && activeId/);
-  assert.match(RENDER, /setQuoteCitation\(activeId, m\.text, null, typeof m\.src === "string" \? m\.src : undefined\);/);
+  assert.match(RENDER, /seedEditorQuote\(activeId, m\.text, typeof m\.src === "string" \? m\.src : undefined\);/);
+  // the editor's highlight owns ONE chip: a cursor move updates it in place, never wiping stacked
+  // transcript quotes beside it; absent, it appends below them (the user 2026-08-04)
+  assert.match(RENDER, /const i = list\.findIndex\(\(c\) => !!c\.src\);\s*\n\s*if \(i >= 0\) list\[i\] = chip; else list\.push\(chip\);/);
   // the chip title leads with the origin; the wrap lead-in points at the code, not the conversation
   assert.match(RENDER, /const title = \(src \? src \+ " — " \+ snip : snip\)\.slice\(0, 140\);/);
-  assert.match(RENDER, /const lead = src \? "Replying to this highlighted code \(" \+ src \+ "\):" : "Replying to this part of the conversation:";/);
-  // both consumers thread the origin through: the send wrap and the chip's audit preview
-  assert.match(RENDER, /quoteReplyBody\(cite\.quote, text, cite\.src\)/);
-  assert.match(RENDER, /quoteReplyBody\(cite\.quote \|\| "", draft \|\| "\(your message\)", cite\.src\)/);
+  assert.match(RENDER, /const lead = c\.src \? "Replying to this highlighted code \(" \+ c\.src \+ "\):" : "Replying to this part of the conversation:";/);
 });
 
 test("deselecting in the editor (editorSelectionCleared) drops the editor chip, scoped + focus-safe (the user 2026-07-14)", () => {
@@ -179,11 +202,12 @@ test("deselecting in the editor (editorSelectionCleared) drops the editor chip, 
   assert.match(RENDER, /m\.type === "editorSelectionCleared"\) clearEditorCitation\(activeId\);/);
   assert.match(RENDER, /function clearEditorCitation\(id: string \| null\): void/);
   const fn = RENDER.split("function clearEditorCitation(")[1].split("\n}")[0];
-  // ONLY the editor-seeded chip (it alone carries src) — a transcript-quote or goal chip is left alone
-  assert.match(fn, /if \(!cite \|\| !cite\.src\) return;/);
+  // ONLY the editor-seeded chip (it alone carries src) — transcript-quote and goal chips are left alone
+  assert.match(fn, /const kept = list \? list\.filter\(\(c\) => !c\.src\) : \[\];/);
+  assert.match(fn, /if \(!list \|\| kept\.length === list\.length\) return;/);
   // an in-progress reply keeps its quote: bail when the active composer has typed text
   assert.match(fn, /if \(id === activeId && ta && ta\.value\.trim\(\)\) return;/);
   // clears state + re-renders, but NEVER steals focus back to the composer (the user is in the editor)
-  assert.match(fn, /composerCitations\.delete\(id\);\s*\n\s*persistDrafts\(\);/);
+  assert.match(fn, /if \(kept\.length\) composerCitations\.set\(id, kept\); else composerCitations\.delete\(id\);/);
   assert.doesNotMatch(fn, /focusComposer/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3581,9 +3581,14 @@ function quoteSelectionIntoComposer(text: string) {
   if (activeId) {
     drafts.set(activeId, ta.value);
     // the selection that opened this menu ALSO seeded the auto quote-chip (selectionchange, the user
-    // 2026-07-13) — the quote now lives IN the composer text, so drop the chip or the send would quote twice
-    const c = composerCitations.get(activeId);
-    if (c?.quote) { composerCitations.delete(activeId); renderComposerChips(activeId); }
+    // 2026-07-13) — the quote now lives IN the composer text, so drop that chip or the send would quote it
+    // twice. Only the NEWEST chip (the one this selection's gesture made) — earlier stacked contexts stay.
+    const list = composerCitations.get(activeId);
+    if (list?.length && list[list.length - 1].quote) {
+      list.pop();
+      if (!list.length) composerCitations.delete(activeId);
+      renderComposerChips(activeId);
+    }
     persistDrafts();
   }
 }
@@ -3838,7 +3843,7 @@ window.addEventListener("keydown", (e) => {
     const q = transcriptSelection();
     if (q && activeId) {
       e.preventDefault();
-      setQuoteCitation(activeId, q.text, q.uuid);
+      seedTranscriptQuote(activeId, q.text, q.uuid);
       focusComposer();
       return;
     }
@@ -6803,14 +6808,19 @@ const drafts = new Map<string, string>();
 // A CITATION seeded into the composer when you click a feed card's summary or a sub-goal into the chat (the
 // user 2026-07-01): a dismissible chip that says "you're following up on THIS". It rides the message out as a
 // romp follow-up (via askFollowUp on send), so the goal's context travels along and the goal reopens
-// (done→working, unless cleared). One per session's composer — clicking another card REPLACES it (matches the
-// singular "one of those little boxes"). Keyed by session id like drafts, so it belongs to its tab.
+// (done→working, unless cleared). Keyed by session id like drafts, so it belongs to its tab.
 // TWO flavors (the user 2026-07-13): a GOAL citation (itemId — the card-click case above) and a QUOTE
 // citation (quote [+ the containing turn's uuid] — highlighting transcript text seeds it). A quote chip has
 // no goal to reopen: the send wraps the highlighted text into a plain message (quoteReplyBody) so the agent
-// knows exactly which part is being replied to. Same chip, same dismissal, last seed wins.
+// knows exactly which part is being replied to.
+// The value is a LIST (the user 2026-08-04): quote chips can STACK. ⌘-selecting (Ctrl off-mac) another piece
+// of text ADDS a context below the ones already held — ⌘ because that is the platform's "add a separate item
+// to a selection", while Shift keeps its native browser meaning (extend the live selection, whose chip just
+// follows). A plain select still replaces, as before. Flavors never mix: the send routes goal XOR quotes, so
+// a goal chip always rides alone — any quote seed drops it, and a goal seed (feed card click) drops the
+// quotes. Each chip keeps its own ✕; Backspace-at-start eats the newest first.
 interface Citation { itemId?: string; title: string; quote?: string; uuid?: string | null; src?: string }   // src = a VS Code editor highlight's origin, workspace-relative file:lines (the user 2026-07-13)
-const composerCitations = new Map<string, Citation>();
+const composerCitations = new Map<string, Citation[]>();
 
 // Persist drafts across a full RELOAD (the user 2026-06-25: a half-typed message must survive a refresh, not
 // only a tab switch). The Map is in-memory, so mirror it into the webview's persisted state — the same store
@@ -6829,12 +6839,16 @@ try {
   const savedCites = ((vscodeApi?.getState?.() || {}) as any).citations;
   if (savedCites && typeof savedCites === "object")
     for (const [k, v] of Object.entries(savedCites)) {
-      const c = v as any;   // either flavor restores: a goal chip (itemId) or a quote chip (quote [+ uuid])
-      if (c && typeof c.title === "string" && (typeof c.itemId === "string" || typeof c.quote === "string"))
-        composerCitations.set(k, { itemId: typeof c.itemId === "string" ? c.itemId : undefined, title: c.title,
-                                   quote: typeof c.quote === "string" ? c.quote : undefined,
-                                   uuid: typeof c.uuid === "string" ? c.uuid : null,
-                                   src: typeof c.src === "string" ? c.src : undefined });
+      // each value is a LIST of chips; a pre-stack state (before 2026-08-04) stored a single object — wrap it
+      const list: Citation[] = [];
+      for (const c of (Array.isArray(v) ? v : [v]) as any[]) {   // either flavor restores: goal (itemId) or quote (quote [+ uuid])
+        if (c && typeof c.title === "string" && (typeof c.itemId === "string" || typeof c.quote === "string"))
+          list.push({ itemId: typeof c.itemId === "string" ? c.itemId : undefined, title: c.title,
+                      quote: typeof c.quote === "string" ? c.quote : undefined,
+                      uuid: typeof c.uuid === "string" ? c.uuid : null,
+                      src: typeof c.src === "string" ? c.src : undefined });
+      }
+      if (list.length) composerCitations.set(k, list);
     }
 } catch { /* ignore */ }
 
@@ -6898,22 +6912,25 @@ function renderComposerChips(id: string | null): void {
     strip.appendChild(chip);
     return;
   }
-  const cite = id ? composerCitations.get(id) : undefined;
-  if (!cite) { strip.style.display = "none"; return; }
+  const cites = id ? composerCitations.get(id) : undefined;
+  if (!cites || !cites.length) { strip.style.display = "none"; return; }
   strip.style.display = "flex";
-  const chip = el("div", "composer-chip");
-  chip.title = cite.quote
-    ? "replying to the highlighted text — click to preview the message · ✕ to remove"
-    : "click to see exactly what romp will send the model · ✕ to remove";
-  chip.style.cursor = "pointer";
-  chip.addEventListener("click", () => { if (id) openCitePreview(id, chip); });
-  // a quote chip wears the typographic quote mark; a goal chip keeps the follow-up arrow
-  const mark = el("span", "composer-chip-mark"); mark.textContent = cite.quote ? "“" : "↩"; chip.appendChild(mark);
-  const label = el("span", "composer-chip-label"); label.textContent = cite.title; chip.appendChild(label);
-  const x = el("button", "composer-chip-x"); x.setAttribute("aria-label", "Remove citation"); x.textContent = "✕";
-  x.addEventListener("click", (e) => { e.stopPropagation(); if (id) removeCitation(id); });   // stop → don't open the preview
-  chip.appendChild(x);
-  strip.appendChild(chip);
+  // one chip per held context, in the order they were added — the strip stacks them (flex column)
+  cites.forEach((cite, i) => {
+    const chip = el("div", "composer-chip");
+    chip.title = cite.quote
+      ? "replying to the highlighted text — click to preview the message · ✕ to remove"
+      : "click to see exactly what romp will send the model · ✕ to remove";
+    chip.style.cursor = "pointer";
+    chip.addEventListener("click", () => { if (id) openCitePreview(id, chip); });
+    // a quote chip wears the typographic quote mark; a goal chip keeps the follow-up arrow
+    const mark = el("span", "composer-chip-mark"); mark.textContent = cite.quote ? "“" : "↩"; chip.appendChild(mark);
+    const label = el("span", "composer-chip-label"); label.textContent = cite.title; chip.appendChild(label);
+    const x = el("button", "composer-chip-x"); x.setAttribute("aria-label", "Remove citation"); x.textContent = "✕";
+    x.addEventListener("click", (e) => { e.stopPropagation(); if (id) removeCitation(id, i); });   // stop → don't open the preview
+    chip.appendChild(x);
+    strip.appendChild(chip);
+  });
 }
 
 // Audit popover — the EXACT wrapped body romp will send the model for this citation, fetched from the kernel's
@@ -6931,8 +6948,8 @@ function citePreviewOutside(e: MouseEvent): void {
   if (citePreviewEl && !citePreviewEl.contains(e.target as Node)) closeCitePreview();
 }
 function openCitePreview(id: string, anchor: HTMLElement): void {
-  const cite = composerCitations.get(id);
-  if (!cite) return;
+  const cites = composerCitations.get(id);
+  if (!cites || !cites.length) return;
   if (citePreviewEl) { closeCitePreview(); return; }   // second click on the chip toggles it closed
   const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
   const draft = (ta?.value || "").trim();
@@ -6948,14 +6965,16 @@ function openCitePreview(id: string, anchor: HTMLElement): void {
   pop.style.top = Math.max(8, r.top - pop.offsetHeight - 8) + "px";
   document.addEventListener("keydown", citePreviewKey, true);
   document.addEventListener("mousedown", citePreviewOutside, true);
-  if (!cite.itemId) {
-    // a QUOTE chip's body is composed CLIENT-side (quoteReplyBody IS the send path — no kernel wrap, so
-    // nothing to fetch and nothing to drift). Same popover, same clamp-after-content.
-    body.textContent = quoteReplyBody(cite.quote || "", draft || "(your message)", cite.src);
+  const goalId = cites.find((c) => c.itemId)?.itemId;
+  if (!goalId) {
+    // QUOTE chips compose CLIENT-side (quoteReplyBody IS the send path — no kernel wrap, so nothing to
+    // fetch and nothing to drift). The preview is the WHOLE outgoing message — every stacked quote in
+    // order, whichever chip was clicked. Same popover, same clamp-after-content.
+    body.textContent = quoteReplyBody(cites.filter((c) => c.quote), draft || "(your message)");
     pop.style.top = Math.max(8, r.top - pop.offsetHeight - 8) + "px";
     return;
   }
-  const url = kernelUrl("/followup-preview?itemId=" + encodeURIComponent(cite.itemId) + "&text=" + encodeURIComponent(draft));
+  const url = kernelUrl("/followup-preview?itemId=" + encodeURIComponent(goalId) + "&text=" + encodeURIComponent(draft));
   fetch(url, { cache: "no-store" }).then((r) => r.json()).then((d) => {
     if (citePreviewEl !== pop) return;   // closed while loading
     body.textContent = (d && typeof d.body === "string" && d.body) ? d.body : "(no context — this goal may have been cleared)";
@@ -6964,22 +6983,27 @@ function openCitePreview(id: string, anchor: HTMLElement): void {
   }).catch(() => { if (citePreviewEl === pop) body.textContent = "(couldn't load the preview)"; });
 }
 
-// Seed the citation for a session (from a feed card click that landed in the chat), replacing any prior one.
+// Seed the citation for a session (from a feed card click that landed in the chat), replacing everything
+// held — a goal chip rides alone, quote chips included (flavors never mix; the send routes goal XOR quotes).
 function setCitation(id: string, cite: Citation): void {
-  composerCitations.set(id, cite);
+  composerCitations.set(id, [cite]);
   persistDrafts();
   if (id === activeId) { renderComposerChips(id); focusComposer(); }
 }
 
-// The outgoing body for a QUOTE citation (the user 2026-07-13): the highlighted text rides ahead of the
+// The outgoing body for QUOTE citations (the user 2026-07-13): the highlighted text rides ahead of the
 // typed message as a markdown quote block, so the agent knows exactly which part is being replied to.
-// Also what the chip's audit preview shows — one function, no drift. `src` (the VS Code editor flavor,
-// same day) names where the highlight came from — a workspace-relative file:lines — so the lead-in points
-// the agent at the code, not the conversation.
-function quoteReplyBody(quote: string, text: string, src?: string | null): string {
-  const q = quote.split("\n").map((l) => "> " + l).join("\n");
-  const lead = src ? "Replying to this highlighted code (" + src + "):" : "Replying to this part of the conversation:";
-  return lead + "\n" + q + "\n\n" + text;
+// Also what the chip's audit preview shows — one function, no drift. Stacked chips (the user 2026-08-04)
+// become one section each, in the order they sit in the strip. `src` (the VS Code editor flavor,
+// 2026-07-13) names where a highlight came from — a workspace-relative file:lines — so that section's
+// lead-in points the agent at the code, not the conversation.
+function quoteReplyBody(cites: { quote?: string; src?: string | null }[], text: string): string {
+  const sections = cites.map((c) => {
+    const q = (c.quote || "").split("\n").map((l) => "> " + l).join("\n");
+    const lead = c.src ? "Replying to this highlighted code (" + c.src + "):" : "Replying to this part of the conversation:";
+    return lead + "\n" + q;
+  });
+  return sections.join("\n\n") + "\n\n" + text;
 }
 
 // HIGHLIGHT-TO-REPLY (the user 2026-07-13): selecting text in the chat transcript seeds the composer chip
@@ -6990,11 +7014,52 @@ function quoteReplyBody(quote: string, text: string, src?: string | null): strin
 // ✕ / Backspace-at-start. Unlike setCitation this never focuses the composer: stealing focus mid-drag
 // would collapse the very selection being made (the focusCardUnlessTyping lesson).
 const QUOTE_CAP = 4000;   // a selection can be huge; the send stays bounded
-function setQuoteCitation(id: string, quote: string, uuid: string | null, src?: string): void {
+function mkQuoteCitation(quote: string, uuid: string | null, src?: string): Citation {
   const snip = quote.replace(/\s+/g, " ").trim();
   // an editor highlight leads its chip with where it came from (file:lines), then the snippet
   const title = (src ? src + " — " + snip : snip).slice(0, 140);
-  composerCitations.set(id, { title, quote: quote.slice(0, QUOTE_CAP), uuid, src: src || undefined });
+  return { title, quote: quote.slice(0, QUOTE_CAP), uuid, src: src || undefined };
+}
+
+// One selection GESTURE owns one chip (the user 2026-08-04). selectionchange fires dozens of times as a
+// drag grows, so appending per event would spray chips — instead the live gesture WRITES THROUGH to the
+// chip it made (quoteSeedLive), and only a NEW gesture decides replace-vs-add. The deciding event is the
+// mousedown that starts the gesture: plain → this selection becomes the whole context (the pre-stack
+// behavior); ⌘ (Ctrl off-mac) held → the chips already held stay and the new one lands below them. A
+// shift-mousedown EXTENDS the live selection (the browser's own semantics), so it neither resets the
+// gesture nor re-reads the modifier — the existing chip just follows the bigger selection. Keyboard
+// extension (shift+arrows) fires no mousedown and rides the same write-through; a collapse (or a
+// selection leaving the transcript) ends the gesture but never clears chips.
+let quoteAddHeld = false;    // ⌘/Ctrl was down at the gesture-starting mousedown
+let quoteSeedLive = false;   // a gesture's chip is live — subsequent selectionchanges update it in place
+document.addEventListener("mousedown", (e) => {
+  if (e.shiftKey) return;                     // shift = extend the live selection: same gesture, same chip
+  quoteAddHeld = e.metaKey || e.ctrlKey;
+  quoteSeedLive = false;
+}, true);
+
+// Gesture-aware seed for TRANSCRIPT selections (the selectionchange listener + the Enter-to-reply shortcut).
+function seedTranscriptQuote(id: string, quote: string, uuid: string | null): void {
+  const chip = mkQuoteCitation(quote, uuid);
+  // a quote seed drops a goal chip (flavors never mix — the send routes goal XOR quotes)
+  const list = (composerCitations.get(id) || []).filter((c) => !c.itemId);
+  if (quoteSeedLive && list.length) list[list.length - 1] = chip;   // the live gesture adjusts its own chip
+  else if (quoteAddHeld && list.length) list.push(chip);            // ⌘-select: add a context below the held ones
+  else list.splice(0, list.length, chip);                           // plain select: this is the context now
+  composerCitations.set(id, list);
+  quoteSeedLive = true;
+  persistDrafts();
+  if (id === activeId) renderComposerChips(id);
+}
+
+// The EDITOR's highlight owns ONE chip — update it in place, append below if absent. A cursor move in the
+// editor must adjust its own context, never wipe transcript quotes stacked beside it (the user 2026-08-04).
+function seedEditorQuote(id: string, quote: string, src?: string): void {
+  const chip = mkQuoteCitation(quote, null, src);
+  const list = (composerCitations.get(id) || []).filter((c) => !c.itemId);   // flavors never mix
+  const i = list.findIndex((c) => !!c.src);
+  if (i >= 0) list[i] = chip; else list.push(chip);
+  composerCitations.set(id, list);
   persistDrafts();
   if (id === activeId) renderComposerChips(id);
 }
@@ -7017,15 +7082,18 @@ function transcriptSelection(): { text: string; uuid: string | null } | null {
 document.addEventListener("selectionchange", () => {
   if (!activeId) return;
   const q = transcriptSelection();
-  if (!q) return;                                           // never clear on collapse
-  setQuoteCitation(activeId, q.text, q.uuid);
+  if (!q) { quoteSeedLive = false; return; }                // never clear on collapse — the gesture just ends
+  seedTranscriptQuote(activeId, q.text, q.uuid);
 });
 
-// Dismiss the citation — via the chip ✕ or Backspace at the very start of an empty composer (so it deletes
-// "like a character", as the user asked). Re-focuses the box so typing continues uninterrupted.
-function removeCitation(id: string): void {
-  if (!composerCitations.has(id)) return;
-  composerCitations.delete(id);
+// Dismiss a citation — via its chip's ✕ (that exact chip, by index) or Backspace at the very start of an
+// empty composer (no index → the NEWEST chip goes first, so repeated presses eat the stack bottom-up,
+// each "like a character" as the user asked). Re-focuses the box so typing continues uninterrupted.
+function removeCitation(id: string, idx?: number): void {
+  const list = composerCitations.get(id);
+  if (!list || !list.length) return;
+  list.splice(idx == null ? list.length - 1 : idx, 1);
+  if (!list.length) composerCitations.delete(id);
   persistDrafts();
   if (id === activeId) { renderComposerChips(id); focusComposer(); }
 }
@@ -7043,11 +7111,12 @@ function focusComposer(): void {
 // never focuses the composer — the user is in the editor, and yanking focus to the chat would be wrong.
 function clearEditorCitation(id: string | null): void {
   if (!id) return;
-  const cite = composerCitations.get(id);
-  if (!cite || !cite.src) return;                          // not an editor-highlight chip → leave it
+  const list = composerCitations.get(id);
+  const kept = list ? list.filter((c) => !c.src) : [];
+  if (!list || kept.length === list.length) return;        // no editor-highlight chip → leave the rest alone
   const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
   if (id === activeId && ta && ta.value.trim()) return;    // a reply is in progress → keep the context
-  composerCitations.delete(id);
+  if (kept.length) composerCitations.set(id, kept); else composerCitations.delete(id);
   persistDrafts();
   if (id === activeId) renderComposerChips(id);            // rebuild the strip WITHOUT stealing focus
 }
@@ -7061,8 +7130,12 @@ function dropCitationByItem(itemId: string, itemIds?: string[]): void {
   const gone = new Set(itemIds && itemIds.length ? itemIds : [itemId]);
   gone.add(itemId);
   let changed = false;
-  for (const [sid, c] of composerCitations) {
-    if (c.itemId && gone.has(c.itemId)) { composerCitations.delete(sid); changed = true; if (sid === activeId) renderComposerChips(sid); }   // quote chips cite no goal — a card clear never drops them
+  for (const [sid, list] of composerCitations) {
+    const kept = list.filter((c) => !(c.itemId && gone.has(c.itemId)));   // quote chips cite no goal — a card clear never drops them
+    if (kept.length === list.length) continue;
+    if (kept.length) composerCitations.set(sid, kept); else composerCitations.delete(sid);
+    changed = true;
+    if (sid === activeId) renderComposerChips(sid);
   }
   if (changed) persistDrafts();
 }
@@ -7640,7 +7713,7 @@ window.addEventListener("message", (e: MessageEvent) => {
   // an EDITOR highlight (VS Code host, onDidChangeTextEditorSelection — the user 2026-07-13) seeds the
   // same quote chip a transcript highlight does, labeled + wrapped with its file:lines origin (m.src)
   else if (m.type === "editorSelection" && typeof m.text === "string" && m.text.trim() && activeId)
-    setQuoteCitation(activeId, m.text, null, typeof m.src === "string" ? m.src : undefined);
+    seedEditorQuote(activeId, m.text, typeof m.src === "string" ? m.src : undefined);
   // the editor selection collapsed (deselect / click away) — drop the chip that highlight seeded
   else if (m.type === "editorSelectionCleared") clearEditorCitation(activeId);
   else if (m.type === "closed") dismissSession(m.id);   // a session died on its own (or the kernel confirms our close)
@@ -7758,14 +7831,16 @@ function setupComposer() {
       // LOCAL kernel, which owns no such session and dropped it into tmux by uuid — nothing sent, no error,
       // the card flashing to Working and back. The kernel keeps deriving its sid from itemId, so this is inert
       // locally; every other card op (askClear/cardNotify/showOnTimeline) already carries the sid the same way.
-      const cite = composerCitations.get(activeId);
+      const cites = composerCitations.get(activeId);
+      const goalCite = cites?.find((c) => c.itemId);   // a goal chip rides alone (flavors never mix)
+      const quoteCites = cites ? cites.filter((c) => c.quote) : [];
       if (vscodeApi) {
-        if (cite?.itemId) vscodeApi.postMessage({ type: "askFollowUp", itemId: cite.itemId, text, sid: activeId });
-        else if (cite?.quote) vscodeApi.postMessage({ type: "sendMessage", id: activeId, text: quoteReplyBody(cite.quote, text, cite.src) });
+        if (goalCite?.itemId) vscodeApi.postMessage({ type: "askFollowUp", itemId: goalCite.itemId, text, sid: activeId });
+        else if (quoteCites.length) vscodeApi.postMessage({ type: "sendMessage", id: activeId, text: quoteReplyBody(quoteCites, text) });
         else { vscodeApi.postMessage({ type: "sendMessage", id: activeId, text }); registerOptimistic(activeId, text); }
         // (a citation follow-up/quote has its own kernel-side echo path; the optimistic bubble covers the plain send)
       }
-      if (cite) { composerCitations.delete(activeId); renderComposerChips(activeId); }   // consumed on send
+      if (cites) { composerCitations.delete(activeId); renderComposerChips(activeId); }   // consumed on send
       drafts.delete(activeId); draftStartedAt.delete(activeId); persistDrafts();   // sent — no draft to restore on a later switch-back
       ta.value = "";
       composerManualH = null;   // a drag-expanded box snaps back to one line after a send (the user 2026-07-07)

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -476,7 +476,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* ── citation chip strip (the user 2026-07-01) ── a click on a feed card summary / sub-goal seeds a
    dismissible pill here, ABOVE the textarea: "you're following up on THIS". Accent-blue, with an ✕ to
    dismiss (Backspace-at-start dismisses too). Reads as attached context, not typed text. */
-#composer-chips { flex: 1 1 100%; display: flex; flex-wrap: wrap; gap: 6px; padding: 0 0 6px 2px; }   /* full-width row of its own, above the compose row */
+#composer-chips { flex: 1 1 100%; display: flex; flex-direction: column; align-items: flex-start; gap: 6px; padding: 0 0 6px 2px; }   /* full-width block of its own, above the compose row; stacked chips each take a row (the user 2026-08-04) */
 .composer-chip {
   display: inline-flex; align-items: center; gap: 5px; max-width: 100%;
   background: color-mix(in srgb, var(--accent) 18%, transparent);


### PR DESCRIPTION
The composer citation slot becomes a per-session list, so reply contexts can stack.

**⌘-select adds a second context.** With ⌘ (Ctrl off-mac) held at the mousedown that starts a selection, the new quote chip lands below the ones already held instead of replacing them. Plain selection still replaces, and Shift keeps its native browser meaning — extend the live selection, whose chip just follows. ⌘ was picked over Shift because Shift already means "grow the current selection" in a browser, while ⌘ is the platform convention (Finder, lists) for adding a separate item.

**One gesture, one chip.** selectionchange fires dozens of times as a drag grows, so the live gesture writes through to the chip it made; only a new gesture decides replace-vs-add. A collapse ends the gesture but never clears chips.

Mechanics that follow: the strip stacks chips vertically (flex column), each chip dismisses itself by index, Backspace-at-start eats the newest first, the audit preview shows the whole outgoing message, and the send wraps one quote section per chip in strip order — a single chip composes byte-identically to the old form, and the kernel is untouched (the wrap stays client-side). Flavors never mix: a goal chip rides alone (the send routes goal XOR quotes). The VS Code editor highlight owns one chip updated in place, so cursor moves in the editor no longer wipe stacked transcript quotes. Persisted webview state migrates from the pre-stack single-object form.

Tests: new pins for the gesture model, stacking CSS, multi-section wrap, per-index dismissal, and the state migration; existing pins updated. Suites green locally (1636 node, 3878 pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)