### PR TITLE
Every nudge leads back to work; repeat nudges vary; awaiting-backstop voice fix

### DIFF
--- a/claude/romp-session-prompt.md
+++ b/claude/romp-session-prompt.md
@@ -13,6 +13,10 @@ unfinished, deferred, delegated, or blocked — list it as a short bulleted
 complete while pieces remain. Finishing a preliminary step — reading,
 mapping, or planning — is not finishing the work it was for.
 
+Don't talk yourself out of work because it looks too big or uncertain: if you
+can see a way to make progress, take it, and check in only when a decision is
+genuinely mine to make.
+
 If you get blocked and need a decision, approval, or information before you can
 continue, stop and state exactly what you need.
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -799,11 +799,14 @@ def _followup_body(iid, title, text, injected=False, auto=False, stalled=False):
             # agent's OWN to-do list still marks open, so instead of a per-piece status report the body asks
             # the agent to pick a branch — continue, or name the blockers (which the planner then applies as
             # blocks). The enumerated quote above already names the open pieces.
-            body = (("Those are still open on your own to-do list. Where does each one stand? Keep going "
-                     "on anything you can. If something's blocked, tell me which one and exactly what you "
-                     "need from me. If one is no longer needed, just say so.") if stalled else
+            # Both branches LEAD BACK TO WORK — explicit permission to continue without the user's
+            # go-ahead (the user 2026-08-11): a status ask alone buys a report turn and another stop.
+            body = (("Those are still open on your own to-do list. Keep going on anything you can; you "
+                     "don't need my go-ahead. If something's blocked, tell me which one and exactly what "
+                     "you need from me. If one is no longer needed, just say so.") if stalled else
                     ("Where does each of those stand? What's done, what's left, and is anything blocked "
-                     "waiting on a decision from me? If one is no longer needed, just say so."))
+                     "waiting on a decision from me? If nothing's actually blocking you, just keep going; "
+                     "you don't need my go-ahead. If one is no longer needed, just say so."))
         elif not injected and str(nd.get("summary") or nd.get("blockSummary") or "").strip():
             # A TYPED follow-up quotes the card's DISTILLED SUMMARY — the takeaway (completed) or decision brief
             # (blocked) that is the card's visible HEADLINE, the thing you're reading + clicked to follow up on
