### PR TITLE
The bottom-right bell arms every task by default, with per-item bells as mutes

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1367,6 +1367,15 @@ def _session_flag(sid, flag):
     return bool(f.get(flag)) if isinstance(f, dict) else False
 
 
+def _session_flag_raw(sid, flag):
+    """The flag's stored value, or None when the session never set it — the tri-state the notify
+    bells need (absent = follow the master default, True/False = an explicit per-session choice).
+    _session_flag's bool() collapses absent and False, which is right for the on/off view flags."""
+    f = _session_flags().get(sid)
+    v = f.get(flag) if isinstance(f, dict) else None
+    return None if v is None else bool(v)
+
+
 def _set_session_flag(sid, flag, value):
     cur = dict(_session_flags())                     # copy: never mutate the cached dict in place
     f = dict(cur.get(sid)) if isinstance(cur.get(sid), dict) else {}
@@ -1412,13 +1421,19 @@ def _set_session_flag(sid, flag, value):
             sys.stderr.write("unmute fast-forward: %s\n" % traceback.format_exc())
 
 
-# ── per-card notification subscriptions (the user 2026-07-28) ─────────────────────────────────────
-# The feed card's right-click "Notify me" toggle: {itemId: true} in notify-cards.json under STATE.
-# Session-level subscriptions ride session-flags.json (flag "notify" — the timeline lane bell / tab
-# menu); this file holds the per-card ones. An armed id gets an OS notification when its card enters
-# needs_input or completed (_feed_notifications). Same mtime+size cache as _session_flags — build_feed
-# echoes it on every push. Ids whose card left the feed are pruned on write (the card is gone; a fresh
-# card is a fresh id), so the file tracks the live feed instead of growing forever.
+# ── notification subscriptions (the user 2026-07-28; master default 2026-08-09) ──────────────────
+# notify-cards.json under STATE holds the per-card bell values plus one reserved key: "*" is the
+# MASTER default — the bottom-right bell. The user's model (2026-08-09): turning that bell on means
+# every task notifies, and the per-session / per-card bells then read as mutes. So arming resolves
+# most-specific-wins: card override > session override (session-flags "notify" — the timeline lane
+# bell / tab menu) > master. Overrides are tri-state — an explicit True/False sticks, absent follows
+# the default — and a bell click that lands back ON its default deletes the override instead of
+# pinning it (see _set_notify_card), so the file records deviations, not echoes. An armed id gets an
+# OS notification when its card enters needs_input or completed (_feed_notifications). Same
+# mtime+size cache as _session_flags — build_feed echoes the effective value on every push. Ids
+# whose card left the feed are pruned on write (the card is gone; a fresh card is a fresh id), so
+# the file tracks the live feed instead of growing forever.
+NOTIFY_ALL_KEY = "*"
 _notify_cards_cache = {}   # str(path) -> ((mtime_ns,size), dict)
 
 
@@ -1441,22 +1456,78 @@ def _notify_cards():
     return d
 
 
-def _set_notify_card(item_id, value):
+def _notify_all_on():
+    """The master default — the bottom-right bell: on = every task notifies unless muted."""
+    return bool(_notify_cards().get(NOTIFY_ALL_KEY))
+
+
+def _set_notify_all(value):
     cur = dict(_notify_cards())                      # copy: never mutate the cached dict in place
     if value:
-        cur[item_id] = True
+        cur[NOTIFY_ALL_KEY] = True
     else:
-        cur.pop(item_id, None)
+        cur.pop(NOTIFY_ALL_KEY, None)
     _atomic_write(jd.STATE / "notify-cards.json", json.dumps(cur, sort_keys=True))
