### PR TITLE
Ultracode joins the effort dropdown

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -562,7 +562,11 @@ def _write_palette_mirror():
 # model literals. The judge accepts only a value from here (setJudgeModel/setIndexModel validate against it).
 MODEL_CHOICES = [{"value": "fable", "label": "Fable"}, {"value": "opus", "label": "Opus"},
                  {"value": "sonnet", "label": "Sonnet"}, {"value": "haiku", "label": "Haiku"}]
-EFFORT_CHOICES = [{"value": v, "label": v} for v in ("low", "medium", "high", "xhigh", "max")]
+# "ultracode" tops the ladder (the user 2026-08-04): the CLI's own /effort offers it — xhigh effort plus
+# standing dynamic-workflow orchestration, per session. tmux delivers the literal "/effort ultracode"; the
+# SDK backend maps it to effort=xhigh + the `ultracode` settings key (the CLI's documented per-session
+# hook), since the SDK's typed EffortLevel has no such value. See sdk_backend ultracode_settings_path.
+EFFORT_CHOICES = [{"value": v, "label": v} for v in ("low", "medium", "high", "xhigh", "max", "ultracode")]
 _MODEL_VALUES = {m["value"] for m in MODEL_CHOICES}
 _EFFORT_VALUES = {e["value"] for e in EFFORT_CHOICES}
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -70,7 +70,7 @@ def pick_identity_color(sid: str, state_dir=None) -> tuple[str, str]:
 # and the init message does NOT echo it back, so romp sets it explicitly and tracks it (otherwise the picker
 # can't show a true value). "high" suits agentic coding; the user changes it per session via the picker.
 DEFAULT_EFFORT = "high"
-EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "max")
+EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "max", "ultracode")   # ultracode = xhigh + workflow orchestration (per session)
 # Cap on a SINGLE stdout JSON message from the CLI. The SDK default is 1 MB, and one message routinely
 # exceeds that in a coding session (a big file Read, a large Bash/grep result, a base64 image echoed in a
 # tool_result). When it does, the SDK transport raises "JSON message exceeded maximum buffer size", which
@@ -951,6 +951,24 @@ def list_regs(state_dir: Path) -> list[dict]:
 # changes still persist per-session (the reg, restored on resume); this is only the seed for new sessions.
 # Stored OUTSIDE sdk/ so list_regs' sdk/*.json glob never mistakes it for a session.
 # ---------------------------------------------------------------------------
+
+ULTRACODE_SETTINGS = "sdk-ultracode.json"   # the --settings payload for sessions whose effort is "ultracode"
+
+
+def ultracode_settings_path(state_dir) -> str:
+    """The settings file handed to the CLI (options.settings — the flag-settings layer, the CLI's
+    documented per-session hook for the `ultracode` key) when a session's effort is "ultracode". The
+    SDK's typed EffortLevel has no such value: ultracode IS xhigh plus standing dynamic-workflow
+    orchestration, so the typed field carries "xhigh" and this key switches the orchestration on.
+    Rewritten on every use (constant content, atomic enough for a one-key file)."""
+    p = os.path.join(str(state_dir), ULTRACODE_SETTINGS)
+    try:
+        with open(p, "w") as f:
+            f.write('{"ultracode": true}\n')
+    except OSError:
+        pass
+    return p
+
 
 def _defaults_path(state_dir: Path) -> Path:
     return Path(state_dir) / "sdk-defaults.json"
@@ -2755,7 +2773,9 @@ class SdkBackend:
                    "SubagentStop": [HookMatcher(matcher=None, hooks=[sess._subagent_stop_hook])]},    #   count/types
             permission_mode=sess.mode,
             include_partial_messages=False,
-            effort=sess.effort or DEFAULT_EFFORT,   # connect-time --effort (no runtime control); a change reconnects
+            # connect-time --effort (no runtime control); a change reconnects. "ultracode" is not a typed
+            # EffortLevel — it rides as xhigh + the `ultracode` settings key (added below).
+            effort=("xhigh" if (sess.effort or DEFAULT_EFFORT) == "ultracode" else (sess.effort or DEFAULT_EFFORT)),
             max_buffer_size=SDK_MAX_BUFFER,   # a >1MB stdout message would crash the receive loop → kill any live picker
         )
         # romp's harness prompt is APPENDED via the SDK's DESIGNED system_prompt field — the Claude Code preset
