### PR TITLE
The closer re-arms on filings, stands down before newer evidence, and hears the unblocker

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -5009,6 +5009,10 @@ def migrate_store(store):
     with _authority():                                # migration IS the cache layer for legacy stores
         for nd in nodes.values():
             changed = _migrate_node(nd) or changed
+    for dead in ("umbSig", "starvedSig"):              # retired 2026-08-13: the closer's one look-stamp
+        if dead in store:                              #   (closerLookT) replaced both signature gates
+            store.pop(dead, None)
+            changed = True
     return changed
 
 
@@ -6861,11 +6865,68 @@ def _turn_menu(turn, store):
     return out
 
 
-def _umb_sig(nodes, children, nid):
-    """The completion-set signature a subtree-done candidate is stamped with once the closer has looked:
-    the sorted ids of its (all-complete) children. The set changing — a new child filed, a child's state
-    flipped — is the EVENT that re-arms the ask; an unchanged set never re-badgers the closer."""
-    return ",".join(sorted(children.get(nid, [])))
+def _top_of(nodes, nid):
+    """The top-level ancestor of nid (cycle-safe)."""
+    top, seen = nid, set()
+    while nodes.get(top, {}).get("parentId") is not None and top not in seen:
+        seen.add(top)
+        top = nodes[top]["parentId"]
+    return top
+
+
+def _sealed_above(nodes, nid):
+    """A complete/cleared ancestor seals the subtree (the fold's job to display) — shared by every
+    closer-nomination channel (was three verbatim copies, collapsed 2026-08-13)."""
+    x, seen = nodes.get(nid, {}).get("parentId"), set()
+    while x and x not in seen:
+        seen.add(x)
+        nd = nodes.get(x)
+        if not nd:
+            return False
+        if nd.get("nodeComplete") or nd.get("cleared"):
+            return True
+        x = nd.get("parentId")
+    return False
+
+
+def _task_open_below(nodes, children, nid):
+    """An agentTask-OPEN self-or-descendant — the authoritative tier says work is owed (shared,
+    collapsed 2026-08-13)."""
+    if (nodes.get(nid, {}).get("agentTask") or {}).get("status") == "open":
+        return True
+    return any(_task_open_below(nodes, children, c) for c in children.get(nid, []))
+
+
+def _newest_filed(nodes, children, nid):
+    """The newest diary row FILED (`at`, the arrival domain) anywhere in nid's TOP subtree. This is
+    the ONE re-arm event the retired umbSig/starvedSig signatures were approximating: 'the child set
+    changed' could not see a verdict landing on an existing child (the g7 orphan, 2026-08-12), and
+    the starved channel's evidence-domain mt>=mint scan starved post-outage filings whose evidence
+    times were old news but whose FILINGS were brand new. A filing is new information by definition;
+    everything downstream keys on it."""
+    top = _top_of(nodes, nid)
+    newest, stack = 0, [top]
+    while stack:
+        x = stack.pop()
+        nd = nodes.get(x)
+        if not nd:
+            continue
+        for e in (nd.get("log") or []):
+            newest = max(newest, int(e.get("at") or 0))
+        stack.extend(children.get(x, []))
+    return newest
+
+
+def _filed_since(nodes, children, nid, stamp):
+    """A diary row filed in nid's top subtree after `stamp` — the closer's re-ask gate."""
+    return _newest_filed(nodes, children, nid) > stamp
+
+
+def _look_stamp(nd):
+    """The closer's last-look watermark for this node: closerLookT once stamped, else the node's own
+    mint — so the FIRST post-upgrade pass re-nominates every already-orphaned candidate exactly once
+    (its child verdicts were filed after its mint by construction)."""
+    return int(nd.get("closerLookT") or nd.get("t") or 0)
 
 
 def _subtree_done_candidates(store):
@@ -6879,30 +6940,13 @@ def _subtree_done_candidates(store):
 
     Skips: nodes already ruled (complete/blocked/cleared), childless nodes, sealed subtrees (a complete/
     cleared ancestor — the fold's job), agentTask-open subtrees (the authoritative tier: the agent says
-    work is owed), and nodes whose completion-set signature is already stamped (`store["umbSig"]` — the
-    closer looked and left it open; only the set CHANGING re-arms, see _umb_sig)."""
+    work is owed), and nodes with NOTHING FILED in their top subtree since the closer's last look
+    (closerLookT — one watermark, shared with every nomination channel; a landed verdict re-arms it,
+    which the retired child-id-set signature never could: the g7 orphan, 2026-08-12)."""
     nodes = store["nodes"]
     children = {}
     for nid, nd in nodes.items():
         children.setdefault(nd.get("parentId"), []).append(nid)
-    sigs = store.get("umbSig") or {}
-
-    def _sealed_above(nid):
-        x, seen = nodes.get(nid, {}).get("parentId"), set()
-        while x and x not in seen:
-            seen.add(x)
-            nd = nodes.get(x)
-            if not nd:
-                return False
-            if nd.get("nodeComplete") or nd.get("cleared"):
-                return True
-            x = nd.get("parentId")
-        return False
-
-    def _task_open(nid):
-        if (nodes.get(nid, {}).get("agentTask") or {}).get("status") == "open":
-            return True
-        return any(_task_open(c) for c in children.get(nid, []))
 
     out = []
     for nid, nd in nodes.items():
@@ -6914,76 +6958,34 @@ def _subtree_done_candidates(store):
         kids = children.get(nid, [])
         if not kids or not all(nodes[c].get("nodeComplete") or nodes[c].get("cleared") for c in kids):
             continue
