### PR TITLE
Usage rows with nothing to show stop holding ghost space in the strip

### DIFF
--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -29,6 +29,11 @@
 #romp-strip[data-tier="2"] .ru-pct, #romp-strip[data-tier="3"] .ru-pct { display: none; }
 #romp-strip[data-tier="3"] .ru-name { display: none; }
 #romp-strip[data-tier="2"] #strip-usage, #romp-strip[data-tier="3"] #strip-usage { gap: 10px; }
+/* a TEXT-ONLY row (strip.ts: no tracks — a spend window with no budget carries dollars, no fill) says
+   nothing once tier 2 hides the readout, its only content: the whole row drops out instead of holding
+   ghost space open (the user 2026-08-11 — three invisible rows drew a fake dead gap mid-strip), and
+   the reclaimed width lets fit() settle on a more legible tier */
+#romp-strip[data-tier="2"] .ru-textonly, #romp-strip[data-tier="3"] .ru-textonly { display: none; }
 #strip-gear { flex: 0 0 auto; background: transparent; border: 1px solid transparent; border-radius: 5px;
   color: var(--vscode-descriptionForeground, #9aa0a6); font-size: 15px; line-height: 1; cursor: pointer;
   padding: 2px 6px; opacity: .8; }

--- a/ui/webview/strip.test.ts
+++ b/ui/webview/strip.test.ts
@@ -6,7 +6,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { usageColor, fmtAgo, fmtReset, usageWindows, STRIP_PANES } from "./strip";
+import { usageColor, fmtAgo, fmtReset, usageWindows, spendWindows, STRIP_PANES } from "./strip";
 
 test("usageColor mirrors the rail's green/amber/red ramp", () => {
   assert.equal(usageColor(0), "#54B204");
@@ -145,6 +145,28 @@ test("both bundles init the strip; the web pages never opt in", () => {
   assert.ok(read("feed.ts").includes("initStrip("), "feed bundle must init the strip");
   const kernel = fs.readFileSync(path.join(ROOT, "bin", "romp-kernel"), "utf8");
   assert.ok(!kernel.includes("__rompShowStrip"), "the web shell keeps its own rail — no strip opt-in kernel-side");
+});
+
+test("a spend window with no budget has no honest fraction — dollars in the readout, no fill", () => {
+  const ws = spendWindows({ spend: { fiveHour: { usd: 12.34, tok: 3_456_000, turns: 5 } } }, 100_000);
+  assert.equal(ws.length, 1);
+  assert.equal(ws[0].pct, null, "no budget → no fraction to fill");
+  assert.equal(ws[0].elapsedPct, null, "a rolling window has no reset boundary to pace against");
+  assert.equal(ws[0].readout, "$12 · 3.5M tok");
+});
+
+test("a readout-only row holds no empty bar slot, and drops out with its text (the user 2026-08-11)", () => {
+  // A wide feed pane showed a bare "?", naked unlabeled bars, and a fake dead gap mid-strip: six
+  // windows forced the ladder to tier 3, where the three budget-less spend rows — no tracks, readout
+  // hidden — each kept an invisible 54px bar slot open. A row with no tracks appends no bars element
+  // at all, and .ru-textonly lets tiers 2/3 (which hide .ru-pct, the row's only content) drop the
+  // whole row, so the reclaimed width lets fit() settle on a legible tier instead.
+  const ROOT = path.resolve(process.cwd(), "..");
+  const src = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
+  assert.match(src, /if \(bars\.childElementCount\) box\.append\(name, bars, pct\);/);
+  assert.match(src, /else \{ box\.classList\.add\("ru-textonly"\); box\.append\(name, pct\); \}/);
+  const css = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.css"), "utf8");
+  assert.match(css, /#romp-strip\[data-tier="2"\] \.ru-textonly, #romp-strip\[data-tier="3"\] \.ru-textonly \{ display: none; \}/);
 });
 
 test("an unknown window draws NO bars — just a '?' in their slot (the user 2026-07-31, round 2)", () => {

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -292,7 +292,13 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
         const pct = document.createElement("span");
         pct.className = "ru-pct";
         pct.textContent = w.readout ?? `${w.pct}%`;
-        box.append(name, bars, pct);
+        // A row with no tracks (a spend window with no budget: dollars only, no honest fill) is
+        // TEXT-ONLY. Appending its empty bar slot anyway held 54px of nothing open — and once the
+        // narrow tiers hid the readout too, the row was pure ghost space: a wide feed pane showed a
+        // bare "?", naked bars, and a fake dead gap (the user 2026-08-11). No empty slot, and the
+        // class lets the tier ladder drop the whole row once its text is gone (strip.css).
+        if (bars.childElementCount) box.append(name, bars, pct);
+        else { box.classList.add("ru-textonly"); box.append(name, pct); }
       }
       usageWrap.appendChild(box);
     }


### PR DESCRIPTION
The VS Code feed pane's bottom strip read as broken (the user 2026-08-11, screenshot): a bare "?", two naked unlabeled bar-pairs, and a wide dead gap before the quick-open buttons. Six usage windows (three subscription + three budget-less spend rows) forced the measured fit() ladder down to tier 3, where labels and readouts are hidden — and each spend row, which never has tracks (dollars only, no honest fill), kept an invisible 54px empty bar slot open. Three ghost rows plus gaps drew ~200px of fake dead space, and the ladder never settled anywhere legible.

Two changes, both in the strip: a row with no tracks appends no bar slot at all, and it is marked .ru-textonly so tiers 2/3 — which hide .ru-pct, the row's only content — drop the whole row instead of keeping ghost space open. The reclaimed width lets fit() settle at a tier that still shows the short window tags, so the same pane now reads "5h ? · 7d · F5" instead of three cryptic marks and a hole. No information is lost relative to today: those rows were already invisible at the compressed tiers.

Adds a spendWindows no-budget unit test and source/CSS pins for the no-empty-slot and drop-out rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)