### PR TITLE
The release check re-runs every 6 hours, not only at boot

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1714,7 +1714,12 @@ def _consume_update_report(running_only=False):
 
 
 def _update_check():
-    """The boot check (its own daemon thread): learn the newest release, then act per mode."""
+    """ONE check pass: learn the newest release, then act per mode. Runs at boot and then on
+    _update_check_loop's cadence — kernels outlive browser tabs by days or weeks (the user
+    2026-08-09), so a boot-only check would almost never fire. Every pass re-reads the mode, so
+    flipping the gear setting takes effect without a restart. A pass acts only when the discovered
+    version CHANGES (new information): the same release re-found every few hours must not re-raise
+    banners or re-file notices."""
     if _update_mode() == "off":
         return
     cur = _semver((_kernel_ver() or "").rstrip("+"))
@@ -1728,6 +1733,8 @@ def _update_check():
     lv = _semver(latest)
     if not lv or lv <= cur:
         return
+    if latest == _UPDATE_AVAIL[0]:
+        return                                      # already discovered and acted on this kernel run
     _UPDATE_AVAIL[0] = latest
     if _update_mode() == "auto":
         tried = ""
@@ -1747,6 +1754,23 @@ def _update_check():
         _run_update(latest)
     else:
         _send_to_app("shell", {"type": "updateAvail", "cur": _kernel_ver() or "", "tag": latest})
+
+
+# Re-check cadence. This is a POLL by nature, not a heuristic standing in for an event: the repo
+# cannot notify a local kernel that a release landed, so there is no event to key on (the same
+# category as the /tunnels poll). Six hours is far under release frequency and far over the cost
+# of one ls-remote.
+_UPDATE_CHECK_EVERY_S = 6 * 3600
+
+
+def _update_check_loop():
+    """The daemon thread: one pass at boot, then one per cadence, forever."""
+    while True:
+        try:
+            _update_check()
+        except Exception:
+            sys.stderr.write("update check pass: %s\n" % traceback.format_exc())
+        time.sleep(_UPDATE_CHECK_EVERY_S)
 
 
 def _auto_update_remotes_on():
