### PR TITLE
The session's real worktree surfaces, and detached HEAD stops posing as a branch

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11699,6 +11699,41 @@ def _tilde(p):
     return p
 
 
+def _norm_branch(br):
+    """Claude Code stamps the transcript's gitBranch verbatim — a detached checkout stamps the literal
+    string 'HEAD', which is not a branch and was displayed as one on every surface (the user 2026-08-13:
+    "HEAD isn't a branch"). The folder-derived path (_git_branch below) already maps detached to '' —
+    this applies the same rule to the transcript path, at the one merge point."""
+    br = (br or "").strip()
+    return "" if br == "HEAD" else br
+
+
+_tree_cache = {}   # dir -> git toplevel ("" = not a repo) — where a path's tree ROOT is; branch stays live
+
+
+def _tree_of(d):
+    """(toplevel, branch) of the git tree containing directory `d`, ("", "") when not in one. The toplevel
+    mapping is cached per directory (it changes only if the tree is moved/deleted — then the branch read
+    below comes back empty and every consumer hides the row); the branch rides _git_branch's own
+    HEAD-mtime cache so it stays current without a second discipline."""
+    if not d:
+        return "", ""
+    top = _tree_cache.get(d)
+    if top is None:
+        top = ""
+        try:
+            r = subprocess.run(["git", "-C", d, "rev-parse", "--show-toplevel"],
+                               capture_output=True, text=True, timeout=2)
+            if r.returncode == 0:
+                top = r.stdout.strip()
+        except Exception:
+            top = ""
+        if len(_tree_cache) > 512:                     # bounded: distinct edit dirs, not unbounded growth
+            _tree_cache.clear()
+        _tree_cache[d] = top
+    return top, (_git_branch(top) if top else "")
+
+
 _branch_cache = {}   # cwd -> (branch, head_mtime) — git branch derived straight from the FOLDER
 
 
@@ -11733,10 +11768,17 @@ def _git_branch(cwd):
     return br
 
 
+_EDIT_TOOLS = ("Edit", "Write", "MultiEdit", "NotebookEdit")   # tools whose file_path proves WHERE work lands
+
+
 def _session_meta(path):
-    """Latest cwd / gitBranch / Claude Code version / permission mode for a session, read straight from the
-    raw transcript (the event model drops these). Cached by (mtime,size) like _parse/_api_error, since
-    build_session runs per push."""
+    """Latest cwd / gitBranch / Claude Code version / permission mode / last EDITED file for a session, read
+    straight from the raw transcript (the event model drops these). Cached by (mtime,size) like
+    _parse/_api_error, since build_session runs per push. lastEditPath is the newest write-tool file_path —
+    the event that proves where the session actually works (repo convention puts real work on per-session
+    worktrees beside the registered clone, so the registered dir alone reads 'main' forever; the user
+    2026-08-13). Zero extra parsing: every assistant record already passes the line filter (each carries
+    cwd/version stamps), so this only walks content blocks of lines the loop was parsing anyway."""
     try:
         sti = os.stat(path)
         key = (sti.st_mtime, sti.st_size)
@@ -11745,7 +11787,7 @@ def _session_meta(path):
     hit = _session_meta_cache.get(path)
     if hit is not None and key is not None and hit[0] == key:
         return hit[1]
-    meta = {"cwd": "", "gitBranch": "", "version": "", "permissionMode": ""}
+    meta = {"cwd": "", "gitBranch": "", "version": "", "permissionMode": "", "lastEditPath": ""}
     try:
         with open(path, errors="replace") as f:
             for line in f:
@@ -11763,6 +11805,17 @@ def _session_meta(path):
                     meta["version"] = o["version"]
                 if o.get("type") == "user" and o.get("permissionMode"):
                     meta["permissionMode"] = o["permissionMode"]
