### PR TITLE
Fork a session into a new parallel thread, from any message or the tip

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9061,9 +9061,17 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
         cstore = load_goals(fsid)
         closed[fsid] = _session_settled(fsid, str(path), session, cstore)
         placed_ids = cstore["placements"]
+        floor = episode_floor(fsid)
         for turn in session["turns"]:
             for seg in _segs(turn, cstore):
                 if seg["id"] in placed_ids:
+                    continue
+                if floor and seg["t"] < floor:
+                    # pre-episode: conversation the agent can no longer see. The planner retires these
+                    # before any model call; the courier needs its own guard because a FORK's copied
+                    # history is the first shape that leaves OLD peer segments visible here (a /clear's
+                    # null-rooted head drops pre-clear history from the parse for free, so this never
+                    # fired before). Defense in depth beside the fork's sealed-placements seed.
                     continue
                 pm = _seg_peer(seg)
                 if not pm or not pm[0]:                # peer-triggered with a known sender only

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4298,6 +4298,121 @@ def _create_sdk_session(nm, cwd, auth=""):
     return sid
 
 
+def _fork_session(parent_sid, cut_msg_uuid, new_name, now=None):
+    """Fork `parent_sid`'s conversation into a NEW parallel session named `new_name` — from just BEFORE
+    user message `cut_msg_uuid` when given (the chat's fork button; same _rewind_target resolution and
+    guards as the edit/delete rewind, so "before this message" means the same thing everywhere), the
+    whole conversation otherwise (the palette's fork-from-tip). The parent is untouched: both continue
+    as separate threads (the user 2026-08-13). Returns an error string for the caller to warn-toast
+    (fail loudly), None on success. SDK sessions only in v1 — the mechanism IS the SDK's
+    resume+fork_session contract; a tmux session says so instead of degrading.
+
+    ORDER MATTERS: the judge stores are seeded BEFORE be.fork writes the names/ entry — discover()
+    iterates names/, so an unseeded fork must not be discoverable even for one judge pass (the replay
+    storm: every copied prompt re-minted as a fresh card, every turn re-captioned). Seeding failure
+    aborts the fork loudly rather than creating an unprotected session. Then the same ACK-FAST shape
+    as _create_sdk_session: focus first, dirty-mark wake, one direct push of the new tab."""
+    nm = (new_name or "").strip()
+    if not NAME_RE.match(nm):
+        return "session names use letters, digits, . _ - only."
+    be = Sessions.backend_for(parent_sid)
+    if not (hasattr(be, "fork") and _sdk_ready()):
+        return "fork needs the SDK backend — this session runs on tmux, so there is nothing to fork from."
+    now = now or time.time()
+    sess = next((s for s in _sessions(now) if s["sid"] == parent_sid), None)
+    if not sess:
+        return "no transcript for this session yet — nothing to fork."
+    cut_uuid = ""
+    if cut_msg_uuid:
+        cut_uuid, err = _rewind_target(sess["path"], parent_sid, str(cut_msg_uuid))
+        if err:
+            return err
+    sid = str(uuid.uuid4())
+    err = _seed_fork_stores(parent_sid, sid, sess["path"], cut_uuid)
+    if err:
+        return err
+    bg, fg = _pick_identity_color()
+    be.fork(nm, parent_sid, cut_uuid, bg, fg, sid=sid)
+    be.connect(sid)          # eager-connect: the CLI copies the conversation and the tab fills in
+    _reveal_chat({"type": "focus", "id": sid})
+    _mark_views_dirty()
+    _push_session_now(sid)
+    return None
+
+
+def _seed_fork_stores(parent_sid, sid, path, cut_uuid):
+    """Judge-store hygiene for a session born as a FORK: its transcript carries the parent's history
+    VERBATIM (uuids + timestamps survive the CLI's fork copy — verified live 2026-08-13), which the
+    judges must not re-judge as fresh work. Three seeds, each preventing a distinct storm:
+      1. episodes/<sid>.jsonl seed+boundary rows → episode_floor(sid) = the cut record's t, so the
+         planner retires every copied unit before any model call (units are time-keyed, so this
+         survives seg-id derivation drift). The seed row carries the conversation ROOT uuid — the
+         boundary tick dedups on it when it sights the fork's head (same uuid, copied), and a
+         chained-head fork (root:false) skips the tick entirely; either way the floor stands.
+      2. captions/<sid>.jsonl transform-copied from the parent (non-live rows at/before the cut, id
+         prefix resid'd) → no Haiku re-caption storm, and the copied history's hovers arrive filled.
+      3. goals/<sid>.json born with the parent's placements SEALED (keys resid'd, every value None =
+         "processed, no goal") — covers the courier, which scans unplaced peer segments, and
+         belts-and-braces the planner. No nodes are copied: copied cards would duplicate across the
+         parent and fork boards.
+    Returns an error string (the fork is aborted) or None — a fork without this seeding re-judges the
+    whole copied history, so failing loudly beats creating it unprotected."""
+    try:
+        cands = [path]
+        anchor = os.path.join(os.path.dirname(path), parent_sid + ".jsonl")
+        if os.path.basename(path) != parent_sid + ".jsonl" and os.path.exists(anchor):
+            cands.append(anchor)
+        ad = em.FileAdapter(cands, path)
+        u, root, hops = ad.leaf_uuid, None, 0
+        while u is not None and hops < 500000:          # active chain leaf → oldest record = the root
+            root = u
+            u = ad.parent_of.get(u); hops += 1
+        if not root:
+            return "no transcript records yet — nothing to fork."
+        cut = cut_uuid or ad.leaf_uuid
+        cut_rec = ad.by_uuid.get(cut) or {}
+        cut_t = int(em.parse_z(cut_rec.get("timestamp")) or time.time())
+        root_rec = ad.by_uuid.get(root) or {}
+        root_t = int(em.parse_z(root_rec.get("timestamp")) or cut_t)
+        parent_fsid = jd._sdk_last_sid(parent_sid) or parent_sid
+        # 1) the episode floor: seed (conversation root) + boundary (the cut) — floor = cut_t
+        jd.append_episode(sid, root, parent_fsid, root_t)
+        jd.append_episode(sid, cut, sid, cut_t)
+        # 2) captions: transform-copy the parent's settled rows at/before the cut
+        src = jd.CAPDIR / (parent_sid + ".jsonl")
+        pref = parent_sid + ":"
+        rows = []
+        if src.exists():
+            for line in src.read_text(errors="replace").splitlines():
+                try:
+                    o = json.loads(line)
+                except ValueError:
+                    continue
+                cid = o.get("id") or ""
+                if o.get("live") or not cid.startswith(pref):
+                    continue
+                parts = cid.rsplit(":", 2)              # <sid>:<t>:<hash> — sids may contain ':', so rsplit
+                try:
+                    if len(parts) != 3 or int(parts[1]) > cut_t:
+                        continue                        # after the cut (not copied), or not id-shaped
+                except ValueError:
+                    continue
+                o["id"] = sid + cid[len(parent_sid):]
+                rows.append(json.dumps(o))
+        if rows:
+            jd.CAPDIR.mkdir(parents=True, exist_ok=True)
+            (jd.CAPDIR / (sid + ".jsonl")).write_text("\n".join(rows) + "\n")
+        # 3) the goal store: fresh skeleton whose placements are the parent's, sealed
+        pstore = jd.load_goals(parent_sid)
+        store = jd.load_goals(sid)                      # the fresh-skeleton path (rompUuid=sid, CAS base set)
+        store["placements"] = {sid + k[len(parent_sid):]: None
+                               for k in (pstore.get("placements") or {}) if k.startswith(pref)}
+        jd.save_goals(sid, store)
+    except Exception as e:
+        return "fork not created — seeding its judge state failed: %s" % e
+    return None
+
+
 # --- optional SDK (non-tmux) session backend (docs/sdk-backend.md) --------------------
 # A second SessionBackend that drives Claude via the Agent SDK instead of a tmux TUI,
 # selectable per session. Built lazily so the tmux-only path never imports the SDK and the
