### PR TITLE
Network popover: every machine's connections, managed from one dashboard

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6552,6 +6552,68 @@ def pairs_snapshot():
     return {"ok": True, "hosts": hosts, "pairs": pairs}
 
 
+def tunnels_of(host):
+    """ONE attached host's own /tunnels payload, read live through its tunnel + serve token
+    (pairs_snapshot's transport, single host, FULL rows) — the popover's per-host "connections"
+    expand: the dashboard renders THAT machine's attached-host list with the same fields its own
+    popover uses (status, kernelVer/kernelSha, outOfDate/behindBy/aheadBy, fastForward/fastPull/
+    askPull, trust, autoPush…), so what's connected to what is managed from one place (the user
+    2026-08-11). Fetched on demand — expand, or after a forwarded action — never in the popover's
+    3s poll, the /tunnels/pairs rule. Loud errors, never a silent empty list."""
+    host = str(host or "").strip()
+    if not host:
+        return {"ok": False, "error": "host required"}
+    with _remotes_lock:
+        r = dict(_remotes.get(host) or {})
+    if not r:
+        return {"ok": False, "error": "no attached tunnel to '%s'" % host}
+    if (r.get("status") or "") != "up":
+        return {"ok": False, "error": "'%s' is %s — its connections are readable only while it is up"
+                                      % (host, r.get("status") or "down")}
+    st, j, err = _remote_kernel_call(r, "GET", "/tunnels", timeout=6)
+    if err or not isinstance(j, dict):
+        return {"ok": False, "error": err or ("HTTP %s from %s" % (st, host))}
+    j = dict(j)
+    j["ok"] = True
+    j["of"] = host
+    return j
+
+
+# Forwarded row actions block on the via machine's own ssh work; update/start push code and wait
+# out a boot, so they get the long leash — everything else is a quick local flip there.
+_VIA_TIMEOUT = {"/tunnels/update": 180, "/tunnels/pull": 120, "/tunnels/askpull": 120,
+                "/tunnels/start": 120}
+
+def _via_forward(body, path):
+    """A popover action carrying {"via": <attached host>} is relayed to THAT machine's kernel over
+    its tunnel + its own serve token — the attach route's "from" forwarding (2026-07-25),
+    generalized to the rest of the row controls so every machine's connections are manageable from
+    one dashboard (the user 2026-08-11). The via machine owns the tunnel being acted on and judges
+    the action itself — ssh reachability, credentials, dirty-tree refusals all happen THERE; we
+    only relay the ask and bubble its answer back tagged with `via`. Same trust boundary as
+    mirror_trust: this only ever dials a tunnel THIS user attached, with the token they already
+    hold. Returns None when the body carries no via — the caller handles the action locally,
+    exactly as before."""
+    via = str((body or {}).get("via") or "").strip() if isinstance(body, dict) else ""
+    if not via:
+        return None
+    with _remotes_lock:
+        r = dict(_remotes.get(via) or {})
+    if not r or r.get("status") != "up":
+        return {"ok": False, "via": via,
+                "error": "'%s' is not an attached, connected host — its connections can't be driven "
+                         "from here until it is" % via}
+    fwd = {k: v for k, v in body.items() if k != "via"}
+    st, j, err = _remote_kernel_call(r, "POST", path, fwd, timeout=_VIA_TIMEOUT.get(path, 15))
+    if err:
+        return {"ok": False, "error": err, "via": via}
+    res = j if isinstance(j, dict) else {"error": "bad answer (HTTP %s) from %s" % (st, via)}
+    if "ok" not in res:
+        res["ok"] = (st == 200)
+    res["via"] = via
+    return res
+
+
 def _checkin_payload(r):
     return {"host": _self_host(), "kernelPort": r.get("rk_port"), "busPort": r.get("rb_port"),
             "token": _load_token()}
@@ -19297,6 +19359,20 @@ var _pendTrust={},_pendMirror={};
 // tunnel, so it never rides the 3s poll itself: refresh() kicks it, one in flight at a time
 // (_pairsBusy), and the answer repaints from the poll's cached args (_lastArgs) — no fetch loop.
 var _pendPair={},_pairs=null,_pairsBusy=false,_lastArgs=null,_lastUp=0;
