### PR TITLE
A relayed connector lands on the recipient's process turn

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13852,7 +13852,7 @@ def _postal_messages(now, alive_sids, id2name):
         if o.get("ev") == "sent" and o.get("id"):
             sent[o["id"]] = o
         elif o.get("ev") == "exec" and o.get("id"):
-            execd[o["id"]] = o.get("t")
+            execd[o["id"]] = (o.get("t"), o.get("dmid"))   # dmid: the recipient-side delivery mid (relayed mail)
         elif o.get("ev") == "unexec" and o.get("id"):    # a drain that CLAIMED the mail then rolled back
             execd.pop(o["id"], None)                     # (postal restore) — it never reached the recipient
     cutoff, out = now - TL_HORIZON, []
@@ -13864,12 +13864,16 @@ def _postal_messages(now, alive_sids, id2name):
         if not f or not t or (f not in alive_sids and t not in alive_sids) or f == t or not st or st < cutoff:
             continue
         ex = execd.get(mid)
-        out.append({"id": mid, "fromId": f, "toId": t,
-                    "from": id2name.get(f, e.get("from", "")), "to": id2name.get(t, ""),
-                    "fromOrig": e.get("from", id2name.get(f, f)),
-                    "sent": st, "exec": ex if ex else st, "hasExec": ex is not None,
-                    "pending": ex is None and (now - st) < MSG_INFLIGHT_MAX,
-                    "text": (e.get("body", "") or "").strip()[:240], "summary": msgsum.get(mid)})
+        ex_t, ex_dmid = (ex if isinstance(ex, tuple) else (ex, None))
+        row = {"id": mid, "fromId": f, "toId": t,
+               "from": id2name.get(f, e.get("from", "")), "to": id2name.get(t, ""),
+               "fromOrig": e.get("from", id2name.get(f, f)),
+               "sent": st, "exec": ex_t if ex_t else st, "hasExec": ex_t is not None,
+               "pending": ex_t is None and (now - st) < MSG_INFLIGHT_MAX,
+               "text": (e.get("body", "") or "").strip()[:240], "summary": msgsum.get(mid)}
+        if ex_dmid:
+            row["dmid"] = ex_dmid   # lets the MERGED view join a relayed connector to the remote turn's mids
+        out.append(row)
     out.sort(key=lambda m: m["sent"])
     return out
 

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -307,7 +307,9 @@ def read_box(sid, consume):
         if consume:
             f.rename(mb / "cur" / f.name)
             _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "exec", "id": f.name})
-            _queue_read_receipt(meta)                # cross-host mail: the sender's host learns it was read
+            _queue_read_receipt(meta, dmid=f.name)   # cross-host mail: the sender's host learns it was read
+            #   dmid = THIS host's delivery mid — the id the recipient's transcript markers carry, so the
+            #   sender's timeline can join the connector to the true process turn (the user 2026-08-06)
     if consume:
         _mark_pending(sid)         # cleared the box -> drop the marker (no-op if more arrived)
     return out
@@ -350,7 +352,7 @@ def restore(sid, mid):
     _mark_pending(sid)                   # new/ is non-empty again -> raise the marker
     return True
 
