### PR TITLE
Every working card narrates its open turn: tool count + running time

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -124,6 +124,32 @@ def _suspended_after(t):
     return any(start > (t or 0) for (start, _e) in _downtime)
 
 
+def _open_turn_progress(turns):
+    """{"since", "toolUses"} for the session's OPEN turn — the live narration every working card wears
+    (the user 2026-08-13: "always some detail about why they're working" — a tool count that climbs
+    and a timer that runs make a silently-stuck session visible at a glance, because a frozen count
+    under a climbing timer LOOKS wrong). None when the last turn ended: the other spin states
+    (Analyzing…, Awaiting…, the stall chip, the Blocked floors) own every idle beat, so this covers
+    exactly the case that used to be mute — an ordinary working card with its turn open. Derived from
+    the same cached parse as the working dot; a tool use is an assistant record's tool_use block."""
+    if not turns:
+        return None
+    lt = turns[-1]
+    if lt.get("ended"):
+        return None
+    n = 0
+    for a in (lt.get("atoms") or []):
+        if a.get("type") != "assistant":
+            continue
+        try:
+            for blk in ((a.get("message") or {}).get("content") or []):
+                if isinstance(blk, dict) and blk.get("type") == "tool_use":
+                    n += 1
+        except Exception:
+            pass
+    return {"since": lt.get("t"), "toolUses": n}
+
+
 def _session_working(turns):
     """Whether a session is ACTIVELY WORKING — the single source of truth for the working signal (the yellow
     dot on every surface, the auto-nudge orphan check). Derived from the EVENT MODEL: its last turn is OPEN
@@ -14201,6 +14227,9 @@ def build_feed(now, tmux=None):
             who_working = False
         if who_working:
             working.append(name)
+        # the open turn's live narration (the user 2026-08-13) — computed once per session, ridden by
+        # every working card below; cache-warm like the dot (a cold start paints plain, then snaps in)
+        sess_progress = _open_turn_progress(ps["turns"]) if (ps and who_working) else None
         # The user's LAST action on this session was an INTERRUPT (no message from them since): its quiet
         # is user-chosen, not a stall — auto-nudge is suppressed (same predicate, _auto_nudge_tick) and
         # the working card wears an "interrupted" badge saying so (the user 2026-07-05). Cache-only,
@@ -14875,7 +14904,8 @@ def build_feed(now, tmux=None):
                 "column": column,
                 "recheck": recheck,                  # targeted follow-up on a soft-block → de-urgented (dotted), moved to Working, pending re-judge
                 "rejudging": rejudging,              # plain thread reply after a block → STAYS in Needs-You, "Re-judging…" swirl while a turn is in flight (the user 2026-06-30)
-                "judging": bool((sess_judging or _stall_inflight) and column == "working"),   # turn settled, closer verdict pending → "Analyzing…" swirl covers the finished-but-still-Working beat (the user 2026-07-13); same key the provisional card wears
+                "judging": bool((sess_judging or _stall_inflight) and column == "working"),
+                "working": (sess_progress if column == "working" else None),   # open-turn narration: tool count + since (the user 2026-08-13)   # turn settled, closer verdict pending → "Analyzing…" swirl covers the finished-but-still-Working beat (the user 2026-07-13); same key the provisional card wears
                 "warnRows": (_card_warn_rows(dbg_rows, fsid, set(_subtree(nid)),
                                              store.get("placements") or {}) or None)
                             if dbg_rows is not None else None,   # debug mode only: the card's judge failures, modal "Warnings" section

--- a/tests/test_kernel_working_narration.py
+++ b/tests/test_kernel_working_narration.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Every working card narrates its open turn (the user 2026-08-13): tool count + running time — the
+previously-mute "ordinary working card" case. A frozen count under a climbing timer is how a silent
+regression becomes visible at a glance. Synthetic fixtures only."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_narr", os.path.join(BIN, "romp-kernel")).load_module()
+
+T0 = 1781100000
+
+
+def _tool(n="Bash"):
+    return {"type": "assistant",
+            "message": {"role": "assistant",
+                        "content": [{"type": "tool_use", "name": n, "input": {}}]}}
+
+
+def _text(t="working on it"):
+    return {"type": "assistant", "message": {"role": "assistant",
+                                             "content": [{"type": "text", "text": t}]}}
+
+
+class OpenTurnProgress(unittest.TestCase):
+    def test_counts_tool_uses_in_the_open_turn(self):
+        turns = [{"id": "t1", "t": T0, "ended": False,
+                  "atoms": [{"type": "user", "message": {}}, _tool(), _text(), _tool(), _tool()]}]
+        self.assertEqual(km._open_turn_progress(turns), {"since": T0, "toolUses": 3})
+
+    def test_an_ended_turn_narrates_nothing(self):
+        # the other spin states (Analyzing…, the stall chip, the floors) own every idle beat
+        turns = [{"id": "t1", "t": T0, "ended": True, "atoms": [_tool()]}]
+        self.assertIsNone(km._open_turn_progress(turns))
+        self.assertIsNone(km._open_turn_progress([]))
+
+    def test_only_assistant_tool_use_blocks_count(self):
+        turns = [{"id": "t1", "t": T0, "ended": False,
+                  "atoms": [{"type": "user", "message": {"content": [{"type": "tool_use"}]}},
+                            _text(), {"type": "assistant", "message": None}]}]
+        self.assertEqual(km._open_turn_progress(turns)["toolUses"], 0)
+
+
+class PayloadPins(unittest.TestCase):
+    def test_working_cards_carry_the_narration(self):
+        import inspect
+        src = inspect.getsource(km.build_feed)
+        self.assertIn('sess_progress = _open_turn_progress(ps["turns"]) if (ps and who_working) else None', src)
+        self.assertIn('"working": (sess_progress if column == "working" else None)', src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -68,7 +68,8 @@ interface AskItem {
   recheck?: boolean;                               // soft-block you answered with a TARGETED follow-up → de-urgented (dotted), moved to Working, dropped from the "need input" count, until the judge resolves or re-blocks it (kernel build_feed; the user 2026-06-27)
   rejudging?: boolean;                             // soft-block + a PLAIN thread reply after it → moves to WORKING while the reply is in flight (echo/open turn), with a "Re-judging…" swirl; returns to Needs-You on its own if the judge leaves it blocked (kernel build_feed; the user 2026-07-02, immediate)
   nudgeFailed?: boolean;                           // the ONE auto-nudge on this stalled goal didn't resolve it → red "follow-up failed" chip (renamed off "stalled" 2026-07-23 — that word is the yellow romp-holding section's now); the failure also records a BLOCK verdict, so the card reaches Needs-you via the normal ladder (kernel _mark_nudge_failed, 2026-07-07)
-  stalled?: { why: string; since: number; note?: string | null; blocked?: boolean } | null;   // romp's nudge gate is HOLDING this working card behind a reviver that isn't retiring, so nothing is moving it (kernel _stalled_goals; the user 2026-07-23). `why` = the kernel's mechanical reason, always present; `note` = the staller's plain-language version, null until the judge writes one. Drives the Stalled section button — its own colour, since this is romp being the bottleneck, not you
+  stalled?: { why: string; since: number; note?: string | null; blocked?: boolean } | null;
+  working?: { since?: number | null; toolUses?: number | null } | null;   // open-turn narration: tool count + start (kernel _open_turn_progress; the user 2026-08-13)   // romp's nudge gate is HOLDING this working card behind a reviver that isn't retiring, so nothing is moving it (kernel _stalled_goals; the user 2026-07-23). `why` = the kernel's mechanical reason, always present; `note` = the staller's plain-language version, null until the judge writes one. Drives the Stalled section button — its own colour, since this is romp being the bottleneck, not you
   interrupting?: boolean;                          // a user interrupt is IN FLIGHT (dispatched, not yet settled) → steady "interrupting…" badge from the click until it settles, THEN yields to `interrupted` — never flickering to "working" in between (kernel build_feed; the user 2026-07-07)
   interrupted?: boolean;                           // the user STOPPED this session mid-turn and hasn't messaged it since → "interrupted" badge; its quiet is user-chosen, auto-nudge holds off until their next message (kernel build_feed; the user 2026-07-05)
   retrying?: { since?: number | null; count?: number } | null;   // the OPEN turn is inside an api-retry storm (kernel _session_retrying, live backend state) → "⚠ retrying since HH:MM" chip on the working card; without it a storm reads as plain healthy Working (the user 2026-07-09)
@@ -1495,7 +1496,7 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // The card is not left mute in that window: the Working displacement only happens under recheck/rejudging,
   // and both raise the "Analyzing…" swirl below, which says the judge is looking at it again.
   const spin = spinFor(it, distillPending(dCompleted, dBlocked, it.summary, it.blockSummary, !!it.blocked),
-                       dCompleted);
+                       dCompleted, Date.now() / 1000);
   const spinCaption = spin.caption, spinTip = spin.tip, awaitingBg = spin.awaitingBg;
   a._awaitSpin.style.display = spinCaption ? "" : "none";
   // The AWAITING case gets a rounded box (its distinct read); the swirl spins in every case now.

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -138,3 +138,35 @@ test("feed.ts routes the card's swirl through spinFor and keeps no inline copy o
   assert.match(FEED, /a\._awaitSpin\.classList\.toggle\("await-paused", awaitingBg\);/);
   assert.match(FEED, /a\._awaitWhy\.textContent = spinCaption; a\._awaitSpin\.title = spinTip \|\| spinCaption;/);
 });
+
+// --- the working narration (the user 2026-08-13): the previously-mute ordinary working card ---------
+test("an ordinary working card with its turn open narrates: tool count + running time", () => {
+  const s = spinFor({ column: "working", working: { since: 1000, toolUses: 23 } },
+                    false, false, 1000 + 8 * 60);
+  assert.equal(s.caption, "Working — 23 tool uses · 8m");
+  const one = spinFor({ column: "working", working: { since: 1000, toolUses: 1 } },
+                      false, false, 1030);
+  assert.equal(one.caption, "Working — 1 tool use · 0m", "singular reads as English");
+  const long = spinFor({ column: "working", working: { since: 1000, toolUses: 400 } },
+                       false, false, 1000 + 95 * 60);
+  assert.equal(long.caption, "Working — 400 tool uses · 1h 35m", "hours split out past sixty minutes");
+});
+
+test("the narration is the FLOOR — every richer story still wins", () => {
+  const w = { since: 1000, toolUses: 5 };
+  assert.equal(spinFor({ column: "working", working: w, judging: true }, false, false, 2000).caption,
+               "Analyzing…", "the settle gap outranks narration");
+  assert.equal(spinFor({ column: "working", working: w, recheck: true }, false, false, 2000).caption,
+               "Analyzing…", "re-check outranks narration");
+  assert.equal(spinFor({ column: "working", working: w, awaiting: { why: null } }, false, false, 2000).caption,
+               "Awaiting background agents", "awaiting outranks narration");
+  assert.equal(spinFor({ column: "working", working: w }, true, false, 2000).caption,
+               "Distilling…", "a pending distill outranks narration");
+});
+
+test("no narration off the working column or without the payload", () => {
+  assert.equal(spinFor({ column: "needs_input", working: { since: 1, toolUses: 2 } }, false, false, 100).caption,
+               null);
+  assert.equal(spinFor({ column: "working" }, false, false, 100).caption, null,
+               "a cache-cold card paints plain until the payload snaps in");
+});

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -33,6 +33,7 @@ export interface SpinItem {
   recheck?: boolean;
   rejudging?: boolean;
   blocked?: unknown;
+  working?: { since?: number | null; toolUses?: number | null } | null;   // open-turn narration (kernel _open_turn_progress; the user 2026-08-13)
 }
 
 /** caption: the body line, or null for no spin. tip: the fuller hover explanation. awaitingBg: the
@@ -48,7 +49,14 @@ const NONE: Spin = { caption: null, tip: "", awaitingBg: false };
 /** dCompleted/dBlocked come from distillInputs(distillState, column) — the GENUINE resolution state, not
  *  the transient column. distillPending is passed in (rather than recomputed) so the two modules keep one
  *  owner for the "is the distiller still working" rule. */
-export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boolean): Spin {
+/** Compact duration for the working narration: minutes under an hour, then h+m. */
+function workingFor(secs: number): string {
+  const m = Math.max(0, Math.floor(secs / 60));
+  return m < 60 ? `${m}m` : `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
+
+export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boolean, nowS?: number): Spin {
   const aw = it.awaiting;
   // a bg-TASK wait no longer boxes its why here (the user 2026-07-13): the compact "Waiting on task" pill
   // on the toggles row carries it (with the task list one click away, like Sub-goals) — see applySections
@@ -128,6 +136,21 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
     return {
       caption: "Distilling…",
       tip: dCompleted ? "Writing the key takeaway…" : "Writing the decision brief…",
+      awaitingBg: false,
+    };
+  }
+  if (it.working && it.column === "working") {
+    // WORKING NARRATION (the user 2026-08-13) — the ordinary working card with its turn open used to
+    // be the ONE mute case ("no spin"). Now it says what is actually happening: the open turn's tool
+    // count and how long it has been running, both live — a frozen count under a climbing timer is
+    // how a silent regression becomes visible at a glance. Every richer story above (awaiting,
+    // provisional, re-check, re-judging, the settle gap, distilling) still wins; this is the floor.
+    const n = it.working.toolUses || 0;
+    const dur = nowS && it.working.since ? ` · ${workingFor(nowS - it.working.since)}` : "";
+    return {
+      caption: `Working — ${n} tool ${n === 1 ? "use" : "uses"}${dur}`,
+      tip: "The open turn's live progress: tool calls made so far, and how long this stretch has been "
+         + "running. If the count freezes while the timer climbs, something is worth a look.",
       awaitingBg: false,
     };
   }


### PR DESCRIPTION
PR E of the stuck-card program. The ordinary working card with its turn open was the spin ladder's one deliberately mute case — deleted: the floor branch now narrates `Working — 23 tool uses · 8m`, from the open turn's assistant `tool_use` blocks (same cached parse as the working dot) and the turn's start time, re-rendered per push. A frozen count under a climbing timer makes a silent regression visible at a glance.

Every richer story still wins (awaiting, provisional, re-check, re-judging, settle gap, distilling) — this is the floor, not a new state. Idle beats are owned by the other spin states and the stall machinery from PR C, so between the two, a card in Working always says what's happening.

`spinFor` gains an optional clock parameter so the executable ladder tests run with a fixed now.

Tests: three new executable ladder cases in `spin-caption.test.ts` (caption text incl. singular/hours, floor precedence, off-column/no-payload) and `tests/test_kernel_working_narration.py` (the counter's behavior + payload pins). Full suites green locally (pytest 4373, node 1870, typecheck clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)