### PR TITLE
The bg-task box grows a Stop button per running task

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3961,7 +3961,7 @@ def _drive(msg, client):
     t = msg.get("type")
     ID_OPS = ("sendMessage", "rewindSend", "rewindDelete", "interrupt", "compactSession", "dismissDialog", "answerAsk", "navAsk", "toggleAsk", "submitAsk",
               "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "setModel", "setEffort", "setMode",
-              "endSession", "renameSession")
+              "endSession", "renameSession", "stopTask")
     if t in ID_OPS and msg.get("id"):
         sid = str(msg["id"])
     elif t in ("compact", "sendCommand") and msg.get("name"):
@@ -4199,6 +4199,13 @@ def _drive(msg, client):
         _set_effort_or_park(be, sid, str(msg["value"])); _push_soon()   # tmux: /effort; SDK: reconnect with --effort; mid-compaction → parked
     elif t == "setMode" and msg.get("value"):
         be.set_mode(sid, str(msg["value"])); _push_soon()
+    elif t == "stopTask" and msg.get("taskId"):
+        # the SDK's designed stop_task control request, addressed by the id the bg-task box shows.
+        # LOUD on refusal (fail loudly, never degrade silently): unknown task / dead client / tmux
+        if not be.stop_task(sid, str(msg["taskId"])):
+            client["send"](json.dumps({"type": "warn",
+                                       "text": "Couldn't stop that background task — it may have already finished."}))
+        _push_soon()
     elif t == "endSession":
         sys.stderr.write("kill: %s via endSession WS op\n" % sid)   # kill attribution (the user 2026-07-16)
         be.kill(sid); _send_to_app("chat", {"type": "closed", "id": sid}); _push_soon()

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2157,6 +2157,28 @@ class SdkSession:
                 self.backend._log("background tasks (%s): registry mirror write failed: %s" % (self.name, e))
             self.backend._poke()
 
+    def request_stop_task(self, tool_use_id: str) -> bool:
+        """Stop ONE background task by the id the chat box shows (its tool-use id). Resolved to the
+        CLI's lifecycle task id (the _bg_tasks key — what the SDK's stop_task control request takes);
+        either id form is accepted. False when the task is unknown/already terminal or the client
+        isn't connected — the kernel warns the user then, never a silent no-op."""
+        with self._sub_lock:
+            tid = next((k for k, v in self._bg_tasks.items()
+                        if k == tool_use_id or v.get("toolUseId") == tool_use_id), "")
+        if not tid or not (self.loop and self.client):
+            return False
+        self.loop.call_soon_threadsafe(lambda: asyncio.ensure_future(self._do_stop_task(tid)))
+        return True
+
+    async def _do_stop_task(self, tid):
+        # loud on failure, like every stop (the interrupt lesson): a stop that vanishes without a trace
+        # is the bug; the task's own terminal lifecycle event is what clears it from the box
+        try:
+            await self.client.stop_task(tid)
+        except Exception as e:
+            self.backend._log("stop_task (%s): control request failed for %s: %s" % (self.name, tid, e))
+        self.backend._poke()
+
     def _live_bg_tasks(self) -> list:
         """The background tasks running RIGHT NOW: [{"desc","type","since","toolUseId","lastTool"}], oldest
         first. Copied under the lock, like _live_subagents."""
@@ -3287,6 +3309,10 @@ class SdkBackend:
             s.perm_mode = mode      # snapshot reflects it immediately (clears the picker's meta-pending)
             s.set_mode_live(mode)
         return True
