### PR TITLE
Slash-command cache: persist across restarts, pre-warm at session events

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4257,6 +4257,7 @@ def _spawn_session(name, cwd=None):
     TMUX* so the child launcher never thinks it is already inside a tmux client. `cwd` is the session's
     working directory (validated by _resolve_create_dir); None falls back to the kernel default."""
     cwd = cwd or _default_create_dir()
+    _commands_for_cwd(cwd)   # pre-warm the slash-command list — a new session predicts a composer (the user 2026-08-13)
     env = {k: v for k, v in os.environ.items() if k not in ("TMUX", "TMUX_PANE")}
     try:
         subprocess.run([str(BIN / "romp"), "new", "-t", "--detach", name], cwd=cwd, env=env, timeout=25,
@@ -4316,6 +4317,7 @@ def _create_sdk_session(nm, cwd, auth=""):
     the next full cycle, ~5-6s on a busy fleet, all of it spent staring at the provisional dots
     (measured live, the user 2026-08-10)."""
     bg, fg = _pick_identity_color()   # fleet-aware: only the kernel sees BOTH backends' live sessions
+    _commands_for_cwd(cwd)   # pre-warm the slash-command list — a new session predicts a composer (the user 2026-08-13)
     sid = _sdk().spawn(nm, cwd, bg, fg, auth=auth)
     _sdk().connect(sid)    # eager-connect so the model lists immediately, not only after the 1st message
     _reveal_chat({"type": "focus", "id": sid})
@@ -4683,6 +4685,8 @@ def _do_warm_commands(cwd):
         err = (str(e) or e.__class__.__name__)[:200]
     with _CMD_CACHE_LOCK:
         _CMD_CACHE[cwd] = {"commands": cmds, "ts": time.time(), "warming": False, "err": err}
+    if cmds and not err:
+        _save_cmd_cache()             # a good probe is worth keeping across restarts (the user 2026-08-13)
 
 
 def _commands_for_cwd(cwd):
@@ -4699,6 +4703,53 @@ def _commands_for_cwd(cwd):
                                "ts": (ent or {}).get("ts", 0.0), "warming": True, "err": ""}
             threading.Thread(target=_do_warm_commands, args=(cwd,), daemon=True).start()
         return (ent or {}).get("commands", []), True
+
+
+# The persisted half of the cache (the user 2026-08-13, whose first "/" on the devbox took seconds): the
+# probe boots a whole `claude` process, and the in-memory cache died with every kernel restart — which is
+# most days, several times, on a repo that deploys by restarting. One JSON file holds every cwd's last
+# good list, keyed to the CLI BINARY (path + mtime): a CLI update changes the command set; nothing else
+# romp can see does. Loaded once at import; a loaded entry keeps its original ts, so the existing
+# stale-while-rewarming semantics decide freshness — the first "/" after a restart serves the persisted
+# list instantly and the background probe refreshes it.
+_CMD_CACHE_FILE = jd.STATE / "commands-cache.json"
+
+
+def _claude_fingerprint():
+    try:
+        p = str(_claude_bin())
+        return "%s:%d" % (p, int(os.stat(p).st_mtime))
+    except Exception:
+        return ""
+
+
+def _save_cmd_cache():
+    try:
+        with _CMD_CACHE_LOCK:
+            cwds = {cwd: {"commands": ent["commands"], "ts": ent.get("ts", 0.0)}
+                    for cwd, ent in _CMD_CACHE.items()
+                    if ent.get("commands") and not ent.get("err")}
+        _atomic_write(_CMD_CACHE_FILE, json.dumps({"claude": _claude_fingerprint(), "cwds": cwds}))
+    except Exception as e:
+        sys.stderr.write("commands-cache save: %s\n" % e)   # a cache that can't persist still serves
+
+
+def _load_cmd_cache():
+    try:
+        d = json.loads(_CMD_CACHE_FILE.read_text())
+    except Exception:
+        return                                       # no file yet / unreadable → cold start, as before
+    if not isinstance(d, dict) or d.get("claude") != _claude_fingerprint():
+        return                                       # a different CLI binary → its command set is stale
+    with _CMD_CACHE_LOCK:
+        for cwd, ent in (d.get("cwds") or {}).items():
+            if isinstance(ent, dict) and isinstance(ent.get("commands"), list) and ent["commands"]:
+                _CMD_CACHE.setdefault(cwd, {"commands": ent["commands"],
+                                            "ts": float(ent.get("ts") or 0.0),
+                                            "warming": False, "err": ""})
+
+
+_load_cmd_cache()
 
 
 # The auto-retry / "Retry now" message romp injects into an API-error-blocked session (the apiRetry route).
@@ -5436,6 +5487,7 @@ def _revive_session(sid):
     name = _name_of(sid) or sid
     be = _sdk()
     ok, detail = False, ""
+    _commands_for_cwd(_cwd_of(sid))   # pre-warm the slash-command list — a revival predicts a composer (the user 2026-08-13)
     try:
         if be and be.owns(sid):
             ok = bool(be.resume(name, sid) and be.connect(sid))

