### PR TITLE
One device subscription buzzes for every connected kernel

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19467,8 +19467,14 @@ class Handler(BaseHTTPRequestHandler):
         if getattr(self, "_set_cookie", None):       # auto-inject the token so a client never 401-loops
             # Max-Age=1yr so the phone persists the token past its browser session (no re-prompt on
             # the tailnet after the tab is closed) — for simplify's auto-serve/permanence work.
+            # SameSite=Lax, NOT Strict (the user 2026-08-08): Android launches an installed
+            # home-screen app through a launcher INTENT, which Chrome scores as a cross-site
+            # top-level navigation — Strict withheld the cookie on every launch and the app opened
+            # on the login page each time, a token re-ask per launch. Lax still attaches only on
+            # top-level navigations (never on a cross-site POST/subresource, and every
+            # state-changing route here is a POST), so the gate the token provides is unchanged.
             self.send_header("Set-Cookie", "romp_token=%s; Path=/; Max-Age=31536000; "
-                             "SameSite=Strict; HttpOnly" % self._set_cookie)
+                             "SameSite=Lax; HttpOnly" % self._set_cookie)
         # CORS delivery for an AUTHORIZED browser origin (set at the _authorize call sites).
         # A VS Code webview's synthetic origin makes every kernel fetch cross-origin, and
         # without an echoed Access-Control-Allow-Origin the browser withholds the response

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6325,6 +6325,21 @@ def known_share(host):
     return bool((e or {}).get("share"))
 
 
+def _host_trust(host):
+    """This kernel's trust tier for `host`: the attached row's level when it is attached, else the
+    level remembered from its last attachment, else "" (never seen here). Callers treat anything
+    but "trusted" as below the line, so unknown fails safe — the same by-origin judgment the bus
+    makes for inbound mail (see set_trust)."""
+    host = (host or "").strip()
+    if not host:
+        return ""
+    with _remotes_lock:
+        r = _remotes.get(host)
+        if r is not None:
+            return str(r.get("trust") or "directed")
+    return str(known_trust(host) or "")
+
+
 def known_forget(host):
     """Drop a remembered host (the popover's Forget). True if it was there."""
     host = (host or "").strip()
@@ -16248,9 +16263,15 @@ def _cached_feed(now, tmux, sig, connect=False):
     feed["buildId"] = bid
     _built_feed[:] = [sig, feed, time.time(), started]
     _badge = _needs_you_count(feed)
-    for _t, _b, _sid in _feed_notifications(feed):        # armed bells: fresh builds are the transition event
+    _fired = _feed_notifications(feed)                    # armed bells: fresh builds are the transition event
+    for _t, _b, _sid in _fired:
         _system_notify(_t, _b)
         _push_notify(_t, _b, _sid, _badge)                # same events to subscribed phones (plans/ios-app.md)
+    if _fired:
+        # …and to trusted peers' devices (plans/federated-push.md): the phone subscribed at the
+        # always-on box must buzz for THIS kernel's cards too — which kernel detected an event is
+        # romp's business, never the user's.
+        _push_forward([{"title": _t, "body": _b, "sid": _sid} for _t, _b, _sid in _fired])
     _badge_push(_badge)                                   # app-icon count for installed shells (proposal 3)
     return feed
 
@@ -16480,13 +16501,15 @@ def _push_send_one(sub, payload):
         return True
 
 
