### PR TITLE
Bars drop the instant their login is gone

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13625,6 +13625,20 @@ def _usage():
                     "color": list(cm.ramp(pct / 100.0, stops))}   # used-% on the selected colormap
         return None
     five, seven, fable = seg(o.get("five_hour")), seg(o.get("seven_day")), seg(o.get("fable"))
+    # THE LOGIN THAT PRODUCED THESE WINDOWS MUST STILL BE SIGNED IN (the user 2026-08-04, who logged
+    # out and asked why the bars couldn't clear immediately — they always waited for the next reading,
+    # which after a logout NEVER comes: get_usage times out on API-key auth and RateLimitEvents stop).
+    # Both writers stamp `acct` (whose reading this was); the credential store is the authority on the
+    # CURRENT login and _claude_account() reads it mtime-cached, so the comparison is immediate and
+    # per-push: a logout empties the store, the stamp no longer matches, the bars drop that push. A
+    # LEGACY unstamped file keeps its bars either way — same-or-different is unknowable there, every
+    # new reading stamps, and a pre-upgrade fossil on a logged-out machine still clears via the #208
+    # auth flip on its next session init (deliberately NOT keyed on the live login here: that would
+    # couple every unstamped fixture and CI run to the machine's real credential file).
+    if five or seven or fable:
+        stamped = o.get("acct") or ""
+        if stamped and stamped != _claude_account():
+            five = seven = fable = None
     if not five and not seven and not fable:
         # No windows. An API-KEY account (the auth-flip marker _note_auth_source writes) shows SPEND
         # where the bars sat (the user 2026-08-04): today's accumulated per-result total_cost_usd,

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -19,6 +19,7 @@ and the kernel degrades gracefully when the SDK is absent.
 from __future__ import annotations
 import asyncio
 import difflib
+import hashlib
 import json
 import os
 import re