+
+    def stop_task(self, sid: str, task_id: str) -> bool:
+        s = self.sessions.get(sid)
+        return bool(s and s.request_stop_task(task_id))
 
     def set_effort(self, sid: str, value: str) -> bool:
         """Change the reasoning effort. effort is a connect-time CLI flag (--effort) with no SDK runtime

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -115,6 +115,12 @@ class SessionBackend(ABC):
     @abstractmethod
     def set_effort(self, sid: str, value: str) -> bool: ...
 
+    def stop_task(self, sid: str, task_id: str) -> bool:
+        """Stop ONE background task (the SDK's designed stop_task control request). SDK-only control:
+        the chat's bg-task box only ever shows live tasks for SDK sessions (the CLI's task lifecycle
+        stream), so this default False just means "no such control here" (tmux)."""
+        return False
+
     # ── lifecycle ────────────────────────────────────────────────────────────────────────────────
     @abstractmethod
     def spawn(self, name: str, cwd: str, bg: str = "", fg: str = "", sid: str | None = None) -> str | None:

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1325,6 +1325,54 @@ class PermissionAndPlanRoundTrip(unittest.TestCase):
 
 
 @unittest.skipUnless(_HAVE_SDK, "claude_agent_sdk not installed")
+class StopTask(unittest.TestCase):
+    """The bg-task box's Stop button rides the SDK's designed stop_task control request (the user
+    2026-08-04). The box shows tasks by TOOL-USE id (the kernel's transcript scan); the control request
+    takes the CLI's lifecycle task id (_bg_tasks' key) — request_stop_task resolves either form. A
+    refusal returns False so the kernel can WARN, never a silent no-op; tmux inherits the ABC's False
+    (its box never shows live tasks)."""
+
+    def _sess(self):
+        d = tempfile.mkdtemp()
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        return sb.SdkSession(be, {"sid": "11111111-2222-3333-4444-555555555555", "name": "n", "cwd": d})
+
+    def test_resolves_the_tool_use_id_to_the_lifecycle_task_id(self):
+        sess = self._sess()
+        sess._bg_tasks["task-1"] = {"desc": "sweep", "type": "bash", "since": 1, "toolUseId": "toolu_9", "lastTool": ""}
+        dispatched = []
+        sess.loop = type("L", (), {"call_soon_threadsafe": staticmethod(lambda cb: dispatched.append(cb))})()
+        sess.client = object()
+        self.assertTrue(sess.request_stop_task("toolu_9"), "the box's tool-use id resolves")
+        self.assertTrue(sess.request_stop_task("task-1"), "the lifecycle id itself is accepted too")
+        self.assertEqual(len(dispatched), 2, "the control request is scheduled on the loop thread")
+
+    def test_unknown_task_or_dead_client_refuses(self):
+        sess = self._sess()
+        self.assertFalse(sess.request_stop_task("toolu_missing"), "unknown/terminal task → False → kernel warns")
+        sess._bg_tasks["task-1"] = {"toolUseId": "toolu_9"}
+        self.assertFalse(sess.request_stop_task("toolu_9"), "no connected client → False, never a crash")
+
+    def test_backend_routes_by_sid_and_tmux_defaults_false(self):
+        d = tempfile.mkdtemp()
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        self.assertFalse(be.stop_task("no-such-sid", "toolu_9"))
+        import importlib.util as _u
+        spec_src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+                                     "kernel", "session_backend.py")).read()
+        self.assertIn("def stop_task(self, sid: str, task_id: str) -> bool:", spec_src)
+        self.assertIn("return False", spec_src.split("def stop_task", 1)[1][:600],
+                      "the ABC default is False — tmux has no such control")
+
+    def test_kernel_op_warns_on_refusal(self):
+        with open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin", "romp-kernel")) as f:
+            src = f.read()
+        self.assertIn('"stopTask")', src.replace("\n", " ")[:200000] if False else src[src.index("ID_OPS"):src.index("ID_OPS")+700],
+                      "stopTask routes by session id like every session op")
+        self.assertIn('elif t == "stopTask" and msg.get("taskId"):', src)
+        self.assertIn("Couldn't stop that background task", src, "a refusal warns the user — never a silent no-op")
+
+
 class OptionsAssembly(unittest.TestCase):
     """_options must use the SDK's DESIGNED option fields, not the extra_args CLI-flag escape hatch (the user
     2026-06-24: implement things the way the SDK designed them). The romp harness prompt is appended via

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1324,7 +1324,6 @@ class PermissionAndPlanRoundTrip(unittest.TestCase):
         self.assertEqual(res.behavior, "deny")
 
 
-@unittest.skipUnless(_HAVE_SDK, "claude_agent_sdk not installed")
 class StopTask(unittest.TestCase):
     """The bg-task box's Stop button rides the SDK's designed stop_task control request (the user
     2026-08-04). The box shows tasks by TOOL-USE id (the kernel's transcript scan); the control request
@@ -1373,6 +1372,7 @@ class StopTask(unittest.TestCase):
         self.assertIn("Couldn't stop that background task", src, "a refusal warns the user — never a silent no-op")
 
 
+@unittest.skipUnless(_HAVE_SDK, "claude_agent_sdk not installed")
 class OptionsAssembly(unittest.TestCase):
     """_options must use the SDK's DESIGNED option fields, not the extra_args CLI-flag escape hatch (the user
     2026-06-24: implement things the way the SDK designed them). The romp harness prompt is appended via

--- a/ui/webview/bg-tasks-layout.test.ts
+++ b/ui/webview/bg-tasks-layout.test.ts
@@ -40,3 +40,16 @@ test("status dots are SOLID — the pulsating yellow animation is gone", () => {
   assert.doesNotMatch(CSS, /@keyframes bg-pulse/);
   assert.match(CSS, /\.bg-dot \{[^}]*background: var\(--bgt\);/);   // just the solid status tint
 });
