### PR TITLE
A fresh API-key kernel shows $0.00, never an empty rail slot

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13631,7 +13631,10 @@ def _usage():
         # from spend.json. A window-less file WITHOUT the marker stays None — nothing known, draw
         # nothing (never a confident zero).
         if o.get("apiKey"):
-            return {"apiKey": True, "spend": _spend_today(),
+            # A fresh API-key kernel has no settled turn yet — an EMPTY slot (no bars, no chip) reads
+            # as broken (the user 2026-08-04, post-restart). $0.00 is the honest zero here: the record
+            # is per-result and the day genuinely holds none yet.
+            return {"apiKey": True, "spend": _spend_today() or {"usd": 0.0, "turns": 0, "date": time.strftime("%Y-%m-%d")},
                     "t": o.get("t") if isinstance(o.get("t"), (int, float)) else None,
                     "acct": _claude_account()}
         return None

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -18,10 +18,11 @@ const BACKEND = fs.readFileSync(path.join(ROOT, "kernel", "sdk_backend.py"), "ut
 test("the kernel serves spend on the auth-flip marker, never a confident zero", () => {
   // the payload rides the SAME _usage() path the bars used — no new wire/handler
   assert.ok(KERNEL.includes('if o.get("apiKey"):'), "gated on the #208 auth-flip marker");
-  assert.ok(KERNEL.includes('"spend": _spend_today()'));
+  // a fresh API-key kernel with no settled turn shows $0.00, never an empty slot that reads as broken
+  assert.ok(KERNEL.includes('"spend": _spend_today() or {"usd": 0.0, "turns": 0, "date": time.strftime("%Y-%m-%d")}'));
   assert.ok(KERNEL.includes("def _spend_today():"));
   // a window-less file WITHOUT the marker stays None — nothing known, draw nothing
-  assert.match(KERNEL, /if o\.get\("apiKey"\):[\s\S]{0,400}?return None/);
+  assert.match(KERNEL, /if o\.get\("apiKey"\):[\s\S]{0,800}?return None/);
   // the accumulator: every result's cost, by local date, pruned
   assert.ok(BACKEND.includes('self.backend._record_spend(getattr(msg, "total_cost_usd", None))'));
   assert.ok(BACKEND.includes("def _record_spend(self, cost) -> None:"));


### PR DESCRIPTION
Follow-up to #209, from live use: right after a kernel restart onto API-key auth, no turn has settled yet, so the rail showed neither bars nor the spend chip — an empty slot that reads as broken. The payload now defaults to `{"usd": 0.0, "turns": 0}` when the day holds no record, so the chip renders `API $0.00 today` from the first push. An honest zero: spend is recorded per result, and the day genuinely holds none.

Suites green locally (3907 pytest, 1654 node). Kernel-side; effective on the next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)