### PR TITLE
One truth for complete, one node per to-do key

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -331,7 +331,9 @@ permission/API-error floors: one interrupt at a time, the present event first.
   Models: `STATE/judge-model` (triage), `STATE/index-model`.
 - Logs: `STATE/judge-usage.jsonl` (per-call cost, one name per prompt),
   `STATE/judge-errors.jsonl` (the row contract above; kinds are parse,
-  call, give-up, cite-miss, rate-limited, task-store, history-unreadable),
+  call, give-up, cite-miss, rate-limited, task-store, history-unreadable,
+  task-key-collision — a duplicated to-do mirror key, reconciled per node
+  and surfaced loudly),
   `STATE/judge-auth.json` (the per-session judge-auth-down latch — see
   "Billing" above).
 - Debugging: run the judge's own code against the live store

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1739,7 +1739,11 @@ def load_goals(fsid):
                  "placementsV": PLACEMENTS_V}
         store["_baseRev"] = 0            # no file yet; a writer that CREATES one still trips the CAS
         return store
-    _replay_overrides(fsid, store)
+    if _replay_overrides(fsid, store):
+        # the replay WROTE (a clobbered user resolve/clear re-flagged): the published status/confirming
+        # predate it, and every reader now trusts those exports as the one truth (no raw-flag second
+        # opinions since 2026-08-13) — so re-derive them at the replay's own write, never serve stale
+        rollup_status(store, session_closed=False)
     # OPTIMISTIC-CONCURRENCY BASE (the user 2026-07-22): remember the revision we read, so save_goals can
     # tell whether anyone else published while we were away (a judge pass holds its store across a
     # minutes-long model call). Transient — popped before the store is ever serialized.
@@ -1772,10 +1776,45 @@ def _rebase_onto_disk(fsid, store):
     except Exception:
         return                                       # nothing readable to rebase onto → publish as-is
     d_nodes, m_nodes = disk.get("nodes") or {}, store.get("nodes") or {}
+    # MERGE TOMBSTONES (2026-08-13): presence-in-a-snapshot is not truth — a stale pre-merge writer
+    # publishing across a grouper merge used to RESURRECT the merged-away node (its id absent from the
+    # newer side, so the adopt-wholesale branch below re-minted it), and the twin then held a duplicate
+    # agentTask key that wedged plan-sync + the open_task veto for 19 hours (g17's g32/g40, 2026-08-12).
+    # The merge already records its own deletion event durably — surv["mergedFrom"] — so key on that
+    # exact event: an id named there, on EITHER side, is deleted; its unseen log rows fold into the
+    # survivor (the append-only covenant: both writers' EVENTS survive, the dead identity does not) and
+    # its placements re-point to the survivor, mirroring _merge_nodes' own rewiring.
+    tomb = {}                                        # dead id -> surviving id
+    for nmap in (d_nodes, m_nodes):
+        for sid_, snd in nmap.items():
+            for rec in (snd.get("mergedFrom") or []):
+                if rec.get("id"):
+                    tomb[rec["id"]] = sid_
+
+    def _fold_log(dead, surv):
+        seen = {(e.get("ev_t"), e.get("src"), e.get("kind")) for e in (surv.get("log") or [])}
+        add = [e for e in (dead.get("log") or [])
+               if (e.get("ev_t"), e.get("src"), e.get("kind")) not in seen]
+        if add:
+            with _authority():
+                surv["log"] = sorted((surv.get("log") or []) + add,
+                                     key=lambda e: (int(e.get("ev_t") or 0), int(e.get("at") or 0)))
+
+    for nid in [n for n in list(m_nodes) if n in tomb]:
+        dead = m_nodes.pop(nid)
+        surv = m_nodes.get(tomb[nid]) or d_nodes.get(tomb[nid])
+        if surv is not None:
+            _fold_log(dead, surv)
+        store.get("status", {}).pop(nid, None)
     for nid, dnd in d_nodes.items():
         mnd = m_nodes.get(nid)
