### PR TITLE
fix: kernel-built event timestamps render at the kernel's wall time for any viewer in another timezone

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13,7 +13,7 @@ Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
 import json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse, parse_qs, unquote, urlencode
@@ -640,8 +640,16 @@ _cancel_pending = set()
 
 # ───────────────────────── helpers ─────────────────────────
 def iso(t):
+    """Epoch → the ISO-8601 UTC ('…Z') form the CLI's own transcript records wear.
+
+    The offset suffix is LOAD-BEARING: these strings ship in chat-event payloads and the client
+    recovers the epoch with Date.parse (render.ts eventEpoch), which reads an OFFSET-LESS string in
+    the BROWSER's timezone. The old naive form (box-local wall clock, no suffix) therefore rendered
+    every rail stamp at the kernel's wall time instead of the viewer's — invisible while both sat in
+    one timezone, wrong by the whole UTC offset the moment they didn't (found reading a UTC box's
+    dashboard from a laptop in another timezone)."""
     try:
-        return datetime.fromtimestamp(t).strftime("%Y-%m-%dT%H:%M:%S")
+        return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     except Exception:
         return ""
 

--- a/tests/test_event_ts_timezone.py
+++ b/tests/test_event_ts_timezone.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Kernel-built event timestamps carry an explicit UTC offset — never a naive wall clock.
+
+The chat payload's `ts` strings (kernel `iso()`) are recovered client-side with Date.parse
+(render.ts eventEpoch), which interprets an OFFSET-LESS string in the BROWSER's timezone. The old
+`iso()` emitted the kernel box's naive local wall clock, so every rail stamp rendered at the
+KERNEL's wall time on every viewer's screen — invisible while the box and the viewer shared a
+timezone, wrong by the whole UTC offset the moment they didn't (found reading a UTC box's
+dashboard from a laptop in another timezone). The transcript's own records were never affected: the CLI
+writes '…Z' and parse_z reads the offset; only romp-built events took the naive path.
+
+The round-trip test pins the semantics, not the spelling: format under a non-UTC process timezone,
+parse the way the browser does, and require the original epoch back.
+"""
+import os
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # hermetic BEFORE any romp code loads
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_tz", os.path.join(BIN, "romp-kernel")).load_module()
+em = SourceFileLoader("romp_event_model_tz", os.path.join(ROOT, "kernel", "event_model.py")).load_module()
+
+EPOCH = 1781100000   # an arbitrary fixed instant
+
+
+class IsoCarriesItsOffset(unittest.TestCase):
+    def _with_tz(self, tz):
+        old = os.environ.get("TZ")
+        os.environ["TZ"] = tz
+        time.tzset()
+        self.addCleanup(lambda: (os.environ.update(TZ=old) if old else os.environ.pop("TZ", None),
+                                 time.tzset()))
+
+    def test_round_trips_regardless_of_the_boxes_timezone(self):
+        # parse_z is the offset-honoring parse — the same semantics as the browser's Date.parse on
+        # an offset-carrying string. Under a naive iso() this recovers a skewed epoch (the bug);
+        # with the offset present it must be exact, whatever TZ the kernel process runs in.
+        for tz in ("UTC", "America/New_York", "Asia/Tokyo"):
+            self._with_tz(tz)
+            s = km.iso(EPOCH)
+            self.assertTrue(s.endswith("Z") or "+" in s,
+                            "iso() must carry an explicit offset; got %r under TZ=%s" % (s, tz))
+            self.assertEqual(em.parse_z(s), EPOCH, "round-trip skewed under TZ=%s: %r" % (tz, s))
+
+    def test_matches_the_transcripts_own_form(self):
+        # one wire format for event `ts`, whether the CLI wrote it or romp built it
+        self._with_tz("America/New_York")
+        self.assertRegex(km.iso(EPOCH), r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+    def test_unparseable_input_still_returns_empty(self):
+        self.assertEqual(km.iso(None), "")
+        self.assertEqual(km.iso(float("nan")), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`iso()` formats kernel-built event timestamps as a naive local wall clock with no offset suffix. Those strings ship in chat-event payloads, and the client recovers the epoch with `Date.parse` (render.ts `eventEpoch`) — which interprets an offset-less string in the **browser's** timezone. Net effect: every kernel-built rail stamp (orphan replies, retry notes, effort notes, clear boundaries, atom stamps) renders at the kernel box's wall time on every viewer's screen. It's invisible while the box and the viewer share a timezone, and wrong by the full UTC offset the moment they don't — found reading a UTC cloud box's dashboard from a laptop in another timezone.

The CLI's own transcript records were never affected: they carry `…Z` and both ends honor it. Only romp-built events took the naive path.

## The fix

One line: format in UTC with the same `…Z` form the transcript already wears —

```python
datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
```

No client change needed: `Date.parse` honors the suffix, and all display paths (`toLocale*`) already render viewer-local.

## Tests

`tests/test_event_ts_timezone.py` round-trips `iso()` → `parse_z` under UTC, America/New_York and Asia/Tokyo process timezones (the round trip is exactly what the naive form breaks), and pins the wire form. It follows the state-isolation preamble `test_state_isolation_order` requires.

This has been running on a fork for a couple of days (UTC kernel, viewers in another timezone) with stamps correct since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)