### PR TITLE
The optimistic send bubble paints on its own keystroke

### DIFF
--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -18,7 +18,26 @@ test("the plain send registers an optimistic bubble; follow-up/quote sends keep 
   assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: activeId, text \}\); registerOptimistic\(activeId, text\); \}/);
   // registerOptimistic shows it NOW (before any push) via reconcile + appendActive
   assert.match(RENDER, /function registerOptimistic\(id: string, text: string\): void/);
-  assert.match(RENDER, /reconcileOptimistic\(s\);\s*\n\s*if \(id === activeId\) appendActive\(\);/);
+  assert.match(RENDER, /if \(v\) v\.stale = true;\s*\n\s*if \(id === activeId\) appendActive\(\);/);
+});
+
+// The reconcile's two IN-PLACE tail mutations — merging into an existing queued group (a busy session
+// already showing queued messages) and pop+push on a repeat send — leave s.events.length unchanged, so
+// syncView's no-op fast path (rendered === len && !stale) concluded "nothing changed" and skipped the
+// repaint: the bubble waited for the NEXT kernel push, a visible beat after Enter (the user 2026-08-07).
+// Only the length-growing case (first send, bare tail) painted on the keystroke. registerOptimistic now
+// marks the view stale before appendActive, so every send takes the stale window re-render immediately.
+test("a send paints on ITS OWN keystroke even when the tail mutates in place (no length change)", () => {
+  // the stale mark sits between the reconcile and the repaint, so appendActive can't hit the fast path
+  assert.match(RENDER, /reconcileOptimistic\(s\);[\s\S]{0,700}const v = views\.get\(id\);\s*\n\s*if \(v\) v\.stale = true;\s*\n\s*if \(id === activeId\) appendActive\(\);/);
+  // the fast path it defeats keys on length + staleness — stale must veto the skip
+  assert.match(RENDER, /if \(v\.rendered === len && !v\.stale && v\.el\.childNodes\.length > 0\) return v;/);
+  // executed replica: the fast-path predicate must not skip once the view is marked stale, even though
+  // the in-place merge keeps the length equal to what was last rendered
+  const skips = (rendered: number, len: number, stale: boolean, children: number) =>
+    rendered === len && !stale && children > 0;
+  assert.equal(skips(50, 50, false, 50), true, "length-neutral mutation without the mark: skipped (the bug)");
+  assert.equal(skips(50, 50, true, 50), false, "the stale mark forces the repaint on the same keystroke");
 });
 
 test("every push entry point re-asserts (or retires) the optimistic tail", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -300,6 +300,14 @@ function registerOptimistic(id: string, text: string): void {
   const s = sessions.get(id);
   if (!s) return;
   reconcileOptimistic(s);
+  // The reconcile can mutate the tail IN PLACE — merging into an existing queued group, or pop+push
+  // on a repeat send — which leaves s.events.length unchanged, and syncView's no-op fast path
+  // (rendered === len) then skipped the repaint: the bubble waited for the next kernel push instead
+  // of this keystroke (the user 2026-08-07, who saw the delay on sends into a busy session). Marking
+  // the view stale takes the same window re-render a tool-group toggle uses, so the send paints NOW
+  // in every case, not just the length-growing bare-bubble one.
+  const v = views.get(id);
+  if (v) v.stale = true;
   if (id === activeId) appendActive();
 }
 


### PR DESCRIPTION
## What

Sending a message could show the provisional (dashed) bubble a beat late — it waited for the next kernel push instead of painting on the Enter keystroke.

## Why

`registerOptimistic`'s reconcile mutates the transcript tail **in place** in two cases: a send into a session already showing a queued group merges into that group, and a repeat send pops the old optimistic bubble and pushes a rebuilt one. Both leave `s.events.length` unchanged, so `syncView`'s no-op fast path (`rendered === len && !stale`) concluded nothing changed and skipped the repaint. Only the first send into a bare tail (a length change) painted immediately.

## Fix

`registerOptimistic` marks the view stale before `appendActive()` — the same invalidation a tool-group toggle uses — so every send takes the stale window re-render in the same keystroke.

## Tests

`ui/webview/optimistic-send.test.ts`: pins the stale mark between reconcile and repaint, pins the fast-path predicate it defeats, and adds an executed replica showing the predicate skips without the mark and repaints with it. Node suite (1669) green, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)