@@ -4835,7 +4950,7 @@ def _drive(msg, client):
     t = msg.get("type")
     ID_OPS = ("sendMessage", "rewindSend", "rewindDelete", "interrupt", "compactSession", "dismissDialog", "answerAsk", "navAsk", "toggleAsk", "submitAsk",
               "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "setModel", "setEffort", "setMode", "setFast",
-              "setAuth", "endSession", "renameSession", "stopTask", "rewindFiles", "mcpAction")
+              "setAuth", "endSession", "renameSession", "stopTask", "rewindFiles", "mcpAction", "forkSession")
     if t in ID_OPS and msg.get("id"):
         sid = str(msg["id"])
     elif t in ("compact", "sendCommand") and msg.get("name"):
@@ -5070,6 +5185,13 @@ def _drive(msg, client):
             client["send"](json.dumps({"type": "warn",
                                        "text": "Couldn't restore files — this session's backend doesn't support it or isn't connected."}))
         _push_soon()
+    elif t == "forkSession" and msg.get("name"):
+        # Fork this conversation into a NEW parallel session (the user 2026-08-13). uuid (optional) is the
+        # user message the fork cuts just BEFORE — absent means the whole conversation. LOUD on refusal;
+        # on success the new tab arrives focused via _fork_session's own push.
+        err = _fork_session(sid, str(msg.get("uuid") or ""), str(msg["name"]))
+        if err:
+            client["send"](json.dumps({"type": "warn", "text": err}))
     elif t == "endSession":
         sys.stderr.write("kill: %s via endSession WS op\n" % sid)   # kill attribution (the user 2026-07-16)
         be.kill(sid); _send_to_app("chat", {"type": "closed", "id": sid}); _push_soon()

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1154,6 +1154,12 @@ class SdkSession:
         self.cwd = reg.get("cwd") or os.path.expanduser("~")
         self.mode = reg.get("mode") or "acceptEdits"
         self.resume_sid = reg.get("lastSid") or None  # resume target after a restart/crash
+        # A FORK being born (backend.fork): lastSid points at the PARENT's transcript and forkOf marks the
+        # resume as a fork, so _options adds fork_session (+ the resume-session-at cut) and the CLI copies
+        # the conversation into a NEW file pinned to THIS sid instead of continuing the parent's. One-shot:
+        # cleared the moment the init's lastSid flip says the fork landed (see _on_message).
+        self._fork_of = reg.get("forkOf") or ""
+        self._fork_at = reg.get("forkAt") or ""
         # Heal STRANDED pending-switch flags (the user 2026-07-11, who reported the three dots sitting there
         # forever): a /model or /effort switch that was mid-flight when the previous kernel/process
         # died can never be cleared by its in-memory switch path — but the persisted flags keep the
@@ -2078,6 +2084,12 @@ class SdkSession:
                 # A lastSid flip IS a fork landing — for a /clear, the fresh conversation now exists, so the
                 # clearing bracket ends here (event-based; the ResultMessage below is only the backstop).
                 self._clearing = False
+            if self._fork_of and fsid == self.sid:
+                # The BORN-AS-A-FORK session's copy landed (the CLI now owns a transcript pinned to this
+                # sid). Spend the fork flags: a later reconnect must resume the fork's OWN conversation
+                # plainly — re-applying fork_session would copy it into yet another session.
+                self._fork_of = self._fork_at = ""
+                self.backend._update_reg(self.sid, forkOf="", forkAt="")
             cli_cwd = d.get("cwd")
             if isinstance(cli_cwd, str) and cli_cwd and cli_cwd != self.cwd:
                 # The CLI's own cwd is the AUTHORITATIVE string: its projects-dir/transcript encoding
@@ -3321,6 +3333,16 @@ class SdkBackend:
             kw["model"] = sess.chosen_model    # keep the picked model across a reconnect (runtime set_model is per-connection)
         if sess.resume_sid:
             kw["resume"] = sess.resume_sid
