### PR TITLE
/mcp opens romp's own MCP panel instead of a dead end

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3965,7 +3965,7 @@ def _drive(msg, client):
     t = msg.get("type")
     ID_OPS = ("sendMessage", "rewindSend", "rewindDelete", "interrupt", "compactSession", "dismissDialog", "answerAsk", "navAsk", "toggleAsk", "submitAsk",
               "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "setModel", "setEffort", "setMode",
-              "endSession", "renameSession", "stopTask", "rewindFiles")
+              "endSession", "renameSession", "stopTask", "rewindFiles", "mcpAction")
     if t in ID_OPS and msg.get("id"):
         sid = str(msg["id"])
     elif t in ("compact", "sendCommand") and msg.get("name"):
@@ -4209,6 +4209,14 @@ def _drive(msg, client):
         if not be.stop_task(sid, str(msg["taskId"])):
             client["send"](json.dumps({"type": "warn",
                                        "text": "Couldn't stop that background task — it may have already finished."}))
+        _push_soon()
+    elif t == "mcpAction" and msg.get("server"):
+        # enable / disable / reconnect ONE MCP server (SDK control requests). The panel refetches after,
+        # so the truth on screen is always the CLI's own status — never an optimistic guess.
+        err = be.mcp_action(sid, str(msg["server"]), str(msg.get("action") or "toggle"),
+                            bool(msg.get("enabled", True)))
+        client["send"](json.dumps({"type": "mcpResult", "id": sid, "server": str(msg["server"]),
+                                   "error": err or ""}))
         _push_soon()
     elif t == "rewindFiles" and msg.get("uuid"):
         # the SDK's file-checkpoint restore — the workspace, not the conversation. LOUD on refusal.
@@ -18933,6 +18941,15 @@ class Handler(BaseHTTPRequestHandler):
                 except Exception:
                     pass
                 return self._send(200, json.dumps({"rows": _fleet_usage(), "host": _self_host()}),
+                                  "application/json", cache="no-cache")
+            if p == "/mcp":                                   # the MCP panel's data (the user 2026-08-05): `/mcp`
+                # in a romp session hits the CLI's INTERACTIVE panel, which an SDK session can't render — it
+                # just says "use a terminal". These are the SAME facts via the SDK's designed control request
+                # (get_mcp_status), so romp renders its own panel. Fails LOUDLY: the reason rides `error`.
+                sid = (q.get("sid") or [""])[0]
+                be = Sessions.backend_for(sid) if sid else None
+                servers, err = be.mcp_status(sid) if be else ([], "unknown session")
+                return self._send(200, json.dumps({"servers": servers, "error": err}),
                                   "application/json", cache="no-cache")
             if p == "/followup-preview":                      # the EXACT wrapped body a citation chip will send (the
                 # user 2026-07-01): clicking the composer chip shows this so you can AUDIT what romp is telling the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2220,6 +2220,37 @@ class SdkSession:
             self.backend._log("stop_task (%s): control request failed for %s: %s" % (self.name, tid, e))
         self.backend._poke()
 
