### PR TITLE
Mobile round: fast badge trims, branch opt-in, WS reassembly fixes attach, keyboard-aware picker

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15801,10 +15801,13 @@ def _ws_pong(wfile, lock, payload):
 
 
 def _ws_recv(rfile):
-    """Read one client (masked) frame → (opcode, payload bytes), or (None, None) on close/EOF."""
+    """Read one client (masked) frame → (opcode, payload bytes, fin), or (None, None, True) on
+    close/EOF. One FRAME, not one message: data messages may span several frames (FIN clear until
+    the last) — _ws_recv_message below reassembles them."""
     b = rfile.read(2)
     if len(b) < 2:
-        return None, None
+        return None, None, True
+    fin = bool(b[0] & 0x80)
     opcode = b[0] & 0x0F
     masked = b[1] & 0x80
     ln = b[1] & 0x7F
@@ -15816,7 +15819,47 @@ def _ws_recv(rfile):
     payload = bytearray(rfile.read(ln))
     for i in range(len(payload)):
         payload[i] ^= mask[i % 4]
-    return opcode, bytes(payload)
+    return opcode, bytes(payload), fin
+
+
+# Reassembly ceiling for one fragmented client message — comfortably above the UI's 50 MB attachment
+# ship cap (SHIP_MAX_BYTES in render.ts) after base64 + JSON overhead; a client streaming past it is
+# broken or hostile, and the connection ends rather than the kernel buffering without bound.
+_WS_MAX_MESSAGE = 80 * 1024 * 1024
+
+
+def _ws_recv_message(rfile, on_ping):
+    """Read frames until one COMPLETE data message is assembled → (opcode, payload), or (None, None)
+    on close/EOF/overrun. Browsers FRAGMENT large sends (RFC 6455 §5.4 — Chrome splits at ~128 KB),
+    and the old per-frame loop handed each fragment straight to json.loads: a phone photo's dropFile
+    (a multi-MB base64 message) dissolved into one unparseable JSON prefix plus a train of silently
+    dropped continuation frames, so the 📎 pick looked like it did nothing (the user 2026-08-10,
+    Chrome on a phone; small desktop files sat under the threshold, which is why it never surfaced).
+    Control frames may interleave between fragments: pings are answered via on_ping, pongs are
+    dropped, close ends the read."""
+    frag_op, frag = None, None
+    while True:
+        op, payload, fin = _ws_recv(rfile)
+        if op is None or op == 0x8:            # EOF / close
+            return None, None
+        if op == 0x9:                          # ping → pong (libraries ping by default and hang up without one)
+            on_ping(payload or b"")
+            continue
+        if op == 0xA:                          # unsolicited pong — nothing to do
+            continue
+        if op == 0x0:                          # continuation of an in-flight fragmented message
+            if frag is None:
+                continue                       # stray continuation with no opening frame — drop it
+            frag += payload
+            if len(frag) > _WS_MAX_MESSAGE:
+                return None, None
+            if fin:
+                out = bytes(frag)
+                return frag_op, out
+            continue
+        if fin:                                # the common case: a whole message in one frame
+            return op, payload
+        frag_op, frag = op, bytearray(payload)  # a data frame OPENING a fragmented message
 
 
 def _send_to_app(app, msg):
@@ -21843,12 +21886,12 @@ class Handler(BaseHTTPRequestHandler):
             _clients.append(client)
         try:
             while client["alive"]:
-                op, payload = _ws_recv(self.rfile)
-                if op is None or op == 0x8:           # EOF / close
+                # one COMPLETE message per iteration — fragments reassembled, pings answered inline
+                # (browsers fragment large sends: a phone photo's dropFile spans dozens of frames)
+                op, payload = _ws_recv_message(
+                    self.rfile, lambda payload: _ws_pong(self.wfile, lock, payload or b""))
+                if op is None:                         # EOF / close / a client overran the reassembly cap
                     break
-                if op == 0x9:                          # ping → pong (libraries ping by default and hang up without one)
-                    _ws_pong(self.wfile, lock, payload or b"")
-                    continue
                 # webview→kernel messages: on "ready", push the initial state to this client
                 try:
                     msg = json.loads(payload.decode("utf-8", "replace"))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19772,7 +19772,12 @@ def _landing():
             # iframe over the whole window (body.picker-open) so the overlay fills the screen and the list gets
             # the full height to scroll. Restored on close.
             "body.picker-open #chat-pane{display:block!important}"