@@ -19236,9 +19260,11 @@ _UPD_HTML = (
 _UPD_JS = (
     "(function(){var box=document.getElementById('rupd');if(!box)return;"
     "var msg=box.querySelector('.rup-msg'),go=document.getElementById('rupd-go'),dm=document.getElementById('rupd-dismiss');"
-    "var dismissed=false,waiting=false,bootNow='';"
+    "var dismissedTag='',curTag='',waiting=false,bootNow='';"
     "function show(m){msg.textContent=m;box.classList.add('show');}"
-    "function offer(cur,tag){if(dismissed||waiting)return;go.hidden=false;go.disabled=false;dm.hidden=false;"
+    # Not-now is PER RELEASE (the periodic re-check re-finds versions for weeks): the dismissed tag
+    # stays quiet, a strictly newer one is new information and re-offers.
+    "function offer(cur,tag){if(waiting||tag===dismissedTag)return;curTag=tag;go.hidden=false;go.disabled=false;dm.hidden=false;"
     "show('romp '+tag+' is available'+(cur?' \\u2014 you are on '+cur:'')+'.');}"
     "window.__rompUpdateOffer=offer;"   # the shell WS relays the kernel's boot-check push here
     "function poll(){fetch('/update-check',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){"
@@ -19253,7 +19279,7 @@ _UPD_JS = (
     "if(!r.ok)return r.text().then(function(t){throw new Error(t||('HTTP '+r.status));});poll();})"
     "['catch'](function(e){waiting=false;go.disabled=false;dm.hidden=false;"
     "show('Could not start the update: '+((e&&e.message)||e));});};"
-    "dm.onclick=function(){dismissed=true;box.classList.remove('show');};"
+    "dm.onclick=function(){dismissedTag=curTag;box.classList.remove('show');};"
     "fetch('/update-check',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){"
     "bootNow=(d&&d.boot)||'';"
     "if(d&&d.state==='running'){waiting=true;go.hidden=true;dm.hidden=true;"
@@ -21857,7 +21883,7 @@ def main():
     _known_load()                                              # remembered past hosts (popover's re-attach rows)
     _remotes_load()                                            # re-attach remote kernels from a prior run
     _consume_update_report()                                   # last self-update's outcome → the Log, once
-    threading.Thread(target=_update_check, daemon=True).start()   # newer release? (mode-gated inside)
+    threading.Thread(target=_update_check_loop, daemon=True).start()   # newer release? boot + every 6h (mode-gated inside)
     threading.Thread(target=_ensure_postal_bus, daemon=True).start()   # a sessionless machine still needs its bus
     threading.Thread(target=_tunnel_supervisor, daemon=True).start()   # keep ssh tunnels alive + poll host↔sid map
     srv = ThreadingHTTPServer((BIND, PORT), Handler)

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -182,10 +182,70 @@ class UpdateCheck(Fresh):
             self.assertEqual(ran, ["v0.7.0"])
             self.assertEqual(json.loads((jd.STATE / "update-attempted.json").read_text())["tag"], "v0.7.0")
             # a SECOND boot finding the same version does not loop the failed attempt — it says so
-            # in the Log and falls back to offering the banner
+            # in the Log and falls back to offering the banner. (The in-memory discovery is
+            # per-run, so a fresh boot starts empty — modeled by clearing it.)
+            km._UPDATE_AVAIL[0] = ""
             km._update_check()
         self.assertEqual(ran, ["v0.7.0"], "one automatic attempt per version")
         self.assertTrue(any(not n["ok"] and "v0.7.0" in n["text"] for n in self.notices()))
+
+    def test_rediscovering_the_same_release_mid_run_stays_quiet(self):
+        # the 6h re-check re-finds a version for weeks — only a CHANGED discovery is new information
+        sent = []
+        with mock.patch.object(km, "_kernel_ver", return_value="v0.6.0"), \
+             mock.patch.object(km, "_latest_release_tag", return_value="v0.7.0"), \
+             mock.patch.object(km, "_send_to_app", side_effect=lambda app, m: sent.append(m)):
+            km._update_check()
+            km._update_check()
+            km._update_check()
+        self.assertEqual(len(sent), 1, "one banner push per discovered version, not one per pass")
+
+    def test_a_newer_release_than_the_announced_one_reoffers(self):
+        sent = []
+        with mock.patch.object(km, "_kernel_ver", return_value="v0.6.0"), \
+             mock.patch.object(km, "_send_to_app", side_effect=lambda app, m: sent.append(m)):
+            with mock.patch.object(km, "_latest_release_tag", return_value="v0.7.0"):
+                km._update_check()
+            with mock.patch.object(km, "_latest_release_tag", return_value="v0.8.0"):
+                km._update_check()
+        self.assertEqual([m["tag"] for m in sent], ["v0.7.0", "v0.8.0"])
+        self.assertEqual(km._UPDATE_AVAIL[0], "v0.8.0")
+
+    def test_a_mode_flip_applies_on_the_next_pass_without_a_restart(self):
+        # every pass re-reads the mode: turning the gear setting on mid-run must not need a boot
+        sent = []
+        km._set_update_mode("off")
+        with mock.patch.object(km, "_kernel_ver", return_value="v0.6.0"), \
+             mock.patch.object(km, "_send_to_app", side_effect=lambda app, m: sent.append(m)):
+            with mock.patch.object(km, "_latest_release_tag", side_effect=AssertionError("off must not ask")):
+                km._update_check()
+            km._set_update_mode("ask")
+            with mock.patch.object(km, "_latest_release_tag", return_value="v0.7.0"):
+                km._update_check()
+        self.assertEqual([m["tag"] for m in sent], ["v0.7.0"])
+
+
+class CheckLoop(Fresh):
+    def test_one_pass_per_cadence_and_a_crash_never_kills_the_thread(self):
+        passes = []
+        naps = []
+
+        def nap(s):
+            naps.append(s)
+            if len(naps) == 2:
+                raise SystemExit                       # unhook the forever-loop after two rounds
+
+        def one_pass():
+            passes.append(1)
+            if len(passes) == 1:
+                raise RuntimeError("boom")             # the first pass dies — the loop must survive it
+        with mock.patch.object(km, "_update_check", side_effect=one_pass), \
+             mock.patch.object(km.time, "sleep", side_effect=nap), \
+             self.assertRaises(SystemExit):
+            km._update_check_loop()
+        self.assertEqual(len(passes), 2, "the pass after a crashed pass still ran")
+        self.assertEqual(naps, [km._UPDATE_CHECK_EVERY_S] * 2)
+        self.assertEqual(km._UPDATE_CHECK_EVERY_S, 6 * 3600)
 
 
 class RunUpdate(Fresh):
@@ -326,9 +386,17 @@ class Wiring(unittest.TestCase):
         cls.src = Path(os.path.join(BIN, "romp-kernel")).resolve().read_text()
         cls.gear = (Path(BIN).parent / "ui" / "webview" / "gear.js").read_text()
 
-    def test_boot_starts_the_check_and_files_the_last_report(self):
-        self.assertIn("threading.Thread(target=_update_check, daemon=True).start()", self.src)
+    def test_boot_starts_the_check_loop_and_files_the_last_report(self):
+        # the LOOP, not a one-shot: kernels outlive browser tabs by weeks (the user 2026-08-09),
+        # so a boot-only check would almost never fire
+        self.assertIn("threading.Thread(target=_update_check_loop, daemon=True).start()", self.src)
         self.assertIn("_consume_update_report()                                   # last self-update's outcome", self.src)
+
+    def test_the_banner_dismissal_is_per_release(self):
+        # Not-now silences THE dismissed tag; a strictly newer release found by a later pass is
+        # new information and re-offers
+        self.assertIn("if(waiting||tag===dismissedTag)return;", self.src)
+        self.assertIn("dm.onclick=function(){dismissedTag=curTag;", self.src)
 
     def test_the_landing_ships_the_banner_and_the_shell_relay(self):
         self.assertIn("_stale_block(v) + _update_block() + _rdrift_block()", self.src)

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -57,7 +57,7 @@ var GEAR_HTML =
   '<span class=rs-sub>When a session goes idle but its goal still shows working (not blocked, not awaiting you), automatically nudge it once for a status update.</span>' +
   '</span></label>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Automatic updates</b>" +
-  '<span class=rs-sub>When romp starts, it checks its repo for a new release. Check and ask (the default) offers it as a banner with an Update button; Install automatically pulls, installs and restarts by itself; Off never checks. Kernel-side setting.</span>' +
+  '<span class=rs-sub>romp checks its repo for a new tagged release at start-up and every 6 hours (ordinary commits never trigger it). Check and ask (the default) offers it as a banner with an Update button; Install automatically pulls, installs and restarts by itself; Off never checks. Kernel-side setting.</span>' +
   "<select id=rs-updates style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
   "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
   '<option value=ask>Check and ask</option><option value=auto>Install automatically</option><option value=off>Off</option>' +


### PR DESCRIPTION
Kernels outlive browser tabs by days or weeks, so the boot-only check from #261 would almost never fire (the user 2026-08-09).

- `_update_check_loop`: one pass at boot, then one per 6h cadence — a poll by nature (the repo cannot notify a kernel that a release landed; same category as the /tunnels poll).
- Each pass re-reads the mode, so flipping the gear setting (ask/auto/off) takes effect without a kernel restart.
- A pass acts only when the discovered version CHANGES: the same release re-found every few hours re-raises no banners and re-files no notices; a strictly newer one does.
- The banner's Not-now is per release — the dismissed tag stays quiet, a newer one re-offers.
- Confirmed and pinned: only release tags (`vX.Y.Z`) trigger anything; ordinary commits never do.

Tests: loop cadence + crash-survival, per-pass mode re-read, unchanged-discovery silence, newer-release re-offer, per-tag dismissal pins. Full Python (4141) and node (1780) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)