### PR TITLE
The rail shows API spend where the subscription bars sat

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13626,6 +13626,14 @@ def _usage():
         return None
     five, seven, fable = seg(o.get("five_hour")), seg(o.get("seven_day")), seg(o.get("fable"))
     if not five and not seven and not fable:
+        # No windows. An API-KEY account (the auth-flip marker _note_auth_source writes) shows SPEND
+        # where the bars sat (the user 2026-08-04): today's accumulated per-result total_cost_usd,
+        # from spend.json. A window-less file WITHOUT the marker stays None — nothing known, draw
+        # nothing (never a confident zero).
+        if o.get("apiKey"):
+            return {"apiKey": True, "spend": _spend_today(),
+                    "t": o.get("t") if isinstance(o.get("t"), (int, float)) else None,
+                    "acct": _claude_account()}
         return None
     # LIMIT REACHED (the user 2026-07-01): a window at 100% whose reset is still in the future = the account is
     # rate-limited on it now. Drives the top banner + the auto retry-pause. A window past its resetsAt has rolled
@@ -13664,6 +13672,20 @@ def _judge_failures():
         val = None
     _jf_cache["fp"], _jf_cache["val"] = fp, val
     return val
+
+
+def _spend_today():
+    """Today's API spend from spend.json — {usd, turns, date} or None. The SDK backend accumulates each
+    result's total_cost_usd there (_record_spend); this is the rail's readout under API-key auth."""
+    try:
+        d = json.loads((jd.STATE / "spend.json").read_text())
+        day = time.strftime("%Y-%m-%d")
+        e = (d.get("days") or {}).get(day)
+        if isinstance(e, dict) and isinstance(e.get("usd"), (int, float)):
+            return {"usd": round(float(e["usd"]), 4), "turns": int(e.get("turns") or 0), "date": day}
+    except Exception:
+        pass
+    return None
 
 
 def _usage_for_client():
@@ -16978,6 +17000,12 @@ if(!on){_limPut('');}   // fully cleared -> forget the logged signature so a fut
 else if(sig!==_limGet()){_limPut(sig);var names=[];if(lim.fiveHour)names.push('Session (5h)');if(lim.sevenDay)names.push('Weekly (7d)');
 if(window.__rompNotify)window.__rompNotify('limit',names.join(' and ')+' usage limit reached \u2014 retries paused until it resets');}}
 function hasBars(u){return !!(u&&(u.fiveHour||u.sevenDay||u.fable));}
+// API-key auth: no subscription windows exist — the rail shows SPEND where the bars sat (the user
+// 2026-08-04): today's accumulated per-result cost from the kernel's spend.json. strip.ts carries the
+// same branch; the two copies must stay in step (rail-spend pins).
+function hasSpend(u){return !!(u&&u.apiKey&&u.spend&&typeof u.spend.usd==='number');}
+function spendHTML(u){var sp=u.spend,n=sp.turns||0;
+return '<div class=ru-spend title="API-key billing \u2014 $'+sp.usd.toFixed(2)+' across '+n+' turn'+(n===1?'':'s')+' today. No subscription windows on this account.">API $'+sp.usd.toFixed(2)+' today</div>';}
 // One account's windows, as markup + the tooltip detail for them. Pure: the caller decides where it goes.
 function winsHTML(u,det){var nowS=Math.floor(Date.now()/1000),html='';
 WINS.forEach(function(w){var seg=u[w[0]];if(!seg)return;
@@ -17012,16 +17040,16 @@ return html;}
 // by account and each group gets its own bars, labelled with a host that is on it, in the quiet lowercase
 // italic `host:` the chat tabs already wear for a federated session \u2014 same idea, same treatment.
 function renderRows(rows,selfHost){ROWS=rows||[];LAST={};
-var live=ROWS.filter(function(r){return hasBars(r.usage);});
+var live=ROWS.filter(function(r){return hasBars(r.usage)||hasSpend(r.usage);});
 if(!live.length){el.innerHTML='';tip.style.display='none';return;}
 if(live.length===1){var det={};det._t=(typeof live[0].usage.t==='number')?live[0].usage.t:null;
-LAST=[{host:'',det:det}];el.innerHTML=winsHTML(live[0].usage,det);return;}
+LAST=[{host:'',det:det}];el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendHTML(live[0].usage);return;}
 var html='';LAST=[];
 live.forEach(function(r){var det={};det._t=(typeof r.usage.t==='number')?r.usage.t:null;
 var hn=r.host||selfHost||'this machine';
 LAST.push({host:hn,det:det});
 html+='<div class=ru-set title="The Claude account signed in on '+esc(hn)+'. Its allowance is separate from the others here, so each login gets its own bars.">'
-+'<span class=ru-host>'+esc(hn)+':</span>'+winsHTML(r.usage,det)+'</div>';});
++'<span class=ru-host>'+esc(hn)+':</span>'+(hasBars(r.usage)?winsHTML(r.usage,det):spendHTML(r.usage))+'</div>';});
 el.innerHTML=html;}
 // The single-payload path the timeline still posts (and the mobile panel's own fetch): treat it as this
 // machine's row, leaving any other account's bars alone.
