### PR TITLE
kernel: the awaiting wake joins the nudge ladder; a wake nobody answers escalates

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -7624,7 +7624,12 @@ def distill_llm(goal_text, work_text, done_why="", prior_summary="", items=None)
 NUDGE_BLOCK_WHY = ("romp followed up once and the response didn't resolve this; "
                    "it won't be re-asked — it needs your direction")
 INTERRUPT_BLOCK_WHY = "you stopped this session mid-turn — it's waiting on your next instruction"
-_PROCEDURAL_BLOCK_WHYS = (NUDGE_BLOCK_WHY, INTERRUPT_BLOCK_WHY)
+# The awaiting WAKE's failure (kernel _mark_nudge_failed wake=True): the session was asked to go check the
+# background work its ⏳ stamp names and no answer landed within the backstop — the wait itself is now the
+# thing that needs eyes (the session may be unreachable, or the awaited work long dead).
+WAKE_BLOCK_WHY = ("romp checked in on the background work this was waiting on and got no answer; "
+                  "the wait looks dead and needs your direction")
+_PROCEDURAL_BLOCK_WHYS = (NUDGE_BLOCK_WHY, INTERRUPT_BLOCK_WHY, WAKE_BLOCK_WHY)
 # The DEBT escalation's why (the user 2026-07-26) carries the unresponsive PEER'S NAME, so it can't be an
 # exact constant: the fixed head is the recognizer (kernel debt_block_why builds it; procedural_block_why
 # prefix-matches it). Still kernel-authored bookkeeping — the variable tail is a session name, never

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -749,7 +749,7 @@ CONTINUE_TEXT = ("Nothing needed from me here. If you're already on it, keep goi
                  "If you can't proceed without me, say exactly what you need in one line.")
 
 
-def _followup_body(iid, title, text, injected=False, auto=False, stalled=False):
+def _followup_body(iid, title, text, injected=False, auto=False, stalled=False, wake=False):
     """Pane message for a feed follow-up: QUOTE the ask being followed up ('> <ask>') above the user's
     text, so the recipient session knows what the reply answers. An explicit `title` (the group modal) is
     used verbatim; otherwise, for a TYPED follow-up, the quote PREFERS the card's DISTILLED SUMMARY — the
@@ -801,12 +801,18 @@ def _followup_body(iid, title, text, injected=False, auto=False, stalled=False):
             # blocks). The enumerated quote above already names the open pieces.
             # Both branches LEAD BACK TO WORK — explicit permission to continue without the user's
             # go-ahead (the user 2026-08-11): a status ask alone buys a report turn and another stop.
-            body = (("Those are still open on your own to-do list. Keep going on anything you can; you "
-                     "don't need my go-ahead. If something's blocked, tell me which one and exactly what "
-                     "you need from me. If one is no longer needed, just say so.") if stalled else
-                    ("Where does each of those stand? What's done, what's left, and is anything blocked "
-                     "waiting on a decision from me? If nothing's actually blocking you, just keep going; "
-                     "you don't need my go-ahead. If one is no longer needed, just say so."))
+            # A WAKE keeps ITS OWN body: the generic status ask invites an answer from memory, and the
+            # audited session gave exactly that twice (a from-memory reassurance that the wait was
+            # deliberate and nothing was owed) while the pid its stamp named had been dead for hours —
+            # the wake's whole point is "go LOOK at the background work", and this replacement was
+            # silently discarding it (the user 2026-08-11).
+            if not wake:
+                body = (("Those are still open on your own to-do list. Keep going on anything you can; you "
+                         "don't need my go-ahead. If something's blocked, tell me which one and exactly what "
+                         "you need from me. If one is no longer needed, just say so.") if stalled else
+                        ("Where does each of those stand? What's done, what's left, and is anything blocked "
+                         "waiting on a decision from me? If nothing's actually blocking you, just keep going; "
+                         "you don't need my go-ahead. If one is no longer needed, just say so."))
         elif not injected and str(nd.get("summary") or nd.get("blockSummary") or "").strip():
             # A TYPED follow-up quotes the card's DISTILLED SUMMARY — the takeaway (completed) or decision brief
             # (blocked) that is the card's visible HEADLINE, the thing you're reading + clicked to follow up on
@@ -1573,10 +1579,12 @@ def _prune_notify_cards(live_ids):
 # (the user 2026-06-26: that produced two nudges ~6s apart in one stop before the agent had consumed the
 # first — the 2nd landed as a type:attachment as the session resumed, so it rendered without the romp logo).
 # On by default; an explicit {"enabled": false} in auto-nudge.json still turns it off. State: auto-nudge.json
-# {"enabled": bool, "nudged": {goalId: {count, lastTurnId}},
-#  "debtNudged": {"<askerSid>><debtorSid>:<askT>": fireT}}   # the DEBT reminder's once-per-ask dedup
+# {"enabled": bool, "nudged": {goalId: {count, lastTurnId}},          # + wake records: {wake, anchor,
+#  "debtNudged": {"<askerSid>><debtorSid>:<askT>": fireT}}            #   answeredAt, ...} (see _wake_goal)
 # (see _fire_debt_reminder); each goal-nudge
 # fire also appends {sid,gid,t,count} to nudge-events.jsonl for the timeline's ⚡ marker.
+# (A legacy `backstop` map — the retired one-shot awaiting wake's once-per-anchor marks — may persist in
+# older files; nothing reads it.)
 # The auto-nudge ask (the manual feed Nudge button was removed 2026-06-30): phrased like a person checking
 # in, not a status form (g13), and it ends by LEADING BACK TO WORK — explicit permission to continue without
 # the user's go-ahead (the user 2026-08-11, after Anthropic's riemann-zeta post, where the operator's whole
@@ -2146,6 +2154,14 @@ def _goal_awaiting_stamp(nodes, top, children=None, answered_at=0):
     predates a peer's answer to this session's ask/handoff is SUPERSEDED — the wait it described was met,
     and waiting for the closer's own lift left a card awaiting 5h after the reply (the user 2026-07-25).
     A stamp with no awaitingAt can't be ordered against the reply and is kept as before."""
+    full = _goal_awaiting_stamp_full(nodes, top, children, answered_at)
+    return full[1] if full else None
+
+
+def _goal_awaiting_stamp_full(nodes, top, children=None, answered_at=0):
+    """(awaitingAt, why) of the freshest live ⏳ stamp in `top`'s subtree, or None — _goal_awaiting_stamp
+    with the ANCHOR alongside the why. The awaiting wake's due-check needs the anchor (see the awaiting
+    branch of _auto_nudge_session's goal walk); every display consumer keeps the why-only twin above."""
     if children is None:
         children = {}
         for nid, nd in nodes.items():
@@ -2162,10 +2178,10 @@ def _goal_awaiting_stamp(nodes, top, children=None, answered_at=0):
                 cand = (at, nd["awaitingWhy"])
                 best = cand if best is None else max(best, cand)
         stack.extend(children.get(x, []))