-        if _sealed_above(nid) or _task_open(nid):
+        if _sealed_above(nodes, nid) or _task_open_below(nodes, children, nid):
             continue
-        if sigs.get(nid) == _umb_sig(nodes, children, nid):
-            continue                                   # the closer already looked at exactly this set
+        if not _filed_since(nodes, children, nid, _look_stamp(nd)):
+            continue                                   # the closer already looked at this world
         out.append(nd)
     out.sort(key=lambda nd: nd.get("t", 0))
     return out
 
 
-def _starved_sig(nodes, children, nid):
-    """The settled-elsewhere signature a no-work-filed candidate is stamped with once the closer has
-    looked: the sorted ids of the COMPLETED nodes in its top's subtree that resolved at/after the
-    candidate's own mint. The set GROWING — another piece of the same effort settling — is the EVENT
-    that re-arms the ask ("was the starved card covered by that work?" just became answerable again);
-    an unchanged set never re-badgers the closer. Empty while nothing has settled since the mint."""
-    top = nid
-    seen = set()
-    while nodes.get(top, {}).get("parentId") is not None and top not in seen:
-        seen.add(top)
-        top = nodes[top]["parentId"]
-    t0 = nodes.get(nid, {}).get("t", 0)
-    out, stack = [], [top]
-    while stack:
-        x = stack.pop()
-        nd = nodes.get(x)
-        if not nd:
-            continue
-        if x != nid and nd.get("nodeComplete") and nd.get("mt", nd.get("t", 0)) >= t0:
-            out.append(x)
-        stack.extend(children.get(x, []))
-    return ",".join(sorted(out))
-
-
 def _starved_candidates(store):
     """OPEN nodes that never received evidence after their mint — the trail holds at most the minting
-    segment and the diary is empty — nominated to the closer once OTHER work in their top's subtree has
-    settled. Without this they are UNREACHABLE by any verdict (the user 2026-07-17, quartz: two
-    born-done metric-trend cards, their approach superseded by the config-pin build, sat open forever): turn
-    menus only list placement-touched nodes, and subtree-done nomination needs all-children-done — a
-    childless open leaf, or a branch whose only child is open, qualifies for neither.
+    segment and the diary is empty — nominated to the closer once OTHER work in their top's subtree
+    filed something new. Without this they are UNREACHABLE by any verdict (the user 2026-07-17, quartz:
+    two born-done metric-trend cards, their approach superseded by the config-pin build, sat open
+    forever): turn menus only list placement-touched nodes, and subtree-done nomination needs
+    all-children-done — a childless open leaf, or a branch whose only child is open, qualifies for
+    neither.
 
-    The nomination EVENT is a sibling settling (_starved_sig non-empty): that is when "was this stale
-    card's outcome delivered elsewhere / its approach replaced?" becomes answerable from goal history.
-    A landed closer reply stamps the signature (store["starvedSig"]); only the settled set growing
-    re-arms the ask, so a card the closer consciously left open costs one look per settle-event, not
-    one per pass. Skips mirror _subtree_done_candidates: ruled nodes (done/blocked/cleared/settledDone),
-    umbrellas (pure containers), sealed subtrees, and agentTask-open subtrees (the authoritative tier:
-    the agent's own list says the work is still owed)."""
+    The nomination EVENT is a new FILING in the top subtree since the closer's last look (closerLookT,
+    the shared watermark): that is when "was this stale card's outcome delivered elsewhere / its
+    approach replaced?" becomes answerable anew from goal history. The retired settled-set signature
+    compared EVIDENCE times (mt >= mint), which starved post-outage filings — old evidence, brand-new
+    information (2026-08-12). Skips mirror _subtree_done_candidates: ruled nodes, umbrellas, sealed
+    subtrees, and agentTask-open subtrees."""
     nodes = store["nodes"]
     children = {}
     for nid, nd in nodes.items():
         children.setdefault(nd.get("parentId"), []).append(nid)
-    sigs = store.get("starvedSig") or {}
-
-    def _sealed_above(nid):
-        x, seen = nodes.get(nid, {}).get("parentId"), set()
-        while x and x not in seen:
-            seen.add(x)
-            nd = nodes.get(x)
-            if not nd:
-                return False
-            if nd.get("nodeComplete") or nd.get("cleared"):
-                return True
-            x = nd.get("parentId")
-        return False
-
-    def _task_open(nid):
-        if (nodes.get(nid, {}).get("agentTask") or {}).get("status") == "open":
-            return True
-        return any(_task_open(c) for c in children.get(nid, []))
 
     out = []
     for nid, nd in nodes.items():
@@ -6996,14 +6998,47 @@ def _starved_candidates(store):
         kids = children.get(nid, [])
         if kids and all(nodes[c].get("nodeComplete") or nodes[c].get("cleared") for c in kids):
             continue                                   # all-children-done → the subtree-done channel owns it
-            #                                            (umbSig gates its re-asks; never double-nominate)
-        if _sealed_above(nid) or _task_open(nid):
+            #                                            (same watermark; never double-nominate)
+        if _sealed_above(nodes, nid) or _task_open_below(nodes, children, nid):
             continue
-        sig = _starved_sig(nodes, children, nid)
-        if not sig or sigs.get(nid) == sig:
-            continue                                   # nothing settled since the mint, or already looked
+        if not _filed_since(nodes, children, nid, _look_stamp(nd)):
+            continue                                   # nothing filed since the last look (or the mint)
         out.append(nd)
     out.sort(key=lambda nd: nd.get("t", 0))
+    return out
+
+
+def _lift_riders(store):
+    """OPEN nodes whose newest state-bearing diary row is an UNBLOCKER LIFT the closer has not looked
+    at — routed onto the closer's done menu (2026-08-13). The unblocker's lift evidence often asserts
+    the work SHIPPED (the g7 orphan: its lift's own why said merged and deployed), but the unblocker
+    may only file unblock — done is the closer's authority. Riding the menu hands the evidence to that
+    existing authority; the unblocker gains no verdict power, and the look-stamp below retires the
+    ride the same way it retires every other nomination (an unstamped rider would re-nominate every
+    pass forever — the exact one-shot defect this cluster deletes)."""
+    nodes = store["nodes"]
+    children = {}
+    for nid, nd in nodes.items():
+        children.setdefault(nd.get("parentId"), []).append(nid)
+    out = []
+    for nid, nd in nodes.items():
+        if nd.get("nodeComplete") or nd.get("cleared") or nd.get("blocked") or nd.get("settledDone"):
+            continue
+        if nd.get("umbrella"):
+            continue
+        rows = [e for e in (nd.get("log") or []) if e.get("kind") in ("done", "block", "unblock", "reopen")]
+        if not rows:
+            continue
+        last = max(rows, key=lambda e: (int(e.get("ev_t") or 0), int(e.get("at") or 0)))
+        if last.get("kind") != "unblock" or last.get("src") != "unblocker":
+            continue
+        if int(last.get("at") or 0) <= _look_stamp(nd):
+            continue                                   # the closer already ruled on a menu holding this lift
+        if _sealed_above(nodes, nid) or _task_open_below(nodes, children, nid):
+            continue
+        nd_why = last.get("why") or ""
+        out.append((nd, nd_why))
+    out.sort(key=lambda pair: pair[0].get("t", 0))
     return out
 
 
@@ -7027,18 +7062,13 @@ def _status_report_candidates(store, turn):
     for nid, nd in nodes.items():
         children.setdefault(nd.get("parentId"), []).append(nid)
 
-    def _task_open(nid):
-        if (nodes.get(nid, {}).get("agentTask") or {}).get("status") == "open":
-            return True
-        return any(_task_open(c) for c in children.get(nid, []))
-
     out = []
     for nid, nd in nodes.items():
         if nd.get("parentId") is not None:
             continue                                   # tops only: the cards the board actually shows
         if nd.get("nodeComplete") or nd.get("cleared") or nd.get("blocked") or nd.get("settledDone"):
             continue
-        if nd.get("umbrella") or _task_open(nid):
+        if nd.get("umbrella") or _task_open_below(nodes, children, nid):
             continue
         out.append(nd)
     out.sort(key=lambda nd: nd.get("t", 0))
@@ -7059,7 +7089,7 @@ def _menu_history_text(store, seg_by_id, menu, char_cap):
     return "\n\n".join(parts)
 
 
-def apply_close(store, menu, verdicts, t=None, touched=None):
+def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
     """Apply the closer's turn-end verdicts over the touched open tops: COMPLETE each in verdicts["done"]
     (recording doneWhy, clearing any soft block), BLOCK each in verdicts["block"] (recording blockWhy =
     the question owed to the user), and STAMP each in verdicts["awaiting"] (the ⏳ annotation: waiting on
@@ -7082,17 +7112,22 @@ def apply_close(store, menu, verdicts, t=None, touched=None):
     for i, nd in enumerate(menu, 1):
         if nd.get("nodeComplete"):
             continue
+        # a verdict's ev_t is the time of the EVIDENCE it rules on (2026-08-13): turn-menu nodes are
+        # ruled from this turn (t, as ever); a lift-rider is ruled from GOAL HISTORY — its newest
+        # state row — so t_overrides carries that anchor. Anchoring a history ruling to the turn made
+        # it pre-shadowed by the very lift that nominated it (the fold orders by evidence time).
+        ev = (t_overrides or {}).get(i, t)
         if i in done:
-            if not record_verdict(store, nd, "closer", "done", t, why=done[i] or None):
+            if not record_verdict(store, nd, "closer", "done", ev, why=done[i] or None):
                 continue                              # the user's follow-up/move postdates this turn's evidence
-            if t is not None:                         # (the event materialized the flags + doneWhy)
-                nd["mt"] = t
+            if ev is not None:                        # (the event materialized the flags + doneWhy)
+                nd["mt"] = ev
             newly.append(nd["id"])
         elif i in block:
-            if not record_verdict(store, nd, "closer", "block", t, why=block[i] or None):   # the user's follow-up postdates this turn's evidence —
+            if not record_verdict(store, nd, "closer", "block", ev, why=block[i] or None):   # the user's follow-up postdates this turn's evidence —
                 continue                               # their reply owns the verdict now, not this stale close
-            if t is not None:                         # (the event materialized the flags + blockWhy)
-                nd["mt"] = t
+            if ev is not None:                        # (the event materialized the flags + blockWhy)
+                nd["mt"] = ev
         elif i in awaiting:
             if nd.get("awaitingWhy") != (awaiting[i] or None):     # same why → keep the original stamp
                 record_verdict(store, nd, "closer", "awaiting", t, why=awaiting[i] or None)
@@ -7131,7 +7166,9 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
     starved = [nd for nd in _starved_candidates(store) if nd["id"] not in seen_ids]
     seen_ids |= {nd["id"] for nd in starved}
     status = [nd for nd in _status_report_candidates(store, turn) if nd["id"] not in seen_ids]
-    menu = menu + cands + starved + status
+    seen_ids |= {nd["id"] for nd in status}
+    lifted = [(nd, why) for nd, why in _lift_riders(store) if nd["id"] not in seen_ids]
+    menu = menu + cands + starved + status + [nd for nd, _ in lifted]
     if not menu:
         return []
     hist = _menu_history_text(store, seg_by_id, menu, CLOSE_HISTORY_CHARS) if seg_by_id is not None else ""
@@ -7168,6 +7205,15 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
                          ", ".join("#%d" % i for i in tflagged),
                          "are" if len(tflagged) > 1 else "is",
                          "each" if len(tflagged) > 1 else "it"))
