### PR TITLE
kernel: a moot nudge retire requires a verdict that actually superseded

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2126,26 +2126,49 @@ def _mark_nudge_failed(gid, ev_t=None):
     if not rec or rec.get("failed") or rec.get("moot"):
         return None
     # MOOT, NOT FAILED (the user 2026-07-29): if a real judge FILED a verdict on this node after the
-    # response turn — an unblock ("answered in passing"), a fresh planner/closer block, a completion —
-    # then the judges have already ruled on evidence at least as new as ours, and "the response didn't
-    # resolve this" is a stale claim. Filing our procedural block anyway would overwrite that ruling AND
-    # resurface the node's LAST decision brief, which the later verdict may have just answered — the
-    # audited card sat in Needs-you presenting a question the user had answered and the unblocker had
-    # ruled answered, five minutes after the fact. Retire the record instead (`moot`, no `failed`, no
-    # block): the anti-loop gate keeps this arm from ever re-firing, and a genuinely still-stalled goal
-    # re-arms on the next GENUINE ended turn, judged against the post-verdict world. The verdict's
-    # FILING time (`at`; ev_t for legacy rows) is the event — same discipline as _nudge_fire_list's
-    # arm-time guard, applied at the eval end of the race. Rows the nudge pipeline itself wrote never
-    # count (jd.nudge_pipeline_row, the user 2026-07-30): placing the reply always files its own
-    # "reopened (nudge)" row after the response turn, and reading that as a fresh ruling mooted EVERY
-    # placed-but-unresolved reply — the ladder's escalation rung went dead and cards parked in Working
-    # with no chip, no block, and no reviver.
+    # response turn — an unblock ("answered in passing"), a completion — then the judges have already
+    # ruled on evidence at least as new as ours, and "the response didn't resolve this" is a stale
+    # claim. Filing our procedural block anyway would overwrite that ruling AND resurface the node's
+    # LAST decision brief, which the later verdict may have just answered — the audited card sat in
+    # Needs-you presenting a question the user had answered and the unblocker had ruled answered, five
+    # minutes after the fact. Retire the record instead (`moot`, no `failed`, no block): the anti-loop
+    # gate keeps this arm from ever re-firing, and a genuinely still-stalled goal re-arms on the next
+    # GENUINE ended turn, judged against the post-verdict world. The verdict's FILING time (`at`; ev_t
+    # for legacy rows) is the event — same discipline as _nudge_fire_list's arm-time guard, applied at
+    # the eval end of the race. Rows the nudge pipeline itself wrote never count (jd.nudge_pipeline_row,
+    # the user 2026-07-30): placing the reply always files its own "reopened (nudge)" row after the
+    # response turn, and reading that as a fresh ruling mooted EVERY placed-but-unresolved reply — the
+    # ladder's escalation rung went dead and cards parked in Working with no chip, no block, and no
+    # reviver.
+    #
+    # TWO row shapes never moot (2026-08-09, a card wedged in Working on an idle, finished session —
+    # both matched the bare filed-after test and together silenced the escalation with no reviver left):
+    # - a BLOCK row: it AGREES with the escalation ("the goal needs the user"), so it cannot mean stand
+    #   down. It only coexists with a still-'working' goal when a LATER unblock lifted it — judge that
+    #   unblock on its own merits — and a slow pass filing a block about pre-response evidence after the
+    #   response is not "a judge looked after the reply" (filing time as a proxy for a newer world — the
+    #   same-trigger lesson from the fire-side guard, met again at the eval end).
+    # - an UNBLOCK evidenced by the RESPONSE TURN ITSELF (ev_t == _ev): the unblocker judged the very
+    #   reply this evaluator is scoring and moved laterally — it lifted a block and resolved nothing, so
+    #   the stall stands and the escalation must proceed. The card's session had answered the status
+    #   check with a wrong claim that nothing was owed; the unblock believed it, the planner's nudge
+    #   unit declined to resolve, and moot then retired the one rung left — Working forever. An unblock
+    #   evidenced ELSEWHERE (the audited 2026-07-29 shape: the user's own earlier answer) still moots:
+    #   re-blocking there would re-present an answered brief.
     _ev = int(ev_t or now)
+
+    def _supersedes(e):
+        if (e.get("at") or e.get("ev_t") or 0) <= _ev or jd.nudge_pipeline_row(e):
+            return False               # predates the reply, or the machinery talking to itself
+        if e.get("kind") == "block":
+            return False               # agrees with the escalation — never a stand-down (see above)
+        if e.get("kind") == "unblock" and (e.get("ev_t") or 0) == _ev:
+            return False               # a lateral move off the reply itself — the stall stands
+        return True
+
     try:
         _nd0 = jd.load_goals(gid.rsplit(":", 1)[0]).get("nodes", {}).get(gid)
-        if _nd0 is not None and any((e.get("at") or e.get("ev_t") or 0) > _ev
-                                    and not jd.nudge_pipeline_row(e)
-                                    for e in _nd0.get("log") or []):
+        if _nd0 is not None and any(_supersedes(e) for e in _nd0.get("log") or []):
             nudged[gid] = dict(rec, moot=True)
             d["nudged"] = nudged
             _write_auto_nudge(d)

--- a/tests/test_nudge_moot_supersede.py
+++ b/tests/test_nudge_moot_supersede.py
@@ -33,6 +33,17 @@ same reopen row — no chip, no needs-you block, the anti-loop arm pinned, the c
 with no reviver until the user happened to message the session. jd.nudge_pipeline_row names the
 machinery's own rows (src=="nudge" plus _reopen(by="nudge")'s two why strings) and the moot scan
 skips them.
