### PR TITLE
New tabs paint at once: targeted one-session push, per-backend CLI-up events, honest provisional chip

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3899,7 +3899,7 @@ def _reap_if_cancelled(name):
 def _spawn_session(name, cwd=None):
     """Create a detached romp session named `name` — the same launch the old TS backend ran
     (`romp new -t --detach <name>`, tmux-backend.ts). Threaded so the ~seconds-long launch never blocks the WS
-    recv loop; the 4s pusher then delivers the new tab and closes the webview's 'Opening…' modal. Scrub
+    recv loop; the targeted push below then delivers the new tab. Scrub
     TMUX* so the child launcher never thinks it is already inside a tmux client. `cwd` is the session's
     working directory (validated by _resolve_create_dir); None falls back to the kernel default."""
     cwd = cwd or _default_create_dir()
@@ -3910,7 +3910,13 @@ def _spawn_session(name, cwd=None):
     except Exception:
         sys.stderr.write("spawn '%s': %s\n" % (name, traceback.format_exc()))
     _reap_if_cancelled(name)   # the ✕ may have fired while this spawn was in flight
-    _push_all()   # surface the new tab promptly (the periodic pusher would catch it within 4s anyway)
+    # Surface the new tab NOW — one targeted single-session push, not the old inline _push_all(): that
+    # duplicated the whole fleet build on this thread (against the push-architecture rule) and still left
+    # the tab's freshness to chance. The dirty wake covers feed/timeline on the next cycle.
+    sid = _live_names(_tmux_sessions()).get(name)
+    if sid:
+        _push_session_now(sid)
+    _mark_views_dirty()
 
 
 def _pick_identity_color(now=None):
