### PR TITLE
The unblocker sees completions: superseded blocked cards lift instead of rotting

### DIFF
--- a/docs/judge-pipeline.md
+++ b/docs/judge-pipeline.md
@@ -94,7 +94,7 @@ The board judges, with what each one reads and the ops it may emit:
 | planner | a segment's work ends | the work + the tree | `mint`, `sub`, `done`, `block`, `retitle`, `skip` |
 | placer | the planner filed under a card that has open sub-goals | that card's subtree only | pick the level inside the card |
 | closer | the turn ends | the goals this turn touched | `done`, `block`, omit (when in doubt, omit) |
-| unblocker | an open blocked sub has ended turns newer than its block (or its last check) | the sub's question + the conversation since | `lift`, `hold` (when unsure, hold) |
+| unblocker | an open blocked goal has ended turns or done filings newer than its block (or its last check of each) | the goal's question + the conversation since + the goals completed since | `lift`, `hold` (when unsure, hold) |
 | courier | a peer message arrives | the message + both sessions' trees | plant a goal + tracking node, or nothing |
 | grouper | the set of open cards changed | open top cards | nest a card, mint an umbrella, nothing |
 | consolidator | the set of completed cards changed | completed top cards | the same ops, done column |

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -37,7 +37,7 @@ so idle sessions cost file stats, not model calls.
 | planner | triage | `PLAN_SYS` | a segment's work ends |
 | placer | triage | `PLACE_SYS` | the planner filed under a card with open sub-goals |
 | closer | triage | `CLOSER_SYS` | a turn ends |
-| unblocker | triage | `UNBLOCK_SYS` | an open blocked sub has ended turns newer than its block (or its last check) |
+| unblocker | triage | `UNBLOCK_SYS` | an open blocked goal has ended turns or done filings newer than its block (or its last check of each) |
 | distiller | triage | `DISTILL_SYS` | a card completed and settled |
 | briefer | triage | `BLOCK_BRIEF_SYS` | a card blocked |
 | grouper | triage | `GROUP_SYS` | the set of open cards changed |
@@ -64,8 +64,9 @@ needs picking. When the turn ends, the closer audits the goals the turn
 touched for quiet completions and the archiver refreshes the session's
 headline. From there the board keeps itself: a completed card settles and
 gets the distiller's takeaway, a blocked card gets the briefer's decision
-brief, a blocked sub with new conversation since its block gets the
-unblocker's re-examination (was its question answered in passing?), a
+brief, a blocked goal with new conversation or new completions since its
+block gets the unblocker's re-examination (was its question answered in
+passing, or overtaken by finished work?), a
 changed set of top cards may get nested by the grouper (open column) or
 the consolidator (done column), and a peer message goes to the courier
 instead of the planners. Every section below is one of those moments in
@@ -148,22 +149,32 @@ stay distinguishable, and both defer to the user floor: a verdict computed
 from evidence at or before your last reply loses.
 
 **unblocker.** The stale-block backstop; it exists because answers arrive
