### PR TITLE
One liveness snapshot per pusher cycle + cached reg parses: the kernel CPU burn, fixed

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5518,10 +5518,24 @@ def _num(x):
     return int(x) if x.lstrip("-").isdigit() else None
 
 
+# One liveness snapshot per PUSHER CYCLE (the 2026-08-10 CPU fix). Every Sessions.live() read forks
+# `tmux list-sessions` and sweeps the SDK reg registry — and the reads hide at every depth of the
+# build stack (_push, the tick jobs, _bg_live_norm, _compacting_now, build_feed's per-session gate…),
+# so one cycle was paying DOZENS of forks+sweeps: profiling attributed the pusher as the kernel's
+# hottest thread, ~50-90% of a core sustained. The scope is the EVENT (one cycle), not a TTL, and it
+# is THREAD-CONFINED: only the thread that opened the scope (the pusher, for exactly one cycle) reads
+# its snapshot; a WS handler or backend thread calling _tmux_sessions() concurrently still gets a
+# fresh read. Within a cycle the jobs always saw a snapshot aged by whatever ran before them — the
+# scope makes that one honest snapshot instead of dozens of marginally-different ones.
+_live_scope = threading.local()   # .snapshot = the current cycle's liveness map, else absent
+
+
 def _tmux_sessions():
     """Live lane metadata across both backends — the fleet-wide liveness merge. Thin delegator kept for its
-    ~20 call sites; the impl is Sessions.live() (tmux @claude-* vars + the SDK backend's live_sessions)."""
-    return Sessions.live()
+    ~20 call sites; the impl is Sessions.live() (tmux @claude-* vars + the SDK backend's live_sessions).
+    Inside a pusher cycle (this thread's _live_scope), the cycle's one snapshot is served instead."""
+    snap = getattr(_live_scope, "snapshot", None)
+    return snap if snap is not None else Sessions.live()
 
 
 # ── tunnel concierge: attach a remote kernel over SSH for the FEDERATED dashboard ────────────────
@@ -12394,8 +12408,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
             "events": events, "status": status, "ledger": ledger,
             # SDK sessions gate the box on the backend's LIVE task set (the CLI's task lifecycle stream —
             # authoritative, terminal-cleared); the spawned_at heuristic remains the tmux/no-snapshot fallback.
+            # Reads the CALLER's snapshot — a fresh _tmux_sessions() here cost a tmux fork + a reg sweep
+            # per session build, on the pusher's hottest path (the 2026-08-10 CPU fix).
             "bgTasks": _bg_tasks(sess["path"], _sdk_spawned_at(sid),
-                                 live=(_tmux_sessions().get(str(sid)) or {}).get("bgTasks")),
+                                 live=(tmux.get(str(sid)) or {}).get("bgTasks")),
             # per-session view flags (the user 2026-06-26): the tab right-click menu toggles these too, mirroring
             # the timeline lane's feed checkbox + postal mailbox. Same flags + legacy fallback as build_timeline.
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),
@@ -16575,16 +16591,18 @@ def _note_chat_divergence(sid, name, chat_state, row_state, now):
         pass
 
 
-def _push(targets, connect=False):
+def _push(targets, connect=False, tmux=None):
     """Build the payloads once (cached parses) and send each target only the pieces that CHANGED for it.
     Drives both the periodic pusher (all clients) and a fresh connect (one client): a new/reconnecting
     client (empty dedup) gets the full state; steady-state sends only diffs. Builds only the apps the
     targets actually need (no timeline parse with no timeline client). connect=True (a fresh client) serves
-    the pusher-warmed feed/timeline WITHOUT rebuilding, so a reload is instant (the user 2026-06-25)."""
+    the pusher-warmed feed/timeline WITHOUT rebuilding, so a reload is instant (the user 2026-06-25).
+    `tmux` lets the periodic pusher hand down its cycle's ONE liveness snapshot (see _pusher_cycle);
+    other callers (connect pushes, ad-hoc _push_all) leave it None and pay their own read."""
     if not targets:
         return
     now = int(time.time())
-    tmux = _tmux_sessions()                       # one tmux read per push, shared by all builders
+    tmux = _tmux_sessions() if tmux is None else tmux   # one liveness read per push, shared by all builders
     _seen_live.update(tmux)                       # remember who's been alive → keep their tab when they die
     want_chat = any(c["app"] == "chat" for c in targets)
     # The FLEET connects as its OWN app (the user 2026-06-29) so we build its per-session ledgers EVEN when no
@@ -16738,10 +16756,10 @@ def _push(targets, connect=False):
         _clients[:] = [c for c in _clients if c.get("alive", True)]
 
 
-def _push_all():
+def _push_all(tmux=None):
     with _clients_lock:
         clients = list(_clients)
-    _push(clients)
+    _push(clients, tmux=tmux)
 
 
 def _push_session_now(sid):
@@ -17421,49 +17439,76 @@ def _producer():
         _producer_wake.wait(3)
 
 
+def _pusher_cycle():
+    """ONE pusher cycle: the client push + every tick job, all sharing ONE liveness snapshot. Split out
+    of the loop so a test can run a single cycle and count the snapshot reads.
+
+    The snapshot hoist is the 2026-08-10 CPU fix: each _tmux_sessions() forks `tmux list-sessions`
+    (~15ms) and re-reads every SDK reg file (~7ms across a couple hundred), and this cycle used to
+    take NINE of them — one in _push plus one per tick job — at the 0.5s cadence: ~200-350ms of CPU
+    per cycle before any build work, sampled live as the kernel's single hottest thread (~50-90% of a
+    core, three quarters of total process CPU). Every job here already took the map as a parameter by
+    design; they now all receive the same one, taken once at cycle start. The jobs tolerate the
+    few-hundred-ms staleness by construction — they always saw a snapshot aged by however many jobs
+    ran before them."""
+    with _clients_lock:
+        any_client = bool(_clients)
+    now = int(time.time())
+    tmux = _tmux_sessions()               # THE cycle's liveness snapshot — one fork + one reg sweep
+    _live_scope.snapshot = tmux           # …served to every read on THIS thread until the cycle ends,
+    #                                       however deep it hides (_bg_live_norm, _compacting_now,
+    #                                       build_feed's per-session gates) — see _live_scope
+    try:
+        _pusher_cycle_jobs(now, tmux, any_client)
+    finally:
+        _live_scope.snapshot = None
+
+
+def _pusher_cycle_jobs(now, tmux, any_client):
+    if any_client:
+        _push_all(tmux=tmux)
+    # (the WS keepalive lives on its own _heartbeat thread — NOT here — so a slow push can't starve it)
+    try:                                  # Auto Nudge runs server-side even with no browser open (cheap when off)
+        _auto_nudge_tick(now, tmux)
+    except Exception:
+        sys.stderr.write("auto-nudge: %s\n" % traceback.format_exc())
+    try:                                  # EXACT retraction first: dispatches returned → the stamp is spent
+        _lift_spent_awaiting(now, tmux)
+    except Exception:
+        sys.stderr.write("awaiting-lift: %s\n" % traceback.format_exc())
+    try:                                  # slow one-shot wake for a session asleep behind a stale awaiting stamp
+        _awaiting_backstop_tick(now, tmux)
+    except Exception:
+        sys.stderr.write("awaiting-backstop: %s\n" % traceback.format_exc())
+    try:                                  # Interrupt → Blocked runs EVERY push, independent of the nudge toggle
+        _interrupt_block_tick(now, tmux)
+    except Exception:
+        sys.stderr.write("interrupt-block: %s\n" % traceback.format_exc())
+    try:                                  # hitting a usage limit auto-engages the retry-pause (before the resume check)
+        _auto_pause_on_limit()
+    except Exception:
+        sys.stderr.write("auto-pause-on-limit: %s\n" % traceback.format_exc())
+    try:                                  # a monthly spend cap (no readable reset) also engages it — else it storms forever
+        _auto_pause_on_spend_limit(now, tmux)
+    except Exception:
+        sys.stderr.write("auto-pause-on-spend-limit: %s\n" % traceback.format_exc())
+    try:                                  # a paused retry auto-clears once any session serves a request again
+        _auto_resume_retry(now, tmux)
+    except Exception:
+        sys.stderr.write("auto-resume-retry: %s\n" % traceback.format_exc())
+    try:                                  # a per-session interrupt-suppressed retry re-arms once that thread lands a clean turn
+        _auto_resume_session_retry(now, tmux)
+    except Exception:
+        sys.stderr.write("auto-resume-session-retry: %s\n" % traceback.format_exc())
+    try:                                  # expire stale set_working notes once a session goes idle + done (cheap when no notes)
+        _clear_done_working_notes(now, tmux)
+    except Exception:
+        sys.stderr.write("clear-working-notes: %s\n" % traceback.format_exc())
+
+
 def _pusher():
     while True:
-        with _clients_lock:
-            any_client = bool(_clients)
-        if any_client:
-            _push_all()
-        # (the WS keepalive lives on its own _heartbeat thread — NOT here — so a slow push can't starve it)
-        try:                                  # Auto Nudge runs server-side even with no browser open (cheap when off)
-            _auto_nudge_tick(int(time.time()), _tmux_sessions())
-        except Exception:
-            sys.stderr.write("auto-nudge: %s\n" % traceback.format_exc())
-        try:                                  # EXACT retraction first: dispatches returned → the stamp is spent
-            _lift_spent_awaiting(int(time.time()), _tmux_sessions())
-        except Exception:
-            sys.stderr.write("awaiting-lift: %s\n" % traceback.format_exc())
-        try:                                  # slow one-shot wake for a session asleep behind a stale awaiting stamp
-            _awaiting_backstop_tick(int(time.time()), _tmux_sessions())
-        except Exception:
-            sys.stderr.write("awaiting-backstop: %s\n" % traceback.format_exc())
-        try:                                  # Interrupt → Blocked runs EVERY push, independent of the nudge toggle
-            _interrupt_block_tick(int(time.time()), _tmux_sessions())
-        except Exception:
-            sys.stderr.write("interrupt-block: %s\n" % traceback.format_exc())
-        try:                                  # hitting a usage limit auto-engages the retry-pause (before the resume check)
-            _auto_pause_on_limit()
-        except Exception:
-            sys.stderr.write("auto-pause-on-limit: %s\n" % traceback.format_exc())
-        try:                                  # a monthly spend cap (no readable reset) also engages it — else it storms forever
-            _auto_pause_on_spend_limit(int(time.time()), _tmux_sessions())
-        except Exception:
-            sys.stderr.write("auto-pause-on-spend-limit: %s\n" % traceback.format_exc())
-        try:                                  # a paused retry auto-clears once any session serves a request again
-            _auto_resume_retry(int(time.time()), _tmux_sessions())
-        except Exception:
-            sys.stderr.write("auto-resume-retry: %s\n" % traceback.format_exc())
-        try:                                  # a per-session interrupt-suppressed retry re-arms once that thread lands a clean turn
-            _auto_resume_session_retry(int(time.time()), _tmux_sessions())
-        except Exception:
-            sys.stderr.write("auto-resume-session-retry: %s\n" % traceback.format_exc())
-        try:                                  # expire stale set_working notes once a session goes idle + done (cheap when no notes)
-            _clear_done_working_notes(int(time.time()), _tmux_sessions())
-        except Exception:
-            sys.stderr.write("clear-working-notes: %s\n" % traceback.format_exc())
+        _pusher_cycle()
         # Event-driven (woken by the SDK live-tail and by /tick on hook events) with a SHORT 0.5s backstop
         # poll, so tmux sessions — which have no per-message event for mid-turn streaming — still refresh
         # responsively as the model generates, instead of waiting out a multi-second tick (the user 2026-06-22).

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -952,18 +952,51 @@ def interrupt_action(level: int, channel_up: bool) -> tuple[str, int]:
     return ("sigkill", 3)
 
 
+# list_regs' per-file parse cache (the 2026-08-10 CPU fix). The registry holds a reg file for EVERY
+# session ever created — a couple hundred, all but a handful dormant — and list_regs sits on the
+# kernel's hottest path: every liveness snapshot (Sessions.live) sweeps it, several times a second.
+# Re-opening + json-parsing a few hundred unchanged files per sweep was a measurable slice of the
+# pusher thread's sustained CPU burn. The file IS the truth, so the cache keys on exactly what
+# changes when the file does — (mtime_ns, size, inode); write_reg's os.replace mints a new inode, so
+# even a same-size same-instant rewrite misses. Entries are handed out as SHALLOW COPIES: the common
+# mutation (_update_reg's reg.update) lands on the copy, never the cache; read_reg stays uncached on
+# purpose — it feeds read-modify-writes and must always be the fresh file.
+_REG_CACHE = {}   # path -> ((mtime_ns, size, ino), parsed reg)
+
+
 def list_regs(state_dir: Path) -> list[dict]:
     d = Path(state_dir) / "sdk"
     out = []
-    if not d.is_dir():
+    try:
+        entries = list(os.scandir(d))
+    except OSError:
         return out
-    for f in d.glob("*.json"):
-        try:
-            r = json.loads(f.read_text())
-            r.setdefault("sid", f.stem)
-            out.append(r)
-        except (OSError, ValueError):
+    seen = set()
+    for de in entries:
+        if not de.name.endswith(".json"):
             continue
+        try:
+            st = de.stat()
+        except OSError:
+            continue
+        key = (st.st_mtime_ns, st.st_size, st.st_ino)
+        seen.add(de.path)
+        hit = _REG_CACHE.get(de.path)
+        if hit is not None and hit[0] == key:
+            out.append(dict(hit[1]))
+            continue
+        try:
+            r = json.loads(Path(de.path).read_text())
+        except (OSError, ValueError):
+            _REG_CACHE.pop(de.path, None)
+            continue
+        r.setdefault("sid", de.name[: -len(".json")])
+        _REG_CACHE[de.path] = (key, r)
+        out.append(dict(r))
+    if len(_REG_CACHE) > len(seen) + 64:          # deleted regs leave the cache once the drift is real
+        for p in list(_REG_CACHE):
+            if p not in seen:
+                _REG_CACHE.pop(p, None)
     return out
 
 

--- a/tests/test_heartbeat_thread.py
+++ b/tests/test_heartbeat_thread.py
@@ -58,7 +58,7 @@ class WsHeartbeat(unittest.TestCase):
         frames = self._fake_client()
         km.KEEPALIVE_S = 0.05
         wedge = threading.Event()                       # never set → the push never returns
-        km._push_all = lambda: wedge.wait()
+        km._push_all = lambda *a, **k: wedge.wait()   # accepts the cycle's snapshot kwarg
         threading.Thread(target=km._pusher, daemon=True).start()
         threading.Thread(target=km._heartbeat, daemon=True).start()
         deadline = time.time() + 3.0

--- a/tests/test_kernel_bg_tasks_stale.py
+++ b/tests/test_kernel_bg_tasks_stale.py
@@ -77,10 +77,11 @@ class BgTasksStale(unittest.TestCase):
 
     def test_build_session_wires_spawned_at(self):
         # spawned_at stays the tmux/no-snapshot fallback; an SDK session's box is gated by the backend's
-        # LIVE task-lifecycle set (the user 2026-07-11) — both ride the same call.
+        # LIVE task-lifecycle set (the user 2026-07-11) — both ride the same call. The live gate reads
+        # the CALLER's snapshot, never a fresh _tmux_sessions() (the 2026-08-10 pusher CPU fix).
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('_bg_tasks(sess["path"], _sdk_spawned_at(sid),', src)
-        self.assertIn('live=(_tmux_sessions().get(str(sid)) or {}).get("bgTasks")', src)
+        self.assertIn('live=(tmux.get(str(sid)) or {}).get("bgTasks")', src)
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_pusher_snapshot.py
+++ b/tests/test_kernel_pusher_snapshot.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""The pusher cycle takes ONE liveness snapshot (the 2026-08-10 CPU fix).
+
+Every _tmux_sessions() read forks `tmux list-sessions` and sweeps the whole SDK reg registry.
+The pusher's cycle used to take NINE of them — one inside _push plus one per tick job — at its
+0.5s cadence, which profiling attributed as the kernel's single hottest thread (~50-90% of one
+core sustained, three quarters of total process CPU). The jobs all take the map as a parameter
+by design, so the fix is purely structural: one snapshot at cycle start, handed to everything.
+
+SYNTHETIC fixtures only: placeholder UUIDs, invented names.
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_pushsnap", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class OneSnapshotPerCycle(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+                      km.NAMES, km.Sessions.live, km._sdk,
+                      km._auto_nudge_tick, km._clear_done_working_notes)
+        names = td / "names"; names.mkdir()
+        proj = td / "projects"; proj.mkdir()
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
+        for d in (jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR):
+            d.mkdir()
+        jd.STATE = td
+        km.NAMES = names
+        km._sdk = lambda: None
+        # a real session on disk, so the push leg builds it and the DEEP helpers (the awaiting/bg-task
+        # sources, the feed's per-session gates) actually run — the reads this fix removes hide there
+        cdir = td / "work"; cdir.mkdir()
+        pdir = proj / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        rec = {"type": "user", "timestamp": "2026-06-11T00:00:00.000Z", "uuid": "u1",
+               "parentUuid": None, "promptSource": "typed",
+               "message": {"role": "user", "content": "hello there"}}
+        (pdir / (SID + ".jsonl")).write_text(json.dumps(rec) + "\n")
+        (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
+        self.row = {SID: {"state": "waiting", "since": NOW - 5, "model": "", "effort": "",
+                          "context": None, "compactPct": None, "color": None, "mode": "",
+                          "backend": "tmux"}}
+        self.saved_clients = list(km._clients)
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+         km.NAMES, km.Sessions.live, km._sdk,
+         km._auto_nudge_tick, km._clear_done_working_notes) = self.saved
+        with km._clients_lock:
+            km._clients[:] = self.saved_clients
+        km._live_scope.snapshot = None
+        self.td.cleanup()
+
+    def test_one_cycle_reads_liveness_once_however_deep_the_call(self):
+        # count REAL liveness reads (Sessions.live — the tmux fork + reg sweep), not the delegator:
+        # inside the cycle's scope every _tmux_sessions() call, at any depth of the build stack,
+        # must be served the cycle's one snapshot instead of taking a fresh read
+        reads = []
+        row = self.row
+        km.Sessions.live = lambda: (reads.append(1), dict(row))[1]
+        got = {}
+        # bracket the job list: the FIRST and the LAST tick job must both receive the cycle's one map
+        km._auto_nudge_tick = lambda now, tmux: got.setdefault("first", tmux)
+        km._clear_done_working_notes = lambda now, tmux: got.setdefault("last", tmux)
+        sent = []
+        with km._clients_lock:   # a connected chat client, so the _push leg builds for real
+            km._clients[:] = [{"app": "chat", "alive": True, "wid": "", "qbytes": 0,
+                               "send": sent.append}]
+        km._pusher_cycle()
+        self.assertEqual(len(reads), 1, "one fork + one reg sweep per cycle — that IS the fix")
+        self.assertIn(SID, got.get("first") or {}, "the jobs got the cycle's snapshot")
+        self.assertIs(got.get("first"), got.get("last"))
+        self.assertTrue(any('"type": "session"' in s or '"type":"session"' in s.replace(" ", "")
+                            for s in sent), "the push leg really built the session")
+        self.assertIsNone(km._live_scope.snapshot, "the scope ends with the cycle")
+        # OUTSIDE a cycle the delegator reads fresh — a WS handler must never see a stale snapshot
+        n = len(reads)
+        km._tmux_sessions()
+        self.assertEqual(len(reads), n + 1)
+
+    def test_build_session_reuses_the_callers_snapshot(self):
+        # build_session used to take a FRESH liveness read per session build (the bgTasks line) — on
+        # the pusher's hottest path that was a tmux fork + reg sweep per tab per push
+        reads = []
+        row = self.row
+        km.Sessions.live = lambda: (reads.append(1), dict(row))[1]
+        m = km.build_session(SID, NOW, dict(self.row))
+        self.assertIsNotNone(m)
+        self.assertEqual(reads, [], "a provided snapshot is enough — no fresh liveness reads")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -2882,6 +2882,44 @@ class LiveAtomKinds(unittest.TestCase):
         self.assertEqual(len(be._live[sid]), 3, "read-only: the live tail is untouched")
 
 
