### PR TITLE
Remote clone discovery reads the remote's own authority, not a guess list

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -489,6 +489,21 @@ def _load_token():
 
 TOKEN = _load_token()
 
+def _persist_repo_root():
+    """The kernel's own repo root, written into state at boot (state/romp/repo-root). This is the
+    AUTHORITATIVE answer for a peer kernel's clone-discovery probes (_start_remote_kernel,
+    _discover_remote_clone): the running kernel knows exactly where it lives, so probes read this
+    file over ssh FIRST instead of guessing conventional dirs — the guess list missed a clone at
+    ~/projects/romp while that machine's kernel was literally up, reporting "romp not installed"
+    (the user 2026-08-11). Best-effort, like the serve-token mint above."""
+    try:
+        jd.STATE.mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "repo-root").write_text(str(ROOT) + "\n")
+    except OSError:
+        pass
+
+_persist_repo_root()
+
 def _ct_eq(a, b):
     """Constant-time string compare (no timing oracle on the serve token); never
     raises on odd input."""
@@ -6650,12 +6665,18 @@ def _remote_kernel_up(host, port):
 
 
 def _start_remote_kernel(host):
-    """Start the remote kernel: nohup romp-serve, found on PATH or in conventional clone locations
-    (a non-login ssh shell often lacks the user's PATH additions). romp-serve itself picks the right
-    python (its pick_python) and self-builds stale UI bundles, so a plain clone is enough. Returns
-    (started, detail) — detail names the next step when romp isn't installed there."""
-    cmd = ('S="$(command -v romp-serve || true)"; '
-           'if [ -z "$S" ]; then for d in "$HOME/GitRepos/romp" "$HOME/romp" "$HOME/code/romp" "$HOME/src/romp"; do '
+    """Start the remote kernel: nohup romp-serve, found via the remote's OWN authority first — the
+    repo-root file its kernel persists at boot (_persist_repo_root; ROMP_REPO_ROOT on the target
+    overrides), never a guess (the authoritative-sources rule; the old guess list missed a clone at
+    ~/projects/romp, the user 2026-08-11) — then PATH (non-login, then a login shell: a non-login
+    ssh shell often lacks the user's PATH additions), then conventional clone locations. romp-serve
+    itself picks the right python (its pick_python) and self-builds stale UI bundles, so a plain
+    clone is enough. Returns (started, detail) — detail names everything the probe tried when romp
+    isn't installed there. KEEP the source order IN SYNC with _discover_remote_clone."""
+    cmd = ('S=""; SR="${ROMP_REPO_ROOT:-$(cat "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/repo-root" 2>/dev/null)}"; '
+           'if [ -n "$SR" ] && [ -x "$SR/bin/romp-serve" ]; then S="$SR/bin/romp-serve"; fi; '
+           'if [ -z "$S" ]; then S="$(command -v romp-serve || bash -lc "command -v romp-serve" 2>/dev/null || true)"; fi; '
+           'if [ -z "$S" ]; then for d in "$HOME/projects/romp" "$HOME/GitRepos/romp" "$HOME/romp" "$HOME/code/romp" "$HOME/src/romp"; do '
            'if [ -x "$d/bin/romp-serve" ]; then S="$d/bin/romp-serve"; break; fi; done; fi; '
            'if [ -z "$S" ]; then echo NOROMP; exit 0; fi; '
            'LOGDIR="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}"; mkdir -p "$LOGDIR"; '
@@ -6666,7 +6687,11 @@ def _start_remote_kernel(host):
         if "STARTED" in out:
             return True, out.partition(":")[2]
         if "NOROMP" in out:
-            return False, "romp not installed on %s — clone it and run ./install.sh" % host
+            return False, ("romp not installed on %s — no repo-root state file (a kernel that has "
+                           "run there writes one; ROMP_REPO_ROOT on that machine also works), no "
+                           "romp-serve on PATH (login shell included), and no clone in "
+                           "~/projects/romp, ~/GitRepos/romp, ~/romp, ~/code/romp, ~/src/romp. "
+                           "Clone romp there and run ./install.sh." % host)
         return False, (_ssh_err(r.stderr) or out or "ssh failed").strip()[:200]
     except Exception as e:
         return False, str(e)
@@ -7577,12 +7602,20 @@ _P2P_REF = "romp-p2p-sync"   # scratch branch the local kernel force-pushes its 
 
 
 def _discover_remote_clone(host):
-    """ssh-discover the remote romp clone (conventional dirs, mirrors _start_remote_kernel) and its
-    state. Returns (dir, head, dirty, error) — error set (and the rest blank) on any failure. Shared
-    by the push (_update_remote) and pull (_pull_remote) directions."""
+    """ssh-discover the remote romp clone and its state. The remote's OWN authority first — the
+    repo-root file its kernel persists at boot (_persist_repo_root; ROMP_REPO_ROOT on the target
+    overrides) — then a romp-serve found on PATH (non-login, then login shell) resolved to the repo
+    that holds it, then conventional dirs. KEEP the source order IN SYNC with _start_remote_kernel.
+    Returns (dir, head, dirty, error) — error set (and the rest blank) on any failure, naming
+    everything tried. Shared by the push (_update_remote) and pull (_pull_remote) directions."""
     disc = (
-        'R=""; for d in "$HOME/GitRepos/romp" "$HOME/romp" "$HOME/code/romp" "$HOME/src/romp"; do '
-        'if [ -d "$d/.git" ]; then R="$d"; break; fi; done; '
+        'R=""; SR="${ROMP_REPO_ROOT:-$(cat "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/repo-root" 2>/dev/null)}"; '
+        'if [ -n "$SR" ] && [ -d "$SR/.git" ]; then R="$SR"; fi; '
+        'if [ -z "$R" ]; then B="$(command -v romp-serve || bash -lc "command -v romp-serve" 2>/dev/null || true)"; '
+        'if [ -n "$B" ]; then B="$(readlink -f "$B" 2>/dev/null || echo "$B")"; D="$(dirname "$(dirname "$B")")"; '
+        'if [ -d "$D/.git" ]; then R="$D"; fi; fi; fi; '
+        'if [ -z "$R" ]; then for d in "$HOME/projects/romp" "$HOME/GitRepos/romp" "$HOME/romp" "$HOME/code/romp" "$HOME/src/romp"; do '
+        'if [ -d "$d/.git" ]; then R="$d"; break; fi; done; fi; '
         'if [ -z "$R" ]; then echo NOROMP; exit 0; fi; '
         'echo "DIR:$R"; echo "HEAD:$(git -C "$R" rev-parse HEAD 2>/dev/null)"; '
         'echo "DIRTY:$(git -C "$R" status --porcelain 2>/dev/null | head -c 1)"')
@@ -7592,7 +7625,9 @@ def _discover_remote_clone(host):
         return "", "", "", str(e)[:200]
     out = d.stdout or ""
     if "NOROMP" in out:
-        return "", "", "", "romp not installed on %s (looked in ~/GitRepos/romp, ~/romp, ~/code/romp, ~/src/romp)" % host
+        return "", "", "", ("romp not installed on %s (no repo-root state file, no romp-serve on "
+                            "PATH — login shell included — and no clone in ~/projects/romp, "
+                            "~/GitRepos/romp, ~/romp, ~/code/romp, ~/src/romp)" % host)
     info = dict((l.split(":", 1) + [""])[:2] for l in out.splitlines() if ":" in l)
     rdir, rhead, rdirty = info.get("DIR", "").strip(), info.get("HEAD", "").strip(), info.get("DIRTY", "").strip()
     if not rdir:

--- a/tests/test_remote_clone_discovery.py
+++ b/tests/test_remote_clone_discovery.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Remote romp-clone discovery reads the remote's OWN authority, never just a guess list. The old
+probes searched four hardcoded dirs, so a clone at ~/projects/romp reported "romp not installed"
+while that machine's kernel was literally up (the user 2026-08-11, who called the hardcoding
+wrong). Now every kernel persists its repo root into state at boot (state/romp/repo-root), and the
+probes (_start_remote_kernel, _discover_remote_clone) consult, in order: ROMP_REPO_ROOT on the
+target, the repo-root state file, romp-serve on PATH (non-login, then a login shell), then the
+conventional dirs — ~/projects/romp included — and a miss names everything tried.
+
+These tests execute the REAL ssh snippets: SSH_BIN is swapped for a stub that runs the probe
+command locally under a synthetic fixture HOME (env -i, so nothing of the test machine leaks in).
+Synthetic paths only; no real machine data.
+"""
+import os
+import subprocess
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_clonedisc", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _mk_clone(root):
+    """A minimal thing the probes recognize as a romp clone: bin/romp-serve (executable stub — the
+    start path nohups it, so it must run and exit clean) and a .git dir."""
+    os.makedirs(os.path.join(root, "bin"), exist_ok=True)
+    os.makedirs(os.path.join(root, ".git"), exist_ok=True)
+    sh = os.path.join(root, "bin", "romp-serve")
+    with open(sh, "w") as f:
+        f.write("#!/bin/sh\nexit 0\n")
+    os.chmod(sh, 0o755)
+    return root
+
+
+def _state_file(home, repo_root):
+    d = os.path.join(home, ".local", "state", "romp")
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, "repo-root"), "w") as f:
+        f.write(repo_root + "\n")
+
+
+def _fake_ssh(home, extra_env=""):
+    """An SSH_BIN stand-in: ignore every ssh arg, execute the probe command (always the last arg)
+    locally under the fixture HOME with a scrubbed environment — the probe's shell logic runs for
+    real, against a filesystem the test fully controls."""
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "ssh")
+    with open(p, "w") as f:
+        f.write('#!/usr/bin/env bash\n'
+                'for last in "$@"; do :; done\n'
+                'exec env -i HOME="%s" PATH="/usr/bin:/bin" %s bash -c "$last"\n' % (home, extra_env))
+    os.chmod(p, 0o755)
+    return p
+
+
+class _ProbeCase(unittest.TestCase):
+    def _use(self, home, extra_env=""):
+        self._saved = km.SSH_BIN
+        km.SSH_BIN = _fake_ssh(home, extra_env)
+        self.addCleanup(lambda: setattr(km, "SSH_BIN", self._saved))
+
+
+class RepoRootStateFile(_ProbeCase):
+    def test_state_file_wins_over_the_candidate_dirs(self):
+        home = tempfile.mkdtemp()
+        real = _mk_clone(os.path.join(home, "weird", "spot", "romp"))   # nowhere a guess would look
+        _mk_clone(os.path.join(home, "projects", "romp"))               # decoy in the candidate list
+        _state_file(home, real)
+        self._use(home)
+        rdir, _, _, err = km._discover_remote_clone("TESTHOST")
+        self.assertEqual((rdir, err), (real, ""))
+        ok, detail = km._start_remote_kernel("TESTHOST")
+        self.assertTrue(ok, detail)
+        self.assertEqual(detail, os.path.join(real, "bin", "romp-serve"))
+
+    def test_target_env_override_beats_the_state_file(self):
+        home = tempfile.mkdtemp()
+        enved = _mk_clone(os.path.join(home, "override", "romp"))
+        _state_file(home, _mk_clone(os.path.join(home, "stale", "romp")))
+        self._use(home, extra_env='ROMP_REPO_ROOT="%s"' % enved)
+        rdir, _, _, err = km._discover_remote_clone("TESTHOST")
+        self.assertEqual((rdir, err), (enved, ""))
+
+    def test_a_stale_state_file_falls_through_to_the_dirs(self):
+        home = tempfile.mkdtemp()
+        _state_file(home, os.path.join(home, "moved-away", "romp"))     # points at nothing
+        want = _mk_clone(os.path.join(home, "projects", "romp"))
+        self._use(home)
+        rdir, _, _, err = km._discover_remote_clone("TESTHOST")
+        self.assertEqual((rdir, err), (want, ""))
+
+    def test_the_kernel_persists_its_own_repo_root_at_boot(self):
+        # the writer half of the contract: what THIS kernel writes is what a peer's probe reads.
+        # Re-run the writer the module-level boot call already ran once — another suite's SPAWNED
+        # kernel inherits this process's XDG env and can stomp the boot-time copy mid-run.
+        f = km.jd.STATE / "repo-root"
+        f.unlink(missing_ok=True)
+        km._persist_repo_root()
+        self.assertEqual(f.read_text().strip(), str(km.ROOT))
+
+
+class CandidateDirs(_ProbeCase):
+    def test_projects_romp_is_now_a_candidate(self):
+        home = tempfile.mkdtemp()
+        want = _mk_clone(os.path.join(home, "projects", "romp"))        # the dir the old list missed
+        self._use(home)
+        rdir, _, _, err = km._discover_remote_clone("TESTHOST")
+        self.assertEqual((rdir, err), (want, ""))
+        ok, detail = km._start_remote_kernel("TESTHOST")
+        self.assertTrue(ok, detail)
+        self.assertEqual(detail, os.path.join(want, "bin", "romp-serve"))
+
+
+class LoginShellPath(_ProbeCase):
+    def test_login_shell_path_finds_the_bin_and_resolves_its_repo(self):
+        # a non-login ssh shell misses the user's PATH additions; the probe retries via `bash -l`,
+        # which reads the fixture's .bash_profile — and the found bin is readlink-resolved to the
+        # clone that holds it, so the git half works from a PATH hit too
+        home = tempfile.mkdtemp()
+        clone = _mk_clone(os.path.join(home, "tucked", "romp"))
+        os.makedirs(os.path.join(home, "mybin"), exist_ok=True)
+        os.symlink(os.path.join(clone, "bin", "romp-serve"), os.path.join(home, "mybin", "romp-serve"))
+        with open(os.path.join(home, ".bash_profile"), "w") as f:
+            f.write('PATH="$HOME/mybin:$PATH"\n')
+        self._use(home)
+        ok, detail = km._start_remote_kernel("TESTHOST")
+        self.assertTrue(ok, detail)
+        self.assertTrue(detail.endswith("romp-serve"), detail)
+        rdir, _, _, err = km._discover_remote_clone("TESTHOST")
+        # realpath both sides: readlink -f canonicalizes (macOS /var → /private/var)
+        self.assertEqual((os.path.realpath(rdir), err), (os.path.realpath(clone), ""))
+
+
+class MissIsLoud(_ProbeCase):
+    def test_noromp_names_every_source_it_tried(self):
+        home = tempfile.mkdtemp()                                       # nothing romp-ish at all
+        self._use(home)
+        rdir, _, _, err = km._discover_remote_clone("TESTHOST")
+        self.assertEqual(rdir, "")
+        self.assertIn("not installed", err)
+        for named in ("repo-root", "PATH", "login shell", "~/projects/romp", "~/GitRepos/romp"):
+            self.assertIn(named, err, "the discover miss must name %r" % named)
+        ok, detail = km._start_remote_kernel("TESTHOST")
+        self.assertFalse(ok)
+        self.assertIn("not installed", detail)
+        for named in ("repo-root", "PATH", "login shell", "~/projects/romp", "./install.sh"):
+            self.assertIn(named, detail, "the start miss must name %r" % named)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The probes behind attach-bootstrap Start (`_start_remote_kernel`) and push/update (`_discover_remote_clone`) searched four hardcoded dirs (`~/GitRepos/romp`, `~/romp`, `~/code/romp`, `~/src/romp`), so a clone at `~/projects/romp` reported "romp not installed" while that machine's kernel was literally up (hit live 2026-08-11 from another machine's view).

Per the authoritative-sources rule:

- **Every kernel persists its own repo root at boot** (`_persist_repo_root` → `state/romp/repo-root`) — it knows exactly where it lives; best-effort, beside the serve-token mint.
- **Both probes consult, in order**: `ROMP_REPO_ROOT` on the target → the repo-root state file → `romp-serve` on PATH (non-login, then a login shell; the found bin readlink-resolves to the repo that holds it) → the conventional dirs, `~/projects/romp` added. Every candidate is validated before use (executable `bin/romp-serve` / a `.git` dir), so a stale file falls through instead of wedging.
- **A miss stays loud** and names every source tried.

Tests execute the real ssh snippets — SSH_BIN swapped for a stub running the probe command locally under a synthetic fixture HOME (`env -i`) — covering source order, the env override, stale-file fall-through, login-shell PATH + readlink derivation, and the loud miss. Full suite: 4237 passed.

Item 1 of 2 from today's network-popover delegate; the popover remote-controls feature builds on this (its dropdown Start buttons fire this probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)