-            "body.picker-open #f-chat{display:block;position:fixed;inset:0;z-index:200;background:transparent}"   # same transparency as the settings lift above
+            # Height = --app-h (the shell's live VISIBLE height, fed by the top-level visualViewport),
+            # not inset:0: the layout viewport ignores the phone keyboard, so a bottom-anchored lift sat
+            # half behind it — and, sized this way, the keyboard opening/closing reaches the iframe as
+            # its own resize event, which is what render.ts keys the picker's short-window fold on
+            # (the user 2026-08-10, Chrome on a phone).
+            "body.picker-open #f-chat{display:block;position:fixed;left:0;right:0;top:0;height:var(--app-h,100dvh);z-index:200;background:transparent}"   # same transparency as the settings lift above
             # ── pane rail (the user 2026-06-24; rotated to a BOTTOM BAR the user 2026-07-05): a thin toolbar with
             # Chat / Timeline / Outline / Feed toggles. It used to be a vertical strip on the far LEFT; it now runs
             # HORIZONTALLY across the bottom of .col, BELOW the timeline band (last child of .col). Each toggle is

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6305,8 +6305,12 @@ class ServeSecurity(unittest.TestCase):
         # render.ts posts {romp:'picker',on} and the shell lifts the chat iframe over the whole window
         # (body.picker-open), so the overlay fills the screen and the list gets the full height to scroll.
         html = km._landing()
-        # background:transparent — same as the settings lift: the opaque iframe element was the black-out
-        self.assertIn("body.picker-open #f-chat{display:block;position:fixed;inset:0;z-index:200;background:transparent}", html)
+        # background:transparent — same as the settings lift: the opaque iframe element was the black-out.
+        # Height rides --app-h (the shell's live VISIBLE height): the layout viewport ignores the phone
+        # keyboard, so an inset:0 lift sat half behind it, and the --app-h sizing is what delivers the
+        # keyboard to the iframe as its own resize — the event the picker's fold keys on (2026-08-10).
+        self.assertIn("body.picker-open #f-chat{display:block;position:fixed;left:0;right:0;top:0;"
+                      "height:var(--app-h,100dvh);z-index:200;background:transparent}", html)
         self.assertIn("body.picker-open #chat-pane{display:block!important}", html)         # un-hide it even if chat is toggled off
         self.assertIn("m.romp==='picker'", html)                                            # the shell listens for the picker post
         self.assertIn("document.body.classList.toggle('picker-open',!!m.on)", html)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4303,13 +4303,15 @@ class ViewBuilder(unittest.TestCase):
 
     def test_gear_has_show_git_branch_toggle(self):
         # the user 2026-06-23: a "Show git branch" checkbox controls whether the chat bottom-bar shows the
-        # session's git branch beside the dir. ON by default (showBranch !== false). It mirrors render.ts'
+        # session's git branch beside the dir. OFF by default since 2026-08-10 (the user, trimming the
+        # statusline for narrow panes): an explicit stored true opts in. It mirrors render.ts'
         # loadSettings().showBranch read, persisted in romp:settings.
         self.assertIn("id=rs-branch", _gear_src())
         self.assertIn("Show git branch", _gear_src())
         self.assertIn("s.showBranch = gb.checked", _gear_src())        # change → persist
-        self.assertIn("gb.checked = s.showBranch !== false", _gear_src())  # open → reflect (default ON)
-        self.assertIn("showBranch: true", _gear_src())                # load() default ON, both branches
+        self.assertIn("gb.checked = s.showBranch === true", _gear_src())  # open → reflect (default OFF)
+        self.assertIn("showBranch: false", _gear_src())               # load() default OFF, both branches
+        self.assertNotIn("showBranch: true", _gear_src())             # the old default must not linger
 
     def test_chat_body_has_an_explicit_send_button(self):
         # The web-dashboard composer (kernel _chat_body, a SECOND copy of vscode-extension/src/page-skeleton.chatBody)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6758,7 +6758,7 @@ class WsLoopResilience(unittest.TestCase):
 
         seq = list(frames)
         saved = km._ws_recv
-        km._ws_recv = lambda rfile: seq.pop(0) if seq else (0x8, b"")   # script the frames; (0x8)=close
+        km._ws_recv = lambda rfile: seq.pop(0) if seq else (0x8, b"", True)   # script the frames; (0x8)=close
         try:
             with contextlib.redirect_stderr(io.StringIO()):             # swallow the logged traceback
                 km.Handler._ws(FakeSelf())                              # returns normally on close / socket error
@@ -6768,14 +6768,14 @@ class WsLoopResilience(unittest.TestCase):
 
     def test_a_throwing_handler_does_not_end_the_loop(self):
         TEXT = 0x1
