### PR TITLE
Backticked filenames with spaces link whole-span, filesystem-verified

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11206,6 +11206,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                         if prompt or reminders or imgs:
                             ev = {"kind": "user", "md": prompt, "uuid": a.get("uuid"), "ts": ts,
                                   "human": author == "human" or bool(imgs), "reminders": reminders}
+                            sp = _space_paths(prompt, sid, a.get("uuid"))
+                            if sp:
+                                ev["spacePaths"] = sp   # backticked filenames WITH spaces, filesystem-verified → whole-span links
                             if reminders:                # join each task-notification to its command + output tail
                                 to = _task_outputs_for(reminders, sess["path"])
                                 if to:
@@ -11280,6 +11283,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                                            "uuid": a.get("uuid"), "ts": ts})
                             continue
                         ev = {"kind": "assistant", "md": txt, "uuid": a.get("uuid"), "ts": ts}
+                        sp = _space_paths(txt, sid, a.get("uuid"))
+                        if sp:
+                            ev["spacePaths"] = sp   # backticked filenames WITH spaces, filesystem-verified → whole-span links
                         if _interrupt_settle(events, txt, a):   # the null settle-reply closing an interrupted
                             ev["interruptSettle"] = True        # turn → rendered as seam marker, not a bubble
                         events.append(ev)
@@ -15494,6 +15500,44 @@ def _feed_artifacts(paths, sid):
         except Exception:
             continue
     return out or None
+
+
+# Inline-code spans that name an EXISTING file despite containing spaces (the user 2026-08-04: a note
+# titled `Moving from correlation to causal components.md` linkified only its last word). The client's
+# token linkifier can never span a space — in prose that boundary is exactly what keeps ordinary text
+# unlinked — but backticks DELIMIT the name, and the FILESYSTEM is the authority on whether the span is
+# a file or something else in backticks: `uv run pytest tests/test_x.py` resolves to no file, so it
+# never whole-links, while a vault note with spaces does. Resolution mirrors a click
+# (_resolve_open_path: ~ expanded, relative → the session's cwd). Checked ONCE per message (keyed by
+# its uuid) — build_session runs per push, and per-push stats would be waste; a file created after its
+# mention simply links from the next message that names it.
+_SPACE_PATH_CACHE = {}                       # (sid, uuid) -> tuple of verified span texts
+_CODE_SPAN_RE = re.compile(r"`([^`\n]{1,300})`")
+
+
+def _space_paths(md, sid, uuid):
+    """Backtick spans in `md` that contain a space AND resolve to a real file for this session — the
+    client whole-links exactly these (spacePaths on the chat event). None when there are none, so the
+    common message adds no payload."""
+    if not uuid or not md or "`" not in md:
+        return None
+    key = (sid, uuid)
+    hit = _SPACE_PATH_CACHE.get(key)
+    if hit is None:
+        out = []
+        for m in _CODE_SPAN_RE.finditer(md):
+            tok = m.group(1).strip()
+            if " " not in tok:
+                continue                     # space-free spans are the client token linkifier's job
+            # cheap pre-filter (an extension at the end, or an anchored start) — existence is the real gate
+            if not (re.search(r"\.[A-Za-z0-9]{1,8}$", tok) or tok.startswith(("/", "~/", "./", "../"))):
+                continue
+            if tok not in out and os.path.isfile(_resolve_open_path(tok, sid)):
+                out.append(tok)
+        if len(_SPACE_PATH_CACHE) > 50000:   # runaway backstop; one entry per rendered message
+            _SPACE_PATH_CACHE.clear()
+        _SPACE_PATH_CACHE[key] = hit = tuple(out)
+    return list(hit) or None
 
 
 def _open_file(p, sid=None):

