### PR TITLE
fix: the durable background-task scan doesn't know the Monitor tool — a monitor-held session reads idle

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -176,8 +176,22 @@ def _parse_task_notification(txt):
         a += len(tag) + 2
         b = txt.find("</" + tag + ">", a)
         return txt[a:b].strip() if b >= 0 else ""
-    return {"status": (fld("status") or "completed").lower(), "summary": fld("summary"),
+    st = fld("status")
+    # has_status: whether <status> was PRESENT, distinct from the "completed" default. A Monitor's
+    # per-EVENT notification carries no status tag (only its terminal one does) — without this bit the
+    # default would let a wrapped event read as "completed" and end a watch that is still live.
+    return {"status": (st or "completed").lower(), "has_status": bool(st), "summary": fld("summary"),
             "output_file": fld("output-file"), "tool_use_id": fld("tool-use-id")}
+
+
+# A non-persistent Monitor records its own lifetime ceiling at launch (timeout_ms — the harness kills
+# it at the deadline), so a scan row still "running" past deadline+grace is a record whose terminal
+# notification can never arrive (the CLI died with the monitor out, and the transcript never learns).
+# Consumers apply this with THEIR now — baking it into the scan would freeze inside the mtime caches,
+# which an idle transcript never busts. The grace absorbs kill/notify latency.
+def _bg_expired(task, now, grace=120.0):
+    dl = (task or {}).get("deadline")
+    return bool(dl) and now > dl + grace
 
 
 def _scan_bg_tasks(path, want_all=False):
@@ -202,6 +216,8 @@ def _scan_bg_tasks(path, want_all=False):
         # a notification keyed by its INNER <tool-use-id> (the string/queue shapes have no wrapper block)
         tid = (note or {}).get("tool_use_id")
         if tid and tid in tasks:
+            if tasks[tid].get("monitor") and not note.get("has_status"):
+                return                     # a monitor EVENT (no <status> tag) — the watch is still live
             tasks[tid].update(status=note["status"], outputFile=note["output_file"],
                               summary=note["summary"] or tasks[tid]["summary"])
 
@@ -218,13 +234,35 @@ def _scan_bg_tasks(path, want_all=False):
                 c = (o.get("message") or {}).get("content")
                 if t == "assistant" and isinstance(c, list):
                     for b in c:
-                        if isinstance(b, dict) and b.get("type") == "tool_use" and (b.get("input") or {}).get("run_in_background"):
-                            tid, inp = b.get("id"), (b.get("input") or {})
-                            if tid and tid not in tasks:
-                                tasks[tid] = {"id": tid, "status": "running", "t": parse_z(o.get("timestamp")),
-                                              "summary": (inp.get("description") or b.get("name") or "Background task"),
-                                              "command": inp.get("command") or "", "outputFile": ""}
-                                order.append(tid)
+                        if not (isinstance(b, dict) and b.get("type") == "tool_use"):
+                            continue
+                        inp = b.get("input") or {}
+                        # The THIRD durable launch shape: a Monitor tool_use. A non-persistent monitor is
+                        # dispatched background work exactly like a backgrounded Bash — a session idle
+                        # behind one read as plain 'ready', its goal stamps could lift only by the 6h
+                        # backstop, and the nudge gates couldn't see the wait. A PERSISTENT monitor is
+                        # skipped: a session-length subscription (a log tail) never returns, so counting it
+                        # would hold "awaiting" forever — it is furniture, not awaited work.
+                        is_mon = b.get("name") == "Monitor"
+                        if is_mon and inp.get("persistent"):
+                            continue
+                        if not (inp.get("run_in_background") or is_mon):
+                            continue
+                        tid = b.get("id")
+                        if tid and tid not in tasks:
+                            tasks[tid] = {"id": tid, "status": "running", "t": parse_z(o.get("timestamp")),
+                                          "summary": (inp.get("description") or b.get("name") or "Background task"),
+                                          "command": inp.get("command") or (inp.get("ws") or {}).get("url", ""),
+                                          "outputFile": ""}
+                            if is_mon:
+                                tasks[tid]["monitor"] = True
+                                # its recorded lifetime ceiling → the deadline consumers expire on
+                                # (see _bg_expired); the harness clamps timeout_ms to [1s, 1h]
+                                tmo = inp.get("timeout_ms")
+                                tmo = float(tmo) if isinstance(tmo, (int, float)) else 300000.0
+                                if tasks[tid]["t"]:
+                                    tasks[tid]["deadline"] = tasks[tid]["t"] + min(max(tmo, 1000.0), 3600000.0) / 1000.0
+                            order.append(tid)
                 elif t == "user" and isinstance(c, list):
                     tur = o.get("toolUseResult")
                     tur = tur if isinstance(tur, dict) else {}
@@ -241,8 +279,16 @@ def _scan_bg_tasks(path, want_all=False):
                                 continue
                             note = _parse_task_notification(_result_text(b.get("content")))
                             if tid in tasks and note:      # its result landed → mark it done; the keep-filter drops it
+                                if tasks[tid].get("monitor") and not note.get("has_status"):
+                                    continue               # a wrapped monitor EVENT — not a terminal (see _mark)
                                 tasks[tid].update(status=note["status"], outputFile=note["output_file"],
                                                   summary=note["summary"] or tasks[tid]["summary"])
+                            elif tid in tasks and note is None and b.get("is_error") \
+                                    and tasks[tid]["status"] == "running":
+                                # the LAUNCH's own ack errored (refused permission, bad input) → nothing ever
+                                # started, and no notification will ever come. Without this, the phantom
+                                # reads "running" forever and holds awaiting/nudge gates open on nothing.
+                                tasks[tid]["status"] = "failed"
                 elif t == "user" and isinstance(c, str):
                     _mark(_parse_task_notification(c))
                 elif t == "queue-operation" and o.get("operation") == "enqueue":

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3972,12 +3972,16 @@ def _bg_unresolved(path):
         return []
     hit = _BG_SCAN_CACHE.get(path)
     if hit and hit[0] == key:
-        return hit[1]
-    tasks = em._scan_bg_tasks(path)
-    if len(_BG_SCAN_CACHE) > 256:         # bounded by fleet size; a wholesale clear on overflow is fine
-        _BG_SCAN_CACHE.clear()
-    _BG_SCAN_CACHE[path] = (key, tasks)
-    return tasks
+        tasks = hit[1]
+    else:
+        tasks = em._scan_bg_tasks(path)
+        if len(_BG_SCAN_CACHE) > 256:     # bounded by fleet size; a wholesale clear on overflow is fine
+            _BG_SCAN_CACHE.clear()
+        _BG_SCAN_CACHE[path] = (key, tasks)
+    # expiry is applied OUTSIDE the cache with a fresh now: a monitor whose CLI died mid-watch has no
+    # terminal record, and an idle transcript never busts the mtime key — a cached verdict would say
+    # "running" forever (see em._bg_expired)
+    return [t for t in tasks if not em._bg_expired(t, time.time())]
 
 
 def _sdk_spawned_at(sid):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2950,7 +2950,10 @@ def _lift_spent_awaiting(now, tmux):
                     jd.save_goals(sid, store)
                     _mark_views_dirty()
                 continue
-            running = {t.get("id") for t in every if t.get("status") == "running"}
+            # a monitor past its recorded lifetime ceiling counts as RETURNED even with no terminal
+            # record (its CLI died mid-watch; the notification can never arrive) — see em._bg_expired
+            running = {t.get("id") for t in every
+                       if t.get("status") == "running" and not em._bg_expired(t, now)}
             placed = _bg_placed_tops(sid, s["path"], [t.get("id") for t in every])
             def _top_of(x):
                 seen = set()
@@ -9605,7 +9608,9 @@ def _bg_live_norm(sid, path):
     sp = _sdk_spawned_at(sid)
     return [{"tid": tk.get("id"), "desc": str(tk.get("summary") or "").strip(), "t": int(tk.get("t") or 0),
              "type": str(tk.get("type") or "")}
-            for tk in _bg_scan_cached(path) if not (sp and tk.get("t") and tk["t"] < sp)]
+            for tk in _bg_scan_cached(path)
+            if not (sp and tk.get("t") and tk["t"] < sp)
+            and not em._bg_expired(tk, time.time())]   # a monitor past its lifetime ceiling is not a live wait
 
 
 def _bg_pending(sid, path, tasks):