+
+
+def _notify_session_effective(sid):
+    """The session bell's effective state: its own override if it has one, else the master."""
+    v = _session_flag_raw(sid, "notify")
+    return _notify_all_on() if v is None else v
+
+
+def _notify_card_effective(cards, item_id, sid):
+    """One card's effective arming — card override > session override > master. `cards` is passed in
+    so the two per-build callers (build_feed's stamp loop, _feed_notifications' gate) resolve every
+    card against ONE read of the store."""
+    v = cards.get(item_id)
+    if v is None:
+        v = _session_flag_raw(sid, "notify")
+    return bool(cards.get(NOTIFY_ALL_KEY)) if v is None else bool(v)
+
+
+def _set_notify_card(item_id, value, sid=""):
+    """Persist a card-bell click. The value the user chose is stored as an override — UNLESS it
+    matches what the card would inherit anyway (session override, else master), in which case the
+    override is deleted: clicking a bell back to its default returns it to FOLLOWING the default,
+    rather than pinning today's default against tomorrow's master flip."""
+    cur = dict(_notify_cards())                      # copy: never mutate the cached dict in place
+    default = _session_flag_raw(sid, "notify")
+    if default is None:
+        default = bool(cur.get(NOTIFY_ALL_KEY))
+    if bool(value) == default:
+        cur.pop(item_id, None)
+    else:
+        cur[item_id] = bool(value)
+    _atomic_write(jd.STATE / "notify-cards.json", json.dumps(cur, sort_keys=True))
+
+
+def _set_notify_session(sid, value):
+    """Persist a session-bell click (tab menu / timeline lane gear) — same delete-if-default
+    discipline as _set_notify_card, against the master. Not _set_session_flag: that setter's
+    pop-on-false is right for the on/off view flags, but here False is a real value (muted while
+    the master is on)."""
+    cur = dict(_session_flags())                     # copy: never mutate the cached dict in place
+    f = dict(cur.get(sid)) if isinstance(cur.get(sid), dict) else {}
+    if bool(value) == _notify_all_on():
+        f.pop("notify", None)
+    else:
+        f["notify"] = bool(value)
+    if f:
+        cur[sid] = f
+    else:
+        cur.pop(sid, None)
+    _atomic_write(jd.STATE / "session-flags.json", json.dumps(cur, sort_keys=True))
 
 
 def _prune_notify_cards(live_ids):
     """Drop armed ids whose card is no longer in the feed (cleared/archived — the id never comes back).
-    Called from the feed-diff detector, so the write happens only on the event of a card leaving."""
+    Called from the feed-diff detector, so the write happens only on the event of a card leaving.
+    The master key is not a card and never prunes; values are kept as stored (False = a mute)."""
     cur = _notify_cards()
-    gone = [i for i in cur if i not in live_ids]
+    gone = [i for i in cur if i not in live_ids and i != NOTIFY_ALL_KEY]
     if gone:
-        kept = {i: True for i in cur if i in live_ids}
+        kept = {i: cur[i] for i in cur if i in live_ids or i == NOTIFY_ALL_KEY}
         _atomic_write(jd.STATE / "notify-cards.json", json.dumps(kept, sort_keys=True))
 
 
@@ -12097,7 +12168,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
             # the timeline lane's feed checkbox + postal mailbox. Same flags + legacy fallback as build_timeline.
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),
             "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"),
-            "notify": _session_flag(sid, "notify"),   # session-level bell: OS notification when its work blocks on you / completes (the user 2026-07-28)
+            "notify": _notify_session_effective(sid),   # session-level bell, EFFECTIVE (override, else the master default): OS notification when its work blocks on you / completes (the user 2026-07-28)
             # NEVER `now`. This rides the chat payload, and _send_client dedups by comparing the
             # SERIALIZED payload against what that client last received — so a firstSeen that ticked
             # with the wall clock made every build differ, defeated the dedup entirely, and re-sent the
@@ -13826,10 +13897,12 @@ def build_feed(now, tmux=None):
     asks.extend(_quarantine_cards(now, cleared))
     # per-card bell (the user 2026-07-28): one pass over the FINAL ask list — goal cards, placeholders,
     # parked handoffs and quarantine cards alike — so every card's right-click menu reflects its armed
-    # state. True/None (not False) keeps unarmed payloads byte-identical to pre-bell ones.
+    # state, EFFECTIVE (card override > session override > the master default, 2026-08-09) — with the
+    # master on, every bell paints on unless muted. True/None (not False) keeps unarmed payloads
+    # byte-identical to pre-bell ones.
     _ncards = _notify_cards()
     for _a in asks:
-        _a["notify"] = True if _ncards.get(_a["itemId"]) else None
+        _a["notify"] = True if _notify_card_effective(_ncards, _a["itemId"], str(_a.get("sid") or "")) else None
     return {"type": "feed", "asks": asks, "now": now,
             "working": working, "awaiting": awaiting,   # awaiting = idle-but-waiting-on-bg-work names → straw dot (the user 2026-07-13)
             # session name -> live judge-classified SERVICE descs (a dev server the session keeps around;
@@ -15320,7 +15393,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
             "faded": faded,
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),    # lane checkbox → mute from feed (timeline-only)
             "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"),  # lane mailbox → isolate from the Romp Postal Service (bin/romp-postal-service)
-            "notify": _session_flag(sid, "notify")})   # lane bell → OS notification when this session's work blocks on you / completes (the user 2026-07-28)
+            "notify": _notify_session_effective(sid)})   # lane bell, EFFECTIVE (override, else the master default) → OS notification when this session's work blocks on you / completes (the user 2026-07-28)
     if with_bars:
         messages = _postal_messages(now, set(id2name), id2name)
         _bind_message_execs(messages, turns)             # connector exec → the recipient's process-start (real transit)
@@ -16430,9 +16503,10 @@ def _cached_feed(now, tmux, sig, connect=False):
 
 
 # ── system notifications: the bell toggles (the user 2026-07-28) ──────────────────────────────────
-# A session's bell (timeline lane / tab menu → session-flags "notify") or a card's bell (right-click →
-# notify-cards.json) arms OS-level notifications, fired when an armed card ENTERS needs_input (blocked
-# on you) or completed. Detection diffs each fresh feed build against the previous one — the exact event
+# The master bell (bottom-right → notify-cards.json "*"), a session's bell (timeline lane / tab menu →
+# session-flags "notify") or a card's bell (right-click → notify-cards.json) arm OS-level notifications
+# — resolved most-specific-wins by _notify_card_effective — fired when an armed card ENTERS needs_input
+# (blocked on you) or completed. Detection diffs each fresh feed build against the previous one — the exact event
 # the columns move on, no separate heuristic — and the FIRST build after a kernel start is a silent
 # baseline: existing state is status, not news (the same policy as extension.ts freshNeedsYou). A card
 # re-entering needs_input later (a new block after an answer) notifies again by construction.
@@ -16476,7 +16550,7 @@ def _feed_notifications(feed):
         col = a.get("column")
         if col not in ("needs_input", "completed") or prev.get(iid) == col:
             continue
-        if not (cards.get(iid) or _session_flag(str(a.get("sid") or ""), "notify")):
+        if not _notify_card_effective(cards, iid, str(a.get("sid") or "")):
             continue
         what = "Needs you" if col == "needs_input" else "Completed"
         txt = str(a.get("text") or "").strip()
@@ -18627,7 +18701,9 @@ if(m&&m.type==='reveal'&&m.pane)show(m.pane);
 // the app-icon badge: setAppBadge only exists where badging works (installed apps) — everyone
 // else falls through silently, so this needs no capability gymnastics
 else if(m&&m.type==='badge'&&'setAppBadge' in navigator){
-try{(m.n?navigator.setAppBadge(m.n):navigator.clearAppBadge())['catch'](function(e){});}catch(e){}}};
+try{(m.n?navigator.setAppBadge(m.n):navigator.clearAppBadge())['catch'](function(e){});}catch(e){}}
+// the master bell toggled somewhere (this tab included) — repaint ours from the kernel's word
+else if(m&&m.type==='notifyAll'&&window.__rompNotifyAllPaint)window.__rompNotifyAllPaint(!!m.on);};
 ws.onclose=function(){setTimeout(shellWS,2000);};}catch(e){}}
 shellWS();
 var last='chat';try{var s=localStorage.getItem(KT);if(s&&F[s])last=s;}catch(e){}show(last);
@@ -18635,44 +18711,55 @@ var last='chat';try{var s=localStorage.getItem(KT);if(s&&F[s])last=s;}catch(e){}
 """
 
 
