### PR TITLE
Timeline drop-downs escape the short bottom band instead of clipping

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -413,6 +413,28 @@ function gearIcon(cx, cy, color) {
   }
   return g;
 }
+// Vertical placement for the fixed-position drop-downs (_openLaneMenu / _openMetaMenu). The timeline
+// often renders as a SHORT bottom band — the web shell's f-timeline iframe — and position:fixed pins
+// to THAT band's viewport, so a menu hung unconditionally at anchor.bottom+4 from a gear near the
+// band's lower edge fell straight past the iframe's bottom and read as invisible / hidden behind the
+// shell (the user 2026-08-07). Prefer below the anchor; flip above when below can't hold the menu;
+// clamp to the viewport as the backstop when NEITHER side can (a band shorter than the menu keeps the
+// menu's top edge on-screen — a cropped last row beats no menu at all).
+function menuTop(anchor, menuH, viewH) {
+  const below = anchor.bottom + 4;
+  if (below + menuH <= viewH - 6) return below;
+  const above = anchor.top - 4 - menuH;
+  if (above >= 6) return above;
+  return Math.max(6, viewH - 6 - menuH);
+}
+// Translate a pane-local anchor rect into a host document's coordinates by summing the intervening
+// iframes' offsets (the moveTip pattern, extracted pure so the arithmetic is testable). `frames` is
+// the list of frameElement rects between the pane and the host, innermost first.
+function offsetRect(rect, frames) {
+  let { left, top, bottom } = rect;
+  for (const fr of frames || []) { left += fr.left; top += fr.top; bottom += fr.top; }
+  return { left, top, bottom };
+}
 // The gear menu's rows, one per per-session flag. `enabled` reads the toggle's MEANING off the session
 // (hideFromFeed/postalServiceOff are off-flags; notify is an on-flag), `value` maps a desired
 // enabled-state back to the flag value _setSessionFlag persists.
@@ -760,6 +782,18 @@ class TimelinePanel {
     this._onDocKey = (e) => { if (e.key === 'Escape') { this._closeMetaMenu(); this._closeLaneMenu(); } };
     document.addEventListener('click', this._onDocClick);
     document.addEventListener('keydown', this._onDocKey);
+    // The menus render in the tip's host document (see _menuHost), so a click or Escape landing on the
+    // HOST page — which now shows the menu — must close them too. Same teardown discipline as the tip:
+    // pagehide unhooks the host listeners and drops any open menu, so an iframe reload can't orphan either.
+    if (tipDoc !== document) {
+      tipDoc.addEventListener('click', this._onDocClick);
+      tipDoc.addEventListener('keydown', this._onDocKey);
+      window.addEventListener('pagehide', () => { try {
+        tipDoc.removeEventListener('click', this._onDocClick);
+        tipDoc.removeEventListener('keydown', this._onDocKey);
+        this._closeMetaMenu(); this._closeLaneMenu();
+      } catch (e) {} });
+    }
 
     this._onResize = () => this.draw();
     this._onWheel = (e) => this.onWheel(e);
@@ -869,6 +903,12 @@ class TimelinePanel {
     if (this._onDragUp) window.removeEventListener('mouseup', this._onDragUp, true);
     document.removeEventListener('click', this._onDocClick);
     document.removeEventListener('keydown', this._onDocKey);
+    try {   // the host-document twins of the two closers above (menus render in the tip's host doc)
+      if (this._tipWin && this._tipWin !== window) {
+        this._tipWin.document.removeEventListener('click', this._onDocClick);
+        this._tipWin.document.removeEventListener('keydown', this._onDocKey);
+      }
+    } catch (e) { /* host gone — its listeners went with it */ }
     this._closeMetaMenu();
     this._closeLaneMenu();
     if (this.tip) this.tip.remove();
@@ -2126,6 +2166,23 @@ class TimelinePanel {
 
   _closeMetaMenu() { if (this._metaMenu) { this._metaMenu.remove(); this._metaMenu = null; } }
 
+  // Where a drop-down should live and be measured: the tip's host document (the topmost same-origin
+  // window — in the web shell that's the whole page, so a menu taller than the timeline band gets the
+  // full window's height instead of the band's few rows; the user 2026-08-07, still cropped after the
+  // flip fix). The anchor rect is translated by the intervening iframes' offsets, moveTip-style. A
+  // cross-origin parent (the VS Code webview) throws on frameElement access → fall back to our own
+  // pane, which is exactly the pre-host behavior.
+  _menuHost(anchorRect) {
+    if (this._tipWin && this._tipWin !== window) {
+      try {
+        const frames = [];
+        for (let w = window; w !== this._tipWin && w.frameElement; w = w.parent) frames.push(w.frameElement.getBoundingClientRect());
+        return { win: this._tipWin, doc: this._tipWin.document, rect: offsetRect(anchorRect, frames) };
+      } catch (e) { /* host went cross-origin/away — position pane-locally */ }
+    }
+    return { win: window, doc: document, rect: anchorRect };
+  }
+
   // Open the model/effort drop-down anchored under the clicked label. Re-clicking the same word's
   // caret toggles it shut. Refused while the lane is AWAITING a prompt — the pane's keyboard belongs to
   // the picker, so a pasted "/model …" + Enter would answer it instead (the chat view guards the same way).
@@ -2155,11 +2212,12 @@ class TimelinePanel {
         this.draw();
       });
     }
-    const r = anchorEl.getBoundingClientRect();
-    // clamp to the viewport so a right-edge lane's menu stays on-screen
-    const left = Math.min(Math.round(r.left), (window.innerWidth || 9999) - 140);
+    const h = this._menuHost(anchorEl.getBoundingClientRect());
+    h.doc.body.appendChild(menu);   // a cross-document append ADOPTS the node; its listeners are kept
+    // clamp to the host viewport so a right-edge lane's menu stays on-screen
+    const left = Math.min(Math.round(h.rect.left), (h.win.innerWidth || 9999) - 140);
     menu.style.left = Math.max(6, left) + 'px';
-    menu.style.top = Math.round(r.bottom + 4) + 'px';
+    menu.style.top = Math.round(menuTop(h.rect, menu.offsetHeight || 0, h.win.innerHeight || 9999)) + 'px';
     this._metaMenu = menu;
   }
 
