### PR TITLE
Cmd+O quick switcher, Cmd+P command palette, and one centered-modal treatment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,23 @@ collapsed tool-group runs, notice cards, postal/teammate cards, nudge gists,
 Task/Agent prompt+report. This is the "Glanceable by default; mechanics one click
 away" bullet of the Philosophy, stated as the standing rule for every new surface.
 
+### Panels open as centered modals over a dimmed, UNCHANGED dashboard (user rule, 2026-08-08)
+Every panel that opens over the dashboard — settings, the new-session picker, the
+Log, remote kernels, the command palette, and every future one — wears ONE
+treatment: a centered card over a translucent `rgba(0,0,0,0.55)` backdrop, with
+everything behind it left exactly as it was (dimmed but visible — never hidden,
+never solid black, never a layout change). Shell-native panels (`#rnet-back`,
+`#rerr-back`, `#rpal-back`) get this for free: their backdrop composites over the
+real panes. A panel living INSIDE a pane iframe that must cover the whole window
+(settings, picker) is lifted by the shell (`body.settings-open` /
+`body.picker-open`) and must then make EVERY layer under its backdrop transparent:
+the step-aside class rides `documentElement` AND `body` (THEME_CSS paints both
+opaque), and the shell's lift rule sets the iframe ELEMENT's own
+`background:transparent` (the default `iframe{background:#1e1e1e}` otherwise turns
+the dim into a full-window black-out — the 2026-08-08 bug, twice). Small
+pane-local dialogs (confirm boxes, the feed's card modal) stay pane-local by
+design; this rule is for panels that present over the dashboard as a whole.
+
 ### Font sizes: few, and consistent by information type (user rule, 2026-07-02)
 Do not multiply font sizes. Similar kinds of information wear the SAME size — labels
 match labels, times match the lines they annotate, section bodies match each other.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18138,14 +18138,18 @@ def _landing():
             "body.settings-open #feed-pane{display:block!important}"
             # inset:0 alone sizes a fixed box to the viewport; the explicit 100vw/100vh OVERRODE it and
             # overshot on iOS, hanging the modal's own actions below the fold (the user 2026-07-29).
-            "body.settings-open #f-feed{display:block;position:fixed;inset:0;z-index:200}"
+            # background:transparent — the shell paints every iframe #1e1e1e (no white flash while a pane
+            # loads), but a LIFTED iframe must show the dashboard through it: its page goes transparent
+            # (rs-modal-open / picker-lifted), and with the element still opaque the modal's dim composited
+            # over solid #1e1e1e — the whole window went black (the user 2026-08-08).
+            "body.settings-open #f-feed{display:block;position:fixed;inset:0;z-index:200;background:transparent}"
             # New-session PICKER full-screen (the user 2026-07-05): the picker lives INSIDE the /chat iframe, so
             # its position:fixed;inset:0 only covered the chat PANE — a short pane couldn't scroll the session
             # list. Same bridge as settings: render.ts posts {romp:'picker',on} and the shell lifts the chat
             # iframe over the whole window (body.picker-open) so the overlay fills the screen and the list gets
             # the full height to scroll. Restored on close.
             "body.picker-open #chat-pane{display:block!important}"
-            "body.picker-open #f-chat{display:block;position:fixed;inset:0;z-index:200}"
+            "body.picker-open #f-chat{display:block;position:fixed;inset:0;z-index:200;background:transparent}"   # same transparency as the settings lift above
             # ── pane rail (the user 2026-06-24; rotated to a BOTTOM BAR the user 2026-07-05): a thin toolbar with
             # Chat / Timeline / Outline / Feed toggles. It used to be a vertical strip on the far LEFT; it now runs
             # HORIZONTALLY across the bottom of .col, BELOW the timeline band (last child of .col). Each toggle is
@@ -18498,16 +18502,19 @@ def _landing():
             "#romp-boot .rl-dots{gap:9px}#romp-boot .rl-dots i{width:11px;height:11px}"
             # The notification center (the user 2026-07-27; replaces the fixed top banners — offline /
             # usage-limit / judge-degraded — which got in the way): the bell in the bottom bar's action
-            # cluster goes RED when an error lands; the popover is a panel anchored above the bell
-            # (bottom-right), newest first, per-row clear + Clear all.
+            # cluster goes RED when an error lands; clicking it opens the Log as a centered modal
+            # (the one panel treatment, the user 2026-08-08), newest first, per-row clear + Clear all.
             "#rail-errs.has,#merr.has{color:#ff6b6b}"   # red bell = something unread / a live problem; no count badge (it clipped, and the number added nothing — the user 2026-07-27)
-            "#rerr-back{position:fixed;inset:0;z-index:210;background:rgba(0,0,0,.35)}"
+            # centered like every other panel (the user 2026-08-08: one modal treatment — centered card,
+            # 0.55 dim, dashboard unchanged behind it; it used to sit bottom-right over the feed)
+            "#rerr-back{position:fixed;inset:0;z-index:210;display:flex;align-items:center;justify-content:center;"
+            "background:rgba(0,0,0,0.55)}#rerr-back[hidden]{display:none}"
             # The panel wears the SAME modal vocabulary as the settings card / network panel (the user
             # 2026-07-27: the first cut's font shorthand leaned on --vscode-font-family, which the browser
             # shell never defines, so the whole shorthand was invalid and the text rendered oversized in
             # the page default): #252526 card, 13px system-ui body, 14px/600 header, 11.5px rows + 11px
             # dim times (the network panel's information-type sizes), rnet-style action button + close.
-            "#rerr-panel{position:absolute;right:10px;bottom:44px;width:min(700px,94vw);max-height:min(60vh,480px);"   # 60% wider (the user 2026-07-28)
+            "#rerr-panel{width:min(700px,94vw);max-height:min(60vh,480px);"   # 60% wider (the user 2026-07-28); a flex child of the centered backdrop, no own positioning
             "display:flex;flex-direction:column;background:#252526;border:1px solid #3a3a3a;border-radius:10px;"
             "box-shadow:0 12px 36px #000000aa;color:#ccc;font:13px/1.6 system-ui,-apple-system,'Segoe UI',sans-serif}"
             "#rerr-panel .rerr-top{display:flex;align-items:center;gap:8px;font-size:14px;font-weight:600;color:#e8eaed;"
@@ -18755,6 +18762,10 @@ def _landing():
             "<script>" + _LANDING_REMOTES_JS + "</script>"
             "<script>" + _LANDING_MOBILE_JS + "</script>"
             "<script>" + _LANDING_COLLAPSE_JS + "</script>"
+            # the command palette (Cmd/Ctrl+P) and the session quick-switcher hotkey (Cmd/Ctrl+O):
+            # a dist bundle (ui/webview/palette-main.ts) like age-color-global above. Loaded last —
+            # it reads the __romp* globals lazily, at command run time, so order is cosmetic.
+            + ("<script src=/dist/palette-main.js?v=%d></script>" % v)
             + _stale_block(v) + _rdrift_block() +
             "</body></html>")
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6207,7 +6207,7 @@ class ServeSecurity(unittest.TestCase):
         # asks the shell to lift the feed iframe over the whole window; the feed then goes TRANSPARENT and
         # hides its own content (rs-modal-open), so the dimmed three-pane DASHBOARD shows through behind the
         # card — not the feed cards blown up full-screen.
