### PR TITLE
No more hidden running sessions: every alive session is a visible tab, × ends it

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1354,21 +1354,11 @@ def _ordered_alive(now, tmux):
     return _ordered(_alive_sessions(now, tmux))
 
 
-def _hidden_tabs():
-    """SIDs the user closed (×) from the chat tab strip — hidden from the tabs but NOT killed: the
-    session keeps running, and clicking it in the feed/timeline (openSession) reopens the tab. A view
-    preference, deliberately not a session kill."""
-    try:
-        a = json.loads((jd.STATE / "hidden-tabs.json").read_text())
-        return set(x for x in a if isinstance(x, str)) if isinstance(a, list) else set()
-    except Exception:
-        return set()
-
-
-def _set_hidden_tab(sid, hidden):
-    cur = _hidden_tabs()
-    cur.add(sid) if hidden else cur.discard(sid)
-    _atomic_write(jd.STATE / "hidden-tabs.json", json.dumps(sorted(cur)))
+# (Hidden tabs are GONE — the user 2026-08-11. ×-closing used to write the sid to hidden-tabs.json and
+# leave the session running with no chat tab and no Fleet-pane section while it kept being judged,
+# carded and billed: a secret running session, a tmux-era affordance (sessions lived outside romp) with
+# no SDK-era use case. Every running session now always shows; × means End session, and close-and-reopen
+# is End + Revive, which keeps history. A stale hidden-tabs.json on disk is inert, like web-kernel.json.)
 
 
 # ── per-session view flags (the user 2026-06-19) ──────────────────────────────────────────────────
@@ -3757,11 +3747,11 @@ def _clear_done_working_notes(now, tmux):
 
 
 def _chat_tab_sessions(now, tmux):
-    """The sessions shown as CHAT TABS, in the shared session order: living sessions PLUS only the dead
-    sessions the user explicitly opened READ-ONLY (_kept_open). A dead session is otherwise TIMELINE-ONLY
-    — it does NOT auto-keep a tab when it dies (the user 2026-06-17 reversed the old 'keep a tab when it
-    dies'); reopen it from the timeline instead. ×-hidden tabs are excluded."""
-    hidden = _hidden_tabs()
+    """The sessions shown as CHAT TABS, in the shared session order: EVERY living session PLUS only the
+    dead sessions the user explicitly opened READ-ONLY (_kept_open). A dead session is otherwise
+    TIMELINE-ONLY — it does NOT auto-keep a tab when it dies (the user 2026-06-17 reversed the old 'keep
+    a tab when it dies'); reopen it from the timeline instead. There is no hidden/open tab subset (the
+    user 2026-08-11): alive = visible, and × ends the session."""
     live = _alive_sessions(now, tmux)
     live_sids = {s["sid"] for s in live}
     all_sessions = _sessions(now)
@@ -3772,7 +3762,7 @@ def _chat_tab_sessions(now, tmux):
     # — the reorder this fix prevents (the user 2026-06-29). Order is purely the persisted session-order.json
     # (see _ordered) — no activity reshuffle; a dying tab keeps its slot. live + dead_kept resolve through the
     # SAME index map _timeline_sessions uses, so chat tabs and timeline lanes stay in lockstep.
-    result = _ordered([s for s in live + dead_kept if s["sid"] not in hidden])
+    result = _ordered(live + dead_kept)
     # Prune sids that are GONE — not alive AND no transcript left in the discover window — so
     # session-order.json stays bounded and a closed / aged-out session drops out on its own (the user
     # 2026-06-24). A session merely dead-but-in-window (or explicitly kept-open) stays known and keeps its slot.
@@ -3796,12 +3786,10 @@ def _timeline_sessions(now, tmux, live_only=False):
     fleet comes up at once without reading any dead session; the producer then adds the dead-within-12h lanes
     on its next pass (the user 2026-06-26, who wanted the main UI up with the live sessions first, dead in background).
 
-    The timeline is a COMPLETE activity history, so ×-hiding a tab does NOT drop its lane (the user
-    2026-06-17 reversed the earlier rule that X-ing a tab in the chat also dropped the timeline lane): closing a tab is a
-    tab-strip view preference and must never erase the session from the timeline. A now-dead session that
-    was active during the visible span appears on scrollback regardless of tab/hidden state — the active
-    filter alone gates it. So `_hidden_tabs()` is deliberately NOT consulted here (it still gates the
-    chat tab strip in _chat_tab_sessions)."""
+    The timeline is a COMPLETE activity history: a session that ended must never be erased from it (the
+    user 2026-06-17 reversed the earlier rule that ×-ing a chat tab also dropped the timeline lane). A
+    now-dead session that was active during the visible span appears on scrollback regardless of tab
+    state — the active filter alone gates it."""
     live = _alive_sessions(now, tmux)
     if live_only:
         return _ordered(live)                          # cold-start first paint: live sessions only, no dead reads
