### PR TITLE
The strip's key spend becomes the rail's API cell: dollars under one label, never rows of bars

### DIFF
--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -46,16 +46,21 @@ test("the kernel serves spend windows for BOTH payload shapes, keyed-only beside
   assert.ok(BACKEND.includes("_fold(hours, hour, 192)"), "8 days of hour buckets feed the rolling windows");
 });
 
-test("VS Code strip: spend rows key on the windows' PRESENCE, one row builder for both kinds", () => {
-  assert.match(STRIP, /export function spendWindows\(usage: any, nowS: number\): UsageWindow\[\]/);
-  // presence, not the apiKey flag: a mixed host's payload carries bars AND spend at once
+test("VS Code strip: spend is ONE API cell keyed on the windows' PRESENCE — the rail's twin", () => {
+  // the strip mirrors apiCellHTML (the user 2026-08-11: the rail moved to the cell and the strip must
+  // reflect it): constant 'API' label, 5-hour burn + month-to-date as designator → dollars·tokens
+  // pairs, the full breakdown (7 days, turn counts) on the hover title. Spend-as-rows is gone.
+  assert.match(STRIP, /export function apiCell\(usage: any\): ApiCell \| null/);
+  // presence, not the apiKey flag: a mixed host's payload carries bars AND spend at once — and the
+  // 5h window is the whole test, the same hasSpend branch the rail runs
   assert.ok(STRIP.includes("const sp = usage && usage.spend;"));
+  assert.ok(STRIP.includes("if (!sp || !sp.fiveHour) return null;"));
   assert.doesNotMatch(STRIP, /usage\.apiKey && usage\.spend/);
-  assert.match(STRIP, /usageWindows\(usage, nowS\)\.concat\(spendWindows\(usage, nowS\)\)/);
-  // labels mirror the subscription table's two-tier form; dollars AND tokens stay visible
-  assert.match(STRIP, /\["fiveHour", "5 hours", "5h"\]/);
-  assert.match(STRIP, /\["month", "Month", "mo"\]/);
-  assert.match(STRIP, /\+ " · " \+ fmtTok\(seg\.tok \|\| 0\) \+ " tok"/);
+  assert.doesNotMatch(STRIP, /spendWindows/, "spend never renders as window rows any more");
+  // the collapsed cell carries 5h + month (like the rail's seg('fiveHour')+seg('month')); one display
+  // name per window, dollars AND tokens beside each other
+  assert.match(STRIP, /\[\["fiveHour", "5 hours", "5h"\], \["month", "Month", "mo"\]\]/);
+  assert.match(STRIP, /tok\.textContent = " · " \+ fmtTok\(s\.tok\) \+ " tok";/);
   // the old one-off chip is gone, and with it any minted style
   assert.doesNotMatch(STRIP, /spendChip/);
   assert.doesNotMatch(STRIPCSS, /\.ru-spend/);
@@ -103,8 +108,8 @@ test("dollars are WHOLE everywhere — no cents on any spend surface", () => {
   const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
   assert.ok(usageJS.includes("function fmtUsd(v){return '$'+String(Math.round(v));}"));
   assert.ok(!usageJS.includes("toFixed(2)"), "no cents anywhere in the rail JS");
-  assert.match(STRIP, /readout: "\$" \+ Math\.round\(seg\.usd\)/);
-  assert.match(STRIP, /title: label \+ " — \$" \+ Math\.round\(seg\.usd\)/);
+  assert.match(STRIP, /export function fmtUsd\(v: number\): string \{ return "\$" \+ String\(Math\.round\(v\)\); \}/,
+    "the strip rounds through the same one formatter");
   assert.doesNotMatch(STRIP, /usd\.toFixed\(2\)/);
 });
 

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -29,11 +29,14 @@
 #romp-strip[data-tier="2"] .ru-pct, #romp-strip[data-tier="3"] .ru-pct { display: none; }
 #romp-strip[data-tier="3"] .ru-name { display: none; }
 #romp-strip[data-tier="2"] #strip-usage, #romp-strip[data-tier="3"] #strip-usage { gap: 10px; }
-/* a TEXT-ONLY row (strip.ts: no tracks — a spend window with no budget carries dollars, no fill) says
-   nothing once tier 2 hides the readout, its only content: the whole row drops out instead of holding
-   ghost space open (the user 2026-08-11 — three invisible rows drew a fake dead gap mid-strip), and
-   the reclaimed width lets fit() settle on a more legible tier */
-#romp-strip[data-tier="2"] .ru-textonly, #romp-strip[data-tier="3"] .ru-textonly { display: none; }
+/* the API spend cell — the rail's apiCellHTML twin (strip.ts apiCell): a constant "API" label, then
+   designator → dollars·tokens pairs, NO bars (the numbers are the information). The dollars wear
+   their own class so the tiers never hide them on a key-billed machine: tier 2 folds the token halves,
+   tier 3 folds the labels like every other row, the value stays at every tier. */
+.ru-w.ru-api { gap: 6px; }
+.ru-apiv { font: 600 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #cfe6ff;
+  font-variant-numeric: tabular-nums; white-space: nowrap; }
+#romp-strip[data-tier="2"] .ru-apitok, #romp-strip[data-tier="3"] .ru-apitok { display: none; }
 #strip-gear { flex: 0 0 auto; background: transparent; border: 1px solid transparent; border-radius: 5px;
   color: var(--vscode-descriptionForeground, #9aa0a6); font-size: 15px; line-height: 1; cursor: pointer;
   padding: 2px 6px; opacity: .8; }

--- a/ui/webview/strip.test.ts
+++ b/ui/webview/strip.test.ts
@@ -6,7 +6,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { usageColor, fmtAgo, fmtReset, usageWindows, spendWindows, STRIP_PANES } from "./strip";
+import { usageColor, fmtAgo, fmtReset, fmtUsd, usageWindows, apiCell, STRIP_PANES } from "./strip";
 
 test("usageColor mirrors the rail's green/amber/red ramp", () => {
   assert.equal(usageColor(0), "#54B204");
@@ -147,26 +147,45 @@ test("both bundles init the strip; the web pages never opt in", () => {
   assert.ok(!kernel.includes("__rompShowStrip"), "the web shell keeps its own rail — no strip opt-in kernel-side");
 });
 
-test("a spend window with no budget has no honest fraction — dollars in the readout, no fill", () => {
-  const ws = spendWindows({ spend: { fiveHour: { usd: 12.34, tok: 3_456_000, turns: 5 } } }, 100_000);
-  assert.equal(ws.length, 1);
-  assert.equal(ws[0].pct, null, "no budget → no fraction to fill");
-  assert.equal(ws[0].elapsedPct, null, "a rolling window has no reset boundary to pace against");
-  assert.equal(ws[0].readout, "$12 · 3.5M tok");
+// ── the API spend CELL (the user 2026-08-11): the rail moved key spend to one compact cell — "API",
+// then the 5-hour burn and the month-to-date as designator → dollars·tokens pairs, no bars — and the
+// strip must mirror it. Spend-as-rows was the old grammar; on a key-billed machine it read as broken.
+test("apiCell arms on the spend windows' presence and carries the 5-hour burn + month-to-date", () => {
+  const cell = apiCell({ spend: {
+    fiveHour: { usd: 12.34, tok: 3_456_000, turns: 5 },
+    sevenDay: { usd: 40.2, tok: 9_000_000, turns: 21 },
+    month: { usd: 87.9, tok: 20_500_000, turns: 60 },
+  } });
+  assert.ok(cell);
+  assert.deepEqual(cell!.segs.map((s) => [s.key, s.label, s.short]),
+    [["fiveHour", "5 hours", "5h"], ["month", "Month", "mo"]],
+    "the collapsed cell shows 5h + month only — 7 days lives in the hover");
+  assert.deepEqual(cell!.segs.map((s) => fmtUsd(s.usd)), ["$12", "$88"], "whole dollars, no cents");
+  assert.match(cell!.title, /^API-key spend\n/);
+  assert.match(cell!.title, /7 days — \$40 · 9M tok · 21 turns/, "the hover keeps the full breakdown");
+  assert.match(cell!.title, /5 hours — \$12 · 3\.5M tok · 5 turns/);
 });
 
-test("a readout-only row holds no empty bar slot, and drops out with its text (the user 2026-08-11)", () => {
-  // A wide feed pane showed a bare "?", naked unlabeled bars, and a fake dead gap mid-strip: six
-  // windows forced the ladder to tier 3, where the three budget-less spend rows — no tracks, readout
-  // hidden — each kept an invisible 54px bar slot open. A row with no tracks appends no bars element
-  // at all, and .ru-textonly lets tiers 2/3 (which hide .ru-pct, the row's only content) drop the
-  // whole row, so the reclaimed width lets fit() settle on a legible tier instead.
+test("no key spend → no cell; and no fragment of any key ever reaches the strip", () => {
+  assert.equal(apiCell(null), null);
+  assert.equal(apiCell({ spend: {} }), null, "presence of the 5h window is the whole test — the rail's hasSpend branch");
   const ROOT = path.resolve(process.cwd(), "..");
   const src = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
-  assert.match(src, /if \(bars\.childElementCount\) box\.append\(name, bars, pct\);/);
-  assert.match(src, /else \{ box\.classList\.add\("ru-textonly"\); box\.append\(name, pct\); \}/);
+  assert.ok(!src.includes("apiTail") && !src.includes("authTail"), "constant 'API' label — no key-tail plumbing");
+});
+
+test("the cell's dollars survive every tier; tokens fold at tier 2, labels at 3 (source pins)", () => {
+  const ROOT = path.resolve(process.cwd(), "..");
+  const src = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
+  assert.match(src, /box\.className = "ru-w ru-api";/);
+  assert.match(src, /lbl\.textContent = "API";/);
+  assert.match(src, /val\.className = "ru-apiv";/, "dollars wear their own class, never .ru-pct");
+  assert.match(src, /tok\.className = "ru-apitok";/);
+  assert.doesNotMatch(src, /spendWindows/, "spend-as-rows is gone, not merely unused");
   const css = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.css"), "utf8");
-  assert.match(css, /#romp-strip\[data-tier="2"\] \.ru-textonly, #romp-strip\[data-tier="3"\] \.ru-textonly \{ display: none; \}/);
+  assert.match(css, /\.ru-apiv \{ font: 600 10px/);
+  assert.match(css, /#romp-strip\[data-tier="2"\] \.ru-apitok, #romp-strip\[data-tier="3"\] \.ru-apitok \{ display: none; \}/);
+  assert.doesNotMatch(css, /ru-textonly/, "the ghost-row mechanism died with spend-as-rows");
 });
 
 test("an unknown window draws NO bars — just a '?' in their slot (the user 2026-07-31, round 2)", () => {

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -17,11 +17,10 @@
 import { kernelUrl } from "./media";
 
 export type UsageWindow = {
-  readout?: string;     // overrides the % readout (a spend row shows dollars)
   key: string;
   label: string;        // the rail's expanded label
   short: string;        // the compressed tag a narrow strip swaps in ("5h" / "7d" / "F5")
-  pct: number | null;   // used % of the limit / budget (LAST-KNOWN when unknown — drawn faded); null = no honest denominator (a spend row with no budget)
+  pct: number | null;   // used % of the limit (LAST-KNOWN when unknown — drawn faded)
   elapsedPct: number | null;  // % of the window elapsed (pace comparison)
   unknown: boolean;     // the window reset since the last report — the reading no longer describes the present
   title: string;        // hover detail
@@ -92,48 +91,38 @@ export function fmtTok(n: number): string {
   return String(n);
 }
 
-// API-key SPEND windows mirror the subscription bars' grammar exactly — same rows, same labels,
-// same twin tracks — so flipping between the two auth modes reads instantly (the user 2026-08-04, who
-// asked for "5 hours / week / month, visually similar"). A row FILLS only when spend-budgets.json names
-// that window's budget: the fill is spend-over-budget, and without a cap there is no honest fraction —
-// the row then carries plain dollars in the readout slot and no used-track. Rolling windows (5h/7d)
-// have no reset boundary, so only month-to-date draws the elapsed track. Keyed on the spend windows'
-// PRESENCE, not the apiKey flag: with per-session auth a host's payload carries bars AND its key's
-// spend at once (the user 2026-08-08), and the strip should show both, not silently drop the dollars.
-export const SPEND_WINS: Array<[string, string, string]> = [
-  ["fiveHour", "5 hours", "5h"],
-  ["sevenDay", "7 days", "7d"],
-  ["month", "Month", "mo"],
-];
-export function spendWindows(usage: any, nowS: number): UsageWindow[] {
+// API-key spend is ONE compact CELL, the strip twin of the web rail's apiCellHTML (the user
+// 2026-08-11: the rail moved to this presentation and the strip must reflect it — spend rendered as
+// three bar-less window rows was the OLD grammar, and on a key-billed machine it read as broken).
+// Spend is NUMBERS, never bars (the user 2026-08-08: the spend bar graphs told you nothing): a
+// constant "API" label — no fragment of any key, not even a last-4 tail, reaches a surface — then the
+// 5-hour burn and the month-to-date, dollars AND tokens (the user 2026-08-09), each designator the
+// window's ONE display name to the LEFT of its value. The full per-window breakdown (7 days and turn
+// counts included) rides the cell's hover title. Keyed on the spend windows' PRESENCE, not the legacy
+// apiKey flag — the same hasSpend branch the rail runs; rail-spend.test.ts holds the two in step.
+export function fmtUsd(v: number): string { return "$" + String(Math.round(v)); }   // whole dollars everywhere — no cents (the user 2026-08-09)
+export type ApiCell = {
+  segs: Array<{ key: string; label: string; short: string; usd: number; tok: number }>;
+  title: string;
+};
+export function apiCell(usage: any): ApiCell | null {
   const sp = usage && usage.spend;
-  if (!sp) return [];
-  const out: UsageWindow[] = [];
-  for (const [key, label, short] of SPEND_WINS) {
+  if (!sp || !sp.fiveHour) return null;
+  const segs: ApiCell["segs"] = [];
+  for (const [key, label, short] of [["fiveHour", "5 hours", "5h"], ["month", "Month", "mo"]] as const) {
     const seg = sp[key];
     if (!seg || typeof seg.usd !== "number") continue;
-    const budget = typeof seg.budget === "number" && seg.budget > 0 ? seg.budget : null;
-    const pct = budget != null ? Math.max(0, Math.min(100, Math.round((seg.usd / budget) * 100))) : null;
-    let elapsedPct: number | null = null;
-    if (key === "month" && budget != null) {
-      const d = new Date(nowS * 1000);
-      const dim = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
-      elapsedPct = Math.max(0, Math.min(100, Math.round(((d.getDate() - 1 + d.getHours() / 24) / dim) * 100)));
-    }
-    const turns = seg.turns || 0;
-    out.push({
-      key, label, short, pct, elapsedPct, unknown: false,
-      // dollars AND tokens stay VISIBLE (the user 2026-08-05 — the hover-only split hid them again);
-      // WHOLE dollars, no cents, matching the rail everywhere (the user 2026-08-09)
-      readout: "$" + Math.round(seg.usd) + " · " + fmtTok(seg.tok || 0) + " tok",
-      title: label + " — $" + Math.round(seg.usd) + " · " + fmtTok(seg.tok || 0) + " tokens · "
-        + turns + " turn" + (turns === 1 ? "" : "s")
-        + (budget != null ? " · " + pct + "% of the $" + budget + " budget"
-           : " · no budget set — dollars only, no fill (set one in spend-budgets.json)")
-        + " · API-key billing",
-    });
+    segs.push({ key, label, short, usd: seg.usd, tok: seg.tok || 0 });
   }
-  return out;
+  if (!segs.length) return null;
+  const lines = ["API-key spend"];
+  for (const [key, label] of [["fiveHour", "5 hours"], ["sevenDay", "7 days"], ["month", "Month"]] as const) {
+    const seg = sp[key];
+    if (!seg || typeof seg.usd !== "number") continue;
+    const turns = seg.turns || 0;
+    lines.push(`${label} — ${fmtUsd(seg.usd)} · ${fmtTok(seg.tok || 0)} tok · ${turns} turn${turns === 1 ? "" : "s"}`);
+  }
+  return { segs, title: lines.join("\n") };
 }
 
 // Which panes get a quick-open label when hidden (the user 2026-07-13, who wanted chat,
@@ -245,9 +234,8 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
   function render(usage: any) {
     const nowS = Math.floor(Date.now() / 1000);
     usageWrap.textContent = "";
-    // ONE loop, one row builder: subscription windows and API spend windows are the same element, so
-    // the two auth modes cannot drift apart visually (the user 2026-08-04)
-    for (const w of usageWindows(usage, nowS).concat(spendWindows(usage, nowS))) {
+    // the subscription windows render as bar rows; key spend follows as ONE API cell (the rail's order)
+    for (const w of usageWindows(usage, nowS)) {
       const box = document.createElement("span");
       box.className = "ru-w" + (w.unknown ? " ru-unk" : "");
       box.title = w.title;
@@ -287,18 +275,46 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
         bars.appendChild(q);
         box.append(name, bars);
       } else {
-        if (w.pct != null) bars.appendChild(mkTrack(w.pct, usageColor(w.pct)));   // no honest denominator → no fill
+        if (w.pct != null) bars.appendChild(mkTrack(w.pct, usageColor(w.pct)));
         if (w.elapsedPct != null) bars.appendChild(mkTrack(w.elapsedPct, "#6b7a8c"));
         const pct = document.createElement("span");
         pct.className = "ru-pct";
-        pct.textContent = w.readout ?? `${w.pct}%`;
-        // A row with no tracks (a spend window with no budget: dollars only, no honest fill) is
-        // TEXT-ONLY. Appending its empty bar slot anyway held 54px of nothing open — and once the
-        // narrow tiers hid the readout too, the row was pure ghost space: a wide feed pane showed a
-        // bare "?", naked bars, and a fake dead gap (the user 2026-08-11). No empty slot, and the
-        // class lets the tier ladder drop the whole row once its text is gone (strip.css).
-        if (bars.childElementCount) box.append(name, bars, pct);
-        else { box.classList.add("ru-textonly"); box.append(name, pct); }
+        pct.textContent = `${w.pct}%`;
+        box.append(name, bars, pct);
+      }
+      usageWrap.appendChild(box);
+    }
+    // The API cell — the rail's apiCellHTML twin (see apiCell above): "API", then designator → value
+    // pairs. The dollars are the cell's own class (.ru-apiv), NOT .ru-pct: they are the information on
+    // a key-billed machine, so the compress tiers fold the tokens (tier 2) and the labels (tier 3,
+    // like every row) but never the dollars themselves.
+    const cell = apiCell(usage);
+    if (cell) {
+      const box = document.createElement("span");
+      box.className = "ru-w ru-api";
+      box.title = cell.title;
+      const lbl = document.createElement("span");
+      lbl.className = "ru-name";
+      lbl.textContent = "API";
+      box.appendChild(lbl);
+      for (const s of cell.segs) {
+        const name = document.createElement("span");
+        name.className = "ru-name";
+        const nameFull = document.createElement("span");
+        nameFull.className = "ru-name-full";
+        nameFull.textContent = s.label;
+        const nameShort = document.createElement("span");
+        nameShort.className = "ru-name-short";
+        nameShort.textContent = s.short;
+        name.append(nameFull, nameShort);
+        const val = document.createElement("span");
+        val.className = "ru-apiv";
+        val.textContent = fmtUsd(s.usd);
+        const tok = document.createElement("span");
+        tok.className = "ru-apitok";
+        tok.textContent = " · " + fmtTok(s.tok) + " tok";
+        val.appendChild(tok);
+        box.append(name, val);
       }
       usageWrap.appendChild(box);
     }


### PR DESCRIPTION
The web rail moved API-key spend to one compact cell (2026-08-08/09): a constant "API" label, then the 5-hour burn and the month-to-date as designator → dollars·tokens pairs — numbers, never bars, no fragment of any key on any surface. The VS Code strip still rendered spend as three bar-less window rows, the old grammar — and on a key-billed machine (the user 2026-08-11) that read as broken: the rows carried nothing but ghost space at the compressed tiers.

The strip now mirrors the rail: spendWindows-as-rows is gone, replaced by an apiCell twin of the rail's apiCellHTML. The collapsed cell shows 5 hours + Month (7 days and turn counts ride the hover title, like the rail's rich tip); it arms on the spend windows' presence — the same hasSpend branch the rail runs. The dollars wear their own class rather than .ru-pct, so the compress ladder can never hide them: tier 2 folds the token halves, tier 3 folds the labels like every other row, the dollars stay at every tier. The tier-2/3 .ru-textonly ghost-row mechanism (PR #287) dies with the rows it existed for.

Verified against the live kernel with a headless harness: at ~700px the strip reads "5h ? · 7d ▮ · F5 ▮ · API 5h $N mo $M"; at full width the tier-0 form matches the rail's cell exactly. apiCell unit tests plus updated rail-parity pins in rail-spend.test.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)