@@ -3951,13 +3957,17 @@ def _create_sdk_session(nm, cwd, auth=""):
     thread, duplicating the rebuild the pusher (woken by spawn's poke) was already doing. Order matters:
     focus FIRST — setActive holds the sid client-side, so the tab lands already-selected whenever the
     pusher's build arrives — then the dirty-mark wake. Never a synchronous fleet build on this path
-    (the push-architecture rule, 2026-07-05)."""
+    (the push-architecture rule, 2026-07-05) — but DO push this ONE session's tab+payload directly
+    (_push_session_now, one near-free transcript-less build): the dirty wake alone left the tab riding
+    the next full cycle, ~5-6s on a busy fleet, all of it spent staring at the provisional dots
+    (measured live, the user 2026-08-10)."""
     bg, fg = _pick_identity_color()   # fleet-aware: only the kernel sees BOTH backends' live sessions
     sid = _sdk().spawn(nm, cwd, bg, fg, auth=auth)
     _sdk().connect(sid)    # eager-connect so the model lists immediately, not only after the 1st message
     _set_hidden_tab(sid, False)
     _reveal_chat({"type": "focus", "id": sid})
     _mark_views_dirty()
+    _push_session_now(sid)   # the tab the user is staring at, ahead of the woken cycle
     return sid
 
 
@@ -4042,6 +4052,7 @@ def _sdk_locked():
             _sdk_backend = sbmod.SdkBackend(
                 jd.STATE, _claude_bin(), _send_to_app,
                 poke=_producer_wake.set, push=_pusher_wake.set,
+                push_session=_push_session_now,   # targeted one-session push for per-session chip events (connect)
                 mcp_config=(str(_SDK_MCP) if _SDK_MCP.exists() else None),
                 append_prompt_path=(str(_SDK_PROMPT) if _SDK_PROMPT.exists() else None),
                 log=lambda m: sys.stderr.write("sdk-backend: %s\n" % m),
@@ -12266,15 +12277,20 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
         chip = _session_chip(sid, sess["path"], session, tm, now)   # THE shared derivation — identical to the timeline lane (the user 2026-07-03)
         # A session whose transcript DOESN'T EXIST YET is OPENING, whatever the snapshot claims (the
         # user 2026-08-05: a just-spawned tab said "Working" over a clock with no honest base). The
-        # deciding event is per-backend. tmux: the transcript's first record — the only observable —
-        # lands, discover() sees it, and the normal derivation takes over. SDK: the backend KNOWS the
-        # earlier designed event, the handshake (tm.connected) — a fresh SDK session writes NO
-        # transcript until its first turn, so keying its chip on the file left a fully-up, idle
-        # session wearing the opening dots until the user's first message, indefinitely (the user
-        # 2026-08-08, who read minutes of dots as creation still running). Never for an override
-        # render (a closed episode's path is historical).
+        # deciding event — "the CLI is up" — is per-backend. SDK: the handshake (tm.connected) — a
+        # fresh SDK session writes NO transcript until its first turn, so keying its chip on the file
+        # left a fully-up, idle session wearing the opening dots until the user's first message,
+        # indefinitely (the user 2026-08-08, who read minutes of dots as creation still running).
+        # tmux: the CLI's statusline hook publishing its first @claude-state — the same wait, the
+        # matching event (2026-08-10; the transcript's first record only lands with the first MESSAGE,
+        # so keying on the file alone held a fully-up tmux session on the dots until the user typed).
+        # SDK snapshots always carry a non-empty state ("waiting" from birth), so the state leg is
+        # tmux-only by construction (backend == "tmux"). Never for an override render (a closed
+        # episode's path is historical).
+        cli_up = bool(tm.get("connected")) or \
+            (tm.get("backend") == "tmux" and bool((tm.get("state") or "").strip()))
         if chip in ("working", "ready") and not path_override and not os.path.exists(sess["path"]) \
-                and not tm.get("connected"):
+                and not cli_up:
             chip = "opening"
         faded = chip == "ready" and bool(tm["since"]) and now - tm["since"] > 3600
         # apiTooLong distinguishes a "prompt is too long" block (on YOU → red dashed tab) from a TRANSIENT API
@@ -16726,6 +16742,45 @@ def _push_all():
     with _clients_lock:
         clients = list(_clients)
     _push(clients)
+
+
+def _push_session_now(sid):
+    """ONE session's tab strip + chat payload to every connected chat client, immediately — the targeted
+    push for a per-session event (a create, the SDK connect handshake). A just-created session used to
+    become visible only on the periodic pusher's NEXT full cycle, and on a busy fleet a cycle runs
+    seconds (measured live 2026-08-10: the tab appeared 5-6s after the create landed, the opening→ready
+    flip 12s after, while the kernel had known the session since 0.4s) — so the one tab the user was
+    guaranteed to be staring at painted last. This builds exactly one session — a transcript-less build
+    is near-free — and sends the tab strip plus that payload directly; the next full cycle re-sends both
+    idempotently (per-client dedup absorbs the overlap).
+
+    Deliberately NOT touched here: the shared delta baseline (_prev_chat_events) — only a push that
+    reaches every client may advance it (the 2026-07-28 stranded-delta lesson), and change_from=0 below
+    always takes the full-session form so no client's tail state can be left ahead of the baseline; and
+    the build cache/_last_tab_order bookkeeping, which belong to the pusher. Never a fleet build (the
+    push-architecture rule, 2026-07-05): callers sit on WS-handler / spawn / backend threads."""
+    sid = str(sid)
+    with _clients_lock:
+        targets = [c for c in _clients if c["app"] == "chat" and c.get("alive", True)]
+    if not targets:
+        return
+    try:
+        now = int(time.time())
+        tmux = _tmux_sessions()
+        chat_list = _chat_tab_sessions(now, tmux)
+        if not any(s["sid"] == sid for s in chat_list):
+            return                                   # hidden / raced a teardown — the periodic pusher owns the rest
+        tab_order = [s["sid"] for s in chat_list]
+        tab_meta = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])} for s in chat_list]
+        m = build_session(sid, now, tmux)
+        if not m:
+            return
+        ms = json.dumps(m)
+        for c in targets:
+            _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta})
+            _send_chat(c, m, ms, 0, True)            # change_from 0 → always the full-session form
+    except Exception:
+        sys.stderr.write("push-session-now (%s): %s\n" % (sid, traceback.format_exc()))
 
 
 # ───────────────────────── producer + push threads ─────────────────────────

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1712,6 +1712,12 @@ class SdkSession:
                 async with ClaudeSDKClient(options=opts) as client:
                     connected = True
                     self.client = client
