### PR TITLE
The trust dropdown survives the connecting-phase polls

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17211,8 +17211,8 @@ function showAdd(on){if(!addBox)return;addBox.hidden=!on;hint.hidden=!on;plus.hi
 if(on&&hostIn){hostIn.value=hostIn.value||mruHost();try{hostIn.focus();hostIn.select();}catch(e){}}}
 var _autoAdd=false;
 var _auto=false;   // "Automatically update" — mirrored from the KERNEL each refresh, never a local guess
-function open(){back.hidden=false;_autoAdd=false;showAdd(false);loadHosts();refresh();}
-function close(){back.hidden=true;}
+function open(){back.hidden=false;_autoAdd=false;showAdd(false);trustEngaged=false;deferredRender=null;loadHosts();refresh();}
+function close(){back.hidden=true;trustEngaged=false;deferredRender=null;}
 if(plus)plus.onclick=function(){showAdd(true);};
 // "How it works" — the gist reads by itself; the mechanics are one click under it.
 if(more)more.onclick=function(){var on=sub.hidden;sub.hidden=!on;more.setAttribute('aria-expanded',on?'true':'false');
@@ -17360,7 +17360,20 @@ schedule(3000);});}
 // as a free variable threw ReferenceError on EVERY render, after list.innerHTML='' had already cleared the
 // list and before any row was appended. The panel therefore showed an empty host list no matter how many
 // hosts were attached, and the bare catch swallowed the error (the user 2026-07-22). Take it as a param.
-function render(ts,known,pmode,via,rholds,tiers){list.innerHTML='';known=known||[];via=via||[];rholds=rholds||[];tiers=tiers||{};
+// A native <select>'s open dropdown dies with its DOM node, and render() rebuilds every row each poll —
+// at the connecting-phase 600ms cadence the trust picker's options dismissed the instant they opened
+// (the user 2026-08-04: click it and it immediately unclicks; fine once the host is up at the 3s
+// cadence). Defer the rebuild while a trust select is ENGAGED (focusin/mousedown on .rnet-trust) and
+// flush the newest snapshot on release (focusout, or the choice landing) — strip.ts carries the same
+// fix; the two copies must stay in step (net-trust-pending.test.ts pins both).
+var trustEngaged=false;var deferredRender=null;
+function releaseTrust(){trustEngaged=false;var f=deferredRender;deferredRender=null;if(f)f();}
+list.addEventListener('mousedown',function(e){if(e.target&&e.target.classList&&e.target.classList.contains('rnet-trust'))trustEngaged=true;},true);
+list.addEventListener('focusin',function(e){if(e.target&&e.target.classList&&e.target.classList.contains('rnet-trust'))trustEngaged=true;});
+list.addEventListener('focusout',function(e){if(e.target&&e.target.classList&&e.target.classList.contains('rnet-trust'))releaseTrust();});
+function render(ts,known,pmode,via,rholds,tiers){
+if(trustEngaged){deferredRender=function(){render(ts,known,pmode,via,rholds,tiers);};return;}
+list.innerHTML='';known=known||[];via=via||[];rholds=rholds||[];tiers=tiers||{};
 // Attached rows win; a via/known row for an attached host would be a duplicate.
 var live={};ts.forEach(function(t){live[t.host]=1;});
 // "connect from" (attach-on-behalf, the user 2026-07-25): offer every CONNECTED host as a tunnel
@@ -17534,7 +17547,7 @@ list.appendChild(hr);});}
 // window repaints the chosen level + applying cue instead of the stale snapshot's old value. A
 // refused/failed write DELETES the pending entry, so the next render honestly reverts — plus the alert.
 list.querySelectorAll('select[data-t]').forEach(function(s){s.onchange=function(){var h=s.getAttribute('data-t');
-_pendTrust[h]=s.value;s.disabled=true;s.classList.add('rnet-applying');
+_pendTrust[h]=s.value;s.disabled=true;s.classList.add('rnet-applying');releaseTrust();
 fetch('/tunnels/trust',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h,trust:s.value})}).then(function(r){return r.json();}).then(function(d){
 if(!(d&&d.ok)){delete _pendTrust[h];alert('trust change on '+h+' failed: '+((d&&d.error)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
 refresh();}).catch(function(){delete _pendTrust[h];alert('trust change on '+h+' failed to reach the kernel.');refresh();});};});

