### PR TITLE
romp updates itself: a boot-time release check, on by default

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -412,6 +412,8 @@ def _version_info():
     return {"kernel_sha": _kernel_sha(), "kernel_ver": _kernel_ver(), "pid": os.getpid(), "started": int(_STARTED),
             "uptime_s": int(time.time() - _STARTED), "dist_ver": _dist_ver(), "bundles": bundles,
             "autoNudge": _auto_nudge_on(),   # server-side toggle state → the gear checkbox reflects the kernel
+            "updateMode": _update_mode(),    # ask|auto|off (the boot release check) → the gear dropdown
+            "updateAvail": _UPDATE_AVAIL[0],   # newer release the boot check found ("" = none/unknown)
             "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),      # current per-tier judge models → the gear dropdowns
             "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort(),  # current per-tier judge efforts ("" = default/none)
             "defaultDir": _tilde(_default_create_dir()),   # the resolved default new-session dir → the gear "Default directory" field
@@ -1594,6 +1596,157 @@ def _set_auto_nudge(enabled):
     d = dict(_auto_nudge_data())
     d["enabled"] = bool(enabled)
     _write_auto_nudge(d)
+
+
+# ── automatic updates of THIS machine (the user 2026-08-09) ───────────────────────────────────────
+# At kernel boot, one async check asks the clone's `origin` for its newest RELEASE tag
+# (`git ls-remote --tags` — network read only, nothing local moves) and compares it against the
+# release this code descends from (_kernel_ver's VERSION file, "+" stripped). Three modes, persisted
+# in update-mode.json under STATE, "ask" by default — the check is ON out of the box:
+#   ask  — a newer release raises the shell's update banner; its Update button POSTs /update.
+#   auto — the kernel updates itself at boot, once per discovered version (update-attempted.json
+#          keeps a failing update from looping on every restart — that stall is logged, not silent).
+#   off  — never even checks.
+# The update itself (_run_update) runs DETACHED (start_new_session: install.sh reloads the manager
+# and the restart takes this kernel down, and the child must outlive both): `git pull --ff-only`,
+# then ./install.sh, everything appended to update.log under STATE, a report written to
+# update-report.json, and a restart through the manager door ONLY on success. The outcome is never
+# silent (fail loudly): the next boot — or the still-running kernel, via /update-check's poll —
+# consumes the report into a sync notice, the Log's standing record of what romp did to your
+# machines. `romp update [host]` remains the other direction (pushing THIS build to remotes).
+_UPDATE_AVAIL = [""]     # newest remote release tag when newer than ours ("" = none/unknown)
+_UPDATE_STATE = [""]     # "" | "running" — one update at a time; the banner reads this
+_UPDATE_MODES = ("ask", "auto", "off")
+
+
+def _update_mode():
+    try:
+        m = json.loads((jd.STATE / "update-mode.json").read_text()).get("mode")
+        return m if m in _UPDATE_MODES else "ask"
+    except (OSError, ValueError, AttributeError):
+        return "ask"
+
+
+def _set_update_mode(mode):
+    if mode in _UPDATE_MODES:
+        _atomic_write(jd.STATE / "update-mode.json", json.dumps({"mode": mode}))
+
+
+def _semver(tag):
+    """'v0.6.0' → (0, 6, 0); None for anything that is not a plain release number."""
+    m = re.match(r"^v?(\d+)\.(\d+)\.(\d+)$", str(tag or "").strip())
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3))) if m else None
+
+
+def _latest_release_tag():
+    """The newest release tag on the clone's `origin`, read from the REMOTE's refs (ls-remote) — never
+    from the local tag list, which says only what this clone last fetched (refs do not travel with
+    commits; _kernel_ver's lesson). Raises on any git/network failure so the caller can say so."""
+    r = subprocess.run(["git", "-C", str(ROOT), "ls-remote", "--tags", "origin"],
+                       capture_output=True, text=True, timeout=20)
+    if r.returncode != 0:
+        raise RuntimeError((r.stderr or "git ls-remote failed").strip()[:200])
+    best, best_v = "", None
+    for line in r.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 2 or parts[1].endswith("^{}"):   # ^{} = peeled duplicate of an annotated tag
+            continue
+        tag = parts[1].rsplit("/", 1)[-1]
+        v = _semver(tag)
+        if v and (best_v is None or v > best_v):
+            best, best_v = tag, v
+    return best
+
+
+def _run_update(tag):
+    """Start the self-update: pull + install + report (+ restart on success), in a DETACHED child.
+    Returns True when the child was launched. The tag has passed _semver before it gets here; the
+    guard repeats anyway because the string lands inside a shell script."""
+    if not _semver(tag) or _UPDATE_STATE[0] == "running":
+        return False
+    _UPDATE_STATE[0] = "running"
+    q = shlex.quote
+    log, rep = q(str(jd.STATE / "update.log")), q(str(jd.STATE / "update-report.json"))
+    mport = os.environ.get("ROMP_MANAGER_PORT") or ""
+    restart = ("  curl -s -X POST http://127.0.0.1:%d/restart-all >/dev/null 2>&1\n" % int(mport)) if mport.isdigit() \
+        else "  : # no manager — the new code arms on the next romp start (the report says so)\n"
+    ok_rep = {"ok": True, "tag": tag, "restarted": bool(mport.isdigit())}
+    script = (
+        "cd %s || exit 1\n" % q(str(ROOT))
+        + "{ echo; echo \"== romp self-update to %s ==\"; date; } >> %s 2>&1\n" % (tag, log)
+        + "if git pull --ff-only >> %s 2>&1 && ./install.sh >> %s 2>&1; then\n" % (log, log)
+        + "  printf '%%s' %s > %s\n" % (q(json.dumps(ok_rep)), rep)
+        + restart
+        + "else\n"
+        + "  printf '%%s' %s > %s\n" % (q(json.dumps({"ok": False, "tag": tag, "why": "the pull or install failed"})), rep)
+        + "fi\n")
+    subprocess.Popen(["bash", "-c", script], start_new_session=True, cwd=str(ROOT),
+                     stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return True
+
+
+def _consume_update_report(running_only=False):
+    """File the updater child's report as a sync notice, ONCE (the file renames on consumption).
+    Two callers: the next boot (the success path — the restart took the reporting kernel down), and
+    /update-check's poll on the still-running kernel (the failure path, and the no-manager success),
+    which passes running_only to also clear the in-flight latch."""
+    p = jd.STATE / "update-report.json"
+    try:
+        rep = json.loads(p.read_text())
+    except (OSError, ValueError):
+        return None
+    try:
+        p.rename(jd.STATE / "update-report-last.json")   # consumed — never re-filed on later boots
+    except OSError:
+        return None
+    if running_only:
+        _UPDATE_STATE[0] = ""
+    tag = str(rep.get("tag") or "a new release")
+    if rep.get("ok") and rep.get("restarted"):
+        _sync_notice("romp updated itself to %s and restarted into it" % tag)
+    elif rep.get("ok"):
+        _sync_notice("romp updated itself to %s — no manager is running, so restart romp yourself to run it" % tag)
+    else:
+        _sync_notice("romp could not update itself to %s: %s — nothing was restarted; update.log under "
+                     "~/.local/state/romp has the full output" % (tag, rep.get("why") or "the update failed"),
+                     ok=False)
+    return rep
+
+
+def _update_check():
+    """The boot check (its own daemon thread): learn the newest release, then act per mode."""
+    if _update_mode() == "off":
+        return
+    cur = _semver((_kernel_ver() or "").rstrip("+"))
+    if cur is None:
+        return                                      # no VERSION / not a release clone → nothing to compare
+    try:
+        latest = _latest_release_tag()
+    except Exception as e:
+        sys.stderr.write("romp-kernel: update check could not read origin's tags: %s\n" % e)
+        return
+    lv = _semver(latest)
+    if not lv or lv <= cur:
+        return
+    _UPDATE_AVAIL[0] = latest
+    if _update_mode() == "auto":
+        tried = ""
+        try:
+            tried = json.loads((jd.STATE / "update-attempted.json").read_text()).get("tag", "")
+        except (OSError, ValueError, AttributeError):
+            pass
+        if tried == latest:
+            # the automatic update to THIS version already ran once and did not land — looping the
+            # same failure every boot helps nobody, but going quiet would hide it (fail loudly)
+            _sync_notice("a newer romp (%s) is available, but the automatic update to it already ran "
+                         "once without landing — update.log under ~/.local/state/romp has the story; "
+                         "the banner still offers it" % latest, ok=False)
+            _send_to_app("shell", {"type": "updateAvail", "cur": _kernel_ver() or "", "tag": latest})
+            return
+        _atomic_write(jd.STATE / "update-attempted.json", json.dumps({"tag": latest, "t": int(time.time())}))
+        _run_update(latest)
+    else:
+        _send_to_app("shell", {"type": "updateAvail", "cur": _kernel_ver() or "", "tag": latest})
 
 
 def _auto_update_remotes_on():
@@ -18881,7 +19034,9 @@ if(m&&m.type==='reveal'&&m.pane)show(m.pane);
 else if(m&&m.type==='badge'&&'setAppBadge' in navigator){
 try{(m.n?navigator.setAppBadge(m.n):navigator.clearAppBadge())['catch'](function(e){});}catch(e){}}
 // the master bell toggled somewhere (this tab included) — repaint ours from the kernel's word
-else if(m&&m.type==='notifyAll'&&window.__rompNotifyAllPaint)window.__rompNotifyAllPaint(!!m.on);};
+else if(m&&m.type==='notifyAll'&&window.__rompNotifyAllPaint)window.__rompNotifyAllPaint(!!m.on);
+// the boot check found a newer romp release — raise the update banner on every open dashboard
+else if(m&&m.type==='updateAvail'&&window.__rompUpdateOffer)window.__rompUpdateOffer(m.cur||'',m.tag||'');};
 ws.onclose=function(){setTimeout(shellWS,2000);};}catch(e){}}
 shellWS();
 var last='chat';try{var s=localStorage.getItem(KT);if(s&&F[s])last=s;}catch(e){}show(last);