+    lift_whys = {nd["id"]: why for nd, why in lifted}
+    lflagged = [(i, lift_whys[nd["id"]]) for i, nd in enumerate(menu, 1) if nd["id"] in lift_whys]
+    for i, why in lflagged:
+        # the unblocker's completion-asserting evidence, routed to the done authority (2026-08-13):
+        # the lift's own why rides the note so the closer judges from goal history, not this turn alone
+        menu_text += ("\n\nGoal #%d's wait was ruled over%s Judge it only from what its goal history "
+                      "plainly shows delivered — done only where the history shows its outcome landed; "
+                      "leaving it open is a fine answer if the history is not plain."
+                      % (i, (": %s." % why.rstrip(".")) if why else "."))
     raw = closer_llm(_unit_text(turn["atoms"]), menu_text, hist)
     out = _parse_close(raw, len(menu))
     if out is None:
@@ -7188,20 +7234,50 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
             #                                            changes the size signature and re-judges (event re-arm)
         return None                                    # under the cap → leave unswept, retry next pass
     store.get("closeFails", {}).pop(turn["id"], None)  # a clean reply clears the turn's strike count
-    if cands or starved:
-        # The reply LANDED → the closer has considered every candidate (a verdict or a considered
-        # omission). Stamp each one's signature so an unchanged set is never re-asked; a verdicted
-        # candidate's stamp is harmless (the ruled/sealed filters exclude it anyway).
-        kidmap = {}
-        for _nid, _nd in store["nodes"].items():
-            kidmap.setdefault(_nd.get("parentId"), []).append(_nid)
-        sigs = store.setdefault("umbSig", {})
-        for nd in cands:
-            sigs[nd["id"]] = _umb_sig(store["nodes"], kidmap, nd["id"])
-        ssigs = store.setdefault("starvedSig", {})
-        for nd in starved:                             # settled-elsewhere set as of THIS look (see _starved_sig)
-            ssigs[nd["id"]] = _starved_sig(store["nodes"], kidmap, nd["id"])
-    newly = apply_close(store, menu, out, t=turn.get("t"), touched=n_touched)
+    # STAND-DOWN (2026-08-13): a writer whose evidence predates the diary stands down — the standing
+    # corollary, applied at the closer's own write site. The backlog sweep anchors verdicts to a stale
+    # turn's ev_t; the fold (the authority) orders by evidence time, so newer diary rows shadow such a
+    # verdict SILENTLY while the turn seals forever (g44 lost two dones to interrupt/unblock rows this
+    # way, 2026-08-12). Simulate the exact row apply_close would append: a verdict that would not
+    # change the node's folded state is dropped and logged loudly (stale-close). Deliberately NO
+    # requeue: the newer evidence's own turn is audited by the same oldest-first sweep, and a requeue
+    # here can loop forever on a fold tie (both critics' finding).
+    # a lift-rider's ruling draws on GOAL HISTORY, so its verdict anchors to the lift's own ev_t —
+    # anchored to the (possibly older) audited turn it would be pre-shadowed by the very lift that
+    # nominated it, and the stand-down below would drop every lift-ridden ruling
+    t_overrides = {}
+    for i, nd in enumerate(menu, 1):
+        if nd["id"] in lift_whys:
+            evs = [int(e.get("ev_t") or 0) for e in (nd.get("log") or [])
+                   if e.get("kind") in ("done", "block", "unblock", "reopen")]
+            if evs:
+                t_overrides[i] = max(evs)
+    for kind in ("done", "block"):
+        for i in list(out.get(kind) or {}):
+            nd = menu[i - 1]
+            ev = t_overrides.get(i, turn.get("t"))
+            sim = dict(nd)
+            sim["log"] = list(nd.get("log") or []) + [{"ev_t": ev, "src": "closer",
+                                                       "kind": kind, "at": int(time.time())}]
+            if _fold_node_state(sim) == _fold_node_state(nd):
+                out[kind].pop(i, None)
+                _log_judge_error("closer", store.get("rompUuid"), "stale-close", goal=nd.get("id"),
+                                 note="a %s anchored to ev_t %s is shadowed by newer diary rows on "
+                                      "%s — the writer stands down; the newer evidence's own turn "
+                                      "carries the ruling" % (kind, ev, nd.get("id")))
+    newly = apply_close(store, menu, out, t=turn.get("t"), touched=n_touched, t_overrides=t_overrides)
+    # The reply LANDED → the closer considered every menu node (a verdict or a considered omission).
+    # ONE look-stamp replaces the retired umbSig/starvedSig signatures (2026-08-13): the newest row
+    # FILED in each node's top subtree as of this look, stamped BELOW apply_close so the reply's own
+    # filings are covered and a just-ruled candidate is not instantly re-nominated. Every partition is
+    # stamped — an unstamped lift-rider the closer HOLDS would re-nominate every pass forever, the
+    # exact one-shot defect this replaces.
+    kidmap = {}
+    for _nid, _nd in store["nodes"].items():
+        kidmap.setdefault(_nd.get("parentId"), []).append(_nid)
+    for nd in menu:
+        if nd["id"] in store["nodes"]:
+            nd["closerLookT"] = _newest_filed(store["nodes"], kidmap, nd["id"])
     segs = _segs(turn, store)                          # seam-aware: post-split, the recap lives in the tail
     if segs:                                           # anchor each resolved (done/blocked) top to the recap
         recap, resolved = segs[-1]["id"], set(out["done"]) | set(out["block"])

