### PR TITLE
A spawning session says Opening with pulsing dots, never Working

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11704,6 +11704,12 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
         # compaction stalls. After that, blocked is the strongest signal — the turn ended in an error, so it
         # beats the live tmux states (the session can't simultaneously be at a permission prompt mid-error).
         chip = _session_chip(sid, sess["path"], session, tm, now)   # THE shared derivation — identical to the timeline lane (the user 2026-07-03)
+        # A session whose transcript DOESN'T EXIST YET is OPENING, whatever the snapshot claims (the
+        # user 2026-08-05: a just-spawned tab said "Working" over a clock with no honest base). The
+        # transcript's first record is the deciding event: it lands, discover() sees it, and the normal
+        # derivation takes over. Never for an override render (a closed episode's path is historical).
+        if chip in ("working", "ready") and not path_override and not os.path.exists(sess["path"]):
+            chip = "opening"
         faded = chip == "ready" and bool(tm["since"]) and now - tm["since"] > 3600
         # apiTooLong distinguishes a "prompt is too long" block (on YOU → red dashed tab) from a TRANSIENT API
         # error (auto-retrying → the tab renders amber/retrying, not alarm-red). chip stays "blocked" either way

--- a/ui/webview/interrupt-ux.test.ts
+++ b/ui/webview/interrupt-ux.test.ts
@@ -28,7 +28,7 @@ test("the stop button acknowledges its click instantly: chip flips, button + tim
 });
 
 test("INTERRUPTING is a first-class chip state: labeled, styled, timerless, buttonless", () => {
-  assert.match(SRC, /"interrupting";/, "in the ChipState union");
+  assert.match(SRC, /"interrupting" \| "opening";/, "in the ChipState union (opening joined it 2026-08-05)");
   assert.match(SRC, /interrupting: "Interrupting…",/);
   // the generic chip branch renders it; the stop button is drawn for working/compacting AND the stuck
   // retrying/blocked states — but NEVER for interrupting (the stop is already in flight)

--- a/ui/webview/opening-state.test.ts
+++ b/ui/webview/opening-state.test.ts
@@ -1,0 +1,39 @@
+// A just-opened session said "Working" over an epoch-sized clock while its transcript didn't exist yet
+// (the user 2026-08-05, who wanted "opening" with animated dots until it's ready). The fix is layered:
+// the KERNEL reports state "opening" for a spawned session whose transcript isn't on disk (the first
+// record is the deciding event — discover() then takes over), and the CLIENT shows the same line for a
+// tab whose session payload hasn't arrived at all (which previously left the PREVIOUS tab's statusline
+// standing). Same in-progress line treatment as compacting, dots in the accent per the loader rule.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const RENDER = fs.readFileSync(path.join(ROOT, "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "styles.css"), "utf8");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+
+test("the kernel reports OPENING while the transcript doesn't exist — never a working chip on a broken clock", () => {
+  assert.ok(KERNEL.includes('if chip in ("working", "ready") and not path_override and not os.path.exists(sess["path"]):'));
+  assert.ok(KERNEL.includes('chip = "opening"'));
+});
+
+test("the statusline shows Opening + dots for BOTH the pre-payload tab and the kernel's opening state", () => {
+  assert.match(RENDER, /function openingLine\(\): HTMLElement/);
+  // pre-payload: a placeholder tab used to leave the PREVIOUS tab's statusline standing
+  assert.match(RENDER, /if \(activeId && !s\) \{[\s\S]{0,700}?sl\.replaceChildren\(openingLine\(\)\);\s*\n\s*return;/);
+  // kernel-reported opening rides the same line
+  assert.match(RENDER, /s\.status\.state === "opening"/);
+  assert.match(RENDER, /"opening"/);
+  assert.ok(RENDER.includes('opening: "Opening…",'), "the chip vocabulary knows the state");
+  // three staggered accent dots — the loader idiom's smallest form, no new fonts
+  assert.match(CSS, /\.opening-line-dots span \{ width: 4px; height: 4px; border-radius: 50%; background: var\(--accent\);/);
+  assert.match(CSS, /@keyframes opening-line-pulse/);
+  assert.match(CSS, /\.opening-line \{ color: var\(--accent\); \}/);
+});
+
+test("the MCP panel names a stale kernel instead of a raw parse error (the user 2026-08-05)", () => {
+  assert.match(RENDER, /this romp kernel predates the MCP panel — restart romp to update it/);
+  assert.match(RENDER, /\(\(e && e\.message\) \|\| e\)/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -195,7 +195,7 @@ type ChatEvent = (
 
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
-type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
+type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
 interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
@@ -4583,7 +4583,9 @@ function openMcpPanel(sid: string): void {
 
 function loadMcpPanel(sid: string, body: HTMLElement): void {
   fetch(kernelUrl("/mcp?sid=" + encodeURIComponent(sid)), { cache: "no-store" })
-    .then((r) => r.json())
+    // a kernel from before this panel 404s here, and .json() on the error page read as a bare "parse
+    // error" (the user 2026-08-05) — name the actual situation instead
+    .then((r) => { if (!r.ok) throw new Error("this romp kernel predates the MCP panel — restart romp to update it"); return r.json(); })
     .then((d) => {
       if (mcpPanelSid !== sid) return;   // panel closed (or reopened for another tab) while loading
       body.textContent = "";
@@ -4623,7 +4625,7 @@ function loadMcpPanel(sid: string, body: HTMLElement): void {
         body.appendChild(row);
       }
     })
-    .catch((e) => { if (mcpPanelSid === sid) body.textContent = "Couldn't load MCP status: " + e; });
+    .catch((e) => { if (mcpPanelSid === sid) body.textContent = "Couldn't load MCP status: " + ((e && e.message) || e); });
 }
 
 function closeConfirm(value: string | null) {
@@ -6802,6 +6804,7 @@ const CHIP_LABEL: Record<ChipState, string> = {
   idle: "Idle", closed: "Closed", compacting: "Compacting", clearing: "Clearing", blocked: "API error",
   retrying: "API retrying…",   // a live session stalled on an API rate-limit/overload auto-retry (api 2026-06-23)
   interrupting: "Interrupting…",   // stop sent, turn not yet settled (the user 2026-07-02) — clears to READY on its own
+  opening: "Opening…",             // spawned, transcript not on disk yet — the first record clears it (the user 2026-08-05)
 };
 
 // A stop/interrupt button that lives beside the state badge in the statusline (the user 2026-06-19):
@@ -6837,10 +6840,30 @@ function stopButton(state?: ChipState): HTMLElement {
   return btn;
 }
 
+// The "Opening session" line + three staggered accent dots (the loading-state rule's small form): shown
+// while a tab has NO session payload yet AND while the kernel itself reports state "opening" (spawned,
+// transcript not on disk). Both clear on real events — the first payload, the first record.
+function openingLine(): HTMLElement {
+  const c = el("span", "compacting-line opening-line");
+  c.appendChild(document.createTextNode("Opening session"));
+  const dots = el("span", "opening-line-dots");
+  for (let i = 0; i < 3; i++) dots.appendChild(el("span"));
+  c.appendChild(dots);
+  return c;
+}
+
 function updateStatusline() {
   const sl = document.getElementById("statusline");
   const s = activeId ? sessions.get(activeId) : null;
-  if (!sl || !s) return;
+  if (!sl) return;
+  if (activeId && !s) {
+    // the tab is a loading placeholder (its session payload hasn't arrived) — the statusline said
+    // whatever the PREVIOUS tab said, or a spawn stub's "Working" over a broken clock (the user
+    // 2026-08-05, who wanted "opening" and animated dots until it's ready)
+    sl.replaceChildren(openingLine());
+    return;
+  }
+  if (!s) return;
   sl.replaceChildren();
   // Left: the state chip — WORKING gets a sine color-pulse + elapsed timer; idle
   // states get the plain chip (no timer). Right: model + effort · ctx%, always.
@@ -6875,6 +6898,8 @@ function updateStatusline() {
     const c = el("span", "compacting-line");   // same in-progress line treatment as compacting (one style per info type)
     c.textContent = "⟳ Clearing conversation…";
     sl.appendChild(c);
+  } else if (s.status.state === "opening") {
+    sl.appendChild(openingLine());             // spawned, transcript not on disk yet — dots until the first record
   } else {
     const chip = el("span", `chip chip-${s.status.state}`);
     chip.textContent = CHIP_LABEL[s.status.state] ?? (s.status.state[0].toUpperCase() + s.status.state.slice(1).toLowerCase());

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1355,6 +1355,15 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .ask-warn { color: var(--st-awaiting-bg); font-weight: 700; margin-bottom: 9px; line-height: 1.4; }
 
 .compacting-line { color: var(--st-compacting-bg); font-weight: 600; }
+/* "Opening session" + three staggered pulsing dots (the user 2026-08-05) — the loader idiom's smallest
+   form: accent-colored, event-cleared (first payload / first record), same line style as compacting */
+.opening-line { color: var(--accent); }
+.opening-line-dots { display: inline-flex; gap: 3px; margin-left: 5px; vertical-align: baseline; }
+.opening-line-dots span { width: 4px; height: 4px; border-radius: 50%; background: var(--accent);
+  animation: opening-line-pulse 1.2s ease-in-out infinite; }
+.opening-line-dots span:nth-child(2) { animation-delay: 0.2s; }
+.opening-line-dots span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes opening-line-pulse { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
 
 /* ---------- to-do checklist (Claude Code Task list, folded from TaskCreate/Update) ---------- */
 .turn-todo { padding-top: 6px; padding-bottom: 6px; }


### PR DESCRIPTION
Two reports from today's first use, one PR since both are small UI honesty fixes:

**Opening state.** A just-spawned session's statusline said `Working` with a garbage clock (the spawn stub has no honest timer base), and a tab whose session payload hadn't arrived at all silently kept the *previous* tab's statusline. Now: the kernel reports `opening` for a spawned session whose transcript isn't on disk yet — the first record landing is the deciding event, after which the normal derivation takes over — and the client renders `Opening session` with three staggered accent-pulse dots (the loader idiom's smallest form, same in-progress line treatment as compacting) for both that state and the pre-payload window. The dots class is `opening-line-dots`, deliberately distinct from the long-removed opening *modal*'s banned `opening-dots` CSS, so that old guard keeps its exact meaning; the ChipState union pin updated for the new member.

**MCP panel error naming.** `/mcp` on a kernel that predates #215 404s, and `.json()` on the error page surfaced as a bare "parse error". The panel now says what's actually happening: "this romp kernel predates the MCP panel — restart romp to update it".

Tests: `opening-state.test.ts` (kernel gate, both client windows, dots CSS, MCP naming); suites green locally (3915 pytest, 1661 node); embedded JS syntax-checked.

Kernel half effective on the next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)