-        frames = [(TEXT, b'{"type":"a"}'), (TEXT, b'{"type":"b"}'), (0x8, b"")]   # a raises, b must still run
+        frames = [(TEXT, b'{"type":"a"}', True), (TEXT, b'{"type":"b"}', True), (0x8, b"", True)]   # a raises, b must still run
         seen = self._run_loop(frames, lambda msg: (_ for _ in ()).throw(RuntimeError("boom"))
                               if msg.get("type") == "a" else None)
         self.assertEqual(seen["types"], ["a", "b"], "'b' still processed after 'a' raised — the socket survived")
 
     def test_a_socket_error_propagates_and_stops_the_loop(self):
         TEXT = 0x1
-        frames = [(TEXT, b'{"type":"a"}'), (TEXT, b'{"type":"b"}'), (0x8, b"")]
+        frames = [(TEXT, b'{"type":"a"}', True), (TEXT, b'{"type":"b"}', True), (0x8, b"", True)]
         seen = self._run_loop(frames, lambda msg: (_ for _ in ()).throw(BrokenPipeError("gone")))
         self.assertEqual(seen["types"], ["a"], "a real socket error ends the loop — 'b' never runs (genuine disconnect)")
 

--- a/tests/test_sdk_kernel.py
+++ b/tests/test_sdk_kernel.py
@@ -437,7 +437,11 @@ class SdkMetadataParity(unittest.TestCase):
         d = tempfile.mkdtemp()
         # -c identity so this never depends on (or is polluted by) the machine's global git config.
         git = ["git", "-C", d, "-c", "user.email=romp-test@example.invalid", "-c", "user.name=romp test"]
-        subprocess.run(["git", "init", "-q", d], check=True, capture_output=True)
+        # --template= (empty): a machine-global init.templateDir would otherwise copy its hooks into
+        # this repo — a maintainer's gitleaks pre-commit hook failed the commit below whenever the
+        # scanner wasn't on the test shell's PATH (2026-08-10). The test is about branch derivation;
+        # no machine hook belongs in it.
+        subprocess.run(["git", "init", "-q", "--template=", d], check=True, capture_output=True)
         open(os.path.join(d, "f"), "w").write("x")
         subprocess.run(git + ["add", "f"], check=True, capture_output=True)
         subprocess.run(git + ["commit", "-qm", "c"], check=True, capture_output=True)

--- a/tests/test_shell_viewport_fit.py
+++ b/tests/test_shell_viewport_fit.py
@@ -55,7 +55,13 @@ class OneHeightBasis(unittest.TestCase):
         # (background:transparent rides the same rules: an opaque lifted iframe blacks out the window —
         # see test_kernel.test_settings_is_a_fullscreen_modal.)
         self.assertIn("body.settings-open #f-feed{display:block;position:fixed;inset:0;z-index:200;background:transparent}", self.html)
-        self.assertIn("body.picker-open #f-chat{display:block;position:fixed;inset:0;z-index:200;background:transparent}", self.html)
+        # The PICKER lift is the one exception on the VERTICAL axis: its height follows --app-h (the
+        # shell's live visible height) because the layout viewport ignores the phone keyboard — inset:0
+        # left the picker's lower rows behind it — and the --app-h sizing is also what turns the keyboard
+        # into an in-iframe resize event for the picker's short-window fold (the user 2026-08-10).
+        # Horizontally it stays inset-sized (left:0;right:0), no 100vw.
+        self.assertIn("body.picker-open #f-chat{display:block;position:fixed;left:0;right:0;top:0;"
+                      "height:var(--app-h,100dvh);z-index:200;background:transparent}", self.html)
 
     def test_an_unpainted_pane_is_dark_not_white(self):
         # a pane whose document has not painted is a white rectangle in a dark frame (Firefox shows it

