### PR TITLE
fix(security): a same-site loopback page rides the cookie into an authenticated WebSocket

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21614,6 +21614,19 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(code)
         self.send_header("Content-Type", ctype)
         self.send_header("Content-Length", str(len(body)))
+        # Take the declared type at its word. Without this a browser may sniff a response whose
+        # bytes look like markup and run it as HTML on the dashboard's own origin, which is the
+        # same escalation the /remote/…/file relay's own type check closes from the other side.
+        self.send_header("X-Content-Type-Options", "nosniff")
+        # Framing gate (clickjacking): the authenticated dashboard must not be loadable in a
+        # cross-origin frame, or a hostile same-site loopback page (the same attacker the cookie
+        # Origin gate below defends against) could frame it and drive it invisibly. SAMEORIGIN keeps
+        # the dashboard's own same-origin sub-frames (/chat, /feed) working. NOTE: the VS Code
+        # webview loads the dashboard from a vscode-webview:// origin — if that surface is still
+        # needed it must be added to a frame-ancestors allowlist; confirm against every shipped
+        # client (webview / phone / tailnet) before relying on this.
+        self.send_header("X-Frame-Options", "SAMEORIGIN")
+        self.send_header("Content-Security-Policy", "frame-ancestors 'self'")
         for k, v in (headers or {}).items():
             self.send_header(k, v)
         if cache:                                     # e.g. "no-cache" — keeps a tab from running a stale bundle
@@ -21678,11 +21691,21 @@ class Handler(BaseHTTPRequestHandler):
         once and ride the auto-set cookie; local CLIs/hooks read the file and send X-Romp-Token (a
         custom header forces a CORS preflight through this same gate, so a cross-site page can't
         forge it either). Token-less browser traffic still hits the Origin gate first (the
-        ClawJacked/WS hole) so a denial names the real reason."""
+        ClawJacked/WS hole) so a denial names the real reason.
+
+        The COOKIE is the one credential that does NOT bypass the Origin gate, because it is the one
+        the browser attaches for you: cookies are scoped by host and NOT by port (RFC 6265 §8.5), so
+        every `http://127.0.0.1:<any-port>` page is same-site with the dashboard and rides this
+        cookie — SameSite=Strict included. Without the Origin check below, any page served by
+        anything else on loopback (an agent-cloned repo's dev server) reached `/ws`, which streams
+        every session and accepts sendMessage. Presenting a token proves you are not a drive-by page;
+        carrying a cookie proves only that the browser had one. Nothing in the shipped UI needs the
+        cookie cross-origin: the dashboard's own socket is same-origin, federation relays through the
+        hub's own origin WITH ?token, and the VS Code webview origin is allowed by _origin_ok."""
         if TOKEN and _ct_eq((q.get("token") or [""])[0], TOKEN):
             return True, TOKEN, ""                    # valid ?token → authorize (any origin) + set cookie
-        if TOKEN and _ct_eq(self._cookie_token(), TOKEN):
-            return True, None, ""                     # valid token cookie → authorize (any origin)
+        if TOKEN and _ct_eq(self._cookie_token(), TOKEN) and self._origin_ok():
+            return True, None, ""                     # valid token cookie + same-site origin
         if TOKEN and _ct_eq(self.headers.get("X-Romp-Token") or "", TOKEN):
             return True, None, ""                     # header form — local CLI/hook/daemon clients
         if not self._origin_ok():
@@ -21707,6 +21730,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-Type", mime)
             self.send_header("Content-Length", str(size))   # the real length, no body (HEAD semantics)
+            self.send_header("X-Content-Type-Options", "nosniff")   # _send's guarantee, restated on the HEAD path
             self.send_header("Cache-Control", "no-cache")
             if getattr(self, "_cors_origin", None):         # the chat's fetch-HEAD probe rides CORS too
                 self.send_header("Access-Control-Allow-Origin", self._cors_origin)
@@ -23266,6 +23290,15 @@ class Handler(BaseHTTPRequestHandler):
         if not port:
             return self._send(404, b"" if head else ("no attached host %r" % host), "text/plain")
         q = parse_qs(query or "")