+
+AND (2026-08-09): two more row shapes never moot — both matched the bare filed-after test on a
+finished idle session and together silenced the escalation with no reviver left, the card wedged in
+Working. A BLOCK row agrees with the escalation, so it can never mean stand down; a late-FILED block
+about pre-response evidence (a slow closer pass) is filing time masquerading as a newer world, the
+fire-side same-trigger lesson met again at the eval end. And an UNBLOCK evidenced by the RESPONSE
+TURN ITSELF is the unblocker judging the very reply this evaluator scores and moving laterally — it
+lifted a block and resolved nothing (the synthetic shape: the reply wrongly claimed a service restart
+was already queued and nothing was owed; the unblocker believed it, the planner's nudge unit resolved
+nothing), so the stall stands and the failed-nudge block must land. An unblock evidenced ELSEWHERE
+(the 2026-07-29 shape above: the user's own earlier answer) still moots.
 """
 import json
 import os
@@ -191,6 +202,39 @@ class NudgeFailedMootWhenSuperseded(unittest.TestCase):
         self.assertEqual(km._mark_nudge_failed(G1, ev_t=RESP_T), "moot")
         store = km.jd.load_goals(SID)
         self.assertFalse(store["nodes"][G1]["blocked"])
+
+    def test_an_unblock_evidenced_by_the_response_itself_does_not_moot(self):
+        # THE 2026-08-09 WEDGE (synthetic): the session finished its work; the closer blocked
+        # ("restarting the api service is left to you"); the status-check reply wrongly claimed the
+        # restart was already queued and nothing was owed; the unblocker believed it and unblocked —
+        # evidenced by that very reply — while the planner's nudge unit resolved nothing. The bare
+        # filed-after scan read the late closer block AND the reply-evidenced unblock as a moved
+        # story: moot, no chip, no block, and no reviver left — Working forever on an idle session.
+        self._write_store([
+            {"ev_t": ARM_T, "src": "planner", "kind": "block",
+             "why": "restart the api service yourself", "at": RESP_T - 25},
+            {"ev_t": ARM_T, "src": "unblocker", "kind": "unblock",
+             "why": "answered in passing: the work moved past the refusal", "at": RESP_T - 12},
+            {"ev_t": ARM_T, "src": "closer", "kind": "block",
+             "why": "the service restart is left to you", "at": RESP_T + 7},
+            {"ev_t": RESP_T, "src": "unblocker", "kind": "unblock",
+             "why": "answered in passing: the restart is already queued", "at": RESP_T + 80}])
+        self.assertEqual(km._mark_nudge_failed(G1, ev_t=RESP_T), "failed")
+        store = km.jd.load_goals(SID)
+        self.assertTrue(store["nodes"][G1]["blocked"],
+                        "the escalation lands: an unresolved status check on an idle session IS needs-you")
+        rec = km._auto_nudge_data()["nudged"][G1]
+        self.assertTrue(rec.get("failed"))
+        self.assertFalse(rec.get("moot"), "a lateral unblock off the reply itself is not a stand-down")
+
+    def test_a_late_filed_block_does_not_moot(self):
+        # a slow pass filing a BLOCK about pre-response evidence after the response turn: filing time
+        # is not a newer world (the fire-side same-trigger lesson, at the eval end) — and a block
+        # agrees with the escalation, so it can never mean stand down
+        self._write_store([{"ev_t": ARM_T, "src": "closer", "kind": "block",
+                            "why": "needs your credentials", "at": RESP_T + 40}])
+        self.assertEqual(km._mark_nudge_failed(G1, ev_t=RESP_T), "failed")
+        self.assertTrue(km._auto_nudge_data()["nudged"][G1].get("failed"))
 
     def test_a_moot_record_is_settled_and_never_reevaluated(self):
         self._write_store([{"ev_t": RESP_T - 10, "src": "unblocker", "kind": "unblock",


### PR DESCRIPTION
A card on a finished, idle session wedged terminally in Working (2026-08-09). The failed-nudge escalation ("a failed nudge IS a block", 2026-07-07) was silenced by the moot retire: two diary row shapes matched the bare filed-after moot scan while resolving nothing.

**The wedge.** The closer had correctly blocked the card needs-you. The auto-nudge status check fired; the reply wrongly claimed the remaining step was already queued and nothing was owed. The unblocker believed the reply and filed an answered-in-passing unblock evidenced by that very response turn; the planner's nudge unit declined to resolve (no done, no block). At eval time the moot scan then found two rows filed after the response — the closer's block (old evidence, slow pass, late filing) and that unblock — and retired the record moot: no chip, no needs-you block, the anti-loop arm pinned, and no genuine turn ever coming on an idle session. No mechanism held done- or block-filing authority anymore.

**The fix**, one rule restored rather than new machinery: a superseding verdict moots only if it could actually mean stand down.
- A **block** row never moots: it agrees with the escalation, and a late-filed block about pre-response evidence is filing time masquerading as a newer world (the fire-side same-trigger lesson, applied at the eval end).
- An **unblock evidenced by the response turn itself** never moots: the unblocker judged the very reply the evaluator is scoring and moved laterally, lifting a block while resolving nothing, so the stall stands. An unblock evidenced elsewhere (the audited 2026-07-29 shape: the user's own earlier answer) still moots — re-blocking there would re-present an answered brief.

**Tests**: two regression tests in tests/test_nudge_moot_supersede.py, both reproducing the wedge (fail pre-fix, pass post-fix); full Python suite (4143 passed) and vscode-extension suite (1780 passed, typecheck clean) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)