### PR TITLE
Statusline wraps on narrow panes; fast-mode state learned at connect and persisted

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1157,12 +1157,16 @@ class SdkSession:
         #   "Reloading session…" notice until the reconnect completes (the user 2026-07-06). Cleared the instant the
         #   new client connects (reconnect loop) — event-based, mirroring _model_pending's dots.
         self.perm_mode = self.mode
-        self.fast = ""      # fast-mode state as the CLI's init message reports it ("on"/"off"/"cooldown");
-        #   "" until an init lands (unknown → the chat shows no fast badge rather than a guess). Flipped
-        #   optimistically by set_fast (the /fast command is delivered like any typed one) and re-asserted
-        #   by fast_mode_state on every init, so a refused toggle can't stick past the next connect.
-        self.fast_reason = ""   # the init's fast_mode_disabled_reason — non-empty means /fast would refuse
-        #   (org-gated / unsupported), so the chat hides the toggle instead of offering a dead control.
+        self.fast = reg.get("liveFast") or ""   # fast-mode state as the CLI last reported it ("on"/"off"/
+        #   "cooldown"); "" = unknown → the chat shows no fast badge rather than a guess. Seeded from the
+        #   reg (the liveModel pattern) so a kernel restart doesn't blank every session's badge until its
+        #   next turn (the user 2026-08-10, who found the fast toggle nowhere). Flipped optimistically by
+        #   set_fast (the /fast command is delivered like any typed one) and re-asserted by
+        #   _adopt_fast_state at every connect and every init, so a refused toggle or a stale seed can't
+        #   stick past the next connect.
+        self.fast_reason = reg.get("liveFastReason") or ""   # the CLI's fast_mode_disabled_reason —
+        #   non-empty means /fast would refuse (org-gated / unsupported), so the chat hides the toggle
+        #   instead of offering a dead control. Persisted and seeded beside liveFast.
         self.fast_opt = bool(reg.get("fast"))   # the user's PERSISTED fast-mode ask (the reg's `fast`).
         #   The CLI refuses /fast to a non-interactive client unless the connect carried the `fastMode`
         #   flag-settings opt-in, so this drives that key in _options at every connect. Per-session on
@@ -1517,6 +1521,57 @@ class SdkSession:
         if changed:
             self.backend._poke()
 