--- a/tests/test_space_paths.py
+++ b/tests/test_space_paths.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Backticked filenames WITH SPACES become whole-span links (the user 2026-08-04): the client's token
+linkifier can never span a space, so a note named like `My spaced note.md` linkified only its last
+word. The kernel decides which space-containing spans deserve the whole-span link by asking the
+FILESYSTEM — _space_paths resolves each candidate exactly like a click (_resolve_open_path: ~ expanded,
+relative against the session's cwd) and keeps only spans that are real files, so a backticked command
+ending in a filename is never mislinked. Verified spans ride the chat event as spacePaths (pinned in
+ui/webview/chat-space-paths.test.ts on the client side). Synthetic fixtures only."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_spaces", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class SpacePaths(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.cwd = Path(self.td.name)
+        (self.cwd / "My spaced note.md").write_text("a note whose NAME has spaces\n")
+        (self.cwd / "tests").mkdir()
+        (self.cwd / "tests" / "test_x.py").write_text("def test_ok(): pass\n")
+        self._saved_cwd_of = km._cwd_of
+        km._cwd_of = lambda sid: str(self.cwd) if sid == SID else None
+        km._SPACE_PATH_CACHE.clear()
+        self._n = 0
+
+    def tearDown(self):
+        km._cwd_of = self._saved_cwd_of
+        km._SPACE_PATH_CACHE.clear()
+        self.td.cleanup()
+
+    def _uuid(self):
+        self._n += 1
+        return "msg-%d" % self._n
+
+    def test_a_spaced_filename_that_exists_is_verified(self):
+        got = km._space_paths("see `My spaced note.md` for the plan", SID, self._uuid())
+        self.assertEqual(got, ["My spaced note.md"])
+
+    def test_a_backticked_command_ending_in_a_real_file_is_not(self):
+        # the adversarial case the whole design guards: tests/test_x.py exists, but the SPAN is a
+        # command — resolving the whole span finds no file, so it never whole-links (the token
+        # linkifier still links tests/test_x.py inside it, client-side)
+        got = km._space_paths("run `uv run pytest tests/test_x.py` first", SID, self._uuid())
+        self.assertIsNone(got)
+
+    def test_an_absolute_spaced_path_verifies_without_a_cwd(self):
+        km._cwd_of = lambda sid: None
+        p = str(self.cwd / "My spaced note.md")
+        got = km._space_paths("wrote `%s` to disk" % p, SID, self._uuid())
+        self.assertEqual(got, [p])
+
+    def test_a_space_free_span_is_left_to_the_client_token_linkifier(self):
+        got = km._space_paths("see `tests/test_x.py`", SID, self._uuid())
+        self.assertIsNone(got)
+
+    def test_a_spaced_span_naming_no_file_is_dropped(self):
+        got = km._space_paths("see `No such note here.md`", SID, self._uuid())
+        self.assertIsNone(got)
+
+    def test_the_prefilter_skips_extensionless_unanchored_prose(self):
+        # documented trade-off: a spaced span with no extension and no anchored start is never stat'd,
+        # even if a file of that exact name exists — backtick emphasis on plain words stays prose
+        (self.cwd / "just some words").write_text("x")
+        got = km._space_paths("as `just some words` shows", SID, self._uuid())
+        self.assertIsNone(got)
+
+    def test_existence_is_checked_once_per_message_uuid(self):
+        u = self._uuid()
+        self.assertEqual(km._space_paths("see `My spaced note.md`", SID, u), ["My spaced note.md"])
+        (self.cwd / "My spaced note.md").unlink()
+        self.assertEqual(km._space_paths("see `My spaced note.md`", SID, u), ["My spaced note.md"],
+                         "cached per (sid, uuid): build_session runs per push, the stat ran once")
+        self.assertIsNone(km._space_paths("see `My spaced note.md`", SID, self._uuid()),
+                          "a NEW message re-checks and sees the deletion")
+
+    def test_no_uuid_or_no_backtick_short_circuits(self):
+        self.assertIsNone(km._space_paths("see `My spaced note.md`", SID, None))
+        self.assertIsNone(km._space_paths("no code spans here at all", SID, self._uuid()))
+
+    def test_build_session_attaches_spacepaths_to_both_event_kinds(self):
+        import inspect
+        src = inspect.getsource(km.build_session)
+        self.assertIn('sp = _space_paths(prompt, sid, a.get("uuid"))', src, "user events verify their spans")
+        self.assertIn('sp = _space_paths(txt, sid, a.get("uuid"))', src, "assistant events verify their spans")
+        self.assertIn('ev["spacePaths"] = sp', src, "verified spans ride the event")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/chat-space-paths.test.ts
+++ b/ui/webview/chat-space-paths.test.ts
@@ -1,0 +1,60 @@
+// Backticked filenames WITH SPACES become whole-span links (the user 2026-08-04): the token linkifier
+// can never span a space — in prose that boundary is what keeps ordinary text unlinked — so a note
+// named like `My spaced note.md` linkified only its last word. The KERNEL verifies which
+// space-containing inline-code spans are real files (build_session's _space_paths: resolved like a
+// click via _resolve_open_path, existence-checked, cached per message uuid) and ships them on the chat
+// event as `spacePaths`; the client whole-links exactly those spans. The filesystem is the authority —
+// a backticked command whose words end in a filename (`uv run pytest tests/x.py`) resolves to no file
+// and is never mislinked. render.ts has no jsdom harness → source pins (the repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the chat event carries kernel-verified spacePaths on user and assistant turns", () => {
+  assert.match(RENDER, /kind: "user";[^\n]*spacePaths\?: string\[\]/);
+  assert.match(RENDER, /kind: "assistant";[^\n]*spacePaths\?: string\[\]/);
+  // both event constructions attach it, gated on non-empty (the common message adds no payload)
+  assert.ok(KERNEL.includes('sp = _space_paths(prompt, sid, a.get("uuid"))'), "user events verify their spans");
+  assert.ok(KERNEL.includes('sp = _space_paths(txt, sid, a.get("uuid"))'), "assistant events verify their spans");
+  assert.ok(KERNEL.includes('ev["spacePaths"] = sp'), "verified spans ride the event");
+});
+
+test("the kernel verifies with the filesystem, resolved exactly like a click", () => {
+  assert.ok(KERNEL.includes("def _space_paths(md, sid, uuid):"));
+  // existence via the SAME resolution the click-to-open uses — cwd-relative, ~ expanded
+  assert.ok(KERNEL.includes("os.path.isfile(_resolve_open_path(tok, sid))"),
+    "the filesystem is the authority, not a lexical guess");
+  // checked once per message (build_session runs per push) — keyed by the message uuid
+  assert.ok(KERNEL.includes("_SPACE_PATH_CACHE"), "existence is checked once per message, not per push");
+  // only space-containing spans: space-free ones are the client token linkifier's job
+  assert.ok(KERNEL.includes('if " " not in tok:'));
+});
+
+test("linkifyFileUris whole-links a verified span's entire inline-code content", () => {
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\]\): void/);
+  // the pass targets inline <code> only, skips anything already linked or fenced
+  assert.match(RENDER, /for \(const code of Array\.from\(root\.querySelectorAll\("code"\)\)\) \{\s*\n\s*if \(code\.closest\("a, \.file-uri-link, pre"\)\) continue;/);
+  // exact-match against the kernel's verified set, then the whole content becomes one open link
+  assert.match(RENDER, /const tok = \(code\.textContent \|\| ""\)\.trim\(\);\s*\n\s*if \(!verified\.has\(tok\)\) continue;/);
+  assert.match(RENDER, /code\.replaceChildren\(link\);/);
+  // a verified image/PDF joins the same full-size preview strip the token links feed
+  assert.match(RENDER, /if \(previewKind\(tok\) && !previewable\.includes\(tok\) && !\(skipThumbs && skipThumbs\.includes\(tok\)\)\) previewable\.push\(tok\);/);
+});
+
+test("the whole-span pass runs BEFORE the token walk, so the new link is skipped by it", () => {
+  const fn = RENDER.slice(RENDER.indexOf("function linkifyFileUris("), RENDER.indexOf("function renderEvent("));
+  const spanPass = fn.indexOf('root.querySelectorAll("code")');
+  const walk = fn.indexOf("createTreeWalker");
+  assert.ok(spanPass >= 0 && walk >= 0 && spanPass < walk,
+    "code-span links land first; the token walker's closest('a') guard then leaves them alone");
+});
+
+test("every message render threads its event's spacePaths through", () => {
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths\);/);   // user bubble
+  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths\);/);     // expanded nudge body
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths\);/);    // assistant reply
+});