+        # Our own verdict on the type, before the remote gets a say: derive the Content-Type from the
+        # requested extension against _PREVIEW_MIME (the same table + 404 the local /file route uses)
+        # and DISCARD the remote's own Content-Type below. Mirroring it let a compromised remote answer
+        # text/html for a path the preview lightbox opens in a same-origin, unsandboxed iframe
+        # (ui/webview/preview.ts) — script on the dashboard's origin with the cookie attached. An
+        # extension the local route would 404 is 404'd here too, so the relay never widens what renders.
+        mime = _PREVIEW_MIME.get(os.path.splitext((q.get("path") or [""])[0])[1].lower())
+        if not mime:
+            return self._send(404, b"" if head else "not found", "text/plain")
         if rtok:
             q["token"] = [rtok]      # the remote's own credential; whatever the browser sent means nothing there
         conn = http.client.HTTPConnection("127.0.0.1", int(port), timeout=15)
@@ -23273,7 +23306,7 @@ class Handler(BaseHTTPRequestHandler):
             conn.request("HEAD" if head else "GET", "/file?" + urlencode(q, doseq=True))
             resp = conn.getresponse()
             body = b"" if head else resp.read(_PREVIEW_MAX_BYTES + 1)
-            status, ctype = resp.status, resp.getheader("Content-Type") or "application/octet-stream"
+            status, ctype = resp.status, mime          # OUR mime, never resp.getheader("Content-Type")
             clen = resp.getheader("Content-Length")
         except (OSError, http.client.HTTPException):
             return self._send(502, b"" if head else ("tunnel to %s is not answering" % host), "text/plain")
@@ -23290,6 +23323,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", ctype)
             if clen is not None:
                 self.send_header("Content-Length", clen)
+            self.send_header("X-Content-Type-Options", "nosniff")   # _send's guarantee, restated on the HEAD path
             self.send_header("Cache-Control", "no-cache")
             if getattr(self, "_cors_origin", None):
                 self.send_header("Access-Control-Allow-Origin", self._cors_origin)

--- a/tests/test_kernel_auth_hardening.py
+++ b/tests/test_kernel_auth_hardening.py
@@ -119,5 +119,73 @@ class TokenRequiredEverywhere(unittest.TestCase):
         self.assertIn("token", why)
 
 
+class CookieDoesNotBypassOrigin(unittest.TestCase):
+    """The cookie is the one credential the browser attaches for you, so it is the one that must
+    NOT bypass the Origin gate. Cookies are host- not port-scoped (RFC 6265 §8.5), so every
+    http://127.0.0.1:<port> page is same-site with the dashboard and rides this cookie — SameSite
+    included. Without the Origin check, any page served by anything else on loopback (a dev server
+    in a repo an agent cloned) reached /ws, which streams every session and accepts sendMessage."""
+
+    def test_cookie_denied_from_a_foreign_loopback_origin(self):
+        # the drive-by case: a page on another loopback PORT is same-site, so the browser attaches
+        # the cookie, but its Origin is not ours → the cookie must not authorize
+        ok, _, why = _auth(headers={"Cookie": "romp_token=" + TOK,
+                                    "Origin": "http://127.0.0.1:59999",
+                                    "Host": "127.0.0.1:%d" % km.PORT})
+        self.assertFalse(ok, "a cookie from another loopback port must not authorize")
+        self.assertEqual(why, "cross-site origin")
+
+    def test_cookie_denied_from_an_offsite_origin(self):
+        ok, _, why = _auth(headers={"Cookie": "romp_token=" + TOK, "Origin": "http://evil.example"})
+        self.assertFalse(ok)
+        self.assertEqual(why, "cross-site origin")
+
+    def test_cookie_still_authorizes_absent_origin(self):
+        # a same-origin GET omits Origin; that path (and non-browser clients) is unchanged
+        ok, _, _ = _auth(headers={"Cookie": "romp_token=" + TOK})
+        self.assertTrue(ok, "a cookie with no Origin (same-origin nav / curl) still authorizes")
+
+    def test_cookie_still_authorizes_the_dashboards_own_origin(self):
+        ok, _, _ = _auth(headers={"Cookie": "romp_token=" + TOK,
+                                  "Origin": "http://127.0.0.1:%d" % km.PORT,
+                                  "Host": "127.0.0.1:%d" % km.PORT})
+        self.assertTrue(ok)
+
+    def test_cookie_still_authorizes_the_vscode_webview(self):
+        ok, _, _ = _auth(headers={"Cookie": "romp_token=" + TOK,
+                                  "Origin": "vscode-webview://0p9m1abc"})
+        self.assertTrue(ok, "the VS Code webview origin is allowed by _origin_ok")
+
+    def test_explicit_token_still_bypasses_origin_for_federation(self):
+        # the escape hatch a cross-site page cannot use: only an EXPLICIT token bypasses origin,
+        # and a drive-by page can't obtain one (it rides only the cookie)
+        ok, _, _ = _auth(headers={"Origin": "http://evil.example"}, token=TOK)
+        self.assertTrue(ok)
+
+
+class ResponseHardeningHeaders(unittest.TestCase):
+    """Every response declares its type as final (nosniff) and refuses cross-origin framing
+    (clickjacking). Source-pinned: the header set lives in _send, exercised on every route."""
+
+    def test_send_sets_nosniff_and_frame_guards(self):
+        import inspect
+        src = inspect.getsource(km.Handler._send)
+        self.assertIn('"X-Content-Type-Options", "nosniff"', src)
+        self.assertIn('"X-Frame-Options", "SAMEORIGIN"', src)
+        self.assertIn("frame-ancestors 'self'", src)
+
+    def test_remote_relay_derives_its_own_mime_and_discards_the_remotes(self):
+        # the /remote/<host>/file relay must decide the Content-Type from the requested extension
+        # (_PREVIEW_MIME) and never mirror the remote's — a remote answering text/html for a .pdf
+        # the lightbox opens in a same-origin iframe would be script on the dashboard's origin
+        import inspect
+        src = inspect.getsource(km.Handler._remote_file)
+        self.assertIn("_PREVIEW_MIME.get(os.path.splitext", src)
+        self.assertIn("status, ctype = resp.status, mime", src)
+        # the type must not be READ from the remote (a comment may still name it as "never this")
+        self.assertNotIn("ctype = resp.getheader", src)
+        self.assertNotIn('resp.status, resp.getheader("Content-Type")', src)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
**DRAFT — needs live client verification before merge (see bottom).** Chain 1 of 5 from a security re-verification against v0.8.0. Each chain is a separate PR.

