### PR TITLE
Tests isolate the real state dir under bare unittest runs

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,11 @@
+"""unittest-side twin of conftest.py's state floor (2026-08-12): `python -m unittest tests.test_x`
+imports this package first, so the floor lands before any test module loads bin/romp-* — which
+resolve their state root at import time. conftest.py covers only pytest; without this, a bare
+unittest run operated on the REAL ~/.local/state/romp (tests/test_kernel.py overwrote the real
+remotes.json that way today). Does NOT cover `cd tests && python -m unittest test_x` or a direct
+script run — the per-module preambles do, and tests/test_state_isolation_order.py enforces them."""
+import os
+import tempfile
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import tempfile
 import pytest
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sessions; it outranks the XDG floor
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_api_retry_backoff.py
+++ b/tests/test_api_retry_backoff.py
@@ -22,9 +22,12 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_retryb", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_askdriver.py
+++ b/tests/test_askdriver.py
@@ -8,10 +8,15 @@ advances as arrows are 'sent', the way the real TUI does). The parser is covered
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_askparse.py
+++ b/tests/test_askparse.py
@@ -9,9 +9,14 @@ invented prompt text, no real session data.
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 ap = SourceFileLoader("romp_askparse", os.path.join(BIN, "romp-askparse")).load_module()
 
 parse = ap.parse_ask_pane

--- a/tests/test_atomic_write.py
+++ b/tests/test_atomic_write.py
@@ -17,6 +17,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_aw", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_auto_update_remotes.py
+++ b/tests/test_auto_update_remotes.py
@@ -9,11 +9,16 @@ import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_autoupd", os.path.join(BIN, "romp-kernel")).load_module()
 
 LOCAL = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/tests/test_awaiting_card.py
