### PR TITLE
kernel: scan past wedged task notifications for the machine-cut resume notice

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -166,20 +166,22 @@ def _turn_romp_injected(turn):
 # The discriminating phrases in the resume notices romp injects to CONTINUE a machine-cut turn
 # (sdk_backend.BOOT_RESUME_NUDGE / CRASH_RESUME_NUDGE). A kernel restart or the session's own claude
 # process dying mid-turn ALSO mints a "[Request interrupted by user]" stop record — but romp, not the
-# user, caused that cut and immediately queued one of these notices as the very next user-role message
-# to pick the work back up. Matching on them (the SAME signal _stamp_interrupt_causes reads for the
-# chat seam's cause label) tells a MACHINE cut from a genuine user stop. Kept in lockstep with the
-# nudge text by test_kernel_interrupt_machine_cut.
+# user, caused that cut and immediately queued one of these notices to pick the work back up. The
+# notice is queued FIRST but is not always the very next user-role record on disk: a background task
+# the same restart killed can land its `<task-notification>` in between (the user 2026-08-10), which
+# is why _machine_cut_cause scans rather than peeking one atom. Matching on these phrases (the SAME
+# signal _stamp_interrupt_causes reads for the chat seam's cause label) tells a MACHINE cut from a
+# genuine user stop. Kept in lockstep with the nudge text by test_kernel_interrupt_machine_cut.
 INTR_RESTART_SIG = "kernel restarted and cut"        # BOOT_RESUME_NUDGE
 INTR_CRASH_SIG = "died mid-turn"                      # CRASH_RESUME_NUDGE
 
 
 def _interrupt_cause(nxt_atom):
-    """The MACHINE-cut cause named by the romp resume notice that FOLLOWS an interrupt record (its very
-    next user-role atom), or None for a genuine user stop. 'restart' = a kernel restart cut the turn;
-    'crash' = the session's own claude process died mid-turn. Both are cuts romp itself caused and is
-    already continuing (via the injected resume notice) — never a user-chosen stop, so they must not
-    suppress the nudge nor paint the "you stopped this" badge (the user 2026-07-14)."""
+    """The MACHINE-cut cause a romp resume notice names, or None for anything else. 'restart' = a
+    kernel restart cut the turn; 'crash' = the session's own claude process died mid-turn. Both are
+    cuts romp itself caused and is already continuing (via the injected resume notice) — never a
+    user-chosen stop, so they must not suppress the nudge nor paint the "you stopped this" badge (the
+    user 2026-07-14). Pure per-atom classifier; _machine_cut_cause owns FINDING the notice."""
     body = (_atom_user_text(nxt_atom) or "") if nxt_atom else ""
     if INTR_RESTART_SIG in body:
         return "restart"
@@ -188,18 +190,40 @@ def _interrupt_cause(nxt_atom):
     return None
 
 
+def _machine_cut_cause(users, i):
+    """The machine-cut cause for the interrupt record at users[i], or None for a genuine user stop.
+    Scans FORWARD for romp's resume notice instead of trusting users[i + 1] alone (the user
+    2026-08-10): the restart that cuts a turn kills its background tasks too, and their
+    `<task-notification>` records (author 'system') land BETWEEN the stop record and the notice — the
+    one-atom lookahead read the notification, found no signature, and filed the machine cut as a user
+    stop, so the focus card re-blocked on the user (INTERRUPT_BLOCK_WHY) at the very moment its
+    finished answer arrived. Only romp's OWN atoms can name a cause (both resume nudges carry the
+    romp-injected marker, so they always author 'romp' — and a task notification whose output tail
+    happens to QUOTE a signature never reads as a notice). The scan stops at the first genuine human
+    message or the next interrupt record: past either, a notice belongs to a LATER cut, never this
+    one. Everything else (system notifications, peers, sdk, tool_result-only) is wedge — read past."""
+    for nxt in users[i + 1:]:
+        if nxt.get("author") == "romp":
+            cause = _interrupt_cause(nxt)
+            if cause:
+                return cause
+        elif em.is_interrupt_record(nxt) or nxt.get("author") == "human":
+            return None
+    return None
+
+
 def _interrupt_marks(turns):
     """(newest genuine user STOP, newest genuine human PROMPT) on this thread, in transcript time —
     the one place the two are tallied, so the predicate below and the interrupt block's EVIDENCE stamp
     read the same events. A MACHINE cut (kernel restart / process death) mints the same stop record but
-    is romp's own, so it never counts as a stop (_interrupt_cause, via the resume notice that follows
+    is romp's own, so it never counts as a stop (_machine_cut_cause, via the resume notice that follows
     it). The interrupt record itself authors 'human', so it's classified FIRST."""
     users = [a for turn in turns for a in (turn.get("atoms") or []) if a.get("type") == "user"]
     last_intr = last_human = 0
     for i, a in enumerate(users):
         t = a.get("t", 0)
         if em.is_interrupt_record(a):
