### PR TITLE
A remote session's drops ship bytes to its own kernel, never a laptop path

### DIFF
--- a/ui/webview/composer-attach.test.ts
+++ b/ui/webview/composer-attach.test.ts
@@ -65,6 +65,24 @@ test("shipFileToHost stamps the session id so federation routes the bytes to the
   assert.match(RENDER, /if \(sid\) msg\.id = sid;\s*\/\/ the owning session → the owning kernel/);
 });
 
+test("a REMOTE session's drops and pastes ship BYTES — a local path never rides its prompt", () => {
+  // The user (2026-08-11) dragged a laptop screenshot into a server-hosted session's chat: the drop
+  // handler preferred the path branches (File.path / text/uri-list), so the prompt carried a path
+  // that exists only on the laptop, and the agent on the server couldn't open it. The path branches
+  // are a LOCAL-session fast path (zero-copy, the agent reads the original file); a session owned by
+  // a remote host (hostOf) skips them and ships the bytes through the same dropFile route the phone
+  // already rides — the saved drops/ path comes back valid on the machine the agent reads.
+  assert.match(RENDER, /const remote = hostOf\(activeId \|\| ""\);/);
+  assert.match(RENDER, /if \(!remote\) \{\s*\n\s*const p = \(f as any\)\.path as string \| undefined;/,
+    "the drop's path branches are gated on local ownership");
+  assert.match(RENDER, /if \(p && !hostOf\(activeId \|\| ""\)\) addComposerFile\(activeId, p\);/,
+    "the paste's path branch wears the same gate");
+  // a path-only drag (no File objects — nothing to ship) is a dead end for a remote session,
+  // and it is SAID, never silently mis-attached
+  assert.match(RENDER, /That drag carried only this machine's path, which/);
+  assert.match(RENDER, /drop the file itself \(or paste it\) and the bytes will be shipped over\./);
+});
+
 test("an oversize file is refused LOUDLY — named size and cap in a toast, never a silent return", () => {
   // one cap constant, checked before the read; drag-drop, paste and both pickers all
   // funnel through shipFileToHost, so the toast covers every arrival path

--- a/ui/webview/composer-files.test.ts
+++ b/ui/webview/composer-files.test.ts
@@ -34,8 +34,9 @@ test("every file arrival becomes an attachment, never raw path text in the box",
   // the drop handler's three path sources all land in addComposerFile
   assert.match(RENDER, /const fromUri = \(u: string\) => addComposerFile\(activeId, decodeURIComponent\(u\.replace\(\/\^file:\\\/\\\/\/, ""\)\)\);/);
   assert.match(RENDER, /if \(p\) \{ addComposerFile\(activeId, p\); return; \}/);
-  // paste-with-files and the host round-trip (dropped bytes, 📎 dialog, phone picker) too
-  assert.match(RENDER, /if \(p\) addComposerFile\(activeId, p\);\s*\n\s*else shipFileToHost\(f\);/);
+  // paste-with-files and the host round-trip (dropped bytes, 📎 dialog, phone picker) too — the
+  // paste's path branch is gated on LOCAL ownership (composer-attach.test.ts owns the remote rule)
+  assert.match(RENDER, /if \(p && !hostOf\(activeId \|\| ""\)\) addComposerFile\(activeId, p\);\s*\n\s*else shipFileToHost\(f\);/);
   assert.match(RENDER, /m\.type === "droppedPath" && typeof m\.path === "string"\) \{[\s\S]{0,300}addComposerFile\(activeId, m\.path\);/);
   // the old insert-at-cursor path is gone with its last caller
   assert.doesNotMatch(RENDER, /function insertComposerText/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -27,7 +27,7 @@ import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
 import { previewKind, previewFull, canPreview, fileUrl } from "./preview";
-import { hostNameNodes, hostPrefix, hostIsDown, hostDownNote } from "./host-prefix";
+import { hostNameNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
@@ -8952,10 +8952,17 @@ function setupComposer() {
   // group ("drop to open", which is why a bare drop opened the PNG) before the
   // webview sees them — hold SHIFT while dropping to suppress the overlay and
   // hand the drop here. Pasting (below) is overlay-free and covers the same
-  // need. Best path source first: File.path (Electron, when exposed), then
-  // text/uri-list file:// entries (explorer drags), else the bytes go to the
-  // host, which saves them and posts the saved path back ("droppedPath") —
-  // sandboxed webviews expose NO filesystem path for OS drags, only content.
+  // need. Best path source first — but ONLY for a session this machine owns:
+  // File.path (Electron, when exposed), then text/uri-list file:// entries
+  // (explorer drags), else the bytes go to the owning kernel, which saves them
+  // and posts the saved path back ("droppedPath") — sandboxed webviews expose
+  // NO filesystem path for OS drags, only content. A REMOTE host's session
+  // (hostOf) never takes the path branches: a path on this machine means
+  // nothing on that kernel's disk — the user 2026-08-11 dragged a laptop
+  // screenshot into a server session and the agent there got a path it could
+  // not open. Its drops/pastes ship the BYTES instead, the same dropFile route
+  // federation already carries for the phone, and the saved path comes back
+  // valid on the machine the agent actually reads.
   ta.addEventListener("dragover", (e) => {
     e.preventDefault(); e.stopPropagation();
     if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
@@ -8967,20 +8974,33 @@ function setupComposer() {
     ta.classList.remove("drop-target");
     const dt = e.dataTransfer;
     if (!dt) return;
+    const remote = hostOf(activeId || "");
     const uris = (dt.getData("text/uri-list") || "").split(/\r?\n/).filter((u) => u && !u.startsWith("#"));
     const fromUri = (u: string) => addComposerFile(activeId, decodeURIComponent(u.replace(/^file:\/\//, "")));
     const files = Array.from(dt.files || []);
-    if (!files.length) { for (const u of uris) if (u.startsWith("file://")) fromUri(u); return; }
+    if (!files.length) {
+      // a path-only drag (no File objects) can't be shipped — a browser can't read file:// bytes.
+      // For a remote session that is a dead end, and it must be said, not silently mis-attached.
+      for (const u of uris) if (u.startsWith("file://")) {
+        if (remote) warnToast("That drag carried only this machine's path, which " + remote
+          + " can't read — drop the file itself (or paste it) and the bytes will be shipped over.");
+        else fromUri(u);
+      }
+      return;
+    }
     files.forEach((f, i) => {
-      const p = (f as any).path as string | undefined;
-      if (p) { addComposerFile(activeId, p); return; }
-      if (uris[i] && uris[i].startsWith("file://")) { fromUri(uris[i]); return; }
+      if (!remote) {
+        const p = (f as any).path as string | undefined;
+        if (p) { addComposerFile(activeId, p); return; }
+        if (uris[i] && uris[i].startsWith("file://")) { fromUri(uris[i]); return; }
+      }
       shipFileToHost(f);
     });
   });
 
   // Cmd+V a copied file (Finder "Copy") or a clipboard screenshot → insert its
-  // path, same pipeline as drops. Plain text pastes have no files on the
+  // path, same pipeline as drops (including the remote rule: a local path only
+  // for a locally-owned session). Plain text pastes have no files on the
   // clipboard and keep the default behavior.
   ta.addEventListener("paste", (e) => {
     const files = Array.from(e.clipboardData?.files || []);
@@ -8988,7 +9008,7 @@ function setupComposer() {
     e.preventDefault();
     files.forEach((f) => {
       const p = (f as any).path as string | undefined;
-      if (p) addComposerFile(activeId, p);
+      if (p && !hostOf(activeId || "")) addComposerFile(activeId, p);
       else shipFileToHost(f);
     });
   });


### PR DESCRIPTION
Dragging a laptop screenshot into the chat of a session owned by a remote host attached the LAPTOP's filesystem path to the prompt (the user 2026-08-11, screenshot: the agent on the server got a /Users/... path it could not open and suggested scp). The drop and paste handlers preferred the path branches — File.path when Electron exposes it, then text/uri-list file:// entries — over shipping bytes, regardless of who owns the session.

The path branches are a LOCAL-session fast path (zero-copy; the agent reads the original file) and now apply only when hostOf(activeId) is empty. A remote host's session ships the BYTES instead, through the machinery that already existed and already routes: shipFileToHost posts dropFile stamped with the session id, federation's SCALAR_ID routing carries it to the owning kernel, that kernel saves under its own drops/ and acks droppedPath with a path valid on the disk the agent actually reads — the exact flow the phone's photo picker has always ridden, now engaged for laptop → server too. No new mechanism, no sync daemon: one ownership decision at the existing choke point.

A path-only drag (text/uri-list with no File objects — nothing shippable) to a remote session warns loudly instead of silently attaching a wrong path.

Pins in composer-attach.test.ts (the remote rule, both handlers, the loud dead-end) and composer-files.test.ts updated to the gated paste form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)