+    # ---- MCP servers (the SDK's designed control requests) ----
+    # `/mcp` in a romp session hits the CLI's INTERACTIVE panel, which an SDK-driven session cannot
+    # render — the CLI just says "use a terminal" (the user 2026-08-05). The SDK exposes the same facts
+    # and actions as control requests, so romp serves its own panel from them: get_mcp_status for the
+    # list, toggle_mcp_server / reconnect_mcp_server for the two repairs. Each runs ON the session's
+    # loop and blocks the calling (kernel) thread only for a bounded wait.
+    def _call_on_loop(self, coro_fn, what, timeout=20.0):
+        """Run a client coroutine on this session's loop and return its result. (None, reason) on any
+        failure — the kernel surfaces the reason; never a silent empty panel."""
+        if not (self.loop and self.client):
+            return None, "this session's CLI isn't connected"
+        try:
+            fut = asyncio.run_coroutine_threadsafe(coro_fn(), self.loop)
+            return fut.result(timeout), ""
+        except Exception as e:
+            self.backend._log("%s (%s) failed: %s: %s" % (what, self.name, type(e).__name__, e))
+            return None, "%s: %s" % (type(e).__name__, e)
+
+    def mcp_status(self):
+        r, err = self._call_on_loop(lambda: self.client.get_mcp_status(), "mcp status")
+        servers = (r or {}).get("mcpServers") if isinstance(r, dict) else None
+        return (servers if isinstance(servers, list) else []), err
+
+    def mcp_toggle(self, name: str, enabled: bool):
+        _r, err = self._call_on_loop(lambda: self.client.toggle_mcp_server(name, enabled), "mcp toggle")
+        return err
+
+    def mcp_reconnect(self, name: str):
+        _r, err = self._call_on_loop(lambda: self.client.reconnect_mcp_server(name), "mcp reconnect")
+        return err
+
     def request_rewind_files(self, uuid: str) -> bool:
         """Restore the workspace's files to their state just before the given user message — the SDK's
         designed rewind_files control request (enable_file_checkpointing is on for every session). The
@@ -3457,6 +3488,18 @@ class SdkBackend:
     def stop_task(self, sid: str, task_id: str) -> bool:
         s = self.sessions.get(sid)
         return bool(s and s.request_stop_task(task_id))
+
+    def mcp_status(self, sid: str):
+        s = self.sessions.get(sid)
+        return s.mcp_status() if s else ([], "romp has no live SDK session for this tab")
+
+    def mcp_action(self, sid: str, name: str, action: str, enabled: bool = True) -> str:
+        s = self.sessions.get(sid)
+        if not s:
+            return "romp has no live SDK session for this tab"
+        if action == "reconnect":
+            return s.mcp_reconnect(name)
+        return s.mcp_toggle(name, enabled)
 
     def rewind_files(self, sid: str, uuid: str) -> bool:
         s = self.sessions.get(sid)

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -121,6 +121,16 @@ class SessionBackend(ABC):
         stream), so this default False just means "no such control here" (tmux)."""
         return False
 
