### PR TITLE
New-session payload streams first; the spend graph stays on API-key accounts only

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13873,10 +13873,9 @@ def _usage():
     limited = {"fiveHour": _lim(five), "sevenDay": _lim(seven), "fable": _lim(fable)}
     t = o.get("t")
     return {"fiveHour": five, "sevenDay": seven, "fable": fable,
-            # the spend windows ride BESIDE the subscription bars now (the user 2026-08-08): the rail's
-            # hover draws the three windows' TOKEN volume on one shared scale for every account, and the
-            # token data lives only here. Rail rows still key on the bars; this is hover detail.
-            "spend": _spend_windows(),
+            # NO spend windows beside the bars (the user 2026-08-08, same day they were added: a login
+            # account's story is its % bars, and its token rows read as noise — token volume + dollars
+            # are API-KEY information, carried only on the spend-only payload above).
             "t": t if isinstance(t, (int, float)) else None,
             # WHOSE allowance this is. These windows are account-wide, so two machines signed into the
             # SAME account share one set of numbers and must not be drawn twice; two machines on
@@ -15979,7 +15978,14 @@ def _push(targets, connect=False):
                                                          "reason": _retry_pause_reason()})   # "spend" → the card says 'raise your cap', no countdown
                 _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta})
             active = {c.get("active") for c in chat_clients if c.get("active")}
-            build_order = sorted(chat_list, key=lambda s: 0 if s["sid"] in active else 1)   # stable: active first
+            # Stable: active tabs first — and TRANSCRIPT-LESS sessions with them. A just-created session
+            # has no transcript, so its build is near-free, and its creator is guaranteed to be staring
+            # at its placeholder — yet the active-first hint can never name it: a client cannot declare
+            # a tab active before that tab's first payload arrives. Ranked last, the new session's
+            # payload waited out the whole fleet's builds (~22s measured), leaving "Opening session"
+            # dots on a session that had been ready for all of it (the user 2026-08-08).
+            build_order = sorted(chat_list, key=lambda s: 0 if s["sid"] in active
+                                 or not os.path.exists(s["path"]) else 1)
             for s in build_order:
                 is_active = s["sid"] in active           # the watched tab(s) always rebuild → stay live
                 sig = _chat_build_sig(s)
@@ -17584,9 +17590,9 @@ if(n>=1e3)return (n/1e3).toFixed(1).replace(/\.0$/,'')+'k';return String(n);}
 // only month-to-date draws the elapsed track. strip.ts carries the same builder \u2014 kept in step.
 var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','Month']];
 function spendColor(p){return p>=90?'#c0392b':p>=70?'#e0b020':'#54B204';}
-// The per-account SPEND detail for the rich hover (the token graph + dollars/turns rows) \u2014 filled for
-// EVERY account whose payload carries spend, subscription accounts included (the kernel now attaches
-// spend windows beside the bars): the hover's token view is the same three windows on ONE scale.
+// The per-account SPEND detail for the rich hover (the token graph + dollars rows) \u2014 spend-only
+// accounts (an API key / a login-less host) carry it; a LOGIN account's payload has no spend windows
+// on purpose (the user 2026-08-08: its % bars are the story, and token rows there read as noise).
 function spendDet(u,det){var sp=u&&u.spend;if(!sp||!det)return;
 SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='number')return;
 var budget=(typeof seg.budget==='number'&&seg.budget>0)?seg.budget:null;
@@ -17650,8 +17656,7 @@ var live=ROWS.filter(function(r){return hasBars(r.usage)||hasSpend(r.usage);});
 if(!live.length){el.innerHTML='';tip.style.display='none';return;}
 if(live.length===1){var det={};det._t=(typeof live[0].usage.t==='number')?live[0].usage.t:null;
 LAST=[{host:'',det:det}];
-if(hasBars(live[0].usage)){el.innerHTML=winsHTML(live[0].usage,det);spendDet(live[0].usage,det);}
-else el.innerHTML=spendWinsHTML(live[0].usage,det);
+el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendWinsHTML(live[0].usage,det);
 return;}
 var html='';LAST=[];
 // no native title on the account set (the user 2026-08-08 — the rich tip is the ONE hover surface);
@@ -17659,9 +17664,7 @@ var html='';LAST=[];
 live.forEach(function(r){var det={};det._t=(typeof r.usage.t==='number')?r.usage.t:null;
 var hn=r.host||selfHost||'this machine';
 LAST.push({host:hn,det:det});
-var inner;
-if(hasBars(r.usage)){inner=winsHTML(r.usage,det);spendDet(r.usage,det);}
-else inner=spendWinsHTML(r.usage,det);
+var inner=hasBars(r.usage)?winsHTML(r.usage,det):spendWinsHTML(r.usage,det);
 html+='<div class=ru-set>'
 +'<span class=ru-host>'+esc(hn)+':</span>'+inner+'</div>';});
 el.innerHTML=html;}