@@ -4080,7 +4068,6 @@ def _end_pending_sid(sid):
             sys.stderr.write("kill: %s via cancelCreate (Opening-cue teardown)\n" % sid)
         except Exception:
             sys.stderr.write("cancelCreate kill '%s': %s\n" % (sid, traceback.format_exc()))
-    _set_hidden_tab(sid, True)
     _send_to_app("chat", {"type": "closed", "id": sid})
     _push_soon()
 
@@ -4163,7 +4150,6 @@ def _create_sdk_session(nm, cwd, auth=""):
     bg, fg = _pick_identity_color()   # fleet-aware: only the kernel sees BOTH backends' live sessions
     sid = _sdk().spawn(nm, cwd, bg, fg, auth=auth)
     _sdk().connect(sid)    # eager-connect so the model lists immediately, not only after the 1st message
-    _set_hidden_tab(sid, False)
     _reveal_chat({"type": "focus", "id": sid})
     _mark_views_dirty()
     _push_session_now(sid)   # the tab the user is staring at, ahead of the woken cycle
@@ -5113,12 +5099,11 @@ def _split_host_id(sid):
 
 
 def _open_or_revive(sid, live=False):
-    """openSession routing: a LIVE session → un-hide its tab + focus the chat; a DEAD one → the
+    """openSession routing: a LIVE session → focus the chat (its tab is always shown); a DEAD one → the
     confirmRevive modal (no silent reopen, no auto read-only tab — the user 2026-06-17). `live` (the user
     2026-07-08): land the chat on its LIVE TAIL, not the last scroll — a blocked card's picker/permission
     prompt is the live bottom, so its feed chip drops you right on it."""
     if sid in _tmux_sessions():
-        _set_hidden_tab(sid, False)
         be = _sdk()
         if be:
             be.connect(sid)   # SDK: eager-connect on OPEN (idempotent; no-op for tmux/unknown sids) so the
@@ -5168,7 +5153,6 @@ def _revive_session(sid):
                               "text": detail or "unknown error"})
         return
     _kept_open.discard(sid)       # it's live again → no longer a read-only kept tab
-    _set_hidden_tab(sid, False)   # it was hidden when closed; show the revived tab
     _push_all()                   # surface it promptly (the 4s pusher would catch it anyway)
     _reveal_chat({"type": "focus", "id": sid})
 
@@ -18102,8 +18086,8 @@ if(s.working){var wd=document.createElement('span');wd.className='workdot';row.a
 else if(s.awaitbg){var wd=document.createElement('span');wd.className='workdot await';row.appendChild(wd);}
 var lbl=document.createElement('span');lbl.className='nm';fillName(lbl,s);if(s.bg)lbl.style.color=s.bg;
 row.appendChild(lbl);
-// End-session x: clicks the hidden desktop tab's own .tab-close, reusing its confirm dialog (Close tab /
-// End session / Cancel) + endSession/closeTab plumbing — the mobile picker's only way to end a session
+// End-session x: clicks the hidden desktop tab's own .tab-close, reusing its confirm dialog (End session /
+// Cancel) + endSession plumbing — the mobile picker's only way to end a session
 // (the user 2026-07-22). stopPropagation so it doesn't also switch to the session.
 var x=document.createElement('span');x.className='mclose';x.textContent='×';x.title='End session';
 x.addEventListener('click',function(e){e.stopPropagation();hide();var rt=realTab(s.id);var c=rt&&rt.querySelector('.tab-close');if(c)c.click();});
@@ -21857,8 +21841,7 @@ class Handler(BaseHTTPRequestHandler):
                                                    "dir": str(msg.get("dir") or ""), "status": st}))
                     else:
                         client["send"](json.dumps({"type": "warn", "text": derr}))
-                elif nm in live:                 # already running → just (re)open it, don't re-spawn
-                    _set_hidden_tab(live[nm], False)
+                elif nm in live:                 # already running → its tab is already up; just focus it
                     _reveal_chat_for(client, {"type": "focus", "id": live[nm]})
                     _mark_views_dirty()          # pusher ships the tab; never a synchronous fleet build here
                 elif msg.get("backend") == "sdk":   # non-tmux: drive via the Agent SDK
@@ -21904,24 +21887,23 @@ class Handler(BaseHTTPRequestHandler):
         elif msg and msg.get("type") in ("pickResult", "openByName") and (msg.get("id") or msg.get("name")):
             sid = msg.get("id") or _live_names(_tmux_sessions()).get(str(msg.get("name")))
             if sid:
-                _set_hidden_tab(sid, False); _push_all()
                 _reveal_chat_for(client, {"type": "focus", "id": sid})
-        elif msg and msg.get("type") == "openAll":
-            for s in _alive_sessions(int(time.time()), _tmux_sessions()):
-                _set_hidden_tab(s["sid"], False)
-            _push_all()
         elif msg and msg.get("type") == "closeSession" and msg.get("id"):
-            # × → ask (Close tab vs End session) instead of hiding straightaway (the user 2026-06-15)
+            # × → confirm End session (the user 2026-08-11: no more Close-tab/hide — a running session is
+            # always visible; close-and-reopen is End + Revive, which keeps history)
             client["send"](json.dumps({"type": "confirmClose", "id": msg["id"],
                                        "name": _name_of(msg["id"]) or msg["id"]}))
         elif msg and msg.get("type") == "closeTab" and msg.get("id"):
-            _set_hidden_tab(msg["id"], True)     # hide the tab; session keeps running
-            _kept_open.discard(msg["id"])        # ×-closing a read-only dead tab forgets it (timeline-only again)
-            _send_to_app("chat", {"type": "closed", "id": msg["id"]})   # prune it in the live view now
+            # Only a DEAD read-only tab has anything to close now (the user 2026-08-11): forget it
+            # (timeline-only again). For a live sid this is a stale client's hide ask — ignored; ending
+            # a live session is endSession's job. The `closed` frame still prunes the client promptly
+            # (and covers the endSession companion post, so an ended session never lingers as a tab).
+            _kept_open.discard(msg["id"])
+            _send_to_app("chat", {"type": "closed", "id": msg["id"]})
             _push_all()
         elif msg and msg.get("type") == "openSession" and msg.get("id"):
-            # live → reopen the hidden tab + focus; dead → the chat's confirmRevive modal. `live` lands on the
-            # chat's LIVE TAIL (a blocked card's picker chip → right on the prompt, the user 2026-07-08).
+            # live → focus its (always-shown) tab; dead → the chat's confirmRevive modal. `live` lands on
+            # the chat's LIVE TAIL (a blocked card's picker chip → right on the prompt, the user 2026-07-08).
             _open_or_revive(msg["id"], live=bool(msg.get("live")))
         elif msg and msg.get("type") == "openFolder" and msg.get("cwd"):
             # A REMOTE session's folder icon must SSH out, not open a local path that doesn't exist here
@@ -21939,7 +21921,7 @@ class Handler(BaseHTTPRequestHandler):
             threading.Thread(target=_revive_session, args=(msg["id"],), daemon=True).start()
         elif msg and msg.get("type") == "viewReadOnly" and msg.get("id"):
             _kept_open.add(msg["id"])            # confirmRevive → "View read-only": this dead session
-            _set_hidden_tab(msg["id"], False)    # gets a (struck) read-only tab now, without resuming it
+            #                                      gets a (struck) read-only tab now, without resuming it
             _push_all()
             _reveal_chat_for(client, {"type": "focus", "id": msg["id"]})
         elif msg and msg.get("type") == "deepLink" and msg.get("session"):

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4087,17 +4087,19 @@ class ViewBuilder(unittest.TestCase):
         finally:
             km._seen_live.clear(); km._seen_live.update(saved_seen); km._has_tmux = saved_has
 
-    def test_dead_kept_tab_excluded_once_hidden(self):
-        # ×-closing a dead-kept tab dismisses it for good.
-        saved_seen, saved_has = set(km._seen_live), km._has_tmux
+    def test_dead_kept_tab_excluded_once_forgotten(self):
+        # ×-closing a dead read-only tab discards it from _kept_open — dead is timeline-only again
+        # (the closeTab route's one remaining duty; hidden-tabs is gone, the user 2026-08-11).
+        saved_seen, saved_has, saved_kept = set(km._seen_live), km._has_tmux, set(km._kept_open)
         km._has_tmux = lambda: True
         try:
             km._seen_live.clear(); km._seen_live.add(SID)
-            km._set_hidden_tab(SID, True)
+            km._kept_open.discard(SID)
             tabs = [s["sid"] for s in km._chat_tab_sessions(NOW, {})]
-            self.assertNotIn(SID, tabs, "a ×-hidden dead tab is not shown")
+            self.assertNotIn(SID, tabs, "a forgotten dead tab is not shown")
         finally:
             km._seen_live.clear(); km._seen_live.update(saved_seen); km._has_tmux = saved_has
+            km._kept_open.clear(); km._kept_open.update(saved_kept)
 
     def test_rel_ago_buckets(self):
         self.assertEqual(km._rel_ago(1000, 1000), "just now")
@@ -5014,13 +5016,12 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(km.build_session(SID, NOW)["status"]["state"], "ready",
                          "ended turn -> ready even when tmux says working")
 
-    def test_close_session_hides_tab(self):
-        # the × hides the tab (reversible), does not kill the session
-        self.assertEqual(km._hidden_tabs(), set())
-        km._set_hidden_tab(SID, True)
-        self.assertIn(SID, km._hidden_tabs())
-        km._set_hidden_tab(SID, False)
-        self.assertNotIn(SID, km._hidden_tabs())
+    def test_no_hidden_tab_state_exists(self):
+        # hidden tabs are GONE (the user 2026-08-11): a running session is always visible — × means End
+        # session. The old _set_hidden_tab/_hidden_tabs pair must stay deleted, or a secret running
+        # session (no tab, no Fleet row, still judged and billed) comes back.
+        self.assertFalse(hasattr(km, "_hidden_tabs"))
+        self.assertFalse(hasattr(km, "_set_hidden_tab"))
 
     def test_open_dead_session_prompts_revive(self):
         # opening a DEAD session pops the chat's confirmRevive modal — no silent reopen — and now from
@@ -5048,14 +5049,13 @@ class ViewBuilder(unittest.TestCase):
         finally:
             km._reveal_chat_for = orig_rc; km._tmux_sessions = orig_tx; km._push_all = orig_pa
 
-    def test_revive_session_resumes_and_unhides_tab(self):
-        # confirming the modal's "Revive" must actually resume the session AND un-hide its tab. The
-        # kernel owns the resume now (`romp <name> --resume <sid> --detach`): the old
-        # `romp-postal-service revive` subcommand was REMOVED in 2b5e181 but _revive_session kept
-        # shelling it — the CLI exits 0 on unknown commands with output DEVNULL'd, so the picker's
-        # Revive silently did nothing (the user 2026-07-05). Full coverage: tests/test_kernel_revive.py.
+    def test_revive_session_resumes(self):
+        # confirming the modal's "Revive" must actually resume the session. The kernel owns the resume
+        # now (`romp <name> --resume <sid> --detach`): the old `romp-postal-service revive` subcommand
+        # was REMOVED in 2b5e181 but _revive_session kept shelling it — the CLI exits 0 on unknown
+        # commands with output DEVNULL'd, so the picker's Revive silently did nothing (the user
+        # 2026-07-05). Full coverage: tests/test_kernel_revive.py.
         import subprocess as _sp
-        km._set_hidden_tab("deadsid000", True)            # it was hidden when closed
         calls, saved = [], km.subprocess.run
         km.subprocess.run = (lambda *a, **k:
                              calls.append(list(a[0])) or _sp.CompletedProcess(a[0], 0, "", ""))
@@ -5069,7 +5069,6 @@ class ViewBuilder(unittest.TestCase):
                         "the kernel owns the resume (bin/romp), never the removed postal subcommand")
         # --name pins the recorded name; this fixture has none, so _name_of falls back to the sid
         self.assertEqual(argv[1:], ["resume", "deadsid000", "--name", "deadsid000", "--detach"])
-        self.assertNotIn("deadsid000", km._hidden_tabs(), "the revived tab is un-hidden")
 
     def test_split_reminders(self):
         p, r = km._split_reminders("do the thing <system-reminder>be careful</system-reminder> now")
@@ -5804,22 +5803,13 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(rows["fresh"]["model"], "Opus", "two live versions → a bare label stays bare")
         self.assertEqual(rows["s"]["model"], "Sonnet 5", "one live version → still borrows")
 
-    def test_timeline_lane_survives_hidden_tab(self):
-        # the user 2026-06-17 (reversing d52f69f): ×-hiding a tab is a tab-strip preference and must NOT
-        # erase the lane from the timeline — the timeline is a complete activity history. So a dead AND
-        # ×-hidden session still appears on the timeline (the render's active-filter alone gates it by
-        # window overlap); only the chat tab strip honors the hidden set.
-        km._set_hidden_tab(SID, True)
-        try:
-            self.assertIn(SID, km._hidden_tabs(), "SID is ×-hidden from the tab strip")
-            s = {x["id"]: x for x in km.build_timeline(NOW, tmux={})["sessions"]}
-            self.assertIn(SID, s, "a ×-hidden dead session is STILL a timeline lane")
-            self.assertFalse(s[SID]["live"], "and it's a dead (struck) lane")
-            # the tab strip still hides it (the hidden set is the tab-strip's, not the timeline's)
-            self.assertNotIn(SID, {x["sid"] for x in km._chat_tab_sessions(NOW, {})},
-                             "the tab strip still honors the hidden set")
-        finally:
-            km._set_hidden_tab(SID, False)
+    def test_timeline_keeps_dead_lanes(self):
+        # the timeline is a complete activity history (the user 2026-06-17): a dead session within the
+        # lane window is still a struck lane, with no tab needed. (The ×-hidden variant of this pin died
+        # with hidden tabs, the user 2026-08-11 — there is no tab state that could erase a lane anymore.)
+        s = {x["id"]: x for x in km.build_timeline(NOW, tmux={})["sessions"]}
+        self.assertIn(SID, s, "a dead session in-window is STILL a timeline lane")
+        self.assertFalse(s[SID]["live"], "and it's a dead (struck) lane")
 
     def test_dead_session_is_timeline_only_until_viewed(self):
         # the user 2026-06-17: a dead session is TIMELINE-ONLY — no auto chat tab. It gets a read-only
@@ -6884,11 +6874,11 @@ class SessionOrderStable(unittest.TestCase):
     pulled into a separate mtime-sorted block, so a session jumped slots the moment it died."""
     def setUp(self):
         self._saved = (km._ordered_alive, km._alive_sessions, km._sessions, km._session_order,
-                       set(km._kept_open), km._hidden_tabs)
+                       set(km._kept_open))
 
     def tearDown(self):
         (km._ordered_alive, km._alive_sessions, km._sessions, km._session_order,
-         kept, km._hidden_tabs) = self._saved
+         kept) = self._saved
         km._kept_open.clear(); km._kept_open.update(kept)
 
     def _fleet(self):