--- a/tests/test_ws_fragmentation.py
+++ b/tests/test_ws_fragmentation.py
@@ -1,0 +1,99 @@
+"""Fragmented client WebSocket messages reassemble into ONE message (RFC 6455 §5.4).
+
+Browsers fragment large sends — Chrome splits at ~128 KB — and the kernel's old loop handed each
+FRAME to json.loads: a phone photo's dropFile (a multi-MB base64 message) dissolved into one
+unparseable JSON prefix plus a train of silently dropped continuation frames, so the chat's 📎 pick
+looked like it did nothing (2026-08-10, Chrome on a phone; small desktop files sit under the
+threshold, which is why it never surfaced). _ws_recv now reports the FIN bit and _ws_recv_message
+reassembles, answering interleaved pings and refusing unbounded buffering.
+"""
+import io
+import os
+import struct
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+MASK = b"\x11\x22\x33\x44"
+
+
+def frame(op, payload, fin=True):
+    """One masked client frame, as a browser would send it."""
+    b0 = (0x80 if fin else 0x00) | op
+    n = len(payload)
+    if n < 126:
+        hdr = bytes([b0, 0x80 | n])
+    elif n < 65536:
+        hdr = bytes([b0, 0x80 | 126]) + struct.pack(">H", n)
+    else:
+        hdr = bytes([b0, 0x80 | 127]) + struct.pack(">Q", n)
+    return hdr + MASK + bytes(c ^ MASK[i % 4] for i, c in enumerate(payload))
+
+
+def read_message(raw, pings=None):
+    on_ping = (pings.append if pings is not None else lambda p: None)
+    return km._ws_recv_message(io.BytesIO(raw), on_ping)
+
+
+class WsFragmentation(unittest.TestCase):
+    def test_a_whole_message_in_one_frame_still_passes(self):
+        op, payload = read_message(frame(0x1, b'{"type":"ready"}'))
+        self.assertEqual((op, payload), (0x1, b'{"type":"ready"}'))
+
+    def test_fragments_reassemble_into_one_message(self):
+        # the Chrome shape: text frame with FIN clear, continuations, FIN on the last
+        body = b'{"type":"dropFile","b64":"' + b"A" * 300 + b'"}'
+        raw = (frame(0x1, body[:100], fin=False)
+               + frame(0x0, body[100:200], fin=False)
+               + frame(0x0, body[200:], fin=True))
+        op, payload = read_message(raw)
+        self.assertEqual(op, 0x1, "the assembled message keeps the OPENING frame's opcode")
+        self.assertEqual(payload, body)
+
+    def test_a_ping_between_fragments_is_answered_and_does_not_corrupt(self):
+        body = b"hello world, in three parts"
+        pings = []
+        raw = (frame(0x1, body[:5], fin=False)
+               + frame(0x9, b"ka")                       # interleaved control frame (spec-legal)
+               + frame(0x0, body[5:16], fin=False)
+               + frame(0x0, body[16:], fin=True))
+        op, payload = read_message(raw, pings)
+        self.assertEqual(payload, body)
+        self.assertEqual(pings, [b"ka"], "the ping was answered mid-message")
+
+    def test_a_stray_continuation_is_dropped_and_the_next_message_parses(self):
+        raw = frame(0x0, b"orphan", fin=True) + frame(0x1, b'{"type":"ready"}')
+        op, payload = read_message(raw)
+        self.assertEqual((op, payload), (0x1, b'{"type":"ready"}'))
+
+    def test_close_and_eof_end_the_read(self):
+        self.assertEqual(read_message(frame(0x8, b"")), (None, None))
+        self.assertEqual(read_message(b""), (None, None))
+        # EOF mid-message (the socket died between fragments) ends it too, not a hang/garbage return
+        self.assertEqual(read_message(frame(0x1, b"half", fin=False)), (None, None))
+
+    def test_reassembly_is_capped_not_unbounded(self):
+        saved = km._WS_MAX_MESSAGE
+        km._WS_MAX_MESSAGE = 64
+        try:
+            raw = frame(0x1, b"x" * 50, fin=False) + frame(0x0, b"y" * 50, fin=False) \
+                + frame(0x0, b"z" * 50, fin=True)
+            self.assertEqual(read_message(raw), (None, None),
+                             "a client streaming past the cap ends the read instead of buffering forever")
+        finally:
+            km._WS_MAX_MESSAGE = saved
+
+    def test_the_handler_loop_reads_messages_not_frames(self):
+        import inspect
+        src = inspect.getsource(km.Handler._ws)
+        self.assertIn("_ws_recv_message(", src, "the loop must consume ASSEMBLED messages")
+        self.assertIn('_ws_pong(self.wfile, lock, payload or b"")', src, "pings still answered")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/fast-toggle.test.ts
+++ b/ui/webview/fast-toggle.test.ts
@@ -1,9 +1,12 @@
 // The chat statusline's FAST badge — a fourth meta control (mode · model · effort · fast) toggling the
 // CLI's fast mode (/fast, Opus-only research preview). The badge exists only when the session REPORTS a
 // fast state — the SDK init's fast_mode_state ("on"/"off"/"cooldown"), threaded kernel → status → badge —
-// so a session that can't run fast mode (or a tmux session whose statusline doesn't publish it yet) shows
-// no dead control. Picking On/Off posts setFast; the kernel delivers the literal "/fast on|off", which the
-// SDK input stream interprets (its CLI descriptor is marked supportsNonInteractive, unlike /model).
+// AND the model can run fast mode at all (fastAvailable: the CLI reports "off" with an EMPTY
+// disabled_reason on a non-Opus session, verified 2026-08-10 against 2.1.226 on a fable session, so
+// state alone would leave a dead toggle there). The label is ONE WORD (the user 2026-08-10, on a
+// phone-width statusline): the tint carries on/off. Picking On/Off posts setFast; the kernel delivers
+// the literal "/fast on|off", which the SDK input stream interprets (its CLI descriptor is marked
+// supportsNonInteractive, unlike /model).
 // render.ts has no jsdom harness → source pins (kernel pins ride along, as in the other meta tests).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -15,11 +18,20 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 const SDK = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
 
