### PR TITLE
A cut romp caused never blames the user: stamp the machine cut when the resume is queued

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -190,7 +190,45 @@ def _interrupt_cause(nxt_atom):
     return None
 
 
-def _machine_cut_cause(users, i):
+_machine_cut_cache = {}   # str(path) -> ((mtime_ns, size), (t, cause))
+
+
+def _last_machine_cut(sid):
+    """(t, cause) of the newest machineCut marker in states/<sid>.jsonl — the backend's own record that
+    ROMP cut this session's turn and queued a resume notice (sdk_backend.append_machine_cut) — or (0, "").
+    The authoritative answer to "whose stop was this?", written by the component that did the cutting,
+    instead of inferred from the transcript.
+
+    mtime+size cached (one stat per call while the file is quiet, the _jerr_cache idiom): the callers run
+    per session on EVERY push, and these files reach ~1MB / 4k lines on a long-lived session, so an
+    uncached scan would add megabytes of reading per push cycle to a loop that is already CPU-bound."""
+    p = jd.STATE / "states" / ("%s.jsonl" % sid)
+    try:
+        st = p.stat(); key = (st.st_mtime_ns, st.st_size)
+    except OSError:
+        return 0.0, ""
+    hit = _machine_cut_cache.get(str(p))
+    if hit is not None and hit[0] == key:
+        return hit[1]
+    t, cause = 0.0, ""
+    try:
+        with open(p, errors="replace") as f:
+            for line in f:
+                if '"machineCut"' not in line:
+                    continue
+                try:
+                    o = json.loads(line)
+                except Exception:
+                    continue
+                if isinstance(o, dict) and o.get("machineCut"):
+                    t, cause = float(o.get("t") or 0), str(o["machineCut"])
+    except OSError:
+        return 0.0, ""
+    _machine_cut_cache[str(p)] = (key, (t, cause))
+    return t, cause
+
+
+def _machine_cut_cause(users, i, cut_t=0.0, cut_cause=""):
     """The machine-cut cause for the interrupt record at users[i], or None for a genuine user stop.
     Scans FORWARD for romp's resume notice instead of trusting users[i + 1] alone (the user
     2026-08-10): the restart that cuts a turn kills its background tasks too, and their
@@ -201,29 +239,44 @@ def _machine_cut_cause(users, i):
     romp-injected marker, so they always author 'romp' — and a task notification whose output tail
     happens to QUOTE a signature never reads as a notice). The scan stops at the first genuine human
     message or the next interrupt record: past either, a notice belongs to a LATER cut, never this
-    one. Everything else (system notifications, peers, sdk, tool_result-only) is wedge — read past."""
+    one. Everything else (system notifications, peers, sdk, tool_result-only) is wedge — read past.
+
+    `cut_t`/`cut_cause` (from _last_machine_cut) settle the case the scan CANNOT: the notice does not
+    exist yet. The stop record hits disk the instant the turn is cut; romp's notice only lands once the
+    resumed CLI writes it, seconds later — and a tick inside that window saw a bare trailing stop and
+    blamed the user, 30 times in 30 hours on the live machine (the user 2026-08-12). So when the scan
+    runs off the end INCONCLUSIVE — no notice, and no human message or later interrupt to prove the stop
+    was theirs — defer to the backend's stamp: an interrupt at or before the moment romp queued a resume
+    IS that cut. Ordering alone makes this exact (the cut always precedes its resume), so a genuine stop
+    made later is always past the stamp and still reads as the user's; no window, no expiry. A scan that
+    reaches a terminator never consults the stamp: there the transcript already answered."""
     for nxt in users[i + 1:]:
         if nxt.get("author") == "romp":
             cause = _interrupt_cause(nxt)
             if cause:
                 return cause
         elif em.is_interrupt_record(nxt) or nxt.get("author") == "human":
-            return None
+            return None                                  # the transcript settled it — the stamp says nothing new
+    if cut_cause and (users[i].get("t") or 0) <= cut_t:   # notice not on disk yet → the backend's own record
+        return cut_cause
     return None
 
 
-def _interrupt_marks(turns):
+def _interrupt_marks(turns, sid=""):
     """(newest genuine user STOP, newest genuine human PROMPT) on this thread, in transcript time —
     the one place the two are tallied, so the predicate below and the interrupt block's EVIDENCE stamp
     read the same events. A MACHINE cut (kernel restart / process death) mints the same stop record but
     is romp's own, so it never counts as a stop (_machine_cut_cause, via the resume notice that follows