+++ b/tests/test_awaiting_card.py
@@ -7,10 +7,15 @@ inputs only: placeholder UUID, no real session data.
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_awaitcard", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_awaiting_same_trigger_wedge.py
+++ b/tests/test_awaiting_same_trigger_wedge.py
@@ -27,11 +27,16 @@ import os
 import random
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_sametrig", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel_sametrig", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_brief_supersede.py
+++ b/tests/test_brief_supersede.py
@@ -12,11 +12,16 @@ then fall through to the staller's fresh where-this-stands note instead.
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_bsup", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_browser_owned_order.py
+++ b/tests/test_browser_owned_order.py
@@ -17,9 +17,12 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_bwo", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_chat_delta_resync.py
+++ b/tests/test_chat_delta_resync.py
@@ -20,8 +20,13 @@ import inspect
 import os
 import re
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_chat_payload_clock_invariant.py
+++ b/tests/test_chat_payload_clock_invariant.py
@@ -28,6 +28,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_clockinv", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel_clockinv", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_checkin_trust_persists.py
+++ b/tests/test_checkin_trust_persists.py
@@ -21,6 +21,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 km = SourceFileLoader("romp_kernel_citrust", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_clear_chat_view.py
+++ b/tests/test_clear_chat_view.py
@@ -26,6 +26,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_clearchat", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 sb = SourceFileLoader("romp_sdk_backend_clearchat",

--- a/tests/test_clear_propagation.py
+++ b/tests/test_clear_propagation.py
@@ -14,6 +14,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_cp", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 

--- a/tests/test_clear_turn_no_card.py
+++ b/tests/test_clear_turn_no_card.py
@@ -19,6 +19,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_clearturn", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_clear_wrap.py
+++ b/tests/test_clear_wrap.py
@@ -32,6 +32,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_clearwrap", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 

--- a/tests/test_closer_optional_offer.py
+++ b/tests/test_closer_optional_offer.py
@@ -18,10 +18,15 @@ Two halves, both pinned here:
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_offer", os.path.join(BIN, "romp-judge")).load_module()
 
 

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -2,8 +2,13 @@
 render.ts COLORMAPS (ledger). They MUST stay identical, else the feed and ledger disagree. cividis was
 mis-sampled (over-saturated middle, ~33/255 off matplotlib) until 2026-06-17. These guard both."""
 import os, re, importlib.util, unittest
+import tempfile
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 spec = importlib.util.spec_from_file_location("romp_colormap", os.path.join(ROOT, "bin", "romp_colormap.py"))
 cm = importlib.util.module_from_spec(spec); spec.loader.exec_module(cm)
 

--- a/tests/test_colormap_aurora.py
+++ b/tests/test_colormap_aurora.py
@@ -5,11 +5,16 @@ import math
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 cm = SourceFileLoader("romp_colormap", os.path.join(BIN, "romp_colormap.py")).load_module()
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_courier_kind_demote_only.py
+++ b/tests/test_courier_kind_demote_only.py
@@ -22,6 +22,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_kinddemote", os.path.join(BIN, "romp-judge")).load_module()
 
 RECIP = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_courier_origin_host.py
+++ b/tests/test_courier_origin_host.py
@@ -20,6 +20,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_courierorigin", os.path.join(BIN, "romp-judge")).load_module()
 
 RECIP = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_create_dir_case.py
+++ b/tests/test_create_dir_case.py
@@ -18,6 +18,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_cdc", os.path.join(ROOT, "bin", "romp-kernel")).load_module()
 
 

--- a/tests/test_distill_paragraph_contract.py
+++ b/tests/test_distill_paragraph_contract.py
@@ -26,8 +26,14 @@ changes only what the audit named.
 import pathlib
 import unittest
 from importlib.machinery import SourceFileLoader
+import os
+import tempfile
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_paras", str(ROOT / "kernel" / "judge.py")).load_module()
 
 PROMPTS = {

--- a/tests/test_drive_foreign_sid.py
+++ b/tests/test_drive_foreign_sid.py
@@ -12,10 +12,15 @@ import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_foreign", os.path.join(BIN, "romp-kernel")).load_module()
 
 OURS = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_echo_backfill.py
+++ b/tests/test_echo_backfill.py
@@ -8,9 +8,14 @@ only the all-old sub clears; pre-existing nodes are never touched. Synthetic sto
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_echobackfill", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_episode_boundary.py
+++ b/tests/test_episode_boundary.py
@@ -21,6 +21,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 

--- a/tests/test_error_center.py
+++ b/tests/test_error_center.py
@@ -22,9 +22,12 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_errc", os.path.join(BIN, "romp-kernel")).load_module()
 
 HARNESS = r"""

--- a/tests/test_event_model_absorbed_injection.py
+++ b/tests/test_event_model_absorbed_injection.py
@@ -20,6 +20,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_em_absorbed", os.path.join(BIN, "romp-event-model")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_event_model_absorbed_ledger_shift.py
+++ b/tests/test_event_model_absorbed_ledger_shift.py
@@ -19,6 +19,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_em_ledger_shift", os.path.join(BIN, "romp-event-model")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_event_model_ansi_stdout.py
+++ b/tests/test_event_model_ansi_stdout.py
@@ -14,6 +14,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model_ansi", os.path.join(BIN, "romp-event-model")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_event_model_author.py
+++ b/tests/test_event_model_author.py
@@ -6,9 +6,14 @@ set, an UNMARKED 'sdk' prompt is the human; romp-injected / postal markers still
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 SCRIPTS = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model", os.path.join(SCRIPTS, "romp-event-model")).load_module()
 
 TEXT = [{"type": "text", "text": "do the thing"}]

--- a/tests/test_event_model_compact_turn.py
+++ b/tests/test_event_model_compact_turn.py
@@ -16,6 +16,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model_compact", os.path.join(BIN, "romp-event-model")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_event_model_golden.py
+++ b/tests/test_event_model_golden.py
@@ -26,6 +26,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 SCRIPTS = os.path.join(os.path.dirname(HERE), "bin")
 GOLDEN = Path(HERE) / "fixtures" / "event-model-golden"
 
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model", os.path.join(SCRIPTS, "romp-event-model")).load_module()
 
 NOW = 1781100000                      # fixed test clock — goldens depend on it

--- a/tests/test_event_model_image_echo.py
+++ b/tests/test_event_model_image_echo.py
@@ -25,6 +25,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model_image_echo", os.path.join(BIN, "romp-event-model")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_event_model_incremental.py
+++ b/tests/test_event_model_incremental.py
@@ -18,6 +18,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model_inc", os.path.join(BIN, "romp-event-model")).load_module()
 
 

--- a/tests/test_event_model_postal_ismeta.py
+++ b/tests/test_event_model_postal_ismeta.py
@@ -23,6 +23,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model_ismeta", os.path.join(BIN, "romp-event-model")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_fleet_archived_tops.py
+++ b/tests/test_fleet_archived_tops.py
@@ -13,6 +13,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_fleetarch", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_fleet_restart.py
+++ b/tests/test_fleet_restart.py
@@ -22,6 +22,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 km = SourceFileLoader("romp_kernel_fleet", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_fleet_sync_log.py
+++ b/tests/test_fleet_sync_log.py
@@ -22,9 +22,12 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_syncnote", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_fresh_install_federation.py
+++ b/tests/test_fresh_install_federation.py
@@ -20,6 +20,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()

--- a/tests/test_goal_status_ux.py
+++ b/tests/test_goal_status_ux.py
@@ -24,6 +24,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 _STATE_TMP = tempfile.mkdtemp()
 os.environ["XDG_STATE_HOME"] = _STATE_TMP
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 kern = SourceFileLoader("romp_kernel_statusux", os.path.join(BIN, "romp-kernel")).load_module()
 jd = kern.jd

--- a/tests/test_heartbeat_thread.py
+++ b/tests/test_heartbeat_thread.py
@@ -12,10 +12,15 @@ import threading
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_hb", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -36,6 +36,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_interrupt_lift_evidence_time.py
+++ b/tests/test_interrupt_lift_evidence_time.py
@@ -28,6 +28,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 _STATE_TMP = tempfile.mkdtemp()
 os.environ["XDG_STATE_HOME"] = _STATE_TMP
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 sb = SourceFileLoader("romp_sdk_backend_ile", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 km = SourceFileLoader("romp_kernel_ile", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_interrupt_settle_machine_cut.py
+++ b/tests/test_interrupt_settle_machine_cut.py
@@ -20,6 +20,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 km = SourceFileLoader("romp_kernel_seam", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -17,6 +17,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 

--- a/tests/test_judge_apierror_no_caption.py
+++ b/tests/test_judge_apierror_no_caption.py
@@ -10,9 +10,14 @@ turn is work-less (no caption); a turn that did real work THEN errored still cap
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_anc", os.path.join(BIN, "romp-judge")).load_module()
 
 

--- a/tests/test_judge_apierror_no_fabricated_done.py
+++ b/tests/test_judge_apierror_no_fabricated_done.py
@@ -19,6 +19,10 @@ import os
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_apierr_done", os.path.join(BIN, "romp-judge")).load_module()
 
 NOW = 1781100000

--- a/tests/test_judge_archiver_giveup.py
+++ b/tests/test_judge_archiver_giveup.py
@@ -18,6 +18,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_archgiveup", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_auth_billing.py
+++ b/tests/test_judge_auth_billing.py
@@ -39,6 +39,10 @@ BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_authbill", os.path.join(BIN, "romp-judge")).load_module()
 
 FAKE_KEY = "romp-test-fixture-key-not-real"   # nothing under test validates the shape, so no sk- prefix:

--- a/tests/test_judge_authoritative_plan_sync.py
+++ b/tests/test_judge_authoritative_plan_sync.py
@@ -23,6 +23,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 

--- a/tests/test_judge_board_dedup.py
+++ b/tests/test_judge_board_dedup.py
@@ -21,6 +21,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model_dedup", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge_dedup", os.path.join(BIN, "romp-judge")).load_module()
 

--- a/tests/test_judge_captions.py
+++ b/tests/test_judge_captions.py
@@ -15,6 +15,10 @@ from unittest import mock
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 

--- a/tests/test_judge_card_first.py
+++ b/tests/test_judge_card_first.py
@@ -13,6 +13,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_cardfirst", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_courier_defer_abandon.py
+++ b/tests/test_judge_courier_defer_abandon.py
@@ -26,6 +26,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_courierdefer", os.path.join(BIN, "romp-judge")).load_module()
 
 RECIP = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_discover_cache.py
+++ b/tests/test_judge_discover_cache.py
@@ -18,6 +18,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_fingerprint_memo.py
+++ b/tests/test_judge_fingerprint_memo.py
@@ -24,6 +24,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_followup_gist_title.py
+++ b/tests/test_judge_followup_gist_title.py
@@ -16,6 +16,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_fugist", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_fresh_block.py
+++ b/tests/test_judge_fresh_block.py
@@ -15,8 +15,13 @@ Synthetic stores only."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_freshblock", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_group_split.py
+++ b/tests/test_judge_group_split.py
@@ -14,8 +14,13 @@ Synthetic store only; group_llm is stubbed (never a live model call)."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_groupsplit", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_guarded_node.py
+++ b/tests/test_judge_guarded_node.py
@@ -16,6 +16,10 @@ import os
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_guarded", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_hidefeed.py
+++ b/tests/test_judge_hidefeed.py
@@ -16,6 +16,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 

--- a/tests/test_judge_may_apply.py
+++ b/tests/test_judge_may_apply.py
@@ -13,6 +13,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_mayapply", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_moot_unblock_rolledup.py
+++ b/tests/test_judge_moot_unblock_rolledup.py
@@ -14,8 +14,13 @@ store only."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_mootheal", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_no_fairness_caps.py
+++ b/tests/test_judge_no_fairness_caps.py
@@ -15,6 +15,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_nofair", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_nudge_awaiting_op.py
+++ b/tests/test_judge_nudge_awaiting_op.py
@@ -20,6 +20,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_nudge_no_reopen_completed.py
+++ b/tests/test_judge_nudge_no_reopen_completed.py
@@ -16,6 +16,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_nudgereopen", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_nudge_wedge_moot_retire.py
+++ b/tests/test_judge_nudge_wedge_moot_retire.py
@@ -20,6 +20,10 @@ import os
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_nudge_wedge", os.path.join(BIN, "romp-judge")).load_module()
 
 NOW = 1781100000

--- a/tests/test_judge_orphan_replies.py
+++ b/tests/test_judge_orphan_replies.py
@@ -19,6 +19,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_em_orphan", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge_orphan", os.path.join(BIN, "romp-judge")).load_module()
 

--- a/tests/test_judge_parse_cache.py
+++ b/tests/test_judge_parse_cache.py
@@ -8,6 +8,10 @@ import time
 from importlib.machinery import SourceFileLoader
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 

--- a/tests/test_judge_pass_frame.py
+++ b/tests/test_judge_pass_frame.py
@@ -17,6 +17,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_passframe", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_placed_key_twins.py
+++ b/tests/test_judge_placed_key_twins.py
@@ -8,9 +8,14 @@ live segment never dedups its twins. Synthetic ids only."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_twins", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_procedural_block_brief.py
+++ b/tests/test_judge_procedural_block_brief.py
@@ -19,9 +19,14 @@ why as <holding>) — see ProceduralBlockStillSpeaks in test_judge.py. SYNTHETIC
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_procbrief", os.path.join(BIN, "romp-judge")).load_module()
 
 REAL_Q = "Python on the server is still 3.8; upgrade it the same no-sudo way, or leave it as secondary?"

--- a/tests/test_judge_proj_dir_underscore.py
+++ b/tests/test_judge_proj_dir_underscore.py
@@ -22,6 +22,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_rate_limit_gate.py
+++ b/tests/test_judge_rate_limit_gate.py
@@ -16,6 +16,10 @@ import os
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_rategate", os.path.join(BIN, "romp-judge")).load_module()
 
 

--- a/tests/test_judge_reopen_floor.py
+++ b/tests/test_judge_reopen_floor.py
@@ -16,6 +16,10 @@ import os
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_usermove", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_retry_burst.py
+++ b/tests/test_judge_retry_burst.py
@@ -18,6 +18,10 @@ import os
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_retry_burst", os.path.join(BIN, "romp-judge")).load_module()
 
 NOW = 1781100000

--- a/tests/test_judge_revert.py
+++ b/tests/test_judge_revert.py
@@ -12,6 +12,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_scratch_prune.py
+++ b/tests/test_judge_scratch_prune.py
@@ -15,6 +15,10 @@ from unittest import mock
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_scratch", os.path.join(BIN, "romp-judge")).load_module()
 
 

--- a/tests/test_judge_sdk_human_prompt_run.py
+++ b/tests/test_judge_sdk_human_prompt_run.py
@@ -21,6 +21,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_sdkhuman", os.path.join(BIN, "romp-judge")).load_module()
 
 SDK_SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_sealed_open_fold.py
+++ b/tests/test_judge_sealed_open_fold.py
@@ -13,8 +13,13 @@ only."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_sealedfold", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_spliced_done.py
+++ b/tests/test_judge_spliced_done.py
@@ -23,6 +23,10 @@ import os
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_spliced_done", os.path.join(BIN, "romp-judge")).load_module()
 
 NOW = 1781100000

--- a/tests/test_judge_store_cas.py
+++ b/tests/test_judge_store_cas.py
@@ -18,6 +18,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_store_noop_publish.py
+++ b/tests/test_judge_store_noop_publish.py
@@ -20,6 +20,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_umbrella_completion.py
+++ b/tests/test_judge_umbrella_completion.py
@@ -23,6 +23,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model_umb", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge_umb", os.path.join(BIN, "romp-judge")).load_module()
 

--- a/tests/test_judge_unblocker.py
+++ b/tests/test_judge_unblocker.py
@@ -19,6 +19,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_verdict_log.py
+++ b/tests/test_judge_verdict_log.py
@@ -16,6 +16,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_vlog", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_warn_retire.py
+++ b/tests/test_judge_warn_retire.py
@@ -18,6 +18,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_judge_workless_followup_wedge.py
+++ b/tests/test_judge_workless_followup_wedge.py
@@ -29,6 +29,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_workless_fu", os.path.join(BIN, "romp-judge")).load_module()
 
 NOW = 1781200000

--- a/tests/test_judging_timeline.py
+++ b/tests/test_judging_timeline.py
@@ -10,9 +10,14 @@ mark. Synthetic data only (placeholder UUID, invented captions/goals)."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(__file__), "..", "bin")
 # romp-judge must load first: romp-kernel imports it as `jd` at module load.
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -17,6 +17,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_agent_open_authority.py
+++ b/tests/test_kernel_agent_open_authority.py
@@ -10,11 +10,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_apierror_working.py
+++ b/tests/test_kernel_apierror_working.py
@@ -8,11 +8,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_apiretry.py
+++ b/tests/test_kernel_apiretry.py
@@ -11,10 +11,15 @@ import os
 import types
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 SRC = open(os.path.join(BIN, "romp-kernel")).read()
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel_apiretry", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_kernel_askanswer.py
+++ b/tests/test_kernel_askanswer.py
@@ -4,8 +4,13 @@ box. The tool_result records answers as `"<q>"="<a>"` pairs; we fill each block'
 handling single/multi question, multiSelect (joined 'A, B, C'), and free-text 'Other'. Synthetic only."""
 import os
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_attach_on_behalf.py
+++ b/tests/test_kernel_attach_on_behalf.py
@@ -16,6 +16,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()

--- a/tests/test_kernel_auth_hardening.py
+++ b/tests/test_kernel_auth_hardening.py
@@ -18,10 +18,15 @@ Mirrors tests/test_kernel_ws_auth.py's module load order.
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -27,6 +27,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_awlift", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-999999999999"

--- a/tests/test_kernel_awaiting_merge.py
+++ b/tests/test_kernel_awaiting_merge.py
@@ -24,6 +24,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_awm", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel_awm", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -24,6 +24,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_awstamp", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-999999999999"

--- a/tests/test_kernel_bg_tasks.py
+++ b/tests/test_kernel_bg_tasks.py
@@ -14,6 +14,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 TUSE = "11111111-aaaa-bbbb-cccc-222222222222"

--- a/tests/test_kernel_bg_tasks_stale.py
+++ b/tests/test_kernel_bg_tasks_stale.py
@@ -13,6 +13,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_blocked_no_goal.py
+++ b/tests/test_kernel_blocked_no_goal.py
@@ -8,11 +8,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_boot_splash.py
+++ b/tests/test_kernel_boot_splash.py
@@ -10,11 +10,16 @@ import os
 import pathlib
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_boot_stub.py
+++ b/tests/test_kernel_boot_stub.py
@@ -10,11 +10,16 @@ import os
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_bootstub", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"

--- a/tests/test_kernel_bundled_echo_prune.py
+++ b/tests/test_kernel_bundled_echo_prune.py
@@ -16,10 +16,15 @@ bundled block retires the echo it came from and nothing else. SYNTHETIC fixtures
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_bundled_echo", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_cachebust.py
+++ b/tests/test_kernel_cachebust.py
@@ -6,8 +6,13 @@ serves HTML no-cache, so a reload always pulls fresh JS. We pin the page-builder
 """
 import os
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_cancel_create.py
+++ b/tests/test_kernel_cancel_create.py
@@ -23,7 +23,10 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())   # hermetic — never touch the real store
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_cancelcreate", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_card_predict.py
+++ b/tests/test_kernel_card_predict.py
@@ -11,11 +11,16 @@ fixtures only."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_cardpredict", os.path.join(BIN, "romp-kernel")).load_module()
 
 # The ACCOUNT gate (_limit_hold: a usage limit / monthly spend cap parks every drive op, tested in

