### PR TITLE
API spend windows mirror the subscription bars

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13645,10 +13645,10 @@ def _usage():
         # from spend.json. A window-less file WITHOUT the marker stays None — nothing known, draw
         # nothing (never a confident zero).
         if o.get("apiKey"):
-            # A fresh API-key kernel has no settled turn yet — an EMPTY slot (no bars, no chip) reads
-            # as broken (the user 2026-08-04, post-restart). $0.00 is the honest zero here: the record
-            # is per-result and the day genuinely holds none yet.
-            return {"apiKey": True, "spend": _spend_today() or {"usd": 0.0, "turns": 0, "tok": 0, "date": time.strftime("%Y-%m-%d")},
+            # The spend WINDOWS mirror the subscription bars (5h / 7d / month) so the two auth modes
+            # read identically; _spend_windows always returns all three, zero-filled on a fresh kernel
+            # (an empty slot reads as broken — the user 2026-08-04, post-restart).
+            return {"apiKey": True, "spend": _spend_windows(),
                     "t": o.get("t") if isinstance(o.get("t"), (int, float)) else None,
                     "acct": _claude_account()}
         return None
@@ -13691,25 +13691,53 @@ def _judge_failures():
     return val
 
 
-def _spend_today():
-    """Today's API spend from spend.json — {usd, turns, tok, tokIn, tokOut, tokCacheR, tokCacheW, date}
-    or None. The SDK backend accumulates each result's total_cost_usd + usage tokens there
-    (_record_spend); this is the rail's readout under API-key auth. `tok` is the visible total (input +
-    output + both cache flavors — everything the API processed); the split rides for the tooltip."""
+def _spend_budgets():
+    """Optional per-window spend budgets (USD) from spend-budgets.json — e.g. {"fiveHour": 5,
+    "sevenDay": 40, "month": 150}, hand-set for now (a gear field is the natural follow-up). A budget is
+    what gives a window's bar its FILL: the fraction is spend-over-budget, and without a cap there is no
+    honest fraction to draw — the row shows plain dollars instead."""
+    try:
+        d = json.loads((jd.STATE / "spend-budgets.json").read_text())
+        return {k: float(d[k]) for k in ("fiveHour", "sevenDay", "month")
+                if isinstance(d.get(k), (int, float)) and d[k] > 0}
+    except Exception:
+        return {}
+
+
+def _spend_windows():
+    """API-mode usage windows MIRRORING the subscription bars (the user 2026-08-04, who wanted the two
+    auth modes to read identically at a glance): rolling 5h and 7d summed from spend.json's hour
+    buckets, month-to-date from its day buckets — each {usd, tok, turns}, plus `budget` where
+    spend-budgets.json names one. Always returns all three windows (zeros when nothing is recorded —
+    the day genuinely holds none; the honest-zero rule from the chip era)."""
     try:
         d = json.loads((jd.STATE / "spend.json").read_text())
-        day = time.strftime("%Y-%m-%d")
-        e = (d.get("days") or {}).get(day)
-        if isinstance(e, dict) and isinstance(e.get("usd"), (int, float)):
-            def ti(k):
-                return int(e.get(k) or 0)
-            return {"usd": round(float(e["usd"]), 4), "turns": int(e.get("turns") or 0),
-                    "tok": ti("tokIn") + ti("tokOut") + ti("tokCacheR") + ti("tokCacheW"),
-                    "tokIn": ti("tokIn"), "tokOut": ti("tokOut"),
-                    "tokCacheR": ti("tokCacheR"), "tokCacheW": ti("tokCacheW"), "date": day}
     except Exception:
-        pass
-    return None
+        d = {}
+    days = d.get("days") if isinstance(d.get("days"), dict) else {}
+    hours = d.get("hours") if isinstance(d.get("hours"), dict) else {}
+
+    def _sum(entries):
+        out = {"usd": 0.0, "tok": 0, "turns": 0}
+        for e in entries:
+            if isinstance(e, dict):
+                out["usd"] = round(out["usd"] + float(e.get("usd") or 0), 4)
+                out["turns"] += int(e.get("turns") or 0)
+                out["tok"] += sum(int(e.get(k) or 0) for k in ("tokIn", "tokOut", "tokCacheR", "tokCacheW"))
+        return out
+
+    now = time.time()
+
+    def _rolling(hrs):
+        keys = {time.strftime("%Y-%m-%dT%H", time.localtime(now - i * 3600)) for i in range(hrs + 1)}
+        return _sum(v for k, v in hours.items() if k in keys)
+
+    month = time.strftime("%Y-%m")
+    win = {"fiveHour": _rolling(5), "sevenDay": _rolling(7 * 24),
+           "month": _sum(v for k, v in days.items() if isinstance(k, str) and k.startswith(month))}
+    for k, v in _spend_budgets().items():
+        win[k]["budget"] = v
+    return win
 
 
 def _usage_for_client():
@@ -17027,17 +17055,34 @@ function hasBars(u){return !!(u&&(u.fiveHour||u.sevenDay||u.fable));}
 // API-key auth: no subscription windows exist — the rail shows SPEND where the bars sat (the user
 // 2026-08-04): today's accumulated per-result cost from the kernel's spend.json. strip.ts carries the
 // same branch; the two copies must stay in step (rail-spend pins).
-function hasSpend(u){return !!(u&&u.apiKey&&u.spend&&typeof u.spend.usd==='number');}
+function hasSpend(u){return !!(u&&u.apiKey&&u.spend&&u.spend.fiveHour);}
 function fmtTok(n){if(n>=1e9)return (n/1e9).toFixed(1).replace(/\.0$/,'')+'B';
 if(n>=1e6)return (n/1e6).toFixed(1).replace(/\.0$/,'')+'M';
 if(n>=1e3)return (n/1e3).toFixed(1).replace(/\.0$/,'')+'k';return String(n);}
-// Dressed in the rail's OWN classes (ru-w row, ru-name label, ru-pct readout) \u2014 same fonts as the
-// bars it replaces, no minted styles (the consistent-fonts rule; the user 2026-08-04, whose first cut
-// wore a one-off 11px). Tokens beside the dollars, the in/out/cache split on the hover.
-function spendHTML(u){var sp=u.spend,n=sp.turns||0,tk=fmtTok(sp.tok||0);
-return '<div class="ru-w ru-spend" title="API-key billing \u2014 $'+sp.usd.toFixed(2)+' across '+n+' turn'+(n===1?'':'s')+' today \u00b7 '+tk+' tokens'+(sp.tokIn!=null?' ('+fmtTok(sp.tokIn)+' in, '+fmtTok(sp.tokOut||0)+' out, '+fmtTok((sp.tokCacheR||0)+(sp.tokCacheW||0))+' cache)':'')+'. No subscription windows on this account.">'
-+'<div class=ru-name>API today</div>'
-+'<div class=ru-pct>$'+sp.usd.toFixed(2)+' \u00b7 '+tk+' tok</div></div>';}
+// API-key auth: SPEND windows mirror the subscription bars' grammar exactly \u2014 same rows, labels,
+// twin tracks \u2014 so flipping auth modes reads instantly (the user 2026-08-04). A row FILLS only when
+// spend-budgets.json names that window's budget (the fill is spend-over-budget; no cap, no honest
+// fraction \u2014 plain dollars in the readout slot instead). Rolling windows have no reset boundary, so
+// only month-to-date draws the elapsed track. strip.ts carries the same builder \u2014 kept in step.
+var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','This month']];
+function spendColor(p){return p>=90?'#c0392b':p>=70?'#e0b020':'#54B204';}
+function spendWinsHTML(u){var sp=u.spend||{},html='';
+SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='number')return;
+var budget=(typeof seg.budget==='number'&&seg.budget>0)?seg.budget:null;
+var pct=budget!=null?Math.max(0,Math.min(100,Math.round(seg.usd/budget*100))):null;
+var el2=null;
+if(w[0]==='month'&&budget!=null){var dd=new Date(),dim=new Date(dd.getFullYear(),dd.getMonth()+1,0).getDate();
+el2=Math.max(0,Math.min(100,Math.round(((dd.getDate()-1+dd.getHours()/24)/dim)*100)));}
+var turns=seg.turns||0,readout='$'+(seg.usd<100?seg.usd.toFixed(2):String(Math.round(seg.usd)));
+html+='<div class="ru-w ru-spend" title="'+w[1]+' \u2014 $'+seg.usd.toFixed(2)+' \u00b7 '+fmtTok(seg.tok||0)+' tokens \u00b7 '+turns+' turn'+(turns===1?'':'s')+(budget!=null?' \u00b7 '+pct+'% of the $'+budget+' budget':' \u00b7 no budget set \u2014 dollars only, no fill (set one in spend-budgets.json)')+' \u00b7 API-key billing">'
++'<div class=ru-name>'+w[1]+'</div>'
++'<div class=ru-bars>'
++(pct!=null?'<div class=ru-track><i class=ru-fill style="width:'+pct+'%;background:'+spendColor(pct)+'"></i></div>':'')
++(el2!=null?'<div class=ru-track><i class=ru-fill style="width:'+el2+'%;background:#6b7a8c"></i></div>':'')
++'</div>'
++'<div class=ru-pct>'+readout+'</div>'
++'</div>';});
+return html;}
 // One account's windows, as markup + the tooltip detail for them. Pure: the caller decides where it goes.
 function winsHTML(u,det){var nowS=Math.floor(Date.now()/1000),html='';
 WINS.forEach(function(w){var seg=u[w[0]];if(!seg)return;
@@ -17075,13 +17120,13 @@ function renderRows(rows,selfHost){ROWS=rows||[];LAST={};
 var live=ROWS.filter(function(r){return hasBars(r.usage)||hasSpend(r.usage);});
 if(!live.length){el.innerHTML='';tip.style.display='none';return;}
 if(live.length===1){var det={};det._t=(typeof live[0].usage.t==='number')?live[0].usage.t:null;
-LAST=[{host:'',det:det}];el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendHTML(live[0].usage);return;}
+LAST=[{host:'',det:det}];el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendWinsHTML(live[0].usage);return;}
 var html='';LAST=[];
 live.forEach(function(r){var det={};det._t=(typeof r.usage.t==='number')?r.usage.t:null;
 var hn=r.host||selfHost||'this machine';
 LAST.push({host:hn,det:det});
 html+='<div class=ru-set title="The Claude account signed in on '+esc(hn)+'. Its allowance is separate from the others here, so each login gets its own bars.">'
-+'<span class=ru-host>'+esc(hn)+':</span>'+(hasBars(r.usage)?winsHTML(r.usage,det):spendHTML(r.usage))+'</div>';});
++'<span class=ru-host>'+esc(hn)+':</span>'+(hasBars(r.usage)?winsHTML(r.usage,det):spendWinsHTML(r.usage))+'</div>';});
 el.innerHTML=html;}
 // The single-payload path the timeline still posts (and the mobile panel's own fetch): treat it as this
 // machine's row, leaving any other account's bars alone.

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2636,25 +2636,32 @@ class SdkBackend:
             v = u.get(k)
             return int(v) if isinstance(v, (int, float)) else 0
         day = time.strftime("%Y-%m-%d")
