### PR TITLE
Restore files to before any message: the SDK's checkpoint rewind

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3965,7 +3965,7 @@ def _drive(msg, client):
     t = msg.get("type")
     ID_OPS = ("sendMessage", "rewindSend", "rewindDelete", "interrupt", "compactSession", "dismissDialog", "answerAsk", "navAsk", "toggleAsk", "submitAsk",
               "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "setModel", "setEffort", "setMode",
-              "endSession", "renameSession", "stopTask")
+              "endSession", "renameSession", "stopTask", "rewindFiles")
     if t in ID_OPS and msg.get("id"):
         sid = str(msg["id"])
     elif t in ("compact", "sendCommand") and msg.get("name"):
@@ -4209,6 +4209,12 @@ def _drive(msg, client):
         if not be.stop_task(sid, str(msg["taskId"])):
             client["send"](json.dumps({"type": "warn",
                                        "text": "Couldn't stop that background task — it may have already finished."}))
+        _push_soon()
+    elif t == "rewindFiles" and msg.get("uuid"):
+        # the SDK's file-checkpoint restore — the workspace, not the conversation. LOUD on refusal.
+        if not be.rewind_files(sid, str(msg["uuid"])):
+            client["send"](json.dumps({"type": "warn",
+                                       "text": "Couldn't restore files — this session's backend doesn't support it or isn't connected."}))
         _push_soon()
     elif t == "endSession":
         sys.stderr.write("kill: %s via endSession WS op\n" % sid)   # kill attribution (the user 2026-07-16)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2197,6 +2197,26 @@ class SdkSession:
             self.backend._log("stop_task (%s): control request failed for %s: %s" % (self.name, tid, e))
         self.backend._poke()
 
+    def request_rewind_files(self, uuid: str) -> bool:
+        """Restore the workspace's files to their state just before the given user message — the SDK's
+        designed rewind_files control request (enable_file_checkpointing is on for every session). The
+        CONVERSATION is untouched; the chat's edit/delete rewinds cover that. False when the client
+        isn't connected — the kernel warns then, never a silent no-op."""
+        if not (uuid and self.loop and self.client):
+            return False
+        self.loop.call_soon_threadsafe(lambda: asyncio.ensure_future(self._do_rewind_files(uuid)))
+        return True
+
+    async def _do_rewind_files(self, uuid):
+        # loud on failure (a restore that vanishes without a trace is the bug): the common refusal is a
+        # message from before checkpointing was enabled — the CLI rejects it and the log says why
+        try:
+            await self.client.rewind_files(uuid)
+            self.backend._log("rewind_files (%s): workspace restored to before %s" % (self.name, uuid))
+        except Exception as e:
+            self.backend._log("rewind_files (%s): control request failed for %s: %s" % (self.name, uuid, e))
+        self.backend._poke()
+
     def _live_bg_tasks(self) -> list:
         """The background tasks running RIGHT NOW: [{"desc","type","since","toolUseId","lastTool"}], oldest
         first. Copied under the lock, like _live_subagents."""
@@ -2794,6 +2814,11 @@ class SdkBackend:
                    "SubagentStart": [HookMatcher(matcher=None, hooks=[sess._subagent_start_hook])],  # live subagent
                    "SubagentStop": [HookMatcher(matcher=None, hooks=[sess._subagent_stop_hook])]},    #   count/types
             permission_mode=sess.mode,
+            # File-checkpoint rewind (the user 2026-08-04): the CLI backs files up before modifying them,
+            # so rewind_files() can put the workspace back to its state at any user message. The uuid a
+            # restore takes comes from the TRANSCRIPT (romp's own parse) — the replay-user-messages extra
+            # flag exists only for SDK consumers with no transcript access, so it stays off.
+            enable_file_checkpointing=True,
             include_partial_messages=False,
             # connect-time --effort (no runtime control); a change reconnects. "ultracode" is not a typed
             # EffortLevel — it rides as xhigh + the `ultracode` settings key (added below).
@@ -3335,6 +3360,10 @@ class SdkBackend:
     def stop_task(self, sid: str, task_id: str) -> bool:
         s = self.sessions.get(sid)
         return bool(s and s.request_stop_task(task_id))
