### PR TITLE
The session surfaces read the delegation wait the feed card already shows

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8037,7 +8037,7 @@ def _session_stamp_read(sid):
         gs = (jd.GOALDIR / (sid + ".json")).stat()
         gkey = (gs.st_mtime, gs.st_size)
     except Exception:
-        return ((None, None, None), frozenset())       # no store yet → nothing to stamp
+        return ((None, None, None), frozenset(), ())   # no store yet → nothing to stamp, nothing delegated
     try:
         ostt = (jd._overrides_dir() / (sid + ".jsonl")).stat()
         okey = (ostt.st_mtime, ostt.st_size)
@@ -8052,7 +8052,7 @@ def _session_stamp_read(sid):
     hit = _SESSION_STAMP_CACHE.get(sid)
     if hit and hit[0] == key:
         return hit[1]
-    full, tops = (None, None, None), set()
+    full, tops, deleg = (None, None, None), set(), ()
     try:                                               # load_goals (not a raw read) so overrides replay —
         nodes = jd.load_goals(sid).get("nodes", {})    # the same view _goal_awaiting_stamp sees on the card
         best = None
@@ -8071,9 +8071,27 @@ def _session_stamp_read(sid):
                 tops.add(top)
         if best:
             full = (best[1], best[0], best[2])         # (gid, at, why)
+        # DELEGATION, the same pass (the user 2026-08-08, whose fully-delegated session wore the feed's
+        # green awaiting dot while chat/timeline/rail read plain ready): a top whose every OPEN leaf is a
+        # courier handoff node is work handed to PEERS — the exact evidence the feed's per-card flavor
+        # reads (_deleg_why in build_feed). Collect the PEER SIDS here (names resolve at read time, so a
+        # renamed peer never shows a stale name from this cache); _session_delegated_why formats them for
+        # _session_awaiting's stamp branch. A PURE-delegation top is excluded to mirror the feed exactly:
+        # its card is suppressed in every column, so it never lights the feed dot either.
+        peers = set()
+        for tid, td_ in nodes.items():
+            if td_.get("parentId") is not None or td_.get("nodeComplete") or td_.get("cleared"):
+                continue
+            if not _all_outstanding_delegated(nodes, tid) or _pure_delegation_top(nodes, tid):
+                continue
+            for x in _open_leaves(nodes, tid):
+                h = nodes.get(x, {}).get("handoff")
+                if isinstance(h, dict) and h.get("peer"):
+                    peers.add(str(h["peer"]))
+        deleg = tuple(sorted(peers))
     except Exception:
-        full, tops = (None, None, None), set()
-    val = (full, frozenset(tops))
+        full, tops, deleg = (None, None, None), set(), ()
+    val = (full, frozenset(tops), deleg)
     _SESSION_STAMP_CACHE[sid] = (key, val)
     return val
 
@@ -8096,6 +8114,21 @@ def _session_stamp_cached(sid):
     """The freshest durable ⏳ stamp's WHY for a session (or None) — the display surfaces' view; see
     _session_stamp_full for the gid + awaitingAt the awaiting backstop consumes."""
     return _session_stamp_full(sid)[2]
+
+
+def _session_delegated_why(sid):
+    """The session-scoped DELEGATION wait (or None): every open leaf of some inbox-visible top is a
+    courier handoff — the only outstanding work lives with peers. The SAME evidence the feed's per-card
+    flavor reads (_deleg_why in build_feed), reaching the rail chip / chat chip / timeline lane through
+    _session_awaiting's stamp branch — before this, a fully-delegated session wore the feed's green
+    awaiting dot while every session-scoped surface read plain ready (the user 2026-08-08, who asked why
+    three surfaces disagreed on one fact). Peer SIDS ride the mtime cache; names resolve here so a
+    renamed peer reads fresh."""
+    peers = _session_stamp_read(sid)[2]
+    if not peers:
+        return None
+    names = sorted(_name_of(p) or "a peer" for p in peers)
+    return "delegated to %s; waiting on their result" % ", ".join(names)
 
 
 def _session_awaiting(sid, path, idle, stamp=False):
