### PR TITLE
The keyboard-up picker fold keeps the create controls; the resume list is what gives way

### DIFF
--- a/ui/webview/picker-keyboard.test.ts
+++ b/ui/webview/picker-keyboard.test.ts
@@ -3,11 +3,11 @@
 // lifted chat iframe to the VISIBLE height (--app-h ← the top-level visualViewport, pinned in
 // tests/test_kernel.py + test_shell_viewport_fit.py), so the keyboard opening/closing lands in the
 // iframe as its own resize event — render.ts keys the kb-tight fold on exactly that, no timers, no UA
-// sniffing. Folded: the advanced create rows (dir, backend, billing, host) hide, and the essentials
-// rearrange for the keyboard (the user 2026-08-12, after the resume list moved to the dialog's
-// bottom): the list flexes to fill the middle directly under the name box, and the actions row pins
-// to the box's bottom edge, right above the keyboard. The same resize expands it all back.
-// Source-level pins (no jsdom for the renderer).
+// sniffing. What folds (the user 2026-08-12, revising two earlier folds that each hid the wrong
+// half): the keyboard is up because a new session's NAME is being typed, so every create control —
+// name, directory, backend, billing, host, Create — stays on screen, and the resume list (the
+// occasional alternative, already scrollable) collapses to the leftover height. The same resize
+// expands the list back. Source-level pins (no jsdom for the renderer).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -23,34 +23,30 @@ test("the fold is keyed on this window's own resize event", () => {
   assert.match(RENDER, /kbFit\(\);/);   // synced at build too, not only on the first resize
 });
 
