### PR TITLE
fix: Browse and attach are silent no-ops off macOS and from remote dashboards

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -415,6 +415,7 @@ def _version_info():
             "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),      # current per-tier judge models → the gear dropdowns
             "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort(),  # current per-tier judge efforts ("" = default/none)
             "defaultDir": _tilde(_default_create_dir()),   # the resolved default new-session dir → the gear "Default directory" field
+            "nativeDialogs": _native_dialogs(),   # whether Browse… can draw a dialog HERE → the gear drops the button when it can't
             # The repo root ($HOME-collapsed), so the VS Code extension host can run vscode-extension/install.sh
             # to self-update a drifted VSIX (a webview reload can't — the code is baked into the on-disk VSIX).
             # ROMP_DIR is reliably exported by romp-serve/launchd; HERE.parent (kernel/ → repo root) backs it up.
@@ -16036,27 +16037,78 @@ def _open_file(p, sid=None):
         pass
 
 
-def _pick_file():
-    """Native file picker (macOS osascript) → the chosen POSIX path, or None if cancelled. Blocks, so
+# ── native file/folder dialogs ─────────────────────────────────────────────────────────────────────
+# These were macOS-only (osascript), which made the picker's "Browse…" and the chat's 📎 do NOTHING at
+# all on Linux: osascript is absent, the OSError was swallowed, no reply was sent, and the button sat
+# there looking functional. Two things follow.
+#
+# First, a Linux box with a desktop CAN open one — through whichever helper it happens to have — so ask
+# the desktop rather than assuming there is none. Second, a box with no desktop at all (a server, a
+# cloud VM, an SSH session) genuinely cannot, and that has to be SAID: `_native_dialogs()` tells the UI
+# up front so the button can present as unavailable, and the browseDir handler answers a click it
+# cannot serve with a warning rather than silence.
+#
+# A display is part of the test, not just the binary: zenity installed under a bare SSH login has no
+# screen to draw on and hangs or errors, which is the same silent nothing wearing a different hat.
+def _dialog_cmd(kind):
+    """argv for a native `kind` ("folder"|"file") picker on THIS machine, or None if it has no way to
+    show one. The dialog draws on the KERNEL's screen (where the paths live), so this is host-local."""
+    folder = kind == "folder"
+    prompt = "Pick a directory for the new session" if folder else "Attach a file"
+    if sys.platform == "darwin":
+        what = "choose folder" if folder else "choose file"
+        return ["osascript", "-e", 'POSIX path of (%s with prompt "%s")' % (what, prompt)]
+    if not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")):
+        return None            # no desktop to draw on — a headless server, or an SSH login with no forwarding
+    for exe in ("zenity", "qarma", "yad"):     # qarma/yad take zenity's flags
+        if shutil.which(exe):
+            return [exe, "--file-selection", "--title=" + prompt] + (["--directory"] if folder else [])
+    if shutil.which("kdialog"):
+        return ["kdialog", "--title", prompt,
+                "--getexistingdirectory" if folder else "--getopenfilename", os.path.expanduser("~")]
+    return None
+
+
+def _native_dialogs():
+    """Can this machine show a native folder/file dialog at all? Advertised to the UI (sessionList,
+    /version) so Browse… and 📎 present as unavailable instead of clicking into nothing."""
+    return _dialog_cmd("folder") is not None
+
+
+def _no_dialog_why(kind):
+    """Why this machine can't show a `kind` dialog, and what to do instead — shown to the user when a
+    click lands on a kernel that cannot serve it. Names the actual reason: a box with a desktop but no
+    helper is one `apt install` from working; a headless one is not, and should stop being told to try."""
+    what = "folder" if kind == "folder" else "file"
+    instead = ("Type the folder path instead — it completes as you type."
+               if kind == "folder" else "Drag the file in, or paste its path, instead.")
+    if sys.platform != "darwin" and not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")):
+        return "No %s dialog: %s has no desktop session to open one on. %s" % (what, _self_host(), instead)
+    return ("No %s dialog: %s has a desktop but no picker installed (zenity or kdialog). %s"
+            % (what, _self_host(), instead))
+
+
+def _run_dialog(kind):
+    """Run the native `kind` picker → the chosen path, or None if cancelled or unavailable. Blocks, so
     callers run it off the message loop."""
+    argv = _dialog_cmd(kind)
+    if not argv:
+        return None
     try:
-        out = subprocess.run(["osascript", "-e", 'POSIX path of (choose file with prompt "Attach a file")'],
-                             capture_output=True, text=True, timeout=180)
+        out = subprocess.run(argv, capture_output=True, text=True, timeout=180)
         return out.stdout.strip() or None
     except (OSError, subprocess.SubprocessError):
         return None
+
+
+def _pick_file():
+    """Native FILE picker → the chosen path, or None if cancelled/unavailable."""
+    return _run_dialog("file")
 
 
 def _pick_folder():
-    """Native FOLDER picker (macOS osascript) → the chosen POSIX path, or None if cancelled. The dialog opens
-    on the KERNEL's machine (where the dirs live), so this is host-local. Blocks → run off the message loop."""
-    try:
-        out = subprocess.run(
-            ["osascript", "-e", 'POSIX path of (choose folder with prompt "Pick a directory for the new session")'],
-            capture_output=True, text=True, timeout=180)
-        return out.stdout.strip() or None
-    except (OSError, subprocess.SubprocessError):
-        return None
+    """Native FOLDER picker → the chosen path, or None if cancelled/unavailable."""
+    return _run_dialog("folder")
 
 
 _CHAT_DIV_LAST = {}   # sid -> (chat_state, row_state) at the last logged transition — event-on-change, in-memory