--- a/tests/test_judge_close_standdown.py
+++ b/tests/test_judge_close_standdown.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""The closer stands down before newer diary evidence, and unblocker lifts ride its menu
+(the user 2026-08-12/13, cluster B of the stuck-card program).
+
+Two defects, both from the post-outage forensics:
+  * The backlog sweep filed done/block verdicts anchored to a STALE turn's ev_t; the fold (the
+    authority) orders by evidence time, so newer diary rows shadowed those verdicts SILENTLY while
+    the turn sealed forever — a card lost two real completions this way. The standing corollary —
+    a writer whose evidence predates the diary stands down — now applies at the closer's own write
+    site: a verdict that would not change the node's folded state is dropped and logged loudly
+    (stale-close). Deliberately NO requeue: the newer evidence's own turn is audited by the same
+    oldest-first sweep, and a requeue can loop forever on a fold tie.
+  * The unblocker's lift evidence often asserts the work SHIPPED, but it may only file unblock —
+    done is the closer's authority. A node whose newest state-bearing row is an unheard lift now
+    rides the closer's menu (with the lift's why in the note), and the landed reply's look-stamp
+    retires the ride — an unstamped rider would re-nominate every pass forever, the exact one-shot
+    defect this cluster deletes.
+
+All fixtures synthetic (placeholder UUIDs, invented text).
+"""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+em = SourceFileLoader("romp_event_model_sd", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge_sd", os.path.join(BIN, "romp-judge")).load_module()
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = NOW - 3600
+T1 = T0 + 100
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": text}, "promptSource": "typed"}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+def _turn():
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / (SID + ".jsonl")
+        recs = [uline(T0, "wire the widget end to end", "u1"),
+                aline(T0 + 20, "Shipped: the widget wiring merged and deployed.", "a1", "u1")]
+        p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        return em.parse_session(str(p), rompuuid=SID, candidate_files=[str(p)], now=NOW)["turns"][0]
+
+
+def _store():
+    return {"rompUuid": SID, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": {},
+            "placements": {}, "status": {}}
+
+
+def _row(kind, ev, src="closer", why=None, at=None):
+    return {"ev_t": ev, "src": src, "kind": kind, **({"why": why} if why else {}),
+            "at": at if at is not None else ev}
+
+
+def _node(s, g, text, parent=None, log=None, **extra):
+    nd = {"id": SID + ":" + g, "text": text,
+          "parentId": (SID + ":" + parent) if parent else None,
+          "nodeComplete": False, "blocked": False, "cleared": False, "trail": [], "t": T0,
+          "log": log or []}
+    nd.update(extra)
+    s["nodes"][nd["id"]] = nd
+    return nd
+
+
+def _errors():
+    try:
+        return [json.loads(l) for l in Path(jd.ERRORS).read_text().splitlines() if l.strip()]
+    except OSError:
+        return []
+
+
+class StandDown(unittest.TestCase):
+    def setUp(self):
+        self._llm = jd.closer_llm
+        self.turn = _turn()
+
+    def tearDown(self):
+        jd.closer_llm = self._llm
+
+    def test_a_shadowed_done_is_dropped_loudly_and_writes_nothing(self):
+        # the incident shape (g44): the node's fold is decided by rows NEWER than the audited turn —
+        # a block then a planner unblock — so a done anchored to the turn's ev_t changes nothing.
+        # It reaches the menu on the steps-finished channel (a done child), whose verdicts anchor to
+        # the audited turn, exactly like the backlog sweep that lost the real card's completions.
+        s = _store()
+        nd = _node(s, "g1", "wire the widget end to end",
+                   log=[_row("block", self.turn["t"] + 100, why="which env?"),
+                        _row("unblock", self.turn["t"] + 300, src="planner",
+                             why="new work filed on this branch")])
+        _node(s, "g2", "wired the first widget", parent="g1",
+              log=[_row("done", self.turn["t"] + 50)], nodeComplete=True)
+        jd.closer_llm = lambda tt, mt, *_a: '{"done": [{"goal": 1, "why": "it shipped"}], "block": []}'
+        before = list(nd["log"])
+        jd._close_turn(s, self.turn)
+        closer_rows = [e for e in nd["log"] if e.get("src") == "closer" and e.get("kind") == "done"]
+        self.assertEqual(closer_rows, [], "the shadowed verdict is never appended")
+        self.assertEqual(nd["log"][:len(before)], before, "no diary mutation at all")
+        self.assertFalse(nd.get("nodeComplete"))
+        rows = [r for r in _errors() if r.get("err") == "stale-close"]
+        self.assertTrue(rows and rows[-1].get("goal") == nd["id"],
+                        "the stand-down is LOUD — a judge-errors row names the node")
+
+    def test_an_unshadowed_done_still_lands(self):
+        s = _store()
+        # steps-finished shape with NO newer shadow: the turn's ev_t is the fold's newest evidence
+        nd = _node(s, "g1", "wire the widget end to end")
+        _node(s, "g2", "wired the first widget", parent="g1",
+              log=[_row("done", T0 + 50)], nodeComplete=True)   # filed AFTER the parent's mint → nominates
+        jd.closer_llm = lambda tt, mt, *_a: '{"done": [{"goal": 1, "why": "it shipped"}], "block": []}'
+        newly = jd._close_turn(s, self.turn)
+        self.assertEqual(newly, [nd["id"]],
+                         "a done whose evidence is the fold's newest state lands as ever")
+        self.assertTrue(nd.get("nodeComplete"))
+
+
+class LiftRiders(unittest.TestCase):
+    def setUp(self):
+        self._llm = jd.closer_llm
+        self.turn = _turn()
+
+    def tearDown(self):
+        jd.closer_llm = self._llm
+
+    def _lifted_store(self):
+        s = _store()
+        _node(s, "g1", "ship the widget wiring",
+              log=[_row("block", T1, why="approve the rollout?"),
+                   _row("unblock", T1 + 50, src="unblocker",
+                        why="answered in passing — merged and deployed")])
+        return s
+
+    def test_an_unheard_lift_rides_the_menu_with_its_why(self):
+        s = self._lifted_store()
+        seen = {}
+        jd.closer_llm = lambda tt, mt, *_a: (seen.update(mt=mt),
+                                             '{"done": [{"goal": 1, "why": "history shows it shipped"}], "block": []}')[1]
+        newly = jd._close_turn(s, self.turn)
+        self.assertEqual(newly, [SID + ":g1"],
+                         "the lift's completion evidence reaches the DONE authority — the closer")
+        self.assertIn("wait was ruled over", seen["mt"])
+        self.assertIn("merged and deployed", seen["mt"], "the lift's own why rides the note")
+
+    def test_the_look_stamp_retires_the_ride(self):
+        s = self._lifted_store()
+        jd.closer_llm = lambda tt, mt, *_a: '{"done": [], "block": []}'
+        self.assertEqual(jd._close_turn(s, self.turn), [], "held open — a considered omission")
+        self.assertGreaterEqual(s["nodes"][SID + ":g1"].get("closerLookT") or 0, T1 + 50)
+        jd.closer_llm = lambda tt, mt, *_a: (_ for _ in ()).throw(
+            AssertionError("a heard lift must not re-nominate without a new filing"))
+        self.assertEqual(jd._close_turn(s, self.turn), [],
+                         "no re-ask until something new is filed — the one-shot defect is dead")
+
+    def test_the_unblocker_gains_no_verdict_power(self):
+        # the lift itself never completes anything: without the closer's done, the node stays open
+        s = self._lifted_store()
+        jd.rollup_status(s, session_closed=False)
+        self.assertNotEqual(s["status"].get(SID + ":g1"), "completed")
+
+
+class DeadlockedChainHeals(unittest.TestCase):
+    def test_a_pre_upgrade_orphan_re_nominates_via_the_default_stamp(self):
+        # the live g7 shape: a working top whose open descendant chain deadlocked the old channels —
+        # subtree-done needs all-kids-complete, the old starved signature refused. Post-upgrade there
+        # is no closerLookT anywhere, so the stamp defaults to each node's own mint and the child
+        # verdicts FILED after it re-arm the ask exactly once.
+        s = _store()
+        _node(s, "g7", "land the billing fix")
+        _node(s, "g8", "publish the branch", parent="g7",
+              log=[_row("done", T1, src="closer", why="pushed and merged")], nodeComplete=True)
+        _node(s, "g9", "verify in CI", parent="g7")
+        _node(s, "g11", "wrap up the rollout", parent="g9")
+        starved = {nd["id"] for nd in jd._starved_candidates(s)}
+        self.assertIn(SID + ":g11", starved,
+                      "the chain's untouched leaf rides the menu on the first post-upgrade pass — "
+                      "a verdict was filed in its top subtree after its mint")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_umbrella_completion.py
+++ b/tests/test_judge_umbrella_completion.py
@@ -10,8 +10,9 @@ connection" child closed, though the experiment never ran. Now:
     never the children;
   - all-children-done NOMINATES the node to the CLOSER (_subtree_done_candidates rides the turn
     menu with a steps-finished note), whose done/block/considered-omission is the ruling;
-  - a landed reply stamps the candidate's completion-set signature (store["umbSig"]) so an
-    unchanged set is never re-asked — the set changing is the re-arm event.
+  - a landed reply stamps the candidate's LOOK watermark (nd["closerLookT"], 2026-08-13 — the
+    retired umbSig/starvedSig signatures could not see a verdict LANDING on an existing child,
+    which orphaned a finished card for a day); a new FILING in the top subtree re-arms the ask.
 All fixtures synthetic (placeholder UUIDs, invented text)."""
 import json
 import os
