### PR TITLE
A workless follow-up is still judged at turn end, releasing its latch

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -611,7 +611,7 @@ class FileAdapter:
             "author": author_of(blocks, None, postal_index, getattr(self, "sdk_human", False)),
             "absorbed": True,   # a mid-turn splice: the turn's FOLLOWING atoms are the interrupted
             #                     ask's continuing work, not provably a reply to this — judges must
-            #                     not read them as one (jd._seg_spliced / _strip_spliced_dones).
+            #                     not read them as one (jd._seg_spliced / _strip_unevidenced_dones).
             #                     Metadata only: the atom set and seg ids are unchanged (no
             #                     PLACEMENTS_V bump).
             "_seq": seq,

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2342,31 +2342,41 @@ def _seg_spliced(seg):
     `absorbed`). The atoms after such a trigger are the interrupted turn's CONTINUING work: by
     wall-clock they follow the enqueue, but they answer the turn's ORIGINAL ask — deterministically
     indistinguishable from a reply to the splice. So work in this segment is never proof that the
-    spliced ask, or any listed goal, was answered (see _strip_spliced_dones)."""
+    spliced ask, or any listed goal, was answered (see _strip_unevidenced_dones)."""
     trig = (seg or {}).get("trigger")
     if not trig:
         return False
     return any(a.get("uuid") == trig and a.get("absorbed") for a in seg.get("atoms") or [])
 
 
-def _strip_spliced_dones(ops, seg, fsid, seg_id):
-    """Drop planner DONE ops filed off a SPLICED-trigger segment (_seg_spliced). A capable planner,
-    handed 'USER ASKED: …' plus the interrupted turn's unrelated tail work, answers the question
-    from its OWN knowledge and files done with a confabulated summary — a queued question completed
-    as a card 30 seconds after it was typed, before the assistant's first post-splice token, off a
-    turn that then crashed without ever replying (the user 2026-07-29). Same failure family as the
-    API-error confabulation (the user 2026-07-25), but that guard keys on NO assistant work, and a
-    splice defeats it: the absorbed segment inherits the running turn's real atoms. Mint/sub/block
-    still apply — placing the ask and filing the tail work are right — and the goal stays OPEN,
-    which is the truth; the turn-level closer keeps done authority once the turn actually ends.
-    Logged (judge-errors, kind 'spliced-done'), never silent."""
-    if not ops or not _seg_spliced(seg):
+def _strip_unevidenced_dones(ops, seg, fsid, seg_id):
+    """Drop planner DONE ops a segment cannot EVIDENCE — two shapes of one rule (a done needs the
+    reply's own post-ask work as proof):
+      - SPLICED trigger (_seg_spliced): a capable planner, handed 'USER ASKED: …' plus the
+        interrupted turn's unrelated tail work, answers the question from its OWN knowledge and
+        files done with a confabulated summary — a queued question completed as a card 30 seconds
+        after it was typed, before the assistant's first post-splice token, off a turn that then
+        crashed without ever replying (the user 2026-07-29).
+      - WORKLESS segment (no assistant work at all): the workless FOLLOW-UP unit (the user
+        2026-08-08, the beacon g10 card) judges the user's reply so the msg-reopen latch gets its
+        verdict — the reply is real evidence of the user's INTENT (pivot / continuation / block),
+        never of completion. Same failure family as the API-error confabulation (the user
+        2026-07-25), whose mint-only prompt-run op filter already enforces this for plain asks.
+    Mint/sub/block still apply — placing the ask and filing the work are right — and the goal stays
+    OPEN, which is the truth; the turn-level closer keeps done authority once the turn actually
+    ends. Logged (judge-errors, kinds 'spliced-done' / 'workless-done'), never silent."""
+    if not ops:
+        return ops
+    spliced = _seg_spliced(seg)
+    workless = not _has_asst_work((seg or {}).get("atoms") or [])
+    if not (spliced or workless):
         return ops
     kept = [o for o in ops if o.get("do") != "done"]
     if len(kept) != len(ops):
