### PR TITLE
fix: the auto-nudge status-checks a blocked-on-the-user goal mid-oscillation

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -269,6 +269,16 @@ _WHY_JUDGING_LEGACY = "a judge pass is mid-flight"
 # INSPECTABLE: this drop used to leave NO record anywhere, which is how a card sat in Working for half an
 # hour with nothing to read (see the kernel's _nudge_fire_list).
 WHY_TURN_IN_FLIGHT = "a judge has ruled on a turn that hasn't finished yet"
+# The fire list's THIRD hold (2026-08-11): a goal whose diary ENDS on a judge's UNBLOCK, with an
+# EARLIER judge unblock already on record, is mid-OSCILLATION — the column has ping-ponged
+# blocked↔working at least once without settling, and the closer's next word is pending. Five false
+# status checks in one live weekend fired in that window: a blocked-on-the-user goal was repeatedly
+# flipped to 'working' by "new work filed" / "answered in passing" rulings while the user's decision was
+# still outstanding, and the nudge read each flip as a stall. A goal's FIRST unblock never holds — that
+# is the 2026-07-30 considered-verdict case, whose own incident was a wrongly-gagged nudge. Same
+# never-paint rule as the holds above; clears on the closer's next word (any newer judge row on the
+# goal) or the deferral backstop.
+WHY_UNBLOCK_UNSETTLED = "an unblock is awaiting the closer's next word on this goal"
 # The CONSOLIDATOR (the user 2026-06-19): the grouper's twin for the COMPLETED column. The working grouper
 # only ever sees OPEN tops, so related goals that finish before they get
 # grouped land as separate cards. The consolidator groups related ALL-COMPLETED sibling tops under a
@@ -8101,7 +8111,11 @@ def stall_llm(goal_text, work_text, holding):
 # so one frozen between retries showed nothing at all — six live records were dark up to 20 hours.
 # Now the kernel's deferral sweep retires each record on its reason's own event, and whatever stands
 # presents somewhere by definition.
-WHY_IN_FLIGHT = (WHY_JUDGING, _WHY_JUDGING_LEGACY, WHY_TURN_IN_FLIGHT)
+# The unblock-unsettled hold is in-flight for the same reason the turn hold is: the closer's next
+# pass is romp's own review mid-flight, not a state the user acts on. Its sweep case retires it on
+# the closer's next filed word (kernel _deferral_sweep_tick, ABOVE the class branch — the class
+# branch's no-judge-running event would retire it early).
+WHY_IN_FLIGHT = (WHY_JUDGING, _WHY_JUDGING_LEGACY, WHY_TURN_IN_FLIGHT, WHY_UNBLOCK_UNSETTLED)
 
 
 def stalled_facts(fsid):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3371,6 +3371,8 @@ def _deferral_sweep_tick(now):
       * the goal left plain 'working' (resolved/cleared/gone) — pop, whatever the why;
       * WHY_TURN_IN_FLIGHT — the held-on evidence's turn has ENDED: newest ended-turn watermark
         >= the record's evT (stamped at mint from the offending diary row);
+      * WHY_UNBLOCK_UNSETTLED — the closer's next word: the goal's newest judge row is no
+        longer an unblock;
       * WHY_JUDGING (+ legacy) — no judge call in flight for the session (jd.active_runs, the
         registry that deregisters in a finally);
       * "the judge tiers are paused" — retry-paused.json cleared;
@@ -3418,6 +3420,13 @@ def _deferral_sweep_tick(now):
                                  if path else [])
                     seen_t = max((t.get("end") or 0) for t in turns if t.get("ended"))                         if any(t.get("ended") for t in turns) else 0
                     pop = seen_t >= ev                 # the held-on turn ENDED — the exact event
+            elif not pop and why == jd.WHY_UNBLOCK_UNSETTLED:
+                # the repeat-unblock hold: retired by the closer's next filed word — the goal's newest
+                # judge row is no longer an unblock. Sits ABOVE the class branch: this why is in
+                # jd.WHY_IN_FLIGHT for presentation, but no-judge-running is not its event.
+                rows = [e for e in (nodes.get(gid) or {}).get("log") or []
+                        if e.get("src") not in NUDGE_HOLD_EXEMPT_SRC]
+                pop = bool(rows) and rows[-1].get("kind") != "unblock"
             elif not pop and why in jd.WHY_IN_FLIGHT:  # judging-class (incl. legacy): the call returned
                 pop = sid not in active
             elif not pop and why and why.startswith("the judge tiers are paused"):
