### PR TITLE
Judges bill the judged session's account, and a refused credential lands on the card

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -262,6 +262,34 @@ While the account usage window is exhausted, the rate gate skips every call
 across every session and logs one `rate-limited` row per window; gate skips count
 toward nothing.
 
+## Billing, and when the credential itself is broken
+
+A judge call bills **the account of the session it judges** — the same pick the
+session's own Billing selector holds, read from the same registry, with the same
+fallback (an explicit login pick → the login; anything else → the manager env's
+API key when one exists, else the login). The key itself has exactly one claimer:
+the SDK backend pops it out of the kernel's environment at first use so no
+session CLI inherits it ambiently, and judges read that same stash through a wire
+the kernel installs (`judge._WORK_KEY_FN`) — before the wire lands, or standalone
+(`romp-judge --once`), the key is still sitting in the environment and is read in
+place. Every judge child env is built with the ambient variable stripped and the
+key injected back only for a key-mode call: billing is an explicit choice per
+call, never inheritance. (Before this, judges inherited the post-claim
+environment: on a host with no login, every call refused "Not logged in" for 13
+hours — ~53k errors — while the board sat frozen in Working with nothing saying
+why.)
+
+A **credential-class** failure (not logged in, an invalid key, an expired OAuth
+token) is one no retry can fix — only the user can. The first such error
+envelope latches judge-auth-down for that session (`STATE/judge-auth.json`), and
+the session's next successful call clears it; both edges are events, nothing is
+re-derived per build. While latched, the feed floors the session's focus card to
+needs-you wearing a filled-red "Can't analyze" chip that names the refused
+credential, and the card face carries the story and the fix — the session may be
+fine; it is romp's analysis of it that is down, and every card of that session is
+frozen until the credential works again. The floor yields to the live
+permission/API-error floors: one interrupt at a time, the present event first.
+
 ## Other machinery that reads the same data
 
 - **rollup_status**: pure code. Folds each node's diary into its state and
@@ -303,6 +331,8 @@ toward nothing.
   Models: `STATE/judge-model` (triage), `STATE/index-model`.
 - Logs: `STATE/judge-usage.jsonl` (per-call cost, one name per prompt),
   `STATE/judge-errors.jsonl` (the row contract above; kinds are parse,
-  call, give-up, cite-miss, rate-limited, task-store, history-unreadable).
+  call, give-up, cite-miss, rate-limited, task-store, history-unreadable),
+  `STATE/judge-auth.json` (the per-session judge-auth-down latch — see
+  "Billing" above).
 - Debugging: run the judge's own code against the live store
   (`SourceFileLoader` on `kernel/judge.py`) rather than inferring from logs.

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -50,6 +50,8 @@ PCACHE   = STATE / "judge-units-cache"   # (mtime,size) cache of a transcript's 
 MESSAGES = STATE / "timeline" / "messages.jsonl"
 ERRORS   = STATE / "judge-errors.jsonl"  # swallowed judge-call failures (parse-fails, call timeouts/exceptions) — surfaced by `romp judges`
 USAGE    = STATE / "judge-usage.jsonl"   # one line per successful judge call: tokens/cost/ms — the kernel/UI roll up pipeline cost
+JUDGE_AUTH = STATE / "judge-auth.json"   # judge-auth-down latch {fsid: {t, mode, note}}: set by a credential-class error
+                                         #   envelope, cleared by the session's next successful call — build_feed floors from it
 SDKDIR   = STATE / "sdk"                 # the SDK backend's per-session registry — lastSid tracks the CURRENT transcript fsid
 # Judge scratch cwd (the user 2026-07-20): every one-shot `claude -p` judge call writes a transcript
 # under the project dir of its CWD. With cwd=/tmp those piled into the SHARED -private-tmp project
@@ -535,7 +537,126 @@ def _log_judge_usage(judge, tier, model, fsid, wrap, sent=None, recv=None):
         pass
 
 
