### PR TITLE
chat tabs: a session the kernel stops listing drops out on the next push

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3251,6 +3251,16 @@ function ackClosingTabs(kernelOrder: readonly string[]): void {
 }
 
 // Apply the kernel's authoritative tab order (its tabOrder push, also re-sent after a timeline drag).
+// Ids any kernel tabOrder push has EVER carried, for the page's whole life. A tab on this list is
+// kernel-owned: when a later push stops carrying it, that omission is the removal event and the tab is
+// dismissed below — the continuous push is the authority, the one-shot `closed` frame just the fast path.
+// Before this, `closed` was the ONLY remover: a client whose socket was down at the kill (a frozen webview
+// force-dropped at the send-queue cap, a sleep, a network blip) missed that single frame forever, and the
+// dead session's tab rode the reconcile keep on every later push — frozen on its last live status, fully
+// clickable, reading as a running session (the 2026-08-11 ghost: an ended session stayed on the strip
+// looking alive). Add-only, never pruned: dropping an entry would hand a late stale `session` frame the
+// never-listed keep and re-mint the ghost. Client-minted ids (the create placeholder) never enter it.
+const kernelListed = new Set<string>();
 function applyTabOrder(o: any, tabs?: any) {
   // name+color per tab → renderTabs paints placeholders for tabs whose session hasn't arrived yet (tabs-first).
   // The payload is the kernel's AUTHORITATIVE current tab set, so REBUILD (not merge) — a closed tab drops out
@@ -3267,9 +3277,19 @@ function applyTabOrder(o: any, tabs?: any) {
   // Adopt the kernel order verbatim, keeping any just-arrived tab the push doesn't carry yet (see tab-order.ts).
   const kernelOrder = Array.isArray(o) ? o.filter((x: any) => typeof x === "string") : [];
   ackClosingTabs(kernelOrder);
-  const next = reconcileTabOrder(kernelOrder, order, (id) => sessions.has(id) || tabMeta.has(id));
+  // A kernel-owned tab the push no longer carries gets the SAME teardown the `closed` event runs — the
+  // session map, its view, drafts and the active-tab reselect all go, not just the strip entry. Under
+  // federation the merged order only omits an id when its OWNING host affirmatively reported it gone
+  // (per-host slices persist across down/detached hosts), so this never fires on a tunnel blip.
+  const inKernel = new Set<string>(kernelOrder);
+  for (const id of order.slice()) {
+    if (kernelListed.has(id) && !inKernel.has(id)) dismissSession(id);
+  }
+  const next = reconcileTabOrder(kernelOrder, order, (id) => sessions.has(id) || tabMeta.has(id),
+                                 (id) => kernelListed.has(id));
   order.length = 0;
   for (const id of next) order.push(id);
+  for (const id of kernelOrder) kernelListed.add(id);
   renderTabs();
 }
 // Order-audit instrumentation (the user 2026-07-02): tabs STILL occasionally reorder themselves and code

--- a/ui/webview/tab-ghost-heal.test.ts
+++ b/ui/webview/tab-ghost-heal.test.ts
@@ -1,0 +1,136 @@
+// An ENDED session must leave the tab strip even when the kernel's one-shot `closed` frame never arrived
+// (the 2026-08-11 ghost: a session the kernel had ended stayed on the dashboard looking alive — last status
+// still "working", transcript cached, fully clickable — and only a manual reload cleared it).
+//
+// The chain that minted it, each link by design: pane JS state survives WS reconnects (the shim reconnects,
+// never reloads); a client that stops draining is force-dropped at the send-queue byte cap (a frozen webview
+// popout, a sleeping laptop), so it is exactly the client that is DISCONNECTED at the kill moment and misses
+// the one-shot `closed`; and applyTabOrder's keep re-adopted any locally-known tab the kernel's order didn't
+// carry — forever. The fix makes the CONTINUOUS tabOrder push the authority: an id any push has carried is
+// kernel-owned (`kernelListed`), and a later push omitting it dismisses the tab with the same teardown the
+// `closed` event runs. `closed` stays as the fast path.
+//
+// The executed model below runs the real reconcileTabOrder through the whole miss-and-heal cycle with
+// applyTabOrder's bookkeeping; the source pins hold that wiring in render.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { reconcileTabOrder } from "./tab-order";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+// A stand-in for the client around a session death: the sessions map, the render order, and applyTabOrder's
+// kernelListed bookkeeping. dismiss() mirrors dismissSession's teardown surface (session + view + draft go).
+function model() {
+  let order: string[] = [];
+  const sessions = new Map<string, { state: string }>();
+  const drafts = new Map<string, string>();
+  const kernelListed = new Set<string>();
+  const dismissed: string[] = [];
+  const dismiss = (id: string) => {
+    dismissed.push(id);
+    sessions.delete(id); drafts.delete(id);
+    order = order.filter((x) => x !== id);
+  };
+  return {
+    dismissed,
+    session(id: string, state = "working") { sessions.set(id, { state }); if (!order.includes(id)) order.push(id); },
+    draft(id: string, text: string) { drafts.set(id, text); },
+    closedEvent(id: string) { dismiss(id); },     // the kernel's one-shot frame, when it DOES arrive
+    // a kernel tabOrder push, with applyTabOrder's new bookkeeping: kernel-owned omissions dismiss first,
+    // then the reconcile (whose keep no longer applies to kernel-owned ids), then the add-only record.
+    push(kernel: string[]) {
+      for (const id of order.slice()) if (kernelListed.has(id) && !kernel.includes(id)) dismiss(id);
+      order = reconcileTabOrder(kernel, order, (id) => sessions.has(id), (id) => kernelListed.has(id));
+      for (const id of kernel) kernelListed.add(id);
+    },
+    tabs() { return order.slice(); },
+    state(id: string) { return sessions.get(id)?.state ?? null; },
+    hasDraft(id: string) { return drafts.has(id); },
+  };
+}
+
+test("a session ended while the socket was down leaves the strip on the reconnect's first push", () => {
+  const m = model();
+  m.session("web"); m.session("api");
+  m.push(["web", "api"]);                 // both kernel-owned
+  // api is ended while this client's socket is down (frozen popout force-dropped at the queue cap): the
+  // one-shot `closed` frame is LOST, api's session survives in the maps with its last live status…
+  assert.equal(m.state("api"), "working", "the cached state still claims a live session");
+  // …and the reconnect's resync push no longer carries it. Before the fix this push KEPT the tab (its
+  // session was locally known), so the ended session sat on the strip looking alive until a manual reload.
+  m.push(["web"]);
+  assert.deepEqual(m.tabs(), ["web"], "the omission is the removal event — the ghost heals");
+  assert.deepEqual(m.dismissed, ["api"], "…with the same teardown the closed event runs");
+  assert.equal(m.state("api"), null, "no live-looking cached session left behind");
+  m.push(["web"]);                        // and it STAYS healed on every later push
+  assert.deepEqual(m.tabs(), ["web"]);
+});
+
+test("the teardown clears the dead session's composer leftovers too", () => {
+  const m = model();
+  m.session("web"); m.session("api");
+  m.push(["web", "api"]);
+  m.draft("api", "half-typed message");
+  m.push(["web"]);
+  assert.equal(m.hasDraft("api"), false, "kernel-driven drop runs the full dismissSession surface");
+});
+
+test("the closed event remains the fast path; the push after it has nothing left to do", () => {
+  const m = model();
+  m.session("web"); m.session("api");
+  m.push(["web", "api"]);
+  m.closedEvent("api");                   // delivered normally this time
+  assert.deepEqual(m.tabs(), ["web"]);
+  m.push(["web"]);                        // the confirming push neither re-adds nor double-dismisses
+  assert.deepEqual(m.tabs(), ["web"]);
+  assert.deepEqual(m.dismissed, ["api"]);
+});
+
+test("a revival re-adopts the same sid after a ghost heal (dead sessions revive with their history)", () => {
+  const m = model();
+  m.session("web"); m.session("api");
+  m.push(["web", "api"]);
+  m.push(["web"]);                        // api ended + healed
+  m.session("api", "opening");            // revived: the kernel lists the SAME sid again
+  m.push(["web", "api"]);
+  assert.deepEqual(m.tabs(), ["web", "api"]);
+  assert.equal(m.state("api"), "opening");
+});
+
+test("a create placeholder the kernel has never listed still survives unrelated pushes", () => {
+  const m = model();
+  m.session("web");
+  m.push(["web"]);
+  m.session("provisional:new");           // client-minted optimistic tab — the kernel knows nothing yet
+  m.push(["web"]);                        // an unrelated push must not eat it (the just-arrived grace)
+  assert.deepEqual(m.tabs(), ["web", "provisional:new"]);
+  assert.deepEqual(m.dismissed, []);
+});
+
+// ---- the wiring in render.ts -------------------------------------------------------------------------
+
+test("applyTabOrder dismisses kernel-owned omissions BEFORE reconciling, then records add-only", () => {
+  // the drop loop sits between ackClosingTabs and the reconcile, and dismissSession is the shared teardown
+  assert.match(RENDER,
+    /ackClosingTabs\(kernelOrder\);[\s\S]{0,700}?for \(const id of order\.slice\(\)\) \{\s*\n\s*if \(kernelListed\.has\(id\) && !inKernel\.has\(id\)\) dismissSession\(id\);\s*\n\s*\}/,
+    "kernel-owned tabs the push stopped carrying get the closed-event teardown");
+  // the reconcile passes the kernelListed predicate, so the pure model enforces the same rule
+  assert.match(RENDER,
+    /reconcileTabOrder\(kernelOrder, order, \(id\) => sessions\.has\(id\) \|\| tabMeta\.has\(id\),\s*\n\s*\(id\) => kernelListed\.has\(id\)\)/);
+  // add-only, recorded AFTER the reconcile: dropping entries would hand a late stale `session` frame the
+  // never-listed keep and re-mint the ghost
+  assert.match(RENDER, /for \(const id of next\) order\.push\(id\);\s*\n\s*for \(const id of kernelOrder\) kernelListed\.add\(id\);/);
+  const body = RENDER.match(/function dismissSession\(id: string\): void \{[\s\S]*?\n\}/);
+  assert.ok(body, "dismissSession not found");
+  assert.doesNotMatch(body![0], /kernelListed/, "the record outlives the dismiss (add-only set)");
+});
+
+test("reconcileTabOrder's keep is gated on the kernel never having listed the id", () => {
+  const TAB_ORDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "tab-order.ts"), "utf8");
+  assert.match(TAB_ORDER, /kernelSeen: \(id: string\) => boolean = \(\) => false/,
+    "the predicate defaults off so single-shot callers keep the plain adopt-verbatim semantics");
+  assert.match(TAB_ORDER, /!inKernel\.has\(id\) && known\(id\) && !kernelSeen\(id\)/,
+    "extras keep = locally known AND never kernel-listed");
+});