@@ -3708,8 +3717,8 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
             held = []
             to_fire = _nudge_fire_list(jd.load_goals(sid), to_fire, arm_t=arm.get("t") or 0,
                                        seen_t=(seen.get("t") or 0) if seen else 0, held=held)
-            to_fire += [f for f, _ev in held
-                        if _nudge_deferred_ok(f[0], jd.WHY_TURN_IN_FLIGHT, now, sid, ev_t=_ev)]
+            to_fire += [f for f, _why, _ev in held
+                        if _nudge_deferred_ok(f[0], _why, now, sid, ev_t=_ev or None)]
         except Exception:
             pass
     if len(to_fire) == 1:
@@ -3797,9 +3806,28 @@ def _nudge_fire_list(fresh, to_fire, arm_t=None, seen_t=None, held=None):
     the writer). A user gesture is exempt for the same reason and one more: it is the event that RE-ARMS
     the nudge, so treating it as grounds to withhold one inverts it.
 
-    `held` (optional list) collects the goals dropped for newer evidence, so the caller can record the
-    hold as a DEFERRAL instead of a silent drop — every other nudge hold leaves a why and rides the 6h
-    backstop, and this one leaving nothing is what made the deadlock unreadable from the state dir."""
+    A REPEATED unblock as the goal's newest judge row is its own hold (2026-08-11; see
+    jd.WHY_UNBLOCK_UNSETTLED). Five false status checks in one live weekend fired in the same window: a
+    goal blocked on the USER's decision was flipped to 'working' by "new work filed" / "answered in
+    passing" rulings while the decision was still outstanding, the nudge read each flip as a stall, and
+    the closer re-filed essentially the same block minutes later — a blocked↔working ping-pong with no
+    user action. The ev_t guard above can't see it: those unblocks rule on turns romp HAS seen end,
+    which the 2026-07-30 "considered verdict" reasoning deliberately treats as nudgeable — and for a
+    goal's FIRST unblock that reasoning stands (its own incident was a wrongly-gagged nudge, pinned in
+    tests/test_awaiting_same_trigger_wedge.py). The discriminator between the two incidents is the
+    diary itself: every flap fire had a PRIOR judge unblock already on the goal. So the hold takes only
+    a goal whose newest judge row is an unblock AND whose diary holds an earlier judge unblock — the
+    column has already ping-ponged once without settling, which is the cards-move rule's named
+    anti-pattern, and a status ask adds nothing until the judges stop moving it. Only JUDGE unblocks
+    count on both ends: a user's own unblock (an interrupt re-engage) is the event that re-ARMS the
+    nudge, and holding on it would invert it. The hold clears on the closer's next word — any newer
+    judge row on the goal — or the deferral backstop.
+
+    `held` (optional list) collects (goal, why, ev_t) triples for the goals dropped by either hold
+    (ev_t = 0 when the why's retirement event is not a turn end), so the
+    caller can record each as a DEFERRAL instead of a silent drop — every other nudge hold leaves a why
+    and rides the 6h backstop, and this one leaving nothing is what made the deadlock unreadable from
+    the state dir."""
     nodes, status = fresh.get("nodes", {}) or {}, fresh.get("status", {}) or {}
     confirming = set(fresh.get("confirming") or ())
     cut = max(arm_t or 0, seen_t or 0)
@@ -3827,10 +3855,17 @@ def _nudge_fire_list(fresh, to_fire, arm_t=None, seen_t=None, held=None):
                       and (e.get("ev_t") or e.get("at") or 0) > cut] if cut else []
         if _offending:
             if held is not None:                     # a ruling on EVIDENCE from a turn romp hasn't seen end —
-                held.append((f, max(_offending)))    # the stall read is a world old; hold it, don't lose it.
-                #                                      The max offending ev_t rides along: the deferral
+                held.append((f, jd.WHY_TURN_IN_FLIGHT, max(_offending)))
+                #                                      the stall read is a world old; hold it, don't lose
+                #                                      it. The max offending ev_t rides along: the deferral
                 #                                      record stamps it (evT) so the sweep can retire the
                 #                                      hold on that turn's own END event (2026-08-13)
