### PR TITLE
Hover any command button and its tooltip names the current hotkey

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19346,7 +19346,10 @@ _LANDING_COLLAPSE_JS = """
     document.body.classList.toggle('po-timeline',!!po.timeline);
     Array.prototype.forEach.call(document.querySelectorAll('.rail-btn[data-pane]'),function(b){
       var k=b.getAttribute('data-pane');b.classList.toggle('on',!!po[k]);
-      b.title=(po[k]?'hide':'show')+' the '+(LBL[k]||k);});
+      // tooltip carries the pane command's CURRENT binding (hover discoverability, the user 2026-08-10) —
+      // __rompKeyHint is palette-main's, absent until it boots; the romp:keys nudge below re-applies then
+      var h=(window.__rompKeyHint&&window.__rompKeyHint('pane.'+(k==='fleet'?'outline':k)))||'';
+      b.title=(po[k]?'hide':'show')+' the '+(LBL[k]||k)+(h?' ('+h+')':'');});
     try{window.dispatchEvent(new Event('romp-panes'));}catch(e){}   // nudge the timeline band to auto-fit when toggled
   }
   function togglePane(k,to){if(!(k in po))return;var nv=(to===undefined)?!po[k]:!!to;
@@ -19356,6 +19359,8 @@ _LANDING_COLLAPSE_JS = """
   Array.prototype.forEach.call(document.querySelectorAll('.rail-btn[data-pane]'),function(b){
     b.addEventListener('click',function(){togglePane(b.getAttribute('data-pane'));});});
   apply();
