### PR TITLE
A quiet hub keeps its bus: kernel-up gates the autostop, refused notifies revive

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5985,6 +5985,26 @@ def _ensure_postal_bus():
         sys.stderr.write("postal bus ensure failed:\n%s" % traceback.format_exc())
 
 
+_bus_revive_lock = threading.Lock()
+_bus_reviving = [False]                      # one ensure in flight at a time; concurrent kicks coalesce
+
+def _revive_postal_bus():
+    """Re-ensure the bus when a bus call is REFUSED — the bus died under a running kernel (it
+    self-stopped in a window its gate didn't cover, or crashed), and boot-time ensure can't help a
+    kernel that is already up. Event-based: the refusal IS the signal (never a poll). Single-flight
+    so a burst of refused notifies — one per tunnel per supervisor pass — coalesces into one ensure.
+    A quiet hub went dark exactly this way twice on 2026-08-12: bus gone, kernel up, every /peer
+    notify failing silently, cross-host mail parked until a manual ensure."""
+    with _bus_revive_lock:
+        if _bus_reviving[0]:
+            return
+        _bus_reviving[0] = True
+    try:
+        _ensure_postal_bus()
+    finally:
+        _bus_reviving[0] = False
+
+
 def _ssh_config_hosts():
     """Host aliases declared in ~/.ssh/config (the 'find the things' for the attach UI). Concrete 'Host'
     patterns only — wildcards/negations are skipped (not connectable targets). Best-effort: a missing or
@@ -6144,7 +6164,9 @@ def _notify_bus_peer(host, port, up, peer_token="", trust="directed"):
     local bus with OUR serve token; peer_token is the PEER machine's serve token (r["token"]), which the
     bus needs to dial that peer's /peer-exchange through the tunnel — both buses are token-gated now.
     trust rides too: the bus gates inbound mail from a 'directed' peer into quarantine and drops an
-    'isolated' peer's mail — it needs the per-host level to make that call at delivery time."""
+    'isolated' peer's mail — it needs the per-host level to make that call at delivery time.
+    A refusal ALSO kicks _revive_postal_bus: a dead bus must not stay dead until the next kernel
+    boot while the supervisor retries into it forever (the 2026-08-12 quiet-hub outage)."""
     try:
         conn = http.client.HTTPConnection("127.0.0.1", BUS_PORT, timeout=2)
         conn.request("POST", "/peer", json.dumps({"host": host, "port": port, "up": bool(up),
@@ -6154,6 +6176,7 @@ def _notify_bus_peer(host, port, up, peer_token="", trust="directed"):
         conn.close()
         return ok
     except Exception:
+        threading.Thread(target=_revive_postal_bus, daemon=True).start()
         return False
 
 
@@ -6162,7 +6185,7 @@ def _notify_bus_origin_trust(host, trust):
     reads when mail from `host` arrives RELAYED through a hub (trust is judged by true origin, never
     by the tunnel it rode in on — the user 2026-07-25). Guarded like _notify_bus_peer: postal being
     down never breaks the caller; the supervisor re-pushes, and a restarted bus re-seeds from
-    /tunnels' `known` rows."""
+    /tunnels' `known` rows. A refusal kicks _revive_postal_bus, like _notify_bus_peer's."""
     try:
         conn = http.client.HTTPConnection("127.0.0.1", BUS_PORT, timeout=2)
         conn.request("POST", "/peer", json.dumps({"host": host, "trust": trust or "directed",
@@ -6172,6 +6195,7 @@ def _notify_bus_origin_trust(host, trust):
         conn.close()
         return ok
     except Exception:
+        threading.Thread(target=_revive_postal_bus, daemon=True).start()
         return False
 
 

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -525,6 +525,24 @@ def _kernel_post(path, body, timeout=2):
         return None
 
 
+def _kernel_up():
+    """True when THIS machine's kernel answers /healthz (auth-exempt, so no token dance). The
+    autostop gate reads it: a machine whose kernel is up is a live romp installation — peer buses
+    dial ITS bus for presence and INBOUND mail — so the bus must keep listening even with zero
+    local sessions. A quiet hub's bus used to self-stop on local-session count alone, and every
+    cross-host message through it silently parked until a manual `ensure` (verified twice,
+    2026-08-12); local sessions are the wrong liveness signal for a hub. False under the
+    ROMP_SESSIONS_FILE seam, like _kernel_post: that seam means a test with no live kernel."""
+    if os.environ.get("ROMP_SESSIONS_FILE"):
+        return False
+    import urllib.request
+    try:
+        with urllib.request.urlopen(KERNEL_BASE + "/healthz", timeout=2) as r:
+            return getattr(r, "status", 200) // 100 == 2
+    except Exception:
+        return False
+
+
 def _publish_working(sid, text):
     """Publish/clear THIS session's working-note via the kernel's backend-agnostic store (POST /working) — no
     tmux. The kernel owns the store and both backends read it (it appears in GET /sessions' `working` field),
@@ -1244,6 +1262,16 @@ def _maybe_restart_for_code(boot_fp):
         return True
     return False
 
+def _idle_tick(n, idle):
+    """One autostop decision: (new_idle, stop). Factored out so the gate is unit-testable (the
+    monitor loop sleeps). Local clients OR a live local kernel reset the count — a hub with zero
+    local sessions still serves inbound peer exchanges as long as its kernel runs (_kernel_up)."""
+    if n > 0 or _kernel_up():
+        return 0, False
+    idle += 1
+    return idle, idle >= IDLE_GRACE
+
+
 def _monitor(httpd, boot_fp=""):
     idle = 0
     while True:
@@ -1261,14 +1289,11 @@ def _monitor(httpd, boot_fp=""):
             n = present_count()
         except Exception:
             n = 1   # on error, err on the side of staying up
-        if n <= 0:
-            idle += 1
-            if idle >= IDLE_GRACE:
-                _log("no romp clients remain; shutting down")
-                threading.Thread(target=httpd.shutdown, daemon=True).start()
-                return
-        else:
-            idle = 0
+        idle, stop = _idle_tick(n, idle)
+        if stop:
+            _log("no romp clients remain (and no local kernel); shutting down")
+            threading.Thread(target=httpd.shutdown, daemon=True).start()
+            return
 
 def _retry_pending():
     """RETRY deferred deliveries — the fix for stranded mail. _push (and the revive

--- a/tests/test_postal_bus_lifetime.py
+++ b/tests/test_postal_bus_lifetime.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""The bus's lifetime follows the MACHINE's romp role, not just local sessions. A quiet hub —
+kernel up, zero local sessions — self-stopped on the local-session count alone, and every
+cross-host message through it silently parked until a manual `ensure` (verified twice,
+2026-08-12): peers dial a machine's bus for presence and INBOUND mail, so it must keep listening
+while the kernel runs. Two guards land here:
+
+- bus: the autostop gate (_idle_tick) counts a live local kernel (_kernel_up, /healthz) as a
+  reason to stay, alongside local clients. No kernel and no clients → the old self-stop.
+- kernel: a REFUSED bus notify kicks _revive_postal_bus (single-flight ensure) — boot-time ensure
+  can't help a kernel that is already up when its bus dies, and the supervisor otherwise retried
+  into the dead bus forever.
+
+Synthetic everything: hermetic state dir, stub HTTP server for the kernel, dead ports, no ssh.
+"""
+import http.server
+import os
+import socket
+import tempfile
+import threading
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+pm = SourceFileLoader("romp_postal_buslife", os.path.join(BIN, "romp-postal-service")).load_module()
+km = SourceFileLoader("romp_kernel_buslife", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _dead_port():
+    """A port with nothing listening: bind, read it, close — refused instantly afterwards."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _HealthzStub:
+    """A minimal kernel: answers /healthz 200, everything else 404."""
+
+    def __enter__(self):
+        class H(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                ok = self.path == "/healthz"
+                self.send_response(200 if ok else 404)
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"ok")
+
+            def log_message(self, *a):
+                pass
+
+        self.srv = http.server.HTTPServer(("127.0.0.1", 0), H)
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        return "http://127.0.0.1:%d" % self.srv.server_port
+
+    def __exit__(self, *a):
+        self.srv.shutdown()
+
+
+class KernelUp(unittest.TestCase):
+    def setUp(self):
+        self._base = pm.KERNEL_BASE
+        self._seam = os.environ.pop("ROMP_SESSIONS_FILE", None)
+
+    def tearDown(self):
+        pm.KERNEL_BASE = self._base
+        if self._seam is not None:
+            os.environ["ROMP_SESSIONS_FILE"] = self._seam
+
+    def test_true_when_healthz_answers(self):
+        with _HealthzStub() as base:
+            pm.KERNEL_BASE = base
+            self.assertTrue(pm._kernel_up())
+
+    def test_false_when_nothing_listens(self):
+        pm.KERNEL_BASE = "http://127.0.0.1:%d" % _dead_port()
+        self.assertFalse(pm._kernel_up())
+
+    def test_false_under_the_no_kernel_test_seam(self):
+        # ROMP_SESSIONS_FILE means "a test with no live kernel" (_kernel_post's seam) — the gate
+        # must read the same way, so the bats autostop tests stay hermetic on a dev machine whose
+        # REAL kernel is up on the default port.
+        with _HealthzStub() as base:
+            pm.KERNEL_BASE = base
+            os.environ["ROMP_SESSIONS_FILE"] = "/nonexistent"
+            self.assertFalse(pm._kernel_up())
+
+
+class IdleGate(unittest.TestCase):
+    def setUp(self):
+        self._ku = pm._kernel_up
+
+    def tearDown(self):
+        pm._kernel_up = self._ku
+
+    def test_local_clients_keep_the_bus_no_kernel_probe_needed(self):
+        pm._kernel_up = lambda: (_ for _ in ()).throw(AssertionError("must not probe with clients present"))
+        self.assertEqual(pm._idle_tick(3, 1), (0, False))
+
+    def test_a_live_kernel_keeps_a_sessionless_bus(self):
+        pm._kernel_up = lambda: True
+        idle, stop = pm._idle_tick(0, 0)
+        self.assertEqual((idle, stop), (0, False), "a quiet hub serves inbound peers; it must not stop")
+        # even a count already at the brink resets — the kernel IS the client
+        self.assertEqual(pm._idle_tick(0, pm.IDLE_GRACE - 1), (0, False))
+
+    def test_no_kernel_and_no_clients_still_self_stops(self):
+        pm._kernel_up = lambda: False
+        idle = 0
+        for _ in range(pm.IDLE_GRACE - 1):
+            idle, stop = pm._idle_tick(0, idle)
+            self.assertFalse(stop)
+        idle, stop = pm._idle_tick(0, idle)
+        self.assertTrue(stop, "a machine with no kernel and no sessions keeps the old autostop")
+
+
+class RefusedNotifyRevives(unittest.TestCase):
+    def setUp(self):
+        self._bp = km.BUS_PORT
+        self._ens = km._ensure_postal_bus
+        km.BUS_PORT = _dead_port()
+        self.kicked = threading.Event()
+        km._ensure_postal_bus = self.kicked.set
+        km._bus_reviving[0] = False
+
+    def tearDown(self):
+        km.BUS_PORT = self._bp
+        km._ensure_postal_bus = self._ens
+        km._bus_reviving[0] = False
+
+    def test_refused_peer_notify_kicks_one_ensure(self):
+        self.assertFalse(km._notify_bus_peer("TESTHOST", 1, True), "the caller still sees the failure")
+        self.assertTrue(self.kicked.wait(5), "the refusal must kick a revive")
+
+    def test_refused_origin_trust_notify_kicks_too(self):
+        self.assertFalse(km._notify_bus_origin_trust("TESTHOST", "directed"))
+        self.assertTrue(self.kicked.wait(5))
+
+    def test_revive_is_single_flight(self):
+        km._bus_reviving[0] = True            # an ensure is (pretend) already in flight
+        km._revive_postal_bus()               # a second kick must coalesce, not stack
+        self.assertFalse(self.kicked.wait(0.3), "no second ensure while one is in flight")
+        km._bus_reviving[0] = False
+        km._revive_postal_bus()
+        self.assertTrue(self.kicked.wait(5), "released → the next kick runs")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
A machine with a running kernel and zero local sessions lost its bus: the autostop counted only local clients, so the bus exited — and every cross-host message through that machine silently parked until someone ran `ensure` by hand (verified twice on a hub, 2026-08-12). Peers dial a machine's bus for presence and INBOUND mail, so local sessions are the wrong liveness signal for a hub.

- **bus**: the autostop gate (`_idle_tick`, factored out of `_monitor` for tests) counts a live local kernel (`_kernel_up` — `/healthz`, auth-exempt) as a reason to stay, alongside local clients. No kernel and no clients → the old self-stop, unchanged; `_kernel_up` honours `_kernel_post`'s `ROMP_SESSIONS_FILE` seam, which keeps the bats autostop test hermetic even on a dev machine whose real kernel is up.
- **kernel**: a REFUSED bus notify (`_notify_bus_peer` + the origin-trust twin) kicks `_revive_postal_bus`, a single-flight ensure. Boot-time ensure can't help a kernel that is already up when its bus dies, and the tunnel supervisor otherwise retried into the dead bus forever, silently. Event-based: the refusal is the signal.

Tests: `tests/test_postal_bus_lifetime.py` (healthz stub / dead ports / seam; the gate's three states; refused-notify kick + single-flight). Full suite 4257 passed; bats self-stop test still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)