-in passing. A sub-goal blocked on a question is only ever unblocked by
-work filed on that exact node — but the answer usually files wherever the
-planner judges the segment to serve, so a dormant blocked sub never hears
-it and holds its whole card in Needs you (a card can otherwise sit for hours
-on a buried sub whose question the very next stretch of conversation already
-answered). Given each open blocked sub's question plus
-the conversation since its block, it verdicts lift or hold, "when unsure,
-hold"; a lift lands as a normal `unblock` diary event, why-prefixed
-"answered in passing". Subs only — a blocked top is the card's Needs you,
-with its own heal paths (your reply re-judges it; a placement under it
-unblocks the chain). Event-gated per node: `blockCheckT` remembers the
-newest ended turn examined, so a stable session costs zero calls and a
-give-up re-arms on the next new turn. Its model call spans seconds, so it
-holds no store copy across the call: verdicts apply to a fresh load, and a
-node that moved on mid-call (you resolved or cleared it) is skipped with a
-`drift-skip` error row rather than overwritten. `ROMP_UNBLOCKER=0`
+in passing and work overtakes asks. A goal blocked on a question is only
+ever unblocked by work filed on that exact node — but the answer usually
+files wherever the planner judges the segment to serve, so a dormant
+blocked goal never hears it and holds its card in Needs you (a card can
+otherwise sit for hours on a buried sub whose question the very next
+stretch of conversation already answered — or on an approval whose work
+the session then visibly did anyway). Given each open blocked goal's
+question (subs and tops both) plus two evidence sections — the
+conversation since its block, and the goals the session has completed
+since then with why each counts as done — it verdicts lift or hold, "when
+unsure, hold"; a lift lands as a normal `unblock` diary event,
+why-prefixed "answered in passing". The completed-since section is the
+durable half: the conversation tail scrolls past its 9k-char window and a
+hold is never re-examined against the same turns, so an ask superseded by
+later completions used to rot in Needs you until cleared by hand (the
+2026-08-08 study: 400 card-hours across 302 manual clears). Event-gated
+per node on both streams: `blockCheckT` remembers the newest ended turn
+examined (turn-time domain — the feed's re-judging latch reads it against
+reply times, so it never carries a filing time), and `blockCheckDoneT`
+remembers the newest done-verdict filing, so a completion arms a
+re-examination even when no new turn ever arrives (a late closer filing
+on an idle session), a stable session costs zero calls, and a give-up
+re-arms on the next new turn or filing. Its model call spans seconds, so
+it holds no store copy across the call: verdicts apply to a fresh load,
+and a node that moved on mid-call (you resolved or cleared it) is skipped
+with a `drift-skip` error row rather than overwritten. `ROMP_UNBLOCKER=0`
 disables.
 
 **distiller.** When a top card completes and settles: `BACKGROUND:`

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -7047,9 +7047,18 @@ def run_close(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, ver
 # walks its chain) — but an answer given in passing files under whichever node the planner judges the
 # segment to serve, so a dormant blocked goal never hears it (a buried sub, or a TOP whose answer came
 # on a sibling card's thread — g48, 2026-07-16). This pass closes that gap: for each open blocked goal
-# with NEW conversation since its block (event-gated), ask whether the conversation answered its
-# question or made it moot, and lift via the same record_verdict("unblock") every other lift uses.
+# with NEW evidence since its block (event-gated), ask whether the record answered its question or
+# made it moot, and lift via the same record_verdict("unblock") every other lift uses.
+# The evidence is TWO-CHANNEL (the user 2026-08-08, the superseded-cards study): the conversation
+# tail scrolls past in UNBLOCK_HISTORY_CHARS and the blockCheckT ratchet never re-presents what one
+# conservative hold let by, so an ask overtaken by later work sat in Needs-you until the user cleaned
+# it up by hand (400 card-hours across 302 manual clears; one audited session held four overtaken
+# asks through ~10h of examines while dozens of sibling cards completed). The session's DONE verdicts
+# are the durable half: they name what was finished and why, they never scroll away, and a new
+# filing is itself an arming event — so a completion can lift a stale ask even when it arrives with
+# no new turn at all (a late closer filing on an idle session).
 UNBLOCK_HISTORY_CHARS = 9000             # the after-conversation tail shown to the unblocker (newest kept)
+UNBLOCK_COMPLETED_CHARS = 4000           # the completed-since section shown to the unblocker (newest kept)
 
 UNBLOCK_SYS = (
     "You review goals a work session earlier marked blocked, each waiting on an answer or decision "
@@ -7057,10 +7066,20 @@ UNBLOCK_SYS = (
     "chat partner: don't act on anything, answer anything, or ask anything.\n\n"
     "Each numbered block in <blocked-goals> is one goal's open question, numbered from 1 (there is no "
     "block 0). <conversation-since> is what "
-    "the session and the user said and did afterwards. Decide for each block whether it is still "
+    "the session and the user said and did afterwards. <completed-since> lists the goals this session "
+    "has finished since the block, with why each counts as done; finished work there can show a "
+    "blocked goal's question was overtaken even when the conversation has moved on. Decide for each "
+    "block whether it is still "
     "genuinely waiting on the user, or whether the conversation has since answered its question or made "
     "it moot (the answer was given in passing, the decision got made another way, or the work visibly "
-    "moved past it). Reply with only a JSON object (no prose, no markdown fences):\n"
+    "moved past it). A goal the session has visibly moved past is moot even though nobody typed an "
+    "answer: an offer or approval whose work was then done anyway (or a newer variant of it shipped), "
+    "or a decision that later work made irrelevant. A blocked goal whose open question is restated by "
+    "a newer blocked goal in the same list is superseded: lift the older, keep the newest. Progress on "
+    "other goals does **not** by itself make an ask moot; if the thing it asks for is still missing "
+    "and still needed, hold. Another goal's completion note or an upbeat wrap-up is not the answer to "
+    "this ask: lift only when the specific thing this goal is waiting on was itself given, done, or "
+    "made irrelevant. Reply with only a JSON object (no prose, no markdown fences):\n"
     '{"verdicts": [{"n": <block number>, "do": "lift" | "hold", "why": "..."}]}\n'
     "- \"lift\": answered or moot. why = where the answer came from, one short plain sentence.\n"
     "- \"hold\": still genuinely waiting on the user. why may be an empty string.\n"
@@ -7068,12 +7087,53 @@ UNBLOCK_SYS = (
     "work proceeding past it; when unsure, hold. Output only the JSON object.")
 
 
-def unblock_llm(blocks_text, since_text):
+def unblock_llm(blocks_text, since_text, completed_text=""):
     """The unblocker's {"verdicts":[...]} reply from the triage-tier model over the numbered open
-    blocked goals + the conversation since the oldest of them. '' on failure (logged by _judge_run)."""
-    user = ("<blocked-goals>\n%s\n</blocked-goals>\n<conversation-since>\n%s\n</conversation-since>"
-            % (blocks_text, since_text))
+    blocked goals + the conversation since the oldest of them + the goals completed since then.
+    '' on failure (logged by _judge_run). Both evidence sections always render (the prompt names
+    them): an examine armed by a done filing alone may carry no new conversation at all."""
+    user = ("<blocked-goals>\n%s\n</blocked-goals>\n<conversation-since>\n%s\n</conversation-since>\n"
+            "<completed-since>\n%s\n</completed-since>"
+            % (blocks_text, since_text.strip() or "(no conversation since the block)",
+               completed_text or "(none)"))
     return _judge_run(_triage_model(), UNBLOCK_SYS, user, judge="unblocker").strip()[:JUDGE_JSON_CAP]
+
+
+def _completed_since(store, oldest_block, exclude):
+    """The goals this session completed since the oldest due block — one '- title: why' line each,
+    oldest first, newest kept under UNBLOCK_COMPLETED_CHARS. This is the DURABLE half of the
+    unblocker's evidence (the replay study, 2026-08-08: an examined-and-held card whose superseding
+    turns had scrolled out of the 9k tail was re-liftable at every later examine once the completions
+    rode along). Synth settle rows are excluded — an episode-boundary settle asserts the conversation
+    ended, not that work was delivered — and so are the due nodes themselves (their own history is
+    not sibling evidence)."""
+    rows = []
+    for nid, nd in store["nodes"].items():
+        if nid in exclude:
+            continue
+        best = None
+        for r in nd.get("log") or []:
+            at = r.get("at") or 0
+            if r.get("kind") == "done" and not r.get("synth") and at > oldest_block \
+                    and (best is None or at > best[0]):
+                best = (at, r.get("why") or nd.get("doneWhy") or "")
+        if best:
+            line = "- %s" % (nd.get("text") or "(goal)")
+            if best[1]:
+                line += ": %s" % str(best[1])[:220]
+            rows.append((best[0], line))
+    rows.sort()
+    return "\n".join(line for _at, line in rows)[-UNBLOCK_COMPLETED_CHARS:]
+
+
+def _newest_done_at(store):
+    """The newest non-synth done verdict FILING time (`at`, arrival domain) in the store — the
+    "something was completed" arming event. Filing time, not ev_t, on purpose: a closer can file a
+    done minutes after its evidence turn ended (or for an already-examined turn), and that filing is
+    the new information a blocked card's supersession check keys on."""
+    return max((r.get("at") or 0 for nd in store["nodes"].values()
+                for r in (nd.get("log") or [])
+                if r.get("kind") == "done" and not r.get("synth")), default=0)
 
 
 def _parse_unblock(raw, n):
@@ -7133,10 +7193,17 @@ def _blocked_sub_candidates(store):
 
 
 def _unblock_session(fsid, path, now):
-    """Re-examine ONE session's stale blocked goals (subs AND tops, 2026-07-16). Event-gated per node: a
-    goal is (re-)examined only when an ENDED turn newer than max(its block, its last check) exists —
-    blockCheckT is the watermark, advanced after every examine (and on the parse give-up) so a stable
-    session costs zero calls. Returns the node ids lifted.
+    """Re-examine ONE session's stale blocked goals (subs AND tops, 2026-07-16). Event-gated per node
+    on TWO event streams, each with its own watermark advanced after every examine (and on the parse
+    give-up) so a stable session costs zero calls. Returns the node ids lifted.
+      - a new ENDED turn — blockCheckT, TURN-time domain. The rejudging latch reads this watermark
+        against reply times (kernel _block_check_floor, PR #144), so it must never carry a filing
+        time: a wall-clock stamp sorts after every turn and would release the latch before any judge
+        saw the reply it latched on.
+      - a new DONE verdict FILED in this session — blockCheckDoneT, arrival-time domain (the user
+        2026-08-08): a completion is the event that can supersede a blocked ask, and it can arrive
+        with no new turn at all (a late closer filing on an idle session). Verdicts file once, so
+        the gate re-arms only on genuinely new filings — no flapping.
 
     Write discipline (the user 2026-07-11): the model call takes seconds and save_goals is a
     last-writer-wins atomic publish, so NO store copy is held across the call — the scan's load is
@@ -7147,27 +7214,31 @@ def _unblock_session(fsid, path, now):
     every fast judge write has; a user action clobbered inside even that window self-heals via the
     override journal replay on the next pass."""
     _judge_ctx.fsid = fsid                            # usage logging: attribute this session's judge calls
-    cands = _blocked_sub_candidates(load_goals(fsid))  # read-only scan; this copy is NOT saved
+    scan = load_goals(fsid)                            # read-only scan; this copy is NOT saved
+    cands = _blocked_sub_candidates(scan)
     if not cands:
         return []
     session = parsed_session(fsid, [path], now)
     turns = session["turns"]
     ended_ts = [turn.get("t") or 0 for turn in turns if not _turn_open(turn, turns)]
     newest = max(ended_ts, default=0)
+    newest_done = _newest_done_at(scan)
     due = [(nid, nd, bt) for nid, nd, bt in cands
-           if newest > max(bt, nd.get("blockCheckT") or 0)]
+           if newest > max(bt, nd.get("blockCheckT") or 0)
+           or newest_done > max(bt, nd.get("blockCheckDoneT") or 0)]
     if not due:
         return []
     oldest_block = min(bt for _nid, _nd, bt in due)
     since = "\n\n".join(_unit_text(turn["atoms"]) for turn in turns
                         if (turn.get("t") or 0) > oldest_block and not _turn_open(turn, turns))
     since = since[-UNBLOCK_HISTORY_CHARS:]
-    if not since.strip():
+    completed = _completed_since(scan, oldest_block, {nid for nid, _nd, _bt in due})
+    if not since.strip() and not completed:
         return []
     blocks_text = "\n".join("%d. %s\n   blocked on: %s" % (i, nd.get("text") or "(goal)",
                                                            nd.get("blockWhy") or "(no recorded question)")
                             for i, (_nid, nd, _bt) in enumerate(due, 1))
-    raw = unblock_llm(blocks_text, since)              # ← seconds; no store copy held across this
+    raw = unblock_llm(blocks_text, since, completed)   # ← seconds; no store copy held across this
     if not raw:
         return []                                      # call failed / paused (logged) → retry next pass
     lifts = _parse_unblock(raw, len(due))
@@ -7179,15 +7250,16 @@ def _unblock_session(fsid, path, now):
         fails = store.setdefault("unblockFails", 0) + 1
         store["unblockFails"] = fails
         if fails >= JUDGE_FAIL_CAP:                    # give up on THIS evidence: advance the watermarks —
-            store["unblockFails"] = 0                  # a NEWER ended turn re-arms every node (event re-arm)
+            store["unblockFails"] = 0                  # a NEWER ended turn / done filing re-arms every node
             for nid, _nd, _bt in due:
                 if nid in nodes:
-                    nodes[nid]["blockCheckT"] = newest
+                    nodes[nid]["blockCheckT"] = max(newest, nodes[nid].get("blockCheckT") or 0)
+                    nodes[nid]["blockCheckDoneT"] = max(newest_done, nodes[nid].get("blockCheckDoneT") or 0)
         save_goals(fsid, store)
         return []
     store["unblockFails"] = 0
     lifted = []
-    for i, (nid, _stale, _bt) in enumerate(due, 1):
+    for i, (nid, _stale, bt) in enumerate(due, 1):
         nd = nodes.get(nid)
         why = lifts.get(i)
         if nd is None or not nd.get("blocked") or nd.get("cleared"):
@@ -7198,10 +7270,16 @@ def _unblock_session(fsid, path, now):
                 _log_judge_error("unblocker", fsid, "drift-skip", goal=nid,
                                  note="node changed during the model call (resolved/cleared/re-planned) — lift skipped")
             continue
-        nd["blockCheckT"] = newest                     # examined up to here — re-ask only on newer evidence
+        # examined up to here — re-ask only on newer evidence. max() because a done-armed examine can
+        # run with an OLDER turn horizon than a prior turn-armed one; assigning bare `newest` would
+        # regress the turn watermark and both spuriously re-arm it and re-open the rejudging latch.
+        nd["blockCheckT"] = max(newest, nd.get("blockCheckT") or 0)
+        nd["blockCheckDoneT"] = max(newest_done, nd.get("blockCheckDoneT") or 0)
         if why is None:
             continue
-        if record_verdict(store, nd, "unblocker", "unblock", newest,
+        # ev floor mirrors the moot-heal: an examine armed by a done filing alone can have newest <
+        # the block's own evidence, and an unblock that folds BEFORE its block lifts nothing.
+        if record_verdict(store, nd, "unblocker", "unblock", max(newest, bt),
                           why=("answered in passing: " + why) if why else "answered in passing"):
             nd["mt"] = now
             lifted.append(nid)

--- a/tests/test_judge_unblocker.py
+++ b/tests/test_judge_unblocker.py
@@ -57,8 +57,8 @@ class UnblockerBase(unittest.TestCase):
         shutil.rmtree(self._td, ignore_errors=True)
 
     def _stub(self, reply):
-        def fake(blocks_text, since_text):
-            self.calls.append((blocks_text, since_text))
+        def fake(blocks_text, since_text, completed_text=""):
+            self.calls.append((blocks_text, since_text, completed_text))
             return reply
         jd.unblock_llm = fake
 
@@ -97,6 +97,21 @@ class UnblockerBase(unittest.TestCase):
         p = Path(self._td) / (SID + ".jsonl")
         p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
         return str(p)
+
+    def _add_completed_sibling(self, done_at, why="the pool sizing table shipped", synth=False,
+                               title="ship the pool sizing table"):
+        """Rebuild the saved store with a completed sibling top carrying its own done verdict row.
+        Written as plain dicts BEFORE save (protected flags are diary-owned once loaded)."""
+        store = json.loads(json.dumps(jd.load_goals(SID)))
+        other = SID + ":g5"
+        store["nodes"][other] = {
+            "id": other, "text": title, "parentId": None,
+            "nodeComplete": True, "blocked": False, "cleared": False, "doneWhy": why,
+            "trail": [], "t": T0, "mt": done_at,
+            "log": [{"ev_t": done_at, "src": "closer", "kind": "done", "why": why,
+                     **({"synth": True} if synth else {}), "at": done_at}]}
+        jd.save_goals(SID, store)
+        return other
 
 
 class Unblocker(UnblockerBase):
@@ -198,8 +213,8 @@ class Unblocker(UnblockerBase):
         path = self._transcript([(T0 + 200, "it is a 10,000mAh pack", "noted")])
         other = SID + ":g9"
 
-        def fake(blocks_text, since_text):
-            self.calls.append((blocks_text, since_text))
+        def fake(blocks_text, since_text, completed_text=""):
+            self.calls.append((blocks_text, since_text, completed_text))
             st = jd.load_goals(SID)
             jd.record_verdict(st, st["nodes"][sub], "user", "done", T0 + 500,
                               why="crossed off by the user mid-call")
@@ -217,6 +232,103 @@ class Unblocker(UnblockerBase):
         rows = [json.loads(line) for line in jd.ERRORS.read_text().splitlines()] if jd.ERRORS.exists() else []
         self.assertTrue(any(r.get("err") == "drift-skip" for r in rows),
                         "the race is observable: a drift-skip row lands in judge-errors")
+
+
+class UnblockerCompletedSince(UnblockerBase):
+    """The two-channel evidence gate (the user 2026-08-08): the session's DONE verdicts ride the
+    examine as <completed-since> (durable — the 9k conversation tail scrolls, a completion doesn't),
+    and a new done FILING is itself an arming event, so supersession can lift a blocked ask even when
+    no new turn ever arrives. All fixtures synthetic."""
+
+    def test_completed_since_rides_the_evidence_and_can_lift(self):
+        top, sub = self._store(block_t=T0 + 100)
+        self._add_completed_sibling(done_at=T0 + 300)
+        path = self._transcript([(T0 + 200, "keep going on the sizing", "on it"),
+                                 (T0 + 400, "anything else?", "wrapping up")])
+        self._stub('{"verdicts": [{"n": 1, "do": "lift", "why": "the sizing table shipped past it"}]}')
+        self.assertEqual(jd._unblock_session(SID, path, NOW), [sub])
+        self.assertIn("ship the pool sizing table", self.calls[0][2],
+                      "the completed sibling is shown as evidence")
+        self.assertIn("the pool sizing table shipped", self.calls[0][2],
+                      "with the done verdict's why")
+        self.assertIn("<completed-since>", jd.UNBLOCK_SYS, "the prompt names the section it receives")
+
+    def test_a_done_filing_arms_the_examination_without_new_turns(self):
+        # Every turn predates the block: the turn gate can never arm. A sibling completion filed
+        # afterwards must — the font-size offer card sat 1.3h with blockCheckT=None while two dones
+        # filed after its block (2026-08-08 study, synthetic equivalent here).
+        top, sub = self._store(block_t=T0 + 100)
+        self._add_completed_sibling(done_at=T0 + 300)
+        path = self._transcript([(T0 + 40, "please size the pool", "asking a question and idling")])
+        self._stub('{"verdicts": [{"n": 1, "do": "lift", "why": "the completion covers it"}]}')
+        self.assertEqual(jd._unblock_session(SID, path, NOW), [sub])
+        store = jd.load_goals(SID)
+        self.assertFalse(store["nodes"][sub]["blocked"],
+                         "the lift lands even though its examine had no new turn (ev floor = the block)")
+        self.assertEqual(self.calls[0][1], "", "no conversation since the block existed")
+        self.assertIn("ship the pool sizing table", self.calls[0][2])
+
+    def test_the_done_watermark_prevents_reasking_until_a_newer_filing(self):
+        top, sub = self._store(block_t=T0 + 100)
+        self._add_completed_sibling(done_at=T0 + 300)
+        path = self._transcript([(T0 + 40, "please size the pool", "asking and idling")])
+        self._stub('{"verdicts": [{"n": 1, "do": "hold", "why": ""}]}')
+        self.assertEqual(jd._unblock_session(SID, path, NOW), [])
+        self.assertEqual(len(self.calls), 1)
+        # same filings again → no second call (blockCheckDoneT watermark)
+        self.assertEqual(jd._unblock_session(SID, path, NOW), [])
+        self.assertEqual(len(self.calls), 1, "no new filing → no re-ask")
+        # a NEWER done filing re-arms the examination
+        store = json.loads(json.dumps(jd.load_goals(SID)))
+        store["nodes"][SID + ":g5"]["log"].append(
+            {"ev_t": T0 + 500, "src": "closer", "kind": "done",
+             "why": "the follow-on table also shipped", "at": T0 + 500})
+        jd.save_goals(SID, store)
+        self.assertEqual(jd._unblock_session(SID, path, NOW), [])
+        self.assertEqual(len(self.calls), 2, "a new done filing → examined again")
+
+    def test_a_done_armed_examine_never_regresses_the_turn_watermark(self):
+        # REGRESSION GUARD for the rejudging latch (PR #144): kernel _block_check_floor reads
+        # blockCheckT against plain-reply TURN times. A done filing is wall-clock and sorts after
+        # every turn, so it must advance only its OWN watermark — a filing time written into
+        # blockCheckT would release the latch before any judge saw the reply it latched on.
+        top, sub = self._store(block_t=T0 + 100)
+        self._add_completed_sibling(done_at=T0 + 300)
+        path = self._transcript([(T0 + 40, "please size the pool", "asking and idling")])
+        self._stub('{"verdicts": [{"n": 1, "do": "hold", "why": ""}]}')
+        jd._unblock_session(SID, path, NOW)
+        store = jd.load_goals(SID)
+        nd = store["nodes"][sub]
+        newest_turn = T0 + 45                          # the one ended turn's reply line
+        self.assertLessEqual(nd.get("blockCheckT") or 0, newest_turn,
+                             "blockCheckT stays in the turn-time domain")
+        self.assertEqual(nd.get("blockCheckDoneT"), T0 + 300,
+                         "the filing advanced its own watermark only")
+
+    def test_pre_block_dones_neither_arm_nor_ride(self):
+        top, sub = self._store(block_t=T0 + 100)
+        self._add_completed_sibling(done_at=T0 + 50)   # finished BEFORE the ask existed
+        path = self._transcript([(T0 + 40, "please size the pool", "asking and idling")])
+        self._stub('{"verdicts": [{"n": 1, "do": "lift", "why": "x"}]}')
+        self.assertEqual(jd._unblock_session(SID, path, NOW), [])
+        self.assertEqual(self.calls, [], "nothing new since the block → no examine at all")
+
+    def test_synth_settle_dones_neither_arm_nor_ride(self):
+        # An episode-boundary settle asserts the conversation ended, not that work was delivered —
+        # it is not supersession evidence and must not wake the examine.
+        top, sub = self._store(block_t=T0 + 100)
+        self._add_completed_sibling(done_at=T0 + 300, synth=True)
+        path = self._transcript([(T0 + 40, "please size the pool", "asking and idling")])
+        self._stub('{"verdicts": [{"n": 1, "do": "lift", "why": "x"}]}')
+        self.assertEqual(jd._unblock_session(SID, path, NOW), [])
+        self.assertEqual(self.calls, [], "a synth settle row is not an arming event")
+        # and when a real turn arms the examine, the synth row still doesn't ride as evidence
+        path2 = self._transcript([(T0 + 40, "please size the pool", "asking and idling"),
+                                  (T0 + 400, "unrelated talk", "unrelated reply")])
+        jd._PARSE_CACHE.clear()
+        self._stub('{"verdicts": [{"n": 1, "do": "hold", "why": ""}]}')
+        jd._unblock_session(SID, path2, NOW)
+        self.assertEqual(self.calls[-1][2], "", "the synth completion is excluded from the section")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The problem

A card blocked on a question whose moment passed sat in Needs-you until the user cleaned it up by hand. The 2026-08-08 study over 1,980 reconstructed blocked episodes: 400 card-hours sat before 302 manual clears, 61% of never-exited blocks had sibling cards complete during the sit, and one audited session held four overtaken asks through ~10 hours of unblocker examines (watermarks prove the examines ran) while dozens of sibling cards completed.

Three structural causes, each visible in a real diary:
- The unblocker's only evidence was the newest 9k chars of conversation, which scrolls past superseding work; a card examined 8 minutes before the user gave up and cleared it was held, yet the same prompt lifts it 3/3 in replay with a clean window.
- The blockCheckT ratchet advances on every hold, so evidence one conservative hold let by is never re-presented.
- The due-gate armed only on new ended turns: a card whose session idled after asking was never examined at all (blockCheckT=None after 1.3h while two done verdicts filed past it).

## The change

- **`<completed-since>` rides every examine**: the goals the session finished since the oldest due block (title + the done verdict's why), capped newest-kept at 4k chars. Durable where the tail scrolls. Synth settle rows excluded: a settle asserts the conversation ended, not that work was delivered.
- **A done-verdict filing is an arming event** with its own per-node watermark (`blockCheckDoneT`, arrival domain). A late closer filing on an idle session re-arms the examine the turn gate never would. Verdicts file once, so the gate cannot flap. `blockCheckT` stays turn-domain on purpose: the feed's re-judging latch (PR #144) reads it against reply times, and a filing-time stamp would release the latch before any judge saw the reply. Regression-tested, plus a guard that a done-armed examine never regresses the turn watermark.
- **`UNBLOCK_SYS` names the overtaken case**: an offer or approval whose work was then done anyway is moot; a newer blocked goal restating an older one supersedes it; a sibling's completion note is not the answer to this ask; progress on other goals does not by itself lift anything.
- The lift's `ev_t` mirrors the moot-heal's floor (`max(newest, block_t)`) so a done-armed examine with no new turn still folds after the block it clears.

## Measured

Replay A/B on real episodes (evidence reconstructed at the moment before the user's clear/reply, or now for still-blocked cards; live triage model; 3 reps per case per arm): stale-card lift 50% to 58% while genuinely-waiting controls stayed held (zero majority false-lifts either arm; the two single-rep flickers are on cases whose sessions themselves stopped listing the ask as pending). The duplicate-ask clause lifts the older twin and keeps the newer 2/3, holds both otherwise, never lifts the wrong one. About a third of user-cleared stale cards have no in-session evidence at all (decided out of band); those are out of any judge's reach by design and stay with Clear/Continue.

## Tests

`tests/test_judge_unblocker.py` gains a synthetic-fixture class: completions ride and can lift, a done filing arms with no new turns, the done watermark prevents re-asking until a newer filing, the turn watermark never regresses (the latch regression), pre-block dones neither arm nor ride, synth settles neither arm nor ride. Full pytest (3,953) and vscode-extension node suite (1,709) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)