### PR TITLE
Composer: pasting a local file's path attaches the file

### DIFF
--- a/ui/webview/composer-attach.test.ts
+++ b/ui/webview/composer-attach.test.ts
@@ -60,8 +60,11 @@ test("shipFileToHost stamps the session id so federation routes the bytes to the
   // routeOutbound routes any `id` field by host prefix (SCALAR_ID); the stamp is what
   // engages it (multi-kernel-merge.test.ts pins the routing itself). The sid is captured
   // at SHIP time (with the pending chip), not at encode time — a tab switch mid-encode
-  // must not reroute the bytes away from the session the user attached them to.
-  assert.match(RENDER, /const sid = activeId;/);
+  // must not reroute the bytes away from the session the user attached them to. Callers
+  // that already verified against a session (the pasted-path flow) pass THEIR captured
+  // sid; the default keeps ship-time capture for everyone else.
+  assert.match(RENDER, /function shipFileToHost\(f: File, sidAt: string \| null = activeId\)/);
+  assert.match(RENDER, /const sid = sidAt;/);
   assert.match(RENDER, /if \(sid\) msg\.id = sid;\s*\/\/ the owning session → the owning kernel/);
 });
 

--- a/ui/webview/composer-paste-path.test.ts
+++ b/ui/webview/composer-paste-path.test.ts
@@ -1,0 +1,89 @@
+// Pasting a local file's PATH into the composer attaches the FILE (the user 2026-08-11): the
+// path text used to ride the prompt verbatim, which on a remote session names a file that exists
+// only on this machine — the agent couldn't open it, while dragging the same file worked (drops
+// ship bytes). Now a paste whose WHOLE text is one path to a kind /file can serve is verified
+// against the PAGE's own kernel — the machine the paste came from — and converted into the same
+// visible attachment chip a drop produces: the zero-copy path for a locally-owned session,
+// shipped bytes (the existing dropFile route) for a remote one. A miss (404: not a local file, or
+// a path from some other machine) puts the EXACT text back at the cursor, so nothing changes for
+// ordinary text. pastedFilePath is a pure module (unit-tested below); the renderer has no jsdom
+// harness, so the wiring is pinned at the source level like the other composer tests.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pastedFilePath } from "./paste-path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const PASTE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "paste-path.ts"), "utf8");
+
+test("pastedFilePath accepts the whole-paste single-path shapes people actually paste", () => {
+  // the plain absolute path, and ~ (the kernel's _resolve_open_path expands it server-side)
+  assert.deepEqual(pastedFilePath("/tmp/shot.png"), { path: "/tmp/shot.png" });
+  assert.deepEqual(pastedFilePath("~/Desktop/Screenshot 2026-08-11 at 8.12.01 PM.png"),
+    { path: "~/Desktop/Screenshot 2026-08-11 at 8.12.01 PM.png" });
+  // Finder/shell quote wrappers come off
+  assert.deepEqual(pastedFilePath("'/tmp/a b.png'"), { path: "/tmp/a b.png" });
+  assert.deepEqual(pastedFilePath('"/tmp/a b.png"'), { path: "/tmp/a b.png" });
+  // terminal drag escaping (\ , \( …) is unescaped
+  assert.deepEqual(pastedFilePath("/tmp/Screenshot\\ at\\ 8.12.01\\ PM.png"),
+    { path: "/tmp/Screenshot at 8.12.01 PM.png" });
+  // file:// URI form is decoded (empty or localhost authority)
+  assert.deepEqual(pastedFilePath("file:///tmp/x%20y.png"), { path: "/tmp/x y.png" });
+  assert.deepEqual(pastedFilePath("file://localhost/tmp/x.pdf"), { path: "/tmp/x.pdf" });
+  // pdf is in the /file allowlist too
+  assert.deepEqual(pastedFilePath("/tmp/report.pdf"), { path: "/tmp/report.pdf" });
+  // surrounding whitespace (a copied line) is fine
+  assert.deepEqual(pastedFilePath("  /tmp/shot.png\n"), { path: "/tmp/shot.png" });
+});
+
+test("pastedFilePath rejects everything that is prose, partial, or unservable", () => {
+  // prose that mentions a path, before or after — the paste must BE the path
+  assert.equal(pastedFilePath("see /tmp/shot.png please"), null);
+  assert.equal(pastedFilePath("/tmp/shot.png is broken"), null);
+  // multi-line pastes are never one path
+  assert.equal(pastedFilePath("/tmp/a.png\n/tmp/b.png"), null);
+  // relative paths and bare words are prose (no cwd to resolve against — /file requires absolute)
+  assert.equal(pastedFilePath("shots/x.png"), null);
+  assert.equal(pastedFilePath("hello"), null);
+  // kinds /file won't serve stay text: code files, data, extensionless dirs
+  assert.equal(pastedFilePath("/tmp/notes.txt"), null);
+  assert.equal(pastedFilePath("/tmp/data.csv"), null);
+  assert.equal(pastedFilePath("/tmp/somedir"), null);
+  assert.equal(pastedFilePath(""), null);
+});
+
+test("the allowlist is previewKind's, imported — never a third copy to drift", () => {
+  assert.match(PASTE, /import \{ previewKind \} from "\.\/preview";/);
+  assert.match(PASTE, /if \(!previewKind\(s\)\) return null;/);
+});
+
+test("a path-shaped paste is verified on the PAGE's own kernel and converted, web only", () => {
+  // recognition + the web gate (the VS Code webview can't reach /file; its drops carry File.path)
+  assert.match(RENDER, /const pasted = pastedFilePath\(raw\);/);
+  assert.match(RENDER, /if \(!pasted \|\| !canPreview\(\)\) return;/);
+  // verified via fileUrl with NO sid — the page's own kernel, never routed to some other machine's
+  // disk; HEAD for a local session (existence only), GET when the bytes must ship
+  assert.match(RENDER, /fetch\(fileUrl\(pasted\.path\), \{ method: remote \? "GET" : "HEAD" \}\)/);
+});
+
+test("a local session keeps the zero-copy path; a remote one ships the bytes it verified", () => {
+  assert.match(RENDER, /if \(!remote\) \{ addComposerFile\(sid, pasted\.path\); return; \}/);
+  // the bytes ride the EXISTING dropFile pipeline (pending chip, 50 MB cap, droppedPath ack) —
+  // with the sid captured when the user pasted, so a tab switch mid-verify can't reroute them
+  assert.match(RENDER,
+    /shipFileToHost\(new File\(\[blob\], pasted\.path\.split\("\/"\)\.pop\(\) \|\| "pasted", \{ type: blob\.type \}\), sid\);/);
+});
+
+test("a miss puts the EXACT pasted text back — plain text behaves exactly like today", () => {
+  assert.match(RENDER, /ta\.setRangeText\(raw, selS, selE, "end"\);\s*\n\s*ta\.dispatchEvent\(new Event\("input", \{ bubbles: true \}\)\);/);
+  // a tab switch mid-verify lands the text in THAT session's draft instead of the wrong box
+  assert.match(RENDER, /drafts\.set\(sid, \(drafts\.get\(sid\) \|\| ""\) \+ raw\);/);
+  // network failure degrades the same way (text, not silence)
+  assert.match(RENDER, /\}\)\.catch\(putBack\);/);
+});
+
+test("an oversize pasted path is refused LOUDLY, and the text still lands", () => {
+  assert.match(RENDER, /if \(r\.status === 413\) \{/);
+  assert.match(RENDER, /is too large to attach from a "\s*\n\s*\+ "pasted path — it was pasted as text instead\./);
+});

--- a/ui/webview/paste-path.ts
+++ b/ui/webview/paste-path.ts
@@ -1,0 +1,23 @@
+// A plain-text paste that IS a local file's path (the user 2026-08-11: pasting a screenshot's
+// path into a remote session's box rode the prompt as text to a machine where that path doesn't
+// exist, while dragging the same file worked). The composer converts such a paste into a real
+// attachment — but only when the WHOLE paste is one plausible path to a file kind the kernel's
+// /file route can serve (previewKind: the same images+pdf allowlist previews wear), so prose that
+// merely mentions a path, multi-line pastes, and non-media paths all stay ordinary text.
+// Recognition here is deliberately SHAPE-only; existence is the kernel's call (/file 404s and the
+// composer puts the exact text back), never a guess — the authoritative-source rule.
+import { previewKind } from "./preview";
+
+export function pastedFilePath(text: string): { path: string } | null {
+  let s = (text || "").trim();
+  if (!s || /[\r\n]/.test(s)) return null;                 // one paste = one line = one path
+  const q = /^"(.*)"$|^'(.*)'$/.exec(s);                   // Finder/shell quote wrappers
+  if (q) s = (q[1] ?? q[2] ?? "").trim();
+  if (/^file:\/\//i.test(s)) {                             // browser / "Copy as URL" form
+    try { s = decodeURIComponent(s.replace(/^file:\/\/[^/]*/i, "")); } catch { return null; }
+  }
+  s = s.replace(/\\([ ()'"&])/g, "$1");                    // terminal-escaped spaces & friends
+  if (!/^[/~]/.test(s)) return null;                       // absolute or ~ only — a bare word is prose
+  if (!previewKind(s)) return null;                        // only kinds /file serves (img + pdf)
+  return { path: s };
+}

--- a/ui/webview/pending-attach.test.ts
+++ b/ui/webview/pending-attach.test.ts
@@ -23,8 +23,9 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kern
 test("the pending chip goes up BEFORE the encode starts — pick-to-feedback is immediate", () => {
   // registry keyed by session, like composerFiles beside it
   assert.match(RENDER, /const pendingShips = new Map<string, string\[\]>\(\);/);
-  // registered at the TOP of shipFileToHost (before new FileReader), with the sid captured once
-  assert.match(RENDER, /const name = f\.name \|\| "pasted\.png";\s*\n\s*const sid = activeId;\s*\n\s*addPendingShip\(sid, name\);\s*\n\s*const reader = new FileReader\(\);/);
+  // registered at the TOP of shipFileToHost (before new FileReader), with the sid captured once —
+  // at call time via the sidAt default (a pasted-path caller passes the sid it verified against)
+  assert.match(RENDER, /const name = f\.name \|\| "pasted\.png";\s*\n\s*const sid = sidAt;.*\n\s*addPendingShip\(sid, name\);.*\n\s*const reader = new FileReader\(\);/);
 });
 
 test("the strip renders pending chips (name + pulsing dots) and shows even with no real attachments", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -27,6 +27,7 @@ import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
 import { previewKind, previewFull, canPreview, fileUrl } from "./preview";
+import { pastedFilePath } from "./paste-path";
 import { hostNameNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
 import { dirStatusHint, nextDirActive, createDirPrompt, type DirStatus } from "./dir-complete";
 import { mediaSrc, kernelUrl } from "./media";
@@ -9000,17 +9001,57 @@ function setupComposer() {
 
   // Cmd+V a copied file (Finder "Copy") or a clipboard screenshot → insert its
   // path, same pipeline as drops (including the remote rule: a local path only
-  // for a locally-owned session). Plain text pastes have no files on the
-  // clipboard and keep the default behavior.
+  // for a locally-owned session). Plain text pastes keep the default behavior —
+  // EXCEPT a paste that IS a local file's path (pastedFilePath: the whole paste
+  // one line, absolute or ~, a kind /file serves). The user (2026-08-11) pasted
+  // a screenshot's PATH into a remote session's box: the text rode the prompt
+  // to a machine where that path doesn't exist, while dragging the same file
+  // worked. A path-shaped paste is verified against the PAGE's own kernel
+  // (/file — the machine the paste came from, auth-gated, existence-checked;
+  // no sid, so it never routes to some other kernel's disk) and converted to
+  // the same visible attachment chip a drop produces: the zero-copy path for a
+  // locally-owned session, shipped bytes for a remote one. A miss puts the
+  // EXACT text back at the cursor, so a path that isn't a local file pastes as
+  // plain text exactly like today. Web dashboard only (canPreview): the
+  // VS Code webview can't reach /file, and its Electron drops carry File.path.
   ta.addEventListener("paste", (e) => {
     const files = Array.from(e.clipboardData?.files || []);
-    if (!files.length) return;
+    if (files.length) {
+      e.preventDefault();
+      files.forEach((f) => {
+        const p = (f as any).path as string | undefined;
+        if (p && !hostOf(activeId || "")) addComposerFile(activeId, p);
+        else shipFileToHost(f);
+      });
+      return;
+    }
+    const raw = e.clipboardData?.getData("text/plain") || "";
+    const pasted = pastedFilePath(raw);
+    if (!pasted || !canPreview()) return;              // ordinary text → default paste
     e.preventDefault();
-    files.forEach((f) => {
-      const p = (f as any).path as string | undefined;
-      if (p && !hostOf(activeId || "")) addComposerFile(activeId, p);
-      else shipFileToHost(f);
-    });
+    const sid = activeId;
+    const selS = ta.selectionStart, selE = ta.selectionEnd;
+    const putBack = () => {                            // miss → the default outcome, a beat late
+      if (activeId === sid && document.contains(ta)) {
+        ta.setRangeText(raw, selS, selE, "end");
+        ta.dispatchEvent(new Event("input", { bubbles: true }));   // draft/grow/slash stay in sync
+      } else if (sid) {                                // tab switched mid-verify → land in that draft
+        drafts.set(sid, (drafts.get(sid) || "") + raw);
+        persistDrafts();
+      }
+    };
+    const remote = hostOf(sid || "");
+    fetch(fileUrl(pasted.path), { method: remote ? "GET" : "HEAD" }).then(async (r) => {
+      if (r.status === 413) {                          // refused LOUDLY, like every oversize arrival
+        warnToast((pasted.path.split("/").pop() || "That file") + " is too large to attach from a "
+          + "pasted path — it was pasted as text instead.");
+        return putBack();
+      }
+      if (!r.ok) return putBack();
+      if (!remote) { addComposerFile(sid, pasted.path); return; }  // zero-copy, like a local drop
+      const blob = await r.blob();                     // ship the BYTES — the remote can't read our path
+      shipFileToHost(new File([blob], pasted.path.split("/").pop() || "pasted", { type: blob.type }), sid);
+    }).catch(putBack);
   });
   wirePasteFallback(ta); // belt-and-braces: native paste disarms it, so no double-insert
 
@@ -9067,7 +9108,7 @@ function setupComposer() {
 // agent on THAT machine, so bytes saved on any other kernel would hand the agent
 // a path that does not exist there.
 const SHIP_MAX_BYTES = 50 * 1024 * 1024;   // payload ceiling for shipped attachment bytes
-function shipFileToHost(f: File) {
+function shipFileToHost(f: File, sidAt: string | null = activeId) {
   if (f.size > SHIP_MAX_BYTES) {
     // an oversize file must be REFUSED VISIBLY, never dropped silently — name the
     // file, its size and the cap, on the same loud surface a failed federation
@@ -9080,8 +9121,8 @@ function shipFileToHost(f: File) {
   // WS send + kernel round trip is seconds of otherwise-blank time that read as a dead click (the
   // user 2026-08-11). Retired by the droppedPath ack / dropSaveFailed nack (see retirePendingShip).
   const name = f.name || "pasted.png";
-  const sid = activeId;
-  addPendingShip(sid, name);
+  const sid = sidAt;   // captured at CALL (= ship) time via the default param — a tab switch
+  addPendingShip(sid, name);   // mid-encode (or mid-verify, for a pasted path) must not reroute
   const reader = new FileReader();
   reader.onload = () => {
     const b64 = String(reader.result || "").split(",")[1] || "";


### PR DESCRIPTION
Pasting a screenshot's path into the message box sent the agent plain text. On a remote session that text names a file that exists only on this machine, so the agent couldn't open it — while dragging the same file worked, because drops ship bytes (#289). The user hit exactly this pasting screenshot paths into remote sessions (2026-08-11).

- **Recognition** (`ui/webview/paste-path.ts`, pure + unit-tested): the WHOLE paste is one path-shaped line — quote wrappers, `file://` form, and terminal escapes normalized; absolute or `~` only; `previewKind`'s img+pdf allowlist imported, never a third copy. Prose that mentions a path, multi-line pastes, and non-media paths stay ordinary text.
- **Verification is the kernel's, never a guess**: the composer fetches `fileUrl(path)` on the PAGE's own kernel (the machine the paste came from; no sid, so the check never routes to another kernel's disk). HEAD for a locally-owned session, GET when the bytes must ship.
- **Conversion is visible**: the same attachment chip a drop produces — zero-copy path for a local session, bytes through the existing dropFile pipeline (pending chip, 50 MB cap, droppedPath ack) for a remote one. A miss puts the EXACT text back at the cursor (or into that session's draft if the tab switched mid-verify); an oversize file is refused loudly (413 → toast). Web dashboard only (`canPreview`): the VS Code webview can't reach `/file`, and its Electron drops already carry `File.path`.
- `shipFileToHost` gains a `sidAt` param (default `activeId` at call time — every existing caller unchanged) so the pasted-path flow ships to the session the user pasted into, not wherever the tab sits after the verify round trip. The two source pins naming the old line are updated.

Tests: `composer-paste-path.test.ts` (parser unit tests + wiring pins). Extension suite: 1839 pass, typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)