### PR TITLE
fix: chat path links resolve against real files instead of 404ing on shape-guesses

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11447,6 +11447,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
             _e = efforts[_ei]; _ei += 1
             events.append({"kind": "effortApplied", "effort": _e["effort"], "ts": iso(_e["t"]),
                            "uuid": "effort:%d" % _e["t"]})
+    _pl_memo = {}   # per-BUILD-pass cache for _path_links: one repo listing serves every message here
     for turn in session["turns"]:
         for a in turn["atoms"]:
             t = a.get("t"); ts = iso(t) if t else None
@@ -11515,6 +11516,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                             sp = _space_paths(prompt, sid, a.get("uuid"))
                             if sp:
                                 ev["spacePaths"] = sp   # backticked filenames WITH spaces, filesystem-verified → whole-span links
+                            pl = _path_links(prompt, sid, a.get("uuid"), _pl_memo)
+                            if pl is not None:
+                                ev["pathLinks"] = pl    # path-shaped tokens, filesystem-verified/fixed → the client's link gate
                             if reminders:                # join each task-notification to its command + output tail
                                 to = _task_outputs_for(reminders, sess["path"])
                                 if to:
@@ -11592,6 +11596,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                         sp = _space_paths(txt, sid, a.get("uuid"))
                         if sp:
                             ev["spacePaths"] = sp   # backticked filenames WITH spaces, filesystem-verified → whole-span links
+                        pl = _path_links(txt, sid, a.get("uuid"), _pl_memo)
+                        if pl is not None:
+                            ev["pathLinks"] = pl    # path-shaped tokens, filesystem-verified/fixed → the client's link gate
                         if _interrupt_settle(events, txt, a):   # the null settle-reply closing an interrupted
                             ev["interruptSettle"] = True        # turn → rendered as seam marker, not a bubble
                         events.append(ev)
@@ -16025,6 +16032,125 @@ def _space_paths(md, sid, uuid):
             _SPACE_PATH_CACHE.clear()
         _SPACE_PATH_CACHE[key] = hit = tuple(out)
     return list(hit) or None