--- a/tests/test_kernel_cmd_cache.py
+++ b/tests/test_kernel_cmd_cache.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""The slash-command cache survives kernel restarts and is warmed by session events (the user
+2026-08-13, whose first "/" on a fresh kernel took the length of a whole `claude` boot). The probe
+result persists to STATE/commands-cache.json keyed to the CLI BINARY (path + mtime — a CLI update
+changes the command set, nothing else romp can see does); load keeps each entry's original ts so the
+existing stale-while-rewarming semantics decide freshness. Spawn/create/revive pre-warm the cwd — the
+events that predict a composer. SYNTHETIC fixtures only."""
+import inspect
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_cmdcache", os.path.join(BIN, "romp-kernel")).load_module()
+
+CMDS = [{"name": "compact", "description": "Compact the conversation"},
+        {"name": "autocompact", "description": "Toggle autocompact", "argumentHint": "[on|off|auto]"}]
+
+
+class CmdCachePersistence(unittest.TestCase):
+    def setUp(self):
+        self._fp = km._claude_fingerprint
+        km._claude_fingerprint = lambda: "/fake/claude:12345"
+        with km._CMD_CACHE_LOCK:
+            km._CMD_CACHE.clear()
+        km._CMD_CACHE_FILE.unlink(missing_ok=True)
+
+    def tearDown(self):
+        km._claude_fingerprint = self._fp
+        with km._CMD_CACHE_LOCK:
+            km._CMD_CACHE.clear()
+        km._CMD_CACHE_FILE.unlink(missing_ok=True)
+
+    def test_round_trip_survives_a_restart(self):
+        with km._CMD_CACHE_LOCK:
+            km._CMD_CACHE["/tmp/proj"] = {"commands": CMDS, "ts": 1781100000.0, "warming": False, "err": ""}
+        km._save_cmd_cache()
+        with km._CMD_CACHE_LOCK:
+            km._CMD_CACHE.clear()                     # the restart
+        km._load_cmd_cache()
+        ent = km._CMD_CACHE.get("/tmp/proj")
+        self.assertIsNotNone(ent, "the persisted list is back without a probe")
+        self.assertEqual(ent["commands"], CMDS)
+        self.assertEqual(ent["ts"], 1781100000.0, "original ts — stale-while-rewarming decides freshness")
+        self.assertFalse(ent["warming"])
+
+    def test_a_stale_persisted_entry_serves_instantly_and_rewarms(self):
+        with km._CMD_CACHE_LOCK:
+            km._CMD_CACHE["/tmp/proj"] = {"commands": CMDS, "ts": 1781100000.0, "warming": False, "err": ""}
+        km._save_cmd_cache()
+        with km._CMD_CACHE_LOCK:
+            km._CMD_CACHE.clear()
+        km._load_cmd_cache()
+        kicked = []
+        _thr = km.threading.Thread
+        km.threading.Thread = lambda **kw: type("T", (), {"start": lambda s: kicked.append(kw.get("args"))})()
+        try:
+            cmds, warming = km._commands_for_cwd("/tmp/proj")
+        finally:
+            km.threading.Thread = _thr
+        self.assertEqual(cmds, CMDS, "the persisted list serves on the FIRST request after a restart")
+        self.assertTrue(warming, "…while the old ts kicks the background refresh")
+        self.assertEqual(kicked, [("/tmp/proj",)])
+
+    def test_a_different_cli_binary_invalidates_the_file(self):
+        with km._CMD_CACHE_LOCK:
+            km._CMD_CACHE["/tmp/proj"] = {"commands": CMDS, "ts": 1781100000.0, "warming": False, "err": ""}
+        km._save_cmd_cache()
+        with km._CMD_CACHE_LOCK:
+            km._CMD_CACHE.clear()
+        km._claude_fingerprint = lambda: "/fake/claude:99999"   # the CLI updated
+        km._load_cmd_cache()
+        self.assertEqual(km._CMD_CACHE, {}, "another binary's command set is not this one's")
+
+    def test_failed_and_empty_probes_are_not_persisted(self):
+        with km._CMD_CACHE_LOCK:
+            km._CMD_CACHE["/tmp/ok"] = {"commands": CMDS, "ts": 1.0, "warming": False, "err": ""}
+            km._CMD_CACHE["/tmp/err"] = {"commands": CMDS, "ts": 1.0, "warming": False, "err": "sdk-unavailable"}
+            km._CMD_CACHE["/tmp/empty"] = {"commands": [], "ts": 1.0, "warming": False, "err": ""}
+        km._save_cmd_cache()
+        d = json.loads(km._CMD_CACHE_FILE.read_text())
+        self.assertEqual(sorted(d["cwds"].keys()), ["/tmp/ok"])
+
+
+class SessionEventsWarmTheCache(unittest.TestCase):
+    """Source pins: the three session events that predict a composer each kick the warm. Placement
+    pins (the functions are heavyweight to execute here); the warm itself is executed above."""
+
+    def test_spawn_create_and_revive_prewarm(self):
+        for fn in (km._spawn_session, km._create_sdk_session, km._revive_session):
+            self.assertIn("_commands_for_cwd(", inspect.getsource(fn),
+                          "%s must pre-warm the slash-command list" % fn.__name__)
+
+    def test_the_probe_persists_its_wins(self):
+        self.assertIn("_save_cmd_cache()", inspect.getsource(km._do_warm_commands),
+                      "a good probe is worth keeping across restarts")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The composer's "/" list is probed by booting a throwaway `claude` process, and the cache was in-memory only — every kernel restart re-colded every cwd. The list now persists to `STATE/commands-cache.json` keyed to the CLI binary (path+mtime), loads at start with original timestamps (stale-while-rewarming decides freshness), and session spawn/create/revive pre-warm their cwd. Greenlit by the user after the devbox diagnosis; `tests/test_kernel_cmd_cache.py` covers the round-trip, instant-serve-then-rewarm, binary invalidation, and the no-persist rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)