### PR TITLE
A connected host with no build identity reads unversioned copy, never a blank

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19371,6 +19371,12 @@ var tt='running '+(buildWord(t.kernelVer,t.kernelSha)||'?')+(t.kernelDate?' from
 +(t.checkinPeer?(t.askPull?' No ssh path from this machine (it checked in over its own tunnel), so Update asks it to fast-forward itself over the link it holds.':' No ssh path from this machine (it checked in over its own tunnel) \\u2014 sync from its own dashboard.'):'');
 ver=' \\u00b7 <span class=\"rnet-old'+(stl?' rnet-stale':'')+'\" title=\"'+tt+sq+'\">'+(stl?'last known: ':'')+(bw?bw+' ':'')+(ar?'('+ar+')':w)+'</span>';}
 else if(bw){ver=' \\u00b7 <span class=\"rnet-sha'+(stl?' rnet-stale':'')+'\" title=\"'+(stl?'same build as this machine when last reached.'+sq:'same build as this machine')+'\">'+(stl?'last known: ':'')+bw+'</span>';}
+// A connected host that reports NO build at all is running a plain file copy — no git checkout, so its
+// kernel cannot name a release or commit, and drift against this machine cannot be measured (it may be
+// months behind and never say so; the user 2026-08-11, whose devbox ran months-old code beside a bare
+// "connected"). Fail loudly where the build word would sit, never a silent blank that reads as fine.
+// strip.ts's popover row carries the same word (rnet parity pins).
+else if(t.status==='up'){ver=' \\u00b7 <span class=\"rnet-old\" title=\"'+t.host+' is running romp from a plain file copy \\u2014 not a git checkout \\u2014 so it cannot name its release or commit, and how far it is from this machine cannot be measured: it may be far behind and never say so. Reinstall it as a git clone to restore the build name and updates.\">unversioned copy</span>';}
 // A push romp is ALREADY doing needs no button — offering one would just invite a duplicate of the work in
 // flight. The row shows the live phase instead (below), and the manual Push returns if it fails.
 var apx=t.autoPush&&(t.autoPush.phase==='pushing'||t.autoPush.phase==='waiting'||t.autoPush.phase==='pulling'||t.autoPush.phase==='asking');

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -4,6 +4,7 @@ scenes. `POST /tunnels/update` runs the ssh git-pull + restart; the rail popover
 SYNTHETIC hosts; subprocess/http are stubbed so nothing actually launches or connects."""
 import json
 import os
+import pathlib
 import shutil
 import subprocess
 import tempfile
@@ -403,6 +404,22 @@ class DriftWordingUI(unittest.TestCase):
         self.assertIn("up=ab>0?('ahead '+ab):''", js)
         self.assertIn("'diverged: '", js)
         self.assertIn("'different build'", js, "an unknown sha says so instead of guessing")
+
+    def test_a_buildless_connected_host_reads_unversioned_not_blank(self):
+        # A connected host that reports NO build at all (a plain file copy, no git checkout) used to
+        # show a bare "connected" — indistinguishable from healthy-and-in-sync, while running
+        # arbitrarily old code drift detection cannot see (the user 2026-08-11, whose devbox sat
+        # months behind beside a blank). The row says "unversioned copy" where the build word sits,
+        # and the tooltip says why and what restores updates. Fail loudly, never a blank that reads
+        # as fine.
+        js = km._LANDING_REMOTES_JS
+        self.assertIn("else if(t.status==='up'){ver=' \\u00b7 <span class=\"rnet-old\"", js)
+        self.assertIn("unversioned copy", js)
+        self.assertIn("Reinstall it as a git clone to restore the build name and updates.", js)
+        # the VS Code strip's popover row carries the same word — the two surfaces must not drift
+        strip = (pathlib.Path(__file__).resolve().parents[1] / "ui" / "webview" / "strip.ts").read_text()
+        self.assertIn('ver = " · unversioned copy";', strip)
+        self.assertIn("!t.kernelSha && !t.kernelVer", strip)
 
     def test_tooltip_carries_the_shas_and_date(self):
         js = km._LANDING_REMOTES_JS

--- a/ui/webview/strip.test.ts
+++ b/ui/webview/strip.test.ts
@@ -102,6 +102,17 @@ test("the strip compresses by measurement: fluid bars, fit()-stepped tiers, wrap
   assert.ok(!src.includes("strip-spacer"), "no spacer item — margin-left:auto keeps the pin across wrapped rows");
 });
 
+test("a buildless connected host reads 'unversioned copy', matching the web popover", () => {
+  // a plain file copy (no git checkout) reports no sha/version, so drift detection is blind to it —
+  // the row must say so where the build word sits, never a bare "connected" that reads as in-sync
+  // (the user 2026-08-11, devbox). test_kernel_remote_update.py pins the web popover's twin wording.
+  const ROOT = path.resolve(process.cwd(), "..");
+  const src = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
+  assert.match(src, /const unversioned = t\.status === "up" && !t\.outOfDate && !t\.kernelSha && !t\.kernelVer;/);
+  assert.match(src, /if \(unversioned\) ver = " · unversioned copy";/);
+  assert.match(src, /Reinstall it as a git clone to restore the build name and updates\./);
+});
+
 // The network button must acknowledge and fail LOUDLY (the user 2026-07-14
 // reported it "doing nothing" in VS Code while every repro elsewhere works):
 // instant .open chrome on the button, instant popover content before any

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -516,9 +516,15 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
         }
         if (stale) ver = ver.replace(" · ", " · last known: ");
       }
+      // A connected host reporting NO build at all runs a plain file copy (no git checkout): it cannot
+      // name a release or commit, and drift can't be measured — it may be months behind and never say
+      // so (the user 2026-08-11, devbox). Say it where the build word sits, matching the web popover.
+      const unversioned = t.status === "up" && !t.outOfDate && !t.kernelSha && !t.kernelVer;
+      if (unversioned) ver = " · unversioned copy";
       nm.textContent = `${t.host} — ${LBL[t.status] || t.status}` + ver;
       nm.title = (TIP[t.status] || "")
         + (t.outOfDate ? `\n\nRunning ${t.kernelSha || "?"}${t.kernelDate ? " from " + t.kernelDate : ""}; this machine is at ${t.localSha || "?"}.` : "")
+        + (unversioned ? `\n\n${t.host} is running romp from a plain file copy — not a git checkout — so it cannot name its release or commit, and how far it is from this machine cannot be measured: it may be far behind and never say so. Reinstall it as a git clone to restore the build name and updates.` : "")
         + (stale && t.outOfDate ? `\nLast confirmed ${seen || "not since this kernel started"}; not re-checked while ${LBL[t.status] || t.status}.` : "")
         + (t.outOfDate && t.checkinPeer
           ? (t.askPull


### PR DESCRIPTION
The Remote kernels panel names every host's build (release + commit) so the rows read against each other — but a connected host whose kernel reports NO build at all showed a bare "connected", indistinguishable from healthy-and-in-sync. That blank is exactly the dangerous case: a kernel that can't name its build is running a plain file copy (no git checkout), so drift detection — which keys on the sha — is blind to it. The user's devbox (2026-08-11) sat on months-old code beside that blank.

Both surfaces now say "unversioned copy" where the build word sits (the web popover in rnet-old chrome, the VS Code strip's popover row in the same words), with a hover explaining why the build can't be named, why drift can't be measured, and that reinstalling as a git clone restores the build name and updates. Fail loudly, never a silent blank that reads as fine.

Pins in test_kernel_remote_update.py (which also holds the two surfaces' wording in step) and strip.test.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)