+            continue
+        judge_rows = [e for e in nd.get("log") or [] if e.get("src") not in NUDGE_HOLD_EXEMPT_SRC]
+        if judge_rows and judge_rows[-1].get("kind") == "unblock" \
+                and any(e.get("kind") == "unblock" for e in judge_rows[:-1]):
+            if held is not None:                     # a REPEAT unblock mid-oscillation: the unblocker spoke
+                held.append((f, jd.WHY_UNBLOCK_UNSETTLED, 0))   # again, the closer hasn't answered (see docstring)
             continue
         keep.append(f)
     return keep

--- a/tests/test_interrupt_lift_evidence_time.py
+++ b/tests/test_interrupt_lift_evidence_time.py
@@ -189,7 +189,7 @@ class TheNudgeIsNotHeldByTheLift(unittest.TestCase):
         held = []
         keep = km._nudge_fire_list(fresh, [(GID, 0, True)], arm_t=CUT_T, seen_t=RESUME_T, held=held)
         self.assertEqual(keep, [])
-        self.assertEqual([f[0] for f, _ev in held], [GID])
+        self.assertEqual([(f[0], why) for f, why, _ev in held], [(GID, jd.WHY_TURN_IN_FLIGHT)])
         self.assertIn(jd.WHY_TURN_IN_FLIGHT, jd.WHY_IN_FLIGHT,
                       "the hold's why is in-flight class: it presents as the Analyzing… swirl "
                       "(and the sweep pops it on the turn's own end) — no silent card since 2026-08-13")

--- a/tests/test_kernel_nudge_last_resort.py
+++ b/tests/test_kernel_nudge_last_resort.py
@@ -364,7 +364,8 @@ class StalledGoals(Base):
         # stalled_facts (judge side) and build_feed's routing key on the SAME jd.WHY_IN_FLIGHT tuple,
         # so the two stall surfaces can never disagree about which reasons wear the chip.
         self.assertEqual(set(jd.WHY_IN_FLIGHT),
-                         {jd.WHY_JUDGING, jd._WHY_JUDGING_LEGACY, jd.WHY_TURN_IN_FLIGHT})
+                         {jd.WHY_JUDGING, jd._WHY_JUDGING_LEGACY, jd.WHY_TURN_IN_FLIGHT,
+                          jd.WHY_UNBLOCK_UNSETTLED})   # the repeat-unblock hold is in-flight too
         self.assertNotIn("the agent's to-do sync is due", jd.WHY_IN_FLIGHT,
                          "store-backed reasons wear the chip — they are genuine stalls to read")
 

--- a/tests/test_nudge_hold_judge_rows.py
+++ b/tests/test_nudge_hold_judge_rows.py
@@ -50,7 +50,7 @@ def _run(rows, **kw):
     held = []
     keep = km._nudge_fire_list(_fresh(rows, **kw), [(GID, 0, True)],
                                arm_t=SEEN_T, seen_t=SEEN_T, held=held)
-    return [f[0] for f in keep], [f[0] for f, _ev in held]   # held carries (fire, offending ev_t) since 2026-08-13
+    return [f[0] for f in keep], [f[0] for f, _why, _ev in held]   # held carries (goal, why, ev_t)
 
 
 class RompsOwnBookkeepingNeverHolds(unittest.TestCase):

--- a/tests/test_nudge_injected_turn_arm.py
+++ b/tests/test_nudge_injected_turn_arm.py
@@ -101,9 +101,10 @@ class FireListSeenTurn(unittest.TestCase):
         held = []
         self.assertEqual(km._nudge_fire_list(self._fresh(), [(G1, 1, False)],
                                              arm_t=ARM_T, seen_t=ARM_T, held=held), [])
