### PR TITLE
Lifted overlays paint their pane in place; Cmd+O becomes a session jump switcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,13 +218,18 @@ never solid black, never a layout change). Shell-native panels (`#rnet-back`,
 `#rerr-back`, `#rpal-back`) get this for free: their backdrop composites over the
 real panes. A panel living INSIDE a pane iframe that must cover the whole window
 (settings, picker) is lifted by the shell (`body.settings-open` /
-`body.picker-open`) and must then make EVERY layer under its backdrop transparent:
-the step-aside class rides `documentElement` AND `body` (THEME_CSS paints both
-opaque), and the shell's lift rule sets the iframe ELEMENT's own
-`background:transparent` (the default `iframe{background:#1e1e1e}` otherwise turns
-the dim into a full-window black-out — the 2026-08-08 bug, twice). Small
-pane-local dialogs (confirm boxes, the feed's card modal) stay pane-local by
-design; this rule is for panels that present over the dashboard as a whole.
+`body.picker-open`) and must then keep every pixel behind its backdrop looking
+untouched: the page's `html` goes transparent AND the shell's lift rule sets the
+iframe ELEMENT's own `background:transparent` (the default
+`iframe{background:#1e1e1e}` otherwise turns the dim into a full-window black-out
+— the 2026-08-08 bug, twice); and the page's BODY is pinned to the pane's old
+screen rect and KEEPS PAINTING (`--pane-*` vars measured from the shell's pane
+div: `placeLifted()` in render.ts / gear.js), because hiding the content instead
+leaves a black hole where that pane was — the same bug's third form. Only an
+unmeasurable pane (hidden, or a cross-origin parent like VS Code) falls back to
+hiding its content (`.pane-gone` / `.rs-pane-gone`). Small pane-local dialogs
+(confirm boxes, the feed's card modal) stay pane-local by design; this rule is
+for panels that present over the dashboard as a whole.
 
 ### Font sizes: few, and consistent by information type (user rule, 2026-07-02)
 Do not multiply font sizes. Similar kinds of information wear the SAME size — labels

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6225,16 +6225,22 @@ class ServeSecurity(unittest.TestCase):
     def test_settings_is_a_fullscreen_modal(self):
         # the user 2026-06-23: the gear's settings is a full-WINDOW modal (was a cramped 240px corner panel).
         # #rsettings is the backdrop + .rs-card the centered card. The gear lives in the feed iframe, so it
-        # asks the shell to lift the feed iframe over the whole window; the feed then goes TRANSPARENT and
-        # hides its own content (rs-modal-open), so the dimmed three-pane DASHBOARD shows through behind the
-        # card — not the feed cards blown up full-screen.
+        # asks the shell to lift the feed iframe over the whole window; the feed's html then goes TRANSPARENT
+        # and its BODY is pinned to the feed pane's old screen rect, still painting (rs-lifted + --pane-*
+        # vars) — so the dimmed dashboard shows through with the feed cards live and visible in place, not
+        # a black hole where the pane was (the user 2026-08-08). Only an unmeasurable pane (hidden, or a
+        # cross-origin parent like VS Code) hides the feed's content instead (rs-pane-gone).
         self.assertIn("#rsettings { position: fixed; inset: 0; z-index: 60; background: rgba(0, 0, 0, 0.55);", _gear_css_src())   # the one modal dim (the user 2026-08-08)
         self.assertIn(".rs-card {", _gear_css_src())
-        self.assertIn(".rs-modal-open { background: transparent; }", _gear_css_src())            # feed iframe transparent while open
-        self.assertIn("body.rs-modal-open #feed-list", _gear_css_src())                     # feed cards hidden while open
+        self.assertIn(".rs-modal-open { background: transparent; }", _gear_css_src())            # the page's html steps aside
+        self.assertIn("body.rs-lifted { position: fixed; left: var(--pane-x, 0); top: var(--pane-y, 0);", _gear_css_src())
+        self.assertIn("body.rs-pane-gone #feed-head, body.rs-pane-gone #feed-list, body.rs-pane-gone #feed-foot { visibility: hidden; }",
+                      _gear_css_src())
         self.assertIn("<div id=rsettings hidden><div class=rs-card>", _gear_src())
         self.assertIn("feedFull(true)", _gear_src())              # open → ask the shell to go full-window
-        self.assertIn("setModalCls(true)", _gear_src())          # open → feed goes transparent + hides content
+        self.assertIn("setModalCls(true)", _gear_src())          # open → transparent html + body pinned in place
+        self.assertIn("placeLifted(5)", _gear_src())             # measure the pane rect (retrying while the shell reacts)
+        self.assertIn("getElementById('feed-pane')", _gear_src())
         self.assertIn("if (e.target === p) closeSettings()", _gear_src())   # backdrop click closes
         # shell side: the feed iframe lifts to cover the whole window (the panes show THROUGH the transparent
         # feed). background:transparent on the LIFTED IFRAME ELEMENT is load-bearing: the shell's default

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -15,10 +15,18 @@
 #rsettings { position: fixed; inset: 0; z-index: 60; background: rgba(0, 0, 0, 0.55); display: flex; align-items: flex-start;
   justify-content: center; overflow: auto; padding: 6vh 16px; box-sizing: border-box; }   /* the one modal dim */
 #rsettings[hidden] { display: none; }
-/* while open: the feed goes transparent + hides its own content, so (in the web shell) the
-   full-window iframe shows the dashboard's panes through it — not the feed cards. */
+/* while open (web shell): the page's html goes transparent and the BODY is pinned to the feed pane's
+   old screen rect (--pane-* vars, gear.js placeLifted), still painting — so the dashboard shows through
+   the full-window iframe with the feed cards live and visible in place under the dim, not a black hole
+   where the pane was (the user 2026-08-08). #rsettings is a fixed child of an untransformed body, so the
+   backdrop still spans and dims the whole viewport. */
 .rs-modal-open { background: transparent; }
