### PR TITLE
Per-session API-key auth, per-turn spend deltas, and a reworked usage hover

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13717,6 +13717,10 @@ def _usage():
     limited = {"fiveHour": _lim(five), "sevenDay": _lim(seven), "fable": _lim(fable)}
     t = o.get("t")
     return {"fiveHour": five, "sevenDay": seven, "fable": fable,
+            # the spend windows ride BESIDE the subscription bars now (the user 2026-08-08): the rail's
+            # hover draws the three windows' TOKEN volume on one shared scale for every account, and the
+            # token data lives only here. Rail rows still key on the bars; this is hover detail.
+            "spend": _spend_windows(),
             "t": t if isinstance(t, (int, float)) else None,
             # WHOSE allowance this is. These windows are account-wide, so two machines signed into the
             # SAME account share one set of numbers and must not be drawn twice; two machines on
@@ -17127,15 +17131,26 @@ if(n>=1e3)return (n/1e3).toFixed(1).replace(/\.0$/,'')+'k';return String(n);}
 // only month-to-date draws the elapsed track. strip.ts carries the same builder \u2014 kept in step.
 var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','Month']];
 function spendColor(p){return p>=90?'#c0392b':p>=70?'#e0b020':'#54B204';}
-function spendWinsHTML(u){var sp=u.spend||{},html='';
+// The per-account SPEND detail for the rich hover (the token graph + dollars/turns rows) \u2014 filled for
+// EVERY account whose payload carries spend, subscription accounts included (the kernel now attaches
+// spend windows beside the bars): the hover's token view is the same three windows on ONE scale.
+function spendDet(u,det){var sp=u&&u.spend;if(!sp||!det)return;
+SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='number')return;
+var budget=(typeof seg.budget==='number'&&seg.budget>0)?seg.budget:null;
+(det._spend=det._spend||{})[w[0]]={label:w[1],usd:seg.usd,tok:seg.tok||0,turns:seg.turns||0,
+budget:budget,pct:budget!=null?Math.max(0,Math.min(100,Math.round(seg.usd/budget*100))):null};});}
+// NO native title attributes anywhere on the rail (the user 2026-08-08, who got the browser's flat
+// yellow box on top of the rich hover, nowhere near the cursor): the rich tip is the ONE hover surface,
+// and everything the titles used to say \u2014 dollars, tokens, turns, the budget hint \u2014 lives there now.
+function spendWinsHTML(u,det){var sp=u.spend||{},html='';spendDet(u,det);
 SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='number')return;
 var budget=(typeof seg.budget==='number'&&seg.budget>0)?seg.budget:null;
 var pct=budget!=null?Math.max(0,Math.min(100,Math.round(seg.usd/budget*100))):null;
 var el2=null;
 if(w[0]==='month'&&budget!=null){var dd=new Date(),dim=new Date(dd.getFullYear(),dd.getMonth()+1,0).getDate();
 el2=Math.max(0,Math.min(100,Math.round(((dd.getDate()-1+dd.getHours()/24)/dim)*100)));}
-var turns=seg.turns||0,readout='$'+(seg.usd<100?seg.usd.toFixed(2):String(Math.round(seg.usd)))+' \u00b7 '+fmtTok(seg.tok||0)+' tok';
-html+='<div class="ru-w ru-spend" title="'+w[1]+' \u2014 $'+seg.usd.toFixed(2)+' \u00b7 '+fmtTok(seg.tok||0)+' tokens \u00b7 '+turns+' turn'+(turns===1?'':'s')+(budget!=null?' \u00b7 '+pct+'% of the $'+budget+' budget':' \u00b7 no budget set \u2014 dollars only, no fill (set one in spend-budgets.json)')+' \u00b7 API-key billing">'
+var readout='$'+(seg.usd<100?seg.usd.toFixed(2):String(Math.round(seg.usd)))+' \u00b7 '+fmtTok(seg.tok||0)+' tok';
+html+='<div class="ru-w ru-spend">'
 +'<div class=ru-name>'+w[1]+'</div>'
 +'<div class=ru-bars>'
 +(pct!=null?'<div class=ru-track><i class=ru-fill style="width:'+pct+'%;background:'+spendColor(pct)+'"></i></div>':'')
@@ -17181,13 +17196,21 @@ function renderRows(rows,selfHost){ROWS=rows||[];LAST={};
 var live=ROWS.filter(function(r){return hasBars(r.usage)||hasSpend(r.usage);});
 if(!live.length){el.innerHTML='';tip.style.display='none';return;}
 if(live.length===1){var det={};det._t=(typeof live[0].usage.t==='number')?live[0].usage.t:null;
-LAST=[{host:'',det:det}];el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendWinsHTML(live[0].usage);return;}
+LAST=[{host:'',det:det}];
+if(hasBars(live[0].usage)){el.innerHTML=winsHTML(live[0].usage,det);spendDet(live[0].usage,det);}
+else el.innerHTML=spendWinsHTML(live[0].usage,det);
+return;}
 var html='';LAST=[];
+// no native title on the account set (the user 2026-08-08 — the rich tip is the ONE hover surface);
+// the separate-allowance note rides the tip's host heading instead (setHTML).
 live.forEach(function(r){var det={};det._t=(typeof r.usage.t==='number')?r.usage.t:null;
 var hn=r.host||selfHost||'this machine';
 LAST.push({host:hn,det:det});
-html+='<div class=ru-set title="The Claude account signed in on '+esc(hn)+'. Its allowance is separate from the others here, so each login gets its own bars.">'
-+'<span class=ru-host>'+esc(hn)+':</span>'+(hasBars(r.usage)?winsHTML(r.usage,det):spendWinsHTML(r.usage))+'</div>';});
+var inner;
+if(hasBars(r.usage)){inner=winsHTML(r.usage,det);spendDet(r.usage,det);}
+else inner=spendWinsHTML(r.usage,det);
+html+='<div class=ru-set>'
++'<span class=ru-host>'+esc(hn)+':</span>'+inner+'</div>';});
 el.innerHTML=html;}
 // The single-payload path the timeline still posts (and the mobile panel's own fetch): treat it as this
 // machine's row, leaving any other account's bars alone.
