### PR TITLE
The billing switch moves from the statusline badge into the tab's right-click menu

### DIFF
--- a/ui/webview/auth-selector.test.ts
+++ b/ui/webview/auth-selector.test.ts
@@ -4,9 +4,10 @@
 //   * the new-session picker's Billing row is ALWAYS there for an SDK session: segmented buttons when
 //     the selected host's own sessionList reply (authAvail) says both choices are real, and the same
 //     spot writes the single choice out as plain text when only one is (a fact, not a control);
-//   * the statusline auth badge is the SWITCHING control, so it keeps the stricter gate: it exists
-//     only when the machine offers both (st.authBoth), posting setAuth and wearing switching-dots
-//     while the applying reconnect is pending;
+//   * the SWITCHING control is a Billing submenu in the chat tab's right-click menu (moved from a
+//     statusline badge, the user 2026-08-09): it exists only when the machine offers both
+//     (st.authBoth), posting the same setAuth; the sub-line says "applying…" while the reconnect
+//     is pending;
 //   * the chat tab's hover carries the fact as a Billing row whenever the backend reports it
 //     (st.auth rides ungated now), naming WHICH login account (st.authAcct) beside 'Login'.
 // The key is labelled plainly 'API key' — NO key material anywhere: not the key, not even a last-4
@@ -59,18 +60,23 @@ test("the pick rides createSession, omitted when the row is hidden or written-ou
   assert.match(RENDER, /const def = a!\.default === "key" \? "key" : "login";/);
 });
 
