### PR TITLE
The tab context gauge shows only past 50% by default

### DIFF
--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -76,10 +76,12 @@ var GEAR_HTML =
   '<span><b>Show git branch</b>' +
   "<span class=rs-sub>Show the session's git branch (when it's in a repo) in the chat bottom bar, beside the directory.</span>" +
   '</span></label>' +
-  '<label class=rs-row><input type=checkbox id=rs-tabctx>' +
-  '<span><b>Context gauge in tabs</b>' +
-  "<span class=rs-sub>A slim vertical bar beside each session's name in the tab strip, filling as its context fills — the same colors as the context battery, no number.</span>" +
-  '</span></label>' +
+  "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Context gauge in tabs</b>" +
+  "<span class=rs-sub>A slim vertical bar beside each session's name in the tab strip, filling as its context fills — the same colors as the context battery, no number. By default it appears only once a session is half full, so quiet tabs stay clean.</span>" +
+  "<select id=rs-tabctx style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
+  "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
+  '<option value=over50>When above 50%</option><option value=always>Always</option><option value=never>Never</option>' +
+  '</select></span></div>' +
   '<div class=rs-sec>Timeline</div>' +
   '<label class=rs-row><input type=checkbox id=rs-collapsegaps checked>' +
   '<span><b>Collapse idle gaps</b>' +
@@ -143,7 +145,10 @@ function initGear(post) {
     cg = document.getElementById('rs-collapsegaps'), jm = document.getElementById('rs-judgemodel'),
     im = document.getElementById('rs-indexmodel'), je = document.getElementById('rs-judgeeffort'),
     ie = document.getElementById('rs-indexeffort');
-  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: true, tabCtx: true, collapseGaps: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: true, tabCtx: true, collapseGaps: true }; } }
+  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: true, tabCtx: 'over50', collapseGaps: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: true, tabCtx: 'over50', collapseGaps: true }; } }
+  // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
+  // few hours as a boolean toggle — false was an explicit hide, true the default nobody chose.
+  function tabCtxMode(v) { return (v === 'always' || v === 'never') ? v : (v === false ? 'never' : 'over50'); }
   // save() ALWAYS dispatches the same-doc 'romp:settings' signal: consumers in
   // THIS document (the feed's card gates, and the chat transcript now that it
   // hosts its own gear) never get a 'storage' event for a same-document write —
@@ -159,7 +164,7 @@ function initGear(post) {
   }
   cc.addEventListener('change', function () { var s = load(); s.compact = cc.checked; save(s); });
   if (gb) gb.addEventListener('change', function () { var s = load(); s.showBranch = gb.checked; save(s); });
-  if (tc) tc.addEventListener('change', function () { var s = load(); s.tabCtx = tc.checked; save(s); });
+  if (tc) tc.addEventListener('change', function () { var s = load(); s.tabCtx = tc.value; save(s); });
   jix.addEventListener('change', function () { var s = load(); s.showIndexJudges = jix.checked; save(s); });
   jtr.addEventListener('change', function () { var s = load(); s.showTriageJudges = jtr.checked; save(s); });
   if (cg) cg.addEventListener('change', function () { var s = load(); s.collapseGaps = cg.checked; save(s); });