-        self.assertIn("#rsettings { position: fixed; inset: 0; z-index: 60; background: #0000009c;", _gear_css_src())
+        self.assertIn("#rsettings { position: fixed; inset: 0; z-index: 60; background: rgba(0, 0, 0, 0.55);", _gear_css_src())   # the one modal dim (the user 2026-08-08)
         self.assertIn(".rs-card {", _gear_css_src())
         self.assertIn(".rs-modal-open { background: transparent; }", _gear_css_src())            # feed iframe transparent while open
         self.assertIn("body.rs-modal-open #feed-list", _gear_css_src())                     # feed cards hidden while open
@@ -6215,9 +6215,12 @@ class ServeSecurity(unittest.TestCase):
         self.assertIn("feedFull(true)", _gear_src())              # open → ask the shell to go full-window
         self.assertIn("setModalCls(true)", _gear_src())          # open → feed goes transparent + hides content
         self.assertIn("if (e.target === p) closeSettings()", _gear_src())   # backdrop click closes
-        # shell side: the feed iframe lifts to cover the whole window (the panes show THROUGH the transparent feed)
+        # shell side: the feed iframe lifts to cover the whole window (the panes show THROUGH the transparent
+        # feed). background:transparent on the LIFTED IFRAME ELEMENT is load-bearing: the shell's default
+        # iframe{background:#1e1e1e} otherwise sits under the transparent page and turns the modal's dim
+        # into a full-window black-out (the user 2026-08-08).
         html = km._landing()
-        self.assertIn("body.settings-open #f-feed{display:block;position:fixed;inset:0;z-index:200", html)   # display:block beats the mobile iframe-hiding
+        self.assertIn("body.settings-open #f-feed{display:block;position:fixed;inset:0;z-index:200;background:transparent}", html)
         self.assertIn("m.romp==='settings'", html)
         self.assertIn("document.body.classList.toggle('settings-open',!!m.on)", html)
 
@@ -6227,12 +6230,29 @@ class ServeSecurity(unittest.TestCase):
         # render.ts posts {romp:'picker',on} and the shell lifts the chat iframe over the whole window
         # (body.picker-open), so the overlay fills the screen and the list gets the full height to scroll.
         html = km._landing()
-        self.assertIn("body.picker-open #f-chat{display:block;position:fixed;inset:0;z-index:200", html)  # lift the chat iframe full-window (display:block beats the mobile hiding)
+        # background:transparent — same as the settings lift: the opaque iframe element was the black-out
+        self.assertIn("body.picker-open #f-chat{display:block;position:fixed;inset:0;z-index:200;background:transparent}", html)
         self.assertIn("body.picker-open #chat-pane{display:block!important}", html)         # un-hide it even if chat is toggled off
         self.assertIn("m.romp==='picker'", html)                                            # the shell listens for the picker post
         self.assertIn("document.body.classList.toggle('picker-open',!!m.on)", html)
         # the settings bridge is untouched (both share the one message handler)
         self.assertIn("document.body.classList.toggle('settings-open',!!m.on)", html)
+
+    def test_log_panel_is_a_centered_modal(self):
+        # the user 2026-08-08: ONE panel treatment — the Log wore the network modal's card but sat
+        # anchored bottom-right over the feed; now its backdrop centers it like #rnet-back, at the
+        # standard 0.55 dim, with the dashboard unchanged (dimmed, visible) behind it.
+        html = km._landing()
+        self.assertIn("#rerr-back{position:fixed;inset:0;z-index:210;display:flex;align-items:center;justify-content:center;", html)
+        self.assertIn("background:rgba(0,0,0,0.55)}#rerr-back[hidden]{display:none}", html)
+        # the panel is a flex child of the centered backdrop — no anchored positioning of its own
+        self.assertNotIn("#rerr-panel{position:absolute", html)
+
+    def test_palette_bundle_wired(self):
+        # the command palette (Cmd/Ctrl+P) + quick-switcher hotkey (Cmd/Ctrl+O): a dist bundle the
+        # shell page loads like age-color-global; behavior is pinned in ui/webview/palette.test.ts.
+        html = km._landing()
+        self.assertIn("<script src=/dist/palette-main.js?v=", html)
 
     def test_fleet_page_served(self):
         # Fleet (the user 2026-06-23): /fleet serves the by-session open-work view, rendered by dist/fleet.js.

--- a/tests/test_shell_viewport_fit.py
+++ b/tests/test_shell_viewport_fit.py
@@ -51,9 +51,11 @@ class OneHeightBasis(unittest.TestCase):
             self.assertNotIn(frag, shell, frag)
 
     def test_a_lifted_pane_is_sized_by_its_insets_not_by_viewport_units(self):
