### PR TITLE
Billing always visible and named; one window vocabulary; Escape closes shell modals

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -131,26 +131,29 @@ a fast-capable one, which the chat shows as the command's own confirmation.
 
 An SDK session can bill either the machine's Claude login (subscription usage)
 or the `ANTHROPIC_API_KEY` the manager's environment carries — per session.
-The choice appears in two places, and only on a machine that actually offers
-both (with one choice there is nothing to pick, so the control is absent):
 
-- the new-session picker's **Billing** row, when the selected host offers both
-  and the backend toggle says SDK;
-- a statusline badge on the session, beside mode/model/effort. Switching
-  reconnects the session to apply (the key rides the launch environment), with
-  the same switching-dots the effort badge wears.
+The new-session picker's **Billing** row states the case whenever the backend
+toggle says SDK: segmented buttons when the selected host offers both choices,
+and with only one real choice, the same spot simply writes out which applies —
+`Login (name@example.com)` or `API key` — so what a session will bill is never
+a mystery. A live session additionally wears a statusline badge for
+*switching*, beside mode/model/effort, and that control keeps the stricter
+rule: it exists only when both choices are real (a one-option selector is
+noise). Switching reconnects the session to apply (the key rides the launch
+environment), with the same switching-dots the effort badge wears.
 
-The key option is labelled plainly `API key` — no fragment of the key, not
-even a last-4 tail, ever reaches a browser or a screen (hosts are told apart
-by name, which is all a mixed setup needs). A new session defaults to the
-last pick made anywhere, and before any pick to the key when one is
-configured — exactly what an ambient key did before the selector existed.
-tmux sessions are not covered: their CLI lives in the tmux server's
+The login is named by its account (the email the credential store records);
+the key option is labelled plainly `API key` — no fragment of the key, not
+even a last-4 tail, ever reaches a browser or a screen. A new session
+defaults to the last pick made anywhere, and before any pick to the key when
+one is configured — exactly what an ambient key did before the selector
+existed. tmux sessions are not covered: their CLI lives in the tmux server's
 environment, which the kernel does not control.
 
-Each chat tab's hover tooltip carries the same fact as a `Billing` row
-(`API key` or `Login`), so a mixed set of sessions reads at a glance; like
-the selector, the row is absent on a one-auth machine.
+Each chat tab's hover tooltip carries the same fact as a `Billing` row —
+`API key`, or `Login (name@example.com)` — whenever the session's backend
+reports it, one-auth machines included; only tmux sessions, whose billing romp
+cannot know, show no row.
 
 Failures are loud rather than silent: a session that lands on the other auth
 than it was launched for (say, a key found through `apiKeyHelper`) is flagged

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2152,7 +2152,9 @@ def _giveup_cause():
     try:
         u = json.loads((STATE / "usage.json").read_text())
         now = time.time()
-        for key, label in (("five_hour", "Session (5h)"), ("seven_day", "Weekly (7d)")):
+        # the windows wear their ONE display name here too (the user 2026-08-09: '5 hours' on the rail
+        # but 'Session (5h)' in this modal was two vocabularies for the same window) — prose-shaped
+        for key, label in (("five_hour", "5-hour"), ("seven_day", "7-day")):
             s = u.get(key) if isinstance(u, dict) else None
             if isinstance(s, dict) and (s.get("pct") or 0) >= 100 and not (s.get("resets_at") and now > s["resets_at"]):
                 names.append(label)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3806,14 +3806,17 @@ def _auth_both():
 
 
 def _auth_avail():
-    """Which billing choices this machine can offer a session: {'login','key','default'}. The
-    picker and the gear render the auth selector ONLY when both are real — one choice is no choice, so
-    the control disappears (the user 2026-08-08). login = the credential store names a signed-in
-    account (_claude_account — the same authority the usage bars trust; a stale login still fails
-    LOUDLY per session via apiKeySource/authErr rather than being second-guessed here). key = the
-    manager's environment carried ANTHROPIC_API_KEY, now held by the SDK backend (work_api_key claimed
-    it out of os.environ) — a bool only, never any fragment of the key (see _auth_key_present).
-    default = what a fresh session would use absent an explicit pick."""
+    """Which billing choices this machine can offer a session: {'login','key','acct','default'}. The
+    picker's Billing row is ALWAYS there for an SDK session (the user 2026-08-09): BUTTONS when both
+    choices are real, and when only one is, the same row simply WRITES OUT which one applies — informative,
+    not a one-option selector (which is what the earlier disappearing rule was really against, the user
+    2026-08-08). login = the credential store names a signed-in account (_claude_account — the same
+    authority the usage bars trust; a stale login still fails LOUDLY per session via apiKeySource/authErr
+    rather than being second-guessed here). key = the manager's environment carried ANTHROPIC_API_KEY,
+    now held by the SDK backend (work_api_key claimed it out of os.environ) — a bool only, never any
+    fragment of the key (see _auth_key_present). acct = the login's display name (_claude_account_label),
+    so 'Login' can say WHICH account it means. default = what a fresh session would use absent an
+    explicit pick."""
     key = _auth_key_present()
     d = {}
     try:
@@ -3824,7 +3827,8 @@ def _auth_avail():
     default = d.get("auth") if d.get("auth") in ("login", "key") else ("key" if key else "login")
     if default == "key" and not key:
         default = "login"
-    return {"login": bool(_claude_account()), "key": key, "default": default}
+    return {"login": bool(_claude_account()), "key": key,
+            "acct": _claude_account_label(), "default": default}
 
 
 def _sdk_problem_count():
@@ -12017,11 +12021,17 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   # no badge — tmux stays "" until its statusline publishes a fast var). A non-empty
                   # disabled_reason means /fast would refuse, so the chat hides the toggle.
                   "fast": "" if tm.get("fastReason") else tm.get("fast", ""),
-                  # which account this session bills ('login'|'key') — present ONLY when this machine
-                  # actually offers both (see _auth_both), so the badge disappears rather than showing
-                  # a one-option selector (the user 2026-08-08). The key is labelled 'API key', never
-                  # any fragment of it (same day: even a last-4 tail is more key than a label needs).
-                  "auth": (tm.get("auth", "") if _auth_both() else ""),
+                  # which account this session bills ('login'|'key') — ALWAYS reported when the backend
+                  # knows it (the user 2026-08-09: the tab hover says Billing even on a one-auth
+                  # machine; tmux sessions report nothing, honestly — their CLI's env is not romp's).
+                  # The key is labelled 'API key', never any fragment of it (2026-08-08: even a last-4
+                  # tail is more key than a label needs); authAcct names WHICH login account.
+                  "auth": tm.get("auth", ""),
+                  # whether this machine offers BOTH choices — the gate for the CONTROLS (statusline
+                  # badge menu / picker buttons); display no longer hangs on it (the user 2026-08-09)
+                  "authBoth": _auth_both(),
+                  # the login's display name, shown beside 'Login' (the user 2026-08-09); "" when no login
+                  "authAcct": _claude_account_label(),
                   "authPending": bool(tm.get("authPending")),   # an /auth reconnect applying → badge dots
                   "modelPending": _model_pending_now(sid, tm),   # switching-dots on the model badge until the pick lands, from EITHER surface (the user 2026-07-03)
                   "effortPending": bool(tm.get("effortPending")),   # switching-dots on the effort badge while the /effort reconnect applies (SDK-only; the user 2026-07-06)
@@ -13889,7 +13899,7 @@ def _state_intervals(sid, want, now):
     return out
 
 
-_ACCT_CACHE = {"mtime": -1.0, "val": ""}
+_ACCT_CACHE = {"mtime": -1.0, "val": "", "label": ""}
 
 
 def _claude_account():
@@ -13902,23 +13912,44 @@ def _claude_account():
     emailAddress — the comparison only needs "same or not", and an email is a personal identifier that
     would then travel to every federated host, sit in a payload and show up in any screenshot of the
     bars. A digest answers the question and carries nothing back. Cached on the file's mtime.
