### PR TITLE
The working narration's tool count earns its place at one

### DIFF
--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -152,6 +152,15 @@ test("an ordinary working card with its turn open narrates: tool count + running
   assert.equal(long.caption, "Working — 400 tool uses · 1h 35m", "hours split out past sixty minutes");
 });
 
+test("zero tool uses says nothing — the timer alone narrates until the first call", () => {
+  // "0 tool uses" was noise (the user 2026-08-13): the count earns its place at one
+  const z = spinFor({ column: "working", working: { since: 1000, toolUses: 0 } },
+                    false, false, 1000 + 3 * 60);
+  assert.equal(z.caption, "Working — 3m");
+  const bare = spinFor({ column: "working", working: { since: null, toolUses: 0 } }, false, false);
+  assert.equal(bare.caption, "Working…", "no count, no clock → the plain swirl still says in-motion");
+});
+
 test("the narration is the FLOOR — every richer story still wins", () => {
   const w = { since: 1000, toolUses: 5 };
   assert.equal(spinFor({ column: "working", working: w, judging: true }, false, false, 2000).caption,

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -146,9 +146,12 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
     // how a silent regression becomes visible at a glance. Every richer story above (awaiting,
     // provisional, re-check, re-judging, the settle gap, distilling) still wins; this is the floor.
     const n = it.working.toolUses || 0;
-    const dur = nowS && it.working.since ? ` · ${workingFor(nowS - it.working.since)}` : "";
+    const dur = nowS && it.working.since ? workingFor(nowS - it.working.since) : "";
+    // zero tool uses says nothing worth reading ("0 tool uses" was noise — the user 2026-08-13):
+    // the count appears once there is one, and until then the timer alone carries the narration
+    const parts = [n >= 1 ? `${n} tool ${n === 1 ? "use" : "uses"}` : "", dur].filter(Boolean);
     return {
-      caption: `Working — ${n} tool ${n === 1 ? "use" : "uses"}${dur}`,
+      caption: parts.length ? `Working — ${parts.join(" · ")}` : "Working…",
       tip: "The open turn's live progress: tool calls made so far, and how long this stretch has been "
          + "running. If the count freezes while the timer climbs, something is worth a look.",
       awaitingBg: false,


### PR DESCRIPTION
Follow-up to #321 per the user: "Working — 0 tool uses · 3m" is noise. The tool count now appears from one call up; at zero the timer alone narrates ("Working — 3m"), and with neither count nor clock the plain "Working…" swirl still reads as in-motion. Executable ladder tests updated (zero case + bare case). Node suite green locally (1876).

🤖 Generated with [Claude Code](https://claude.com/claude-code)