-test("kb-tight folds the advanced create rows and keeps the essentials", () => {
-  // the advanced rows fold — !important because pick-mode / auth availability drive these rows'
-  // visibility via inline styles, and the fold must win while it holds
-  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-dir,\s*\n\.picker-overlay\.kb-tight \.picker-backend \{ display: none !important; \}/);
-  // the essentials never fold: no display rule hides actions, list, or search while kb-tight holds
-  assert.doesNotMatch(CSS, /kb-tight \.picker-actions \{[^}]*display/);
-  assert.doesNotMatch(CSS, /kb-tight \.picker-list \{[^}]*display/);
+test("kb-tight keeps every create control — the resume list is what gives way", () => {
+  // the 2026-08-10 fold hid dir/backend/billing/host, and the first revision of it inverted the
+  // column so the list filled the screen instead — both showed the wrong half (the user
+  // 2026-08-12). No kb-tight rule may hide a row or reorder the controls-first layout: the list,
+  // last in the column and scrollable, is the ONE element that shrinks, and it needs no rule to
+  // do it (an overflow container's flex min-height is zero)
+  assert.doesNotMatch(CSS, /kb-tight[^{}]*\{[^}]*display: none/);
+  assert.doesNotMatch(CSS, /kb-tight[^{}]*\{[^}]*\border\s*:/);   // \b: flex "order:", not "border:"
+  assert.doesNotMatch(CSS, /kb-tight \.picker-actions/);
+  // …but the list gives way to a FLOOR, not to nothing: when the control rows alone overflow the
+  // cap, a zero flex floor left a 0px scroller under a heading still promising the section — a
+  // dead-end (no row visible, scrollable, or clickable). One row stays; it scrolls within itself
+  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-list \{ min-height: 52px; \}/);
 });
 
 test("folded, the box hugs the short viewport instead of centering into the keyboard", () => {
-  // both contexts tighten to the same 12px frame — the fixed-height box below assumes exactly it,
-  // and the standalone overlay's 56px anchor would otherwise push the pinned actions row off-screen
+  // both contexts tighten to the same 12px frame — the standalone overlay's 56px anchor would
+  // otherwise push the bottom of the box off-screen
   assert.match(CSS, /#picker\.kb-tight,\s*\nbody\.picker-lifted > #picker\.kb-tight \{ align-items: flex-start; padding: 12px 16px; \}/);
-  // a FIXED height, not just a cap: the pinned actions row below the list must not shift as typing
-  // re-filters the list's height. dvh, not vh — standalone on a phone, vh is the LARGEST viewport
-  // while the fold keys on the current innerHeight, and the mismatch clipped the pinned actions row
-  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-box \{ height: calc\(100dvh - 24px\); max-height: calc\(100dvh - 24px\); \}/);
-});
-
-test("folded, the list fills the middle and the actions row pins to the bottom edge", () => {
-  // the tall layout is controls-first, list last (picker-order.test.ts); the short window inverts
-  // exactly that — the filtered matches sit directly under the name box being typed in, and the
-  // Create button holds still at the bottom, above the keyboard, where a thumb expects it
-  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-list \{ flex: 1 1 auto; min-height: 0; \}/);
-  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-actions \{ order: 1; \}/);
-  // with the create rows between them hidden, the heading sits directly under the name box — its
-  // border-top would double the search box's own border-bottom into a thick seam
-  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-alt-head \{ border-top: none; \}/);
+  // dvh, not vh — standalone on a phone, vh is the LARGEST viewport while the fold keys on the
+  // current innerHeight, and the mismatch clipped the bottom of the box behind the browser chrome.
+  // overflow-y:auto is the backstop for a window too short for even the control rows alone (a
+  // landscape phone): the box scrolls rather than the Create button becoming unreachable
+  assert.match(CSS, /\.picker-overlay\.kb-tight \.picker-box \{ max-height: calc\(100dvh - 24px\); overflow-y: auto; \}/);
 });
 
 test("the name box opts the phone keyboard out of predictions and autofill", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4786,11 +4786,12 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     // picker's lower rows sat behind it and nothing gave. The shell sizes this lifted iframe to the
     // VISIBLE height (--app-h ← the top-level visualViewport, which the keyboard shrinks), so the
     // keyboard opening/closing lands here as this window's own resize — the exact event to key on, no
-    // timers, no UA sniffing. Short window → kb-tight folds the advanced create rows (dir, backend,
-    // billing, host) and rearranges the essentials for the keyboard — the list flexes to fill the
-    // middle under the name box and the actions row pins to the bottom edge (styles.css, the user
-    // 2026-08-12); the same resize expands it all back the moment there is room again (a genuinely
-    // small screen folds too, which is the right call there as well).
+    // timers, no UA sniffing. Short window → kb-tight tightens the frame and lets the RESUME LIST
+    // give way (styles.css; the user 2026-08-12, after two folds that each hid the wrong half): the
+    // keyboard is up because a new session's name is being typed, so every create control stays on
+    // screen and the list collapses to the leftover height. The same resize expands the list back the
+    // moment there is room again (a genuinely small screen folds too, which is the right call there
+    // as well).
     const kbFit = () => document.getElementById("picker")?.classList.toggle("kb-tight", window.innerHeight < 480);
     window.addEventListener("resize", kbFit);
     kbFit();

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1834,37 +1834,32 @@ body.picker-lifted.pane-gone::before { display: none; }
 body.picker-lifted > #picker { align-items: flex-start; padding: 56px 16px 16px; }
 /* SHORT WINDOW (the on-screen keyboard is up — the shell's --app-h sizing turns that into this
    window's own height — or a genuinely small screen; render.ts toggles kb-tight on resize): the
-   ADVANCED create rows fold so the essentials share the height with the keyboard, and expand back on
-   the resize that restores the room (the user 2026-08-10, Chrome on a phone). !important: these rows'
-   visibility is otherwise driven by inline styles (pick-mode, auth availability), and the fold must
-   win while it holds.
-   Folded, the ESSENTIALS rearrange for the keyboard (the user 2026-08-12): with the resume list moved
-   to the dialog's bottom, the tall layout's order left the short window showing the name box, the
-   Create button, a heading — and one row of the list, the thing you type to filter. So while folded:
-   the box takes the WHOLE short viewport (a fixed height, so nothing below shifts as typing
-   re-filters the list), the list flexes to fill the middle directly under the name box, and the
-   actions row orders to the bottom edge — pinned still, right above the keyboard where a thumb
-   expects the button. The tall layout keeps its controls-first order; this reorder exists only while
-   the keyboard (or a genuinely small screen) makes the viewport the scarce thing. */
-/* BOTH contexts — lifted and standalone — tighten to the same 12px frame: the box below takes a
-   FIXED height of the viewport minus exactly that frame, so a context still wearing the tall 56px
-   anchor would push the bottom-pinned actions row off-screen. (The lifted selector must keep its
-   own line: the base lifted rule carries #picker, which outweighs a class-only override.) */
+   frame tightens and the RESUME LIST is what gives way (the user 2026-08-12, revising two earlier
+   folds that each hid the wrong half — 2026-08-10 hid the advanced create rows, then the first cut
+   of this rule let the list fill the screen instead). The keyboard is up because you are TYPING a
+   new session's name, so every create control — name, directory, backend, billing, host, Create —
+   stays on screen exactly as laid out; the list of previous sessions is the occasional alternative,
+   already shrinkable (it scrolls), and it collapses to whatever height is left. No row hides and
+   nothing reorders: the tall layout and the folded one differ only in frame and cap, so the resize
+   that restores the room changes nothing but how much list you see. */
+/* BOTH contexts — lifted and standalone — tighten to the same 12px frame: a context still wearing
+   the tall 56px anchor would push the bottom of the box off-screen. (The lifted selector must keep
+   its own line: the base lifted rule carries #picker, which outweighs a class-only override.) */
 #picker.kb-tight,
 body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 16px; }
