### PR TITLE
Feed: Continue on needs-you cards, a one-click canned keep-going reply

### DIFF
--- a/docs/goal-state.md
+++ b/docs/goal-state.md
@@ -92,7 +92,10 @@ Sort events by evidence time (`ev_t`; arrival `at` breaks ties) and replay:
 Judge rulings at segment/turn end · your reply (any column; reopens
 instantly, optimistically, moves the card to Working, and clears blocks across
 the card's whole subtree (you reply to the card, never to its blocked
-sub-goals) · Clear / Undo clear · Resolve · the agent checking off its to-dos ·
+sub-goals) · Continue (a needs-you card's one-click canned reply, 2026-08-08:
+"nothing needed from me, keep going" — the same reply path end to end, so it
+inherits the optimistic reopen and the judges' reassert; never a bare column
+move) · Clear / Undo clear · Resolve · the agent checking off its to-dos ·
 a peer completing delegated work (courier link-back) · a failed auto-nudge
 (records a block) · the settle moment · the live floors below.
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -682,6 +682,21 @@ def _open_leaf_bullets(nodes, subs, cap=12, indent="  "):
     return out
 
 
+# The Continue button's canned reply (the user 2026-08-08): one click on a needs-you card whose ask the
+# user has nothing to add to. Sent as an ORDINARY follow-up so the whole reply path applies: context
+# quote, goal marker, optimistic reopen + subtree unblock, judge reassert, and the followupAt floor.
+# The evidence behind the button (14 days of card history, 2026-07-25..08-08): 58% of blocked episodes
+# resolved with no user gesture on the card while the card sat a median 5 minutes (p90 72m) in
+# needs-you; a fifth of Clears landed on sessions visibly mid-turn, where Clear's wrap-up says the
+# opposite of what the user meant; and the short-reply tail was dominated by hand-typed go-aheads.
+# VOICE (test_injected_voice.py renders this through _followup_body): the person the agent works for,
+# no tracking-system nouns. The last line licenses one sharp re-ask when the block is REAL (the agent
+# needs something only the user has): the judges then re-block from that reply, a correct move on new
+# information, so a mispressed Continue costs one turn and returns a tighter brief.
+CONTINUE_TEXT = ("Nothing needed from me here. Keep going, and make any open calls yourself. "
+                 "If you can't proceed without me, say exactly what you need in one line.")
+
+
 def _followup_body(iid, title, text, injected=False, auto=False, stalled=False):
     """Pane message for a feed follow-up: QUOTE the ask being followed up ('> <ask>') above the user's
     text, so the recipient session knows what the reply answers. An explicit `title` (the group modal) is
@@ -4058,8 +4073,16 @@ def _drive(msg, client):
         # (the user 2026-07-01): the SDK path used to take raw text, so an SDK follow-up got no context quote
         # and no header; wrapping unifies it (the SDK `send` is a plain text send, no injection of its own).
         # nudge:true (the canned Nudge button) → romp-authored gray bubble; a typed follow-up → blue human.
-        body = (_followup_body(iid, msg.get("title"), msg["text"], injected=bool(msg.get("nudge")))
-                if iid else str(msg["text"]))
+        # cont:true is the card's Continue button (the user 2026-08-08): the one-click "nothing needed
+        # from me, keep going" reply on a needs-you card. The TEXT is the kernel's (CONTINUE_TEXT: one
+        # source of truth, voice-tested); everything else rides this typed-reply arm UNCHANGED, because
+        # the button's design is a reply with a canned body, never a new mechanism. The removed
+        # messageless cardMove is the cautionary tale: a move with no message adds no information, so
+        # its natural end state was parked-in-Working. Human-authored like the modal's canned Check
+        # status (no romp-injected marker): the gesture asserts the USER's own state, in their voice.
+        text = CONTINUE_TEXT if msg.get("cont") else str(msg["text"])
+        body = (_followup_body(iid, msg.get("title"), text, injected=bool(msg.get("nudge")))
+                if iid else text)
         # Optimistic echo for a tmux follow-up/nudge (the user 2026-06-29): without it, a follow-up sent while
         # the session is WORKING showed as a queued bubble that VANISHED in the dequeue→landed gap (the queue-op
         # record resolves before the real user atom lands). The echo + the while-working queued fold keep it
@@ -4074,7 +4097,7 @@ def _drive(msg, client):
             #                                               next push confirms it against
             ok = False
             try:
-                ok = bool(jd.optimistic_followup(sid, iid, text=str(msg["text"]), now=int(time.time())))
+                ok = bool(jd.optimistic_followup(sid, iid, text=text, now=int(time.time())))
                 if ok:
                     # (the reopen event holds the top open + wears the chip; stub nodes retired 2026-07-07)
                     _note_user_goal_write(sid)            # …and it shows even mid-judge-pass (_feed_goals)

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -104,6 +104,9 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
                 km._followup_body(TOP, None, km.AUTO_NUDGE_STALLED_TEXT, injected=True, auto=True,
                                   stalled=True),
             "typed follow-up on a summary": km._followup_body(TOP, None, "ship it"),
+            # the Continue button's canned reply (the user 2026-08-08) — rides the typed-reply path,
+            # rendered exactly as the recipient session will see it
+            "continue button": km._followup_body(TOP, None, km.CONTINUE_TEXT),
             "multi-goal bundle": km._nudge_bundle_body([TOP, TOP2], nodes, set()),
             "multi-goal bundle (fork)": km._nudge_bundle_body([TOP, TOP2], nodes, {TOP}),
             "clear wrap-up": km._clear_wrap_body([TOP], nodes),

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1141,6 +1141,20 @@ class ViewBuilder(unittest.TestCase):
         src = inspect.getsource(km._drive)
         self.assertIn('echo=("romp" if msg.get("nudge") else "human") if be is _TMUX else None', src)
 
+    def test_continue_button_rides_the_followup_arm_with_the_kernel_canned_body(self):
+        # the Continue button (the user 2026-08-08) posts askFollowUp cont:true; the kernel substitutes
+        # CONTINUE_TEXT and the arm otherwise IS the typed-reply path — same body compose, same optimistic
+        # reopen, same ack. A reply with a canned body, never a new mechanism: the removed messageless
+        # cardMove showed that a move with no message adds no information and parks the card in Working.
+        import inspect
+        src = inspect.getsource(km._drive)
+        self.assertIn('text = CONTINUE_TEXT if msg.get("cont") else str(msg["text"])', src)
+        self.assertIn("jd.optimistic_followup(sid, iid, text=text, now=int(time.time()))", src)
+        # the canned body ends with the one-line escape hatch: a REAL block (the agent needs something
+        # only the user has) comes back as one sharp re-ask, which the judges re-block from — the
+        # correct move on new information, so a mispressed Continue costs one turn, not the thread
+        self.assertIn("say exactly what you need in one line", km.CONTINUE_TEXT)
+
     def test_feed_awaiting_via_session_signal_is_held_in_working_with_a_badge(self):
         # AWAITING = a flavor of WORKING (the user 2026-06-22): when the EVENT-MODEL signal says the session
         # is paused on dispatched/delegated work, its working top stays in the working column (never

--- a/ui/webview/done-confirming.test.ts
+++ b/ui/webview/done-confirming.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const dcBadge = el\("span", "fask-doneconfirming"\)/);
   assert.match(FEED, /dcBadge\.textContent = "done, confirming"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._doneConfirming = dcBadge;/);
 });
 

--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -12,16 +12,19 @@ import * as path from "node:path";
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
 
-test("COMPACTNESS (the user 2026-07-07): time trails the title; Clear on the name row; toggles grouped on row3", () => {
+test("COMPACTNESS (the user 2026-07-07; action corner 2026-08-08): time trails the title; Continue+Clear in row1's corner; toggles grouped on row3", () => {
   // the TIME now trails the title on row1 (both cards); row3 holds the Background/Summary/Sub-goals toggles
   assert.match(FEED, /row1\.append\(title, time\)/, "the time trails the title on row1");
   assert.match(FEED, /row3\.append\(bgBtn, takeBtn, stallBtn, subBtn, taskBtn, actions\)/, "ask card: row3 is Background/Summary/Stalled/Sub-goals/Waiting-on-task (+ rare Retry/Revive)");
   assert.match(FEED, /actions\.append\(apiRetry, revive,/, "…so the action row is Retry/Revive (+ resume-gate) only (Clear + toggles moved up)");
-  // Clear is the rightmost control on the NAME row now (both ask + group cards)
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "ask card: Clear on the name row");
+  // the action corner (the user 2026-08-08): Continue+Clear ride the END of row1 in every mode; the
+  // name row keeps only identity + chips
+  assert.match(FEED, /btns\.append\(cont, clr\);/, "ask card: Continue left of Clear in the action corner");
+  assert.match(FEED, /row1\.append\(btns\);/, "the corner floats from the END of row1's flow (title+time keep first claim)");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "ask card: the name row is identity + chips only");
   // its tooltip is plain-spoken (the user 2026-07-13): "clear this task", not the inbox-zero jargon
   assert.match(FEED, /clr\.title = "clear this task";/);
-  assert.match(FEED, /row2\.append\(idwrap, clr\)/, "group card: Clear on the name row");
+  assert.match(FEED, /btns\.append\(clr\);\s*\n\s*row1\.append\(btns\);\s*\n\s*row2\.append\(idwrap\);/, "group card: Clear in row1's action corner, name row is the name only");
   // the group card has no row3 anymore (its only content, the time, moved to row1)
   assert.match(FEED, /main\.append\(row1, row2, memberList\)/, "group card: no row3 (time moved to row1)");
   assert.doesNotMatch(FEED, /const row3 = el\("div", "fask-row3"\); row3\.append\(time\)/, "the group card's time-only row3 is gone");
@@ -57,7 +60,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
   assert.match(FEED, /const origin = el\("a", "fask-origin"\); origin\.style\.display = "none"/);
   // it's a direct child of the wrapping row2 (NOT nested in idwrap) so a narrow card wraps it under the
   // name instead of overlapping the chips (the user 2026-06-20)
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "the origin marker rides the name row beside the chips");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "the origin marker rides the name row beside the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested inside idwrap");
   // populated from it.origin in the update path: a dim gray "↪ from" + the peer in the bold session-name
   // style (its own identity colour); click opens the sender (the user 2026-06-16)
@@ -74,7 +77,7 @@ test("courier handoff: the '↪ from <sender>' origin marker is wired and styled
 test("the follow-up badge serves ONLY '↩ re-judging' now — the '↻ Followed up' chip was removed (the user 2026-07-01)", () => {
   assert.match(FEED, /el\("span", "fask-followedup"\); fupBadge\.textContent = "↩ re-judging"/);
   // the badge rides the SESSION-NAME row (right-justified), NOT the bottom action row
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   // the CARD badge block is now recheck-only: recheck → "↩ re-judging", else hidden. No followupPending branch.
   // (The modal tree's per-node "↻ Followed up" chip, ftree-followedup, is a separate thing and stays.)
   assert.match(FEED, /if \(it\.recheck\) \{\s*\n\s*a\._followedup\.style\.display = "";\s*\n\s*a\._followedup\.textContent = "↩ re-judging";[\s\S]*?\} else \{\s*\n\s*a\._followedup\.style\.display = "none";\s*\n\s*\}/);

--- a/ui/webview/feed-checkstatus.test.ts
+++ b/ui/webview/feed-checkstatus.test.ts
@@ -19,11 +19,11 @@ test("the manual Nudge button is gone (Auto Nudge replaces it)", () => {
   assert.match(FEED, /actions\.append\(apiRetry, revive,/);
 });
 
-test("the modal footer is age · Follow up · Check status · Clear", () => {
+test("the modal footer is age · Follow up · Check status · Continue · Clear", () => {
   // "Check status" (the user 2026-07-20) is NOT the old manual Nudge coming back: the Nudge was a
   // contentless poke at a stalled session (auto-nudge replaced it, above); Check status is a per-item
   // sweep — one message asking where every open/blocked sub-goal stands, whose replies file back per item.
-  assert.match(FEED, /footRow\.append\(age, fup, cs, clr\)/);   // cs = Check status ("Move to Working" removed, the user 2026-07-25)
+  assert.match(FEED, /footRow\.append\(age, fup, cs, cont, clr\)/);   // cs = Check status ("Move to Working" removed, the user 2026-07-25)
   assert.match(FEED, /el\("button", "fdismiss feed-modal-status"\)/);
   assert.match(FEED, /cs\.textContent = "Check status"/);
 });

--- a/ui/webview/feed-continue.test.ts
+++ b/ui/webview/feed-continue.test.ts
@@ -1,0 +1,66 @@
+// The CONTINUE button (the user 2026-08-08): a needs-you card's one-click "nothing needed from me,
+// keep going". It is a REPLY with a kernel-canned body — askFollowUp cont:true — never a bare column
+// move (the messageless cardMove was removed 2026-07-25 for exactly that: a move with no message adds
+// no information). The card history that earned it (2026-07-25..08-08): 58% of blocked episodes
+// resolved with no user gesture on the card, and a fifth of Clears landed on sessions visibly
+// mid-turn — a "stop" sent where the user meant "keep going".
+//
+// Layout (the user 2026-08-08): Clear sits as high and as far right as it can while the title and the
+// time-ago keep first claim; Continue sits LEFT of Clear when they share a line; when only one button
+// fits per line, Clear takes the upper line. No jsdom for the feed renderer, so pin at the source.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("Continue posts askFollowUp cont:true — the kernel owns the canned body (one voice-tested home)", () => {
+  // the client sends only the gesture; no text rides along, so the copy can't fork from CONTINUE_TEXT
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "askFollowUp", itemId: it\.itemId, sid: it\.sid, cont: true \}\);/);
+  // the kernel substitutes its constant and the arm otherwise IS the typed-reply path (optimistic
+  // reopen included) — pinned here because the button's whole design is "a reply, not a new mechanism"
+  assert.match(KERNEL, /text = CONTINUE_TEXT if msg\.get\("cont"\) else str\(msg\["text"\]\)/);
+  assert.match(KERNEL, /CONTINUE_TEXT = \("Nothing needed from me here\./);
+});
+
+test("Continue shows only on a LIVE needs-you card with no live ask (and never on a placeholder)", () => {
+  // a live permission/picker/apiError/quarantine block (it.blocked) can't be answered by "keep going" —
+  // text sent there would queue behind the ask; Working/Completed cards have nothing to continue
+  assert.match(FEED, /contBtn\.style\.display = \(askColumn\(it\) === "needsInput" && it\.live && !it\.provisional && !it\.blocked\)/);
+});
+
+test("Continue acknowledges INSTANTLY (disable + relabel) and re-arms only after the judge has ruled", () => {
+  // the click-safety rule: the ack precedes any kernel round-trip; same contract as the modal's
+  // Check status ("Sent" survives re-renders while followupPending/recheck holds)
+  assert.match(FEED, /cont\.disabled = true; cont\.textContent = "Sent";/);
+  assert.match(FEED, /optimisticFollowMove\(it\.itemId\);\s*\n\s*render\(\);\s*\n\s*\};/);
+  assert.match(FEED, /if \(contBtn\.disabled && !it\.followupPending && !it\.recheck && !it\.rejudging\) \{\s*\n\s*contBtn\.disabled = false; contBtn\.textContent = "Continue";\s*\n\s*\}/);
+});
+
+test("the action corner: Continue left of Clear on one line; Clear on the UPPER line when they stack", () => {
+  // source order [cont, clr] + row flex = Continue left of Clear when they share a line; wrap-reverse
+  // places the overflow line ABOVE the first, so Clear (second in source, the one that wraps) lands on
+  // the upper line when only one button fits per line — Clear stays as high and right as it can
+  assert.match(FEED, /btns\.append\(cont, clr\);/);
+  assert.match(CSS, /\.fask-btns \{ float: right; margin-left: 8px; display: flex; flex-wrap: wrap-reverse;\s*\n\s*justify-content: flex-end; gap: 3px 8px; \}/);
+  // the corner floats from the END of row1's inline flow, so the title + time-ago keep first claim
+  assert.match(FEED, /row1\.append\(bellBtn\);/);
+  assert.match(FEED, /row1\.append\(btns\);/);
+});
+
+test("no re-home dance: the corner lives in row1 in EVERY mode (strongest form of click-safety)", () => {
+  assert.doesNotMatch(FEED, /clrHome/, "the grouped-mode Clear re-home is gone");
+});
+
+test("the modal footer carries the same Continue (single-ask branch), left of Clear", () => {
+  assert.match(FEED, /const cont = el\("button", "fdismiss feed-modal-continue"\); cont\.id = "feed-modal-continue"; cont\.textContent = "Continue";/);
+  assert.match(FEED, /footRow\.append\(age, fup, cs, cont, clr\)/);
+  // same gating + ack contract as the card button
+  assert.match(FEED, /if \(contEl && askColumn\(it\) === "needsInput" && it\.live && !it\.provisional && !it\.blocked\) \{/);
+  assert.match(FEED, /contEl\.disabled = true; contEl\.textContent = "Sent";/);
+  // default-hidden and reset each render; only the single-ask branch shows it
+  assert.match(FEED, /if \(contEl\) \{ contEl\.style\.display = "none"; \}/);
+});

--- a/ui/webview/feed-delegation.test.ts
+++ b/ui/webview/feed-delegation.test.ts
@@ -45,7 +45,7 @@ test("a narrow card WRAPS the '↪ from' provenance under the name instead of ov
   // chip. Fix: row2 wraps, and origin is a direct row2 child (sibling of the chips) so it drops to a
   // second line rather than overlapping when name + provenance + chips don't all fit.
   assert.match(CSS, /\.fask-row2 \{[^}]*flex-wrap: wrap/, "the name row wraps so trailing items never overlap");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/, "origin is a row2 sibling of the chips");
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/, "origin is a row2 sibling of the chips");
   assert.doesNotMatch(FEED, /idwrap\.append\(name, origin\)/, "origin is no longer nested in the shrinking idwrap");
   // the old overflow mechanism is gone — flex-grow on idwrap right-aligns it instead of an auto margin
   assert.doesNotMatch(CSS, /\.fask-origin \{[^}]*margin-left: auto/);

--- a/ui/webview/feed-group-mode.test.ts
+++ b/ui/webview/feed-group-mode.test.ts
@@ -1,8 +1,9 @@
 // GROUPED mode (the user 2026-07-13): a footer "Group" toggle organizes each column BY SESSION — session
 // order = the kernel's session-order list (the same order the chat tabs + timeline lanes hold), a
 // name+working-dot header on the column backdrop opens each session's run, and the cards below drop their
-// own name row (the header carries the identity). Clear re-homes beside the timestamp (float-right: on the
-// time line when it fits, else its own right-justified line — the compactness ladder). Source pins.
+// own name row (the header carries the identity). (Clear used to re-home beside the timestamp in this mode
+// only; since 2026-08-08 the action corner lives in row1 in EVERY mode — see feed-continue.test.ts.)
+// Source pins.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -47,15 +48,16 @@ test("a name+dot header entry opens each session's run; only runs that exist get
   assert.match(CSS, /\.feed-sess-head \{ display: flex; flex-wrap: wrap; align-items: center;/);
 });
 
-test("grouped cards drop their own name row; Clear re-homes beside the timestamp (guarded move)", () => {
-  // the name row hides (the header carries it); Clear moves ONLY on a mode change (click-safety) — a
-  // steady-state re-render never detaches the button mid-press
+test("grouped cards drop their own name row; the action corner needs no re-home (2026-08-08)", () => {
+  // the name row hides (the header carries it)
   assert.match(FEED, /\(\(a\._name as HTMLElement\)\.parentElement as HTMLElement\)\.style\.display = gmode \? "none" : "";/);
-  assert.match(FEED, /if \(\(a\._clr as HTMLElement\)\.parentElement !== clrHome\) clrHome\.append\(a\._clr\);/);
-  // row2 hides once nothing on it shows (ask card: badges may remain; group card: always name+Clear)
+  // the Clear re-home between rows is GONE: the action corner (fask-btns) lives in row1 in every mode,
+  // so a mode flip moves nothing — the strongest form of the click-safety rule
+  assert.doesNotMatch(FEED, /clrHome/);
+  // row2 hides once nothing on it shows (ask card: badges may remain; group card: only the name now)
   assert.match(FEED, /r2\.style\.display = gmode && !r2live \? "none" : "";/);
   // float-right = right-justified beside the time when it fits, else its own right-aligned line
-  assert.match(CSS, /\.fask-row1 \.fdismiss \{ float: right; margin-left: 8px; \}/);
+  assert.match(CSS, /\.fask-btns \{ float: right; margin-left: 8px;/);
 });
 
 test("clearing a run's last card drops its session header at once, not on the next push (the user 2026-07-13)", () => {

--- a/ui/webview/feed-interrupted.test.ts
+++ b/ui/webview/feed-interrupted.test.ts
@@ -15,7 +15,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the interrupted badge is built once and rides the wrapping chip row", () => {
   assert.match(FEED, /const intBadge = el\("span", "fask-interrupted"\)/);
   assert.match(FEED, /intBadge\.textContent = "interrupted"/, "text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._interrupted = intBadge;/);
 });
 

--- a/ui/webview/feed-interrupting.test.ts
+++ b/ui/webview/feed-interrupting.test.ts
@@ -15,7 +15,7 @@ test("the interrupting badge is built once and rides the wrapping chip row", () 
   assert.match(FEED, /const intingBadge = el\("span", "fask-interrupting"\)/);
   assert.match(FEED, /intingBadge\.textContent = "interrupting…"/, "text label, no emoji/glyph");
   // sits immediately left of the past-tense interrupted badge on the same wrapping row
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._interrupting = intingBadge;/);
 });
 

--- a/ui/webview/feed-modal-layout.test.ts
+++ b/ui/webview/feed-modal-layout.test.ts
@@ -4,7 +4,7 @@
 //     its top-level goal IS the tree root, a notch larger than its sub-items);
 //   - the tree/checklist sits directly below, with per-node "(Xm ago)" times pulled in close to the
 //     content (fit-content) and right-aligned, in parentheses;
-//   - BOTTOM bar: the (recency-tinted) age + Follow up + Clear in one row, the composer dropping in below.
+//   - BOTTOM bar: the (recency-tinted) age + Follow up + Continue + Clear in one row, the composer dropping in below.
 // No jsdom harness for the feed, so — like the other feed-*.test.ts — pin it at the source level.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -26,8 +26,8 @@ test("TOP bar = session name (left) + ✕ (right); age is no longer in the heade
   assert.match(CSS, /\.feed-modal-close \{[^}]*margin-left: auto/);   // ✕ pinned far-right
 });
 
-test("BOTTOM bar = age + Follow up + Check status + Clear in one row, the checklist sitting above it", () => {
-  assert.match(FEED, /footRow\.append\(age, fup, cs, clr\)/);   // Nudge moved off the footer onto the card (the user 2026-06-18); Move to Working removed (the user 2026-07-25); cs the user 2026-07-20
+test("BOTTOM bar = age + Follow up + Check status + Continue + Clear in one row, the checklist sitting above it", () => {
+  assert.match(FEED, /footRow\.append\(age, fup, cs, cont, clr\)/);   // Nudge moved off the footer onto the card (the user 2026-06-18); Move to Working removed (the user 2026-07-25); cs the user 2026-07-20
   // the per-sub follow-up target label sits between the button row and the composer box
   assert.match(FEED, /foot\.append\(nudges, footRow, futgt, fubox\)/);
   assert.match(FEED, /inner\.append\(head, body, foot\)/);            // head, then tree, then footer

--- a/ui/webview/feed-nudge-failed.test.ts
+++ b/ui/webview/feed-nudge-failed.test.ts
@@ -16,7 +16,7 @@ test("the follow-up-failed chip is built once and rides the wrapping chip row", 
   assert.match(FEED, /const nfBadge = el\("span", "fask-nudgefailed"\)/);
   assert.match(FEED, /nfBadge\.textContent = "follow-up failed"/,
     "the label is 'follow-up failed' (the user 2026-07-23) — 'stalled' is the yellow section's word; no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._nudgeFailed = nfBadge;/);
 });
 

--- a/ui/webview/feed-waiton.test.ts
+++ b/ui/webview/feed-waiton.test.ts
@@ -12,7 +12,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 
 test("a waiting-on chip is built and rides the wrapping chip row (its own line when it doesn't fit)", () => {
   assert.match(FEED, /const waitOnBadge = el\("span", "fask-waiton"\)/);
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._waitOn = waitOnBadge;/);
 });
 

--- a/ui/webview/feed-warn-chip.test.ts
+++ b/ui/webview/feed-warn-chip.test.ts
@@ -15,7 +15,7 @@ test("the warning chip is a button built once, riding the wrapping chip row", ()
   assert.match(FEED, /const warnChip = el\("button", "fask-warnchip"\)/,
     "a BUTTON (focusable), not a span — it has a click action");
   assert.match(FEED, /warnChip\.textContent = "warning"/, "plain text label, no emoji/glyph");
-  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr\)/);
+  assert.match(FEED, /row2\.append\(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge\)/);
   assert.match(FEED, /a\._warnChip = warnChip;/);
 });
 

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -169,10 +169,15 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fask-row1 { display: flow-root; }
 .fask-row1 .fcard-title { display: inline; }
 .fask-row1 .ftime { margin-left: 8px; }
-/* GROUPED mode (the user 2026-07-13): Clear floats right on the TIME line — right-justified beside the
-   timestamp when it fits, else it drops to its own right-aligned line (the compactness ladder; row1's
-   flow-root above is what makes that line take real height instead of overlaying row 3). */
-.fask-row1 .fdismiss { float: right; margin-left: 8px; }
+/* The ACTION CORNER, every mode (the user 2026-08-08; generalizes the 2026-07-13 grouped-mode float):
+   Clear — plus Continue on a needs-you card — floats right on the TIME line, right-justified beside the
+   timestamp when it fits, else dropping to its own right-aligned line. Title + time keep first claim on
+   the width (the float anchors at the END of the inline flow); row1's flow-root makes the dropped line
+   take real height. Inside the group, wrap-reverse places the OVERFLOW line ABOVE the first: when only
+   one button fits per line, Clear (second in source, so it is the one that wraps) lands on the upper
+   line — Clear above Continue; on one line Continue sits left of Clear, in source order. */
+.fask-btns { float: right; margin-left: 8px; display: flex; flex-wrap: wrap-reverse;
+  justify-content: flex-end; gap: 3px 8px; }
 /* the by-session header on the column BACKDROP opening that session's run of cards: identity-colored
    name + the working dot; cards under it drop their own name row. NO font-size of its own (the user
    2026-07-13): it wears the base size + weight the CARD TITLES render at, so the two read as one rank. */

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -769,6 +769,23 @@ function makeAskCard(it: AskItem): HTMLElement {
   // agents" box in the card body, which says the same thing with room for the full "why" — so the chip was
   // pure redundancy. The awaiting state now reads only from that body box (see the awaitSpin block below).
   const clr = el("button", "fdismiss"); clr.textContent = "Clear"; clr.title = "clear this task";   // plain-spoken (the user 2026-07-13, over the inbox-zero jargon)
+  // "Continue" (the user 2026-08-08): the needs-you card's one-click "nothing needed from me, keep
+  // going" — a REPLY with a kernel-canned body (askFollowUp cont:true), never a bare column move (the
+  // removed cardMove is the cautionary tale: a move with no message adds no information). The card
+  // history that earned it (2026-07-25..08-08): 58% of blocked episodes resolved with no input on the
+  // card, and a fifth of Clears landed on sessions visibly mid-turn — a "stop" sent where the user
+  // meant "keep going". Shown only on live needs-you cards without a live ask (updateAskCard).
+  const cont = el("button", "fdismiss fcontinue") as HTMLButtonElement; cont.textContent = "Continue";
+  cont.title = "nothing needed from you — tells this session to keep going and decide open questions itself";
+  cont.style.display = "none";
+  // The action corner (the user 2026-08-08): Continue+Clear ride the END of row1 in EVERY mode —
+  // right-justified beside the timestamp when there's room, dropping below when the title/time need
+  // the width (they keep first claim). wrap-reverse stacks the overflow line UNDER the first, so when
+  // only one button fits per line Clear stays the higher one; on one line Continue sits left of Clear
+  // (source order). Generalizes the grouped-mode float (2026-07-13) to all modes — the re-home dance
+  // between rows is gone, which is the strongest form of the click-safety rule (the buttons never move).
+  const btns = el("span", "fask-btns");
+  btns.append(cont, clr);
   // The card-face "Status?" sweep was REMOVED (the user 2026-07-21): a card still Working doesn't need a
   // status poke from the card face, and once the decision brief carries a paragraph per blocked sub-goal
   // (the briefer's per-sub-goal takeaway) the summary already says where each thing stands, so the sweep was
@@ -793,8 +810,8 @@ function makeAskCard(it: AskItem): HTMLElement {
   // "↪ from <peer>" provenance + the "reopened"/"↻ Followed up" chips ride the name row's right side;
   // row2 wraps them onto a new line when there isn't room, so the provenance never overlaps a chip
   // (the user 2026-06-20). origin sits left of the chips, matching the "from … · Followed up" reading order.
-  // Clear is the rightmost, always-present control on this row (idwrap flex:1 pushes it to the edge).
-  row2.append(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge, clr);
+  // (Clear left this row 2026-08-08 — it rides row1's action corner in every mode now, see fask-btns.)
+  row2.append(idwrap, origin, fupBadge, dcBadge, nfBadge, intingBadge, intBadge, warnChip, waitOnBadge);
   // the bell BUTTON (the user 2026-07-28): INLINE in row1's metadata cluster, right after the
   // timestamp (the last line's tail), the one spot that never shoves the title — and in-flow, so it
   // cannot overlap the floated Clear. It hides with VISIBILITY, so its slot is reserved whether or
@@ -810,6 +827,7 @@ function makeAskCard(it: AskItem): HTMLElement {
     setCardNotify(card, live, !cardNotifyOn(live));
   };
   row1.append(bellBtn);   // inline after the time — the metadata cluster's tail
+  row1.append(btns);      // the action corner floats from the END of the flow, so title+time keep first claim
   // ROW 3 — Background (left) · Summary (right), always one line, opposite sides. Populated below, once the
   // toggle buttons exist (they're declared with the distiller sections). The time now trails the title (row1).
   const row3 = el("div", "fask-row3");
@@ -928,6 +946,16 @@ function makeAskCard(it: AskItem): HTMLElement {
     vscodeApi?.postMessage({ type: "askClear", itemId: it.itemId, sid: it.sid });
     setTimeout(() => { if (askEls.get(it.itemId) === card && card.classList.contains("dismissing")) { card.remove(); askEls.delete(it.itemId); dropDismissed([it.itemId]); } }, 180);
   };
+  cont.onclick = (ev) => {
+    ev.stopPropagation();
+    // the kernel supplies the canned body (CONTINUE_TEXT) — the client sends only the gesture, so the
+    // copy has one voice-tested home. Ack INSTANTLY (disable + relabel, the click-safety rule), then the
+    // same optimistic move a typed reply gets; updateAskCard re-arms the label once the judge has ruled.
+    vscodeApi?.postMessage({ type: "askFollowUp", itemId: it.itemId, sid: it.sid, cont: true });
+    cont.disabled = true; cont.textContent = "Sent";
+    optimisticFollowMove(it.itemId);
+    render();
+  };
   // HOVER (120ms intent debounce so sweeps don't spam) → white border + preview
   // this card's timeline journey. LEAVE → restore the pinned card's journey, or
   // clear if none pinned.
@@ -994,6 +1022,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   a._waitOn = waitOnBadge;
   a._blocked = blkBadge;
   a._apiBadge = apiBadge; a._apiRetry = apiRetry; a._retryBadge = retryBadge; a._revive = revive; a._clr = clr;
+  a._cont = cont;
   a._qApprove = qApprove; a._qDeny = qDeny; a._qBody = qbody;
   a._delegations = delegations;
   a._checklist = checklist;
@@ -1539,6 +1568,17 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // A spent MODEL allowance is the same shape: Retry re-fails until you switch model or top up, and the
   // badge says so (the user 2026-08-01). Its window does reset on its own, which the badge title carries.
   a._apiRetry.style.display = (isApiErr && !spendLimit && !modelLimit) ? "" : "none";
+  // "Continue" shows on a LIVE needs-you card with no live ask attached: the gesture claims "you're not
+  // waiting on me", which means nothing in Working/Completed, can't answer a real permission prompt or
+  // picker (it.blocked — text sent there would just queue behind the ask), and has no one to tell on a
+  // dead session. Re-arm the label only once its own reply has been judged (same contract as the modal's
+  // Check status): while followupPending/recheck holds, the disabled "Sent" IS the acknowledgement.
+  const contBtn = a._cont as HTMLButtonElement;
+  contBtn.style.display = (askColumn(it) === "needsInput" && it.live && !it.provisional && !it.blocked)
+    ? "" : "none";
+  if (contBtn.disabled && !it.followupPending && !it.recheck && !it.rejudging) {
+    contBtn.disabled = false; contBtn.textContent = "Continue";
+  }
   if (isApiErr && it.blocked) {
     // on-you errors name themselves: a spend cap (raise it), "prompt too long" (compact), or a spent model
     // allowance (switch model); other API errors are transient and auto-retrying (2026-06-29 / 07-14 / 08-01).
@@ -1651,13 +1691,12 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   ho.style.display = ho.children.length ? "" : "none";
 
   // GROUPED mode (the user 2026-07-13): the session header on the backdrop carries the identity + working
-  // dot, so the card drops its own name and Clear moves up beside the timestamp (float-right: on the time
-  // line when it fits, else its own right-justified line). The move is guarded so a steady-state re-render
-  // never detaches the button mid-press (click-safety); row2 hides entirely once nothing on it shows.
+  // dot, so the card drops its own name; row2 hides entirely once nothing on it shows. (The Clear re-home
+  // between rows is GONE, the user 2026-08-08: the action corner lives in row1 in every mode now — see
+  // fask-btns at construction — so there is nothing to move between renders, which is the strongest form
+  // of the click-safety rule.)
   const gmode = feedPrefs().grouped;
   ((a._name as HTMLElement).parentElement as HTMLElement).style.display = gmode ? "none" : "";
-  const clrHome = (gmode ? a._row1 : a._row2) as HTMLElement;
-  if ((a._clr as HTMLElement).parentElement !== clrHome) clrHome.append(a._clr);
   const r2 = a._row2 as HTMLElement;
   const r2live = (Array.from(r2.children) as HTMLElement[]).some((c) => c.style.display !== "none");
   r2.style.display = gmode && !r2live ? "none" : "";
@@ -1776,7 +1815,13 @@ function makeGroupCard(g: AskGroup): HTMLElement {
   const name = el("a", "fname"); name.title = "open this session";
   idwrap.append(name);   // no "· N parts" label — the member checklist below already shows the count
   const clr = el("button", "fdismiss"); clr.textContent = "Clear"; clr.title = "clear ALL sub-asks of this request (inbox-zero)";
-  row2.append(idwrap, clr);   // Clear rides the name row (the user 2026-07-07, compactness) — matches the ask card
+  // Clear rides row1's action corner in every mode (the user 2026-08-08) — matches the ask card. Same
+  // fask-btns wrapper so the float/wrap CSS is shared; no Continue here (a group is a multi-ask turn —
+  // its members carry their own).
+  const btns = el("span", "fask-btns");
+  btns.append(clr);
+  row1.append(btns);
+  row2.append(idwrap);
   const memberList = el("div", "fgroup-members");   // no row3: the group card has no time-row content left
   main.append(row1, row2, memberList);
   card.append(main);
@@ -1837,7 +1882,7 @@ function makeGroupCard(g: AskGroup): HTMLElement {
 
   const a = card as any;
   a._title = title; a._name = name; a._time = time; a._members = memberList;
-  a._row1 = row1; a._row2 = row2; a._clr = clr;   // grouped mode re-homes Clear between the rows (2026-07-13)
+  a._row1 = row1; a._row2 = row2; a._clr = clr;   // Clear lives in row1's action corner (2026-08-08)
   return card;
 }
 
@@ -1871,12 +1916,11 @@ function updateGroupCard(card: HTMLElement, g: AskGroup) {
     }
   }
   // GROUPED mode (the user 2026-07-13) — same treatment as the ask card: the backdrop header carries the
-  // name + dot, Clear rides up beside the timestamp, the emptied name row hides. Move guarded (click-safety).
+  // name + dot, the emptied name row hides. (Clear rides row1's action corner in every mode now, the
+  // user 2026-08-08 — no re-home between renders.)
   const gmode = feedPrefs().grouped;
   ((a._name as HTMLElement).parentElement as HTMLElement).style.display = gmode ? "none" : "";
-  const clrHome = (gmode ? a._row1 : a._row2) as HTMLElement;
-  if ((a._clr as HTMLElement).parentElement !== clrHome) clrHome.append(a._clr);
-  (a._row2 as HTMLElement).style.display = gmode ? "none" : "";   // the group's row2 is only name + Clear
+  (a._row2 as HTMLElement).style.display = gmode ? "none" : "";   // the group's row2 is only the name now
 }
 
 // Transient hover-highlight signal: hovering a modal line emits its event id(s);
@@ -2502,7 +2546,12 @@ function renderModal() {
     cs.title = "ask this session where every open item on this card stands — replies file back onto the card";
     cs.style.display = "none";
     const clr = el("button", "fdismiss feed-modal-clear"); clr.id = "feed-modal-clear"; clr.textContent = "Clear";
-    const footRow = el("div", "feed-modal-foot-row"); footRow.append(age, fup, cs, clr);
+    // "Continue" (the user 2026-08-08): the card's one-click "nothing needed from me, keep going", in the
+    // modal too. Left of Clear, matching the card's action corner. The single-ask branch wires + shows it.
+    const cont = el("button", "fdismiss feed-modal-continue"); cont.id = "feed-modal-continue"; cont.textContent = "Continue";
+    cont.title = "nothing needed from you — tells this session to keep going and decide open questions itself";
+    cont.style.display = "none";
+    const footRow = el("div", "feed-modal-foot-row"); footRow.append(age, fup, cs, cont, clr);
     const fubox = el("div", "ffollow-box feed-modal-follow-box"); fubox.id = "feed-modal-follow-box"; fubox.style.display = "none";
     const fuin = el("textarea", "fq-input feed-modal-follow-input") as HTMLTextAreaElement; fuin.id = "feed-modal-follow-input"; fuin.placeholder = "follow up on this…"; fuin.rows = 1;
     fuin.addEventListener("input", () => growFollowUp(fuin));
@@ -2593,6 +2642,7 @@ function renderModal() {
   const ageEl = document.getElementById("feed-modal-age") as HTMLElement;
   const clrEl = document.getElementById("feed-modal-clear") as HTMLElement;
   const csEl = document.getElementById("feed-modal-status") as HTMLButtonElement | null;
+  const contEl = document.getElementById("feed-modal-continue") as HTMLButtonElement | null;
   const fupEl = document.getElementById("feed-modal-follow") as HTMLButtonElement;
   const fuboxEl = document.getElementById("feed-modal-follow-box") as HTMLElement;
   const fuinEl = document.getElementById("feed-modal-follow-input") as HTMLTextAreaElement;
@@ -2628,6 +2678,7 @@ function renderModal() {
   clrEl.style.display = "";   // re-shown here because the blocked branch below hides it
   // default-hidden + reset every render; only the single-ask branch shows it (group/standalone never do)
   if (csEl) { csEl.style.display = "none"; }   // disabled/label NOT reset here — "Asked" survives the per-push re-render
+  if (contEl) { contEl.style.display = "none"; }   // same contract as Check status: "Sent" survives re-renders
   let titleHoverId: string | null = null;   // the originating typed turn → chat/timeline hover highlight
   if (grp) {
     ttlEl.textContent = grp.title;
@@ -2669,6 +2720,17 @@ function renderModal() {
         if (!sweep.n) return;
         vscodeApi?.postMessage({ type: "askFollowUp", itemId: it.itemId, text: sweep.text, sid: it.sid });
         csEl.disabled = true; csEl.textContent = "Asked";
+        optimisticFollowMove(it.itemId);
+        render();
+      };
+    }
+    // "Continue" — same gating as the card's button (live needs-you, no live ask), same ack contract.
+    if (contEl && askColumn(it) === "needsInput" && it.live && !it.provisional && !it.blocked) {
+      contEl.style.display = "";
+      if (contEl.disabled && !it.followupPending && !it.recheck && !it.rejudging) { contEl.disabled = false; contEl.textContent = "Continue"; }
+      contEl.onclick = () => {
+        vscodeApi?.postMessage({ type: "askFollowUp", itemId: it.itemId, sid: it.sid, cont: true });
+        contEl.disabled = true; contEl.textContent = "Sent";
         optimisticFollowMove(it.itemId);
         render();
       };


### PR DESCRIPTION
A needs-you card whose ask the user has nothing to add to gets a **Continue** button next to Clear: one click sends a kernel-canned reply (`CONTINUE_TEXT`) through the existing follow-up path (`askFollowUp cont:true`). The typed-reply arm supplies everything else: body compose with the card's context quote, optimistic reopen + subtree unblock, the judges' reassert, the followupAt floor. Never a bare column move (the messageless cardMove was removed 2026-07-25 for exactly that).

**Evidence** (card history 2026-07-25..08-08, reconstructed from the goal stores' verdict logs):
- 58% of blocked episodes resolved with no user gesture on the card, after sitting a median 5 min (p90 72 min) in needs-you; 233 card-hours total.
- ~a fifth of Clears on blocked cards landed on sessions visibly mid-turn, where Clear's wrap-up ("you can stop here") says the opposite of what the user meant.
- The short-reply tail was dominated by hand-typed go-aheads; pure-content replies stay the typed path.

**Gating**: live needs-you cards with no live ask attached (a permission prompt/picker can't be answered by "keep going"), never on provisional placeholders. Instant ack (disable + relabel), re-armed once the judge rules. The modal footer carries the same button.

**Layout** (the user's spec): the action corner. Continue+Clear ride the END of row1 in every mode, floating right beside the timestamp when there's room, dropping below when title + time-ago need the width. `fask-btns` wrap-reverse puts the overflow line above the first: one line reads Continue · Clear; stacked, Clear takes the upper line. Generalizes the grouped-mode float to all modes; the Clear re-home between rows is deleted (buttons never move across renders).

**Tests**: new `feed-continue.test.ts` (op, gating, ack, corner CSS, kernel arm); the voice test renders the canned body through `_followup_body`; `test_kernel` pins the cont substitution; stale row2/footer pins moved to the new truth. Both suites green locally (node 1676, pytest 3930).

🤖 Generated with [Claude Code](https://claude.com/claude-code)