### PR TITLE
Feed session filter, instant colour echo, token delta-folding, uniform timeline lanes, failed-create tab

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13569,6 +13569,12 @@ def build_feed(now, tmux=None):
             # the shared session order (session-order.json — the tab/lane order): grouped mode sorts each
             # column's session runs by it (the user 2026-07-13); federation prefixes + concatenates per host
             "order": _session_order(),
+            # the chat tab strip's sessions, name+color resolved exactly as tab_meta resolves them: the
+            # feed footer's session-filter menu lists precisely the tabs (the user 2026-08-08) — including
+            # a session with no cards on the board, which filters to an empty board rather than being
+            # unlistable. Federation prefixes sid+name per host and concatenates.
+            "sessions": [{"sid": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}
+                         for s in _chat_tab_sessions(now, tmux)],
             # /clear boundary settles, newest per session → the bell logs each once (the user 2026-07-27)
             "clearNotices": _boundary_clear_notices(alive),
             # SDK-backend failures → the same bell, one entry per occurrence (the user 2026-07-28)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1120,6 +1120,11 @@ class SdkSession:
         #   so spend folds the DELTA between results — folding the raw value re-added the whole
         #   session-so-far cost every turn (the user 2026-08-08, whose spend line was fiction). Reset
         #   at each connect: a fresh CLI process starts its counter at zero.
+        self._last_usage_totals = {}  # same for the TOKEN counts: the result event's usage is the
+        #   process-lifetime `this.totalUsage` counter (verified in the bundle beside total_cost_usd),
+        #   so each field folds as a delta too — raw folding compounded the token readout exactly like
+        #   the dollars (the user 2026-08-08, round two: the hover's 5h/7d/month $-per-token ratios
+        #   diverged wildly because each window carried a different inflation factor).
         # Pending conversation REWIND (the chat's edit-message branch): the target record uuid +
         # the transcript leaf recorded at request time (the one-shot guard — see rewind_disposition).
         # Seeded from the reg so a kernel death mid-rewind re-applies it iff nothing landed since.
@@ -1616,6 +1621,7 @@ class SdkSession:
                     connected = True
                     self.client = client
                     self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero
+                    self._last_usage_totals = {}  # …and its cumulative token counters
                     # The CLI is demonstrably up, so any recorded launch failure is HISTORY — clear it
                     # here, at the proof, rather than on a timer. This is what lifts the usage-limit
                     # hold once the window resets: the next _ensure connects, the error record goes, and
@@ -1956,7 +1962,18 @@ class SdkSession:
             if isinstance(total, (int, float)) and total > 0:
                 delta = total - self._last_cost_total if total >= self._last_cost_total else total
                 self._last_cost_total = float(total)
-                self.backend._record_spend(delta, getattr(msg, "usage", None))   # the rail's spend + token readout
+                # the usage dict is the SAME kind of counter (`usage: this.totalUsage` in the bundle):
+                # per-field deltas, a shrunken field folding whole — see _last_usage_totals in __init__
+                u = getattr(msg, "usage", None)
+                u = u if isinstance(u, dict) else {}
+                turn_u = {}
+                for k in ("input_tokens", "output_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"):
+                    v = u.get(k)
+                    v = int(v) if isinstance(v, (int, float)) else 0
+                    last = self._last_usage_totals.get(k, 0)
+                    turn_u[k] = v - last if v >= last else v
+                    self._last_usage_totals[k] = v
+                self.backend._record_spend(delta, turn_u)   # the rail's spend + token readout
             self.retrying = False
             self.retry_count = 0                    # turn over → clear the storm count (a turn that errored out without recovering leaves no "recovered" note)
             self.retry_info = None

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -563,6 +563,19 @@ class ViewBuilder(unittest.TestCase):
         feed = km.build_feed(NOW)
         self.assertNotIn("testsess", feed["awaiting"])
 