@@ -17207,24 +17230,48 @@ function barRows(d){return (d.unk
 +'<span class=ru-tip-track><i style="width:'+d.tp+'%;background:#6b7a8c"></i></span>'
 +'<span class=ru-tip-v>'+d.tp+'%</span></div>':'');}
 // LAST is one entry per ACCOUNT (2026-07-30), so the tooltip is the same window rows it always was, once
-// per login \u2014 with the host heading it only when there IS more than one, so the ordinary single-account
-// hover is byte-for-byte what it used to be.
+// per login \u2014 with the host heading it only when there IS more than one. A SPEND-ONLY account (an
+// API key / a login-less host) used to return '' here, so a mixed fleet's hover silently showed only
+// the subscription login (the user 2026-08-08) \u2014 its dollars now render as their own section.
 function setHTML(e,many){var d=e.det,keys=['fiveHour','sevenDay','fable'].filter(function(k){return d[k];});
-if(!keys.length)return '';
-return (many?'<div class=ru-tip-host>'+esc(e.host)+'</div>':'')
-+keys.map(function(k){var v=d[k];
+var sp=d._spend||null;
+if(!keys.length&&!sp)return '';
+var spendOnly=!keys.length;                       // no subscription windows \u2192 an API-key / no-login account
+var h=(many?'<div class=ru-tip-host>'+esc(e.host)+' \u2014 its own allowance</div>':'');
+h+=keys.map(function(k){var v=d[k];
 return '<div class=ru-tip-win><div class=ru-tip-name><span>'+esc(v.name)+' ('+esc(v.span)+')</span>'
 +(v.unk?'<span class=ru-tip-reset>window reset '+esc(v.ago)+' \u2014 no reading since; current usage unknown</span>'
-:(v.reset?'<span class=ru-tip-reset>resets in '+esc(v.reset)+'</span>':''))+'</div>'+barRows(v)+'</div>';}).join('')
-+(d._t?'<div class=ru-tip-age>updated '+fmtAgo(d._t)+'</div>':'');}
+:(v.reset?'<span class=ru-tip-reset>resets in '+esc(v.reset)+'</span>':''))+'</div>'+barRows(v)+'</div>';}).join('');
+// The TOKEN GRAPH (the user 2026-08-08): the three spend windows' token volume on ONE shared scale \u2014
+// each bar auto-scales to the largest window, so 5h vs 7d vs month compares at a glance in the same
+// track idiom as the % bars above. Dollars ride the value column only where they are REAL billing (a
+// spend-only account); a subscription login's nominal cost would read as a bill, so it stays tokens.
+if(sp){var ks=['fiveHour','sevenDay','month'].filter(function(k){return sp[k];});
+if(ks.length){var mx=1;ks.forEach(function(k){if(sp[k].tok>mx)mx=sp[k].tok;});
+h+='<div class=ru-tip-win><div class=ru-tip-name><span>'+(spendOnly?'API-key spend':'Tokens')+'</span>'
++'<span class=ru-tip-reset>5h / 7d / month \u00b7 one scale</span></div>'
++ks.map(function(k){var v=sp[k],wpct=v.tok>0?Math.max(2,Math.round(v.tok/mx*100)):0;
+return '<div class=ru-tip-row><span class=ru-tip-k>'+esc(v.label)+'</span>'
++'<span class=ru-tip-track><i style="width:'+wpct+'%;background:#6b7a8c"></i></span>'
++'<span class=ru-tip-v>'+fmtTok(v.tok)+(spendOnly?' \u00b7 $'+(v.usd<100?v.usd.toFixed(2):String(Math.round(v.usd))):'')+'</span></div>';}).join('')
++(spendOnly&&!ks.some(function(k){return sp[k].budget!=null;})
+?'<div class=ru-tip-age>no budget set \u2014 dollars only; name one in spend-budgets.json to fill the rail bars</div>':'')
++'</div>';}}
+h+=(d._t?'<div class=ru-tip-age>updated '+fmtAgo(d._t)+'</div>':'');
+return h;}
 function tipHTML(){var sets=LAST||[];if(!sets.length)return '';
 var many=sets.length>1;
-return sets.map(function(e){return setHTML(e,many);}).join('');}
-function showTip(){var h=tipHTML();
+var h=sets.map(function(e){return setHTML(e,many);}).join('');
+return h?h+'<div class=ru-tip-age>click the bars to refresh</div>':'';}
+// The tip anchors ABOVE the rail, centered on the cursor (the user 2026-08-08: it used to pin to the
+// container's RIGHT edge, nowhere near a hover on the left end of a wide multi-account rail).
+function showTip(ev){var h=tipHTML();
 if(!h){tip.style.display='none';return;}
 tip.classList.remove('ru-modal');tip.innerHTML=h;
 var r=el.getBoundingClientRect();tip.style.display='block';
-tip.style.left=(r.right+9)+'px';tip.style.top=Math.max(6,Math.min(window.innerHeight-tip.offsetHeight-6,r.top-4))+'px';}
+var x=(ev&&typeof ev.clientX==='number')?ev.clientX:(r.left+r.width/2);
+tip.style.left=Math.max(6,Math.min(window.innerWidth-tip.offsetWidth-6,x-tip.offsetWidth/2))+'px';
+tip.style.top=Math.max(6,r.top-tip.offsetHeight-8)+'px';}
 // Mobile usage PANEL (the user 2026-07-11): the same window bars the desktop tooltip shows, opened as a
 // centered modal from the bottom bar's Usage button (the rail — and its hover — don't exist on mobile).
 // Pulls fresh first so the numbers aren't a stale boot snapshot; any tap or Escape dismisses.