@@ -6914,7 +6904,6 @@ class SessionOrderStable(unittest.TestCase):
     def test_dead_chat_tab_keeps_its_slot(self):
         self._fleet()
         km._kept_open.clear(); km._kept_open.add("B")    # B's tab kept open (read-only) after death
-        km._hidden_tabs = lambda: set()
         got = [s["sid"] for s in km._chat_tab_sessions(NOW, {})]
         self.assertEqual(got, ["A", "B", "C"], "kept-open dead tab keeps its slot, same stable key as the timeline")
 

--- a/tests/test_kernel_cancel_create.py
+++ b/tests/test_kernel_cancel_create.py
@@ -42,7 +42,6 @@ class CancelCreateTest(unittest.TestCase):
     def setUp(self):
         self.be = FakeBackend()
         self.sent = []        # (app, msg) handed to the chat view
-        self.hidden = []      # (sid, hidden) tab-hide calls
         self._live = {}       # sid -> meta; drives the monkeypatched name lookup
         self._saved = {}
 
@@ -50,7 +49,6 @@ class CancelCreateTest(unittest.TestCase):
             self._saved[nm] = getattr(km, nm)
             setattr(km, nm, fn)
 
-        patch("_set_hidden_tab", lambda sid, hidden: self.hidden.append((sid, hidden)))
         patch("_send_to_app", lambda app, m: self.sent.append((app, m)))
         patch("_push_soon", lambda: None)
         patch("_push_all", lambda: None)