-        _log_judge_error("planner", fsid, "spliced-done", seg=seg_id,
-                         note="dropped %d done op(s): a spliced-trigger segment cannot evidence an answer"
-                              % (len(ops) - len(kept)))
+        kind, shape = (("spliced-done", "spliced-trigger") if spliced else ("workless-done", "workless"))
+        _log_judge_error("planner", fsid, kind, seg=seg_id,
+                         note="dropped %d done op(s): a %s segment cannot evidence an answer"
+                              % (len(ops) - len(kept), shape))
     return kept
 
 
@@ -3907,6 +3917,20 @@ def plan_units(session, store=None):
                         ptext = _strip_cmd_prefix(ptext, seg)
                     if ptext:
                         out.append((seg["id"], "prompt", seg["t"], ptext, True, None, trig, vq))
+                elif _seg_followup(seg) and not _seg_nudge(seg) and not _seg_peer(seg):
+                    # A workless FOLLOW-UP is still JUDGED (the user 2026-08-08, the beacon g10 card):
+                    # the card reply armed the fold's msg-reopen latch (followupPending — the card pins
+                    # Working and the nudge gate defers on "your reply is still being judged" until a
+                    # judge verdict lands on the top), and the follow-up work-run is the ONLY unit that
+                    # files that verdict. A reply that lands as its own turn while the response opens
+                    # the NEXT turn stays workless forever, so skipping it here left the latch waiting
+                    # on an event that could never arrive — a card wedged in Working+Stalled on an idle
+                    # session. Turn end is the event the has-work proxy was approximating; the branch's
+                    # own reopen/dismiss row is the release, and _strip_unevidenced_dones keeps a
+                    # workless reply from CLAIMING completion (the closer holds done authority). Nudges
+                    # keep their skip: their machinery re-asks and escalates on its own.
+                    out.append((seg["id"], "work", seg["t"], work_text, _seg_human(seg),
+                                _seg_followup(seg), trig, vq))
                 continue
             if _seg_peer(seg):                            # POSTAL segment → DELEGATION work-run (files under the courier's goal)
                 if not is_open_final:                     # ended → the recipient's work is known; place it under G
@@ -5309,7 +5333,7 @@ def _plan_session(fsid, path, now):
             hist = _goal_work_text(store, seg_by_id, target, GOAL_HISTORY_CHARS)
             ops = _parse_plan(plan_llm(text, _menu_text(store, sub), human=False,
                                        goal_history=hist, goal_num=1), len(sub)) or []
-            ops = _strip_spliced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # a peer message spliced
+            ops = _strip_unevidenced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # a peer message spliced
             #                                           mid-turn can't evidence an answer any more than a
             #                                           spliced human ask can — the fallback sub still files
             # Full expressivity, ROOTED under G: a delegation gets the same sub/done/block a human-minted top
@@ -5398,7 +5422,7 @@ def _plan_session(fsid, path, now):
                 ops = [{"do": "sub", "under": 1, "text": o.get("text"), "why": o.get("why")}
                        if o["do"] == "mint" else o for o in ops if o["do"] != "skip"]
                 ops = _restrict_retitle(ops, 1)          # goal_num=1 above → retitle is only valid on #1
-                ops = _strip_spliced_dones(ops, _tseg, fsid, seg_id)   # a nudge spliced mid-turn reads the
+                ops = _strip_unevidenced_dones(ops, _tseg, fsid, seg_id)   # a nudge spliced mid-turn reads the
                 #                                           interrupted turn's work as its reply — resolve
                 #                                           nothing; the goal stays open and re-nudgeable
                 apply_plan(store, seg_id, seg_t, ops, sub, place_key=_pkey, prompt_uuid=trig, quote=vq)
@@ -5434,7 +5458,7 @@ def _plan_session(fsid, path, now):
                                            goal_history=hist, goal_num=gi, followup=True,
                                            lifted_blocks=[(i, a) for i, (_n, a) in sorted(lifted_by_num.items())] or None),
                                   len(menu)) or []
-                ops = _strip_spliced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # a card reply spliced
+                ops = _strip_unevidenced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # a card reply spliced
                 #                                           mid-turn: strip BEFORE the pivot apply and before
                 #                                           the continuation lifts `res`, so a confabulated
                 #                                           done never re-completes the reopened target
