### PR TITLE
The picker card anchors at the top: filtering only ever moves the list's bottom edge

### DIFF
--- a/ui/webview/picker-host-list.test.ts
+++ b/ui/webview/picker-host-list.test.ts
@@ -87,8 +87,10 @@ test("the page keeps painting in place while the shell has it lifted", () => {
   assert.match(STYLES, /body\.picker-lifted\.pane-gone > #picker \{ visibility: visible; \}/);
   // visibility, not display: nothing reflows, so the chat is exactly where it was when the picker closes
   assert.doesNotMatch(STYLES, /body\.picker-lifted\.pane-gone > \* \{ display: none/);
-  // …and it centres like a modal instead of hugging the top edge
-  assert.match(STYLES, /body\.picker-lifted > #picker \{ align-items: center;/);
+  // …and it TOP-ANCHORS (the user 2026-08-12, superseding the 2026-08-08 centering): vertical
+  // centering re-centered the card every time typing re-filtered the resume list, sliding the create
+  // controls mid-use. Pinned top → the card only grows/collapses at its bottom edge, the list's edge.
+  assert.match(STYLES, /body\.picker-lifted > #picker \{ align-items: flex-start; padding: 56px 16px 16px; \}/);
   // two thirds of the window: the list is what you came to read
   assert.match(STYLES, /width: min\(66vw, 900px\); min-width: min\(560px, 96vw\);/);
 });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1823,9 +1823,13 @@ body.picker-lifted::before { content: ""; position: absolute; inset: 0; backgrou
 body.picker-lifted.pane-gone > * { visibility: hidden; }
 body.picker-lifted.pane-gone > #picker { visibility: visible; }
 body.picker-lifted.pane-gone::before { display: none; }
-/* centred, like every other modal. Top-aligned made sense when this filled the screen and the list
-   wanted every pixel of height; as a dialog over the dashboard it should sit in the middle. */
-body.picker-lifted > #picker { align-items: center; padding: 24px 16px; }
+/* TOP-ANCHORED, like the base overlay rule and the command palette (the user 2026-08-12): vertical
+   centering re-centered the whole card every time typing re-filtered the resume list — the create
+   controls at the top slid up and down exactly while being used. With the top pinned, the card only
+   ever grows or collapses at its BOTTOM edge, which since the 2026-08-12 reorder is the list's edge:
+   the controls hold perfectly still. (Same 56px anchor as the un-lifted rule, so the two contexts
+   agree; kb-tight below keeps its tighter fold.) */
+body.picker-lifted > #picker { align-items: flex-start; padding: 56px 16px 16px; }
 /* SHORT WINDOW (the on-screen keyboard is up — the shell's --app-h sizing turns that into this
    window's own height — or a genuinely small screen; render.ts toggles kb-tight on resize): the
    ADVANCED create rows fold so the essentials — name box, session list, actions — share the height


### PR DESCRIPTION
The lifted picker (the web dashboard's full-window context) centered the card vertically, so every keystroke that re-filtered the resume list changed the card's height and re-centered it — the create controls at the top slid up and down exactly while being used (the user 2026-08-12, right after the reorder put the list at the bottom for the same reason). The card now top-anchors at the same 56px the un-lifted overlay rule always used, so its only moving edge is the bottom one — the resume list's edge — and the name box, directory, backend/billing/host rows and the New session button hold perfectly still. kb-tight keeps its tighter phone fold; the dim, width, and everything else about the modal treatment are unchanged.

Pin updated in picker-host-list.test.ts (it deliberately pinned the 2026-08-08 centering this supersedes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)