### PR TITLE
One cmd-drag never lists the same context twice

### DIFF
--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -114,7 +114,7 @@ test("highlighting transcript text seeds a QUOTE chip — the same chip, reply-c
   assert.match(RENDER, /const a = turnOf\(sel\.anchorNode\), f = turnOf\(sel\.focusNode\);/);
   assert.match(RENDER, /if \(!a \|\| !f\) return null;/);
   assert.match(RENDER, /document\.addEventListener\("selectionchange", \(\) => \{/);
-  assert.match(RENDER, /if \(!q\) \{ quoteSeedLive = false; return; \}\s*\/\/ never clear on collapse/);
+  assert.match(RENDER, /if \(!q\) return;\s*\n\s*seedTranscriptQuote\(activeId, q\.text, q\.uuid\);/);   // never clears chips, never touches the gesture
   // seeding NEVER focuses the composer — a focus steal would collapse the selection mid-drag
   const seeder = RENDER.split("function seedTranscriptQuote(")[1].split("\n}")[0];
   assert.doesNotMatch(seeder, /focusComposer/);
@@ -125,14 +125,14 @@ test("⌘-selecting another piece of text ADDS a context below the held ones (th
   // The deciding event is the mousedown that STARTS the selection gesture: plain → replace (the pre-stack
   // behavior), ⌘/Ctrl → add. Shift is deliberately left to the browser (it extends the live selection, and
   // the live gesture's chip follows), so a shift-mousedown neither resets the gesture nor re-reads the key.
-  assert.match(RENDER, /document\.addEventListener\("mousedown", \(e\) => \{\s*\n\s*if \(e\.shiftKey\) return;[\s\S]*?quoteAddHeld = e\.metaKey \|\| e\.ctrlKey;\s*\n\s*quoteSeedLive = false;\s*\n\}, true\);/);
-  // One gesture owns one chip: selectionchange fires dozens of times mid-drag, so the live gesture WRITES
-  // THROUGH to its own chip; only a new gesture appends (⌘) or replaces (plain). Without the write-through
-  // a single ⌘-drag would spray a chip per selectionchange event.
+  assert.match(RENDER, /document\.addEventListener\("mousedown", \(e\) => \{\s*\n\s*if \(e\.shiftKey\) return;[\s\S]*?quoteAddHeld = e\.metaKey \|\| e\.ctrlKey;\s*\n\s*quoteSeedIdx = null;\s*\n\}, true\);/);
+  // One gesture owns one chip BY INDEX: selectionchange fires dozens of times mid-drag, so the live
+  // gesture WRITES THROUGH to the chip it owns; only a new gesture appends (⌘) or replaces (plain).
+  // Without the write-through a single ⌘-drag would spray a chip per selectionchange event.
   const seeder = RENDER.split("function seedTranscriptQuote(")[1].split("\n}")[0];
-  assert.match(seeder, /if \(quoteSeedLive && list\.length\) list\[list\.length - 1\] = chip;/);
-  assert.match(seeder, /else if \(quoteAddHeld && list\.length\) list\.push\(chip\);/);
-  assert.match(seeder, /else list\.splice\(0, list\.length, chip\);/);
+  assert.match(seeder, /let idx = quoteSeedIdx != null && quoteSeedIdx < list\.length \? quoteSeedIdx : null;/);
+  assert.match(seeder, /if \(quoteAddHeld && list\.length\) idx = list\.length;/);
+  assert.match(seeder, /else \{ list\.length = 0; idx = 0; \}/);
   // flavors never mix: any quote seed drops a goal chip (the send routes goal XOR quotes)
   assert.match(seeder, /\.filter\(\(c\) => !c\.itemId\)/);
   // the second chip sits BELOW the first: the strip stacks (flex column), one chip per row
@@ -141,6 +141,20 @@ test("⌘-selecting another piece of text ADDS a context below the held ones (th
   assert.match(RENDER, /list\.splice\(idx == null \? list\.length - 1 : idx, 1\);/);
   // the persisted state restores a LIST, and still accepts the pre-stack single-object form
   assert.match(RENDER, /for \(const c of \(Array\.isArray\(v\) \? v : \[v\]\) as any\[\]\)/);
+});
+
+test("one ⌘-drag never lists the same context twice (the user 2026-08-04)", () => {
+  // The reported bug: a mid-drag selectionchange tick can momentarily fail to qualify (the cursor crossing
+  // the gap between two turns puts an endpoint outside any .turn). Ending the gesture on that tick made the
+  // next qualifying tick APPEND AGAIN — one ⌘-drag produced two copies of the same context. Plain select
+  // masked the identical flicker because its re-seed replaces. So:
+  // (1) a non-qualifying tick leaves the gesture alone — ONLY a mousedown ends it…
+  const listener = RENDER.split('document.addEventListener("selectionchange"')[1].split("});")[0];
+  assert.doesNotMatch(listener, /quoteSeedIdx/, "the selectionchange listener never touches the gesture");
+  // (2) …and identical text collapses regardless of the path that re-cited it (a repeated double-click,
+  // a drag re-traced after a transcript rebuild killed the selection) — the gesture's own chip survives.
+  const seeder = RENDER.split("function seedTranscriptQuote(")[1].split("\n}")[0];
+  assert.match(seeder, /if \(i !== idx && list\[i\]\.quote === chip\.quote\) \{\s*\n\s*list\.splice\(i, 1\);\s*\n\s*if \(i < idx\) idx--;/);
 });
 
 test("Enter with a live transcript selection drops into the message box with the quote as context (the user 2026-08-04)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7040,19 +7040,22 @@ function mkQuoteCitation(quote: string, uuid: string | null, src?: string): Cita
 
 // One selection GESTURE owns one chip (the user 2026-08-04). selectionchange fires dozens of times as a
 // drag grows, so appending per event would spray chips — instead the live gesture WRITES THROUGH to the
-// chip it made (quoteSeedLive), and only a NEW gesture decides replace-vs-add. The deciding event is the
+// chip it owns (quoteSeedIdx), and only a NEW gesture decides replace-vs-add. The deciding event is the
 // mousedown that starts the gesture: plain → this selection becomes the whole context (the pre-stack
 // behavior); ⌘ (Ctrl off-mac) held → the chips already held stay and the new one lands below them. A
 // shift-mousedown EXTENDS the live selection (the browser's own semantics), so it neither resets the
 // gesture nor re-reads the modifier — the existing chip just follows the bigger selection. Keyboard
-// extension (shift+arrows) fires no mousedown and rides the same write-through; a collapse (or a
-// selection leaving the transcript) ends the gesture but never clears chips.
-let quoteAddHeld = false;    // ⌘/Ctrl was down at the gesture-starting mousedown
-let quoteSeedLive = false;   // a gesture's chip is live — subsequent selectionchanges update it in place
+// extension (shift+arrows) fires no mousedown and rides the same write-through.
+// ONLY a mousedown ends a gesture. A mid-drag tick can momentarily fail to qualify (the cursor crossing
+// the gap between two turns puts an endpoint outside any .turn) — treating that as a gesture end made
+// the very next qualifying tick APPEND AGAIN, so one ⌘-drag listed the same context twice (the user
+// 2026-08-04). Plain select masked the same flicker, because its re-seed replaces.
+let quoteAddHeld = false;              // ⌘/Ctrl was down at the gesture-starting mousedown
+let quoteSeedIdx: number | null = null;   // index of the chip the live gesture owns — its write-through target
 document.addEventListener("mousedown", (e) => {
   if (e.shiftKey) return;                     // shift = extend the live selection: same gesture, same chip
   quoteAddHeld = e.metaKey || e.ctrlKey;
-  quoteSeedLive = false;
+  quoteSeedIdx = null;
 }, true);
 
 // Gesture-aware seed for TRANSCRIPT selections (the selectionchange listener + the Enter-to-reply shortcut).
@@ -7060,11 +7063,23 @@ function seedTranscriptQuote(id: string, quote: string, uuid: string | null): vo
   const chip = mkQuoteCitation(quote, uuid);
   // a quote seed drops a goal chip (flavors never mix — the send routes goal XOR quotes)
   const list = (composerCitations.get(id) || []).filter((c) => !c.itemId);
-  if (quoteSeedLive && list.length) list[list.length - 1] = chip;   // the live gesture adjusts its own chip
-  else if (quoteAddHeld && list.length) list.push(chip);            // ⌘-select: add a context below the held ones
-  else list.splice(0, list.length, chip);                           // plain select: this is the context now
+  let idx = quoteSeedIdx != null && quoteSeedIdx < list.length ? quoteSeedIdx : null;   // the live gesture's chip
+  if (idx == null) {
+    if (quoteAddHeld && list.length) idx = list.length;   // ⌘-select: add a context below the held ones
+    else { list.length = 0; idx = 0; }                    // plain select: this is the context now
+  }
+  list[idx] = chip;
+  // Identical text never lists twice (the user 2026-08-04): whatever path re-cites text already held —
+  // re-selecting the same sentence, a double-click repeated, a drag re-traced after a transcript rebuild
+  // killed the selection — the OTHER copy collapses and the gesture's own chip survives.
+  for (let i = list.length - 1; i >= 0; i--) {
+    if (i !== idx && list[i].quote === chip.quote) {
+      list.splice(i, 1);
+      if (i < idx) idx--;
+    }
+  }
+  quoteSeedIdx = idx;
   composerCitations.set(id, list);
-  quoteSeedLive = true;
   persistDrafts();
   if (id === activeId) renderComposerChips(id);
 }
@@ -7099,7 +7114,10 @@ function transcriptSelection(): { text: string; uuid: string | null } | null {
 document.addEventListener("selectionchange", () => {
   if (!activeId) return;
   const q = transcriptSelection();
-  if (!q) { quoteSeedLive = false; return; }                // never clear on collapse — the gesture just ends
+  // Never clear chips on a collapse — and never touch the GESTURE either: a mid-drag tick can flicker
+  // non-qualifying (endpoint in the gap between turns), and ending the gesture there made the next tick
+  // append a second copy of the same context (the user 2026-08-04). Gestures end at the next mousedown.
+  if (!q) return;
   seedTranscriptQuote(activeId, q.text, q.uuid);
 });
 


### PR DESCRIPTION
Reported today: ⌘-multi-select lists the same context twice.

Root cause: the selection gesture ended whenever a `selectionchange` tick failed to qualify — and a mid-drag tick does exactly that when the cursor crosses the gap between two turns (an endpoint momentarily lands outside any `.turn`). The next qualifying tick of the same drag then read as a fresh gesture and, with ⌘ held, appended again: one drag, two copies. Plain select had the identical flicker all along, invisibly, because its re-seed replaces.

Two-layer fix in `seedTranscriptQuote`:
- Only a mousedown ends a gesture; a non-qualifying tick leaves it alone. The gesture now owns its chip by index (`quoteSeedIdx`) instead of assuming the newest slot, so write-through always hits the right chip.
- Identical quote text collapses whenever it re-enters the list (repeated double-click, a drag re-traced after a transcript rebuild killed the selection) — the gesture's own chip survives. Same text can never be listed twice by any path.

Tests: pins updated to the index-owned gesture model plus a regression test asserting the selectionchange listener never touches the gesture and the identical-text collapse. Suites green locally (1642 node, 3887 pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)