### PR TITLE
Interrupted sessions re-block their live focus goal; the intrBlocked marker is verified, never trusted

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -7167,7 +7167,13 @@ def _blocked_sub_candidates(store):
     g48): a blocked top's designed heal paths — a reply on its own thread, a placement under it — cover
     only answers that land ON the card; an answer given on a sibling card's thread reaches neither, and
     the card sat in Needs-you forever. Each with its block-event time (the diary is the authority; mt
-    gets bumped by other touches)."""
+    gets bumped by other touches).
+
+    INTERRUPT-src blocks excluded (the user 2026-08-08): "waiting on your next instruction" is not a
+    question session output can answer — the kernel lifts it on the user's re-engagement, and a done
+    verdict completes over it. Re-examining one here lifted a stop-block seconds after placement, off
+    the cut turn's own settling output, and the stopped session's card went back to Working with
+    auto-nudge suppressed: invisible-blocked."""
     nodes = store["nodes"]
 
     def _sealed(nid):
@@ -7186,6 +7192,9 @@ def _blocked_sub_candidates(store):
     for nid, nd in nodes.items():
         if not nd.get("blocked") or nd.get("cleared") or _sealed(nid):
             continue
+        if next((e.get("src") for e in reversed(nd.get("log") or [])
+                 if e.get("kind") == "block"), None) == "interrupt":
+            continue                    # a procedural stop-block: only the user's re-engagement lifts it
         block_t = max((e.get("ev_t") or 0 for e in (nd.get("log") or []) if e.get("kind") == "block"),
                       default=nd.get("mt", nd.get("t", 0)))
         out.append((nid, nd, block_t))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1954,9 +1954,18 @@ def _record_interrupt_block(sid, ev):
     block rides — and remember the gid in auto-nudge.json so the LIFT on re-engage is cheap (only
     sessions we blocked get their store re-checked). Returns the gid blocked, or None.
 
-    `ev` = the STOP's own transcript time (_interrupt_marks), never wall-clock now: the diary is an
-    evidence-time ledger, and a wall-clock stamp on a store the judges also write is what deadlocked
-    the lift below."""
+    `ev` = the newest evidence of the stopped QUIET — the stop's own transcript time joined by the
+    tick with the transcript's newest event — never wall-clock now: the diary is an evidence-time
+    ledger, and a wall-clock stamp on a store the judges also write is what deadlocked the lift below.
+    The join matters (the user 2026-08-08): injected activity (a task notification, a peer message)
+    can run and settle AFTER the stop with the user silent throughout, and the judges file rows off
+    it — a block stamped at the bare stop folds UNDER those rows as a silent no-op.
+
+    Stands down (returns None, appending NOTHING) when the target's diary already holds a newer
+    unblock/reopen/done/settle row: the judges ruled on a newer world than this evidence, and the
+    fold would bury the row anyway. The tick retries every push, so a refused APPEND would grow the
+    diary at push cadence; refusing without one keeps it clean until newer evidence (the next settled
+    turn) makes the block land."""
     store = jd.load_goals(sid)
     gid = _interrupt_focus_top(store)
     if not gid:
@@ -1964,6 +1973,10 @@ def _record_interrupt_block(sid, ev):
     nd = store["nodes"][gid]
     why = jd.INTERRUPT_BLOCK_WHY      # shared constant, PROCEDURAL (see judge.procedural_block_why)
     ev = int(ev or 0)
+    ceil = max((e.get("ev_t") or 0 for e in (nd.get("log") or [])
+                if e.get("kind") in ("unblock", "reopen", "done", "settle")), default=0)
+    if ev <= ceil:
+        return None                   # the diary outranks this evidence — stand down (see docstring)
     if not jd.record_verdict(store, nd, "interrupt", "block", ev, why=why):
         return None
     nd["mt"] = max(nd.get("mt") or 0, ev)            # the event materialized blocked + blockWhy (never
@@ -2026,6 +2039,24 @@ def _set_intr_blocked(sid, gid):
     _write_auto_nudge(d)
 
 