+            if sess._fork_of:
+                # A FORK resume (backend.fork): fork_session makes the CLI copy the loaded conversation
+                # into a NEW session instead of continuing the parent's, and session_id pins the new
+                # fsid to the romp sid (the SDK's typed contract: session_id combines with resume only
+                # under fork_session — types.py). The optional cut rides the CLI's designed
+                # --resume-session-at, same passthrough the rewind uses.
+                kw["fork_session"] = True
+                kw["session_id"] = sess.sid
+                if sess._fork_at:
+                    kw.setdefault("extra_args", {})["resume-session-at"] = sess._fork_at
         else:
             kw["session_id"] = sess.sid
         # A pending conversation REWIND (the chat's edit-message branch) rides --resume-session-at —
@@ -3334,7 +3356,7 @@ class SdkBackend:
         disp = rewind_disposition(sess._rewind_to, sess._rewind_leaf,
                                   last_record_uuid(transcript_path(sess.cwd, sess.resume_sid or sess.sid)))
         if disp == "apply":
-            kw["extra_args"] = {"resume-session-at": sess._rewind_to}
+            kw.setdefault("extra_args", {})["resume-session-at"] = sess._rewind_to   # merge-safe beside the fork's args
             sess._rewind_armed = True
         elif disp == "spent":
             sess._rewind_to = sess._rewind_leaf = ""
@@ -3396,6 +3418,39 @@ class SdkBackend:
         if a:
             reg["auth"] = a
         write_reg(self.state_dir, sid, reg)
+        append_state(self.state_dir, sid, "waiting")
+        self._poke()
+        return sid
+
+    def fork(self, name: str, parent_sid: str, cut_uuid: str = "", bg: str = "", fg: str = "",
+             sid: str | None = None) -> str:
+        """Mint a NEW session that is a FORK of `parent_sid`'s conversation — up to `cut_uuid` when given
+        (a transcript record uuid; empty = the whole conversation), the parent untouched either way (the
+        user 2026-08-13). The new session gets its OWN sid, registry, name and identity colour — a fork
+        with the parent's title would be discovered as a fork LANE of the parent and hidden. Mechanism:
+        the reg is born with lastSid = the parent's newest fsid plus forkOf/forkAt, which _options turns
+        into resume + fork_session + session_id (+ resume-session-at) on first connect; the init's
+        lastSid flip to this sid spends the flags. Model / effort / mode / auth inherit from the parent —
+        it is that conversation, continued elsewhere. Resumable by construction: a fork whose CLI dies
+        before init still carries the flags and retries on the next connect."""
+        parent = read_reg(self.state_dir, parent_sid) or {}
+        cwd = parent.get("cwd") or os.path.expanduser("~")
+        sid = sid or str(uuid.uuid4())      # the kernel pre-mints it so the judge seeds can precede us
+        if not bg:
+            bg, fg = pick_identity_color(sid, self.state_dir)
+        reg = {"sid": sid, "name": name, "cwd": cwd,
+               "mode": parent.get("mode", "acceptEdits"),
+               "effort": parent.get("effort", DEFAULT_EFFORT),
+               "lastSid": parent.get("lastSid") or parent_sid,
+               "forkOf": parent_sid, "forkAt": cut_uuid or "", "alive": True}
+        if parent.get("model") and parent["model"] != "default":
+            reg["model"] = parent["model"]
+        if parent.get("auth") in ("login", "key"):
+            reg["auth"] = parent["auth"]
+        write_reg(self.state_dir, sid, reg)
+        # the names/ entry LAST — it is the discoverability trigger (discover() iterates names/), and
+        # everything above must exist before any judge pass can see the session
+        write_name(self.state_dir, sid, name, cwd, bg, fg)
         append_state(self.state_dir, sid, "waiting")
         self._poke()
         return sid

