### PR TITLE
Wrapped statusline controls cluster right; a failed bundle build cures dep drift

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -22012,7 +22012,13 @@ def _ensure_bundles():
     (render.ts, styles.css, feed.ts, …), so an edit there never marked the bundle stale — a
     render.ts-only fix could sit unshipped through every kernel restart, with the ?v= cache token
     frozen so browsers kept the old bundle as well (found 2026-08-09 hunting the optimistic-echo
-    bug: the docstring promised a rebuild the check couldn't see)."""
+    bug: the docstring promised a rebuild the check couldn't see).
+
+    A failed build gets ONE retry after `npm install`: the common failure is dep drift — a merged
+    commit imports a package this machine's node_modules predates (2026-08-10: the katex import
+    broke every restart's rebuild for a day, and the kernel served an eight-day-old bundle — no
+    fast toggle, no attach fixes — with only a stderr line saying so). npm install is exactly the
+    cure for that class, cheap when it's a no-op, and the retry stays loud when it isn't the cure."""
     cv = ROOT / "vscode-extension"
     render = DIST / "render.js"
     if not (cv / "node_modules").exists():
@@ -22033,8 +22039,15 @@ def _ensure_bundles():
         try:
             subprocess.run(argv, cwd=str(cv), check=True,
                            capture_output=True, timeout=120)
-        except Exception as e:
-            sys.stderr.write("romp-kernel: bundle build failed (%s) — UI may be stale\n" % e)
+        except Exception:
+            sys.stderr.write("romp-kernel: bundle build failed — refreshing UI deps (npm install) and retrying…\n")
+            try:
+                subprocess.run(["npm", "install", "--no-audit", "--no-fund"], cwd=str(cv), check=True,
+                               capture_output=True, timeout=300)
+                subprocess.run(argv, cwd=str(cv), check=True,
+                               capture_output=True, timeout=120)
+            except Exception as e:
+                sys.stderr.write("romp-kernel: bundle build failed (%s) — UI may be stale\n" % e)
 
 
 def _pid_alive(pid):

--- a/tests/test_bundle_build_mode.py
+++ b/tests/test_bundle_build_mode.py
@@ -57,6 +57,23 @@ class BundleBuildMode(unittest.TestCase):
         self.assertIn("ROMP_EXT_DEV_BUILD", _read(EXT_INSTALL))
         self.assertIn("ROMP_EXT_DEV_BUILD", _read(KERNEL))
 
+    def test_a_failed_build_retries_once_after_npm_install(self):
+        """The common build failure is DEP DRIFT: a merged commit imports a package this machine's
+        node_modules predates, so every restart's rebuild fails and the kernel silently serves the
+        old bundle (2026-08-10: the katex import kept an eight-day-old render.js live — no fast
+        toggle, no attach fixes — with only a stderr line saying so). npm install is exactly the
+        cure for that class, so a failed build must refresh deps and retry once — and still be
+        loud when that isn't the cure."""
+        src = _read(KERNEL)
+        m = re.search(r"def _ensure_bundles\(\):.*?(?=\ndef )", src, re.S)
+        body = m.group(0)
+        self.assertIn('"npm", "install"', body,
+                      "a failed build must refresh UI deps — dep drift is the common cause")
+        self.assertEqual(body.count("subprocess.run(argv"), 2,
+                         "…and retry the same build command once after the refresh")
+        self.assertIn("UI may be stale", body,
+                      "a retry that still fails must stay loud")
+
     def test_the_staleness_scan_covers_every_source_root_esbuild_reads(self):
         """esbuild.js builds the webview entrypoints from ../ui/webview (render.ts, styles.css,
         feed.ts, …), but _ensure_bundles used to scan only vscode-extension/src — so a

--- a/ui/webview/picker-dir.test.ts
+++ b/ui/webview/picker-dir.test.ts
@@ -45,7 +45,7 @@ test("a session carries cwd, shown on the statusline just left of the mode/model
   // #spinner-meta (the controls cluster)
   assert.match(RENDER, /el\("span", "status-dir"\)/);
   assert.match(RENDER, /asFolderLink\(dir, s\.cwd, activeId \|\| undefined\)/);
-  assert.match(RENDER, /sl\.appendChild\(dir\);[\s\S]*?const meta = el\("span", "spinner-meta"\)/);
+  assert.match(RENDER, /right\.appendChild\(dir\);[\s\S]*?const meta = el\("span", "spinner-meta"\)/);
   // and NOT on the tab anymore (the user 2026-06-23)
   assert.doesNotMatch(RENDER, /tab-dir/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7292,9 +7292,15 @@ function updateStatusline() {
   // INTERRUPTING (the stop is already in flight; re-pressing it is a lie — the user 2026-07-02).
   if (s.status.state === "working" || s.status.state === "compacting"
       || s.status.state === "retrying" || s.status.state === "blocked") sl.appendChild(stopButton(s.status.state));
+  // The right-side cluster — dir · branch · mode/model/effort/fast badges · ctx battery — grouped in ONE
+  // container (.sl-right) that carries the right-justify margin and wraps INTERNALLY with right-aligned
+  // rows. Grouped, not flat: when a narrow pane wraps the statusline, flat children restart each extra row
+  // at the LEFT edge (justify only reaches the row holding the auto margin) — the user 2026-08-10, on a
+  // phone, wanted the wrapped controls to stay clustered on the right.
+  const right = el("span", "sl-right");
   // The session's working directory (fixed at creation), leading the right-side cluster — just left of the
-  // mode/model/effort controls (the user 2026-06-23). Basename only; full path on hover. It carries the
-  // right-justify margin so it anchors the cluster; empty (rare, no cwd) it's a zero-width spacer.
+  // mode/model/effort controls (the user 2026-06-23). Basename only; full path on hover. Empty (rare, no
+  // cwd) it's a zero-width spacer.
   const dir = el("span", "status-dir");
   if (s.cwd) {
     dir.appendChild(folderIcon());
@@ -7305,7 +7311,7 @@ function updateStatusline() {
     // activeId rides along so a REMOTE session's click SSHes out instead of no-op'ing on a local path (2026-07-03).
     asFolderLink(dir, s.cwd, activeId || undefined);
   }
-  sl.appendChild(dir);
+  right.appendChild(dir);
   // The session's git branch, just right of the dir — only when known and only if the user hasn't hidden it
   // (Settings → "Show git branch", on by default — the user 2026-06-23). Read from the TOP-LEVEL session field,
   // never the head system event: that event is windowed out of the wire tail on any >250-event session, which
@@ -7314,15 +7320,16 @@ function updateStatusline() {
     const br = el("span", "status-branch");
     br.textContent = "⎇ " + s.gitBranch;
     br.title = "git branch: " + s.gitBranch;
-    sl.appendChild(br);
+    right.appendChild(br);
   }
   const meta = el("span", "spinner-meta");
   meta.id = "spinner-meta";
   syncMetaControls(meta, s.status);
-  sl.appendChild(meta);
+  right.appendChild(meta);
   const bar = ctxBar();
   setCtxBar(bar, s.status.ctx, s.status.state === "compacting", s.status.ctxColor);
-  sl.appendChild(bar);
+  right.appendChild(bar);
+  sl.appendChild(right);
 }
 
 // Unsent composer text, per session — a draft belongs to the tab it was typed

--- a/ui/webview/statusline-branch.test.ts
+++ b/ui/webview/statusline-branch.test.ts
@@ -31,7 +31,7 @@ test("updateStatusline appends a status-branch span from the top-level gitBranch
 
 test("the branch span sits right after the dir, before the meta cluster", () => {
   // ordering: status-dir append → branch block → spinner-meta
-  assert.match(RENDER, /sl\.appendChild\(dir\);[\s\S]*?status-branch[\s\S]*?const meta = el\("span", "spinner-meta"\)/);
+  assert.match(RENDER, /right\.appendChild\(dir\);[\s\S]*?status-branch[\s\S]*?const meta = el\("span", "spinner-meta"\)/);
 });
 
 test("styles define .status-branch (dim mono, shrinks before the dir)", () => {

--- a/ui/webview/statusline-wrap.test.ts
+++ b/ui/webview/statusline-wrap.test.ts
@@ -2,12 +2,16 @@
 // battery) onto extra rows, not clip them (the user 2026-08-10, whose controls vanished one by one as
 // the pane shrank: the no-wrap flex row shrank the dir/branch to nothing and pushed the rest past the
 // right edge). The footer is flex: 0 0 auto, so extra rows grow it instead of overflowing.
+// And the wrapped rows stay CLUSTERED ON THE RIGHT (the user 2026-08-10, on a phone): the right-side
+// controls live in ONE .sl-right container that carries the auto margin and right-justifies its own
+// wrapped rows — flat statusline children would restart each extra row at the left edge.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
 test("the statusline wraps instead of clipping when the pane narrows", () => {
   assert.match(CSS, /\.statusline \{[^}]*flex-wrap: wrap/);
@@ -18,4 +22,23 @@ test("the meta-badge cluster wraps between badges, keeping each badge whole", ()
   assert.match(rule, /flex-wrap: wrap/);
   // badges must not break INSIDE their own label — the container wraps, the badge doesn't
   assert.match(rule, /white-space: nowrap/);
+  // its own wrapped badge rows hug the right edge too
+  assert.match(rule, /justify-content: flex-end/);
+});
+
+test("the right-side controls are one container whose wrapped rows hug the right edge", () => {
+  const rule = CSS.match(/\.sl-right \{[^}]*\}/)?.[0] || "";
+  assert.match(rule, /margin-left: auto/);        // the container, not .status-dir, anchors the cluster
+  assert.match(rule, /flex-wrap: wrap/);
+  assert.match(rule, /justify-content: flex-end/);
+  const dir = CSS.match(/\.status-dir \{[^}]*\}/)?.[0] || "";
+  assert.doesNotMatch(dir, /margin-left: auto/);  // the old flat-anchor must not come back
+});
+
+test("render.ts groups dir, branch, badges and ctx battery into .sl-right", () => {
+  assert.match(RENDER, /el\("span", "sl-right"\)/);
+  assert.match(RENDER, /right\.appendChild\(dir\)/);
+  assert.match(RENDER, /right\.appendChild\(meta\)/);
+  assert.match(RENDER, /right\.appendChild\(bar\)/);
+  assert.match(RENDER, /sl\.appendChild\(right\)/);
 });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -717,10 +717,19 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   0%, 100% { color: #1a1a1a; }   /* near-black */
   50%      { color: #0d9488; }   /* teal */
 }
+/* the right-side cluster — dir · branch · badges · ctx battery — ONE container carrying the
+   right-justify margin, wrapping INTERNALLY with right-aligned rows: a narrow pane's extra rows stay
+   clustered on the right edge instead of restarting at the left (the user 2026-08-10, on a phone;
+   flat statusline children right-justify only the row holding the auto margin). Same 10px column gap
+   the statusline uses between siblings, so the wide-pane look is unchanged. */
+.sl-right {
+  margin-left: auto; min-width: 0;
+  display: inline-flex; flex-wrap: wrap; justify-content: flex-end; align-items: center; gap: 4px 10px;
+}
 /* working directory (fixed at creation), leading the right-side cluster — just left of mode/model/effort.
-   Carries the right-justify margin so the whole cluster anchors right; basename only, full path on hover. */
+   Basename only, full path on hover. */
 .status-dir {
-  margin-left: auto; flex: 0 1 auto; min-width: 0; max-width: 200px;
+  flex: 0 1 auto; min-width: 0; max-width: 200px;
   color: var(--dim); font-family: var(--mono); font-size: 0.92em;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
@@ -740,13 +749,13 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .spinner-meta {
-  margin-left: 12px; /* sits just right of the directory; the cluster is right-justified by .status-dir */
+  margin-left: 12px; /* sits just right of the dir/branch; + .sl-right's 10px gap = the pre-cluster spacing */
   color: var(--dim);
   font-family: var(--mono);
   font-size: 0.92em;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;   /* each badge stays one line; the container wraps BETWEEN badges instead */
-  display: inline-flex; flex-wrap: wrap; align-items: center; gap: 4px 8px; min-width: 0;
+  display: inline-flex; flex-wrap: wrap; justify-content: flex-end; align-items: center; gap: 4px 8px; min-width: 0;
 }
 /* model / effort as click-to-change dropdowns */
 .meta-btn {


### PR DESCRIPTION
Two fixes from a phone-sized pane.

**Statusline: wrapped controls stay clustered on the right.** The wrap (90e21954) kept every control visible on a narrow pane, but flat statusline children right-justify only the row holding the auto margin — each wrapped row restarted at the left edge. The right-side controls (dir · branch · mode/model/effort/fast badges · ctx battery) now live in one `.sl-right` container that carries the auto margin and wraps internally with `justify-content: flex-end`, so every extra row hugs the right edge. Wide-pane spacing is unchanged.

**Kernel: a failed bundle build refreshes UI deps and retries once.** The common build failure is dep drift — a merged commit imports a package this machine's `node_modules` predates. Today that (the katex import) kept an eight-day-old render.js live through every restart — no fast toggle, no attach fixes — with only a stderr line saying so. `npm install` is exactly the cure for that class; a retry that still fails keeps the loud warning.

Tests: statusline-wrap.test.ts pins the container + right-justified wrap (picker-dir / statusline-branch order pins updated); test_bundle_build_mode.py pins the refresh-and-retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)