### PR TITLE
Logging out to an API key clears the frozen /usage bars

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1418,6 +1418,8 @@ class SdkSession:
         context refresh) and on demand from the kernel's /usage click. Guarded: one in flight."""
         if not self.client or self._usage_refreshing:
             return
+        if self.backend.api_key_auth:
+            return   # API-key auth has no /usage windows and get_usage only times out — nothing to poll
         self._usage_refreshing = True
         r = None
         try:
@@ -1765,6 +1767,10 @@ class SdkSession:
             d = msg.data if isinstance(msg.data, dict) else {}
             self._learn_model(pretty_model(d.get("model")))
             self.perm_mode = d.get("permissionMode") or self.perm_mode
+            # HOW this CLI authenticates (verified live 2026-08-04: 'ANTHROPIC_API_KEY' on API-key auth;
+            # the field is absent on a subscription login). An auth flip is the deciding event for the
+            # rail's /usage bars — see _note_auth_source.
+            self.backend._note_auth_source(self.name, d.get("apiKeySource"))
             fsid = d.get("session_id")
             if fsid and fsid != self.resume_sid:
                 self.resume_sid = fsid
@@ -2328,6 +2334,7 @@ class SdkBackend:
         self._pending_ask: dict[str, bool] = {}   # sid -> has an ask awaiting answer
         self._live: dict[str, dict] = {}          # sid -> {key -> atom}: the in-memory LIVE TAIL (ahead of disk)
         self._rl_lock = threading.Lock()          # serializes usage.json read-merge-write (_record_rate_limit)
+        self.api_key_auth = False                 # last init's apiKeySource, truthy = API-key auth (no /usage windows)
         # Backend PROBLEMS, kept in a bounded ring so the dashboard can show them (see _log): until
         # 2026-07-28 every SDK failure went to the kernel log alone, which nobody tails, so a session
         # whose stream died or whose model switch was refused just looked odd with no way to find out.
@@ -2596,6 +2603,32 @@ class SdkBackend:
         if live:
             self._log("usage refresh: %d live session(s), none with a loop to run it on — the rail bars "
                       "keep their last reading" % len(live), problem=True)