+                if o.get("type") == "assistant":
+                    try:
+                        for blk in (o.get("message") or {}).get("content") or []:
+                            if (isinstance(blk, dict) and blk.get("type") == "tool_use"
+                                    and blk.get("name") in _EDIT_TOOLS):
+                                fp = (blk.get("input") or {}).get("file_path") or \
+                                     (blk.get("input") or {}).get("notebook_path")
+                                if isinstance(fp, str) and fp.startswith("/"):
+                                    meta["lastEditPath"] = fp
+                    except Exception:
+                        pass
     except OSError:
         pass
     if key is not None:
@@ -12979,10 +13032,23 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     meta = _session_meta(sess["path"])
     scwd = _cwd_of(sid) or meta.get("cwd") or ""    # the session's fixed dir — known even before the first turn
     docs = _claudemd_docs(meta.get("cwd") or scwd)
+    # The WORKTREE the session actually works in (the user 2026-08-13): the repo convention here puts real
+    # work on per-session worktrees beside the registered clone, so the registered dir's branch read 'main'
+    # forever and the real location showed nowhere. The newest write-tool file_path names the tree — the
+    # edit EVENT is the proof of where work happens (no declared source exists; the CLI doesn't know
+    # either) — and it latches until a newer edit lands elsewhere. Shown only when that tree differs from
+    # the registered dir's own: same-tree work needs no second row.
+    _wt_top, _wt_br = _tree_of(os.path.dirname(meta.get("lastEditPath") or "") or "")
+    _reg_top, _ = _tree_of(os.path.expanduser(scwd)) if scwd else ("", "")
+    work_tree = ({"dir": _tilde(_wt_top), "branch": _wt_br}
+                 if _wt_top and os.path.realpath(_wt_top) != os.path.realpath(_reg_top or "/nonexistent")
+                 else None)
     sysinfo = {"kind": "system", "model": last_model, "cwd": _tilde(meta.get("cwd") or scwd),
-               # branch from the transcript if present, else derived straight from the folder so it shows on
-               # open (the user 2026-06-24) — works for a never-run session of EITHER backend.
-               "gitBranch": meta.get("gitBranch") or _git_branch(scwd), "version": meta.get("version") or "",
+               # branch from the transcript if present (normalized: a detached stamp says 'HEAD', not a
+               # branch), else derived straight from the folder so it shows on open (the user 2026-06-24) —
+               # works for a never-run session of EITHER backend.
+               "gitBranch": _norm_branch(meta.get("gitBranch")) or _git_branch(scwd),
+               "workTree": work_tree, "version": meta.get("version") or "",
                "mode": meta.get("permissionMode") or "", "claudemd": docs}
     # The /clear boundary card (the user 2026-07-27): a session whose episodes log records ≥2 episodes had
     # its conversation cleared — the chat's fresh episode opens with a collapsed "Conversation cleared"
@@ -13012,6 +13078,8 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
             # system event (and its branch) fell off the wire and the branch vanished (the user 2026-06-30). A
             # top-level field is never windowed, so the branch is always resident.
             "gitBranch": sysinfo["gitBranch"],
+            # the detected worktree rides top-level for the same windowing reason as gitBranch above
+            "workTree": sysinfo["workTree"],
             "events": events, "status": status, "ledger": ledger,
             # SDK sessions gate the box on the backend's LIVE task set (the CLI's task lifecycle stream —
             # authoritative, terminal-cleared); the spawned_at heuristic remains the tmux/no-snapshot fallback.

--- a/tests/test_kernel_sysmeta.py
+++ b/tests/test_kernel_sysmeta.py
@@ -47,7 +47,8 @@ class SessionMeta(unittest.TestCase):
 
     def test_missing_file_is_empty_not_an_error(self):
         meta = km._session_meta("/no/such/transcript.jsonl")
-        self.assertEqual(meta, {"cwd": "", "gitBranch": "", "version": "", "permissionMode": ""})
+        self.assertEqual(meta, {"cwd": "", "gitBranch": "", "version": "", "permissionMode": "",
+                                "lastEditPath": ""})
 
     def test_cache_keys_on_mtime_size(self):
         with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:

