### PR TITLE
The lifted body can't propagate to the canvas; same-account hosts share one reading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,9 +225,17 @@ iframe ELEMENT's own `background:transparent` (the default
 — the 2026-08-08 bug, twice); and the page's BODY is pinned to the pane's old
 screen rect and KEEPS PAINTING (`--pane-*` vars measured from the shell's pane
 div: `placeLifted()` in render.ts / gear.js), because hiding the content instead
-leaves a black hole where that pane was — the same bug's third form. Only an
-unmeasurable pane (hidden, or a cross-origin parent like VS Code) falls back to
-hiding its content (`.pane-gone` / `.rs-pane-gone`). Small pane-local dialogs
+leaves a black hole where that pane was — the same bug's third form. The pinned
+body's own `background` must stay TRANSPARENT, with the pane-rect backing on a
+`::before` child (absolute inset 0, `--bg`, z-index -1): with the root
+transparent, CSS promotes the BODY's background to the CANVAS — the whole
+viewport — so an opaque body background painted a full-window sheet under the dim
+and blacked out every pane outside the pinned rect. That is the bug's FOURTH form
+(2026-08-09, found by headless pixel comparison after the third fix; a child's
+background never propagates). Only an unmeasurable pane (hidden, or a
+cross-origin parent like VS Code) falls back to hiding its content (`.pane-gone`
+/ `.rs-pane-gone`), which also hides the backing pseudo — its var-less box spans
+the viewport. Small pane-local dialogs
 (confirm boxes, the feed's card modal) stay pane-local by design; this rule is
 for panels that present over the dashboard as a whole.
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17911,9 +17911,27 @@ return '<div class="ru-w ru-api">'
 // down per host: with per-session auth a host can carry BOTH a login's windows and its key's spend.
 // The one-host common case renders the same bars it always did, just without a host label anywhere.
 // (No native title anywhere on the rail, the user 2026-08-08: the rich tip is the ONE hover surface.)
+// Same account, ONE truth (the user 2026-08-09): the windows are ACCOUNT-wide allowances, so two
+// hosts signed into the same login are reporting the SAME quantity — and a host that hasn't polled
+// in hours sat beside the live number contradicting it (stale %, rolled '?', an 'updated 2h ago'
+// footer). Hosts are grouped by the acct digest (equality is exactly what it exists for) and every
+// member takes the freshest member's window reading; each host keeps its OWN key spend — dollars
+// really are host-local. Copies stay per host, so the hover still reads per host, just agreeing.
+function shareFreshest(live){var by={};
+live.forEach(function(r){var a=r.usage&&r.usage.acct;if(a)(by[a]=by[a]||[]).push(r);});
+Object.keys(by).forEach(function(a){var g=by[a];if(g.length<2)return;
+var best=g[0];g.forEach(function(r){
+var tb=(typeof best.usage.t==='number')?best.usage.t:-1,tr=(typeof r.usage.t==='number')?r.usage.t:-1;
+if(tr>tb)best=r;});
+g.forEach(function(r){if(r===best)return;var v={},u=r.usage,b=best.usage,k;
+for(k in u)v[k]=u[k];
+['fiveHour','sevenDay','fable','t','limited','acctLabel'].forEach(function(w){
+if(b[w]!==undefined)v[w]=b[w];else delete v[w];});
+r.usage=v;});});}
 function renderRows(rows,selfHost){ROWS=rows||[];LAST=[];
 var live=ROWS.filter(function(r){return hasBars(r.usage)||hasSpend(r.usage);});
 if(!live.length){el.innerHTML='';tip.style.display='none';return;}
+shareFreshest(live);
 LAST=live.map(function(r){var det={};det._t=(typeof r.usage.t==='number')?r.usage.t:null;
 winDet(r.usage,det);spendDet(r.usage,det);
 return {host:r.host||selfHost||'this machine',det:det};});

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -19,19 +19,26 @@
    old screen rect (--pane-* vars, gear.js placeLifted), still painting — so the dashboard shows through
    the full-window iframe with the feed cards live and visible in place under the dim, not a black hole
    where the pane was (the user 2026-08-08). #rsettings is a fixed child of an untransformed body, so the
-   backdrop still spans and dims the whole viewport. */
+   backdrop still spans and dims the whole viewport.
+
+   The body's own background MUST stay transparent (the user 2026-08-09, pixel-verified headless): with
+   the root transparent, CSS promotes the BODY's background to the CANVAS — the whole viewport — so an
+   opaque background here painted a full-window #1e1e1e sheet under the dim and blacked out every pane
+   outside the pinned rect (the fourth form of the 2026-08-08 bug, live in both lifted modals until
+   today). The pane-rect backing lives on a ::before child instead: absolute inset 0 resolves against
+   the fixed body = exactly the pinned box, z-index -1 sits behind the content, and a child's
+   background never propagates anywhere. */
 .rs-modal-open { background: transparent; }
 body.rs-lifted { position: fixed; left: var(--pane-x, 0); top: var(--pane-y, 0);
   width: var(--pane-w, 100%); height: var(--pane-h, 100%); overflow: hidden;
-  background: var(--bg, #1e1e1e); }
+  background: transparent; }
+body.rs-lifted::before { content: ""; position: absolute; inset: 0; background: var(--bg, #1e1e1e); z-index: -1; }
 /* no measurable pane to stand in for (hidden pane, a sliver, mobile's display:contents rows, or a
-   cross-origin parent like VS Code): hide the feed's own content so only the settings card draws —
-   and the fallback box goes TRANSPARENT (the user 2026-08-09): with no --pane-* vars set, body.rs-lifted
-   above is a full-viewport sheet, and painted --bg it blacked out every pane behind the modal (the
-   chat vanished, unlike every other panel). Transparent, the dashboard shows through the dim exactly
-   like the measurable case; in VS Code the webview's own background stands behind it, same as before. */
+   cross-origin parent like VS Code): hide the feed's own content so only the settings card draws — and
+   the backing pseudo goes with it (the user 2026-08-09): with no --pane-* vars the box spans the whole
+   viewport, and painted --bg it would be the same full-window black-out from the other branch. */
 body.rs-pane-gone #feed-head, body.rs-pane-gone #feed-list, body.rs-pane-gone #feed-foot { visibility: hidden; }
-body.rs-lifted.rs-pane-gone { background: transparent; }
+body.rs-lifted.rs-pane-gone::before { display: none; }
 .rs-card { width: min(560px, 94%); max-height: 88vh; overflow: auto; background: #252526; border: 1px solid #3a3a3a;
   border-radius: 10px; padding: 16px 20px; font: 13px/1.6 system-ui, -apple-system, 'Segoe UI', sans-serif; color: #ccc; box-shadow: 0 12px 36px #000000aa; }
 #rsettings .rs-h { font-size: 14px; font-weight: 600; margin-bottom: 6px; color: #e8eaed; }

--- a/ui/webview/palette.test.ts
+++ b/ui/webview/palette.test.ts
@@ -154,9 +154,14 @@ test("picker lift pins the body to the pane's old rect and keeps painting; hidde
   assert.match(CSS, /body\.picker-lifted \{\s*\n\s*position: fixed;\s*\n\s*left: var\(--pane-x, 0\); top: var\(--pane-y, 0\);/);
   assert.match(CSS, /body\.picker-lifted\.pane-gone > \* \{ visibility: hidden; \}/);
   assert.match(CSS, /body\.picker-lifted\.pane-gone > #picker \{ visibility: visible; \}/);
-  // the gone-fallback box is TRANSPARENT: with no --pane-* vars it spans the viewport, and painted
-  // --bg it would black out every pane behind the dialog (the settings modal's 2026-08-09 bug)
-  assert.match(CSS, /body\.picker-lifted\.pane-gone \{ background: transparent; \}/);
+  // The body's background is TRANSPARENT with the pane-rect backing on a ::before child (the user
+  // 2026-08-09, pixel-verified headless): with the root transparent, CSS promotes the BODY's
+  // background to the CANVAS — the whole viewport — so an opaque body blacked out the feed and the
+  // bottom bar behind the picker. A child's background never propagates; the gone branch hides the
+  // pseudo too (its var-less box spans the viewport).
+  assert.match(CSS, /body\.picker-lifted \{[\s\S]{0,220}?background: transparent;\s*\n\}/);
+  assert.match(CSS, /body\.picker-lifted::before \{ content: ""; position: absolute; inset: 0; background: var\(--bg\); z-index: -1; \}/);
+  assert.match(CSS, /body\.picker-lifted\.pane-gone::before \{ display: none; \}/);
 });
 
 test("settings lift does the same via rs-lifted / rs-pane-gone", () => {
@@ -164,9 +169,13 @@ test("settings lift does the same via rs-lifted / rs-pane-gone", () => {
   assert.match(GEAR, /getElementById\('feed-pane'\)/);
   assert.match(GEAR_CSS, /body\.rs-lifted \{ position: fixed; left: var\(--pane-x, 0\); top: var\(--pane-y, 0\);/);
   assert.match(GEAR_CSS, /body\.rs-pane-gone #feed-head, body\.rs-pane-gone #feed-list, body\.rs-pane-gone #feed-foot \{ visibility: hidden; \}/);
-  // the 2026-08-09 blackout, pinned shut three ways: the gone-fallback sheet is transparent (never
-  // an opaque full-viewport cover over the chat)…
-  assert.match(GEAR_CSS, /body\.rs-lifted\.rs-pane-gone \{ background: transparent; \}/);
+  // the 2026-08-09 blackout, pinned shut four ways: the body's background is transparent with the
+  // pane-rect backing on a ::before child (an opaque BODY background propagates to the CANVAS — the
+  // whole viewport — and blacked out every pane outside the pinned rect, in BOTH lift branches)…
+  assert.match(GEAR_CSS, /body\.rs-lifted \{ position: fixed;[\s\S]{0,200}?background: transparent; \}/);
+  assert.match(GEAR_CSS, /body\.rs-lifted::before \{ content: ""; position: absolute; inset: 0; background: var\(--bg, #1e1e1e\); z-index: -1; \}/);
+  // …the gone branch hides the backing pseudo (its var-less box spans the viewport)…
+  assert.match(GEAR_CSS, /body\.rs-lifted\.rs-pane-gone::before \{ display: none; \}/);
   // …the shell is signalled BEFORE the first measurement (feedFull un-hides #feed-pane; measuring
   // first burned the whole retry against a display:none pane)…
   assert.match(GEAR, /p\.hidden = false; feedFull\(true\); setModalCls\(true\);/);

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -133,6 +133,18 @@ test("the rich tip is the ONE hover surface: no native titles, per-host sections
   assert.ok(usageJS.includes("'<div class=ru-tip-age>click to refresh</div>'"));
 });
 
+test("same-account hosts share the FRESHEST window reading — one truth per login", () => {
+  // the user 2026-08-09: the windows are account-wide allowances, so a host that hadn't polled in
+  // hours sat beside the live number contradicting it. Grouped on the acct digest, freshest t wins,
+  // window fields shared; each host keeps its OWN key spend (dollars are host-local).
+  const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
+  assert.ok(usageJS.includes("function shareFreshest(live)"));
+  assert.ok(usageJS.includes("var a=r.usage&&r.usage.acct;if(a)(by[a]=by[a]||[]).push(r);"), "grouped on the digest; key-only hosts (no acct) stand alone");
+  assert.ok(usageJS.includes("if(tr>tb)best=r;"), "freshest reading wins the group");
+  assert.ok(usageJS.includes("['fiveHour','sevenDay','fable','t','limited','acctLabel'].forEach"), "window fields shared — spend deliberately not");
+  assert.ok(usageJS.includes("shareFreshest(live);"), "…and it runs on every render");
+});
+
 test("the hover names WHICH login the window bars belong to (the tab hover's label)", () => {
   // the user 2026-08-09: the usage tip says whose account the windows are, like the tab hover;
   // the cross-host dedup stays on the opaque acct digest — acctLabel is display only

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1766,21 +1766,26 @@ pre.has-copy:hover .code-copy, .code-copy:focus-visible { opacity: 0.9; }
    position:fixed child of the body, and the body has no transform, so the overlay still spans and dims
    the WHOLE viewport. */
 html.picker-lifted { background: transparent !important; }   /* THEME_CSS paints html AND body — html must step aside */
+/* The body's own background stays TRANSPARENT (the user 2026-08-09, pixel-verified headless): with the
+   root transparent, CSS promotes the BODY's background to the CANVAS — the whole viewport — so an opaque
+   background here painted a full-window #1e1e1e sheet under the dim, blacking out the feed and the bottom
+   bar behind the picker (the fourth form of the 2026-08-08 bug). The chat's backing where the pane was is
+   the ::before child: absolute inset 0 = exactly the pinned box, z-index -1 behind the content, and a
+   child's background never propagates to the canvas. */
 body.picker-lifted {
   position: fixed;
   left: var(--pane-x, 0); top: var(--pane-y, 0);
   width: var(--pane-w, 100%); height: var(--pane-h, 100%);
   overflow: hidden;
-  background: var(--bg);   /* the body now paints the chat exactly where the pane was */
+  background: transparent;
 }
+body.picker-lifted::before { content: ""; position: absolute; inset: 0; background: var(--bg); z-index: -1; }
 /* No measurable pane to stand in for (the pane is hidden, or the parent is cross-origin — VS Code):
-   fall back to hiding the page's own content so only the picker draws — and the fallback box goes
-   TRANSPARENT: with no --pane-* vars, body.picker-lifted above is a full-viewport sheet, and painted
-   --bg it would black out every pane behind the dialog (the settings modal's 2026-08-09 bug; this is
-   the same branch, fixed before it fired here). */
+   fall back to hiding the page's own content so only the picker draws — the backing pseudo included:
+   with no --pane-* vars its box spans the whole viewport, the same black-out from the other branch. */
 body.picker-lifted.pane-gone > * { visibility: hidden; }
 body.picker-lifted.pane-gone > #picker { visibility: visible; }
-body.picker-lifted.pane-gone { background: transparent; }
+body.picker-lifted.pane-gone::before { display: none; }
 /* centred, like every other modal. Top-aligned made sense when this filled the screen and the list
    wanted every pixel of height; as a dialog over the dashboard it should sit in the middle. */
 body.picker-lifted > #picker { align-items: center; padding: 24px 16px; }


### PR DESCRIPTION
Two fixes (the user 2026-08-09):

- **The real blackout mechanism, fourth form.** After #253, the picker still blacked out the feed (and settings the chat): CSS canvas background propagation — with the root transparent, the BODY's background becomes the viewport canvas, so the pinned body's opaque `--bg` covered everything outside the pane rect. Diagnosed by headless pixel comparison (the black region measured exactly `0.45 × #1e1e1e` with no DOM element painting it) and verified with an isolated two-iframe repro. Fix: the lifted body's background is transparent; the pane-rect backing is a `::before` child (absolute inset 0, z -1), which cannot propagate; the pane-gone branch hides the pseudo. Applied to both lifts, CLAUDE.md's modal rule updated.
- **Same-account usage readings agree.** Hosts sharing an acct digest now all display the freshest member's window reading in the rail hover (each keeps its own API spend). No more "63% updated just now" beside "41% updated 2h ago" for the same login.

pytest 4059 green, node suite green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)