-test("the fast badge is a meta control that appears only when the session reports a state", () => {
+test("the fast badge appears only when the session reports a state AND the model can run it", () => {
   assert.match(RENDER, /fast\?: string;/);                                   // status carries it
   assert.match(RENDER, /type MetaKind = "mode" \| "model" \| "effort" \| "fast";/);   // billing moved to the tab menu (2026-08-09)
-  assert.match(RENDER, /st\.fast \? "fast" : ""/);                           // no state → no badge
-  assert.match(RENDER, /meta\.appendChild\(metaButton\("fast", prettyFast\(st\.fast\)\)\)/);
+  assert.match(RENDER, /st\.fast && fastAvailable\(st\) \? st\.fast : ""/);  // no state / unsupported model → no badge
+  assert.match(RENDER, /meta\.appendChild\(metaButton\("fast", prettyFast\(fast\)\)\)/);
+  // the availability gate: opus-family (or unknown/default — the account default may be Opus)
+  const gate = RENDER.match(/function fastAvailable\(st: Status\): boolean \{[\s\S]*?\n\}/)?.[0] || "";
+  assert.match(gate, /!m \|\| m === "default" \|\| m\.includes\("opus"\)/);
+});
+
+test("the badge label is one word — the tint, not the label, carries on/off", () => {
+  const pf = RENDER.match(/function prettyFast[\s\S]*?\n\}/)?.[0] || "";
+  assert.match(pf, /"Cooldown" : "Fast"/);
+  assert.doesNotMatch(pf, /Fast on|Fast off/);
 });
 
 test("the picker offers On/Off and posts setFast; ON wears the CLI's fast orange", () => {

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -152,7 +152,7 @@ function initGear(post) {
     cg = document.getElementById('rs-collapsegaps'), jm = document.getElementById('rs-judgemodel'),
     im = document.getElementById('rs-indexmodel'), je = document.getElementById('rs-judgeeffort'),
     ie = document.getElementById('rs-indexeffort'), upm = document.getElementById('rs-updates');
-  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: true, tabCtx: 'over50', collapseGaps: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: true, tabCtx: 'over50', collapseGaps: true }; } }
+  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true }; } }
   // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
   // few hours as a boolean toggle — false was an explicit hide, true the default nobody chose.
   function tabCtxMode(v) { return (v === 'always' || v === 'never') ? v : (v === false ? 'never' : 'over50'); }
@@ -301,7 +301,7 @@ function initGear(post) {
     // settings-open, which is what un-hides #feed-pane when the feed is toggled off — measuring first
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch !== false; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cg) cg.checked = s.collapseGaps !== false; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cg) cg.checked = s.collapseGaps !== false; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the

