### PR TITLE
Each session picks which account it bills, and the rail reads mixed hosts honestly

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -127,6 +127,40 @@ rate-limited — and never appears on a session that cannot run fast mode.
 Turning it on while the session is on a non-Opus model makes the CLI switch to
 a fast-capable one, which the chat shows as the command's own confirmation.
 
+### Per-session billing (login vs API key)
+
+An SDK session can bill either the machine's Claude login (subscription usage)
+or the `ANTHROPIC_API_KEY` the manager's environment carries — per session.
+The choice appears in two places, and only on a machine that actually offers
+both (with one choice there is nothing to pick, so the control is absent):
+
+- the new-session picker's **Billing** row, when the selected host offers both
+  and the backend toggle says SDK;
+- a statusline badge on the session, beside mode/model/effort. Switching
+  reconnects the session to apply (the key rides the launch environment), with
+  the same switching-dots the effort badge wears.
+
+The key option is always labelled by the key's last 4 characters (`API …wxyz`)
+so you can tell which key it is; the key itself never appears. A new session
+defaults to the last pick made anywhere, and before any pick to the key when
+one is configured — exactly what an ambient key did before the selector
+existed. tmux sessions are not covered: their CLI lives in the tmux server's
+environment, which the kernel does not control.
+
+Failures are loud rather than silent: a session that lands on the other auth
+than it was launched for (say, a key found through `apiKeyHelper`) is flagged
+in the Log panel, and a dead credential — "Not logged in", an invalid or
+expired key — blocks the session's card with the fix named, and is never
+auto-retried.
+
+The usage rail reflects a mixed machine: the window bars (5 hours / 7 days /
+Fable 5) are drawn once, aggregated across every connected host's login as the
+worst reading per window, and an `API …wxyz` cell beside them carries the
+key-billed dollars (5-hour burn and month-to-date, numbers only). Hovering
+breaks both down per host; a host can show its login's windows and its key's
+spend side by side. Only turns whose session billed the key count toward the
+API numbers — a login turn's computed cost is dollars nobody pays.
+
 ### Install-time switches
 
 For `./install.sh`:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3663,7 +3663,7 @@ def _pick_identity_color(now=None):
     return bgs[i], fgs[i]
 
 
-def _create_sdk_session(nm, cwd):
+def _create_sdk_session(nm, cwd, auth=""):
     """Create + open a new SDK-backed session, ACK-FAST (the user 2026-07-14, who asked why it took so long
     to open a new SDK session). spawn() is file writes and connect() is threaded (~0.4s to a booting
     CLI) — the 7-10s the user waited was the handler's inline _push_all(): a new session invalidates the
@@ -3673,7 +3673,7 @@ def _create_sdk_session(nm, cwd):
     pusher's build arrives — then the dirty-mark wake. Never a synchronous fleet build on this path
     (the push-architecture rule, 2026-07-05)."""
     bg, fg = _pick_identity_color()   # fleet-aware: only the kernel sees BOTH backends' live sessions
-    sid = _sdk().spawn(nm, cwd, bg, fg)
+    sid = _sdk().spawn(nm, cwd, bg, fg, auth=auth)
     _sdk().connect(sid)    # eager-connect so the model lists immediately, not only after the 1st message
     _set_hidden_tab(sid, False)
     _reveal_chat({"type": "focus", "id": sid})
@@ -3786,6 +3786,45 @@ _SDK_BOOT_PROBLEMS = []
 def _sdk_problem(text):
     _SDK_BOOT_PROBLEMS.append({"seq": len(_SDK_BOOT_PROBLEMS) + 1, "t": time.time(), "text": str(text)})
     del _SDK_BOOT_PROBLEMS[:-20]
+
+
+def _auth_key_tail():
+    """Last 4 characters of the manager's API key ("" = none) — the label that says WHICH key without
+    saying the key. Cheap: an attribute read off the backend singleton, safe per-push."""
+    be = _sdk()
+    key = str(getattr(be, "work_key", "") or "") if be else ""
+    return key[-4:] if key else ""
+
+
+def _auth_both():
+    """True when this machine offers BOTH billing choices (a signed-in login and a manager-env key) —
+    the condition for the per-session auth selector to exist anywhere (picker, gear). Cheap per-push:
+    _claude_account is mtime-cached and the key is an attribute read."""
+    return bool(_auth_key_tail()) and bool(_claude_account())
+
+
+def _auth_avail():
+    """Which billing choices this machine can offer a session: {'login','key','tail','default'}. The
+    picker and the gear render the auth selector ONLY when both are real — one choice is no choice, so
+    the control disappears (the user 2026-08-08). login = the credential store names a signed-in
+    account (_claude_account — the same authority the usage bars trust; a stale login still fails
+    LOUDLY per session via apiKeySource/authErr rather than being second-guessed here). key = the
+    manager's environment carried ANTHROPIC_API_KEY, now held by the SDK backend (work_api_key claimed
+    it out of os.environ). tail = the key's last 4 characters — the label that says WHICH key without
+    saying the key. default = what a fresh session would use absent an explicit pick."""
+    be = _sdk()
+    key = str(getattr(be, "work_key", "") or "") if be else ""
+    d = {}
+    try:
+        d = json.loads((jd.STATE / "sdk-defaults.json").read_text())
+        d = d if isinstance(d, dict) else {}
+    except Exception:
+        d = {}
+    default = d.get("auth") if d.get("auth") in ("login", "key") else ("key" if key else "login")
+    if default == "key" and not key:
+        default = "login"
+    return {"login": bool(_claude_account()), "key": bool(key),
+            "tail": key[-4:] if key else "", "default": default}
 
 
 def _sdk_problem_count():
@@ -4071,7 +4110,7 @@ def _drive(msg, client):
     t = msg.get("type")
     ID_OPS = ("sendMessage", "rewindSend", "rewindDelete", "interrupt", "compactSession", "dismissDialog", "answerAsk", "navAsk", "toggleAsk", "submitAsk",
               "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "setModel", "setEffort", "setMode", "setFast",
-              "endSession", "renameSession", "stopTask", "rewindFiles", "mcpAction")
+              "setAuth", "endSession", "renameSession", "stopTask", "rewindFiles", "mcpAction")
     if t in ID_OPS and msg.get("id"):
         sid = str(msg["id"])
     elif t in ("compact", "sendCommand") and msg.get("name"):
@@ -4327,6 +4366,15 @@ def _drive(msg, client):
         _push_soon()
     elif t == "setMode" and msg.get("value"):
         be.set_mode(sid, str(msg["value"])); _push_soon()
+    elif t == "setAuth" and msg.get("value") in ("login", "key"):
+        # per-session billing (login vs the manager env's API key) — SDK-only, applied via reconnect
+        # like /effort; mid-compaction → parked in the same FIFO. LOUD on refusal (fail loudly): tmux
+        # sessions and a keyless manager can't apply it, and a silent swallow leaves a dead control.
+        if not _set_auth_or_park(be, sid, str(msg["value"])):
+            client["send"](json.dumps({"type": "warn",
+                                       "text": "Couldn't switch the account this session bills — "
+                                               "it isn't an SDK session, or no API key is configured."}))
+        _push_soon()
     elif t == "stopTask" and msg.get("taskId"):
         # the SDK's designed stop_task control request, addressed by the id the bg-task box shows.
         # LOUD on refusal (fail loudly, never degrade silently): unknown task / dead client / tmux
@@ -4784,7 +4832,7 @@ class TmuxBackend(sb.SessionBackend):
 
     # lifecycle — tmux sessions are launched by bin/romp (not the kernel) and revived via romp-postal, so
     # spawn/resume aren't backend primitives here; the kernel uses _spawn_session/_revive_session for those.
-    def spawn(self, name, cwd, bg="", fg="", sid=None):
+    def spawn(self, name, cwd, bg="", fg="", sid=None, auth=""):
         return None
 
     def resume(self, name, sid, cwd=None):
@@ -5097,6 +5145,8 @@ class Sessions:
                                 "context": ctx if isinstance(ctx, (int, float)) else None, "compactPct": None,
                                 "fast": st.get("fast", ""),   # fast-mode state from the CLI's init ("on"/"off"/"cooldown"; "" = unknown → no badge)
                                 "fastReason": st.get("fastReason", ""),   # init's disabled_reason — non-empty hides the chat toggle
+                                "auth": st.get("auth", ""),   # which account this session bills ('login'|'key') → gear badge
+                                "authPending": bool(st.get("authPending")),   # an /auth switch reconnecting → badge dots
                                 "color": (st.get("color") or None), "mode": st.get("mode", ""), "backend": "sdk",
                                 "subagents": st.get("subagents") or [],   # live Task subagents (SDK only) → lane pill
                                 # live BACKGROUND TASKS (the CLI's task lifecycle stream) — the awaiting
@@ -6514,26 +6564,22 @@ def _poll_remote_usage(r):
 
 
 def _fleet_usage():
-    """Every DISTINCT Claude account across the fleet, each with the usage to draw for it.
+    """One row per HOST whose usage is known — local always first (the notices read off it), each row
+    {host, acct, usage}.
 
-    The rail drew one set of bars for this machine alone, which is right exactly when every machine is
-    signed into the same account — the windows are account-wide, so drawing them per host would just
-    repeat one number. When accounts DIFFER the single set was wrong instead: two real allowances shown
-    as one (the user 2026-07-30). So group by account digest and emit one row per group, labelled with a
-    host that is on it. Rows whose account matches this machine's collapse into the local row, and a
-    remote that cannot report an account at all (an older kernel) is left out rather than guessed at —
-    a phantom second set of bars would be worse than the honest single one."""
+    This USED to emit one row per distinct account digest, because the rail drew every row as its own
+    set of bars and a shared login drawn twice reads as two allowances (the user 2026-07-30). The rail
+    no longer draws rows: it AGGREGATES one set of bars (worst window across accounts, deduped by
+    `acct` client-side) and breaks down PER HOST on hover (the user 2026-08-08) — so every reporting
+    host must ride along. That includes a host with no login at all (acct ""), whose API-key spend the
+    dedup used to drop entirely: with per-session auth a host's payload can carry bars AND spend, and
+    the spend half has no account digest to group by — the host IS its identity."""
     local = _usage() or {}
     rows = [{"host": "", "acct": local.get("acct") or "", "usage": local or None}]
-    seen = {rows[0]["acct"]} if rows[0]["acct"] else set()
     with _remotes_lock:
         cand = [(r["host"], r.get("usage")) for r in _remotes.values() if (r.get("status") == "up") and r.get("usage")]
     for host, u in sorted(cand):
-        acct = (u or {}).get("acct") or ""
-        if not acct or acct in seen:
-            continue      # same login as somewhere already drawn (or a kernel too old to say) → one set
-        seen.add(acct)
-        rows.append({"host": host, "acct": acct, "usage": u})
+        rows.append({"host": host, "acct": (u or {}).get("acct") or "", "usage": u})
     return rows
 
 
@@ -9030,6 +9076,22 @@ def _is_model_limit(text):
     return "limit" in low and ("/usage-credits" in low or "switch models" in low)
 
 
+# An AUTH failure — no working login ("Not logged in · Please run /login"), or a key the API refuses
+# (401 "API key is invalid", "Failed to authenticate", an expired OAuth token). On YOU like the three
+# limit classes: retrying re-presents the same dead credential forever, and with per-session auth
+# (2026-08-08) this is precisely how a session that picked a broken side surfaces — the alternative was
+# an unclassified "transient" error, i.e. an invisible working card that never works again. Matched on
+# the CLI's own phrasings plus the API's 401 wording; a transient 5xx/timeout matches none of these.
+def _is_auth_error(text):
+    low = (text or "").lower()
+    return ("not logged in" in low
+            or "api key is invalid" in low
+            or "invalid x-api-key" in low
+            or "failed to authenticate" in low
+            or ("oauth token" in low and ("expired" in low or "revoked" in low))
+            or "authentication_error" in low)
+
+
 def _spend_dialog_showing(pane):
     """Is the CLI's spend-cap MODAL currently up in this pane capture? When a tmux session hits the
     monthly cap MID-TURN the CLI drops into an interactive menu ("What do you want to do? / Adjust
@@ -9091,7 +9153,10 @@ def _api_error(path):
                                # a model's own allowance is spent — on YOU too (switch model / add
                                # credits), and the auto-retry keeps running only because the window does
                                # eventually reset; see _is_model_limit
-                               "modelLimit": _is_model_limit(text)}
+                               "modelLimit": _is_model_limit(text),
+                               # a dead credential (no login / refused key) — on YOU, never auto-retried;
+                               # see _is_auth_error (per-session auth, the user 2026-08-08)
+                               "authErr": _is_auth_error(text)}
                     elif (isinstance(c, list) and any(isinstance(b, dict)
                             and b.get("type") in ("text", "tool_use", "thinking") for b in c)) \
                             or (isinstance(c, str) and c.strip()):
@@ -10604,6 +10669,18 @@ def _set_effort_or_park(be, sid, value):
         be.set_effort(sid, value)
 
 
+def _set_auth_or_park(be, sid, value):
+    """Apply a billing-account change now — or park it while the session compacts, in the same FIFO as
+    /model and /effort (it reconnects the session, which mid-compaction would derail the compaction
+    exactly the way a model switch would). Returns the backend's verdict so the caller can be loud."""
+    if value not in ("login", "key"):
+        return False
+    if _ops_gate(sid):
+        _park_op(sid, ("auth", value))
+        return True
+    return be.set_auth(sid, value)
+
+
 def _set_fast_or_park(be, sid, value):
     """Apply a fast-mode toggle now — or park it while the session compacts, exactly like /model and
     /effort (it is a slash command and must keep press order in the same FIFO). Returns the backend's
@@ -10679,6 +10756,9 @@ def _apply_pending_ops():
                     ops.pop(0)
                 elif op[0] == "fast":
                     be.set_fast(sid, op[1])
+                    ops.pop(0)
+                elif op[0] == "auth":
+                    be.set_auth(sid, op[1])
                     ops.pop(0)
                 else:
                     ops.pop(0)                        # unknown op kind → drop, never wedge the queue
@@ -11918,6 +11998,11 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   # client's retry-all skips it: nothing retries into it until the model changes or its
                   # window resets, and an amber "retrying" tab said the opposite (the user 2026-08-01)
                   "apiModelLimit": bool(aerr and aerr.get("modelLimit")),
+                  # an AUTH failure (not logged in / invalid or expired key) is on-you like the three
+                  # above — retrying can't fix a credential, only you can (claude /login, or fix
+                  # service.env) — and with per-session auth it's how a session that landed on a broken
+                  # side gets seen at all instead of idling as an invisible transient (the user 2026-08-08)
+                  "apiAuthErr": bool(aerr and aerr.get("authErr")),
                   # user interrupted this thread's retry/API-error storm → romp's auto-retry stays OFF for it
                   # until a successful turn re-arms (the user 2026-07-06); the card + retry loop read this
                   "retrySuppressed": _session_retry_suppressed(sid),
@@ -11932,6 +12017,12 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   # no badge — tmux stays "" until its statusline publishes a fast var). A non-empty
                   # disabled_reason means /fast would refuse, so the chat hides the toggle.
                   "fast": "" if tm.get("fastReason") else tm.get("fast", ""),
+                  # which account this session bills ('login'|'key') — present ONLY when this machine
+                  # actually offers both (see _auth_both), so the badge disappears rather than showing
+                  # a one-option selector (the user 2026-08-08). authTail labels the key option.
+                  "auth": (tm.get("auth", "") if _auth_both() else ""),
+                  "authPending": bool(tm.get("authPending")),   # an /auth reconnect applying → badge dots
+                  "authTail": (_auth_key_tail() if _auth_both() else ""),
                   "modelPending": _model_pending_now(sid, tm),   # switching-dots on the model badge until the pick lands, from EITHER surface (the user 2026-07-03)
                   "effortPending": bool(tm.get("effortPending")),   # switching-dots on the effort badge while the /effort reconnect applies (SDK-only; the user 2026-07-06)
                   "ctx": str(tm["context"]) if tm["context"] is not None else "",
@@ -13460,7 +13551,7 @@ def build_feed(now, tmux=None):
             # a session nothing could move — not nudged (the api-error gate suppresses it), not blocked,
             # not awaiting, for 80 minutes.
             api_block = (nid == api_top and bool(aerr and (aerr.get("tooLong") or aerr.get("spendLimit")
-                                                          or aerr.get("modelLimit"))))
+                                                          or aerr.get("modelLimit") or aerr.get("authErr"))))
             # NUDGE FAILED (plans/stalled-open-todos-nudge.md, the user 2026-07-01): the tick stamped
             # `failed` on this goal's nudge record — the nudge-response turn completed (judged) and the goal
             # was still working-stalled; per the anti-loop rule it is never re-nudged, so the card carries
@@ -13623,11 +13714,15 @@ def build_feed(now, tmux=None):
                              "text": aerr.get("text"), "tooLong": bool(aerr.get("tooLong")),
                              "spendLimit": bool(aerr.get("spendLimit")),
                              "modelLimit": bool(aerr.get("modelLimit")),
+                             "authErr": bool(aerr.get("authErr")),
                              "what": ("this account hit its monthly spend limit — raise it at claude.ai/settings/usage to continue" if aerr.get("spendLimit")
                                       else "this session's prompt is too long — compact it to continue" if aerr.get("tooLong")
                                       # the CLI's own text names the model and the two remedies; the card
                                       # states them, because "Retry to resume" is false here (the user 2026-08-01)
                                       else "this session's model is out of allowance — switch its model or add credits to continue" if aerr.get("modelLimit")
+                                      # a dead credential: retrying re-presents it forever — name the fix
+                                      # (per-session auth, the user 2026-08-08)
+                                      else "this session's sign-in or API key isn't working — fix the login (claude /login) or the key, or switch which one it bills" if aerr.get("authErr")
                                       else "this session stopped on an API error — Retry to resume")} if nid == api_top
                             else {"state": perm_state,
                                   "what": ("this session is stopped awaiting your input" if perm_state == "picker"
@@ -13875,8 +13970,10 @@ def _usage():
         if o.get("apiKey") or (not _claude_account() and (jd.STATE / "spend.json").exists()):
             # The spend WINDOWS mirror the subscription bars (5h / 7d / month) so the two auth modes
             # read identically; _spend_windows always returns all three, zero-filled on a fresh kernel
-            # (an empty slot reads as broken — the user 2026-08-04, post-restart).
-            return {"apiKey": True, "spend": _spend_windows(),
+            # (an empty slot reads as broken — the user 2026-08-04, post-restart). TOTAL sums, not the
+            # keyed split: on a no-login machine every turn bills the key, and legacy files predate
+            # the split. apiTail names WHICH key (last 4) — the rail's API label (the user 2026-08-08).
+            return {"apiKey": True, "spend": _spend_windows(), "apiTail": _auth_key_tail(),
                     "t": o.get("t") if isinstance(o.get("t"), (int, float)) else None,
                     "acct": _claude_account()}
         return None
@@ -13887,17 +13984,26 @@ def _usage():
         return bool(s and s.get("pct", 0) >= 100 and not (s.get("resetsAt") and time.time() > s["resetsAt"]))
     limited = {"fiveHour": _lim(five), "sevenDay": _lim(seven), "fable": _lim(fable)}
     t = o.get("t")
-    return {"fiveHour": five, "sevenDay": seven, "fable": fable,
-            # NO spend windows beside the bars (the user 2026-08-08, same day they were added: a login
-            # account's story is its % bars, and its token rows read as noise — token volume + dollars
-            # are API-KEY information, carried only on the spend-only payload above).
-            "t": t if isinstance(t, (int, float)) else None,
-            # WHOSE allowance this is. These windows are account-wide, so two machines signed into the
-            # SAME account share one set of numbers and must not be drawn twice; two machines on
-            # DIFFERENT accounts have genuinely separate allowances and pooling them was a lie (the user
-            # 2026-07-30). An opaque digest — equality is the whole question, and no identifier travels.
-            "acct": _claude_account(),
-            "limited": limited if any(limited.values()) else None}
+    out = {"fiveHour": five, "sevenDay": seven, "fable": fable,
+           "t": t if isinstance(t, (int, float)) else None,
+           # WHOSE allowance this is. These windows are account-wide, so two machines signed into the
+           # SAME account share one set of numbers and must not be drawn twice; two machines on
+           # DIFFERENT accounts have genuinely separate allowances and pooling them was a lie (the user
+           # 2026-07-30). An opaque digest — equality is the whole question, and no identifier travels.
+           "acct": _claude_account(),
+           "limited": limited if any(limited.values()) else None}
+    # API-KEY spend BESIDE the bars — the KEYED split only (turns whose session billed the key; a login
+    # turn's computed cost is dollars nobody pays), attached only when key turns actually exist, so a
+    # host that never uses its key shows nothing extra. This supersedes the same-day rule that bars
+    # never carry spend (the user 2026-08-08, morning): that held for a machine whose sessions all
+    # share one auth; per-session auth (same day, evening) makes one host BOTH, and the key's real
+    # dollars belong on the rail next to the login's real %.
+    if _auth_key_tail():
+        ksp = _spend_windows(keyed_only=True)
+        if any((ksp.get(k) or {}).get("turns") for k in ("fiveHour", "sevenDay", "month")):
+            out["spend"] = ksp
+            out["apiTail"] = _auth_key_tail()
+    return out
 
 
 _jf_cache = {"fp": None, "val": None}                 # judge-failure scan, mtime-fingerprinted over the goals dir
@@ -13935,12 +14041,18 @@ def _spend_budgets():
         return {}
 
 
-def _spend_windows():
+def _spend_windows(keyed_only=False):
     """API-mode usage windows MIRRORING the subscription bars (the user 2026-08-04, who wanted the two
     auth modes to read identically at a glance): rolling 5h and 7d summed from spend.json's hour
     buckets, month-to-date from its day buckets — each {usd, tok, turns}, plus `budget` where
     spend-budgets.json names one. Always returns all three windows (zeros when nothing is recorded —
-    the day genuinely holds none; the honest-zero rule from the chip era)."""
+    the day genuinely holds none; the honest-zero rule from the chip era).
+
+    keyed_only=True sums each bucket's `key` sub-counters instead — the turns whose SESSION billed an
+    API key (see _record_spend). That is what the rail's API readout shows beside a login's bars on a
+    mixed host: the total would fold login turns' computed costs in — dollars nobody is billed (the
+    user 2026-08-08). The no-login machine keeps the total (everything there IS the key, and legacy
+    files predate the split)."""
     try:
         d = json.loads((jd.STATE / "spend.json").read_text())
     except Exception:
@@ -13952,9 +14064,15 @@ def _spend_windows():
         out = {"usd": 0.0, "tok": 0, "turns": 0}
         for e in entries:
             if isinstance(e, dict):
-                out["usd"] = round(out["usd"] + float(e.get("usd") or 0), 4)
-                out["turns"] += int(e.get("turns") or 0)
-                out["tok"] += sum(int(e.get(k) or 0) for k in ("tokIn", "tokOut", "tokCacheR", "tokCacheW"))
+                if keyed_only:
+                    e = e.get("key") if isinstance(e.get("key"), dict) else {}
+                    out["usd"] = round(out["usd"] + float(e.get("usd") or 0), 4)
+                    out["turns"] += int(e.get("turns") or 0)
+                    out["tok"] += int(e.get("tok") or 0)
+                else:
+                    out["usd"] = round(out["usd"] + float(e.get("usd") or 0), 4)
+                    out["turns"] += int(e.get("turns") or 0)
+                    out["tok"] += sum(int(e.get(k) or 0) for k in ("tokIn", "tokOut", "tokCacheR", "tokCacheW"))
         return out
 
     now = time.time()
@@ -17602,9 +17720,9 @@ function esc(s){return String(s).replace(/[&<>"]/g,function(c){return{'&':'&amp;
 var WINS=[['fiveHour',5*3600,'5h','Session','5 hours'],
           ['sevenDay',7*86400,'7d','Weekly','7 days'],
           ['fable',7*86400,'F5','Fable 5','Fable 5']];
-// ROWS is one entry per DISTINCT Claude account across the fleet, local first (see /usage/fleet); LAST is
-// the tooltip detail for the ones actually drawn; SELF names this machine, for labelling the local set
-// when there is more than one. A one-account fleet keeps a single unlabelled set, exactly as before.
+// ROWS is one entry per HOST whose usage is known, local first (see /usage/fleet); LAST is the per-host
+// tooltip detail for the ones drawn into the aggregate; SELF names this machine for its hover heading
+// when there is more than one host.
 var ROWS=[],LAST=[],SELF='';
 // Limit / judge-degraded SIGNATURES (the user 2026-07-03; reshaped 2026-07-27): these used to gate fixed
 // top banners with a ✕ dismissal; the banners are gone — the same situations now log ONE entry each in
@@ -17642,98 +17760,92 @@ if(!on){_limPut('');}   // fully cleared -> forget the logged signature so a fut
 else if(sig!==_limGet()){_limPut(sig);var names=[];if(lim.fiveHour)names.push('Session (5h)');if(lim.sevenDay)names.push('Weekly (7d)');
 if(window.__rompNotify)window.__rompNotify('limit',names.join(' and ')+' usage limit reached \u2014 retries paused until it resets');}}
 function hasBars(u){return !!(u&&(u.fiveHour||u.sevenDay||u.fable));}
-// API-key auth: no subscription windows exist — the rail shows SPEND where the bars sat (the user
-// 2026-08-04): today's accumulated per-result cost from the kernel's spend.json. strip.ts carries the
-// same branch; the two copies must stay in step (rail-spend pins).
-function hasSpend(u){return !!(u&&u.apiKey&&u.spend&&u.spend.fiveHour);}
+// API-key spend rides the payload's `spend` windows. It used to require the apiKey flag (a no-login
+// machine, spend INSTEAD of bars); with per-session auth one host carries bars AND its key's spend at
+// once (the user 2026-08-08), so presence of the windows is the whole test. strip.ts carries the same
+// branch; the two copies must stay in step (rail-spend pins).
+function hasSpend(u){return !!(u&&u.spend&&u.spend.fiveHour);}
 function fmtTok(n){if(n>=1e9)return (n/1e9).toFixed(1).replace(/\.0$/,'')+'B';
 if(n>=1e6)return (n/1e6).toFixed(1).replace(/\.0$/,'')+'M';
 if(n>=1e3)return (n/1e3).toFixed(1).replace(/\.0$/,'')+'k';return String(n);}
-// API-key auth: SPEND windows mirror the subscription bars' grammar exactly \u2014 same rows, labels,
-// twin tracks \u2014 so flipping auth modes reads instantly (the user 2026-08-04). A row FILLS only when
-// spend-budgets.json names that window's budget (the fill is spend-over-budget; no cap, no honest
-// fraction \u2014 plain dollars in the readout slot instead). Rolling windows have no reset boundary, so
-// only month-to-date draws the elapsed track. strip.ts carries the same builder \u2014 kept in step.
+function fmtUsd(v){return '$'+(v<100?v.toFixed(2):String(Math.round(v)));}
 var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','Month']];
-function spendColor(p){return p>=90?'#c0392b':p>=70?'#e0b020':'#54B204';}
-// The per-account SPEND detail for the rich hover (the token graph + dollars rows) \u2014 spend-only
-// accounts (an API key / a login-less host) carry it; a LOGIN account's payload has no spend windows
-// on purpose (the user 2026-08-08: its % bars are the story, and token rows there read as noise).
+// The per-host SPEND detail for the rich hover: plain NUMBERS per window (dollars, tokens, turns).
+// No bars anywhere for spend (the user 2026-08-08: the spend bar graphs told you nothing. The old
+// hover scaled each window's bar to the largest window, a shape with no meaning, and the budget-fill
+// tracks die with it): the numbers are the information, so the numbers are the rendering.
 function spendDet(u,det){var sp=u&&u.spend;if(!sp||!det)return;
+if(u.apiTail)det._tail=u.apiTail;
 SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='number')return;
-var budget=(typeof seg.budget==='number'&&seg.budget>0)?seg.budget:null;
-(det._spend=det._spend||{})[w[0]]={label:w[1],usd:seg.usd,tok:seg.tok||0,turns:seg.turns||0,
-budget:budget,pct:budget!=null?Math.max(0,Math.min(100,Math.round(seg.usd/budget*100))):null};});}
-// NO native title attributes anywhere on the rail (the user 2026-08-08, who got the browser's flat
-// yellow box on top of the rich hover, nowhere near the cursor): the rich tip is the ONE hover surface,
-// and everything the titles used to say \u2014 dollars, tokens, turns, the budget hint \u2014 lives there now.
-function spendWinsHTML(u,det){var sp=u.spend||{},html='';spendDet(u,det);
-SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='number')return;
-var budget=(typeof seg.budget==='number'&&seg.budget>0)?seg.budget:null;
-var pct=budget!=null?Math.max(0,Math.min(100,Math.round(seg.usd/budget*100))):null;
-var el2=null;
-if(w[0]==='month'&&budget!=null){var dd=new Date(),dim=new Date(dd.getFullYear(),dd.getMonth()+1,0).getDate();
-el2=Math.max(0,Math.min(100,Math.round(((dd.getDate()-1+dd.getHours()/24)/dim)*100)));}
-var readout='$'+(seg.usd<100?seg.usd.toFixed(2):String(Math.round(seg.usd)))+' \u00b7 '+fmtTok(seg.tok||0)+' tok';
-html+='<div class="ru-w ru-spend">'
-+'<div class=ru-name>'+w[1]+'</div>'
-+'<div class=ru-bars>'
-+(pct!=null?'<div class=ru-track><i class=ru-fill style="width:'+pct+'%;background:'+spendColor(pct)+'"></i></div>':'')
-+(el2!=null?'<div class=ru-track><i class=ru-fill style="width:'+el2+'%;background:#6b7a8c"></i></div>':'')
-+'</div>'
-+'<div class=ru-pct>'+readout+'</div>'
-+'</div>';});
-return html;}
-// One account's windows, as markup + the tooltip detail for them. Pure: the caller decides where it goes.
-function winsHTML(u,det){var nowS=Math.floor(Date.now()/1000),html='';
+(det._spend=det._spend||{})[w[0]]={label:w[1],usd:seg.usd,tok:seg.tok||0,turns:seg.turns||0};});}
+// One payload's WINDOW detail for the hover (used/elapsed/reset per window). Detail only, no markup:
+// the rail no longer draws each account's own bars (they aggregate, below), but the tip still tells
+// each host's story from this.
+function winDet(u,det){var nowS=Math.floor(Date.now()/1000);
 WINS.forEach(function(w){var seg=u[w[0]];if(!seg)return;
 // A ROLLED window (its reset passed since the last report) is UNKNOWN, not 0 (the user 2026-07-31: a
 // remote whose kernel had no live session to ask sat on a days-old snapshot, and the rail drew a
-// confident 0% beside a live account's real bars). Last-known fill drawn FADED + a '?' readout, so
-// unknown and genuinely-empty can never be confused; the tooltip dates the gap.
+// confident 0% beside a live account's real bars). The last-known number renders in the hover,
+// labelled as such; the rail's aggregate never counts an unknown as a value.
 var rolled=!!(seg.resetsAt&&nowS>seg.resetsAt),pct=Math.max(0,Math.min(100,seg.pct||0));
 var col=(seg.color&&seg.color.length===3)?('rgb('+seg.color.join(',')+')'):'#54B204';   // selected colormap (server-computed)
 var tp=(!rolled&&seg.resetsAt&&w[1])?Math.max(0,Math.min(100,Math.round((nowS-(seg.resetsAt-w[1]))/w[1]*100))):null;
-det[w[0]]={name:w[3],span:w[2],pct:pct,col:col,tp:tp,unk:rolled,ago:(rolled?fmtAgo(seg.resetsAt):null),reset:(!rolled&&seg.resetsAt)?fmtR(seg.resetsAt):null};
-// Horizontal fill bars (the user 2026-07-05): an expanded label, then TWO stacked horizontal tracks \u2014 the
+det[w[0]]={name:w[3],span:w[2],pct:pct,col:col,tp:tp,unk:rolled,ago:(rolled?fmtAgo(seg.resetsAt):null),reset:(!rolled&&seg.resetsAt)?fmtR(seg.resetsAt):null};});}
+// ONE aggregated set of bars for every account at once (the user 2026-08-08: never repeat the windows
+// per host; say '5 hours' once). Per window, the WORST known reading across the fleet: the windows are
+// allowances and the binding one is the fullest; each host's own number lives in the hover. A window
+// every reporter has ROLLED is unknown ('?'), exactly as a single account's was; a shared login on two
+// hosts reports the same number twice and the max collapses it for free.
+function aggBarsHTML(live){var html='';
+WINS.forEach(function(w){var best=null,anyRolled=false;
+live.forEach(function(e){var d=e.det[w[0]];if(!d)return;
+if(d.unk){anyRolled=true;return;}
+if(!best||d.pct>best.pct)best=d;});
+if(!best&&!anyRolled)return;
+// Horizontal fill bars (the user 2026-07-05): an expanded label, then TWO stacked horizontal tracks: the
 // used-% bar (colormap colour) ON TOP of the elapsed-% bar (slate) so you can compare pace at a glance (used
-// ahead of elapsed = burning too fast) \u2014 then the used-% readout. All inline (label \u00b7 bars \u00b7 %).
+// ahead of elapsed = burning too fast), then the used-% readout. All inline (label \u00b7 bars \u00b7 %).
 // An UNKNOWN window draws NO BARS (the user 2026-07-31, round 2): a faded last-known fill still
-// asserts a value we do not have \u2014 the length itself is the lie. Its slot holds a single '?' so the
-// rows stay aligned, and the last-known number moves to the hover, labelled as such.
-html+='<div class="ru-w'+(rolled?' ru-unk':'')+'" data-w="'+w[0]+'">'
+// asserts a value we do not have; the length itself is the lie. Its slot holds a single '?' so the
+// rows stay aligned, and the last-known number lives in the hover, labelled as such.
+html+='<div class="ru-w'+(best?'':' ru-unk')+'" data-w="'+w[0]+'">'
 +'<div class=ru-name>'+w[4]+'</div>'
-+(rolled?'<div class=ru-bars><div class=ru-qmark>?</div></div>'
-:('<div class=ru-bars>'
-+'<div class=ru-track><i class=ru-fill style="width:'+pct+'%;background:'+col+'"></i></div>'
-+'<div class=ru-track><i class=ru-fill style="width:'+(tp||0)+'%;background:#6b7a8c"></i></div>'
++(best?('<div class=ru-bars>'
++'<div class=ru-track><i class=ru-fill style="width:'+best.pct+'%;background:'+best.col+'"></i></div>'
++'<div class=ru-track><i class=ru-fill style="width:'+(best.tp||0)+'%;background:#6b7a8c"></i></div>'
 +'</div>'
-+'<div class=ru-pct>'+pct+'%</div>'))
++'<div class=ru-pct>'+best.pct+'%</div>')
+:'<div class=ru-bars><div class=ru-qmark>?</div></div>')
 +'</div>';});
 return html;}