+
+test("each RUNNING task row has a Stop button riding the stable delegate (the user 2026-08-04)", () => {
+  // the button posts the SDK's designed stop_task control request, keyed by the id the box shows;
+  // gated on status so a finished row never grows a dead control
+  assert.match(RENDER, /if \(\(t\.status \|\| "running"\) === "running"\) \{/);
+  assert.match(RENDER, /stop\.dataset\.act = "bg-stop"; stop\.dataset\.id = t\.id;/);
+  // click-safe: handled on the SAME delegate as the fold toggles, never a per-render listener…
+  assert.match(RENDER, /"bg-stop": \(el\) => \{/);
+  assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "stopTask", id: activeId, taskId: id \}\);/);
+  // …and the click acknowledges IMMEDIATELY, before any round-trip; the row's disappearance (the task's
+  // own terminal lifecycle event) is the real confirmation, and a re-render restores a live task's button
+  assert.match(RENDER, /btn\.disabled = true; btn\.textContent = "Stopping…";/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5956,6 +5956,16 @@ function renderBgTasks() {
     rh.appendChild(el("span", "bg-dot"));
     const sum = el("span", "bg-sum"); sum.textContent = t.summary || "Background task"; rh.appendChild(sum);
     const st = el("span", "bg-status"); st.textContent = t.status || "running"; rh.appendChild(st);
+    if ((t.status || "running") === "running") {
+      // Stop this ONE task (the SDK's stop_task control request — the user 2026-08-04). Rides the same
+      // stable delegate as the fold toggles (click-safe across re-renders); the click acknowledges by
+      // disabling + relabeling ITSELF, and the row's disappearance (the task's own terminal lifecycle
+      // event) is the real confirmation — a task still running at the next render gets a fresh button.
+      const stop = el("button", "bg-stop");
+      stop.dataset.act = "bg-stop"; stop.dataset.id = t.id;
+      stop.textContent = "Stop"; stop.title = "stop this background task";
+      rh.appendChild(stop);
+    }
     const rc = el("span", "bg-caret"); rc.textContent = tOpen ? "▾" : "▸"; rh.appendChild(rc);
     row.appendChild(rh);
     if (tOpen) {
@@ -8347,6 +8357,12 @@ setupSettings();
       const id = el.dataset.id; if (!id) return;
       if (bgExpanded.has(id)) bgExpanded.delete(id); else bgExpanded.add(id);
       renderBgTasks();
+    },
+    "bg-stop": (el) => {   // stop this ONE task; the row disappears on its terminal lifecycle event
+      const id = el.dataset.id; if (!id || !activeId) return;
+      const btn = el as HTMLButtonElement;
+      btn.disabled = true; btn.textContent = "Stopping…";   // immediate acknowledgement, before the round-trip
+      vscodeApi?.postMessage({ type: "stopTask", id: activeId, taskId: id });
     },
   });
 })();

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -416,6 +416,10 @@ body { display: flex; flex-direction: column; }
   padding: 7px 11px; cursor: pointer; user-select: none; font-size: 12px; }
 .bg-fold-head.open { border-bottom: 1px solid var(--box-border); }
 .bg-fold-head:hover { background: rgba(255, 255, 255, 0.04); }
+.bg-stop { flex: 0 0 auto; font-size: 0.74em; padding: 1px 8px; border-radius: 9px; cursor: pointer;
+  border: 1px solid color-mix(in srgb, var(--fg) 25%, transparent); background: transparent; color: var(--fg); }
+.bg-stop:hover { border-color: var(--accent); color: var(--accent); }
+.bg-stop:disabled { opacity: 0.55; cursor: default; }
 .bg-fold-head.bg-failed { --bgt: var(--st-blocked-bg); }
 .bg-fold-head.bg-completed { --bgt: var(--st-ready-bg); }
 .bg-fold-label { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--fg); }


### PR DESCRIPTION
Requested today: expose the SDK's `stop_task`.

Each running row in the chat's background-task box gets a Stop button. It posts a `stopTask` op keyed by the id the box shows (the tool-use id from the kernel's transcript scan); the SDK backend resolves that to the CLI's lifecycle task id (the `_bg_tasks` key — what the designed `stop_task` control request takes; either id form is accepted) and schedules the request on the session's loop, loud on failure like every stop. A refusal — unknown/already-terminal task, disconnected client, or tmux (the `SessionBackend` ABC default is False; a tmux box never shows live tasks) — warns the user rather than no-oping silently.

UI mechanics per the standing rules: the button rides the same stable delegate as the fold toggles (click-safe across re-renders), acknowledges immediately (disabled + "Stopping…") before any round-trip, and the row's disappearance — the task's own terminal lifecycle event, which already clears `_bg_tasks` — is the real confirmation; a task still running at the next render gets a fresh button.

Tests: a new `StopTask` class (id resolution both ways, refusal paths, ABC default, kernel warn pins — verified under the SDK venv) plus node pins for the button, delegate, and acknowledgement. Suites green locally (3891 pytest, 1649 node).

Note: kernel-side halves take effect on the next kernel restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)