-        # inset:0 already IS the viewport box for a fixed element; the explicit 100vw/100vh overrode it
-        self.assertIn("body.settings-open #f-feed{display:block;position:fixed;inset:0;z-index:200}", self.html)
-        self.assertIn("body.picker-open #f-chat{display:block;position:fixed;inset:0;z-index:200}", self.html)
+        # inset:0 already IS the viewport box for a fixed element; the explicit 100vw/100vh overrode it.
+        # (background:transparent rides the same rules: an opaque lifted iframe blacks out the window —
+        # see test_kernel.test_settings_is_a_fullscreen_modal.)
+        self.assertIn("body.settings-open #f-feed{display:block;position:fixed;inset:0;z-index:200;background:transparent}", self.html)
+        self.assertIn("body.picker-open #f-chat{display:block;position:fixed;inset:0;z-index:200;background:transparent}", self.html)
 
     def test_an_unpainted_pane_is_dark_not_white(self):
         # a pane whose document has not painted is a white rectangle in a dark frame (Firefox shows it

--- a/ui/webview/commands.test.ts
+++ b/ui/webview/commands.test.ts
@@ -1,0 +1,31 @@
+// The command registry behind the palette (ui/webview/commands.ts) — real unit tests.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { registerCommand, commandList, runCommand } from "./commands";
+
+test("registers and lists in registration order (the palette's empty-query order)", () => {
+  registerCommand({ id: "t.one", title: "First thing", run: () => {} });
+  registerCommand({ id: "t.two", title: "Second thing", run: () => {} });
+  const ids = commandList().map((c) => c.id);
+  assert.ok(ids.indexOf("t.one") >= 0 && ids.indexOf("t.two") >= 0);
+  assert.ok(ids.indexOf("t.one") < ids.indexOf("t.two"));
+});
+
+test("re-registering an id replaces the command instead of duplicating it", () => {
+  let hits = 0;
+  registerCommand({ id: "t.re", title: "Old title", run: () => { hits = 1; } });
+  registerCommand({ id: "t.re", title: "New title", run: () => { hits = 2; } });
+  const matches = commandList().filter((c) => c.id === "t.re");
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].title, "New title");
+  assert.ok(runCommand("t.re"));
+  assert.equal(hits, 2);
+});
+
+test("runCommand runs the handler and reports unknown ids", () => {
+  let ran = false;
+  registerCommand({ id: "t.run", title: "Run me", run: () => { ran = true; } });
+  assert.equal(runCommand("t.run"), true);
+  assert.equal(ran, true);
+  assert.equal(runCommand("t.nope"), false);
+});

--- a/ui/webview/commands.ts
+++ b/ui/webview/commands.ts
@@ -1,0 +1,27 @@
+// The command registry behind the palette (Cmd/Ctrl+P). Anything the dashboard can do gets
+// registered here as a command; the palette is a fuzzy view over this list, so a new action
+// becomes keyboard-reachable by registering it — never by minting another hotkey.
+
+export type PaletteCommand = {
+  id: string;      // stable, dot-namespaced ("session.open")
+  title: string;   // what the palette shows and matches on — the user's words, verb first
+  kbd?: string;    // display-only hotkey chip ("⌘O"); the actual binding lives with the key wiring
+  run: () => void;
+};
+
+const commands = new Map<string, PaletteCommand>();
+
+export function registerCommand(cmd: PaletteCommand): void {
+  commands.set(cmd.id, cmd);   // re-registering an id replaces it, so a re-boot never duplicates
+}
+
+export function commandList(): PaletteCommand[] {
+  return Array.from(commands.values());   // registration order — the palette's empty-query order
+}
+
+export function runCommand(id: string): boolean {
+  const c = commands.get(id);
+  if (!c) return false;
+  c.run();
+  return true;
+}

--- a/ui/webview/fuzzy.test.ts
+++ b/ui/webview/fuzzy.test.ts
@@ -1,0 +1,47 @@
+// The palette's fuzzy matcher (ui/webview/fuzzy.ts) — real unit tests, it's pure and DOM-free.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { fuzzyMatch } from "./fuzzy";
+
+test("matches subsequences, rejects non-subsequences", () => {
+  assert.ok(fuzzyMatch("ops", "Open settings"));
+  assert.ok(fuzzyMatch("log", "Open the log"));
+  assert.equal(fuzzyMatch("xyz", "Open settings"), null);
+  assert.equal(fuzzyMatch("settingsx", "Open settings"), null);   // every query char must land
+});
+
+test("is case-insensitive both ways", () => {
+  assert.ok(fuzzyMatch("OPEN", "open settings"));
+  assert.ok(fuzzyMatch("open", "OPEN SETTINGS"));
+});
+
+test("empty or blank query matches everything with score 0", () => {
+  assert.deepEqual(fuzzyMatch("", "anything"), { score: 0, ranges: [] });
+  assert.deepEqual(fuzzyMatch("   ", "anything"), { score: 0, ranges: [] });
+});
+
+test("spaces in the query separate words without needing their own match", () => {
+  // the greedy walk consumes "open" then finds "set" later; the space itself is skipped
+  assert.ok(fuzzyMatch("open set", "Open settings"));
+  assert.ok(fuzzyMatch("o s", "Open settings"));
+});
+
+test("word starts outrank mid-word scatter", () => {
+  // "os" as two word-initials ("Open settings") must beat "os" buried mid-word ("ghosts")
+  const initials = fuzzyMatch("os", "open settings")!;
+  const buried = fuzzyMatch("os", "ghosts")!;
+  assert.ok(initials.score > buried.score);
+});
+
+test("consecutive runs outrank spread matches of the same letters", () => {
+  const run = fuzzyMatch("log", "log")!;
+  const spread = fuzzyMatch("log", "lxoxg")!;   // same letters, buried mid-word with gaps
+  assert.ok(run.score > spread.score);
+});
+
+test("ranges merge adjacent characters and cover exactly the matched chars", () => {
+  const hit = fuzzyMatch("open", "Open settings")!;
+  assert.deepEqual(hit.ranges, [[0, 4]]);   // one merged run, not four single-char ranges
+  const split = fuzzyMatch("ose", "Open settings")!;
+  assert.deepEqual(split.ranges, [[0, 1], [5, 7]]);   // "O" + "se" of settings
+});

