### PR TITLE
The resume notices disarm the stop record the machine cut wrote

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -735,11 +735,19 @@ def write_reg(state_dir: Path, sid: str, reg: dict) -> None:
 # kernel's death interrupted): visible in the chat as a gray romp card, so the recovery is never
 # silent, and instructing the model — whose transcript tail is an unanswered user message — to pick
 # the work back up. romp-injected → author 'romp' (gray bubble), skipped by the planner as a goal.
+# The middle sentence DISARMS the CLI's stop record (the user 2026-08-08): a machine cut writes the
+# same "[Request interrupted by user]" record as a real Esc, and a resumed model that wasn't told
+# otherwise read it as the user's intent — across the fleet's transcripts roughly one restart-cut
+# session in six answered this notice by standing down and awaiting direction instead of resuming. Naming the record verbatim and disowning it is what
+# lets "pick the work back up" win. Lockstep: kernel INTR_RESTART_SIG/INTR_CRASH_SIG match on these
+# texts (test_kernel_interrupt_machine_cut), so the leading sentences must keep their phrases.
 BOOT_RESUME_NUDGE = (
     "<!-- romp-injected --><!-- romp-system -->[romp] The romp kernel restarted and cut this session's "
-    "in-flight turn; the session has been resumed with its history intact. Re-read the tail of the "
-    "conversation and pick the work back up where it stopped. Any messages queued before the restart "
-    "follow this one.")
+    "in-flight turn; the session has been resumed with its history intact. If the conversation tail "
+    "shows '[Request interrupted by user]', that record came from this cut, not from the user: nobody "
+    "asked you to stop. Re-read the tail of the conversation and pick the work back up where it "
+    "stopped, without asking whether to continue. Any messages queued before the restart follow "
+    "this one.")
 
 # Staggered boot-resume (the user 2026-07-20): spawning every reconciled session's CLI at once
 # detonated a fleet-wide CPU storm — each resumed claude burns ~a full core catching up on its
@@ -756,8 +764,10 @@ BOOT_RESUME_SLOT_S = float(os.environ.get("ROMP_BOOT_RESUME_SLOT_S", "180"))
 # for the next boot's reconcile.
 CRASH_RESUME_NUDGE = (
     "<!-- romp-injected --><!-- romp-system -->[romp] This session's claude process died mid-turn "
-    "(killed or crashed); the session has been resumed with its history intact. Re-read the tail of "
-    "the conversation and pick the work back up where it stopped.")
+    "(killed or crashed); the session has been resumed with its history intact. If the conversation "
+    "tail shows '[Request interrupted by user]', that record came from this cut, not from the user: "
+    "nobody asked you to stop. Re-read the tail of the conversation and pick the work back up where "
+    "it stopped, without asking whether to continue.")
 
 
 # A CLI that cannot even START says so on the way out — and the ONE cause that reliably does this is the

--- a/tests/test_kernel_interrupt_machine_cut.py
+++ b/tests/test_kernel_interrupt_machine_cut.py
@@ -356,5 +356,28 @@ class StaleInterruptMarker(_FeedHarness):
                          "re-surfaced the moment the stop is the newest information again")
 
 
+class ResumeNudgeDisarmsTheStopRecord(unittest.TestCase):
+    """The resume notices must DISARM the interrupt record they follow (the user 2026-08-08). A machine
+    cut writes the same '[Request interrupted by user]' record as a real Esc, and the resumed model
+    reads that record as the user's intent: across the fleet's transcripts, roughly one restart-cut
+    session in six answered the resume notice by standing down and awaiting direction instead of resuming. The notice must therefore name the record,
+    say the user did not write it, and instruct the model to continue without asking."""
+
+    def test_both_nudges_name_and_disown_the_stop_record(self):
+        for nudge in (sb.BOOT_RESUME_NUDGE, sb.CRASH_RESUME_NUDGE):
+            self.assertIn("[Request interrupted by user]", nudge,
+                          "the notice names the record it is disarming, verbatim")
+            self.assertIn("nobody asked you to stop", nudge,
+                          "…and says plainly the user did not stop the session")
+            self.assertIn("without asking", nudge,
+                          "…and that resuming needs no permission")
+
+    def test_signatures_survive_the_copy(self):
+        self.assertIn(km.INTR_RESTART_SIG, sb.BOOT_RESUME_NUDGE)
+        self.assertIn(km.INTR_CRASH_SIG, sb.CRASH_RESUME_NUDGE)
+        self.assertNotIn(km.INTR_RESTART_SIG, sb.CRASH_RESUME_NUDGE,
+                         "the two causes stay distinguishable")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## The bug (2026-08-08)

When the kernel restarts and cuts an in-flight turn, the CLI writes the same `[Request interrupted by user]` record a real Esc writes. The resumed session sees that record right at its tail, then romp's resume notice. A transcript review across the fleet (465 notice deliveries following a genuine interrupt record): ~82% resumed with real work, but roughly **one in six stood down** — text-only status reports, silent no-ops, or explicit refusals ('stopping as you asked' in so many words), reading the machine cut as the user's intent. The notice said 'pick the work back up' but never addressed the stop record contradicting it, and the explicit record won.

## The fix

Both resume nudges (`BOOT_RESUME_NUDGE`, `CRASH_RESUME_NUDGE`) now:
- name the `[Request interrupted by user]` record **verbatim** and disown it: it came from this cut, not from the user, and nobody asked the session to stop;
- instruct the model to pick the work back up **without asking whether to continue**.

The leading sentences keep their `INTR_RESTART_SIG` / `INTR_CRASH_SIG` phrases, so the machine-cut vs user-stop discrimination (nudge gating, the chat seam's cause label, the needs-you flip) is untouched. The injected-voice rules hold: these notices are the sanctioned exception that names romp, and the new copy adds no romp nouns.

## Tests

`test_kernel_interrupt_machine_cut.py` gains lockstep assertions (red before the fix): both nudges name and disown the stop record and carry the no-permission-needed instruction, and the signatures survive the copy and stay mutually distinguishable. Full suites green: pytest 4012, vscode-extension typecheck + 1732 node tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)