-def _queue_read_receipt(meta, unread=False):
+def _queue_read_receipt(meta, unread=False, dmid=""):
     """Cross-host read backflow: mail delivered over the peer bus carries X-Peer-Mid/X-Peer-Via
     (see deliver); consuming it queues {mid, t} into the readbox for the DIRECT peer it arrived
     from, so the sender's host can finally log the exec its receipt view joins on. An `origin`
@@ -362,6 +364,8 @@ def _queue_read_receipt(meta, unread=False):
     if not pm or not via:
         return
     rec = {"mid": pm, "t": int(time.time())}
+    if dmid:
+        rec["dmid"] = dmid   # the recipient-side delivery mid — the sender's timeline joins turns on it
     if unread:
         rec["unread"] = True
     oh = meta.get("x-from-host", "")
@@ -1683,12 +1687,18 @@ def _read_arrived(host, r):
     if origin and origin != self_host():
         if PEERS.get(origin):                    # only toward a peer the kernel told us about
             fwd = {"mid": mid, "t": r.get("t")}
+            if r.get("dmid"):
+                fwd["dmid"] = r.get("dmid")
             if r.get("unread"):
                 fwd["unread"] = True
             readbox_put(origin, fwd)
         return
     ev = "unexec" if r.get("unread") else "exec"
-    _tl_append("messages.jsonl", {"t": int(r.get("t") or time.time()), "ev": ev, "id": mid})
+    row = {"t": int(r.get("t") or time.time()), "ev": ev, "id": mid}
+    d = str((r or {}).get("dmid") or "")
+    if _safe_id(d):
+        row["dmid"] = d   # the recipient's own delivery mid → the timeline's exact turn join (2026-08-06)
+    _tl_append("messages.jsonl", row)
 
 def _bounce_apply(host, b):
     """A peer refused one of our parked messages — return it to the SENDER as a bus-authored note,