-.picker-overlay.kb-tight .picker-dir,
-.picker-overlay.kb-tight .picker-backend { display: none !important; }
 /* dvh, not vh: lifted, the shell sizes this iframe to the visible height so the two agree, but
    STANDALONE on a phone 100vh is the largest viewport (URL bar collapsed) while the fold keys on
    the current innerHeight — a vh-sized box ran past the visible bottom by exactly the browser
-   chrome, clipping the bottom-pinned actions row this rule exists to keep on screen. dvh tracks
-   the real visible height in both contexts (the shell's own --app-h fallback unit). */
-.picker-overlay.kb-tight .picker-box { height: calc(100dvh - 24px); max-height: calc(100dvh - 24px); }
-.picker-overlay.kb-tight .picker-list { flex: 1 1 auto; min-height: 0; }
-.picker-overlay.kb-tight .picker-actions { order: 1; }
-/* the heading sits directly under the name box while folded (the create rows between them are
-   hidden), so its seam would double the search box's own border-bottom */
-.picker-overlay.kb-tight .picker-alt-head { border-top: none; }
+   chrome. dvh tracks the real visible height in both contexts (the shell's own --app-h fallback
+   unit). overflow-y:auto is the backstop for a window too short for even the control rows alone
+   (a landscape phone): the box scrolls rather than the Create button becoming unreachable. */
+.picker-overlay.kb-tight .picker-box { max-height: calc(100dvh - 24px); overflow-y: auto; }
+/* …the list gives way, but never to NOTHING. In the backstop geometry the control rows alone
+   overflow the cap, and the list — the only child with a zero flex floor — would resolve to 0px
+   while its "Or reopen…" heading still rendered: a labeled section with no way to see, scroll,
+   or click a single row (a dead-end, which a compact view must never be). One row's floor keeps
+   the resume path alive at every height; the list scrolls the rest within itself. */
+.picker-overlay.kb-tight .picker-list { min-height: 52px; }
 
 .picker-box {
   /* two thirds of the window, not a narrow column: it is a dialog over the whole dashboard now, and the


### PR DESCRIPTION
Bug report (2026-08-12, mobile): with the keyboard up, the new-session picker showed the previous-sessions list instead of the create controls.

The kb-tight fold was showing the wrong half — twice over. The 2026-08-10 fold hid the advanced create rows (dir, backend, billing, host); today's first revision inverted the column so the resume list filled the screen with Create pinned at the bottom. But the keyboard is up because a new session's *name* is being typed, so it's the create controls that must stay on screen; the previous-sessions list is the occasional alternative and should be the thing that gives way.

Folded now, no row hides and nothing reorders: the frame tightens to 12px, the box caps at `100dvh - 24px`, and the list — last in the column, already scrollable, the only flex child with a zero minimum — collapses to the leftover height with no rule needed. Two guardrails, both from adversarial review at real phone geometries: the box scrolls as a backstop when even the control rows alone overflow the cap (landscape phone), and the list keeps one row's floor (52px) so the resume section is never a heading over a 0px scroller — a dead-end a compact view must never be.

`picker-keyboard.test.ts` re-pins the fold: no kb-tight rule may hide a row or reorder the column, the dvh cap and scroll backstop hold, and the list floor stays. Node suite passes 1864/1864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)