### PR TITLE
A refused fast-mode pick says why instead of vanishing, and the badge reads Slow when off

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -119,13 +119,16 @@ code {dir}                          # VS Code instead
 ### Fast mode, from the chat statusline
 
 The statusline's badges — permission mode, model, effort — are each a small
-dropdown. A fourth, **Fast**, appears when the session reports Claude Code's
-fast-mode state (an Opus-only research preview, billed at a premium). Picking
-On or Off sends the CLI's own `/fast` command; the badge reads the state the
-CLI reports — orange while on, and a cooldown label while fast requests are
-rate-limited — and never appears on a session that cannot run fast mode.
-Turning it on while the session is on a non-Opus model makes the CLI switch to
-a fast-capable one, which the chat shows as the command's own confirmation.
+dropdown. A fourth appears when the session reports Claude Code's fast-mode
+state (an Opus-only research preview, billed at a premium): it reads **Fast**
+in orange while fast mode is on, **Slow** while it's off, and **Cooldown**
+while fast requests are rate-limited. Picking On or Off sends the CLI's own
+`/fast` command; the badge never appears on a session that cannot run fast
+mode. Turning it on while the session is on a non-Opus model makes the CLI
+switch to a fast-capable one, which the chat shows as the command's own
+confirmation. If the CLI refuses the toggle (for example, the account has
+extra usage turned off), a toast says why and the pick reverts to off —
+the control never silently disappears.
 
 ### Per-session billing (login vs API key)
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1012,6 +1012,13 @@ def list_regs(state_dir: Path) -> list[dict]:
 
 FLAG_SETTINGS_DIR = "sdk-flag-settings"   # per-session --settings payloads, one file per sid
 
+# fast_mode_disabled_reason tokens humanized for the refusal toast (_adopt_fast_state's refused-ask
+# path). An unmapped token is shown raw — a loud unfamiliar word beats a silent vanish.
+_FAST_REFUSALS = {
+    "extra_usage_disabled": "the account has extra usage turned off, and fast mode bills through it "
+                            "(claude.ai → Settings → Usage)",
+}
+
 
 def flag_settings_path(state_dir, sid: str, *, ultracode: bool = False, fast: bool = False) -> str:
     """The settings file handed to the CLI (options.settings — the flag-settings layer, the CLI's
@@ -1577,17 +1584,42 @@ class SdkSession:
         # 2.1.226: opus/fable/sonnet headless connects all report off + this reason). Keeping
         # it in fast_reason hid the chat toggle on every SDK session — the control that
         # GRANTS the opt-in was gated on already having it (the user 2026-08-10, who switched
-        # to Opus and looked for the toggle). Blank it: the badge shows "Fast off" and a
+        # to Opus and looked for the toggle). Blank it: the badge shows "Slow" and a
         # click cures the reason; every OTHER reason still hides the dead control.
         reason = "" if reason == "sdk_opt_in_required" else reason
+        # A refusal that lands while the user's ask is ARMED (fast_opt — they picked On) is the CLI
+        # ANSWERING that ask, not standing state to hide behind: adopting it silently made the toggle
+        # the user had just clicked vanish without a word, with the ask left armed on disk forever
+        # (the user 2026-08-11, whose tap on a phone was refused with extra_usage_disabled). Fail
+        # loudly instead: tell the user WHY in a warn toast, clear the ask (reg + fast_opt) so the
+        # opt-in flag doesn't stay armed, and reconnect — the flagless connect reports
+        # sdk_opt_in_required, which blanks the reason above, so the badge comes BACK instead of
+        # disappearing under the dead-control rule.
+        refused_ask = bool(reason) and self.fast_opt and fast != "on"
+        if refused_ask:
+            self.fast_opt = False
         changed = fast != self.fast or reason != self.fast_reason
         self.fast, self.fast_reason = fast, reason
-        if changed:
+        if changed or refused_ask:
             try:
-                self.backend._update_reg(self.sid, liveFast=fast, liveFastReason=reason)
+                kw = dict(liveFast=fast, liveFastReason=reason)
+                if refused_ask:
+                    kw["fast"] = False
+                self.backend._update_reg(self.sid, **kw)
             except Exception as e:
                 self.backend._log("fast-state persist (%s): registry write failed: %s" % (self.name, e))
-        return changed
+        if refused_ask:
+            why = _FAST_REFUSALS.get(reason, "the CLI reports %r" % reason)
+            self.backend._log("fast mode (%s): the CLI refused the toggle — %s" % (self.name, reason),
+                              problem=True)
+            try:
+                self.backend._notify("chat", {"type": "warn", "text":
+                    "fast mode isn't available for %s — %s; the pick is back off" % (self.name, why)})
+            except Exception as e:
+                self.backend._log("fast mode (%s): could not tell the chat about the refusal: %s"
+                                  % (self.name, e))
+            self.request_reconnect()
+        return changed or refused_ask
 
     async def _do_adopt_server_info(self):
         """Fast-mode state at CONNECT, before any turn. The init message _adopt_fast_state feeds on

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -567,6 +567,54 @@ class LiveTail(unittest.TestCase):
         self.assertEqual(s.snapshot()["fastReason"], "Fast mode is org-disabled",
                          "a real refusal still hides the toggle")
 
