### PR TITLE
Judge-tier settings follow to every linked kernel

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16910,6 +16910,48 @@ def _set_judge_effort(v): _set_judge_state("judge-effort", v, _EFFORT_VALUES, al
 def _set_index_effort(v): _set_judge_state("index-effort", v, _EFFORT_VALUES, allow_empty=True)
 
 
+# The four judge-tier settings PROPAGATE: a pick made here follows to every linked kernel (the user
+# 2026-08-12, who set the triage model to a new family and wanted all machines on it — per-machine
+# judge tiers are a surprise, not a feature). The gear's WS ops apply locally and then fan out
+# (_propagate_judge_settings) to each up remote over its tunnel + its own serve token —
+# mirror_trust's transport and trust boundary: only the human holding the tokens can set another
+# machine's judges. The receiving kernel's /judge-settings route applies WITHOUT re-propagating, so
+# the machines converge in one hop from the machine the user touched and can never ping-pong. A
+# machine reachable only through a relay holds no admin path from here; it adopts when the pick is
+# made from (or forwarded via) the machine that owns its tunnel.
+
+_JUDGE_SETTING_FIELDS = (("judgeModel", _set_judge_model), ("indexModel", _set_index_model),
+                         ("judgeEffort", _set_judge_effort), ("indexEffort", _set_index_effort))
+
+
+def _apply_judge_settings(body):
+    """Apply any of the four judge-tier fields in `body` through the validated setters (garbage
+    never reaches the state files or `claude --model`), and answer with the CURRENT four values —
+    the ack shows what actually landed, since an invalid value is deliberately ignored."""
+    for key, setter in _JUDGE_SETTING_FIELDS:
+        if isinstance(body, dict) and key in body:
+            setter(str(body.get(key) or ""))
+    return {"ok": True, "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),
+            "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort()}
+
+
+def _propagate_judge_settings(body):
+    """Fan `body` (already applied locally) to every up linked kernel's /judge-settings — one call
+    per machine over its tunnel + its own token. Callers run this on a daemon thread: the pick
+    itself never blocks on the machines. A miss is LOUD (a machine that missed the pick would
+    silently run its judges on another model forever) but not retried — the next change re-fans,
+    and /judge-settings with {"propagate": true} re-syncs on demand."""
+    with _remotes_lock:
+        rows = [dict(r) for r in _remotes.values()
+                if r.get("status") == "up" and r.get("local_port") and r.get("token")]
+    for r in rows:
+        st, _j, err = _remote_kernel_call(r, "POST", "/judge-settings", body, timeout=8)
+        if err or st != 200:
+            sys.stderr.write("judge-settings: %s did not take the pick (%s) — its judges keep "
+                             "their old model/effort until the next change\n"
+                             % (r.get("host"), err or ("HTTP %s" % st)))
+
+
 def _reply(c, msg):
     """Send a one-shot reply to ONE client (no per-key dedup; for request/response like imgData)."""
     try:
@@ -22213,6 +22255,22 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(400, json.dumps({"ok": False, "error": "host required"}), "application/json")
                 ok, detail = _start_remote(host)
                 return self._send(200 if ok else 502, json.dumps({"ok": ok, "detail": detail}), "application/json")
+            if u.path == "/judge-settings":
+                # The judge-tier settings surface a peer kernel drives when a pick propagates —
+                # mirror_trust's trust boundary: only the human's own tunnels + tokens reach here.
+                # Applies via the validated setters, answers with the CURRENT four values.
+                # {"propagate": true} additionally fans the pick out from THIS machine (the manual /
+                # scripted re-sync); forwarded bodies never carry it, so propagation is one hop and
+                # can never ping-pong around the mesh.
+                try:
+                    body = json.loads(raw_body or b"{}")
+                except Exception:
+                    body = None
+                res = _apply_judge_settings(body if isinstance(body, dict) else {})
+                if isinstance(body, dict) and body.get("propagate"):
+                    fwd = {k: v for k, v in body.items() if k != "propagate"}
+                    threading.Thread(target=_propagate_judge_settings, args=(fwd,), daemon=True).start()
+                return self._send(200, json.dumps(res), "application/json")
             return self._send(404, "not found", "text/plain")
         except (BrokenPipeError, ConnectionResetError):
             pass
@@ -22686,12 +22744,20 @@ class Handler(BaseHTTPRequestHandler):
             _set_palette(str(msg["name"]))     # gear "Session colors" → remap the fleet onto the chosen set
         elif msg and msg.get("type") == "setJudgeModel" and msg.get("model"):
             _set_judge_model(str(msg["model"]))     # gear "Triage model" dropdown → the judge uses it next pass
+            threading.Thread(target=_propagate_judge_settings,   # …and every linked kernel's judges with it
+                             args=({"judgeModel": str(msg["model"])},), daemon=True).start()
         elif msg and msg.get("type") == "setIndexModel" and msg.get("model"):
             _set_index_model(str(msg["model"]))     # gear "Indexing model" dropdown
+            threading.Thread(target=_propagate_judge_settings,
+                             args=({"indexModel": str(msg["model"])},), daemon=True).start()
         elif msg and msg.get("type") == "setJudgeEffort":
             _set_judge_effort(str(msg.get("effort") or ""))   # gear "Triage effort" ("" = default/none)
+            threading.Thread(target=_propagate_judge_settings,
+                             args=({"judgeEffort": str(msg.get("effort") or "")},), daemon=True).start()
         elif msg and msg.get("type") == "setIndexEffort":
             _set_index_effort(str(msg.get("effort") or ""))   # gear "Indexing effort"
+            threading.Thread(target=_propagate_judge_settings,
+                             args=({"indexEffort": str(msg.get("effort") or "")},), daemon=True).start()
 
     def _ws(self):
         key = self.headers.get("Sec-WebSocket-Key")

--- a/tests/test_judge_settings_sync.py
+++ b/tests/test_judge_settings_sync.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Judge-tier settings follow to every linked kernel (the user 2026-08-12, who picked a new triage
+model and wanted all machines on it — per-machine judge tiers are a surprise, not a feature).
+
+Three pieces, each covered here:
+- POST /judge-settings: the settable surface a peer kernel drives — applies any of the four fields
+  through the EXISTING validated setters (_apply_judge_settings) and answers with the current
+  values, so an ignored invalid value is visible in the ack.
+- _propagate_judge_settings: the fan-out — one call per up linked kernel over its tunnel + its own
+  serve token (mirror_trust's transport and trust boundary), loud on a miss, never blocking the
+  pick (callers thread it).
+- One hop, never a loop: the gear's WS ops and the route's explicit {"propagate": true} fan out;
+  a FORWARDED body never carries the flag, so a receiving kernel applies and stops.
+
+Synthetic hosts and tokens; hermetic state dir; the transport is stubbed — no sockets.
+"""
+import contextlib
+import io
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_judgesync", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class ApplySettings(unittest.TestCase):
+    def setUp(self):
+        for f in ("judge-model", "index-model", "judge-effort", "index-effort"):
+            try:
+                (km.jd.STATE / f).unlink()
+            except OSError:
+                pass
+
+    def test_valid_fields_land_and_the_ack_reports_them(self):
+        res = km._apply_judge_settings({"judgeModel": "fable", "indexEffort": "low"})
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable")
+        self.assertEqual((km.jd.STATE / "index-effort").read_text(), "low")
+        self.assertEqual((res["judgeModel"], res["indexEffort"]), ("fable", "low"))
+        self.assertTrue(res["ok"])
+
+    def test_an_invalid_value_is_ignored_and_the_ack_shows_what_actually_holds(self):
+        km._apply_judge_settings({"judgeModel": "fable"})
+        res = km._apply_judge_settings({"judgeModel": "gpt-99"})
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable",
+                         "garbage never reaches `claude --model`")
+        self.assertEqual(res["judgeModel"], "fable")
+
+    def test_an_empty_effort_clears_back_to_default(self):
+        km._apply_judge_settings({"judgeEffort": "high"})
+        res = km._apply_judge_settings({"judgeEffort": ""})
+        self.assertEqual((km.jd.STATE / "judge-effort").read_text(), "")
+        self.assertEqual(res["judgeEffort"], "")
+
+    def test_fields_not_in_the_body_are_untouched(self):
+        km._apply_judge_settings({"judgeModel": "fable"})
+        km._apply_judge_settings({"indexModel": "haiku"})
+        self.assertEqual((km.jd.STATE / "judge-model").read_text(), "fable")
+
+
+class PropagateFansOut(unittest.TestCase):
+    def setUp(self):
+        self._rkc = km._remote_kernel_call
+        self._rem = dict(km._remotes)
+        km._remotes.clear()
+        km._remotes.update({
+            "boxup":    {"host": "boxup", "status": "up", "local_port": 1, "token": "t1"},
+            "boxdown":  {"host": "boxdown", "status": "down", "local_port": 2, "token": "t2"},
+            "boxnotok": {"host": "boxnotok", "status": "up", "local_port": 3, "token": ""},
+        })
+        self.calls = []
+
+    def tearDown(self):
+        km._remote_kernel_call = self._rkc
+        km._remotes.clear()
+        km._remotes.update(self._rem)
+
+    def test_every_up_kernel_with_an_admin_path_gets_the_pick(self):
+        km._remote_kernel_call = lambda r, m, p, payload=None, timeout=8: (
+            self.calls.append((r["host"], m, p, payload)) or (200, {"ok": True}, None))
+        km._propagate_judge_settings({"judgeModel": "fable"})
+        self.assertEqual(self.calls, [("boxup", "POST", "/judge-settings", {"judgeModel": "fable"})],
+                         "up + token only; a down row or one with no token is not an admin path")
+
+    def test_a_miss_is_loud_and_names_the_machine(self):
+        km._remote_kernel_call = lambda *a, **k: (None, None, "could not reach boxup's kernel: boom")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            km._propagate_judge_settings({"judgeModel": "fable"})
+        self.assertIn("boxup", err.getvalue())
+        self.assertIn("did not take the pick", err.getvalue())
+
+
+class OneHopNeverALoop(unittest.TestCase):
+    """The wiring is inline (WS handlers + the route) — pinned at the source; the behaviors the
+    pins delegate to are tested above."""
+
+    def setUp(self):
+        with open(os.path.join(BIN, "romp-kernel")) as f:
+            self.src = f.read()
+
+    def test_the_route_exists_and_only_fans_out_on_the_explicit_flag(self):
+        self.assertIn('if u.path == "/judge-settings":', self.src)
+        self.assertIn('if isinstance(body, dict) and body.get("propagate"):', self.src)
+        self.assertIn('fwd = {k: v for k, v in body.items() if k != "propagate"}', self.src,
+                      "a forwarded body never carries the flag — one hop, never a mesh loop")
+
+    def test_every_gear_op_propagates_its_own_field(self):
+        for frag in ('args=({"judgeModel": str(msg["model"])},)',
+                     'args=({"indexModel": str(msg["model"])},)',
+                     'args=({"judgeEffort": str(msg.get("effort") or "")},)',
+                     'args=({"indexEffort": str(msg.get("effort") or "")},)'):
+            self.assertIn(frag, self.src, frag)
+
+    def test_the_gear_copy_says_the_pick_follows(self):
+        with open(os.path.join(os.path.dirname(HERE), "ui", "webview", "gear.js")) as f:
+            gear = f.read()
+        self.assertGreaterEqual(gear.count("connected machine's kernel"), 4,
+                                "all four judge rows say the pick follows to the other machines")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -69,10 +69,10 @@ var GEAR_HTML =
   '<option value=sdk>SDK</option><option value=tmux>tmux (terminal)</option>' +
   '</select></span></div>' +
   '<div class=rs-sec>Judges</div>' +
-  "<div class='rs-row rs-jrow'><b>Triage model</b><span class=rs-sub>The model the triage judges use — planner, grouper, closer, distiller, courier (the judgment-heavy tier). Applies on the judges' next pass; no restart.</span><select id=rs-judgemodel></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Triage effort</b><span class=rs-sub>Thinking effort for the triage judges. Default = no effort flag (the judges' standard behavior). Not every model accepts every level.</span><select id=rs-judgeeffort></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Indexing model</b><span class=rs-sub>The model the indexing judges use — captioner + archiver (high-volume, low-stakes summarization). Haiku by default for cost.</span><select id=rs-indexmodel></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Indexing effort</b><span class=rs-sub>Thinking effort for the indexing judges. Default = none (indexing runs with thinking disabled as a cost lever; leave Default unless you know you want it).</span><select id=rs-indexeffort></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Triage model</b><span class=rs-sub>The model the triage judges use — planner, grouper, closer, distiller, courier (the judgment-heavy tier). Applies on the judges' next pass; no restart. A pick here follows to every connected machine's kernel.</span><select id=rs-judgemodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Triage effort</b><span class=rs-sub>Thinking effort for the triage judges. Default = no effort flag (the judges' standard behavior). Not every model accepts every level. Follows to every connected machine's kernel.</span><select id=rs-judgeeffort></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Indexing model</b><span class=rs-sub>The model the indexing judges use — captioner + archiver (high-volume, low-stakes summarization). Haiku by default for cost. Follows to every connected machine's kernel.</span><select id=rs-indexmodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Indexing effort</b><span class=rs-sub>Thinking effort for the indexing judges. Default = none (indexing runs with thinking disabled as a cost lever; leave Default unless you know you want it). Follows to every connected machine's kernel.</span><select id=rs-indexeffort></select></div>" +
   '<div class=rs-sec>Keyboard shortcuts</div>' + SHORTCUT_ROWS +
   '<div class=rs-sec>Chat</div>' +
   '<label class=rs-row><input type=checkbox id=rs-compact>' +


### PR DESCRIPTION
The gear's four judge settings (triage/indexing model + effort) were per-machine: the pick landed only on the kernel the dashboard was talking to, and every other machine's judges silently kept their old model.

- **POST /judge-settings** — the settable surface a peer kernel drives: any of the four fields through the existing validated setters (garbage still never reaches `claude --model`), answering with the current values so an ignored invalid value is visible in the ack. `{"propagate": true}` fans out from the receiving machine (manual re-sync).
- **The gear WS ops propagate**: apply locally, then fan the field to every up linked kernel over its tunnel + its own serve token (mirror_trust's transport and trust boundary), daemon-threaded so the pick never blocks. A miss is loud (stderr names the machine); the next change re-fans.
- **One hop, never a loop**: forwarded bodies never carry the flag — a receiving kernel applies and stops. A relay-only machine adopts when the pick is made from (or via) the machine that owns its tunnel.
- The gear rows say it: "A pick here follows to every connected machine's kernel."

Tests: `tests/test_judge_settings_sync.py` (apply/validate/ack, fan-out targeting + loud miss, one-hop pins, gear copy); the existing `test_kernel_judge_model.py` chain is untouched and green. Suites: 4336 Python / 1864 extension, typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)