### PR TITLE
The dir field keeps ONE suggestion box: the stale recent-dirs datalist is gone

### DIFF
--- a/ui/webview/picker-dir.test.ts
+++ b/ui/webview/picker-dir.test.ts
@@ -1,7 +1,8 @@
 // The new-session DIRECTORY field + per-session dir display (the user 2026-06-22). A session's working
-// directory is fixed at creation, so the picker lets you choose it (prefilled from the gear default, recent
-// dirs autocompleting), and every session shows its dir — dimmed basename on the lane tab (full path on
-// hover) and in the system-context card's collapsed summary. Source-level pins (no jsdom for the renderer).
+// directory is fixed at creation, so the picker lets you choose it (prefilled from the gear default, the
+// kernel-fed completer offering real folders), and every session shows its dir — dimmed basename on the
+// lane tab (full path on hover) and in the system-context card's collapsed summary. Source-level pins
+// (no jsdom for the renderer).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -11,12 +12,19 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 const SETTINGS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "settings.ts"), "utf8");
 
-test("the picker has a directory field with a recent-dirs datalist", () => {
+test("the picker has a directory field — with ONE suggestion surface, the kernel-fed completer", () => {
   assert.match(RENDER, /el\("input", "picker-dir-input"\)/);
-  assert.match(RENDER, /dirInput\.setAttribute\("list", "picker-dir-list"\)/);
-  assert.match(RENDER, /createElement\("datalist"\); dirList\.id = "picker-dir-list"/);
   // appended into the picker box
   assert.match(RENDER, /box\.appendChild\(dirWrap\);/);
+  // The recent-dirs datalist is GONE, not merely hidden (the user 2026-08-11): it was superseded by the
+  // completer (2026-07-28) but stayed wired, and autocomplete="off" does not suppress a list-attribute
+  // dropdown in Chromium — so TWO boxes popped over the field, the native one offering session-history
+  // dirs that no longer exist on disk (a recorded dir outlives a rename). The completer asks the OWNING
+  // kernel (dirComplete), the authoritative source for what a path IS.
+  assert.doesNotMatch(RENDER, /picker-dir-list/);
+  assert.doesNotMatch(RENDER, /createElement\("datalist"\)/);
+  assert.match(RENDER, /dirInput\.setAttribute\("autocomplete", "off"\)/,
+    "…and the browser's own form-history dropdown stays off the field too");
 });
 
 test("createSession carries the chosen dir, alongside name + backend", () => {
@@ -32,10 +40,10 @@ test("the dir field is prefilled with the gear default and hidden in pick-mode",
   assert.match(RENDER, /dirWrap\.style\.display = pick \? "none" : ""/);
 });
 
-test("renderPicker populates the datalist from items' dirs (unique, non-empty)", () => {
-  assert.match(RENDER, /getElementById\("picker-dir-list"\)/);
-  assert.match(RENDER, /const d = \(it\.dir \|\| ""\)\.trim\(\);/);
-  assert.match(RENDER, /seen\.has\(d\)/);
+test("renderPicker no longer refills a recent-dirs list — the completer owns suggestions", () => {
+  assert.doesNotMatch(RENDER, /Recent dirs → the new-session field's autocomplete/);
+  assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "dirComplete", value, reqId: \+\+dirReq, host: dirAskedHost \}\)/,
+    "the live kernel-fed completer is the one suggestion path");
 });
 
 test("a session carries cwd, shown on the statusline just left of the mode/model/effort controls", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4634,17 +4634,21 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       if (row) setActiveRow(row as HTMLElement);
     });
     // Directory for a NEW session — fixed once the session starts, so it's chosen here. Prefilled with the
-    // gear's "Default directory" on open; recent dirs autocomplete from the datalist; the kernel expands
-    // ~ / $VARs and validates it exists. Hidden in pick-mode (choosing an existing session).
+    // gear's "Default directory" on open; the kernel-fed completer below offers real folders as you type
+    // and the kernel expands ~ / $VARs and validates it exists. Hidden in pick-mode (choosing an existing
+    // session). ONE suggestion surface, deliberately: this field once ALSO carried a native datalist of
+    // every listed session's recorded dir, superseded by the completer (2026-07-28) but left wired — and
+    // autocomplete="off" does NOT suppress a list-attribute dropdown in Chromium, so TWO boxes popped over
+    // the field, the native one offering dirs that no longer exist (a session's dir outlives a rename; the
+    // user 2026-08-11, offered a long-gone folder next to the real one). The completer asks the OWNING
+    // kernel — the authoritative source — so the stale-capable history list is gone, not merely hidden.
     const dirWrap = el("div", "picker-dir");
     const dirInput = el("input", "picker-dir-input") as HTMLInputElement;
     dirInput.id = "picker-dir";
     dirInput.spellcheck = false;
     dirInput.placeholder = "New-session directory (blank = default)";
     dirInput.title = "Working directory for a NEW session — fixed once it starts. Blank uses the kernel's default. ~ and $VARs expand; type to complete folders (Tab walks into one), on this machine or the selected host.";
-    dirInput.setAttribute("list", "picker-dir-list");
-    dirInput.setAttribute("autocomplete", "off");   // the browser's own dropdown would fight the completer
-    const dirList = document.createElement("datalist"); dirList.id = "picker-dir-list";
+    dirInput.setAttribute("autocomplete", "off");   // belt: no browser dropdown of past form values either
     const browseBtn = el("button", "picker-browse") as HTMLButtonElement;
     browseBtn.type = "button"; browseBtn.textContent = "Browse…";
     browseBtn.title = "Pick a folder with the native dialog (opens on the kernel's machine — host-local)";
@@ -4655,7 +4659,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     dirInput.addEventListener("input", () => askDirComplete(dirInput.value));
     dirInput.addEventListener("focus", () => askDirComplete(dirInput.value));
     dirInput.addEventListener("blur", () => closeDirMenu());   // a row's mousedown preventDefaults, so it never blurs
-    dirWrap.appendChild(dirInput); dirWrap.appendChild(dirList); dirWrap.appendChild(browseBtn);
+    dirWrap.appendChild(dirInput); dirWrap.appendChild(browseBtn);
     dirWrap.appendChild(dirMenu); dirWrap.appendChild(dirStat);
     // per-session BACKEND picker (the user 2026-06-23): a tmux | SDK segmented toggle, defaulting to the
     // gear's Default backend but overridable for THIS new session. Hidden in pick-mode (like dirWrap).
@@ -5187,16 +5191,8 @@ function renderPicker(items: any[]) {
     });
     list.appendChild(row);
   }