--- a/tests/test_kernel_fork.py
+++ b/tests/test_kernel_fork.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Fork a session (the user 2026-08-13): a NEW parallel session branches from the parent's conversation —
+from just before a chosen user message (the chat's fork button; the same _rewind_target resolution the
+edit/delete rewind uses) or from the tip — and the parent is untouched.
+
+The load-bearing half is STORE HYGIENE: the fork's transcript carries the parent's history VERBATIM
+(uuids + timestamps survive the CLI's fork copy — verified live 2026-08-13), and an unseeded new sid
+would re-judge all of it as fresh work (the v3 replay storm: every copied prompt re-minted as a card,
+every turn re-captioned). _seed_fork_stores runs BEFORE the session becomes discoverable and writes:
+  1. an episode seed+boundary → episode_floor(new) = the cut record's t (the planner's retire gate);
+  2. a transform-copy of the parent's captions (no Haiku re-caption storm);
+  3. a goal store born with the parent's placements SEALED (value None) — the courier's cover.
+run_courier additionally grew its own episode-floor guard: a fork's copied history is the first shape
+that leaves OLD peer segments visible to it (a /clear's null-rooted head drops them from the parse).
+
+SYNTHETIC fixtures only (placeholder UUIDs, invented text)."""
+import json
+import os
+import re
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_fork", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+PARENT = "11111111-2222-3333-4444-555555555555"
+NEWSID = "99999999-8888-7777-6666-555555555555"
+T_U1, T_A1, T_U2, T_A2 = 1781100000, 1781100010, 1781100100, 1781100110
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": text}, "promptSource": "typed"}
+
+
+def aline(t, text, uuid, parent):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+def write_transcript(path):
+    recs = [uline(T_U1, "set up the api", "u1"),
+            aline(T_A1, "done — the api is up", "a1", "u1"),
+            uline(T_U2, "now add the tests", "u2", "a1"),
+            aline(T_A2, "tests added", "a2", "u2")]
+    Path(path).write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+
+
+class ForkStoreSeeding(unittest.TestCase):
+    """_seed_fork_stores: the three writes, keyed to the cut."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.td.name, PARENT + ".jsonl")
+        write_transcript(self.path)
+
+    def tearDown(self):
+        for d in (jd.EPIDIR, jd.CAPDIR, jd.GOALDIR):
+            for f in Path(d).glob("*"):
+                f.unlink()
+        self.td.cleanup()
+
+    def test_episode_floor_lands_on_the_cut(self):
+        err = km._seed_fork_stores(PARENT, NEWSID, self.path, "a1")   # fork from before u2
+        self.assertIsNone(err)
+        rows = jd.episode_rows(NEWSID)
+        self.assertEqual([r["head"] for r in rows], ["u1", "a1"],
+                         "seed = the conversation ROOT (dedups the boundary tick's sighting); boundary = the cut")
+        self.assertEqual(rows[0]["fsid"], PARENT, "the seed names the file the fork copies from")
+        self.assertEqual(rows[1]["fsid"], NEWSID, "the boundary is the fork's own (pinned) fsid")
+        self.assertEqual(jd.episode_floor(NEWSID), T_A1,
+                         "floor = the cut record's t — the planner retires every copied unit below it")
+
+    def test_fork_from_tip_floors_at_the_leaf(self):
+        self.assertIsNone(km._seed_fork_stores(PARENT, NEWSID, self.path, ""))
+        self.assertEqual(jd.episode_floor(NEWSID), T_A2)
+
+    def test_captions_transform_copy(self):
+        jd.CAPDIR.mkdir(parents=True, exist_ok=True)
+        (jd.CAPDIR / (PARENT + ".jsonl")).write_text("\n".join([
+            json.dumps({"id": "%s:%d:aaaa" % (PARENT, T_U1), "cap": "set up the api"}),
+            json.dumps({"id": "%s:%d:bbbb" % (PARENT, T_U2), "cap": "add the tests"}),   # after the cut
+            json.dumps({"id": "%s:%d:cccc" % (PARENT, T_U1), "cap": "working…", "live": True}),
+            json.dumps({"id": "othersid:%d:dddd" % T_U1, "cap": "not ours"}),
+        ]) + "\n")
+        self.assertIsNone(km._seed_fork_stores(PARENT, NEWSID, self.path, "a1"))
+        got = [json.loads(l) for l in (jd.CAPDIR / (NEWSID + ".jsonl")).read_text().splitlines()]
+        self.assertEqual([o["id"] for o in got], ["%s:%d:aaaa" % (NEWSID, T_U1)],
+                         "kept: settled rows at/before the cut, resid'd; dropped: post-cut, live, foreign")
+        self.assertEqual(got[0]["cap"], "set up the api")
+
+    def test_placements_arrive_sealed_and_no_nodes_copy(self):
+        pstore = jd.load_goals(PARENT)
+        pstore["placements"] = {"%s:%d:aaaa" % (PARENT, T_U1): "g1",
+                                "%s:%d:bbbb#p" % (PARENT, T_U2): None}
+        pstore["nodes"] = {"%s:g1" % PARENT: {"text": "a card the fork must NOT inherit"}}
+        jd.save_goals(PARENT, pstore)
+        self.assertIsNone(km._seed_fork_stores(PARENT, NEWSID, self.path, "a1"))
+        store = jd.load_goals(NEWSID)
+        self.assertEqual(store["placements"],
+                         {"%s:%d:aaaa" % (NEWSID, T_U1): None, "%s:%d:bbbb#p" % (NEWSID, T_U2): None},
+                         "every parent placement arrives resid'd and SEALED (processed, no goal)")
+        self.assertEqual(store["nodes"], {}, "no cards copy — they would duplicate across both boards")
+
+    def test_empty_transcript_fails_loudly(self):
+        empty = os.path.join(self.td.name, "empty.jsonl")
+        Path(empty).write_text("")
+        self.assertIn("nothing to fork", km._seed_fork_stores(PARENT, NEWSID, empty, "") or "")
+
+
+class _FakeForkBackend:
+    def __init__(self):
+        self.events = []
+
+    def fork(self, name, parent_sid, cut_uuid="", bg="", fg="", sid=None):
+        self.events.append(("fork", name, parent_sid, cut_uuid, sid))
+        return sid
+
+    def connect(self, sid):
+        self.events.append(("connect", sid))
+
+
+class ForkSessionOp(unittest.TestCase):
+    """_fork_session: validation, the rewind-family cut resolution, and seeding BEFORE the backend."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.td.name, PARENT + ".jsonl")
+        write_transcript(self.path)
+        self.be = _FakeForkBackend()
+        self.saved = (km.Sessions.backend_for, km._sdk_ready, km._sessions, km._pick_identity_color,
+                      km._reveal_chat, km._mark_views_dirty, km._push_session_now, km._seed_fork_stores)
+        km.Sessions.backend_for = lambda sid: self.be
+        km._sdk_ready = lambda: True
+        km._sessions = lambda now: [{"sid": PARENT, "path": self.path}]
+        km._pick_identity_color = lambda: ("#123456", "#ffffff")
+        km._reveal_chat = lambda m: None
+        km._mark_views_dirty = lambda: None
+        km._push_session_now = lambda sid: None
+        self._real_seed = km._seed_fork_stores
+        km._seed_fork_stores = lambda *a: self.be.events.append(("seed",) + a[:2]) or None
+
+    def tearDown(self):
+        (km.Sessions.backend_for, km._sdk_ready, km._sessions, km._pick_identity_color,
+         km._reveal_chat, km._mark_views_dirty, km._push_session_now, km._seed_fork_stores) = self.saved
+        for d in (jd.EPIDIR, jd.CAPDIR, jd.GOALDIR):
+            for f in Path(d).glob("*"):
+                f.unlink()
+        self.td.cleanup()
+
+    def test_bad_name_refused(self):
+        self.assertIn("letters, digits", km._fork_session(PARENT, "", "bad name!") or "")
+        self.assertEqual(self.be.events, [])
+
+    def test_tmux_backend_refused(self):
+        km.Sessions.backend_for = lambda sid: object()   # no .fork
+        self.assertIn("SDK backend", km._fork_session(PARENT, "", "api-fork") or "")
+
+    def test_seeding_precedes_the_backend_and_the_cut_resolves_like_a_rewind(self):
+        self.assertIsNone(km._fork_session(PARENT, "u2", "api-fork"))
+        kinds = [e[0] for e in self.be.events]
+        self.assertEqual(kinds, ["seed", "fork", "connect"],
+                         "stores are seeded BEFORE the names/ entry exists (discoverability)")
+        fork = next(e for e in self.be.events if e[0] == "fork")
+        self.assertEqual(fork[3], "a1", "forking 'before u2' cuts at its nearest message ancestor — "
+                                        "the same _rewind_target the edit/delete rewind uses")
+        self.assertEqual(fork[4], self.be.events[0][2], "the backend gets the sid the seeds were written for")
+
+    def test_fork_from_tip_passes_no_cut(self):
+        self.assertIsNone(km._fork_session(PARENT, "", "api-fork"))
+        fork = next(e for e in self.be.events if e[0] == "fork")
+        self.assertEqual(fork[3], "", "no message uuid → the whole conversation")
+
+    def test_seed_failure_aborts_the_fork(self):
+        km._seed_fork_stores = lambda *a: "fork not created — seeding its judge state failed: boom"
+        self.assertIn("seeding", km._fork_session(PARENT, "", "api-fork") or "")
+        self.assertEqual([e[0] for e in self.be.events], [],
+                         "an unprotected fork must never be created (the replay storm)")
+
+
+class CourierEpisodeFloor(unittest.TestCase):
+    """run_courier skips segments below the episode floor — a fork's copied history is the first
+    shape that leaves OLD peer segments visible to it (mirrors the planner's pre-episode retire)."""
+
+    RECIP = "11111111-2222-3333-4444-555555555555"
+    SENDER = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    MID = "1781100000.11111_22222.TESTHOST"
+    T0 = 1781100000
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        munged = re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        (proj / munged).mkdir(parents=True)
+        self.proj_dir = proj / munged
+        names = td / "names"; names.mkdir()
+        (names / self.RECIP).write_text("recip\t%s\t#abcdef\n" % str(cdir))
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+                      jd.MESSAGES, jd.ERRORS, jd.EPIDIR, jd.courier_llm)
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.GOALDIR = td / "goals"
+        jd.CAPDIR, jd.ARCHDIR, jd.PCACHE = td / "captions", td / "archive", td / "pcache"
+        jd.EPIDIR = td / "episodes"
+        jd.MESSAGES = td / "messages.jsonl"
+        jd.ERRORS = td / "judge-errors.jsonl"
+        jd.MESSAGES.write_text(json.dumps(
+            {"t": self.T0 - 5, "ev": "sent", "id": self.MID, "from": "sender", "from_id": self.SENDER,
+             "to_id": self.RECIP, "body": "what subnet is the new box on?"}) + "\n")
+        self.calls = []
+        jd.courier_llm = lambda *a, **k: self.calls.append(1) or '{"verdict": "delegating", "goal": 0, "text": "x"}'
+        jd._PARSE_CACHE.clear()
+        jd._discover_cache.clear()
+        jd._postal_from_memo["key"] = None
+        recs = [uline(self.T0, "what subnet is the new box on?\nromp-msg-id: %s" % self.MID, "u1"),
+                aline(self.T0 + 30, "It's on the flat /24.", "a1", "u1")]
+        (self.proj_dir / (self.RECIP + ".jsonl")).write_text(
+            "\n".join(json.dumps(r) for r in recs) + "\n")
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+         jd.MESSAGES, jd.ERRORS, jd.EPIDIR, jd.courier_llm) = self.saved
+        jd._postal_from_memo["key"] = None
+        jd._PARSE_CACHE.clear()
+        jd._discover_cache.clear()
+        self.td.cleanup()
+
+    def test_pre_floor_peer_segment_is_skipped(self):
+        jd.append_episode(self.RECIP, "u0", "oldfsid", self.T0 - 100)   # seed
+        jd.append_episode(self.RECIP, "cut", self.RECIP, self.T0 + 50)  # boundary → floor ABOVE the message
+        jd.run_courier(now=self.T0 + 100)
+        store = jd.load_goals(self.RECIP)
+        self.assertEqual(store["nodes"], {}, "nothing planted from pre-episode history")
+        self.assertEqual(store["placements"], {}, "not even placed — skipped outright, no model call")
+        self.assertEqual(self.calls, [])
+
+    def test_current_episode_peer_segment_still_plants(self):
+        jd.append_episode(self.RECIP, "u0", "oldfsid", self.T0 - 100)
+        jd.append_episode(self.RECIP, "cut", self.RECIP, self.T0 - 50)  # floor BELOW the message
+        jd.run_courier(now=self.T0 + 100)
+        store = jd.load_goals(self.RECIP)
+        self.assertEqual(len(self.calls), 1, "an in-episode delegation still reaches the courier model")
+        self.assertTrue(store["placements"], "and gets placed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_rewind.py
+++ b/tests/test_sdk_rewind.py
@@ -100,8 +100,8 @@ class RewindDisposition(unittest.TestCase):
 class WiringPins(unittest.TestCase):
     def test_options_arms_via_extra_args_one_shot(self):
         # the SDK has no typed field for --resume-session-at → extra_args (designed passthrough),
-        # applied only on rewind_disposition's say-so
-        self.assertIn('kw["extra_args"] = {"resume-session-at": sess._rewind_to}', BACKEND_SRC)
+        # applied only on rewind_disposition's say-so; merge-safe beside the fork's own extra_args
+        self.assertIn('kw.setdefault("extra_args", {})["resume-session-at"] = sess._rewind_to', BACKEND_SRC)
         self.assertIn('disp = rewind_disposition(sess._rewind_to, sess._rewind_leaf,', BACKEND_SRC)
         self.assertIn('sess._rewind_armed = True', BACKEND_SRC)
 

--- a/ui/webview/fork-session.test.ts
+++ b/ui/webview/fork-session.test.ts
@@ -1,0 +1,63 @@
+// Fork a session (the user 2026-08-13): a NEW parallel session branches from just before a chosen user
+// message (the bubble's hover "fork") or from the tip (the palette's "Fork this session…"); the parent
+// is untouched and both continue as separate threads. The modal asks the new name — default
+// "<session>-fork", editable — and the provisional tab is the instant acknowledgement, joined by NAME
+// exactly like a picker create. Source-level pins (no jsdom for the chat renderer), plus the kernel
+// side of the contract (node-tests-pin-kernel-source precedent).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const PALETTE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "palette-main.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const BACKEND = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
+
+test("a fork button rides each editable bubble — non-destructive, accent hover, single click to the modal", () => {
+  assert.match(RENDER, /const fk = el\("button", "msg-fork"\) as HTMLButtonElement;/);
+  assert.match(RENDER, /fk\.addEventListener\("click", \(e\) => \{ e\.stopPropagation\(\); showForkPrompt\(editSid, uuid\); \}\);/);
+  assert.match(RENDER, /acts\.appendChild\(fk\);/);
+  // fork is not a rewind: no two-click arm (the modal is the confirmation), and never the destructive red
+  assert.match(CSS, /\.msg-fork:hover \{ color: var\(--fg\); border-color: var\(--accent\); \}/);
+  assert.doesNotMatch(CSS, /\.msg-fork\.armed/);
+});
+
+test("the modal defaults to <session>-fork and posts forkSession {id, uuid, name}", () => {
+  assert.match(RENDER, /function showForkPrompt\(sid: string, uuid: string\): void \{/);
+  assert.match(RENDER, /input\.value = base \+ "-fork";/);
+  assert.match(RENDER, /if \(!\/\^\[A-Za-z0-9._-\]\+\$\/\.test\(name\)\) \{ input\.classList\.add\("bad"\); input\.focus\(\); return; \}/);
+  assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "forkSession", id: sid, uuid, name \}\);/);
+  // the instant acknowledgement is the provisional tab, name-joined like a picker create
+  assert.match(RENDER, /openProvisional\(\{ name, backend: "sdk", dir: "", host: hostOf\(sid\) \}\);/);
+  // both cut semantics are said in the dialog itself
+  assert.match(RENDER, /continues from just before this message/);
+  assert.match(RENDER, /continues this whole conversation/);
+  assert.match(CSS, /\.fork-name \{ display: block; width: 100%;/);
+});
+
+test("the palette forks the ACTIVE session from the tip, via the chat pane", () => {
+  assert.match(PALETTE, /id: "session\.fork", title: "Fork this session…"/);
+  assert.match(PALETTE, /pane\("f-chat"\)!\.contentWindow!\.postMessage\(\{ romp: "forkSession" \}, "\*"\)/);
+  assert.match(RENDER, /if \(m\.romp === "forkSession"\) \{/);
+  assert.match(RENDER, /if \(activeId && !isProvisionalId\(activeId\) && sessions\.get\(activeId\)\) showForkPrompt\(activeId, ""\);/);
+});
+
+test("kernel: forkSession is a session op; seeding precedes discoverability; the fsid is pinned to the sid", () => {
+  assert.match(KERNEL, /"forkSession"\)/);   // in ID_OPS — routed by session id like every session op
+  assert.match(KERNEL, /elif t == "forkSession" and msg\.get\("name"\):/);
+  assert.match(KERNEL, /def _fork_session\(parent_sid, cut_msg_uuid, new_name, now=None\):/);
+  // the cut means the same thing the edit/delete rewind means: just before the clicked user message
+  assert.match(KERNEL, /cut_uuid, err = _rewind_target\(sess\["path"\], parent_sid, str\(cut_msg_uuid\)\)/);
+  // the judge stores are seeded BEFORE be.fork writes the names/ entry (discoverability)
+  assert.match(KERNEL, /err = _seed_fork_stores\(parent_sid, sid, sess\["path"\], cut_uuid\)[\s\S]{0,200}be\.fork\(nm, parent_sid, cut_uuid, bg, fg, sid=sid\)/);
+  // the backend rides the SDK's designed fork contract, with the new fsid PINNED to the romp sid
+  assert.match(BACKEND, /kw\["fork_session"\] = True/);
+  assert.match(BACKEND, /"forkOf": parent_sid, "forkAt": cut_uuid or ""/);
+  // one-shot: the init's lastSid flip spends the flags, so a reconnect resumes the fork's own transcript
+  assert.match(BACKEND, /if self\._fork_of and fsid == self\.sid:/);
+  assert.match(BACKEND, /self\.backend\._update_reg\(self\.sid, forkOf="", forkAt=""\)/);
+  // …and the names/ entry is written LAST (it is the discoverability trigger)
+  assert.match(BACKEND, /write_reg\(self\.state_dir, sid, reg\)[\s\S]{0,400}write_name\(self\.state_dir, sid, name, cwd, bg, fg\)[\s\S]{0,200}append_state\(self\.state_dir, sid, "waiting"\)/);
+});