+
+    (_claude_account_label below is the deliberate, narrower exception: the login's own name, for the
+    login-facing UI rows the user asked to carry it. Cross-host equality stays on this digest.)
     """
+    _acct_read()
+    return _ACCT_CACHE["val"]
+
+
+def _claude_account_label():
+    """The signed-in login's display name — emailAddress (the identity `claude /login` itself shows),
+    falling back to displayName — or "" when there is none. FOR DISPLAY beside 'Login': the new-session
+    picker's Billing row and the chat tab's hover (the user 2026-08-09, who wanted to see WHICH account
+    'Login' means). The one sanctioned account-identity payload field; anything that only needs
+    same-or-not (the rail's per-host dedup) keeps the _claude_account digest, which carries nothing."""
+    _acct_read()
+    return _ACCT_CACHE["label"]
+
+
+def _acct_read():
+    """Refresh _ACCT_CACHE (digest + label) from ~/.claude.json, mtime-cached — one stat per push."""
     p = os.path.expanduser("~/.claude.json")
     try:
         m = os.stat(p).st_mtime
     except OSError:
-        return ""
+        _ACCT_CACHE["mtime"], _ACCT_CACHE["val"], _ACCT_CACHE["label"] = -1.0, "", ""
+        return
     if _ACCT_CACHE["mtime"] == m:
-        return _ACCT_CACHE["val"]
-    val = ""
+        return
+    val = label = ""
     try:
-        uuid = ((json.loads(open(p, encoding="utf-8").read()) or {}).get("oauthAccount") or {}).get("accountUuid")
+        oa = (json.loads(open(p, encoding="utf-8").read()) or {}).get("oauthAccount") or {}
+        uuid = oa.get("accountUuid")
         if uuid:
             val = hashlib.sha256(str(uuid).encode("utf-8")).hexdigest()[:12]
+        label = str(oa.get("emailAddress") or oa.get("displayName") or "")
     except Exception:
-        val = ""
-    _ACCT_CACHE["mtime"], _ACCT_CACHE["val"] = m, val
-    return val
+        val = label = ""
+    _ACCT_CACHE["mtime"], _ACCT_CACHE["val"], _ACCT_CACHE["label"] = m, val, label
 
 
 def _usage():
@@ -17695,7 +17726,34 @@ back.addEventListener('click',function(e){if(e.target===back)close();});
 if(x)x.addEventListener('click',close);
 if(clearBtn)clearBtn.addEventListener('click',function(){NOTES=[];save();renderList();paint();});
 window.__rompOpenErrs=open;   // the mobile bar's bell routes here (no rail on mobile)
+window.__rompCloseErrs=close;   // Escape routes here (_LANDING_ESC_JS) — close owns the state cleanup
 paint();})();
