### PR TITLE
Spend rows say Month and keep tokens visible

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17064,7 +17064,7 @@ if(n>=1e3)return (n/1e3).toFixed(1).replace(/\.0$/,'')+'k';return String(n);}
 // spend-budgets.json names that window's budget (the fill is spend-over-budget; no cap, no honest
 // fraction \u2014 plain dollars in the readout slot instead). Rolling windows have no reset boundary, so
 // only month-to-date draws the elapsed track. strip.ts carries the same builder \u2014 kept in step.
-var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','This month']];
+var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','Month']];
 function spendColor(p){return p>=90?'#c0392b':p>=70?'#e0b020':'#54B204';}
 function spendWinsHTML(u){var sp=u.spend||{},html='';
 SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='number')return;
@@ -17073,7 +17073,7 @@ var pct=budget!=null?Math.max(0,Math.min(100,Math.round(seg.usd/budget*100))):nu
 var el2=null;
 if(w[0]==='month'&&budget!=null){var dd=new Date(),dim=new Date(dd.getFullYear(),dd.getMonth()+1,0).getDate();
 el2=Math.max(0,Math.min(100,Math.round(((dd.getDate()-1+dd.getHours()/24)/dim)*100)));}
-var turns=seg.turns||0,readout='$'+(seg.usd<100?seg.usd.toFixed(2):String(Math.round(seg.usd)));
+var turns=seg.turns||0,readout='$'+(seg.usd<100?seg.usd.toFixed(2):String(Math.round(seg.usd)))+' \u00b7 '+fmtTok(seg.tok||0)+' tok';
 html+='<div class="ru-w ru-spend" title="'+w[1]+' \u2014 $'+seg.usd.toFixed(2)+' \u00b7 '+fmtTok(seg.tok||0)+' tokens \u00b7 '+turns+' turn'+(turns===1?'':'s')+(budget!=null?' \u00b7 '+pct+'% of the $'+budget+' budget':' \u00b7 no budget set \u2014 dollars only, no fill (set one in spend-budgets.json)')+' \u00b7 API-key billing">'
 +'<div class=ru-name>'+w[1]+'</div>'
 +'<div class=ru-bars>'

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -44,7 +44,10 @@ test("VS Code strip: ONE row builder for both auth modes — spend rows ride the
   assert.match(STRIP, /if \(key === "month" && budget != null\)/);
   // labels mirror the subscription table's two-tier form
   assert.match(STRIP, /\["fiveHour", "5 hours", "5h"\]/);
-  assert.match(STRIP, /\["month", "This month", "mo"\]/);
+  assert.match(STRIP, /\["month", "Month", "mo"\]/);
+  // dollars AND tokens stay visible in the readout (the user 2026-08-05); the split stays on hover
+  assert.match(STRIP, /\+ " · " \+ fmtTok\(seg\.tok \|\| 0\) \+ " tok"/);
+  assert.ok(KERNEL.includes("+' \\u00b7 '+fmtTok(seg.tok||0)+' tok'"), "web readout carries tokens too");
   // the old one-off chip is gone, and with it any minted style
   assert.doesNotMatch(STRIP, /spendChip/);
   assert.doesNotMatch(STRIPCSS, /\.ru-spend/);
@@ -52,7 +55,7 @@ test("VS Code strip: ONE row builder for both auth modes — spend rows ride the
 
 test("the web landing copy carries the SAME builder — the two rails stay in step", () => {
   assert.ok(KERNEL.includes("function spendWinsHTML(u)"));
-  assert.ok(KERNEL.includes("var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','This month']];"));
+  assert.ok(KERNEL.includes("var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','Month']];"));
   assert.ok(KERNEL.includes("function hasSpend(u){return !!(u&&u.apiKey&&u.spend&&u.spend.fiveHour);}"));
   // same row markup as winsHTML: ru-w → ru-name → ru-bars (tracks) → ru-pct readout
   assert.ok(KERNEL.includes("+'<div class=ru-name>'+w[1]+'</div>'"));

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -102,7 +102,7 @@ export function fmtTok(n: number): string {
 export const SPEND_WINS: Array<[string, string, string]> = [
   ["fiveHour", "5 hours", "5h"],
   ["sevenDay", "7 days", "7d"],
-  ["month", "This month", "mo"],
+  ["month", "Month", "mo"],
 ];
 export function spendWindows(usage: any, nowS: number): UsageWindow[] {
   const sp = usage && usage.apiKey && usage.spend;
@@ -122,7 +122,9 @@ export function spendWindows(usage: any, nowS: number): UsageWindow[] {
     const turns = seg.turns || 0;
     out.push({
       key, label, short, pct, elapsedPct, unknown: false,
-      readout: "$" + (seg.usd < 100 ? seg.usd.toFixed(2) : String(Math.round(seg.usd))),
+      // dollars AND tokens stay VISIBLE (the user 2026-08-05 — the hover-only split hid them again)
+      readout: "$" + (seg.usd < 100 ? seg.usd.toFixed(2) : String(Math.round(seg.usd)))
+        + " · " + fmtTok(seg.tok || 0) + " tok",
       title: label + " — $" + seg.usd.toFixed(2) + " · " + fmtTok(seg.tok || 0) + " tokens · "
         + turns + " turn" + (turns === 1 ? "" : "s")
         + (budget != null ? " · " + pct + "% of the $" + budget + " budget"


### PR DESCRIPTION
Two first-use corrections to #213 from the user: the month row is labeled `Month` (was "This month"), and tokens return to the visible readout beside the dollars — `$0.42 · 34k tok` — on both rail copies. The window-rows rewrite had moved token counts to hover-only, which quietly un-answered the original "I'd like to see tokens" ask. The in/out/cache split stays on the hover.

(Also from the same report, explanation rather than code: the 5h window reading zero right after this restart is a one-time upgrade artifact — hour-level buckets only began existing with #213, so rolling windows start counting from that restart; the file persists across future restarts.)

Pins updated. Suites green locally (3915 pytest, 1654 node); embedded JS syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)