+
+
+# ── verified path links ────────────────────────────────────────────────────────────────────────────
+# The chat linkifies path-shaped tokens by SHAPE alone (render.ts CLICKABLE_PATH_RE), so a bare
+# `render.js` in a reply became a blue link that 404'd on click — the token resolved against the
+# session's cwd, where no such file lives. The kernel is the machine that HAS the filesystem, so it
+# verifies at message-build time and, when a shortened mention names exactly one real file, FIXES the
+# link to that file. Three tiers, first hit wins:
+#   1. exact — the token resolves like a click (_resolve_open_path) to a real file;
+#   2. suffix — the token has a slash and exactly ONE repo file ends with "/" + token;
+#   3. basename — the token has no slash and exactly ONE repo file bears that name.
+# Zero matches or several → the token stays OUT of the map, and the client leaves it prose: a
+# silently-wrong link is worse than no link, so ambiguity is never guessed at.
+# The repo list is `git ls-files -co --exclude-standard` in the SESSION's cwd (each session may be a
+# different repo), re-run per build pass — ~6ms here, and any mtime-keyed cache would miss the
+# untracked files agents create constantly. Ignored files are deliberately invisible to tiers 2/3.
+_PATH_TOKEN_RE = re.compile(          # Python port of render.ts CLICKABLE_PATH_RE — parity pinned in
+    r"file:///?[^\s<>\"'`)]+"         #   tests/test_path_links.py + chat-path-links.test.ts over the
+    r"|[~.\w\-]*/[~.\w\-/]*[\w\-]"    #   shared tests/fixtures/path_token_parity.json
+    r"|[\w\-][\w\-.]*\.[A-Za-z0-9]{1,8}",
+    re.IGNORECASE)
+_PATH_TRAIL_RE = re.compile(r"[.,;:!?)\]}>\"'`]+$")   # the client's trailing-punctuation strip, mirrored
+_REPO_LIST_MAX = 200_000              # a runaway listing skips tiers 2/3 rather than indexing forever
+_PATH_LINK_CACHE = {}                 # (sid, uuid) -> (links dict, misses tuple) — see _path_links
+
+
+def _repo_file_index(cwd):
+    """basename -> [repo-relative paths] for every tracked or untracked-unignored file under `cwd`,
+    or None when there is no list to be had (not a git repo, git absent/failing, or a listing past
+    _REPO_LIST_MAX). None means tiers 2/3 stand down for this build; tier 1 needs no list."""
+    try:
+        out = subprocess.run(["git", "ls-files", "-co", "--exclude-standard"],
+                             cwd=cwd, capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError, UnicodeDecodeError):
+        return None
+    if out.returncode != 0:
+        return None
+    names = set(out.stdout.splitlines())   # a set: an index/worktree duplicate must not fake ambiguity
+    if len(names) > _REPO_LIST_MAX:
+        return None
+    idx = {}
+    for p in names:
+        idx.setdefault(p.rsplit("/", 1)[-1], []).append(p)
+    return idx
+
+
+def _resolve_path_token(tok, sid, memo):
+    """One shape-matched token → the file it names (the open target), or None. Tier 1 keeps the token
+    as its own target (a click already resolves it against the session's cwd); tiers 2/3 return the
+    repo-relative path from the file list, which the same click-time resolution reaches. `memo` is the
+    per-build cache — the file index is built at most once per build pass, and only when some token
+    actually misses tier 1."""
+    ap = _resolve_open_path(tok, sid)
+    if os.path.isabs(ap) and os.path.isfile(ap):
+        return tok                                        # tier 1 — exact, exactly today's click
+    cwd = _cwd_of(sid)
+    if not cwd:
+        return None                                       # nowhere to resolve a repo-relative fix
+    if "idx" not in memo:
+        memo["idx"] = _repo_file_index(cwd)
+    idx = memo["idx"]
+    if idx is None:
+        return None
+    cands = idx.get(tok.rsplit("/", 1)[-1]) or []
+    if "/" in tok:                                        # tier 2 — unique suffix fixes a shortened path
+        cands = [p for p in cands if p == tok or p.endswith("/" + tok)]
+    if len(cands) == 1 and os.path.isfile(os.path.join(cwd, cands[0])):
+        return cands[0]                                   # tier 3 is the no-slash case of the same test
+    return None
+
+
+def _path_tokens(md):
+    """CLICKABLE_PATH_RE's matches over `md`, trailing punctuation stripped, deduped — the exact token
+    strings the client will look up in pathLinks. Resumes after the STRIPPED token, as the client's
+    exec loop does. Parity with the client regex is pinned over tests/fixtures/path_token_parity.json
+    (tests/test_path_links.py here, chat-path-links.test.ts there)."""
+    toks, pos = [], 0
+    while True:
+        m = _PATH_TOKEN_RE.search(md, pos)
+        if not m:
+            break
+        tok = _PATH_TRAIL_RE.sub("", m.group(0))
+        pos = max(m.start() + len(tok), pos + 1)
+        if tok and tok not in toks:
+            toks.append(tok)
+    return toks
+
+
+def _path_links(md, sid, uuid, memo):
+    """Path-shaped tokens in `md` the filesystem VERIFIES → {token: open target}, shipped as pathLinks
+    on the chat event. Returns None when the message has no candidate tokens at all (the common message
+    adds no payload); an EMPTY dict when tokens exist but none resolved — the key's presence is what
+    tells the client a verdict was rendered, so it gates rather than falling back to shape-only.
+
+    The cache is deliberately ASYMMETRIC: a resolved token is cached for the message's life — a link
+    never flaps away — while an unresolved one is retried on every build, because the standard agent
+    flow mentions `report.md` moments BEFORE creating it, and the Write that creates it triggers the
+    very rebuild that should turn the mention into a link."""
+    if not uuid or not md:
+        return None
+    key = (sid, uuid)
+    hit = _PATH_LINK_CACHE.get(key)
+    if hit is None:
+        hit = ({}, tuple(t for t in _path_tokens(md)
+                         if not t.lower().startswith("file://")))   # file:// stays the client's verbatim link, ungated
+    links, misses = hit
+    if misses:
+        still = []
+        for tok in misses:
+            r = _resolve_path_token(tok, sid, memo)
+            if r is None:
+                still.append(tok)
+            else:
+                links[tok] = r
+        misses = tuple(still)
+    if len(_PATH_LINK_CACHE) > 50000:                     # runaway backstop; one entry per rendered message
+        _PATH_LINK_CACHE.clear()
+    _PATH_LINK_CACHE[key] = (links, misses)
+    return dict(links) if (links or misses) else None
 
 
 def _open_file(p, sid=None):

--- a/tests/fixtures/path_token_parity.json
+++ b/tests/fixtures/path_token_parity.json
@@ -1,0 +1,17 @@
+{
+  "note": "Shared tokenizer-parity fixture: the kernel's _path_tokens (Python port of CLICKABLE_PATH_RE, trailing punctuation stripped, deduped) and the client regex extracted from render.ts must produce EXACTLY these tokens for each text. Tokens here are pre-gate: prose like and/or is a TOKEN on both sides (the shape gates and the pathLinks map are what keep it prose). pd.DataFram pins the {1,8} extension cap behaving identically. Synthetic paths only.",
+  "cases": [
+    { "text": "see design/foo.md for details", "tokens": ["design/foo.md"] },
+    { "text": "the fix is in ui/webview/render.ts and kernel/kernel.py.", "tokens": ["ui/webview/render.ts", "kernel/kernel.py"] },
+    { "text": "wrote report.md, then plot.png!", "tokens": ["report.md", "plot.png"] },
+    { "text": "and/or read/write 24/7 TCP/IP", "tokens": ["and/or", "read/write", "24/7", "TCP/IP"] },
+    { "text": "np.array and pd.DataFrame are not files, e.g. this", "tokens": ["np.array", "pd.DataFram", "e.g"] },
+    { "text": "file:///tmp/a%20b.pdf, plus ~/notes/plan.md and ./x.py ../y.ts /abs/z.log", "tokens": ["file:///tmp/a%20b.pdf", "~/notes/plan.md", "./x.py", "../y.ts", "/abs/z.log"] },
+    { "text": "(see src/util/helpers.py):", "tokens": ["src/util/helpers.py"] },
+    { "text": "backticked `render.js` should resolve", "tokens": ["render.js"] },
+    { "text": "version 0.4.293 and 24/7 uptime", "tokens": ["0.4.293", "24/7"] },
+    { "text": "results in output/final report.md maybe", "tokens": ["output/final", "report.md"] },
+    { "text": "report.md twice: report.md is deduped", "tokens": ["report.md"] },
+    { "text": "no paths here at all", "tokens": [] }
+  ]
+}

