### PR TITLE
A slim vertical context gauge on every chat tab

### DIFF
--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -76,6 +76,10 @@ var GEAR_HTML =
   '<span><b>Show git branch</b>' +
   "<span class=rs-sub>Show the session's git branch (when it's in a repo) in the chat bottom bar, beside the directory.</span>" +
   '</span></label>' +
+  '<label class=rs-row><input type=checkbox id=rs-tabctx>' +
+  '<span><b>Context gauge in tabs</b>' +
+  "<span class=rs-sub>A slim vertical bar beside each session's name in the tab strip, filling as its context fills — the same colors as the context battery, no number.</span>" +
+  '</span></label>' +
   '<div class=rs-sec>Timeline</div>' +
   '<label class=rs-row><input type=checkbox id=rs-collapsegaps checked>' +
   '<span><b>Collapse idle gaps</b>' +
@@ -135,10 +139,11 @@ function initGear(post) {
     jix = document.getElementById('rs-judges-index'), jtr = document.getElementById('rs-judges-triage'),
     an = document.getElementById('rs-autonudge'), bk = document.getElementById('rs-backend'),
     dd = document.getElementById('rs-defaultdir'), gb = document.getElementById('rs-branch'),
+    tc = document.getElementById('rs-tabctx'),
     cg = document.getElementById('rs-collapsegaps'), jm = document.getElementById('rs-judgemodel'),
     im = document.getElementById('rs-indexmodel'), je = document.getElementById('rs-judgeeffort'),
     ie = document.getElementById('rs-indexeffort');
-  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: true, collapseGaps: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: true, collapseGaps: true }; } }
+  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: true, tabCtx: true, collapseGaps: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: true, tabCtx: true, collapseGaps: true }; } }
   // save() ALWAYS dispatches the same-doc 'romp:settings' signal: consumers in
   // THIS document (the feed's card gates, and the chat transcript now that it
   // hosts its own gear) never get a 'storage' event for a same-document write —
@@ -154,6 +159,7 @@ function initGear(post) {
   }
   cc.addEventListener('change', function () { var s = load(); s.compact = cc.checked; save(s); });
   if (gb) gb.addEventListener('change', function () { var s = load(); s.showBranch = gb.checked; save(s); });
+  if (tc) tc.addEventListener('change', function () { var s = load(); s.tabCtx = tc.checked; save(s); });
   jix.addEventListener('change', function () { var s = load(); s.showIndexJudges = jix.checked; save(s); });
   jtr.addEventListener('change', function () { var s = load(); s.showTriageJudges = jtr.checked; save(s); });
   if (cg) cg.addEventListener('change', function () { var s = load(); s.collapseGaps = cg.checked; save(s); });
@@ -246,7 +252,7 @@ function initGear(post) {
     if (on) { de.classList.add(m); document.body.classList.add(m); } else { de.classList.remove(m); document.body.classList.remove(m); } }
   function closeSettings() { p.hidden = true; setModalCls(false); feedFull(false); }
   function openSettings() { if (!p.hidden) { closeSettings(); return; }   // the opener toggles the modal
-    p.hidden = false; setModalCls(true); feedFull(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch !== false; if (cg) cg.checked = s.collapseGaps !== false; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; setModalCls(true); feedFull(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch !== false; if (tc) tc.checked = s.tabCtx !== false; if (cg) cg.checked = s.collapseGaps !== false; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   p.addEventListener('click', function (e) { if (e.target === p) closeSettings(); });   // click the dimmed backdrop (not the card) → close

--- a/ui/webview/render-settings.test.ts
+++ b/ui/webview/render-settings.test.ts
@@ -33,7 +33,9 @@ test("a collapsed tool run renders bold tool labels via toolCounts and is click-
 
 test("the chat has NO gear of its own — it only consumes the shared setting (gear is on the timeline)", () => {
   assert.doesNotMatch(RENDER, /chat-settings-gear/, "the gear was moved to the timeline");
-  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; rerenderAll\(\); \}\)/);
+  // renderTabs rides the change too: the tab strip reads settings (the context gauge toggle,
+  // the user 2026-08-08) and rerenderAll only rebuilds the transcript views.
+  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; renderTabs\(\); rerenderAll\(\); \}\)/);
 });
 
 test("the + New session button sends the picker's backend toggle, defaulting to the gear's (the user 2026-06-23)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3420,6 +3420,22 @@ function syncNoSessionsPlaceholder(visibleCount: number) {
   content.appendChild(ph);
 }
 