-    it). The interrupt record itself authors 'human', so it's classified FIRST."""
+    it, or — before that notice reaches disk — the backend's machineCut stamp). The interrupt record
+    itself authors 'human', so it's classified FIRST. `sid` is optional only so the pure-atom callers in
+    the tests stay pure: pass it wherever it is known, or a cut still on its way to disk reads as a stop."""
     users = [a for turn in turns for a in (turn.get("atoms") or []) if a.get("type") == "user"]
+    cut_t, cut_cause = _last_machine_cut(sid) if sid else (0.0, "")
     last_intr = last_human = 0
     for i, a in enumerate(users):
         t = a.get("t", 0)
         if em.is_interrupt_record(a):
-            if _machine_cut_cause(users, i):
+            if _machine_cut_cause(users, i, cut_t, cut_cause):
                 continue                                 # machine cut → romp re-engaged, not the user
             last_intr = max(last_intr, t)
         elif a.get("author") == "human":
@@ -231,7 +284,7 @@ def _interrupt_marks(turns):
     return last_intr, last_human
 
 
-def _interrupt_suppresses_nudge(turns):
+def _interrupt_suppresses_nudge(turns, sid=""):
     """True while the session's most recent USER action is a GENUINE user INTERRUPT: the user stopped
     the agent and hasn't spoken since, so they're at the controls — auto-nudge stays suppressed until
     their NEXT message (the user 2026-07-05, refined via ui: re-engage on the user-message EVENT, never
@@ -245,8 +298,9 @@ def _interrupt_suppresses_nudge(turns):
     work, so it must never suppress the nudge nor paint "you stopped this — romp won't follow up" (the
     user 2026-07-14: restart-cut SDK sessions sat inertly in Working wearing that false badge, and
     auto-nudge stayed off so a genuine RE-stall was never caught). Such a cut is identified by the romp
-    resume notice that FOLLOWS its record (_interrupt_cause) and is EXCLUDED from the user-stop tally."""
-    last_intr, last_human = _interrupt_marks(turns)
+    resume notice that FOLLOWS its record (_interrupt_cause) and is EXCLUDED from the user-stop tally —
+    or, in the window before that notice reaches disk, by the backend's machineCut stamp (pass `sid`)."""
+    last_intr, last_human = _interrupt_marks(turns, sid)
     return last_intr > last_human
 
 
@@ -2461,7 +2515,7 @@ def _interrupt_block_tick(now, tmux):
             turns = jd.parsed_session(sid, [s["path"]], now)["turns"]
         except Exception:
             continue
-        stop_t, human_t = _interrupt_marks(turns)        # the two EVENTS this tick reasons about — and the
+        stop_t, human_t = _interrupt_marks(turns, sid)   # the two EVENTS this tick reasons about — and the
         #                                                  evidence times both writes are stamped with
         block_it = bool(turns) and not _session_working(turns) and stop_t > human_t
         if block_it:                                     # a GENUINE user stop → block the focus goal on them,
@@ -3390,7 +3444,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
     lt = turns[-1]
     if _session_working(turns):                      # still actively working (event model) → not orphaned
         return False
-    if _interrupt_suppresses_nudge(turns):           # the user's LAST action was a GENUINE interrupt → they're
+    if _interrupt_suppresses_nudge(turns, sid):      # the user's LAST action was a GENUINE interrupt → they're
         return False                                # driving; suppressed until their NEXT message. The stopped
         #                                              focus goal's BLOCKED-on-you flip is owned by the always-on
         #                                              _interrupt_block_tick (a needs-you rule, not a nudge feature).
@@ -13968,7 +14022,7 @@ def build_feed(now, tmux=None):
         # the working card wears an "interrupted" badge saying so (the user 2026-07-05). Cache-only,
         # like the working dot: the badge snaps in once _warm_fleet_bg fills the parse.
         try:
-            sess_interrupted = bool(ps) and not who_working and _interrupt_suppresses_nudge(ps["turns"])
+            sess_interrupted = bool(ps) and not who_working and _interrupt_suppresses_nudge(ps["turns"], fsid)
         except Exception:
             sess_interrupted = False
         # A user interrupt still IN FLIGHT (dispatched, not yet settled): the card wears a steady

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -581,6 +581,35 @@ def append_effort_applied(state_dir: Path, sid: str, effort: str, t: int | None 
         f.write(json.dumps(rec) + "\n")
 
 
+def append_machine_cut(state_dir: Path, sid: str, cause: str, t: float | None = None) -> None:
+    """Record that ROMP cut this session's turn and is continuing it — written at the instant a resume
+    notice is QUEUED (boot reconcile → "restart"; _heal_cut_session → "crash"), which is the event the
+    kernel's transcript scan can only INFER later, once that notice reaches disk.
+
+    Why this marker exists (the user 2026-08-12, who sees the false block "again and again"): a machine
+    cut mints the same "[Request interrupted by user]" record as a real Esc, and _machine_cut_cause tells
+    them apart by scanning FORWARD for the resume notice. But the stop record is on disk the moment the
+    turn is cut, while the notice only lands once the resumed CLI writes it — seconds later. Every
+    _interrupt_block_tick inside that window reads a bare stop with nothing after it, concludes the user
+    stopped the session, and blocks the focus card on them with INTERRUPT_BLOCK_WHY. Measured on the live
+    machine: 30 such false blocks in 30 hours, each one an interrupt/block row the user never caused,
+    followed by an unblock once the notice landed — a card round-trip on an event that carried no new
+    information at all (CLAUDE.md: cards move on new information, never on inference flaps).
+
+    Time-ordering is what makes the marker exact, so no grace period is needed: the cut always precedes
+    the resume we are queueing here, so an interrupt record at or before `t` belongs to THIS cut, and a
+    genuine stop the user makes later is always past it. That also makes the marker self-limiting — a
+    stale one can never relabel a newer stop — so nothing has to expire or be swept. `t` stays a FLOAT
+    (the other appenders truncate to int, which would move the bound EARLIER and could drop a stop record
+    written in the same second). Its own "machineCut" key, so the state/awaiting/recovery readers, which
+    filter by their own keys, skip it."""
+    p = Path(state_dir) / "states" / (sid + ".jsonl")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    rec = {"t": time.time() if t is None else float(t), "machineCut": str(cause)}
+    with open(p, "a") as f:
+        f.write(json.dumps(rec) + "\n")
+
+
 def append_awaiting(state_dir: Path, sid: str, awaiting: bool, why: str = "") -> None:
     """Append an "awaiting" OVERLAY record to states/<sid>.jsonl (interleaved with the state
     records; the kernel reader scans for the latest line carrying an "awaiting" key). "Awaiting" =
@@ -2812,6 +2841,12 @@ class SdkBackend:
                             if dead_tasks:
                                 reg["bgTasks"] = []   # reported — never re-notify for the same deaths
                             write_reg(self.state_dir, sid, reg)
+                    if cut:
+                        # Durable "romp cut this, romp is continuing it" stamp, written with the resume
+                        # notice rather than waiting for it to reach disk — so the interrupt-block tick
+                        # cannot read the intervening bare stop record as the user stopping the session
+                        # (see append_machine_cut).
+                        append_machine_cut(self.state_dir, sid, "restart")
                     resumed += 1 if cut else 0
                     notified += 1 if dead_tasks else 0
                     restored += len(queued)
@@ -4326,6 +4361,7 @@ class SdkBackend:
                 reg["queue"] = [CRASH_RESUME_NUDGE] + [t for t in (reg.get("queue") or [])
                                                        if isinstance(t, str) and t and t != CRASH_RESUME_NUDGE]
                 write_reg(self.state_dir, sid, reg)
+            append_machine_cut(self.state_dir, sid, "crash")   # romp's cut, romp's resume — never a user stop
             self._ensure(sid)
         except Exception:
             self._log("session %s: crash-resume FAILED (turn left cut for the next kernel restart): %s"

--- a/tests/test_kernel_interrupt_machine_cut.py
+++ b/tests/test_kernel_interrupt_machine_cut.py
@@ -188,6 +188,7 @@ class _FeedHarness(unittest.TestCase):
         km._downtime[:] = []
         km._parse_cache.clear()
         km._autonudge_cache.clear()
+        km._machine_cut_cache.clear()
         km._pending_ops.clear()
         km._write_auto_nudge({"enabled": True, "nudged": {}, "intrBlocked": {}})
         self.tmux = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
@@ -440,6 +441,212 @@ class ResumeNudgeDisarmsTheStopRecord(unittest.TestCase):
         self.assertIn(km.INTR_CRASH_SIG, sb.CRASH_RESUME_NUDGE)
         self.assertNotIn(km.INTR_RESTART_SIG, sb.CRASH_RESUME_NUDGE,
                          "the two causes stay distinguishable")
+
+
+# ── the race: the cut is real, its resume notice has not reached disk yet ─────────────────────────
+# Every test above hands the classifier a transcript that ALREADY contains romp's resume notice. On the
+# live machine that notice arrives seconds after the stop record, and every _interrupt_block_tick inside
+# that window read a bare trailing stop and blocked the focus card on the user: 30 false interrupt/block
+# rows in 30 hours, each followed by an unblock once the notice landed (the user 2026-08-12, for whom this
+# came up "again and again"). The backend's machineCut stamp — written when the resume is QUEUED, not when
+# it lands — is what closes the window.
+
+class MachineCutStampClassifier(unittest.TestCase):
+    """_machine_cut_cause defers to the backend's stamp ONLY where the transcript is inconclusive, and
+    time-ordering keeps that exact: the cut precedes the resume it is stamped with, so a stop the user
+    makes later is always past the stamp."""
+
+    def _users(self, atoms):
+        return atoms
+
+    def test_a_bare_trailing_stop_with_a_stamp_is_the_machine_cut(self):
+        users = self._users([uatom(T0, "wire the thing"), intr(T0 + 60)])
+        self.assertEqual(km._machine_cut_cause(users, 1, T0 + 62, "restart"), "restart",
+                         "romp queued a resume at +62 for the stop at +60 — its own cut, notice or no notice")
+
+    def test_the_stamped_cause_is_reported_verbatim(self):
+        users = self._users([uatom(T0, "wire the thing"), intr(T0 + 60)])
+        self.assertEqual(km._machine_cut_cause(users, 1, T0 + 61, "crash"), "crash")
+
+    def test_a_bare_trailing_stop_with_no_stamp_is_still_a_user_stop(self):
+        users = self._users([uatom(T0, "wire the thing"), intr(T0 + 60)])
+        self.assertIsNone(km._machine_cut_cause(users, 1),
+                          "no stamp, no notice → the user stopped it; the default must not move")
+
+    def test_a_stop_AFTER_the_stamp_is_the_user_stopping_the_resumed_turn(self):
+        # the restart's cut was resumed at +62; the user then hit Esc on that resumed turn at +90.
+        # Nothing follows it on disk, so only the ordering tells them apart.
+        users = self._users([uatom(T0, "wire the thing"), intr(T0 + 60),
+                             uatom(T0 + 62, sb.BOOT_RESUME_NUDGE, "romp"), intr(T0 + 90)])
+        self.assertIsNone(km._machine_cut_cause(users, 3, T0 + 62, "restart"),
+                          "a stop past the resume romp queued is the user's, and a stale stamp must not eat it")
+
+    def test_the_stamp_never_overrides_a_transcript_that_already_answered(self):
+        # a human message after the stop proves it was theirs — the scan terminates there and the stamp,
+        # however recent, is never consulted
+        users = self._users([uatom(T0, "wire the thing"), intr(T0 + 60),
+                             uatom(T0 + 70, "actually, try the other approach")])
+        self.assertIsNone(km._machine_cut_cause(users, 1, T0 + 9999, "restart"))
+
+    def test_the_notice_still_wins_when_it_has_landed(self):
+        users = self._users([uatom(T0, "wire the thing"), intr(T0 + 60),
+                             uatom(T0 + 62, sb.CRASH_RESUME_NUDGE, "romp")])
+        self.assertEqual(km._machine_cut_cause(users, 1), "crash",
+                         "the transcript answers on its own once the notice is there — no stamp needed")
+
+
+class MachineCutStampWiring(unittest.TestCase):
+    """The stamp is written where romp QUEUES a resume — both choke points — and read back by the kernel.
+    Pinned so a future edit cannot move the queueing without the stamp, which would silently reopen the
+    window this whole mechanism closes."""
+
+    def test_boot_reconcile_stamps_the_restart_cut(self):
+        src = Path(BIN, "romp_sdk_backend.py").read_text()
+        cut = src.index("prepend = ([BOOT_RESUME_NUDGE] if cut else [])")
+        self.assertIn('append_machine_cut(self.state_dir, sid, "restart")', src[cut:cut + 2000],
+                      "the boot reconcile that queues BOOT_RESUME_NUDGE must stamp the cut it is resuming")
+
+    def test_crash_resume_stamps_the_crash_cut(self):
+        src = Path(BIN, "romp_sdk_backend.py").read_text()
+        cut = src.index("reg[\"queue\"] = [CRASH_RESUME_NUDGE]")
+        self.assertIn('append_machine_cut(self.state_dir, sid, "crash")', src[cut:cut + 1200],
+                      "the crash resume must stamp its cut too")
+
+    def setUp(self):
+        km._machine_cut_cache.clear()      # the reader is mtime+size cached — never read a sibling's file
+
+    def tearDown(self):
+        km._machine_cut_cache.clear()
+
+    def test_the_reader_and_the_writer_agree(self):
+        # round-trip through the real appender and the real reader: one key, one cause, newest wins
+        with tempfile.TemporaryDirectory() as td:
+            saved = jd.STATE
+            try:
+                jd.STATE = Path(td)
+                self.assertEqual(km._last_machine_cut(SID), (0.0, ""), "no marker → no claim")
+                sb.append_machine_cut(Path(td), SID, "restart", T0 + 10)
+                km._machine_cut_cache.clear()
+                self.assertEqual(km._last_machine_cut(SID), (float(T0 + 10), "restart"))
+                sb.append_machine_cut(Path(td), SID, "crash", T0 + 99)
+                km._machine_cut_cache.clear()
+                self.assertEqual(km._last_machine_cut(SID), (float(T0 + 99), "crash"),
+                                 "the newest cut is the one in force")
+            finally:
+                jd.STATE = saved
+
+    def test_the_cache_refreshes_when_a_new_cut_is_appended(self):
+        # the cache must key on the file's identity, not just its path: a fresh cut written into a file
+        # already read this push has to be seen (mtime+size both move), or the window reopens
+        with tempfile.TemporaryDirectory() as td:
+            saved = jd.STATE
+            try:
+                jd.STATE = Path(td)
+                sb.append_machine_cut(Path(td), SID, "restart", T0 + 10)
+                self.assertEqual(km._last_machine_cut(SID), (float(T0 + 10), "restart"))
+                sb.append_machine_cut(Path(td), SID, "crash", T0 + 99)   # no manual cache clear
+                self.assertEqual(km._last_machine_cut(SID), (float(T0 + 99), "crash"),
+                                 "an appended cut must invalidate the cached read")
+            finally:
+                jd.STATE = saved
+
+    def test_the_stamp_keeps_sub_second_precision(self):
+        # int() truncation would move the bound EARLIER and drop a stop record written in the same second
+        with tempfile.TemporaryDirectory() as td:
+            saved = jd.STATE
+            try:
+                jd.STATE = Path(td)
+                sb.append_machine_cut(Path(td), SID, "restart", T0 + 10.75)
+                self.assertEqual(km._last_machine_cut(SID)[0], float(T0) + 10.75)
+            finally:
+                jd.STATE = saved
+
+    def test_the_marker_is_skipped_by_the_other_keyed_readers(self):
+        # it shares states/<sid>.jsonl with the state and awaiting records — its own key keeps them apart
+        with tempfile.TemporaryDirectory() as td:
+            sb.append_state(Path(td), SID, "working", T0)
+            sb.append_machine_cut(Path(td), SID, "restart", T0 + 1)
+            self.assertEqual(sb.last_state_value(Path(td), SID), "working",
+                             "the state reader must read past a machineCut record")
+
+
+class MachineCutBeforeItsNoticeLands(_FeedHarness):
+    """THE REGRESSION, end to end through the real parse and the real tick: a restart-cut session whose
+    resume notice has not been written yet must not be blocked on the user, must not wear the badge, and
+    must not have its focus card flipped out of Working."""
+
+    def _cut_awaiting_its_notice(self, cause="restart"):
+        """The window: the CLI wrote the stop record when the turn was cut; romp has queued the resume
+        (stamped) but the resumed CLI has not written the notice to the transcript yet."""
+        recs = [uline(T0, "wire the thing", "u1"),
+                aline(T0 + 20, "digging in", "a1", "u1", "tool_use"),
+                uline(T0 + 60, "[Request interrupted by user]", "u2", "a1")]
+        self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        sb.append_machine_cut(jd.STATE, SID, cause, T0 + 62)
+
+    def test_the_focus_card_is_not_blocked_on_the_user(self):
+        self._cut_awaiting_its_notice()
+        g = self._goal()
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(jd.load_goals(SID)["status"][g], "working",
+                         "romp cut this turn and is resuming it — the user is owed nothing")
+
+    def test_no_interrupt_block_row_is_filed_at_all(self):
+        # the row itself is the damage the user sees repeatedly: an interrupt/block verdict in the card's
+        # log claiming they stopped a session they never touched
+        self._cut_awaiting_its_notice()
+        g = self._goal()
+        km._interrupt_block_tick(NOW, self.tmux)
+        log = jd.load_goals(SID)["nodes"][g].get("log") or []
+        self.assertEqual([r for r in log if r.get("src") == "interrupt"], [],
+                         "no interrupt verdict may be written for a cut romp itself caused")
+        self.assertNotIn(jd.INTERRUPT_BLOCK_WHY, json.dumps(log))
+
+    def test_the_card_stays_in_working(self):
+        self._cut_awaiting_its_notice()
+        self._goal()
+        km._interrupt_block_tick(NOW, self.tmux)
+        card = self._card()
+        self.assertEqual(card["column"], "working")
+        self.assertFalse(card.get("interrupted"), "and wears no 'you stopped this' badge")
+
+    def test_a_crash_cut_awaiting_its_notice_is_also_continued(self):
+        self._cut_awaiting_its_notice("crash")
+        g = self._goal()
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(jd.load_goals(SID)["status"][g], "working")
+
+    def test_auto_nudge_still_fires_so_a_real_re_stall_is_caught(self):
+        # the false block's other half: a machine cut must not suppress the nudge (the 2026-07-14 rule)
+        self._cut_awaiting_its_notice()
+        turns = jd.parsed_session(SID, [str(self.tpath)], NOW)["turns"]
+        self.assertFalse(km._interrupt_suppresses_nudge(turns, SID),
+                         "romp caused the cut — the nudge must stay armed")
+
+    def test_the_same_transcript_with_no_stamp_still_blocks(self):
+        # the guard on the guard: without the backend's stamp this shape IS a genuine user stop, and must
+        # still reach the user. If this ever goes green-by-default the mechanism has stopped discriminating.
+        self._genuine_stop()
+        g = self._goal()
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(jd.load_goals(SID)["status"][g], "blocked",
+                         "a real Esc with no machine-cut stamp still needs the user")
+
+    def test_a_user_stop_after_the_resumed_turn_still_blocks(self):
+        # the restart's cut (+60) was stamped at +62 and resumed; the user then genuinely stopped the
+        # resumed turn at +200. The stale stamp must not swallow that stop.
+        recs = [uline(T0, "wire the thing", "u1"),
+                aline(T0 + 20, "digging in", "a1", "u1", "tool_use"),
+                uline(T0 + 60, "[Request interrupted by user]", "u2", "a1"),
+                uline(T0 + 62, sb.BOOT_RESUME_NUDGE, "u3", "u2"),
+                aline(T0 + 80, "picked it back up", "a2", "u3", "tool_use"),
+                uline(T0 + 200, "[Request interrupted by user]", "u4", "a2")]
+        self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        sb.append_machine_cut(jd.STATE, SID, "restart", T0 + 62)
+        g = self._goal()
+        km._interrupt_block_tick(NOW, self.tmux)
+        self.assertEqual(jd.load_goals(SID)["status"][g], "blocked",
+                         "the user stopped the RESUMED turn — that one is theirs and belongs in needs-you")
 
 
 if __name__ == "__main__":

--- a/tests/test_nudge_bundle.py
+++ b/tests/test_nudge_bundle.py
@@ -258,7 +258,7 @@ class AutoNudgeBundlesSameTick(unittest.TestCase):
         km._compacting_now = lambda sid: False
         km._api_error = lambda path: None
         km._session_working = lambda turns: False
-        km._interrupt_suppresses_nudge = lambda turns: False
+        km._interrupt_suppresses_nudge = lambda turns, sid="": False
         km._backend_queued = lambda sid: False
         km._backend_rewind_pending = lambda sid: False
         km._last_state = lambda sid: ("", 0)

--- a/tests/test_nudge_injected_turn_arm.py
+++ b/tests/test_nudge_injected_turn_arm.py
@@ -139,7 +139,7 @@ class InjectedTurnDeadlockEndToEnd(unittest.TestCase):
         km._compacting_now = lambda sid: False
         km._api_error = lambda path: None
         km._session_working = lambda turns: False
-        km._interrupt_suppresses_nudge = lambda turns: False
+        km._interrupt_suppresses_nudge = lambda turns, sid="": False
         km._backend_queued = lambda sid: False
         km._backend_rewind_pending = lambda sid: False
         km._last_state = lambda sid: ("", 0)


### PR DESCRIPTION
## The bug

A kernel restart mints the same `[Request interrupted by user]` record as a real Esc, so `_interrupt_block_tick` told them apart by scanning the transcript forward for romp's resume notice. The stop record is on disk the instant the turn is cut; the notice only lands once the resumed CLI writes it, seconds later. Every tick inside that gap read a bare trailing stop, concluded the user stopped the session, and blocked its focus card on them with `INTERRUPT_BLOCK_WHY`.

Measured on the live machine: **30 false interrupt/block rows in 30 hours**, each followed by an unblock once the notice arrived. A card round trip on an event that carried no new information, against the standing rule that cards move only on new information. The user reports hitting it repeatedly.

## The fix

Read the fact from the component that owns it instead of inferring it later. `append_machine_cut` stamps `states/<sid>.jsonl` at the moment romp **queues** a resume, at both choke points (boot reconcile → `restart`, `_heal_cut_session` → `crash`). `_machine_cut_cause` consults that stamp **only** where the transcript is inconclusive: the scan ran off the end having found no notice, and no human message or later interrupt to prove the stop was the user's.

Time ordering alone makes it exact, so there is no window and nothing to expire:

- the cut always precedes the resume it is stamped with, so a stop the user makes **later** is always past the stamp and still reads as theirs;
- a stale stamp can never relabel a newer stop, so nothing has to be swept;
- the stamp keeps float precision, because `int()` truncation would move the bound earlier and could drop a stop written in the same second.

The reader is mtime+size cached (the `_jerr_cache` idiom): its callers run per session on every push and these files reach ~1MB / 4k lines on a long-lived session, so an uncached scan would add megabytes of reading per cycle to an already CPU-bound loop.

## What is deliberately NOT changed

Restart **timing**. The same investigation found the dashboard's fleet Restart bypasses the quiet window the CLI deploy path uses, and that was considered and rejected: bouncing mid-turn is the accepted cost of developing romp while running it (the user 2026-08-12, who would rather have a tested fix now than a quiet window that rarely arrives). Only the misattribution was wrong.

## Tests

- the race end to end through the real parse and the real tick: no block, no verdict row, card stays in Working, nudge stays armed
- the discrimination guards that must keep blocking: no stamp at all, and a genuine stop past the stamp
- the wiring pinned at both choke points, so queueing a resume cannot move without its stamp
- the cache invalidating on a freshly appended cut

Verified load-bearing by disabling the fix: 7 tests fail, and the genuine-stop guards still pass, so the fix discriminates rather than blanket-disabling blocks.

Python 4267 passed / 31 skipped; extension 1844 passed, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)