--- a/tests/test_kernel_worktree_display.py
+++ b/tests/test_kernel_worktree_display.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""The session's REAL working location surfaces, and detached HEAD stops posing as a branch
+(the user 2026-08-13).
+
+Two audit findings, both pinned here:
+  * The branch shown above the chat / on the tab tooltip is a property of the session's REGISTERED
+    directory — by design (2026-06-24) — but the repo convention does real work on per-session
+    worktrees beside the registered clone, so every surface read 'main' forever and the actual
+    working location showed nowhere. The kernel now derives the WORKTREE from the newest write-tool
+    file_path in the transcript (the edit event is the proof of where work happens; no declared
+    source exists) and ships it only when that tree differs from the registered dir's own.
+  * The transcript's gitBranch stamp passes the literal string 'HEAD' through on a detached
+    checkout — "HEAD isn't a branch". The folder-derived path already normalized detached to '';
+    _norm_branch applies the same rule to the transcript path at the one merge point.
+
+Synthetic transcripts only (invented text, placeholder UUIDs); the git fixtures are throwaway tmp
+repos with fixture identities.
+"""
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_worktree", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _git(*args, cwd=None):
+    return subprocess.run(["git", "-c", "user.email=t@TESTHOST", "-c", "user.name=t", *args],
+                          cwd=cwd, capture_output=True, text=True, check=True)
+
+
+class NormBranch(unittest.TestCase):
+    def test_detached_head_is_not_a_branch(self):
+        self.assertEqual(km._norm_branch("HEAD"), "")
+        self.assertEqual(km._norm_branch(" HEAD "), "")
+
+    def test_real_branches_pass_through(self):
+        self.assertEqual(km._norm_branch("main"), "main")
+        self.assertEqual(km._norm_branch("feature/x"), "feature/x")
+        self.assertEqual(km._norm_branch(None), "")
+        self.assertEqual(km._norm_branch(""), "")
+
+
+class LastEditPath(unittest.TestCase):
+    def _transcript(self, rows):
+        d = tempfile.mkdtemp()
+        p = os.path.join(d, "t.jsonl")
+        with open(p, "w") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+        return p
+
+    def _arow(self, blocks):
+        return {"type": "assistant", "uuid": "11111111-2222-3333-4444-555555555555",
+                "cwd": "/home/u/proj", "version": "9.9.9",
+                "message": {"role": "assistant", "content": blocks}}
+
+    def test_the_newest_write_tool_path_wins_and_reads_ignore(self):
+        p = self._transcript([
+            self._arow([{"type": "tool_use", "name": "Edit", "input": {"file_path": "/w/a/one.py"}}]),
+            self._arow([{"type": "tool_use", "name": "Read", "input": {"file_path": "/elsewhere/x.py"}}]),
+            self._arow([{"type": "tool_use", "name": "Write", "input": {"file_path": "/w/b/two.py"}}]),
+        ])
+        meta = km._session_meta(p)
+        self.assertEqual(meta["lastEditPath"], "/w/b/two.py",
+                         "the newest EDIT event names the tree; a Read is not work landing anywhere")
+
+    def test_no_edits_no_path(self):
+        p = self._transcript([self._arow([{"type": "text", "text": "just words"}])])
+        self.assertEqual(km._session_meta(p)["lastEditPath"], "")
+
+
+class TreeOf(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.root = tempfile.mkdtemp()
+        cls.main = os.path.join(cls.root, "repo")
+        os.makedirs(cls.main)
+        _git("init", "-q", "-b", "main", cwd=cls.main)
+        open(os.path.join(cls.main, "f.txt"), "w").write("x\n")
+        _git("add", "f.txt", cwd=cls.main)
+        _git("commit", "-q", "-m", "seed", cwd=cls.main)
+        cls.wt = os.path.join(cls.root, "repo-feature")
+        _git("worktree", "add", "-q", "-b", "feature", cls.wt, "HEAD", cwd=cls.main)
+        os.makedirs(os.path.join(cls.wt, "sub"))
+
+    def test_a_worktree_path_resolves_to_its_own_tree_and_branch(self):
+        top, br = km._tree_of(os.path.join(self.wt, "sub"))
+        self.assertEqual(os.path.realpath(top), os.path.realpath(self.wt))
+        self.assertEqual(br, "feature")
+
+    def test_the_registered_clone_resolves_to_itself(self):
+        top, br = km._tree_of(self.main)
+        self.assertEqual(os.path.realpath(top), os.path.realpath(self.main))
+        self.assertEqual(br, "main")
+
+    def test_a_non_repo_dir_is_no_tree(self):
+        self.assertEqual(km._tree_of(tempfile.mkdtemp()), ("", ""))
+        self.assertEqual(km._tree_of(""), ("", ""))
+
+
+class PayloadWiring(unittest.TestCase):
+    """build_session's wiring, pinned by source (the build_* test pattern)."""
+
+    def test_the_worktree_ships_only_when_it_differs_from_the_registered_tree(self):
+        import inspect
+        src = inspect.getsource(km.build_session)
+        self.assertIn('_wt_top, _wt_br = _tree_of(os.path.dirname(meta.get("lastEditPath") or "") or "")', src)
+        self.assertIn('if _wt_top and os.path.realpath(_wt_top) != os.path.realpath(_reg_top or "/nonexistent")', src)
+        self.assertIn('"workTree": sysinfo["workTree"]', src, "top-level like gitBranch — never windowed off the wire")
+
+    def test_the_transcript_branch_is_normalized_at_the_merge_point(self):
+        import inspect
+        src = inspect.getsource(km.build_session)
+        self.assertIn('_norm_branch(meta.get("gitBranch")) or _git_branch(scwd)', src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_kernel.py
+++ b/tests/test_sdk_kernel.py
@@ -466,7 +466,7 @@ class SdkMetadataParity(unittest.TestCase):
         oor = src.split("def _open_or_revive", 1)[1].split("\ndef ", 1)[0]
         self.assertIn("be.connect(sid)", oor)
         # sysinfo branch falls back to the folder when the transcript lacks it
-        self.assertIn('meta.get("gitBranch") or _git_branch(scwd)', src)
+        self.assertIn('_norm_branch(meta.get("gitBranch")) or _git_branch(scwd)', src)   # detached 'HEAD' normalized at the merge point (the user 2026-08-13)
         # the SDK merge passes the backend's context-fill % through (was hardcoded None)
         self.assertIn('ctx = st.get("ctx")', src)
         self.assertIn("ctx if isinstance(ctx, (int, float)) else None", src)

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -191,7 +191,7 @@ type ChatEvent = (
   // Pinned, collapsed "system context" card at the top of the transcript (the user 2026-06-19): the
   // CLAUDE.md instructions in effect + session config. NOT the verbatim harness prompt — it's never
   // recorded, so it can't be shown (renderSystem says so). No ts/uuid → off the rail (no dot/hover).
-  | { kind: "system"; model?: string; cwd?: string; gitBranch?: string; version?: string; mode?: string;
+  | { kind: "system"; model?: string; cwd?: string; gitBranch?: string; workTree?: { dir: string; branch: string } | null; version?: string; mode?: string;
       claudemd?: { path: string; scope: string; text: string }[]; uuid?: string; ts?: string }
 ) & { tlId?: string };   // tlId: the timeline atom this event's hover lights — a prompt → the DOT, work → the BAR
 
@@ -209,7 +209,7 @@ interface BgTasks { count: number; tasks: BgTask[]; }
 // kernel ships only the last WIRE_TAIL events (headFrom > 0) to keep startup light; older history streams in
 // on scroll-back (loadOlder → chatHead prepends, lowering headFrom). headFrom 0 = the whole transcript is
 // resident. chatTail's `from` is GLOBAL and mapped through headFrom.
-interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; headFrom?: number; headTotal?: number; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; notify?: boolean; }
+interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; workTree?: { dir: string; branch: string } | null; headFrom?: number; headTotal?: number; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; notify?: boolean; }
 
 const vscodeApi =
   typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
