### PR TITLE
fix: fast mode never engages on SDK sessions — supply the flag-settings opt-in

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -584,7 +584,7 @@ MODEL_CHOICES = [{"value": "fable", "label": "Fable"}, {"value": "opus", "label"
 # "ultracode" tops the ladder (the user 2026-08-04): the CLI's own /effort offers it — xhigh effort plus
 # standing dynamic-workflow orchestration, per session. tmux delivers the literal "/effort ultracode"; the
 # SDK backend maps it to effort=xhigh + the `ultracode` settings key (the CLI's documented per-session
-# hook), since the SDK's typed EffortLevel has no such value. See sdk_backend ultracode_settings_path.
+# hook), since the SDK's typed EffortLevel has no such value. See sdk_backend flag_settings_path.
 EFFORT_CHOICES = [{"value": v, "label": v} for v in ("low", "medium", "high", "xhigh", "max", "ultracode")]
 _MODEL_VALUES = {m["value"] for m in MODEL_CHOICES}
 _EFFORT_VALUES = {e["value"] for e in EFFORT_CHOICES}

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -977,21 +977,42 @@ def list_regs(state_dir: Path) -> list[dict]:
 # Stored OUTSIDE sdk/ so list_regs' sdk/*.json glob never mistakes it for a session.
 # ---------------------------------------------------------------------------
 
-ULTRACODE_SETTINGS = "sdk-ultracode.json"   # the --settings payload for sessions whose effort is "ultracode"
+FLAG_SETTINGS_DIR = "sdk-flag-settings"   # per-session --settings payloads, one file per sid
 
 
-def ultracode_settings_path(state_dir) -> str:
+def flag_settings_path(state_dir, sid: str, *, ultracode: bool = False, fast: bool = False) -> str:
     """The settings file handed to the CLI (options.settings — the flag-settings layer, the CLI's
-    documented per-session hook for the `ultracode` key) when a session's effort is "ultracode". The
-    SDK's typed EffortLevel has no such value: ultracode IS xhigh plus standing dynamic-workflow
-    orchestration, so the typed field carries "xhigh" and this key switches the orchestration on.
-    Rewritten on every use (constant content, atomic enough for a one-key file)."""
-    p = os.path.join(str(state_dir), ULTRACODE_SETTINGS)
+    documented per-session hook for keys the SDK has no typed field for). Returns "" when a session
+    needs none, which is the common case.
+
+    Two keys ride here, both per-session:
+    - `ultracode`: the SDK's typed EffortLevel has no such value — ultracode IS xhigh plus standing
+      dynamic-workflow orchestration, so the typed field carries "xhigh" and this key switches the
+      orchestration on.
+    - `fastMode`: the CLI REFUSES fast mode to any non-interactive client ("Fast mode is not available
+      in the Agent SDK") unless this exact key is true in the flag-settings layer — that check is the
+      host's designed opt-in, not a loophole (verified against claude 2.1.224 on 2026-08-07: with the
+      key, a headless run reports fast_mode_state "on"; without it, "off" with the disabled reason
+      "sdk_opt_in_required").
+
+    One file PER SESSION (not the single shared file the ultracode key used to get): the content now
+    varies by session, so a shared file would hand one session's fast mode to every other one. Rewritten
+    on every use — a couple of boolean keys, atomic enough."""
+    keys = {}
+    if ultracode:
+        keys["ultracode"] = True
+    if fast:
+        keys["fastMode"] = True
+    if not keys:
+        return ""
+    d = os.path.join(str(state_dir), FLAG_SETTINGS_DIR)
+    p = os.path.join(d, "%s.json" % sid)
     try:
+        os.makedirs(d, exist_ok=True)
         with open(p, "w") as f:
-            f.write('{"ultracode": true}\n')
+            f.write(json.dumps(keys) + "\n")
     except OSError:
-        pass
+        return ""     # no settings file → the session still launches, just without these keys
     return p
 
 
@@ -1142,6 +1163,14 @@ class SdkSession:
         #   by fast_mode_state on every init, so a refused toggle can't stick past the next connect.
         self.fast_reason = ""   # the init's fast_mode_disabled_reason — non-empty means /fast would refuse
         #   (org-gated / unsupported), so the chat hides the toggle instead of offering a dead control.
+        self.fast_opt = bool(reg.get("fast"))   # the user's PERSISTED fast-mode ask (the reg's `fast`).
+        #   The CLI refuses /fast to a non-interactive client unless the connect carried the `fastMode`
+        #   flag-settings opt-in, so this drives that key in _options at every connect. Per-session on
+        #   purpose: fast mode draws credits at a higher rate, so it is never a remembered default.
+        self._fast_unlocked = False   # whether THIS connection was made with the opt-in flag — the
+        #   per-CONNECTION snapshot of fast_opt, taken where _connect_once builds options and never
+        #   persisted. Only an unlocked connection accepts literal '/fast on|off' sends; without the
+        #   flag the CLI refuses them, so set_fast reconnects instead.
         self.api_key_auth = False   # THIS session's init said it authenticates with an API key — a
         #   PER-SESSION fact (the user 2026-08-08: one keyed session must not speak for the login's
         #   windows). Gates this session's get_usage polls + its RateLimitEvent records; set by
@@ -1665,6 +1694,11 @@ class SdkSession:
                 self.backend.retire_live_work(self.sid)   # the abandoned turn's stream is gone with its client
                 self.backend._poke()
             opts = self.backend._options(self, ClaudeAgentOptions)
+            # Whether THIS connection carries the fastMode opt-in — snapshotted at the same moment
+            # _options composes the flag-settings file, so the two can never disagree. The CLI only
+            # interprets literal '/fast on|off' sends on a connection made with the flag; set_fast
+            # reads this to choose between the live send and an applying reconnect.
+            self._fast_unlocked = self.fast_opt
             connected = False
             try:
                 async with ClaudeSDKClient(options=opts) as client:
@@ -3140,8 +3174,12 @@ class SdkBackend:
                       % sess.name)
         if self.mcp_config:
             kw["mcp_servers"] = self.mcp_config
-        if (sess.effort or "") == "ultracode":
-            kw["settings"] = ultracode_settings_path(self.state_dir)   # the `ultracode` settings key, per session
+        # The flag-settings layer carries the two keys the SDK has no typed field for — ultracode
+        # (effort) and fastMode. Both are connect-time, which is why changing either reconnects.
+        fs = flag_settings_path(self.state_dir, sess.sid,
+                                ultracode=(sess.effort or "") == "ultracode", fast=sess.fast_opt)
+        if fs:
+            kw["settings"] = fs
         # Per-session auth (the user 2026-08-08): the work key was claimed OUT of this process's env at
         # startup (work_api_key), so a login session's CLI inherits a clean environment and finds the
         # login on its own; a key session gets the key injected here, explicitly. options.env merges
@@ -3636,23 +3674,44 @@ class SdkBackend:
         return True
 
     def set_fast(self, sid: str, value: str) -> bool:
-        """Toggle fast mode by delivering the literal '/fast on|off' text through the normal send path.
-        Unlike /model (which the SDK input stream does not interpret — see set_model), the CLI's /fast
-        descriptor is marked supportsNonInteractive, so the stream-json input DOES run it: the send's
-        echo gives the chat its command chip, and the CLI answers with its own confirmation line
-        ("Fast mode ON …" — including the model switch it performs when the session isn't on a
-        fast-capable model). The flip here is optimistic for the badge; fast_mode_state on the next
-        init re-asserts the truth, and a refusal (cooldown, org-disabled) is visible as the CLI's own
-        reply. Dormant sessions refuse — fast mode lives in the CLI's own settings, so there is nothing
-        to apply until a client is running (the kernel warns instead of pretending)."""
+        """Toggle fast mode ('on'|'off'). The CLI's /fast descriptor is marked supportsNonInteractive,
+        so the SDK input stream DOES interpret the literal '/fast on|off' text (unlike /model — see
+        set_model) — but only on a connection made with the `fastMode` flag-settings opt-in; without
+        it the CLI refuses the command outright ("Fast mode is not available in the Agent SDK",
+        verified against claude 2.1.224). So this is a hybrid:
+
+        - The reg's `fast` mirrors EVERY toggle first — the persisted ask that drives the connect-time
+          opt-in (_options → flag_settings_path), so a lingering flag on a session the user turned off
+          is impossible, and a dormant session applies the pick at its next connect. Deliberately NOT
+          write_sdk_default: fast mode draws credits at a higher rate and carries its own rate limits,
+          so it stays per-session rather than quietly spreading to every new session.
+        - A connection made WITH the flag (_fast_unlocked) takes the literal send in both directions:
+          the send's echo is the chat's acknowledgement, the flip here is optimistic for the badge,
+          and fast_mode_state on the next init re-asserts the truth.
+        - A connection made WITHOUT the flag can't take the send, but 'off' needs none (fast mode is
+          already off there) and 'on' reconnects — the flag applies at the (re)connect, immediately
+          if idle, at the end of the current turn if busy (request_reconnect, the /effort machinery)."""
         if value not in ("on", "off"):
             return False
+        reg = read_reg(self.state_dir, sid)
+        if not reg:
+            return False
+        reg["fast"] = (value == "on")
+        write_reg(self.state_dir, sid, reg)
         s = self.sessions.get(sid)
         if not s or not s.thread.is_alive():
-            return False
-        if not self.send(sid, "/fast " + value):
-            return False
-        s.fast = value
+            return True                        # dormant: the persisted ask applies at the next connect
+        s.fast_opt = (value == "on")
+        if s._fast_unlocked:                   # opted in at connect → the CLI interprets the literal send
+            if not self.send(sid, "/fast " + value):
+                return False
+            s.fast = value
+            self._wake_push()
+            return True
+        if value == "off":                     # no flag at connect → fast mode is already off; nothing to send
+            return True
+        s.request_reconnect()                  # first opt-in: the flag applies at the (re)connect
+        s.fast = "on"                          # optimistic for the badge; init re-asserts the truth
         self._wake_push()
         return True
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1171,6 +1171,12 @@ class SdkSession:
         #   per-CONNECTION snapshot of fast_opt, taken where _connect_once builds options and never
         #   persisted. Only an unlocked connection accepts literal '/fast on|off' sends; without the
         #   flag the CLI refuses them, so set_fast reconnects instead.
+        self._fast_expect = ""   # one-shot: the word a literal '/fast' send asked for. The toggle's own
+        #   turn opens with an init whose fast_mode_state is the state at turn START — one word stale,
+        #   since the toggle applies after it — and taking it verbatim stomps the optimistic flip until
+        #   the NEXT turn's init (the badge reads off for a whole turn right after the CLI acknowledged
+        #   the toggle). The init re-sync lets that single stale word yield to this; the next init wins
+        #   unconditionally.
         self.api_key_auth = False   # THIS session's init said it authenticates with an API key — a
         #   PER-SESSION fact (the user 2026-08-08: one keyed session must not speak for the login's
         #   windows). Gates this session's get_usage polls + its RateLimitEvent records; set by
@@ -1699,6 +1705,8 @@ class SdkSession:
             # interprets literal '/fast on|off' sends on a connection made with the flag; set_fast
             # reads this to choose between the live send and an applying reconnect.
             self._fast_unlocked = self.fast_opt
+            self._fast_expect = ""   # a fresh connection's first init speaks for the flag, not for any
+            #   toggle sent on the old one — never hold a pre-reconnect expectation against it
             connected = False
             try:
                 async with ClaudeSDKClient(options=opts) as client:
@@ -1902,6 +1910,12 @@ class SdkSession:
             # set_fast's optimistic flip. Absent field (older CLI) → stay unknown, never fabricate "off".
             fast = d.get("fast_mode_state")
             if isinstance(fast, str) and fast:
+                # …except the one init opened by a literal /fast send itself, whose word predates the
+                # toggle it carries. A disabled_reason is real refusal evidence, so it always wins.
+                if self._fast_expect and fast != self._fast_expect \
+                        and not d.get("fast_mode_disabled_reason"):
+                    fast = self._fast_expect
+                self._fast_expect = ""
                 self.fast = fast
                 self.fast_reason = str(d.get("fast_mode_disabled_reason") or "")
             # HOW this CLI authenticates (verified live 2026-08-04: 'ANTHROPIC_API_KEY' on API-key auth;
@@ -3706,6 +3720,7 @@ class SdkBackend:
             if not self.send(sid, "/fast " + value):
                 return False
             s.fast = value
+            s._fast_expect = value             # the send's own turn-init is one word stale; let it yield
             self._wake_push()
             return True
         if value == "off":                     # no flag at connect → fast mode is already off; nothing to send

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -117,10 +117,10 @@ class SessionBackend(ABC):
 
     @abstractmethod
     def set_fast(self, sid: str, value: str) -> bool:
-        """Toggle fast mode (value 'on'|'off') — the CLI's /fast command, which its descriptor marks as
-        supported non-interactively, so BOTH backends deliver it as the literal '/fast on|off' text (the
-        SDK input stream interprets it, unlike /model). False when it can't be delivered (dormant SDK
-        session, bad value) so the kernel can be loud instead of pretending."""
+        """Toggle fast mode (value 'on'|'off'). tmux delivers the literal '/fast on|off' text into the
+        pane; the SDK opts in at connect (the `fastMode` flag-settings key) and takes the literal text
+        only on a connection made with that flag — see SdkBackend.set_fast for the hybrid. False when
+        it can't be applied (bad value, unknown sid) so the kernel can be loud instead of pretending."""
 
     def set_auth(self, sid: str, value: str) -> bool:
         """Pick which account this session bills — 'login' (the machine's Claude login) or 'key' (the

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -405,41 +405,109 @@ class LiveTail(unittest.TestCase):
         self.assertTrue(be.set_effort(sid, "low"))
         self.assertEqual(be.live_atoms(sid), [])
 
-    def _live_fast_session(self, d, sid):
-        """A constructed SdkSession whose thread READS alive (set_fast's gate) without spawning a CLI."""
+    def _live_fast_session(self, d, sid, unlocked=False):
+        """A constructed SdkSession whose thread READS alive (set_fast's gate) without spawning a CLI.
+        `unlocked` simulates a connection made WITH the fastMode flag (the _connect_once snapshot)."""
         be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
         sb.write_reg(d, sid, {"sid": sid, "name": "n", "cwd": "/tmp", "alive": True})
         s = sb.SdkSession(be, {"sid": sid, "name": "n", "cwd": "/tmp"})
         s.thread = type("T", (), {"is_alive": lambda self: True})()
+        s._fast_unlocked = unlocked
         be.sessions[sid] = s
         return be, s
 
-    def test_set_fast_delivers_the_slash_command_and_flips_optimistically(self):
-        """/fast is one of the slash commands the SDK input stream DOES interpret (its CLI descriptor is
-        marked supportsNonInteractive, unlike /model — see set_model's control-channel note). set_fast
-        therefore delivers the literal '/fast on' through the normal send path — the echo is the chat's
-        acknowledgement, the CLI's own confirmation follows — and flips the badge state optimistically;
-        fast_mode_state on the next init re-asserts the truth."""
+    def test_set_fast_on_an_unlocked_connection_delivers_the_slash_command(self):
+        """A connection made WITH the fastMode flag-settings opt-in interprets the literal '/fast on|off'
+        (the CLI's descriptor is marked supportsNonInteractive; without the flag it refuses the command
+        outright — verified against claude 2.1.224). So an unlocked session takes the live send in BOTH
+        directions, no reconnect: the echo is the chat's acknowledgement, the flip is optimistic, and
+        fast_mode_state on the next init re-asserts the truth. The reg mirrors every toggle — the
+        persisted ask that drives the next connect's flag, so a lingering opt-in is impossible."""
         d = tempfile.mkdtemp()
-        sid = "11111111-2222-3333-4444-888888888888"
-        be, s = self._live_fast_session(d, sid)
+        sid = "11111111-2222-3333-4444-777777777777"
+        be, s = self._live_fast_session(d, sid, unlocked=True)
+        self.assertTrue(s._fast_unlocked, "precondition: THIS connection carries the opt-in flag")
+        reconnects = []
+        s.request_reconnect = lambda: reconnects.append(1)
         self.assertTrue(be.set_fast(sid, "on"))
         self.assertEqual(s.pending(), ["/fast on"], "the literal command is queued for the CLI to interpret")
         echoes = [a for a in be.live_atoms(sid) if a.get("_echo_text") == "/fast on"]
         self.assertEqual(len(echoes), 1, "the send path's echo IS the chat acknowledgement")
         self.assertEqual(s.fast, "on", "optimistic flip — init re-asserts")
         self.assertEqual(s.snapshot()["fast"], "on", "the badge reads it from the snapshot")
+        self.assertTrue(sb.read_reg(d, sid)["fast"], "the reg mirrors the toggle")
+        self.assertTrue(be.set_fast(sid, "off"), "…and OFF is a live send too, not a reconnect")
+        self.assertEqual(s.pending(), ["/fast on", "/fast off"])
+        self.assertFalse(sb.read_reg(d, sid)["fast"], "the reg mirrors the off as well")
+        self.assertEqual(reconnects, [], "an unlocked connection never reconnects for a toggle")
 
-    def test_set_fast_refuses_bad_values_and_dormant_sessions(self):
-        # only on|off are /fast arguments; a dormant session has no live CLI to apply the toggle —
-        # refuse (the kernel is LOUD about it) rather than reviving a session as a click side effect.
+    def test_set_fast_first_opt_in_reconnects_to_apply_the_flag(self):
+        # The current connection was made WITHOUT the flag, so the CLI would refuse the literal send;
+        # the opt-in applies at the (re)connect that carries it — request_reconnect, the /effort
+        # machinery: immediately if idle, at the end of the current turn if busy.
+        d = tempfile.mkdtemp()
+        sid = "11111111-2222-3333-4444-888888888888"
+        be, s = self._live_fast_session(d, sid, unlocked=False)
+        reconnects = []
+        s.request_reconnect = lambda: reconnects.append(1)
+        self.assertTrue(be.set_fast(sid, "on"))
+        self.assertEqual(len(reconnects), 1, "the flag is connect-time here → reconnect to apply")
+        self.assertEqual(s.pending(), [], "no literal send — this connection would refuse it")
+        self.assertTrue(s.fast_opt, "the next _options carries the flag")
+        self.assertEqual(s.fast, "on", "optimistic for the badge; init re-asserts")
+        self.assertTrue(sb.read_reg(d, sid)["fast"])
+
+    def test_set_fast_off_on_a_locked_connection_is_a_no_op_beyond_the_reg(self):
+        # No flag at connect → fast mode is already off on this connection; there is nothing to send
+        # and nothing to reconnect for. The reg still flips — it is the persisted ask.
         d = tempfile.mkdtemp()
         sid = "11111111-2222-3333-4444-999999999999"
-        be, s = self._live_fast_session(d, sid)
+        be, s = self._live_fast_session(d, sid, unlocked=False)
+        sb.write_reg(d, sid, dict(sb.read_reg(d, sid), fast=True))   # a stale on-disk ask to clear
+        reconnects = []
+        s.request_reconnect = lambda: reconnects.append(1)
+        self.assertTrue(be.set_fast(sid, "off"))
+        self.assertEqual(s.pending(), [], "nothing to send — the connection never had fast mode")
+        self.assertEqual(reconnects, [], "and nothing to reconnect for")
+        self.assertFalse(sb.read_reg(d, sid)["fast"], "but the ask is cleared, so the next connect is plain")
+        self.assertFalse(s.fast_opt)
+
+    def test_set_fast_on_a_dormant_session_persists_and_applies_at_the_next_connect(self):
+        # No live thread → nothing to send and nothing to reconnect; the reg carries the ask and the
+        # NEXT connect applies it (fast_opt seeds from the reg, _options writes the flag file).
+        d = tempfile.mkdtemp()
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        sid = "11111111-2222-3333-4444-aaaaaaaaaaaa"
+        sb.write_reg(d, sid, {"sid": sid, "name": "n", "cwd": "/tmp", "alive": True})
+        self.assertTrue(be.set_fast(sid, "on"), "accepted: the pick applies at the next connect")
+        self.assertTrue(sb.read_reg(d, sid)["fast"])
+        self.assertEqual(be.live_atoms(sid), [], "nothing claimed in the chat — no live CLI took it")
+        s = sb.SdkSession(be, {"sid": sid, "name": "n", "cwd": "/tmp", "fast": True})
+        self.assertTrue(s.fast_opt, "a fresh construction picks the ask up from the reg")
+        # the per-connection unlock is snapshotted from fast_opt exactly where _connect_once builds
+        # the options that carry the flag, so the two can never disagree
+        import inspect
+        self.assertIn("self._fast_unlocked = self.fast_opt", inspect.getsource(sb.SdkSession._amain))
+
+    def test_set_fast_refuses_bad_values_and_unknown_sids(self):
+        d = tempfile.mkdtemp()
+        sid = "11111111-2222-3333-4444-bbbbbbbbbbbb"
+        be, s = self._live_fast_session(d, sid, unlocked=True)
         self.assertFalse(be.set_fast(sid, "maybe"))
         self.assertEqual(s.pending(), [], "a bad value never reaches the CLI")
         be2 = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
         self.assertFalse(be2.set_fast("no-such-sid", "on"))
+
+    def test_fast_mode_is_never_remembered_as_the_seed_for_new_sessions(self):
+        # Fast mode draws credits at a higher rate and has its own rate limit, so it stays per-session —
+        # the same call ultracode makes, and the reason romp never spreads it to every new session.
+        d = tempfile.mkdtemp()
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        sid = be.spawn("a", d)
+        self.assertTrue(be.set_fast(sid, "on"))
+        self.assertNotIn("fast", sb.read_sdk_defaults(d), "never becomes the default for the next session")
+        self.assertFalse(sb.read_reg(d, be.spawn("b", d)).get("fast"), "a NEW session starts plain")
+        self.assertTrue(sb.read_reg(d, sid)["fast"], "but THIS session keeps it")
 
     def test_init_reports_fast_mode_state_into_the_snapshot(self):
         """fast_mode_state rides the CLI's init message ("on"/"off"/"cooldown", plus a disabled_reason
@@ -1705,7 +1773,7 @@ class OptionsAssembly(unittest.TestCase):
         sess.effort = "ultracode"
         opts = be._options(sess, _sdk.ClaudeAgentOptions)
         self.assertEqual(opts.effort, "xhigh", "the typed field carries the effort half of ultracode")
-        self.assertTrue(opts.settings and opts.settings.endswith(sb.ULTRACODE_SETTINGS))
+        self.assertTrue(opts.settings and sb.FLAG_SETTINGS_DIR in opts.settings)
         with open(opts.settings) as f:
             self.assertEqual(json.load(f), {"ultracode": True})
         self.assertNotIn("effort", opts.extra_args or {})
@@ -1716,7 +1784,45 @@ class OptionsAssembly(unittest.TestCase):
         sess.effort = "max"
         opts = be._options(sess, _sdk.ClaudeAgentOptions)
         self.assertEqual(opts.effort, "max")
-        self.assertIsNone(opts.settings, "no ultracode → no flag-settings file")
+        self.assertIsNone(opts.settings, "no ultracode and no fast mode → no flag-settings file")
+
+    def test_fast_mode_rides_the_flag_settings_opt_in(self):
+        # The CLI REFUSES fast mode to any non-interactive client ("Fast mode is not available in the
+        # Agent SDK") unless `fastMode` is true in the flag-settings layer — options.settings is that
+        # layer, and this key is the host's designed opt-in (verified against claude 2.1.224).
+        be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        sess = self._sess(be)
+        sess.fast_opt = True
+        opts = be._options(sess, _sdk.ClaudeAgentOptions)
+        self.assertTrue(opts.settings, "fast mode needs a flag-settings file to opt in through")
+        with open(opts.settings) as f:
+            self.assertEqual(json.load(f), {"fastMode": True})
+
+    def test_ultracode_and_fast_mode_share_one_settings_file(self):
+        # options.settings takes ONE path, so both keys must compose — an earlier shape wrote a fixed
+        # single-key file and the second setting would have silently dropped the first.
+        be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        sess = self._sess(be)
+        sess.effort, sess.fast_opt = "ultracode", True
+        opts = be._options(sess, _sdk.ClaudeAgentOptions)
+        with open(opts.settings) as f:
+            self.assertEqual(json.load(f), {"ultracode": True, "fastMode": True})
+
+    def test_each_session_gets_its_own_flag_settings_file(self):
+        # The file is per-sid, not one shared file: its content now VARIES by session, so a shared path
+        # would hand one session's fast mode to every other session that reads it.
+        be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
+        a, b = self._sess(be), self._sess(be)
+        b.sid = "99999999-8888-7777-6666-555555555555"
+        a.fast_opt, b.fast_opt = True, False
+        b.effort = "ultracode"
+        pa = be._options(a, _sdk.ClaudeAgentOptions).settings
+        pb = be._options(b, _sdk.ClaudeAgentOptions).settings
+        self.assertNotEqual(pa, pb, "two sessions, two settings files")
+        with open(pa) as f:
+            self.assertEqual(json.load(f), {"fastMode": True})
+        with open(pb) as f:
+            self.assertEqual(json.load(f), {"ultracode": True}, "b's file is untouched by a's fast mode")
 
     def test_ultracode_is_a_choice_everywhere_but_never_the_seeded_default(self):
         self.assertIn("ultracode", sb.EFFORT_LEVELS, "the SDK backend accepts the pick")

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -539,6 +539,44 @@ class LiveTail(unittest.TestCase):
         asyncio.run(run({}))                             # an init with no field → the last truth STANDS
         self.assertEqual(s.fast, "off", "absent field never overwrites the known state")
 
+    def test_the_toggle_turns_own_init_yields_to_the_sent_word_once(self):
+        """A literal '/fast on' send opens a turn whose init still reports the state at turn START —
+        one word stale, since the toggle applies after it. Taking it verbatim stomps set_fast's
+        optimistic flip until the NEXT turn's init, so the badge reads off for a whole turn right
+        after the CLI acknowledged the toggle. That single stale, reason-less word yields to the
+        send's one-shot expectation; the next init wins unconditionally, and a disabled_reason
+        (real refusal evidence) always wins immediately."""
+        import asyncio
+        class _Sys:
+            def __init__(self, data): self.subtype = "init"; self.data = data
+        d = tempfile.mkdtemp()
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        sid = "11111111-2222-3333-4444-bbbbbbbbbbbb"
+        sb.write_reg(d, sid, {"sid": sid, "name": "n", "cwd": "/tmp", "alive": True})
+        s = sb.SdkSession(be, {"sid": sid, "name": "n", "cwd": "/tmp"})
+        s.thread = type("T", (), {"is_alive": lambda self: True})()
+        s._fast_unlocked = True
+        be.sessions[sid] = s
+        async def _noop(): pass
+        s._do_refresh_context = _noop
+        async def run(data):
+            s._on_message(_Sys(data), _AssistantMessage, _ResultMessage, _Sys)
+            await asyncio.sleep(0)
+
+        self.assertTrue(be.set_fast(sid, "on"))
+        self.assertEqual(s.fast, "on", "optimistic flip on the live send")
+        self.assertEqual(s._fast_expect, "on", "…armed for the send's own turn-init")
+        asyncio.run(run({"fast_mode_state": "off"}))     # the toggle turn's init: one word stale
+        self.assertEqual(s.fast, "on", "the same-turn stale word yields")
+        asyncio.run(run({"fast_mode_state": "off"}))     # any LATER init is authoritative
+        self.assertEqual(s.fast, "off", "one-shot — the next init wins")
+
+        self.assertTrue(be.set_fast(sid, "on"))          # armed again…
+        asyncio.run(run({"fast_mode_state": "off",
+                         "fast_mode_disabled_reason": "Fast mode is org-disabled"}))
+        self.assertEqual(s.fast, "off", "…but a disabled_reason beats the expectation immediately")
+        self.assertEqual(s.snapshot()["fastReason"], "Fast mode is org-disabled")
+
     def test_send_echo_authors_a_romp_nudge_as_romp_not_human(self):
         # the bug (the user 2026-06-28): an auto-nudge sent through send() echoed as a BLUE HUMAN "Follow-up"
         # instead of the GRAY "from romp" auto-nudge it is, because the echo hardcoded author="human". The echo


### PR DESCRIPTION
## The bug

The fast-mode toggle shipped in #222 can never enable fast mode on an SDK session. The CLI refuses `/fast` to any SDK client unless the connection was made with `fastMode: true` in the flag-settings layer (`options.settings`) — verified against claude 2.1.224, where every toggle lands as `fast_mode_state=off, fast_mode_disabled_reason=sdk_opt_in_required`. The kernel's own badge-blanking on `fastReason` then hides the control, so the feature is silently inert on exactly the sessions the kernel launches. (A second latent effect of send-only toggling: fast state is lost on any reconnect, e.g. crash-heal or an `/effort` change.)

## The fix

Three pieces, `kernel/sdk_backend.py` only — the badge, parking, init re-sync, and UI all survive as they are:

- **Persist the ask**: the session reg's `fast` (bool) mirrors every toggle.
- **Carry it at connect**: `ultracode_settings_path` generalizes into a per-session `flag_settings_path` composing `ultracode` + `fastMode`, rewritten from the reg at every connect (per-session because `options.settings` is one path and `fastMode` varies per session; rewritten-per-connect so a stale on-disk value is never read). This also makes fast state survive reconnects.
- **Hybrid `set_fast`**: a connection made *with* the flag accepts literal `/fast on|off` live in both directions (verified: the flag also bypasses the SDK gate for the rest of the session), so the existing literal-send body stays as the main path. Only the *first* opt-in needs the flag applied at a (re)connect — `request_reconnect`, the same machinery `/effort` uses: immediately when idle, at turn end when busy. Dormant sessions persist the pick and apply it at their next connect instead of refusing.

One follow-up commit fixes a chip artifact the live path exposes: the `/fast` send's own turn opens with an init reporting `fast_mode_state` as of turn *start* — one word stale — which stomped the optimistic flip until the next message. A one-shot expectation lets exactly that init yield; any later init wins unconditionally, and a `disabled_reason` always wins immediately.

## Verified behavior (claude 2.1.224)

- No flag: `fast_mode_state: "off"`, `fast_mode_disabled_reason: "sdk_opt_in_required"` → badge hidden (unchanged).
- Flag on an Opus model: connects with fast on; live `/fast off` and `/fast on` both take effect with no reconnect.
- Flag on a non-Opus model (sonnet): `"off"` with the reason field entirely absent → badge shows "Fast off", harmless.
- Running in production on a fork's kernel: first opt-in reconnects once, subsequent toggles are live, state persists across session restarts.

## Tests

`tests/test_sdk_backend.py`: the literal-send path now asserts the unlocked precondition and reg mirroring; dormant-refusal becomes dormant-persists; new cases for the first-opt-in reconnect, off-while-locked no-op, per-session flag-file isolation, and the one-shot init yield. `fast-toggle.test.ts` passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)