-def _push_notify(title, body, sid="", badge=0):
+def _push_notify(title, body, sid="", badge=None):
     """_system_notify's sibling sink: the same (title, body) — the card's gist and nothing more —
     to every subscribed device, plus two pieces of ROUTING metadata, not content: sid, so tapping
     the notification lands on the session that fired (the user 2026-08-08), and badge, the
-    needs-you count the service worker paints on the app icon while the app is closed. Runs on
-    the pusher thread, so all network work moves to a daemon thread (the _refresh_remote_prices
-    discipline) and this never blocks or raises."""
+    needs-you count the service worker paints on the app icon while the app is closed. badge=None
+    OMITS the key and the worker leaves the icon's count alone — the shape a mirrored federated
+    event wears, because the origin kernel's count is not this kernel's count
+    (plans/federated-push.md). Runs on the pusher thread, so all network work moves to a daemon
+    thread (the _refresh_remote_prices discipline) and this never blocks or raises."""
     subs = _push_subs()
     if not subs:
         return
@@ -16496,8 +16519,10 @@ def _push_notify(title, body, sid="", badge=0):
         print("romp: web push: %d subscription(s) on file but the python 'cryptography' package "
               "is missing — notification not delivered" % len(subs), file=sys.stderr)
         return
-    payload = json.dumps({"title": str(title), "body": str(body),
-                          "sid": str(sid or ""), "badge": int(badge or 0)}).encode()
+    d = {"title": str(title), "body": str(body), "sid": str(sid or "")}
+    if badge is not None:
+        d["badge"] = int(badge or 0)
+    payload = json.dumps(d).encode()
 
     def run():
         dead = []
@@ -16509,6 +16534,37 @@ def _push_notify(title, body, sid="", badge=0):
                 pass                               # one bad subscription must not block the rest
         for ep in dead:
             _del_push_sub(ep)
+
+    threading.Thread(target=run, daemon=True).start()
+
+
+def _push_forward(events):
+    """The federated half of the push sink (plans/federated-push.md; the user 2026-08-08, who wants
+    one device subscription to buzz for EVERY connected kernel): hand this kernel's fresh bell
+    events — [{title, body, sid}] — to every attached TRUSTED peer, and each peer delivers them to
+    the devices subscribed to IT. Rides the channel every kernel-to-kernel control call already
+    rides (_peer_call: the pair's tunnel + the token exchanged at attach) — no new legs, no new
+    trust surface. Only events THIS kernel detected are ever forwarded, and /push/relay mirrors to
+    devices only, never onward, so a cycle of attachments cannot echo an event back. Fire-and-forget
+    on a daemon thread (the _push_notify discipline); a peer that is down misses the moment by
+    design — its own dashboard was equally blind while it was down. No status filter on purpose: a
+    flapping tunnel mark must not cost a bell, and a dead peer just times out inside the thread."""
+    if not events:
+        return
+    with _remotes_lock:
+        peers = [dict(r) for r in _remotes.values()
+                 if (r.get("trust") or "directed") == "trusted"
+                 and r.get("local_port") and r.get("token")]
+    if not peers:
+        return
+    body = {"origin": _self_host(), "events": [dict(e) for e in events]}
+
+    def run():
+        for r in peers:
+            try:
+                _peer_call(r, "POST", "/push/relay", body, timeout=6)
+            except Exception:
+                pass                               # one unreachable peer must not block the rest
 
     threading.Thread(target=run, daemon=True).start()
 
@@ -16532,7 +16588,10 @@ var work=[self.registration.showNotification(d.title||'romp',
 {body:d.body||'',icon:'/media/romp-app-192.png',badge:'/media/romp-app-192.png',data:{sid:d.sid||''}})];
 // the app-icon count, kept current while the app is CLOSED (the open shell re-paints it live over
 // its own WS). setAppBadge exists in the SW only where badging works at all (iOS installed apps).
-if('setAppBadge' in self.navigator)work.push(self.navigator.setAppBadge(d.badge||0)['catch'](function(){}));
+// Numeric-only on purpose: a mirrored federated event omits badge (the ORIGIN kernel's count is
+// not this kernel's count — plans/federated-push.md), and repainting 0 for it would CLEAR a real
+// local count.
+if('setAppBadge' in self.navigator&&typeof d.badge==='number')work.push(self.navigator.setAppBadge(d.badge)['catch'](function(){}));
 e.waitUntil(Promise.all(work));
 });
 // Land ON the thing that notified (the user 2026-08-08, whose first push opened a different
@@ -16563,6 +16622,13 @@ def _reveal_msg(sid):
     """What lands in the chat pane: a live session gets the focus (live=True → the live tail,
     where the blocking prompt sits); a dead one gets the revive prompt, never a silent reveal —
     the same split _reveal_or_confirm makes for feed/timeline taps."""
+    if ":" in str(sid or ""):
+        # a federated session ("host:sid" — the prefix federation.js stamps on every remote id, and
+        # a local sid is a bare uuid that never carries a colon): its liveness is the ORIGIN
+        # kernel's truth, not ours, and the merged dashboard's own tabs route the prefixed id
+        # (plans/federated-push.md) — so hand the focus over as-is, never a confirmRevive minted
+        # from the wrong kernel's session list.
+        return {"type": "focus", "id": sid, "live": True}
     if sid and sid not in _tmux_sessions():
         return {"type": "confirmRevive", "id": sid, "name": _name_of(sid) or sid}
     return {"type": "focus", "id": sid, "live": True}
@@ -19828,6 +19894,51 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(400, "bad json", "text/plain")
                 _del_push_sub(ep)
                 return self._send(200, json.dumps({"ok": True}), "application/json")
+            if u.path == "/push/relay":
+                # A federated peer mirroring its bell events into THIS kernel's subscriptions
+                # (plans/federated-push.md): deliver to the devices subscribed HERE and stop — a
+                # relayed event is terminal (never re-forwarded), so attachment cycles cannot echo.
+                # The serve token already authorized the caller like any client; the ORIGIN's tier
+                # is the HUMAN boundary on top of it: only a host the user marked trusted may buzz
+                # their pocket, and anything else drops with its reason on stderr (fail loudly),
+                # never a silent buzz and never a silent drop.
+                try:
+                    body = json.loads(raw_body or b"{}")
+                    origin = str(body.get("origin") or "").strip()
+                    events = body.get("events")
+                except (ValueError, AttributeError):
+                    return self._send(400, "bad json", "text/plain")
+                if not origin or not isinstance(events, list):
+                    return self._send(400, "missing origin or events", "text/plain")
+                tier = _host_trust(origin)
+                if tier != "trusted":
+                    print("romp: web push: dropped %d bell event(s) relayed from '%s' (its trust "
+                          "here is '%s'; only a trusted host's events reach this kernel's devices "
+                          "— the network panel's per-host selector raises it)"
+                          % (len(events), origin, tier or "unknown"), file=sys.stderr)
+                    return self._send(200, json.dumps({"ok": False, "mirrored": 0,
+                                                       "tier": tier or "unknown"}), "application/json")
+                n = 0
+                for ev in events[:16]:            # a bell mirror, not a bulk pipe — cap the fan-in
+                    if not isinstance(ev, dict):
+                        continue
+                    t = str(ev.get("title") or "")
+                    b = str(ev.get("body") or "")
+                    sid = str(ev.get("sid") or "")
+                    if not (t or b):
+                        continue
+                    # Wear the origin the way every federated surface wears it (host-prefix.ts):
+                    # the sid gains "origin:" so a tap routes through the merged dashboard's own
+                    # tabs, and the title's session name gains the same prefix. Tolerant surgery:
+                    # a title a different build composed passes through unprefixed rather than
+                    # mangled — version skew between peers is a normal state, not an error.
+                    if sid and ":" not in sid:
+                        sid = "%s:%s" % (origin, sid)
+                    if t.startswith("romp: "):
+                        t = "romp: %s:%s" % (origin, t[len("romp: "):])
+                    _push_notify(t, b, sid)       # badge omitted: the origin's count is not ours
+                    n += 1
+                return self._send(200, json.dumps({"ok": True, "mirrored": n}), "application/json")
             if u.path == "/reveal":
                 # The cold-start half of a push tap (see _PENDING_REVEAL): the freshly opened
                 # shell asks for the focus its ?push-reveal= URL named, aimed by its own wid so

--- a/plans/federated-push.md
+++ b/plans/federated-push.md
@@ -1,0 +1,71 @@
+# Federated push: one subscription buzzes for every connected kernel
+
+Status: IMPLEMENTED, landing in the commit that adds this file.
+
+The ask (the user 2026-08-08, minutes after installing the home-screen app): with kernels
+linked, having to think about WHICH kernel a notification comes from is exactly the mechanics
+romp exists to hide — a device subscribed at one kernel should get the bell events of every
+kernel connected to it. Concretely: the phone is installed against the always-on box, the
+laptop's sessions do the day's work, and the laptop's "needs you" must still buzz the pocket.
+
+**The invariant: push scope = dashboard scope.** The dashboard you subscribed from shows every
+attached host's sessions merged together; the bell you tapped there means "notify me about all
+of this", not "about the slice this kernel happens to own".
+
+## Why the gap existed
+
+The merged multi-host view is assembled in the BROWSER (`federation.js`: one socket per kernel,
+ids prefixed `host:`); the serving kernel splices relay connections and reads nothing. So the
+kernel that holds a push subscription never sees another host's cards, and its bell detector
+(`_feed_notifications`, diffing fresh feed builds) fires for local sessions only.
+
+## Design: forward at the event source, mirror at the subscriber
+
+When a kernel's bell fires (the same armed-card feed-build transition that drives every other
+sink), `_push_forward` hands the fired events — `[{title, body, sid}]` — to every attached
+TRUSTED peer via `POST /push/relay`; the receiving kernel mirrors them out through its own
+`_push_notify` to the devices subscribed to it.
+
+Decisions, and the reasons they went this way:
+
+- **The existing pair channel, no new legs.** Every attached pair can already `_peer_call` each
+  other: the tunnel plus the serve token exchanged at attach/check-in. Both sides run the same
+  code, so events flow in both directions of an attachment automatically.
+- **A relayed event is terminal.** `/push/relay` delivers to local devices and never forwards
+  onward, so attachment cycles cannot echo an event; no event ids or seen-sets are needed.
+- **Trust is judged by origin at delivery time, receiver-side** — the same by-origin judgment
+  the postal bus makes for inbound mail. Only a host the user marked `trusted` may buzz their
+  devices; `directed`/`isolated`/unknown drops WITH ITS REASON on stderr (fail loudly), naming
+  the network panel's per-host selector as the remedy. The sender also forwards only to trusted
+  peers: your events leave your kernel only toward boxes you control.
+- **The origin is worn the way every federated surface wears it** (`host-prefix.ts`): the
+  mirrored event's sid gains `origin:` so a tap routes through the merged dashboard's own tabs,
+  and the title's session name gains the same prefix (`romp: boxa:web`). The title surgery is
+  tolerant — a title composed by a different build passes through unprefixed rather than
+  mangled, because version skew between peers is a normal state.
+- **Mirrored events omit `badge`** and the service worker applies `setAppBadge` only to a
+  numeric value: the origin kernel's needs-you count is not the receiving kernel's count, and
+  repainting 0 would clear a real local badge.
+- **`_reveal_msg` trusts the browser for prefixed sids.** A `host:sid` focus is handed to the
+  chat pane as-is (its tabs route it); the local session-list liveness check would otherwise
+  mint a wrong `confirmRevive` from the wrong kernel's world.
+
+## Verified findings that shaped it
+
+1. `_remotes` rows carry `local_port` + `token` for BOTH attach styles (ssh-attach fetches the
+   token; check-in hands it over in `_checkin_payload`) — so the authenticated kernel-to-kernel
+   channel needed no new trust surface.
+2. The chat pane's `focus` handler routes by tab id and already expects jumps "incl. from a
+   remote kernel"; remote tabs exist under their prefixed ids once federation merges them.
+
+## Known follow-ups, deliberately not in this landing
+
+- **Cold-start precision for remote sids.** A tap that boots the app delivers its parked reveal
+  on the chat pane's `ready` — possibly before federation has merged the origin host's tabs, in
+  which case the focus lands on the dashboard, not the session. Event-based fix when it earns
+  its keep: park the prefixed focus browser-side until that host's tabs arrive.
+- **A merged badge count.** The icon count is the local kernel's needs-you number; a truly
+  federated count is a design question (sum across hosts? per-host chips?) for later.
+- **Visibility for tier-dropped relays.** stderr satisfies fail-loudly for an operator; if
+  dropped relays turn out to matter in practice, the bus's held-mail quarantine-card treatment
+  is the pattern to copy.

--- a/tests/test_kernel_installable_app.py
+++ b/tests/test_kernel_installable_app.py
@@ -128,5 +128,23 @@ class InstallMetas(unittest.TestCase):
         self.assertNotIn("apple-touch-icon", km._TOKEN_LOGIN_HTML)
 
 
+class AuthCookieSurvivesAppLaunches(unittest.TestCase):
+    def test_cookie_is_lax_not_strict(self):
+        # The user 2026-08-08: the installed Android app asked for the token on EVERY launch.
+        # Android opens a home-screen app through a launcher INTENT, which Chrome scores as a
+        # cross-site top-level navigation — SameSite=Strict withheld the cookie each time, so the
+        # app booted cookieless onto the login page. Lax attaches on top-level navigations (the
+        # launch) while still never riding a cross-site POST or subresource — and every
+        # state-changing kernel route is a POST, so the gate is unchanged.
+        status, _, headers = _serve_get("/sw.js?token=" + km.TOKEN)   # any gated route sets it
+        self.assertEqual(status, 200)
+        cookie = headers.get("Set-Cookie") or ""
+        self.assertIn("romp_token=", cookie)
+        self.assertIn("SameSite=Lax", cookie)
+        self.assertNotIn("Strict", cookie)
+        self.assertIn("HttpOnly", cookie)                 # still no script access
+        self.assertIn("Max-Age=31536000", cookie)         # still the year the phone needs
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kernel_webpush_federation.py
+++ b/tests/test_kernel_webpush_federation.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Federated push (plans/federated-push.md): one device subscription buzzes for every connected
+kernel. Push scope = dashboard scope.
+
+What these pin, by layer:
+
+  * the forward — _push_forward ships this kernel's fired bell events to attached TRUSTED peers
+    only (never directed/isolated, never a row without the pair channel), over _peer_call.
+  * the relay route — POST /push/relay is token-gated, judges the ORIGIN's trust tier at delivery
+    time (unknown fails safe, with the reason on stderr — fail loudly), mirrors capped, wears the
+    origin the way every federated surface does (host-prefixed sid + title), and NEVER forwards
+    onward (a relayed event is terminal, so attachment cycles cannot echo).
+  * the payload — a mirrored event omits `badge` (the origin kernel's count is not this kernel's),
+    _push_notify omits the key for badge=None, and the worker applies setAppBadge to numeric
+    values only, so a mirrored event can never clear a real local count.
+  * the reveal — a host-prefixed sid is handed to the merged dashboard's own routing, never a
+    confirmRevive minted from the WRONG kernel's session list.
+
+Synthetic only — invented host names (boxa/boxb/TESTHOST), placeholder ids, no real session data.
+"""
+import contextlib
+import io
+import json
+import os
+import threading
+import unittest
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+# Belt over conftest's suspenders (the webpush test's 2026-08-08 lesson): a RAW run of this file
+# must never see live state, so the state root is rebound BEFORE the kernel module loads and
+# captures jd.STATE into its path constants.
+import tempfile
+from pathlib import Path
+_STATE_TD = tempfile.TemporaryDirectory()
+jd.STATE = Path(_STATE_TD.name)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel_webpush_fed", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _serve_post(path, body=None, headers=None):
+    """Drive the REAL do_POST dispatcher over a fake socket (the auth-hardening harness):
+    (status, body_bytes)."""
+    raw = json.dumps(body).encode() if isinstance(body, (dict, list)) else (body or b"")
+    h = km.Handler.__new__(km.Handler)
+    h.client_address = ("127.0.0.1", 0)
+    hdrs = dict(headers or {})
+    hdrs.setdefault("Content-Length", str(len(raw)))
+    h.headers = hdrs
+    h.path = path
+    h.command = "POST"
+    h.request_version = "HTTP/1.1"
+    h.wfile = io.BytesIO()
+    h.rfile = io.BytesIO(raw)
+    h.close_connection = True
+    captured = {}
+    h.send_response = lambda code, *a: captured.__setitem__("status", code)
+    h.send_header = lambda k, v: None
+    h.end_headers = lambda: None
+    h.log_message = lambda *a: None
+    h.do_POST()
+    return captured.get("status"), h.wfile.getvalue()
+
+
+def _seed_remote(host, trust, local_port=1, token="tok"):
+    with km._remotes_lock:
+        km._remotes[host] = {"host": host, "kernel_port": 1, "local_port": local_port,
+                             "token": token, "proc": None, "status": "up", "trust": trust}
+
+
+def _clear_remotes():
+    with km._remotes_lock:
+        km._remotes.clear()
+    with km._known_lock:
+        km._known.clear()
+
+
+class PushForward(unittest.TestCase):
+    def setUp(self):
+        _clear_remotes()
+
+    def tearDown(self):
+        _clear_remotes()
+
+    def _run_forward(self, events):
+        calls, done = [], threading.Event()
+
+        def fake_peer_call(r, method, path, body=None, timeout=8):
+            calls.append((r.get("host"), method, path, body))
+            done.set()
+            return 200, {"ok": True}
+
+        with mock.patch.object(km, "_peer_call", side_effect=fake_peer_call):
+            km._push_forward(events)
+            # fire-and-forget thread; the event marks first delivery, the join grace the rest
+            if km._remotes:
+                done.wait(5)
+        return calls
+
+    def test_only_trusted_peers_with_a_pair_channel_hear_events(self):
+        _seed_remote("boxa", "trusted")                       # hears it
+        _seed_remote("boxb", "directed")                      # policy: never
+        _seed_remote("boxc", "isolated")                      # policy: never
+        _seed_remote("boxd", "trusted", token="")             # no channel to speak through
+        _seed_remote("boxe", "trusted", local_port=0)         # no channel to speak through
+        calls = self._run_forward([{"title": "romp: web", "body": "Needs you: x", "sid": "S1"}])
+        self.assertEqual([c[0] for c in calls], ["boxa"])
+        host, method, path, body = calls[0]
+        self.assertEqual((method, path), ("POST", "/push/relay"))
+        self.assertEqual(body["origin"], km._self_host())
+        self.assertEqual(body["events"], [{"title": "romp: web", "body": "Needs you: x", "sid": "S1"}])
+
+    def test_no_events_or_no_peers_is_silent(self):
+        self.assertEqual(self._run_forward([]), [])           # nothing fired
+        _seed_remote("boxb", "directed")
+        calls = self._run_forward([{"title": "t", "body": "b", "sid": ""}])
+        self.assertEqual(calls, [])                           # nobody trusted
+
+
+class RelayRoute(unittest.TestCase):
+    def setUp(self):
+        _clear_remotes()
+
+    def tearDown(self):
+        _clear_remotes()
+
+    def _relay(self, body, token=True):
+        headers = {"X-Romp-Token": km.TOKEN} if token else {}
+        with mock.patch.object(km, "_push_notify") as pn, \
+             mock.patch.object(km, "_push_forward") as pf, \
+             contextlib.redirect_stderr(io.StringIO()) as err:
+            status, raw = _serve_post("/push/relay", body, headers=headers)
+        try:
+            parsed = json.loads(raw.decode() or "{}")
+        except ValueError:
+            parsed = {}
+        return status, parsed, pn, pf, err.getvalue()
+
+    def test_gated_like_every_route(self):
+        status, _, pn, _, _ = self._relay({"origin": "boxa", "events": []}, token=False)
+        self.assertEqual(status, 403)
+        pn.assert_not_called()
+
+    def test_malformed_bodies_are_400(self):
+        st, _ = _serve_post("/push/relay", b"not json", headers={"X-Romp-Token": km.TOKEN})
+        self.assertEqual(st, 400)
+        for bad in ({"events": [{}]},                          # no origin
+                    {"origin": "boxa"},                        # no events
+                    {"origin": "boxa", "events": "x"}):        # events not a list
+            status, _, pn, _, _ = self._relay(bad)
+            self.assertEqual(status, 400)
+            pn.assert_not_called()
+
+    def test_a_trusted_origin_mirrors_wearing_its_host_prefix(self):
+        _seed_remote("boxa", "trusted")
+        ev = {"title": "romp: web", "body": "Needs you: fix the login flow", "sid": "11111111-2222"}
+        status, parsed, pn, _, err = self._relay({"origin": "boxa", "events": [ev]})
+        self.assertEqual(status, 200)
+        self.assertEqual(parsed, {"ok": True, "mirrored": 1})
+        # the origin rides the sid AND the title, the way every federated surface wears it —
+        # and badge is OMITTED (positional call, default None): the origin's count is not ours
+        pn.assert_called_once_with("romp: boxa:web", "Needs you: fix the login flow",
+                                   "boxa:11111111-2222")
+        self.assertEqual(err, "")
+
+    def test_title_and_sid_surgery_is_tolerant(self):
+        _seed_remote("boxa", "trusted")
+        evs = [{"title": "Custom shape", "body": "b", "sid": "already:prefixed"},
+               {"title": "", "body": "", "sid": "S"}]          # empty event: skipped, not an error
+        status, parsed, pn, _, _ = self._relay({"origin": "boxa", "events": evs})
+        self.assertEqual(status, 200)
+        self.assertEqual(parsed["mirrored"], 1)
+        pn.assert_called_once_with("Custom shape", "b", "already:prefixed")
+
+    def test_a_remembered_trusted_host_counts(self):
+        # trust is judged by origin, attached or not — the remembered table is the origin store
+        km._known_note("boxb", "trusted")
+        status, parsed, pn, _, _ = self._relay(
+            {"origin": "boxb", "events": [{"title": "romp: api", "body": "Completed: done", "sid": "S2"}]})
+        self.assertEqual(parsed, {"ok": True, "mirrored": 1})
+        pn.assert_called_once_with("romp: boxb:api", "Completed: done", "boxb:S2")
+
+    def test_below_trusted_drops_loudly_and_never_buzzes(self):
+        _seed_remote("boxa", "directed")
+        for origin, want_tier in (("boxa", "directed"), ("TESTHOST", "unknown")):
+            status, parsed, pn, _, err = self._relay(
+                {"origin": origin, "events": [{"title": "t", "body": "b", "sid": "S"}]})
+            self.assertEqual(status, 200)
+            self.assertEqual(parsed, {"ok": False, "mirrored": 0, "tier": want_tier})
+            pn.assert_not_called()
+            self.assertIn(origin, err)                        # the drop names its origin…
+            self.assertIn(want_tier, err)                     # …its tier…
+            self.assertIn("network panel", err)               # …and the remedy
+
+    def test_a_relayed_event_is_terminal(self):
+        # never forwarded onward — this is the whole cycle-safety argument, so it is pinned
+        _seed_remote("boxa", "trusted")
+        _seed_remote("boxb", "trusted")                       # a second trusted peer is listening…
+        status, _, _, pf, _ = self._relay(
+            {"origin": "boxa", "events": [{"title": "t", "body": "b", "sid": "S"}]})
+        self.assertEqual(status, 200)
+        pf.assert_not_called()                                # …and still hears nothing from a relay
+
+    def test_the_fan_in_is_capped(self):
+        _seed_remote("boxa", "trusted")
+        evs = [{"title": "t%d" % i, "body": "b", "sid": "S%d" % i} for i in range(20)]
+        status, parsed, pn, _, _ = self._relay({"origin": "boxa", "events": evs})
+        self.assertEqual(parsed["mirrored"], 16)
+        self.assertEqual(pn.call_count, 16)
+
+
+class MirroredPayloadShape(unittest.TestCase):
+    def test_badge_none_omits_the_key_and_numeric_keeps_it(self):
+        sent, done = [], threading.Event()
+
+        def fake_send(sub, payload):
+            sent.append(json.loads(payload.decode()))
+            done.set()
+            return True
+
+        km._PUSH_CRYPTO[0] = {"stub": True}                   # sink runs; no real crypto touched
+        try:
+            with mock.patch.object(km, "_push_subs", return_value={"ep": {"k": 1}}), \
+                 mock.patch.object(km, "_push_send_one", side_effect=fake_send):
+                km._push_notify("t", "b", "S")                # the mirrored-event shape
+                self.assertTrue(done.wait(5))
+                done.clear()
+                km._push_notify("t", "b", "S", badge=3)       # the local shape
+                self.assertTrue(done.wait(5))
+        finally:
+            km._PUSH_CRYPTO[0] = None
+        self.assertNotIn("badge", sent[0])
+        self.assertEqual(sent[1]["badge"], 3)
+
+    def test_the_worker_paints_numeric_badges_only(self):
+        # a mirrored event (no badge) must never CLEAR a real local count via `d.badge||0`
+        self.assertIn("typeof d.badge==='number'", km._SW_JS)
+        self.assertNotIn("d.badge||0", km._SW_JS)
+
+
+class FederatedReveal(unittest.TestCase):
+    def test_a_prefixed_sid_is_handed_to_the_merged_dashboard(self):
+        # liveness is the ORIGIN kernel's truth: the local session list must not turn a remote
+        # session's tap into a confirmRevive minted from the wrong world
+        with mock.patch.object(km, "_tmux_sessions", return_value={}), \
+             mock.patch.object(km, "_name_of", return_value="web"):
+            self.assertEqual(km._reveal_msg("boxa:11111111-2222"),
+                             {"type": "focus", "id": "boxa:11111111-2222", "live": True})
+            # …while a bare unknown sid keeps the revive prompt it always had
+            self.assertEqual(km._reveal_msg("11111111-2222")["type"], "confirmRevive")
+
+
+class ForwardWiring(unittest.TestCase):
+    def test_the_forward_rides_the_same_fired_events(self):
+        # the one choke point: the forward consumes the SAME _feed_notifications result the bells
+        # and local pushes consumed — never a second diff that could disagree
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("_fired = _feed_notifications(feed)", src)
+        self.assertIn('_push_forward([{"title": _t, "body": _b, "sid": _sid} for _t, _b, _sid in _fired])',
+                      src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -200,9 +200,12 @@ class NotifyWiring(unittest.TestCase):
 
     def test_fresh_feed_builds_drive_the_notifier(self):
         # the detector runs where the fresh build lands — the one choke point every push shares
-        # (the sid joined the tuple 2026-08-08 so the push sink can aim its tap-to-open)
-        self.assertIn("for _t, _b, _sid in _feed_notifications(feed):", self.src)
+        # (the sid joined the tuple 2026-08-08 so the push sink can aim its tap-to-open; the list
+        # got a name the same day so the federated forward rides the SAME events, never a re-diff)
+        self.assertIn("_fired = _feed_notifications(feed)", self.src)
+        self.assertIn("for _t, _b, _sid in _fired:", self.src)
         self.assertIn("_system_notify(_t, _b)", self.src)
+        self.assertIn("_push_forward([{", self.src)   # trusted peers hear the same transition
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**The ask (2026-08-08, minutes after installing the home-screen app):** with kernels linked, which kernel a notification comes from is mechanics the user should never think about — a device subscribed at one kernel should get the bell events of every kernel connected to it. The invariant this lands: **push scope = dashboard scope.**

**Why the gap existed:** the merged multi-host view is assembled in the browser (one socket per kernel, `host:`-prefixed ids); the kernel holding a push subscription never sees another host's cards, so its bell detector fires for local sessions only.

**Design (plans/federated-push.md records it):** forward at the event source, mirror at the subscriber.
- When a kernel's bell fires (the same armed-card feed-build transition as every other sink), `_push_forward` hands the fired events to every attached **trusted** peer via `POST /push/relay`, over the pair channel that already exists (`_peer_call`: the tunnel + the token exchanged at attach). No new legs, no new trust surface; both attach styles hold the pair token, so events flow in both directions of an attachment.
- The receiving kernel mirrors to its own devices, wearing the origin the way every federated surface wears it: sid and title gain the `origin:` prefix, so a tap routes through the merged dashboard's own tabs. Title surgery is skew-tolerant (an unrecognized shape passes through unprefixed).
- **A relayed event is terminal** — never forwarded onward — so attachment cycles cannot echo; no event ids needed.
- **Trust is judged by origin at delivery time** (attached row, else the remembered-hosts table), the same by-origin judgment the bus makes for mail. Below trusted drops with its reason and remedy on stderr — never a silent buzz, never a silent drop.
- Mirrored events **omit `badge`** and the worker now applies `setAppBadge` to numeric values only: the origin's needs-you count is not the receiver's, and repainting 0 would clear a real local count.
- `_reveal_msg` hands a `host:sid` focus to the merged dashboard as-is instead of minting a `confirmRevive` from the wrong kernel's session list.

**Second commit, same phone-install context:** the installed Android app re-asked for the token on every launch — launcher intents score as cross-site navigations, so the `SameSite=Strict` auth cookie never rode along. Now `Lax`: still never attaches to a cross-site POST/subresource (every state-changing route is a POST), so the gate is unchanged.

**Known follow-ups, deliberately out:** cold-start tap precision for remote sids (the parked reveal can consume before federation merges that host's tabs), a merged badge count, quarantine-card visibility for tier-dropped relays.

## Verification

Full suite on this branch: **4027 passed** (28 skipped, same set as main), extension suite **1732 passed**. New coverage: `tests/test_kernel_webpush_federation.py` (forward gating incl. channel-less rows, relay auth/tier/prefix/cap/terminality, badge-key omission, worker numeric-badge pin, federated reveal, choke-point wiring) and the `SameSite=Lax` regression pin in `tests/test_kernel_installable_app.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)