--- a/tests/test_bg_scan_monitor.py
+++ b/tests/test_bg_scan_monitor.py
@@ -1,0 +1,166 @@
+"""The durable background-task scan knows the Monitor tool — the THIRD launch shape.
+
+A session idle behind a Monitor watch (a timed check on a long server-side run) scanned as
+"nothing dispatched": the pip read plain ready, its goal's awaiting stamp could lift only by the
+6h backstop, and the nudge gates couldn't see the wait (the user 2026-08-10, whose session was
+plainly waiting on server jobs). The live lifecycle path (SDK stream) already handled monitors —
+verified by live probe — so the gap was only the transcript pairing, which recognized just
+backgrounded Bash and async Agent launches.
+
+Shapes derived from a 44-monitor corpus across real transcripts (rebuilt synthetically here, per
+the privacy rules): a monitor's per-EVENT notification carries task-id + summary + event but NO
+status and NO tool-use-id; only its TERMINAL notification carries tool-use-id + an explicit
+status. The parser's missing-status→"completed" default therefore must never end a monitor.
+Non-persistent monitors also record their lifetime ceiling (timeout_ms) at launch — the deadline
+consumers expire on when a CLI dies mid-watch and the terminal record can never arrive.
+"""
+import io
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # hermetic BEFORE any romp code loads
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+em = SourceFileLoader("romp_event_model_t", os.path.join(ROOT, "kernel", "event_model.py")).load_module()
+
+TS = "2026-01-01T00:00:00.000Z"
+T0 = em.parse_z(TS)
+TID = "toolu_11111111222233334444555555555555"
+
+
+def launch(name="Monitor", inp=None, tid=TID):
+    return {"type": "assistant", "timestamp": TS,
+            "message": {"content": [{"type": "tool_use", "id": tid, "name": name,
+                                     "input": inp or {}}]}}
+
+
+def ack(tid=TID, text="Monitor started (task b1a2b3c4d, timeout 300000ms).", err=False):
+    r = {"type": "user", "timestamp": TS,
+         "message": {"content": [{"type": "tool_result", "tool_use_id": tid, "content": text}]}}
+    if err:
+        r["message"]["content"][0]["is_error"] = True
+    return r
+
+
+def event_note(task="b1a2b3c4d"):
+    # the EVENT shape: task-id + summary + event, NO tool-use-id, NO status (corpus-derived)
+    return {"type": "user", "timestamp": TS, "message": {"content":
+            "<task-notification>\n<task-id>%s</task-id>\n<summary>Monitor event: \"synthetic watch\"</summary>\n"
+            "<event>tick</event>\n</task-notification>" % task}}
+
+
+def terminal_note(tid=TID, task="b1a2b3c4d", status="completed"):
+    return {"type": "user", "timestamp": TS, "message": {"content":
+            "<task-notification>\n<task-id>%s</task-id>\n<tool-use-id>%s</tool-use-id>\n"
+            "<output-file>/tmp/t/%s.output</output-file>\n<status>%s</status>\n"
+            "<summary>Monitor \"synthetic watch\" stream ended</summary>\n</task-notification>"
+            % (task, tid, task, status)}}
+
+
+def scan(records, want_all=False):
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+        f.write("\n".join(json.dumps(r) for r in records) + "\n")
+    try:
+        return em._scan_bg_tasks(f.name, want_all=want_all)
+    finally:
+        os.unlink(f.name)
+
+
+class MonitorLaunchShape(unittest.TestCase):
+    def test_a_monitor_launch_registers_as_running(self):
+        rows = scan([launch(inp={"command": "sleep 60; echo tick", "description": "synthetic watch",
+                                 "timeout_ms": 300000, "persistent": False}), ack()])
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["status"], "running")
+        self.assertTrue(rows[0]["monitor"])
+        self.assertEqual(rows[0]["summary"], "synthetic watch")
+        self.assertAlmostEqual(rows[0]["deadline"], T0 + 300.0)
+
+    def test_a_persistent_monitor_is_furniture_not_awaited_work(self):
+        rows = scan([launch(inp={"command": "tail -f x.log", "persistent": True}), ack()])
+        self.assertEqual(rows, [], "a session-length subscription must never hold 'awaiting'")
+
+    def test_a_ws_monitor_records_its_url_as_the_command(self):
+        rows = scan([launch(inp={"ws": {"url": "wss://TESTHOST/stream"}, "timeout_ms": 60000})])
+        self.assertEqual(rows[0]["command"], "wss://TESTHOST/stream")
+
+    def test_backgrounded_bash_launches_are_unchanged(self):
+        rows = scan([launch(name="Bash", inp={"command": "make -j", "run_in_background": True,
+                                              "description": "build"})])
+        self.assertEqual((rows[0]["status"], rows[0].get("monitor")), ("running", None))
+        self.assertNotIn("deadline", rows[0])
+
+
+class EventsNeverTerminate(unittest.TestCase):
+    MON = launch(inp={"command": "sleep 60", "description": "synthetic watch",
+                      "timeout_ms": 300000, "persistent": False})
+
+    def test_an_event_notification_leaves_the_watch_running(self):
+        rows = scan([self.MON, ack(), event_note(), event_note()])
+        self.assertEqual([r["status"] for r in rows], ["running"])
+
+    def test_a_wrapped_event_without_status_cannot_default_to_completed(self):
+        # the trap: _parse_task_notification defaults a missing <status> to "completed"; an event
+        # arriving in the older tool_result-wrapper shape must still not end the watch
+        wrapped = {"type": "user", "timestamp": TS, "message": {"content": [
+            {"type": "tool_result", "tool_use_id": TID,
+             "content": event_note()["message"]["content"]}]}}
+        rows = scan([self.MON, wrapped])
+        self.assertEqual([r["status"] for r in rows], ["running"])
+
+    def test_the_terminal_notification_ends_it(self):
+        rows = scan([self.MON, ack(), event_note(), terminal_note()], want_all=True)
+        self.assertEqual([r["status"] for r in rows], ["completed"])
+        self.assertEqual(scan([self.MON, ack(), event_note(), terminal_note()]), [],
+                         "the running-only view drops a finished watch")
+
+    def test_a_stopped_terminal_ends_it_too(self):
+        rows = scan([self.MON, terminal_note(status="stopped")], want_all=True)
+        self.assertEqual(rows[0]["status"], "stopped")
+
+    def test_parser_reports_status_presence_distinct_from_the_default(self):
+        ev = em._parse_task_notification(event_note()["message"]["content"])
+        self.assertEqual((ev["status"], ev["has_status"]), ("completed", False))
+        tm = em._parse_task_notification(terminal_note()["message"]["content"])
+        self.assertEqual((tm["status"], tm["has_status"]), ("completed", True))
+
+
+class ErroredLaunchesAndExpiry(unittest.TestCase):
+    def test_an_errored_launch_ack_is_a_phantom_not_a_forever_running_task(self):
+        rows = scan([launch(inp={"command": "sleep 60", "timeout_ms": 60000}),
+                     ack(text="InputValidationError: timeout_ms too small", err=True)], want_all=True)
+        self.assertEqual([r["status"] for r in rows], ["failed"])
+
+    def test_expiry_is_the_recorded_ceiling_plus_grace_applied_with_the_consumers_now(self):
+        rows = scan([launch(inp={"command": "sleep 60", "timeout_ms": 300000})])
+        t = rows[0]
+        self.assertFalse(em._bg_expired(t, T0 + 300.0), "inside its lifetime")
+        self.assertFalse(em._bg_expired(t, T0 + 300.0 + 60.0), "grace absorbs kill/notify latency")
+        self.assertTrue(em._bg_expired(t, T0 + 300.0 + 121.0), "past ceiling+grace → can never return")
+        self.assertFalse(em._bg_expired({"id": "x", "status": "running"}, 9e12),
+                         "no recorded ceiling (a bash task) → never expires this way")
+
+    def test_the_ceiling_is_clamped_to_the_harness_bounds(self):
+        rows = scan([launch(inp={"command": "x", "timeout_ms": 999999999})])
+        self.assertAlmostEqual(rows[0]["deadline"], T0 + 3600.0)
+
+
+class ConsumersApplyExpiry(unittest.TestCase):
+    def test_the_lift_and_the_judge_gate_read_expiry_outside_their_caches(self):
+        kernel = open(os.path.join(ROOT, "kernel", "kernel.py"), encoding="utf-8").read()
+        judge = open(os.path.join(ROOT, "kernel", "judge.py"), encoding="utf-8").read()
+        self.assertIn('t.get("status") == "running" and not em._bg_expired(t, now)', kernel,
+                      "the awaiting-stamp lift must not wait forever on a dead monitor")
+        self.assertIn("em._bg_expired(tk, time.time())", kernel,
+                      "source 0.75's normalized rows must drop expired monitors")
+        self.assertIn("em._bg_expired(t, time.time())", judge,
+                      "the judge's settled gate must apply expiry with a fresh now, not the cached one")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The gap

