### PR TITLE
Never declare an unkeyable self-host to peers

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,7 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
-import json, os, queue, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid
+import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid
 from pathlib import Path
 from datetime import datetime
 from importlib.machinery import SourceFileLoader
@@ -6251,11 +6251,99 @@ def _bus_quarantine_act(body):
 # except it owns no ssh — the mobile supervises its own tunnel, so the attach supervisor's keep-alive IS
 # the keep-connected behavior. Unchecking = checkout: the hub forgets the row + token.
 
+# ── self-host safety (KEEP IN SYNC with postal_service.py: _safe_id, _host_name_candidates,
+# _sanitize_host_name, _minted_host_id, self_host — the postal copy is the reference and carries
+# the full 2026-08-11 story). Peers key the mail they hold FOR this machine by the name we declare,
+# as a path component, so a kern.hostname stomped with junk that fails path-safety half-breaks
+# peering: presence crosses, every reply back is refused and parks "unreachable". Kernel and bus
+# must fall back IDENTICALLY — the minted last-resort id is persisted at jd.STATE/"self-host", the
+# SAME file the bus uses (its STATE.parent == jd.STATE) — so this machine can never check in under
+# one name while its bus declares another.
+
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+def _safe_id(s):
+    """True iff `s` is safe as a single path component (postal_service._safe_id, duplicated)."""
+    if not s or len(s) > 128:
+        return False
+    if "/" in s or "\\" in s or "\x00" in s or s.startswith("."):
+        return False
+    return bool(_SAFE_ID_RE.match(s))
+
+def _host_name_candidates():
+    """Raw machine-name candidates for the self-host fallback, most meaningful first. macOS keeps
+    user-set names in scutil (LocalHostName is mDNS-restricted, ComputerName is free-form);
+    elsewhere there is no second authority — the minted id below is the fallback."""
+    if sys.platform != "darwin":
+        return []
+    out = []
+    for key in ("LocalHostName", "ComputerName"):
+        try:
+            r = subprocess.run(["scutil", "--get", key], capture_output=True, text=True, timeout=3)
+            if r.returncode == 0 and r.stdout.strip():
+                out.append(r.stdout.strip())
+        except Exception:
+            pass
+    return out
+
+def _sanitize_host_name(name):
+    """A candidate machine name reduced to a _safe_id-safe label: first dot-label, runs of unsafe
+    chars folded to '-', trimmed. "" when nothing meaningful survives (a 1-char remnant of junk is
+    an unstable identity, not a name)."""
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", str(name or "").split(".")[0]).strip("-._")
+    return name if len(name) >= 2 and _safe_id(name) else ""
+
+_HOST_ID_FILE = jd.STATE / "self-host"   # minted-once stable identity; the bus's STATE.parent/"self-host" — the SAME file
+
+def _minted_host_id():
+    """Last-resort stable identity: mint once, persist, reuse. O_EXCL so two processes (bus and
+    kernel) racing to mint converge on whoever wrote first."""
+    try:
+        name = _HOST_ID_FILE.read_text().strip()
+        if _safe_id(name):
+            return name
+    except OSError:
+        pass
+    name = "host-%08x" % random.getrandbits(32)
+    try:
+        _HOST_ID_FILE.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(str(_HOST_ID_FILE), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        os.write(fd, (name + "\n").encode())
+        os.close(fd)
+    except FileExistsError:
+        try:
+            prior = _HOST_ID_FILE.read_text().strip()
+            if _safe_id(prior):
+                return prior
+        except OSError:
+            pass
+    except OSError:
+        pass                                 # unwritable state root: stable per-process only, still safe
+    return name
+
+_self_host_fb = None                         # resolved fallback identity, cached after the first (logged) resolve
+
 def _self_host():
-    """This machine's name in a check-in handshake (the hub's key for us). Short hostname;
-    ROMP_HOST_NAME overrides (tests; unusual naming)."""
-    import socket
-    return os.environ.get("ROMP_HOST_NAME") or socket.gethostname().split(".")[0]
+    """This machine's name to peers (the check-in handshake, trust pushes, usage rows). Short
+    hostname; ROMP_HOST_NAME overrides (tests; unusual naming). The name MUST clear _safe_id — the
+    hub keys the mail it holds for us by it, as a path component — so an unsafe kernel hostname
+    falls back loudly, exactly like the bus's self_host(): the platform's user-set machine name,
+    else the minted id persisted in the SHARED file above (kernel and bus converge on one identity).
+    gethostname stays first and live — fixing the machine's hostname takes effect on the next call
+    with no restart."""
+    env = os.environ.get("ROMP_HOST_NAME")
+    if env:
+        return env
+    name = socket.gethostname().split(".")[0]
+    if _safe_id(name):
+        return name
+    global _self_host_fb
+    if _self_host_fb is None:
+        _self_host_fb = next((s for s in map(_sanitize_host_name, _host_name_candidates()) if s),
+                             "") or _minted_host_id()
+        sys.stderr.write("self-host: kernel hostname %r fails path-safety; using %r for peering "
+                         "(fix the machine's hostname to control the name)\n" % (name, _self_host_fb))
+    return _self_host_fb
 
 
 def checkin_set(host, on):

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -201,8 +201,10 @@ def _mailbox(sid):
     return mb
 
 def _unique():
-    host = socket.gethostname().split(".")[0] or "host"
-    return f"{int(time.time())}.{os.getpid()}_{random.randint(0, 99999)}.{host}"
+    # self_host(), not raw gethostname: the mid is a path component under mail/ and the peer's
+    # outbox (_safe_id-checked at outbox_put), so a stomped hostname baked in here silently killed
+    # every OUTBOUND cross-host send too — same 2026-08-11 breakage as self_host's docstring.
+    return f"{int(time.time())}.{os.getpid()}_{random.randint(0, 99999)}.{self_host()}"
 
 def _mark_pending(sid):
     """Reconcile the on-disk pending-mail marker with reality: mail-pending/<sid>
@@ -1555,10 +1557,82 @@ _peer_threads = {}                         # host -> Thread (one dialer loop per
 _peer_pending = {}                         # host -> {"acks": [mid], "bounces": [{mid, why}]} for the NEXT request
 _peer_lock = threading.Lock()
 
+def _host_name_candidates():
+    """Raw machine-name candidates for the self_host fallback, most meaningful first. macOS keeps
+    user-set names in scutil (LocalHostName is mDNS-restricted, ComputerName is free-form);
+    elsewhere there is no second authority — the minted id below is the fallback."""
+    if sys.platform != "darwin":
+        return []
+    out = []
+    for key in ("LocalHostName", "ComputerName"):
+        try:
+            r = subprocess.run(["scutil", "--get", key], capture_output=True, text=True, timeout=3)
+            if r.returncode == 0 and r.stdout.strip():
+                out.append(r.stdout.strip())
+        except Exception:
+            pass
+    return out
+
+def _sanitize_host_name(name):
+    """A candidate machine name reduced to a _safe_id-safe label: first dot-label, runs of unsafe
+    chars folded to '-', trimmed. "" when nothing meaningful survives (a 1-char remnant of junk is
+    an unstable identity, not a name)."""
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", str(name or "").split(".")[0]).strip("-._")
+    return name if len(name) >= 2 and _safe_id(name) else ""
+
+_HOST_ID_FILE = STATE.parent / "self-host"   # minted-once stable identity; the kernel's _self_host shares it
+
+def _minted_host_id():
+    """Last-resort stable identity: mint once, persist, reuse. O_EXCL so two processes (bus and
+    kernel) racing to mint converge on whoever wrote first."""
+    try:
+        name = _HOST_ID_FILE.read_text().strip()
+        if _safe_id(name):
+            return name
+    except OSError:
+        pass
+    name = "host-%08x" % random.getrandbits(32)
+    try:
+        _HOST_ID_FILE.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(str(_HOST_ID_FILE), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        os.write(fd, (name + "\n").encode())
+        os.close(fd)
+    except FileExistsError:
+        try:
+            prior = _HOST_ID_FILE.read_text().strip()
+            if _safe_id(prior):
+                return prior
+        except OSError:
+            pass
+    except OSError:
+        pass                                 # unwritable state root: stable per-process only, still safe
+    return name
+
+_self_host_fb = None                         # resolved fallback identity, cached after the first (logged) resolve
+
 def self_host():
     """This machine's postal identity: short hostname (each side keys the OTHER by its own name for
-    it, so exact agreement across machines is not required). ROMP_POSTAL_HOST overrides (tests)."""
-    return os.environ.get("ROMP_POSTAL_HOST") or socket.gethostname().split(".")[0]
+    it, so exact agreement across machines is not required). ROMP_POSTAL_HOST overrides (tests).
+    The name MUST clear _safe_id: peers key the outbox that holds mail FOR us by it, as a path
+    component, so an unkeyable kernel hostname half-works — presence still crosses (PEER_STATE is a
+    dict), but outbox_put on the peer refuses every message back, parked "unreachable" forever with
+    the only trace a server-log line (2026-08-11, a kern.hostname stomped with control bytes). An
+    unsafe name falls back, loudly: the platform's user-set machine name, else a minted persisted
+    id. gethostname stays first and live, so fixing the machine's hostname takes effect on the next
+    call with no restart."""
+    env = os.environ.get("ROMP_POSTAL_HOST")
+    if env:
+        return env
+    name = socket.gethostname().split(".")[0]
+    if _safe_id(name):
+        return name
+    global _self_host_fb
+    if _self_host_fb is None:
+        _self_host_fb = next((s for s in map(_sanitize_host_name, _host_name_candidates()) if s),
+                             "") or _minted_host_id()
+        _log("self_host: kernel hostname %r fails path-safety; declaring %r to peers instead "
+             "(fix the machine's hostname to control the name)" % (name, _self_host_fb))
+    return _self_host_fb
 
 def _peer_wake(host):
     with _peer_lock:
@@ -1958,6 +2032,15 @@ def peer_exchange_handle(data):
     # session rows), and the relays below are trust-judged under the alias the user actually tiered.
     bus_id = str((data or {}).get("busId") or "")
     host = _canon_peer_name(host, bus_id)
+    if not _safe_id(host):
+        # An unkeyable name would HALF-work: presence lands (PEER_STATE is a dict), but outbox_put
+        # refuses it as a path component, so every reply parks "unreachable" with no error anywhere
+        # (2026-08-11). Refuse the whole exchange instead — loud on the dialer's side (_peer_loop
+        # logs the refusal) — unless the canonicalization above already folded the junk into a
+        # checked-in alias, which is the existing self-heal and still works. Updated dialers never
+        # declare such a name (self_host falls back); this guards against un-updated ones.
+        return {"error": "unsafe host name %r — this machine's hostname fails path-safety; fix its "
+                         "hostname (or set ROMP_POSTAL_HOST) and redial" % host}, 400
     PEER_STATE[host] = {"presence": data.get("presence") or [], "epoch": data.get("epoch"),
                         "holds": data.get("holds") or [], "seenAt": int(time.time())}
     if bus_id:
@@ -2101,6 +2184,15 @@ def _peer_loop(host):
                 _peer_wake(host).clear()
                 _peer_wake(host).wait(60)
                 continue
