### PR TITLE
The picker's name box asks the phone keyboard not to predict or autofill

### DIFF
--- a/ui/webview/picker-keyboard.test.ts
+++ b/ui/webview/picker-keyboard.test.ts
@@ -34,3 +34,15 @@ test("folded, the box hugs the short viewport instead of centering into the keyb
   assert.match(CSS, /body\.picker-lifted > #picker\.kb-tight \{ align-items: flex-start; padding: 12px 16px; \}/);
   assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-box \{ max-height: calc\(100vh - 24px\); \}/);
 });
+
+test("the name box opts the phone keyboard out of predictions and autofill", () => {
+  // the keyboard's prediction bar had learned the user's own session names and offered them over
+  // this box (the user 2026-08-12, Samsung keyboard) — redundant next to the picker's real list,
+  // and mistakable for romp UI. These are the standard opt-out hints; a keyboard may still ignore
+  // them (its predictive-text setting is the only sure switch), so the code comment must keep
+  // saying so rather than claiming the bar is gone.
+  assert.match(RENDER, /search\.setAttribute\("autocomplete", "off"\)/);
+  assert.match(RENDER, /search\.autocapitalize = "none"/);
+  assert.match(RENDER, /search\.setAttribute\("autocorrect", "off"\)/);
+  assert.match(RENDER, /its predictive-text setting is the only sure/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4631,6 +4631,16 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     search.id = "picker-search";
     search.placeholder = "Search sessions…";
     search.spellcheck = false;
+    // The phone keyboard's prediction bar had learned the user's session names and offered them over
+    // this box — redundant next to the real session list right below it, and mistakable for romp UI
+    // (the user 2026-08-12, Samsung keyboard). These are the standard opt-out HINTS: autocomplete
+    // also keeps the browser's own form-history dropdown off (the dir field wears the same belt),
+    // autocapitalize suits session names anyway ("dev", not "Dev"), autocorrect is iOS's spelling of
+    // the same ask. A keyboard may still ignore them — its predictive-text setting is the only sure
+    // switch, so nothing here may claim the bar is gone, only unrequested.
+    search.setAttribute("autocomplete", "off");
+    search.autocapitalize = "none";
+    search.setAttribute("autocorrect", "off");
     search.addEventListener("input", () => { filterPicker(search.value); pickerError(null); });
     const errLine = el("div", "picker-error"); errLine.id = "picker-error";
     const list = el("div", "picker-list"); list.id = "picker-list";


### PR DESCRIPTION
The prediction bar on the user's phone keyboard (Samsung) had learned their session names and offered them as suggestion chips over the new-session picker — redundant next to the picker's own session list, and easily mistaken for romp UI. It isn't romp's UI, so nothing can be removed — only requested: the name/search box now carries the standard opt-out hints (`autocomplete=off`, `autocapitalize=none`, `autocorrect=off`), matching the belt the directory field already wears. A keyboard may still ignore them; the code comment keeps that limit explicit.

Pinned in `picker-keyboard.test.ts` (the phone-keyboard picker test home), including the honesty clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)