### PR TITLE
apiKeySource 'none' is a subscription login, not an API key

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2714,15 +2714,22 @@ class SdkBackend:
 
     def _note_auth_source(self, name, source) -> None:
         """An init message named HOW its CLI authenticates. API-key auth (apiKeySource e.g.
-        'ANTHROPIC_API_KEY'; absent on a subscription login — both verified live 2026-08-04) has NO
-        subscription windows, and get_usage just TIMES OUT there — no snapshot ever arrives to correct
-        usage.json, so after logging out the rail bars showed the last subscription reading forever,
-        frozen (the user 2026-08-04). The auth flip is the deciding event: flipping TO an API key drops
-        the stale windows (bars disappear, _usage() returns None on a window-less file) and gates the
-        pointless get_usage polls off; flipping BACK resumes them, and the next real snapshot repaints.
-        Logged raw each flip, so every host's kernel log self-documents its auth mode."""
+        'ANTHROPIC_API_KEY') has NO subscription windows, and get_usage just TIMES OUT there — no
+        snapshot ever arrives to correct usage.json, so after logging out the rail bars showed the
+        last subscription reading forever, frozen (the user 2026-08-04). The auth flip is the deciding
+        event: flipping TO an API key drops the stale windows (bars disappear, _usage() returns None on
+        a window-less file) and gates the pointless get_usage polls off; flipping BACK resumes them,
+        and the next real snapshot repaints. Logged raw each flip, so every host's kernel log
+        self-documents its auth mode.
+
+        A subscription login answers with the ABSENCE of an API key, and the CLI has said that two
+        ways: the field simply absent (verified live 2026-08-04), and — since about CLI 2.1.222 — the
+        literal string 'none' (two hosts' journals, 2026-08-08). A plain bool() read 'none' as truthy,
+        so every subscription machine was misclassified as API-key auth on every session init: windows
+        wiped, polls gated off, and the rail stuck on a lone event-derived bar that nothing could ever
+        heal — the /usage click included, because the gate returns before the request."""
         was = self.api_key_auth
-        self.api_key_auth = bool(source)
+        self.api_key_auth = bool(source) and str(source).strip().lower() != "none"
         if self.api_key_auth == was:
             return
         self._log("auth (%s): apiKeySource=%r — %s" % (name, source,

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1468,6 +1468,22 @@ class ApiKeyAuthUsage(unittest.TestCase):
         self.assertFalse(self.be.api_key_auth)
         self.assertEqual(self.p.read_text(), before, "no flip, no write")
 
+    def test_the_string_none_is_a_subscription_login_not_an_api_key(self):
+        """The CLI has said "no API key" two ways: the field absent (verified 2026-08-04) and — since
+        about CLI 2.1.222 — the literal string 'none' (both hosts' journals, 2026-08-08). bool('none')
+        is True, so the old check misread every subscription init as an API-key flip: it wiped the
+        usage windows and gated the polls off, leaving the rail a lone event-derived five-hour bar at
+        0% that no /usage click could ever heal (the gate returns before the request)."""
+        before = self.p.read_text()
+        self.be._note_auth_source("n", "none")
+        self.assertFalse(self.be.api_key_auth, "'none' means NO api key — a subscription login")
+        self.assertEqual(self.p.read_text(), before, "no wipe: the windows on file stay")
+        # and it flips an API-key backend BACK, exactly like the absent field
+        self.be._note_auth_source("n", "ANTHROPIC_API_KEY")
+        self.assertTrue(self.be.api_key_auth)
+        self.be._note_auth_source("n", "none")
+        self.assertFalse(self.be.api_key_auth, "'none' resumes usage polls after an API-key stretch")
+
     def test_flipping_back_keeps_the_file_for_the_next_snapshot(self):
         self.be._note_auth_source("n", "ANTHROPIC_API_KEY")
         dropped = self.p.read_text()


### PR DESCRIPTION
## What

The dashboard's usage bars broke on every subscription machine: weekly + Fable bars gone, a lone five-hour bar stuck at 0%, and the click-to-refresh doing nothing.

## Why

Claude Code (about 2.1.222+) now reports `apiKeySource: 'none'` on subscription logins, where it previously omitted the field. Romp's auth-flip detector (2026-08-04) classifies with `bool(source)` — and `'none'` is truthy — so every session init read as "switched to API-key auth": usage windows wiped, `get_usage` polls gated off (silently, before the request — which is why the heal click did nothing), and the only thing left was the ungated rate-limit event stream re-creating a fresh-window five-hour segment at 0%. Both attached hosts' journals show the misfire verbatim:

```
auth (rand): apiKeySource='none' — API-key auth: dropping stale /usage windows; usage polls off
```

## Fix

`'none'` reads as what it says — no API key. One line, plus tests covering both directions (no wipe on 'none'; 'none' flips an API-key backend back so polls resume). Self-healing on deploy: the next session init reclassifies, the next snapshot repaints all three windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)