-# The bell in the mobile tab bar: this device opting in/out of the needs-you pushes
-# (plans/ios-app.md proposal 2). Progressive disclosure at the capability level: the button ships
-# hidden and only appears where push can actually work — which on iOS means the INSTALLED
-# home-screen app (Safari in-browser has no PushManager), exactly the surface the feature is for.
-# Notification.requestPermission runs synchronously in the tap (iOS voids the gesture across an
-# await), which is why the on/off branch keys on a state var painted at boot, not a fresh query.
+# The bell in the bottom bar's action cluster / mobile tab bar: the MASTER notification switch
+# (the user 2026-08-09, who expected the bottom-right bell to turn notifications on for every task,
+# with per-item bells as the way to mute some — not a switch that arms nothing by itself). ON = the
+# kernel arms every card by default (notify-cards.json "*", POST /notify-all) and the session/card
+# bells read as mutes; the same tap also opts THIS device into the web pushes where the Push API
+# exists (plans/ios-app.md proposal 2 — on iOS that means the installed home-screen app), so one
+# gesture buys the arming and the delivery together. The bell paints from the KERNEL's state (GET
+# /notify-all at boot, a {type:'notifyAll'} shell push on every toggle) — never from the device
+# subscription, so every device's bell agrees. The push-subscribe leg is best-effort ON TOP of the
+# master flip: a denied permission lands in the Log but leaves notifications on (the kernel box
+# still speaks, other devices still buzz). Notification.requestPermission runs synchronously in the
+# tap (iOS voids the gesture across an await), which is why it is kicked off BEFORE the /notify-all
+# round-trip rather than chained after it.
 _LANDING_PUSH_JS = """
 (function(){var bells=[].slice.call(document.querySelectorAll('#mbell,#rail-bell'));if(!bells.length)return;
-if(!('serviceWorker' in navigator)||!('PushManager' in window)||!('Notification' in window))return;
 bells.forEach(function(b){b.hidden=false;});
+var canPush=('serviceWorker' in navigator)&&('PushManager' in window)&&('Notification' in window);
 var isOn=false,busy=false;
 function paint(){bells.forEach(function(b){b.classList.toggle('on',isOn);
-var t=isOn?'Notifications on for this device — tap to turn off':'Notify this device when a session needs you';
+var t=isOn?'Notifications on for every task — tap to turn off':'Notify when any task needs you or completes';
 b.setAttribute('title',t);b.setAttribute('aria-label',t);});}
+window.__rompNotifyAllPaint=function(on){isOn=!!on;paint();};   // the shell WS repaints every open dashboard on a toggle
+fetch('/notify-all').then(function(r){return r.json();}).then(function(d){isOn=!!(d&&d.on);paint();}).catch(function(e){});
 function sub(){return navigator.serviceWorker.getRegistration('/').then(function(r){return r?r.pushManager.getSubscription():null;});}
-sub().then(function(s){isOn=!!s;paint();}).catch(function(e){});
 function fail(e){try{window.__rompNotify&&window.__rompNotify('error','Notifications: '+((e&&e.message)||e));}catch(err){}}
 function post(path,obj){return fetch(path,{method:'POST',body:JSON.stringify(obj)}).then(function(r){
 if(!r.ok)return r.text().then(function(t){throw new Error(t||('HTTP '+r.status));});});}
 function b64u(s){var raw=atob((s+'==='.slice((s.length+3)%4)).replace(/-/g,'+').replace(/_/g,'/'));
 var a=new Uint8Array(raw.length);for(var i=0;i<raw.length;i++)a[i]=raw.charCodeAt(i);return a;}
 function done(){busy=false;bells.forEach(function(b){b.classList.remove('busy');});}
-bells.forEach(function(bl){bl.addEventListener('click',function(){
-if(busy)return;busy=true;bells.forEach(function(b){b.classList.add('busy');});   // acknowledge the tap before any round-trip
-if(isOn){
-sub().then(function(s){var ep=s?s.endpoint:'';
-return (s?s.unsubscribe():Promise.resolve()).then(function(){return post('/push/unsubscribe',{endpoint:ep});});})
-.then(function(){isOn=false;paint();done();},function(e){fail(e);done();});
-return;}
-Notification.requestPermission().then(function(perm){
-if(perm!=='granted')throw new Error('not allowed on this device');
+function devSub(perm){return perm.then(function(p){
+if(p!=='granted')throw new Error('push not allowed on this device');
 return navigator.serviceWorker.register('/sw.js');
 }).then(function(){return fetch('/push/vapid-key').then(function(r){
 if(!r.ok)return r.text().then(function(t){throw new Error(t||'no server key');});return r.json();});
 }).then(function(k){return navigator.serviceWorker.ready.then(function(reg){
 return reg.pushManager.subscribe({userVisibleOnly:true,applicationServerKey:b64u(k.key)});});
-}).then(function(s){return post('/push/subscribe',s.toJSON());})
-.then(function(){isOn=true;paint();done();},function(e){fail(e);done();});
+}).then(function(s){return post('/push/subscribe',s.toJSON());});}
+function devUnsub(){return sub().then(function(s){var ep=s?s.endpoint:'';
+return (s?s.unsubscribe():Promise.resolve()).then(function(){return ep?post('/push/unsubscribe',{endpoint:ep}):null;});});}
+bells.forEach(function(bl){bl.addEventListener('click',function(){
+if(busy)return;busy=true;bells.forEach(function(b){b.classList.add('busy');});   // acknowledge the tap before any round-trip
+var want=!isOn;
+var perm=(want&&canPush)?Notification.requestPermission():null;   // in the tap's own stack, before any await
+post('/notify-all',{on:want}).then(function(){
+isOn=want;paint();                       // the master flipped — the bell says so even if the push leg fails below
+if(!canPush)return;
+return want?devSub(perm):devUnsub();
+}).then(function(){done();},function(e){fail(e);done();});
 });});
 })();
 // Landing a push tap on the session that fired (the user 2026-08-08). Two arrivals:
@@ -20001,6 +20088,11 @@ class Handler(BaseHTTPRequestHandler):
                 # register() fetch is same-origin and carries the cookie, and only an authed shell
                 # ever registers it. no-cache so a changed worker is picked up on the next launch.
                 return self._send(200, _SW_JS, "text/javascript; charset=utf-8", cache="no-cache")
+            if p == "/notify-all":
+                # the master bell's state (the user 2026-08-09): on = every task notifies when it
+                # blocks on you or completes, unless its session/card bell mutes it. The shell
+                # paints the bottom-right bell from this at boot.
+                return self._send(200, json.dumps({"on": _notify_all_on()}), "application/json", cache="no-cache")
             if p == "/push/vapid-key":
                 # the public key the shell subscribes with (applicationServerKey). Gated like every
                 # page fetch; the 500 carries the missing-package message for the bell to surface.
@@ -20088,6 +20180,19 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, FLEET_REPORT.read_text(), "application/json")
                 except OSError:
                     return self._send(200, json.dumps({"rows": []}), "application/json")
+            if u.path == "/notify-all":
+                # the master bell's toggle (the user 2026-08-09). Kernel-authoritative: the click
+                # posts here first, and only a 200 flips the bell — the device push subscription is
+                # a separate, best-effort leg on top. Every connected shell repaints at once, and
+                # the dirty mark rebuilds the feed so per-card bells show their new effective state.
+                try:
+                    _on = bool(json.loads(raw_body or b"{}").get("on"))
+                except (ValueError, AttributeError):
+                    return self._send(400, "bad json", "text/plain")
+                _set_notify_all(_on)
+                _mark_views_dirty()
+                _send_to_app("shell", {"type": "notifyAll", "on": _on})
+                return self._send(200, json.dumps({"ok": True, "on": _on}), "application/json")
             if u.path == "/push/subscribe":
                 # A device opting into the bell pushes (plans/ios-app.md proposal 2): body is the
                 # browser's own PushSubscription JSON, stored keyed by endpoint — so re-subscribing
@@ -20643,13 +20748,19 @@ class Handler(BaseHTTPRequestHandler):
                     pass
         elif msg and msg.get("type") == "setSessionFlag" and msg.get("id") and msg.get("flag"):
             # timeline lane gear → toggle a per-session view flag (e.g. hideFromFeed). Persisted +
-            # re-broadcast so the feed drops/restores that session's cards immediately.
-            _set_session_flag(str(msg["id"]), str(msg["flag"]), bool(msg.get("value")))
+            # re-broadcast so the feed drops/restores that session's cards immediately. The notify
+            # bell is tri-state (an override on the master default) → its own setter.
+            if str(msg["flag"]) == "notify":
+                _set_notify_session(str(msg["id"]), bool(msg.get("value")))
+            else:
+                _set_session_flag(str(msg["id"]), str(msg["flag"]), bool(msg.get("value")))
             _mark_views_dirty()
         elif msg and msg.get("type") == "cardNotify" and msg.get("itemId"):
             # feed card right-click → per-card bell (OS notification when THIS card blocks on you /
             # completes). Persisted to notify-cards.json; build_feed echoes it back as ask.notify.
-            _set_notify_card(str(msg["itemId"]), bool(msg.get("value")))
+            # sid rides so the override can be resolved against the card's own default (session, else
+            # the master) and deleted when it merely restates it.
+            _set_notify_card(str(msg["itemId"]), bool(msg.get("value")), str(msg.get("sid") or ""))
             _mark_views_dirty()
         elif msg and msg.get("type") == "setSessionColor" and msg.get("id") and msg.get("bg"):
             # tab right-click color picker → override the session's identity color (persisted to the names

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -524,23 +524,104 @@ class LandingRevealPins(unittest.TestCase):
 
 
 class RailBell(unittest.TestCase):
-    """The desktop rail carries the same push bell as the mobile tab bar (the user 2026-08-08: a
-    laptop Chrome tab can receive Web Push with no install at all, but the opt-in bell rendered
-    only on the mobile layout, so a desktop tab had no way in)."""
+    """The desktop rail carries the same bell as the mobile tab bar (the user 2026-08-08), and the
+    pair is the MASTER notification switch (the user 2026-08-09): on = every task notifies unless
+    its own bell mutes it, with the device push subscription a best-effort leg on top."""
 
     def test_shell_serves_both_bells_and_one_flow_drives_them(self):
         status, body = _serve_get("/", headers={"X-Romp-Token": km.TOKEN})
         self.assertEqual(status, 200)
         page = body.decode()
-        self.assertIn("id=rail-bell hidden", page, "the rail bell ships hidden, revealed on Push support")
+        self.assertIn("id=rail-bell hidden", page, "the bells ship hidden; the wiring reveals them at boot")
         self.assertIn("id=mbell hidden", page, "the mobile bell is unchanged")
         # ONE wiring drives the pair — reveal, paint and busy all iterate the same list — so the
-        # two bells can never disagree about this device's subscription state
+        # two bells can never disagree about the master's state
         self.assertIn("querySelectorAll('#mbell,#rail-bell')", page)
         self.assertNotIn("getElementById('mbell')", page, "the single-bell wiring is gone")
         # the rail bell paints its states exactly like the mobile one
         self.assertIn(".rail-acts #rail-bell.on{color:var(--accent)}", page)
         self.assertIn(".rail-acts #rail-bell.busy{opacity:.45}", page)
+
+    def test_the_bell_is_the_master_switch_not_a_device_toggle(self):
+        _, body = _serve_get("/", headers={"X-Romp-Token": km.TOKEN})
+        page = body.decode()
+        # kernel-authoritative paint: state comes from GET /notify-all at boot and the shell WS
+        # push on every toggle — never from this device's push subscription
+        self.assertIn("fetch('/notify-all')", page)
+        self.assertIn("window.__rompNotifyAllPaint", page)
+        self.assertIn("m.type==='notifyAll'", page, "the shell WS repaints every open dashboard")
+        self.assertIn("post('/notify-all',{on:want})", page)
+        # the bell shows everywhere — the master matters even where the Push API is missing (the
+        # kernel box still gets osascript, other devices still buzz); only the subscribe leg gates
+        self.assertNotIn("('Notification' in window))return", page,
+                         "the old whole-bell capability bail is gone")
+        self.assertIn("var canPush=", page)
+        # the permission ask still runs in the tap's own stack (iOS voids the gesture across awaits)
+        self.assertIn("Notification.requestPermission():null", page)
+
+
+class MasterBellRoute(unittest.TestCase):
+    """GET/POST /notify-all — the master bell's kernel half (the user 2026-08-09). Live server for
+    the POST (the SubscribeRoutes pattern: a fake socket cannot exercise Content-Length reads)."""
+
+    @classmethod
+    def setUpClass(cls):
+        from http.server import ThreadingHTTPServer
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        try:
+            (jd.STATE / "notify-cards.json").unlink()
+        except OSError:
+            pass
+        km._notify_cards_cache.clear()
+
+    def _post(self, path, body, token=True, raw=None):
+        import urllib.request, urllib.error
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["X-Romp-Token"] = km.TOKEN
+        data = raw if raw is not None else json.dumps(body).encode()
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path),
+                                     method="POST", data=data, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, r.read().decode()
+        except urllib.error.HTTPError as e:
+            return e.code, e.read().decode()
+
+    def test_get_is_gated_and_reads_the_store(self):
+        status, _ = _serve_get("/notify-all")
+        self.assertEqual(status, 403, "the master state is behind the serve token like every page")
+        status, body = _serve_get("/notify-all", headers={"X-Romp-Token": km.TOKEN})
+        self.assertEqual((status, json.loads(body)), (200, {"on": False}))
+
+    def test_post_flips_and_broadcasts(self):
+        sent = []
+        with mock.patch.object(km, "_send_to_app", side_effect=lambda app, m: sent.append((app, m))):
+            code, body = self._post("/notify-all", {"on": True})
+        self.assertEqual((code, json.loads(body)), (200, {"ok": True, "on": True}))
+        self.assertTrue(km._notify_all_on())
+        self.assertIn(("shell", {"type": "notifyAll", "on": True}), sent,
+                      "every open dashboard's bell repaints on the toggle, not just the clicker's")
+        _, body = _serve_get("/notify-all", headers={"X-Romp-Token": km.TOKEN})
+        self.assertEqual(json.loads(body), {"on": True})
+        code, _ = self._post("/notify-all", {"on": False})
+        self.assertEqual(code, 200)
+        self.assertFalse(km._notify_all_on())
+
+    def test_post_requires_token_and_refuses_garbage(self):
+        code, _ = self._post("/notify-all", {"on": True}, token=False)
+        self.assertEqual(code, 403)
+        code, _ = self._post("/notify-all", None, raw=b"not json")
+        self.assertEqual(code, 400)
+        self.assertFalse(km._notify_all_on(), "a refused body must not flip the master")
 
 
 if __name__ == "__main__":

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""The notification bells (the user 2026-07-28): a session-level bell (timeline lane / tab menu →
+"""The notification bells (the user 2026-07-28; master default 2026-08-09): the master bell
+(notify-cards.json "*" — the bottom bar's bell), a session-level bell (timeline lane / tab menu →
 session-flags "notify") and a per-card bell (feed card right-click → notify-cards.json) arm OS-level
