### PR TITLE
Switcher rows wear the tab identity: colored bold names, remote sessions included

### DIFF
--- a/ui/webview/palette-main.ts
+++ b/ui/webview/palette-main.ts
@@ -8,6 +8,7 @@
 // focus, and the window/tab-management set (Cmd+W/T/N/L/Q) stays untouched.
 import { registerCommand } from "./commands";
 import { initPalette, PickItem } from "./palette";
+import { hostPrefix } from "./host-prefix";   // pure display helper — safe here (never federation.ts, which boots a manager on import)
 
 type SessionRow = { id: string; name: string; dir: string; bg: string };
 
@@ -37,40 +38,56 @@ type SessionRow = { id: string; name: string; dir: string; bg: string };
   }
 
   // ── the session jump switcher (Cmd/Ctrl+O) ────────────────────────────────────────────────
-  // Sessions come from the kernel's /sessions (the authoritative list, same-origin, kernel
-  // order); recency comes from the chat pane's __rompMru (most-recently-ACTIVATED tab ids,
-  // current session first). Obsidian's trick, kept: the current session is excluded and the
-  // previous one sorts first, so Cmd+O Enter toggles between your two most recent sessions.
+  // Sessions come from the CHAT page's registry first (__rompSessionList: tab order, identity
+  // colors — and the only place this page can see the federation-merged REMOTE sessions),
+  // unioned with the kernel's /sessions (locals whose tab was closed). Recency comes from the
+  // chat pane's __rompMru (most-recently-ACTIVATED tab ids, current session first). Obsidian's
+  // trick, kept: the current session is excluded and the previous one sorts first, so Cmd+O
+  // Enter toggles between your two most recent sessions.
+  type SwitchRow = { id: string; name: string; bg: string; dir: string };
+  function chatSessions(): SwitchRow[] {
+    try {
+      const ls = (pane("f-chat")?.contentWindow as any)?.__rompSessionList;
+      return ls ? ls().map((r: any) => ({ id: String(r.id), name: String(r.name), bg: String(r.bg || ""), dir: "" })) : [];
+    } catch (e) { return []; }
+  }
   function mruIds(): string[] {
     try { return (pane("f-chat")?.contentWindow as any)?.__rompMru?.slice() || []; }
     catch (e) { return []; }
   }
