### PR TITLE
An optimistic send retires only on its own landing; the bundle watch sees its sources

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21171,16 +21171,21 @@ def _ensure_bundles():
     """Build the shared webview bundles (the human's tuned UI) if missing/stale — keeps the
     kernel a single command and auto-rebuilds after TS/CSS edits (mirrors bin/romp-serve). Watches
     .css as well as .ts: a CSS-only change must still trigger a rebuild on restart (the user 2026-06-16
-    hit a shipped style that didn't go live because only *.ts was checked)."""
+    hit a shipped style that didn't go live because only *.ts was checked). Watches ui/webview TOO,
+    not just vscode-extension/src: esbuild.js builds the webview entrypoints from ../ui/webview
+    (render.ts, styles.css, feed.ts, …), so an edit there never marked the bundle stale — a
+    render.ts-only fix could sit unshipped through every kernel restart, with the ?v= cache token
+    frozen so browsers kept the old bundle as well (found 2026-08-09 hunting the optimistic-echo
+    bug: the docstring promised a rebuild the check couldn't see)."""
     cv = ROOT / "vscode-extension"
     render = DIST / "render.js"
     if not (cv / "node_modules").exists():
         sys.stderr.write("romp-kernel: UI deps missing — run once: (cd %s && npm install)\n" % cv)
         return
-    src = cv / "src"
+    srcs = [cv / "src", ROOT / "ui" / "webview"]
     stale = not render.exists() or any(
         f.stat().st_mtime > render.stat().st_mtime
-        for f in [*src.rglob("*.ts"), *src.rglob("*.css")])
+        for src in srcs for f in [*src.rglob("*.ts"), *src.rglob("*.css")])
     if stale:
         sys.stderr.write("romp-kernel: building UI bundles…\n")
         # --production (minified, no sourcemaps), matching vscode-extension/install.sh. Both

--- a/tests/test_bundle_build_mode.py
+++ b/tests/test_bundle_build_mode.py
@@ -57,6 +57,21 @@ class BundleBuildMode(unittest.TestCase):
         self.assertIn("ROMP_EXT_DEV_BUILD", _read(EXT_INSTALL))
         self.assertIn("ROMP_EXT_DEV_BUILD", _read(KERNEL))
 
+    def test_the_staleness_scan_covers_every_source_root_esbuild_reads(self):
+        """esbuild.js builds the webview entrypoints from ../ui/webview (render.ts, styles.css,
+        feed.ts, …), but _ensure_bundles used to scan only vscode-extension/src — so a
+        ui/webview-only edit never marked the bundle stale, and the fix sat unshipped through
+        every kernel restart with the ?v= cache token frozen (found 2026-08-09 hunting the
+        optimistic-echo bug: the docstring promised a rebuild the check couldn't see)."""
+        self.assertIn("ui/webview", _read(ESBUILD).replace("\\", "/"),
+                      "esbuild reads the shared webview sources — the premise of this guard")
+        src = _read(KERNEL)
+        m = re.search(r"def _ensure_bundles\(\):.*?(?=\ndef )", src, re.S)
+        body = m.group(0)
+        self.assertIn('ROOT / "ui" / "webview"', body,
+                      "the staleness scan must watch ui/webview, where the webview sources live")
+        self.assertIn("for src in srcs", body, "…as one scan over every source root")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kernel_delta_send.py
+++ b/tests/test_kernel_delta_send.py
@@ -149,7 +149,9 @@ class RenderHandlesTheTail(unittest.TestCase):
         # resident tail is fine). A GAP (from past what we hold) → ask for a full session: "wait for the
         # next full" was a promise nothing kept, and the tab froze there until its socket dropped.
         self.assertIn("if (from < 0) return;", r)
