### PR TITLE
An off-window send enters at track height, not a left-edge lane hug

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2991,10 +2991,16 @@ class TimelinePanel {
       if (vidx[mm.fromId] == null || vidx[mm.toId] == null) return;
       if (execAt(mm) < t0 || mm.sent > t1) return;
       const sLane = vidx[mm.fromId], rLane = vidx[mm.toId];
-      const xs = x(Math.max(mm.sent, t0)), ys = laneY(sLane), xe = x(execAt(mm)), ye = laneY(rLane), col = colorOf(mm.fromId);
+      const offL = mm.sent < t0;   // sent BEFORE the visible window — only the delivery is in view
+      const xs = x(offL ? t0 : mm.sent), ys = laneY(sLane), xe = x(execAt(mm)), ye = laneY(rLane), col = colorOf(mm.fromId);
       const dir = (ys < ye) ? 1 : -1, track = ye - dir * MSG_DROP;
       const xc = crossX(sLane, rLane, xs, xe, obstacles);
-      const pts = (xc > xs + 0.5) ? [{ x: xs, y: ys }, { x: xc, y: ys }, { x: xc, y: track }, { x: xe, y: track }, { x: xe, y: ye }]
+      // An off-window send used to CLAMP to the left edge and hug the sender's lane all the way to the
+      // crossing — which read as "sent at the window's start", a send time that never existed (the user
+      // 2026-08-06: "a timing issue maybe?"). Enter from the edge at the crossing track height instead,
+      // so an off-screen send reads as exactly that; the tooltip carries the true send time.
+      const pts = offL ? [{ x: xs, y: track }, { x: xe, y: track }, { x: xe, y: ye }]
+                : (xc > xs + 0.5) ? [{ x: xs, y: ys }, { x: xc, y: ys }, { x: xc, y: track }, { x: xe, y: track }, { x: xe, y: ye }]
                                   : [{ x: xs, y: ys }, { x: xs, y: track }, { x: xe, y: track }, { x: xe, y: ye }];
       const d = roundedPath(pts, CORNER);
       const lineAttr = { d, fill: 'none', stroke: col, 'stroke-width': MSG_W0, opacity: mm.pending ? 0.4 : 0.5, 'stroke-linecap': 'round', 'stroke-linejoin': 'round' };

--- a/ui/timeline-render.test.ts
+++ b/ui/timeline-render.test.ts
@@ -704,13 +704,13 @@ test("a skeleton-only update preserves the bars from the last applyBars (no per-
 // elbow (two+ corners). The tooltip carries the true send time either way.
 test("an off-window send enters at track height — never a sender-lane hug from the left edge", () => {
   const panel: any = new TimelinePanel(makeNode("div"));
-  const d0 = synthData();
+  const d0: any = synthData();   // messages: [] infers never[] — the synthetic payload is untyped by design
   d0.sessions[0].color = "#f7768e";                                  // sender distinct, so its connector is findable
   d0.messages = [
     { id: "m-old", fromId: "S1", toId: "S2", from: "alpha", to: "beta",
-      sent: d0.now - 500_000, exec: d0.now - 30, pending: false, summary: "sent long before the window" },
+      sent: d0.now - 500_000, exec: d0.now - 30, pending: false, summary: "sent long before the window" } as any,
     { id: "m-new", fromId: "S2", toId: "S1", from: "beta", to: "alpha",
-      sent: d0.now - 40, exec: d0.now - 10, pending: false, summary: "sent inside the window" },
+      sent: d0.now - 40, exec: d0.now - 10, pending: false, summary: "sent inside the window" } as any,
   ];
   panel.update(d0);
   const paths: any[] = [];

--- a/ui/timeline-render.test.ts
+++ b/ui/timeline-render.test.ts
@@ -695,3 +695,32 @@ test("a skeleton-only update preserves the bars from the last applyBars (no per-
   panel.update(next);
   assert.deepEqual(panel.data.turns, full.turns, "the prior bars survive a lanes-only update (carried over)");
 });
+
+// A message SENT before the visible window used to clamp its start to the left edge and hug the
+// sender's lane all the way to the crossing — reading as "sent at the window's start", a send time
+// that never existed (the user 2026-08-06: a connector spanning the whole window, "a timing issue
+// maybe?"). An off-window send now enters from the edge at the crossing track height: structurally a
+// SINGLE-corner path (track horizontal → one turn → arrival), where an in-window send keeps the full
+// elbow (two+ corners). The tooltip carries the true send time either way.
+test("an off-window send enters at track height — never a sender-lane hug from the left edge", () => {
+  const panel: any = new TimelinePanel(makeNode("div"));
+  const d0 = synthData();
+  d0.sessions[0].color = "#f7768e";                                  // sender distinct, so its connector is findable
+  d0.messages = [
+    { id: "m-old", fromId: "S1", toId: "S2", from: "alpha", to: "beta",
+      sent: d0.now - 500_000, exec: d0.now - 30, pending: false, summary: "sent long before the window" },
+    { id: "m-new", fromId: "S2", toId: "S1", from: "beta", to: "alpha",
+      sent: d0.now - 40, exec: d0.now - 10, pending: false, summary: "sent inside the window" },
+  ];
+  panel.update(d0);
+  const paths: any[] = [];
+  (function walk(n: any) { for (const c of n.children || []) { if (c.tag === "path") paths.push(c); walk(c); } })(panel.svg);
+  const conns = paths.filter((p) => p._attrs && p._attrs.fill === "none" && p._attrs.opacity === 0.5);
+  const oldConn = conns.find((p) => p._attrs.stroke === "#f7768e");
+  const newConn = conns.find((p) => p._attrs.stroke === "#7aa2f7");
+  assert.ok(oldConn, "the off-window message still draws its connector");
+  assert.ok(newConn, "the in-window message draws too");
+  const corners = (d: string) => (String(d).match(/Q /g) || []).length;
+  assert.equal(corners(oldConn._attrs.d), 1, "off-window send: track entry + ONE corner up to the arrival");
+  assert.ok(corners(newConn._attrs.d) >= 2, "in-window send keeps the full elbow from its true send point");
+});


### PR DESCRIPTION
Reported today with a screenshot: a message connector spanning the whole timeline window along the sender's lane before rising at the recipient — "a timing issue maybe?"

The timing was fine; the drawing lied. A message **sent before the visible window** (delivered inside it — e.g. parked mail, or simply an old send) clamped its start x to the window's left edge (`Math.max(mm.sent, t0)`) and then routed normally: a horizontal hug of the sender's lane from the very edge to the crossing point, which reads as "sent at the window's start" — a send time that never existed.

An off-window send now enters from the edge at the **crossing track height** (the between-lanes channel), so it reads as exactly what it is: a message arriving from off-screen. In-window sends keep their full elbow from the true send point, and the hover tooltip carries the real send/delivery clock either way.

Test: an executed geometry case in the headless draw() harness — the off-window connector is structurally a single-corner path while the in-window one keeps two-plus corners. Suites green locally (3915 pytest, 1662 node).

Timeline is the shared one-file view, so Obsidian and the web get it together; effective on reload (web serves it live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)