+    def mcp_status(self, sid: str):
+        """(servers, error) — the live MCP server list for this session (the SDK's get_mcp_status).
+        SDK-only: tmux sessions render the CLI's own /mcp panel in their pane, so the default says so
+        rather than pretending an empty list is the truth."""
+        return [], "MCP status is available on SDK sessions; this one runs in a terminal — use /mcp there"
+
+    def mcp_action(self, sid: str, name: str, action: str, enabled: bool = True) -> str:
+        """"" on success, else why not. Enable/disable or reconnect one MCP server (SDK control requests)."""
+        return "MCP controls are available on SDK sessions; this one runs in a terminal — use /mcp there"
+
     def rewind_files(self, sid: str, uuid: str) -> bool:
         """Restore workspace files to their state before a user message (the SDK's rewind_files,
         backed by file checkpointing). SDK-only control — the default False means "no such control

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1517,7 +1517,7 @@ class RewindFiles(unittest.TestCase):
                       "every session checkpoints, so any user message is a restore point")
         with open(os.path.join(base, "bin", "romp-kernel")) as f:
             src = f.read()
-        self.assertIn('"rewindFiles")', src[src.index("ID_OPS"):src.index("ID_OPS") + 700])
+        self.assertIn('"rewindFiles"', src[src.index("ID_OPS"):src.index("ID_OPS") + 700])
         self.assertIn('elif t == "rewindFiles" and msg.get("uuid"):', src)
         self.assertIn("Couldn't restore files", src, "a refusal warns the user — never a silent no-op")
 

--- a/ui/webview/mcp-panel.test.ts
+++ b/ui/webview/mcp-panel.test.ts
@@ -1,0 +1,58 @@
+// `/mcp` in a romp session used to be a dead end (the user 2026-08-05): the CLI's own panel is an
+// interactive TUI an SDK-driven session cannot render, so it replied "use a terminal". The SDK exposes
+// the same facts and repairs as designed control requests — get_mcp_status, toggle_mcp_server,
+// reconnect_mcp_server — so romp intercepts the command and renders its own panel from them. Fails
+// LOUDLY: a tmux session or a disconnected CLI is NAMED, never an empty list that reads as
+// "no servers configured". No jsdom harness → source pins (the repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const RENDER = fs.readFileSync(path.join(ROOT, "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "styles.css"), "utf8");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+const BACKEND = fs.readFileSync(path.join(ROOT, "kernel", "sdk_backend.py"), "utf8");
+const ABC = fs.readFileSync(path.join(ROOT, "kernel", "session_backend.py"), "utf8");
+
+test("the composer intercepts /mcp before it can reach the CLI", () => {
+  assert.match(RENDER, /if \(\/\^\\\/mcp\\s\*\$\/\.test\(text\)\) \{/);
+  assert.match(RENDER, /openMcpPanel\(sid\);/);
+  // the box clears like any consumed command, and the draft with it
+  assert.match(RENDER, /ta\.value = ""; composerManualH = null; ta\.style\.height = "";\s*\n\s*drafts\.delete\(sid\); persistDrafts\(\);\s*\n\s*openMcpPanel\(sid\);/);
+});
+
+test("the panel reads the SDK's designed control requests through the kernel", () => {
+  // backend: status + the two repairs, each bounded and loud on failure
+  assert.ok(BACKEND.includes("def mcp_status(self):"));
+  assert.ok(BACKEND.includes("self.client.get_mcp_status()"));
+  assert.ok(BACKEND.includes("self.client.toggle_mcp_server(name, enabled)"));
+  assert.ok(BACKEND.includes("self.client.reconnect_mcp_server(name)"));
+  assert.ok(BACKEND.includes("asyncio.run_coroutine_threadsafe(coro_fn(), self.loop)"),
+    "runs on the session's own loop, bounded wait on the kernel thread");
+  // kernel: a GET for the list, a WS op for the actions
+  assert.ok(KERNEL.includes('if p == "/mcp":'));
+  assert.ok(KERNEL.includes('json.dumps({"servers": servers, "error": err})'));
+  assert.ok(KERNEL.includes('elif t == "mcpAction" and msg.get("server"):'));
+  assert.ok(KERNEL.includes('"mcpAction")'), "routes by session id like every session op");
+  // tmux says so explicitly rather than returning a misleading empty list
+  assert.ok(ABC.includes("def mcp_status(self, sid: str):"));
+  assert.ok(ABC.includes("use /mcp there"));
+});
+
+test("every action refetches — the panel never shows an optimistic row", () => {
+  assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "mcpAction", id: sid, server: srv\.name, action, enabled \}\);/);
+  assert.match(RENDER, /b\.disabled = true; b\.textContent = busy;/);   // acknowledged before the round-trip
+  assert.match(RENDER, /if \(body && mcpPanelSid\) loadMcpPanel\(mcpPanelSid, body\);/);
+  assert.match(RENDER, /if \(m\.error\) warnToast\("MCP " \+ \(m\.server \|\| "server"\) \+ ": " \+ m\.error\);/);
+});
+
+test("a refusal is named, and the panel borrows the confirm overlay's chrome", () => {
+  assert.match(RENDER, /if \(d\?\.error\) \{/);
+  assert.match(RENDER, /"No MCP servers configured for this session\."/);
+  assert.match(RENDER, /el\("div", "picker-overlay confirm-overlay"\); overlay\.id = "mcp-panel";/);
+  // layout + status tint only — the fonts come from .confirm-detail (the consistent-fonts rule)
+  assert.match(CSS, /\.mcp-list \{ display: flex; flex-direction: column;/);
+  assert.doesNotMatch(CSS, /\.mcp-(row|name|status|meta)[^{]*\{[^}]*font-size/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4553,6 +4553,79 @@ function showConfirm(title: string, detail: string, buttons: Array<{ label: stri
   document.addEventListener("keydown", onKey, true);
   (actions.firstElementChild as HTMLElement | null)?.focus();
 }
+// THE MCP PANEL (the user 2026-08-05). `/mcp` in a romp session used to be a dead end: the CLI's own
+// panel is an interactive TUI an SDK-driven session cannot render, so it replied "use a terminal". The
+// SDK exposes the same facts and repairs as control requests (get_mcp_status / toggle_mcp_server /
+// reconnect_mcp_server), so this renders them: one row per server with its status dot, tool count, the
+// error when it failed, and the two actions. Every action refetches — the panel only ever shows the
+// CLI's own status, never an optimistic guess. Reuses the confirm overlay's chrome (no new styles).
+let mcpPanelSid: string | null = null;
+function openMcpPanel(sid: string): void {
+  mcpPanelSid = sid;
+  document.getElementById("mcp-panel")?.remove();
+  const overlay = el("div", "picker-overlay confirm-overlay"); overlay.id = "mcp-panel";
+  const box = el("div", "picker-box confirm-box mcp-box");
+  const h = el("div", "confirm-title"); h.textContent = "MCP servers";
+  const body = el("div", "confirm-detail mcp-list");
+  body.textContent = "Loading…";
+  const actions = el("div", "confirm-actions");
+  const closeBtn = el("button", "picker-action confirm-btn"); closeBtn.textContent = "Close";
+  closeBtn.addEventListener("click", () => { mcpPanelSid = null; overlay.remove(); document.removeEventListener("keydown", onKey, true); });
+  actions.appendChild(closeBtn);
+  box.append(h, body, actions);
+  overlay.appendChild(box);
+  const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.stopPropagation(); closeBtn.click(); } };
+  overlay.addEventListener("click", (e) => { if (e.target === overlay) closeBtn.click(); });
+  document.addEventListener("keydown", onKey, true);
+  document.body.appendChild(overlay);
+  loadMcpPanel(sid, body);
+}
+
+function loadMcpPanel(sid: string, body: HTMLElement): void {
+  fetch(kernelUrl("/mcp?sid=" + encodeURIComponent(sid)), { cache: "no-store" })
+    .then((r) => r.json())
+    .then((d) => {
+      if (mcpPanelSid !== sid) return;   // panel closed (or reopened for another tab) while loading
+      body.textContent = "";
+      const servers: any[] = Array.isArray(d?.servers) ? d.servers : [];
+      // FAIL LOUDLY: a refusal (tmux session, disconnected CLI) is named, never an empty list that
+      // reads as "no servers configured".
+      if (d?.error) {
+        const e = el("div", "mcp-err"); e.textContent = String(d.error); body.appendChild(e);
+      }
+      if (!servers.length) {
+        if (!d?.error) { const n = el("div", "mcp-none"); n.textContent = "No MCP servers configured for this session."; body.appendChild(n); }
+        return;
+      }
+      for (const srv of servers) {
+        const row = el("div", "mcp-row");
+        const dot = el("span", "mcp-dot mcp-" + String(srv.status || "unknown"));
+        const name = el("span", "mcp-name"); name.textContent = String(srv.name || "?");
+        const st = el("span", "mcp-status"); st.textContent = String(srv.status || "unknown");
+        const tools = Array.isArray(srv.tools) ? srv.tools.length : null;
+        const meta = el("span", "mcp-meta");
+        meta.textContent = [tools != null ? tools + " tool" + (tools === 1 ? "" : "s") : "",
+                            srv.scope ? String(srv.scope) : ""].filter(Boolean).join(" · ");
+        row.append(dot, name, st, meta);
+        const disabled = String(srv.status) === "disabled";
+        const act = (action: string, enabled: boolean, label: string, busy: string) => {
+          const b = el("button", "mcp-act") as HTMLButtonElement;
+          b.textContent = label;
+          b.addEventListener("click", () => {
+            b.disabled = true; b.textContent = busy;   // acknowledge before the round-trip
+            vscodeApi?.postMessage({ type: "mcpAction", id: sid, server: srv.name, action, enabled });
+          });
+          row.appendChild(b);
+        };
+        if (!disabled) act("reconnect", true, "Reconnect", "Reconnecting…");
+        act("toggle", disabled, disabled ? "Enable" : "Disable", disabled ? "Enabling…" : "Disabling…");
+        if (srv.error) { const er = el("div", "mcp-err"); er.textContent = String(srv.error); row.appendChild(er); }
+        body.appendChild(row);
+      }
+    })
+    .catch((e) => { if (mcpPanelSid === sid) body.textContent = "Couldn't load MCP status: " + e; });
+}
+
 function closeConfirm(value: string | null) {
   const o = document.getElementById("confirm");
   if (o) {
@@ -7753,6 +7826,11 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "dropCitationsAll") {
     if (composerCitations.size) { composerCitations.clear(); persistDrafts(); renderComposerChips(activeId); }
   }
+  else if (m.type === "mcpResult") {
+    if (m.error) warnToast("MCP " + (m.server || "server") + ": " + m.error);
+    const body = document.querySelector("#mcp-panel .mcp-list") as HTMLElement | null;
+    if (body && mcpPanelSid) loadMcpPanel(mcpPanelSid, body);   // refetch — never an optimistic row
+  }
   else if (m.type === "nextTab") cycleTab(1);
   else if (m.type === "prevTab") cycleTab(-1);
   else if (m.type === "warn" && typeof m.text === "string" && m.text) {
@@ -8030,6 +8108,16 @@ function setupComposer() {
     // session's open cards with it. The composer sees the command BEFORE it runs — the one
     // interception point — so open cards put an explicit confirm between Enter and the drop
     // (the user 2026-07-27). Cancel keeps the text in the box; no open cards → no modal.
+    // `/mcp` NEVER reaches the CLI (the user 2026-08-05): its own panel is an interactive TUI an
+    // SDK session can't render, so the CLI answers "use a terminal". romp shows the same facts from
+    // the SDK's control requests instead — status, enable/disable, reconnect. Intercepted here, the
+    // one point that sees a command before it runs (the /clear precedent below).
+    if (/^\/mcp\s*$/.test(text)) {
+      ta.value = ""; composerManualH = null; ta.style.height = "";
+      drafts.delete(sid); persistDrafts();
+      openMcpPanel(sid);
+      return;
+    }
     const dropDetail = isClearCmd(text) ? clearConfirmDetail(openTopTitles(ledgers.get(sid)?.tree)) : null;
     if (dropDetail) {
       showConfirm("Clear this conversation?", dropDetail,

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2133,3 +2133,24 @@ body.picker-lifted > #picker { align-items: center; padding: 24px 16px; }
    and hid the sessions to announce that one machine had gone away. The drop now flashes the rail's
    network glyph — .rn-drop / @keyframes rnet-drop, in the shell the kernel serves — and the steady state
    stays on .tab.host-off and .host-prefix.off above, which cost no space to begin with.) */
+
+/* the MCP panel (the user 2026-08-05): rows inside the confirm overlay's chrome — no new fonts, the
+   sizes come from .confirm-detail; only layout and the status tint are new */
+.mcp-box { min-width: 420px; max-width: 620px; }
+.mcp-list { display: flex; flex-direction: column; gap: 8px; max-height: 60vh; overflow-y: auto; text-align: left; }
+.mcp-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 6px;
+  background: var(--code-bg); border: 1px solid var(--box-border); }
+.mcp-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--dim); flex: 0 0 auto; }
+.mcp-connected { background: var(--st-ready-bg); }
+.mcp-failed, .mcp-needs-auth { background: #E5534B; }
+.mcp-pending { background: var(--st-working-bg); }
+.mcp-disabled { background: var(--dim); }
+.mcp-name { font-weight: 600; }
+.mcp-status, .mcp-meta { color: var(--dim); }
+.mcp-act { margin-left: auto; padding: 2px 8px; border-radius: 6px; cursor: pointer;
+  border: 1px solid var(--box-border); background: transparent; color: var(--fg); }
+.mcp-act + .mcp-act { margin-left: 0; }
+.mcp-act:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+.mcp-act:disabled { opacity: 0.55; cursor: default; }
+.mcp-err { flex: 1 1 100%; color: #E5534B; }
+.mcp-none { color: var(--dim); }


### PR DESCRIPTION
Reported today: typing `/mcp` in the romp UI just says to use the terminal.

That's the CLI refusing honestly — its `/mcp` is an interactive TUI panel an SDK-driven session can't render. But the SDK exposes the same facts and repairs as designed control requests (`get_mcp_status`, `toggle_mcp_server`, `reconnect_mcp_server` — from the earlier unexposed-features audit), so romp can answer it itself.

The composer now intercepts `/mcp` at the same before-it-runs point `/clear` uses, and opens a panel: one row per server with a status tint (connected / pending / failed / needs-auth / disabled), tool count, scope, and the error text when it failed, plus **Reconnect** and **Enable/Disable** per server.

Mechanics per the repo's rules: each control request runs on the session's own event loop with a bounded wait, never blocking the kernel thread indefinitely. Every action **refetches** the status, so the panel only ever shows the CLI's own truth rather than an optimistic row, and each button acknowledges (disabled + "Reconnecting…") before the round-trip. Failures are named, not swallowed — a tmux session or a disconnected CLI produces an explicit line in the panel (a terminal session still has the CLI's own `/mcp`), never an empty list that would read as "no servers configured". The panel borrows the confirm overlay's chrome and adds layout plus the status tint only — no new fonts.

Tests: `mcp-panel.test.ts` (intercept, control-request wiring through kernel + backend + ABC, refetch-not-optimistic, named refusals, borrowed chrome) and an ID_OPS pin relaxed for the new op. Suites green locally (3915 pytest, 1658 node).

Kernel-side halves take effect on the next kernel restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)