@@ -18167,6 +18195,7 @@ def _landing():
             # the windows sit side-by-side. Full detail (elapsed %, reset countdown, age) stays in the hover panel.
             "#rail-usage{flex:0 0 auto;display:flex;flex-direction:row;align-items:center;gap:16px}"
             ".ru-w{display:flex;flex-direction:row;align-items:center;gap:7px;cursor:default}"
+            ".ru-spend{color:#9aa7b4;font-size:11px;white-space:nowrap;cursor:default}"
             ".ru-name{font:600 10px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#9aa4ad;letter-spacing:.02em;white-space:nowrap}"
             ".ru-bars{display:flex;flex-direction:column;gap:2px;flex:0 0 auto}"   # used bar stacked over elapsed bar
             ".ru-track{position:relative;width:54px;height:5px;background:rgba(255,255,255,0.12);border-radius:3px;overflow:hidden;flex:0 0 auto}"

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1909,6 +1909,7 @@ class SdkSession:
             if m and "claude" in m.lower():
                 self._learn_model(pretty_model(m))
         elif isinstance(msg, ResultMessage):
+            self.backend._record_spend(getattr(msg, "total_cost_usd", None))   # the rail's spend readout under API-key auth
             self.retrying = False
             self.retry_count = 0                    # turn over → clear the storm count (a turn that errored out without recovering leaves no "recovered" note)
             self.retry_info = None
@@ -2603,6 +2604,34 @@ class SdkBackend:
         if live:
             self._log("usage refresh: %d live session(s), none with a loop to run it on — the rail bars "
                       "keep their last reading" % len(live), problem=True)