@@ -75,9 +73,8 @@ class CancelCreateTest(unittest.TestCase):
         self._live = {SID: {}}                                 # the session already materialized
         self._cancel(NAME)
         self.assertEqual(self.be.killed, [SID], "the live pending session is killed on its backend")
-        self.assertIn((SID, True), self.hidden, "its tab is hidden")
         self.assertTrue(any(m.get("type") == "closed" and m.get("id") == SID for _a, m in self.sent),
-                        "the live view is told to prune it")
+                        "the live view is told to prune it (no tab-hide state anymore — the kill is the event)")
         self.assertNotIn(NAME, km._cancel_pending, "a resolved cancel never arms the pending set")
 
     def test_not_yet_live_arms_then_reaped_on_arrival(self):
@@ -123,7 +120,6 @@ class CancelCreateTest(unittest.TestCase):
         self._live = {SID: {}}
         self._cancel(NAME)
         self.assertEqual(self.be.killed, [], "a session with a human turn is work, never a pending spawn")
-        self.assertEqual(self.hidden, [], "its tab stays visible")
         self.assertEqual(self.sent, [], "and the live view is not told to prune it")
 
     def test_a_fresh_spawn_with_only_init_lines_is_still_torn_down(self):
@@ -133,7 +129,6 @@ class CancelCreateTest(unittest.TestCase):
         self._live = {SID: {}}
         self._cancel(NAME)
         self.assertEqual(self.be.killed, [SID], "only system/init lines → a genuine pending spawn")