@@ -892,7 +895,8 @@ def _nudge_bundle_body(gids, nodes, stalled_gids):
         if gid in stalled_gids:
             stall_nums.append(i)
     body = ("Where do these %d stand? For each one: what's done, what's left, and is anything blocked "
-            "waiting on a decision from me? If one is already finished or no longer needed, just say so."
+            "waiting on a decision from me? If one is already finished or no longer needed, just say so. "
+            "Anywhere nothing's blocking you, just keep going; you don't need my go-ahead."
             % len(gids))
     if stall_nums:
         body += ("\n\nOn %s you've still got open items on your to-do list. Keep going on those unless "
@@ -1573,15 +1577,51 @@ def _prune_notify_cards(live_ids):
 #  "debtNudged": {"<askerSid>><debtorSid>:<askT>": fireT}}   # the DEBT reminder's once-per-ask dedup
 # (see _fire_debt_reminder); each goal-nudge
 # fire also appends {sid,gid,t,count} to nudge-events.jsonl for the timeline's ⚡ marker.
-AUTO_NUDGE_TEXT = "Where does this stand? What's done, what's left, and is anything blocked waiting on a decision from me?"   # the auto-nudge ask (the manual feed Nudge button was removed 2026-06-30); phrased like a person checking in, not a status form (g13)
+# The auto-nudge ask (the manual feed Nudge button was removed 2026-06-30): phrased like a person checking
+# in, not a status form (g13), and it ends by LEADING BACK TO WORK — explicit permission to continue without
+# the user's go-ahead (the user 2026-08-11, after Anthropic's riemann-zeta post, where the operator's whole
+# input was keep-going encouragement: a status ask alone buys a report turn and another stop, while
+# permission to persist is what unsticks an agent that talked itself out of continuing).
+AUTO_NUDGE_TEXT = ("Where does this stand? What's done, what's left, and is anything blocked waiting on "
+                   "a decision from me? If nothing's actually blocking you, just keep going; you don't "
+                   "need my go-ahead.")
 # The FORK nudge (plans/stalled-open-todos-nudge.md, the user 2026-07-01): sent INSTEAD of AUTO_NUDGE_TEXT
 # when the stalled goal has items the agent's OWN to-do list still marks open (authoritative-open). Claude
 # Code's to-do system has no "blocked" state, so a session routinely stops with open items and can't say why —
 # this asks the agent to pick a branch: continue the work, or name what it needs from the user (which the
 # planner's nudge-mode note then turns into a block + blockWhy → the block-distiller's decision brief).
-AUTO_NUDGE_STALLED_TEXT = ("You've still got open items on your to-do list. Where does each one stand? "
-                           "Keep going on anything you can. If something's blocked, tell me which one and "
-                           "exactly what you need from me. If one is no longer needed, just say so.")
+AUTO_NUDGE_STALLED_TEXT = ("You've still got open items on your to-do list. Keep going on anything you "
+                           "can; you don't need my go-ahead. If something's blocked, tell me which one "
+                           "and exactly what you need from me. If one is no longer needed, just say so.")
+# Repeat nudges wear DIFFERENT WORDS for the same ask (the user 2026-08-11): a goal that re-stalls across
+# genuine new turns climbs its count, and the identical sentence arriving a second or third time is the one
+# tell that the asker is canned — the injected voice must read as a person every time. Every variant carries
+# the SAME message: where things stand, keep going if you can (no go-ahead needed), what's blocked on me.
+# Variant 1 IS the canonical constant, so a first fire is byte-identical to before and counts past the end
+# wrap around. Rendered through tests/test_injected_voice.py and test_nudge_block_prompts.py like the rest.
+AUTO_NUDGE_VARIANTS = (
+    AUTO_NUDGE_TEXT,
+    "Checking in on this one again. If you can keep going, keep going; you don't need my go-ahead. "
+    "Otherwise: what's done, what's left, and is anything blocked waiting on a decision from me?",
+    "Still moving on this? If there's a clear next step, keep going; the open calls are yours to make. "
+    "If not: what's done, what's left, and is anything blocked waiting on a decision from me?",
+)
+AUTO_NUDGE_STALLED_VARIANTS = (
+    AUTO_NUDGE_STALLED_TEXT,
+    "Those to-do items are still open. If you can move any of them, keep going; that's your call, not "
+    "mine. If one's blocked, tell me which one and exactly what you need from me. If one is no longer "
+    "needed, just say so.",
+    "Your to-do list still shows open items. Keep going on whatever you can; you don't need my sign-off. "
+    "If something's blocked, say which one and exactly what you need from me. If one is no longer "
+    "needed, just say so.",
+)
+
+
+def _nudge_text(count, stalled=False):
+    """The nth nudge on the same goal: same ask, different words (see AUTO_NUDGE_VARIANTS). count is the
+    escalation count as fired (1-based), so the first fire is the canonical text."""
+    variants = AUTO_NUDGE_STALLED_VARIANTS if stalled else AUTO_NUDGE_VARIANTS
+    return variants[max(int(count) - 1, 0) % len(variants)]
 _autonudge_cache = {}   # str(path) -> ((mtime_ns,size), dict)
 
 
@@ -2660,10 +2700,14 @@ def _auto_nudge_tick(now, tmux):
 # re-check its OWN async work. It is patient — a legitimate dispatched/external wait almost always resolves
 # well inside the window, so a stamp still open past it is very likely a lost wakeup.
 AWAITING_BACKSTOP_SECS = 6 * 3600
+# The TEXT reads as the person checking in (the user 2026-08-11): the first version said "goal" twice and
+# announced itself "(Automated re-check…)" — romp vocabulary plus an automated-origin disclosure, both
+# banned by the injected-voice rule — and sat outside tests/test_injected_voice.py's index, which is how it
+# survived the 2026-07-24 sweep. It is indexed there now.
 AWAITING_BACKSTOP_TEXT = (
-    "Checking in on the background work you set in motion for this goal. If it finished, pick the result up "
-    "and continue. If it stalled, died, or you are now waiting on me, say what you need. If it is genuinely "
-    "still running, a one-line status is enough. (Automated re-check: this goal has been awaiting a while.)")
+    "Checking in on the background work you set in motion here. If it finished, pick the result up and "
+    "keep going. If it stalled or died, relaunch it or find another way; your call. If you're now blocked, "
+    "say exactly what you need from me. If it's genuinely still running, a one-line status is enough.")
 
 
 def _mark_awaiting_backstop(gid, at):