-// ONE SET PER CLAUDE ACCOUNT (the user 2026-07-30). These windows are ACCOUNT-wide, so a fleet signed into
-// one login has one allowance and drawing it per host would repeat the same number \u2014 that is the common
-// case and it renders exactly as it always did, bare. Sign a machine into a SECOND account, though, and the
-// single set was flatly wrong: two independent allowances added up and shown as one. So the kernel groups
-// by account and each group gets its own bars, labelled with a host that is on it, in the quiet lowercase
-// italic `host:` the chat tabs already wear for a federated session \u2014 same idea, same treatment.
-function renderRows(rows,selfHost){ROWS=rows||[];LAST={};
+// The API cell (the user 2026-08-08): ONE compact entry for everything key-billed across the fleet,
+// labelled by the key's own last 4 (\u2026wxyz names WHICH key without saying the key; several distinct
+// keys fall back to the bare 'API'), with NUMBERS beside it: the 5h burn and the month-to-date. No
+// bars (see spendDet). The full per-window, per-host breakdown is the hover's job.
+function apiCellHTML(live){var tails={},sum={fiveHour:0,month:0},any=false;
+live.forEach(function(e){var sp=e.det._spend;if(!sp)return;any=true;
+if(e.det._tail)tails[e.det._tail]=1;
+['fiveHour','month'].forEach(function(k){if(sp[k])sum[k]+=sp[k].usd;});});
+if(!any)return '';
+var tl=Object.keys(tails);
+var label='API'+(tl.length===1?' \u2026'+esc(tl[0]):'');
+return '<div class="ru-w ru-api">'
++'<div class=ru-name>'+label+'</div>'
++'<div class=ru-pct>'+fmtUsd(sum.fiveHour)+' 5h \u00b7 '+fmtUsd(sum.month)+' mo</div>'
++'</div>';}
+// The collapsed rail is the AGGREGATE story (the user 2026-08-08; supersedes the one-set-per-account
+// rendering of 2026-07-30): one set of window bars for the whole fleet plus one API cell, never a
+// per-host repeat. Each host still computes its own detail (LAST), and the hover is where that breaks
+// down per host: with per-session auth a host can carry BOTH a login's windows and its key's spend.
+// The one-host common case renders the same bars it always did, just without a host label anywhere.
+// (No native title anywhere on the rail, the user 2026-08-08: the rich tip is the ONE hover surface.)
+function renderRows(rows,selfHost){ROWS=rows||[];LAST=[];
 var live=ROWS.filter(function(r){return hasBars(r.usage)||hasSpend(r.usage);});
 if(!live.length){el.innerHTML='';tip.style.display='none';return;}
-if(live.length===1){var det={};det._t=(typeof live[0].usage.t==='number')?live[0].usage.t:null;
-LAST=[{host:'',det:det}];
-el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendWinsHTML(live[0].usage,det);
-return;}
-var html='';LAST=[];
-// no native title on the account set (the user 2026-08-08 — the rich tip is the ONE hover surface);
-// the separate-allowance note rides the tip's host heading instead (setHTML).
-live.forEach(function(r){var det={};det._t=(typeof r.usage.t==='number')?r.usage.t:null;
-var hn=r.host||selfHost||'this machine';
-LAST.push({host:hn,det:det});
-var inner=hasBars(r.usage)?winsHTML(r.usage,det):spendWinsHTML(r.usage,det);
-html+='<div class=ru-set>'
-+'<span class=ru-host>'+esc(hn)+':</span>'+inner+'</div>';});
-el.innerHTML=html;}
+LAST=live.map(function(r){var det={};det._t=(typeof r.usage.t==='number')?r.usage.t:null;
+winDet(r.usage,det);spendDet(r.usage,det);
+return {host:r.host||selfHost||'this machine',det:det};});
+el.innerHTML=aggBarsHTML(LAST)+apiCellHTML(LAST);}
 // The single-payload path the timeline still posts (and the mobile panel's own fetch): treat it as this
 // machine's row, leaving any other account's bars alone.
 function render(u){notices(u);
@@ -17751,33 +17863,30 @@ function barRows(d){return (d.unk
 +(d.tp!=null?'<div class=ru-tip-row><span class=ru-tip-k>elapsed</span>'
 +'<span class=ru-tip-track><i style="width:'+d.tp+'%;background:#6b7a8c"></i></span>'
 +'<span class=ru-tip-v>'+d.tp+'%</span></div>':'');}
-// LAST is one entry per ACCOUNT (2026-07-30), so the tooltip is the same window rows it always was, once
-// per login \u2014 with the host heading it only when there IS more than one. A SPEND-ONLY account (an
-// API key / a login-less host) used to return '' here, so a mixed fleet's hover silently showed only
-// the subscription login (the user 2026-08-08) \u2014 its dollars now render as their own section.
-// EVERY string here must carry data the reader acts on (the user 2026-08-08, who found the tip overly
-// verbose): the host name alone heads a section (no "its own allowance" tail), the token rows label
-// themselves (no "5h / 7d / month" subtitle), and config hints live in the docs, not a hover.
+// LAST is one entry per HOST (the user 2026-08-08: the hover is the per-host breakdown the collapsed
+// rail no longer draws), each with the window rows it always had, the host name heading it when there
+// is more than one. A host carries BOTH sections when it has both: its login's windows and its key's
+// spend (per-session auth). EVERY string here must carry data the reader acts on (the user 2026-08-08,
+// who found the tip overly verbose): the host name alone heads a section, the spend rows label
+// themselves, and config hints live in the docs, not a hover.
 function setHTML(e,many){var d=e.det,keys=['fiveHour','sevenDay','fable'].filter(function(k){return d[k];});
 var sp=d._spend||null;
 if(!keys.length&&!sp)return '';
-var spendOnly=!keys.length;                       // no subscription windows \u2192 an API-key / no-login account
 var h=(many?'<div class=ru-tip-host>'+esc(e.host)+'</div>':'');
 h+=keys.map(function(k){var v=d[k];
 return '<div class=ru-tip-win><div class=ru-tip-name><span>'+esc(v.name)+' ('+esc(v.span)+')</span>'
 +(v.unk?'<span class=ru-tip-reset>window reset '+esc(v.ago)+'; no reading since</span>'
 :(v.reset?'<span class=ru-tip-reset>resets in '+esc(v.reset)+'</span>':''))+'</div>'+barRows(v)+'</div>';}).join('');
-// The API-KEY SPEND graph (the user 2026-08-08): the three windows' token volume on ONE shared scale
-// \u2014 each bar auto-scales to the largest window \u2014 with the real dollars beside each count. SPEND-ONLY
-// accounts only (same day): a login account's story is its % bars, and token rows there read as noise
-// (the guard also holds against an older kernel in the fleet still attaching spend beside its bars).
-if(sp&&spendOnly){var ks=['fiveHour','sevenDay','month'].filter(function(k){return sp[k];});
-if(ks.length){var mx=1;ks.forEach(function(k){if(sp[k].tok>mx)mx=sp[k].tok;});
-h+='<div class=ru-tip-win><div class=ru-tip-name><span>API-key spend</span></div>'
-+ks.map(function(k){var v=sp[k],wpct=v.tok>0?Math.max(2,Math.round(v.tok/mx*100)):0;
+// The API-KEY SPEND rows (the user 2026-08-08): dollars, tokens and turns per window, NUMBERS ONLY.
+// The old token-volume graph scaled each window's bar to the largest window, a shape that told the
+// reader nothing; it is gone, and this section now renders for ANY host with key spend, beside that
+// host's own bars when it has both (per-session auth).
+if(sp){var ks=['fiveHour','sevenDay','month'].filter(function(k){return sp[k];});
+if(ks.length){
+h+='<div class=ru-tip-win><div class=ru-tip-name><span>API'+(d._tail?' \u2026'+esc(d._tail):'')+' spend</span></div>'
++ks.map(function(k){var v=sp[k];
 return '<div class=ru-tip-row><span class=ru-tip-k>'+esc(v.label)+'</span>'
-+'<span class=ru-tip-track><i style="width:'+wpct+'%;background:#6b7a8c"></i></span>'
-+'<span class=ru-tip-v>'+fmtTok(v.tok)+' \u00b7 $'+(v.usd<100?v.usd.toFixed(2):String(Math.round(v.usd)))+'</span></div>';}).join('')
++'<span class=ru-tip-v>'+fmtUsd(v.usd)+' \u00b7 '+fmtTok(v.tok)+' tok \u00b7 '+(v.turns||0)+' turns</span></div>';}).join('')
 +'</div>';}}
 h+=(d._t?'<div class=ru-tip-age>updated '+fmtAgo(d._t)+'</div>':'');
 return h;}
@@ -19028,20 +19137,15 @@ def _landing():
             ".ru-tip-k{opacity:.55;min-width:46px}"
             ".ru-tip-track{width:64px;height:6px;border-radius:3px;background:rgba(255,255,255,0.10);overflow:hidden;display:inline-block}"
             ".ru-tip-track i{display:block;height:100%;border-radius:3px;transition:width .3s ease}"
-            ".ru-tip-v{min-width:30px;text-align:right;font-variant-numeric:tabular-nums}"
+            # margin-left:auto right-aligns every value to one edge, so the bar rows and the numbers-only
+            # spend rows (no track span, the user 2026-08-08) read as one table.
+            ".ru-tip-v{min-width:30px;text-align:right;font-variant-numeric:tabular-nums;margin-left:auto}"
             ".ru-tip-age{margin-top:7px;padding-top:5px;border-top:1px solid rgba(255,255,255,0.08);"
             "opacity:.55;font-size:10px}"
-            # PER-ACCOUNT bar sets (the user 2026-07-30): a machine on a different Claude login has its own
-            # allowance, so it gets its own set, named by a host that is on it. The label is the exact
-            # treatment a federated session's name wears in the chat tabs — quiet, lowercase, italic, and
-            # visibly metadata rather than part of the reading. Only rendered when there IS more than one
-            # account; a same-login fleet keeps a single bare set and this costs nothing.
-            ".ru-set{display:flex;flex-direction:row;align-items:center;gap:10px;flex:0 0 auto}"
-            # a hairline between allowances, so two sets of bars read as two accounts rather than one long
-            # run of windows. Only ever drawn between sets, so the single-account rail is untouched.
-            ".ru-set+.ru-set{padding-left:16px;border-left:1px solid #313234}"
-            ".ru-host{font:italic 400 10px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;"
-            "color:#6e7681;white-space:nowrap;text-transform:lowercase}"
+            # (The per-host .ru-set/.ru-host rail sets are gone, the user 2026-08-08: the collapsed rail
+            # aggregates one set of bars + one API cell, and the per-host story lives in the hover, whose
+            # .ru-tip-host heading keeps the quiet lowercase-italic treatment a federated session's name
+            # wears in the chat tabs.)
             ".ru-tip-host{font:italic 400 10px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;"
             "color:#9aa0a6;text-transform:lowercase;margin:0 0 4px}"
             "#ru-tip .ru-tip-host:not(:first-child){margin-top:10px;padding-top:8px;"
@@ -20063,7 +20167,8 @@ class Handler(BaseHTTPRequestHandler):
                     if not _sdk_ready():          # see _sdk_ready — a built backend is not a working one
                         return self._send(200, json.dumps({"ok": False, "error": SDK_SETUP_HINT}),
                                           "application/json")
-                    sid = _create_sdk_session(nm, cwd)
+                    a = (b or {}).get("auth")
+                    sid = _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""))
                     return self._send(200, json.dumps({"ok": True, "id": sid, "dir": cwd}),
                                       "application/json")
                 threading.Thread(target=_spawn_session, args=(nm, cwd), daemon=True).start()
@@ -20593,7 +20698,10 @@ class Handler(BaseHTTPRequestHandler):
                     # missing, so the old check took it as a yes and created a session that could never
                     # run — silently, which is the whole failure (the user 2026-07-28).
                     if _sdk_ready():
-                        _create_sdk_session(nm, cwd)
+                        # auth ('login'|'key') is the picker's per-session billing pick; anything else
+                        # (older clients, no pick) means the remembered/ambient default (spawn's seed).
+                        a = msg.get("auth")
+                        _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""))
                     else:
                         # NEVER silently fall back to tmux (the user asked for SDK and got a mystery tmux
                         # session on a remote host without the venv, 2026-07-02). Say what's missing.
@@ -20618,7 +20726,10 @@ class Handler(BaseHTTPRequestHandler):
             # walk is ~78ms cold once forks are off, so paging it in bought nothing (the user 2026-07-24).
             client["send"](json.dumps({"type": "sessionList",
                                        "items": _session_list(int(time.time()), _tmux_sessions()),
-                                       "defaultDir": _tilde(_default_create_dir())}))   # prefill the new-session dir field
+                                       "defaultDir": _tilde(_default_create_dir()),   # prefill the new-session dir field
+                                       # billing choices THIS host can offer a new session — the picker
+                                       # shows its auth control only when both are real (see _auth_avail)
+                                       "authAvail": _auth_avail()}))
         elif msg and msg.get("type") in ("pickResult", "openByName") and (msg.get("id") or msg.get("name")):
             sid = msg.get("id") or _live_names(_tmux_sessions()).get(str(msg.get("name")))
             if sid:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1021,6 +1021,27 @@ def write_sdk_default(state_dir: Path, **fields) -> None:
     os.replace(tmp, p)
 
 
+_WORK_KEY: str | None = None   # process-lifetime stash; None = not yet claimed from the environment
+
+
+def work_api_key() -> str:
+    """The API key the manager's environment carried at startup (service.env, or however the manager
+    was launched), CLAIMED OUT of os.environ on first read — "" when it carried none. The SDK's
+    transport hands the CLI this process's environment wholesale (options.env merges OVER it), so an
+    ambient ANTHROPIC_API_KEY bills EVERY session to the key no matter what auth the user picked for
+    it; popping it here makes the key explicit per session — _options injects it only where the
+    session's auth says so, and a login session launches with a genuinely clean environment (the CLI
+    treats even an EMPTY var as "API-key mode, no key" and refuses with "Not logged in" — verified
+    live 2026-08-08 — so removal, not blanking, is the only correct strip). Module-level so a
+    re-constructed backend (tests, the WS handler's lazy construction) still finds the key after the
+    first pop; the kernel process never re-execs itself, so a manager restart re-inherits the
+    service env and a fresh process re-stashes."""
+    global _WORK_KEY
+    if _WORK_KEY is None:
+        _WORK_KEY = os.environ.pop("ANTHROPIC_API_KEY", "") or ""
+    return _WORK_KEY
+
+
 # ---------------------------------------------------------------------------
 # The live session (one quarantined asyncio thread).
 # ---------------------------------------------------------------------------
@@ -1050,8 +1071,8 @@ class SdkSession:
         # in live_sessions). A FRESH construction makes them moot by definition: effort is a
         # connect-time flag this session's next _options applies, and the chosen model alias
         # (reg['model']) rides the same connect — the switch is effectively applied, so pending is over.
-        if reg.get("effortPending") or reg.get("modelPending"):
-            backend._update_reg(self.sid, effortPending=False, modelPending=False)
+        if reg.get("effortPending") or reg.get("modelPending") or reg.get("authPending"):
+            backend._update_reg(self.sid, effortPending=False, modelPending=False, authPending=False)
         # protocol/runtime state
         self.loop: asyncio.AbstractEventLoop | None = None
         self.client = None
@@ -1125,6 +1146,15 @@ class SdkSession:
         #   PER-SESSION fact (the user 2026-08-08: one keyed session must not speak for the login's
         #   windows). Gates this session's get_usage polls + its RateLimitEvent records; set by
         #   _note_auth_source on every init.
+        self.auth = reg.get("auth") if reg.get("auth") in ("login", "key") else ""   # the user's
+        #   per-session auth pick (the user 2026-08-08: some sessions on the personal login, some on
+        #   the work key). "" = no explicit pick → effective_auth() preserves the pre-selector world.
+        self._auth_pending = ""      # target while the applying reconnect is in flight (auth is
+        #   connect-time env, no runtime control) — mirrors _effort_pending's dots + notice
+        self._launched_keyed = False  # what _options actually handed the CLI (key injected or not);
+        #   _note_auth_source compares the init's apiKeySource against THIS, so a CLI that lands on
+        #   the other auth (a stale login, a key found via apiKeyHelper) is flagged loudly instead
+        #   of silently billing the wrong account
         self._last_cost_total = 0.0   # the CLI's totalCostUSD is CUMULATIVE per process (verified in
         #   the bundle: the result event's total_cost_usd sits beside total_duration/lines counters),
         #   so spend folds the DELTA between results — folding the raw value re-added the whole
@@ -1452,6 +1482,16 @@ class SdkSession:
         if changed:
             self.backend._poke()
 
+    def effective_auth(self) -> str:
+        """'key' or 'login' — what _options launches this session with. An explicit pick wins; unset
+        preserves the pre-selector world, where a manager environment that carried a key billed every
+        session to it (so absent a choice, the key still wins when one exists). 'key' with no key to
+        inject falls to login rather than launching with a var the CLI would refuse on — _options
+        logs that fall loudly (it is a misconfiguration, not a preference)."""
+        if self.auth == "login":
+            return "login"
+        return "key" if self.backend.work_key else "login"
+
     async def _do_refresh_usage(self):
         """Pull the EXACT account-wide /usage snapshot from the CLI — the designed data behind the /usage
         screen itself. `get_usage` is a CLI control request (the bridge's onGetUsage handler; the Python
@@ -1654,6 +1694,14 @@ class SdkSession:
                         append_effort_applied(self.backend.state_dir, self.sid, self._effort_pending)
                         self._effort_pending = ""
                         self.backend._update_reg(self.sid, effortPending=False)
+                        self.backend._poke()
+                    # A pending AUTH switch is applied the same way — the key rode (or was withheld
+                    # from) _options' env on THIS connect. The init's apiKeySource is the CLI's own
+                    # confirmation and _note_auth_source flags a mismatch loudly; here we just clear
+                    # the switching-dots, event-based on the connect like effort above.
+                    if self._auth_pending:
+                        self._auth_pending = ""
+                        self.backend._update_reg(self.sid, authPending=False)
                         self.backend._poke()
                     # PRE-TURN PUBLISH (the user 2026-06-27): pull the live model + context % the INSTANT we
                     # connect — before any turn — so a freshly-created SDK session shows its model and context on
@@ -1983,7 +2031,9 @@ class SdkSession:
                     last = self._last_usage_totals.get(k, 0)
                     turn_u[k] = v - last if v >= last else v
                     self._last_usage_totals[k] = v
-                self.backend._record_spend(delta, turn_u)   # the rail's spend + token readout
+                self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth)   # the rail's spend
+                #   + token readout; keyed = THIS session's init-reported auth, so the API sum stays
+                #   honest on a mixed host (see _record_spend)
             self.retrying = False
             self.retry_count = 0                    # turn over → clear the storm count (a turn that errored out without recovering leaves no "recovered" note)
             self.retry_info = None
@@ -2369,6 +2419,8 @@ class SdkSession:
                 "model": model_label(self.model, self.chosen_model), "effort": self.effort,
                 "modelPending": bool(self._model_pending),   # a /model switch resolving → the badge shows switching-dots
                 "effortPending": bool(self._effort_pending),   # an /effort switch reconnecting → effort-badge dots + "Reloading session…"
+                "auth": self.effective_auth(),   # which account this session bills ('login'|'key') → gear badge
+                "authPending": bool(self._auth_pending),   # an /auth switch reconnecting → badge dots
                 "mode": self.perm_mode, "ctx": self._ctx_pct(), "summary": "",
                 "connected": bool(self.client),   # the SDK handshake is up (set at connect, cleared at
                 #   teardown) — the "this session is OPEN" event for a transcript-less fresh session:
@@ -2452,6 +2504,9 @@ class SdkBackend:
         self._pending_ask: dict[str, bool] = {}   # sid -> has an ask awaiting answer
         self._live: dict[str, dict] = {}          # sid -> {key -> atom}: the in-memory LIVE TAIL (ahead of disk)
         self._rl_lock = threading.Lock()          # serializes usage.json read-merge-write (_record_rate_limit)
+        self.work_key = work_api_key()            # the manager env's API key, claimed out of os.environ
+        #   ("" = none): per-session auth injects it via _options; its presence is the "key" half of
+        #   the availability the kernel publishes to the picker/gear (the user 2026-08-08)
         # Backend PROBLEMS, kept in a bounded ring so the dashboard can show them (see _log): until
         # 2026-07-28 every SDK failure went to the kernel log alone, which nobody tails, so a session
         # whose stream died or whose model switch was refused just looked odd with no way to find out.
@@ -2722,14 +2777,18 @@ class SdkBackend:
             self._log("usage refresh: %d live session(s), none with a loop to run it on — the rail bars "
                       "keep their last reading" % len(live), problem=True)
 
-    def _record_spend(self, cost, usage=None) -> None:
+    def _record_spend(self, cost, usage=None, keyed=False) -> None:
         """Accumulate a turn's total_cost_usd AND its token counts into spend.json, keyed by LOCAL date —
         the rail's spend readout where the subscription bars sat, under API-key auth (the user
         2026-08-04; tokens added the same day, who wanted them beside the dollars). Recorded on every
         result regardless of auth (subscription results report a computed cost too; the DISPLAY is gated
-        on the auth mode, the record is not — flipping auth mid-day keeps the number honest). Token
-        fields mirror the ResultMessage usage dict: input/output plus the two cache flavors, kept
-        separately so the tooltip can break them down. Pruned to the last 90 days; atomic."""
+        on the auth mode, the record is not — flipping auth mid-day keeps the number honest). A turn
+        billed to an API KEY (keyed=True — the session's own init said so) additionally folds into the
+        bucket's `key` sub-counters: with per-session auth a host holds both kinds at once, and the
+        rail's API readout must sum ONLY the key's turns — a login turn's computed cost there would be
+        dollars nobody is billed (the user 2026-08-08). Token fields mirror the ResultMessage usage
+        dict: input/output plus the two cache flavors, kept separately so the tooltip can break them
+        down. Pruned to the last 90 days; atomic."""
         if not isinstance(cost, (int, float)) or cost <= 0:
             return
         u = usage if isinstance(usage, dict) else {}
@@ -2749,12 +2808,20 @@ class SdkBackend:
 
             def _fold(buckets, key, keep):
                 e = buckets.get(key) if isinstance(buckets.get(key), dict) else {}