--- a/tests/test_kernel_cardtime.py
+++ b/tests/test_kernel_cardtime.py
@@ -16,6 +16,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_ct", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd        # the SAME judge module the kernel uses → our fixture overrides reach discover()/build_feed
 

--- a/tests/test_kernel_citation.py
+++ b/tests/test_kernel_citation.py
@@ -6,10 +6,15 @@ Synthetic fixtures only (placeholder UUIDs / TESTHOST)."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_cite", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_clear_perf.py
+++ b/tests/test_kernel_clear_perf.py
@@ -11,11 +11,16 @@ import os
 import re
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_color_pick.py
+++ b/tests/test_kernel_color_pick.py
@@ -15,6 +15,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_cp", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 

--- a/tests/test_kernel_compacting_event.py
+++ b/tests/test_kernel_compacting_event.py
@@ -7,11 +7,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_context_colormap.py
+++ b/tests/test_kernel_context_colormap.py
@@ -8,11 +8,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_cors.py
+++ b/tests/test_kernel_cors.py
@@ -23,12 +23,17 @@ import threading
 import unittest
 from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 # Mirror tests/test_kernel_ws_auth.py's load order. The token env keeps _load_token()
 # away from the real state dir; NO_OPEN keeps the import from launching a browser.
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_create_session_ack.py
+++ b/tests/test_kernel_create_session_ack.py
@@ -14,6 +14,7 @@ import unittest
 from importlib.machinery import SourceFileLoader
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # isolate: importing the kernel must not touch live state
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 HERE = os.path.dirname(os.path.realpath(__file__))

--- a/tests/test_kernel_debt_nudge.py
+++ b/tests/test_kernel_debt_nudge.py
@@ -10,10 +10,15 @@ import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_debt", os.path.join(BIN, "romp-kernel")).load_module()
 
 DEBTOR = "11111111-2222-3333-4444-555555555555"     # the idle session that owes replies

--- a/tests/test_kernel_deliver.py
+++ b/tests/test_kernel_deliver.py
@@ -13,6 +13,10 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_deliver", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_delta_send.py
+++ b/tests/test_kernel_delta_send.py
@@ -11,11 +11,16 @@ import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -11,11 +11,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_dismiss_dialog.py
+++ b/tests/test_kernel_dismiss_dialog.py
@@ -14,6 +14,7 @@ import unittest
 from importlib.machinery import SourceFileLoader
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 HERE = os.path.dirname(os.path.realpath(__file__))

--- a/tests/test_kernel_dismiss_lane.py
+++ b/tests/test_kernel_dismiss_lane.py
@@ -7,11 +7,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_distill_state.py
+++ b/tests/test_kernel_distill_state.py
@@ -10,11 +10,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_done_confirming.py
+++ b/tests/test_kernel_done_confirming.py
@@ -10,11 +10,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_dot_open.py
+++ b/tests/test_kernel_dot_open.py
@@ -19,6 +19,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 SourceFileLoader("romp_event_model_dotopen", os.path.join(BIN, "romp-event-model")).load_module()

