### PR TITLE
Tab rename resolves the live tab by id, never a node captured at menu-open

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3559,7 +3559,7 @@ function renderTabs() {
     // double-click a tab to show/hide the ledger overview — same as the strip's caret
     tab.addEventListener("dblclick", (e) => { e.preventDefault(); toggleLedgerCollapsed(); });
     // right-click → context menu; "Rename" edits the title in place
-    tab.addEventListener("contextmenu", (e) => { e.preventDefault(); e.stopPropagation(); showTabMenu(e, tab, label, id); });
+    tab.addEventListener("contextmenu", (e) => { e.preventDefault(); e.stopPropagation(); showTabMenu(e, id); });
     bar.appendChild(tab);
   }
   const add = el("div", "tab tab-add");
@@ -3677,12 +3677,15 @@ function ctxIcon(kind: "feed" | "mail" | "bell", off: boolean): HTMLElement {
   return span;
 }
 
-function showTabMenu(e: MouseEvent, tab: HTMLElement, label: HTMLElement, id: string) {
+function showTabMenu(e: MouseEvent, id: string) {
   dismissTabMenu();
   const menu = el("div", "ctx-menu");
   const rename = el("div", "ctx-item");
   rename.textContent = "Rename";
-  rename.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); startTabRename(tab, label, id); });
+  // id only, never the tab node under the cursor: the menu (on document.body) outlives kernel pushes,
+  // but the tab it was opened from does not — renderTabs() swaps the strip on every push, so a node
+  // captured here is usually DETACHED by the time Rename is clicked (the click-safety rule).
+  rename.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); startTabRename(id); });
   menu.appendChild(rename);
   // Feed + Mail per-session toggles (the user 2026-06-26) — the same controls as the timeline lane's feed
   // checkbox + postal mailbox, here as icon + label + a faint "what it does" sub-line. State from the session.
@@ -3750,9 +3753,20 @@ window.addEventListener("blur", () => dismissTabMenu());
 // "Rename" (tab context menu): swap the tab's label for an inline input. Enter
 // or clicking away commits (the host renames the tmux session and confirms with
 // a "renamed" message — the label only changes once that lands), Esc cancels.