-notifications, fired by the kernel when an armed card ENTERS needs_input (blocked on you) or completed.
-Detection diffs each fresh feed build against the previous one — the exact event the columns move on —
-and the first build after a kernel start is a silent baseline (existing state is status, not news).
-Synthetic ids/names only."""
+notifications, resolved most-specific-wins (card > session > master) — so the master on means every
+task notifies and the per-item bells read as mutes. Fired when an armed card ENTERS needs_input
+(blocked on you) or completed. Detection diffs each fresh feed build against the previous one — the
+exact event the columns move on — and the first build after a kernel start is a silent baseline
+(existing state is status, not news). Synthetic ids/names only."""
 import json
 import os
 import sys
@@ -37,6 +39,7 @@ class NotifyCardStore(unittest.TestCase):
         self.saved = jd.STATE
         jd.STATE = Path(self.td.name)
         km._notify_cards_cache.clear()
+        km._flags_cache.clear()
 
     def tearDown(self):
         jd.STATE = self.saved
@@ -44,17 +47,53 @@ class NotifyCardStore(unittest.TestCase):
 
     def test_default_is_empty(self):
         self.assertEqual(km._notify_cards(), {})
+        self.assertFalse(km._notify_all_on())
 
     def test_set_get_then_unset_drops_the_entry(self):
         km._set_notify_card("TESTSID:g1", True)
         self.assertEqual(km._notify_cards(), {"TESTSID:g1": True})
         km._set_notify_card("TESTSID:g1", False)