-def _judge_env(tier):
+_WORK_KEY_FN = None   # the kernel wires this to sdk_backend.work_api_key when it loads that module
+                      # (_sdk_locked), so judges read the SAME once-per-process stash sessions bill from
+
+
+def _work_key():
+    """The manager-environment API key available for key-mode judge billing — READ, never claimed.
+    In the kernel process the SDK backend is the one claimer (work_api_key pops os.environ so its
+    transport can't hand session CLIs an ambient key), and the kernel wires _WORK_KEY_FN to that
+    stash; until that wire lands — or standalone (romp-judge --once/--test, tests) — the key is
+    still sitting in os.environ and the plain read returns the same value. Neither path mutates the
+    environment: _judge_env strips the ambient var from every child env itself, and a second claimer
+    would only race the backend's pop (whoever popped second would stash "" — sessions or judges
+    losing the key on thread timing). This is what broke on 2026-08-12: judges inherited the
+    post-claim environment on a host with no login, and every call refused "Not logged in" for
+    13 hours (~53k errors) while the cards sat parked in Working."""
+    if _WORK_KEY_FN is not None:
+        try:
+            return _WORK_KEY_FN() or ""
+        except Exception:
+            return ""
+    return os.environ.get("ANTHROPIC_API_KEY", "") or ""
+
+
+def _judge_auth(fsid):
+    """'key' or 'login' — which account THIS judge call bills: the judged session's own billing (the
+    user 2026-08-12: a judge rides the account of the session it judges, never a third choice and
+    never a silent fall to the other one — a judge quietly billing the login on a session the user
+    put on the key is the same wrong-account failure the per-session picker exists to prevent).
+    Same resolution as the picker (sdk_backend default_auth / effective_auth), read from the same
+    registry file: an explicit 'login' pick → login; anything else → the key when the environment
+    carries one, else login. A call with no session (fleet-level rows) takes the same default a
+    fresh session would."""
+    a = ""
+    if fsid:
+        try:
+            a = json.loads((SDKDIR / (fsid + ".json")).read_text()).get("auth") or ""
+        except Exception:
+            a = ""
+    if a == "login":
+        return "login"
+    return "key" if _work_key() else "login"
+
+
+def _is_auth_error(text):
+    """A credential-class failure — the latch trigger: no retry can fix it, only the user can (fix the
+    key / sign in / switch the session's billing). Mirror of the kernel's _is_auth_error over session
+    transcripts, kept in sync by tests rather than imports (judge.py loads standalone)."""
+    low = (text or "").lower()
+    return ("not logged in" in low
+            or "api key is invalid" in low
+            or "invalid x-api-key" in low
+            or "failed to authenticate" in low
+            or ("oauth token" in low and ("expired" in low or "revoked" in low))
+            or "authentication_error" in low)
+
+
+_auth_lock = threading.Lock()            # guards the read-modify-write of JUDGE_AUTH
+_auth_cache = [None, {}]                 # (mtime_ns_or_None, dict) — one stat per read, like _DEBUG_CACHE
+
+
+def _auth_down_map():
+    """{fsid: {"t": first-failure, "mode": "key"|"login", "note": the CLI's own words}} — the
+    judge-auth-down latch build_feed floors cards from. mtime-cached; {} when absent/unreadable."""
+    try:
+        key = JUDGE_AUTH.stat().st_mtime_ns
+    except OSError:
+        return {}
+    if _auth_cache[0] != key:
+        try:
+            d = json.loads(JUDGE_AUTH.read_text())
+            _auth_cache[:] = [key, d if isinstance(d, dict) else {}]
+        except Exception:
+            _auth_cache[:] = [key, {}]
+    return _auth_cache[1]
+
+
+def _auth_write_locked(d):
+    """Atomic tmp+rename (callers hold _auth_lock). Best-effort like every latch write: a failed write
+    means a stale latch, and the next mark/clear retries it."""
+    try:
+        tmp = JUDGE_AUTH.with_suffix(".tmp")
+        tmp.write_text(json.dumps(d))
+        os.replace(tmp, JUDGE_AUTH)
+    except Exception:
+        pass
+
+
+def _auth_down_mark(fsid, mode, note):
+    """LATCH judge-auth-down for one session: its judge call just failed with a credential-class error.
+    That error is the deciding event — credentials are binary state, not noise, so the FIRST one is
+    decisive (the user 2026-08-12: loud and quick, on the card) — and the latch holds until the
+    deciding event in the other direction (_auth_down_clear on a successful call), never re-derived
+    per build. Keeps the first failure time across repeats so the card can say how long judging has
+    been down; skips the write when the evidence is unchanged (no mtime churn at retry rate). No-op
+    without a session to pin it on (fleet-level rows stay in judge-errors.jsonl)."""
+    if not fsid:
+        return
+    note = str(note or "")[:300]
+    with _auth_lock:
+        d = dict(_auth_down_map())
+        row = d.get(fsid) or {}
+        if row.get("mode") == mode and row.get("note") == note:
+            return
+        d[fsid] = {"t": int(row.get("t") or time.time()), "mode": mode, "note": note}
+        _auth_write_locked(d)
+
+
+def _auth_down_clear(fsid):
+    """Unlatch on the deciding event in the other direction: a judge call for this session SUCCEEDED,
+    so its billing works again — the floored card returns to its judged column on the next build.
+    Cheap when unlatched (one cached read, zero writes): this runs on every successful call."""
+    if not fsid or fsid not in _auth_down_map():
+        return
+    with _auth_lock:
+        d = dict(_auth_down_map())
+        if d.pop(fsid, None) is not None:
+            _auth_write_locked(d)
+
+
+def _judge_env(tier, auth="login"):
     """The subprocess env for ONE judge call. Drops the TMUX vars (so the child isn't taken for a live
     pane) and trips the Stop-hook recursion guard. For the INDEX tier it also disables extended thinking
     (MAX_THINKING_TOKENS=0): the captioner + archiver do mechanical one-shot summarization, where Haiku's
@@ -543,13 +664,24 @@ def _judge_env(tier):
     caption (722 -> 24 output tokens, 7.1s -> 0.9s per call, ~92% cheaper, identical caption). TRIAGE keeps
     thinking: the planner / closer / grouper / distiller make real placement + closure judgments. Output is
     the expensive half (Haiku $5/Mtok out) AND the latency driver (~58 tok/s, serial), so this is the
-    captioner's biggest single lever — and it's what makes any future batching latency-safe."""
+    captioner's biggest single lever — and it's what makes any future batching latency-safe.
+
+    `auth` is the call's resolved billing (_judge_auth). The ambient ANTHROPIC_API_KEY is stripped
+    unconditionally — in the kernel process the SDK backend already claimed it out of os.environ, and
+    standalone the var is still there, where a login-mode child would otherwise bill the key by mere
+    inheritance — and injected back EXPLICITLY for a key-mode call only. Removal, not blanking, same
+    rule as sdk_backend._options: the CLI treats even an empty var as key-mode-without-a-key and
+    refuses with "Not logged in"."""
+    wk = _work_key()                                  # read before the strip (standalone: same env)
     env = dict(os.environ)
+    env.pop("ANTHROPIC_API_KEY", None)                # never ambient: billing is an explicit choice per call
     for k in ("TMUX", "TMUX_PANE"):
         env.pop(k, None)
     env["ROMP_SUMMARIZING"] = "1"                     # trips the Stop-hook recursion guard
     if tier == "index":
         env["MAX_THINKING_TOKENS"] = "0"              # no thinking for mechanical summarization (the cost lever)
+    if auth == "key" and wk:
+        env["ANTHROPIC_API_KEY"] = wk
     return env
 
 
@@ -587,12 +719,13 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage"):
                 return ""
     except Exception:
         pass
-    env = _judge_env(tier)
+    fsid = getattr(_judge_ctx, "fsid", None)
+    auth = _judge_auth(fsid)                          # this call bills what the judged session bills
+    env = _judge_env(tier, auth)
     # Per-tier effort from the gear (STATE/judge-effort | index-effort) when the caller didn't pass one — "" or
     # None means NO --effort flag, the long-standing default. An explicit caller effort (the plan A/B) still wins.
     if effort is None:
         effort = (_index_effort() if tier == "index" else _triage_effort()) or None
-    fsid = getattr(_judge_ctx, "fsid", None)
     # Stash this call for the debug view: if the CALLER later rejects the reply, _log_judge_error attaches
     # this input+reply pair to the failure row (debug mode only), so a rejection is inspectable from the
     # card modal. Per-thread and overwritten per call: only the failing call's pair can ever be attached.
@@ -622,13 +755,19 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage"):
                 # on 07-06: every parser rejected the error text, every caller retried. Log the truth (a
                 # CALL failure, message attached) and return "" so callers treat it like any failed call.
                 # No usage row: a zero-cost error envelope is not a model call the cost rollup should count.
+                msg = str(wrap.get("result") or wrap.get("subtype") or "")
                 _judge_ctx.last["reply"] = str(wrap.get("result") or "")[:2000]
                 _log_judge_error(judge or tier, fsid, "call",
-                                 note="error envelope: %r" % str(wrap.get("result") or wrap.get("subtype") or "")[:160])
+                                 note="error envelope: %r" % msg[:160])
+                if _is_auth_error(msg):
+                    # credential-class: only the user can fix it — latch, so build_feed floors this
+                    # session's focus card instead of leaving the board silently frozen (2026-08-12)
+                    _auth_down_mark(fsid, auth, msg[:160])
                 return ""
             if isinstance(wrap, dict) and isinstance(wrap.get("result"), str):
                 _judge_ctx.last["reply"] = _mid_elide(wrap["result"])
                 _log_judge_usage(judge or tier, tier, model, fsid, wrap, sent, recv)
+                _auth_down_clear(fsid)                # billing works → unlatch (cheap no-op when unlatched)
                 return wrap["result"]
         except Exception:
             pass

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4303,6 +4303,13 @@ def _sdk_locked():
                 # that, a fresh install whose romp-sdk-setup had bailed looked like romp silently eating
                 # every message (the user 2026-07-28).
             sbmod = SourceFileLoader("romp_sdk_backend", str(HERE / "sdk_backend.py")).load_module()
+            # ONE claimer for the manager env's API key: the backend's work_api_key pops it out of
+            # os.environ (so no session CLI inherits it ambiently), and judges read that same stash
+            # through this wire. Before it lands the key is still in os.environ and judge._work_key
+            # reads it there — the handoff is order-independent, no second claim to race (2026-08-12:
+            # the unwired judges inherited the post-claim env on a login-less host and every call
+            # refused "Not logged in" for 13 hours while the cards sat parked in Working).
+            jd._WORK_KEY_FN = sbmod.work_api_key
             _sdk_backend = sbmod.SdkBackend(
                 jd.STATE, _claude_bin(), _send_to_app,
                 poke=_producer_wake.set, push=_pusher_wake.set,
@@ -14018,6 +14025,7 @@ def build_feed(now, tmux=None):
     alive = _alive_sessions(now, tmux)               # hard filter: living sessions only
     wmap = _wait_for_graph(now, {s["sid"] for s in alive})   # per-session 'waiting on a live peer' (the user 2026-06-22)
     _stalls = _stalled_goals()                       # goals romp's nudge gate is holding → the card's Stalled section
+    _jauth_map = jd._auth_down_map()                 # judge-auth-down latch → the per-session card floor below
     cold_parse = False                               # any living session not yet parsed → warm it in the background
     for s in alive:
         fsid, name = s["sid"], s["name"]
@@ -14284,6 +14292,22 @@ def build_feed(now, tmux=None):
                 f = nodes[f]["parentId"]
             if f in nodes and status.get(f) not in ("completed", "cleared"):   # rollup status, not raw nodeComplete (see perm floor)
                 api_top = f
+        # JUDGE-AUTH floor (the user 2026-08-12): this session's judges are failing on their CREDENTIAL
+        # (judge.py latched a credential-class error envelope; its next successful call clears it) — romp
+        # cannot analyze the session, so no card here can move on its own, and only the user can fix it
+        # (the key, the login, or the session's billing pick). Floor the focus top to needs-you wearing
+        # the story: the alternative was a board silently frozen in Working, which is exactly how a
+        # login-less host spent 13 hours and ~53k refused calls without a pixel changing. Yields to the
+        # LIVE floors (a permission prompt, the session's own API error): one interrupt at a time, the
+        # present event first — and the api floor's authErr copy already names the same credential fix.
+        jerr = _jauth_map.get(fsid)
+        jauth_top = None
+        if jerr and api_top is None and perm_top is None:
+            f = store.get("lastNode")
+            while f and nodes.get(f, {}).get("parentId") is not None:
+                f = nodes[f]["parentId"]
+            if f in nodes and status.get(f) not in ("completed", "cleared"):
+                jauth_top = f
         plain_user_t = _last_plain_user_turn_t(ps["turns"]) if ps else 0   # re-check: a plain reply after a soft block de-urgents it
         had_working = False                          # does this session show ANY working card? → drives the provisional placeholder
         had_awaiting = False                         # …and does any of them read AWAITING? → the session's straw dot (below)
@@ -14516,7 +14540,7 @@ def build_feed(now, tmux=None):
             # the truth: build_feed said working while the card showed under Blocked, and the distiller line,
             # keyed on it.column, then stayed hidden). Now it.column is authoritative: the card IS blocked, the
             # client files by it.column, and the distiller line shows (the user 2026-06-29).
-            column = ("needs_input" if (api_block or nid == perm_top
+            column = ("needs_input" if (api_block or nid == jauth_top or nid == perm_top
                                         or (col == "blocked" and not recheck and not rejudging))
                       else "completed" if col == "completed" else "working")
             had_working = had_working or column == "working"
@@ -14529,7 +14553,8 @@ def build_feed(now, tmux=None):
             # perm_top / col=="blocked"), so the brief/takeaway stays put through the re-judge window; the
             # column still moves for placement. Completed is stable (never recheck/rejudged), so it matches.
             distill_state = ("completed" if col == "completed"
-                             else "blocked" if (api_block or nid == perm_top or col == "blocked")
+                             else "blocked" if (api_block or nid == jauth_top or nid == perm_top
+                                                or col == "blocked")
                              else None)
             # summaryAnchorUuid: where a click on the distilled summary line lands.
             # COMPLETED goals pin to the COMPLETION TURN'S wrap-up — event-derived, not a guess: the
@@ -14643,6 +14668,13 @@ def build_feed(now, tmux=None):
                                       # (per-session auth, the user 2026-08-08)
                                       else "this session's sign-in or API key isn't working — fix the login (claude /login) or the key, or switch which one it bills" if aerr.get("authErr")
                                       else "this session stopped on an API error — Retry to resume")} if nid == api_top
+                            # the session itself is fine — it's romp's ANALYSIS of it whose credential is
+                            # refused, so the copy blames the judges, not the session (the user 2026-08-12)
+                            else {"state": "judgeAuth", "mode": jerr.get("mode"),
+                                  "since": jerr.get("t"), "text": jerr.get("note") or "",
+                                  "what": ("romp can't analyze this session — the API key its judges bill is being refused. Fix the key (service.env) or switch which account this session bills"
+                                           if jerr.get("mode") == "key" else
+                                           "romp can't analyze this session — the login its judges bill is being refused. Sign in again (claude /login) or switch which account this session bills")} if nid == jauth_top
                             else {"state": perm_state,
                                   "what": ("this session is stopped awaiting your input" if perm_state == "picker"
                                            else "this session is stopped awaiting your approval")} if nid == perm_top

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,17 @@ import pytest
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")
 
+# No test may reach the REAL `claude` CLI (2026-08-12): _judge_claude_bin honors ROMP_CLAUDE_BIN
+# first, so this floors every judge call a test forgot to stub at /bin/false — empty stdout, the
+# dead-CLI row, byte-for-byte what a claude-less CI runner produces. Found when an unstubbed
+# _judge_run in the kernel suite exec'd the live CLI on a dev machine: run alone it made a real
+# (billed!) model call and passed; in the full suite the process env's key had already been claimed
+# by an sdk-backend construction, the live CLI refused "Not logged in", and the judge-auth latch
+# that refusal now correctly feeds floored the synthetic session's cards — 25 stays-in-Working
+# tests red locally, green on CI, purely machine-dependent. Tests that assert _judge_claude_bin's
+# own resolution pop this var themselves (test_judge.py), as they always had to.
+os.environ["ROMP_CLAUDE_BIN"] = "/bin/false"
+
 
 @pytest.fixture(autouse=True)
 def _stub_place_llm(monkeypatch):

--- a/tests/test_judge_auth_billing.py
+++ b/tests/test_judge_auth_billing.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Judges bill the account of the session they judge (the user 2026-08-12).
+
+The incident this pins: per-session billing (f48af49c) claims the manager env's
+ANTHROPIC_API_KEY out of os.environ (sdk_backend.work_api_key) so no session CLI
+inherits it ambiently — but the judges' subprocess env was still a plain copy of
+os.environ, taken AFTER that claim. On a host whose only credential is the env key
+(no login), every judge call refused "Not logged in · Please run /login" for 13
+hours (~53k errors) while the cards sat parked in Working with nothing on screen
+saying why. The mechanics under test:
+
+  * _work_key READS the key, never claims it: through the kernel's wire
+    (_WORK_KEY_FN → sdk_backend.work_api_key, the one claimer) once it lands, and
+    straight from os.environ before it / standalone — no second pop to race.
+  * _judge_auth resolves a call's billing to the JUDGED SESSION's own pick (the
+    registry's `auth`), with the session picker's exact fallback: explicit
+    'login' → login; anything else → key when one exists, else login.
+  * _judge_env strips the ambient key from every child env and injects it back
+    explicitly for a key-mode call only (removal, not blanking — the CLI treats
+    an empty var as key-mode-without-a-key and refuses).
+  * A credential-class error envelope LATCHES judge-auth-down for the session
+    (STATE/judge-auth.json); the session's next successful call clears it. Both
+    edges are events — no timers, no per-build re-derivation.
+  * build_feed floors a latched session's focus card to needs-you wearing the
+    "judgeAuth" story (source pins, the build_feed test pattern), and the feed
+    bundle carries the chip.
+
+Synthetic sids only; the fixture key is an invented string; no real key material.
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from types import SimpleNamespace
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+jd = SourceFileLoader("romp_judge_authbill", os.path.join(BIN, "romp-judge")).load_module()
+
+FAKE_KEY = "romp-test-fixture-key-not-real"   # nothing under test validates the shape, so no sk- prefix:
+                                              # the maintainer's gitleaks pre-commit hook rightly refuses
+                                              # anything that even looks like a real key in a commit
+SID = "11111111-2222-3333-4444-555555555555"
+NOT_LOGGED_IN = "Not logged in · Please run /login"   # the CLI's live refusal, verbatim shape
+
+
+class _JudgeAuthBase(unittest.TestCase):
+    """Clean slate per test: no wire, no latch file, no ambient key, no session reg."""
+
+    def setUp(self):
+        self._env_before = os.environ.pop("ANTHROPIC_API_KEY", None)
+        self._fn_before = jd._WORK_KEY_FN
+        jd._WORK_KEY_FN = None
+        jd._auth_cache[:] = [None, {}]
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        for p in (jd.JUDGE_AUTH, jd.SDKDIR / (SID + ".json"),
+                  jd.STATE / "retry-paused.json", jd.STATE / "usage.json"):
+            try:
+                p.unlink()
+            except OSError:
+                pass
+
+    def tearDown(self):
+        jd._WORK_KEY_FN = self._fn_before
+        os.environ.pop("ANTHROPIC_API_KEY", None)
+        if self._env_before is not None:
+            os.environ["ANTHROPIC_API_KEY"] = self._env_before
+        jd._judge_ctx.fsid = None
+        # leave NOTHING latched in the shared STATE: the suite runs every test file against one
+        # XDG state home, and a leftover judge-auth.json row for the shared synthetic sid floors
+        # OTHER files' build_feed cards to needs-you (25 stays-in-Working tests, found 2026-08-12)
+        jd._auth_cache[:] = [None, {}]
+        for p in (jd.JUDGE_AUTH, jd.SDKDIR / (SID + ".json")):
+            try:
+                p.unlink()
+            except OSError:
+                pass
+
+    def _reg(self, auth):
+        (jd.SDKDIR / (SID + ".json")).write_text(json.dumps({"sid": SID, "auth": auth}))
+
+
+class WorkKeyRead(_JudgeAuthBase):
+    def test_reads_through_the_kernel_wire_once_it_lands(self):
+        jd._WORK_KEY_FN = lambda: FAKE_KEY
+        self.assertEqual(jd._work_key(), FAKE_KEY)
+
+    def test_reads_the_environment_before_the_wire_lands_without_claiming_it(self):
+        os.environ["ANTHROPIC_API_KEY"] = FAKE_KEY
+        self.assertEqual(jd._work_key(), FAKE_KEY)
+        # never a second claimer: the variable is still there for sdk_backend's own pop
+        self.assertEqual(os.environ.get("ANTHROPIC_API_KEY"), FAKE_KEY)
+
+    def test_a_broken_wire_reads_as_no_key_not_a_crash(self):
+        jd._WORK_KEY_FN = lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+        self.assertEqual(jd._work_key(), "")
+
+
+class JudgeBillingResolution(_JudgeAuthBase):
+    def test_defaults_to_the_key_when_one_exists(self):
+        jd._WORK_KEY_FN = lambda: FAKE_KEY
+        self.assertEqual(jd._judge_auth(SID), "key")      # no reg on disk
+        self.assertEqual(jd._judge_auth(None), "key")     # fleet-level call, same default
+
+    def test_defaults_to_login_when_no_key_exists(self):
+        self.assertEqual(jd._judge_auth(SID), "login")
+        self.assertEqual(jd._judge_auth(None), "login")
+
+    def test_an_explicit_login_pick_wins_over_an_available_key(self):
+        jd._WORK_KEY_FN = lambda: FAKE_KEY
+        self._reg("login")
+        self.assertEqual(jd._judge_auth(SID), "login")
+
+    def test_a_key_pick_rides_the_key(self):
+        jd._WORK_KEY_FN = lambda: FAKE_KEY
+        self._reg("key")
+        self.assertEqual(jd._judge_auth(SID), "key")
+
+    def test_a_key_pick_with_no_key_falls_to_login_like_the_session_itself(self):
+        self._reg("key")   # effective_auth logs the fall loudly and launches on login; judges mirror it
+        self.assertEqual(jd._judge_auth(SID), "login")
+
+
+class JudgeEnvBilling(_JudgeAuthBase):
+    def test_key_mode_injects_the_key_explicitly(self):
+        jd._WORK_KEY_FN = lambda: FAKE_KEY
+        env = jd._judge_env("triage", "key")
+        self.assertEqual(env.get("ANTHROPIC_API_KEY"), FAKE_KEY)
+
+    def test_login_mode_carries_no_key_at_all(self):
+        jd._WORK_KEY_FN = lambda: FAKE_KEY
+        env = jd._judge_env("triage", "login")
+        self.assertNotIn("ANTHROPIC_API_KEY", env)        # removal, not blanking
+
+    def test_the_ambient_key_is_stripped_from_a_login_mode_child_standalone(self):
+        # standalone (romp-judge --once): nobody claimed the env key, but a login-mode child
+        # must still not inherit it — billing is an explicit choice per call, never ambient
+        os.environ["ANTHROPIC_API_KEY"] = FAKE_KEY
+        env = jd._judge_env("index", "login")
+        self.assertNotIn("ANTHROPIC_API_KEY", env)
+        env = jd._judge_env("index", "key")
+        self.assertEqual(env.get("ANTHROPIC_API_KEY"), FAKE_KEY)
+
+    def test_the_existing_env_contract_survives(self):
+        os.environ["TMUX"] = "sock,1,0"
+        try:
+            env = jd._judge_env("index", "login")
+            self.assertNotIn("TMUX", env)
+            self.assertEqual(env.get("ROMP_SUMMARIZING"), "1")
+            self.assertEqual(env.get("MAX_THINKING_TOKENS"), "0")
+        finally:
+            os.environ.pop("TMUX", None)
+
+
+class AuthErrorClass(_JudgeAuthBase):
+    def test_credential_failures_classify(self):
+        for s in (NOT_LOGGED_IN, "API key is invalid · Please run /login",
+                  "invalid x-api-key", "Failed to authenticate",
+                  "OAuth token has expired", '{"type":"authentication_error"}'):
+            self.assertTrue(jd._is_auth_error(s), s)
+
+    def test_transient_failures_do_not(self):
+        for s in ("overloaded_error", "prompt is too long", "rate_limit_error",
+                  "Internal server error", "", None):
+            self.assertFalse(jd._is_auth_error(s), repr(s))
+
+
+class AuthLatch(_JudgeAuthBase):
+    def test_mark_then_clear_round_trip(self):
+        jd._auth_down_mark(SID, "key", NOT_LOGGED_IN)
+        row = jd._auth_down_map().get(SID)
+        self.assertTrue(row and row["mode"] == "key" and row["note"] == NOT_LOGGED_IN)
+        self.assertGreater(row["t"], 0)
+        jd._auth_down_clear(SID)
+        self.assertNotIn(SID, jd._auth_down_map())
+
+    def test_repeat_marks_keep_the_first_failure_time_and_skip_identical_writes(self):
+        jd._auth_down_mark(SID, "key", NOT_LOGGED_IN)
+        t0 = jd._auth_down_map()[SID]["t"]
+        m0 = jd.JUDGE_AUTH.stat().st_mtime_ns
+        jd._auth_down_mark(SID, "key", NOT_LOGGED_IN)     # same evidence: no write, no mtime churn
+        self.assertEqual(jd.JUDGE_AUTH.stat().st_mtime_ns, m0)
+        jd._auth_down_mark(SID, "key", "API key is invalid")   # new evidence: note moves, t holds
+        row = jd._auth_down_map()[SID]
+        self.assertEqual(row["t"], t0)
+        self.assertEqual(row["note"], "API key is invalid")
+
+    def test_no_session_no_row(self):
+        jd._auth_down_mark(None, "key", NOT_LOGGED_IN)
+        jd._auth_down_mark("", "key", NOT_LOGGED_IN)
+        self.assertEqual(jd._auth_down_map(), {})
+
+    def test_clear_without_a_row_writes_nothing(self):
+        jd._auth_down_clear(SID)
+        self.assertFalse(jd.JUDGE_AUTH.exists())
+
+
+class JudgeRunLatchAndInjection(_JudgeAuthBase):
+    """_judge_run end to end with a fake CLI: the envelope drives the latch, the env carries the billing."""
+
+    def _run(self, envelope, auth_reg=None, key=FAKE_KEY):
+        if key:
+            jd._WORK_KEY_FN = lambda: key
+        if auth_reg:
+            self._reg(auth_reg)
+        jd._judge_ctx.fsid = SID
+        seen = {}
+
+        def fake_run(cmd, input=None, capture_output=None, text=None, cwd=None, env=None, timeout=None):
+            seen["env"] = env
+            return SimpleNamespace(stdout=json.dumps(envelope), stderr="", returncode=0)
+
+        saved = jd.subprocess.run
+        jd.subprocess.run = fake_run
+        try:
+            out = jd._judge_run("sonnet", "SYS", "u", judge="planner", tier="triage")
+        finally:
+            jd.subprocess.run = saved
+        return out, seen
+
+    def test_a_not_logged_in_envelope_latches_and_the_call_reports_failure(self):
+        out, seen = self._run({"is_error": True, "result": NOT_LOGGED_IN})
+        self.assertEqual(out, "")
+        row = jd._auth_down_map().get(SID)
+        self.assertTrue(row, "credential refusal must latch judge-auth-down")
+        self.assertEqual(row["mode"], "key")
+        self.assertIn("Not logged in", row["note"])
+        self.assertEqual(seen["env"].get("ANTHROPIC_API_KEY"), FAKE_KEY)   # key-mode call carried the key
+
+    def test_a_transient_error_envelope_does_not_latch(self):
+        out, _ = self._run({"is_error": True, "result": "Overloaded, please retry"})
+        self.assertEqual(out, "")
+        self.assertEqual(jd._auth_down_map(), {})
+
+    def test_the_next_success_clears_the_latch(self):
+        self._run({"is_error": True, "result": NOT_LOGGED_IN})
+        self.assertIn(SID, jd._auth_down_map())
+        out, _ = self._run({"result": "ok", "usage": {}, "duration_ms": 3})
+        self.assertEqual(out, "ok")
+        self.assertNotIn(SID, jd._auth_down_map())
+
+    def test_a_login_pick_launches_the_judge_with_a_clean_env(self):
+        _, seen = self._run({"result": "ok", "usage": {}, "duration_ms": 3}, auth_reg="login")
+        self.assertNotIn("ANTHROPIC_API_KEY", seen["env"])
+
+
+class KernelWiringAndFloorPins(unittest.TestCase):
+    """The kernel side, pinned the way every build_feed behavior is (inspect.getsource)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.km = SourceFileLoader("romp_kernel_authbill", os.path.join(BIN, "romp-kernel")).load_module()
+
+    def test_the_kernel_wires_judges_to_the_one_key_claimer(self):
+        import inspect
+        self.assertIn("jd._WORK_KEY_FN = sbmod.work_api_key", inspect.getsource(self.km._sdk_locked))
+
+    def test_build_feed_floors_a_latched_session_yielding_to_the_live_floors(self):
+        import inspect
+        src = inspect.getsource(self.km.build_feed)
+        self.assertIn("_jauth_map = jd._auth_down_map()", src)
+        self.assertIn("jerr and api_top is None and perm_top is None", src)
+        self.assertIn('column = ("needs_input" if (api_block or nid == jauth_top or nid == perm_top', src)
+
+    def test_the_floored_card_carries_the_judgeAuth_story(self):
+        import inspect
+        src = inspect.getsource(self.km.build_feed)
+        self.assertIn('"state": "judgeAuth"', src)
+        self.assertIn("the API key its judges bill is being refused. Fix the key (service.env)", src)
+        self.assertIn("the login its judges bill is being refused. Sign in again (claude /login)", src)
+
+    def test_the_judge_auth_classifier_mirrors_the_kernels(self):
+        # judge.py loads standalone, so the classifier is a copy, not an import — the two must agree
+        # on the strings that matter (each side may only ever grow strictly looser together).
+        for s in ("Not logged in", "API key is invalid", "invalid x-api-key",
+                  "failed to authenticate", "OAuth token has expired", "oauth token revoked",
+                  "authentication_error", "overloaded", "rate_limit_error", ""):
+            self.assertEqual(jd._is_auth_error(s), self.km._is_auth_error(s), s)
+
+    def test_the_feed_bundle_carries_the_chip(self):
+        ts = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "feed.ts")).read()
+        css = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "feed.css")).read()
+        self.assertIn('it.blocked?.state === "judgeAuth"', ts)
+        self.assertIn("fask-jauth", ts)
+        self.assertIn(".fask-jauth", css)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_apierror_working.py
+++ b/tests/test_kernel_apierror_working.py
@@ -28,7 +28,7 @@ class ApiErrorWorking(unittest.TestCase):
         # user 2026-08-08); a transient error does NOT move the card (it auto-retries in Working).
         self.assertIn('api_block = (nid == api_top and bool(aerr and (aerr.get("tooLong") or aerr.get("spendLimit")', src)
         self.assertIn('or aerr.get("modelLimit") or aerr.get("authErr"))))', src)