@@ -2799,6 +2819,8 @@ class SdkBackend:
                       % sess.name)
         if self.mcp_config:
             kw["mcp_servers"] = self.mcp_config
+        if (sess.effort or "") == "ultracode":
+            kw["settings"] = ultracode_settings_path(self.state_dir)   # the `ultracode` settings key, per session
         return ClaudeAgentOptions(**kw)
 
     # ---- lifecycle (kernel-thread API) ----
@@ -3300,7 +3322,8 @@ class SdkBackend:
         reg["effort"] = value
         reg["effortPending"] = True   # the reconnect that applies it hasn't completed yet → dots + "Reloading session…"
         write_reg(self.state_dir, sid, reg)
-        write_sdk_default(self.state_dir, effort=value)   # remember as the seed for the NEXT new session (the user 2026-06-27)
+        if value != "ultracode":   # ultracode is per-session by design (the CLI: "this session only") — never a seed
+            write_sdk_default(self.state_dir, effort=value)   # remember as the seed for the NEXT new session (the user 2026-06-27)
         s = self.sessions.get(sid)
         if s:
             s.effort = value        # picker label reflects it now; the reconnect makes it real

--- a/tests/test_kernel_judge_model.py
+++ b/tests/test_kernel_judge_model.py
@@ -55,7 +55,8 @@ class JudgeSettings(unittest.TestCase):
     # ---- ONE source: the kernel owns MODEL_CHOICES / EFFORT_CHOICES; no per-surface hardcoding ----
     def test_model_choices_are_the_single_source(self):
         self.assertEqual([m["value"] for m in km.MODEL_CHOICES], ["fable", "opus", "sonnet", "haiku"])
-        self.assertEqual([e["value"] for e in km.EFFORT_CHOICES], ["low", "medium", "high", "xhigh", "max"])
+        self.assertEqual([e["value"] for e in km.EFFORT_CHOICES],
+                         ["low", "medium", "high", "xhigh", "max", "ultracode"])   # ultracode tops the ladder (the user 2026-08-04)
         # the judge no longer keeps its own model list — it trusts the kernel-validated STATE value
         self.assertNotIn("JUDGE_MODELS", dir(jd), "the judge holds no model list (kernel is the single source)")
 

--- a/tests/test_kernel_model_colors.py
+++ b/tests/test_kernel_model_colors.py
@@ -53,7 +53,7 @@ class ModelColors(unittest.TestCase):
         mx = km._effort_color("max", self.stops)
         self.assertGreater(self._lum(mx), self._lum(lo))
         # ordered low < medium < high < xhigh < max
-        vals = [self._lum(km._effort_color(e, self.stops)) for e in ("low", "medium", "high", "xhigh", "max")]
+        vals = [self._lum(km._effort_color(e, self.stops)) for e in ("low", "medium", "high", "xhigh", "max", "ultracode")]
         self.assertEqual(vals, sorted(vals))
 
     def test_effort_case_insensitive_unknown_is_none(self):
@@ -65,7 +65,7 @@ class ModelColors(unittest.TestCase):
         # the most/least capable and the extreme efforts hit the map's endpoints exactly
         self.assertEqual(km._model_color("fable", self.stops), list(km.cm.ramp(1.0, self.stops)))
         self.assertEqual(km._model_color("haiku", self.stops), list(km.cm.ramp(0.0, self.stops)))
-        self.assertEqual(km._effort_color("max", self.stops), list(km.cm.ramp(1.0, self.stops)))
+        self.assertEqual(km._effort_color("ultracode", self.stops), list(km.cm.ramp(1.0, self.stops)))   # the ladder's new top (the user 2026-08-04)
         self.assertEqual(km._effort_color("low", self.stops), list(km.cm.ramp(0.0, self.stops)))
 
     def test_build_session_status_carries_model_and_effort_colors(self):

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1355,6 +1355,43 @@ class OptionsAssembly(unittest.TestCase):
         opts = be._options(self._sess(be), _sdk.ClaudeAgentOptions)
         self.assertIsNone(opts.system_prompt, "no harness prompt → leave the CLI's default system prompt")
 