-        self.assertIn((SID, True), self.hidden)
 
     def test_an_unreadable_transcript_fails_toward_refusing(self):
         self._saved["_path_of"] = km._path_of

--- a/tests/test_kernel_color_pick.py
+++ b/tests/test_kernel_color_pick.py
@@ -93,15 +93,14 @@ class PickColor(unittest.TestCase):
             def connect(self, sid):
                 return True
 
-        saved = (km._sdk, km._set_hidden_tab, km._reveal_chat, km._mark_views_dirty)
+        saved = (km._sdk, km._reveal_chat, km._mark_views_dirty)
         km._sdk = lambda: _FakeSdk()
-        km._set_hidden_tab = lambda *a: None
         km._reveal_chat = lambda *a: None
         km._mark_views_dirty = lambda: None
         try:
             km._create_sdk_session("newsess", "/tmp/x")
         finally:
-            (km._sdk, km._set_hidden_tab, km._reveal_chat, km._mark_views_dirty) = saved
+            (km._sdk, km._reveal_chat, km._mark_views_dirty) = saved
         self.assertEqual(got.get("bg"), self.bgs[1], "colour 0 is live → spawn is handed the next free one")
         self.assertTrue(got.get("fg"), "its paired foreground rides along")
 

--- a/tests/test_kernel_create_session_ack.py
+++ b/tests/test_kernel_create_session_ack.py
@@ -46,9 +46,8 @@ class CreateSessionAckFast(unittest.TestCase):
         self.fake = _FakeSdk()
         self.events = []
         self._saved = {n: getattr(km, n) for n in
-                       ("_sdk", "_set_hidden_tab", "_reveal_chat", "_mark_views_dirty", "_push_all")}
+                       ("_sdk", "_reveal_chat", "_mark_views_dirty", "_push_all")}
         km._sdk = lambda: self.fake
