### PR TITLE
Continue renders as a gesture-styled user bubble, not typed prose

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5115,7 +5115,11 @@ def _drive(msg, client):
         # messageless cardMove is the cautionary tale: a move with no message adds no information, so
         # its natural end state was parked-in-Working. Human-authored like the modal's canned Check
         # status (no romp-injected marker): the gesture asserts the USER's own state, in their voice.
-        text = CONTINUE_TEXT if msg.get("cont") else str(msg["text"])
+        # The romp-canned marker (the user 2026-08-13) tells the CHAT ONLY that these are canned words
+        # behind a gesture, not typed prose — the bubble stays blue and folds to a "Continue" gist.
+        # Comment form (the markers rule); the agent ignores it like every romp-* comment; authorship,
+        # judge filing, and the planner's view are all unchanged.
+        text = (CONTINUE_TEXT + "\n\n<!-- romp-canned: continue -->") if msg.get("cont") else str(msg["text"])
         body = (_followup_body(iid, msg.get("title"), text, injected=bool(msg.get("nudge")))
                 if iid else text)
         # Optimistic echo for a tmux follow-up/nudge (the user 2026-06-29): without it, a follow-up sent while
@@ -12820,6 +12824,11 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                                     ev["goal"] = fu_goal
                                 if fu_ctx:                       # the FULL stripped quote — the ↩ header expands to show it
                                     ev["fuCtx"] = fu_ctx
+                            if author == "human" and "<!-- romp-canned: continue -->" in text:
+                                # the card's Continue button (the user 2026-08-13): the USER's gesture with
+                                # romp's canned words — still blue, but the chat folds it to a gist instead
+                                # of posing the prose as typed. Comment form only, like romp-system above.
+                                ev["canned"] = "continue"
                             if author == "romp":         # a feed nudge/follow-up romp injected → gray romp bubble
                                 ev["romp"] = True
                                 if a.get("rompAuto"):    # an AUTO-nudge (not the Nudge button) → the chat draws the romp swirl

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1165,7 +1165,9 @@ class ViewBuilder(unittest.TestCase):
         # cardMove showed that a move with no message adds no information and parks the card in Working.
         import inspect
         src = inspect.getsource(km._drive)
-        self.assertIn('text = CONTINUE_TEXT if msg.get("cont") else str(msg["text"])', src)
+        # …plus the romp-canned marker (the user 2026-08-13): the chat folds the canned words to a
+        # gesture gist; a typed follow-up stays unmarked
+        self.assertIn('text = (CONTINUE_TEXT + "\\n\\n<!-- romp-canned: continue -->") if msg.get("cont") else str(msg["text"])', src)
         self.assertIn("jd.optimistic_followup(sid, iid, text=text, now=int(time.time()))", src)
         # the canned body covers its three arrival contexts (the user 2026-08-08). ALREADY WORKING is
         # the commonest press — the judge missed a continuation and the user sees the session busy —