-body.rs-modal-open #feed-head, body.rs-modal-open #feed-list, body.rs-modal-open #feed-foot { visibility: hidden; }
+body.rs-lifted { position: fixed; left: var(--pane-x, 0); top: var(--pane-y, 0);
+  width: var(--pane-w, 100%); height: var(--pane-h, 100%); overflow: hidden;
+  background: var(--bg, #1e1e1e); }
+/* no measurable pane to stand in for (hidden pane, or a cross-origin parent like VS Code):
+   fall back to hiding the feed's own content so only the settings card draws */
+body.rs-pane-gone #feed-head, body.rs-pane-gone #feed-list, body.rs-pane-gone #feed-foot { visibility: hidden; }
 .rs-card { width: min(560px, 94%); max-height: 88vh; overflow: auto; background: #252526; border: 1px solid #3a3a3a;
   border-radius: 10px; padding: 16px 20px; font: 13px/1.6 system-ui, -apple-system, 'Segoe UI', sans-serif; color: #ccc; box-shadow: 0 12px 36px #000000aa; }
 #rsettings .rs-h { font-size: 14px; font-weight: 600; margin-bottom: 6px; color: #e8eaed; }

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -34,7 +34,8 @@ var SHORTCUT_ROWS =
   '<div class=rs-key><span class=rs-key-combo><kbd>Esc</kbd></span><span class=rs-key-desc>Jump to the session tabs</span></div>' +
   '<div class=rs-key><span class=rs-key-combo><kbd>←</kbd> / <kbd>→</kbd></span><span class=rs-key-desc>Switch session (from the tabs)</span></div>' +
   '<div class=rs-key><span class=rs-key-combo><kbd>Ctrl</kbd> + <kbd>C</kbd></span><span class=rs-key-desc>Interrupt the session</span></div>' +
-  '<div class=rs-key><span class=rs-key-combo><kbd>⌘/Ctrl</kbd> + <kbd>O</kbd></span><span class=rs-key-desc>Open or create a session (quick switcher)</span></div>' +
+  '<div class=rs-key><span class=rs-key-combo><kbd>⌘/Ctrl</kbd> + <kbd>O</kbd></span><span class=rs-key-desc>Jump to a session (quick switcher)</span></div>' +
+  '<div class=rs-key><span class=rs-key-combo><kbd>⌘/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>O</kbd></span><span class=rs-key-desc>New session picker</span></div>' +
   '<div class=rs-key><span class=rs-key-combo><kbd>⌘/Ctrl</kbd> + <kbd>P</kbd></span><span class=rs-key-desc>Command palette (browser dashboard)</span></div>';
 
 // The modal markup — ported verbatim from the kernel's _gear_html; the model/
@@ -253,8 +254,31 @@ function initGear(post) {
   // The settings modal is full-WINDOW in the web shell — ask it to expand the
   // feed iframe while open (no-op elsewhere: VS Code's feed panel IS the window).
   function feedFull(on) { try { if (window.parent !== window) window.parent.postMessage({ romp: 'settings', on: !!on }, '*'); } catch (e) {} }
+  // While lifted, pin the BODY to the feed pane's old screen rect and keep painting (rs-lifted +
+  // --pane-* vars), so the feed stays exactly where it was — live and visible under the dim like every
+  // other pane — instead of leaving a black hole where its pane had been (the user 2026-08-08; same
+  // technique as the chat picker's placeLifted). A pane we can't measure (hidden pane, or a
+  // cross-origin parent like VS Code) falls back to hiding the feed's content (rs-pane-gone). The
+  // measurement retries a few frames: opening from a hidden feed pane, the shell's settings-open class
+  // (which forces the pane visible) lands only after the postMessage round-trip.
+  function paneRect() { try { var el = window.parent !== window ? window.parent.document.getElementById('feed-pane') : null;
+    return el ? el.getBoundingClientRect() : null; } catch (e) { return null; } }
+  function placeLifted(tries) {
+    if (p.hidden || !document.body.classList.contains('rs-lifted')) return;   // closed while retrying
+    var r = paneRect(), gone = !r || r.width < 40 || r.height < 40;
+    document.body.classList.toggle('rs-pane-gone', gone);
+    if (!gone) { var st = document.documentElement.style;
+      st.setProperty('--pane-x', r.left + 'px'); st.setProperty('--pane-y', r.top + 'px');
+      st.setProperty('--pane-w', r.width + 'px'); st.setProperty('--pane-h', r.height + 'px'); }
+    else if (tries > 0) requestAnimationFrame(function () { placeLifted(tries - 1); });
+  }
+  function onRsResize() { placeLifted(0); }   // panes track the window; follow them while open
   function setModalCls(on) { var de = document.documentElement, m = 'rs-modal-open';
-    if (on) { de.classList.add(m); document.body.classList.add(m); } else { de.classList.remove(m); document.body.classList.remove(m); } }
+    if (on) { de.classList.add(m); document.body.classList.add(m);
+      if (window.parent !== window) { document.body.classList.add('rs-lifted'); placeLifted(5); window.addEventListener('resize', onRsResize); } }
+    else { de.classList.remove(m); document.body.classList.remove(m);
+      document.body.classList.remove('rs-lifted'); document.body.classList.remove('rs-pane-gone');
+      window.removeEventListener('resize', onRsResize); } }
   function closeSettings() { p.hidden = true; setModalCls(false); feedFull(false); }
   function openSettings() { if (!p.hidden) { closeSettings(); return; }   // the opener toggles the modal
     p.hidden = false; setModalCls(true); feedFull(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch !== false; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cg) cg.checked = s.collapseGaps !== false; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }

--- a/ui/webview/palette-main.ts
+++ b/ui/webview/palette-main.ts
@@ -1,12 +1,15 @@
-// Shell-page boot for the command palette and the global hotkeys (browser dashboard only —
-// the VS Code surface gets real contributed keybindings instead, rebindable in its own
-// Keyboard Shortcuts editor). Cmd/Ctrl+P toggles the palette; Cmd/Ctrl+O opens the session
-// quick switcher — the existing new-session picker in the chat pane, one picker, one code
-// path. Both combos are claimable by a page (Google Docs and Figma take exactly these), the
-// override lasts only while this tab has focus, and the window/tab-management set
-// (Cmd+W/T/N/L/Q) stays untouched.
+// Shell-page boot for the quick-pick hotkeys (browser dashboard only — the VS Code surface
+// gets real contributed keybindings instead, rebindable in its own Keyboard Shortcuts
+// editor). Obsidian's split, per the user (2026-08-08): Cmd/Ctrl+O is the SESSION JUMP
+// switcher — sessions most-recently-used first, fuzzy by name, Enter switches; it never
+// creates. Cmd/Ctrl+Shift+O opens the full new-session picker (create, directory, backend,
+// host). Cmd/Ctrl+P toggles the command palette. All three combos are claimable by a page
+// (Google Docs and Figma take Cmd+O/Cmd+P), the override lasts only while this tab has
+// focus, and the window/tab-management set (Cmd+W/T/N/L/Q) stays untouched.
 import { registerCommand } from "./commands";
-import { initPalette } from "./palette";
+import { initPalette, PickItem } from "./palette";
+
+type SessionRow = { id: string; name: string; dir: string; bg: string };
 
 (function boot() {
   // The shell page only, never inside a pane: the pane documents get the KEY wiring below
@@ -20,21 +23,64 @@ import { initPalette } from "./palette";
   function pane(id: string): HTMLIFrameElement | null {
     return document.getElementById(id) as HTMLIFrameElement | null;
   }
-  function openSwitcher(): void {
-    // Reveal the chat pane if it's toggled off, focus it, and toggle the picker there. The
-    // __romp* globals and the picker's message handler are read lazily at RUN time, so boot
+  function chatPost(msg: object): void {
+    // Reveal the chat pane if it's toggled off, focus it, and hand it the message. The
+    // __romp* globals and the pane's message handlers are read lazily at RUN time, so boot
     // order across the shell's script tags doesn't matter.
     try { if (w.__rompPaneToggle) w.__rompPaneToggle("chat", true); } catch (e) { /* rail not booted yet */ }
     const f = pane("f-chat");
-    try {
-      f!.contentWindow!.focus();
-      f!.contentWindow!.postMessage({ type: "openPicker", toggle: true }, "*");
-    } catch (e) { /* chat pane not loaded yet — nothing to open a picker in */ }
+    try { f!.contentWindow!.focus(); f!.contentWindow!.postMessage(msg, "*"); }
+    catch (e) { /* chat pane not loaded yet — nothing to talk to */ }
+  }
+  function openNewSessionPicker(): void {
+    chatPost({ type: "openPicker", toggle: true });
   }
 
-  // The dashboard's actions, registered as commands. Each calls the SAME code path its rail
-  // button uses; the palette adds reachability, not behavior.
-  registerCommand({ id: "session.open", title: "Open or create a session", kbd: mod + "O", run: openSwitcher });
+  // ── the session jump switcher (Cmd/Ctrl+O) ────────────────────────────────────────────────
+  // Sessions come from the kernel's /sessions (the authoritative list, same-origin, kernel
+  // order); recency comes from the chat pane's __rompMru (most-recently-ACTIVATED tab ids,
+  // current session first). Obsidian's trick, kept: the current session is excluded and the
+  // previous one sorts first, so Cmd+O Enter toggles between your two most recent sessions.
+  function mruIds(): string[] {
+    try { return (pane("f-chat")?.contentWindow as any)?.__rompMru?.slice() || []; }
+    catch (e) { return []; }
+  }
+  function sessionItems(rows: SessionRow[]): PickItem[] {
+    const mru = mruIds();
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    const ordered: SessionRow[] = [];
+    for (const id of mru.slice(1)) { const r = byId.get(id); if (r) { ordered.push(r); byId.delete(id); } }
+    for (const r of rows) if (byId.has(r.id) && r.id !== mru[0]) ordered.push(r);
+    const base = (d: string) => (d || "").replace(/\/+$/, "").split("/").pop() || "";
+    return ordered.map((r) => ({
+      title: r.name,
+      dot: r.bg || "#8a8a8a",
+      dim: base(r.dir),
+      run: () => chatPost({ type: "jumpSession", id: r.id }),
+    }));
+  }
+  function openSessionSwitcher(): void {
+    fetch("/sessions").then((r) => r.json()).then((rows: SessionRow[]) => {
+      palette.openPick({
+        placeholder: "Jump to a session…",
+        items: sessionItems(Array.isArray(rows) ? rows : []),
+        altEnter: { label: "new session…", run: openNewSessionPicker },
+      });
+    }).catch(() => {
+      // fail loudly, not with a silently empty list: the kernel not answering is the story
+      palette.openPick({
+        placeholder: "Jump to a session…",
+        items: [{ title: "Couldn't load sessions — the kernel didn't answer", run: () => {} }],
+        altEnter: { label: "new session…", run: openNewSessionPicker },
+      });
+    });
+  }
+
+  // ── the dashboard's actions, registered as commands ──────────────────────────────────────
+  // Each calls the SAME code path its rail button uses; the palette adds reachability, not
+  // behavior.
+  registerCommand({ id: "session.jump", title: "Jump to a session", kbd: mod + "O", run: openSessionSwitcher });
+  registerCommand({ id: "session.new", title: "New session", kbd: mod + (mac ? "⇧O" : "Shift+O"), run: openNewSessionPicker });
   registerCommand({
     id: "settings.open", title: "Open settings",
     run: () => { try { pane("f-feed")!.contentWindow!.postMessage({ romp: "openSettings" }, "*"); } catch (e) { /* feed not loaded */ } },
@@ -53,21 +99,27 @@ import { initPalette } from "./palette";
     });
   }
 
-  // Esc (or running a command) hands focus back to the chat pane, so "palette, Esc, type"
+  // Esc (or running an item) hands focus back to the chat pane, so "palette, Esc, type"
   // never strands the keyboard on the shell document.
   const palette = initPalette({ onClose: () => { try { pane("f-chat")!.contentWindow!.focus(); } catch (e) { /* no chat pane */ } } });
   w.__rompPalette = palette;   // reachable by other shell scripts (e.g. a future mobile-bar button)
 
   function onKey(e: KeyboardEvent): void {
-    if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey || e.repeat) return;
+    if (!(e.metaKey || e.ctrlKey) || e.altKey || e.repeat) return;
     const k = (e.key || "").toLowerCase();
-    if (k === "o") { e.preventDefault(); e.stopPropagation(); palette.close(); openSwitcher(); }
-    else if (k === "p") { e.preventDefault(); e.stopPropagation(); palette.toggle(); }
+    if (k === "o") {
+      e.preventDefault(); e.stopPropagation();
+      palette.close();
+      if (e.shiftKey) openNewSessionPicker(); else openSessionSwitcher();
+    } else if (k === "p" && !e.shiftKey) {   // Cmd+Shift+P stays the browser's / VS Code's
+      e.preventDefault(); e.stopPropagation();
+      palette.toggle();
+    }
   }
   // The same dual wiring as the Alt+Arrow pane nav (_LANDING_FOCUS_JS): capture on the shell
   // document AND on every same-origin pane document, re-attached on every iframe (re)load.
-  // When focus is already in the chat document, render.ts's own window-capture Cmd+O handler
-  // runs first and stops propagation, so this one never double-fires.
+  // render.ts's own window-capture Cmd+O handler stands down inside the shell (inRompShell),
+  // so a keystroke in the chat document lands here exactly once.
   document.addEventListener("keydown", onKey, true);
   ["f-chat", "f-fleet", "f-feed", "f-timeline"].forEach((id) => {
     const f = pane(id);

--- a/ui/webview/palette.test.ts
+++ b/ui/webview/palette.test.ts
@@ -1,7 +1,8 @@
-// The command palette (Cmd/Ctrl+P) + session quick-switcher hotkey (Cmd/Ctrl+O), and the
-// one-modal-treatment conversions that came with them (the user 2026-08-08). Source-level
-// pins (no jsdom for the DOM pieces); fuzzy.ts and commands.ts have real unit tests, and the
-// kernel-side shell CSS/wiring is pinned in tests/test_kernel.py.
+// The quick-pick hotkeys — Cmd/Ctrl+O session jump switcher, Cmd/Ctrl+Shift+O new-session
+// picker, Cmd/Ctrl+P command palette — and the one-modal-treatment conversions that came with
+// them (the user 2026-08-08). Source-level pins (no jsdom for the DOM pieces); fuzzy.ts and
+// commands.ts have real unit tests, and the kernel-side shell CSS/wiring is pinned in
+// tests/test_kernel.py.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -23,23 +24,31 @@ test("palette backdrop is the standard centered 0.55 dim, above every shell pane
   assert.match(PALETTE, /#rpal-back\[hidden\]\{display:none\}/);
 });
 
-test("palette keyboard model: arrows wrap, Enter runs, Esc closes, backdrop click closes", () => {
+test("palette keyboard model: arrows wrap, Enter runs, Shift+Enter is the alt action, Esc closes, backdrop click closes", () => {
   assert.match(PALETTE, /e\.key === "ArrowDown"[\s\S]*?\(active \+ 1\) % rows\.length/);
   assert.match(PALETTE, /e\.key === "ArrowUp"[\s\S]*?\(active - 1 \+ rows\.length\) % rows\.length/);
-  assert.match(PALETTE, /e\.key === "Enter"[\s\S]*?run\(r\.cmd\)/);
+  assert.match(PALETTE, /e\.key === "Enter" && e\.shiftKey && spec\.altEnter/);
+  assert.match(PALETTE, /e\.key === "Enter"[\s\S]*?run\(r\.item\)/);
   assert.match(PALETTE, /e\.key === "Escape"[\s\S]*?close\(\)/);
   assert.match(PALETTE, /if \(e\.target === back\) close\(\);/);
 });
 
-test("running a command closes the palette FIRST so its own modal never lands underneath", () => {
-  assert.match(PALETTE, /function run\(cmd: PaletteCommand\): void \{\s*\n\s*close\(\);[\s\S]*?cmd\.run\(\);/);
+test("running an item closes the palette FIRST so its own modal never lands underneath", () => {
+  assert.match(PALETTE, /function run\(item: PickItem\): void \{\s*\n\s*close\(\);[\s\S]*?item\.run\(\);/);
 });
 
-// ── the shell boot: hotkeys reach every pane, commands call the rail's own code paths ──────
-test("Cmd/Ctrl+O opens the quick switcher and Cmd/Ctrl+P toggles the palette, claimed with preventDefault", () => {
-  assert.match(MAIN, /if \(!\(e\.metaKey \|\| e\.ctrlKey\) \|\| e\.altKey \|\| e\.shiftKey \|\| e\.repeat\) return;/);
-  assert.match(MAIN, /if \(k === "o"\) \{ e\.preventDefault\(\); e\.stopPropagation\(\); palette\.close\(\); openSwitcher\(\); \}/);
-  assert.match(MAIN, /else if \(k === "p"\) \{ e\.preventDefault\(\); e\.stopPropagation\(\); palette\.toggle\(\); \}/);
+test("session rows carry the session color dot and a dim directory tail", () => {
+  assert.match(PALETTE, /\.rpal-dot\{flex:0 0 auto;width:8px;height:8px;border-radius:50%\}/);
+  assert.match(PALETTE, /\.rpal-dim\{[^}]*font-size:11px/);
+  assert.match(PALETTE, /d\.style\.background = item\.dot;/);
+});
+
+// ── the shell boot: three combos, wired into every pane ────────────────────────────────────
+test("Cmd/Ctrl+O = jump switcher, +Shift = new-session picker, Cmd/Ctrl+P = palette (Shift+P left alone)", () => {
+  assert.match(MAIN, /if \(!\(e\.metaKey \|\| e\.ctrlKey\) \|\| e\.altKey \|\| e\.repeat\) return;/);
+  assert.match(MAIN, /if \(e\.shiftKey\) openNewSessionPicker\(\); else openSessionSwitcher\(\);/);
+  assert.match(MAIN, /k === "p" && !e\.shiftKey/);
+  assert.match(MAIN, /e\.preventDefault\(\); e\.stopPropagation\(\);[\s\S]*?palette\.toggle\(\);/);
 });
 
 test("key wiring mirrors the Alt+Arrow pane nav: capture on the shell doc AND every pane doc, re-wired on load", () => {
@@ -49,23 +58,52 @@ test("key wiring mirrors the Alt+Arrow pane nav: capture on the shell doc AND ev
   assert.match(MAIN, /f\.addEventListener\("load", wire\);\s*\n\s*wire\(\);/);
 });
 
-test("the switcher IS the existing picker (one code path), revealed and toggled via the chat pane", () => {
+test("the jump switcher reads /sessions (kernel-authoritative), sorts by the chat's MRU, and excludes the current session", () => {
+  assert.match(MAIN, /fetch\("\/sessions"\)/);
+  assert.match(MAIN, /__rompMru/);
+  assert.match(MAIN, /for \(const id of mru\.slice\(1\)\)/);          // previous session first → Cmd+O Enter toggles back
+  assert.match(MAIN, /if \(byId\.has\(r\.id\) && r\.id !== mru\[0\]\)/); // current session excluded
+  assert.match(MAIN, /chatPost\(\{ type: "jumpSession", id: r\.id \}\)/);
+});
+
+test("the switcher fails loudly when the kernel doesn't answer, and Shift+Enter reaches the new-session picker", () => {
+  assert.match(MAIN, /Couldn't load sessions — the kernel didn't answer/);
+  assert.match(MAIN, /altEnter: \{ label: "new session…", run: openNewSessionPicker \}/);
+});
+
+test("the new-session picker opens via the chat pane, revealed first (one code path)", () => {
   assert.match(MAIN, /__rompPaneToggle\("chat", true\)/);
-  assert.match(MAIN, /postMessage\(\{ type: "openPicker", toggle: true \}, "\*"\)/);
+  assert.match(MAIN, /postMessage\(msg, "\*"\)/);
+  assert.match(MAIN, /chatPost\(\{ type: "openPicker", toggle: true \}\)/);
 });
 
 test("built-in commands call the same globals the rail buttons use", () => {
   for (const g of ["__rompOpenErrs", "__rompOpenNet", "__rompUsagePanel", "__rompRestart", "__rompPaneToggle"]) {
     assert.ok(MAIN.includes(g), g + " missing from palette-main.ts");
   }
+  assert.match(MAIN, /id: "session\.jump", title: "Jump to a session"/);
+  assert.match(MAIN, /id: "session\.new", title: "New session"/);
 });
 
 test("palette-main is bundled for the shell page", () => {
   assert.match(ESBUILD, /"\.\.\/ui\/webview\/palette-main\.ts"/);
 });
 
-// ── the chat page's own Cmd+O (standalone + VS Code webview, and first-responder in the shell) ──
-test("render.ts claims Cmd/Ctrl+O at window capture and toggles the picker", () => {
+// ── the chat page: MRU + jumpSession, and the in-page fallback standing down in the shell ──
+test("render.ts tracks a session MRU on window for the shell's switcher", () => {
+  assert.match(RENDER, /\(window as any\)\.__rompMru = sessionMru;/);
+  assert.match(RENDER, /function setActive\([\s\S]{0,200}?noteMru\(id\);/);
+});
+
+test("jumpSession activates an open tab like a feed jump, and opens a closed session through the host", () => {
+  assert.match(RENDER, /m\.type === "jumpSession" && typeof m\.id === "string"/);
+  assert.match(RENDER, /if \(order\.includes\(m\.id\)\) \{ revealSelfPane\(\); closingTabs\.delete\(m\.id\); setActive\(m\.id\); \}/);
+  assert.match(RENDER, /else if \(vscodeApi\) vscodeApi\.postMessage\(\{ type: "openSession", id: m\.id \}\);/);
+});
+
+test("the in-page Cmd+O fallback stands down inside the romp shell and toggles the picker elsewhere", () => {
+  assert.match(RENDER, /function inRompShell\(\): boolean/);
+  assert.match(RENDER, /if \(inRompShell\(\)\) return;/);
   assert.match(RENDER, /\(e\.key \|\| ""\)\.toLowerCase\(\) !== "o"\) return;/);
   assert.match(RENDER, /if \(pickerVisible\(\)\) closePicker\(\); else openPicker\(\);/);
 });
@@ -74,11 +112,23 @@ test("the openPicker message accepts toggle:true (the hotkey form relayed by the
   assert.match(RENDER, /if \(m\.toggle && pickerVisible\(\)\) closePicker\(\);\s*\n\s*else openPicker\(!!m\.pick, m\.prompt, !!m\.allowNew\);/);
 });
 
-// ── the black-out fixes: every layer under a lifted overlay's backdrop goes transparent ────
-test("picker lift rides documentElement AND body (THEME_CSS paints both opaque)", () => {
+// ── lifted overlays paint their pane's content in place (no black hole behind the modal) ───
+test("picker lift pins the body to the pane's old rect and keeps painting; hidden panes fall back to .pane-gone", () => {
   assert.match(RENDER, /document\.documentElement\.classList\.toggle\("picker-lifted", on\);\s*\n\s*document\.body\.classList\.toggle\("picker-lifted", on\);/);
+  assert.match(RENDER, /getElementById\("chat-pane"\)/);
+  assert.match(RENDER, /st\.setProperty\("--pane-x", r!\.left \+ "px"\);/);
+  assert.match(RENDER, /window\.addEventListener\("resize", onLiftResize\);/);
   assert.match(CSS, /html\.picker-lifted \{ background: transparent !important; \}/);
-  assert.match(CSS, /body\.picker-lifted \{ background: transparent !important; \}/);
+  assert.match(CSS, /body\.picker-lifted \{\s*\n\s*position: fixed;\s*\n\s*left: var\(--pane-x, 0\); top: var\(--pane-y, 0\);/);
+  assert.match(CSS, /body\.picker-lifted\.pane-gone > \* \{ visibility: hidden; \}/);
+  assert.match(CSS, /body\.picker-lifted\.pane-gone > #picker \{ visibility: visible; \}/);
+});
+
+test("settings lift does the same via rs-lifted / rs-pane-gone", () => {
+  assert.match(GEAR, /document\.body\.classList\.add\('rs-lifted'\); placeLifted\(5\);/);
+  assert.match(GEAR, /getElementById\('feed-pane'\)/);
+  assert.match(GEAR_CSS, /body\.rs-lifted \{ position: fixed; left: var\(--pane-x, 0\); top: var\(--pane-y, 0\);/);
+  assert.match(GEAR_CSS, /body\.rs-pane-gone #feed-head, body\.rs-pane-gone #feed-list, body\.rs-pane-gone #feed-foot \{ visibility: hidden; \}/);
 });
 
 test("overlay dims are the one standard 0.55", () => {
@@ -86,8 +136,9 @@ test("overlay dims are the one standard 0.55", () => {
   assert.match(GEAR_CSS, /#rsettings \{ position: fixed; inset: 0; z-index: 60; background: rgba\(0, 0, 0, 0\.55\);/);
 });
 
-// ── discoverability: the settings' shortcut list names both hotkeys ────────────────────────
-test("the gear's shortcut rows document Cmd/Ctrl+O and Cmd/Ctrl+P", () => {
-  assert.match(GEAR, /<kbd>⌘\/Ctrl<\/kbd> \+ <kbd>O<\/kbd>[\s\S]*?quick switcher/);
+// ── discoverability: the settings' shortcut list names all three hotkeys ───────────────────
+test("the gear's shortcut rows document Cmd/Ctrl+O, Cmd/Ctrl+Shift+O and Cmd/Ctrl+P", () => {
+  assert.match(GEAR, /<kbd>⌘\/Ctrl<\/kbd> \+ <kbd>O<\/kbd>[\s\S]*?Jump to a session \(quick switcher\)/);
+  assert.match(GEAR, /<kbd>⌘\/Ctrl<\/kbd> \+ <kbd>Shift<\/kbd> \+ <kbd>O<\/kbd>[\s\S]*?New session picker/);
   assert.match(GEAR, /<kbd>⌘\/Ctrl<\/kbd> \+ <kbd>P<\/kbd>[\s\S]*?Command palette/);
 });

--- a/ui/webview/palette.ts
+++ b/ui/webview/palette.ts
@@ -1,15 +1,35 @@
-// The command palette overlay (Cmd/Ctrl+P) — Obsidian's shape: a card centered near the top,
-// a type-ahead input, fuzzy-filtered rows with highlighted matches, arrows + Enter, Esc or a
-// backdrop click to close. It lives in the SHELL document, so like the network panel it
-// composites over the real panes: one centered card, the standard 0.55 dim, and the dashboard
-// unchanged behind it (the one modal treatment, the user 2026-08-08).
-import { commandList, PaletteCommand } from "./commands";
+// The quick-pick overlay behind BOTH shell hotkeys — Obsidian's shape: a card centered near
+// the top, a type-ahead input, fuzzy-filtered rows with highlighted matches, arrows + Enter,
+// Esc or a backdrop click to close. Cmd/Ctrl+P opens it over the command registry; Cmd/Ctrl+O
+// opens it over the sessions (the jump switcher — palette-main.ts builds those items). It
+// lives in the SHELL document, so like the network panel it composites over the real panes:
+// one centered card, the standard 0.55 dim, and the dashboard unchanged behind it (the one
+// modal treatment, the user 2026-08-08).
+import { commandList } from "./commands";
 import { fuzzyMatch, FuzzyHit, FuzzyRange } from "./fuzzy";
 
+// One row of a pick list. Commands map onto this 1:1; session rows add a color dot and a dim
+// directory tail. run() is the whole contract — the palette closes itself, then runs it.
+export type PickItem = {
+  title: string;   // what's shown and fuzzy-matched
+  kbd?: string;    // display-only hotkey chip ("⌘O")
+  dot?: string;    // CSS color for a leading session dot
+  dim?: string;    // dim tail after the title (a session's directory basename)
+  run: () => void;
+};
+
+export type PickSpec = {
+  placeholder: string;
+  items: PickItem[];
+  // Shift+Enter, when the mode has a secondary action (the switcher's "new session…").
+  // Rendered as a footer hint so the key is discoverable, Obsidian-style.
+  altEnter?: { label: string; run: () => void };
+};
+
 // The modal vocabulary the shell's panels share (#rnet-panel / #rerr-panel): #252526 card,
-// 1px #3a3a3a border, radius 10, 13px system-ui body, 11px chips. Injected as a <style> tag by
-// ensure() so the palette ships as ONE dist bundle with no separate <link> to plumb through
-// _landing. z-index 300: over every shell panel (net 200, log 210, restart report 220, usage 290).
+// 1px #3a3a3a border, radius 10, 13px system-ui body, 11px chips/dims. Injected as a <style>
+// tag by ensure() so the palette ships as ONE dist bundle with no separate <link> to plumb
+// through _landing. z-index 300: over every shell panel (net 200, log 210, report 220, usage 290).
 const CSS =
   "#rpal-back{position:fixed;inset:0;z-index:300;display:flex;align-items:flex-start;justify-content:center;" +
   "padding:14vh 16px 16px;background:rgba(0,0,0,0.55);box-sizing:border-box}" +
@@ -23,18 +43,29 @@ const CSS =
   "#rpal-list{flex:1 1 auto;overflow-y:auto;margin-top:6px}" +
   ".rpal-row{display:flex;align-items:center;gap:10px;padding:5px 10px;border-radius:6px;cursor:pointer}" +
   ".rpal-row.active{background:rgba(156,210,255,0.12)}" +   // accent-blue focus cue, not a status color
+  ".rpal-dot{flex:0 0 auto;width:8px;height:8px;border-radius:50%}" +
   ".rpal-title{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}" +
   ".rpal-title b{color:var(--accent,#9cd2ff);font-weight:600}" +
+  ".rpal-dim{flex:0 1 auto;color:#9aa0a6;font-size:11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}" +
   ".rpal-kbd{flex:0 0 auto;color:#9aa0a6;font-size:11px;border:1px solid #3a3a3a;border-radius:4px;padding:0 5px}" +
-  ".rpal-empty{padding:8px 10px;color:#9aa0a6}";
+  ".rpal-empty{padding:8px 10px;color:#9aa0a6}" +
+  ".rpal-hint{flex:0 0 auto;padding:4px 10px 0;color:#9aa0a6;font-size:11px}";
 
-export type Palette = { open(): void; close(): void; toggle(): void; isOpen(): boolean };
+export type Palette = {
+  open(): void;                    // command mode, over the registry (Cmd+P)
+  openPick(spec: PickSpec): void;  // any mode — the session switcher passes its own items
+  close(): void;
+  toggle(): void;                  // command-mode toggle (Cmd+P)
+  isOpen(): boolean;
+};
 
 export function initPalette(opts?: { onClose?: () => void }, doc: Document = document): Palette {
   let back: HTMLElement | null = null;
   let input: HTMLInputElement;
   let list: HTMLElement;
-  let rows: { cmd: PaletteCommand; el: HTMLElement }[] = [];
+  let hint: HTMLElement;
+  let spec: PickSpec = { placeholder: "", items: [] };
+  let rows: { item: PickItem; el: HTMLElement }[] = [];
   let active = 0;
 
   // Built once, lazily; the palette is not subject to the dashboard's re-render pushes (the
@@ -51,12 +82,15 @@ export function initPalette(opts?: { onClose?: () => void }, doc: Document = doc
     panel.id = "rpal";
     input = doc.createElement("input");
     input.id = "rpal-in";
-    input.placeholder = "Type a command…";
     input.spellcheck = false;
     list = doc.createElement("div");
     list.id = "rpal-list";
+    hint = doc.createElement("div");
+    hint.className = "rpal-hint";
+    hint.hidden = true;
     panel.appendChild(input);
     panel.appendChild(list);
+    panel.appendChild(hint);
     back.appendChild(panel);
     doc.body.appendChild(back);
     input.addEventListener("input", () => render(input.value));
@@ -70,7 +104,7 @@ export function initPalette(opts?: { onClose?: () => void }, doc: Document = doc
     list.addEventListener("click", (e) => {
       const row = (e.target as HTMLElement).closest(".rpal-row");
       const hit = rows.find((r) => r.el === row);
-      if (hit) run(hit.cmd);
+      if (hit) run(hit.item);
     });
   }
 
@@ -89,32 +123,44 @@ export function initPalette(opts?: { onClose?: () => void }, doc: Document = doc
   }
 
   function render(query: string): void {
-    const hits = commandList()
-      .map((cmd) => ({ cmd, hit: fuzzyMatch(query, cmd.title) }))
-      .filter((x): x is { cmd: PaletteCommand; hit: FuzzyHit } => !!x.hit);
-    hits.sort((a, b) => b.hit.score - a.hit.score);   // stable sort: ties keep registration order
+    const hits = spec.items
+      .map((item) => ({ item, hit: fuzzyMatch(query, item.title) }))
+      .filter((x): x is { item: PickItem; hit: FuzzyHit } => !!x.hit);
+    hits.sort((a, b) => b.hit.score - a.hit.score);   // stable sort: ties keep the given order
     list.textContent = "";
     rows = [];
-    for (const { cmd, hit } of hits) {
+    for (const { item, hit } of hits) {
       const row = doc.createElement("div");
       row.className = "rpal-row";
+      if (item.dot) {
+        const d = doc.createElement("span");
+        d.className = "rpal-dot";
+        d.style.background = item.dot;
+        row.appendChild(d);
+      }
       const title = doc.createElement("span");
       title.className = "rpal-title";
-      title.appendChild(highlight(cmd.title, hit.ranges));
+      title.appendChild(highlight(item.title, hit.ranges));
       row.appendChild(title);
-      if (cmd.kbd) {
+      if (item.dim) {
+        const m = doc.createElement("span");
+        m.className = "rpal-dim";
+        m.textContent = item.dim;
+        row.appendChild(m);
+      }
+      if (item.kbd) {
         const k = doc.createElement("span");
         k.className = "rpal-kbd";
-        k.textContent = cmd.kbd;
+        k.textContent = item.kbd;
         row.appendChild(k);
       }
       list.appendChild(row);
-      rows.push({ cmd, el: row });
+      rows.push({ item, el: row });
     }
     if (!rows.length) {
       const empty = doc.createElement("div");
       empty.className = "rpal-empty";
-      empty.textContent = "No matching commands";
+      empty.textContent = "No matches";
       list.appendChild(empty);
     }
     setActive(0);
@@ -131,20 +177,36 @@ export function initPalette(opts?: { onClose?: () => void }, doc: Document = doc
     if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); close(); }
     else if (e.key === "ArrowDown") { e.preventDefault(); if (rows.length) setActive((active + 1) % rows.length); }
     else if (e.key === "ArrowUp") { e.preventDefault(); if (rows.length) setActive((active - 1 + rows.length) % rows.length); }
-    else if (e.key === "Enter") { e.preventDefault(); const r = rows[active]; if (r) run(r.cmd); }
+    else if (e.key === "Enter" && e.shiftKey && spec.altEnter) {
+      e.preventDefault();
+      const alt = spec.altEnter;
+      close();   // close FIRST, same as run(): the secondary action opens its own surface
+      alt.run();
+    }
+    else if (e.key === "Enter") { e.preventDefault(); const r = rows[active]; if (r) run(r.item); }
   }
 
-  function run(cmd: PaletteCommand): void {
-    close();   // close FIRST: a command that opens its own modal must not land under the palette
-    cmd.run();
+  function run(item: PickItem): void {
+    close();   // close FIRST: an action that opens its own modal must not land under the palette
+    item.run();
   }
 
-  function open(): void {
+  function openPick(s: PickSpec): void {
     ensure();
+    spec = s;
+    input.placeholder = s.placeholder;
+    hint.hidden = !s.altEnter;
+    if (s.altEnter) hint.textContent = "↵ open · shift ↵ " + s.altEnter.label;
     back!.hidden = false;
     input.value = "";
     render("");
     input.focus();
+  }
+  function open(): void {
+    openPick({
+      placeholder: "Type a command…",
+      items: commandList().map((c) => ({ title: c.title, kbd: c.kbd, run: c.run })),
+    });
   }
   function close(): void {
     if (!back || back.hidden) return;
@@ -154,5 +216,5 @@ export function initPalette(opts?: { onClose?: () => void }, doc: Document = doc
   function isOpen(): boolean { return !!back && !back.hidden; }
   function toggle(): void { if (isOpen()) close(); else open(); }
 
-  return { open, close, toggle, isOpen };
+  return { open, openPick, close, toggle, isOpen };
 }

--- a/ui/webview/picker-host-list.test.ts
+++ b/ui/webview/picker-host-list.test.ts
@@ -72,18 +72,21 @@ test("a reachable host with no sessions says so, instead of looking like a faile
 });
 
 // ── the picker is a dialog over the dashboard, not the chat pane blown up (the user 2026-07-29) ──────
-// The shell lifts this iframe full-window so the session list gets the whole height, but the iframe is
-// opaque, so the picker read as the chat expanded to fill the screen. While lifted the page steps aside
-// and only the picker draws, leaving the timeline, feed and chat visible behind it.
-test("the page steps aside while the shell has it lifted", () => {
+// The shell lifts this iframe full-window so the session list gets the whole height. While lifted the
+// page pins its BODY to the chat pane's old screen rect and keeps painting (2026-08-08: hiding the
+// content instead left a black hole where the pane was), so the whole dashboard — the transcript
+// included — stays visible behind the dim. Details pinned in palette.test.ts.
+test("the page keeps painting in place while the shell has it lifted", () => {
   const STYLES = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
   assert.match(RENDER, /document\.body\.classList\.toggle\("picker-lifted", on\);/);
   assert.match(RENDER, /window\.parent\.postMessage\(\{ romp: "picker", on \}, "\*"\);/, "the shell still lifts it");
-  assert.match(STYLES, /body\.picker-lifted \{ background: transparent !important; \}/);
-  assert.match(STYLES, /body\.picker-lifted > \* \{ visibility: hidden; \}/);
-  assert.match(STYLES, /body\.picker-lifted > #picker \{ visibility: visible; \}/);
+  assert.match(STYLES, /html\.picker-lifted \{ background: transparent !important; \}/);
+  assert.match(STYLES, /body\.picker-lifted \{\s*\n\s*position: fixed;/);
+  // only an unmeasurable pane (hidden / cross-origin parent) hides the content instead
+  assert.match(STYLES, /body\.picker-lifted\.pane-gone > \* \{ visibility: hidden; \}/);
+  assert.match(STYLES, /body\.picker-lifted\.pane-gone > #picker \{ visibility: visible; \}/);
   // visibility, not display: nothing reflows, so the chat is exactly where it was when the picker closes
-  assert.doesNotMatch(STYLES, /body\.picker-lifted > \* \{ display: none/);
+  assert.doesNotMatch(STYLES, /body\.picker-lifted\.pane-gone > \* \{ display: none/);
   // …and it centres like a modal instead of hugging the top edge
   assert.match(STYLES, /body\.picker-lifted > #picker \{ align-items: center;/);
   // two thirds of the window: the list is what you came to read

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3942,15 +3942,20 @@ window.addEventListener("keydown", (e) => {
     if (focusComposerOrAsk()) e.preventDefault();   // the picker card if one's up, else the message box
   }
 });
-// Cmd/Ctrl+O — toggle the session quick switcher (the picker), from anywhere in the page INCLUDING
-// the composer, the way Obsidian's quick switcher opens over the editor (the user 2026-08-08). The
-// page may claim this combo: preventDefault cancels the browser's own Cmd+O (open file) while this
-// tab has focus, and only there. Capture + stopPropagation so it wins over focused-control handlers —
-// and so the combined shell's per-pane capture handler (palette-main.ts, which relays the same combo
-// from the OTHER panes) never double-fires when focus is already in this document: window-capture
-// runs before document-capture, so this handler acts and stops the event first.
+// Cmd/Ctrl+O and Cmd/Ctrl+Shift+O — the in-PAGE fallback, from anywhere including the composer, the
+// way Obsidian's quick switcher opens over the editor (the user 2026-08-08). Inside the romp shell
+// this handler STANDS DOWN: the shell owns both combos (palette-main.ts — plain O is the session jump
+// switcher up in the shell document, Shift+O this picker), and its per-pane capture handler sees the
+// keystroke once this window-capture one declines to stop it. Standalone and in VS Code (no shell
+// handler on this document) both combos fall back to the picker here. preventDefault cancels the
+// browser's own Cmd+O (open file) while this tab has focus, and only there.
+function inRompShell(): boolean {
+  try { return !!(window.parent && window.parent !== window && window.parent.document.getElementById("chat-pane")); }
+  catch (e) { return false; }   // cross-origin parent (VS Code) — not the romp shell
+}
 window.addEventListener("keydown", (e) => {
-  if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey || (e.key || "").toLowerCase() !== "o") return;
+  if (!(e.metaKey || e.ctrlKey) || e.altKey || (e.key || "").toLowerCase() !== "o") return;
+  if (inRompShell()) return;   // the shell's handler on this document takes it from here
   e.preventDefault(); e.stopPropagation();
   if (pickerVisible()) closePicker(); else openPicker();
 }, true);
@@ -4098,15 +4103,37 @@ function revealSelfPane(): void {
 // Mirror the settings bridge: tell the shell to lift #f-chat over the whole window (body.picker-open) while
 // the picker is up, so the overlay fills the screen and the list gets the full viewport height. Standalone
 // (no parent) is a no-op.
+//
+// While lifted, this page keeps PAINTING its content at the chat pane's old screen rect (--pane-* vars,
+// measured from the shell's pane div): the transcript stays exactly where it was, live and visible under
+// the overlay's dim like every other pane. The first cut hid the page's content instead, which left a
+// BLACK HOLE where the chat pane had been — the one region of the dashboard that changed behind the
+// centered modal (the user 2026-08-08). A pane we can't measure (hidden, or a cross-origin parent like
+// VS Code) falls back to that hiding via .pane-gone.
+function liftPaneRect(): DOMRect | null {
+  try {
+    const p = window.parent?.document?.getElementById("chat-pane");
+    return p ? p.getBoundingClientRect() : null;
+  } catch (e) { return null; }   // cross-origin parent (VS Code) — no shell pane to measure
+}
+function placeLifted(): void {
+  const r = liftPaneRect();
+  const gone = !r || r.width < 40 || r.height < 40;
+  document.body.classList.toggle("pane-gone", gone);
+  if (gone) return;
+  const st = document.documentElement.style;
+  st.setProperty("--pane-x", r!.left + "px");
+  st.setProperty("--pane-y", r!.top + "px");
+  st.setProperty("--pane-w", r!.width + "px");
+  st.setProperty("--pane-h", r!.height + "px");
+}
+function onLiftResize(): void { if (pickerVisible()) placeLifted(); }   // panes track the window; follow them
 function signalPickerOverlay(on: boolean) {
   try {
     if (window.parent && window.parent !== window) {
       window.parent.postMessage({ romp: "picker", on }, "*");
-      // …and get out of the way while lifted (the user 2026-07-29). The shell lifts this iframe over the
-      // whole window, and the iframe is OPAQUE, so the picker read as the chat pane blown up to full
-      // screen rather than as a dialog over the dashboard. Dropping this page's background and hiding
-      // its own content leaves only the picker drawn, so the timeline, feed and chat stay visible
-      // (dimmed by the picker's own backdrop) behind a modal that floats over all of them.
+      if (on) { placeLifted(); window.addEventListener("resize", onLiftResize); }
+      else window.removeEventListener("resize", onLiftResize);
       // The class rides documentElement AND body (like the gear's rs-modal-open): THEME_CSS paints
       // html and body separately, and an opaque html kept the lift a full black-out (the user 2026-08-08).
       document.documentElement.classList.toggle("picker-lifted", on);
@@ -7501,7 +7528,20 @@ function restoreActiveDraftOnce(): void {
   renderComposerFiles(activeId);   // attachments persisted across the reload → thumbnails again → show its chip again
 }
 
+// Most-recently-ACTIVATED session ids, current first — the recency the shell's session jump
+// switcher (Cmd/Ctrl+O, palette-main.ts) sorts by, read directly off this window (same-origin).
+// Session order elsewhere stays kernel-authoritative; this is only "what did I look at last".
+const sessionMru: string[] = [];
+(window as any).__rompMru = sessionMru;
+function noteMru(id: string): void {
+  const i = sessionMru.indexOf(id);
+  if (i >= 0) sessionMru.splice(i, 1);
+  sessionMru.unshift(id);
+  if (sessionMru.length > 50) sessionMru.pop();
+}
+
 function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: string) {
+  noteMru(id);
   if (activeId === id && anchor == null && anchorT == null) return; // already active, nothing to do
   closeMetaMenu(); // an open model/effort menu targets the tab we're leaving
   pendingAnchorT = anchorT ?? null;
@@ -8020,11 +8060,18 @@ window.addEventListener("message", (e: MessageEvent) => {
       if (di) { di.value = m.path; di.focus(); }
     }
   }
-  // toggle:true is the hotkey form (Cmd/Ctrl+O relayed by the shell): a second press closes an open
-  // picker instead of re-opening it, so the key behaves like Obsidian's quick switcher.
+  // toggle:true is the hotkey form (Cmd/Ctrl+Shift+O relayed by the shell): a second press closes an
+  // open picker instead of re-opening it.
   else if (m.type === "openPicker") {
     if (m.toggle && pickerVisible()) closePicker();
     else openPicker(!!m.pick, m.prompt, !!m.allowNew);
+  }
+  // The shell's session jump switcher (Cmd/Ctrl+O) picked a session: an open tab activates like a
+  // feed jump (the `focus` path above); one without a tab opens through the host, the exact message
+  // a picker row sends.
+  else if (m.type === "jumpSession" && typeof m.id === "string") {
+    if (order.includes(m.id)) { revealSelfPane(); closingTabs.delete(m.id); setActive(m.id); }
+    else if (vscodeApi) vscodeApi.postMessage({ type: "openSession", id: m.id });
   }
   // The host asks US to confirm (in-page, no native dialogs): ending a live
   // session on tab-close, and reviving a dead one on open.

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1760,16 +1760,26 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
 @keyframes tx-starting-spin { to { transform: rotate(-360deg); } }
 @media (prefers-reduced-motion: reduce) { .tx-starting-swirl { animation: none; } }
 
-/* LIFTED over the dashboard (the user 2026-07-29): while the shell has this iframe full-window, the page
-   itself steps aside — no background, and its own content hidden — so what remains on screen is the
-   picker alone, floating over the panes behind it. Without this the opaque chat page covered the
-   timeline and feed, which is why the picker read as the chat expanded to full screen instead of as a
-   dialog. `visibility` (not display) so nothing reflows: layout is untouched, and the chat is exactly
-   where it was when the picker closes. */
-html.picker-lifted { background: transparent !important; }   /* THEME_CSS paints html AND body — both must step aside */
-body.picker-lifted { background: transparent !important; }
-body.picker-lifted > * { visibility: hidden; }
-body.picker-lifted > #picker { visibility: visible; }
+/* LIFTED over the dashboard (the user 2026-07-29, reworked 2026-08-08): while the shell has this iframe
+   full-window, the page pins its BODY to the chat pane's old screen rect (--pane-* vars set by
+   placeLifted() from the shell's pane div) and keeps painting. The transcript therefore stays exactly
+   where it was — live and visible under the picker's dim like every other pane — and the html around the
+   body stays transparent, so the rest of the dashboard shows through the full-window iframe. (The first
+   cut hid the page's content instead, which left a black hole where the chat pane had been.) #picker is a
+   position:fixed child of the body, and the body has no transform, so the overlay still spans and dims
+   the WHOLE viewport. */
+html.picker-lifted { background: transparent !important; }   /* THEME_CSS paints html AND body — html must step aside */
+body.picker-lifted {
+  position: fixed;
+  left: var(--pane-x, 0); top: var(--pane-y, 0);
+  width: var(--pane-w, 100%); height: var(--pane-h, 100%);
+  overflow: hidden;
+  background: var(--bg);   /* the body now paints the chat exactly where the pane was */
+}
+/* No measurable pane to stand in for (the pane is hidden, or the parent is cross-origin — VS Code):
+   fall back to hiding the page's own content so only the picker draws. */
+body.picker-lifted.pane-gone > * { visibility: hidden; }
+body.picker-lifted.pane-gone > #picker { visibility: visible; }
 /* centred, like every other modal. Top-aligned made sense when this filled the screen and the list
    wanted every pixel of height; as a dialog over the dashboard it should sit in the middle. */
 body.picker-lifted > #picker { align-items: center; padding: 24px 16px; }


### PR DESCRIPTION
## What

**Black-hole fix (user report).** The new-session picker opened centered but the chat pane behind it went black; settings did the same over the feed pane. Root cause: the lift moves the pane's iframe full-window and the page *hid* its own content, leaving a dark hole where the pane had been — the network/Log modals never move anything, so they didn't have it. While lifted, the page now pins its body to the pane's old screen rect (`--pane-*` vars measured from the shell's pane div, re-measured on resize) and keeps painting: the transcript/feed stay live and visible under the standard dim, pixel-identical to the shell-native modals. Unmeasurable panes (hidden, or cross-origin parent = VS Code) fall back to hiding content (`.pane-gone` / `.rs-pane-gone`). This should also cure the reported stale "extra faded tabs until hover" repaint artifact, which the hide/unhide cycle caused.

**Cmd+O split (user request, Obsidian semantics).** Cmd/Ctrl+O is now a session **jump switcher**: sessions most-recently-used first (render.ts tracks an activation MRU on `window.__rompMru`), fuzzy filter, Enter switches — current session excluded so a bare Cmd+O ⏎ toggles to the previous session; Shift+Enter hands off to the new-session picker. The **full picker** (create, directory, backend, host) moves to Cmd/Ctrl+Shift+O, and both live in the command palette. The palette generalizes to a two-mode quick-pick (commands / sessions) with session color dots and directory tails. Jumping routes through a new `jumpSession` message: open tabs activate like a feed jump; closed sessions open via the host's existing `openSession` path. Standalone/VS Code chat pages keep the picker fallback on both combos; inside the shell the in-page handler stands down so the shell owns the keys.

CLAUDE.md's centered-modal rule updated to record the paint-in-place mechanics; gear's shortcut list documents all three combos.

## Tests

- `palette.test.ts` rewritten for the new pins (switcher MRU/exclusion/fail-loud, key split, in-place lift for both surfaces).
- `picker-host-list.test.ts` lift pins updated; `test_kernel.py` settings pins now assert `rs-lifted`/`rs-pane-gone` and `placeLifted`.
- Suites green locally: 3947 Python + 1715 node; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)