@@ -252,7 +257,7 @@ function initGear(post) {
     if (on) { de.classList.add(m); document.body.classList.add(m); } else { de.classList.remove(m); document.body.classList.remove(m); } }
   function closeSettings() { p.hidden = true; setModalCls(false); feedFull(false); }
   function openSettings() { if (!p.hidden) { closeSettings(); return; }   // the opener toggles the modal
-    p.hidden = false; setModalCls(true); feedFull(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch !== false; if (tc) tc.checked = s.tabCtx !== false; if (cg) cg.checked = s.collapseGaps !== false; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; setModalCls(true); feedFull(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch !== false; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cg) cg.checked = s.collapseGaps !== false; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   p.addEventListener('click', function (e) { if (e.target === p) closeSettings(); });   // click the dimmed backdrop (not the card) → close

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3557,9 +3557,12 @@ function renderTabs() {
     // Slim vertical context gauge right of the name (the user 2026-08-08): the statusline battery's
     // fill % + colormap colour, rotated upright and with no % text — so "this session is filling up"
     // reads at a glance across the whole strip. Skipped while compacting (the compacting bar owns that
-    // moment, and the % is about to be wrong) and on dead tabs; gear → Chat toggles it (default on).
-    if (settings.tabCtx !== false && s.status.ctx && st !== "compacting" && st !== "closed") {
-      tab.appendChild(tabCtxGauge(s.status.ctx, s.status.ctxColor));
+    // moment, and the % is about to be wrong) and on dead tabs. gear → Chat picks WHEN it shows:
+    // only once ≥50% full (the default — a gauge on every quiet tab is clutter; it appears when it
+    // has news), always, or never (the user 2026-08-08 v2, replacing the on/off toggle).
+    if (settings.tabCtx !== "never" && s.status.ctx && st !== "compacting" && st !== "closed") {
+      const pct = Math.max(0, Math.min(100, parseInt(s.status.ctx, 10) || 0));
+      if (settings.tabCtx === "always" || pct >= 50) tab.appendChild(tabCtxGauge(s.status.ctx, s.status.ctxColor));
     }
     // Rich hover tooltip (custom DOM — a native title can't colour/bold): backend in its own colour, the
     // full dir path, and mode/model/effort/context each on a line (the user 2026-06-23). See showTabTip.

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -16,19 +16,33 @@ export interface RompSettings {
   backend: "tmux" | "sdk";   // which backend a NEWLY-created session uses (the user 2026-06-22): "tmux" (terminal) or "sdk" (Agent SDK). Both coexist; this is only the default for the + button. Read at createSession time (render.ts). Default sdk (the user 2026-07-13).
   defaultDir: string;        // default working directory PREFILLED in the new-session field (the user 2026-06-22). A session's dir is fixed at creation. Empty → the kernel's serve dir. ~ / $VAR expanded server-side.
   showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). ON by default.
-  tabCtx: boolean;           // chat tabs: slim vertical context gauge beside each session name (the user 2026-08-08). ON by default.
+  tabCtx: TabCtxMode;        // chat tabs: WHEN the context gauge shows beside each session name (the user 2026-08-08) — "over50" (default: only once half full, so quiet tabs stay clean), "always", or "never".
+}
+// When the tab strip's context gauge shows. "over50" is the default (the user 2026-08-08): a gauge
+// on every tab is clutter while nothing is filling up — it should appear only when it has news.
+export type TabCtxMode = "always" | "over50" | "never";
+// The gauge shipped for a few hours as a boolean toggle (2026-08-08) — normalize a stored
+// true/false (or anything else unrecognized) into the mode enum: false was an explicit "hide"
+// → never; true was the shipped default nobody chose → the new default. loadSettings applies
+// this, so consumers always see a mode.
+export function tabCtxMode(v: unknown): TabCtxMode {
+  return v === "always" || v === "never" ? v : v === false ? "never" : "over50";
 }
 // NOTE: the old `explanations` pref is GONE (the user 2026-06-18) — cards no longer show the planner's
 // hand-written "why" as their line; they show the distiller's summary instead (the why demotes to a hover).
 // compact defaults ON (the user 2026-07-14): a fresh install reads the tidy transcript
 // (thinking hidden, tool runs folded); the gear opts back into the full stream.
-export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: true, tabCtx: true };
+export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: true, tabCtx: "over50" };
 const KEY = "romp:settings";
 
 export function loadSettings(): RompSettings {
   try {
     const raw = localStorage.getItem(KEY);
-    if (raw) return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
+    if (raw) {
+      const s = { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
+      s.tabCtx = tabCtxMode(s.tabCtx);   // a store written by the boolean-era gear holds true/false
+      return s;
+    }
   } catch { /* corrupt / unavailable → defaults */ }
   return { ...DEFAULT_SETTINGS };
 }

--- a/ui/webview/tab-ctx-gauge.test.ts
+++ b/ui/webview/tab-ctx-gauge.test.ts
@@ -2,12 +2,15 @@
 // the statusline battery's fill % + global-colormap colour, rotated upright, no % text — so "this
 // session is filling up" reads at a glance across the whole strip. Space for it comes from tightening
 // the strip (inter-tab gap 0, smaller in-tab gap/padding), with the ✕ pushed to the tab's right edge
-// by DOM order (dot · name · gauge · ✕). A gear → Chat toggle shows/hides it, DEFAULT ON. Source-pin
-// (no jsdom for the tab-bar draw path, like the sibling tab-*.test.ts).
+// by DOM order (dot · name · gauge · ✕). WHEN it shows is a gear → Chat picker (the user 2026-08-08
+// v2, replacing the on/off toggle): only once ≥50% full (the DEFAULT — a gauge on every quiet tab is
+// clutter), always, or never. Source-pin (no jsdom for the tab-bar draw path, like the sibling
+// tab-*.test.ts); the mode normalization is pure and unit-tested directly.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { tabCtxMode, DEFAULT_SETTINGS } from "./settings";
 
 const WEBVIEW = path.resolve(process.cwd(), "..", "ui", "webview");
 const RENDER = fs.readFileSync(path.join(WEBVIEW, "render.ts"), "utf8");
@@ -15,9 +18,10 @@ const CSS = fs.readFileSync(path.join(WEBVIEW, "styles.css"), "utf8");
 const SETTINGS = fs.readFileSync(path.join(WEBVIEW, "settings.ts"), "utf8");
 const GEAR = fs.readFileSync(path.join(WEBVIEW, "gear.js"), "utf8");
 
-test("renderTabs appends the gauge after the label, gated on the setting + a reported ctx%", () => {
-  // default-on gate: `!== false` so a fresh store (no key yet) still shows the gauge
-  assert.match(RENDER, /settings\.tabCtx !== false && s\.status\.ctx && st !== "compacting" && st !== "closed"/);
+test("renderTabs appends the gauge after the label, gated on the mode + a reported ctx%", () => {
+  assert.match(RENDER, /settings\.tabCtx !== "never" && s\.status\.ctx && st !== "compacting" && st !== "closed"/);
+  // the 50% threshold: over50 (the default) shows the gauge only once it has news
+  assert.match(RENDER, /settings\.tabCtx === "always" \|\| pct >= 50/);
   assert.match(RENDER, /tab\.appendChild\(tabCtxGauge\(s\.status\.ctx, s\.status\.ctxColor\)\)/);
   // DOM order: label first, then the gauge, then the ✕ — so the ✕ sits at the tab's right edge
   const label = RENDER.indexOf("tab.appendChild(label);");
@@ -44,12 +48,25 @@ test("the gauge is a slim VERTICAL bar and the strip tightened to make room for 
   assert.match(CSS, /\.tab \{[\s\S]{0,400}gap: 4px;[^\n]*\n\s*padding: 6px 7px;/);
 });
 
-test("gear → Chat toggle, default ON, persisted as settings.tabCtx", () => {
-  assert.match(SETTINGS, /tabCtx: boolean;/);
-  assert.match(SETTINGS, /DEFAULT_SETTINGS: RompSettings = \{[^}]*tabCtx: true/);
+test("the mode defaults to over50 and normalizes the boolean-era store", () => {
+  assert.equal(DEFAULT_SETTINGS.tabCtx, "over50");
+  assert.equal(tabCtxMode("always"), "always");
+  assert.equal(tabCtxMode("never"), "never");
+  assert.equal(tabCtxMode("over50"), "over50");
+  assert.equal(tabCtxMode(false), "never", "boolean-era false was an explicit hide");
+  assert.equal(tabCtxMode(true), "over50", "boolean-era true was the shipped default nobody chose");
+  assert.equal(tabCtxMode(undefined), "over50", "a fresh store gets the default");
+  // loadSettings applies it, so render/gear consumers always see a mode
+  assert.match(SETTINGS, /s\.tabCtx = tabCtxMode\(s\.tabCtx\);/);
+});
+
+test("gear → Chat picker (When above 50% / Always / Never), persisted as settings.tabCtx", () => {
   assert.match(GEAR, /id=rs-tabctx/);
-  assert.match(GEAR, /s\.tabCtx = tc\.checked; save\(s\);/);
-  assert.match(GEAR, /tc\.checked = s\.tabCtx !== false;/);   // modal reopens showing the stored value (default on)
+  assert.match(GEAR, /<option value=over50>When above 50%<\/option><option value=always>Always<\/option><option value=never>Never<\/option>/);
+  assert.match(GEAR, /s\.tabCtx = tc\.value; save\(s\);/);
+  // modal reopens showing the stored value, normalized (gear.js can't import the TS module)
+  assert.match(GEAR, /tc\.value = tabCtxMode\(s\.tabCtx\);/);
+  assert.match(GEAR, /function tabCtxMode\(v\) \{ return \(v === 'always' \|\| v === 'never'\) \? v : \(v === false \? 'never' : 'over50'\); \}/);
 });
 
 test("a gear change repaints the tab strip live, not on the next kernel push", () => {


### PR DESCRIPTION
Follow-up to #233. The "Context gauge in tabs" on/off toggle becomes a three-way picker (gear → Chat): **When above 50%** (new default), **Always**, or **Never**. A gauge on every quiet tab is clutter — by default it now appears only once a session's context is half full, when it actually has news.

- `settings.tabCtx` becomes a mode enum (`"always" | "over50" | "never"`); `tabCtxMode()` normalizes the boolean-era store (false, an explicit hide → never; true, the shipped default nobody chose → over50), applied in `loadSettings` and mirrored in `gear.js` (which can't import the TS module).
- `renderTabs` gates on the mode + the 50% threshold; everything else about the gauge is unchanged.
- Tests: `tab-ctx-gauge.test.ts` updated — mode gate + threshold pins, gear select pins, and direct unit tests of the normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)