### PR TITLE
Pair trust is set from the hub: the popover gains Between your machines

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6323,6 +6323,31 @@ def set_trust(host, level):
         return (_remote_public(_remotes[host]) if host in _remotes else None), None
 
 
+def _remote_kernel_call(r, method, path, payload=None, timeout=8):
+    """One HTTP call to an attached host's kernel: through the tunnel's local forward, authorized with
+    THAT machine's own serve token (the admin access the user already holds). This is mirror_trust's
+    transport, shared by the pair-trust routes. `r` is a remotes-row snapshot.
+    Returns (status, parsed_json, None) or (None, None, error)."""
+    host = r.get("host") or "?"
+    port, tok = r.get("local_port") or 0, r.get("token") or ""
+    if not port or not tok:
+        return None, None, "no admin path to '%s' (missing forward or token)" % host
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", int(port), timeout=timeout)
+        hdrs = {"X-Romp-Token": tok}
+        body = None
+        if payload is not None:
+            body = json.dumps(payload)
+            hdrs["Content-Type"] = "application/json"
+        conn.request(method, path, body, hdrs)
+        resp = conn.getresponse()
+        data = resp.read()
+        conn.close()
+        return resp.status, json.loads(data.decode() or "{}"), None
+    except Exception as e:
+        return None, None, "could not reach %s's kernel: %s" % (host, e)
+
+
 def mirror_trust(host):
     """Set OUR current trust level for `host` as ITS trust level for US — through the admin access the
     user already holds on that machine (the attached tunnel's local forward + that machine's serve
@@ -6338,23 +6363,90 @@ def mirror_trust(host):
     if not r:
         return None, "no attached tunnel to '%s' — set trust from that machine's own dashboard" % host
     level = r.get("trust") or "directed"
-    port, tok = r.get("local_port") or 0, r.get("token") or ""
-    if not port or not tok:
-        return None, "no admin path to '%s' (missing forward or token) — set trust from its dashboard" % host
-    try:
-        conn = http.client.HTTPConnection("127.0.0.1", int(port), timeout=8)
-        conn.request("POST", "/tunnels/trust",
-                     json.dumps({"host": _self_host(), "trust": level}),
-                     {"Content-Type": "application/json", "X-Romp-Token": tok})
-        resp = conn.getresponse()
-        data = resp.read()
-        conn.close()
-        j = json.loads(data.decode() or "{}")
-    except Exception as e:
-        return None, "could not reach %s's kernel: %s" % (host, e)
+    st, j, err = _remote_kernel_call(r, "POST", "/tunnels/trust", {"host": _self_host(), "trust": level})
+    if err:
+        return None, err + (" — set trust from its dashboard" if err.startswith("no admin path") else "")
     if not j.get("ok"):
-        return None, j.get("error") or ("HTTP %s from %s" % (resp.status, host))
+        return None, j.get("error") or ("HTTP %s from %s" % (st, host))
     return {"host": host, "trust": level}, None
+
+
+def remote_trust(on_host, of_host, level):
+    """Set ON one attached machine ITS trust level for another host — the popover's 'Between your
+    machines' rows (the user 2026-08-11, who wanted to say from the laptop that two of their machines
+    trust each other, instead of opening each machine's own dashboard). The write crosses the on-host
+    tunnel with that machine's own serve token and lands on its /tunnels/trust, so it persists there
+    exactly like a locally-set level (remotes row, or origin-only known entry — a pair usually has no
+    direct tunnel between its ends, only relay reach). Same trust boundary as mirror_trust: the human
+    holding admin on the machine acts; a peer can never raise its own standing.
+    Returns ({onHost, host, trust}, None) or (None, error)."""
+    if level not in TRUST_LEVELS:
+        return None, "trust must be one of %s" % ", ".join(TRUST_LEVELS)
+    on_host, of_host = (on_host or "").strip(), (of_host or "").strip()
+    if not on_host or not of_host:
+        return None, "onHost and host required"
+    if on_host == of_host:
+        return None, "a machine does not tier its own mail"
+    with _remotes_lock:
+        r = dict(_remotes.get(on_host) or {})
+    if not r:
+        return None, "no attached tunnel to '%s' — its trust table is set through your own tunnel" % on_host
+    st, j, err = _remote_kernel_call(r, "POST", "/tunnels/trust", {"host": of_host, "trust": level})
+    if err:
+        return None, err
+    if not j.get("ok"):
+        return None, j.get("error") or ("HTTP %s from %s" % (st, on_host))
+    return {"onHost": on_host, "host": of_host, "trust": level}, None
+
+
+def pairs_snapshot():
+    """How each pair of attached machines holds EACH OTHER's mail, read live from each machine's own
+    kernel through its tunnel + token — the authoritative tables (the bus gossip only carries how
+    peers hold THIS machine's mail, so a third-party link is invisible to it). Feeds the popover's
+    'Between your machines' section; /tunnels/trust-remote writes back. Hosts are read in parallel,
+    and one that cannot be read carries its error instead of silently dropping its directions (fail
+    loudly). A direction with no explicit row on the holding machine reads "" — effectively directed,
+    the inbound default for a relayed origin."""
+    with _remotes_lock:
+        rows = {h: dict(r) for h, r in _remotes.items()}
+    hosts, tables = {}, {}
+
+    def one(h, r):
+        if (r.get("status") or "") != "up":
+            hosts[h] = {"ok": False, "error": "not connected"}
+            return
+        st, j, err = _remote_kernel_call(r, "GET", "/tunnels", timeout=6)
+        if err or not isinstance(j, dict):
+            hosts[h] = {"ok": False, "error": err or ("HTTP %s" % st)}
+            return
+        t = {}
+        for row in (j.get("tunnels") or []):          # attached rows are that kernel's authority…
+            if row.get("host"):
+                t[row["host"]] = row.get("trust") or "directed"
+        for row in (j.get("known") or []):            # …then remembered hosts, then relay-known rows
+            if row.get("host"):
+                t.setdefault(row["host"], row.get("trust") or "directed")
+        for row in (j.get("viaReach") or []):
+            if row.get("host"):
+                t.setdefault(row["host"], row.get("trust") or "directed")
+        hosts[h] = {"ok": True}
+        tables[h] = t
+
+    ths = [threading.Thread(target=one, args=(h, r), daemon=True) for h, r in rows.items()]
+    for t in ths:
+        t.start()
+    for t in ths:
+        t.join(timeout=8)
+    for h in rows:
+        if h not in hosts:                            # a reader still past the join deadline
+            hosts[h] = {"ok": False, "error": "timed out"}
+    pairs, names = [], sorted(rows)
+    for i, a in enumerate(names):
+        for b in names[i + 1:]:
+            pairs.append({"a": a, "b": b,
+                          "ab": (tables.get(a) or {}).get(b, "") if hosts[a]["ok"] else None,
+                          "ba": (tables.get(b) or {}).get(a, "") if hosts[b]["ok"] else None})
+    return {"ok": True, "hosts": hosts, "pairs": pairs}
 
 
 def _checkin_payload(r):
@@ -19052,7 +19144,7 @@ function showAdd(on){if(!addBox)return;addBox.hidden=!on;hint.hidden=!on;plus.hi
 if(on&&hostIn){hostIn.value=hostIn.value||mruHost();try{hostIn.focus();hostIn.select();}catch(e){}}}
 var _autoAdd=false;
 var _auto=false;   // "Automatically update" — mirrored from the KERNEL each refresh, never a local guess
-function open(){back.hidden=false;_autoAdd=false;showAdd(false);trustEngaged=false;deferredRender=null;loadHosts();refresh();}
+function open(){back.hidden=false;_autoAdd=false;showAdd(false);trustEngaged=false;deferredRender=null;_pairs=null;loadHosts();refresh();}
 function close(){back.hidden=true;trustEngaged=false;deferredRender=null;}
 if(plus)plus.onclick=function(){showAdd(true);};
 // "How it works" — the gist reads by itself; the mechanics are one click under it.
@@ -19076,6 +19168,12 @@ var _cfg=[],_seen=[];
 // (the user 2026-07-27). Pending is keyed per host and survives re-renders: rows show the CHOSEN
 // level, disabled with an applying cue, until a snapshot agrees (the confirming EVENT — no timer).
 var _pendTrust={},_pendMirror={};
+// BETWEEN YOUR MACHINES state (the user 2026-08-11): _pairs is the last /tunnels/pairs answer (null =
+// not read yet this opening), _pendPair the per-direction pending map (keyed holder|sender — a host
+// name cannot contain '|' — with _pendTrust's confirm-by-snapshot discipline). Reading pairs dials EACH machine's kernel over its
+// tunnel, so it never rides the 3s poll itself: refresh() kicks it, one in flight at a time
+// (_pairsBusy), and the answer repaints from the poll's cached args (_lastArgs) — no fetch loop.
+var _pendPair={},_pairs=null,_pairsBusy=false,_lastArgs=null,_lastUp=0;
 function pendLvl(map,host,current){var p=map[host];if(p&&current===p){delete map[host];p=null;}return p;}
 function fillHosts(){if(!dl)return;var hs=[];
 [[mruHost()],_seen,_cfg].forEach(function(g){(g||[]).forEach(function(h){if(h&&hs.indexOf(h)<0)hs.push(h);});});   // most-recently-connected first, not just ssh-config order
@@ -19186,7 +19284,9 @@ icon.title=ts.length?('Remote kernels \\u00b7 '+_head+'\\n'+ts.map(function(t){v
 var ap=t.autoPush?('\\n    auto-update: '+(t.autoPush.detail||t.autoPush.phase)):'';
 var dw=t.outOfDate?(' \\u00b7 '+(t.status==='up'?'':'last known ')+driftWord(t)):'';
 return '\\u2022 '+t.host+': '+(LBL[t.status]||t.status)+' ('+n+' session'+(n===1?'':'s')+')'+dw+(t.token?'':' \\u00b7 no token')+ap;}).join('\\n')):'Remote kernels \\u2014 none attached (click to connect)';
-if(!back.hidden)render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[],(d&&d.remoteHolds)||[],(d&&d.peerTiers)||{});   // pmode is refresh-local — render must be GIVEN it
+_lastArgs=[ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[],(d&&d.remoteHolds)||[],(d&&d.peerTiers)||{}];
+_lastUp=ts.filter(function(t){return t.status==='up';}).length;
+if(!back.hidden){render.apply(null,_lastArgs);refreshPairs();}   // pmode is refresh-local — render must be GIVEN it (it rides _lastArgs)
 // while any tunnel is mid-attach, poll fast so the phase words (authorizing -> connecting -> connected)
 // are actually visible in the couple seconds it takes; settle to a slow keep-alive once all up/down.
 schedule((busy||pushing.length)?600:3000);   // poll fast while an auto-push runs, so its progress reads live
@@ -19213,6 +19313,15 @@ function releaseTrust(){trustEngaged=false;var f=deferredRender;deferredRender=n
 list.addEventListener('mousedown',function(e){if(e.target&&e.target.classList&&e.target.classList.contains('rnet-trust'))trustEngaged=true;},true);
 list.addEventListener('focusin',function(e){if(e.target&&e.target.classList&&e.target.classList.contains('rnet-trust'))trustEngaged=true;});
 list.addEventListener('focusout',function(e){if(e.target&&e.target.classList&&e.target.classList.contains('rnet-trust'))releaseTrust();});
+// Fetch the pair table when it can mean anything (two live hosts), at most one dial in flight; the
+// answer repaints from the poll's cached args rather than forcing another /tunnels round trip.
+function refreshPairs(){if(_lastUp<2){_pairs=null;return;}
+if(_pairsBusy)return;
+_pairsBusy=true;
+fetch('/tunnels/pairs',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){
+_pairsBusy=false;_pairs=(d&&d.ok)?d:{error:(d&&d.error)||'unreadable'};repaint();
+}).catch(function(e){_pairsBusy=false;_pairs={error:String((e&&(e.message||e.name))||e)};repaint();});}
+function repaint(){if(!back.hidden&&_lastArgs)render.apply(null,_lastArgs);}
 function render(ts,known,pmode,via,rholds,tiers){
 if(trustEngaged){deferredRender=function(){render(ts,known,pmode,via,rholds,tiers);};return;}
 list.innerHTML='';known=known||[];via=via||[];rholds=rholds||[];tiers=tiers||{};
@@ -19371,6 +19480,38 @@ var vtrust='<select class=\"rnet-trust'+(vpd?' rnet-applying':'')+'\"'+(vpd?' di
 vr.innerHTML='<span class=rnet-dot style=\"background:transparent;box-shadow:inset 0 0 0 1.5px #7a6a3a\" title=\"No direct tunnel; reachable one hop through '+v.via+'.\"></span>'+
 '<span class=nm><b>'+v.host+'</b> <span class=st title=\"Its sessions are gossiped one hop by '+v.via+'; attach it directly for full control.\">via '+v.via+' \\u00b7 '+(v.agents||0)+' session'+((v.agents||0)===1?'':'s')+'</span></span>'+vtrust;
 list.appendChild(vr);});}
+// BETWEEN YOUR MACHINES (the user 2026-08-11): how attached machines hold EACH OTHER's mail. The
+// pair link a\\u2194b appears nowhere above — every list in this panel manages only THIS machine's own
+// gates — so making two remote boxes trust each other used to mean opening each box's own dashboard.
+// One row per direction, read live from each machine's kernel (/tunnels/pairs) and written back
+// through your tunnel + that machine's own serve token (/tunnels/trust-remote): the same
+// you-with-both-tokens boundary as Match, so a peer still can never raise its own standing.
+var upn=ts.filter(function(t){return t.status==='up';});
+if(upn.length>=2){
+var bh=document.createElement('div');bh.className='rnet-khead';bh.textContent='Between your machines';
+bh.title='How your attached machines hold each other\\u2019s postal mail, one line per direction, read live from each machine\\u2019s own kernel. Changing a line writes to the holding machine through your tunnel and its own access token (like Match): you are acting on both ends; the machines never set each other\\u2019s trust.';
+list.appendChild(bh);
+if(_pairs&&_pairs.pairs){_pairs.pairs.forEach(function(pr){
+[[pr.a,pr.b,pr.ab],[pr.b,pr.a,pr.ba]].forEach(function(dd){var hold=dd[0],frm=dd[1],tier=dd[2];
+var br=document.createElement('div');br.className='rnet-row rnet-known';
+// null = that machine's table was unreadable this pass (named error, retried next kick); '' = no
+// explicit row there yet, which the receiving bus treats as directed for a relayed origin.
+if(tier===null){var he=(_pairs.hosts&&_pairs.hosts[hold]&&_pairs.hosts[hold].error)||'unreadable';
+br.innerHTML='<span class=nm><b>'+hold+'</b> holds <b>'+frm+'</b>\\u2019s mail: <span class=st title=\"Could not read '+hold+'\\u2019s trust table over the tunnel: '+he+'. It keeps gating mail by its own last-set levels; retried on the next refresh.\">unreadable \\u2014 '+he+'</span></span>';
+list.appendChild(br);return;}
+var pk=hold+'|'+frm;
+var ppd=pendLvl(_pendPair,pk,tier||'');   // confirmed when the holder's own table shows the chosen level
+var pcur=ppd||tier||'directed';
+var imp=(!tier&&!ppd)?' Never set explicitly \\u2014 directed is its default.':'';
+br.innerHTML='<span class=nm><b>'+hold+'</b> holds <b>'+frm+'</b>\\u2019s mail</span>'+
+'<span class=rnet-set><select class=\"rnet-trust'+(ppd?' rnet-applying':'')+'\"'+(ppd?' disabled':'')+' data-pt-on=\"'+hold+'\" data-pt-of=\"'+frm+'\" title=\"What '+hold+' does with postal mail from '+frm+'.'+imp+' trusted: delivered straight to its sessions. directed: held on '+hold+' for your approval. isolated: none.\">'+
+['trusted','directed','isolated'].map(function(v){return '<option value='+v+(pcur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select>'+(ppd?'<span class=rnet-pend>'+spin()+'applying\\u2026</span>':'')+'</span>';
+list.appendChild(br);});});}
+else if(_pairs&&_pairs.error){var be=document.createElement('div');be.className='rnet-row rnet-known';
+be.innerHTML='<span class=st>Could not read how your machines hold each other: '+_pairs.error+' \\u2014 retrying.</span>';list.appendChild(be);}
+else{var bl=document.createElement('div');bl.className='rnet-row rnet-known';
+bl.innerHTML='<span class=st>'+spin()+'reading how your machines hold each other\\u2026</span>';list.appendChild(bl);}
+}
 // HELD ELSEWHERE (the user 2026-07-25): mail waiting for approval on OTHER machines — direct peers
 // and one relay hop — which used to be visible only on the holding machine's own dashboard. One
 // line per machine (count first, gists on hover); acting on them still happens on that machine.
@@ -19398,6 +19539,14 @@ _pendMirror[h]=b.getAttribute('data-lvl')||'';b.disabled=true;b.textContent='Mat
 fetch('/tunnels/trust-mirror',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h})}).then(function(r){return r.json();}).then(function(d){
 if(!(d&&d.ok)){delete _pendMirror[h];alert('trust match on '+h+' failed: '+((d&&d.error)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
 refresh();}).catch(function(){delete _pendMirror[h];alert('trust match on '+h+' failed to reach the kernel.');refresh();});};});
+// A pair direction: pending on the click (ack now), written to the HOLDING machine via the kernel's
+// trust-remote proxy, confirmed only when a later pairs read shows the level on that machine's table.
+list.querySelectorAll('select[data-pt-on]').forEach(function(s){s.onchange=function(){
+var on=s.getAttribute('data-pt-on'),of=s.getAttribute('data-pt-of');
+_pendPair[on+'|'+of]=s.value;s.disabled=true;s.classList.add('rnet-applying');releaseTrust();
+fetch('/tunnels/trust-remote',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({onHost:on,host:of,trust:s.value})}).then(function(r){return r.json();}).then(function(d){
+if(!(d&&d.ok)){delete _pendPair[on+'|'+of];alert('trust change on '+on+' for '+of+'\\u2019s mail failed: '+((d&&d.error)||'unknown'));repaint();}   // fail LOUDLY (CLAUDE.md)
+refreshPairs();}).catch(function(){delete _pendPair[on+'|'+of];alert('trust change on '+on+' for '+of+'\\u2019s mail failed to reach the kernel.');repaint();refreshPairs();});};});
 list.querySelectorAll('input[data-k]').forEach(function(c){c.onchange=function(){var h=c.getAttribute('data-k');
 c.disabled=true;fetch('/tunnels/checkin',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h,on:c.checked})}).then(function(r){return r.json();}).then(function(d){
 if(!(d&&d.ok)){c.checked=!c.checked;alert('keep-connected on '+h+' failed: '+((d&&d.error)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
@@ -20957,6 +21106,11 @@ class Handler(BaseHTTPRequestHandler):
                                                              "host": _self_host()},
                                                    "peersMode": _postal_peers_on()}),
                                   "application/json", cache="no-cache")
+            if p == "/tunnels/pairs":                         # how attached machines hold EACH OTHER's mail —
+                # read live from each machine's kernel through its tunnel (the popover's "Between your
+                # machines" rows). Fetched on demand, never folded into /tunnels: this one fans out
+                # over ssh and must not tax the popover's 3s poll.
+                return self._send(200, json.dumps(pairs_snapshot()), "application/json", cache="no-cache")
             # HTML pages are served no-cache so a reload always gets the freshest markup — which carries
             # the latest ?v= bundle url, so even a cached old bundle is bypassed (stale-client fix).
             if p in ("/", ""):
@@ -21516,6 +21670,27 @@ class Handler(BaseHTTPRequestHandler):
                     code = 404 if err.startswith("no attached") else 502
                     return self._send(code, json.dumps({"ok": False, "error": err}), "application/json")
                 return self._send(200, json.dumps({"ok": True, "mirrored": res}), "application/json")
+            if u.path == "/tunnels/trust-remote":
+                # Set on ONE attached machine its trust level for ANOTHER host — the popover's
+                # "Between your machines" rows (the user 2026-08-11). Body: {"onHost", "host",
+                # "trust"}. The write crosses onHost's tunnel with its own serve token: the human
+                # with admin on that machine acting, exactly like Match; a peer can never set
+                # another machine's trust, and this route never lets one (it only ever dials a
+                # tunnel THIS user attached).
+                try:
+                    body = json.loads(raw_body or b"{}")
+                except Exception:
+                    body = None
+                on_h = str((body or {}).get("onHost") or "").strip() if isinstance(body, dict) else ""
+                of_h = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
+                level = str((body or {}).get("trust") or "").strip() if isinstance(body, dict) else ""
+                res, err = remote_trust(on_h, of_h, level)
+                if err:
+                    code = (404 if err.startswith("no attached")
+                            else 400 if (err.startswith("trust must be") or err.endswith("required")
+                                         or err.endswith("own mail")) else 502)
+                    return self._send(code, json.dumps({"ok": False, "error": err}), "application/json")
+                return self._send(200, json.dumps({"ok": True, "set": res}), "application/json")
             if u.path == "/checkin":
                 # A mobile machine's check-in handshake arriving through its own reverse forward.
                 try:

--- a/tests/test_kernel_trust.py
+++ b/tests/test_kernel_trust.py
@@ -275,5 +275,177 @@ class MirrorTrust(unittest.TestCase):
         self.assertIn("no admin path", err)
 
 
+def _stub_kernel(cleanup_with, seen=None, tunnels=None):
+    """A pretend remote kernel on a loopback port: records any POST into `seen` (mirror/remote-trust
+    tests) and answers GET /tunnels with `tunnels` (pairs tests)."""
+    from http.server import BaseHTTPRequestHandler
+
+    class H(BaseHTTPRequestHandler):
+        def _out(self, payload):
+            out = json.dumps(payload).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(out)))
+            self.end_headers()
+            self.wfile.write(out)
+
+        def do_POST(self):
+            if seen is not None:
+                seen["path"] = self.path
+                seen["token"] = self.headers.get("X-Romp-Token")
+                seen["body"] = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
+            self._out({"ok": True})
+
+        def do_GET(self):
+            self._out(tunnels or {})
+
+        def log_message(self, *a):
+            pass
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    cleanup_with(srv.shutdown)
+    return srv.server_address[1]
+
+
+class RemoteTrust(unittest.TestCase):
+    """remote_trust (the user 2026-08-11): the hub sets ON one attached machine ITS trust level for
+    another host — the popover's 'Between your machines' rows. Same boundary as mirror_trust: the
+    write crosses the on-host tunnel with that machine's own serve token, and that machine's own
+    /tunnels/trust route persists it; a peer can never raise its own standing."""
+
+    def tearDown(self):
+        with km._remotes_lock:
+            km._remotes.pop("boxa", None)
+
+    def test_writes_the_pair_level_through_the_holders_tunnel(self):
+        seen = {}
+        port = _stub_kernel(self.addCleanup, seen=seen)
+        with km._remotes_lock:
+            km._remotes["boxa"] = _row("boxa", local_port=port, token="remote-tok", trust="directed")
+        res, err = km.remote_trust("boxa", "boxb", "trusted")
+        self.assertIsNone(err)
+        self.assertEqual(res, {"onHost": "boxa", "host": "boxb", "trust": "trusted"})
+        self.assertEqual(seen["path"], "/tunnels/trust", "the holder's own persisting route does the write")
+        self.assertEqual(seen["token"], "remote-tok", "authorized with the HOLDING machine's serve token")
+        self.assertEqual(seen["body"], {"host": "boxb", "trust": "trusted"},
+                         "boxa is told to hold boxb at the chosen level")
+
+    def test_bad_level_refused_before_any_dial(self):
+        res, err = km.remote_trust("boxa", "boxb", "bogus")
+        self.assertIsNone(res)
+        self.assertIn("trust must be one of", err)
+
+    def test_without_a_tunnel_errors_plainly(self):
+        res, err = km.remote_trust("nosuchhost", "boxb", "trusted")
+        self.assertIsNone(res)
+        self.assertTrue(err.startswith("no attached"), err)
+
+    def test_a_machine_never_tiers_its_own_mail(self):
+        res, err = km.remote_trust("boxa", "boxa", "trusted")
+        self.assertIsNone(res)
+        self.assertIn("own mail", err)
+
+
+class PairsSnapshot(unittest.TestCase):
+    """pairs_snapshot: the hub reads each attached machine's own trust table over its tunnel and
+    assembles per-pair directions. '' = the holder has no explicit row (the bus treats a relayed
+    origin as directed); None + a named per-host error = that machine was unreadable this pass —
+    surfaced, never silently dropped (fail loudly)."""
+
+    def tearDown(self):
+        with km._remotes_lock:
+            for h in ("boxa", "boxb"):
+                km._remotes.pop(h, None)
+
+    def test_pairs_read_both_directions_from_each_machines_own_table(self):
+        # boxa holds boxb via an attached-tunnel row; boxb holds boxa via a relay (viaReach) row —
+        # the three row kinds a tier can live on are all consulted.
+        pa = _stub_kernel(self.addCleanup, tunnels={"tunnels": [{"host": "boxb", "trust": "trusted"}],
+                                                    "known": [], "viaReach": []})
+        pb = _stub_kernel(self.addCleanup, tunnels={"tunnels": [], "known": [],
+                                                    "viaReach": [{"host": "boxa", "trust": "isolated"}]})
+        with km._remotes_lock:
+            km._remotes["boxa"] = _row("boxa", local_port=pa, token="ta")
+            km._remotes["boxb"] = _row("boxb", local_port=pb, token="tb")
+        snap = km.pairs_snapshot()
+        self.assertTrue(snap["ok"])
+        self.assertEqual(snap["hosts"], {"boxa": {"ok": True}, "boxb": {"ok": True}})
+        self.assertEqual(snap["pairs"], [{"a": "boxa", "b": "boxb", "ab": "trusted", "ba": "isolated"}])
+
+    def test_no_explicit_row_reads_empty_never_an_invented_level(self):
+        pa = _stub_kernel(self.addCleanup, tunnels={"tunnels": [], "known": [], "viaReach": []})
+        pb = _stub_kernel(self.addCleanup, tunnels={"tunnels": [],
+                                                    "known": [{"host": "boxa", "trust": "trusted"}],
+                                                    "viaReach": []})
+        with km._remotes_lock:
+            km._remotes["boxa"] = _row("boxa", local_port=pa, token="ta")
+            km._remotes["boxb"] = _row("boxb", local_port=pb, token="tb")
+        snap = km.pairs_snapshot()
+        self.assertEqual(snap["pairs"], [{"a": "boxa", "b": "boxb", "ab": "", "ba": "trusted"}])
+
+    def test_an_unreadable_machine_carries_its_error_not_a_guess(self):
+        pa = _stub_kernel(self.addCleanup, tunnels={"tunnels": [{"host": "boxb", "trust": "directed"}]})
+        with km._remotes_lock:
+            km._remotes["boxa"] = _row("boxa", local_port=pa, token="ta")
+            km._remotes["boxb"] = _row("boxb", status="down")
+        snap = km.pairs_snapshot()
+        self.assertEqual(snap["hosts"]["boxb"], {"ok": False, "error": "not connected"})
+        self.assertEqual(snap["pairs"], [{"a": "boxa", "b": "boxb", "ab": "directed", "ba": None}])
+
+
+class PairRoutes(unittest.TestCase):
+    """Route wiring for the pair section: GET /tunnels/pairs answers the snapshot; POST
+    /tunnels/trust-remote proxies the write and maps errors to honest statuses."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.srv.server_close()
+
+    def setUp(self):
+        with km._remotes_lock:
+            km._remotes.clear()
+
+    def _call(self, method, path, body=None):
+        c = http.client.HTTPConnection("127.0.0.1", self.port, timeout=5)
+        c.request(method, path, None if body is None else json.dumps(body),
+                  {"Content-Type": "application/json", "X-Romp-Token": km.TOKEN})
+        r = c.getresponse()
+        data = json.loads(r.read().decode() or "{}")
+        c.close()
+        return r.status, data
+
+    def test_pairs_route_answers_empty_world(self):
+        code, data = self._call("GET", "/tunnels/pairs")
+        self.assertEqual(code, 200)
+        self.assertEqual(data, {"ok": True, "hosts": {}, "pairs": []})
+
+    def test_trust_remote_route_round_trips_to_the_stub(self):
+        seen = {}
+        port = _stub_kernel(self.addCleanup, seen=seen)
+        with km._remotes_lock:
+            km._remotes["boxa"] = _row("boxa", local_port=port, token="remote-tok")
+        code, data = self._call("POST", "/tunnels/trust-remote",
+                                {"onHost": "boxa", "host": "boxb", "trust": "trusted"})
+        self.assertEqual(code, 200)
+        self.assertEqual(data, {"ok": True, "set": {"onHost": "boxa", "host": "boxb", "trust": "trusted"}})
+        self.assertEqual(seen["body"], {"host": "boxb", "trust": "trusted"})
+
+    def test_trust_remote_route_maps_errors_to_statuses(self):
+        code, data = self._call("POST", "/tunnels/trust-remote",
+                                {"onHost": "boxa", "host": "boxb", "trust": "bogus"})
+        self.assertEqual((code, data["ok"]), (400, False))
+        code, data = self._call("POST", "/tunnels/trust-remote",
+                                {"onHost": "ghost", "host": "boxb", "trust": "trusted"})
+        self.assertEqual((code, data["ok"]), (404, False))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_remotes_panel_render.py
+++ b/tests/test_remotes_panel_render.py
@@ -68,11 +68,16 @@ const document = {
 };
 const localStorage = { getItem(){return null;}, setItem(){} };
 const TUNNELS = __TUNNELS__;
+const PAIRS = __PAIRS__;        // /tunnels/pairs answer; null = the read never lands (loader-state test)
 const POSTS = [];               // every write the panel makes, so a test can assert what Attach sent
 function fetch(url, opts){
   if (opts && opts.method === 'POST') {
     POSTS.push({url:url, body:JSON.parse(opts.body || '{}')});
     return Promise.resolve({ ok:true, json(){ return Promise.resolve({ok:true}); } });
+  }
+  if (url.indexOf('/tunnels/pairs') >= 0) {
+    if (PAIRS === null) return new Promise(function(){});
+    return Promise.resolve({ ok:true, json(){ return Promise.resolve(PAIRS); } });
   }
   const body = url.indexOf('/ssh-hosts') >= 0 ? {hosts:['TESTHOST']} : TUNNELS;
   return Promise.resolve({ ok:true, json(){ return Promise.resolve(body); } });
@@ -113,9 +118,10 @@ setTimeout_(() => {
 
 
 class RemotesPanelRender(unittest.TestCase):
-    def _run(self, drive="", tunnels=None):
+    def _run(self, drive="", tunnels=None, pairs=None):
         js = (HARNESS.replace("__PANEL_JS__", km._LANDING_REMOTES_JS)
                      .replace("__TUNNELS__", json.dumps(tunnels if tunnels is not None else TUNNELS))
+                     .replace("__PAIRS__", json.dumps(pairs))
                      .replace("__DRIVE__", drive))
         p = subprocess.run(["node", "-e", js], capture_output=True, text=True, timeout=30)
         self.assertEqual(p.returncode, 0, "panel JS crashed:\n%s" % p.stderr[-2000:])
@@ -136,7 +142,9 @@ class RemotesPanelRender(unittest.TestCase):
     def test_render_is_given_pmode_rather_than_reading_it_free(self):
         js = km._LANDING_REMOTES_JS
         self.assertIn("function render(ts,known,pmode,via,rholds,tiers)", js)
-        self.assertIn("render(ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[],(d&&d.remoteHolds)||[],(d&&d.peerTiers)||{})", js)
+        # pmode rides the cached args (which also let a pairs answer repaint without a new /tunnels)
+        self.assertIn("_lastArgs=[ts,(d&&d.known)||[],pmode,(d&&d.viaReach)||[],(d&&d.remoteHolds)||[],(d&&d.peerTiers)||{}]", js)
+        self.assertIn("render.apply(null,_lastArgs)", js)
 
     def test_reverse_trust_mismatch_renders_the_direction_and_a_match_button(self):
         # Both directions of the pair on one row (the user 2026-07-26): ours is the select, theirs is
@@ -298,6 +306,55 @@ class RemotesPanelRender(unittest.TestCase):
         tun = json.loads(json.dumps(TUNNELS))
         tun["tunnels"][0].update({"status": "down", "fails": 1, "nextTry": 0})
         self.assertIn("retrying", self._run(tunnels=tun).get("html", ""))
+
+    # ---- between your machines (the user 2026-08-11) ----------------------------------------------
+    # The pair link a↔b appears on NONE of the rows above: every list in the panel manages only this
+    # machine's own gates, so making two remote boxes trust each other used to mean opening each
+    # box's own dashboard. The section reads each machine's table live (/tunnels/pairs) and writes
+    # back through the kernel's trust-remote proxy.
+
+    def _two_hosts(self):
+        tn = json.loads(json.dumps(TUNNELS))
+        b = json.loads(json.dumps(tn["tunnels"][0]))
+        b["host"] = "PEERBOX"
+        tn["tunnels"].append(b)
+        return tn
+
+    def test_one_host_offers_no_pair_section(self):
+        out = self._run()
+        self.assertNotIn("Between your machines", out.get("html", ""))
+
+    def test_two_hosts_render_a_row_per_direction_with_the_shared_select(self):
+        pairs = {"ok": True, "hosts": {"PEERBOX": {"ok": True}, "TESTHOST": {"ok": True}},
+                 "pairs": [{"a": "PEERBOX", "b": "TESTHOST", "ab": "trusted", "ba": ""}]}
+        out = self._run(tunnels=self._two_hosts(), pairs=pairs)
+        html = out.get("html", "")
+        self.assertIn("Between your machines", html)
+        self.assertIn("<b>PEERBOX</b> holds <b>TESTHOST</b>", html)
+        self.assertIn("<b>TESTHOST</b> holds <b>PEERBOX</b>", html)
+        self.assertIn("data-pt-on=", html, "the write control is the same trust select, keyed per direction")
+        # a direction with no explicit row renders as directed and says it was never set
+        self.assertIn("directed is its default", html)
+
+    def test_an_unreadable_holder_names_its_error_instead_of_a_select(self):
+        pairs = {"ok": True, "hosts": {"PEERBOX": {"ok": False, "error": "not connected"},
+                                       "TESTHOST": {"ok": True}},
+                 "pairs": [{"a": "PEERBOX", "b": "TESTHOST", "ab": None, "ba": "directed"}]}
+        out = self._run(tunnels=self._two_hosts(), pairs=pairs)
+        html = out.get("html", "")
+        self.assertIn("unreadable", html)
+        self.assertIn("not connected", html)
+
+    def test_the_pair_read_in_flight_shows_the_loader_not_a_blank(self):
+        # PAIRS null = the fetch never settles; the section must say it is working, not sit empty.
+        out = self._run(tunnels=self._two_hosts(), pairs=None)
+        self.assertIn("reading how your machines hold each other", out.get("html", ""))
+
+    def test_pair_binding_posts_the_trust_remote_route(self):
+        js = km._LANDING_REMOTES_JS
+        self.assertIn("select[data-pt-on]", js)
+        self.assertIn("/tunnels/trust-remote", js)
+        self.assertIn("/tunnels/pairs", js)
 
 
 if __name__ == "__main__":

--- a/ui/webview/net-popover-known.test.ts
+++ b/ui/webview/net-popover-known.test.ts
@@ -17,7 +17,9 @@ test("web popover renders remembered hosts with re-attach + forget", () => {
   // pmode rides along as a PARAM: it is computed in refresh()'s callback, and reading it as a free
   // variable in render() threw ReferenceError on every draw (see tests/test_remotes_panel_render.py)
   assert.match(KERNEL, /function render\(ts,known,pmode,via,rholds,tiers\)/, "render takes the known list + pmode + via-reach + remote holds + peer tiers");
-  assert.match(KERNEL, /if\(!back\.hidden\)render\(ts,\(d&&d\.known\)\|\|\[\],pmode,\(d&&d\.viaReach\)\|\|\[\],\(d&&d\.remoteHolds\)\|\|\[\],\(d&&d\.peerTiers\)\|\|\{\}\);/, "refresh passes them through");
+  // refresh passes them through — via the cached-args form, which also lets a pairs answer repaint
+  assert.match(KERNEL, /_lastArgs=\[ts,\(d&&d\.known\)\|\|\[\],pmode,\(d&&d\.viaReach\)\|\|\[\],\(d&&d\.remoteHolds\)\|\|\[\],\(d&&d\.peerTiers\)\|\|\{\}\];/);
+  assert.match(KERNEL, /if\(!back\.hidden\)\{render\.apply\(null,_lastArgs\);refreshPairs\(\);\}/);
   assert.match(KERNEL, /Held for approval elsewhere/, "remote holds get their own section");
   assert.match(KERNEL, /rnet-from/, "the add box offers which machine owns the tunnel (attach-on-behalf)");
   assert.match(KERNEL, /Reachable via relay/, "via-reach hosts get their own section (trust-by-origin rows)");
@@ -31,7 +33,7 @@ test("web popover renders remembered hosts with re-attach + forget", () => {
 
 test("VS Code strip renders remembered hosts with re-attach + forget", () => {
   assert.match(STRIP, /function renderList\(ts: any\[\], known: any\[\] = \[\]\)/);
-  assert.match(STRIP, /renderList\(ts, \(d && d\.known\) \|\| \[\]\)/);
+  assert.match(STRIP, /lastList = \[ts, \(d && d\.known\) \|\| \[\]\];\s*\n\s*renderList\(lastList\[0\], lastList\[1\]\);/);
   assert.match(STRIP, /Previously attached/);
   assert.match(STRIP, /"Re-attach"/);
   assert.match(STRIP, /"Forget"/);

--- a/ui/webview/net-trust-pending.test.ts
+++ b/ui/webview/net-trust-pending.test.ts
@@ -77,3 +77,29 @@ test("an engaged trust select DEFERS the rebuild — its open dropdown survives 
   assert.match(KERNEL, /rnet-applying'\);releaseTrust\(\);/);
   assert.match(KERNEL, /function close\(\)\{back\.hidden=true;trustEngaged=false;deferredRender=null;\}/);
 });
+
+test("pair rows (Between your machines) wear the same pending discipline in both copies (the user 2026-08-11)", () => {
+  // Web copy: per-direction pending map (holder|sender — '|' cannot appear in a host name), recorded
+  // on the click, cleared only when a later pairs read agrees, honest revert on a refused write.
+  assert.match(KERNEL, /var _pendPair=\{\},_pairs=null,_pairsBusy=false/, "pair state outlives render()");
+  assert.match(KERNEL, /var pk=hold\+'\|'\+frm;/);
+  assert.match(KERNEL, /var ppd=pendLvl\(_pendPair,pk,tier\|\|''\)/, "cleared by agreement with the holder's table");
+  assert.match(KERNEL, /_pendPair\[on\+'\|'\+of\]=s\.value;s\.disabled=true;s\.classList\.add\('rnet-applying'\);releaseTrust\(\);/);
+  assert.match(KERNEL, /delete _pendPair\[on\+'\|'\+of\];alert\('trust change on '/, "refused write reverts AND alerts");
+  // the pair select is a .rnet-trust, so the engaged-defer above covers it too
+  assert.match(KERNEL, /select class=\\"rnet-trust'\+\(ppd\?' rnet-applying':''\)/);
+  // the write crosses to the HOLDING machine via the kernel proxy; reads come from /tunnels/pairs
+  assert.match(KERNEL, /'\/tunnels\/trust-remote'/);
+  assert.match(KERNEL, /fetch\('\/tunnels\/pairs',\{cache:'no-store'\}\)/);
+  // Strip copy: same map, same ack-on-click, same honest revert, same engage/defer paths.
+  assert.match(STRIP, /const pendingPair = new Map<string, string>\(\);/);
+  assert.match(STRIP, /const pk = `\$\{hold\}\|\$\{frm\}`;/);
+  assert.match(STRIP, /if \(pend && \(tier \|\| ""\) === pend\) \{ pendingPair\.delete\(pk\); pend = undefined; \}/);
+  assert.match(STRIP, /pendingPair\.set\(pk, sel\.value\);/, "recorded on the click");
+  assert.match(STRIP, /if \(!\(d && d\.ok\)\) pendingPair\.delete\(pk\)/, "refused write reverts honestly");
+  assert.match(STRIP, /sel\.addEventListener\("focus", \(\) => \{ trustEngaged = true; \}\);/);
+  assert.match(STRIP, /sel\.addEventListener\("mousedown", \(\) => \{ trustEngaged = true; \}\);/);
+  assert.match(STRIP, /sel\.addEventListener\("blur", releaseTrust\);/);
+  assert.match(STRIP, /\/tunnels\/trust-remote/);
+  assert.match(STRIP, /\/tunnels\/pairs/);
+});

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -435,6 +435,21 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
   // event — no timer). A refused write deletes the entry, so the next render honestly reverts.
   const pendingTrust = new Map<string, string>();
 
+  // BETWEEN YOUR MACHINES (the user 2026-08-11): how attached machines hold EACH OTHER's mail — a
+  // pair link appears nowhere else in this popover; every other row manages only this machine's own
+  // gate. Read live from each machine's kernel via /tunnels/pairs (kicked once per refresh, one dial
+  // in flight — it fans out over the tunnels and must not ride the 3s poll itself), written back
+  // through the kernel's /tunnels/trust-remote proxy: your tunnel + that machine's own serve token,
+  // the same you-with-both-tokens boundary as the web popover's Match. Pending per direction (keyed
+  // holder|sender), confirmed only when a later pairs read shows the level on the holder's own
+  // table — never a timer. A pairs answer repaints from the poll's cached args (lastList), so it
+  // costs no extra /tunnels round trip and cannot loop.
+  const pendingPair = new Map<string, string>();
+  let pairs: any = null;          // last /tunnels/pairs answer; null = not read yet this opening
+  let pairsBusy = false;
+  let lastUp = 0;
+  let lastList: [any[], any[]] | null = null;
+
   // A native <select>'s open dropdown dies with its DOM node, and renderList rebuilds every row each
   // poll — at the connecting-phase 600ms cadence (schedule below) the trust picker's options dismissed
   // the instant they opened (the user 2026-08-04: click it and "it just immediately unclicks"; fine
@@ -456,6 +471,12 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
     if (trustEngaged) { deferredRender = () => renderList(ts, known); return; }   // mid-pick — land it after
     list.textContent = "";
     button.classList.toggle("on", ts.some((t) => t.status === "up"));
+    // Each option carries its own plain gloss: the bare words are romp's vocabulary, not English, and a
+    // dropdown whose meaning only appears on hover makes you uncover every option before you can choose.
+    // (Shared by the per-host selects and the pair rows below.)
+    const TRUSTW: Record<string, string> = {
+      trusted: "trusted (auto-accept)", directed: "directed (held for you)", isolated: "isolated (no mail)",
+    };
     if (!ts.length && !known.length) {
       const e = document.createElement("div");
       e.className = "sn-empty";
@@ -511,11 +532,6 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       trust.className = "sn-trust";
       trust.title = `What happens to postal mail from ${t.host}. trusted: delivered straight to `
         + "your sessions. directed: held for your approval. isolated: none, dashboard only.";
-      // Each option carries its own plain gloss: the bare words are romp's vocabulary, not English, and a
-      // dropdown whose meaning only appears on hover makes you uncover every option before you can choose.
-      const TRUSTW: Record<string, string> = {
-        trusted: "trusted (auto-accept)", directed: "directed (held for you)", isolated: "isolated (no mail)",
-      };
       let pend = pendingTrust.get(t.host);
       if (pend && (t.trust || "directed") === pend) { pendingTrust.delete(t.host); pend = undefined; }
       for (const lvl of ["trusted", "directed", "isolated"]) {
@@ -643,6 +659,107 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
         list.appendChild(r);
       }
     }
+    // BETWEEN YOUR MACHINES — one row per direction; mechanics on the state block above. Only offered
+    // when two machines are live: with fewer there is no pair to speak of.
+    if (ts.filter((t) => t.status === "up").length >= 2) {
+      const hd = document.createElement("div");
+      hd.className = "sn-khead";
+      hd.textContent = "Between your machines";
+      hd.title = "How your attached machines hold each other's postal mail, one line per direction, read live "
+        + "from each machine's own kernel. Changing a line writes to the holding machine through your tunnel "
+        + "and its own access token: you are acting on both ends; the machines never set each other's trust.";
+      list.appendChild(hd);
+      if (pairs && pairs.pairs) {
+        for (const pr of pairs.pairs) {
+          const dirs: [string, string, string | null][] = [[pr.a, pr.b, pr.ab], [pr.b, pr.a, pr.ba]];
+          for (const [hold, frm, tier] of dirs) {
+            const r = document.createElement("div");
+            r.className = "sn-row sn-known";
+            const nm = document.createElement("span");
+            nm.className = "sn-name";
+            // null = that machine's table was unreadable this pass (named error, retried on the next
+            // kick); "" = no explicit row there yet, which its bus treats as directed for a relayed origin.
+            if (tier === null) {
+              const he = (pairs.hosts && pairs.hosts[hold] && pairs.hosts[hold].error) || "unreadable";
+              nm.textContent = `${hold} holds ${frm}'s mail: unreadable — ${he}`;
+              nm.title = `Could not read ${hold}'s trust table over the tunnel: ${he}. It keeps gating mail `
+                + `by its own last-set levels; retried on the next refresh.`;
+              r.appendChild(nm);
+              list.appendChild(r);
+              continue;
+            }
+            nm.textContent = `${hold} holds ${frm}'s mail`;
+            r.appendChild(nm);
+            const pk = `${hold}|${frm}`;
+            let pend = pendingPair.get(pk);
+            if (pend && (tier || "") === pend) { pendingPair.delete(pk); pend = undefined; }
+            const sel = document.createElement("select");
+            sel.className = "sn-trust";
+            const imp = !tier && !pend ? " Never set explicitly — directed is its default." : "";
+            sel.title = `What ${hold} does with postal mail from ${frm}.${imp} trusted: delivered straight `
+              + `to its sessions. directed: held on ${hold} for your approval. isolated: none.`;
+            for (const lvl of ["trusted", "directed", "isolated"]) {
+              const o = document.createElement("option");
+              o.value = lvl; o.textContent = TRUSTW[lvl];
+              if ((pend || tier || "directed") === lvl) o.selected = true;
+              sel.appendChild(o);
+            }
+            if (pend) { sel.disabled = true; sel.classList.add("sn-applying"); }
+            sel.addEventListener("focus", () => { trustEngaged = true; });      // keyboard path
+            sel.addEventListener("mousedown", () => { trustEngaged = true; });  // pointer path
+            sel.addEventListener("blur", releaseTrust);
+            sel.addEventListener("change", () => {
+              pendingPair.set(pk, sel.value);   // ack on the click; re-renders show the chosen level
+              sel.disabled = true;
+              sel.classList.add("sn-applying");
+              releaseTrust();   // the choice is made — land any deferred snapshot (pendingPair keeps it painted)
+              fetch(kernelUrl("/tunnels/trust-remote"), { method: "POST", headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ onHost: hold, host: frm, trust: sel.value }) })
+                .then((rp) => rp.json())
+                .then((d) => { if (!(d && d.ok)) pendingPair.delete(pk); refreshPairs(); })
+                .catch(() => { pendingPair.delete(pk); refreshPairs(); });
+            });
+            r.appendChild(sel);
+            if (pend) {
+              const pn = document.createElement("span");
+              pn.className = "sn-pend";
+              pn.textContent = "applying…";
+              r.appendChild(pn);
+            }
+            list.appendChild(r);
+          }
+        }
+      } else if (pairs && pairs.error) {
+        const e = document.createElement("div");
+        e.className = "sn-empty";
+        e.textContent = `Couldn't read how your machines hold each other: ${pairs.error} — retrying.`;
+        list.appendChild(e);
+      } else {
+        const e = document.createElement("div");
+        e.className = "sn-empty";
+        e.textContent = "Reading how your machines hold each other…";
+        list.appendChild(e);
+      }
+    }
+  }
+
+  // The pair table is read OUTSIDE the poll (each read dials every live machine's kernel over its
+  // tunnel): refresh() kicks it, at most one in flight, and the answer repaints from the cached poll
+  // args. Fewer than two live hosts means no pairs — clear and skip the dial.
+  function refreshPairs(ts?: any[]) {
+    if (ts) lastUp = ts.filter((t) => t.status === "up").length;
+    if (lastUp < 2) { pairs = null; return; }
+    if (pairsBusy) return;
+    pairsBusy = true;
+    fetch(kernelUrl("/tunnels/pairs"), { cache: "no-store" }).then((r) => r.json()).then((d) => {
+      pairsBusy = false;
+      pairs = d && d.ok ? d : { error: (d && d.error) || "unreadable" };
+      if (!pop.hidden && lastList) renderList(lastList[0], lastList[1]);
+    }).catch((err) => {
+      pairsBusy = false;
+      pairs = { error: String(err) };
+      if (!pop.hidden && lastList) renderList(lastList[0], lastList[1]);
+    });
   }
 
   let diagPending = false;   // report the first /tunnels outcome of each open, not every 3s poll
@@ -651,7 +768,9 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       const ts = (d && d.tunnels) || [];
       if (diagPending) { diagPending = false; post?.({ type: "clientDiag", surface: "strip", what: "netFetch", data: { ok: true, tunnels: ts.length } }); }
       if (!autoCb.disabled) autoCb.checked = !!(d && d.autoUpdate);   // mirror the kernel; never clobber a write in flight
-      renderList(ts, (d && d.known) || []);
+      lastList = [ts, (d && d.known) || []];
+      renderList(lastList[0], lastList[1]);
+      refreshPairs(ts);
       // An automatic push in flight counts as busy: the button marches while romp works in the background,
       // and the poll runs fast so the phase reads live.
       const pushing = ts.some((t: any) => t.autoPush && (t.autoPush.phase === "pushing" || t.autoPush.phase === "waiting" || t.autoPush.phase === "pulling"));
@@ -697,6 +816,7 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
       const strip = document.getElementById("romp-strip");
       if (strip) pop.style.bottom = `${strip.offsetHeight + 6}px`;
       diagPending = true;
+      pairs = null;   // fresh read per opening — the loader line, then live data (never a stale table)
       loadHosts();
       refresh();
     }


### PR DESCRIPTION
Two remote machines that see each other only through this hub held each other at directed, and raising that meant opening each machine's own dashboard: the hub popover managed only its own links. The user wanted to declare two of their machines trusted from the laptop.

**What changed**
- The network popover (web `_LANDING_REMOTES_JS` and the VS Code strip alike) ends in a **Between your machines** section: one row per direction of each pair of live hosts ("a holds b's mail" with the shared trust select).
- Reads: `GET /tunnels/pairs` fans out to each attached machine's own kernel through its tunnel + token (parallel, kicked once per popover refresh, never folded into the 3s poll). An unreadable machine carries its named error instead of silently dropping its directions; an absent row reads as the directed default it effectively is.
- Writes: `POST /tunnels/trust-remote {onHost, host, trust}` lands on the holding machine's own `/tunnels/trust` through the hub's tunnel and that machine's serve token, so it persists there like a locally-set level. Same boundary as Match: the human with admin on the machine acts; a peer can never raise its own standing. `mirror_trust` now shares the transport helper.
- Pending selections follow the existing confirm-by-snapshot discipline (per direction, cleared only when the holder's own table agrees), and pair selects ride the engaged-defer that keeps open dropdowns alive across polls.

**Tests**
- `tests/test_kernel_trust.py`: `remote_trust` round-trip/validation, `pairs_snapshot` (three row kinds, absent row, unreadable host), route wiring + status mapping.
- `tests/test_remotes_panel_render.py`: the section renders per direction from a two-host fixture, names an unreadable holder's error, shows the loader while the read is in flight, and stays absent with one host.
- `ui/webview/net-trust-pending.test.ts`: pins the pair pending discipline in both copies; stale refresh-call pins updated for the cached-args form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)