-        self.assertEqual(km._notify_cards(), {}, "disarming removes the key, not stores False")
+        self.assertEqual(km._notify_cards(), {}, "off matches the (off) default → the override is deleted")
 
     def test_cache_invalidates_on_write(self):
         self.assertEqual(km._notify_cards(), {})            # primes the (empty) read path
         km._set_notify_card("TESTSID:g1", True)
         self.assertTrue(km._notify_cards().get("TESTSID:g1"), "the (mtime_ns,size) cache key sees the write")
+
+    def test_master_set_and_unset(self):
+        km._set_notify_all(True)
+        self.assertTrue(km._notify_all_on())
+        self.assertEqual(km._notify_cards(), {"*": True})
+        km._set_notify_all(False)
+        self.assertEqual(km._notify_cards(), {})
+
+    def test_a_click_matching_the_default_deletes_the_override(self):
+        # master on: arming a card merely restates the default → no entry (a pinned True would
+        # keep it armed against a later master-off, which is not what the click said) …
+        km._set_notify_all(True)
+        km._set_notify_card("TESTSID:g1", True, "TESTSID")
+        self.assertEqual(km._notify_cards(), {"*": True})
+        # … while muting it deviates → an explicit False
+        km._set_notify_card("TESTSID:g1", False, "TESTSID")
+        self.assertEqual(km._notify_cards(), {"*": True, "TESTSID:g1": False})
+
+    def test_the_cards_default_is_its_sessions_override_first(self):
+        # session muted under a master-on: the card's default is OFF, so arming it is a deviation
+        km._set_notify_all(True)
+        km._set_notify_session("TESTSID", False)
+        km._set_notify_card("TESTSID:g1", True, "TESTSID")
+        self.assertEqual(km._notify_cards().get("TESTSID:g1"), True)
+        km._set_notify_card("TESTSID:g1", False, "TESTSID")     # back to the session's own default
+        self.assertNotIn("TESTSID:g1", km._notify_cards())
+
+    def test_session_override_delete_if_default(self):
+        km._set_notify_session("TESTSID", True)                  # master off → a deviation, stored
+        self.assertEqual(km._session_flag_raw("TESTSID", "notify"), True)
+        km._set_notify_session("TESTSID", False)                 # matches master-off → removed
+        self.assertIsNone(km._session_flag_raw("TESTSID", "notify"))
+        km._set_notify_all(True)
+        km._set_notify_session("TESTSID", False)                 # a mute under master-on is a real value
+        self.assertEqual(km._session_flag_raw("TESTSID", "notify"), False)
 
     def test_prune_drops_only_ids_that_left_the_feed(self):
         km._set_notify_card("TESTSID:g1", True)
