### PR TITLE
An in-flight attachment shows a pending chip until the kernel acks it

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -22024,6 +22024,10 @@ class Handler(BaseHTTPRequestHandler):
             fp = _save_dropped_file(str(msg["name"]), str(msg["b64"]))   # bytes → saved file → insert its path
             if fp:
                 _reply(client, {"type": "droppedPath", "path": fp})
+            else:
+                # a failed save must be NACKED, not silent (fail loudly): the client keeps a pending
+                # chip up from the moment the file was picked, and only this reply can retire it
+                _reply(client, {"type": "dropSaveFailed", "name": str(msg["name"])})
         elif msg and msg.get("type") == "openFile" and msg.get("path"):
             _open_file(str(msg["path"]), sid=msg.get("id"))       # caption / linkified path click → open it (relative → resolved vs the session cwd)
         elif msg and msg.get("type") == "pickFile":

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5103,6 +5103,12 @@ class ViewBuilder(unittest.TestCase):
         self.assertTrue(os.path.isfile(fp))
         self.assertEqual(open(fp, "rb").read(), b"hello")
         self.assertIn("drops", fp)
+        # a save that fails returns None — and the WS handler NACKS it (dropSaveFailed) so the
+        # client's pending chip never pulses forever over a file that is not coming (fail loudly,
+        # the user 2026-08-11; source pin — the branch lives inline in the WS message loop)
+        self.assertIsNone(km._save_dropped_file("bad.png", "%%%not-base64%%%"), "undecodable bytes → None")
+        src = Path(BIN, "romp-kernel").read_text()
+        self.assertIn('_reply(client, {"type": "dropSaveFailed", "name": str(msg["name"])})', src)
 
     def test_permission_mode_cycle_presses(self):
         # shift+tab press count from current → target in the cycle (the user 2026-06-16): there's no

--- a/ui/webview/composer-attach.test.ts
+++ b/ui/webview/composer-attach.test.ts
@@ -43,7 +43,8 @@ test("📎 routes the chosen files through the existing dropFile pipeline (no ne
   // chosen files go to shipFileToHost, which already posts {type:"dropFile"} and
   // gets {type:"droppedPath"} back — we reuse it rather than add a second uploader
   assert.match(RENDER, /filePicker\.files \|\| \[\]\)\.forEach\(\(f\) => shipFileToHost\(f\)\)/);