--- a/tests/test_path_links.py
+++ b/tests/test_path_links.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Chat file links are filesystem-VERIFIED, and shortened mentions are FIXED.
+
+The client linkifies path-shaped tokens by shape alone (render.ts CLICKABLE_PATH_RE), so a bare
+`render.js` in a reply became a blue link that 404'd on click — the token resolved against the
+session's cwd, where no such file lives. The kernel is the machine with the filesystem, so at
+message-build time it resolves every shape-matched token in three tiers (exact stat; unique
+"/"+token suffix in the repo list; unique basename) and ships {token: open target} as pathLinks on
+the chat event. Zero or several matches → absent from the map → the client leaves the token prose:
+a silently-wrong link is worse than no link. The per-message cache is deliberately asymmetric —
+hits latch for the message's life (a link never flaps away), misses retry every build, because
+agents mention `report.md` moments before the Write that creates it.
+
+The repo list is `git ls-files -co --exclude-standard` in the SESSION's cwd, so untracked files
+count and gitignored ones never do. Client-side gates are pinned in chat-path-links.test.ts; the
+tokenizer parity between the Python port and CLICKABLE_PATH_RE is pinned on both sides over
+tests/fixtures/path_token_parity.json. Synthetic fixtures only.
+"""
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_pathlinks", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class _Repo(unittest.TestCase):
+    """A synthetic git repo as the session's cwd: tracked, untracked and ignored files."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.cwd = Path(self.td.name)
+        subprocess.run(["git", "init", "-q"], cwd=self.cwd, check=True)
+        self.write("tests/test_x.py", "def test_ok(): pass\n")
+        self.write("ui/render.js", "// unique basename\n")
+        self.write("kernel/sub/deep.py", "# tier-2 target\n")
+        self.write("a/dup.py", "# ambiguous basename\n")
+        self.write("b/dup.py", "# ambiguous basename\n")
+        self.write("a/x/same.py", "# ambiguous suffix\n")
+        self.write("b/x/same.py", "# ambiguous suffix\n")
+        self.write(".gitignore", "ignored/\n")
+        self.write("ignored/secret.log", "never listed\n")
+        # half the repo TRACKED, half untracked — ls-files -co must surface both
+        subprocess.run(["git", "add", "tests", "ui", ".gitignore"], cwd=self.cwd, check=True)
+        self._saved_cwd_of = km._cwd_of
+        km._cwd_of = lambda sid: str(self.cwd) if sid == SID else ""
+        km._PATH_LINK_CACHE.clear()
+        self._n = 0
+
+    def tearDown(self):
+        km._cwd_of = self._saved_cwd_of
+        km._PATH_LINK_CACHE.clear()
+        self.td.cleanup()
+
+    def write(self, rel, text):
+        p = self.cwd / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text)
+        return str(p)
+
+    def _uuid(self):
+        self._n += 1
+        return "msg-%d" % self._n
+
+    def links(self, md, uuid=None):
+        return km._path_links(md, SID, uuid or self._uuid(), {})
+
+
+class ThreeTiers(_Repo):
+    def test_tier1_an_exact_path_links_as_written(self):
+        self.assertEqual(self.links("see tests/test_x.py for the check"),
+                         {"tests/test_x.py": "tests/test_x.py"})
+
+    def test_tier2_a_unique_suffix_is_fixed_to_the_real_file(self):
+        self.assertEqual(self.links("edit sub/deep.py next"),
+                         {"sub/deep.py": "kernel/sub/deep.py"})
+
+    def test_tier3_a_unique_basename_is_fixed_even_untracked(self):
+        # ui/render.js is tracked; an UNTRACKED unique file must fix too (agents create files constantly)
+        self.assertEqual(self.links("the bug is in render.js"), {"render.js": "ui/render.js"})
+        self.write("docs/fresh.md", "brand new, never git-added\n")
+        self.assertEqual(self.links("wrote fresh.md"), {"fresh.md": "docs/fresh.md"})
+
+    def test_ambiguity_is_never_guessed_at(self):
+        # two dup.py, two x/same.py — a silently-wrong link is worse than no link
+        self.assertEqual(self.links("check dup.py and x/same.py"), {})
+
+    def test_a_file_that_exists_nowhere_stays_out_of_the_map(self):
+        self.assertEqual(self.links("will write missing.md soon"), {})
+
+    def test_prose_shaped_tokens_resolve_to_nothing(self):
+        self.assertEqual(self.links("and/or 24/7, np.array"), {})
+
+    def test_an_empty_map_still_ships_but_no_tokens_ships_nothing(self):
+        # {} tells the client a verdict WAS rendered (gate everything off); None means no candidates at
+        # all, so the event carries no key — that absence is also the old-kernel fallback signal.
+        self.assertEqual(self.links("mentions missing.md only"), {})
+        self.assertIsNone(self.links("no path shaped tokens here"))
+
+    def test_a_tracked_but_deleted_file_never_links(self):
+        (self.cwd / "ui" / "render.js").unlink()   # still in the index (ls-files -c) — but not on disk
+        self.assertEqual(self.links("see render.js"), {})
+
+    def test_gitignored_files_are_invisible_to_tiers_2_and_3(self):
+        self.assertEqual(self.links("check secret.log and ignored/secret.log"),
+                         {"ignored/secret.log": "ignored/secret.log"},
+                         "the exact path still stats (tier 1); the ignored file never FIXES a bare name")
+
+    def test_file_uris_are_not_the_kernels_to_gate(self):
+        self.assertIsNone(self.links("file:///tmp/somewhere.pdf"),
+                          "explicit absolute — the client keeps today's verbatim link, ungated")
+
+
+class AsymmetricCache(_Repo):
+    def test_a_miss_that_later_resolves_appears(self):
+        u = self._uuid()
+        self.assertEqual(self.links("writing report.md now", u), {},
+                         "mentioned BEFORE the Write that creates it")
+        self.write("report.md", "# now it exists\n")
+        self.assertEqual(self.links("writing report.md now", u), {"report.md": "report.md"},
+                         "the creating Write triggers the rebuild that must turn the mention into a link")
+
+    def test_a_miss_that_later_resolves_by_repo_list_appears(self):
+        u = self._uuid()
+        self.assertEqual(self.links("adding late.js", u), {})
+        self.write("ui/late.js", "// created after the mention\n")
+        self.assertEqual(self.links("adding late.js", u), {"late.js": "ui/late.js"})
+
+    def test_a_hit_latches_for_the_messages_life(self):
+        u = self._uuid()
+        self.assertEqual(self.links("see tests/test_x.py", u), {"tests/test_x.py": "tests/test_x.py"})
+        (self.cwd / "tests" / "test_x.py").unlink()
+        self.assertEqual(self.links("see tests/test_x.py", u), {"tests/test_x.py": "tests/test_x.py"},
+                         "a link never flaps away without user action; a NEW message re-checks")
+        self.assertEqual(self.links("see tests/test_x.py"), {}, "…and the new message sees the deletion")
+
+    def test_no_uuid_short_circuits(self):
+        self.assertIsNone(km._path_links("see tests/test_x.py", SID, None, {}))
+
+
+class RepoListEdges(_Repo):
+    def test_a_non_git_cwd_keeps_tier1_and_stands_down_tiers_2_and_3(self):
+        with tempfile.TemporaryDirectory() as plain:
+            (Path(plain) / "real.md").write_text("x\n")
+            (Path(plain) / "sub").mkdir()
+            (Path(plain) / "sub" / "only.md").write_text("x\n")
+            km._cwd_of = lambda sid: plain if sid == SID else ""
+            self.assertEqual(self.links("see real.md"), {"real.md": "real.md"}, "tier 1 needs no git")
+            self.assertEqual(self.links("see only.md"), {},
+                             "no repo list → no basename fixing, silently")
+
+    def test_a_runaway_listing_skips_tiers_2_and_3(self):
+        saved = km._REPO_LIST_MAX
+        try:
+            km._REPO_LIST_MAX = 1
+            self.assertEqual(self.links("see render.js but tests/test_x.py works"),
+                             {"tests/test_x.py": "tests/test_x.py"})
+        finally:
+            km._REPO_LIST_MAX = saved
+
+    def test_the_repo_list_honors_ignore_and_dedupes(self):
+        idx = km._repo_file_index(str(self.cwd))
+        self.assertNotIn("secret.log", idx)
+        self.assertEqual(sorted(idx["dup.py"]), ["a/dup.py", "b/dup.py"])
+        self.assertEqual(idx["render.js"], ["ui/render.js"])
+
+    def test_the_index_is_built_at_most_once_per_build_pass(self):
+        calls = []
+        saved = km._repo_file_index
+        try:
+            km._repo_file_index = lambda cwd: calls.append(cwd) or saved(cwd)
+            memo = {}
+            km._path_links("see render.js", SID, self._uuid(), memo)
+            km._path_links("see sub/deep.py", SID, self._uuid(), memo)
+            self.assertEqual(len(calls), 1, "one ls-files serves every message in the pass")
+        finally:
+            km._repo_file_index = saved
+
+
+class TokenizerParity(unittest.TestCase):
+    """The Python port and render.ts CLICKABLE_PATH_RE must agree on what a token IS — the map's keys
+    are what the client looks up, so a tokenizer drift silently unlinks. The client side of the same
+    fixture runs in chat-path-links.test.ts."""
+
+    def test_the_shared_fixture_tokenizes_identically(self):
+        with open(os.path.join(HERE, "fixtures", "path_token_parity.json")) as f:
+            cases = json.load(f)["cases"]
+        self.assertGreaterEqual(len(cases), 10, "the fixture is the parity surface — keep it broad")
+        for c in cases:
+            self.assertEqual(km._path_tokens(c["text"]), c["tokens"], c["text"])
+
+
+class BuildSessionWiring(unittest.TestCase):
+    def test_both_event_kinds_carry_the_map_when_a_verdict_exists(self):
+        import inspect
+        src = inspect.getsource(km.build_session)
+        self.assertIn('pl = _path_links(prompt, sid, a.get("uuid"), _pl_memo)', src,
+                      "user events get the resolver's verdict")
+        self.assertIn('pl = _path_links(txt, sid, a.get("uuid"), _pl_memo)', src,
+                      "assistant events get the resolver's verdict")
+        self.assertIn('ev["pathLinks"] = pl', src, "the map rides the event")
+        self.assertIn("if pl is not None:", src,
+                      "an EMPTY map still ships — its presence is what gates the client")
+        self.assertIn("_pl_memo = {}", src, "one repo listing per build pass")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/chat-path-links.test.ts
+++ b/ui/webview/chat-path-links.test.ts
@@ -1,0 +1,88 @@
+// Chat file links are filesystem-VERIFIED, and shortened mentions are FIXED.
+// The linkifier matched path-shaped tokens by SHAPE alone, so a bare `render.js` became a blue link
+// that 404'd on click — it resolved against the session's cwd, where no such file lives. The KERNEL
+// now resolves every shape-matched token at message-build time (build_session's _path_links: tier 1
+// exact stat, tiers 2/3 a UNIQUE match in `git ls-files -co --exclude-standard` run in the session's
+// cwd) and ships {token: open target} as `pathLinks` on user + assistant events. The client keeps
+// every shape gate it had and merely requires map membership; the map's value is what a click opens,
+// so a unique `sub/deep.py` mention opens the real kernel/sub/deep.py and hover shows that target.
+// Zero or several candidates → absent from the map → prose (a silently-wrong link is worse than no
+// link). render.ts has no jsdom harness → source pins + an executed tokenizer parity check over the
+// shared fixture (the kernel side runs the same fixture in tests/test_path_links.py).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the chat event carries the kernel's pathLinks verdict on user and assistant turns", () => {
+  assert.match(RENDER, /kind: "user";[^\n]*pathLinks\?: Record<string, string>/);
+  assert.match(RENDER, /kind: "assistant";[^\n]*pathLinks\?: Record<string, string>/);
+  assert.ok(KERNEL.includes('pl = _path_links(prompt, sid, a.get("uuid"), _pl_memo)'), "user events resolve their tokens");
+  assert.ok(KERNEL.includes('pl = _path_links(txt, sid, a.get("uuid"), _pl_memo)'), "assistant events resolve their tokens");
+  assert.ok(KERNEL.includes('ev["pathLinks"] = pl'), "the map rides the event");
+  // an EMPTY map still ships — its presence (not its size) is what tells the client a verdict exists
+  assert.ok(KERNEL.includes("if pl is not None:"), "None (no candidate tokens) ships nothing; {} ships");
+});
+
+test("membership in pathLinks gates the link, and the map's value is the OPEN target", () => {
+  // every existing shape gate stays — the map only ever narrows, never widens
+  assert.match(RENDER, /if \(!isUri && !looksLikeFilePath\(tok\) && !\(inCode && looksLikeBareFileName\(tok\)\)\) continue;/);
+  assert.match(RENDER, /const fixed = !isUri && pathLinks \? pathLinks\[tok\] : undefined;/);
+  assert.match(RENDER, /if \(!isUri && pathLinks && typeof fixed !== "string"\) continue;/);
+  // the fixed target is what opens (and openPathLink titles it, so hover shows where a fix points);
+  // with NO pathLinks key on the event (old kernel, cached payload) the token opens as written
+  assert.match(RENDER, /const open = isUri \? fileUriToPath\(tok\) : \(fixed \?\? tok\);/);
+  assert.match(RENDER, /frag\.appendChild\(isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\)\);/);
+  assert.match(RENDER, /a\.title = "Open " \+ open;/);
+});
+
+test("file:// URIs are explicit absolute paths — never gated on the map", () => {
+  // both guards above test !isUri first, so a file:// token can't be dropped by the map…
+  assert.match(RENDER, /const isUri = \/\^file:\\\/\\\/\/i\.test\(tok\);/);
+  // …and the kernel never puts file:// tokens in it
+  assert.ok(KERNEL.includes('if not t.lower().startswith("file://")'), "kernel skips file:// tokens");
+});
+
+test("the kernel resolves in three tiers over the session repo's real file list", () => {
+  assert.ok(KERNEL.includes("def _path_links(md, sid, uuid, memo):"));
+  assert.ok(KERNEL.includes("def _resolve_path_token(tok, sid, memo):"));
+  assert.ok(KERNEL.includes('["git", "ls-files", "-co", "--exclude-standard"]'),
+    "untracked files count, ignored files never do");
+  // the asymmetric per-message cache: hits latch (no flapping), misses retry every build — a file
+  // mentioned before the Write that creates it links on the very rebuild that Write triggers
+  assert.ok(KERNEL.includes("_PATH_LINK_CACHE"), "per-message cache");
+  assert.ok(KERNEL.includes("misses = tuple(still)"), "misses are re-checked, not cached");
+  // one repo listing per build pass, built lazily, never keyed on .git/index mtime
+  assert.ok(KERNEL.includes("_pl_memo = {}"), "per-build memo");
+  assert.ok(KERNEL.includes("_REPO_LIST_MAX"), "a runaway listing skips tiers 2/3");
+});
+
+// executed: the Python tokenizer (_path_tokens) and CLICKABLE_PATH_RE must agree on what a token IS —
+// the map keys the kernel ships are what this client looks up, so drift silently unlinks. Same fixture
+// runs against the kernel in tests/test_path_links.py. The regex is EXTRACTED from render.ts, so this
+// pins the real one, not a copy.
+test("tokenizer parity: the client regex over the shared fixture", () => {
+  const m = RENDER.match(/const CLICKABLE_PATH_RE = \/(.*)\/gi;/);
+  assert.ok(m, "CLICKABLE_PATH_RE found in render.ts");
+  const fixture = JSON.parse(fs.readFileSync(
+    path.resolve(process.cwd(), "..", "tests", "fixtures", "path_token_parity.json"), "utf8"));
+  assert.ok(fixture.cases.length >= 10, "the fixture is the parity surface — keep it broad");
+  const re = new RegExp(m![1], "gi");
+  for (const c of fixture.cases as { text: string; tokens: string[] }[]) {
+    // replicate the client loop: match, strip trailing punctuation, resume after the STRIPPED token
+    const toks: string[] = [];
+    let pos = 0;
+    for (;;) {
+      re.lastIndex = pos;
+      const mm = re.exec(c.text);
+      if (!mm) break;
+      const tok = mm[0].replace(/[.,;:!?)\]}>"'`]+$/, "");
+      pos = Math.max(mm.index + tok.length, pos + 1);
+      if (tok && !toks.includes(tok)) toks.push(tok);
+    }
+    assert.deepEqual(toks, c.tokens, c.text);
+  }
+});

