### PR TITLE
The SDK handshake ends the opening chip, not the transcript

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4981,6 +4981,7 @@ class Sessions:
                                 "effortPending": bool(st.get("effortPending")),   # an /effort switch reconnecting → effort-badge dots + "Reloading session…"
                                 "retryCount": int(st.get("retryCount") or 0),   # api_retry backoff attempts → the chat's "API retrying — attempt N…" element
                                 "retryInfo": st.get("retryInfo") or None,   # the attempt's detail (attempt/max, error, next-attempt epoch) → the retrying element's context lines (the user 2026-07-10)
+                                "connected": bool(st.get("connected")),   # SDK handshake up → the opening-chip override stands down (fresh sessions have no transcript yet)
                                 "context": ctx if isinstance(ctx, (int, float)) else None, "compactPct": None,
                                 "fast": st.get("fast", ""),   # fast-mode state from the CLI's init ("on"/"off"/"cooldown"; "" = unknown → no badge)
                                 "fastReason": st.get("fastReason", ""),   # init's disabled_reason — non-empty hides the chat toggle
@@ -11757,9 +11758,15 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
         chip = _session_chip(sid, sess["path"], session, tm, now)   # THE shared derivation — identical to the timeline lane (the user 2026-07-03)
         # A session whose transcript DOESN'T EXIST YET is OPENING, whatever the snapshot claims (the
         # user 2026-08-05: a just-spawned tab said "Working" over a clock with no honest base). The
-        # transcript's first record is the deciding event: it lands, discover() sees it, and the normal
-        # derivation takes over. Never for an override render (a closed episode's path is historical).
-        if chip in ("working", "ready") and not path_override and not os.path.exists(sess["path"]):
+        # deciding event is per-backend. tmux: the transcript's first record — the only observable —
+        # lands, discover() sees it, and the normal derivation takes over. SDK: the backend KNOWS the
+        # earlier designed event, the handshake (tm.connected) — a fresh SDK session writes NO
+        # transcript until its first turn, so keying its chip on the file left a fully-up, idle
+        # session wearing the opening dots until the user's first message, indefinitely (the user
+        # 2026-08-08, who read minutes of dots as creation still running). Never for an override
+        # render (a closed episode's path is historical).
+        if chip in ("working", "ready") and not path_override and not os.path.exists(sess["path"]) \
+                and not tm.get("connected"):
             chip = "opening"
         faded = chip == "ready" and bool(tm["since"]) and now - tm["since"] > 3600
         # apiTooLong distinguishes a "prompt is too long" block (on YOU → red dashed tab) from a TRANSIENT API

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2321,6 +2321,12 @@ class SdkSession:
                 "modelPending": bool(self._model_pending),   # a /model switch resolving → the badge shows switching-dots
                 "effortPending": bool(self._effort_pending),   # an /effort switch reconnecting → effort-badge dots + "Reloading session…"
                 "mode": self.perm_mode, "ctx": self._ctx_pct(), "summary": "",
+                "connected": bool(self.client),   # the SDK handshake is up (set at connect, cleared at
+                #   teardown) — the "this session is OPEN" event for a transcript-less fresh session:
+                #   the kernel's opening-chip override stands down on it, so a new SDK session reads
+                #   ready the moment it can take a message instead of wearing the opening dots until
+                #   its first turn writes a transcript (the user 2026-08-08, whose fresh session sat
+                #   on animated dots for minutes while fully up)
                 "fast": self.fast,   # fast-mode state from init ("on"/"off"/"cooldown"; "" = unknown → no badge)
                 "fastReason": self.fast_reason,   # init's disabled_reason — non-empty hides the chat toggle
                 "retryCount": self.retry_count,   # api_retry backoff attempts in the current storm → the live 'attempt N' in the chat's retrying element