@@ -17698,17 +17701,17 @@ h+=keys.map(function(k){var v=d[k];
 return '<div class=ru-tip-win><div class=ru-tip-name><span>'+esc(v.name)+' ('+esc(v.span)+')</span>'
 +(v.unk?'<span class=ru-tip-reset>window reset '+esc(v.ago)+'; no reading since</span>'
 :(v.reset?'<span class=ru-tip-reset>resets in '+esc(v.reset)+'</span>':''))+'</div>'+barRows(v)+'</div>';}).join('');
-// The TOKEN GRAPH (the user 2026-08-08): the three spend windows' token volume on ONE shared scale \u2014
-// each bar auto-scales to the largest window, so 5h vs 7d vs month compares at a glance in the same
-// track idiom as the % bars above. Dollars ride the value column only where they are REAL billing (a
-// spend-only account); a subscription login's nominal cost would read as a bill, so it stays tokens.
-if(sp){var ks=['fiveHour','sevenDay','month'].filter(function(k){return sp[k];});
+// The API-KEY SPEND graph (the user 2026-08-08): the three windows' token volume on ONE shared scale
+// \u2014 each bar auto-scales to the largest window \u2014 with the real dollars beside each count. SPEND-ONLY
+// accounts only (same day): a login account's story is its % bars, and token rows there read as noise
+// (the guard also holds against an older kernel in the fleet still attaching spend beside its bars).
+if(sp&&spendOnly){var ks=['fiveHour','sevenDay','month'].filter(function(k){return sp[k];});
 if(ks.length){var mx=1;ks.forEach(function(k){if(sp[k].tok>mx)mx=sp[k].tok;});
-h+='<div class=ru-tip-win><div class=ru-tip-name><span>'+(spendOnly?'API-key spend':'Tokens')+'</span></div>'
+h+='<div class=ru-tip-win><div class=ru-tip-name><span>API-key spend</span></div>'
 +ks.map(function(k){var v=sp[k],wpct=v.tok>0?Math.max(2,Math.round(v.tok/mx*100)):0;
 return '<div class=ru-tip-row><span class=ru-tip-k>'+esc(v.label)+'</span>'
 +'<span class=ru-tip-track><i style="width:'+wpct+'%;background:#6b7a8c"></i></span>'
-+'<span class=ru-tip-v>'+fmtTok(v.tok)+(spendOnly?' \u00b7 $'+(v.usd<100?v.usd.toFixed(2):String(Math.round(v.usd))):'')+'</span></div>';}).join('')
++'<span class=ru-tip-v>'+fmtTok(v.tok)+' \u00b7 $'+(v.usd<100?v.usd.toFixed(2):String(Math.round(v.usd)))+'</span></div>';}).join('')
 +'</div>';}}
 h+=(d._t?'<div class=ru-tip-age>updated '+fmtAgo(d._t)+'</div>':'');
 return h;}

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -2352,7 +2352,9 @@ class ViewBuilder(unittest.TestCase):
         saved = (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
                  km.build_timeline, km._send_client)
         km._tmux_sessions = lambda: {}
-        km._chat_tab_sessions = lambda now, tmux: [{"sid": "A"}, {"sid": "B"}, {"sid": "C"}]
+        p = str(self.tpath)   # a transcript ON DISK — a pathless fake would rank as just-created (top tier)
+        km._chat_tab_sessions = lambda now, tmux: [{"sid": "A", "path": p}, {"sid": "B", "path": p},
+                                                   {"sid": "C", "path": p}]
         km.build_session = lambda sid, now, tmux: {"id": sid, "name": sid, "color": None,
                                                    "status": None, "ledger": None}
         km.build_feed = lambda now, tmux: {"working": [], "asks": []}
@@ -2378,7 +2380,9 @@ class ViewBuilder(unittest.TestCase):
         saved = (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
                  km.build_timeline, km._send_client)
         km._tmux_sessions = lambda: {}
-        km._chat_tab_sessions = lambda now, tmux: [{"sid": "A"}, {"sid": "B"}, {"sid": "C"}]
+        p = str(self.tpath)
+        km._chat_tab_sessions = lambda now, tmux: [{"sid": "A", "path": p}, {"sid": "B", "path": p},
+                                                   {"sid": "C", "path": p}]
         km.build_session = lambda sid, now, tmux: {"id": sid, "name": sid, "color": None,
                                                    "status": None, "ledger": None}
         km.build_feed = lambda now, tmux: {"working": [], "asks": []}
