### PR TITLE
Discontiguous cmd-ranges become separate chips, not one concatenation

### DIFF
--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -110,8 +110,8 @@ test("highlighting transcript text seeds a QUOTE chip — the same chip, reply-c
   // The qualification lives in transcriptSelection(), shared with the Enter-to-reply shortcut so the
   // two can never disagree on what counts as a transcript selection.
   assert.match(RENDER, /function transcriptSelection\(\): \{ text: string; uuid: string \| null \} \| null/);
-  assert.match(RENDER, /if \(!sel \|\| !sel\.rangeCount \|\| sel\.isCollapsed\) return null;/);
-  assert.match(RENDER, /const a = turnOf\(sel\.anchorNode\), f = turnOf\(sel\.focusNode\);/);
+  assert.match(RENDER, /if \(!sel \|\| !sel\.rangeCount\) return null;/);
+  assert.match(RENDER, /const a = turnOf\(r\.startContainer\), f = turnOf\(r\.endContainer\);/);
   assert.match(RENDER, /if \(!a \|\| !f\) return null;/);
   assert.match(RENDER, /document\.addEventListener\("selectionchange", \(\) => \{/);
   assert.match(RENDER, /if \(!q\) return;\s*\n\s*seedTranscriptQuote\(activeId, q\.text, q\.uuid\);/);   // never clears chips, never touches the gesture
@@ -141,6 +141,20 @@ test("⌘-selecting another piece of text ADDS a context below the held ones (th
   assert.match(RENDER, /list\.splice\(idx == null \? list\.length - 1 : idx, 1\);/);
   // the persisted state restores a LIST, and still accepts the pre-stack single-object form
   assert.match(RENDER, /for \(const c of \(Array\.isArray\(v\) \? v : \[v\]\) as any\[\]\)/);
+});
+
+test("discontiguous ⌘-ranges become separate chips — the seed reads the ACTIVE range, never sel.toString() (the user 2026-08-04)", () => {
+  // The browser's own discontiguous selection keeps the earlier highlight live as its own range while a
+  // new one is dragged; sel.toString() CONCATENATES every range, so seeding from it merged two sections
+  // into one chip. The seed reads the newest range alone — the earlier ranges already own their chips
+  // from their own gestures — with endpoints from the range's containers (anchor/focus describe only the
+  // last-modified range, and flip on a backwards drag).
+  assert.match(RENDER, /const r = sel\.getRangeAt\(sel\.rangeCount - 1\);/);
+  assert.match(RENDER, /if \(r\.collapsed\) return null;/);
+  assert.match(RENDER, /const text = r\.toString\(\)\.trim\(\);/);
+  const fn = RENDER.split("function transcriptSelection(")[1].split("\n}")[0];
+  assert.doesNotMatch(fn, /sel\.toString/, "the concatenating read is gone");
+  assert.doesNotMatch(fn, /sel\.anchorNode|sel\.focusNode/, "endpoints come from the active range");
 });
 
 test("one ⌘-drag never lists the same context twice (the user 2026-08-04)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7184,16 +7184,24 @@ function seedEditorQuote(id: string, quote: string, src?: string): void {
 // The current selection when (and only when) it qualifies as transcript text — both endpoints inside
 // `.turn` elements, non-collapsed, non-empty. Shared by the selectionchange seeding below and the
 // Enter-to-reply shortcut (window keydown), so the two can never disagree on what counts.
+// A ⌘-multi-select holds SEVERAL ranges — the browser's own discontiguous selection keeps the earlier
+// highlight live while a new one is dragged. The chip being built belongs to the range the user is
+// ACTIVELY dragging — the newest — so this reads THAT range alone, never sel.toString(), which
+// concatenates every range and merged two discontiguous sections into one chip (the user 2026-08-04).
+// The earlier ranges already own their chips from their own gestures. Endpoints come from the range's
+// own containers (anchor/focus describe only the last-modified range, and flip on a backwards drag).
 function transcriptSelection(): { text: string; uuid: string | null } | null {
   const sel = window.getSelection();
-  if (!sel || !sel.rangeCount || sel.isCollapsed) return null;
+  if (!sel || !sel.rangeCount) return null;
+  const r = sel.getRangeAt(sel.rangeCount - 1);
+  if (r.collapsed) return null;                             // the ACTIVE range must be a real span
   const turnOf = (n: Node | null) => {
     const e = n instanceof Element ? n : n?.parentElement;
     return e?.closest?.(".turn") ?? null;
   };
-  const a = turnOf(sel.anchorNode), f = turnOf(sel.focusNode);
+  const a = turnOf(r.startContainer), f = turnOf(r.endContainer);
   if (!a || !f) return null;                                // both endpoints must be transcript turns
-  const text = sel.toString().trim();
+  const text = r.toString().trim();
   if (!text) return null;
   return { text, uuid: a.getAttribute("data-uuid") };
 }


### PR DESCRIPTION
Reported today: ⌘-multi-select concatenates two sections into one chip; discontiguous sections should be separate chips.

What happens: the browser's own discontiguous selection keeps the earlier highlight live as its own range while the new ⌘-drag adds another — and `transcriptSelection` read `sel.toString()`, which concatenates the text of **every** range. So the chip being built for the second section swallowed the first one too.

The seed now reads the **active** range alone (`sel.getRangeAt(sel.rangeCount - 1)`, the newest), qualifying and extracting from that range's own containers — `anchorNode`/`focusNode` describe only the last-modified range and flip on a backwards drag, so the range's `startContainer`/`endContainer` are the reliable endpoints. The earlier ranges already own their chips from their own gestures, so each discontiguous section lands in its own chip. On engines that only ever hold one range, this is behaviorally identical to before.

Tests: pins moved to the per-range read plus a regression test asserting `sel.toString()`/`sel.anchorNode` are gone from the qualifier. Suites green locally (1648 node, 3891 pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)