### PR TITLE
Continue copy: the already-working press reads as carry-on, not a question

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -690,10 +690,16 @@ def _open_leaf_bullets(nodes, subs, cap=12, indent="  "):
 # needs-you; a fifth of Clears landed on sessions visibly mid-turn, where Clear's wrap-up says the
 # opposite of what the user meant; and the short-reply tail was dominated by hand-typed go-aheads.
 # VOICE (test_injected_voice.py renders this through _followup_body): the person the agent works for,
-# no tracking-system nouns. The last line licenses one sharp re-ask when the block is REAL (the agent
-# needs something only the user has): the judges then re-block from that reply, a correct move on new
-# information, so a mispressed Continue costs one turn and returns a tighter brief.
-CONTINUE_TEXT = ("Nothing needed from me here. Keep going, and make any open calls yourself. "
+# no tracking-system nouns. Three arrival contexts, each with its own sentence (the user 2026-08-08,
+# same day): ALREADY WORKING is the commonest press by far (36% of blocked episodes had the session
+# busy through the blocked window — the card was wrong, not the agent), and the message lands at the
+# next turn boundary, so "keep going, no reply needed" makes that turn continue the work instead of
+# stopping for a status report. A pending question gets "open calls are yours". And the last line
+# licenses one sharp re-ask when the block is REAL (the agent needs something only the user has): the
+# judges then re-block from that reply, a correct move on new information, so a mispressed Continue
+# costs one turn and returns a tighter brief.
+CONTINUE_TEXT = ("Nothing needed from me here. If you're already on it, keep going, no reply needed. "
+                 "Any open calls are yours to make. "
                  "If you can't proceed without me, say exactly what you need in one line.")
 
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1150,9 +1150,16 @@ class ViewBuilder(unittest.TestCase):
         src = inspect.getsource(km._drive)
         self.assertIn('text = CONTINUE_TEXT if msg.get("cont") else str(msg["text"])', src)
         self.assertIn("jd.optimistic_followup(sid, iid, text=text, now=int(time.time()))", src)
-        # the canned body ends with the one-line escape hatch: a REAL block (the agent needs something
-        # only the user has) comes back as one sharp re-ask, which the judges re-block from — the
-        # correct move on new information, so a mispressed Continue costs one turn, not the thread
+        # the canned body covers its three arrival contexts (the user 2026-08-08). ALREADY WORKING is
+        # the commonest press — the judge missed a continuation and the user sees the session busy —
+        # and the message lands at the next turn boundary, so it must read as "carry on, don't stop
+        # to reply", not as a question that stops the work for a status report:
+        self.assertIn("If you're already on it, keep going, no reply needed", km.CONTINUE_TEXT)
+        # a pending question is delegated, not answered:
+        self.assertIn("open calls are yours", km.CONTINUE_TEXT)
+        # and it ends with the one-line escape hatch: a REAL block (the agent needs something only the
+        # user has) comes back as one sharp re-ask, which the judges re-block from — the correct move
+        # on new information, so a mispressed Continue costs one turn, not the thread
         self.assertIn("say exactly what you need in one line", km.CONTINUE_TEXT)
 
     def test_feed_awaiting_via_session_signal_is_held_in_working_with_a_badge(self):


### PR DESCRIPTION
Follow-up to #227, from the user's review of the canned body: the commonest Continue press is on a card whose session is visibly ALREADY working the thing (36% of blocked episodes had the session busy through the blocked window — the card was wrong, not the agent). The first cut presumed a pending question, so landing at the next turn boundary mid-work it invited a status-report stop.

New body, one sentence per arrival context:

> Nothing needed from me here. If you're already on it, keep going, no reply needed. Any open calls are yours to make. If you can't proceed without me, say exactly what you need in one line.

`test_kernel` pins all three sentences; the voice test renders the constant as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)