--- a/ui/webview/tab-order.test.ts
+++ b/ui/webview/tab-order.test.ts
@@ -88,3 +88,59 @@ test("output is deduped and string-only", () => {
   assert.deepEqual(reconcileTabOrder(["A", "A", "B"] as string[], ["B", "B"], () => true), ["A", "B"]);
   assert.deepEqual(reconcileTabOrder(["A", 7 as any, "B"], [], () => true), ["A", "B"]);
 });
+
+// ── kernel-owned tabs drop when the kernel's order stops carrying them (the 2026-08-11 ghost) ──────────
+// A session was ended while this client's socket was down, so the one-shot `closed` frame never arrived.
+// The dead tab's session is still in the client's maps (known(id) = true — JS state survives reconnects),
+// so the unconditional keep resurrected it on every later push: a live-looking tab for an ended session.
+// The kernelSeen predicate is the fix: an id ANY kernel push has carried is kernel-owned, and a later push
+// omitting it is the removal event — known or not, it drops out.
+
+// The model with kernelSeen tracking, mirroring render.ts's applyTabOrder bookkeeping (add-only set).
+function seenModel() {
+  let order: string[] = [];
+  const knownIds = new Set<string>();
+  const kernelListed = new Set<string>();
+  return {
+    onSession(id: string) { knownIds.add(id); if (!order.includes(id)) order.push(id); },
+    onKernelOrder(kernel: string[]) {
+      order = reconcileTabOrder(kernel, order, (id) => knownIds.has(id), (id) => kernelListed.has(id));
+      for (const id of kernel) kernelListed.add(id);
+    },
+    list() { return order.slice(); },
+  };
+}
+
+test("a tab the kernel once listed drops out when a later push omits it, even with its session still cached", () => {
+  const m = seenModel();
+  m.onSession("A"); m.onSession("B");
+  m.onKernelOrder(["A", "B"]);            // both kernel-owned now
+  assert.deepEqual(m.list(), ["A", "B"]);
+  // B is ended while this client's socket is down: the `closed` frame is lost, B's session stays cached
+  // (known), and the next push — the reconnect's resync — no longer carries B.
+  m.onKernelOrder(["A"]);
+  assert.deepEqual(m.list(), ["A"], "the missed one-shot closed heals on the next push");
+  m.onKernelOrder(["A"]);                 // and it stays healed
+  assert.deepEqual(m.list(), ["A"]);
+});
+
+test("an id the kernel has never listed keeps the just-arrived grace (create placeholder, session-first push)", () => {
+  const m = seenModel();
+  m.onSession("prov");                    // client-minted: the kernel has never carried it
+  m.onKernelOrder(["A"]);                 // pushes that predate its adoption must not drop it
+  assert.deepEqual(m.list(), ["A", "prov"]);
+  m.onKernelOrder(["A", "prov"]);         // the kernel adopts it → reconciled into place, now kernel-owned
+  assert.deepEqual(m.list(), ["A", "prov"]);
+  m.onKernelOrder(["A"]);                 // ...so from here an omission drops it like any other tab
+  assert.deepEqual(m.list(), ["A"]);
+});
+
+test("a revived session (same sid re-listed after a drop) is adopted back cleanly", () => {
+  const m = seenModel();
+  m.onSession("A"); m.onSession("B");
+  m.onKernelOrder(["A", "B"]);
+  m.onKernelOrder(["A"]);                 // B ended + dropped
+  assert.deepEqual(m.list(), ["A"]);
+  m.onKernelOrder(["A", "B"]);            // B revived (dead sessions revive with their history)
+  assert.deepEqual(m.list(), ["A", "B"]);
+});