+    def _adopt_fast_state(self, d) -> bool:
+        """Adopt fast-mode truth from a CLI payload that carries it. The per-turn init message and the
+        connect-time initialize response (get_server_info) share the exact field names (verified live
+        2026-08-10 on 2.1.226): fast_mode_state "on"/"off"/"cooldown" plus fast_mode_disabled_reason.
+        An absent field (older CLI) leaves the last truth standing — never fabricate "off". Returns
+        whether anything changed; a change persists to the reg (liveFast/liveFastReason, the liveModel
+        pattern) so a kernel restart doesn't blank a dormant session's badge."""
+        fast = d.get("fast_mode_state")
+        if not (isinstance(fast, str) and fast):
+            return False
+        # …except the one init opened by a literal /fast send itself, whose word predates the
+        # toggle it carries. A disabled_reason is real refusal evidence, so it always wins.
+        if self._fast_expect and fast != self._fast_expect \
+                and not d.get("fast_mode_disabled_reason"):
+            fast = self._fast_expect
+        self._fast_expect = ""
+        reason = str(d.get("fast_mode_disabled_reason") or "")
+        # 'sdk_opt_in_required' is NOT a refusal to respect — it is the one refusal romp is
+        # BUILT to cure (set_fast reconnects with the fastMode flag-settings opt-in), and the
+        # CLI stamps it on EVERY connect made without the flag (verified live 2026-08-10 on
+        # 2.1.226: opus/fable/sonnet headless connects all report off + this reason). Keeping
+        # it in fast_reason hid the chat toggle on every SDK session — the control that
+        # GRANTS the opt-in was gated on already having it (the user 2026-08-10, who switched
+        # to Opus and looked for the toggle). Blank it: the badge shows "Fast off" and a
+        # click cures the reason; every OTHER reason still hides the dead control.
+        reason = "" if reason == "sdk_opt_in_required" else reason
+        changed = fast != self.fast or reason != self.fast_reason
+        self.fast, self.fast_reason = fast, reason
+        if changed:
+            try:
+                self.backend._update_reg(self.sid, liveFast=fast, liveFastReason=reason)
+            except Exception as e:
+                self.backend._log("fast-state persist (%s): registry write failed: %s" % (self.name, e))
+        return changed
+
+    async def _do_adopt_server_info(self):
+        """Fast-mode state at CONNECT, before any turn. The init message _adopt_fast_state feeds on
+        only streams WITH a turn — so after a kernel restart every session's fast badge sat blank
+        until it next spoke, and a /model switch never made one appear at all (the user 2026-08-10,
+        who switched a session to Opus and found no toggle). The initialize response the SDK stored
+        at connect (get_server_info — the designed connect-time snapshot, this path's
+        get_context_usage) carries the same fast fields, so adopt them the moment we connect."""
+        if not self.client:
+            return
+        try:
+            info = await self.client.get_server_info()
+        except Exception:
+            return
+        if isinstance(info, dict) and self._adopt_fast_state(info):
+            self.backend._poke()
+
     def effective_auth(self) -> str:
         """'key' or 'login' — what _options launches this session with. An explicit pick wins; unset
         preserves the pre-selector world, where a manager environment that carried a key billed every
@@ -1756,6 +1811,10 @@ class SdkSession:
                     # and returns BOTH the live model id and the % pre-turn, so this one refresh fills both. Runs on
                     # every (re)connect; guarded + idempotent + pokes only on change.
                     asyncio.ensure_future(self._do_refresh_context())
+                    # …and the fast-mode fields the same way: they ride the initialize response the
+                    # SDK already holds (get_server_info), so the badge exists pre-turn too — without
+                    # this, nothing showed after a kernel restart until each session's next turn.
+                    asyncio.ensure_future(self._do_adopt_server_info())
                     feeder = asyncio.ensure_future(client.query(inputs()))
                     recv = asyncio.ensure_future(drain(client))
                     waker = asyncio.ensure_future(self._wake.wait())
@@ -1905,28 +1964,9 @@ class SdkSession:
             d = msg.data if isinstance(msg.data, dict) else {}
             self._learn_model(pretty_model(d.get("model")))
             self.perm_mode = d.get("permissionMode") or self.perm_mode
-            # Fast-mode truth rides the init payload (fast_mode_state: on/off/cooldown, plus a
-            # disabled_reason when the org/model can't use it) — the AUTHORITATIVE re-assert behind
-            # set_fast's optimistic flip. Absent field (older CLI) → stay unknown, never fabricate "off".
-            fast = d.get("fast_mode_state")
-            if isinstance(fast, str) and fast:
-                # …except the one init opened by a literal /fast send itself, whose word predates the
-                # toggle it carries. A disabled_reason is real refusal evidence, so it always wins.
-                if self._fast_expect and fast != self._fast_expect \
-                        and not d.get("fast_mode_disabled_reason"):
-                    fast = self._fast_expect
-                self._fast_expect = ""
-                self.fast = fast
-                reason = str(d.get("fast_mode_disabled_reason") or "")
-                # 'sdk_opt_in_required' is NOT a refusal to respect — it is the one refusal romp is
-                # BUILT to cure (set_fast reconnects with the fastMode flag-settings opt-in), and the
-                # CLI stamps it on EVERY connect made without the flag (verified live 2026-08-10 on
-                # 2.1.226: opus/fable/sonnet headless connects all report off + this reason). Keeping
-                # it in fast_reason hid the chat toggle on every SDK session — the control that
-                # GRANTS the opt-in was gated on already having it (the user 2026-08-10, who switched
-                # to Opus and looked for the toggle). Blank it: the badge shows "Fast off" and a
-                # click cures the reason; every OTHER reason still hides the dead control.
-                self.fast_reason = "" if reason == "sdk_opt_in_required" else reason
+            # Fast-mode truth rides the init payload — the AUTHORITATIVE re-assert behind set_fast's
+            # optimistic flip, shared with the connect-time initialize response (_adopt_fast_state).
+            self._adopt_fast_state(d)
             # HOW this CLI authenticates (verified live 2026-08-04: 'ANTHROPIC_API_KEY' on API-key auth;
             # the field is absent on a subscription login). An auth flip is the deciding event for the
             # rail's /usage bars — see _note_auth_source.
@@ -3720,6 +3760,8 @@ class SdkBackend:
         if not reg:
             return False
         reg["fast"] = (value == "on")
+        reg["liveFast"] = value   # mirror the optimistic flip where the badge reads it while dormant /
+        #                           across a restart; _adopt_fast_state re-asserts at the next connect
         write_reg(self.state_dir, sid, reg)
         s = self.sessions.get(sid)
         if not s or not s.thread.is_alive():
@@ -3891,6 +3933,10 @@ class SdkBackend:
                             "auth": self.default_auth(reg),
                             "authPending": bool(reg.get("authPending")),
                             "mode": reg.get("mode", ""),
+                            # last persisted fast state (liveFast, like liveCtx above) → the badge
+                            # survives idle/restart instead of vanishing until the next turn
+                            "fast": reg.get("liveFast", ""),
+                            "fastReason": reg.get("liveFastReason", ""),
                             "ctx": lc if isinstance(lc, (int, float)) else "", "summary": ""}
         return out
 

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -605,6 +605,63 @@ class LiveTail(unittest.TestCase):
         self.assertEqual(s.fast, "off", "…but a disabled_reason beats the expectation immediately")
         self.assertEqual(s.snapshot()["fastReason"], "Fast mode is org-disabled")
 
+    def test_fast_state_survives_a_kernel_restart_via_the_reg(self):
+        """The init message only streams WITH a turn, so in-memory-only fast state meant every kernel
+        restart blanked every session's badge until it next spoke (the user 2026-08-10, who found the
+        toggle nowhere). The state persists to the reg on adoption (liveFast/liveFastReason, the
+        liveModel pattern) and seeds the next construction — and a DORMANT session (no thread at all
+        after a restart) reports it straight from the reg in live_sessions."""
+        import asyncio
+        class _Sys:
+            def __init__(self, data): self.subtype = "init"; self.data = data
+        d = tempfile.mkdtemp()
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        sid = "11111111-2222-3333-4444-dddddddddddd"
+        sb.write_reg(d, sid, {"sid": sid, "name": "n", "cwd": "/tmp", "alive": True})
+        s = sb.SdkSession(be, {"sid": sid, "name": "n", "cwd": "/tmp"})
+        async def _noop(): pass
+        s._do_refresh_context = _noop
+        async def run(data):
+            s._on_message(_Sys(data), _AssistantMessage, _ResultMessage, _Sys)
+            await asyncio.sleep(0)
+        asyncio.run(run({"fast_mode_state": "off", "fast_mode_disabled_reason": "sdk_opt_in_required"}))
+        reg = sb.read_reg(d, sid)
+        self.assertEqual(reg["liveFast"], "off", "adoption persists the state")
+        self.assertEqual(reg["liveFastReason"], "", "…with the curable reason already blanked")
+        # "the kernel restarts": a fresh construction from the same reg — the badge is there pre-turn
+        s2 = sb.SdkSession(be, sb.read_reg(d, sid))
+        self.assertEqual(s2.fast, "off", "seeded from the reg, no init needed")
+        self.assertEqual(s2.fast_reason, "")
+        # …and a session with NO thread at all reports it straight from the reg
+        live = be.live_sessions()
+        self.assertEqual(live[sid]["fast"], "off", "a dormant session's badge survives the restart")
+        self.assertEqual(live[sid]["fastReason"], "")
+
+    def test_connect_adopts_fast_state_from_the_initialize_response(self):
+        """A turn-less connect emits NO init message, so a session that merely reconnected (every
+        session, after a kernel restart) knew nothing until it next spoke — and a /model switch never
+        produced a badge at all. The initialize response the SDK stores at connect (get_server_info)
+        carries the same fast_mode_state/fast_mode_disabled_reason fields (verified live 2026-08-10 on
+        2.1.226), and _connect_once adopts it right beside the pre-turn context/model refresh."""
+        import asyncio
+        import inspect
+        d = tempfile.mkdtemp()
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        sid = "11111111-2222-3333-4444-eeeeeeeeeeee"
+        sb.write_reg(d, sid, {"sid": sid, "name": "n", "cwd": "/tmp", "alive": True})
+        s = sb.SdkSession(be, {"sid": sid, "name": "n", "cwd": "/tmp"})
+        self.assertEqual(s.fast, "", "unknown before the connect")
+        class _Client:
+            async def get_server_info(self):
+                return {"fast_mode_state": "off", "fast_mode_disabled_reason": "sdk_opt_in_required"}
+        s.client = _Client()
+        asyncio.run(s._do_adopt_server_info())
+        self.assertEqual(s.fast, "off", "the badge exists pre-turn")
+        self.assertEqual(s.fast_reason, "", "the curable opt-in reason never hides the toggle")
+        self.assertEqual(sb.read_reg(d, sid)["liveFast"], "off", "…and it persisted")
+        # the adoption is wired into the connect path, beside the pre-turn context refresh
+        self.assertIn("_do_adopt_server_info", inspect.getsource(sb.SdkSession._amain))
+
     def test_send_echo_authors_a_romp_nudge_as_romp_not_human(self):
         # the bug (the user 2026-06-28): an auto-nudge sent through send() echoed as a BLUE HUMAN "Follow-up"
         # instead of the GRAY "from romp" auto-nudge it is, because the echo hardcoded author="human". The echo

--- a/ui/webview/statusline-wrap.test.ts
+++ b/ui/webview/statusline-wrap.test.ts
@@ -1,0 +1,21 @@
+// A narrow pane must WRAP the statusline controls (dir, branch, mode/model/effort/fast badges, ctx
+// battery) onto extra rows, not clip them (the user 2026-08-10, whose controls vanished one by one as
+// the pane shrank: the no-wrap flex row shrank the dir/branch to nothing and pushed the rest past the
+// right edge). The footer is flex: 0 0 auto, so extra rows grow it instead of overflowing.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("the statusline wraps instead of clipping when the pane narrows", () => {
+  assert.match(CSS, /\.statusline \{[^}]*flex-wrap: wrap/);
+});
+
+test("the meta-badge cluster wraps between badges, keeping each badge whole", () => {
+  const rule = CSS.match(/\.spinner-meta \{[^}]*\}/)?.[0] || "";
+  assert.match(rule, /flex-wrap: wrap/);
+  // badges must not break INSIDE their own label — the container wraps, the badge doesn't
+  assert.match(rule, /white-space: nowrap/);
+});

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -490,7 +490,7 @@ body { display: flex; flex-direction: column; }
 body.composer-resizing { cursor: ns-resize; user-select: none; }
 .statusline {
   max-width: var(--chat-col); margin: 0 auto; padding: 7px 24px 0 44px;   /* left matches .thread's 44px gutter so the controls align with the transcript column */
-  display: flex; align-items: center; gap: 10px;
+  display: flex; flex-wrap: wrap; align-items: center; gap: 4px 10px;   /* a narrow pane wraps the controls onto extra rows — every control stays visible (the user 2026-08-10, whose branch/model/mode badges vanished as the pane shrank) */
 }
 /* Signal-style compose ROW (the user 2026-07-30): paperclip · pill input · round send — the layout every
    phone messenger trained thumbs on. Laid out by flex `order` so the shared markup (input before the two
@@ -741,8 +741,8 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   font-family: var(--mono);
   font-size: 0.92em;
   font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-  display: inline-flex; align-items: center; gap: 8px;
+  white-space: nowrap;   /* each badge stays one line; the container wraps BETWEEN badges instead */
+  display: inline-flex; flex-wrap: wrap; align-items: center; gap: 4px 8px; min-width: 0;
 }
 /* model / effort as click-to-change dropdowns */
 .meta-btn {


### PR DESCRIPTION
Two user-reported issues from 2026-08-10, one narrow-pane, one fast-mode.

## Statusline controls vanished as the pane narrowed
The chat statusline was a no-wrap flex row: shrinking the pane first crushed the dir/branch (min-width: 0 + overflow: hidden), then pushed the mode/model/effort/fast badges and the ctx battery past the right edge. The row now wraps (4px row gap), and the badge cluster wraps between badges, so every control stays visible; #footer is flex: 0 0 auto and simply grows. Test: `statusline-wrap.test.ts`.

## The fast toggle still appeared nowhere (after #265)
#265 cured the `sdk_opt_in_required` gating, but the badge still depended on the CLI's init message, which only streams WITH a turn. So after every kernel restart each session's fast state was unknown (no badge) until that session next spoke, and a `/model` switch to Opus never produced one at all (runtime set_model opens no turn). Verified live against the running kernel: only the sessions that had spoken since the 10:57 restart carried `fast: "off"`; every dormant one carried `""`.

Two legs, both event-based:
- **Connect-time adoption**: the initialize response the SDK stores at connect (`get_server_info`) carries the same `fast_mode_state`/`fast_mode_disabled_reason` fields (verified live on claude 2.1.226), so `_connect_once` adopts it beside the pre-turn context/model refresh.
- **Reg persistence** (the liveModel pattern): adoption writes `liveFast`/`liveFastReason`, the constructor seeds from them, and a dormant session (no thread after a restart) now reports them straight from the reg in `live_sessions` - it previously omitted the fields entirely.

Both paths share one `_adopt_fast_state` (same `_fast_expect` one-shot, same `sdk_opt_in_required` cure). Tests: `test_fast_state_survives_a_kernel_restart_via_the_reg`, `test_connect_adopts_fast_state_from_the_initialize_response`.

Suites: 4146 Python + 1782 node, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)