### PR TITLE
A pre-click backend snapshot can no longer settle the interrupt stamp

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9945,7 +9945,15 @@ def _interrupting(sid, session, now, tm):
     if t0 is None:
         return False
     inflight = (tm or {}).get("interrupting")     # SDK exposes True/False; tmux has no such key → None
-    if inflight is not None:
+    # A snapshot TAKEN BEFORE the click carries no verdict on it (the user 2026-08-04): the push loop
+    # snapshots every backend once and then builds for a while, so a stop clicked mid-loop reaches this
+    # function with a PRE-click interrupting:False — which used to pop the stamp and eat the whole
+    # in-flight window (the chip read Interrupting…, fell to Working until the real settle, then Ready;
+    # later builds saw the flag True but no stamp, which deliberately paints nothing). Evidence older
+    # than the click stands down: fall through to the transcript path below, and the next FRESH snapshot
+    # settles it properly. A snapshot without snapT (tmux, older fixtures) is treated as current.
+    snap_t = (tm or {}).get("snapT")
+    if inflight is not None and not (snap_t is not None and snap_t < t0):
         if not inflight or now - t0 > 120:
             _interrupt_clicked.pop(sid, None)
             return False

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2199,6 +2199,11 @@ class SdkSession:
                 "interrupting": bool(self._interrupted),   # a user interrupt is IN FLIGHT: set at dispatch,
                 #   cleared EXACTLY when the aborted turn's ResultMessage settles → the kernel holds the chip +
                 #   feed badge on 'interrupting' across that whole window, no dependence on the flickering tail
+                "snapT": time.time(),   # when THIS snapshot was taken. The kernel's push loop snapshots every
+                #   backend once, then builds for a while; a stop clicked mid-loop postdates the snapshot, so
+                #   its interrupting:False is pre-click evidence and must not settle the click (the user
+                #   2026-08-04: Interrupting… fell back to Working, then Ready — the stale snapshot popped
+                #   the click stamp). _interrupting compares this against the click time.
                 "subagents": subs,   # live Task subagents (count + types) → lane affordance; [] when none
                 "bgTasks": self._live_bg_tasks()}   # live background tasks (task lifecycle stream) → an idle
                 #   session waiting on a timer/watcher reads AWAITING, why = the task's description; [] when none

--- a/tests/test_kernel_interrupt.py
+++ b/tests/test_kernel_interrupt.py
@@ -184,6 +184,43 @@ class InterruptingSdkFlag(unittest.TestCase):
         # chip — only a user-initiated stop (which stamps _interrupt_clicked) reads as 'interrupting'
         self.assertFalse(km._interrupting(SID, {"turns": [{"atoms": []}]}, NOW, {"interrupting": True}))
 
+    def test_a_pre_click_snapshot_cannot_settle_the_click(self):
+        # THE 2026-08-04 FLAP: the push loop snapshots every backend once, then builds for a while — a stop
+        # clicked mid-loop reaches _interrupting with a snapshot taken BEFORE the click, whose
+        # interrupting:False is pre-click evidence. It used to pop the stamp and eat the whole in-flight
+        # window: the chip read Interrupting…, fell to Working until the real settle, then Ready (later
+        # builds saw the flag True but no stamp, which deliberately paints nothing). A stale snapshot must
+        # stand down to the transcript path instead — no stop record yet → still interrupting, stamp kept.
+        km._interrupt_clicked[SID] = NOW - 2
+        stale = {"interrupting": False, "snapT": NOW - 5}   # snapshotted 3s before the click
+        self.assertTrue(km._interrupting(SID, {"turns": [{"atoms": []}]}, NOW, stale),
+                        "a snapshot older than the click carries no verdict on it")
+        self.assertIn(SID, km._interrupt_clicked, "the stamp survives the stale snapshot")
+
+    def test_a_fresh_snapshot_still_settles(self):
+        # the guard is scoped to STALE snapshots only: one taken after the click keeps its authority
+        km._interrupt_clicked[SID] = NOW - 2
+        fresh = {"interrupting": False, "snapT": NOW - 1}
+        self.assertFalse(km._interrupting(SID, {"turns": [{"atoms": []}]}, NOW, fresh),
+                         "a post-click snapshot's False flag is the settle event, as designed")
+        self.assertNotIn(SID, km._interrupt_clicked)
+
+    def test_a_stale_snapshot_with_a_landed_stop_record_still_settles(self):
+        # standing down means falling to the TRANSCRIPT path, not returning True unconditionally — the
+        # CLI's stop record at/after the click settles it even while the snapshot lags
+        km._interrupt_clicked[SID] = NOW - 2
+        intr = {"type": "user", "t": NOW - 1,
+                "message": {"role": "user", "content": "[Request interrupted by user]"}}
+        stale = {"interrupting": False, "snapT": NOW - 5}
+        self.assertFalse(km._interrupting(SID, {"turns": [{"atoms": [intr]}]}, NOW, stale))
+        self.assertNotIn(SID, km._interrupt_clicked)
+
+    def test_the_sdk_snapshot_carries_its_capture_time(self):
+        # the guard needs snapT on every SDK snapshot — pin the field at source (kernel/sdk_backend.py)
+        with open(os.path.join(os.path.dirname(BIN), "kernel", "sdk_backend.py")) as f:
+            src = f.read()
+        self.assertIn('"snapT": time.time()', src, "snapshot() stamps when it was taken")
+
 
 class FeedCardInterruptingBadge(unittest.TestCase):
     """The feed CARD wears a steady 'interrupting…' badge while a stop is in flight, then swaps to the


### PR DESCRIPTION
Reported today: hitting stop showed "Interrupting…" for a second, fell back to "Working", then settled to "Ready" (the feed card was right throughout).

Root cause: the push loop snapshots every backend once and then builds each session's frame, which takes a while across many sessions. A stop clicked mid-loop reaches `_interrupting` with a snapshot taken **before** the click. Its `interrupting: False` is pre-click evidence, but it read as the settle verdict — the click stamp was popped and eaten. From then on, later builds saw the backend flag True but no stamp (which deliberately paints nothing, to keep internal interrupts from painting the chip), so the whole remaining in-flight window rendered as "Working" until the real settle.

This is the standing "a writer whose evidence predates the diary stands down" rule applied to the chip: the SDK snapshot now carries `snapT` (capture time), and `_interrupting` treats a snapshot older than the click as carrying no verdict — it falls through to the transcript path (stop record / 120s cap), and the next fresh snapshot settles it properly. Snapshots without `snapT` (tmux, older fixtures) keep their existing authority, so behavior is unchanged everywhere else.

Tests: four new cases in `tests/test_kernel_interrupt.py` — stale snapshot keeps the stamp, fresh snapshot still settles, stale snapshot + landed stop record settles, and a source pin on `snapT`. Suites green locally (3882 pytest, 1635 node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)