### PR TITLE
Slash menu: key hints on the selected row, per-line args when expanded

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8876,6 +8876,14 @@ function setupComposer() {
       .sort((a, b) => b.best - a.best || a.c.name.localeCompare(b.c.name))
       .map((x) => x.c).slice(0, 60);
   };
+  // The expanded view lists a multi-group arg hint one bracketed group per line ("[--fix] [--comment]" →
+  // two lines) — but ONLY when the whole hint is bracketed groups; any free-form hint stays one line
+  // rather than being split by a guess.
+  const argLines = (hint: string): string[] => {
+    const groups = hint.match(/\[[^\]]*\]/g) || [];
+    const residue = hint.replace(/\[[^\]]*\]/g, "").trim();
+    return groups.length >= 2 && !residue ? groups : [hint.trim()];
+  };
   const closeSlash = () => { if (pop) { pop.remove(); pop = null; } if (slashPoll) { clearTimeout(slashPoll); slashPoll = undefined; } slashExpanded = false; };
   const positionSlash = () => {
     if (!pop) return;
@@ -8907,23 +8915,41 @@ function setupComposer() {
       pop.appendChild(e); positionSlash(); return;
     }
     items.forEach((c, i) => {
+      const expanded = i === sel && slashExpanded;
       const row = document.createElement("div");
-      row.className = "slash-row" + (i === sel ? " sel" : "") + (i === sel && slashExpanded ? " expanded" : "");
-      const nm = document.createElement("span"); nm.className = "slash-name"; nm.textContent = "/" + c.name;
-      if (c.argumentHint) { const a = document.createElement("span"); a.className = "slash-arg"; a.textContent = " " + c.argumentHint; nm.appendChild(a); }
-      const ds = document.createElement("span"); ds.className = "slash-desc"; ds.textContent = c.description || "";
-      row.append(nm, ds);
+      row.className = "slash-row" + (i === sel ? " sel" : "") + (expanded ? " expanded" : "");
+      if (expanded) {
+        // full text, stacked for reading: /name (+ the ← key hint), then each bracketed arg group on its
+        // own line, then the whole description (the user 2026-08-13, round 2: one wrapped soup was legal
+        // but not readable)
+        const head = document.createElement("div"); head.className = "slash-x-head";
+        const nm = document.createElement("span"); nm.className = "slash-name"; nm.textContent = "/" + c.name;
+        const k = document.createElement("span"); k.className = "slash-key-hint"; k.textContent = "← all commands";
+        head.append(nm, k);
+        row.appendChild(head);
+        if (c.argumentHint) {
+          const args = document.createElement("div"); args.className = "slash-x-args";
+          for (const g of argLines(c.argumentHint)) {
+            const a = document.createElement("div"); a.className = "slash-arg"; a.textContent = g; args.appendChild(a);
+          }
+          row.appendChild(args);
+        }
+        if (c.description) { const ds = document.createElement("div"); ds.className = "slash-desc"; ds.textContent = c.description; row.appendChild(ds); }
+      } else {
+        const nm = document.createElement("span"); nm.className = "slash-name"; nm.textContent = "/" + c.name;
+        if (c.argumentHint) { const a = document.createElement("span"); a.className = "slash-arg"; a.textContent = " " + c.argumentHint; nm.appendChild(a); }
+        const ds = document.createElement("span"); ds.className = "slash-desc"; ds.textContent = c.description || "";
+        row.append(nm, ds);
+        // the → key hint rides the SELECTED row itself — a popup-bottom footer sat below the fold of the
+        // scrolling list (the user 2026-08-13, round 2); the selected row is always scrolled into view
+        if (i === sel) { const k = document.createElement("span"); k.className = "slash-key-hint"; k.textContent = "→ expand"; row.appendChild(k); }
+      }
       row.addEventListener("mousedown", (ev) => { ev.preventDefault(); pickSlash(c); });   // mousedown keeps focus
       // hover-select is frozen while expanded: the tall row re-flows heights under the cursor, and a repaint
       // per crossed row would flap the expansion around; ↑/↓ still browse
       row.addEventListener("mousemove", () => { if (!slashExpanded && sel !== i) { sel = i; paintSlash(); } });
       pop!.appendChild(row);
     });
-    // a dim one-line footer teaches the keys (the user 2026-08-13: the expand must be discoverable in place)
-    const hint = document.createElement("div"); hint.className = "slash-hint";
-    hint.textContent = slashExpanded ? "← back · ⏎ fill" : "→ full description · ⏎ fill";
-    hint.addEventListener("mousedown", (ev) => ev.preventDefault());   // not a row: a click must not blur/close
-    pop.appendChild(hint);
     positionSlash();
     (pop.querySelector(".slash-row.sel") as HTMLElement | null)?.scrollIntoView({ block: "nearest" });
   };

