### PR TITLE
Web-dropped attachments render: the kernel page gets the strip div

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16604,10 +16604,15 @@ def _chat_body():
             '<div id="footer">'
             '<div id="composer-resize" title="Drag to resize the message box"></div>'   # drag the divider to grow/shrink the message box (the user 2026-07-07)
             '<div id="statusline" class="statusline"></div>'
-            '<div id="composer"><div id="composer-chips" style="display:none"></div>'   # click-to-cite chip strip (the user 2026-07-01)
+            # composer-files MUST mirror vscode-extension/src/page-skeleton.ts (pinned by
+            # ui/webview/composer-files.test.ts): the attachment strip renders by id, and this page IS the
+            # web dashboard's skeleton — when only the extension skeleton grew the div, a file dropped on
+            # the web surface attached invisibly, showing nothing at all (the user 2026-08-04)
+            '<div id="composer"><div id="composer-files" style="display:none"></div>'
+            '<div id="composer-chips" style="display:none"></div>'   # click-to-cite chip strip (the user 2026-07-01)
             '<textarea id="composer-input" rows="1" '
             'placeholder="Message this session…"></textarea>'
-            '<button id="composer-attach" title="Attach a file — inserts its path">'
+            '<button id="composer-attach" title="Attach a file">'
             '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" '
             'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'
             '<path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66'

--- a/ui/webview/composer-files.test.ts
+++ b/ui/webview/composer-files.test.ts
@@ -12,11 +12,17 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 const SKELETON = fs.readFileSync(path.resolve(process.cwd(), "src", "page-skeleton.ts"), "utf8");
 
-test("the composer has an attachment strip, its own row above the chips", () => {
+test("the composer has an attachment strip, its own row above the chips — on BOTH skeletons", () => {
   assert.match(SKELETON, /<div id="composer-files" style="display:none"><\/div><div id="composer-chips"/);
+  // the WEB dashboard's page skeleton is the kernel's own HTML, not page-skeleton.ts — when only the
+  // extension skeleton grew this div, a file dropped on the web surface attached invisibly, showing
+  // nothing at all (the user 2026-08-04). The two skeletons must carry the strip in step.
+  assert.match(KERNEL, /<div id="composer"><div id="composer-files" style="display:none"><\/div>'/);
+  assert.match(KERNEL, /<div id="composer-chips" style="display:none"><\/div>'/);
   assert.match(CSS, /#composer-files \{ flex: 1 1 100%; display: flex; flex-wrap: wrap/);
   assert.match(CSS, /\.composer-file-img \{ display: block; height: 46px/);
   // the ✕ rides the tab-close idiom: hidden until hover, no clutter on a quiet strip
@@ -42,8 +48,10 @@ test("an image thumbnail renders per surface; other files wear an ext + name chi
   assert.match(fn, /if \(canPreview\(\)\) \{/);
   assert.match(fn, /img\.src = fileUrl\(p, id\);/);
   assert.match(fn, /const w = buildPathImg\(p\);/);
-  // an unservable path falls to the doc chip rather than a broken image
-  assert.match(fn, /img\.onerror = \(\) => \{ img\.replaceWith\(composerFileDoc\(p\)\); \};/);
+  // name first, pixels when ready (the user 2026-08-04): the ext + name chip renders immediately and
+  // the image swaps in on its own load event — a slow fetch never shows a blank box, a 404 keeps the chip
+  assert.match(fn, /const doc = composerFileDoc\(p\);\s*\n\s*box\.appendChild\(doc\);/);
+  assert.match(fn, /img\.addEventListener\("load", \(\) => doc\.replaceWith\(img\)\);/);
   // non-image: extension badge + basename, both TEXT (no glyphs)
   assert.match(RENDER, /ext\.textContent = \(dot > 0 \? p\.slice\(dot \+ 1\) : "file"\)\.slice\(0, 5\)\.toUpperCase\(\);/);
   assert.match(RENDER, /nm\.textContent = p\.split\("\/"\)\.pop\(\) \|\| p;/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6982,12 +6982,16 @@ function renderComposerFiles(id: string | null): void {
     box.title = p + " — click opens it · ✕ removes";
     if (previewKind(p) === "img") {
       if (canPreview()) {
+        // Name first, pixels when ready (the user 2026-08-04): the ext + name chip goes up IMMEDIATELY
+        // and the image swaps in on its own load event — a slow /file fetch never leaves a blank box,
+        // and a 404 simply keeps the chip (event-based on load/error, nothing timed).
+        const doc = composerFileDoc(p);
+        box.appendChild(doc);
         const img = document.createElement("img");
         img.className = "composer-file-img";
-        img.src = fileUrl(p, id);
         img.alt = p;
-        img.onerror = () => { img.replaceWith(composerFileDoc(p)); };   // unservable → fall to the ext chip
-        box.appendChild(img);
+        img.addEventListener("load", () => doc.replaceWith(img));
+        img.src = fileUrl(p, id);
       } else {
         const w = buildPathImg(p);                 // VS Code: host-read data URL fills in; chip until then
         w.classList.add("composer-file-hostimg");


### PR DESCRIPTION
Reported today: files dropped on the chat box showed up as nothing at all — no thumbnail, no path (the drops landed in the state dir fine).

Root cause: the web dashboard's page HTML is the **kernel's own skeleton** (kernel.py), not `page-skeleton.ts` — PR #201 added the attachment strip's `#composer-files` div only to the extension skeleton. On the web surface the element doesn't exist, so `renderComposerFiles` early-returned and dropped files attached invisibly (they were in the map, persisted, and would have ridden the send — just rendered nowhere). The kernel page now carries the div, and `composer-files.test.ts` pins **both** skeletons in step so the surfaces cannot diverge on this again.

Also per the same report: thumbnails render **name-first** — the ext + name chip appears immediately and the image swaps in on its own load event, so a slow `/file` fetch never leaves a blank box and a 404 simply keeps the chip (event-based, nothing timed). The attach button's stale "inserts its path" tooltip is updated too.

Note: the kernel HTML change takes effect on the next kernel restart; the webview half rides the normal dist reload.

Tests: both-skeletons pin plus the name-first/load-swap pins. Suites green locally (1647 node, 3891 pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)