-            if _interrupt_cause(users[i + 1] if i + 1 < len(users) else None):
+            if _machine_cut_cause(users, i):
                 continue                                 # machine cut → romp re-engaged, not the user
             last_intr = max(last_intr, t)
         elif a.get("author") == "human":
@@ -11586,9 +11610,13 @@ def _interrupt_settle(events, txt, atom=None):
 def _stamp_interrupt_causes(events):
     """Label each interrupt marker with WHY the turn was cut, when the transcript itself says: after a
     kernel-restart cut (BOOT_RESUME_NUDGE) or a mid-turn process death (CRASH_RESUME_NUDGE) the resume
-    notice romp injects is the next user-role event, so the seam reads "interrupted — kernel restart"
-    instead of implying the user pressed stop (the user 2026-07-09). Event-based: keyed on the notice
-    record romp itself wrote, never a time window. No notice → a genuine user stop → unlabeled."""
+    notice romp injects follows the marker, so the seam reads "interrupted — kernel restart" instead
+    of implying the user pressed stop (the user 2026-07-09). Event-based: keyed on the notice record
+    romp itself wrote, never a time window. No notice → a genuine user stop → unlabeled. The scan
+    reads PAST non-human user records (the user 2026-08-10: a `<task-notification>` from a background
+    task the same restart killed wedged between the marker and the notice, and "first user-role event
+    decides" mislabeled the machine cut as a user stop) — only romp's own notice, the user speaking,
+    or the NEXT cut's marker decides the seam."""
     for i, ev in enumerate(events):
         if not ev.get("interruptMarker"):
             continue
@@ -11601,7 +11629,7 @@ def _stamp_interrupt_causes(events):
             if nxt.get("rompSystem"):
                 body = nxt.get("md") or ""
                 cause = ("restart" if INTR_RESTART_SIG in body else    # same signatures the nudge gate
-                         "crash" if INTR_CRASH_SIG in body else None)  # reads (_interrupt_cause)
+                         "crash" if INTR_CRASH_SIG in body else None)  # reads (_machine_cut_cause)
                 if cause:
                     ev["interruptCause"] = cause
                     # A MACHINE cut leaves no "no response — turn settled" line (the user 2026-07-22): romp
@@ -11612,7 +11640,12 @@ def _stamp_interrupt_causes(events):
                     # time-marker restampMarkers still measures (at y=0), throwing off the spacing pass.
                     for s in settles:
                         s["_dropSettle"] = True
-            break                                         # first user-role event decides; a typed prompt = user stop
+                break                                     # romp's own notice decides, matched or not
+            if nxt.get("interruptMarker") or nxt.get("human"):
+                break                                     # a typed prompt = user stop; a later marker owns
+                #                                           any notice past it (never this seam's)
+            # any other user record — a `<task-notification>` from a background task the same restart
+            # killed — is wedge between the marker and the notice (the user 2026-08-10): read past it
     if any(e.get("_dropSettle") for e in events):
         events[:] = [e for e in events if not e.get("_dropSettle")]
     return events

--- a/tests/test_kernel_interrupt_machine_cut.py
+++ b/tests/test_kernel_interrupt_machine_cut.py
@@ -122,6 +122,48 @@ class MachineCutSuppression(unittest.TestCase):
                              uatom(T0 + 40, "ok, take plan B")])
         self.assertFalse(km._interrupt_suppresses_nudge(turns))
 
