### PR TITLE
A directly-peered box never presents or routes as reachable-via-relay

### DIFF
--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1092,11 +1092,23 @@ class Handler(BaseHTTPRequestHandler):
                 # Peer-bus fleet view (DISPLAY only — all_agents() itself stays local so the delivery
                 # paths can never mistake a peer entry for a local maildir): each peer's last-gossiped
                 # presence, with honest staleness. Address cross-host with 'host:name' on collisions.
+                # Gossip that duplicates a direct peer's row is folded (_via_duplicate), and a session
+                # already listed never lists again under a second path — the doubled '[remote]' rows
+                # (the user 2026-08-12).
                 now = time.time()
+                direct_bus = _direct_bus_ids()
+                listed = {a["id"] for a in agents if a.get("id")}
                 for host, st in PEER_STATE.items():
                     age = int(now - (st.get("seenAt") or 0))
                     for pa in st.get("presence") or []:
-                        agents.append({"name": pa.get("name") or "?", "id": pa.get("id") or "",
+                        if _via_duplicate(pa, direct_bus):
+                            continue
+                        sid = pa.get("id") or ""
+                        if sid and sid in listed:
+                            continue
+                        if sid:
+                            listed.add(sid)
+                        agents.append({"name": pa.get("name") or "?", "id": sid,
                                        "remote": True, "peer": host, "seenAgo": age})
             return self._send({"agents": agents, "me": me})
         if u.path == "/sent":
@@ -1463,19 +1475,49 @@ def peer_update(data):
     _peer_threads_reconcile(host)                    # an up peer gets its dialer; a down one is woken to exit
     return {"ok": True, "up": sum(1 for p in PEERS.values() if p["up"])}, 200
 
+def _direct_bus_ids():
+    """The bus ids of every DIRECTLY-peered bus (a dialable PEERS row): the identity set the
+    via-row consumers test gossip against. The id — proven by the peer exchange itself — is what
+    "same box" means; a NICKNAME can't say it, because the same machine wears different ssh
+    aliases on different hosts (the user 2026-08-12, whose directly connected box was also listed
+    "reachable via relay" under the hub's name for it, and whose mail could hop the hub)."""
+    out = set()
+    for h, st in PEER_STATE.items():
+        if (PEERS.get(h) or {}).get("port") and st.get("busId"):
+            out.add(st["busId"])
+    return out
+
+
+def _via_duplicate(pa, direct_bus):
+    """True when a GOSSIPED presence row (via set) names a box that is also a direct peer here —
+    by bus id when the hub gossips it (viaBus, the nickname-proof identity), by name for a hub
+    that predates the field. Duplicates are folded everywhere gossip is consumed: display
+    (via_reach), addressing (peer_route), and the agent list — a direct link always wins over a
+    relay hop, and never renders beside it."""
+    far = pa.get("via")
+    if not far:
+        return False
+    if (PEERS.get(far) or {}).get("port"):
+        return True
+    return bool(pa.get("viaBus")) and pa.get("viaBus") in direct_bus
+
+
 def via_reach():
     """Hosts reachable only THROUGH a directly-peered hub: the far spokes whose sessions a hub
     gossips with `via` labels (fleet_presence — one hop, never re-gossiped). One row per far host:
     {"host", "via", "agents", "seenAgo", "trust"} — the popover's "reachable via relay" section, and
-    the hook a trust-by-origin tier hangs on even though no tunnel to that host exists here."""
+    the hook a trust-by-origin tier hangs on even though no tunnel to that host exists here.
+    A spoke we ALSO hold a direct link to is folded (_via_duplicate: bus-id identity, so a nickname
+    difference can't sneak the duplicate back in)."""
     now, out = int(time.time()), {}
+    direct_bus = _direct_bus_ids()
     for hub, st in PEER_STATE.items():
         age = int(now - (st.get("seenAt") or 0))
         for pa in st.get("presence") or []:
             far = pa.get("via")
             if not far:      # a hub's exchange never gossips OUR sessions back (fleet_presence
                 continue     # excludes the asking host), so no self-row can appear here
-            if (PEERS.get(far) or {}).get("port"):    # directly peered here → its own row, not via
+            if _via_duplicate(pa, direct_bus):        # directly peered here → its own row, not via
                 continue
             e = out.setdefault(far, {"host": far, "via": hub, "agents": 0, "seenAgo": age,
                                      "trust": (PEERS.get(far) or {}).get("trust") or "directed"})
@@ -1819,7 +1861,10 @@ def fleet_presence(exclude_host):
     """Presence for an exchange payload: local agents + ONE hop of gossip from our other peers, each
     labeled `via` (plans/postal-peer-buses.md 3b) — so a spoke can address the far spoke through the
     hub. A via-entry is never re-gossiped (one-hop reach only; a topology needing two hops should
-    check the second spoke in to the hub directly)."""
+    check the second spoke in to the hub directly). Each via row also carries the far bus's own id
+    (`viaBus`): the receiver folds gossip about a box it ALREADY peers with directly, and the id is
+    the identity that survives nickname drift — the same machine wears different ssh aliases on
+    different hosts, so a name can't say "same box" (the user 2026-08-12; see _via_duplicate)."""
     out = list(local_agents())
     for h, st in PEER_STATE.items():
         if h == exclude_host:
@@ -1827,7 +1872,7 @@ def fleet_presence(exclude_host):
         for pa in st.get("presence") or []:
             if pa.get("via"):
                 continue
-            out.append(dict(pa, via=h))
+            out.append(dict(pa, via=h, viaBus=st.get("busId") or ""))
     return out
 
 # ── quarantine (per-host trust model) ───────────────────────────────────────────
@@ -2162,17 +2207,34 @@ def peer_exchange_apply(host, req_sent, resp):
 
 def peer_route(to):
     """Where a non-local name lives: (host, agent) for exactly ONE peer match; (None, candidates) on
-    ambiguity; (None, []) when unknown. Accepts the explicit 'host:name' form to break ties."""
+    ambiguity; (None, []) when unknown. Accepts the explicit 'host:name' form to break ties.
+    Gossiped duplicates are folded BEFORE the ambiguity count: a session on a directly-peered box
+    also arrives via a hub's gossip (under the hub's nickname for that box), and counting both read
+    as two sessions — a false ambiguity — or, picked, would relay mail through the hub a direct
+    link already covers (the user 2026-08-12). Same session seen from two hubs folds too (one id,
+    one candidate); the direct row always wins."""
     want_host = None
     if ":" in to:
         want_host, to = to.split(":", 1)
-    hits = []
+    direct_bus = _direct_bus_ids()
+    hits, seen_ids = [], {}
     for host, st in PEER_STATE.items():
         if want_host and host != want_host:
             continue
         for a in st.get("presence") or []:
-            if a.get("name") == to:
-                hits.append((host, a))
+            if a.get("name") != to or _via_duplicate(a, direct_bus):
+                continue
+            sid = a.get("id") or ""
+            if sid and sid in seen_ids:                # one session, two gossip paths → one candidate;
+                if a.get("via") and not hits[seen_ids[sid]][1].get("via"):
+                    continue                           # …and a direct row beats a relayed one
+                if not a.get("via") and hits[seen_ids[sid]][1].get("via"):
+                    hits[seen_ids[sid]] = (host, a)
+                    continue
+                continue
+            if sid:
+                seen_ids[sid] = len(hits)
+            hits.append((host, a))
     if len(hits) == 1:
         return hits[0]
     return None, hits

--- a/tests/test_postal_via_dedupe.py
+++ b/tests/test_postal_via_dedupe.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""A box that is DIRECTLY peered must never also present — or route — as "reachable via relay"
+(the user 2026-08-12). The name test alone missed it: the same machine wears different ssh
+aliases on different hosts, so the hub gossips the spoke under a name the receiver doesn't
+recognize as its own direct peer. Identity now rides the gossip as the far bus's own id
+(fleet_presence viaBus) — the thing the exchange already proves, immune to nickname drift — and
+one shared test (_via_duplicate: bus id first, name for hubs that predate the field) folds the
+duplicates everywhere gossip is consumed: the popover rows (via_reach), addressing (peer_route —
+where the duplicate read as a FALSE ambiguity, or worse picked the relay hop a direct link
+already covers), and the agent list (the doubled '[remote]' rows).
+
+Synthetic hosts, ids, and bus ids throughout; hermetic state dir; no sockets.
+"""
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+pm = SourceFileLoader("romp_postal_viadedupe", os.path.join(BIN, "romp-postal-service")).load_module()
+
+WEB_ID = "11111111-1111-1111-1111-111111111111"
+HUB_ID = "22222222-2222-2222-2222-222222222222"
+FAR_ID = "33333333-3333-3333-3333-333333333333"
+
+
+class _Seeded(unittest.TestCase):
+    """The user's shape: a spoke peered directly under OUR alias, and a hub that gossips the same
+    box under ITS OWN name for it (names differ; bus ids agree)."""
+
+    def setUp(self):
+        self._peers, self._pstate = dict(pm.PEERS), dict(pm.PEER_STATE)
+        pm.PEERS.clear()
+        pm.PEER_STATE.clear()
+        now = int(time.time())
+        # hub FIRST in insertion order, so consumers meet the gossiped duplicate before the
+        # direct row — the ordering that would have hidden a keep-the-first bug
+        pm.PEERS["hub"] = {"port": 12, "up": True}
+        pm.PEER_STATE["hub"] = {"busId": "bus-HHHH", "seenAt": now, "presence": [
+            {"name": "hubapp", "id": HUB_ID},
+            # the SAME box we peer with directly, under the hub's different nickname for it
+            {"name": "web", "id": WEB_ID, "via": "spoke-other-name", "viaBus": "bus-AAAA"},
+            # a genuine far spoke: no direct link here — must keep presenting via relay
+            {"name": "farapp", "id": FAR_ID, "via": "farbox", "viaBus": "bus-FFFF"},
+        ]}
+        pm.PEERS["spokealias"] = {"port": 11, "up": True, "trust": "trusted"}
+        pm.PEER_STATE["spokealias"] = {"busId": "bus-AAAA", "seenAt": now, "presence": [
+            {"name": "web", "id": WEB_ID},
+        ]}
+
+    def tearDown(self):
+        pm.PEERS.clear()
+        pm.PEERS.update(self._peers)
+        pm.PEER_STATE.clear()
+        pm.PEER_STATE.update(self._pstate)
+
+
+class ViaReachFolds(_Seeded):
+    def test_a_directly_peered_box_never_shows_as_via_relay(self):
+        rows = {r["host"]: r for r in pm.via_reach()}
+        self.assertNotIn("spoke-other-name", rows,
+                         "the hub's nickname differs, but the bus id proves it is our direct peer")
+        self.assertNotIn("spokealias", rows)
+
+    def test_a_genuine_far_spoke_still_presents(self):
+        rows = {r["host"]: r for r in pm.via_reach()}
+        self.assertIn("farbox", rows, "no direct link exists — via relay is real reach")
+        self.assertEqual(rows["farbox"]["via"], "hub")
+
+    def test_an_old_hub_without_the_id_still_folds_matching_names(self):
+        # a hub that predates viaBus: the name path keeps today's behavior
+        pm.PEER_STATE["hub"]["presence"].append({"name": "web2", "id": FAR_ID, "via": "spokealias"})
+        rows = {r["host"]: r for r in pm.via_reach()}
+        self.assertNotIn("spokealias", rows)
+
+
+class PeerRoutePrefersDirect(_Seeded):
+    def test_no_false_ambiguity_and_the_direct_link_carries_the_mail(self):
+        host, agent = pm.peer_route("web")
+        self.assertEqual(host, "spokealias", "one candidate, and it is the direct peer — never the hub")
+        self.assertEqual(agent.get("id"), WEB_ID)
+        self.assertFalse(agent.get("via"), "the chosen row is the direct one")
+
+    def test_two_hubs_gossiping_one_session_is_one_candidate(self):
+        pm.PEERS["hub2"] = {"port": 13, "up": True}
+        pm.PEER_STATE["hub2"] = {"busId": "bus-JJJJ", "seenAt": int(time.time()), "presence": [
+            {"name": "farapp", "id": FAR_ID, "via": "farbox-alias", "viaBus": "bus-FFFF"},
+        ]}
+        host, agent = pm.peer_route("farapp")
+        self.assertIsNotNone(host, "one session seen along two relay paths is ONE candidate, not two")
+        self.assertEqual(agent.get("id"), FAR_ID)
+
+    def test_resolve_recipient_lands_direct_with_no_ambiguity_error(self):
+        pm.local_agents, saved = (lambda: []), pm.local_agents
+        try:
+            r = pm.resolve_recipient("web", frm_id=HUB_ID)
+        finally:
+            pm.local_agents = saved
+        self.assertEqual(r.get("kind"), "relay")
+        self.assertEqual(r.get("host"), "spokealias")
+
+
+class GossipCarriesIdentity(_Seeded):
+    def test_fleet_presence_rides_the_far_bus_id_on_via_rows(self):
+        pm.local_agents, saved = (lambda: []), pm.local_agents
+        try:
+            rows = pm.fleet_presence("asker")
+        finally:
+            pm.local_agents = saved
+        gossiped = [r for r in rows if r.get("via")]
+        self.assertTrue(gossiped)
+        for r in gossiped:
+            self.assertIn("viaBus", r)
+        by_via = {r["via"]: r for r in gossiped}
+        self.assertEqual(by_via["spokealias"]["viaBus"], "bus-AAAA")
+
+    def test_the_agents_list_wiring_folds_duplicates_too(self):
+        # the /agents handler is inline — pin its wiring; the folding behavior itself is
+        # exercised through via_reach/peer_route above (same _via_duplicate)
+        with open(os.path.join(BIN, "romp-postal-service")) as f:
+            src = f.read()
+        self.assertIn("if _via_duplicate(pa, direct_bus):", src)
+        self.assertIn("if sid and sid in listed:", src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The fold existed but keyed on the NICKNAME: `via_reach` skipped a gossiped spoke only when the hub's name for it matched our own `PEERS` key — and the same machine wears different ssh aliases on different hosts. So a box with a live direct link here was also listed "reachable via relay" under the hub's name for it, its sessions doubled in the agent list, addressing hit false ambiguity (two candidates for one session), and a pick could relay mail through the hub a direct link already covers.

- **Identity rides the gossip**: `fleet_presence` stamps each via row with the far bus's own id (`viaBus`) — the identity the peer exchange already proves (the same key `_canon_peer_name` folds direct aliases with), immune to nickname drift.
- **One shared test** (`_via_duplicate`: bus id first, name for hubs predating the field) folds duplicates at every consumer: `via_reach` (the popover's relay rows — both copies read it), `peer_route` (no false ambiguity; the direct row always carries the mail; one session seen along two relay paths is one candidate), and `/agents` (the doubled `[remote]` rows).
- A genuine far spoke — no direct link — keeps presenting and routing via relay, unchanged.

Tests: `tests/test_postal_via_dedupe.py` (the differing-nickname fold, the genuine-spoke keep, the old-hub name fallback, direct-wins routing, two-hub single-candidate, gossip identity). Full suite 4322 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)