+
+    def rewind_files(self, sid: str, uuid: str) -> bool:
+        s = self.sessions.get(sid)
+        return bool(s and s.request_rewind_files(uuid))
 
     def set_effort(self, sid: str, value: str) -> bool:
         """Change the reasoning effort. effort is a connect-time CLI flag (--effort) with no SDK runtime

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -121,6 +121,12 @@ class SessionBackend(ABC):
         stream), so this default False just means "no such control here" (tmux)."""
         return False
 
+    def rewind_files(self, sid: str, uuid: str) -> bool:
+        """Restore workspace files to their state before a user message (the SDK's rewind_files,
+        backed by file checkpointing). SDK-only control — the default False means "no such control
+        here" (tmux), and the kernel warns the user on a refusal."""
+        return False
+
     # ── lifecycle ────────────────────────────────────────────────────────────────────────────────
     @abstractmethod
     def spawn(self, name: str, cwd: str, bg: str = "", fg: str = "", sid: str | None = None) -> str | None:

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1366,10 +1366,57 @@ class StopTask(unittest.TestCase):
     def test_kernel_op_warns_on_refusal(self):
         with open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin", "romp-kernel")) as f:
             src = f.read()
-        self.assertIn('"stopTask")', src.replace("\n", " ")[:200000] if False else src[src.index("ID_OPS"):src.index("ID_OPS")+700],
+        self.assertIn('"stopTask"', src[src.index("ID_OPS"):src.index("ID_OPS") + 700],
                       "stopTask routes by session id like every session op")
         self.assertIn('elif t == "stopTask" and msg.get("taskId"):', src)
         self.assertIn("Couldn't stop that background task", src, "a refusal warns the user — never a silent no-op")
+
+
+class RewindFiles(unittest.TestCase):
+    """The bubble's restore-files affordance rides the SDK's designed rewind_files control request (the
+    user 2026-08-04): the WORKSPACE goes back to its state before a user message; the conversation is
+    untouched (edit/delete cover that). Checkpointing is enabled on every session so the checkpoints
+    exist. A refusal returns False so the kernel warns — never a silent no-op; tmux inherits the ABC's
+    False. No SDK import needed here (dispatch is deferred), so this runs in every venv."""
+
+    def _sess(self):
+        d = tempfile.mkdtemp()
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        return be, sb.SdkSession(be, {"sid": "11111111-2222-3333-4444-555555555555", "name": "n", "cwd": d})
+
+    def test_dispatches_on_the_loop_when_connected(self):
+        _, sess = self._sess()
+        dispatched = []
+        sess.loop = type("L", (), {"call_soon_threadsafe": staticmethod(lambda cb: dispatched.append(cb))})()
+        sess.client = object()
+        self.assertTrue(sess.request_rewind_files("aaaa-uuid"))
+        self.assertEqual(len(dispatched), 1, "the control request is scheduled on the loop thread")
+
+    def test_refuses_without_a_client_or_uuid(self):
+        _, sess = self._sess()
+        self.assertFalse(sess.request_rewind_files("aaaa-uuid"), "no connected client → False → kernel warns")
+        sess.loop = object(); sess.client = object()
+        self.assertFalse(sess.request_rewind_files(""), "no uuid → refuse, never a blind restore")
+
+    def test_backend_routes_by_sid_and_tmux_defaults_false(self):
+        be, _ = self._sess()
+        self.assertFalse(be.rewind_files("no-such-sid", "aaaa-uuid"))
+        spec_src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+                                     "kernel", "session_backend.py")).read()
+        self.assertIn("def rewind_files(self, sid: str, uuid: str) -> bool:", spec_src)
+        self.assertIn("return False", spec_src.split("def rewind_files", 1)[1][:600],
+                      "the ABC default is False — tmux has no such control")
+
+    def test_checkpointing_is_on_and_the_kernel_op_warns_on_refusal(self):
+        base = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+        sdk_src = open(os.path.join(base, "kernel", "sdk_backend.py")).read()
+        self.assertIn("enable_file_checkpointing=True", sdk_src,
+                      "every session checkpoints, so any user message is a restore point")
+        with open(os.path.join(base, "bin", "romp-kernel")) as f:
+            src = f.read()
+        self.assertIn('"rewindFiles")', src[src.index("ID_OPS"):src.index("ID_OPS") + 700])
+        self.assertIn('elif t == "rewindFiles" and msg.get("uuid"):', src)
+        self.assertIn("Couldn't restore files", src, "a refusal warns the user — never a silent no-op")
 
 
 @unittest.skipUnless(_HAVE_SDK, "claude_agent_sdk not installed")

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1732,9 +1732,28 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         });
         del.addEventListener("blur", disarm);
         del.addEventListener("pointerleave", disarm);