--- a/ui/webview/chat-relpath-link.test.ts
+++ b/ui/webview/chat-relpath-link.test.ts
@@ -17,7 +17,9 @@ test("the linkifier matches file:// URIs AND bare paths, and gates each token ki
   assert.ok(RENDER.includes("const CLICKABLE_PATH_RE = /file:"), "regex still handles file:// URIs");
   assert.ok(RENDER.includes("[~.\\w\\-]"), "regex has the slashed-path alternative");
   assert.match(RENDER, /if \(!isUri && !looksLikeFilePath\(tok\) && !\(inCode && looksLikeBareFileName\(tok\)\)\) continue;/);
-  assert.match(RENDER, /frag\.appendChild\(isUri \? fileUriLink\(tok\) : openPathLink\(tok, tok, true\)\);/);
+  // the kernel's pathLinks verdict then narrows further, and its value is the OPEN target — pinned
+  // in chat-path-links.test.ts; here we pin that the link opens `open`, whatever chose it
+  assert.match(RENDER, /frag\.appendChild\(isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\)\);/);
 });
 
 test("a relative path click carries the active session id so the kernel resolves against its cwd", () => {

--- a/ui/webview/chat-space-paths.test.ts
+++ b/ui/webview/chat-space-paths.test.ts
@@ -35,7 +35,7 @@ test("the kernel verifies with the filesystem, resolved exactly like a click", (
 });
 
 test("linkifyFileUris whole-links a verified span's entire inline-code content", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\]\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>\): void/);
   // the pass targets inline <code> only, skips anything already linked or fenced
   assert.match(RENDER, /for \(const code of Array\.from\(root\.querySelectorAll\("code"\)\)\) \{\s*\n\s*if \(code\.closest\("a, \.file-uri-link, pre"\)\) continue;/);
   // exact-match against the kernel's verified set, then the whole content becomes one open link
@@ -54,7 +54,7 @@ test("the whole-span pass runs BEFORE the token walk, so the new link is skipped
 });
 
 test("every message render threads its event's spacePaths through", () => {
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths\);/);   // user bubble
-  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths\);/);     // expanded nudge body
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths\);/);    // assistant reply
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks\);/);   // user bubble
+  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks\);/);     // expanded nudge body
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks\);/);    // assistant reply
 });