+                    # The handshake IS the "this session is open" event (snapshot `connected`, the flip
+                    # the kernel's opening chip stands down on) — push THIS session now. Left to the
+                    # periodic cycle, a fresh session wore the opening dots seconds after its CLI was
+                    # ready to take a message (measured live 2026-08-10: connect done ~1.5s after
+                    # create, the ready chip landing at 5-12s with the cycle).
+                    self.backend._push_session(self.sid)
                     self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero
                     self._last_usage_totals = {}  # …and its cumulative token counters
                     # The CLI is demonstrably up, so any recorded launch failure is HISTORY — clear it
@@ -2544,6 +2550,7 @@ class SdkBackend:
     pushing to clients and a few launch parameters that mirror the tmux launch."""
 
     def __init__(self, state_dir, claude_bin: str, notify, poke=None, push=None,
+                 push_session=None,
                  mcp_config: str | None = None, append_prompt_path: str | None = None,
                  log=None, reconcile: bool = False):
         self.state_dir = Path(state_dir)
@@ -2551,6 +2558,9 @@ class SdkBackend:
         self._notify = notify              # notify(app, msg) -> push to clients (kernel._send_to_app)
         self._poke_cb = poke               # wake the kernel's producer/judges (optional)
         self._push_cb = push               # wake the kernel's PUSHER → immediate chat push (live tail)
+        self._push_session_cb = push_session   # targeted ONE-session push (kernel _push_session_now) for
+        #   per-session chip events (the connect handshake): a wake alone leaves the flip riding the next
+        #   full push cycle, which runs seconds on a busy fleet (the user 2026-08-10)
         self.mcp_config = mcp_config
         self.append_prompt_path = append_prompt_path
         self._log_cb = log
@@ -3955,6 +3965,22 @@ class SdkBackend:
                 self._push_cb()
             except Exception as e:
                 self._log("chat push wake failed: %s" % e)
+
+    def _push_session(self, sid: str) -> None:
+        """Targeted one-session push (kernel _push_session_now), for per-session events the chat chip
+        keys on — today the connect handshake, the exact flip the opening chip stands down on. THREADED:
+        the callback builds and serializes that session's payload, which must never run on the session's
+        asyncio loop thread (it would stall the stream it is reporting on). Falls back to the plain
+        pusher wake when the kernel didn't wire the callback (older kernel / tests)."""
+        if not self._push_session_cb:
+            self._wake_push()
+            return
+        def run():
+            try:
+                self._push_session_cb(sid)
+            except Exception as e:
+                self._log("session push (%s) failed: %s" % (sid, e))
+        threading.Thread(target=run, name="sdk-push-session", daemon=True).start()
 
     def live_atoms(self, sid: str) -> list:
         """The session's in-memory live-tail atoms (newest last), for build_session to merge ahead of disk."""