-  assert.match(RENDER, /\{ type: "dropFile", name: f\.name \|\| "pasted\.png", b64 \}/);
+  assert.match(RENDER, /const name = f\.name \|\| "pasted\.png";/);
+  assert.match(RENDER, /\{ type: "dropFile", name, b64 \}/);
 });
 
 test("📎 in the VS Code webview still uses the native host dialog (pickFile)", () => {
@@ -57,8 +58,11 @@ test("shipFileToHost stamps the session id so federation routes the bytes to the
   // the saved drops/ path rides the prompt and is read by the agent on the session's own
   // machine — bytes saved on any other kernel would hand the agent a nonexistent path.
   // routeOutbound routes any `id` field by host prefix (SCALAR_ID); the stamp is what
-  // engages it (multi-kernel-merge.test.ts pins the routing itself).
-  assert.match(RENDER, /if \(activeId\) msg\.id = activeId;\s*\/\/ the owning session → the owning kernel/);
+  // engages it (multi-kernel-merge.test.ts pins the routing itself). The sid is captured
+  // at SHIP time (with the pending chip), not at encode time — a tab switch mid-encode
+  // must not reroute the bytes away from the session the user attached them to.
+  assert.match(RENDER, /const sid = activeId;/);
+  assert.match(RENDER, /if \(sid\) msg\.id = sid;\s*\/\/ the owning session → the owning kernel/);
 });
 
 test("an oversize file is refused LOUDLY — named size and cap in a toast, never a silent return", () => {

--- a/ui/webview/composer-files.test.ts
+++ b/ui/webview/composer-files.test.ts
@@ -36,7 +36,7 @@ test("every file arrival becomes an attachment, never raw path text in the box",
   assert.match(RENDER, /if \(p\) \{ addComposerFile\(activeId, p\); return; \}/);
   // paste-with-files and the host round-trip (dropped bytes, 📎 dialog, phone picker) too
   assert.match(RENDER, /if \(p\) addComposerFile\(activeId, p\);\s*\n\s*else shipFileToHost\(f\);/);
-  assert.match(RENDER, /m\.type === "droppedPath" && typeof m\.path === "string"\) addComposerFile\(activeId, m\.path\);/);
+  assert.match(RENDER, /m\.type === "droppedPath" && typeof m\.path === "string"\) \{[\s\S]{0,300}addComposerFile\(activeId, m\.path\);/);
   // the old insert-at-cursor path is gone with its last caller
   assert.doesNotMatch(RENDER, /function insertComposerText/);
 });

--- a/ui/webview/pending-attach.test.ts
+++ b/ui/webview/pending-attach.test.ts
@@ -1,0 +1,75 @@
+// While a picked/dropped/pasted file's bytes ship to the kernel (shipFileToHost →
+// dropFile → droppedPath), the attachment strip shows a PENDING chip — name +
+// pulsing dots — from the instant the file is chosen. On a phone that round trip
+// is seconds long (base64 + a fragmented WS send + the kernel write), and with
+// nothing on screen it read as a dead click (the user 2026-08-11: "seemed like it
+// didn't work for a second and then the thumbnail appeared").
+//
+// Lifecycle is EVENT-based end to end: the chip goes up on pick, and comes down
+// only on the ack (droppedPath), the kernel's loud nack (dropSaveFailed), a
+// FileReader error, or the user's own ✕ — never a timer.
+//
+// The chat renderer has no jsdom harness, so — like the other webview tests —
+// pin the wiring at the source level.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the pending chip goes up BEFORE the encode starts — pick-to-feedback is immediate", () => {
+  // registry keyed by session, like composerFiles beside it
+  assert.match(RENDER, /const pendingShips = new Map<string, string\[\]>\(\);/);
+  // registered at the TOP of shipFileToHost (before new FileReader), with the sid captured once
+  assert.match(RENDER, /const name = f\.name \|\| "pasted\.png";\s*\n\s*const sid = activeId;\s*\n\s*addPendingShip\(sid, name\);\s*\n\s*const reader = new FileReader\(\);/);
+});
+
+test("the strip renders pending chips (name + pulsing dots) and shows even with no real attachments", () => {
+  // the strip's empty-check counts pending ships too
+  assert.match(RENDER, /if \(!paths\.length && !pending\.length\) \{ strip\.style\.display = "none"; return; \}/);
+  // each pending entry renders as a composer-file-pending chip with the ship-dots
+  assert.match(RENDER, /composer-file composer-file-pending/);
+  assert.match(RENDER, /composer-ship-dots/);
+  // the ✕ removes just the CHIP — the escape hatch for an ack lost to a mid-ship disconnect
+  assert.match(RENDER, /aria-label", "Dismiss pending attachment"/);
+});
+
+test("the droppedPath ack retires the chip it answers, then attaches the thumbnail", () => {
+  assert.match(RENDER, /retirePendingShip\(m\.path\);/);
+  assert.match(RENDER, /retirePendingShip\(m\.path\);[\s\S]{0,200}addComposerFile\(activeId, m\.path\)/);
+});
+
+test("ack↔chip matching mirrors the kernel's saved-name sanitizer, FIFO as the fallback", () => {
+  // drops/<ms>-<safe name>: the JS sanitizer mirrors _save_dropped_file's regex …
+  assert.match(RENDER, /name\.replace\(\/\[\^\\w.-\]\+\/g, "_"\)\.slice\(-80\)/);
+  assert.match(KERNEL, /re\.sub\(r"\[\^\\w.-\]\+", "_", name\)\[-80:\]/);
+  // … and an unmatched ack still retires the OLDEST entry (the kernel answers in order)
+  assert.match(RENDER, /list\.splice\(i >= 0 \? i : 0, 1\);/);
+});
+
+test("a failed kernel save is NACKED and surfaces loudly — never a silent stuck chip", () => {
+  // kernel: the no-path branch replies dropSaveFailed instead of nothing
+  assert.match(KERNEL, /_reply\(client, \{"type": "dropSaveFailed", "name": str\(msg\["name"\]\)\}\)/);
+  // client: the nack retires the chip and says so in a toast
+  assert.match(RENDER, /m\.type === "dropSaveFailed" && typeof m\.name === "string"/);
+  assert.match(RENDER, /retirePendingShip\(m\.name\);\s*\n\s*warnToast\(m\.name \+ " couldn't be saved on the kernel/);
+  // a FileReader failure retires it too — an unreadable file must not pulse forever
+  assert.match(RENDER, /reader\.onerror = \(\) => retirePendingShip\(name\);/);
+});
+
+test("pending chips are in-memory only — never persisted with drafts", () => {
+  // a reload kills the page whose socket the ack would ride; persisting the chip would
+  // revive dots that nothing can ever retire
+  assert.doesNotMatch(RENDER, /pendingShips[\s\S]{0,80}persistDrafts|persistDrafts[\s\S]{0,300}pendingShips/);
+});
+
+test("the chip wears the accent loader-dots motif from styles.css", () => {
+  assert.match(CSS, /\.composer-file-pending \{[^}]*dashed/);
+  assert.match(CSS, /\.composer-ship-dots i \{[^}]*var\(--accent\)/);
+  assert.match(CSS, /@keyframes ship-bnc/);
+  // staggered like the romp loader's dots
+  assert.match(CSS, /\.composer-ship-dots i:nth-child\(3\) \{ animation-delay: 0\.32s; \}/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7400,6 +7400,49 @@ const composerCitations = new Map<string, Citation[]>();
 // insert-at-cursor produced, now legible while you compose.
 const composerFiles = new Map<string, string[]>();   // sid -> attachment paths, in drop order
 
+// Files whose BYTES are still in flight to the kernel (shipFileToHost → dropFile → droppedPath ack).
+// On a phone that round trip is seconds long — base64 + a fragmented WS send + the kernel write — and
+// with nothing on screen it reads as a dead click (the user 2026-08-11). So the strip shows a pending
+// chip (name + pulsing dots) from the instant the file is picked, replaced by the real thumbnail when
+// the ack lands, or removed with a loud toast when the kernel nacks (dropSaveFailed). In-memory only,
+// NOT persisted with drafts: a reload kills the page whose socket the ack would ride.
+const pendingShips = new Map<string, string[]>();    // sid -> shipped names awaiting droppedPath
+
+// The kernel saves a shipped file as drops/<ms>-<sanitized name> (_save_dropped_file). Mirror its
+// sanitizer so an ack can be matched back to the pending chip it retires by basename suffix; the
+// FIFO fallback in resolvePendingShip covers any mismatch (e.g. non-ASCII, where Python's \w and
+// JS's \w disagree).
+function shipSafeName(name: string): string {
+  return (name.replace(/[^\w.-]+/g, "_").slice(-80)) || "drop";
+}
+
+function addPendingShip(id: string | null, name: string): void {
+  if (!id) return;
+  const list = pendingShips.get(id) || [];
+  list.push(name);
+  pendingShips.set(id, list);
+  if (id === activeId) renderComposerFiles(id);
+}
+
+// An ack (or nack) retires ONE pending chip: the entry whose sanitized name `key` ends with — `key`
+// is the saved path on ack (basename <ms>-<safe name>) or the raw name on nack, and both end with
+// the sanitized original — else the oldest (the kernel answers a connection's dropFiles in order).
+// Searched active-tab-first across all sessions because the ack carries no session id — like the
+// attachment itself, it lands wherever the user now is.
+function retirePendingShip(key: string): void {
+  const k = "-" + shipSafeName(key.split("/").pop() || key);
+  const ids = activeId ? [activeId, ...pendingShips.keys()] : [...pendingShips.keys()];
+  for (const id of ids) {
+    const list = pendingShips.get(id);
+    if (!list || !list.length) continue;
+    const i = list.findIndex((n) => k.endsWith("-" + shipSafeName(n)));
+    list.splice(i >= 0 ? i : 0, 1);
+    if (!list.length) pendingShips.delete(id);
+    if (id === activeId) renderComposerFiles(id);
+    return;
+  }
+}
+
 // Persist drafts across a full RELOAD (the user 2026-06-25: a half-typed message must survive a refresh, not
 // only a tab switch). The Map is in-memory, so mirror it into the webview's persisted state — the same store
 // that remembers the active tab — and reload it at startup. restoreActiveDraftOnce() drops the active tab's
@@ -7527,8 +7570,9 @@ function renderComposerFiles(id: string | null): void {
   const strip = document.getElementById("composer-files");
   if (!strip) return;
   strip.replaceChildren();
-  const paths = id ? composerFiles.get(id) : undefined;
-  if (!paths || !paths.length) { strip.style.display = "none"; return; }
+  const paths = (id ? composerFiles.get(id) : undefined) || [];
+  const pending = (id ? pendingShips.get(id) : undefined) || [];
+  if (!paths.length && !pending.length) { strip.style.display = "none"; return; }
   strip.style.display = "flex";
   paths.forEach((p, i) => {
     const box = el("span", "composer-file");
@@ -7558,6 +7602,31 @@ function renderComposerFiles(id: string | null): void {
     x.setAttribute("aria-label", "Remove attachment");
     x.textContent = "\u2715";
     x.addEventListener("click", (e) => { e.stopPropagation(); if (id) removeComposerFile(id, i); });
+    box.appendChild(x);
+    strip.appendChild(box);
+  });
+  // In-flight ships, after the real thumbnails: name + pulsing dots until the droppedPath ack swaps
+  // in the thumbnail above. The ✕ removes just the CHIP (there is no cancelling a send in flight) —
+  // the escape hatch for an ack lost to a mid-ship disconnect, so a stuck chip is never trapped.
+  pending.forEach((n, i) => {
+    const box = el("span", "composer-file composer-file-pending");
+    box.title = n + " — uploading";
+    const nm = el("span", "composer-file-name");
+    nm.textContent = n;
+    const dots = el("span", "composer-ship-dots");
+    dots.append(el("i"), el("i"), el("i"));
+    box.append(nm, dots);
+    const x = el("button", "composer-file-x");
+    x.setAttribute("aria-label", "Dismiss pending attachment");
+    x.textContent = "✕";
+    x.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const list = id ? pendingShips.get(id) : undefined;
+      if (!list) return;
+      list.splice(i, 1);
+      if (!list.length && id) pendingShips.delete(id);
+      renderComposerFiles(id);
+    });
     box.appendChild(x);
     strip.appendChild(box);
   });
@@ -8459,7 +8528,15 @@ window.addEventListener("message", (e: MessageEvent) => {
     const s = sessions.get(m.id);
     if (s && s.name !== m.name) { s.name = m.name; renderTabs(); }
   }
-  else if (m.type === "droppedPath" && typeof m.path === "string") addComposerFile(activeId, m.path);   // host-saved drop/paste/pick → a thumbnail, not path text (the user 2026-08-04)
+  else if (m.type === "droppedPath" && typeof m.path === "string") {   // host-saved drop/paste/pick → a thumbnail, not path text (the user 2026-08-04)
+    retirePendingShip(m.path);                                         // the in-flight chip this ack answers (no-op for pickFile, which never ships)
+    addComposerFile(activeId, m.path);
+  } else if (m.type === "dropSaveFailed" && typeof m.name === "string") {
+    // the kernel could not SAVE the shipped bytes — clear the pending chip and say so loudly,
+    // never leave dots pulsing over a file that is not coming (fail loudly, don't degrade silently)
+    retirePendingShip(m.name);
+    warnToast(m.name + " couldn't be saved on the kernel, so it was not attached — try again.");
+  }
   // an EDITOR highlight (VS Code host, onDidChangeTextEditorSelection — the user 2026-07-13) seeds the
   // same quote chip a transcript highlight does, labeled + wrapped with its file:lines origin (m.src)
   else if (m.type === "editorSelection" && typeof m.text === "string" && m.text.trim() && activeId)
@@ -8967,15 +9044,22 @@ function shipFileToHost(f: File) {
       + " MB — attachments over 50 MB can't be shipped, so it was not attached.");
     return;
   }
+  // The pending chip goes up NOW, before the encode even starts — on a phone the encode + fragmented
+  // WS send + kernel round trip is seconds of otherwise-blank time that read as a dead click (the
+  // user 2026-08-11). Retired by the droppedPath ack / dropSaveFailed nack (see retirePendingShip).
+  const name = f.name || "pasted.png";
+  const sid = activeId;
+  addPendingShip(sid, name);
   const reader = new FileReader();
   reader.onload = () => {
     const b64 = String(reader.result || "").split(",")[1] || "";
-    if (!b64 || !vscodeApi) return;
+    if (!b64 || !vscodeApi) { retirePendingShip(name); return; }
     const msg: { type: string; name: string; b64: string; id?: string } =
-      { type: "dropFile", name: f.name || "pasted.png", b64 };
-    if (activeId) msg.id = activeId;   // the owning session → the owning kernel
+      { type: "dropFile", name, b64 };
+    if (sid) msg.id = sid;   // the owning session → the owning kernel
     vscodeApi.postMessage(msg);
   };
+  reader.onerror = () => retirePendingShip(name);   // an unreadable file must not leave a stuck chip
   reader.readAsDataURL(f);
 }
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -526,6 +526,18 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   color: var(--fg); font-size: 10px; cursor: pointer; display: none; }
 .composer-file:hover .composer-file-x { display: block; }   /* the tab-close idiom: no clutter until hover */
 .composer-file-x:hover { background: color-mix(in srgb, var(--accent) 28%, transparent); }   /* full-width block of its own, above the compose row; stacked chips each take a row (the user 2026-08-04) */
+/* An attachment still SHIPPING to the kernel: the doc-chip look, dashed + faint, with pulsing accent
+   dots until the droppedPath ack swaps in the real thumbnail (the user 2026-08-11: on a phone the
+   ship is seconds long, and a blank strip read as a dead click). Dots are the loader-dots motif. */
+.composer-file-pending { gap: 6px; padding: 4px 8px; border-radius: 6px; cursor: default;
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--accent) 35%, transparent); }
+.composer-ship-dots { display: inline-flex; gap: 3px; }
+.composer-ship-dots i { width: 4px; height: 4px; border-radius: 50%; background: var(--accent);
+  animation: ship-bnc 1.1s ease-in-out infinite; }
+.composer-ship-dots i:nth-child(2) { animation-delay: 0.16s; }
+.composer-ship-dots i:nth-child(3) { animation-delay: 0.32s; }
+@keyframes ship-bnc { 0%, 75%, 100% { opacity: 0.25; } 38% { opacity: 1; } }
 .composer-chip {
   display: inline-flex; align-items: center; gap: 5px; max-width: 100%;
   background: color-mix(in srgb, var(--accent) 18%, transparent);


### PR DESCRIPTION
On a phone, attaching a photo meant seconds of nothing between picking the file and the thumbnail appearing — base64 encode + a fragmented WS send + the kernel write — and the blank strip read as a dead click (the user 2026-08-11, right after the WS reassembly fix made mobile attach work at all).

The attachment strip now shows a pending chip (filename + pulsing accent dots, dashed border) from the instant the file is picked. Its lifecycle is event-based end to end:
- the `droppedPath` ack retires it and the real thumbnail swaps in (matched by the kernel's saved-name sanitizer, FIFO fallback);
- a failed kernel save now answers with a `dropSaveFailed` nack → chip cleared + loud toast (it used to answer with nothing);
- a FileReader error clears it;
- the chip's own ✕ is the escape hatch for an ack lost to a mid-ship disconnect.

In-memory only, deliberately not persisted with drafts: a reload kills the page whose socket the ack would ride.

Tests: 7 new source pins in `ui/webview/pending-attach.test.ts` (chip-before-encode, strip render, ack/nack retire, sanitizer mirror, no-persist, CSS motif), kernel nack pin + undecodable-bytes case in `tests/test_kernel.py`; two existing pins updated for the reshaped ship/ack code. UI suite 1825 pass, Python suite 4209 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)