+
+    def _note_auth_source(self, name, source) -> None:
+        """An init message named HOW its CLI authenticates. API-key auth (apiKeySource e.g.
+        'ANTHROPIC_API_KEY'; absent on a subscription login — both verified live 2026-08-04) has NO
+        subscription windows, and get_usage just TIMES OUT there — no snapshot ever arrives to correct
+        usage.json, so after logging out the rail bars showed the last subscription reading forever,
+        frozen (the user 2026-08-04). The auth flip is the deciding event: flipping TO an API key drops
+        the stale windows (bars disappear, _usage() returns None on a window-less file) and gates the
+        pointless get_usage polls off; flipping BACK resumes them, and the next real snapshot repaints.
+        Logged raw each flip, so every host's kernel log self-documents its auth mode."""
+        was = self.api_key_auth
+        self.api_key_auth = bool(source)
+        if self.api_key_auth == was:
+            return
+        self._log("auth (%s): apiKeySource=%r — %s" % (name, source,
+                  "API-key auth: dropping stale /usage windows; usage polls off" if self.api_key_auth
+                  else "subscription auth: usage polls resume"))
+        if not self.api_key_auth:
+            return                                # bars repaint from the next real snapshot on their own
+        with self._rl_lock:
+            try:
+                tmp = self.state_dir / "usage.json.tmp"
+                tmp.write_text(json.dumps({"t": int(time.time()), "apiKey": True}))
+                os.replace(tmp, self.state_dir / "usage.json")
+            except Exception as e:
+                self._log("auth (%s): could not drop stale usage windows: %s" % (name, e))
 
     def _record_usage_snapshot(self, r) -> None:
         """Fold a get_usage control-request snapshot into usage.json — EXACT utilization for every window,

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1372,6 +1372,52 @@ class StopTask(unittest.TestCase):
         self.assertIn("Couldn't stop that background task", src, "a refusal warns the user — never a silent no-op")
 
 
+class ApiKeyAuthUsage(unittest.TestCase):
+    """Logging out to an API key froze the rail's /usage bars on the last subscription reading (the
+    user 2026-08-04): API-key auth has no subscription windows and get_usage only TIMES OUT there, so
+    no snapshot ever arrived to correct usage.json. The init message's apiKeySource (verified live:
+    'ANTHROPIC_API_KEY' on API-key auth, absent on a subscription login) is the deciding event —
+    flipping TO an API key drops the stale windows and gates the pointless polls off; flipping back
+    lets the next real snapshot repaint."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        self.p = Path(self.d) / "usage.json"
+        self.p.write_text(json.dumps({"t": 1785898746,
+                                      "five_hour": {"pct": 46, "resets_at": 1785907200},
+                                      "seven_day": {"pct": 21, "resets_at": 1786388400}}))
+
+    def test_flipping_to_api_key_drops_the_stale_windows(self):
+        self.be._note_auth_source("n", "ANTHROPIC_API_KEY")
+        self.assertTrue(self.be.api_key_auth)
+        d = json.loads(self.p.read_text())
+        self.assertTrue(d.get("apiKey"))
+        for k in ("five_hour", "seven_day", "fable"):
+            self.assertNotIn(k, d, "stale subscription windows are gone → _usage() returns None → no bars")
+
+    def test_subscription_auth_leaves_the_file_alone(self):
+        before = self.p.read_text()
+        self.be._note_auth_source("n", None)
+        self.assertFalse(self.be.api_key_auth)
+        self.assertEqual(self.p.read_text(), before, "no flip, no write")
+
+    def test_flipping_back_keeps_the_file_for_the_next_snapshot(self):
+        self.be._note_auth_source("n", "ANTHROPIC_API_KEY")
+        dropped = self.p.read_text()
+        self.be._note_auth_source("n", None)
+        self.assertFalse(self.be.api_key_auth)
+        self.assertEqual(self.p.read_text(), dropped, "bars repaint from the next REAL snapshot, not a guess")
+
+    def test_init_reads_the_field_and_the_poll_is_gated(self):
+        src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+                                "kernel", "sdk_backend.py")).read()
+        self.assertIn('self.backend._note_auth_source(self.name, d.get("apiKeySource"))', src,
+                      "the init message is the one in-band auth signal")
+        self.assertIn("if self.backend.api_key_auth:", src.split("async def _do_refresh_usage", 1)[1][:1600],
+                      "get_usage is never polled on API-key auth — it only times out there")
+
+
 class RewindFiles(unittest.TestCase):
     """The bubble's restore-files affordance rides the SDK's designed rewind_files control request (the
     user 2026-08-04): the WORKSPACE goes back to its state before a user message; the conversation is


### PR DESCRIPTION
Reported today: after switching this machine to an API key (logged out of the subscription), the rail's usage bars kept showing — they should be gone.

Root cause, verified live: on API-key auth the `get_usage` control request **times out** (kernel log: `Control request timeout: get_usage` on every session), and `_record_usage_snapshot` only ever writes when a snapshot maps to windows — so nothing could ever correct `usage.json`, and the bars rendered the final subscription reading forever, frozen.

The fix keys on the designed, event-based signal: the SDK init message's `apiKeySource` (probed live on this machine: `'ANTHROPIC_API_KEY'` under API-key auth; absent on a subscription login). On a flip to API-key auth the backend drops the stale windows from `usage.json` — the bars disappear, since `_usage()` already returns `None` for a window-less file — and gates off the `get_usage` polls, which only produced a timeout per turn end. Flipping back resumes polls, and the next real snapshot repaints the bars on its own; both flips log the raw value, so each host's kernel log self-documents its auth mode. Federation behaves per host by construction: a machine still logged in keeps its own bars (the user's live A/B: this machine vs a still-logged-in remote).

Tests: `ApiKeyAuthUsage` — flip drops windows, subscription leaves the file alone, flip-back defers to the next real snapshot, and pins on the init read + poll gate. Suites green locally (3903 pytest, 1651 node).

Note: kernel-side, so it takes effect per host on that host's next kernel restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)