-        self.assertIn("if (from > s.events.length) {", r)
+        # the gap check runs in KERNEL coordinates — the client's injected optimistic tail is not part
+        # of the kernel's index space, and counting it masked genuine gaps (the user 2026-08-09)
+        self.assertIn("if (from > kernelLen) {", r)
         self.assertIn("requestFullSession(msg.id);", r)
         self.assertIn("s.events.length = from;", r)                            # truncate the superseded tail
         self.assertIn("for (const e of (msg.events || [])) s.events.push(e);", r)  # append the suffix

--- a/ui/webview/chat-delta-resync.test.ts
+++ b/ui/webview/chat-delta-resync.test.ts
@@ -17,8 +17,12 @@ const FEED = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.ts"), "utf8"
 const KERNEL = fs.readFileSync(path.join(ROOT, "bin", "romp-kernel"), "utf8");
 
 test("a delta gap asks the kernel for a full session instead of freezing", () => {
-  assert.match(RENDER, /if \(from > s\.events\.length\) \{/,
+  // measured against the KERNEL-owned length: the injected optimistic tail is not in the kernel's
+  // coordinate space, and counting it masked a genuine 1-event gap (the user 2026-08-09)
+  assert.match(RENDER, /if \(from > kernelLen\) \{/,
     "chatTail must treat a too-far-ahead delta as its own case, not fold it into the silent return");
+  assert.match(RENDER, /while \(kernelLen > 0 && isOptimistic\(s\.events\[kernelLen - 1\]\)\) kernelLen--;/,
+    "…in kernel coordinates, with the injected tail excluded");
   assert.match(RENDER, /requestFullSession\(msg\.id\);/, "…and request a re-base");
   assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "needFull", id \}\)/,
     "the resync request must actually reach the kernel");

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -3,8 +3,17 @@
 // VANISH in the server-side echo→landed gap — so a just-sent message looked lost for a beat (the user
 // 2026-07-15: "showing up as a provisional message ... and it disappeared"). Fix: a CLIENT-side optimistic
 // bubble injected at the tail the moment you hit Enter, re-asserted on every push until the kernel's payload
-// demonstrably carries the message, then retired. render.ts has import-time DOM side effects → source pins +
-// an executed replica of the reconcile decision (user-img-dedup.test.ts precedent).
+// demonstrably carries the message, then retired.
+//
+// Reshaped 2026-08-09 (the user, who watched sends vanish again and suspected the fix was hollow): the
+// retire test was a bare substring scan, so (A) a resend — or any short message that substrings an older
+// bubble — retired its own entry in the very call that created it and showed nothing, and (B) the kernel's
+// own PROVISIONAL copy (queued bubble / "echo:" atom) counted as landed and deleted the entry one-way, so
+// when that provisional blinked in the echo→landed handoff nothing was left to cover the gap. Now: a
+// per-send `base` count makes only NEW landed user atoms retire it, kernel provisionals merely SUPPRESS
+// injection for the push they're visible on, and the TTL stays the backstop.
+// render.ts has import-time DOM side effects → source pins + an executed replica of the reconcile decision
+// (user-img-dedup.test.ts precedent).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -18,7 +27,14 @@ test("the plain send registers an optimistic bubble; follow-up/quote sends keep 
   assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: activeId, text \}\); registerOptimistic\(activeId, text\); \}/);
   // registerOptimistic shows it NOW (before any push) via reconcile + appendActive
   assert.match(RENDER, /function registerOptimistic\(id: string, text: string\): void/);
-  assert.match(RENDER, /if \(v\) v\.stale = true;\s*\n\s*if \(id === activeId\) appendActive\(\);/);
+  assert.match(RENDER, /if \(v\) v\.stale = true;\s*\n\s*if \(id === activeId\) \{\s*\n\s*appendActive\(\);/);
+});
+
+test("your OWN send always reveals itself — the >80px stick rule never hides it below the fold", () => {
+  // appendActive keeps the viewport still when the reader is scrolled up; a send made from there
+  // painted below the fold and looked like it never appeared (the user 2026-08-09). Enter = intent
+  // to see the message, so registerOptimistic scrolls to the bottom, once, at send time.
+  assert.match(RENDER, /appendActive\(\);[\s\S]{0,500}if \(content\) content\.scrollTop = content\.scrollHeight;\s*\n\s*\}\s*\n\}/);
 });
 
 // The reconcile's two IN-PLACE tail mutations — merging into an existing queued group (a busy session
