### PR TITLE
fix: WS frame reader crashes on EOF mid-frame; per-byte unmask stalls the reader thread on large frames

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16773,13 +16773,24 @@ def _ws_recv(rfile):
     masked = b[1] & 0x80
     ln = b[1] & 0x7F
     if ln == 126:
-        ln = struct.unpack(">H", rfile.read(2))[0]
+        ext = rfile.read(2)
+        if len(ext) < 2:
+            return None, None, True
+        ln = struct.unpack(">H", ext)[0]
     elif ln == 127:
-        ln = struct.unpack(">Q", rfile.read(8))[0]
+        ext = rfile.read(8)
+        if len(ext) < 8:
+            return None, None, True
+        ln = struct.unpack(">Q", ext)[0]
     mask = rfile.read(4) if masked else b"\x00\x00\x00\x00"
-    payload = bytearray(rfile.read(ln))
-    for i in range(len(payload)):
-        payload[i] ^= mask[i % 4]
+    payload = rfile.read(ln)
+    if len(mask) < 4 or len(payload) < ln:   # EOF mid-frame → a clean close, not a struct.error crash
+        return None, None, True
+    if masked and ln:
+        # C-speed unmask via big-int XOR: a per-byte Python loop takes seconds on a multi-MB
+        # attachment frame, blocking this client's reader thread the whole time.
+        rep = (mask * (ln // 4 + 1))[:ln]
+        payload = (int.from_bytes(payload, "big") ^ int.from_bytes(rep, "big")).to_bytes(ln, "big")
     return opcode, bytes(payload), fin
 
 

--- a/tests/test_ws_hardening.py
+++ b/tests/test_ws_hardening.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Hardening on the WebSocket frame reader, beyond tests/test_ws_fragmentation.py.
+
+That file covers reassembly itself (fragments, pings, strays, the cap). Pinned HERE:
+
+- EOF mid-frame reads as a clean close — a connection that dies inside a frame's length
+  extension or payload must return (None, None, True), never crash the reader thread with a
+  struct.error mid-read.
+- the big-int XOR unmask — the per-byte Python loop takes SECONDS on a multi-MB attachment
+  frame, blocking that client's reader thread the whole time; the multi-megabyte round trip
+  below runs against the reference per-byte XOR the frame() helper encodes with.
+- the reassembly cap actually clears the composer's shipped-attachment ceiling (render.ts
+  SHIP_MAX_BYTES base64-inflated), or the client-side cap would lie.
+"""
+import io
+import os
+import struct
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # hermetic BEFORE any romp code loads
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_wsh", os.path.join(BIN, "romp-kernel")).load_module()
+
+MASK = b"\x11\x22\x33\x44"
+
+
+def frame(payload, opcode, fin=True, mask=MASK):
+    """One client (masked) frame, wire-encoded — unmasking done per byte, the reference the
+    kernel's big-int fast path must agree with."""
+    b0 = (0x80 if fin else 0x00) | opcode
+    ln = len(payload)
+    if ln < 126:
+        hdr = bytes([b0, 0x80 | ln])
+    elif ln < 65536:
+        hdr = bytes([b0, 0x80 | 126]) + struct.pack(">H", ln)
+    else:
+        hdr = bytes([b0, 0x80 | 127]) + struct.pack(">Q", ln)
+    return hdr + mask + bytes(c ^ mask[i % 4] for i, c in enumerate(payload))
+
+
+def fragmented(payload, chunk, opcode=0x1):
+    """A message split into continuation frames of `chunk` bytes, as a browser would send it."""
+    parts = [payload[i:i + chunk] for i in range(0, len(payload), chunk)] or [b""]
+    out = b""
+    for i, p in enumerate(parts):
+        out += frame(p, opcode if i == 0 else 0x0, fin=(i == len(parts) - 1))
+    return out
+
+
+def recv_message(wire):
+    pings = []
+    return km._ws_recv_message(io.BytesIO(wire), pings.append)
+
+
+class WsRecvHardening(unittest.TestCase):
+    def test_multi_megabyte_payload_round_trips(self):
+        # a realistic attachment: ~6 MB of base64-ish bytes in browser-sized (~128 KB) fragments —
+        # exercises the big-int unmask fast path against frame()'s reference per-byte XOR
+        body = (b'{"type":"dropFile","b64":"' + os.urandom(3 * 1024 * 1024).hex().encode() + b'"}')
+        op, payload = recv_message(fragmented(body, chunk=128 * 1024))
+        self.assertEqual((op, payload), (0x1, body))
+
+    def test_unmask_agrees_with_the_reference_at_awkward_lengths(self):
+        # lengths straddling the 4-byte mask stride, where a repeat-and-slice bug would show
+        for ln in (0, 1, 3, 4, 5, 125, 126, 127, 65535, 65536, 65537):
+            body = os.urandom(ln)
+            op, payload, fin = km._ws_recv(io.BytesIO(frame(body, 0x2)))
+            self.assertEqual((op, payload, fin), (0x2, body, True), "length %d" % ln)
+
+    def test_eof_mid_frame_reads_as_dead_connection_not_a_crash(self):
+        whole = frame(b'{"type":"ready"}', 0x1)
+        for cut in (1, 3, 9, len(whole) - 1):          # header, extension, mask, payload
+            self.assertEqual(km._ws_recv(io.BytesIO(whole[:cut])), (None, None, True),
+                             "truncated at byte %d" % cut)
+        big = frame(b"x" * 70000, 0x1)                 # 2-byte length extension, cut inside it
+        self.assertEqual(km._ws_recv(io.BytesIO(big[:3])), (None, None, True))
+        huge = frame(b"x" * 70000, 0x1)                # …and the same for a truncated payload
+        self.assertEqual(km._ws_recv(io.BytesIO(huge[:2000])), (None, None, True))
+
+    def test_eof_mid_message_reads_as_dead_connection(self):
+        wire = fragmented(b'{"type":"ready"}', chunk=4)[:9]   # truncated mid-payload
+        self.assertEqual(recv_message(wire), (None, None))
+
+    def test_the_cap_covers_the_composers_shipped_attachment_ceiling(self):
+        # render.ts refuses attachments over SHIP_MAX_BYTES (50 MB); base64 inflates by 4/3, so the
+        # receiver's ceiling must clear ~67 MB of payload plus JSON framing or the client-side cap lies
+        self.assertGreater(km._WS_MAX_MESSAGE, 50 * 1024 * 1024 * 4 // 3 + 4096)
+        render = open(os.path.join(ROOT, "ui", "webview", "render.ts"), encoding="utf-8").read()
+        self.assertIn("SHIP_MAX_BYTES = 50 * 1024 * 1024", render)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two hardenings on `_ws_recv`, found while merging v0.7.0's fragmentation fix into a fork that had fixed the same bug independently — the reassembly design here (`_ws_recv` per-frame + `_ws_recv_message`) won the comparison, and these are the two pieces the fork's version had that this one lacks.

## 1. EOF mid-frame is a crash, not a close

The 2-byte header read checks its length, but the paths after it don't: a connection that dies inside a length extension raises `struct.error` out of the reader thread, and one that dies mid-payload hands a short buffer to the unmask loop. Both are ordinary events on flaky links (phones especially — the same clients whose large sends motivated reassembly). Every truncation point now reads as a clean close, `(None, None, True)`, exactly like the header path already did.

## 2. The per-byte unmask blocks the reader thread for seconds

```python
for i in range(len(payload)):
    payload[i] ^= mask[i % 4]
```

is pure-Python per byte — on a multi-MB attachment frame (a phone photo's `dropFile`) it takes seconds, during which that client's reader thread is wedged. Replaced with a big-int XOR (repeat the 4-byte mask, one `int.from_bytes ^ int.from_bytes` — effectively C speed). Verified against the per-byte reference at mask-stride-straddling lengths (0, 1, 3, 4, 5, 125-127, 65535-65537).

## Tests

`tests/test_ws_hardening.py` pins both behaviors plus the cap-vs-`SHIP_MAX_BYTES` arithmetic (the reassembly ceiling must clear the composer's 50 MB cap after base64 inflation, or the client-side cap lies). `tests/test_ws_fragmentation.py` still covers reassembly itself and passes unchanged, as does the `WsLoopResilience` stub in `test_kernel.py` — the `_ws_recv` signature is untouched. The new file follows the `test_state_isolation_order` preamble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)