+  window.addEventListener('romp:keys',apply);   // a rebind (or palette-main's boot nudge) refreshes the titles
+  window.addEventListener('storage',apply);     // …including one made in another tab
 })();
 """
 
@@ -20105,24 +20110,24 @@ def _landing():
             "<div class=rail-btn data-pane=feed>Feed</div>"
             # the Claude /usage rate-limit bars (Pro/Max): three compact vertical bar-pairs (used % colored +
             # elapsed % slate), %-label, full detail on hover — side-by-side in the bottom bar.
-            "<div id=rail-usage></div>"
+            "<div id=rail-usage data-keycmd=usage.open></div>"
             "</div>"   # /.rail-scroll
             # refresh + network + settings, pinned to the far RIGHT (settings last), always visible:
             "<div class=rail-acts>"
             # the log's warning triangle (a bell until 2026-07-28 — the bell now means the
             # notification toggles): monochrome outline like its neighbors; goes red with the unread
             # count drawn INSIDE the triangle when an entry lands (see _ERRS_SVG + _LANDING_ERRS_JS).
-            "<div class=rail-act id=rail-errs title='Log — click to open' aria-label=Log>"
+            "<div class=rail-act id=rail-errs data-keycmd=log.open title='Log — click to open' aria-label=Log>"
             + _ERRS_SVG +
             "</div>"
             # the refresh glyph is a REAL browser-style reload icon now (the user 2026-07-27: the ↻ text
             # glyph stopped at 11 o'clock and never read as refresh): a near-full circular arc sweeping
             # clockwise to 1 o'clock with the arrowhead there, drawn like its svg neighbors. QUOTED attrs.
-            "<div class=rail-act id=rail-refresh title='Restart the romp kernel' aria-label=Refresh>"
+            "<div class=rail-act id=rail-refresh data-keycmd=kernel.restart title='Restart the romp kernel' aria-label=Refresh>"
             + _REFRESH_SVG + "</div>"
             # remote-kernels (federation): a LAN glyph — one device wired down a bus to two below. Goes
             # accent-blue (.on) while a remote is connected. Below help, above settings (the user 2026-06-30).
-            "<div class=rail-act id=rail-net title='Remote kernels' aria-label='Remote kernels'>"
+            "<div class=rail-act id=rail-net data-keycmd=net.open title='Remote kernels' aria-label='Remote kernels'>"
             # A network tree: one node wired down a bus to two below. ATTRIBUTES MUST BE QUOTED — unquoted
             # `fill=currentColor/>` HTML-parses as the invalid color `currentColor/`, so the filled squares
             # render INVISIBLE and only the connector lines show (the whole "single square" saga, 2026-06-30).
@@ -20145,7 +20150,7 @@ def _landing():
             "<path d='M8 2 C5.7 2 4.3 3.8 4.3 6.2 L4.3 9 L3 11.2 L13 11.2 L11.7 9 L11.7 6.2 C11.7 3.8 10.3 2 8 2 Z'"
             " fill='none' stroke='currentColor' stroke-width='1.2' stroke-linejoin='round'/>"
             "<path d='M6.5 13 A1.7 1.7 0 0 0 9.5 13' fill='none' stroke='currentColor' stroke-width='1.2'/></svg></div>"
-            "<div class=rail-act id=rail-gear title=Settings aria-label=Settings>⛭</div>"   # ⛭ (gear-without-hub): the bigger, bolder gear the user prefers (restored 2026-06-29)
+            "<div class=rail-act id=rail-gear data-keycmd=settings.open title=Settings aria-label=Settings>⛭</div>"   # ⛭ (gear-without-hub): the bigger, bolder gear the user prefers (restored 2026-06-29)
             "</div>"   # /.rail-acts
             "</div>"   # /.pane-rail (bottom bar)
             "</div>"
@@ -20161,13 +20166,13 @@ def _landing():
             # the ACTUAL rail icons, not words (the user 2026-07-11). Usage has no desktop icon (the rail
             # shows the live bars themselves) — its icon is the same motif: two stacked fill bars at
             # different levels. SVG ATTRIBUTES MUST BE QUOTED (the rail-net invisible-squares saga).
-            "<button class=mact data-act=usage aria-label=Usage title=Usage>"
+            "<button class=mact data-act=usage data-keycmd=usage.open aria-label=Usage title=Usage>"
             "<svg viewBox='0 0 16 16' width='18' height='18'>"
             "<rect x='1' y='3' width='14' height='4' rx='1' fill='none' stroke='currentColor' stroke-width='1'/>"
             "<rect x='1' y='3' width='9' height='4' rx='1' fill='currentColor'/>"
             "<rect x='1' y='9' width='14' height='4' rx='1' fill='none' stroke='currentColor' stroke-width='1'/>"
             "<rect x='1' y='9' width='6' height='4' rx='1' fill='currentColor'/></svg></button>"
-            "<button class=mact data-act=net aria-label='Remote kernels' title='Remote kernels'>"
+            "<button class=mact data-act=net data-keycmd=net.open aria-label='Remote kernels' title='Remote kernels'>"
             "<svg viewBox='0 0 16 16' width='18' height='18'>"
             "<path d='M8 5 L8 8 M3 11 L3 8 L13 8 L13 11' fill='none' stroke='currentColor' stroke-width='1' stroke-linejoin='round'/>"
             "<rect class=rn-me x='6' y='1' width='4' height='4' rx='0.6' fill='currentColor'/>"
@@ -20175,9 +20180,9 @@ def _landing():
             "<rect class=rn-b x='11' y='11' width='4' height='4' rx='0.6' fill='currentColor'/></svg></button>"
             # restart the kernel (the user 2026-07-22): the rail's ↻ is hidden on mobile, so mirror it here.
             # Same glyph as the rail; wired to window.__rompRestart (POST /restart, poll /healthz, reload).
-            "<button class=mact data-act=restart aria-label='Restart kernel' title='Restart kernel'>" + _REFRESH_SVG + "</button>"
+            "<button class=mact data-act=restart data-keycmd=kernel.restart aria-label='Restart kernel' title='Restart kernel'>" + _REFRESH_SVG + "</button>"
             # the log triangle on mobile too (same glyph + in-body count; opens the same popover)
-            "<button class=mact id=merr data-act=errs aria-label=Log title='Log — click to open'>"
+            "<button class=mact id=merr data-act=errs data-keycmd=log.open aria-label=Log title='Log — click to open'>"
             + _ERRS_SVG +
             "</button>"
             # the push bell (plans/ios-app.md proposal 2): opt this DEVICE into needs-you notifications.
@@ -20189,7 +20194,7 @@ def _landing():
             " fill='none' stroke='currentColor' stroke-width='1.2' stroke-linejoin='round'/>"
             "<path d='M6.5 13 A1.7 1.7 0 0 0 9.5 13' fill='none' stroke='currentColor' stroke-width='1.2'/></svg></button>"
             # settings wears the desktop rail's OWN gear glyph, ⛭ (U+26ED), not the outlined star it had.
-            "<button class=mact data-act=settings aria-label=Settings title=Settings>⛭</button>"
+            "<button class=mact data-act=settings data-keycmd=settings.open aria-label=Settings title=Settings>⛭</button>"
             "</nav>"
             # the rail's network popover — manage federated remote kernels (driven by _LANDING_REMOTES_JS).
             "<div id=rnet-back hidden><div id=rnet-panel>"

--- a/tests/test_hotkey_hints.py
+++ b/tests/test_hotkey_hints.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Hover discoverability on the landing page (the user 2026-08-10): the shell's own buttons carry
+data-keycmd=<command id>, which palette-main's sweep turns into a "(⌘⇧O)" tooltip tail showing the
+command's CURRENT binding; the pane toggles, whose titles are rewritten per toggle by inline JS, read
+the same hint through window.__rompKeyHint. Source pins over kernel.py's HTML/JS strings — the kernel
+module is deliberately NOT imported (importing it runs boot reconcile against live state)."""
+import os
+import re
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+SRC = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py"), encoding="utf-8").read()
+
+
+class HotkeyHints(unittest.TestCase):
+    def test_every_rail_button_with_a_command_carries_its_id(self):
+        for el_id, cmd in [("rail-errs", "log.open"), ("rail-refresh", "kernel.restart"),
+                           ("rail-net", "net.open"), ("rail-gear", "settings.open"),
+                           ("rail-usage", "usage.open")]:
+            self.assertRegex(SRC, "id=%s data-keycmd=%s|id=%s[^>]* data-keycmd=%s" % (el_id, cmd, el_id, cmd),
+                             "%s advertises %s on hover" % (el_id, cmd))
+
+    def test_the_mobile_bar_mirrors_the_rail(self):
+        for act, cmd in [("usage", "usage.open"), ("net", "net.open"), ("restart", "kernel.restart"),
+                         ("errs", "log.open"), ("settings", "settings.open")]:
+            self.assertRegex(SRC, "data-act=%s[^>]* data-keycmd=%s|data-act=%s data-keycmd=%s"
+                             % (act, cmd, act, cmd), "mobile %s advertises %s" % (act, cmd))
+
+    def test_pane_toggles_append_the_live_hint_and_refresh_on_rebinds(self):
+        self.assertIn("window.__rompKeyHint&&window.__rompKeyHint('pane.'+(k==='fleet'?'outline':k))", SRC,
+                      "the toggle titles read the hint through the shell global (fleet wears its Outline id)")
+        self.assertIn("(h?' ('+h+')':'')", SRC, "unbound pane commands show no empty parens")
+        self.assertIn("window.addEventListener('romp:keys',apply);", SRC,
+                      "a rebind (or palette-main's boot nudge) refreshes the titles")
+        self.assertIn("window.addEventListener('storage',apply);", SRC)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -45,10 +45,10 @@ class LandingShell(unittest.TestCase):
         # ICONS, not words (the user 2026-07-11): settings wears the desktop rail's own gear glyph, net its
         # network-tree SVG; usage gets the theme's own motif — two stacked fill bars at different levels
         # the settings icon is the SAME gear the desktop rail uses (U+26ED ⛭), not the outlined star it had