-        self.assertEqual([f[0] for f, _ev in held], [G1],
+        self.assertEqual([f[0] for f, _why, _ev in held], [G1],
                          "the hold must reach the caller so it can be recorded, not silently dropped")
-        self.assertTrue(all(isinstance(_ev, int) and _ev for _f, _ev in held),
+        self.assertTrue(all(isinstance(_ev, int) and _ev for _f, _why, _ev in held
+                            if _why == jd.WHY_TURN_IN_FLIGHT),
                         "…with the offending evidence time riding along (the sweep's retire event)")
 
     def test_a_resolved_goal_is_never_held(self):

--- a/tests/test_nudge_unblock_hold.py
+++ b/tests/test_nudge_unblock_hold.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""A repeated unblock is not a settlement: the nudge stands down until the closer's next word.
+
+Five false status checks in one live weekend (2026-08-10/11) fired in the same window: a goal
+blocked on the USER's decision was flipped to 'working' by a judge's unblock — the planner's
+"new work filed on this branch", the unblocker's "answered in passing" — while the decision was
+still outstanding; the nudge read the flip as a stall and status-checked an idle session that was
+waiting on the user; the closer re-filed essentially the same block (or done) seconds-to-minutes
+later. The card ping-ponged blocked→working→blocked with no user action — the cards-move rule's
+named anti-pattern — and each 'working' window produced a nudge.
+
+The existing ev_t guard can't catch it: those unblocks rule on turns romp HAS seen end, which the
+2026-07-30 "considered verdict" reasoning deliberately treats as nudgeable — and for a goal's
+FIRST unblock that reasoning is pinned doctrine (its own incident was a wrongly-gagged nudge,
+tests/test_awaiting_same_trigger_wedge.py). The discriminator between the incidents is the diary:
+every flap fire had a PRIOR judge unblock already on the goal. So the hold takes only a goal whose
+newest judge row is an unblock with an earlier judge unblock on record — already ping-ponged once,
+still unsettled — and holds it loudly (deferral record + backstop) until the closer's next word. A
+USER's own unblock (an interrupt re-engage) never counts on either end.
+
+Synthetic fixtures throughout (invented goal text, placeholder ids).
+"""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # hermetic BEFORE any romp code loads
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_ubh", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_ubh", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+GID = SID + ":g4"
+ARM_T = 1786400000          # the arm turn's trigger
+BLOCK_T = ARM_T - 900       # the block predates the arm turn (its ask is old news to the ev_t guard)
+UNBLOCK_T = ARM_T - 60      # ...and so does the unblock's evidence turn
+
+
+def store(log, status="working"):
+    return {"nodes": {GID: {"id": GID, "text": "Regroup the rows by speaker", "log": list(log)}},
+            "status": {GID: status}}
+
+
+BLOCK = {"ev_t": BLOCK_T, "src": "closer", "kind": "block", "at": BLOCK_T + 20,
+         "why": "Two calls are yours: materialize the derived file, or contact the authors?"}
+UNBLOCK_1 = {"ev_t": BLOCK_T - 300, "src": "planner", "kind": "unblock", "at": BLOCK_T - 290,
+             "why": "new work filed on this branch"}
+UNBLOCK_2 = {"ev_t": UNBLOCK_T, "src": "unblocker", "kind": "unblock", "at": UNBLOCK_T + 5,
+             "why": "answered in passing: the thread pivoted"}
+FLAP = [UNBLOCK_1, BLOCK, UNBLOCK_2]     # the live incident shape: already ping-ponged once, unsettled
+
+
+class RepeatUnblockHoldsTheNudge(unittest.TestCase):
+    def _run(self, log, status="working"):
+        held = []
+        keep = km._nudge_fire_list(store(log, status), [(GID, 1, False)],
+                                   arm_t=ARM_T, seen_t=ARM_T, held=held)
+        return keep, held
+
+    def test_the_incident_shape_a_repeat_trailing_unblock_holds(self):
+        keep, held = self._run(FLAP)
+        self.assertEqual(keep, [])
+        self.assertEqual([(f[0], why) for f, why, _ev in held], [(GID, jd.WHY_UNBLOCK_UNSETTLED)],
+                         "the column already ping-ponged and the closer hasn't answered — never a stall")
+
+    def test_a_goals_first_unblock_still_fires_the_pinned_doctrine(self):
+        # the 2026-07-30 considered-verdict case (tests/test_awaiting_same_trigger_wedge.py): one
+        # block, one unblock, goal working, session idle — a status check is exactly what is due
+        keep, held = self._run([BLOCK, UNBLOCK_2])
+        self.assertEqual([f[0] for f in keep], [GID])
+        self.assertEqual(held, [])
+
+    def test_the_closers_next_word_releases_it(self):
+        # the closer answered and LEFT the goal working → adjudication settled → nudgeable again
+        after = {"ev_t": UNBLOCK_T, "src": "closer", "kind": "awaiting", "at": UNBLOCK_T + 40, "lift": True}
+        keep, held = self._run(FLAP + [after])
+        self.assertEqual([f[0] for f in keep], [GID])
+        self.assertEqual(held, [])
+
+    def test_a_re_block_needs_no_hold_the_status_drop_already_covers_it(self):
+        keep, held = self._run(FLAP + [dict(BLOCK, at=UNBLOCK_T + 90)], status="blocked")
+        self.assertEqual((keep, held), ([], []), "resolved goals are dropped, never held (backstop safety)")
+
+    def test_user_unblocks_never_count_on_either_end(self):
+        # an interrupt re-engage is the event that re-ARMS the nudge; it neither holds as the trailing
+        # row nor primes the repeat count as the earlier one
+        user_unblock = {"ev_t": UNBLOCK_T, "src": "user", "kind": "unblock", "at": UNBLOCK_T + 5}
+        keep, held = self._run([BLOCK, user_unblock])
+        self.assertEqual([f[0] for f in keep], [GID])
+        keep, held = self._run([dict(user_unblock, at=BLOCK_T - 200), BLOCK, UNBLOCK_2])
+        self.assertEqual([f[0] for f in keep], [GID],
+                         "a user unblock before the judge's first isn't a prior oscillation")
+        self.assertEqual(held, [])
+
+    def test_exempt_bookkeeping_after_the_unblock_does_not_release_the_hold(self):
+        # a user gesture or romp row after the judge's unblock isn't the closer's word
+        keep, held = self._run(FLAP + [
+            {"ev_t": UNBLOCK_T + 10, "src": "user", "kind": "unblock", "at": UNBLOCK_T + 10},
+            {"ev_t": UNBLOCK_T + 12, "src": "romp", "kind": "awaiting", "lift": True, "at": UNBLOCK_T + 12}])
+        self.assertEqual(keep, [])
+        self.assertEqual([why for _, why, _ev in held], [jd.WHY_UNBLOCK_UNSETTLED])
+
+    def test_a_settled_diary_still_fires(self):
+        keep, held = self._run(FLAP + [{"ev_t": UNBLOCK_T, "src": "planner", "kind": "done",
+                                        "at": UNBLOCK_T + 30}])
+        self.assertEqual([f[0] for f in keep], [GID], "a diary ending on a non-unblock is nudgeable")
+
+    def test_the_hold_presents_as_in_flight_and_the_sweep_retires_it_on_the_closers_word(self):
+        # stall_why_stands is gone (2026-08-13): every hold presents somewhere. Ours joins the
+        # in-flight class — the Analyzing… swirl, never the stalled chip — and the sweep's own case
+        # must sit ABOVE the class branch, whose no-judge-running event would retire it early.
+        self.assertIn(jd.WHY_UNBLOCK_UNSETTLED, jd.WHY_IN_FLIGHT,
+                      "the closer's next pass is romp's own review — never presented as a stall")
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py"), encoding="utf-8").read()
+        sweep = src[src.index("def _deferral_sweep_tick"):]
+        sweep = sweep[:sweep.index("\ndef ")]
+        ours = sweep.index("why == jd.WHY_UNBLOCK_UNSETTLED")
+        cls = sweep.index("why in jd.WHY_IN_FLIGHT")
+        self.assertLess(ours, cls, "the specific retirement event must be checked before the class branch")
+        self.assertIn('rows[-1].get("kind") != "unblock"', sweep,
+                      "retired by the closer's next filed word, not by no-judge-running")
+
+    def test_the_ev_t_hold_still_wins_first_and_carries_its_own_why(self):
+        newer = {"ev_t": ARM_T + 50, "src": "closer", "kind": "block", "at": ARM_T + 60}
+        keep, held = self._run(FLAP + [newer])
+        self.assertEqual(keep, [])
+        self.assertEqual([why for _, why, _ev in held], [jd.WHY_TURN_IN_FLIGHT])
+
+
+class TheCallSiteDefersPerWhy(unittest.TestCase):
+    def test_the_tick_records_each_held_goal_under_its_own_why(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py"), encoding="utf-8").read()
+        self.assertIn("to_fire += [f for f, _why, _ev in held", src)
+        self.assertIn("if _nudge_deferred_ok(f[0], _why, now, sid, ev_t=_ev or None)]", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The incident class

A goal blocked on the **user's** decision gets flipped to `working` by judge unblocks that don't actually answer the block — rulings like *"new work was filed on this branch"* or *"answered in passing"* — while the decision is still outstanding. The auto-nudge reads each flip as a stall and fires a status ask at a session that is waiting on a human; the closer then re-files essentially the same block minutes later. Five false status checks in one weekend fired in exactly that blocked↔working ping-pong window, including while the user was actively messaging the session about *other* threads (so "has the user replied since the block" doesn't discriminate).

## The fix

The fire list gains a third hold, keyed on the goal's own diary: **a goal whose newest judge row is an unblock, and whose diary already holds an earlier judge unblock, stands down until the closer's next word.** The discriminator was checked against all five live fires and the doctrine cases: every flap fire had a prior judge unblock on record; the legitimate cases had none.

Plumbing rides the hold system's own rules (the 2026-08-13 rework): `held` rows become `(goal, why, ev_t)` triples so each hold defers under its own why; `WHY_UNBLOCK_UNSETTLED` joins `WHY_IN_FLIGHT` (it presents as the Analyzing… swirl — the closer's pending pass is romp working the card, not a stall); and `_deferral_sweep_tick` gains its retirement case — the closer's next filed word — placed **above** the in-flight class branch, because no-judge-running is not this hold's event.

## Consequences to weigh (the part worth your review)

This hold deliberately trades a little nudge latency for not interrupting a human who is the actual blocker. The edges we checked, and one real tradeoff:

1. **The first-unblock doctrine is preserved.** A goal's FIRST block→unblock leaving it working still nudges — `test_awaiting_same_trigger_wedge` (your pinned case, whose own incident was a *wrongly-gagged* nudge) passes unchanged. The hold requires a *prior* judge unblock, so it can only engage once a goal has already ping-ponged.
2. **User gestures can't trigger or extend the hold.** Only judge rows count on both ends (`NUDGE_HOLD_EXEMPT_SRC`): a user's own unblock is the event that re-ARMS the nudge, and holding on it would invert it. Pinned in tests on both ends, plus the case where exempt bookkeeping rows land after the judge's unblock.
3. **No deadlock if the closer never speaks again.** The hold defers loudly (a deferral record with its own why), rides the standard 6h backstop, and the sweep also pops it when the goal leaves `working` for any reason. Worst case is a status ask delayed by 6h on a goal the judges abandoned mid-flap.
4. **The known tradeoff: the prior-unblock memory is unbounded.** A goal legitimately unblocked once long ago, then blocked and unblocked again much later, engages the hold on the second unblock even if no flap is happening *now*. In practice the cost is small — the hold releases on the closer's very next filed word on that goal (usually the next judge pass), and the backstop caps it — but a time- or count-bounded discriminator would be a coherent alternative if you'd rather not hold on ancient history. We chose the diary-only form because it's exactly event-based (no tunable window) and because every real fire we audited had its prior unblock minutes-to-hours earlier, not weeks.
5. **Presentation:** cards under this hold show the Analyzing… swirl rather than the yellow stalled chip. If you'd rather these read as their own state, the why is already distinct — routing is one branch.

## Tests

`tests/test_nudge_unblock_hold.py` (10 tests) rebuilds the incident shapes synthetically: the flap holds; the first unblock fires; the closer's next word releases; a re-block is dropped not held; user unblocks count on neither end; exempt rows don't release; the ev_t hold still wins first with its own why; the class membership and sweep-case ordering are pinned. The existing held-shape consumers (`test_nudge_hold_judge_rows`, `test_nudge_injected_turn_arm`, `test_interrupt_lift_evidence_time`, `test_kernel_nudge_last_resort`) are updated for the triple and all pass, as do `test_stall_note` and `test_state_isolation_order`.

Running on a fork since 2026-08-11 (pre-rework form) and since 2026-08-13 in this exact form; the false status checks stopped with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)