### PR TITLE
Picker copy: the button says Create session, and the resume heading names its 30-day reach

### DIFF
--- a/ui/webview/picker-order.test.ts
+++ b/ui/webview/picker-order.test.ts
@@ -27,13 +27,28 @@ test("the create controls precede the list, and the list sits last under its hea
 });
 
 test("the heading presents the list as the alternative to creating, and hides in pick-mode", () => {
-  assert.match(RENDER, /altHead\.textContent = "Or reopen an existing session"/);
+  assert.match(RENDER, /altHead\.textContent = "Or reopen an existing session \(last 30 days\)"/);
   // pick-mode: the list IS the dialog (choosing an existing session), so the heading hides with the
   // create rows rather than labeling the only thing on screen an "alternative"
   assert.match(RENDER, /altHeadEl\.style\.display = pick \? "none" : ""/);
   assert.match(CSS, /\.picker-alt-head \{ flex: 0 0 auto; color: var\(--dim\)/);
   assert.match(CSS, /\.picker-alt-head \{[^}]*border-top: 1px solid var\(--box-border\)/,
     "the heading's rule draws the seam above the resume section");
+});
+
+test("the heading's '(last 30 days)' states the kernel's REAL reach — the two must move together", () => {
+  // the kernel's PICKER_WINDOW is how far back the list actually goes (30 days, the user 2026-07-24);
+  // the label quotes it (the user 2026-08-12), so a widened window must rewrite both or fail here
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNEL, /PICKER_WINDOW = 30 \* 86400/);
+  assert.match(RENDER, /\(last 30 days\)/);
+});
+
+test("the in-dialog button says Create session — New session is the door, not the act", () => {
+  // you already pressed New session to open this dialog (the user 2026-08-12); the palette command
+  // that OPENS the picker keeps the New session name (palette.test.ts pins that one)
+  assert.match(RENDER, /newSess\.textContent = "✛ Create session"/);
+  assert.doesNotMatch(RENDER, /textContent = "✛ New session"/);
 });
 
 test("the dir row lost its border-top — the name box's own border-bottom draws that seam now", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4715,7 +4715,10 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     const actions = el("div", "picker-actions");
     const newSess = el("button", "picker-action");
     newSess.id = "picker-new-btn";
-    newSess.textContent = "✛ New session";
+    // "Create session", not "New session" (the user 2026-08-12): you already pressed New session to
+    // open this dialog — the button here is the ACT, not the door. (The palette command that opens
+    // the picker keeps the New session name; that one IS the door.)
+    newSess.textContent = "✛ Create session";
     newSess.title = "create a fresh romp session, named by the search box, and open it as a tab";
     newSess.addEventListener("click", () => {
       // The search box doubles as the name field — no native dialog.
@@ -4753,7 +4756,9 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     // label hides with the create rows (openPicker below).
     const altHead = el("div", "picker-alt-head");
     altHead.id = "picker-alt-head";
-    altHead.textContent = "Or reopen an existing session";
+    // "(last 30 days)" is the kernel's real reach — PICKER_WINDOW in kernel.py; picker-order.test.ts
+    // holds the two in step so a widened window can't leave this label lying.
+    altHead.textContent = "Or reopen an existing session (last 30 days)";
     box.appendChild(search);
     box.appendChild(errLine);
     box.appendChild(dirWrap);
@@ -5062,7 +5067,7 @@ function setActiveRow(row: HTMLElement | null) {
   syncNewButton();   // an active row and an armed New-session button are mutually exclusive Enter targets
 }
 
-// Arm the "✛ New session" button exactly when Enter should CREATE: create mode (the + flow), a name
+// Arm the "✛ Create session" button exactly when Enter should CREATE: create mode (the + flow), a name
 // typed, and no row explicitly active. A typed name belongs to "create" (the user 2026-07-28) — it
 // must never be re-routed onto a fuzzy match — so matches don't steal the arm; stepping onto a row
 // with ArrowDown (or hovering one) is the explicit act that hands Enter to that row instead.


### PR DESCRIPTION
Two words from using the reordered picker (the user 2026-08-12):

- The action button read "✛ New session" — but you already pressed New session to open this dialog; the button here is the act, not the door. It now reads "✛ Create session". The palette command that OPENS the picker keeps its New session name, deliberately.
- The resume heading now reads "Or reopen an existing session (last 30 days)" — naming the list's real reach. The parenthetical quotes the kernel's PICKER_WINDOW (30 days since 2026-07-24), and picker-order.test.ts holds the label and the constant in step so a widened window can't leave the label lying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)