### PR TITLE
Slash menu: one-line rows, → expands the selected command's full text

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8844,6 +8844,11 @@ function setupComposer() {
   // out, typing more of the same "/token" must NOT re-pop it — only deleting back past the "/" (slashQuery →
   // null) re-arms it. Latched here; set on Esc, cleared the moment the "/token" context is gone.
   let slashDismissed = false;
+  // The list is strictly one line per command; → on the selected row opens its FULL name + arg hint +
+  // description, wrapped, and ←/Esc return to the list (the user 2026-08-13, after /code-review's long arg
+  // hint squeezed a wrapping description into a one-letter-wide column). A mode, not a per-row bit: ↑/↓
+  // while expanded browse the full texts.
+  let slashExpanded = false;
   const loadCmds = (sid: string, then?: () => void) => {
     fetch(kernelUrl("/commands?sid=" + encodeURIComponent(sid)), { cache: "no-store" })
       .then((r) => r.json())
@@ -8871,7 +8876,7 @@ function setupComposer() {
       .sort((a, b) => b.best - a.best || a.c.name.localeCompare(b.c.name))
       .map((x) => x.c).slice(0, 60);
   };
-  const closeSlash = () => { if (pop) { pop.remove(); pop = null; } if (slashPoll) { clearTimeout(slashPoll); slashPoll = undefined; } };
+  const closeSlash = () => { if (pop) { pop.remove(); pop = null; } if (slashPoll) { clearTimeout(slashPoll); slashPoll = undefined; } slashExpanded = false; };
   const positionSlash = () => {
     if (!pop) return;
     const r = ta.getBoundingClientRect();
@@ -8902,15 +8907,23 @@ function setupComposer() {
       pop.appendChild(e); positionSlash(); return;
     }
     items.forEach((c, i) => {
-      const row = document.createElement("div"); row.className = "slash-row" + (i === sel ? " sel" : "");
+      const row = document.createElement("div");
+      row.className = "slash-row" + (i === sel ? " sel" : "") + (i === sel && slashExpanded ? " expanded" : "");
       const nm = document.createElement("span"); nm.className = "slash-name"; nm.textContent = "/" + c.name;
       if (c.argumentHint) { const a = document.createElement("span"); a.className = "slash-arg"; a.textContent = " " + c.argumentHint; nm.appendChild(a); }
       const ds = document.createElement("span"); ds.className = "slash-desc"; ds.textContent = c.description || "";
       row.append(nm, ds);
       row.addEventListener("mousedown", (ev) => { ev.preventDefault(); pickSlash(c); });   // mousedown keeps focus
-      row.addEventListener("mousemove", () => { if (sel !== i) { sel = i; paintSlash(); } });
+      // hover-select is frozen while expanded: the tall row re-flows heights under the cursor, and a repaint
+      // per crossed row would flap the expansion around; ↑/↓ still browse
+      row.addEventListener("mousemove", () => { if (!slashExpanded && sel !== i) { sel = i; paintSlash(); } });
       pop!.appendChild(row);
     });
+    // a dim one-line footer teaches the keys (the user 2026-08-13: the expand must be discoverable in place)
+    const hint = document.createElement("div"); hint.className = "slash-hint";
+    hint.textContent = slashExpanded ? "← back · ⏎ fill" : "→ full description · ⏎ fill";
+    hint.addEventListener("mousedown", (ev) => ev.preventDefault());   // not a row: a click must not blur/close
+    pop.appendChild(hint);
     positionSlash();
     (pop.querySelector(".slash-row.sel") as HTMLElement | null)?.scrollIntoView({ block: "nearest" });
   };
@@ -8932,7 +8945,18 @@ function setupComposer() {
     if (e.key === "ArrowDown") { e.preventDefault(); if (items.length) { sel = (sel + 1) % items.length; paintSlash(); } return true; }
     if (e.key === "ArrowUp") { e.preventDefault(); if (items.length) { sel = (sel - 1 + items.length) % items.length; paintSlash(); } return true; }
     if ((e.key === "Enter" || e.key === "Tab") && items.length) { e.preventDefault(); pickSlash(items[sel]); return true; }
-    if (e.key === "Escape") { e.preventDefault(); slashDismissed = true; closeSlash(); return true; }   // stays dismissed until the "/" is cleared
+    // → expands the selected row — but only with the caret at the END of the query, where the key has no
+    // text left to cross; anywhere else it stays an ordinary caret move. ← is consumed only while expanded.
+    if (e.key === "ArrowRight" && items.length && !slashExpanded
+        && ta.selectionStart === ta.value.length && ta.selectionEnd === ta.value.length) {
+      e.preventDefault(); slashExpanded = true; paintSlash(); return true;
+    }
+    if (e.key === "ArrowLeft" && slashExpanded) { e.preventDefault(); slashExpanded = false; paintSlash(); return true; }
+    if (e.key === "Escape") {
+      // Esc peels one layer: the full text first, then the menu (which stays dismissed until the "/" is cleared)
+      if (slashExpanded) { e.preventDefault(); slashExpanded = false; paintSlash(); return true; }
+      e.preventDefault(); slashDismissed = true; closeSlash(); return true;
+    }
     return false;
   };
   ta.addEventListener("focus", () => { if (slashSid !== (activeId || "")) loadCmds(activeId || ""); });   // pre-warm the cache before "/"

--- a/ui/webview/slash-commands.test.ts
+++ b/ui/webview/slash-commands.test.ts
@@ -38,7 +38,7 @@ test("the menu OWNS ↑/↓/⏎/Tab/Esc while open, so they don't send / leave t
   assert.match(RENDER, /if \(e\.key === "ArrowDown"\) \{ e\.preventDefault\(\); if \(items\.length\) \{ sel = \(sel \+ 1\) % items\.length/);
   assert.match(RENDER, /if \(e\.key === "ArrowUp"\)/);
   assert.match(RENDER, /if \(\(e\.key === "Enter" \|\| e\.key === "Tab"\) && items\.length\) \{ e\.preventDefault\(\); pickSlash\(items\[sel\]\); return true; \}/);
-  assert.match(RENDER, /if \(e\.key === "Escape"\) \{ e\.preventDefault\(\); slashDismissed = true; closeSlash\(\); return true; \}/);
+  assert.match(RENDER, /e\.preventDefault\(\); slashDismissed = true; closeSlash\(\); return true;/);   // Esc (list layer) dismisses
   // when the menu is closed, slashKey returns false so Enter still sends and Esc still leaves the box
   assert.match(RENDER, /const slashKey = \(e: KeyboardEvent\): boolean => \{\s*\n\s*if \(!pop\) return false;/);
 });
@@ -74,12 +74,39 @@ test("the popup + selected-row accent + loader spin are styled", () => {
   assert.match(CSS, /@media \(prefers-reduced-motion: reduce\) \{ \.slash-spin \{ animation: none; \} \}/);
 });
 
-test("descriptions WRAP — the whole line is readable, never ellipsized (the user 2026-08-12)", () => {
-  // the popup is pinned to the composer's width (positionSlash), so wrapping grows the row, not the menu
+test("rows are strictly ONE LINE: name capped + ellipsized, description ellipsized in the rest (the user 2026-08-13)", () => {
+  // the first cut let the description wrap in place; .slash-name never shrank, so /code-review's long arg
+  // hint squeezed the description to a one-letter-wide column hundreds of lines tall. The list is compact,
+  // and the full text lives behind → instead.
+  const name = CSS.match(/\.slash-name \{[\s\S]*?\}/)?.[0] ?? "";
   const desc = CSS.match(/\.slash-desc \{[\s\S]*?\}/)?.[0] ?? "";
-  assert.ok(desc, "styles.css must style .slash-desc");
-  assert.doesNotMatch(desc, /nowrap|ellipsis/);
-  assert.match(desc, /overflow-wrap: break-word/);
+  assert.match(name, /max-width: 68%/);
+  assert.match(name, /text-overflow: ellipsis/);
+  assert.match(desc, /white-space: nowrap/);
+  assert.match(desc, /text-overflow: ellipsis/);
+});
+
+test("→ expands the selected row to its full wrapped text; ←/Esc return to the list (the user 2026-08-13)", () => {
+  assert.match(RENDER, /let slashExpanded = false/);
+  // → only with the caret at the END of the query, so arrow-editing the "/token" still works
+  assert.match(RENDER, /e\.key === "ArrowRight" && items\.length && !slashExpanded\s*&& ta\.selectionStart === ta\.value\.length && ta\.selectionEnd === ta\.value\.length/);
+  assert.match(RENDER, /if \(e\.key === "ArrowLeft" && slashExpanded\) \{ e\.preventDefault\(\); slashExpanded = false; paintSlash\(\); return true; \}/);
+  // Esc peels one layer (full text → list → dismissed), and closing the menu resets the mode
+  assert.match(RENDER, /if \(slashExpanded\) \{ e\.preventDefault\(\); slashExpanded = false; paintSlash\(\); return true; \}/);
+  assert.match(RENDER, /slashExpanded = false; \};/);
+  // the expanded row stacks name over description, both wrapping at the popup's width
+  assert.match(RENDER, /i === sel && slashExpanded \? " expanded" : ""/);
+  assert.match(CSS, /\.slash-row\.expanded \{ display: block; \}/);
+  assert.match(CSS, /\.slash-row\.expanded \.slash-name, \.slash-row\.expanded \.slash-desc \{ display: block;[\s\S]*?white-space: normal/);
+  // hover-select is frozen while expanded (repaints re-flow heights under the cursor and would flap the mode)
+  assert.match(RENDER, /if \(!slashExpanded && sel !== i\)/);
+});
+
+test("a footer hint teaches the keys, in place, and follows the state (the user 2026-08-13)", () => {
+  assert.match(RENDER, /hint\.className = "slash-hint"/);
+  assert.match(RENDER, /slashExpanded \? "← back · ⏎ fill" : "→ full description · ⏎ fill"/);
+  assert.match(RENDER, /hint\.addEventListener\("mousedown", \(ev\) => ev\.preventDefault\(\)\)/);   // a click on it must not blur/close
+  assert.match(CSS, /\.slash-hint \{ padding: 4px 9px 2px; font-size: 0\.82em; opacity: 0\.6;/);   // menu sub-line size/opacity
 });
 
 test("the composer placeholder hints that / opens commands (the user 2026-06-30)", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -578,11 +578,23 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .slash-row { display: flex; align-items: baseline; gap: 9px; padding: 5px 9px; border-radius: 5px; cursor: pointer; }
 .slash-row.sel { background: var(--accent); }
 .slash-row.sel .slash-name, .slash-row.sel .slash-desc, .slash-row.sel .slash-arg { color: var(--accent-fg); }
-.slash-name { flex: 0 0 auto; font-weight: 650; color: var(--fg); white-space: nowrap; }
+/* One line per command, ALWAYS: the name+arg-hint keeps at most ~2/3 of the row and the description gets
+   the rest — both ellipsize, and → on the selected row shows the full text instead (the user 2026-08-13:
+   letting the description wrap in place meant /code-review's long arg hint squeezed it to a one-letter-wide
+   column hundreds of lines tall). */
+.slash-name { flex: 0 1 auto; min-width: 0; max-width: 68%; overflow: hidden; text-overflow: ellipsis;
+  font-weight: 650; color: var(--fg); white-space: nowrap; }
 .slash-arg { font-weight: 400; opacity: 0.7; font-style: italic; }
-.slash-desc { flex: 1 1 auto; min-width: 0; overflow-wrap: break-word;   /* wraps — the whole description
-  is readable, never ellipsized (the user 2026-08-12); the popup is pinned to the composer's width, so
-  wrapping grows the row, not the menu */
+.slash-desc { flex: 1 1 0; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  /* basis 0, not auto: with auto, the description's huge natural width out-weighs the name in shrink
+     arithmetic and truncates even a short arg hint; at 0 the name takes what it needs (to its cap) first */
+  color: var(--vscode-descriptionForeground, #9a9a9a); }
+/* the → expansion: name+args over the description, both wrapped in full at the popup's width */
+.slash-row.expanded { display: block; }
+.slash-row.expanded .slash-name, .slash-row.expanded .slash-desc { display: block; max-width: none;
+  overflow: visible; text-overflow: clip; white-space: normal; overflow-wrap: break-word; }
+.slash-row.expanded .slash-desc { margin-top: 2px; }
+.slash-hint { padding: 4px 9px 2px; font-size: 0.82em; opacity: 0.6;
   color: var(--vscode-descriptionForeground, #9a9a9a); }
 .slash-empty, .slash-loading { padding: 8px 10px; color: var(--vscode-descriptionForeground, #9a9a9a);
   display: flex; align-items: center; gap: 8px; }


### PR DESCRIPTION
Fixes the wrap regression from #313: a long arg hint (`/code-review`'s) squeezed the wrapping description into a one-letter-wide column. Rows are now strictly one line (name capped at ~2/3, both sides ellipsize); → with the caret at the end of the query expands the selected row to its full wrapped text, ←/Esc return, ↑/↓ browse while expanded, and a dim footer hint teaches the keys in place. Source-pin tests updated; rendering verified by headless screenshot of both states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)