### PR TITLE
Configurable shortcuts dialog; settings lift can't black out the chat; usage hover names its login

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14023,6 +14023,10 @@ def _usage():
            # DIFFERENT accounts have genuinely separate allowances and pooling them was a lie (the user
            # 2026-07-30). An opaque digest — equality is the whole question, and no identifier travels.
            "acct": _claude_account(),
+           # …and its NAME, for the hover (the user 2026-08-09, who wanted the usage tip to say which
+           # account the windows belong to, the way the tab hover does). The dedup stays on the digest;
+           # this is display only, "" when no login.
+           "acctLabel": _claude_account_label(),
            "limited": limited if any(limited.values()) else None}
     # API-KEY spend BESIDE the bars — the KEYED split only (turns whose session billed the key; a login
     # turn's computed cost is dollars nobody pays), attached only when key turns actually exist, so a
@@ -17737,17 +17741,20 @@ paint();})();
 # Alt+Arrow nav (_LANDING_FOCUS_JS): capture on the shell document AND on every same-origin pane
 # document, re-attached on every iframe (re)load. Each panel exposes its OWN close (their state
 # cleanup lives in those closures); this block only decides which panel Escape means, topmost first
-# (usage z300 > Log z210 > net z200). With no shell modal open it touches nothing, so pane-local
-# Escapes (dialogs, menus inside the chat) keep working.
+# (shortcuts dialog z300 — whose close() first CANCELS an in-progress chord recording, one Escape
+# level at a time — then usage z300 > Log z210 > net z200). With no shell modal open it touches
+# nothing, so pane-local Escapes (dialogs, menus inside the chat) keep working.
 _LANDING_ESC_JS = """
 (function(){
 function onEsc(e){if(e.key!=='Escape')return;
-var closed=false,ru=document.getElementById('ru-back');
+var closed=false;
+if(window.__rompKeysClose&&window.__rompKeysClose()){closed=true;}
+else{var ru=document.getElementById('ru-back');
 if(ru&&ru.classList.contains('on')&&window.__rompUsageClose){window.__rompUsageClose();closed=true;}
 else{var er=document.getElementById('rerr-back');
 if(er&&!er.hidden&&window.__rompCloseErrs){window.__rompCloseErrs();closed=true;}
 else{var nt=document.getElementById('rnet-back');
-if(nt&&!nt.hidden&&window.__rompCloseNet){window.__rompCloseNet();closed=true;}}}
+if(nt&&!nt.hidden&&window.__rompCloseNet){window.__rompCloseNet();closed=true;}}}}
 if(closed){e.preventDefault();e.stopPropagation();}}
 document.addEventListener('keydown',onEsc,true);
 ['f-chat','f-fleet','f-feed','f-timeline'].forEach(function(id){var f=document.getElementById(id);if(!f)return;
@@ -17843,6 +17850,7 @@ SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='numbe
 // the rail no longer draws each account's own bars (they aggregate, below), but the tip still tells
 // each host's story from this.
 function winDet(u,det){var nowS=Math.floor(Date.now()/1000);
+if(u.acctLabel)det._acct=u.acctLabel;   // WHICH login the windows belong to (the user 2026-08-09) — hover-only
 WINS.forEach(function(w){var seg=u[w[0]];if(!seg)return;
 // A ROLLED window (its reset passed since the last report) is UNKNOWN, not 0 (the user 2026-07-31: a
 // remote whose kernel had no live session to ask sat on a days-old snapshot, and the rail drew a
@@ -17937,6 +17945,9 @@ function setHTML(e,many){var d=e.det,keys=['fiveHour','sevenDay','fable'].filter
 var sp=d._spend||null;
 if(!keys.length&&!sp)return '';
 var h=(many?'<div class=ru-tip-host>'+esc(e.host)+'</div>':'');
+// the account the window bars belong to, named the way the tab hover names it (the user 2026-08-09);
+// only beside actual window sections — a key-only host's spend already says whose dollars they are
+if(d._acct&&keys.length)h+='<div class=ru-tip-acct>'+esc(d._acct)+'</div>';
 h+=keys.map(function(k){var v=d[k];
 return '<div class=ru-tip-win><div class=ru-tip-name><span>'+esc(v.name)+'</span>'
 +(v.unk?'<span class=ru-tip-reset>window reset '+esc(v.ago)+'; no reading since</span>'
@@ -19227,6 +19238,10 @@ def _landing():
             "color:#9aa0a6;text-transform:lowercase;margin:0 0 4px}"
             "#ru-tip .ru-tip-host:not(:first-child){margin-top:10px;padding-top:8px;"
             "border-top:1px solid rgba(255,255,255,0.08)}"
+            # the login the window bars belong to (the user 2026-08-09) — quiet, above the sections,
+            # the host heading's size without its lowercase-italic host vocabulary
+            ".ru-tip-acct{font:400 10px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;"
+            "color:#9aa0a6;margin:0 0 4px}"
             # the three TOP panes flex-grow by a per-pane var (resized by the gutters, persisted); toggling one
             # off hides it AND the now-orphaned gutters. Fixed order: chat, fleet, feed. Timeline is the band.
             "#chat-pane{flex:var(--g-chat,60) 1 0}#fleet-pane{flex:var(--g-fleet,34) 1 0}#feed-pane{flex:var(--g-feed,40) 1 0}"

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -167,17 +167,17 @@ class PaneRailTest(unittest.TestCase):
         # folded into settings (the user 2026-06-30): no standalone ? modal in the shell anymore
         self.assertNotIn("id=rhelp-overlay", self.html)
         self.assertNotIn("id=rail-help", self.html)
-        # the shortcuts render as a section in the feed's settings modal — a flat verified list, keys in <kbd>
-        # the modal lives in the feed BUNDLE now (ui/webview/gear.js, 2026-07-13)
+        # the section is a LINK now (the user 2026-08-09): the configurable shortcuts dialog
+        # (ui/webview/shortcuts-modal.ts) is the one home for the whole list — record, conflicts,
+        # reset — and the gear row just opens it (VS Code's row points at its own keybindings editor
+        # instead). The old static list is gone with its stale-per-surface copies, Enter row first.
         import pathlib
         gear = (pathlib.Path(__file__).resolve().parent.parent / "ui" / "webview" / "gear.js").read_text()
         self.assertIn(">Keyboard shortcuts</div>", gear)
-        self.assertIn("class=rs-key", gear)
-        self.assertIn("<kbd>Enter</kbd>", gear)
-        self.assertIn("Send message", gear)
-        self.assertIn("Interrupt the session", gear)
-        self.assertIn("Switch session (from the tabs)", gear)
-        self.assertIn("Jump to the session tabs", gear)
+        self.assertIn("Customize shortcuts…", gear)
+        self.assertIn("'openKeys'", gear)
+        self.assertNotIn("Send message", gear, "the Enter row is gone — a typing key nobody looks up")
+        self.assertNotIn("<kbd>Enter</kbd>", gear)
         self.assertNotIn("Slash-command menu", gear)
         self.assertNotIn("Question picker", gear)
 

--- a/tests/test_usage_per_account.py
+++ b/tests/test_usage_per_account.py
@@ -69,6 +69,9 @@ class AccountIdentity(unittest.TestCase):
 
     def test_the_usage_payload_carries_it(self):
         self.assertIn('"acct": _claude_account(),', inspect.getsource(km._usage))
+        # …and, since 2026-08-09, the login's NAME beside it — display for the hover only (the
+        # rail's cross-host dedup stays on the digest, which carries nothing)
+        self.assertIn('"acctLabel": _claude_account_label(),', inspect.getsource(km._usage))
 
 
 class FleetRollup(unittest.TestCase):

--- a/ui/webview/commands.ts
+++ b/ui/webview/commands.ts
@@ -3,9 +3,14 @@
 // becomes keyboard-reachable by registering it — never by minting another hotkey.
 
 export type PaletteCommand = {
-  id: string;      // stable, dot-namespaced ("session.open")
-  title: string;   // what the palette shows and matches on — the user's words, verb first
-  kbd?: string;    // display-only hotkey chip ("⌘O"); the actual binding lives with the key wiring
+  id: string;       // stable, dot-namespaced ("session.open")
+  title: string;    // what the palette shows and matches on — the user's words, verb first
+  chord?: string;   // DEFAULT key binding, "Mod" form ("Mod+O" — Meta on a Mac, Ctrl elsewhere).
+                    // The user's overrides live in the keybindings store (romp:keys); what a command
+                    // actually answers to is effectiveChord(), and the palette's hotkey chip shows
+                    // that, so a rebound command never advertises a stale default (the user 2026-08-09).
+  hidden?: boolean; // bindable but not listed in the palette (palette.toggle: running "toggle the
+                    // palette" FROM the palette would just blink it)
   run: () => void;
 };
 

--- a/ui/webview/esc-close.test.ts
+++ b/ui/webview/esc-close.test.ts
@@ -23,12 +23,15 @@ test("the shared Escape block wires the shell document AND every pane document",
 });
 
 test("topmost first, and only when a shell modal is actually open", () => {
-  // usage modal (z300) beats the Log (z210) beats the net panel (z200); with nothing open the
-  // handler touches nothing, so pane-local Escapes (chat dialogs, menus) keep working
+  // the shortcuts dialog (z300, whose close() first cancels an in-progress recording) beats the
+  // usage modal (z300, opened from elsewhere) beats the Log (z210) beats the net panel (z200);
+  // with nothing open the handler touches nothing, so pane-local Escapes keep working
+  const ky = ESC.indexOf("__rompKeysClose");
   const ru = ESC.indexOf("__rompUsageClose");
   const er = ESC.indexOf("__rompCloseErrs");
   const nt = ESC.indexOf("__rompCloseNet");
-  assert.ok(ru > -1 && er > ru && nt > er, "priority order: usage, Log, net");
+  assert.ok(ky > -1 && ru > ky && er > ru && nt > er, "priority order: shortcuts, usage, Log, net");
+  assert.ok(ESC.includes("window.__rompKeysClose&&window.__rompKeysClose()"), "the dialog reports whether it consumed the press");
   assert.ok(ESC.includes("ru.classList.contains('on')"));
   assert.ok(ESC.includes("!er.hidden"));
   assert.ok(ESC.includes("!nt.hidden"));

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -24,9 +24,14 @@
 body.rs-lifted { position: fixed; left: var(--pane-x, 0); top: var(--pane-y, 0);
   width: var(--pane-w, 100%); height: var(--pane-h, 100%); overflow: hidden;
   background: var(--bg, #1e1e1e); }
-/* no measurable pane to stand in for (hidden pane, or a cross-origin parent like VS Code):
-   fall back to hiding the feed's own content so only the settings card draws */
+/* no measurable pane to stand in for (hidden pane, a sliver, mobile's display:contents rows, or a
+   cross-origin parent like VS Code): hide the feed's own content so only the settings card draws —
+   and the fallback box goes TRANSPARENT (the user 2026-08-09): with no --pane-* vars set, body.rs-lifted
+   above is a full-viewport sheet, and painted --bg it blacked out every pane behind the modal (the
+   chat vanished, unlike every other panel). Transparent, the dashboard shows through the dim exactly
+   like the measurable case; in VS Code the webview's own background stands behind it, same as before. */
 body.rs-pane-gone #feed-head, body.rs-pane-gone #feed-list, body.rs-pane-gone #feed-foot { visibility: hidden; }
+body.rs-lifted.rs-pane-gone { background: transparent; }
 .rs-card { width: min(560px, 94%); max-height: 88vh; overflow: auto; background: #252526; border: 1px solid #3a3a3a;
   border-radius: 10px; padding: 16px 20px; font: 13px/1.6 system-ui, -apple-system, 'Segoe UI', sans-serif; color: #ccc; box-shadow: 0 12px 36px #000000aa; }
 #rsettings .rs-h { font-size: 14px; font-weight: 600; margin-bottom: 6px; color: #e8eaed; }
@@ -81,6 +86,11 @@ body.rs-pane-gone #feed-head, body.rs-pane-gone #feed-list, body.rs-pane-gone #f
 #rsettings .rs-key { display: flex; align-items: baseline; gap: 12px; padding: 3px 0; }
 #rsettings .rs-key-combo { flex: 0 0 auto; min-width: 108px; }
 #rsettings .rs-key-desc { flex: 1 1 auto; color: #cdd3da; }
+#rsettings .rs-key[hidden] { display: none; }
+/* the customize link that replaced the static list (the shell's shortcuts dialog owns it now) */
+#rs-keys-btn { flex: 0 0 auto; cursor: pointer; background: #2a2a2a; color: #ccc;
+  border: 1px solid #3a3a3a; border-radius: 5px; padding: 3px 8px; font: inherit; }
+#rs-keys-btn:hover { background: #333; color: #e8eaed; }
 #rsettings kbd { display: inline-block; background: #1c1c1f; border: 1px solid #3d3d42; border-bottom-width: 2px;
   border-radius: 4px; padding: 1px 6px; font: 600 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; color: #e6e6e6; }
 /* token-usage analytics: a button in the gear panel opens a centered modal with the chart. */

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -27,16 +27,16 @@ function ku(path) {
   return kb() + path + (path.indexOf('?') >= 0 ? '&' : '?') + 'token=' + encodeURIComponent(tok);
 }
 
-// Static port of the kernel's _shortcut_rows() (the chat-surface shortcuts).
+// The keyboard-shortcuts SECTION is one link now (the user 2026-08-09): the full list — bindable
+// commands, recording, conflicts — lives in the shell's shortcuts dialog (shortcuts-modal.ts), and
+// this row just opens it. Web shell only: in VS Code the same actions are contributed rompChat.*
+// commands, rebindable in VS Code's own Keyboard Shortcuts editor, so the row says that instead
+// (a second editor there would fight the native one). The old static list is gone with the section
+// (it opened with "Enter — send message", a typing key nobody looks up, and went stale per surface).
 var SHORTCUT_ROWS =
-  '<div class=rs-key><span class=rs-key-combo><kbd>Enter</kbd></span><span class=rs-key-desc>Send message</span></div>' +
-  '<div class=rs-key><span class=rs-key-combo><kbd>Shift</kbd> + <kbd>Enter</kbd></span><span class=rs-key-desc>New line</span></div>' +
-  '<div class=rs-key><span class=rs-key-combo><kbd>Esc</kbd></span><span class=rs-key-desc>Jump to the session tabs</span></div>' +
-  '<div class=rs-key><span class=rs-key-combo><kbd>←</kbd> / <kbd>→</kbd></span><span class=rs-key-desc>Switch session (from the tabs)</span></div>' +
-  '<div class=rs-key><span class=rs-key-combo><kbd>Ctrl</kbd> + <kbd>C</kbd></span><span class=rs-key-desc>Interrupt the session</span></div>' +
-  '<div class=rs-key><span class=rs-key-combo><kbd>⌘/Ctrl</kbd> + <kbd>O</kbd></span><span class=rs-key-desc>Jump to a session (quick switcher)</span></div>' +
-  '<div class=rs-key><span class=rs-key-combo><kbd>⌘/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>O</kbd></span><span class=rs-key-desc>New session picker</span></div>' +
-  '<div class=rs-key><span class=rs-key-combo><kbd>⌘/Ctrl</kbd> + <kbd>P</kbd></span><span class=rs-key-desc>Command palette (browser dashboard)</span></div>';
+  '<div class=rs-key id=rs-keys-web hidden><button id=rs-keys-btn type=button>Customize shortcuts…</button>' +
+  '<span class=rs-key-desc>view, record and rebind every dashboard shortcut</span></div>' +
+  '<div class=rs-key id=rs-keys-vsc hidden><span class=rs-key-desc>Shortcuts are VS Code keybindings here — search "rompChat" in Keyboard Shortcuts.</span></div>';
 
 // The modal markup — ported verbatim from the kernel's _gear_html; the model/
 // effort selects start empty and are filled from /models (see fill()).
@@ -273,17 +273,36 @@ function initGear(post) {
     else if (tries > 0) requestAnimationFrame(function () { placeLifted(tries - 1); });
   }
   function onRsResize() { placeLifted(0); }   // panes track the window; follow them while open
+  function clearPaneVars() { var st = document.documentElement.style;   // a stale rect from THIS open must not
+    ['--pane-x', '--pane-y', '--pane-w', '--pane-h'].forEach(function (k) { st.removeProperty(k); }); }   // place the NEXT one (the user 2026-08-09)
   function setModalCls(on) { var de = document.documentElement, m = 'rs-modal-open';
     if (on) { de.classList.add(m); document.body.classList.add(m);
       if (window.parent !== window) { document.body.classList.add('rs-lifted'); placeLifted(5); window.addEventListener('resize', onRsResize); } }
     else { de.classList.remove(m); document.body.classList.remove(m);
       document.body.classList.remove('rs-lifted'); document.body.classList.remove('rs-pane-gone');
+      clearPaneVars();
       window.removeEventListener('resize', onRsResize); } }
   function closeSettings() { p.hidden = true; setModalCls(false); feedFull(false); }
   function openSettings() { if (!p.hidden) { closeSettings(); return; }   // the opener toggles the modal
-    p.hidden = false; setModalCls(true); feedFull(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch !== false; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cg) cg.checked = s.collapseGaps !== false; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    // Signal the SHELL first, then measure (the picker's order, adopted 2026-08-09): feedFull posts
+    // settings-open, which is what un-hides #feed-pane when the feed is toggled off — measuring first
+    // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
+    // full-viewport fallback box blacked out every pane behind the modal.
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch !== false; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cg) cg.checked = s.collapseGaps !== false; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
+  // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the
+  // shell's shortcuts dialog and closes this modal so the two never stack; VS Code (cross-origin
+  // parent) gets the pointer at its own Keyboard Shortcuts editor instead (the user 2026-08-09).
+  (function () {
+    var web = false;
+    try { web = window.parent !== window && !!window.parent.document; } catch (e) { web = false; }
+    var wrow = document.getElementById('rs-keys-web'), vrow = document.getElementById('rs-keys-vsc');
+    if (wrow) wrow.hidden = !web;
+    if (vrow) vrow.hidden = web;
+    var kb2 = document.getElementById('rs-keys-btn');
+    if (kb2) kb2.onclick = function () { closeSettings(); try { window.parent.postMessage({ romp: 'openKeys' }, '*'); } catch (e) { /* no shell to ask */ } };
+  })();
   p.addEventListener('click', function (e) { if (e.target === p) closeSettings(); });   // click the dimmed backdrop (not the card) → close
   document.addEventListener('click', function (e) { if (!p.hidden && e.target !== g && !p.contains(e.target)) closeSettings(); });
   var rf = document.getElementById('rrefresh');   // ↻ (web shell rail only): POST /restart, poll /healthz, reload

--- a/ui/webview/keybindings.test.ts
+++ b/ui/webview/keybindings.test.ts
@@ -1,0 +1,85 @@
+// The keybindings model (ui/webview/keybindings.ts) — real unit tests: chord normalization, platform
+// resolution and display, the override/default/conflict rules the shortcuts dialog enforces, and the
+// dispatch guard. Pure module, no DOM at import (the store functions guard their localStorage/window
+// touches), so these run the REAL code — not a replica.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  bindable, chordMap, chordOf, conflictOf, dispatchable, displayChord, effectiveChord, resolveChord,
+} from "./keybindings";
+
+const ev = (key: string, m: Partial<{ ctrl: boolean; alt: boolean; shift: boolean; meta: boolean }> = {}) =>
+  ({ key, ctrlKey: !!m.ctrl, altKey: !!m.alt, shiftKey: !!m.shift, metaKey: !!m.meta });
+
+test("chordOf normalizes: fixed modifier order, uppercased letters, named keys kept, bare modifiers null", () => {
+  assert.equal(chordOf(ev("o", { meta: true })), "Meta+O");
+  assert.equal(chordOf(ev("O", { meta: true, shift: true })), "Shift+Meta+O", "canonical order: Ctrl, Alt, Shift, Meta — Apple's own \u2303\u2325\u21e7\u2318");
+  assert.equal(chordOf(ev("p", { ctrl: true, alt: true, shift: true, meta: true })), "Ctrl+Alt+Shift+Meta+P");
+  assert.equal(chordOf(ev("ArrowLeft", { alt: true })), "Alt+ArrowLeft");
+  assert.equal(chordOf(ev("F5")), "F5");
+  assert.equal(chordOf(ev("Meta", { meta: true })), null, "a held modifier is not a chord yet");
+  assert.equal(chordOf(ev("Shift", { shift: true })), null);
+});
+
+test("Mod resolves per platform, only as a modifier prefix", () => {
+  assert.equal(resolveChord("Mod+O", true), "Meta+O");
+  assert.equal(resolveChord("Mod+O", false), "Ctrl+O");
+  assert.equal(resolveChord("Mod+Shift+O", true), "Shift+Meta+O", "resolution NORMALIZES: a Shift-carrying default must equal the keydown's own spelling");
+  assert.equal(resolveChord("Meta+O", false), "Meta+O", "concrete chords pass through untouched");
+});
+
+test("display: mac wears symbols with no separators, elsewhere spells the names", () => {
+  assert.equal(displayChord("Mod+Shift+O", true), "⇧⌘O");
+  assert.equal(displayChord("Mod+Shift+O", false), "Ctrl+Shift+O");
+  assert.equal(displayChord("Alt+ArrowLeft", true), "⌥←");
+  assert.equal(displayChord("Alt+ArrowLeft", false), "Alt+←");
+});
+
+test("bindable refuses what the panes own: bare typing keys and Escape in any dress", () => {
+  for (const bad of ["Escape", "Enter", "Tab", "Backspace", "Delete", "A", "1"]) {
+    assert.equal(bindable(bad), false, bad + " must not be bindable bare");
+  }
+  assert.equal(bindable("Ctrl+Enter"), true, "with a real modifier a typing key is a chord");
+  assert.equal(bindable("Meta+Shift+Escape"), false, "Escape stays the universal close");
+  assert.equal(bindable("F5"), true, "bare named keys are fine");
+  assert.equal(bindable("Home"), true);
+});
+
+const CMDS = [
+  { id: "a.one", chord: "Mod+O" },
+  { id: "a.two", chord: "Mod+P" },
+  { id: "a.free" },   // no default
+];
+
+test("effectiveChord: override beats default, empty override means deliberately unbound", () => {
+  assert.equal(effectiveChord("a.one", "Mod+O", {}, true), "Meta+O");
+  assert.equal(effectiveChord("a.one", "Mod+O", { "a.one": "Ctrl+J" }, true), "Ctrl+J");
+  assert.equal(effectiveChord("a.one", "Mod+O", { "a.one": "" }, true), "", "unbound stays unbound");
+  assert.equal(effectiveChord("a.free", undefined, {}, true), "", "no default, no override → nothing");
+});
+
+test("chordMap resolves the whole registry through the overrides", () => {
+  const m = chordMap(CMDS, { "a.two": "Ctrl+K", "a.free": "F6" }, false);
+  assert.equal(m.get("Ctrl+O"), "a.one");         // default, Mod resolved for the platform
+  assert.equal(m.get("Ctrl+K"), "a.two");         // override wins
+  assert.equal(m.get("Ctrl+P"), undefined, "the overridden default no longer answers");
+  assert.equal(m.get("F6"), "a.free");
+});
+
+test("conflictOf names the command already holding a chord — and respects overrides", () => {
+  assert.equal(conflictOf("Mod+P", "a.one", CMDS, {}, true), "a.two");
+  assert.equal(conflictOf("Mod+P", "a.two", CMDS, {}, true), null, "a command never conflicts with itself");
+  assert.equal(conflictOf("Mod+P", "a.one", CMDS, { "a.two": "" }, true), null,
+    "an unbound command holds nothing to conflict with");
+  assert.equal(conflictOf("F6", "a.one", CMDS, { "a.free": "F6" }, true), "a.free",
+    "an override-held chord conflicts like a default");
+});
+
+test("dispatchable: never on repeat; modifier-less chords never fire while typing", () => {
+  assert.equal(dispatchable({ ctrlKey: false, altKey: false, metaKey: false, repeat: true }, false), false);
+  assert.equal(dispatchable({ ctrlKey: false, altKey: false, metaKey: false }, true), false,
+    "a bare (or Shift-only) key in a composer is typing, not a command");
+  assert.equal(dispatchable({ ctrlKey: false, altKey: false, metaKey: false }, false), true);
+  assert.equal(dispatchable({ ctrlKey: false, altKey: false, metaKey: true }, true), true,
+    "a real modifier fires regardless of focus");
+});

--- a/ui/webview/keybindings.ts
+++ b/ui/webview/keybindings.ts
@@ -1,0 +1,120 @@
+// Keyboard bindings for the shell's commands (the user 2026-08-09, who wanted the shortcuts
+// configurable "the way VS Code does it": record a chord, see conflicts, reset). This module is the
+// PURE half — chord normalization, display, the localStorage store, conflict resolution, and the
+// dispatch decision — so every rule here runs under real tests; the DOM (the dialog, the key wiring)
+// lives in shortcuts-modal.ts / palette-main.ts. The VS Code surface does NOT use any of this: there
+// the same actions are contributed commands, rebindable in VS Code's own Keyboard Shortcuts editor.
+//
+// A chord is a normalized string: modifiers in the fixed order Ctrl, Alt, Shift, Meta, then the key —
+// "Meta+Shift+O", "Ctrl+P", "Alt+ArrowLeft". Single-character keys are uppercased; named keys keep
+// their KeyboardEvent.key spelling. Defaults are declared with the "Mod" placeholder ("Mod+O"), which
+// resolves to Meta on a Mac and Ctrl elsewhere — one declaration, both platforms.
+
+export type Bindings = Record<string, string>;   // command id → chord ("" = deliberately unbound)
+
+const KEY = "romp:keys";
+export const KEYS_EVENT = "romp:keys";           // window event raised on every save (same-document)
+
+// ── chord model ───────────────────────────────────────────────────────────────────────────────────
+
+const MOD_ORDER = ["Ctrl", "Alt", "Shift", "Meta"];
+
+// The chord a keydown spells, or null when it's a bare modifier (still being held, nothing to bind).
+export function chordOf(e: { key: string; ctrlKey: boolean; altKey: boolean; shiftKey: boolean; metaKey: boolean }): string | null {
+  const k = e.key;
+  if (!k || k === "Control" || k === "Alt" || k === "Shift" || k === "Meta") return null;
+  const parts: string[] = [];
+  if (e.ctrlKey) parts.push("Ctrl");
+  if (e.altKey) parts.push("Alt");
+  if (e.shiftKey) parts.push("Shift");
+  if (e.metaKey) parts.push("Meta");
+  parts.push(k.length === 1 ? k.toUpperCase() : k);
+  return parts.join("+");
+}
+
+// A default's "Mod" resolves per platform, and the result is NORMALIZED to the canonical modifier
+// order — every comparison flows through here, so a default declared "Mod+Shift+O" (Meta+Shift) and
+// the keydown's own spelling (Shift+Meta) land on the same string. The executed test caught the
+// mismatch: without the re-sort, no Shift-carrying default ever matched a real keypress.
+export function resolveChord(chord: string, mac: boolean): string {
+  const parts = chord.replace(/(^|\+)Mod(\+)/, (m, a, b) => a + (mac ? "Meta" : "Ctrl") + b).split("+");
+  const key = parts.pop() || "";
+  const mods = MOD_ORDER.filter((m) => parts.includes(m));
+  return [...mods, key].join("+");
+}
+
+// Chords a binding may NOT be: bare typing/navigation keys the panes own (Escape closes modals,
+// Enter/Tab/Space/Backspace type). With modifiers they're fine (Ctrl+Enter is a real chord).
+export function bindable(chord: string): boolean {
+  if (chord.includes("+")) {
+    const key = chord.split("+").pop() || "";
+    return key !== "Escape";   // Escape stays the universal close, whatever the modifiers
+  }
+  if (/^(Escape|Enter|Tab| |Backspace|Delete)$/.test(chord)) return false;   // the panes own these bare
+  return chord.length > 1;     // bare named keys (F1, Home) are fine; a bare letter would fire while typing
+}
+
+// Display: ⌘⇧O on a Mac (symbols, no separators), Ctrl+Shift+O elsewhere.
+export function displayChord(chord: string, mac: boolean): string {
+  const c = resolveChord(chord, mac);
+  const KEYCAP: Record<string, string> = { ArrowLeft: "←", ArrowRight: "→", ArrowUp: "↑", ArrowDown: "↓" };
+  const parts = c.split("+").map((p) => KEYCAP[p] || p);
+  if (!mac) return parts.join("+");
+  const SYM: Record<string, string> = { Ctrl: "⌃", Alt: "⌥", Shift: "⇧", Meta: "⌘" };
+  return parts.map((p) => SYM[p] || p).join("");
+}
+
+// ── the store: user overrides over per-command defaults ──────────────────────────────────────────
+
+export function loadOverrides(): Bindings {
+  try {
+    const d = JSON.parse(localStorage.getItem(KEY) || "{}");
+    return d && typeof d === "object" ? (d as Bindings) : {};
+  } catch (e) { return {}; }
+}
+
+// chord = the new binding; "" = unbind; null = forget the override (back to the default)
+export function saveOverride(id: string, chord: string | null): void {
+  const all = loadOverrides();
+  if (chord === null) delete all[id]; else all[id] = chord;
+  try { localStorage.setItem(KEY, JSON.stringify(all)); } catch (e) { /* storage full/blocked */ }
+  try { window.dispatchEvent(new Event(KEYS_EVENT)); } catch (e) { /* non-DOM (tests) */ }
+}
+
+// The chord a command answers to right now: the override when one exists, else its default, resolved.
+export function effectiveChord(id: string, defaultChord: string | undefined, overrides: Bindings, mac: boolean): string {
+  const o = overrides[id];
+  if (o !== undefined) return o === "" ? "" : resolveChord(o, mac);
+  return defaultChord ? resolveChord(defaultChord, mac) : "";
+}
+
+// chord → command id for the dispatcher, built from the full command list. Collisions can only enter
+// via a hand-edited store (the dialog refuses them) — the LAST registered command wins there, and the
+// dialog shows both so the loser is visible, not silently dead.
+export function chordMap(cmds: { id: string; chord?: string }[], overrides: Bindings, mac: boolean): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const c of cmds) {
+    const ch = effectiveChord(c.id, c.chord, overrides, mac);
+    if (ch) m.set(ch, c.id);
+  }
+  return m;
+}
+
+// The command already holding a chord (the conflict the dialog names), or null.
+export function conflictOf(chord: string, forId: string, cmds: { id: string; chord?: string }[], overrides: Bindings, mac: boolean): string | null {
+  for (const c of cmds) {
+    if (c.id === forId) continue;
+    if (effectiveChord(c.id, c.chord, overrides, mac) === resolveChord(chord, mac)) return c.id;
+  }
+  return null;
+}
+
+// ── the dispatch decision (pure: the wiring calls this per keydown) ───────────────────────────────
+
+// Modifier-less (or Shift-only) chords must never fire while typing — same rule the chat's bare-arrow
+// handlers follow. Chords with a real modifier fire regardless of focus.
+export function dispatchable(e: { ctrlKey: boolean; altKey: boolean; metaKey: boolean; repeat?: boolean }, typing: boolean): boolean {
+  if (e.repeat) return false;
+  if (typing && !e.ctrlKey && !e.altKey && !e.metaKey) return false;
+  return true;
+}

--- a/ui/webview/palette-main.ts
+++ b/ui/webview/palette-main.ts
@@ -6,8 +6,10 @@
 // host). Cmd/Ctrl+P toggles the command palette. All three combos are claimable by a page
 // (Google Docs and Figma take Cmd+O/Cmd+P), the override lasts only while this tab has
 // focus, and the window/tab-management set (Cmd+W/T/N/L/Q) stays untouched.
-import { registerCommand } from "./commands";
+import { registerCommand, runCommand, commandList } from "./commands";
 import { initPalette, PickItem } from "./palette";
+import { initShortcutsModal } from "./shortcuts-modal";
+import { chordMap, chordOf, dispatchable, displayChord, effectiveChord, loadOverrides, KEYS_EVENT } from "./keybindings";
 import { hostPrefix } from "./host-prefix";   // pure display helper — safe here (never federation.ts, which boots a manager on import)
 
 type SessionRow = { id: string; name: string; dir: string; bg: string };
@@ -19,7 +21,6 @@ type SessionRow = { id: string; name: string; dir: string; bg: string };
   if (window.parent && window.parent !== window) return;
   const w = window as any;
   const mac = /Mac|iP(hone|ad|od)/.test(navigator.platform || "");
-  const mod = mac ? "⌘" : "Ctrl+";
 
   function pane(id: string): HTMLIFrameElement | null {
     return document.getElementById(id) as HTMLIFrameElement | null;
@@ -96,8 +97,8 @@ type SessionRow = { id: string; name: string; dir: string; bg: string };
   // ── the dashboard's actions, registered as commands ──────────────────────────────────────
   // Each calls the SAME code path its rail button uses; the palette adds reachability, not
   // behavior.
-  registerCommand({ id: "session.jump", title: "Jump to a session", kbd: mod + "O", run: openSessionSwitcher });
-  registerCommand({ id: "session.new", title: "New session", kbd: mod + (mac ? "⇧O" : "Shift+O"), run: openNewSessionPicker });
+  registerCommand({ id: "session.jump", title: "Jump to a session", chord: "Mod+O", run: openSessionSwitcher });
+  registerCommand({ id: "session.new", title: "New session", chord: "Mod+Shift+O", run: openNewSessionPicker });
   registerCommand({
     id: "settings.open", title: "Open settings",
     run: () => { try { pane("f-feed")!.contentWindow!.postMessage({ romp: "openSettings" }, "*"); } catch (e) { /* feed not loaded */ } },
@@ -117,21 +118,50 @@ type SessionRow = { id: string; name: string; dir: string; bg: string };
   }
 
   // Esc (or running an item) hands focus back to the chat pane, so "palette, Esc, type"
-  // never strands the keyboard on the shell document.
-  const palette = initPalette({ onClose: () => { try { pane("f-chat")!.contentWindow!.focus(); } catch (e) { /* no chat pane */ } } });
+  // never strands the keyboard on the shell document. The palette's hotkey chips show each
+  // command's EFFECTIVE binding (kbdFor), so a rebound command never advertises a stale default.
+  const palette = initPalette({
+    onClose: () => { try { pane("f-chat")!.contentWindow!.focus(); } catch (e) { /* no chat pane */ } },
+    kbdFor: (c) => { const ch = effectiveChord(c.id, c.chord, loadOverrides(), mac); return ch ? displayChord(ch, mac) : undefined; },
+  });
   w.__rompPalette = palette;   // reachable by other shell scripts (e.g. a future mobile-bar button)
 
+  // The palette toggle is itself a bindable command — hidden from the palette's own list (running
+  // "toggle the palette" from the palette would just blink it). Cmd+Shift+P deliberately stays
+  // unbound: it is the browser's / VS Code's own palette.
+  registerCommand({ id: "palette.toggle", title: "Command palette", chord: "Mod+P", hidden: true, run: () => palette.toggle() });
+
+  // The shortcuts dialog: every command above, rebindable — VS Code's grammar, the browser's home
+  // (the user 2026-08-09). Reachable from the palette, the gear's customize link ({romp:'openKeys'}
+  // from the feed iframe), and the shell Escape chain closes it first (topmost, z300).
+  const keys = initShortcutsModal(mac);
+  registerCommand({ id: "keys.open", title: "Keyboard shortcuts", run: () => keys.open() });
+  w.__rompKeysOpen = () => keys.open();
+  w.__rompKeysClose = () => keys.close();   // false when not open — the Escape chain moves on
+  window.addEventListener("message", (e) => { if (e.data && e.data.romp === "openKeys") keys.open(); });
+
+  // ONE dispatcher for every bound chord, rebuilt lazily when the store changes (KEYS_EVENT from
+  // this document's saves, `storage` from another tab's).
+  let byChord: Map<string, string> | null = null;
+  const invalidate = () => { byChord = null; };
+  window.addEventListener(KEYS_EVENT, invalidate);
+  window.addEventListener("storage", invalidate);
+  function isTyping(t: EventTarget | null): boolean {
+    const el = t as HTMLElement | null;
+    if (!el || !el.closest) return false;
+    return !!el.closest("input, textarea, select, [contenteditable=true]");
+  }
   function onKey(e: KeyboardEvent): void {
-    if (!(e.metaKey || e.ctrlKey) || e.altKey || e.repeat) return;
-    const k = (e.key || "").toLowerCase();
-    if (k === "o") {
-      e.preventDefault(); e.stopPropagation();
-      palette.close();
-      if (e.shiftKey) openNewSessionPicker(); else openSessionSwitcher();
-    } else if (k === "p" && !e.shiftKey) {   // Cmd+Shift+P stays the browser's / VS Code's
-      e.preventDefault(); e.stopPropagation();
-      palette.toggle();
-    }
+    if (keys.isOpen()) return;                    // the dialog is recording/browsing — never dispatch under it
+    if (!dispatchable(e, isTyping(e.target))) return;
+    const ch = chordOf(e);
+    if (!ch) return;
+    if (!byChord) byChord = chordMap(commandList(), loadOverrides(), mac);
+    const id = byChord.get(ch);
+    if (!id) return;
+    e.preventDefault(); e.stopPropagation();
+    palette.close();                              // a command fired by key must not land under an open palette
+    runCommand(id);
   }
   // The same dual wiring as the Alt+Arrow pane nav (_LANDING_FOCUS_JS): capture on the shell
   // document AND on every same-origin pane document, re-attached on every iframe (re)load.

--- a/ui/webview/palette.test.ts
+++ b/ui/webview/palette.test.ts
@@ -55,12 +55,23 @@ test("session rows wear the TAB identity language: bold name in the session colo
   assert.match(STYLES, /\.host-prefix \{ color: var\(--dim\); font-weight: 400; font-style: italic; font-size: 0\.88em; \}/);
 });
 
-// ── the shell boot: three combos, wired into every pane ────────────────────────────────────
-test("Cmd/Ctrl+O = jump switcher, +Shift = new-session picker, Cmd/Ctrl+P = palette (Shift+P left alone)", () => {
-  assert.match(MAIN, /if \(!\(e\.metaKey \|\| e\.ctrlKey\) \|\| e\.altKey \|\| e\.repeat\) return;/);
-  assert.match(MAIN, /if \(e\.shiftKey\) openNewSessionPicker\(\); else openSessionSwitcher\(\);/);
-  assert.match(MAIN, /k === "p" && !e\.shiftKey/);
-  assert.match(MAIN, /e\.preventDefault\(\); e\.stopPropagation\(\);[\s\S]*?palette\.toggle\(\);/);
+// ── the shell boot: the bindings dispatcher, wired into every pane ─────────────────────────
+test("the defaults hold — Mod+O jump, Mod+Shift+O picker, Mod+P palette — through the bindings store", () => {
+  // the chords are DEFAULTS on the commands now (the user 2026-08-09, configurable shortcuts):
+  // one dispatcher resolves keydown → chord → command through the user's overrides
+  assert.match(MAIN, /registerCommand\(\{ id: "session\.jump", title: "Jump to a session", chord: "Mod\+O", run: openSessionSwitcher \}\);/);
+  assert.match(MAIN, /registerCommand\(\{ id: "session\.new", title: "New session", chord: "Mod\+Shift\+O", run: openNewSessionPicker \}\);/);
+  // the palette toggle is itself bindable, hidden from its own list; Cmd+Shift+P stays the browser's
+  assert.match(MAIN, /id: "palette\.toggle", title: "Command palette", chord: "Mod\+P", hidden: true/);
+  assert.match(MAIN, /if \(!dispatchable\(e, isTyping\(e\.target\)\)\) return;/);
+  assert.match(MAIN, /byChord = chordMap\(commandList\(\), loadOverrides\(\), mac\);/);
+  assert.match(MAIN, /e\.preventDefault\(\); e\.stopPropagation\(\);\s*\n\s*palette\.close\(\);.*\n\s*runCommand\(id\);/);
+  // a store change (this document or another tab) rebuilds the chord map on the next keydown
+  assert.match(MAIN, /window\.addEventListener\(KEYS_EVENT, invalidate\);/);
+  assert.match(MAIN, /window\.addEventListener\("storage", invalidate\);/);
+  // …and the palette chips show the EFFECTIVE binding, never a stale default
+  assert.match(MAIN, /kbdFor: \(c\) => \{ const ch = effectiveChord\(c\.id, c\.chord, loadOverrides\(\), mac\); return ch \? displayChord\(ch, mac\) : undefined; \}/);
+  assert.match(PALETTE, /commandList\(\)\.filter\(\(c\) => !c\.hidden\)/);
 });
 
 test("key wiring mirrors the Alt+Arrow pane nav: capture on the shell doc AND every pane doc, re-wired on load", () => {
@@ -143,6 +154,9 @@ test("picker lift pins the body to the pane's old rect and keeps painting; hidde
   assert.match(CSS, /body\.picker-lifted \{\s*\n\s*position: fixed;\s*\n\s*left: var\(--pane-x, 0\); top: var\(--pane-y, 0\);/);
   assert.match(CSS, /body\.picker-lifted\.pane-gone > \* \{ visibility: hidden; \}/);
   assert.match(CSS, /body\.picker-lifted\.pane-gone > #picker \{ visibility: visible; \}/);
+  // the gone-fallback box is TRANSPARENT: with no --pane-* vars it spans the viewport, and painted
+  // --bg it would black out every pane behind the dialog (the settings modal's 2026-08-09 bug)
+  assert.match(CSS, /body\.picker-lifted\.pane-gone \{ background: transparent; \}/);
 });
 
 test("settings lift does the same via rs-lifted / rs-pane-gone", () => {
@@ -150,6 +164,15 @@ test("settings lift does the same via rs-lifted / rs-pane-gone", () => {
   assert.match(GEAR, /getElementById\('feed-pane'\)/);
   assert.match(GEAR_CSS, /body\.rs-lifted \{ position: fixed; left: var\(--pane-x, 0\); top: var\(--pane-y, 0\);/);
   assert.match(GEAR_CSS, /body\.rs-pane-gone #feed-head, body\.rs-pane-gone #feed-list, body\.rs-pane-gone #feed-foot \{ visibility: hidden; \}/);
+  // the 2026-08-09 blackout, pinned shut three ways: the gone-fallback sheet is transparent (never
+  // an opaque full-viewport cover over the chat)…
+  assert.match(GEAR_CSS, /body\.rs-lifted\.rs-pane-gone \{ background: transparent; \}/);
+  // …the shell is signalled BEFORE the first measurement (feedFull un-hides #feed-pane; measuring
+  // first burned the whole retry against a display:none pane)…
+  assert.match(GEAR, /p\.hidden = false; feedFull\(true\); setModalCls\(true\);/);
+  // …and a close clears the measured rect, so the next open can't inherit a stale one
+  assert.match(GEAR, /function clearPaneVars\(\)/);
+  assert.match(GEAR, /clearPaneVars\(\);\s*\n\s*window\.removeEventListener\('resize', onRsResize\);/);
 });
 
 test("overlay dims are the one standard 0.55", () => {
@@ -157,9 +180,10 @@ test("overlay dims are the one standard 0.55", () => {
   assert.match(GEAR_CSS, /#rsettings \{ position: fixed; inset: 0; z-index: 60; background: rgba\(0, 0, 0, 0\.55\);/);
 });
 
-// ── discoverability: the settings' shortcut list names all three hotkeys ───────────────────
-test("the gear's shortcut rows document Cmd/Ctrl+O, Cmd/Ctrl+Shift+O and Cmd/Ctrl+P", () => {
-  assert.match(GEAR, /<kbd>⌘\/Ctrl<\/kbd> \+ <kbd>O<\/kbd>[\s\S]*?Jump to a session \(quick switcher\)/);
-  assert.match(GEAR, /<kbd>⌘\/Ctrl<\/kbd> \+ <kbd>Shift<\/kbd> \+ <kbd>O<\/kbd>[\s\S]*?New session picker/);
-  assert.match(GEAR, /<kbd>⌘\/Ctrl<\/kbd> \+ <kbd>P<\/kbd>[\s\S]*?Command palette/);
+// ── discoverability: the settings section links the shortcuts dialog (the static list is gone) ──
+test("the gear links the shortcuts dialog instead of carrying its own stale list", () => {
+  assert.match(GEAR, /Customize shortcuts…/);
+  assert.match(GEAR, /\{ romp: 'openKeys' \}/);
+  assert.doesNotMatch(GEAR, /quick switcher/);
+  assert.doesNotMatch(GEAR, /<kbd>⌘\/Ctrl<\/kbd>/);
 });

--- a/ui/webview/palette.ts
+++ b/ui/webview/palette.ts
@@ -5,7 +5,7 @@
 // lives in the SHELL document, so like the network panel it composites over the real panes:
 // one centered card, the standard 0.55 dim, and the dashboard unchanged behind it (the one
 // modal treatment, the user 2026-08-08).
-import { commandList } from "./commands";
+import { commandList, PaletteCommand } from "./commands";
 import { fuzzyMatch, FuzzyHit, FuzzyRange } from "./fuzzy";
 
 // One row of a pick list. Commands map onto this 1:1; session rows wear the TAB's identity
@@ -68,7 +68,10 @@ export type Palette = {
   isOpen(): boolean;
 };
 
-export function initPalette(opts?: { onClose?: () => void }, doc: Document = document): Palette {
+// kbdFor computes a command's hotkey chip at OPEN time from the live keybindings store, so the
+// palette always shows what the key actually does today, never a hardcoded default (the user
+// 2026-08-09, with the configurable shortcuts).
+export function initPalette(opts?: { onClose?: () => void; kbdFor?: (c: PaletteCommand) => string | undefined }, doc: Document = document): Palette {
   let back: HTMLElement | null = null;
   let input: HTMLInputElement;
   let list: HTMLElement;
@@ -235,7 +238,9 @@ export function initPalette(opts?: { onClose?: () => void }, doc: Document = doc
   function open(): void {
     openPick({
       placeholder: "Type a command…",
-      items: commandList().map((c) => ({ title: c.title, kbd: c.kbd, run: c.run })),
+      // hidden commands are bindable but not listed (palette.toggle from the palette just blinks it)
+      items: commandList().filter((c) => !c.hidden)
+        .map((c) => ({ title: c.title, kbd: opts && opts.kbdFor ? opts.kbdFor(c) : undefined, run: c.run })),
     });
   }
   function close(): void {

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -133,6 +133,17 @@ test("the rich tip is the ONE hover surface: no native titles, per-host sections
   assert.ok(usageJS.includes("'<div class=ru-tip-age>click to refresh</div>'"));
 });
 
+test("the hover names WHICH login the window bars belong to (the tab hover's label)", () => {
+  // the user 2026-08-09: the usage tip says whose account the windows are, like the tab hover;
+  // the cross-host dedup stays on the opaque acct digest — acctLabel is display only
+  const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
+  assert.ok(usageJS.includes("if(u.acctLabel)det._acct=u.acctLabel;"));
+  assert.ok(usageJS.includes("if(d._acct&&keys.length)h+='<div class=ru-tip-acct>'+esc(d._acct)+'</div>';"),
+    "…and only beside actual window sections — key-only hosts' spend already says whose dollars");
+  assert.ok(KERNEL.includes('"acctLabel": _claude_account_label(),'));
+  assert.ok(KERNEL.includes(".ru-tip-acct{"));
+});
+
 test("a multi-host breakdown lays hosts SIDE BY SIDE, one column each", () => {
   // the user 2026-08-09: the per-host breakdown used to stack every host into one tall pillar;
   // now each host is a flex column, and flex-wrap folds the mobile modal back to a stack on its own

--- a/ui/webview/shortcuts-modal.test.ts
+++ b/ui/webview/shortcuts-modal.test.ts
@@ -1,0 +1,80 @@
+// The keyboard-shortcuts dialog (ui/webview/shortcuts-modal.ts): the configurable list the settings
+// gear now links to instead of carrying a static table (the user 2026-08-09) — VS Code's grammar:
+// click Change, press the chord, conflicts named with an explicit reassign, Backspace unbinds, Reset
+// returns the default. DOM-heavy → source pins; the decision rules it renders are the REAL exported
+// functions under test in keybindings.test.ts, not a replica.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const MODAL = fs.readFileSync(path.join(ROOT, "ui", "webview", "shortcuts-modal.ts"), "utf8");
+const MAIN = fs.readFileSync(path.join(ROOT, "ui", "webview", "palette-main.ts"), "utf8");
+const GEARJS = fs.readFileSync(path.join(ROOT, "ui", "webview", "gear.js"), "utf8");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+
+test("wears the shared modal vocabulary at z300, over a 0.55 dim, dashboard untouched behind", () => {
+  assert.match(MODAL, /#rkeys-back\{position:fixed;inset:0;z-index:300;/);
+  assert.match(MODAL, /background:rgba\(0,0,0,0\.55\)/);
+  assert.match(MODAL, /#rkeys\{width:min\(640px,94%\)/);
+  assert.match(MODAL, /background:#252526;/);
+});
+
+test("recording is a captured card-level listener: chords never type into the filter or leak out", () => {
+  assert.match(MODAL, /panel\.addEventListener\("keydown", onRecordKey, true\);/);
+  assert.match(MODAL, /if \(!recId\) return;/);
+  assert.match(MODAL, /e\.preventDefault\(\);\s*\n\s*e\.stopPropagation\(\);/);
+  // a bare modifier is a chord still being built; unbindable keys keep the recorder listening
+  assert.match(MODAL, /if \(!ch\) return;\s*.*\n\s*if \(!bindable\(ch\)\) return;/);
+});
+
+test("a conflict is named and resolved explicitly — reassign unbinds the loser visibly", () => {
+  assert.match(MODAL, /const other = conflictOf\(ch, recId, bindableCommands\(\), loadOverrides\(\), mac\);/);
+  assert.match(MODAL, /is used by “/);
+  assert.match(MODAL, /Enter reassigns it here, Esc keeps it there/);
+  assert.match(MODAL, /saveOverride\(pendOther!, ""\);\s*\/\/ the loser is visibly unbound, never silently dead/);
+});
+
+test("Backspace unbinds, Reset returns the default, the chips read the EFFECTIVE binding", () => {
+  assert.match(MODAL, /if \(e\.key === "Backspace" \|\| e\.key === "Delete"\) \{ commit\(recId, ""\); return; \}/);
+  assert.match(MODAL, /saveOverride\(c\.id, null\); render\(\);/);
+  assert.match(MODAL, /const eff = effectiveChord\(c\.id, c\.chord, overrides, mac\);/);
+  assert.match(MODAL, /textContent = "not bound";/);
+});
+
+test("Escape is one level at a time and owned by the shell chain: recording → cancel, open → close", () => {
+  // the recorder deliberately does NOT handle Escape; the shell's Escape chain calls close(),
+  // whose first level cancels the recording and reports consumed
+  assert.match(MODAL, /if \(e\.key === "Escape"\) return;\s*\/\/ the shell Escape chain routes it/);
+  assert.match(MODAL, /if \(recId\) \{ cancelRecord\(\); return true; \}/);
+  assert.match(MODAL, /if \(!back \|\| back\.hidden\) return false;/);
+  // …and the kernel's chain asks this dialog FIRST (topmost, z300)
+  assert.match(KERNEL, /if\(window\.__rompKeysClose&&window\.__rompKeysClose\(\)\)\{closed=true;\}/);
+});
+
+test("the built-in section keeps the non-command keys — without an Enter-to-send row", () => {
+  assert.match(MODAL, /\["Shift\+Enter", "New line in the composer"\]/);
+  assert.match(MODAL, /\["Ctrl\+C", "Interrupt the session \(composer\)"\]/);
+  assert.match(MODAL, /\["Alt\+Arrows", "Move focus between panes"\]/);
+  assert.doesNotMatch(MODAL, /Send message/);
+});
+
+test("reachable from the palette, the gear's customize link, and __rompKeysOpen", () => {
+  assert.match(MAIN, /registerCommand\(\{ id: "keys\.open", title: "Keyboard shortcuts", run: \(\) => keys\.open\(\) \}\);/);
+  assert.match(MAIN, /w\.__rompKeysOpen = \(\) => keys\.open\(\);/);
+  assert.match(MAIN, /if \(e\.data && e\.data\.romp === "openKeys"\) keys\.open\(\);/);
+  // the gear's link: web shell only (VS Code points at its own Keyboard Shortcuts editor), and it
+  // closes the settings modal first so the two never stack
+  assert.match(GEARJS, /id=rs-keys-web hidden/);
+  assert.match(GEARJS, /id=rs-keys-vsc hidden/);
+  assert.match(GEARJS, /closeSettings\(\); try \{ window\.parent\.postMessage\(\{ romp: 'openKeys' \}, '\*'\); \}/);
+  assert.match(GEARJS, /search "rompChat" in Keyboard Shortcuts/);
+  // the static list is gone — the dialog is the one home for shortcuts
+  assert.doesNotMatch(GEARJS, /<kbd>Enter<\/kbd><\/span><span class=rs-key-desc>Send message/);
+  assert.doesNotMatch(GEARJS, /Jump to the session tabs/);
+});
+
+test("while the dialog is up the dispatcher stands down — browsing the list can't fire commands", () => {
+  assert.match(MAIN, /if \(keys\.isOpen\(\)\) return;\s*.*never dispatch under it/);
+});

--- a/ui/webview/shortcuts-modal.ts
+++ b/ui/webview/shortcuts-modal.ts
@@ -1,0 +1,256 @@
+// The keyboard-shortcuts dialog (the user 2026-08-09): every bindable command with its current
+// chord, VS Code's grammar — click Change, press the keys, conflicts named and resolvable, Reset
+// per row. Lives in the SHELL document like the palette (browser dashboard only — VS Code rebinds
+// its contributed rompChat.* commands in its own Keyboard Shortcuts editor), wears the shared
+// modal vocabulary (centered card, 0.55 dim, dashboard unchanged behind it), and ships in the
+// palette-main dist bundle. The pure rules — chords, conflicts, the store — are keybindings.ts;
+// this file is only the DOM over them.
+import { commandList } from "./commands";
+import { fuzzyMatch } from "./fuzzy";
+import {
+  bindable, chordOf, conflictOf, displayChord, effectiveChord,
+  loadOverrides, saveOverride, KEYS_EVENT,
+} from "./keybindings";
+
+// The chat/pane keys that are BEHAVIOR, not bindable commands — listed so the one dialog answers
+// "what can my keyboard do" completely, clearly marked built-in. (Enter-to-send is deliberately
+// not here: a typing key nobody looks up, the user 2026-08-09.)
+const BUILT_IN: Array<[string, string]> = [
+  ["Shift+Enter", "New line in the composer"],
+  ["Escape", "Leave the composer / close a panel"],
+  ["ArrowLeft / ArrowRight", "Switch session (from the tab bar)"],
+  ["Ctrl+C", "Interrupt the session (composer)"],
+  ["Alt+Arrows", "Move focus between panes"],
+];
+
+const CSS =
+  "#rkeys-back{position:fixed;inset:0;z-index:300;display:flex;align-items:flex-start;justify-content:center;" +
+  "padding:10vh 16px 16px;background:rgba(0,0,0,0.55);box-sizing:border-box}" +
+  "#rkeys-back[hidden]{display:none}" +
+  "#rkeys{width:min(640px,94%);max-height:76vh;display:flex;flex-direction:column;background:#252526;" +
+  "border:1px solid #3a3a3a;border-radius:10px;box-shadow:0 12px 36px #000000aa;padding:14px 16px;" +
+  "color:#ccc;font:13px/1.6 system-ui,-apple-system,'Segoe UI',sans-serif;box-sizing:border-box}" +
+  "#rkeys-h{flex:0 0 auto;font-size:14px;font-weight:600;color:#e8eaed;margin-bottom:8px}" +
+  "#rkeys-in{flex:0 0 auto;background:#1b1b1c;border:1px solid #3a3a3a;border-radius:6px;color:#e8eaed;" +
+  "font:inherit;padding:6px 10px;outline:none;box-sizing:border-box;width:100%}" +
+  "#rkeys-in:focus{border-color:var(--accent,#9cd2ff)}" +
+  "#rkeys-list{flex:1 1 auto;overflow-y:auto;margin-top:8px}" +
+  ".rkeys-row{display:flex;align-items:center;gap:10px;padding:5px 8px;border-radius:6px}" +
+  ".rkeys-row:hover{background:rgba(255,255,255,0.05)}" +
+  ".rkeys-title{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}" +
+  ".rkeys-chip{flex:0 0 auto;color:#cfd6dd;font:600 11px ui-monospace,SFMono-Regular,Menlo,monospace;" +
+  "border:1px solid #3d3d42;border-bottom-width:2px;border-radius:4px;padding:1px 7px;background:#1c1c1f}" +
+  ".rkeys-none{flex:0 0 auto;color:#6e7681;font-size:11px}" +
+  ".rkeys-act{flex:0 0 auto;visibility:hidden;cursor:pointer;background:#2a2a2a;color:#ccc;" +
+  "border:1px solid #3a3a3a;border-radius:5px;padding:1px 8px;font-size:11px}" +
+  ".rkeys-row:hover .rkeys-act{visibility:visible}" +
+  ".rkeys-act:hover{background:#333;color:#e8eaed}" +
+  // recording / conflict states: the accent marks "the dialog is listening", never a status color
+  ".rkeys-row.recording{background:rgba(156,210,255,0.10);outline:1px solid var(--accent,#9cd2ff)}" +
+  ".rkeys-hint{flex:0 0 auto;color:var(--accent,#9cd2ff);font-size:11px}" +
+  ".rkeys-conflict{flex:0 0 auto;color:#d29922;font-size:11px}" +
+  "#rkeys-fixed{flex:0 0 auto;margin-top:10px;padding-top:8px;border-top:1px solid rgba(255,255,255,0.08)}" +
+  "#rkeys-fixed .rkeys-sec{color:#9aa0a6;font-size:11px;margin-bottom:2px}" +
+  "#rkeys-fixed .rkeys-row{padding:2px 8px}" +
+  "#rkeys-fixed .rkeys-chip{color:#9aa0a6;border-color:#33363b}" +
+  "#rkeys-fixed .rkeys-title{color:#9aa0a6}";
+
+export type ShortcutsModal = {
+  open(): void;
+  // One Escape level at a time: recording → cancel it (stay open); open → close. Returns whether
+  // it consumed the press — the shell's Escape chain (_LANDING_ESC_JS) calls this FIRST.
+  close(): boolean;
+  isOpen(): boolean;
+};
+
+export function initShortcutsModal(mac: boolean, doc: Document = document): ShortcutsModal {
+  let back: HTMLElement | null = null;
+  let input: HTMLInputElement;
+  let list: HTMLElement;
+  // recording state: which command is listening, and a held candidate when it conflicted
+  let recId: string | null = null;
+  let pendChord: string | null = null;
+  let pendOther: string | null = null;
+
+  function ensure(): void {
+    if (back) return;
+    const style = doc.createElement("style");
+    style.textContent = CSS;
+    doc.head.appendChild(style);
+    back = doc.createElement("div");
+    back.id = "rkeys-back";
+    back.hidden = true;
+    const panel = doc.createElement("div");
+    panel.id = "rkeys";
+    const h = doc.createElement("div");
+    h.id = "rkeys-h";
+    h.textContent = "Keyboard shortcuts";
+    input = doc.createElement("input");
+    input.id = "rkeys-in";
+    input.placeholder = "Filter commands…";
+    input.spellcheck = false;
+    list = doc.createElement("div");
+    list.id = "rkeys-list";
+    const fixed = doc.createElement("div");
+    fixed.id = "rkeys-fixed";
+    const sec = doc.createElement("div");
+    sec.className = "rkeys-sec";
+    sec.textContent = "Built in";
+    fixed.appendChild(sec);
+    for (const [chord, what] of BUILT_IN) {
+      const row = doc.createElement("div");
+      row.className = "rkeys-row";
+      const t = doc.createElement("span");
+      t.className = "rkeys-title";
+      t.textContent = what;
+      const c = doc.createElement("span");
+      c.className = "rkeys-chip";
+      c.textContent = chord.split(" / ").map((x) => displayChord(x, mac)).join(" / ");
+      row.appendChild(t);
+      row.appendChild(c);
+      fixed.appendChild(row);
+    }
+    panel.appendChild(h);
+    panel.appendChild(input);
+    panel.appendChild(list);
+    panel.appendChild(fixed);
+    back.appendChild(panel);
+    doc.body.appendChild(back);
+    input.addEventListener("input", () => render());
+    back.addEventListener("click", (e) => {
+      if (e.target === back) { if (recId) cancelRecord(); else close(); }   // the dim, not the card
+    });
+    // The recorder: CAPTURE on the card so a pressed chord never types into the filter box or
+    // leaks to the page. Escape is NOT handled here — the shell's Escape chain owns it and calls
+    // close(), whose first level cancels the recording.
+    panel.addEventListener("keydown", onRecordKey, true);
+    // another tab (or the dispatcher's own save) changed the store → repaint the chips
+    try { (doc.defaultView || window).addEventListener(KEYS_EVENT, () => { if (isOpen()) render(); }); } catch (e) { /* tests */ }
+  }
+
+  function bindableCommands() {
+    return commandList();   // every command is bindable — `hidden` only hides from the PALETTE list
+  }
+
+  function startRecord(id: string): void {
+    recId = id;
+    pendChord = pendOther = null;
+    render();
+  }
+  function cancelRecord(): void {
+    recId = null;
+    pendChord = pendOther = null;
+    render();
+    input.focus();
+  }
+  function commit(id: string, chord: string): void {
+    saveOverride(id, chord);
+    recId = null;
+    pendChord = pendOther = null;
+    render();
+    input.focus();
+  }
+
+  function onRecordKey(e: KeyboardEvent): void {
+    if (!recId) return;
+    if (e.key === "Escape") return;   // the shell Escape chain routes it into close() → cancelRecord
+    e.preventDefault();
+    e.stopPropagation();
+    // a held conflict resolves on Enter (reassign: the other command loses the chord) — anything
+    // else keeps recording
+    if (pendChord && e.key === "Enter") {
+      saveOverride(pendOther!, "");   // the loser is visibly unbound, never silently dead
+      commit(recId, pendChord);
+      return;
+    }
+    if (e.key === "Backspace" || e.key === "Delete") { commit(recId, ""); return; }   // unbind
+    const ch = chordOf(e);
+    if (!ch) return;                  // a bare modifier — still building the chord
+    if (!bindable(ch)) return;        // typing/close keys the panes own — keep listening
+    const other = conflictOf(ch, recId, bindableCommands(), loadOverrides(), mac);
+    if (other) { pendChord = ch; pendOther = other; render(); return; }
+    commit(recId, ch);
+  }
+
+  function render(): void {
+    const q = input.value.trim();
+    const overrides = loadOverrides();
+    list.textContent = "";
+    for (const c of bindableCommands()) {
+      if (q && !fuzzyMatch(q, c.title)) continue;
+      const row = doc.createElement("div");
+      row.className = "rkeys-row" + (c.id === recId ? " recording" : "");
+      const t = doc.createElement("span");
+      t.className = "rkeys-title";
+      t.textContent = c.title;
+      row.appendChild(t);
+      if (c.id === recId) {
+        const hint = doc.createElement("span");
+        if (pendChord) {
+          hint.className = "rkeys-conflict";
+          const other = bindableCommands().find((x) => x.id === pendOther);
+          hint.textContent = displayChord(pendChord, mac) + " is used by “" + (other ? other.title : pendOther) +
+            "” — Enter reassigns it here, Esc keeps it there";
+        } else {
+          hint.className = "rkeys-hint";
+          hint.textContent = "press a key combination… (Backspace removes, Esc cancels)";
+        }
+        row.appendChild(hint);
+      } else {
+        const eff = effectiveChord(c.id, c.chord, overrides, mac);
+        if (eff) {
+          const chip = doc.createElement("span");
+          chip.className = "rkeys-chip";
+          chip.textContent = displayChord(eff, mac);
+          row.appendChild(chip);
+        } else {
+          const none = doc.createElement("span");
+          none.className = "rkeys-none";
+          none.textContent = "not bound";
+          row.appendChild(none);
+        }
+        const change = doc.createElement("button");
+        change.type = "button";
+        change.className = "rkeys-act";
+        change.textContent = "Change";
+        change.addEventListener("click", (e) => { e.stopPropagation(); startRecord(c.id); });
+        row.appendChild(change);
+        if (overrides[c.id] !== undefined) {
+          const reset = doc.createElement("button");
+          reset.type = "button";
+          reset.className = "rkeys-act";
+          reset.textContent = "Reset";
+          reset.title = "back to the default" + (c.chord ? " (" + displayChord(c.chord, mac) + ")" : " (none)");
+          reset.addEventListener("click", (e) => { e.stopPropagation(); saveOverride(c.id, null); render(); });
+          row.appendChild(reset);
+        }
+      }
+      list.appendChild(row);
+    }
+    if (!list.childElementCount) {
+      const empty = doc.createElement("div");
+      empty.className = "rkeys-none";
+      empty.textContent = "No matches";
+      list.appendChild(empty);
+    }
+  }
+
+  function open(): void {
+    ensure();
+    back!.hidden = false;
+    input.value = "";
+    recId = null;
+    pendChord = pendOther = null;
+    render();
+    input.focus();
+  }
+  function close(): boolean {
+    if (!back || back.hidden) return false;
+    if (recId) { cancelRecord(); return true; }   // one Escape level: leave recording, stay open
+    back.hidden = true;
+    return true;
+  }
+  function isOpen(): boolean { return !!back && !back.hidden; }
+
+  return { open, close, isOpen };
+}

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1774,9 +1774,13 @@ body.picker-lifted {
   background: var(--bg);   /* the body now paints the chat exactly where the pane was */
 }
 /* No measurable pane to stand in for (the pane is hidden, or the parent is cross-origin — VS Code):
-   fall back to hiding the page's own content so only the picker draws. */
+   fall back to hiding the page's own content so only the picker draws — and the fallback box goes
+   TRANSPARENT: with no --pane-* vars, body.picker-lifted above is a full-viewport sheet, and painted
+   --bg it would black out every pane behind the dialog (the settings modal's 2026-08-09 bug; this is
+   the same branch, fixed before it fired here). */
 body.picker-lifted.pane-gone > * { visibility: hidden; }
 body.picker-lifted.pane-gone > #picker { visibility: visible; }
+body.picker-lifted.pane-gone { background: transparent; }
 /* centred, like every other modal. Top-aligned made sense when this filled the screen and the list
    wanted every pixel of height; as a dialog over the dashboard it should sit in the middle. */
 body.picker-lifted > #picker { align-items: center; padding: 24px 16px; }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -127,11 +127,13 @@
     "keybindings": [
       {
         "command": "rompChat.nextTab",
+        "key": "ctrl+alt+right",
         "mac": "cmd+alt+right",
         "when": "activeWebviewPanelId == 'rompChat'"
       },
       {
         "command": "rompChat.prevTab",
+        "key": "ctrl+alt+left",
         "mac": "cmd+alt+left",
         "when": "activeWebviewPanelId == 'rompChat'"
       },


### PR DESCRIPTION
Three asks (the user 2026-08-09):

- **Configurable keyboard shortcuts** (browser shell): a bindable-command registry over the existing palette commands — defaults declared per command, overrides in `romp:keys`, one dispatcher with the palette's dual shell+pane wiring. The new dialog records chords VS Code-style: conflicts named with explicit reassign, Backspace unbinds, Reset per row, built-in (non-command) keys listed without the Enter-to-send row. Settings' static list is now a single Customize link; in VS Code the row points at the native Keyboard Shortcuts editor (contributed `rompChat.*` commands, now with win/linux key variants). Escape chain asks the dialog first, one level at a time (recording → cancel → close).
- **Settings-open blackout fixed**: the lift's unmeasurable-pane fallback painted an opaque full-viewport sheet over every pane. Now transparent (picker's identical latent branch too), the shell is signalled before the first measurement, and the measured rect clears on close.
- **Usage hover names the login** (`acctLabel`) beside each host's window bars — same label as the tab hover's Billing row; cross-host dedup stays on the opaque digest.

Tests: keybindings.test.ts runs the REAL module (it caught a genuine modifier-order bug: Shift-carrying defaults could never match a keydown); shortcuts-modal/gear/palette/esc-close/rail-spend pins updated; pytest 4059 green, node suite green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)