+def _intr_block_stands(sid, gid):
+    """True while the block the intrBlocked marker points at still HOLDS its card: the node exists in
+    the live store and is blocked (any src — a real judge block owning the card counts; the episode's
+    job, surfacing the stop, is done either way). The marker alone is a CLAIM, not evidence: the world
+    moves under it — judges unblock or complete the goal off newer turns, the user clears the card,
+    compaction archives it — and a tick that trusts the bare marker skips the re-block forever while
+    the session's live focus goal sits in Working wearing only the 'interrupted' badge, auto-nudge
+    suppressed: invisible-blocked (the user 2026-08-08, whose stopped session's marker pointed at a
+    goal since ruled done, cleared, and archived)."""
+    if not gid:
+        return False
+    try:
+        nd = jd.load_goals(sid).get("nodes", {}).get(gid)
+    except Exception:
+        return False
+    return bool(nd and nd.get("blocked"))
+
+
 def _interrupt_block_tick(now, tmux):
     """Interrupt → Blocked, INDEPENDENT of the auto-nudge switch (the user 2026-07-14). A session the
     user genuinely STOPPED mid-turn is waiting on their next instruction: its focus goal needs THEM, so
@@ -2035,7 +2066,12 @@ def _interrupt_block_tick(now, tmux):
     process death) is NOT a user stop — _interrupt_marks already excludes it — so those are continued,
     never blocked. On re-engage (the user's next message, or once a machine cut is no longer the latest
     action) the block WE placed is lifted; a real judge verdict recorded since then stays. Both writes
-    are stamped with the EVENT they are about, never wall-clock now — see _lift_interrupt_block."""
+    are stamped with the EVENT they are about, never wall-clock now — see _lift_interrupt_block.
+
+    The once-per-episode marker is VERIFIED against the store each tick, never trusted (the user
+    2026-08-08): judges complete/clear the goal it points at off newer turns (or compaction archives
+    it), and trusting the bare marker skipped the re-block forever — the live focus goal sat in
+    Working wearing only the badge, auto-nudge suppressed: invisible-blocked."""
     changed = False
     for s in _alive_sessions(now, tmux):
         sid = s["sid"]
@@ -2054,8 +2090,20 @@ def _interrupt_block_tick(now, tmux):
         #                                                  evidence times both writes are stamped with
         block_it = bool(turns) and not _session_working(turns) and stop_t > human_t
         if block_it:                                     # a GENUINE user stop → block the focus goal on them,
-            if not _intr_blocked(sid):                   # once per interrupt episode (the intrBlocked marker)
-                g = _record_interrupt_block(sid, stop_t)
+            ib = _intr_blocked(sid)                      # once per interrupt episode (the intrBlocked marker) —
+            if ib and not _intr_block_stands(sid, ib):   # but VERIFY the marked block still holds its card (see
+                _set_intr_blocked(sid, None)             # _intr_block_stands): a stale marker is the 'already
+                ib = None                                # surfaced' claim with its evidence gone
+            if not ib:
+                # the evidence is the CURRENT quiet, not just the stop: the transcript's newest event
+                # time is the horizon the user has stayed silent through — injected activity (a task
+                # notification, a peer message) may have run and settled since the stop, and it can
+                # FOLD into the cut turn rather than open one, so the last turn's trigger undershoots.
+                # Stamped so, a re-block lands over the judges' rows off that activity instead of
+                # folding under them — see _record_interrupt_block's stand-down
+                ev = max([stop_t] + [a.get("t") or 0 for turn in turns
+                                     for a in (turn.get("atoms") or [])])
+                g = _record_interrupt_block(sid, ev)
                 if g:
                     _set_intr_blocked(sid, g); changed = True
         else:                                            # working / re-engaged / machine cut → lift OUR block if any

--- a/tests/test_judge_unblocker.py
+++ b/tests/test_judge_unblocker.py
@@ -114,6 +114,46 @@ class UnblockerBase(unittest.TestCase):
         return other
 
 
+class InterruptBlocksAreNotUnblockerBusiness(UnblockerBase):
+    """INTERRUPT-src blocks are out of the candidate set (the user 2026-08-08): "waiting on your next
+    instruction" is not a question session output can answer — the kernel lifts it on the user's
+    re-engagement, and a done verdict completes over it. Re-examining one here lifted a stop-block
+    seconds after placement, off the cut turn's own settling output, and the stopped session's card
+    went back to Working with auto-nudge suppressed: invisible-blocked."""
+
+    def _interrupt_store(self, block_t):
+        top = SID + ":g1"
+        why = jd.INTERRUPT_BLOCK_WHY
+        store = {"rompUuid": SID, "seq": 1, "lastNode": top, "placements": {}, "status": {},
+                 "nodes": {top: {"id": top, "text": "wire the widget", "parentId": None,
+                                 "nodeComplete": False, "cleared": False, "blocked": True,
+                                 "blockWhy": why, "trail": [], "t": T0, "mt": block_t,
+                                 "log": [{"ev_t": block_t, "src": "interrupt", "kind": "block",
+                                          "why": why, "at": block_t}]}}}
+        jd.save_goals(SID, store)
+        return top
+
+    def test_a_stop_block_is_never_shown_to_the_model(self):
+        top = self._interrupt_store(block_t=T0 + 100)
+        self.assertEqual(jd._blocked_sub_candidates(jd.load_goals(SID)), [])
+        path = self._transcript([(T0 + 200, "<task-notification>a background task finished</task-notification>",
+                                  "picked the work back up and shipped it")])
+        self._stub('{"verdicts": [{"n": 1, "do": "lift", "why": "the session picked the work back up"}]}')
+        self.assertEqual(jd._unblock_session(SID, path, NOW), [])
+        self.assertEqual(self.calls, [], "no model call — the stop-block was never a candidate")
+        self.assertTrue(jd.load_goals(SID)["nodes"][top]["blocked"],
+                        "only the user's re-engagement lifts a stop-block")
+
+    def test_a_newer_real_judge_block_re_enters_the_set(self):
+        top = self._interrupt_store(block_t=T0 + 100)
+        store = jd.load_goals(SID)
+        jd.record_verdict(store, store["nodes"][top], "closer", "block", T0 + 300, why="pick a port")
+        jd.save_goals(SID, store)
+        cands = jd._blocked_sub_candidates(jd.load_goals(SID))
+        self.assertEqual([nid for nid, _nd, _bt in cands], [top],
+                         "the LATEST block row decides — a real question is examined again")
+
+
 class Unblocker(UnblockerBase):
     def test_an_answered_in_passing_block_is_lifted(self):
         top, sub = self._store(block_t=T0 + 100)

--- a/tests/test_kernel_interrupt_blocks.py
+++ b/tests/test_kernel_interrupt_blocks.py
@@ -92,6 +92,45 @@ class InterruptBlocks(unittest.TestCase):
         kern._set_intr_blocked(SID, None)
         self.assertIsNone(kern._intr_blocked(SID))
 
+    def test_the_marker_is_verified_against_the_store_not_trusted(self):
+        # the marker means "this episode already surfaced the stop" — but the world moves under it
+        # (the user 2026-08-08): _intr_block_stands is the tick's check that the block still HOLDS
+        _seed()
+        self.assertFalse(kern._intr_block_stands(SID, GID), "no block recorded → nothing stands")
+        self.assertFalse(kern._intr_block_stands(SID, SID + ":g99"),
+                         "a vanished node (cleared + archived by compaction) cannot stand")
+        kern._record_interrupt_block(SID, STOP_T)
+        self.assertTrue(kern._intr_block_stands(SID, GID))
+        st = jd.load_goals(SID)
+        jd.record_verdict(st, st["nodes"][GID], "unblocker", "unblock", STOP_T + 6,
+                          why="answered in passing: picked the work back up")
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+        self.assertFalse(kern._intr_block_stands(SID, GID),
+                         "the judges lifted it — the marker no longer holds a card")
+
+    def test_record_stands_down_under_newer_judge_rows_without_appending(self):
+        # a block stamped at the old stop would fold UNDER rows the judges filed off newer turns — a
+        # silent no-op retried every push. It must refuse WITHOUT appending, then land the moment the
+        # quiet's evidence (the newest settled turn) outranks the diary (the user 2026-08-08).
+        _seed()
+        st = jd.load_goals(SID)
+        jd.record_verdict(st, st["nodes"][GID], "interrupt", "block", STOP_T, why=jd.INTERRUPT_BLOCK_WHY)
+        jd.record_verdict(st, st["nodes"][GID], "unblocker", "unblock", STOP_T + 6,
+                          why="answered in passing: picked the work back up")
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+        rows = len(jd.load_goals(SID)["nodes"][GID]["log"])
+        self.assertIsNone(kern._record_interrupt_block(SID, STOP_T),
+                          "evidence older than the judges' newest row — stand down")
+        st = jd.load_goals(SID)
+        self.assertEqual(len(st["nodes"][GID]["log"]), rows,
+                         "refused WITHOUT appending — no diary growth at push cadence")
+        self.assertEqual(st["status"][GID], "working")
+        # an injected turn settled later with the user still silent → the quiet's evidence is newer
+        self.assertEqual(kern._record_interrupt_block(SID, STOP_T + 300), GID)
+        self.assertEqual(jd.load_goals(SID)["status"][GID], "blocked")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kernel_interrupt_machine_cut.py
+++ b/tests/test_kernel_interrupt_machine_cut.py
@@ -123,10 +123,10 @@ class MachineCutSuppression(unittest.TestCase):
         self.assertFalse(km._interrupt_suppresses_nudge(turns))
 
 
-class MachineCutFeedAndNudge(unittest.TestCase):
-    """End to end through the parse: a restart-cut session is CONTINUED (auto-nudge fires), wears NO
-    'interrupted' badge, and is never interrupt-blocked. A genuine user stop flips the focus goal to
-    Blocked (needs-you) even with auto-nudge OFF, and wears the badge in the needs-you column."""
+class _FeedHarness(unittest.TestCase):
+    """Shared transcript + store + feed fixture for the tick-level classes below (no tests of its
+    own): a temp project dir, a named session, redirected judge/kernel paths, and helpers to write
+    the transcript shapes and read the built card."""
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
@@ -201,9 +201,16 @@ class MachineCutFeedAndNudge(unittest.TestCase):
             km._tmux_send, jd.optimistic_followup = saved
         return sent, restore
 
-    def _card(self):
+    def _card(self, item_id=None):
         km._parse(str(self.tpath), SID, NOW)                       # warm the cache (stands in for _warm_fleet_bg)
-        return next(a for a in km.build_feed(NOW, self.tmux)["asks"] if a["itemId"] == SID + ":gw")
+        return next(a for a in km.build_feed(NOW, self.tmux)["asks"]
+                    if a["itemId"] == (item_id or SID + ":gw"))
+
+
+class MachineCutFeedAndNudge(_FeedHarness):
+    """End to end through the parse: a restart-cut session is CONTINUED (auto-nudge fires), wears NO
+    'interrupted' badge, and is never interrupt-blocked. A genuine user stop flips the focus goal to
+    Blocked (needs-you) even with auto-nudge OFF, and wears the badge in the needs-you column."""
 
     # --- restart / crash cut: continued, no badge, not blocked ------------------------------------
 
@@ -271,6 +278,82 @@ class MachineCutFeedAndNudge(unittest.TestCase):
         km._interrupt_block_tick(NOW, self.tmux)
         self.assertEqual(jd.load_goals(SID)["status"][SID + ":gw"], "working",
                          "the user re-engaged → our interrupt block lifts")
+
+
+class StaleInterruptMarker(_FeedHarness):
+    """The once-per-episode intrBlocked marker is VERIFIED against the store each tick, never trusted
+    (the user 2026-08-08). The audited shape: a genuine stop blocked the then-focus goal; the judges
+    lifted and completed it off newer turns; an injected turn (a task notification) ran and settled
+    with the user silent throughout. The marker still pointed at the finished goal, so the tick read
+    "already blocked this episode" and skipped the re-block forever — the session's LIVE focus goal
+    sat in Working wearing only the 'interrupted' badge, auto-nudge suppressed: invisible-blocked.
+    The re-record stamps the CURRENT quiet (the stop joined with the transcript's newest event — an
+    injected record can FOLD into the cut turn rather than open one, so the last turn's trigger
+    undershoots), landing over the judges' newer rows instead of folding under them."""
+
+    INJECTED = "<task-notification>a background task finished</task-notification>"
+
+    def test_a_wedged_marker_reblocks_the_live_focus_goal(self):
+        km._set_auto_nudge(False)
+        self._genuine_stop()
+        g1 = self._goal()
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(jd.load_goals(SID)["status"][g1], "blocked")
+        self.assertEqual(km._intr_blocked(SID), g1)
+        # the judges move on from newer turns: the stopped goal is lifted and completed, and a second
+        # goal is the live focus now — the marker still points at the finished one
+        st = jd.load_goals(SID)
+        jd.record_verdict(st, st["nodes"][g1], "unblocker", "unblock", T0 + 70,
+                          why="answered in passing: picked the work back up")
+        jd.record_verdict(st, st["nodes"][g1], "planner", "done", T0 + 80, why="shipped")
+        g2 = SID + ":g2"
+        st["nodes"][g2] = {"id": g2, "text": "polish the widget", "parentId": None,
+                           "nodeComplete": False, "blocked": False, "cleared": False,
+                           "trail": [], "t": T0 + 80}
+        st["lastNode"] = g2
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+        # an injected turn ran and settled AFTER the stop, the user silent throughout
+        with open(self.tpath, "a") as f:
+            f.write(json.dumps(uline(T0 + 200, self.INJECTED, "u3", "u2")) + "\n")
+            f.write(json.dumps(aline(T0 + 220, "wrapped that up; the build is green", "a2", "u3",
+                                     "end_turn")) + "\n")
+        km._parse_cache.clear()
+        km._interrupt_block_tick(NOW, self.tmux)
+        st = jd.load_goals(SID)
+        self.assertEqual(st["status"][g2], "blocked",
+                         "the marker was verified stale → the LIVE focus goal re-blocks on the user")
+        self.assertEqual(km._intr_blocked(SID), g2, "the marker follows the block it actually placed")
+        card = self._card(g2)
+        self.assertEqual(card["column"], "needs_input")
+        self.assertTrue(card.get("interrupted"), "the needs-you card says the user stopped this session")
+
+    def test_reblock_stands_down_until_newer_quiet_evidence(self):
+        km._set_auto_nudge(False)
+        self._genuine_stop()
+        g1 = self._goal()
+        km._interrupt_block_tick(NOW, self.tmux)
+        # a judge lifts OUR block off newer evidence — rows the bare stop's stamp cannot outrank
+        st = jd.load_goals(SID)
+        jd.record_verdict(st, st["nodes"][g1], "unblocker", "unblock", T0 + 70,
+                          why="answered in passing: picked the work back up")
+        jd.rollup_status(st, False)
+        jd.save_goals(SID, st)
+        rows = len(jd.load_goals(SID)["nodes"][g1]["log"])
+        km._interrupt_block_tick(NOW, self.tmux)
+        st = jd.load_goals(SID)
+        self.assertEqual(st["status"][g1], "working",
+                         "the judges ruled on a newer world — the re-block stands down")
+        self.assertEqual(len(st["nodes"][g1]["log"]), rows, "refused WITHOUT appending — no diary spam")
+        self.assertIsNone(km._intr_blocked(SID), "the stale marker is cleared, not re-set")
+        # an injected turn settles later, the user still silent → the quiet's evidence is newest again
+        with open(self.tpath, "a") as f:
+            f.write(json.dumps(uline(T0 + 200, self.INJECTED, "u3", "u2")) + "\n")
+            f.write(json.dumps(aline(T0 + 220, "wrapped that up", "a2", "u3", "end_turn")) + "\n")
+        km._parse_cache.clear()
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(jd.load_goals(SID)["status"][g1], "blocked",
+                         "re-surfaced the moment the stop is the newest information again")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The bug