--- a/tests/test_kernel_opening.py
+++ b/tests/test_kernel_opening.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""A just-created session: the OPENING chip and the targeted single-session push (2026-08-10).
+
+Two failures this closes, both measured live against a busy fleet:
+- The opening chip's stand-down event was per-backend but INCOMPLETE: SDK had the connect handshake
+  (`connected`), tmux had only "the transcript's first record" — which lands with the first MESSAGE,
+  so a fully-up tmux CLI wore the opening dots until the user typed. The matching tmux event is the
+  CLI's statusline hook publishing its first @claude-state.
+- A new session's tab + payload rode the periodic FULL push cycle, which runs seconds on a busy fleet
+  (tab appeared 5-6s after the create, opening→ready 12s, while /sessions knew the session at 0.4s).
+  _push_session_now sends the tab strip + that ONE session's payload to chat clients directly; the
+  create paths and the SDK connect handshake fire it.
+
+SYNTHETIC fixtures only: invented text, placeholder UUIDs.
+"""
+import json
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_opening", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+def _row(**over):
+    """A Sessions.live()-shaped lane row with every key build_session touches."""
+    r = {"state": "", "since": None, "model": "", "effort": "", "context": None,
+         "compactPct": None, "color": None, "mode": "", "backend": "tmux"}
+    r.update(over)
+    return r
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+                      km.NAMES, km._tmux_sessions, km._sdk)
+        names = td / "names"; names.mkdir()
+        proj = td / "projects"; proj.mkdir()
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
+        for d in (jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR):
+            d.mkdir()
+        jd.STATE = td
+        km.NAMES = names
+        km._sdk = lambda: None            # no SDK backend: the synthesized tmux path is under test
+        km._parse_cache.clear()
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+         km.NAMES, km._tmux_sessions, km._sdk) = self.saved
+        self.td.cleanup()
+
+
+class OpeningChipStandsDownOnTheBackendEvent(_Base):
+    """build_session's chip for a session whose transcript doesn't exist yet: OPENING until the
+    backend's own "CLI is up" event — tmux's first published @claude-state / SDK's handshake —
+    never until the first transcript record (that lands only with the first message)."""
+
+    def _chip(self, row):
+        tmux = {SID: row}
+        km._tmux_sessions = lambda: tmux
+        m = km.build_session(SID, NOW, tmux)
+        self.assertIsNotNone(m, "a live transcript-less session still gets a frame")
+        return m["status"]["state"]
+
+    def test_tmux_booting_cli_reads_opening(self):
+        # spawned (the lane row exists — the launcher sets @romp-session-id at creation) but the
+        # CLI's statusline hook hasn't published a @claude-state yet → still opening
+        self.assertEqual(self._chip(_row(state="")), "opening")
+
+    def test_tmux_first_claude_state_ends_opening(self):
+        # the hook published "waiting": the CLI is up at its prompt — no transcript exists yet
+        # (the first record only lands with the first message), and the chip must NOT wait for it
+        self.assertEqual(self._chip(_row(state="waiting", since=NOW - 5)), "ready")
+
+    def test_sdk_pre_handshake_reads_opening(self):
+        # SDK snapshots carry a non-empty state from birth ("waiting"), so the state leg must not
+        # stand the override down for them — only the handshake does
+        self.assertEqual(self._chip(_row(state="waiting", backend="sdk", connected=False)), "opening")
+
+    def test_sdk_handshake_ends_opening(self):
+        self.assertEqual(self._chip(_row(state="waiting", backend="sdk", connected=True)), "ready")
+
+
+class PushSessionNow(_Base):
+    """_push_session_now: one session's tab strip + chat payload to every CHAT client, directly."""
+
+    def setUp(self):
+        super().setUp()
+        # a live tmux session WITH a transcript (the ordinary shape; the transcript-less shape is
+        # covered above) — pdir keyed like discover expects
+        cdir = Path(self.td.name) / "work"; cdir.mkdir()
+        pdir = jd.PROJECTS / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        rec = {"type": "user", "timestamp": "2026-06-11T00:00:00.000Z", "uuid": "u1",
+               "parentUuid": None, "promptSource": "typed",
+               "message": {"role": "user", "content": "hello there"}}
+        (pdir / (SID + ".jsonl")).write_text(json.dumps(rec) + "\n")
+        (jd.NAMES / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
+        self.tmux = {SID: _row(state="waiting", since=NOW - 5)}
+        km._tmux_sessions = lambda: self.tmux
+        self.sent = []
+        self.client = {"app": "chat", "alive": True, "wid": "", "qbytes": 0,
+                       "send": lambda s: self.sent.append(json.loads(s))}
+        self.other = {"app": "feed", "alive": True, "wid": "", "qbytes": 0,
+                      "send": lambda s: self.fail("a feed client must not receive chat frames")}
+        self.saved_clients = list(km._clients)
+        with km._clients_lock:
+            km._clients[:] = [self.client, self.other]
+
+    def tearDown(self):
+        with km._clients_lock:
+            km._clients[:] = self.saved_clients
+        super().tearDown()
+
+    def test_sends_the_tab_strip_and_that_sessions_payload(self):
+        km._push_session_now(SID)
+        types = [m["type"] for m in self.sent]
+        self.assertIn("tabOrder", types, "the tab strip lands so the client can place the tab")
+        self.assertIn("session", types, "…and the session payload fills it in")
+        tabs = next(m for m in self.sent if m["type"] == "tabOrder")
+        self.assertIn(SID, tabs["order"])
+        self.assertEqual(next(t["name"] for t in tabs["tabs"] if t["id"] == SID), "web")
+        sess = next(m for m in self.sent if m["type"] == "session")
+        self.assertEqual(sess["id"], SID)
+        self.assertLess(types.index("tabOrder"), types.index("session"),
+                        "strip first — a session frame for an unknown tab would have nowhere to land")
+
+    def test_idempotent_with_the_periodic_pusher(self):
+        # the next full cycle re-sends both slots; per-client dedup absorbs the overlap, so a second
+        # identical targeted push sends NOTHING new
+        km._push_session_now(SID)
+        n = len(self.sent)
+        km._push_session_now(SID)
+        self.assertEqual(len(self.sent), n, "unchanged payloads dedup — no re-send storm")
+
+    def test_a_hidden_or_unknown_sid_sends_nothing(self):
+        km._set_hidden_tab(SID, True)
+        try:
+            km._push_session_now(SID)
+            self.assertEqual(self.sent, [], "a ×-hidden tab stays hidden — the pusher owns the rest")
+            self.sent.clear()
+            km._push_session_now("99999999-8888-7777-6666-555555555555")
+            self.assertEqual(self.sent, [], "an unknown sid is not an error, just a no-op")
+        finally:
+            km._set_hidden_tab(SID, False)
+
+    def test_the_shared_delta_baseline_is_left_alone(self):
+        # only a push that reaches EVERY client may advance _prev_chat_events (the 2026-07-28
+        # stranded-delta lesson) — the targeted push must not touch it
+        km._prev_chat_events.pop(SID, None)
+        km._push_session_now(SID)
+        self.assertNotIn(SID, km._prev_chat_events)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -2825,5 +2825,47 @@ class LiveAtomKinds(unittest.TestCase):
         self.assertEqual(len(be._live[sid]), 3, "read-only: the live tail is untouched")
 
 
+class PushSessionCallback(unittest.TestCase):
+    """_push_session — the connect handshake's targeted one-session push (2026-08-10). The handshake is
+    the exact event the kernel's opening chip stands down on, and a plain pusher wake left that flip
+    riding the next FULL push cycle (seconds on a busy fleet) — so the flip pushes its one session
+    directly. Threaded, because the callback builds+serializes a payload and must never run on the
+    session's asyncio loop thread."""
+
+    SID = "11111111-2222-3333-4444-555555555555"
+
+    def test_threaded_callback_receives_the_sid(self):
+        got, done = [], threading.Event()
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None,
+                           push_session=lambda sid: (got.append(sid), done.set()))
+        be._push_session(self.SID)
+        self.assertTrue(done.wait(5), "the callback fires, on its own thread")
+        self.assertEqual(got, [self.SID])
+
+    def test_without_the_callback_it_falls_back_to_the_pusher_wake(self):
+        # an older kernel (or a test) that didn't wire push_session still gets the pre-existing
+        # behavior: the periodic pusher wake, never a silent no-op
+        woke = []
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None,
+                           push=lambda: woke.append(True))
+        be._push_session(self.SID)
+        self.assertEqual(woke, [True])
+
+    def test_a_failing_callback_is_contained_and_logged(self):
+        logs = []   # the ctor may log too (a missing-SDK note) — poll for THIS failure's line
+
+        def boom(sid):
+            raise RuntimeError("nope")
+
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None,
+                           push_session=boom, log=logs.append)
+        be._push_session(self.SID)   # must not raise into the caller (the connect path)
+        deadline = time.time() + 5
+        while time.time() < deadline and not any("session push" in str(m) for m in logs):
+            time.sleep(0.01)
+        self.assertTrue(any("session push" in str(m) for m in logs),
+                        "the failure is reported, not swallowed: %r" % logs)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ui/webview/opening-state.test.ts
+++ b/ui/webview/opening-state.test.ts
@@ -16,19 +16,38 @@ const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
 
 test("the kernel reports OPENING while the transcript doesn't exist — never a working chip on a broken clock", () => {
   assert.ok(KERNEL.includes('if chip in ("working", "ready") and not path_override and not os.path.exists(sess["path"]) \\'));
-  assert.ok(KERNEL.includes('and not tm.get("connected"):'));
+  assert.ok(KERNEL.includes("and not cli_up:"));
   assert.ok(KERNEL.includes('chip = "opening"'));
 });
 
