### PR TITLE
A working card never claims motion that is not there: anchor the awaiting lift, wrap the process list

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2293,6 +2293,24 @@ def _last_awaiting_is_lift(nd):
     return bool(evs) and bool(evs[-1].get("lift"))
 
 
+def _lift_ev_t(nd, now):
+    """EVIDENCE time for a lift row: the ANCHOR of the stamp it retracts, never wall-clock `now`.
+
+    The fold orders a node's diary by (ev_t, at), and a closer's awaiting assert carries the audited TURN's
+    trigger — always older than the moment a lift fires. So a lift stamped `now` outranked every assert the
+    closer would ever file on that segment, and one lift silenced it permanently: the session relaunched its
+    watcher 24s after the lift, the closer re-asserted the wait three times over the next two minutes, and
+    the fold discarded all three. The card sat in Working with no awaiting box, no spin (its session idle),
+    its live watcher demoted to a neutral background-process chip, and its nudge exemption gone — so the
+    nudge fired into a session that was genuinely waiting (the user 2026-08-06).
+
+    Anchored at the stamp, the lift retracts exactly the wait it looked at and loses the (ev_t, at) tie to
+    anything filed AFTER it: a later assert on the same segment restores the stamp, which is the judge's
+    newest ruling winning, not a flap. This is the diary's standing evidence-time rule (see
+    judge.record_verdict) — a `now` row outranks the judges on the in-flight segment forever."""
+    return nd.get("awaitingAt") or now
+
+
 def _stamp_written_at(nd):
     """WHEN the awaiting stamp was written — the ownership horizon for the time-window fallback below.
 
@@ -2354,7 +2372,7 @@ def _lift_spent_awaiting(now, tmux):
                       and not _last_awaiting_is_lift(nd)]
             changed = False
             for nd in rolled:
-                if jd.record_verdict(store, nd, "romp", "awaiting", now, lift=True):
+                if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
                     changed = True
             if not stamped:
                 if changed:
@@ -2400,7 +2418,7 @@ def _lift_spent_awaiting(now, tmux):
                     continue
                 if any(t.get("id") in running for t in own):
                     continue                          # at least one is genuinely still out
-                if jd.record_verdict(store, nd, "romp", "awaiting", now, lift=True):
+                if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
                     changed = True
             if changed:
                 jd.rollup_status(store, False)

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -268,6 +268,49 @@ class AwaitingLift(unittest.TestCase):
                          "no journalled write time → the old anchor bound, unchanged")
         self.assertEqual(km._stamp_written_at({"awaitingAt": STAMP}), STAMP, "no log at all is safe")
 
+    # ---- the lift's EVIDENCE time (the user 2026-08-06): the stamp's anchor, never wall-clock ----
+    # The fold reads a node's diary in (ev_t, at) order, and a closer assert carries its audited TURN's
+    # trigger — always older than the moment a lift fires. So a lift stamped `now` outranked every assert
+    # the closer could still file on that segment, permanently: a session relaunched its watcher seconds
+    # after a lift, the closer re-asserted the wait three times over the next two minutes, and the fold
+    # discarded all three. The card sat in Working with no awaiting box and no spin (its session idle), its
+    # live watcher demoted to a background-process chip, and its nudge exemption gone.
+    def test_the_lift_is_stamped_at_the_anchor_not_wall_clock(self):
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed()
+        self._tick(now=BACK + 5000)
+        log = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())["nodes"][self.gid]["log"]
+        lift = [e for e in log if e.get("kind") == "awaiting" and e.get("lift")][0]
+        self.assertEqual(lift["ev_t"], STAMP,
+                         "the lift retracts the wait it LOOKED at, so it carries that stamp's anchor")
+        self.assertNotEqual(lift["ev_t"], BACK + 5000, "never the tick's wall clock")
+
+    def test_a_closer_reassert_filed_after_the_lift_restores_the_stamp(self):
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed()
+        self._tick()
+        self.assertIsNone(self._stamp(), "precondition: the returned dispatch lifted the wait")
+        # the session relaunches its watcher and the closer, auditing the SAME turn, says the wait is on
+        store = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())
+        nd = store["nodes"][self.gid]
+        again = "the relaunched watcher on the two open PRs; it deploys once they merge"
+        self.assertTrue(km.jd.record_verdict(store, nd, "closer", "awaiting", STAMP, why=again),
+                        "the closer's re-assert is allowed to land")
+        self.assertEqual(km.jd._fold_node(nd)["awaitingWhy"], again,
+                         "the newest RULING wins: an assert filed after the lift puts the stamp back")
+        self.assertEqual(km._goal_awaiting_stamp(store["nodes"], self.gid), again,
+                         "so the card wears its awaiting box again, and keeps its nudge exemption")
+
+    def test_the_lift_still_wins_when_nothing_is_filed_after_it(self):
+        # the ordinary case is unchanged: nobody re-asserts, so the retraction stands
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed(anchor=STAMP, written=STAMP + 10)
+        self._tick()
+        store = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())
+        nd = store["nodes"][self.gid]
+        self.assertIsNone(km.jd._fold_node(nd)["awaitingWhy"], "the wait is over and stays over")
+        self.assertIsNone(km._goal_awaiting_stamp(store["nodes"], self.gid))
+
     def test_running_only_scan_still_hides_returned_tasks(self):
         # the want_all split must not change the existing running-only view
         self._transcript([_launch("t1", LAUNCH), _launch("t2", LAUNCH + 5), _notification("t1", BACK)])

--- a/ui/webview/feed-bg-service-chip.test.ts
+++ b/ui/webview/feed-bg-service-chip.test.ts
@@ -42,9 +42,20 @@ test("the CSS keeps it neutral: dim chip, section-body sized list, no status col
   // un-bolds from the header's 600 so it reads as a label, not a second title
   assert.match(CSS, /\.feed-sess-svcbtn \{ font-weight: 400; \}/);
   // full-width line under the header (the header wraps), 0.86em like the other section bodies
-  assert.match(CSS, /\.feed-sess-svclist \{ flex-basis: 100%; font-weight: 400; font-size: 0\.86em; color: var\(--dim\); \}/);
+  assert.match(CSS, /\.feed-sess-svclist \{ flex-basis: 100%;[^}]*font-size: 0\.86em; color: var\(--dim\); \}/);
   assert.match(CSS, /\.feed-sess-head \{ display: flex; flex-wrap: wrap;/);
   // never the working/blocked status colors
   assert.doesNotMatch(CSS, /\.feed-sess-svc(btn|list|row)[^}]*st-working/);
   assert.doesNotMatch(CSS, /\.feed-sess-svc(btn|list|row)[^}]*#f66/);
+});
+
+test("the expanded list WRAPS inside the column instead of running on (the user 2026-08-06)", () => {
+  // A process description is a sentence. Truncating it dead-ends the one surface that exists to show it,
+  // and `white-space: nowrap` on the row did worse than truncate: the list is a FLEX item, whose default
+  // min-width:auto is its min-content size, so it could not shrink to the column — the line ran out past
+  // the column's edge and under the neighbouring one.
+  assert.match(CSS, /\.feed-sess-svclist \{[^}]*min-width: 0;/);
+  assert.doesNotMatch(CSS, /\.feed-sess-svcrow \{[^}]*white-space: nowrap/);
+  assert.doesNotMatch(CSS, /\.feed-sess-svcrow \{[^}]*text-overflow: ellipsis/);
+  assert.match(CSS, /\.feed-sess-svcrow \{[^}]*overflow-wrap: anywhere/);   // a long path/url breaks too
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -199,9 +199,15 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    the header's 600 so it reads as a label, not a second title. NO waiting/urgency framing anywhere. */
 .feed-sess-svcbtn { font-weight: 400; }
 /* the expanded process list: its own full-width line under the header (flex-basis:100%), section-body
-   sized (0.86em, matches .fask-awaiting) and dim — mechanics one click away, quiet by default. */
-.feed-sess-svclist { flex-basis: 100%; font-weight: 400; font-size: 0.86em; color: var(--dim); }
-.feed-sess-svcrow { padding: 1px 0 1px 10px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+   sized (0.86em, matches .fask-awaiting) and dim — mechanics one click away, quiet by default.
+   min-width:0 is what makes that line the HEADER's width: a flex item defaults to min-width:auto, i.e. its
+   min-CONTENT size, so a nowrap description could not shrink and ran straight out of the column and under
+   the next one (the user 2026-08-06). */
+.feed-sess-svclist { flex-basis: 100%; min-width: 0; font-weight: 400; font-size: 0.86em; color: var(--dim); }
+/* WRAPS, never truncates (the user 2026-08-06): this is the expanded level of the disclosure — the chip is
+   the compact form, so clicking it must show the whole description, and a service why is a sentence, not a
+   label. Wrapped lines keep the row's 10px indent, so the list still reads as one block under the header. */
+.feed-sess-svcrow { padding: 1px 0 1px 10px; overflow-wrap: anywhere; }
 /* row 2 — the session name on its own row below the title; sized to its text so blank space
    to its right stays card-body (opens the modal), and wrapping so a long name can't overflow. */
 /* wraps: when the name + "↪ from <peer>" provenance + the reopened/Followed-up chips can't all fit on


### PR DESCRIPTION
Two fixes from one live diagnosis. A card sat in the Working column with no awaiting box, no spin, and an idle session, while its watcher was genuinely running.

## 1. An awaiting lift carries the stamp's anchor, not wall-clock time

The fold reads a node's diary in `(ev_t, at)` order, and a closer's `awaiting` assert carries the audited turn's TRIGGER time, always older than the moment `_lift_spent_awaiting` fires. Stamping the lift with `now` outranked every assert the closer could still file on that segment, permanently.

Live sequence on the audited card: lift filed, watcher relaunched 24s later, closer re-asserted the wait three times over the next two minutes, fold discarded all three. Result: a Working card with no awaiting box and no spin, its live watcher demoted to a neutral background-process chip, and its nudge exemption gone, so a nudge fired into a session that was genuinely waiting on CI.

Anchored at the stamp it retracts, the lift still ends a spent wait but loses the tie to anything filed after it, so a later assert on the same segment restores the stamp. The move is justified by a fresh closer verdict, not a per-build recomputation.

## 2. The expanded background-process list wraps inside its column

The chip's expanded row was `white-space: nowrap` inside a flex item with the default `min-width:auto`, so it could not shrink to the column: the line ran 80px past the column's edge and under the neighbouring one instead of truncating. `min-width:0` plus wrapping fixes it, verified by measuring both variants in a standalone repro (old `row.right=468` vs `col.right=388`; new `row.right=385`, two lines).

## Tests

- `tests/test_kernel_awaiting_lift.py`: three new cases (the lift's ev_t is the anchor; a closer re-assert filed after a lift restores the stamp; a lift with nothing filed after it still wins). Both new behaviours fail on `main`.
- `ui/webview/feed-bg-service-chip.test.ts`: the list wraps, does not truncate, and can shrink to its column.
- Full suites green: 3921 pytest, 1662 node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)