### PR TITLE
kernel: the kernel drives the transient-api-error retry itself

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4473,6 +4473,102 @@ def _clear_retry_backoff(sid):
     _auto_retry_state.pop(sid, None)   # recovered: the next outage starts at the bottom rung again
 
 
+def _fire_api_retry(sid, be, manual=False):
+    """Inject a "retry" into an API-error-blocked session, behind every retry gate — the ONE retry
+    decision, shared by the apiRetry route (a client's ask: the dashboard's countdown tick or the manual
+    Retry-now button) and the kernel's own _auto_retry_tick (the unattended driver, 2026-08-11). Every
+    gate below was already kernel state; a client ask contributes nothing but the asking, so the kernel
+    asking itself is the same decision on the same state.
+
+    The GATE block is for the AUTO path only: a global pause or a thread the user interrupted must not
+    relapse into the storm. A MANUAL Retry-now is an explicit one-shot override — it ALWAYS fires so the
+    button is never a dead no-op on a suppressed/paused thread (the user 2026-07-06). It fires ONE retry
+    without clearing the suppression, so it doesn't re-arm the auto-loop the user turned off."""
+    if not manual and (_retry_paused_on() or _session_retry_suppressed(sid)):
+        return
+    # IDEMPOTENCY (the user 2026-07-08): don't stack a fresh auto-"retry" when the one romp already sent is
+    # still QUEUED and unconsumed — the session is blocked, so the previous retry hasn't run yet and another
+    # only piles up. Without this the auto-loop enqueued N bare "retry"s into the SDK queue during one
+    # API-error storm — the "retry retry retry retry…" card. A MANUAL "Retry now" still ALWAYS fires: it's an
+    # explicit user override (mirrors the pause/suppression gate above), and it resets the client countdown.
+    if not manual:
+        try:
+            if any(q == RETRY_MSG for q in be.pending_queued(sid)):
+                return
+        except Exception:
+            pass                                          # a backend without a live queue → fall through, send
+    # ONE RETRY PER ERROR EPISODE (the user 2026-07-20, the retry-storm root cause): the queued check
+    # above goes blind the moment a retry FORWARDS into the CLI — pending_queued empties while the
+    # session still reads blocked (the same mid-turn-forward seam as the echo-durability fixes) — and
+    # the client tick runs PER OPEN VIEW, so every connected client stacked another "retry" into the
+    # CLI's belly each cycle; a wedged session collected hundreds, delivered as one flood when its
+    # turn finally opened. Event-based fix: the CURRENT error record's uuid IS the episode. An
+    # auto-retry fires once per episode; the next fires only when a NEW error record lands (the
+    # attempt actually ran and failed again) or the error cleared (then there is nothing to retry —
+    # a stale ask into a recovered session sends nothing). A manual Retry-now always fires,
+    # and stamps the episode too, so the auto loop never stacks a second attempt behind the user's.
+    _rk = None
+    _rerr = None
+    try:
+        _rerr = _api_error(_path_of(sid) or "")
+        _rk = (_rerr.get("uuid") or _rerr.get("text") or "") if _rerr else None
+    except Exception:
+        pass                                              # unreadable state → manual still fires below
+    if _rk is None:
+        _clear_retry_backoff(sid)                         # recovered (or never blocked): reset the ladder
+    if not manual:
+        if _rk is None:
+            return                                        # not api-blocked right now → nothing to retry
+        # ON-YOU classes are never auto-retried (server-side twin of the client tick's skip, and the
+        # kernel driver's own guard): a retry cannot compact a too-long prompt, raise a spend cap, refill
+        # a model allowance, or mend a credential — the card names the real fix. Manual keeps firing:
+        # the button is only rendered where a retry can work, and an explicit click is the user's call.
+        if _rerr and (_rerr.get("tooLong") or _rerr.get("spendLimit")
+                      or _rerr.get("modelLimit") or _rerr.get("authErr")):
+            return
+        if _auto_retried.get(sid) == _rk:
+            return                                        # this episode already got its retry
+        if time.time() < _retry_gate_state(sid)[1]:
+            return                                        # backing off: this outage's next rung isn't due
+    if _rk is not None:
+        if len(_auto_retried) > 256:
+            _auto_retried.clear()
+        _auto_retried[sid] = _rk
+    # ALWAYS mark the retry romp-injected → GRAY romp bubble on BOTH backends (the user 2026-06-30): an
+    # auto-retry is romp's action, not the human's. Without the marker the SDK retry was authored 'human'
+    # (promptSource 'sdk' + sdk_human → blue bubble) AND the planner mis-read each bare "retry" as a user
+    # message, force-pinning a junk goal per retry via the never-skip hard guard ("retry — kept on the
+    # board…", 71 of them in one API-error storm). The marker makes author_of return 'romp' (ROMP_INJECT_RE)
+    # so the echo + transcript render gray and the planner skips a work-less retry instead of minting a goal.
+    be.send(sid, RETRY_MSG)
+    _note_retry_sent(sid, manual=manual)
+
+
+def _auto_retry_tick(now, tmux):
+    """KERNEL-side driver for the transient-api-error auto-retry (the user 2026-08-11). The ladder, the
+    episode gate and every suppression were already the kernel's — but the clock that ASKED lived in each
+    open dashboard (apiRetryTick, ui/webview/render.ts), so a session that died on a transient error with
+    no client open never retried at all: the ui session sat 7.5h on an overnight ENOTFOUND — invisible
+    (transient = Working + chip), unrecoverable, and, because the nudge walk skips api-errored sessions,
+    its awaiting wake could never fire either. The kernel asks for itself now, every pusher cycle; the
+    client tick stays as the countdown display and a redundant asker (harmless: the decision in
+    _fire_api_retry is idempotent against double-asking, and an older kernel still needs the client).
+    Dormant sessions are skipped — a dead CLI's api-error is settled history, and reviving a session is
+    the nudge machinery's call, not a retry's."""
+    for s in _alive_sessions(now, tmux):
+        sid = s["sid"]
+        try:
+            if tmux.get(sid) is None:
+                continue                                  # dormant CLI → nothing live to retry into
+            if not _api_error(s["path"]):
+                continue                                  # (mtime-cached) not api-blocked → nothing to do
+            be = Sessions.backend_for(sid)
+            if be is not None:
+                _fire_api_retry(sid, be)
+        except Exception:
+            sys.stderr.write("auto-retry (session %s): %s\n" % (sid or "?", traceback.format_exc()))
+
+
 def _predict_working(flavor, ids=None, sid=None):
     """Instant cross-view cue (the user 2026-07-20): a context-carrying reply just fired — a follow-up (feed
     composer or chat citation chip), a Move to Working, or a picker/permission answer — so tell every FEED
@@ -4791,61 +4887,10 @@ def _drive(msg, client):
             client["send"](json.dumps({"type": "warn", "text": derr}))
         _push_soon()
     elif t == "apiRetry":
-        # The GATE is for the AUTO-retry loop only (romp's 10s tick): a global pause or a thread the user
-        # interrupted must not relapse into the storm. But a MANUAL "Retry now" click (msg.manual) is an
-        # explicit one-shot override — it ALWAYS fires so the button is never a dead no-op on a suppressed/
-        # paused thread (the user 2026-07-06, who reported Retry now doing nothing on the SDK backend). It fires ONE retry
-        # without clearing the suppression, so it doesn't re-arm the auto-loop the user turned off.
-        if not msg.get("manual") and (_retry_paused_on() or _session_retry_suppressed(sid)):
-            return
-        # IDEMPOTENCY (the user 2026-07-08): don't stack a fresh auto-"retry" when the one romp already sent is
-        # still QUEUED and unconsumed — the session is blocked, so the previous retry hasn't run yet and another
-        # only piles up. Without this the 10s auto-loop enqueued N bare "retry"s into the SDK queue during one
-        # API-error storm — the "retry retry retry retry…" card. A MANUAL "Retry now" still ALWAYS fires: it's an
-        # explicit user override (mirrors the pause/suppression gate above), and it resets the client countdown.
-        if not msg.get("manual"):
-            try:
-                if any(q == RETRY_MSG for q in be.pending_queued(sid)):
-                    return
-            except Exception:
-                pass                                          # a backend without a live queue → fall through, send
-        # ONE RETRY PER ERROR EPISODE (the user 2026-07-20, the retry-storm root cause): the queued check
-        # above goes blind the moment a retry FORWARDS into the CLI — pending_queued empties while the
-        # session still reads blocked (the same mid-turn-forward seam as the echo-durability fixes) — and
-        # the 10s tick runs PER OPEN VIEW, so every connected client stacked another "retry" into the
-        # CLI's belly each cycle; a wedged session collected hundreds, delivered as one flood when its
-        # turn finally opened. Event-based fix: the CURRENT error record's uuid IS the episode. An
-        # auto-retry fires once per episode; the next fires only when a NEW error record lands (the
-        # attempt actually ran and failed again) or the error cleared (then there is nothing to retry —
-        # a stale client tick into a recovered session sends nothing). A manual Retry-now always fires,
-        # and stamps the episode too, so the auto loop never stacks a second attempt behind the user's.
-        _rk = None
-        try:
-            _rerr = _api_error(_path_of(sid) or "")
-            _rk = (_rerr.get("uuid") or _rerr.get("text") or "") if _rerr else None
-        except Exception:
-            pass                                              # unreadable state → manual still fires below
-        if _rk is None:
-            _clear_retry_backoff(sid)                         # recovered (or never blocked): reset the ladder
-        if not msg.get("manual"):
-            if _rk is None:
-                return                                        # not api-blocked right now → nothing to retry
-            if _auto_retried.get(sid) == _rk:
-                return                                        # this episode already got its retry
-            if time.time() < _retry_gate_state(sid)[1]:
-                return                                        # backing off: this outage's next rung isn't due
-        if _rk is not None:
-            if len(_auto_retried) > 256:
-                _auto_retried.clear()
-            _auto_retried[sid] = _rk
-        # ALWAYS mark the retry romp-injected → GRAY romp bubble on BOTH backends (the user 2026-06-30): an
-        # auto-retry is romp's action, not the human's. Without the marker the SDK retry was authored 'human'
-        # (promptSource 'sdk' + sdk_human → blue bubble) AND the planner mis-read each bare "retry" as a user
-        # message, force-pinning a junk goal per retry via the never-skip hard guard ("retry — kept on the
-        # board…", 71 of them in one API-error storm). The marker makes author_of return 'romp' (ROMP_INJECT_RE)
-        # so the echo + transcript render gray and the planner skips a work-less retry instead of minting a goal.
-        be.send(sid, RETRY_MSG)
-        _note_retry_sent(sid, manual=bool(msg.get("manual")))
+        # ONE retry decision, all of it kernel state — see _fire_api_retry (shared with the kernel's own
+        # _auto_retry_tick, which drives recovery unattended since 2026-08-11; this route remains for the
+        # manual Retry-now button and the dashboard tick's redundant asks, both idempotent against it).
+        _fire_api_retry(sid, be, manual=bool(msg.get("manual")))
     elif t == "setModel" and msg.get("value"):
         _set_model_or_park(be, sid, str(msg["value"])); _push_soon()   # mid-compaction → parked as a queued command
     elif t == "setEffort" and msg.get("value"):
@@ -17803,6 +17848,10 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _auto_resume_session_retry(now, tmux)
     except Exception:
         sys.stderr.write("auto-resume-session-retry: %s\n" % traceback.format_exc())
+    try:                                  # the kernel drives the transient-api-error retry itself (unattended;
+        _auto_retry_tick(now, tmux)       # the dashboard tick is just the countdown + a redundant asker)
+    except Exception:
+        sys.stderr.write("auto-retry-tick: %s\n" % traceback.format_exc())
     try:                                  # expire stale set_working notes once a session goes idle + done (cheap when no notes)
         _clear_done_working_notes(now, tmux)
     except Exception:

--- a/tests/test_api_retry_backoff.py
+++ b/tests/test_api_retry_backoff.py
@@ -93,23 +93,23 @@ class Ladder(unittest.TestCase):
 
 class Wiring(unittest.TestCase):
     def test_the_route_refuses_an_auto_retry_inside_the_backoff_window(self):
-        src = inspect.getsource(km._drive)
+        src = inspect.getsource(km._fire_api_retry)
         self.assertIn("if time.time() < _retry_gate_state(sid)[1]:", src)
-        self.assertIn("_note_retry_sent(sid, manual=bool(msg.get(\"manual\")))", src)
+        self.assertIn("_note_retry_sent(sid, manual=manual)", src)
         # …and the send happens BEFORE the stamp, so a refused send doesn't burn a rung
         self.assertLess(src.index("be.send(sid, RETRY_MSG)"), src.index("_note_retry_sent(sid"))
 
     def test_recovery_clears_the_ladder_on_the_next_tick(self):
-        src = inspect.getsource(km._drive)
+        src = inspect.getsource(km._fire_api_retry)
         self.assertIn("_clear_retry_backoff(sid)", src)
 
     def test_a_manual_retry_is_never_gated_by_the_backoff(self):
-        src = inspect.getsource(km._drive)
+        src = inspect.getsource(km._fire_api_retry)
         gate = src[src.index("if time.time() < _retry_gate_state(sid)[1]:")]
         self.assertTrue(gate)
-        # the whole gate block sits under `if not msg.get("manual")`
+        # the whole gate block sits under `if not manual:`
         head = src[:src.index("if time.time() < _retry_gate_state(sid)[1]:")]
-        self.assertIn('if not msg.get("manual"):', head.split("elif t ==")[-1])
+        self.assertIn('if not manual:', head)
 
     def test_the_status_payload_publishes_the_schedule(self):
         src = inspect.getsource(km.build_session)

--- a/tests/test_kernel_apiretry.py
+++ b/tests/test_kernel_apiretry.py
@@ -43,7 +43,10 @@ class ApiRetryRendersAsRomp(unittest.TestCase):
         # (blue bubble) and let the planner mint a junk goal per bare "retry". See
         # tests/test_kernel_retry_authorship.py for the authorship end-to-end.
         ap = SRC.split('t == "apiRetry"', 1)[1].split("elif t ==", 1)[0]
-        self.assertIn("be.send(sid, RETRY_MSG)", ap, "the handler sends the shared RETRY_MSG constant")
+        self.assertIn("_fire_api_retry(sid, be, manual=", ap,
+                      "the route delegates to the ONE shared retry decision")
+        fn = SRC.split("def _fire_api_retry(", 1)[1].split("\ndef ", 1)[0]
+        self.assertIn("be.send(sid, RETRY_MSG)", fn, "the shared decision sends the shared RETRY_MSG constant")
         # the constant itself carries the romp-injected marker → never a bare retry on either backend
         self.assertEqual(km.RETRY_MSG, RETRY, "RETRY_MSG is the marked retry text")
         self.assertIn("romp-injected", km.RETRY_MSG)
@@ -52,8 +55,8 @@ class ApiRetryRendersAsRomp(unittest.TestCase):
         # the gate (global pause / interrupted-thread suppression) stops the AUTO-retry loop only; a MANUAL
         # "Retry now" click (msg.manual) is an explicit one-shot override that ALWAYS fires, so the button is
         # never a dead no-op on a suppressed/paused thread (the user 2026-07-06, SDK backend)
-        ap = SRC.split('t == "apiRetry"', 1)[1].split("elif t ==", 1)[0]
-        self.assertIn('if not msg.get("manual") and (_retry_paused_on() or _session_retry_suppressed(sid)):', ap,
+        fn = SRC.split("def _fire_api_retry(", 1)[1].split("\ndef ", 1)[0]
+        self.assertIn('if not manual and (_retry_paused_on() or _session_retry_suppressed(sid)):', fn,
                       "the auto-retry gate is skipped for a manual click")
 
     def test_that_injected_retry_is_authored_romp_not_human(self):
@@ -126,6 +129,93 @@ class ApiRetryIdempotency(unittest.TestCase):
         be = FakeBackend(pending=[RETRY])
         self._drive_retry(be, manual=True)
         self.assertEqual(be.sent, [RETRY], "a manual retry is not deduped by the pending-queue guard")
+
+
+class KernelAutoRetryTick(unittest.TestCase):
+    """_auto_retry_tick (the user 2026-08-11): the KERNEL drives the transient-api-error retry itself.
+    Before it, the only clock was apiRetryTick in each open dashboard — a session that died on a transient
+    error with no client open never retried at all (the ui session sat 7.5h on an overnight ENOTFOUND,
+    invisible AND gating its awaiting wake, since the nudge walk skips api-errored sessions). Same
+    decision, same gates: the tick calls the shared _fire_api_retry."""
+
+    SID = "11111111-2222-3333-4444-888888888888"
+
+    def setUp(self):
+        self._saved = (km.Sessions, km._retry_paused_on, km._session_retry_suppressed,
+                       km._api_error, km._path_of, km._alive_sessions)
+        km._retry_paused_on = lambda: False
+        km._session_retry_suppressed = lambda sid: False
+        km._alive_sessions = lambda now, tmux: [{"sid": self.SID, "path": "/TESTDIR/x.jsonl"}]
+        km._path_of = lambda sid, now=None: "/TESTDIR/x.jsonl"
+        self.aerr = {"text": "Unable to connect to API (ENOTFOUND)", "status": None,
+                     "category": "network", "uuid": "ep-1",
+                     "tooLong": False, "spendLimit": False, "modelLimit": False, "authErr": False}
+        km._api_error = lambda path: self.aerr
+        self.be = FakeBackend(pending=[])
+        km.Sessions = types.SimpleNamespace(backend_for=lambda sid: self.be)
+        km._auto_retried.clear()
+        km._auto_retry_state.clear()
+
+    def tearDown(self):
+        (km.Sessions, km._retry_paused_on, km._session_retry_suppressed,
+         km._api_error, km._path_of, km._alive_sessions) = self._saved
+        km._auto_retried.clear()
+        km._auto_retry_state.clear()
+
+    def _tick(self, tmux=None):
+        km._auto_retry_tick(1_000_000, {self.SID: {"state": ""}} if tmux is None else tmux)
+
+    def test_fires_unattended_with_no_client(self):
+        # THE live wedge: a transient-errored idle session, zero clients. The kernel now asks for itself.
+        self._tick()
+        self.assertEqual(self.be.sent, [RETRY], "the kernel retries a transient error with no client open")
+        self.assertEqual(km._auto_retried.get(self.SID), "ep-1", "the episode is stamped")
+        self.assertGreater(km._retry_gate_state(self.SID)[1], 0, "the backoff ladder steps")
+
+    def test_once_per_error_episode(self):
+        self._tick(); self._tick()
+        self.assertEqual(self.be.sent, [RETRY], "the same error record never collects a second retry")
+
+    def test_a_new_episode_retries_after_the_backoff(self):
+        self._tick()
+        self.aerr = dict(self.aerr, uuid="ep-2")     # the attempt ran and failed again → a new error record
+        km._auto_retry_state[self.SID]["next"] = 0   # …and its backoff rung has come due
+        self._tick()
+        self.assertEqual(self.be.sent, [RETRY, RETRY], "a fresh episode past its rung retries again")
+
+    def test_on_you_classes_are_never_auto_retried(self):
+        # a retry cannot compact a prompt, raise a cap, refill an allowance, or mend a credential — the
+        # kernel driver must carry the skip the client tick used to provide (server-side twin)
+        for k in ("tooLong", "spendLimit", "modelLimit", "authErr"):
+            with self.subTest(cls=k):
+                self.be.sent.clear()
+                km._auto_retried.clear(); km._auto_retry_state.clear()
+                self.aerr = dict(self.aerr, **{k: True})
+                self._tick()
+                self.assertEqual(self.be.sent, [], "%s is on-you; auto-retry stands down" % k)
+                self.aerr = dict(self.aerr, **{k: False})
+        # …while a MANUAL Retry-now through the shared decision still fires (explicit user override)
+        self.aerr = dict(self.aerr, tooLong=True)
+        km._fire_api_retry(self.SID, self.be, manual=True)
+        self.assertEqual(self.be.sent, [RETRY])
+
+    def test_dormant_sessions_are_skipped(self):
+        self._tick(tmux={})                          # SID not in the live set → no live CLI
+        self.assertEqual(self.be.sent, [], "a dead CLI's api-error is settled history, not retried into")
+
+    def test_global_pause_stands(self):
+        km._retry_paused_on = lambda: True
+        self._tick()
+        self.assertEqual(self.be.sent, [], "the tick rides the same global pause as every auto path")
+
+    def test_recovered_session_is_left_alone(self):
+        km._api_error = lambda path: None
+        self._tick()
+        self.assertEqual(self.be.sent, [], "no api error → nothing to retry")
+
+    def test_the_pusher_cycle_runs_the_tick(self):
+        self.assertIn("_auto_retry_tick(now, tmux)", SRC,
+                      "the pusher cycle drives retries server-side — unattended recovery")
 
 
 if __name__ == "__main__":

--- a/tests/test_session_retry_suppress.py
+++ b/tests/test_session_retry_suppress.py
@@ -108,9 +108,9 @@ class SessionRetrySuppressWiring(unittest.TestCase):
                       "interrupting a thread arms its per-session retry-suppression")
 
     def test_apiretry_gate_checks_per_session_suppression(self):
-        ap = SRC.split('t == "apiRetry"', 1)[1].split("elif t ==", 1)[0]
-        self.assertIn("_session_retry_suppressed(sid)", ap,
-                      "the apiRetry drive-op skips a thread the user interrupted, not just the global pause")
+        fn = SRC.split("def _fire_api_retry(", 1)[1].split("\ndef ", 1)[0]
+        self.assertIn("_session_retry_suppressed(sid)", fn,
+                      "the retry decision skips a thread the user interrupted, not just the global pause")
 
     def test_status_carries_the_flag(self):
         self.assertIn('"retrySuppressed": _session_retry_suppressed(sid)', SRC,


### PR DESCRIPTION
## The bug (found while shipping #279)

Every retry gate — the backoff ladder, the one-per-error-episode key, the global pause, per-session suppression, queued-idempotency — was already kernel state. But the clock that *asked* lived in each open dashboard: `apiRetryTick()` in `ui/webview/render.ts` posts the `apiRetry` route once a second. **No client open → no retry, ever.** The `ui` session sat 7.5h on an overnight `ENOTFOUND`: invisible (a transient error keeps the card in Working with a chip), unrecoverable, and — because the nudge walk skips api-errored sessions — its awaiting wake (#279) could never fire either. A dead transient error re-created the sleeping-card wedge by another door.

## The fix: the kernel is the driver, the client is a viewer

- The `apiRetry` route body moves **verbatim** into `_fire_api_retry(sid, be, manual)` — one retry decision. The route now just delegates (manual Retry-now + the dashboard's redundant asks, both idempotent against the shared gates).
- New `_auto_retry_tick` in the pusher cycle asks unattended for every live, api-blocked session (`_api_error` is mtime-cached, so the pre-filter is cheap). It joins auto-nudge, the debt loop, the awaiting-wake sweep, and the auto-resume jobs — the kernel now owns *every* unattended recovery loop.
- The auto path gains the **on-you-class guard** (`tooLong`/`spendLimit`/`modelLimit`/`authErr`) that previously existed only as the client tick's skip — required once the kernel asks for everyone, and defense-in-depth for client asks. Manual keeps firing as the explicit override (the button is only rendered where a retry can work).
- Dormant CLIs are skipped: a dead CLI's api-error is settled history, and reviving a session is the nudge machinery's call.

No webview changes: the client tick stays as the countdown display and a redundant asker (harmless — the decision is idempotent — and an older kernel still needs it).

## Tests

- Source-pins in `test_kernel_apiretry.py` / `test_api_retry_backoff.py` / `test_session_retry_suppress.py` re-pointed at the new seam (same invariants: RETRY_MSG constant, manual bypasses, send-before-stamp order, ladder reset on recovery).
- New `KernelAutoRetryTick`: fires unattended with no client (the live wedge), once per episode, new episode past its rung retries, on-you classes never auto-retried (manual still fires), dormant skipped, global pause stands, recovered session untouched, pusher-cycle wiring pinned.
- Full suites green: 4204 pytest + 1811 node + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)