### PR TITLE
Try again feedback: toast on success, refusal, and kernel silence

### DIFF
--- a/ui/webview/feed-warn-chip.test.ts
+++ b/ui/webview/feed-warn-chip.test.ts
@@ -55,6 +55,19 @@ test("a given-up summarizer wears its NAME — 'distill failed' — and its moda
   assert.match(FEED, /couldn't retry the summary: /);
 });
 
+test("Try again answers OUT LOUD in every column — success, refusal, and silence (the user 2026-08-13, round 2)", () => {
+  // the first cut leaned on the Distilling… swirl, which a Working card withholds — the retry SUCCEEDED
+  // and still read as a silent no-op. Success now toasts a promise true in every column…
+  assert.match(FEED, /feedToast\("summary retry armed — it regenerates on the next judge pass over this card"\)/);
+  // …and SILENCE is named too: a kernel that predates the redistill op drops it with no result at all,
+  // so the click arms a backstop watch that only speaks when the ack never comes
+  assert.match(FEED, /armRedistillWatch\(ctx\.itemId\);/);
+  assert.match(FEED, /let redistillWatch: \{ itemId: string; timer: number \} \| null = null;/);
+  assert.match(FEED, /no answer from the kernel about the summary retry — it may predate this feature/);
+  // the ack — either verdict — disarms the watch before it can cry wolf
+  assert.match(FEED, /if \(redistillWatch && redistillWatch\.itemId === m\.itemId\) \{\s*\n\s*window\.clearTimeout\(redistillWatch\.timer\);/);
+});
+
 test("the overlay lists each warn's kind/age and full detail", () => {
   assert.match(FEED, /function feedWarnModal\(cardTitle: string/);
   assert.match(FEED, /meta\.textContent = w\.kind \+ " · " \+ relAge\(/);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -557,6 +557,24 @@ function feedConfirm(message: string, confirmLabel: string, onConfirm: () => voi
 // failed" chip label and the modal's Try again (the user 2026-08-13); other anomaly kinds stay "warning".
 const DISTILL_FAIL_RE = /^(summary|brief|stall)-failed$/;
 
+// Feedback for the modal's Try again (the user 2026-08-13, round 2: the first cut leaned on the card's
+// Distilling… swirl, which only shows where the done-side line is the visible one — on a Working card
+// the click looked like a silent no-op even as the retry SUCCEEDED). Success and refusal both toast,
+// and silence itself is caught: a kernel that predates the redistill op drops it with no result at all,
+// so a backstop timer names that case instead of leaving the click unanswered (the ack event is the
+// signal; the timer only speaks when it never comes).
+let redistillWatch: { itemId: string; timer: number } | null = null;
+function armRedistillWatch(itemId: string): void {
+  if (redistillWatch) window.clearTimeout(redistillWatch.timer);
+  redistillWatch = {
+    itemId,
+    timer: window.setTimeout(() => {
+      redistillWatch = null;
+      feedToast("no answer from the kernel about the summary retry — it may predate this feature (restart romp to update it)");
+    }, 6000),
+  };
+}
+
 function feedWarnModal(cardTitle: string, warns: { kind: string; t: number; msg: string; detail: string }[],
                        ctx?: { itemId: string; sid: string }): void {
   const back = el("div", "fconfirm-back fwarn-back");
@@ -582,6 +600,7 @@ function feedWarnModal(cardTitle: string, warns: { kind: string; t: number; msg:
     retry.onclick = (e) => {
       e.stopPropagation();
       retry.disabled = true; retry.textContent = "retrying…";   // acknowledged before any round-trip
+      armRedistillWatch(ctx.itemId);                            // silence gets named, never swallowed
       vscodeApi?.postMessage({ type: "redistill", itemId: ctx.itemId, sid: ctx.sid });
       window.setTimeout(close, 300);   // cosmetic beat so the pressed label registers; the op is already posted
     };
@@ -3744,9 +3763,16 @@ window.addEventListener("message", (e: MessageEvent) => {
       feedToast("couldn't mark that sub-goal done: " + (String(m.error || "") || "the kernel refused it"));
     }
   } else if (m.type === "redistillResult" && typeof m.itemId === "string") {
-    // The kernel's verdict on the warn modal's Try again. Success is silent — the re-armed line reads
-    // pending, so the card's own "Distilling…" swirl takes over. A refusal says why, out loud.
-    if (!m.ok) feedToast("couldn't retry the summary: " + (String(m.error || "") || "the kernel refused it"));
+    // The kernel's verdict on the warn modal's Try again — BOTH answers toast (the user 2026-08-13,
+    // round 2: success used to lean on the Distilling… swirl, which a Working card withholds, so a
+    // WORKING retry read as a silent no-op). The success copy promises what is actually true in every
+    // column: the line regenerates on the next judge pass over this card.
+    if (redistillWatch && redistillWatch.itemId === m.itemId) {
+      window.clearTimeout(redistillWatch.timer);
+      redistillWatch = null;
+    }
+    if (m.ok) feedToast("summary retry armed — it regenerates on the next judge pass over this card");
+    else feedToast("couldn't retry the summary: " + (String(m.error || "") || "the kernel refused it"));
   } else if (m.type === "revealCards") {
     // chat rail CLICK → scroll to the card(s) covering that turn and pulse them (the user 2026-07-23).
     // Distinct from hoverCards, which only outlines whatever is already on screen: this one MOVES the


### PR DESCRIPTION
Round 2 of the distill retry (#326): the retry succeeded but read as a silent no-op — the Distilling… swirl is withheld outside the Completed column. Success now toasts ("summary retry armed — it regenerates on the next judge pass over this card"), refusal keeps its toast, and a no-ack backstop names the silent-drop case (a kernel predating the op). Pins updated in `feed-warn-chip.test.ts`; suite 1878 green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)