--- a/ui/webview/file-uri-link.test.ts
+++ b/ui/webview/file-uri-link.test.ts
@@ -12,7 +12,7 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("a bare file:// URL becomes a clickable .file-uri-link that opens the file in the host app", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\]\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\]\): void/);
   assert.match(RENDER, /el\("span", "file-uri-link"\)/);
   // clicking routes to the host opener (kernel `open <path>`), NOT a blocked window.open(file://) — a file://
   // URI is absolute, so it goes through the shared openPathLink's no-session-id branch
@@ -24,9 +24,9 @@ test("a bare file:// URL becomes a clickable .file-uri-link that opens the file 
 });
 
 test("linkify runs on chat message bodies (assistant reply + user bubble + nudge full text) and nowhere else — never tool summaries", () => {
-  assert.match(RENDER, /linkifyFileUris\(body\)/);             // the assistant reply
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths\)/); // your own bubble (in-bubble images don't re-thumb)
-  assert.match(RENDER, /linkifyFileUris\(full, imgPaths\)/);   // a compact nudge's expanded full text (2026-07-17)
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths\)/);   // the assistant reply
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths\)/); // your own bubble (in-bubble images don't re-thumb)
+  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths\)/);   // a compact nudge's expanded full text (2026-07-17)
   // exactly the definition + those three applications — so tool-use reports/summaries stay untouched
   const uses = RENDER.match(/linkifyFileUris\(/g) || [];
   assert.equal(uses.length, 4, "linkifyFileUris is defined once and applied to exactly the three chat bodies");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -73,8 +73,8 @@ type TaskOutputs = Record<string, { command: string; output: string }>;
 type ChatEvent = (
   // mid/mids: postal message ids the kernel could NOT resolve into cards, carried on the raw turn so a
   // timeline arc into it still lands (see _hydrate_postal's unresolved path)
-  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number }
-  | { kind: "assistant"; md: string; uuid?: string; ts?: string }
+  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; spacePaths?: string[] }
+  | { kind: "assistant"; md: string; uuid?: string; ts?: string; spacePaths?: string[] }   // spacePaths: backticked filenames WITH spaces the kernel verified exist (build_session _space_paths) → whole-span links
   | { kind: "thinking"; text: string; encrypted: boolean; uuid?: string; ts?: string }
   | {
       kind: "tool";
@@ -920,12 +920,29 @@ const CLICKABLE_PATH_RE = /file:\/\/\/?[^\s<>"'`)]+|[~.\w\-]*\/[~.\w\-/]*[\w\-]|
 // `skipThumbs`: paths this turn ALREADY renders as full in-bubble images (a pasted screenshot's
 // ev.images) — they stay clickable links but are excluded from the mentioned-path thumbnail strip,
 // otherwise the same picture renders twice (the user 2026-07-10).
-function linkifyFileUris(root: HTMLElement, skipThumbs?: string[]): void {
+// `spacePaths` (the user 2026-08-04): backticked filenames WITH SPACES that the KERNEL verified exist
+// (build_session's _space_paths — resolved like a click, existence-checked). The token regex below can
+// never span a space — in prose that boundary is what keeps ordinary text unlinked — so a note titled
+// `Moving from correlation to causal components.md` linkified only its last word. For exactly these
+// verified spans, the whole inline-code content becomes ONE link; the filesystem is the authority, so a
+// backticked command like `uv run pytest tests/x.py` (no such file) is never mislinked.
+function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: string[]): void {
+  const previewable: string[] = [];   // renderable paths found in this message → a thumbnail strip below it
+  if (spacePaths && spacePaths.length) {
+    const verified = new Set(spacePaths);
+    for (const code of Array.from(root.querySelectorAll("code"))) {
+      if (code.closest("a, .file-uri-link, pre")) continue;    // already linked, or a fenced block
+      const tok = (code.textContent || "").trim();
+      if (!verified.has(tok)) continue;
+      const link = openPathLink(tok, tok, true);
+      code.replaceChildren(link);                              // the <code> chrome stays; its content is the link
+      if (previewKind(tok) && !previewable.includes(tok) && !(skipThumbs && skipThumbs.includes(tok))) previewable.push(tok);
+    }
+  }
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
   const nodes: Text[] = [];
   let n: Node | null;
   while ((n = walker.nextNode())) nodes.push(n as Text);
-  const previewable: string[] = [];   // renderable paths found in this message → a thumbnail strip below it
   for (const tn of nodes) {
     if (tn.parentElement?.closest("a, .file-uri-link, pre")) continue;   // already a link, or a fenced code block
     const inCode = !!tn.parentElement?.closest("code");                  // inline code — where bare filenames may link
@@ -1627,7 +1644,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         if (more) {
           const full = el("div", "nudge-full md");
           full.innerHTML = md(raw);
-          linkifyFileUris(full, imgPaths);
+          linkifyFileUris(full, imgPaths, ev.spacePaths);
           bubble.appendChild(full);
           bubble.classList.add("nudge-collapsible");
           // toggle rides the stable document.body delegate (data-act), NOT a per-render listener —
@@ -1640,7 +1657,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         }
       } else if (ev.md) {
         bubble.innerHTML = md(ev.md);
-        linkifyFileUris(bubble, imgPaths);   // bare file:// URLs in a message → clickable (open in the host's default app)
+        linkifyFileUris(bubble, imgPaths, ev.spacePaths);   // bare file:// URLs in a message → clickable (open in the host's default app)
       }
       // images, IN the bubble (part of his message): thumbnail + open/copy caption;
       // a literal path in the typed text becomes the same open-link inline.
@@ -1760,7 +1777,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
     const body = el("div", "assistant md");
     body.innerHTML = md(ev.md);
     highlight(body);
-    linkifyFileUris(body);   // bare file:// URLs in the reply → clickable (open in the host's default app)
+    linkifyFileUris(body, undefined, ev.spacePaths);   // bare file:// URLs + verified spaced filenames → clickable
     turn.appendChild(body);
     return turn;
   }

--- a/ui/webview/slash-cmd-chip.test.ts
+++ b/ui/webview/slash-cmd-chip.test.ts
@@ -16,7 +16,7 @@ test("a leading slash command in a human bubble becomes a .slash-cmd-chip, args 
   assert.match(RENDER, /const chip = el\("span", "slash-cmd-chip"\); chip\.textContent = m\[1\];/);
   assert.match(RENDER, /const args = el\("span", "slash-cmd-args"\); args\.textContent = rest;/);
   // the non-command path still renders markdown as before (now also linkifies bare file:// URLs)
-  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n\s*bubble\.innerHTML = md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths\);[^\n]*\n\s*\}/);
+  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n\s*bubble\.innerHTML = md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths\);[^\n]*\n\s*\}/);
 });
 
 test("the chip is a monospace, outlined keyword pill that reads on the blue bubble", () => {

--- a/ui/webview/user-img-dedup.test.ts
+++ b/ui/webview/user-img-dedup.test.ts
@@ -15,7 +15,7 @@ const RENDER = fs.readFileSync(
   path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
 test("linkifyFileUris takes skipThumbs and excludes those paths from the thumbnail strip", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\]\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\]\): void/);
   // the previewable push gates on skipThumbs — the path stays a LINK, it just doesn't thumb
   assert.match(RENDER,
     /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) previewable\.push\(open\);/);