+        hour = time.strftime("%Y-%m-%dT%H")
         with self._rl_lock:
             p = self.state_dir / "spend.json"
             try:
                 d = json.loads(p.read_text())
                 days = d.get("days") if isinstance(d, dict) and isinstance(d.get("days"), dict) else {}
+                hours = d.get("hours") if isinstance(d, dict) and isinstance(d.get("hours"), dict) else {}
             except Exception:
-                days = {}
-            e = days.get(day) if isinstance(days.get(day), dict) else {}
-            days[day] = {"usd": round(float(e.get("usd") or 0) + float(cost), 6),
-                         "turns": int(e.get("turns") or 0) + 1,
-                         "tokIn": int(e.get("tokIn") or 0) + _tok("input_tokens"),
-                         "tokOut": int(e.get("tokOut") or 0) + _tok("output_tokens"),
-                         "tokCacheR": int(e.get("tokCacheR") or 0) + _tok("cache_read_input_tokens"),
-                         "tokCacheW": int(e.get("tokCacheW") or 0) + _tok("cache_creation_input_tokens")}
-            for k in sorted(days)[:-90]:
-                days.pop(k, None)
+                days, hours = {}, {}
+
+            def _fold(buckets, key, keep):
+                e = buckets.get(key) if isinstance(buckets.get(key), dict) else {}
+                buckets[key] = {"usd": round(float(e.get("usd") or 0) + float(cost), 6),
+                                "turns": int(e.get("turns") or 0) + 1,
+                                "tokIn": int(e.get("tokIn") or 0) + _tok("input_tokens"),
+                                "tokOut": int(e.get("tokOut") or 0) + _tok("output_tokens"),
+                                "tokCacheR": int(e.get("tokCacheR") or 0) + _tok("cache_read_input_tokens"),
+                                "tokCacheW": int(e.get("tokCacheW") or 0) + _tok("cache_creation_input_tokens")}
+                for k in sorted(buckets)[:-keep]:
+                    buckets.pop(k, None)
+
+            _fold(days, day, 90)      # the daily ledger: month-to-date + history
+            _fold(hours, hour, 192)   # hour buckets, 8 days — the rolling 5h/7d windows read these
             try:
                 tmp = self.state_dir / "spend.json.tmp"