@@ -8136,7 +8169,15 @@ def _session_awaiting(sid, path, idle, stamp=False):
          per session, for which "the session is awaiting" is the right summary). The FEED does NOT: it scopes
          the stamp per goal via _goal_awaiting_stamp, so a stamp on one goal never floors its siblings to
          awaiting (a session-wide _await_ok would). The nudge gates skip via their own per-goal stamp check.
-    Postal peer-waits are handled separately in build_feed."""
+      2.5 the DELEGATION wait (_session_delegated_why), same opt-in gate as source 2: a top whose every
+         open leaf is a courier handoff has all its outstanding work with PEERS — the same evidence the
+         feed card's _deleg_why reads, so the session dot and the card flavor answer alike (the user
+         2026-08-08). Ends on the graph's own events: run_propagate completes the handoff node when the
+         peer's linked goal lands, busting the store mtime this read is cached on.
+    The one remaining feed-only flavor is the blocked-card peer-wait flip (col blocked + _peer_wait in
+    build_feed): it corrects a needs-you verdict against the wait-for graph, which requires the card's
+    block context — a session-scoped mirror would light this badge for ANY unanswered peer ask, saying
+    MORE than the feed does. Postal peer-waits otherwise stay build_feed's."""
     if not idle:
         return None
     # Source 0 (the user 2026-07-05, jld_audit): the backend snapshot's LIVE subagent count — the designed
@@ -8187,7 +8228,11 @@ def _session_awaiting(sid, path, idle, stamp=False):
         # durable stamp below. Same stamp=True gate: the session-scoped surfaces want one summary answer,
         # while the FEED keeps scoping per goal — a session-wide _await_ok would floor every sibling card
         # to awaiting, which is exactly what that gate has always prevented.
-        return _owned_yield_why(sid, path) or _session_stamp_cached(sid)
+        # …and the DELEGATION wait (the courier handoff graph — the feed card's _deleg_why evidence),
+        # AFTER the judge's stamp, mirroring the feed's own precedence (its _deleg_why yields to
+        # _stamp_why/_await_ok). Without this arm a fully-delegated session was the feed's green dot
+        # and nobody else's (the user 2026-08-08): the three surfaces answered one question two ways.
+        return _owned_yield_why(sid, path) or _session_stamp_cached(sid) or _session_delegated_why(sid)
     return None
 
 
@@ -13123,7 +13168,9 @@ def build_feed(now, tmux=None):
             # every OPEN leaf under this top is a handoff-tracking node → the only outstanding work lives
             # with peers, so the card reads ⏳ "delegated to <peer>" instead of plain working (which reads
             # as "this session should be doing something"). Ends on the graph's own event: run_propagate
-            # checks the handoff off the moment the peer's linked goal completes.
+            # checks the handoff off the moment the peer's linked goal completes. The session-scoped
+            # surfaces (rail/chat/timeline) read the SAME evidence via _session_delegated_why in
+            # _session_awaiting's stamp branch — keep the two in step (the user 2026-08-08).
             _deleg_why = None
             if col == "working" and not _stamp_why and not _await_ok \
                     and _all_outstanding_delegated(nodes, nid):

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -7310,12 +7310,12 @@ class WaitGraphDelegatesAndStampSupersede(unittest.TestCase):
                           "awaitingAt": NOW - 500}},
             "placements": {}, "status": {g: "working"}}))
         self._log(self._msg(self.A, self.B, NOW - 600, "delegate"))
