### PR TITLE
The Analyzing… swirl lights while a judge call for the session is in flight

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14036,6 +14036,7 @@ def build_feed(now, tmux=None):
     wmap = _wait_for_graph(now, {s["sid"] for s in alive})   # per-session 'waiting on a live peer' (the user 2026-06-22)
     _stalls = _stalled_goals()                       # goals romp's nudge gate is holding → the card's Stalled section
     _jauth_map = jd._auth_down_map()                 # judge-auth-down latch → the per-session card floor below
+    _jactive = {r.get("fsid") for r in jd.active_runs()}   # judge calls in flight NOW → the Analyzing… prong
     cold_parse = False                               # any living session not yet parsed → warm it in the background
     for s in alive:
         fsid, name = s["sid"], s["name"]
@@ -14080,13 +14081,24 @@ def build_feed(now, tmux=None):
         sess_retrying = _session_retrying(fsid, tm)
         store = _feed_goals(fsid)                # pre-pass snapshot while a judge pass is mid-flight → the card's
                                                  # status never shows a half-applied intermediate (atomic visibility)
-        # ANALYZING gap (the user 2026-07-13): the turn just SETTLED but the closer hasn't delivered its
-        # verdict yet — without this the card sits inertly in Working after the session finished, until the
-        # judge's pass lands. Session-scoped (we don't know WHICH goal the turn resolved until the verdict);
-        # each working card wears the Analyzing… swirl meanwhile (feed.ts spinCaption). Cache-warm only,
-        # like the working dot: a cold start paints plain and the swirl snaps in after _warm_fleet_bg.
-        sess_judging = bool(live and ps and not who_working
-                            and _closer_pending(fsid, s["path"], now, store))
+        # ANALYZING (the user 2026-07-13; broadened 2026-08-12): the card must say when romp is working
+        # on it. Two prongs, either lights the swirl:
+        #   * the SETTLE GAP — the turn just settled but the closer hasn't delivered its verdict yet
+        #     (cache-warm only: it needs the parse; the swirl snaps in after _warm_fleet_bg);
+        #   * a judge call for this session ACTUALLY IN FLIGHT — jd.active_runs(), the same in-process
+        #     registry the nudge gate trusts (_revivers_pending), whose comment always claimed "the
+        #     Analyzing… swirl already says so"; now it does. This is what a backlog drain looks like:
+        #     when the judge-auth outage healed, 201 calls swept an 18-hour backlog while every card
+        #     sat inertly in Working (the user 2026-08-12, who asked for the queue to be visible on
+        #     the card) — planner/grouper work on OLDER turns never trips the settle gap, and a fresh
+        #     kernel's caches are cold exactly when the drain runs, so the closer prong alone stayed
+        #     dark. The active prong deliberately needs neither `live` nor a warm parse: the registry
+        #     is an in-process fact, free to read.
+        # Session-scoped (we don't know WHICH goal a verdict will land on until it does); each working
+        # card wears the Analyzing… swirl meanwhile (feed.ts spinCaption).
+        sess_judging = bool(not who_working
+                            and (fsid in _jactive
+                                 or (live and ps and _closer_pending(fsid, s["path"], now, store))))
         nodes, status = store.get("nodes", {}), store.get("status", {})
         confirming = set(store.get("confirming") or ())   # rollup export: done verdict in, settle pending (judge rollup_status, the user 2026-07-24)
         # Exact click-to-jump anchors: map each goal segment → the work/reply uuid — the SAME anchors the