+    def test_feed_payload_lists_the_tab_sessions_for_the_footer_filter(self):
+        """The footer's session-filter menu lists exactly the chat tab strip (the user 2026-08-08): the
+        payload carries the SAME list _chat_tab_sessions renders, in ITS order, name+colour resolved
+        like tab_meta — so the menu, the tabs, and the grouped headers can never disagree. A session
+        with no cards still appears (filtering to it shows an empty board, it is never unlistable)."""
+        feed = km.build_feed(NOW)
+        rows = feed["sessions"]
+        self.assertEqual([r["sid"] for r in rows],
+                         [s["sid"] for s in km._chat_tab_sessions(NOW, km._tmux_sessions())])
+        me = next(r for r in rows if r["sid"] == SID)
+        self.assertEqual(me["name"], "testsess")
+        self.assertEqual(me["color"], km._name_color(SID), "the tab_meta colour resolution, verbatim")
+
     def test_judge_awaiting_stamp_suppresses_the_stalled_chip(self):
         """The false-'stalled' chain, reproduced end to end: a failed-nudge record exists, the live
         awaiting sources are dark, but the goal store carries the judge's stamp — the card must wear

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1561,10 +1561,12 @@ class SpendRecord(unittest.TestCase):
     def test_result_message_records_and_the_kernel_serves_it(self):
         src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
                                 "kernel", "sdk_backend.py")).read()
-        self.assertIn('self.backend._record_spend(delta, getattr(msg, "usage", None))', src,
-                      "the settle folds THIS turn's DELTA — total_cost_usd is cumulative per process")
+        self.assertIn("self.backend._record_spend(delta, turn_u)", src,
+                      "the settle folds THIS turn's DELTAS — cost AND tokens are cumulative per process")
         self.assertIn("self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero",
                       src, "each connect resets the watermark with its new process")
+        self.assertIn("self._last_usage_totals = {}  # …and its cumulative token counters", src,
+                      "the token watermarks reset with the same new process")
         with open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin", "romp-kernel")) as f:
             ksrc = f.read()
         self.assertIn('if o.get("apiKey") or (not _claude_account() and (jd.STATE / "spend.json").exists()):',
@@ -1573,11 +1575,13 @@ class SpendRecord(unittest.TestCase):
         self.assertIn("def _spend_windows():", ksrc)
 
     def test_cumulative_process_totals_fold_as_per_turn_deltas(self):
-        """The CLI's total_cost_usd is CUMULATIVE per process (the result event's totalCostUSD counter):
-        folding the raw value re-added the whole session-so-far cost on every turn, compounding the
-        spend readout into fiction — one live hour bucket showed a single 'turn' worth the session's
-        entire total (the user 2026-08-08, who did not believe the bottom line). Fold deltas; reset the
-        watermark with each new CLI process; treat a shrunken total as a reset we missed."""
+        """The CLI's total_cost_usd AND its usage dict are CUMULATIVE per process (the result event
+        carries totalCostUSD beside `usage: this.totalUsage`): folding the raw values re-added the
+        whole session-so-far on every turn, compounding the readouts into fiction — the dollars first
+        (the user 2026-08-08, who did not believe the bottom line), then the tokens (same day, round
+        two: the hover's 5h/7d/month dollars-per-token ratios diverged wildly because each window
+        carried a different inflation factor). Fold deltas for both; reset the watermarks with each
+        new CLI process; treat a shrunken counter as a reset we missed."""
         import asyncio
         sid = "11111111-2222-3333-4444-bbbbbbbbbbbb"
         s = sb.SdkSession(self.be, {"sid": sid, "name": "n", "cwd": "/tmp"})
@@ -1586,24 +1590,30 @@ class SpendRecord(unittest.TestCase):
         async def _noop(): pass
         s._do_refresh_context = _noop
         s._do_refresh_usage = _noop
-        def _result(total):
+        def _result(total, tok_in):
             r = _ResultMessage()
             r.total_cost_usd = total
-            r.usage = {"input_tokens": 10}
+            r.usage = {"input_tokens": tok_in}
             return r
-        async def run(total):
-            s._on_message(_result(total), _AssistantMessage, _ResultMessage, type("S", (), {}))
+        async def run(total, tok_in):
+            s._on_message(_result(total, tok_in), _AssistantMessage, _ResultMessage, type("S", (), {}))
             await asyncio.sleep(0)
-        asyncio.run(run(1.0))     # first turn of the process: delta = the whole total
-        asyncio.run(run(2.5))     # second turn: delta = 1.5, NOT another 2.5
-        d = json.loads(self.p.read_text())["days"][self._today()]
+        def day():
+            return json.loads(self.p.read_text())["days"][self._today()]
+        asyncio.run(run(1.0, 100))   # first turn of the process: delta = the whole counter
+        asyncio.run(run(2.5, 140))   # second turn: deltas = 1.5 / 40 tokens, NOT another 2.5 / 140
+        d = day()
         self.assertAlmostEqual(d["usd"], 2.5, msg="two turns fold to the process total, never more")
+        self.assertEqual(d["tokIn"], 140, "tokens fold as deltas of the totalUsage counter too")
         self.assertEqual(d["turns"], 2)
-        s._last_cost_total = 0.0  # the connect reset: a fresh CLI process starts at zero
-        asyncio.run(run(0.8))
-        self.assertAlmostEqual(json.loads(self.p.read_text())["days"][self._today()]["usd"], 3.3)
-        asyncio.run(run(0.5))     # a total BELOW the watermark = a reset we missed → fold it whole
-        self.assertAlmostEqual(json.loads(self.p.read_text())["days"][self._today()]["usd"], 3.8)
+        s._last_cost_total = 0.0     # the connect reset: a fresh CLI process starts at zero…
+        s._last_usage_totals = {}    # …on both counters
+        asyncio.run(run(0.8, 30))
+        self.assertAlmostEqual(day()["usd"], 3.3)
+        self.assertEqual(day()["tokIn"], 170)
+        asyncio.run(run(0.5, 20))    # a counter BELOW the watermark = a reset we missed → fold it whole
+        self.assertAlmostEqual(day()["usd"], 3.8)
+        self.assertEqual(day()["tokIn"], 190)
 
 
 class RewindFiles(unittest.TestCase):

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -1526,12 +1526,11 @@ class TimelinePanel {
   _rowDragMove(ev) {
     const d = this._drag; if (!d) return;
     const n = d.order.length, y = this._svgY(ev);
-    // invert laneY with the host-group offsets: pick the lane whose center is nearest the pointer
-    // (offsets shift live as the drag crosses a group boundary — nearest-center keeps it stable).
-    const offs = (this._geom && this._geom.laneOffs) || [];
+    // invert laneY: pick the lane whose center is nearest the pointer (rows are uniform now — the
+    // host-group offsets are gone with the boundary gap)
     let toIdx = 0, bestDy = Infinity;
     for (let i = 0; i < n; i++) {
-      const ly = this._geom.top + i * LANE_GAP + (offs[i] || 0) + LANE_GAP / 2;
+      const ly = this._geom.top + i * LANE_GAP + LANE_GAP / 2;
       const dy = Math.abs(y - ly);
       if (dy < bestDy) { bestDy = dy; toIdx = i; }
     }
@@ -1809,7 +1808,7 @@ class TimelinePanel {
     const g = this._geom; if (!g) return;
     const i = (this._vis || []).findIndex((s) => s.id === sid);
     if (i < 0) return;
-    const y = g.top + i * LANE_GAP + ((g.laneOffs && g.laneOffs[i]) || 0) + LANE_GAP * 0.5;
+    const y = g.top + i * LANE_GAP + LANE_GAP * 0.5;
     const X = (tt) => g.ml + ((g.compress ? g.compress(tt) : tt) - g.cT0) / g.winSec * g.plotW;   // compressed-time x
     const startMs = (typeof performance !== 'undefined' && performance.now) ? performance.now() : null;
     const DUR = 1400;
@@ -2404,17 +2403,9 @@ class TimelinePanel {
     }
     this._vis = vis;   // visible lanes in order → keyboard ↑/↓ selection
     const vidx = {}; vis.forEach((s, i) => { vidx[s.id] = i; });
-    // Host grouping (federation): the merged payload stamps each session's owning kernel on s.host
-    // ('' = local; the merge concatenates local-first). Remote hosts' lanes sit BELOW the local group
-    // with a HALF-ROW gap at each host boundary (the user 2026-07-02) so "a different machine" reads at
-    // a glance. laneOffs[i] = the cumulative extra y before lane i; single-kernel data has no host
-    // field → all offsets 0 → layout identical to before.
-    const laneOffs = []; let laneOffAcc = 0;
-    for (let i = 0; i < vis.length; i++) {
-      if (i > 0 && (vis[i].host || '') !== (vis[i - 1].host || '')) laneOffAcc += LANE_GAP * 0.5;
-      laneOffs.push(laneOffAcc);
-    }
-    const laneOffTotal = laneOffAcc;
+    // (The half-row gap at host boundaries — a 2026-07-02 cue for remote lanes — was REMOVED (the user
+    // 2026-08-08): hosts no longer interleave in one shared order, so the lanes list out uniformly and
+    // the quiet "host:" name prefix alone marks a remote session.)
 
 
     // "compacting" = the real @claude-state OR an OPTIMISTIC click not yet confirmed (≤6s) — so the cue
@@ -2471,12 +2462,12 @@ class TimelinePanel {
     const jShow = !!(shownJudges.length && data.judging && data.judging.some((e) => shownKeys.has(e.judge) && inWin(e.t)));
     const bandH = jShow ? (JB_TOPGAP + shownJudges.length * JROW + JB_BOTGAP) : 0;
     const W = Math.max(640, this.wrap.clientWidth || 900);
-    const plotW = W - M.left - M.right, H = M.top + Math.max(1, vis.length) * LANE_GAP + laneOffTotal + bandH + M.bottom;
+    const plotW = W - M.left - M.right, H = M.top + Math.max(1, vis.length) * LANE_GAP + bandH + M.bottom;
     svg.setAttribute('viewBox', '0 0 ' + W + ' ' + H); svg.setAttribute('height', H); svg.setAttribute('width', W);
     // x is LINEAR in compressed time → smooth pan (only zoom rescales). Identity compress = plain linear.
     const x = (t) => M.left + (compress(t) - cT0) / winSec * plotW;
-    const laneY = (i) => M.top + i * LANE_GAP + (laneOffs[i] || 0) + LANE_GAP * 0.5;
-    this._geom = { ml: M.left, plotW, W, H, top: M.top, t0, t1, cT0, winSec, compress, decompress, laneOffs };
+    const laneY = (i) => M.top + i * LANE_GAP + LANE_GAP * 0.5;
+    this._geom = { ml: M.left, plotW, W, H, top: M.top, t0, t1, cT0, winSec, compress, decompress };
 
     // axis — gridlines + time labels. Ticks at real nice intervals, drawn at their compressed x (evenly
     // spaced in active regions, squished across gaps). A tick inside a collapsed gap is skipped — the
@@ -3119,7 +3110,7 @@ class TimelinePanel {
     // by the SESSION it acted on; adjacent same-session marks merge into a stretch of attention. A mark
     // within ~8s of the live edge is "running now" (white-outlined). (docs/judges.md; data.judging.)
     if (jShow) {
-      const jb0 = M.top + vis.length * LANE_GAP + laneOffTotal + JB_TOPGAP;     // top of the first judge row (below the host-group gaps)
+      const jb0 = M.top + vis.length * LANE_GAP + JB_TOPGAP;     // top of the first judge row, under the lanes
       const jY = (i) => jb0 + i * JROW + JROW * 0.5;
       const nameOf = (sid) => { const s = data.sessions.find((z) => z.id === sid); return s ? s.name : sid; };
       const sepY = jb0 - JB_TOPGAP * 0.5;

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -51,7 +51,7 @@ function dashboardWid(): string {
 // message type) so a new message type that reuses these field names is covered automatically:
 const SCALAR_ID = ["id", "sid"]; //               a single session id
 const ARRAY_ID = ["order", "names", "working", "awaiting"]; // an array of session ids
-const OBJ_SID = ["asks", "items", "ledgers"]; //  an array of objects keyed by `.sid`
+const OBJ_SID = ["asks", "items", "ledgers", "sessions"]; //  an array of objects keyed by `.sid`
 const OBJ_ID = ["tabs"]; //                       an array of objects keyed by `.id`
 
 /** Return a COPY of an inbound message with every session-id field prefixed by `host`. The local host
@@ -278,7 +278,7 @@ export function mergeHostOrder(perHost: Record<string, readonly string[]>, hostS
 export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly string[],
                                view: readonly string[] = []): any {
   const local = perHost[LOCAL] || {};
-  const merged: any = { ...local, type: "feed", items: [], asks: [], working: [], awaiting: [], order: [] };
+  const merged: any = { ...local, type: "feed", items: [], asks: [], working: [], awaiting: [], order: [], sessions: [] };
   // `ledgers` drives the FLEET pane (it rides the same feed message). Only include it once at least one host
   // has actually BUILT its ledgers — else the fleet's loader-gate (needs an array) would drop onto an empty
   // pane. Kept undefined until then so the loader holds, exactly like the single-kernel path.
@@ -295,6 +295,7 @@ export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly s
     if (Array.isArray(f.working)) merged.working.push(...f.working);
     if (Array.isArray(f.awaiting)) merged.awaiting.push(...f.awaiting);   // straw awaiting dots ride like working
     if (Array.isArray(f.order)) merged.order.push(...f.order);   // grouped-mode session rank: local first, ids pre-prefixed
+    if (Array.isArray(f.sessions)) merged.sessions.push(...f.sessions);   // the tab-strip session list (footer filter menu), sid+name pre-prefixed
     if (Array.isArray(f.ledgers)) { anyLedgers = true; ledgers.push(...f.ledgers); }
     if (typeof f.dismissedCount === "number") { anyDismissed = true; dismissed += f.dismissedCount; }
     if (f.canUndoClear) canUndo = true;

--- a/ui/webview/feed-color-echo.test.ts
+++ b/ui/webview/feed-color-echo.test.ts
@@ -1,0 +1,39 @@
+// The optimistic colour echo (the user 2026-08-08): picking a tab-menu swatch in the CHAT pane
+// repainted the tabs instantly, but the FEED kept the old colour until the kernel's next feed REBUILD
+// pushed — a second or two. The echo now travels kernel-free on the same host-matched pair settings
+// sync rides: the browser's same-origin iframes hear a localStorage write (`storage` fires
+// cross-document), and in VS Code — separate synthetic origins, no storage events — the extension fans
+// {colorSync} to its other panels. setSessionColor still goes to the kernel, whose re-broadcast
+// reconciles behind the echo. Source pins (no jsdom harness — the repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const RENDER = fs.readFileSync(path.join(ROOT, "ui", "webview", "render.ts"), "utf8");
+const FEED = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.ts"), "utf8");
+const EXT = fs.readFileSync(path.join(ROOT, "vscode-extension", "src", "extension.ts"), "utf8");
+
+test("the chat pane writes the echo on the swatch click itself, before any kernel round-trip", () => {
+  assert.ok(RENDER.includes('localStorage.setItem("romp:color-echo", JSON.stringify({ sid: id, bg, t: Date.now() }))'),
+    "the `t` stamp makes re-picking the same colour still fire the storage event");
+  assert.ok(RENDER.includes('if ((window as any).__rompShowStrip) vscodeApi?.postMessage({ type: "colorSync", sid: id, bg });'),
+    "the host fan-out leg fires only under VS Code — the browser's storage event already covers its iframes");
+  // the authoritative write still goes to the kernel, unchanged
+  assert.ok(RENDER.includes('vscodeApi.postMessage({ type: "setSessionColor", id, bg })'));
+});
+
+test("the feed applies the echo to every copy it holds and re-renders at once", () => {
+  assert.ok(FEED.includes('if (e.key !== "romp:color-echo" || !e.newValue) return;'), "the browser leg");
+  assert.ok(FEED.includes('m.type === "colorSync" && typeof m.sid === "string" && typeof m.bg === "string"'), "the VS Code leg");
+  assert.ok(FEED.includes("for (const a of asks) if (a.sid === sid) { a.color = color; hit = true; }"), "card borders + titles");
+  assert.ok(FEED.includes("for (const s of sessionsMeta) if (s.sid === sid) { s.color = color; hit = true; }"), "the session-filter menu");
+  assert.ok(FEED.includes("if (nm) sessionColors.set(nm, bg);"), "held-mail cards look colours up by name");
+  assert.ok(FEED.includes("if (hit) render();"), "…then one immediate repaint, no kernel wait");
+});
+
+test("the VS Code host fans colorSync to its other panels, exactly like settingsSync", () => {
+  assert.ok(EXT.includes('if (m.type === "colorSync") { broadcastColorSync(m, p.webview); return; }'));
+  assert.match(EXT, /function broadcastColorSync[\s\S]{0,500}?w\.postMessage\(\{ type: "colorSync", sid: m\.sid, bg: m\.bg \}\)/);
+});

--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -1,0 +1,60 @@
+// The feed footer's SESSION FILTER (the user 2026-08-08): a menu right of the Group toggle listing
+// every session the chat tab strip shows, in ITS order, each in canonical form — identity-colour dot +
+// name with any "host:" prefix folded quiet (.host-prefix). Picking one shows only that session's
+// cards; the DEFAULT is nothing selected, everything shows. The kernel attaches the tab list to the
+// feed payload (name+colour resolved exactly as tab_meta); federation prefixes and concatenates it.
+// The federation legs are pure and tested functionally; feed.ts has no jsdom harness → source pins
+// (the repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { prefixInbound, mergeHostFeeds } from "./federation";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const FEED = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+
+const U = "11111111-2222-3333-4444-555555555555";
+const V = "99999999-8888-7777-6666-555555555555";
+
+test("the kernel's feed payload carries the chat tab strip's sessions, tab_meta-shaped", () => {
+  assert.ok(KERNEL.includes('"sessions": [{"sid": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}'));
+  assert.ok(KERNEL.includes("for s in _chat_tab_sessions(now, tmux)]"), "the SAME list the tabs render, in ITS order");
+});
+
+test("federation prefixes each sessions[] entry's sid AND name, and the merge concatenates local-first", () => {
+  const out = prefixInbound("TESTHOST", { type: "feed", sessions: [{ sid: U, name: "api", color: null }] });
+  assert.equal(out.sessions[0].sid, "TESTHOST:" + U);
+  assert.equal(out.sessions[0].name, "TESTHOST:api");
+  const merged = mergeHostFeeds({
+    "": { type: "feed", sessions: [{ sid: U, name: "web" }] },
+    TESTHOST: { type: "feed", sessions: [{ sid: "TESTHOST:" + V, name: "TESTHOST:api" }] },
+  }, ["", "TESTHOST"]);
+  assert.deepEqual(merged.sessions.map((s: any) => s.name), ["web", "TESTHOST:api"]);
+});
+
+test("the filter defaults to NOTHING selected and only ever narrows the RENDER, never the data", () => {
+  assert.ok(FEED.includes("let feedOnlySid: string | null = null;"));
+  assert.ok(FEED.includes('sessionStorage.getItem("romp:feedOnly")'),
+    "survives this tab's reloads only — a fresh window always starts unfiltered");
+  assert.ok(FEED.includes("const shown = feedOnlySid ? asks.filter((a) => a.sid === feedOnlySid) : asks;"));
+  assert.ok(FEED.includes("for (const a of shown) {"), "the group-fold loop reads the filtered view");
+  assert.ok(FEED.includes("for (const a of shown) { if (grouped.has(a.itemId)) continue;"), "…and the singles loop");
+  // a filter aimed at a session the tab strip no longer shows clears itself — the deciding EVENT is
+  // the session leaving the tab list, never a timer
+  assert.ok(FEED.includes("if (feedOnlySid && !sessionsMeta.some((s) => s.sid === feedOnlySid)) setFeedOnly(null);"));
+});
+
+test("the menu sits right of Group, lists sessions in tab order, canonical form, click-safe", () => {
+  assert.match(FEED, /ensureGroupToggle\(\)\.style\.display = showCA \? "" : "none";[^\n]*\n\s*ensureSessionFilter\(\)\.style\.display = showCA \? "" : "none";/);
+  // tab order: ranked by the kernel's session-order list — the same rank grouped mode sorts by
+  assert.ok(FEED.includes("const rows = sessionsMeta.slice().sort((a, b) => (rank.get(a.sid) ?? 1e9) - (rank.get(b.sid) ?? 1e9));"));
+  // canonical form: identity dot + host-folded name (the shared .host-prefix treatment)
+  assert.ok(FEED.includes("row(feedOnlySid === s.sid, s.sid, sessDot(s.color?.bg), ...hostNameNodes(s.name, s.sid));"));
+  // the menu lives on document.body — outside render()'s reconcile, so a push can't rebuild it mid-press
+  assert.ok(FEED.includes("document.body.appendChild(menu);"));
+  // with a filter on, the button wears the picked session's dot+name and the accent .on state — a
+  // narrowed board must never look like the whole one
+  assert.ok(FEED.includes('if (cur) b.replaceChildren(sessDot(cur.color?.bg), ...hostNameNodes(cur.name, cur.sid), document.createTextNode(" ▴"));'));
+});

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -811,6 +811,20 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    + faint wash), the same selected-state look the card section toggles use (the user 2026-07-07) */
 #feed-foot .feed-modetoggle.on { color: var(--accent); border-color: var(--accent);
   background: rgba(156, 210, 255, 0.12); opacity: 1; }
+/* the SESSION FILTER (the user 2026-08-08): the footer button carries the picked session's dot+name;
+   its menu opens UPWARD (position from the button rect, feed.ts), one row per tab-order session in
+   canonical form — identity dot + name, any host: prefix folded quiet (.host-prefix, shared). */
+#feed-sessfilter { display: inline-flex; align-items: center; gap: 5px; }
+.fsm-dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; }
+.fsm-dot.blank { border: 1px solid var(--dim); box-sizing: border-box; }   /* a colourless session still gets a slot — rows stay aligned */
+.feed-sessmenu { position: fixed; z-index: 60; min-width: 150px; max-height: 60vh; overflow-y: auto;
+  padding: 4px; border: 1px solid var(--card-border); border-radius: 6px;
+  background: var(--vscode-editorWidget-background, #252526);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45); }
+.feed-sessmenu .fsm-row { display: flex; align-items: center; gap: 7px; padding: 4px 9px;
+  border-radius: 4px; cursor: pointer; font-size: 11.5px; white-space: nowrap; }
+.feed-sessmenu .fsm-row:hover { background: rgba(255, 255, 255, 0.07); }
+.feed-sessmenu .fsm-row.on { color: var(--accent); }
 /* downstream sessions an ask is waiting on (drop points) — experiment
    2026-06-10; live working dot + age per session, newest first */
 /* active downstream sessions (the user's handoff spec, 2026-06-10): one line per

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -431,6 +431,43 @@ function feedPrefs(): { newestFirst: boolean; collapsed: boolean; grouped: boole
 // user 2026-07-13: grouped-mode sessions must match it). Rides every feed push; federation concatenates
 // per-host orders local-first, ids pre-prefixed.
 let sessionOrder: string[] = [];
+// The chat tab strip's sessions (sid+name+color), riding every feed push: the footer's session-filter
+// menu lists exactly the tabs (the user 2026-08-08) — a session with no cards still appears, and
+// filtering to it shows an empty board. Federation prefixes sid+name per host and concatenates.
+let sessionsMeta: { sid: string; name: string; color: { bg: string; fg: string } | null }[] = [];
+// The one session the board is filtered to, or null — the DEFAULT, nothing selected, everything shows.
+// sessionStorage, deliberately: it survives this tab's reloads (webviews reload on updates) but a fresh
+// window always starts unfiltered — a filter that persisted for days would read as silently lost cards.
+let feedOnlySid: string | null = null;
+try { feedOnlySid = sessionStorage.getItem("romp:feedOnly") || null; } catch { /* storage blocked */ }
+function setFeedOnly(sid: string | null): void {
+  feedOnlySid = sid;
+  try { sid ? sessionStorage.setItem("romp:feedOnly", sid) : sessionStorage.removeItem("romp:feedOnly"); } catch { /* ignore */ }
+}
+
+// OPTIMISTIC colour echo from the chat pane's tab menu (the user 2026-08-08): the chat repaints its
+// tabs the instant a swatch is picked, but this pane kept the old colour until the kernel's next feed
+// REBUILD pushed — a second or two. The echo arrives kernel-free on two host-matched channels (the
+// same pair settings sync rides): the browser's same-origin iframes hear the localStorage write
+// (`storage` fires cross-document), and VS Code's extension fans {colorSync} to its other panels.
+// Apply it to every copy this pane holds and re-render; the kernel's own re-broadcast reconciles.
+function applyColorEcho(sid: string, bg: string): void {
+  if (!sid || !bg) return;
+  const color = { bg, fg: "#ffffff" };   // fg fixed white, matching the kernel's _name_color
+  let hit = false;
+  for (const a of asks) if (a.sid === sid) { a.color = color; hit = true; }
+  for (const s of sessionsMeta) if (s.sid === sid) { s.color = color; hit = true; }
+  const nm = sessionsMeta.find((s) => s.sid === sid)?.name || asks.find((a) => a.sid === sid)?.name;
+  if (nm) sessionColors.set(nm, bg);     // held-mail cards look colours up by name
+  if (hit) render();
+}
+window.addEventListener("storage", (e) => {
+  if (e.key !== "romp:color-echo" || !e.newValue) return;
+  try {
+    const v = JSON.parse(e.newValue);
+    applyColorEcho(typeof v.sid === "string" ? v.sid : "", typeof v.bg === "string" ? v.bg : "");
+  } catch { /* malformed echo — the kernel push corrects momentarily */ }
+});
 // names of sessions currently WORKING → a working dot before that name everywhere
 // it renders (card titles, modal title, group name). Pushed in each feed message.
 let workingSet = new Set<string>();
@@ -2976,6 +3013,74 @@ function ensureGroupToggle(): HTMLElement {
     "group each column's cards by session (tab order), a session header between runs");
 }
 
+// The SESSION FILTER (the user 2026-08-08): a footer menu listing every session the chat tab strip
+// shows, in ITS order, each in its canonical form — identity-colour dot + name with any "host:"
+// prefix folded quiet (hostNameNodes). Picking one shows only that session's cards; "All sessions"
+// (the default — nothing selected) shows everything. The menu opens UPWARD from the footer (that is
+// where the space is) and lives on document.body, outside render()'s reconcile, so a push can never
+// rebuild it mid-press; the button itself is ensure-once like the other footer controls.
+let sessMenuEl: HTMLElement | null = null;
+function closeSessMenu(): void {
+  sessMenuEl?.remove(); sessMenuEl = null;
+  document.removeEventListener("pointerdown", sessMenuAway, true);
+  document.removeEventListener("keydown", sessMenuKey, true);
+}
+function sessMenuAway(ev: Event): void {
+  const t = ev.target as Node;
+  if (sessMenuEl && !sessMenuEl.contains(t) && !(document.getElementById("feed-sessfilter")?.contains(t))) closeSessMenu();
+}
+function sessMenuKey(ev: KeyboardEvent): void { if (ev.key === "Escape") closeSessMenu(); }
+function sessDot(bg: string | undefined): HTMLElement {
+  const d = el("span", "fsm-dot");
+  if (bg) d.style.background = bg; else d.classList.add("blank");
+  return d;
+}
+function openSessMenu(btn: HTMLElement): void {
+  const menu = el("div", "feed-sessmenu");
+  const row = (on: boolean, pick: string | null, ...label: Node[]) => {
+    const r = el("div", "fsm-row" + (on ? " on" : ""));
+    r.append(...label);
+    r.setAttribute("role", "menuitemradio"); r.setAttribute("aria-checked", on ? "true" : "false");
+    r.onclick = (ev) => { ev.stopPropagation(); setFeedOnly(on ? null : pick); closeSessMenu(); render(); };
+    menu.appendChild(r);
+  };
+  row(!feedOnlySid, null, document.createTextNode("All sessions"));
+  // tab order: rank by the kernel's session-order list (the same rank grouped mode sorts by); a sid the
+  // list doesn't know keeps its place in the kernel's tab list (stable sort), after the ranked ones
+  const rank = new Map(sessionOrder.map((s, i) => [s, i] as const));
+  const rows = sessionsMeta.slice().sort((a, b) => (rank.get(a.sid) ?? 1e9) - (rank.get(b.sid) ?? 1e9));
+  for (const s of rows) row(feedOnlySid === s.sid, s.sid, sessDot(s.color?.bg), ...hostNameNodes(s.name, s.sid));
+  document.body.appendChild(menu);
+  // above the footer, left-aligned to the button, clamped into the viewport
+  const r = btn.getBoundingClientRect();
+  menu.style.bottom = Math.round(window.innerHeight - r.top + 6) + "px";
+  menu.style.left = Math.round(Math.max(6, Math.min(r.left, window.innerWidth - menu.offsetWidth - 6))) + "px";
+  sessMenuEl = menu;
+  document.addEventListener("pointerdown", sessMenuAway, true);
+  document.addEventListener("keydown", sessMenuKey, true);
+}
+function ensureSessionFilter(): HTMLElement {
+  let b = document.getElementById("feed-sessfilter") as HTMLElement | null;
+  if (!b) {
+    b = el("button", "fdismiss ffollow feed-modetoggle");
+    b.id = "feed-sessfilter";
+    b.onclick = (ev) => {   // opening the menu IS the acknowledgement (same as the fold caret)
+      ev.stopPropagation();
+      if (sessMenuEl) closeSessMenu(); else openSessMenu(b!);
+    };
+    (document.getElementById("feed-foot") || document.body).appendChild(b);
+  }
+  const cur = feedOnlySid ? sessionsMeta.find((s) => s.sid === feedOnlySid) : undefined;
+  const on = !!feedOnlySid;
+  b.classList.toggle("on", on);
+  b.setAttribute("aria-pressed", on ? "true" : "false");
+  b.title = cur ? "showing only " + cur.name + " — click to change or show all"
+    : "show a single session's cards (default: all)";
+  if (cur) b.replaceChildren(sessDot(cur.color?.bg), ...hostNameNodes(cur.name, cur.sid), document.createTextNode(" ▴"));
+  else b.replaceChildren(document.createTextNode("Session ▴"));
+  return b;
+}
+
 // (The footer "Sub-goals" checkbox was removed 2026-07-08: sub-goals is now a per-card "Sub-goals" button
 // beside Summary — wired in applySections as the third mutually-exclusive section.)
 
@@ -3169,6 +3274,7 @@ function render() {
   ensureNewestFirst().style.display = showCA ? "" : "none";       // reverse the column order
   ensureCollapsedToggle().style.display = showCA ? "" : "none";   // default section state (collapsed / expanded)
   ensureGroupToggle().style.display = showCA ? "" : "none";       // by-session grouping (the user 2026-07-13)
+  ensureSessionFilter().style.display = showCA ? "" : "none";     // one-session filter menu (the user 2026-08-08)
   ensureClearAll().style.display = showCA ? "" : "none";
   ensureUndoClear().style.display = canUndoClear ? "" : "none";
   const foot = document.getElementById("feed-foot");
@@ -3195,11 +3301,15 @@ function render() {
 
   const cols = ensureCols(list);
   const buckets: Record<Column, Entry[]> = { asks: [], needsInput: [], completed: [] };
+  // The footer session filter (the user 2026-08-08): with a session picked, the board draws ONLY its
+  // cards. Display-side only — `asks` stays complete, so flipping the filter needs no kernel round-trip
+  // and everything else (the modal, optimistic moves, the empty check above) still sees the whole board.
+  const shown = feedOnlySid ? asks.filter((a) => a.sid === feedOnlySid) : asks;
   // Derive sibling GROUPS at render time, keyed by the shared typed turn (turnId).
   // Only host-flagged asks (groupTitle) participate, and a turn needs ≥2 current
   // members to fold — a lone survivor (siblings cleared) renders as a single card.
   const byTurn = new Map<string, AskItem[]>();
-  for (const a of asks) {
+  for (const a of shown) {
     if (!a.groupTitle || !a.turnId) continue;
     const arr = byTurn.get(a.turnId) || []; arr.push(a); byTurn.set(a.turnId, arr);
   }
@@ -3210,7 +3320,7 @@ function render() {
     const g = buildGroup(tid, members);
     buckets[g.column].push({ kind: "group", t: g.t, group: g });
   }
-  for (const a of asks) { if (grouped.has(a.itemId)) continue; buckets[askColumn(a)].push({ kind: "ask", t: a.t, ask: a }); }
+  for (const a of shown) { if (grouped.has(a.itemId)) continue; buckets[askColumn(a)].push({ kind: "ask", t: a.t, ask: a }); }
   // Oldest-at-top by default (the user 2026-06-27): the newest work sits at the BOTTOM of each column, and
   // new/moved cards stack onto the bottom (matches the fly animation). The footer "Newest first" toggle
   // (default off, the user 2026-07-07) reverses each column to newest-at-top.
@@ -3535,6 +3645,12 @@ window.addEventListener("message", (e: MessageEvent) => {
     awaitingSet = new Set(Array.isArray(m.awaiting) ? m.awaiting : []);   // straw awaiting dots (the user 2026-07-13)
     bgServicesMap = m.bgServices && typeof m.bgServices === "object" ? m.bgServices : {};   // session name -> judge-classified service descs → the session-header chip (2026-07-24)
     if (Array.isArray(m.order)) sessionOrder = m.order.filter((x: any) => typeof x === "string");   // grouped-mode session rank (tab/lane order)
+    if (Array.isArray(m.sessions)) {
+      sessionsMeta = m.sessions.filter((s: any) => s && typeof s.sid === "string" && typeof s.name === "string");
+      // a filter aimed at a session the tab strip no longer shows is moot — clear it (the deciding
+      // event: the session left the tab list), rather than leaving the board silently pinned to nothing
+      if (feedOnlySid && !sessionsMeta.some((s) => s.sid === feedOnlySid)) setFeedOnly(null);
+    }
     hostNow = typeof m.now === "number" ? m.now : Math.floor(Date.now() / 1000);
     mirrorBadges(incomingAsks, Array.isArray(m.clearNotices) ? m.clearNotices : [],
       Array.isArray(m.sdkNotices) ? m.sdkNotices : [],
@@ -3589,6 +3705,10 @@ window.addEventListener("message", (e: MessageEvent) => {
     // same options in-page; a choice goes back as keystrokes (transport only,
     // the user decides — the never-auto-answer rule holds).
     showPickerDialog(String(m.name), Array.isArray(m.options) ? m.options.map(String) : []);
+  } else if (m.type === "colorSync" && typeof m.sid === "string" && typeof m.bg === "string") {
+    // VS Code leg of the optimistic colour echo (see applyColorEcho): the extension fans the chat
+    // pane's swatch pick here, since each webview's localStorage is its own — no storage event.
+    applyColorEcho(m.sid, m.bg);
   } else if (m.type === "cardPredict" && Array.isArray(m.ids)) {
     // kernel fan-back (the user 2026-07-20): a context-carrying reply just fired SOMEWHERE — the chat's
     // citation follow-up, a picker/permission answer typed in the chat, another feed view's button — so

--- a/ui/webview/provisional.test.ts
+++ b/ui/webview/provisional.test.ts
@@ -62,9 +62,10 @@ test("creating a session opens the provisional tab instead of a modal", () => {
 });
 
 test("a send on a provisional tab is HELD, not posted to a session that doesn't exist", () => {
-  assert.match(RENDER, /if \(isProvisionalId\(sid\)\) \{\s*\n\s*provisionalQueue\.push\(text\);/);
   assert.match(RENDER, /provisionalQueue\.push\(text\);\s*\n\s*registerOptimistic\(sid, text\);/,
     "the dashed bubble goes up now — romp has it, it is not delivered");
+  // a FAILED tab has no pending spawn to queue onto: refuse loudly, the box keeps the only copy
+  assert.match(RENDER, /if \(sid !== provisionalId\) \{\s*\n\s*warnToast\("“" \+ \(sessions\.get\(sid\)\?\.name \|\| "this session"\)/);
 });
 
 test("adoption flushes the held messages FOR REAL and carries the draft across", () => {
@@ -77,11 +78,25 @@ test("adoption flushes the held messages FOR REAL and carries the draft across",
     "setActive reads the draft map, so the carry has to be in it first");
 });
 
-test("a failed create says so in a dialog, in the kernel's own words", () => {
+test("a failed create says so in a dialog, in the kernel's own words — ON the failed thread", () => {
   assert.match(RENDER, /if \(provisionalId\) failProvisional\(m\.text\); else warnToast\(m\.text\);/);
   assert.match(RENDER, /showConfirm\("Couldn't start " \+ name,/);
-  assert.match(RENDER, /What you typed is back in the message box\./,
+  assert.match(RENDER, /What you typed is in this tab's message box\./,
     "losing the text would be the one unrecoverable part");
+  // The failure JUMPS BACK to its own tab first, and the text goes into THAT tab's box (the user
+  // 2026-08-08, whose held text landed in the draft of an unrelated thread they happened to be
+  // reading). The tab stays — the dialog is on top of the thread it is about.
+  const fail = RENDER.slice(RENDER.indexOf("function failProvisional"), RENDER.indexOf("function cancelProvisional"));
+  assert.ok(fail.includes("setActive(id);"), "foreground the failed thread before saying anything");
+  assert.ok(fail.includes("drafts.set(id, held); persistDrafts();"), "the text belongs to the failed tab, no other");
+  assert.ok(fail.indexOf("setActive(id);") < fail.indexOf("showConfirm("), "jump first, dialog second");
+  assert.ok(!fail.includes("= dropProvisional()"), "the tab is NOT torn down — it holds the text");
+  assert.ok(fail.includes("failedProvisionals.add(id);"));
+  // the failed tab's transcript says what happened (the starting loader would be a lie)…
+  assert.match(RENDER, /This session couldn't start\. What you typed is kept in the box below/);
+  assert.match(RENDER, /const staleStart = !!only && only\.classList\?\.contains\("tx-starting"\) && failedProvisionals\.has\(id\);/);
+  // …and its composer stays LIVE despite the closed-tab treatment, so the text is editable/copyable
+  assert.match(RENDER, /const closed = s\.status\.state === "closed" && !failedProvisionals\.has\(activeId!\);/);
 });
 
 test("the silent-failure backstop is long, because it is no longer what you wait on", () => {
@@ -90,9 +105,11 @@ test("the silent-failure backstop is long, because it is no longer what you wait
   assert.ok(Number(m![1].replace(/_/g, "")) >= 60_000, "well past the old 30s cue");
 });
 
-test("closing a provisional tab aborts the pending spawn", () => {
-  assert.match(RENDER, /if \(isProvisionalId\(id\)\) \{ cancelProvisional\(\); return; \}/);
+test("closing a provisional tab aborts the pending spawn; a FAILED one is a plain local discard", () => {
+  assert.match(RENDER, /if \(id === provisionalId\) cancelProvisional\(\);\s*\n\s*else \{ failedProvisionals\.delete\(id\); dismissSession\(id\); \}/);
   assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "cancelCreate", name \}\)/);
+  // the kernel never knew a provisional id — the dead-tab ✕ must not post closeTab for one
+  assert.match(RENDER, /if \(!isProvisionalId\(id\)\) vscodeApi\.postMessage\(\{ type: "closeTab", id \}\);/);
 });
 
 test("the folder question retires the tab and holds what was typed for the retry", () => {
@@ -102,7 +119,7 @@ test("the folder question retires the tab and holds what was typed for the retry
 });
 
 test("a starting tab shows the romp loader, not the 'No messages yet' placeholder", () => {
-  assert.match(RENDER, /if \(isProvisionalId\(id\)\) \{\s*\n\s*ph\.classList\.add\("tx-starting"\);/);
+  assert.match(RENDER, /\} else if \(isProvisionalId\(id\)\) \{\s*\n\s*ph\.classList\.add\("tx-starting"\);/);
   assert.match(RENDER, /romp-swirl-glyph\.svg/);
   assert.match(RENDER, /"Starting " \+ s\.name \+ "… you can type now; romp sends it when it's up\."/);
   assert.match(CSS, /\.tx-starting-swirl \{[\s\S]*?animation: tx-starting-spin/);

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -32,10 +32,12 @@ test("the kernel serves spend WINDOWS on the auth-flip marker, zero-filled when 
   // the subscription payload carries the spend windows BESIDE the bars — the hover's token graph
   // needs them for every account, not just spend-only ones (the user 2026-08-08)
   assert.match(KERNEL, /"fiveHour": five, "sevenDay": seven, "fable": fable,[\s\S]{0,600}?"spend": _spend_windows\(\),/);
-  // the accumulator: total_cost_usd is CUMULATIVE per CLI process — fold the per-turn DELTA, and a
-  // shrunken total (an unwatched reset) folds whole, never negative (the user 2026-08-08)
+  // the accumulator: total_cost_usd AND the usage token counts are CUMULATIVE per CLI process — fold
+  // per-turn DELTAS for both, and a shrunken counter (an unwatched reset) folds whole, never negative
+  // (the user 2026-08-08, dollars in the morning and tokens by the evening)
   assert.ok(BACKEND.includes("delta = total - self._last_cost_total if total >= self._last_cost_total else total"));
-  assert.ok(BACKEND.includes('self.backend._record_spend(delta, getattr(msg, "usage", None))'));
+  assert.ok(BACKEND.includes("turn_u[k] = v - last if v >= last else v"));
+  assert.ok(BACKEND.includes("self.backend._record_spend(delta, turn_u)"));
   assert.ok(BACKEND.includes("_fold(days, day, 90)"));
   assert.ok(BACKEND.includes("_fold(hours, hour, 192)"), "8 days of hour buckets feed the rolling windows");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4002,6 +4002,12 @@ const provisionalQueue: string[] = [];
 let provisionalTimer: ReturnType<typeof setTimeout> | undefined;
 // Text typed into a provisional tab whose create had to ask something first, waiting for the retry's tab.
 let pendingCarry = "";
+// Provisional tabs whose create FAILED (the user 2026-08-08): the tab — and whatever was typed into
+// it — STAYS, foregrounded, with the failure dialog on top. It used to be torn down and the held text
+// dumped into whichever tab happened to be active, polluting an unrelated thread's draft. The set keys
+// the failed transcript placeholder, the send refusal, and the composer's read-only exemption; the
+// tab's ✕ discards tab and text together (an explicit choice, local-only — the kernel never knew it).
+const failedProvisionals = new Set<string>();
 // The backstop, for a create that fails with nothing said. Every failure the kernel CAN name arrives as a
 // warn / createDirMissing and lands the dialog at once; this covers a spawn that dies silently. It is
 // deliberately long — the point is that it is no longer what you wait on, the way the old 30s cue was.
@@ -4063,21 +4069,39 @@ function adoptProvisional(realId: string): void {
 
 // A create that FAILED. The kernel's own words are the message wherever it gave any (a bad name, an
 // unreadable parent, the SDK setup hint) — a dialog naming the reason beats the old cue, which simply
-// stopped after thirty seconds and left you to work out that nothing had happened. Whatever was typed
-// comes back in the box, because losing it would be the one unrecoverable part of this.
+// stopped after thirty seconds and left you to work out that nothing had happened. The TAB STAYS and is
+// foregrounded first, with whatever was typed back in ITS box (the user 2026-08-08): tearing it down
+// restored the text into whichever tab happened to be active, so a failure that landed while you were
+// reading another thread silently rewrote that thread's draft.
 function failProvisional(why: string): void {
   if (!provisionalId) return;
+  const id = provisionalId;
   const name = pendingNewSession || "that session";
-  const { queued, draft } = dropProvisional();
+  // retire the create MACHINERY only — dropProvisional() would dismiss the tab too
+  provisionalId = null;
+  pendingNewSession = null;
+  if (provisionalTimer) { clearTimeout(provisionalTimer); provisionalTimer = undefined; }
+  const queued = provisionalQueue.slice();
+  provisionalQueue.length = 0;
+  const ta0 = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+  const draft = (activeId === id && ta0) ? ta0.value : (drafts.get(id) ?? "");
   const held = [...queued, draft].filter(Boolean).join("\n\n");
-  showConfirm("Couldn't start " + name,
-    why + (held ? "\n\nWhat you typed is back in the message box." : ""),
-    [{ label: "OK", value: "ok" }], () => { /* nothing to undo — the tab is already gone */ });
+  pendingSent.delete(id);            // the dashed "received" bubbles fold into the held text instead
+  failedProvisionals.add(id);
+  const s = sessions.get(id);
+  // "closed" gives the tab the dead treatment (struck label, plain ✕) — but the composer stays LIVE
+  // for a failed provisional (the read-only exemption below), since the held text must stay editable
+  if (s) s.status = { state: "closed", sinceEpoch: Math.floor(Date.now() / 1000) };
+  setActive(id);                     // jump back to the failed thread BEFORE saying anything
   if (held) {
+    drafts.set(id, held); persistDrafts();
     const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
     if (ta) { ta.value = held; growComposer(ta); }
-    if (activeId) { drafts.set(activeId, held); persistDrafts(); }
   }
+  renderTabs();
+  showConfirm("Couldn't start " + name,
+    why + (held ? "\n\nWhat you typed is in this tab's message box." : ""),
+    [{ label: "OK", value: "ok" }], () => { /* the tab keeps the text until its ✕ discards both */ });
 }
 
 // The ✕ on a provisional tab: tell the kernel to abort the pending spawn too, so a slow-but-successful
@@ -5163,13 +5187,20 @@ function syncView(id: string, atBottom?: boolean): View {
   // (the user 2026-06-19). Idempotent: leaves an existing placeholder in place; the first real event clears it.
   if (s.events.length === 0) {
     const only = v.el.childNodes.length === 1 ? (v.el.firstChild as HTMLElement) : null;
-    if (!only || !only.classList?.contains("tx-empty")) {
+    // …and rebuild a placeholder whose STARTING loader outlived its create (the failure flips it to
+    // the couldn't-start notice below — the spinning loader would be a lie on a failed tab)
+    const staleStart = !!only && only.classList?.contains("tx-starting") && failedProvisionals.has(id);
+    if (!only || !only.classList?.contains("tx-empty") || staleStart) {
       while (v.el.firstChild) v.el.removeChild(v.el.firstChild);
       const ph = el("div", "tx-empty"); v.el.appendChild(ph);
       // A PROVISIONAL tab is not empty, it is STARTING — so it wears the romp loader (the repo's rule for
       // any wait), not the placeholder that tells you to send something. The composer below it is live
-      // either way: anything typed here is held and flushed when the session lands.
-      if (isProvisionalId(id)) {
+      // either way: anything typed here is held and flushed when the session lands. A FAILED create's
+      // tab says what happened instead (the user 2026-08-08) — the loader would be a lie.
+      if (isProvisionalId(id) && failedProvisionals.has(id)) {
+        ph.textContent = "This session couldn't start. What you typed is kept in the box below; "
+          + "✕ on the tab discards both.";
+      } else if (isProvisionalId(id)) {
         ph.classList.add("tx-starting");
         const sw = el("img", "tx-starting-swirl") as HTMLImageElement;
         sw.src = mediaSrc("romp-swirl-glyph.svg"); sw.alt = ""; sw.onerror = () => sw.remove();
@@ -5591,7 +5622,9 @@ function showActive() {
   // while you're viewing it disables the box live; switching back to a live tab re-enables it.
   const composer = document.getElementById("composer-input") as HTMLTextAreaElement | null;
   if (composer) {
-    const closed = s.status.state === "closed";
+    // a FAILED provisional wears the closed treatment on its tab, but its composer stays LIVE: it holds
+    // the only copy of what was typed, which must stay editable/copyable (the send path refuses loudly)
+    const closed = s.status.state === "closed" && !failedProvisionals.has(activeId!);
     composer.disabled = closed;
     composer.placeholder = closed ? "Session closed — read-only" : composerRestingPlaceholder();
     const sendBtn = document.getElementById("composer-send") as HTMLButtonElement | null;
@@ -7842,8 +7875,13 @@ function statusOnly(msg: any) {
 // must not be recorded as a close of ours, which is why the record is written HERE, not in there.)
 function closeTabLocally(id: string): void {
   // A provisional tab has no session to close — closing it means "never mind", so it cancels the spawn
-  // the kernel may still be running, the way the old cue's ✕ did.
-  if (isProvisionalId(id)) { cancelProvisional(); return; }
+  // the kernel may still be running, the way the old cue's ✕ did. A FAILED one has no spawn left either
+  // (and the kernel never knew the id): its ✕ is a plain local discard — tab, draft, and all.
+  if (isProvisionalId(id)) {
+    if (id === provisionalId) cancelProvisional();
+    else { failedProvisionals.delete(id); dismissSession(id); }
+    return;
+  }
   dismissSession(id);
   closingTabs.set(id, Date.now());
 }
@@ -8195,6 +8233,13 @@ function setupComposer() {
         return;
       }
       if (isProvisionalId(sid)) {
+        // a FAILED create's tab: there is no pending spawn to queue onto, and never a session to send
+        // to — refuse loudly and leave the text exactly where it is (the box is the only copy)
+        if (sid !== provisionalId) {
+          warnToast("“" + (sessions.get(sid)?.name || "this session") + "” never started, so there's "
+            + "nowhere to send this. It stays in the box — create the session again to use it.");
+          return;
+        }
         provisionalQueue.push(text);
         registerOptimistic(sid, text);
         if (attached.length) { composerFiles.delete(sid); if (sid === activeId) renderComposerFiles(sid); }
@@ -8694,8 +8739,13 @@ setupSettings();
     close: (el) => {
       const id = el.dataset.id;
       if (!id || !vscodeApi) return;
-      // dead → just drop the read-only tab (optimistically too: it's the same kernel round-trip to wait on)
-      if (el.dataset.dead === "1") { vscodeApi.postMessage({ type: "closeTab", id }); closeTabLocally(id); return; }
+      // dead → just drop the read-only tab (optimistically too: it's the same kernel round-trip to wait
+      // on). A failed provisional is local-only — the kernel never knew its id, so nothing to post.
+      if (el.dataset.dead === "1") {
+        if (!isProvisionalId(id)) vscodeApi.postMessage({ type: "closeTab", id });
+        closeTabLocally(id);
+        return;
+      }
       // LIVE session: show the End/Close confirm IMMEDIATELY, client-side — NOT via a closeSession→confirmClose
       // kernel round-trip, which made the ✕ feel unresponsive (and sometimes never opened the modal when the
       // kernel was busy). The dialog is static; the kernel doesn't need to decide it (the user 2026-06-24).

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3685,6 +3685,14 @@ function setSessionColor(id: string, bg: string) {
   const meta = tabMeta.get(id);
   if (meta) meta.color = color;
   renderTabs();
+  // OPTIMISTIC cross-pane echo (the user 2026-08-08): the tabs repaint on this very click, but the
+  // FEED kept the old colour until the kernel's next feed rebuild pushed — a second or two. Tell the
+  // other panes kernel-free, on the same host-matched pair settings sync rides: the browser's
+  // same-origin iframes hear the localStorage write (`storage` fires cross-document; `t` makes
+  // re-picking the same colour still fire it), and in VS Code — where each webview's localStorage is
+  // its own — the host fans {colorSync} to its other panels (__rompShowStrip marks that host).
+  try { localStorage.setItem("romp:color-echo", JSON.stringify({ sid: id, bg, t: Date.now() })); } catch { /* storage blocked */ }
+  if ((window as any).__rompShowStrip) vscodeApi?.postMessage({ type: "colorSync", sid: id, bg });
   if (vscodeApi) vscodeApi.postMessage({ type: "setSessionColor", id, bg });
 }
 

--- a/ui/webview/tab-close-optimistic.test.ts
+++ b/ui/webview/tab-close-optimistic.test.ts
@@ -118,7 +118,8 @@ test("closeTabLocally drops the tab, THEN records the close — in that order", 
   // this shipped as set-then-dismiss while dismissSession opened with closingTabs.delete(id), so the
   // record was erased the instant it was written — the executed model above passed while the composed
   // wiring was a no-op. Hence these pins hold the ORDER, and the next test holds dismissSession's hands.
-  assert.match(RENDER, /if \(isProvisionalId\(id\)\) \{ cancelProvisional\(\); return; \}\s*\n\s*dismissSession\(id\);\s*\n\s*closingTabs\.set\(id, Date\.now\(\)\);/);
+  assert.match(RENDER, /return;\s*\n\s*\}\s*\n\s*dismissSession\(id\);\s*\n\s*closingTabs\.set\(id, Date\.now\(\)\);/,
+    "the provisional short-circuit returns above; a real tab still dismisses THEN records");
   // declared beside tabMeta, NOT down by dismissSession: renderTabs reads it and can run before the module
   // finishes evaluating, which would make a `const` down there a temporal-dead-zone throw.
   assert.match(RENDER, /const tabMeta = new Map[\s\S]{0,900}?const closingTabs = new Map<string, number>\(\);/);
@@ -133,7 +134,9 @@ test("the strip skips a just-closed tab on BOTH passes (order AND the tabMeta pl
 
 test("every close path is optimistic — the in-page ✕, a dead read-only tab, and the kernel's confirmClose", () => {
   assert.match(RENDER, /closeTab", id \}\);\s*\n\s*closeTabLocally\(id\);/, "the in-page ✕ confirm");
-  assert.match(RENDER, /el\.dataset\.dead === "1"\) \{ vscodeApi\.postMessage\(\{ type: "closeTab", id \}\); closeTabLocally\(id\); return; \}/);
+  // the dead-tab ✕: still optimistic, with the closeTab post skipped for a failed provisional id the
+  // kernel never knew (2026-08-08 — the failed tab now lingers holding its text)
+  assert.match(RENDER, /if \(el\.dataset\.dead === "1"\) \{\s*\n\s*if \(!isProvisionalId\(id\)\) vscodeApi\.postMessage\(\{ type: "closeTab", id \}\);\s*\n\s*closeTabLocally\(id\);\s*\n\s*return;/);
   // the kernel-driven confirmClose modal used to post and then just sit there waiting for the push
   assert.match(RENDER, /m\.type === "confirmClose"[\s\S]*?closeTabLocally\(m\.id\);/);
 });

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -332,6 +332,16 @@ function broadcastSettings(settings: unknown, from?: vscode.Webview) {
   }
 }
 
+// The optimistic colour echo rides the same fan-out (the user 2026-08-08): a tab-menu swatch pick in
+// the chat pane repaints the FEED's cards immediately, instead of waiting out the kernel's next feed
+// rebuild. The kernel still gets setSessionColor and its re-broadcast reconciles; this is display-only.
+function broadcastColorSync(m: { sid?: unknown; bg?: unknown }, from?: vscode.Webview) {
+  if (typeof m.sid !== "string" || typeof m.bg !== "string") return;
+  for (const w of [panel?.webview, feedPanel?.webview, fleetPanel?.webview, timelineView?.webview]) {
+    if (w && w !== from) w.postMessage({ type: "colorSync", sid: m.sid, bg: m.bg });
+  }
+}
+
 // ---- the kernel: ENSURE-THEN-ATTACH (the manager owns it; we never spawn) ----
 // VS Code does NOT spawn the kernel. It attaches to a manager-owned kernel on romp.kernelPort; if none
 // is there, it asks the `romp up` manager to ENSURE one (the manager spawns + owns it), waits for it,
@@ -537,6 +547,7 @@ function wirePanel(p: vscode.WebviewPanel) {
     if (m.type === "openLink" && typeof m.href === "string") { openLink(String(m.href)); return; }
     if (m.type === "openPane") { openPaneByKey(String(m.pane)); return; }   // strip quick-open
     if (m.type === "settingsSync") { broadcastSettings(m.settings, p.webview); return; }   // gear save → other panes
+    if (m.type === "colorSync") { broadcastColorSync(m, p.webview); return; }   // tab swatch pick → feed repaints now
     if (m.type === "pickFile") { void pickFileForComposer(p); return; }
     if (m.type === "readClipboard") {
       vscode.env.clipboard.readText().then(

--- a/vscode-extension/src/timeline-host-gap.test.ts
+++ b/vscode-extension/src/timeline-host-gap.test.ts
@@ -1,0 +1,19 @@
+// The half-row gap at host boundaries is GONE (the user 2026-08-08): remote hosts' lanes no longer
+// interleave with local ones in a single shared order, so the boundary said nothing — lanes list out
+// uniformly and the quiet "host:" name prefix alone marks a remote session. This pins the uniform
+// geometry everywhere a lane y was computed with the old offsets (draw, drag-invert, focus pulse,
+// judge band), so the gap cannot creep back into one path and skew the others.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const TL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
+
+test("timeline lanes are uniform — no host-boundary offsets in any geometry path", () => {
+  assert.doesNotMatch(TL, /laneOff/, "the offset machinery is fully removed, not just zeroed");
+  assert.ok(TL.includes("const laneY = (i) => M.top + i * LANE_GAP + LANE_GAP * 0.5;"), "draw");
+  assert.ok(TL.includes("const ly = this._geom.top + i * LANE_GAP + LANE_GAP / 2;"), "drag invert");
+  assert.ok(TL.includes("const y = g.top + i * LANE_GAP + LANE_GAP * 0.5;"), "focus pulse");
+  assert.ok(TL.includes("const jb0 = M.top + vis.length * LANE_GAP + JB_TOPGAP;"), "judge band top");
+});


### PR DESCRIPTION
Five changes from one session (the user 2026-08-08):

- **Feed session filter.** A footer menu right of the Group toggle listing every session the chat tab strip shows, in its order, canonical form (identity dot + quiet host: prefix). Pick one to narrow the board; default is nothing selected. The kernel attaches the tab list to the feed payload; federation prefixes + concatenates; the filter narrows the render only and clears itself when its session leaves the tab strip.
- **Instant colour echo.** A tab-menu swatch pick now repaints the feed immediately via a kernel-free cross-pane echo (localStorage storage event in the browser, a colorSync host fan-out in VS Code — the settings-sync pair). The kernel re-broadcast reconciles behind it.
- **Token delta-folding.** The result event's `usage` is the process-lifetime totalUsage counter, like total_cost_usd — folding it raw compounded the token readout (wild $-per-token divergence across the 5h/7d/month windows). Per-field deltas with per-process watermark reset.
- **Uniform timeline lanes.** The host-boundary half-row gap is removed from every geometry path — hosts no longer interleave in one order, so it said nothing.
- **Failed create keeps its tab.** "Couldn't start X" used to tear down the provisional tab and dump the held text into whichever tab was active, rewriting an unrelated thread's draft. The failure now jumps back to its own tab first; the tab stays with the text in its box, composer live, send refused loudly, ✕ discards both.

Tests: feed-session-filter.test.ts (+ functional federation legs), feed-color-echo.test.ts, timeline-host-gap.test.ts, provisional.test.ts extensions, test_kernel.py feed-payload sessions, test_sdk_backend.py token-delta folding. Suites green: 3948 py, 1717 node, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)