--- a/ui/webview/file-uri-link.test.ts
+++ b/ui/webview/file-uri-link.test.ts
@@ -12,7 +12,7 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("a bare file:// URL becomes a clickable .file-uri-link that opens the file in the host app", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\]\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>\): void/);
   assert.match(RENDER, /el\("span", "file-uri-link"\)/);
   // clicking routes to the host opener (kernel `open <path>`), NOT a blocked window.open(file://) — a file://
   // URI is absolute, so it goes through the shared openPathLink's no-session-id branch
@@ -24,9 +24,9 @@ test("a bare file:// URL becomes a clickable .file-uri-link that opens the file 
 });
 
 test("linkify runs on chat message bodies (assistant reply + user bubble + nudge full text) and nowhere else — never tool summaries", () => {
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths\)/);   // the assistant reply
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths\)/); // your own bubble (in-bubble images don't re-thumb)
-  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths\)/);   // a compact nudge's expanded full text (2026-07-17)
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks\)/);   // the assistant reply
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks\)/); // your own bubble (in-bubble images don't re-thumb)
+  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks\)/);   // a compact nudge's expanded full text (2026-07-17)
   // exactly the definition + those three applications — so tool-use reports/summaries stay untouched
   const uses = RENDER.match(/linkifyFileUris\(/g) || [];
   assert.equal(uses.length, 4, "linkifyFileUris is defined once and applied to exactly the three chat bodies");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -73,8 +73,8 @@ type TaskOutputs = Record<string, { command: string; output: string }>;
 type ChatEvent = (
   // mid/mids: postal message ids the kernel could NOT resolve into cards, carried on the raw turn so a
   // timeline arc into it still lands (see _hydrate_postal's unresolved path)
-  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; spacePaths?: string[] }
-  | { kind: "assistant"; md: string; uuid?: string; ts?: string; spacePaths?: string[] }   // spacePaths: backticked filenames WITH spaces the kernel verified exist (build_session _space_paths) → whole-span links
+  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; spacePaths?: string[]; pathLinks?: Record<string, string> }
+  | { kind: "assistant"; md: string; uuid?: string; ts?: string; spacePaths?: string[]; pathLinks?: Record<string, string> }   // spacePaths: backticked filenames WITH spaces the kernel verified exist (build_session _space_paths) → whole-span links. pathLinks: path-shaped tokens the kernel verified against the filesystem, token → real open target (build_session _path_links) — the linkifier's gate
   | { kind: "thinking"; text: string; encrypted: boolean; uuid?: string; ts?: string }
   | {
       kind: "tool";
@@ -964,7 +964,15 @@ const CLICKABLE_PATH_RE = /file:\/\/\/?[^\s<>"'`)]+|[~.\w\-]*\/[~.\w\-/]*[\w\-]|
 // `Moving from correlation to causal components.md` linkified only its last word. For exactly these
 // verified spans, the whole inline-code content becomes ONE link; the filesystem is the authority, so a
 // backticked command like `uv run pytest tests/x.py` (no such file) is never mislinked.
-function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: string[]): void {
+// `pathLinks`: the kernel's verdict on every path-shaped token in this message (build_session's
+// _path_links — tier 1 exact stat, tiers 2/3 a unique repo-list match that FIXES a shortened mention
+// to its real file). When the key is present, a token links ONLY if it's in the map, and it opens the
+// map's value — so `render.js` in prose stops 404ing, and hover shows the real target. Every shape
+// gate below still applies; the map only ever narrows. An event with NO pathLinks key at all (an old
+// kernel, a cached payload) keeps today's shape-only linking rather than unlinking history.
+// file:// URIs are explicit absolute paths — never gated on the map.
+function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: string[],
+                         pathLinks?: Record<string, string>): void {
   const previewable: string[] = [];   // renderable paths found in this message → a thumbnail strip below it
   if (spacePaths && spacePaths.length) {
     const verified = new Set(spacePaths);
@@ -996,9 +1004,11 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
       if (!tok) continue;
       const isUri = /^file:\/\//i.test(tok);
       if (!isUri && !looksLikeFilePath(tok) && !(inCode && looksLikeBareFileName(tok))) continue;   // "and/or", `np.array` etc. — leave as prose
+      const fixed = !isUri && pathLinks ? pathLinks[tok] : undefined;   // the kernel's verdict, when it rendered one
+      if (!isUri && pathLinks && typeof fixed !== "string") continue;   // checked against the filesystem: no such file (or several) → prose
       if (m.index > last) frag.appendChild(document.createTextNode(text.slice(last, m.index)));
-      frag.appendChild(isUri ? fileUriLink(tok) : openPathLink(tok, tok, true));
-      const open = isUri ? fileUriToPath(tok) : tok;
+      const open = isUri ? fileUriToPath(tok) : (fixed ?? tok);
+      frag.appendChild(isUri ? fileUriLink(tok) : openPathLink(tok, open, true));
       if (previewKind(open) && !previewable.includes(open) && !(skipThumbs && skipThumbs.includes(open))) previewable.push(open);
       last = m.index + tok.length;
       re.lastIndex = last;
@@ -1682,7 +1692,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         if (more) {
           const full = el("div", "nudge-full md");
           full.innerHTML = md(raw);
-          linkifyFileUris(full, imgPaths, ev.spacePaths);
+          linkifyFileUris(full, imgPaths, ev.spacePaths, ev.pathLinks);
           bubble.appendChild(full);
           bubble.classList.add("nudge-collapsible");
           // toggle rides the stable document.body delegate (data-act), NOT a per-render listener —
@@ -1695,7 +1705,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         }
       } else if (ev.md) {
         bubble.innerHTML = md(ev.md);
-        linkifyFileUris(bubble, imgPaths, ev.spacePaths);   // bare file:// URLs in a message → clickable (open in the host's default app)
+        linkifyFileUris(bubble, imgPaths, ev.spacePaths, ev.pathLinks);   // bare file:// URLs in a message → clickable (open in the host's default app)
       }
       // images, IN the bubble (part of his message): thumbnail + open/copy caption;
       // a literal path in the typed text becomes the same open-link inline.
@@ -1834,7 +1844,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
     const body = el("div", "assistant md");
     body.innerHTML = md(ev.md);
     highlight(body);
-    linkifyFileUris(body, undefined, ev.spacePaths);   // bare file:// URLs + verified spaced filenames → clickable
+    linkifyFileUris(body, undefined, ev.spacePaths, ev.pathLinks);   // bare file:// URLs + verified spaced filenames → clickable
     turn.appendChild(body);
     return turn;
   }

--- a/ui/webview/slash-cmd-chip.test.ts
+++ b/ui/webview/slash-cmd-chip.test.ts
@@ -16,7 +16,7 @@ test("a leading slash command in a human bubble becomes a .slash-cmd-chip, args 
   assert.match(RENDER, /const chip = el\("span", "slash-cmd-chip"\); chip\.textContent = m\[1\];/);
   assert.match(RENDER, /const args = el\("span", "slash-cmd-args"\); args\.textContent = rest;/);
   // the non-command path still renders markdown as before (now also linkifies bare file:// URLs)
-  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n\s*bubble\.innerHTML = md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths\);[^\n]*\n\s*\}/);
+  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n\s*bubble\.innerHTML = md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks\);[^\n]*\n\s*\}/);
 });
 
 test("the chip is a monospace, outlined keyword pill that reads on the blue bubble", () => {

--- a/ui/webview/user-img-dedup.test.ts
+++ b/ui/webview/user-img-dedup.test.ts
@@ -15,7 +15,7 @@ const RENDER = fs.readFileSync(
   path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
 test("linkifyFileUris takes skipThumbs and excludes those paths from the thumbnail strip", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\]\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>\): void/);
   // the previewable push gates on skipThumbs — the path stays a LINK, it just doesn't thumb
   assert.match(RENDER,
     /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) previewable\.push\(open\);/);