+class RegListCache(unittest.TestCase):
+    """list_regs' per-file parse cache (the 2026-08-10 CPU fix): the registry keeps a reg for every
+    session EVER created, and list_regs sits on the liveness snapshot the kernel takes several times
+    a second — re-parsing hundreds of unchanged files per sweep was a measured slice of the pusher's
+    CPU burn. The cache keys on (mtime_ns, size, inode) — the file stays the truth — and hands out
+    copies, so the _update_reg read-modify-write pattern can never corrupt it."""
+
+    def setUp(self):
+        self.sd = Path(tempfile.mkdtemp())
+        (self.sd / "sdk").mkdir()
+        sb.write_reg(self.sd, "aaaa", {"sid": "aaaa", "alive": True, "name": "web"})
+        sb.write_reg(self.sd, "bbbb", {"sid": "bbbb", "alive": False, "name": "api"})
+
+    def test_unchanged_files_serve_cached_parses_with_equal_content(self):
+        first = sorted(sb.list_regs(self.sd), key=lambda r: r["sid"])
+        second = sorted(sb.list_regs(self.sd), key=lambda r: r["sid"])
+        self.assertEqual(first, second)
+        self.assertEqual([r["sid"] for r in first], ["aaaa", "bbbb"])
+
+    def test_a_mutated_result_never_leaks_into_the_cache(self):
+        one = next(r for r in sb.list_regs(self.sd) if r["sid"] == "aaaa")
+        one["name"] = "clobbered"          # the _update_reg pattern mutates its read
+        again = next(r for r in sb.list_regs(self.sd) if r["sid"] == "aaaa")
+        self.assertEqual(again["name"], "web", "the cache hands out copies, never its own dict")
+
+    def test_a_rewrite_is_picked_up(self):
+        # write_reg replaces the file (new inode), so even a same-instant rewrite misses the cache
+        sb.list_regs(self.sd)              # warm
+        sb.write_reg(self.sd, "aaaa", {"sid": "aaaa", "alive": True, "name": "renamed"})
+        got = next(r for r in sb.list_regs(self.sd) if r["sid"] == "aaaa")
+        self.assertEqual(got["name"], "renamed")
+
+    def test_a_deleted_reg_drops_out(self):
+        sb.list_regs(self.sd)              # warm
+        (self.sd / "sdk" / "bbbb.json").unlink()
+        self.assertEqual([r["sid"] for r in sb.list_regs(self.sd)], ["aaaa"])
+
+
 class PushSessionCallback(unittest.TestCase):
     """_push_session — the connect handshake's targeted one-session push (2026-08-10). The handshake is
     the exact event the kernel's opening chip stands down on, and a plain pusher wake left that flip

--- a/tests/test_session_retry_suppress.py
+++ b/tests/test_session_retry_suppress.py
@@ -117,7 +117,8 @@ class SessionRetrySuppressWiring(unittest.TestCase):
                       "the chat status exposes retrySuppressed so the client retry loop + card can read it")
 
     def test_pusher_runs_the_per_session_resume_sweep(self):
-        self.assertIn("_auto_resume_session_retry(int(time.time()), _tmux_sessions())", SRC,
+        # (now, tmux) — the cycle's ONE liveness snapshot, not a per-job fresh read (2026-08-10 CPU fix)
+        self.assertIn("_auto_resume_session_retry(now, tmux)", SRC,
                       "the pusher tick re-arms suppressed threads that land a clean turn")
 
 


### PR DESCRIPTION
Follow-up to #267, which decoupled new-tab latency from the push cycle; this fixes the cycle itself.

**Profiled live**: the kernel sat at 50–90% of a core sustained; per-thread CPU deltas put ~75% of total process CPU on the pusher thread, whose sampled call shape was subprocess forks + whole-file text reads + json decode. Every `_tmux_sessions()` read forks `tmux list-sessions` (~15ms) and re-parses all ~240 SDK reg files (~7ms, all but a handful dormant) — and those reads hide at every depth of the build stack: one in `_push`, one per tick job (8 more), plus per-session reads inside `_bg_live_norm` / `_compacting_now` / `build_feed`'s gates. One cycle at the 0.5s cadence paid dozens of forks + registry sweeps before any build work — a fair slice of the ~5–6s cycle time on a busy fleet.

Three layers, all event-scoped (no TTLs):

- **`_pusher_cycle` takes ONE snapshot** and hands it to `_push_all` and every tick job (they always took the map as a parameter; now they receive the same one). Split out of the loop so a test can run one cycle and count reads.
- **A thread-local scope** publishes that snapshot for the cycle, and `_tmux_sessions()` consults it — so the deep interior reads, unreachable by parameter threading without touching dozens of signatures, are served the same map. Thread-confined: WS handler and backend threads still read fresh; the scope is the cycle (an event), not a timer.
- **`list_regs` caches per-file parses** keyed on `(mtime_ns, size, inode)` — the file stays the truth; `write_reg`'s `os.replace` mints a new inode, so no rewrite can be missed — and hands out shallow copies so the `_update_reg` read-modify-write pattern can never corrupt the cache. `read_reg` stays uncached on purpose (it feeds RMWs). Measured on the real 241-file registry: 7.1ms → 0.73ms per warm sweep.

`build_session`'s bgTasks gate now reads the caller's snapshot. New tests: the one-read cycle (counting real `Sessions.live` calls with the deep build path exercised, plus scope-teardown and outside-a-cycle freshness), `build_session` snapshot reuse, and the reg cache's copy/rewrite/delete semantics. Updated the three source pins that quoted the old lines. Suites: 4163 Python + 1783 node, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)