--- a/ui/webview/fuzzy.ts
+++ b/ui/webview/fuzzy.ts
@@ -1,0 +1,39 @@
+// Fuzzy subsequence matching for the command palette (Obsidian-style): every query character
+// must appear in the text in order; the score rewards word starts, consecutive runs and early
+// matches. Pure and DOM-free — the palette renders the returned ranges as highlights.
+
+export type FuzzyRange = [number, number];   // [start, end) into the original text
+export type FuzzyHit = { score: number; ranges: FuzzyRange[] };
+
+// Greedy left-to-right walk, not optimal alignment: predictable, fast, and plenty for short
+// command titles and session names. Spaces in the query order words but need no match of
+// their own, so "open set" hits "Open settings" whether or not the greedy walk eats the space.
+export function fuzzyMatch(query: string, text: string): FuzzyHit | null {
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  if (!q.trim()) return { score: 0, ranges: [] };   // empty query matches everything, scoreless
+  const idx: number[] = [];
+  let ti = 0;
+  for (let qi = 0; qi < q.length; qi++) {
+    const c = q[qi];
+    if (c === " ") continue;
+    ti = t.indexOf(c, ti);
+    if (ti < 0) return null;
+    idx.push(ti);
+    ti++;
+  }
+  let score = 0;
+  for (let i = 0; i < idx.length; i++) {
+    const p = idx[i];
+    if (p === 0 || !/[a-z0-9]/.test(t[p - 1])) score += 3;   // start of the text or of a word
+    if (i > 0 && idx[i - 1] === p - 1) score += 2;           // consecutive run
+    score -= p * 0.01;                                       // earlier is a little better
+  }
+  const ranges: FuzzyRange[] = [];
+  for (const p of idx) {
+    const last = ranges[ranges.length - 1];
+    if (last && last[1] === p) last[1] = p + 1;
+    else ranges.push([p, p + 1]);
+  }
+  return { score, ranges };
+}

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -12,8 +12,8 @@
 /* The settings panel is a full-screen MODAL (the user 2026-06-23): #rsettings is the backdrop
    (the web shell expands the feed iframe to the whole window first — _LANDING_SETTINGS_JS;
    the VS Code feed panel already fills its group), .rs-card the roomy centered card. */
-#rsettings { position: fixed; inset: 0; z-index: 60; background: #0000009c; display: flex; align-items: flex-start;
-  justify-content: center; overflow: auto; padding: 6vh 16px; box-sizing: border-box; }
+#rsettings { position: fixed; inset: 0; z-index: 60; background: rgba(0, 0, 0, 0.55); display: flex; align-items: flex-start;
+  justify-content: center; overflow: auto; padding: 6vh 16px; box-sizing: border-box; }   /* the one modal dim */
 #rsettings[hidden] { display: none; }
 /* while open: the feed goes transparent + hides its own content, so (in the web shell) the
    full-window iframe shows the dashboard's panes through it — not the feed cards. */

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -33,7 +33,9 @@ var SHORTCUT_ROWS =
   '<div class=rs-key><span class=rs-key-combo><kbd>Shift</kbd> + <kbd>Enter</kbd></span><span class=rs-key-desc>New line</span></div>' +
   '<div class=rs-key><span class=rs-key-combo><kbd>Esc</kbd></span><span class=rs-key-desc>Jump to the session tabs</span></div>' +
   '<div class=rs-key><span class=rs-key-combo><kbd>←</kbd> / <kbd>→</kbd></span><span class=rs-key-desc>Switch session (from the tabs)</span></div>' +
-  '<div class=rs-key><span class=rs-key-combo><kbd>Ctrl</kbd> + <kbd>C</kbd></span><span class=rs-key-desc>Interrupt the session</span></div>';
+  '<div class=rs-key><span class=rs-key-combo><kbd>Ctrl</kbd> + <kbd>C</kbd></span><span class=rs-key-desc>Interrupt the session</span></div>' +
+  '<div class=rs-key><span class=rs-key-combo><kbd>⌘/Ctrl</kbd> + <kbd>O</kbd></span><span class=rs-key-desc>Open or create a session (quick switcher)</span></div>' +
+  '<div class=rs-key><span class=rs-key-combo><kbd>⌘/Ctrl</kbd> + <kbd>P</kbd></span><span class=rs-key-desc>Command palette (browser dashboard)</span></div>';
 
 // The modal markup — ported verbatim from the kernel's _gear_html; the model/
 // effort selects start empty and are filled from /models (see fill()).