-function startTabRename(tab: HTMLElement, label: HTMLElement, id: string) {
+function startTabRename(id: string) {
   const s = sessions.get(id);
-  if (!s || tab.querySelector(".tab-rename")) return;
+  if (!s) return;
+  // Resolve the tab NOW, by id. The old signature took the nodes captured at menu-open time, and a
+  // kernel push while the menu sat open replaced the strip under it — so the first Rename click did all
+  // its work on a detached orphan (invisible input, focus() a no-op) and left renameActive stuck true,
+  // since only that orphan input's Enter/Esc/blur could clear it. The frozen strip is why a SECOND
+  // attempt always worked, and why committing it healed everything (the user 2026-08-08: "rename only
+  // takes on the second try"). A vanished tab (session closed mid-menu) bails out BEFORE the flag.
+  const bar = document.getElementById("tabs");
+  const tab = bar && Array.from(bar.children).find(
+    (t): t is HTMLElement => t instanceof HTMLElement && t.dataset.id === id);
+  const label = tab && tab.querySelector<HTMLElement>(".tab-label");
+  if (!tab || !label || tab.querySelector(".tab-rename")) return;
   // A remote session displays as "host:name", where "host:" is METADATA this viewer added (see
   // ./host-prefix) — the far kernel knows the session by the bare name alone. Seeding the editor with
   // the whole display string handed the user the host to edit and sent it back on the other side of the

--- a/ui/webview/tab-rename-clicksafe.test.ts
+++ b/ui/webview/tab-rename-clicksafe.test.ts
@@ -1,0 +1,41 @@
+// Tab rename must act on the CURRENT tab node, never one captured when the menu opened (the user
+// 2026-08-08: "right-click → Rename does nothing; the second try works"). The context menu lives on
+// document.body and survives kernel pushes, but the tab it was opened FROM does not: renderTabs()
+// replaceChildren()s the strip on every push and nothing defers rebuilds while a menu is open. So by
+// the time Rename was clicked, the closure's tab/label were usually detached — startTabRename hid the
+// orphan's label, inserted an input nobody could see, and focus() was a silent no-op. Worse, the failed
+// call still set renameActive = true, and the only code clearing it sits on that detached input's
+// Enter/Esc/blur handlers, which can never fire — freezing the strip's re-renders, which is exactly why
+// the SECOND attempt always worked (its captured node could no longer be destroyed) and the freeze then
+// healed itself on commit. The fix is this codebase's standing click-safety rule: key the action off the
+// id and resolve the node at action time.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const rename = RENDER.slice(RENDER.indexOf("function startTabRename"),
+                            RENDER.indexOf("// Keyboard nav on a focused tab"));
+
+test("the menu's Rename hands over the id alone — no captured nodes", () => {
+  assert.match(RENDER, /dismissTabMenu\(\); startTabRename\(id\); \}\);/,
+               "the click resolves the tab itself; a node captured at menu-open time may be detached");
+  assert.doesNotMatch(RENDER, /startTabRename\(tab, label, id\)/);
+});
+
+test("startTabRename resolves the live tab by data-id at call time", () => {
+  assert.match(rename, /function startTabRename\(id: string\)/);
+  assert.match(rename, /dataset\.id === id/, "the strip is searched for the CURRENT node wearing this id");
+  assert.match(rename, /querySelector<HTMLElement>\("\.tab-label"\)/, "…and its label is taken from that node");
+});
+
+test("a vanished tab bails out before renameActive is touched", () => {
+  // the stuck-flag half of the bug: renameActive = true with no live input to ever clear it froze the
+  // strip until an unrelated rename committed. The guard must run BEFORE the flag is set.
+  const guard = rename.indexOf("if (!tab || !label");
+  const flag = rename.indexOf("renameActive = true");
+  assert.ok(guard > 0, "the resolve is guarded");
+  assert.ok(flag > 0, "the defer flag is still set for the live edit");
+  assert.ok(guard < flag, "the bail-out precedes the flag, so a dead tab can never freeze the strip");
+});


### PR DESCRIPTION
## The bug (2026-08-08)

Right-clicking a tab and choosing **Rename** did nothing the first time; repeating it worked. Deterministic, not a race you sometimes won.

## Root cause

The context menu is appended to `document.body`, so it survives kernel pushes — but the tab it was opened from does not: `renderTabs()` runs `replaceChildren()` on every push (0.5–3s cadence), and nothing defers rebuilds while a menu is open (only `renameActive` and `tabPointerHeld` defer). The Rename item's handler closed over the `tab`/`label` nodes captured at right-click time, so by click time they were usually detached. `startTabRename` then did all its work on the orphan: hid its label, inserted an input nobody could see, and `focus()` was a silent no-op.

The failed call still set `renameActive = true`, and the only code that clears it lives on that orphan input's Enter/Esc/blur handlers — which can never fire. The strip's re-renders froze from that moment, which is precisely why the **second** attempt always worked (its captured node could no longer be destroyed) and why committing it healed the freeze (`done()` clears the flag and flushes). The freeze masked the damage as "takes two tries".

## Fix

The repo's standing click-safety rule, applied: `showTabMenu(e, id)` and `startTabRename(id)` carry the id alone, and `startTabRename` resolves the current tab node (`#tabs` child with matching `dataset.id`) and its `.tab-label` at call time — bailing out **before** the `renameActive` flag if the tab is gone (session closed while the menu was open), so a dead tab can never freeze the strip. The menu's other items (color swatches, feed/mail/bell toggles) already acted on the id and are unchanged.

## Tests

`ui/webview/tab-rename-clicksafe.test.ts` (source pins, house style; red before the fix): the menu hands over the id alone, the tab is resolved by `data-id` at call time, and the vanished-tab bail-out precedes the flag. Full runs green: vscode-extension typecheck + build + 1702 node tests, pytest 3946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)