@@ -2213,10 +2271,11 @@ class TimelinePanel {
       }
     };
     build();
-    const r = anchorEl.getBoundingClientRect();
-    const left = Math.min(Math.round(r.left), (window.innerWidth || 9999) - 300);   // clamp on-screen
+    const h = this._menuHost(anchorEl.getBoundingClientRect());
+    h.doc.body.appendChild(menu);   // a cross-document append ADOPTS the node; its listeners are kept
+    const left = Math.min(Math.round(h.rect.left), (h.win.innerWidth || 9999) - 300);   // clamp on-screen
     menu.style.left = Math.max(6, left) + 'px';
-    menu.style.top = Math.round(r.bottom + 4) + 'px';
+    menu.style.top = Math.round(menuTop(h.rect, menu.offsetHeight || 0, h.win.innerHeight || 9999)) + 'px';
     this._laneMenu = menu;
   }
 
@@ -3317,4 +3376,4 @@ class TimelinePanel {
   body(s) { return s ? '<div class="b">' + s + '</div>' : ''; }
 }
 
-module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText };
+module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect };

--- a/ui/timeline-menu-place.test.ts
+++ b/ui/timeline-menu-place.test.ts
@@ -1,0 +1,67 @@
+// Drop-down placement for the lane gear / model / effort menus. The timeline often renders as a
+// short bottom band (the web shell's f-timeline iframe), and the menus are position:fixed INSIDE
+// that band — so hanging them unconditionally below the anchor pushed a bottom-lane menu straight
+// past the iframe's viewport: it opened, but the user saw at most a sliver (2026-08-07). menuTop
+// prefers below, flips above when below can't hold the menu, and clamps on-screen when neither fits.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FILE = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const SRC = fs.readFileSync(FILE, "utf8");
+const { menuTop, offsetRect } = require(FILE);
+
+test("a menu that fits below the anchor opens below it", () => {
+  // tall viewport, anchor near the top: the classic desktop case is unchanged
+  assert.equal(menuTop({ top: 40, bottom: 56 }, 150, 800), 60);
+});
+
+test("a menu that would clip past the viewport bottom flips ABOVE the anchor", () => {
+  // a 200px bottom band with the gear on its lowest lane: below has ~30px, above has room
+  assert.equal(menuTop({ top: 170, bottom: 186 }, 140, 200), 170 - 4 - 140);
+});
+
+test("a band shorter than the menu clamps the top on-screen instead of vanishing", () => {
+  // neither side fits a 150px menu in a 120px band: pin toward the bottom, never above y=6,
+  // so the menu's top rows stay visible and reachable
+  const top = menuTop({ top: 100, bottom: 116 }, 150, 120);
+  assert.equal(top, 6);
+  // and a band just big enough bottom-aligns rather than hiding the head of the menu
+  assert.equal(menuTop({ top: 150, bottom: 166 }, 150, 170), 170 - 6 - 150);
+});
+
+test("both the lane gear menu and the model/effort menu place through menuTop", () => {
+  // the fix must cover BOTH fixed-position drop-downs; a bare `r.bottom + 4` is the bug's signature
+  const opens = SRC.match(/menu\.style\.top = Math\.round\(menuTop\(h\.rect, menu\.offsetHeight \|\| 0, h\.win\.innerHeight \|\| 9999\)\)/g) || [];
+  assert.equal(opens.length, 2, "expected _openMetaMenu and _openLaneMenu to both use menuTop");
+  assert.doesNotMatch(SRC, /menu\.style\.top = Math\.round\(r\.bottom \+ 4\)/);
+});
+
+// A band SHORTER than the menu can't be fixed by flipping — the menu must escape the iframe. It
+// renders in the tip's host document (the topmost same-origin window), with the anchor translated
+// by the intervening frames' offsets, so in the web shell it gets the whole window's height.
+
+test("offsetRect translates a pane-local anchor by each intervening frame's offset", () => {
+  // gear at y=150 inside a band whose iframe sits at y=620 in the shell → host-coords y=770
+  assert.deepEqual(
+    offsetRect({ left: 30, top: 150, bottom: 166 }, [{ left: 0, top: 620 }]),
+    { left: 30, top: 770, bottom: 786 });
+  // nested frames sum; no frames = identity
+  assert.deepEqual(
+    offsetRect({ left: 10, top: 20, bottom: 40 }, [{ left: 5, top: 7 }, { left: 100, top: 300 }]),
+    { left: 115, top: 327, bottom: 347 });
+  assert.deepEqual(
+    offsetRect({ left: 10, top: 20, bottom: 40 }, []),
+    { left: 10, top: 20, bottom: 40 });
+});
+
+test("both menus append into the host document and read the host viewport", () => {
+  const appends = SRC.match(/h\.doc\.body\.appendChild\(menu\)/g) || [];
+  assert.equal(appends.length, 2, "expected _openMetaMenu and _openLaneMenu to adopt into the host doc");
+  assert.match(SRC, /_menuHost\(anchorRect\)[\s\S]*?offsetRect\(anchorRect, frames\)/);
+  // the host page shows the menu now, so its clicks/Escape must close it (with pagehide cleanup)
+  assert.match(SRC, /tipDoc\.addEventListener\('click', this\._onDocClick\)/);
+  assert.match(SRC, /tipDoc\.addEventListener\('keydown', this\._onDocKey\)/);
+  assert.match(SRC, /tipDoc\.removeEventListener\('click', this\._onDocClick\)/);
+});


