### PR TITLE
The fast toggle shows again: sdk_opt_in_required is a curable state, not a refusal

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1917,7 +1917,16 @@ class SdkSession:
                     fast = self._fast_expect
                 self._fast_expect = ""
                 self.fast = fast
-                self.fast_reason = str(d.get("fast_mode_disabled_reason") or "")
+                reason = str(d.get("fast_mode_disabled_reason") or "")
+                # 'sdk_opt_in_required' is NOT a refusal to respect — it is the one refusal romp is
+                # BUILT to cure (set_fast reconnects with the fastMode flag-settings opt-in), and the
+                # CLI stamps it on EVERY connect made without the flag (verified live 2026-08-10 on
+                # 2.1.226: opus/fable/sonnet headless connects all report off + this reason). Keeping
+                # it in fast_reason hid the chat toggle on every SDK session — the control that
+                # GRANTS the opt-in was gated on already having it (the user 2026-08-10, who switched
+                # to Opus and looked for the toggle). Blank it: the badge shows "Fast off" and a
+                # click cures the reason; every OTHER reason still hides the dead control.
+                self.fast_reason = "" if reason == "sdk_opt_in_required" else reason
             # HOW this CLI authenticates (verified live 2026-08-04: 'ANTHROPIC_API_KEY' on API-key auth;
             # the field is absent on a subscription login). An auth flip is the deciding event for the
             # rail's /usage bars — see _note_auth_source.

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -539,6 +539,34 @@ class LiveTail(unittest.TestCase):
         asyncio.run(run({}))                             # an init with no field → the last truth STANDS
         self.assertEqual(s.fast, "off", "absent field never overwrites the known state")
 
+    def test_the_opt_in_required_reason_never_hides_the_toggle(self):
+        """The CLI stamps 'sdk_opt_in_required' on EVERY connect made without the fastMode
+        flag-settings opt-in (verified live 2026-08-10 on 2.1.226 — opus/fable/sonnet headless
+        connects alike). Treating it like a real refusal hid the chat toggle on every SDK session:
+        the control that GRANTS the opt-in was gated on already having it (the user 2026-08-10,
+        who switched to Opus and found no toggle anywhere). It reads as 'available, currently off';
+        every other reason still hides the dead control."""
+        import asyncio
+        class _Sys:
+            def __init__(self, data): self.subtype = "init"; self.data = data
+        d = tempfile.mkdtemp()
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        sid = "11111111-2222-3333-4444-cccccccccccc"
+        sb.write_reg(d, sid, {"sid": sid, "name": "n", "cwd": "/tmp", "alive": True})
+        s = sb.SdkSession(be, {"sid": sid, "name": "n", "cwd": "/tmp"})
+        async def _noop(): pass
+        s._do_refresh_context = _noop
+
+        async def run(data):
+            s._on_message(_Sys(data), _AssistantMessage, _ResultMessage, _Sys)
+            await asyncio.sleep(0)
+        asyncio.run(run({"fast_mode_state": "off", "fast_mode_disabled_reason": "sdk_opt_in_required"}))
+        self.assertEqual(s.fast, "off")
+        self.assertEqual(s.snapshot()["fastReason"], "", "the curable opt-in reason shows the badge")
+        asyncio.run(run({"fast_mode_state": "off", "fast_mode_disabled_reason": "Fast mode is org-disabled"}))
+        self.assertEqual(s.snapshot()["fastReason"], "Fast mode is org-disabled",
+                         "a real refusal still hides the toggle")
+
     def test_the_toggle_turns_own_init_yields_to_the_sent_word_once(self):
         """A literal '/fast on' send opens a turn whose init still reports the state at turn START —
         one word stale, since the toggle applies after it. Taking it verbatim stomps set_fast's


### PR DESCRIPTION
The CLI stamps `fast_mode_disabled_reason: "sdk_opt_in_required"` on **every** connect made without the `fastMode` flag-settings opt-in — verified live today on 2.1.226: opus/fable/sonnet headless connects all report `off` + that reason. Since the chat hides the fast toggle on any non-empty reason, the toggle was hidden on every SDK session: the control that grants the opt-in was gated on already having it.

The init handler now blanks exactly that one reason — it is the refusal `set_fast` is built to cure (it reconnects with the opt-in flag) — so the badge shows `Fast off` and a click cures it. Every other `disabled_reason` (org-gating etc.) still hides the dead control, and a reason still beats the one-shot toggle expectation as refusal evidence.

Test: init with `sdk_opt_in_required` → `fastReason` empty (badge shows); an org-disabled reason still rides through (badge hides). Full Python (4144) and node (1780) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)