+// The tab strip's vertical context gauge: fill height = context-used %, coloured by the SAME
+// server-computed global-colormap RGB the statusline battery / timeline use (setCtxBar), with the
+// same traffic-light fallback for an older kernel that doesn't ship ctxColor. Passive — a click
+// falls through to the tab's own select; the statusline battery keeps the click-to-/compact.
+function tabCtxGauge(ctxStr: string, ctxColor?: number[]): HTMLElement {
+  const pct = Math.max(0, Math.min(100, parseInt(ctxStr, 10) || 0));
+  const g = el("span", "tab-ctx");
+  const fill = el("span", "tab-ctx-fill");
+  fill.style.height = pct + "%";
+  fill.style.background = (ctxColor && ctxColor.length === 3) ? `rgb(${ctxColor.join(",")})`
+    : (pct >= 85 ? "#c0392b" : pct >= 60 ? "#e0b020" : "#54B204");
+  g.appendChild(fill);
+  g.title = `context ${pct}% used`;
+  return g;
+}
+
 function renderTabs() {
   if (renameActive) { renderPendingAfterRename = true; return; }
   if (tabPointerHeld) { renderPendingWhilePressed = true; return; }   // don't destroy a tab mid-click (see tabPointerHeld)
@@ -3538,6 +3554,13 @@ function renderTabs() {
       tab.addEventListener("mouseleave", () => { label.style.color = fadedColor(full); label.classList.add("name-faded"); });
     }
     tab.appendChild(label);
+    // Slim vertical context gauge right of the name (the user 2026-08-08): the statusline battery's
+    // fill % + colormap colour, rotated upright and with no % text — so "this session is filling up"
+    // reads at a glance across the whole strip. Skipped while compacting (the compacting bar owns that
+    // moment, and the % is about to be wrong) and on dead tabs; gear → Chat toggles it (default on).
+    if (settings.tabCtx !== false && s.status.ctx && st !== "compacting" && st !== "closed") {
+      tab.appendChild(tabCtxGauge(s.status.ctx, s.status.ctxColor));
+    }
     // Rich hover tooltip (custom DOM — a native title can't colour/bold): backend in its own colour, the
     // full dir path, and mode/model/effort/context each on a line (the user 2026-06-23). See showTabTip.
     tab.addEventListener("mouseenter", () => showTabTip(tab, s));
@@ -8522,7 +8545,9 @@ function shipFileToHost(f: File) {
 // CONSUMES the shared 'romp:settings' (compact mode) — applying a change made there, in a same-origin
 // tab, live via the storage event; and reading it at startup. ----
 function setupSettings(): void {
-  onExternalSettingsChange((s) => { settings = s; rerenderAll(); });
+  // renderTabs too: the tab strip reads settings (the context gauge toggle) but rerenderAll only
+  // rebuilds the transcript views, so without it a gear change waited for the next kernel push.
+  onExternalSettingsChange((s) => { settings = s; renderTabs(); rerenderAll(); });
 }
 
 setupComposer();

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -16,12 +16,13 @@ export interface RompSettings {
   backend: "tmux" | "sdk";   // which backend a NEWLY-created session uses (the user 2026-06-22): "tmux" (terminal) or "sdk" (Agent SDK). Both coexist; this is only the default for the + button. Read at createSession time (render.ts). Default sdk (the user 2026-07-13).
   defaultDir: string;        // default working directory PREFILLED in the new-session field (the user 2026-06-22). A session's dir is fixed at creation. Empty → the kernel's serve dir. ~ / $VAR expanded server-side.
   showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). ON by default.
+  tabCtx: boolean;           // chat tabs: slim vertical context gauge beside each session name (the user 2026-08-08). ON by default.
 }
 // NOTE: the old `explanations` pref is GONE (the user 2026-06-18) — cards no longer show the planner's
 // hand-written "why" as their line; they show the distiller's summary instead (the why demotes to a hover).
 // compact defaults ON (the user 2026-07-14): a fresh install reads the tidy transcript
 // (thinking hidden, tool runs folded); the gear opts back into the full stream.
-export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: true };
+export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: true, tabCtx: true };
 const KEY = "romp:settings";
 
 export function loadSettings(): RompSettings {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -81,15 +81,17 @@ body { display: flex; flex-direction: column; }
   border-bottom: 1px solid var(--box-border);
   background: var(--vscode-sideBar-background, var(--bg));
 }