-        full, tops = km._session_stamp_read(self.A)
+        full, tops, _deleg = km._session_stamp_read(self.A)   # 3rd slot = delegated-peer sids (2026-08-08)
         self.assertEqual(full[2], "sent to a peer to build the flag parser")
         self.assertEqual(tops, frozenset({g}))
         # the peer's reply lands (also busts the postal-key on the stamp cache) → the stamp view lifts
         self._log(self._msg(self.B, self.A, NOW - 100, "coordinate", body="built and merged"))
-        full, tops = km._session_stamp_read(self.A)
+        full, tops, _deleg = km._session_stamp_read(self.A)
         self.assertEqual(full, (None, None, None), "the answered handoff supersedes the older stamp")
         self.assertEqual(tops, frozenset())
 

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -185,6 +185,106 @@ class SessionLevelStamp(unittest.TestCase):
         self.assertEqual(km._session_stamp_cached(SID), "second wait, a different length so size differs")
 
 
+class SessionLevelDelegation(unittest.TestCase):
+    """Source 2.5 of _session_awaiting (the user 2026-08-08, who saw three surfaces answer one question
+    two ways): a session whose only outstanding work is a courier HANDOFF wore the feed's green awaiting
+    dot (the card flavor reads _deleg_why off the handoff graph) while the rail chip, chat chip, and
+    timeline lane — which read _session_awaiting, blind to delegation — said plain ready. The delegation
+    evidence now reaches the session-scoped surfaces through the same stamp-gated branch, computed in
+    _session_stamp_read's one cached store pass."""
+
+    PEER = "33333333-4444-5555-6666-777777777777"
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self._saved = (km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions,
+                       km._states_awaiting_overlay, km._name_of)
+        km.jd.STATE = td
+        km.jd.GOALDIR = td / "goals"
+        km.jd.GOALDIR.mkdir(parents=True)
+        km._SESSION_STAMP_CACHE.clear()
+        km._states_awaiting_overlay = lambda sid: None
+        km._name_of = lambda s: "probe" if s == self.PEER else None
+        # LIVE snapshot, empty bg sets (SDK-style): every live source falls through, like SessionLevelStamp
+        km._tmux_sessions = lambda: {SID: {"state": "", "since": None, "subagents": [], "bgTasks": []}}
+
+    def tearDown(self):
+        (km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions,
+         km._states_awaiting_overlay, km._name_of) = self._saved
+        km._SESSION_STAMP_CACHE.clear()
+        self.td.cleanup()
+
+    def _seed(self, nodes):
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": nodes}))
+
+    def _handoff(self, nid, parent, complete=False):
+        nd = _node(nid, parent=parent)
+        nd["handoff"] = {"peer": self.PEER, "msgId": "1111111111.00000_00000.TESTHOST"}
+        nd["nodeComplete"] = complete
+        return nd
+
+    def _delegated_store(self):
+        """A top with one COMPLETED own-work leaf and one OPEN handoff — the synth shape: the card shows
+        (not pure delegation), and its only open work is the peer's."""
+        done = _node("s1", parent="g1"); done["nodeComplete"] = True
+        return {"g1": _node("g1"), "s1": done, "h1": self._handoff("h1", "g1")}
+
+    def test_a_fully_delegated_session_reads_awaiting_on_the_session_surfaces(self):
+        self._seed(self._delegated_store())
+        self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
+                         "delegated to probe; waiting on their result")
+
+    def test_stamp_false_stays_none_so_the_feed_keeps_scoping_per_card(self):
+        self._seed(self._delegated_store())
+        self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=False))
+
+    def test_the_judge_stamp_outranks_delegation_like_the_feeds_own_precedence(self):
+        nodes = self._delegated_store()
+        nodes["g1"]["awaitingWhy"], nodes["g1"]["awaitingAt"] = "the sweep it launched", 200
+        self._seed(nodes)
+        self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True), "the sweep it launched")
+
+    def test_a_pure_delegation_top_stays_dark_matching_its_suppressed_card(self):
+        # EVERY leaf a handoff → the feed suppresses the card in every column, so its dot never lights;
+        # the session surfaces must not say MORE than the feed does
+        self._seed({"g1": _node("g1"), "h1": self._handoff("h1", "g1")})
+        self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True))
+
+    def test_a_completed_handoff_ends_the_wait_on_the_graphs_own_event(self):
+        nodes = self._delegated_store()
+        nodes["h1"]["nodeComplete"] = True             # run_propagate checked it off — peer delivered
+        self._seed(nodes)
+        self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True))
+
+    def test_own_open_work_keeps_the_session_plain_not_awaiting(self):
+        nodes = self._delegated_store()
+        own = _node("s2", parent="g1")                 # an open OWN leaf → the session can still act
+        nodes["s2"] = own
+        self._seed(nodes)
+        self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True))
+
+    def test_a_dormant_session_never_lights_off_the_graph(self):
+        self._seed(self._delegated_store())
+        km._tmux_sessions = lambda: {}
+        self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True))
+
+    def test_the_chip_reads_awaitingBg_end_to_end(self):
+        # the shared _session_chip derivation (chat chip AND timeline lane) lights off the same arm
+        self._seed(self._delegated_store())
+        saved = (km._session_working, km._api_error, km._compacting, km._interrupting)
+        km._session_working = lambda turns: False
+        km._api_error = lambda path: None
+        km._compacting = lambda *a, **k: False
+        km._interrupting = lambda *a, **k: False
+        try:
+            chip = km._session_chip(SID, "/p", {"turns": []}, km._tmux_sessions()[SID], NOW)
+        finally:
+            km._session_working, km._api_error, km._compacting, km._interrupting = saved
+        self.assertEqual(chip, "awaitingBg")
+
+
 class OverlayDoesNotVeto(unittest.TestCase):
     """The production regression (the user 2026-07-27): the SDK Stop hook writes awaiting:false at EVERY
     turn end, and nothing has written true since 2026-07-07 — so every real SDK session carries a trailing


### PR DESCRIPTION
## What

One session, one question, two answers: a session whose only outstanding work was **delegated to a peer** (courier handoff) wore the feed's green awaiting dot, while the chat chip, timeline lane, and rail — all fed by `_session_awaiting` — said plain ready. (Live repro this morning: a session at rest whose open leaf was "↪ delegated to probe: …" — feed `awaiting: ["<name>"]`, timeline `awaitingBg: null`, chat `ready`.)

## Why

The feed's card flavor reads the delegation evidence directly (`_deleg_why` off the handoff graph in build_feed), and its session dot follows the cards. `_session_awaiting` consulted subagents, bg tasks, the states overlay, the owned yield, and the judge's stamp — but never the handoff graph.

## Fix

`_session_stamp_read`'s one mtime-cached store pass now also collects the delegated-peer sids of every inbox-visible top whose open leaves are all handoffs — pure-delegation tops excluded, since their cards are suppressed and the session dot must never say more than the feed. `_session_delegated_why` formats names at read time (renames stay fresh), and `_session_awaiting`'s stamp-gated branch consults it after the judge's stamp, mirroring the feed's own precedence. One source of truth; all three surfaces now light together and go dark together on the graph's own events (the handoff completing busts the cached read).

Deliberately not mirrored: the feed's blocked-card peer-wait flip — it corrects a needs-you verdict using the card's block context; a session-scoped mirror would light for any unanswered peer ask, overstating what the feed shows. Documented in the `_session_awaiting` docstring.

## Tests

`tests/test_kernel_awaiting_stamp.py` gains a `SessionLevelDelegation` class (8 cases): the delegated session lights on stamp=True, stays None on stamp=False (feed scopes per card), judge stamp outranks, pure-delegation stays dark, a completed handoff ends the wait, own open work keeps it plain, dormant never lights, and the shared `_session_chip` reads awaitingBg end to end. One existing `_session_stamp_read` unpack updated to the new arity.

Full Python suite (3944) and node suite (1676) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)