@@ -5560,7 +5584,7 @@ def _plan_session(fsid, path, now):
             ops = _coerce_place(menu, text, title=_prompt_gist(fsid, seg_id) or None)   # HARD GUARD: a user
             #                                           message never silently vanishes
         store.get("parseFails", {}).pop(seg_id, None)  # placed → forget any earlier parse-fails on it
-        ops = _strip_spliced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # the incident path (the user
+        ops = _strip_unevidenced_dones(ops, seg_by_id.get(seg_id), fsid, seg_id)   # the incident path (the user
         #                                           2026-07-29): a queued ask's work-run confabulated a done
         if not ops:                                    # the reply was done-ONLY and stripped → same floor as a
             if not human or p_target:                  #  skip: record processed, or hard-place the ask (a user

--- a/tests/test_judge_spliced_done.py
+++ b/tests/test_judge_spliced_done.py
@@ -10,7 +10,7 @@ work, none of it a reply to the spliced ask — so the no-work guard from the AP
 own knowledge and filed done with a confabulated summary — 30 seconds after the ask was typed,
 before the assistant's first post-splice token. Now the event model marks the synthesized splice
 atom `absorbed`, and planner DONE ops filed off a spliced-trigger segment are stripped
-(_strip_spliced_dones): work in such a segment is never proof the spliced ask — or any listed goal —
+(_strip_unevidenced_dones, spliced leg): work in such a segment is never proof the spliced ask — or any listed goal —
 was answered. Mint/sub still apply (the ask gets its card, the tail work files), the goal stays
 open — the truth — and the turn-level closer keeps done authority. SYNTHETIC fixtures only."""
 import json

--- a/tests/test_judge_workless_followup_wedge.py
+++ b/tests/test_judge_workless_followup_wedge.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""A workless FOLLOW-UP segment must still be judged once its turn ends (the user 2026-08-08, the
+beacon g10 card).
+
+A card reply sets the fold's msg-reopen latch (followupPending): the card is pinned Working and the
+nudge gate defers on "your reply is still being judged" until a judge verdict lands on the top. The
+unit builder, though, skipped any ended segment with no assistant work ("files nothing" — the
+anti-confabulation rule for API-error turns), and a follow-up is WORK-RUN ONLY — so a reply that
+landed as its own turn while the response opened the NEXT turn left the reply's segment workless
+forever. Nothing ever judged it, the latch's deciding event could never arrive, and the card sat
+wedged: pinned Working on an idle session, the nudge gate frozen, the feed's Stalled section holding
+it. Same law as the moot-#p wedge (PR #69): a unit the pipeline declines to judge must not leave a
+latch waiting on that judgment.
+
+The fix: a follow-up segment's work-run fires at TURN END (the event the has-work proxy was
+approximating), workless or not — the planner's own reopen/dismiss row is the latch release. What a
+workless segment cannot evidence is COMPLETION, so its done ops are stripped by the same guard that
+strips spliced ones (_strip_unevidenced_dones); the turn-level closer keeps done authority.
+
+SYNTHETIC fixtures only: placeholder UUIDs, the neutral notes-api demo domain.
+"""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+jd = SourceFileLoader("romp_judge_workless_fu", os.path.join(BIN, "romp-judge")).load_module()
+
+NOW = 1781200000
+SID = "11111111-2222-3333-4444-777777777777"
+GID = SID + ":g1"
+T0 = NOW - 3600          # the original ask
+T_R = NOW - 1800         # the user's card reply (its own turn, never answered in it)
+T_W = NOW - 1700         # the later turn where the actual response work happened
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, stop="end_turn"):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+REPLY = "Looks right — keep the single worker and ship the notes-api deploy as is."
+SKIP = '{"ops":[{"why":"nothing to file","do":"skip"}]}'
+FU_DONE = '{"ops":[{"why":"the reply says it is finished","do":"done","goal":1}]}'
+FU_PIVOT = ('{"ops":[{"why":"the reply asks for something new","do":"mint",'
+            '"text":"Add a health check to the notes-api deploy"}]}')
+
+
+class WorklessFollowupWedge(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self.td))
+        jd._PARSE_CACHE.clear()
+        # an OPEN top the user just replied to: the optimistic msg-reopen is the latch
+        self.store = {"rompUuid": SID, "seq": 1, "placementsV": jd.PLACEMENTS_V,
+                      "nodes": {GID: {"id": GID, "text": "Ship the notes-api deploy", "parentId": None,
+                                      "nodeComplete": False, "blocked": False, "cleared": False,
+                                      "trail": [], "t": T0, "mt": T0,
+                                      "log": [{"ev_t": T_R, "src": "user", "kind": "reopen",
+                                               "why": "reopened (optimistic)", "msg": True, "at": T_R}]}},
+                      "placements": {}, "status": {}, "lastNode": GID}
+        jd.save_goals(SID, self.store)
+        self._saved = (jd.plan_llm, jd.opener_llm, jd._group_store)
+        jd.opener_llm = lambda *a, **k: ""
+        jd._group_store = lambda *a, **k: None
+        self._set_followup_plan(SKIP)
+
+    def tearDown(self):
+        jd.plan_llm, jd.opener_llm, jd._group_store = self._saved
+
+    def _set_followup_plan(self, fu_plan):
+        """plan_llm stub: `fu_plan` for the follow-up unit, SKIP for everything else."""
+        self.fu_calls = []
+        def fake(*a, **k):
+            if k.get("followup"):
+                self.fu_calls.append(k)
+                return fu_plan
+            return SKIP
+        jd.plan_llm = fake
+
+    def _transcript(self, reply_answered=False):
+        """Turn 1: the ask, worked and ended. The reply lands next with NO assistant response of its
+        own (unless reply_answered); the actual follow-through happens under a later prompt — the
+        beacon shape."""
+        recs = [
+            uline(T0, "Ship the notes-api deploy", "u1"),
+            aline(T0 + 60, "Deployed to staging; single worker for now.", "a1", "u1"),
+            uline(T_R, REPLY + "<!-- romp-goal-id: %s -->" % GID, "r1", "a1"),
+        ]
+        parent = "r1"
+        if reply_answered:
+            recs.append(aline(T_R + 20, "Shipping it as is now — done.", "ar1", "r1"))
+            parent = "ar1"
+        recs += [
+            uline(T_W, "also bump the client pin", "u2", parent),
+            aline(T_W + 60, "Pinned and pushed.", "a2", "u2"),
+        ]
+        path = os.path.join(self.td, SID + ".jsonl")
+        open(path, "w").write("\n".join(json.dumps(r) for r in recs) + "\n")
+        jd._PARSE_CACHE.clear()
+        return path
+
+    def _fold(self):
+        nodes = jd.load_goals(SID)["nodes"]
+        return jd._fold_node(nodes[GID]), nodes
+
+    def _reply_seg_placed(self, store):
+        return any(("%d:" % T_R) in k for k in store["placements"])
+
+    # ---- the wedge ----
+    def test_workless_followup_is_judged_and_releases_the_latch(self):
+        path = self._transcript()
+        f, _ = self._fold()
+        self.assertTrue(f["pending"], "the msg-reopen latch is armed before the pass")
+        jd._plan_session(SID, path, NOW)
+        store = jd.load_goals(SID)
+        self.assertTrue(self._reply_seg_placed(store),
+                        "the reply's segment is processed once its turn has ended")
+        f, _ = self._fold()
+        self.assertFalse(f["pending"],
+                         "a planner row landed on the top — the latch's deciding event arrived")
+        self.assertTrue(self.fu_calls, "…via the follow-up unit, not the free path")
+
+    # ---- done authority stays with real work ----
+    def test_workless_followup_done_is_stripped_but_still_releases(self):
+        path = self._transcript()
+        self._set_followup_plan(FU_DONE)
+        jd._plan_session(SID, path, NOW)
+        f, nodes = self._fold()
+        self.assertFalse(nodes[GID].get("nodeComplete"),
+                         "a workless reply can prove intent, never completion")
+        self.assertFalse(f["pending"], "the strip still leaves the latch released")
+        errs = (jd.STATE / "judge-errors.jsonl").read_text()
+        self.assertIn("workless-done", errs, "the drop is loud, never silent")
+
+    def test_answered_followup_done_still_carries_through(self):
+        path = self._transcript(reply_answered=True)
+        self._set_followup_plan(FU_DONE)
+        jd._plan_session(SID, path, NOW)
+        f, nodes = self._fold()
+        self.assertTrue(nodes[GID].get("nodeComplete"),
+                        "a reply answered in its own turn keeps the g142 carry-through")
+        self.assertFalse(f["pending"])
+
+    # ---- the pivot shape ----
+    def test_workless_followup_pivot_dismisses_the_latch(self):
+        path = self._transcript()
+        self._set_followup_plan(FU_PIVOT)
+        jd._plan_session(SID, path, NOW)
+        f, nodes = self._fold()
+        self.assertFalse(f["pending"], "the pivot's dismiss answers the msg-reopen")
+        self.assertFalse(nodes[GID].get("nodeComplete"), "the cited goal is unchanged")
+        self.assertTrue(any(n.get("parentId") is None and n["id"] != GID for n in nodes.values()),
+                        "the reply's new thread got its own top")
+
+    # ---- nudges keep their own design ----
+    def test_workless_nudge_still_files_nothing(self):
+        """An unanswered NUDGE stays re-nudgeable (its own machinery escalates it); the follow-up fix
+        must not sweep nudge segments into judgment."""
+        nudge = ("Where does this stand?<!-- romp-injected --><!-- romp-auto -->"
+                 "<!-- romp-goal-id: %s -->" % GID)
+        recs = [
+            uline(T0, "Ship the notes-api deploy", "u1"),
+            aline(T0 + 60, "Deployed to staging.", "a1", "u1"),
+            uline(T_R, nudge, "n1", "a1"),
+            uline(T_W, "also bump the client pin", "u2", "n1"),
+            aline(T_W + 60, "Pinned and pushed.", "a2", "u2"),
+        ]
+        path = os.path.join(self.td, SID + ".jsonl")
+        open(path, "w").write("\n".join(json.dumps(r) for r in recs) + "\n")
+        jd._PARSE_CACHE.clear()
+        jd._plan_session(SID, path, NOW)
+        self.assertFalse(self.fu_calls, "a nudge is never a follow-up unit")
+        store = jd.load_goals(SID)
+        self.assertFalse(self._reply_seg_placed(store), "the unanswered nudge stays unfiled")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug (2026-08-08)