@@ -24,9 +24,9 @@ test("linkifyFileUris takes skipThumbs and excludes those paths from the thumbna
 test("the user bubble passes its ev.images paths (caption path AND path:-src) as skipThumbs", () => {
   // both ways an in-bubble image names its file: im.path (caption) and a "path:<abs>" src
   assert.match(RENDER, /\.flatMap\(\(im\) => \[im\.path, im\.src\.startsWith\("path:"\) \? im\.src\.slice\(5\) : ""\]\)/);
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths\);/);
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks\);/);
   // the assistant reply has no ev.images — its call stays bare (mentioned plots still thumb there)
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths\);/);
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks\);/);
 });
 
 // executed: replicate the strip-collection decision — a path already rendered as an in-bubble


### PR DESCRIPTION
## The bug

The chat linkifier (`CLICKABLE_PATH_RE` plus the `looksLike*` gates in `ui/webview/render.ts`) turns any path-shaped token into a link with nothing checking that a file exists. Two failure modes follow:

- a shortened mention — an agent writing a bare `render.js` for `ui/webview/render.js` — becomes a blue link that 404s on click, because the token resolves against the session's cwd where no such file lives;
- phantom paths (a file the agent is about to write, a path it misremembered) link exactly the same way.

## The fix: the kernel verifies, the client gates