@@ -1958,6 +1958,10 @@ function renderSystem(ev: Extract<ChatEvent, { kind: "system" }>): HTMLElement {
   if (ev.mode) rows.push(["Permission mode", ev.mode]);
   if (ev.cwd) rows.push(["Directory", ev.cwd]);
   if (ev.gitBranch) rows.push(["Git branch", ev.gitBranch]);
+  // where the work ACTUALLY lands (the user 2026-08-13): the repo convention here does real work on
+  // per-session worktrees beside the registered clone, so the Directory/branch rows alone read 'main'
+  // forever; the kernel derives this from the newest edit event and sends it only when it differs.
+  if (ev.workTree) rows.push(["Worktree", ev.workTree.dir + (ev.workTree.branch ? "  ⎇ " + ev.workTree.branch : "")]);
   if (ev.version) rows.push(["Claude Code", ev.version]);
   if (rows.length) {
     const grid = el("div", "sys-meta");
@@ -3341,11 +3345,15 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   tip.replaceChildren();
   const now = Date.now() / 1000;
   const be = s.status.backend;
-  if (s.cwd) { const d = el("div", "tab-tip-path"); d.textContent = s.cwd; tip.appendChild(d); }
-  // labelled rows: git branch (top-level session field, resident even when the head system event is windowed
-  // out of the wire tail — the user 2026-06-30) + mode / model / effort + backend
+  // labelled rows, one visual grammar (the user 2026-08-13): the directory is a ROW like the others —
+  // the 📁 glyph in the label slot, path right of it, aligned — not a naked line floating on top; the
+  // branch row wears the ⎇ glyph in its label slot for the same consistency. Branch is the top-level
+  // session field, resident even when the head system event is windowed out of the wire tail (the user
+  // 2026-06-30), and the worktree row shows where the work actually lands when that differs.
   const rows: Array<[string, string]> = [];
-  if (s.gitBranch) rows.push(["Branch", s.gitBranch]);
+  if (s.cwd) rows.push(["📁", s.cwd]);
+  if (s.gitBranch) rows.push(["⎇", s.gitBranch]);
+  if (s.workTree) rows.push(["Worktree", s.workTree.dir + (s.workTree.branch ? "  ⎇ " + s.workTree.branch : "")]);
   if (s.status.mode) rows.push(["Mode", prettyMode(s.status.mode)]);
   if (s.status.model) rows.push(["Model", s.status.model]);
   if (s.status.effort) rows.push(["Effort", s.status.effort]);
@@ -7405,10 +7413,11 @@ function updateStatusline() {
   // for narrow panes; it shipped on by default 2026-06-23). Read from the TOP-LEVEL session field,
   // never the head system event: that event is windowed out of the wire tail on any >250-event session, which
   // used to blank the branch on most sessions (the user 2026-06-30).
-  if (loadSettings().showBranch === true && s.gitBranch) {
+  if (loadSettings().showBranch === true && ((s.workTree && s.workTree.branch) || s.gitBranch)) {
     const br = el("span", "status-branch");
-    br.textContent = "⎇ " + s.gitBranch;
-    br.title = "git branch: " + s.gitBranch;
+    const liveBr = (s.workTree && s.workTree.branch) || s.gitBranch;
+    br.textContent = "⎇ " + liveBr;
+    br.title = s.workTree ? `worktree ${s.workTree.dir} — git branch: ${liveBr}` : "git branch: " + liveBr;
     right.appendChild(br);
   }
   const meta = el("span", "spinner-meta");
@@ -8053,6 +8062,7 @@ function upsert(msg: any) {
     // system event — that event lives at events[0] and the WIRE_TAIL window drops it on any >250-event session,
     // so the branch used to vanish there. A chatTail delta omits it → keep the last-known via prev.
     gitBranch: msg.gitBranch ?? (prev ? prev.gitBranch : ""),
+    workTree: msg.workTree ?? (prev ? prev.workTree : null),
     // A trimmed full send carries headFrom/headTotal; a whole-transcript send omits them (headFrom 0).
     headFrom: msg.headFrom ?? 0,
     headTotal: msg.headTotal ?? ((msg.events || (prev ? prev.events : [])).length),

--- a/ui/webview/statusline-branch.test.ts
+++ b/ui/webview/statusline-branch.test.ts
@@ -26,12 +26,15 @@ test("settings carry showBranch, defaulting OFF", () => {
 
 test("updateStatusline appends a status-branch span from the top-level gitBranch, gated on the setting", () => {
   // gated on the live setting (default-OFF: only an explicit true shows it) AND on a known branch
-  assert.match(RENDER, /loadSettings\(\)\.showBranch === true && s\.gitBranch/);
-  // reads the branch off the TOP-LEVEL session field, NOT the windowed head system event
-  assert.match(RENDER, /br\.textContent = "⎇ " \+ s\.gitBranch/);
+  assert.match(RENDER, /loadSettings\(\)\.showBranch === true && \(\(s\.workTree && s\.workTree\.branch\) \|\| s\.gitBranch\)/);
+  // reads the branch off the TOP-LEVEL session fields, NOT the windowed head system event — preferring
+  // the WORKTREE the session actually works in over the registered dir's branch (the user 2026-08-13)
+  assert.match(RENDER, /const liveBr = \(s\.workTree && s\.workTree\.branch\) \|\| s\.gitBranch/);
+  assert.match(RENDER, /br\.textContent = "⎇ " \+ liveBr/);
   assert.match(RENDER, /el\("span", "status-branch"\)/);
   // upsert carries the top-level field, falling back to the last-known on a chatTail delta that omits it
   assert.match(RENDER, /gitBranch: msg\.gitBranch \?\? \(prev \? prev\.gitBranch : ""\)/);
+  assert.match(RENDER, /workTree: msg\.workTree \?\? \(prev \? prev\.workTree : null\)/);
 });
 
 test("the branch span sits right after the dir, before the meta cluster", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -280,7 +280,6 @@ body { display: flex; flex-direction: column; }
      positioner (render.ts) clamps it to a small left margin once it's this wide; short tips stay content-sized. */
   max-width: calc(100vw - 12px);
 }
-.tab-tip-path { color: var(--dim); word-break: break-all; margin-bottom: 4px; }
 .tab-tip-row { display: flex; gap: 8px; align-items: baseline; }   /* baseline so a wrapping Summary/Latest value aligns to its label */
 .tab-tip-ctx { margin: 4px 0; align-items: center; }   /* the context battery is tall → give it vertical breathing room */
 .tab-tip-k { color: var(--dim); flex: 0 0 auto; min-width: 58px; }

--- a/ui/webview/tab-backend-tooltip.test.ts
+++ b/ui/webview/tab-backend-tooltip.test.ts
@@ -31,7 +31,7 @@ test("backend is a plain labelled FIELD ROW under the others — no coloured top
 });
 
 test("v4: git branch + context battery + Summary row + the last 5 worked-on items, recency-coloured (the user 2026-06-24)", () => {
-  assert.match(RENDER, /rows\.push\(\["Branch", s\.gitBranch\]\)/);                   // git branch from the top-level session field (resident even when the head system event is windowed out — the user 2026-06-30)
+  assert.match(RENDER, /rows\.push\(\["⎇", s\.gitBranch\]\)/);                       // git branch from the top-level session field (resident even when the head system event is windowed out — the user 2026-06-30); the ⎇ glyph IS the label now (the user 2026-08-13)
   assert.match(RENDER, /const bar = ctxBar\(\); setCtxBar\(bar, s\.status\.ctx/);     // the battery widget, not "X%"
   assert.match(RENDER, /const lg = ledgers\.get\(s\.id\)/);
   assert.match(RENDER, /k\.textContent = "Summary"[\s\S]*?v\.textContent = lg\.summary/);   // labelled Summary row
@@ -75,8 +75,14 @@ test("the tall context battery gets vertical breathing room", () => {
   assert.match(CSS, /\.tab-tip-ctx \{ margin: 4px 0/);
 });
 
-test("the tooltip still shows the full path + mode/model/effort", () => {
-  assert.match(RENDER, /el\("div", "tab-tip-path"\); d\.textContent = s\.cwd/);
+test("the tooltip still shows the full path + mode/model/effort — path and branch as aligned icon rows", () => {
+  // one visual grammar (the user 2026-08-13): the directory is a ROW like the others — 📁 in the label
+  // slot, path right-aligned with its siblings — not a naked line floating on top; the branch row wears
+  // the ⎇ glyph in its label slot; the worktree row shows where the work actually lands when it differs.
+  assert.match(RENDER, /rows\.push\(\["📁", s\.cwd\]\)/);
+  assert.match(RENDER, /rows\.push\(\["⎇", s\.gitBranch\]\)/);
+  assert.match(RENDER, /rows\.push\(\["Worktree", s\.workTree\.dir/);
+  assert.doesNotMatch(RENDER, /tab-tip-path/, "the naked top path line is gone — the grid row replaced it");
   assert.match(RENDER, /rows\.push\(\["Mode", prettyMode\(s\.status\.mode\)\]\)/);
   assert.match(RENDER, /rows\.push\(\["Model", s\.status\.model\]\)/);
   assert.match(RENDER, /rows\.push\(\["Effort", s\.status\.effort\]\)/);


### PR DESCRIPTION
Audit findings (the user 2026-08-13: "I never see anything that's not on the main branch… sometimes it said HEAD… I never get any visibility into worktrees"):

- **Always-main was structural, not a glitch**: both branch sources (the transcript's `gitBranch` stamps and the folder-derived fallback) read the session's *registered* directory, while the repo convention does all real work on per-session worktrees beside it. Truthful but useless.
- **"HEAD" leak was a real bug**: the merge point `meta.gitBranch || _git_branch(scwd)` passes the transcript's literal detached-HEAD stamp through verbatim; only the fallback normalized it.

Changes:
- `_norm_branch` at the single merge point — no surface shows `HEAD` as a branch again.
- `_session_meta` also captures the newest write-tool `file_path` (zero extra parsing — assistant records already pass the line filter); `_tree_of` resolves it to (toplevel, branch); the payload ships `workTree {dir, branch}` top-level (unwindowable, like `gitBranch`) only when it differs from the registered dir's tree. The edit event is the authoritative "where work lands" — latching until a newer edit lands elsewhere, so it cannot flap.
- Head system card + tab tooltip gain a **Worktree** row; the opt-in statusline branch prefers the worktree's branch (its title names the worktree dir).
- Tooltip grammar: the directory becomes an aligned row with the 📁 glyph in the label slot (the naked top path line is gone, dead CSS deleted); the Branch row wears the ⎇ glyph.

Tests: `tests/test_kernel_worktree_display.py` (normalization, lastEditPath extraction from synthetic transcripts, `_tree_of` against a real tmp repo + linked worktree, payload wiring pins); updated pins in `tab-backend-tooltip.test.ts`, `statusline-branch.test.ts`, `test_kernel_sysmeta.py`, `test_sdk_kernel.py`. Full suites green locally (pytest 4342, node 1864, build clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)