### PR TITLE
Distill failures: the chip says so, and the modal offers Try again

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2014,6 +2014,22 @@ def _replay_overrides(fsid, store):
             if record_verdict(store, nd, src, "block", t, why=ev.get("why")):
                 nd["mt"] = max(int(nd.get("mt") or 0), t)
                 applied = True
+        elif op == "redistill":
+            # The warn modal's "Try again" (the user 2026-08-13): re-arm a GIVEN-UP summary line so the
+            # next triage pass re-runs the distiller — the same flip rearm_failed_summaries applies on
+            # the usage-limit recovery edge, journaled here so a concurrent pass's last-writer save
+            # can't silently erase the click. Idempotent by shape: only the "" give-up sentinel flips
+            # to None (owed); a line that has since succeeded (non-empty) or is already owed (None) is
+            # untouched, so replays past a success never clobber it. No supersede guard needed — this
+            # is a field flip, not a log verdict, and its no-op form IS the guard.
+            for k in ("summary", "blockSummary"):
+                if nd.get(k) == "":
+                    nd[k] = None
+                    applied = True
+            for k in ("distillFails", "briefFails"):
+                if nd.get(k):
+                    nd[k] = 0
+                    applied = True
     return applied
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -22793,6 +22793,27 @@ class Handler(BaseHTTPRequestHandler):
                 _clear_all([str(msg["nodeId"])])
                 _send_to_app("chat", {"type": "dropCitation", "itemId": str(msg["nodeId"]), "itemIds": _gone})
                 _mark_views_dirty()
+        elif msg and msg.get("type") == "redistill" and msg.get("sid") and msg.get("itemId"):
+            # The warn modal's "Try again" (the user 2026-08-13): re-arm this card's GIVEN-UP summary
+            # line(s) so the next triage pass re-runs the distiller. Journal FIRST (jd.append_override):
+            # a concurrent pass holds the store across a model call and its save is last-writer-wins —
+            # the journaled row replays the flip on every load, so the click can't be silently erased.
+            # The re-armed line reads None = pending, so the card's "Distilling…" swirl is the live
+            # acknowledgement; the ACK below is the failure path's voice (fail loudly).
+            _dsid, _dnid = str(msg["sid"]), str(msg["itemId"])
+            try:
+                jd.append_override(_dsid, _dnid, "redistill", int(time.time()))
+                _dst = jd.load_goals(_dsid)              # load replays the journal → the flip is applied
+                if _dst.get("nodes", {}).get(_dnid) is None:
+                    _dok, _derr = False, "that card is no longer in this session's goal store"
+                else:
+                    jd.save_goals(_dsid, _dst)
+                    _dok, _derr = True, ""
+                    _mark_views_dirty()
+            except Exception as _e:
+                _dok, _derr = False, (str(_e) or _e.__class__.__name__)
+                sys.stderr.write("redistill: %s\n" % traceback.format_exc())
+            _send_to_app("feed", {"type": "redistillResult", "itemId": _dnid, "ok": _dok, "error": _derr})
         elif msg and msg.get("type") == "clearAll":
             d = build_feed(int(time.time()))
             _clear_all([a["itemId"] for a in d["asks"]] + [c["itemId"] for c in d["items"]])

