### PR TITLE
Slash-command turns render as ✦ system rows, not user bubbles

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1672,7 +1672,11 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         .flatMap((im) => [im.path, im.src.startsWith("path:") ? im.src.slice(5) : ""])
         .filter((p): p is string => !!p);
       if (!romp && !injected && ev.md && renderSlashCmd(bubble, ev.md)) {
-        /* rendered as a command chip */
+        // a COMMAND is a user GESTURE, not a user message (the user 2026-08-13): it changes something
+        // rather than saying something, so it sheds the blue said-thing bubble and reads in the
+        // system-event family (the ✦ dividers) — a dim left-aligned row: ✦ mark, mono chip, args
+        turn.classList.add("turn-cmd");
+        bubble.classList.add("cmd-row");
       } else if (romp && ev.md) {
         // A romp-injected NUDGE (auto status-check, Nudge button, injected follow-up) is mechanical
         // bookkeeping — progressive disclosure (the user 2026-07-17): default is a ONE-LINE gist with a

--- a/ui/webview/slash-cmd-chip.test.ts
+++ b/ui/webview/slash-cmd-chip.test.ts
@@ -25,6 +25,16 @@ test("the chip is a monospace, outlined keyword pill that reads on the blue bubb
   assert.match(CSS, /\.slash-cmd-args \{ margin-left: 7px; \}/);
 });
 
+test("a command turn reads in the system-event family, not as a said thing (the user 2026-08-13)", () => {
+  // a command is a user GESTURE — it changes something rather than saying something — so the turn sheds
+  // the blue right-pinned bubble for a dim left-aligned ✦ row, rhyming with the context dividers
+  assert.match(RENDER, /turn\.classList\.add\("turn-cmd"\);\s*\n\s*bubble\.classList\.add\("cmd-row"\);/);
+  assert.match(CSS, /\.turn-user\.turn-cmd:not\(\.injected\) \{ align-items: flex-start; \}/);
+  assert.match(CSS, /\.user-bubble\.cmd-row \{ max-width: none; background: none; border: none;/);
+  assert.match(CSS, /\.user-bubble\.cmd-row::before \{ content: "✦"; margin-right: 8px; color: var\(--dim\); \}/);
+  assert.match(CSS, /\.turn-cmd \.msg-acts \{ align-self: flex-start; \}/);
+});
+
 // guards on the regex's intent (executed): a whole leading token is chipped; a path is not.
 test("the chip regex matches a whole leading /token but not a /path", () => {
   const re = /^(\/[A-Za-z][\w-]*)(?=\s|$)([\s\S]*)$/;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1163,6 +1163,17 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   padding: 1px 7px; line-height: 1.5; white-space: nowrap;
 }
 .slash-cmd-args { margin-left: 7px; }
+/* A slash COMMAND turn is a user GESTURE, not a message (the user 2026-08-13): it changes something
+   rather than saying something — so it sheds the blue bubble and reads in the system-event family
+   (the ✦ dividers): a dim, left-aligned, full-width row with the ✦ mark, the mono chip, the args. */
+.turn-user.turn-cmd:not(.injected) { align-items: flex-start; }
+.user-bubble.cmd-row { max-width: none; background: none; border: none; border-radius: 0;
+  padding: 2px 0; color: var(--dim); }
+.user-bubble.cmd-row::before { content: "✦"; margin-right: 8px; color: var(--dim); }
+.user-bubble.cmd-row .slash-cmd-chip { background: var(--code-bg); color: var(--fg);
+  border-color: var(--box-border); }
+.user-bubble.cmd-row .slash-cmd-args { color: var(--dim); }
+.turn-cmd .msg-acts { align-self: flex-start; }   /* the hover actions follow the row to the left */
 /* ---------- romp-injected message (a feed nudge / follow-up) ----------
    A GRAY bubble in the SAME right-aligned spot as the blue user bubble (so it sits where "an outgoing
    message" goes), but clearly NOT you — gray, with a small "↯ romp" tag above it (the user 2026-06-19).


### PR DESCRIPTION
A typed command is a gesture, not a message — it changes something rather than saying something. Command turns now shed the blue bubble for a dim left-aligned ✦ row (the context-divider family) carrying the existing mono chip + args; the turn structure is untouched so edit/delete/restore/fork hover actions keep working. Verified by headless screenshot beside ordinary bubbles; source pins added to `slash-cmd-chip.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)