@@ -3394,7 +3438,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
             pass
     if len(to_fire) == 1:
         gid, count, stalled = to_fire[0]
-        text = AUTO_NUDGE_STALLED_TEXT if stalled else AUTO_NUDGE_TEXT
+        text = _nudge_text(count, stalled)             # variant by escalation count — a repeat re-asks in fresh words
         Sessions.backend_for(sid).send(sid, _followup_body(gid, None, text, injected=True, auto=True, stalled=stalled))   # gray romp bubble + romp-logo (both backends)
     elif to_fire:
         # BUNDLE (the user 2026-07-24): several goals due in the SAME tick → ONE message naming them all,

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -95,7 +95,7 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
     def _bodies(self):
         """Every message romp injects, by name, rendered from the same synthetic store."""
         nodes = _nodes()
-        return {
+        bodies = {
             "auto-nudge": km.AUTO_NUDGE_TEXT,
             "fork nudge": km.AUTO_NUDGE_STALLED_TEXT,
             "nudge on a hierarchical goal":
@@ -118,7 +118,19 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             "debt reminder (several)": km._debt_reminder_body(
                 [("web", T0, "question", "Which port should the staging server use?"),
                  ("api", T0 + 5, "delegate", "Take over the fixtures backfill.")]),
+            # the awaiting BACKSTOP (kernel AWAITING_BACKSTOP_TEXT): missed by the 2026-07-24 sweep's
+            # index, so it shipped saying "goal" twice and announcing "(Automated re-check…)" until
+            # 2026-08-11 — exactly the drift this index exists to catch
+            "awaiting backstop": km.AWAITING_BACKSTOP_TEXT,
         }
+        # every repeat-nudge variant wears the same voice as the first fire (the user 2026-08-11): the
+        # rotation exists so a re-ask doesn't read canned, so a variant that broke the voice rule would
+        # defeat its own purpose
+        for i, v in enumerate(km.AUTO_NUDGE_VARIANTS, 1):
+            bodies["auto-nudge variant %d" % i] = v
+        for i, v in enumerate(km.AUTO_NUDGE_STALLED_VARIANTS, 1):
+            bodies["fork nudge variant %d" % i] = v
+        return bodies
 
     def test_no_romp_vocabulary_reaches_the_session(self):
         for name, body in self._bodies().items():

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -2649,10 +2649,12 @@ class ViewBuilder(unittest.TestCase):
             km._auto_nudge_tick(NOW, km._tmux_sessions())
             self.assertEqual(len(sent), 1, "the stalled goal is nudged")
             # the fork ask (both the flat and the hierarchical-enumeration form carry these sentences):
-            # per-item progress + the continue-or-name-the-blocker fork (the user 2026-07-02)
+            # the continue-or-name-the-blocker fork (the user 2026-07-02), leading with permission to
+            # continue instead of a per-item report (the user 2026-08-11)
             self.assertIn("Keep going on anything you can", sent[0][1],
                           "the FORK text, not the plain status check")
-            self.assertIn("Where does each one stand?", sent[0][1], "asks for per-item progress")
+            self.assertIn("you don't need my go-ahead", sent[0][1],
+                          "licenses continuing without checking in first")
             self.assertIn("tell me which one and exactly what you need from me", sent[0][1])
             self.assertIn("hook up the adapter", sent[0][1], "the open item is named in the quote")
             self.assertNotIn(km.AUTO_NUDGE_TEXT, sent[0][1])
@@ -2684,7 +2686,8 @@ class ViewBuilder(unittest.TestCase):
         self.assertIn("migrate stores and land the branch", body, "open to-do #2 is named")
         self.assertNotIn("a genuinely done step", body, "a done step is not")
         self.assertIn("still open on your own to-do list", body, "the fork body rides the enumeration")
-        self.assertIn("Where does each one stand?", body, "and asks for per-item progress")
+        self.assertIn("you don't need my go-ahead", body,
+                      "and licenses continuing without a per-item report first (the user 2026-08-11)")
 
     def test_auto_nudge_stamps_failed_when_its_response_leaves_the_goal_stalled(self):
         # plans/stalled-open-todos-nudge.md: after the ONE nudge, the agent's response turn ends (judged —

--- a/tests/test_nudge_block_prompts.py
+++ b/tests/test_nudge_block_prompts.py
@@ -37,22 +37,56 @@ class AutoNudgePrompt(unittest.TestCase):
         self.assertNotRegex(src, r'nudge\.onclick', "the manual Nudge button stays removed")
 
     def test_prompt_elicits_done_and_blocked_on_user(self):
-        t = km.AUTO_NUDGE_TEXT.lower()
+        # every VARIANT must elicit the same split — the rotation re-asks the same question in fresh
+        # words, so a variant that dropped "done" or "blocked" would break the working/blocked filing
         self.assertNotEqual(km.AUTO_NUDGE_TEXT, OLD_BARE_STATUS,
                             "the bare status question is what caused the working/blocked mis-classification")
-        self.assertIn("done", t, "nudge should ask what's done")
-        self.assertIn("blocked", t, "nudge should ask what's blocked")
-        self.assertTrue("me" in t or "you" in t,
-                        "nudge should ask whether anything is blocked waiting on the user")
+        for v in km.AUTO_NUDGE_VARIANTS:
+            t = v.lower()
+            with self.subTest(variant=v[:40]):
+                self.assertIn("done", t, "nudge should ask what's done")
+                self.assertIn("blocked", t, "nudge should ask what's blocked")
+                self.assertTrue("me" in t or "you" in t,
+                                "nudge should ask whether anything is blocked waiting on the user")
 
     def test_prompt_reads_like_a_person_not_a_status_form(self):
         # g13 (the user 2026-07-01): the nudge must read like an ordinary user turn, never disclose an
         # automated/tracking origin, and not open with a form-like "Status on the goal above:" header.
-        t = km.AUTO_NUDGE_TEXT.lower()
-        for robotic in ("status on the goal above", "romp", "automated", "tracking"):
+        for v in km.AUTO_NUDGE_VARIANTS:
+            t = v.lower()
+            with self.subTest(variant=v[:40]):
+                for robotic in ("status on the goal above", "romp", "automated", "tracking"):
+                    self.assertNotIn(robotic, t, robotic)
+                self.assertTrue(v[0].isupper() and "?" in v,
+                                "a natural question, addressed to the session")
+
+    def test_every_nudge_text_licenses_continuing_without_permission(self):
+        # the user 2026-08-11 (after Anthropic's riemann-zeta post, where the operator's whole input was
+        # keep-going encouragement): a nudge must LEAD BACK TO WORK, not just buy a report turn — every
+        # variant, plain and fork, carries explicit permission to continue without the user's go-ahead.
+        for v in km.AUTO_NUDGE_VARIANTS + km.AUTO_NUDGE_STALLED_VARIANTS:
+            with self.subTest(variant=v[:40]):
+                self.assertIn("keep going", v.lower(),
+                              "every nudge variant must license just continuing the work")
+
+    def test_first_fire_is_canonical_and_repeats_vary(self):
+        # variant 1 IS the constant, so the first nudge is byte-identical to the pre-variant behavior
+        # (test_kernel's verbatim-carry assertions ride on this); repeats rotate, and counts past the
+        # list wrap around rather than erroring.
+        self.assertEqual(km._nudge_text(1), km.AUTO_NUDGE_TEXT)
+        self.assertEqual(km._nudge_text(1, stalled=True), km.AUTO_NUDGE_STALLED_TEXT)
+        self.assertEqual(len({km._nudge_text(c) for c in (1, 2, 3)}), 3,
+                         "repeat nudges wear different words for the same ask")
+        self.assertEqual(km._nudge_text(4), km.AUTO_NUDGE_TEXT, "counts wrap around the variant list")
+        self.assertEqual(km._nudge_text(0), km.AUTO_NUDGE_TEXT, "a defensive floor for a malformed count")
+
+    def test_awaiting_backstop_reads_like_a_person(self):
+        # the user 2026-08-11: the backstop text said "goal" twice and ANNOUNCED itself automated — the
+        # exact disclosures g13 bans — and sat outside test_injected_voice's index, which is how it
+        # survived the 2026-07-24 sweep. Indexed there now; belt-and-suspenders ban here too.
+        t = km.AWAITING_BACKSTOP_TEXT.lower()
+        for robotic in ("goal", "romp", "automated", "tracking"):
             self.assertNotIn(robotic, t, robotic)
-        self.assertTrue(km.AUTO_NUDGE_TEXT[0].isupper() and "?" in km.AUTO_NUDGE_TEXT,
-                        "a natural question, addressed to the session")
 
 
 class PlannerBlockRule(unittest.TestCase):

--- a/tests/test_session_prompt.py
+++ b/tests/test_session_prompt.py
@@ -39,6 +39,15 @@ class SessionPrompt(unittest.TestCase):
         self.assertIn("preliminary step", self.flat,
                       "the prompt must say a preliminary step (reading/mapping/planning) is not finishing the work")
 
+    def test_licenses_persisting_through_daunting_work(self):
+        # the user 2026-08-11 (after Anthropic's riemann-zeta post, where the operator's whole input was
+        # keep-going encouragement): the prompt must license continuing on work that merely LOOKS too big
+        # or uncertain — stopping is reserved for decisions that are genuinely the user's to make.
+        self.assertIn("talk yourself out of", self.flat,
+                      "the prompt must tell the session not to abandon work that merely looks daunting")
+        self.assertIn("make progress", self.flat,
+                      "the prompt must license taking any visible path to progress without checking in")
+
     def test_housekeeping_note_preexplains_romp_artifacts(self):
         # The ONE place romp is named to a session (the user 2026-07-25): pre-explain the artifacts
         # every session eventually sees — [romp] notices and <!-- romp-* --> comments — so a kernel


### PR DESCRIPTION
Prompted by Anthropic's riemann-zeta post (2026-08-10): the operator's whole input was keep-going encouragement, and it carried the run. Romp's own blocked-episode data points the same way (58% of blocked cards self-resolved behind the Continue button), so the injected asks now lead back to work instead of only asking for a report.

**What changed**
- The auto-nudge, the stalled fork, the hierarchical nudge bodies, and the multi-goal bundle closer all end with explicit permission to continue without the user's go-ahead. The stalled fork leads with it instead of a per-item report. The done / blocked-on-you / drop-it exits all stay, so a finished or genuinely blocked goal still files correctly.
- Repeat nudges on the same goal rotate through variants of the same ask, chosen by escalation count. The first fire is byte-identical to the previous text and counts wrap, so a re-ask reads like a person asking again rather than a canned line repeating.
- `AWAITING_BACKSTOP_TEXT` rewritten: it said "goal" twice and announced itself "(Automated re-check...)", both banned by the injected-voice rule, and it sat outside `tests/test_injected_voice.py`'s index, which is how it survived the 2026-07-24 sweep. It is indexed there now.
- The session prompt gains one line licensing persistence on work that merely looks too big or uncertain; stopping stays reserved for decisions only the user can make.

**Tests**
- Voice index now covers the awaiting backstop and every nudge variant.
- Nudge prompt-shape tests iterate all variants; new pins for variant selection (first fire canonical, repeats differ, wrap-around), the keep-going license on every variant, a person-voice ban on the backstop text, and the session-prompt persistence line.
- The two fork-nudge expectations in `test_kernel.py` updated to the new lead.

Both suites green locally: pytest 4189 passed, node 1801 passed, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)