--- a/ui/webview/net-trust-pending.test.ts
+++ b/ui/webview/net-trust-pending.test.ts
@@ -54,3 +54,26 @@ test("VS Code strip: same pending-trust treatment", () => {
   assert.match(STRIP, /pn\.textContent = "applying…"/, "a visible note, not just a disabled control");
   assert.match(STRIPCSS, /\.sn-trust\.sn-applying \{ border-color: var\(--accent, #9cd2ff\)/);
 });
+
+test("an engaged trust select DEFERS the rebuild — its open dropdown survives the connecting-phase polls (the user 2026-08-04)", () => {
+  // The bug: renderList rebuilds every row each poll, and while a host is CONNECTING the poll runs at
+  // 600ms — a native select's open dropdown dies with its DOM node, so the options dismissed the
+  // instant they opened. The popover now defers the rebuild while the select is engaged and flushes
+  // the newest snapshot on release (blur or a made choice) — the timeline's defer-don't-rebuild idiom.
+  assert.match(STRIP, /if \(trustEngaged\) \{ deferredRender = \(\) => renderList\(ts, known\); return; \}/);
+  // engaged on BOTH paths in (pointer opens the popup on mousedown; keyboard via focus)…
+  assert.match(STRIP, /trust\.addEventListener\("focus", \(\) => \{ trustEngaged = true; \}\);/);
+  assert.match(STRIP, /trust\.addEventListener\("mousedown", \(\) => \{ trustEngaged = true; \}\);/);
+  // …released by blur or by the choice landing, which flushes the newest deferred snapshot
+  assert.match(STRIP, /trust\.addEventListener\("blur", releaseTrust\);/);
+  assert.match(STRIP, /const flush = deferredRender;\s*\n\s*deferredRender = null;\s*\n\s*if \(flush\) flush\(\);/);
+  assert.match(STRIP, /releaseTrust\(\);   \/\/ the choice is made/);
+  // toggling the popover clears the latch — a hidden popover can never blur its way free
+  assert.match(STRIP, /trustEngaged = false; deferredRender = null;   \/\/ a toggled popover/);
+  // …and the WEB copy (kernel _LANDING_REMOTES_JS) carries the SAME fix — the two must stay in step
+  assert.match(KERNEL, /if\(trustEngaged\)\{deferredRender=function\(\)\{render\(ts,known,pmode,via,rholds,tiers\);\};return;\}/);
+  assert.match(KERNEL, /list\.addEventListener\('mousedown',function\(e\)\{if\(e\.target&&e\.target\.classList&&e\.target\.classList\.contains\('rnet-trust'\)\)trustEngaged=true;\},true\);/);
+  assert.match(KERNEL, /list\.addEventListener\('focusout',function\(e\)\{if\(e\.target&&e\.target\.classList&&e\.target\.classList\.contains\('rnet-trust'\)\)releaseTrust\(\);\}\);/);
+  assert.match(KERNEL, /rnet-applying'\);releaseTrust\(\);/);
+  assert.match(KERNEL, /function close\(\)\{back\.hidden=true;trustEngaged=false;deferredRender=null;\}/);
+});

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -357,7 +357,25 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
   // event — no timer). A refused write deletes the entry, so the next render honestly reverts.
   const pendingTrust = new Map<string, string>();
 
+  // A native <select>'s open dropdown dies with its DOM node, and renderList rebuilds every row each
+  // poll — at the connecting-phase 600ms cadence (schedule below) the trust picker's options dismissed
+  // the instant they opened (the user 2026-08-04: click it and "it just immediately unclicks"; fine
+  // once the host is up, whose 3s cadence usually leaves room). So the popover DEFERS the rebuild while
+  // a trust select is engaged — focus/mousedown arms it, blur or a made choice releases — and flushes
+  // the newest deferred snapshot on release: the timeline's defer-don't-rebuild idiom (_pointerHeld),
+  // select-flavored. Event-based, no timers; reopening the popover resets the latch (a hidden popover
+  // can never blur its way free, and its select is gone anyway).
+  let trustEngaged = false;
+  let deferredRender: (() => void) | null = null;
+  const releaseTrust = () => {
+    trustEngaged = false;
+    const flush = deferredRender;
+    deferredRender = null;
+    if (flush) flush();
+  };
+
   function renderList(ts: any[], known: any[] = []) {
+    if (trustEngaged) { deferredRender = () => renderList(ts, known); return; }   // mid-pick — land it after
     list.textContent = "";
     button.classList.toggle("on", ts.some((t) => t.status === "up"));
     if (!ts.length && !known.length) {
@@ -429,6 +447,9 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
         trust.appendChild(o);
       }
       if (pend) { trust.disabled = true; trust.classList.add("sn-applying"); }
+      trust.addEventListener("focus", () => { trustEngaged = true; });      // keyboard path
+      trust.addEventListener("mousedown", () => { trustEngaged = true; });  // pointer path, before the popup opens
+      trust.addEventListener("blur", releaseTrust);
       trust.addEventListener("change", () => {
         pendingTrust.set(t.host, trust.value);   // ack on the click; re-renders show the chosen level
         trust.disabled = true;
@@ -438,6 +459,7 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
           .then((rp) => rp.json())
           .then((d) => { if (!(d && d.ok)) pendingTrust.delete(t.host); schedule(600); })
           .catch(() => { pendingTrust.delete(t.host); schedule(600); });
+        releaseTrust();   // the choice is made — land any deferred snapshot now (pendingTrust keeps it painted)
       });
       r.appendChild(trust);
       if (pend) {
@@ -579,6 +601,7 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
     pop.hidden = !open;
     button.classList.toggle("open", open);   // instant acknowledgment on the button itself
     if (!open) clearTimeout(timer);
+    trustEngaged = false; deferredRender = null;   // a toggled popover starts (or leaves) unengaged — no stale latch
   };
   button.addEventListener("click", (e) => {
     e.stopPropagation();


### PR DESCRIPTION
Reported today: while a new SSH host says "connecting", the trust dropdown can't be changed — the options open and "immediately unclick"; it works once fully connected.

Root cause: both network popovers rebuild every host row on every poll, and the poll runs at **600 ms while any host is mid-attach** (the phase where you'd naturally set a new host's trust tier) versus 3 s once it's up. The trust picker is a native `<select>`, whose open dropdown is bound to its DOM element — each rebuild destroys the element and the browser dismisses the popup instantly. The connecting phase makes it near-certain; the 3-second cadence after connect leaves enough room, which is why it "works fine" then.

Fix, in **both copies** (the web dashboard's `_LANDING_REMOTES_JS` in kernel.py and VS Code's `strip.ts` — the same two-copies split the pending-trust fix already navigates): defer the row rebuild while a trust select is engaged — focus/mousedown arms it, blur or a made choice releases — and flush the newest deferred snapshot on release. The timeline's defer-don't-rebuild idiom (`_pointerHeld`), select-flavored: event-based, no timers. Toggling the popover clears the latch so a hidden popover can never strand it, and the existing pending-trust "applying…" machinery is untouched.

Tests: the regression pins live in `net-trust-pending.test.ts`, covering both copies so they stay in step. Embedded JS syntax-checked (`node --check`). Suites green locally (3899 pytest, 1651 node).

Note: the web-copy half takes effect on the next kernel restart; the VS Code half rides the normal deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)