-        km._set_hidden_tab = lambda sid, hidden: self.events.append(("unhide", sid, hidden))
         km._reveal_chat = lambda m: self.events.append(("reveal", m))
         km._mark_views_dirty = lambda: self.events.append(("dirty",))
         km._push_all = lambda: self.events.append(("PUSH_ALL",))

--- a/tests/test_kernel_opening.py
+++ b/tests/test_kernel_opening.py
@@ -148,16 +148,9 @@ class PushSessionNow(_Base):
         km._push_session_now(SID)
         self.assertEqual(len(self.sent), n, "unchanged payloads dedup — no re-send storm")
 
-    def test_a_hidden_or_unknown_sid_sends_nothing(self):
-        km._set_hidden_tab(SID, True)
-        try:
-            km._push_session_now(SID)
-            self.assertEqual(self.sent, [], "a ×-hidden tab stays hidden — the pusher owns the rest")
-            self.sent.clear()
-            km._push_session_now("99999999-8888-7777-6666-555555555555")
-            self.assertEqual(self.sent, [], "an unknown sid is not an error, just a no-op")
-        finally:
-            km._set_hidden_tab(SID, False)
+    def test_an_unknown_sid_sends_nothing(self):
+        km._push_session_now("99999999-8888-7777-6666-555555555555")
+        self.assertEqual(self.sent, [], "an unknown sid is not an error, just a no-op")
 
     def test_the_shared_delta_baseline_is_left_alone(self):
         # only a push that reaches EVERY client may advance _prev_chat_events (the 2026-07-28

--- a/tests/test_kernel_order.py
+++ b/tests/test_kernel_order.py
@@ -33,18 +33,15 @@ class SessionOrder(unittest.TestCase):
         self.td = tempfile.TemporaryDirectory()
         # redirect every state read/write (_session_order / _write_session_order) into a temp dir
         self._saved = {"STATE": km.jd.STATE, "_kept_open": km._kept_open,
-                       "_alive_sessions": km._alive_sessions, "_sessions": km._sessions,
-                       "_hidden_tabs": km._hidden_tabs}
+                       "_alive_sessions": km._alive_sessions, "_sessions": km._sessions}
         km.jd.STATE = Path(self.td.name)
         km._kept_open = set()
-        km._hidden_tabs = lambda: set()
 
     def tearDown(self):
         km.jd.STATE = self._saved["STATE"]
         km._kept_open = self._saved["_kept_open"]
         km._alive_sessions = self._saved["_alive_sessions"]
         km._sessions = self._saved["_sessions"]
-        km._hidden_tabs = self._saved["_hidden_tabs"]
         self.td.cleanup()
 
     def order_file(self):

--- a/tests/test_kernel_revive.py
+++ b/tests/test_kernel_revive.py
@@ -45,18 +45,17 @@ class ReviveSession(unittest.TestCase):
 
     def setUp(self):
         self.saved = (km._sdk, km._name_of, km._cwd_of, km._push_all, km._reveal_chat,
-                      km._send_to_app, km._set_hidden_tab, subprocess.run)
+                      km._send_to_app, subprocess.run)
         self.sent, self.focused, self.runs = [], [], []
         km._name_of = lambda sid: "testsess"
         km._cwd_of = lambda sid: "/nonexistent-dir-for-test"
         km._push_all = lambda: None
         km._reveal_chat = lambda msg: self.focused.append(msg)
         km._send_to_app = lambda app, msg: self.sent.append((app, msg))