+            body = ""
+            try:
+                body = " ".join((e.read() or b"").decode("utf-8", "replace").split())[:200]
+            except Exception:
+                pass
+            st = PEER_STATE.setdefault(host, {})
+            if st.get("refused") != (e.code, body):      # each DISTINCT refusal once, not per retry —
+                st["refused"] = (e.code, body)           # a 4xx (e.g. the unsafe-host gate) otherwise
+                _log("peer %s: exchange refused (HTTP %s) %s" % (host, e.code, body))   # retries silently forever
             fails += 1
             _peer_wake(host).clear()
             _peer_wake(host).wait(min(30, 2 ** min(fails, 5)))

--- a/tests/test_postal_self_host.py
+++ b/tests/test_postal_self_host.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""The self-host safety net: neither the bus nor the kernel may ever declare a machine name that
+fails _safe_id. Peers key the mail they hold FOR this machine by that name, as a path component —
+so a kern.hostname stomped with junk (control bytes, 2026-08-11) used to HALF-break peering:
+presence still crossed (PEER_STATE is a dict), but outbox_put on every peer refused the name, so
+each reply parked "unreachable" forever with only a server-log line as trace — and _unique() baked
+the junk into message ids, killing outbound the same way. self_host (bus) and _self_host (kernel)
+now validate and fall back loudly: the platform's user-set machine name, else a minted id persisted
+at the state root's self-host file, SHARED between the two daemons so the machine can never appear
+under two names. peer_exchange_handle refuses an unkeyable declared name (guarding against
+un-updated dialers) — but only AFTER _canon_peer_name, so the checked-in-alias fold keeps
+self-healing.
+
+Synthetic only — invented hostnames (TESTHOST, a control-byte junk form), hermetic temp state dir,
+no real machine data.
+"""
+import os
+import socket as _socket
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state dir BEFORE the loads: both daemons resolve their state root at import, and the
+# minted-id file must land here — shared by the two module instances, never in real state.
+# (ROMP_POSTAL_HOST / ROMP_HOST_NAME are deliberately NOT popped here: they are read at CALL time,
+# other test modules set them at IMPORT time, and pytest imports every module before running any
+# test — a module-level pop would erase theirs for the whole run. _HostnameSeams clears per test.)
+STATE_HOME = os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+pm = SourceFileLoader("romp_postal_selfhost", os.path.join(BIN, "romp-postal-service")).load_module()
+km = SourceFileLoader("romp_kernel_selfhost", os.path.join(BIN, "romp-kernel")).load_module()
+
+JUNK = "TEST\x04HOST"          # a control byte mid-name, the 2026-08-11 shape — fails _safe_id
+
+
+class _HostnameSeams(unittest.TestCase):
+    """Shared seams: fake gethostname (the stdlib socket module is one object, shared by both
+    loads), no platform name candidates unless a test supplies them, fallback caches reset — every
+    test states its own hostname world and leaks nothing."""
+
+    def setUp(self):
+        self._env = {k: os.environ.pop(k, None) for k in ("ROMP_POSTAL_HOST", "ROMP_HOST_NAME")}
+        self._gethostname = _socket.gethostname
+        self._pc, self._kc = pm._host_name_candidates, km._host_name_candidates
+        pm._host_name_candidates = km._host_name_candidates = lambda: []
+        pm._self_host_fb = km._self_host_fb = None
+
+    def tearDown(self):
+        for k, v in self._env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        _socket.gethostname = self._gethostname
+        pm._host_name_candidates, km._host_name_candidates = self._pc, self._kc
+        pm._self_host_fb = km._self_host_fb = None
+
+
+class BusSelfHost(_HostnameSeams):
+    def test_safe_hostname_passes_through_live(self):
+        _socket.gethostname = lambda: "TESTHOST.local"
+        self.assertEqual(pm.self_host(), "TESTHOST")
+        _socket.gethostname = lambda: "TESTHOST2"
+        self.assertEqual(pm.self_host(), "TESTHOST2", "a hostname fix lands with no restart")
+        self.assertIsNone(pm._self_host_fb, "no fallback engages for a healthy name")
+
+    def test_junk_falls_back_to_the_platform_machine_name(self):
+        _socket.gethostname = lambda: JUNK
+        pm._host_name_candidates = lambda: ["Test Person's Laptop!!"]
+        self.assertEqual(pm.self_host(), "Test-Person-s-Laptop", "sanitized, never raw")
+        self.assertTrue(pm._safe_id(pm.self_host()))
+
+    def test_junk_mints_a_stable_persisted_id(self):
+        _socket.gethostname = lambda: JUNK
+        a = pm.self_host()
+        self.assertTrue(pm._safe_id(a))
+        self.assertEqual(a, pm.self_host(), "cached within the process")
+        # A fresh load of the same bin (= a restarted bus) must resolve the SAME identity: peers
+        # key our mailbox by this name, so a per-process id would strand mail on every restart.
+        # Pin XDG to THIS module's state dir for the load — a later-imported test module may have
+        # re-pointed the env at its own tempdir during collection (imports all run before tests).
+        saved = os.environ.get("XDG_STATE_HOME")
+        os.environ["XDG_STATE_HOME"] = STATE_HOME
+        try:
+            pm2 = SourceFileLoader("romp_postal_selfhost_reload",
+                                   os.path.join(BIN, "romp-postal-service")).load_module()
+        finally:
+            os.environ["XDG_STATE_HOME"] = saved
+        pm2._host_name_candidates = lambda: []
+        pm2._self_host_fb = None
+        self.assertEqual(pm2.self_host(), a, "the minted id is persisted, not per-process")
+
+    def test_unique_mid_stays_path_safe(self):
+        # Mids are path components at outbox_put on BOTH ends, so a junk hostname baked into them
+        # killed outbound cross-host mail the same way the declared name killed inbound.
+        _socket.gethostname = lambda: JUNK
+        mid = pm._unique()
+        self.assertTrue(pm._safe_id(mid), "the mid must survive the outbox path check")
+        pm.outbox_put("TESTHOST", {"mid": mid, "body": "hi"})
+        self.assertEqual((pm.outbox_get("TESTHOST", mid) or {}).get("body"), "hi")
+        self.assertTrue(pm.outbox_del("TESTHOST", mid))
+
+
+class ExchangeUnkeyableHostGate(_HostnameSeams):
+    """peer_exchange_handle refuses a declared name that fails _safe_id — an un-updated dialer
+    could still declare one — but only AFTER _canon_peer_name, so the checked-in-alias fold (the
+    existing self-heal for a bus we already peer with under a dialable name) keeps working."""
+
+    def setUp(self):
+        super().setUp()
+        self._peers, self._pstate = dict(pm.PEERS), dict(pm.PEER_STATE)
+        self._agents = pm.local_agents
+        pm.local_agents = lambda: []          # presence enumeration is not under test; stay hermetic
+
+    def tearDown(self):
+        pm.local_agents = self._agents
+        pm.PEERS.clear(); pm.PEERS.update(self._peers)
+        pm.PEER_STATE.clear(); pm.PEER_STATE.update(self._pstate)
+        super().tearDown()
+
+    def test_unkeyable_declared_host_is_refused_400(self):
+        payload, status = pm.peer_exchange_handle({"host": JUNK, "proto": pm.PEER_PROTO})
+        self.assertEqual(status, 400, "refuse whole — half-working (presence without replies) is worse")
+        self.assertIn("error", payload)
+        self.assertNotIn(JUNK, pm.PEER_STATE, "no half-registered row for an unkeyable name")
+
+    def test_canon_fold_to_checked_in_alias_still_accepted(self):
+        pm.PEERS["safealias"] = {"port": 1}                       # dialable: the kernel notified this alias
+        pm.PEER_STATE["safealias"] = {"busId": "bus-11111111"}    # same bus, seen before under the alias
+        payload, status = pm.peer_exchange_handle(
+            {"host": JUNK, "busId": "bus-11111111", "proto": pm.PEER_PROTO})
+        self.assertEqual(status, 200, "the alias fold self-heals ahead of the gate")
+        self.assertIn("safealias", pm.PEER_STATE)
+        self.assertNotIn(JUNK, pm.PEER_STATE)
+
+
+class KernelSelfHost(_HostnameSeams):
+    def test_env_override_wins(self):
+        os.environ["ROMP_HOST_NAME"] = "TESTHOST"
+        try:
+            self.assertEqual(km._self_host(), "TESTHOST")
+        finally:
+            os.environ.pop("ROMP_HOST_NAME", None)
+
+    def test_safe_hostname_passes_through_live(self):
+        _socket.gethostname = lambda: "TESTHOST"
+        self.assertEqual(km._self_host(), "TESTHOST")
+        self.assertIsNone(km._self_host_fb, "no fallback engages for a healthy name")
+
+    def test_junk_is_never_declared_and_kernel_matches_bus(self):
+        _socket.gethostname = lambda: JUNK
+        k = km._self_host()
+        self.assertTrue(km._safe_id(k))
+        self.assertNotIn("\x04", k)
+        self.assertEqual(k, pm.self_host(),
+                         "kernel and bus share the persisted identity — one machine, one name")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
A machine whose kern.hostname is stomped with junk that fails `_safe_id` half-breaks peering: presence still crosses (PEER_STATE is a dict), but `outbox_put` on every peer refuses the name as a path component, so mail back parks "parked (unreachable)" forever — the only trace a server-log line. `_unique()` bakes the hostname into message ids (path-checked at `outbox_put`), so outbound cross-host mail died the same way. Seen live 2026-08-11 (control bytes in a stomped hostname).

- **bus `self_host()`**: validate the short hostname against `_safe_id`; fall back loudly — the platform's user-set machine name (scutil, sanitized), else a minted id persisted at the state root's `self-host` file (O_EXCL so racing processes converge). Healthy hostnames stay live-read: fixing the machine's name needs no restart. `_unique()` mids ride through it.
- **kernel `_self_host()`**: the same fallback, duplicated with a KEEP IN SYNC block (postal copy is the reference), reading the SAME persisted file — kernel and bus can never introduce the machine under two names. `ROMP_HOST_NAME` still overrides first.
- **`peer_exchange_handle()`**: refuse an unkeyable declared host with 400 — AFTER `_canon_peer_name`, so the checked-in-alias fold keeps self-healing; guards against un-updated dialers. `_peer_loop()` logs each distinct non-409 refusal once instead of retrying silently forever.
- **Tests** (`tests/test_postal_self_host.py`, synthetic hostnames only): live pass-through, junk→platform name, junk→minted id stable across reload, kernel/bus shared identity, mid path-safety round-trip, exchange 400 + canon-fold acceptance.

Full local suite: 4229 passed, 31 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)