-                tmp.write_text(json.dumps({"days": days}))
+                tmp.write_text(json.dumps({"days": days, "hours": hours}))
                 os.replace(tmp, p)
             except Exception as ex:
                 self._log("spend record failed: %s" % ex)

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1431,14 +1431,18 @@ class SpendRecord(unittest.TestCase):
     def _today(self):
         return time.strftime("%Y-%m-%d")
 
-    def test_accumulates_cost_turns_and_tokens_by_day(self):
+    def test_accumulates_cost_turns_and_tokens_by_day_and_hour(self):
         self.be._record_spend(0.02, {"input_tokens": 100, "output_tokens": 40,
                                      "cache_read_input_tokens": 1000, "cache_creation_input_tokens": 60})
         self.be._record_spend(0.03, {"input_tokens": 10, "output_tokens": 5})
-        d = json.loads(self.p.read_text())["days"][self._today()]
+        o = json.loads(self.p.read_text())
+        d = o["days"][self._today()]
         self.assertAlmostEqual(d["usd"], 0.05)
         self.assertEqual(d["turns"], 2)
         self.assertEqual((d["tokIn"], d["tokOut"], d["tokCacheR"], d["tokCacheW"]), (110, 45, 1000, 60))
+        h = o["hours"][time.strftime("%Y-%m-%dT%H")]   # the rolling 5h/7d windows read these buckets
+        self.assertAlmostEqual(h["usd"], 0.05)
+        self.assertEqual(h["turns"], 2)
 
     def test_a_result_without_usage_still_records_cost(self):
         self.be._record_spend(0.02)