-        self.assertIn('column = ("needs_input" if (api_block or nid == perm_top', src)   # stalled_floor retired 2026-07-07
+        self.assertIn('column = ("needs_input" if (api_block or nid == jauth_top or nid == perm_top', src)   # stalled_floor retired 2026-07-07; jauth_top = the judge-auth floor (2026-08-12)
         self.assertIn('or (col == "blocked" and not recheck and not rejudging))', src)
 
     def test_spend_cap_is_classified_and_floors_like_tooLong(self):

--- a/tests/test_kernel_distill_state.py
+++ b/tests/test_kernel_distill_state.py
@@ -22,10 +22,12 @@ class DistillState(unittest.TestCase):
     def test_distill_state_is_computed_from_the_genuine_block_not_the_column(self):
         src = inspect.getsource(km.build_feed)
         # "completed" mirrors col; "blocked" fires for the SAME hard blocks that make the card genuinely
-        # needs-you (api_block / a live perm_top / a soft col=="blocked") — but WITHOUT the recheck/rejudging
-        # suppression that `column` carries, so the brief survives the Working flip.
+        # needs-you (api_block / the judge-auth floor / a live perm_top / a soft col=="blocked") — but
+        # WITHOUT the recheck/rejudging suppression that `column` carries, so the brief survives the
+        # Working flip.
         self.assertIn('distill_state = ("completed" if col == "completed"', src)