-/* #tabs fills the bar width and wraps its tabs across multiple rows */
-#tabs { display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 4px; }
+/* #tabs fills the bar width and wraps its tabs across multiple rows. gap 0 (was 4px, the user
+   2026-08-08): the strip trades its empty inter-tab space for room for the per-tab context gauge —
+   the active/hover fills and per-tab padding still separate neighbours visually. */
+#tabs { display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; }
 /* (the settings gear + modal live on the TIMELINE now — see ui/romp-timeline-view.js) */
 
 .tab {
   --state: transparent;                 /* working/awaiting state color (set by class) */
   position: relative;                   /* for the drag drop-indicator pseudo-element */
-  display: flex; flex: 0 0 auto; align-items: center; gap: 6px;
-  padding: 6px 9px; font-size: 0.92em; color: var(--dim);
+  display: flex; flex: 0 0 auto; align-items: center; gap: 4px;   /* 4px (was 6): tighter dot↔name↔gauge↔✕ run (the user 2026-08-08) */
+  padding: 6px 7px; font-size: 0.92em; color: var(--dim);         /* 7px sides (was 9): the saved space goes to the context gauge (the user 2026-08-08) */
   background: transparent; border: 1px solid transparent; border-bottom: none;
   border-radius: 6px 6px 0 0; cursor: pointer; white-space: nowrap; user-select: none;
   /* No UA focus ring: ⏎-send / Escape move keyboard focus ONTO the active tab (so ←/→ switch), and the
@@ -146,6 +148,13 @@ body { display: flex; flex-direction: column; }
 /* WORKING: a small yellow dot left of the name (replaces the old yellow outline). */
 .tab-dot { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: var(--st-working-bg); }   /* solid — dot oscillation was distracting (the user 2026-06-16) */
 .tab-dot.await { background: var(--st-awaitbg-bg); }   /* awaiting-bg: the dot matches the straw chip (the user 2026-07-13) */
+/* Vertical context gauge right of the name (the user 2026-08-08): the statusline battery rotated
+   upright — fills bottom-up with the context-used %, in the SAME global-colormap colour (fill set
+   inline by tabCtxGauge, render.ts), no % text. A faint track so an empty gauge still reads as
+   "gauge", not dirt. Toggled in gear → Chat ("Context gauge in tabs"), default on. */
+.tab-ctx { flex: 0 0 auto; position: relative; width: 4px; height: 13px; border-radius: 2px;
+  overflow: hidden; background: rgba(255, 255, 255, 0.13); }
+.tab-ctx-fill { position: absolute; left: 0; right: 0; bottom: 0; border-radius: 2px; }
 /* compacting → a tiny animated compaction bar before the name (this state gets no tab outline, so the bar
    is the cue). A teal fill whose right edge slides left and loops — the same compression motion as the
    statusline ctx-scan bar, miniaturised — so it reads as a transient process, not a status colour (the user
@@ -185,7 +194,7 @@ body { display: flex; flex-direction: column; }
 .tab.tab-placeholder.colored .tab-label { opacity: 0.75; }   /* keep the identity color but a touch muted while loading */
 .tab.tab-placeholder:hover { color: var(--dim); background: none; }
 .tab-ph-swirl { width: 12px; height: 12px; border-radius: 2px; flex: none;
-  animation: tab-ph-swirl-spin 7s linear infinite; }   /* .tab is flex with gap:6px, so no margin needed */
+  animation: tab-ph-swirl-spin 7s linear infinite; }   /* .tab is flex with its own gap, so no margin needed */
 @keyframes tab-ph-swirl-spin { to { transform: rotate(-360deg); } }
 /* SELECTED: gray fill PLUS an outline in the session's own identity color. */
 .tab.active { color: var(--fg); background: rgba(255, 255, 255, 0.14); }