@@ -24,9 +24,9 @@ test("linkifyFileUris takes skipThumbs and excludes those paths from the thumbna
 test("the user bubble passes its ev.images paths (caption path AND path:-src) as skipThumbs", () => {
   // both ways an in-bubble image names its file: im.path (caption) and a "path:<abs>" src
   assert.match(RENDER, /\.flatMap\(\(im\) => \[im\.path, im\.src\.startsWith\("path:"\) \? im\.src\.slice\(5\) : ""\]\)/);
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths\);/);
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths\);/);
   // the assistant reply has no ev.images — its call stays bare (mentioned plots still thumb there)
-  assert.match(RENDER, /linkifyFileUris\(body\);/);
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths\);/);
 });
 
 // executed: replicate the strip-collection decision — a path already rendered as an in-bubble


### PR DESCRIPTION
Reported today with a screenshot: filenames with spaces mentioned in backticks (vault notes like `Moving from correlation to causal components.md`) render with only the last word as a link — the token linkifier can never span a space, because in prose that boundary is exactly what keeps ordinary text unlinked.

The hard part is that a backticked command whose last word is a file (`uv run pytest tests/x.py`) is lexically identical to a spaced filename, so no lexical rule can pick between them. Per the authoritative-sources rule, the filesystem decides: `build_session`'s new `_space_paths` resolves each space-containing inline-code span exactly like a click would be resolved (`_resolve_open_path`: `~` expanded, relative against the session's cwd) and attaches the spans that are real files to the chat event as `spacePaths`. Existence is checked once per message uuid (build_session runs per push; a file created later simply links from its next mention). The command case resolves to no file and never mislinks; the real note does and whole-links.

Client side, `linkifyFileUris` gains a pass that runs before the token walk: an inline `<code>` span whose trimmed content is in the verified set has its whole content become one open link (the `<code>` chrome stays), and a verified image/PDF joins the existing full-size preview strip. Both surfaces get this for free since it rides the event payload.

Tests: `tests/test_space_paths.py` (verified span, the adversarial command case, absolute paths, prefilter trade-off, per-uuid caching, build_session attachment) and `ui/webview/chat-space-paths.test.ts` (event field, whole-span pass, ordering before the token walk, call-site threading); three existing pin files updated for the new signature. Suites green locally (3887 pytest, 1640 node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)