--- a/ui/webview/palette-main.ts
+++ b/ui/webview/palette-main.ts
@@ -1,0 +1,82 @@
+// Shell-page boot for the command palette and the global hotkeys (browser dashboard only —
+// the VS Code surface gets real contributed keybindings instead, rebindable in its own
+// Keyboard Shortcuts editor). Cmd/Ctrl+P toggles the palette; Cmd/Ctrl+O opens the session
+// quick switcher — the existing new-session picker in the chat pane, one picker, one code
+// path. Both combos are claimable by a page (Google Docs and Figma take exactly these), the
+// override lasts only while this tab has focus, and the window/tab-management set
+// (Cmd+W/T/N/L/Q) stays untouched.
+import { registerCommand } from "./commands";
+import { initPalette } from "./palette";
+
+(function boot() {
+  // The shell page only, never inside a pane: the pane documents get the KEY wiring below
+  // (a keydown fires in whichever document holds focus and never crosses the iframe boundary),
+  // but the palette itself must sit in the top document to composite over all the panes.
+  if (window.parent && window.parent !== window) return;
+  const w = window as any;
+  const mac = /Mac|iP(hone|ad|od)/.test(navigator.platform || "");
+  const mod = mac ? "⌘" : "Ctrl+";
+
+  function pane(id: string): HTMLIFrameElement | null {
+    return document.getElementById(id) as HTMLIFrameElement | null;
+  }
+  function openSwitcher(): void {
+    // Reveal the chat pane if it's toggled off, focus it, and toggle the picker there. The
+    // __romp* globals and the picker's message handler are read lazily at RUN time, so boot
+    // order across the shell's script tags doesn't matter.
+    try { if (w.__rompPaneToggle) w.__rompPaneToggle("chat", true); } catch (e) { /* rail not booted yet */ }
+    const f = pane("f-chat");
+    try {
+      f!.contentWindow!.focus();
+      f!.contentWindow!.postMessage({ type: "openPicker", toggle: true }, "*");
+    } catch (e) { /* chat pane not loaded yet — nothing to open a picker in */ }
+  }
+
+  // The dashboard's actions, registered as commands. Each calls the SAME code path its rail
+  // button uses; the palette adds reachability, not behavior.
+  registerCommand({ id: "session.open", title: "Open or create a session", kbd: mod + "O", run: openSwitcher });
+  registerCommand({
+    id: "settings.open", title: "Open settings",
+    run: () => { try { pane("f-feed")!.contentWindow!.postMessage({ romp: "openSettings" }, "*"); } catch (e) { /* feed not loaded */ } },
+  });
+  registerCommand({ id: "log.open", title: "Open the log", run: () => { if (w.__rompOpenErrs) w.__rompOpenErrs(); } });
+  registerCommand({ id: "net.open", title: "Remote kernels", run: () => { if (w.__rompOpenNet) w.__rompOpenNet(); } });
+  registerCommand({ id: "usage.open", title: "Token usage", run: () => { if (w.__rompUsagePanel) w.__rompUsagePanel(); } });
+  registerCommand({ id: "kernel.restart", title: "Restart the romp kernel", run: () => { if (w.__rompRestart) w.__rompRestart(); } });
+  // Pane toggles. The Outline pane's INTERNAL key stays 'fleet' (the pane controller's API);
+  // the command speaks the user-facing name.
+  const panes: Array<[string, string]> = [["chat", "chat"], ["timeline", "timeline"], ["fleet", "outline"], ["feed", "feed"]];
+  for (const [key, label] of panes) {
+    registerCommand({
+      id: "pane." + label, title: "Show or hide the " + label + " pane",
+      run: () => { if (w.__rompPaneToggle) w.__rompPaneToggle(key); },
+    });
+  }
+
+  // Esc (or running a command) hands focus back to the chat pane, so "palette, Esc, type"
+  // never strands the keyboard on the shell document.
+  const palette = initPalette({ onClose: () => { try { pane("f-chat")!.contentWindow!.focus(); } catch (e) { /* no chat pane */ } } });
+  w.__rompPalette = palette;   // reachable by other shell scripts (e.g. a future mobile-bar button)
+
+  function onKey(e: KeyboardEvent): void {
+    if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey || e.repeat) return;
+    const k = (e.key || "").toLowerCase();
+    if (k === "o") { e.preventDefault(); e.stopPropagation(); palette.close(); openSwitcher(); }
+    else if (k === "p") { e.preventDefault(); e.stopPropagation(); palette.toggle(); }
+  }
+  // The same dual wiring as the Alt+Arrow pane nav (_LANDING_FOCUS_JS): capture on the shell
+  // document AND on every same-origin pane document, re-attached on every iframe (re)load.
+  // When focus is already in the chat document, render.ts's own window-capture Cmd+O handler
+  // runs first and stops propagation, so this one never double-fires.
+  document.addEventListener("keydown", onKey, true);
+  ["f-chat", "f-fleet", "f-feed", "f-timeline"].forEach((id) => {
+    const f = pane(id);
+    if (!f) return;
+    const wire = () => {
+      try { if (f.contentDocument) f.contentDocument.addEventListener("keydown", onKey, true); }
+      catch (e) { /* cross-origin frame: not one of ours */ }
+    };
+    f.addEventListener("load", wire);
+    wire();
+  });
+})();