+    # --- the wedge (the user 2026-08-10): the restart that cuts the turn kills its background tasks
+    # too, and their `<task-notification>` records land BETWEEN the stop record and the resume notice.
+    # The one-atom lookahead read the notification, found no signature, and filed the machine cut as a
+    # user stop — so the focus card re-blocked "you stopped this session mid-turn" at the very moment
+    # its finished answer arrived.
+
+    WEDGE = "<task-notification>the restart killed background task b0000000000</task-notification>"
+
+    def test_a_wedged_task_notification_does_not_hide_the_cut(self):
+        turns = self._turns([uatom(T0, "wire the thing"), intr(T0 + 60),
+                             uatom(T0 + 61, self.WEDGE, "system"),
+                             uatom(T0 + 62, sb.BOOT_RESUME_NUDGE, "romp")])
+        self.assertFalse(km._interrupt_suppresses_nudge(turns),
+                         "the notice past the wedged notification still names the cut as romp's")
+
+    def test_a_genuine_stop_with_a_trailing_notification_still_suppresses(self):
+        # same wedge, no notice anywhere: the stop is real — scanning past the notification must
+        # never invent a machine cut
+        turns = self._turns([uatom(T0, "wire the thing"), intr(T0 + 60),
+                             uatom(T0 + 61, self.WEDGE, "system")])
+        self.assertTrue(km._interrupt_suppresses_nudge(turns))
+
+    def test_a_notification_quoting_a_signature_is_not_a_notice(self):
+        # a background task's output tail can QUOTE the signature phrase (romp's own test runs echo the
+        # nudge texts) — only romp's OWN notice (author 'romp') names a cause, never a notification body
+        quoting = "<task-notification>test output: '%s'</task-notification>" % km.INTR_RESTART_SIG
+        turns = self._turns([uatom(T0, "wire the thing"), intr(T0 + 60),
+                             uatom(T0 + 61, quoting, "system")])
+        self.assertTrue(km._interrupt_suppresses_nudge(turns),
+                        "a genuine stop stays a stop even when a notification echoes the phrase")
+
+    def test_a_notice_past_the_next_stop_record_stays_a_user_stop(self):
+        # genuine stop → a romp nudge re-engages → the nudged turn is machine-cut and resumed: the scan
+        # for the FIRST record stops at the second record, so the later notice never reaches back to
+        # disown the real stop — and the user's stop is still the newest thing THEY did → suppressed
+        turns = self._turns([uatom(T0, "wire the thing"), intr(T0 + 10),
+                             uatom(T0 + 20, "status? pick it back up", "romp"),
+                             intr(T0 + 30),
+                             uatom(T0 + 31, sb.BOOT_RESUME_NUDGE, "romp")])
+        self.assertTrue(km._interrupt_suppresses_nudge(turns),
+                        "the notice belongs to the SECOND cut; the first stop is the user's")
+
 
 class _FeedHarness(unittest.TestCase):
     """Shared transcript + store + feed fixture for the tick-level classes below (no tests of its
@@ -158,14 +200,20 @@ class _FeedHarness(unittest.TestCase):
         km._autonudge_cache.clear()
         self.td.cleanup()
 
-    def _machine_cut(self, notice):
+    def _machine_cut(self, notice, wedge=None):
         # a genuine turn CUT mid-flight (interrupt record ends it), then romp's resume notice opens a
-        # fresh turn that ran and re-stalled with the goal still working
+        # fresh turn that ran and re-stalled with the goal still working. `wedge`: a user-role record
+        # (a `<task-notification>` from a background task the same restart killed) that lands BETWEEN
+        # the stop record and the notice (the user 2026-08-10)
         recs = [uline(T0, "wire the thing", "u1"),
                 aline(T0 + 20, "digging in", "a1", "u1", "tool_use"),
-                uline(T0 + 60, "[Request interrupted by user]", "u2", "a1"),
-                uline(T0 + 61, notice, "u3", "u2"),
-                aline(T0 + 80, "picked it back up; still on it", "a2", "u3", "end_turn")]
+                uline(T0 + 60, "[Request interrupted by user]", "u2", "a1")]
+        prev = "u2"
+        if wedge:
+            recs.append(uline(T0 + 61, wedge, "u2b", prev))
+            prev = "u2b"
+        recs += [uline(T0 + 62, notice, "u3", prev),
+                 aline(T0 + 80, "picked it back up; still on it", "a2", "u3", "end_turn")]
         self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
 
     def _genuine_stop(self):
@@ -245,6 +293,21 @@ class MachineCutFeedAndNudge(_FeedHarness):
         km._interrupt_block_tick(NOW, self.tmux)
         self.assertEqual(jd.load_goals(SID)["status"][SID + ":gw"], "working")
         self.assertFalse(self._card().get("interrupted"))
+
+    def test_restart_cut_with_a_wedged_task_notification_is_not_blocked(self):
+        # end to end through the real parse (author_of assigns the wedge 'system', the notice 'romp'):
+        # the notification a dying background task lands between the stop record and the notice must
+        # not turn the machine cut into "you stopped this session mid-turn" (the user 2026-08-10 — the
+        # audited card re-blocked at the very moment its finished answer arrived)
+        self._machine_cut(sb.BOOT_RESUME_NUDGE,
+                          wedge="<task-notification>the restart killed a background task"
+                                "</task-notification>")
+        self._goal()
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(jd.load_goals(SID)["status"][SID + ":gw"], "working",
+                         "a machine cut is continued even when a notification wedges before the notice")
+        self.assertFalse(self._card().get("interrupted"))
+        self.assertEqual(self._card()["column"], "working")
 
     # --- genuine user stop: blocked (needs-you) even with auto-nudge OFF --------------------------
 

--- a/tests/test_kernel_interrupt_seam.py
+++ b/tests/test_kernel_interrupt_seam.py
@@ -111,6 +111,27 @@ class StampInterruptCauses(unittest.TestCase):
         km._stamp_interrupt_causes(evs)
         self.assertEqual(evs[0].get("interruptCause"), "restart")
 
+    def test_a_wedged_task_notification_does_not_hide_the_notice(self):
+        # a `<task-notification>` from a background task the same restart killed lands BETWEEN the
+        # marker and the notice (the user 2026-08-10) — a non-human user record, so the scan reads
+        # past it instead of ruling "a typed prompt = user stop" on it
+        evs = self._events("[romp] The romp kernel restarted and cut this session's in-flight turn; …")
+        evs.insert(3, {"kind": "user", "md": "",
+                       "reminders": ["<task-notification>a background task stopped</task-notification>"]})
+        km._stamp_interrupt_causes(evs)
+        self.assertEqual(evs[0].get("interruptCause"), "restart")
+
+    def test_a_second_marker_before_the_notice_keeps_the_first_seam_a_user_stop(self):
+        # genuine stop, then a machine cut further down: the later cut's notice labels ITS OWN seam,
+        # never the earlier one — the scan for the first marker stops at the second marker
+        evs = self._events(None)
+        evs.append(dict(MARKER))
+        evs.append({"kind": "user", "romp": True, "rompSystem": True,
+                    "md": "[romp] The romp kernel restarted and cut this session's in-flight turn; …"})
+        km._stamp_interrupt_causes(evs)
+        self.assertNotIn("interruptCause", evs[0], "the notice belongs to the SECOND cut")
+        self.assertEqual(evs[-2].get("interruptCause"), "restart")
+
 
 class BuildSessionWiring(unittest.TestCase):
     """build_session is too dependency-heavy to run here (live backends) — source pins, matching the


### PR DESCRIPTION
Opening on behalf of session bug (its own PR creation was permission-blocked; the branch is pushed as machine-cut-wedge, full suite reported green — 4171 passed).

From the commit: a kernel restart that cuts a turn kills that turn's background tasks too, and their `<task-notification>` records can land between the CLI's stop record and the resume notice romp queues. Both machine-cut classifiers trusted the very next user-role record, so a wedged notification hid the notice and the cut was filed as a user stop — the focus card re-blocked with the interrupt-why at the very moment its finished answer arrived, and the chat seam lost its "kernel restart" label. Both now scan forward: only romp's own atoms can name a cause, and the scan stops at the first genuine human message or the next interrupt record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)