@@ -130,16 +131,29 @@ class SubtreeDoneCandidates(unittest.TestCase):
         self.assertEqual(cands, {SID + ":g1"},
                          "only the open, unruled, all-children-done, unsealed, no-open-todo parent")
 
-    def test_sig_stamp_gates_and_the_set_change_rearms(self):
+    def test_look_stamp_gates_and_a_new_filing_rearms(self):
         s = _store()
         _node(s, "g1", "all steps finished, unruled")
-        _node(s, "g2", "finished step", parent="g1", done=True)
-        kidmap = {None: [SID + ":g1"], SID + ":g1": [SID + ":g2"]}
-        s["umbSig"] = {SID + ":g1": jd._umb_sig(s["nodes"], kidmap, SID + ":g1")}
+        _node(s, "g2", "finished step", parent="g1", done=True)           # done row at=T1
+        s["nodes"][SID + ":g1"]["closerLookT"] = T1                       # the closer looked at this world
         self.assertEqual(jd._subtree_done_candidates(s), [],
-                         "a stamped, unchanged completion set is never re-asked")
-        _node(s, "g3", "a newly finished step", parent="g1", done=True)   # the set changed → re-arm
+                         "nothing filed since the look → never re-asked")
+        _node(s, "g3", "a newly finished step", parent="g1", done=True,
+              log=[_row("done", T1 + 50)])                                # a NEW filing → re-arm
         self.assertEqual([nd["id"] for nd in jd._subtree_done_candidates(s)], [SID + ":g1"])