@@ -1467,8 +1471,8 @@ class SpendRecord(unittest.TestCase):
         with open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin", "romp-kernel")) as f:
             ksrc = f.read()
         self.assertIn('if o.get("apiKey"):', ksrc, "_usage serves the spend payload on the auth-flip marker")
-        self.assertIn('"spend": _spend_today()', ksrc)
-        self.assertIn("def _spend_today():", ksrc)
+        self.assertIn('"spend": _spend_windows()', ksrc)
+        self.assertIn("def _spend_windows():", ksrc)
 
 
 class RewindFiles(unittest.TestCase):

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -1,9 +1,11 @@
-// Under API-KEY auth the rail shows SPEND where the subscription bars sat (the user 2026-08-04): the
-// account has no 5h/weekly windows (get_usage only times out there — see the #208 auth-flip fix), so
-// the kernel serves {apiKey, spend:{usd,turns,date}} built from spend.json, which accumulates each
-// ResultMessage's total_cost_usd by local date. BOTH rail copies render it — VS Code's strip.ts and
-// the web landing's usage JS in kernel.py — and must stay in step (the two-copies lesson, again).
-// No jsdom harness → source pins (the repo convention).
+// Under API-KEY auth the rail shows SPEND WINDOWS that mirror the subscription bars' grammar — the
+// same rows, labels, and twin tracks, for 5h / 7d / month-to-date — so flipping between the two auth
+// modes reads instantly (the user 2026-08-04/05). A row FILLS only when spend-budgets.json names that
+// window's budget: the fill is spend-over-budget, and without a cap there is no honest fraction — the
+// row carries plain dollars in the readout slot and no used-track. Spend accumulates per ResultMessage
+// (total_cost_usd + usage tokens) into spend.json's day AND hour buckets (the rolling windows read the
+// hours). BOTH rail copies carry the builder — VS Code's strip.ts and the web landing's usage JS in
+// kernel.py — and must stay in step. No jsdom harness → source pins (the repo convention).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -15,48 +17,47 @@ const STRIP = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf
 const STRIPCSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.css"), "utf8");
 const BACKEND = fs.readFileSync(path.join(ROOT, "kernel", "sdk_backend.py"), "utf8");
 