@@ -17245,7 +17292,7 @@ el.addEventListener('mouseleave',function(){tip.style.display='none';});
 // rules); a 60s TIMER runs it silently as a BACKUP so the bars stay fresh even when the timeline iframe isn't
 // forwarding usage (idle, or the Timeline pane toggled off) — the gap that made them look stale until a click.
 // The listener sits on the STABLE #rail-usage container, so render()'s innerHTML swap can't drop it.
-el.style.cursor='pointer';el.title='Click to refresh usage';
+el.style.cursor='pointer';   // no native title (the user 2026-08-08) — the tip's footer carries the click hint
 var _ruBusy=false;
 // /usage/fleet is /usage plus one row per OTHER Claude account in the fleet (the remote readings come from
 // the tunnel supervisor's own cached poll, so this never dials anything). It collapses to a single row \u2014

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13690,11 +13690,18 @@ def _usage():
         if stamped and stamped != _claude_account():
             five = seven = fable = None
     if not five and not seven and not fable:
-        # No windows. An API-KEY account (the auth-flip marker _note_auth_source writes) shows SPEND
-        # where the bars sat (the user 2026-08-04): today's accumulated per-result total_cost_usd,
-        # from spend.json. A window-less file WITHOUT the marker stays None — nothing known, draw
-        # nothing (never a confident zero).
-        if o.get("apiKey"):
+        # No windows. A machine with NO Claude login shows SPEND where the bars sat (the user
+        # 2026-08-04): today's accumulated per-result cost from spend.json. The deciding evidence is
+        # the CREDENTIAL STORE (the login's own lifecycle), not a per-session auth report: one session
+        # using an API key never speaks for the login's windows (the user 2026-08-08 — _note_auth_source
+        # is per-session now and writes no marker; the legacy `apiKey` marker is still honored so a
+        # pre-upgrade file shows spend until the next snapshot heals it). The no-login arm additionally
+        # requires spend.json to EXIST: a keyless machine with no recorded spend has nothing to show —
+        # and the guard is what keeps unstamped fixtures/CI (temp STATE, no credential file, no spend)
+        # reading None instead of coupling to the runner's real login (the deliberate decoupling the
+        # acct-stamp comment above records). A window-less file on a LOGGED-IN machine stays None —
+        # nothing known, draw nothing (never a confident zero).
+        if o.get("apiKey") or (not _claude_account() and (jd.STATE / "spend.json").exists()):
             # The spend WINDOWS mirror the subscription bars (5h / 7d / month) so the two auth modes
             # read identically; _spend_windows always returns all three, zero-filled on a fresh kernel
             # (an empty slot reads as broken — the user 2026-08-04, post-restart).

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1111,6 +1111,15 @@ class SdkSession:
         #   by fast_mode_state on every init, so a refused toggle can't stick past the next connect.
         self.fast_reason = ""   # the init's fast_mode_disabled_reason — non-empty means /fast would refuse
         #   (org-gated / unsupported), so the chat hides the toggle instead of offering a dead control.
+        self.api_key_auth = False   # THIS session's init said it authenticates with an API key — a
+        #   PER-SESSION fact (the user 2026-08-08: one keyed session must not speak for the login's
+        #   windows). Gates this session's get_usage polls + its RateLimitEvent records; set by
+        #   _note_auth_source on every init.
+        self._last_cost_total = 0.0   # the CLI's totalCostUSD is CUMULATIVE per process (verified in
+        #   the bundle: the result event's total_cost_usd sits beside total_duration/lines counters),
+        #   so spend folds the DELTA between results — folding the raw value re-added the whole
+        #   session-so-far cost every turn (the user 2026-08-08, whose spend line was fiction). Reset
+        #   at each connect: a fresh CLI process starts its counter at zero.
         # Pending conversation REWIND (the chat's edit-message branch): the target record uuid +
         # the transcript leaf recorded at request time (the one-shot guard — see rewind_disposition).
         # Seeded from the reg so a kernel death mid-rewind re-applies it iff nothing landed since.
@@ -1439,8 +1448,9 @@ class SdkSession:
         context refresh) and on demand from the kernel's /usage click. Guarded: one in flight."""
         if not self.client or self._usage_refreshing:
             return
-        if self.backend.api_key_auth:
-            return   # API-key auth has no /usage windows and get_usage only times out — nothing to poll
+        if self.api_key_auth:
+            return   # THIS session bills an API key (per-session — see _note_auth_source): it has no
+            #          subscription windows and get_usage only times out — nothing to poll
         self._usage_refreshing = True
         r = None
         try:
@@ -1605,6 +1615,7 @@ class SdkSession:
                 async with ClaudeSDKClient(options=opts) as client:
                     connected = True
                     self.client = client
+                    self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero
                     # The CLI is demonstrably up, so any recorded launch failure is HISTORY — clear it
                     # here, at the proof, rather than on a timer. This is what lifts the usage-limit
                     # hold once the window resets: the next _ensure connects, the error record goes, and
@@ -1798,7 +1809,7 @@ class SdkSession:
             # HOW this CLI authenticates (verified live 2026-08-04: 'ANTHROPIC_API_KEY' on API-key auth;
             # the field is absent on a subscription login). An auth flip is the deciding event for the
             # rail's /usage bars — see _note_auth_source.
-            self.backend._note_auth_source(self.name, d.get("apiKeySource"))
+            self.backend._note_auth_source(self, d.get("apiKeySource"))
             fsid = d.get("session_id")
             if fsid and fsid != self.resume_sid:
                 self.resume_sid = fsid