@@ -689,6 +690,20 @@ def write_name(state_dir: Path, sid: str, name: str, cwd: str, bg: str = "", fg:
 
 def _reg_path(state_dir: Path, sid: str) -> Path:
     return Path(state_dir) / "sdk" / (sid + ".json")
+
+
+def acct_digest() -> str:
+    """The signed-in Claude account as an opaque 12-hex digest, "" when logged out — duplicated tiny
+    from the kernel's _claude_account (same file, same field, same hash) so usage-window WRITES can
+    stamp whose reading they hold without a kernel import. The stamp is what lets the kernel drop bars
+    the INSTANT that login goes away (the user 2026-08-04), instead of waiting for a next reading that
+    never comes after a logout."""
+    try:
+        acct = ((json.loads(open(os.path.expanduser("~/.claude.json"), encoding="utf-8").read()) or {})
+                .get("oauthAccount") or {}).get("accountUuid")
+        return hashlib.sha256(str(acct).encode("utf-8")).hexdigest()[:12] if acct else ""
+    except Exception:
+        return ""
 
 
 def read_reg(state_dir: Path, sid: str) -> dict | None:
@@ -2704,6 +2719,7 @@ class SdkBackend:
             except Exception:
                 cur = {}
             data = {"t": int(time.time()),
+                    "acct": acct_digest(),   # whose reading this is — the kernel drops the bars the moment that login is gone
                     "five_hour": out.get("five_hour", cur.get("five_hour")),
                     "seven_day": out.get("seven_day", cur.get("seven_day")),
                     "fable": out.get("fable", cur.get("fable"))}
@@ -2799,7 +2815,8 @@ class SdkBackend:
             if new == seg:
                 return                                # no change → keep t honest (the tooltip's "updated … ago")
             cur[key] = new
-            data = {"t": int(time.time()), "five_hour": cur.get("five_hour"),
+            data = {"t": int(time.time()), "acct": acct_digest(),   # whose reading — see the snapshot writer
+                    "five_hour": cur.get("five_hour"),
                     "seven_day": cur.get("seven_day"), "fable": cur.get("fable")}
             try:
                 tmp = self.state_dir / "usage.json.tmp"

--- a/tests/test_usage_acct_flip.py
+++ b/tests/test_usage_acct_flip.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Bars drop the INSTANT the login that produced them is gone (the user 2026-08-04, who logged out and
+still saw the old bars: they always waited for the next reading, which after a logout never comes —
+get_usage times out on API-key auth and RateLimitEvents stop). Snapshot writers stamp `acct` (whose
+reading this is, the kernel\'s opaque login digest); _usage() compares it per push against the CURRENT
+login from the credential store, the authority on login state. Synthetic fixtures only."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_acctflip", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+WINDOWS = {"t": 1785898746, "acct": "aaaaaaaaaaaa",
+           "five_hour": {"pct": 46, "resets_at": 1785907200},
+           "seven_day": {"pct": 21, "resets_at": 1786388400}}
+
+
+class AcctFlip(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved_state, jd.STATE = jd.STATE, Path(self.td.name)
+        self.saved_acct = km._claude_account
+
+    def tearDown(self):
+        jd.STATE = self.saved_state
+        km._claude_account = self.saved_acct
+        self.td.cleanup()
+
+    def _write(self, o):
+        (jd.STATE / "usage.json").write_text(json.dumps(o))
+
+    def test_same_login_keeps_its_bars(self):
+        self._write(WINDOWS)
+        km._claude_account = lambda: "aaaaaaaaaaaa"
+        u = km._usage()
+        self.assertIsNotNone(u)
+        self.assertEqual(u["fiveHour"]["pct"], 46)
+
+    def test_logout_drops_the_bars_immediately(self):
+        self._write(WINDOWS)
+        km._claude_account = lambda: ""             # the credential store says: nobody signed in
+        self.assertIsNone(km._usage(), "the reading describes no present allowance — no bars, no wait")
+
+    def test_a_different_login_drops_the_stale_readings_too(self):
+        self._write(WINDOWS)
+        km._claude_account = lambda: "bbbbbbbbbbbb"
+        self.assertIsNone(km._usage(), "another account\'s fossil must not masquerade as this login\'s")
+
+    def test_legacy_unstamped_file_with_a_login_keeps_showing(self):
+        legacy = dict(WINDOWS); legacy.pop("acct")
+        self._write(legacy)
+        km._claude_account = lambda: "cccccccccccc"
+        self.assertIsNotNone(km._usage(), "same-or-different is unknowable on a legacy file — the next reading stamps it")
+
+    def test_legacy_unstamped_files_never_consult_the_live_login(self):
+        # Deliberate: keying an UNSTAMPED file on the machine's real credential store would couple every
+        # fixture and CI run to it. A pre-upgrade fossil on a logged-out machine still clears via the
+        # #208 auth flip at its next session init; every new reading is stamped from here on.
+        legacy = dict(WINDOWS); legacy.pop("acct")
+        self._write(legacy)
+        km._claude_account = lambda: ""
+        self.assertIsNotNone(km._usage(), "unstamped → shown as before, regardless of login state")
+
+    def test_logout_on_an_api_key_machine_falls_to_the_spend_chip(self):
+        o = dict(WINDOWS); o["apiKey"] = True       # windows + marker (an auth flip raced a late reading)
+        self._write(o)
+        km._claude_account = lambda: ""
+        u = km._usage()
+        self.assertTrue(u and u.get("apiKey"), "the spend chip takes the slot, never the fossil bars")
+
+    def test_both_writers_stamp_whose_reading_it_is(self):
+        base = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+        src = open(os.path.join(base, "kernel", "sdk_backend.py")).read()
+        self.assertIn("def acct_digest() -> str:", src)
+        self.assertEqual(src.count('"acct": acct_digest()'), 2,
+                         "the get_usage snapshot writer AND the RateLimitEvent merge writer both stamp")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reported today: logged out on a host, and its rail row kept showing the old bars — "this thing has always been kind of stale. Can it update immediately?"

It couldn't: the bars only changed when a next reading arrived, and after a logout no reading ever comes (`get_usage` times out under API-key auth; RateLimitEvents stop). The file was a fossil with nothing scheduled to correct it.

Now both `usage.json` writers — the `get_usage` snapshot and the RateLimitEvent merge — stamp `acct`, the same opaque login digest the usage payload already carries (sha-256 of the CLI's `oauthAccount.accountUuid`, 12 hex chars, no identifier travels). `_usage()` compares the stamp against the **current** login on every push; the credential store (`~/.claude.json`) is the authority on login state and is read mtime-cached, so a logout empties it and the bars drop on the very next push — likewise an account switch drops the previous login's readings instead of letting them masquerade as the new account's.

Legacy unstamped files deliberately never consult the live login — keying them on it would couple every test fixture and CI run to the machine's real credential file (found the hard way: 16 fixture failures on a logged-out dev machine). They render as before, every new reading stamps, and a pre-upgrade fossil on a logged-out machine still clears via #208's auth flip at its next session init.

Tests: `test_usage_acct_flip.py` — same login keeps bars, logout drops immediately, account switch drops, legacy files ignore login state, API-key marker falls to the spend chip, and both writers stamp. Suites green locally (3914 pytest, 1654 node).

Kernel-side; effective per host on its next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)