`_scan_bg_tasks` pairs async launches with their `<task-notification>` results for two shapes: backgrounded Bash and async Agent. The Monitor tool is a third — a session dispatches a watch and goes idle until the harness re-invokes it — and the scan doesn't see it. A session idle behind a monitor reads as *nothing dispatched, plain ready*: its awaiting stamp can lift only by the 6h backstop, and every consumer of the pairing (the stamp lift, the nudge gates, the awaiting chip) is blind to a wait the session is genuinely in. The live SDK lifecycle path handles monitors fine; the hole is transcript-durability only — but that's exactly the path the settled gate and the stamp lift ride.

## The fix, shaped by the tool's actual contract

We harvested 44 real monitor lifecycles from transcripts before writing this; the test file rebuilds those shapes synthetically. Four behaviors, each matching a contract detail:

- **Persistent monitors are skipped.** A session-length subscription (a log tail) never returns; counting it would hold "awaiting" forever. It's furniture, not awaited work.
- **Event notifications never end a live watch.** A monitor's per-event notification carries no `<status>` tag — only its terminal one does. The parser now exposes `has_status`, because the existing missing-status→`"completed"` default would let the first event mark a live watch finished.
- **A launch whose own ack errored is `failed`.** Refused permission / bad input means nothing started and no notification will ever come; without this the phantom reads "running" forever and holds gates open on nothing.
- **The launch's recorded `timeout_ms` becomes a deadline** (`_bg_expired`, +120s grace): a monitor whose CLI died mid-watch has no terminal record, and an idle transcript never busts the scan's mtime caches — so expiry is applied with the *caller's* clock, outside the caches (`_bg_unresolved` filters after cache read; the stamp lift and the live-wait rows check it with their own `now`). This closes a staleness hole bash tasks can't close, since they record no lifetime ceiling.

## Tests

`tests/test_bg_scan_monitor.py` (13 tests): the launch registers, persistent is skipped, events don't end the watch (bare and wrapped), terminals do, errored acks fail the phantom, the deadline derives from `timeout_ms` with the harness's [1s, 1h] clamp, and expiry stays out of the cache. `test_event_model_golden` and every awaiting/lift suite pass unchanged. The new file follows the `test_state_isolation_order` preamble.

Running on a fork since 2026-08-11; the monitor-held sessions that used to read idle now carry the awaiting state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)