--- a/tests/test_relay_exec_dmid.py
+++ b/tests/test_relay_exec_dmid.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""A relayed message's timeline connector landed at the read-receipt time — the relay handoff — never
+at the recipient's true process turn, because the join key (the RECIPIENT's own delivery mid, which is
+what its transcript markers record) never flowed back to the sender (the user 2026-08-06). The read
+receipt now carries it: read_box stamps dmid at consume, the backflow forwards it hop-by-hop, and
+_read_arrived logs it beside the exec row so the sender's timeline payload can hand it to the merged
+view for the exact turn join. Synthetic only — hermetic temp state, placeholder mids, TESTHOST."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+_SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
+Path(_SESS).write_text(json.dumps([{"id": "sess-web", "name": "web", "dir": "/tmp/notes-api",
+                                    "state": "waiting", "working": ""}]))
+os.environ["ROMP_SESSIONS_FILE"] = _SESS
+ps = SourceFileLoader("romp_postal_dmid", os.path.join(BIN, "romp-postal-service")).load_module()
+
+
+class ReceiptCarriesDeliveryMid(unittest.TestCase):
+    def test_consuming_relayed_mail_queues_a_dmid_receipt(self):
+        # relayed-in mail: deliver with the relay headers, then the session reads its box
+        ps.deliver("sess-web", "api", "id-api", "please review the schema", kind="question",
+                   from_host="TESTHOST", relay_mid="px-1111.2222_3.TESTHOST", relay_via="TESTHOST")
+        out = ps.read_box("sess-web", consume=True)
+        self.assertEqual(len(out), 1)
+        dmid = out[0]["id"]                                  # the delivery mid = the maildir name = the marker id
+        recs = list((ps.READBOX / "TESTHOST").glob("*.json"))
+        self.assertEqual(len(recs), 1, "one receipt queued for the direct peer")
+        rec = json.loads(recs[0].read_text())
+        self.assertEqual(rec["mid"], "px-1111.2222_3.TESTHOST")
+        self.assertEqual(rec["dmid"], dmid, "the receipt names the RECIPIENT-side delivery mid")
+
+    def test_read_arrived_logs_the_dmid_beside_the_exec(self):
+        ps._read_arrived("TESTHOST", {"mid": "px-9999.8888_7.TESTHOST", "t": 1786000000,
+                                      "dmid": "1786000000.11111_22.TESTHOST"})
+        rows = [json.loads(l) for l in
+                (ps.TLDIR / "messages.jsonl").read_text().splitlines() if l]
+        row = next(r for r in rows if r.get("id") == "px-9999.8888_7.TESTHOST")
+        self.assertEqual(row["ev"], "exec")
+        self.assertEqual(row["dmid"], "1786000000.11111_22.TESTHOST")
+
+    def test_the_kernel_payload_hands_dmid_to_the_merged_view(self):
+        with open(os.path.join(BIN, "romp-kernel")) as f:
+            src = f.read()
+        self.assertIn('execd[o["id"]] = (o.get("t"), o.get("dmid"))', src)
+        self.assertIn('row["dmid"] = ex_dmid', src, "the connector carries the join key to the view")
+        view = open(os.path.join(os.path.dirname(BIN), "ui", "romp-timeline-view.js")).read()
+        self.assertIn("midStart[mm.toId + '|' + (mm.dmid || '')]", view,
+                      "the merged view joins on id OR dmid — remote lanes included")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2366,6 +2366,24 @@ class TimelinePanel {
     // pending (queued / in-flight, not yet worked) it rides the live `now` edge (nowS); once processed
     // the data carries a FIXED past time so it can never equal now again (anti-"perpetual-just-landing").
     const execAt = (mm) => mm.pending ? nowS : mm.exec;
+    // RELAYED mail's exec refinement (the user 2026-08-06): a cross-host message's true process-start
+    // lives in the RECIPIENT's turns, which only meet the sender's connector HERE, in the merged view —
+    // the kernel's own binder (_bind_message_execs) never sees a remote lane's turns. The read receipt
+    // now carries the remote's delivery mid (dmid) — exactly what the recipient's transcript markers
+    // record — so the join is exact: the earliest bar on the recipient's lane whose mids carry the
+    // message's id or dmid, its start is the landing. Idempotent for local mail (the kernel already
+    // bound those to the same bar start), and a no-match leaves the receipt time as before.
+    if (data.messages && data.messages.length) {
+      const midStart = {};
+      Object.keys(data.turns || {}).forEach((sid) => (data.turns[sid] || []).forEach((b) => {
+        (b.mids || []).forEach((mid) => { const k = sid + '|' + mid; if (!(k in midStart) || b.start < midStart[k]) midStart[k] = b.start; });
+      }));
+      data.messages.forEach((mm) => {
+        const s1 = midStart[mm.toId + '|' + (mm.id || '')], s2 = midStart[mm.toId + '|' + (mm.dmid || '')];
+        const st = (s1 != null && s2 != null) ? Math.min(s1, s2) : (s1 != null ? s1 : s2);
+        if (st != null) { mm.exec = st; mm.pending = false; }
+      });
+    }
     const startAt = (t) => t.pending ? nowS : t.start;
     // LANE IDENTITY IS THE SID (data.turns + vidx + connectors all key by session.id, since two
     // live sessions can share a name and a rename keeps the id). `name` is display-only.

--- a/ui/timeline-render.test.ts
+++ b/ui/timeline-render.test.ts
@@ -723,22 +723,24 @@ test("an off-window send enters at track height — never a sender-lane hug from
   const corners = (d: string) => (String(d).match(/Q /g) || []).length;
   assert.equal(corners(oldConn._attrs.d), 1, "off-window send: track entry + ONE corner up to the arrival");
   assert.ok(corners(newConn._attrs.d) >= 2, "in-window send keeps the full elbow from its true send point");
+});
+
 // RELAYED mail's landing binds to the recipient's true process turn in the MERGED view (the user
 // 2026-08-06: a cross-host connector landed at the read-receipt time — the relay handoff — because the
 // kernel-side binder never sees a remote lane's turns). The receipt now carries the remote's delivery
 // mid; the view joins it against every lane's bar mids, including merged remote lanes.
 test("a relayed message's exec re-binds to the recipient turn whose mids carry its dmid", () => {
   const panel: any = new TimelinePanel(makeNode("div"));
-  const d0 = synthData();
-  (d0.turns.S2[0] as any).mids = ["dm-remote-1"];                    // the recipient turn knows its delivery mid
+  const d0: any = synthData();   // messages: [] infers never[] — the synthetic payload is untyped by design
+  d0.turns.S2[0].mids = ["dm-remote-1"];                             // the recipient turn knows its delivery mid
   d0.messages = [{ id: "px-1", dmid: "dm-remote-1", fromId: "S1", toId: "S2", from: "alpha", to: "beta",
-                   sent: d0.now - 250, exec: d0.now - 20, pending: false, summary: "relayed" } as any];
+                   sent: d0.now - 250, exec: d0.now - 20, pending: false, summary: "relayed" }];
   panel.update(d0);
   assert.equal(panel.data.messages[0].exec, d0.turns.S2[0].start,
     "the landing is the recipient turn's start, not the receipt time");