-        self.assertIn('else "blocked" if (api_block or nid == perm_top or col == "blocked")', src)
+        self.assertIn('else "blocked" if (api_block or nid == jauth_top or nid == perm_top', src)
+        self.assertIn('or col == "blocked")', src)
         self.assertIn("else None)", src)
 
     def test_distill_state_drops_the_recheck_rejudging_suppression_that_column_keeps(self):

--- a/ui/webview/feed-card-layout.test.ts
+++ b/ui/webview/feed-card-layout.test.ts
@@ -89,8 +89,8 @@ test("session-STATE badges (⏸ approval / ⚠ API error) ride the name row; the
   // the bug: ⏸ approval + buttons + Clear in the SAME footer row shoved them off a narrow card.
   // Fix: the state badges move up beside the session name; the action row holds only the buttons.
   // The ⏳ "awaiting" chip was REMOVED (the user 2026-07-04) — the body "Awaiting background agents" box says it.
-  assert.match(FEED, /idwrap\.append\(retryBadge, apiBadge, blkBadge\)/,
-    "state badges sit beside the name (no awaiting chip; retrying joined 2026-07-09)");
+  assert.match(FEED, /idwrap\.append\(retryBadge, apiBadge, jauthBadge, blkBadge\)/,
+    "state badges sit beside the name (no awaiting chip; retrying joined 2026-07-09, judge-auth 2026-08-12)");
   assert.doesNotMatch(FEED, /waitBadge/, "the redundant awaiting chip element is gone entirely");
   assert.match(FEED, /actions\.append\(apiRetry, revive,/, "action row = Retry/Revive (+ resume-gate) only (Clear moved to the name row 2026-07-07)");
   assert.match(FEED, /a\._blocked = blkBadge;/);

--- a/ui/webview/feed-judge-auth.test.ts
+++ b/ui/webview/feed-judge-auth.test.ts
@@ -1,0 +1,54 @@
+// The "⚠ Can't analyze · API key / login" chip (the user 2026-08-12): when a session's judges fail on
+// their CREDENTIAL, romp cannot analyze that session at all — no verdict can move its cards — and for 13
+// hours on a key-only host that read as a board silently frozen in Working. The kernel floors the latched
+// session's focus card to needs_input carrying blocked.state "judgeAuth" (judge.py's latch, set by a
+// credential-class error envelope, cleared by the next successful call); the card wears a FILLED red chip
+// — deliberately a new style, inverted from the outlined api-trouble family: those say "the session hit
+// trouble", this one says "romp can't even look" — and the card face carries the explanation itself.
+// Source-level pin like feed-retrying.test.ts (no jsdom harness); the latch + billing behavior is tested
+// in tests/test_judge_auth_billing.py.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
+
+test("the judge-auth chip is built once, rides the session-state row, and keys on blocked.state", () => {
+  assert.match(FEED, /const jauthBadge = el\("span", "fask-jauth"\)/);
+  assert.match(FEED, /idwrap\.append\(retryBadge, apiBadge, jauthBadge, blkBadge\)/,
+    "the chip rides the name row with its api-trouble siblings");
+  assert.match(FEED, /a\._jauthBadge = jauthBadge;/);
+  assert.match(FEED, /const isJudgeAuth = it\.blocked\?\.state === "judgeAuth"/);
+});
+
+test("the chip names WHICH credential is refused, and the ⏸ picker chip stands down", () => {
+  assert.match(FEED, /"⚠ Can't analyze · API key" : "⚠ Can't analyze · login"/,
+    "mode 'key' vs 'login' — the label says what to go fix");
+  assert.match(FEED, /!isApiErr && !isJudgeAuth && it\.blocked\.state !== "quarantine"/,
+    "the generic ⏸ approval/picker chip must not misread a judgeAuth block as a picker");
+});
+
+test("the card face carries the explanation itself — a message, not just a chip", () => {
+  // no decision brief can exist here (the distiller is one of the judges that are down), so the
+  // distill line shows blocked.what instead of sitting empty; applyDistillLine re-runs every push,
+  // so the line restores itself the moment the latch clears.
+  assert.match(FEED, /if \(isJudgeAuth && it\.blocked && !distillShown\)/);
+  assert.match(FEED, /dle\.textContent = it\.blocked\.what \|\| ""/);
+});
+
+test("filled red — a new chip style, same size as its api-trouble siblings (same information type)", () => {
+  assert.match(CSS, /\.fask-jauth \{[^}]*font-size: 0\.7em/, "same size as .fask-apierror / .fask-retrying");
+  assert.match(CSS, /\.fask-jauth \{[^}]*background: #c0392b/, "filled, not outlined — 'romp can't even look'");
+});
+
+test("the kernel floors a latched session's focus card with the judgeAuth story", () => {
+  assert.match(KERNEL, /_jauth_map = jd\._auth_down_map\(\)/, "one latch read per build");
+  assert.match(KERNEL, /jerr and api_top is None and perm_top is None/,
+    "yields to the LIVE floors — one interrupt at a time, the present event first");
+  assert.match(KERNEL, /"state": "judgeAuth"/);
+  assert.match(KERNEL, /the API key its judges bill is being refused/, "the key copy names the fix");
+  assert.match(KERNEL, /the login its judges bill is being refused/, "the login copy names the fix");
+});

--- a/ui/webview/feed-retrying.test.ts
+++ b/ui/webview/feed-retrying.test.ts
@@ -15,7 +15,7 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-ke
 
 test("the retrying badge is built once and rides the session-state row beside the API-error badge", () => {
   assert.match(FEED, /const retryBadge = el\("span", "fask-retrying"\)/);
-  assert.match(FEED, /idwrap\.append\(retryBadge, apiBadge, blkBadge\)/,
+  assert.match(FEED, /idwrap\.append\(retryBadge, apiBadge, jauthBadge, blkBadge\)/,
     "session-STATE badges ride the name row, off the action row");
   assert.match(FEED, /a\._retryBadge = retryBadge;/);
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -679,6 +679,14 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   color: #e5484d; border: 1px solid rgba(229, 72, 77, 0.6); border-radius: 5px; padding: 1px 6px;
   opacity: 0.85;
 }
+/* ⚠ Can't analyze · API key / login — judge-auth-down (the user 2026-08-12): romp's OWN analysis of
+   this session is refused on its credential, so nothing here can move without the user. FILLED red —
+   a deliberately new chip, same size as its api-trouble siblings (same information type) but
+   inverted: the outlined chips say "the session hit trouble", this one says "romp can't even look". */
+.fask-jauth {
+  flex: 0 0 auto; font-size: 0.7em; font-weight: 800; letter-spacing: 0.03em; white-space: nowrap;
+  color: #fff; background: #c0392b; border: 1px solid #c0392b; border-radius: 5px; padding: 1px 6px;
+}
 .fdismiss.fretry { color: #e5484d; border-color: #e5484d; }
 .fdismiss.fretry:hover:not(:disabled) { color: #fff; background: #e5484d; border-color: #e5484d; }
 .fdismiss.fretry:disabled { opacity: 0.55; cursor: default; }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -80,6 +80,7 @@ interface AskItem {
               tooLong?: boolean;   // apiError: a "prompt is too long" error (on you → compact) vs a transient API error
               spendLimit?: boolean;   // apiError: a monthly spend cap (on you → raise it, never auto-retried; the user 2026-07-14)
               modelLimit?: boolean;   // apiError: this session's MODEL is out of allowance (on you → switch model or add credits; the user 2026-08-01)
+              mode?: string; since?: number;   // judgeAuth adds these: which billing its judges ride ('key'|'login') + the first refusal time — romp can't analyze the session until the credential is fixed (the user 2026-08-12)
               toName?: string; toSid?: string;    // parkedHandoff adds to*
               mid?: string; frm?: string; to?: string; origin?: string; body?: string; gist?: string };   // quarantine (held peer mail) adds these; gist = the bus's 90-char collapse for the compact card line
   summary?: string | null;                         // distiller's key takeaway for a COMPLETED goal → the done card's one auto-written line (kernel asks.append); null until produced
@@ -789,6 +790,10 @@ function makeAskCard(it: AskItem): HTMLElement {
   const waitOnBadge = el("span", "fask-waiton"); waitOnBadge.style.display = "none";   // "Awaiting <peer>" / "Deadlock <peer>", peer name in native colour (the user 2026-06-22)
   const blkBadge = el("a", "fask-blocked"); blkBadge.style.display = "none";   // ⏸ live permission/picker block → click opens the session
   const apiBadge = el("span", "fask-apierror"); apiBadge.textContent = "⚠ API error"; apiBadge.style.display = "none";   // red: session stopped on an API error
+  // filled red (a new chip, deliberately distinct from the outlined api-trouble family): romp's OWN
+  // analysis of this session is refused on its credential — the session may be fine; the judges are
+  // down, and every card here is frozen until the user fixes the key/login (the user 2026-08-12)
+  const jauthBadge = el("span", "fask-jauth"); jauthBadge.style.display = "none";
   // "⚠ retrying since HH:MM" (the user 2026-07-09): the session's OPEN turn is inside an api-retry storm —
   // still in motion, so the card stays in Working, but the storm must be visible: the API-error badge above
   // only fires once the session is idle-stalled, and nimbus's card read plain healthy "Working" through an
@@ -841,7 +846,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   // name — they describe the session's live state, and keeping them OFF the action row stops them shoving
   // the buttons past the card's right edge on a narrow card (the user 2026-06-19; mirrors the ↻ Followed-up
   // chip moved up 2026-06-18). idwrap is flex:1 so the name ellipsizes before the badge is ever clipped.
-  idwrap.append(retryBadge, apiBadge, blkBadge);
+  idwrap.append(retryBadge, apiBadge, jauthBadge, blkBadge);
   // COMPACTNESS (the user 2026-07-07): Clear rides the NAME row (right side, after the chips) and the
   // Background/Summary toggles ride the TIME row — freeing a whole action row. So the action row holds only
   // Retry / Revive (rare states); both rows flex-WRAP so nothing overflows or overlaps on a narrow card.
@@ -1061,6 +1066,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   a._waitOn = waitOnBadge;
   a._blocked = blkBadge;
   a._apiBadge = apiBadge; a._apiRetry = apiRetry; a._retryBadge = retryBadge; a._revive = revive; a._clr = clr;
+  a._jauthBadge = jauthBadge;
   a._cont = cont;
   a._qApprove = qApprove; a._qDeny = qDeny; a._qBody = qbody;
   a._delegations = delegations;
@@ -1502,9 +1508,10 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // ⏸ live block badge: the session is stopped mid-turn on a permission prompt /
   // picker FOR THIS CARD's work — the card files under BLOCKED while it lasts
   const isApiErr = it.blocked?.state === "apiError";
+  const isJudgeAuth = it.blocked?.state === "judgeAuth";
   // the resume-gate card carries its own explanatory text + Proceed/Compact/Skip buttons, so the ⏸ chip
   // (which only speaks permission/picker) would just misread — suppress it there (the user 2026-07-21).
-  const showBlk = !!it.blocked && !isApiErr && it.blocked.state !== "quarantine";
+  const showBlk = !!it.blocked && !isApiErr && !isJudgeAuth && it.blocked.state !== "quarantine";
   a._blocked.style.display = showBlk ? "" : "none";
   if (showBlk && it.blocked) {
     // live prompts only — the paused-stall badge retired with the floor (2026-07-07; a failed nudge now
@@ -1522,6 +1529,15 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // turn off once — the user 2026-06-29). updateAskCard runs every push, so this re-applies on every refresh.
   const distillShown = applyDistillLine(a._distill as HTMLElement, dCompleted, dBlocked,
                    it.summary, it.blockSummary);
+  // A judge-auth card explains itself ON THE CARD FACE (the user 2026-08-12: a message, not just a
+  // chip): no decision brief can exist here — the distiller is one of the very judges that are down —
+  // so the distill line carries blocked.what instead of sitting empty. applyDistillLine re-runs every
+  // push, so the line restores itself the moment the latch clears and a real brief/takeaway returns.
+  if (isJudgeAuth && it.blocked && !distillShown) {
+    const dle = a._distill as HTMLElement;
+    dle.textContent = it.blocked.what || "";
+    dle.style.display = it.blocked.what ? "" : "none";
+  }
   // PER-PARAGRAPH ages (the user 2026-07-24): a MULTI-item decision brief writes one paragraph per
   // owed item IN ORDER (judge BLOCK_BRIEF_SYS 2026-07-21 + briefParts), so each paragraph can wear
   // the age of ITS OWN ask — the exact block-event time — and a stale re-surfaced ask shows its real
@@ -1632,6 +1648,16 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
       vscodeApi?.postMessage({ type: "apiRetry", id: it.sid });
       a._apiRetry.disabled = true; a._apiRetry.textContent = "Retrying…";
     };
+  }
+  // JUDGE-AUTH (the user 2026-08-12): romp's own analysis of this session is refused on its credential —
+  // the judges bill what the session bills (kernel _judge_auth), that credential is failing, and no card
+  // here can move until the user fixes it. The chip names which credential; no Retry (nothing in-session
+  // to resume — the latch clears itself on the judges' next successful call once the credential works).
+  (a._jauthBadge as HTMLElement).style.display = isJudgeAuth ? "" : "none";
+  if (isJudgeAuth && it.blocked) {
+    a._jauthBadge.textContent = it.blocked.mode === "key" ? "⚠ Can't analyze · API key" : "⚠ Can't analyze · login";
+    a._jauthBadge.title = (it.blocked.what || "")
+      + (it.blocked.text ? ` — the CLI said: ${it.blocked.text}` : "");
   }
   // "⚠ retrying since HH:MM" — the OPEN turn is inside an api-retry storm (kernel `retrying`: the live
   // backend state, with the storm's start from the states log). The card stays in Working — the storm is


### PR DESCRIPTION
## What broke

Per-session billing (f48af49c) claims the manager env's `ANTHROPIC_API_KEY` out of `os.environ` so no session CLI inherits it ambiently — but the judges' child env was still a plain copy of `os.environ` taken **after** that claim. On a host whose only credential is the env key (no login), every judge call refused `Not logged in · Please run /login` for 13 hours (~53k errors) while the cards sat parked in Working with nothing on screen saying why. On logged-in hosts the same change silently flipped judge billing from the key to the login.

## What this does

- **A judge call bills what the session it judges bills** — the registry's own auth pick with the picker's exact fallback (explicit login → login, else the key when one exists, else login). Fleet-level calls take the same default a fresh session would.
- **One claimer, order-independent handoff.** The SDK backend keeps its single `work_api_key()` claim; the kernel wires `judge._WORK_KEY_FN` to that stash at module load. Before the wire lands — or standalone (`romp-judge --once`, tests) — the key is still in the environment and is read in place, never popped a second time, so nothing races.
- **Billing is explicit per call, never inheritance.** Every judge child env strips the ambient variable and injects the key back only for a key-mode call (removal, not blanking — an empty var reads as key-mode-without-a-key to the CLI).
- **A refused credential is loud where the user looks.** The first credential-class error envelope latches judge-auth-down for the session (`STATE/judge-auth.json`); the next successful call clears it — both edges events. While latched, `build_feed` floors the session's focus card to needs-you wearing a new filled-red "⚠ Can't analyze · API key / login" chip, with the story and the fix on the card face. Yields to the live permission/API-error floors: one interrupt at a time.
- **The suite can never exec the real CLI again.** conftest pins `ROMP_CLAUDE_BIN=/bin/false`: an unstubbed `_judge_run` in the kernel suite was reaching the live `claude` on a dev machine — run alone it made a real billed model call and passed; in the full suite the env key had already been claimed, the CLI refused, and the new latch correctly floored the synthetic session's cards (25 red tests locally, green on CI, purely machine-dependent). Every forgotten stub now produces the dead-CLI row, byte-for-byte what a claude-less CI runner produces.

## Tests

- `tests/test_judge_auth_billing.py` (new): the read-never-claim key handoff, the per-session resolution matrix, explicit injection/strip per mode, the credential-class classifier (kept mirror-equal to the kernel's), latch mark/clear round-trips, `_judge_run` end-to-end with a fake CLI, and the kernel wiring + floor + chip pins.
- `ui/webview/feed-judge-auth.test.ts` (new): the chip, its copy, the ⏸-chip standdown, the on-card message, the filled-red style, and the kernel floor story.
- Updated pins: `test_kernel_apierror_working.py`, `test_kernel_distill_state.py`, `feed-card-layout.test.ts`, `feed-retrying.test.ts`.
- Full suites green locally: pytest 4301 passed; node 1856 passed; extension typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)