### PR TITLE
Postal mail delivers through Claude Code's inbox socket, with a 2.1.224 floor nudge

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1325,6 +1325,23 @@ fi
 [[ -f "$HOME/.claude/romp-session-prompt.md" ]] && \
     claude_cmd="$claude_cmd --append-system-prompt \"\$(cat $HOME/.claude/romp-session-prompt.md)\""
 
+# Claude Code ≥ 2.1.224 gives every session an inbox socket the kernel can
+# deliver agent mail through — instant, and it never touches a half-typed
+# draft. The CLI's inbound gate may HOLD mail from an unverifiable sender
+# (the kernel) when the session runs a bypass-class permission mode, and a
+# held message quietly expires — so accept it explicitly at launch, the
+# CLI's documented setting for unattended inboxes (the user approved this
+# 2026-08-08: same-user processes can already reach the pane itself via
+# send-keys with FULL user authority; socket mail arrives with LESS — the
+# CLI labels it another-session traffic and strips approval power).
+# @romp-inbound-accept (tagged at create, below) tells the kernel this
+# launch carries the setting; an older CLI gets neither flag nor tag, and
+# mail keeps arriving by pane injection exactly as before.
+claude_meets_floor=false
+if _romp_claude_meets_floor; then
+    claude_meets_floor=true
+    claude_cmd="$claude_cmd --settings '{\"crossSessionInbound\":\"accept\"}'"
+fi
 # An old Claude Code falls back to pane-injected agent mail — say so once here,
 # where a session is being launched (see the version-floor helpers up top).
 _romp_claude_floor_nudge
@@ -1345,6 +1362,12 @@ else
 
     # Tag it as a romp session so the dashboard / hook / attach find it.
     tmux set -t "$name" @romp 1
+
+    # The kernel's inbox-socket delivery leg keys on this tag: it marks a launch
+    # that passed the inbound-accept setting (above), i.e. a session whose inbox
+    # socket can never hold-and-drop the kernel's mail. Written here, by the same
+    # code path that added the setting, so tag and setting can never disagree.
+    if $claude_meets_floor; then tmux set -t "$name" @romp-inbound-accept 1; fi
 
     # Install the tmux glue romp needs (hooks/bindings server-wide if absent,
     # status line + tab title on this session) — works on a stock tmux.

--- a/bin/romp
+++ b/bin/romp
@@ -40,6 +40,63 @@ ROMP_NAMES_DIR="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/na
 ROMP_ARCHIVE_DIR="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/archive"
 ROMP_CAPTIONS_DIR="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/captions"
 