--- a/tests/test_kernel_judging_active.py
+++ b/tests/test_kernel_judging_active.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""The Analyzing… swirl covers a judge call actually in flight (the user 2026-08-12).
+
+The incident: when the judge-auth outage healed, the pipeline swept an 18-hour backlog — 201
+successful calls in minutes — while every card sat inertly in Working. Two blind spots, both
+pinned here:
+  * the swirl's only trigger was the SETTLE GAP (latest turn settled, closer verdict pending),
+    which planner/grouper work on OLDER turns never trips;
+  * that trigger is cache-warm-only by design, and a fresh kernel's parse caches are cold at
+    exactly the moment a drain runs (the restart that healed the outage is the restart that
+    emptied the caches).
+So build_feed now lights the swirl from jd.active_runs() too — the in-process registry of judge
+calls in flight, the same authority the nudge gate trusts (_revivers_pending, whose comment
+always claimed the swirl covered this) — needing neither a live pane nor a warm parse.
+
+The registry round-trip runs for real; the build_feed wiring is pinned by source, the build_feed
+test pattern (see test_kernel_apierror_working.py).
+"""
+import inspect
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+jd = SourceFileLoader("romp_judge_jactive", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_jactive", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class ActiveRegistryRoundTrip(unittest.TestCase):
+    def test_a_call_is_visible_with_its_session_while_in_flight_and_gone_after(self):
+        rid = jd._active_begin("planner", SID, 123.0)
+        try:
+            self.assertIn(SID, {r.get("fsid") for r in jd.active_runs()},
+                          "an in-flight call names its session — the Analyzing… prong reads exactly this")
+        finally:
+            jd._active_end(rid)
+        self.assertNotIn(SID, {r.get("fsid") for r in jd.active_runs()},
+                         "deregistered in a finally — the swirl can never outlive the call")
+
+
+class BuildFeedWiring(unittest.TestCase):
+    def test_the_feed_reads_the_registry_once_per_build(self):
+        src = inspect.getsource(km.build_feed)
+        self.assertIn('_jactive = {r.get("fsid") for r in jd.active_runs()}', src)
+
+    def test_either_prong_lights_the_swirl_and_the_active_prong_needs_no_warm_parse(self):
+        src = inspect.getsource(km.build_feed)
+        # the active prong stands alone — no `live`, no `ps`: a fresh kernel's caches are cold at
+        # exactly the moment a backlog drain runs, and the registry is an in-process fact
+        self.assertIn("sess_judging = bool(not who_working", src)
+        self.assertIn("and (fsid in _jactive", src)
+        # the settle-gap prong keeps its cache-warm gates — it needs the parse
+        self.assertIn('or (live and ps and _closer_pending(fsid, s["path"], now, store))', src)
+
+    def test_an_open_turn_still_reads_working_not_analyzing(self):
+        # who_working guards BOTH prongs: a session actively mid-turn is Working — a captioner call
+        # running beside an open turn must not re-dress the card as Analyzing…
+        src = inspect.getsource(km.build_feed)
+        self.assertIn("bool(not who_working\n", src)
+
+    def test_the_card_key_is_unchanged(self):
+        # feed.ts + spin-caption.ts key on `judging` as before — the kernel broadened WHEN it is
+        # true, not the contract
+        self.assertIn('"judging": bool(sess_judging and column == "working")',
+                      inspect.getsource(km.build_feed))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When the judge-auth outage healed (#305), the pipeline swept an 18-hour backlog — 201 successful calls in minutes — while every card sat inertly in Working. The user asked for queued/undergoing analysis to be visible on the card.

Two blind spots in the existing "Analyzing…" swirl:
- its only trigger was the **settle gap** (latest turn settled, closer verdict pending) — planner/grouper work on *older* turns never trips it;
- that trigger is **cache-warm-only** by design, and a fresh kernel's parse caches are cold at exactly the moment a drain runs (the restart that heals an outage is the restart that empties them).

`build_feed` now lights the swirl from `jd.active_runs()` too — the in-process registry of judge calls in flight, per session, the same authority the nudge gate already trusts (`_revivers_pending`, whose comment always claimed the swirl covered this; now it does). The active prong needs neither a live pane nor a warm parse; the settle-gap prong keeps its gates; `who_working` still guards both so an open turn reads Working, never re-dressed by a captioner call running beside it. The card contract (`judging`) is unchanged.

Tests: `tests/test_kernel_judging_active.py` — the registry round-trip runs for real; the build_feed wiring is pinned by source (the build_feed test pattern). Full pytest suite green locally (4316 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)