+
+    def test_a_verdict_landing_on_an_existing_child_rearms(self):
+        # THE g7 defect (2026-08-12): the retired child-id-set signature promised "a child's state
+        # flipped" re-arms, but an id-only set never delivered it — a done verdict FILED on an
+        # already-listed child left the umbrella orphaned forever. The filing watermark sees it.
+        s = _store()
+        _node(s, "g1", "all steps finished, unruled")
+        g2 = _node(s, "g2", "finished step", parent="g1", done=True)
+        s["nodes"][SID + ":g1"]["closerLookT"] = T1
+        self.assertEqual(jd._subtree_done_candidates(s), [], "looked, nothing new")
+        g2["log"].append(_row("done", T1 + 80, src="agent"))              # same child SET, new FILING
+        self.assertEqual([nd["id"] for nd in jd._subtree_done_candidates(s)], [SID + ":g1"],
+                         "the filing is the event — the id set never changed and must not matter")
 
 
 class CloserRulesTheCandidate(unittest.TestCase):
@@ -172,14 +186,16 @@ class CloserRulesTheCandidate(unittest.TestCase):
         self.assertTrue(top["trail"], "DONE-ANCHOR: the ruling turn's recap segment lands on the trail")
         self.assertIn("Run long soak experiment", seen["mt"])
         self.assertIn("is finished", seen["mt"], "the steps-finished note rides the menu")
