### PR TITLE
The tab hover names its billing, and no fragment of the key reaches a surface

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -140,12 +140,17 @@ both (with one choice there is nothing to pick, so the control is absent):
   reconnects the session to apply (the key rides the launch environment), with
   the same switching-dots the effort badge wears.
 
-The key option is always labelled by the key's last 4 characters (`API …wxyz`)
-so you can tell which key it is; the key itself never appears. A new session
-defaults to the last pick made anywhere, and before any pick to the key when
-one is configured — exactly what an ambient key did before the selector
-existed. tmux sessions are not covered: their CLI lives in the tmux server's
+The key option is labelled plainly `API key` — no fragment of the key, not
+even a last-4 tail, ever reaches a browser or a screen (hosts are told apart
+by name, which is all a mixed setup needs). A new session defaults to the
+last pick made anywhere, and before any pick to the key when one is
+configured — exactly what an ambient key did before the selector existed.
+tmux sessions are not covered: their CLI lives in the tmux server's
 environment, which the kernel does not control.
+
+Each chat tab's hover tooltip carries the same fact as a `Billing` row
+(`API key` or `Login`), so a mixed set of sessions reads at a glance; like
+the selector, the row is absent on a one-auth machine.
 
 Failures are loud rather than silent: a session that lands on the other auth
 than it was launched for (say, a key found through `apiKeyHelper`) is flagged
@@ -155,11 +160,12 @@ auto-retried.
 
 The usage rail reflects a mixed machine: the window bars (5 hours / 7 days /
 Fable 5) are drawn once, aggregated across every connected host's login as the
-worst reading per window, and an `API …wxyz` cell beside them carries the
+worst reading per window, and an `API` cell beside them carries the
 key-billed dollars (5-hour burn and month-to-date, numbers only). Hovering
-breaks both down per host; a host can show its login's windows and its key's
-spend side by side. Only turns whose session billed the key count toward the
-API numbers — a login turn's computed cost is dollars nobody pays.
+breaks both down per host — one column per host, side by side — and a host
+can show its login's windows and its key's spend together. Only turns whose
+session billed the key count toward the API numbers — a login turn's computed
+cost is dollars nobody pays.
 
 ### Install-time switches
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3788,32 +3788,33 @@ def _sdk_problem(text):
     del _SDK_BOOT_PROBLEMS[:-20]
 
 
-def _auth_key_tail():
-    """Last 4 characters of the manager's API key ("" = none) — the label that says WHICH key without
-    saying the key. Cheap: an attribute read off the backend singleton, safe per-push."""
+def _auth_key_present():
+    """Whether the manager's environment carried an API key (now held by the SDK backend). A bool on
+    purpose: no fragment of the key — not even a last-4 tail — leaves the kernel process for a label
+    (the user 2026-08-08, who judged even a tail more key than any surface needs; 'API key' is the
+    display everywhere, and host names already tell keys apart in the per-host hover). Cheap: an
+    attribute read off the backend singleton, safe per-push."""
     be = _sdk()
-    key = str(getattr(be, "work_key", "") or "") if be else ""
-    return key[-4:] if key else ""
+    return bool(str(getattr(be, "work_key", "") or "") if be else "")
 
 
 def _auth_both():
     """True when this machine offers BOTH billing choices (a signed-in login and a manager-env key) —
     the condition for the per-session auth selector to exist anywhere (picker, gear). Cheap per-push:
     _claude_account is mtime-cached and the key is an attribute read."""
-    return bool(_auth_key_tail()) and bool(_claude_account())
+    return _auth_key_present() and bool(_claude_account())
 
 
 def _auth_avail():
-    """Which billing choices this machine can offer a session: {'login','key','tail','default'}. The
+    """Which billing choices this machine can offer a session: {'login','key','default'}. The
     picker and the gear render the auth selector ONLY when both are real — one choice is no choice, so
     the control disappears (the user 2026-08-08). login = the credential store names a signed-in
     account (_claude_account — the same authority the usage bars trust; a stale login still fails
     LOUDLY per session via apiKeySource/authErr rather than being second-guessed here). key = the
     manager's environment carried ANTHROPIC_API_KEY, now held by the SDK backend (work_api_key claimed
-    it out of os.environ). tail = the key's last 4 characters — the label that says WHICH key without
-    saying the key. default = what a fresh session would use absent an explicit pick."""
-    be = _sdk()
-    key = str(getattr(be, "work_key", "") or "") if be else ""
+    it out of os.environ) — a bool only, never any fragment of the key (see _auth_key_present).
+    default = what a fresh session would use absent an explicit pick."""
+    key = _auth_key_present()
     d = {}
     try:
         d = json.loads((jd.STATE / "sdk-defaults.json").read_text())