@@ -2391,6 +2395,35 @@ class ViewBuilder(unittest.TestCase):
              km.build_timeline, km._send_client) = saved
         self.assertEqual([key[1] for (key, _) in sent if key[0] == "chat"], ["A", "B", "C"],
                          "no active hint → tab order, all tabs still delivered")
+
+    def test_push_builds_a_transcript_less_session_at_active_priority(self):
+        """A JUST-CREATED session has no transcript, and its creator cannot declare it active — a
+        client can't post activeTab for a tab whose first payload hasn't arrived — so ranked last it
+        waited out the whole fleet's builds (~22s measured live), leaving "Opening session" dots on a
+        session that had been ready the whole time (the user 2026-08-08). Its build is near-free, so
+        it rides the ACTIVE tier and its payload streams at the top of the cycle."""
+        sent = []
+        saved = (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
+                 km.build_timeline, km._send_client)
+        km._tmux_sessions = lambda: {}
+        p = str(self.tpath)
+        km._chat_tab_sessions = lambda now, tmux: [
+            {"sid": "A", "path": p},
+            {"sid": "NEW", "path": p + ".does-not-exist"},   # just created: nothing on disk yet
+            {"sid": "C", "path": p}]
+        km.build_session = lambda sid, now, tmux: {"id": sid, "name": sid, "color": None,
+                                                   "status": None, "ledger": None}
+        km.build_feed = lambda now, tmux: {"working": [], "asks": []}
+        km.build_timeline = lambda now, tmux: None
+        km._send_client = lambda c, key, msg, pre=None: sent.append((key, msg))
+        try:
+            km._push([{"app": "chat", "active": "C", "alive": True}])
+        finally:
+            (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
+             km.build_timeline, km._send_client) = saved
+        chat_order = [key[1] for (key, _) in sent if key[0] == "chat"]
+        self.assertEqual(chat_order, ["NEW", "C", "A"],
+                         "the transcript-less session shares the active tier (stable within it)")
 
     def test_push_caches_unchanged_background_tabs_but_always_rebuilds_active(self):
         # the user 2026-06-24 (sluggish UI): the 0.5s pusher rebuilt EVERY open tab — a full transcript reshape

--- a/ui/webview/opening-state.test.ts
+++ b/ui/webview/opening-state.test.ts
@@ -49,3 +49,12 @@ test("the MCP panel names a stale kernel instead of a raw parse error (the user 
   assert.match(RENDER, /this romp kernel predates the MCP panel — restart romp to update it/);
   assert.match(RENDER, /\(\(e && e\.message\) \|\| e\)/);
 });