@@ -1937,8 +1948,15 @@ class SdkSession:
             if m and "claude" in m.lower():
                 self._learn_model(pretty_model(m))
         elif isinstance(msg, ResultMessage):
-            self.backend._record_spend(getattr(msg, "total_cost_usd", None),
-                                       getattr(msg, "usage", None))   # the rail's spend + token readout under API-key auth
+            # total_cost_usd is CUMULATIVE per CLI process (the result event's totalCostUSD counter, beside
+            # total_duration/lines) — fold only THIS turn's delta, or every result re-adds the whole
+            # session-so-far cost and the spend readout compounds into fiction (the user 2026-08-08). A
+            # total below the last seen means a counter we didn't watch reset — fold it whole, never negative.
+            total = getattr(msg, "total_cost_usd", None)
+            if isinstance(total, (int, float)) and total > 0:
+                delta = total - self._last_cost_total if total >= self._last_cost_total else total
+                self._last_cost_total = float(total)
+                self.backend._record_spend(delta, getattr(msg, "usage", None))   # the rail's spend + token readout
             self.retrying = False
             self.retry_count = 0                    # turn over → clear the storm count (a turn that errored out without recovering leaves no "recovered" note)
             self.retry_info = None
@@ -1987,7 +2005,11 @@ class SdkSession:
             # (The 2026-07-01 TEMPORARY cadence instrumentation lived here; its 19h/452-event answer — events
             # arrive ~per-API-call but carry utilization ONLY in the allowed_warning band — is baked into
             # _record_rate_limit's status-aware merge, so the jsonl capture is gone.)
-            self.backend._record_rate_limit(msg.rate_limit_info)
+            # PER-SESSION auth gate (the user 2026-08-08): an API-keyed session's events describe the KEY's
+            # limits, not the login's subscription windows — writing them into usage.json contaminated the
+            # login's bars with another allowance's numbers.
+            if not self.api_key_auth:
+                self.backend._record_rate_limit(msg.rate_limit_info)
         # Forward the raw message to the kernel for live chat/event use.
         self.backend._forward(self, msg)
 
@@ -2403,7 +2425,6 @@ class SdkBackend:
         self._pending_ask: dict[str, bool] = {}   # sid -> has an ask awaiting answer
         self._live: dict[str, dict] = {}          # sid -> {key -> atom}: the in-memory LIVE TAIL (ahead of disk)
         self._rl_lock = threading.Lock()          # serializes usage.json read-merge-write (_record_rate_limit)
-        self.api_key_auth = False                 # last init's apiKeySource, truthy = API-key auth (no /usage windows)
         # Backend PROBLEMS, kept in a bounded ring so the dashboard can show them (see _log): until
         # 2026-07-28 every SDK failure went to the kernel log alone, which nobody tails, so a session
         # whose stream died or whose model switch was refused just looked odd with no way to find out.
@@ -2662,10 +2683,11 @@ class SdkBackend:
         Every candidate is tried until one accepts, not just the first (the user 2026-08-02): one session
         whose loop has gone away is enough to make a click do nothing at all, and the rail then shows a
         stale reading with no sign that the refresh never happened. Says so in the log when none can be
-        asked, rather than returning quietly."""
+        asked, rather than returning quietly. API-keyed sessions are not candidates (per-session auth,
+        the user 2026-08-08): their get_usage only times out, and the windows belong to the login."""
         with self._lock:
             sessions = list(self.sessions.values())
-        live = [s for s in sessions if s.client and s.loop and not s.ended]
+        live = [s for s in sessions if s.client and s.loop and not s.ended and not s.api_key_auth]
         for s in live:
             if s.refresh_usage():
                 return
@@ -2718,38 +2740,30 @@ class SdkBackend:
             except Exception as ex:
                 self._log("spend record failed: %s" % ex)
 
-    def _note_auth_source(self, name, source) -> None:
-        """An init message named HOW its CLI authenticates. API-key auth (apiKeySource e.g.
-        'ANTHROPIC_API_KEY') has NO subscription windows, and get_usage just TIMES OUT there — no
-        snapshot ever arrives to correct usage.json, so after logging out the rail bars showed the
-        last subscription reading forever, frozen (the user 2026-08-04). The auth flip is the deciding
-        event: flipping TO an API key drops the stale windows (bars disappear, _usage() returns None on
-        a window-less file) and gates the pointless get_usage polls off; flipping BACK resumes them,
-        and the next real snapshot repaints. Logged raw each flip, so every host's kernel log
-        self-documents its auth mode.
+    def _note_auth_source(self, sess, source) -> None:
+        """An init message named HOW its CLI authenticates — a PER-SESSION fact, not a backend one (the
+        user 2026-08-08): with a real ANTHROPIC_API_KEY in the service env, only the sessions whose
+        project had approved the key used it, while every other session rode the subscription login —
+        yet the old backend-global flag let whichever init arrived LAST speak for all of them, wiping
+        the login's usage windows and re-wiping them on every keyed session's reconnect. The flag now
+        lives on the session: it gates that session's own get_usage polls (which only time out on
+        API-key auth) and its RateLimitEvents (which describe the KEY's limits, not the login's
+        windows) — see _do_refresh_usage, refresh_usage, and the _on_message rate-limit branch. The
+        subscription windows belong to the LOGIN, whose lifecycle the kernel already tracks read-side:
+        the acct stamp drops bars when the login changes, and a machine with NO login shows spend
+        (kernel _usage() keys that on the credential store now, not on a wipe marker written here).
 
         A subscription login answers with the ABSENCE of an API key, and the CLI has said that two
         ways: the field simply absent (verified live 2026-08-04), and — since about CLI 2.1.222 — the