+        // RESTORE-FILES affordance (the user 2026-08-04): put the WORKSPACE back the way it was just
+        // before this message — the SDK's file-checkpoint rewind (rewind_files). The conversation is
+        // untouched; edit/delete cover that. Same two-click arm as delete (destructive — every miss
+        // fails toward "not restored"); the kernel warns on a refusal (tmux, disconnected).
+        const rf = el("button", "msg-restorefiles") as HTMLButtonElement;
+        rf.type = "button";
+        rf.textContent = "restore files";
+        rf.title = "Restore files to their state just before this message — the conversation is untouched";
+        const rfDisarm = () => { rf.classList.remove("armed"); rf.textContent = "restore files"; };
+        rf.addEventListener("click", (e) => {
+          e.stopPropagation();
+          if (!rf.classList.contains("armed")) { rf.classList.add("armed"); rf.textContent = "revert files?"; return; }
+          rfDisarm();
+          rf.disabled = true; rf.textContent = "restoring…";   // acknowledged; a re-render resets the label
+          vscodeApi?.postMessage({ type: "rewindFiles", id: editSid, uuid });
+        });
+        rf.addEventListener("blur", rfDisarm);
+        rf.addEventListener("pointerleave", rfDisarm);
         const acts = el("div", "msg-acts");   // one row under the bubble (the turn is a column flex)
         acts.appendChild(edit);
         acts.appendChild(del);
+        acts.appendChild(rf);
         turn.appendChild(acts);
       }
     }