@@ -20838,6 +20890,9 @@ class Handler(BaseHTTPRequestHandler):
             client["send"](json.dumps({"type": "sessionList",
                                        "items": _session_list(int(time.time()), _tmux_sessions()),
                                        "defaultDir": _tilde(_default_create_dir()),   # prefill the new-session dir field
+                                       # …and whether Browse… can do anything here, so a kernel with no
+                                       # desktop shows the button as unavailable rather than inert.
+                                       "nativeDialogs": _native_dialogs(),
                                        # billing choices THIS host can offer a new session — the picker
                                        # shows its auth control only when both are real (see _auth_avail)
                                        "authAvail": _auth_avail()}))
@@ -20967,11 +21022,14 @@ class Handler(BaseHTTPRequestHandler):
         elif msg and msg.get("type") == "openFile" and msg.get("path"):
             _open_file(str(msg["path"]), sid=msg.get("id"))       # caption / linkified path click → open it (relative → resolved vs the session cwd)
         elif msg and msg.get("type") == "pickFile":
-            def _pf(c=client):                                    # 📎 → native dialog (blocks) → insert the picked path
-                fp = _pick_file()
-                if fp:
-                    _reply(c, {"type": "droppedPath", "path": fp})
-            threading.Thread(target=_pf, daemon=True).start()
+            if not _native_dialogs():                             # same silent-nothing as Browse… — say it instead
+                client["send"](json.dumps({"type": "warn", "text": _no_dialog_why("file")}))
+            else:
+                def _pf(c=client):                                # 📎 → native dialog (blocks) → insert the picked path
+                    fp = _pick_file()
+                    if fp:
+                        _reply(c, {"type": "droppedPath", "path": fp})
+                threading.Thread(target=_pf, daemon=True).start()
         elif msg and msg.get("type") == "dirComplete":
             # Inline path completion for the new-session directory field. Answered by the kernel that will
             # own the session — federation routes this by the picker's Host selection — so completing a
@@ -20986,11 +21044,17 @@ class Handler(BaseHTTPRequestHandler):
                                 **_dir_completions(_val)))
         elif msg and msg.get("type") == "browseDir":
             tgt = str(msg.get("target") or "picker")          # which dir field to fill: the new-session picker or the gear
-            def _bd(c=client, t=tgt):                          # Browse → native FOLDER dialog (blocks) → fill that field
-                fp = _pick_folder()
-                if fp:
-                    _reply(c, {"type": "browseResult", "path": _tilde(fp), "target": t})
-            threading.Thread(target=_bd, daemon=True).start()
+            if not _native_dialogs():
+                # This kernel has no screen to draw a dialog on. Say so — a click that returns silence is
+                # the bug this replaced. The UI drops the button once it knows, so reaching here means an
+                # older client, or a desktop that went away since it was told.
+                client["send"](json.dumps({"type": "warn", "text": _no_dialog_why("folder")}))
+            else:
+                def _bd(c=client, t=tgt):                      # Browse → native FOLDER dialog (blocks) → fill that field
+                    fp = _pick_folder()
+                    if fp:
+                        _reply(c, {"type": "browseResult", "path": _tilde(fp), "target": t})
+                threading.Thread(target=_bd, daemon=True).start()
         elif msg and msg.get("type") == "setDefaultDir":      # gear/CLI persist the default new-session dir (a file)
             path, err = _set_default_dir(msg.get("value"))
             if err:

