### PR TITLE
Session death is a recorded, corroborated event; dead sessions finalize and end loudly

### DIFF
--- a/hooks/tmux-status.sh
+++ b/hooks/tmux-status.sh
@@ -103,6 +103,15 @@ if [[ "$DISPLAY_TMUX" == 1 ]]; then
         if [[ -f "$ndir/$sid" && ! -e "$ndir/$HOOK_SID" ]]; then
             cp "$ndir/$sid" "$ndir/$HOOK_SID" 2>/dev/null || true
         fi
+        # Record the SUCCESSION this hook is the sole witness of (2026-08-13), BEFORE the var flip
+        # makes the old fsid's departure observable to the kernel's death sweep: at the pane, a
+        # /clear'd-or-resumed-away lane and a genuine death look identical (the sid vanishes from the
+        # live scan while its name stays occupied) — this row is what tells them apart, vetoing the
+        # death stamp so the episode machinery keeps owning supersessions. Second-shape row (no
+        # "state" key, like the awaiting overlays), so every state-keyed reader already skips it.
+        sdir="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/states"
+        mkdir -p "$sdir" 2>/dev/null || true
+        printf '{"t":%s,"supersededBy":"%s"}\n' "$(date +%s)" "$HOOK_SID" >> "$sdir/$sid.jsonl" 2>/dev/null || true
         tmux set -t "$session_name" @romp-session-id "$HOOK_SID" 2>/dev/null || true
         sid="$HOOK_SID"                                 # everything below (state log, etc.) uses the LIVE fsid now
     fi

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -52,6 +52,10 @@ ERRORS   = STATE / "judge-errors.jsonl"  # swallowed judge-call failures (parse-
 USAGE    = STATE / "judge-usage.jsonl"   # one line per successful judge call: tokens/cost/ms — the kernel/UI roll up pipeline cost
 JUDGE_AUTH = STATE / "judge-auth.json"   # judge-auth-down latch {fsid: {t, mode, note}}: set by a credential-class error
                                          #   envelope, cleared by the session's next successful call — build_feed floors from it
+GONEDIR  = STATE / "gone"                # session-death markers {t, by[, endedAt]} — one small json per sid, written by the
+                                         #   kernel's death writers at the death EVENT (kill gesture / probe-confirmed absence),
+                                         #   read by a CLOSED list: _cli_epoch, run_close's death-pending drain, and the writers'
+                                         #   own idempotence check (2026-08-13; the reader list is test-pinned so it cannot creep)
 SDKDIR   = STATE / "sdk"                 # the SDK backend's per-session registry — lastSid tracks the CURRENT transcript fsid
 # Judge scratch cwd (the user 2026-07-20): every one-shot `claude -p` judge call writes a transcript
 # under the project dir of its CWD. With cwd=/tmp those piled into the SHARED -private-tmp project