-        self.assertIn("data-act=settings aria-label=Settings title=Settings>⛭</button>", html)
-        self.assertIn("id=rail-gear title=Settings aria-label=Settings>⛭</div>", html)  # matches the rail
+        self.assertIn("data-act=settings data-keycmd=settings.open aria-label=Settings title=Settings>⛭</button>", html)
+        self.assertIn("id=rail-gear data-keycmd=settings.open title=Settings aria-label=Settings>⛭</div>", html)  # matches the rail
         self.assertNotIn("&#9885;", html)                               # the old outlined-star glyph is gone
-        self.assertIn("data-act=net aria-label='Remote kernels'", html)
+        self.assertIn("data-act=net data-keycmd=net.open aria-label='Remote kernels'", html)
         self.assertIn("<rect x='1' y='3' width='9' height='4' rx='1' fill='currentColor'/>", html)   # the used-bar fill
         self.assertNotIn(">Gear</button>", html)
         self.assertIn("{romp:'openSettings'}", km._LANDING_MOBILE_JS)   # same path as the desktop gear
@@ -66,7 +66,7 @@ class LandingShell(unittest.TestCase):
         # (POST /restart, poll /healthz, reload) so both surfaces share one path, not a copy.
         html = km._landing()
         # …and it wears the SAME browser-style reload svg as the rail (the ↻ text glyph is gone, 2026-07-27)