--- a/ui/webview/picker-keyboard.test.ts
+++ b/ui/webview/picker-keyboard.test.ts
@@ -1,0 +1,36 @@
+// The new-session picker folds for a SHORT window (the user 2026-08-10, Chrome on a phone): with the
+// on-screen keyboard up, the picker's lower rows sat behind it and nothing gave. The shell sizes the
+// lifted chat iframe to the VISIBLE height (--app-h ← the top-level visualViewport, pinned in
+// tests/test_kernel.py + test_shell_viewport_fit.py), so the keyboard opening/closing lands in the
+// iframe as its own resize event — render.ts keys the kb-tight fold on exactly that, no timers, no UA
+// sniffing. Folded: the advanced create rows (dir, backend, billing, host) hide; the essentials (name
+// box, session list, actions) share the height with the keyboard. The same resize expands them back.
+// Source-level pins (no jsdom for the renderer).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const W = path.resolve(process.cwd(), "..", "ui", "webview");
+const RENDER = fs.readFileSync(path.join(W, "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.join(W, "styles.css"), "utf8");
+
+test("the fold is keyed on this window's own resize event", () => {
+  assert.match(RENDER, /const kbFit = \(\) => document\.getElementById\("picker"\)\?\.classList\.toggle\("kb-tight", window\.innerHeight < 480\)/);
+  assert.match(RENDER, /window\.addEventListener\("resize", kbFit\)/);
+  assert.match(RENDER, /kbFit\(\);/);   // synced at build too, not only on the first resize
+});
+
+test("kb-tight folds the advanced create rows and keeps the essentials", () => {
+  // the advanced rows fold — !important because pick-mode / auth availability drive these rows'
+  // visibility via inline styles, and the fold must win while it holds
+  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-dir,\s*\n\.picker-overlay\.kb-tight \.picker-backend \{ display: none !important; \}/);
+  // .picker-backend covers billing + host too (they wear the class); actions/list/search have no fold rule
+  assert.doesNotMatch(CSS, /kb-tight \.picker-actions/);
+  assert.doesNotMatch(CSS, /kb-tight \.picker-list \{ display/);
+});
+
+test("folded, the box hugs the short viewport instead of centering into the keyboard", () => {
+  assert.match(CSS, /body\.picker-lifted > #picker\.kb-tight \{ align-items: flex-start; padding: 12px 16px; \}/);
+  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-box \{ max-height: calc\(100vh - 24px\); \}/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4725,6 +4725,17 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     overlay.addEventListener("click", (e) => { if (e.target === overlay) closePicker(); });
     document.body.appendChild(overlay);
     document.addEventListener("keydown", pickerKey);
+    // SHORT-WINDOW FOLD (the user 2026-08-10, Chrome on a phone): with the on-screen keyboard up, the
+    // picker's lower rows sat behind it and nothing gave. The shell sizes this lifted iframe to the
+    // VISIBLE height (--app-h ← the top-level visualViewport, which the keyboard shrinks), so the
+    // keyboard opening/closing lands here as this window's own resize — the exact event to key on, no
+    // timers, no UA sniffing. Short window → kb-tight folds the advanced create rows (dir, backend,
+    // billing, host — styles.css) so the essentials share the height with the keyboard; the same
+    // resize expands them back the moment there is room again (a genuinely small screen folds too,
+    // which is the right call there as well).
+    const kbFit = () => document.getElementById("picker")?.classList.toggle("kb-tight", window.innerHeight < 480);
+    window.addEventListener("resize", kbFit);
+    kbFit();
   }
   overlay.style.display = "flex";
   signalPickerOverlay(true);   // lift the chat iframe full-window so the picker covers the whole screen

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6949,13 +6949,21 @@ const FAST_CHOICES: { label: string; value: string }[] = [
 // so a one-auth machine shows no dead selector, and still labelled plainly 'API key' — no fragment
 // of the key, not even a last-4 tail, is shipped or shown (2026-08-08, evening). The tab hover's
 // Billing row keeps carrying the fact everywhere.
-// the fast-mode state ("on"/"off"/"cooldown") → the badge label
+// the fast-mode state ("on"/"off"/"cooldown") → the badge label. ONE WORD (the user 2026-08-10, on a
+// phone-width statusline): the on/off fact is carried by the tint — ON wears the CLI's fast orange
+// (metaColor), off the default dim — and the picker's ✓ names the state on click.
 function prettyFast(f: string | undefined): string {
-  switch ((f || "").toLowerCase()) {
-    case "on": return "Fast on";
-    case "cooldown": return "Fast cooldown";   // rate-limited: the CLI resumes fast mode when the limit resets
-    default: return "Fast off";
-  }
+  return (f || "").toLowerCase() === "cooldown" ? "Cooldown" : "Fast";   // rate-limited: the CLI resumes fast mode when the limit resets
+}
+// Whether the session's MODEL can run fast mode at all (the CLI's /fast is an Opus-only research
+// preview). Gated HERE, on the model, because the CLI is no help: fast_mode_state arrives "off" with
+// an EMPTY fast_mode_disabled_reason on a non-Opus session (verified 2026-08-10 against 2.1.226 on a
+// fable session), so state alone would leave a dead toggle on every model /fast refuses (the user
+// 2026-08-10). Unknown/default stays visible: the account default may be Opus, and hiding a live
+// control is worse than a rare dead one.
+function fastAvailable(st: Status): boolean {
+  const m = (st.model || "").toLowerCase();
+  return !m || m === "default" || m.includes("opus");
 }
 // the @claude-permission-mode var → a short readable badge label
 function prettyMode(m: string | undefined): string {
@@ -7045,16 +7053,18 @@ function metaColor(kind: MetaKind, st: Status): string {
 // updateStatusline (fresh container) and the 1s ticker (label refresh in place).
 function syncMetaControls(meta: HTMLElement, st: Status) {
   // order left→right: mode · model · effort · fast — the mode selector sits LEFT of the model name
-  // (the user 2026-06-16); fast exists only when the session reports it (SDK init). Billing moved to
-  // the tab's right-click menu (the user 2026-08-09) — no badge here.
-  const want = [st.mode ? "mode" : "", st.model ? "model" : "", st.effort ? "effort" : "", st.fast ? "fast" : ""].filter(Boolean).join();
+  // (the user 2026-06-16); fast exists only when the session reports it (SDK init) AND the model can
+  // run it (fastAvailable). Billing moved to the tab's right-click menu (the user 2026-08-09) — no
+  // badge here.
+  const fast = st.fast && fastAvailable(st) ? st.fast : "";   // reported AND the model can run it — else no dead control
+  const want = [st.mode ? "mode" : "", st.model ? "model" : "", st.effort ? "effort" : "", fast ? "fast" : ""].filter(Boolean).join();
   const btns = Array.from(meta.querySelectorAll(".meta-btn")) as HTMLElement[];
   if (btns.map((b) => b.dataset.kind).join() !== want) {
     meta.replaceChildren();
     if (st.mode) meta.appendChild(metaButton("mode", prettyMode(st.mode)));
     if (st.model) meta.appendChild(metaButton("model", st.model));
     if (st.effort) meta.appendChild(metaButton("effort", st.effort));
-    if (st.fast) meta.appendChild(metaButton("fast", prettyFast(st.fast)));
+    if (fast) meta.appendChild(metaButton("fast", prettyFast(fast)));
   }
   for (const b of Array.from(meta.querySelectorAll(".meta-btn")) as HTMLElement[]) {
     const kind = b.dataset.kind as MetaKind;
@@ -7312,11 +7322,12 @@ function updateStatusline() {
     asFolderLink(dir, s.cwd, activeId || undefined);
   }
   right.appendChild(dir);
-  // The session's git branch, just right of the dir — only when known and only if the user hasn't hidden it
-  // (Settings → "Show git branch", on by default — the user 2026-06-23). Read from the TOP-LEVEL session field,
+  // The session's git branch, just right of the dir — only when known and only if the user has OPTED IN
+  // (Settings → Chat → "Show git branch"; off by default — the user 2026-08-10, trimming the statusline
+  // for narrow panes; it shipped on by default 2026-06-23). Read from the TOP-LEVEL session field,
   // never the head system event: that event is windowed out of the wire tail on any >250-event session, which
   // used to blank the branch on most sessions (the user 2026-06-30).
-  if (loadSettings().showBranch !== false && s.gitBranch) {
+  if (loadSettings().showBranch === true && s.gitBranch) {
     const br = el("span", "status-branch");
     br.textContent = "⎇ " + s.gitBranch;
     br.title = "git branch: " + s.gitBranch;

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -15,7 +15,7 @@ export interface RompSettings {
   debug?: boolean;    // LEGACY (the user 2026-06-17): the old single judging-band toggle; read as the migration fallback for the two judge-set toggles when those are unset. The ↻ restart button is always-visible (decoupled).
   backend: "tmux" | "sdk";   // which backend a NEWLY-created session uses (the user 2026-06-22): "tmux" (terminal) or "sdk" (Agent SDK). Both coexist; this is only the default for the + button. Read at createSession time (render.ts). Default sdk (the user 2026-07-13).
   defaultDir: string;        // default working directory PREFILLED in the new-session field (the user 2026-06-22). A session's dir is fixed at creation. Empty → the kernel's serve dir. ~ / $VAR expanded server-side.
-  showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). ON by default.
+  showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). OFF by default (the user 2026-08-10, trimming the statusline for narrow panes; an explicit stored true keeps showing it).
   tabCtx: TabCtxMode;        // chat tabs: WHEN the context gauge shows beside each session name (the user 2026-08-08) — "over50" (default: only once half full, so quiet tabs stay clean), "always", or "never".
 }
 // When the tab strip's context gauge shows. "over50" is the default (the user 2026-08-08): a gauge
@@ -32,7 +32,7 @@ export function tabCtxMode(v: unknown): TabCtxMode {
 // hand-written "why" as their line; they show the distiller's summary instead (the why demotes to a hover).
 // compact defaults ON (the user 2026-07-14): a fresh install reads the tidy transcript
 // (thinking hidden, tool runs folded); the gear opts back into the full stream.
-export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: true, tabCtx: "over50" };
+export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50" };
 const KEY = "romp:settings";
 
 export function loadSettings(): RompSettings {

--- a/ui/webview/statusline-branch.test.ts
+++ b/ui/webview/statusline-branch.test.ts
@@ -1,6 +1,7 @@
 // Chat bottom-bar git branch (the user 2026-06-23): the statusline shows the session's git branch (when it's
 // in a repo) just right of the directory, read from the TOP-LEVEL session.gitBranch field. A Settings toggle
-// ("Show git branch", ON by default) hides it. The renderer has no jsdom harness, so pin the wiring at source.
+// (Chat → "Show git branch") opts IN — OFF by default since 2026-08-10 (the user, trimming the statusline
+// for narrow panes; it shipped default-ON 2026-06-23). The renderer has no jsdom harness, so pin at source.
 // The branch MUST NOT be dug out of the head system event: that event lives at events[0] and the WIRE_TAIL
 // window ships only the last 250 events, so on any >250-event session it (and its branch) fall off the wire —
 // which blanked the branch on most sessions until the top-level field was added (the user 2026-06-30).
@@ -14,14 +15,18 @@ const RENDER = fs.readFileSync(path.join(W, "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.join(W, "styles.css"), "utf8");
 const SETTINGS = fs.readFileSync(path.join(W, "settings.ts"), "utf8");
 
-test("settings carry showBranch, defaulting ON", () => {
+test("settings carry showBranch, defaulting OFF", () => {
   assert.match(SETTINGS, /showBranch: boolean/);
-  assert.match(SETTINGS, /DEFAULT_SETTINGS[^;]*showBranch: true/);
+  assert.match(SETTINGS, /DEFAULT_SETTINGS[^;]*showBranch: false/);
+  // the gear page (its own JS, its own default objects) must agree, or the checkbox lies
+  const GEAR = fs.readFileSync(path.join(W, "gear.js"), "utf8");
+  assert.doesNotMatch(GEAR, /showBranch: true/);
+  assert.match(GEAR, /gb\.checked = s\.showBranch === true/);
 });
 
 test("updateStatusline appends a status-branch span from the top-level gitBranch, gated on the setting", () => {
-  // gated on the live setting (default-ON: only `=== false` hides it) AND on a known branch
-  assert.match(RENDER, /loadSettings\(\)\.showBranch !== false && s\.gitBranch/);
+  // gated on the live setting (default-OFF: only an explicit true shows it) AND on a known branch
+  assert.match(RENDER, /loadSettings\(\)\.showBranch === true && s\.gitBranch/);
   // reads the branch off the TOP-LEVEL session field, NOT the windowed head system event
   assert.match(RENDER, /br\.textContent = "⎇ " \+ s\.gitBranch/);
   assert.match(RENDER, /el\("span", "status-branch"\)/);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1814,6 +1814,16 @@ body.picker-lifted.pane-gone::before { display: none; }
 /* centred, like every other modal. Top-aligned made sense when this filled the screen and the list
    wanted every pixel of height; as a dialog over the dashboard it should sit in the middle. */
 body.picker-lifted > #picker { align-items: center; padding: 24px 16px; }
+/* SHORT WINDOW (the on-screen keyboard is up — the shell's --app-h sizing turns that into this
+   window's own height — or a genuinely small screen; render.ts toggles kb-tight on resize): the
+   ADVANCED create rows fold so the essentials — name box, session list, actions — share the height
+   with the keyboard, and expand back on the resize that restores the room (the user 2026-08-10,
+   Chrome on a phone). !important: these rows' visibility is otherwise driven by inline styles
+   (pick-mode, auth availability), and the fold must win while it holds. */
+body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 16px; }
+.picker-overlay.kb-tight .picker-dir,
+.picker-overlay.kb-tight .picker-backend { display: none !important; }
+.picker-overlay.kb-tight .picker-box { max-height: calc(100vh - 24px); }
 
 .picker-box {
   /* two thirds of the window, not a narrow column: it is a dialog over the whole dashboard now, and the


### PR DESCRIPTION
Four changes from using the dashboard on a phone, plus test catch-ups.

**Fast badge: one word, and only where fast mode exists.** `prettyFast` collapses to "Fast" ("Cooldown" while rate-limited) — the orange tint already carries on/off. And the badge is gated on the model: the CLI reports `fast_mode_state` "off" with an EMPTY disabled reason on a non-Opus session (verified against 2.1.226 on a fable session), so state alone left a dead toggle on models `/fast` refuses.

**Show git branch defaults OFF.** The Settings → Chat toggle has existed since 2026-06-23; the default flips to opt-in. The gear page's own default objects and checkbox restore agree.

**Kernel WS: fragmented client messages reassemble — mobile attach works.** Browsers fragment large sends (Chrome at ~128 KB) and the receive loop handed each FRAME to json.loads: a phone photo's dropFile dissolved into an unparseable prefix plus silently dropped continuation frames — the 📎 pick looked like it did nothing. `_ws_recv` now reports FIN and `_ws_recv_message` reassembles (interleaved pings answered, stray continuations dropped, 80 MB cap).

**The new-session picker folds for the phone keyboard.** The shell's picker lift is sized by `--app-h` (the live visible height) instead of `inset:0`, so the keyboard reaches the chat iframe as its own resize event; render.ts folds the advanced create rows (dir/backend/billing/host) on a short window and expands them back on the resize that restores the room.

Also re-lands the detached-head test's `--template=` hermeticity fix, whose original commit was pushed after #275's auto-merge had already fired and never reached main.

Tests: fast-toggle.test.ts, statusline-branch.test.ts, test_kernel.py gear pin, test_ws_fragmentation.py (new), picker-keyboard.test.ts (new), test_shell_viewport_fit.py / test_kernel.py lift pins. Both suites green: 1801 UI, 4190 Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)