The kernel is the machine that has the filesystem, so it resolves every shape-matched token at message-build time and ships `{token: real open target}` as `pathLinks` on user and assistant chat events. Three tiers, first hit wins, ambiguity never guessed:

1. **exact** — the token resolves like a click (`_resolve_open_path`) to a real file;
2. **suffix** — the token has a slash and exactly ONE file in `git ls-files -co --exclude-standard` ends with `"/" + token`;
3. **basename** — the token has no slash and exactly ONE repo file bears that name.

Using `ls-files -co --exclude-standard` means untracked and uncommitted files count — agents mention files before committing them — while gitignored files never fix a bare name. Zero or several candidates leave the token out of the map and the client leaves it prose: a silently-wrong link is worse than no link.

The client keeps every shape gate it had and merely adds map membership: when the event carries a `pathLinks` key, a token links only if it is in the map, and it opens the map's **value** — so a unique `sub/deep.py` mention opens the real `kernel/sub/deep.py`, and hover shows that target.

## Wire shape and clean degradation

- `None` (no candidate tokens in the message, the common case) ships **no key** — no payload growth on ordinary messages.
- An **empty map** still ships: the key's presence is what tells the client a verdict was rendered.
- An event with **no `pathLinks` key at all** — an older kernel, a federated peer that predates this, a cached payload — keeps today's shape-only linking, so nothing in existing history gets unlinked and mixed-version setups degrade to exactly current behavior.
- `file://` URIs are explicit absolute paths and are never gated on the map, on either side.