@@ -19053,6 +19208,62 @@ _LANDING_COLLAPSE_JS = """
 def _stale_block(v):
     return ("<style>" + _STALE_CSS + "</style>" + _STALE_HTML
             + "<script>" + _STALE_JS.replace("__LOADEDVER__", str(int(v))) + "</script>")
+
+
+# UPDATE banner (the user 2026-08-09): a newer romp RELEASE exists (the boot check, _update_check) —
+# distinct from #rstale, which is about this tab running an older BUNDLE than the kernel serves. Same
+# top-center prompt vocabulary, offset below rstale so the two can stack. The Update button POSTs
+# /update and then polls /update-check: a changed `boot` means the new kernel is up → reload; a
+# `failed`/`updated` answer means the still-running kernel consumed the child's report → say so.
+# "Not now" is page-scoped on purpose — the next kernel start re-offers (what the user asked for).
+_UPD_CSS = (
+    "#rupd{position:fixed;top:56px;left:50%;transform:translateX(-50%);z-index:99999;display:none;"
+    "align-items:center;gap:12px;max-width:92vw;background:#2b2d30;border:1px solid #4a4d51;"
+    "border-radius:10px;padding:10px 14px;color:#e6e6e6;box-shadow:0 10px 30px #0000008a;"
+    "font:13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}"
+    "#rupd.show{display:flex}#rupd .rup-msg{font-weight:500}"
+    "#rupd button{font:inherit;cursor:pointer;border-radius:6px;padding:5px 11px;"
+    "border:1px solid transparent;white-space:nowrap}"
+    "#rupd button:disabled{opacity:.55;cursor:default}"
+    "#rupd .rup-go{background:#54B204;color:#0c1a00;font-weight:600;border-color:#3f8a00}"
+    "#rupd .rup-go:hover:not(:disabled){background:#62c80a}"
+    "#rupd .rup-dismiss{background:none;color:#9aa0a6;border-color:#4a4d51}"
+    "#rupd .rup-dismiss:hover{color:#e6e6e6}")
+_UPD_HTML = (
+    "<div id=rupd role=alert><span class=rup-msg></span>"
+    "<button class=rup-go id=rupd-go>Update</button>"
+    "<button class=rup-dismiss id=rupd-dismiss>Not now</button></div>")
+_UPD_JS = (
+    "(function(){var box=document.getElementById('rupd');if(!box)return;"
+    "var msg=box.querySelector('.rup-msg'),go=document.getElementById('rupd-go'),dm=document.getElementById('rupd-dismiss');"
+    "var dismissed=false,waiting=false,bootNow='';"
+    "function show(m){msg.textContent=m;box.classList.add('show');}"
+    "function offer(cur,tag){if(dismissed||waiting)return;go.hidden=false;go.disabled=false;dm.hidden=false;"
+    "show('romp '+tag+' is available'+(cur?' \\u2014 you are on '+cur:'')+'.');}"
+    "window.__rompUpdateOffer=offer;"   # the shell WS relays the kernel's boot-check push here
+    "function poll(){fetch('/update-check',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){"
+    "if(!waiting)return;"
+    "if(d.boot&&bootNow&&d.boot!==bootNow){location.reload();return;}"
+    "if(d.failed){waiting=false;go.hidden=false;go.disabled=false;show('The update did not finish: '+d.failed);return;}"
+    "if(d.updated){waiting=false;show('romp updated to '+d.updated+' \\u2014 restart romp (the \\u21bb button) to run it.');return;}"
+    "setTimeout(poll,3000);}).catch(function(){if(waiting)setTimeout(poll,3000);});}"
+    "go.onclick=function(){go.disabled=true;dm.hidden=true;waiting=true;"
+    "show('Updating romp \\u2014 this can take a minute; the dashboard reloads when it restarts\\u2026');"
+    "fetch('/update',{method:'POST'}).then(function(r){"
+    "if(!r.ok)return r.text().then(function(t){throw new Error(t||('HTTP '+r.status));});poll();})"
+    "['catch'](function(e){waiting=false;go.disabled=false;dm.hidden=false;"
+    "show('Could not start the update: '+((e&&e.message)||e));});};"
+    "dm.onclick=function(){dismissed=true;box.classList.remove('show');};"
+    "fetch('/update-check',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){"
+    "bootNow=(d&&d.boot)||'';"
+    "if(d&&d.state==='running'){waiting=true;go.hidden=true;dm.hidden=true;"
+    "show('romp is updating \\u2014 the dashboard reloads when it restarts\\u2026');poll();return;}"
+    "if(d&&d.tag&&d.mode==='ask')offer(d.cur||'',d.tag);})"
+    "['catch'](function(e){});})();")
+
+
+def _update_block():
+    return "<style>" + _UPD_CSS + "</style>" + _UPD_HTML + "<script>" + _UPD_JS + "</script>"
 
 
 # REMOTE-DRIFT banner (the user 2026-07-04): a proactive "push your build to the remote?" prompt with LIVE
@@ -19919,7 +20130,7 @@ def _landing():
             # a dist bundle (ui/webview/palette-main.ts) like age-color-global above. Loaded last —
             # it reads the __romp* globals lazily, at command run time, so order is cosmetic.
             + ("<script src=/dist/palette-main.js?v=%d></script>" % v)
-            + _stale_block(v) + _rdrift_block() +
+            + _stale_block(v) + _update_block() + _rdrift_block() +
             "</body></html>")
 
 
@@ -20266,6 +20477,32 @@ class Handler(BaseHTTPRequestHandler):
                 # register() fetch is same-origin and carries the cookie, and only an authed shell
                 # ever registers it. no-cache so a changed worker is picked up on the next launch.
                 return self._send(200, _SW_JS, "text/javascript; charset=utf-8", cache="no-cache")
+            if p == "/update-check":
+                # the update banner's state (the user 2026-08-09): what release we're on, what's newer,
+                # the mode, and whether an update is in flight. `boot` lets the banner detect the NEW
+                # kernel answering after a successful update (same trick as the restart flow); polling
+                # this route is also what consumes a report the still-running kernel would otherwise
+                # sit on (the failure path, and the no-manager success).
+                failed = updated = ""
+                if _UPDATE_STATE[0] == "running":
+                    # PEEK before consuming: a success that is about to restart belongs to the NEXT
+                    # kernel's boot — consuming it here would file the notice into this dying
+                    # process's in-memory ring and the new kernel would find nothing to log. Only a
+                    # failure, or a success with no manager to restart, is this kernel's to file.
+                    try:
+                        _peek = json.loads((jd.STATE / "update-report.json").read_text())
+                    except (OSError, ValueError):
+                        _peek = None
+                    if _peek is not None and not (_peek.get("ok") and _peek.get("restarted")):
+                        rep = _consume_update_report(running_only=True)
+                        if rep is not None and not rep.get("ok"):
+                            failed = str(rep.get("why") or "the pull or install failed")
+                        elif rep is not None:
+                            updated = str(rep.get("tag") or "")
+                return self._send(200, json.dumps({
+                    "cur": _kernel_ver() or "", "tag": _UPDATE_AVAIL[0], "mode": _update_mode(),
+                    "state": _UPDATE_STATE[0], "failed": failed, "updated": updated,
+                    "boot": _BOOT_ID}), "application/json", cache="no-cache")
             if p == "/notify-all":
                 # the master bell's state (the user 2026-08-09): on = every task notifies when it
                 # blocks on you or completes, unless its session/card bell mutes it. The shell
@@ -20358,6 +20595,16 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, FLEET_REPORT.read_text(), "application/json")
                 except OSError:
                     return self._send(200, json.dumps({"rows": []}), "application/json")
+            if u.path == "/update":
+                # the banner's Update button (the user 2026-08-09). Only a release the boot check
+                # actually found is ever installed — the route takes no version from the client.
+                tag = _UPDATE_AVAIL[0]
+                if not tag:
+                    return self._send(409, "no newer release known to this kernel", "text/plain")
+                if _UPDATE_STATE[0] != "running":
+                    _audit_restart_request("self-update", tag=tag, addr=str(self.client_address[0]))
+                    _run_update(tag)
+                return self._send(200, json.dumps({"ok": True, "state": _UPDATE_STATE[0]}), "application/json")
             if u.path == "/notify-all":
                 # the master bell's toggle (the user 2026-08-09). Kernel-authoritative: the click
                 # posts here first, and only a 200 flips the bell — the device push subscription is
@@ -20948,6 +21195,8 @@ class Handler(BaseHTTPRequestHandler):
         elif msg and msg.get("type") == "setAutoNudge" and msg.get("enabled") is not None:
             _set_auto_nudge(bool(msg["enabled"]))   # feed gear → server-side Auto Nudge on/off
             _auto_nudge_tick(int(time.time()), _tmux_sessions())   # act immediately on turn-on (don't wait 4s)
+        elif msg and msg.get("type") == "setUpdateMode" and msg.get("mode") in _UPDATE_MODES:
+            _set_update_mode(str(msg["mode"]))      # feed gear → how romp handles new releases at boot
         elif msg and msg.get("type") == "askClear" and msg.get("itemId"):
             # a cleared card drops any composer citation chip pointing INTO it (the user 2026-07-01) — the
             # goal is gone, so following up on it makes no sense. Chips can cite a SUB-goal of the card
@@ -21607,6 +21856,8 @@ def main():
     threading.Thread(target=_parent_watch, daemon=True).start()
     _known_load()                                              # remembered past hosts (popover's re-attach rows)
     _remotes_load()                                            # re-attach remote kernels from a prior run
+    _consume_update_report()                                   # last self-update's outcome → the Log, once
+    threading.Thread(target=_update_check, daemon=True).start()   # newer release? (mode-gated inside)
     threading.Thread(target=_ensure_postal_bus, daemon=True).start()   # a sessionless machine still needs its bus
     threading.Thread(target=_tunnel_supervisor, daemon=True).start()   # keep ssh tunnels alive + poll host↔sid map
     srv = ThreadingHTTPServer((BIND, PORT), Handler)

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -166,9 +166,9 @@ class LandingShell(unittest.TestCase):
         # (the user 2026-06-23; + boot-splash + rail-usage 2026-06-26; + connection-status banner
         # 2026-06-27; + the visible-viewport pin; + the remote-drift banner 2026-07-04; + the head's
         # ios-standalone viewport flip and the push bell 2026-08-07, plans/ios-app.md; + the shared
-        # Escape-closes-the-topmost-modal block 2026-08-09).
+        # Escape-closes-the-topmost-modal block 2026-08-09; + the release-update banner 2026-08-09).
         html = km._landing()
-        self.assertEqual(html.count("<script>"), 15)
+        self.assertEqual(html.count("<script>"), 16)
 
     def test_bottom_bar_is_text_only_and_compact(self):
         html = km._landing()

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Automatic updates of THIS machine (the user 2026-08-09): at kernel boot, one async check reads
+origin's newest release tag (git ls-remote — the remote's own refs, never the local tag list) and
+compares it against the VERSION-file release. Modes (update-mode.json, default "ask" — ON out of
+the box): ask = the shell's update banner offers it; auto = the kernel updates itself once per
+discovered version; off = never checks. The update runs DETACHED (git pull --ff-only + install.sh,
+report to update-report.json, restart through the manager door only on success), and the outcome is
+always filed as a sync notice — by the next boot, or by /update-check's poll on the still-running
+kernel (fail loudly, never silent). Synthetic tags/paths only."""
+import io
+import json
+import os
+import subprocess
+import tempfile
+import threading
+import unittest
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Raw-run belt over conftest's suspenders — via the ENVIRONMENT, not a module attribute: loading the
+# kernel re-executes romp_judge into the same module object, which RESETS a hand-assigned jd.STATE
+# back to the env-derived default (verified 2026-08-09 — the webpush test's attribute rebind only
+# holds under pytest because conftest moves XDG_STATE_HOME first). ROMP_STATE_DIR is the designed
+# override and is read on every (re)execution, so it protects a bare `python3 tests/...` run too.
+# Scoped to the loads and RESTORED right after (the modules capture STATE at exec): left set, it
+# outranks conftest's XDG_STATE_HOME for every test module pytest imports after this one — which is
+# exactly how this file's first cut broke two postal-bus tests three modules downstream.
+_STATE_TD = tempfile.TemporaryDirectory()
+_PREV_STATE_DIR = os.environ.get("ROMP_STATE_DIR")
+os.environ["ROMP_STATE_DIR"] = _STATE_TD.name
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_update", os.path.join(BIN, "romp-kernel")).load_module()
+if _PREV_STATE_DIR is None:
+    os.environ.pop("ROMP_STATE_DIR", None)
+else:
+    os.environ["ROMP_STATE_DIR"] = _PREV_STATE_DIR
+
+
+def _serve_get(path, headers=None):
+    """The real do_GET over a fake socket (the webpush-test harness): (status, body_bytes)."""
+    h = km.Handler.__new__(km.Handler)
+    h.client_address = ("127.0.0.1", 0)
+    h.headers = dict(headers or {})
+    h.path = path
+    h.command = "GET"
+    h.request_version = "HTTP/1.1"
+    h.wfile = io.BytesIO()
+    h.rfile = io.BytesIO()
+    h.close_connection = True
+    captured = {}
+    h.send_response = lambda code, *a: captured.__setitem__("status", code)
+    h.send_header = lambda k, v: None
+    h.end_headers = lambda: None
+    h.log_message = lambda *a: None
+    h.do_GET()
+    return captured.get("status"), h.wfile.getvalue()
+
+
+class Fresh(unittest.TestCase):
+    """Every test starts with no update state: fresh STATE dir, empty avail/latch, empty notices."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._UPDATE_AVAIL[0] = ""
+        km._UPDATE_STATE[0] = ""
+        with km._SYNC_LOCK:
+            del km._SYNC_NOTICES[:]
+
+    def tearDown(self):
+        jd.STATE = self.saved
+        self.td.cleanup()
+
+    def notices(self):
+        with km._SYNC_LOCK:
+            return list(km._SYNC_NOTICES)
+
+
+class Semver(unittest.TestCase):
+    def test_parses_plain_releases_only(self):
+        self.assertEqual(km._semver("v0.6.0"), (0, 6, 0))
+        self.assertEqual(km._semver("1.12.3"), (1, 12, 3))
+        for junk in ("", None, "v1.2", "v1.2.3-rc1", "release", "v1.2.3.4", "v1.2.x"):
+            self.assertIsNone(km._semver(junk), junk)
+
+    def test_orders_numerically_not_lexically(self):
+        self.assertGreater(km._semver("v0.10.0"), km._semver("v0.9.9"))
+
+
+class ModeStore(Fresh):
+    def test_default_is_ask_the_check_is_on_out_of_the_box(self):
+        self.assertEqual(km._update_mode(), "ask")
+
+    def test_set_and_persist(self):
+        km._set_update_mode("auto")
+        self.assertEqual(km._update_mode(), "auto")
+        km._set_update_mode("off")
+        self.assertEqual(km._update_mode(), "off")
+
+    def test_garbage_is_refused_at_both_ends(self):
+        km._set_update_mode("yes please")               # setter drops it
+        self.assertEqual(km._update_mode(), "ask")
+        (jd.STATE / "update-mode.json").write_text(json.dumps({"mode": "banana"}))
+        self.assertEqual(km._update_mode(), "ask", "an unknown stored mode reads as the default")
+
+
+class LatestReleaseTag(unittest.TestCase):
+    def _ls(self, stdout, rc=0, stderr=""):
+        return mock.patch.object(km.subprocess, "run", return_value=subprocess.CompletedProcess(
+            args=[], returncode=rc, stdout=stdout, stderr=stderr))
+
+    def test_picks_the_numerically_newest_real_release(self):
+        out = ("aaa\trefs/tags/v0.9.9\n"
+               "bbb\trefs/tags/v0.10.0\n"
+               "ccc\trefs/tags/v0.10.0^{}\n"          # peeled duplicate of the annotated tag
+               "ddd\trefs/tags/nightly\n"             # not a release number
+               "eee\trefs/tags/v0.2.0\n")
+        with self._ls(out):
+            self.assertEqual(km._latest_release_tag(), "v0.10.0")
+
+    def test_no_release_tags_is_empty_not_an_error(self):
+        with self._ls("aaa\trefs/tags/nightly\n"):
+            self.assertEqual(km._latest_release_tag(), "")
+
+    def test_git_failure_raises_so_the_caller_can_say_so(self):
+        with self._ls("", rc=128, stderr="fatal: could not read from remote"):
+            with self.assertRaises(RuntimeError):
+                km._latest_release_tag()
+
+
+class UpdateCheck(Fresh):
+    def test_mode_off_never_even_asks_the_network(self):
+        km._set_update_mode("off")
+        with mock.patch.object(km, "_latest_release_tag", side_effect=AssertionError("must not run")):
+            km._update_check()
+        self.assertEqual(km._UPDATE_AVAIL[0], "")
+
+    def test_newer_release_in_ask_mode_raises_the_banner_on_every_shell(self):
+        sent = []
+        with mock.patch.object(km, "_kernel_ver", return_value="v0.6.0+"), \
+             mock.patch.object(km, "_latest_release_tag", return_value="v0.7.0"), \
+             mock.patch.object(km, "_send_to_app", side_effect=lambda app, m: sent.append((app, m))):
+            km._update_check()
+        self.assertEqual(km._UPDATE_AVAIL[0], "v0.7.0")
+        self.assertEqual(sent, [("shell", {"type": "updateAvail", "cur": "v0.6.0+", "tag": "v0.7.0"})])
+
+    def test_same_or_older_release_is_silence(self):
+        sent = []
+        for latest in ("v0.6.0", "v0.5.9", ""):
+            with mock.patch.object(km, "_kernel_ver", return_value="v0.6.0"), \
+                 mock.patch.object(km, "_latest_release_tag", return_value=latest), \
+                 mock.patch.object(km, "_send_to_app", side_effect=lambda app, m: sent.append(m)):
+                km._update_check()
+        self.assertEqual((km._UPDATE_AVAIL[0], sent), ("", []))
+
+    def test_no_local_release_number_means_nothing_to_compare(self):
+        with mock.patch.object(km, "_kernel_ver", return_value=None), \
+             mock.patch.object(km, "_latest_release_tag", side_effect=AssertionError("must not run")):
+            km._update_check()                        # no raise — the check just stands down
+
+    def test_network_failure_is_a_stderr_note_never_a_crash(self):
+        with mock.patch.object(km, "_kernel_ver", return_value="v0.6.0"), \
+             mock.patch.object(km, "_latest_release_tag", side_effect=RuntimeError("no route to host")):
+            km._update_check()
+        self.assertEqual(km._UPDATE_AVAIL[0], "")
+
+    def test_auto_mode_updates_once_per_discovered_version(self):
+        ran = []
+        with mock.patch.object(km, "_kernel_ver", return_value="v0.6.0"), \
+             mock.patch.object(km, "_latest_release_tag", return_value="v0.7.0"), \
+             mock.patch.object(km, "_run_update", side_effect=lambda tag: ran.append(tag) or True), \
+             mock.patch.object(km, "_send_to_app"):
+            km._set_update_mode("auto")
+            km._update_check()
+            self.assertEqual(ran, ["v0.7.0"])
+            self.assertEqual(json.loads((jd.STATE / "update-attempted.json").read_text())["tag"], "v0.7.0")
+            # a SECOND boot finding the same version does not loop the failed attempt — it says so
+            # in the Log and falls back to offering the banner
+            km._update_check()
+        self.assertEqual(ran, ["v0.7.0"], "one automatic attempt per version")
+        self.assertTrue(any(not n["ok"] and "v0.7.0" in n["text"] for n in self.notices()))
+
+
+class RunUpdate(Fresh):
+    def test_detached_child_pulls_installs_reports_and_restarts_only_on_success(self):
+        calls = []
+        with mock.patch.object(km.subprocess, "Popen", side_effect=lambda *a, **kw: calls.append((a, kw))), \
+             mock.patch.dict(km.os.environ, {"ROMP_MANAGER_PORT": "7777"}):
+            self.assertTrue(km._run_update("v0.7.0"))
+        (a, kw), = calls
+        self.assertEqual(a[0][:2], ["bash", "-c"])
+        self.assertTrue(kw.get("start_new_session"), "install.sh + the restart take the kernel down — the child must outlive it")
+        script = a[0][2]
+        self.assertIn("git pull --ff-only", script)
+        self.assertIn("./install.sh", script)
+        self.assertIn("update-report.json", script)
+        # the restart rides the SUCCESS branch only: everything after `if` up to `else` has it,
+        # the failure branch does not
+        ok_branch, fail_branch = script.split("else\n", 1)
+        self.assertIn("/restart-all", ok_branch)
+        self.assertNotIn("/restart-all", fail_branch)
+        self.assertEqual(km._UPDATE_STATE[0], "running")
+
+    def test_no_manager_means_no_restart_leg(self):
+        calls = []
+        env = {k: v for k, v in km.os.environ.items() if k != "ROMP_MANAGER_PORT"}
+        with mock.patch.object(km.subprocess, "Popen", side_effect=lambda *a, **kw: calls.append(a)), \
+             mock.patch.dict(km.os.environ, env, clear=True):
+            self.assertTrue(km._run_update("v0.7.0"))
+        self.assertNotIn("/restart-all", calls[0][0][2])
+
+    def test_refuses_junk_tags_and_reentry(self):
+        with mock.patch.object(km.subprocess, "Popen", side_effect=AssertionError("must not spawn")):
+            self.assertFalse(km._run_update("v1; rm -rf /"), "a tag is shell payload — semver or nothing")
+        with mock.patch.object(km.subprocess, "Popen"):
+            self.assertTrue(km._run_update("v0.7.0"))
+            self.assertFalse(km._run_update("v0.7.0"), "one update at a time")
+
+
+class ReportConsumption(Fresh):
+    def test_success_with_restart_files_once_and_archives(self):
+        (jd.STATE / "update-report.json").write_text(json.dumps({"ok": True, "tag": "v0.7.0", "restarted": True}))
+        rep = km._consume_update_report()
+        self.assertTrue(rep["ok"])
+        ns = self.notices()
+        self.assertEqual(len(ns), 1)
+        self.assertTrue(ns[0]["ok"])
+        self.assertIn("v0.7.0", ns[0]["text"])
+        self.assertFalse((jd.STATE / "update-report.json").exists(), "consumed — never re-filed")
+        self.assertTrue((jd.STATE / "update-report-last.json").exists())
+        self.assertIsNone(km._consume_update_report(), "second boot: nothing left to file")
+
+    def test_failure_is_a_loud_not_ok_notice(self):
+        (jd.STATE / "update-report.json").write_text(json.dumps({"ok": False, "tag": "v0.7.0",
+                                                                 "why": "the pull or install failed"}))
+        km._consume_update_report()
+        ns = self.notices()
+        self.assertEqual(len(ns), 1)
+        self.assertFalse(ns[0]["ok"])
+        self.assertIn("update.log", ns[0]["text"])
+
+    def test_running_only_clears_the_inflight_latch(self):
+        km._UPDATE_STATE[0] = "running"
+        (jd.STATE / "update-report.json").write_text(json.dumps({"ok": False, "tag": "v0.7.0"}))
+        km._consume_update_report(running_only=True)
+        self.assertEqual(km._UPDATE_STATE[0], "")
+
+
+class Routes(Fresh):
+    @classmethod
+    def setUpClass(cls):
+        from http.server import ThreadingHTTPServer
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def _post(self, path, token=True):
+        import urllib.request, urllib.error
+        headers = {"X-Romp-Token": km.TOKEN} if token else {}
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path), method="POST",
+                                     data=b"{}", headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, r.read().decode()
+        except urllib.error.HTTPError as e:
+            return e.code, e.read().decode()
+
+    def test_update_check_is_gated_and_reports_the_state(self):
+        status, _ = _serve_get("/update-check")
+        self.assertEqual(status, 403)
+        km._UPDATE_AVAIL[0] = "v0.7.0"
+        status, body = _serve_get("/update-check", headers={"X-Romp-Token": km.TOKEN})
+        d = json.loads(body)
+        self.assertEqual((status, d["tag"], d["mode"], d["state"]), (200, "v0.7.0", "ask", ""))
+        self.assertEqual(d["boot"], km._BOOT_ID, "the banner detects the NEW kernel by this flipping")
+
+    def test_update_check_poll_consumes_a_failed_report_mid_run(self):
+        km._UPDATE_STATE[0] = "running"
+        (jd.STATE / "update-report.json").write_text(json.dumps({"ok": False, "tag": "v0.7.0",
+                                                                 "why": "the pull or install failed"}))
+        _, body = _serve_get("/update-check", headers={"X-Romp-Token": km.TOKEN})
+        d = json.loads(body)
+        self.assertEqual((d["failed"], d["state"]), ("the pull or install failed", ""))
+        self.assertTrue(any(not n["ok"] for n in self.notices()), "the failure reached the Log too")
+
+    def test_a_success_headed_for_restart_is_left_for_the_next_boot(self):
+        # consuming it mid-run would file the notice into THIS dying kernel's in-memory ring — the
+        # new kernel's boot must find the report and log the success durably
+        km._UPDATE_STATE[0] = "running"
+        (jd.STATE / "update-report.json").write_text(json.dumps({"ok": True, "tag": "v0.7.0",
+                                                                 "restarted": True}))
+        _, body = _serve_get("/update-check", headers={"X-Romp-Token": km.TOKEN})
+        d = json.loads(body)
+        self.assertEqual((d["failed"], d["updated"], d["state"]), ("", "", "running"))
+        self.assertTrue((jd.STATE / "update-report.json").exists(), "not consumed — the next boot files it")
+        self.assertEqual(self.notices(), [])
+
+    def test_post_update_requires_a_known_release_and_the_token(self):
+        code, _ = self._post("/update", token=False)
+        self.assertEqual(code, 403)
+        code, body = self._post("/update")
+        self.assertEqual(code, 409, "no newer release known → nothing to install: " + body)
+        km._UPDATE_AVAIL[0] = "v0.7.0"
+        ran = []
+        with mock.patch.object(km, "_run_update", side_effect=lambda tag: ran.append(tag) or True):
+            code, body = self._post("/update")
+        self.assertEqual((code, ran), (200, ["v0.7.0"]))
+
+
+class Wiring(unittest.TestCase):
+    """Source pins: the check runs at boot, the banner ships on the landing page, the gear posts."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = Path(os.path.join(BIN, "romp-kernel")).resolve().read_text()
+        cls.gear = (Path(BIN).parent / "ui" / "webview" / "gear.js").read_text()
+
+    def test_boot_starts_the_check_and_files_the_last_report(self):
+        self.assertIn("threading.Thread(target=_update_check, daemon=True).start()", self.src)
+        self.assertIn("_consume_update_report()                                   # last self-update's outcome", self.src)
+
+    def test_the_landing_ships_the_banner_and_the_shell_relay(self):
+        self.assertIn("_stale_block(v) + _update_block() + _rdrift_block()", self.src)
+        self.assertIn("window.__rompUpdateOffer=offer", self.src)
+        self.assertIn("m.type==='updateAvail'&&window.__rompUpdateOffer", self.src)
+
+    def test_the_gear_offers_the_three_modes_and_posts_the_pick(self):
+        self.assertIn("id=rs-updates", self.gear)
+        for opt in ("value=ask", "value=auto", "value=off"):
+            self.assertIn(opt, self.gear)
+        self.assertIn("post({ type: 'setUpdateMode', mode: upm.value })", self.gear)
+        self.assertIn("upm.value = v.updateMode", self.gear)
+        self.assertIn('msg.get("type") == "setUpdateMode"', self.src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -56,6 +56,12 @@ var GEAR_HTML =
   '<span><b>Auto Nudge</b>' +
   '<span class=rs-sub>When a session goes idle but its goal still shows working (not blocked, not awaiting you), automatically nudge it once for a status update.</span>' +
   '</span></label>' +
+  "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Automatic updates</b>" +
+  '<span class=rs-sub>When romp starts, it checks its repo for a new release. Check and ask (the default) offers it as a banner with an Update button; Install automatically pulls, installs and restarts by itself; Off never checks. Kernel-side setting.</span>' +
+  "<select id=rs-updates style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
+  "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
+  '<option value=ask>Check and ask</option><option value=auto>Install automatically</option><option value=off>Off</option>' +
+  '</select></span></div>' +
   "<div class='rs-row rs-sep' style='cursor:default'><span style='flex:1 1 auto'><b>Default backend</b>" +
   '<span class=rs-sub>What the + button uses for a NEW session — tmux drives a terminal pane; SDK runs via the Agent SDK. Both kinds run side by side; this only sets the default.</span>' +
   "<select id=rs-backend style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
@@ -145,7 +151,7 @@ function initGear(post) {
     tc = document.getElementById('rs-tabctx'),
     cg = document.getElementById('rs-collapsegaps'), jm = document.getElementById('rs-judgemodel'),
     im = document.getElementById('rs-indexmodel'), je = document.getElementById('rs-judgeeffort'),
-    ie = document.getElementById('rs-indexeffort');
+    ie = document.getElementById('rs-indexeffort'), upm = document.getElementById('rs-updates');
   function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: true, tabCtx: 'over50', collapseGaps: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: true, tabCtx: 'over50', collapseGaps: true }; } }
   // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
   // few hours as a boolean toggle — false was an explicit hide, true the default nobody chose.
