### PR TITLE
The chat statusline gains a fast-mode toggle

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -107,6 +107,17 @@ ghostty --working-directory={dir}   # Linux: Ghostty
 code {dir}                          # VS Code instead
 ```
 
+### Fast mode, from the chat statusline
+
+The statusline's badges — permission mode, model, effort — are each a small
+dropdown. A fourth, **Fast**, appears when the session reports Claude Code's
+fast-mode state (an Opus-only research preview, billed at a premium). Picking
+On or Off sends the CLI's own `/fast` command; the badge reads the state the
+CLI reports — orange while on, and a cooldown label while fast requests are
+rate-limited — and never appears on a session that cannot run fast mode.
+Turning it on while the session is on a non-Opus model makes the CLI switch to
+a fast-capable one, which the chat shows as the command's own confirmation.
+
 ### Install-time switches
 
 For `./install.sh`:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3982,7 +3982,7 @@ def _drive(msg, client):
         return False
     t = msg.get("type")
     ID_OPS = ("sendMessage", "rewindSend", "rewindDelete", "interrupt", "compactSession", "dismissDialog", "answerAsk", "navAsk", "toggleAsk", "submitAsk",
-              "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "setModel", "setEffort", "setMode",
+              "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "setModel", "setEffort", "setMode", "setFast",
               "endSession", "renameSession", "stopTask", "rewindFiles", "mcpAction")
     if t in ID_OPS and msg.get("id"):
         sid = str(msg["id"])
@@ -4047,6 +4047,8 @@ def _drive(msg, client):
             _set_model_or_park(be, sid, cmd[len("/model "):].strip())   # mid-compaction → parked as a queued command
         elif cmd.startswith("/effort "):
             _set_effort_or_park(be, sid, cmd[len("/effort "):].strip())   # mid-compaction → parked as a queued command
+        elif cmd.startswith("/fast "):
+            _set_fast_or_park(be, sid, cmd[len("/fast "):].strip())   # mid-compaction → parked as a queued command
         else:
             _send_or_park(be, sid, cmd)   # mid-compaction → parked as a queued command
     elif t == "askFollowUp":
@@ -4219,6 +4221,14 @@ def _drive(msg, client):
         _set_model_or_park(be, sid, str(msg["value"])); _push_soon()   # mid-compaction → parked as a queued command
     elif t == "setEffort" and msg.get("value"):
         _set_effort_or_park(be, sid, str(msg["value"])); _push_soon()   # tmux: /effort; SDK: reconnect with --effort; mid-compaction → parked
+    elif t == "setFast" and msg.get("value") in ("on", "off"):
+        # the chat's fast badge — /fast on|off delivered like any slash command; mid-compaction → parked.
+        # LOUD on refusal (fail loudly, never degrade silently): a dormant SDK session has no live CLI to
+        # apply it, and silently swallowing the click would leave a toggle that "did nothing".
+        if not _set_fast_or_park(be, sid, str(msg["value"])):
+            client["send"](json.dumps({"type": "warn",
+                                       "text": "Couldn't toggle fast mode — the session isn't connected right now."}))
+        _push_soon()
     elif t == "setMode" and msg.get("value"):
         be.set_mode(sid, str(msg["value"])); _push_soon()
     elif t == "stopTask" and msg.get("taskId"):
@@ -4670,6 +4680,12 @@ class TmuxBackend(sb.SessionBackend):
         _tmux_send(_name_of(sid) or sid, "/effort " + value)
         return True
 
+    def set_fast(self, sid, value):
+        if value not in ("on", "off"):
+            return False
+        _tmux_send(_name_of(sid) or sid, "/fast " + value)   # args form applies directly (no picker/confirm)
+        return True
+
     # lifecycle — tmux sessions are launched by bin/romp (not the kernel) and revived via romp-postal, so
     # spawn/resume aren't backend primitives here; the kernel uses _spawn_session/_revive_session for those.
     def spawn(self, name, cwd, bg="", fg="", sid=None):
@@ -4966,6 +4982,8 @@ class Sessions:
                                 "retryCount": int(st.get("retryCount") or 0),   # api_retry backoff attempts → the chat's "API retrying — attempt N…" element
                                 "retryInfo": st.get("retryInfo") or None,   # the attempt's detail (attempt/max, error, next-attempt epoch) → the retrying element's context lines (the user 2026-07-10)
                                 "context": ctx if isinstance(ctx, (int, float)) else None, "compactPct": None,
+                                "fast": st.get("fast", ""),   # fast-mode state from the CLI's init ("on"/"off"/"cooldown"; "" = unknown → no badge)
+                                "fastReason": st.get("fastReason", ""),   # init's disabled_reason — non-empty hides the chat toggle
                                 "color": (st.get("color") or None), "mode": st.get("mode", ""), "backend": "sdk",
                                 "subagents": st.get("subagents") or [],   # live Task subagents (SDK only) → lane pill
                                 # live BACKGROUND TASKS (the CLI's task lifecycle stream) — the awaiting
@@ -10174,7 +10192,7 @@ def _save_pending_ops():
         sys.stderr.write("pending-ops save: %s\n" % traceback.format_exc())
 
 
-_pending_ops = _load_pending_ops()   # sid -> [("send", text, echo) | ("model", v) | ("effort", v) | ("compact",), …] in park order
+_pending_ops = _load_pending_ops()   # sid -> [("send", text, echo) | ("model", v) | ("effort", v) | ("fast", v) | ("compact",), …] in park order
 
 
 def _compacting_now(sid):
@@ -10299,7 +10317,7 @@ def _park_op(sid, op):
     earlier parked op of the same kind IN PLACE — its queue position stands, its value updates — so the
     chat shows one "/model …" chip carrying the latest pick. Messages always append."""
     q = _pending_ops.setdefault(str(sid), [])
-    if op[0] in ("model", "effort"):
+    if op[0] in ("model", "effort", "fast"):
         for i, o in enumerate(q):
             if o[0] == op[0]:
                 q[i] = op
@@ -10448,6 +10466,18 @@ def _set_effort_or_park(be, sid, value):
         be.set_effort(sid, value)
 
 
+def _set_fast_or_park(be, sid, value):
+    """Apply a fast-mode toggle now — or park it while the session compacts, exactly like /model and
+    /effort (it is a slash command and must keep press order in the same FIFO). Returns the backend's
+    verdict so the caller can be loud when a live apply refuses (dormant SDK session)."""
+    if value not in ("on", "off"):
+        return False
+    if _ops_gate(sid):
+        _park_op(sid, ("fast", value))
+        return True
+    return be.set_fast(sid, value)
+
+
 def _deliver_send_batch(be, sid, run):
     """Deliver a run of consecutive parked ('send', text, echo) ops AT ONCE (the user 2026-07-17: a pile of
     queued messages should all go in together, not one turn each). A backend that forwards its own sends
@@ -10508,6 +10538,9 @@ def _apply_pending_ops():
                     ops.pop(0)
                 elif op[0] == "effort":
                     be.set_effort(sid, op[1])
+                    ops.pop(0)
+                elif op[0] == "fast":
+                    be.set_fast(sid, op[1])
                     ops.pop(0)
                 else:
                     ops.pop(0)                        # unknown op kind → drop, never wedge the queue
@@ -11751,6 +11784,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   "retryTries": _retry_gate_state(sid)[0] or None,
                   "backend": _session_backend(sid, tm),
                   "model": tm["model"], "effort": tm["effort"], "mode": tm.get("mode", ""),
+                  # fast-mode badge (SDK sessions; the CLI's init reports on/off/cooldown, "" = unknown →
+                  # no badge — tmux stays "" until its statusline publishes a fast var). A non-empty
+                  # disabled_reason means /fast would refuse, so the chat hides the toggle.
+                  "fast": "" if tm.get("fastReason") else tm.get("fast", ""),
                   "modelPending": _model_pending_now(sid, tm),   # switching-dots on the model badge until the pick lands, from EITHER surface (the user 2026-07-03)
                   "effortPending": bool(tm.get("effortPending")),   # switching-dots on the effort badge while the /effort reconnect applies (SDK-only; the user 2026-07-06)
                   "ctx": str(tm["context"]) if tm["context"] is not None else "",
@@ -16030,7 +16067,7 @@ def _fleet_view_sig(now, tmux):
             pass
     for s in sorted(tmux):
         t = tmux[s]
-        sig["t:" + s] = (t.get("state"), t.get("model"), t.get("ctx"), t.get("effort"), t.get("mode"), t.get("since"))
+        sig["t:" + s] = (t.get("state"), t.get("model"), t.get("ctx"), t.get("effort"), t.get("mode"), t.get("fast"), t.get("since"))
     return tuple(sorted(sig.items()))
 
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1105,6 +1105,12 @@ class SdkSession:
         #   "Reloading session…" notice until the reconnect completes (the user 2026-07-06). Cleared the instant the
         #   new client connects (reconnect loop) — event-based, mirroring _model_pending's dots.
         self.perm_mode = self.mode
+        self.fast = ""      # fast-mode state as the CLI's init message reports it ("on"/"off"/"cooldown");
+        #   "" until an init lands (unknown → the chat shows no fast badge rather than a guess). Flipped
+        #   optimistically by set_fast (the /fast command is delivered like any typed one) and re-asserted
+        #   by fast_mode_state on every init, so a refused toggle can't stick past the next connect.
+        self.fast_reason = ""   # the init's fast_mode_disabled_reason — non-empty means /fast would refuse
+        #   (org-gated / unsupported), so the chat hides the toggle instead of offering a dead control.
         # Pending conversation REWIND (the chat's edit-message branch): the target record uuid +
         # the transcript leaf recorded at request time (the one-shot guard — see rewind_disposition).
         # Seeded from the reg so a kernel death mid-rewind re-applies it iff nothing landed since.
@@ -1782,6 +1788,13 @@ class SdkSession:
             d = msg.data if isinstance(msg.data, dict) else {}
             self._learn_model(pretty_model(d.get("model")))
             self.perm_mode = d.get("permissionMode") or self.perm_mode
+            # Fast-mode truth rides the init payload (fast_mode_state: on/off/cooldown, plus a
+            # disabled_reason when the org/model can't use it) — the AUTHORITATIVE re-assert behind
+            # set_fast's optimistic flip. Absent field (older CLI) → stay unknown, never fabricate "off".
+            fast = d.get("fast_mode_state")
+            if isinstance(fast, str) and fast:
+                self.fast = fast
+                self.fast_reason = str(d.get("fast_mode_disabled_reason") or "")
             # HOW this CLI authenticates (verified live 2026-08-04: 'ANTHROPIC_API_KEY' on API-key auth;
             # the field is absent on a subscription login). An auth flip is the deciding event for the
             # rail's /usage bars — see _note_auth_source.
@@ -2308,6 +2321,8 @@ class SdkSession:
                 "modelPending": bool(self._model_pending),   # a /model switch resolving → the badge shows switching-dots
                 "effortPending": bool(self._effort_pending),   # an /effort switch reconnecting → effort-badge dots + "Reloading session…"
                 "mode": self.perm_mode, "ctx": self._ctx_pct(), "summary": "",
+                "fast": self.fast,   # fast-mode state from init ("on"/"off"/"cooldown"; "" = unknown → no badge)
+                "fastReason": self.fast_reason,   # init's disabled_reason — non-empty hides the chat toggle
                 "retryCount": self.retry_count,   # api_retry backoff attempts in the current storm → the live 'attempt N' in the chat's retrying element
                 "retryInfo": self.retry_info,     # the latest attempt's detail (attempt/max, error status+message, next-attempt epoch) → the retrying element's context lines (the user 2026-07-10)
                 "interrupting": bool(self._interrupted),   # a user interrupt is IN FLIGHT: set at dispatch,
@@ -3467,6 +3482,27 @@ class SdkBackend:
             reg["liveModel"] = _alias_label(value)
             reg["modelPending"] = False
             write_reg(self.state_dir, sid, reg)
+        return True
+
+    def set_fast(self, sid: str, value: str) -> bool:
+        """Toggle fast mode by delivering the literal '/fast on|off' text through the normal send path.
+        Unlike /model (which the SDK input stream does not interpret — see set_model), the CLI's /fast
+        descriptor is marked supportsNonInteractive, so the stream-json input DOES run it: the send's
+        echo gives the chat its command chip, and the CLI answers with its own confirmation line
+        ("Fast mode ON …" — including the model switch it performs when the session isn't on a
+        fast-capable model). The flip here is optimistic for the badge; fast_mode_state on the next
+        init re-asserts the truth, and a refusal (cooldown, org-disabled) is visible as the CLI's own
+        reply. Dormant sessions refuse — fast mode lives in the CLI's own settings, so there is nothing
+        to apply until a client is running (the kernel warns instead of pretending)."""
+        if value not in ("on", "off"):
+            return False
+        s = self.sessions.get(sid)
+        if not s or not s.thread.is_alive():
+            return False
+        if not self.send(sid, "/fast " + value):
+            return False
+        s.fast = value
+        self._wake_push()
         return True
 
     def set_mode(self, sid: str, mode: str) -> bool:

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -15,7 +15,7 @@ A conformance test asserts SdkBackend implements every abstract method, so the d
 
 Method groups:
   liveness/identity — owns, live_sessions
-  control           — send, interrupt, set_model, set_mode, set_effort
+  control           — send, interrupt, set_model, set_mode, set_effort, set_fast
   lifecycle         — spawn, resume, connect, kill, rename
   coordination      — working_note, set_working_note, wake   (backend-agnostic; tmux used @romp-working +
                       send-keys, the SDK now gets a store + an enqueue-wake so it has both too)
@@ -114,6 +114,13 @@ class SessionBackend(ABC):
 
     @abstractmethod
     def set_effort(self, sid: str, value: str) -> bool: ...
+
+    @abstractmethod
+    def set_fast(self, sid: str, value: str) -> bool:
+        """Toggle fast mode (value 'on'|'off') — the CLI's /fast command, which its descriptor marks as
+        supported non-interactively, so BOTH backends deliver it as the literal '/fast on|off' text (the
+        SDK input stream interprets it, unlike /model). False when it can't be delivered (dormant SDK
+        session, bad value) so the kernel can be loud instead of pretending."""
 
     def stop_task(self, sid: str, task_id: str) -> bool:
         """Stop ONE background task (the SDK's designed stop_task control request). SDK-only control:

--- a/tests/test_kernel_send_park.py
+++ b/tests/test_kernel_send_park.py
@@ -42,6 +42,10 @@ class _FakeBackend:
         self.calls.append(("effort", value))
         return True
 
+    def set_fast(self, sid, value):
+        self.calls.append(("fast", value))
+        return True
+
 
 class OpQueueParkOrDeliver(unittest.TestCase):
     def setUp(self):
@@ -88,6 +92,27 @@ class OpQueueParkOrDeliver(unittest.TestCase):
         km._send_or_park(self.be, SID, "second", echo=None)
         self.assertEqual(km._pending_ops.get(SID),
                          [("model", "sonnet"), ("send", "first", None), ("send", "second", None)])
+
+    def test_fast_toggle_parks_replaces_in_place_and_delivers_like_model_and_effort(self):
+        # /fast is a slash command like /model and /effort, so it rides the SAME FIFO: parked while the
+        # gate holds (compaction/open turn), a re-pick replaces the earlier parked toggle in place, and
+        # _apply_pending_ops hands it to the backend once the session is quiet.
+        km._compacting_now = lambda sid: True
+        self.assertTrue(km._set_fast_or_park(self.be, SID, "on"))
+        km._send_or_park(self.be, SID, "then this", echo=None)
+        self.assertTrue(km._set_fast_or_park(self.be, SID, "off"))   # re-pick → in-place replace
+        self.assertEqual(self.be.calls, [], "mid-compaction the backend is NOT touched")
+        self.assertEqual(km._pending_ops.get(SID),
+                         [("fast", "off"), ("send", "then this", None)])
+        self.assertFalse(km._set_fast_or_park(self.be, SID, "sideways"), "only on|off are /fast arguments")
+        km.Sessions.backend_for = lambda sid: self.be
+        km._compacting_now = lambda sid: False
+        km._apply_pending_ops()
+        self.assertEqual(self.be.calls, [("fast", "off"), ("send", "then this")],
+                         "the toggle applies and delivery continues; the send ends the pass")
+        km._compacting_now = lambda sid: False
+        self.assertTrue(km._set_fast_or_park(self.be, SID, "on"), "quiet session → applies immediately")
+        self.assertEqual(self.be.calls[-1], ("fast", "on"))
 
     def test_apply_delivers_sequentially_when_quiet_and_not_before(self):
         # SEQUENTIAL delivery (the user 2026-07-02, compact-mid-turn): settings ops apply and delivery

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -405,6 +405,72 @@ class LiveTail(unittest.TestCase):
         self.assertTrue(be.set_effort(sid, "low"))
         self.assertEqual(be.live_atoms(sid), [])
 
+    def _live_fast_session(self, d, sid):
+        """A constructed SdkSession whose thread READS alive (set_fast's gate) without spawning a CLI."""
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        sb.write_reg(d, sid, {"sid": sid, "name": "n", "cwd": "/tmp", "alive": True})
+        s = sb.SdkSession(be, {"sid": sid, "name": "n", "cwd": "/tmp"})
+        s.thread = type("T", (), {"is_alive": lambda self: True})()
+        be.sessions[sid] = s
+        return be, s
+
+    def test_set_fast_delivers_the_slash_command_and_flips_optimistically(self):
+        """/fast is one of the slash commands the SDK input stream DOES interpret (its CLI descriptor is
+        marked supportsNonInteractive, unlike /model — see set_model's control-channel note). set_fast
+        therefore delivers the literal '/fast on' through the normal send path — the echo is the chat's
+        acknowledgement, the CLI's own confirmation follows — and flips the badge state optimistically;
+        fast_mode_state on the next init re-asserts the truth."""
+        d = tempfile.mkdtemp()
+        sid = "11111111-2222-3333-4444-888888888888"
+        be, s = self._live_fast_session(d, sid)
+        self.assertTrue(be.set_fast(sid, "on"))
+        self.assertEqual(s.pending(), ["/fast on"], "the literal command is queued for the CLI to interpret")
+        echoes = [a for a in be.live_atoms(sid) if a.get("_echo_text") == "/fast on"]
+        self.assertEqual(len(echoes), 1, "the send path's echo IS the chat acknowledgement")
+        self.assertEqual(s.fast, "on", "optimistic flip — init re-asserts")
+        self.assertEqual(s.snapshot()["fast"], "on", "the badge reads it from the snapshot")
+
+    def test_set_fast_refuses_bad_values_and_dormant_sessions(self):
+        # only on|off are /fast arguments; a dormant session has no live CLI to apply the toggle —
+        # refuse (the kernel is LOUD about it) rather than reviving a session as a click side effect.
+        d = tempfile.mkdtemp()
+        sid = "11111111-2222-3333-4444-999999999999"
+        be, s = self._live_fast_session(d, sid)
+        self.assertFalse(be.set_fast(sid, "maybe"))
+        self.assertEqual(s.pending(), [], "a bad value never reaches the CLI")
+        be2 = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+        self.assertFalse(be2.set_fast("no-such-sid", "on"))
+
+    def test_init_reports_fast_mode_state_into_the_snapshot(self):
+        """fast_mode_state rides the CLI's init message ("on"/"off"/"cooldown", plus a disabled_reason
+        when the org/model can't use it) — the AUTHORITATIVE source behind the chat's fast badge. An
+        init WITHOUT the field (older CLI) must leave the state unknown, never fabricate "off"."""
+        import asyncio
+        class _Sys:
+            def __init__(self, data): self.subtype = "init"; self.data = data
+        d = tempfile.mkdtemp()
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        sid = "11111111-2222-3333-4444-aaaaaaaaaaaa"
+        sb.write_reg(d, sid, {"sid": sid, "name": "n", "cwd": "/tmp", "alive": True})
+        s = sb.SdkSession(be, {"sid": sid, "name": "n", "cwd": "/tmp"})
+        async def _noop(): pass
+        s._do_refresh_context = _noop
+        self.assertEqual(s.snapshot()["fast"], "", "unknown until an init lands → no badge")
+
+        async def run(data):
+            s._on_message(_Sys(data), _AssistantMessage, _ResultMessage, _Sys)
+            await asyncio.sleep(0)                       # let the ensure_future'd refresh run
+        asyncio.run(run({"fast_mode_state": "on"}))
+        self.assertEqual(s.fast, "on")
+        self.assertEqual(s.snapshot()["fast"], "on")
+        self.assertEqual(s.snapshot()["fastReason"], "")
+        asyncio.run(run({"fast_mode_state": "off", "fast_mode_disabled_reason": "Fast mode is org-disabled"}))
+        self.assertEqual(s.fast, "off")
+        self.assertEqual(s.snapshot()["fastReason"], "Fast mode is org-disabled",
+                         "a disabled_reason rides along so the kernel can hide the toggle")
+        asyncio.run(run({}))                             # an init with no field → the last truth STANDS
+        self.assertEqual(s.fast, "off", "absent field never overwrites the known state")
+
     def test_send_echo_authors_a_romp_nudge_as_romp_not_human(self):
         # the bug (the user 2026-06-28): an auto-nudge sent through send() echoed as a BLUE HUMAN "Follow-up"
         # instead of the GRAY "from romp" auto-nudge it is, because the echo hardcoded author="human". The echo

--- a/ui/webview/fast-toggle.test.ts
+++ b/ui/webview/fast-toggle.test.ts
@@ -1,0 +1,47 @@
+// The chat statusline's FAST badge — a fourth meta control (mode · model · effort · fast) toggling the
+// CLI's fast mode (/fast, Opus-only research preview). The badge exists only when the session REPORTS a
+// fast state — the SDK init's fast_mode_state ("on"/"off"/"cooldown"), threaded kernel → status → badge —
+// so a session that can't run fast mode (or a tmux session whose statusline doesn't publish it yet) shows
+// no dead control. Picking On/Off posts setFast; the kernel delivers the literal "/fast on|off", which the
+// SDK input stream interprets (its CLI descriptor is marked supportsNonInteractive, unlike /model).
+// render.ts has no jsdom harness → source pins (kernel pins ride along, as in the other meta tests).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const SDK = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
+
+test("the fast badge is a meta control that appears only when the session reports a state", () => {
+  assert.match(RENDER, /fast\?: string;/);                                   // status carries it
+  assert.match(RENDER, /type MetaKind = "mode" \| "model" \| "effort" \| "fast";/);
+  assert.match(RENDER, /st\.fast \? "fast" : ""/);                           // no state → no badge
+  assert.match(RENDER, /meta\.appendChild\(metaButton\("fast", prettyFast\(st\.fast\)\)\)/);
+});
+
+test("the picker offers On/Off and posts setFast; ON wears the CLI's fast orange", () => {
+  assert.match(RENDER, /\{ label: "On", value: "on" \}/);
+  assert.match(RENDER, /\{ label: "Off", value: "off" \}/);
+  assert.match(RENDER, /fast: FAST_CHOICES/);
+  assert.match(RENDER, /kind === "fast" \? "setFast"/);                      // the pick posts the op
+  assert.match(RENDER, /"on" \? "var\(--fast\)" : ""/);                      // ON tint, off/cooldown default
+  assert.match(CSS, /--fast: #ff6a00;/);                                     // the CLI's own fastMode orange
+});
+
+test("the kernel threads fast_mode_state from the SDK init to the chat status", () => {
+  assert.match(SDK, /d\.get\("fast_mode_state"\)/);                          // init is the authoritative source
+  assert.match(SDK, /"fast": self\.fast/);                                   // snapshot carries it
+  assert.match(KERNEL, /"fast": st\.get\("fast", ""\)/);                     // merged into the live map
+  // a disabled_reason (org-gated / unsupported) hides the toggle rather than offering a dead control
+  assert.match(KERNEL, /"fast": "" if tm\.get\("fastReason"\) else tm\.get\("fast", ""\)/);
+});
+
+test("setFast is a drive op that parks like /model and /effort", () => {
+  assert.match(KERNEL, /"setModel", "setEffort", "setMode", "setFast",/);    // in the drive-op allowlist
+  assert.match(KERNEL, /def _set_fast_or_park\(be, sid, value\)/);
+  assert.match(KERNEL, /op\[0\] in \("model", "effort", "fast"\)/);          // repeat pick replaces in place
+  assert.match(KERNEL, /elif op\[0\] == "fast":/);                           // parked delivery branch
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -196,7 +196,7 @@ type ChatEvent = (
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
 type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
-interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03)
+interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed.
@@ -6568,7 +6568,7 @@ function elapsedMs(sinceMs: number | null): string {
 // Each value is a little dropdown: picking an entry has the host inject the matching
 // /model or /effort slash command into the session's pane; the label then updates
 // when the TUI's statusline republishes the tmux vars (meta-pending bridges the gap).
-type MetaKind = "mode" | "model" | "effort";
+type MetaKind = "mode" | "model" | "effort" | "fast";
 // Model + effort choices come from the kernel's /models — the ONE list shared with the timeline lanes and the
 // judge-tier settings (the user 2026-07-02, who wanted one shared code path, not hardcoded in multiple places), so
 // the client holds no model literals (mirrors paletteColors above). Populated in place on load so META_CHOICES
@@ -6587,6 +6587,22 @@ const MODE_CHOICES: { label: string; value: string }[] = [
   { label: "Auto", value: "auto" },
   { label: "Plan", value: "plan" },
 ];
+// Fast mode (the CLI's /fast — Opus-only research preview): a two-state toggle offered as the same
+// dropdown shape as the other badges. The badge exists only when the session REPORTS a fast state
+// (st.fast, from the SDK init's fast_mode_state) — a session that can't run it, or a tmux session
+// whose statusline doesn't publish it yet, shows no dead control.
+const FAST_CHOICES: { label: string; value: string }[] = [
+  { label: "On", value: "on" },
+  { label: "Off", value: "off" },
+];
+// the fast-mode state ("on"/"off"/"cooldown") → the badge label
+function prettyFast(f: string | undefined): string {
+  switch ((f || "").toLowerCase()) {
+    case "on": return "Fast on";
+    case "cooldown": return "Fast cooldown";   // rate-limited: the CLI resumes fast mode when the limit resets
+    default: return "Fast off";
+  }
+}
 // the @claude-permission-mode var → a short readable badge label
 function prettyMode(m: string | undefined): string {
   switch ((m || "").toLowerCase()) {
@@ -6599,17 +6615,18 @@ function prettyMode(m: string | undefined): string {
   }
 }
 const META_CHOICES: Record<MetaKind, { label: string; value: string }[]> = {
-  mode: MODE_CHOICES, model: MODEL_CHOICES, effort: EFFORT_CHOICES,
+  mode: MODE_CHOICES, model: MODEL_CHOICES, effort: EFFORT_CHOICES, fast: FAST_CHOICES,
 };
 // the live value of a meta kind for the active session
 function metaCurrent(kind: MetaKind, st: Status): string {
-  return (kind === "model" ? st.model : kind === "effort" ? st.effort : st.mode) || "";
+  return (kind === "model" ? st.model : kind === "effort" ? st.effort : kind === "fast" ? st.fast : st.mode) || "";
 }
 
 // Is this menu entry the session's current value? Effort matches exactly; the
 // model var holds a display name ("Opus 4.8"), so match on the leading word.
 function isCurrentMeta(kind: MetaKind, st: Status, value: string): boolean {
   if (kind === "effort") return (st.effort || "").toLowerCase() === value;
+  if (kind === "fast") return (st.fast || "").toLowerCase() === value;   // "cooldown" marks neither entry
   if (kind === "mode") {
     const m = (st.mode || "").toLowerCase();
     if (value === "default") return m === "" || m === "default" || m === "normal";
@@ -6653,6 +6670,7 @@ function metaButton(kind: MetaKind, text: string): HTMLElement {
   btn.appendChild(caret);
   btn.title = kind === "model" ? "change model (sends /model)"
     : kind === "effort" ? "change thinking effort (sends /effort)"
+    : kind === "fast" ? "toggle fast mode (sends /fast)"
     : "change permission mode (shift+tab cycle)";
   btn.addEventListener("click", (e) => { e.stopPropagation(); toggleMetaMenu(kind, btn); });
   return btn;
@@ -6661,6 +6679,9 @@ function metaButton(kind: MetaKind, text: string): HTMLElement {
 // The model/effort label tint, from the server-computed colormap RGB (by capability/effort rank, the user
 // 2026-07-02) — "" for mode (untinted) or an unknown model/effort, which resets to the default gray.
 function metaColor(kind: MetaKind, st: Status): string {
+  // fast ON wears the CLI's own fast-mode orange (--fast, a status color) so the badge reads the same
+  // here as in the Claude Code TUI; off/cooldown stay the default gray.
+  if (kind === "fast") return (st.fast || "").toLowerCase() === "on" ? "var(--fast)" : "";
   const c = kind === "model" ? st.modelColor : kind === "effort" ? st.effortColor : undefined;
   return (c && c.length === 3) ? `rgb(${c[0]},${c[1]},${c[2]})` : "";
 }
@@ -6668,18 +6689,20 @@ function metaColor(kind: MetaKind, st: Status): string {
 // Build or refresh the model/effort buttons inside #spinner-meta. Called from
 // updateStatusline (fresh container) and the 1s ticker (label refresh in place).
 function syncMetaControls(meta: HTMLElement, st: Status) {
-  // order left→right: mode · model · effort — the mode selector sits LEFT of the model name (the user 2026-06-16)
-  const want = [st.mode ? "mode" : "", st.model ? "model" : "", st.effort ? "effort" : ""].filter(Boolean).join();
+  // order left→right: mode · model · effort · fast — the mode selector sits LEFT of the model name (the
+  // user 2026-06-16); fast is rightmost and exists only when the session reports a state (SDK init).
+  const want = [st.mode ? "mode" : "", st.model ? "model" : "", st.effort ? "effort" : "", st.fast ? "fast" : ""].filter(Boolean).join();
   const btns = Array.from(meta.querySelectorAll(".meta-btn")) as HTMLElement[];
   if (btns.map((b) => b.dataset.kind).join() !== want) {
     meta.replaceChildren();
     if (st.mode) meta.appendChild(metaButton("mode", prettyMode(st.mode)));
     if (st.model) meta.appendChild(metaButton("model", st.model));
     if (st.effort) meta.appendChild(metaButton("effort", st.effort));
+    if (st.fast) meta.appendChild(metaButton("fast", prettyFast(st.fast)));
   }
   for (const b of Array.from(meta.querySelectorAll(".meta-btn")) as HTMLElement[]) {
     const kind = b.dataset.kind as MetaKind;
-    const disp = kind === "mode" ? prettyMode(st.mode) : metaCurrent(kind, st);
+    const disp = kind === "mode" ? prettyMode(st.mode) : kind === "fast" ? prettyFast(st.fast) : metaCurrent(kind, st);
     const label = b.querySelector(".meta-label") as HTMLElement | null;
     // A switching MODEL shows animated dots, not the stale/premature name (the user 2026-07-03): the
     // server drives it (st.modelPending) — event-based, cleared the instant the new model actually lands —
@@ -6723,7 +6746,7 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement) {
     item.addEventListener("click", (e) => {
       e.stopPropagation();
       if (activeId && vscodeApi) {
-        vscodeApi.postMessage({ type: kind === "model" ? "setModel" : kind === "effort" ? "setEffort" : "setMode", id: activeId, value: c.value });
+        vscodeApi.postMessage({ type: kind === "model" ? "setModel" : kind === "effort" ? "setEffort" : kind === "fast" ? "setFast" : "setMode", id: activeId, value: c.value });
         const was = metaCurrent(kind, s.status);
         metaPending.set(`${activeId}:${kind}`, { was, until: Date.now() + 20_000 });
         btn.classList.add("meta-pending");

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -35,6 +35,9 @@
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
      their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it. */
   --accent: #9cd2ff; --accent-fg: #0c1a2e;
+  /* fast mode ON — the CLI's own fastMode orange, a STATUS color (means "this session runs fast
+     mode"), so the badge reads the same here as in the Claude Code TUI. Not the accent. */
+  --fast: #ff6a00;
 
   /* romp dashboard badge colors */
   --st-working-bg: #e0b020; --st-working-fg: #332600;

--- a/vscode-extension/src/pipe-intent.test.ts
+++ b/vscode-extension/src/pipe-intent.test.ts
@@ -12,7 +12,7 @@ test("typed-text ops are intent — losing them loses the user's words", () => {
 });
 
 test("explicit state-changing picks are intent", () => {
-  for (const t of ["setModel", "setEffort", "setMode", "interrupt", "endSession",
+  for (const t of ["setModel", "setEffort", "setMode", "setFast", "interrupt", "endSession",
     "nodeOverride", "askClear", "answerAsk", "submitAsk", "renameSession"]) {
     assert.ok(intentOp(t), `${t} must survive a reconnect`);
   }

--- a/vscode-extension/src/pipe-intent.ts
+++ b/vscode-extension/src/pipe-intent.ts
@@ -10,7 +10,7 @@ export const INTENT_OPS: ReadonlySet<string> = new Set([
   "sendMessage", "askFollowUp", "askText", "addCustomAsk", "sendCommand", "rewindSend",
   // explicit clicks that mutate kernel/session state
   "interrupt", "apiRetry", "rewindDelete",
-  "setModel", "setEffort", "setMode",
+  "setModel", "setEffort", "setMode", "setFast",
   "renameSession", "endSession", "reviveSession",
   "nodeOverride", "askClear", "undoClear", "cardMove", "cardNotify",
   "answerAsk", "submitAsk", "toggleAsk", "navAsk", "cancelAsk",


### PR DESCRIPTION
## What

A fourth meta badge in the chat statusline (mode · model · effort · **fast**) toggles Claude Code's fast mode (the Opus-only research preview), from the same dropdown pattern as the existing controls.

## How

- **Authoritative state**: the SDK init message's `fast_mode_state` (`on`/`off`/`cooldown`) plus `fast_mode_disabled_reason`, captured in the session snapshot and threaded through the live map into the chat status. A session that reports no state — or a disabled reason — shows **no control at all** rather than a dead one; tmux sessions stay blank until their statusline publishes a fast var.
- **The toggle**: the CLI's `/fast` descriptor is marked `supportsNonInteractive`, so unlike `/model` the SDK input stream interprets it. `set_fast` delivers the literal `/fast on|off` through the normal send path: the echo is the chat's acknowledgement, the CLI's confirmation follows as command feedback (including the model switch it performs when the session isn't on a fast-capable model). The flip is optimistic; init re-asserts on the next connect.
- **Press order**: `setFast` parks in the same FIFO as `/model` and `/effort` (in-place replace on a repeat pick). A dormant SDK session refuses loudly (warn toast) instead of pretending.
- **Both backends**: `set_fast` joins the SessionBackend ABC; tmux injects the args form (`/fast on` applies directly, no picker).
- Fast ON tints the badge with the CLI's own fastMode orange (`--fast`), a status color distinct from the accent.

## Tests

- `tests/test_sdk_backend.py`: set_fast delivery + optimistic flip, bad-value/dormant refusal, init capture of `fast_mode_state`/`disabled_reason` into the snapshot.
- `tests/test_kernel_send_park.py`: the fast op parks, replaces in place, and delivers like model/effort.
- `ui/webview/fast-toggle.test.ts`: source pins for the badge, the op, the kernel threading, and the hide-when-unavailable rule.
- `vscode-extension/src/pipe-intent.test.ts`: `setFast` survives a KernelPipe reconnect.

Full Python suite (3925 passed) and node suite (1668 passed) green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)