--- a/ui/webview/mcp-panel.test.ts
+++ b/ui/webview/mcp-panel.test.ts
@@ -35,7 +35,7 @@ test("the panel reads the SDK's designed control requests through the kernel", (
   assert.ok(KERNEL.includes('if p == "/mcp":'));
   assert.ok(KERNEL.includes('json.dumps({"servers": servers, "error": err})'));
   assert.ok(KERNEL.includes('elif t == "mcpAction" and msg.get("server"):'));
-  assert.ok(KERNEL.includes('"mcpAction")'), "routes by session id like every session op");
+  assert.ok(KERNEL.includes('"mcpAction"'), "routes by session id like every session op (ID_OPS)");
   // tmux says so explicitly rather than returning a misleading empty list
   assert.ok(ABC.includes("def mcp_status(self, sid: str):"));
   assert.ok(ABC.includes("use /mcp there"));

--- a/ui/webview/palette-main.ts
+++ b/ui/webview/palette-main.ts
@@ -102,6 +102,12 @@ type SessionRow = { id: string; name: string; dir: string; bg: string };
   registerCommand({ id: "session.jump", title: "Jump to a session", run: openSessionSwitcher });
   registerCommand({ id: "session.new", title: "New session", run: openNewSessionPicker });
   registerCommand({
+    id: "session.fork", title: "Fork this session…",
+    // the chat pane owns the modal (it knows the active session); from the palette the fork is
+    // from-the-tip — the whole conversation (per-message forks live on the message's own hover row)
+    run: () => { try { pane("f-chat")!.contentWindow!.postMessage({ romp: "forkSession" }, "*"); } catch (e) { /* chat not loaded */ } },
+  });
+  registerCommand({
     id: "settings.open", title: "Open settings",
     run: () => { try { pane("f-feed")!.contentWindow!.postMessage({ romp: "openSettings" }, "*"); } catch (e) { /* feed not loaded */ } },
   });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1800,10 +1800,20 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         });
         rf.addEventListener("blur", rfDisarm);
         rf.addEventListener("pointerleave", rfDisarm);
