### PR TITLE
The settled gate holds while the session awaits its own background work

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -152,6 +152,114 @@ def parse_z(s):
     return None
 
 
+def _result_text(content):
+    """The text of a tool_result's content, whether it's a plain string or a list of {type:text} blocks."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text")
+    return ""
+
+
+def _parse_task_notification(txt):
+    """Parse a <task-notification> block's fields, or None if it isn't one. Keys on the exact tags the
+    harness emits (status / summary / output-file / tool-use-id), not a guess. tool_use_id is the join
+    key back to the LAUNCHING tool_use — the standalone (string-content) notification shape carries it
+    only inside the text, unlike the older tool_result wrapper whose block names it."""
+    if not txt or "<task-notification>" not in txt:
+        return None
+
+    def fld(tag):
+        a = txt.find("<" + tag + ">")
+        if a < 0:
+            return ""
+        a += len(tag) + 2
+        b = txt.find("</" + tag + ">", a)
+        return txt[a:b].strip() if b >= 0 else ""
+    return {"status": (fld("status") or "completed").lower(), "summary": fld("summary"),
+            "output_file": fld("output-file"), "tool_use_id": fld("tool-use-id")}
+
+
+def _scan_bg_tasks(path, want_all=False):
+    """Walk the transcript pairing async LAUNCHES with their <task-notification> results, and surface a task
+    ONLY while it's still RUNNING (in flight across turns). A finished task drops out the instant its result
+    lands. Newest-launched first, capped. No output content here (a running task's output grows independently
+    of the transcript). Shared substrate: the kernel's chat box + awaiting sources read it through their
+    mtime caches, and the judge's settled gate reads it as the DURABLE awaited-work source — the pairing
+    lives in the transcript, so unlike any live snapshot it survives a kernel restart (2026-08-08).
+
+    Launches come in TWO durable shapes: a Bash tool_use with run_in_background:true, and an async
+    Agent dispatch — its ack is a user record whose TOP-LEVEL toolUseResult says isAsync/"async_launched"
+    (the tool_result block names the launching tool_use id). Results come in THREE: the notification inside
+    a tool_result block (the older wrapper), a standalone user record whose message.content IS the
+    notification string (the current dominant shape — missing this left finished tasks reading 'running'
+    forever), and a queue-operation enqueue holding the notification while the session is busy — the task
+    itself is already finished the moment any of the three exists.
+    Returns [{id,status,summary,command,outputFile}]."""
+    tasks, order = {}, []
+
+    def _mark(note):
+        # a notification keyed by its INNER <tool-use-id> (the string/queue shapes have no wrapper block)
+        tid = (note or {}).get("tool_use_id")
+        if tid and tid in tasks:
+            tasks[tid].update(status=note["status"], outputFile=note["output_file"],
+                              summary=note["summary"] or tasks[tid]["summary"])
+
+    try:
+        with open(path, errors="replace") as f:
+            for line in f:
+                if '"type"' not in line:
+                    continue
+                try:
+                    o = json.loads(line)
+                except Exception:
+                    continue
+                t = o.get("type")
+                c = (o.get("message") or {}).get("content")
+                if t == "assistant" and isinstance(c, list):
+                    for b in c:
+                        if isinstance(b, dict) and b.get("type") == "tool_use" and (b.get("input") or {}).get("run_in_background"):
+                            tid, inp = b.get("id"), (b.get("input") or {})
+                            if tid and tid not in tasks:
+                                tasks[tid] = {"id": tid, "status": "running", "t": parse_z(o.get("timestamp")),
+                                              "summary": (inp.get("description") or b.get("name") or "Background task"),
+                                              "command": inp.get("command") or "", "outputFile": ""}
+                                order.append(tid)
+                elif t == "user" and isinstance(c, list):
+                    tur = o.get("toolUseResult")
+                    tur = tur if isinstance(tur, dict) else {}
+                    async_launch = bool(tur.get("isAsync")) or tur.get("status") == "async_launched"
+                    for b in c:
+                        if isinstance(b, dict) and b.get("type") == "tool_result":
+                            tid = b.get("tool_use_id")
+                            if async_launch and tid and tid not in tasks:
+                                # an async Agent dispatch ack — the durable "this work is now running" record
+                                tasks[tid] = {"id": tid, "status": "running", "t": parse_z(o.get("timestamp")),
+                                              "summary": (tur.get("description") or "Background agent"),
+                                              "command": "", "outputFile": tur.get("outputFile") or ""}
+                                order.append(tid)
+                                continue
+                            note = _parse_task_notification(_result_text(b.get("content")))
+                            if tid in tasks and note:      # its result landed → mark it done; the keep-filter drops it
+                                tasks[tid].update(status=note["status"], outputFile=note["output_file"],
+                                                  summary=note["summary"] or tasks[tid]["summary"])
+                elif t == "user" and isinstance(c, str):
+                    _mark(_parse_task_notification(c))
+                elif t == "queue-operation" and o.get("operation") == "enqueue":
+                    _mark(_parse_task_notification(o.get("content") or ""))
+    except OSError:
+        return []
+    if want_all:
+        # EVERY task the transcript knows, launch-ordered, each carrying its launch `t` and its CURRENT
+        # status (still "running", or the terminal status its notification reported). The awaiting-stamp
+        # lift (_lift_spent_awaiting) needs the RETURNED ones too: "this goal's dispatches have all come
+        # back" is precisely the event that ends a wait, and the running-only view cannot express it.
+        return [tasks[tid] for tid in order]
+    keep = [tasks[tid] for tid in order if tasks[tid]["status"] == "running"]
+    keep.reverse()
+    return keep[:60]
+
+
 def _read_jsonl(path):
     """Yield parsed json objects from a .jsonl file; [] on any error."""
     try:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3727,6 +3727,93 @@ def _session_closed(session):
     return bool(last.get("ended")) or any(a["type"] == "idle" for a in last["atoms"])
 
 
+_BG_SCAN_CACHE = {}                       # path -> ((mtime, size), running tasks) — mirrors the kernel's _bg_scan_cached
+
+
+def _bg_unresolved(path):
+    """The transcript's still-RUNNING background launches (em._scan_bg_tasks pairing), mtime+size-cached.
+    The DURABLE awaited-work source: the pairing lives in the transcript, so unlike any live backend
+    snapshot it survives a kernel restart and covers tmux CLIs whose tasks outlive the kernel."""
+    try:
+        st = os.stat(path)
+        key = (st.st_mtime, st.st_size)
+    except OSError:
+        return []
+    hit = _BG_SCAN_CACHE.get(path)
+    if hit and hit[0] == key:
+        return hit[1]
+    tasks = em._scan_bg_tasks(path)
+    if len(_BG_SCAN_CACHE) > 256:         # bounded by fleet size; a wholesale clear on overflow is fine
+        _BG_SCAN_CACHE.clear()
+    _BG_SCAN_CACHE[path] = (key, tasks)
+    return tasks
+
+
+def _sdk_spawned_at(sid):
+    """When this SDK session's CURRENT CLI spawned (reg spawnedAt, stamped by SdkSession._run), or None
+    for tmux/never-spawned sessions. The bg-tasks ghost gate: a task launched before the live CLI died
+    with its old one — its <task-notification> can never arrive. (The kernel's copy delegates here.)"""
+    try:
+        with open(STATE / "sdk" / (sid + ".json")) as f:
+            v = json.load(f).get("spawnedAt")
+        return v if isinstance(v, (int, float)) else None
+    except Exception:
+        return None
+
+
+def _awaiting_bg_hold(fsid, path, session, store):
+    """True while the session is awaiting its own dispatched background work — the settle must hold.
+
+    A turn that ends with a live awaited task has NOT handed back the floor: the harness re-invokes the
+    session the moment the task's <task-notification> lands, so "ended" is a proxy that reads a wait as
+    a settlement (the user 2026-08-08: a turn ended announcing a comparison batch running in the
+    background; the settle fired in the 57-second gap before the notification re-invoked the session,
+    the focus card froze to Completed — sticky, correctly irreversible without a user gesture — and the
+    board sat empty through three minutes of visible work).
+
+    Event-keyed releases, no timers:
+      - the notification lands → the pairing resolves the launch (em._scan_bg_tasks);
+      - the launch predates the live CLI's spawn → a GHOST whose notification can never arrive
+        (kernel restart mid-wait), never held;
+      - the closer AUDITED the launch's turn (closedTurns) without a live ⏳ stamp anywhere open → the
+        judges declined to affirm a wait, so the task is the session's furniture (a dev server) — the
+        same placed-unstamped-is-a-service rule as the kernel's _bg_split, translated to judge-native
+        events. A live awaitingWhy stamp re-affirms the hold past that audit; its lift releases it.
+    Pre-verdict the hold is conservative (a launch whose turn nothing has swept always holds), matching
+    _bg_split's PENDING→awaited prior."""
+    tasks = _bg_unresolved(path)
+    if not tasks:
+        return False
+    sp = _sdk_spawned_at(fsid)
+    tasks = [t for t in tasks if not (sp and t.get("t") and t["t"] < sp)]
+    if not tasks:
+        return False
+    nodes = store.get("nodes") or {}
+    if any(nd.get("awaitingWhy") and not nd.get("cleared") and not nd.get("nodeComplete")
+           for nd in nodes.values()):
+        return True                       # the closer affirmed a wait somewhere open — hold
+    swept = set(store.get("closedTurns") or [])
+    launch_turn = {}                      # tool_use id -> the turn that dispatched it (launch or its ack)
+    for turn in reversed(session.get("turns") or []):
+        for a in turn["atoms"]:
+            blocks = (a.get("message") or {}).get("content")
+            if not isinstance(blocks, list):
+                continue
+            for b in blocks:
+                if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("id"):
+                    launch_turn.setdefault(b["id"], turn.get("id"))
+                elif isinstance(b, dict) and b.get("type") == "tool_result" and b.get("tool_use_id"):
+                    launch_turn.setdefault(b["tool_use_id"], turn.get("id"))
+    return any(launch_turn.get(t["id"]) not in swept for t in tasks)
+
+
+def _session_settled(fsid, path, session, store):
+    """The rollup's settled gate: the turn ended AND nothing the session dispatched is still awaited.
+    _session_closed alone read the 'ended' proxy; this keys the settle on the event it was
+    approximating — the session actually handing back the floor."""
+    return _session_closed(session) and not _awaiting_bg_hold(fsid, path, session, store)
+
+
 def _seg_anchor(seg):
     """The segment's landable anchor uuid: its trigger when the event model recognized one, else the
     first non-idle atom's uuid. A peer/system segment has no recognized trigger, and every node minted
@@ -5499,7 +5586,7 @@ def _plan_session(fsid, path, now):
                            prompt_uuid=(latest_seg or {}).get("trigger")):
         _group_store(store, fsid, now)
         save_goals(fsid, store)
-    rollup_status(store, _session_closed(session))
+    rollup_status(store, _session_settled(fsid, path, session, store))
     save_goals(fsid, store)
     return placed
 
@@ -6196,7 +6283,7 @@ def _group_session(fsid, path, now):
     after = (store.get("groupedSig"), store.get("groupFails"), store.get("groupFailSig"))
     if relinks or after != before:                     # persist a relink, a new sig, or a strike-counter change
         if relinks:                                    # a structural change needs a status re-roll
-            rollup_status(store, _session_closed(parsed_session(fsid, [path], now)))
+            rollup_status(store, _session_settled(fsid, path, parsed_session(fsid, [path], now), store))
         save_goals(fsid, store)
     return relinks
 
@@ -6305,7 +6392,7 @@ def _consolidate_session(fsid, path, now):
     after = (store.get("consolidatedSig"), store.get("consolidateFails"), store.get("consolidateFailSig"))
     if changed or after != before:                     # persist a change, a new sig, or a strike-counter change
         if changed:
-            rollup_status(store, _session_closed(parsed_session(fsid, [path], now)))
+            rollup_status(store, _session_settled(fsid, path, parsed_session(fsid, [path], now), store))
         save_goals(fsid, store)
     return 1 if changed else 0
 
@@ -6930,7 +7017,7 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
         swept.add(tid); sig[tid] = fp; did += 1        # remember the size we judged at → detect later growth
     store["closedTurns"] = sorted(swept)
     store["closedSig"] = sig
-    rollup_status(store, _session_closed(session))
+    rollup_status(store, _session_settled(fsid, path, session, store))
     save_goals(fsid, store)
     return newly
 
@@ -7118,7 +7205,7 @@ def _unblock_session(fsid, path, now):
                           why=("answered in passing: " + why) if why else "answered in passing"):
             nd["mt"] = now
             lifted.append(nid)
-    rollup_status(store, _session_closed(session))
+    rollup_status(store, _session_settled(fsid, path, session, store))
     save_goals(fsid, store)
     return lifted
 
@@ -7151,7 +7238,7 @@ def _ab_close_session(fsid, path, now):
     drops from later menus, no double-counting). Returns (a, b, new_goal_texts, samples)."""
     session = parsed_session(fsid, [path], now)
     store = load_goals(fsid)
-    closed = _session_closed(session)
+    closed = _session_settled(fsid, path, session, store)
     rollup_status(store, closed)                        # (a) reflects the current positive-only marks
 
     def completed_tops(s):
@@ -8544,8 +8631,8 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             session = parsed_session(fsid, [str(path)], now)   # states-aware + cached, so _session_closed is correct
         except Exception:
             continue
-        closed[fsid] = _session_closed(session)
         cstore = load_goals(fsid)
+        closed[fsid] = _session_settled(fsid, str(path), session, cstore)
         placed_ids = cstore["placements"]
         for turn in session["turns"]:
             for seg in _segs(turn, cstore):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8613,32 +8613,11 @@ def _effort_changes(sid):
 _bgtasks_cache = {}   # path -> ((mtime,size), [task dicts, no output])
 
 
-def _result_text(content):
-    """The text of a tool_result's content, whether it's a plain string or a list of {type:text} blocks."""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        return "\n".join(b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text")
-    return ""
-
-
-def _parse_task_notification(txt):
-    """Parse a <task-notification> block's fields, or None if it isn't one. Keys on the exact tags the
-    harness emits (status / summary / output-file / tool-use-id), not a guess. tool_use_id is the join
-    key back to the LAUNCHING tool_use — the standalone (string-content) notification shape carries it
-    only inside the text, unlike the older tool_result wrapper whose block names it."""
-    if not txt or "<task-notification>" not in txt:
-        return None
-
-    def fld(tag):
-        a = txt.find("<" + tag + ">")
-        if a < 0:
-            return ""
-        a += len(tag) + 2
-        b = txt.find("</" + tag + ">", a)
-        return txt[a:b].strip() if b >= 0 else ""
-    return {"status": (fld("status") or "completed").lower(), "summary": fld("summary"),
-            "output_file": fld("output-file"), "tool_use_id": fld("tool-use-id")}
+# _result_text / _parse_task_notification / _scan_bg_tasks moved to event_model (2026-08-08): the judge's
+# settled gate needs the same launch↔notification pairing and cannot import this module (importing the
+# kernel runs boot reconcile). Same names re-exported here so every kernel-side consumer is untouched.
+_result_text = em._result_text
+_parse_task_notification = em._parse_task_notification
 
 
 _task_out_cache = {}                                  # output-file path -> ((mtime, size), tail)
@@ -8696,96 +8675,15 @@ def _task_outputs_for(reminders, path):
     return out
 
 
-def _scan_bg_tasks(path, want_all=False):
-    """Walk the transcript pairing async LAUNCHES with their <task-notification> results, and surface a task
-    ONLY while it's still RUNNING (in flight across turns). A finished task drops out of the box the instant
-    its result lands — the box is a live "what's running now" indicator, and a task's COMPLETION is already
-    shown in the chat as its AGENT notice card (renderAgentNotif), so keeping it here lingered as an "empty"
-    bordered line the user didn't want (the user 2026-07-06). Newest-launched first, capped. No output content
-    here (read fresh in _bg_tasks — a running task's output grows independently of the transcript).
-
-    Launches come in TWO durable shapes: a Bash tool_use with run_in_background:true, and an async
-    Agent dispatch — its ack is a user record whose TOP-LEVEL toolUseResult says isAsync/"async_launched"
-    (the tool_result block names the launching tool_use id). Results come in THREE: the notification inside
-    a tool_result block (the older wrapper), a standalone user record whose message.content IS the
-    notification string (the current dominant shape — missing this left finished tasks reading 'running'
-    forever), and a queue-operation enqueue holding the notification while the session is busy — the task
-    itself is already finished the moment any of the three exists.
-    Returns [{id,status,summary,command,outputFile}]."""
-    tasks, order = {}, []
-
-    def _mark(note):
-        # a notification keyed by its INNER <tool-use-id> (the string/queue shapes have no wrapper block)
-        tid = (note or {}).get("tool_use_id")
-        if tid and tid in tasks:
-            tasks[tid].update(status=note["status"], outputFile=note["output_file"],
-                              summary=note["summary"] or tasks[tid]["summary"])
-
-    try:
-        with open(path, errors="replace") as f:
-            for line in f:
-                if '"type"' not in line:
-                    continue
-                try:
-                    o = json.loads(line)
-                except Exception:
-                    continue
-                t = o.get("type")
-                c = (o.get("message") or {}).get("content")
-                if t == "assistant" and isinstance(c, list):
-                    for b in c:
-                        if isinstance(b, dict) and b.get("type") == "tool_use" and (b.get("input") or {}).get("run_in_background"):
-                            tid, inp = b.get("id"), (b.get("input") or {})
-                            if tid and tid not in tasks:
-                                tasks[tid] = {"id": tid, "status": "running", "t": _msg_epoch(o),
-                                              "summary": (inp.get("description") or b.get("name") or "Background task"),
-                                              "command": inp.get("command") or "", "outputFile": ""}
-                                order.append(tid)
-                elif t == "user" and isinstance(c, list):
-                    tur = o.get("toolUseResult")
-                    tur = tur if isinstance(tur, dict) else {}
-                    async_launch = bool(tur.get("isAsync")) or tur.get("status") == "async_launched"
-                    for b in c:
-                        if isinstance(b, dict) and b.get("type") == "tool_result":
-                            tid = b.get("tool_use_id")
-                            if async_launch and tid and tid not in tasks:
-                                # an async Agent dispatch ack — the durable "this work is now running" record
-                                tasks[tid] = {"id": tid, "status": "running", "t": _msg_epoch(o),
-                                              "summary": (tur.get("description") or "Background agent"),
-                                              "command": "", "outputFile": tur.get("outputFile") or ""}
-                                order.append(tid)
-                                continue
-                            note = _parse_task_notification(_result_text(b.get("content")))
-                            if tid in tasks and note:      # its result landed → mark it done; the keep-filter drops it
-                                tasks[tid].update(status=note["status"], outputFile=note["output_file"],
-                                                  summary=note["summary"] or tasks[tid]["summary"])
-                elif t == "user" and isinstance(c, str):
-                    _mark(_parse_task_notification(c))
-                elif t == "queue-operation" and o.get("operation") == "enqueue":
-                    _mark(_parse_task_notification(o.get("content") or ""))
-    except OSError:
-        return []
-    if want_all:
-        # EVERY task the transcript knows, launch-ordered, each carrying its launch `t` and its CURRENT
-        # status (still "running", or the terminal status its notification reported). The awaiting-stamp
-        # lift (_lift_spent_awaiting) needs the RETURNED ones too: "this goal's dispatches have all come
-        # back" is precisely the event that ends a wait, and the running-only view cannot express it.
-        return [tasks[tid] for tid in order]
-    keep = [tasks[tid] for tid in order if tasks[tid]["status"] == "running"]
-    keep.reverse()
-    return keep[:60]
+_scan_bg_tasks = em._scan_bg_tasks   # moved to event_model (2026-08-08) — see the note above _result_text
 
 
 def _sdk_spawned_at(sid):
     """When this SDK session's CURRENT CLI spawned (reg spawnedAt, stamped by SdkSession._run), or None
     for tmux/never-spawned sessions. The bg-tasks ghost gate: a task launched before the live CLI died
-    with its old one — its <task-notification> can never arrive."""
-    try:
-        with open(jd.STATE / "sdk" / (sid + ".json")) as f:
-            v = json.load(f).get("spawnedAt")
-        return v if isinstance(v, (int, float)) else None
-    except Exception:
-        return None
+    with its old one — its <task-notification> can never arrive. Delegates to the judge's copy (its
+    settled gate applies the same ghost rule) so the two can never drift."""
+    return jd._sdk_spawned_at(sid)
 
 
 def _bg_scan_cached(path):

--- a/tests/test_settle_awaits_background_tasks.py
+++ b/tests/test_settle_awaits_background_tasks.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""The settled gate must not fire while the session is awaiting its own background work (the user
+2026-08-08).
+
+_session_closed read "the turn ended" (end_turn / an idle atom) as "the session handed back the
+floor" — but a turn that ends with a live awaited background task has handed nothing back: the
+harness re-invokes the session the moment the task's <task-notification> lands. Live case: a turn
+ended announcing a batch of background comparisons; the rollup settled the focus card to Completed
+inside the 57-second gap before the notification re-invoked the session, which then worked three
+more minutes with the Working and Blocked columns empty (working chip, empty board). Sticky
+completion then correctly refused to reopen without a user gesture, so the premature settle was
+unrecoverable.
+
+_session_settled keys on events, never timers: the transcript's launch↔notification pairing
+(em._scan_bg_tasks — durable across kernel restarts, unlike any live snapshot) says what is still
+awaited; the hold releases when the notification lands, when the launch predates the live CLI's
+spawn (a ghost — its notification can never arrive), or when the closer has audited the launch's
+turn without affirming a wait (a service, e.g. a dev server — otherwise it would hold the settle
+forever). A live ⏳ awaiting stamp anywhere open re-affirms the hold past that audit.
+
+SYNTHETIC fixtures only: placeholder UUIDs, invented prompts and task descriptions.
+"""
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+jd = SourceFileLoader("romp_judge_settle_bg", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "11111111-2222-3333-4444-666666666666"
+T0 = 1780000000                      # prompt lands
+LAUNCH = T0 + 60                     # background task dispatched
+ENDED = T0 + 120                     # turn ends, task still running
+BACK = T0 + 300                      # notification lands, session resumes
+NOW = T0 + 600
+
+
+def _iso(ep):
+    import datetime
+    return datetime.datetime.fromtimestamp(ep, tz=datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _prompt(t, uuid="p1"):
+    return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": None,
+            "message": {"role": "user", "content": "run the comparison batch and report"}}
+
+
+def _launch(tid, t):
+    """A Bash run_in_background launch — the durable dispatch record."""
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": "a" + tid, "parentUuid": None,
+            "message": {"role": "assistant", "content": [
+                {"type": "tool_use", "id": tid, "name": "Bash",
+                 "input": {"command": "./run-batch.sh", "run_in_background": True,
+                           "description": "comparison batch"}}], "stop_reason": None}}
+
+
+def _ack(tid, t):
+    return {"type": "user", "timestamp": _iso(t), "uuid": "k" + tid, "parentUuid": None,
+            "message": {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": tid, "content": "started in background"}]}}
+
+
+def _end(t, uuid="e1", text="Harness is running in the background; I'll pick it up when it finishes."):
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": None,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+def _notification(tid, t):
+    """The standalone <task-notification> user record that ends the wait (the dominant live shape)."""
+    body = ("<task-notification>\n<task-id>%s</task-id>\n<tool-use-id>%s</tool-use-id>\n"
+            "<status>completed</status>\n<summary>the batch finished</summary>\n"
+            "</task-notification>" % (tid, tid))
+    return {"type": "user", "timestamp": _iso(t), "uuid": "n" + tid, "parentUuid": None,
+            "message": {"role": "user", "content": body}}
+
+
+class SettleAwaitsBackgroundTasks(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        jd._rebind_state(Path(self.td.name))
+        self.path = str(Path(self.td.name) / (SID + ".jsonl"))
+        self.gid = SID + ":g1"
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def _transcript(self, recs):
+        prev = None
+        for r in recs:                    # a real transcript is a uuid→parentUuid chain; the parse walks it
+            r["parentUuid"] = prev
+            prev = r["uuid"]
+        with open(self.path, "w") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+        jd._PARSE_CACHE.clear()
+        jd._BG_SCAN_CACHE.clear()
+
+    def _store(self, **node_extra):
+        """A focus card the planner already ruled done (the done-but-unsettled shape the gate protects)."""
+        nd = {"id": self.gid, "text": "Run the comparison batch", "parentId": None,
+              "nodeComplete": False, "blocked": False, "cleared": False, "trail": [],
+              "t": T0, "mt": ENDED,
+              "log": [{"ev_t": ENDED, "src": "planner", "kind": "done",
+                       "why": "the batch is dispatched", "at": ENDED}]}
+        nd.update(node_extra)
+        return {"rompUuid": SID, "seq": 1, "placementsV": jd.PLACEMENTS_V,
+                "nodes": {self.gid: nd}, "placements": {}, "status": {}, "lastNode": self.gid}
+
+    def _mid_wait(self):
+        """Turn ended, launch unresolved — the live incident's 57-second gap."""
+        self._transcript([_prompt(T0), _launch("t1", LAUNCH), _ack("t1", LAUNCH + 1), _end(ENDED)])
+        return jd.parsed_session(SID, [self.path], NOW)
+
+    def _after_back(self):
+        """The notification landed, the session resumed and ended cleanly — nothing awaited."""
+        self._transcript([_prompt(T0), _launch("t1", LAUNCH), _ack("t1", LAUNCH + 1), _end(ENDED),
+                          _notification("t1", BACK),
+                          _end(BACK + 60, uuid="e2", text="Batch read and folded in; done.")])
+        return jd.parsed_session(SID, [self.path], NOW)
+
+    # ---- the bug ----
+    def test_hold_while_awaited_task_unresolved(self):
+        session = self._mid_wait()
+        store = self._store()
+        self.assertTrue(jd._session_closed(session), "the raw floor still reads the turn as ended")
+        self.assertFalse(jd._session_settled(SID, self.path, session, store),
+                         "an ended turn with an unresolved awaited launch has not handed back the floor")
+
+    def test_no_settle_while_awaited(self):
+        session = self._mid_wait()
+        store = self._store()
+        jd.rollup_status(store, jd._session_settled(SID, self.path, session, store))
+        self.assertEqual(store["status"][self.gid], "working",
+                         "the done-but-unsettled card stays in Working through the wait")
+        self.assertNotIn("settle", [e.get("kind") for e in store["nodes"][self.gid]["log"]],
+                         "no settle event is filed mid-wait")
+        self.assertIn(self.gid, store.get("confirming", []),
+                      "the held card still carries the done-confirming cue")
+
+    # ---- the releases ----
+    def test_settles_once_notification_lands_and_turn_ends(self):
+        session = self._after_back()
+        store = self._store()
+        self.assertTrue(jd._session_settled(SID, self.path, session, store))
+        jd.rollup_status(store, jd._session_settled(SID, self.path, session, store))
+        self.assertEqual(store["status"][self.gid], "completed")
+
+    def test_ghost_launch_never_holds(self):
+        """A launch from before the live CLI spawned can never be answered — no hold."""
+        session = self._mid_wait()
+        store = self._store()
+        (jd.STATE / "sdk").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "sdk" / (SID + ".json")).write_text(json.dumps({"spawnedAt": LAUNCH + 30}))
+        self.assertTrue(jd._session_settled(SID, self.path, session, store))
+
+    def test_audited_unstamped_launch_is_a_service(self):
+        """The closer swept the launch's turn without affirming a wait — a dev-server-shaped task
+        must not hold the settle forever."""
+        session = self._mid_wait()
+        store = self._store()
+        store["closedTurns"] = [t["id"] for t in session["turns"]]
+        self.assertTrue(jd._session_settled(SID, self.path, session, store))
+
+    def test_live_awaiting_stamp_holds_past_the_audit(self):
+        """A live ⏳ stamp on an open top re-affirms the wait even after the launch turn was swept."""
+        session = self._mid_wait()
+        store = self._store()
+        g2 = SID + ":g2"
+        store["nodes"][g2] = {"id": g2, "text": "Fold the batch results in", "parentId": None,
+                              "nodeComplete": False, "blocked": False, "cleared": False,
+                              "trail": [], "t": T0, "mt": ENDED,
+                              "awaitingWhy": "waiting on the comparison batch", "awaitingAt": ENDED,
+                              "log": [{"ev_t": ENDED, "src": "closer", "kind": "awaiting",
+                                       "why": "waiting on the comparison batch", "at": ENDED}]}
+        store["seq"] = 2
+        store["closedTurns"] = [t["id"] for t in session["turns"]]
+        self.assertFalse(jd._session_settled(SID, self.path, session, store))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug (2026-08-08)

A session's turn ended announcing a comparison batch running in the background. `_session_closed` read the end_turn as settled, the rollup froze the done-but-unsettled focus card to Completed inside the 57-second gap before the task-notification re-invoked the session, and the session then worked three more minutes with the Working and Blocked columns empty (working chip, empty board). Sticky completion (by design) made the premature settle irreversible without a user gesture, so the user cleared a card the board claimed was finished while the work was still visibly running.

## The fix

`end_turn` was a proxy for "the session handed back the floor" — but a turn ending with live awaited background work has handed nothing back: the harness is guaranteed to re-invoke it. `_session_settled` keys the settle on the event the proxy approximated: turn closed AND nothing dispatched still awaited.

- The awaited set reads the transcript's launch↔notification pairing (`_scan_bg_tasks`), the durable source — it survives kernel restarts and covers tmux CLIs whose tasks outlive the kernel, unlike any live snapshot.
- Ghost gate: a launch predating the live CLI's spawn stamp can never be answered — never held.
- Service release: a launch whose turn the closer audited without a live awaiting stamp anywhere open is the session's furniture (a dev server) — the same placed-unstamped-is-a-service rule as `_bg_split`, in judge-native events. A live awaitingWhy stamp re-affirms the hold; its lift releases it.
- `_scan_bg_tasks` / `_parse_task_notification` / `_result_text` move to event_model so the judge shares them without importing the kernel (which runs boot reconcile on import); the kernel re-exports the same names, so no display-side consumer changes. Coordinated with the adjacent awaiting-dot investigation: no shared-surface collision, `_bg_live_norm`/`_bg_pending` signatures untouched.

## Tests

`tests/test_settle_awaits_background_tasks.py` (synthetic transcripts): the mid-wait hold, the no-settle rollup (card stays Working with the confirming cue), and the three releases (notification landed, ghost, audited-unstamped service) plus the stamp re-affirming past an audit. Full pytest suite (3935), vscode-extension typecheck + node tests (1670), and root manager node tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)