### PR DESCRIPTION
**Repro:** in the web dashboard, click the settings gear (or the model/effort word) on one of the lowest lanes in the timeline. The drop-down opens at `anchor.bottom + 4` inside the timeline's own document — which is the `f-timeline` iframe, a short band at the bottom of the window — so it falls straight past the iframe's viewport: technically open, practically invisible.

**Fix, two cooperating pieces:**
- `menuTop()` places a menu below its anchor when the viewport can hold it, flips it above when it can't, and clamps on-screen when neither side fits.
- The menus render in the tooltip's host document (the topmost same-origin window — the same adoption pattern `moveTip` has used all along), so in the web shell they get the whole window's height instead of the band's few rows. Anchor coordinates are translated by the intervening frames' offsets (`offsetRect`, the `moveTip` arithmetic extracted pure). The menu is still built in the pane's own realm, so the `createDiv` polyfill and the row listeners survive the cross-document append (adoption keeps listeners per the DOM spec). Host-page clicks/Escape close it; `pagehide` and `destroy()` unhook the host listeners. A cross-origin parent (the VS Code webview) falls back to pane-local placement — the prior behavior, unchanged.

**Tests:** behavioral coverage of `menuTop` and `offsetRect` through the module exports, plus wiring pins that both call sites route through them; each pin was verified to fail against a reverted call site. Extension suite green (1670).

🤖 Generated with [Claude Code](https://claude.com/claude-code)