--- a/tests/test_new_session_dir.py
+++ b/tests/test_new_session_dir.py
@@ -12,11 +12,16 @@ remote host: federation routes the same ops to that host's kernel, and it reads 
 
 Synthetic paths in a temp dir only.
 """
+import inspect
 import json
 import os
 import tempfile
+import threading
+import types
 import unittest
+from unittest import mock
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -222,6 +227,126 @@ class CreateSessionDirFork(_Wire):
         self.send({"type": "createSession", "name": "web", "dir": self.tmp, "backend": "sdk"})
         self.assertEqual(len(self.spawned), 1)
         self.assertNotIn("createDirMissing", [m.get("type") for m in self.sent])
+
+
+class NativeDialogAvailability(unittest.TestCase):
+    """Browse… (and 📎) reach a dialog on the KERNEL's machine, and that machine may have no way to show
+    one. It was osascript-only, so on Linux the click hit a missing binary, the OSError was swallowed, no
+    reply came back, and the button sat there looking alive. Ask the desktop what it has; when the answer
+    is nothing, say so instead of returning silence."""
+
+    def cmd(self, kind="folder", platform="linux", which=(), env=None):
+        have = set(which)
+        with mock.patch.object(km.sys, "platform", platform), \
+             mock.patch.object(km.shutil, "which", lambda e: ("/usr/bin/" + e) if e in have else None), \
+             mock.patch.dict(os.environ, env or {}, clear=False):
+            for k in ("DISPLAY", "WAYLAND_DISPLAY"):
+                if not (env or {}).get(k):
+                    os.environ.pop(k, None)
+            return km._dialog_cmd(kind)
+
+    def test_a_headless_machine_has_no_dialog_at_all(self):
+        self.assertIsNone(self.cmd(which=("zenity",)),
+                          "zenity with no screen to draw on is the same silent nothing in a new hat")
+        self.assertIsNone(self.cmd(which=()))
+
+    def test_a_linux_desktop_uses_whichever_picker_it_has(self):
+        z = self.cmd(which=("zenity",), env={"DISPLAY": ":0"})
+        self.assertEqual(z[0], "zenity")
+        self.assertIn("--directory", z)                       # a session cwd is a folder, never a file
+        self.assertNotIn("--directory", self.cmd("file", which=("zenity",), env={"DISPLAY": ":0"}))
+        k = self.cmd(which=("kdialog",), env={"WAYLAND_DISPLAY": "wayland-0"})
+        self.assertEqual(k[0], "kdialog")                     # KDE, and Wayland counts as a desktop
+        self.assertIn("--getexistingdirectory", k)
+        self.assertIn("--getopenfilename", self.cmd("file", which=("kdialog",), env={"DISPLAY": ":0"}))
+
+    def test_macos_still_uses_osascript_and_needs_no_display_var(self):
+        c = self.cmd(platform="darwin", which=())
+        self.assertEqual(c[0], "osascript")
+        self.assertIn("choose folder", c[-1])
+        self.assertIn("choose file", self.cmd("file", platform="darwin", which=())[-1])
+
+    def test_the_capability_is_what_the_ui_is_told(self):
+        with mock.patch.object(km, "_dialog_cmd", lambda kind: None):
+            self.assertFalse(km._native_dialogs())
+        with mock.patch.object(km, "_dialog_cmd", lambda kind: ["zenity"]):
+            self.assertTrue(km._native_dialogs())
+
+    def test_a_cancelled_or_failed_dialog_is_None_not_a_crash(self):
+        with mock.patch.object(km, "_dialog_cmd", lambda kind: ["picker"]):
+            with mock.patch.object(km.subprocess, "run",
+                                   lambda *a, **k: types.SimpleNamespace(stdout="  /tmp/chosen \n")):
+                self.assertEqual(km._run_dialog("folder"), "/tmp/chosen")
+            with mock.patch.object(km.subprocess, "run", lambda *a, **k: types.SimpleNamespace(stdout="\n")):
+                self.assertIsNone(km._run_dialog("folder"), "cancelled → empty stdout")
+            with mock.patch.object(km.subprocess, "run", mock.Mock(side_effect=OSError("gone"))):
+                self.assertIsNone(km._run_dialog("folder"))
+
+    def test_the_reason_names_the_actual_cause_and_what_to_do_instead(self):
+        with mock.patch.object(km.sys, "platform", "linux"), \
+             mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DISPLAY", None); os.environ.pop("WAYLAND_DISPLAY", None)
+            why = km._no_dialog_why("folder")
+            self.assertIn("No folder dialog", why)
+            self.assertIn("no desktop session", why)
+            self.assertNotIn("zenity", why, "no point telling a headless box to install a picker")
+            self.assertIn("Type the folder path", why)
+            f = km._no_dialog_why("file")
+            self.assertIn("No file dialog", f, "the 📎 refusal is about a FILE, not a folder")
+            self.assertIn("paste its path", f)
+        with mock.patch.object(km.sys, "platform", "linux"), \
+             mock.patch.dict(os.environ, {"DISPLAY": ":0"}, clear=False):
+            self.assertIn("zenity", km._no_dialog_why("folder"), "a desktop with no picker CAN install one")
+
+
+class NativeDialogWire(_Wire):
+    """What the client sees: the capability up front, and a spoken refusal if a click lands anyway."""
+
+    def test_the_session_list_advertises_whether_browse_can_work(self):
+        for cap in (True, False):
+            with mock.patch.object(km, "_native_dialogs", lambda c=cap: c):
+                self.sent.clear()
+                r = self.send({"type": "requestSessions"})
+                self.assertEqual(r["type"], "sessionList")
+                self.assertIs(r["nativeDialogs"], cap)
+
+    def test_a_click_a_headless_kernel_cannot_serve_is_answered_not_swallowed(self):
+        with mock.patch.object(km, "_native_dialogs", lambda: False):
+            for msg, said in (({"type": "browseDir"}, "No folder dialog"),
+                              ({"type": "browseDir", "target": "gear"}, "No folder dialog"),
+                              ({"type": "pickFile"}, "No file dialog")):
+                self.sent.clear()
+                r = self.send(msg)
+                self.assertIsNotNone(r, "silence is the bug: %r returned nothing" % (msg,))
+                self.assertEqual(r["type"], "warn")
+                self.assertIn(said, r["text"])
+
+    def test_a_kernel_that_can_show_one_says_nothing_and_opens_it(self):
+        opened = []
+        with mock.patch.object(km, "_native_dialogs", lambda: True), \
+             mock.patch.object(km, "_pick_folder", lambda: opened.append("folder") or ""), \
+             mock.patch.object(km, "_pick_file", lambda: opened.append("file") or ""):
+            for msg in ({"type": "browseDir"}, {"type": "pickFile"}):
+                self.sent.clear()
+                self.send(msg)
+                self.assertEqual([m for m in self.sent if m.get("type") == "warn"], [],
+                                 "an available dialog must not be talked about, only shown")
+        for t in threading.enumerate():                      # the dialog runs off the message loop
+            if t is not threading.current_thread() and t.daemon:
+                t.join(timeout=2)
+        self.assertEqual(sorted(opened), ["file", "folder"])
+
+    def test_the_gear_learns_the_same_thing_from_its_own_route(self):
+        # The gear has no socket — it fetches /version — so the capability rides there too, beside the
+        # default directory it already reads.
+        src = inspect.getsource(km._version_info)
+        self.assertIn('"nativeDialogs": _native_dialogs()', src)
+        self.assertIn("v.nativeDialogs", _gear())
+        self.assertIn("ddb.style.display", _gear(), "no dialog on this machine → no Browse button")
+
+
+def _gear():
+    return Path(os.path.dirname(HERE), "ui", "webview", "gear.js").read_text()
 
 
 class HeadlessParity(unittest.TestCase):

--- a/ui/webview/composer-attach.test.ts
+++ b/ui/webview/composer-attach.test.ts
@@ -1,10 +1,18 @@
-// The composer 📎 attach button. On DESKTOP it asks the host to run a native open
-// dialog (type:"pickFile") and the picked path comes back as droppedPath. On a
-// TOUCH device that dialog would pop on the desktop running the kernel, not the
-// phone — useless — so 📎 instead opens the phone's own photo picker (a hidden
-// <input type=file accept=image/*>) and ships the chosen image's bytes to the
-// host via shipFileToHost → dropFile, which saves them under the state dir and
-// posts the saved path back for insertion (the user 2026-06-17).
+// The composer 📎 attach button opens a file picker on the machine whose SCREEN
+// the user is looking at, routed by host the same way Browse… splits:
+//
+//   • VS Code webview → the host extension's native open dialog (type:"pickFile");
+//     the editor IS the local machine, so the dialog is on the right screen and
+//     the picked path comes back as droppedPath.
+//   • Web dashboard (http/https, any pointer) → the BROWSER's own picker (a
+//     hidden <input type=file>) and the bytes ship via shipFileToHost → dropFile.
+//     The old behavior posted pickFile to the kernel, whose native dialog opens
+//     on the KERNEL's machine — the wrong screen entirely from a remote browser,
+//     and on a headless kernel nothing but a warning.
+//   • TOUCH keeps the phone photo-picker UX (accept=image/*, the user 2026-06-17);
+//     a desktop browser gets an unscoped multi-select picker — attributes set per
+//     open, when the pointer type is known.
+//
 // The chat renderer has no jsdom harness, so — like the other webview tests —
 // pin the wiring at the source level.
 import { test } from "node:test";
@@ -14,26 +22,53 @@ import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
-test("📎 on touch opens an image file picker, not the desktop-only host dialog", () => {
-  // a hidden file input scoped to images
+test("📎 on the web (touch or desktop) opens the BROWSER's picker, never the kernel's dialog", () => {
+  // a hidden file input…
   assert.match(RENDER, /createElement\("input"\)/);
   assert.match(RENDER, /filePicker\.type = "file"/);
-  assert.match(RENDER, /filePicker\.accept = "image\/\*"/);
+  // …opened from the click handler (a real gesture, required by iOS) whenever the page
+  // is the web dashboard OR the pointer is touch; only VS Code desktop falls through
+  assert.match(RENDER, /const isWebPage = location\.protocol === "http:" \|\| location\.protocol === "https:";/);
+  assert.match(RENDER, /if \(!isTouch\(\) && !isWebPage\) return;\s*\/\/ VS Code desktop → the host-dialog path/);
   // touch is gated on pointer:coarse (a phone), NOT viewport width — desktop panes are narrow too
   assert.match(RENDER, /matchMedia\("\(pointer:coarse\)"\)\.matches/);
-  // the click handler (real gesture, required by iOS to open a file input) opens the picker on touch
-  assert.match(RENDER, /attach\?\.addEventListener\("click", \(e\) => \{ if \(isTouch\(\)\) \{ e\.preventDefault\(\); filePicker\.click\(\); \} \}\)/);
+  // picker scope is decided PER OPEN: photos-only single pick on touch (the phone photo-picker
+  // UX), any files + multi-select on a desktop browser
+  assert.match(RENDER, /if \(isTouch\(\)\) \{ filePicker\.accept = "image\/\*"; filePicker\.multiple = false; \}/);
+  assert.match(RENDER, /else \{ filePicker\.removeAttribute\("accept"\); filePicker\.multiple = true; \}/);
+  assert.match(RENDER, /filePicker\.click\(\);/);
 });
 
-test("📎 routes the chosen image through the existing dropFile pipeline (no new path)", () => {
+test("📎 routes the chosen files through the existing dropFile pipeline (no new path)", () => {
   // chosen files go to shipFileToHost, which already posts {type:"dropFile"} and
   // gets {type:"droppedPath"} back — we reuse it rather than add a second uploader
   assert.match(RENDER, /filePicker\.files \|\| \[\]\)\.forEach\(\(f\) => shipFileToHost\(f\)\)/);
-  assert.match(RENDER, /vscodeApi\)\s*vscodeApi\.postMessage\(\{ type: "dropFile"/);
+  assert.match(RENDER, /\{ type: "dropFile", name: f\.name \|\| "pasted\.png", b64 \}/);
 });
 
-test("📎 on desktop still uses the native host dialog (pickFile), unchanged", () => {
-  // mousedown bails on touch so the picker (click handler) owns the phone; desktop posts pickFile
-  assert.match(RENDER, /addEventListener\("mousedown", \(e\) => \{\s*if \(isTouch\(\)\) return;/);
+test("📎 in the VS Code webview still uses the native host dialog (pickFile)", () => {
+  // mousedown (keeps the textarea focused) bails on touch AND on the web page,
+  // so the browser picker owns those; only the VS Code webview posts pickFile
+  assert.match(RENDER, /addEventListener\("mousedown", \(e\) => \{\s*if \(isTouch\(\) \|\| isWebPage\) return;/);
   assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "pickFile" \}\)/);
+});
+
+test("shipFileToHost stamps the session id so federation routes the bytes to the OWNING kernel", () => {
+  // the saved drops/ path rides the prompt and is read by the agent on the session's own
+  // machine — bytes saved on any other kernel would hand the agent a nonexistent path.
+  // routeOutbound routes any `id` field by host prefix (SCALAR_ID); the stamp is what
+  // engages it (multi-kernel-merge.test.ts pins the routing itself).
+  assert.match(RENDER, /if \(activeId\) msg\.id = activeId;\s*\/\/ the owning session → the owning kernel/);
+});
+
+test("an oversize file is refused LOUDLY — named size and cap in a toast, never a silent return", () => {
+  // one cap constant, checked before the read; drag-drop, paste and both pickers all
+  // funnel through shipFileToHost, so the toast covers every arrival path
+  assert.match(RENDER, /const SHIP_MAX_BYTES = 50 \* 1024 \* 1024;/);
+  assert.match(RENDER, /if \(f\.size > SHIP_MAX_BYTES\) \{/);
+  // the refusal names the file, its actual size, and the 50 MB cap
+  assert.match(RENDER, /warnToast\(\(f\.name \|\| "This file"\) \+ " is " \+ \(f\.size \/ \(1024 \* 1024\)\)\.toFixed\(1\)/);
+  assert.match(RENDER, /attachments over 50 MB can't be shipped, so it was not attached\./);
+  // the bare silent return is gone
+  assert.doesNotMatch(RENDER, /too big to ship over postMessage/);
 });

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -249,6 +249,11 @@ function initGear(post) {
     if (je && typeof v.judgeEffort === 'string') je.value = v.judgeEffort;
     if (ie && typeof v.indexEffort === 'string') ie.value = v.indexEffort;
     if (dd && typeof v.defaultDir === 'string') dd.value = v.defaultDir;   // the kernel's persisted default is authoritative
+    // Browse… draws on the KERNEL's screen, and a kernel with no desktop has none — the click used to
+    // vanish into a macOS-only dialog. Drop the button rather than offer one that cannot work; the
+    // field takes a typed path, which is what that machine has. An older kernel sends no verdict and
+    // keeps the button it always had.
+    if (ddb && typeof v.nativeDialogs === 'boolean') ddb.style.display = v.nativeDialogs ? '' : 'none';
     var x = lv(); b.innerHTML = 'kernel ' + (v.kernel_sha || '?') + '\nserving v' + v.dist_ver + '\nthis tab v' + (x || '?');
   }).catch(function () { b.textContent = '(version unavailable)'; }); }
   // The settings modal is full-WINDOW in the web shell — ask it to expand the

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -134,6 +134,26 @@ test("routeOutbound: showAskPath routes by sid — a remote card's hover glow re
   assert.equal(routeOutbound({ type: "showAskPath", itemId: U + ":g4", sid: U, off: true })[0].host, "");
 });
 
+test("routeOutbound: dropFile routes by its session id — attachment bytes reach the OWNING kernel", () => {
+  // A composer attachment (📎 picker, drag-drop, paste) ships bytes as dropFile; the kernel that
+  // takes them saves under ITS drops/ and the saved path rides the prompt, read by the agent on
+  // that machine. So the bytes must land on the session's own kernel: saved anywhere else, the
+  // agent is handed a path that does not exist on its filesystem (before the id was stamped,
+  // every remote session's attachment was saved on the LOCAL kernel).
+  const routes = routeOutbound({ type: "dropFile", name: "screenshot.png", b64: "aGVsbG8=", id: "gpu1:" + U });
+  assert.equal(routes.length, 1);
+  assert.equal(routes[0].host, "gpu1", "the session id picks the owning kernel");
+  assert.equal(routes[0].msg.id, U, "id stripped back to bare for that kernel");
+  assert.equal(routes[0].msg.name, "screenshot.png", "payload rides through untouched");
+  assert.equal(routes[0].msg.b64, "aGVsbG8=");
+  // a local session's attachment (bare id) stays local, the single-kernel path unchanged
+  assert.equal(routeOutbound({ type: "dropFile", name: "a.png", b64: "eA==", id: U })[0].host, "");
+  // ...and the droppedPath REPLY carries no session field, so prefixInbound passes it through
+  // untouched — the pane attaches it to its own activeId, which is already host-prefixed.
+  const reply = { type: "droppedPath", path: "~/.local/state/romp/drops/1-screenshot.png" };
+  assert.deepEqual(prefixInbound("gpu1", reply), reply);
+});
+
 test("prefixInbound: glowTurns groups get sid-prefixed so the merged chat finds the remote pane", () => {
   // The return leg of the same highlight: the owning kernel answers with glowTurns keyed by its own
   // bare sids, but the merged chat page keys its views "host:sid" — unprefixed groups matched nothing.

--- a/ui/webview/picker-dir.test.ts
+++ b/ui/webview/picker-dir.test.ts
@@ -66,6 +66,30 @@ test("a Browse button opens the host-native folder dialog (browseDir → browseR
   assert.match(CSS, /\.picker-browse \{/);
 });
 
+// The dialog is drawn by the KERNEL, and not every kernel can draw one — a Linux server or cloud VM has
+// no desktop session, and the button was a no-op there. The capability rides in on the local sessionList;
+// every place that touches the button goes through ONE helper, so a new call site can't reintroduce a
+// button that promises what the machine cannot do.
+test("Browse… disappears on a kernel with no desktop, and is disabled (not hidden) for a remote host", () => {
+  assert.match(RENDER, /let kernelNativeDialogs = true;/, "unknown → keep the button an older kernel always had");
+  assert.match(RENDER, /function applyBrowseState\(host: string\)[\s\S]*?b\.style\.display = kernelNativeDialogs \? "" : "none";[\s\S]*?b\.disabled = !!host;/);
+  // one helper, called from all three places the button's state can change
+  assert.match(RENDER, /applyBrowseState\(h\);/);                // the host row was clicked
+  assert.match(RENDER, /applyBrowseState\(""\);/);               // the picker opened
+  assert.match(RENDER, /applyBrowseState\(pickerHost\(\)\);/);   // the capability landed while it was open
+  assert.doesNotMatch(RENDER, /browse0/, "the old inline reset is gone — the state lives in the helper");
+  assert.match(CSS, /\.picker-browse:disabled \{/, "a disabled button must LOOK disabled, not just ignore clicks");
+});
+
+test("the capability is adopted only from the LOCAL kernel's reply, like defaultDir", () => {
+  // a remote's answer is about that machine's screen, not this one's
+  assert.match(RENDER, /if \(typeof m\.nativeDialogs === "boolean" && !from\) \{\s*\n\s*kernelNativeDialogs = m\.nativeDialogs;/);
+});
+
+test("no tooltip still claims the folder dialog is macOS-only", () => {
+  assert.doesNotMatch(RENDER, /native macOS dialog/);
+});
+
 test("the dir field prefills with the kernel's real default path (not blank), still editable", () => {
   // …and only from the LOCAL reply: a remote kernel's default directory is that machine's, not this one's
   assert.match(RENDER, /if \(typeof m\.defaultDir === "string" && !from\) kernelDefaultDir = m\.defaultDir/);

--- a/ui/webview/picker-host.test.ts
+++ b/ui/webview/picker-host.test.ts
@@ -25,5 +25,8 @@ test("createSession carries the picked host (empty = local) so the manager route
 });
 
 test("picking a remote host disables the (host-local) Browse… dialog", () => {
-  assert.match(RENDER, /browse\.disabled = !!h/);
+  // The disable moved into applyBrowseState, which also hides the button on a kernel with no desktop at
+  // all — see picker-dir.test.ts. The host row's job is unchanged: pick remote, lose Browse.
+  assert.match(RENDER, /applyBrowseState\(h\);/);
+  assert.match(RENDER, /function applyBrowseState\(host: string\)[\s\S]*?b\.disabled = !!host;/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4261,6 +4261,30 @@ function dirPrefill(host: string): string {
   return host ? "" : (kernelDefaultDir || loadSettings().defaultDir || "");
 }
 
+// Browse… is served by the kernel, and only when THAT machine can actually draw a dialog. Two ways it
+// can't: a REMOTE host, whose dialog would open on the local screen and list the wrong disk; and a kernel
+// with no desktop session at all — a server, a cloud VM — where the click used to reach a macOS-only
+// osascript and return nothing whatsoever. Neither is a reason to leave a button that looks live, and
+// neither costs anything to lose: the field beside it already does the job — the completer asks the
+// OWNING kernel, so a path on any host is typed with real folders offered as you go.
+// The capability rides in on the local sessionList; assume yes until a kernel says otherwise, so an older
+// kernel that doesn't send it keeps the button it always had.
+let kernelNativeDialogs = true;
+
+// The two cases are shown differently, because one of them can change and the other cannot. A REMOTE host
+// is one click back to local, so the button stays in place, disabled, saying so. A kernel with no desktop
+// can NEVER open a dialog, so the button is not rendered at all: a permanently grey control explained only
+// by a hover title is no explanation on a phone, and the field beside it is the whole affordance anyway.
+function applyBrowseState(host: string): void {
+  const b = document.querySelector("#picker .picker-browse") as HTMLButtonElement | null;
+  if (!b) return;
+  b.style.display = kernelNativeDialogs ? "" : "none";
+  b.disabled = !!host;
+  b.title = host
+    ? `The native dialog is local-only. Type the path on ${host} instead; it completes as you type.`
+    : "Pick a folder with the native dialog (opens on the kernel's machine — host-local)";
+}
+
 // Which host's sessions the picker list is currently showing ("" = this machine). The Host row picks the
 // machine a NEW session would be created on; it now also picks whose EXISTING sessions are listed, so a
 // remote session can be reopened or revived without going to that machine's own dashboard.
@@ -4530,7 +4554,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     const dirList = document.createElement("datalist"); dirList.id = "picker-dir-list";
     const browseBtn = el("button", "picker-browse") as HTMLButtonElement;
     browseBtn.type = "button"; browseBtn.textContent = "Browse…";
-    browseBtn.title = "Pick a folder with the native macOS dialog (opens on the kernel's machine — host-local)";
+    browseBtn.title = "Pick a folder with the native dialog (opens on the kernel's machine — host-local)";
     browseBtn.addEventListener("click", () => { if (vscodeApi) vscodeApi.postMessage({ type: "browseDir" }); });
     // the completer's dropdown + the one-line status of whatever is typed, both fed by the owning kernel
     const dirMenu = el("div", "picker-dir-menu"); dirMenu.id = "picker-dir-menu"; dirMenu.style.display = "none";
@@ -4660,8 +4684,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
         hostWrapEl.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", x === b));
         // the native Browse… dialog opens on the LOCAL kernel's screen, so it can't stand for a remote
         // machine's disk; the inline completer can — it asks that host's own kernel (the user 2026-07-28)
-        const browse = overlay!.querySelector(".picker-browse") as HTMLButtonElement | null;
-        if (browse) { browse.disabled = !!h; browse.title = h ? `The native dialog is local-only. Type the path on ${h} instead; it completes as you type.` : "Pick a folder with the native macOS dialog (opens on the kernel's machine — host-local)"; }
+        applyBrowseState(h);
         const dirIn = document.getElementById("picker-dir") as HTMLInputElement | null;
         if (dirIn) dirIn.placeholder = h ? `New-session directory on ${h} (blank = its default)` : "New-session directory (blank = default)";
         // …and the SESSIONS listed above belong to that machine now too (the user 2026-07-29): the list
@@ -4680,9 +4703,8 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       });
       hostWrapEl.appendChild(b);
     }
-    const browse0 = overlay.querySelector(".picker-browse") as HTMLButtonElement | null;
-    if (browse0) browse0.disabled = false;   // fresh open defaults back to local
   }
+  applyBrowseState("");   // fresh open defaults back to local — enabled unless this kernel has no desktop
   const di = document.getElementById("picker-dir") as HTMLInputElement | null;
   // the host row resets to local on every open, so this is the local prefill: what you last used here,
   // else the kernel's persisted default (file→env; localStorage is a same-tab cache)
@@ -8249,6 +8271,12 @@ window.addEventListener("message", (e: MessageEvent) => {
     const from = typeof m.host === "string" ? m.host : "";
     if (from !== pickerListHost) return;
     if (typeof m.defaultDir === "string" && !from) kernelDefaultDir = m.defaultDir;   // the LOCAL default dir
+    // …and whether that kernel can open a folder dialog at all. It arrives after the picker is already on
+    // screen, so re-settle the button now rather than leaving it live until the next open.
+    if (typeof m.nativeDialogs === "boolean" && !from) {
+      kernelNativeDialogs = m.nativeDialogs;
+      applyBrowseState(pickerHost());
+    }
     // the selected host's billing choices ride its own list reply — this is what arms (or hides) the
     // picker's Billing row (the user 2026-08-08); an older kernel sends none and the row stays away
     pickerAuthAvail = (m.authAvail && typeof m.authAvail === "object") ? m.authAvail : null;
@@ -8770,48 +8798,76 @@ function setupComposer() {
   });
   wirePasteFallback(ta); // belt-and-braces: native paste disarms it, so no double-insert
 
-  // The bulletproof path: 📎 asks the host to run a native open dialog (no
-  // workbench drop overlay to fight) and the picked path comes back as
-  // droppedPath → an attachment thumbnail (the user 2026-08-04; it used to insert
-  // the raw path at the cursor). Mousedown (not click) so the textarea keeps focus.
+  // 📎 opens a file picker on the machine whose SCREEN you are looking at, routed
+  // by host the same way Browse… splits:
   //
-  // TOUCH devices (phone/tablet on the web dashboard) can't use the host dialog:
-  // it pops on the DESKTOP running the kernel, not the phone. So 📎 instead opens
-  // the phone's own photo picker (a hidden <input type=file accept=image/*>), and
-  // the chosen image's bytes ship to the host (shipFileToHost → dropFile), which
-  // saves them under ~/.local/state/romp/drops/ and posts the saved path back
-  // (droppedPath), landing as an attachment thumbnail — a screenshot reaches the
-  // session with no AirDrop/path gymnastics (the user 2026-06-17).
+  //   • VS Code webview → the host extension's native open dialog (pickFile): the
+  //     editor IS the local machine, so the dialog is on the right screen and the
+  //     picked path comes back as droppedPath → an attachment thumbnail (the user
+  //     2026-08-04; it used to insert the raw path at the cursor).
+  //   • Web dashboard (http/https) → the BROWSER's own picker (the hidden
+  //     <input type=file> below), and the chosen files' bytes ship to the kernel
+  //     (shipFileToHost → dropFile → droppedPath), the flow drag/paste already
+  //     rides. The old behavior posted pickFile to the kernel, whose native dialog
+  //     opens on the KERNEL's machine — the wrong screen entirely from a remote
+  //     browser, and on a headless kernel nothing but a warning.
+  //
+  // TOUCH devices keep the phone photo-picker UX (accept=image/*, the user
+  // 2026-06-17: a screenshot reaches the session with no AirDrop/path gymnastics);
+  // a desktop browser gets an unscoped, multi-select picker — attributes are set
+  // per open, at the moment the pointer type is known.
   const attach = document.getElementById("composer-attach") as HTMLButtonElement | null;
   const isTouch = isCoarsePointer;
+  const isWebPage = location.protocol === "http:" || location.protocol === "https:";
   const filePicker = document.createElement("input");
   filePicker.type = "file";
-  filePicker.accept = "image/*";
   filePicker.style.display = "none";
   filePicker.addEventListener("change", () => {
     Array.from(filePicker.files || []).forEach((f) => shipFileToHost(f));
     filePicker.value = ""; // let the same file be picked again
   });
   document.body.appendChild(filePicker);
-  // touch: open the phone's photo picker — must fire from a real click gesture (iOS)
-  attach?.addEventListener("click", (e) => { if (isTouch()) { e.preventDefault(); filePicker.click(); } });
-  // desktop: native host dialog; mousedown keeps the textarea focused for cursor-position insert
+  // web (touch or desktop): open the browser's picker — must fire from a real click gesture (iOS)
+  attach?.addEventListener("click", (e) => {
+    if (!isTouch() && !isWebPage) return;   // VS Code desktop → the host-dialog path (mousedown below)
+    e.preventDefault();
+    if (isTouch()) { filePicker.accept = "image/*"; filePicker.multiple = false; }
+    else { filePicker.removeAttribute("accept"); filePicker.multiple = true; }
+    filePicker.click();
+  });
+  // VS Code desktop: native host dialog; mousedown keeps the textarea focused for cursor-position insert
   attach?.addEventListener("mousedown", (e) => {
-    if (isTouch()) return;
+    if (isTouch() || isWebPage) return;
     e.preventDefault();
     vscodeApi?.postMessage({ type: "pickFile" });
   });
 }
 
-// No filesystem path available for a dropped/pasted file → ship the bytes to
-// the host, which saves them under ~/.local/state/romp/drops/ and posts back
-// {type:"droppedPath", path} — which lands as an attachment thumbnail.
+// No filesystem path available for a picked/dropped/pasted file → ship the bytes
+// to the kernel that OWNS the active session, which saves them under its state
+// dir's drops/ and posts back {type:"droppedPath", path} — which lands as an
+// attachment thumbnail. dropFile carries the session id so federation routes it
+// (routeOutbound's SCALAR_ID): the saved path rides the prompt and is read by the
+// agent on THAT machine, so bytes saved on any other kernel would hand the agent
+// a path that does not exist there.
+const SHIP_MAX_BYTES = 50 * 1024 * 1024;   // payload ceiling for shipped attachment bytes
 function shipFileToHost(f: File) {
-  if (f.size > 50 * 1024 * 1024) return;   // too big to ship over postMessage
+  if (f.size > SHIP_MAX_BYTES) {
+    // an oversize file must be REFUSED VISIBLY, never dropped silently — name the
+    // file, its size and the cap, on the same loud surface a failed federation
+    // delivery uses.
+    warnToast((f.name || "This file") + " is " + (f.size / (1024 * 1024)).toFixed(1)
+      + " MB — attachments over 50 MB can't be shipped, so it was not attached.");
+    return;
+  }
   const reader = new FileReader();
   reader.onload = () => {
     const b64 = String(reader.result || "").split(",")[1] || "";
-    if (b64 && vscodeApi) vscodeApi.postMessage({ type: "dropFile", name: f.name || "pasted.png", b64 });
+    if (!b64 || !vscodeApi) return;
+    const msg: { type: string; name: string; b64: string; id?: string } =
+      { type: "dropFile", name: f.name || "pasted.png", b64 };
+    if (activeId) msg.id = activeId;   // the owning session → the owning kernel
+    vscodeApi.postMessage(msg);
   };
   reader.readAsDataURL(f);
 }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1846,6 +1846,11 @@ body.picker-lifted > #picker { align-items: center; padding: 24px 16px; }
   border: 1px solid var(--box-border); border-radius: 5px; padding: 5px 9px; font-size: 0.82em;
 }
 .picker-browse:hover { background: rgba(255, 255, 255, 0.12); }
+/* Disabled while a REMOTE host is selected — that machine's dialog can't open on this screen. It had no
+   disabled look, so it read as an ordinary button that ignored clicks; dim it and drop the hover lift so
+   it says unavailable. The title explains, and the field beside it still works. */
+.picker-browse:disabled { opacity: 0.4; cursor: not-allowed; }
+.picker-browse:disabled:hover { background: rgba(255, 255, 255, 0.06); }
 /* the typed path's one-line verdict from the kernel that would own the session (exists / will be
    created / is a file), so the answer arrives before the create does (the user 2026-07-28) */
 .picker-dir-status {


### PR DESCRIPTION
## The bugs

Three holes, one seam: the file/folder dialogs assume the kernel is a macOS desktop and the viewer is sitting at it.

1. **On any non-macOS kernel, Browse… (new-session picker and gear) and the chat's 📎 do nothing at all.** `_pick_folder`/`_pick_file` run `osascript`; off macOS the `OSError` is caught and returned as `None`, so the click sends `browseDir`, gets no reply, and the button sits there looking functional.
2. **Even where the kernel dialog works, it opens on the KERNEL's screen** — the wrong machine whenever the dashboard is read from a phone or another computer.
3. **A remote session's attachment lands on the wrong kernel, and an oversize file vanishes.** `dropFile` carried no session id, so federation fell through to LOCAL: the bytes saved under the *viewer's* kernel's `drops/`, and the prompt handed the agent a path that does not exist on its machine. Separately, `shipFileToHost`'s 50 MB cap was a bare `return` — the file just disappeared.

## The fix

**Kernel dialogs (bug 1):**
- `_dialog_cmd` asks the machine what it has: `osascript` on macOS; `zenity`/`qarma`/`yad`/`kdialog` on Linux, gated on `DISPLAY`/`WAYLAND_DISPLAY` — an installed picker under a bare SSH login has no screen to draw on and hangs, the same silent nothing in a different hat.
- A new `nativeDialogs` capability rides the `sessionList` reply and `/version`, so the UI knows up front. The picker's Browse… is not rendered on a kernel that can never show a dialog (and stays in place, disabled with an explanation, for a remote host — that state can change with one click); the gear's Browse does the same via `/version`.
- A `browseDir`/`pickFile` click that lands on a kernel that cannot serve it (older client, desktop went away) is answered with a `warn` naming the actual reason — headless vs. no picker installed — and what to do instead. Silence was the bug; it never answers with silence now.

**📎 routes by host (bug 2):**
- Web dashboard (http/https): 📎 opens the **browser's own picker** — the hidden `<input type=file>` flow touch already used — and ships bytes over the existing `dropFile` → `droppedPath` path. Scope is set per open: photos-only single pick on phones (unchanged UX), any files + multi-select on a desktop browser.
- VS Code webview: keeps posting `pickFile` — the editor IS the local machine there, so the host-native dialog is on the right screen. Unchanged.

**Attach routing + loud cap (bug 3):**
- `shipFileToHost` stamps the active session's id on `dropFile`; `routeOutbound`'s existing `SCALAR_ID` routing then carries the bytes to the owning kernel with the host prefix stripped. The kernel handler ignores the extra field, and the `droppedPath` reply carries no session field, so `prefixInbound` passes it through untouched.
- An oversize file gets a warn toast naming the file, its actual size, and the 50 MB cap, instead of a silent return.

## Verified

- `tests/test_new_session_dir.py`: 35/35 OK (new coverage: dialog selection per platform/display, capability advertisement, spoken refusal vs. silent swallow, gear wiring).
- `npm test` in vscode-extension: **1772/1772 pass** (new pins in `picker-dir.test.ts`, `picker-host.test.ts`, rewritten `composer-attach.test.ts`, `dropFile` routing in `multi-kernel-merge.test.ts`). `npm run typecheck` clean.
- `tests/test_kernel.py`: 408 tests, 7 errors — byte-identical failure list to a pristine `main` checkout run on the same box (pre-existing; they trace to `_gear_src` being defined below `unittest.main()` when the file is run directly).

A follow-up building on this will route linkified file paths for remote dashboards the same way (an in-page viewer instead of the kernel-side opener).

🤖 Generated with [Claude Code](https://claude.com/claude-code)