### PR TITLE
Slash-command descriptions wrap instead of ellipsizing

### DIFF
--- a/ui/webview/slash-commands.test.ts
+++ b/ui/webview/slash-commands.test.ts
@@ -74,6 +74,14 @@ test("the popup + selected-row accent + loader spin are styled", () => {
   assert.match(CSS, /@media \(prefers-reduced-motion: reduce\) \{ \.slash-spin \{ animation: none; \} \}/);
 });
 
+test("descriptions WRAP — the whole line is readable, never ellipsized (the user 2026-08-12)", () => {
+  // the popup is pinned to the composer's width (positionSlash), so wrapping grows the row, not the menu
+  const desc = CSS.match(/\.slash-desc \{[\s\S]*?\}/)?.[0] ?? "";
+  assert.ok(desc, "styles.css must style .slash-desc");
+  assert.doesNotMatch(desc, /nowrap|ellipsis/);
+  assert.match(desc, /overflow-wrap: break-word/);
+});
+
 test("the composer placeholder hints that / opens commands (the user 2026-06-30)", () => {
   // the resting placeholder now comes from composerRestingPlaceholder(); its DESKTOP form keeps the "type /
   // for commands" hint (mobile drops the ⏎/⇧⏎ part — see the composer-send mobile test)

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -580,7 +580,9 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .slash-row.sel .slash-name, .slash-row.sel .slash-desc, .slash-row.sel .slash-arg { color: var(--accent-fg); }
 .slash-name { flex: 0 0 auto; font-weight: 650; color: var(--fg); white-space: nowrap; }
 .slash-arg { font-weight: 400; opacity: 0.7; font-style: italic; }
-.slash-desc { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+.slash-desc { flex: 1 1 auto; min-width: 0; overflow-wrap: break-word;   /* wraps — the whole description
+  is readable, never ellipsized (the user 2026-08-12); the popup is pinned to the composer's width, so
+  wrapping grows the row, not the menu */
   color: var(--vscode-descriptionForeground, #9a9a9a); }
 .slash-empty, .slash-loading { padding: 8px 10px; color: var(--vscode-descriptionForeground, #9a9a9a);
   display: flex; align-items: center; gap: 8px; }


### PR DESCRIPTION
The autocomplete popup is pinned to the composer's width, so a long description (e.g. /loop's) was cut off with no way to read the rest. Wrapping grows the row, not the menu. Pinned by a new source-level test in `slash-commands.test.ts`.

Held un-merged until `v0.8.0` is tagged so it doesn't slip into the release mid-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)