### PR TITLE
Slash commands park mid-turn and fire alone at turn end

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4858,7 +4858,7 @@ def _drive(msg, client):
     be = Sessions.backend_for(sid)
     if t == "sendMessage" and msg.get("text"):
 
-        _send_or_park(be, sid, str(msg["text"]), echo="human"); _push_soon()  # idle → instant echo; SDK busy → queued bubble forwarded mid-turn + folded; tmux busy → held + merged at turn end
+        _send_or_park(be, sid, str(msg["text"]), echo="human"); _push_soon()  # idle → instant echo; SDK busy → queued bubble forwarded mid-turn + folded (but a SLASH COMMAND parks to fire alone at turn end — mid-turn it would land as text, not execute); tmux busy → held + merged at turn end
     elif t == "rewindSend" and msg.get("uuid") and msg.get("text"):
         # Edit a past message (SDK sessions): rewind the conversation to just before it and send the
         # edited text as the branch's next turn. NO optimistic kernel echo — the edit lands mid-chat
@@ -11519,6 +11519,8 @@ def _parked_md(op):
     matches the park slot before removing it (the user 2026-07-08)."""
     if op[0] == "send":
         return _split_followup(op[1])[1]
+    if op[0] == "command":
+        return op[1]                     # the typed slash command IS the bubble (so the running-/compact fold matches it too)
     if op[0] == "compact":
         return "/compact"
     return "/%s %s" % (op[0], op[1])
@@ -11602,6 +11604,18 @@ def _forwards_sends(be):
         return False
 
 
+# A leading slash-COMMAND token ("/autocompact auto", "/compact"), not a path ("/tmp/x is broken",
+# "/Users/…"): the token must end at whitespace/EOL before any second "/". Shape-matched, not matched
+# against the session's command list, deliberately — the CLI owns what executes; romp only decides WHEN
+# it can execute (as a fresh top-level prompt). A slash-shaped non-command just arrives at turn end as
+# text, same as it always did, a beat later.
+_SLASH_CMD_RE = re.compile(r"^/[A-Za-z0-9][\w:-]*(\s|$)")
+
+
+def _is_slash_command(text):
+    return bool(_SLASH_CMD_RE.match((text or "").strip()))
+
+
 def _send_or_park(be, sid, text, echo=None):
     """Deliver `text` now — or PARK it in the sid's FIFO. Park when: (a) the session is COMPACTING (the user
     2026-07-02: a mid-compaction send's live-tail echo opened a turn that KILLED the 'compacting' cue — a
@@ -11616,12 +11630,20 @@ def _send_or_park(be, sid, text, echo=None):
     boundary, folds several queued sends into one turn, and holds them across an interrupt (the user
     2026-07-17: "get user messages in as soon as possible; we don't have to interrupt but get them in"); the
     still-waiting message renders as a queued bubble (its echo is suppressed) until it forwards. `echo` is
-    the _optimistic_echo author stamped when the send actually fires (None = the backend echoes for itself)."""
+    the _optimistic_echo author stamped when the send actually fires (None = the backend echoes for itself).
+
+    EXCEPTION to the forward-now rule: a typed SLASH COMMAND ("/autocompact auto") parks whenever a turn is
+    open, even on a forwards_sends backend (the user 2026-08-13): the CLI only EXECUTES a slash command
+    arriving as a fresh top-level prompt — forwarded into a running turn it lands as plain user text, the
+    model politely replies to it, and the setting never changes. Parked as a ("command",) op, it fires ALONE
+    at turn end (never folded into a send batch, which would bury it as text the same way)."""
+    cmd = _is_slash_command(text)
+    op = ("command", text, echo) if cmd else ("send", text, echo)
     if _compacting_now(sid) or _pending_ops.get(sid) or _limit_hold(sid):
-        _park_op(sid, ("send", text, echo))
+        _park_op(sid, op)
         return
-    if _working_now(sid) and not _forwards_sends(be):
-        _park_op(sid, ("send", text, echo))
+    if _working_now(sid) and (cmd or not _forwards_sends(be)):
+        _park_op(sid, op)
         return
     be.send(sid, text)
     if echo:
@@ -11723,6 +11745,18 @@ def _apply_pending_ops():
                         run.append(ops.pop(0))
                     _deliver_send_batch(be, sid, run)
                     break                             # the delivered turn must END before any op behind it fires
+                elif op[0] == "command":
+                    # a typed slash command fires ALONE as its own fresh top-level prompt — folded into a
+                    # send batch (or forwarded mid-turn) it reaches the model as text instead of executing
+                    # (the user 2026-08-13: /autocompact absorbed mid-turn got a polite reply and no
+                    # setting change). Echo stamped at fire time, like a delivered send.
+                    be.send(sid, op[1])
+                    if len(op) > 2 and op[2]:
+                        _optimistic_echo(sid, op[1], author=op[2])
+                    if op[1].strip().split()[0] == "/compact":
+                        _mark_compacting(sid)         # a TYPED /compact gets the same instant cue as the button's op
+                    ops.pop(0)
+                    break                             # its turn must end before anything behind it fires
                 elif op[0] == "compact":
                     be.send(sid, "/compact")
                     _mark_compacting(sid)