-        self.assertIn(SID + ":g1", s.get("umbSig", {}), "the landed reply stamps the signature")
+        self.assertGreaterEqual(s["nodes"][SID + ":g1"].get("closerLookT") or 0, T1,
+                                "the landed reply stamps the look watermark (below apply, so the "
+                                "reply's own filing is covered)")
 
     def test_considered_omission_stamps_and_the_goal_stays_open(self):
         s = self._cand_store()
         jd.closer_llm = lambda tt, mt, *_a: '{"done": [], "block": []}'
         self.assertEqual(jd._close_turn(s, self.turn), [])
         self.assertFalse(s["nodes"][SID + ":g1"].get("nodeComplete"), "left open — steps are not the ask")
-        self.assertIn(SID + ":g1", s.get("umbSig", {}))
+        self.assertGreaterEqual(s["nodes"][SID + ":g1"].get("closerLookT") or 0, T1)
         jd.closer_llm = lambda tt, mt, *_a: (_ for _ in ()).throw(
             AssertionError("an unchanged completion set must not re-run the closer"))
         self.assertEqual(jd._close_turn(s, self.turn), [], "stamped + nothing touched → no LLM call")
@@ -188,7 +204,8 @@ class CloserRulesTheCandidate(unittest.TestCase):
         s = self._cand_store()
         jd.closer_llm = lambda tt, mt, *_a: ""                            # call failed → retry next pass
         self.assertIsNone(jd._close_turn(s, self.turn))
-        self.assertNotIn(SID + ":g1", s.get("umbSig", {}), "no ruling landed → the candidate stays armed")
+        self.assertIsNone(s["nodes"][SID + ":g1"].get("closerLookT"),
+                          "no ruling landed → the candidate stays armed")
 
 
 class StarvedCandidates(unittest.TestCase):
@@ -235,18 +252,28 @@ class StarvedCandidates(unittest.TestCase):
         self.assertEqual(jd._starved_candidates(s), [],
                          "nothing settled since the mint → nothing to judge the card against")
 
-    def test_sig_stamp_gates_and_a_new_settle_rearms(self):
+    def test_look_stamp_gates_and_a_new_filing_rearms(self):
         s = self._board()