## The hole

Cookies are host- not port-scoped (RFC 6265 §8.5), so every `http://127.0.0.1:<port>` page on the machine — e.g. a dev server in a repo an agent cloned — is **same-site** with the dashboard, and the browser attaches the `romp_token` cookie to its requests, **including the WebSocket handshake** (which CORS does not cover). `_authorize` accepted a valid cookie *before* it ever consulted the Origin gate (`kernel.py`), so that page could open an authenticated `/ws`, stream every session, and drive `sendMessage` / `answerAsk` (approve a pending permission prompt) / `forkSession` — full control of the romp instance and, through injected prompts + approvals, the host.

SECURITY.md already states *"An Origin check additionally protects the browser surfaces against cross-site requests, including the WebSocket upgrade"* — this makes the code match that promise.

## The fixes

1. **Cookie no longer bypasses Origin.** The cookie branch of `_authorize` now also requires `_origin_ok()`. An **explicitly presented** `?token` / `X-Romp-Token` still bypasses Origin (federation needs it; a drive-by page can't obtain one, it rides only the cookie). Absent-Origin (same-origin nav, curl) and `vscode-webview://` still authorize, so no shipped client regresses.
2. **nosniff** on every response (`_send`) — a response whose bytes look like markup can otherwise be sniffed and run as HTML on the dashboard's origin.
3. **X-Frame-Options: SAMEORIGIN + CSP frame-ancestors 'self'** on every response — clickjacking: the authenticated dashboard must not be framable by the same loopback attacker. (This finding was noted-but-deferred in the original audit; authored fresh here.)
4. **The `/remote/<host>/file` relay derives its own Content-Type** from the requested extension (`_PREVIEW_MIME`, same 404 as the local route) and discards the remote's — a compromised remote answering `text/html` for a `.pdf` the lightbox opens in a same-origin unsandboxed iframe was script on the dashboard's origin.

## Tests

`tests/test_kernel_auth_hardening.py` gains the cookie-vs-origin cases (denied from a foreign loopback port and from offsite; still authorized with absent-Origin / same-origin / `vscode-webview://` / explicit token) plus source-pins for the nosniff + frame headers and the relay's local-mime derivation. `test_kernel_remote_file_relay`, `test_kernel_ws_auth`, and `test_state_isolation_order` pass unchanged.

## Why this is a draft

The framing header and the cookie/Origin tightening **can't be verified offline against the real clients**: the VS Code webview loads the dashboard from a `vscode-webview://` origin, and phone/tailnet access must keep working. The `frame-ancestors 'self'` policy in particular may need a webview allowlist entry. These need confirming on every shipped client before merge — happy to adjust once maintainers weigh in on which client surfaces must keep framing / cross-origin cookie behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
