### PR TITLE
A new session lands at the END of the merged tab strip, and stays there

### DIFF
--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -11,8 +11,8 @@
 // local kernel is just connection #0 with the empty-string host key, so its messages pass through
 // unprefixed and the single-kernel path is byte-for-byte unchanged.
 
-import { applyViewOrder, applyViewOrderTo, pruneViewOrder, readViewOrder, writeViewOrder,
-         VIEW_ORDER_KEY, VIEW_ORDER_EVENT } from "./view-order";
+import { adoptArrivals, applyViewOrder, applyViewOrderTo, churnSwaps, healOrder, pruneViewOrder,
+         readViewOrder, writeViewOrder, VIEW_ORDER_KEY, VIEW_ORDER_EVENT } from "./view-order";
 import { hostOf, bareId } from "./host-prefix";
 
 export const SEP = ":";
@@ -434,14 +434,14 @@ export class FederationManager {
     // only in other same-origin contexts) and this one through the writer's own CustomEvent. Both land here,
     // and re-emitting all three merged payloads is what moves the tabs, lanes and feed groups together.
     // ...and it RE-EMITS ONLY: reacting to an arrangement by rewriting it is what made a drag fail to
-    // stick. gcView (below) drops ids the reporting hosts no longer list, judged against THIS context's
-    // session lists — so any pane holding a stale list (a dashboard window whose socket died, a surface
-    // that never got the newest session's push) answered another pane's drag by pruning the very tab
-    // that had just moved, and the writer obeyed the write-back. On the audited drag the strip permuted
-    // correctly and reverted in the same second, twice per attempt, so the tab looked like it never
-    // moved at all — and it was always the NEWEST tab, the one a stale list is most likely to be missing
-    // (the user 2026-08-02). A view arrangement is not new information about what exists; only a host's
-    // own report is, so only an inbound tabOrder push may gc (see emitMergedOrder's `gc`).
+    // stick. The old gc-on-emit dropped ids the reporting hosts no longer list, judged against THIS
+    // context's session lists — so any pane holding a stale list (a dashboard window whose socket died, a
+    // surface that never got the newest session's push) answered another pane's drag by pruning the very
+    // tab that had just moved, and the writer obeyed the write-back. On the audited drag the strip
+    // permuted correctly and reverted in the same second, twice per attempt, so the tab looked like it
+    // never moved at all — and it was always the NEWEST tab, the one a stale list is most likely to be
+    // missing (the user 2026-08-02). A view arrangement is not new information about what exists; only a
+    // host's own report is, so only an inbound tabOrder push may touch the store (absorbHostReport).
     const reorder = () => { this.emitMergedOrder(); this.emitMergedFeed(); this.emitMergedTimeline(false); };
     w.addEventListener("storage", (e: StorageEvent) => { if (!e.key || e.key === VIEW_ORDER_KEY) reorder(); });
     w.addEventListener(VIEW_ORDER_EVENT, reorder);
@@ -460,10 +460,13 @@ export class FederationManager {
       (this.perHostSids[host] ||= new Set()).add(m.id);
     }
     if (m && m.type === "tabOrder") {
+      const prevOrder = this.perHostOrder[host] || [];
+      const prevTabs = this.perHostTabs[host] || [];
       this.perHostOrder[host] = Array.isArray(m.order) ? m.order.filter((x: any) => typeof x === "string") : [];
       this.perHostTabs[host] = Array.isArray(m.tabs) ? m.tabs : [];
       this.ensureHost(host);
-      this.emitMergedOrder(true);   // a host just reported its sessions → the one moment gc has fresh evidence
+      this.absorbHostReport(host, prevOrder, prevTabs);   // a host just reported its sessions → the one
+      this.emitMergedOrder();                             //   moment the stored arrangement may be touched
       return;
     }
     if (m && m.type === "feed") {
@@ -528,30 +531,49 @@ export class FederationManager {
     window.dispatchEvent(new MessageEvent("message", { data }));
   }
 
-  // `gc` is the caller's answer to "did a host just tell me what it has?" — true only on an inbound
-  // tabOrder push, which carries a fresh, complete list for that host. Every other caller (a drag
-  // landing here through the storage / CustomEvent path) re-emits without touching the stored
-  // arrangement, so no pane can prune away what another pane just arranged.
-  private emitMergedOrder(gc = false): void {
-    if (gc) this.gcView();
+  // Every caller re-emits WITHOUT touching the stored arrangement — a drag landing here through the
+  // storage / CustomEvent path must never be answered by a rewrite (the 2026-08-02 revert bug: a pane
+  // holding a stale session list pruned the very tab another pane had just moved). Only an inbound
+  // tabOrder push mutates the store, in absorbHostReport below, because only a host's own report is
+  // evidence about what exists.
+  private emitMergedOrder(): void {
     const order = mergeHostOrder(this.perHostOrder, this.hostSeq, this.view());
     const tabs = this.hostSeq.flatMap((h) => this.perHostTabs[h] || []);
     window.dispatchEvent(new MessageEvent("message", { data: { type: "tabOrder", order, tabs } }));
   }
 
-  // Self-clean the stored arrangement, event-based: a host that has just reported its sessions is telling
-  // us exactly which of its ids still exist, so any of ITS ids missing from that report is gone for good and
-  // can be dropped. A host that is detached or unreachable reports nothing and is left entirely alone —
-  // pruning against a tunnel blip would flatten every remote session's placement and stack them all at the
-  // end of the strip when the host came back. Rewritten only when it actually changes.
-  private gcView(): void {
+  // Fold a host's OWN report — the one moment with fresh evidence about what exists — into the stored
+  // arrangement, in three steps, one conditional write:
+  // 1. HEAL fsid churn: a /clear or relaunch mints a new transcript fsid for the SAME logical session,
+  //    and the kernel's own list inherits the old slot by the stable session NAME (`_ordered`, the
+  //    2026-06-29 fix). The arrangement inherits the same way (churnSwaps matches vanished→appeared ids
+  //    by display name within this host's report), or the relaunched session would read as brand-new.
+  // 2. PRUNE ids the reporting hosts no longer list (the old gcView rule, unchanged): event-based, never
+  //    aged out. A detached / unreachable host reports nothing and its ids are left entirely alone —
+  //    pruning against a tunnel blip would flatten every remote session's placement and stack them all
+  //    at the end of the strip when the host came back.
+  // 3. ADOPT arrivals: every id the viewer has never placed appends at the very END of the arrangement,
+  //    so a NEW session lands at the end of the whole strip — exactly where its provisional tab already
+  //    rendered — not at the end of its host's block, mid-strip in front of another host's sessions
+  //    (the user 2026-08-10, who watched the new tab pop from last place to second-to-last). Writing the
+  //    placement down is what makes it hold: an unadopted id was re-derived from the host-blocked seed
+  //    on every merge and every reload.
+  private absorbHostReport(host: string, prevOrder: readonly string[], prevTabs: readonly any[]): void {
+    const names = (tabs: readonly any[]) => {
+      const byId = new Map<string, string>();
+      for (const t of tabs) if (t && typeof t.id === "string") byId.set(t.id, String(t.name || ""));
+      return byId;
+    };
+    const cur = this.view();
+    const healed = healOrder(cur, churnSwaps(prevOrder, names(prevTabs),
+                                             this.perHostOrder[host] || [], names(this.perHostTabs[host] || [])));
     const reporting = new Set(Object.keys(this.perHostOrder));
-    if (!reporting.size) return;
     const live = new Set<string>();
     for (const h of reporting) for (const id of this.perHostOrder[h] || []) live.add(id);
-    const cur = this.view();
-    const kept = pruneViewOrder(cur, hostOf, reporting, live);
-    if (kept.length !== cur.length) writeViewOrder(kept);
+    const seed: string[] = [];
+    for (const h of this.hostSeq) seed.push(...(this.perHostOrder[h] || []));
+    const next = adoptArrivals(pruneViewOrder(healed, hostOf, reporting, live), seed);
+    if (next.length !== cur.length || next.some((id, i) => id !== cur[i])) writeViewOrder(next);
   }
 
   private lastClearHost = LOCAL; // where the most recent askClear routed — undoClear follows it

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -478,3 +478,69 @@ test("pickWid prefers the host-supplied ?wid=, then the shell's per-tab id", () 
 test("pickWid survives a malformed query instead of throwing the connect away", () => {
   assert.equal(pickWid("%", "from-storage"), "from-storage");
 });
+
+// ── absorbHostReport: the merged strip keeps its promises about placement ─────────────────────────────
+// End-to-end through the real manager: stub window (emissions) + localStorage (the stored arrangement),
+// feed inbound tabOrder pushes, read the merged order the panes would render.
+function withManager(fn: (fm: FederationManager, emitted: any[], store: Map<string, string>) => void): void {
+  const emitted: any[] = [];
+  const store = new Map<string, string>();
+  const g: any = globalThis;
+  const hadWindow = "window" in g, prevWindow = g.window;
+  const hadLS = "localStorage" in g, prevLS = g.localStorage;
+  g.window = { dispatchEvent: (ev: any) => { if (ev && ev.data) emitted.push(ev.data); } };
+  g.localStorage = { getItem: (k: string) => store.get(k) ?? null,
+                     setItem: (k: string, v: string) => { store.set(k, v); } };
+  try {
+    fn(new FederationManager(), emitted, store);
+  } finally {
+    if (hadWindow) g.window = prevWindow; else delete g.window;
+    if (hadLS) g.localStorage = prevLS; else delete g.localStorage;
+  }
+}
+const lastOrder = (emitted: any[]) => emitted.filter((m) => m && m.type === "tabOrder").pop()!.order;
+
+test("a session created after a remote host attached lands at the END of the merged strip", () => {
+  // The 2026-08-10 report: the new session's provisional tab rendered last, then the merged push
+  // re-slotted it in front of the remote host's block (host-blocked seed, local first).
+  withManager((fm, emitted) => {
+    fm.inbound("", { type: "tabOrder", order: ["a", "b"],
+                     tabs: [{ id: "a", name: "web" }, { id: "b", name: "api" }] });
+    fm.inbound("TESTHOST", { type: "tabOrder", order: [V], tabs: [{ id: V, name: "tests" }] });
+    assert.deepEqual(lastOrder(emitted), ["a", "b", "TESTHOST:" + V]);
+    // the new session appears mid-seed, at the end of the LOCAL kernel's block…
+    fm.inbound("", { type: "tabOrder", order: ["a", "b", "n"],
+                     tabs: [{ id: "a", name: "web" }, { id: "b", name: "api" }, { id: "n", name: "fresh" }] });
+    // …but the merged strip shows it at the very end, where its provisional tab already rendered
+    assert.deepEqual(lastOrder(emitted), ["a", "b", "TESTHOST:" + V, "n"]);
+    // and the placement is WRITTEN, so it survives the next merge and a reload identically
+    fm.inbound("TESTHOST", { type: "tabOrder", order: [V], tabs: [{ id: V, name: "tests" }] });
+    assert.deepEqual(lastOrder(emitted), ["a", "b", "TESTHOST:" + V, "n"]);
+  });
+});
+
+test("a relaunch that swaps the transcript fsid keeps the session's slot — it is not a new session", () => {
+  withManager((fm, emitted) => {
+    fm.inbound("", { type: "tabOrder", order: ["f1", "s"],
+                     tabs: [{ id: "f1", name: "web" }, { id: "s", name: "api" }] });
+    fm.inbound("TESTHOST", { type: "tabOrder", order: [V], tabs: [{ id: V, name: "tests" }] });
+    // /clear: the kernel's own order already inherited the slot by name; the arrangement must follow
+    fm.inbound("", { type: "tabOrder", order: ["f2", "s"],
+                     tabs: [{ id: "f2", name: "web" }, { id: "s", name: "api" }] });
+    assert.deepEqual(lastOrder(emitted), ["f2", "s", "TESTHOST:" + V],
+      "f2 holds f1's slot instead of jumping to the end");
+  });
+});
+
+test("a closed session leaves the arrangement; a detached host's sessions keep their slots", () => {
+  withManager((fm, emitted, store) => {
+    fm.inbound("", { type: "tabOrder", order: ["a", "b"],
+                     tabs: [{ id: "a", name: "web" }, { id: "b", name: "api" }] });
+    fm.inbound("TESTHOST", { type: "tabOrder", order: [V], tabs: [{ id: V, name: "tests" }] });
+    fm.inbound("", { type: "tabOrder", order: ["b"], tabs: [{ id: "b", name: "api" }] });   // a closed
+    assert.deepEqual(lastOrder(emitted), ["b", "TESTHOST:" + V]);
+    assert.ok(!JSON.parse(store.get("romp:vieworder")!).includes("a"), "the closed id is pruned from storage");
+    assert.ok(JSON.parse(store.get("romp:vieworder")!).includes("TESTHOST:" + V),
+      "the remote id stays placed — its host simply wasn't the one reporting");
+  });
+});

--- a/ui/webview/view-order-wiring.test.ts
+++ b/ui/webview/view-order-wiring.test.ts
@@ -51,15 +51,23 @@ test("a pane answers another pane's drag by re-emitting, never by rewriting the 
   // Every revert arrived through the `storage` listener — another context answering the write by running
   // its own gc, which prunes ids ITS session lists don't name and so dropped the tab that had just moved
   // (the newest tab is the one a stale list is likeliest to be missing). An arrangement is not evidence
-  // about what exists; only a host's own report is, and that is the one caller allowed to gc.
-  assert.match(FED, /this\.emitMergedOrder\(true\);\s+\/\/ a host just reported/, "inbound tabOrder gc's");
-  assert.match(FED, /private emitMergedOrder\(gc = false\): void \{\s*\n\s*if \(gc\) this\.gcView\(\);/,
+  // about what exists; only a host's own report is, and that is the one caller allowed to touch the store.
+  assert.match(FED, /this\.absorbHostReport\(host, prevOrder, prevTabs\);\s+\/\/ a host just reported/,
+    "inbound tabOrder is the one store-mutating moment");
+  assert.match(FED, /private emitMergedOrder\(\): void \{\s*\n\s*const order = mergeHostOrder/,
     "every other caller — both drag paths included — re-emits without touching the stored order");
+  assert.doesNotMatch(FED, /private gcView|this\.gcView/,
+    "the old gc-on-emit hook is gone, folded into absorbHostReport");
 });
 
-test("the stale arrangement self-cleans on the host's own report, not on a clock", () => {
+test("the host's report heals churn, prunes the gone, and adopts arrivals — one conditional write", () => {
+  // heal: a /clear relaunch keeps its slot (the kernel's own name inheritance, mirrored browser-side);
+  // prune: the old gcView rule, unchanged — event-based, detached hosts left entirely alone;
+  // adopt: a NEW session lands at the end of the WHOLE strip, where its provisional tab already
+  // rendered, not at the end of its host's block mid-strip (the user 2026-08-10).
+  assert.match(FED, /const healed = healOrder\(cur, churnSwaps\(prevOrder, names\(prevTabs\),/);
   assert.match(FED, /const reporting = new Set\(Object\.keys\(this\.perHostOrder\)\);/);
-  assert.match(FED, /if \(!reporting\.size\) return;/, "no report in hand → prune nothing");
-  assert.match(FED, /const kept = pruneViewOrder\(cur, hostOf, reporting, live\);/);
-  assert.match(FED, /if \(kept\.length !== cur\.length\) writeViewOrder\(kept\);/, "written only when it changed");
+  assert.match(FED, /const next = adoptArrivals\(pruneViewOrder\(healed, hostOf, reporting, live\), seed\);/);
+  assert.match(FED, /if \(next\.length !== cur\.length \|\| next\.some\(\(id, i\) => id !== cur\[i\]\)\) writeViewOrder\(next\);/,
+    "written only when it actually changed");
 });

--- a/ui/webview/view-order.test.ts
+++ b/ui/webview/view-order.test.ts
@@ -4,7 +4,7 @@
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import {
-  applyViewOrder, applyViewOrderTo, pruneViewOrder, parseViewOrder,
+  adoptArrivals, applyViewOrder, applyViewOrderTo, churnSwaps, healOrder, pruneViewOrder, parseViewOrder,
   VIEW_ORDER_KEY, VIEW_ORDER_CAP,
 } from "./view-order";
 
@@ -86,4 +86,44 @@ test("a corrupt or foreign stored value reads as no arrangement, never throws", 
 
 test("the key is namespaced alongside the feed's other browser-owned state", () => {
   assert.match(VIEW_ORDER_KEY, /^romp:/);
+});
+
+// ── adoptArrivals / healOrder / churnSwaps: arrivals land at the END, a relaunch keeps its slot ──────
+test("adoptArrivals appends never-placed ids at the END, in seed order among themselves", () => {
+  assert.deepEqual(adoptArrivals(["b", "a"], ["a", "b", "n1", "TESTHOST:r", "n2"]),
+    ["b", "a", "n1", "TESTHOST:r", "n2"]);
+  // placed ids never move, and ids the seed doesn't carry (a detached host's) stay put too
+  assert.deepEqual(adoptArrivals(["GONEHOST:x", "a"], ["a", "n"]), ["GONEHOST:x", "a", "n"]);
+  // an empty arrangement adopts the whole seed verbatim — the shown order is unchanged by the write
+  assert.deepEqual(adoptArrivals([], ["a", "TESTHOST:r"]), ["a", "TESTHOST:r"]);
+});
+
+test("a NEW local session shows after a remote host's sessions, not in front of them", () => {
+  // The 2026-08-10 report: the provisional tab rendered at the very end, then the merge re-derived the
+  // host-blocked seed (local block first) and popped the tab to in front of the remote block. Adoption
+  // writes the end placement down, so every later merge and reload agrees with what first rendered.
+  const view0 = adoptArrivals([], ["a", "b", "TESTHOST:r"]);        // the strip as first adopted
+  const seed1 = ["a", "b", "NEW", "TESTHOST:r"];                    // the local kernel appends NEW to ITS block
+  const view1 = adoptArrivals(view0, seed1);
+  assert.deepEqual(applyViewOrder(seed1, view1), ["a", "b", "TESTHOST:r", "NEW"]);
+});
+
+test("healOrder hands a slot to the heir id in place", () => {
+  assert.deepEqual(healOrder(["a", "old", "b"], new Map([["old", "new"]])), ["a", "new", "b"]);
+  // a swap that would duplicate an id keeps the first occurrence
+  assert.deepEqual(healOrder(["a", "old", "new"], new Map([["old", "new"]])), ["a", "new"]);
+  assert.deepEqual(healOrder(["a", "b"], new Map()), ["a", "b"], "no swaps → unchanged");
+});
+
+test("churnSwaps pairs a vanished id with the appeared id of the same NAME — fsid churn, not a new session", () => {
+  // a /clear mints a new transcript fsid for the same logical session; the kernel's own order inherits
+  // the slot by name (_ordered, 2026-06-29) and the browser arrangement must follow the same way
+  const swaps = churnSwaps(["f1", "s"], new Map([["f1", "web"], ["s", "api"]]),
+                           ["f2", "s"], new Map([["f2", "web"], ["s", "api"]]));
+  assert.deepEqual([...swaps], [["f1", "f2"]]);
+  // no name recorded for the vanished id → no inheritance (a genuinely new session must not be claimed)
+  assert.deepEqual([...churnSwaps(["x"], new Map(), ["y"], new Map([["y", "web"]]))], []);
+  // an id present in both reports is never treated as churn
+  assert.deepEqual([...churnSwaps(["x"], new Map([["x", "web"]]), ["x", "y"],
+                                  new Map([["x", "web"], ["y", "web"]]))], []);
 });

--- a/ui/webview/view-order.ts
+++ b/ui/webview/view-order.ts
@@ -16,7 +16,12 @@
 //   view  = the ids this viewer has arranged, in their arranged order
 //   shown = every id the view names, in view order, then everything else in SEED order
 // An empty view is the identity transform, so a viewer who has never dragged sees precisely the old
-// behaviour, and the first drag is what takes ownership.
+// behaviour. Since 2026-08-10 the arrangement is DENSE: a host's own report ADOPTS any id the viewer
+// has never placed by appending it at the end (adoptArrivals below, called from federation's
+// absorbHostReport) — so a NEW session lands at the end of the whole strip, not at the end of its
+// host's block mid-strip, and the placement survives merges and reloads. A drag was already dense
+// (commitTabOrder writes the full rendered order); adoption just stops the never-dragged and
+// stale-arrangement states from re-deriving host-block positions for newcomers.
 //
 // The three surfaces that must agree on this (chat tab strip, timeline lanes, feed grouped mode) read the
 // same key out of the same origin's localStorage, so they cannot drift; federation.ts applies this at all
@@ -66,6 +71,70 @@ export function applyViewOrderTo<T>(rows: readonly T[], view: readonly string[],
     .map((r, i) => ({ r, i, k: rank.has(idOf(r)) ? rank.get(idOf(r))! : Number.MAX_SAFE_INTEGER }))
     .sort((a, b) => (a.k - b.k) || (a.i - b.i))
     .map((x) => x.r);
+}
+
+/** Append every seed id the arrangement has never placed at its END — in seed order among themselves.
+ *  This is what puts a NEW session at the end of the WHOLE strip rather than at the end of its host's
+ *  block mid-strip (the user 2026-08-10: a fresh session's provisional tab rendered last, then the merge
+ *  re-derived host-block order and popped it in front of a remote host's sessions). Adopting writes the
+ *  placement down, so it holds across merges and reloads instead of depending on which hosts happen to
+ *  sit later in the seed. Ids already placed are untouched — this never re-arranges, only appends. */
+export function adoptArrivals(view: readonly string[], seed: readonly string[]): string[] {
+  const have = new Set(view.filter((id) => typeof id === "string"));
+  const out = view.filter((id) => typeof id === "string");
+  for (const id of seed) {
+    if (typeof id === "string" && !have.has(id)) {
+      have.add(id);
+      out.push(id);
+    }
+  }
+  return out;
+}
+
+/** Rewrite arrangement ids through `swap` (old id → its heir), keeping their positions: the SLOT follows
+ *  the session, not the fsid. Duplicates that a swap would create keep the first occurrence. */
+export function healOrder(view: readonly string[], swap: ReadonlyMap<string, string>): string[] {
+  if (!swap.size) return view.filter((id) => typeof id === "string");
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const id of view) {
+    if (typeof id !== "string") continue;
+    const next = swap.get(id) || id;
+    if (!seen.has(next)) {
+      seen.add(next);
+      out.push(next);
+    }
+  }
+  return out;
+}
+
+/** One host's report, diffed against its previous one: which ids were SWAPPED rather than closed+opened.
+ *  A /clear or a relaunch mints a NEW transcript fsid for the SAME logical session, and the kernel's own
+ *  order inherits the old slot by the stable session NAME (`_ordered`, the 2026-06-29 fix). The viewer's
+ *  arrangement must inherit the same way, or the relaunched session would read as brand-new and jump to
+ *  the end of the strip. An id that vanished from the report is matched to an id that appeared in it and
+ *  carries the same display name (first unclaimed wins, mirroring the kernel); no name, no match. SDK
+ *  session ids are stable, so this fires only for the transcript-fsid (tmux) world. */
+export function churnSwaps(
+  prevOrder: readonly string[], prevNames: ReadonlyMap<string, string>,
+  nextOrder: readonly string[], nextNames: ReadonlyMap<string, string>,
+): Map<string, string> {
+  const prevSet = new Set(prevOrder);
+  const nextSet = new Set(nextOrder);
+  const fresh = nextOrder.filter((id) => !prevSet.has(id));
+  const swaps = new Map<string, string>();
+  const claimed = new Set<string>();
+  for (const oldId of prevOrder) {
+    if (nextSet.has(oldId)) continue;
+    const name = prevNames.get(oldId);
+    if (!name) continue;
+    const heir = fresh.find((id) => !claimed.has(id) && nextNames.get(id) === name);
+    if (heir) {
+      claimed.add(heir);
+      swaps.set(oldId, heir);
+    }
+  }
+  return swaps;
 }
 
 /** Drop arrangement entries for sessions that are GONE, and only those.


### PR DESCRIPTION
User report (2026-08-10): a newly created session's loading tab shows at the very end of the strip, then pops back to second-to-last, in front of the session from another server. They want it to stay at the very end.

**Cause:** the client appends a not-yet-known tab at the end, but the merged `tabOrder` push re-derives the host-blocked seed (local kernel's block first, remote hosts after), so the new session re-slots at the end of its host's *block*, mid-strip.

**Fix** in the view-order layer (where order became viewer-owned on 2026-07-31): a host's own tabOrder report — already the one moment allowed to touch the stored arrangement — now **adopts** every id the viewer has never placed by appending it at the end (`adoptArrivals`). The placement is written, so it holds across merges and reloads, and all three surfaces (tabs, timeline lanes, feed groups) agree. Two guards:

- **fsid churn heals** (`churnSwaps`/`healOrder`): a `/clear`/relaunch mints a new transcript fsid for the same logical session; the arrangement hands the old slot to the same-named heir within the same host's report, mirroring the kernel's `_ordered` name inheritance — a relaunch never reads as a new session.
- **Prune rule unchanged**: ids leave the arrangement only when their own host reports without them; detached hosts keep every placement. The old `gcView` hook is folded into one `absorbHostReport` with a single conditional write, preserving the 2026-08-02 invariant that a drag is answered by re-emitting, never rewriting.

**Deliberate behavior change:** re-showing a ×-hidden tab lands it at the end of the strip (its id was pruned while hidden) instead of its old slot — rejoining reads as arriving.

Tests: pure-rule coverage in `view-order.test.ts`, end-to-end manager coverage (stubbed window/localStorage) in `multi-kernel-merge.test.ts`, wiring pins updated in `view-order-wiring.test.ts`. Suites: 4157 Python + 1790 node, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)