+        // FORK affordance (the user 2026-08-13): branch a NEW parallel session from just before this
+        // message — old and new then run as separate threads (the rewind family above edits THIS
+        // session; fork leaves it untouched). Non-destructive, so no two-click arm: the name modal is
+        // the confirmation.
+        const fk = el("button", "msg-fork") as HTMLButtonElement;
+        fk.type = "button";
+        fk.textContent = "fork";
+        fk.title = "Fork the session from just before this message — a new parallel session carries the conversation up to here; this one is untouched";
+        fk.addEventListener("click", (e) => { e.stopPropagation(); showForkPrompt(editSid, uuid); });
         const acts = el("div", "msg-acts");   // one row under the bubble (the turn is a column flex)
         acts.appendChild(edit);
         acts.appendChild(del);
         acts.appendChild(rf);
+        acts.appendChild(fk);
         turn.appendChild(acts);
       }
     }
@@ -4971,6 +4981,51 @@ function showConfirm(title: string, detail: string, buttons: Array<{ label: stri
   document.addEventListener("keydown", onKey, true);
   (actions.firstElementChild as HTMLElement | null)?.focus();
 }
+// THE FORK MODAL (the user 2026-08-13): fork this conversation into a NEW parallel session — from just
+// before a given user message (the bubble's fork button) or from the tip (the palette command, uuid "").
+// One small dialog on the confirm chrome: a name box prefilled "<session>-fork" (editable), Fork/Cancel.
+// The kernel owns the mechanics (forkSession op); the provisional tab is the instant acknowledgement,
+// joined by NAME when the real session lands — exactly the picker-create flow.
+function showForkPrompt(sid: string, uuid: string): void {
+  const sess = sessions.get(sid);
+  const base = (sess?.name || "session").replace(/[^A-Za-z0-9._-]/g, "-");
+  document.getElementById("fork-prompt")?.remove();
+  const overlay = el("div", "picker-overlay confirm-overlay"); overlay.id = "fork-prompt";
+  const box = el("div", "picker-box confirm-box");
+  const h = el("div", "confirm-title"); h.textContent = "Fork session";
+  const d = el("div", "confirm-detail");
+  d.textContent = uuid
+    ? "A new session continues from just before this message; this one is untouched."
+    : "A new session continues this whole conversation; this one is untouched.";
+  const input = document.createElement("input");
+  input.type = "text"; input.className = "fork-name"; input.value = base + "-fork";
+  input.setAttribute("autocapitalize", "off"); input.setAttribute("autocomplete", "off");
+  input.setAttribute("autocorrect", "off"); input.setAttribute("spellcheck", "false");
+  const actions = el("div", "confirm-actions");
+  const cancel = el("button", "picker-action confirm-btn"); cancel.textContent = "Cancel";
+  const create = el("button", "picker-action confirm-btn"); create.textContent = "Fork";
+  const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.stopPropagation(); close(); } };
+  const close = () => { overlay.remove(); document.removeEventListener("keydown", onKey, true); };
+  const go = () => {
+    const name = input.value.trim();
+    if (!/^[A-Za-z0-9._-]+$/.test(name)) { input.classList.add("bad"); input.focus(); return; }
+    vscodeApi?.postMessage({ type: "forkSession", id: sid, uuid, name });
+    close();
+    openProvisional({ name, backend: "sdk", dir: "", host: hostOf(sid) });
+  };
+  cancel.addEventListener("click", close);
+  create.addEventListener("click", go);
+  input.addEventListener("keydown", (e) => { if (e.key === "Enter") { e.preventDefault(); go(); } });
+  input.addEventListener("input", () => input.classList.remove("bad"));
+  overlay.addEventListener("click", (e) => { if (e.target === overlay) close(); });
+  box.append(h, d, input, actions);
+  actions.append(cancel, create);
+  overlay.appendChild(box);
+  document.body.appendChild(overlay);
+  document.addEventListener("keydown", onKey, true);
+  input.focus(); input.setSelectionRange(0, input.value.length);
+}
+
 // THE MCP PANEL (the user 2026-08-05). `/mcp` in a romp session used to be a dead end: the CLI's own
 // panel is an interactive TUI an SDK-driven session cannot render, so it replied "use a terminal". The
 // SDK exposes the same facts and repairs as control requests (get_mcp_status / toggle_mcp_server /