-  const d1 = synthData();
+  const d1: any = synthData();
   d1.messages = [{ id: "m-local", fromId: "S1", toId: "S2", from: "alpha", to: "beta",
-                   sent: d1.now - 250, exec: d1.now - 20, pending: false, summary: "no join" } as any];
+                   sent: d1.now - 250, exec: d1.now - 20, pending: false, summary: "no join" }];
   panel.update(d1);
   assert.equal(panel.data.messages[0].exec, d1.now - 20, "no matching mids → the receipt time stands");
 });

--- a/ui/timeline-render.test.ts
+++ b/ui/timeline-render.test.ts
@@ -723,4 +723,22 @@ test("an off-window send enters at track height — never a sender-lane hug from
   const corners = (d: string) => (String(d).match(/Q /g) || []).length;
   assert.equal(corners(oldConn._attrs.d), 1, "off-window send: track entry + ONE corner up to the arrival");
   assert.ok(corners(newConn._attrs.d) >= 2, "in-window send keeps the full elbow from its true send point");
+// RELAYED mail's landing binds to the recipient's true process turn in the MERGED view (the user
+// 2026-08-06: a cross-host connector landed at the read-receipt time — the relay handoff — because the
+// kernel-side binder never sees a remote lane's turns). The receipt now carries the remote's delivery
+// mid; the view joins it against every lane's bar mids, including merged remote lanes.
+test("a relayed message's exec re-binds to the recipient turn whose mids carry its dmid", () => {
+  const panel: any = new TimelinePanel(makeNode("div"));
+  const d0 = synthData();
+  (d0.turns.S2[0] as any).mids = ["dm-remote-1"];                    // the recipient turn knows its delivery mid
+  d0.messages = [{ id: "px-1", dmid: "dm-remote-1", fromId: "S1", toId: "S2", from: "alpha", to: "beta",
+                   sent: d0.now - 250, exec: d0.now - 20, pending: false, summary: "relayed" } as any];
+  panel.update(d0);
+  assert.equal(panel.data.messages[0].exec, d0.turns.S2[0].start,
+    "the landing is the recipient turn's start, not the receipt time");
+  const d1 = synthData();
+  d1.messages = [{ id: "m-local", fromId: "S1", toId: "S2", from: "alpha", to: "beta",
+                   sent: d1.now - 250, exec: d1.now - 20, pending: false, summary: "no join" } as any];
+  panel.update(d1);
+  assert.equal(panel.data.messages[0].exec, d1.now - 20, "no matching mids → the receipt time stands");
 });


### PR DESCRIPTION
Second half of today's timeline-connector report: after #218 fixed the left-edge geometry, the arc still landed at the *end* of the recipient's bar — "shouldn't there be a work period after message delivered?"

The landing was the read-receipt time — when the relay handoff completed — not when the recipient's turn picked the message up. The kernel's exec binder (`_bind_message_execs`) can never refine a relayed message: the recipient's turns live on the remote kernel, and the two lanes only meet client-side in the merged view. Worse, the join key didn't exist on the sender's side at all: the recipient's transcript markers carry **its own delivery mid**, which never flowed back.

Now it does, riding the existing receipt channel end to end: `read_box` stamps `dmid` (the maildir delivery mid — exactly the marker id) into the receipt at consume, the backflow forwards it hop-by-hop like the receipt itself, `_read_arrived` logs it beside the exec row, the kernel's timeline payload carries it on the connector, and the **merged view** joins every connector against every lane's bar `mids` — by id or dmid, remote lanes included — re-binding `exec` to the earliest matching turn's start. Idempotent for local mail (the kernel binder already landed those on the same value); no match leaves the receipt time standing; old peers omit `dmid` harmlessly in both directions.

Tests: postal end-to-end (consume stamps dmid; `_read_arrived` logs it; payload/view pins) plus an executed merged-view case in the headless draw harness (dmid join re-binds, no-join stands). Suites green locally (3918 pytest, 1662 node).

Both hosts need a build with this for the full effect (receipt sender + view); snape auto-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)