+// ITS CONNECTIONS (the user 2026-08-11): every up host's row expands into THAT machine's own
+// attached-host list — same row treatment, working controls — so what's connected to what is
+// managed from one dashboard. Rows come from /tunnels/of (its own /tunnels over your tunnel + its
+// serve token), fetched on EXPAND and after a forwarded action, never in the 3s poll (the
+// /tunnels/pairs rule). Actions post the normal routes with {via}; the kernel relays them to the
+// machine that owns the tunnel (_via_forward). Keyed expand state + a via|host pending-trust
+// latch survive re-renders. strip.ts carries the same feature; the copies must stay in step
+// (net-remote-controls.test.ts pins both).
+var _openSub={},_subInfo={},_subBusy={},_pendSub={};
+function fetchSub(h){if(_subBusy[h])return;_subBusy[h]=1;
+fetch('/tunnels/of?host='+encodeURIComponent(h),{cache:'no-store'}).then(function(r){return r.json();})
+.catch(function(e){return {ok:false,error:String((e&&(e.message||e.name))||e)};})
+.then(function(d){delete _subBusy[h];_subInfo[h]=d||{ok:false,error:'empty answer'};
+if(_openSub[h])repaint();});}
 function pendLvl(map,host,current){var p=map[host];if(p&&current===p){delete map[host];p=null;}return p;}
 function fillHosts(){if(!dl)return;var hs=[];
 [[mruHost()],_seen,_cfg].forEach(function(g){(g||[]).forEach(function(h){if(h&&hs.indexOf(h)<0)hs.push(h);});});   // most-recently-connected first, not just ssh-config order
@@ -19460,6 +19536,41 @@ via=via.filter(function(v){return !live[v.host];});
 var viaHosts={};via.forEach(function(v){viaHosts[v.host]=1;});
 known=known.filter(function(k){return !viaHosts[k.host];});   // a relay row shows the SAME trust select, plus live reach
 var TRUSTW={trusted:'trusted (auto-accept)',directed:'directed (held for you)',isolated:'isolated (no mail)'};
+// The expanded "connections" block under an up host: THAT machine's attached rows, indented, with
+// the controls its own popover would offer — drift there is measured between the via machine and
+// its remote (its own numbers), and every action rides the normal route + {via}. Loading and a
+// failed read say so (with Retry), never a silent blank.
+function subBlock(via){var box=document.createElement('div');box.className='rnet-subwrap';
+var d=_subInfo[via];
+if(!d){box.innerHTML='<div class=\"rnet-empty rnet-sub\">'+spin()+'Reading '+via+'\\u2019s connections\\u2026</div>';return box;}
+if(!d.ok){box.innerHTML='<div class=\"rnet-empty rnet-sub\">Couldn\\u2019t read '+via+'\\u2019s connections: '+(d.error||'unknown error')+' <button data-xr=\"'+via+'\">Retry</button></div>';return box;}
+var rows=d.tunnels||[];
+if(!rows.length){box.innerHTML='<div class=\"rnet-empty rnet-sub\">'+via+' has no hosts attached.</div>';return box;}
+rows.forEach(function(s){
+var sr=document.createElement('div');sr.className='rnet-row rnet-sub';
+var sdot=s.status==='up'?'background:var(--accent)':(s.status==='error'||s.status==='no-kernel')?'background:#E5534B':(s.status==='down')?'background:#8a8a8a':'background:transparent;box-shadow:inset 0 0 0 1.5px var(--accent)';
+var sver='',sbw=buildWord(s.kernelVer,s.kernelSha);
+if(s.outOfDate){var sar=driftCounts(s);
+sver=' \\u00b7 <span class=rnet-old title=\"'+s.host+' runs '+(sbw||'?')+'; '+via+' is at '+(buildWord(s.localVer,s.localSha)||'?')+' \\u2014 drift here is between THOSE two machines, not this one.\">'+(sbw?sbw+' ':'')+(sar?'('+sar+')':driftWord(s))+'</span>';}
+else if(sbw){sver=' \\u00b7 <span class=rnet-sha title=\"same build as '+via+'\">'+sbw+'</span>';}
+var vk=via+'|'+s.host;
+var spd=pendLvl(_pendSub,vk,s.trust||'directed');
+var scur=spd||s.trust||'directed';
+var strust='<select class=\"rnet-trust'+(spd?' rnet-applying':'')+'\"'+(spd?' disabled':'')+' data-vt=\"'+vk+'\" title=\"What '+via+' does with postal mail from '+s.host+'. Set on '+via+', over your tunnel + its own token \\u2014 the you-with-both-tokens boundary.\">'+
+['trusted','directed','isolated'].map(function(v){return '<option value='+v+(scur===v?' selected':'')+'>'+TRUSTW[v]+'</option>';}).join('')+'</select>'+(spd?'<span class=rnet-pend>'+spin()+'applying\\u2026</span>':'');
+// the same provably-possible gating as the top rows, judged with the fields VIA computed about
+// ITS remote (fastForward/fastPull/askPull are relative to via's own build).
+var sapx=s.autoPush&&apBusy(s.autoPush.phase);
+var sb='';
+if(s.status==='up'&&s.fastForward&&!sapx&&!s.checkinPeer)sb+='<button class=rnet-upd data-vu=\"'+vk+'\" title=\"Push '+via+'\\u2019s committed romp to '+s.host+' and restart its kernel \\u2014 the work runs on '+via+'.\">Push</button>';
+if(s.status==='up'&&s.askPull&&!sapx)sb+='<button class=rnet-upd data-va=\"'+vk+'\" title=\"'+s.host+' checked in to '+via+' over its own tunnel, so '+via+' cannot push to it. This asks it to pull '+via+'\\u2019s commits over the link it already holds.\">Update</button>';
+if(s.status==='up'&&s.fastPull&&!sapx&&!s.checkinPeer)sb+='<button class=rnet-upd data-vp=\"'+vk+'\" title=\"Pull '+s.host+'\\u2019s newer commits into '+via+'\\u2019s romp (fast-forward only) \\u2014 the work runs on '+via+'.\">Pull</button>';
+if(s.status==='no-kernel')sb+='<button class=rnet-upd data-vs=\"'+vk+'\" title=\"No kernel answers '+via+'\\u2019s tunnel to '+s.host+'. This has '+via+' push its romp there and boot it.\">Start</button>';
+sr.innerHTML='<span class=rnet-dot style=\"'+sdot+'\" title=\"'+(TIP[s.status]||'')+'\"></span>'+
+'<span class=nm><b>'+s.host+'</b> <span class=st title=\"'+via+'\\u2019s tunnel to '+s.host+'. '+(TIP[s.status]||'')+'\">'+(busyStatus(s.status)?spin():'')+(LBL[s.status]||s.status)+sver+'</span></span>'+
+strust+sb+'<button data-vh=\"'+vk+'\" title=\"Close '+via+'\\u2019s ssh tunnel to '+s.host+'. It stays in '+via+'\\u2019s previously-attached list.\">Detach</button>';
+box.appendChild(sr);});
+return box;}
 // Every host romp knows about feeds the add box's completions, so a machine you typed in once is a
 // couple of keystrokes the next time even after you forget its exact spelling.
 _seen=ts.map(function(t){return t.host;}).concat(known.map(function(k){return k.host;}));fillHosts();
@@ -19558,7 +19669,10 @@ row.innerHTML='<span class=rnet-dot style=\"'+dot+'\" title=\"'+(TIP[t.status]||
 // the status word, so "connecting" reads as something HAPPENING rather than a label that might be stuck.
 // The repo's loading rule spelled small: same glyph, same reverse spin as the composer's slash spinner.
 '<span class=nm><b>'+t.host+'</b> <span class=st title=\"'+(TIP[t.status]||'')+'\">'+(busyStatus(t.status)?spin():'')+(LBL[t.status]||t.status)+(t.checkinPeer?' \\u00b7 checked in here':'')+(t.token?'':' \\u00b7 no token')+(again?' \\u00b7 '+again:'')+ver+'</span></span>'+
-retry+pull+ask+upd+strt+'<button data-h=\"'+t.host+'\" title=\"Close the ssh tunnel to '+t.host+'. It stays in this list as a previously-attached host, keeping its trust level, so you can re-attach in one click.\">Detach</button>';
+retry+pull+ask+upd+strt+'<button data-h=\"'+t.host+'\" title=\"Close the ssh tunnel to '+t.host+'. It stays in this list as a previously-attached host, keeping its trust level, so you can re-attach in one click.\">Detach</button>'+
+// ITS CONNECTIONS toggle — the keyed expand (progressive disclosure): compact row by default,
+// that machine's own attached list one click deeper, fetched on the click, never the poll.
+(t.status==='up'?'<button class=rnet-subtoggle data-x=\"'+t.host+'\" title=\"'+t.host+'\\u2019s own attached hosts \\u2014 see and manage what IT is connected to, from here. Rows read live from its kernel over your tunnel + its own token; actions run there.\">'+(_openSub[t.host]?'\\u25be':'\\u25b8')+' connections</button>':'');
 item.appendChild(row);
 // Live automatic-update phase, on its own line under the row — this is the whole reason the modal could
 // go away: the work still announces itself, it just does it here instead of over your screen. A FAILURE
@@ -19575,6 +19689,7 @@ ap.title=t.autoPush.phase==='failed'?'romp tried to update this host automatical
 item.appendChild(ap);}
 var r2=document.createElement('div');r2.className='rnet-row2';r2.innerHTML=trust+keep;
 item.appendChild(r2);
+if(t.status==='up'&&_openSub[t.host])item.appendChild(subBlock(t.host));
 list.appendChild(item);});
 // PREVIOUSLY ATTACHED (the user 2026-07-22): hosts you attached before, kept after detach so they are
 // one click away instead of something you retype. Dimmed, and each remembers the trust