+
+    def _record_spend(self, cost) -> None:
+        """Accumulate a turn's total_cost_usd into spend.json, keyed by LOCAL date — the rail's spend
+        readout where the subscription bars sat, under API-key auth (the user 2026-08-04). Recorded on
+        every result regardless of auth (subscription results report a computed cost too; the DISPLAY is
+        gated on the auth mode, the record is not — flipping auth mid-day keeps the number honest).
+        Pruned to the last 90 days; atomic like every state write."""
+        if not isinstance(cost, (int, float)) or cost <= 0:
+            return
+        day = time.strftime("%Y-%m-%d")
+        with self._rl_lock:
+            p = self.state_dir / "spend.json"
+            try:
+                d = json.loads(p.read_text())
+                days = d.get("days") if isinstance(d, dict) and isinstance(d.get("days"), dict) else {}
+            except Exception:
+                days = {}
+            e = days.get(day) if isinstance(days.get(day), dict) else {}
+            days[day] = {"usd": round(float(e.get("usd") or 0) + float(cost), 6),
+                         "turns": int(e.get("turns") or 0) + 1}
+            for k in sorted(days)[:-90]:
+                days.pop(k, None)
+            try:
+                tmp = self.state_dir / "spend.json.tmp"
+                tmp.write_text(json.dumps({"days": days}))
+                os.replace(tmp, p)
+            except Exception as ex:
+                self._log("spend record failed: %s" % ex)
 
     def _note_auth_source(self, name, source) -> None:
         """An init message named HOW its CLI authenticates. API-key auth (apiKeySource e.g.

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1418,6 +1418,51 @@ class ApiKeyAuthUsage(unittest.TestCase):
                       "get_usage is never polled on API-key auth — it only times out there")
 
 
+class SpendRecord(unittest.TestCase):
+    """Under API-key auth the rail shows SPEND where the subscription bars sat (the user 2026-08-04):
+    each ResultMessage's total_cost_usd accumulates into spend.json by LOCAL date. Recorded on every
+    result regardless of auth (display is gated, the record is not); pruned to 90 days."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        self.p = Path(self.d) / "spend.json"
+
+    def _today(self):
+        return time.strftime("%Y-%m-%d")
+
+    def test_accumulates_cost_and_turns_by_day(self):
+        self.be._record_spend(0.02)
+        self.be._record_spend(0.03)
+        d = json.loads(self.p.read_text())["days"][self._today()]
+        self.assertAlmostEqual(d["usd"], 0.05)
+        self.assertEqual(d["turns"], 2)
+
+    def test_ignores_missing_zero_and_junk_costs(self):
+        for v in (None, 0, -1, "0.5"):
+            self.be._record_spend(v)
+        self.assertFalse(self.p.exists(), "no real cost → no file, never a confident zero")
+
+    def test_prunes_to_ninety_days(self):
+        days = {"2020-01-%02d" % (i + 1) for i in range(25)}
+        self.p.write_text(json.dumps({"days": {k: {"usd": 1, "turns": 1} for k in days}}))
+        self.be._record_spend(0.01)
+        kept = json.loads(self.p.read_text())["days"]
+        self.assertLessEqual(len(kept), 90)
+        self.assertIn(self._today(), kept)
+
+    def test_result_message_records_and_the_kernel_serves_it(self):
+        src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+                                "kernel", "sdk_backend.py")).read()
+        self.assertIn('self.backend._record_spend(getattr(msg, "total_cost_usd", None))', src,
+                      "every ResultMessage's cost is folded in at the settle")
+        with open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin", "romp-kernel")) as f:
+            ksrc = f.read()
+        self.assertIn('if o.get("apiKey"):', ksrc, "_usage serves the spend payload on the auth-flip marker")
+        self.assertIn('"spend": _spend_today()', ksrc)
+        self.assertIn("def _spend_today():", ksrc)
+
+
 class RewindFiles(unittest.TestCase):
     """The bubble's restore-files affordance rides the SDK's designed rewind_files control request (the
     user 2026-08-04): the WORKSPACE goes back to its state before a user message; the conversation is

--- a/tests/test_sdk_compacting_signal.py
+++ b/tests/test_sdk_compacting_signal.py
@@ -35,6 +35,7 @@ class _FakeBackend:
     def _turn_completed(self, sid): pass
     def retire_live_work(self, sid): pass
     def _poke(self): pass
+    def _record_spend(self, cost): pass   # the settle folds cost into spend.json; irrelevant to these transitions
     def _update_reg(self, *a, **k): pass
     def _forward(self, s, msg): pass
 

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -1,0 +1,46 @@
+// Under API-KEY auth the rail shows SPEND where the subscription bars sat (the user 2026-08-04): the
+// account has no 5h/weekly windows (get_usage only times out there — see the #208 auth-flip fix), so
+// the kernel serves {apiKey, spend:{usd,turns,date}} built from spend.json, which accumulates each
+// ResultMessage's total_cost_usd by local date. BOTH rail copies render it — VS Code's strip.ts and
+// the web landing's usage JS in kernel.py — and must stay in step (the two-copies lesson, again).
+// No jsdom harness → source pins (the repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+const STRIP = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
+const STRIPCSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.css"), "utf8");
+const BACKEND = fs.readFileSync(path.join(ROOT, "kernel", "sdk_backend.py"), "utf8");
+
+test("the kernel serves spend on the auth-flip marker, never a confident zero", () => {
+  // the payload rides the SAME _usage() path the bars used — no new wire/handler
+  assert.ok(KERNEL.includes('if o.get("apiKey"):'), "gated on the #208 auth-flip marker");
+  assert.ok(KERNEL.includes('"spend": _spend_today()'));
+  assert.ok(KERNEL.includes("def _spend_today():"));
+  // a window-less file WITHOUT the marker stays None — nothing known, draw nothing
+  assert.match(KERNEL, /if o\.get\("apiKey"\):[\s\S]{0,400}?return None/);
+  // the accumulator: every result's cost, by local date, pruned
+  assert.ok(BACKEND.includes('self.backend._record_spend(getattr(msg, "total_cost_usd", None))'));
+  assert.ok(BACKEND.includes("def _record_spend(self, cost) -> None:"));
+});
+
+test("VS Code strip renders the spend chip where the bars sat", () => {
+  assert.match(STRIP, /function spendChip\(usage: any\): HTMLElement \| null/);
+  assert.match(STRIP, /const sp = usage && usage\.apiKey && usage\.spend;/);
+  assert.match(STRIP, /box\.textContent = "API \$" \+ sp\.usd\.toFixed\(2\) \+ " today";/);
+  assert.match(STRIP, /if \(spend\) usageWrap\.appendChild\(spend\);/);
+  assert.match(STRIPCSS, /\.ru-spend \{/);
+});
+
+test("the web landing copy carries the SAME branch — the two rails stay in step", () => {
+  assert.ok(KERNEL.includes("function hasSpend(u){return !!(u&&u.apiKey&&u.spend&&typeof u.spend.usd==='number');}"));
+  assert.ok(KERNEL.includes("function spendHTML(u)"));
+  // spend rows count as live rows, and both the single- and multi-account paths fall to the chip
+  assert.ok(KERNEL.includes("return hasBars(r.usage)||hasSpend(r.usage);"));
+  assert.ok(KERNEL.includes("el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendHTML(live[0].usage);return;"));
+  assert.ok(KERNEL.includes("(hasBars(r.usage)?winsHTML(r.usage,det):spendHTML(r.usage))"));
+  assert.ok(KERNEL.includes('".ru-spend{'), "the landing CSS styles the chip");
+});

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -33,6 +33,8 @@
   color: var(--vscode-descriptionForeground, #9aa0a6); font-size: 15px; line-height: 1; cursor: pointer;
   padding: 2px 6px; opacity: .8; }
 #strip-gear:hover { opacity: 1; background: rgba(255, 255, 255, 0.08); color: var(--vscode-foreground, #ccc); }
+.ru-spend { color: #9aa7b4; font: 500 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  white-space: nowrap; cursor: default; }   /* API-key auth: the spend readout where the bars sat (2026-08-04) */
 .ru-w { display: flex; flex-direction: row; align-items: center; gap: 7px; cursor: default;
   flex: 0 1 auto; min-width: 0; }
 .ru-name { font: 600 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #9aa4ad;

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -188,9 +188,26 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
     fit();
   }
 
+  // API-key auth: no subscription windows exist — the rail shows SPEND where the bars sat (the user
+  // 2026-08-04): today's accumulated per-result cost from the kernel's spend.json. The web landing
+  // carries the same branch (kernel.py hasSpend/spendHTML); the two copies must stay in step.
+  function spendChip(usage: any): HTMLElement | null {
+    const sp = usage && usage.apiKey && usage.spend;
+    if (!sp || typeof sp.usd !== "number") return null;
+    const box = document.createElement("div");
+    box.className = "ru-spend";
+    const n = sp.turns || 0;
+    box.textContent = "API $" + sp.usd.toFixed(2) + " today";
+    box.title = "API-key billing — $" + sp.usd.toFixed(2) + " across " + n + " turn" + (n === 1 ? "" : "s")
+      + " today. No subscription windows on this account.";
+    return box;
+  }
+
   function render(usage: any) {
     const nowS = Math.floor(Date.now() / 1000);
     usageWrap.textContent = "";
+    const spend = spendChip(usage);
+    if (spend) usageWrap.appendChild(spend);   // API-key auth: the spend readout replaces the bars
     for (const w of usageWindows(usage, nowS)) {
       const box = document.createElement("span");
       box.className = "ru-w" + (w.unknown ? " ru-unk" : "");


### PR DESCRIPTION
Requested today: with the machine on an API key (bars now correctly gone after #208), show a per-token/spend readout at the bottom instead.

**Data**: every `ResultMessage` carries `total_cost_usd` (verified live earlier today — $0.0247 for the probe turn). The SDK backend folds it into `spend.json` keyed by local date — recorded on every result regardless of auth mode (the display is gated, the record is not, so flipping auth mid-day keeps the number honest), pruned to 90 days, atomic.

**Payload**: `_usage()` already returns the bar windows or `None`; it now returns `{apiKey, spend: {usd, turns, date}, t, acct}` when the file carries #208's auth-flip marker — riding the exact payload path the bars used, no new wire or handler. A window-less file *without* the marker stays `None` (nothing known, draw nothing — never a confident zero).

**Render**: both rail copies — VS Code's `strip.ts` and the web landing's usage JS in kernel.py — show a quiet chip in the bars' slot: `API $X.XX today`, with turn count and billing mode in the tooltip. The web copy's per-account grouping treats a spend row as a live row, so a federated machine still on a subscription keeps its own bars beside this machine's spend. Both copies are pinned in step by the new `rail-spend.test.ts` (the two-copies lesson from the thumbnails and trust-dropdown fixes, applied preemptively this time).

Tests: `SpendRecord` (accumulation, junk-cost rejection, 90-day pruning, settle + payload pins) and `rail-spend.test.ts` (kernel payload, both renderers, CSS). Embedded JS syntax-checked. Suites green locally (3907 pytest, 1654 node).

Note: kernel-side halves take effect on the next kernel restart; spend accumulates from that restart forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)