### PR TITLE
Picker: the Host row names this machine, and the keyboard-up fold pins Create below a flexing list

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -22463,7 +22463,11 @@ class Handler(BaseHTTPRequestHandler):
                                        "nativeDialogs": _native_dialogs(),
                                        # billing choices THIS host can offer a new session — the picker
                                        # shows its auth control only when both are real (see _auth_avail)
-                                       "authAvail": _auth_avail()}))
+                                       "authAvail": _auth_avail(),
+                                       # this machine's name (the identity peers see) — the picker's
+                                       # Host row labels its this-machine option with it, so every
+                                       # option is a machine by name (the user 2026-08-12)
+                                       "selfHost": _self_host()}))
         elif msg and msg.get("type") in ("pickResult", "openByName") and (msg.get("id") or msg.get("name")):
             sid = msg.get("id") or _live_names(_tmux_sessions()).get(str(msg.get("name")))
             if sid:

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5607,6 +5607,28 @@ class ViewBuilder(unittest.TestCase):
         self.assertIsNotNone(sl, "requestSessions returns a sessionList")
         self.assertEqual(sl.get("defaultDir"), km._tilde(wd), "the dir field prefills the kernel's default path")
 
+    def test_requestSessions_payload_carries_self_host(self):
+        """The picker's Host row labels its this-machine option with the machine's real name instead of
+        'local' (the user 2026-08-12). The name rides the sessionList payload as selfHost, and it is the
+        SAME identity peers see (_self_host — short hostname, ROMP_HOST_NAME override), so the picker
+        and federation never disagree about what this machine is called."""
+        saved_sdk, saved_hn = km._sdk, os.environ.get("ROMP_HOST_NAME")
+        km._sdk = lambda: None                               # don't construct the real SDK backend
+        os.environ["ROMP_HOST_NAME"] = "TESTHOST"
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s)), "app": "chat"}
+        try:
+            km.Handler._dispatch_ws(None, {"type": "requestSessions"}, client)
+        finally:
+            km._sdk = saved_sdk
+            if saved_hn is None:
+                os.environ.pop("ROMP_HOST_NAME", None)
+            else:
+                os.environ["ROMP_HOST_NAME"] = saved_hn
+        sl = next((m for m in sent if m.get("type") == "sessionList"), None)
+        self.assertIsNotNone(sl, "requestSessions returns a sessionList")
+        self.assertEqual(sl.get("selfHost"), "TESTHOST", "the payload names this machine as peers know it")
+
     def test_createSession_sdk_backend_unavailable_warns_instead_of_tmux_fallback(self):
         """The user asked for an SDK session on a kernel without the SDK venv and got a MYSTERY TMUX session
         instead (TESTHOST, 2026-07-02) — the handler silently fell through to _spawn_session. Now it warns

--- a/ui/webview/picker-host.test.ts
+++ b/ui/webview/picker-host.test.ts
@@ -1,6 +1,7 @@
-// The + dialog's HOST picker (federation, the user 2026-07-02): local | each attached SSH host, so a new
-// session can be created ON a remote kernel (the federation manager routes createSession over that host's
-// tunnel; the tab arrives prefixed host:name). Source-pin over render.ts, like picker-backend.test.ts.
+// The + dialog's HOST picker (federation, the user 2026-07-02): this machine | each attached SSH host,
+// so a new session can be created ON a remote kernel (the federation manager routes createSession over
+// that host's tunnel; the tab arrives prefixed host:name). Source-pin over render.ts, like
+// picker-backend.test.ts.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -14,6 +15,24 @@ test("the + dialog builds a Host row listing local + attached hosts, hidden with
   // options rebuilt each open from the federation manager's live host list
   assert.match(RENDER, /__rompFed\?\.hosts\?\.\(\)/);
   assert.match(RENDER, /hostWrapEl\.style\.display = pick \|\| !hosts\.length \? "none" : ""/);
+});
+
+test("the this-machine option wears the machine's REAL name, not 'local' (the user 2026-08-12)", () => {
+  // the name is the kernel's peer identity (_self_host — short hostname, ROMP_HOST_NAME override),
+  // carried on the local sessionList reply; the row then reads as a list of machines by name
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNEL, /"selfHost": _self_host\(\)/);
+  assert.match(RENDER, /b\.textContent = h \|\| localSelfHost \|\| "local"/);
+  // the Host row is built on open, BEFORE the reply lands — the handler relabels the button in
+  // place, so only the first-ever open briefly shows the "local" placeholder
+  assert.match(RENDER, /if \(typeof m\.selfHost === "string" && m\.selfHost && !from\) \{\s*\n\s*localSelfHost = m\.selfHost;/);
+  assert.match(RENDER, /querySelector\('#picker \.picker-host \.picker-be-opt\[data-host=""\]'\)/);
+  // …and the adoption sits BEFORE the stale-list drop guard: the name is this machine's identity,
+  // not list data — switching the picker to a remote host before the local reply lands must not
+  // throw the name away with the (rightly dropped) stale list
+  const adopt = RENDER.indexOf("localSelfHost = m.selfHost");
+  const drop = RENDER.indexOf("if (from !== pickerListHost) return;");
+  assert.ok(adopt >= 0 && drop >= 0 && adopt < drop, "selfHost is adopted before the stale-list drop");
 });
 
 test("createSession carries the picked host (empty = local) so the manager routes it to that kernel", () => {

--- a/ui/webview/picker-keyboard.test.ts
+++ b/ui/webview/picker-keyboard.test.ts
@@ -3,8 +3,10 @@
 // lifted chat iframe to the VISIBLE height (--app-h ← the top-level visualViewport, pinned in
 // tests/test_kernel.py + test_shell_viewport_fit.py), so the keyboard opening/closing lands in the
 // iframe as its own resize event — render.ts keys the kb-tight fold on exactly that, no timers, no UA
-// sniffing. Folded: the advanced create rows (dir, backend, billing, host) hide; the essentials (name
-// box, session list, actions) share the height with the keyboard. The same resize expands them back.
+// sniffing. Folded: the advanced create rows (dir, backend, billing, host) hide, and the essentials
+// rearrange for the keyboard (the user 2026-08-12, after the resume list moved to the dialog's
+// bottom): the list flexes to fill the middle directly under the name box, and the actions row pins
+// to the box's bottom edge, right above the keyboard. The same resize expands it all back.
 // Source-level pins (no jsdom for the renderer).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -25,12 +27,28 @@ test("kb-tight folds the advanced create rows and keeps the essentials", () => {
   // the advanced rows fold — !important because pick-mode / auth availability drive these rows'
   // visibility via inline styles, and the fold must win while it holds
   assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-dir,\s*\n\.picker-overlay\.kb-tight \.picker-backend \{ display: none !important; \}/);
-  // .picker-backend covers billing + host too (they wear the class); actions/list/search have no fold rule
-  assert.doesNotMatch(CSS, /kb-tight \.picker-actions/);
-  assert.doesNotMatch(CSS, /kb-tight \.picker-list \{ display/);
+  // the essentials never fold: no display rule hides actions, list, or search while kb-tight holds
+  assert.doesNotMatch(CSS, /kb-tight \.picker-actions \{[^}]*display/);
+  assert.doesNotMatch(CSS, /kb-tight \.picker-list \{[^}]*display/);
 });
 
 test("folded, the box hugs the short viewport instead of centering into the keyboard", () => {
-  assert.match(CSS, /body\.picker-lifted > #picker\.kb-tight \{ align-items: flex-start; padding: 12px 16px; \}/);
-  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-box \{ max-height: calc\(100vh - 24px\); \}/);
+  // both contexts tighten to the same 12px frame — the fixed-height box below assumes exactly it,
+  // and the standalone overlay's 56px anchor would otherwise push the pinned actions row off-screen
+  assert.match(CSS, /#picker\.kb-tight,\s*\nbody\.picker-lifted > #picker\.kb-tight \{ align-items: flex-start; padding: 12px 16px; \}/);
+  // a FIXED height, not just a cap: the pinned actions row below the list must not shift as typing
+  // re-filters the list's height. dvh, not vh — standalone on a phone, vh is the LARGEST viewport
+  // while the fold keys on the current innerHeight, and the mismatch clipped the pinned actions row
+  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-box \{ height: calc\(100dvh - 24px\); max-height: calc\(100dvh - 24px\); \}/);
+});
+
+test("folded, the list fills the middle and the actions row pins to the bottom edge", () => {
+  // the tall layout is controls-first, list last (picker-order.test.ts); the short window inverts
+  // exactly that — the filtered matches sit directly under the name box being typed in, and the
+  // Create button holds still at the bottom, above the keyboard, where a thumb expects it
+  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-list \{ flex: 1 1 auto; min-height: 0; \}/);
+  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-actions \{ order: 1; \}/);
+  // with the create rows between them hidden, the heading sits directly under the name box — its
+  // border-top would double the search box's own border-bottom into a thick seam
+  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-alt-head \{ border-top: none; \}/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4777,9 +4777,10 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     // VISIBLE height (--app-h ← the top-level visualViewport, which the keyboard shrinks), so the
     // keyboard opening/closing lands here as this window's own resize — the exact event to key on, no
     // timers, no UA sniffing. Short window → kb-tight folds the advanced create rows (dir, backend,
-    // billing, host — styles.css) so the essentials share the height with the keyboard; the same
-    // resize expands them back the moment there is room again (a genuinely small screen folds too,
-    // which is the right call there as well).
+    // billing, host) and rearranges the essentials for the keyboard — the list flexes to fill the
+    // middle under the name box and the actions row pins to the bottom edge (styles.css, the user
+    // 2026-08-12); the same resize expands it all back the moment there is room again (a genuinely
+    // small screen folds too, which is the right call there as well).
     const kbFit = () => document.getElementById("picker")?.classList.toggle("kb-tight", window.innerHeight < 480);
     window.addEventListener("resize", kbFit);
     kbFit();
@@ -4810,7 +4811,11 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     hostWrapEl.querySelectorAll(".picker-be-opt").forEach((x) => x.remove());
     for (const h of ["", ...hosts]) {
       const b = el("button", "picker-be-opt" + (h === "" ? " sel" : "")) as HTMLButtonElement;
-      b.type = "button"; b.textContent = h || "local"; b.dataset.host = h;
+      // This machine wears its REAL name, like the remote options wear theirs (the user 2026-08-12):
+      // "local" made the row read as one named machine plus an unnamed one. The name rides the local
+      // sessionList reply (selfHost), so the very first open may briefly say "local" until it lands —
+      // the handler below relabels the button in place.
+      b.type = "button"; b.textContent = h || localSelfHost || "local"; b.dataset.host = h;
       b.title = h ? `Create the session on ${h} (its kernel spawns it; the tab shows as ${h}:name).`
                   : "Create the session on this machine.";
       b.addEventListener("click", () => {
@@ -5123,6 +5128,10 @@ function pickerKey(e: KeyboardEvent) {
 // The kernel's real default new-session directory (its serve cwd, ~-ified), from the sessionList payload —
 // prefilled into the dir field when there's no gear default, so "the default path is written in there".
 let kernelDefaultDir = "";
+// This machine's name as the kernel's peers know it (_self_host — short hostname, ROMP_HOST_NAME
+// override), from the same payload. The + picker's Host row labels its first option with it, so the
+// row reads as a list of machines by name rather than named hosts plus a "local" (the user 2026-08-12).
+let localSelfHost = "";
 // Is this session already an open tab in THIS dashboard? (loaded session, or a not-yet-loaded placeholder tab
 // the kernel's order carries.) The + picker uses it to hide sessions you can already reach by a tab-click.
 function isOpenTab(id: string): boolean {
@@ -8476,6 +8485,17 @@ window.addEventListener("message", (e: MessageEvent) => {
     // host the picker has since switched away from is dropped rather than painted over the current one
     // (the user 2026-07-29) — two kernels answer at their own speeds, so order is not a given.
     const from = typeof m.host === "string" ? m.host : "";
+    // The LOCAL kernel's own machine name — adopted BEFORE the stale-list drop below, on purpose:
+    // the name is this machine's identity, not list data, so it must not die with a reply whose
+    // LIST is stale (picker already switched to a remote host — the drop's one job). The Host row
+    // is built before this reply lands (its options rebuild on every open), so also relabel the
+    // this-machine button in place — the row's first-ever open is the only one that shows the
+    // "local" placeholder.
+    if (typeof m.selfHost === "string" && m.selfHost && !from) {
+      localSelfHost = m.selfHost;
+      const lb = document.querySelector('#picker .picker-host .picker-be-opt[data-host=""]') as HTMLElement | null;
+      if (lb) lb.textContent = localSelfHost;
+    }
     if (from !== pickerListHost) return;
     if (typeof m.defaultDir === "string" && !from) kernelDefaultDir = m.defaultDir;   // the LOCAL default dir
     // …and whether that kernel can open a folder dialog at all. It arrives after the picker is already on

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1832,14 +1832,37 @@ body.picker-lifted.pane-gone::before { display: none; }
 body.picker-lifted > #picker { align-items: flex-start; padding: 56px 16px 16px; }
 /* SHORT WINDOW (the on-screen keyboard is up — the shell's --app-h sizing turns that into this
    window's own height — or a genuinely small screen; render.ts toggles kb-tight on resize): the
-   ADVANCED create rows fold so the essentials — name box, session list, actions — share the height
-   with the keyboard, and expand back on the resize that restores the room (the user 2026-08-10,
-   Chrome on a phone). !important: these rows' visibility is otherwise driven by inline styles
-   (pick-mode, auth availability), and the fold must win while it holds. */
+   ADVANCED create rows fold so the essentials share the height with the keyboard, and expand back on
+   the resize that restores the room (the user 2026-08-10, Chrome on a phone). !important: these rows'
+   visibility is otherwise driven by inline styles (pick-mode, auth availability), and the fold must
+   win while it holds.
+   Folded, the ESSENTIALS rearrange for the keyboard (the user 2026-08-12): with the resume list moved
+   to the dialog's bottom, the tall layout's order left the short window showing the name box, the
+   Create button, a heading — and one row of the list, the thing you type to filter. So while folded:
+   the box takes the WHOLE short viewport (a fixed height, so nothing below shifts as typing
+   re-filters the list), the list flexes to fill the middle directly under the name box, and the
+   actions row orders to the bottom edge — pinned still, right above the keyboard where a thumb
+   expects the button. The tall layout keeps its controls-first order; this reorder exists only while
+   the keyboard (or a genuinely small screen) makes the viewport the scarce thing. */
+/* BOTH contexts — lifted and standalone — tighten to the same 12px frame: the box below takes a
+   FIXED height of the viewport minus exactly that frame, so a context still wearing the tall 56px
+   anchor would push the bottom-pinned actions row off-screen. (The lifted selector must keep its
+   own line: the base lifted rule carries #picker, which outweighs a class-only override.) */
+#picker.kb-tight,
 body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 16px; }
 .picker-overlay.kb-tight .picker-dir,
 .picker-overlay.kb-tight .picker-backend { display: none !important; }
-.picker-overlay.kb-tight .picker-box { max-height: calc(100vh - 24px); }
+/* dvh, not vh: lifted, the shell sizes this iframe to the visible height so the two agree, but
+   STANDALONE on a phone 100vh is the largest viewport (URL bar collapsed) while the fold keys on
+   the current innerHeight — a vh-sized box ran past the visible bottom by exactly the browser
+   chrome, clipping the bottom-pinned actions row this rule exists to keep on screen. dvh tracks
+   the real visible height in both contexts (the shell's own --app-h fallback unit). */
+.picker-overlay.kb-tight .picker-box { height: calc(100dvh - 24px); max-height: calc(100dvh - 24px); }
+.picker-overlay.kb-tight .picker-list { flex: 1 1 auto; min-height: 0; }
+.picker-overlay.kb-tight .picker-actions { order: 1; }
+/* the heading sits directly under the name box while folded (the create rows between them are
+   hidden), so its seam would double the search box's own border-bottom */
+.picker-overlay.kb-tight .picker-alt-head { border-top: none; }
 
 .picker-box {
   /* two thirds of the window, not a narrow column: it is a dialog over the whole dashboard now, and the


### PR DESCRIPTION
Two picker changes (requested 2026-08-12):

**The Host row's this-machine option wears its real name.** It said "local" next to remote options wearing real hostnames. The kernel now sends its peer identity (`_self_host` — short hostname, `ROMP_HOST_NAME` override) as `selfHost` on the sessionList payload; the picker labels the button with it and relabels in place when the reply lands (the row is built on open, before it). The adoption sits before the stale-list drop guard — the name is identity, not list data, so switching to a remote host mid-flight doesn't throw it away with the rightly-dropped list.

**The keyboard-up fold reflows for the bottom-anchored resume list.** After the reorder that moved the resume list to the dialog's bottom, a short keyboard-up viewport showed the name box, the Create button, a heading — and barely one row of the list, the thing typing filters. Folded (kb-tight), the box now takes the whole short viewport at a fixed height so nothing shifts as typing re-filters, the list flexes to fill the middle directly under the name box, and the actions row orders to the bottom edge, pinned above the keyboard where a thumb expects it. The 12px tight frame covers the standalone (un-lifted) context too, and the height uses `dvh`, not `vh` — standalone on a phone, `vh` is the largest viewport while the fold keys on `innerHeight`, and the mismatch would clip exactly the pinned actions row.

Tests: `picker-host.test.ts` pins the label, the payload field, and the adopt-before-drop order; `picker-keyboard.test.ts` pins the fold's new geometry; `test_kernel.py` covers the payload with `ROMP_HOST_NAME=TESTHOST`. Node suite (1858) and the kernel Python files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)