@@ -66,6 +105,14 @@ class NotifyCardStore(unittest.TestCase):
         before = p.stat().st_mtime_ns
         km._prune_notify_cards({"TESTSID:g2"})
         self.assertEqual(p.stat().st_mtime_ns, before)
+
+    def test_prune_keeps_the_master_and_the_mutes(self):
+        km._set_notify_all(True)
+        km._set_notify_card("TESTSID:g1", False, "TESTSID")      # a live card's mute
+        km._set_notify_card("TESTSID:g2", False, "TESTSID")      # a mute whose card then leaves
+        km._prune_notify_cards({"TESTSID:g1"})
+        self.assertEqual(km._notify_cards(), {"*": True, "TESTSID:g1": False},
+                         "the master is not a card and never prunes; kept values stay as stored")
 
 
 class FeedNotifications(unittest.TestCase):
@@ -146,6 +193,42 @@ class FeedNotifications(unittest.TestCase):
         km._feed_notifications(_feed())                     # cleared/archived → id never comes back
         self.assertEqual(km._notify_cards(), {}, "the store tracks the live feed, not history")
 
+    def test_the_master_arms_everything_by_default(self):
+        # the user 2026-08-09: the bottom-right bell alone must mean "notify me about all the tasks"
+        km._set_notify_all(True)
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working")))
+        out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
+        self.assertEqual(len(out), 1, "no per-item bell touched — the master alone arms the card")
+
+    def test_a_card_mute_silences_it_under_the_master(self):
+        km._set_notify_all(True)
+        km._set_notify_card("TESTSID:g1", False, "TESTSID")
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working"),
+                                     _card("TESTSID:g2", "TESTSID", "working")))
+        out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input"),
+                                           _card("TESTSID:g2", "TESTSID", "completed")))
+        self.assertEqual(len(out), 1, "the muted card is silent; its unmuted sibling still speaks")
+        self.assertTrue(out[0][1].startswith("Completed: "), out[0][1])
+
+    def test_a_session_mute_silences_its_cards_under_the_master(self):
+        km._set_notify_all(True)
+        km._set_notify_session("TESTSID", False)
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working"),
+                                     _card("OTHERSID:g1", "OTHERSID", "working")))
+        out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input"),
+                                           _card("OTHERSID:g1", "OTHERSID", "needs_input")))
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0][2], "OTHERSID", "only the unmuted session's card notifies")
+
+    def test_a_card_arm_overrides_its_sessions_mute(self):
+        # most-specific-wins: card > session > master
+        km._set_notify_all(True)
+        km._set_notify_session("TESTSID", False)
+        km._set_notify_card("TESTSID:g1", True, "TESTSID")
+        km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "working")))
+        out = km._feed_notifications(_feed(_card("TESTSID:g1", "TESTSID", "needs_input")))
+        self.assertEqual(len(out), 1)
+
 
 class SystemNotify(unittest.TestCase):
     def test_darwin_shells_out_to_osascript_with_escaped_strings(self):
