### PR TITLE
The picker holds still: create controls first, the resume list last under its own heading

### DIFF
--- a/ui/webview/picker-order.test.ts
+++ b/ui/webview/picker-order.test.ts
@@ -1,0 +1,42 @@
+// The new-session picker's layout (the user 2026-08-12): CREATE controls first — the name box, then
+// directory, backend, billing, host, and the New session button — and the resume list LAST, under a
+// heading that names it as the alternative. Typing in the name box re-filters the list, whose height
+// changes with every keystroke; with the list mid-dialog, every control below it jumped exactly while
+// being reached for — and creating is the common case, reviving the occasional one. Source pins (the
+// renderer has no jsdom harness — the repo convention).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("the create controls precede the list, and the list sits last under its heading", () => {
+  const seq = [
+    "box.appendChild(search);", "box.appendChild(errLine);", "box.appendChild(dirWrap);",
+    "box.appendChild(beWrap);", "box.appendChild(auWrap);", "box.appendChild(hostWrap);",
+    "box.appendChild(actions);", "box.appendChild(altHead);", "box.appendChild(list);",
+  ];
+  let at = -1;
+  for (const s of seq) {
+    const i = RENDER.indexOf(s);
+    assert.ok(i > at, `${s} must appear, after its predecessor`);
+    at = i;
+  }
+});
+
+test("the heading presents the list as the alternative to creating, and hides in pick-mode", () => {
+  assert.match(RENDER, /altHead\.textContent = "Or reopen an existing session"/);
+  // pick-mode: the list IS the dialog (choosing an existing session), so the heading hides with the
+  // create rows rather than labeling the only thing on screen an "alternative"
+  assert.match(RENDER, /altHeadEl\.style\.display = pick \? "none" : ""/);
+  assert.match(CSS, /\.picker-alt-head \{ flex: 0 0 auto; color: var\(--dim\)/);
+  assert.match(CSS, /\.picker-alt-head \{[^}]*border-top: 1px solid var\(--box-border\)/,
+    "the heading's rule draws the seam above the resume section");
+});
+
+test("the dir row lost its border-top — the name box's own border-bottom draws that seam now", () => {
+  const dir = CSS.match(/\.picker-dir \{[^}]*\}/)![0];
+  assert.doesNotMatch(dir, /border-top/, "search-bottom + dir-top would stack a doubled hairline");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4744,14 +4744,25 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
                     dir: dirInput.value.trim(), host: hostSel, ...(auth ? { auth } : {}) });
     });
     actions.appendChild(newSess);
+    // CREATE controls first, the resume list LAST (the user 2026-08-12): typing in the name box
+    // re-filters the list, whose height changes with every keystroke — with the list mid-dialog the
+    // controls below it jumped around exactly when you were reaching for them. The stable, most-used
+    // half (name → directory → backend → billing → host → New session) now holds still at the top,
+    // and the list — the occasional alternative, not the main act — grows and shrinks harmlessly at
+    // the bottom, under a label that says what it is. In pick-mode the list IS the dialog, so the
+    // label hides with the create rows (openPicker below).
+    const altHead = el("div", "picker-alt-head");
+    altHead.id = "picker-alt-head";
+    altHead.textContent = "Or reopen an existing session";
     box.appendChild(search);
     box.appendChild(errLine);
-    box.appendChild(list);
     box.appendChild(dirWrap);
     box.appendChild(beWrap);
     box.appendChild(auWrap);
     box.appendChild(hostWrap);
     box.appendChild(actions);
+    box.appendChild(altHead);
+    box.appendChild(list);
     overlay.appendChild(box);
     overlay.addEventListener("click", (e) => { if (e.target === overlay) closePicker(); });
     document.body.appendChild(overlay);
@@ -4772,6 +4783,8 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   signalPickerOverlay(true);   // lift the chat iframe full-window so the picker covers the whole screen
   const actions = overlay.querySelector(".picker-actions") as HTMLElement | null;
   if (actions) actions.style.display = pick ? "none" : "";
+  const altHeadEl = document.getElementById("picker-alt-head");
+  if (altHeadEl) altHeadEl.style.display = pick ? "none" : "";   // pick-mode: the list IS the dialog, not an alternative
   const dirWrap = overlay.querySelector(".picker-dir") as HTMLElement | null;
   if (dirWrap) dirWrap.style.display = pick ? "none" : "";   // dir only matters when creating, not picking
   const beWrapEl = overlay.querySelector(".picker-backend:not(.picker-host):not(.picker-auth)") as HTMLElement | null;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1869,8 +1869,10 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 }
 .picker-error.show { display: block; }
 /* one line: the verdict lives inside the field now, not on a second row; the folder menu is
-   absolutely positioned so it lays OVER the rows below instead of shoving the dialog around */
-.picker-dir { display: flex; align-items: center; gap: 6px; padding: 8px 14px; border-top: 1px solid var(--box-border); position: relative; }
+   absolutely positioned so it lays OVER the rows below instead of shoving the dialog around.
+   (No border-top: the dir row sits directly under the name box now — create controls first, the
+   resume list last, the user 2026-08-12 — and the search box's own border-bottom draws that seam.) */
+.picker-dir { display: flex; align-items: center; gap: 6px; padding: 8px 14px; position: relative; }
 .picker-dir::before { content: "📁"; opacity: 0.55; font-size: 0.9em; flex: 0 0 auto; }
 /* the input and its in-box verdict share one box: the hint overlays the input's right end, and
    render.ts reserves that much input padding so the typed path never runs under it */
@@ -1941,6 +1943,12 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
    the buttons' 0.82em, plain, no button chrome (it is a fact, not a control) */
 .picker-auth-fixed { flex: 0 0 auto; color: var(--fg); font-size: 0.82em; padding: 4px 0; }
 .picker-list { overflow-y: auto; }
+/* The resume list's heading (the user 2026-08-12): the list sits LAST in the dialog — typing in the
+   name box re-filters it, and its changing height used to jump every control below it — so this line
+   both names the section and presents it as the alternative to creating. Same quiet label vocabulary
+   as the row labels (0.82em dim); hidden in pick-mode, where the list IS the dialog. */
+.picker-alt-head { flex: 0 0 auto; color: var(--dim); font-family: var(--sans); font-size: 0.82em;
+  padding: 9px 14px 3px; border-top: 1px solid var(--box-border); }
 .picker-row {
   padding: 9px 14px; cursor: pointer;
   border-bottom: 1px solid rgba(255, 255, 255, 0.04);


### PR DESCRIPTION
Typing a new session's name re-filters the session list, whose height changes with every keystroke — and the list sat mid-dialog, so the directory field, backend/billing/host rows and the New session button all jumped exactly while being reached for (the user 2026-08-12). Creating is the common case; reviving is the occasional one.

The dialog now reads top-down in the order the common case uses it: name box → directory → backend → billing → host → New session button — all fixed-height, so nothing moves as you type — then "Or reopen an existing session" heading the list at the bottom, where its filter-driven growth is harmless. In pick-mode (choosing an existing session) the heading hides with the create rows: the list is the whole dialog there, not an alternative. The dir row's border-top went with the move (the name box's own border-bottom draws that seam now — the two would have stacked a doubled hairline).

picker-order.test.ts pins the sequence, the heading + its pick-mode hiding, and the seam rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)