+"""
+
+
+# Escape closes the TOPMOST open shell modal (the user 2026-08-09: the usage/network/Log panels could
+# only be clicked away; Escape did nothing whenever focus sat inside a pane iframe, because a keydown
+# never crosses the iframe boundary). Same dual wiring as the palette (palette-main.ts) and the
+# Alt+Arrow nav (_LANDING_FOCUS_JS): capture on the shell document AND on every same-origin pane
+# document, re-attached on every iframe (re)load. Each panel exposes its OWN close (their state
+# cleanup lives in those closures); this block only decides which panel Escape means, topmost first
+# (usage z300 > Log z210 > net z200). With no shell modal open it touches nothing, so pane-local
+# Escapes (dialogs, menus inside the chat) keep working.
+_LANDING_ESC_JS = """
+(function(){
+function onEsc(e){if(e.key!=='Escape')return;
+var closed=false,ru=document.getElementById('ru-back');
+if(ru&&ru.classList.contains('on')&&window.__rompUsageClose){window.__rompUsageClose();closed=true;}
+else{var er=document.getElementById('rerr-back');
+if(er&&!er.hidden&&window.__rompCloseErrs){window.__rompCloseErrs();closed=true;}
+else{var nt=document.getElementById('rnet-back');
+if(nt&&!nt.hidden&&window.__rompCloseNet){window.__rompCloseNet();closed=true;}}}
+if(closed){e.preventDefault();e.stopPropagation();}}
+document.addEventListener('keydown',onEsc,true);
+['f-chat','f-fleet','f-feed','f-timeline'].forEach(function(id){var f=document.getElementById(id);if(!f)return;
+var wire=function(){try{if(f.contentDocument)f.contentDocument.addEventListener('keydown',onEsc,true);}catch(e){}};
+f.addEventListener('load',wire);wire();});
+})();
 """
 
 
@@ -17717,9 +17775,13 @@ var m=Math.round(dt/60);if(m<60)return m+'m ago';var h=Math.floor(m/60);m-=h*60;
 return(h<24?h+'h '+(m?m+'m ':''):Math.floor(h/24)+'d ')+'ago';}
 function esc(s){return String(s).replace(/[&<>"]/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});}
 // [key, spanSec, shortTag (tooltip), name (tooltip), label (bottom-bar, expanded — plenty of horizontal room)]
-var WINS=[['fiveHour',5*3600,'5h','Session','5 hours'],
-          ['sevenDay',7*86400,'7d','Weekly','7 days'],
-          ['fable',7*86400,'F5','Fable 5','Fable 5']];
+// ONE display name per window, worn EVERYWHERE it appears — the collapsed bars, the hover's window
+// sections, the API cell's designators (the user 2026-08-09: '5 hours' on the bars but '5h' on the API
+// numbers, plus a third 'Session (5h)' in the hover, was three vocabularies for one thing; same words,
+// same font, same left-of-value position across all of it).
+var WINS=[['fiveHour',5*3600,'5 hours'],
+          ['sevenDay',7*86400,'7 days'],
+          ['fable',7*86400,'Fable 5']];
 // ROWS is one entry per HOST whose usage is known, local first (see /usage/fleet); LAST is the per-host
 // tooltip detail for the ones drawn into the aggregate; SELF names this machine for its hover heading
 // when there is more than one host.
@@ -17757,7 +17819,7 @@ if(window.__rompNotify)window.__rompNotify('judge',nc+' '+noun+" couldn't be sum
 var lim=u&&u.limited,on=!!(lim&&(lim.fiveHour||lim.sevenDay));
 var sig=on?((lim.fiveHour?'5':'')+(lim.sevenDay?'7':'')):'';
 if(!on){_limPut('');}   // fully cleared -> forget the logged signature so a future limit logs again
-else if(sig!==_limGet()){_limPut(sig);var names=[];if(lim.fiveHour)names.push('Session (5h)');if(lim.sevenDay)names.push('Weekly (7d)');
+else if(sig!==_limGet()){_limPut(sig);var names=[];if(lim.fiveHour)names.push('5-hour');if(lim.sevenDay)names.push('7-day');
 if(window.__rompNotify)window.__rompNotify('limit',names.join(' and ')+' usage limit reached \u2014 retries paused until it resets');}}
 function hasBars(u){return !!(u&&(u.fiveHour||u.sevenDay||u.fable));}
 // API-key spend rides the payload's `spend` windows. It used to require the apiKey flag (a no-login
@@ -17768,7 +17830,7 @@ function hasSpend(u){return !!(u&&u.spend&&u.spend.fiveHour);}
 function fmtTok(n){if(n>=1e9)return (n/1e9).toFixed(1).replace(/\.0$/,'')+'B';
 if(n>=1e6)return (n/1e6).toFixed(1).replace(/\.0$/,'')+'M';
 if(n>=1e3)return (n/1e3).toFixed(1).replace(/\.0$/,'')+'k';return String(n);}
-function fmtUsd(v){return '$'+(v<100?v.toFixed(2):String(Math.round(v)));}
+function fmtUsd(v){return '$'+String(Math.round(v));}   // whole dollars everywhere — no cents (the user 2026-08-09)
 var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','Month']];
 // The per-host SPEND detail for the rich hover: plain NUMBERS per window (dollars, tokens, turns).
 // No bars anywhere for spend (the user 2026-08-08: the spend bar graphs told you nothing. The old
@@ -17789,7 +17851,7 @@ WINS.forEach(function(w){var seg=u[w[0]];if(!seg)return;
 var rolled=!!(seg.resetsAt&&nowS>seg.resetsAt),pct=Math.max(0,Math.min(100,seg.pct||0));
 var col=(seg.color&&seg.color.length===3)?('rgb('+seg.color.join(',')+')'):'#54B204';   // selected colormap (server-computed)
 var tp=(!rolled&&seg.resetsAt&&w[1])?Math.max(0,Math.min(100,Math.round((nowS-(seg.resetsAt-w[1]))/w[1]*100))):null;
-det[w[0]]={name:w[3],span:w[2],pct:pct,col:col,tp:tp,unk:rolled,ago:(rolled?fmtAgo(seg.resetsAt):null),reset:(!rolled&&seg.resetsAt)?fmtR(seg.resetsAt):null};});}
+det[w[0]]={name:w[2],pct:pct,col:col,tp:tp,unk:rolled,ago:(rolled?fmtAgo(seg.resetsAt):null),reset:(!rolled&&seg.resetsAt)?fmtR(seg.resetsAt):null};});}
 // ONE aggregated set of bars for every account at once (the user 2026-08-08: never repeat the windows
 // per host; say '5 hours' once). Per window, the WORST known reading across the fleet: the windows are
 // allowances and the binding one is the fullest; each host's own number lives in the hover. A window
@@ -17808,7 +17870,7 @@ if(!best&&!anyRolled)return;
 // asserts a value we do not have; the length itself is the lie. Its slot holds a single '?' so the
 // rows stay aligned, and the last-known number lives in the hover, labelled as such.
 html+='<div class="ru-w'+(best?'':' ru-unk')+'" data-w="'+w[0]+'">'
-+'<div class=ru-name>'+w[4]+'</div>'
++'<div class=ru-name>'+w[2]+'</div>'
 +(best?('<div class=ru-bars>'
 +'<div class=ru-track><i class=ru-fill style="width:'+best.pct+'%;background:'+best.col+'"></i></div>'
 +'<div class=ru-track><i class=ru-fill style="width:'+(best.tp||0)+'%;background:#6b7a8c"></i></div>'
@@ -17817,18 +17879,23 @@ html+='<div class="ru-w'+(best?'':' ru-unk')+'" data-w="'+w[0]+'">'
 :'<div class=ru-bars><div class=ru-qmark>?</div></div>')
 +'</div>';});
 return html;}
-// The API cell (the user 2026-08-08): ONE compact entry for everything key-billed across the fleet,
-// with NUMBERS beside it: the 5h burn and the month-to-date. No bars (see spendDet). The label is the
-// constant 'API' \u2014 no fragment of any key, not even a last-4 tail, reaches a surface (the user
-// 2026-08-08, evening: a tail is still key material, and the hover's HOST names already tell whose
-// spend is whose). The full per-window, per-host breakdown is the hover's job.
-function apiCellHTML(live){var sum={fiveHour:0,month:0},any=false;
+// The API cell (the user 2026-08-08): ONE compact entry for everything key-billed across the fleet \u2014
+// the 5-hour burn and the month-to-date, dollars AND tokens (the user 2026-08-09, who wanted the
+// tokens kept beside the spend). No bars (see spendDet). It wears the window cells' own grammar
+// (same day): each designator is the window's ONE display name, in the name font, LEFT of its value \u2014
+// never a '$12 5h' with the window trailing the number in a second vocabulary. The label is the
+// constant 'API' \u2014 no fragment of any key, not even a last-4 tail, reaches a surface (2026-08-08,
+// evening: a tail is still key material, and the hover's HOST names already tell whose spend is
+// whose). The full per-window, per-host breakdown is the hover's job.
+function apiCellHTML(live){var sum={fiveHour:{usd:0,tok:0},month:{usd:0,tok:0}},any=false;
 live.forEach(function(e){var sp=e.det._spend;if(!sp)return;any=true;
-['fiveHour','month'].forEach(function(k){if(sp[k])sum[k]+=sp[k].usd;});});
+['fiveHour','month'].forEach(function(k){var s=sp[k];if(s){sum[k].usd+=s.usd;sum[k].tok+=s.tok||0;}});});
 if(!any)return '';
+var seg=function(k,lbl){return '<div class=ru-name>'+lbl+'</div>'
++'<div class=ru-pct>'+fmtUsd(sum[k].usd)+' \u00b7 '+fmtTok(sum[k].tok)+' tok</div>';};
 return '<div class="ru-w ru-api">'
 +'<div class=ru-name>API</div>'
-+'<div class=ru-pct>'+fmtUsd(sum.fiveHour)+' 5h \u00b7 '+fmtUsd(sum.month)+' mo</div>'
++seg('fiveHour','5 hours')+seg('month','Month')
 +'</div>';}
 // The collapsed rail is the AGGREGATE story (the user 2026-08-08; supersedes the one-set-per-account
 // rendering of 2026-07-30): one set of window bars for the whole fleet plus one API cell, never a
@@ -17871,7 +17938,7 @@ var sp=d._spend||null;
 if(!keys.length&&!sp)return '';
 var h=(many?'<div class=ru-tip-host>'+esc(e.host)+'</div>':'');
 h+=keys.map(function(k){var v=d[k];
-return '<div class=ru-tip-win><div class=ru-tip-name><span>'+esc(v.name)+' ('+esc(v.span)+')</span>'
+return '<div class=ru-tip-win><div class=ru-tip-name><span>'+esc(v.name)+'</span>'
 +(v.unk?'<span class=ru-tip-reset>window reset '+esc(v.ago)+'; no reading since</span>'
 :(v.reset?'<span class=ru-tip-reset>resets in '+esc(v.reset)+'</span>':''))+'</div>'+barRows(v)+'</div>';}).join('');
 // The API-KEY SPEND rows (the user 2026-08-08): dollars, tokens and turns per window, NUMBERS ONLY.
@@ -17914,9 +17981,11 @@ function openIt(){var h=tipHTML();if(!h)return;
 tip.innerHTML=h;tip.classList.add('ru-modal');tip.style.left='';tip.style.top='';tip.style.display='block';
 back.classList.add('on');
 var off=function(){tip.style.display='none';tip.classList.remove('ru-modal');back.classList.remove('on');
-document.removeEventListener('keydown',esc2,true);};
-var esc2=function(e){if(e.key==='Escape')off();};
-back.onclick=off;document.addEventListener('keydown',esc2,true);}
+window.__rompUsageClose=null;};
+// Escape lands via _LANDING_ESC_JS (shell AND pane documents — the shell-only listener this modal
+// used to bind was deaf whenever focus sat inside a pane iframe); the backdrop tap stays.
+window.__rompUsageClose=off;
+back.onclick=off;}
 pullFleet().then(openIt,openIt);};
 el.addEventListener('mouseenter',showTip);
 el.addEventListener('mouseleave',function(){tip.style.display='none';});
@@ -18066,9 +18135,10 @@ if(more)more.onclick=function(){var on=sub.hidden;sub.hidden=!on;more.setAttribu
 more.textContent=on?'Hide':'How it works';};
 icon.onclick=function(e){e.stopPropagation();if(back.hidden)open();else close();};
 window.__rompOpenNet=open;   // the mobile bottom bar's Net button (the rail is hidden there)
+window.__rompCloseNet=close;   // Escape routes here (_LANDING_ESC_JS — shell AND pane documents; the
+                               // shell-only keydown this panel used to hold was deaf with focus in an iframe)
 back.onclick=function(e){if(e.target===back)close();};
 if(x)x.onclick=close;
-document.addEventListener('keydown',function(e){if(e.key==='Escape'&&!back.hidden)close();});
 function mruHost(){try{return localStorage.getItem('romp:lastRemoteHost')||'';}catch(e){return '';}}
 // SUGGESTIONS, not the menu. The box takes any ssh target: attach_remote validates it with _safe_ssh_host
 // and hands it to ssh as a positional arg, so ~/.ssh/config is one source of completions rather than the
@@ -19535,6 +19605,7 @@ def _landing():
             "<script>" + _LANDING_USAGE_JS + "</script>"
             "<script>" + _LANDING_JS + "</script>"
             "<script>" + _LANDING_FOCUS_JS + "</script>"
+            "<script>" + _LANDING_ESC_JS + "</script>"
             "<script>" + _LANDING_FLEET_JS + "</script>"
             # the restart flow needs this kernel's boot id (to detect the NEW kernel answering /healthz)
             # and the loader markup (to rebuild the boot splash the boot JS removed) — spliced, not

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -5553,7 +5553,7 @@ class Distiller(unittest.TestCase):
             jd.run_distill(now=now)
         det = [w for w in jd.load_goals(SID)["nodes"][gid].get("warns") or []
                if w.get("kind") == "brief-failed"][0]["detail"]
-        self.assertIn("Session (5h)", det, "the maxed account window is named as the cause")
+        self.assertIn("5-hour", det, "the maxed account window is named as the cause, in the rail's own window vocabulary")
         self.assertNotIn("Fable", det, "Fable-5 is model-scoped — never blamed for a Sonnet-summarizer failure")
         self.assertIn("resets", det, "rate-limit copy says it retries automatically on reset")
 

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -165,9 +165,10 @@ class LandingShell(unittest.TestCase):
         # per-pane collapse handles + the build-staleness banner + the remote-drift push banner = 12
         # (the user 2026-06-23; + boot-splash + rail-usage 2026-06-26; + connection-status banner
         # 2026-06-27; + the visible-viewport pin; + the remote-drift banner 2026-07-04; + the head's
-        # ios-standalone viewport flip and the push bell 2026-08-07, plans/ios-app.md).
+        # ios-standalone viewport flip and the push bell 2026-08-07, plans/ios-app.md; + the shared
+        # Escape-closes-the-topmost-modal block 2026-08-09).
         html = km._landing()
-        self.assertEqual(html.count("<script>"), 14)
+        self.assertEqual(html.count("<script>"), 15)
 
     def test_bottom_bar_is_text_only_and_compact(self):
         html = km._landing()

--- a/tests/test_kernel_rail_usage.py
+++ b/tests/test_kernel_rail_usage.py
@@ -97,7 +97,7 @@ class RailUsage(unittest.TestCase):
         # the included Fable 5 weekly allowance (the user 2026-07-02): a third bar in the rail, a third
         # window in the tooltip, and a third pair on the timeline's standalone toolbar copy
         import inspect
-        self.assertIn("['fable',7*86400,'F5','Fable 5','Fable 5']", self.html, "the rail renders a Fable 5 bar (expanded bottom-bar label)")
+        self.assertIn("['fable',7*86400,'Fable 5']", self.html, "the rail renders a Fable 5 bar (its ONE display name — the user 2026-08-09)")
         self.assertIn("['fiveHour','sevenDay','fable'].filter", self.html, "the tooltip covers it")
         self.assertIn('"fable": fable', inspect.getsource(km._usage), "_usage serves the fable window")
         tv = (pathlib.Path(BIN).parent / "ui" / "romp-timeline-view.js").read_text()

--- a/tests/test_kernel_usage_limit.py
+++ b/tests/test_kernel_usage_limit.py
@@ -234,7 +234,7 @@ class FableBanner(unittest.TestCase):
 
     def test_fable_is_still_flagged_limited_for_the_rail_bar(self):
         # the passive third rail bar still reflects the Fable window — only the proactive BANNER is suppressed
-        self.assertIn("['fable',7*86400,'F5','Fable 5','Fable 5']", km._LANDING_USAGE_JS, "the rail still has the Fable bar")
+        self.assertIn("['fable',7*86400,'Fable 5']", km._LANDING_USAGE_JS, "the rail still has the Fable bar")
 
 
 class JudgeFailureBanner(unittest.TestCase):

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -318,14 +318,15 @@ class Availability(unittest.TestCase):
     """The selector exists only when BOTH choices are real — everywhere it could appear."""
 
     def setUp(self):
-        self.real_sdk, self.real_acct = km._sdk, km._claude_account
+        self.real_sdk, self.real_acct, self.real_label = km._sdk, km._claude_account, km._claude_account_label
 
     def tearDown(self):
-        km._sdk, km._claude_account = self.real_sdk, self.real_acct
+        km._sdk, km._claude_account, km._claude_account_label = self.real_sdk, self.real_acct, self.real_label
 
-    def _world(self, key, acct):
+    def _world(self, key, acct, label="user@example.com"):
         km._sdk = lambda: type("B", (), {"work_key": key})()
         km._claude_account = lambda: acct
+        km._claude_account_label = lambda: (label if acct else "")
 
     def test_both_gates_the_selector_and_no_key_material_travels(self):
         self._world(FAKE_KEY, "aaaaaaaaaaaa")
@@ -333,6 +334,8 @@ class Availability(unittest.TestCase):
         self.assertTrue(km._auth_key_present())
         a = km._auth_avail()
         self.assertEqual((a["login"], a["key"]), (True, True))
+        # the login is NAMED, so 'Login' can say which account it means (the user 2026-08-09)
+        self.assertEqual(a["acct"], "user@example.com")
         # No fragment of the key leaves the kernel — not the key, not even its last-4 tail
         # (the user 2026-08-08, evening: a tail is still key material; 'API key' is label enough,
         # and host names already tell keys apart in the per-host hover).
@@ -340,17 +343,54 @@ class Availability(unittest.TestCase):
         self.assertNotIn(FAKE_KEY, json.dumps(a), "the key itself never travels")
         self.assertNotIn("wxyz", json.dumps(a), "…and neither does any substring of it")
 
-    def test_one_choice_is_no_choice(self):
+    def test_one_choice_still_reports_availability_for_the_written_out_row(self):
+        # One real choice hides the CONTROLS, but the picker row still WRITES OUT which auth applies
+        # (the user 2026-08-09) — so availability itself is always reported, only _auth_both flips.
         self._world("", "aaaaaaaaaaaa")
         self.assertFalse(km._auth_both())
+        a = km._auth_avail()
+        self.assertEqual((a["login"], a["key"], a["acct"]), (True, False, "user@example.com"))
         self._world(FAKE_KEY, "")
         self.assertFalse(km._auth_both())
+        a = km._auth_avail()
+        self.assertEqual((a["login"], a["key"], a["acct"]), (False, True, ""))
 
-    def test_the_session_payload_carries_auth_only_when_both_exist(self):
+    def test_the_session_payload_always_carries_auth_and_gates_only_the_controls(self):
         import inspect
         src = inspect.getsource(km.build_session)
-        self.assertIn('"auth": (tm.get("auth", "") if _auth_both() else "")', src)
+        # auth rides ungated (the user 2026-08-09: the tab hover says Billing on one-auth machines
+        # too); authBoth is the separate gate the CONTROLS key on; authAcct names the login.
+        self.assertIn('"auth": tm.get("auth", "")', src)
+        self.assertIn('"authBoth": _auth_both()', src)
+        self.assertIn('"authAcct": _claude_account_label()', src)
         self.assertNotIn("authTail", src, "the status payload carries the choice, never key material")
+
+    def test_the_label_reads_the_oauth_account_and_misses_quietly(self):
+        # The label comes from the CLI's own store (~/.claude.json oauthAccount): emailAddress first,
+        # displayName as the fallback, "" when nothing is signed in — never an exception.
+        real_home = os.environ.get("HOME")
+        home = tempfile.mkdtemp()
+        os.environ["HOME"] = home
+        try:
+            km._ACCT_CACHE["mtime"] = -2.0   # bust the mtime cache; the path just changed under it
+            self.assertEqual(km._claude_account_label(), "", "no file → no label, no error")
+            p = Path(home) / ".claude.json"
+            p.write_text(json.dumps({"oauthAccount": {"accountUuid": "11111111-2222-3333-4444-555555555555",
+                                                      "emailAddress": "user@example.com",
+                                                      "displayName": "A User"}}))
+            km._ACCT_CACHE["mtime"] = -2.0
+            self.assertEqual(km._claude_account_label(), "user@example.com")
+            self.assertTrue(km._claude_account(), "the digest still reads beside the label")
+            p.write_text(json.dumps({"oauthAccount": {"accountUuid": "11111111-2222-3333-4444-555555555555",
+                                                      "displayName": "A User"}}))
+            km._ACCT_CACHE["mtime"] = -2.0
+            self.assertEqual(km._claude_account_label(), "A User", "displayName is the fallback")
+        finally:
+            if real_home is None:
+                os.environ.pop("HOME", None)
+            else:
+                os.environ["HOME"] = real_home
+            km._ACCT_CACHE["mtime"] = -2.0   # never leak the temp world into later tests
 
     def test_the_picker_learns_availability_on_the_session_list(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()

--- a/tests/test_usage_per_account.py
+++ b/tests/test_usage_per_account.py
@@ -39,13 +39,19 @@ def _usage(acct):
 
 class AccountIdentity(unittest.TestCase):
     def test_it_is_a_digest_and_never_the_raw_identifier(self):
-        src = inspect.getsource(km._claude_account)
+        # the read mechanics live in _acct_read now: ONE cached parse feeds the digest AND the
+        # display label (the user 2026-08-09 added the label; the digest's own rules stand)
+        src = inspect.getsource(km._acct_read)
         self.assertIn("accountUuid", src, "the account identity the CLI itself uses")
         self.assertIn("sha256", src)
-        self.assertNotIn('"emailAddress"', src)
-        self.assertNotIn("emailAddress\"", src)
-        # the digest is short and opaque: enough to answer "same or not", carrying nothing back
+        # the digest is short and opaque: enough to answer "same or not", carrying nothing back —
+        # and it hashes the uuid ALONE, never the email, so cross-host equality carries no identity
         self.assertIn("hexdigest()[:12]", src)
+        self.assertIn('hashlib.sha256(str(uuid).encode("utf-8"))', src)
+        # the label is the deliberate, narrower exception: display-only (picker Billing row, tab
+        # hover), read through _claude_account_label — the digest path itself never returns it
+        self.assertIn('return _ACCT_CACHE["val"]', inspect.getsource(km._claude_account))
+        self.assertNotIn('_ACCT_CACHE["label"]', inspect.getsource(km._claude_account))
 
     def test_a_missing_or_unreadable_file_is_no_account_not_a_crash(self):
         old = os.environ.get("HOME")
@@ -59,7 +65,7 @@ class AccountIdentity(unittest.TestCase):
             km._ACCT_CACHE["mtime"] = -1.0
 
     def test_the_reading_is_cached_on_the_file_and_not_reparsed_per_poll(self):
-        self.assertIn('_ACCT_CACHE["mtime"] == m', inspect.getsource(km._claude_account))
+        self.assertIn('_ACCT_CACHE["mtime"] == m', inspect.getsource(km._acct_read))
 
     def test_the_usage_payload_carries_it(self):
         self.assertIn('"acct": _claude_account(),', inspect.getsource(km._usage))
@@ -163,11 +169,13 @@ class RailRendering(unittest.TestCase):
 
     def test_the_api_cell_is_numbers_under_a_constant_label_and_no_bars(self):
         # a bare 'API' label — never any fragment of the key, not even a last-4 tail (the user
-        # 2026-08-08, evening); value = 5h burn + month-to-date dollars; the spend bar graphs are
-        # gone everywhere (same day, morning: they told you nothing)
+        # 2026-08-08, evening); each window then wears its ONE display name LEFT of its dollars+tokens
+        # (the user 2026-08-09 — same words, font and position as the account bars); the spend bar
+        # graphs are gone everywhere (2026-08-08, morning: they told you nothing)
         self.assertIn("'<div class=ru-name>API</div>'", self.js)
         self.assertNotIn("_tail", self.js)
-        self.assertIn("fmtUsd(sum.fiveHour)+' 5h · '+fmtUsd(sum.month)+' mo</div>'", self.js)
+        self.assertIn("seg('fiveHour','5 hours')+seg('month','Month')", self.js)
+        self.assertIn("'<div class=ru-pct>'+fmtUsd(sum[k].usd)+' · '+fmtTok(sum[k].tok)+' tok</div>'", self.js)
         self.assertNotIn("spendColor", self.js)
         self.assertNotIn("spendWinsHTML", self.js)
 

--- a/ui/webview/auth-selector.test.ts
+++ b/ui/webview/auth-selector.test.ts
@@ -1,13 +1,16 @@
-// Per-session BILLING selector (the user 2026-08-08): pick, per session, whether it bills the Claude
-// login or the API key the manager's environment carries. Two surfaces, both existence-gated on the
-// machine actually offering BOTH choices (one choice is no choice — the control disappears):
-//   * the new-session picker's Billing row, armed by the selected host's own sessionList reply
-//     (authAvail) and shown only while the backend toggle says SDK;
-//   * the statusline auth badge, present only when the kernel emits st.auth (it gates on _auth_both),
-//     posting setAuth and wearing switching-dots while the applying reconnect is pending.
+// Per-session BILLING (the user 2026-08-08, reshaped 2026-08-09): pick, per session, whether it bills
+// the Claude login or the API key the manager's environment carries — and SEE the fact everywhere even
+// when there is nothing to pick.
+//   * the new-session picker's Billing row is ALWAYS there for an SDK session: segmented buttons when
+//     the selected host's own sessionList reply (authAvail) says both choices are real, and the same
+//     spot writes the single choice out as plain text when only one is (a fact, not a control);
+//   * the statusline auth badge is the SWITCHING control, so it keeps the stricter gate: it exists
+//     only when the machine offers both (st.authBoth), posting setAuth and wearing switching-dots
+//     while the applying reconnect is pending;
+//   * the chat tab's hover carries the fact as a Billing row whenever the backend reports it
+//     (st.auth rides ungated now), naming WHICH login account (st.authAcct) beside 'Login'.
 // The key is labelled plainly 'API key' — NO key material anywhere: not the key, not even a last-4
 // tail (the user 2026-08-08, evening: a tail is still key material; hosts are told apart by name).
-// The chat tab's hover tooltip carries the same fact as a Billing row (same day).
 // No jsdom harness → source pins (the repo convention).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -18,11 +21,13 @@ const ROOT = path.resolve(process.cwd(), "..");
 const RENDER = fs.readFileSync(path.join(ROOT, "ui", "webview", "render.ts"), "utf8");
 const INTENT = fs.readFileSync(path.join(ROOT, "vscode-extension", "src", "pipe-intent.ts"), "utf8");
 
-test("the picker's Billing row exists only when the host offers both, and only for SDK", () => {
-  // hidden until the selected host's OWN sessionList reply proves both choices exist; the backend
-  // toggle re-decides it (tmux CLIs live in the tmux server's env, which the kernel doesn't control)
-  assert.match(RENDER, /const show = !pickMode && !!\(a && a\.login && a\.key\) && \(beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend\) === "sdk";/);
-  assert.match(RENDER, /auWrap\.style\.display = "none";\s*\/\/ hidden until a sessionList reply proves both choices exist/);
+test("the picker's Billing row shows for SDK whenever availability is known", () => {
+  // one known choice is enough to SHOW the row (the user 2026-08-09) — the both-test only decides
+  // buttons vs written-out text; the backend toggle still re-decides the row (tmux CLIs live in the
+  // tmux server's env, which the kernel doesn't control)
+  assert.match(RENDER, /const show = !pickMode && !!\(a && \(a\.login \|\| a\.key\)\) && \(beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend\) === "sdk";/);
+  assert.match(RENDER, /const both = !!\(a!\.login && a!\.key\);/);
+  assert.match(RENDER, /auWrap\.style\.display = "none";\s*\/\/ hidden until a sessionList reply carries authAvail/);
   assert.match(RENDER, /beWrap\.addEventListener\("click", \(\) => syncPickerAuth\(\)\);/);
   // a host switch clears the availability — the choices on screen belong to the OLD host
   assert.match(RENDER, /pickerAuthAvail = null;\s*\n\s*syncPickerAuth\(\);/);
@@ -30,28 +35,43 @@ test("the picker's Billing row exists only when the host offers both, and only f
   assert.match(RENDER, /pickerAuthAvail = \(m\.authAvail && typeof m\.authAvail === "object"\) \? m\.authAvail : null;/);
 });
 
-test("the pick rides createSession, omitted when the row is hidden", () => {
-  // the pick is omitted entirely when the row is hidden — the kernel's own default stands
+test("one real choice renders WRITTEN OUT in the buttons' place, naming the login account", () => {
+  // the buttons hide, the fixed span shows the single applying choice as plain text (the user
+  // 2026-08-09: informative, never a one-option selector) — Login named by its account when known
+  assert.match(RENDER, /wrap\.querySelectorAll\("\.picker-be-opt"\)\.forEach\(\(x\) => \(\(x as HTMLElement\)\.style\.display = both \? "" : "none"\)\);/);
+  assert.match(RENDER, /fixed\.style\.display = both \? "none" : "";/);
+  assert.match(RENDER, /fixed\.textContent = both \? "" : \(a!\.key \? "API key" : \(a!\.acct \? `Login \(\$\{a!\.acct\}\)` : "Login"\)\);/);
+  assert.match(RENDER, /const auFixed = el\("span", "picker-auth-fixed"\);/);
+  // in button mode, the Login button's hover names WHICH account
+  assert.match(RENDER, /if \(loginBtn && a!\.acct\) loginBtn\.title = `Bill this session to the machine's Claude login \(\$\{a!\.acct\}\)\.`;/);
+});
+
+test("the pick rides createSession, omitted when the row is hidden or written-out", () => {
   assert.match(RENDER, /function pickerAuthChoice\(\): string/);
   assert.match(RENDER, /host: hostSel, \.\.\.\(auth \? \{ auth \} : \{\}\) \}\);/);
   assert.match(RENDER, /interface CreateReq \{ name: string; backend: string; dir: string; host: string; auth\?: string \}/);
+  // text mode sends nothing — the kernel default IS the single choice, and a stale .sel from a
+  // previously-selected both-offering host must not ride along
+  assert.match(RENDER, /if \(!sel \|\| sel\.style\.display === "none"\) return "";/);
   // fresh open forgets last time's pick + availability; the local reply re-arms it
   assert.match(RENDER, /auWrapEl\.querySelectorAll\("\.picker-be-opt"\)\.forEach\(\(x\) => x\.classList\.remove\("sel"\)\);/);
   // the default selection comes from the host's own answer, once, not on every re-sync
   assert.match(RENDER, /const def = a!\.default === "key" \? "key" : "login";/);
 });
 
-test("the statusline auth badge is a MetaKind gated on the kernel emitting st.auth", () => {
+test("the statusline auth badge — the switching CONTROL — still gates on both", () => {
   assert.match(RENDER, /type MetaKind = "mode" \| "model" \| "effort" \| "fast" \| "auth";/);
-  assert.match(RENDER, /st\.auth \? "auth" : ""/);
-  assert.match(RENDER, /meta\.appendChild\(metaButton\("auth", prettyAuth\(st\)\)\)/);
+  // st.auth is always reported now; the CONTROL keys on st.authBoth so a one-auth machine
+  // shows no dead selector (the display rows carry the fact instead)
+  assert.match(RENDER, /\(st\.auth && st\.authBoth\) \? "auth" : ""/);
+  assert.match(RENDER, /if \(st\.auth && st\.authBoth\) meta\.appendChild\(metaButton\("auth", prettyAuth\(st\)\)\);/);
   // the badge label is the plain choice, never key material
   assert.match(RENDER, /return \(st\.auth \|\| ""\)\.toLowerCase\(\) === "key" \? "API key" : "Login";/);
   // the pick posts setAuth, and the applying reconnect drives the switching-dots
   assert.match(RENDER, /kind === "auth" \? "setAuth"/);
   assert.match(RENDER, /\(kind === "auth" && !!st\.authPending\)/);
   assert.match(RENDER, /kind === "model" \|\| kind === "effort" \|\| kind === "auth"\);/);
-  assert.match(RENDER, /auth\?: string; authPending\?: boolean;/);
+  assert.match(RENDER, /auth\?: string; authPending\?: boolean; authBoth\?: boolean; authAcct\?: string;/);
 });
 
 test("no key material reaches the webview — no tail plumbing survives anywhere", () => {
@@ -62,10 +82,10 @@ test("no key material reaches the webview — no tail plumbing survives anywhere
   assert.doesNotMatch(RENDER, /a!\.tail/);
 });
 
-test("the chat tab hover carries a Billing row with the same disappearing rule", () => {
-  // whether this tab bills the API key or the login, on the tab tooltip (the user 2026-08-08);
-  // st.auth is both-gated by the kernel, so a one-auth machine shows no row at all
-  assert.match(RENDER, /if \(s\.status\.auth\) rows\.push\(\["Billing", s\.status\.auth === "key" \? "API key" : "Login"\]\);/);
+test("the chat tab hover says Billing whenever the backend reports it, naming the login", () => {
+  // ungated on machine shape (the user 2026-08-09: one-auth machines included; only a tmux session,
+  // whose CLI env romp does not control, reports nothing) — and 'Login (account)' when known
+  assert.match(RENDER, /if \(s\.status\.auth\) rows\.push\(\["Billing", s\.status\.auth === "key" \? "API key"\s*\n\s*: \(s\.status\.authAcct \? `Login \(\$\{s\.status\.authAcct\}\)` : "Login"\)\]\);/);
 });
 
 test("setAuth is an intent op — held through a kernel-restart window, never dropped", () => {

--- a/ui/webview/esc-close.test.ts
+++ b/ui/webview/esc-close.test.ts
@@ -1,0 +1,46 @@
+// Escape closes the TOPMOST open shell modal (the user 2026-08-09: the usage/network/Log panels could
+// only be clicked away — Escape did nothing whenever focus sat inside a pane iframe, because a keydown
+// never crosses the iframe boundary). The fix is one shared handler with the palette's own dual
+// wiring: capture on the shell document AND on every same-origin pane document, re-attached per
+// iframe (re)load. Each panel exposes its OWN close (state cleanup lives in those closures); the
+// shared block only decides which panel Escape means, topmost first. No jsdom harness → source pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+const ESC = KERNEL.split('_LANDING_ESC_JS = """')[1].split('"""')[0];
+
+test("the shared Escape block wires the shell document AND every pane document", () => {
+  assert.ok(ESC.includes("document.addEventListener('keydown',onEsc,true);"));
+  assert.ok(ESC.includes("['f-chat','f-fleet','f-feed','f-timeline'].forEach"));
+  assert.ok(ESC.includes("f.contentDocument.addEventListener('keydown',onEsc,true);"));
+  assert.ok(ESC.includes("f.addEventListener('load',wire);wire();"), "re-attached on every iframe (re)load");
+  // and the block is actually spliced into the landing page
+  assert.ok(KERNEL.includes('"<script>" + _LANDING_ESC_JS + "</script>"'));
+});
+
+test("topmost first, and only when a shell modal is actually open", () => {
+  // usage modal (z300) beats the Log (z210) beats the net panel (z200); with nothing open the
+  // handler touches nothing, so pane-local Escapes (chat dialogs, menus) keep working
+  const ru = ESC.indexOf("__rompUsageClose");
+  const er = ESC.indexOf("__rompCloseErrs");
+  const nt = ESC.indexOf("__rompCloseNet");
+  assert.ok(ru > -1 && er > ru && nt > er, "priority order: usage, Log, net");
+  assert.ok(ESC.includes("ru.classList.contains('on')"));
+  assert.ok(ESC.includes("!er.hidden"));
+  assert.ok(ESC.includes("!nt.hidden"));
+  assert.ok(ESC.includes("if(closed){e.preventDefault();e.stopPropagation();}"));
+});
+
+test("each panel exposes its real close — cleanup stays in the owning closure", () => {
+  assert.ok(KERNEL.includes("window.__rompCloseErrs=close;"));
+  assert.ok(KERNEL.includes("window.__rompCloseNet=close;"));
+  assert.ok(KERNEL.includes("window.__rompUsageClose=off;"));
+  assert.ok(KERNEL.includes("window.__rompUsageClose=null;"), "the usage close disarms when the modal shuts");
+  // the panels' own shell-only Escape listeners are gone — deaf-with-iframe-focus was the bug
+  assert.ok(!KERNEL.includes("if(e.key==='Escape'&&!back.hidden)close()"), "net's old shell-only listener removed");
+  assert.ok(!KERNEL.includes("var esc2=function(e){if(e.key==='Escape')off();};"), "usage's old shell-only listener removed");
+});

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -63,17 +63,49 @@ test("VS Code strip: spend rows key on the windows' PRESENCE, one row builder fo
 
 test("the web rail's API cell is numbers under a constant label — no spend bars anywhere", () => {
   const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
-  // one compact cell: a bare 'API' label (never any key fragment), 5h + month dollars
+  // one compact cell: a bare 'API' label (never any key fragment), then per-window pairs in the
+  // window cells' own grammar — the window's ONE display name, name-font, LEFT of its value, with
+  // dollars AND tokens (the user 2026-08-09: no more '$12 5h' second vocabulary trailing the number)
   assert.ok(usageJS.includes("function apiCellHTML(live)"));
   assert.ok(usageJS.includes("'<div class=ru-name>API</div>'"));
   assert.ok(!usageJS.includes("_tail"), "no tail plumbing survives in the rail JS");
-  assert.ok(usageJS.includes("fmtUsd(sum.fiveHour)+' 5h \\u00b7 '+fmtUsd(sum.month)+' mo</div>'"));
+  assert.ok(usageJS.includes("seg('fiveHour','5 hours')+seg('month','Month')"));
+  assert.ok(usageJS.includes("var seg=function(k,lbl){return '<div class=ru-name>'+lbl+'</div>'"));
+  assert.ok(usageJS.includes("'<div class=ru-pct>'+fmtUsd(sum[k].usd)+' \\u00b7 '+fmtTok(sum[k].tok)+' tok</div>'"));
   // the graph and the budget fills are gone: no spend track, no spend color ramp, no shared scale
   assert.ok(!usageJS.includes("spendColor"), "the budget-fill ramp died with the spend bars");
   assert.ok(!usageJS.includes("spendWinsHTML"), "spend never renders as window rows with tracks");
   assert.ok(!usageJS.includes("var mx=1;"), "the token auto-scale graph is gone");
   // presence-keyed, like the strip
   assert.ok(usageJS.includes("function hasSpend(u){return !!(u&&u.spend&&u.spend.fiveHour);}"));
+});
+
+test("one display name per window, worn everywhere: bars, hover sections, API cell, notices", () => {
+  // the user 2026-08-09: '5 hours' on the bars, '5h' on the API numbers and 'Session (5h)' in the
+  // hover were three vocabularies for one thing — WINS now carries the ONE display name per window
+  const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
+  assert.ok(usageJS.includes("var WINS=[['fiveHour',5*3600,'5 hours'],"));
+  assert.ok(usageJS.includes("['sevenDay',7*86400,'7 days'],"));
+  assert.ok(usageJS.includes("['fable',7*86400,'Fable 5']];"));
+  assert.ok(usageJS.includes("'<div class=ru-name>'+w[2]+'</div>'"), "the collapsed bars wear it");
+  // the hover window heading is the bare name — no '(5h)' span, no Session/Weekly third vocabulary
+  assert.ok(usageJS.includes("'<div class=ru-tip-win><div class=ru-tip-name><span>'+esc(v.name)+'</span>'"));
+  assert.ok(!usageJS.includes("'Session'"), "the Session/Weekly names are retired");
+  assert.ok(!usageJS.includes("Weekly (7d)"));
+  // the limit notice speaks the same windows, prose-shaped
+  assert.ok(usageJS.includes("names.push('5-hour')"));
+  assert.ok(usageJS.includes("names.push('7-day')"));
+});
+
+test("dollars are WHOLE everywhere — no cents on any spend surface", () => {
+  // the user 2026-08-09: cents are noise at these magnitudes; the rail, its hover, and the VS Code
+  // strip all round to whole dollars through their one formatter each
+  const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
+  assert.ok(usageJS.includes("function fmtUsd(v){return '$'+String(Math.round(v));}"));
+  assert.ok(!usageJS.includes("toFixed(2)"), "no cents anywhere in the rail JS");
+  assert.match(STRIP, /readout: "\$" \+ Math\.round\(seg\.usd\)/);
+  assert.match(STRIP, /title: label \+ " — \$" \+ Math\.round\(seg\.usd\)/);
+  assert.doesNotMatch(STRIP, /usd\.toFixed\(2\)/);
 });
 
 test("the rich tip is the ONE hover surface: no native titles, per-host sections, numbers-only spend", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -196,7 +196,7 @@ type ChatEvent = (
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
 type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
-interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed.
@@ -3290,10 +3290,11 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   // Backend is a plain labelled FIELD now, under the others (the user 2026-07-08 — no longer a coloured
   // "SDK backend" badge at the top of the tooltip; it reads as one of the session's config fields).
   if (be === "sdk" || be === "tmux") rows.push(["Backend", be === "sdk" ? "SDK" : "tmux"]);
-  // Billing: whether this tab bills the API key or the Claude login (the user 2026-08-08). st.auth
-  // exists only when the machine offers both (kernel _auth_both), so a one-auth machine shows no row —
-  // the selector's own disappearing rule. The label carries no key material, ever.
-  if (s.status.auth) rows.push(["Billing", s.status.auth === "key" ? "API key" : "Login"]);
+  // Billing: whether this tab bills the API key or the Claude login — and WHICH login account (the
+  // user 2026-08-09: shown whenever the backend reports it, one-auth machines included; only a tmux
+  // session, whose CLI env romp does not control, reports nothing). No key material, ever.
+  if (s.status.auth) rows.push(["Billing", s.status.auth === "key" ? "API key"
+    : (s.status.authAcct ? `Login (${s.status.authAcct})` : "Login")]);
   for (const [k, v] of rows) {
     const r = el("div", "tab-tip-row");
     const ke = el("span", "tab-tip-k"); ke.textContent = k;
@@ -4246,19 +4247,34 @@ function requestSessionList(host: string): void {
 }
 
 // Per-session BILLING for a NEW session (the user 2026-08-08): login vs the API key the selected host's
-// manager environment carries. The row exists only when that host offers BOTH (authAvail on its
-// sessionList reply) AND the backend toggle says SDK (a tmux session's CLI lives in the tmux server's
-// environment, which the kernel does not control) — otherwise it disappears entirely.
-let pickerAuthAvail: { login?: boolean; key?: boolean; default?: string } | null = null;
+// manager environment carries. The row is ALWAYS there for an SDK session (the user 2026-08-09):
+// segmented BUTTONS when the selected host offers both, and when it offers ONE, the same spot just
+// writes out which it is — informative, never a one-option selector (what the earlier disappearing
+// rule was really against). The row still disappears when the backend toggle says tmux (that CLI
+// lives in the tmux server's environment, which the kernel does not control) and until the host's
+// sessionList reply carries authAvail (an older kernel never answers with one).
+let pickerAuthAvail: { login?: boolean; key?: boolean; acct?: string; default?: string } | null = null;
 
 function syncPickerAuth(): void {
   const wrap = document.querySelector("#picker .picker-auth") as HTMLElement | null;
   if (!wrap) return;
   const beSel = document.querySelector("#picker .picker-backend:not(.picker-host):not(.picker-auth) .picker-be-opt.sel") as HTMLElement | null;
   const a = pickerAuthAvail;
-  const show = !pickMode && !!(a && a.login && a.key) && (beSel?.dataset.be || loadSettings().backend) === "sdk";
+  const show = !pickMode && !!(a && (a.login || a.key)) && (beSel?.dataset.be || loadSettings().backend) === "sdk";
   wrap.style.display = show ? "" : "none";
   if (!show) return;
+  const both = !!(a!.login && a!.key);
+  wrap.querySelectorAll(".picker-be-opt").forEach((x) => ((x as HTMLElement).style.display = both ? "" : "none"));
+  const fixed = wrap.querySelector(".picker-auth-fixed") as HTMLElement | null;
+  if (fixed) {
+    fixed.style.display = both ? "none" : "";
+    // one real choice → written out in the buttons' place, naming the login account when known
+    fixed.textContent = both ? "" : (a!.key ? "API key" : (a!.acct ? `Login (${a!.acct})` : "Login"));
+  }
+  if (!both) return;   // the fixed text is the whole row — nothing to seed
+  // the Login button's hover names WHICH account (the user 2026-08-09)
+  const loginBtn = wrap.querySelector('.picker-be-opt[data-auth="login"]') as HTMLElement | null;
+  if (loginBtn && a!.acct) loginBtn.title = `Bill this session to the machine's Claude login (${a!.acct}).`;
   // seed the selection from the host's default only when nothing is selected yet this open
   if (!wrap.querySelector(".picker-be-opt.sel")) {
     const def = a!.default === "key" ? "key" : "login";
@@ -4266,11 +4282,15 @@ function syncPickerAuth(): void {
   }
 }
 
-// the picked billing for the create payload — "" when the row is hidden (kernel default applies)
+// the picked billing for the create payload — "" when the row is hidden or written-out (one real
+// choice: the kernel default IS that choice, and a stale .sel from a previously-selected both-offering
+// host must not ride along)
 function pickerAuthChoice(): string {
   const wrap = document.querySelector("#picker .picker-auth") as HTMLElement | null;
   if (!wrap || wrap.style.display === "none") return "";
-  return (wrap.querySelector(".picker-be-opt.sel") as HTMLElement | null)?.dataset.auth || "";
+  const sel = wrap.querySelector(".picker-be-opt.sel") as HTMLElement | null;
+  if (!sel || sel.style.display === "none") return "";
+  return sel.dataset.auth || "";
 }
 
 function pickerHost(): string {
@@ -4504,10 +4524,11 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
                   mkBe("tmux", "tmux", "Drives a real terminal pane (tmux)."));   // SDK first — the de-facto default (the user 2026-07-02)
     // the billing row exists only for SDK sessions — re-decide on every backend toggle
     beWrap.addEventListener("click", () => syncPickerAuth());
-    // per-session BILLING row (the user 2026-08-08): Login | API key, shown only when the selected
-    // host offers both (see syncPickerAuth); the same segmented-toggle grammar as Backend above.
+    // per-session BILLING row (the user 2026-08-08): Login | API key buttons when the selected host
+    // offers both; with ONE real choice the same spot writes it out as plain text (the user
+    // 2026-08-09) — see syncPickerAuth. Same segmented-toggle grammar as Backend above.
     const auWrap = el("div", "picker-backend picker-auth");
-    auWrap.style.display = "none";   // hidden until a sessionList reply proves both choices exist
+    auWrap.style.display = "none";   // hidden until a sessionList reply carries authAvail
     const auLabel = el("span", "picker-backend-label"); auLabel.textContent = "Billing";
     const mkAu = (val: string, txt: string, tip: string) => {
       const b = el("button", "picker-be-opt") as HTMLButtonElement;
@@ -4515,8 +4536,11 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       b.addEventListener("click", () => auWrap.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", x === b)));
       return b;
     };
+    const auFixed = el("span", "picker-auth-fixed");   // the written-out single choice
+    auFixed.style.display = "none";
     auWrap.append(auLabel, mkAu("login", "Login", "Bill this session to the machine's Claude login (subscription usage)."),
-                  mkAu("key", "API key", "Bill this session to the API key the manager's environment carries (per-token)."));
+                  mkAu("key", "API key", "Bill this session to the API key the manager's environment carries (per-token)."),
+                  auFixed);
     // per-session HOST picker (federation, the user 2026-07-02): local | each attached SSH host — the new
     // session is created BY that host's kernel (over its tunnel) and appears prefixed `host:name`. The
     // options are rebuilt on every open (hosts attach/detach live); the row hides with no hosts attached.
@@ -6795,10 +6819,11 @@ const FAST_CHOICES: { label: string; value: string }[] = [
   { label: "Off", value: "off" },
 ];
 // Per-session billing (the user 2026-08-08): the Claude login vs the API key the manager's environment
-// carries. The badge exists only when the session REPORTS a choice (st.auth) — the kernel emits it only
-// when the machine actually offers BOTH, so a one-auth machine shows no dead selector at all. The key
-// entry is labelled 'API key', full stop — no fragment of the key, not even a last-4 tail, is shipped
-// or shown (the user 2026-08-08, evening: a tail is still key material and no surface needs it).
+// carries. st.auth is now ALWAYS reported when the backend knows it (the user 2026-08-09 — the tab
+// hover says Billing everywhere), so this SWITCHING badge gates on st.authBoth instead: a one-auth
+// machine still shows no dead selector, while the hover stays informative. The key entry is labelled
+// 'API key', full stop — no fragment of the key, not even a last-4 tail, is shipped or shown (the
+// user 2026-08-08, evening: a tail is still key material and no surface needs it).
 const AUTH_CHOICES: { label: string; value: string }[] = [
   { label: "Login", value: "login" },
   { label: "API key", value: "key" },
@@ -6907,7 +6932,7 @@ function syncMetaControls(meta: HTMLElement, st: Status) {
   // order left→right: mode · model · effort · fast · auth — the mode selector sits LEFT of the model name
   // (the user 2026-06-16); fast/auth exist only when the session reports them (SDK init / a both-auth
   // machine), so a machine with one billing choice shows no dead selector (the user 2026-08-08).
-  const want = [st.mode ? "mode" : "", st.model ? "model" : "", st.effort ? "effort" : "", st.fast ? "fast" : "", st.auth ? "auth" : ""].filter(Boolean).join();
+  const want = [st.mode ? "mode" : "", st.model ? "model" : "", st.effort ? "effort" : "", st.fast ? "fast" : "", (st.auth && st.authBoth) ? "auth" : ""].filter(Boolean).join();
   const btns = Array.from(meta.querySelectorAll(".meta-btn")) as HTMLElement[];
   if (btns.map((b) => b.dataset.kind).join() !== want) {
     meta.replaceChildren();
@@ -6915,7 +6940,7 @@ function syncMetaControls(meta: HTMLElement, st: Status) {
     if (st.model) meta.appendChild(metaButton("model", st.model));
     if (st.effort) meta.appendChild(metaButton("effort", st.effort));
     if (st.fast) meta.appendChild(metaButton("fast", prettyFast(st.fast)));
-    if (st.auth) meta.appendChild(metaButton("auth", prettyAuth(st)));
+    if (st.auth && st.authBoth) meta.appendChild(metaButton("auth", prettyAuth(st)));
   }
   for (const b of Array.from(meta.querySelectorAll(".meta-btn")) as HTMLElement[]) {
     const kind = b.dataset.kind as MetaKind;

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -123,10 +123,10 @@ export function spendWindows(usage: any, nowS: number): UsageWindow[] {
     const turns = seg.turns || 0;
     out.push({
       key, label, short, pct, elapsedPct, unknown: false,
-      // dollars AND tokens stay VISIBLE (the user 2026-08-05 — the hover-only split hid them again)
-      readout: "$" + (seg.usd < 100 ? seg.usd.toFixed(2) : String(Math.round(seg.usd)))
-        + " · " + fmtTok(seg.tok || 0) + " tok",
-      title: label + " — $" + seg.usd.toFixed(2) + " · " + fmtTok(seg.tok || 0) + " tokens · "
+      // dollars AND tokens stay VISIBLE (the user 2026-08-05 — the hover-only split hid them again);
+      // WHOLE dollars, no cents, matching the rail everywhere (the user 2026-08-09)
+      readout: "$" + Math.round(seg.usd) + " · " + fmtTok(seg.tok || 0) + " tok",
+      title: label + " — $" + Math.round(seg.usd) + " · " + fmtTok(seg.tok || 0) + " tokens · "
         + turns + " turn" + (turns === 1 ? "" : "s")
         + (budget != null ? " · " + pct + "% of the $" + budget + " budget"
            : " · no budget set — dollars only, no fill (set one in spend-budgets.json)")

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1873,6 +1873,9 @@ body.picker-lifted > #picker { align-items: center; padding: 24px 16px; }
 }
 .picker-be-opt:hover { background: rgba(255, 255, 255, 0.12); color: var(--fg); }
 .picker-be-opt.sel { background: var(--accent); color: var(--accent-fg); border-color: transparent; }   /* selected backend = accent, not working-yellow (the user 2026-06-24) */
+/* the Billing row's single-choice text: written out where the buttons would sit (the user 2026-08-09) —
+   the buttons' 0.82em, plain, no button chrome (it is a fact, not a control) */
+.picker-auth-fixed { flex: 0 0 auto; color: var(--fg); font-size: 0.82em; padding: 4px 0; }
 .picker-list { overflow-y: auto; }
 .picker-row {
   padding: 9px 14px; cursor: pointer;


### PR DESCRIPTION
Three asks from the user (2026-08-09), one surface:

- **Billing never hides.** The picker's Billing row always renders for SDK sessions: buttons when the host offers both auths, the single choice written out as plain text in the same spot otherwise. The chat tab hover carries a Billing row whenever the backend reports it, and the login is named by its account (`Login (name@example.com)`) from the CLI's own oauthAccount store. The statusline badge remains a switching control gated on both choices existing.
- **One window vocabulary.** '5 hours' / '7 days' / 'Fable 5' / 'Month' everywhere — bars, hover sections, the API cell (designators left of values, name font), the limit notice, and the judge's give-up cause. The API cell keeps tokens beside dollars; all dollar readouts round to whole dollars (rail, hover, VS Code strip).
- **Escape dismisses shell modals** (usage / Log / network), topmost first, via the palette's dual shell+pane-document wiring — the old shell-only listeners were deaf with focus inside a pane iframe.

Tests: pytest 4058 green (pins updated for the new payload shape and vocabulary; new `_claude_account_label` behavior test), node suite green incl. new `esc-close.test.ts`, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)