--- a/ui/webview/palette.test.ts
+++ b/ui/webview/palette.test.ts
@@ -1,0 +1,93 @@
+// The command palette (Cmd/Ctrl+P) + session quick-switcher hotkey (Cmd/Ctrl+O), and the
+// one-modal-treatment conversions that came with them (the user 2026-08-08). Source-level
+// pins (no jsdom for the DOM pieces); fuzzy.ts and commands.ts have real unit tests, and the
+// kernel-side shell CSS/wiring is pinned in tests/test_kernel.py.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const PALETTE = read("palette.ts");
+const MAIN = read("palette-main.ts");
+const RENDER = read("render.ts");
+const CSS = read("styles.css");
+const GEAR_CSS = read("gear.css");
+const GEAR = read("gear.js");
+const ESBUILD = fs.readFileSync(path.resolve(process.cwd(), "esbuild.js"), "utf8");
+
+// ── the palette overlay wears the one modal treatment ──────────────────────────────────────
+test("palette backdrop is the standard centered 0.55 dim, above every shell panel", () => {
+  assert.match(PALETTE, /#rpal-back\{position:fixed;inset:0;z-index:300;display:flex;align-items:flex-start;justify-content:center;/);
+  assert.match(PALETTE, /background:rgba\(0,0,0,0\.55\)/);
+  assert.match(PALETTE, /#rpal-back\[hidden\]\{display:none\}/);
+});
+
+test("palette keyboard model: arrows wrap, Enter runs, Esc closes, backdrop click closes", () => {
+  assert.match(PALETTE, /e\.key === "ArrowDown"[\s\S]*?\(active \+ 1\) % rows\.length/);
+  assert.match(PALETTE, /e\.key === "ArrowUp"[\s\S]*?\(active - 1 \+ rows\.length\) % rows\.length/);
+  assert.match(PALETTE, /e\.key === "Enter"[\s\S]*?run\(r\.cmd\)/);
+  assert.match(PALETTE, /e\.key === "Escape"[\s\S]*?close\(\)/);
+  assert.match(PALETTE, /if \(e\.target === back\) close\(\);/);
+});
+
+test("running a command closes the palette FIRST so its own modal never lands underneath", () => {
+  assert.match(PALETTE, /function run\(cmd: PaletteCommand\): void \{\s*\n\s*close\(\);[\s\S]*?cmd\.run\(\);/);
+});
+
+// ── the shell boot: hotkeys reach every pane, commands call the rail's own code paths ──────
+test("Cmd/Ctrl+O opens the quick switcher and Cmd/Ctrl+P toggles the palette, claimed with preventDefault", () => {
+  assert.match(MAIN, /if \(!\(e\.metaKey \|\| e\.ctrlKey\) \|\| e\.altKey \|\| e\.shiftKey \|\| e\.repeat\) return;/);
+  assert.match(MAIN, /if \(k === "o"\) \{ e\.preventDefault\(\); e\.stopPropagation\(\); palette\.close\(\); openSwitcher\(\); \}/);
+  assert.match(MAIN, /else if \(k === "p"\) \{ e\.preventDefault\(\); e\.stopPropagation\(\); palette\.toggle\(\); \}/);
+});
+
+test("key wiring mirrors the Alt+Arrow pane nav: capture on the shell doc AND every pane doc, re-wired on load", () => {
+  assert.match(MAIN, /document\.addEventListener\("keydown", onKey, true\);/);
+  assert.match(MAIN, /\["f-chat", "f-fleet", "f-feed", "f-timeline"\]\.forEach/);
+  assert.match(MAIN, /f\.contentDocument\.addEventListener\("keydown", onKey, true\)/);
+  assert.match(MAIN, /f\.addEventListener\("load", wire\);\s*\n\s*wire\(\);/);
+});
+
+test("the switcher IS the existing picker (one code path), revealed and toggled via the chat pane", () => {
+  assert.match(MAIN, /__rompPaneToggle\("chat", true\)/);
+  assert.match(MAIN, /postMessage\(\{ type: "openPicker", toggle: true \}, "\*"\)/);
+});
+
+test("built-in commands call the same globals the rail buttons use", () => {
+  for (const g of ["__rompOpenErrs", "__rompOpenNet", "__rompUsagePanel", "__rompRestart", "__rompPaneToggle"]) {
+    assert.ok(MAIN.includes(g), g + " missing from palette-main.ts");
+  }
+});
+
+test("palette-main is bundled for the shell page", () => {
+  assert.match(ESBUILD, /"\.\.\/ui\/webview\/palette-main\.ts"/);
+});
+
+// ── the chat page's own Cmd+O (standalone + VS Code webview, and first-responder in the shell) ──
+test("render.ts claims Cmd/Ctrl+O at window capture and toggles the picker", () => {
+  assert.match(RENDER, /\(e\.key \|\| ""\)\.toLowerCase\(\) !== "o"\) return;/);
+  assert.match(RENDER, /if \(pickerVisible\(\)\) closePicker\(\); else openPicker\(\);/);
+});
+
+test("the openPicker message accepts toggle:true (the hotkey form relayed by the shell)", () => {
+  assert.match(RENDER, /if \(m\.toggle && pickerVisible\(\)\) closePicker\(\);\s*\n\s*else openPicker\(!!m\.pick, m\.prompt, !!m\.allowNew\);/);
+});
+
+// ── the black-out fixes: every layer under a lifted overlay's backdrop goes transparent ────
+test("picker lift rides documentElement AND body (THEME_CSS paints both opaque)", () => {
+  assert.match(RENDER, /document\.documentElement\.classList\.toggle\("picker-lifted", on\);\s*\n\s*document\.body\.classList\.toggle\("picker-lifted", on\);/);
+  assert.match(CSS, /html\.picker-lifted \{ background: transparent !important; \}/);
+  assert.match(CSS, /body\.picker-lifted \{ background: transparent !important; \}/);
+});
+
+test("overlay dims are the one standard 0.55", () => {
+  assert.match(CSS, /\.picker-overlay \{[\s\S]*?background: rgba\(0, 0, 0, 0\.55\);/);
+  assert.match(GEAR_CSS, /#rsettings \{ position: fixed; inset: 0; z-index: 60; background: rgba\(0, 0, 0, 0\.55\);/);
+});
+
+// ── discoverability: the settings' shortcut list names both hotkeys ────────────────────────
+test("the gear's shortcut rows document Cmd/Ctrl+O and Cmd/Ctrl+P", () => {
+  assert.match(GEAR, /<kbd>⌘\/Ctrl<\/kbd> \+ <kbd>O<\/kbd>[\s\S]*?quick switcher/);
+  assert.match(GEAR, /<kbd>⌘\/Ctrl<\/kbd> \+ <kbd>P<\/kbd>[\s\S]*?Command palette/);
+});

--- a/ui/webview/palette.ts
+++ b/ui/webview/palette.ts
@@ -1,0 +1,158 @@
+// The command palette overlay (Cmd/Ctrl+P) — Obsidian's shape: a card centered near the top,
+// a type-ahead input, fuzzy-filtered rows with highlighted matches, arrows + Enter, Esc or a
+// backdrop click to close. It lives in the SHELL document, so like the network panel it
+// composites over the real panes: one centered card, the standard 0.55 dim, and the dashboard
+// unchanged behind it (the one modal treatment, the user 2026-08-08).
+import { commandList, PaletteCommand } from "./commands";
+import { fuzzyMatch, FuzzyHit, FuzzyRange } from "./fuzzy";
+
+// The modal vocabulary the shell's panels share (#rnet-panel / #rerr-panel): #252526 card,
+// 1px #3a3a3a border, radius 10, 13px system-ui body, 11px chips. Injected as a <style> tag by
+// ensure() so the palette ships as ONE dist bundle with no separate <link> to plumb through
+// _landing. z-index 300: over every shell panel (net 200, log 210, restart report 220, usage 290).
+const CSS =
+  "#rpal-back{position:fixed;inset:0;z-index:300;display:flex;align-items:flex-start;justify-content:center;" +
+  "padding:14vh 16px 16px;background:rgba(0,0,0,0.55);box-sizing:border-box}" +
+  "#rpal-back[hidden]{display:none}" +
+  "#rpal{width:min(560px,94%);max-height:60vh;display:flex;flex-direction:column;background:#252526;" +
+  "border:1px solid #3a3a3a;border-radius:10px;box-shadow:0 12px 36px #000000aa;padding:8px;" +
+  "color:#ccc;font:13px/1.6 system-ui,-apple-system,'Segoe UI',sans-serif;box-sizing:border-box}" +
+  "#rpal-in{flex:0 0 auto;background:#1b1b1c;border:1px solid #3a3a3a;border-radius:6px;color:#e8eaed;" +
+  "font:inherit;padding:7px 10px;outline:none;box-sizing:border-box;width:100%}" +
+  "#rpal-in:focus{border-color:var(--accent,#9cd2ff)}" +
+  "#rpal-list{flex:1 1 auto;overflow-y:auto;margin-top:6px}" +
+  ".rpal-row{display:flex;align-items:center;gap:10px;padding:5px 10px;border-radius:6px;cursor:pointer}" +
+  ".rpal-row.active{background:rgba(156,210,255,0.12)}" +   // accent-blue focus cue, not a status color
+  ".rpal-title{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}" +
+  ".rpal-title b{color:var(--accent,#9cd2ff);font-weight:600}" +
+  ".rpal-kbd{flex:0 0 auto;color:#9aa0a6;font-size:11px;border:1px solid #3a3a3a;border-radius:4px;padding:0 5px}" +
+  ".rpal-empty{padding:8px 10px;color:#9aa0a6}";
+
+export type Palette = { open(): void; close(): void; toggle(): void; isOpen(): boolean };
+
+export function initPalette(opts?: { onClose?: () => void }, doc: Document = document): Palette {
+  let back: HTMLElement | null = null;
+  let input: HTMLInputElement;
+  let list: HTMLElement;
+  let rows: { cmd: PaletteCommand; el: HTMLElement }[] = [];
+  let active = 0;
+
+  // Built once, lazily; the palette is not subject to the dashboard's re-render pushes (the
+  // shell document never rebuilds), so rows stay click-safe without delegation gymnastics.
+  function ensure(): void {
+    if (back) return;
+    const style = doc.createElement("style");
+    style.textContent = CSS;
+    doc.head.appendChild(style);
+    back = doc.createElement("div");
+    back.id = "rpal-back";
+    back.hidden = true;
+    const panel = doc.createElement("div");
+    panel.id = "rpal";
+    input = doc.createElement("input");
+    input.id = "rpal-in";
+    input.placeholder = "Type a command…";
+    input.spellcheck = false;
+    list = doc.createElement("div");
+    list.id = "rpal-list";
+    panel.appendChild(input);
+    panel.appendChild(list);
+    back.appendChild(panel);
+    doc.body.appendChild(back);
+    input.addEventListener("input", () => render(input.value));
+    back.addEventListener("keydown", onKey);
+    back.addEventListener("click", (e) => { if (e.target === back) close(); });   // the dim, not the card
+    list.addEventListener("mouseover", (e) => {
+      const row = (e.target as HTMLElement).closest(".rpal-row");
+      const i = rows.findIndex((r) => r.el === row);
+      if (i >= 0) setActive(i);   // hover and keyboard share one active row, like the picker
+    });
+    list.addEventListener("click", (e) => {
+      const row = (e.target as HTMLElement).closest(".rpal-row");
+      const hit = rows.find((r) => r.el === row);
+      if (hit) run(hit.cmd);
+    });
+  }
+
+  function highlight(title: string, ranges: FuzzyRange[]): DocumentFragment {
+    const frag = doc.createDocumentFragment();
+    let at = 0;
+    for (const [s, e] of ranges) {
+      if (s > at) frag.appendChild(doc.createTextNode(title.slice(at, s)));
+      const b = doc.createElement("b");
+      b.textContent = title.slice(s, e);
+      frag.appendChild(b);
+      at = e;
+    }
+    if (at < title.length) frag.appendChild(doc.createTextNode(title.slice(at)));
+    return frag;
+  }
+
+  function render(query: string): void {
+    const hits = commandList()
+      .map((cmd) => ({ cmd, hit: fuzzyMatch(query, cmd.title) }))
+      .filter((x): x is { cmd: PaletteCommand; hit: FuzzyHit } => !!x.hit);
+    hits.sort((a, b) => b.hit.score - a.hit.score);   // stable sort: ties keep registration order
+    list.textContent = "";
+    rows = [];
+    for (const { cmd, hit } of hits) {
+      const row = doc.createElement("div");
+      row.className = "rpal-row";
+      const title = doc.createElement("span");
+      title.className = "rpal-title";
+      title.appendChild(highlight(cmd.title, hit.ranges));
+      row.appendChild(title);
+      if (cmd.kbd) {
+        const k = doc.createElement("span");
+        k.className = "rpal-kbd";
+        k.textContent = cmd.kbd;
+        row.appendChild(k);
+      }
+      list.appendChild(row);
+      rows.push({ cmd, el: row });
+    }
+    if (!rows.length) {
+      const empty = doc.createElement("div");
+      empty.className = "rpal-empty";
+      empty.textContent = "No matching commands";
+      list.appendChild(empty);
+    }
+    setActive(0);
+  }
+
+  function setActive(i: number): void {
+    active = i;
+    rows.forEach((r, j) => r.el.classList.toggle("active", j === i));
+    const el = rows[i]?.el;
+    if (el && el.scrollIntoView) el.scrollIntoView({ block: "nearest" });
+  }
+
+  function onKey(e: KeyboardEvent): void {
+    if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); close(); }
+    else if (e.key === "ArrowDown") { e.preventDefault(); if (rows.length) setActive((active + 1) % rows.length); }
+    else if (e.key === "ArrowUp") { e.preventDefault(); if (rows.length) setActive((active - 1 + rows.length) % rows.length); }
+    else if (e.key === "Enter") { e.preventDefault(); const r = rows[active]; if (r) run(r.cmd); }
+  }
+
+  function run(cmd: PaletteCommand): void {
+    close();   // close FIRST: a command that opens its own modal must not land under the palette
+    cmd.run();
+  }
+
+  function open(): void {
+    ensure();
+    back!.hidden = false;
+    input.value = "";
+    render("");
+    input.focus();
+  }
+  function close(): void {
+    if (!back || back.hidden) return;
+    back.hidden = true;
+    if (opts && opts.onClose) opts.onClose();
+  }
+  function isOpen(): boolean { return !!back && !back.hidden; }
+  function toggle(): void { if (isOpen()) close(); else open(); }
+
+  return { open, close, toggle, isOpen };
+}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3902,6 +3902,18 @@ window.addEventListener("keydown", (e) => {
     if (focusComposerOrAsk()) e.preventDefault();   // the picker card if one's up, else the message box
   }
 });
+// Cmd/Ctrl+O — toggle the session quick switcher (the picker), from anywhere in the page INCLUDING
+// the composer, the way Obsidian's quick switcher opens over the editor (the user 2026-08-08). The
+// page may claim this combo: preventDefault cancels the browser's own Cmd+O (open file) while this
+// tab has focus, and only there. Capture + stopPropagation so it wins over focused-control handlers —
+// and so the combined shell's per-pane capture handler (palette-main.ts, which relays the same combo
+// from the OTHER panes) never double-fires when focus is already in this document: window-capture
+// runs before document-capture, so this handler acts and stops the event first.
+window.addEventListener("keydown", (e) => {
+  if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey || (e.key || "").toLowerCase() !== "o") return;
+  e.preventDefault(); e.stopPropagation();
+  if (pickerVisible()) closePicker(); else openPicker();
+}, true);
 // Nearest tab in the row above (dir<0) or below (dir>0) the given tab, by column.
 function tabInAdjacentRow(id: string, dir: number): string | null {
   const bar = document.getElementById("tabs");
@@ -4055,6 +4067,9 @@ function signalPickerOverlay(on: boolean) {
       // screen rather than as a dialog over the dashboard. Dropping this page's background and hiding
       // its own content leaves only the picker drawn, so the timeline, feed and chat stay visible
       // (dimmed by the picker's own backdrop) behind a modal that floats over all of them.
+      // The class rides documentElement AND body (like the gear's rs-modal-open): THEME_CSS paints
+      // html and body separately, and an opaque html kept the lift a full black-out (the user 2026-08-08).
+      document.documentElement.classList.toggle("picker-lifted", on);
       document.body.classList.toggle("picker-lifted", on);
     }
   } catch (e) { /* standalone: no shell to lift */ }
