### PR TITLE
Timeline: show active sessions only — idle lanes thin out of the visible window

### DIFF
--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -78,6 +78,15 @@ class SettingsSectionsTest(unittest.TestCase):
         self.assertIn("collapseGaps: true", _gear_src())
         self.assertIn("s.collapseGaps = cg.checked", _gear_src())
 
+    def test_show_active_only_is_wired_to_the_shared_activeOnly_setting(self):
+        # "Show active sessions only" (the user 2026-08-12): a Timeline-section checkbox, default ON,
+        # persisted as romp:settings.activeOnly; the timeline hides lanes with no activity in the
+        # visible window and re-shows them when zoom/pan reaches their work (romp-timeline-view.js).
+        self.assertIn("id=rs-activeonly checked", _gear_src())
+        self.assertIn("activeOnly: true", _gear_src())
+        self.assertIn("s.activeOnly = ao.checked", _gear_src())
+        self.assertIn("ao.checked = s.activeOnly !== false", _gear_src())
+
     def test_section_header_styling_exists(self):
         self.assertIn("#rsettings .rs-sec {", _gear_css_src())
         self.assertIn("#rsettings .rs-sec-first { border-top: 0;", _gear_css_src())

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -535,6 +535,12 @@ class TimelinePanel {
     // broken-axis: collapse long idle gaps (no work on any lane — e.g. overnight) into a thin squiggle
     // break, so the active periods get the width. ON by default; the checkbox below the axis toggles it.
     this._collapseGaps = true;
+    // "Show active sessions only" (the user 2026-08-12): at any zoom, a lane only draws if that session
+    // has activity intersecting the VISIBLE window — a live-but-idle session (no bar in view) drops out
+    // and its row space is reclaimed, reappearing the moment you pan/zoom to a range where it did work.
+    // The session stays fully in the chat; this only thins the timeline. ON by default. Read fresh here
+    // + on the 'storage' event, exactly like collapseGaps; draw()'s `active()` gate reads _activeOnly.
+    this._activeOnly = true;
     // 🔒 lock-to-now (the user 2026-06-11): the live edge is pinned PERMANENTLY — pan gestures can't
     // leave it, and a focus that's off-screen ZOOMS OUT (window widens leftward, right edge stays at
     // now, target lands ~mid-window) instead of panning away. OFF by default; checkbox far right.
@@ -550,6 +556,7 @@ class TimelinePanel {
       const raw = localStorage.getItem('romp:settings');
       if (raw) this._collapseGaps = JSON.parse(raw).collapseGaps !== false;
       else if (localStorage.getItem(this.CSTORE) === '0') this._collapseGaps = false;
+      if (raw) this._activeOnly = JSON.parse(raw).activeOnly !== false;   // default ON; a stored false opts out
     } catch (e) {}
     try { if (localStorage.getItem(this.LSTORE) === '1') this._lockNow = true; } catch (e) {}
     try { const v = localStorage.getItem(this.WSTORE); if (v != null && /^\d+(\.\d+)?$/.test(v)) { this._winSec = +v; this.fitted = true; } } catch (e) {}
@@ -780,7 +787,8 @@ class TimelinePanel {
     try {
       window.addEventListener('storage', (e) => {
         if (!e || e.key !== 'romp:settings') return;
-        try { this._collapseGaps = JSON.parse(e.newValue || localStorage.getItem('romp:settings') || '{}').collapseGaps !== false; } catch (e2) {}
+        try { const s2 = JSON.parse(e.newValue || localStorage.getItem('romp:settings') || '{}');
+          this._collapseGaps = s2.collapseGaps !== false; this._activeOnly = s2.activeOnly !== false; } catch (e2) {}
         this.draw();
       });
     } catch (e) {}
@@ -2461,12 +2469,25 @@ class TimelinePanel {
     const turnsOf = (sid) => data.turns[sid] || [];
     const colorOf = (sid) => { const s = data.sessions.find((x) => x.id === sid); return s ? s.color : '#888'; };
 
-    // live sessions ALWAYS get a lane (even with no activity in this window);
-    // closed sessions appear only when the window covers their past activity
-    const active = (s) => s.live ||
-      turnsOf(s.id).some((t) => overlaps(t.start, t.end)) ||
+    // A lane shows when it has activity intersecting THIS window — a turn bar or a message endpoint.
+    // Normally a live session ALSO always gets a lane (even idle, so you can see who's running); with
+    // "Show active sessions only" ON (the user 2026-08-12, default) that unconditional pass is dropped,
+    // so a live-but-idle session with nothing in view thins out and its row space is reclaimed, and it
+    // returns the instant the window covers work it did. Closed sessions were always window-gated; this
+    // makes live ones obey the same rule. The session is untouched in the chat — this is a view filter.
+    // barEndT extends an OPEN (still-working) turn to the live edge, exactly as the bar is drawn — so a
+    // session working RIGHT NOW counts as active whenever the window reaches now, and never blinks out
+    // from under a live-follow just because its last poll's end lags a hair behind t0.
+    const hasWork = (s) =>
+      turnsOf(s.id).some((t) => overlaps(t.start, barEndT(t, nowS, data.now))) ||
       data.messages.some((m) => (m.fromId === s.id || m.toId === s.id) && overlaps(Math.min(m.sent, m.exec), Math.max(m.sent, m.exec)));
+    const active = (s) => (s.live && !this._activeOnly) || hasWork(s);
     let vis = data.sessions.filter(active);
+    // …but never hide EVERYONE: with every lane idle in this window the filter would blank the whole
+    // band — which reads as broken (the loading rule), and leaves no row space to grab-drag back out
+    // of the quiet stretch (rowHit is the only mouse-pan surface). An all-quiet window falls back to
+    // the live lanes (the old rule), so active-only only ever THINS a view that has activity to show.
+    if (this._activeOnly && !vis.length) vis = data.sessions.filter((s) => s.live || hasWork(s));
     // while a row is being dragged, honor the transient drag order so the lanes shuffle live under
     // the cursor (data.sessions still holds the persisted order; _dragOrder overrides until drop).
     if (this._dragOrder) {

--- a/ui/timeline-nan-window.test.ts
+++ b/ui/timeline-nan-window.test.ts
@@ -72,6 +72,8 @@ function remoteLanes(): any {
 
 test("a remote-first merge (no data.now) must not latch a NaN window; the first clock sample heals it", () => {
   const panel: any = new TimelinePanel(makeNode("div"));
+  panel._activeOnly = false;   // this test is about the NaN heal, and `loc` below has no turns — keep the
+  //                              always-show-live rule so both lanes render (active-only has its own tests)
   panel.update(remoteLanes());
   panel.applyBars({ type: "bars", turns: { "r1:aaa": [{ id: "x", start: NOW - 3000, end: NOW - 2000 }] },
                     messages: [], judging: [] });

--- a/ui/timeline-render.test.ts
+++ b/ui/timeline-render.test.ts
@@ -7,6 +7,7 @@
 // future draw()-level crash trips.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { createRequire } from "node:module";
 
@@ -205,6 +206,56 @@ test("draw() also survives with an active hover set (atom-id highlight path)", (
   panel._hover = { ids: ["S1:1:aa#w", "S2:1:cc#p"] };
   assert.doesNotThrow(() => panel.draw(), "draw() must not throw while a hover highlight is active");
   assert.equal(panel._vis.length, 2);
+});
+
+// "Show active sessions only" (the user 2026-08-12, default ON): a lane draws only when the session
+// has activity intersecting the VISIBLE window — a live-but-idle session thins out (its chat tab is
+// untouched) and returns when zoom/pan reaches a range where it worked. Toggled off (the gear), the
+// old rule stands: live lanes always show. Recomputed per draw off the window — pure view state.
+test("an idle live lane thins out under active-only, and returns when the toggle is off", () => {
+  const panel: any = new TimelinePanel(makeNode("div"));
+  const data: any = synthData();
+  // beta's only activity is ~25h before the window — with gap-collapse off it is genuinely off-screen
+  const old = data.turns.S2[0];
+  data.turns.S2 = [Object.assign({}, old, { start: data.now - 90000, end: data.now - 89000 })];
+  panel._collapseGaps = false;   // a collapsed axis SHOWS that old period on screen — defeat it for determinism
+  panel.data = data;
+  panel.draw();
+  assert.deepEqual(panel._vis.map((s: any) => s.id), ["S1"], "the idle live lane is hidden by default");
+  panel._activeOnly = false;     // the gear toggle writes romp:settings.activeOnly; the storage event re-reads it
+  panel.draw();
+  assert.equal(panel._vis.length, 2, "toggled off, a live-but-idle session keeps its lane");
+  // …and zooming out to cover the old work brings the lane back WITH the toggle on (the window rule,
+  // not a latch): widen the window past the 25h-old turn.
+  panel._activeOnly = true;
+  panel._winSec = 200000; panel._offDirty = true; panel._pinned = true;
+  panel.draw();
+  assert.equal(panel._vis.length, 2, "zoomed out over its past work, the lane returns");
+});
+
+test("an ALL-quiet window falls back to the live lanes — never a blank, un-grabbable band", () => {
+  // Panning into a stretch where nothing happened must not empty the timeline: a blank band reads as
+  // broken, and the per-lane row space is the only mouse-drag pan surface, so an empty _vis would
+  // strand the pan gesture there (caught by the drag-pan test when active-only first landed).
+  const panel: any = new TimelinePanel(makeNode("div"));
+  const data: any = synthData();
+  panel._collapseGaps = false;
+  panel.data = data;
+  panel._winSec = 600; panel._offSec = 50000; panel._pinned = false; panel._offDirty = true;
+  panel.draw();
+  assert.equal(panel._vis.length, 2, "both LIVE lanes stand in an all-quiet window");
+  const src = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
+  assert.match(src, /if \(this\._activeOnly && !vis\.length\) vis = data\.sessions\.filter\(\(s\) => s\.live \|\| hasWork\(s\)\)/);
+});
+
+test("the active-only flag rides romp:settings like collapseGaps (source pins)", () => {
+  const src = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
+  assert.match(src, /this\._activeOnly = true;/, "default ON");
+  assert.match(src, /if \(raw\) this\._activeOnly = JSON\.parse\(raw\)\.activeOnly !== false/, "constructor read");
+  assert.match(src, /this\._activeOnly = s2\.activeOnly !== false/, "storage live-sync");
+  assert.match(src, /const active = \(s\) => \(s\.live && !this\._activeOnly\) \|\| hasWork\(s\)/, "the gate");
+  assert.match(src, /overlaps\(t\.start, barEndT\(t, nowS, data\.now\)\)/,
+    "an OPEN turn counts to the live edge, exactly as its bar is drawn — a working session never hides");
 });
 
 // A romp NUDGE prompt marks its dot as a ROMP MESSAGE: a BLACK-filled dot with the romp favicon swirl

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -90,6 +90,10 @@ var GEAR_HTML =
   '<option value=over50>When above 50%</option><option value=always>Always</option><option value=never>Never</option>' +
   '</select></span></div>' +
   '<div class=rs-sec>Timeline</div>' +
+  '<label class=rs-row><input type=checkbox id=rs-activeonly checked>' +
+  '<span><b>Show active sessions only</b>' +
+  '<span class=rs-sub>Only draw lanes for sessions with work in the visible time range, so idle sessions do not take up room. They stay in the chat, and a lane reappears the moment you zoom or pan to a stretch where it did something.</span>' +
+  '</span></label>' +
   '<label class=rs-row><input type=checkbox id=rs-collapsegaps checked>' +
   '<span><b>Collapse idle gaps</b>' +
   '<span class=rs-sub>Squish long idle stretches (no work on any lane — e.g. overnight) into a thin break on the timeline, so the active periods get the width.</span>' +
@@ -149,10 +153,11 @@ function initGear(post) {
     an = document.getElementById('rs-autonudge'), bk = document.getElementById('rs-backend'),
     dd = document.getElementById('rs-defaultdir'), gb = document.getElementById('rs-branch'),
     tc = document.getElementById('rs-tabctx'),
-    cg = document.getElementById('rs-collapsegaps'), jm = document.getElementById('rs-judgemodel'),
+    cg = document.getElementById('rs-collapsegaps'), ao = document.getElementById('rs-activeonly'),
+    jm = document.getElementById('rs-judgemodel'),
     im = document.getElementById('rs-indexmodel'), je = document.getElementById('rs-judgeeffort'),
     ie = document.getElementById('rs-indexeffort'), upm = document.getElementById('rs-updates');
-  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true }; } }
+  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }; } }
   // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
   // few hours as a boolean toggle — false was an explicit hide, true the default nobody chose.
   function tabCtxMode(v) { return (v === 'always' || v === 'never') ? v : (v === false ? 'never' : 'over50'); }
@@ -175,6 +180,7 @@ function initGear(post) {
   jix.addEventListener('change', function () { var s = load(); s.showIndexJudges = jix.checked; save(s); });
   jtr.addEventListener('change', function () { var s = load(); s.showTriageJudges = jtr.checked; save(s); });
   if (cg) cg.addEventListener('change', function () { var s = load(); s.collapseGaps = cg.checked; save(s); });
+  if (ao) ao.addEventListener('change', function () { var s = load(); s.activeOnly = ao.checked; save(s); });
   // Auto Nudge / judge tiers are SERVER-SIDE (the kernel runs them): post the
   // change; the controls re-initialize from /version on every open (fill()).
   if (an) an.addEventListener('change', function () { post({ type: 'setAutoNudge', enabled: an.checked }); });
@@ -301,7 +307,7 @@ function initGear(post) {
     // settings-open, which is what un-hides #feed-pane when the feed is toggled off — measuring first
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cg) cg.checked = s.collapseGaps !== false; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the


### PR DESCRIPTION
A new Timeline setting in the gear dialog, "Show active sessions only" (default ON, the user's ask 2026-08-11): at any zoom, a lane draws only when its session has activity intersecting the visible window — a turn bar (an OPEN turn counts to the live edge, exactly as its bar is drawn) or a message endpoint. A live-but-idle session thins out and its row space is reclaimed; it stays fully in the chat, and the lane returns the instant zoom/pan reaches a stretch where it did something. Closed sessions were always window-gated; this makes live ones obey the same rule. Pure per-draw view state, recomputed off the window — no latches, no timers.

Two safeguards the tests forced: an all-quiet window falls back to the live lanes (an empty band reads as broken, and the per-lane row space is the only mouse-drag pan surface — the drag-pan test caught the gesture stranding before this); and the fallback plus the existing vidx null-guards keep message arcs and reorder correct when lanes are filtered.

Plumbing follows collapseGaps exactly: persisted as romp:settings.activeOnly (default-on via the !== false convention in the constructor read, the storage-event live-sync, and the gear row), toggled in the gear's Timeline section. Executed tests in timeline-render.test.ts (hide by default / toggle off restores / zoom-out returns / all-quiet fallback) plus wiring pins in test_kernel_settings_sections.py; the NaN-heal test pins the always-show-live rule it was implicitly relying on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)