## Cache design

Per-message, deliberately asymmetric:

- **hits latch** for the message's life — a link never flaps away underneath the user;
- **misses retry on every build** — the standard agent flow mentions `report.md` moments *before* the Write that creates it, and that Write triggers the very rebuild that should turn the mention into a link.

## Performance

The repo file index is built from one `git ls-files -co` per feed build pass, lazily (only when some token misses tier 1), and shared across every message in the pass — ~6ms on this repo. A runaway listing (>200k files) just stands tiers 2/3 down; tier 1 needs no list.

## Verification

- `tests/test_path_links.py` — 20 tests over a synthetic git repo: the three tiers, ambiguity, gitignore invisibility, tracked-but-deleted files, the asymmetric cache, non-git cwds, the runaway-listing guard, and the `build_session` wiring. All pass.
- `ui/webview/chat-path-links.test.ts` — pins the client gates and the event type.
- Both sides run an executed tokenizer-parity check over the shared `tests/fixtures/path_token_parity.json` (12 cases), so the Python port of `CLICKABLE_PATH_RE` cannot drift from the client regex — the regex is extracted from `render.ts` at test time, not copied.
- Full extension suite: 1771/1771 tests pass, `tsc --noEmit` clean.

## Note

A sibling PR fixing the non-macOS Browse… dialogs touches nearby lines in `render.ts`; the overlap is trivial and the two rebase cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)