+    def test_a_refusal_answering_the_users_ask_warns_clears_it_and_restores_the_badge(self):
+        """A disabled_reason that lands while the user's ask is ARMED (fast_opt — they picked On) is
+        the CLI ANSWERING that ask, not standing state to hide behind. Adopting it silently was the
+        vanishing-button bug (the user 2026-08-11, whose tap on a phone-width statusline was refused
+        with extra_usage_disabled): the reason hid the very toggle they had just clicked, no word
+        why, and the reg's ask stayed armed forever. The refusal is LOUD now — one warn toast naming
+        the humanized reason — the ask clears (fast_opt + reg, so the opt-in flag doesn't linger),
+        and a flagless reconnect is requested: its connect-time re-probe reports the blanked
+        sdk_opt_in_required, so the badge comes BACK instead of staying vanished."""
+        import asyncio
+        class _Sys:
+            def __init__(self, data): self.subtype = "init"; self.data = data
+        d = tempfile.mkdtemp()
+        notes = []
+        be = sb.SdkBackend(d, "/bin/true", lambda app, msg: notes.append((app, msg)))
+        sid = "11111111-2222-3333-4444-eeeeeeeeeeee"
+        sb.write_reg(d, sid, {"sid": sid, "name": "n", "cwd": "/tmp", "alive": True})
+        s = sb.SdkSession(be, {"sid": sid, "name": "n", "cwd": "/tmp"})
+        s.thread = type("T", (), {"is_alive": lambda self: True})()
+        be.sessions[sid] = s
+        async def _noop(): pass
+        s._do_refresh_context = _noop
+        reconnects = []
+        s.request_reconnect = lambda: reconnects.append(1)
+        async def run(data):
+            s._on_message(_Sys(data), _AssistantMessage, _ResultMessage, _Sys)
+            await asyncio.sleep(0)
+
+        def warns():
+            return [m for _, m in notes if isinstance(m, dict) and m.get("type") == "warn"]
+
+        self.assertTrue(be.set_fast(sid, "on"))          # arms the ask (locked connection → reconnect)
+        self.assertEqual(len(reconnects), 1)
+        asyncio.run(run({"fast_mode_state": "off",
+                         "fast_mode_disabled_reason": "extra_usage_disabled"}))
+        self.assertEqual(len(warns()), 1, "ONE toast says why — a refusal is never a silent vanish")
+        self.assertIn("extra usage", warns()[0]["text"], "the reason is humanized, not the raw token")
+        self.assertFalse(s.fast_opt, "the ask is answered — cleared, not left armed forever")
+        self.assertFalse(sb.read_reg(d, sid)["fast"], "…and cleared on disk, so the next connect is plain")
+        self.assertEqual(len(reconnects), 2, "a flagless reconnect re-probes so the badge comes back")
+        # the same refusal WITHOUT an armed ask stays the quiet dead-control hide it always was
+        asyncio.run(run({"fast_mode_state": "off",
+                         "fast_mode_disabled_reason": "extra_usage_disabled"}))
+        self.assertEqual(len(warns()), 1, "no fresh ask → no re-warn")
+        self.assertEqual(len(reconnects), 2, "…and no reconnect churn")
+        self.assertEqual(s.snapshot()["fastReason"], "extra_usage_disabled",
+                         "the reason still hides the dead control when nobody asked")
+
     def test_the_toggle_turns_own_init_yields_to_the_sent_word_once(self):
         """A literal '/fast on' send opens a turn whose init still reports the state at turn START —
         one word stale, since the toggle applies after it. Taking it verbatim stomps set_fast's

--- a/ui/webview/fast-toggle.test.ts
+++ b/ui/webview/fast-toggle.test.ts
@@ -4,7 +4,8 @@
 // AND the model can run fast mode at all (fastAvailable: the CLI reports "off" with an EMPTY
 // disabled_reason on a non-Opus session, verified 2026-08-10 against 2.1.226 on a fable session, so
 // state alone would leave a dead toggle there). The label is ONE WORD (the user 2026-08-10, on a
-// phone-width statusline): the tint carries on/off. Picking On/Off posts setFast; the kernel delivers
+// phone-width statusline) and the word carries the state: "Fast" on, "Slow" off (the user 2026-08-11 —
+// tint alone didn't say which side the toggle was on). Picking On/Off posts setFast; the kernel delivers
 // the literal "/fast on|off", which the SDK input stream interprets (its CLI descriptor is marked
 // supportsNonInteractive, unlike /model).
 // render.ts has no jsdom harness → source pins (kernel pins ride along, as in the other meta tests).
@@ -28,9 +29,10 @@ test("the fast badge appears only when the session reports a state AND the model
   assert.match(gate, /!m \|\| m === "default" \|\| m\.includes\("opus"\)/);
 });
 
-test("the badge label is one word — the tint, not the label, carries on/off", () => {
+test("the badge label is one word, and the word carries the state: Fast on, Slow off", () => {
   const pf = RENDER.match(/function prettyFast[\s\S]*?\n\}/)?.[0] || "";
-  assert.match(pf, /"Cooldown" : "Fast"/);
+  assert.match(pf, /"Cooldown"/);
+  assert.match(pf, /s === "on" \? "Fast" : "Slow"/);   // off is not a second "Fast" (the user 2026-08-11)
   assert.doesNotMatch(pf, /Fast on|Fast off/);
 });
 
@@ -49,6 +51,17 @@ test("the kernel threads fast_mode_state from the SDK init to the chat status", 
   assert.match(KERNEL, /"fast": st\.get\("fast", ""\)/);                     // merged into the live map
   // a disabled_reason (org-gated / unsupported) hides the toggle rather than offering a dead control
   assert.match(KERNEL, /"fast": "" if tm\.get\("fastReason"\) else tm\.get\("fast", ""\)/);
+});
+
+test("a refusal answering the user's ask is loud — warn toast, ask cleared, badge restored", () => {
+  // Behavior is covered in tests/test_sdk_backend.py; these pins keep the shape findable from the
+  // badge's own test. Before this, the CLI's refusal (e.g. extra_usage_disabled) just hid the toggle
+  // the user had JUST clicked — a silently vanishing button (the user 2026-08-11, on a phone).
+  const adopt = SDK.match(/def _adopt_fast_state[\s\S]*?\n    async def /)?.[0] || "";
+  assert.match(adopt, /refused_ask = bool\(reason\) and self\.fast_opt/);
+  assert.match(adopt, /_FAST_REFUSALS/);                 // humanized reason in the toast
+  assert.match(adopt, /"type": "warn"/);                 // fail loudly, not a vanishing control
+  assert.match(adopt, /self\.request_reconnect\(\)/);    // flagless reconnect → the badge comes back
 });
 
 test("setFast is a drive op that parks like /model and /effort", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6970,10 +6970,13 @@ const FAST_CHOICES: { label: string; value: string }[] = [
 // of the key, not even a last-4 tail, is shipped or shown (2026-08-08, evening). The tab hover's
 // Billing row keeps carrying the fact everywhere.
 // the fast-mode state ("on"/"off"/"cooldown") → the badge label. ONE WORD (the user 2026-08-10, on a
-// phone-width statusline): the on/off fact is carried by the tint — ON wears the CLI's fast orange
-// (metaColor), off the default dim — and the picker's ✓ names the state on click.
+// phone-width statusline), but the WORD carries the state: off reads "Slow", not a second "Fast" —
+// tint alone (orange on, dim off) didn't say which side the toggle was on (the user 2026-08-11).
+// ON keeps the CLI's fast orange (metaColor); the picker's ✓ names the state on click.
 function prettyFast(f: string | undefined): string {
-  return (f || "").toLowerCase() === "cooldown" ? "Cooldown" : "Fast";   // rate-limited: the CLI resumes fast mode when the limit resets
+  const s = (f || "").toLowerCase();
+  return s === "cooldown" ? "Cooldown"   // rate-limited: the CLI resumes fast mode when the limit resets
+    : s === "on" ? "Fast" : "Slow";
 }
 // Whether the session's MODEL can run fast mode at all (the CLI's /fast is an Opus-only research
 // preview). Gated HERE, on the model, because the CLI is no help: fast_mode_state arrives "off" with


### PR DESCRIPTION
Tapping the statusline's fast toggle On could make the whole badge disappear with no explanation: the reconnect's CLI refusal (e.g. `extra_usage_disabled` — the account has extra usage turned off) landed as a `fastReason`, which hides the control under the dead-control rule. The button the user had just clicked silently vanished, and the armed ask (`fast: true`) stayed in the registry forever, re-arming the opt-in flag at every future connect.

**A refusal that answers the user's ask is now loud, and self-healing:**
- One warn toast names the humanized reason (`_FAST_REFUSALS`; unmapped tokens shown raw).
- The ask clears — `fast_opt` and the reg — so the opt-in flag doesn't linger armed.
- A flagless reconnect re-probes: its `sdk_opt_in_required` blanks the reason, so the badge comes back instead of staying gone.
- A reason with NO armed ask keeps the quiet dead-control hide it always had.

**And the badge's word now carries the state** — **Fast** (orange) on, **Slow** off, **Cooldown** while rate-limited — because tint alone didn't say which side the toggle was on (phone-width statusline, 2026-08-11).

Tests: new `test_a_refusal_answering_the_users_ask_warns_clears_it_and_restores_the_badge` (warn once, reg + fast_opt cleared, second reconnect, no re-warn without a fresh ask); `fast-toggle.test.ts` label pins updated plus shape pins for the refusal path; docs/reference.md updated. Full local runs: 4210 Python OK, 1819 node OK, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)