-                buckets[key] = {"usd": round(float(e.get("usd") or 0) + float(cost), 6),
-                                "turns": int(e.get("turns") or 0) + 1,
-                                "tokIn": int(e.get("tokIn") or 0) + _tok("input_tokens"),
-                                "tokOut": int(e.get("tokOut") or 0) + _tok("output_tokens"),
-                                "tokCacheR": int(e.get("tokCacheR") or 0) + _tok("cache_read_input_tokens"),
-                                "tokCacheW": int(e.get("tokCacheW") or 0) + _tok("cache_creation_input_tokens")}
+                n = {"usd": round(float(e.get("usd") or 0) + float(cost), 6),
+                     "turns": int(e.get("turns") or 0) + 1,
+                     "tokIn": int(e.get("tokIn") or 0) + _tok("input_tokens"),
+                     "tokOut": int(e.get("tokOut") or 0) + _tok("output_tokens"),
+                     "tokCacheR": int(e.get("tokCacheR") or 0) + _tok("cache_read_input_tokens"),
+                     "tokCacheW": int(e.get("tokCacheW") or 0) + _tok("cache_creation_input_tokens")}
+                ke = e.get("key") if isinstance(e.get("key"), dict) else {}
+                if keyed or ke:   # carry an existing key split forward even on a login turn
+                    n["key"] = {"usd": round(float(ke.get("usd") or 0) + (float(cost) if keyed else 0), 6),
+                                "turns": int(ke.get("turns") or 0) + (1 if keyed else 0),
+                                "tok": int(ke.get("tok") or 0) + (sum(_tok(k) for k in (
+                                    "input_tokens", "output_tokens", "cache_read_input_tokens",
+                                    "cache_creation_input_tokens")) if keyed else 0)}
+                buckets[key] = n
                 for k in sorted(buckets)[:-keep]:
                     buckets.pop(k, None)
 
@@ -2785,6 +2852,16 @@ class SdkBackend:
         literal string 'none' (two hosts' journals, 2026-08-08). Logged once per per-session change,
         so every host's kernel log still self-documents who authenticates how."""
         keyed = bool(source) and str(source).strip().lower() != "none"
+        # The CLI landed on a DIFFERENT auth than _options launched it with (a key found some other
+        # way — apiKeyHelper, a project setting — or a login where the key was expected): that is a
+        # session billing the wrong account, the one failure this feature must never let pass
+        # silently (the user 2026-08-08). Flagged on every init that disagrees, not just flips, and
+        # into the problems ring so the Log panel shows it.
+        if keyed != sess._launched_keyed:
+            self._log("auth (%s): launched for %s but the CLI reports apiKeySource=%r — this session "
+                      "is billing the %s. Check the login (claude /login) and service.env."
+                      % (sess.name, "the API key" if sess._launched_keyed else "the login", source,
+                         "API key" if keyed else "login"), problem=True)
         if keyed == sess.api_key_auth:
             return
         sess.api_key_auth = keyed
@@ -3065,10 +3142,25 @@ class SdkBackend:
             kw["mcp_servers"] = self.mcp_config
         if (sess.effort or "") == "ultracode":
             kw["settings"] = ultracode_settings_path(self.state_dir)   # the `ultracode` settings key, per session
+        # Per-session auth (the user 2026-08-08): the work key was claimed OUT of this process's env at
+        # startup (work_api_key), so a login session's CLI inherits a clean environment and finds the
+        # login on its own; a key session gets the key injected here, explicitly. options.env merges
+        # OVER the inherited env in the SDK's transport, which is exactly the one-way door we need —
+        # inject or stay silent; never blank (an empty var reads as "API-key mode, no key" to the CLI).
+        launch_keyed = sess.effective_auth() == "key"
+        if launch_keyed:
+            kw["env"] = dict(kw["env"], ANTHROPIC_API_KEY=self.work_key)
+        elif sess.auth == "key":
+            # picked "key", but this manager's env carries none — falling to login silently would bill
+            # the wrong account with nothing to see; say so where the Log panel shows it.
+            self._log("auth (%s): session is set to the API key but the manager environment carries "
+                      "none (service.env) — launching on the login instead" % sess.name, problem=True)
+        sess._launched_keyed = launch_keyed
         return ClaudeAgentOptions(**kw)
 
     # ---- lifecycle (kernel-thread API) ----
-    def spawn(self, name: str, cwd: str, bg: str = "", fg: str = "", sid: str | None = None) -> str:
+    def spawn(self, name: str, cwd: str, bg: str = "", fg: str = "", sid: str | None = None,
+              auth: str = "") -> str:
         sid = sid or str(uuid.uuid4())
         cwd = os.path.realpath(cwd) if os.path.exists(cwd) else cwd
         if not bg:                                   # give the session a stable identity colour like tmux sessions get
@@ -3087,6 +3179,11 @@ class SdkBackend:
                "effort": eff, "lastSid": "", "alive": True}
         if d.get("model") and d["model"] != "default":
             reg["model"] = d["model"]
+        # Auth: the picker's explicit pick wins; else the remembered default (a gear /auth pick on any
+        # session); unset stays unset — effective_auth's fallback IS the pre-selector behavior.
+        a = auth if auth in ("login", "key") else (d.get("auth") if d.get("auth") in ("login", "key") else "")
+        if a:
+            reg["auth"] = a
         write_reg(self.state_dir, sid, reg)
         append_state(self.state_dir, sid, "waiting")
         self._poke()
@@ -3629,6 +3726,49 @@ class SdkBackend:
             self._wake_push()
         return True
 
+    def set_auth(self, sid: str, value: str) -> bool:
+        """Change which account this session bills — 'login' (the machine's Claude login) or 'key'
+        (the manager environment's API key). Auth is connect-time (the key rides _options' env;
+        there is no runtime control), so this persists the pick and RECONNECTS to apply, exactly
+        like set_effort: immediately if idle, at the end of the current turn if busy. The CLI's
+        next init confirms via apiKeySource (_note_auth_source flags a landing on the wrong side)."""
+        if value not in ("login", "key"):
+            return False
+        if value == "key" and not self.work_key:
+            return False   # nothing to inject — the UI never offers this; refuse rather than half-apply
+        reg = read_reg(self.state_dir, sid)
+        if not reg:
+            return False
+        reg["auth"] = value
+        reg["authPending"] = True   # the applying reconnect hasn't completed → badge dots
+        write_reg(self.state_dir, sid, reg)
+        write_sdk_default(self.state_dir, auth=value)   # the seed for the NEXT new session, like model/effort
+        s = self.sessions.get(sid)
+        if s:
+            s.auth = value
+            s._auth_pending = value
+            s.request_reconnect()
+            # Acknowledge the pick in the chat exactly as set_effort does: the reconnect writes no
+            # transcript record, so without a synthesized chip an idle session's auth change shows
+            # nothing at all.
+            t = int(time.time())
+            disp = "/auth " + value
+            uid = "cmd:%d:auth" % t
+            self._live.setdefault(sid, {})[uid] = {
+                "type": "user", "uuid": uid, "session_id": sid, "fsid": s.resume_sid, "parentUuid": None,
+                "t": t, "author": "human", "command": "/auth", "_echo_text": disp,
+                "message": {"role": "user", "content": [{"type": "text", "text": disp}]}}
+            self._wake_push()
+        return True
+
+    def default_auth(self, reg: dict | None = None) -> str:
+        """The auth a session with no live SdkSession object would launch with — the dormant twin of
+        SdkSession.effective_auth(), reading the same registry field with the same fallback."""
+        a = (reg or {}).get("auth")
+        if a == "login":
+            return "login"
+        return "key" if self.work_key else "login"
+
     def owns(self, sid: str) -> bool:
         return read_reg(self.state_dir, sid) is not None
 
@@ -3665,6 +3805,8 @@ class SdkBackend:
                             "modelPending": bool(reg.get("modelPending")),
                             "effortPending": bool(reg.get("effortPending")),
                             "effort": reg.get("effort", ""),
+                            "auth": self.default_auth(reg),
+                            "authPending": bool(reg.get("authPending")),
                             "mode": reg.get("mode", ""),
                             "ctx": lc if isinstance(lc, (int, float)) else "", "summary": ""}
         return out

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -122,6 +122,15 @@ class SessionBackend(ABC):
         SDK input stream interprets it, unlike /model). False when it can't be delivered (dormant SDK
         session, bad value) so the kernel can be loud instead of pretending."""
 
+    def set_auth(self, sid: str, value: str) -> bool:
+        """Pick which account this session bills — 'login' (the machine's Claude login) or 'key' (the
+        API key the manager's environment carries). SDK-only control: an SDK session's CLI inherits
+        the KERNEL's environment, so the kernel owns the choice (SdkBackend injects or withholds the
+        key per session at connect). A tmux session's CLI lives in the tmux server's environment,
+        which the kernel does not control — the default False means "no such control here" and the
+        kernel warns on a refusal instead of pretending."""
+        return False
+
     def stop_task(self, sid: str, task_id: str) -> bool:
         """Stop ONE background task (the SDK's designed stop_task control request). SDK-only control:
         the chat's bg-task box only ever shows live tasks for SDK sessions (the CLI's task lifecycle
@@ -146,8 +155,10 @@ class SessionBackend(ABC):
 
     # ── lifecycle ────────────────────────────────────────────────────────────────────────────────
     @abstractmethod
-    def spawn(self, name: str, cwd: str, bg: str = "", fg: str = "", sid: str | None = None) -> str | None:
-        """Start a NEW session; return its sid (or None on failure)."""
+    def spawn(self, name: str, cwd: str, bg: str = "", fg: str = "", sid: str | None = None,
+              auth: str = "") -> str | None:
+        """Start a NEW session; return its sid (or None on failure). `auth` ('login'|'key'|'') is the
+        picker's per-session billing pick — meaningful on the SDK backend only (see set_auth)."""
 
     @abstractmethod
     def resume(self, name: str, sid: str, cwd: str | None = None) -> bool:

--- a/tests/test_kernel_apierror_working.py
+++ b/tests/test_kernel_apierror_working.py
@@ -23,10 +23,11 @@ class ApiErrorWorking(unittest.TestCase):
 
     def test_only_on_you_errors_floor_the_card_to_needs_input(self):
         src = inspect.getsource(km.build_feed)
-        # api_block fires for an ON-YOU api_top — "prompt too long" (compact) OR a monthly spend cap (raise it,
-        # the user 2026-07-14); a transient error does NOT move the card (it auto-retries in Working).
+        # api_block fires for an ON-YOU api_top — "prompt too long" (compact), a monthly spend cap (raise
+        # it, the user 2026-07-14), a spent model allowance, or a dead credential (per-session auth, the
+        # user 2026-08-08); a transient error does NOT move the card (it auto-retries in Working).
         self.assertIn('api_block = (nid == api_top and bool(aerr and (aerr.get("tooLong") or aerr.get("spendLimit")', src)
-        self.assertIn('or aerr.get("modelLimit"))))', src)
+        self.assertIn('or aerr.get("modelLimit") or aerr.get("authErr"))))', src)
         self.assertIn('column = ("needs_input" if (api_block or nid == perm_top', src)   # stalled_floor retired 2026-07-07
         self.assertIn('or (col == "blocked" and not recheck and not rejudging))', src)
 

--- a/tests/test_kernel_color_pick.py
+++ b/tests/test_kernel_color_pick.py
@@ -87,7 +87,7 @@ class PickColor(unittest.TestCase):
         got = {}
 
         class _FakeSdk:
-            def spawn(self, nm, cwd, bg="", fg="", sid=None):
+            def spawn(self, nm, cwd, bg="", fg="", sid=None, auth=""):
                 got.update(bg=bg, fg=fg)
                 return SID % 9
             def connect(self, sid):

--- a/tests/test_kernel_create_session_ack.py
+++ b/tests/test_kernel_create_session_ack.py
@@ -29,7 +29,7 @@ class _FakeSdk:
 
     # mirrors the real SdkBackend.spawn: the kernel now picks a fleet-aware identity colour and hands it
     # down (test_kernel_color_pick.py), so the fake must accept it exactly like the real one does
-    def spawn(self, nm, cwd, bg="", fg="", sid=None):
+    def spawn(self, nm, cwd, bg="", fg="", sid=None, auth=""):
         self.calls.append(("spawn", nm, cwd))
         return "11111111-2222-3333-4444-555555555555"
 

--- a/tests/test_kernel_model_limit.py
+++ b/tests/test_kernel_model_limit.py
@@ -131,7 +131,7 @@ class SurfacesPinTheOnYouTreatment(unittest.TestCase):
 
     def test_the_card_floors_to_needs_you(self):
         src = inspect.getsource(km.build_feed)
-        self.assertIn('or aerr.get("modelLimit"))))', src,
+        self.assertIn('or aerr.get("modelLimit") or aerr.get("authErr"))))', src,
                       "api_block must include the model limit — otherwise the card sits in Working "
                       "with the nudge suppressed and nothing able to move it")
 

--- a/tests/test_kernel_rail_usage.py
+++ b/tests/test_kernel_rail_usage.py
@@ -55,9 +55,11 @@ class RailUsage(unittest.TestCase):
         self.assertIn(".ru-track{position:relative;width:54px;height:5px", self.html, "narrower horizontal track")
         self.assertIn(".ru-fill{position:absolute;left:0;top:0;height:100%", self.html, "the fill grows in WIDTH")
         self.assertNotIn(".ru-mark{", self.html, "the single-track pace tick is gone (two bars now)")
-        # both fills render: used-% (colormap col) on top, elapsed-% (slate #6b7a8c) below
-        self.assertIn("ru-fill style=\"width:'+pct+'%;background:'+col", self.html, "the used-% bar")
-        self.assertIn("ru-fill style=\"width:'+(tp||0)+'%;background:#6b7a8c", self.html, "the elapsed-% bar below it")
+        # both fills render: used-% (colormap col) on top, elapsed-% (slate #6b7a8c) below. Since
+        # 2026-08-08 the drawn values come from the AGGREGATE (the worst known reading per window
+        # across every host — aggBarsHTML's `best`), never per-host rows.
+        self.assertIn("ru-fill style=\"width:'+best.pct+'%;background:'+best.col", self.html, "the used-% bar")
+        self.assertIn("ru-fill style=\"width:'+(best.tp||0)+'%;background:#6b7a8c", self.html, "the elapsed-% bar below it")
         # order within a window: label, then the bars, then % — all inline
         # anchor past the spend chip (it wears ru-name/ru-pct too, with no bars — the user 2026-08-04):
         # the slice must start at a WINDOW row, whose label is built from the WINS table
@@ -83,10 +85,10 @@ class RailUsage(unittest.TestCase):
         # "updated ... ago" (the user 2026-07-02): the bars lagged the CLI's own /usage with no cue the reading
         # was old — usage.json refreshes only when a statusline render or a rate-limit event produces a NEW
         # reading, so staleness must be VISIBLE, not silent. The footer formats usage.json's `t`.
-        # (2026-07-30: the snapshot time moved into the per-ACCOUNT detail object, since a second Claude
-        # login has its own reading with its own age — the footer itself is unchanged.)
-        self.assertIn("det._t=(typeof live[0].usage.t==='number')?live[0].usage.t:null", self.html,
-                      "the renderer keeps the snapshot time")
+        # (2026-07-30: the snapshot time moved into the per-account detail object; 2026-08-08: the
+        # detail is per HOST now, one object per fleet row — the footer itself is unchanged.)
+        self.assertIn("det._t=(typeof r.usage.t==='number')?r.usage.t:null", self.html,
+                      "the renderer keeps each host's snapshot time")
         self.assertIn("ru-tip-age", self.html, "the tooltip carries an age footer")
         self.assertIn("updated '+fmtAgo(d._t)", self.html, "formatted as 'updated ... ago'")
         self.assertIn("function fmtAgo(ep)", self.html)
@@ -114,8 +116,12 @@ class RailUsage(unittest.TestCase):
                       "no pace bar against a window that already ended")
         # NO BARS at all (round 2): a fill of any length asserts a value we do not have, so the bars'
         # slot holds only a '?'. The last-known number survives in the tooltip, labelled as such.
-        self.assertIn("rolled?'<div class=ru-bars><div class=ru-qmark>?</div></div>'", self.html,
-                      "an unknown window draws a '?' where its bars would be")
+        # (2026-08-08: the aggregate draws the '?' only when EVERY host's reading of that window has
+        # rolled — one live reading is a real value, and an unknown never counts as one.)
+        self.assertIn("if(d.unk){anyRolled=true;return;}", self.html,
+                      "a rolled reading never competes as a value in the aggregate")
+        self.assertIn(":'<div class=ru-bars><div class=ru-qmark>?</div></div>'", self.html,
+                      "an all-unknown window draws a '?' where its bars would be")
         self.assertIn(".ru-qmark{width:54px", self.html, "the mark takes the bars' width, so rows stay aligned")
         self.assertNotIn(".ru-unk .ru-fill{opacity:.3}", self.html, "no faded fill on the face any more")
         self.assertIn("<span class=ru-tip-k>last known</span>", self.html,

--- a/tests/test_new_session_dir.py
+++ b/tests/test_new_session_dir.py
@@ -189,7 +189,7 @@ class CreateSessionDirFork(_Wire):
         self.spawned = []
         self._real_sdk = km._create_sdk_session
         self._real_ready = km._sdk_ready
-        km._create_sdk_session = lambda nm, cwd: self.spawned.append((nm, cwd)) or "TESTSID"
+        km._create_sdk_session = lambda nm, cwd, auth="": self.spawned.append((nm, cwd)) or "TESTSID"
         km._sdk_ready = lambda: True
         self.addCleanup(setattr, km, "_create_sdk_session", self._real_sdk)
         self.addCleanup(setattr, km, "_sdk_ready", self._real_ready)

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1561,8 +1561,9 @@ class SpendRecord(unittest.TestCase):
     def test_result_message_records_and_the_kernel_serves_it(self):
         src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
                                 "kernel", "sdk_backend.py")).read()