@@ -67,9 +71,10 @@ def _rebind_state(path):
     save_goals wrote synthetic fixtures into the live goals/ and the triage pass then stormed
     judge-errors.jsonl over those orphans every pass forever (the user 2026-06-24). A test must call this
     instead of assigning jd.STATE alone. Not used in production (STATE is bound once at import)."""
-    global STATE, NAMES, CAPDIR, ARCHDIR, GOALDIR, GOALARCHDIR, STATESDIR, PCACHE, MESSAGES, ERRORS, USAGE, SDKDIR, EPIDIR
+    global STATE, NAMES, CAPDIR, ARCHDIR, GOALDIR, GOALARCHDIR, STATESDIR, PCACHE, MESSAGES, ERRORS, USAGE, SDKDIR, EPIDIR, GONEDIR, JUDGE_AUTH
     STATE = path
     NAMES, CAPDIR, ARCHDIR, GOALDIR = STATE / "names", STATE / "captions", STATE / "archive", STATE / "goals"
+    GONEDIR, JUDGE_AUTH = STATE / "gone", STATE / "judge-auth.json"
     GOALARCHDIR = STATE / "goals-archive"
     STATESDIR, PCACHE = STATE / "states", STATE / "judge-units-cache"
     MESSAGES, ERRORS, USAGE = STATE / "timeline" / "messages.jsonl", STATE / "judge-errors.jsonl", STATE / "judge-usage.jsonl"
@@ -3996,16 +4001,38 @@ def _bg_unresolved(path):
     return tasks
 
 
-def _sdk_spawned_at(sid):
-    """When this SDK session's CURRENT CLI spawned (reg spawnedAt, stamped by SdkSession._run), or None
-    for tmux/never-spawned sessions. The bg-tasks ghost gate: a task launched before the live CLI died
-    with its old one — its <task-notification> can never arrive. (The kernel's copy delegates here.)"""
+def _death_marker(sid):
+    """STATE/gone/<sid>.json — the recorded death event, or None. Reg-file read cost by design: this
+    sits on _cli_epoch's per-push path, so it must never scan the growing states stream."""
+    try:
+        with open(GONEDIR / (sid + ".json")) as f:
+            m = json.load(f)
+        return m if isinstance(m, dict) else None
+    except Exception:
+        return None
+
+
+def _cli_epoch(sid):
+    """When this session's CURRENT CLI epoch began — the bg-tasks ghost gate, now backend-agnostic
+    (2026-08-13): max(reg spawnedAt, the recorded death marker's t), None when neither exists (the
+    pre-marker world, byte-for-byte today's SDK behavior). A task launched before the epoch died with
+    its CLI — its <task-notification> can never arrive — and keying the gate on the recorded death
+    EVENT is what finally gives a dead tmux session's still-'running' launches an end: the RC7
+    unretirable hold. max() stays correct across every cycle: an SDK revival's fresh CLI stamps reg
+    spawnedAt above the old marker; a re-stamped marker (death after revival) lifts the floor to the
+    second death. (The kernel's copy delegates here.)"""
+    sp = None
     try:
         with open(STATE / "sdk" / (sid + ".json")) as f:
             v = json.load(f).get("spawnedAt")
-        return v if isinstance(v, (int, float)) else None
+        sp = v if isinstance(v, (int, float)) else None
     except Exception:
+        sp = None
+    m = _death_marker(sid)
+    mt = m.get("t") if m and isinstance(m.get("t"), (int, float)) else None
+    if sp is None and mt is None:
         return None
+    return max(sp or 0, mt or 0)
 
 
 def _awaiting_bg_hold(fsid, path, session, store):
@@ -4031,7 +4058,7 @@ def _awaiting_bg_hold(fsid, path, session, store):
     tasks = _bg_unresolved(path)
     if not tasks:
         return False
-    sp = _sdk_spawned_at(fsid)
+    sp = _cli_epoch(fsid)
     tasks = [t for t in tasks if not (sp and t.get("t") and t["t"] < sp)]
     if not tasks:
         return False
@@ -7369,17 +7396,144 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
         swept.add(tid); sig[tid] = fp; did += 1        # remember the size we judged at → detect later growth
     store["closedTurns"] = sorted(swept)
     store["closedSig"] = sig
-    rollup_status(store, _session_settled(fsid, path, session, store))
+    settled = _session_settled(fsid, path, session, store)
+    rollup_status(store, settled)
     save_goals(fsid, store)
+    _death_finalize(fsid, store, settled)             # the death marker's one-shot epilogue (2026-08-13)
     return newly
+
+
+DEATH_DRAIN_PER_PASS = CONCURRENCY   # a QUEUE-DRAIN bound on death-pending finalizes per closer pass —
+#   NOT a fairness cap on live sessions (those were removed 2026-06-30 and stay removed): the pending
+#   set is a finite backlog that strictly shrinks (every drained marker gains endedAt, superseded ones
+#   retire), so the bound only spreads the one-time upgrade backfill over successive passes instead of
+#   letting the first post-upgrade pass submit hundreds of dead stores at once.
+DEATH_BACKFILL_WINDOW = 365 * 86400  # how far back the drain resolves a dead sid's transcript (cached
+#   per (window, forks) like the picker's wide walk — one filesystem walk, not one per marker)
+
+_gone_memo = {}                      # sid -> (marker mtime_ns, finalized) — a finalized marker is skipped
+#                                      with ZERO reads (the _namefp_memo idiom)
+
+
+def _write_death_marker(fsid, m):
+    """Atomic marker rewrite (tmp+rename), best-effort like every marker write."""
+    try:
+        GONEDIR.mkdir(parents=True, exist_ok=True)
+        tmp = GONEDIR / (fsid + ".json.tmp")
+        tmp.write_text(json.dumps(m))
+        os.replace(tmp, GONEDIR / (fsid + ".json"))
+        _gone_memo.pop(fsid, None)
+    except Exception:
+        pass
+
+
+def _newest_states_t(fsid):
+    """The newest states-row t for a sid, any row shape — the finalize's supersession read."""
+    try:
+        rows = (STATESDIR / (fsid + ".jsonl")).read_text().splitlines()
+        for ln in reversed(rows):
+            try:
+                r = json.loads(ln)
+                if isinstance(r, dict) and r.get("t") is not None:
+                    return int(r["t"])
+            except (ValueError, TypeError):
+                continue
+    except OSError:
+        pass
+    return 0
+
+
+def _death_pending(exclude):
+    """Up to DEATH_DRAIN_PER_PASS unfinalized death markers, oldest first, excluding sids the pass
+    already covers (a recently dead sid can appear in discover's file-based fleet too — a duplicate
+    would race two _close_session calls on one store; the final gate's second finding). Finalized
+    markers skip straight from the mtime memo with zero reads."""
+    out = []
+    try:
+        entries = sorted(((p.stat().st_mtime_ns, p) for p in GONEDIR.iterdir()
+                          if p.name.endswith(".json")), key=lambda x: x[0])
+    except OSError:
+        return out
+    for mt, p in entries:
+        sid = p.name[:-5]
+        if sid in exclude:
+            continue
+        memo = _gone_memo.get(sid)
+        if memo and memo[0] == mt and memo[1]:
+            continue
+        try:
+            m = json.loads(p.read_text())
+        except Exception:
+            continue
+        done = isinstance(m, dict) and "endedAt" in m
+        _gone_memo[sid] = (mt, bool(done))
+        if done:
+            continue
+        out.append(sid)
+        if len(out) >= DEATH_DRAIN_PER_PASS:
+            break
+    return out
+
+
+def _death_finalize(fsid, store, settled):
+    """The death marker's one-shot finalize, run at the end of every _close_session (2026-08-13).
+    No marker (the common case) → one small-json read, no-op. A marker SUPERSEDED by newer states
+    evidence — a revival's SessionStart row, or the re-anchor hook's supersededBy row — retires as
+    superseded (endedAt stamped) so the pending queue strictly shrinks; a marker stranded pending
+    forever was the final gate's third finding, and the retire is what keeps the drain's bound
+    honest. Otherwise, once the pass has SETTLED the dead store: endedAt stamps UNCONDITIONALLY
+    (nothing-open sessions included — the dedup must fire for the common case, the gate's second
+    finding), and only when open (non-complete, non-cleared) tops remain, ONE 'ended' settle record
+    (keyed on the marker's t, so it can never re-fire) lists the still-open cards on the same
+    episodes channel the /clear bell reads — cards end loudly instead of vanishing."""
+    m = _death_marker(fsid)
+    if not isinstance(m, dict) or "endedAt" in m:
+        return
+    mt = int(m.get("t") or 0)
+    if _newest_states_t(fsid) > mt:
+        m["endedAt"] = mt
+        m["superseded"] = True
+        _write_death_marker(fsid, m)
+        return
+    if not settled:
+        return
+    status = store.get("status") or {}
+    nodes = store.get("nodes") or {}
+    open_tops = [{"id": gid, "text": (nodes.get(gid) or {}).get("text") or ""}
+                 for gid, st in status.items() if st in ("working", "blocked")
+                 and (nodes.get(gid) or {}).get("parentId") is None]
+    m["endedAt"] = mt
+    _write_death_marker(fsid, m)
+    if open_tops:
+        append_episode_settle(fsid, "ended:%d" % mt, int(time.time()), open_tops)
 
 
 def run_close(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, verbose=False):
     """One CLOSER pass (the turn-end completion backstop), triage tier, run after run_plan.
-    Per-session sequential (the tree accretes), sessions concurrent. Returns nodes completed."""
+    Per-session sequential (the tree accretes), sessions concurrent. Returns nodes completed.
+    The fleet is the discover set PLUS a bounded drain of death-pending sids (markers without
+    endedAt) — window-independent, so a session already dead longer than the caption horizon at
+    upgrade still gets its finalize (the promised backfill; the re-critique's population fix)."""
     if now is None:
         now = int(time.time())
     fleet = [s for s in discover(now) if not _hidden_from_feed(s[0])][:sessions_cap]   # muted sessions are out of task tracking
+    fleet_sids = {f[0] for f in fleet}
+    pending = _death_pending(exclude=fleet_sids)
+    if pending:
+        wide = {f[0]: f for f in discover(now, window=DEATH_BACKFILL_WINDOW)}
+        for sid in pending:
+            ent = wide.get(sid)
+            if ent is not None and not _hidden_from_feed(sid):
+                fleet.append(ent)
+            else:
+                # no transcript anywhere in the wide window (rotated away, or hidden): there is
+                # nothing left to settle and no card any surface renders — retire the marker so the
+                # queue shrinks, loudly enough to find in the state dir
+                m = _death_marker(sid)
+                if isinstance(m, dict) and "endedAt" not in m:
+                    m["endedAt"] = int(m.get("t") or 0)
+                    m["noTranscript"] = True
+                    _write_death_marker(sid, m)
     n = 0
     with ThreadPoolExecutor(max_workers=concurrency) as ex:
         futs = {ex.submit(_close_session, fsid, str(path), now): fsid
@@ -9112,6 +9266,10 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
             _log_judge_error("courier", fsid, "give-up", seg=seg_id,
                              note="peer message unsummarized past the %dh retry horizon (usage-limited) — abandoned"
                                   % (COURIER_RETRY_HORIZON // 3600))
+            rollup_status(store, closed.get(fsid, False))   # the release its demote-only sibling always had
+            #                                                 (2026-08-13): without it, a node this abandoned
+            #                                                 unit was holding stayed un-rolled until some
+            #                                                 other pass happened to touch the store
             save_goals(fsid, store)
             continue
         if declared in ("coordinate", "question"):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1240,12 +1240,31 @@ def _alive_sessions(now, tmux):
     So: tmux reachable (sessions present, or a tmux binary exists) → trust the empty result and show
     only living sessions; no tmux at all → fall back so a headless box isn't blank."""
     alive = [s for s in _sessions(now) if s["sid"] in tmux]
+    # LIVE IS ALWAYS VISIBLE (2026-08-13, generalizing the SDK-only exception below): a genuinely
+    # LIVE sid missing from the 48h _sessions set — a session idle longer than the caption window,
+    # which used to silently VANISH from every surface while still running — resolves through
+    # discover's cached wide walk (the picker's own (window, forks) cache key: one filesystem walk,
+    # not one per session). Liveness owns visibility; age owns nothing but caption/walk cost.
+    have = {s["sid"] for s in alive}
+    stale_live = [sid for sid in tmux if sid not in have]
+    if stale_live:
+        wide = {f[0]: f for f in jd.discover(now, window=jd.DEATH_BACKFILL_WINDOW)}
+        for sid in stale_live:
+            ent = wide.get(sid)
+            if ent is not None:
+                fsid, path, anchor, name = ent
+                try:
+                    mtime = os.stat(path).st_mtime
+                except OSError:
+                    mtime = 0
+                alive.append({"sid": fsid, "name": name or fsid[:8], "anchor": anchor,
+                              "path": str(path), "mtime": mtime})
+                have.add(sid)
     # SDK sessions that are alive (in the merged `tmux` map) but have no transcript on disk yet — a
     # just-created or never-run SDK session — aren't in discover()/_sessions, so add them here, else
     # their tab never opens (the user 2026-06-22). Once they run and write a transcript, discover takes over.
     be = _sdk()
     if be:
-        have = {s["sid"] for s in alive}
         for sid in tmux:
             if sid not in have and be.owns(sid):
                 alive.append(_sdk_sess(sid, now))
@@ -5226,7 +5245,8 @@ def _drive(msg, client):
             client["send"](json.dumps({"type": "warn", "text": err}))
     elif t == "endSession":
         sys.stderr.write("kill: %s via endSession WS op\n" % sid)   # kill attribution (the user 2026-07-16)
-        be.kill(sid); _send_to_app("chat", {"type": "closed", "id": sid}); _push_soon()
+        be.kill(sid); _record_death(sid, int(time.time()), "kill")   # the one SDK event with no designed reviver
+        _send_to_app("chat", {"type": "closed", "id": sid}); _push_soon()
     elif t == "renameSession" and msg.get("name"):
         new = str(msg["name"]).strip()
         if not NAME_RE.match(new):
@@ -5528,6 +5548,27 @@ class TmuxBackend(sb.SessionBackend):
     def list_lines(self, fmt, t=2.5):
         r = self._run(["list-sessions", "-F", fmt], t)
         return r.stdout.splitlines() if (r and r.returncode == 0) else []
+
+    def alive_sids(self, t=3):
+        """The set of romp session ids the tmux SERVER answers for right now — the death writers'
+        corroboration primitive (2026-08-13). Identity-true: reads @romp-session-id, the key every
+        sid-keyed contract method resolves through — never a NAME (same-named generations coexist,
+        which is the whole reason kill-by-name is refused; a name probe would read a dead session as
+        alive whenever a different generation currently bears its name). None ONLY on a real probe
+        failure (exec error/timeout): a death writer must stand down then — never inherit
+        list_lines' error→[] collapse, which would read the whole board as dead. A NONZERO exit
+        whose stderr names a missing server IS the authoritative zero-sessions answer (verified:
+        `list-sessions` with no server exits 1 with 'error connecting … No such file or directory')
+        — the mass-death/reboot shape, and the boot backfill's normal world."""
+        r = self._run(["list-sessions", "-F", "#{@romp-session-id}"], t)
+        if r is None:
+            return None
+        if r.returncode != 0:
+            err = (r.stderr or "").lower()
+            if "no server running" in err or "error connecting" in err:
+                return set()
+            return None
+        return {ln.strip() for ln in r.stdout.splitlines() if ln.strip()}
 
     def send_keys(self, name, *keys, t=3):
         self._fire(["send-keys", "-t", name, *keys], t)
@@ -8984,6 +9025,128 @@ def _interrupt(name, _async=True):
     threading.Thread(target=go, daemon=True).start() if _async else go()
 
 
+_prev_live_sids = [None]   # last cycle's live-map sids — the set-diff death TRIGGER; corroboration decides
+
+
+def _death_sweep_tick(now, tmux):
+    """Stamp deaths as they happen: a sid that LEFT the live map since the last cycle is a candidate,
+    and the liveness OWNER answers before anything is written (per-batch TmuxBackend.alive_sids —
+    identity-true; probe failure → loud no-op, never a stamp). SDK-owned sids are skipped here: their
+    death event is the kill gesture (reg alive:False partitions ownership — alive:True is
+    revivable/crash-looped and must NEVER be stamped, the boot-resume contract rides on that bit)."""
+    cur = set(tmux or {})
+    prev = _prev_live_sids[0]
+    _prev_live_sids[0] = cur
+    if prev is None:
+        return
+    departed = [sid for sid in prev - cur if not (jd.SDKDIR / (sid + ".json")).exists()]
+    scan = None
+    for sid in departed:
+        if not _death_stamp_due(sid):
+            continue
+        if scan is None:
+            scan = _TMUX.alive_sids() if _TMUX.available() else set()
+            if scan is None:
+                sys.stderr.write("death-sweep: liveness probe failed — no stamps this tick\n")
+                return
+        if sid in scan:
+            continue                                 # the owner says alive — our snapshot blinked, not the session
+        _record_death(sid, now, "gone")
+
+
+def _death_boot_pass(now=None):
+    """One boot walk over the names/ registry (every romp session ever, tmux included — reg-less tmux
+    sids live only here): stamp the deaths no kernel was up to see. Same gate as the tick writer, so
+    it also covers re-deaths-after-revival that happened while the kernel was down, and the whole
+    upgrade backfill. SDK-owned sids stamp only on reg alive:False; tmux sids only when the fresh
+    identity scan lacks them; a failed probe stands down loudly."""
+    now = int(now or time.time())
+    if not jd.NAMES.is_dir():
+        return
+    scan = _TMUX.alive_sids() if _TMUX.available() else set()   # headless: no server IS zero-alive
+    if scan is None:
+        sys.stderr.write("death-boot: liveness probe failed — tmux sids skipped this boot\n")
+    n = 0
+    for f in sorted(jd.NAMES.iterdir()):
+        sid = f.name
+        reg = jd.SDKDIR / (sid + ".json")
+        if reg.exists():
+            try:
+                if bool(json.loads(reg.read_text()).get("alive")):
+                    continue                         # revivable/crash-looped: the resume contract owns it
+            except Exception:
+                continue
+        else:
+            if scan is None or sid in scan:
+                continue                             # probe failed (stand down) or genuinely alive
+        if _record_death(sid, now, "boot"):
+            n += 1
+    if n:
+        sys.stderr.write("death-boot: recorded %d session death(s) from before this kernel\n" % n)
+
+
+def _last_states_row(sid):
+    """The newest row of states/<sid>.jsonl, any shape (state rows, awaiting overlays, the re-anchor's
+    supersededBy row) — the death writers' idempotence/veto read. Event-rate only (a kill gesture, a
+    set-diff departure, one boot pass); never on a per-push path."""
+    try:
+        rows = (jd.STATE / "states" / (sid + ".jsonl")).read_text().splitlines()
+        for ln in reversed(rows):
+            try:
+                r = json.loads(ln)
+                if isinstance(r, dict):
+                    return r
+            except ValueError:
+                continue
+    except OSError:
+        pass
+    return None
+
+
+def _death_stamp_due(sid):
+    """May a death be recorded for this sid RIGHT NOW? One shared predicate for all three writers
+    (2026-08-13). Not due when the newest states row is a SUPERSESSION (the re-anchor hook's
+    supersededBy row — the fsid was re-anchored away, which the episode machinery owns; at the pane a
+    /clear'd lane and a death look identical, so only the recorded event tells them apart). Otherwise
+    due iff no marker exists, or a states row POSTDATES the marker — idempotence keyed on the marker
+    being the NEWEST event, not on file presence, so die → revive → die is recordable every cycle
+    (the first design keyed on presence, which made every death after the first invisible)."""
+    last = _last_states_row(sid)
+    if last is not None and last.get("supersededBy") and "state" not in last:
+        return False
+    m = None
+    try:
+        m = json.loads((jd.STATE / "gone" / (sid + ".json")).read_text())
+    except Exception:
+        m = None
+    if not isinstance(m, dict):
+        return True
+    return int((last or {}).get("t") or 0) > int(m.get("t") or 0)
+
+
+def _record_death(sid, now, by):
+    """Record a session's death: the marker (STATE/gone/<sid>.json, atomically — a re-stamp drops any
+    prior endedAt, re-arming the finalize) plus ONE plain idle row via _record_idle, byte-identical to
+    a Stop-hook idle so the states vocabulary stays one-flavored and every downstream (the idle atom,
+    _session_closed, _turn_open, the closer sweep, rollup settle) finalizes with zero new judge code.
+    The marker's t matches the idle row's (now-1), so the writer's own row never reads as 'newer'
+    to _death_stamp_due — a repeat stamp with no intervening revival is a no-op by the time key."""
+    if not sid or not _death_stamp_due(sid):
+        return False
+    try:
+        gd = jd.STATE / "gone"
+        gd.mkdir(parents=True, exist_ok=True)
+        tmp = gd / (sid + ".json.tmp")
+        tmp.write_text(json.dumps({"t": int(now) - 1, "by": by}))
+        os.replace(tmp, gd / (sid + ".json"))
+    except Exception:
+        sys.stderr.write("record-death %s: %s\n" % (sid, traceback.format_exc()))
+        return False
+    _record_idle(sid, now)
+    sys.stderr.write("death: %s recorded (by %s)\n" % (sid, by))   # kill-attribution convention
+    return True
+
+
 def _record_idle(sid, now):
     """Append a state:"idle" transition to states/<sid>.jsonl so the session reads as DONE on the next build.
     The chat status chip is driven by the event-model open-turn signal (open turn + no idle atom): a normal
@@ -10098,11 +10261,11 @@ _scan_bg_tasks = em._scan_bg_tasks   # moved to event_model (2026-08-08) — see
 
 
 def _sdk_spawned_at(sid):
-    """When this SDK session's CURRENT CLI spawned (reg spawnedAt, stamped by SdkSession._run), or None
-    for tmux/never-spawned sessions. The bg-tasks ghost gate: a task launched before the live CLI died
-    with its old one — its <task-notification> can never arrive. Delegates to the judge's copy (its
-    settled gate applies the same ghost rule) so the two can never drift."""
-    return jd._sdk_spawned_at(sid)
+    """The session's current CLI-epoch start — the bg-tasks ghost gate, backend-agnostic since
+    2026-08-13 (reg spawnedAt OR the recorded death marker, whichever is newer). Delegates to the
+    judge's _cli_epoch (its settled gate applies the same ghost rule) so the two can never drift;
+    the name stays for the existing call sites."""
+    return jd._cli_epoch(sid)
 
 
 def _bg_scan_cached(path):
@@ -14331,8 +14494,20 @@ def _boundary_clear_notices(alive):
     mirrors each into the shell's notification bell exactly once (client seen-set), so a clear that
     dropped open cards is always visible after the fact instead of the cards silently leaving the
     board (the user 2026-07-27). Newest-only bounds the payload; the log read is an mtime memo, so
-    this is cheap per push."""
+    this is cheap per push.
+
+    Since 2026-08-13 the same channel carries a DEAD session's end: the death finalize appends an
+    'ended:' settle record when a session died with cards still open, and those sessions are by
+    definition NOT in `alive` — so a second sweep reads the death-finalized sids (the gone/ markers,
+    endedAt-stamped, non-superseded) and mirrors their newest 'ended:' record too. Cards end loudly
+    instead of vanishing. One payload-only guard: no bell when the record's snapshotted NAME is
+    currently borne by a LIVE session under a different sid — the lifecycle on disk is identical,
+    only the interrupt is suppressed, because "web ended" ringing while a live web sits in front of
+    the user misreads as being about the live one (name reuse, and every pre-upgrade re-anchored
+    /clear lane the boot backfill stamps)."""
     out = []
+    live_names = {s["name"] for s in alive}
+    live_sids = {s["sid"] for s in alive}
     for s in alive:
         try:
             settles = jd.episode_settles(s["sid"])
@@ -14342,6 +14517,32 @@ def _boundary_clear_notices(alive):
             continue
         r = max(settles.values(), key=lambda x: x.get("t") or 0)
         out.append({"sid": s["sid"], "name": s["name"], "t": r.get("t") or 0,
+                    "titles": [str(d.get("text") or "") for d in (r.get("settled") or [])]})
+    try:
+        gone = [p.name[:-5] for p in (jd.STATE / "gone").iterdir() if p.name.endswith(".json")]
+    except OSError:
+        gone = []
+    for sid in gone:
+        if sid in live_sids:
+            continue
+        m = jd._death_marker(sid)
+        if not isinstance(m, dict) or "endedAt" not in m or m.get("superseded") or m.get("noTranscript"):
+            continue
+        try:
+            settles = jd.episode_settles(sid)
+        except Exception:
+            continue
+        ended = [v for k, v in settles.items() if str(k).startswith("ended:")]
+        if not ended:
+            continue                                   # died with nothing open: records on disk, no interrupt
+        r = max(ended, key=lambda x: x.get("t") or 0)
+        try:
+            name = (jd.NAMES / sid).read_text().split("\t")[0].strip()
+        except Exception:
+            name = sid[:8]
+        if name in live_names:
+            continue                                   # the payload-only name-reuse guard (see docstring)
+        out.append({"sid": sid, "name": name, "t": r.get("t") or 0, "ended": True,
                     "titles": [str(d.get("text") or "") for d in (r.get("settled") or [])]})
     return out
 
@@ -18609,6 +18810,10 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _lift_spent_awaiting(now, tmux)   # so the nudge tick below never wakes a wait that already ended
     except Exception:
         sys.stderr.write("awaiting-lift: %s\n" % traceback.format_exc())
+    try:                                  # death is a recorded EVENT: a sid that left the live map is
+        _death_sweep_tick(now, tmux)      # corroborated with the liveness owner, then stamped (2026-08-13)
+    except Exception:
+        sys.stderr.write("death-sweep: %s\n" % traceback.format_exc())
     try:                                  # deferral records retire on their reasons' own events — BEFORE
         _deferral_sweep_tick(now)         # the walk, independent of the nudge toggle (the stall/swirl
     except Exception:                     # surfaces read these records regardless)
@@ -22249,6 +22454,7 @@ class Handler(BaseHTTPRequestHandler):
                 else:
                     sys.stderr.write("kill: %s via /kill route\n" % sid)   # kill attribution (the user 2026-07-16)
                     be.kill(sid)
+                    _record_death(sid, int(time.time()), "kill")
                     _send_to_app("chat", {"type": "closed", "id": sid})
                 _push_all()
                 return self._send(200, json.dumps({"ok": True}), "application/json")
@@ -23420,6 +23626,7 @@ def main():
     signal.signal(signal.SIGTERM, _graceful_term)             # drain, don't die mid-flight (see _graceful_term)
     _ensure_bundles()
     try:                                                      # the diary boot sweep (2026-07-07): migrate every
+        _death_boot_pass()                                    # deaths no kernel was up to see: stamp them
         _n = jd.migrate_all_stores()                          # goal store/archive BEFORE any judge pass runs —
         if _n:                                                # the hot paths carry no migration logic anymore
             sys.stderr.write("romp-kernel: diary sweep migrated %d store file(s)\n" % _n)

--- a/tests/test_judge_session_death.py
+++ b/tests/test_judge_session_death.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""The death marker's readers: the ghost epoch, the pending drain, and the one-shot finalize
+(cluster D of the stuck-card program, 2026-08-13). All fixtures synthetic."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+jd = SourceFileLoader("romp_judge_death", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_death2", os.path.join(BIN, "romp-kernel")).load_module()
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+def _write_marker(sid, **m):
+    jd.GONEDIR.mkdir(parents=True, exist_ok=True)
+    (jd.GONEDIR / (sid + ".json")).write_text(json.dumps(m))
+    jd._gone_memo.pop(sid, None)
+
+
+def _wipe(sid):
+    for p in (jd.GONEDIR / (sid + ".json"), jd.STATESDIR / (sid + ".jsonl"),
+              jd.SDKDIR / (sid + ".json"), jd.EPIDIR / (sid + ".jsonl")):
+        try:
+            p.unlink()
+        except OSError:
+            pass
+    for mod in (jd, km.jd):                            # BOTH judge instances share the state dir; a
+        mod._gone_memo.pop(sid, None)                  # deleted-then-recreated file within one mtime
+        mod._episode_memo.pop(sid, None)               # tick would otherwise serve a stale memo
+
+
+def _store(status=None, nodes=None):
+    return {"rompUuid": SID, "seq": 1, "placements": {},
+            "status": status or {}, "nodes": nodes or {}}
+
+
+class CliEpoch(unittest.TestCase):
+    def tearDown(self):
+        _wipe(SID)
+
+    def test_reg_only_marker_only_and_max(self):
+        self.assertIsNone(jd._cli_epoch(SID), "neither source → None, today's behavior byte-for-byte")
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        (jd.SDKDIR / (SID + ".json")).write_text(json.dumps({"spawnedAt": NOW}))
+        self.assertEqual(jd._cli_epoch(SID), NOW)
+        _write_marker(SID, t=NOW + 50, by="kill")
+        self.assertEqual(jd._cli_epoch(SID), NOW + 50, "a death after the spawn lifts the floor")
+        (jd.SDKDIR / (SID + ".json")).write_text(json.dumps({"spawnedAt": NOW + 100}))
+        self.assertEqual(jd._cli_epoch(SID), NOW + 100, "a revival's fresh CLI lifts it back")
+
+
+class DeathPending(unittest.TestCase):
+    def tearDown(self):
+        for i in range(12):
+            _wipe(SID[:-2] + "%02d" % i)
+
+    def _sid(self, i):
+        return SID[:-2] + "%02d" % i
+
+    def test_unfinalized_markers_drain_oldest_first_bounded_and_deduped(self):
+        import time as _t
+        for i in range(9):
+            _write_marker(self._sid(i), t=NOW + i, by="boot")
+            os.utime(jd.GONEDIR / (self._sid(i) + ".json"), (NOW + i, NOW + i))
+        _write_marker(self._sid(9), t=NOW + 9, by="boot", endedAt=NOW + 9)   # finalized → skipped
+        os.utime(jd.GONEDIR / (self._sid(9) + ".json"), (NOW + 9, NOW + 9))
+        got = jd._death_pending(exclude={self._sid(0)})
+        self.assertEqual(len(got), jd.DEATH_DRAIN_PER_PASS, "the queue-drain bound holds")
+        self.assertNotIn(self._sid(0), got, "a sid the fleet already covers is never doubled — "
+                                            "a duplicate would race two closes on one store")
+        self.assertNotIn(self._sid(9), got)
+        self.assertEqual(got, sorted(got, key=lambda s: int(s[-2:])), "oldest marker first")
+
+    def test_the_memo_skips_finalized_markers_with_zero_reads(self):
+        _write_marker(self._sid(1), t=NOW, by="kill", endedAt=NOW)
+        jd._death_pending(exclude=set())               # primes the memo
+        p = jd.GONEDIR / (self._sid(1) + ".json")
+        mt = p.stat().st_mtime_ns
+        self.assertEqual(jd._gone_memo.get(self._sid(1)), (mt, True))
+
+
+class DeathFinalize(unittest.TestCase):
+    def tearDown(self):
+        _wipe(SID)
+
+    def test_a_settled_dead_store_with_open_tops_ends_loudly(self):
+        _write_marker(SID, t=NOW, by="kill")
+        st = _store(status={SID + ":g1": "working"},
+                    nodes={SID + ":g1": {"id": SID + ":g1", "parentId": None,
+                                         "text": "an unfinished thing", "t": NOW - 100, "log": []}})
+        jd._death_finalize(SID, st, settled=True)
+        m = json.loads((jd.GONEDIR / (SID + ".json")).read_text())
+        self.assertEqual(m.get("endedAt"), NOW, "one-shot: the finalize is keyed on the marker's t")
+        settles = jd.episode_settles(SID)
+        ended = [v for k, v in settles.items() if str(k).startswith("ended:")]
+        self.assertTrue(ended and ended[0]["settled"][0]["text"] == "an unfinished thing",
+                        "cards END loudly — the /clear treatment, not a silent vanish")
+
+    def test_nothing_open_still_finalizes_without_a_record(self):
+        # the final gate's second finding: most sessions die with nothing open, and the dedup stamp
+        # must fire for them or they sit in the pending queue forever
+        _write_marker(SID, t=NOW, by="kill")
+        jd._death_finalize(SID, _store(), settled=True)
+        m = json.loads((jd.GONEDIR / (SID + ".json")).read_text())
+        self.assertEqual(m.get("endedAt"), NOW)
+        self.assertEqual([k for k in jd.episode_settles(SID) if str(k).startswith("ended:")], [])
+
+    def test_a_superseded_marker_retires_instead_of_stranding(self):
+        # the final gate's third finding: die → revive before the drain → the marker must EXIT the
+        # pending queue (retired as superseded), or the drain's finite-queue bound is a lie
+        _write_marker(SID, t=NOW, by="gone")
+        jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+        with open(jd.STATESDIR / (SID + ".jsonl"), "a") as f:
+            f.write(json.dumps({"t": NOW + 60, "state": "waiting"}) + "\n")
+        jd._death_finalize(SID, _store(), settled=False)
+        m = json.loads((jd.GONEDIR / (SID + ".json")).read_text())
+        self.assertTrue(m.get("superseded") and m.get("endedAt") == NOW)
+
+    def test_unsettled_waits_for_the_closer(self):
+        _write_marker(SID, t=NOW, by="kill")
+        jd._death_finalize(SID, _store(), settled=False)
+        self.assertNotIn("endedAt", json.loads((jd.GONEDIR / (SID + ".json")).read_text()))
+
+
+class BellCarriesTheEnd(unittest.TestCase):
+    def setUp(self):
+        # km.jd is the SHARED "romp_judge" module object, which other test files may rebind to
+        # their own state dirs mid-suite — pin its paths to OURS for the duration (the production
+        # kernel holds exactly one instance, so this is a harness artifact, not a code path)
+        self._saved = (km.jd.STATE, km.jd.NAMES, km.jd.GONEDIR, km.jd.STATESDIR,
+                       km.jd.EPIDIR, km.jd.SDKDIR)
+        km.jd.STATE, km.jd.NAMES, km.jd.GONEDIR = jd.STATE, jd.NAMES, jd.GONEDIR
+        km.jd.STATESDIR, km.jd.EPIDIR, km.jd.SDKDIR = jd.STATESDIR, jd.EPIDIR, jd.SDKDIR
+        km.jd._episode_memo.clear()
+
+    def tearDown(self):
+        (km.jd.STATE, km.jd.NAMES, km.jd.GONEDIR, km.jd.STATESDIR,
+         km.jd.EPIDIR, km.jd.SDKDIR) = self._saved
+        _wipe(SID)
+        try:
+            (jd.NAMES / SID).unlink()
+        except OSError:
+            pass
+
+    def test_a_dead_finalized_session_with_open_cards_reaches_the_bell(self):
+        _write_marker(SID, t=NOW, by="kill", endedAt=NOW)
+        jd.append_episode_settle(SID, "ended:%d" % NOW, NOW + 1,
+                                 [{"id": SID + ":g1", "text": "an unfinished thing"}])
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+        (jd.NAMES / SID).write_text("web\t/tmp\t#123456\t#fff\n")
+        rows = km._boundary_clear_notices([])          # the dead sid is by definition not in alive
+        mine = [r for r in rows if r["sid"] == SID]
+        diag = "marker=%r settles=%r gone=%r rows=%r" % (
+            km.jd._death_marker(SID), km.jd.episode_settles(SID),
+            sorted(p.name for p in (km.jd.STATE / "gone").iterdir()), rows)
+        self.assertTrue(mine and mine[0].get("ended") and mine[0]["titles"] == ["an unfinished thing"], diag)
+
+    def test_the_name_reuse_guard_suppresses_only_the_interrupt(self):
+        _write_marker(SID, t=NOW, by="kill", endedAt=NOW)
+        jd.append_episode_settle(SID, "ended:%d" % NOW, NOW + 1, [{"id": SID + ":g1", "text": "x"}])
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+        (jd.NAMES / SID).write_text("web\t/tmp\t#123456\t#fff\n")
+        alive = [{"sid": "22222222-3333-4444-5555-666666666666", "name": "web"}]
+        saved = jd.episode_settles
+        jd.episode_settles = lambda sid: {} if sid != SID else saved(sid)
+        try:
+            rows = km._boundary_clear_notices(alive)
+        finally:
+            jd.episode_settles = saved
+        self.assertEqual([r for r in rows if r["sid"] == SID], [],
+                         "'web ended' ringing beside a LIVE web misreads — records stay on disk, "
+                         "only the interrupt is suppressed")
+
+
+class RunClosePins(unittest.TestCase):
+    def test_the_drain_is_deduped_and_window_independent(self):
+        import inspect
+        src = inspect.getsource(jd.run_close)
+        self.assertIn('pending = _death_pending(exclude=fleet_sids)', src)
+        self.assertIn('discover(now, window=DEATH_BACKFILL_WINDOW)', src)
+
+    def test_the_finalize_rides_every_close(self):
+        import inspect
+        self.assertIn('_death_finalize(fsid, store, settled)', inspect.getsource(jd._close_session))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_session_death.py
+++ b/tests/test_kernel_session_death.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Session death is a recorded, corroborated EVENT (cluster D of the stuck-card program, 2026-08-13).
+
+A dead session used to leave no terminal state row, so nothing downstream ever finalized: cards sat
+in Working forever with unretirable holds (RC7), and old sessions' cards vanished rather than ended
+(RC8). Now death is one owned record — a plain idle row (byte-identical to a Stop-hook idle: ONE
+state vocabulary) plus a load-bearing marker in STATE/gone/ with a closed reader list — written by
+the backend that owns the liveness fact and corroborated before every stamp:
+  * SDK sids: the kill gesture only (reg alive:True — dormant-revivable AND crash-looped — is never
+    stamped by anyone, so the boot-resume contract is untouched by construction);
+  * tmux sids: the set-diff is a TRIGGER; the tmux server itself answers per batch via
+    TmuxBackend.alive_sids() — identity-true (@romp-session-id, never a NAME: same-named
+    generations coexist), where the no-server exit IS the authoritative zero-sessions answer;
+  * a boot pass over names/ covers deaths no kernel was up to see, re-deaths after revival, and the
+    upgrade backfill.
+Idempotence keys on the marker being the NEWEST event (die → revive → die is recordable every
+cycle); the re-anchor hook's supersededBy row vetoes the stamp outright (a /clear'd lane is a
+supersession the episode machinery owns, not a death).
+
+All fixtures synthetic (placeholder UUIDs, invented names).
+"""
+import json
+import os
+import tempfile
+import types
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_death", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+SID2 = "99999999-8888-7777-6666-555555555555"
+
+
+def _marker(sid):
+    try:
+        return json.loads((jd.STATE / "gone" / (sid + ".json")).read_text())
+    except OSError:
+        return None
+
+
+def _states(sid):
+    try:
+        return [json.loads(l) for l in
+                (jd.STATE / "states" / (sid + ".jsonl")).read_text().splitlines()]
+    except OSError:
+        return []
+
+
+def _wipe(sid):
+    for p in (jd.STATE / "gone" / (sid + ".json"), jd.STATE / "states" / (sid + ".jsonl"),
+              jd.SDKDIR / (sid + ".json"), jd.NAMES / sid):
+        try:
+            p.unlink()
+        except OSError:
+            pass
+
+
+class RecordDeath(unittest.TestCase):
+    def tearDown(self):
+        _wipe(SID)
+
+    def test_stamps_the_marker_and_one_plain_idle_row(self):
+        self.assertTrue(km._record_death(SID, NOW, "kill"))
+        m = _marker(SID)
+        self.assertEqual((m["t"], m["by"]), (NOW - 1, "kill"))
+        rows = _states(SID)
+        self.assertEqual(rows[-1], {"t": NOW - 1, "state": "idle"},
+                         "byte-identical to a Stop-hook idle — ONE state vocabulary, no death flavor")
+
+    def test_a_second_death_with_no_revival_is_a_no_op(self):
+        km._record_death(SID, NOW, "kill")
+        self.assertFalse(km._record_death(SID, NOW + 50, "gone"),
+                         "the writer's own idle row is AT the marker's t, never newer")
+        self.assertEqual(_marker(SID)["t"], NOW - 1)
+
+    def test_death_after_revival_restamps_and_rearms_the_finalize(self):
+        km._record_death(SID, NOW, "kill")
+        m = _marker(SID)
+        m["endedAt"] = m["t"]
+        (jd.STATE / "gone" / (SID + ".json")).write_text(json.dumps(m))   # finalized once
+        with open(jd.STATE / "states" / (SID + ".jsonl"), "a") as f:      # the revival's own row
+            f.write(json.dumps({"t": NOW + 100, "state": "waiting"}) + "\n")
+        self.assertTrue(km._record_death(SID, NOW + 200, "kill"),
+                        "a states row newer than the marker re-arms the writer — die→revive→die is "
+                        "recordable every cycle (the first design's presence key made it invisible)")
+        m2 = _marker(SID)
+        self.assertEqual(m2["t"], NOW + 199)
+        self.assertNotIn("endedAt", m2, "a re-stamp drops the old finalize — the drain runs again")
+
+    def test_a_supersession_vetoes_the_stamp(self):
+        sdir = jd.STATE / "states"
+        sdir.mkdir(parents=True, exist_ok=True)
+        with open(sdir / (SID + ".jsonl"), "a") as f:
+            f.write(json.dumps({"t": NOW, "state": "working"}) + "\n")
+            f.write(json.dumps({"t": NOW + 10, "supersededBy": SID2}) + "\n")
+        self.assertFalse(km._record_death(SID, NOW + 20, "gone"),
+                         "a re-anchored lane is a SUPERSESSION the episode machinery owns — at the "
+                         "pane it looks exactly like a death, and only the recorded event tells them apart")
+        self.assertIsNone(_marker(SID))
+
+
+class AliveSids(unittest.TestCase):
+    def _probe(self, rc, out="", err=""):
+        saved = km._TMUX._run
+        km._TMUX._run = lambda args, t=3: types.SimpleNamespace(returncode=rc, stdout=out, stderr=err)
+        try:
+            return km._TMUX.alive_sids()
+        finally:
+            km._TMUX._run = saved
+
+    def test_a_healthy_scan_returns_the_sid_set(self):
+        self.assertEqual(self._probe(0, out=SID + "\n\n" + SID2 + "\n"), {SID, SID2})
+
+    def test_no_server_is_the_authoritative_zero_answer(self):
+        # verified live: `list-sessions` with no server exits 1 with 'error connecting … No such
+        # file or directory' — the mass-death/reboot shape, and the boot backfill's normal world
+        self.assertEqual(self._probe(1, err="error connecting to /tmp/tmux-1000/default (No such file or directory)"),
+                         set())
+        self.assertEqual(self._probe(1, err="no server running on /tmp/tmux-1000/default"), set())
+
+    def test_a_real_probe_failure_is_none_so_writers_stand_down(self):
+        self.assertIsNone(self._probe(1, err="some other tmux error"))
+        saved = km._TMUX._run
+        km._TMUX._run = lambda args, t=3: None
+        try:
+            self.assertIsNone(km._TMUX.alive_sids())
+        finally:
+            km._TMUX._run = saved
+
+
+class DeathSweepTick(unittest.TestCase):
+    def setUp(self):
+        self._saved_avail, self._saved_run = km._TMUX.available, km._TMUX._run
+        km._TMUX.available = lambda: True
+        km._prev_live_sids[0] = None
+
+    def tearDown(self):
+        km._TMUX.available, km._TMUX._run = self._saved_avail, self._saved_run
+        km._prev_live_sids[0] = None
+        _wipe(SID)
+        _wipe(SID2)
+
+    def _scan(self, sids):
+        km._TMUX._run = lambda args, t=3: types.SimpleNamespace(
+            returncode=0, stdout="\n".join(sids), stderr="")
+
+    def test_a_departed_sid_confirmed_gone_is_stamped(self):
+        self._scan([])
+        km._death_sweep_tick(NOW, {SID: {}})
+        km._death_sweep_tick(NOW + 5, {})
+        self.assertIsNotNone(_marker(SID), "left the map + the owner confirms absence → stamped")
+
+    def test_the_owner_saying_alive_blocks_the_stamp(self):
+        self._scan([SID])
+        km._death_sweep_tick(NOW, {SID: {}})
+        km._death_sweep_tick(NOW + 5, {})
+        self.assertIsNone(_marker(SID), "our snapshot blinked; the session is alive")
+
+    def test_an_sdk_owned_sid_is_never_stamped_here(self):
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        (jd.SDKDIR / (SID + ".json")).write_text(json.dumps({"sid": SID, "alive": True}))
+        self._scan([])
+        km._death_sweep_tick(NOW, {SID: {}})
+        km._death_sweep_tick(NOW + 5, {})
+        self.assertIsNone(_marker(SID),
+                          "SDK deaths are the kill gesture's to stamp — alive:True is revivable/"
+                          "crash-looped and the boot-resume contract rides on never stamping it")
+
+    def test_a_failed_probe_stamps_nothing(self):
+        km._TMUX._run = lambda args, t=3: None
+        km._death_sweep_tick(NOW, {SID: {}})
+        km._death_sweep_tick(NOW + 5, {})
+        self.assertIsNone(_marker(SID))
+
+
+class DeathBootPass(unittest.TestCase):
+    def tearDown(self):
+        _wipe(SID)
+        _wipe(SID2)
+        km._TMUX.available, km._TMUX._run = self._saved_avail, self._saved_run
+
+    def setUp(self):
+        self._saved_avail, self._saved_run = km._TMUX.available, km._TMUX._run
+        km._TMUX.available = lambda: True
+        km._TMUX._run = lambda args, t=3: types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+
+    def test_a_regless_tmux_sid_dead_before_boot_is_stamped(self):
+        (jd.NAMES / SID).write_text("web\t/tmp\t#123456\t#fff\n")
+        km._death_boot_pass(NOW)
+        self.assertIsNotNone(_marker(SID), "the RC7 case: a tmux death no kernel was up to see")
+
+    def test_an_alive_true_reg_is_left_for_the_resume_contract(self):
+        (jd.NAMES / SID).write_text("api\t/tmp\t#123456\t#fff\n")
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        (jd.SDKDIR / (SID + ".json")).write_text(json.dumps({"sid": SID, "alive": True}))
+        km._death_boot_pass(NOW)
+        self.assertIsNone(_marker(SID))
+
+    def test_a_killed_reg_is_stamped(self):
+        (jd.NAMES / SID).write_text("api\t/tmp\t#123456\t#fff\n")
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        (jd.SDKDIR / (SID + ".json")).write_text(json.dumps({"sid": SID, "alive": False}))
+        km._death_boot_pass(NOW)
+        self.assertIsNotNone(_marker(SID))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/badge-mirror.ts
+++ b/ui/webview/badge-mirror.ts
@@ -74,7 +74,7 @@ export function badgeNotices(items: BadgeItem[], seen: Set<string>): { notices: 
 // entry per boundary (sid + its t), so a clear that silently dropped cards is always findable in
 // the bell after the fact (the user 2026-07-27). The entry names the dropped cards and the way back
 // (Undo clear restores the batch).
-export interface ClearNoticeRow { sid: string; name: string; t: number; titles: string[]; }
+export interface ClearNoticeRow { sid: string; name: string; t: number; titles: string[]; ended?: boolean; }   // ended: a session death finalized these cards (2026-08-13), not a /clear
 
 export function clearBoundaryNotices(rows: ClearNoticeRow[], seen: Set<string>): { notices: BadgeNotice[]; active: Set<string> } {
   const notices: BadgeNotice[] = [];
@@ -84,9 +84,15 @@ export function clearBoundaryNotices(rows: ClearNoticeRow[], seen: Set<string>):
     active.add(sig);
     if (seen.has(sig)) continue;
     const n = r.titles.length;
-    notices.push({ kind: "cleared", sig, sid: r.sid, itemId: "",   // no single card — the jump opens the session
-      text: r.name + " — /clear dropped " + n + " open card" + (n === 1 ? "" : "s") + ": "
-        + cap(r.titles.join(", "), 120) + " (Undo clear on the feed restores them)" });
+    // an ENDED row is a session death that finalized open cards (2026-08-13) — same channel as the
+    // /clear drop, its own phrasing: nothing here is restorable by Undo clear, the session is gone
+    notices.push(r.ended
+      ? { kind: "ended", sig, sid: r.sid, itemId: "",
+          text: r.name + " ended with " + n + " open card" + (n === 1 ? "" : "s") + ": "
+            + cap(r.titles.join(", "), 120) }
+      : { kind: "cleared", sig, sid: r.sid, itemId: "",   // no single card — the jump opens the session
+          text: r.name + " — /clear dropped " + n + " open card" + (n === 1 ? "" : "s") + ": "
+            + cap(r.titles.join(", "), 120) + " (Undo clear on the feed restores them)" });
   }
   return { notices, active };
 }


### PR DESCRIPTION
Cluster D — the final piece of the stuck-card program, after two adversarial design-revision rounds (six findings → four → three, all resolved or folded in).

**The problem:** a dead session left no terminal state row — its last turn never closed, holds on its dispatched work became unretirable, and cards on sessions older than the caption window vanished rather than ended.

**The design:** death becomes one owned, corroborated record — a plain `idle` row (byte-identical to a Stop-hook idle: one state vocabulary, zero new judge lifecycle code downstream) plus a load-bearing marker in `STATE/gone/` with a closed, test-pinned reader list. Writers partition on liveness ownership: SDK sids stamp at the kill gesture only (`alive:True` — revivable and crash-looped — is never stamped, so the boot-resume contract is safe *by construction*); tmux sids are corroborated per batch by the server itself (`alive_sids()`, identity-true via `@romp-session-id`; the no-server exit is the authoritative zero answer; real probe failures stand down loudly). Idempotence keys on the marker being the newest event, so die→revive→die records every cycle; the re-anchor hook records supersessions, vetoing death stamps for /clear'd lanes.

**Finalization** rides the existing closer with a bounded, deduplicated, window-independent drain of pending markers; `endedAt` stamps unconditionally once settled; superseded markers retire (the queue genuinely shrinks); sessions that died with open cards get an "ended with N open cards" bell record on the /clear settle channel. `_cli_epoch` merges the ghost gate backend-agnostically; live sessions never vanish for being old; the courier abandon path gains its missing `rollup_status`.

**Tests:** `tests/test_kernel_session_death.py` (stamp/idempotence/supersession-veto, the probe's three answers, the sweep's corroboration + SDK skip + failed-probe standdown, the boot pass incl. the reg-less tmux case) and `tests/test_judge_session_death.py` (the epoch matrix, the bounded deduped oldest-first drain + zero-read memo, the finalize's four shapes incl. both residual-gate findings, the bell carry + name-reuse guard). Full suites green locally (pytest 4424, node 1877, build clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)