@@ -3823,8 +3824,7 @@ def _auth_avail():
     default = d.get("auth") if d.get("auth") in ("login", "key") else ("key" if key else "login")
     if default == "key" and not key:
         default = "login"
-    return {"login": bool(_claude_account()), "key": bool(key),
-            "tail": key[-4:] if key else "", "default": default}
+    return {"login": bool(_claude_account()), "key": key, "default": default}
 
 
 def _sdk_problem_count():
@@ -12019,10 +12019,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   "fast": "" if tm.get("fastReason") else tm.get("fast", ""),
                   # which account this session bills ('login'|'key') — present ONLY when this machine
                   # actually offers both (see _auth_both), so the badge disappears rather than showing
-                  # a one-option selector (the user 2026-08-08). authTail labels the key option.
+                  # a one-option selector (the user 2026-08-08). The key is labelled 'API key', never
+                  # any fragment of it (same day: even a last-4 tail is more key than a label needs).
                   "auth": (tm.get("auth", "") if _auth_both() else ""),
                   "authPending": bool(tm.get("authPending")),   # an /auth reconnect applying → badge dots
-                  "authTail": (_auth_key_tail() if _auth_both() else ""),
                   "modelPending": _model_pending_now(sid, tm),   # switching-dots on the model badge until the pick lands, from EITHER surface (the user 2026-07-03)
                   "effortPending": bool(tm.get("effortPending")),   # switching-dots on the effort badge while the /effort reconnect applies (SDK-only; the user 2026-07-06)
                   "ctx": str(tm["context"]) if tm["context"] is not None else "",
@@ -13972,8 +13972,9 @@ def _usage():
             # read identically; _spend_windows always returns all three, zero-filled on a fresh kernel
             # (an empty slot reads as broken — the user 2026-08-04, post-restart). TOTAL sums, not the
             # keyed split: on a no-login machine every turn bills the key, and legacy files predate
-            # the split. apiTail names WHICH key (last 4) — the rail's API label (the user 2026-08-08).
-            return {"apiKey": True, "spend": _spend_windows(), "apiTail": _auth_key_tail(),
+            # the split. The rail's label is the constant 'API' — no fragment of the key travels
+            # (the user 2026-08-08; hosts are told apart by name in the hover, not by key).
+            return {"apiKey": True, "spend": _spend_windows(),
                     "t": o.get("t") if isinstance(o.get("t"), (int, float)) else None,
                     "acct": _claude_account()}
         return None
@@ -13998,11 +13999,10 @@ def _usage():
     # never carry spend (the user 2026-08-08, morning): that held for a machine whose sessions all
     # share one auth; per-session auth (same day, evening) makes one host BOTH, and the key's real
     # dollars belong on the rail next to the login's real %.
-    if _auth_key_tail():
+    if _auth_key_present():
         ksp = _spend_windows(keyed_only=True)
         if any((ksp.get(k) or {}).get("turns") for k in ("fiveHour", "sevenDay", "month")):
             out["spend"] = ksp
-            out["apiTail"] = _auth_key_tail()
     return out
 
 
@@ -17775,7 +17775,6 @@ var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','Month']];
 // hover scaled each window's bar to the largest window, a shape with no meaning, and the budget-fill
 // tracks die with it): the numbers are the information, so the numbers are the rendering.
 function spendDet(u,det){var sp=u&&u.spend;if(!sp||!det)return;
-if(u.apiTail)det._tail=u.apiTail;
 SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='number')return;
 (det._spend=det._spend||{})[w[0]]={label:w[1],usd:seg.usd,tok:seg.tok||0,turns:seg.turns||0};});}
 // One payload's WINDOW detail for the hover (used/elapsed/reset per window). Detail only, no markup:
@@ -17819,18 +17818,16 @@ html+='<div class="ru-w'+(best?'':' ru-unk')+'" data-w="'+w[0]+'">'
 +'</div>';});
 return html;}
 // The API cell (the user 2026-08-08): ONE compact entry for everything key-billed across the fleet,
