### PR TITLE
The spend chip shows tokens and wears the rail's own dress

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13634,7 +13634,7 @@ def _usage():
             # A fresh API-key kernel has no settled turn yet — an EMPTY slot (no bars, no chip) reads
             # as broken (the user 2026-08-04, post-restart). $0.00 is the honest zero here: the record
             # is per-result and the day genuinely holds none yet.
-            return {"apiKey": True, "spend": _spend_today() or {"usd": 0.0, "turns": 0, "date": time.strftime("%Y-%m-%d")},
+            return {"apiKey": True, "spend": _spend_today() or {"usd": 0.0, "turns": 0, "tok": 0, "date": time.strftime("%Y-%m-%d")},
                     "t": o.get("t") if isinstance(o.get("t"), (int, float)) else None,
                     "acct": _claude_account()}
         return None
@@ -13678,14 +13678,21 @@ def _judge_failures():
 
 
 def _spend_today():
-    """Today's API spend from spend.json — {usd, turns, date} or None. The SDK backend accumulates each
-    result's total_cost_usd there (_record_spend); this is the rail's readout under API-key auth."""
+    """Today's API spend from spend.json — {usd, turns, tok, tokIn, tokOut, tokCacheR, tokCacheW, date}
+    or None. The SDK backend accumulates each result's total_cost_usd + usage tokens there
+    (_record_spend); this is the rail's readout under API-key auth. `tok` is the visible total (input +
+    output + both cache flavors — everything the API processed); the split rides for the tooltip."""
     try:
         d = json.loads((jd.STATE / "spend.json").read_text())
         day = time.strftime("%Y-%m-%d")
         e = (d.get("days") or {}).get(day)
         if isinstance(e, dict) and isinstance(e.get("usd"), (int, float)):
-            return {"usd": round(float(e["usd"]), 4), "turns": int(e.get("turns") or 0), "date": day}
+            def ti(k):
+                return int(e.get(k) or 0)
+            return {"usd": round(float(e["usd"]), 4), "turns": int(e.get("turns") or 0),
+                    "tok": ti("tokIn") + ti("tokOut") + ti("tokCacheR") + ti("tokCacheW"),
+                    "tokIn": ti("tokIn"), "tokOut": ti("tokOut"),
+                    "tokCacheR": ti("tokCacheR"), "tokCacheW": ti("tokCacheW"), "date": day}
     except Exception:
         pass
     return None
@@ -17007,8 +17014,16 @@ function hasBars(u){return !!(u&&(u.fiveHour||u.sevenDay||u.fable));}
 // 2026-08-04): today's accumulated per-result cost from the kernel's spend.json. strip.ts carries the
 // same branch; the two copies must stay in step (rail-spend pins).
 function hasSpend(u){return !!(u&&u.apiKey&&u.spend&&typeof u.spend.usd==='number');}
-function spendHTML(u){var sp=u.spend,n=sp.turns||0;
-return '<div class=ru-spend title="API-key billing \u2014 $'+sp.usd.toFixed(2)+' across '+n+' turn'+(n===1?'':'s')+' today. No subscription windows on this account.">API $'+sp.usd.toFixed(2)+' today</div>';}
+function fmtTok(n){if(n>=1e9)return (n/1e9).toFixed(1).replace(/\.0$/,'')+'B';
+if(n>=1e6)return (n/1e6).toFixed(1).replace(/\.0$/,'')+'M';
+if(n>=1e3)return (n/1e3).toFixed(1).replace(/\.0$/,'')+'k';return String(n);}
+// Dressed in the rail's OWN classes (ru-w row, ru-name label, ru-pct readout) \u2014 same fonts as the
+// bars it replaces, no minted styles (the consistent-fonts rule; the user 2026-08-04, whose first cut
+// wore a one-off 11px). Tokens beside the dollars, the in/out/cache split on the hover.
+function spendHTML(u){var sp=u.spend,n=sp.turns||0,tk=fmtTok(sp.tok||0);
+return '<div class="ru-w ru-spend" title="API-key billing \u2014 $'+sp.usd.toFixed(2)+' across '+n+' turn'+(n===1?'':'s')+' today \u00b7 '+tk+' tokens'+(sp.tokIn!=null?' ('+fmtTok(sp.tokIn)+' in, '+fmtTok(sp.tokOut||0)+' out, '+fmtTok((sp.tokCacheR||0)+(sp.tokCacheW||0))+' cache)':'')+'. No subscription windows on this account.">'
++'<div class=ru-name>API today</div>'
++'<div class=ru-pct>$'+sp.usd.toFixed(2)+' \u00b7 '+tk+' tok</div></div>';}
 // One account's windows, as markup + the tooltip detail for them. Pure: the caller decides where it goes.
 function winsHTML(u,det){var nowS=Math.floor(Date.now()/1000),html='';
 WINS.forEach(function(w){var seg=u[w[0]];if(!seg)return;
@@ -18198,7 +18213,6 @@ def _landing():
             # the windows sit side-by-side. Full detail (elapsed %, reset countdown, age) stays in the hover panel.
             "#rail-usage{flex:0 0 auto;display:flex;flex-direction:row;align-items:center;gap:16px}"
             ".ru-w{display:flex;flex-direction:row;align-items:center;gap:7px;cursor:default}"
-            ".ru-spend{color:#9aa7b4;font-size:11px;white-space:nowrap;cursor:default}"
             ".ru-name{font:600 10px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#9aa4ad;letter-spacing:.02em;white-space:nowrap}"
             ".ru-bars{display:flex;flex-direction:column;gap:2px;flex:0 0 auto}"   # used bar stacked over elapsed bar
             ".ru-track{position:relative;width:54px;height:5px;background:rgba(255,255,255,0.12);border-radius:3px;overflow:hidden;flex:0 0 auto}"

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1909,7 +1909,8 @@ class SdkSession:
             if m and "claude" in m.lower():
                 self._learn_model(pretty_model(m))
         elif isinstance(msg, ResultMessage):
-            self.backend._record_spend(getattr(msg, "total_cost_usd", None))   # the rail's spend readout under API-key auth
+            self.backend._record_spend(getattr(msg, "total_cost_usd", None),
+                                       getattr(msg, "usage", None))   # the rail's spend + token readout under API-key auth
             self.retrying = False
             self.retry_count = 0                    # turn over → clear the storm count (a turn that errored out without recovering leaves no "recovered" note)
             self.retry_info = None
@@ -2605,14 +2606,20 @@ class SdkBackend:
             self._log("usage refresh: %d live session(s), none with a loop to run it on — the rail bars "
                       "keep their last reading" % len(live), problem=True)
 
-    def _record_spend(self, cost) -> None:
-        """Accumulate a turn's total_cost_usd into spend.json, keyed by LOCAL date — the rail's spend
-        readout where the subscription bars sat, under API-key auth (the user 2026-08-04). Recorded on
-        every result regardless of auth (subscription results report a computed cost too; the DISPLAY is
-        gated on the auth mode, the record is not — flipping auth mid-day keeps the number honest).
-        Pruned to the last 90 days; atomic like every state write."""
+    def _record_spend(self, cost, usage=None) -> None:
+        """Accumulate a turn's total_cost_usd AND its token counts into spend.json, keyed by LOCAL date —
+        the rail's spend readout where the subscription bars sat, under API-key auth (the user
+        2026-08-04; tokens added the same day, who wanted them beside the dollars). Recorded on every
+        result regardless of auth (subscription results report a computed cost too; the DISPLAY is gated
+        on the auth mode, the record is not — flipping auth mid-day keeps the number honest). Token
+        fields mirror the ResultMessage usage dict: input/output plus the two cache flavors, kept
+        separately so the tooltip can break them down. Pruned to the last 90 days; atomic."""
         if not isinstance(cost, (int, float)) or cost <= 0:
             return
+        u = usage if isinstance(usage, dict) else {}
+        def _tok(k):
+            v = u.get(k)
+            return int(v) if isinstance(v, (int, float)) else 0
         day = time.strftime("%Y-%m-%d")
         with self._rl_lock:
             p = self.state_dir / "spend.json"
@@ -2623,7 +2630,11 @@ class SdkBackend:
                 days = {}
             e = days.get(day) if isinstance(days.get(day), dict) else {}
             days[day] = {"usd": round(float(e.get("usd") or 0) + float(cost), 6),
-                         "turns": int(e.get("turns") or 0) + 1}
+                         "turns": int(e.get("turns") or 0) + 1,
+                         "tokIn": int(e.get("tokIn") or 0) + _tok("input_tokens"),
+                         "tokOut": int(e.get("tokOut") or 0) + _tok("output_tokens"),
+                         "tokCacheR": int(e.get("tokCacheR") or 0) + _tok("cache_read_input_tokens"),
+                         "tokCacheW": int(e.get("tokCacheW") or 0) + _tok("cache_creation_input_tokens")}
             for k in sorted(days)[:-90]:
                 days.pop(k, None)
             try:

--- a/tests/test_kernel_rail_usage.py
+++ b/tests/test_kernel_rail_usage.py
@@ -59,7 +59,9 @@ class RailUsage(unittest.TestCase):
         self.assertIn("ru-fill style=\"width:'+pct+'%;background:'+col", self.html, "the used-% bar")
         self.assertIn("ru-fill style=\"width:'+(tp||0)+'%;background:#6b7a8c", self.html, "the elapsed-% bar below it")
         # order within a window: label, then the bars, then % — all inline
-        one = self.html[self.html.index("<div class=ru-name>"):]
+        # anchor past the spend chip (it wears ru-name/ru-pct too, with no bars — the user 2026-08-04):
+        # the slice must start at a WINDOW row, whose label is built from the WINS table
+        one = self.html[self.html.index("<div class=ru-name>'+w"):]
         self.assertLess(one.index("ru-name"), one.index("ru-bars"))
         self.assertLess(one.index("ru-bars"), one.index("ru-pct"))
         # expanded labels use the 5th WINS field (plenty of horizontal room)

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1431,12 +1431,19 @@ class SpendRecord(unittest.TestCase):
     def _today(self):
         return time.strftime("%Y-%m-%d")
 
-    def test_accumulates_cost_and_turns_by_day(self):
-        self.be._record_spend(0.02)
-        self.be._record_spend(0.03)
+    def test_accumulates_cost_turns_and_tokens_by_day(self):
+        self.be._record_spend(0.02, {"input_tokens": 100, "output_tokens": 40,
+                                     "cache_read_input_tokens": 1000, "cache_creation_input_tokens": 60})
+        self.be._record_spend(0.03, {"input_tokens": 10, "output_tokens": 5})
         d = json.loads(self.p.read_text())["days"][self._today()]
         self.assertAlmostEqual(d["usd"], 0.05)
         self.assertEqual(d["turns"], 2)
+        self.assertEqual((d["tokIn"], d["tokOut"], d["tokCacheR"], d["tokCacheW"]), (110, 45, 1000, 60))
+
+    def test_a_result_without_usage_still_records_cost(self):
+        self.be._record_spend(0.02)
+        d = json.loads(self.p.read_text())["days"][self._today()]
+        self.assertEqual((d["usd"], d["tokIn"], d["tokOut"]), (0.02, 0, 0))
 
     def test_ignores_missing_zero_and_junk_costs(self):
         for v in (None, 0, -1, "0.5"):
@@ -1454,8 +1461,9 @@ class SpendRecord(unittest.TestCase):
     def test_result_message_records_and_the_kernel_serves_it(self):
         src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
                                 "kernel", "sdk_backend.py")).read()
-        self.assertIn('self.backend._record_spend(getattr(msg, "total_cost_usd", None))', src,
+        self.assertIn('self.backend._record_spend(getattr(msg, "total_cost_usd", None),', src,
                       "every ResultMessage's cost is folded in at the settle")
+        self.assertIn('getattr(msg, "usage", None))', src, "…with its token counts")
         with open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin", "romp-kernel")) as f:
             ksrc = f.read()
         self.assertIn('if o.get("apiKey"):', ksrc, "_usage serves the spend payload on the auth-flip marker")

--- a/tests/test_sdk_compacting_signal.py
+++ b/tests/test_sdk_compacting_signal.py
@@ -35,7 +35,7 @@ class _FakeBackend:
     def _turn_completed(self, sid): pass
     def retire_live_work(self, sid): pass
     def _poke(self): pass
-    def _record_spend(self, cost): pass   # the settle folds cost into spend.json; irrelevant to these transitions
+    def _record_spend(self, cost, usage=None): pass   # the settle folds cost+tokens into spend.json; irrelevant here
     def _update_reg(self, *a, **k): pass
     def _forward(self, s, msg): pass
 

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -19,29 +19,44 @@ test("the kernel serves spend on the auth-flip marker, never a confident zero", 
   // the payload rides the SAME _usage() path the bars used — no new wire/handler
   assert.ok(KERNEL.includes('if o.get("apiKey"):'), "gated on the #208 auth-flip marker");
   // a fresh API-key kernel with no settled turn shows $0.00, never an empty slot that reads as broken
-  assert.ok(KERNEL.includes('"spend": _spend_today() or {"usd": 0.0, "turns": 0, "date": time.strftime("%Y-%m-%d")}'));
+  assert.ok(KERNEL.includes('"spend": _spend_today() or {"usd": 0.0, "turns": 0, "tok": 0, "date": time.strftime("%Y-%m-%d")}'));
   assert.ok(KERNEL.includes("def _spend_today():"));
   // a window-less file WITHOUT the marker stays None — nothing known, draw nothing
   assert.match(KERNEL, /if o\.get\("apiKey"\):[\s\S]{0,800}?return None/);
-  // the accumulator: every result's cost, by local date, pruned
-  assert.ok(BACKEND.includes('self.backend._record_spend(getattr(msg, "total_cost_usd", None))'));
-  assert.ok(BACKEND.includes("def _record_spend(self, cost) -> None:"));
+  // the accumulator: every result's cost AND its token counts, by local date, pruned
+  assert.ok(BACKEND.includes('self.backend._record_spend(getattr(msg, "total_cost_usd", None),'));
+  assert.ok(BACKEND.includes("def _record_spend(self, cost, usage=None) -> None:"));
+  for (const k of ["tokIn", "tokOut", "tokCacheR", "tokCacheW"]) assert.ok(BACKEND.includes('"' + k + '"'), k);
+  assert.ok(KERNEL.includes('"tok": ti("tokIn") + ti("tokOut") + ti("tokCacheR") + ti("tokCacheW")'),
+    "the visible total is everything the API processed; the split rides for the tooltip");
 });
 
-test("VS Code strip renders the spend chip where the bars sat", () => {
+test("VS Code strip renders spend + tokens, dressed in the rail's OWN classes", () => {
   assert.match(STRIP, /function spendChip\(usage: any\): HTMLElement \| null/);
   assert.match(STRIP, /const sp = usage && usage\.apiKey && usage\.spend;/);
-  assert.match(STRIP, /box\.textContent = "API \$" \+ sp\.usd\.toFixed\(2\) \+ " today";/);
+  // ru-w row, ru-name label with the tier spans, ru-pct readout — the bars' exact dress, so the chip
+  // compresses with the rail like every other element (the consistent-fonts rule; no minted styles)
+  assert.match(STRIP, /box\.className = "ru-w ru-spend";/);
+  assert.match(STRIP, /name\.className = "ru-name";/);
+  assert.match(STRIP, /full\.className = "ru-name-full";/);
+  assert.match(STRIP, /val\.className = "ru-pct";/);
+  assert.match(STRIP, /val\.textContent = "\$" \+ sp\.usd\.toFixed\(2\) \+ " · " \+ fmtTok\(sp\.tok \|\| 0\) \+ " tok";/);
   assert.match(STRIP, /if \(spend\) usageWrap\.appendChild\(spend\);/);
-  assert.match(STRIPCSS, /\.ru-spend \{/);
+  // no one-off .ru-spend font rule — the class is a hook, the DRESS comes from ru-name/ru-pct
+  assert.doesNotMatch(STRIPCSS, /\.ru-spend/);
+  // compact token formatting, shared shape with the web copy
+  assert.match(STRIP, /function fmtTok\(n: number\): string/);
 });
 
 test("the web landing copy carries the SAME branch — the two rails stay in step", () => {
   assert.ok(KERNEL.includes("function hasSpend(u){return !!(u&&u.apiKey&&u.spend&&typeof u.spend.usd==='number');}"));
   assert.ok(KERNEL.includes("function spendHTML(u)"));
+  assert.ok(KERNEL.includes("function fmtTok(n)"));
+  assert.ok(KERNEL.includes("'<div class=ru-name>API today</div>'"), "the web chip wears ru-name/ru-pct too");
+  assert.ok(KERNEL.includes("+'<div class=ru-pct>$'+sp.usd.toFixed(2)+"), "readout in the rail's own class");
   // spend rows count as live rows, and both the single- and multi-account paths fall to the chip
   assert.ok(KERNEL.includes("return hasBars(r.usage)||hasSpend(r.usage);"));
   assert.ok(KERNEL.includes("el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendHTML(live[0].usage);return;"));
   assert.ok(KERNEL.includes("(hasBars(r.usage)?winsHTML(r.usage,det):spendHTML(r.usage))"));
-  assert.ok(KERNEL.includes('".ru-spend{'), "the landing CSS styles the chip");
+  assert.ok(!KERNEL.includes('".ru-spend{'), "no minted landing style — the rail's own classes dress the chip");
 });

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -33,8 +33,6 @@
   color: var(--vscode-descriptionForeground, #9aa0a6); font-size: 15px; line-height: 1; cursor: pointer;
   padding: 2px 6px; opacity: .8; }
 #strip-gear:hover { opacity: 1; background: rgba(255, 255, 255, 0.08); color: var(--vscode-foreground, #ccc); }
-.ru-spend { color: #9aa7b4; font: 500 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  white-space: nowrap; cursor: default; }   /* API-key auth: the spend readout where the bars sat (2026-08-04) */
 .ru-w { display: flex; flex-direction: row; align-items: center; gap: 7px; cursor: default;
   flex: 0 1 auto; min-width: 0; }
 .ru-name { font: 600 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #9aa4ad;

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -188,18 +188,42 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
     fit();
   }
 
-  // API-key auth: no subscription windows exist — the rail shows SPEND where the bars sat (the user
-  // 2026-08-04): today's accumulated per-result cost from the kernel's spend.json. The web landing
-  // carries the same branch (kernel.py hasSpend/spendHTML); the two copies must stay in step.
+  // API-key auth: no subscription windows exist — the rail shows SPEND + TOKENS where the bars sat
+  // (the user 2026-08-04): today's accumulated per-result cost and usage from the kernel's spend.json.
+  // The web landing carries the same branch (kernel.py hasSpend/spendHTML); the two copies must stay
+  // in step. Dressed ENTIRELY in the rail's own classes — ru-w row, ru-name label (full/short tier
+  // spans), ru-pct readout — same fonts and compression tiers as the bars it replaces, no minted
+  // styles (the consistent-fonts rule; the user 2026-08-04, whose first cut wore a one-off 11px).
+  function fmtTok(n: number): string {
+    if (n >= 1e9) return (n / 1e9).toFixed(1).replace(/\.0$/, "") + "B";
+    if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
+    if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "k";
+    return String(n);
+  }
   function spendChip(usage: any): HTMLElement | null {
     const sp = usage && usage.apiKey && usage.spend;
     if (!sp || typeof sp.usd !== "number") return null;
     const box = document.createElement("div");
-    box.className = "ru-spend";
+    box.className = "ru-w ru-spend";
+    const name = document.createElement("div");
+    name.className = "ru-name";
+    const full = document.createElement("span");
+    full.className = "ru-name-full";
+    full.textContent = "API today";
+    const short = document.createElement("span");
+    short.className = "ru-name-short";
+    short.textContent = "API";
+    name.append(full, short);
+    const val = document.createElement("div");
+    val.className = "ru-pct";
+    val.textContent = "$" + sp.usd.toFixed(2) + " · " + fmtTok(sp.tok || 0) + " tok";
     const n = sp.turns || 0;
-    box.textContent = "API $" + sp.usd.toFixed(2) + " today";
     box.title = "API-key billing — $" + sp.usd.toFixed(2) + " across " + n + " turn" + (n === 1 ? "" : "s")
-      + " today. No subscription windows on this account.";
+      + " today · " + fmtTok(sp.tok || 0) + " tokens"
+      + (sp.tokIn != null ? " (" + fmtTok(sp.tokIn) + " in, " + fmtTok(sp.tokOut || 0) + " out, "
+         + fmtTok((sp.tokCacheR || 0) + (sp.tokCacheW || 0)) + " cache)" : "")
+      + ". No subscription windows on this account.";
+    box.append(name, val);
     return box;
   }
 


### PR DESCRIPTION
Two corrections from first live use of #209/#210:

**Tokens beside the dollars.** Each `ResultMessage.usage`'s counts (input, output, cache-read, cache-creation) accumulate into `spend.json` alongside the cost. The chip reads `API today · $0.42 · 34k tok` (compact k/M/B formatting), and the hover carries the in/out/cache split plus the turn count. The visible total is everything the API processed; the split rides for the tooltip.

**No minted styles.** The first cut wore a one-off 11px font — exactly what the consistent-fonts rule forbids. The chip now composes entirely from the rail's existing classes: `ru-w` row, `ru-name` label (with the `ru-name-full`/`ru-name-short` tier spans on the VS Code strip), `ru-pct` readout — same fonts as the bars it replaces, and it compresses with the rail's width tiers like every other element. Both hardcoded `.ru-spend` font rules are deleted; the class stays as a hook only.

Both copies updated in step (web landing + VS Code strip), pins updated accordingly; the rail-usage ordering test re-anchors past the chip (it wears `ru-name`/`ru-pct` with no bars). Embedded JS syntax-checked. Suites green locally (3908 pytest, 1654 node).

Kernel-side halves effective on the next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)