### PR TITLE
De-ink the usage hover; session-filter rows wear the tab identity treatment

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17638,14 +17638,17 @@ function barRows(d){return (d.unk
 // per login \u2014 with the host heading it only when there IS more than one. A SPEND-ONLY account (an
 // API key / a login-less host) used to return '' here, so a mixed fleet's hover silently showed only
 // the subscription login (the user 2026-08-08) \u2014 its dollars now render as their own section.
+// EVERY string here must carry data the reader acts on (the user 2026-08-08, who found the tip overly
+// verbose): the host name alone heads a section (no "its own allowance" tail), the token rows label
+// themselves (no "5h / 7d / month" subtitle), and config hints live in the docs, not a hover.
 function setHTML(e,many){var d=e.det,keys=['fiveHour','sevenDay','fable'].filter(function(k){return d[k];});
 var sp=d._spend||null;
 if(!keys.length&&!sp)return '';
 var spendOnly=!keys.length;                       // no subscription windows \u2192 an API-key / no-login account
-var h=(many?'<div class=ru-tip-host>'+esc(e.host)+' \u2014 its own allowance</div>':'');
+var h=(many?'<div class=ru-tip-host>'+esc(e.host)+'</div>':'');
 h+=keys.map(function(k){var v=d[k];
 return '<div class=ru-tip-win><div class=ru-tip-name><span>'+esc(v.name)+' ('+esc(v.span)+')</span>'
-+(v.unk?'<span class=ru-tip-reset>window reset '+esc(v.ago)+' \u2014 no reading since; current usage unknown</span>'
++(v.unk?'<span class=ru-tip-reset>window reset '+esc(v.ago)+'; no reading since</span>'
 :(v.reset?'<span class=ru-tip-reset>resets in '+esc(v.reset)+'</span>':''))+'</div>'+barRows(v)+'</div>';}).join('');
 // The TOKEN GRAPH (the user 2026-08-08): the three spend windows' token volume on ONE shared scale \u2014
 // each bar auto-scales to the largest window, so 5h vs 7d vs month compares at a glance in the same
@@ -17653,21 +17656,18 @@ return '<div class=ru-tip-win><div class=ru-tip-name><span>'+esc(v.name)+' ('+es
 // spend-only account); a subscription login's nominal cost would read as a bill, so it stays tokens.
 if(sp){var ks=['fiveHour','sevenDay','month'].filter(function(k){return sp[k];});
 if(ks.length){var mx=1;ks.forEach(function(k){if(sp[k].tok>mx)mx=sp[k].tok;});
-h+='<div class=ru-tip-win><div class=ru-tip-name><span>'+(spendOnly?'API-key spend':'Tokens')+'</span>'
-+'<span class=ru-tip-reset>5h / 7d / month \u00b7 one scale</span></div>'
+h+='<div class=ru-tip-win><div class=ru-tip-name><span>'+(spendOnly?'API-key spend':'Tokens')+'</span></div>'
 +ks.map(function(k){var v=sp[k],wpct=v.tok>0?Math.max(2,Math.round(v.tok/mx*100)):0;
 return '<div class=ru-tip-row><span class=ru-tip-k>'+esc(v.label)+'</span>'
 +'<span class=ru-tip-track><i style="width:'+wpct+'%;background:#6b7a8c"></i></span>'
 +'<span class=ru-tip-v>'+fmtTok(v.tok)+(spendOnly?' \u00b7 $'+(v.usd<100?v.usd.toFixed(2):String(Math.round(v.usd))):'')+'</span></div>';}).join('')
-+(spendOnly&&!ks.some(function(k){return sp[k].budget!=null;})
-?'<div class=ru-tip-age>no budget set \u2014 dollars only; name one in spend-budgets.json to fill the rail bars</div>':'')
 +'</div>';}}
 h+=(d._t?'<div class=ru-tip-age>updated '+fmtAgo(d._t)+'</div>':'');
 return h;}
 function tipHTML(){var sets=LAST||[];if(!sets.length)return '';
 var many=sets.length>1;
 var h=sets.map(function(e){return setHTML(e,many);}).join('');
-return h?h+'<div class=ru-tip-age>click the bars to refresh</div>':'';}
+return h?h+'<div class=ru-tip-age>click to refresh</div>':'';}
 // The tip anchors ABOVE the rail, centered on the cursor (the user 2026-08-08: it used to pin to the
 // container's RIGHT edge, nowhere near a hover on the left end of a wide multi-account rail).
 function showTip(ev){var h=tipHTML();

--- a/tests/test_kernel_rail_usage.py
+++ b/tests/test_kernel_rail_usage.py
@@ -121,14 +121,18 @@ class RailUsage(unittest.TestCase):
         self.assertIn("<span class=ru-tip-k>last known</span>", self.html,
                       "the hover is the ONE place the stale number appears, and it says what it is")
         self.assertIn("window reset '+esc(v.ago)", self.html, "the tooltip dates how stale the reading is")
-        self.assertIn("current usage unknown", self.html)
+        # "no reading since" carries the whole fact; "current usage unknown" restated what the '?' and
+        # the "last known" label already say (the user 2026-08-08 de-inking pass)
+        self.assertIn("; no reading since", self.html)
+        self.assertNotIn("current usage unknown", self.html)
         # the STANDALONE timeline copy (Obsidian) says the same thing — one rule, every surface
         tv = (pathlib.Path(BIN).parent / "ui" / "romp-timeline-view.js").read_text()
         self.assertIn("const rolled = !!(seg.resetsAt && nowS > seg.resetsAt);", tv)
         self.assertIn("b.usage.txt.textContent = rolled ? '?' : pct + '%';", tv)
         self.assertIn("if (track) track.style.display = rolled ? 'none' : '';", tv,
                       "the bar itself is hidden, not faded")
-        self.assertIn("current usage unknown (last known ", tv)
+        self.assertIn("; no reading since (last known ", tv)
+        self.assertNotIn("current usage unknown", tv)
 
     def test_the_timeline_forwards_usage_to_the_shell_and_hides_its_own_copy_when_embedded(self):
         tv = (pathlib.Path(BIN).parent / "ui" / "romp-timeline-view.js").read_text()

--- a/tests/test_kernel_usage_refresh.py
+++ b/tests/test_kernel_usage_refresh.py
@@ -67,7 +67,8 @@ class UsageRefreshWiring(unittest.TestCase):
         # footer, never a native title (the user 2026-08-08: the browser's flat box fought the tip)
         self.assertIn("id=rail-usage", html)
         self.assertIn("el.style.cursor='pointer'", html)
-        self.assertIn("click the bars to refresh", html)
+        self.assertIn("click to refresh", html)
+        self.assertNotIn("click the bars", html)   # tightened 2026-08-08 — the reader is already on the bars
         self.assertNotIn("Click to refresh usage", html)
         # a click fetches the on-demand endpoint and re-renders through the normal render() path.
         # (2026-07-30: /usage/fleet — /usage plus one row per OTHER Claude account signed in across the

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -1294,7 +1294,7 @@ class TimelinePanel {
       b.time.row.style.display = (timePct == null) ? 'none' : 'inline-flex';
       if (timePct != null) { b.time.fill.style.width = timePct + '%'; b.time.txt.textContent = timePct + '%'; }
       b.group.setAttribute('title', rolled
-        ? name + ' — window reset ' + this._fmtAgo(seg.resetsAt) + ' and no reading has arrived since; current usage unknown (last known ' + pct + '%)'
+        ? name + ' — window reset ' + this._fmtAgo(seg.resetsAt) + '; no reading since (last known ' + pct + '%)'
         : name + ' — usage ' + pct + '%' + (timePct != null ? ' · ' + timePct + '% through the window' : '') + (seg.resetsAt ? ' · resets in ' + this._fmtReset(seg.resetsAt) : ''));
     };
     apply('fiveHour', usage.fiveHour, 'Session (5h)');

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -46,8 +46,9 @@ test("the feed dot matches too: dotFor picks work/await per name, the dot retint
   assert.match(FEED, /const dotFor = \(name: string\): DotState => workingSet\.has\(name\) \? "work" : awaitingSet\.has\(name\) \? "await" : "";/);
   // an existing dot RETINTS when the state flips (working → awaiting), instead of only add/remove
   assert.match(FEED, /else if \(st && has\) prev!\.classList\.toggle\("await", st === "await"\);/);
-  // every name-dot site routes through dotFor: cards, group cards, both modal headers, grouped headers
-  assert.equal((FEED.match(/setWorkDot\((?:a\._name|agent|nm), dotFor\(/g) || []).length, 5);
+  // every name-dot site routes through dotFor: cards, group cards, both modal headers, grouped
+  // headers, and the session-filter button (2026-08-08; its menu rows route via setWorkDot(label,…))
+  assert.equal((FEED.match(/setWorkDot\((?:a\._name|agent|nm), dotFor\(/g) || []).length, 6);
   assert.match(FEEDCSS, /\.fwork-dot\.await \{ background: #54B204; \}/);
   assert.match(FED, /const ARRAY_ID = \["order", "names", "working", "awaiting"\];/);
   assert.match(FED, /if \(Array\.isArray\(f\.awaiting\)\) merged\.awaiting\.push\(\.\.\.f\.awaiting\);/);

--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -50,11 +50,24 @@ test("the menu sits right of Group, lists sessions in tab order, canonical form,
   assert.match(FEED, /ensureGroupToggle\(\)\.style\.display = showCA \? "" : "none";[^\n]*\n\s*ensureSessionFilter\(\)\.style\.display = showCA \? "" : "none";/);
   // tab order: ranked by the kernel's session-order list — the same rank grouped mode sorts by
   assert.ok(FEED.includes("const rows = sessionsMeta.slice().sort((a, b) => (rank.get(a.sid) ?? 1e9) - (rank.get(b.sid) ?? 1e9));"));
-  // canonical form: identity dot + host-folded name (the shared .host-prefix treatment)
-  assert.ok(FEED.includes("row(feedOnlySid === s.sid, s.sid, sessDot(s.color?.bg), ...hostNameNodes(s.name, s.sid));"));
   // the menu lives on document.body — outside render()'s reconcile, so a push can't rebuild it mid-press
   assert.ok(FEED.includes("document.body.appendChild(menu);"));
-  // with a filter on, the button wears the picked session's dot+name and the accent .on state — a
-  // narrowed board must never look like the whole one
-  assert.ok(FEED.includes('if (cur) b.replaceChildren(sessDot(cur.color?.bg), ...hostNameNodes(cur.name, cur.sid), document.createTextNode(" ▴"));'));
+});
+
+test("menu rows write a session the way the tabs do — coloured bold name + the shared status dot", () => {
+  // the identity treatment every other surface gives a session (the user 2026-08-08, round two: a
+  // colour SWATCH read as a status dot — on this board a dot beside a name means working/awaiting)
+  assert.ok(FEED.includes("nm.replaceChildren(...hostNameNodes(s.name, s.sid));"), "host prefix folded quiet");
+  assert.ok(FEED.includes("if (s.color) nm.style.color = s.color.bg;"), "name IN the identity colour");
+  assert.ok(FEED.includes("for (const s of rows) row(feedOnlySid === s.sid, s.sid, sessMenuName(s), s.name);"));
+  assert.ok(FEED.includes("if (dotName) setWorkDot(label, dotFor(dotName));"),
+    "the SAME working/awaiting dot the tabs and headers wear — never a colour swatch");
+  assert.ok(!FEED.includes("sessDot"), "the swatch helper is gone");
+  const CSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.css"), "utf8");
+  assert.match(CSS, /\.fsm-name \{ font-weight: 600; \}/, "bold, like the tab titles and session headers");
+  assert.ok(!CSS.includes(".fsm-dot"), "no swatch styles either");
+  // with a filter on, the button quotes the picked session verbatim, dot included — a narrowed board
+  // must never look like the whole one
+  assert.ok(FEED.includes('b.replaceChildren(nm, document.createTextNode(" ▴"));'));
+  assert.ok(FEED.includes("setWorkDot(nm, dotFor(cur.name));"));
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -811,12 +811,13 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    + faint wash), the same selected-state look the card section toggles use (the user 2026-07-07) */
 #feed-foot .feed-modetoggle.on { color: var(--accent); border-color: var(--accent);
   background: rgba(156, 210, 255, 0.12); opacity: 1; }
-/* the SESSION FILTER (the user 2026-08-08): the footer button carries the picked session's dot+name;
-   its menu opens UPWARD (position from the button rect, feed.ts), one row per tab-order session in
-   canonical form — identity dot + name, any host: prefix folded quiet (.host-prefix, shared). */
+/* the SESSION FILTER (the user 2026-08-08): the footer button quotes the picked session; its menu
+   opens UPWARD (position from the button rect, feed.ts), one row per tab-order session written the
+   way the tabs and session headers write it — .fsm-name is BOLD in the session's identity colour
+   (inline, from the payload), host: prefix quiet (.host-prefix, shared), and the shared .fwork-dot
+   status dot in front. Selection is the accent wash, so the identity colours stay untouched. */
 #feed-sessfilter { display: inline-flex; align-items: center; gap: 5px; }
-.fsm-dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; }
-.fsm-dot.blank { border: 1px solid var(--dim); box-sizing: border-box; }   /* a colourless session still gets a slot — rows stay aligned */
+.fsm-name { font-weight: 600; }
 .feed-sessmenu { position: fixed; z-index: 60; min-width: 150px; max-height: 60vh; overflow-y: auto;
   padding: 4px; border: 1px solid var(--card-border); border-radius: 6px;
   background: var(--vscode-editorWidget-background, #252526);
@@ -824,7 +825,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .feed-sessmenu .fsm-row { display: flex; align-items: center; gap: 7px; padding: 4px 9px;
   border-radius: 4px; cursor: pointer; font-size: 11.5px; white-space: nowrap; }
 .feed-sessmenu .fsm-row:hover { background: rgba(255, 255, 255, 0.07); }
-.feed-sessmenu .fsm-row.on { color: var(--accent); }
+.feed-sessmenu .fsm-row.on { background: rgba(156, 210, 255, 0.12); }
 /* downstream sessions an ask is waiting on (drop points) — experiment
    2026-06-10; live working dot + age per session, newest first */
 /* active downstream sessions (the user's handoff spec, 2026-06-10): one line per

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3014,11 +3014,12 @@ function ensureGroupToggle(): HTMLElement {
 }
 
 // The SESSION FILTER (the user 2026-08-08): a footer menu listing every session the chat tab strip
-// shows, in ITS order, each in its canonical form — identity-colour dot + name with any "host:"
-// prefix folded quiet (hostNameNodes). Picking one shows only that session's cards; "All sessions"
-// (the default — nothing selected) shows everything. The menu opens UPWARD from the footer (that is
-// where the space is) and lives on document.body, outside render()'s reconcile, so a push can never
-// rebuild it mid-press; the button itself is ensure-once like the other footer controls.
+// shows, in ITS order, each written the way every other surface writes a session — bold name in its
+// identity colour, "host:" prefix folded quiet, the shared working/awaiting status dot. Picking one
+// shows only that session's cards; "All sessions" (the default — nothing selected) shows everything.
+// The menu opens UPWARD from the footer (that is where the space is) and lives on document.body,
+// outside render()'s reconcile, so a push can never rebuild it mid-press; the button itself is
+// ensure-once like the other footer controls.
 let sessMenuEl: HTMLElement | null = null;
 function closeSessMenu(): void {
   sessMenuEl?.remove(); sessMenuEl = null;
@@ -3030,26 +3031,34 @@ function sessMenuAway(ev: Event): void {
   if (sessMenuEl && !sessMenuEl.contains(t) && !(document.getElementById("feed-sessfilter")?.contains(t))) closeSessMenu();
 }
 function sessMenuKey(ev: KeyboardEvent): void { if (ev.key === "Escape") closeSessMenu(); }
-function sessDot(bg: string | undefined): HTMLElement {
-  const d = el("span", "fsm-dot");
-  if (bg) d.style.background = bg; else d.classList.add("blank");
-  return d;
+// A session's name in the menu wears EXACTLY the identity treatment every other surface gives it (the
+// user 2026-08-08): bold, in the session's own colour, host prefix folded quiet — the way the chat tabs
+// and the grouped session headers write it. Never a colour swatch: a dot beside a name on this board
+// already MEANS working/awaiting (the shared fwork-dot vocabulary), so that status dot rides here too.
+function sessMenuName(s: { sid: string; name: string; color: { bg: string; fg: string } | null }): HTMLElement {
+  const nm = el("span", "fsm-name");
+  nm.replaceChildren(...hostNameNodes(s.name, s.sid));
+  if (s.color) nm.style.color = s.color.bg;
+  return nm;
 }
 function openSessMenu(btn: HTMLElement): void {
   const menu = el("div", "feed-sessmenu");
-  const row = (on: boolean, pick: string | null, ...label: Node[]) => {
+  const row = (on: boolean, pick: string | null, label: HTMLElement, dotName?: string) => {
     const r = el("div", "fsm-row" + (on ? " on" : ""));
-    r.append(...label);
+    r.appendChild(label);
+    if (dotName) setWorkDot(label, dotFor(dotName));   // inserts the status dot before the name, in place
     r.setAttribute("role", "menuitemradio"); r.setAttribute("aria-checked", on ? "true" : "false");
     r.onclick = (ev) => { ev.stopPropagation(); setFeedOnly(on ? null : pick); closeSessMenu(); render(); };
     menu.appendChild(r);
   };
-  row(!feedOnlySid, null, document.createTextNode("All sessions"));
+  const all = el("span", "");
+  all.textContent = "All sessions";
+  row(!feedOnlySid, null, all);
   // tab order: rank by the kernel's session-order list (the same rank grouped mode sorts by); a sid the
   // list doesn't know keeps its place in the kernel's tab list (stable sort), after the ranked ones
   const rank = new Map(sessionOrder.map((s, i) => [s, i] as const));
   const rows = sessionsMeta.slice().sort((a, b) => (rank.get(a.sid) ?? 1e9) - (rank.get(b.sid) ?? 1e9));
-  for (const s of rows) row(feedOnlySid === s.sid, s.sid, sessDot(s.color?.bg), ...hostNameNodes(s.name, s.sid));
+  for (const s of rows) row(feedOnlySid === s.sid, s.sid, sessMenuName(s), s.name);
   document.body.appendChild(menu);
   // above the footer, left-aligned to the button, clamped into the viewport
   const r = btn.getBoundingClientRect();
@@ -3076,8 +3085,11 @@ function ensureSessionFilter(): HTMLElement {
   b.setAttribute("aria-pressed", on ? "true" : "false");
   b.title = cur ? "showing only " + cur.name + " — click to change or show all"
     : "show a single session's cards (default: all)";
-  if (cur) b.replaceChildren(sessDot(cur.color?.bg), ...hostNameNodes(cur.name, cur.sid), document.createTextNode(" ▴"));
-  else b.replaceChildren(document.createTextNode("Session ▴"));
+  if (cur) {
+    const nm = sessMenuName(cur);
+    b.replaceChildren(nm, document.createTextNode(" ▴"));
+    setWorkDot(nm, dotFor(cur.name));   // the button quotes the picked session verbatim, dot included
+  } else b.replaceChildren(document.createTextNode("Session ▴"));
   return b;
 }
 

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -91,7 +91,6 @@ test("the rich tip is the ONE hover surface: no native titles, every account ren
   assert.ok(usageJS.includes("var spendOnly=!keys.length;"));
   // the token graph: the three spend windows' volume on ONE shared auto-scale, in the tip's track idiom
   assert.ok(usageJS.includes("function spendDet(u,det)"));
-  assert.ok(usageJS.includes("5h / 7d / month \\u00b7 one scale"));
   assert.ok(usageJS.includes("var mx=1;ks.forEach(function(k){if(sp[k].tok>mx)mx=sp[k].tok;});"));
   // dollars ride the value column only where they are REAL billing (spend-only accounts)
   assert.ok(usageJS.includes("+fmtTok(v.tok)+(spendOnly?' \\u00b7 $'"));
@@ -100,5 +99,19 @@ test("the rich tip is the ONE hover surface: no native titles, every account ren
   assert.ok(usageJS.includes("x-tip.offsetWidth/2"));
   assert.ok(usageJS.includes("r.top-tip.offsetHeight-8"));
   // the click hint the native title used to carry lives in the tip's footer now
-  assert.ok(usageJS.includes("'<div class=ru-tip-age>click the bars to refresh</div>'"));
+  assert.ok(usageJS.includes("'<div class=ru-tip-age>click to refresh</div>'"));
+});
+
+test("every tip string carries data — the narration is gone and stays gone", () => {
+  // The de-inking pass (the user 2026-08-08, who found the tip overly verbose): the host name alone
+  // heads a section, the token rows label themselves, config hints live in the docs, and the reader
+  // is already hovering the bars when the refresh hint shows.
+  const usageJS = KERNEL.split("_LANDING_USAGE_JS = \"\"\"")[1].split('"""')[0];
+  const code = usageJS.split("\n").map((l) => l.split("//")[0]).join("\n");
+  assert.ok(!code.includes("its own allowance"), "the host heading is the host name, bare");
+  assert.ok(!code.includes("one scale"), "the token rows are their own labels");
+  assert.ok(!code.includes("no budget set"), "no config instructions in a glance surface");
+  assert.ok(!code.includes("current usage unknown"), "the ? row already says unknown");
+  assert.ok(!code.includes("click the bars"), "the short hint replaced it");
+  assert.ok(code.includes("window reset '+esc(v.ago)+'; no reading since"), "the rolled note keeps only its facts");
 });


### PR DESCRIPTION
Two follow-ups from the user (2026-08-08):

**Usage hover de-inking.** Every string in the rich tip now carries data (JLD: a display is complete once nothing more can be removed): the host heading is the bare host name ("its own allowance" cut), the token section loses its "5h / 7d / month · one scale" subtitle (rows are already labelled), the spend-budgets.json config hint is gone, the rolled-window note drops its restatement ("current usage unknown" — the ? and "last known" already say it; the standalone timeline title matches), and the footer tightens to "click to refresh".

**Session-filter menu identity.** The colour swatch beside each row read as a status dot. Rows now write a session the way the chat tabs and grouped headers do: bold name in its identity colour, host prefix folded quiet, the shared fwork-dot working/awaiting dot in front (setWorkDot + dotFor). The button quotes the picked session the same way; selection is the accent wash.

(The "only snape sessions in the menu" report was deploy skew — the local kernel restarted seconds before the sessions-payload commit landed — and heals on the queued refresh.)

Pins updated: rail-spend.test.ts (+ a narration-stays-gone test), test_kernel_usage_refresh.py, test_kernel_rail_usage.py, feed-session-filter.test.ts, awaiting-state.test.ts. Suites green (3996 py, 1731 node, typecheck clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)