-        literal string 'none' (two hosts' journals, 2026-08-08). A plain bool() read 'none' as truthy,
-        so every subscription machine was misclassified as API-key auth on every session init: windows
-        wiped, polls gated off, and the rail stuck on a lone event-derived bar that nothing could ever
-        heal — the /usage click included, because the gate returns before the request."""
-        was = self.api_key_auth
-        self.api_key_auth = bool(source) and str(source).strip().lower() != "none"
-        if self.api_key_auth == was:
+        literal string 'none' (two hosts' journals, 2026-08-08). Logged once per per-session change,
+        so every host's kernel log still self-documents who authenticates how."""
+        keyed = bool(source) and str(source).strip().lower() != "none"
+        if keyed == sess.api_key_auth:
             return
-        self._log("auth (%s): apiKeySource=%r — %s" % (name, source,
-                  "API-key auth: dropping stale /usage windows; usage polls off" if self.api_key_auth
-                  else "subscription auth: usage polls resume"))
-        if not self.api_key_auth:
-            return                                # bars repaint from the next real snapshot on their own
-        with self._rl_lock:
-            try:
-                tmp = self.state_dir / "usage.json.tmp"
-                tmp.write_text(json.dumps({"t": int(time.time()), "apiKey": True}))
-                os.replace(tmp, self.state_dir / "usage.json")
-            except Exception as e:
-                self._log("auth (%s): could not drop stale usage windows: %s" % (name, e))
+        sess.api_key_auth = keyed
+        self._log("auth (%s): apiKeySource=%r — %s" % (sess.name, source,
+                  "this session bills an API key: its usage polls and rate-limit events are ignored"
+                  if keyed else "subscription auth: this session's usage polls resume"))
 
     def _record_usage_snapshot(self, r) -> None:
         """Fold a get_usage control-request snapshot into usage.json — EXACT utilization for every window,

--- a/tests/test_kernel_usage_refresh.py
+++ b/tests/test_kernel_usage_refresh.py
@@ -63,10 +63,12 @@ class UsageRefreshWiring(unittest.TestCase):
 
     def test_rail_usage_widget_is_click_to_refresh(self):
         html = km._landing()
-        # the widget is a clickable, discoverable affordance
+        # the widget is a clickable, discoverable affordance — the click hint lives in the rich tip's
+        # footer, never a native title (the user 2026-08-08: the browser's flat box fought the tip)
         self.assertIn("id=rail-usage", html)
         self.assertIn("el.style.cursor='pointer'", html)
-        self.assertIn("Click to refresh usage", html)
+        self.assertIn("click the bars to refresh", html)
+        self.assertNotIn("Click to refresh usage", html)
         # a click fetches the on-demand endpoint and re-renders through the normal render() path.
         # (2026-07-30: /usage/fleet — /usage plus one row per OTHER Claude account signed in across the
         # fleet. It collapses to the single local row whenever every machine is on the same login.)

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1439,12 +1439,13 @@ class StopTask(unittest.TestCase):
 
 
 class ApiKeyAuthUsage(unittest.TestCase):
-    """Logging out to an API key froze the rail's /usage bars on the last subscription reading (the
-    user 2026-08-04): API-key auth has no subscription windows and get_usage only TIMES OUT there, so
-    no snapshot ever arrived to correct usage.json. The init message's apiKeySource (verified live:
-    'ANTHROPIC_API_KEY' on API-key auth, absent on a subscription login) is the deciding event —
-    flipping TO an API key drops the stale windows and gates the pointless polls off; flipping back
-    lets the next real snapshot repaint."""
+    """API-key auth is a PER-SESSION fact (the user 2026-08-08): with a real key in the service env,
+    only the sessions whose project approved it used it, while every other session rode the
+    subscription login — yet the old backend-global flag let whichever init arrived LAST speak for all
+    of them, wiping the login's windows and re-wiping on every keyed session's reconnect. The flag now
+    lives on the session: it gates that session's own get_usage polls and its RateLimitEvent records,
+    and NOTHING wipes usage.json — the login's lifecycle is tracked read-side (the acct stamp, plus
+    kernel _usage()'s no-login spend arm)."""
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
@@ -1453,51 +1454,64 @@ class ApiKeyAuthUsage(unittest.TestCase):
         self.p.write_text(json.dumps({"t": 1785898746,
                                       "five_hour": {"pct": 46, "resets_at": 1785907200},
                                       "seven_day": {"pct": 21, "resets_at": 1786388400}}))
+        self.s = sb.SdkSession(self.be, {"sid": "11111111-2222-3333-4444-000000000001",
+                                         "name": "n", "cwd": "/tmp"})
 
-    def test_flipping_to_api_key_drops_the_stale_windows(self):
-        self.be._note_auth_source("n", "ANTHROPIC_API_KEY")
-        self.assertTrue(self.be.api_key_auth)
-        d = json.loads(self.p.read_text())
-        self.assertTrue(d.get("apiKey"))
-        for k in ("five_hour", "seven_day", "fable"):
-            self.assertNotIn(k, d, "stale subscription windows are gone → _usage() returns None → no bars")
-
-    def test_subscription_auth_leaves_the_file_alone(self):
+    def test_a_keyed_init_marks_only_its_own_session_and_never_wipes(self):
         before = self.p.read_text()