-    return best[1] if best else None
+    return best
 
 
-def _mark_nudge_failed(gid, ev_t=None):
+def _mark_nudge_failed(gid, ev_t=None, wake=False):
     """Stamp `failed` on `gid`'s nudge record — the nudge-RESPONSE turn completed (closer-settled, so the
     planner has processed it too) and the goal is STILL working-stalled: the one ask didn't resolve it, and
     per the anti-loop rule we never re-ask. Event-based — stamped at the tick's re-arm gate, whose
@@ -2176,21 +2192,30 @@ def _mark_nudge_failed(gid, ev_t=None):
     won't ask again, so by definition the goal now needs the user. Record the block verdict so the card
     moves to Needs-you through the NORMAL ladder (decision brief and all) instead of sitting in Working
     wearing a chip; the user's reply then unblocks it exactly like any other block. (Previously only the
-    FORK flavor floored to needs-you read-side; the common case idled in Working — the user's complaint.)"""
+    FORK flavor floored to needs-you read-side; the common case idled in Working — the user's complaint.)
+
+    `wake=True` = the AWAITING WAKE's failure (see the awaiting branch of _auto_nudge_session): romp asked
+    the session to go check the background work its ⏳ stamp names, and NO answer landed within the
+    backstop. The stamp cannot stand that down — the wake fired BECAUSE of the stamp, so its no-answer
+    evidence postdates the stamp by at least the whole backstop window, and yielding to it is how a dead
+    wait slept 20h in Working behind three spent wakes (the ui session, 2026-08-11). The moot guard below
+    still applies in full: any REAL judge row filed after the wake is a newer ruling and stands us down."""
     # An AWAITING session isn't stalled — its nudge reply ("waiting on the experiment/watcher") DID
     # explain itself, so converting the nudge into a needs-you block manufactures a false interrupt
     # (nimbus, the user 2026-07-11). Normally unreachable (the tick's awaiting gate skips the whole
     # session first), but the gate and this writer read different moments — re-check at the write.
-    try:
-        _sid = gid.rsplit(":", 1)[0]
-        if _session_awaiting(_sid, _path_of(_sid) or "", True):
-            return None
-        if _goal_awaiting_stamp(jd.load_goals(_sid).get("nodes", {}), gid,
-                                answered_at=_peer_answered_at(_sid)):
-            return None                                # the judge's durable ⏳ stamp says the goal waits on
-            #                                            async work — same rule as above, restart-proof
-    except Exception:
-        pass
+    # WAKE failures skip this stand-down (docstring): for them the stamp is the trigger, not a veto.
+    if not wake:
+        try:
+            _sid = gid.rsplit(":", 1)[0]
+            if _session_awaiting(_sid, _path_of(_sid) or "", True):
+                return None
+            if _goal_awaiting_stamp(jd.load_goals(_sid).get("nodes", {}), gid,
+                                    answered_at=_peer_answered_at(_sid)):
+                return None                            # the judge's durable ⏳ stamp says the goal waits on
+                #                                        async work — same rule as above, restart-proof
+        except Exception:
+            pass
     now = int(time.time())
     d = dict(_auto_nudge_data())
     nudged = dict(d.get("nudged", {}))
@@ -2258,8 +2283,9 @@ def _mark_nudge_failed(gid, ev_t=None):
         sid = gid.rsplit(":", 1)[0]
         store = jd.load_goals(sid)
         nd = store.get("nodes", {}).get(gid)
-        why = jd.NUDGE_BLOCK_WHY          # shared constant: the briefer recognizes it as PROCEDURAL and
-        #                                   writes no decision brief, rather than inventing one from <work>
+        why = jd.WAKE_BLOCK_WHY if wake else jd.NUDGE_BLOCK_WHY   # shared constants: the briefer recognizes
+        #                                   these as PROCEDURAL and writes no decision brief, rather than
+        #                                   inventing one from <work>
         # EVIDENCE TIME (_ev, hoisted above for the moot check) = the nudge RESPONSE turn, not wall-clock
         # `now` (the user 2026-07-22). The block's evidence IS that response; claiming `now` made the stamp
         # structurally outrank the user's own reply floor (_block_is_stale voids a block only when
@@ -2688,17 +2714,32 @@ def _auto_nudge_tick(now, tmux):
         _debt_backstop_tick(now)                       # reminder outcomes for debtors the walk can't reach
     except Exception:
         sys.stderr.write("debt-backstop: %s\n" % traceback.format_exc())
+    try:
+        fired = _awaiting_wake_outcomes(now) or fired  # wake outcomes for sessions the walk can't reach
+    except Exception:
+        sys.stderr.write("awaiting-wake outcomes: %s\n" % traceback.format_exc())
     if fired:
         _push_all()
 
 
-# The awaiting BACKSTOP (the user 2026-07-22): a durable ⏳ stamp can, in the worst case, outlive its story
-# — the agent scheduled its own check-back and that wakeup was lost (a kernel restart between arming and
-# firing, a watcher that silently died), so the session sleeps behind the stamp with nothing to wake it.
-# This is the ONE place a time threshold is unavoidable: we are detecting a MISSING event (the wake that
-# never came), which no other event announces. So, SLOWLY and ONCE per stamp episode, wake the session to
+# The awaiting WAKE (the user 2026-07-22, reworked 2026-08-11): a durable ⏳ stamp can, in the worst case,
+# outlive its story — the agent scheduled its own check-back and that wakeup was lost (a kernel restart
+# between arming and firing, a watcher that silently died), so the session sleeps behind the stamp with
+# nothing to wake it. This is the ONE place a time threshold is unavoidable: we are detecting a MISSING
+# event (the wake that never came), which no other event announces. So, SLOWLY, wake the session to
 # re-check its OWN async work. It is patient — a legitimate dispatched/external wait almost always resolves
 # well inside the window, so a stamp still open past it is very likely a lost wakeup.
+#
+# The wake is a FULL MEMBER of the nudge ladder (2026-08-11), not the fire-and-forget one-shot it began as:
+# it records itself in the same `nudged` ledger, its response rides the same _nudge_response_ready gates,
+# and a wake NOBODY answers escalates through _mark_nudge_failed(wake=True) to a real block — Needs-you —
+# instead of sleeping. The one-shot design marked itself spent at SEND time keyed on the stamp anchor
+# (auto-nudge.json's old `backstop` map, now unread): when a wake's response turn died on an API error the
+# anchor never moved (identical re-asserts coalesce, judge apply_close), the mark held forever, and the
+# card slept 20h in Working over a pid that was long dead — unreachable by every other mechanism, because
+# the stamp also stood down the whole nudge ladder (the ui session, 2026-08-11). Episodes re-arm on the
+# ANSWER (a judged response), not the anchor, so a genuinely long wait is re-checked every window and a
+# dead one surfaces after exactly one unanswered wake.
 AWAITING_BACKSTOP_SECS = 6 * 3600
 # The TEXT reads as the person checking in (the user 2026-08-11): the first version said "goal" twice and
 # announced itself "(Automated re-check…)" — romp vocabulary plus an automated-origin disclosure, both
@@ -2710,14 +2751,13 @@ AWAITING_BACKSTOP_TEXT = (
     "say exactly what you need from me. If it's genuinely still running, a one-line status is enough.")
 
 
-def _mark_awaiting_backstop(gid, at):
-    """Record the ONE backstop wake for a stamp EPISODE, keyed on the stamp anchor (awaitingAt): a new
-    episode (a fresh awaitingAt from the closer's next awaiting verdict) re-arms; a re-assert of the same
-    wait does not re-wake. Lives beside `nudged` in auto-nudge.json under its own `backstop` key."""
+def _put_nudged(gid, rec):
+    """Persist ONE nudge/wake record into auto-nudge.json's `nudged` ledger — the read-modify-write the
+    failed stamp already does inline, shared so the wake's answered/fired records take the same shape."""
     d = dict(_auto_nudge_data())
-    bs = dict(d.get("backstop", {}))
-    bs[gid] = at
-    d["backstop"] = bs
+    nudged = dict(d.get("nudged", {}))
+    nudged[gid] = rec
+    d["nudged"] = nudged
     _write_auto_nudge(d)
 
 
@@ -2786,7 +2826,8 @@ def _lift_spent_awaiting(now, tmux):
     awaiting flavors are untouched: we lift only when this goal DID dispatch background work of its own by
     stamp time and every one of those has come back. A stamp naming a CI run, a scheduled check-back or a
     peer handoff owns no such dispatches, so it never matches and keeps its stamp — those still rely on the
-    6h backstop below, which is exactly the case a timer is the only tool for.
+    6h awaiting wake (_wake_goal, in the nudge tick's goal walk), which is exactly the case a timer is the
+    only tool for.
 
     Dormant sessions are skipped: their tasks died with their CLI, so the death notice is the truth there,
     not a lift (same rule as _session_awaiting's source 0.75)."""
@@ -2864,43 +2905,130 @@ def _lift_spent_awaiting(now, tmux):
             sys.stderr.write("awaiting-lift (session %s): %s\n" % (sid or "?", traceback.format_exc()))
 
 
-def _awaiting_backstop_tick(now, tmux):
-    """Slow one-shot wake for a LIVE session asleep behind a stale awaiting stamp (see the block comment
-    above). NEVER a needs-you floor — the wait was legitimate; the agent re-checks and decides (proceed,
-    block, or ask). Rides the auto-nudge master toggle and reuses the nudge's idle / genuine-stop / queue
-    suppressions so it can never fire mid-turn or jump queued user input. The auto-nudge tick already SKIPS
-    awaiting-stamped goals, so this is the only writer that touches them, and at most once per 6h episode."""
-    if not _auto_nudge_on():
-        return
-    backstop = _auto_nudge_data().get("backstop", {})
+def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
+    """The AWAITING branch of _auto_nudge_session's goal walk — one stamped top goal. The stamp is a
+    judged wait, so the plain status nudge stays off; but a wait is not an exemption from the ladder
+    (the user 2026-08-11): fire the check-in past the backstop, track its outcome through the same record
+    + response gates as a nudge, and escalate a wake nobody answered. Returns True when something fired or
+    a failure stamped (the tick pushes once at the end). Episodes:
+      due       now - max(anchor, last ANSWERED wake) >= AWAITING_BACKSTOP_SECS → send AWAITING_BACKSTOP_TEXT,
+                record {wake, anchor, count, lastTurnId, armAtoms, at} in the shared `nudged` ledger.
+                lastTurnId is the NEWEST turn (romp-injected or not) — the wake isn't arm-keyed like a
+                nudge; the record only needs the growth yardstick _nudge_response_ready reads.
+      answered  the response landed and the judges ruled on it (same _nudge_response_ready gates) while
+                the stamp still stands → the wait was re-affirmed; keep the record with answeredAt so the
+                NEXT wake measures from the answer — NOT the anchor, which a same-why re-assert
+                deliberately freezes (judge apply_close's coalesce rule; keying episodes on the anchor is
+                what made the one-shot design terminal).
+      silent    no response within the same window (from the FIRE, rec["at"]) → _mark_nudge_failed(wake=True):
+                the block rides the normal ladder to Needs-you. A failed/moot record re-arms only on a
+                genuinely NEW stamp episode (anchor newer than the one that failed)."""
+    at, why = stamp
+    if tmux.get(sid) is None:
+        return False                                 # dormant CLI → its work died with it; the death notice
+        #                                              owns that story, not a wake (same rule as the lifts)
+    rec = nudged.get(gid) or {}
+    if not rec.get("wake"):
+        rec = {}                                     # a REGULAR nudge record (predates the stamp): the wake
+        #                                              keeps its own episodes; never misread its fields
+    if rec and not rec.get("answeredAt") and not rec.get("failed") and not rec.get("moot"):
+        # a wake is in flight — judge its outcome (the leg the one-shot backstop never had)
+        ready, resp = _nudge_response_ready(turns, store, rec, gid, now)
+        if not ready:
+            return False                             # response not arrived/ruled yet — re-check next tick,
+            #                                          bounded by the window from the fire time
+        if resp is not None:
+            # the judges ruled on the answer and the stamp still stands → the wait was re-affirmed
+            nudged[gid] = dict(rec, answeredAt=(resp.get("t") or int(now)))
+            _put_nudged(gid, nudged[gid])
+            return False
+        _sdefer = _revivers_pending(sid, store, turns, gid)
+        if _sdefer and not _nudge_deferred_ok(gid, _sdefer, now, sid):
+            return False                             # something else can still move it (judge pass, retry
+            #                                          pause) → inspectable deferral, 6h-backstopped
+        # EVIDENCE TIME: the fire itself (the injected message is a real transcript event) or any turn
+        # that ended after it — never the pre-stamp turn end, whose time PREDATES the stamp's own filing
+        # `at`, so the moot guard would read the stamp as "a judge ruled after the evidence" and the
+        # escalation would stand itself down on the very stamp it fired for.
+        _ev = max(rec.get("at") or 0, lt.get("end") or lt.get("t") or 0) or None
+        _fate = _mark_nudge_failed(gid, ev_t=_ev, wake=True)
+        if _fate:
+            nudged[gid] = dict(rec, **({"failed": True} if _fate == "failed" else {"moot": True}))
+        return _fate == "failed"
+    if rec.get("failed") or rec.get("moot"):
+        if (rec.get("anchor") or 0) >= at:
+            return False                             # this episode already escalated / was superseded —
+            #                                          the anti-loop rule; a user reply unblocks as usual
+        rec = {}                                     # a genuinely NEW wait (fresh anchor) re-arms the wake
+    since = max(at, rec.get("answeredAt") or 0, rec.get("at") or 0)
+    if now - since < AWAITING_BACKSTOP_SECS:
+        return False                                 # still patient
+    _defer = _revivers_pending(sid, store, turns, gid)
+    if _defer and not _nudge_deferred_ok(gid, _defer, now, sid):
+        return False
+    try:
+        # last-moment fresh-store re-read (the judges run concurrently with this tick): the wake's whole
+        # justification is "the stamp stands and the goal is open" — re-key on the store as written
+        _fresh = jd.load_goals(sid)
+        if (not _goal_awaiting_stamp(_fresh.get("nodes", {}), gid, answered_at=_peer_answered_at(sid))
+                or _fresh.get("status", {}).get(gid, "working") != "working"):
+            return False
+    except Exception:
+        pass
+    Sessions.backend_for(sid).send(sid, _followup_body(gid, None, AWAITING_BACKSTOP_TEXT,
+                                                       injected=True, auto=True, wake=True))
+    _nudge_deferred_ok(gid, "", now, sid)            # the hold is over — drop any deferral record
+    nudged[gid] = {"wake": True, "anchor": at, "count": (rec.get("count") or 0) + 1,
+                   "lastTurnId": lt.get("id"), "armAtoms": len(lt.get("atoms") or []), "at": int(now)}
+    _put_nudged(gid, nudged[gid])
+    _log_nudge_event(sid, gid, now, 0)               # timeline romp-logo dot (count 0 marks a wake, not an escalation)
+    return True
+
+
+def _awaiting_wake_outcomes(now):
+    """Outcome sweep for wake records whose sessions the per-goal walk can't reach — mirrors
+    _debt_backstop_tick. The walk's own outcome leg is gentler (it waits for the judges), but it runs only
+    for sessions that pass the session gates, and a dead wake leaves its session in EXACTLY a gated state:
+    the ui case's response turn died on an API error, so the _api_error gate skipped the whole session
+    forever and no mechanism ever looked at the spent wake again (2026-08-11). Here: a wake past the
+    window with no ruled response escalates regardless of session state; an answered/ruled one is left to
+    the walk. Returns True when a failure stamped (the tick pushes)."""
     fired = False
-    for s in _alive_sessions(now, tmux):
-        sid = s["sid"]
+    nudged = _auto_nudge_data().get("nudged", {})
+    for gid, rec in list(nudged.items()):
         try:
-            if tmux.get(sid) is None:                # not a live CLI → a dormant session's work is gone, not asleep
+            if not (isinstance(rec, dict) and rec.get("wake")) or rec.get("failed") \
+                    or rec.get("moot") or rec.get("answeredAt"):
                 continue
-            gid, at, why = _session_stamp_full(sid)
-            if not gid or not at or now - at < AWAITING_BACKSTOP_SECS:
-                continue                             # no stamp, or still patient
-            if backstop.get(gid) == at:
-                continue                             # already woke for THIS stamp episode (once per anchor)
-            turns = jd.parsed_session(sid, [s["path"]], now).get("turns", [])
-            if not turns or _session_working(turns):
-                continue                             # actively producing → not asleep
-            ls_val, ls_t = _last_state(sid)          # authoritative state log: a progressing record at/after the
-            lt = turns[-1]                           # turn end is a mid-turn lull, not a real idle — same
-            if ls_val in _PROGRESSING_STATES and ls_t >= lt.get("end", lt.get("t", 0)):
-                continue                             # genuine-stop discriminator the nudge uses
-            if _pending_ops.get(str(sid)) or _backend_queued(sid) or _backend_rewind_pending(sid):
-                continue                             # the user has input queued / a rewind armed → don't jump it
-            Sessions.backend_for(sid).send(sid, _followup_body(gid, None, AWAITING_BACKSTOP_TEXT, injected=True, auto=True))
-            _mark_awaiting_backstop(gid, at)
-            _log_nudge_event(sid, gid, now, 0)       # timeline romp-logo dot (count 0 marks a backstop, not an escalation)
-            fired = True
+            if now - (rec.get("at") or 0) <= AWAITING_BACKSTOP_SECS:
+                continue                             # the walk still owns this one
+            sid = gid.rsplit(":", 1)[0]
+            store = jd.load_goals(sid)
+            nd = store.get("nodes", {}).get(gid)
+            if (nd is None or nd.get("cleared") or nd.get("nodeComplete") or nd.get("blocked")
+                    or store.get("status", {}).get(gid, "working") != "working"):
+                continue                             # the world moved on; the record is inert
+            path = _path_of(sid) or ""
+            turns = jd.parsed_session(sid, [path], now).get("turns", []) if path else []
+            if turns and _session_working(turns):
+                continue                             # actively producing — let the walk judge it
+            ready, resp = _nudge_response_ready(turns, store, rec, gid, now)
+            if ready and resp is not None:
+                # answered and ruled — re-arm from the answer, exactly as the walk's eval would have (the
+                # walk never got to: its session gates held, e.g. an api-error AFTER the judged response)
+                _put_nudged(gid, dict(rec, answeredAt=(resp.get("t") or int(now))))
+                continue
+            if resp is not None:
+                continue                             # visible but not ruled yet — the judges own it
+            # resp is None past the window: NOTHING answered the wake — not even the injected message's
+            # own segment grew the parse (a lost send, a response turn that died before landing). Silent.
+            _ev = max(rec.get("at") or 0,
+                      (turns[-1].get("end") or turns[-1].get("t") or 0) if turns else 0) or None
+            if _mark_nudge_failed(gid, ev_t=_ev, wake=True) == "failed":
+                fired = True
         except Exception:
-            sys.stderr.write("awaiting-backstop (session %s): %s\n" % (sid or "?", traceback.format_exc()))
-    if fired:
-        _push_all()
+            sys.stderr.write("awaiting-wake outcome (%s): %s\n" % (gid, traceback.format_exc()))
+    return fired
 
 
 def _launch_error(sid):
@@ -3353,13 +3481,16 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
             continue                                 # all open work handed to peers → nothing for THIS session
         if sid in waitfor and nd.get("t", 0) <= waitfor[sid]["since"]:
             continue                                 # awaiting a live peer's reply to a question this goal predates
-        if _goal_awaiting_stamp(nodes, gid, _kids, answered_at=_peer_answered_at(sid)):
-            continue                                 # the judge's durable ⏳ stamp (closer awaiting verdict):
-            #                                          the goal's latest audited turn ended waiting on async
-            #                                          work it dispatched — not a stall. Restart-proof, unlike
-            #                                          the session-level live gate above; lifted by exact
-            #                                          events (next audited turn / done / block / user reply /
-            #                                          a peer's answer superseding the stamp)
+        _stamp = _goal_awaiting_stamp_full(nodes, gid, _kids, answered_at=_peer_answered_at(sid))
+        if _stamp:
+            # The judge's durable ⏳ stamp (closer awaiting verdict): the goal's latest audited turn ended
+            # waiting on async work it dispatched — not a stall, so the status nudge stays off. Restart-
+            # proof, unlike the session-level live gate above; lifted by exact events (next audited turn /
+            # done / block / user reply / a peer's answer superseding the stamp). But a wait is not an
+            # exemption from the ladder (the user 2026-08-11): past the backstop the goal takes a WAKE —
+            # same records, same response gates, same escalation, its own copy (see _wake_goal).
+            fired = _wake_goal(sid, gid, _stamp, nudged, turns, store, now, lt, tmux) or fired
+            continue
         # LAST-RESORT GATE (the user 2026-07-22): every OTHER mechanism that could still move this card
         # off 'working' must be exhausted first. This is what the 2026-07-22 false interrupt needed: the
         # card's 'working' came from a STALE agent-to-do mirror, and the nudge fired before the sync that
@@ -8692,8 +8823,7 @@ def _session_stamp_read(sid):
 
 def _session_stamp_full(sid):
     """(gid, awaitingAt, why) of the freshest durable ⏳ awaiting stamp across ALL of a session's goals, or
-    (None, None, None). _session_stamp_cached returns just the why (the display surfaces); the awaiting
-    backstop needs the gid + awaitingAt too."""
+    (None, None, None). _session_stamp_cached returns just the why (the display surfaces)."""
     return _session_stamp_read(sid)[0]
 
 
@@ -8705,8 +8835,7 @@ def _session_stamped_tops(sid):
 
 
 def _session_stamp_cached(sid):
-    """The freshest durable ⏳ stamp's WHY for a session (or None) — the display surfaces' view; see
-    _session_stamp_full for the gid + awaitingAt the awaiting backstop consumes."""
+    """The freshest durable ⏳ stamp's WHY for a session (or None) — the display surfaces' view."""
     return _session_stamp_full(sid)[2]
 
 
@@ -12637,7 +12766,7 @@ def _mark_nodes_cleared(item_ids, value, src="user", why=None):
 # machines then carried them into the fresh, unrelated conversation: the closer's history-nominated
 # candidates, the unblocker's per-turn re-examines, the auto-nudge (quoting pre-clear goals at an agent
 # with no memory of them, then recording a "nudge failed" block when its reply couldn't resolve them),
-# and the awaiting backstop. The boundary tick makes the clear visible: it records each observed
+# and the awaiting wake. The boundary tick makes the clear visible: it records each observed
 # episode head in jd's episodes/<sid>.jsonl (also the durable map to past episodes' transcripts —
 # lastSid is overwritten per fork, so this log is the only attribution of old files to their session),
 # and settles the open cards that died with their episode — sealed like the mute path (cleared.jsonl +
@@ -17646,18 +17775,14 @@ def _pusher_cycle_jobs(now, tmux, any_client):
     if any_client:
         _push_all(tmux=tmux)
     # (the WS keepalive lives on its own _heartbeat thread — NOT here — so a slow push can't starve it)
-    try:                                  # Auto Nudge runs server-side even with no browser open (cheap when off)
-        _auto_nudge_tick(now, tmux)
-    except Exception:
-        sys.stderr.write("auto-nudge: %s\n" % traceback.format_exc())
-    try:                                  # EXACT retraction first: dispatches returned → the stamp is spent
-        _lift_spent_awaiting(now, tmux)
+    try:                                  # EXACT retraction first: dispatches returned → the stamp is spent,
+        _lift_spent_awaiting(now, tmux)   # so the nudge tick below never wakes a wait that already ended
     except Exception:
         sys.stderr.write("awaiting-lift: %s\n" % traceback.format_exc())
-    try:                                  # slow one-shot wake for a session asleep behind a stale awaiting stamp
-        _awaiting_backstop_tick(now, tmux)
+    try:                                  # Auto Nudge runs server-side even with no browser open (cheap when
+        _auto_nudge_tick(now, tmux)       # off); the awaiting WAKE rides its goal walk (see _wake_goal)
     except Exception:
-        sys.stderr.write("awaiting-backstop: %s\n" % traceback.format_exc())
+        sys.stderr.write("auto-nudge: %s\n" % traceback.format_exc())
     try:                                  # Interrupt → Blocked runs EVERY push, independent of the nudge toggle
         _interrupt_block_tick(now, tmux)
     except Exception:

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -4,9 +4,12 @@
 restarts, where the LIVE awaiting sources (in-memory subagents/bgTasks) go dark. Consumers here:
 
   * _goal_awaiting_stamp — the subtree scan both the feed floor and the nudge gates share;
-  * _mark_nudge_failed — a stamped goal's nudge is never converted into a needs-you block (the
+  * _mark_nudge_failed — a stamped goal's NUDGE is never converted into a needs-you block (the
     restart-proof twin of the session-level awaiting re-check): this is exactly the false "stalled"
-    a genuinely-waiting session showed after a kernel restart.
+    a genuinely-waiting session showed after a kernel restart. The awaiting WAKE (wake=True) is the
+    deliberate exception: it fires BECAUSE of the stamp, so an unanswered wake escalates through it;
+  * _wake_goal / _awaiting_wake_outcomes — the wake itself (2026-08-11): the stamped goal's seat in
+    the nudge ladder, with the outcome leg the retired one-shot backstop never had.
 
 SYNTHETIC fixtures only (placeholder UUIDs, invented text)."""
 import json
@@ -345,18 +348,21 @@ class _FakeBackend:
     def pending_queued(self, sid): return False       # → _backend_queued False; no pending_cut → rewind False
 
 
-class AwaitingBackstop(unittest.TestCase):
-    """The slow one-shot wake for a session asleep behind a STALE awaiting stamp whose own wakeup was lost
-    (the user 2026-07-22). Patient (6h), once per stamp episode (keyed on awaitingAt), never a needs-you
-    floor. The one place a time threshold is unavoidable: detecting a MISSING event (the wake that never
-    came). SYNTHETIC fixtures only."""
+class AwaitingWake(unittest.TestCase):
+    """The awaiting WAKE (2026-08-11, replacing the one-shot backstop): a stamped goal past the 6h window
+    takes a check-in through the NUDGE ladder — recorded in the shared `nudged` ledger, its response judged
+    by the same gates, and a wake NOBODY answers escalated to a real block (Needs-you). The one-shot design
+    marked itself spent at SEND time keyed on the stamp anchor, so a wake whose response turn died (an API
+    error) left the card asleep in Working forever: the anchor never moves (identical re-asserts coalesce)
+    and the stamp also stood down the whole ladder. Episodes re-arm on the ANSWER, not the anchor.
+    SYNTHETIC fixtures only."""
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         td = Path(self.td.name)
         self.saved = {k: getattr(km, k) for k in
-                      ("_alive_sessions", "_session_working", "_last_state", "_log_nudge_event",
-                       "_push_all", "_followup_body")}
+                      ("_session_working", "_log_nudge_event", "_push_all", "_revivers_pending",
+                       "_peer_answered_at", "_path_of", "_session_awaiting")}
         self.saved_jd = (km.jd.STATE, km.jd.GOALDIR, km.jd.parsed_session)
         self.saved_backend = km.Sessions.backend_for
         km.jd.STATE = td
@@ -365,15 +371,17 @@ class AwaitingBackstop(unittest.TestCase):
         (td / "auto-nudge.json").write_text(json.dumps({"enabled": True, "nudged": {}}))
         self.fb = _FakeBackend()
         km.Sessions.backend_for = lambda sid: self.fb
-        km._alive_sessions = lambda now, tmux: [{"sid": SID, "path": "/p"}]
         km._session_working = lambda turns: False           # idle by default
-        km._last_state = lambda sid: ("waiting", 0)         # not a progressing state → genuine idle
-        km.jd.parsed_session = lambda sid, paths, now: {"turns": [{"id": "t1", "ended": True, "end": 100, "atoms": []}]}
         km._log_nudge_event = lambda *a, **k: None
         km._push_all = lambda *a, **k: None
-        km._followup_body = lambda *a, **k: "wake body"
+        km._revivers_pending = lambda *a, **k: ""           # no other reviver holds the wake
+        km._peer_answered_at = lambda sid: 0
+        km._path_of = lambda sid, now=None: "/p"
+        km._session_awaiting = lambda sid, path, idle, stamp=False: None
         km._pending_ops.pop(SID, None)
         self.gid = SID + ":g1"
+        self.turns = [{"id": "t1", "ended": True, "end": 100, "t": 90, "atoms": []}]
+        km.jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
 
     def tearDown(self):
         for k, v in self.saved.items():
@@ -383,76 +391,262 @@ class AwaitingBackstop(unittest.TestCase):
         km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()
         self.td.cleanup()
 
-    def _seed(self, at):
+    def _seed(self, at, row_at=1):
         nd = _node(self.gid, why="the trace it dispatched; reports when it returns", at=at)
+        nd["log"][0]["at"] = row_at                  # when the closer FILED the stamp (arrival time)
         (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
             "rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}))
 
-    def _tick(self, now, tmux=None):
-        km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()   # deterministic: never hit a stale cache
-        km._awaiting_backstop_tick(now, {SID: {"state": ""}} if tmux is None else tmux)
+    def _wake(self, now, rec=None, tmux=None):
+        km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()   # deterministic: never a stale cache
+        if rec is not None:
+            d = json.loads((Path(self.td.name) / "auto-nudge.json").read_text())
+            d["nudged"] = {self.gid: rec}
+            (Path(self.td.name) / "auto-nudge.json").write_text(json.dumps(d))
+        store = km.jd.load_goals(SID)
+        nudged = dict(km._auto_nudge_data().get("nudged", {}))
+        stamp = km._goal_awaiting_stamp_full(store.get("nodes", {}), self.gid)
+        self.assertIsNotNone(stamp, "fixture: the goal must be stamped")
+        out = km._wake_goal(SID, self.gid, stamp, nudged, self.turns, store, now,
+                            self.turns[-1], {SID: {"state": ""}} if tmux is None else tmux)
+        km._autonudge_cache.clear()
+        return out
 
     def test_stamp_full_exposes_gid_and_at(self):
         self._seed(at=500)
         self.assertEqual(km._session_stamp_full(SID), (self.gid, 500, "the trace it dispatched; reports when it returns"))
 
-    def test_fires_once_for_a_stale_stamp(self):
+    def test_fires_past_the_window_and_records_the_episode(self):
         now = 1_000_000
         self._seed(at=now - 7 * 3600)                # older than the 6h window
-        self._tick(now)
-        self.assertEqual(len(self.fb.sent), 1, "a stamp open past the window gets one wake")
-        self.assertEqual(km._auto_nudge_data().get("backstop", {}).get(self.gid), now - 7 * 3600,
-                         "the wake is recorded against the stamp anchor")
+        self.assertTrue(self._wake(now))
+        self.assertEqual(len(self.fb.sent), 1, "a stamp open past the window gets a wake")
+        rec = km._auto_nudge_data()["nudged"][self.gid]
+        self.assertTrue(rec.get("wake"))
+        self.assertEqual(rec.get("anchor"), now - 7 * 3600)
+        self.assertEqual(rec.get("at"), now)
+        self.assertEqual(rec.get("lastTurnId"), "t1")
 
-    def test_stays_patient_for_a_fresh_stamp(self):
+    def test_stays_patient_inside_the_window(self):
         now = 1_000_000
         self._seed(at=now - 3600)                    # only an hour old
-        self._tick(now)
+        self.assertFalse(self._wake(now))
         self.assertEqual(self.fb.sent, [], "a legitimate wait inside the window is left alone")
 
-    def test_does_not_wake_twice_for_the_same_anchor(self):
+    def test_in_flight_wake_does_not_refire(self):
         now = 1_000_000
-        self._seed(at=now - 7 * 3600)
-        self._tick(now); self._tick(now + 60)
-        self.assertEqual(len(self.fb.sent), 1, "once per stamp episode, not every tick")
+        self._seed(at=now - 20 * 3600)
+        rec = {"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t1",
+               "armAtoms": 0, "at": now - 3600}      # fired an hour ago, response not judged yet
+        self.assertFalse(self._wake(now, rec=rec))
+        self.assertEqual(self.fb.sent, [], "one wake in flight — never a second while unjudged")
 
-    def test_re_arms_for_a_new_stamp_episode(self):
+    def test_silent_wake_escalates_to_a_needs_you_block(self):
+        # THE 2026-08-11 ui wedge: wake fired, its response turn died on an API error, nothing ever
+        # landed — under the one-shot design the spent anchor-mark slept forever and the stamp stood
+        # down the ladder. Now: past the window with no response, the wake fails and files a real block.
         now = 1_000_000
-        self._seed(at=now - 7 * 3600)
-        self._tick(now)
-        self._seed(at=now - 6 * 3600 - 1)            # a NEW awaitingAt (the closer re-classified) → new anchor
-        self._tick(now)
-        self.assertEqual(len(self.fb.sent), 2, "a fresh awaiting episode re-arms the backstop")
+        self._seed(at=now - 20 * 3600)
+        rec = {"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t0",
+               "armAtoms": 0, "at": now - 7 * 3600}  # fired 7h ago, nothing since
+        self.assertTrue(self._wake(now, rec=rec))
+        store = km.jd.load_goals(SID)
+        self.assertTrue(store["nodes"][self.gid]["blocked"],
+                        "an unanswered wake IS a block — the card must reach Needs-you")
+        self.assertEqual(store["nodes"][self.gid].get("blockWhy"), km.jd.WAKE_BLOCK_WHY)
+        self.assertTrue(km._auto_nudge_data()["nudged"][self.gid].get("failed"))
 
-    def test_skips_when_the_master_toggle_is_off(self):
-        (Path(self.td.name) / "auto-nudge.json").write_text(json.dumps({"enabled": False, "nudged": {}}))
-        self._seed(at=1_000_000 - 7 * 3600)
-        self._tick(1_000_000)
-        self.assertEqual(self.fb.sent, [], "the backstop rides the auto-nudge master toggle")
+    def test_silent_escalation_evidence_is_the_fire_not_the_stale_turn(self):
+        # The stamp's own diary row is FILED (at) after the sleeping session's last turn END — anchoring
+        # the block at the turn end would let the moot guard read the stamp itself as "a judge ruled
+        # after the evidence" and the escalation would stand itself down on the very stamp it fired for.
+        now = 1_000_000
+        fire = now - 7 * 3600
+        self._seed(at=now - 20 * 3600, row_at=5000)  # stamp filed AFTER the turn end (100), before the fire
+        rec = {"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t0",
+               "armAtoms": 0, "at": fire}
+        self.assertTrue(self._wake(now, rec=rec), "the stamp row must not moot the silent escalation")
+        nd = km.jd.load_goals(SID)["nodes"][self.gid]
+        rows = [e for e in nd["log"] if e.get("kind") == "block"]
+        self.assertEqual(rows[-1].get("ev_t"), fire, "the block's evidence time is the unanswered fire")
 
-    def test_skips_a_working_session(self):
-        km._session_working = lambda turns: True
-        self._seed(at=1_000_000 - 7 * 3600)
-        self._tick(1_000_000)
-        self.assertEqual(self.fb.sent, [], "a session actively producing is not asleep")
+    def test_answered_wake_re_arms_from_the_answer(self):
+        now = 1_000_000
+        self._seed(at=now - 20 * 3600)
+        rec = {"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t1",
+               "armAtoms": 0, "at": now - 7 * 3600}
+        saved = km._nudge_response_ready
+        km._nudge_response_ready = lambda *a, **k: (True, {"id": "s9", "t": now - 6 * 3600})
+        try:
+            self.assertFalse(self._wake(now, rec=rec), "an answered wake never escalates")
+        finally:
+            km._nudge_response_ready = saved
+        rec2 = km._auto_nudge_data()["nudged"][self.gid]
+        self.assertEqual(rec2.get("answeredAt"), now - 6 * 3600,
+                         "the episode re-arms from the ANSWER — the anchor may never move (coalesced "
+                         "re-asserts keep the original stamp), so it cannot be the episode key")
+        self.assertFalse(km.jd.load_goals(SID)["nodes"][self.gid]["blocked"])
+        # ...and the next wake fires once the ANSWER goes stale, same stamp anchor throughout
+        self.assertFalse(self._wake(now - 6 * 3600 + 60, rec=rec2), "still patient after the answer")
+        self.assertTrue(self._wake(now + 3600, rec=rec2), "re-armed: 6h past the answer it asks again")
 
-    def test_skips_a_mid_turn_lull_per_the_state_log(self):
-        km._last_state = lambda sid: ("working", 200)   # authoritative state progressing AT/AFTER turn end (100)
-        self._seed(at=1_000_000 - 7 * 3600)
-        self._tick(1_000_000)
-        self.assertEqual(self.fb.sent, [], "a progressing state record means a lull, not a real stop")
+    def test_failed_episode_never_refires_until_a_new_anchor(self):
+        now = 1_000_000
+        anchor = now - 20 * 3600
+        self._seed(at=anchor)
+        rec = {"wake": True, "anchor": anchor, "count": 1, "lastTurnId": "t0",
+               "armAtoms": 0, "at": now - 8 * 3600, "failed": True, "failedAt": now - 3600}
+        self.assertFalse(self._wake(now, rec=rec))
+        self.assertEqual(self.fb.sent, [], "a failed episode is settled — the anti-loop rule")
+        self._seed(at=now - 7 * 3600)                # the closer filed a genuinely NEW wait
+        self.assertTrue(self._wake(now, rec=rec), "a fresh anchor re-arms the wake")
 
     def test_dormant_session_is_not_woken(self):
-        self._seed(at=1_000_000 - 7 * 3600)
-        self._tick(1_000_000, tmux={})               # SID not in the live set → not a live CLI
-        self.assertEqual(self.fb.sent, [], "a dormant session's dispatched work is gone, not asleep")
-
-    def test_never_writes_a_block(self):
         now = 1_000_000
         self._seed(at=now - 7 * 3600)
-        self._tick(now)
-        nd = km.jd.load_goals(SID)["nodes"][self.gid]
-        self.assertFalse(nd.get("blocked"), "the backstop wakes, it never floors to needs-you")
+        self.assertFalse(self._wake(now, tmux={}))   # SID not in the live set → not a live CLI
+        self.assertEqual(self.fb.sent, [], "a dormant session's dispatched work is gone, not asleep")
+
+    def test_wake_that_judges_resolved_mid_tick_stands_down(self):
+        now = 1_000_000
+        self._seed(at=now - 7 * 3600)
+        store = km.jd.load_goals(SID)
+        stamp = km._goal_awaiting_stamp_full(store["nodes"], self.gid)
+        # the fresh-store re-read at send time sees the goal already blocked → no wake
+        d = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())
+        d["status"] = {self.gid: "blocked"}
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(d))
+        self.assertFalse(km._wake_goal(SID, self.gid, stamp, {}, self.turns, store, now,
+                                       self.turns[-1], {SID: {"state": ""}}))
+        self.assertEqual(self.fb.sent, [], "the last-moment store re-read keys on the judges' landing")
+
+
+class AwaitingWakeOutcomeSweep(unittest.TestCase):
+    """_awaiting_wake_outcomes: the outcome leg for wake records whose sessions the goal walk can't reach.
+    A dead wake leaves its session in EXACTLY a walk-gated state (the ui case: the response turn died on an
+    API error, so the _api_error session gate skipped every later evaluation) — the sweep escalates a wake
+    past the window with no response regardless of session gates, and re-arms an answered one."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.saved = {k: getattr(km, k) for k in
+                      ("_session_working", "_path_of", "_session_awaiting", "_peer_answered_at",
+                       "_log_nudge_event", "_push_all")}
+        self.saved_jd = (km.jd.STATE, km.jd.GOALDIR, km.jd.parsed_session)
+        km.jd.STATE = td
+        km.jd.GOALDIR = td / "goals"; km.jd.GOALDIR.mkdir(parents=True)
+        km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()
+        km._session_working = lambda turns: False
+        km._path_of = lambda sid, now=None: "/p"
+        km._session_awaiting = lambda sid, path, idle, stamp=False: None
+        km._peer_answered_at = lambda sid: 0
+        km._log_nudge_event = lambda *a, **k: None
+        km._push_all = lambda *a, **k: None
+        self.gid = SID + ":g1"
+        self.turns = [{"id": "t1", "ended": True, "end": 100, "t": 90, "atoms": []}]
+        km.jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
+
+    def tearDown(self):
+        for k, v in self.saved.items():
+            setattr(km, k, v)
+        km.jd.STATE, km.jd.GOALDIR, km.jd.parsed_session = self.saved_jd
+        km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()
+        self.td.cleanup()
+
+    def _seed_goal(self, at):
+        nd = _node(self.gid, why="the reinstaller it detached; reports when the box is quiet", at=at)
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}))
+
+    def _seed_rec(self, rec):
+        (Path(self.td.name) / "auto-nudge.json").write_text(json.dumps(
+            {"enabled": True, "nudged": {self.gid: rec}}))
+        km._autonudge_cache.clear()
+
+    def test_sweep_escalates_a_silent_wake_the_walk_cannot_reach(self):
+        now = 1_000_000
+        self._seed_goal(at=now - 20 * 3600)
+        self._seed_rec({"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t0",
+                        "armAtoms": 0, "at": now - 7 * 3600})
+        self.assertTrue(km._awaiting_wake_outcomes(now))
+        store = km.jd.load_goals(SID)
+        self.assertTrue(store["nodes"][self.gid]["blocked"],
+                        "the sweep runs without the walk's session gates — an api-errored session's dead "
+                        "wake still surfaces")
+        self.assertEqual(store["nodes"][self.gid].get("blockWhy"), km.jd.WAKE_BLOCK_WHY)
+
+    def test_sweep_leaves_a_fresh_wake_to_the_walk(self):
+        now = 1_000_000
+        self._seed_goal(at=now - 20 * 3600)
+        self._seed_rec({"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t1",
+                        "armAtoms": 0, "at": now - 3600})
+        self.assertFalse(km._awaiting_wake_outcomes(now))
+        self.assertFalse(km.jd.load_goals(SID)["nodes"][self.gid]["blocked"])
+
+    def test_sweep_ignores_a_goal_the_world_moved_past(self):
+        now = 1_000_000
+        self._seed_goal(at=now - 20 * 3600)
+        d = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())
+        d["nodes"][self.gid]["nodeComplete"] = True
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(d))
+        self._seed_rec({"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t0",
+                        "armAtoms": 0, "at": now - 7 * 3600})
+        self.assertFalse(km._awaiting_wake_outcomes(now))
+        self.assertFalse(km.jd.load_goals(SID)["nodes"][self.gid].get("blocked"),
+                         "a completed goal's stale record is inert")
+
+    def test_sweep_re_arms_an_answered_wake_the_walk_never_saw(self):
+        now = 1_000_000
+        self._seed_goal(at=now - 20 * 3600)
+        self._seed_rec({"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t1",
+                        "armAtoms": 0, "at": now - 7 * 3600})
+        saved = km._nudge_response_ready
+        km._nudge_response_ready = lambda *a, **k: (True, {"id": "s9", "t": now - 6 * 3600})
+        try:
+            self.assertFalse(km._awaiting_wake_outcomes(now))
+        finally:
+            km._nudge_response_ready = saved
+        self.assertEqual(km._auto_nudge_data()["nudged"][self.gid].get("answeredAt"), now - 6 * 3600)
+        self.assertFalse(km.jd.load_goals(SID)["nodes"][self.gid]["blocked"])
+
+
+class WakeBodyKeepsItsCopy(unittest.TestCase):
+    """_followup_body(wake=True): the wake's ask survives the hierarchical enumeration branch. The generic
+    status ask invites an answer from memory — the audited session twice reassured from memory that its
+    wait was deliberate while the pid its stamp named was long dead — and the enumeration branch was
+    silently REPLACING the wake's 'go check the background work' body with exactly that generic ask
+    (the user 2026-08-11)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.saved_jd = (km.jd.STATE, km.jd.GOALDIR)
+        km.jd.STATE = td
+        km.jd.GOALDIR = td / "goals"; km.jd.GOALDIR.mkdir(parents=True)
+        self.gid = SID + ":g1"
+        nodes = {self.gid: _node(self.gid),
+                 SID + ":s1": _node(SID + ":s1", parent=self.gid),
+                 SID + ":s2": _node(SID + ":s2", parent=self.gid)}
+        nodes[self.gid]["text"] = "fix the pusher burn"
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": nodes}))
+
+    def tearDown(self):
+        km.jd.STATE, km.jd.GOALDIR = self.saved_jd
+        self.td.cleanup()
+
+    def test_wake_body_survives_the_hierarchical_branch(self):
+        body = km._followup_body(self.gid, None, km.AWAITING_BACKSTOP_TEXT,
+                                 injected=True, auto=True, wake=True)
+        self.assertIn("Still open on this:", body, "the enumerated quote still rides along")
+        self.assertIn(km.AWAITING_BACKSTOP_TEXT, body, "the wake's own ask is never replaced")
+        self.assertNotIn("Where does each of those stand?", body)
+
+    def test_plain_nudge_keeps_the_status_ask(self):
+        body = km._followup_body(self.gid, None, km.AUTO_NUDGE_TEXT, injected=True, auto=True)
+        self.assertIn("Where does each of those stand?", body,
+                      "the regular nudge's hierarchical replacement is unchanged")
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_nudge_last_resort.py
+++ b/tests/test_kernel_nudge_last_resort.py
@@ -350,7 +350,7 @@ class StampEvidenceTime(unittest.TestCase):
     def test_the_stamp_passes_an_evidence_time_through(self):
         import inspect
         src = inspect.getsource(km._mark_nudge_failed)
-        self.assertIn("def _mark_nudge_failed(gid, ev_t=None):", src)
+        self.assertIn("def _mark_nudge_failed(gid, ev_t=None, wake=False):", src)
         self.assertIn("_ev = int(ev_t or now)", src)
         self.assertIn('jd.record_verdict(store, nd, "nudge", "block", _ev', src)
         self.assertIn('jd.append_block(sid, gid, "nudge", why, _ev)', src)

--- a/tests/test_nudge_block_prompts.py
+++ b/tests/test_nudge_block_prompts.py
@@ -88,6 +88,13 @@ class AutoNudgePrompt(unittest.TestCase):
         for robotic in ("goal", "romp", "automated", "tracking"):
             self.assertNotIn(robotic, t, robotic)
 
+    def test_wake_block_why_is_procedural(self):
+        # The awaiting wake's escalation (kernel _mark_nudge_failed wake=True) files jd.WAKE_BLOCK_WHY.
+        # It must be registered as PROCEDURAL, or the briefer invents a decision brief from <work> —
+        # the 2026-07-22 cross-session leak is what exact-match registration prevents.
+        self.assertTrue(jd.procedural_block_why(jd.WAKE_BLOCK_WHY))
+        self.assertTrue(jd.procedural_block_why(jd.NUDGE_BLOCK_WHY), "the siblings stay registered")
+
 
 class PlannerBlockRule(unittest.TestCase):
     def test_block_rule_covers_awaiting_go_ahead(self):


### PR DESCRIPTION
## The bug

A card stamped awaiting (⏳) could sleep **forever** in the Working column over a dead wait. Live case (2026-08-11): the `ui` session held three cards 14–20h behind a detached reinstaller pid that had long died — session idle, nothing in Needs-you. This broke the standing principle that anything stalled and needing the user must surface as blocked.

## Why it wedged (three compounding causes)

1. **The one-shot backstop was fire-and-forget.** It marked itself spent at *send* time, keyed on the stamp anchor (`awaitingAt`), and tracked no outcome. Its last wake's response turn died on `API Error: ENOTFOUND`; identical re-asserts coalesce by design (judge `apply_close`), so the anchor never moved, the once-per-anchor mark held forever, and no wake ever fired again.
2. **The stamp stood down the whole ladder categorically** — the nudge walk skipped stamped goals and `_mark_nudge_failed` returned `None` on any live stamp — so no other mechanism could ever move the card.
3. **`_followup_body` swallowed the wake's copy** on hierarchical goals, replacing "go check the background work" with the generic status ask — so the woken agent twice answered from memory that the wait was fine, without ever looking at the dead pid.

## The fix: one ladder, not two mechanisms

Awaiting-stamped goals become first-class citizens of the nudge walk (`_wake_goal`, the WAKE flavor):

- **Same ledger** (`nudged`), same `_nudge_response_ready` outcome gates, same `_mark_nudge_failed` escalation. `wake=True` means the stamp is the wake's *trigger*, never its *veto* — the no-answer evidence postdates the stamp by the whole backstop window. The battle-tested moot supersede guards apply unchanged: any real judge row filed after the wake stands the escalation down.
- **Episodes re-arm on the ANSWER, not the anchor.** A genuinely long wait is re-checked every 6h (each answered wake re-arms the next); a dead one surfaces in Needs-you after exactly one unanswered wake.
- **`_awaiting_wake_outcomes`** (the debt loop's proven sweep pattern) escalates wake records whose sessions the walk can't reach — an api-errored session is *exactly* the state a dead wake leaves behind.
- **Evidence-time discipline:** the silent escalation's block is anchored at the *fire* (a real transcript event), not the stale turn end — else the stamp's own filing time would moot the very escalation it triggered. Diary rows keep the standing rule (never wall-clock now).
- **The wake's copy survives** the hierarchical enumeration branch (`_followup_body(wake=True)`).

Deleted outright: `_awaiting_backstop_tick`, `_mark_awaiting_backstop`, and the `backstop` ledger (legacy entries in `auto-nudge.json` are ignored). `WAKE_BLOCK_WHY` joins the procedural block-why registry so the briefer writes no invented decision brief.

## Behavior preserved

- A **regular** nudge racing a fresh stamp still stands down (the nimbus false-interrupt rule) — the categorical shield narrows to `wake=False`, which is the race guard it really was.
- The stamp still exempts stamped goals from the plain status nudge; dormant CLIs are still never woken; the exact-event lift (`_lift_spent_awaiting`) now runs *before* the nudge tick so a wake never fires for a wait that already ended.
- First-fire nudge copy, bundling, deferral records, and the timeline's count-0 wake dot are unchanged.

## Tests

- `tests/test_kernel_awaiting_stamp.py`: the old `AwaitingBackstop` class (which pinned once-per-anchor and never-a-block — the two behaviors this PR deliberately replaces) is rewritten as `AwaitingWake` + `AwaitingWakeOutcomeSweep` + `WakeBodyKeepsItsCopy`, including a repro of the live wedge (silent wake → Needs-you block with `WAKE_BLOCK_WHY`) and a pin on the fire-time evidence rule.
- `tests/test_nudge_block_prompts.py`: `WAKE_BLOCK_WHY` registered as procedural.
- Full suites green: 4196 pytest + 1801 node + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)