--- a/tests/test_kernel_redistill.py
+++ b/tests/test_kernel_redistill.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""The warn modal's "Try again" (the user 2026-08-13): a card whose summary line GAVE UP (the ""
+sentinel after DISTILL_FAIL_CAP consecutive failures) can be re-armed by hand — the redistill op
+journals the flip (append_override) so a concurrent triage pass's last-writer save can't silently
+erase the click, and the replay flips only the give-up sentinel: "" → None (owed). A line that has
+since succeeded (non-empty) or is already owed (None) is untouched, so replays past a success never
+clobber it. SYNTHETIC fixtures only (placeholder UUIDs, invented text)."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_redistill", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NID = SID + ":g1"
+
+
+def _seed_store(summary="", block_summary=None, fails=2):
+    store = jd.load_goals(SID)
+    nd = {"text": "ship the api", "parentId": None, "mt": 1781100000,
+          "summary": summary, "distillFails": fails,
+          "warns": [{"kind": "summary-failed", "t": 1781100000,
+                     "msg": "romp tried to generate this summary several times and each attempt failed",
+                     "detail": "synthetic detail"}]}
+    if block_summary is not None:
+        nd["blockSummary"] = block_summary
+    store["nodes"][NID] = jd.GuardedNode(nd)
+    jd.save_goals(SID, store)
+    return store
+
+
+class RedistillOverrideReplay(unittest.TestCase):
+    def tearDown(self):
+        for d in (jd.GOALDIR, jd._overrides_dir()):
+            for f in d.glob("*"):
+                f.unlink()
+
+    def test_replay_flips_the_giveup_sentinel_to_owed(self):
+        _seed_store(summary="", block_summary="", fails=2)
+        jd.append_override(SID, NID, "redistill", 1781100100)
+        nd = jd.load_goals(SID).get("nodes", {}).get(NID)
+        self.assertIsNone(nd.get("summary"), '"" (gave up) → None (owed): the next pass re-runs the distiller')
+        self.assertIsNone(nd.get("blockSummary"), "the blocked line re-arms the same way")
+        self.assertEqual(nd.get("distillFails"), 0, "the consecutive-fail counter starts over")
+
+    def test_replay_never_clobbers_a_line_that_succeeded_since(self):
+        _seed_store(summary="", fails=0)
+        jd.append_override(SID, NID, "redistill", 1781100100)
+        store = jd.load_goals(SID)                       # replay applies: "" → None
+        store["nodes"][NID]["summary"] = "All four endpoints shipped and tested."
+        jd.save_goals(SID, store)
+        nd = jd.load_goals(SID).get("nodes", {}).get(NID)   # journal replays again on this load
+        self.assertEqual(nd.get("summary"), "All four endpoints shipped and tested.",
+                         "the flip touches ONLY the give-up sentinel — a later success stands")
+
+    def test_replay_is_idempotent_and_skips_missing_nodes(self):
+        _seed_store(summary="")
+        jd.append_override(SID, NID, "redistill", 1781100100)
+        jd.append_override(SID, NID, "redistill", 1781100200)     # a second click — same shape
+        jd.append_override(SID, SID + ":gone", "redistill", 1781100300)   # a cleared/compacted card
+        nd = jd.load_goals(SID).get("nodes", {}).get(NID)
+        self.assertIsNone(nd.get("summary"))
+        self.assertIsNone(jd.load_goals(SID).get("nodes", {}).get(SID + ":gone"))
+
+
+class RedistillOpWiring(unittest.TestCase):
+    """Source pins on the kernel handler — the ws plumbing is exercised end-to-end by the push
+    responsiveness suite; here we pin the journal-first order and the loud ACK."""
+
+    def test_handler_journals_first_then_saves_and_acks(self):
+        import inspect
+        km = SourceFileLoader("romp_kernel_redistill", os.path.join(BIN, "romp-kernel")).load_module()
+        src = inspect.getsource(km.Handler._dispatch_ws)
+        # split on the CONDITION, not the bare op string — the journal call carries "redistill" too
+        seg = src.split('msg.get("type") == "redistill"')[1].split("elif msg and")[0]
+        self.assertLess(seg.index("jd.append_override(_dsid"), seg.index("jd.load_goals"),
+                        "journal FIRST — the replay is what survives a concurrent pass's save")
+        self.assertIn('jd.save_goals', seg)
+        self.assertIn('"redistillResult"', seg, "the feed always hears back (fail loudly)")
+        self.assertIn('_mark_views_dirty()', seg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/feed-warn-chip.test.ts
+++ b/ui/webview/feed-warn-chip.test.ts
@@ -31,10 +31,28 @@ test("the click reads the card's CURRENT warns and opens the detail overlay (cli
 test("updateAskCard toggles the chip on it.warns and refreshes the data it reads", () => {
   assert.match(FEED, /a\._warnsData = it\.warns \|\| null;/);
   assert.match(FEED, /a\._warnChip\.style\.display = "";/);
-  assert.match(FEED, /a\._warnChip\.textContent = it\.warns\.length > 1 \? `warning ×\$\{it\.warns\.length\}` : "warning";/,
+  assert.match(FEED, /a\._warnChip\.textContent = it\.warns\.length > 1 \? `\$\{lbl\} ×\$\{it\.warns\.length\}` : lbl;/,
     "multiple live warns show a count");
   assert.match(FEED, /it\.warns\[it\.warns\.length - 1\]\.msg \+ " — click for what happened and why"/,
     "hover says the latest msg + that detail is a click away");
+});
+
+test("a given-up summarizer wears its NAME — 'distill failed' — and its modal offers Try again (the user 2026-08-13)", () => {
+  // the chip says what actually happened when the warns are all summarizer give-ups; other anomaly
+  // kinds keep the generic label (a mixed set is not purely a distill story)
+  assert.match(FEED, /const DISTILL_FAIL_RE = \/\^\(summary\|brief\|stall\)-failed\$\/;/);
+  assert.match(FEED, /const allDistill = it\.warns\.every\(\(w\) => DISTILL_FAIL_RE\.test\(w\.kind\)\);/);
+  assert.match(FEED, /const lbl = allDistill \? "distill failed" : "warning";/);
+  // the modal's Try again: ids threaded from the card's freshest payload, instant acknowledgement,
+  // then the redistill op — the re-armed line reads pending, so the card's Distilling… swirl takes over
+  assert.match(FEED, /ctx\?: \{ itemId: string; sid: string \}/);
+  assert.match(FEED, /wit \? \{ itemId: wit\.itemId, sid: wit\.sid \} : undefined/);
+  assert.match(FEED, /if \(ctx && warns\.some\(\(w\) => DISTILL_FAIL_RE\.test\(w\.kind\)\)\) \{/);
+  assert.match(FEED, /retry\.disabled = true; retry\.textContent = "retrying…";/);
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "redistill", itemId: ctx\.itemId, sid: ctx\.sid \}\);/);
+  // the kernel's refusal is loud; success is the swirl, silently
+  assert.match(FEED, /m\.type === "redistillResult" && typeof m\.itemId === "string"/);
+  assert.match(FEED, /couldn't retry the summary: /);
 });
 
 test("the overlay lists each warn's kind/age and full detail", () => {

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -553,7 +553,12 @@ function feedConfirm(message: string, confirmLabel: string, onConfirm: () => voi
 // one entry per judge-stamped anomaly, each telling in detail what happened and why it's unexpected,
 // so pipeline misbehavior is followable from the card instead of buried in judge-errors.jsonl.
 // Same lightweight overlay pattern as feedConfirm (its own state machine; Esc / backdrop / Close).
-function feedWarnModal(cardTitle: string, warns: { kind: string; t: number; msg: string; detail: string }[]): void {
+// A warn kind stamped by a GIVEN-UP summarizer line (summary/brief/stall) — these get the "distill
+// failed" chip label and the modal's Try again (the user 2026-08-13); other anomaly kinds stay "warning".
+const DISTILL_FAIL_RE = /^(summary|brief|stall)-failed$/;
+
+function feedWarnModal(cardTitle: string, warns: { kind: string; t: number; msg: string; detail: string }[],
+                       ctx?: { itemId: string; sid: string }): void {
   const back = el("div", "fconfirm-back fwarn-back");
   const box = el("div", "fconfirm-box fwarn-box");
   const head = el("div", "fwarn-head"); head.textContent = "Unexpected behavior";
@@ -568,6 +573,20 @@ function feedWarnModal(cardTitle: string, warns: { kind: string; t: number; msg:
     box.append(entry);
   }
   const btns = el("div", "fconfirm-btns");
+  // "Try again" on a given-up summary line (the user 2026-08-13): the kernel journals the re-arm and the
+  // next triage pass re-runs the distiller — the card's own "Distilling…" swirl is the live cue after
+  // the modal closes; a kernel refusal comes back as a redistillResult toast (fail loudly).
+  if (ctx && warns.some((w) => DISTILL_FAIL_RE.test(w.kind))) {
+    const retry = el("button", "fconfirm-btn") as HTMLButtonElement;
+    retry.textContent = "Try again";
+    retry.onclick = (e) => {
+      e.stopPropagation();
+      retry.disabled = true; retry.textContent = "retrying…";   // acknowledged before any round-trip
+      vscodeApi?.postMessage({ type: "redistill", itemId: ctx.itemId, sid: ctx.sid });
+      window.setTimeout(close, 300);   // cosmetic beat so the pressed label registers; the op is already posted
+    };
+    btns.append(retry);
+  }
   const ok = el("button", "fconfirm-btn primary"); ok.textContent = "Close";
   btns.append(ok);
   box.append(btns);
@@ -786,7 +805,9 @@ function makeAskCard(it: AskItem): HTMLElement {
   warnChip.onclick = (ev) => {
     ev.stopPropagation();
     const ws = (card as any)._warnsData as AskItem["warns"];
-    if (ws && ws.length) feedWarnModal((card as any)._title?.textContent || "", ws);
+    const wit = (card as any)._it as AskItem | undefined;   // freshest payload → the ids Try again posts with
+    if (ws && ws.length) feedWarnModal((card as any)._title?.textContent || "", ws,
+                                       wit ? { itemId: wit.itemId, sid: wit.sid } : undefined);
   };
   const waitOnBadge = el("span", "fask-waiton"); waitOnBadge.style.display = "none";   // "Awaiting <peer>" / "Deadlock <peer>", peer name in native colour (the user 2026-06-22)
   const blkBadge = el("a", "fask-blocked"); blkBadge.style.display = "none";   // ⏸ live permission/picker block → click opens the session
@@ -1446,10 +1467,14 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     : "romp followed up once; the response didn't resolve it and it won't be re-asked — it's waiting on you";
   // "warning" chip: a judge stamped an anomaly on this goal — show the latest msg on hover, detail on click.
   // Data rides the card element so the click handler (wired once in build) always reads the current push.
+  // When the warns are all GIVEN-UP summarizer lines, the chip SAYS so — "distill failed" (the user
+  // 2026-08-13, who read the generic label as a mystery) — and its modal carries the Try again.
   a._warnsData = it.warns || null;
   if (it.warns && it.warns.length) {
+    const allDistill = it.warns.every((w) => DISTILL_FAIL_RE.test(w.kind));
+    const lbl = allDistill ? "distill failed" : "warning";
     a._warnChip.style.display = "";
-    a._warnChip.textContent = it.warns.length > 1 ? `warning ×${it.warns.length}` : "warning";
+    a._warnChip.textContent = it.warns.length > 1 ? `${lbl} ×${it.warns.length}` : lbl;
     a._warnChip.title = it.warns[it.warns.length - 1].msg + " — click for what happened and why";
   } else {
     a._warnChip.style.display = "none";
@@ -3718,6 +3743,10 @@ window.addEventListener("message", (e: MessageEvent) => {
       renderModal();
       feedToast("couldn't mark that sub-goal done: " + (String(m.error || "") || "the kernel refused it"));
     }
+  } else if (m.type === "redistillResult" && typeof m.itemId === "string") {
+    // The kernel's verdict on the warn modal's Try again. Success is silent — the re-armed line reads
+    // pending, so the card's own "Distilling…" swirl takes over. A refusal says why, out loud.
+    if (!m.ok) feedToast("couldn't retry the summary: " + (String(m.error || "") || "the kernel refused it"));
   } else if (m.type === "revealCards") {
     // chat rail CLICK → scroll to the card(s) covering that turn and pulse them (the user 2026-07-23).
     // Distinct from hoverCards, which only outlines whatever is already on screen: this one MOVES the

--- a/vscode-extension/src/pipe-intent.ts
+++ b/vscode-extension/src/pipe-intent.ts
@@ -12,7 +12,7 @@ export const INTENT_OPS: ReadonlySet<string> = new Set([
   "interrupt", "apiRetry", "rewindDelete",
   "setModel", "setEffort", "setMode", "setFast", "setAuth",
   "renameSession", "endSession", "reviveSession",
-  "nodeOverride", "askClear", "undoClear", "cardMove", "cardNotify",
+  "nodeOverride", "askClear", "undoClear", "cardMove", "cardNotify", "redistill",
   "answerAsk", "submitAsk", "toggleAsk", "navAsk", "cancelAsk",
   "setSessionFlag", "setSessionColor", "setGlobalRetryPaused",
   "reorderTabs", "closeTab",


### PR DESCRIPTION
The card chip reads **distill failed** when the warns are all summarizer give-ups (generic "warning" stays for mixed kinds), and the warn modal gains **Try again**: instant acknowledgement → the new `redistill` op → the card's Distilling… swirl takes over (the re-armed line reads pending). The op journals first via a new `append_override` replay branch, so a concurrent pass's save can't erase it, and the flip touches only the `""` give-up sentinel — a since-succeeded line stands. Tests: `tests/test_kernel_redistill.py` + updated `feed-warn-chip.test.ts`; both suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)