-        self.assertIn("data-act=restart aria-label='Restart kernel' title='Restart kernel'>" + km._REFRESH_SVG + "</button>", html)
+        self.assertIn("data-act=restart data-keycmd=kernel.restart aria-label='Restart kernel' title='Restart kernel'>" + km._REFRESH_SVG + "</button>", html)
         self.assertIn("window.__rompRestart=function", km._LANDING_SETTINGS_JS)   # the shared restart path
         self.assertIn("fetch('/restart',{method:'POST'})", km._LANDING_SETTINGS_JS)
         self.assertIn("rf.onclick=function(){rf.style.pointerEvents='none';rf.style.opacity='0.5';window.__rompRestart();}", km._LANDING_SETTINGS_JS)

--- a/ui/webview/commands.ts
+++ b/ui/webview/commands.ts
@@ -14,10 +14,22 @@ export type PaletteCommand = {
   run: () => void;
 };
 
+// Every DEFAULT key binding, by command id — ONE table, so the palette registration below, the shell
+// dispatcher, and the hover hints (keybindings' titleWithKey) can never disagree about what a command
+// answers to out of the box. A command absent here ships unbound; the shortcuts dialog can still bind
+// it, and every surface reads the result from the overrides store.
+export const DEFAULT_CHORDS: Record<string, string> = {
+  "session.jump": "Mod+O",
+  "session.new": "Mod+Shift+O",
+  "palette.toggle": "Mod+P",
+};
+
 const commands = new Map<string, PaletteCommand>();
 
 export function registerCommand(cmd: PaletteCommand): void {
-  commands.set(cmd.id, cmd);   // re-registering an id replaces it, so a re-boot never duplicates
+  // re-registering an id replaces it, so a re-boot never duplicates; the default chord comes from the
+  // one table above unless the caller carries its own
+  commands.set(cmd.id, cmd.chord === undefined ? { ...cmd, chord: DEFAULT_CHORDS[cmd.id] } : cmd);
 }
 
 export function commandList(): PaletteCommand[] {

--- a/ui/webview/hotkey-hints.test.ts
+++ b/ui/webview/hotkey-hints.test.ts
@@ -1,0 +1,67 @@
+// Hover discoverability (the user 2026-08-10): every button that runs a command advertises the
+// command's CURRENT binding in its tooltip — the live overrides store, never a hardcoded chord — so
+// the shortcuts are discoverable by hovering the control that does the same thing.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { DEFAULT_CHORDS, registerCommand, commandList } from "./commands";
+import { displayChord, keyHint, titleWithKey } from "./keybindings";
+
+const p = (...f: string[]) => path.resolve(process.cwd(), "..", ...f);
+
+// keyHint detects the platform from `navigator` (which node ≥21 exposes), so expectations are built
+// through the same displayChord it uses — the tests assert the plumbing, not the runner's platform.
+const MAC = typeof navigator !== "undefined" && /Mac|iP(hone|ad|od)/.test((navigator as any).platform || "");
+const disp = (chord: string) => displayChord(chord, MAC);
+
+// node has no localStorage; install a stub so the overrides store is exercisable, and restore after.
+function withOverrides(overrides: Record<string, string>, fn: () => void): void {
+  const g: any = globalThis;
+  const had = "localStorage" in g, prev = g.localStorage;
+  g.localStorage = { getItem: (k: string) => (k === "romp:keys" ? JSON.stringify(overrides) : null),
+                     setItem: () => {} };
+  try { fn(); } finally { if (had) g.localStorage = prev; else delete g.localStorage; }
+}
+
+test("registerCommand fills the default chord from the ONE table", () => {
+  registerCommand({ id: "session.new", title: "New session", run: () => {} });
+  const c = commandList().find((x) => x.id === "session.new")!;
+  assert.equal(c.chord, DEFAULT_CHORDS["session.new"], "call sites declare no chord; the table is the source");
+  assert.equal(c.chord, "Mod+Shift+O");
+});
+
+test("titleWithKey appends the current binding; the bare title when unbound", () => {
+  // no localStorage in node → no overrides → the default chord shows
+  assert.equal(titleWithKey("Open a session", "session.new"), `Open a session (${disp("Mod+Shift+O")})`);
+  assert.equal(titleWithKey("Open the log", "log.open"), "Open the log", "log.open ships unbound → no hint");
+  assert.equal(titleWithKey("Open a session", "no.such.command"), "Open a session");
+});
+
+test("a REBIND changes what the next hover says; an explicit unbind removes the hint", () => {
+  withOverrides({ "session.new": "Ctrl+K" }, () => {
+    assert.equal(titleWithKey("Open a session", "session.new"), `Open a session (${disp("Ctrl+K")})`);
+  });
+  withOverrides({ "session.new": "" }, () => {
+    assert.equal(titleWithKey("Open a session", "session.new"), "Open a session",
+      "deliberately unbound → the tooltip stops advertising the default");
+  });
+  // …and a command with NO default becomes discoverable the moment the user binds it
+  withOverrides({ "log.open": "Alt+ArrowDown" }, () => {
+    assert.equal(keyHint("log.open"), disp("Alt+ArrowDown"), "named keys wear their keycap form");
+  });
+});
+
+test("the shell sweeps [data-keycmd] tooltips and re-syncs on every rebind", () => {
+  const MAIN = fs.readFileSync(p("ui", "webview", "palette-main.ts"), "utf8");
+  assert.match(MAIN, /querySelectorAll\("\[data-keycmd\]"\)/);
+  assert.match(MAIN, /el\.title = titleWithKey\(base, el\.dataset\.keycmd \|\| ""\)/);
+  assert.match(MAIN, /window\.addEventListener\(KEYS_EVENT, syncKeyTitles\);/);
+  assert.match(MAIN, /window\.addEventListener\("storage", syncKeyTitles\);/, "a rebind in another tab counts too");
+  assert.match(MAIN, /w\.__rompKeyHint = keyHint;/, "the landing page's inline scripts (pane toggles) read this");
+});
+
+test("the chat strip's + button carries the binding", () => {
+  const RENDER = fs.readFileSync(p("ui", "webview", "render.ts"), "utf8");
+  assert.match(RENDER, /add\.title = titleWithKey\("Open a session", "session\.new"\);/);
+});

--- a/ui/webview/keybindings.ts
+++ b/ui/webview/keybindings.ts
@@ -10,6 +10,8 @@
 // their KeyboardEvent.key spelling. Defaults are declared with the "Mod" placeholder ("Mod+O"), which
 // resolves to Meta on a Mac and Ctrl elsewhere — one declaration, both platforms.
 
+import { DEFAULT_CHORDS } from "./commands";
+
 export type Bindings = Record<string, string>;   // command id → chord ("" = deliberately unbound)
 
 const KEY = "romp:keys";
@@ -107,6 +109,25 @@ export function conflictOf(chord: string, forId: string, cmds: { id: string; cho
     if (effectiveChord(c.id, c.chord, overrides, mac) === resolveChord(chord, mac)) return c.id;
   }
   return null;
+}
+
+// ── hover discoverability (the user 2026-08-10) ───────────────────────────────────────────────────
+
+// The binding a command answers to RIGHT NOW, in display form ("⌘⇧O" on a Mac, "Ctrl+Shift+O"
+// elsewhere); "" when unbound. Reads the live overrides store, so a rebind changes what the next
+// hover says — a tooltip advertises the user's configuration, never a stale default.
+export function keyHint(id: string): string {
+  const mac = typeof navigator !== "undefined" && /Mac|iP(hone|ad|od)/.test(navigator.platform || "");
+  const ch = effectiveChord(id, DEFAULT_CHORDS[id], loadOverrides(), mac);
+  return ch ? displayChord(ch, mac) : "";
+}
+
+// A control's tooltip with its command's current binding appended — "Open a session (⌘⇧O)" — so every
+// shortcut is discoverable by hovering the button that does the same thing (the user 2026-08-10).
+// The bare title when the command is unbound.
+export function titleWithKey(base: string, id: string): string {
+  const k = keyHint(id);
+  return k ? (base ? base + " (" + k + ")" : k) : base;
 }
 
 // ── the dispatch decision (pure: the wiring calls this per keydown) ───────────────────────────────

--- a/ui/webview/palette-main.ts
+++ b/ui/webview/palette-main.ts
@@ -9,7 +9,7 @@
 import { registerCommand, runCommand, commandList } from "./commands";
 import { initPalette, PickItem } from "./palette";
 import { initShortcutsModal } from "./shortcuts-modal";
-import { chordMap, chordOf, dispatchable, displayChord, effectiveChord, loadOverrides, KEYS_EVENT } from "./keybindings";
+import { chordMap, chordOf, dispatchable, displayChord, effectiveChord, keyHint, loadOverrides, titleWithKey, KEYS_EVENT } from "./keybindings";
 import { hostPrefix } from "./host-prefix";   // pure display helper — safe here (never federation.ts, which boots a manager on import)
 
 type SessionRow = { id: string; name: string; dir: string; bg: string };
@@ -97,8 +97,10 @@ type SessionRow = { id: string; name: string; dir: string; bg: string };
   // ── the dashboard's actions, registered as commands ──────────────────────────────────────
   // Each calls the SAME code path its rail button uses; the palette adds reachability, not
   // behavior.
-  registerCommand({ id: "session.jump", title: "Jump to a session", chord: "Mod+O", run: openSessionSwitcher });
-  registerCommand({ id: "session.new", title: "New session", chord: "Mod+Shift+O", run: openNewSessionPicker });
+  // Default chords come from commands.ts's DEFAULT_CHORDS — one table for the palette, the
+  // dispatcher, and the hover hints — so none is declared at these call sites.
+  registerCommand({ id: "session.jump", title: "Jump to a session", run: openSessionSwitcher });
+  registerCommand({ id: "session.new", title: "New session", run: openNewSessionPicker });
   registerCommand({
     id: "settings.open", title: "Open settings",
     run: () => { try { pane("f-feed")!.contentWindow!.postMessage({ romp: "openSettings" }, "*"); } catch (e) { /* feed not loaded */ } },
@@ -129,7 +131,7 @@ type SessionRow = { id: string; name: string; dir: string; bg: string };
   // The palette toggle is itself a bindable command — hidden from the palette's own list (running
   // "toggle the palette" from the palette would just blink it). Cmd+Shift+P deliberately stays
   // unbound: it is the browser's / VS Code's own palette.
-  registerCommand({ id: "palette.toggle", title: "Command palette", chord: "Mod+P", hidden: true, run: () => palette.toggle() });
+  registerCommand({ id: "palette.toggle", title: "Command palette", hidden: true, run: () => palette.toggle() });
 
   // The shortcuts dialog: every command above, rebindable — VS Code's grammar, the browser's home
   // (the user 2026-08-09). Reachable from the palette, the gear's customize link ({romp:'openKeys'}
@@ -139,6 +141,26 @@ type SessionRow = { id: string; name: string; dir: string; bg: string };
   w.__rompKeysOpen = () => keys.open();
   w.__rompKeysClose = () => keys.close();   // false when not open — the Escape chain moves on
   window.addEventListener("message", (e) => { if (e.data && e.data.romp === "openKeys") keys.open(); });
+
+  // ── hover discoverability (the user 2026-08-10) ───────────────────────────────────────────────
+  // Every shell control that runs a command carries data-keycmd=<command id> (the rail buttons and
+  // the mobile bar's, in the landing HTML); this sweep appends the command's CURRENT binding to its
+  // tooltip and re-runs on every rebind, so shortcuts are discoverable by hovering the button that
+  // does the same thing — and a rebound command never advertises a stale chord. The original title
+  // is kept in data-kt0 so the sweep is idempotent. __rompKeyHint serves the landing page's inline
+  // scripts (the pane toggles, whose titles are rewritten per toggle), and the KEYS_EVENT nudge
+  // below hands them their first hints once this module has booted.
+  function syncKeyTitles(): void {
+    for (const el of Array.from(document.querySelectorAll("[data-keycmd]")) as HTMLElement[]) {
+      const base = el.dataset.kt0 !== undefined ? el.dataset.kt0 : (el.dataset.kt0 = el.title || "");
+      el.title = titleWithKey(base, el.dataset.keycmd || "");
+    }
+  }
+  w.__rompKeyHint = keyHint;
+  syncKeyTitles();
+  window.addEventListener(KEYS_EVENT, syncKeyTitles);
+  window.addEventListener("storage", syncKeyTitles);
+  try { window.dispatchEvent(new Event(KEYS_EVENT)); } catch (e) { /* nudge inline listeners once __rompKeyHint exists */ }
 
   // ONE dispatcher for every bound chord, rebuilt lazily when the store changes (KEYS_EVENT from
   // this document's saves, `storage` from another tab's).

--- a/ui/webview/palette.test.ts
+++ b/ui/webview/palette.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { DEFAULT_CHORDS } from "./commands";
 
 const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
 const PALETTE = read("palette.ts");
@@ -57,12 +58,17 @@ test("session rows wear the TAB identity language: bold name in the session colo
 
 // ── the shell boot: the bindings dispatcher, wired into every pane ─────────────────────────
 test("the defaults hold — Mod+O jump, Mod+Shift+O picker, Mod+P palette — through the bindings store", () => {
-  // the chords are DEFAULTS on the commands now (the user 2026-08-09, configurable shortcuts):
-  // one dispatcher resolves keydown → chord → command through the user's overrides
-  assert.match(MAIN, /registerCommand\(\{ id: "session\.jump", title: "Jump to a session", chord: "Mod\+O", run: openSessionSwitcher \}\);/);
-  assert.match(MAIN, /registerCommand\(\{ id: "session\.new", title: "New session", chord: "Mod\+Shift\+O", run: openNewSessionPicker \}\);/);
+  // the chords are DEFAULTS on the commands now (the user 2026-08-09, configurable shortcuts), and
+  // since 2026-08-10 they live in commands.ts's DEFAULT_CHORDS — one table shared with the hover
+  // hints — with registerCommand filling them in by id; one dispatcher resolves keydown → chord →
+  // command through the user's overrides
+  assert.equal(DEFAULT_CHORDS["session.jump"], "Mod+O");
+  assert.equal(DEFAULT_CHORDS["session.new"], "Mod+Shift+O");
+  assert.equal(DEFAULT_CHORDS["palette.toggle"], "Mod+P");
+  assert.match(MAIN, /registerCommand\(\{ id: "session\.jump", title: "Jump to a session", run: openSessionSwitcher \}\);/);
+  assert.match(MAIN, /registerCommand\(\{ id: "session\.new", title: "New session", run: openNewSessionPicker \}\);/);
   // the palette toggle is itself bindable, hidden from its own list; Cmd+Shift+P stays the browser's
-  assert.match(MAIN, /id: "palette\.toggle", title: "Command palette", chord: "Mod\+P", hidden: true/);
+  assert.match(MAIN, /id: "palette\.toggle", title: "Command palette", hidden: true/);
   assert.match(MAIN, /if \(!dispatchable\(e, isTyping\(e\.target\)\)\) return;/);
   assert.match(MAIN, /byChord = chordMap\(commandList\(\), loadOverrides\(\), mac\);/);
   assert.match(MAIN, /e\.preventDefault\(\); e\.stopPropagation\(\);\s*\n\s*palette\.close\(\);.*\n\s*runCommand\(id\);/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -21,6 +21,7 @@ import { isClearCmd, openTopTitles, clearConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
 import { reconcileTabOrder } from "./tab-order";
 import { writeViewOrder } from "./view-order";
+import { titleWithKey } from "./keybindings";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
@@ -3641,7 +3642,11 @@ function renderTabs() {
   }
   const add = el("div", "tab tab-add");
   add.textContent = "+";
-  add.title = "Open a session";
+  // tooltip carries the CURRENT binding (the user 2026-08-10: shortcuts discoverable by hover). True on
+  // every surface: the shell dispatches the effective chord from the same store this reads, and outside
+  // the shell (VS Code / standalone, their own localStorage → the default) the in-page Cmd+O fallback
+  // below answers it. Rebuilt with the strip each push, so a rebind shows on the next render.
+  add.title = titleWithKey("Open a session", "session.new");
   add.addEventListener("click", () => openPicker());
   bar.appendChild(add);
   // Restore tab-mode focus if a tab held it before this rebuild (see the top of renderTabs).


### PR DESCRIPTION
User request (2026-08-10): hovering any button that runs a command should show the current hotkey configuration for that action, so shortcuts are discoverable by hovering.

**Mechanism** (one, small): tooltips append the command's **effective** binding, read live from the `romp:keys` overrides store — never a hardcoded chord. A rebind updates the tooltips (KEYS_EVENT + cross-tab `storage`), and an explicitly unbound command drops the hint.

- `commands.ts` grows `DEFAULT_CHORDS` — the single table `registerCommand` fills chords from, so the palette chips, the dispatcher, and the hover hints cannot drift.
- `keybindings.ts` grows `keyHint(id)` / `titleWithKey(base, id)` ("Open a session (⌘⇧O)").
- `palette-main.ts` sweeps every shell element carrying `data-keycmd`, on boot and on each rebind, and publishes `__rompKeyHint` for the landing page's inline scripts.

**Wired controls:** the chat strip's `+` (session.new — rebuilt per push, so it tracks rebinds), the rail's log / restart / net / gear / usage, their mobile-bar twins, and the pane toggles (their per-toggle title rewrite appends the hint and refreshes on rebinds). Commands that ship unbound (log.open etc.) show their plain tooltip until the user binds one in the shortcuts dialog — then the binding appears on hover.

Tests: behavioral coverage of the table-fill, the append/unbind/rebind rules (`hotkey-hints.test.ts`), landing-HTML pins (`tests/test_hotkey_hints.py`), and updated pins in `palette.test.ts` / `test_kernel_mobile.py`. Suites: 4166 Python + 1795 node, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)