--- a/ui/webview/tab-ctx-gauge.test.ts
+++ b/ui/webview/tab-ctx-gauge.test.ts
@@ -1,0 +1,57 @@
+// Each chat tab wears a slim VERTICAL context gauge beside the session name (the user 2026-08-08):
+// the statusline battery's fill % + global-colormap colour, rotated upright, no % text — so "this
+// session is filling up" reads at a glance across the whole strip. Space for it comes from tightening
+// the strip (inter-tab gap 0, smaller in-tab gap/padding), with the ✕ pushed to the tab's right edge
+// by DOM order (dot · name · gauge · ✕). A gear → Chat toggle shows/hides it, DEFAULT ON. Source-pin
+// (no jsdom for the tab-bar draw path, like the sibling tab-*.test.ts).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const WEBVIEW = path.resolve(process.cwd(), "..", "ui", "webview");
+const RENDER = fs.readFileSync(path.join(WEBVIEW, "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.join(WEBVIEW, "styles.css"), "utf8");
+const SETTINGS = fs.readFileSync(path.join(WEBVIEW, "settings.ts"), "utf8");
+const GEAR = fs.readFileSync(path.join(WEBVIEW, "gear.js"), "utf8");
+
+test("renderTabs appends the gauge after the label, gated on the setting + a reported ctx%", () => {
+  // default-on gate: `!== false` so a fresh store (no key yet) still shows the gauge
+  assert.match(RENDER, /settings\.tabCtx !== false && s\.status\.ctx && st !== "compacting" && st !== "closed"/);
+  assert.match(RENDER, /tab\.appendChild\(tabCtxGauge\(s\.status\.ctx, s\.status\.ctxColor\)\)/);
+  // DOM order: label first, then the gauge, then the ✕ — so the ✕ sits at the tab's right edge
+  const label = RENDER.indexOf("tab.appendChild(label);");
+  const gauge = RENDER.indexOf("tab.appendChild(tabCtxGauge(");
+  const close = RENDER.indexOf('const close = el("span", "tab-close");');
+  assert.ok(label >= 0 && label < gauge && gauge < close, "expected label < gauge < close in renderTabs");
+});
+
+test("the gauge mirrors setCtxBar: clamped %, server ctxColor, the same traffic-light fallback", () => {
+  assert.match(RENDER, /function tabCtxGauge\(ctxStr: string, ctxColor\?: number\[\]\)/);
+  assert.match(RENDER, /Math\.max\(0, Math\.min\(100, parseInt\(ctxStr, 10\) \|\| 0\)\)[\s\S]{0,400}fill\.style\.height = pct \+ "%"/);
+  // colormap colour when the kernel ships one; setCtxBar's exact fallback ramp when it doesn't
+  assert.match(RENDER, /tabCtxGauge[\s\S]{0,600}ctxColor && ctxColor\.length === 3\) \? `rgb\(\$\{ctxColor\.join\(","\)\}\)`\s*\n\s*: \(pct >= 85 \? "#c0392b" : pct >= 60 \? "#e0b020" : "#54B204"\)/);
+});
+
+test("the gauge is a slim VERTICAL bar and the strip tightened to make room for it", () => {
+  // vertical: markedly taller than wide, fill anchored to the bottom
+  const g = CSS.match(/\.tab-ctx \{[^}]*width: (\d+)px; height: (\d+)px/);
+  assert.ok(g, ".tab-ctx must declare width+height");
+  assert.ok(+g![1] < +g![2], `gauge must be vertical (w ${g![1]} < h ${g![2]})`);
+  assert.match(CSS, /\.tab-ctx-fill \{ position: absolute; left: 0; right: 0; bottom: 0/);
+  // the strip's spacing trade (the user 2026-08-08): inter-tab gap 0; in-tab gap/padding shrunk
+  assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; \}/);
+  assert.match(CSS, /\.tab \{[\s\S]{0,400}gap: 4px;[^\n]*\n\s*padding: 6px 7px;/);
+});
+
+test("gear → Chat toggle, default ON, persisted as settings.tabCtx", () => {
+  assert.match(SETTINGS, /tabCtx: boolean;/);
+  assert.match(SETTINGS, /DEFAULT_SETTINGS: RompSettings = \{[^}]*tabCtx: true/);
+  assert.match(GEAR, /id=rs-tabctx/);
+  assert.match(GEAR, /s\.tabCtx = tc\.checked; save\(s\);/);
+  assert.match(GEAR, /tc\.checked = s\.tabCtx !== false;/);   // modal reopens showing the stored value (default on)
+});
+
+test("a gear change repaints the tab strip live, not on the next kernel push", () => {
+  assert.match(RENDER, /onExternalSettingsChange\(\(s\) => \{ settings = s; renderTabs\(\); rerenderAll\(\); \}\)/);
+});


### PR DESCRIPTION
Each chat tab now carries a slim vertical context gauge right of the session name: the statusline battery rotated upright — fill height = context-used %, same server-computed global-colormap colour (traffic-light fallback for older kernels), no % text. A session filling up reads at a glance across the whole strip.

- Skipped while compacting (the compacting bar owns that moment) and on dead tabs.
- Room comes from tightening the strip: inter-tab gap 0, in-tab gap 6→4px, side padding 9→7px; the ✕ sits at the tab's right edge (dot · name · gauge · ✕).
- Gear → Chat: "Context gauge in tabs" toggle, default on. The settings-change handler now repaints the tab strip too, so the toggle applies live.
- Test: `ui/webview/tab-ctx-gauge.test.ts` pins the gate, the setCtxBar-mirroring colour logic, the vertical geometry + strip tightening, and the gear wiring; `render-settings.test.ts` updated for the extended settings-change line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)