--- a/tests/test_kernel_send_park.py
+++ b/tests/test_kernel_send_park.py
@@ -528,5 +528,83 @@ class CancelBackendQueued(unittest.TestCase):
                          "too late to cancel /model — the session already has it")
 
 
+class SlashCommandParksWhileTurnOpen(unittest.TestCase):
+    """A typed SLASH COMMAND parks whenever a turn is open — even on a forwards_sends (SDK) backend — and
+    fires ALONE at turn end (the user 2026-08-13): forwarded mid-turn, "/autocompact auto" reached the
+    model as plain text, the model politely replied, and the setting never changed. Plain messages keep
+    the forward-now path; slash-SHAPED paths ("/tmp/x") are not commands and keep it too."""
+
+    def setUp(self):
+        self.be = _FakeBackend()
+        self.be.forwards_sends = lambda: True          # an SDK-like backend: takes sends mid-turn
+        self.echoes = []
+        self._saved = (km._compacting_now, km.Sessions.backend_for, km._push_all, km._optimistic_echo,
+                       km._working_now)
+        km._push_all = lambda: None
+        km._optimistic_echo = lambda sid, text, author="human": self.echoes.append((text, author))
+        km._compacting_now = lambda sid: False
+        km._working_now = lambda sid: True             # a turn is OPEN throughout, unless a test says otherwise
+        km._pending_ops.clear()
+
+    def tearDown(self):
+        (km._compacting_now, km.Sessions.backend_for, km._push_all, km._optimistic_echo,
+         km._working_now) = self._saved
+        km._pending_ops.clear()
+
+    def test_shape_matcher_commands_yes_paths_and_prose_no(self):
+        for t in ("/autocompact auto", "/compact", "/model opus", "/mcp__srv__tool go", "/loop 5m /foo"):
+            self.assertTrue(km._is_slash_command(t), t)
+        for t in ("/tmp/x is broken", "/Users/nobody/file.txt", "hello /compact", "", "  ", "/"):
+            self.assertFalse(km._is_slash_command(t), t)
+
+    def test_plain_text_still_forwards_mid_turn_but_a_command_parks(self):
+        km._send_or_park(self.be, SID, "keep going, and also check the logs", echo="human")
+        self.assertEqual(self.be.calls, [("send", "keep going, and also check the logs")],
+                         "plain text keeps the forward-now path — get messages in ASAP")
+        km._send_or_park(self.be, SID, "/autocompact auto", echo="human")
+        self.assertEqual(self.be.calls[1:], [], "the command did NOT go into the running turn")
+        self.assertEqual(km._pending_ops.get(SID), [("command", "/autocompact auto", "human")])
+        self.assertEqual(self.echoes, [("keep going, and also check the logs", "human")],
+                         "the parked command has not echoed yet — it renders as a queued bubble instead")
+
+    def test_parked_command_fires_alone_at_turn_end_with_its_echo_and_ends_the_pass(self):
+        km._pending_ops[SID] = [("command", "/autocompact auto", "human"), ("send", "then this", None)]
+        km.Sessions.backend_for = lambda sid: self.be
+        km._apply_pending_ops()
+        self.assertEqual(self.be.calls, [], "turn still open → still parked")
+        km._working_now = lambda sid: False
+        km._apply_pending_ops()
+        self.assertEqual(self.be.calls, [("send", "/autocompact auto")],
+                         "the command fires ALONE — never folded into a send batch")
+        self.assertEqual(self.echoes, [("/autocompact auto", "human")], "echo stamps at fire time")
+        self.assertEqual(km._pending_ops.get(SID), [("send", "then this", None)],
+                         "the pass ends at the command — its turn must finish first")
+
+    def test_typed_compact_marks_compacting_like_the_buttons_op(self):
+        marked = []
+        _saved_mark = km._mark_compacting
+        km._mark_compacting = lambda sid: marked.append(sid)
+        try:
+            km._pending_ops[SID] = [("command", "/compact", None)]
+            km.Sessions.backend_for = lambda sid: self.be
+            km._working_now = lambda sid: False
+            km._apply_pending_ops()
+            self.assertEqual(self.be.calls, [("send", "/compact")])
+            self.assertEqual(marked, [SID], "a typed /compact gets the same instant compacting cue")
+        finally:
+            km._mark_compacting = _saved_mark
+
+    def test_parked_md_renders_the_command_itself(self):
+        self.assertEqual(km._parked_md(("command", "/autocompact auto", "human")), "/autocompact auto")
+
+    def test_idle_command_goes_straight_through(self):
+        km._working_now = lambda sid: False
+        km._send_or_park(self.be, SID, "/autocompact auto", echo="human")
+        self.assertEqual(self.be.calls, [("send", "/autocompact auto")],
+                         "idle → a fresh top-level prompt already, nothing to park")
+        self.assertEqual(self.echoes, [("/autocompact auto", "human")])
+        self.assertNotIn(SID, km._pending_ops)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A typed slash command forwarded into a running SDK turn lands as plain user text — the model replies to it and nothing executes (the /autocompact incident). Slash-shaped text now parks as a ("command",) pending op whenever a turn is open and fires alone as a fresh top-level prompt at turn end, with its queued bubble, echo-at-fire, cancel handshake, and an instant compacting cue for a typed /compact. Covered in tests/test_kernel_send_park.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)