-        self.be._note_auth_source("n", None)
-        self.assertFalse(self.be.api_key_auth)
-        self.assertEqual(self.p.read_text(), before, "no flip, no write")
+        self.be._note_auth_source(self.s, "ANTHROPIC_API_KEY")
+        self.assertTrue(self.s.api_key_auth)
+        self.assertEqual(self.p.read_text(), before,
+                         "one keyed session never speaks for the login's windows — no wipe, ever")
+        other = sb.SdkSession(self.be, {"sid": "11111111-2222-3333-4444-000000000002",
+                                        "name": "m", "cwd": "/tmp"})
+        self.assertFalse(other.api_key_auth, "the flag is the session's, not the backend's")
 
     def test_the_string_none_is_a_subscription_login_not_an_api_key(self):
         """The CLI has said "no API key" two ways: the field absent (verified 2026-08-04) and — since
-        about CLI 2.1.222 — the literal string 'none' (both hosts' journals, 2026-08-08). bool('none')
-        is True, so the old check misread every subscription init as an API-key flip: it wiped the
-        usage windows and gated the polls off, leaving the rail a lone event-derived five-hour bar at
-        0% that no /usage click could ever heal (the gate returns before the request)."""
-        before = self.p.read_text()
-        self.be._note_auth_source("n", "none")
-        self.assertFalse(self.be.api_key_auth, "'none' means NO api key — a subscription login")
-        self.assertEqual(self.p.read_text(), before, "no wipe: the windows on file stay")
-        # and it flips an API-key backend BACK, exactly like the absent field
-        self.be._note_auth_source("n", "ANTHROPIC_API_KEY")
-        self.assertTrue(self.be.api_key_auth)
-        self.be._note_auth_source("n", "none")
-        self.assertFalse(self.be.api_key_auth, "'none' resumes usage polls after an API-key stretch")
+        about CLI 2.1.222 — the literal string 'none' (both hosts' journals, 2026-08-08)."""
+        self.be._note_auth_source(self.s, "none")
+        self.assertFalse(self.s.api_key_auth, "'none' means NO api key — a subscription login")
+        self.be._note_auth_source(self.s, "ANTHROPIC_API_KEY")
+        self.assertTrue(self.s.api_key_auth)
+        self.be._note_auth_source(self.s, "none")
+        self.assertFalse(self.s.api_key_auth, "'none' flips a keyed session back, like the absent field")
 
-    def test_flipping_back_keeps_the_file_for_the_next_snapshot(self):
-        self.be._note_auth_source("n", "ANTHROPIC_API_KEY")
-        dropped = self.p.read_text()
-        self.be._note_auth_source("n", None)
-        self.assertFalse(self.be.api_key_auth)
-        self.assertEqual(self.p.read_text(), dropped, "bars repaint from the next REAL snapshot, not a guess")
+    def test_a_keyed_sessions_rate_limit_events_never_reach_the_login_windows(self):
+        # the key's limits are ANOTHER allowance — recording them contaminated the login's bars
+        calls = []
+        self.be._record_rate_limit = lambda info: calls.append(info)
+        class _RL:
+            rate_limit_info = {"kind": "five_hour"}
+        self.be._forward = lambda sess, msg: None
+        self.s.api_key_auth = True
+        self.s._on_message(_RL(), _AssistantMessage, _ResultMessage, type("S", (), {}))
+        self.assertEqual(calls, [], "a keyed session's events are ignored")
+        self.s.api_key_auth = False
+        self.s._on_message(_RL(), _AssistantMessage, _ResultMessage, type("S", (), {}))
+        self.assertEqual(len(calls), 1, "a subscription session's events record as ever")
 
-    def test_init_reads_the_field_and_the_poll_is_gated(self):
+    def test_refresh_skips_keyed_sessions_and_polls_a_subscription_one(self):
+        keyed = self.s
+        keyed.api_key_auth = True
+        keyed.client, keyed.loop, keyed.ended = object(), object(), False
+        sub = sb.SdkSession(self.be, {"sid": "11111111-2222-3333-4444-000000000003",
+                                      "name": "m", "cwd": "/tmp"})
+        sub.client, sub.loop, sub.ended = object(), object(), False
+        polled = []
+        keyed.refresh_usage = lambda: polled.append("keyed") or True
+        sub.refresh_usage = lambda: polled.append("sub") or True
+        self.be.sessions = {keyed.sid: keyed, sub.sid: sub}
+        self.be.refresh_usage()
+        self.assertEqual(polled, ["sub"], "the click heals off the login's session, never the keyed one")
+
+    def test_init_reads_the_field_and_the_poll_is_gated_per_session(self):
         src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
                                 "kernel", "sdk_backend.py")).read()
-        self.assertIn('self.backend._note_auth_source(self.name, d.get("apiKeySource"))', src,
-                      "the init message is the one in-band auth signal")
-        self.assertIn("if self.backend.api_key_auth:", src.split("async def _do_refresh_usage", 1)[1][:1600],
-                      "get_usage is never polled on API-key auth — it only times out there")
+        self.assertIn('self.backend._note_auth_source(self, d.get("apiKeySource"))', src,
+                      "the init message is the one in-band auth signal, handed the SESSION")
+        self.assertIn("if self.api_key_auth:", src.split("async def _do_refresh_usage", 1)[1][:1600],
+                      "get_usage is gated on the SESSION's own auth — it only times out on a keyed one")
 
 
 class SpendRecord(unittest.TestCase):
@@ -1547,14 +1561,49 @@ class SpendRecord(unittest.TestCase):
     def test_result_message_records_and_the_kernel_serves_it(self):
         src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
                                 "kernel", "sdk_backend.py")).read()
-        self.assertIn('self.backend._record_spend(getattr(msg, "total_cost_usd", None),', src,
-                      "every ResultMessage's cost is folded in at the settle")
-        self.assertIn('getattr(msg, "usage", None))', src, "…with its token counts")
+        self.assertIn('self.backend._record_spend(delta, getattr(msg, "usage", None))', src,
+                      "the settle folds THIS turn's DELTA — total_cost_usd is cumulative per process")
+        self.assertIn("self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero",
+                      src, "each connect resets the watermark with its new process")
         with open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin", "romp-kernel")) as f:
             ksrc = f.read()
-        self.assertIn('if o.get("apiKey"):', ksrc, "_usage serves the spend payload on the auth-flip marker")
+        self.assertIn('if o.get("apiKey") or (not _claude_account() and (jd.STATE / "spend.json").exists()):',
+                      ksrc, "_usage serves spend on the legacy marker OR a login-less machine with recorded spend")
         self.assertIn('"spend": _spend_windows()', ksrc)
         self.assertIn("def _spend_windows():", ksrc)