@@ -172,6 +178,7 @@ function initGear(post) {
   // Auto Nudge / judge tiers are SERVER-SIDE (the kernel runs them): post the
   // change; the controls re-initialize from /version on every open (fill()).
   if (an) an.addEventListener('change', function () { post({ type: 'setAutoNudge', enabled: an.checked }); });
+  if (upm) upm.addEventListener('change', function () { post({ type: 'setUpdateMode', mode: upm.value }); });
   if (jm) jm.addEventListener('change', function () { post({ type: 'setJudgeModel', model: jm.value }); });
   if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value }); });
   if (je) je.addEventListener('change', function () { post({ type: 'setJudgeEffort', effort: je.value }); });
@@ -244,6 +251,7 @@ function initGear(post) {
     var m = t && t.getAttribute('src').match(/[?&]v=(\d+)/); return m ? +m[1] : 0; }
   function fill() { fillChoices().then(function () { return fetch(ku('/version'), { cache: 'no-store' }); }).then(function (r) { return r.json(); }).then(function (v) {
     if (an) an.checked = !!v.autoNudge;
+    if (upm && typeof v.updateMode === 'string') upm.value = v.updateMode;   // the kernel's persisted mode is authoritative
     if (jm && typeof v.judgeModel === 'string') jm.value = v.judgeModel;   // the judge's ACTUAL current model/effort per tier is authoritative
     if (im && typeof v.indexModel === 'string') im.value = v.indexModel;
     if (je && typeof v.judgeEffort === 'string') je.value = v.judgeEffort;


### PR DESCRIPTION
The user (2026-08-09) asked for automatic updates: pull romp when there's a new version, or ask, checked at startup, configurable in settings, default on.

**The check.** At kernel start, one async daemon thread reads origin's newest release tag (`git ls-remote --tags` — the remote's own refs, never the local tag list, which only says what this clone last fetched) and compares it semver-wise against the release this code descends from (the VERSION file, `+` stripped). No VERSION or no reachable origin → it stands down with a stderr note.

**Three modes** (settings gear → "Automatic updates", persisted kernel-side in `update-mode.json`, default **Check and ask**):
- **ask** — a top-center banner (the `#rstale` family, offset so the two can stack) names both versions with an Update button. Update POSTs `/update`, the banner polls `/update-check`, and the page reloads when the response carries a different boot id — the restart flow's exact trick.
- **auto** — the kernel updates itself at boot, once per discovered version (`update-attempted.json`), so a failing update can't loop on every restart; the stall files a Log notice and the banner still offers it.
- **off** — never even asks the network.

**The update** runs DETACHED (`start_new_session` — install.sh reloads the manager and the restart takes the kernel down; the child must outlive both): `git pull --ff-only` → `./install.sh`, everything appended to `update.log` under STATE, a report to `update-report.json`, and a restart through the manager door only on success. The outcome always lands in the Log as a sync notice: the next boot files it, or `/update-check`'s poll files a failure (or a no-manager success) on the still-running kernel. A success headed for restart is deliberately left for the next boot, so the notice survives the process that wrote it. `romp update [host]` remains the other direction.

**Tests**: 27 new (`tests/test_kernel_update.py`) — semver, mode store, ls-remote parsing, check behavior per mode, the detached script's shape (restart only in the success branch; junk tags refused as shell payload), report consumption on both kernels, both routes, and wiring pins. The new file also fixes a harness trap it first tripped itself: a module-level `ROMP_STATE_DIR` write outranks conftest's `XDG_STATE_HOME` for every later-imported module (it broke two postal-bus tests three modules downstream), so the env override is scoped to the module loads and restored.

Full Python suite 4136 green, node 1780 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)