@@ -184,15 +267,30 @@ class NotifyWiring(unittest.TestCase):
         cls.src = Path(os.path.join(BIN, "romp-kernel")).resolve().read_text()
 
     def test_the_session_flag_rides_both_session_payloads(self):
-        # the timeline lane row AND the chat session payload both echo the flag (lane bell + tab menu)
-        self.assertEqual(self.src.count('"notify": _session_flag(sid, "notify")'), 2)
+        # the timeline lane row AND the chat session payload both echo the EFFECTIVE bell state
+        # (override, else master) — with the master on, an untouched session's bell paints on
+        self.assertEqual(self.src.count('"notify": _notify_session_effective(sid)'), 2)
 
     def test_every_ask_carries_its_card_arming(self):
-        self.assertIn('_a["notify"] = True if _ncards.get(_a["itemId"]) else None', self.src)
+        self.assertIn('_a["notify"] = True if _notify_card_effective(_ncards, _a["itemId"], '
+                      'str(_a.get("sid") or "")) else None', self.src)
 
     def test_the_ws_handler_persists_the_card_toggle(self):
         self.assertIn('msg.get("type") == "cardNotify"', self.src)
-        self.assertIn('_set_notify_card(str(msg["itemId"]), bool(msg.get("value")))', self.src)
+        # sid rides so delete-if-default resolves against the card's own default
+        self.assertIn('_set_notify_card(str(msg["itemId"]), bool(msg.get("value")), str(msg.get("sid") or ""))',
+                      self.src)
+
+    def test_the_session_bell_routes_to_its_tristate_setter(self):
+        # setSessionFlag's pop-on-false is right for the view flags but would eat a mute
+        self.assertIn('_set_notify_session(str(msg["id"]), bool(msg.get("value")))', self.src)
+
+    def test_the_master_has_both_routes_and_broadcasts(self):
+        # GET paints the bell at boot; POST flips it, rebuilds the feed (per-card bells repaint
+        # their new effective state) and tells every open shell at once
+        self.assertIn('if p == "/notify-all":', self.src)
+        self.assertIn('if u.path == "/notify-all":', self.src)
+        self.assertIn('_send_to_app("shell", {"type": "notifyAll", "on": _on})', self.src)
 
     def test_the_store_mtime_busts_the_feed_cache(self):
         self.assertIn('(jd.STATE / "notify-cards.json", "__ncards__")', self.src,

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -100,7 +100,7 @@ interface AskItem {
   groupN?: number;                                 // host: sibling count for that turn (>1 ⇒ fold into one group card)
   provisional?: boolean;                           // a LIVE-PROMPT placeholder (kernel _provisional_card): the session is working an in-progress turn the planner hasn't classified yet. No goal node (empty tree) — dim, non-interactive, no clear/nudge/modal; replaced by the real card once the planner places the segment.
   judging?: boolean;                               // the turn has SETTLED and the judge's pass is due/in flight → the swirl chip says Analyzing… — on a provisional card while the planner's classify is pending (the user 2026-07-12), and on a REAL working card while the closer's verdict is (the settle→verdict gap, the user 2026-07-13); an open turn stays the honest Working…
-  notify?: boolean | null;                         // per-card bell (the user 2026-07-28): the kernel fires an OS notification when THIS card enters needs_input/completed (kernel notify-cards.json ← the card's right-click menu). True/absent, never false
+  notify?: boolean | null;                         // per-card bell (the user 2026-07-28): the kernel fires an OS notification when THIS card enters needs_input/completed. EFFECTIVE state (card override > session override > the master bell's default, 2026-08-09) — with the master on, every card arrives armed unless muted. True/absent, never false
   tree: AskTreeNode[];                             // the ask's DAG, rendered as a tree in the expanded body
 }
 // A GROUP = N sibling asks minted by ONE typed turn (shared turnId), folded into a
@@ -637,7 +637,9 @@ function ensureHeader() {
 // Every card wears a small bell BUTTON in its bottom-right corner (the user 2026-07-28, round 2 —
 // promoted from a right-click-only toggle): click it to arm/disarm an OS notification for when THIS
 // card blocks on you or completes (kernel notify-cards.json; the session-wide version lives on the
-// timeline lane / tab menu). Armed = accent bell, always visible; off = slashed dim bell, revealed on
+// timeline lane / tab menu, and the bottom bar's master bell defaults every card ON at once — the
+// kernel resolves the three most-specific-wins and sends the effective state, so a click here is a
+// per-card override against the defaults). Armed = accent bell, always visible; off = slashed dim bell, revealed on
 // card hover (the tab-close idiom — no clutter on a quiet feed). Right-clicking the card still opens
 // the labelled menu for the same toggle. Optimism mirrors the lane toggles: pendingNotify holds the
 // clicked value sticky across pushes until the kernel's payload agrees, so the bell never flickers


### PR DESCRIPTION
The master bell only opted a device into push delivery — with nothing armed, turning it on did nothing at all. The user (2026-08-09) expected it to mean notifications for all the tasks, with per-item bells as the way to turn some off. This flips the model:

- `notify-cards.json`'s reserved `"*"` key is the master default. Arming resolves most-specific-wins (card override > session override > master); all three tiers are tri-state, and a bell click that lands back on its default deletes the override instead of pinning it, so the file records deviations, not echoes.
- `GET`/`POST /notify-all` is the kernel-authoritative master toggle. Every open shell repaints over the shell WS on a toggle, and the feed rebuilds so per-card bells show their new effective state.
- The landing bell always shows — the master matters even where the Push API is missing (the kernel box still gets osascript, other devices still buzz). It paints from the kernel's state, never from the device subscription, and keeps the per-device push subscribe as a best-effort leg on top, with `requestPermission` still in the tap's own stack for iOS.
- Session and card payloads carry EFFECTIVE bell state, so the tab menu, timeline lane gear, and feed bells all agree with what will actually fire.

Tests: new store/precedence/prune coverage and `/notify-all` route tests; the wiring pins updated. Full Python suite (4074) and node suite (1766) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)