A stopped session's card sat in Working wearing only the "interrupted" badge, with auto-nudge suppressed: invisible-blocked. The interrupt tick had blocked the then-focus goal and remembered it in the once-per-episode `intrBlocked` marker; the judges then lifted and completed that goal off newer turns, the user cleared it, and compaction archived it. The marker still pointed at the finished goal, so every subsequent tick read "already blocked this episode" and skipped the re-block forever. The session's live focus goal never surfaced, and since the interrupt predicate also suppresses auto-nudge, nothing would ever move it again.

## The fix, three legs

1. **Verify the marker, never trust it.** `_interrupt_block_tick` now checks that the marked block still holds its card (`_intr_block_stands`: the node exists in the live store and is blocked). A stale marker is cleared and the live focus goal re-blocks.

2. **Stamp the re-block with the current quiet's evidence.** The stop's own transcript time, joined with the transcript's newest event. Injected activity (a task notification, a peer message) can run and settle after the stop with the user silent throughout, and it can fold into the cut turn rather than open one, so the last turn's trigger undershoots. Stamped at the bare stop, the block folds under the judges' newer rows as a silent no-op. `_record_interrupt_block` also stands down WITHOUT appending while the diary holds newer unblock/reopen/done/settle rows: the tick retries every push, so a refused append would grow the diary at push cadence. The block lands the moment the stop is the newest information again.

3. **The unblocker no longer re-examines interrupt-src blocks.** "Waiting on your next instruction" is not a question session output can answer. It lifted a stop-block seconds after placement, off the cut turn's own settling output, which was the first domino in the incident. Only the user's re-engagement lifts a stop-block; a done verdict completes over it.

## Tests

- `test_kernel_interrupt_machine_cut.py`: harness extracted into a shared base; new `StaleInterruptMarker` class reproduces the full wedge at tick level (marker pointing at a finished goal, injected turn settled since the stop, live focus goal re-blocks into needs_input with the badge) and the stand-down/land cycle against a newer judge lift.
- `test_kernel_interrupt_blocks.py`: unit coverage for `_intr_block_stands` (vanished node, judge-lifted block) and for the stand-down guard (refuses without appending, lands on newer evidence).
- `test_judge_unblocker.py`: interrupt-src blocks are out of the candidate set and never shown to the model; a newer real judge block on the same node re-enters it.

Both suites pass: 4002 Python, 1729 node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)