-// The deciding event is per-backend (the user 2026-08-08, who read minutes of dots as creation still
-// running): a fresh SDK session writes NO transcript until its first turn, so keying its chip on the
-// file left a fully-up idle session on the opening dots indefinitely. The SDK handshake (snapshot
-// `connected`, set the moment the client context opens) stands the override down; tmux — whose only
-// observable IS the file — keeps the transcript's first record as its event.
-test("the SDK handshake ends OPENING before any transcript exists", () => {
+// The deciding event — "the CLI is up" — is per-backend (the user 2026-08-08, who read minutes of dots
+// as creation still running): a fresh session of EITHER backend writes NO transcript until its first
+// turn, so keying the chip on the file alone held a fully-up idle session on the opening dots until the
+// user typed. SDK: the handshake (snapshot `connected`, set the moment the client context opens).
+// tmux: the CLI's statusline hook publishing its first @claude-state (2026-08-10) — the matching event,
+// since the transcript's first record only lands with the first MESSAGE.
+test("each backend's own 'CLI is up' event ends OPENING before any transcript exists", () => {
   const SDK = fs.readFileSync(path.join(ROOT, "kernel", "sdk_backend.py"), "utf8");
   assert.ok(SDK.includes('"connected": bool(self.client)'), "the snapshot carries the handshake event");
   assert.ok(KERNEL.includes('"connected": bool(st.get("connected"))'), "the live merge threads it through");
+  assert.ok(KERNEL.includes('cli_up = bool(tm.get("connected")) or \\'), "SDK: the handshake");
+  assert.ok(KERNEL.includes('(tm.get("backend") == "tmux" and bool((tm.get("state") or "").strip()))'),
+    "tmux: the first published @claude-state");
+});
+
+// A per-session chip event must not ride the periodic full push cycle, which runs SECONDS on a busy
+// fleet (measured live 2026-08-10: the tab appeared 5-6s after the create landed, the opening→ready
+// flip 12s after, while the kernel had known the session since 0.4s). The create paths and the SDK
+// connect handshake each fire the kernel's targeted one-session push, so the one tab the user is
+// guaranteed to be staring at paints first, not last.
+test("create + connect push the ONE session directly instead of waiting out a full push cycle", () => {
+  const SDK = fs.readFileSync(path.join(ROOT, "kernel", "sdk_backend.py"), "utf8");
+  assert.ok(KERNEL.includes("def _push_session_now(sid):"), "the targeted push exists");
+  assert.match(KERNEL, /_mark_views_dirty\(\)\s*\n\s*_push_session_now\(sid\)/,
+    "an SDK create pushes its tab at once");
+  assert.ok(KERNEL.includes("push_session=_push_session_now,"), "the backend is wired to it");
+  assert.match(SDK, /self\.client = client\s*\n(\s*#[^\n]*\n)*\s*self\.backend\._push_session\(self\.sid\)/,
+    "the handshake — the flip the opening chip stands down on — pushes immediately");
 });
 
 test("the statusline shows Opening + dots for BOTH the pre-payload tab and the kernel's opening state", () => {

--- a/ui/webview/provisional.test.ts
+++ b/ui/webview/provisional.test.ts
@@ -57,7 +57,15 @@ test("creating a session opens the provisional tab instead of a modal", () => {
   assert.match(RENDER, /openProvisional\(req\);/);
   assert.doesNotMatch(RENDER, /showOpeningModal/, "the modal is gone, not merely hidden");
   assert.doesNotMatch(RENDER, /hideOpeningModal/);
-  assert.match(RENDER, /status: \{ state: "working", sinceEpoch/, "the chip is honest: romp IS starting it");
+  // "opening", never "working": the working chip renders an elapsed timer off sinceEpoch, and a
+  // provisional tab has no honest work clock — the old "working" seed (in SECONDS, at that) showed
+  // "Working" + an epoch-sized number until the first kernel payload arrived (the user 2026-08-10).
+  assert.match(RENDER, /status: \{ state: "opening", sinceEpoch: Date\.now\(\) \}/,
+    "the chip says what this phase IS — the session is opening");
+  assert.doesNotMatch(RENDER, /state: "working", sinceEpoch: Math\.floor/, "the broken-clock seed is gone");
+  // …and the tab strip shows the accent loader dot for the opening state, so the starting tab has a cue
+  assert.match(RENDER, /else if \(st === "opening"\) tab\.appendChild\(el\("span", "tab-dot opening"\)\);/);
+  assert.match(CSS, /\.tab-dot\.opening \{ background: var\(--accent\); animation: opening-line-pulse/);
   assert.match(RENDER, /order\.push\(id\);/, "the tab survives reconcileTabOrder as a not-yet-kernel-known extra");
 });
 

--- a/ui/webview/provisional.ts
+++ b/ui/webview/provisional.ts
@@ -3,7 +3,7 @@
 // Creating a session used to raise a modal "Opening session…" over the whole pane, and you waited: the
 // kernel resolves the directory, spawns tmux or connects the SDK, and the first transcript poll comes
 // back — seconds, sometimes many. Nothing could be typed in that gap, and the only thing on screen was a
-// dialog with three dots. So the tab appears at once with a working chip and a live composer; anything
+// dialog with three dots. So the tab appears at once in the OPENING state with a live composer; anything
 // typed is held and flushed the moment the real session lands, and a create that FAILS says so in a
 // dialog instead of the cue quietly timing out after thirty seconds.
 //

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3571,6 +3571,10 @@ function renderTabs() {
     // red tab highlight instead (the user 2026-06-16).
     if (st === "working") tab.appendChild(el("span", "tab-dot"));
     else if (st === "awaitingBg") tab.appendChild(el("span", "tab-dot await"));
+    // OPENING (a provisional tab, or the kernel's own opening chip): the accent loader dot — the session
+    // is starting, and a tab with no cue at all read as dead (the user 2026-08-10). Same pulse as the
+    // statusline's opening dots; never the solid working yellow, which claims work that isn't happening.
+    else if (st === "opening") tab.appendChild(el("span", "tab-dot opening"));
     // compacting → a tiny animated compaction bar before the name (the tab gets no outline for this state,
     // so the bar IS the cue). A teal fill whose right edge slides left and loops — the same "compression"
     // motion as the statusline ctx-scan bar (.ctx-compress), miniaturised. Replaces the static ⇲ glyph the
@@ -4093,8 +4097,10 @@ let pickAllowNew = false;
 // could do nothing with, watching three dots. See ./provisional.ts for why the id carries no colon.
 //
 // `pendingNewSession` is the NAME the created session will arrive under; it is the only join available,
-// since the kernel mints the id. The provisional tab carries a working chip (romp genuinely is starting
-// it), a live composer, and anything typed into it, held until the real session lands.
+// since the kernel mints the id. The provisional tab carries the OPENING state (the same "Opening
+// session" dots the kernel's own opening chip renders — it seeded "working" once, which put a Working
+// chip over an epoch-sized clock in the statusline until the first real payload arrived; the user
+// 2026-08-10), a live composer, and anything typed into it, held until the real session lands.
 let pendingNewSession: string | null = null;
 let provisionalId: string | null = null;
 const provisionalQueue: string[] = [];
@@ -4118,8 +4124,13 @@ function openProvisional(req: CreateReq): void {
   pendingNewSession = display;
   const id = mintProvisionalId(Date.now().toString(36) + Math.random().toString(36).slice(2));
   provisionalId = id;
+  // state "opening", NOT "working": updateStatusline renders the working chip with an elapsed timer off
+  // sinceEpoch, and a provisional tab has no honest work clock — the seed showed "Working" + a giant
+  // number for however long the first kernel payload took (the user 2026-08-10, who read it as "a random
+  // string of numbers"). "opening" is the designed vocabulary for exactly this phase, and the kernel's
+  // first payload for the real session continues it seamlessly. sinceEpoch is MILLISECONDS everywhere.
   sessions.set(id, { id, name: display, color: null, events: [],
-                     status: { state: "working", sinceEpoch: Math.floor(Date.now() / 1000) } });
+                     status: { state: "opening", sinceEpoch: Date.now() } });
   order.push(id);                          // a tab the kernel does not know yet survives reconcileTabOrder
   renderTabs();
   setActive(id);
@@ -4190,7 +4201,7 @@ function failProvisional(why: string): void {
   const s = sessions.get(id);
   // "closed" gives the tab the dead treatment (struck label, plain ✕) — but the composer stays LIVE
   // for a failed provisional (the read-only exemption below), since the held text must stay editable
-  if (s) s.status = { state: "closed", sinceEpoch: Math.floor(Date.now() / 1000) };
+  if (s) s.status = { state: "closed", sinceEpoch: Date.now() };   // ms, like every kernel payload
   setActive(id);                     // jump back to the failed thread BEFORE saying anything
   if (held) {
     drafts.set(id, held); persistDrafts();

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -148,6 +148,10 @@ body { display: flex; flex-direction: column; }
 /* WORKING: a small yellow dot left of the name (replaces the old yellow outline). */
 .tab-dot { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: var(--st-working-bg); }   /* solid — dot oscillation was distracting (the user 2026-06-16) */
 .tab-dot.await { background: var(--st-awaitbg-bg); }   /* awaiting-bg: the dot matches the straw chip (the user 2026-07-13) */
+/* OPENING: the accent loader dot — a session still starting is a WAIT, so it pulses like the statusline's
+   opening dots (the loading-state rule; the working dot above stays solid on purpose — that rule is about
+   real work, this one is about a load in progress). */
+.tab-dot.opening { background: var(--accent); animation: opening-line-pulse 1.2s ease-in-out infinite; }
 /* Vertical context gauge right of the name (the user 2026-08-08): the statusline battery rotated
    upright — fills bottom-up with the context-used %, in the SAME global-colormap colour (fill set
    inline by tabCtxGauge, render.ts), no % text. A faint track so an empty gauge still reads as


### PR DESCRIPTION
Opening a new tab left the user staring at "Opening session" dots for 5-12 seconds — sometimes until they typed — and occasionally flashed "Working" plus an epoch-sized number first (the user 2026-08-10).

Measured live against a busy fleet before the fix: the kernel's /sessions listed a created session at **0.4s**, but its tab reached the chat only at **5-6s** and the opening→ready flip at **12s**, while the bare SDK connect takes ~1.2s. Everything about the one tab the user is guaranteed to be watching rode the periodic FULL push cycle, which runs seconds long on a busy fleet. Verified end-to-end on a sandboxed kernel after the fix: tab at **1.3s**, ready at **2.1s**.

Three event-based changes plus a client seed fix:

- **`_push_session_now(sid)`** — one session's tab strip + chat payload to every chat client, directly (a transcript-less build is near-free). Fired from both create paths; replaces `_spawn_session`'s inline `_push_all()` (a fleet build on a spawn thread, against the push-architecture rule). The next full cycle re-sends idempotently (per-client dedup); the shared delta baseline is deliberately untouched (the 2026-07-28 stranded-delta lesson), and `change_from=0` keeps every send in the full-session form.
- **The SDK connect handshake fires that push** via a new backend callback (threaded off the loop thread, pusher-wake fallback when unwired) — the handshake is the exact event the opening chip stands down on, so *ready* lands when the CLI is up instead of one-to-two cycles later.
- **tmux's missing stand-down event**: the transcript's first record only lands with the first MESSAGE, so a fully-up tmux CLI wore the opening dots until the user typed. The CLI's statusline hook publishing its first `@claude-state` is tmux's "CLI is up" event, mirroring SDK's `connected` (SDK snapshots carry a non-empty state from birth, so the state leg is tmux-only by construction).
- **The provisional tab seeds state `"opening"`** (ms epoch) instead of `"working"` with a SECONDS epoch — the statusline rendered a Working chip + `Date.now()ms − seconds` as an elapsed timer, i.e. a giant number, until the first payload arrived. The tab strip gets an accent loader dot for the opening state (the pulse the statusline dots use), replacing the solid working-yellow dot that claimed work that wasn't happening.

Tests: `tests/test_kernel_opening.py` (chip stand-down per backend event; `_push_session_now` sends strip+payload, dedups, respects hidden tabs, leaves the delta baseline alone), `tests/test_sdk_backend.py::PushSessionCallback`, and updated source pins in `opening-state.test.ts` / `provisional.test.ts`. Both suites green: 4155 Python, 1781 node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)