--- a/ui/webview/rewind-delete.test.ts
+++ b/ui/webview/rewind-delete.test.ts
@@ -46,8 +46,9 @@ test("the bare overlay dims the deleted bubble itself, not just the tail", () =>
 
 test("the delete button dresses like edit, with a destructive armed state", () => {
   assert.match(CSS, /\.msg-acts \{ display: flex; gap: 4px; align-self: flex-end; \}/);
-  assert.match(CSS, /\.turn-user:hover \.msg-del, \.msg-del:focus-visible \{ opacity: 0\.9; \}/);
-  assert.match(CSS, /\.msg-del\.armed \{ color: #ff6a6a; border-color: #ff6a6a;/);
+  // restore-files shares delete's dress (same reveal, same destructive armed red — the user 2026-08-04)
+  assert.match(CSS, /\.turn-user:hover \.msg-del, \.msg-del:focus-visible,\s*\n\.turn-user:hover \.msg-restorefiles, \.msg-restorefiles:focus-visible \{ opacity: 0\.9; \}/);
+  assert.match(CSS, /\.msg-del\.armed, \.msg-restorefiles\.armed \{ color: #ff6a6a; border-color: #ff6a6a;/);
 });
 
 // Executed replica of the BARE keep/retire decision: dim from the deleted bubble (idx, not idx+1),

--- a/ui/webview/rewind-edit.test.ts
+++ b/ui/webview/rewind-edit.test.ts
@@ -111,3 +111,15 @@ test("kernel: rewindSend validates against the transcript and the SDK backend ap
   assert.match(KERNEL, /def _rewind_target\(path, sid, user_uuid\):/);
   assert.match(BACKEND, /kw\["extra_args"\] = \{"resume-session-at": sess\._rewind_to\}/);
 });
+
+test("a restore-files affordance rides each editable bubble — workspace only, armed like delete (the user 2026-08-04)", () => {
+  // the SDK's file-checkpoint rewind: files go back to before this message, the conversation stays
+  assert.match(RENDER, /const rf = el\("button", "msg-restorefiles"\) as HTMLButtonElement;/);
+  assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "rewindFiles", id: editSid, uuid \}\);/);
+  // two-click arm, disarmed on blur/pointerleave — every miss fails toward "not restored"
+  assert.match(RENDER, /if \(!rf\.classList\.contains\("armed"\)\) \{ rf\.classList\.add\("armed"\); rf\.textContent = "revert files\?"; return; \}/);
+  assert.match(RENDER, /rf\.addEventListener\("blur", rfDisarm\);/);
+  assert.match(RENDER, /rf\.addEventListener\("pointerleave", rfDisarm\);/);
+  // acknowledged immediately on fire; a re-render resets the label
+  assert.match(RENDER, /rf\.disabled = true; rf\.textContent = "restoring…";/);
+});

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1060,18 +1060,19 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* edit + delete share one row under the bubble (the turn is a column flex; the row is the flex item) */
 .msg-acts { display: flex; gap: 4px; align-self: flex-end; }
 /* the DELETE affordance wears the edit button's exact clothes (one size, one shape — labels differ) */
-.msg-del {
+.msg-del, .msg-restorefiles {
   align-self: flex-end; margin-top: 3px;
   font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
   border: 1px solid var(--box-border); background: var(--code-bg); color: var(--dim);
   cursor: pointer; opacity: 0; user-select: none;
   transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
-.turn-user:hover .msg-del, .msg-del:focus-visible { opacity: 0.9; }
-.msg-del:hover { color: var(--fg); border-color: #ff6a6a; }
+.turn-user:hover .msg-del, .msg-del:focus-visible,
+.turn-user:hover .msg-restorefiles, .msg-restorefiles:focus-visible { opacity: 0.9; }
+.msg-del:hover, .msg-restorefiles:hover { color: var(--fg); border-color: #ff6a6a; }
 /* armed = one click from rolling back: destructive red, holds until blur/pointerleave/re-render */
-.msg-del.armed { color: #ff6a6a; border-color: #ff6a6a; opacity: 0.95; }
-@media (hover: none) { .msg-del { opacity: 0.6; } }   /* touch: no hover state, so keep it visible */
+.msg-del.armed, .msg-restorefiles.armed { color: #ff6a6a; border-color: #ff6a6a; opacity: 0.95; }
+@media (hover: none) { .msg-del, .msg-restorefiles { opacity: 0.6; } }   /* touch: no hover state, so keep it visible */
 /* pending-rewind overlay: turns after an edited message belong to the branch being abandoned — they
    dim until the kernel's rewound payload replaces them (reconcileRewind retires the flag then). */
 .turn.rewound { opacity: 0.35; transition: opacity 0.2s ease; }


### PR DESCRIPTION
Requested today: expose the SDK's file-checkpoint rewind.

Every SDK session now connects with `enable_file_checkpointing=True`, so the CLI backs files up before modifying them. Each editable user bubble grows a third affordance beside edit/delete: **restore files** — the workspace goes back to its state just before that message via the SDK's designed `rewind_files` control request, while the conversation stays put (edit/delete already cover conversation rewinds).

Mechanics: the same two-click arm as delete ("revert files?" — destructive, so every miss fails toward "not restored"), immediate acknowledgement on fire, and the same dress/reveal CSS. A refusal (tmux via the `SessionBackend` ABC default, a disconnected client) warns the user; a failed restore is logged loudly — the common case being a message that predates checkpointing (older than this feature or than the session's current CLI). The uuid rides from romp's own transcript parse, so the SDK's `replay-user-messages` flag (which exists only for consumers with no transcript access) stays off.

Tests: a `RewindFiles` class (loop dispatch, refusal paths, ABC default, checkpointing-on and kernel-warn pins — runs in both venvs) plus node pins for the affordance, armed idiom, and shared dress. Suites green locally (3895 pytest, 1649 node).

Note: kernel-side halves take effect on the next kernel restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)