--- a/ui/webview/tab-order.ts
+++ b/ui/webview/tab-order.ts
@@ -11,22 +11,33 @@
 
 /**
  * The render order after a kernel `tabOrder` push: adopt the kernel's order verbatim, but keep any tab the
- * client already knows that the push doesn't carry yet (a `session` push that beat its `tabOrder` push) —
- * appended at the end — so a just-arrived tab never vanishes; the next push reconciles it into place.
- * Deduped; non-string entries dropped.
+ * client already knows that the push doesn't carry yet (a `session` push that beat its `tabOrder` push, or
+ * the optimistic create placeholder) — appended at the end — so a just-arrived tab never vanishes; the next
+ * push reconciles it into place. Deduped; non-string entries dropped.
+ *
+ * The keep applies ONLY to ids the kernel has never listed. A tab the kernel HAS carried in a tabOrder push
+ * is kernel-owned, and a later push omitting it IS the removal event — it must drop out here, never ride the
+ * keep. Before this, the keep was unconditional and the one-shot `closed` frame was the only remover, so a
+ * client whose socket was down at the kill (a frozen webview force-dropped at the send-queue cap, a sleep, a
+ * network blip) missed that single frame and the dead session's tab survived every later push — frozen on
+ * its last live status, fully clickable, indistinguishable from a running session (the 2026-08-11 ghost: a
+ * session the kernel had ended stayed on the strip looking alive). JS state survives reconnects by design,
+ * so only this per-push reconcile can heal it.
  *
  * @param kernelOrder the authoritative SID order from the kernel's tabOrder push
  * @param local       the client's current order (preserves transient, not-yet-pushed tabs)
  * @param known       whether the client actually has a tab for this id (a session arrived / is a placeholder)
+ * @param kernelSeen  whether ANY kernel tabOrder push has ever carried this id (kernel-owned → no keep)
  */
 export function reconcileTabOrder(
   kernelOrder: readonly string[],
   local: readonly string[],
   known: (id: string) => boolean,
+  kernelSeen: (id: string) => boolean = () => false,
 ): string[] {
   const kernel = kernelOrder.filter((id): id is string => typeof id === "string");
   const inKernel = new Set(kernel);
-  const extras = local.filter((id) => typeof id === "string" && !inKernel.has(id) && known(id));
+  const extras = local.filter((id) => typeof id === "string" && !inKernel.has(id) && known(id) && !kernelSeen(id));
   const out: string[] = [];
   const seen = new Set<string>();
   for (const id of [...kernel, ...extras]) {


### PR DESCRIPTION
## The bug

A session the kernel had ended stayed visible on the dashboard, live-looking: its tab kept its last status ("working"), rendered the full cached transcript, and clicking it read as a running session. Only a manual reload cleared it.

## Root cause

Three designed behaviors compose into a ghost:

1. Pane JS state survives WS reconnects (the shim reconnects, never reloads), so a dead session's payload stays in the client's `sessions` map.
2. A client that stops draining is force-dropped at the 16MB send-queue cap — a frozen webview popout or a sleeping laptop is exactly the client that is *disconnected at the kill moment*.
3. The kernel's `closed` frame is one-shot, and it was the only remover: `applyTabOrder`'s keep re-adopted any locally-known tab missing from the kernel's order — on every later push, forever.

Miss the single `closed` frame and the ended session's tab is permanent. The stale-connection banner even clears itself on the resync frame, blessing the ghost.

## The fix

The continuous tabOrder push becomes the authority; `closed` stays as the fast path. An id any kernel push has ever carried is kernel-owned (add-only `kernelListed` set in render.ts); when a later push stops carrying it, that omission is the removal event and the tab gets the same teardown the `closed` event runs (session map, view, drafts, active-tab reselect). Ids the kernel has never listed — the optimistic create placeholder — keep the just-arrived grace, gated in `reconcileTabOrder` by a new `kernelSeen` predicate.

Federation-safe: the merged order only omits an id when its owning host affirmatively reported it gone (per-host slices persist across down/detached hosts), so a tunnel blip never fires the drop.

## Tests

- `tab-order.test.ts`: executed-model tests for the new predicate (kernel-owned drop, never-listed grace, revival re-adopt) — fail against the old code.
- `tab-ghost-heal.test.ts`: the full miss-and-heal cycle as an executed model, plus source pins holding the render.ts wiring (drop-before-reconcile, add-only record, teardown parity).

Both suites green: 1811 node tests, 4189 pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)