-        self.assertIn("self.backend._record_spend(delta, turn_u)", src,
-                      "the settle folds THIS turn's DELTAS — cost AND tokens are cumulative per process")
+        self.assertIn("self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth)", src,
+                      "the settle folds THIS turn's DELTAS — cost AND tokens are cumulative per process — "
+                      "tagged with the session's own auth so the API sum stays honest on a mixed host")
         self.assertIn("self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero",
                       src, "each connect resets the watermark with its new process")
         self.assertIn("self._last_usage_totals = {}  # …and its cumulative token counters", src,
@@ -1572,7 +1573,7 @@ class SpendRecord(unittest.TestCase):
         self.assertIn('if o.get("apiKey") or (not _claude_account() and (jd.STATE / "spend.json").exists()):',
                       ksrc, "_usage serves spend on the legacy marker OR a login-less machine with recorded spend")
         self.assertIn('"spend": _spend_windows()', ksrc)
-        self.assertIn("def _spend_windows():", ksrc)
+        self.assertIn("def _spend_windows(keyed_only=False):", ksrc)   # keyed_only: the mixed-host API sum (test_session_auth)
 
     def test_cumulative_process_totals_fold_as_per_turn_deltas(self):
         """The CLI's total_cost_usd AND its usage dict are CUMULATIVE per process (the result event

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Per-session billing (the user 2026-08-08): some sessions on the Claude login, some on the API key.
+
+The mechanics under test:
+  * The manager environment's ANTHROPIC_API_KEY is CLAIMED OUT of os.environ once per process
+    (work_api_key) — the SDK's transport hands the CLI this process's env wholesale, so an ambient
+    key would bill every session regardless of its pick. Injection is explicit per session: _options
+    adds the key only when the session's effective auth says so, and a login session launches with a
+    genuinely clean env (the CLI treats even an EMPTY var as key-mode-without-a-key and refuses with
+    "Not logged in" — verified live 2026-08-08 — so removal is the only correct strip).
+  * set_auth mirrors set_effort: persist + authPending + reconnect to apply (auth is connect-time).
+  * The CLI's init apiKeySource is compared against what _options actually launched with — a landing
+    on the wrong side is a session billing the wrong account, flagged into the problems ring.
+  * spend.json buckets carry a `key` sub-count for key-billed turns, so the rail's API readout on a
+    mixed host sums ONLY the key's turns (_spend_windows(keyed_only=True)); a login turn's computed
+    cost is dollars nobody is billed.
+  * An auth failure ("Not logged in", a 401 key) is an ON-YOU api-error class (authErr): retrying
+    re-presents the same dead credential forever, so it blocks visibly and is never auto-retried.
+  * Availability gates every selector: the kernel offers the choice only when BOTH a signed-in login
+    (_claude_account) and a manager-env key exist — one choice is no choice, the control disappears.
+
+Synthetic sids/paths only; no real key material (the fixture key is an invented string).
+"""
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+sb = SourceFileLoader("romp_sdk_backend_auth", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+km = SourceFileLoader("romp_kernel_auth", os.path.join(BIN, "romp-kernel")).load_module()
+
+FAKE_KEY = "sk-ant-api03-TESTFIXTUREKEYNOTREAL-wxyz"
+
+
+class _Keyed(unittest.TestCase):
+    """Base: a backend whose process env carried the fixture key (the stash is module-global and
+    once-per-process, so each test re-arms it explicitly and restores the world after)."""
+
+    KEY = FAKE_KEY
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self._env_before = os.environ.pop("ANTHROPIC_API_KEY", None)
+        self._stash_before = sb._WORK_KEY
+        sb._WORK_KEY = None                       # force a fresh claim from the env
+        if self.KEY:
+            os.environ["ANTHROPIC_API_KEY"] = self.KEY
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+
+    def tearDown(self):
+        sb._WORK_KEY = self._stash_before
+        os.environ.pop("ANTHROPIC_API_KEY", None)
+        if self._env_before is not None:
+            os.environ["ANTHROPIC_API_KEY"] = self._env_before
+
+    def _sess(self, n=1, **reg):
+        return sb.SdkSession(self.be, {"sid": "11111111-2222-3333-4444-%012d" % n,
+                                       "name": "s%d" % n, "cwd": "/tmp", **reg})
+
+
+class WorkKeyStash(_Keyed):
+    def test_the_key_is_claimed_out_of_the_environment_exactly_once(self):
+        self.assertEqual(self.be.work_key, FAKE_KEY)
+        self.assertNotIn("ANTHROPIC_API_KEY", os.environ,
+                         "an ambient key would bill EVERY session — the transport merges options.env "
+                         "over this process's env, so the strip must happen here")
+        # a re-constructed backend (the WS handler's lazy construction, tests) still finds it
+        be2 = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+        self.assertEqual(be2.work_key, FAKE_KEY)
+
+    def test_an_empty_var_counts_as_no_key(self):
+        sb._WORK_KEY = None
+        os.environ["ANTHROPIC_API_KEY"] = ""
+        self.assertEqual(sb.work_api_key(), "")
+
+
+class EffectiveAuth(_Keyed):
+    def test_explicit_pick_wins_and_unset_preserves_the_ambient_world(self):
+        self.assertEqual(self._sess(1, auth="login").effective_auth(), "login")
+        self.assertEqual(self._sess(2, auth="key").effective_auth(), "key")
+        # unset + a key in the manager env = key, exactly what the pre-selector world did
+        self.assertEqual(self._sess(3).effective_auth(), "key")
+
+    def test_a_junk_registry_value_is_ignored(self):
+        self.assertEqual(self._sess(4, auth="both-please").auth, "")
+
+
+class EffectiveAuthKeyless(_Keyed):
+    KEY = ""
+
+    def test_everything_falls_to_login_when_no_key_exists(self):
+        self.assertEqual(self._sess(1).effective_auth(), "login")
+        self.assertEqual(self._sess(2, auth="key").effective_auth(), "login",
+                         "'key' with nothing to inject launches on the login — loudly, via _options")
+
+
+class OptionsInjection(_Keyed):
+    def setUp(self):
+        super().setUp()
+        # ClaudeAgentOptions is a parameter (a dict stands in) and the in-function import only needs
+        # HookMatcher — stub the module when the real dependency is absent (CI without the venv), so
+        # the one behavior this feature must never get wrong is tested everywhere
+        import sys
+        import types
+        self._fake_sdk = "claude_agent_sdk" not in sys.modules and not sb.sdk_importable()
+        if self._fake_sdk:
+            fake = types.ModuleType("claude_agent_sdk")
+            fake.HookMatcher = lambda **kw: kw
+            sys.modules["claude_agent_sdk"] = fake
+
+    def tearDown(self):
+        import sys
+        if self._fake_sdk:
+            sys.modules.pop("claude_agent_sdk", None)
+        super().tearDown()
+
+    def _options_kw(self, sess):
+        return self.be._options(sess, dict)
+
+    def test_a_key_session_gets_the_key_and_a_login_session_a_clean_env(self):
+        kw = self._options_kw(self._sess(1, auth="key"))
+        self.assertEqual(kw["env"].get("ANTHROPIC_API_KEY"), FAKE_KEY)
+        kw2 = self._options_kw(self._sess(2, auth="login"))
+        self.assertNotIn("ANTHROPIC_API_KEY", kw2["env"],
+                         "removal, not blanking: an empty var reads as key-mode-without-a-key")
+
+    def test_options_records_what_it_launched_with_for_the_init_check(self):
+        s = self._sess(3, auth="key")
+        self._options_kw(s)
+        self.assertTrue(s._launched_keyed)
+        s2 = self._sess(4, auth="login")
+        self._options_kw(s2)
+        self.assertFalse(s2._launched_keyed)
+
+    def test_a_key_pick_with_no_key_is_a_logged_problem_not_a_silent_fall(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
+        self.assertIn("session is set to the API key but the manager environment carries", src)
+        self.assertIn('kw["env"] = dict(kw["env"], ANTHROPIC_API_KEY=self.work_key)', src)
+
+
+class InitMismatchIsLoud(_Keyed):
+    def test_a_cli_landing_on_the_wrong_side_reaches_the_problems_ring(self):
+        s = self._sess(1, auth="login")
+        s._launched_keyed = False
+        self.be._note_auth_source(s, "ANTHROPIC_API_KEY")   # found a key some other way (apiKeyHelper…)
+        texts = [p["text"] for p in self.be.problems(10)]
+        self.assertTrue(any("billing the API key" in t for t in texts),
+                        "a session billing the wrong account must never pass silently")
+
+    def test_the_agreeing_init_stays_quiet(self):
+        s = self._sess(2, auth="key")
+        s._launched_keyed = True
+        self.be._note_auth_source(s, "ANTHROPIC_API_KEY")
+        self.assertFalse([p for p in self.be.problems(10) if "billing" in p["text"]])
+
+
+class SetAuth(_Keyed):
+    def test_persists_pending_and_seeds_the_next_session(self):
+        sid = self.be.spawn("n", "/tmp")
+        self.assertTrue(self.be.set_auth(sid, "login"))
+        reg = sb.read_reg(self.be.state_dir, sid)
+        self.assertEqual(reg["auth"], "login")
+        self.assertTrue(reg["authPending"], "the applying reconnect hasn't happened yet — badge dots")
+        self.assertEqual(sb.read_sdk_defaults(self.be.state_dir).get("auth"), "login")
+        # …and the next spawn seeds from it
+        sid2 = self.be.spawn("m", "/tmp")
+        self.assertEqual(sb.read_reg(self.be.state_dir, sid2).get("auth"), "login")
+
+    def test_the_picker_pick_beats_the_remembered_default(self):
+        sb.write_sdk_default(self.be.state_dir, auth="login")
+        sid = self.be.spawn("n", "/tmp", auth="key")
+        self.assertEqual(sb.read_reg(self.be.state_dir, sid)["auth"], "key")
+
+    def test_refuses_junk_and_a_key_pick_on_a_keyless_manager(self):
+        sid = self.be.spawn("n", "/tmp")
+        self.assertFalse(self.be.set_auth(sid, "credit-card"))
+        self.be.work_key = ""
+        self.assertFalse(self.be.set_auth(sid, "key"),
+                         "nothing to inject — refuse rather than half-apply; the UI never offers it")
+
+    def test_a_live_session_reconnects_and_gets_the_ack_chip(self):
+        sid = self.be.spawn("n", "/tmp")
+        s = self._sess(9)
+        s.sid = sid
+        called = []
+        s.request_reconnect = lambda: called.append(True)
+        self.be.sessions[sid] = s
+        self.assertTrue(self.be.set_auth(sid, "key"))
+        self.assertTrue(called, "auth is connect-time — the reconnect is what applies it")
+        self.assertEqual(s.auth, "key")
+        self.assertEqual(s._auth_pending, "key")
+        chips = [a for a in self.be._live.get(sid, {}).values() if a.get("command") == "/auth"]
+        self.assertEqual(len(chips), 1, "an idle session's switch must still show SOMETHING in the chat")
+
+    def test_a_stranded_pending_flag_heals_on_construction(self):
+        sid = self.be.spawn("n", "/tmp")
+        self.be._update_reg(sid, authPending=True)
+        self._sess(1, sid=sid)
+        s = sb.SdkSession(self.be, sb.read_reg(self.be.state_dir, sid))
+        self.assertFalse(sb.read_reg(self.be.state_dir, sid).get("authPending"),
+                         "a fresh construction applies the reg on its next connect — pending is over")
+
+    def test_snapshot_and_dormant_rows_both_carry_the_choice(self):
+        sid = self.be.spawn("n", "/tmp", auth="login")
+        s = sb.SdkSession(self.be, sb.read_reg(self.be.state_dir, sid))
+        self.assertEqual(s.snapshot()["auth"], "login")
+        rows = self.be.live_sessions()
+        self.assertEqual(rows[sid]["auth"], "login", "a dormant session's gear must read the same truth")
+
+
+class SpendKeyedSplit(_Keyed):
+    def test_key_turns_fold_into_the_key_subcount_and_login_turns_do_not(self):
+        self.be._record_spend(1.0, {"input_tokens": 10, "output_tokens": 5}, keyed=True)
+        self.be._record_spend(2.0, {"input_tokens": 100}, keyed=False)
+        d = json.loads((Path(self.d) / "spend.json").read_text())
+        day = d["days"][time.strftime("%Y-%m-%d")]
+        self.assertEqual(day["usd"], 3.0, "the total keeps every turn (display gates, the record doesn't)")
+        self.assertEqual(day["key"]["usd"], 1.0, "…but the key sub-count holds ONLY the key-billed turn")
+        self.assertEqual(day["key"]["turns"], 1)
+        self.assertEqual(day["key"]["tok"], 15)
+
+    def test_spend_windows_keyed_only_reads_the_subcounts(self):
+        self.be._record_spend(1.5, {"input_tokens": 10}, keyed=True)
+        self.be._record_spend(4.0, None, keyed=False)
+        real_state = km.jd.STATE
+        try:
+            km.jd.STATE = Path(self.d)
+            total = km._spend_windows()
+            keyed = km._spend_windows(keyed_only=True)
+        finally:
+            km.jd.STATE = real_state
+        self.assertEqual(total["month"]["usd"], 5.5)
+        self.assertEqual(keyed["month"]["usd"], 1.5,
+                         "a login turn's computed cost is dollars nobody is billed — never in the API sum")
+        self.assertEqual(keyed["month"]["turns"], 1)
+
+
+class UsagePayloadMixed(unittest.TestCase):
+    """_usage() attaches the keyed spend + the key's tail BESIDE the login's bars — only when key
+    turns actually exist, so a host that never uses its key shows nothing extra."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.real_state = km.jd.STATE
+        km.jd.STATE = Path(self.d)
+        self.real_tail = km._auth_key_tail
+        (Path(self.d) / "usage.json").write_text(json.dumps(
+            {"t": 1000, "five_hour": {"pct": 40, "resets_at": None}}))   # unstamped = legacy, keeps bars
+
+    def tearDown(self):
+        km.jd.STATE = self.real_state
+        km._auth_key_tail = self.real_tail
+
+    def _spend(self, keyed_turns):
+        day = time.strftime("%Y-%m-%d")
+        hour = time.strftime("%Y-%m-%dT%H")
+        b = {"usd": 2.0, "turns": 3, "tokIn": 1, "tokOut": 1, "tokCacheR": 0, "tokCacheW": 0}
+        if keyed_turns:
+            b["key"] = {"usd": 0.5, "turns": keyed_turns, "tok": 7}
+        (Path(self.d) / "spend.json").write_text(json.dumps({"days": {day: b}, "hours": {hour: b}}))
+
+    def test_bars_carry_the_keyed_spend_when_key_turns_exist(self):
+        km._auth_key_tail = lambda: "wxyz"
+        self._spend(keyed_turns=2)
+        u = km._usage()
+        self.assertTrue(u["fiveHour"], "the login's bars stay the headline")
+        self.assertEqual(u["apiTail"], "wxyz")
+        self.assertEqual(u["spend"]["month"]["usd"], 0.5, "keyed-only, never the total")
+
+    def test_no_key_turns_or_no_key_means_no_spend_beside_the_bars(self):
+        km._auth_key_tail = lambda: "wxyz"
+        self._spend(keyed_turns=0)
+        self.assertNotIn("spend", km._usage())
+        km._auth_key_tail = lambda: ""
+        self._spend(keyed_turns=2)
+        self.assertNotIn("spend", km._usage())
+
+    def test_the_spend_only_arm_names_the_key_too(self):
+        km._auth_key_tail = lambda: "wxyz"
+        (Path(self.d) / "usage.json").write_text(json.dumps({"t": 1000, "apiKey": True}))
+        self._spend(keyed_turns=0)
+        u = km._usage()
+        self.assertTrue(u["apiKey"])
+        self.assertEqual(u["apiTail"], "wxyz")
+
+
+class AuthErrorClass(unittest.TestCase):
+    def test_the_cli_and_api_phrasings_classify_and_transients_do_not(self):
+        for text in ("Not logged in · Please run /login",
+                     "Failed to authenticate. API Error: 401 API key is invalid.",
+                     "invalid x-api-key",
+                     "OAuth token has expired",
+                     'API Error: 401 {"type":"error","error":{"type":"authentication_error"}}'):
+            self.assertTrue(km._is_auth_error(text), text)
+        for text in ("500 server_error", "Request timed out", "prompt is too long",
+                     "You've reached your Fable 5 limit", ""):
+            self.assertFalse(km._is_auth_error(text), text)
+
+    def test_it_is_an_on_you_class_end_to_end(self):
+        import inspect
+        self.assertIn('"authErr": _is_auth_error(text)', inspect.getsource(km._api_error))
+        self.assertIn('"apiAuthErr": bool(aerr and aerr.get("authErr"))', inspect.getsource(km.build_session))
+        feed = inspect.getsource(km.build_feed)
+        self.assertIn('aerr.get("authErr"))))', feed, "the card floors to needs-you")
+        self.assertIn("sign-in or API key isn't working", feed, "the card names the real remedy")
+
+
+class Availability(unittest.TestCase):
+    """The selector exists only when BOTH choices are real — everywhere it could appear."""
+
+    def setUp(self):
+        self.real_sdk, self.real_acct = km._sdk, km._claude_account
+
+    def tearDown(self):
+        km._sdk, km._claude_account = self.real_sdk, self.real_acct
+
+    def _world(self, key, acct):
+        km._sdk = lambda: type("B", (), {"work_key": key})()
+        km._claude_account = lambda: acct
+
+    def test_both_gates_the_selector_and_the_tail_names_the_key(self):
+        self._world(FAKE_KEY, "aaaaaaaaaaaa")
+        self.assertTrue(km._auth_both())
+        self.assertEqual(km._auth_key_tail(), "wxyz")
+        a = km._auth_avail()
+        self.assertEqual((a["login"], a["key"], a["tail"]), (True, True, "wxyz"))
+        self.assertNotIn(FAKE_KEY, json.dumps(a), "the key itself never travels")
+
+    def test_one_choice_is_no_choice(self):
+        self._world("", "aaaaaaaaaaaa")
+        self.assertFalse(km._auth_both())
+        self._world(FAKE_KEY, "")
+        self.assertFalse(km._auth_both())
+
+    def test_the_session_payload_carries_auth_only_when_both_exist(self):
+        import inspect
+        src = inspect.getsource(km.build_session)
+        self.assertIn('"auth": (tm.get("auth", "") if _auth_both() else "")', src)
+        self.assertIn('"authTail": (_auth_key_tail() if _auth_both() else "")', src)
+
+    def test_the_picker_learns_availability_on_the_session_list(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn('"authAvail": _auth_avail()', src)
+
+
+class DrivePlumbing(unittest.TestCase):
+    """setAuth rides the same drive/park path as the other per-session switches (source pins)."""
+
+    def test_the_op_is_routed_parked_and_replayed(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn('"setAuth", "endSession"', src.replace("\n", " "), "an ID_OPS member")
+        self.assertIn('elif t == "setAuth" and msg.get("value") in ("login", "key"):', src)
+        self.assertIn("def _set_auth_or_park(be, sid, value):", src)
+        self.assertIn('_park_op(sid, ("auth", value))', src)
+        self.assertIn('elif op[0] == "auth":', src)
+        self.assertIn("be.set_auth(sid, op[1])", src)
+
+    def test_create_paths_pass_the_pick_through(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("def _create_sdk_session(nm, cwd, auth=\"\"):", src)
+        self.assertEqual(src.count('auth=(a if a in ("login", "key") else "")'), 2,
+                         "the WS op and POST /new both pass it")
+
+    def test_the_abc_names_the_control_and_tmux_refuses(self):
+        sbc = open(os.path.join(os.path.dirname(HERE), "kernel", "session_backend.py")).read()
+        self.assertIn("def set_auth(self, sid: str, value: str) -> bool:", sbc)
+        self.assertIn("return False", sbc.split("def set_auth", 1)[1][:900])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_usage_per_account.py
+++ b/tests/test_usage_per_account.py
@@ -1,14 +1,16 @@
-"""One set of usage bars per Claude ACCOUNT (the user 2026-07-30).
+"""Fleet usage: one PAYLOAD ROW PER HOST, one AGGREGATED rendering (the user 2026-08-08).
 
-The 5h / 7d windows are account-wide, so a fleet signed into one login has ONE allowance and drawing it
-per host would just repeat the same number — that case renders exactly as it always did, a single bare
-set. But sign a second machine into a DIFFERENT account and the single set was flatly wrong: two
-independent allowances, shown as one.
+The 5h / 7d windows are account-wide allowances, so the collapsed rail draws ONE set of bars — per
+window, the worst known reading across every account (a shared login reports the same number from every
+host and the max collapses it for free) — plus one API cell for everything key-billed. The per-host
+story lives in the hover, so /usage/fleet now emits every reporting host, INCLUDING a key-only host with
+no account digest at all (the old per-account dedup dropped those entirely, and a mixed host's key spend
+never rendered anywhere).
 
 The account is read from Claude Code's own ~/.claude.json (`oauthAccount.accountUuid`) — the identity the
 CLI itself uses, with no API that reports it. It travels as an opaque digest, never the email: the only
-question is "same login or not", and an email is a personal identifier that would otherwise ride to every
-federated host, sit in a payload and appear in any screenshot of the bars.
+question is "same login or not" (the client's aggregation and a reader of the hover both lean on it),
+and an email is a personal identifier that would otherwise ride to every federated host.
 
 Synthetic accounts and hosts only; no real uuid, email or hostname appears here.
 """
@@ -78,41 +80,39 @@ class FleetRollup(unittest.TestCase):
         with km._remotes_lock:
             km._remotes[host] = {"host": host, "status": status, "usage": _usage(acct) if acct else None}
 
-    def test_one_account_everywhere_stays_one_set(self):
+    def test_every_reporting_host_rides_along_shared_login_or_not(self):
+        # the rail aggregates and the hover breaks down per host, so a shared login is NOT deduped
+        # server-side any more — each host's row carries the same acct and the client collapses it
         km._usage = lambda: _usage(ACCT_A)
         self._remote("api", ACCT_A)
         self._remote("gpu", ACCT_A)
         rows = km._fleet_usage()
-        self.assertEqual(len(rows), 1, "an account-wide window drawn twice would repeat one number")
-        self.assertEqual(rows[0]["host"], "", "the local row is unlabelled")
+        self.assertEqual([r["host"] for r in rows], ["", "api", "gpu"])
+        self.assertEqual({r["acct"] for r in rows}, {ACCT_A}, "the digest is what lets the client collapse them")
 
-    def test_a_second_account_gets_its_own_set(self):
+    def test_a_second_account_gets_its_own_row(self):
         km._usage = lambda: _usage(ACCT_A)
         self._remote("api", ACCT_B)
         rows = km._fleet_usage()
         self.assertEqual([r["host"] for r in rows], ["", "api"])
         self.assertEqual(rows[1]["acct"], ACCT_B)
 
-    def test_two_hosts_on_the_same_second_account_share_one_set(self):
-        km._usage = lambda: _usage(ACCT_A)
-        self._remote("api", ACCT_B)
-        self._remote("gpu", ACCT_B)
-        rows = km._fleet_usage()
-        self.assertEqual(len(rows), 2, "one allowance, however many machines are burning it")
-
     def test_a_disconnected_host_contributes_nothing(self):
         km._usage = lambda: _usage(ACCT_A)
         self._remote("api", ACCT_B, status="down")
         self.assertEqual(len(km._fleet_usage()), 1)
 
-    def test_a_host_that_cannot_report_an_account_is_left_out_rather_than_guessed(self):
-        # an older remote kernel has no `acct` field; a phantom second set of bars would be worse than
-        # the honest single one
+    def test_a_key_only_host_is_included_even_with_no_account_to_report(self):
+        # the old per-account dedup dropped an acct-less row entirely, so a remote key-only host's
+        # spend could never reach the rail (found 2026-08-08 while adding per-session auth): the host
+        # itself is the identity for the spend half of a payload
         km._usage = lambda: _usage(ACCT_A)
         self._remote("api", "")
         with km._remotes_lock:
-            km._remotes["api"]["usage"] = {"fiveHour": {"pct": 5}, "t": 1}
-        self.assertEqual(len(km._fleet_usage()), 1)
+            km._remotes["api"]["usage"] = {"apiKey": True, "spend": {"fiveHour": {"usd": 1.0}}, "t": 1, "acct": ""}
+        rows = km._fleet_usage()
+        self.assertEqual([r["host"] for r in rows], ["", "api"])
+        self.assertEqual(rows[1]["acct"], "")
 
     def test_the_local_row_is_always_first_so_the_notices_read_off_this_machine(self):
         km._usage = lambda: _usage(ACCT_A)
@@ -151,17 +151,34 @@ class RailRendering(unittest.TestCase):
         self.assertIn("fetch('/usage/fleet'", self.js)
         self.assertIn("function renderRows(rows,selfHost)", self.js)
 
-    def test_a_single_account_renders_exactly_as_before_with_no_label(self):
-        self.assertIn("if(live.length===1)", self.js)
-        # the host label markup is reached only on the many-account branch
-        self.assertIn("class=ru-set", self.js)
-        self.assertIn("class=ru-host", self.js)
+    def test_the_rail_aggregates_and_never_repeats_the_windows_per_host(self):
+        # collapsed = one set of bars (worst window across hosts) + one API cell; the per-host
+        # .ru-set/.ru-host rail markup is gone (the user 2026-08-08) — hosts appear only in the hover
+        self.assertIn("function aggBarsHTML(live)", self.js)
+        self.assertIn("function apiCellHTML(live)", self.js)
+        self.assertIn("aggBarsHTML(LAST)+apiCellHTML(LAST)", self.js)
+        self.assertNotIn("class=ru-set", self.js)
+        self.assertNotIn("class=ru-host>", self.js)
+        self.assertIn("if(!best||d.pct>best.pct)best=d;", self.js, "worst known reading wins the bar")
 
-    def test_the_label_is_the_chat_tabs_quiet_lowercase_italic_host_prefix(self):
+    def test_the_api_cell_is_numbers_with_the_keys_own_tail_and_no_bars(self):
+        # label 'API …wxyz' (one distinct key) or bare 'API'; value = 5h burn + month-to-date dollars;
+        # the spend bar graphs are gone everywhere (the user 2026-08-08: they told you nothing)
+        self.assertIn("'API'+(tl.length===1?' …'+esc(tl[0]):'')", self.js)
+        self.assertIn("fmtUsd(sum.fiveHour)+' 5h · '+fmtUsd(sum.month)+' mo</div>'", self.js)
+        self.assertNotIn("spendColor", self.js)
+        self.assertNotIn("spendWinsHTML", self.js)
+
+    def test_the_hover_is_the_per_host_breakdown_in_the_quiet_lowercase_italic(self):
         css = km._landing()
-        self.assertIn(".ru-host{font:italic 400 10px", css)
+        self.assertIn(".ru-tip-host{font:italic 400 10px", css)
         self.assertIn("text-transform:lowercase", css)
-        self.assertIn("'<span class=ru-host>'+esc(hn)+':</span>'", self.js, "…and it ends in a colon")
+        # a host section can carry BOTH its login's windows and its key's spend (per-session auth),
+        # and the spend rows are numbers only — no track span
+        self.assertIn("function winDet(u,det)", self.js)
+        self.assertIn("winDet(r.usage,det);spendDet(r.usage,det);", self.js)
+        self.assertIn("API'+(d._tail?' …'+esc(d._tail):'')+' spend</span>", self.js)
+        self.assertIn("' tok · '+(v.turns||0)+' turns</span>", self.js)
 
     def test_the_account_wide_notices_read_off_THIS_machine(self):
         # a limit pauses THIS kernel's retries and judges; a remote account's limit does not

--- a/ui/webview/apierror-spend-limit.test.ts
+++ b/ui/webview/apierror-spend-limit.test.ts
@@ -18,12 +18,13 @@ test("Status carries the per-session apiSpendLimit flag", () => {
 });
 
 test("the auto-retry tick SKIPS a spend-capped thread (retrying can't fix a billing cap)", () => {
-  // a spent MODEL allowance is skipped by the same rule (the user 2026-08-01)
-  assert.match(R, /!s\.status\.retrySuppressed && !s\.status\.apiSpendLimit && !s\.status\.apiModelLimit/);
+  // a spent MODEL allowance is skipped by the same rule (the user 2026-08-01), and a dead credential
+  // too (per-session auth, the user 2026-08-08): every retry re-presents the same broken login/key
+  assert.match(R, /!s\.status\.retrySuppressed && !s\.status\.apiSpendLimit && !s\.status\.apiModelLimit && !s\.status\.apiAuthErr/);
 });
 
 test("a spend cap paints the tab alarm-red (on-you), not amber retrying", () => {
-  assert.match(R, /\(s\.status\.apiTooLong \|\| s\.status\.apiSpendLimit \|\| s\.status\.apiModelLimit\) \? "tab-blocked" : "tab-retrying"/);
+  assert.match(R, /\(s\.status\.apiTooLong \|\| s\.status\.apiSpendLimit \|\| s\.status\.apiModelLimit \|\| s\.status\.apiAuthErr\) \? "tab-blocked" : "tab-retrying"/);
 });
 
 test("the paused line names the spend cap and points at the settings page (no fake countdown)", () => {

--- a/ui/webview/auth-selector.test.ts
+++ b/ui/webview/auth-selector.test.ts
@@ -1,0 +1,59 @@
+// Per-session BILLING selector (the user 2026-08-08): pick, per session, whether it bills the Claude
+// login or the API key the manager's environment carries. Two surfaces, both existence-gated on the
+// machine actually offering BOTH choices (one choice is no choice — the control disappears):
+//   * the new-session picker's Billing row, armed by the selected host's own sessionList reply
+//     (authAvail) and shown only while the backend toggle says SDK;
+//   * the statusline auth badge, present only when the kernel emits st.auth (it gates on _auth_both),
+//     posting setAuth and wearing switching-dots while the applying reconnect is pending.
+// The key is always named by its LAST 4 (…wxyz) — which key, never the key.
+// No jsdom harness → source pins (the repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const RENDER = fs.readFileSync(path.join(ROOT, "ui", "webview", "render.ts"), "utf8");
+const INTENT = fs.readFileSync(path.join(ROOT, "vscode-extension", "src", "pipe-intent.ts"), "utf8");
+
+test("the picker's Billing row exists only when the host offers both, and only for SDK", () => {
+  // hidden until the selected host's OWN sessionList reply proves both choices exist; the backend
+  // toggle re-decides it (tmux CLIs live in the tmux server's env, which the kernel doesn't control)
+  assert.match(RENDER, /const show = !pickMode && !!\(a && a\.login && a\.key\) && \(beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend\) === "sdk";/);
+  assert.match(RENDER, /auWrap\.style\.display = "none";\s*\/\/ hidden until a sessionList reply proves both choices exist/);
+  assert.match(RENDER, /beWrap\.addEventListener\("click", \(\) => syncPickerAuth\(\)\);/);
+  // a host switch clears the availability — the choices on screen belong to the OLD host
+  assert.match(RENDER, /pickerAuthAvail = null;\s*\n\s*syncPickerAuth\(\);/);
+  // …and the reply that re-arms it is dropped-if-stale by the same host check the list itself uses
+  assert.match(RENDER, /pickerAuthAvail = \(m\.authAvail && typeof m\.authAvail === "object"\) \? m\.authAvail : null;/);
+});
+
+test("the picker's key option names WHICH key, and the pick rides createSession", () => {
+  assert.match(RENDER, /keyBtn\.textContent = a!\.tail \? `API …\$\{a!\.tail\}` : "API key";/);
+  // the pick is omitted entirely when the row is hidden — the kernel's own default stands
+  assert.match(RENDER, /function pickerAuthChoice\(\): string/);
+  assert.match(RENDER, /host: hostSel, \.\.\.\(auth \? \{ auth \} : \{\}\) \}\);/);
+  assert.match(RENDER, /interface CreateReq \{ name: string; backend: string; dir: string; host: string; auth\?: string \}/);
+  // fresh open forgets last time's pick + availability; the local reply re-arms it
+  assert.match(RENDER, /auWrapEl\.querySelectorAll\("\.picker-be-opt"\)\.forEach\(\(x\) => x\.classList\.remove\("sel"\)\);/);
+  // the default selection comes from the host's own answer, once, not on every re-sync
+  assert.match(RENDER, /const def = a!\.default === "key" \? "key" : "login";/);
+});
+
+test("the statusline auth badge is a MetaKind gated on the kernel emitting st.auth", () => {
+  assert.match(RENDER, /type MetaKind = "mode" \| "model" \| "effort" \| "fast" \| "auth";/);
+  assert.match(RENDER, /st\.auth \? "auth" : ""/);
+  assert.match(RENDER, /meta\.appendChild\(metaButton\("auth", prettyAuth\(st\)\)\)/);
+  // the badge and its menu name the key by its tail
+  assert.match(RENDER, /`API …\$\{st\.authTail\}`/);
+  assert.match(RENDER, /kind === "auth" && c\.value === "key" && s\.status\.authTail/);
+  // the pick posts setAuth, and the applying reconnect drives the switching-dots
+  assert.match(RENDER, /kind === "auth" \? "setAuth"/);
+  assert.match(RENDER, /\(kind === "auth" && !!st\.authPending\)/);
+  assert.match(RENDER, /kind === "model" \|\| kind === "effort" \|\| kind === "auth"\);/);
+  assert.match(RENDER, /auth\?: string; authPending\?: boolean; authTail\?: string;/);
+});
+
+test("setAuth is an intent op — held through a kernel-restart window, never dropped", () => {
+  assert.match(INTENT, /"setModel", "setEffort", "setMode", "setFast", "setAuth",/);
+});

--- a/ui/webview/dismiss-dialog.test.ts
+++ b/ui/webview/dismiss-dialog.test.ts
@@ -15,7 +15,7 @@ const K = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py
 const apiErr = R.slice(R.indexOf("function renderApiError"), R.indexOf("// ── API-error auto-retry"));
 
 test("a spend cap suppresses the Retry button entirely", () => {
-  assert.match(apiErr, /const spendCap = !!st\?\.apiSpendLimit \|\| !!st\?\.apiModelLimit;/);
+  assert.match(apiErr, /const spendCap = !!st\?\.apiSpendLimit \|\| !!st\?\.apiModelLimit \|\| !!st\?\.apiAuthErr;/);
   assert.match(apiErr, /if \(!spendCap\) \{[\s\S]*?retry\.textContent = "Retry now";/);
 });
 

--- a/ui/webview/effort-switch-pending.test.ts
+++ b/ui/webview/effort-switch-pending.test.ts
@@ -14,7 +14,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the effort badge shows switching-dots while a reconnect is pending, like the model badge", () => {
   assert.match(RENDER, /effortPending\?: boolean;/);   // status carries it
   assert.match(RENDER, /\(kind === "effort" && !!st\.effortPending\)/);          // effort feeds `pending`
-  assert.match(RENDER, /const showDots = pending && \(kind === "model" \|\| kind === "effort"\);/);   // dots for BOTH now
+  assert.match(RENDER, /const showDots = pending && \(kind === "model" \|\| kind === "effort" \|\| kind === "auth"\);/);   // dots for all three reconnect-style switches
 });
 
 test("a live reconnect has its own ChatEvent kind, dispatched to renderReconnecting", () => {

--- a/ui/webview/fast-toggle.test.ts
+++ b/ui/webview/fast-toggle.test.ts
@@ -17,7 +17,7 @@ const SDK = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_bac
 
 test("the fast badge is a meta control that appears only when the session reports a state", () => {
   assert.match(RENDER, /fast\?: string;/);                                   // status carries it
-  assert.match(RENDER, /type MetaKind = "mode" \| "model" \| "effort" \| "fast";/);
+  assert.match(RENDER, /type MetaKind = "mode" \| "model" \| "effort" \| "fast" \| "auth";/);
   assert.match(RENDER, /st\.fast \? "fast" : ""/);                           // no state → no badge
   assert.match(RENDER, /meta\.appendChild\(metaButton\("fast", prettyFast\(st\.fast\)\)\)/);
 });

--- a/ui/webview/model-switch-dots.test.ts
+++ b/ui/webview/model-switch-dots.test.ts
@@ -16,8 +16,8 @@ test("Status carries the server-driven modelPending flag", () => {
 
 test("syncMetaControls renders dots for a pending model, driven by the server flag (+ local click heuristic)", () => {
   // model + effort both drive dots now (effort reconnects to apply); the model clause is still present
-  assert.match(RENDER, /const pending = \(kind === "model" && !!st\.modelPending\) \|\| \(kind === "effort" && !!st\.effortPending\) \|\| isMetaPending\(kind, st\);/);
-  assert.match(RENDER, /const showDots = pending && \(kind === "model" \|\| kind === "effort"\);/);
+  assert.match(RENDER, /const pending = \(kind === "model" && !!st\.modelPending\) \|\| \(kind === "effort" && !!st\.effortPending\)\s*\n\s*\|\| \(kind === "auth" && !!st\.authPending\) \|\| isMetaPending\(kind, st\);/);
+  assert.match(RENDER, /const showDots = pending && \(kind === "model" \|\| kind === "effort" \|\| kind === "auth"\);/);
   assert.match(RENDER, /if \(!label\.querySelector\("\.meta-dots"\)\) label\.replaceChildren\(metaDots\(\)\);/);
 });
 

--- a/ui/webview/picker-dir.test.ts
+++ b/ui/webview/picker-dir.test.ts
@@ -23,7 +23,7 @@ test("createSession carries the chosen dir, alongside name + backend", () => {
   // backend comes from the + dialog's per-session toggle, falling back to the gear default (the user
   // 2026-06-23). The whole request goes through startCreate, which remembers it so a missing directory
   // can be created and the SAME create re-sent (the user 2026-07-28).
-  assert.match(RENDER, /startCreate\(\{ name, backend: beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend,\s*\n\s*dir: dirInput\.value\.trim\(\), host: hostSel \}\)/);
+  assert.match(RENDER, /startCreate\(\{ name, backend: beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend,\s*\n\s*dir: dirInput\.value\.trim\(\), host: hostSel, \.\.\.\(auth \? \{ auth \} : \{\}\) \}\)/);
   assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "createSession", \.\.\.req/);
 });
 

--- a/ui/webview/picker-host.test.ts
+++ b/ui/webview/picker-host.test.ts
@@ -18,7 +18,7 @@ test("the + dialog builds a Host row listing local + attached hosts, hidden with
 
 test("createSession carries the picked host (empty = local) so the manager routes it to that kernel", () => {
   assert.match(RENDER, /const hostSel = \(hostWrap\.querySelector\("\.picker-be-opt\.sel"\) as HTMLElement \| null\)\?\.dataset\.host \|\| ""/);
-  assert.match(RENDER, /startCreate\(\{ name, backend: beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend,\s*\n\s*dir: dirInput\.value\.trim\(\), host: hostSel \}\)/);
+  assert.match(RENDER, /startCreate\(\{ name, backend: beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend,\s*\n\s*dir: dirInput\.value\.trim\(\), host: hostSel, \.\.\.\(auth \? \{ auth \} : \{\}\) \}\)/);
   // the PROVISIONAL tab (2026-07-30, which replaced the "Opening…" cue) must be matched against the
   // PREFIXED tab name a remote create produces — provisionalName() is where that join is spelled
   assert.match(RENDER, /openProvisional\(req\);/);

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -1,11 +1,12 @@
-// Under API-KEY auth the rail shows SPEND WINDOWS that mirror the subscription bars' grammar — the
-// same rows, labels, and twin tracks, for 5h / 7d / month-to-date — so flipping between the two auth
-// modes reads instantly (the user 2026-08-04/05). A row FILLS only when spend-budgets.json names that
-// window's budget: the fill is spend-over-budget, and without a cap there is no honest fraction — the
-// row carries plain dollars in the readout slot and no used-track. Spend accumulates per ResultMessage
-// (total_cost_usd + usage tokens) into spend.json's day AND hour buckets (the rolling windows read the
-// hours). BOTH rail copies carry the builder — VS Code's strip.ts and the web landing's usage JS in
-// kernel.py — and must stay in step. No jsdom harness → source pins (the repo convention).
+// API-KEY SPEND on the rail (redesigned 2026-08-08, with per-session auth): spend is NUMBERS, never
+// bars — the old hover graph scaled each window's bar to the largest window, a shape that told the
+// reader nothing, and the budget-fill tracks on the web rail died with it. A host's payload can now
+// carry a login's WINDOWS and its key's SPEND at once (`spend` beside the bars, keyed-only sums), so
+// presence of the spend windows — not the legacy apiKey flag — is what turns the dollars on. The
+// collapsed web rail shows one API cell (key tail + 5h/month dollars); the hover breaks spend down
+// per window per host. Spend accumulates per ResultMessage (total_cost_usd + usage tokens) into
+// spend.json's day AND hour buckets, each bucket carrying a `key` sub-count for key-billed turns.
+// No jsdom harness → source pins (the repo convention).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -17,85 +18,75 @@ const STRIP = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf
 const STRIPCSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.css"), "utf8");
 const BACKEND = fs.readFileSync(path.join(ROOT, "kernel", "sdk_backend.py"), "utf8");
 
-test("the kernel serves spend WINDOWS on the auth-flip marker, zero-filled when fresh", () => {
-  // the spend view arms on the legacy apiKey marker OR a login-less machine with recorded spend
-  // (per-session auth writes no marker any more — the user 2026-08-08)
+test("the kernel serves spend windows for BOTH payload shapes, keyed-only beside bars", () => {
+  // the spend-only view arms on the legacy apiKey marker OR a login-less machine with recorded spend,
+  // and keeps TOTAL sums (everything there bills the key; legacy files predate the split)
   assert.ok(KERNEL.includes('if o.get("apiKey") or (not _claude_account() and (jd.STATE / "spend.json").exists()):'));
-  assert.ok(KERNEL.includes('"spend": _spend_windows()'));
-  assert.ok(KERNEL.includes("def _spend_windows():"));
-  assert.ok(KERNEL.includes("def _spend_budgets():"), "budgets give a window its fill denominator");
+  assert.ok(KERNEL.includes('"spend": _spend_windows(), "apiTail": _auth_key_tail(),'));
+  // the bars payload attaches the KEYED split only — a login turn's computed cost there would be
+  // dollars nobody is billed — and only when key turns actually exist (the user 2026-08-08)
+  assert.ok(KERNEL.includes("def _spend_windows(keyed_only=False):"));
+  assert.ok(KERNEL.includes("ksp = _spend_windows(keyed_only=True)"));
+  assert.match(KERNEL, /if any\(\(ksp\.get\(k\) or \{\}\)\.get\("turns"\) for k in \("fiveHour", "sevenDay", "month"\)\):/);
+  assert.ok(KERNEL.includes('out["apiTail"] = _auth_key_tail()'));
   // rolling 5h/7d read the HOUR buckets; month-to-date reads the day ledger
   assert.match(KERNEL, /"fiveHour": _rolling\(5\), "sevenDay": _rolling\(7 \* 24\)/);
-  assert.ok(KERNEL.includes('k.startswith(month)'));
-  // a window-less file on a logged-in machine stays None — nothing known, draw nothing
-  assert.match(KERNEL, /if o\.get\("apiKey"\) or [\s\S]{0,900}?return None/);
-  // the subscription payload carries NO spend windows (the user 2026-08-08, same day they were
-  // added beside the bars): a login account's story is its % bars — token volume + dollars are
-  // API-KEY information, carried only on the spend-only payload
-  assert.doesNotMatch(KERNEL, /"fiveHour": five, "sevenDay": seven, "fable": fable,[\s\S]{0,600}?"spend": _spend_windows\(\),/);
-  // the accumulator: total_cost_usd AND the usage token counts are CUMULATIVE per CLI process — fold
-  // per-turn DELTAS for both, and a shrunken counter (an unwatched reset) folds whole, never negative
-  // (the user 2026-08-08, dollars in the morning and tokens by the evening)
+  assert.ok(KERNEL.includes("k.startswith(month)"));
+  // the accumulator: cumulative-per-process DELTAS, and each bucket splits out the key's own turns
   assert.ok(BACKEND.includes("delta = total - self._last_cost_total if total >= self._last_cost_total else total"));
   assert.ok(BACKEND.includes("turn_u[k] = v - last if v >= last else v"));
-  assert.ok(BACKEND.includes("self.backend._record_spend(delta, turn_u)"));
+  assert.ok(BACKEND.includes("self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth)"));
+  assert.ok(BACKEND.includes("if keyed or ke:   # carry an existing key split forward even on a login turn"));
   assert.ok(BACKEND.includes("_fold(days, day, 90)"));
   assert.ok(BACKEND.includes("_fold(hours, hour, 192)"), "8 days of hour buckets feed the rolling windows");
 });
 
-test("VS Code strip: ONE row builder for both auth modes — spend rows ride the same loop as the bars", () => {
+test("VS Code strip: spend rows key on the windows' PRESENCE, one row builder for both kinds", () => {
   assert.match(STRIP, /export function spendWindows\(usage: any, nowS: number\): UsageWindow\[\]/);
+  // presence, not the apiKey flag: a mixed host's payload carries bars AND spend at once
+  assert.ok(STRIP.includes("const sp = usage && usage.spend;"));
+  assert.doesNotMatch(STRIP, /usage\.apiKey && usage\.spend/);
   assert.match(STRIP, /usageWindows\(usage, nowS\)\.concat\(spendWindows\(usage, nowS\)\)/);
-  // no budget → no used-track and a dollars readout; never a made-up fraction
-  assert.match(STRIP, /const pct = budget != null \? Math\.max\(0, Math\.min\(100, Math\.round\(\(seg\.usd \/ budget\) \* 100\)\)\) : null;/);
-  assert.match(STRIP, /if \(w\.pct != null\) bars\.appendChild\(mkTrack\(w\.pct, usageColor\(w\.pct\)\)\);/);
-  assert.match(STRIP, /pct\.textContent = w\.readout \?\? `\$\{w\.pct\}%`;/);
-  // rolling windows draw no elapsed track; month-to-date does (it has a real boundary)
-  assert.match(STRIP, /if \(key === "month" && budget != null\)/);
-  // labels mirror the subscription table's two-tier form
+  // labels mirror the subscription table's two-tier form; dollars AND tokens stay visible
   assert.match(STRIP, /\["fiveHour", "5 hours", "5h"\]/);
   assert.match(STRIP, /\["month", "Month", "mo"\]/);
-  // dollars AND tokens stay visible in the readout (the user 2026-08-05); the split stays on hover
   assert.match(STRIP, /\+ " · " \+ fmtTok\(seg\.tok \|\| 0\) \+ " tok"/);
-  assert.ok(KERNEL.includes("+' \\u00b7 '+fmtTok(seg.tok||0)+' tok'"), "web readout carries tokens too");
   // the old one-off chip is gone, and with it any minted style
   assert.doesNotMatch(STRIP, /spendChip/);
   assert.doesNotMatch(STRIPCSS, /\.ru-spend/);
 });
 
-test("the web landing copy carries the SAME builder — the two rails stay in step", () => {
-  assert.ok(KERNEL.includes("function spendWinsHTML(u,det)"));
-  assert.ok(KERNEL.includes("var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','Month']];"));
-  assert.ok(KERNEL.includes("function hasSpend(u){return !!(u&&u.apiKey&&u.spend&&u.spend.fiveHour);}"));
-  // same row markup as winsHTML: ru-w → ru-name → ru-bars (tracks) → ru-pct readout
-  assert.ok(KERNEL.includes("+'<div class=ru-name>'+w[1]+'</div>'"));
-  assert.ok(KERNEL.includes("(pct!=null?'<div class=ru-track><i class=ru-fill style=\"width:'+pct+'%;background:'+spendColor(pct)+'\"></i></div>':'')"));
-  // both the single- and multi-account paths fall to the window rows; only the spend path fills the
-  // hover's spend detail (spendDet inside spendWinsHTML) — a bars account gets no token section
-  assert.ok(KERNEL.includes("el.innerHTML=hasBars(live[0].usage)?winsHTML(live[0].usage,det):spendWinsHTML(live[0].usage,det);"));
-  assert.ok(KERNEL.includes("var inner=hasBars(r.usage)?winsHTML(r.usage,det):spendWinsHTML(r.usage,det);"));
+test("the web rail's API cell is numbers with the key's own tail — no spend bars anywhere", () => {
+  const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
+  // one compact cell: 'API …wxyz' (several distinct keys fall back to bare 'API'), 5h + month dollars
+  assert.ok(usageJS.includes("function apiCellHTML(live)"));
+  assert.ok(usageJS.includes("'API'+(tl.length===1?' \\u2026'+esc(tl[0]):'')"));
+  assert.ok(usageJS.includes("fmtUsd(sum.fiveHour)+' 5h \\u00b7 '+fmtUsd(sum.month)+' mo</div>'"));
+  // the graph and the budget fills are gone: no spend track, no spend color ramp, no shared scale
+  assert.ok(!usageJS.includes("spendColor"), "the budget-fill ramp died with the spend bars");
+  assert.ok(!usageJS.includes("spendWinsHTML"), "spend never renders as window rows with tracks");
+  assert.ok(!usageJS.includes("var mx=1;"), "the token auto-scale graph is gone");
+  // presence-keyed, like the strip
+  assert.ok(usageJS.includes("function hasSpend(u){return !!(u&&u.spend&&u.spend.fiveHour);}"));
 });
 
-test("the rich tip is the ONE hover surface: no native titles, every account renders, cursor-anchored", () => {
+test("the rich tip is the ONE hover surface: no native titles, per-host sections, numbers-only spend", () => {
   // NO native title attributes anywhere on the rail (the user 2026-08-08, who got the browser's flat
   // yellow box on top of the rich hover): the usage JS may mention titles only in comments
-  const usageJS = KERNEL.split("_LANDING_USAGE_JS = \"\"\"")[1].split('"""')[0];
+  const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
   for (const line of usageJS.split("\n")) {
     const code = line.split("//")[0];
     assert.ok(!/\btitle\s*=/.test(code) && !code.includes(".title="), `native title in usage JS: ${line.trim()}`);
   }
-  // a SPEND-ONLY account used to return '' from setHTML, so a mixed hover showed only the
-  // subscription login (the user 2026-08-08) — now it renders its own section
+  // a host section can carry BOTH its login's windows and its key's spend (per-session auth) — the
+  // spendOnly gate that hid a bars host's dollars is gone
   assert.ok(usageJS.includes("if(!keys.length&&!sp)return '';"));
-  assert.ok(usageJS.includes("var spendOnly=!keys.length;"));
-  // the spend graph: the three windows' token volume on ONE shared auto-scale, in the tip's track
-  // idiom, dollars beside each — SPEND-ONLY accounts only (the user 2026-08-08: a login account's
-  // story is its % bars, and token rows there read as noise). The guard also covers an older kernel
-  // in the fleet still attaching spend beside its bars.
+  assert.ok(!usageJS.includes("spendOnly"), "spend renders for ANY host that has it");
+  assert.ok(usageJS.includes("if(sp){var ks=['fiveHour','sevenDay','month'].filter(function(k){return sp[k];});"));
+  // numbers only: dollars · tokens · turns per window, labelled by the key's tail
   assert.ok(usageJS.includes("function spendDet(u,det)"));
-  assert.ok(usageJS.includes("if(sp&&spendOnly){"));
-  assert.ok(usageJS.includes("var mx=1;ks.forEach(function(k){if(sp[k].tok>mx)mx=sp[k].tok;});"));
-  assert.ok(usageJS.includes("+fmtTok(v.tok)+' \\u00b7 $'"));
+  assert.ok(usageJS.includes("API'+(d._tail?' \\u2026'+esc(d._tail):'')+' spend</span>"));
+  assert.ok(usageJS.includes("fmtUsd(v.usd)+' \\u00b7 '+fmtTok(v.tok)+' tok \\u00b7 '+(v.turns||0)+' turns</span>"));
   // the tip anchors ABOVE the rail, centered on the CURSOR — never pinned to the container edge
   assert.ok(usageJS.includes("var x=(ev&&typeof ev.clientX==='number')?ev.clientX:(r.left+r.width/2);"));
   assert.ok(usageJS.includes("x-tip.offsetWidth/2"));
@@ -106,12 +97,12 @@ test("the rich tip is the ONE hover surface: no native titles, every account ren
 
 test("every tip string carries data — the narration is gone and stays gone", () => {
   // The de-inking pass (the user 2026-08-08, who found the tip overly verbose): the host name alone
-  // heads a section, the token rows label themselves, config hints live in the docs, and the reader
+  // heads a section, the spend rows label themselves, config hints live in the docs, and the reader
   // is already hovering the bars when the refresh hint shows.
-  const usageJS = KERNEL.split("_LANDING_USAGE_JS = \"\"\"")[1].split('"""')[0];
+  const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
   const code = usageJS.split("\n").map((l) => l.split("//")[0]).join("\n");
   assert.ok(!code.includes("its own allowance"), "the host heading is the host name, bare");
-  assert.ok(!code.includes("one scale"), "the token rows are their own labels");
+  assert.ok(!code.includes("one scale"), "the spend rows are their own labels");
   assert.ok(!code.includes("no budget set"), "no config instructions in a glance surface");
   assert.ok(!code.includes("current usage unknown"), "the ? row already says unknown");
   assert.ok(!code.includes("click the bars"), "the short hint replaced it");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -196,7 +196,7 @@ type ChatEvent = (
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
 type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
-interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authTail?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed.
@@ -2651,7 +2651,9 @@ function renderApiError(ev: Extract<ChatEvent, { kind: "apiError" }>): HTMLEleme
   const st = activeId ? sessions.get(activeId)?.status : undefined;
   // A spent MODEL allowance gets no Retry either (the user 2026-08-01): "retry" re-fails until the model
   // changes or its own window resets, so the card names the fix instead of offering a button that cannot work.
-  const spendCap = !!st?.apiSpendLimit || !!st?.apiModelLimit;
+  // A dead CREDENTIAL is the same shape (the user 2026-08-08, per-session auth): retrying re-presents the
+  // broken login/key forever — the fix is /login, the key, or switching which one the session bills.
+  const spendCap = !!st?.apiSpendLimit || !!st?.apiModelLimit || !!st?.apiAuthErr;
   if (!spendCap) {
     const retry = el("button", "apierror-retry") as HTMLButtonElement;
     retry.textContent = "Retry now";
@@ -2747,7 +2749,7 @@ function apiRetryTick(): void {
     // never auto-retried — the card asks you to raise it instead (the global pause it engages also gates this).
     // A spent MODEL allowance (apiModelLimit) is out for the same reason: every retry re-fails until the
     // user switches model or tops up, and the card says exactly that (the user 2026-08-01).
-    sessions.forEach((s, id) => { if (s.status.state === "blocked" && !s.status.retrySuppressed && !s.status.apiSpendLimit && !s.status.apiModelLimit) blocked.add(id); });
+    sessions.forEach((s, id) => { if (s.status.state === "blocked" && !s.status.retrySuppressed && !s.status.apiSpendLimit && !s.status.apiModelLimit && !s.status.apiAuthErr) blocked.add(id); });
     apiRetryNext.forEach((_, id) => { if (!blocked.has(id)) apiRetryNext.delete(id); });   // recovered / suppressed → stop
     blocked.forEach((id) => {
       // The kernel owns the cadence now (the user 2026-07-29): it backs each outage's attempts off up to
@@ -3513,7 +3515,7 @@ function renderTabs() {
     // "blocked" is an API error. An on-YOU one — "prompt is too long" (compact), a monthly spend cap (raise it,
     // the user 2026-07-14), or a spent model allowance (switch model, the user 2026-08-01) — is alarm-red dashed; a TRANSIENT API error is auto-retrying and needs no attention → the
     // amber retrying treatment, not red (the user 2026-06-29).
-    else if (st === "blocked") tab.classList.add((s.status.apiTooLong || s.status.apiSpendLimit || s.status.apiModelLimit) ? "tab-blocked" : "tab-retrying");
+    else if (st === "blocked") tab.classList.add((s.status.apiTooLong || s.status.apiSpendLimit || s.status.apiModelLimit || s.status.apiAuthErr) ? "tab-blocked" : "tab-retrying");
     else if (st === "awaiting") tab.classList.add("tab-awaiting");
     else if (st === "retrying") tab.classList.add("tab-retrying");       // amber: soft-blocked on an API auto-retry
     else if (st === "compacting" || st === "clearing") tab.classList.add("tab-compacting");   // both: a context op in flight
@@ -4231,7 +4233,42 @@ let pickerListHost = "";
 
 function requestSessionList(host: string): void {
   pickerListHost = host;
+  // the billing choices on screen belong to the host that just stopped being selected — hide the auth
+  // row until ITS kernel's sessionList answers with its own availability (the same staleness rule the
+  // dir status follows; an older kernel never answers with one and the row simply stays away)
+  pickerAuthAvail = null;
+  syncPickerAuth();
   if (vscodeApi) vscodeApi.postMessage({ type: "requestSessions", host });
+}
+
+// Per-session BILLING for a NEW session (the user 2026-08-08): login vs the API key the selected host's
+// manager environment carries. The row exists only when that host offers BOTH (authAvail on its
+// sessionList reply) AND the backend toggle says SDK (a tmux session's CLI lives in the tmux server's
+// environment, which the kernel does not control) — otherwise it disappears entirely.
+let pickerAuthAvail: { login?: boolean; key?: boolean; tail?: string; default?: string } | null = null;
+
+function syncPickerAuth(): void {
+  const wrap = document.querySelector("#picker .picker-auth") as HTMLElement | null;
+  if (!wrap) return;
+  const beSel = document.querySelector("#picker .picker-backend:not(.picker-host):not(.picker-auth) .picker-be-opt.sel") as HTMLElement | null;
+  const a = pickerAuthAvail;
+  const show = !pickMode && !!(a && a.login && a.key) && (beSel?.dataset.be || loadSettings().backend) === "sdk";
+  wrap.style.display = show ? "" : "none";
+  if (!show) return;
+  const keyBtn = wrap.querySelector('.picker-be-opt[data-auth="key"]') as HTMLElement | null;
+  if (keyBtn) keyBtn.textContent = a!.tail ? `API …${a!.tail}` : "API key";   // name WHICH key, never the key
+  // seed the selection from the host's default only when nothing is selected yet this open
+  if (!wrap.querySelector(".picker-be-opt.sel")) {
+    const def = a!.default === "key" ? "key" : "login";
+    wrap.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", (x as HTMLElement).dataset.auth === def));
+  }
+}
+
+// the picked billing for the create payload — "" when the row is hidden (kernel default applies)
+function pickerAuthChoice(): string {
+  const wrap = document.querySelector("#picker .picker-auth") as HTMLElement | null;
+  if (!wrap || wrap.style.display === "none") return "";
+  return (wrap.querySelector(".picker-be-opt.sel") as HTMLElement | null)?.dataset.auth || "";
 }
 
 function pickerHost(): string {
@@ -4372,7 +4409,7 @@ function dirKey(e: KeyboardEvent): boolean {
 // warned into a toast the "Opening…" cue was covering, so the create looked like it silently did
 // nothing for 30 seconds (the user 2026-07-28). The request is remembered so "Create it" can re-send
 // exactly the same create with mkdir set, host and backend included.
-interface CreateReq { name: string; backend: string; dir: string; host: string }
+interface CreateReq { name: string; backend: string; dir: string; host: string; auth?: string }
 let lastCreate: CreateReq | null = null;
 
 function startCreate(req: CreateReq, mkdir = false): void {
@@ -4463,6 +4500,21 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     };
     beWrap.append(beLabel, mkBe("sdk", "SDK", "Runs via the Claude Agent SDK."),   // not "headless" — same full chat UI (the user 2026-07-12)
                   mkBe("tmux", "tmux", "Drives a real terminal pane (tmux)."));   // SDK first — the de-facto default (the user 2026-07-02)
+    // the billing row exists only for SDK sessions — re-decide on every backend toggle
+    beWrap.addEventListener("click", () => syncPickerAuth());
+    // per-session BILLING row (the user 2026-08-08): Login | API …wxyz, shown only when the selected
+    // host offers both (see syncPickerAuth); the same segmented-toggle grammar as Backend above.
+    const auWrap = el("div", "picker-backend picker-auth");
+    auWrap.style.display = "none";   // hidden until a sessionList reply proves both choices exist
+    const auLabel = el("span", "picker-backend-label"); auLabel.textContent = "Billing";
+    const mkAu = (val: string, txt: string, tip: string) => {
+      const b = el("button", "picker-be-opt") as HTMLButtonElement;
+      b.type = "button"; b.textContent = txt; b.title = tip; b.dataset.auth = val;
+      b.addEventListener("click", () => auWrap.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", x === b)));
+      return b;
+    };
+    auWrap.append(auLabel, mkAu("login", "Login", "Bill this session to the machine's Claude login (subscription usage)."),
+                  mkAu("key", "API key", "Bill this session to the API key the manager's environment carries (per-token)."));
     // per-session HOST picker (federation, the user 2026-07-02): local | each attached SSH host — the new
     // session is created BY that host's kernel (over its tunnel) and appears prefixed `host:name`. The
     // options are rebuilt on every open (hosts attach/detach live); the row hides with no hosts attached.
@@ -4494,8 +4546,11 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       const beSel = beWrap.querySelector(".picker-be-opt.sel") as HTMLElement | null;
       // host: local ("") or an attached SSH host — the federation manager routes createSession there.
       const hostSel = (hostWrap.querySelector(".picker-be-opt.sel") as HTMLElement | null)?.dataset.host || "";
+      // billing: the picker's Billing row when it is showing (both choices real on that host); ""
+      // omits the field and the kernel's own default stands (the user 2026-08-08)
+      const auth = pickerAuthChoice();
       startCreate({ name, backend: beSel?.dataset.be || loadSettings().backend,
-                    dir: dirInput.value.trim(), host: hostSel });
+                    dir: dirInput.value.trim(), host: hostSel, ...(auth ? { auth } : {}) });
     });
     const openAll = el("button", "picker-action");
     openAll.textContent = "↗ Open all running sessions";
@@ -4510,6 +4565,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     box.appendChild(list);
     box.appendChild(dirWrap);
     box.appendChild(beWrap);
+    box.appendChild(auWrap);
     box.appendChild(hostWrap);
     box.appendChild(actions);
     overlay.appendChild(box);
@@ -4523,11 +4579,16 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   if (actions) actions.style.display = pick ? "none" : "";
   const dirWrap = overlay.querySelector(".picker-dir") as HTMLElement | null;
   if (dirWrap) dirWrap.style.display = pick ? "none" : "";   // dir only matters when creating, not picking
-  const beWrapEl = overlay.querySelector(".picker-backend:not(.picker-host)") as HTMLElement | null;
+  const beWrapEl = overlay.querySelector(".picker-backend:not(.picker-host):not(.picker-auth)") as HTMLElement | null;
   if (beWrapEl) {   // reset the backend toggle to the gear default each open (overridable for this session)
     beWrapEl.style.display = pick ? "none" : "";
     const def = loadSettings().backend || "tmux";
     beWrapEl.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", (x as HTMLElement).dataset.be === def));
+  }
+  const auWrapEl = overlay.querySelector(".picker-auth") as HTMLElement | null;
+  if (auWrapEl) {   // fresh open: forget last time's pick + availability; the local sessionList reply re-arms it
+    auWrapEl.style.display = "none";
+    auWrapEl.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.remove("sel"));
   }
   const hostWrapEl = overlay.querySelector(".picker-host") as HTMLElement | null;
   if (hostWrapEl) {   // rebuild the host options each open (attach/detach is live); hide with no remotes
@@ -6704,7 +6765,7 @@ function elapsedMs(sinceMs: number | null): string {
 // Each value is a little dropdown: picking an entry has the host inject the matching
 // /model or /effort slash command into the session's pane; the label then updates
 // when the TUI's statusline republishes the tmux vars (meta-pending bridges the gap).
-type MetaKind = "mode" | "model" | "effort" | "fast";
+type MetaKind = "mode" | "model" | "effort" | "fast" | "auth";
 // Model + effort choices come from the kernel's /models — the ONE list shared with the timeline lanes and the
 // judge-tier settings (the user 2026-07-02, who wanted one shared code path, not hardcoded in multiple places), so
 // the client holds no model literals (mirrors paletteColors above). Populated in place on load so META_CHOICES
@@ -6731,6 +6792,14 @@ const FAST_CHOICES: { label: string; value: string }[] = [
   { label: "On", value: "on" },
   { label: "Off", value: "off" },
 ];
+// Per-session billing (the user 2026-08-08): the Claude login vs the API key the manager's environment
+// carries. The badge exists only when the session REPORTS a choice (st.auth) — the kernel emits it only
+// when the machine actually offers BOTH, so a one-auth machine shows no dead selector at all. The key
+// entry's menu label carries the key's last 4 (st.authTail) so you can tell WHICH key it is.
+const AUTH_CHOICES: { label: string; value: string }[] = [
+  { label: "Login", value: "login" },
+  { label: "API key", value: "key" },
+];
 // the fast-mode state ("on"/"off"/"cooldown") → the badge label
 function prettyFast(f: string | undefined): string {
   switch ((f || "").toLowerCase()) {
@@ -6738,6 +6807,10 @@ function prettyFast(f: string | undefined): string {
     case "cooldown": return "Fast cooldown";   // rate-limited: the CLI resumes fast mode when the limit resets
     default: return "Fast off";
   }
+}
+// the per-session billing choice → the badge label; the key wears its own last 4
+function prettyAuth(st: Status): string {
+  return (st.auth || "").toLowerCase() === "key" ? (st.authTail ? `API …${st.authTail}` : "API key") : "Login";
 }
 // the @claude-permission-mode var → a short readable badge label
 function prettyMode(m: string | undefined): string {
@@ -6751,11 +6824,12 @@ function prettyMode(m: string | undefined): string {
   }
 }
 const META_CHOICES: Record<MetaKind, { label: string; value: string }[]> = {
-  mode: MODE_CHOICES, model: MODEL_CHOICES, effort: EFFORT_CHOICES, fast: FAST_CHOICES,
+  mode: MODE_CHOICES, model: MODEL_CHOICES, effort: EFFORT_CHOICES, fast: FAST_CHOICES, auth: AUTH_CHOICES,
 };
 // the live value of a meta kind for the active session
 function metaCurrent(kind: MetaKind, st: Status): string {
-  return (kind === "model" ? st.model : kind === "effort" ? st.effort : kind === "fast" ? st.fast : st.mode) || "";
+  return (kind === "model" ? st.model : kind === "effort" ? st.effort : kind === "fast" ? st.fast
+    : kind === "auth" ? st.auth : st.mode) || "";
 }
 
 // Is this menu entry the session's current value? Effort matches exactly; the
@@ -6763,6 +6837,7 @@ function metaCurrent(kind: MetaKind, st: Status): string {
 function isCurrentMeta(kind: MetaKind, st: Status, value: string): boolean {
   if (kind === "effort") return (st.effort || "").toLowerCase() === value;
   if (kind === "fast") return (st.fast || "").toLowerCase() === value;   // "cooldown" marks neither entry
+  if (kind === "auth") return (st.auth || "").toLowerCase() === value;
   if (kind === "mode") {
     const m = (st.mode || "").toLowerCase();
     if (value === "default") return m === "" || m === "default" || m === "normal";
@@ -6807,6 +6882,7 @@ function metaButton(kind: MetaKind, text: string): HTMLElement {
   btn.title = kind === "model" ? "change model (sends /model)"
     : kind === "effort" ? "change thinking effort (sends /effort)"
     : kind === "fast" ? "toggle fast mode (sends /fast)"
+    : kind === "auth" ? "switch which account this session bills (login vs API key; reconnects to apply)"
     : "change permission mode (shift+tab cycle)";
   btn.addEventListener("click", (e) => { e.stopPropagation(); toggleMetaMenu(kind, btn); });
   return btn;
@@ -6825,9 +6901,10 @@ function metaColor(kind: MetaKind, st: Status): string {
 // Build or refresh the model/effort buttons inside #spinner-meta. Called from
 // updateStatusline (fresh container) and the 1s ticker (label refresh in place).
 function syncMetaControls(meta: HTMLElement, st: Status) {
-  // order left→right: mode · model · effort · fast — the mode selector sits LEFT of the model name (the
-  // user 2026-06-16); fast is rightmost and exists only when the session reports a state (SDK init).
-  const want = [st.mode ? "mode" : "", st.model ? "model" : "", st.effort ? "effort" : "", st.fast ? "fast" : ""].filter(Boolean).join();
+  // order left→right: mode · model · effort · fast · auth — the mode selector sits LEFT of the model name
+  // (the user 2026-06-16); fast/auth exist only when the session reports them (SDK init / a both-auth
+  // machine), so a machine with one billing choice shows no dead selector (the user 2026-08-08).
+  const want = [st.mode ? "mode" : "", st.model ? "model" : "", st.effort ? "effort" : "", st.fast ? "fast" : "", st.auth ? "auth" : ""].filter(Boolean).join();
   const btns = Array.from(meta.querySelectorAll(".meta-btn")) as HTMLElement[];
   if (btns.map((b) => b.dataset.kind).join() !== want) {
     meta.replaceChildren();
@@ -6835,10 +6912,12 @@ function syncMetaControls(meta: HTMLElement, st: Status) {
     if (st.model) meta.appendChild(metaButton("model", st.model));
     if (st.effort) meta.appendChild(metaButton("effort", st.effort));
     if (st.fast) meta.appendChild(metaButton("fast", prettyFast(st.fast)));
+    if (st.auth) meta.appendChild(metaButton("auth", prettyAuth(st)));
   }
   for (const b of Array.from(meta.querySelectorAll(".meta-btn")) as HTMLElement[]) {
     const kind = b.dataset.kind as MetaKind;
-    const disp = kind === "mode" ? prettyMode(st.mode) : kind === "fast" ? prettyFast(st.fast) : metaCurrent(kind, st);
+    const disp = kind === "mode" ? prettyMode(st.mode) : kind === "fast" ? prettyFast(st.fast)
+      : kind === "auth" ? prettyAuth(st) : metaCurrent(kind, st);
     const label = b.querySelector(".meta-label") as HTMLElement | null;
     // A switching MODEL shows animated dots, not the stale/premature name (the user 2026-07-03): the
     // server drives it (st.modelPending) — event-based, cleared the instant the new model actually lands —
@@ -6846,8 +6925,9 @@ function syncMetaControls(meta: HTMLElement, st: Status) {
     // model resolves live; effort reconnects to apply (--effort is connect-time) — both drive the switching-
     // dots from the server (st.modelPending / st.effortPending), with isMetaPending covering the sub-second
     // before the first server push (the user 2026-07-06).
-    const pending = (kind === "model" && !!st.modelPending) || (kind === "effort" && !!st.effortPending) || isMetaPending(kind, st);
-    const showDots = pending && (kind === "model" || kind === "effort");
+    const pending = (kind === "model" && !!st.modelPending) || (kind === "effort" && !!st.effortPending)
+      || (kind === "auth" && !!st.authPending) || isMetaPending(kind, st);
+    const showDots = pending && (kind === "model" || kind === "effort" || kind === "auth");   // all three apply via a resolve/reconnect the server tracks
     if (label) {
       if (showDots) {
         if (!label.querySelector(".meta-dots")) label.replaceChildren(metaDots());
@@ -6878,11 +6958,12 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement) {
   menu.dataset.kind = kind;
   for (const c of META_CHOICES[kind]) {
     const item = el("div", "meta-item" + (isCurrentMeta(kind, s.status, c.value) ? " current" : ""));
-    item.textContent = c.label;
+    // the key entry names WHICH key by its last 4 (the user 2026-08-08) — same string the badge wears
+    item.textContent = (kind === "auth" && c.value === "key" && s.status.authTail) ? `API …${s.status.authTail}` : c.label;
     item.addEventListener("click", (e) => {
       e.stopPropagation();
       if (activeId && vscodeApi) {
-        vscodeApi.postMessage({ type: kind === "model" ? "setModel" : kind === "effort" ? "setEffort" : kind === "fast" ? "setFast" : "setMode", id: activeId, value: c.value });
+        vscodeApi.postMessage({ type: kind === "model" ? "setModel" : kind === "effort" ? "setEffort" : kind === "fast" ? "setFast" : kind === "auth" ? "setAuth" : "setMode", id: activeId, value: c.value });
         const was = metaCurrent(kind, s.status);
         metaPending.set(`${activeId}:${kind}`, { was, until: Date.now() + 20_000 });
         btn.classList.add("meta-pending");
@@ -8104,6 +8185,10 @@ window.addEventListener("message", (e: MessageEvent) => {
     const from = typeof m.host === "string" ? m.host : "";
     if (from !== pickerListHost) return;
     if (typeof m.defaultDir === "string" && !from) kernelDefaultDir = m.defaultDir;   // the LOCAL default dir
+    // the selected host's billing choices ride its own list reply — this is what arms (or hides) the
+    // picker's Billing row (the user 2026-08-08); an older kernel sends none and the row stays away
+    pickerAuthAvail = (m.authAvail && typeof m.authAvail === "object") ? m.authAvail : null;
+    syncPickerAuth();
     renderPicker(m.items || []);
   }
   else if (m.type === "browseResult" && typeof m.path === "string") {   // native Browse dialog returned a folder

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -92,20 +92,21 @@ export function fmtTok(n: number): string {
   return String(n);
 }
 
-// API-key auth: SPEND windows mirror the subscription bars' grammar exactly — same rows, same labels,
+// API-key SPEND windows mirror the subscription bars' grammar exactly — same rows, same labels,
 // same twin tracks — so flipping between the two auth modes reads instantly (the user 2026-08-04, who
 // asked for "5 hours / week / month, visually similar"). A row FILLS only when spend-budgets.json names
 // that window's budget: the fill is spend-over-budget, and without a cap there is no honest fraction —
 // the row then carries plain dollars in the readout slot and no used-track. Rolling windows (5h/7d)
-// have no reset boundary, so only month-to-date draws the elapsed track. The web landing carries the
-// same builder (kernel.py spendWinsHTML); the two copies must stay in step.
+// have no reset boundary, so only month-to-date draws the elapsed track. Keyed on the spend windows'
+// PRESENCE, not the apiKey flag: with per-session auth a host's payload carries bars AND its key's
+// spend at once (the user 2026-08-08), and the strip should show both, not silently drop the dollars.
 export const SPEND_WINS: Array<[string, string, string]> = [
   ["fiveHour", "5 hours", "5h"],
   ["sevenDay", "7 days", "7d"],
   ["month", "Month", "mo"],
 ];
 export function spendWindows(usage: any, nowS: number): UsageWindow[] {
-  const sp = usage && usage.apiKey && usage.spend;
+  const sp = usage && usage.spend;
   if (!sp) return [];
   const out: UsageWindow[] = [];
   for (const [key, label, short] of SPEND_WINS) {

--- a/vscode-extension/src/pipe-intent.ts
+++ b/vscode-extension/src/pipe-intent.ts
@@ -10,7 +10,7 @@ export const INTENT_OPS: ReadonlySet<string> = new Set([
   "sendMessage", "askFollowUp", "askText", "addCustomAsk", "sendCommand", "rewindSend",
   // explicit clicks that mutate kernel/session state
   "interrupt", "apiRetry", "rewindDelete",
-  "setModel", "setEffort", "setMode", "setFast",
+  "setModel", "setEffort", "setMode", "setFast", "setAuth",
   "renameSession", "endSession", "reviveSession",
   "nodeOverride", "askClear", "undoClear", "cardMove", "cardNotify",
   "answerAsk", "submitAsk", "toggleAsk", "navAsk", "cancelAsk",


### PR DESCRIPTION
Per-session auth (login vs API key) for SDK sessions, plus the usage-rail redesign that makes a mixed machine legible.

**Per-session billing.** The manager env's `ANTHROPIC_API_KEY` is claimed out of `os.environ` once at startup and injected per session at connect. Sessions pick `login` or `key` in the new-session picker (a Billing row) or on the statusline badge; both controls exist only on a machine that actually offers both, and the key is always labelled by its last 4, never shown. Applying reconnects the session, exactly like `/effort`, and `setAuth` parks in the same compaction FIFO. Defaults preserve the pre-selector world: no pick + an ambient key = key.

**Loud failures.** The CLI init's `apiKeySource` is checked against what `_options` launched with; a mismatch hits the problems ring (Log panel). "Not logged in" / invalid-key errors become a new on-you api-error class (`authErr`): red tab, blocked card naming the fix, never auto-retried.

**Rail.** The collapsed rail draws each window once (worst known reading across hosts, `?` only when every reporter rolled) plus one `API …wxyz` cell with 5h + month dollars, numbers only; the spend bar graphs are gone. Hover breaks down per host, where a host can carry its login's windows and its key's spend side by side. `spend.json` buckets grow a `key` sub-count so the API numbers sum only key-billed turns, and `/usage/fleet` emits every reporting host, including key-only hosts the per-account dedup used to drop.

Tests: `tests/test_session_auth.py` (30 cases) and `ui/webview/auth-selector.test.ts` are new; the rail/spend pins were rewritten for the new design. Both suites green: pytest 4057 passed, node 1736 passed, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)