-  // Recent dirs → the new-session field's autocomplete (unique, non-empty, in list order).
-  const dl = document.getElementById("picker-dir-list");
-  if (dl) {
-    dl.replaceChildren();
-    const seen = new Set<string>();
-    for (const it of items) {
-      const d = (it.dir || "").trim();
-      if (d && !seen.has(d)) { seen.add(d); const o = document.createElement("option"); o.value = d; dl.appendChild(o); }
-    }
-  }
+  // (The recent-dirs datalist that was refilled here is gone — the kernel-fed completer is the ONE
+  // suggestion surface for the dir field; see the field's construction for the two-boxes story.)
   // Prefill the dir field with the kernel's real default path once it arrives (only if untouched + no gear
   // default) — so the actual default is written in there as an editable starting point (the user 2026-06-23).
   const di = document.getElementById("picker-dir") as HTMLInputElement | null;


### PR DESCRIPTION
Typing in the new-session directory field popped **two** suggestion dropdowns over each other (the user 2026-08-11): the kernel-fed completer offering real folders, and a native `datalist` of every listed session's *recorded* dir. The datalist was the field's original autocomplete, superseded by the completer (2026-07-28) but left wired — `autocomplete="off"` was set with a comment saying the browser dropdown "would fight the completer", but that attribute does not suppress a `list`-attribute dropdown in Chromium, so the fight happened anyway. Worse, its suggestions were session history, not the filesystem: a recorded dir outlives a rename, so it offered a folder that no longer exists right next to the real one.

The datalist, its `list` attribute, and its per-render refill are removed, not hidden. The completer asks the owning kernel (`dirComplete`) — the authoritative source for what a path is, on this machine or the selected host. Source pins updated: the field asserts one suggestion surface and the absence of any datalist.

Suites: 4204 Python + 1811 node, green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)