--- a/tests/test_kernel_opening_chip.py
+++ b/tests/test_kernel_opening_chip.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""The opening chip's deciding event is per-backend.
+
+A session whose transcript doesn't exist yet reads "opening" (2026-08-05: a just-spawned tab said
+"Working" over a clock with no honest base). For tmux the transcript's first record is the only
+observable, so the file IS the event. For an SDK session it isn't: a fresh SDK session writes NO
+transcript until its first turn, so keying the chip on the file left a fully-up, idle session wearing
+the animated opening dots until the user's first message — indefinitely (the user 2026-08-08, who read
+minutes of dots as creation still running). The SDK backend knows the earlier designed event — the
+handshake (snapshot `connected`, set the moment the client context opens) — and the override stands
+down on it.
+
+SYNTHETIC fixtures only (placeholder uuid, temp dirs), modeled on test_chat_payload_clock_invariant.
+"""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+jd = SourceFileLoader("romp_judge_openchip", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_openchip", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NOW = 1781100000
+
+
+class OpeningChipDecidingEvent(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        self.pdir = proj / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        self.pdir.mkdir(parents=True)
+        names = td / "names"; names.mkdir()
+        (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
+        # Patch BOTH judge instances: this module's `jd` and the kernel's own `km.jd` — kernel.py loads
+        # judge.py itself (SourceFileLoader "romp_judge"), so they are distinct module objects, and
+        # _sessions()/discover() reads km.jd. Patching only the test's jd leaves discovery scanning the
+        # real ~/.claude/projects, and the fixture transcript is never found (chip stuck "opening").
+        self.saved = [(m, k, getattr(m, k)) for m in (jd, km.jd)
+                      for k in ("NAMES", "PROJECTS", "CAPDIR", "ARCHDIR", "GOALDIR", "STATE")]
+        self.saved += [(km, "NAMES", km.NAMES), (km, "_tmux_sessions", km._tmux_sessions),
+                       (km, "_GLOBAL_CLAUDE_MD", km._GLOBAL_CLAUDE_MD)]
+        for m in (jd, km.jd):
+            m.NAMES, m.PROJECTS = names, proj
+            m.CAPDIR, m.ARCHDIR, m.GOALDIR = td / "captions", td / "archive", td / "goals"
+            m.STATE = td
+        km.NAMES = names
+        km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+        self.tm = {"state": "waiting", "since": NOW - 5, "model": "Opus 5", "effort": "xhigh",
+                   "context": None, "compactPct": None, "color": None, "backend": "sdk"}
+        km._tmux_sessions = lambda: {SID: dict(self.tm)}
+
+    def tearDown(self):
+        for m, k, v in self.saved:
+            setattr(m, k, v)
+        self.td.cleanup()
+
+    def _state(self):
+        m = km.build_session(SID, NOW)
+        self.assertIsNotNone(m, "fixture session must build")
+        return (m.get("status") or {}).get("state")
+
+    def test_no_transcript_and_no_handshake_is_opening(self):
+        # spawned but the CLI hasn't proven up and nothing is on disk → opening (the 2026-08-05 rule)
+        self.assertEqual(self._state(), "opening")
+
+    def test_the_sdk_handshake_ends_opening_before_any_transcript_exists(self):
+        # a fresh SDK session is fully open the moment its client connects — its transcript only
+        # appears with the FIRST TURN, so the file must not keep the dots up on a ready session
+        self.tm["connected"] = True
+        self.assertEqual(self._state(), "ready",
+                         "connected + idle = ready to take a message; the dots would be a lie")
+
+    def test_the_transcripts_first_record_still_ends_opening(self):
+        # the tmux path (no `connected` signal): the file landing remains the deciding event. A
+        # COMPLETED turn, so the chip settles to ready rather than working (an open turn).
+        def iso(t):
+            return datetime.fromtimestamp(t, timezone.utc).isoformat().replace("+00:00", "Z")
+        (self.pdir / (SID + ".jsonl")).write_text("\n".join(json.dumps(r) for r in [
+            {"type": "user", "timestamp": iso(NOW - 60), "uuid": "u1", "parentUuid": None,
+             "promptSource": "typed", "message": {"role": "user", "content": "start the notes-api spike"}},
+            {"type": "assistant", "timestamp": iso(NOW - 20), "uuid": "a1", "parentUuid": "u1",
+             "message": {"role": "assistant", "content": [{"type": "text", "text": "Spike is up."}],
+                         "stop_reason": "end_turn"}},
+        ]) + "\n")
+        self.assertEqual(self._state(), "ready")

--- a/ui/webview/opening-state.test.ts
+++ b/ui/webview/opening-state.test.ts
@@ -15,8 +15,20 @@ const CSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "styles.css"), "utf
 const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
 
 test("the kernel reports OPENING while the transcript doesn't exist — never a working chip on a broken clock", () => {
-  assert.ok(KERNEL.includes('if chip in ("working", "ready") and not path_override and not os.path.exists(sess["path"]):'));
+  assert.ok(KERNEL.includes('if chip in ("working", "ready") and not path_override and not os.path.exists(sess["path"]) \\'));
+  assert.ok(KERNEL.includes('and not tm.get("connected"):'));
   assert.ok(KERNEL.includes('chip = "opening"'));
+});
+
+// The deciding event is per-backend (the user 2026-08-08, who read minutes of dots as creation still
+// running): a fresh SDK session writes NO transcript until its first turn, so keying its chip on the
+// file left a fully-up idle session on the opening dots indefinitely. The SDK handshake (snapshot
+// `connected`, set the moment the client context opens) stands the override down; tmux — whose only
+// observable IS the file — keeps the transcript's first record as its event.
+test("the SDK handshake ends OPENING before any transcript exists", () => {
+  const SDK = fs.readFileSync(path.join(ROOT, "kernel", "sdk_backend.py"), "utf8");
+  assert.ok(SDK.includes('"connected": bool(self.client)'), "the snapshot carries the handshake event");
+  assert.ok(KERNEL.includes('"connected": bool(st.get("connected"))'), "the live merge threads it through");
 });
 
 test("the statusline shows Opening + dots for BOTH the pre-payload tab and the kernel's opening state", () => {


### PR DESCRIPTION
## What

A freshly created SDK session showed the animated "Opening…" dots until its **first message**, however long that took — minutes of dots on a session that was ready within seconds (today's live repro: a new session sat idle-but-ready from 09:45:37, dots up, until its first turn at 09:50:15 wrote the transcript).

## Why

The opening chip (2026-08-05) keys on the transcript file existing. Right for tmux (the file is the only observable); wrong for SDK sessions, which write no transcript until the first turn — so "fully up and idle" was indistinguishable from "still starting".

## Fix

The SDK backend reports the earlier designed event: the handshake. `snapshot()` carries `connected` (set exactly when the client context opens, cleared at teardown), the live merge threads it through, and the opening override stands down on it. tmux behavior unchanged.

## Tests

- `tests/test_kernel_opening_chip.py` (new): no transcript + no handshake → opening; handshake alone → ready; transcript's first completed turn alone → ready.
- `ui/webview/opening-state.test.ts`: pins updated for the per-backend condition + the snapshot/merge threading.

Full Python suite (3928) and node suite (1670) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)