### PR TITLE
The Continue button's gesture reaches the kernel

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4866,7 +4866,13 @@ def _drive(msg, client):
         sid = str(msg["id"])
     elif t in ("compact", "sendCommand") and msg.get("name"):
         sid = _sid_of(str(msg["name"]))                   # the timeline keys these by session NAME
-    elif t == "askFollowUp" and (msg.get("itemId") or msg.get("id")) and msg.get("text"):
+    elif t == "askFollowUp" and (msg.get("itemId") or msg.get("id")) and (msg.get("text") or msg.get("cont")):
+        # cont:true is the Continue button (2026-08-08), which deliberately carries NO text — the kernel
+        # supplies CONTINUE_TEXT in the handler body below. The old text-only guard turned every Continue
+        # press into a dropped message: no send, no reopen, no cardMoveAck — so the feed's optimistic move
+        # timed out and bounced the card back with "romp didn't confirm that move" on EVERY click (the
+        # user 2026-08-13, who reasonably concluded the button was useless). The handler always supported
+        # cont; its front door never let it in.
         sid = str(msg["itemId"]).rsplit(":", 1)[0] if msg.get("itemId") else str(msg["id"])
     else:
         return False                                      # not a drive op (UI/nav) → _dispatch_ws handles it

--- a/tests/test_kernel_continue_button.py
+++ b/tests/test_kernel_continue_button.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""The Continue button's gesture is a drive op (the user 2026-08-13).
+
+The incident: Continue (askFollowUp with cont:true) deliberately carries NO text — the kernel supplies
+CONTINUE_TEXT in the handler body — but the drive-op entry guard required text, so every press was
+silently dropped: no send, no optimistic reopen, no cardMoveAck. The feed's optimistic move then timed
+out and bounced the card back to Blocked with "romp didn't confirm that move" on EVERY click, which
+made the button read as useless. The handler always supported cont; its front door never let it in.
+
+Synthetic sids only.
+"""
+import inspect
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_contbtn", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+GID = SID + ":g7"
+
+
+class ContinueIsADriveOp(unittest.TestCase):
+    """_drive's entry classifier must admit the gesture — the regression that killed the button."""
+
+    def _classified(self, msg):
+        """Whether _drive CLAIMS the message (anything but the not-a-drive-op False), with every
+        downstream dependency stubbed to a refusal-free no-op so only the classifier is under test."""
+        saved = km._kernel_knows
+        km._kernel_knows = lambda sid: False   # short-circuit right after classification: the foreign-sid
+        try:                                   # refusal path returns True (claimed), False means unclassified
+            saved_refuse = km._refuse_drive
+            km._refuse_drive = lambda *a, **k: None
+            try:
+                return km._drive(dict(msg), client=None) is not False
+            finally:
+                km._refuse_drive = saved_refuse
+        finally:
+            km._kernel_knows = saved
+
+    def test_a_continue_gesture_is_classified(self):
+        self.assertTrue(self._classified({"type": "askFollowUp", "itemId": GID, "sid": SID, "cont": True}),
+                        "cont:true carries no text BY DESIGN — the guard must admit it")
+
+    def test_a_typed_followup_is_classified(self):
+        self.assertTrue(self._classified({"type": "askFollowUp", "itemId": GID, "sid": SID,
+                                          "text": "already answered this in the thread"}))
+
+    def test_an_empty_followup_is_still_refused(self):
+        self.assertFalse(self._classified({"type": "askFollowUp", "itemId": GID, "sid": SID}),
+                         "no text and no cont → still not a sendable gesture")
+
+    def test_the_handler_body_supplies_the_canned_text(self):
+        src = inspect.getsource(km._drive)
+        self.assertIn('text = CONTINUE_TEXT if msg.get("cont") else str(msg["text"])', src)
+        self.assertIn('(msg.get("text") or msg.get("cont"))', src,
+                      "the front door admits what the body supports — one contract")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Continue (`askFollowUp` with `cont:true`) deliberately carries no text — the kernel supplies `CONTINUE_TEXT` in the handler body. But the drive-op **entry guard** required `msg.text`, so every press was silently dropped: no send, no optimistic reopen, no `cardMoveAck` — the feed's optimistic move timed out and bounced the card back with "romp didn't confirm that move" on every single click. The handler body always supported `cont`; its front door never let it in.

One-line guard fix (`text or cont`), with behavioral tests: a cont gesture is classified as a drive op, a typed follow-up still is, an empty follow-up (neither) is still refused, and the front-door/body contract is pinned. Full pytest suite green locally (4377 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)