-test("the kernel serves spend on the auth-flip marker, never a confident zero", () => {
-  // the payload rides the SAME _usage() path the bars used — no new wire/handler
+test("the kernel serves spend WINDOWS on the auth-flip marker, zero-filled when fresh", () => {
   assert.ok(KERNEL.includes('if o.get("apiKey"):'), "gated on the #208 auth-flip marker");
-  // a fresh API-key kernel with no settled turn shows $0.00, never an empty slot that reads as broken
-  assert.ok(KERNEL.includes('"spend": _spend_today() or {"usd": 0.0, "turns": 0, "tok": 0, "date": time.strftime("%Y-%m-%d")}'));
-  assert.ok(KERNEL.includes("def _spend_today():"));
+  assert.ok(KERNEL.includes('"spend": _spend_windows()'));
+  assert.ok(KERNEL.includes("def _spend_windows():"));
+  assert.ok(KERNEL.includes("def _spend_budgets():"), "budgets give a window its fill denominator");
+  // rolling 5h/7d read the HOUR buckets; month-to-date reads the day ledger
+  assert.match(KERNEL, /"fiveHour": _rolling\(5\), "sevenDay": _rolling\(7 \* 24\)/);
+  assert.ok(KERNEL.includes('k.startswith(month)'));
   // a window-less file WITHOUT the marker stays None — nothing known, draw nothing
   assert.match(KERNEL, /if o\.get\("apiKey"\):[\s\S]{0,800}?return None/);
-  // the accumulator: every result's cost AND its token counts, by local date, pruned
+  // the accumulator: every result's cost + tokens, folded into BOTH bucket sets
   assert.ok(BACKEND.includes('self.backend._record_spend(getattr(msg, "total_cost_usd", None),'));
-  assert.ok(BACKEND.includes("def _record_spend(self, cost, usage=None) -> None:"));
-  for (const k of ["tokIn", "tokOut", "tokCacheR", "tokCacheW"]) assert.ok(BACKEND.includes('"' + k + '"'), k);
-  assert.ok(KERNEL.includes('"tok": ti("tokIn") + ti("tokOut") + ti("tokCacheR") + ti("tokCacheW")'),
-    "the visible total is everything the API processed; the split rides for the tooltip");
+  assert.ok(BACKEND.includes("_fold(days, day, 90)"));
+  assert.ok(BACKEND.includes("_fold(hours, hour, 192)"), "8 days of hour buckets feed the rolling windows");
 });
 
-test("VS Code strip renders spend + tokens, dressed in the rail's OWN classes", () => {
-  assert.match(STRIP, /function spendChip\(usage: any\): HTMLElement \| null/);
-  assert.match(STRIP, /const sp = usage && usage\.apiKey && usage\.spend;/);
-  // ru-w row, ru-name label with the tier spans, ru-pct readout — the bars' exact dress, so the chip
-  // compresses with the rail like every other element (the consistent-fonts rule; no minted styles)
-  assert.match(STRIP, /box\.className = "ru-w ru-spend";/);
-  assert.match(STRIP, /name\.className = "ru-name";/);
-  assert.match(STRIP, /full\.className = "ru-name-full";/);
-  assert.match(STRIP, /val\.className = "ru-pct";/);
-  assert.match(STRIP, /val\.textContent = "\$" \+ sp\.usd\.toFixed\(2\) \+ " · " \+ fmtTok\(sp\.tok \|\| 0\) \+ " tok";/);
-  assert.match(STRIP, /if \(spend\) usageWrap\.appendChild\(spend\);/);
-  // no one-off .ru-spend font rule — the class is a hook, the DRESS comes from ru-name/ru-pct
+test("VS Code strip: ONE row builder for both auth modes — spend rows ride the same loop as the bars", () => {
+  assert.match(STRIP, /export function spendWindows\(usage: any, nowS: number\): UsageWindow\[\]/);
+  assert.match(STRIP, /usageWindows\(usage, nowS\)\.concat\(spendWindows\(usage, nowS\)\)/);
+  // no budget → no used-track and a dollars readout; never a made-up fraction
+  assert.match(STRIP, /const pct = budget != null \? Math\.max\(0, Math\.min\(100, Math\.round\(\(seg\.usd \/ budget\) \* 100\)\)\) : null;/);
+  assert.match(STRIP, /if \(w\.pct != null\) bars\.appendChild\(mkTrack\(w\.pct, usageColor\(w\.pct\)\)\);/);
+  assert.match(STRIP, /pct\.textContent = w\.readout \?\? `\$\{w\.pct\}%`;/);
+  // rolling windows draw no elapsed track; month-to-date does (it has a real boundary)
+  assert.match(STRIP, /if \(key === "month" && budget != null\)/);
+  // labels mirror the subscription table's two-tier form
+  assert.match(STRIP, /\["fiveHour", "5 hours", "5h"\]/);
+  assert.match(STRIP, /\["month", "This month", "mo"\]/);
+  // the old one-off chip is gone, and with it any minted style
+  assert.doesNotMatch(STRIP, /spendChip/);
   assert.doesNotMatch(STRIPCSS, /\.ru-spend/);
-  // compact token formatting, shared shape with the web copy
-  assert.match(STRIP, /function fmtTok\(n: number\): string/);
 });
 
-test("the web landing copy carries the SAME branch — the two rails stay in step", () => {
-  assert.ok(KERNEL.includes("function hasSpend(u){return !!(u&&u.apiKey&&u.spend&&typeof u.spend.usd==='number');}"));
-  assert.ok(KERNEL.includes("function spendHTML(u)"));
-  assert.ok(KERNEL.includes("function fmtTok(n)"));
-  assert.ok(KERNEL.includes("'<div class=ru-name>API today</div>'"), "the web chip wears ru-name/ru-pct too");
-  assert.ok(KERNEL.includes("+'<div class=ru-pct>$'+sp.usd.toFixed(2)+"), "readout in the rail's own class");
-  // spend rows count as live rows, and both the single- and multi-account paths fall to the chip
-  assert.ok(KERNEL.includes("return hasBars(r.usage)||hasSpend(r.usage);"));
-  assert.ok(KERNEL.includes("el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendHTML(live[0].usage);return;"));
-  assert.ok(KERNEL.includes("(hasBars(r.usage)?winsHTML(r.usage,det):spendHTML(r.usage))"));
-  assert.ok(!KERNEL.includes('".ru-spend{'), "no minted landing style — the rail's own classes dress the chip");
+test("the web landing copy carries the SAME builder — the two rails stay in step", () => {
+  assert.ok(KERNEL.includes("function spendWinsHTML(u)"));
+  assert.ok(KERNEL.includes("var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','This month']];"));
+  assert.ok(KERNEL.includes("function hasSpend(u){return !!(u&&u.apiKey&&u.spend&&u.spend.fiveHour);}"));
+  // same row markup as winsHTML: ru-w → ru-name → ru-bars (tracks) → ru-pct readout
+  assert.ok(KERNEL.includes("+'<div class=ru-name>'+w[1]+'</div>'"));
+  assert.ok(KERNEL.includes("(pct!=null?'<div class=ru-track><i class=ru-fill style=\"width:'+pct+'%;background:'+spendColor(pct)+'\"></i></div>':'')"));
+  // both the single- and multi-account paths fall to the window rows
+  assert.ok(KERNEL.includes("el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendWinsHTML(live[0].usage);return;}"));
+  assert.ok(KERNEL.includes("(hasBars(r.usage)?winsHTML(r.usage,det):spendWinsHTML(r.usage))"));
 });

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -17,10 +17,11 @@
 import { kernelUrl } from "./media";
 
 export type UsageWindow = {
+  readout?: string;     // overrides the % readout (a spend row shows dollars)
   key: string;
   label: string;        // the rail's expanded label
   short: string;        // the compressed tag a narrow strip swaps in ("5h" / "7d" / "F5")
-  pct: number;          // used % of the limit (the LAST-KNOWN reading when unknown — drawn faded)
+  pct: number | null;   // used % of the limit / budget (LAST-KNOWN when unknown — drawn faded); null = no honest denominator (a spend row with no budget)
   elapsedPct: number | null;  // % of the window elapsed (pace comparison)
   unknown: boolean;     // the window reset since the last report — the reading no longer describes the present
   title: string;        // hover detail
@@ -79,6 +80,54 @@ export function usageWindows(usage: any, nowS: number): UsageWindow[] {
         : `${label} — used ${pct}%`
           + (elapsedPct != null ? ` · ${elapsedPct}% through the window` : "")
           + (seg.resetsAt ? ` · resets in ${fmtReset(seg.resetsAt, nowS)}` : ""),
+    });
+  }
+  return out;
+}
+
+export function fmtTok(n: number): string {
+  if (n >= 1e9) return (n / 1e9).toFixed(1).replace(/\.0$/, "") + "B";
+  if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
+  if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "k";
+  return String(n);
+}
+
+// API-key auth: SPEND windows mirror the subscription bars' grammar exactly — same rows, same labels,
+// same twin tracks — so flipping between the two auth modes reads instantly (the user 2026-08-04, who
+// asked for "5 hours / week / month, visually similar"). A row FILLS only when spend-budgets.json names
+// that window's budget: the fill is spend-over-budget, and without a cap there is no honest fraction —
+// the row then carries plain dollars in the readout slot and no used-track. Rolling windows (5h/7d)
+// have no reset boundary, so only month-to-date draws the elapsed track. The web landing carries the
+// same builder (kernel.py spendWinsHTML); the two copies must stay in step.
+export const SPEND_WINS: Array<[string, string, string]> = [
+  ["fiveHour", "5 hours", "5h"],
+  ["sevenDay", "7 days", "7d"],
+  ["month", "This month", "mo"],
+];
+export function spendWindows(usage: any, nowS: number): UsageWindow[] {
+  const sp = usage && usage.apiKey && usage.spend;
+  if (!sp) return [];
+  const out: UsageWindow[] = [];
+  for (const [key, label, short] of SPEND_WINS) {
+    const seg = sp[key];
+    if (!seg || typeof seg.usd !== "number") continue;
+    const budget = typeof seg.budget === "number" && seg.budget > 0 ? seg.budget : null;
+    const pct = budget != null ? Math.max(0, Math.min(100, Math.round((seg.usd / budget) * 100))) : null;
+    let elapsedPct: number | null = null;
+    if (key === "month" && budget != null) {
+      const d = new Date(nowS * 1000);
+      const dim = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+      elapsedPct = Math.max(0, Math.min(100, Math.round(((d.getDate() - 1 + d.getHours() / 24) / dim) * 100)));
+    }
+    const turns = seg.turns || 0;
+    out.push({
+      key, label, short, pct, elapsedPct, unknown: false,
+      readout: "$" + (seg.usd < 100 ? seg.usd.toFixed(2) : String(Math.round(seg.usd))),
+      title: label + " — $" + seg.usd.toFixed(2) + " · " + fmtTok(seg.tok || 0) + " tokens · "
+        + turns + " turn" + (turns === 1 ? "" : "s")
+        + (budget != null ? " · " + pct + "% of the $" + budget + " budget"
+           : " · no budget set — dollars only, no fill (set one in spend-budgets.json)")
+        + " · API-key billing",
     });
   }
   return out;
@@ -188,51 +237,14 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
     fit();
   }
 
-  // API-key auth: no subscription windows exist — the rail shows SPEND + TOKENS where the bars sat
-  // (the user 2026-08-04): today's accumulated per-result cost and usage from the kernel's spend.json.
-  // The web landing carries the same branch (kernel.py hasSpend/spendHTML); the two copies must stay
-  // in step. Dressed ENTIRELY in the rail's own classes — ru-w row, ru-name label (full/short tier
-  // spans), ru-pct readout — same fonts and compression tiers as the bars it replaces, no minted
-  // styles (the consistent-fonts rule; the user 2026-08-04, whose first cut wore a one-off 11px).
-  function fmtTok(n: number): string {
-    if (n >= 1e9) return (n / 1e9).toFixed(1).replace(/\.0$/, "") + "B";
-    if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
-    if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "k";
-    return String(n);
-  }
-  function spendChip(usage: any): HTMLElement | null {
-    const sp = usage && usage.apiKey && usage.spend;
-    if (!sp || typeof sp.usd !== "number") return null;
-    const box = document.createElement("div");
-    box.className = "ru-w ru-spend";
-    const name = document.createElement("div");
-    name.className = "ru-name";
-    const full = document.createElement("span");
-    full.className = "ru-name-full";
-    full.textContent = "API today";
-    const short = document.createElement("span");
-    short.className = "ru-name-short";
-    short.textContent = "API";
-    name.append(full, short);
-    const val = document.createElement("div");
-    val.className = "ru-pct";
-    val.textContent = "$" + sp.usd.toFixed(2) + " · " + fmtTok(sp.tok || 0) + " tok";
-    const n = sp.turns || 0;
-    box.title = "API-key billing — $" + sp.usd.toFixed(2) + " across " + n + " turn" + (n === 1 ? "" : "s")
-      + " today · " + fmtTok(sp.tok || 0) + " tokens"
-      + (sp.tokIn != null ? " (" + fmtTok(sp.tokIn) + " in, " + fmtTok(sp.tokOut || 0) + " out, "
-         + fmtTok((sp.tokCacheR || 0) + (sp.tokCacheW || 0)) + " cache)" : "")
-      + ". No subscription windows on this account.";
-    box.append(name, val);
-    return box;
-  }
+
 
   function render(usage: any) {
     const nowS = Math.floor(Date.now() / 1000);
     usageWrap.textContent = "";
-    const spend = spendChip(usage);
-    if (spend) usageWrap.appendChild(spend);   // API-key auth: the spend readout replaces the bars
-    for (const w of usageWindows(usage, nowS)) {
+    // ONE loop, one row builder: subscription windows and API spend windows are the same element, so
+    // the two auth modes cannot drift apart visually (the user 2026-08-04)
+    for (const w of usageWindows(usage, nowS).concat(spendWindows(usage, nowS))) {
       const box = document.createElement("span");
       box.className = "ru-w" + (w.unknown ? " ru-unk" : "");
       box.title = w.title;
@@ -272,11 +284,11 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
         bars.appendChild(q);
         box.append(name, bars);
       } else {
-        bars.appendChild(mkTrack(w.pct, usageColor(w.pct)));
+        if (w.pct != null) bars.appendChild(mkTrack(w.pct, usageColor(w.pct)));   // no honest denominator → no fill
         if (w.elapsedPct != null) bars.appendChild(mkTrack(w.elapsedPct, "#6b7a8c"));
         const pct = document.createElement("span");
         pct.className = "ru-pct";
-        pct.textContent = `${w.pct}%`;
+        pct.textContent = w.readout ?? `${w.pct}%`;
         box.append(name, bars, pct);
       }
       usageWrap.appendChild(box);


### PR DESCRIPTION
Requested today: make the API-key rail element analogous to the subscription bars — "5 hours, week, month or something, visually similar, so switching between the two makes the meaning immediately obvious."

The spend chip becomes **window rows in the subscription bars' exact grammar**: `5 hours`, `7 days`, `This month` — same labels (full/short tier spans on the strip), same twin tracks, same readout slot. On the VS Code strip the spend rows literally ride the same loop and row builder as the subscription windows (`usageWindows(...).concat(spendWindows(...))`), so the two modes cannot drift apart visually; the web landing carries the mirrored builder, pinned in step.

The honest-denominator rule: a fill bar claims a fraction, and API spend has no account-side cap romp can read. So a row **fills only when `spend-budgets.json` names that window's budget** (e.g. `{"fiveHour": 5, "sevenDay": 40, "month": 150}` in the state dir — hand-set for now, a gear field is the natural follow-up); the fill is spend-over-budget on the usual green/amber/red ramp. Without a budget the row shows plain dollars in the readout slot and draws no used-track — never a made-up fraction. Rolling windows draw no elapsed track (no reset boundary exists); month-to-date draws one. Hover carries dollars, tokens, turns, and budget % per window.

Recording: `spend.json` gains hour buckets (8 days kept, pruned like the 90-day daily ledger) so the rolling 5h/7d sums are real rather than day-approximated.

Tests: `rail-spend.test.ts` rewritten for the window model (kernel payload + both renderers + honest-denominator pins); `SpendRecord` extended for the hour buckets. Embedded JS syntax-checked. Suites green locally (3915 pytest, 1654 node).

Kernel-side; effective on the next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)