--- a/tests/test_kernel_continue_bubble.py
+++ b/tests/test_kernel_continue_bubble.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""The Continue button's reply is the USER's gesture with romp's canned words (the user 2026-08-13):
+it stays human-authored — blue bubble, judge-filed as the user's reply, no romp-injected marker — but
+the chat must not pose the prose as typed. The cont:true send stamps <!-- romp-canned: continue -->
+(comment form, the markers rule), the event build lifts it into canned:"continue" for genuine human
+turns only, and the display strip drops it like every other romp comment. SYNTHETIC fixtures only."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_contbubble", os.path.join(BIN, "romp-kernel")).load_module()
+
+MARK = "<!-- romp-canned: continue -->"
+
+
+class ContinueMarker(unittest.TestCase):
+    def test_cont_sends_stamp_the_marker_and_typed_sends_do_not(self):
+        import inspect
+        src = inspect.getsource(km._drive)               # askFollowUp is a DRIVE op, not a _dispatch_ws one
+        self.assertIn('(CONTINUE_TEXT + "\\n\\n' + MARK + '") if msg.get("cont") else str(msg["text"])', src,
+                      "the canned marker rides ONLY the button's send — a typed follow-up stays unmarked")
+
+    def test_the_event_build_lifts_it_for_human_turns_only(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn('if author == "human" and "' + MARK + '" in text:', src,
+                      "comment-form check, and never on a romp-authored turn (a nudge quoting the copy)")
+        self.assertIn('ev["canned"] = "continue"', src)
+
+    def test_display_split_strips_the_marker_with_the_other_romp_comments(self):
+        body = ("> Ship the api\n\n" + km.CONTINUE_TEXT + "\n\n" + MARK +
+                "\n<!-- romp-goal-id: 11111111-2222-3333-4444-555555555555:g1 -->")
+        goal, clean, fu, ctx = km._split_followup(body)
+        self.assertTrue(fu)
+        self.assertEqual(goal, "Ship the api")
+        self.assertNotIn("romp-canned", clean, "the marker is display-stripped like every romp comment")
+        self.assertIn("Nothing needed from me here", clean)
+
+    def test_the_canned_copy_itself_is_marker_free(self):
+        self.assertNotIn("<!--", km.CONTINUE_TEXT,
+                         "CONTINUE_TEXT stays pure prose — the marker is appended at the ONE send site, "
+                         "so every other consumer (voice tests, the courier, the judges) sees clean copy")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_continue_button.py
+++ b/tests/test_kernel_continue_button.py
@@ -59,7 +59,9 @@ class ContinueIsADriveOp(unittest.TestCase):
 
     def test_the_handler_body_supplies_the_canned_text(self):
         src = inspect.getsource(km._drive)
-        self.assertIn('text = CONTINUE_TEXT if msg.get("cont") else str(msg["text"])', src)
+        # the romp-canned marker rides the button's send only (the user 2026-08-13): the chat folds the
+        # canned words to a gesture gist; a typed follow-up stays unmarked
+        self.assertIn('text = (CONTINUE_TEXT + "\\n\\n<!-- romp-canned: continue -->") if msg.get("cont") else str(msg["text"])', src)
         self.assertIn('(msg.get("text") or msg.get("cont"))', src,
                       "the front door admits what the body supports — one contract")
 

--- a/ui/webview/continue-bubble.test.ts
+++ b/ui/webview/continue-bubble.test.ts
@@ -1,0 +1,37 @@
+// The Continue button's reply renders as a GESTURE in the user family (the user 2026-08-13): blue —
+// the judges file it as your reply — but folded to a one-line gist ("Continue — keep going; open calls
+// are yours") with the exact canned words one click deeper, so unwritten prose never poses as typed.
+// Keyed on the kernel's romp-canned marker (event-based), never on text-matching the copy. Source pins
+// (no jsdom for the chat renderer), plus the kernel side of the contract (node-tests-pin-kernel-source).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the canned Continue folds to a gist in the BLUE bubble — gesture, not prose", () => {
+  assert.match(RENDER, /canned\?: string/, "the user event carries the kernel's lift");
+  assert.match(RENDER, /\} else if \(!romp && !injected && ev\.md && ev\.canned === "continue"\) \{/,
+    "keyed on the lifted marker, never on text-matching the canned copy");
+  assert.match(RENDER, /Continue — keep going; open calls are yours/);
+  // the same fold machinery nudges use: keyed expand, the stable body delegate, never a per-render listener
+  assert.match(RENDER, /const ckey = ev\.uuid \? "cont:" \+ ev\.uuid : undefined;/);
+  assert.match(RENDER, /bubble\.classList\.add\("nudge-collapsible"\);\s*\n\s*bubble\.dataset\.act = "nudgetoggle";\s*\n?\s*\/\/ the stable body delegate/);
+});
+
+test("the user-family fold is white-on-blue, not romp's dim gray", () => {
+  assert.match(CSS, /\.user-bubble\.nudge-collapsible \{ cursor: pointer; \}/);
+  assert.match(CSS, /\.user-bubble \.nudge-gist, \.user-bubble \.nudge-caret \{ color: rgba\(255, 255, 255, 0\.92\); \}/);
+  assert.match(CSS, /\.user-bubble \.nudge-full \{ display: none; \}/);
+  assert.match(CSS, /\.user-bubble\.expanded \.nudge-full \{ display: block; \}/);
+  assert.match(CSS, /\.user-bubble\.expanded \.nudge-gist \{ display: none; \}/);
+});
+
+test("kernel: the marker is stamped at the ONE cont send and lifted for human turns only", () => {
+  assert.match(KERNEL, /\(CONTINUE_TEXT \+ "\\n\\n<!-- romp-canned: continue -->"\) if msg\.get\("cont"\) else str\(msg\["text"\]\)/);
+  assert.match(KERNEL, /if author == "human" and "<!-- romp-canned: continue -->" in text:/);
+  assert.match(KERNEL, /ev\["canned"\] = "continue"/);
+});

--- a/ui/webview/feed-continue.test.ts
+++ b/ui/webview/feed-continue.test.ts
@@ -22,7 +22,8 @@ test("Continue posts askFollowUp cont:true — the kernel owns the canned body (
   assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "askFollowUp", itemId: it\.itemId, sid: it\.sid, cont: true \}\);/);
   // the kernel substitutes its constant and the arm otherwise IS the typed-reply path (optimistic
   // reopen included) — pinned here because the button's whole design is "a reply, not a new mechanism"