+
+test("the pusher builds a transcript-less session at ACTIVE priority — its creator can't declare it yet", () => {
+  // A new session's payload took ~22s to reach the client that created it (the user 2026-08-08,
+  // round two: the dots outlived a fully-ready session): the active-first build hint can never name
+  // a JUST-CREATED sid, because a client cannot post activeTab for a tab whose first payload hasn't
+  // arrived. A transcript-less session's build is near-free, so it rides the top priority tier.
+  assert.ok(KERNEL.includes('build_order = sorted(chat_list, key=lambda s: 0 if s["sid"] in active'));
+  assert.ok(KERNEL.includes('or not os.path.exists(s["path"]) else 1)'));
+});

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -29,9 +29,10 @@ test("the kernel serves spend WINDOWS on the auth-flip marker, zero-filled when 
   assert.ok(KERNEL.includes('k.startswith(month)'));
   // a window-less file on a logged-in machine stays None — nothing known, draw nothing
   assert.match(KERNEL, /if o\.get\("apiKey"\) or [\s\S]{0,900}?return None/);
-  // the subscription payload carries the spend windows BESIDE the bars — the hover's token graph
-  // needs them for every account, not just spend-only ones (the user 2026-08-08)
-  assert.match(KERNEL, /"fiveHour": five, "sevenDay": seven, "fable": fable,[\s\S]{0,600}?"spend": _spend_windows\(\),/);
+  // the subscription payload carries NO spend windows (the user 2026-08-08, same day they were
+  // added beside the bars): a login account's story is its % bars — token volume + dollars are
+  // API-KEY information, carried only on the spend-only payload
+  assert.doesNotMatch(KERNEL, /"fiveHour": five, "sevenDay": seven, "fable": fable,[\s\S]{0,600}?"spend": _spend_windows\(\),/);
   // the accumulator: total_cost_usd AND the usage token counts are CUMULATIVE per CLI process — fold
   // per-turn DELTAS for both, and a shrunken counter (an unwatched reset) folds whole, never negative
   // (the user 2026-08-08, dollars in the morning and tokens by the evening)
@@ -69,12 +70,10 @@ test("the web landing copy carries the SAME builder — the two rails stay in st
   // same row markup as winsHTML: ru-w → ru-name → ru-bars (tracks) → ru-pct readout
   assert.ok(KERNEL.includes("+'<div class=ru-name>'+w[1]+'</div>'"));
   assert.ok(KERNEL.includes("(pct!=null?'<div class=ru-track><i class=ru-fill style=\"width:'+pct+'%;background:'+spendColor(pct)+'\"></i></div>':'')"));
-  // both the single- and multi-account paths fall to the window rows, and BOTH fill the hover detail
-  // (spendDet) so a bars account still gets the token graph
-  assert.ok(KERNEL.includes("if(hasBars(live[0].usage)){el.innerHTML=winsHTML(live[0].usage,det);spendDet(live[0].usage,det);}"));
-  assert.ok(KERNEL.includes("else el.innerHTML=spendWinsHTML(live[0].usage,det);"));
-  assert.ok(KERNEL.includes("if(hasBars(r.usage)){inner=winsHTML(r.usage,det);spendDet(r.usage,det);}"));
-  assert.ok(KERNEL.includes("else inner=spendWinsHTML(r.usage,det);"));
+  // both the single- and multi-account paths fall to the window rows; only the spend path fills the
+  // hover's spend detail (spendDet inside spendWinsHTML) — a bars account gets no token section
+  assert.ok(KERNEL.includes("el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendWinsHTML(live[0].usage,det);"));
+  assert.ok(KERNEL.includes("var inner=hasBars(r.usage)?winsHTML(r.usage,det):spendWinsHTML(r.usage,det);"));
 });
 
 test("the rich tip is the ONE hover surface: no native titles, every account renders, cursor-anchored", () => {
@@ -89,11 +88,14 @@ test("the rich tip is the ONE hover surface: no native titles, every account ren
   // subscription login (the user 2026-08-08) — now it renders its own section
   assert.ok(usageJS.includes("if(!keys.length&&!sp)return '';"));
   assert.ok(usageJS.includes("var spendOnly=!keys.length;"));
-  // the token graph: the three spend windows' volume on ONE shared auto-scale, in the tip's track idiom
+  // the spend graph: the three windows' token volume on ONE shared auto-scale, in the tip's track
+  // idiom, dollars beside each — SPEND-ONLY accounts only (the user 2026-08-08: a login account's
+  // story is its % bars, and token rows there read as noise). The guard also covers an older kernel
+  // in the fleet still attaching spend beside its bars.
   assert.ok(usageJS.includes("function spendDet(u,det)"));
+  assert.ok(usageJS.includes("if(sp&&spendOnly){"));
   assert.ok(usageJS.includes("var mx=1;ks.forEach(function(k){if(sp[k].tok>mx)mx=sp[k].tok;});"));
-  // dollars ride the value column only where they are REAL billing (spend-only accounts)
-  assert.ok(usageJS.includes("+fmtTok(v.tok)+(spendOnly?' \\u00b7 $'"));
+  assert.ok(usageJS.includes("+fmtTok(v.tok)+' \\u00b7 $'"));
   // the tip anchors ABOVE the rail, centered on the CURSOR — never pinned to the container edge
   assert.ok(usageJS.includes("var x=(ev&&typeof ev.clientX==='number')?ev.clientX:(r.left+r.width/2);"));
   assert.ok(usageJS.includes("x-tip.offsetWidth/2"));


### PR DESCRIPTION
Two fixes (the user 2026-08-08):

**"Opening session" dots outliving a ready session.** The kernel side was already fixed (the SDK handshake ends the opening chip), but the payload carrying that status took ~22s measured to reach the creating client: the pusher builds active tabs first, and a client can never declare a just-created tab active — its first payload hasn't arrived. Transcript-less sessions (near-free builds) now ride the active tier, so the placeholder resolves in about a second.

**Token rows on login accounts.** A subscription account's hover showed a zero token graph under its % bars (snape). Token volume and dollars are API-key information: the kernel no longer attaches spend windows to the subscription payload, and the tip renders the spend section (headed "API-key spend", dollars beside every count) only for spend-only accounts, with a client-side guard against older kernels in a mixed fleet.

Tests: a new push-order test (transcript-less session shares the active tier) + path-carrying fakes in the two existing push tests; opening-state.test.ts pins the tier; rail-spend.test.ts re-pins the payload and tip shapes. Suites green (4010 py, 1732 node, typecheck clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)