+
+    def test_cumulative_process_totals_fold_as_per_turn_deltas(self):
+        """The CLI's total_cost_usd is CUMULATIVE per process (the result event's totalCostUSD counter):
+        folding the raw value re-added the whole session-so-far cost on every turn, compounding the
+        spend readout into fiction — one live hour bucket showed a single 'turn' worth the session's
+        entire total (the user 2026-08-08, who did not believe the bottom line). Fold deltas; reset the
+        watermark with each new CLI process; treat a shrunken total as a reset we missed."""
+        import asyncio
+        sid = "11111111-2222-3333-4444-bbbbbbbbbbbb"
+        s = sb.SdkSession(self.be, {"sid": sid, "name": "n", "cwd": "/tmp"})
+        self.be._forward = lambda sess, msg: None
+        self.be._turn_completed = lambda sid: None
+        async def _noop(): pass
+        s._do_refresh_context = _noop
+        s._do_refresh_usage = _noop
+        def _result(total):
+            r = _ResultMessage()
+            r.total_cost_usd = total
+            r.usage = {"input_tokens": 10}
+            return r
+        async def run(total):
+            s._on_message(_result(total), _AssistantMessage, _ResultMessage, type("S", (), {}))
+            await asyncio.sleep(0)
+        asyncio.run(run(1.0))     # first turn of the process: delta = the whole total
+        asyncio.run(run(2.5))     # second turn: delta = 1.5, NOT another 2.5
+        d = json.loads(self.p.read_text())["days"][self._today()]
+        self.assertAlmostEqual(d["usd"], 2.5, msg="two turns fold to the process total, never more")
+        self.assertEqual(d["turns"], 2)
+        s._last_cost_total = 0.0  # the connect reset: a fresh CLI process starts at zero
+        asyncio.run(run(0.8))
+        self.assertAlmostEqual(json.loads(self.p.read_text())["days"][self._today()]["usd"], 3.3)
+        asyncio.run(run(0.5))     # a total BELOW the watermark = a reset we missed → fold it whole
+        self.assertAlmostEqual(json.loads(self.p.read_text())["days"][self._today()]["usd"], 3.8)
 
 
 class RewindFiles(unittest.TestCase):

--- a/tests/test_sdk_rate_limit_usage.py
+++ b/tests/test_sdk_rate_limit_usage.py
@@ -158,6 +158,7 @@ class ExactSnapshotRefresh(unittest.TestCase):
         self.td.cleanup()
 
     def _session(self, scheduled, **kw):
+        kw.setdefault("api_key_auth", False)   # per-session auth (2026-08-08): a keyed one is no candidate
         s = SimpleNamespace(client=object(), loop=object(), ended=False, **kw)
         s.refresh_usage = lambda: scheduled
         return s

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -18,17 +18,24 @@ const STRIPCSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.css"), 
 const BACKEND = fs.readFileSync(path.join(ROOT, "kernel", "sdk_backend.py"), "utf8");
 
 test("the kernel serves spend WINDOWS on the auth-flip marker, zero-filled when fresh", () => {
-  assert.ok(KERNEL.includes('if o.get("apiKey"):'), "gated on the #208 auth-flip marker");
+  // the spend view arms on the legacy apiKey marker OR a login-less machine with recorded spend
+  // (per-session auth writes no marker any more — the user 2026-08-08)
+  assert.ok(KERNEL.includes('if o.get("apiKey") or (not _claude_account() and (jd.STATE / "spend.json").exists()):'));
   assert.ok(KERNEL.includes('"spend": _spend_windows()'));
   assert.ok(KERNEL.includes("def _spend_windows():"));
   assert.ok(KERNEL.includes("def _spend_budgets():"), "budgets give a window its fill denominator");
   // rolling 5h/7d read the HOUR buckets; month-to-date reads the day ledger
   assert.match(KERNEL, /"fiveHour": _rolling\(5\), "sevenDay": _rolling\(7 \* 24\)/);
   assert.ok(KERNEL.includes('k.startswith(month)'));
-  // a window-less file WITHOUT the marker stays None — nothing known, draw nothing
-  assert.match(KERNEL, /if o\.get\("apiKey"\):[\s\S]{0,800}?return None/);
-  // the accumulator: every result's cost + tokens, folded into BOTH bucket sets
-  assert.ok(BACKEND.includes('self.backend._record_spend(getattr(msg, "total_cost_usd", None),'));
+  // a window-less file on a logged-in machine stays None — nothing known, draw nothing
+  assert.match(KERNEL, /if o\.get\("apiKey"\) or [\s\S]{0,900}?return None/);
+  // the subscription payload carries the spend windows BESIDE the bars — the hover's token graph
+  // needs them for every account, not just spend-only ones (the user 2026-08-08)
+  assert.match(KERNEL, /"fiveHour": five, "sevenDay": seven, "fable": fable,[\s\S]{0,600}?"spend": _spend_windows\(\),/);
+  // the accumulator: total_cost_usd is CUMULATIVE per CLI process — fold the per-turn DELTA, and a
+  // shrunken total (an unwatched reset) folds whole, never negative (the user 2026-08-08)
+  assert.ok(BACKEND.includes("delta = total - self._last_cost_total if total >= self._last_cost_total else total"));
+  assert.ok(BACKEND.includes('self.backend._record_spend(delta, getattr(msg, "usage", None))'));
   assert.ok(BACKEND.includes("_fold(days, day, 90)"));
   assert.ok(BACKEND.includes("_fold(hours, hour, 192)"), "8 days of hour buckets feed the rolling windows");
 });