-  function sessionItems(rows: SessionRow[]): PickItem[] {
+  function sessionItems(locals: SessionRow[] | null): PickItem[] {
+    const rows = chatSessions();
+    const seen = new Set(rows.map((r) => r.id));
+    for (const l of locals || []) {
+      if (!seen.has(l.id)) rows.push({ id: l.id, name: l.name, bg: l.bg || "", dir: l.dir || "" });
+      else { const r = rows.find((x) => x.id === l.id); if (r) r.dir = l.dir || ""; }   // dir tails for tab rows too
+    }
     const mru = mruIds();
     const byId = new Map(rows.map((r) => [r.id, r]));
-    const ordered: SessionRow[] = [];
+    const ordered: SwitchRow[] = [];
     for (const id of mru.slice(1)) { const r = byId.get(id); if (r) { ordered.push(r); byId.delete(id); } }
     for (const r of rows) if (byId.has(r.id) && r.id !== mru[0]) ordered.push(r);
     const base = (d: string) => (d || "").replace(/\/+$/, "").split("/").pop() || "";
-    return ordered.map((r) => ({
-      title: r.name,
-      dot: r.bg || "#8a8a8a",
-      dim: base(r.dir),
-      run: () => chatPost({ type: "jumpSession", id: r.id }),
-    }));
+    return ordered.map((r) => {
+      const p = hostPrefix(r.name, r.id);   // remote → {host:"host:", rest}; local (bare uuid) → null
+      return {
+        title: p ? p.host + p.rest : r.name,
+        hostLen: p ? p.host.length : 0,
+        color: r.bg || undefined,
+        dim: base(r.dir),
+        run: () => chatPost({ type: "jumpSession", id: r.id }),
+      };
+    });
   }
   function openSessionSwitcher(): void {
-    fetch("/sessions").then((r) => r.json()).then((rows: SessionRow[]) => {
+    fetch("/sessions").then((r) => r.json()).catch(() => null).then((locals) => {
+      const items = sessionItems(Array.isArray(locals) ? (locals as SessionRow[]) : null);
+      // fail loudly, not with a silently empty list: nothing from the chat pane AND no answer
+      // from the kernel means the kernel is the story, not "you have no sessions"
       palette.openPick({
         placeholder: "Jump to a session…",
-        items: sessionItems(Array.isArray(rows) ? rows : []),
-        altEnter: { label: "new session…", run: openNewSessionPicker },
-      });
-    }).catch(() => {
-      // fail loudly, not with a silently empty list: the kernel not answering is the story
-      palette.openPick({
-        placeholder: "Jump to a session…",
-        items: [{ title: "Couldn't load sessions — the kernel didn't answer", run: () => {} }],
+        items: items.length || locals !== null ? items
+          : [{ title: "Couldn't load sessions — the kernel didn't answer", run: () => {} }],
         altEnter: { label: "new session…", run: openNewSessionPicker },
       });
     });

--- a/ui/webview/palette.test.ts
+++ b/ui/webview/palette.test.ts
@@ -37,10 +37,22 @@ test("running an item closes the palette FIRST so its own modal never lands unde
   assert.match(PALETTE, /function run\(item: PickItem\): void \{\s*\n\s*close\(\);[\s\S]*?item\.run\(\);/);
 });
 
-test("session rows carry the session color dot and a dim directory tail", () => {
-  assert.match(PALETTE, /\.rpal-dot\{flex:0 0 auto;width:8px;height:8px;border-radius:50%\}/);
+test("session rows wear the TAB identity language: bold name in the session color, host: prefix dim italic", () => {
+  // the user 2026-08-08: visual consistency across surfaces — .tab.colored .tab-label is 600-weight
+  // in the identity color; .host-prefix is dim italic at 0.88em. The switcher copies both, and the
+  // fuzzy-match marks underline instead of recoloring so the identity color stays intact.
+  assert.match(PALETTE, /\.rpal-name\{font-weight:600\}/);
+  assert.match(PALETTE, /\.rpal-host\{color:#9aa0a6;font-weight:400;font-style:italic;font-size:0\.88em\}/);
+  assert.match(PALETTE, /\.rpal-name b,\.rpal-host b\{color:inherit;font-weight:inherit;text-decoration:underline\}/);
+  assert.match(PALETTE, /n\.style\.color = item\.color;/);
   assert.match(PALETTE, /\.rpal-dim\{[^}]*font-size:11px/);
-  assert.match(PALETTE, /d\.style\.background = item\.dot;/);
+  // one fuzzy match over "host:name", split across the two styled spans
+  assert.match(PALETTE, /clipRanges\(hit\.ranges, 0, hl\)/);
+  assert.match(PALETTE, /clipRanges\(hit\.ranges, hl, item\.title\.length\)/);
+  // …and the same treatment the tabs use, pinned at its source so the two can't drift silently
+  const STYLES = read("styles.css");
+  assert.match(STYLES, /\.tab\.colored \.tab-label \{ color: var\(--chip-bg\); font-weight: 600; \}/);
+  assert.match(STYLES, /\.host-prefix \{ color: var\(--dim\); font-weight: 400; font-style: italic; font-size: 0\.88em; \}/);
 });
 
 // ── the shell boot: three combos, wired into every pane ────────────────────────────────────
@@ -58,12 +70,21 @@ test("key wiring mirrors the Alt+Arrow pane nav: capture on the shell doc AND ev
   assert.match(MAIN, /f\.addEventListener\("load", wire\);\s*\n\s*wire\(\);/);
 });
 
-test("the jump switcher reads /sessions (kernel-authoritative), sorts by the chat's MRU, and excludes the current session", () => {
-  assert.match(MAIN, /fetch\("\/sessions"\)/);
+test("the jump switcher merges the chat registry (remote sessions included) with /sessions, MRU-first, current excluded", () => {
+  assert.match(MAIN, /__rompSessionList/);                           // the chat page's merged registry — the only source of federated remotes
+  assert.match(MAIN, /fetch\("\/sessions"\)/);                       // …unioned with locals whose tab is closed
+  assert.match(MAIN, /if \(!seen\.has\(l\.id\)\) rows\.push/);
   assert.match(MAIN, /__rompMru/);
   assert.match(MAIN, /for \(const id of mru\.slice\(1\)\)/);          // previous session first → Cmd+O Enter toggles back
   assert.match(MAIN, /if \(byId\.has\(r\.id\) && r\.id !== mru\[0\]\)/); // current session excluded
   assert.match(MAIN, /chatPost\(\{ type: "jumpSession", id: r\.id \}\)/);
+  // remote rows split the "host:" prefix off with the shared helper (host-prefix.ts, never federation.ts)
+  assert.match(MAIN, /import \{ hostPrefix \} from "\.\/host-prefix";/);
+  assert.match(MAIN, /title: p \? p\.host \+ p\.rest : r\.name,/);
+  assert.match(MAIN, /hostLen: p \? p\.host\.length : 0,/);
+  // render.ts publishes the registry snapshot the shell reads
+  assert.match(RENDER, /__rompSessionList/);
+  assert.match(RENDER, /order\.map\(\(id\) => \{\s*\n\s*const m = tabMeta\.get\(id\);/);
 });
 
 test("the switcher fails loudly when the kernel doesn't answer, and Shift+Enter reaches the new-session picker", () => {

--- a/ui/webview/palette.ts
+++ b/ui/webview/palette.ts
@@ -8,13 +8,17 @@
 import { commandList } from "./commands";
 import { fuzzyMatch, FuzzyHit, FuzzyRange } from "./fuzzy";
 
-// One row of a pick list. Commands map onto this 1:1; session rows add a color dot and a dim
-// directory tail. run() is the whole contract — the palette closes itself, then runs it.
+// One row of a pick list. Commands map onto this 1:1; session rows wear the TAB's identity
+// language (the user 2026-08-08: visual consistency across surfaces) — the name bold in the
+// session color, a remote's "host:" prefix in the dim italic, exactly like .tab-label /
+// .host-prefix — plus a dim directory tail. run() is the whole contract — the palette closes
+// itself, then runs it.
 export type PickItem = {
-  title: string;   // what's shown and fuzzy-matched
-  kbd?: string;    // display-only hotkey chip ("⌘O")
-  dot?: string;    // CSS color for a leading session dot
-  dim?: string;    // dim tail after the title (a session's directory basename)
+  title: string;    // what's shown and fuzzy-matched — for a remote session "host:name", host included
+  kbd?: string;     // display-only hotkey chip ("⌘O")
+  hostLen?: number; // leading chars of title that are the "host:" prefix (0/absent = local)
+  color?: string;   // session identity color for the name (the tab's --chip-bg)
+  dim?: string;     // dim tail after the title (a session's directory basename)
   run: () => void;
 };
 
@@ -43,9 +47,14 @@ const CSS =
   "#rpal-list{flex:1 1 auto;overflow-y:auto;margin-top:6px}" +
   ".rpal-row{display:flex;align-items:center;gap:10px;padding:5px 10px;border-radius:6px;cursor:pointer}" +
   ".rpal-row.active{background:rgba(156,210,255,0.12)}" +   // accent-blue focus cue, not a status color
-  ".rpal-dot{flex:0 0 auto;width:8px;height:8px;border-radius:50%}" +
   ".rpal-title{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}" +
   ".rpal-title b{color:var(--accent,#9cd2ff);font-weight:600}" +
+  // the tabs' identity language, verbatim: .tab.colored .tab-label is 600-weight in the session
+  // color; .host-prefix is dim italic at 0.88em. Matched characters keep the row's own colors
+  // (underline marks them) — an accent-blue <b> inside a colored name would fight the identity.
+  ".rpal-name{font-weight:600}" +
+  ".rpal-host{color:#9aa0a6;font-weight:400;font-style:italic;font-size:0.88em}" +
+  ".rpal-name b,.rpal-host b{color:inherit;font-weight:inherit;text-decoration:underline}" +
   ".rpal-dim{flex:0 1 auto;color:#9aa0a6;font-size:11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}" +
   ".rpal-kbd{flex:0 0 auto;color:#9aa0a6;font-size:11px;border:1px solid #3a3a3a;border-radius:4px;padding:0 5px}" +
   ".rpal-empty{padding:8px 10px;color:#9aa0a6}" +
@@ -122,6 +131,17 @@ export function initPalette(opts?: { onClose?: () => void }, doc: Document = doc
     return frag;
   }
 
+  // Clip highlight ranges to [start,end) and re-base them on start — one fuzzy match over the
+  // whole "host:name" string, split across the two differently-styled spans.
+  function clipRanges(ranges: FuzzyRange[], start: number, end: number): FuzzyRange[] {
+    const out: FuzzyRange[] = [];
+    for (const [s, e] of ranges) {
+      const cs = Math.max(s, start), ce = Math.min(e, end);
+      if (cs < ce) out.push([cs - start, ce - start]);
+    }
+    return out;
+  }
+
   function render(query: string): void {
     const hits = spec.items
       .map((item) => ({ item, hit: fuzzyMatch(query, item.title) }))
@@ -132,15 +152,25 @@ export function initPalette(opts?: { onClose?: () => void }, doc: Document = doc
     for (const { item, hit } of hits) {
       const row = doc.createElement("div");
       row.className = "rpal-row";
-      if (item.dot) {
-        const d = doc.createElement("span");
-        d.className = "rpal-dot";
-        d.style.background = item.dot;
-        row.appendChild(d);
-      }
       const title = doc.createElement("span");
       title.className = "rpal-title";
-      title.appendChild(highlight(item.title, hit.ranges));
+      const hl = item.hostLen || 0;
+      if (hl > 0 || item.color) {
+        // a session row: "host:" dim italic + the name bold in its identity color — the tab treatment
+        if (hl > 0) {
+          const h = doc.createElement("span");
+          h.className = "rpal-host";
+          h.appendChild(highlight(item.title.slice(0, hl), clipRanges(hit.ranges, 0, hl)));
+          title.appendChild(h);
+        }
+        const n = doc.createElement("span");
+        n.className = "rpal-name";
+        if (item.color) n.style.color = item.color;
+        n.appendChild(highlight(item.title.slice(hl), clipRanges(hit.ranges, hl, item.title.length)));
+        title.appendChild(n);
+      } else {
+        title.appendChild(highlight(item.title, hit.ranges));
+      }
       row.appendChild(title);
       if (item.dim) {
         const m = doc.createElement("span");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7574,6 +7574,15 @@ function restoreActiveDraftOnce(): void {
 // Session order elsewhere stays kernel-authoritative; this is only "what did I look at last".
 const sessionMru: string[] = [];
 (window as any).__rompMru = sessionMru;
+// …and the sessions this page knows, for the same switcher: every tab in tab order — local AND
+// the federation-merged remote ones (host-prefixed ids), with the tab's identity colors — so the
+// switcher's rows carry the exact identity language the tabs do (the user 2026-08-08: bold name
+// in the session color, host: prefix in the dim italic). A snapshot accessor, not live state.
+(window as any).__rompSessionList = () =>
+  order.map((id) => {
+    const m = tabMeta.get(id);
+    return { id, name: m?.name || id, bg: m?.color?.bg || "", fg: m?.color?.fg || "" };
+  });
 function noteMru(id: string): void {
   const i = sessionMru.indexOf(id);
   if (i >= 0) sessionMru.splice(i, 1);


### PR DESCRIPTION
## What

User feedback on the Cmd+O jump switcher:

- **Rows now wear the tabs' identity language.** The color dot is gone; the session name renders bold in its identity color (copying `.tab.colored .tab-label { color: var(--chip-bg); font-weight: 600 }`), and a remote session shows its `host:` prefix in lowercase italic gray (copying `.host-prefix`). Fuzzy-match highlights underline instead of recoloring so the identity color stays intact. Both source treatments are pinned in the test so the surfaces can't drift apart silently.
- **Cross-server sessions are listed.** Items come from the chat page's merged registry (new `window.__rompSessionList` snapshot: tab order, identity colors, federation-merged host-prefixed sessions), unioned with `/sessions` for locals whose tab is closed. The `host:` prefix splits off via the shared pure helper in `host-prefix.ts` (deliberately not `federation.ts`, whose import boots a twin manager). MRU ordering and current-session exclusion unchanged.

## Tests

`palette.test.ts` updated: tab-treatment pins (both sides), registry merge/union pins, host split pins. Suites green locally: 4001 Python + 1729 node; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)