-// labelled by the key's own last 4 (\u2026wxyz names WHICH key without saying the key; several distinct
-// keys fall back to the bare 'API'), with NUMBERS beside it: the 5h burn and the month-to-date. No
-// bars (see spendDet). The full per-window, per-host breakdown is the hover's job.
-function apiCellHTML(live){var tails={},sum={fiveHour:0,month:0},any=false;
+// with NUMBERS beside it: the 5h burn and the month-to-date. No bars (see spendDet). The label is the
+// constant 'API' \u2014 no fragment of any key, not even a last-4 tail, reaches a surface (the user
+// 2026-08-08, evening: a tail is still key material, and the hover's HOST names already tell whose
+// spend is whose). The full per-window, per-host breakdown is the hover's job.
+function apiCellHTML(live){var sum={fiveHour:0,month:0},any=false;
 live.forEach(function(e){var sp=e.det._spend;if(!sp)return;any=true;
-if(e.det._tail)tails[e.det._tail]=1;
 ['fiveHour','month'].forEach(function(k){if(sp[k])sum[k]+=sp[k].usd;});});
 if(!any)return '';
-var tl=Object.keys(tails);
-var label='API'+(tl.length===1?' \u2026'+esc(tl[0]):'');
 return '<div class="ru-w ru-api">'
-+'<div class=ru-name>'+label+'</div>'
++'<div class=ru-name>API</div>'
 +'<div class=ru-pct>'+fmtUsd(sum.fiveHour)+' 5h \u00b7 '+fmtUsd(sum.month)+' mo</div>'
 +'</div>';}
 // The collapsed rail is the AGGREGATE story (the user 2026-08-08; supersedes the one-set-per-account
@@ -17883,7 +17880,7 @@ return '<div class=ru-tip-win><div class=ru-tip-name><span>'+esc(v.name)+' ('+es
 // host's own bars when it has both (per-session auth).
 if(sp){var ks=['fiveHour','sevenDay','month'].filter(function(k){return sp[k];});
 if(ks.length){
-h+='<div class=ru-tip-win><div class=ru-tip-name><span>API'+(d._tail?' \u2026'+esc(d._tail):'')+' spend</span></div>'
+h+='<div class=ru-tip-win><div class=ru-tip-name><span>API spend</span></div>'
 +ks.map(function(k){var v=sp[k];
 return '<div class=ru-tip-row><span class=ru-tip-k>'+esc(v.label)+'</span>'
 +'<span class=ru-tip-v>'+fmtUsd(v.usd)+' \u00b7 '+fmtTok(v.tok)+' tok \u00b7 '+(v.turns||0)+' turns</span></div>';}).join('')
@@ -17892,8 +17889,14 @@ h+=(d._t?'<div class=ru-tip-age>updated '+fmtAgo(d._t)+'</div>':'');
 return h;}
 function tipHTML(){var sets=LAST||[];if(!sets.length)return '';
 var many=sets.length>1;
-var h=sets.map(function(e){return setHTML(e,many);}).join('');
-return h?h+'<div class=ru-tip-age>click to refresh</div>':'';}
+var blocks=sets.map(function(e){return setHTML(e,many);}).filter(function(b){return b;});
+if(!blocks.length)return '';
+// Hosts sit SIDE BY SIDE, one column each (the user 2026-08-08: the breakdown used to stack every
+// host into one tall pillar; columns put them beside each other so hosts compare at a glance).
+// flex-wrap folds the columns back into a stack when width runs out — the mobile Usage modal
+// reuses this exact HTML, so narrow screens degrade on their own, no second layout.
+var h=many?('<div class=ru-tip-cols>'+blocks.map(function(b){return '<div class=ru-tip-col>'+b+'</div>';}).join('')+'</div>'):blocks[0];
+return h+'<div class=ru-tip-age>click to refresh</div>';}
 // The tip anchors ABOVE the rail, centered on the cursor (the user 2026-08-08: it used to pin to the
 // container's RIGHT edge, nowhere near a hover on the left end of a wide multi-account rail).
 function showTip(ev){var h=tipHTML();
@@ -19131,6 +19134,10 @@ def _landing():
             "padding:8px 10px;font:500 11px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#cfd6dd;"
             "box-shadow:0 5px 18px rgba(0,0,0,0.45);pointer-events:none;line-height:1.4}"
             ".ru-tip-win{margin-bottom:8px}#ru-tip .ru-tip-win:last-child{margin-bottom:0}"
+            # Multi-host breakdown: one COLUMN per host, side by side (the user 2026-08-08 — not one
+            # tall stack). flex-wrap lets the mobile modal (92vw cap) fold back to a stack on its own.
+            ".ru-tip-cols{display:flex;gap:18px;align-items:flex-start;flex-wrap:wrap}"
+            ".ru-tip-col{flex:0 1 auto;min-width:150px}"
             ".ru-tip-name{font-weight:700;color:#e8eef5;display:flex;justify-content:space-between;gap:14px;margin-bottom:3px}"
             ".ru-tip-reset{font-weight:400;opacity:.6;font-size:10px}"
             ".ru-tip-row{display:flex;align-items:center;gap:6px;margin-top:3px}"

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -244,20 +244,21 @@ class SpendKeyedSplit(_Keyed):
 
 
 class UsagePayloadMixed(unittest.TestCase):
-    """_usage() attaches the keyed spend + the key's tail BESIDE the login's bars — only when key
-    turns actually exist, so a host that never uses its key shows nothing extra."""
+    """_usage() attaches the keyed spend BESIDE the login's bars — only when key turns actually
+    exist, so a host that never uses its key shows nothing extra. No key material rides along:
+    the API label is constant, so the payload carries no tail (the user 2026-08-08, evening)."""
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
         self.real_state = km.jd.STATE
         km.jd.STATE = Path(self.d)
-        self.real_tail = km._auth_key_tail
+        self.real_key = km._auth_key_present
         (Path(self.d) / "usage.json").write_text(json.dumps(
             {"t": 1000, "five_hour": {"pct": 40, "resets_at": None}}))   # unstamped = legacy, keeps bars
 
     def tearDown(self):
         km.jd.STATE = self.real_state
-        km._auth_key_tail = self.real_tail
+        km._auth_key_present = self.real_key
 
     def _spend(self, keyed_turns):
         day = time.strftime("%Y-%m-%d")
@@ -268,28 +269,28 @@ class UsagePayloadMixed(unittest.TestCase):
         (Path(self.d) / "spend.json").write_text(json.dumps({"days": {day: b}, "hours": {hour: b}}))
 
     def test_bars_carry_the_keyed_spend_when_key_turns_exist(self):
-        km._auth_key_tail = lambda: "wxyz"
+        km._auth_key_present = lambda: True
         self._spend(keyed_turns=2)
         u = km._usage()
         self.assertTrue(u["fiveHour"], "the login's bars stay the headline")
-        self.assertEqual(u["apiTail"], "wxyz")
         self.assertEqual(u["spend"]["month"]["usd"], 0.5, "keyed-only, never the total")
+        self.assertNotIn("apiTail", u, "no key fragment travels — the rail's label is the constant 'API'")
 
     def test_no_key_turns_or_no_key_means_no_spend_beside_the_bars(self):
-        km._auth_key_tail = lambda: "wxyz"
+        km._auth_key_present = lambda: True
         self._spend(keyed_turns=0)
         self.assertNotIn("spend", km._usage())
-        km._auth_key_tail = lambda: ""
+        km._auth_key_present = lambda: False
         self._spend(keyed_turns=2)
         self.assertNotIn("spend", km._usage())
 
-    def test_the_spend_only_arm_names_the_key_too(self):
-        km._auth_key_tail = lambda: "wxyz"
+    def test_the_spend_only_arm_carries_no_key_material_either(self):
+        km._auth_key_present = lambda: True
         (Path(self.d) / "usage.json").write_text(json.dumps({"t": 1000, "apiKey": True}))
         self._spend(keyed_turns=0)
         u = km._usage()
         self.assertTrue(u["apiKey"])
-        self.assertEqual(u["apiTail"], "wxyz")
+        self.assertNotIn("apiTail", u)
 
 
 class AuthErrorClass(unittest.TestCase):
@@ -326,13 +327,18 @@ class Availability(unittest.TestCase):
         km._sdk = lambda: type("B", (), {"work_key": key})()
         km._claude_account = lambda: acct
 
-    def test_both_gates_the_selector_and_the_tail_names_the_key(self):
+    def test_both_gates_the_selector_and_no_key_material_travels(self):
         self._world(FAKE_KEY, "aaaaaaaaaaaa")
         self.assertTrue(km._auth_both())
-        self.assertEqual(km._auth_key_tail(), "wxyz")
+        self.assertTrue(km._auth_key_present())
         a = km._auth_avail()
-        self.assertEqual((a["login"], a["key"], a["tail"]), (True, True, "wxyz"))
+        self.assertEqual((a["login"], a["key"]), (True, True))
+        # No fragment of the key leaves the kernel — not the key, not even its last-4 tail
+        # (the user 2026-08-08, evening: a tail is still key material; 'API key' is label enough,
+        # and host names already tell keys apart in the per-host hover).
+        self.assertNotIn("tail", a)
         self.assertNotIn(FAKE_KEY, json.dumps(a), "the key itself never travels")
+        self.assertNotIn("wxyz", json.dumps(a), "…and neither does any substring of it")
 
     def test_one_choice_is_no_choice(self):
         self._world("", "aaaaaaaaaaaa")
@@ -344,7 +350,7 @@ class Availability(unittest.TestCase):
         import inspect
         src = inspect.getsource(km.build_session)
         self.assertIn('"auth": (tm.get("auth", "") if _auth_both() else "")', src)
-        self.assertIn('"authTail": (_auth_key_tail() if _auth_both() else "")', src)
+        self.assertNotIn("authTail", src, "the status payload carries the choice, never key material")
 
     def test_the_picker_learns_availability_on_the_session_list(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()

--- a/tests/test_usage_per_account.py
+++ b/tests/test_usage_per_account.py
@@ -161,10 +161,12 @@ class RailRendering(unittest.TestCase):
         self.assertNotIn("class=ru-host>", self.js)
         self.assertIn("if(!best||d.pct>best.pct)best=d;", self.js, "worst known reading wins the bar")
 
-    def test_the_api_cell_is_numbers_with_the_keys_own_tail_and_no_bars(self):
-        # label 'API …wxyz' (one distinct key) or bare 'API'; value = 5h burn + month-to-date dollars;
-        # the spend bar graphs are gone everywhere (the user 2026-08-08: they told you nothing)
-        self.assertIn("'API'+(tl.length===1?' …'+esc(tl[0]):'')", self.js)
+    def test_the_api_cell_is_numbers_under_a_constant_label_and_no_bars(self):
+        # a bare 'API' label — never any fragment of the key, not even a last-4 tail (the user
+        # 2026-08-08, evening); value = 5h burn + month-to-date dollars; the spend bar graphs are
+        # gone everywhere (same day, morning: they told you nothing)
+        self.assertIn("'<div class=ru-name>API</div>'", self.js)
+        self.assertNotIn("_tail", self.js)
         self.assertIn("fmtUsd(sum.fiveHour)+' 5h · '+fmtUsd(sum.month)+' mo</div>'", self.js)
         self.assertNotIn("spendColor", self.js)
         self.assertNotIn("spendWinsHTML", self.js)
@@ -177,7 +179,7 @@ class RailRendering(unittest.TestCase):
         # and the spend rows are numbers only — no track span
         self.assertIn("function winDet(u,det)", self.js)
         self.assertIn("winDet(r.usage,det);spendDet(r.usage,det);", self.js)
-        self.assertIn("API'+(d._tail?' …'+esc(d._tail):'')+' spend</span>", self.js)
+        self.assertIn("<span>API spend</span>", self.js)
         self.assertIn("' tok · '+(v.turns||0)+' turns</span>", self.js)
 
     def test_the_account_wide_notices_read_off_THIS_machine(self):

--- a/ui/webview/auth-selector.test.ts
+++ b/ui/webview/auth-selector.test.ts
@@ -5,7 +5,9 @@
 //     (authAvail) and shown only while the backend toggle says SDK;
 //   * the statusline auth badge, present only when the kernel emits st.auth (it gates on _auth_both),
 //     posting setAuth and wearing switching-dots while the applying reconnect is pending.
-// The key is always named by its LAST 4 (…wxyz) — which key, never the key.
+// The key is labelled plainly 'API key' — NO key material anywhere: not the key, not even a last-4
+// tail (the user 2026-08-08, evening: a tail is still key material; hosts are told apart by name).
+// The chat tab's hover tooltip carries the same fact as a Billing row (same day).
 // No jsdom harness → source pins (the repo convention).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -28,8 +30,7 @@ test("the picker's Billing row exists only when the host offers both, and only f
   assert.match(RENDER, /pickerAuthAvail = \(m\.authAvail && typeof m\.authAvail === "object"\) \? m\.authAvail : null;/);
 });
 
-test("the picker's key option names WHICH key, and the pick rides createSession", () => {
-  assert.match(RENDER, /keyBtn\.textContent = a!\.tail \? `API …\$\{a!\.tail\}` : "API key";/);
+test("the pick rides createSession, omitted when the row is hidden", () => {
   // the pick is omitted entirely when the row is hidden — the kernel's own default stands
   assert.match(RENDER, /function pickerAuthChoice\(\): string/);
   assert.match(RENDER, /host: hostSel, \.\.\.\(auth \? \{ auth \} : \{\}\) \}\);/);
@@ -44,14 +45,27 @@ test("the statusline auth badge is a MetaKind gated on the kernel emitting st.au
   assert.match(RENDER, /type MetaKind = "mode" \| "model" \| "effort" \| "fast" \| "auth";/);
   assert.match(RENDER, /st\.auth \? "auth" : ""/);
   assert.match(RENDER, /meta\.appendChild\(metaButton\("auth", prettyAuth\(st\)\)\)/);
-  // the badge and its menu name the key by its tail
-  assert.match(RENDER, /`API …\$\{st\.authTail\}`/);
-  assert.match(RENDER, /kind === "auth" && c\.value === "key" && s\.status\.authTail/);
+  // the badge label is the plain choice, never key material
+  assert.match(RENDER, /return \(st\.auth \|\| ""\)\.toLowerCase\(\) === "key" \? "API key" : "Login";/);
   // the pick posts setAuth, and the applying reconnect drives the switching-dots
   assert.match(RENDER, /kind === "auth" \? "setAuth"/);
   assert.match(RENDER, /\(kind === "auth" && !!st\.authPending\)/);
   assert.match(RENDER, /kind === "model" \|\| kind === "effort" \|\| kind === "auth"\);/);
-  assert.match(RENDER, /auth\?: string; authPending\?: boolean; authTail\?: string;/);
+  assert.match(RENDER, /auth\?: string; authPending\?: boolean;/);
+});
+
+test("no key material reaches the webview — no tail plumbing survives anywhere", () => {
+  // the user 2026-08-08 (evening): even a last-4 tail is more key than any label needs. The kernel
+  // stopped shipping authTail/apiTail/tail, and the client has no code left that could render one.
+  assert.doesNotMatch(RENDER, /authTail/);
+  assert.doesNotMatch(RENDER, /apiTail/);
+  assert.doesNotMatch(RENDER, /a!\.tail/);
+});
+
+test("the chat tab hover carries a Billing row with the same disappearing rule", () => {
+  // whether this tab bills the API key or the login, on the tab tooltip (the user 2026-08-08);
+  // st.auth is both-gated by the kernel, so a one-auth machine shows no row at all
+  assert.match(RENDER, /if \(s\.status\.auth\) rows\.push\(\["Billing", s\.status\.auth === "key" \? "API key" : "Login"\]\);/);
 });
 
 test("setAuth is an intent op — held through a kernel-restart window, never dropped", () => {

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -3,7 +3,8 @@
 // reader nothing, and the budget-fill tracks on the web rail died with it. A host's payload can now
 // carry a login's WINDOWS and its key's SPEND at once (`spend` beside the bars, keyed-only sums), so
 // presence of the spend windows — not the legacy apiKey flag — is what turns the dollars on. The
-// collapsed web rail shows one API cell (key tail + 5h/month dollars); the hover breaks spend down
+// collapsed web rail shows one API cell (constant 'API' label + 5h/month dollars — no key material,
+// not even a last-4 tail, the user 2026-08-08 evening); the hover breaks spend down
 // per window per host. Spend accumulates per ResultMessage (total_cost_usd + usage tokens) into
 // spend.json's day AND hour buckets, each bucket carrying a `key` sub-count for key-billed turns.
 // No jsdom harness → source pins (the repo convention).
@@ -22,13 +23,17 @@ test("the kernel serves spend windows for BOTH payload shapes, keyed-only beside
   // the spend-only view arms on the legacy apiKey marker OR a login-less machine with recorded spend,
   // and keeps TOTAL sums (everything there bills the key; legacy files predate the split)
   assert.ok(KERNEL.includes('if o.get("apiKey") or (not _claude_account() and (jd.STATE / "spend.json").exists()):'));
-  assert.ok(KERNEL.includes('"spend": _spend_windows(), "apiTail": _auth_key_tail(),'));
+  assert.ok(KERNEL.includes('return {"apiKey": True, "spend": _spend_windows(),'));
   // the bars payload attaches the KEYED split only — a login turn's computed cost there would be
   // dollars nobody is billed — and only when key turns actually exist (the user 2026-08-08)
   assert.ok(KERNEL.includes("def _spend_windows(keyed_only=False):"));
   assert.ok(KERNEL.includes("ksp = _spend_windows(keyed_only=True)"));
   assert.match(KERNEL, /if any\(\(ksp\.get\(k\) or \{\}\)\.get\("turns"\) for k in \("fiveHour", "sevenDay", "month"\)\):/);
-  assert.ok(KERNEL.includes('out["apiTail"] = _auth_key_tail()'));
+  // no fragment of the key rides ANY payload (the user 2026-08-08, evening): the tail plumbing is
+  // gone from the kernel wholesale, and the keyed-spend gate is a plain existence check
+  assert.ok(KERNEL.includes("if _auth_key_present():"));
+  assert.ok(!KERNEL.includes("apiTail"), "no key material in any usage payload");
+  assert.ok(!KERNEL.includes("authTail"), "no key material in the status payload either");
   // rolling 5h/7d read the HOUR buckets; month-to-date reads the day ledger
   assert.match(KERNEL, /"fiveHour": _rolling\(5\), "sevenDay": _rolling\(7 \* 24\)/);
   assert.ok(KERNEL.includes("k.startswith(month)"));
@@ -56,11 +61,12 @@ test("VS Code strip: spend rows key on the windows' PRESENCE, one row builder fo
   assert.doesNotMatch(STRIPCSS, /\.ru-spend/);
 });
 
-test("the web rail's API cell is numbers with the key's own tail — no spend bars anywhere", () => {
+test("the web rail's API cell is numbers under a constant label — no spend bars anywhere", () => {
   const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
-  // one compact cell: 'API …wxyz' (several distinct keys fall back to bare 'API'), 5h + month dollars
+  // one compact cell: a bare 'API' label (never any key fragment), 5h + month dollars
   assert.ok(usageJS.includes("function apiCellHTML(live)"));
-  assert.ok(usageJS.includes("'API'+(tl.length===1?' \\u2026'+esc(tl[0]):'')"));
+  assert.ok(usageJS.includes("'<div class=ru-name>API</div>'"));
+  assert.ok(!usageJS.includes("_tail"), "no tail plumbing survives in the rail JS");
   assert.ok(usageJS.includes("fmtUsd(sum.fiveHour)+' 5h \\u00b7 '+fmtUsd(sum.month)+' mo</div>'"));
   // the graph and the budget fills are gone: no spend track, no spend color ramp, no shared scale
   assert.ok(!usageJS.includes("spendColor"), "the budget-fill ramp died with the spend bars");
@@ -83,9 +89,9 @@ test("the rich tip is the ONE hover surface: no native titles, per-host sections
   assert.ok(usageJS.includes("if(!keys.length&&!sp)return '';"));
   assert.ok(!usageJS.includes("spendOnly"), "spend renders for ANY host that has it");
   assert.ok(usageJS.includes("if(sp){var ks=['fiveHour','sevenDay','month'].filter(function(k){return sp[k];});"));
-  // numbers only: dollars · tokens · turns per window, labelled by the key's tail
+  // numbers only: dollars · tokens · turns per window, under a plain 'API spend' heading
   assert.ok(usageJS.includes("function spendDet(u,det)"));
-  assert.ok(usageJS.includes("API'+(d._tail?' \\u2026'+esc(d._tail):'')+' spend</span>"));
+  assert.ok(usageJS.includes("<span>API spend</span>"));
   assert.ok(usageJS.includes("fmtUsd(v.usd)+' \\u00b7 '+fmtTok(v.tok)+' tok \\u00b7 '+(v.turns||0)+' turns</span>"));
   // the tip anchors ABOVE the rail, centered on the CURSOR — never pinned to the container edge
   assert.ok(usageJS.includes("var x=(ev&&typeof ev.clientX==='number')?ev.clientX:(r.left+r.width/2);"));
@@ -93,6 +99,17 @@ test("the rich tip is the ONE hover surface: no native titles, per-host sections
   assert.ok(usageJS.includes("r.top-tip.offsetHeight-8"));
   // the click hint the native title used to carry lives in the tip's footer now
   assert.ok(usageJS.includes("'<div class=ru-tip-age>click to refresh</div>'"));
+});
+
+test("a multi-host breakdown lays hosts SIDE BY SIDE, one column each", () => {
+  // the user 2026-08-09: the per-host breakdown used to stack every host into one tall pillar;
+  // now each host is a flex column, and flex-wrap folds the mobile modal back to a stack on its own
+  const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
+  assert.ok(usageJS.includes("'<div class=ru-tip-cols>'+blocks.map(function(b){return '<div class=ru-tip-col>'+b+'</div>';}).join('')+'</div>'"));
+  // a single host keeps its plain un-columned layout — the wrapper exists only when there is a fleet
+  assert.ok(usageJS.includes("var h=many?"));
+  assert.ok(KERNEL.includes(".ru-tip-cols{display:flex;gap:18px;align-items:flex-start;flex-wrap:wrap}"));
+  assert.ok(KERNEL.includes(".ru-tip-col{flex:0 1 auto;min-width:150px}"));
 });
 
 test("every tip string carries data — the narration is gone and stays gone", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -196,7 +196,7 @@ type ChatEvent = (
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
 type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
-interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authTail?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed.
@@ -3290,6 +3290,10 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   // Backend is a plain labelled FIELD now, under the others (the user 2026-07-08 — no longer a coloured
   // "SDK backend" badge at the top of the tooltip; it reads as one of the session's config fields).
   if (be === "sdk" || be === "tmux") rows.push(["Backend", be === "sdk" ? "SDK" : "tmux"]);
+  // Billing: whether this tab bills the API key or the Claude login (the user 2026-08-08). st.auth
+  // exists only when the machine offers both (kernel _auth_both), so a one-auth machine shows no row —
+  // the selector's own disappearing rule. The label carries no key material, ever.
+  if (s.status.auth) rows.push(["Billing", s.status.auth === "key" ? "API key" : "Login"]);
   for (const [k, v] of rows) {
     const r = el("div", "tab-tip-row");
     const ke = el("span", "tab-tip-k"); ke.textContent = k;
@@ -4245,7 +4249,7 @@ function requestSessionList(host: string): void {
 // manager environment carries. The row exists only when that host offers BOTH (authAvail on its
 // sessionList reply) AND the backend toggle says SDK (a tmux session's CLI lives in the tmux server's
 // environment, which the kernel does not control) — otherwise it disappears entirely.
-let pickerAuthAvail: { login?: boolean; key?: boolean; tail?: string; default?: string } | null = null;
+let pickerAuthAvail: { login?: boolean; key?: boolean; default?: string } | null = null;
 
 function syncPickerAuth(): void {
   const wrap = document.querySelector("#picker .picker-auth") as HTMLElement | null;
@@ -4255,8 +4259,6 @@ function syncPickerAuth(): void {
   const show = !pickMode && !!(a && a.login && a.key) && (beSel?.dataset.be || loadSettings().backend) === "sdk";
   wrap.style.display = show ? "" : "none";
   if (!show) return;
-  const keyBtn = wrap.querySelector('.picker-be-opt[data-auth="key"]') as HTMLElement | null;
-  if (keyBtn) keyBtn.textContent = a!.tail ? `API …${a!.tail}` : "API key";   // name WHICH key, never the key
   // seed the selection from the host's default only when nothing is selected yet this open
   if (!wrap.querySelector(".picker-be-opt.sel")) {
     const def = a!.default === "key" ? "key" : "login";
@@ -4502,7 +4504,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
                   mkBe("tmux", "tmux", "Drives a real terminal pane (tmux)."));   // SDK first — the de-facto default (the user 2026-07-02)
     // the billing row exists only for SDK sessions — re-decide on every backend toggle
     beWrap.addEventListener("click", () => syncPickerAuth());
-    // per-session BILLING row (the user 2026-08-08): Login | API …wxyz, shown only when the selected
+    // per-session BILLING row (the user 2026-08-08): Login | API key, shown only when the selected
     // host offers both (see syncPickerAuth); the same segmented-toggle grammar as Backend above.
     const auWrap = el("div", "picker-backend picker-auth");
     auWrap.style.display = "none";   // hidden until a sessionList reply proves both choices exist
@@ -6795,7 +6797,8 @@ const FAST_CHOICES: { label: string; value: string }[] = [
 // Per-session billing (the user 2026-08-08): the Claude login vs the API key the manager's environment
 // carries. The badge exists only when the session REPORTS a choice (st.auth) — the kernel emits it only
 // when the machine actually offers BOTH, so a one-auth machine shows no dead selector at all. The key
-// entry's menu label carries the key's last 4 (st.authTail) so you can tell WHICH key it is.
+// entry is labelled 'API key', full stop — no fragment of the key, not even a last-4 tail, is shipped
+// or shown (the user 2026-08-08, evening: a tail is still key material and no surface needs it).
 const AUTH_CHOICES: { label: string; value: string }[] = [
   { label: "Login", value: "login" },
   { label: "API key", value: "key" },
@@ -6808,9 +6811,9 @@ function prettyFast(f: string | undefined): string {
     default: return "Fast off";
   }
 }
-// the per-session billing choice → the badge label; the key wears its own last 4
+// the per-session billing choice → the badge label (never any key material)
 function prettyAuth(st: Status): string {
-  return (st.auth || "").toLowerCase() === "key" ? (st.authTail ? `API …${st.authTail}` : "API key") : "Login";
+  return (st.auth || "").toLowerCase() === "key" ? "API key" : "Login";
 }
 // the @claude-permission-mode var → a short readable badge label
 function prettyMode(m: string | undefined): string {
@@ -6958,8 +6961,7 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement) {
   menu.dataset.kind = kind;
   for (const c of META_CHOICES[kind]) {
     const item = el("div", "meta-item" + (isCurrentMeta(kind, s.status, c.value) ? " current" : ""));
-    // the key entry names WHICH key by its last 4 (the user 2026-08-08) — same string the badge wears
-    item.textContent = (kind === "auth" && c.value === "key" && s.status.authTail) ? `API …${s.status.authTail}` : c.label;
+    item.textContent = c.label;
     item.addEventListener("click", (e) => {
       e.stopPropagation();
       if (activeId && vscodeApi) {


### PR DESCRIPTION
Follow-up to #248, from the user's review of the key-tail labels.

- **Chat tab hover: a Billing row.** Each tab's tooltip says which account the session bills (`API key` / `Login`), from the same both-gated `st.auth` the statusline badge reads. One-auth machines show no row — the selector's own disappearing rule.
- **No key material on any surface.** The last-4 tail was still key material, and nothing needed it: hosts are told apart by name in the per-host hover. `_auth_key_tail` becomes `_auth_key_present` (a bool — the kernel no longer slices the key for display at all); `authTail`/`apiTail`/`tail` leave every payload; every label is now plain (`API`, `API key`). Tests pin the absence: no key substring travels.
- **Rail hover: hosts side by side.** The per-host breakdown renders one flex column per host instead of one tall stack; flex-wrap folds the mobile Usage modal back to a stack on its own.

Tests: pytest 4057 passed; node 1739 passed; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)