### PR TITLE
The fast toggle's menu speaks the badge's words: Fast and Slow, never On and Off

### DIFF
--- a/ui/webview/fast-toggle.test.ts
+++ b/ui/webview/fast-toggle.test.ts
@@ -36,9 +36,12 @@ test("the badge label is one word, and the word carries the state: Fast on, Slow
   assert.doesNotMatch(pf, /Fast on|Fast off/);
 });
 
-test("the picker offers On/Off and posts setFast; ON wears the CLI's fast orange", () => {
-  assert.match(RENDER, /\{ label: "On", value: "on" \}/);
-  assert.match(RENDER, /\{ label: "Off", value: "off" \}/);
+test("the picker speaks the badge's words — Fast/Slow, never On/Off — and posts setFast", () => {
+  // one vocabulary for one toggle (the user 2026-08-11: a badge reading "Slow" opened a menu of
+  // "On"/"Off"); the VALUES stay the wire's on/off — only the labels wear the badge's words
+  assert.match(RENDER, /\{ label: "Fast", value: "on" \}/);
+  assert.match(RENDER, /\{ label: "Slow", value: "off" \}/);
+  assert.doesNotMatch(RENDER, /\{ label: "On", value: "on" \}/);
   assert.match(RENDER, /fast: FAST_CHOICES/);
   assert.match(RENDER, /kind === "fast" \? "setFast"/);                      // the pick posts the op
   assert.match(RENDER, /"on" \? "var\(--fast\)" : ""/);                      // ON tint, off/cooldown default

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6972,10 +6972,13 @@ const MODE_CHOICES: { label: string; value: string }[] = [
 // Fast mode (the CLI's /fast — Opus-only research preview): a two-state toggle offered as the same
 // dropdown shape as the other badges. The badge exists only when the session REPORTS a fast state
 // (st.fast, from the SDK init's fast_mode_state) — a session that can't run it, or a tmux session
-// whose statusline doesn't publish it yet, shows no dead control.
+// whose statusline doesn't publish it yet, shows no dead control. The options speak the BADGE's two
+// words — Fast/Slow, never On/Off (the user 2026-08-11: a badge reading "Slow" opened a menu of
+// "On"/"Off", two vocabularies for one toggle; prettyFast is the one wording, the values stay the
+// wire's on/off).
 const FAST_CHOICES: { label: string; value: string }[] = [
-  { label: "On", value: "on" },
-  { label: "Off", value: "off" },
+  { label: "Fast", value: "on" },
+  { label: "Slow", value: "off" },
 ];
 // Per-session billing (the user 2026-08-08) — the Claude login vs the API key the manager's
 // environment carries — is no longer a statusline badge: the SWITCHING control lives in the tab's


### PR DESCRIPTION
The statusline's fast-mode badge reads "Fast" or "Slow" (one word, the word carrying the state — 2026-08-10), but clicking it opened a menu whose two options said "On" and "Off": two vocabularies for one toggle, and "On" beside a badge saying "Slow" made you translate (the user 2026-08-11). The menu options now wear the badge's own words — Fast and Slow — with the wire values (on/off) unchanged, so the ✓ in the menu and the badge always say the same thing.

fast-toggle.test.ts pins the one-vocabulary rule (labels Fast/Slow, the old On label refused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)