-        km._set_hidden_tab = lambda sid, hidden: None
 
     def tearDown(self):
         (km._sdk, km._name_of, km._cwd_of, km._push_all, km._reveal_chat,
-         km._send_to_app, km._set_hidden_tab, subprocess.run) = self.saved
+         km._send_to_app, subprocess.run) = self.saved
 
     def _stub_run(self, returncode=0, stderr=""):
         def run(cmd, **kw):

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -410,9 +410,9 @@ const tabMeta = new Map<string, { name: string; color: Color | null }>();
 // swirl, looking like a shutdown you had to wait out (the user 2026-07-24, who wanted the tab to just go and
 // the shutdown to run behind it). Cleared on the kernel's ack — its push dropping the id — not on a timer.
 const closingTabs = new Map<string, number>();
-// …with a backstop for the ack that never comes. `closeTab` only flips a hidden flag kernel-side, so there is
-// no failure EVENT to key on: the sole evidence a close didn't take is the kernel still listing the tab long
-// after. Past this we say so and let the tab back, rather than hiding a session that's really still open.
+// …with a backstop for the ack that never comes. A refused/failed end leaves no failure EVENT to key on:
+// the sole evidence a close didn't take is the kernel still listing the tab long after. Past this we say
+// so and let the tab back, rather than hiding a session that's really still open.
 const CLOSE_ACK_MS = 15_000;
 // The romp identity palette for the tab right-click color picker (the user 2026-06-29). Fetched once from the
 // kernel's /palette so the client holds no color literals; empty until it lands (the menu just omits the row).
@@ -3646,7 +3646,7 @@ function renderTabs() {
     // "End session?" confirm (the user 2026-06-16). A live session still routes through the host's
     // Close-tab / End-session confirm (closeSession → confirmClose).
     const dead = st === "closed";
-    close.title = dead ? "Close tab" : "Close tab (or end the session)";
+    close.title = dead ? "Close tab" : "End session";
     // Click-safe (see ./actions): renderTabs() does `#tabs`.replaceChildren() on every kernel push, so a
     // handler hung on this ✕ is destroyed mid-click and the click is dropped (the "had to click End session
     // several times" bug). The action lives on the stable #tabs delegate instead; this node just declares it.
@@ -4729,14 +4729,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       startCreate({ name, backend: beSel?.dataset.be || loadSettings().backend,
                     dir: dirInput.value.trim(), host: hostSel, ...(auth ? { auth } : {}) });
     });
-    const openAll = el("button", "picker-action");
-    openAll.textContent = "↗ Open all running sessions";
-    openAll.addEventListener("click", () => {
-      if (vscodeApi) vscodeApi.postMessage({ type: "openAll" });
-      closePicker();
-    });
     actions.appendChild(newSess);
-    actions.appendChild(openAll);
     box.appendChild(search);
     box.appendChild(errLine);
     box.appendChild(list);
@@ -8415,16 +8408,19 @@ window.addEventListener("message", (e: MessageEvent) => {
   // The host asks US to confirm (in-page, no native dialogs): ending a live
   // session on tab-close, and reviving a dead one on open.
   else if (m.type === "confirmClose" && m.id) {
+    // × = End session, full stop (the user 2026-08-11): the old "Close tab" branch hid a RUNNING session
+    // — no tab, no Fleet row, still judged and billed — a secret running session with no SDK-era use
+    // case. Close-and-reopen is End + Revive, which keeps the whole history.
     const nm = String(m.name || "");
     showConfirm(`End “${nm}”?`,
-      "“Close tab” just removes it from this panel and leaves the session running. “End session” shuts it down (the transcript stays on disk).",
-      [{ label: "Close tab", value: "close" }, { label: "End session", value: "end", danger: true }, { label: "Cancel", value: "" }],
+      "The session shuts down. Its history stays on disk — revive it any time from the picker or timeline.",
+      [{ label: "End session", value: "end", danger: true }, { label: "Cancel", value: "" }],
       (v) => {
-        if (v !== "close" && v !== "end") return;   // Cancel → nothing
+        if (v !== "end") return;   // Cancel → nothing
         // End session = shut it down AND remove the tab (the user 2026-06-16: an explicitly-ended session
         // shouldn't linger as a struck-through read-only tab — that's only for sessions that die on their
-        // own). closeTab must durably dismiss it so the death event doesn't re-add the struck tab.
-        if (v === "end") vscodeApi?.postMessage({ type: "endSession", id: m.id });
+        // own). closeTab durably forgets a kept read-only tab so the death event doesn't re-add it.
+        vscodeApi?.postMessage({ type: "endSession", id: m.id });
         vscodeApi?.postMessage({ type: "closeTab", id: m.id });
         closeTabLocally(m.id);   // same optimistic drop as the in-page ✕ — this path used to sit and wait
       });
@@ -9114,16 +9110,19 @@ setupSettings();
         closeTabLocally(id);
         return;
       }
-      // LIVE session: show the End/Close confirm IMMEDIATELY, client-side — NOT via a closeSession→confirmClose
+      // LIVE session: show the End confirm IMMEDIATELY, client-side — NOT via a closeSession→confirmClose
       // kernel round-trip, which made the ✕ feel unresponsive (and sometimes never opened the modal when the
       // kernel was busy). The dialog is static; the kernel doesn't need to decide it (the user 2026-06-24).
+      // × = End session, full stop (the user 2026-08-11): the old "Close tab" branch hid a RUNNING
+      // session — still judged and billed, but invisible — a tmux-era affordance with no SDK-era use
+      // case. Close-and-reopen is End + Revive, which keeps the whole history.
       const nm = sessions.get(id)?.name || "";
       showConfirm(`End “${nm}”?`,
-        "“Close tab” just removes it from this panel and leaves the session running. “End session” shuts it down (the transcript stays on disk).",
-        [{ label: "Close tab", value: "close" }, { label: "End session", value: "end", danger: true }, { label: "Cancel", value: "" }],
+        "The session shuts down. Its history stays on disk — revive it any time from the picker or timeline.",
+        [{ label: "End session", value: "end", danger: true }, { label: "Cancel", value: "" }],
         (v) => {
-          if (v !== "close" && v !== "end") return;   // Cancel → nothing
-          if (v === "end") vscodeApi?.postMessage({ type: "endSession", id });
+          if (v !== "end") return;   // Cancel → nothing
+          vscodeApi?.postMessage({ type: "endSession", id });
           vscodeApi?.postMessage({ type: "closeTab", id });
           closeTabLocally(id);   // drop the tab + reselect NOW, and keep it gone while the kernel catches up
         });

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -43,10 +43,6 @@
         "title": "romp: Previous Tab"
       },
       {
-        "command": "rompChat.openAll",
-        "title": "romp: Open All Running Sessions"
-      },
-      {
         "command": "rompChat.pickSession",
         "title": "romp: Pick a Session"
       },

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -220,7 +220,6 @@ export function activate(context: vscode.ExtensionContext) {
         typeof arg === "string" ? { prompt: arg }
           : arg && typeof arg === "object" ? (arg as { prompt?: string; allowNew?: boolean })
           : {})),