-        kidmap = {}
-        for nid, nd in s["nodes"].items():
-            kidmap.setdefault(nd.get("parentId"), []).append(nid)
-        s["starvedSig"] = {nid: jd._starved_sig(s["nodes"], kidmap, nid)
-                           for nid in (SID + ":g2", SID + ":g3")}
+        for nid in (SID + ":g2", SID + ":g3"):
+            s["nodes"][nid]["closerLookT"] = T1                # the closer looked at this world (g4's done)
         self.assertEqual(jd._starved_candidates(s), [],
-                         "a stamped, unchanged settled set is never re-asked")
-        _node(s, "g8", "Verified detection in offline mode", parent="g1", done=True, mt=T1 + 50)
+                         "nothing filed since the look → never re-asked")
+        _node(s, "g8", "Verified detection in offline mode", parent="g1", done=True,
+              log=[_row("done", T1 + 50)])                     # a new FILING in the subtree → re-arm
         self.assertEqual({nd["id"] for nd in jd._starved_candidates(s)},
-                         {SID + ":g2", SID + ":g3"}, "another piece settling re-arms the ask")
+                         {SID + ":g2", SID + ":g3"}, "another piece filing re-arms the ask")
+
+    def test_a_post_outage_filing_with_old_evidence_still_rearms(self):
+        # the retired settled-set signature compared EVIDENCE times (mt >= mint) — a backlog sweep's
+        # verdict carries an OLD ev_t but a brand-new FILING (`at`); the watermark keys on the filing
+        s = self._board()
+        for nid in (SID + ":g2", SID + ":g3"):
+            s["nodes"][nid]["closerLookT"] = T1
+        old_evidence = {"ev_t": T0 - 500, "src": "closer", "kind": "done", "at": T1 + 90}
+        _node(s, "g9", "Swept-backlog completion", parent="g1", done=True, log=[old_evidence])
+        self.assertEqual({nd["id"] for nd in jd._starved_candidates(s)},
+                         {SID + ":g2", SID + ":g3"},
+                         "old evidence, new information — the arrival domain sees it")
 
 
 class CloserRulesTheStarved(unittest.TestCase):
@@ -281,14 +308,15 @@ class CloserRulesTheStarved(unittest.TestCase):
                          "the completion has an author and a diary row")
         self.assertIn("Deployed improved metric-trend detection fix", seen["mt"])
         self.assertIn("no work filed since creation", seen["mt"], "the no-work-filed note rides the menu")
-        self.assertIn(SID + ":g2", s.get("starvedSig", {}), "the landed reply stamps the signature")
+        self.assertGreaterEqual(s["nodes"][SID + ":g2"].get("closerLookT") or 0, T1,
+                                "the landed reply stamps the look watermark")
 
     def test_considered_omission_stamps_and_never_reasks(self):
         s = self._board()
         jd.closer_llm = lambda tt, mt, *_a: '{"done": [], "block": []}'
         self.assertEqual(jd._close_turn(s, self.turn), [])
         self.assertFalse(s["nodes"][SID + ":g2"].get("nodeComplete"), "left open on purpose")
-        self.assertIn(SID + ":g2", s.get("starvedSig", {}))
+        self.assertGreaterEqual(s["nodes"][SID + ":g2"].get("closerLookT") or 0, T1)
         jd.closer_llm = lambda tt, mt, *_a: (_ for _ in ()).throw(
             AssertionError("an unchanged settled set must not re-run the closer"))
         self.assertEqual(jd._close_turn(s, self.turn), [], "stamped + nothing new settled → no LLM call")
@@ -297,7 +325,8 @@ class CloserRulesTheStarved(unittest.TestCase):
         s = self._board()
         jd.closer_llm = lambda tt, mt, *_a: ""                            # call failed → retry next pass
         self.assertIsNone(jd._close_turn(s, self.turn))
-        self.assertNotIn(SID + ":g2", s.get("starvedSig", {}), "no ruling landed → the card stays armed")
+        self.assertIsNone(s["nodes"][SID + ":g2"].get("closerLookT"),
+                          "no ruling landed → the card stays armed")
 
 
 class PromptPins(unittest.TestCase):


### PR DESCRIPTION
PR B of the stuck-card program (subtractive designs + adversarial critics; all must-fix findings folded in, plus one interaction the tests caught that the critics missed).

The orphan this kills: a finished card sat open for a day because the closer's re-ask gates were one-shot signatures — the umbrella channel keyed on the child ID SET (blind to a verdict landing on an existing child), the starved channel compared EVIDENCE times (blind to post-outage filings whose evidence was old but whose information was new), and the unblocker's lift — whose own why said "merged and deployed" — had no path to the done authority.

- **Deleted:** `_umb_sig`/`umbSig`, `_starved_sig`/`starvedSig`, and their stamp block; three verbatim helper closures collapsed to module level; `migrate_store` pops the dead keys.
- **One look-stamp** (`closerLookT`) re-armed by the exact event both signatures approximated: a diary row **filed** in the node's top subtree since the last look. Stamped below `apply_close` (the reply's own filings covered); deploy default = the node's mint, so already-orphaned candidates re-nominate once on the first post-upgrade pass.
- **Lift-riders:** an unheard unblocker lift puts the node on the closer's menu with the lift's why — evidence routed to the existing authority, no new verdict power.
- **Stand-down** at the closer's write site: a verdict that would not change the node's folded state (simulated with `_fold_node`, the authority itself) is dropped + logged loudly (`stale-close`); no requeue (loops forever on fold ties — both critics flagged it).
- **Evidence anchoring:** a lift-rider's verdict anchors to its lift's ev_t, not the audited turn's — otherwise the stand-down sees the ruling as pre-shadowed by the very lift that nominated it (caught by the new behavioral tests).

Tests: `tests/test_judge_close_standdown.py` (new — shadowed verdicts drop loudly and write nothing; unshadowed land; lifts ride with their why and retire on the look-stamp; the unblocker completes nothing by itself; the pre-upgrade orphan shape re-nominates via the default stamp) and `tests/test_judge_umbrella_completion.py` rewritten to filing-event semantics, including the exact defect case (a verdict on an existing child re-arms) and the arrival-vs-evidence domain case. Full pytest suite green locally (4360 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)