### PR TITLE
Web popover: sub-rows must not wear the panel's .rnet-sub explainer class

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19542,12 +19542,12 @@ var TRUSTW={trusted:'trusted (auto-accept)',directed:'directed (held for you)',i
 // failed read say so (with Retry), never a silent blank.
 function subBlock(via){var box=document.createElement('div');box.className='rnet-subwrap';
 var d=_subInfo[via];
-if(!d){box.innerHTML='<div class=\"rnet-empty rnet-sub\">'+spin()+'Reading '+via+'\\u2019s connections\\u2026</div>';return box;}
-if(!d.ok){box.innerHTML='<div class=\"rnet-empty rnet-sub\">Couldn\\u2019t read '+via+'\\u2019s connections: '+(d.error||'unknown error')+' <button data-xr=\"'+via+'\">Retry</button></div>';return box;}
+if(!d){box.innerHTML='<div class=\"rnet-empty rnet-subnote\">'+spin()+'Reading '+via+'\\u2019s connections\\u2026</div>';return box;}
+if(!d.ok){box.innerHTML='<div class=\"rnet-empty rnet-subnote\">Couldn\\u2019t read '+via+'\\u2019s connections: '+(d.error||'unknown error')+' <button data-xr=\"'+via+'\">Retry</button></div>';return box;}
 var rows=d.tunnels||[];
-if(!rows.length){box.innerHTML='<div class=\"rnet-empty rnet-sub\">'+via+' has no hosts attached.</div>';return box;}
+if(!rows.length){box.innerHTML='<div class=\"rnet-empty rnet-subnote\">'+via+' has no hosts attached.</div>';return box;}
 rows.forEach(function(s){
-var sr=document.createElement('div');sr.className='rnet-row rnet-sub';
+var sr=document.createElement('div');sr.className='rnet-row rnet-subrow';
 var sdot=s.status==='up'?'background:var(--accent)':(s.status==='error'||s.status==='no-kernel')?'background:#E5534B':(s.status==='down')?'background:#8a8a8a':'background:transparent;box-shadow:inset 0 0 0 1.5px var(--accent)';
 var sver='',sbw=buildWord(s.kernelVer,s.kernelSha);
 if(s.outOfDate){var sar=driftCounts(s);
@@ -20599,8 +20599,8 @@ def _landing():
             ".rnet-ap.bad{color:#E5534B}"
             # "connections" sub-rows: an up host's OWN attached list, indented one level under its row —
             # compact by default (the toggle), rows read live from that machine (strip.css parity)
-            ".rnet-row.rnet-sub{margin-left:20px}"
-            ".rnet-empty.rnet-sub{margin-left:20px;text-align:left;padding:4px 0}"
+            ".rnet-row.rnet-subrow{margin-left:20px}"
+            ".rnet-empty.rnet-subnote{margin-left:20px;text-align:left;padding:4px 0}"
             ".rnet-subtoggle{flex:0 0 auto}"
             # usage rate-limit bars in the bottom bar (the user 2026-06-26; HORIZONTAL redesign 2026-07-05): per
             # window, an expanded label ("5 hours" / "7 days" / "Fable 5"), then TWO stacked horizontal tracks — the

--- a/ui/webview/net-remote-controls.test.ts
+++ b/ui/webview/net-remote-controls.test.ts
@@ -80,10 +80,20 @@ test("VS Code popover: the same expand, same on-demand read, same via actions", 
 });
 
 test("both copies indent the sub-rows and keep the toggle compact by default", () => {
-  assert.match(KERNEL, /\.rnet-row\.rnet-sub\{margin-left:20px\}/);
+  assert.match(KERNEL, /\.rnet-row\.rnet-subrow\{margin-left:20px\}/);
   assert.match(STRIPCSS, /\.sn-row\.sn-sub \{ margin-left: 20px; \}/);
   assert.match(STRIPCSS, /\.sn-actfail \{ border-color: #E5534B; color: #E5534B; \}/);
   // the toggle glyphs: closed ▸, open ▾ — one keyed expand per host
   assert.match(KERNEL, /_openSub\[t\.host\]\?'\\\\u25be':'\\\\u25b8'/);
   assert.match(STRIP, /\(openSub\.has\(t\.host\) \? "▾" : "▸"\) \+ " connections"/);
+});
+
+test("the web sub-rows never wear the panel's pre-existing .rnet-sub explainer class", () => {
+  // .rnet-sub is the panel's DESCRIPTION block, styled margin:-6px 0 11px — a sub-ROW wearing it
+  // is pulled up over the element above it (the user 2026-08-12, whose expanded connections
+  // painted over the parent row's settings line). The rows and notes carry their own names.
+  assert.match(KERNEL, /sr\.className='rnet-row rnet-subrow';/);
+  assert.match(KERNEL, /rnet-empty rnet-subnote/);
+  assert.doesNotMatch(KERNEL, /className='rnet-row rnet-sub'/, "the colliding class name must not return");
+  assert.doesNotMatch(KERNEL, /rnet-empty rnet-sub\\"/, "sub notes must not wear .rnet-sub either");
 });


### PR DESCRIPTION
Follow-up to #295. The connections sub-rows reused the class name `rnet-sub`, which the landing page already owns — the panel's description block, styled `margin:-6px 0 11px` — so the negative top margin pulled every sub-row up over the element above it: an expanded host's list painted across the parent row's settings line (user screenshot, 2026-08-12). Rows are now `rnet-subrow`, notes `rnet-subnote`, and a pin keeps the colliding name from returning. The VS Code copy used fresh names and is untouched. Extension suite: 1845 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)