-        if mnd is None:                              # a node the OTHER writer minted → adopt it wholesale
-            m_nodes[nid] = dnd
+        if mnd is None:
+            if nid in tomb:                          # deleted by a merge, not minted by the other writer
+                surv = m_nodes.get(tomb[nid])
+                if surv is not None:
+                    _fold_log(dnd, surv)
+                continue
+            m_nodes[nid] = dnd                       # a node the OTHER writer minted → adopt it wholesale
             continue
         seen = {(e.get("ev_t"), e.get("src"), e.get("kind")) for e in (mnd.get("log") or [])}
         add = [e for e in (dnd.get("log") or [])
@@ -1791,6 +1830,9 @@ def _rebase_onto_disk(fsid, store):
             mnd["mt"] = int(dnd["mt"])
     store["nodes"] = m_nodes
     pl = dict(disk.get("placements") or {}); pl.update(store.get("placements") or {})
+    for k, v in list(pl.items()):                    # a tombstoned target re-points to its survivor —
+        if v in tomb:                                # mirrors _merge_nodes' own rewiring; a dangling
+            pl[k] = tomb[v]                          # target would read as unplaced and re-mint the twin
     store["placements"] = pl                         # union: neither writer's dedup bookkeeping is lost
     store["seq"] = max(int(store.get("seq") or 0), int(disk.get("seq") or 0))   # never reuse a gid
     ct = list(disk.get("closedTurns") or [])
@@ -1798,6 +1840,8 @@ def _rebase_onto_disk(fsid, store):
         if t not in ct:
             ct.append(t)
     store["closedTurns"] = ct
+    if store.get("lastNode") in tomb:
+        store["lastNode"] = tomb[store["lastNode"]]
     if store.get("lastNode") not in (store.get("nodes") or {}):
         store["lastNode"] = disk.get("lastNode") or store.get("lastNode")
     rollup_status(store, session_closed=False)       # re-derive every flag + the status map from the merged logs
@@ -1879,13 +1923,14 @@ def _replay_overrides(fsid, store):
     user reply in the same second as a nudge stamp genuinely answers it."""
     fp = _overrides_dir() / (fsid + ".jsonl")
     if not fp.is_file():
-        return
+        return False
     try:
         lines = fp.read_text().splitlines()
     except OSError as e:
         _log_judge_error("romp", fsid, "history-unreadable",
                          note="override journal unreadable: %s — user actions may show undone until it reads" % e)
-        return
+        return False
+    applied = False                                    # any write → load_goals re-runs rollup (one truth)
     arch_nodes = None                                  # the archive is read once, only if a restore entry needs it
     for ln in lines:
         try:
@@ -1900,9 +1945,24 @@ def _replay_overrides(fsid, store):
                 if nid in store.get("nodes", {}) or nid in arch_nodes:
                     continue                           # alive, or re-cleared into the archive → nothing lost
                 store.setdefault("nodes", {})[nid] = GuardedNode(dict(nddata))
+                applied = True
                 st = (ev.get("status") or {}).get(nid)
                 if st is not None:
                     store.setdefault("status", {})[nid] = st
+                # the journaled status must survive rollup (one truth, 2026-08-13): rollup derives
+                # completion from the LOG ("verdicts only — completion needs an author"), and a
+                # restored card's compacted log may lack its done evidence entirely. The journal is
+                # the durable record of what the user restored — re-record what it attests: the done
+                # row (when none survived) and the settle (the unclear branch's existing move for
+                # exactly this shape), so any later rollup re-derives completed instead of quietly
+                # waking the card up as Working.
+                if st == "completed":
+                    nd_r = store["nodes"][nid]
+                    if not any(e.get("kind") == "done" for e in (nd_r.get("log") or [])):
+                        record_verdict(store, nd_r, "romp", "done", t,
+                                       why="restored by undo — the journal recorded it completed")
+                    if not nd_r.get("settledDone"):
+                        record_verdict(store, nd_r, "romp", "settle", t)
             continue
         nd = store.get("nodes", {}).get(ev.get("node"))
         if nd is None:
@@ -1919,6 +1979,7 @@ def _replay_overrides(fsid, store):
             if record_verdict(store, nd, "user", "done", t,
                               why=nd.get("doneWhy") or "Resolved by the user."):
                 nd["mt"] = t
+                applied = True
         elif op in ("followup", "move"):
             if later or _twin("reopen", msg=(op == "followup"), undo=False):
                 continue
@@ -1929,6 +1990,7 @@ def _replay_overrides(fsid, store):
             _unblock_subtree(store, ev["node"], t,
                              "answered by the user's reply to the card" if op == "followup"
                              else "moved to Working by the user")
+            applied = True
         elif op == "unclear":
             # The undo-clear's un-seal (_mark_nodes_cleared value=False), replayed so a pre-restore
             # snapshot/clobbered store un-clears exactly as the live one did (the user 2026-07-23: the
@@ -1943,6 +2005,7 @@ def _replay_overrides(fsid, store):
             was_done = nd.get("parentId") is None and (
                 store.get("status", {}).get(ev.get("node")) == "completed" or nd.get("nodeComplete"))
             if record_verdict(store, nd, "user", "reopen", t, why="undo clear", undo=True):
+                applied = True
                 if was_done and not nd.get("settledDone"):
                     record_verdict(store, nd, "romp", "settle", t)
         elif op == "block":
@@ -1956,6 +2019,8 @@ def _replay_overrides(fsid, store):
                 continue                               # answered since, or the original write survived
             if record_verdict(store, nd, src, "block", t, why=ev.get("why")):
                 nd["mt"] = max(int(nd.get("mt") or 0), t)
+                applied = True
+    return applied
 
 
 _NONCONTENT_KEYS = ("rev", "_baseRev")   # the revision counter + the transient CAS base: not store CONTENT
@@ -3104,56 +3169,76 @@ def _sync_declared_plan(store, session, seg_id, seg_t, prompt_uuid=None):
         plan = em.declared_plan(session)                    # no store dir → legacy transcript fold
     items = {it["key"]: it for it in plan}
     nodes = store["nodes"]
-    has_child, by_key = set(), {}
+    has_child, key_nodes = set(), {}                    # key -> [nids]: EVERY holder, not a last-wins pick
     for nid, nd in nodes.items():
         if nd.get("parentId") is not None:
             has_child.add(nd["parentId"])
         k = (nd.get("agentTask") or {}).get("key")
         if k is not None:
-            by_key[k] = nid
-    if not items and not by_key:
+            key_nodes.setdefault(k, []).append(nid)
+    if not items and not key_nodes:
         return False
 
     def _is_open(it):
         return bool(it) and it["status"] not in ("completed", "cancelled", "deleted")
 
     changed = False
-    # 1) reconcile the agentTask nodes we already track against the current declared plan
-    for key, nid in list(by_key.items()):
-        it, nd = items.get(key), nodes[nid]
-        at = nd.get("agentTask") or {}
-        if _is_open(it):
-            if at.get("status") != "open" or at.get("raw") != it["status"] or not nd.get("agentBornOpen"):
-                nd["agentTask"] = {"key": key, "status": "open", "raw": it["status"]}
-                nd["agentBornOpen"] = True                  # adopt: watched-open now → protected from the done-heal
-                if nd.get("agentDone"):                     # agent RE-OPENED it → an agent reopen EVENT (an
-                    record_verdict(store, nd, "agent", "reopen", seg_t,   # eventless un-done would be re-DONE'd
-                                   why="the agent re-opened its own to-do")   # by the next materialize)
-                    nd["agentDone"] = False
-                nd["mt"] = seg_t
+    # 1) reconcile EVERY agentTask node against the current declared plan — per NODE, not per key. A
+    # grouper merge once left two nodes claiming one key, and the old key→nid dict silently kept only
+    # the LAST: the shadowed OPEN mirror never heard its item complete, and is_complete's open_task
+    # authority veto held its umbrella at 'working' for 19 hours with no mover and no indication (g17,
+    # 2026-08-12). The dict was the lossy compression; reconciling each holder is strictly less
+    # mechanism (this loop already existed) and a duplicated key now heals toward done on the next
+    # pass — the done twin is never re-opened, and the collision itself surfaces loudly below.
+    for key, nids in list(key_nodes.items()):
+        it = items.get(key)
+        if len(nids) > 1 and any((nodes[n].get("agentTask") or {}).get("status") == "open" for n in nids):
+            # a wedge-capable shape the merge/rebase tombstones should have prevented — say so while
+            # self-healing (fail loudly, never freeze silently)
+            _log_judge_error("planner", store.get("rompUuid") or "", "task-key-collision",
+                             note="to-do key %r held by %d nodes (%s) — reconciling each; the done "
+                                  "twin is never re-opened" % (key, len(nids), ", ".join(sorted(nids))))
+        for nid in list(nids):
+            nd = nodes[nid]
+            at = nd.get("agentTask") or {}
+            if _is_open(it):
+                if len(nids) > 1 and at.get("status") == "done":
+                    continue                            # a DONE twin of a duplicated key: the agent
+                    #                                     reopened nothing — the duplicate did; heal
+                    #                                     toward done, never resurrect a completed card
+                if at.get("status") != "open" or at.get("raw") != it["status"] or not nd.get("agentBornOpen"):
+                    nd["agentTask"] = {"key": key, "status": "open", "raw": it["status"]}
+                    nd["agentBornOpen"] = True              # adopt: watched-open now → protected from the done-heal
+                    if nd.get("agentDone"):                 # agent RE-OPENED it → an agent reopen EVENT (an
+                        record_verdict(store, nd, "agent", "reopen", seg_t,   # eventless un-done would be re-DONE'd
+                                       why="the agent re-opened its own to-do")   # by the next materialize)
+                        nd["agentDone"] = False
+                    nd["mt"] = seg_t
+                    changed = True
+            elif nd.get("agentBornOpen"):                   # watched-open item that has now COMPLETED → authoritative-done (kept)
+                if at.get("status") != "done" and record_verdict(store, nd, "agent", "done", seg_t,
+                                                                 why="the agent crossed it off its own list"):
+                    nd["agentTask"] = {"key": key, "status": "done", "raw": (it or {}).get("status") or "completed"}
+                    nd["agentDone"] = True; nd["mt"] = seg_t
+                    if seg_id and seg_id not in (nd.get("trail") or []):
+                        # DONE-ANCHOR, plan-sync edition (the user 2026-07-14): the syncing segment holds the
+                        # work that crossed the item off — ride the trail so the distiller reads that work and
+                        # the summary link can land on it, mirroring the closer's recap append. Without it a
+                        # mirror completed only here kept its mint-time trail, so the distiller saw nothing but
+                        # the announcement segment and the summary anchored on a stub.
+                        nd.setdefault("trail", []).append(seg_id)
+                    changed = True
+            elif nid not in has_child:                      # born-DONE backlog leaf (pre-fix) → self-heal it away
+                nodes.pop(nid, None)
+                store.get("status", {}).pop(nid, None)
+                key_nodes[key].remove(nid)
+                if not key_nodes[key]:
+                    del key_nodes[key]
                 changed = True
-        elif nd.get("agentBornOpen"):                       # watched-open item that has now COMPLETED → authoritative-done (kept)
-            if at.get("status") != "done" and record_verdict(store, nd, "agent", "done", seg_t,
-                                                             why="the agent crossed it off its own list"):
-                nd["agentTask"] = {"key": key, "status": "done", "raw": (it or {}).get("status") or "completed"}
-                nd["agentDone"] = True; nd["mt"] = seg_t
-                if seg_id and seg_id not in (nd.get("trail") or []):
-                    # DONE-ANCHOR, plan-sync edition (the user 2026-07-14): the syncing segment holds the
-                    # work that crossed the item off — ride the trail so the distiller reads that work and
-                    # the summary link can land on it, mirroring the closer's recap append. Without it a
-                    # mirror completed only here kept its mint-time trail, so the distiller saw nothing but
-                    # the announcement segment and the summary anchored on a stub.
-                    nd.setdefault("trail", []).append(seg_id)
-                changed = True
-        elif nid not in has_child:                          # born-DONE backlog leaf (pre-fix) → self-heal it away
-            nodes.pop(nid, None)
-            store.get("status", {}).pop(nid, None)
-            del by_key[key]
-            changed = True
 
     # 2) mint the OPEN items we don't track yet (a done item is NEVER minted retroactively)
     for key, it in items.items():
-        if key in by_key or not _is_open(it):
+        if key in key_nodes or not _is_open(it):
             continue
         store["seq"] = store.get("seq", 0) + 1
         nid = "%s:g%d" % (store["rompUuid"], store["seq"])
@@ -3162,7 +3247,7 @@ def _sync_declared_plan(store, session, seg_id, seg_t, prompt_uuid=None):
                       "trail": [seg_id] if seg_id else [], "promptUuid": prompt_uuid, "t": seg_t, "mt": seg_t,
                       "why": "declared in the agent's own to-do list",
                       "agentTask": {"key": key, "status": "open", "raw": it["status"]}, "agentBornOpen": True, "log": []})
-        by_key[key] = nid
+        key_nodes[key] = [nid]
         changed = True
 
     # 3) BACKSTOP (the user 2026-07-21): an OPEN to-do link belongs on a LEAF the card can render, never
@@ -3173,7 +3258,8 @@ def _sync_declared_plan(store, session, seg_id, seg_t, prompt_uuid=None):
     # visible, and revert the container to a plain node. A node BORN a to-do renders its OWN row (its
     # text IS the step) — leaving those alone is exactly what keeps a legit to-do that grew sub-steps
     # from being split. Idempotent: the split leaf is a placed to-do child the grouper leaves put.
-    for key, nid in list(by_key.items()):
+    for key, nids in list(key_nodes.items()):
+      for nid in list(nids):
         nd = nodes.get(nid)
         if (not nd or (nd.get("agentTask") or {}).get("status") != "open"
                 or nd.get("why") == "declared in the agent's own to-do list"):
@@ -3192,7 +3278,7 @@ def _sync_declared_plan(store, session, seg_id, seg_t, prompt_uuid=None):
                       "agentTask": dict(nd["agentTask"]), "agentBornOpen": True, "log": []})
         for f in ("agentTask", "agentBornOpen", "agentDone"):
             nd.pop(f, None)
-        by_key[key] = leaf
+        key_nodes[key][key_nodes[key].index(nid)] = leaf
         changed = True
     return changed
 
@@ -6264,6 +6350,11 @@ def _merge_nodes(store, dupe_id, surv_id, t, why):
         surv["promptUuid"] = dupe["promptUuid"]
     surv["t"] = min(surv.get("t") or t, dupe.get("t") or t)
     surv["mt"] = t
+    # chained merges keep every tombstone: the dupe's own mergedFrom rides along, so an id merged
+    # A→B→C stays deleted even when B itself is gone (the rebase tombstone gate keys on these records)
+    for _rec in (dupe.get("mergedFrom") or []):
+        if _rec.get("id") and all(r.get("id") != _rec["id"] for r in (surv.get("mergedFrom") or [])):
+            surv.setdefault("mergedFrom", []).append(_rec)
     surv.setdefault("mergedFrom", []).append({"id": dupe_id, "text": dupe.get("text"), "why": why, "at": t})
     for k, v in list((store.get("placements") or {}).items()):
         if v == dupe_id:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1080,9 +1080,10 @@ def _debt_escalate(asker, debtor, ask_ts, now):
     try:
         store = jd.load_goals(asker)
         nodes, status = store.get("nodes", {}), store.get("status", {})
+        _confirming = set(store.get("confirming") or ())
         cands = [nd for gid, nd in nodes.items()
                  if nd.get("parentId") is None and status.get(gid) == "working"
-                 and not nd.get("blocked") and not nd.get("cleared") and not nd.get("nodeComplete")
+                 and gid not in _confirming            # one completion truth: the rollup exports (2026-08-13)
                  and (nd.get("t") or 0) <= ask_ts]
         if not cands:
             return False
@@ -3064,9 +3065,10 @@ def _awaiting_wake_outcomes(now):
             sid = gid.rsplit(":", 1)[0]
             store = jd.load_goals(sid)
             nd = store.get("nodes", {}).get(gid)
-            if (nd is None or nd.get("cleared") or nd.get("nodeComplete") or nd.get("blocked")
-                    or store.get("status", {}).get(gid, "working") != "working"):
-                continue                             # the world moved on; the record is inert
+            if (nd is None or store.get("status", {}).get(gid, "working") != "working"
+                    or gid in set(store.get("confirming") or ())):
+                continue                             # the world moved on; the record is inert (one
+                #                                      completion truth: the rollup exports, 2026-08-13)
             path = _path_of(sid) or ""
             turns = jd.parsed_session(sid, [path], now).get("turns", []) if path else []
             if turns and _session_working(turns):
@@ -3236,7 +3238,11 @@ def _revivers_pending(sid, store, turns, gid):
             return jd.WHY_JUDGING
         if nd.get("followupPending"):
             return "your reply to the card is still being judged"
-        if nd.get("nodeComplete"):
+        if gid in set(store.get("confirming") or ()):
+            # the rollup's own export of exactly this sentence (done verdict in, settle pending). NOT the
+            # raw nodeComplete flag (2026-08-13): a vetoed umbrella — done-flagged but refused by the
+            # open_task authority — read "complete and merely unsettled" here forever, deferring the very
+            # nudge that was its only path to completion (g17's 20h dark deferral)
             return "the card is already complete and merely unsettled"
         if _plan_sync_pending(sid, nodes):
             return "the agent's to-do sync is due"
@@ -3715,18 +3721,27 @@ def _nudge_fire_list(fresh, to_fire, arm_t=None, seen_t=None, held=None):
     hold as a DEFERRAL instead of a silent drop — every other nudge hold leaves a why and rides the 6h
     backstop, and this one leaving nothing is what made the deadlock unreadable from the state dir."""
     nodes, status = fresh.get("nodes", {}) or {}, fresh.get("status", {}) or {}
+    confirming = set(fresh.get("confirming") or ())
     cut = max(arm_t or 0, seen_t or 0)
     keep = []
     for f in to_fire:
         if f[0] not in nodes:
             continue                                 # gone from the fresh store: cleared + compacted mid-tick
         nd = nodes[f[0]]
-        if status.get(f[0], "working") != "working" or nd.get("cleared") \
-                or nd.get("nodeComplete") or nd.get("blocked"):
+        if status.get(f[0], "working") != "working" or f[0] in confirming:
             continue                                 # the judges resolved it since the tick's snapshot: no
             #                                          status check, and nothing to hold either — a RESOLVED
             #                                          goal must never reach `held`, or the backstop below
-            #                                          would eventually nudge a card that is already done
+            #                                          would eventually nudge a card that is already done.
+            #                                          ONE completion truth (2026-08-13): the rollup's own
+            #                                          exports — status + confirming — never the raw flags.
+            #                                          The raw nodeComplete arm silently dropped a VETOED
+            #                                          umbrella (done-flagged, to-do still open, status
+            #                                          'working') every tick, which killed the one backstop
+            #                                          the wedged g17 had; a done-but-unsettled top keeps
+            #                                          its no-nudge behavior via `confirming`, and every
+            #                                          verdict writer runs rollup_status before save_goals,
+            #                                          so the exports are never staler than the flags
         if cut and any(e.get("src") not in NUDGE_HOLD_EXEMPT_SRC
                        and (e.get("ev_t") or e.get("at") or 0) > cut
                        for e in nd.get("log") or []):

--- a/tests/test_judge_one_completion_truth.py
+++ b/tests/test_judge_one_completion_truth.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""One truth for "complete", one node per to-do key (the user 2026-08-12/13).
+
+The incident this pins, reproduced synthetically: a grouper merge left two goal nodes carrying the
+same agentTask mirror key; plan-sync's old key→nid dict kept only the LAST, so the shadowed OPEN
+mirror never heard its live to-do complete, is_complete's open_task authority veto held the umbrella
+at 'working' — and the nudge backstop, reading the RAW nodeComplete flag instead of the rollup's own
+verdict, silently dropped the goal every tick. 19 hours, no mover, no indication. Three mechanisms
+deleted/merged:
+  * plan-sync reconciles EVERY node holding a key (the lossy by_key compression is gone), heals a
+    duplicated key toward done (the done twin is never re-opened), and surfaces the collision loudly;
+  * _rebase_onto_disk keys deletion on the merge's own durable record (mergedFrom tombstones) instead
+    of snapshot presence, so a stale pre-merge writer can no longer resurrect a merged-away node —
+    the door the duplicate came through — and a dropped duplicate's placements re-point to the
+    survivor so the planner cannot re-mint it through the unplaced-segments door;
+  * the nudge ladder's four completion predicates collapse onto the rollup exports (status +
+    confirming) — the same truth the feed renders — and load_goals re-runs rollup after an override
+    replay that wrote anything, so those exports are never staler than a user gesture.
+
+Synthetic stores only: placeholder UUID, invented goal text, tmp CLAUDE_CONFIG_DIR task stores.
+"""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+jd = SourceFileLoader("romp_judge_onetruth", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_onetruth", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = 1780000000
+
+
+def _node(nid, **kw):
+    d = {"id": nid, "parentId": None, "nodeComplete": False, "blocked": False, "cleared": False,
+         "t": T0, "mt": T0, "text": "invented goal", "log": []}
+    d.update(kw)
+    return d
+
+
+def _store(nodes):
+    return jd._guard_nodes({"rompUuid": SID, "seq": len(nodes) + 10, "nodes": nodes,
+                            "placements": {}, "status": {}})
+
+
+def _task_store(items):
+    """A tmp CLAUDE_CONFIG_DIR live task store for SID; returns the config dir."""
+    cfg = tempfile.mkdtemp()
+    d = os.path.join(cfg, "tasks", SID)
+    os.makedirs(d)
+    for key, status in items.items():
+        with open(os.path.join(d, "%s.json" % key), "w") as f:
+            json.dump({"id": key, "subject": "step %s" % key, "status": status}, f)
+    return cfg
+
+
+class DuplicateKeyHeals(unittest.TestCase):
+    """The live g17 shape: umbrella + open twin shadowing a completed item, healed with no surgery."""
+
+    def _incident_store(self):
+        top = _node(SID + ":g1", umbrella=True, nodeComplete=True)
+        done_twin = _node(SID + ":g2", parentId=SID + ":g1",
+                          agentTask={"key": "5", "status": "done", "raw": "completed"},
+                          agentBornOpen=True, agentDone=True, nodeComplete=True)
+        shadowed = _node(SID + ":g3", parentId=SID + ":g1",
+                         agentTask={"key": "5", "status": "open", "raw": "in_progress"},
+                         agentBornOpen=True)
+        genuinely_open = _node(SID + ":g4", parentId=SID + ":g1",
+                               agentTask={"key": "4", "status": "open", "raw": "pending"},
+                               agentBornOpen=True)
+        return _store({n["id"]: n for n in (top, done_twin, shadowed, genuinely_open)})
+
+    def test_the_shadowed_open_mirror_hears_its_items_completion(self):
+        store = self._incident_store()
+        old = os.environ.get("CLAUDE_CONFIG_DIR")
+        os.environ["CLAUDE_CONFIG_DIR"] = _task_store({"5": "completed", "4": "in_progress"})
+        try:
+            changed = jd._sync_declared_plan(store, {"leafFsid": SID}, "seg1", T0 + 100)
+        finally:
+            if old is None:
+                os.environ.pop("CLAUDE_CONFIG_DIR", None)
+            else:
+                os.environ["CLAUDE_CONFIG_DIR"] = old
+        self.assertTrue(changed)
+        g3 = store["nodes"][SID + ":g3"]
+        self.assertEqual((g3.get("agentTask") or {}).get("status"), "done",
+                         "every holder hears the key's events — no last-wins shadowing")
+        self.assertTrue(g3.get("agentDone"))
+        g4 = store["nodes"][SID + ":g4"]
+        self.assertEqual((g4.get("agentTask") or {}).get("status"), "open",
+                         "the genuinely open item keeps the veto honest")
+        jd.rollup_status(store, session_closed=False)
+        self.assertEqual(store["status"].get(SID + ":g1"), "working",
+                         "the umbrella still waits on the REAL open item — the veto shrank to the truth")
+
+    def test_completing_the_last_item_completes_the_umbrella(self):
+        store = self._incident_store()
+        old = os.environ.get("CLAUDE_CONFIG_DIR")
+        os.environ["CLAUDE_CONFIG_DIR"] = _task_store({"5": "completed", "4": "completed"})
+        try:
+            jd._sync_declared_plan(store, {"leafFsid": SID}, "seg1", T0 + 100)
+        finally:
+            if old is None:
+                os.environ.pop("CLAUDE_CONFIG_DIR", None)
+            else:
+                os.environ["CLAUDE_CONFIG_DIR"] = old
+        jd.rollup_status(store, session_closed=False)
+        self.assertIn(store["status"].get(SID + ":g1"), ("completed", "working"),
+                      "with every mirror done the open_task veto is gone")
+        self.assertNotEqual((store["nodes"][SID + ":g3"].get("agentTask") or {}).get("status"), "open")
+
+    def test_the_done_twin_is_never_reopened_and_the_collision_is_loud(self):
+        store = self._incident_store()
+        old = os.environ.get("CLAUDE_CONFIG_DIR")
+        os.environ["CLAUDE_CONFIG_DIR"] = _task_store({"5": "in_progress", "4": "pending"})
+        try:
+            jd._sync_declared_plan(store, {"leafFsid": SID}, "seg1", T0 + 100)
+        finally:
+            if old is None:
+                os.environ.pop("CLAUDE_CONFIG_DIR", None)
+            else:
+                os.environ["CLAUDE_CONFIG_DIR"] = old
+        g2 = store["nodes"][SID + ":g2"]
+        self.assertEqual((g2.get("agentTask") or {}).get("status"), "done",
+                         "reconciliation must not mint a card move the agent never made")
+        self.assertTrue(g2.get("agentDone"))
+        rows = [json.loads(l) for l in open(jd.ERRORS).read().splitlines() if l.strip()]
+        self.assertTrue(any(r.get("err") == "task-key-collision" and r.get("fsid") == SID for r in rows),
+                        "a live duplicate key surfaces loudly while self-healing")
+
+
+class RebaseTombstones(unittest.TestCase):
+    """The door the duplicate came through: snapshot presence is not truth — the merge event is."""
+
+    def _merged_disk(self):
+        surv = _node(SID + ":g1", mergedFrom=[{"id": SID + ":g2", "text": "twin", "why": "same work", "at": T0 + 50}])
+        return _store({surv["id"]: surv})
+
+    def test_a_stale_writer_cannot_resurrect_a_merged_node(self):
+        disk = self._merged_disk()
+        (jd.GOALDIR).mkdir(parents=True, exist_ok=True)
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(disk))
+        try:
+            stale = _store({SID + ":g1": _node(SID + ":g1"),
+                            SID + ":g2": _node(SID + ":g2", log=[{"ev_t": T0 + 60, "at": T0 + 60,
+                                                                  "src": "planner", "kind": "step"}])})
+            stale["placements"] = {"segA": SID + ":g2"}
+            stale["lastNode"] = SID + ":g2"
+            jd._rebase_onto_disk(SID, stale)
+            self.assertNotIn(SID + ":g2", stale["nodes"], "a tombstoned id is deleted, never adopted or kept")
+            self.assertEqual(stale["placements"].get("segA"), SID + ":g1",
+                             "a dropped duplicate's placements re-point to the survivor — no unplaced re-mint door")
+            self.assertEqual(stale["lastNode"], SID + ":g1")
+            surv_log = stale["nodes"][SID + ":g1"].get("log") or []
+            self.assertTrue(any(e.get("ev_t") == T0 + 60 for e in surv_log),
+                            "the dead identity goes; its EVENTS fold into the survivor (append-only covenant)")
+        finally:
+            (jd.GOALDIR / (SID + ".json")).unlink()
+
+    def test_the_reverse_direction_and_chained_merges(self):
+        # memory did the merge; disk still holds the dupe → not re-adopted
+        disk = _store({SID + ":g1": _node(SID + ":g1"), SID + ":g2": _node(SID + ":g2")})
+        (jd.GOALDIR).mkdir(parents=True, exist_ok=True)
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(disk))
+        try:
+            mem = self._merged_disk()
+            jd._rebase_onto_disk(SID, mem)
+            self.assertNotIn(SID + ":g2", mem["nodes"])
+        finally:
+            (jd.GOALDIR / (SID + ".json")).unlink()
+        # chained: A merged into B, then B merged into C → C names both
+        nodes = {SID + ":gA": jd.GuardedNode(_node(SID + ":gA")),
+                 SID + ":gB": jd.GuardedNode(_node(SID + ":gB",
+                                                   mergedFrom=[{"id": SID + ":gA", "text": "a", "why": "w", "at": T0}])),
+                 SID + ":gC": jd.GuardedNode(_node(SID + ":gC"))}
+        store = _store({})
+        store["nodes"] = nodes
+        jd._merge_nodes(store, SID + ":gB", SID + ":gC", T0 + 1, "chained")
+        ids = {r.get("id") for r in (store["nodes"][SID + ":gC"].get("mergedFrom") or [])}
+        self.assertEqual(ids, {SID + ":gA", SID + ":gB"}, "chained merges keep every tombstone")
+
+
+class RollupAfterReplay(unittest.TestCase):
+    def test_a_journaled_user_resolve_settles_the_loaded_status(self):
+        store = _store({SID + ":g1": _node(SID + ":g1")})
+        jd.rollup_status(store, session_closed=False)
+        (jd.GOALDIR).mkdir(parents=True, exist_ok=True)
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(store))
+        od = jd._overrides_dir()
+        od.mkdir(parents=True, exist_ok=True)
+        (od / (SID + ".jsonl")).write_text(json.dumps(
+            {"op": "resolve", "node": SID + ":g1", "t": T0 + 500}) + "\n")
+        try:
+            loaded = jd.load_goals(SID)
+            self.assertEqual(loaded["status"].get(SID + ":g1"), "completed",
+                             "the replay WROTE, so load re-runs rollup — the exports the one-truth "
+                             "readers now trust are never staler than the user's gesture")
+        finally:
+            (jd.GOALDIR / (SID + ".json")).unlink()
+            (od / (SID + ".jsonl")).unlink()
+
+
+class OneTruthOnTheNudgeLadder(unittest.TestCase):
+    def test_a_vetoed_umbrella_stays_in_the_fire_list(self):
+        fresh = _store({SID + ":g1": _node(SID + ":g1", nodeComplete=True)})
+        fresh["status"] = {SID + ":g1": "working"}    # the rollup REFUSED the completion (open to-do veto)
+        fresh["confirming"] = []
+        kept = km._nudge_fire_list(fresh, [(SID + ":g1", "why")])
+        self.assertEqual([k[0] for k in kept], [SID + ":g1"],
+                         "the raw nodeComplete flag no longer kills the wedged card's only backstop")
+
+    def test_a_genuinely_confirming_top_is_dropped(self):
+        fresh = _store({SID + ":g1": _node(SID + ":g1", nodeComplete=True)})
+        fresh["status"] = {SID + ":g1": "working"}
+        fresh["confirming"] = [SID + ":g1"]           # done verdict in, settle pending — the rollup's word
+        self.assertEqual(km._nudge_fire_list(fresh, [(SID + ":g1", "why")]), [])
+
+    def test_a_resolved_status_is_dropped(self):
+        fresh = _store({SID + ":g1": _node(SID + ":g1")})
+        fresh["status"] = {SID + ":g1": "blocked"}
+        fresh["confirming"] = []
+        self.assertEqual(km._nudge_fire_list(fresh, [(SID + ":g1", "why")]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -591,8 +591,11 @@ class AwaitingWakeOutcomeSweep(unittest.TestCase):
     def test_sweep_ignores_a_goal_the_world_moved_past(self):
         now = 1_000_000
         self._seed_goal(at=now - 20 * 3600)
-        d = json.loads((km.jd.GOALDIR / (SID + ".json")).read_text())
-        d["nodes"][self.gid]["nodeComplete"] = True
+        d = km.jd._guard_nodes(json.loads((km.jd.GOALDIR / (SID + ".json")).read_text()))
+        # a COHERENT completed goal (one truth, 2026-08-13): completion is a VERDICT in the log —
+        # rollup re-derives the flags from it — never a bare hand-set nodeComplete
+        km.jd.record_verdict(d, d["nodes"][self.gid], "closer", "done", now - 3600, why="test done")
+        km.jd.rollup_status(d, session_closed=False)
         (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(d))
         self._seed_rec({"wake": True, "anchor": now - 20 * 3600, "count": 1, "lastTurnId": "t0",
                         "armAtoms": 0, "at": now - 7 * 3600})

--- a/tests/test_kernel_debt_nudge.py
+++ b/tests/test_kernel_debt_nudge.py
@@ -247,9 +247,11 @@ class DebtEscalate(DebtBase):
     def test_nothing_eligible_is_a_quiet_no_op(self):
         import json as _json
         p = km.jd.GOALDIR / (ASKER + ".json")
-        s = _json.loads(p.read_text())
-        for nd in s["nodes"].values():
-            nd["nodeComplete"] = True
+        s = km.jd._guard_nodes(_json.loads(p.read_text()))
+        # coherent completion is a VERDICT in the log (one truth, 2026-08-13), never a bare flag
+        for nd in list(s["nodes"].values()):
+            km.jd.record_verdict(s, nd, "closer", "done", NOW - 10, why="test done")
+        km.jd.rollup_status(s, session_closed=False)
         p.write_text(_json.dumps(s))
         self.assertFalse(km._debt_escalate(ASKER, DEBTOR, T_ASK, NOW))
 

--- a/tests/test_kernel_nudge_last_resort.py
+++ b/tests/test_kernel_nudge_last_resort.py
@@ -200,8 +200,18 @@ class OtherReviverGates(Base):
         self.assertIn("reply", km._revivers_pending(SID, st, _turns(), GID))
 
     def test_a_complete_but_unsettled_card_defers(self):
+        # ONE completion truth (2026-08-13): "complete and merely unsettled" is the rollup's own
+        # `confirming` export, not the raw nodeComplete flag — a store the rollup actually settled
         st = _store(nodeComplete=True)
+        st["confirming"] = [GID]
         self.assertIn("complete", km._revivers_pending(SID, st, _turns(), GID))
+
+    def test_a_vetoed_umbrella_stays_nudgeable(self):
+        # the g17 shape (2026-08-12): done-flagged but REFUSED by the rollup (open to-do authority
+        # veto) — status 'working', NOT confirming. Under the old raw-flag read this deferred forever,
+        # dark, while the same flag dropped its nudge every tick: no mover, no indication, 19 hours.
+        st = _store(nodeComplete=True)                # rollup refused: no confirming export
+        self.assertEqual(km._revivers_pending(SID, st, _turns(), GID), "")
 
     def test_a_quiet_store_does_not_defer(self):
         # the guard against the WORSE bug: absent markers must never read as "pending" and suppress

--- a/tests/test_nudge_bundle.py
+++ b/tests/test_nudge_bundle.py
@@ -172,6 +172,9 @@ class NudgeFireList(unittest.TestCase):
 
     def test_cleared_and_vanished_goals_drop(self):
         fresh = _store({G1: _node(G1, "crossed off", cleared=True)})
+        fresh["status"][G1] = "cleared"                # the rollup's export (one truth, 2026-08-13):
+        #                                                every writer rollups before save, and a cleared
+        #                                                node's status IS "cleared" (judge rollup_status)
         self.assertEqual(km._nudge_fire_list(fresh, [(G1, 1, False), (G2, 1, False)]), [],
                          "a cleared card and a compacted-away card both lose their nudge")
 


### PR DESCRIPTION
PR A of the stuck-card program (design: subtractive pass over the forensics of 2026-08-12's frozen board; four designers + two adversarial critics, all must-fix findings folded in).

The wedge this kills: a grouper merge left two nodes carrying one agentTask mirror key; plan-sync's last-wins `by_key` dict hid the OPEN twin from the live to-do's completion, the `open_task` authority veto held the umbrella at working, and the nudge backstop — reading the raw `nodeComplete` flag instead of the rollup's verdict — silently dropped the goal every tick. 19 hours stuck, dark.

Deletions/mergers (no new mechanisms):
- **Plan-sync reconciles every holder of a key** (the lossy compression is deleted). A duplicated key heals toward done — the done twin is never re-opened — and collisions surface loudly (`task-key-collision`).
- **Rebase keys deletion on the merge's durable record** (`mergedFrom` tombstones, folded across chains) instead of snapshot presence — closing the resurrection door the duplicate came through; the dead node's diary rows fold into its survivor, and its placements/lastNode re-point there (no re-mint via the unplaced-segments door).
- **The nudge ladder's four completion predicates collapse onto the rollup exports** (`status` + `confirming`) — the truth the feed already renders. A vetoed umbrella stays nudgeable; a done-but-unsettled top keeps its no-nudge behavior.
- `load_goals` re-runs rollup after an override replay that wrote (event-keyed), and the restore branch re-records the done+settle evidence the journal attests — rollup derives completion from the log ("verdicts only"), so journaled status must be backed by rows.

Tests: `tests/test_judge_one_completion_truth.py` reproduces the live incident shape end-to-end (shadowed mirror hears its completion; veto shrinks to the truth; done twin never reopens; collision row filed; resurrection blocked both directions; chained tombstones; placements re-point; rollup-after-replay; fire-list one-truth matrix). Three existing fixtures that hand-set raw flags without verdicts now model coherent stores. Full pytest suite green locally (4352 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)