+# --- Claude Code version floor ---------------------------------------------
+# Agent mail delivers through Claude Code's per-session inbox socket, which
+# appeared in 2.1.224; an older CLI still works, but delivery falls back to
+# the slower, more fragile pane injection. `claude --version` costs ~1s of
+# node startup, so the answer is cached keyed on the binary's mtime and
+# re-read only when the binary actually changes (an event, not a TTL).
+ROMP_CLAUDE_FLOOR="2.1.224"
+
+_romp_claude_version() {
+    local bin mtime cache line ver
+    bin="$(command -v claude 2>/dev/null || true)"
+    [[ -n "$bin" ]] || { echo ""; return 0; }
+    mtime="$(stat -c %Y "$bin" 2>/dev/null || stat -f %m "$bin" 2>/dev/null || echo 0)"
+    cache="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/claude-version"
+    if line="$(cat "$cache" 2>/dev/null)" && [[ "$line" == "$mtime "* ]]; then
+        echo "${line#* }"; return 0
+    fi
+    ver="$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    # cache only a real answer — a transient --version failure shouldn't stick until the next update
+    if [[ -n "$ver" ]]; then
+        { mkdir -p "$(dirname "$cache")" && printf '%s %s\n' "$mtime" "$ver" > "$cache"; } 2>/dev/null || true
+    fi
+    echo "$ver"
+}
+
+_romp_version_lt() {
+    # true when dotted version $1 < $2 (numeric per part; missing parts are 0)
+    local IFS=. i x y; local -a a b
+    read -r -a a <<<"$1"; read -r -a b <<<"$2"
+    for i in 0 1 2; do
+        x="${a[i]:-0}"; y="${b[i]:-0}"
+        if (( 10#$x < 10#$y )); then return 0; fi
+        if (( 10#$x > 10#$y )); then return 1; fi
+    done
+    return 1
+}
+
+_romp_claude_meets_floor() {
+    # unknown version (no claude on PATH, unparsable output) → below the floor:
+    # callers keep the safe old path rather than assuming a capability
+    local v; v="$(_romp_claude_version)"
+    [[ -n "$v" ]] || return 1
+    if _romp_version_lt "$v" "$ROMP_CLAUDE_FLOOR"; then return 1; fi
+    return 0
+}
+
+_romp_claude_floor_nudge() {
+    # An informative line, not a gate: romp still runs and mail still delivers
+    # (by pane injection); the nudge names what the upgrade buys and the command.
+    local v; v="$(_romp_claude_version)"
+    [[ -n "$v" ]] || return 0
+    if _romp_version_lt "$v" "$ROMP_CLAUDE_FLOOR"; then
+        echo "[romp] Claude Code $v found; romp wants $ROMP_CLAUDE_FLOOR or newer so agent mail arrives instantly (older versions fall back to slower typing into the pane). Upgrade with: claude update" >&2
+    fi
+    return 0
+}
+
 _romp_record() {   # <sid> <name> <dir> [bg] [fg] — write/replace the map entry
     local sid="$1" nm="$2" dir="$3" bg="${4:-}" fg="${5:-}"
     [[ -n "$sid" ]] || return 0
@@ -732,6 +789,7 @@ if [[ $# -eq 0 ]]; then
         exit 1
     fi
     _url="http://127.0.0.1:$_kport/?token=$_tok"
+    _romp_claude_floor_nudge
     # Is this a machine we could plausibly open a browser on? An ssh session or a Linux box with no
     # DISPLAY is headless — opening would silently do nothing, so say so instead of faking success.
     _headless=0
@@ -1266,6 +1324,10 @@ fi
 # the launch shell expands it at exec time (see respawn-pane below).
 [[ -f "$HOME/.claude/romp-session-prompt.md" ]] && \
     claude_cmd="$claude_cmd --append-system-prompt \"\$(cat $HOME/.claude/romp-session-prompt.md)\""
+
+# An old Claude Code falls back to pane-injected agent mail — say so once here,
+# where a session is being launched (see the version-floor helpers up top).
+_romp_claude_floor_nudge
 
 # --- Launch or attach ---
 if tmux has-session -t "=$name" 2>/dev/null; then

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -116,6 +116,39 @@ read and render. This is the producer/consumer split the whole system rests on,
 collapsed into a single process for the common (one-machine) case while preserving
 single-writer.
 
+### How mail reaches a session
+
+The bus stores mail per recipient (a Maildir) and the kernel owns the wake
+(`POST /deliver`). Three delivery legs, chosen by what the recipient is:
+
+1. **SDK session** — the kernel enqueues the banner on the session's SDK input
+   queue. First-class, nothing to scrape.
+2. **tmux session on Claude Code ≥ 2.1.224** — one JSON user record written to
+   the session's **inbox socket**, the per-session Unix socket the CLI binds and
+   registers (with its session id) in `~/.claude/sessions/<pid>.json`. The
+   kernel joins that registry on the session's current transcript id
+   (`lastSid`), connects, writes one line, done: instant, wakes an idle session,
+   delivers between tool calls mid-turn, and never touches the composer, so a
+   half-typed draft survives with no stash dance. The CLI treats socket arrivals
+   as another-session traffic; its inbound gate can HOLD mail from an
+   unverifiable sender (the kernel is one) when the session runs a bypass-class
+   permission mode, and a held message silently expires after ~5 minutes — and
+   the socket acks nothing, so a hold would read as delivered. That is why
+   `bin/romp` launches sessions with the CLI's inbound-accept setting
+   (`crossSessionInbound: accept`) and tags them `@romp-inbound-accept`, and the
+   kernel takes this leg ONLY for tagged sessions: the tag is written by the
+   same launch that made holds impossible, so tag and setting can never
+   disagree. Security shape: the socket is owner-only (0600 inside a 0700 dir),
+   unreachable from off-machine and from other local users; a same-user process
+   could already type into any pane via `tmux send-keys` with FULL user
+   authority, while socket mail arrives explicitly labeled as peer traffic with
+   approval power stripped — the lower-privilege injection path of the two.
+3. **Everything else** (older CLI, untagged launch, socket gone) —
+   draft-preserving pane injection at a live ❯ prompt, with the Stop-hook drain
+   (`hooks/romp-postal-drain.sh`) as the turn-boundary backstop. Unchanged, and
+   still the fallback whenever leg 2 fails for any reason: non-delivery is
+   caught by the maildir claim/retry and stuck-mail warnings either way.
+
 ## The two inputs
 
 1. **Durable judge records** (`docs/judges.md` writes these):

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -89,6 +89,15 @@ romp mail remote                 # connect this remote machine to your laptop's 
 | `check_sent()` | Whether your sent messages were read yet |
 | `recall_message(to, id?)` | Unsend a message the recipient hasn't read |
 
+### Claude Code 2.1.224 or newer
+
+Mail to a terminal (tmux) session delivers through Claude Code's per-session
+inbox socket, which the CLI added in 2.1.224: delivery is instant and never
+touches a half-typed draft. An older Claude Code still works — delivery falls
+back to typing the mail into the pane, which is slower and waits for a free
+prompt — and `romp` says so at launch, with the upgrade being one
+`claude update` away.
+
 ## Configuration
 
 ### Folder click, in your terminal or editor

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4777,6 +4777,22 @@ class TmuxBackend(sb.SessionBackend):
         state = (self.live_sessions().get(str(sid)) or {}).get("state", "")
         if state not in ("waiting", "idle", "working"):
             return False                                  # permission / unknown / picker → drain later
+        # Inbox-socket leg first (Claude Code ≥ 2.1.224): one JSON line to the CLI's own inbox
+        # socket — wakes an idle session, queues mid-turn, and never touches the composer, so
+        # every pane hazard below (copy-mode, no ❯ prompt, drafts) doesn't exist on this path.
+        # Gated on @romp-inbound-accept, the tag bin/romp writes at the same launch that passes
+        # the CLI --settings '{"crossSessionInbound":"accept"}': without that setting the CLI's
+        # inbound gate can HOLD an unverifiable sender's message and silently expire it after
+        # ~5min, and the socket sends no ack — a held-then-dropped banner would read as delivered
+        # here. The tag is written by the exact event that makes holds impossible, so it can
+        # never flap; untagged (old launch, old CLI) sessions keep pane injection unchanged.
+        try:
+            if self.show_var(name, "@romp-inbound-accept").strip() == "1":
+                sock = _messaging_socket_for(jd._sdk_last_sid(sid) or str(sid))
+                if sock and _socket_deliver(sock, text):
+                    return True
+        except Exception:
+            pass                                          # any socket hiccup → the pane path below
         if self.pane_in_mode(name):                       # scrolled up = copy-mode, where a paste's Enter is eaten
             self.send_keys(name, "-X", "cancel")          # exit it (drop to the live prompt) or bail
             if not _deliver_wait(lambda: not self.pane_in_mode(name), 1.0):
@@ -7497,6 +7513,73 @@ def _session_rows():
                     "lastSid": jd._sdk_last_sid(sid) or sid,
                     "working": notes.get(sid, ""), "backend": meta.get("backend", "")})
     return out
+
+
+# ── inbox-socket delivery (Claude Code ≥ 2.1.224) ──
+# The CLI binds a per-session Unix inbox socket and registers it — with its own session id and pid —
+# in ~/.claude/sessions/<pid>.json. One JSON line {"type":"user","message":{"role":"user","content":…}}
+# posted there injects a message with the CLI's own another-session framing: it wakes an idle session,
+# delivers between tool calls mid-turn, and never touches the composer, so a user's draft survives
+# with no stash dance. This is the CLI's designed external-injection surface (it prints exactly this
+# recipe in its startup log and exports the path to hooks as CLAUDE_CODE_MESSAGING_SOCKET). A session
+# on an older CLI has no registry row, so callers fall through to pane injection.
+
+
+def _claude_sessions_dir():
+    return os.environ.get("ROMP_CLAUDE_SESSIONS_DIR") or os.path.expanduser("~/.claude/sessions")
+
+
+def _messaging_socket_for(fsid):
+    """The inbox-socket path registered for CLI session id `fsid` (a romp row's lastSid), or None.
+    Rows are per-PID: a dead pid's row can linger (the CLI prunes lazily), and a resumed conversation
+    leaves the old pid's row behind with the same session id — so prefer a row whose pid is alive,
+    newest first. The real liveness proof stays the connect in _socket_deliver."""
+    fsid = str(fsid or "")
+    if not fsid:
+        return None
+    base = _claude_sessions_dir()
+    try:
+        names = os.listdir(base)
+    except OSError:
+        return None
+    rows = []
+    for n in names:
+        if not n.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(base, n)) as f:
+                d = json.load(f)
+        except Exception:
+            continue                                      # malformed/foreign row → skip
+        if not isinstance(d, dict) or d.get("sessionId") != fsid:
+            continue
+        sock = d.get("messagingSocketPath")
+        if isinstance(sock, str) and sock:
+            rows.append(d)
+    if not rows:
+        return None
+    rows.sort(key=lambda d: (bool(_pid_alive(d["pid"])) if isinstance(d.get("pid"), int) else False,
+                             d.get("startedAt") or 0), reverse=True)
+    return rows[0]["messagingSocketPath"]
+
+
+def _socket_deliver(sock_path, text, timeout=3.0):
+    """Post one user message down a session's inbox socket; True iff the write completed. Fire-and-
+    forget by design — the CLI acks nothing for a plain send. Returning True is still an honest
+    "injected": the caller only takes this path for sessions launched with the inbound-accept
+    setting (see TmuxBackend.deliver), where an accepted write cannot be held or dropped."""
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            s.settimeout(timeout)
+            s.connect(sock_path)
+            s.sendall((json.dumps({"type": "user", "message": {"role": "user", "content": str(text)}})
+                       + "\n").encode("utf-8"))
+        finally:
+            s.close()
+        return True
+    except OSError:
+        return False
 
 
 # ── deliver-time prompt-box parsing (ported from the postal bus; PURE — operate on a captured pane) ──

--- a/postal/README.md
+++ b/postal/README.md
@@ -6,7 +6,13 @@ each session gets (`claude/romp-postal.mcp.json`) and the shell CLI
 (`romp mail`); the `bin/romp-postal-service` symlink points here.
 
 The bus is a port-keyed singleton that self-restarts when its source changes.
-Delivery is turn-boundary–safe: mail lands via the Stop hook
-(`hooks/romp-postal-drain.sh`) so it never interleaves with a working turn.
+Delivery is push-first with a turn-boundary backstop: the kernel wakes the
+recipient (`POST /deliver`) — an SDK enqueue, or for tmux sessions on Claude
+Code ≥ 2.1.224 one JSON line down the session's own inbox socket (instant,
+draft-safe; only for launches tagged `@romp-inbound-accept`, whose inbound gate
+provably can't hold-and-drop), else draft-preserving pane injection — and the
+Stop hook (`hooks/romp-postal-drain.sh`) drains whatever a wake couldn't land,
+so mail never interleaves with a working turn. The mechanics live in
+`docs/read-side.md` ("How mail reaches a session").
 User-facing guide: `docs/guide/postal-service.md`; agent-facing usage lives in
 the `romp-postal` skill (`claude/skills/romp-postal/`).

--- a/tests/romp-claude-floor.bats
+++ b/tests/romp-claude-floor.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+# Claude Code version floor (2.1.224): agent mail delivers through the CLI's per-session
+# inbox socket from that version on; an older CLI still works but falls back to pane
+# injection. bin/romp says so once at the user-facing entrypoints (bare `romp`, launches)
+# and caches the `claude --version` answer keyed on the binary's mtime, so the ~1s node
+# startup is paid once per installed binary, not on every romp command.
+
+ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    export XDG_STATE_HOME="$TEST_DIR/state"
+    mkdir -p "$XDG_STATE_HOME/romp"
+    printf 'TESTTOKEN123\n' > "$XDG_STATE_HOME/romp/serve-token"
+    export ROMP_KERNEL_PORT=29855
+    MOCK="$TEST_DIR/mock"; mkdir -p "$MOCK"
+    export PATH="$MOCK:$PATH"
+    export ROMP_OPENER=            # never open a real browser
+    export CLAUDE_CALLS="$TEST_DIR/claude-calls.log"
+    unset SSH_CONNECTION SSH_TTY
+    export DISPLAY=":0"
+}
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+_stub_claude() {   # $1 = the version the stub reports
+    cat > "$MOCK/claude" <<STUB
+#!/usr/bin/env bash
+echo "called \$*" >> "$CLAUDE_CALLS"
+echo "$1 (Claude Code)"
+STUB
+    chmod +x "$MOCK/claude"
+}
+
+@test "old claude: bare romp prints the upgrade nudge and still prints the URL" {
+    _stub_claude "2.1.220"
+    run "$ROMP_SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"2.1.220"* ]]
+    [[ "$output" == *"claude update"* ]]
+    [[ "$output" == *"http://127.0.0.1:29855/?token=TESTTOKEN123"* ]]   # the URL contract holds
+}
+
+@test "new claude: no nudge" {
+    _stub_claude "2.1.226"
+    run "$ROMP_SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"claude update"* ]]
+}
+
+@test "equal to the floor counts as meeting it" {
+    _stub_claude "2.1.224"
+    run "$ROMP_SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"claude update"* ]]
+}
+
+@test "unparsable claude --version: silent, and nothing cached" {
+    cat > "$MOCK/claude" <<'STUB'
+#!/usr/bin/env bash
+echo "flimflam"
+STUB
+    chmod +x "$MOCK/claude"
+    run "$ROMP_SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"claude update"* ]]
+    [ ! -f "$XDG_STATE_HOME/romp/claude-version" ]   # a transient failure must not stick
+}
+
+@test "the version answer is cached on the binary's mtime (one spawn, not two)" {
+    _stub_claude "2.1.220"
+    run "$ROMP_SCRIPT"; [ "$status" -eq 0 ]
+    run "$ROMP_SCRIPT"; [ "$status" -eq 0 ]
+    [ "$(grep -c 'called --version' "$CLAUDE_CALLS")" -eq 1 ]
+    [[ "$output" == *"claude update"* ]]             # the nudge still fires, from the cache
+}
+
+@test "a replaced (updated) binary re-reads its version" {
+    _stub_claude "2.1.220"
+    run "$ROMP_SCRIPT"
+    [[ "$output" == *"claude update"* ]]
+    sleep 1                                          # whole-second mtimes on some filesystems
+    _stub_claude "2.1.226"
+    run "$ROMP_SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"claude update"* ]]
+}

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -71,6 +71,12 @@ exit 0
 MOCK
     chmod +x "$MOCK_DIR/tmux"
 
+    # Hermetic claude: the launch path probes `claude --version` for the 2.1.224
+    # floor (the inbound-accept setting + @romp-inbound-accept tag) — a dev
+    # machine's real claude would nondeterministically flip those on. Pin a
+    # modern version; per-test override via _stub_claude.
+    _stub_claude "2.1.226"
+
     export PATH="$MOCK_DIR:$PATH"
     unset TMUX            # default: outside tmux → attach-session branch
     # Hermetic HOME: bin/romp probes $HOME/.claude/romp-postal.mcp.json (would
@@ -92,6 +98,16 @@ teardown() {
 # Helper — runs romp with merged stdout+stderr so BATS captures errors
 run_romp() {
     "$ROMP_SCRIPT" "$@" 2>&1
+}
+
+# Helper — a fake `claude` reporting the given version (the launch path only ever
+# runs `claude --version`; the exec line itself lands in the tmux mock's log)
+_stub_claude() {
+    cat > "$MOCK_DIR/claude" <<STUB
+#!/usr/bin/env bash
+echo "$1 (Claude Code)"
+STUB
+    chmod +x "$MOCK_DIR/claude"
 }
 
 # ─── Launch tests ────────────────────────────────────────────────────
@@ -116,6 +132,26 @@ run_romp() {
     # handed to the pane with respawn-pane (atomic), not typed with send-keys.
     grep -qE 'tmux respawn-pane -k -t myproject exec claude --name "myproject" --session-id [0-9a-f-]{36}' "$MOCK_LOG"
     grep -q 'tmux attach-session -t myproject' "$MOCK_LOG"
+}
+
+@test "new -t on a 2.1.224+ claude: inbound-accept setting + @romp-inbound-accept tag" {
+    # The kernel's inbox-socket delivery leg fires only for launches that passed the
+    # CLI's inbound-accept setting (an unverifiable sender's mail can otherwise be
+    # held and silently expire); the tag records exactly those launches — one code
+    # path writes both, so they can never disagree. Setup pins claude at 2.1.226.
+    run run_romp new -t myproject
+    [ "$status" -eq 0 ]
+    grep -qF -- "--settings '{\"crossSessionInbound\":\"accept\"}'" "$MOCK_LOG"
+    grep -q 'tmux set -t myproject @romp-inbound-accept 1' "$MOCK_LOG"
+}
+
+@test "new -t on an old claude: no setting, no tag, one upgrade nudge" {
+    _stub_claude "2.1.220"
+    run run_romp new -t myproject
+    [ "$status" -eq 0 ]
+    ! grep -q -- '--settings' "$MOCK_LOG"
+    ! grep -q -- '@romp-inbound-accept' "$MOCK_LOG"
+    [[ "$output" == *"claude update"* ]]     # the informative floor line, not a failure
 }
 
 @test "launch hands the exec line to respawn-pane, never typed via send-keys (dropped-char bug)" {
@@ -203,7 +239,10 @@ run_romp() {
     [ -n "$line" ]
     # no shell metacharacters survive in the exec line
     ! grep -qE '[$();]' <<<"$line"
-    # exactly the two quotes that wrap --name "<name>", no injected extras
+    # exactly the two quotes that wrap --name "<name>", no injected extras. The
+    # fixed --settings tail romp itself appends carries its own JSON quotes — a
+    # trusted constant, not name-derived — so strip it before counting.
+    line="${line%%--settings*}"
     [ "$(grep -o '"' <<<"$line" | wc -l | tr -d ' ')" -eq 2 ]
 }
 

--- a/tests/test_kernel_socket_deliver.py
+++ b/tests/test_kernel_socket_deliver.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Postal mail's inbox-socket delivery leg (Claude Code >= 2.1.224). The CLI registers each
+session's inbox socket in ~/.claude/sessions/<pid>.json; one JSON line posted there injects a
+message without touching the composer. The kernel uses that leg ONLY for sessions tagged
+@romp-inbound-accept — the tag bin/romp writes at the same launch that passes the CLI's
+inbound-accept setting, so a held-then-dropped banner can never read as delivered (the socket
+sends no ack). Untagged sessions must keep today's pane injection untouched. Synthetic
+fixtures only."""
+import json
+import os
+import socket
+import tempfile
+import threading
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_socketleg", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+DEAD_PID = 4999999                       # above every platform's default pid ceiling
+
+
+def _registry_row(dirpath, pid, session_id, sock, started_at=1000):
+    with open(os.path.join(dirpath, "%d.json" % pid), "w") as f:
+        json.dump({"pid": pid, "sessionId": session_id, "messagingSocketPath": sock,
+                   "startedAt": started_at, "cwd": "/tmp/x", "kind": "interactive"}, f)
+
+
+class _OneShotInbox:
+    """A real AF_UNIX listener capturing everything one client writes (the CLI parses per
+    line and acks nothing for a plain send, so capture-and-close mirrors it exactly)."""
+
+    def __init__(self):
+        self.dir = tempfile.mkdtemp(prefix="rompsock", dir="/tmp")
+        self.path = os.path.join(self.dir, "inbox.sock")
+        self.got = []
+        self._srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._srv.bind(self.path)
+        self._srv.listen(1)
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self):
+        try:
+            conn, _ = self._srv.accept()
+        except OSError:
+            return
+        buf = b""
+        while True:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+        self.got.append(buf)
+        conn.close()
+
+    def wait(self, timeout=3.0):
+        self._thread.join(timeout)
+        return self.got
+
+    def close(self):
+        try:
+            self._srv.close()
+        except OSError:
+            pass
+
+
+class SocketRegistry(unittest.TestCase):
+    """_messaging_socket_for: the ~/.claude/sessions registry join."""
+
+    def setUp(self):
+        self.reg = tempfile.mkdtemp(prefix="rompreg")
+        os.environ["ROMP_CLAUDE_SESSIONS_DIR"] = self.reg
+
+    def tearDown(self):
+        os.environ.pop("ROMP_CLAUDE_SESSIONS_DIR", None)
+
+    def test_matches_session_id(self):
+        _registry_row(self.reg, 111, SID, "/tmp/cc-socks/111.sock")
+        self.assertEqual(km._messaging_socket_for(SID), "/tmp/cc-socks/111.sock")
+
+    def test_no_row_no_dir_and_malformed_rows(self):
+        self.assertIsNone(km._messaging_socket_for(SID))            # empty registry
+        with open(os.path.join(self.reg, "bad.json"), "w") as f:
+            f.write("{not json")                                     # malformed → skipped
+        _registry_row(self.reg, 222, "99999999-aaaa-bbbb-cccc-dddddddddddd", "/tmp/other.sock")
+        self.assertIsNone(km._messaging_socket_for(SID))             # other session's row
+        os.environ["ROMP_CLAUDE_SESSIONS_DIR"] = self.reg + "-missing"
+        self.assertIsNone(km._messaging_socket_for(SID))             # registry dir absent
+
+    def test_row_without_socket_is_not_a_hit(self):
+        with open(os.path.join(self.reg, "333.json"), "w") as f:
+            json.dump({"pid": 333, "sessionId": SID}, f)             # pre-2.1.224 CLI: no socket field
+        self.assertIsNone(km._messaging_socket_for(SID))
+
+    def test_prefers_live_pid_over_newer_dead_row(self):
+        # A resumed conversation leaves the old (dead) pid's row behind under the same
+        # session id; the join must pick the row whose pid is alive even when the stale
+        # row looks newer.
+        _registry_row(self.reg, os.getpid(), SID, "/tmp/cc-socks/alive.sock", started_at=1000)
+        _registry_row(self.reg, DEAD_PID, SID, "/tmp/cc-socks/dead.sock", started_at=2000)
+        self.assertEqual(km._messaging_socket_for(SID), "/tmp/cc-socks/alive.sock")
+
+
+class SocketWrite(unittest.TestCase):
+    """_socket_deliver: exactly one {"type":"user"} JSON line, and honest False on failure."""
+
+    def test_writes_one_user_record(self):
+        inbox = _OneShotInbox()
+        try:
+            self.assertTrue(km._socket_deliver(inbox.path, "mail body <!-- romp-msg-id: 1 -->"))
+            got = inbox.wait()
+            self.assertEqual(len(got), 1)
+            rec = json.loads(got[0].decode("utf-8"))
+            self.assertEqual(rec["type"], "user")
+            self.assertEqual(rec["message"]["role"], "user")
+            self.assertEqual(rec["message"]["content"], "mail body <!-- romp-msg-id: 1 -->")
+        finally:
+            inbox.close()
+
+    def test_false_when_socket_is_gone(self):
+        self.assertFalse(km._socket_deliver("/tmp/rompsock-nonexistent/inbox.sock", "x"))
+
+
+class _StubTmux(km.TmuxBackend):
+    """TmuxBackend with every raw tmux touchpoint stubbed; records pane-path probes so the
+    tests can assert which delivery leg ran."""
+
+    def __init__(self, accept):
+        self._accept = accept
+        self.pane_calls = []
+
+    def live_sessions(self):
+        return {SID: {"state": "idle", "backend": "tmux"}}
+
+    def show_var(self, name, var, t=2.5):
+        return "1" if (var == "@romp-inbound-accept" and self._accept) else ""
+
+    def pane_in_mode(self, name):
+        self.pane_calls.append("pane_in_mode")
+        return False
+
+    def capture(self, name, colour=False):
+        self.pane_calls.append("capture")
+        return ""                                          # never a live ❯ prompt → pane path bails
+
+    def send_keys(self, name, *keys):
+        self.pane_calls.append("send_keys")
+
+
+class DeliverGate(unittest.TestCase):
+    """TmuxBackend.deliver: socket leg iff tagged; pane path otherwise and on socket failure."""
+
+    def setUp(self):
+        self.reg = tempfile.mkdtemp(prefix="rompreg")
+        os.environ["ROMP_CLAUDE_SESSIONS_DIR"] = self.reg
+        self._name_of = km._name_of
+        km._name_of = lambda sid: "tsess"
+        self._last_sid = km.jd._sdk_last_sid
+        km.jd._sdk_last_sid = lambda sid: None             # tmux session: fsid IS the sid
+
+    def tearDown(self):
+        os.environ.pop("ROMP_CLAUDE_SESSIONS_DIR", None)
+        km._name_of = self._name_of
+        km.jd._sdk_last_sid = self._last_sid
+
+    def test_tagged_session_delivers_down_the_socket(self):
+        inbox = _OneShotInbox()
+        try:
+            _registry_row(self.reg, os.getpid(), SID, inbox.path)
+            be = _StubTmux(accept=True)
+            self.assertTrue(be.deliver(SID, "banner text"))
+            got = inbox.wait()
+            self.assertEqual(json.loads(got[0].decode("utf-8"))["message"]["content"], "banner text")
+            self.assertEqual(be.pane_calls, [])            # the pane was never touched
+        finally:
+            inbox.close()
+
+    def test_untagged_session_keeps_the_pane_path(self):
+        inbox = _OneShotInbox()
+        try:
+            _registry_row(self.reg, os.getpid(), SID, inbox.path)
+            be = _StubTmux(accept=False)
+            be.deliver(SID, "banner text")                 # pane stub has no ❯ prompt → undelivered
+            time.sleep(0.2)
+            self.assertEqual(inbox.got, [])                # nothing reached the socket
+            self.assertIn("capture", be.pane_calls)        # the pane path ran instead
+        finally:
+            inbox.close()
+
+    def test_tagged_but_dead_socket_falls_back_to_the_pane(self):
+        _registry_row(self.reg, os.getpid(), SID, "/tmp/rompsock-nonexistent/inbox.sock")
+        be = _StubTmux(accept=True)
+        self.assertFalse(be.deliver(SID, "banner text"))   # pane stub can't inject either
+        self.assertIn("capture", be.pane_calls)            # but it was TRIED — no silent drop
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Claude Code 2.1.224 binds a per-session Unix inbox socket (registered in `~/.claude/sessions/<pid>.json`) that accepts one JSON user record — the CLI's designed external-injection surface. Postal mail to a tmux session now delivers through it: instant, wakes an idle session, queues mid-turn between tool calls, and never touches the composer, so a half-typed draft survives with no stash dance. Pane injection stays as the fallback for older CLIs, untagged launches, and any socket failure.

## Why the tag gate

The CLI's inbound gate can HOLD mail from an unverifiable sender (the kernel) when the receiving session runs a bypass-class permission mode, and a held message silently expires after ~5 minutes — while the socket acks nothing, so a hold would read as delivered. Mail must never silently drop, so:

- `bin/romp` launches tmux sessions on a 2.1.224+ CLI with `--settings '{"crossSessionInbound":"accept"}'` and tags them `@romp-inbound-accept` in the same code path (tag and setting can never disagree).
- The kernel takes the socket leg ONLY for tagged sessions; everyone else keeps pane injection byte-for-byte.

The user approved the accept wiring 2026-08-08 after the authority comparison: any same-user process can already `tmux send-keys` into a pane with full user authority, while socket mail arrives labeled as another-session traffic with approval power stripped — the lower-privilege injection path of the two.

## Version floor

`bin/romp` now probes `claude --version` (cached on the binary's mtime, ~1s paid once per installed binary) and prints one informative line at the user-facing entrypoints when the CLI is older than 2.1.224, naming what the upgrade buys and the exact command. Informative, not a gate: romp still runs and mail still delivers.

## Docs

Delivery mechanics in `docs/read-side.md` ("How mail reaches a session"), pointer from `postal/README.md`, requirement note in `docs/reference.md`.

## Tests

New `tests/test_kernel_socket_deliver.py` (registry join incl. live-pid preference, socket write shape, deliver gating + fallback) and `tests/romp-claude-floor.bats` (nudge, floor boundary, mtime cache); `romp.bats` gains launch-wiring tests and a hermetic claude stub so a dev machine's real claude can't flip the launch line. Full suites green: 3939 py, 304 bats, 1676 node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)