@@ -8397,6 +8452,11 @@ function pipeBanner(up: boolean, queued: number): void {
 window.addEventListener("message", (e: MessageEvent) => {
   const m = e.data;
   if (!m) return;
+  // the shell's palette: "Fork this session…" → the fork modal for the ACTIVE session, from the tip
+  if (m.romp === "forkSession") {
+    if (activeId && !isProvisionalId(activeId) && sessions.get(activeId)) showForkPrompt(activeId, "");
+    return;
+  }
   if (m.type === "pipeState") { pipeBanner(!!m.up, Number(m.queued) || 0); return; }
   if (m.type === "session") upsert(m);
   else if (m.type === "globalRetryPaused") {

--- a/ui/webview/rewind-delete.test.ts
+++ b/ui/webview/rewind-delete.test.ts
@@ -47,7 +47,7 @@ test("the bare overlay dims the deleted bubble itself, not just the tail", () =>
 test("the delete button dresses like edit, with a destructive armed state", () => {
   assert.match(CSS, /\.msg-acts \{ display: flex; gap: 4px; align-self: flex-end; \}/);
   // restore-files shares delete's dress (same reveal, same destructive armed red — the user 2026-08-04)
-  assert.match(CSS, /\.turn-user:hover \.msg-del, \.msg-del:focus-visible,\s*\n\.turn-user:hover \.msg-restorefiles, \.msg-restorefiles:focus-visible \{ opacity: 0\.9; \}/);
+  assert.match(CSS, /\.turn-user:hover \.msg-del, \.msg-del:focus-visible,\s*\n\.turn-user:hover \.msg-restorefiles, \.msg-restorefiles:focus-visible,\s*\n\.turn-user:hover \.msg-fork, \.msg-fork:focus-visible \{ opacity: 0\.9; \}/);
   assert.match(CSS, /\.msg-del\.armed, \.msg-restorefiles\.armed \{ color: #ff6a6a; border-color: #ff6a6a;/);
 });
 

--- a/ui/webview/rewind-edit.test.ts
+++ b/ui/webview/rewind-edit.test.ts
@@ -109,7 +109,8 @@ test("kernel: rewindSend validates against the transcript and the SDK backend ap
   const BACKEND = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
   assert.match(KERNEL, /elif t == "rewindSend" and msg\.get\("uuid"\) and msg\.get\("text"\):/);
   assert.match(KERNEL, /def _rewind_target\(path, sid, user_uuid\):/);
-  assert.match(BACKEND, /kw\["extra_args"\] = \{"resume-session-at": sess\._rewind_to\}/);
+  // merge-safe beside the fork's extra_args (both write the same designed --resume-session-at passthrough)
+  assert.match(BACKEND, /kw\.setdefault\("extra_args", \{\}\)\["resume-session-at"\] = sess\._rewind_to/);
 });
 
 test("a restore-files affordance rides each editable bubble — workspace only, armed like delete (the user 2026-08-04)", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1126,7 +1126,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* edit + delete share one row under the bubble (the turn is a column flex; the row is the flex item) */
 .msg-acts { display: flex; gap: 4px; align-self: flex-end; }
 /* the DELETE affordance wears the edit button's exact clothes (one size, one shape — labels differ) */
-.msg-del, .msg-restorefiles {
+.msg-del, .msg-restorefiles, .msg-fork {
   align-self: flex-end; margin-top: 3px;
   font-family: var(--sans); font-size: 11px; line-height: 1; padding: 3px 7px; border-radius: 4px;
   border: 1px solid var(--box-border); background: var(--code-bg); color: var(--dim);
@@ -1134,11 +1134,19 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
 .turn-user:hover .msg-del, .msg-del:focus-visible,
-.turn-user:hover .msg-restorefiles, .msg-restorefiles:focus-visible { opacity: 0.9; }
+.turn-user:hover .msg-restorefiles, .msg-restorefiles:focus-visible,
+.turn-user:hover .msg-fork, .msg-fork:focus-visible { opacity: 0.9; }
 .msg-del:hover, .msg-restorefiles:hover { color: var(--fg); border-color: #ff6a6a; }
+.msg-fork:hover { color: var(--fg); border-color: var(--accent); }   /* non-destructive: accent, never the rewind red */
 /* armed = one click from rolling back: destructive red, holds until blur/pointerleave/re-render */
 .msg-del.armed, .msg-restorefiles.armed { color: #ff6a6a; border-color: #ff6a6a; opacity: 0.95; }
-@media (hover: none) { .msg-del, .msg-restorefiles { opacity: 0.6; } }   /* touch: no hover state, so keep it visible */
+@media (hover: none) { .msg-del, .msg-restorefiles, .msg-fork { opacity: 0.6; } }   /* touch: no hover state, so keep it visible */
+/* the fork modal's name box (the user 2026-08-13): the confirm chrome + one text input */
+.fork-name { display: block; width: 100%; box-sizing: border-box; margin: 10px 0 2px; padding: 7px 9px;
+  font: inherit; color: var(--fg); background: var(--code-bg);
+  border: 1px solid var(--box-border); border-radius: 6px; outline: none; }
+.fork-name:focus { border-color: var(--accent); }
+.fork-name.bad { border-color: #ff6a6a; }
 /* pending-rewind overlay: turns after an edited message belong to the branch being abandoned — they
    dim until the kernel's rewound payload replaces them (reconcileRewind retires the flag then). */
 .turn.rewound { opacity: 0.35; transition: opacity 0.2s ease; }


### PR DESCRIPTION
The chat's message hover row gains a non-destructive **fork** button: a modal (name defaults to `<session>-fork`) creates a NEW session continuing from just before that message — same `_rewind_target` cut semantics as edit/delete — leaving the parent untouched. The palette's **Fork this session…** forks from the tip.

Kernel: `forkSession` op → `_fork_session` → `SdkBackend.fork` riding the SDK's designed contract (`resume` + `fork_session` + `session_id` pinned to the new romp sid + optional `resume-session-at`), all four composition behaviors verified live against the bundled CLI (verbatim copy, uuids/timestamps preserved, inclusive truncation). Fork flags are one-shot in the reg, spent on the init's lastSid flip.

Store hygiene (the load-bearing half): `_seed_fork_stores` writes the episode seed+boundary (floor = cut t), transform-copies captions, and seals the parent's placements into the fork's fresh goal store — all before the `names/` entry makes it discoverable, so the judges never re-judge the copied history (replay storm). `run_courier` grew its own episode-floor guard with tests.

Tests: `tests/test_kernel_fork.py` (12: seeding, cut resolution, op ordering, courier floor) + `ui/webview/fork-session.test.ts` source pins; both suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)