### PR TITLE
Command rows right-aligned, on the user's side

### DIFF
--- a/ui/webview/slash-cmd-chip.test.ts
+++ b/ui/webview/slash-cmd-chip.test.ts
@@ -25,14 +25,15 @@ test("the chip is a monospace, outlined keyword pill that reads on the blue bubb
   assert.match(CSS, /\.slash-cmd-args \{ margin-left: 7px; \}/);
 });
 
-test("a command turn reads in the system-event family, not as a said thing (the user 2026-08-13)", () => {
-  // a command is a user GESTURE — it changes something rather than saying something — so the turn sheds
-  // the blue right-pinned bubble for a dim left-aligned ✦ row, rhyming with the context dividers
+test("a command turn wears the ✦ chip dress on the USER's side (the user 2026-08-13, round 2)", () => {
+  // a command is a user GESTURE — it sheds the blue bubble for the ✦ + mono chip, but it is still
+  // something THEY did, so it sits where their messages sit: right-aligned, riding .turn-user's own
+  // flex-end (round 1's left-aligned override is deliberately GONE)
   assert.match(RENDER, /turn\.classList\.add\("turn-cmd"\);\s*\n\s*bubble\.classList\.add\("cmd-row"\);/);
-  assert.match(CSS, /\.turn-user\.turn-cmd:not\(\.injected\) \{ align-items: flex-start; \}/);
+  assert.doesNotMatch(CSS, /\.turn-user\.turn-cmd:not\(\.injected\) \{ align-items: flex-start; \}/);
+  assert.doesNotMatch(CSS, /\.turn-cmd \.msg-acts \{ align-self: flex-start; \}/);
   assert.match(CSS, /\.user-bubble\.cmd-row \{ max-width: none; background: none; border: none;/);
   assert.match(CSS, /\.user-bubble\.cmd-row::before \{ content: "✦"; margin-right: 8px; color: var\(--dim\); \}/);
-  assert.match(CSS, /\.turn-cmd \.msg-acts \{ align-self: flex-start; \}/);
 });
 
 // guards on the regex's intent (executed): a whole leading token is chipped; a path is not.

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1164,16 +1164,15 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 }
 .slash-cmd-args { margin-left: 7px; }
 /* A slash COMMAND turn is a user GESTURE, not a message (the user 2026-08-13): it changes something
-   rather than saying something — so it sheds the blue bubble and reads in the system-event family
-   (the ✦ dividers): a dim, left-aligned, full-width row with the ✦ mark, the mono chip, the args. */
-.turn-user.turn-cmd:not(.injected) { align-items: flex-start; }
+   rather than saying something — so it sheds the blue bubble for the ✦ + mono-chip dress, but stays on
+   the USER's side of the chat (the user 2026-08-13, round 2: it is still something they did, so it sits
+   where their messages sit — right-aligned, riding .turn-user's own flex-end). */
 .user-bubble.cmd-row { max-width: none; background: none; border: none; border-radius: 0;
   padding: 2px 0; color: var(--dim); }
 .user-bubble.cmd-row::before { content: "✦"; margin-right: 8px; color: var(--dim); }
 .user-bubble.cmd-row .slash-cmd-chip { background: var(--code-bg); color: var(--fg);
   border-color: var(--box-border); }
 .user-bubble.cmd-row .slash-cmd-args { color: var(--dim); }
-.turn-cmd .msg-acts { align-self: flex-start; }   /* the hover actions follow the row to the left */
 /* ---------- romp-injected message (a feed nudge / follow-up) ----------
    A GRAY bubble in the SAME right-aligned spot as the blue user bubble (so it sits where "an outgoing
    message" goes), but clearly NOT you — gray, with a small "↯ romp" tag above it (the user 2026-06-19).


### PR DESCRIPTION
The ✦ chip rows move to the right edge — a command is still the user's act, so it sits with their messages, keeping the #325 dress. The persistence half of the ask was verified already-working (the executed command's wrapper emits one durable atom; the map also surfaced two latent shape-B command bugs, filed separately for a PLACEMENTS_V-bumping follow-up). Screenshot-verified; pins updated; suite 1881 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)