A card sat wedged in Working with the feed's Stalled section holding it ("your reply to the card is still being judged", frozen for over an hour) while its session idled. The user's reply had armed the msg-reopen latch (`followupPending`), which by design releases only when a judge verdict lands on the top.

The reply landed as its own turn; the actual response opened the NEXT turn. Follow-ups are work-run only, and the unit builder skips any ended segment with no assistant work ("files nothing" — the API-error anti-confabulation rule). So the reply's segment stayed workless and unjudged forever: the latch's deciding event could never arrive. Rollup pinned the card Working, the nudge gate deferred forever, `_stalled_goals` surfaced the hold. The planner's three attempts to rule via other (spliced) segments were correctly dropped by the spliced-done guard, which masked the real gap.

## The fix

Same law as the moot-#p wedge (PR #69): a unit the pipeline declines to judge must not leave a latch waiting on that judgment.

- The follow-up work-run fires at **turn end** — the event the has-work proxy was approximating — workless or not. The branch's own reopen (continuation) or dismiss (pivot) row is the latch release; both already land unconditionally.
- A workless reply evidences the user's **intent**, never **completion**: `_strip_spliced_dones` generalizes to `_strip_unevidenced_dones` (spliced OR workless — two shapes of "a done needs the reply's own post-ask work as proof"), logged as `spliced-done` / `workless-done`. The turn-level closer keeps done authority.
- Workless **nudges** keep their designed skip (their machinery re-asks and escalates); answered replies keep the done carry-through (quartz g142); the API-error mint-only prompt-run is untouched.
- Self-healing: a live wedged card's reply segment was never marked processed, so the first plan pass on the fixed code judges it and releases the latch — no manual store surgery.

## Tests

`tests/test_judge_workless_followup_wedge.py` (synthetic, notes-api domain; red before the fix): the wedge (workless reply → judged at turn end, latch released), done stripped-but-released with the loud log, answered-reply carry-through, pivot dismiss, and nudge-skip non-regression. Full suites green: pytest 4001, vscode-extension typecheck + 1729 node tests, manager tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)