@@ -4654,6 +4669,11 @@ function pickerError(msg: string | null) {
   if (!e) return;
   e.textContent = msg || "";
   e.classList.toggle("show", !!msg);
+}
+
+function pickerVisible(): boolean {
+  const o = document.getElementById("picker");
+  return !!o && o.style.display !== "none";
 }
 
 function closePicker() {
@@ -7960,7 +7980,12 @@ window.addEventListener("message", (e: MessageEvent) => {
       if (di) { di.value = m.path; di.focus(); }
     }
   }
-  else if (m.type === "openPicker") openPicker(!!m.pick, m.prompt, !!m.allowNew);
+  // toggle:true is the hotkey form (Cmd/Ctrl+O relayed by the shell): a second press closes an open
+  // picker instead of re-opening it, so the key behaves like Obsidian's quick switcher.
+  else if (m.type === "openPicker") {
+    if (m.toggle && pickerVisible()) closePicker();
+    else openPicker(!!m.pick, m.prompt, !!m.allowNew);
+  }
   // The host asks US to confirm (in-page, no native dialogs): ending a live
   // session on tab-close, and reviving a dead one on open.
   else if (m.type === "confirmClose" && m.id) {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1736,7 +1736,7 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
 /* ---------- session picker overlay (colored, Claude-Code-history style) ---------- */
 .picker-overlay {
   position: fixed; inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.55);   /* the one modal dim — same as the shell's network/Log/palette backdrops */
   display: none; align-items: flex-start; justify-content: center;
   z-index: 1000; padding: 56px 16px 16px;
 }
@@ -1757,6 +1757,7 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
    timeline and feed, which is why the picker read as the chat expanded to full screen instead of as a
    dialog. `visibility` (not display) so nothing reflows: layout is untouched, and the chat is exactly
    where it was when the picker closes. */
+html.picker-lifted { background: transparent !important; }   /* THEME_CSS paints html AND body — both must step aside */
 body.picker-lifted { background: transparent !important; }
 body.picker-lifted > * { visibility: hidden; }
 body.picker-lifted > #picker { visibility: visible; }

--- a/vscode-extension/esbuild.js
+++ b/vscode-extension/esbuild.js
@@ -47,6 +47,7 @@ const webview = {
     "../ui/webview/gear.css",            // the settings modal (linked by the kernel feed page + VS Code chat/feed)
     "../ui/webview/federation.ts",   // multi-kernel manager: loaded after the shim on chat/feed/fleet pages
     "../ui/webview/age-color-global.ts",   // window.__rompAgeColor for the kernel's inline shell scripts (bell panel)
+    "../ui/webview/palette-main.ts",   // command palette + Cmd/Ctrl+O/P hotkeys for the kernel's shell page
   ],
   nodePaths: [path.join(__dirname, "node_modules")],
   bundle: true,


### PR DESCRIPTION
## What

**Hotkeys (browser dashboard).** Cmd/Ctrl+O toggles the session quick switcher — the existing new-session picker, one code path — and Cmd/Ctrl+P toggles a new Obsidian-style command palette. Both work from any pane and from the composer; capture is wired like the Alt+Arrow pane nav (shell document + every same-origin pane document, re-attached on iframe load). The gear's shortcut list documents both.

**Command registry.** `ui/webview/commands.ts` + `ui/webview/palette.ts` + boot glue `palette-main.ts` (a new shell-page dist bundle, like `age-color-global`). The rail's actions are registered as commands that call their existing code paths (`__rompPaneToggle`, `__rompOpenErrs`, `__rompOpenNet`, `__rompUsagePanel`, `__rompRestart`, the settings/picker message bridges). Fuzzy matching in `ui/webview/fuzzy.ts`.

**One modal treatment** (recorded in CLAUDE.md as a standing design rule): every panel presents as a centered card over a `rgba(0,0,0,0.55)` dim with the dashboard unchanged behind it.
- Settings/picker black-outs fixed: the shell's default `iframe{background:#1e1e1e}` now goes transparent while a pane is lifted, and the picker's step-aside class rides `documentElement` as well as `body` (THEME_CSS paints both opaque).
- The Log panel moves from bottom-right-anchored to the same centered treatment.
- Backdrop dims standardized to 0.55 (settings was `#0000009c`, picker 0.5, Log 0.35).

## Tests

- Real unit tests: `fuzzy.test.ts`, `commands.test.ts`.
- Source pins: `palette.test.ts` (palette behavior, hotkey wiring, black-out fixes, shortcut rows).
- Kernel pins: `test_kernel.py` (transparent lifts, centered Log, palette bundle wired), `test_shell_viewport_fit.py` updated for the extended lift rules.
- Both suites green locally: 3931 Python + 1693 node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)