### PR TITLE
A self-update lands exactly on the release tag, never the branch tip

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1608,9 +1608,10 @@ def _set_auto_nudge(enabled):
 #          keeps a failing update from looping on every restart — that stall is logged, not silent).
 #   off  — never even checks.
 # The update itself (_run_update) runs DETACHED (start_new_session: install.sh reloads the manager
-# and the restart takes this kernel down, and the child must outlive both): `git pull --ff-only`,
-# then ./install.sh, everything appended to update.log under STATE, a report written to
-# update-report.json, and a restart through the manager door ONLY on success. The outcome is never
+# and the restart takes this kernel down, and the child must outlive both): fetch the tag, then
+# `git merge --ff-only <tag>` — the tree lands EXACTLY on the release commit, never the branch tip
+# (the user 2026-08-09) — then ./install.sh, everything appended to update.log under STATE, a
+# report written to update-report.json, and a restart through the manager door ONLY on success. The outcome is never
 # silent (fail loudly): the next boot — or the still-running kernel, via /update-check's poll —
 # consumes the report into a sync notice, the Log's standing record of what romp did to your
 # machines. `romp update [host]` remains the other direction (pushing THIS build to remotes).
@@ -1659,9 +1660,14 @@ def _latest_release_tag():
 
 
 def _run_update(tag):
-    """Start the self-update: pull + install + report (+ restart on success), in a DETACHED child.
-    Returns True when the child was launched. The tag has passed _semver before it gets here; the
-    guard repeats anyway because the string lands inside a shell script."""
+    """Start the self-update: fetch the tag, fast-forward EXACTLY onto it, install, report (+ restart
+    on success), in a DETACHED child. Returns True when the child was launched. The tree lands on the
+    RELEASE COMMIT, never the branch tip (the user 2026-08-09: a pull took whatever main had gained
+    since the tag — an update to v0.7.0 must mean running v0.7.0): the tag is fetched by explicit
+    refspec and merged --ff-only, so the current branch moves precisely to the tagged commit, a tag
+    already behind HEAD is a no-op, and a diverged tree fails loudly instead of guessing. The tag has
+    passed _semver before it gets here; the guard repeats anyway because the string lands inside a
+    shell script."""
     if not _semver(tag) or _UPDATE_STATE[0] == "running":
         return False
     _UPDATE_STATE[0] = "running"
@@ -1674,11 +1680,13 @@ def _run_update(tag):
     script = (
         "cd %s || exit 1\n" % q(str(ROOT))
         + "{ echo; echo \"== romp self-update to %s ==\"; date; } >> %s 2>&1\n" % (tag, log)
-        + "if git pull --ff-only >> %s 2>&1 && ./install.sh >> %s 2>&1; then\n" % (log, log)
+        + "if git fetch origin refs/tags/%s:refs/tags/%s >> %s 2>&1 && git merge --ff-only %s >> %s 2>&1 "
+          "&& ./install.sh >> %s 2>&1; then\n" % (tag, tag, log, tag, log, log)
         + "  printf '%%s' %s > %s\n" % (q(json.dumps(ok_rep)), rep)
         + restart
         + "else\n"
-        + "  printf '%%s' %s > %s\n" % (q(json.dumps({"ok": False, "tag": tag, "why": "the pull or install failed"})), rep)
+        + "  printf '%%s' %s > %s\n" % (q(json.dumps({"ok": False, "tag": tag,
+                                                      "why": "the fetch, fast-forward or install failed"})), rep)
         + "fi\n")
     subprocess.Popen(["bash", "-c", script], start_new_session=True, cwd=str(ROOT),
                      stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -3,7 +3,7 @@
 origin's newest release tag (git ls-remote — the remote's own refs, never the local tag list) and
 compares it against the VERSION-file release. Modes (update-mode.json, default "ask" — ON out of
 the box): ask = the shell's update banner offers it; auto = the kernel updates itself once per
-discovered version; off = never checks. The update runs DETACHED (git pull --ff-only + install.sh,
+discovered version; off = never checks. The update runs DETACHED (fetch + ff-only merge ONTO THE TAG + install.sh,
 report to update-report.json, restart through the manager door only on success), and the outcome is
 always filed as a sync notice — by the next boot, or by /update-check's poll on the still-running
 kernel (fail loudly, never silent). Synthetic tags/paths only."""
@@ -249,7 +249,7 @@ class CheckLoop(Fresh):
 
 
 class RunUpdate(Fresh):
-    def test_detached_child_pulls_installs_reports_and_restarts_only_on_success(self):
+    def test_detached_child_lands_on_the_tag_installs_reports_and_restarts_only_on_success(self):
         calls = []
         with mock.patch.object(km.subprocess, "Popen", side_effect=lambda *a, **kw: calls.append((a, kw))), \
              mock.patch.dict(km.os.environ, {"ROMP_MANAGER_PORT": "7777"}):
@@ -258,7 +258,11 @@ class RunUpdate(Fresh):
         self.assertEqual(a[0][:2], ["bash", "-c"])
         self.assertTrue(kw.get("start_new_session"), "install.sh + the restart take the kernel down — the child must outlive it")
         script = a[0][2]
-        self.assertIn("git pull --ff-only", script)
+        # EXACTLY the release commit, never the branch tip (the user 2026-08-09): the tag is fetched
+        # by explicit refspec and fast-forwarded onto — an update to v0.7.0 means running v0.7.0
+        self.assertIn("git fetch origin refs/tags/v0.7.0:refs/tags/v0.7.0", script)
+        self.assertIn("git merge --ff-only v0.7.0", script)
+        self.assertNotIn("git pull", script, "a pull takes whatever the branch has gained past the tag")
         self.assertIn("./install.sh", script)
         self.assertIn("update-report.json", script)
         # the restart rides the SUCCESS branch only: everything after `if` up to `else` has it,

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -57,7 +57,7 @@ var GEAR_HTML =
   '<span class=rs-sub>When a session goes idle but its goal still shows working (not blocked, not awaiting you), automatically nudge it once for a status update.</span>' +
   '</span></label>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Automatic updates</b>" +
-  '<span class=rs-sub>romp checks its repo for a new tagged release at start-up and every 6 hours (ordinary commits never trigger it). Check and ask (the default) offers it as a banner with an Update button; Install automatically pulls, installs and restarts by itself; Off never checks. Kernel-side setting.</span>' +
+  '<span class=rs-sub>romp checks its repo for a new tagged release at start-up and every 6 hours (ordinary commits never trigger it; updating lands exactly on the release). Check and ask (the default) offers it as a banner with an Update button; Install automatically fetches, installs and restarts by itself; Off never checks. Kernel-side setting.</span>' +
   "<select id=rs-updates style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
   "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
   '<option value=ask>Check and ask</option><option value=auto>Install automatically</option><option value=off>Off</option>' +


### PR DESCRIPTION
`git pull` took whatever the branch had gained since the tag — an update to v0.7.0 must mean running v0.7.0 (the user 2026-08-09). The updater now fetches the tag by explicit refspec (`refs/tags/vX.Y.Z:refs/tags/vX.Y.Z`) and runs `git merge --ff-only <tag>`: the current branch moves precisely to the tagged commit, a tag already behind HEAD is a no-op, and a diverged tree still fails loudly instead of guessing. Test pins updated (`git pull` is now asserted ABSENT from the updater script); gear copy says updating lands exactly on the release. Full Python (4141) and node (1780) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)