@@ -54,13 +61,42 @@ test("VS Code strip: ONE row builder for both auth modes — spend rows ride the
 });
 
 test("the web landing copy carries the SAME builder — the two rails stay in step", () => {
-  assert.ok(KERNEL.includes("function spendWinsHTML(u)"));
+  assert.ok(KERNEL.includes("function spendWinsHTML(u,det)"));
   assert.ok(KERNEL.includes("var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','Month']];"));
   assert.ok(KERNEL.includes("function hasSpend(u){return !!(u&&u.apiKey&&u.spend&&u.spend.fiveHour);}"));
   // same row markup as winsHTML: ru-w → ru-name → ru-bars (tracks) → ru-pct readout
   assert.ok(KERNEL.includes("+'<div class=ru-name>'+w[1]+'</div>'"));
   assert.ok(KERNEL.includes("(pct!=null?'<div class=ru-track><i class=ru-fill style=\"width:'+pct+'%;background:'+spendColor(pct)+'\"></i></div>':'')"));
-  // both the single- and multi-account paths fall to the window rows
-  assert.ok(KERNEL.includes("el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendWinsHTML(live[0].usage);return;}"));
-  assert.ok(KERNEL.includes("(hasBars(r.usage)?winsHTML(r.usage,det):spendWinsHTML(r.usage))"));
+  // both the single- and multi-account paths fall to the window rows, and BOTH fill the hover detail
+  // (spendDet) so a bars account still gets the token graph
+  assert.ok(KERNEL.includes("if(hasBars(live[0].usage)){el.innerHTML=winsHTML(live[0].usage,det);spendDet(live[0].usage,det);}"));
+  assert.ok(KERNEL.includes("else el.innerHTML=spendWinsHTML(live[0].usage,det);"));
+  assert.ok(KERNEL.includes("if(hasBars(r.usage)){inner=winsHTML(r.usage,det);spendDet(r.usage,det);}"));
+  assert.ok(KERNEL.includes("else inner=spendWinsHTML(r.usage,det);"));
+});
+
+test("the rich tip is the ONE hover surface: no native titles, every account renders, cursor-anchored", () => {
+  // NO native title attributes anywhere on the rail (the user 2026-08-08, who got the browser's flat
+  // yellow box on top of the rich hover): the usage JS may mention titles only in comments
+  const usageJS = KERNEL.split("_LANDING_USAGE_JS = \"\"\"")[1].split('"""')[0];
+  for (const line of usageJS.split("\n")) {
+    const code = line.split("//")[0];
+    assert.ok(!/\btitle\s*=/.test(code) && !code.includes(".title="), `native title in usage JS: ${line.trim()}`);
+  }
+  // a SPEND-ONLY account used to return '' from setHTML, so a mixed hover showed only the
+  // subscription login (the user 2026-08-08) — now it renders its own section
+  assert.ok(usageJS.includes("if(!keys.length&&!sp)return '';"));
+  assert.ok(usageJS.includes("var spendOnly=!keys.length;"));
+  // the token graph: the three spend windows' volume on ONE shared auto-scale, in the tip's track idiom
+  assert.ok(usageJS.includes("function spendDet(u,det)"));
+  assert.ok(usageJS.includes("5h / 7d / month \\u00b7 one scale"));
+  assert.ok(usageJS.includes("var mx=1;ks.forEach(function(k){if(sp[k].tok>mx)mx=sp[k].tok;});"));
+  // dollars ride the value column only where they are REAL billing (spend-only accounts)
+  assert.ok(usageJS.includes("+fmtTok(v.tok)+(spendOnly?' \\u00b7 $'"));
+  // the tip anchors ABOVE the rail, centered on the CURSOR — never pinned to the container edge
+  assert.ok(usageJS.includes("var x=(ev&&typeof ev.clientX==='number')?ev.clientX:(r.left+r.width/2);"));
+  assert.ok(usageJS.includes("x-tip.offsetWidth/2"));
+  assert.ok(usageJS.includes("r.top-tip.offsetHeight-8"));
+  // the click hint the native title used to carry lives in the tip's footer now
+  assert.ok(usageJS.includes("'<div class=ru-tip-age>click the bars to refresh</div>'"));
 });


### PR DESCRIPTION
Two commits, one usage-widget arc (the user 2026-08-08):

**Commit 1 — API-key auth is a per-session fact, and spend folds per-turn deltas.**
`_note_auth_source` marked the whole backend keyed when ANY session initialized
with an API key, wiping usage.json — so two keyed sessions (real `ANTHROPIC_API_KEY`
from service.env) kept erasing the subscription login's bars. Auth is now a
per-session flag: a keyed session skips usage polling and its rate-limit events
never touch the login's windows, while subscription sessions keep the bars live.
And `total_cost_usd` on ResultMessages is CUMULATIVE per CLI process — folding
it whole every turn compounded the spend readout into fiction ($158/5h). The
backend now folds only the per-turn delta, treating a shrunken total as a
counter reset (fold whole, never negative).

**Commit 2 — the rail hover is the one usage surface.**
- No native `title` attributes on the rail: the rich tip is the only hover, and
  the click hint moves into its footer.
- The tip anchors above the rail, centered on the cursor (it used to pin to the
  container's right edge).
- Spend-only accounts render their own section in the hover instead of being
  silently dropped (a mixed hover showed only the subscription login).
- New token graph in the tip: the 5h / 7d / month windows' token volume on one
  shared auto-scale, same track idiom as the % bars. The kernel attaches spend
  windows beside the subscription bars so every account carries the data;
  dollars show only where they are real billing (spend-only accounts).

Tests: per-session auth + delta-folding units in test_sdk_backend.py; fixture
updates in test_sdk_rate_limit_usage.py; rail-spend.test.ts pins the new
literals plus a no-native-title sweep; test_kernel_usage_refresh.py pins the
footer hint. Full suites green (3947 py, 1700 node, typecheck clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)