-test("the statusline auth badge — the switching CONTROL — still gates on both", () => {
-  assert.match(RENDER, /type MetaKind = "mode" \| "model" \| "effort" \| "fast" \| "auth";/);
-  // st.auth is always reported now; the CONTROL keys on st.authBoth so a one-auth machine
-  // shows no dead selector (the display rows carry the fact instead)
-  assert.match(RENDER, /\(st\.auth && st\.authBoth\) \? "auth" : ""/);
-  assert.match(RENDER, /if \(st\.auth && st\.authBoth\) meta\.appendChild\(metaButton\("auth", prettyAuth\(st\)\)\);/);
-  // the badge label is the plain choice, never key material
-  assert.match(RENDER, /return \(st\.auth \|\| ""\)\.toLowerCase\(\) === "key" \? "API key" : "Login";/);
-  // the pick posts setAuth, and the applying reconnect drives the switching-dots
-  assert.match(RENDER, /kind === "auth" \? "setAuth"/);
-  assert.match(RENDER, /\(kind === "auth" && !!st\.authPending\)/);
-  assert.match(RENDER, /kind === "model" \|\| kind === "effort" \|\| kind === "auth"\);/);
+test("the switching CONTROL is the tab menu's Billing submenu, gated on both", () => {
+  // moved OUT of the statusline (the user 2026-08-09): no auth badge kind survives there
+  assert.match(RENDER, /type MetaKind = "mode" \| "model" \| "effort" \| "fast";/);
+  assert.doesNotMatch(RENDER, /metaButton\("auth"/);
+  assert.doesNotMatch(RENDER, /AUTH_CHOICES/);
+  // …and INTO showTabMenu: only when the machine offers both choices does the item exist at all
+  // (a one-auth machine keeps the fact on the tab hover, never a dead selector)
+  assert.match(RENDER, /if \(st && st\.auth && st\.authBoth\) \{/);
+  // the flyout offers the two plain labels — Login named by its account, the key by NO material —
+  // with the session's current choice check-marked
+  assert.match(RENDER, /\{ label: st\.authAcct \? `Login \(\$\{st\.authAcct\}\)` : "Login", value: "login" \},/);
+  assert.match(RENDER, /\{ label: "API key", value: "key" \}\]/);
+  assert.match(RENDER, /el\("div", "ctx-item" \+ \(st\.auth === c\.value \? " current" : ""\)\)/);
+  // a pick posts the same setAuth the badge used, and only a CHANGE posts (current = dismiss)
+  assert.match(RENDER, /if \(st\.auth !== c\.value && vscodeApi\) vscodeApi\.postMessage\(\{ type: "setAuth", id, value: c\.value \}\);/);
+  // the item's sub-line names the current billing, or the applying reconnect
+  assert.match(RENDER, /st\.authPending \? "applying…"/);
   assert.match(RENDER, /auth\?: string; authPending\?: boolean; authBoth\?: boolean; authAcct\?: string;/);
 });
 

--- a/ui/webview/effort-switch-pending.test.ts
+++ b/ui/webview/effort-switch-pending.test.ts
@@ -14,7 +14,7 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the effort badge shows switching-dots while a reconnect is pending, like the model badge", () => {
   assert.match(RENDER, /effortPending\?: boolean;/);   // status carries it
   assert.match(RENDER, /\(kind === "effort" && !!st\.effortPending\)/);          // effort feeds `pending`
-  assert.match(RENDER, /const showDots = pending && \(kind === "model" \|\| kind === "effort" \|\| kind === "auth"\);/);   // dots for all three reconnect-style switches
+  assert.match(RENDER, /const showDots = pending && \(kind === "model" \|\| kind === "effort"\);/);   // dots for both reconnect-style badges (billing moved to the tab menu, 2026-08-09)
 });
 
 test("a live reconnect has its own ChatEvent kind, dispatched to renderReconnecting", () => {

--- a/ui/webview/fast-toggle.test.ts
+++ b/ui/webview/fast-toggle.test.ts
@@ -17,7 +17,7 @@ const SDK = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_bac
 
 test("the fast badge is a meta control that appears only when the session reports a state", () => {
   assert.match(RENDER, /fast\?: string;/);                                   // status carries it
-  assert.match(RENDER, /type MetaKind = "mode" \| "model" \| "effort" \| "fast" \| "auth";/);
+  assert.match(RENDER, /type MetaKind = "mode" \| "model" \| "effort" \| "fast";/);   // billing moved to the tab menu (2026-08-09)
   assert.match(RENDER, /st\.fast \? "fast" : ""/);                           // no state → no badge
   assert.match(RENDER, /meta\.appendChild\(metaButton\("fast", prettyFast\(st\.fast\)\)\)/);
 });

--- a/ui/webview/model-switch-dots.test.ts
+++ b/ui/webview/model-switch-dots.test.ts
@@ -16,8 +16,8 @@ test("Status carries the server-driven modelPending flag", () => {
 
 test("syncMetaControls renders dots for a pending model, driven by the server flag (+ local click heuristic)", () => {
   // model + effort both drive dots now (effort reconnects to apply); the model clause is still present
-  assert.match(RENDER, /const pending = \(kind === "model" && !!st\.modelPending\) \|\| \(kind === "effort" && !!st\.effortPending\)\s*\n\s*\|\| \(kind === "auth" && !!st\.authPending\) \|\| isMetaPending\(kind, st\);/);
-  assert.match(RENDER, /const showDots = pending && \(kind === "model" \|\| kind === "effort" \|\| kind === "auth"\);/);
+  assert.match(RENDER, /const pending = \(kind === "model" && !!st\.modelPending\) \|\| \(kind === "effort" && !!st\.effortPending\)\s*\n\s*\|\| isMetaPending\(kind, st\);/);
+  assert.match(RENDER, /const showDots = pending && \(kind === "model" \|\| kind === "effort"\);/);   // billing moved to the tab menu (2026-08-09)
   assert.match(RENDER, /if \(!label\.querySelector\("\.meta-dots"\)\) label\.replaceChildren\(metaDots\(\)\);/);
 });
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3735,14 +3735,16 @@ function setSessionColor(id: string, bg: string) {
 
 // Small inline-SVG icon for the tab menu's toggle items (trusted constant markup; `off` slashes + dims it,
 // matching the timeline lane toggles). 16-unit viewBox; currentColor so .ctx-icon/.off set the tint.
-function ctxIcon(kind: "feed" | "mail" | "bell", off: boolean): HTMLElement {
+function ctxIcon(kind: "feed" | "mail" | "bell" | "bill", off: boolean): HTMLElement {
   const span = el("span", "ctx-icon" + (off ? " off" : ""));
   const slash = off ? '<line x1="1.6" y1="14.4" x2="14.4" y2="1.6"/>' : "";
   const body = kind === "feed"
     ? '<circle cx="8" cy="8" r="6"/><path d="M5 8.3 L7.2 10.7 L11.4 5.3"/>'              // circle + check (on the feed)
     : kind === "mail"
       ? '<rect x="2" y="4" width="12" height="8" rx="1.5"/><path d="M2.5 5 L8 9 L13.5 5"/>'  // envelope (on the postal service)
-      : '<path d="M8 2 C5.9 2.2 4.7 3.8 4.7 5.8 L4.7 8 L3.4 9.9 L12.6 9.9 L11.3 8 L11.3 5.8 C11.3 3.8 10.1 2.2 8 2 Z"/><path d="M6.6 11.6 A1.5 1.5 0 0 0 9.4 11.6"/>';  // bell (system notifications)
+      : kind === "bill"
+        ? '<rect x="2" y="4" width="12" height="8" rx="1.5"/><line x1="2" y1="6.8" x2="14" y2="6.8"/><line x1="4.2" y1="9.6" x2="7.4" y2="9.6"/>'  // payment card (billing)
+        : '<path d="M8 2 C5.9 2.2 4.7 3.8 4.7 5.8 L4.7 8 L3.4 9.9 L12.6 9.9 L11.3 8 L11.3 5.8 C11.3 3.8 10.1 2.2 8 2 Z"/><path d="M6.6 11.6 A1.5 1.5 0 0 0 9.4 11.6"/>';  // bell (system notifications)
   span.innerHTML = '<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" '
     + 'stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">' + body + slash + "</svg>";
   return span;
@@ -3789,6 +3791,51 @@ function showTabMenu(e: MouseEvent, id: string) {
     onBell ? "Stop notifying" : "Notify me",
     onBell ? "no more system notifications for this session" : "system notification when its work blocks on you or completes",
     () => setSessionFlag(id, "notify", !onBell));
+  // Billing submenu (the user 2026-08-09, who wants the login/API-key switch here rather than as a
+  // statusline badge). Only when the machine offers BOTH choices (st.authBoth) — a one-auth machine
+  // keeps the fact on the tab hover, never a dead selector — and the key stays labelled plainly
+  // 'API key', no fragment of it anywhere. Clicking opens a flyout with the two choices, the
+  // session's current one check-marked; a pick posts the same setAuth the badge used (the session
+  // reconnects to apply, so the sub-line says "applying…" while st.authPending rides the status).
+  const st = s ? s.status : null;
+  if (st && st.auth && st.authBoth) {
+    menu.appendChild(el("div", "ctx-sep"));
+    const item = el("div", "ctx-item ctx-item-toggle ctx-item-billing");
+    item.appendChild(ctxIcon("bill", false));
+    const bodyEl = el("span", "ctx-item-body");
+    const l = el("span", "ctx-item-label"); l.textContent = "Billing"; bodyEl.appendChild(l);
+    const sb = el("span", "ctx-item-sub");
+    sb.textContent = st.authPending ? "applying…"
+      : (st.auth === "key" ? "API key" : (st.authAcct ? `Login (${st.authAcct})` : "Login"));
+    bodyEl.appendChild(sb);
+    item.appendChild(bodyEl);
+    const caret = el("span", "ctx-caret"); caret.textContent = "▸"; item.appendChild(caret);
+    item.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      const open = menu.querySelector(".ctx-sub");
+      if (open) { open.remove(); return; }                       // second click folds the flyout
+      const sub = el("div", "ctx-menu ctx-sub");
+      for (const c of [{ label: st.authAcct ? `Login (${st.authAcct})` : "Login", value: "login" },
+                       { label: "API key", value: "key" }]) {
+        const opt = el("div", "ctx-item" + (st.auth === c.value ? " current" : ""));
+        opt.textContent = c.label;
+        opt.addEventListener("click", (ev2) => {
+          ev2.stopPropagation();
+          dismissTabMenu();
+          if (st.auth !== c.value && vscodeApi) vscodeApi.postMessage({ type: "setAuth", id, value: c.value });
+        });
+        sub.appendChild(opt);
+      }
+      // INSIDE the menu node (so dismissTabMenu and the outside-mousedown check cover it), placed
+      // beside the item — .ctx-menu is position:fixed, so the coords are viewport-space, clamped
+      menu.appendChild(sub);
+      const ir = item.getBoundingClientRect();
+      const sr = sub.getBoundingClientRect();
+      sub.style.left = Math.max(0, Math.min(ir.right + 2, window.innerWidth - sr.width - 4)) + "px";
+      sub.style.top = Math.max(0, Math.min(ir.top, window.innerHeight - sr.height - 4)) + "px";
+    });
+    menu.appendChild(item);
+  }
   // Color swatches (the user 2026-06-29): the romp identity palette as circles, the session's current one
   // ringed. Click one to recolor the session. Omitted until /palette has loaded (paletteColors empty).
   if (paletteColors.length) {
@@ -6821,7 +6868,7 @@ function elapsedMs(sinceMs: number | null): string {
 // Each value is a little dropdown: picking an entry has the host inject the matching
 // /model or /effort slash command into the session's pane; the label then updates
 // when the TUI's statusline republishes the tmux vars (meta-pending bridges the gap).
-type MetaKind = "mode" | "model" | "effort" | "fast" | "auth";
+type MetaKind = "mode" | "model" | "effort" | "fast";
 // Model + effort choices come from the kernel's /models — the ONE list shared with the timeline lanes and the
 // judge-tier settings (the user 2026-07-02, who wanted one shared code path, not hardcoded in multiple places), so
 // the client holds no model literals (mirrors paletteColors above). Populated in place on load so META_CHOICES
@@ -6848,16 +6895,12 @@ const FAST_CHOICES: { label: string; value: string }[] = [
   { label: "On", value: "on" },
   { label: "Off", value: "off" },
 ];
-// Per-session billing (the user 2026-08-08): the Claude login vs the API key the manager's environment
-// carries. st.auth is now ALWAYS reported when the backend knows it (the user 2026-08-09 — the tab
-// hover says Billing everywhere), so this SWITCHING badge gates on st.authBoth instead: a one-auth
-// machine still shows no dead selector, while the hover stays informative. The key entry is labelled
-// 'API key', full stop — no fragment of the key, not even a last-4 tail, is shipped or shown (the
-// user 2026-08-08, evening: a tail is still key material and no surface needs it).
-const AUTH_CHOICES: { label: string; value: string }[] = [
-  { label: "Login", value: "login" },
-  { label: "API key", value: "key" },
-];
+// Per-session billing (the user 2026-08-08) — the Claude login vs the API key the manager's
+// environment carries — is no longer a statusline badge: the SWITCHING control lives in the tab's
+// right-click menu (showTabMenu's Billing flyout, the user 2026-08-09), still gated on st.authBoth
+// so a one-auth machine shows no dead selector, and still labelled plainly 'API key' — no fragment
+// of the key, not even a last-4 tail, is shipped or shown (2026-08-08, evening). The tab hover's
+// Billing row keeps carrying the fact everywhere.
 // the fast-mode state ("on"/"off"/"cooldown") → the badge label
 function prettyFast(f: string | undefined): string {
   switch ((f || "").toLowerCase()) {
@@ -6865,10 +6908,6 @@ function prettyFast(f: string | undefined): string {
     case "cooldown": return "Fast cooldown";   // rate-limited: the CLI resumes fast mode when the limit resets
     default: return "Fast off";
   }
-}
-// the per-session billing choice → the badge label (never any key material)
-function prettyAuth(st: Status): string {
-  return (st.auth || "").toLowerCase() === "key" ? "API key" : "Login";
 }
 // the @claude-permission-mode var → a short readable badge label
 function prettyMode(m: string | undefined): string {
@@ -6882,12 +6921,12 @@ function prettyMode(m: string | undefined): string {
   }
 }
 const META_CHOICES: Record<MetaKind, { label: string; value: string }[]> = {
-  mode: MODE_CHOICES, model: MODEL_CHOICES, effort: EFFORT_CHOICES, fast: FAST_CHOICES, auth: AUTH_CHOICES,
+  mode: MODE_CHOICES, model: MODEL_CHOICES, effort: EFFORT_CHOICES, fast: FAST_CHOICES,
 };
 // the live value of a meta kind for the active session
 function metaCurrent(kind: MetaKind, st: Status): string {
   return (kind === "model" ? st.model : kind === "effort" ? st.effort : kind === "fast" ? st.fast
-    : kind === "auth" ? st.auth : st.mode) || "";
+    : st.mode) || "";
 }
 
 // Is this menu entry the session's current value? Effort matches exactly; the
@@ -6895,7 +6934,6 @@ function metaCurrent(kind: MetaKind, st: Status): string {
 function isCurrentMeta(kind: MetaKind, st: Status, value: string): boolean {
   if (kind === "effort") return (st.effort || "").toLowerCase() === value;
   if (kind === "fast") return (st.fast || "").toLowerCase() === value;   // "cooldown" marks neither entry
-  if (kind === "auth") return (st.auth || "").toLowerCase() === value;
   if (kind === "mode") {
     const m = (st.mode || "").toLowerCase();
     if (value === "default") return m === "" || m === "default" || m === "normal";
@@ -6940,7 +6978,6 @@ function metaButton(kind: MetaKind, text: string): HTMLElement {
   btn.title = kind === "model" ? "change model (sends /model)"
     : kind === "effort" ? "change thinking effort (sends /effort)"
     : kind === "fast" ? "toggle fast mode (sends /fast)"
-    : kind === "auth" ? "switch which account this session bills (login vs API key; reconnects to apply)"
     : "change permission mode (shift+tab cycle)";
   btn.addEventListener("click", (e) => { e.stopPropagation(); toggleMetaMenu(kind, btn); });
   return btn;
@@ -6959,10 +6996,10 @@ function metaColor(kind: MetaKind, st: Status): string {
 // Build or refresh the model/effort buttons inside #spinner-meta. Called from
 // updateStatusline (fresh container) and the 1s ticker (label refresh in place).
 function syncMetaControls(meta: HTMLElement, st: Status) {
-  // order left→right: mode · model · effort · fast · auth — the mode selector sits LEFT of the model name
-  // (the user 2026-06-16); fast/auth exist only when the session reports them (SDK init / a both-auth
-  // machine), so a machine with one billing choice shows no dead selector (the user 2026-08-08).
-  const want = [st.mode ? "mode" : "", st.model ? "model" : "", st.effort ? "effort" : "", st.fast ? "fast" : "", (st.auth && st.authBoth) ? "auth" : ""].filter(Boolean).join();
+  // order left→right: mode · model · effort · fast — the mode selector sits LEFT of the model name
+  // (the user 2026-06-16); fast exists only when the session reports it (SDK init). Billing moved to
+  // the tab's right-click menu (the user 2026-08-09) — no badge here.
+  const want = [st.mode ? "mode" : "", st.model ? "model" : "", st.effort ? "effort" : "", st.fast ? "fast" : ""].filter(Boolean).join();
   const btns = Array.from(meta.querySelectorAll(".meta-btn")) as HTMLElement[];
   if (btns.map((b) => b.dataset.kind).join() !== want) {
     meta.replaceChildren();
@@ -6970,12 +7007,11 @@ function syncMetaControls(meta: HTMLElement, st: Status) {
     if (st.model) meta.appendChild(metaButton("model", st.model));
     if (st.effort) meta.appendChild(metaButton("effort", st.effort));
     if (st.fast) meta.appendChild(metaButton("fast", prettyFast(st.fast)));
-    if (st.auth && st.authBoth) meta.appendChild(metaButton("auth", prettyAuth(st)));
   }
   for (const b of Array.from(meta.querySelectorAll(".meta-btn")) as HTMLElement[]) {
     const kind = b.dataset.kind as MetaKind;
     const disp = kind === "mode" ? prettyMode(st.mode) : kind === "fast" ? prettyFast(st.fast)
-      : kind === "auth" ? prettyAuth(st) : metaCurrent(kind, st);
+      : metaCurrent(kind, st);
     const label = b.querySelector(".meta-label") as HTMLElement | null;
     // A switching MODEL shows animated dots, not the stale/premature name (the user 2026-07-03): the
     // server drives it (st.modelPending) — event-based, cleared the instant the new model actually lands —
@@ -6984,8 +7020,8 @@ function syncMetaControls(meta: HTMLElement, st: Status) {
     // dots from the server (st.modelPending / st.effortPending), with isMetaPending covering the sub-second
     // before the first server push (the user 2026-07-06).
     const pending = (kind === "model" && !!st.modelPending) || (kind === "effort" && !!st.effortPending)
-      || (kind === "auth" && !!st.authPending) || isMetaPending(kind, st);
-    const showDots = pending && (kind === "model" || kind === "effort" || kind === "auth");   // all three apply via a resolve/reconnect the server tracks
+      || isMetaPending(kind, st);
+    const showDots = pending && (kind === "model" || kind === "effort");   // both apply via a resolve/reconnect the server tracks
     if (label) {
       if (showDots) {
         if (!label.querySelector(".meta-dots")) label.replaceChildren(metaDots());
@@ -7020,7 +7056,7 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement) {
     item.addEventListener("click", (e) => {
       e.stopPropagation();
       if (activeId && vscodeApi) {
-        vscodeApi.postMessage({ type: kind === "model" ? "setModel" : kind === "effort" ? "setEffort" : kind === "fast" ? "setFast" : kind === "auth" ? "setAuth" : "setMode", id: activeId, value: c.value });
+        vscodeApi.postMessage({ type: kind === "model" ? "setModel" : kind === "effort" ? "setEffort" : kind === "fast" ? "setFast" : "setMode", id: activeId, value: c.value });
         const was = metaCurrent(kind, s.status);
         metaPending.set(`${activeId}:${kind}`, { was, until: Date.now() + 20_000 });
         btn.classList.add("meta-pending");

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -241,6 +241,18 @@ body { display: flex; flex-direction: column; }
 .ctx-item-sub { font-size: 0.82em; opacity: 0.6; }
 /* identity-color swatches (the user 2026-06-29): the romp palette as circles, the current one ringed. A grid
    so 9 colors wrap to a tidy block instead of one long row. */
+/* Billing submenu (the user 2026-08-09: the login/API-key switch lives here now, not the statusline).
+   The caret marks a level deeper (progressive disclosure); the flyout is a second .ctx-menu placed
+   beside its item, and .current wears the same check the statusline meta menus use. */
+.ctx-caret { margin-left: auto; padding-left: 10px; opacity: 0.55; align-self: center; }
+.ctx-sub { z-index: 101; }
+.ctx-sub .ctx-item { padding-right: 26px; position: relative; }
+.ctx-sub .ctx-item.current::after {
+  content: "✓"; position: absolute; right: 6px; top: 50%; transform: translateY(-50%);
+  background: var(--check-bg); color: #fff; border-radius: 50%;
+  width: 13px; height: 13px; font-size: 9px; font-weight: 900;
+  display: inline-flex; align-items: center; justify-content: center; line-height: 1;
+}
 .ctx-colors { display: grid; grid-template-columns: repeat(5, 18px); gap: 7px; padding: 6px 8px 4px;
   justify-content: start; }
 .ctx-swatch { width: 18px; height: 18px; padding: 0; border: 0; border-radius: 50%; cursor: pointer;

--- a/vscode-extension/src/tab-menu-flags.test.ts
+++ b/vscode-extension/src/tab-menu-flags.test.ts
@@ -28,7 +28,7 @@ test("the tab menu adds Feed + Mail toggle items with state-dependent labels", (
 });
 
 test("each toggle item carries an icon (slashed when off) and a sub-description", () => {
-  assert.match(SRC, /function ctxIcon\(kind: "feed" \| "mail" \| "bell", off: boolean\)/);
+  assert.match(SRC, /function ctxIcon\(kind: "feed" \| "mail" \| "bell" \| "bill", off: boolean\)/);   // "bill" joined for the Billing submenu (2026-08-09)
   assert.match(SRC, /off \? '<line /);   // slash when the flag is off
   assert.match(SRC, /ctx-item-sub/);
   assert.match(CSS, /\.ctx-item-toggle \{ display: flex;/);


### PR DESCRIPTION
A **Billing** item with a Login/API-key flyout joins the tab context menu (the user 2026-08-09, who wants the selector under the tab name rather than as a statusline badge):

- Shown only when the machine offers both choices (`st.authBoth`) — a one-auth machine keeps the fact on the tab hover, never a dead selector.
- The flyout check-marks the session's current choice, names the login account beside `Login`, and posts the same `setAuth` the badge used; picking the current choice just dismisses. The item's sub-line names the current billing, or "applying…" while the reconnect is pending.
- The statusline auth badge is removed (`MetaKind` drops `"auth"`, `AUTH_CHOICES`/`prettyAuth` gone); the new-session picker's Billing row is untouched.
- No key material anywhere, as before — the key is labelled plainly `API key`.

Tests: the badge test in `auth-selector.test.ts` is rewritten to pin the tab-menu submenu; stale `MetaKind`/dots/ctxIcon pins updated in four sibling files. Full Python suite (4074) and node suite (1766) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)