-    vscode.commands.registerCommand("rompChat.openAll", () => { openPanel(); chatPipe?.send({ type: "openAll" }); }),
     vscode.commands.registerCommand("rompChat.nextTab", () => panel?.webview.postMessage({ type: "nextTab" })),
     vscode.commands.registerCommand("rompChat.prevTab", () => panel?.webview.postMessage({ type: "prevTab" })),
     vscode.commands.registerCommand("rompChat.openCurrent", () => {


### PR DESCRIPTION
## The change (the user's call, 2026-08-11)

×-closing a tab used to write the sid to `hidden-tabs.json` and leave the session **running with no chat tab and no Fleet-pane section** — still judged, still carding into the feed, still billing. A secret running session: a tmux-era affordance (sessions lived outside romp; the dashboard was a viewer you declutter) with no SDK-era use case. Close-and-reopen already has a first-class path that keeps the whole history: **End session + Revive**.

Now: every alive session is a visible tab, and × means End session, full stop.

## Removed

- `_hidden_tabs` / `_set_hidden_tab` and every un-hide leg (open, revive, create-existing, pickResult/openByName, viewReadOnly)
- the `openAll` route, the picker's "↗ Open all running sessions" button, and the extension's `rompChat.openAll` command (its only job was bulk-undoing hides)
- the "Close tab" branch of both ×-confirm dialogs (in-page and kernel-initiated) — the dialog is now End session / Cancel
- `hidden-tabs.json` is no longer read or written; a stale file on disk is inert, like `web-kernel.json` (282 accumulated sids, never GC'd — also a small leak plugged)

## Kept, deliberately

- **`closeTab` route survives with its one remaining duty**: forgetting a dead read-only tab (`_kept_open` discard) + the prompt `closed` client prune. A stale client's hide ask for a live sid is ignored — the tab just stays visible, the safe direction.
- `_kept_open` (View read-only tabs for dead sessions), `hideFromFeed` (the feed/judging mute — a different axis), and SDK eager-connect on the open/create/revive gestures.
- **The timeline is untouched**: lanes were already independent of tab state. The old "lane survives a hidden tab" pin becomes "the timeline keeps dead lanes".

The Fleet pane and the feed's session-filter menu derive from the tab list, so they now show every running session too — one honest inventory everywhere.

## Tests

- New pin: `test_no_hidden_tab_state_exists` (the pair must stay deleted, or secret running sessions come back).
- Rewritten: dead-kept-tab dismissal via `_kept_open`, revive without the unhide leg, timeline dead-lane pin, cancel-create teardown without the hide event; stub tuples updated in 6 test files.
- Full suites green: 4204 pytest + 1811 node + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)