### PR TITLE
The dir field's verdict moves INTO the box: compact hint at the right end, second row gone

### DIFF
--- a/ui/webview/dir-complete.test.ts
+++ b/ui/webview/dir-complete.test.ts
@@ -1,12 +1,13 @@
-// The new-session directory field (the user 2026-07-28): what the status line says about a typed path,
-// how the keyboard walks the folder list, and how the "that folder isn't there" dialog reads. EXECUTES
-// ./dir-complete; the picker plumbing (the request/reply pacing, the create fork, the host routing) is
-// source-pinned against render.ts below.
+// The new-session directory field (the user 2026-07-28): what the verdict says about a typed path
+// (the full sentence, and the compact form shown inside the field), how the keyboard walks the folder
+// list, and how the "that folder isn't there" dialog reads. EXECUTES ./dir-complete; the picker
+// plumbing (the request/reply pacing, the create fork, the host routing) is source-pinned against
+// render.ts below.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { dirStatusLine, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
+import { dirStatusLine, dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8")
   + fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
@@ -53,6 +54,60 @@ test("an unreachable path says so rather than offering to create it", () => {
 
 test("no answer yet says nothing at all", () => {
   assert.deepEqual(dirStatusLine(null), { text: "", cls: "" });
+});
+
+// ── the compact in-box form (the user 2026-08-11): the verdict sits inside the field, so it never
+// repeats the path sitting right beside it — unless the kernel's expansion ADDS something — and the
+// full sentence (dirStatusLine, wording history above) rides on hover as `title`.
+test("an existing folder's hint is a bare ✓ when the kernel's path IS what was typed", () => {
+  const said = dirStatusHint(st({}));
+  assert.deepEqual(said, { text: "✓", cls: "", title: "✓ ~/GitRepos/api" });
+  assert.equal(dirStatusHint(st({ value: "~/GitRepos/api/" })).text, "✓",
+    "a trailing slash is not an expansion worth echoing");
+});
+
+test("…and shows the expansion when ~ / $VARs resolved to something new", () => {
+  assert.equal(dirStatusHint(st({ value: "$REPOS/api" })).text, "✓ ~/GitRepos/api");
+});
+
+test("a blank field's hint names the default that blank stands for", () => {
+  const said = dirStatusHint(st({ value: "", isDefault: true }));
+  assert.equal(said.text, "~/GitRepos/api (the default)");
+  assert.equal(said.cls, "");
+});
+
+test("a missing folder's hint is the offer, with the named-path sentence a hover away", () => {
+  const said = dirStatusHint(st({ exists: false, isDir: false, canCreate: true, missing: 1 }));
+  assert.equal(said.cls, "warn");
+  assert.equal(said.text, "will be created");
+  assert.match(said.title, /Starting will create ~\/GitRepos\/api$/,
+    "the 2026-07-29 'which folder, where' answer still exists — on hover");
+  const deep = dirStatusHint(st({ exists: false, isDir: false, canCreate: true, missing: 3 }));
+  assert.equal(deep.text, "will be created (3 folders)");
+});
+
+test("bad paths read as verdicts, not path echoes — the path is already in the box", () => {
+  const file = dirStatusHint(st({ isDir: false, isFile: true, canCreate: false }));
+  assert.deepEqual([file.text, file.cls], ["a file, not a folder", "bad"]);
+  const gone = dirStatusHint(st({ exists: false, isDir: false, canCreate: false, nearest: "" }));
+  assert.deepEqual([gone.text, gone.cls], ["invalid path", "bad"]);
+});
+
+test("no answer yet: the hint says nothing and carries no stale title", () => {
+  assert.deepEqual(dirStatusHint(null), { text: "", cls: "", title: "" });
+});
+
+test("the hint lives IN the field — no second row under it", () => {
+  assert.match(RENDER, /el\("span", "picker-dir-hint"\); dirHint\.id = "picker-dir-hint"/);
+  assert.match(RENDER, /hint\.title = said\.title;/, "the full sentence rides on hover");
+  // the typed text must stop where the hint starts: the input's right padding is measured off the
+  // rendered hint, never guessed
+  assert.match(RENDER, /input\.style\.paddingRight = said\.text && w \? w \+ 16 \+ "px" : ""/);
+  // a press on the hint belongs to the input underneath
+  assert.match(RENDER, /dirHint\.addEventListener\("mousedown"/);
+  assert.doesNotMatch(RENDER, /picker-dir-status/, "the old status row is gone, not merely hidden");
+  assert.match(STYLES, /\.picker-dir-hint \{/);
+  assert.doesNotMatch(STYLES, /picker-dir-status/);
 });
 
 test("walking the list passes through 'nothing chosen' at both ends", () => {
@@ -128,8 +183,8 @@ test("opening the picker asks about the path but does NOT drop a folder list ove
 });
 
 test("the field itself goes red for a path that cannot work, amber for one that isn't there yet", () => {
-  assert.match(RENDER, /box\.classList\.toggle\("bad", said\.cls === "bad"\)/);
-  assert.match(RENDER, /box\.classList\.toggle\("warn", said\.cls === "warn"\)/);
+  assert.match(RENDER, /input\.classList\.toggle\("bad", said\.cls === "bad"\)/);
+  assert.match(RENDER, /input\.classList\.toggle\("warn", said\.cls === "warn"\)/);
   assert.match(STYLES, /\.picker-dir-input\.bad \{ border-color: #e5484d;/);
   assert.match(STYLES, /\.picker-dir-input\.warn \{ border-color: #e0a030; \}/);
 });

--- a/ui/webview/dir-complete.ts
+++ b/ui/webview/dir-complete.ts
@@ -9,7 +9,9 @@ export interface DirStatus {
   canCreate: boolean; nearest: string; missing: number; isDefault: boolean;
 }
 
-/** One line saying what the typed path IS, and the tone to say it in. "" = say nothing (no answer yet). */
+/** The full sentence saying what the typed path IS, and the tone to say it in. "" = say nothing (no
+ *  answer yet). This is the hint's hover title (and the wording history below still governs it);
+ *  what sits IN the field is dirStatusHint's compact form. */
 export function dirStatusLine(s: DirStatus | null): { text: string; cls: string } {
   if (!s) return { text: "", cls: "" };
   if (s.isDefault) return { text: s.path + "  (the default)", cls: "" };
@@ -27,6 +29,28 @@ export function dirStatusLine(s: DirStatus | null): { text: string; cls: string 
     return { text: `no such folder yet. Starting will create ${s.path}${above}`, cls: "warn" };
   }
   return { text: "invalid path: " + s.path, cls: "bad" };
+}
+
+/** The compact verdict shown INSIDE the field, at its right edge (the user 2026-08-11, folding the
+ *  status line into the box to save the row). The path itself is the text sitting beside the hint, so
+ *  the hint only repeats it when the kernel's expansion ADDS something (~ / $VARs resolved, or the
+ *  default a blank field stands for); everything longer — the full sentence, with the path named
+ *  outright — rides in `title` for hover, so the 2026-07-29 "which folder, where" answer is one hover
+ *  away instead of a second line. */
+export function dirStatusHint(s: DirStatus | null): { text: string; cls: string; title: string } {
+  const full = dirStatusLine(s);
+  if (!s) return { ...full, title: "" };
+  if (s.isDefault) return { text: s.path + " (the default)", cls: "", title: full.text };
+  if (s.isDir) {
+    const typed = s.value.replace(/\/+$/, "") || s.value;
+    return { text: s.path === typed ? "✓" : "✓ " + s.path, cls: "", title: full.text };
+  }
+  if (s.isFile) return { text: "a file, not a folder", cls: "bad", title: full.text };
+  if (s.canCreate) {
+    const n = s.missing > 1 ? ` (${s.missing} folders)` : "";
+    return { text: `will be created${n}`, cls: "warn", title: full.text };
+  }
+  return { text: "invalid path", cls: "bad", title: full.text };
 }
 
 /** Walk the completion list. -1 ("nothing chosen") is part of the cycle in BOTH directions, so walking

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -28,7 +28,7 @@ import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
 import { previewKind, previewFull, canPreview, fileUrl } from "./preview";
 import { hostNameNodes, hostPrefix, hostIsDown, hostDownNote } from "./host-prefix";
-import { dirStatusLine, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
+import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
 import { apiErrorReason } from "./api-error-reason";
@@ -4483,30 +4483,35 @@ function closeDirMenu(): void {
   dirActive = -1;
 }
 
-// The status line is the one-glance version: what this path is right now. The menu underneath is the
-// deeper level, and it only exists while there is something to choose.
+// The verdict is the one-glance version: what this path is right now, folded INTO the field's right
+// end (the user 2026-08-11, trading the second row for an in-box hint) — the full sentence rides on
+// hover. The menu underneath is the deeper level, and it only exists while there is something to choose.
 function renderDirMenu(truncated: boolean): void {
-  const line = document.getElementById("picker-dir-status");
-  const said = dirStatus || !dirInFlight ? dirStatusLine(dirStatus)
-    : { text: dirAskedHost ? `checking on ${dirAskedHost}…` : "checking…", cls: "" };
-  if (line) {
-    line.className = "picker-dir-status" + (said.cls ? " " + said.cls : "");
-    line.textContent = said.text;
+  const hint = document.getElementById("picker-dir-hint");
+  const said = dirStatus || !dirInFlight ? dirStatusHint(dirStatus)
+    : { text: dirAskedHost ? `checking on ${dirAskedHost}…` : "checking…", cls: "", title: "" };
+  const input = document.getElementById("picker-dir") as HTMLInputElement | null;
+  if (hint) {
+    hint.className = "picker-dir-hint" + (said.cls ? " " + said.cls : "");
+    hint.textContent = said.text;
+    hint.title = said.title;
+    // the hint borrows the box's right end, so the typed text must stop where it starts — measured,
+    // not guessed (the width varies by verdict and ellipsis cap; 0 = the field is folded away)
+    const w = hint.offsetWidth;
+    if (input) input.style.paddingRight = said.text && w ? w + 16 + "px" : "";
   }
   // and the FIELD itself carries it (the user 2026-07-29): a path that cannot work goes red where the
-  // path is, not only in a line under it, so the problem is visible without reading anything.
-  const box = document.getElementById("picker-dir");
-  if (box) {
-    box.classList.toggle("bad", said.cls === "bad");
-    box.classList.toggle("warn", said.cls === "warn");
+  // path is, not only in a hint at its edge, so the problem is visible without reading anything.
+  if (input) {
+    input.classList.toggle("bad", said.cls === "bad");
+    input.classList.toggle("warn", said.cls === "warn");
   }
-  const input = document.getElementById("picker-dir");
   const menu = document.getElementById("picker-dir-menu");
   if (!menu) return;
   menu.replaceChildren();
   // Only when you are IN the field (the user 2026-07-29): opening the + picker asks the kernel about the
-  // prefilled path so the status line can vet it straight away, and that answer used to drop a folder
-  // list over the dialog before anyone had touched it. The status is the passive half; the menu is the
+  // prefilled path so the hint can vet it straight away, and that answer used to drop a folder
+  // list over the dialog before anyone had touched it. The hint is the passive half; the menu is the
   // half you asked for by putting the cursor there.
   if (!dirItems.length || document.activeElement !== input) { menu.style.display = "none"; return; }
   dirItems.forEach((it, i) => {
@@ -4643,6 +4648,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     // user 2026-08-11, offered a long-gone folder next to the real one). The completer asks the OWNING
     // kernel — the authoritative source — so the stale-capable history list is gone, not merely hidden.
     const dirWrap = el("div", "picker-dir");
+    const dirField = el("span", "picker-dir-field");   // input + its in-box verdict share one box
     const dirInput = el("input", "picker-dir-input") as HTMLInputElement;
     dirInput.id = "picker-dir";
     dirInput.spellcheck = false;
@@ -4653,14 +4659,21 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     browseBtn.type = "button"; browseBtn.textContent = "Browse…";
     browseBtn.title = "Pick a folder with the native dialog (opens on the kernel's machine — host-local)";
     browseBtn.addEventListener("click", () => { if (vscodeApi) vscodeApi.postMessage({ type: "browseDir" }); });
-    // the completer's dropdown + the one-line status of whatever is typed, both fed by the owning kernel
+    // the completer's dropdown + the typed path's verdict, both fed by the owning kernel. The verdict
+    // sits IN the box, right-aligned and non-editable (the user 2026-08-11); a press on it belongs to
+    // the input underneath, so it hands the focus (and the caret's usual click-the-empty-end spot) over.
     const dirMenu = el("div", "picker-dir-menu"); dirMenu.id = "picker-dir-menu"; dirMenu.style.display = "none";
-    const dirStat = el("div", "picker-dir-status"); dirStat.id = "picker-dir-status";
+    const dirHint = el("span", "picker-dir-hint"); dirHint.id = "picker-dir-hint";
+    dirHint.addEventListener("mousedown", (e) => {
+      e.preventDefault(); dirInput.focus();
+      dirInput.setSelectionRange(dirInput.value.length, dirInput.value.length);
+    });
     dirInput.addEventListener("input", () => askDirComplete(dirInput.value));
     dirInput.addEventListener("focus", () => askDirComplete(dirInput.value));
     dirInput.addEventListener("blur", () => closeDirMenu());   // a row's mousedown preventDefaults, so it never blurs
-    dirWrap.appendChild(dirInput); dirWrap.appendChild(browseBtn);
-    dirWrap.appendChild(dirMenu); dirWrap.appendChild(dirStat);
+    dirField.appendChild(dirInput); dirField.appendChild(dirHint);
+    dirWrap.appendChild(dirField); dirWrap.appendChild(browseBtn);
+    dirWrap.appendChild(dirMenu);
     // per-session BACKEND picker (the user 2026-06-23): a tmux | SDK segmented toggle, defaulting to the
     // gear's Default backend but overridable for THIS new session. Hidden in pick-mode (like dirWrap).
     const beWrap = el("div", "picker-backend");

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1868,10 +1868,13 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
   border-bottom: 1px solid var(--box-border);
 }
 .picker-error.show { display: block; }
-/* the row wraps so the completer's status line gets its own line under the field; the folder menu is
+/* one line: the verdict lives inside the field now, not on a second row; the folder menu is
    absolutely positioned so it lays OVER the rows below instead of shoving the dialog around */
-.picker-dir { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; padding: 8px 14px; border-top: 1px solid var(--box-border); position: relative; }
+.picker-dir { display: flex; align-items: center; gap: 6px; padding: 8px 14px; border-top: 1px solid var(--box-border); position: relative; }
 .picker-dir::before { content: "📁"; opacity: 0.55; font-size: 0.9em; flex: 0 0 auto; }
+/* the input and its in-box verdict share one box: the hint overlays the input's right end, and
+   render.ts reserves that much input padding so the typed path never runs under it */
+.picker-dir-field { position: relative; flex: 1 1 auto; display: flex; min-width: 0; }
 .picker-dir-input {
   flex: 1 1 auto; min-width: 0;
   background: rgba(255, 255, 255, 0.05);
@@ -1898,15 +1901,18 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
    it says unavailable. The title explains, and the field beside it still works. */
 .picker-browse:disabled { opacity: 0.4; cursor: not-allowed; }
 .picker-browse:disabled:hover { background: rgba(255, 255, 255, 0.06); }
-/* the typed path's one-line verdict from the kernel that would own the session (exists / will be
-   created / is a file), so the answer arrives before the create does (the user 2026-07-28) */
-.picker-dir-status {
-  flex: 1 0 100%; margin-top: 4px; min-width: 0;
+/* the typed path's verdict from the kernel that would own the session (exists / will be created / is
+   a file), so the answer arrives before the create does (the user 2026-07-28) — folded into the
+   field's right end as non-editable text (the user 2026-08-11): compact by default, the full sentence
+   on hover. cursor:text because a press on it falls through to the input. */
+.picker-dir-hint {
+  position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
+  max-width: 55%; cursor: text;
   color: var(--dim); font-family: var(--mono, monospace); font-size: 0.82em;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.picker-dir-status.warn { color: #e0a030; }
-.picker-dir-status.bad { color: #e5484d; }
+.picker-dir-hint.warn { color: #e0a030; }
+.picker-dir-hint.bad { color: #e5484d; }
 /* folder completions: Tab walks into one, so a path is assembled without a modal or a native dialog */
 .picker-dir-menu {
   position: absolute; left: 14px; right: 14px; top: calc(100% - 4px); z-index: 6;


### PR DESCRIPTION
The new-session picker's directory field carried a second row under the box for the kernel's verdict on the typed path. That row is now folded into the field itself: a right-aligned, non-editable hint in the verdict's color (dim / amber / red), reserved out of the typing area by measured input padding, with the full sentence (which names the expanded path outright) riding on hover.

The compact grammar never repeats the path sitting right beside it unless the kernel's expansion adds something: an existing folder is a bare check (or the expansion when ~/$VARs resolved), a blank field names the default it stands for, a missing folder says "will be created" (with the folder count when parents are missing too), a file or unreachable path reads as the plain verdict. A press on the hint hands focus to the input underneath.

dirStatusHint() joins dirStatusLine() in dir-complete.ts (the full line is the hover title and keeps its wording history); render.ts swaps the status div for the in-box span; styles.css drops the second-row block. Executed tests for every hint form plus source pins that the old status row is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)