+    def test_ultracode_maps_to_xhigh_plus_the_settings_key(self):
+        # "ultracode" (the user 2026-08-04) is not a typed EffortLevel: the CLI's documented per-session
+        # hook is the `ultracode` settings key (--settings / flag-settings layer), and ultracode IS xhigh
+        # plus standing workflow orchestration — so the typed field carries xhigh and the key rides a
+        # settings file. Never through extra_args.
+        be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        sess = self._sess(be)
+        sess.effort = "ultracode"
+        opts = be._options(sess, _sdk.ClaudeAgentOptions)
+        self.assertEqual(opts.effort, "xhigh", "the typed field carries the effort half of ultracode")
+        self.assertTrue(opts.settings and opts.settings.endswith(sb.ULTRACODE_SETTINGS))
+        with open(opts.settings) as f:
+            self.assertEqual(json.load(f), {"ultracode": True})
+        self.assertNotIn("effort", opts.extra_args or {})
+
+    def test_plain_efforts_pass_through_with_no_settings_file(self):
+        be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        sess = self._sess(be)
+        sess.effort = "max"
+        opts = be._options(sess, _sdk.ClaudeAgentOptions)
+        self.assertEqual(opts.effort, "max")
+        self.assertIsNone(opts.settings, "no ultracode → no flag-settings file")
+
+    def test_ultracode_is_a_choice_everywhere_but_never_the_seeded_default(self):
+        self.assertIn("ultracode", sb.EFFORT_LEVELS, "the SDK backend accepts the pick")
+        with open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin", "romp-kernel")) as f:
+            self.assertIn('("low", "medium", "high", "xhigh", "max", "ultracode")', f.read(),
+                          "the effort dropdown (kernel EFFORT_CHOICES) offers ultracode")
+        # per-session by design (the CLI: "this session only") — picking it must not seed NEW sessions
+        be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        sid = "11111111-2222-3333-4444-555555555555"
+        sb.write_reg(self.d, sid, {"sid": sid, "name": "n", "cwd": self.d})
+        self.assertTrue(be.set_effort(sid, "ultracode"))
+        self.assertNotEqual(sb.read_sdk_defaults(self.d).get("effort"), "ultracode",
+                            "ultracode never becomes the default for the next new session")
+        self.assertEqual(sb.read_reg(self.d, sid)["effort"], "ultracode", "but THIS session keeps it")
+
     def test_raises_max_buffer_size_well_above_the_1mb_default(self):
         # A single >1MB stdout message (a big Read / grep result / echoed image) would otherwise crash the
         # receive loop → tear down the client → close stdin → the CLI rejects any PENDING picker with "Tool


### PR DESCRIPTION
Requested today: ultracode as an option on the effort dropdown.

The CLI's own `/effort` already offers ultracode (xhigh effort + standing dynamic-workflow orchestration, per session); romp's menu was just the hardcoded five levels. Now:

- `EFFORT_CHOICES` (kernel, feeds the dropdown via `/models`) and `EFFORT_LEVELS` (SDK backend validation) gain `ultracode` at the top of the ladder.
- **tmux sessions** need nothing new — they already deliver the literal `/effort ultracode` keystroke, which the CLI accepts.
- **SDK sessions** map it to the designed pieces, since the SDK's typed `EffortLevel` has no such value: the typed field carries `effort="xhigh"` (ultracode *is* xhigh plus orchestration) and the CLI's documented per-session hook — the `ultracode` settings key — rides a flag-settings file through `options.settings`. Never `extra_args`.
- Per-session by design (the CLI's own framing: "this session only"): picking ultracode is the one effort pick that is **not** remembered as the seed for new sessions.
- The timeline's effort brightness ramp tops out at ultracode.

Tests: three new cases in `OptionsAssembly` (xhigh + settings-key mapping with file content, plain efforts untouched with no settings file, choice-everywhere + never-the-seed) — verified under the SDK venv since the project venv skips SDK-dependent tests — plus updated ramp/choices expectations. Suites green locally (3891 pytest, 1648 node).

Note: takes effect on the next kernel restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)