-  assert.match(KERNEL, /text = CONTINUE_TEXT if msg\.get\("cont"\) else str\(msg\["text"\]\)/);
+  // …with the romp-canned marker riding the button's send (the chat folds it to a gesture gist)
+  assert.match(KERNEL, /text = \(CONTINUE_TEXT \+ "\\n\\n<!-- romp-canned: continue -->"\) if msg\.get\("cont"\) else str\(msg\["text"\]\)/);
   assert.match(KERNEL, /CONTINUE_TEXT = \("Nothing needed from me here\./);
 });
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -75,7 +75,7 @@ type TaskOutputs = Record<string, { command: string; output: string }>;
 type ChatEvent = (
   // mid/mids: postal message ids the kernel could NOT resolve into cards, carried on the raw turn so a
   // timeline arc into it still lands (see _hydrate_postal's unresolved path)
-  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; spacePaths?: string[]; pathLinks?: Record<string, string> }
+  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; canned?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; spacePaths?: string[]; pathLinks?: Record<string, string> }
   | { kind: "assistant"; md: string; uuid?: string; ts?: string; spacePaths?: string[]; pathLinks?: Record<string, string> }   // spacePaths: backticked filenames WITH spaces the kernel verified exist (build_session _space_paths) → whole-span links. pathLinks: path-shaped tokens the kernel verified against the filesystem, token → real open target (build_session _path_links) — the linkifier's gate
   | { kind: "thinking"; text: string; encrypted: boolean; uuid?: string; ts?: string }
   | {
@@ -1677,6 +1677,24 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         // system-event family (the ✦ dividers) — a dim left-aligned row: ✦ mark, mono chip, args
         turn.classList.add("turn-cmd");
         bubble.classList.add("cmd-row");
+      } else if (!romp && !injected && ev.md && ev.canned === "continue") {
+        // The card's Continue button (the user 2026-08-13): YOUR gesture in YOUR colour — the judges
+        // file it as your reply, the bubble stays blue — but not your prose: a one-line gist says what
+        // you did, and the exact canned words sit one click deeper (the nudge fold, in the user
+        // family). The ↩ follow-up header above already names the goal it answers.
+        const gistEl = el("div", "nudge-gist");
+        const c = el("span", "nudge-caret"); c.textContent = "▸"; gistEl.appendChild(c);
+        gistEl.appendChild(document.createTextNode("Continue — keep going; open calls are yours"));
+        bubble.appendChild(gistEl);
+        const full = el("div", "nudge-full md");
+        full.innerHTML = md(ev.md);
+        bubble.appendChild(full);
+        bubble.classList.add("nudge-collapsible");
+        bubble.dataset.act = "nudgetoggle";   // the stable body delegate, never a per-render listener (CLAUDE.md)
+        const ckey = ev.uuid ? "cont:" + ev.uuid : undefined;
+        if (ckey) bubble.dataset.nkey = ckey;
+        applyFold(bubble, "expanded", ckey);
+        bubble.title = bubble.classList.contains("expanded") ? "click to collapse" : "click to expand";
       } else if (romp && ev.md) {
         // A romp-injected NUDGE (auto status-check, Nudge button, injected follow-up) is mechanical
         // bookkeeping — progressive disclosure (the user 2026-07-17): default is a ONE-LINE gist with a

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1201,6 +1201,14 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .romp-bubble .nudge-full { display: none; }
 .romp-bubble.expanded .nudge-full { display: block; }
 .romp-bubble.expanded .nudge-gist { display: none; }
+/* The Continue button's reply wears the SAME fold in the USER family (the user 2026-08-13): your
+   gesture in your colour — blue, judge-filed as your reply — but not your prose, so the gist speaks
+   and the canned words sit one click deeper. White-on-blue, not the dim gray of romp bookkeeping. */
+.user-bubble.nudge-collapsible { cursor: pointer; }
+.user-bubble .nudge-gist, .user-bubble .nudge-caret { color: rgba(255, 255, 255, 0.92); }
+.user-bubble .nudge-full { display: none; }
+.user-bubble.expanded .nudge-full { display: block; }
+.user-bubble.expanded .nudge-gist { display: none; }
 /* QUEUED: the user's messages submitted while the session is still working — pending,
    not yet a turn. Right-aligned like his sent bubbles, but faint + dashed to read
    as "waiting", with a header count. (Mirrors the queue Claude Code shows.) */


### PR DESCRIPTION
The Continue button's canned reply stays user-authored (blue, judge semantics untouched) but stops posing as typed words: the send stamps a comment-form `romp-canned` marker, the chat build lifts it, and the bubble folds to a one-line gist — `▸ Continue — keep going; open calls are yours` — with the exact canned text one click deeper (the nudge fold, white-on-blue in the user family). Screenshot-verified beside typed bubbles; suites green (Python 4412, node 1881).

🤖 Generated with [Claude Code](https://claude.com/claude-code)