@@ -19714,7 +19829,32 @@ b.disabled=true;b.textContent='Asking\\u2026';   // the work runs on the PEER, o
 fetch('/tunnels/askpull',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h})}).then(function(r){return r.json();}).then(function(d){
 if(d&&d.ok){b.textContent='Updating';schedule(2000);}   // it pulled + is restarting → its next /version clears the flag
 else{b.disabled=false;b.textContent='Retry';alert('Updating '+h+' failed: '+((d&&d.detail)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
-}).catch(function(){b.disabled=false;b.textContent='Retry';alert('Updating '+h+' failed to reach the kernel.');});};});}
+}).catch(function(){b.disabled=false;b.textContent='Retry';alert('Updating '+h+' failed to reach the kernel.');});};});
+// ITS CONNECTIONS wiring: the expand toggle, the failed-read Retry, and the forwarded row actions —
+// one shape (vact) for all five, posting the normal route + {via} and re-reading the via machine's
+// list when it lands. Refusals alert with the via machine named (fail LOUDLY, CLAUDE.md).
+list.querySelectorAll('button[data-x]').forEach(function(b){b.onclick=function(){var h=b.getAttribute('data-x');
+if(_openSub[h])delete _openSub[h];else{_openSub[h]=1;if(!_subInfo[h])fetchSub(h);}
+repaint();};});
+list.querySelectorAll('button[data-xr]').forEach(function(b){b.onclick=function(){var h=b.getAttribute('data-xr');
+delete _subInfo[h];fetchSub(h);repaint();};});
+function vparts(s){var i=s.indexOf('|');return [s.slice(0,i),s.slice(i+1)];}
+function vact(b,attr,path,busyT,doneT,word){var vp=vparts(b.getAttribute(attr)),via=vp[0],h=vp[1];
+b.disabled=true;b.textContent=busyT;
+fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h,via:via})}).then(function(r){return r.json();}).then(function(d){
+if(d&&d.ok){b.textContent=doneT;fetchSub(via);schedule(1000);}
+else{b.disabled=false;b.textContent='Retry';alert(word+' on '+via+'\\u2019s '+h+' failed: '+((d&&(d.detail||d.error))||'unknown'));}   // fail LOUDLY (CLAUDE.md)
+}).catch(function(){b.disabled=false;b.textContent='Retry';alert(word+' on '+via+'\\u2019s '+h+' failed to reach the kernel.');});}
+list.querySelectorAll('button[data-vu]').forEach(function(b){b.onclick=function(){vact(b,'data-vu','/tunnels/update','Pushing\\u2026','Pushed','Push');};});
+list.querySelectorAll('button[data-va]').forEach(function(b){b.onclick=function(){vact(b,'data-va','/tunnels/askpull','Asking\\u2026','Updating','Update');};});
+list.querySelectorAll('button[data-vp]').forEach(function(b){b.onclick=function(){vact(b,'data-vp','/tunnels/pull','Pulling\\u2026','Pulled','Pull');};});
+list.querySelectorAll('button[data-vs]').forEach(function(b){b.onclick=function(){vact(b,'data-vs','/tunnels/start','Starting\\u2026','Started','Start');};});
+list.querySelectorAll('button[data-vh]').forEach(function(b){b.onclick=function(){vact(b,'data-vh','/tunnels/detach','\\u2026','Detached','Detach');};});
+list.querySelectorAll('select[data-vt]').forEach(function(s){s.onchange=function(){var vp=vparts(s.getAttribute('data-vt')),via=vp[0],h=vp[1],vk=via+'|'+h;
+_pendSub[vk]=s.value;s.disabled=true;s.classList.add('rnet-applying');releaseTrust();
+fetch('/tunnels/trust',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:h,via:via,trust:s.value})}).then(function(r){return r.json();}).then(function(d){
+if(!(d&&d.ok)){delete _pendSub[vk];alert('trust change on '+via+' for '+h+'\\u2019s mail failed: '+((d&&d.error)||'unknown'));}   // fail LOUDLY (CLAUDE.md)
+fetchSub(via);}).catch(function(){delete _pendSub[vk];alert('trust change on '+via+' for '+h+'\\u2019s mail failed to reach the kernel.');fetchSub(via);});};});}
 attach.onclick=function(){var h=(hostIn.value||'').trim();if(!h)return;
 try{localStorage.setItem('romp:lastRemoteHost',h);}catch(e){}   // remember for MRU-first ordering next time
 attach.disabled=true;attach.textContent='Attaching\\u2026';
@@ -20457,6 +20597,11 @@ def _landing():
             # the live auto-push phase on a row: accent while it works, red when it failed and needs a look
             ".rnet-ap{display:block;color:var(--accent);font-size:11px;margin:2px 0 0 16px}"
             ".rnet-ap.bad{color:#E5534B}"
+            # "connections" sub-rows: an up host's OWN attached list, indented one level under its row —
+            # compact by default (the toggle), rows read live from that machine (strip.css parity)
+            ".rnet-row.rnet-sub{margin-left:20px}"
+            ".rnet-empty.rnet-sub{margin-left:20px;text-align:left;padding:4px 0}"
+            ".rnet-subtoggle{flex:0 0 auto}"
             # usage rate-limit bars in the bottom bar (the user 2026-06-26; HORIZONTAL redesign 2026-07-05): per
             # window, an expanded label ("5 hours" / "7 days" / "Fable 5"), then TWO stacked horizontal tracks — the
             # used-% bar (.ru-fill in the colormap colour) OVER the elapsed-% bar (slate) so you can compare pace at
@@ -21240,6 +21385,11 @@ class Handler(BaseHTTPRequestHandler):
                 # machines" rows). Fetched on demand, never folded into /tunnels: this one fans out
                 # over ssh and must not tax the popover's 3s poll.
                 return self._send(200, json.dumps(pairs_snapshot()), "application/json", cache="no-cache")
+            if p == "/tunnels/of":                            # ONE attached host's own /tunnels, live through
+                # its tunnel + token — the popover's per-host "connections" expand (fetched on demand,
+                # never in the 3s poll; same rule as /tunnels/pairs).
+                return self._send(200, json.dumps(tunnels_of((q.get("host") or [""])[0])),
+                                  "application/json", cache="no-cache")
             # HTML pages are served no-cache so a reload always gets the freshest markup — which carries
             # the latest ?v= bundle url, so even a cached old bundle is bypassed (stale-client fix).
             if p in ("/", ""):
@@ -21721,11 +21871,16 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(500, json.dumps({"ok": False, "error": str(e)}), "application/json")
                 return self._send(200, json.dumps({"ok": True, "tunnel": pub}), "application/json")
             if u.path == "/tunnels/detach":
-                # Detach a remote: kill its tunnel + forget it. Body: {"host": <ssh alias>}.
+                # Detach a remote: kill its tunnel + forget it. Body: {"host": <ssh alias>}. With
+                # {"via": <attached host>} the action runs on THAT machine's kernel (_via_forward)
+                # — the pattern every row-action route below follows.
                 try:
                     body = json.loads(raw_body or b"{}")
                 except Exception:
                     body = None
+                fw = _via_forward(body, "/tunnels/detach")
+                if fw is not None:
+                    return self._send(200, json.dumps(fw), "application/json")
                 host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
                 if not host:
                     return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
@@ -21736,6 +21891,9 @@ class Handler(BaseHTTPRequestHandler):
                     body = json.loads(raw_body or b"{}")
                 except Exception:
                     body = None
+                fw = _via_forward(body, "/tunnels/checkin")
+                if fw is not None:
+                    return self._send(200, json.dumps(fw), "application/json")
                 host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
                 if not host:
                     return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
@@ -21750,6 +21908,9 @@ class Handler(BaseHTTPRequestHandler):
                     body = json.loads(raw_body or b"{}")
                 except Exception:
                     body = None
+                fw = _via_forward(body, "/tunnels/autoupdate")
+                if fw is not None:
+                    return self._send(200, json.dumps(fw), "application/json")
                 if not isinstance(body, dict) or "on" not in body:
                     return self._send(400, json.dumps({"ok": False, "error": "on required"}), "application/json")
                 _set_auto_update_remotes(bool(body.get("on")))
@@ -21762,6 +21923,9 @@ class Handler(BaseHTTPRequestHandler):
                     body = json.loads(raw_body or b"{}")
                 except Exception:
                     body = None
+                fw = _via_forward(body, "/tunnels/forget")
+                if fw is not None:
+                    return self._send(200, json.dumps(fw), "application/json")
                 host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
                 if not host:
                     return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
@@ -21774,6 +21938,9 @@ class Handler(BaseHTTPRequestHandler):
                     body = json.loads(raw_body or b"{}")
                 except Exception:
                     body = None
+                fw = _via_forward(body, "/tunnels/trust")
+                if fw is not None:
+                    return self._send(200, json.dumps(fw), "application/json")
                 host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
                 level = str((body or {}).get("trust") or "").strip() if isinstance(body, dict) else ""
                 if not host:
@@ -21846,6 +22013,9 @@ class Handler(BaseHTTPRequestHandler):
                     body = json.loads(raw_body or b"{}")
                 except Exception:
                     body = None
+                fw = _via_forward(body, "/tunnels/update")
+                if fw is not None:
+                    return self._send(200, json.dumps(fw), "application/json")
                 host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
                 if not host:
                     return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
@@ -21860,6 +22030,9 @@ class Handler(BaseHTTPRequestHandler):
                     body = json.loads(raw_body or b"{}")
                 except Exception:
                     body = None
+                fw = _via_forward(body, "/tunnels/pull")
+                if fw is not None:
+                    return self._send(200, json.dumps(fw), "application/json")
                 host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
                 if not host:
                     return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
@@ -21874,6 +22047,9 @@ class Handler(BaseHTTPRequestHandler):
                     body = json.loads(raw_body or b"{}")
                 except Exception:
                     body = None
+                fw = _via_forward(body, "/tunnels/askpull")
+                if fw is not None:
+                    return self._send(200, json.dumps(fw), "application/json")
                 host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
                 if not host:
                     return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
@@ -21888,6 +22064,9 @@ class Handler(BaseHTTPRequestHandler):
                     body = json.loads(raw_body or b"{}")
                 except Exception:
                     body = None
+                fw = _via_forward(body, "/tunnels/start")
+                if fw is not None:
+                    return self._send(200, json.dumps(fw), "application/json")
                 host = str((body or {}).get("host") or "").strip() if isinstance(body, dict) else ""
                 if not host:
                     return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")

--- a/tests/test_tunnels_via.py
+++ b/tests/test_tunnels_via.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""The popover's remote-connection controls (the user 2026-08-11: manage what's connected to what
+from ONE dashboard). Two kernel pieces carry it: tunnels_of() reads ONE attached host's own
+/tunnels through its tunnel + serve token (pairs_snapshot's transport, full rows), and
+_via_forward() relays a row action carrying {"via": <attached host>} to that machine's kernel —
+the attach route's "from" forwarding, generalized. The via machine judges the action itself; its
+answer bubbles back tagged. Every row-action route consults _via_forward right after parsing its
+body (source-pinned below; the behavior is function-tested with a stubbed transport).
+
+Synthetic hosts only; hermetic state dir; the transport is stubbed — no ssh, no sockets.
+"""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_via", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class _Stubbed(unittest.TestCase):
+    """Seeded _remotes + a stubbed _remote_kernel_call, restored after every test."""
+
+    def setUp(self):
+        self._rkc = km._remote_kernel_call
+        self._rem = dict(km._remotes)
+        km._remotes.clear()
+
+    def tearDown(self):
+        km._remote_kernel_call = self._rkc
+        km._remotes.clear()
+        km._remotes.update(self._rem)
+
+
+class TunnelsOf(_Stubbed):
+    def test_unattached_host_is_a_loud_error(self):
+        d = km.tunnels_of("TESTHOST")
+        self.assertFalse(d["ok"])
+        self.assertIn("no attached tunnel", d["error"])
+
+    def test_a_down_host_says_so_instead_of_an_empty_list(self):
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "status": "down"}
+        d = km.tunnels_of("TESTHOST")
+        self.assertFalse(d["ok"])
+        self.assertIn("down", d["error"])
+
+    def test_an_up_host_returns_its_full_rows_tagged_with_of(self):
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "status": "up", "local_port": 1, "token": "t"}
+        km._remote_kernel_call = lambda r, m, p, payload=None, timeout=8: (
+            200, {"tunnels": [{"host": "third", "status": "up", "outOfDate": True, "behindBy": 2}],
+                  "known": [], "local": {"sha": "abc"}}, None)
+        d = km.tunnels_of("TESTHOST")
+        self.assertTrue(d["ok"])
+        self.assertEqual(d["of"], "TESTHOST")
+        self.assertEqual(d["tunnels"][0]["host"], "third")
+        self.assertEqual(d["tunnels"][0]["behindBy"], 2, "row fields pass through untouched")
+
+    def test_a_failed_read_carries_the_transport_error(self):
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "status": "up", "local_port": 1, "token": "t"}
+        km._remote_kernel_call = lambda *a, **k: (None, None, "could not reach TESTHOST's kernel: boom")
+        d = km.tunnels_of("TESTHOST")
+        self.assertFalse(d["ok"])
+        self.assertIn("boom", d["error"])
+
+
+class ViaForward(_Stubbed):
+    def test_no_via_means_local_handling_exactly_as_before(self):
+        self.assertIsNone(km._via_forward({"host": "x"}, "/tunnels/detach"))
+        self.assertIsNone(km._via_forward(None, "/tunnels/detach"))
+        self.assertIsNone(km._via_forward({"host": "x", "via": ""}, "/tunnels/detach"))
+
+    def test_an_unattached_via_is_a_loud_refusal(self):
+        d = km._via_forward({"host": "third", "via": "TESTHOST"}, "/tunnels/detach")
+        self.assertFalse(d["ok"])
+        self.assertEqual(d["via"], "TESTHOST")
+        self.assertIn("not an attached, connected host", d["error"])
+
+    def test_forwards_the_body_minus_via_to_the_same_route(self):
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "status": "up", "local_port": 1, "token": "t"}
+        seen = {}
+
+        def rkc(r, method, path, payload=None, timeout=8):
+            seen.update(host=r["host"], method=method, path=path, payload=payload)
+            return 200, {"ok": True, "tunnel": {"host": "third"}}, None
+
+        km._remote_kernel_call = rkc
+        d = km._via_forward({"host": "third", "trust": "trusted", "via": "TESTHOST"}, "/tunnels/trust")
+        self.assertEqual((seen["host"], seen["method"], seen["path"]), ("TESTHOST", "POST", "/tunnels/trust"))
+        self.assertEqual(seen["payload"], {"host": "third", "trust": "trusted"}, "via never crosses the wire")
+        self.assertTrue(d["ok"])
+        self.assertEqual(d["via"], "TESTHOST", "the answer names the machine that acted")
+
+    def test_slow_actions_get_the_long_leash_quick_ones_do_not(self):
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "status": "up", "local_port": 1, "token": "t"}
+        timeouts = {}
+
+        def rkc(r, m, p, payload=None, timeout=8):
+            timeouts[p] = timeout
+            return 200, {"ok": True}, None
+
+        km._remote_kernel_call = rkc
+        for p in ("/tunnels/update", "/tunnels/start", "/tunnels/detach", "/tunnels/trust"):
+            km._via_forward({"host": "x", "via": "TESTHOST"}, p)
+        self.assertGreaterEqual(timeouts["/tunnels/update"], 120, "a via push blocks on git + a restart")
+        self.assertGreaterEqual(timeouts["/tunnels/start"], 60, "a via start waits out a boot")
+        self.assertLessEqual(timeouts["/tunnels/detach"], 30)
+        self.assertLessEqual(timeouts["/tunnels/trust"], 30)
+
+    def test_a_transport_failure_is_loud_and_tagged(self):
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "status": "up", "local_port": 1, "token": "t"}
+        km._remote_kernel_call = lambda *a, **k: (None, None, "could not reach TESTHOST's kernel: boom")
+        d = km._via_forward({"host": "x", "via": "TESTHOST"}, "/tunnels/start")
+        self.assertFalse(d["ok"])
+        self.assertIn("boom", d["error"])
+        self.assertEqual(d["via"], "TESTHOST")
+
+    def test_a_non_200_answer_without_ok_reads_as_failure(self):
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "status": "up", "local_port": 1, "token": "t"}
+        km._remote_kernel_call = lambda *a, **k: (502, {"detail": "dirty tree"}, None)
+        d = km._via_forward({"host": "x", "via": "TESTHOST"}, "/tunnels/update")
+        self.assertFalse(d["ok"])
+        self.assertEqual(d["detail"], "dirty tree", "the via machine's own refusal comes through verbatim")
+
+
+class RouteWiring(unittest.TestCase):
+    """Every row-action route consults _via_forward right after parsing its body, and the GET side
+    serves /tunnels/of — pinned at the source (the handlers are inline methods; the behavior above
+    is what the pins delegate to)."""
+
+    def test_every_action_route_is_via_forwardable(self):
+        with open(os.path.join(BIN, "romp-kernel")) as f:
+            src = f.read()
+        for route in ("/tunnels/detach", "/tunnels/checkin", "/tunnels/autoupdate", "/tunnels/forget",
+                      "/tunnels/trust", "/tunnels/update", "/tunnels/pull", "/tunnels/askpull",
+                      "/tunnels/start"):
+            self.assertIn('_via_forward(body, "%s")' % route, src, "route %s must forward via" % route)
+        self.assertIn('if p == "/tunnels/of":', src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ui/webview/net-remote-controls.test.ts
+++ b/ui/webview/net-remote-controls.test.ts
@@ -1,0 +1,89 @@
+// Every attached host's row expands into THAT machine's own attached-host list with WORKING
+// controls (the user 2026-08-11: manage what's connected to what from one dashboard — the concrete
+// case, managing a far box's attach of a third machine from the laptop). The list comes from
+// /tunnels/of — the machine's own /tunnels read over your tunnel + its serve token — fetched on
+// EXPAND and after a forwarded action, never in the 3s poll (the /tunnels/pairs rule). Actions
+// post the normal routes with {via}; the kernel relays them to the machine that owns the tunnel
+// (_via_forward) and its answer comes back tagged. Keyed expand state and a via|host
+// pending-trust latch survive re-renders (progressive disclosure + pending-confirm rules).
+//
+// Pinned in BOTH copies (web _LANDING_REMOTES_JS in kernel.py, VS Code strip.ts) — the
+// net-trust-pending discipline: the two popovers must stay in step.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
+const STRIP = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
+const STRIPCSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.css"), "utf8");
+
+test("kernel: /tunnels/of reads ONE host's own list; every action route forwards {via}", () => {
+  assert.match(KERNEL, /def tunnels_of\(host\):/);
+  assert.match(KERNEL, /def _via_forward\(body, path\):/);
+  assert.ok(KERNEL.includes('if p == "/tunnels/of":'), "the GET route serves the expand");
+  for (const route of ["/tunnels/detach", "/tunnels/checkin", "/tunnels/autoupdate", "/tunnels/forget",
+                       "/tunnels/trust", "/tunnels/update", "/tunnels/pull", "/tunnels/askpull",
+                       "/tunnels/start"]) {
+    assert.ok(KERNEL.includes(`_via_forward(body, "${route}")`), `${route} must consult _via_forward`);
+  }
+  // slow forwarded actions (push/boot over the via machine's ssh) get the long leash
+  assert.match(KERNEL, /_VIA_TIMEOUT = \{"\/tunnels\/update": 180/);
+});
+
+test("web popover: rows expand into that machine's connections, fetched on demand", () => {
+  assert.match(KERNEL, /var _openSub=\{\},_subInfo=\{\},_subBusy=\{\},_pendSub=\{\};/,
+    "keyed expand + sub-list state outlive render()");
+  assert.match(KERNEL, /'\/tunnels\/of\?host='\+encodeURIComponent\(h\),\{cache:'no-store'\}/,
+    "the expand fetches /tunnels/of — never folded into the 3s poll");
+  assert.match(KERNEL, /function subBlock\(via\)/);
+  assert.match(KERNEL, /if\(t\.status==='up'&&_openSub\[t\.host\]\)item\.appendChild\(subBlock\(t\.host\)\);/,
+    "the block renders under the host's own row");
+  // loading and a failed read SAY so, with Retry — never a silent blank (the inline JS lives in a
+  // Python string, so its \uXXXX escapes are literally TWO backslashes in the file — hence \\\\)
+  assert.match(KERNEL, /Reading '\+via\+'\\\\u2019s connections/);
+  assert.match(KERNEL, /Couldn\\\\u2019t read '\+via\+'\\\\u2019s connections/);
+  assert.match(KERNEL, /data-xr=/);
+});
+
+test("web popover: sub-row actions ride the normal routes with {via}, refusals alert loudly", () => {
+  assert.match(KERNEL, /body:JSON\.stringify\(\{host:h,via:via\}\)/, "one vact shape for all five actions");
+  for (const attr of ["data-vu", "data-va", "data-vp", "data-vs", "data-vh"]) {
+    assert.ok(KERNEL.includes(`button[${attr}]`), `${attr} action is wired`);
+  }
+  assert.match(KERNEL, /host:h,via:via,trust:s\.value/, "sub trust writes on the via machine");
+  assert.match(KERNEL, /failed to reach the kernel\.'\);\}\)\;\}/,
+    "a dead kernel is named, not swallowed");
+  // the sub trust select wears the same class the defer-while-engaged latch keys on
+  assert.match(KERNEL, /class=\\"rnet-trust'\+\(spd\?' rnet-applying':''\)/);
+});
+
+test("VS Code popover: the same expand, same on-demand read, same via actions", () => {
+  assert.match(STRIP, /const openSub = new Set<string>\(\);/);
+  assert.match(STRIP, /const pendingSub = new Map<string, string>\(\);/);
+  assert.match(STRIP, /fetch\(kernelUrl\("\/tunnels\/of\?host=" \+ encodeURIComponent\(host\)\), \{ cache: "no-store" \}\)/);
+  assert.match(STRIP, /function renderSub\(via: string\)/);
+  assert.match(STRIP, /function subRow\(via: string, s: any\)/);
+  assert.match(STRIP, /if \(t\.status === "up" && openSub\.has\(t\.host\)\) renderSub\(t\.host\);/);
+  // act() grew the optional via and posts it; a forwarded refusal is named on the button itself
+  assert.match(STRIP, /function act\(path: string, host: string, b: HTMLButtonElement, busyText: string, via\?: string\)/);
+  assert.match(STRIP, /JSON\.stringify\(via \? \{ host, via \} : \{ host \}\)/);
+  assert.match(STRIP, /b\.classList\.add\("sn-actfail"\);/);
+  // the five forwarded actions, riding the same gating fields the via machine computed
+  assert.match(STRIP, /act\("\/tunnels\/update", s\.host, u, "Pushing…", via\)/);
+  assert.match(STRIP, /act\("\/tunnels\/askpull", s\.host, a, "Asking…", via\)/);
+  assert.match(STRIP, /act\("\/tunnels\/pull", s\.host, pl, "Pulling…", via\)/);
+  assert.match(STRIP, /act\("\/tunnels\/start", s\.host, st, "Starting…", via\)/);
+  assert.match(STRIP, /act\("\/tunnels\/detach", s\.host, dt, "…", via\)/);
+  assert.match(STRIP, /body: JSON\.stringify\(\{ via, host: s\.host, trust: sel\.value \}\)/);
+});
+
+test("both copies indent the sub-rows and keep the toggle compact by default", () => {
+  assert.match(KERNEL, /\.rnet-row\.rnet-sub\{margin-left:20px\}/);
+  assert.match(STRIPCSS, /\.sn-row\.sn-sub \{ margin-left: 20px; \}/);
+  assert.match(STRIPCSS, /\.sn-actfail \{ border-color: #E5534B; color: #E5534B; \}/);
+  // the toggle glyphs: closed ▸, open ▾ — one keyed expand per host
+  assert.match(KERNEL, /_openSub\[t\.host\]\?'\\\\u25be':'\\\\u25b8'/);
+  assert.match(STRIP, /\(openSub\.has\(t\.host\) \? "▾" : "▸"\) \+ " connections"/);
+});

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -120,3 +120,10 @@
 /* the live auto-push phase on a row: accent while it works, red when it failed and needs a look */
 .sn-ap { color: var(--accent, #9cd2ff); font-size: 11px; margin: 2px 0 0 16px; }
 .sn-ap.bad { color: #E5534B; }
+/* "connections" sub-rows: an up host's OWN attached list, indented one level under its row —
+   compact by default (the ▸ toggle), rows read live from that machine. The failed forwarded
+   action wears red on the button itself (its refusal has no status row of its own here). */
+.sn-row.sn-sub { margin-left: 20px; }
+.sn-sub.sn-empty { margin-left: 20px; text-align: left; padding: 4px 0; }
+.sn-subtoggle { flex: 0 0 auto; }
+.sn-actfail { border-color: #E5534B; color: #E5534B; }

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -419,12 +419,25 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
     }).catch(() => { sel.innerHTML = `<option value="">(kernel unreachable)</option>`; });   // loud, never silently empty
   }
 
-  function act(path: string, host: string, b: HTMLButtonElement, busyText: string) {
+  function act(path: string, host: string, b: HTMLButtonElement, busyText: string, via?: string) {
     b.disabled = true;
     const prev = b.textContent;
     b.textContent = busyText;
-    fetch(kernelUrl(path), { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ host }) })
-      .then(() => schedule(600))
+    fetch(kernelUrl(path), { method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(via ? { host, via } : { host }) })
+      .then((rp) => rp.json().catch(() => null))
+      .then((d) => {
+        if (via && d && d.ok === false) {
+          // a forwarded refusal has no status row of its own to land on — name it HERE (fail loudly)
+          b.disabled = false;
+          b.textContent = prev;
+          b.classList.add("sn-actfail");
+          b.title = String(d.error || d.detail || "refused");
+          return;
+        }
+        schedule(600);
+        if (via) fetchSub(via);   // the sub-list's state lives on the via machine — re-read it
+      })
       .catch(() => { b.disabled = false; b.textContent = prev; });
   }
 
@@ -449,6 +462,32 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
   let pairsBusy = false;
   let lastUp = 0;
   let lastList: [any[], any[]] | null = null;
+
+  // ITS CONNECTIONS (the user 2026-08-11): every up host's row expands into THAT machine's own
+  // attached-host list — same row treatment, working controls — so what's connected to what is
+  // managed from one dashboard. Rows come from /tunnels/of (the machine's own /tunnels, read over
+  // your tunnel + its serve token), fetched on EXPAND and after a forwarded action, never in the
+  // 3s poll — the /tunnels/pairs rule. Actions post the normal routes with {via}: the kernel
+  // relays them to the machine that owns the tunnel (_via_forward), which judges the action
+  // itself; a refusal is named on the button. Keyed expand state and a via|host pending-trust
+  // latch survive re-renders (the progressive-disclosure and pending-confirm rules).
+  const openSub = new Set<string>();
+  const subInfo = new Map<string, any>();       // via-host -> last /tunnels/of answer
+  const subBusy = new Set<string>();
+  const pendingSub = new Map<string, string>(); // `${via}|${host}` -> chosen trust, confirmed by a later read
+
+  function fetchSub(host: string) {
+    if (subBusy.has(host)) return;
+    subBusy.add(host);
+    fetch(kernelUrl("/tunnels/of?host=" + encodeURIComponent(host)), { cache: "no-store" })
+      .then((r) => r.json())
+      .catch(() => ({ ok: false, error: "kernel unreachable" }))
+      .then((d) => {
+        subBusy.delete(host);
+        subInfo.set(host, d || { ok: false, error: "empty answer" });
+        if (openSub.has(host) && lastList) renderList(...lastList);
+      });
+  }
 
   // A native <select>'s open dropdown dies with its DOM node, and renderList rebuilds every row each
   // poll — at the connecting-phase 600ms cadence (schedule below) the trust picker's options dismissed
@@ -615,6 +654,21 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
         + `keeping its trust level, so you can re-attach in one click.`;
       d.addEventListener("click", () => act("/tunnels/detach", t.host, d, "…"));
       r.appendChild(d);
+      if (t.status === "up") {
+        // ITS CONNECTIONS — the keyed expand (progressive disclosure): compact row by default,
+        // that machine's own attached list one click deeper, fetched on the click, never the poll.
+        const xp = document.createElement("button");
+        xp.className = "sn-subtoggle";
+        xp.textContent = (openSub.has(t.host) ? "▾" : "▸") + " connections";
+        xp.title = `${t.host}'s own attached hosts — see and manage what IT is connected to, from here. `
+          + `Rows read live from its kernel over your tunnel + its own token; actions run there.`;
+        xp.addEventListener("click", () => {
+          if (openSub.has(t.host)) openSub.delete(t.host);
+          else { openSub.add(t.host); if (!subInfo.has(t.host)) fetchSub(t.host); }
+          if (lastList) renderList(...lastList);
+        });
+        r.appendChild(xp);
+      }
       list.appendChild(r);
       // Live automatic-update phase under the row — the work still announces itself, it just does it here
       // instead of over your screen. A FAILURE stays put and red (fail loudly) rather than vanishing into a
@@ -629,6 +683,7 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
           : "romp is updating this host in the background.";
         list.appendChild(ap);
       }
+      if (t.status === "up" && openSub.has(t.host)) renderSub(t.host);
     }
     // PREVIOUSLY ATTACHED (the user 2026-07-22): hosts attached before, kept after detach so they are one
     // click away instead of buried in the ssh-config dropdown. Dimmed, each remembering the trust level
@@ -747,6 +802,155 @@ function initNetPopover(button: HTMLButtonElement, post?: (m: Record<string, unk
         list.appendChild(e);
       }
     }
+  }
+
+  // The expanded "connections" block under an up host: THAT machine's attached rows, indented,
+  // with the controls its own popover would offer — status/version drift from the fields IT
+  // computed (drift there is measured between the via machine and its remote, so the numbers are
+  // its own), and every action riding the normal route + {via}. Loading and errors say so; a
+  // failed read gets a Retry, never a silent blank.
+  function renderSub(via: string) {
+    const d = subInfo.get(via);
+    if (!d) {
+      const e = document.createElement("div");
+      e.className = "sn-sub sn-empty";
+      e.textContent = `Reading ${via}'s connections…`;
+      list.appendChild(e);
+      return;
+    }
+    if (!d.ok) {
+      const e = document.createElement("div");
+      e.className = "sn-sub sn-empty";
+      e.textContent = `Couldn't read ${via}'s connections: ${d.error || "unknown error"} `;
+      const rt = document.createElement("button");
+      rt.textContent = "Retry";
+      rt.addEventListener("click", () => {
+        subInfo.delete(via);
+        fetchSub(via);
+        if (lastList) renderList(...lastList);
+      });
+      e.appendChild(rt);
+      list.appendChild(e);
+      return;
+    }
+    const rows = d.tunnels || [];
+    if (!rows.length) {
+      const e = document.createElement("div");
+      e.className = "sn-sub sn-empty";
+      e.textContent = `${via} has no hosts attached.`;
+      list.appendChild(e);
+      return;
+    }
+    for (const s of rows) subRow(via, s);
+  }
+
+  function subRow(via: string, s: any) {
+    const TRUSTW: Record<string, string> = {
+      trusted: "trusted (auto-accept)", directed: "directed (held for you)", isolated: "isolated (no mail)",
+    };
+    const r = document.createElement("div");
+    r.className = "sn-row sn-sub";
+    const dot = document.createElement("span");
+    dot.className = "sn-dot";
+    dot.style.background = s.status === "up" ? "var(--accent, #9cd2ff)"
+      : (s.status === "error" || s.status === "no-kernel") ? "#E5534B"
+      : (s.status === "down") ? "#8a8a8a" : "transparent";
+    if (dot.style.background === "transparent") dot.style.boxShadow = "inset 0 0 0 1.5px var(--accent, #9cd2ff)";
+    dot.title = TIP[s.status] || "";
+    const nm = document.createElement("span");
+    nm.className = "sn-name";
+    let ver = "";
+    if (s.outOfDate) {
+      const bb = s.behindBy, ab = s.aheadBy;
+      ver = " · different build";
+      if (typeof bb === "number" && typeof ab === "number") {
+        ver = bb > 0 && ab > 0 ? " · diverged"
+          : ab > 0 ? ` · ahead ${ab} commit${ab === 1 ? "" : "s"}`
+          : bb > 0 ? ` · behind ${bb} commit${bb === 1 ? "" : "s"}` : ver;
+      }
+    }
+    nm.textContent = `${s.host} — ${LBL[s.status] || s.status}${ver}`;
+    nm.title = `${via}'s tunnel to ${s.host}. ` + (TIP[s.status] || "")
+      + (s.outOfDate ? `\n\n${s.host} runs ${s.kernelSha || "?"}; ${via} is at ${s.localSha || "?"} — `
+        + `drift here is between THOSE two machines, not this one.` : "");
+    r.append(dot, nm);
+    // trust: what VIA does with this host's mail — written on via over your tunnel + its token,
+    // the same you-with-both-tokens boundary as the pair rows. Pending latches per via|host until
+    // a later /tunnels/of read agrees (the confirming event, never a timer).
+    const pk = `${via}|${s.host}`;
+    let pend = pendingSub.get(pk);
+    if (pend && (s.trust || "directed") === pend) { pendingSub.delete(pk); pend = undefined; }
+    const sel = document.createElement("select");
+    sel.className = "sn-trust";
+    sel.title = `What ${via} does with postal mail from ${s.host}. trusted: delivered straight to its `
+      + `sessions. directed: held on ${via} for approval. isolated: none.`;
+    for (const lvl of ["trusted", "directed", "isolated"]) {
+      const o = document.createElement("option");
+      o.value = lvl; o.textContent = TRUSTW[lvl];
+      if ((pend || s.trust || "directed") === lvl) o.selected = true;
+      sel.appendChild(o);
+    }
+    if (pend) { sel.disabled = true; sel.classList.add("sn-applying"); }
+    sel.addEventListener("focus", () => { trustEngaged = true; });
+    sel.addEventListener("mousedown", () => { trustEngaged = true; });
+    sel.addEventListener("blur", releaseTrust);
+    sel.addEventListener("change", () => {
+      pendingSub.set(pk, sel.value);
+      sel.disabled = true;
+      sel.classList.add("sn-applying");
+      releaseTrust();
+      fetch(kernelUrl("/tunnels/trust"), { method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ via, host: s.host, trust: sel.value }) })
+        .then((rp) => rp.json())
+        .then((dd) => { if (!(dd && dd.ok)) pendingSub.delete(pk); fetchSub(via); })
+        .catch(() => { pendingSub.delete(pk); fetchSub(via); });
+    });
+    r.appendChild(sel);
+    if (pend) {
+      const pn = document.createElement("span");
+      pn.className = "sn-pend";
+      pn.textContent = "applying…";
+      r.appendChild(pn);
+    }
+    // The same provably-possible gating as the top rows, judged with the fields VIA computed
+    // about ITS remote (fastForward/fastPull/askPull are relative to via's own build).
+    const apx = !!(s.autoPush && (s.autoPush.phase === "pushing" || s.autoPush.phase === "waiting"
+      || s.autoPush.phase === "pulling" || s.autoPush.phase === "asking"));
+    if (s.status === "up" && s.fastForward && !apx && !s.checkinPeer) {
+      const u = document.createElement("button");
+      u.textContent = "Push";
+      u.title = `Push ${via}'s committed romp to ${s.host} and restart its kernel — the work runs on ${via}.`;
+      u.addEventListener("click", () => act("/tunnels/update", s.host, u, "Pushing…", via));
+      r.appendChild(u);
+    }
+    if (s.status === "up" && s.askPull && !apx) {
+      const a = document.createElement("button");
+      a.textContent = "Update";
+      a.title = `${s.host} checked in to ${via} over its own tunnel, so ${via} cannot push to it. This asks `
+        + `it to pull ${via}'s commits over the link it already holds.`;
+      a.addEventListener("click", () => act("/tunnels/askpull", s.host, a, "Asking…", via));
+      r.appendChild(a);
+    }
+    if (s.status === "up" && s.fastPull && !apx && !s.checkinPeer) {
+      const pl = document.createElement("button");
+      pl.textContent = "Pull";
+      pl.title = `Pull ${s.host}'s newer commits into ${via}'s romp (fast-forward only) — the work runs on ${via}.`;
+      pl.addEventListener("click", () => act("/tunnels/pull", s.host, pl, "Pulling…", via));
+      r.appendChild(pl);
+    }
+    if (s.status === "no-kernel") {
+      const st = document.createElement("button");
+      st.textContent = "Start";
+      st.title = `No kernel answers ${via}'s tunnel to ${s.host}. This has ${via} push its romp there and boot it.`;
+      st.addEventListener("click", () => act("/tunnels/start", s.host, st, "Starting…", via));
+      r.appendChild(st);
+    }
+    const dt = document.createElement("button");
+    dt.textContent = "Detach";
+    dt.title = `Close ${via}'s ssh tunnel to ${s.host}. It stays in ${via}'s previously-attached list.`;
+    dt.addEventListener("click", () => act("/tunnels/detach", s.host, dt, "…", via));
+    r.appendChild(dt);
+    list.appendChild(r);
   }
 
   // The pair table is read OUTSIDE the poll (each read dials every live machine's kernel over its


### PR DESCRIPTION
Item 2 of the network-popover delegate (item 1 was #294). The popover managed this machine's attached hosts, but managing what a REMOTE machine is attached to meant opening that machine's own dashboard. Now every up host's row expands into THAT machine's own attached-host list with working controls — the concrete case: manage a far box's attach of a third machine from the laptop.

**Kernel**
- `tunnels_of()` / `GET /tunnels/of?host=X`: one attached host's own `/tunnels`, read live through its tunnel + serve token (pairs_snapshot's transport, full rows). Fetched on expand and after a forwarded action — never in the 3s poll (the `/tunnels/pairs` rule). Loud errors, never a silent empty list.
- `_via_forward()`: a row action carrying `{via}` relays to that machine's kernel — the attach route's `from` forwarding generalized to detach/checkin/autoupdate/forget/trust/update/pull/askpull/start. The via machine judges the action itself (ssh reachability, dirty-tree refusals, boot waits all happen there); its answer bubbles back tagged `via`. Push/boot get a long timeout. Same trust boundary as `mirror_trust`: only tunnels this user attached, with the token they already hold.

**Both popover copies** (the net-trust-pending both-copies discipline)
- `▸ connections` keyed expand per up host (progressive disclosure — compact by default, one click deeper). Sub-rows wear the same row treatment, with drift words computed BY the via machine about ITS remote, and working controls: trust select (pending latch keyed `via|host`, confirmed by a later read, never a timer), Push/Update/Pull/Start under the same provably-possible gating, Detach.
- Loading and failed reads say so, with Retry; forwarded refusals are named loudly (alert on the web copy, red + titled button in the strip copy).
- `strip.ts` `act()` grows an optional `via` (default behavior unchanged for every existing caller).

**Tests**: `tests/test_tunnels_via.py` (stubbed-transport function tests + route-wiring pins), `ui/webview/net-remote-controls.test.ts` (both copies pinned in step). Python suite 4248 passed; extension suite 1844 passed; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)