@@ -29,7 +45,7 @@ test("the plain send registers an optimistic bubble; follow-up/quote sends keep 
 // marks the view stale before appendActive, so every send takes the stale window re-render immediately.
 test("a send paints on ITS OWN keystroke even when the tail mutates in place (no length change)", () => {
   // the stale mark sits between the reconcile and the repaint, so appendActive can't hit the fast path
-  assert.match(RENDER, /reconcileOptimistic\(s\);[\s\S]{0,700}const v = views\.get\(id\);\s*\n\s*if \(v\) v\.stale = true;\s*\n\s*if \(id === activeId\) appendActive\(\);/);
+  assert.match(RENDER, /reconcileOptimistic\(s\);[\s\S]{0,700}const v = views\.get\(id\);\s*\n\s*if \(v\) v\.stale = true;/);
   // the fast path it defeats keys on length + staleness — stale must veto the skip
   assert.match(RENDER, /if \(v\.rendered === len && !v\.stale && v\.el\.childNodes\.length > 0\) return v;/);
   // executed replica: the fast-path predicate must not skip once the view is marked stale, even though
@@ -46,6 +62,17 @@ test("every push entry point re-asserts (or retires) the optimistic tail", () =>
   assert.ok(calls.length >= 4, "reconcile wired into send + all three push paths, got " + calls.length);
 });
 
+test("retire needs a NEW landed atom (base count); kernel provisionals only suppress", () => {
+  // base is stamped on the first reconcile after the send: pre-existing matches are background
+  assert.match(RENDER, /arr\.push\(\{ text, ts: Date\.now\(\), base: -1 \}\);/);
+  assert.match(RENDER, /for \(const p of list\) if \(p\.base < 0\) p\.base = landedCount\(p\.text\);/);
+  // a landed atom is a user event WITHOUT the backend's "echo:" uuid prefix
+  assert.match(RENDER, /&& !String\(\(e as any\)\.uuid \|\| ""\)\.startsWith\("echo:"\)\)\.length;/);
+  // retire = TTL or growth past base; suppression is a separate, non-destructive filter
+  assert.match(RENDER, /const keep = list\.filter\(\(p\) => now - p\.ts < OPT_TTL_MS && landedCount\(p\.text\) <= p\.base\);/);
+  assert.match(RENDER, /const inject = keep\.filter\(\(p\) => !shownProvisional\(p\.text\)\);/);
+});
+
 // The optimistic echo rides the QUEUED idiom (the user 2026-07-16): to the reader an unconfirmed send and a
 // queued one are the same state, so they wear the same dashed bubble — and the look then only ever moves
 // provisional→settled. It first shipped as a 0.6-opacity SOLID bubble, which invented a third look and made a
@@ -56,21 +83,25 @@ test("an optimistic echo is a tail-appended, kernel-invisible QUEUED event — n
   assert.match(RENDER, /const mk = \(p: \{ text: string \}\) => \(\{ md: p\.text, optimistic: true, cancelable: false \}\);/);
   // stale ones pop cheaply off the end (always tail-appended)
   assert.match(RENDER, /while \(s\.events\.length && isOptimistic\(s\.events\[s\.events\.length - 1\]\)\) s\.events\.pop\(\);/);
-  // the abandoned dim idiom is gone from both the render and the stylesheet
+  // the abandoned dim/pending idiom is FULLY gone: render, guard fields, and stylesheet — the last
+  // leftovers (a `!e.pending` guard on a field no event carries, and a stylesheet paragraph describing
+  // the deleted rendering as if it shipped) misdirected the 2026-08-09 bug hunt and are pinned out
   assert.doesNotMatch(RENDER, /ev\.pending/);
+  assert.doesNotMatch(RENDER, /!e\.pending/);
   assert.doesNotMatch(CSS, /\.user-bubble\.pending \{/);
+  assert.doesNotMatch(CSS, /renders EXACTLY like a landed/);
   // it reuses the chat's ONE provisional look rather than adding CSS of its own
   assert.match(CSS, /\.queued-bubble \{[\s\S]*?border: 1px dashed/);
 });
 
 test("nothing known-queued → a BARE dashed bubble (no 'N queued' header we can't back)", () => {
-  assert.match(RENDER, /s\.events\.push\(\{ kind: "queued", bare: true, texts: keep\.map\(mk\), uuid: OPT_PREFIX \+ keep\[0\]\.ts \}\);/);
+  assert.match(RENDER, /s\.events\.push\(\{ kind: "queued", bare: true, texts: inject\.map\(mk\), uuid: OPT_PREFIX \+ inject\[0\]\.ts \}\);/);
   assert.match(RENDER, /if \(!ev\.bare\) \{/, "renderQueued skips the header for a bare group");
 });
 
 test("something IS queued → ours merges into that group, counted under its header", () => {
-  assert.match(RENDER, /s\.events\[qj\] = \{ \.\.\.q, texts: \[\.\.\.q\.texts, \.\.\.keep\.map\(mk\)\] \};/);
-  // and the extension is undone before `landed` runs, so reconcile only ever reads kernel truth
+  assert.match(RENDER, /s\.events\[qj\] = \{ \.\.\.q, texts: \[\.\.\.q\.texts, \.\.\.inject\.map\(mk\)\] \};/);
+  // and the extension is undone before the counts run, so reconcile only ever reads kernel truth
   assert.match(RENDER, /if \(q\.texts\.some\(\(t\) => t\.optimistic\)\) s\.events\[qi\] = \{ \.\.\.q, texts: q\.texts\.filter\(\(t\) => !t\.optimistic\) \};/);
 });
 
@@ -80,27 +111,66 @@ test("an unconfirmed echo gets its own tooltip and never an ✕ (nothing confirm
   assert.match(RENDER, /if \(t\.cancelable && \(t\.idx !== undefined \|\| t\.park !== undefined\)\) \{/);
 });
 
-// executed replica of reconcileOptimistic's keep/retire decision: a send survives until the kernel's payload
-// carries its text (a landed user atom OR a queued bubble), or until the TTL backstop expires.
-test("reconcile keeps an in-flight send until the kernel surfaces it, then drops it", () => {
-  type Ev = { kind: string; md?: string; texts?: { md: string }[] };
+test("chatTail speaks the KERNEL's coordinates — the injected tail is not part of its space", () => {
+  // counting the injected bubble in the gap check masked a genuine 1-event desync (the repair never
+  // fired) and let a delta land PAST the bubble, freezing it into resident events as fake history
+  assert.match(RENDER, /let kernelLen = s\.events\.length;\s*\n\s*while \(kernelLen > 0 && isOptimistic\(s\.events\[kernelLen - 1\]\)\) kernelLen--;/);
+  assert.match(RENDER, /if \(from > kernelLen\) \{/);
+});
+
+// Executed replica of reconcileOptimistic's decision, synced to the reshaped semantics: three outcomes
+// per entry per push — inject (payload has nothing), suppress (a kernel PROVISIONAL is visible: its
+// queued bubble or its "echo:" atom), retire (a NEW landed user atom beyond base, or the TTL).
+test("reconcile: inject on nothing, suppress on kernel provisionals, retire only on NEW landings", () => {
+  type Ev = { kind: string; md?: string; uuid?: string; texts?: { md: string }[] };
   const OPT_TTL_MS = 20_000, OPT_TAIL_SCAN = 30;
-  const reconcile = (events: Ev[], list: { text: string; ts: number }[], now: number) => {
+  type P = { text: string; ts: number; base: number };
+  const reconcile = (events: Ev[], list: P[], now: number) => {
     const tail = events.slice(-OPT_TAIL_SCAN);
-    const landed = (t: string) => tail.some((e) =>
-      (e.kind === "user" && typeof e.md === "string" && e.md.includes(t)) ||
-      (e.kind === "queued" && Array.isArray(e.texts) && e.texts.some((x) => typeof x.md === "string" && x.md.includes(t))));
-    return list.filter((p) => now - p.ts < OPT_TTL_MS && !landed(p.text));
+    const landedCount = (t: string) => tail.filter((e) =>
+      e.kind === "user" && typeof e.md === "string" && e.md.includes(t)
+      && !String(e.uuid || "").startsWith("echo:")).length;
+    const shownProvisional = (t: string) => tail.some((e) =>
+      (e.kind === "queued" && Array.isArray(e.texts) && e.texts.some((x) => typeof x.md === "string" && x.md.includes(t))) ||
+      (e.kind === "user" && typeof e.md === "string" && String(e.uuid || "").startsWith("echo:") && e.md.includes(t)));
+    for (const p of list) if (p.base < 0) p.base = landedCount(p.text);
+    const keep = list.filter((p) => now - p.ts < OPT_TTL_MS && landedCount(p.text) <= p.base);
+    return { keep, inject: keep.filter((p) => !shownProvisional(p.text)) };
   };
   const T0 = 1_000_000;
-  const sent = [{ text: "ship the docs", ts: T0 }];
+  const fresh = (): P[] => [{ text: "continue", ts: T0, base: -1 }];
 
-  // gap: the kernel push carries NEITHER a user atom nor a queued bubble for it → keep asserting
-  assert.equal(reconcile([{ kind: "assistant", md: "working on the prior turn" }], sent, T0 + 500).length, 1);
-  // kernel echoed it as a landed user atom → drop (its real bubble now owns the spot)
-  assert.equal(reconcile([{ kind: "user", md: "ship the docs" }], sent, T0 + 500).length, 0);
-  // busy session: kernel shows it as a QUEUED bubble → also counts as surfaced → drop
-  assert.equal(reconcile([{ kind: "queued", texts: [{ md: "ship the docs" }] }], sent, T0 + 500).length, 0);
+  // gap: the payload carries nothing for it → keep AND inject
+  let r = reconcile([{ kind: "assistant", md: "working on the prior turn" }], fresh(), T0 + 500);
+  assert.equal(r.inject.length, 1);
+
+  // DEFECT A (the resend): an OLDER identical message sits in the tail — base counts it as background,
+  // so the new send still injects instead of retiring itself in the call that created it
+  r = reconcile([{ kind: "user", md: "continue", uuid: "u-old" }], fresh(), T0 + 500);
+  assert.equal(r.inject.length, 1, "a resend must still show its own bubble");
+
+  // …and the same protection for a short message that substrings an older bubble
+  r = reconcile([{ kind: "user", md: "test the continue button", uuid: "u-old" }], fresh(), T0 + 500);
+  assert.equal(r.inject.length, 1, "substring-of-history must not count as landed");
+
+  // kernel shows its QUEUED bubble → suppressed for this push, but NOT retired…
+  const p = fresh();
+  r = reconcile([{ kind: "queued", texts: [{ md: "continue" }] }], p, T0 + 500);
+  assert.equal(r.keep.length, 1);
+  assert.equal(r.inject.length, 0, "no double render beside the kernel's own copy");
+  // …same for the kernel's unlanded echo atom (uuid keeps the backend's echo: prefix)
+  r = reconcile([{ kind: "user", md: "continue", uuid: "echo:abc123" }], p, T0 + 800);
+  assert.equal(r.keep.length, 1);
+  assert.equal(r.inject.length, 0);
+  // DEFECT B (the flash-out): the provisional blinks away in the echo→landed handoff — the entry
+  // survived the suppression, so ours steps straight back in and the message never disappears
+  r = reconcile([{ kind: "assistant", md: "…" }], p, T0 + 1_100);
+  assert.equal(r.inject.length, 1, "the kept entry covers the kernel's own gap");
+  // the real landing (a user atom with a real uuid, beyond base) finally retires it
+  r = reconcile([{ kind: "user", md: "continue", uuid: "u-new" }], p, T0 + 1_400);
+  assert.equal(r.keep.length, 0, "a NEW landed atom is the one retire event");
+
   // TTL backstop: nothing ever surfaced, but past the window we stop asserting a possibly-dropped send
-  assert.equal(reconcile([{ kind: "assistant", md: "…" }], sent, T0 + OPT_TTL_MS + 1).length, 0);
+  r = reconcile([{ kind: "assistant", md: "…" }], fresh(), T0 + OPT_TTL_MS + 1);
+  assert.equal(r.keep.length, 0);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -247,7 +247,13 @@ const order: string[] = [];           // positional tab order (for cycling)
 const OPT_PREFIX = "optimistic:";
 const OPT_TTL_MS = 20_000;    // backstop: a real send always echoes within this; past it we stop asserting
 const OPT_TAIL_SCAN = 30;     // the kernel's version (user atom / queued bubble) always lands at the tail
-const pendingSent = new Map<string, { text: string; ts: number }[]>();   // sid → in-flight optimistic sends
+// sid → in-flight optimistic sends. `base` is how many LANDED user atoms carrying this text the tail
+// already held at send time (stamped on the first reconcile, -1 until then): only a count BEYOND base
+// means THIS send landed. The old retire test was a bare substring scan with no notion of which event
+// carried the text, so a resend — or any short message that substrings an older bubble ("continue",
+// "test") — retired its own entry in the very call that created it, and the send showed nothing at
+// all (the user 2026-08-09, who watched sends vanish for a beat before appearing).
+const pendingSent = new Map<string, { text: string; ts: number; base: number }[]>();
 const isOptimistic = (e: ChatEvent): boolean => !!e.uuid && e.uuid.startsWith(OPT_PREFIX);
 
 // The kernel's own queued group, if one is at the tail. Ours merges INTO it when present: the session is
@@ -274,28 +280,44 @@ function reconcileOptimistic(s: Session): void {
   if (!list || !list.length) return;
   const now = Date.now();
   const tail = s.events.slice(-OPT_TAIL_SCAN);
-  const landed = (t: string) => tail.some((e) =>
-    (e.kind === "user" && typeof e.md === "string" && e.md.includes(t)) ||
-    (e.kind === "queued" && Array.isArray(e.texts) && e.texts.some((x) => typeof x.md === "string" && x.md.includes(t))));
-  const keep = list.filter((p) => now - p.ts < OPT_TTL_MS && !landed(p.text));
+  // A LANDED copy of the text is a real user atom — never the kernel's own provisional echo, whose
+  // uuid keeps the backend's "echo:" prefix all the way into the payload. Retiring on the echo was
+  // the flash-out: the echo deleted our entry for good, then blinked in its own echo→landed handoff
+  // with nothing left to cover the gap (the user 2026-08-09). The header above always said "until
+  // the payload DEMONSTRABLY carries the message" — an unlanded echo demonstrates nothing yet.
+  const landedCount = (t: string) => tail.filter((e) =>
+    e.kind === "user" && typeof e.md === "string" && e.md.includes(t)
+    && !String((e as any).uuid || "").startsWith("echo:")).length;
+  // The kernel's own PROVISIONAL copy — its queued bubble, or its echo atom — SUPPRESSES our bubble
+  // for this push (injecting beside it would show the send twice) but never retires the entry: if
+  // the provisional blinks out on the next push, ours steps straight back in.
+  const shownProvisional = (t: string) => tail.some((e) =>
+    (e.kind === "queued" && Array.isArray(e.texts) && e.texts.some((x) => typeof x.md === "string" && x.md.includes(t))) ||
+    (e.kind === "user" && typeof e.md === "string" && String((e as any).uuid || "").startsWith("echo:") && e.md.includes(t)));
+  // First reconcile after the send (registerOptimistic calls this synchronously): whatever matching
+  // atoms the tail ALREADY holds are background — an older identical message, a bubble this text
+  // substrings — not this send. Only growth past this count is a landing.
+  for (const p of list) if (p.base < 0) p.base = landedCount(p.text);
+  const keep = list.filter((p) => now - p.ts < OPT_TTL_MS && landedCount(p.text) <= p.base);
   if (keep.length) pendingSent.set(s.id, keep); else pendingSent.delete(s.id);
-  if (!keep.length) return;
+  const inject = keep.filter((p) => !shownProvisional(p.text));
+  if (!inject.length) return;
   const mk = (p: { text: string }) => ({ md: p.text, optimistic: true, cancelable: false });
   const qj = tailQueuedIdx(s.events);
   if (qj >= 0) {
     // something IS queued here → ours queues behind it: show it in that group, under its header, counted
     const q = s.events[qj] as Extract<ChatEvent, { kind: "queued" }>;
-    s.events[qj] = { ...q, texts: [...q.texts, ...keep.map(mk)] };
+    s.events[qj] = { ...q, texts: [...q.texts, ...inject.map(mk)] };
   } else {
     // nothing known-queued → a BARE dashed bubble: no "N queued messages" header to claim what we can't back
-    s.events.push({ kind: "queued", bare: true, texts: keep.map(mk), uuid: OPT_PREFIX + keep[0].ts });
+    s.events.push({ kind: "queued", bare: true, texts: inject.map(mk), uuid: OPT_PREFIX + inject[0].ts });
   }
 }
 
 // Record a composer send as in-flight and show its optimistic bubble NOW (before any kernel push).
 function registerOptimistic(id: string, text: string): void {
   const arr = pendingSent.get(id) || [];
-  arr.push({ text, ts: Date.now() });
+  arr.push({ text, ts: Date.now(), base: -1 });   // base is stamped by the reconcile just below
   pendingSent.set(id, arr);
   const s = sessions.get(id);
   if (!s) return;
@@ -308,7 +330,15 @@ function registerOptimistic(id: string, text: string): void {
   // in every case, not just the length-growing bare-bubble one.
   const v = views.get(id);
   if (v) v.stale = true;
-  if (id === activeId) appendActive();
+  if (id === activeId) {
+    appendActive();
+    // Your OWN send always reveals itself: appendActive's stick rule keeps the viewport still when
+    // you're read up >80px from the bottom, so a send made while scrolled up painted below the fold
+    // and looked like it never appeared (the user 2026-08-09). Hitting Enter is the intent to see
+    // the message — scroll to it, exactly once, at send time.
+    const content = document.getElementById("content");
+    if (content) content.scrollTop = content.scrollHeight;
+  }
 }
 
 // ── conversation rewind (edit a past message, SDK sessions) ──────────────────────────────────────
@@ -338,7 +368,7 @@ function reconcileRewind(s: Session): void {
   if (s.status?.backend === "sdk") {
     for (let i = lastCompact + 1; i < s.events.length; i++) {
       const e = s.events[i] as any;
-      if (e.kind === "user" && e.human && e.uuid && !e.romp && !e.interruptMarker && !e.pending
+      if (e.kind === "user" && e.human && e.uuid && !e.romp && !e.interruptMarker
           && !e.uuid.startsWith(OPT_PREFIX)) editable.add(e.uuid);
     }
   }
@@ -7888,7 +7918,14 @@ function chatTail(msg: any) {
   if (!s) return;                                  // no base yet → ignore; a full session must arrive first
   // msg.from is a GLOBAL transcript index; the resident events are the tail [headFrom, …) → map to local.
   const from = (msg.from | 0) - (s.headFrom || 0);
-  if (from > s.events.length) {
+  // The kernel's coordinate space ends at ITS OWN events — our injected optimistic tail is not in it.
+  // Comparing `from` against the inflated length masked a genuine 1-event gap (the repair below never
+  // fired, PR #107's desync class), and a delta starting exactly one past kernel truth landed BEYOND
+  // the injected bubble, freezing it into the resident events as fake history the reconcile's strip
+  // loop could never pop (the user 2026-08-09).
+  let kernelLen = s.events.length;
+  while (kernelLen > 0 && isOptimistic(s.events[kernelLen - 1])) kernelLen--;
+  if (from > kernelLen) {
     // GAP: the delta starts PAST what we hold, so the events in between never reached us. Applying it would
     // fabricate a transcript that silently skips them. This used to just `return` and "wait for the next
     // full" — but no full was ever coming: the kernel's per-client bookkeeping (_send_chat's echat) advances

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1050,13 +1050,10 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   border-radius: 14px; padding: 9px 14px; color: #ffffff;
   display: flow-root;   /* contain inner floats (e.g. image captions) */
 }
-/* A just-sent message, shown optimistically before the kernel echoes it back, renders EXACTLY like a landed
-   one — no dim, no distinct state (the user 2026-07-16). It first shipped dimmed-to-0.6, which invented a
-   THIRD provisional look next to the dashed .queued-bubble and made every send flicker dim→solid as the
-   kernel's copy superseded it. The chat already has one provisional idiom (dashed = queued behind a busy
-   turn); a plain send isn't that, and a fake "sending" state would only lie on an idle session. So the
-   optimistic bubble is visually identical to its replacement: the message simply appears and stays. If it
-   really is queued, the kernel's dashed bubble takes over a beat later — that flip is real information. */
+/* (A just-sent message renders as the dashed .queued-bubble via the QUEUED idiom — see render.ts's
+   optimistic-echo block. An earlier design rendered it as a solid user bubble with a .pending state;
+   that rule is long gone, and the paragraph here describing it outlived it by a month, asserting the
+   opposite of the shipped behavior — removed 2026-08-09 when it misdirected a bug hunt.) */
 /* ── edit-message affordance (SDK sessions) ── hover a human bubble → a small "edit" button under it;
    clicking arms the composer's edit mode (rewind + branch). Mirrors .code-copy's reveal-on-hover. */
 .msg-edit {


### PR DESCRIPTION
Diagnosis and fix for the recurring "my sent message doesn't appear / vanishes for a beat" report (the user 2026-08-09).

Two real defects in the optimistic-echo layer's retire logic (`reconcileOptimistic`):
- **A — self-retire at send time.** The landed test was a bare substring scan over the last 30 events. A resend, or a short message that substrings an older bubble ("continue", "test"), matched history and retired the entry in the same call that created it — no bubble, deterministically. Now each send stamps a `base` count of matching landed atoms at send time; only growth past it retires.
- **B — one-way retirement on the kernel's own provisionals.** The kernel's queued bubble and its `echo:` atom counted as landed and deleted the entry; when that provisional blinked in the echo→landed handoff the send vanished briefly. Provisionals (recognized by the `echo:` uuid prefix that rides into the payload) now merely suppress injection per push; the entry survives to step back in.

Also fixed on the same path: chatTail's gap check ran against a length inflated by the injected tail (masking real desyncs and able to freeze the bubble into resident events as fake history) — now kernel-owned coordinates; a send made while scrolled up painted below the fold — own sends scroll to bottom once; the stale stylesheet paragraph and dead `e.pending` guard that misdirected the hunt are removed; and `_ensure_bundles` staleness now watches `ui/webview`, where esbuild actually reads the webview sources — a render.ts-only fix used to never mark the bundle stale.

Tests: the optimistic-send replica is synced to the new inject/suppress/retire semantics with cases for both defects; chatTail coordinate pins updated (node + python twins); new bundle-staleness-scan test. pytest 4059 green, node suite green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)