--- a/tests/test_kernel_effort_note.py
+++ b/tests/test_kernel_effort_note.py
@@ -13,11 +13,16 @@ import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_effort", os.path.join(BIN, "romp-kernel")).load_module()
 sb = SourceFileLoader("romp_sdk_backend_effort", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 BACKEND_SRC = open(os.path.join(BIN, "romp_sdk_backend.py")).read()

--- a/tests/test_kernel_effort_reconnect.py
+++ b/tests/test_kernel_effort_reconnect.py
@@ -7,11 +7,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_efr", os.path.join(BIN, "romp-kernel")).load_module()
 BACKEND_SRC = open(os.path.join(BIN, "romp_sdk_backend.py")).read()
 

--- a/tests/test_kernel_feed_warm.py
+++ b/tests/test_kernel_feed_warm.py
@@ -10,11 +10,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_fleet_cache.py
+++ b/tests/test_kernel_fleet_cache.py
@@ -7,11 +7,16 @@ import os
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_followup_render.py
+++ b/tests/test_kernel_followup_render.py
@@ -6,11 +6,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 FOLLOWUP = ("> Add a widget-count field to the report header (done)\n"

--- a/tests/test_kernel_goal_compaction.py
+++ b/tests/test_kernel_goal_compaction.py
@@ -19,6 +19,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 

--- a/tests/test_kernel_headless_ops.py
+++ b/tests/test_kernel_headless_ops.py
@@ -27,6 +27,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 _STATE_TMP = tempfile.mkdtemp()
 os.environ["XDG_STATE_HOME"] = _STATE_TMP
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 km = SourceFileLoader("romp_kernel_headless", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_kernel_hook_notice_strip.py
+++ b/tests/test_kernel_hook_notice_strip.py
@@ -9,10 +9,15 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_hn", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_inject.py
+++ b/tests/test_kernel_inject.py
@@ -8,6 +8,7 @@ import os
 import unittest
 from unittest import mock
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -16,6 +17,10 @@ os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 # host explicitly so they assert the same thing on a machine without tmux installed, where the
 # backend is otherwise inert by design (see TmuxBackend.available).
 os.environ["ROMP_TMUX_AVAILABLE"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_inj", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_installable_app.py
+++ b/tests/test_kernel_installable_app.py
@@ -21,10 +21,15 @@ import os
 import struct
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_interrupt.py
+++ b/tests/test_kernel_interrupt.py
@@ -13,6 +13,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_interrupt_blocks.py
+++ b/tests/test_kernel_interrupt_blocks.py
@@ -14,6 +14,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 _STATE_TMP = tempfile.mkdtemp()
 os.environ["XDG_STATE_HOME"] = _STATE_TMP
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 kern = SourceFileLoader("romp_kernel_intrblk", os.path.join(BIN, "romp-kernel")).load_module()
 jd = kern.jd

--- a/tests/test_kernel_interrupt_machine_cut.py
+++ b/tests/test_kernel_interrupt_machine_cut.py
@@ -20,6 +20,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model_mc", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge_mc", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_interrupt_seam.py
+++ b/tests/test_kernel_interrupt_seam.py
@@ -9,8 +9,13 @@ next user-role event) says so. Synthetic fixtures only."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_judge_model.py
+++ b/tests/test_kernel_judge_model.py
@@ -17,6 +17,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # isolate STATE so the test never touches the real picks
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()

--- a/tests/test_kernel_known_hosts.py
+++ b/tests/test_kernel_known_hosts.py
@@ -21,6 +21,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()

--- a/tests/test_kernel_limit_queue.py
+++ b/tests/test_kernel_limit_queue.py
@@ -29,6 +29,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -6,10 +6,15 @@ brings the chat forward. Pure-HTML + routing asserts; no real session data.
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_mobile", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_model_colors.py
+++ b/tests/test_kernel_model_colors.py
@@ -7,11 +7,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_model_limit.py
+++ b/tests/test_kernel_model_limit.py
@@ -37,6 +37,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_modellimit", os.path.join(BIN, "romp-kernel")).load_module()
 
 T0 = 1781100000

--- a/tests/test_kernel_model_queue.py
+++ b/tests/test_kernel_model_queue.py
@@ -9,11 +9,16 @@ import os
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_modelq", os.path.join(BIN, "romp-kernel")).load_module()
 
 # The ACCOUNT gate (_limit_hold: a usage limit / monthly spend cap parks every drive op, tested in

--- a/tests/test_kernel_msgcaption.py
+++ b/tests/test_kernel_msgcaption.py
@@ -15,6 +15,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_mc", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 em = km.em

--- a/tests/test_kernel_nudge_compacting_skip.py
+++ b/tests/test_kernel_nudge_compacting_skip.py
@@ -14,6 +14,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_ncs", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 

--- a/tests/test_kernel_nudge_last_resort.py
+++ b/tests/test_kernel_nudge_last_resort.py
@@ -23,6 +23,10 @@ from pathlib import Path
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_nlr", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 

--- a/tests/test_kernel_nudgebar.py
+++ b/tests/test_kernel_nudgebar.py
@@ -15,6 +15,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_nb", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 em = km.em

--- a/tests/test_kernel_nudgedelegated.py
+++ b/tests/test_kernel_nudgedelegated.py
@@ -8,10 +8,15 @@ nudgeable. _all_outstanding_delegated decides it: True iff every open LEAF in th
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_nd", os.path.join(BIN, "romp-kernel")).load_module()
 
 TOP = "s:g1"

--- a/tests/test_kernel_open_relative_path.py
+++ b/tests/test_kernel_open_relative_path.py
@@ -4,11 +4,16 @@ against _cwd_of(sid). Absolute paths (incl. file:// caption links) pass through;
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_orp", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_open_terminal.py
+++ b/tests/test_kernel_open_terminal.py
@@ -19,6 +19,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 GOOD = "/tmp/TESTHOST/somedir"

--- a/tests/test_kernel_opening.py
+++ b/tests/test_kernel_opening.py
@@ -23,6 +23,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_opening_chip.py
+++ b/tests/test_kernel_opening_chip.py
@@ -23,6 +23,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_openchip", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel_openchip", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_kernel_ops_gate_busy.py
+++ b/tests/test_kernel_ops_gate_busy.py
@@ -16,6 +16,7 @@ import unittest
 from importlib.machinery import SourceFileLoader
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # isolate: importing the kernel must not touch live state
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 HERE = os.path.dirname(os.path.realpath(__file__))

--- a/tests/test_kernel_order.py
+++ b/tests/test_kernel_order.py
@@ -16,6 +16,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_order", os.path.join(BIN, "romp-kernel")).load_module()
 
 A = "aaaaaaaa-0000-0000-0000-000000000001"

--- a/tests/test_kernel_order_audit.py
+++ b/tests/test_kernel_order_audit.py
@@ -16,6 +16,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_orderaudit", os.path.join(BIN, "romp-kernel")).load_module()
 
 A = "aaaaaaaa-0000-0000-0000-000000000001"

--- a/tests/test_kernel_orphan_reply.py
+++ b/tests/test_kernel_orphan_reply.py
@@ -7,11 +7,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_orphan", os.path.join(BIN, "romp-kernel")).load_module()
 sb = SourceFileLoader("romp_sdk_backend_orphan_k", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 

--- a/tests/test_kernel_owned_yield_awaiting.py
+++ b/tests/test_kernel_owned_yield_awaiting.py
@@ -31,6 +31,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_ownyield", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-888888888888"

--- a/tests/test_kernel_pane_loader_ignore.py
+++ b/tests/test_kernel_pane_loader_ignore.py
@@ -6,11 +6,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -10,11 +10,16 @@ Source-level pin against km._landing().
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_panenav.py
+++ b/tests/test_kernel_panenav.py
@@ -7,10 +7,15 @@ Source-pin the wiring (no headless DOM for the shell)."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_pn", os.path.join(BIN, "romp-kernel")).load_module()
 
 JS = km._LANDING_FOCUS_JS

--- a/tests/test_kernel_parkedhandoff.py
+++ b/tests/test_kernel_parkedhandoff.py
@@ -16,6 +16,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_ph", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 

--- a/tests/test_kernel_patch_rows.py
+++ b/tests/test_kernel_patch_rows.py
@@ -3,11 +3,16 @@
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_picker_text_salvage.py
+++ b/tests/test_kernel_picker_text_salvage.py
@@ -11,11 +11,16 @@ SYNTHETIC only."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_pts", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_pkill_self_match.py
+++ b/tests/test_kernel_pkill_self_match.py
@@ -26,6 +26,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()

--- a/tests/test_kernel_postal_isolation_routes.py
+++ b/tests/test_kernel_postal_isolation_routes.py
@@ -14,6 +14,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_postal_longbody.py
+++ b/tests/test_kernel_postal_longbody.py
@@ -10,11 +10,16 @@ import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_postal_out_gist.py
+++ b/tests/test_kernel_postal_out_gist.py
@@ -10,11 +10,16 @@ import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_outgist", os.path.join(BIN, "romp-kernel")).load_module()
 
 BODY = "Please pick up the notes-api deploy: tests are green, only the changelog is left."

--- a/tests/test_kernel_preview.py
+++ b/tests/test_kernel_preview.py
@@ -20,6 +20,10 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_provisional_command.py
+++ b/tests/test_kernel_provisional_command.py
@@ -26,6 +26,10 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_provcmd", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_push_responsiveness.py
+++ b/tests/test_kernel_push_responsiveness.py
@@ -19,11 +19,16 @@ import os
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_pushresp", os.path.join(BIN, "romp-kernel")).load_module()
 
 # The ACCOUNT gate (_limit_hold: a usage limit / monthly spend cap parks every drive op, tested in

--- a/tests/test_kernel_pusher_snapshot.py
+++ b/tests/test_kernel_pusher_snapshot.py
@@ -18,6 +18,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_rail_fit.py
+++ b/tests/test_kernel_rail_fit.py
@@ -6,11 +6,16 @@ to the RIGHT (margin-left:auto) so the actions never get pushed off. The old ver
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_rail_usage.py
+++ b/tests/test_kernel_rail_usage.py
@@ -8,11 +8,16 @@ import os
 import pathlib
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_recent_tops.py
+++ b/tests/test_kernel_recent_tops.py
@@ -14,6 +14,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_refresh_button.py
+++ b/tests/test_kernel_refresh_button.py
@@ -7,11 +7,16 @@ only governs the timeline's judging band. Source-level pin against the kernel's 
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_remote_file_relay.py
+++ b/tests/test_kernel_remote_file_relay.py
@@ -21,12 +21,17 @@ import urllib.request
 import urllib.error
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 # Mirror tests/test_kernel_ws_auth.py's load order. The token env keeps _load_token() away from
 # the real state dir; NO_OPEN keeps the import from launching a browser.
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_remote_identity.py
+++ b/tests/test_kernel_remote_identity.py
@@ -16,6 +16,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()

--- a/tests/test_kernel_remote_pull.py
+++ b/tests/test_kernel_remote_pull.py
@@ -10,11 +10,16 @@ SYNTHETIC fixtures only — invented hosts and placeholder shas; subprocess/ssh 
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_pull", os.path.join(BIN, "romp-kernel")).load_module()
 
 LOCAL = "a" * 40                     # local HEAD (full sha)

--- a/tests/test_kernel_remote_start.py
+++ b/tests/test_kernel_remote_start.py
@@ -7,11 +7,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_start", os.path.join(BIN, "romp-kernel")).load_module()
 
 HOST = "TESTHOST"

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -15,6 +15,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_remote_ws_proxy.py
+++ b/tests/test_kernel_remote_ws_proxy.py
@@ -21,12 +21,17 @@ import threading
 import unittest
 from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 # Mirror tests/test_kernel_ws_auth.py's load order. The token env keeps _load_token() away from
 # the real state dir; NO_OPEN keeps the import from launching a browser.
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_remotes_perms.py
+++ b/tests/test_kernel_remotes_perms.py
@@ -19,6 +19,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()

--- a/tests/test_kernel_resolve_node.py
+++ b/tests/test_kernel_resolve_node.py
@@ -14,6 +14,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 _STATE_TMP = tempfile.mkdtemp()
 os.environ["XDG_STATE_HOME"] = _STATE_TMP
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 kern = SourceFileLoader("romp_kernel_resolvenode", os.path.join(BIN, "romp-kernel")).load_module()
 jd = kern.jd

--- a/tests/test_kernel_restore_flicker.py
+++ b/tests/test_kernel_restore_flicker.py
@@ -28,6 +28,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 _STATE_TMP = tempfile.mkdtemp()
 os.environ["XDG_STATE_HOME"] = _STATE_TMP
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 kern = SourceFileLoader("romp_kernel_restoreflick", os.path.join(BIN, "romp-kernel")).load_module()
 jd = kern.jd

--- a/tests/test_kernel_retry_episode.py
+++ b/tests/test_kernel_retry_episode.py
@@ -17,6 +17,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_retryep", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_retrying_chip.py
+++ b/tests/test_kernel_retrying_chip.py
@@ -13,6 +13,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_retrying_event.py
+++ b/tests/test_kernel_retrying_event.py
@@ -11,11 +11,16 @@ import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_retrying", os.path.join(BIN, "romp-kernel")).load_module()
 sb = SourceFileLoader("romp_sdk_backend_retrying", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 BACKEND_SRC = open(os.path.join(BIN, "romp_sdk_backend.py")).read()

--- a/tests/test_kernel_revive.py
+++ b/tests/test_kernel_revive.py
@@ -16,6 +16,10 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_rev", os.path.join(BIN, "romp-kernel")).load_module()
 sb = SourceFileLoader("romp_sdk_backend_rev", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 

--- a/tests/test_kernel_rewind.py
+++ b/tests/test_kernel_rewind.py
@@ -19,6 +19,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_rw", os.path.join(BIN, "romp-kernel")).load_module()
 
 # The ACCOUNT gate (_limit_hold: a usage limit / monthly spend cap parks every drive op, tested in

--- a/tests/test_kernel_runspans.py
+++ b/tests/test_kernel_runspans.py
@@ -14,6 +14,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_rs", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 

--- a/tests/test_kernel_segdrift.py
+++ b/tests/test_kernel_segdrift.py
@@ -21,6 +21,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_segdrift", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_send.py
+++ b/tests/test_kernel_send.py
@@ -7,10 +7,15 @@ import os
 import unittest
 from unittest import mock
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_send", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_send_park.py
+++ b/tests/test_kernel_send_park.py
@@ -9,11 +9,16 @@ SYNTHETIC fixtures only."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_sendpark", os.path.join(BIN, "romp-kernel")).load_module()
 
 # The ACCOUNT gate (_limit_hold: a usage limit / monthly spend cap parks every drive op, tested in

--- a/tests/test_kernel_sendvis_diag.py
+++ b/tests/test_kernel_sendvis_diag.py
@@ -6,11 +6,16 @@ probing; failures inside the diagnostic report as strings, never silently. SYNTH
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_sendvis", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_session_color.py
+++ b/tests/test_kernel_session_color.py
@@ -15,6 +15,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_session_flags.py
+++ b/tests/test_kernel_session_flags.py
@@ -9,6 +9,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -8,11 +8,16 @@ global Colormap, lives under Colors now.)
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_socket_deliver.py
+++ b/tests/test_kernel_socket_deliver.py
@@ -16,6 +16,10 @@ import unittest
 from importlib.machinery import SourceFileLoader
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_ssh_noise.py
+++ b/tests/test_kernel_ssh_noise.py
@@ -21,6 +21,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()

--- a/tests/test_kernel_stalled_blocks.py
+++ b/tests/test_kernel_stalled_blocks.py
@@ -16,6 +16,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 _STATE_TMP = tempfile.mkdtemp()
 os.environ["XDG_STATE_HOME"] = _STATE_TMP
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 kern = SourceFileLoader("romp_kernel_stalledblk", os.path.join(BIN, "romp-kernel")).load_module()
 jd = kern.jd

--- a/tests/test_kernel_sysmeta.py
+++ b/tests/test_kernel_sysmeta.py
@@ -12,6 +12,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_tab_flags.py
+++ b/tests/test_kernel_tab_flags.py
@@ -6,12 +6,17 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 KPATH = os.path.join(BIN, "romp-kernel")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", KPATH).load_module()
 
 

--- a/tests/test_kernel_tabs_first.py
+++ b/tests/test_kernel_tabs_first.py
@@ -6,12 +6,17 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 KPATH = os.path.join(BIN, "romp-kernel")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", KPATH).load_module()
 
 

--- a/tests/test_kernel_timeline_awaiting.py
+++ b/tests/test_kernel_timeline_awaiting.py
@@ -18,6 +18,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_tlaw", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel_tlaw", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_kernel_timeline_split.py
+++ b/tests/test_kernel_timeline_split.py
@@ -11,11 +11,16 @@ import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_kernel_trust.py
+++ b/tests/test_kernel_trust.py
@@ -19,6 +19,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()

--- a/tests/test_kernel_tunnel_truth.py
+++ b/tests/test_kernel_tunnel_truth.py
@@ -9,8 +9,13 @@ Synthetic fixtures only."""
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_tunnels.py
+++ b/tests/test_kernel_tunnels.py
@@ -23,6 +23,7 @@ BIN = os.path.join(os.path.dirname(HERE), "bin")
 # Hermetic STATE (so remotes.json + serve-token never touch real state) BEFORE import, and a token so
 # _load_token() returns early. NO_OPEN so importing never launches a browser. Mirrors test_kernel_ws_auth.
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()

--- a/tests/test_kernel_undo_restore_completed.py
+++ b/tests/test_kernel_undo_restore_completed.py
@@ -8,11 +8,16 @@ import os
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_kernel_usage_limit.py
+++ b/tests/test_kernel_usage_limit.py
@@ -14,6 +14,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_usage_refresh.py
+++ b/tests/test_kernel_usage_refresh.py
@@ -14,6 +14,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_waitfor.py
+++ b/tests/test_kernel_waitfor.py
@@ -16,6 +16,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_wf", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -27,6 +27,7 @@ import threading
 import unittest
 from unittest import mock
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 try:
     from cryptography.hazmat.primitives import hashes
@@ -41,6 +42,10 @@ except ImportError:                                   # pragma: no cover — CI 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 # Belt over conftest's suspenders. Under pytest, conftest.py rebinds XDG_STATE_HOME to a tempdir
@@ -49,7 +54,6 @@ jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module
 # LIVE store, wiping the maintainer's phone subscription and rotating the real VAPID key (which
 # orphans every subscription bound to it). Rebind the state root here, unconditionally, BEFORE the
 # kernel module loads and captures jd.STATE into its path constants.
-import tempfile
 from pathlib import Path
 _STATE_TD = tempfile.TemporaryDirectory()
 jd.STATE = Path(_STATE_TD.name)

--- a/tests/test_kernel_webpush_federation.py
+++ b/tests/test_kernel_webpush_federation.py
@@ -26,16 +26,20 @@ import threading
 import unittest
 from unittest import mock
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 # Belt over conftest's suspenders (the webpush test's 2026-08-08 lesson): a RAW run of this file
 # must never see live state, so the state root is rebound BEFORE the kernel module loads and
 # captures jd.STATE into its path constants.
-import tempfile
 from pathlib import Path
 _STATE_TD = tempfile.TemporaryDirectory()
 jd.STATE = Path(_STATE_TD.name)

--- a/tests/test_kernel_ws_auth.py
+++ b/tests/test_kernel_ws_auth.py
@@ -23,12 +23,17 @@ import threading
 import unittest
 from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 # Mirror tests/test_kernel.py's load order. Set a token so _load_token() returns early
 # (never touches the real state dir) and NO_OPEN so importing doesn't launch a browser.
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_kernel_ws_heartbeat.py
+++ b/tests/test_kernel_ws_heartbeat.py
@@ -11,11 +11,16 @@ import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 KSRC = open(os.path.join(BIN, "romp-kernel"), encoding="utf-8").read()

--- a/tests/test_kernel_ws_pong.py
+++ b/tests/test_kernel_ws_pong.py
@@ -8,11 +8,16 @@ import os
 import threading
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_known_attached_flag.py
+++ b/tests/test_known_attached_flag.py
@@ -17,6 +17,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 km = SourceFileLoader("romp_kernel_knownflag", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_ledger_anchors.py
+++ b/tests/test_ledger_anchors.py
@@ -6,8 +6,13 @@ import os
 import re
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_model_fallback_notice.py
+++ b/tests/test_model_fallback_notice.py
@@ -20,6 +20,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_em_mswap", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge_mswap", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel_mswap", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_new_session_dir.py
+++ b/tests/test_new_session_dir.py
@@ -27,6 +27,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_newdir", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_node_override_ack.py
+++ b/tests/test_node_override_ack.py
@@ -20,6 +20,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 SourceFileLoader("romp_event_model_ack", os.path.join(BIN, "romp-event-model")).load_module()

--- a/tests/test_notice_cards.py
+++ b/tests/test_notice_cards.py
@@ -13,6 +13,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_notify_bells.py
+++ b/tests/test_notify_bells.py
@@ -16,6 +16,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_nudge_block_prompts.py
+++ b/tests/test_nudge_block_prompts.py
@@ -13,6 +13,7 @@ import os
 import re
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)
@@ -20,6 +21,10 @@ BIN = os.path.join(ROOT, "bin")
 
 # romp-kernel imports romp-judge as `jd` at load, which imports romp-event-model — load deps first
 # (mirrors tests/test_kernel_cachebust.py).
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel_nudge", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_nudge_bundle.py
+++ b/tests/test_nudge_bundle.py
@@ -32,6 +32,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_bundle", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 

--- a/tests/test_nudge_hold_judge_rows.py
+++ b/tests/test_nudge_hold_judge_rows.py
@@ -22,6 +22,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 km = SourceFileLoader("romp_kernel_nhjr", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd

--- a/tests/test_nudge_injected_turn_arm.py
+++ b/tests/test_nudge_injected_turn_arm.py
@@ -37,6 +37,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_injarm", os.path.join(BIN, "romp-kernel")).load_module()
 jd = km.jd
 

--- a/tests/test_nudge_moot_supersede.py
+++ b/tests/test_nudge_moot_supersede.py
@@ -56,6 +56,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_nudgemoot", os.path.join(BIN, "romp-kernel")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_palette.py
+++ b/tests/test_palette.py
@@ -15,6 +15,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pal = SourceFileLoader("romp_palette", os.path.join(BIN, "romp_palette.py")).load_module()
 
 ROMP_BG = ["#1EA1EB", "#54B204", "#4EA8A9", "#DD42FF", "#E87221",

--- a/tests/test_pane_loader_reconnect.py
+++ b/tests/test_pane_loader_reconnect.py
@@ -27,11 +27,16 @@ Source-pinning, like the other _pane_spin tests (this JS has no jsdom harness).
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_path_links.py
+++ b/tests/test_path_links.py
@@ -26,6 +26,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_payload_dedup_invariant.py
+++ b/tests/test_payload_dedup_invariant.py
@@ -30,6 +30,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_dedupinv", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel_dedupinv", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_peer_fast_forward.py
+++ b/tests/test_peer_fast_forward.py
@@ -14,11 +14,16 @@ import json
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_peerff", os.path.join(BIN, "romp-kernel")).load_module()
 
 LOCAL = "a" * 40        # this machine's HEAD

--- a/tests/test_per_viewer_focus.py
+++ b/tests/test_per_viewer_focus.py
@@ -19,9 +19,12 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_pvf", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_placements_canary.py
+++ b/tests/test_placements_canary.py
@@ -29,6 +29,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_canary", os.path.join(BIN, "romp-judge")).load_module()
 em = SourceFileLoader("romp_em_canary", os.path.join(BIN, "romp-event-model")).load_module()
 

--- a/tests/test_planner_episode_floor.py
+++ b/tests/test_planner_episode_floor.py
@@ -27,6 +27,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_epifloor", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_postal_bus_lifetime.py
+++ b/tests/test_postal_bus_lifetime.py
@@ -25,6 +25,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 pm = SourceFileLoader("romp_postal_buslife", os.path.join(BIN, "romp-postal-service")).load_module()
 km = SourceFileLoader("romp_kernel_buslife", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_postal_code_staleness.py
+++ b/tests/test_postal_code_staleness.py
@@ -17,6 +17,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()      # hermetic; constants resolve under here at import
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal", os.path.join(BIN, "romp-postal-service")).load_module()
 
 

--- a/tests/test_postal_deferred_push_identity.py
+++ b/tests/test_postal_deferred_push_identity.py
@@ -23,6 +23,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()      # hermetic; constants resolve under here at import
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal", os.path.join(BIN, "romp-postal-service")).load_module()
 
 TO = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_postal_delivery.py
+++ b/tests/test_postal_delivery.py
@@ -11,6 +11,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal_delivery", os.path.join(BIN, "romp-postal-service")).load_module()
 
 

--- a/tests/test_postal_freshness.py
+++ b/tests/test_postal_freshness.py
@@ -15,6 +15,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()      # hermetic; constants resolve under here at import
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal", os.path.join(BIN, "romp-postal-service")).load_module()
 
 STALE = "(idle now — claim may be stale)"

--- a/tests/test_postal_hydrate_unresolved.py
+++ b/tests/test_postal_hydrate_unresolved.py
@@ -21,6 +21,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 SourceFileLoader("romp_event_model_ph", os.path.join(BIN, "romp-event-model")).load_module()

--- a/tests/test_postal_identity.py
+++ b/tests/test_postal_identity.py
@@ -8,8 +8,13 @@ timeline icon (keyed on the real fsid) correctly showed it un-isolated. Syntheti
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal_id", os.path.join(BIN, "romp-postal-service")).load_module()
 
 FSID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_postal_isolation.py
+++ b/tests/test_postal_isolation.py
@@ -16,6 +16,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()      # hermetic; constants resolve under here at import
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal", os.path.join(BIN, "romp-postal-service")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_postal_live_only.py
+++ b/tests/test_postal_live_only.py
@@ -17,6 +17,7 @@ BIN = os.path.join(ROOT, "bin")
 SKILL = os.path.join(ROOT, "claude", "skills", "romp-postal", "SKILL.md")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()      # hermetic; constants resolve under here at import
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal", os.path.join(BIN, "romp-postal-service")).load_module()
 
 ALPHA = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_postal_native_steering.py
+++ b/tests/test_postal_native_steering.py
@@ -17,7 +17,10 @@ ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 SKILL = os.path.join(ROOT, "claude", "skills", "romp-postal", "SKILL.md")
 
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal_steering", os.path.join(BIN, "romp-postal-service")).load_module()
 
 

--- a/tests/test_postal_peer_identity.py
+++ b/tests/test_postal_peer_identity.py
@@ -17,6 +17,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 _SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
 Path(_SESS).write_text(json.dumps([{"id": "sess-web", "name": "web", "dir": "/tmp/notes-api",
                                     "state": "waiting", "working": ""}]))

--- a/tests/test_postal_peer_tier.py
+++ b/tests/test_postal_peer_tier.py
@@ -17,6 +17,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 _SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
 Path(_SESS).write_text(json.dumps([{"id": "sess-web", "name": "web", "dir": "/tmp/notes-api",
                                     "state": "waiting", "working": ""}]))

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -11,6 +11,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal_peers", os.path.join(BIN, "romp-postal-service")).load_module()
 
 

--- a/tests/test_postal_quarantine.py
+++ b/tests/test_postal_quarantine.py
@@ -17,6 +17,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 # One live local session ("web") via the sessions-file seam (no live kernel needed).
 _SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
 Path(_SESS).write_text(json.dumps([{"id": "sess-web", "name": "web", "dir": "/tmp/notes-api",

--- a/tests/test_postal_read_receipts.py
+++ b/tests/test_postal_read_receipts.py
@@ -19,6 +19,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_POSTAL_HOST"] = "TESTHOST"
 _SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
 Path(_SESS).write_text(json.dumps([{"id": "sess-web", "name": "web", "dir": "/tmp/notes-api",

--- a/tests/test_postal_safe_id.py
+++ b/tests/test_postal_safe_id.py
@@ -17,6 +17,7 @@ BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 # Hermetic state dir so exercising the bus never touches real mail.
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal", os.path.join(BIN, "romp-postal-service")).load_module()
 
 

--- a/tests/test_postal_sdk_agents.py
+++ b/tests/test_postal_sdk_agents.py
@@ -13,6 +13,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()      # hermetic; constants resolve under here at import
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal", os.path.join(BIN, "romp-postal-service")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_postal_self_identity.py
+++ b/tests/test_postal_self_identity.py
@@ -22,6 +22,7 @@ STABLE = "11111111-2222-3333-4444-555555555555"
 FORK = "99999999-8888-7777-6666-555555555555"
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 _SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
 Path(_SESS).write_text(json.dumps([
     {"id": STABLE, "name": "web", "dir": "/tmp/notes-api", "state": "waiting",

--- a/tests/test_postal_self_send.py
+++ b/tests/test_postal_self_send.py
@@ -21,6 +21,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()      # hermetic; constants resolve under here
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal_self_send", os.path.join(BIN, "romp-postal-service")).load_module()
 
 ME = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_postal_send_echo.py
+++ b/tests/test_postal_send_echo.py
@@ -11,7 +11,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 ps = SourceFileLoader("romp_postal_echo", os.path.join(BIN, "romp-postal-service")).load_module()
 
 

--- a/tests/test_postal_token.py
+++ b/tests/test_postal_token.py
@@ -25,6 +25,7 @@ BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 # Hermetic state dir; the sessions-file seam signals "no live kernel" to the bus.
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 _SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
 Path(_SESS).write_text("[]")
 os.environ["ROMP_SESSIONS_FILE"] = _SESS

--- a/tests/test_postal_undelivered.py
+++ b/tests/test_postal_undelivered.py
@@ -19,6 +19,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal_undelivered", os.path.join(BIN, "romp-postal-service")).load_module()
 
 SENDER = "11111111-1111-1111-1111-111111111111"

--- a/tests/test_postal_working.py
+++ b/tests/test_postal_working.py
@@ -11,6 +11,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()      # hermetic; constants resolve under here at import
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 pm = SourceFileLoader("romp_postal", os.path.join(BIN, "romp-postal-service")).load_module()
 
 

--- a/tests/test_relay_exec_dmid.py
+++ b/tests/test_relay_exec_dmid.py
@@ -16,6 +16,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 _SESS = os.path.join(os.environ["XDG_STATE_HOME"], "sessions.json")
 Path(_SESS).write_text(json.dumps([{"id": "sess-web", "name": "web", "dir": "/tmp/notes-api",
                                     "state": "waiting", "working": ""}]))

--- a/tests/test_remote_clone_discovery.py
+++ b/tests/test_remote_clone_discovery.py
@@ -21,6 +21,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 km = SourceFileLoader("romp_kernel_clonedisc", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_remotes_panel_render.py
+++ b/tests/test_remotes_panel_render.py
@@ -24,6 +24,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 km = SourceFileLoader("romp_kernel_rpanel", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_remotes_stale_and_persist.py
+++ b/tests/test_remotes_stale_and_persist.py
@@ -29,6 +29,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 km = SourceFileLoader("romp_kernel_stale", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_reply_bulk_unblock.py
+++ b/tests/test_reply_bulk_unblock.py
@@ -17,6 +17,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 _STATE_TMP = tempfile.mkdtemp()
 os.environ["XDG_STATE_HOME"] = _STATE_TMP
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_bulkunblock", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_resolve_override_replay.py
+++ b/tests/test_resolve_override_replay.py
@@ -43,6 +43,10 @@ import os
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-666666666666"

--- a/tests/test_restart_audit.py
+++ b/tests/test_restart_audit.py
@@ -18,10 +18,15 @@ import unittest
 import urllib.request
 from http.server import ThreadingHTTPServer
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_retry_gaveup.py
+++ b/tests/test_retry_gaveup.py
@@ -19,6 +19,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend_gaveup", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 km = SourceFileLoader("romp_kernel_gaveup", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_retry_pause_autoresume.py
+++ b/tests/test_retry_pause_autoresume.py
@@ -18,6 +18,10 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_rp", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_rewind_ghost_reply.py
+++ b/tests/test_rewind_ghost_reply.py
@@ -27,6 +27,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_em_ghost", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge_ghost", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel_ghost", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_romp_idle_dots.py
+++ b/tests/test_romp_idle_dots.py
@@ -14,9 +14,14 @@ import os
 import sys
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 SCRIPTS = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 dots = SourceFileLoader("romp_idle_dots_t", os.path.join(SCRIPTS, "romp-idle-dots")).load_module()
 
 NOW = 1_781_153_000

--- a/tests/test_romp_version.py
+++ b/tests/test_romp_version.py
@@ -4,8 +4,13 @@ vs served-vs-built bundles. Network/git are stubbed so the formatting + the stal
 deterministically."""
 import os
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 ver = SourceFileLoader("romp_version", os.path.join(BIN, "romp-version")).load_module()
 
 

--- a/tests/test_sdk_api_retry_detail.py
+++ b/tests/test_sdk_api_retry_detail.py
@@ -28,11 +28,16 @@ import os
 import unittest
 from contextlib import redirect_stderr
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend_retrydetail", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -21,6 +21,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 

--- a/tests/test_sdk_boot_stagger.py
+++ b/tests/test_sdk_boot_stagger.py
@@ -20,6 +20,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend_stagger", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 

--- a/tests/test_sdk_busy_count.py
+++ b/tests/test_sdk_busy_count.py
@@ -12,6 +12,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend_busy", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 

--- a/tests/test_sdk_clear_fork.py
+++ b/tests/test_sdk_clear_fork.py
@@ -25,6 +25,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_sdk_compacting_signal.py
+++ b/tests/test_sdk_compacting_signal.py
@@ -15,6 +15,10 @@ import unittest
 from importlib.machinery import SourceFileLoader
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend_compact", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_sdk_echo_durability.py
+++ b/tests/test_sdk_echo_durability.py
@@ -22,6 +22,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend_echo", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_sdk_error_visibility.py
+++ b/tests/test_sdk_error_visibility.py
@@ -15,11 +15,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_sdkerr", os.path.join(BIN, "romp-kernel")).load_module()
 sb = SourceFileLoader("romp_sdk_backend_sdkerr", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 SB_SRC = open(os.path.join(BIN, "romp_sdk_backend.py")).read()

--- a/tests/test_sdk_interrupt_escalation.py
+++ b/tests/test_sdk_interrupt_escalation.py
@@ -10,8 +10,13 @@ is the signal's targeting: it can only ever match our OWN child resuming our sid
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend_intr", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_sdk_kernel.py
+++ b/tests/test_sdk_kernel.py
@@ -9,10 +9,15 @@ plus the live-session merge. (the user 2026-06-26: tmux + SDK behind one session
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_sdk_launch_error.py
+++ b/tests/test_sdk_launch_error.py
@@ -32,6 +32,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend_launcherr", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -30,6 +30,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 

--- a/tests/test_sdk_orphan_reply.py
+++ b/tests/test_sdk_orphan_reply.py
@@ -12,6 +12,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend_orphan", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_sdk_rate_limit_usage.py
+++ b/tests/test_sdk_rate_limit_usage.py
@@ -19,6 +19,10 @@ from types import SimpleNamespace
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 

--- a/tests/test_sdk_rewind.py
+++ b/tests/test_sdk_rewind.py
@@ -22,6 +22,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend_rw", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 BACKEND_SRC = open(os.path.join(BIN, "romp_sdk_backend.py")).read()
 

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -7,9 +7,14 @@ import os
 import re
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_session_backend", os.path.join(BIN, "romp_session_backend.py")).load_module()
 
 ABSTRACT = sorted(sb.SessionBackend.__abstractmethods__)

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -31,9 +31,12 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 sb = SourceFileLoader("romp_sdk_backend_auth", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 km = SourceFileLoader("romp_kernel_auth", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_session_retry_suppress.py
+++ b/tests/test_session_retry_suppress.py
@@ -18,6 +18,10 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 SRC = open(os.path.join(BIN, "romp-kernel")).read()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_srs", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_settle_awaits_background_tasks.py
+++ b/tests/test_settle_awaits_background_tasks.py
@@ -29,6 +29,10 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_settle_bg", os.path.join(BIN, "romp-judge")).load_module()
 
 SID = "11111111-2222-3333-4444-666666666666"

--- a/tests/test_shell_mobile_composer_pad.py
+++ b/tests/test_shell_mobile_composer_pad.py
@@ -19,9 +19,12 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_mcomp", os.path.join(BIN, "romp-kernel")).load_module()
 STYLES = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "styles.css")).read()
 

--- a/tests/test_shell_viewport_fit.py
+++ b/tests/test_shell_viewport_fit.py
@@ -22,9 +22,12 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_vhfit", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_skill_content.py
+++ b/tests/test_skill_content.py
@@ -17,6 +17,10 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_em_skill", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_space_paths.py
+++ b/tests/test_space_paths.py
@@ -13,6 +13,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_stall_note.py
+++ b/tests/test_stall_note.py
@@ -12,8 +12,13 @@ import sys
 import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
+import os
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge_stall", str(ROOT / "kernel" / "judge.py")).load_module()
 
 FSID = "11111111-2222-3333-4444-555555555555"

--- a/tests/test_state_isolation_order.py
+++ b/tests/test_state_isolation_order.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Every test module that loads romp code must make its state root hermetic FIRST (2026-08-12).
+
+bin/romp-kernel, bin/romp-judge, bin/romp-event-model, bin/romp-postal-service and the modules
+they pull in resolve STATE = ROMP_STATE_DIR || XDG_STATE_HOME/romp || ~/.local/state/romp at
+IMPORT time (and romp-judge mkdirs it). tests/conftest.py points XDG_STATE_HOME at a temp dir,
+but conftest is pytest-only: under `python -m unittest` (or a direct `./tests/test_x.py` run)
+nothing sets the floor, and the module operates on the REAL ~/.local/state/romp. On 2026-08-12
+exactly that happened: a unittest run of tests/test_kernel.py persisted its synthetic check-in
+fixtures (TESTHOST, hubhost) into the real remotes.json / remotes-known.json — dropping a real
+attached host's row — and the live kernel re-read the file at its next restart and began
+ssh-dialing the fixtures. tests/__init__.py now gives unittest package runs the same floor
+conftest gives pytest, but neither covers `cd tests && python -m unittest test_x` or a direct
+script run, so the per-module preamble is the primary defence and this test is the ratchet.
+
+The rule this file enforces, per tests/test_*.py module: if the module loads romp code (any
+SourceFileLoader call, or an import of the kernel/postal/cli packages), then BEFORE the first
+such load, at module top level, it must (a) assign os.environ["XDG_STATE_HOME"] (or
+["ROMP_STATE_DIR"]) and (b) handle ROMP_STATE_DIR (assign it, or pop it — a live kernel exports
+it to its sessions, and it outranks the XDG floor). The canonical preamble:
+
+    # Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+    # pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+    os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+    os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+
+Static AST scan, ordered by line number; every in-process load call counts as state-touching —
+SourceFileLoader and the importlib idioms (spec_from_file_location/exec_module/import_module/
+__import__) alike, since most bin/* files are or transitively load a STATE-resolving module, and
+the few that aren't pay two harmless lines rather than this test resolving targets. Out of scope by design: a subprocess
+spawned with a hand-built env= dict that carries the real HOME — env construction is dynamic and
+defeats static checking; the preamble covers the common case because a child spawned without
+env= inherits the mutated os.environ.
+"""
+import ast
+import os
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+
+# Any entry must justify itself here: a module that genuinely needs the real state root (none
+# known — reading real state from a test was always a bug) or a false positive worth documenting.
+EXEMPT: set[str] = set()
+
+PREAMBLE = (
+    '    os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()\n'
+    '    os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel\'s export outranks the XDG floor'
+)
+
+ROOT_PACKAGES = {"kernel", "postal", "cli"}
+# Every in-process load form counts, not just the repo's usual SourceFileLoader: the
+# spec_from_file_location + exec_module idiom (tests/test_colormap.py) aimed at a STATE-resolving
+# bin file would recreate the corruption with the ratchet silent otherwise.
+LOAD_CALLS = {"SourceFileLoader", "spec_from_file_location", "exec_module", "import_module",
+              "__import__"}
+
+
+def _is_environ_attr(node):
+    return isinstance(node, ast.Attribute) and node.attr == "environ"
+
+
+def _environ_key(node):
+    """The constant key of an `<x>.environ[...]` subscript, else None."""
+    if isinstance(node, ast.Subscript) and _is_environ_attr(node.value):
+        if isinstance(node.slice, ast.Constant):
+            return node.slice.value
+    return None
+
+
+def scan(path):
+    """Return (first_load, first_set, rsd_handled) linenos for one module (None where absent)."""
+    tree = ast.parse(open(path).read(), filename=path)
+    first_load = first_set = rsd_handled = None
+
+    def keep_min(cur, lineno):
+        return lineno if cur is None or lineno < cur else cur
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            f = node.func
+            name = f.id if isinstance(f, ast.Name) else f.attr if isinstance(f, ast.Attribute) else None
+            if name in LOAD_CALLS:
+                first_load = keep_min(first_load, node.lineno)
+        elif isinstance(node, ast.Import):
+            if any(a.name.split(".")[0] in ROOT_PACKAGES for a in node.names):
+                first_load = keep_min(first_load, node.lineno)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module and node.module.split(".")[0] in ROOT_PACKAGES:
+                first_load = keep_min(first_load, node.lineno)
+
+    for stmt in tree.body:                       # top level only: a set inside a function does not
+        if isinstance(stmt, ast.Assign):         # run before an import-time load
+            keys = {_environ_key(t) for t in stmt.targets}
+            if keys & {"XDG_STATE_HOME", "ROMP_STATE_DIR"}:
+                first_set = keep_min(first_set, stmt.lineno)
+            if "ROMP_STATE_DIR" in keys:
+                rsd_handled = keep_min(rsd_handled, stmt.lineno)
+        elif isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            f = stmt.value.func
+            if (isinstance(f, ast.Attribute) and f.attr == "pop" and _is_environ_attr(f.value)
+                    and stmt.value.args and isinstance(stmt.value.args[0], ast.Constant)
+                    and stmt.value.args[0].value == "ROMP_STATE_DIR"):
+                rsd_handled = keep_min(rsd_handled, stmt.lineno)
+    return first_load, first_set, rsd_handled
+
+
+class StateIsolationOrder(unittest.TestCase):
+    def test_every_loading_module_isolates_state_first(self):
+        bad = []
+        for fn in sorted(os.listdir(HERE)):
+            if not (fn.startswith("test_") and fn.endswith(".py")) or fn in EXEMPT:
+                continue
+            first_load, first_set, rsd_handled = scan(os.path.join(HERE, fn))
+            if first_load is None:
+                continue
+            if first_set is None or first_set >= first_load:
+                bad.append("%s: loads romp code at line %d with no prior state-root assignment"
+                           % (fn, first_load))
+            elif rsd_handled is None or rsd_handled >= first_load:
+                bad.append("%s: sets the XDG floor (line %d) but never handles ROMP_STATE_DIR "
+                           "before the load at line %d" % (fn, first_set, first_load))
+        self.assertFalse(bad,
+            "These modules load romp code before making the state root hermetic — under a bare\n"
+            "unittest or script run they operate on the REAL ~/.local/state/romp (which is how\n"
+            "tests/test_kernel.py overwrote the real remotes.json on 2026-08-12). Put this at\n"
+            "module top level, above the first SourceFileLoader line:\n\n%s\n\n%s"
+            % (PREAMBLE, "\n".join(bad)))
+
+    def test_the_suite_wide_floors_stay_in_place(self):
+        # The suspenders: conftest.py (pytest) and __init__.py (unittest package runs) each set the
+        # XDG floor and drop an inherited ROMP_STATE_DIR override. Pin them so neither is silently
+        # deleted or loses the pop.
+        for fn in ("conftest.py", "__init__.py"):
+            src = open(os.path.join(HERE, fn)).read()
+            self.assertIn('os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp', src,
+                          "%s must keep the temp XDG_STATE_HOME floor" % fn)
+            self.assertIn('os.environ.pop("ROMP_STATE_DIR", None)', src,
+                          "%s must keep dropping an inherited ROMP_STATE_DIR override" % fn)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_teammate_message.py
+++ b/tests/test_teammate_message.py
@@ -14,6 +14,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_timeline_idle_fade.py
+++ b/tests/test_timeline_idle_fade.py
@@ -7,11 +7,16 @@ import inspect
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_tlfade", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_tmux_optional.py
+++ b/tests/test_tmux_optional.py
@@ -9,10 +9,15 @@ Synthetic only: no real session data; the fake tmux is a stub path.
 import os
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_tmuxopt", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_token_login_page.py
+++ b/tests/test_token_login_page.py
@@ -14,10 +14,15 @@ import os
 import re
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_loginpage", os.path.join(BIN, "romp-kernel")).load_module()
 
 HTML = km._TOKEN_LOGIN_HTML

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -12,6 +12,10 @@ from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
 
 BIN = os.path.join(os.path.dirname(__file__), "..", "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_tunnel_flap.py
+++ b/tests/test_tunnel_flap.py
@@ -25,9 +25,12 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_flap", os.path.join(BIN, "romp-kernel")).load_module()
 
 

--- a/tests/test_tunnel_reconnect_backoff.py
+++ b/tests/test_tunnel_reconnect_backoff.py
@@ -21,6 +21,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 km = SourceFileLoader("romp_kernel_rbackoff", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_tunnel_stale_and_logging.py
+++ b/tests/test_tunnel_stale_and_logging.py
@@ -28,6 +28,7 @@ from importlib.machinery import SourceFileLoader
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 km = SourceFileLoader("romp_kernel_stale", os.path.join(BIN, "romp-kernel")).load_module()

--- a/tests/test_tunnels_via.py
+++ b/tests/test_tunnels_via.py
@@ -18,6 +18,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 km = SourceFileLoader("romp_kernel_via", os.path.join(BIN, "romp-kernel")).load_module()
 

--- a/tests/test_usage_acct_flip.py
+++ b/tests/test_usage_acct_flip.py
@@ -12,6 +12,10 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"

--- a/tests/test_usage_per_account.py
+++ b/tests/test_usage_per_account.py
@@ -23,9 +23,12 @@ from importlib.machinery import SourceFileLoader
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
-os.environ.setdefault("XDG_STATE_HOME", tempfile.mkdtemp())
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_acctusage", os.path.join(BIN, "romp-kernel")).load_module()
 
 ACCT_A = "aaaaaaaaaaaa"

--- a/tests/test_ws_fragmentation.py
+++ b/tests/test_ws_fragmentation.py
@@ -12,11 +12,16 @@ import os
 import struct
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
 
 MASK = b"\x11\x22\x33\x44"

--- a/tests/test_ws_send_bounded.py
+++ b/tests/test_ws_send_bounded.py
@@ -29,10 +29,15 @@ import threading
 import time
 import unittest
 from importlib.machinery import SourceFileLoader
+import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = SourceFileLoader("romp_kernel_wsbound", os.path.join(BIN, "romp-kernel")).load_module()
 
 


### PR DESCRIPTION
## Why

`tests/conftest.py`'s XDG_STATE_HOME floor is pytest-only. Under `python -m unittest` (how tests are run on dev machines) nothing set the floor, so any test module that loads `bin/romp-*` code — which resolves its state root at import time — operated on the REAL `~/.local/state/romp`. On 2026-08-12, a unittest run of `tests/test_kernel.py` persisted its synthetic check-in fixtures (TESTHOST, hubhost) into the real `remotes.json`/`remotes-known.json`, dropping a real attached host's row; the live kernel re-read the file at its next restart and began ssh-dialing the fixtures. An audit found 311 of 325 test modules carried the same latent leak.

## What

Three layers, each covering a run form the others miss:

- **Per-module preamble** (257 files, plus the `ROMP_STATE_DIR` pop in the 55 already-XDG-hermetic ones): point `XDG_STATE_HOME` at a `mkdtemp` and pop an inherited `ROMP_STATE_DIR` before the first load line. The only layer covering `cd tests && python -m unittest test_x` and direct script runs. Thirteen dead `setdefault("XDG_STATE_HOME")` lines the preamble supersedes are removed — `setdefault` keeps an inherited real value, so it never was hermetic.
- **`tests/test_state_isolation_order.py`** (the ratchet): AST guard that fails any module ordering a state-touching load (`SourceFileLoader` or the importlib idioms) before isolation, and pins the two suite-wide floors so they cannot be silently deleted. Hand-built `env=` dicts passed to subprocesses are documented as out of scope (dynamic construction defeats static checking; children spawned without `env=` inherit the hermetic environ).
- **`tests/__init__.py`** (the suspenders): unittest-side twin of conftest's floor for package runs; conftest additionally pops `ROMP_STATE_DIR` (a live kernel exports it to its sessions, and it outranks the XDG floor).

## Verification

- Full suite green under `python -m unittest discover` (4291 tests, 34 pre-existing skips), with a before/after hash of the real `remotes-known.json` showing no write across the run.
- The original culprit module now resolves its state root under `/tmp` in the worst-case entry form (direct import from inside `tests/`, bypassing both floors).
- Three independent adversarial reviews of the sweep; their findings (the importlib bypass of the guard, dead setdefault lines, two duplicate imports) are folded in.

Noted for a follow-up, out of scope here: `bin/romp-kernel`'s account-cache refresh reads the real `~/.claude.json` (read-only, folds to empty on absence) — the same tests-touch-real-HOME class, but not state-dir shaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)