--- a/ui/webview/slash-commands.test.ts
+++ b/ui/webview/slash-commands.test.ts
@@ -95,18 +95,37 @@ test("→ expands the selected row to its full wrapped text; ←/Esc return to t
   assert.match(RENDER, /if \(slashExpanded\) \{ e\.preventDefault\(\); slashExpanded = false; paintSlash\(\); return true; \}/);
   assert.match(RENDER, /slashExpanded = false; \};/);
   // the expanded row stacks name over description, both wrapping at the popup's width
-  assert.match(RENDER, /i === sel && slashExpanded \? " expanded" : ""/);
+  assert.match(RENDER, /const expanded = i === sel && slashExpanded;/);
+  assert.match(RENDER, /\(expanded \? " expanded" : ""\)/);
   assert.match(CSS, /\.slash-row\.expanded \{ display: block; \}/);
   assert.match(CSS, /\.slash-row\.expanded \.slash-name, \.slash-row\.expanded \.slash-desc \{ display: block;[\s\S]*?white-space: normal/);
   // hover-select is frozen while expanded (repaints re-flow heights under the cursor and would flap the mode)
   assert.match(RENDER, /if \(!slashExpanded && sel !== i\)/);
 });
 
-test("a footer hint teaches the keys, in place, and follows the state (the user 2026-08-13)", () => {
-  assert.match(RENDER, /hint\.className = "slash-hint"/);
-  assert.match(RENDER, /slashExpanded \? "← back · ⏎ fill" : "→ full description · ⏎ fill"/);
-  assert.match(RENDER, /hint\.addEventListener\("mousedown", \(ev\) => ev\.preventDefault\(\)\)/);   // a click on it must not blur/close
-  assert.match(CSS, /\.slash-hint \{ padding: 4px 9px 2px; font-size: 0\.82em; opacity: 0\.6;/);   // menu sub-line size/opacity
+test("the key hints ride the SELECTED row, never a below-the-fold footer (the user 2026-08-13, round 2)", () => {
+  // round 1 put the hint at the popup's bottom — with a long list it sat below the fold of the scrolling
+  // menu. The selected row is always scrolled into view, so the hint lives there, right-aligned and dim.
+  assert.doesNotMatch(RENDER, /slash-hint/);
+  assert.doesNotMatch(CSS, /\.slash-hint/);
+  assert.match(RENDER, /if \(i === sel\) \{ const k = document\.createElement\("span"\); k\.className = "slash-key-hint"; k\.textContent = "→ expand"; row\.appendChild\(k\); \}/);
+  assert.match(RENDER, /k\.textContent = "← all commands"/);
+  assert.match(CSS, /\.slash-key-hint \{ flex: 0 0 auto; margin-left: auto; font-size: 0\.82em; opacity: 0\.6;/);   // menu sub-line size/opacity
+  assert.match(CSS, /\.slash-row\.sel \.slash-key-hint \{ color: var\(--accent-fg\); \}/);   // legible on the accent row
+});
+
+test("the expanded view lists a multi-group arg hint one bracketed group per line (the user 2026-08-13, round 2)", () => {
+  // "[--fix] [--comment]" → two lines; a free-form hint (anything not wholly bracketed groups) stays ONE
+  // line rather than being split by a guess
+  assert.match(RENDER, /const argLines = \(hint: string\): string\[\] => \{/);
+  assert.match(RENDER, /const groups = hint\.match\(\/\\\[\[\^\\\]\]\*\\\]\/g\) \|\| \[\];/);
+  assert.match(RENDER, /return groups\.length >= 2 && !residue \? groups : \[hint\.trim\(\)\];/);
+  assert.match(RENDER, /args\.className = "slash-x-args"/);
+  assert.match(CSS, /\.slash-x-args \{ margin-top: 2px; padding-left: 12px; \}/);
+  assert.match(CSS, /\.slash-x-args \.slash-arg \{ display: block; white-space: normal;/);
+  // the expanded head keeps /name and the ← hint on one line
+  assert.match(RENDER, /head\.className = "slash-x-head"/);
+  assert.match(CSS, /\.slash-x-head \{ display: flex; align-items: baseline; gap: 9px; \}/);
 });
 
 test("the composer placeholder hints that / opens commands (the user 2026-06-30)", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -577,7 +577,8 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 }
 .slash-row { display: flex; align-items: baseline; gap: 9px; padding: 5px 9px; border-radius: 5px; cursor: pointer; }
 .slash-row.sel { background: var(--accent); }
-.slash-row.sel .slash-name, .slash-row.sel .slash-desc, .slash-row.sel .slash-arg { color: var(--accent-fg); }
+.slash-row.sel .slash-name, .slash-row.sel .slash-desc, .slash-row.sel .slash-arg,
+.slash-row.sel .slash-key-hint { color: var(--accent-fg); }
 /* One line per command, ALWAYS: the name+arg-hint keeps at most ~2/3 of the row and the description gets
    the rest — both ellipsize, and → on the selected row shows the full text instead (the user 2026-08-13:
    letting the description wrap in place meant /code-review's long arg hint squeezed it to a one-letter-wide
@@ -589,13 +590,19 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   /* basis 0, not auto: with auto, the description's huge natural width out-weighs the name in shrink
      arithmetic and truncates even a short arg hint; at 0 the name takes what it needs (to its cap) first */
   color: var(--vscode-descriptionForeground, #9a9a9a); }
-/* the → expansion: name+args over the description, both wrapped in full at the popup's width */
+/* The ←/→ key hints ride the SELECTED row (right-aligned), never a popup-bottom footer — a footer sat
+   below the fold of the scrolling list, and the selected row is always scrolled into view (the user
+   2026-08-13, round 2). Menu sub-line size/opacity. */
+.slash-key-hint { flex: 0 0 auto; margin-left: auto; font-size: 0.82em; opacity: 0.6; white-space: nowrap; }
+/* the → expansion, stacked for reading: /name + hint, one arg GROUP per line, then the full description */
 .slash-row.expanded { display: block; }
 .slash-row.expanded .slash-name, .slash-row.expanded .slash-desc { display: block; max-width: none;
   overflow: visible; text-overflow: clip; white-space: normal; overflow-wrap: break-word; }
 .slash-row.expanded .slash-desc { margin-top: 2px; }
-.slash-hint { padding: 4px 9px 2px; font-size: 0.82em; opacity: 0.6;
-  color: var(--vscode-descriptionForeground, #9a9a9a); }
+.slash-x-head { display: flex; align-items: baseline; gap: 9px; }
+.slash-x-head .slash-name { flex: 0 1 auto; min-width: 0; }
+.slash-x-args { margin-top: 2px; padding-left: 12px; }
+.slash-x-args .slash-arg { display: block; white-space: normal; overflow-wrap: break-word; }
 .slash-empty, .slash-loading { padding: 8px 10px; color: var(--vscode-descriptionForeground, #9a9a9a);
   display: flex; align-items: center; gap: 8px; }
 .slash-spin { display: inline-block; width: 13px; height: 13px; flex: 0 0 auto;


### PR DESCRIPTION
Follow-up to #315: the popup-bottom hint footer sat below the fold of the scrolling list. The ←/→ key hints now ride the selected row (always scrolled into view), right-aligned in the menu sub-line style; the expanded view stacks /name + hint, one bracketed arg group per line (free-form hints stay whole), then the full description. Source-pin tests updated; rendering verified by headless screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)