### PR TITLE
Hive: a game-feel 3D command view of your sessions

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -948,6 +948,29 @@ if [[ "${1:-}" == "default-dir" ]]; then
     exit 0
 fi
 
+# `romp default-host [NAME]` — the machine NEW sessions are created on by default. Persisted to
+# ~/.config/romp/default-host and read by the kernel's _default_create_host(), which ships it to the
+# client: the + picker preselects that machine in its Host row and a hive tray drop lands there. No arg
+# prints it; an empty arg ("") clears it (back to this machine). Read live — no restart.
+if [[ "${1:-}" == "default-host" ]]; then
+    _dh_file="$HOME/.config/romp/default-host"
+    if [[ $# -lt 2 ]]; then
+        if [[ -s "$_dh_file" ]]; then cat "$_dh_file"; else echo "(unset — new sessions land on this machine)"; fi
+        exit 0
+    fi
+    if [[ -z "$2" ]]; then
+        rm -f "$_dh_file"; echo "default new-session host cleared (new sessions land on this machine)."
+        exit 0
+    fi
+    if [[ ! "$2" =~ ^[A-Za-z0-9._@:-]+$ ]]; then
+        echo "romp default-host: not a host name: $2" >&2; exit 1
+    fi
+    mkdir -p "$(dirname "$_dh_file")"
+    printf '%s\n' "$2" > "$_dh_file"
+    echo "default new-session host set to: $2"
+    exit 0
+fi
+
 # NB: `romp --serve` (a persisted 0.0.0.0 opt-in for direct tailnet binding) was
 # REMOVED 2026-07-19: phone/tailnet reach goes through `tailscale serve` proxying
 # to the loopback-bound kernel instead — the kernel never leaves 127.0.0.1, and
@@ -1080,6 +1103,8 @@ resume=false
 resume_id=""
 detach=false
 dir_arg=""
+model_arg=""
+effort_arg=""
 use_tmux=false
 
 case "${1:-}" in
@@ -1094,6 +1119,19 @@ case "${1:-}" in
                                echo "usage: romp new [-t] [-d <dir>] <name>" >&2; exit 2
                            fi
                            dir_arg="$1"; shift ;;
+                # Per-spawn model/effort (the hive tray's bean drop, the user 2026-08-13): an explicit
+                # choice for THIS session, outranking the session-defaults file below. Validated where
+                # they are appended to the launch command, like every other interpolated value.
+                --model)   shift
+                           if [[ $# -eq 0 || "$1" == -* ]]; then
+                               echo "usage: romp new [--model <model>] <name>" >&2; exit 2
+                           fi
+                           model_arg="$1"; shift ;;
+                --effort)  shift
+                           if [[ $# -eq 0 || "$1" == -* ]]; then
+                               echo "usage: romp new [--effort <level>] <name>" >&2; exit 2
+                           fi
+                           effort_arg="$1"; shift ;;
                 -*)        echo "romp new: unknown option: $1" >&2; exit 2 ;;
                 *)         if [[ -n "$session_arg" ]]; then
                                echo "usage: romp new [-t] [-d <dir>] <name>" >&2; exit 2
@@ -1350,6 +1388,37 @@ else
     sid="$(_romp_uuid)"
     claude_cmd="claude --name \"$display\" --session-id $sid"
 fi
+
+# Per-session launch defaults — model, effort level, permission mode — applied to EVERY romp session
+# (the user 2026-08-13, who wanted one answer for all of them rather than setting each session by hand).
+# A FILE (~/.config/romp/session-defaults, KEY=VALUE lines) for the same reason default-dir is one: the
+# kernel that spawns these is launchd-rooted and never sees a shell env var. Blank/absent value → the flag
+# is omitted entirely and the CLI's own settings.json default stands, so this can never pin a session to a
+# model that no longer exists. Parsed line-by-line, never sourced: a malformed line is skipped rather than
+# executed. The values are validated here because they land in the launch shell command below.
+_rsd_file="$HOME/.config/romp/session-defaults"
+_sd_model=""; _sd_effort=""; _sd_mode=""
+if [[ -f "$_rsd_file" ]]; then
+    while IFS= read -r _line || [[ -n "$_line" ]]; do
+        case "$_line" in
+            MODEL=*)      _sd_model="${_line#MODEL=}" ;;
+            EFFORT=*)     _sd_effort="${_line#EFFORT=}" ;;
+            PERM_MODE=*)  _sd_mode="${_line#PERM_MODE=}" ;;
+        esac
+    done < "$_rsd_file"
+fi
+# An explicit per-spawn choice (`romp new --model/--effort`, which the hive tray's bean drop passes)
+# outranks the file for this one session.
+[[ -n "$model_arg" ]] && _sd_model="$model_arg"
+[[ -n "$effort_arg" ]] && _sd_effort="$effort_arg"
+# A resume keeps the conversation's own model/effort — re-pinning them at resume would silently rewrite
+# what that session was running (the mode is a per-launch choice, so it still applies).
+if ! $resume; then
+    [[ "$_sd_model" =~ ^[A-Za-z0-9._-]+(\[[0-9]+[a-z]\])?$ ]] && claude_cmd="$claude_cmd --model $_sd_model"
+    [[ "$_sd_effort" =~ ^(low|medium|high|xhigh|max)$ ]] && claude_cmd="$claude_cmd --effort $_sd_effort"
+fi
+[[ "$_sd_mode" =~ ^(acceptEdits|auto|bypassPermissions|manual|dontAsk|plan)$ ]] \
+    && claude_cmd="$claude_cmd --permission-mode $_sd_mode"
 
 # Load the Romp Postal Service MCP server (tool-native messaging) into romp
 # sessions only (scoped via --mcp-config), when installed.

--- a/bin/romp
+++ b/bin/romp
@@ -709,6 +709,37 @@ _romp_token() {
     cat "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/serve-token" 2>/dev/null || true
 }
 
+# Is a kernel listening on the port? ANY HTTP status (even a 401 without the token) proves
+# life; curl's 000 means nothing is there. ROMP_ALIVE_PROBE is the test seam (hermetic
+# tests can't bind the real port), same pattern as ROMP_OPENER / ROMP_MANAGER_BIN.
+_romp_kernel_alive() {
+    if [[ -n "${ROMP_ALIVE_PROBE:-}" ]]; then
+        # shellcheck disable=SC2206
+        local _probe=(${ROMP_ALIVE_PROBE})
+        "${_probe[@]}" "$1" >/dev/null 2>&1
+        return $?
+    fi
+    [[ "$(curl -s -o /dev/null -w '%{http_code}' -m 2 "http://127.0.0.1:$1/" 2>/dev/null)" != "000" ]]
+}
+
+# Start the stack the way the login service would — the manager, detached, spawning and
+# owning the kernel — then wait (bounded) for a live kernel and its minted token. With the
+# login service installed (install.sh) this path never runs in daily life; it exists so
+# ONE command works from ANY state — fresh clone, stopped service, a box that never ran
+# install.sh (the user 2026-08-13, who wanted the whole thing behind one command).
+_romp_start_stack() {
+    local _port="$1" _state="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}" _i
+    mkdir -p "$_state"
+    nohup "${ROMP_MANAGER_BIN:-romp-manager}" up >> "$_state/manager.log" 2>&1 &
+    disown 2>/dev/null || true
+    for _i in $(seq 1 "${ROMP_START_TRIES:-60}"); do
+        if _romp_kernel_alive "$_port" && [[ -n "$(_romp_token)" ]]; then return 0; fi
+        sleep 0.25
+    done
+    echo "romp: started the manager, but no kernel answered on :$_port — see $_state/manager.log" >&2
+    return 1
+}
+
 # `romp url` — print the tokened dashboard URL, nothing else (scripting/piping; bare `romp` is the
 # human entry point). The first open seeds a year-long cookie; after that the bare URL works.
 # `--url` stays as a silent alias (agent-facing text names it).
@@ -784,12 +815,21 @@ fi
 if [[ $# -eq 0 ]]; then
     _tok="$(_romp_token)"
     _kport="${ROMP_KERNEL_PORT:-29855}"
-    # The floor nudge comes BEFORE the token bail: a fresh install whose service
-    # hasn't minted a token yet is exactly the run that should hear about an old
-    # Claude Code, not be cut off by the earlier exit.
+    # The floor nudge comes BEFORE any bail: a fresh install is exactly the run that
+    # should hear about an old Claude Code, not be cut off by an earlier exit.
     _romp_claude_floor_nudge
+    # ONE command from any state (the user 2026-08-13): nothing listening → start the
+    # stack right here instead of pointing at a second command. Everything you already
+    # have then attaches by DISCOVERY, no flags: tmux sessions by their @romp tag, SDK
+    # sessions from kernel state, attached remote hosts from their persisted rows (they
+    # survive restarts). Scripts that must never start anything keep `romp url`.
+    if ! _romp_kernel_alive "$_kport"; then
+        echo "    romp isn't running — starting it..."
+        _romp_start_stack "$_kport" || exit 1
+        _tok="$(_romp_token)"
+    fi
     if [[ -z "$_tok" ]]; then
-        echo "romp: no serve token yet; the kernel mints it. Is romp running? (the login service starts it; \`romp up\` runs it by hand)" >&2
+        echo "romp: the kernel is up on :$_kport but there's no serve token — check \`romp status\`." >&2
         exit 1
     fi
     _url="http://127.0.0.1:$_kport/?token=$_tok"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -310,6 +310,30 @@ def _interrupt_marks(turns, sid=""):
     return last_intr, last_human
 
 
+def _wakeup_scheduled(turns):
+    """True while the session's newest GENUINE ended turn scheduled its own future work — the /loop
+    dynamic-pacing ScheduleWakeup, or a CronCreate self-invocation. Such a session is deliberately
+    idle between iterations it paces ITSELF: a timer, not the human and not a stall, owns the next
+    move — so auto-nudge must stand down (the user 2026-08-15, who ran looping workers and watched
+    romp nudge one four times in an hour, twice 69s apart: every iteration's ended turn re-armed the
+    nudge, the goal never completes because it's a loop, and each 'where does this stand?' landed as
+    a boss-message that burned the next beat and could supersede the pending wakeup — the loop died
+    of concern). Romp-injected turns (a nudge's own response) are skipped exactly like the arming
+    scan below, so one derailment can't strip a loop that still claims its cadence; the gate lifts
+    on the first genuine turn that ends WITHOUT scheduling (the loop finished, or the user redirected
+    it) — an event, never a timer."""
+    arm = next((tn for tn in reversed(turns) if tn.get("ended") and not _turn_romp_injected(tn)), None)
+    for a in (arm or {}).get("atoms") or []:
+        if a.get("type") != "assistant":
+            continue
+        blocks = (a.get("message") or {}).get("content")
+        if isinstance(blocks, list) and any(
+                isinstance(b, dict) and b.get("type") == "tool_use"
+                and b.get("name") in ("ScheduleWakeup", "CronCreate") for b in blocks):
+            return True
+    return False
+
+
 def _interrupt_suppresses_nudge(turns, sid=""):
     """True while the session's most recent USER action is a GENUINE user INTERRUPT: the user stopped
     the agent and hasn't spoken since, so they're at the controls — auto-nudge stays suppressed until
@@ -3540,6 +3564,9 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
         return False                                # driving; suppressed until their NEXT message. The stopped
         #                                              focus goal's BLOCKED-on-you flip is owned by the always-on
         #                                              _interrupt_block_tick (a needs-you rule, not a nudge feature).
+    if _wakeup_scheduled(turns):                     # the session paced ITSELF (ScheduleWakeup / a self-cron):
+        return False                                #   idle between iterations is the loop working as designed —
+        #                                              let it loop (the user 2026-08-15); see _wakeup_scheduled.
     if _pending_ops.get(str(sid)) or _backend_queued(sid):   # the user has messages queued — parked drive ops OR the
         return False                                         # backend's own queue (SDK _pending, where composer sends now
         #                                                      wait) → queued intent; a nudge would jump it (the user 2026-07-05)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4303,7 +4303,7 @@ def _pick_identity_color(now=None):
     return bgs[i], fgs[i]
 
 
-def _create_sdk_session(nm, cwd, auth=""):
+def _create_sdk_session(nm, cwd, auth="", model="", effort=""):
     """Create + open a new SDK-backed session, ACK-FAST (the user 2026-07-14, who asked why it took so long
     to open a new SDK session). spawn() is file writes and connect() is threaded (~0.4s to a booting
     CLI) — the 7-10s the user waited was the handler's inline _push_all(): a new session invalidates the
@@ -4316,7 +4316,7 @@ def _create_sdk_session(nm, cwd, auth=""):
     the next full cycle, ~5-6s on a busy fleet, all of it spent staring at the provisional dots
     (measured live, the user 2026-08-10)."""
     bg, fg = _pick_identity_color()   # fleet-aware: only the kernel sees BOTH backends' live sessions
-    sid = _sdk().spawn(nm, cwd, bg, fg, auth=auth)
+    sid = _sdk().spawn(nm, cwd, bg, fg, auth=auth, model=model, effort=effort)
     _sdk().connect(sid)    # eager-connect so the model lists immediately, not only after the 1st message
     _reveal_chat({"type": "focus", "id": sid})
     _mark_views_dirty()
@@ -21905,7 +21905,16 @@ class Handler(BaseHTTPRequestHandler):
                     "palettes": [{"name": k, "label": v["label"], "colors": v["bg"]}
                                  for k, v in pal.PALETTES.items()]}), "application/json", cache="no-cache")
             if p == "/models":                                # the ONE model + effort choice list — chat statusline, timeline lanes, AND judge settings all read it (the user 2026-07-02: no hardcoding in multiple places)
-                return self._send(200, json.dumps({"models": MODEL_CHOICES, "efforts": EFFORT_CHOICES}), "application/json", cache="no-cache")
+                # `defaults` (the user 2026-08-13): the remembered new-session seed, so the hive tray can
+                # mark the default bean. Read from the same store spawn() seeds from — never a cached copy.
+                try:
+                    _sd = json.loads((jd.STATE / "sdk-defaults.json").read_text())
+                except (OSError, ValueError):
+                    _sd = {}
+                _sd = _sd if isinstance(_sd, dict) else {}
+                return self._send(200, json.dumps({"models": MODEL_CHOICES, "efforts": EFFORT_CHOICES,
+                                                   "defaults": {k: _sd[k] for k in ("model", "effort") if _sd.get(k)}}),
+                                  "application/json", cache="no-cache")
             if p == "/usage":                                 # the /usage rate-limit bars, re-read on demand: the rail's
                 # usage widget is click-to-refresh (the user 2026-06-30). Returns the freshest on-disk snapshot
                 # NOW, and (2026-07-02) also pokes one live SDK session for an exact get_usage snapshot — the
@@ -22916,6 +22925,24 @@ class Handler(BaseHTTPRequestHandler):
             # changed — so the reordered cards lagged up to ~2s (the user 2026-07-15). The dirty mark bypasses
             # the throttle AND wakes the pusher, so the rebuilt payload (fresh order) ships right away.
             _mark_views_dirty()
+        elif msg and msg.get("type") == "setSpawnDefaults" and (msg.get("model") or msg.get("effort")):
+            # The hive tray's 'make this my default' (the user 2026-08-13): the model/effort seed every
+            # NEW session starts from — the same sdk-defaults store the statusline picks feed implicitly
+            # (write_sdk_default). Not a per-session drive op: it has no sid, so it lives here with the
+            # other backend-global ops. Values must come from the /models lists; refused loudly otherwise.
+            mdl = msg.get("model") if msg.get("model") in _MODEL_VALUES else None
+            eff = msg.get("effort") if msg.get("effort") in _EFFORT_VALUES else None
+            if eff == "ultracode":
+                eff = None    # per-session by design (set_effort: "never a seed") — skipping it silently would lie
+            if (msg.get("model") and mdl is None) or (msg.get("effort") and eff is None):
+                client["send"](json.dumps({"type": "warn",
+                                           "text": "that model/effort isn't one of the offered choices (ultracode is per-session only)."}))
+            else:
+                be = _sdk()
+                if be:
+                    be.set_spawn_defaults(model=mdl, effort=eff)
+                    client["send"](json.dumps({"type": "spawnDefaults",
+                                               "model": mdl or "", "effort": eff or ""}))
         elif msg and msg.get("type") == "createSession" and msg.get("name"):
             nm = str(msg["name"]).strip()
             if not NAME_RE.match(nm):
@@ -22948,7 +22975,13 @@ class Handler(BaseHTTPRequestHandler):
                         # auth ('login'|'key') is the picker's per-session billing pick; anything else
                         # (older clients, no pick) means the remembered/ambient default (spawn's seed).
                         a = msg.get("auth")
-                        _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""))
+                        # model/effort: the hive tray's per-spawn choice (the user 2026-08-13) — an
+                        # explicit alias/level from the /models lists outranks the remembered seed for
+                        # this one session; anything else means the seed, exactly as before.
+                        mdl = msg.get("model") if msg.get("model") in _MODEL_VALUES else ""
+                        eff = msg.get("effort") if msg.get("effort") in _EFFORT_VALUES else ""
+                        _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""),
+                                            model=mdl, effort=eff)
                     else:
                         # NEVER silently fall back to tmux (the user asked for SDK and got a mystery tmux
                         # session on a remote host without the venv, 2026-07-02). Say what's missing.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19324,6 +19324,14 @@ else window.__rompPaneToggle('fleet');});})();
 if(window.__rompPaneToggle)window.__rompPaneToggle('chat',true);
 var f=document.getElementById('f-chat');
 if(f&&f.contentWindow)try{f.contentWindow.postMessage({romp:'openPicker'},'*');}catch(err){}});})();
+// The INSTANT tab switch (the user 2026-08-13: a hive click must be truly reactive): a pane posts
+// {romp:'focusChat',id} and the shell hands the chat iframe a focus frame DIRECTLY — one client-side
+// hop, indistinguishable from a kernel focus (the shim delivers kernel frames as window messages
+// too), no kernel round trip in the critical path. The sender still posts its kernel op for
+// everything else that op does (eager-connect, other dashboards, the dead-session revive prompt).
+(function(){window.addEventListener('message',function(e){var m=e.data;if(!m||m.romp!=='focusChat'||!m.id)return;
+var f=document.getElementById('f-chat');
+if(f&&f.contentWindow)try{f.contentWindow.postMessage({type:'focus',id:m.id},'*');}catch(err){}});})();
 """
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5081,8 +5081,15 @@ def _drive(msg, client):
         else:
             _push_soon()
     elif t == "interrupt":
+        # Gauge BEFORE dispatch (tmux interrupt records idle as part of settling): a stop pressed on a
+        # session with NO open turn stops nothing, so it must paint nothing — the stamp's only clear
+        # events are a settle (which an idle press never produces) and the 120s wedge cap, so stamping
+        # an idle press pinned "Interrupting…" for two minutes per press ("it never goes back to
+        # normal", the user 2026-08-14). _working_now is the authoritative-first busy read.
+        _intr_live = _working_now(str(sid))
         be.interrupt(sid)                                 # Esc/stop AND settle idle (in the backend)
-        _interrupt_clicked[str(sid)] = time.time()        # chip → "interrupting" NOW (event-cleared on settle)
+        if _intr_live:
+            _interrupt_clicked[str(sid)] = time.time()    # chip → "interrupting" NOW (event-cleared on settle)
         _suppress_session_retry(sid)                      # interrupting a thread STOPS romp's auto-retry into it until a
                                                           # successful turn re-arms (the user 2026-07-06) — the interrupt
                                                           # already aborted any in-flight CLI retry; this stops the relapse
@@ -22430,8 +22437,10 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps({"ok": True}), "application/json")
                 be = Sessions.backend_for(sid)
                 if u.path == "/interrupt":
+                    _intr_live = _working_now(str(sid))         # same idle-press gate as the WS op
                     be.interrupt(sid)                           # Esc/stop AND settle idle (in the backend)
-                    _interrupt_clicked[str(sid)] = time.time()  # chip → "interrupting" NOW, same as the WS op
+                    if _intr_live:
+                        _interrupt_clicked[str(sid)] = time.time()  # chip → "interrupting" NOW, same as the WS op
                 else:
                     sys.stderr.write("kill: %s via /kill route\n" % sid)   # kill attribution (the user 2026-07-16)
                     be.kill(sid)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17698,8 +17698,8 @@ def _push(targets, connect=False, tmux=None):
     # The FLEET connects as its OWN app (the user 2026-06-29) so we build its per-session ledgers EVEN when no
     # chat client is open — previously the fleet rode app=feed and got ledgers only as a side effect of a chat
     # build (want_chat), so opening the fleet alone showed an empty/loading screen until a chat push happened.
-    want_fleet = any(c["app"] == "fleet" for c in targets)
-    want_feed = any(c["app"] in ("feed", "fleet", "chat") for c in targets)   # fleet rides the feed payload; chat needs feed["working"]
+    want_fleet = any(c["app"] in ("fleet", "hive") for c in targets)   # hive rides the same ledgers attach
+    want_feed = any(c["app"] in ("feed", "fleet", "hive", "chat") for c in targets)   # fleet/hive ride the feed payload; chat needs feed["working"]
     want_tl = any(c["app"] == "timeline" for c in targets)
     chat_clients = [c for c in targets if c["app"] == "chat"]
     try:
@@ -17860,7 +17860,7 @@ def _push(targets, connect=False, tmux=None):
     global _feed_wire, _bars_wire
     feed_ms = feed_sig = bars = bars_ms = bars_sig = None
     for c in targets:
-        if c["app"] in ("feed", "fleet"):   # the feed pane AND the Fleet view both ride the feed payload (Fleet reads feed.ledgers)
+        if c["app"] in ("feed", "fleet", "hive"):   # the feed pane, the Fleet view AND the Hive all ride the feed payload (ledgers + asks)
             if feed_ms is None:
                 w = _feed_wire                           # tuple snapshot — rebound whole, never mutated (torn reads)
                 if w is not None and w[0] is feed_src and w[1] == feed.get("ledgers"):
@@ -19057,6 +19057,31 @@ def _fleet_page():
             % (v, THEME_CSS, fleet_css, _pane_spin("fleet-list"), _shim("fleet", v), v, v))
 
 
+# Hive — the game-feel command view (plans/hive.md): a 3D honeycomb, one hex pad + character per session,
+# acting out that session's live state; click a hex to fly in, read the gist, and talk to it. Rendered by
+# ui/webview/hive.ts (three.js, bundled to dist/hive.js); layout/overlay CSS in ui/webview/hive-pane.css,
+# read live here and bundled into the VSIX by vscode-extension/esbuild.js like the other panes. It connects
+# as app=hive, a rider on the feed payload (ledgers + asks) — see the want_fleet/want_feed computations.
+def _hive_page():
+    try:
+        hive_css = (UI / "webview" / "hive-pane.css").read_text()
+    except OSError:
+        return ("<!DOCTYPE html><html><body style='font-family:-apple-system,sans-serif;color:#999;"
+                "background:#1e1e1e;padding:12px'>romp hive needs the ui/ modules "
+                "(webview/hive-pane.css).</body></html>")
+    v = _dist_ver()
+    return ("<!DOCTYPE html><html lang=en><head><meta charset=UTF-8>"
+            "<meta name=viewport content='width=device-width,initial-scale=1'>"
+            "<link rel=icon type=image/svg+xml href=/media/romp-swirl-glyph.svg><title>Romp · hive</title>"
+            "<style>%s\n%s</style></head><body>"
+            # #hive-root stays EMPTY until the first ledgers land (hive.ts mounts the canvas then), so the
+            # shared _pane_spin loader holds through the cold build, exactly like the outline pane.
+            "<div id=hive-root></div>%s"
+            "<script>%s</script><script src=/dist/federation.js?v=%d></script>"   # multi-kernel manager: after the shim
+            "<script src=/dist/hive.js?v=%d></script></body></html>"
+            % (THEME_CSS, hive_css, _pane_spin("hive-root"), _shim("hive", v), v, v))
+
+
 # The romp-tl-* wrapper styles live in ui/webview/timeline-pane.css — ONE file, read live here (like the
 # view JS itself) and bundled into the VS Code VSIX by vscode-extension/esbuild.js, so the two hosts cannot drift.
 
@@ -19177,12 +19202,12 @@ window.addEventListener('mousemove',mv);window.addEventListener('mouseup',up);})
 // ── pane gutters (chat|fleet|feed, fixed order) sized by flex-grow. gv-a is always chat|fleet; gv-b's left
 // neighbour is fleet when shown else chat (so it's the chat|feed gutter when fleet is off). On grab we
 // normalise every visible pane's grow to its px width so the drag shifts only that pair; grows persist.
-var PANES=['chat-pane','fleet-pane','feed-pane'];
-var GK='romp-pane-grow',grow={chat:60,fleet:34,feed:40};
+var PANES=['chat-pane','fleet-pane','feed-pane','hive-pane'];
+var GK='romp-pane-grow',grow={chat:60,fleet:34,feed:40,hive:50};
 try{var g=JSON.parse(localStorage.getItem(GK)||'null');if(g)grow=Object.assign(grow,g);}catch(e){}
 function setGrow(k,v){grow[k]=v;row.style.setProperty('--g-'+k,v);}
 for(var k in grow)setGrow(k,grow[k]);
-function key(id){return id==='chat-pane'?'chat':id==='fleet-pane'?'fleet':'feed';}
+function key(id){return id==='chat-pane'?'chat':id==='fleet-pane'?'fleet':id==='hive-pane'?'hive':'feed';}
 function shown(id){var p=document.getElementById(id);return p&&getComputedStyle(p).display!=='none';}
 // a pane re-shown from the rail gets a grow comparable to the panes already visible, so it never slots back
 // in as a sliver after the others were dragged to extreme widths (grows are stored as px). Timeline is the
@@ -19201,6 +19226,8 @@ window.removeEventListener('mousemove',mv);window.removeEventListener('mouseup',
 window.addEventListener('mousemove',mv);window.addEventListener('mouseup',up);});}
 gutter('gv-a',function(){return 'chat-pane';},'fleet-pane');
 gutter('gv-b',function(){return document.body.classList.contains('po-fleet')?'fleet-pane':'chat-pane';},'feed-pane');
+gutter('gv-c',function(){var b=document.body.classList;
+return b.contains('po-feed')?'feed-pane':b.contains('po-fleet')?'fleet-pane':'chat-pane';},'hive-pane');
 tf&&tf.addEventListener('load',function(){autosize();
 try{new ResizeObserver(autosize).observe(tf.contentDocument.body);}catch(e){}});
 window.addEventListener('resize',autosize);
@@ -19215,8 +19242,8 @@ window.addEventListener('romp-panes',autosize);   // re-fit when the Timeline to
 # all EVENT-based (no polling). Re-wires on every iframe (re)load; chat is the default focus on open. Inert on
 # mobile (one pane at a time; .pane is display:contents).
 _LANDING_FOCUS_JS = """
-(function(){var PANE={'f-chat':'chat-pane','f-fleet':'fleet-pane','f-feed':'feed-pane','f-timeline':'tl-pane'};   // Fleet is its own pane
-var COLS=['f-chat','f-fleet','f-feed'];   // the side-by-side column panes, left->right (Fleet = the Outline)
+(function(){var PANE={'f-chat':'chat-pane','f-fleet':'fleet-pane','f-feed':'feed-pane','f-hive':'hive-pane','f-timeline':'tl-pane'};   // Fleet is its own pane
+var COLS=['f-chat','f-fleet','f-feed','f-hive'];   // the side-by-side column panes, left->right (Fleet = the Outline)
 var TL='f-timeline';                       // the timeline is a bottom BAND under the columns
 var curFocus='f-chat', lastCol='f-chat';   // for Shift-Up out of the timeline: return to the last column used
 // The active pane gets a focus RING (.pane-focused). Same-origin iframes, so the shell sets it directly on
@@ -19415,7 +19442,7 @@ if(m&&m.romp==='notify'&&m.text)window.__rompNotify(m.kind||'error',m.text,
 var st={};
 function shown(k){return document.body.classList.contains('po-'+k);}
 function liveDown(){for(var k in st){if(st[k]==='down'&&shown(k))return true;}return false;}
-var PN={chat:'Chat',feed:'Feed',timeline:'Timeline',fleet:'Outline'};
+var PN={chat:'Chat',feed:'Feed',timeline:'Timeline',fleet:'Outline',hive:'Hive'};
 window.addEventListener('message',function(e){var m=e&&e.data;if(!m||m.romp!=='wsState')return;
 var s=(m.state==='up')?'up':'down',prev=st[m.app];st[m.app]=s;
 if(s==='down'&&prev!=='down'&&shown(m.app))
@@ -20624,16 +20651,17 @@ _STALE_JS = (
 # key,to?) so the legacy toggleFleet postMessage (_LANDING_FLEET_JS) routes through the same path.
 _LANDING_COLLAPSE_JS = """
 (function(){
-  var PK='romp-panes',po={chat:true,fleet:false,feed:true,timeline:true};
+  var PK='romp-panes',po={chat:true,fleet:false,feed:true,hive:false,timeline:true};
   try{var s=JSON.parse(localStorage.getItem(PK)||'null');if(s)po=Object.assign(po,s);}catch(e){}
   var qp=new URLSearchParams(location.search).get('panes');
-  if(qp!==null){po={chat:false,fleet:false,feed:false,timeline:false};qp.split(',').forEach(function(k){k=k.trim();if(k in po)po[k]=true;});}
+  if(qp!==null){po={chat:false,fleet:false,feed:false,hive:false,timeline:false};qp.split(',').forEach(function(k){k=k.trim();if(k in po)po[k]=true;});}
   function saveP(){try{localStorage.setItem(PK,JSON.stringify(po));}catch(e){}}
-  var LBL={chat:'chat',fleet:'fleet',feed:'feed',timeline:'timeline'};
+  var LBL={chat:'chat',fleet:'fleet',feed:'feed',hive:'hive',timeline:'timeline'};
   function apply(){
     document.body.classList.toggle('po-chat',!!po.chat);
     document.body.classList.toggle('po-fleet',!!po.fleet);
     document.body.classList.toggle('po-feed',!!po.feed);
+    document.body.classList.toggle('po-hive',!!po.hive);
     document.body.classList.toggle('po-timeline',!!po.timeline);
     Array.prototype.forEach.call(document.querySelectorAll('.rail-btn[data-pane]'),function(b){
       var k=b.getAttribute('data-pane');b.classList.toggle('on',!!po[k]);
@@ -21202,11 +21230,15 @@ def _landing():
             # the three TOP panes flex-grow by a per-pane var (resized by the gutters, persisted); toggling one
             # off hides it AND the now-orphaned gutters. Fixed order: chat, fleet, feed. Timeline is the band.
             "#chat-pane{flex:var(--g-chat,60) 1 0}#fleet-pane{flex:var(--g-fleet,34) 1 0}#feed-pane{flex:var(--g-feed,40) 1 0}"
+            "#hive-pane{flex:var(--g-hive,50) 1 0}"
             "body:not(.po-chat) #chat-pane{display:none}body:not(.po-fleet) #fleet-pane{display:none}body:not(.po-feed) #feed-pane{display:none}"
+            "body:not(.po-hive) #hive-pane{display:none}"
             ".row>.gv{flex:0 0 5px}"
             # gv-a sits chat|fleet (only when both shown); gv-b sits (fleet|chat)|feed — the chat|feed gutter when fleet off.
             "body:not(.po-chat) #gv-a,body:not(.po-fleet) #gv-a{display:none}"
             "body:not(.po-feed) #gv-b,body:not(.po-chat):not(.po-fleet) #gv-b{display:none}"
+            # gv-c sits (feed|fleet|chat)|hive — shown only when hive is on AND some column pane is left of it.
+            "body:not(.po-hive) #gv-c,body:not(.po-feed):not(.po-chat):not(.po-fleet) #gv-c{display:none}"
             # ── timeline BOTTOM BAND (the user 2026-06-25): a full-width band UNDER the pane row, shown only when
             # po-timeline (the rail's Timeline toggle); the gh gutter above it resizes it (auto-fits otherwise).
             # Band + gutter both hide when the toggle is off, so the pane row fills the height.
@@ -21257,7 +21289,7 @@ def _landing():
             ".pane.pane-focused::after{display:none}"
             # the Outline (fleet) rides the tab bar like every other pane (the user 2026-07-11, who couldn't
             # access the outline view in the mobile UI — it was desktop-only before)
-            "#chat-pane,#fleet-pane,#feed-pane,#tl-pane{display:contents!important}"
+            "#chat-pane,#fleet-pane,#feed-pane,#hive-pane,#tl-pane{display:contents!important}"
             # reset the desktop iframe absolute-fill (the bare `iframe` reset below re-flows them as tab panes)
             ".pane>iframe{position:static;inset:auto;width:100%;height:100%}"
             "iframe{position:static;display:none;width:100%;height:100%;border:0}"
@@ -21393,6 +21425,8 @@ def _landing():
             "<div class=pane id=fleet-pane><iframe id=f-fleet src=/fleet></iframe></div>"
             "<div class=gv id=gv-b></div>"
             "<div class=pane id=feed-pane><iframe id=f-feed src=/feed></iframe></div>"
+            "<div class=gv id=gv-c></div>"
+            "<div class=pane id=hive-pane><iframe id=f-hive src=/hive></iframe></div>"
             "</div>"
             # the timeline BOTTOM BAND: full-width below the pane row, with a row-resize gutter above it. Both
             # are hidden (CSS) unless po-timeline (the rail's Timeline toggle).
@@ -21409,6 +21443,7 @@ def _landing():
             "<div class=rail-btn data-pane=timeline>Timeline</div>"
             "<div class=rail-btn data-pane=fleet>Outline</div>"   # data-pane key stays 'fleet' (internal); the user-facing label is Outline
             "<div class=rail-btn data-pane=feed>Feed</div>"
+            "<div class=rail-btn data-pane=hive>Hive</div>"
             # the Claude /usage rate-limit bars (Pro/Max): three compact vertical bar-pairs (used % colored +
             # elapsed % slate), %-label, full detail on hover — side-by-side in the bottom bar.
             "<div id=rail-usage data-keycmd=usage.open></div>"
@@ -21945,6 +21980,9 @@ class Handler(BaseHTTPRequestHandler):
             if p == "/fleet":
                 _client_seen[0] = time.time()
                 return self._send(200, _fleet_page(), "text/html; charset=utf-8", cache="no-cache")
+            if p == "/hive":
+                _client_seen[0] = time.time()
+                return self._send(200, _hive_page(), "text/html; charset=utf-8", cache="no-cache")
             if p == "/sw.js":
                 # the push service worker (see _SW_JS). Behind the gate on purpose: the browser's
                 # register() fetch is same-origin and carries the cookie, and only an authed shell

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21865,15 +21865,34 @@ class Handler(BaseHTTPRequestHandler):
 
     def _file_preview(self, q, head=False):
         """GET/HEAD /file — the preview bytes behind a chat path-thumbnail / feed artifact strip (the
-        user 2026-07-08). Same path resolution as click-to-open (~ expanded, relative → the session's
-        cwd — _resolve_open_path); RENDERABLE media only (_PREVIEW_MIME), anything else 404s and the
-        client keeps its plain link. Oversize 413s rather than silently truncating. HEAD is the
-        existence probe for a chip that can't self-verify like an <img> (a PDF): headers only, so a
+        user 2026-07-08), and since 2026-08-14 the OPEN behind a remote path click: renderable media
+        (_PREVIEW_MIME) serves natively, text serves inline, anything else downloads — a devbox
+        session's file has no other way onto the viewer's screen, so a click must always land
+        something. Same path resolution as click-to-open (~ expanded, relative → the session's cwd —
+        _resolve_open_path). Oversize 413s rather than silently truncating. HEAD is the existence
+        probe for a chip that can't self-verify like an <img> (a PDF): headers only, so a
         since-deleted file costs no download and never shows a dead chip."""
         fp = _resolve_open_path((q.get("path") or [""])[0], (q.get("sid") or [None])[0])
-        mime = _PREVIEW_MIME.get(os.path.splitext(fp)[1].lower())
-        if not mime or not os.path.isabs(fp) or not os.path.isfile(fp):
+        if not os.path.isabs(fp) or not os.path.isfile(fp):
             return self._send(404, b"" if head else "not found", "text/plain")
+        mime = _PREVIEW_MIME.get(os.path.splitext(fp)[1].lower())
+        dispo = None
+        if not mime:
+            # OPEN-on-click, not just previews (the user 2026-08-14): a REMOTE session's path can only
+            # open on the viewer's screen through this route, so a non-media file must still land
+            # something — text (no NUL in the first 8KB) serves inline as text/plain, anything else
+            # downloads (the browser's `open` for a binary). The client previews still key on
+            # _PREVIEW_MIME kinds; this widens only what a deliberate click can fetch.
+            try:
+                with open(fp, "rb") as f:
+                    sniff = f.read(8192)
+            except OSError:
+                return self._send(404, b"" if head else "not found", "text/plain")
+            if b"\x00" not in sniff:
+                mime = "text/plain; charset=utf-8"
+            else:
+                mime = "application/octet-stream"
+                dispo = 'attachment; filename="%s"' % os.path.basename(fp).replace('"', "")
         size = os.path.getsize(fp)
         if size > _PREVIEW_MAX_BYTES:
             return self._send(413, b"" if head else "too large to preview", "text/plain")
@@ -21882,13 +21901,16 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", mime)
             self.send_header("Content-Length", str(size))   # the real length, no body (HEAD semantics)
             self.send_header("Cache-Control", "no-cache")
+            if dispo:
+                self.send_header("Content-Disposition", dispo)
             if getattr(self, "_cors_origin", None):         # the chat's fetch-HEAD probe rides CORS too
                 self.send_header("Access-Control-Allow-Origin", self._cors_origin)
                 self.send_header("Vary", "Origin")
             self.end_headers()
             return
         with open(fp, "rb") as f:
-            return self._send(200, f.read(), mime, cache="no-cache")
+            return self._send(200, f.read(), mime, cache="no-cache",
+                              headers={"Content-Disposition": dispo} if dispo else None)
 
     def do_OPTIONS(self):
         """CORS preflight. The strip's tunnel actions POST JSON (Content-Type:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19310,6 +19310,12 @@ if(!window.__rompPaneToggle)return;
 if(m.to==='chat')window.__rompPaneToggle('chat',true);
 else if(m.to==='fleet')window.__rompPaneToggle('fleet',true);
 else window.__rompPaneToggle('fleet');});})();
+(function(){window.addEventListener('message',function(e){var m=e.data;if(!m||m.romp!=='openPicker')return;
+// the hive's ghost hex: reveal the chat pane, then hand the ask into its iframe — the
+// picker lives there (render.ts openPicker), and the shell lifts it full-screen as usual
+if(window.__rompPaneToggle)window.__rompPaneToggle('chat',true);
+var f=document.getElementById('f-chat');
+if(f&&f.contentWindow)try{f.contentWindow.postMessage({romp:'openPicker'},'*');}catch(err){}});})();
 """
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1240,15 +1240,22 @@ def _alive_sessions(now, tmux):
     So: tmux reachable (sessions present, or a tmux binary exists) → trust the empty result and show
     only living sessions; no tmux at all → fall back so a headless box isn't blank."""
     alive = [s for s in _sessions(now) if s["sid"] in tmux]
-    # SDK sessions that are alive (in the merged `tmux` map) but have no transcript on disk yet — a
-    # just-created or never-run SDK session — aren't in discover()/_sessions, so add them here, else
-    # their tab never opens (the user 2026-06-22). Once they run and write a transcript, discover takes over.
+    # Sessions that are alive (in the merged `tmux` map) but have no transcript on disk yet aren't in
+    # discover()/_sessions, so add them here, else their tab never opens (the user 2026-06-22, for SDK
+    # sessions). This covers BOTH backends (the user 2026-08-13): a tmux session writes no transcript
+    # record until its first MESSAGE, so a freshly created one — or one parked on the CLI's first-run
+    # folder-trust prompt, which can sit there indefinitely — was filtered off every surface while
+    # running perfectly well. The client then never got a payload for the tab it was holding open, and
+    # its create cue timed out with "Couldn't start", naming a session that had in fact started. That
+    # is the exact silent-degradation the fail-loudly rule forbids: the session existed, so it must be
+    # SHOWN (build_session already synthesizes a frame for this case) and left to say what state it is
+    # in. Once it runs and writes a transcript, discover() takes over.
     be = _sdk()
-    if be:
-        have = {s["sid"] for s in alive}
-        for sid in tmux:
-            if sid not in have and be.owns(sid):
-                alive.append(_sdk_sess(sid, now))
+    have = {s["sid"] for s in alive}
+    for sid in tmux:
+        if sid in have:
+            continue
+        alive.append(_sdk_sess(sid, now) if (be and be.owns(sid)) else _tmux_sess(sid, now))
     if tmux or _has_tmux():
         return alive
     return _sessions(now)
@@ -4073,6 +4080,45 @@ def _set_default_dir(raw):
     return path, None
 
 
+_DEFAULT_HOST_FILE = Path(os.path.expanduser("~/.config/romp/default-host"))
+
+
+def _default_create_host():
+    """The machine a NEW session is created on by default — an attached host's name, or "" for this one.
+
+    A FILE for the same reason default-dir is one: the choice has to survive a kernel restart and reach a
+    launchd-rooted process that never sees a shell env var. The client preselects it in the + picker's Host
+    row and the hive tray drops on it, so someone who works on one box all day stops re-picking it every
+    time (the user 2026-08-13, whose sessions all live on a remote machine — the local laptop was never the
+    one they wanted). Not validated against the attached set here: a host can be detached and re-attached,
+    and a stored name that isn't up right now is still the right answer once it comes back; the client falls
+    back to this machine when the name isn't on its list."""
+    try:
+        return _DEFAULT_HOST_FILE.read_text().strip()
+    except OSError:
+        return ""
+
+
+def _set_default_host(raw):
+    """Persist (or clear) the default create host → (name_or_'', error). Blank CLEARS (back to this
+    machine). The name is an ssh host alias, the same string the tunnel registry is keyed by."""
+    name = (raw or "").strip()
+    if not name:
+        try:
+            _DEFAULT_HOST_FILE.unlink()
+        except OSError:
+            pass
+        return "", None
+    if not _safe_ssh_host(name):        # the same gate the tunnel dialer applies (resolved at call time)
+        return None, "not a host name: %r" % name
+    try:
+        _DEFAULT_HOST_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _DEFAULT_HOST_FILE.write_text(name + "\n")
+    except OSError as e:
+        return None, "could not save default host: %s" % e
+    return name, None
+
+
 def _true_case(path):
     """`path` (absolute) with every component in its true on-disk casing. os.path.realpath resolves
     symlinks but never case-corrects, and on macOS's case-insensitive filesystem a typed
@@ -4250,16 +4296,25 @@ def _reap_if_cancelled(name):
             _end_pending_sid(sid)
 
 
-def _spawn_session(name, cwd=None):
+def _spawn_session(name, cwd=None, model="", effort=""):
     """Create a detached romp session named `name` — the same launch the old TS backend ran
     (`romp new -t --detach <name>`, tmux-backend.ts). Threaded so the ~seconds-long launch never blocks the WS
     recv loop; the targeted push below then delivers the new tab. Scrub
     TMUX* so the child launcher never thinks it is already inside a tmux client. `cwd` is the session's
-    working directory (validated by _resolve_create_dir); None falls back to the kernel default."""
+    working directory (validated by _resolve_create_dir); None falls back to the kernel default.
+
+    `model`/`effort` are an explicit per-spawn choice (the hive tray's bean drop) forwarded to the
+    launcher, which otherwise reads the session-defaults file. Passed as separate argv items — never
+    interpolated — and the launcher validates them again before they reach the CLI's command line."""
     cwd = cwd or _default_create_dir()
     env = {k: v for k, v in os.environ.items() if k not in ("TMUX", "TMUX_PANE")}
+    argv = [str(BIN / "romp"), "new", "-t", "--detach", name]
+    if model in _MODEL_VALUES:
+        argv += ["--model", model]
+    if effort in _EFFORT_VALUES:
+        argv += ["--effort", effort]
     try:
-        subprocess.run([str(BIN / "romp"), "new", "-t", "--detach", name], cwd=cwd, env=env, timeout=25,
+        subprocess.run(argv, cwd=cwd, env=env, timeout=25,
                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except Exception:
         sys.stderr.write("spawn '%s': %s\n" % (name, traceback.format_exc()))
@@ -12324,6 +12379,15 @@ def _sdk_transcript_path(sid):
     except OSError:
         cwd = os.path.expanduser("~")
     return jd._proj_dir(cwd) / (sid + ".jsonl")
+
+
+def _tmux_sess(sid, now):
+    """A _sessions()-shaped entry for a LIVE tmux session discover() can't see yet — the CLI is up but has
+    written no transcript record (its first lands with the first message; a session parked on the CLI's
+    first-run folder-trust prompt never gets there at all). Same sentinel-path stub build_session
+    synthesizes for this case, so the two agree on what a transcriptless tmux session looks like."""
+    return {"sid": sid, "name": _name_of(sid) or sid[:8],
+            "path": str(jd.STATE / "boot-stub" / (sid + ".jsonl")), "mtime": now}
 
 
 def _sdk_sess(sid, now):
@@ -21912,8 +21976,15 @@ class Handler(BaseHTTPRequestHandler):
                 except (OSError, ValueError):
                     _sd = {}
                 _sd = _sd if isinstance(_sd, dict) else {}
+                _defaults = {k: _sd[k] for k in ("model", "effort") if _sd.get(k)}
+                # …and WHERE a tray drop lands (the user 2026-08-13): the same default create host the +
+                # picker preselects, so both spawn surfaces agree on the machine without the tray having
+                # to ask a second endpoint. "" = this machine (key omitted).
+                _dh = _default_create_host()
+                if _dh:
+                    _defaults["host"] = _dh
                 return self._send(200, json.dumps({"models": MODEL_CHOICES, "efforts": EFFORT_CHOICES,
-                                                   "defaults": {k: _sd[k] for k in ("model", "effort") if _sd.get(k)}}),
+                                                   "defaults": _defaults}),
                                   "application/json", cache="no-cache")
             if p == "/usage":                                 # the /usage rate-limit bars, re-read on demand: the rail's
                 # usage widget is click-to-refresh (the user 2026-06-30). Returns the freshest on-disk snapshot
@@ -22952,6 +23023,12 @@ class Handler(BaseHTTPRequestHandler):
                 # "that folder doesn't exist" dialog and chose to make it (see createDirMissing below).
                 cwd, derr = _resolve_create_dir(msg.get("dir"), create=bool(msg.get("mkdir")))
                 live = _live_names(_tmux_sessions())
+                # model/effort: the hive tray's per-spawn choice (the user 2026-08-13) — an explicit
+                # alias/level from the /models lists outranks the remembered seed for this one session;
+                # anything else means the seed, exactly as before. Vetted ONCE here because BOTH backends
+                # take them now.
+                mdl0 = msg.get("model") if msg.get("model") in _MODEL_VALUES else ""
+                eff0 = msg.get("effort") if msg.get("effort") in _EFFORT_VALUES else ""
                 if derr:
                     st = _dir_status(msg.get("dir"))
                     if st["canCreate"] and not msg.get("mkdir"):
@@ -22975,19 +23052,18 @@ class Handler(BaseHTTPRequestHandler):
                         # auth ('login'|'key') is the picker's per-session billing pick; anything else
                         # (older clients, no pick) means the remembered/ambient default (spawn's seed).
                         a = msg.get("auth")
-                        # model/effort: the hive tray's per-spawn choice (the user 2026-08-13) — an
-                        # explicit alias/level from the /models lists outranks the remembered seed for
-                        # this one session; anything else means the seed, exactly as before.
-                        mdl = msg.get("model") if msg.get("model") in _MODEL_VALUES else ""
-                        eff = msg.get("effort") if msg.get("effort") in _EFFORT_VALUES else ""
                         _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""),
-                                            model=mdl, effort=eff)
+                                            model=mdl0, effort=eff0)
                     else:
                         # NEVER silently fall back to tmux (the user asked for SDK and got a mystery tmux
                         # session on a remote host without the venv, 2026-07-02). Say what's missing.
                         client["send"](json.dumps({"type": "warn", "text": SDK_SETUP_HINT}))
                 else:
-                    threading.Thread(target=_spawn_session, args=(nm, cwd), daemon=True).start()
+                    # tmux create: the tray's per-spawn model/effort ride along too (the user 2026-08-13),
+                    # so a bean drop means the same thing whichever backend the board is set to — before
+                    # this, a tmux drop silently ignored the bean and took the launcher's own default.
+                    threading.Thread(target=_spawn_session, args=(nm, cwd),
+                                     kwargs={"model": mdl0, "effort": eff0}, daemon=True).start()
         elif msg and msg.get("type") == "cancelCreate" and msg.get("name"):
             # The webview's "Opening…" cue was cancelled (the ✕/Esc/backdrop — the spawn hung/failed, or the
             # user changed their mind). We only know the NAME (no id yet). Tear down a matching LOCAL session
@@ -23007,6 +23083,10 @@ class Handler(BaseHTTPRequestHandler):
             client["send"](json.dumps({"type": "sessionList",
                                        "items": _session_list(int(time.time()), _tmux_sessions()),
                                        "defaultDir": _tilde(_default_create_dir()),   # prefill the new-session dir field
+                                       # …and which MACHINE that create lands on by default (~/.config/romp/
+                                       # default-host, `romp default-host`): the picker preselects it in the
+                                       # Host row and the hive tray drops onto it. "" = this machine.
+                                       "defaultHost": _default_create_host(),
                                        # …and whether Browse… can do anything here, so a kernel with no
                                        # desktop shows the button as unavailable rather than inert.
                                        "nativeDialogs": _native_dialogs(),

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15209,6 +15209,10 @@ def build_feed(now, tmux=None):
     # QUARANTINED PEER MAIL (per-host trust model): mail from a DIRECTED federated host is held, never
     # auto-injected — each is a human decision (approve/deny/edit), so it surfaces as a needs-you card.
     asks.extend(_quarantine_cards(now, cleared))
+    # HOOKLESS HOST (fail loudly, never degrade silently): terminal sessions whose @claude-state has
+    # never been written have no state source at all — say so as a needs-you card instead of letting
+    # every status surface quietly read calm (see _hookless_tmux_card).
+    asks.extend(_hookless_tmux_card(now, tmux, alive, cleared))
     # per-card bell (the user 2026-07-28): one pass over the FINAL ask list — goal cards, placeholders,
     # parked handoffs and quarantine cards alike — so every card's right-click menu reflects its armed
     # state, EFFECTIVE (card override > session override > the master default, 2026-08-09) — with the
@@ -15721,6 +15725,48 @@ def _quarantine_cards(now, cleared):
             "tree": []})
     out.sort(key=lambda c: c["t"])
     return out
+
+
+def _hookless_tmux_card(now, tmux, alive, cleared):
+    """ONE needs-you card when terminal sessions on THIS host are running with romp's Claude Code
+    hooks not firing — the authoritative-sources rule's loud half: without the hooks there is NO
+    state source for a tmux session (@claude-state stays empty), so the chip can never say
+    Awaiting, a live permission prompt reads Working, and the hive/feed never light up — silently
+    (the user 2026-08-13, whose fresh remote host skipped install.sh and lost exactly that).
+
+    Evidence is per-session and event-exact, no timers: a live tmux-backend session that HAS a
+    conversation (its SessionStart/UserPromptSubmit hooks would have fired long before the first
+    user turn landed on disk) yet whose @claude-state has never been written. Config guesses
+    (parsing settings.json) are deliberately not the trigger — a registered-but-broken hook must
+    trip this too. itemId 'hooks:<host>' rides cleared.jsonl so a Clear dismisses it for good on
+    that host. blocked stays None on purpose: feed.ts's ⏸ chip speaks permission/picker only, and
+    the card face already carries the remedy via blockSummary (the decision-brief line)."""
+    dark = sorted(s["name"] for s in alive
+                  if (tmux.get(s["sid"]) or {}).get("backend") == "tmux"
+                  and not (tmux.get(s["sid"]) or {}).get("state")
+                  and _session_has_history(s["sid"]))
+    if not dark:
+        return []
+    host = _self_host()
+    item_id = "hooks:" + host
+    if item_id in cleared:
+        return []
+    return [{
+        "itemId": item_id, "sid": "", "name": host, "color": None,
+        "text": "Terminal sessions here aren't reporting their state",
+        "t": now, "live": False,
+        "trgb": list(cm.age_rgb(0, _colormap())),
+        "turnId": item_id, "origin": None,
+        "followupPending": None, "waitingOn": None,
+        "summary": None, "background": None, "summaryAnchorUuid": None, "warns": None,
+        "nudged": None, "blocked": None,
+        "blockSummary": "romp's Claude Code hooks aren't firing on %s, so %s can't report "
+                        "working / needs-input / mode — a session stopped on a question will look "
+                        "calm everywhere. Run install.sh from the romp clone on %s, then relaunch "
+                        "the affected sessions (a running Claude only picks hooks up at launch)."
+                        % (host, ", ".join(dark[:6]) + (" +%d more" % (len(dark) - 6) if len(dark) > 6 else ""), host),
+        "column": "needs_input",
+        "tree": []}]
 
 
 def _seg_anchors(atoms):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5405,8 +5405,20 @@ def _open_or_revive(sid, live=False):
     """openSession routing: a LIVE session → focus the chat (its tab is always shown); a DEAD one → the
     confirmRevive modal (no silent reopen, no auto read-only tab — the user 2026-06-17). `live` (the user
     2026-07-08): land the chat on its LIVE TAIL, not the last scroll — a blocked card's picker/permission
-    prompt is the live bottom, so its feed chip drops you right on it."""
-    if sid in _tmux_sessions():
+    prompt is the live bottom, so its feed chip drops you right on it.
+
+    ORDER (the user 2026-08-13, who clocked the switch at one to two seconds): the focus frame goes
+    out FIRST — the chat flips its always-shown tab instantly on what it already holds — and the
+    slow work follows: the SDK eager-connect (which dials a session this chat hasn't touched yet;
+    kept for the reasons below) and the full push that freshens every client. Before this, connect
+    + _push_all ran ahead of the focus, so the one frame that actually switches the tab queued
+    behind seconds of build."""
+    live_now = sid in _tmux_sessions()
+    focus = {"type": "focus", "id": sid}
+    if live:
+        focus["live"] = True
+    _reveal_or_confirm(sid, focus)
+    if live_now:
         be = _sdk()
         if be:
             be.connect(sid)   # SDK: eager-connect on OPEN (idempotent; no-op for tmux/unknown sids) so the
@@ -5414,10 +5426,6 @@ def _open_or_revive(sid, live=False):
                               # is changeable BEFORE the first message — not only after one (the user 2026-06-24:
                               # opening an SDK session showed no model/effort until a message was sent).
         _push_all()
-    focus = {"type": "focus", "id": sid}
-    if live:
-        focus["live"] = True
-    _reveal_or_confirm(sid, focus)
 
 
 def _revive_session(sid):

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1441,7 +1441,13 @@ class SdkSession:
             # call, and the very next snapshot() must already read 'interrupting' — otherwise the chip/feed
             # badge would miss the click and only catch up an event-loop tick later (the flicker this whole
             # signal exists to kill). _do_interrupt sets it again (harmless); the ResultMessage clears it.
-            self._interrupted = True
+            # ONLY when a turn exists for the stop to stop (the same guard _signal_cli carries): the flag's
+            # sole clear events are that turn's ResultMessage / a fresh turn, so latching on an IDLE press
+            # left the snapshot 'interrupting' FOREVER — every later stop press then bought another 120s of
+            # 'stopping…' off the eternal flag, which is exactly "it never goes back to normal" (the user
+            # 2026-08-14; the 2026-07-20 strand, polite-channel flavor).
+            if self.inflight > 0:
+                self._interrupted = True
             self.loop.call_soon_threadsafe(
                 lambda: asyncio.ensure_future(self._do_interrupt()))
             return
@@ -1536,8 +1542,11 @@ class SdkSession:
         # forcing inflight=0 here too would double-count and corrupt the next turn's release. The snapshot
         # reads 'waiting' while inflight>0 (kills the 2026-06-23 zombie-working); a truly-wedged turn that
         # never results keeps inflight>0 and PAUSES the queue — honest (kill recovers). A fresh turn clears
-        # _interrupted (see inputs()), and the ResultMessage clears it too.
-        self._interrupted = True
+        # _interrupted (see inputs()), and the ResultMessage clears it too — which is exactly why an IDLE
+        # press must NOT latch it (no turn → no clear event → 'interrupting' forever; interrupt() and
+        # _signal_cli carry the same inflight guard).
+        if self.inflight > 0:
+            self._interrupted = True
         self.backend._poke()
         try:
             await self.client.interrupt()

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1111,6 +1111,40 @@ def write_sdk_default(state_dir: Path, **fields) -> None:
     os.replace(tmp, p)
 
 
+# The launch-defaults FILE's validation — bin/romp's exact rules, kept in lockstep so the two
+# spawn paths can never accept different values for the same line (the launcher's regexes are
+# the reference; tests pin both). EFFORT deliberately excludes ultracode: per-session only.
+_SD_MODEL_RE = re.compile(r"^[A-Za-z0-9._-]+(\[[0-9]+[a-z]\])?$")
+_SD_EFFORTS = ("low", "medium", "high", "xhigh", "max")
+_SD_MODES = ("acceptEdits", "auto", "bypassPermissions", "manual", "dontAsk", "plan")
+
+
+def read_session_defaults() -> dict:
+    """The user's per-session LAUNCH defaults — ~/.config/romp/session-defaults, the SAME KEY=VALUE
+    file bin/romp's tmux launcher reads (the user 2026-08-13: ONE answer for what a new session
+    launches as). This is the SDK spawn's copy of that answer: without it the file governed tmux
+    launches only, and a board/tray spawn quietly kept the remembered-last-pick mode — the user set
+    PERM_MODE=auto and still watched an SDK session launch asking for permissions. Parsed
+    line-by-line and validated with the launcher's exact rules (values UNstripped, as in bash),
+    never sourced; malformed lines are skipped. {} when absent. Keys out: model / effort / mode."""
+    out: dict = {}
+    try:
+        lines = (Path(os.path.expanduser("~")) / ".config" / "romp" / "session-defaults").read_text().splitlines()
+    except OSError:
+        return out
+    for line in lines:
+        k, eq, v = line.partition("=")
+        if not eq:
+            continue
+        if k == "MODEL" and _SD_MODEL_RE.match(v):
+            out["model"] = v
+        elif k == "EFFORT" and v in _SD_EFFORTS:
+            out["effort"] = v
+        elif k == "PERM_MODE" and v in _SD_MODES:
+            out["mode"] = v
+    return out
+
+
 _WORK_KEY: str | None = None   # process-lifetime stash; None = not yet claimed from the environment
 
 
@@ -3406,15 +3440,19 @@ class SdkBackend:
         # fills in on connect from get_context_usage(). The seed lands in THIS session's reg — exactly what
         # _options launches with and what the badge reads — so the display can never desync from what's used.
         d = read_sdk_defaults(self.state_dir)
-        # An EXPLICIT per-spawn choice (the hive tray's model bean, the user 2026-08-13) outranks the
-        # remembered seed for THIS session only — the seed itself is untouched, so a one-off Haiku
-        # spawn never silently becomes everyone's default.
+        # Precedence, most deliberate first: an EXPLICIT per-spawn choice (the hive tray's model
+        # bean, the user 2026-08-13) > the launch-defaults FILE (~/.config/romp/session-defaults —
+        # the user's declared one answer, same file the tmux launcher reads) > the remembered
+        # last-pick seed > the hardcoded floor. The seed itself is untouched by the first two, so
+        # a one-off Haiku spawn never silently becomes everyone's default.
+        sd = read_session_defaults()
         eff = (effort if effort in EFFORT_LEVELS
+               else sd["effort"] if sd.get("effort") in EFFORT_LEVELS
                else d.get("effort") if d.get("effort") in EFFORT_LEVELS else DEFAULT_EFFORT)
-        mode = d.get("mode") or "acceptEdits"   # seed the permission mode from the remembered default too (the user 2026-06-27)
+        mode = sd.get("mode") or d.get("mode") or "acceptEdits"   # the file, else the remembered default (the user 2026-06-27)
         reg = {"sid": sid, "name": name, "cwd": cwd, "mode": mode,
                "effort": eff, "lastSid": "", "alive": True}
-        m = model or d.get("model")
+        m = model or sd.get("model") or d.get("model")
         if m and m != "default":
             reg["model"] = m
         # Auth: the picker's explicit pick wins; else the remembered default (a gear /auth pick on any

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3393,7 +3393,7 @@ class SdkBackend:
 
     # ---- lifecycle (kernel-thread API) ----
     def spawn(self, name: str, cwd: str, bg: str = "", fg: str = "", sid: str | None = None,
-              auth: str = "") -> str:
+              auth: str = "", model: str = "", effort: str = "") -> str:
         sid = sid or str(uuid.uuid4())
         cwd = os.path.realpath(cwd) if os.path.exists(cwd) else cwd
         if not bg:                                   # give the session a stable identity colour like tmux sessions get
@@ -3406,12 +3406,17 @@ class SdkBackend:
         # fills in on connect from get_context_usage(). The seed lands in THIS session's reg — exactly what
         # _options launches with and what the badge reads — so the display can never desync from what's used.
         d = read_sdk_defaults(self.state_dir)
-        eff = d.get("effort") if d.get("effort") in EFFORT_LEVELS else DEFAULT_EFFORT
+        # An EXPLICIT per-spawn choice (the hive tray's model bean, the user 2026-08-13) outranks the
+        # remembered seed for THIS session only — the seed itself is untouched, so a one-off Haiku
+        # spawn never silently becomes everyone's default.
+        eff = (effort if effort in EFFORT_LEVELS
+               else d.get("effort") if d.get("effort") in EFFORT_LEVELS else DEFAULT_EFFORT)
         mode = d.get("mode") or "acceptEdits"   # seed the permission mode from the remembered default too (the user 2026-06-27)
         reg = {"sid": sid, "name": name, "cwd": cwd, "mode": mode,
                "effort": eff, "lastSid": "", "alive": True}
-        if d.get("model") and d["model"] != "default":
-            reg["model"] = d["model"]
+        m = model or d.get("model")
+        if m and m != "default":
+            reg["model"] = m
         # Auth: the picker's explicit pick wins; else the remembered default (a gear /auth pick on any
         # session); unset stays unset — effective_auth's fallback IS the pre-selector behavior.
         a = auth if auth in ("login", "key") else (d.get("auth") if d.get("auth") in ("login", "key") else "")
@@ -3981,6 +3986,12 @@ class SdkBackend:
     def rewind_files(self, sid: str, uuid: str) -> bool:
         s = self.sessions.get(sid)
         return bool(s and s.request_rewind_files(uuid))
+
+    def set_spawn_defaults(self, model: str | None = None, effort: str | None = None) -> None:
+        """An explicit 'make this my default' (the hive tray's bean click, the user 2026-08-13) — the
+        same store the statusline picks feed implicitly (write_sdk_default), set deliberately. The
+        caller validates values against the choice lists; None leaves that field alone."""
+        write_sdk_default(self.state_dir, model=model, effort=effort)
 
     def set_effort(self, sid: str, value: str) -> bool:
         """Change the reasoning effort. effort is a connect-time CLI flag (--effort) with no SDK runtime

--- a/plans/hive.md
+++ b/plans/hive.md
@@ -1,0 +1,148 @@
+# Hive — a game-feel command view of your sessions
+
+A fifth dashboard pane: a 3D honeycomb diorama, one hex pad per session, a small
+friendly character on each pad acting out what that session is doing right now.
+Halo-Wars-style tactical camera; click a hex to fly in, read the gist, and talk
+to that session. The aim is the Philosophy's "spend attention, don't drain it"
+rendered literally: the whole board is glanceable posture + color, and every
+mechanic is one click deeper.
+
+## Why a game view earns its place
+
+- **Glanceable by default.** Posture is pre-attentive: a slumped character reads
+  as "broken" faster than a red badge. State is DOUBLE-encoded (silhouette +
+  status color) so it survives color-blindness and small sizes.
+- **Interrupt only when the human is the bottleneck.** Exactly one state gets a
+  look-at-me animation (waving/jumping + ❗): `awaiting` — a live permission or
+  picker prompt, the one state that IS the user's bottleneck. Everything else is
+  calm ambient motion.
+- **Make re-engagement cheap.** The fly-in card leads with the outcome language
+  the feed already computes (goal text, decision brief, open-turn narration) —
+  never play-by-play.
+- **Never lose the thread.** Hex slots are stable: a session keeps its hex for
+  its whole life (persisted), so spatial memory works like a real base layout.
+
+## Architecture (all decisions verified against the tree, 2026-08-13)
+
+- **Pane, not page.** `#hive-pane` + `<iframe id=f-hive src=/hive>` joins the
+  landing's flex row (chat | outline | feed | hive | timeline order TBD at the
+  gutter chain), with a `Hive` rail button, `po-hive` visibility class, grow var,
+  gutter, and an entry in the shell's `PANE` wsState map. Desktop first; the
+  mobile tab bar keeps its current three panes (the hex world is a poor phone
+  fit until proven otherwise).
+- **Data: the existing feed/ledgers channel, zero push-loop changes.** The page
+  boots `_shim("fleet")`; the kernel already treats `app=fleet` as a feed rider
+  (`c["app"] in ("feed","fleet")` in the push loop) and attaches `ledgers`
+  whenever such a client is connected. (`app=fleet` is the existing wire name of
+  that channel — reused, not new vocabulary.) Everything the hive needs is
+  already in that payload:
+  - `ledgers[]` → sid, name, identity color, `status.state` (the shared chip:
+    clearing / compacting / interrupting / blocked / awaiting / retrying /
+    working / awaitingBg / ready, plus opening and faded), goal tree.
+  - `asks[]` → per-goal cards: column, goal text, blockSummary (decision brief),
+    background, `working` (open-turn narration), awaiting {why, tasks},
+    waitingOn (peer), provisional.
+  - `working[]` / `awaiting[]` name lists ride along.
+- **Renderer: three.js**, installed as a dependency of `vscode-extension/`
+  (which owns `node_modules`; esbuild's `nodePaths` already resolves from
+  there), bundled into `dist/hive.js` like every other pane bundle. No external
+  assets at runtime: all geometry is procedural primitives, all textures are
+  generated (canvas gradients) — nothing to ship, nothing to leak.
+- **Files.** `ui/webview/hive.ts` (boot + scene), pure logic split for node
+  tests: `hive-layout.ts` (axial spiral, stable slot assignment),
+  `hive-model.ts` (payload → HiveSession[] + DIFF events). `hive-pane.css` for
+  the page frame + overlay card. esbuild entries: `hive.ts`, `hive-pane.css`.
+
+## The model: state in, events out (CLAUDE.md "cards move on new information")
+
+`hive-model.ts` consumes each feed push and emits a minimal event stream the
+scene animates from — the scene is NEVER rebuilt per push:
+
+- `added(sid, slot)` / `removed(sid)` — session appeared / left the ledgers.
+- `stateChanged(sid, from, to)` — the chip moved. Identical re-pushes emit
+  NOTHING (tested), so animations can't flap without new information.
+- `goalDone(sid)` — a top goal for that sid transitioned to done → one-shot
+  celebration. Keyed on the observed done-transition (the fleet's `seenDone`
+  pattern), never re-derived per build.
+- Slot assignment: sid→slot map in localStorage (`romp:hiveSlots`); a new
+  session takes the lowest free spiral slot; a removed session frees its slot
+  only after the departure animation lands. The board never reshuffles.
+
+## State → performance (the whole cast)
+
+| chip | pad ring | the little guy |
+|---|---|---|
+| working | soft yellow pulse | sits at a tiny desk, typing bursts, screen glow, keystroke sparks |
+| awaiting (needs YOU) | strong red pulse | stands, faces camera, waves/jumps, bobbing ❗ overhead |
+| blocked (API error) | steady red | slumped, head in hands, laptop smoking |
+| retrying | amber flicker | paces the pad, glancing back at the laptop |
+| awaitingBg | straw/green | leans back, watches a slowly-spinning hourglass overhead |
+| compacting / clearing | teal swirl orbit | levitating cross-legged meditation |
+| interrupting | dims briefly | freeze mid-pose + squash |
+| ready | calm green | breathing idle, look-arounds, stretch; `faded` (>1h) → asleep, zzz motes |
+| opening | pale shimmer | an egg wobbles, cracks, the character pops out (one-shot) |
+| (session gone) | — | waves goodbye, hops off, pad sinks + fades (one-shot, then slot frees) |
+| goalDone event | — | jump + arms up + confetti burst over the pad (one-shot overlay on any state) |
+
+Ambient life for everyone: blink (3–7s), 2% breath scale, occasional head turns.
+Status colors reuse the standing meanings (working `--st-working-bg` yellow,
+blocked/awaiting red family, ready `--st-ready-bg`, compacting teal); the romp
+accent `#9cd2ff` is reserved for selection/hover/focus chrome, never status.
+
+## Camera & feel (the game-design checklist)
+
+- Perspective tactical view, ~40° elevation, auto-framed to the occupied hexes;
+  slow idle orbit drift. Wheel = dolly, drag = orbit/pan, double-click empty
+  ground = re-frame all.
+- Every motion is a critically-damped spring (position, ring color, pad lift) —
+  overshoot on arrivals, no linear lerps, nothing teleports.
+- Hover: pad lifts ~0.1u + rim brightens inside 100ms; cursor pointer.
+- Click: immediate press-dip on the pad (acknowledge FIRST, per CLAUDE.md
+  click-safety rule), then the ~0.8s fly-to; ESC / ✕ flies back.
+- Reward moments are honest: confetti only on a real goalDone event.
+- Empty ghost hex at the spiral frontier: hovering shows a soft "+" — click
+  opens the session picker (`window.parent.postMessage` picker reveal). Later
+  iteration if the wiring fights back.
+- Perf: DPR ≤ 2; ≤ 32 fully-animated characters, LOD bob beyond; rAF gated by
+  IntersectionObserver (pane hidden = display:none iframe → not intersecting)
+  AND document.hidden; pause = zero GPU work. The romp loader (`_pane_spin`)
+  holds until the first ledgers land, exactly like the outline pane.
+
+## The fly-in card (progressive disclosure, pane-local)
+
+DOM overlay (not WebGL text), anchored to the pane's right edge, one card:
+
+1. **Gist line**: color dot + name + plain state ("working — 3 tools in, 2m" /
+   "needs you" / "ready").
+2. **Now**: current goal text; when blocked/awaiting, the decision brief
+   (blockSummary / awaiting.why) — the same words the feed card shows.
+3. **Sub-goals**: top few checklist rows, "…and N more" behind an expand.
+4. **Talk**: a composer. Send posts the user's text into that session over the
+   pane's own channel (the kernel's existing text-delivery message; verify the
+   exact type at the `_send_or_park` call site ~kernel:5008 — if it's gated to
+   app=chat sockets, accept it from this channel too as a small kernel change).
+   Acknowledge instantly: composer clears + a paper-plane particle arcs from
+   the card to the hex. Delivery semantics are the kernel's normal park/forward.
+5. **Open session** → `openSession` postMessage + shell reveal of the chat pane.
+
+The card is a pane-local panel (CLAUDE.md: pane-local dialogs stay pane-local);
+it does NOT use the full-window modal lift. Menus, if any, wear the standard
+menu vocabulary from styles.css.
+
+## Tests (land with the feature, per CLAUDE.md)
+
+- `hive-layout.test.ts` — spiral coords, lowest-free-slot assignment, stability
+  across pushes, slot release after departure.
+- `hive-model.test.ts` — chip mapping for EVERY state above; diff events;
+  the no-flap invariant (identical payload twice → zero events); goalDone fires
+  once per done-transition.
+- `hive-wiring.test.ts` — pins the kernel landing/route strings + esbuild
+  entries (the prebuild.test.ts pattern) so the pane can't silently unwire.
+- All fixtures synthetic (`web`/`api`/`tests`, TESTHOST, placeholder UUIDs).
+
+## Deliberately later
+
+- VS Code extension surface (needs its own webview registration; the bundle
+  already ships in the VSIX harmlessly).
+- Mobile tab-bar entry; sound design (off unless asked); subagent satellite
+  mini-hexes budding off a session's pad; per-hex postal/teammate visual links.

--- a/plans/hive.md
+++ b/plans/hive.md
@@ -108,9 +108,10 @@ accent `#9cd2ff` is reserved for selection/hover/focus chrome, never status.
 - Click: immediate press-dip on the pad (acknowledge FIRST, per CLAUDE.md
   click-safety rule), then the ~0.8s fly-to; ESC / ✕ flies back.
 - Reward moments are honest: confetti only on a real goalDone event.
-- Empty ghost hex at the spiral frontier: hovering shows a soft "+" — click
-  opens the session picker (`window.parent.postMessage` picker reveal). Later
-  iteration if the wiring fights back.
+- Empty ghost hex at the spiral frontier (SHIPPED): a hairline outline on the
+  first free slot, deliberately quieter than any real pad; hover wakes its "+",
+  click asks the shell (`{romp:"openPicker"}`) to reveal chat + open the same
+  new-session picker the + tab uses.
 - Perf: DPR ≤ 2; ≤ 32 fully-animated characters, LOD bob beyond; rAF gated by
   IntersectionObserver (pane hidden = display:none iframe → not intersecting)
   AND document.hidden; pause = zero GPU work. The romp loader (`_pane_spin`)

--- a/plans/hive.md
+++ b/plans/hive.md
@@ -3,7 +3,15 @@
 A fifth dashboard pane: a 3D honeycomb diorama, one hex pad per session, a small
 friendly character on each pad acting out what that session is doing right now.
 Halo-Wars-style tactical camera; click a hex to fly in, read the gist, and talk
-to that session. The aim is the Philosophy's "spend attention, don't drain it"
+to that session.
+
+**Art direction (the user, 2026-08-13):** the world is TRON — near-black glossy
+ground with a faint accent grid, pads as dark slabs whose status color is their
+glowing rim, bloom doing the neon work — and the characters are CUTE AND BLOBBY
+(Fall Guys / PEAK): session-colored bean bodies with squash-and-stretch, dark
+glossy visors, glowing eyes, stubby arms. Not angular low-poly fantasy (a KayKit
+adventurers direction was tried and rejected). Free CC0 assets are allowed if
+one genuinely matches this look; the procedural bean is the current build. The aim is the Philosophy's "spend attention, don't drain it"
 rendered literally: the whole board is glanceable posture + color, and every
 mechanic is one click deeper.
 

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -999,3 +999,87 @@ PY
     grep -q '"backend": "sdk"' "$TEST_DIR/req.log"
     [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
 }
+
+# ── per-session launch defaults: model / effort / permission mode ────────────────────────────
+# Every romp session takes one answer for these (the user 2026-08-13), from
+# ~/.config/romp/session-defaults — a FILE because the launchd-rooted kernel that spawns
+# sessions never sees a shell env var. A per-spawn --model/--effort (the hive tray's bean drop)
+# outranks the file; a resume keeps the conversation's own model/effort.
+
+_write_session_defaults() {
+    mkdir -p "$HOME/.config/romp"
+    printf '%s\n' "$@" > "$HOME/.config/romp/session-defaults"
+}
+
+@test "session-defaults: model, effort and permission mode reach the launch line" {
+    _write_session_defaults "MODEL=fable" "EFFORT=max" "PERM_MODE=auto"
+    run run_romp new -t myproject
+    [ "$status" -eq 0 ]
+    local line; line="$(grep -F 'respawn-pane' "$MOCK_LOG" | grep -F 'exec claude')"
+    [[ "$line" == *"--model fable"* ]]
+    [[ "$line" == *"--effort max"* ]]
+    [[ "$line" == *"--permission-mode auto"* ]]
+}
+
+@test "session-defaults: absent file leaves every flag off (the CLI's own settings stand)" {
+    run run_romp new -t myproject
+    [ "$status" -eq 0 ]
+    local line; line="$(grep -F 'respawn-pane' "$MOCK_LOG" | grep -F 'exec claude')"
+    [[ "$line" != *"--model"* ]]
+    [[ "$line" != *"--effort"* ]]
+    [[ "$line" != *"--permission-mode"* ]]
+}
+
+@test "session-defaults: a junk value is dropped rather than passed to the CLI" {
+    _write_session_defaults "MODEL=fable; touch INJECTED" "EFFORT=turbo" "PERM_MODE=yolo"
+    run run_romp new -t myproject
+    [ "$status" -eq 0 ]
+    local line; line="$(grep -F 'respawn-pane' "$MOCK_LOG" | grep -F 'exec claude')"
+    [[ "$line" != *"--model"* ]]
+    [[ "$line" != *"--effort"* ]]
+    [[ "$line" != *"--permission-mode"* ]]
+    [ ! -e INJECTED ]
+}
+
+@test "new --model/--effort (a tray bean drop) outrank the file for that session" {
+    _write_session_defaults "MODEL=fable" "EFFORT=max"
+    run run_romp new -t --model opus --effort high myproject
+    [ "$status" -eq 0 ]
+    local line; line="$(grep -F 'respawn-pane' "$MOCK_LOG" | grep -F 'exec claude')"
+    [[ "$line" == *"--model opus"* ]]
+    [[ "$line" == *"--effort high"* ]]
+    [[ "$line" != *"--model fable"* ]]
+}
+
+@test "a resume keeps the conversation's own model/effort, but still takes the mode" {
+    _write_session_defaults "MODEL=fable" "EFFORT=max" "PERM_MODE=auto"
+    run run_romp resume abc123-uuid --name web --detach
+    [ "$status" -eq 0 ]
+    local line; line="$(grep -F 'respawn-pane' "$MOCK_LOG" | grep -F 'exec claude')"
+    [[ "$line" == *"--resume abc123-uuid"* ]]
+    [[ "$line" != *"--model"* ]]
+    [[ "$line" != *"--effort"* ]]
+    [[ "$line" == *"--permission-mode auto"* ]]
+}
+
+# ── romp default-host: which machine new sessions land on ───────────────────────────────────
+@test "default-host: round-trips, prints, and clears" {
+    run run_romp default-host
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unset"* ]]
+    run run_romp default-host TESTHOST
+    [ "$status" -eq 0 ]
+    [ "$(cat "$HOME/.config/romp/default-host")" = "TESTHOST" ]
+    run run_romp default-host
+    [[ "$output" == *"TESTHOST"* ]]
+    run run_romp default-host ""
+    [ "$status" -eq 0 ]
+    [ ! -f "$HOME/.config/romp/default-host" ]
+}
+
+@test "default-host: refuses an ssh-option-shaped name" {
+    run run_romp default-host "-oProxyCommand=touch /tmp/pwned"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not a host name"* ]]
+    [ ! -f "$HOME/.config/romp/default-host" ]
+}

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -112,13 +112,47 @@ STUB
 
 # ─── Launch tests ────────────────────────────────────────────────────
 
-@test "bare romp is the dashboard front door: no kernel, loud error, never a session" {
-    # Round 3 (2026-07-25): the shortest command does the most common thing. In this
-    # hermetic env there is no serve token, so it must fail loudly and launch nothing.
-    touch "$MOCK_LOG"    # this path makes no tmux calls at all
+@test "bare romp with nothing running STARTS the stack — one command from any state" {
+    # 2026-08-13: the front door heals instead of pointing at a second command. The
+    # manager stub stands in for the real supervisor: it "boots a kernel" by minting
+    # the serve token; the probe stub answers alive once that has happened.
+    touch "$MOCK_LOG"
+    cat > "$MOCK_DIR/mgr" << STUB
+#!/usr/bin/env bash
+echo "manager \$1" >> "\$MOCK_LOG"
+mkdir -p "$XDG_STATE_HOME/romp"
+echo tok123 > "$XDG_STATE_HOME/romp/serve-token"
+STUB
+    chmod +x "$MOCK_DIR/mgr"
+    cat > "$MOCK_DIR/probe" << STUB
+#!/usr/bin/env bash
+[[ -f "$XDG_STATE_HOME/romp/serve-token" ]]
+STUB
+    chmod +x "$MOCK_DIR/probe"
+    export ROMP_MANAGER_BIN="$MOCK_DIR/mgr"
+    export ROMP_ALIVE_PROBE="$MOCK_DIR/probe"
+    export ROMP_OPENER=""      # set-but-empty: print the URL, open nothing (the standing seam)
+    run run_romp
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"starting it"* ]]
+    grep -q 'manager up' "$MOCK_LOG"
+    [[ "$output" == *"?token=tok123"* ]]
+    [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]   # the front door never launches a session
+}
+
+@test "bare romp: a manager that yields no kernel fails loudly, never a session" {
+    touch "$MOCK_LOG"
+    cat > "$MOCK_DIR/mgr" << STUB
+#!/usr/bin/env bash
+echo "manager \$1" >> "\$MOCK_LOG"
+STUB
+    chmod +x "$MOCK_DIR/mgr"
+    export ROMP_MANAGER_BIN="$MOCK_DIR/mgr"
+    export ROMP_ALIVE_PROBE=false     # never alive
+    export ROMP_START_TRIES=2         # keep the bounded wait short in tests
     run run_romp
     [ "$status" -eq 1 ]
-    [[ "$output" == *"no serve token"* ]]
+    [[ "$output" == *"no kernel answered"* ]]
     [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
 }
 

--- a/tests/test_hookless_host_card.py
+++ b/tests/test_hookless_host_card.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""A hookless host must FAIL LOUDLY (the authoritative-sources rule): a live tmux session with a
+conversation but no @claude-state ever written has NO state source — its chip can never say
+Awaiting, so a session stopped on a question reads calm everywhere, silently. _hookless_tmux_card
+surfaces that as ONE dismissible needs-you card naming the host and the dark sessions (the user
+2026-08-13, whose fresh remote host skipped install.sh and hit exactly this). Synthetic fixtures
+only: TESTHOST, placeholder sids."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["ROMP_HOST_NAME"] = "TESTHOST"
+km = SourceFileLoader("romp_kernel_hookless", os.path.join(BIN, "romp-kernel")).load_module()
+
+NOW = 1781200000
+SID_WEB = "11111111-2222-3333-4444-555555555555"
+SID_API = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+
+
+def _alive(*rows):
+    return [{"sid": sid, "name": name} for sid, name in rows]
+
+
+class HooklessHostCard(unittest.TestCase):
+    def setUp(self):
+        self._orig_hist = km._session_has_history
+        km._session_has_history = lambda sid: True
+
+    def tearDown(self):
+        km._session_has_history = self._orig_hist
+
+    def test_dark_tmux_session_yields_one_needs_you_card(self):
+        tmux = {SID_WEB: {"state": "", "backend": "tmux"}}
+        cards = km._hookless_tmux_card(NOW, tmux, _alive((SID_WEB, "web")), set())
+        self.assertEqual(len(cards), 1)
+        c = cards[0]
+        self.assertEqual(c["itemId"], "hooks:TESTHOST")
+        self.assertEqual(c["column"], "needs_input")
+        self.assertIsNone(c["blocked"], "no ⏸ chip — feed.ts's chip copy speaks permission/picker only")
+        self.assertEqual(c["sid"], "", "host-scoped, not a session card")
+        self.assertIn("TESTHOST", c["blockSummary"])
+        self.assertIn("web", c["blockSummary"])
+        self.assertIn("install.sh", c["blockSummary"])
+
+    def test_any_recorded_state_means_hooks_fired(self):
+        for st in ("working", "waiting", "idle", "permission", "picker", "compacting"):
+            tmux = {SID_WEB: {"state": st, "backend": "tmux"}}
+            self.assertEqual(km._hookless_tmux_card(NOW, tmux, _alive((SID_WEB, "web")), set()), [],
+                             "state %r is evidence the hooks run" % st)
+
+    def test_only_tmux_backend_counts(self):
+        # SDK sessions publish state through their own backend, no hooks involved
+        tmux = {SID_WEB: {"state": "", "backend": "sdk"}}
+        self.assertEqual(km._hookless_tmux_card(NOW, tmux, _alive((SID_WEB, "web")), set()), [])
+
+    def test_a_fresh_shell_with_no_conversation_is_not_evidence(self):
+        # pre-first-prompt there is no guarantee any hook has had cause to fire yet
+        km._session_has_history = lambda sid: False
+        tmux = {SID_WEB: {"state": "", "backend": "tmux"}}
+        self.assertEqual(km._hookless_tmux_card(NOW, tmux, _alive((SID_WEB, "web")), set()), [])
+
+    def test_clear_dismisses_for_good(self):
+        tmux = {SID_WEB: {"state": "", "backend": "tmux"}}
+        self.assertEqual(
+            km._hookless_tmux_card(NOW, tmux, _alive((SID_WEB, "web")), {"hooks:TESTHOST"}), [])
+
+    def test_many_dark_sessions_fold_into_one_card(self):
+        tmux, rows = {}, []
+        for i in range(8):
+            sid = "%08d-1111-2222-3333-444444444444" % i
+            tmux[sid] = {"state": "", "backend": "tmux"}
+            rows.append((sid, "sess%d" % i))
+        cards = km._hookless_tmux_card(NOW, tmux, _alive(*rows), set())
+        self.assertEqual(len(cards), 1)
+        self.assertIn("+2 more", cards[0]["blockSummary"])
+
+    def test_build_feed_wires_the_card_in(self):
+        import inspect
+        src = inspect.getsource(km.build_feed)
+        self.assertIn("_hookless_tmux_card(now, tmux, alive, cleared)", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6287,7 +6287,7 @@ class ServeSecurity(unittest.TestCase):
         self.assertNotIn("nav-typing", html)                           # the typing/dimming logic is gone
         # the wiring: maps each iframe id → its pane, toggles pane-focused exclusively, defaults to chat.
         # Fleet is its OWN pane now (the user 2026-06-24), so f-fleet maps to fleet-pane, not the chat pane.
-        self.assertIn("var PANE={'f-chat':'chat-pane','f-fleet':'fleet-pane','f-feed':'feed-pane','f-timeline':'tl-pane'}", html)
+        self.assertIn("var PANE={'f-chat':'chat-pane','f-fleet':'fleet-pane','f-feed':'feed-pane','f-hive':'hive-pane','f-timeline':'tl-pane'}", html)
         self.assertIn("classList.toggle('pane-focused'", html)
         self.assertIn("d.addEventListener('pointerdown',emit,true)", html)
         self.assertIn("d.addEventListener('focusin',emit,true)", html)
@@ -7474,3 +7474,34 @@ class ChatDivergenceTripwire(unittest.TestCase):
         jd._debug_mode = lambda: False
         km._note_chat_divergence(SID, "web", "working", "waiting", NOW)       # debug off: silent
         self.assertEqual(self._rows(), [])
+
+
+class OpenSessionFocusFirst(unittest.TestCase):
+    """openSession's focus frame must OUTRUN the slow work (the user 2026-08-13: the chat
+    switch took one to two seconds). The chat's tab is always shown for a live session, so
+    the frame that flips it goes out first; the SDK eager-connect and the full push follow."""
+
+    def _run(self, live_sids):
+        calls = []
+        orig = (km._tmux_sessions, km._sdk, km._push_all, km._reveal_or_confirm)
+        try:
+            km._tmux_sessions = lambda: live_sids
+            km._sdk = lambda: types.SimpleNamespace(connect=lambda sid: calls.append("connect"))
+            km._push_all = lambda *a, **k: calls.append("push")
+            km._reveal_or_confirm = lambda sid, focus, client=None: calls.append(("focus", focus))
+            km._open_or_revive(SID)
+        finally:
+            km._tmux_sessions, km._sdk, km._push_all, km._reveal_or_confirm = orig
+        return calls
+
+    def test_live_session_focus_beats_connect_and_push(self):
+        calls = self._run({SID: {}})
+        self.assertEqual([c if isinstance(c, str) else c[0] for c in calls],
+                         ["focus", "connect", "push"],
+                         "the tab-flipping frame must never queue behind connect/_push_all")
+        self.assertEqual(calls[0][1], {"type": "focus", "id": SID})
+
+    def test_dead_session_routes_to_reveal_only(self):
+        calls = self._run({})
+        self.assertEqual([c if isinstance(c, str) else c[0] for c in calls], ["focus"],
+                         "a dead sid gets the confirmRevive path, never a connect or a push")

--- a/tests/test_kernel_color_pick.py
+++ b/tests/test_kernel_color_pick.py
@@ -91,7 +91,7 @@ class PickColor(unittest.TestCase):
         got = {}
 
         class _FakeSdk:
-            def spawn(self, nm, cwd, bg="", fg="", sid=None, auth=""):
+            def spawn(self, nm, cwd, bg="", fg="", sid=None, auth="", model="", effort=""):
                 got.update(bg=bg, fg=fg)
                 return SID % 9
             def connect(self, sid):

--- a/tests/test_kernel_create_session_ack.py
+++ b/tests/test_kernel_create_session_ack.py
@@ -30,7 +30,7 @@ class _FakeSdk:
 
     # mirrors the real SdkBackend.spawn: the kernel now picks a fleet-aware identity colour and hands it
     # down (test_kernel_color_pick.py), so the fake must accept it exactly like the real one does
-    def spawn(self, nm, cwd, bg="", fg="", sid=None, auth=""):
+    def spawn(self, nm, cwd, bg="", fg="", sid=None, auth="", model="", effort=""):
         self.calls.append(("spawn", nm, cwd))
         return "11111111-2222-3333-4444-555555555555"
 

--- a/tests/test_kernel_fleet_ledgers.py
+++ b/tests/test_kernel_fleet_ledgers.py
@@ -14,16 +14,16 @@ SRC = open(os.path.join(os.path.dirname(HERE), "bin", "romp-kernel")).read()
 
 class FleetLedgers(unittest.TestCase):
     def test_fleet_is_its_own_app_in_the_push(self):
-        self.assertIn('want_fleet = any(c["app"] == "fleet" for c in targets)', SRC)
+        self.assertIn('want_fleet = any(c["app"] in ("fleet", "hive") for c in targets)', SRC)
         # the fleet rides the feed payload, so want_feed must include it
-        self.assertIn('want_feed = any(c["app"] in ("feed", "fleet", "chat") for c in targets)', SRC)
+        self.assertIn('want_feed = any(c["app"] in ("feed", "fleet", "hive", "chat") for c in targets)', SRC)
 
     def test_chat_sessions_are_built_for_a_fleet_only_push(self):
         # the ledger slices come from chat_sessions; build them for want_chat OR want_fleet (not chat-only)
         self.assertIn("if want_chat or want_fleet:", SRC)
 
     def test_the_feed_payload_routes_to_both_feed_and_fleet_clients(self):
-        self.assertIn('if c["app"] in ("feed", "fleet"):', SRC)
+        self.assertIn('if c["app"] in ("feed", "fleet", "hive"):', SRC)
 
     def test_ledgers_are_attached_from_chat_sessions(self):
         self.assertIn('feed["ledgers"] = [{"sid": m["id"]', SRC)

--- a/tests/test_kernel_interrupt.py
+++ b/tests/test_kernel_interrupt.py
@@ -588,6 +588,100 @@ class AutoNudgeInterruptGate(unittest.TestCase):
         self.assertFalse(card.get("interrupted"), "the user's next message retires the badge")
 
 
+class AutoNudgeLoopGate(AutoNudgeInterruptGate):
+    """A session that schedules its own next move is not stalled (the user 2026-08-15, whose looping
+    workers were nudged four times in an hour — every iteration's ended turn re-armed the nudge, the
+    goal never completes because it's a loop, and each status-ask burned the next beat and could
+    supersede the pending wakeup). While the newest genuine ended turn carries a ScheduleWakeup or
+    CronCreate tool_use, auto-nudge stands down; the first genuine turn that ends WITHOUT scheduling
+    lifts the gate — an event, never a timer."""
+
+    def _sched_line(self, uuid, parent, tool):
+        return {"type": "assistant", "timestamp": iso(T0 + 220), "uuid": uuid, "parentUuid": parent,
+                "message": {"role": "assistant",
+                            "content": [{"type": "text", "text": "quiet hold; next pass on the timer"},
+                                        {"type": "tool_use", "name": tool, "input": {"delaySeconds": 1200}}],
+                            "stop_reason": "end_turn"}}
+
+    def _loop_transcript(self, tool="ScheduleWakeup"):
+        self._transcript(interrupted=False)
+        self._append([uline(T0 + 200, "keep the batches coming on your own cadence", "u5", "a3"),
+                      self._sched_line("a5", "u5", tool)])
+
+    def test_a_self_pacing_session_is_never_nudged(self):
+        for tool in ("ScheduleWakeup", "CronCreate"):
+            km._parse_cache.clear()
+            km._autonudge_cache.clear()
+            self._loop_transcript(tool)
+            self._goal()
+            sent, restore = self._stub()
+            try:
+                km._auto_nudge_tick(NOW, self.tmux)
+                self.assertEqual(sent, [], "%s = the session paces itself — let it loop" % tool)
+            finally:
+                restore()
+
+    def test_a_nudge_response_cannot_strip_the_loops_protection(self):
+        # one derailment already happened (a nudge's own romp-injected response turn ended, without
+        # scheduling) — the arm scan skips injected turns, so the loop's own last word still rules
+        self._loop_transcript()
+        self._append([uline(T0 + 300, "<!-- romp-injected -->[romp] where does this stand?", "u6", "a5"),
+                      aline(T0 + 320, "still iterating on the timer.", "a6", "u6", "end_turn")])
+        self._goal()
+        sent, restore = self._stub()
+        try:
+            km._auto_nudge_tick(NOW, self.tmux)
+            self.assertEqual(sent, [], "a romp-injected turn neither re-arms nor lifts the loop gate")
+        finally:
+            restore()
+
+    def test_a_genuine_unscheduled_end_lifts_the_gate(self):
+        # the loop finished (or the user redirected it): its last genuine turn ends with no
+        # scheduling tool → normal stall rules resume and the orphaned working goal is nudged
+        self._loop_transcript()
+        self._append([uline(T0 + 300, "wrap it up and summarize", "u6", "a5"),
+                      aline(T0 + 320, "stopping the loop; summary next.", "a6", "u6", "end_turn")])
+        self._goal()
+        sent, restore = self._stub()
+        try:
+            km._auto_nudge_tick(NOW, self.tmux)
+            self.assertEqual(len(sent), 1, "no pending self-schedule → the stall is real again")
+        finally:
+            restore()
+
+
+class WakeupScheduledUnit(unittest.TestCase):
+    """_wakeup_scheduled in isolation: the newest genuine ended turn's tool_use blocks decide."""
+
+    def _turn(self, ended=True, tools=(), injected=False):
+        atoms = []
+        if injected:
+            atoms.append({"type": "user", "t": T0,
+                          "message": {"role": "user", "content": "<!-- romp-injected -->[romp] hi"}})
+        else:
+            atoms.append({"type": "user", "t": T0, "message": {"role": "user", "content": "go"}})
+        content = [{"type": "text", "text": "ok"}] + [{"type": "tool_use", "name": t, "input": {}} for t in tools]
+        atoms.append({"type": "assistant", "t": T0 + 1, "message": {"role": "assistant", "content": content}})
+        return {"id": "t", "t": T0, "ended": ended, "atoms": atoms,
+                "trigger": None if injected else {"uuid": "u"}}
+
+    def test_schedule_and_cron_both_count_nothing_else_does(self):
+        self.assertTrue(km._wakeup_scheduled([self._turn(tools=("ScheduleWakeup",))]))
+        self.assertTrue(km._wakeup_scheduled([self._turn(tools=("Bash", "CronCreate"))]))
+        self.assertFalse(km._wakeup_scheduled([self._turn(tools=("Bash", "TaskCreate"))]))
+        self.assertFalse(km._wakeup_scheduled([self._turn(tools=())]))
+        self.assertFalse(km._wakeup_scheduled([]))
+
+    def test_only_the_newest_genuine_ended_turn_rules(self):
+        older = self._turn(tools=("ScheduleWakeup",))
+        newer = self._turn(tools=())
+        self.assertFalse(km._wakeup_scheduled([older, newer]),
+                         "a later genuine turn without scheduling lifts the gate")
+        open_turn = self._turn(ended=False, tools=())
+        self.assertTrue(km._wakeup_scheduled([older, open_turn]),
+                        "an OPEN turn has not ruled yet — the loop's last ended word stands")
+
+
 class AutoNudgeArming(AutoNudgeInterruptGate):
     """Arming keys on the newest GENUINE ended turn (arm_id), not the latest turn (the user 2026-07-06,
     business): a kernel-restart resume banner (romp-injected) opened a session's last turn and the old

--- a/tests/test_kernel_interrupt.py
+++ b/tests/test_kernel_interrupt.py
@@ -226,6 +226,64 @@ class InterruptingSdkFlag(unittest.TestCase):
         self.assertIn('"snapT": time.time()', src, "snapshot() stamps when it was taken")
 
 
+class IdleInterruptNeverStrands(unittest.TestCase):
+    """A stop pressed on an IDLE session must not paint (let alone strand) 'Interrupting…' (the user
+    2026-08-14: it never went back to normal). The flag's only clear events are the aborted turn's
+    ResultMessage or a fresh turn — an idle press produces NEITHER, so latching it pinned the snapshot
+    at interrupting:True forever, and every later press bought another 120s of 'stopping…' off the
+    eternal flag. Same guard _signal_cli has carried since the 2026-07-20 strand; and the kernel's op
+    sites stamp _interrupt_clicked only when a turn is actually open (_working_now), so a tmux idle
+    press doesn't ride the 120s wedge cap either."""
+
+    def _session(self, inflight):
+        sb = SourceFileLoader("romp_sdk_backend_intr", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+        be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None)
+        s = sb.SdkSession(be, {"sid": SID, "name": "web"})
+        s.inflight = inflight
+        return s
+
+    class _Loop:
+        def __init__(self):
+            self.scheduled = 0
+        def call_soon_threadsafe(self, fn):
+            self.scheduled += 1              # record the dispatch; never run it (no real loop here)
+
+    def test_an_idle_press_does_not_latch_the_flag_but_still_dispatches(self):
+        s = self._session(inflight=0)
+        s.loop, s.client = self._Loop(), object()          # channel up → the polite control rung
+        s.interrupt()
+        self.assertFalse(s._interrupted, "no turn to stop → no latch → nothing can strand")
+        self.assertEqual(s.loop.scheduled, 1, "the control request itself still goes out (Esc semantics)")
+
+    def test_a_busy_press_latches_exactly_as_before(self):
+        s = self._session(inflight=1)
+        s.loop, s.client = self._Loop(), object()
+        s.interrupt()
+        self.assertTrue(s._interrupted, "a running turn latches — its ResultMessage clears it")
+
+    def test_do_interrupt_carries_the_same_guard(self):
+        import asyncio
+        class _Client:
+            async def interrupt(self):
+                return None
+        s = self._session(inflight=0)
+        s.client = _Client()
+        asyncio.run(s._do_interrupt())
+        self.assertFalse(s._interrupted, "the async leg must not re-latch what interrupt() declined to")
+        s2 = self._session(inflight=2)
+        s2.client = _Client()
+        asyncio.run(s2._do_interrupt())
+        self.assertTrue(s2._interrupted)
+
+    def test_the_kernel_op_sites_gate_the_stamp_on_a_live_turn(self):
+        with open(os.path.join(BIN, "romp-kernel")) as f:
+            src = f.read()
+        self.assertEqual(src.count("_intr_live = _working_now(str(sid))"), 2,
+                         "both interrupt entry points (WS op + HTTP route) gauge before dispatch")
+        self.assertEqual(src.count("if _intr_live:"), 2,
+                         "…and stamp only when a turn was actually open")
+
+
 class FeedCardInterruptingBadge(unittest.TestCase):
     """The feed CARD wears a steady 'interrupting…' badge while a stop is in flight, then swaps to the
     past-tense 'interrupted' — never flickering between 'working' and 'interrupted' as the live-tail retires

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -48,10 +48,9 @@ class PaneRailTest(unittest.TestCase):
     def test_three_top_panes_in_fixed_order_then_the_timeline_band(self):
         # the TOP row is chat | gv-a | fleet | gv-b | feed; the timeline is the bottom band (gh + #tl-pane) AFTER
         # the row closes — so the DOM order is row panes first, then the gh gutter, then #tl-pane.
-        order = ["id=chat-pane", "id=gv-a", "id=fleet-pane", "id=gv-b", "id=feed-pane", "id=gh", "id=tl-pane"]
+        order = ["id=chat-pane", "id=gv-a", "id=fleet-pane", "id=gv-b", "id=feed-pane", "id=gv-c", "id=hive-pane", "id=gh", "id=tl-pane"]
         idxs = [self.html.index(tok) for tok in order]
         self.assertEqual(idxs, sorted(idxs), "row panes, then the gh gutter, then the timeline band")
-        self.assertNotIn("id=gv-c", self.html)                   # no 4th-pane gutter
         # the pane rail is the BOTTOM BAR (the user 2026-07-05): LAST child of .col, AFTER the timeline band —
         # no longer the first child of .row. So its markup falls after #tl-pane.
         self.assertGreater(self.html.index("class=pane-rail"), self.html.index("id=tl-pane"),
@@ -81,7 +80,7 @@ class PaneRailTest(unittest.TestCase):
     def test_rail_drives_a_persisted_pane_controller_exposed_for_the_legacy_toggle(self):
         # the controller toggles po-* from the rail, persists the set, and exposes __rompPaneToggle so the
         # legacy {romp:'toggleFleet'} postMessage routes through the same path
-        self.assertIn("var PK='romp-panes',po={chat:true,fleet:false,feed:true,timeline:true}", self.html)
+        self.assertIn("var PK='romp-panes',po={chat:true,fleet:false,feed:true,hive:false,timeline:true}", self.html)
         self.assertIn("window.__rompPaneToggle=togglePane", self.html)
         self.assertIn("togglePane(b.getAttribute('data-pane'))", self.html)
         self.assertIn("document.body.classList.toggle('po-chat',!!po.chat)", self.html)
@@ -190,7 +189,7 @@ class PaneRailTest(unittest.TestCase):
         # mobile shows one pane at a time via the bottom tab bar, not the rail; the desktop po-* pane-hiding
         # must NOT leak in (the tab bar governs), so chat/feed/timeline panes are forced back to display:contents
         self.assertIn(".gv,.gh,.pane-rail{display:none}", self.html)
-        self.assertIn("#chat-pane,#fleet-pane,#feed-pane,#tl-pane{display:contents!important}", self.html)
+        self.assertIn("#chat-pane,#fleet-pane,#feed-pane,#hive-pane,#tl-pane{display:contents!important}", self.html)
         # the Outline (fleet) is a mobile TAB now, no longer desktop-only (the user 2026-07-11)
         self.assertNotIn("#fleet-pane{display:none!important}", self.html)
         self.assertIn("body[data-tab=timeline] .row{display:none}", self.html)   # timeline tab → band fills

--- a/tests/test_kernel_panenav.py
+++ b/tests/test_kernel_panenav.py
@@ -23,7 +23,7 @@ JS = km._LANDING_FOCUS_JS
 
 class PaneNav(unittest.TestCase):
     def test_spatial_layout_constants(self):
-        self.assertIn("var COLS=['f-chat','f-fleet','f-feed']", JS, "the three side-by-side columns, left->right")
+        self.assertIn("var COLS=['f-chat','f-fleet','f-feed','f-hive']", JS, "the three side-by-side columns, left->right")
         self.assertIn("var TL='f-timeline'", JS, "the timeline is the bottom band")
 
     def test_alt_arrow_is_the_trigger_only_outside_text_fields(self):

--- a/tests/test_kernel_preview.py
+++ b/tests/test_kernel_preview.py
@@ -77,10 +77,26 @@ class FilePreviewEndpoint(unittest.TestCase):
         code, _, _ = self._req("/file?path=" + urllib.parse.quote(os.path.join(self.tmp.name, "gone.png")))
         self.assertEqual(code, 404)
 
-    def test_non_renderable_extension_404s(self):
-        # the allowlist is RENDERABLE media only — a .txt (or anything else) never leaves the machine
-        code, _, _ = self._req("/file?path=" + urllib.parse.quote(self.txt))
-        self.assertEqual(code, 404)
+    def test_text_serves_inline_for_the_click_open(self):
+        # since 2026-08-14 the route is also the OPEN behind a remote path click (a devbox session's
+        # file has no other way onto the viewer's screen): text serves inline instead of 404ing
+        code, hdrs, body = self._req("/file?path=" + urllib.parse.quote(self.txt))
+        self.assertEqual(code, 200)
+        self.assertEqual(hdrs.get("Content-Type"), "text/plain; charset=utf-8")
+        self.assertEqual(body, b"not renderable")
+        self.assertIsNone(hdrs.get("Content-Disposition"), "inline — a click should SHOW text, not save it")
+
+    def test_binary_downloads_instead_of_rendering(self):
+        # a NUL byte in the sniff window = not text: the click still lands something — a download,
+        # the browser's `open` for a binary — never a mojibake tab and never a silent nothing
+        binp = os.path.join(self.tmp.name, "blob.dat")
+        with open(binp, "wb") as f:
+            f.write(b"\x00\x01\x02romp")
+        code, hdrs, body = self._req("/file?path=" + urllib.parse.quote(binp))
+        self.assertEqual(code, 200)
+        self.assertEqual(hdrs.get("Content-Type"), "application/octet-stream")
+        self.assertEqual(hdrs.get("Content-Disposition"), 'attachment; filename="blob.dat"')
+        self.assertEqual(body, b"\x00\x01\x02romp")
 
     def test_relative_path_without_sid_404s(self):
         # unresolvable relative path (no session cwd) must not fall back to the kernel's own cwd
@@ -102,7 +118,12 @@ class FilePreviewEndpoint(unittest.TestCase):
         self.assertEqual(code, 200)
         self.assertEqual(hdrs.get("Content-Length"), str(len(PNG)))
         self.assertEqual(body, b"")
-        code, _, _ = self._req("/file?path=" + urllib.parse.quote(self.txt), method="HEAD")
+        # a text file now reports existence too (it is openable since the click-open widening) —
+        # only a genuinely missing path HEADs 404
+        code, _, body = self._req("/file?path=" + urllib.parse.quote(self.txt), method="HEAD")
+        self.assertEqual((code, body), (200, b""))
+        code, _, _ = self._req("/file?path=" + urllib.parse.quote(os.path.join(self.tmp.name, "gone.txt")),
+                               method="HEAD")
         self.assertEqual(code, 404)
 
 

--- a/tests/test_kernel_push_responsiveness.py
+++ b/tests/test_kernel_push_responsiveness.py
@@ -107,12 +107,32 @@ class DriveOpsAckFast(unittest.TestCase):
         self.assertTrue(km._pusher_wake.is_set())
 
     def test_interrupt_stamps_and_marks_the_views_dirty(self):
-        before = km._views_dirty[0]
-        self.assertTrue(self._drive({"type": "interrupt", "id": SID}))
-        self.assertIn(SID, km._interrupt_clicked, "the optimistic 'Interrupting…' stamp lands first")
-        self.assertGreater(km._views_dirty[0], before,
-                           "the stamp is in-memory — no sig sees it, so the views must dirty-rebuild")
-        self.assertTrue(km._pusher_wake.is_set())
+        # the stamp is gated on a turn actually being open (_working_now): an idle press stops
+        # nothing, so it paints nothing — stamping it stranded 'Interrupting…' for the 120s wedge
+        # cap per press (the user 2026-08-14). Busy here, so the optimistic stamp lands as designed.
+        saved = km._working_now
+        km._working_now = lambda sid: True
+        try:
+            before = km._views_dirty[0]
+            self.assertTrue(self._drive({"type": "interrupt", "id": SID}))
+            self.assertIn(SID, km._interrupt_clicked, "the optimistic 'Interrupting…' stamp lands first")
+            self.assertGreater(km._views_dirty[0], before,
+                               "the stamp is in-memory — no sig sees it, so the views must dirty-rebuild")
+            self.assertTrue(km._pusher_wake.is_set())
+        finally:
+            km._working_now = saved
+
+    def test_an_idle_interrupt_paints_nothing_but_still_dispatches(self):
+        saved = km._working_now
+        km._working_now = lambda sid: False
+        try:
+            self.assertTrue(self._drive({"type": "interrupt", "id": SID}))
+            self.assertNotIn(SID, km._interrupt_clicked,
+                             "no open turn → no 'Interrupting…' stamp to strand (the user 2026-08-14)")
+            self.assertEqual([c for c in self.be.calls if c[0] == "interrupt"], [("interrupt", SID)],
+                             "the Esc/stop itself still reaches the backend")
+        finally:
+            km._working_now = saved
 
     def test_no_drive_op_calls_push_all_inline(self):
         src = inspect.getsource(km._drive)

--- a/tests/test_new_session_dir.py
+++ b/tests/test_new_session_dir.py
@@ -198,7 +198,7 @@ class CreateSessionDirFork(_Wire):
         self.spawned = []
         self._real_sdk = km._create_sdk_session
         self._real_ready = km._sdk_ready
-        km._create_sdk_session = lambda nm, cwd, auth="": self.spawned.append((nm, cwd)) or "TESTSID"
+        km._create_sdk_session = lambda nm, cwd, auth="", model="", effort="": self.spawned.append((nm, cwd)) or "TESTSID"
         km._sdk_ready = lambda: True
         self.addCleanup(setattr, km, "_create_sdk_session", self._real_sdk)
         self.addCleanup(setattr, km, "_sdk_ready", self._real_ready)

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -830,7 +830,10 @@ class LiveTail(unittest.TestCase):
     def test_interrupt_sets_the_flag_synchronously_at_dispatch(self):
         """interrupt() schedules the async _do_interrupt, but the kernel stamps _interrupt_clicked and pushes
         the instant it returns — so _interrupted must already be True SYNCHRONOUSLY, not one event-loop tick
-        later (else the first snapshot after the click misses it and the badge flickers, the user 2026-07-07)."""
+        later (else the first snapshot after the click misses it and the badge flickers, the user 2026-07-07).
+        FOR A RUNNING TURN only (inflight > 0): an idle press latches nothing — the flag's sole clear events
+        are that turn's ResultMessage / a fresh turn, so an idle latch stranded 'interrupting' forever (the
+        user 2026-08-14; tests/test_kernel_interrupt.py IdleInterruptNeverStrands)."""
         import asyncio
         be = sb.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
         s = sb.SdkSession(be, {"sid": "11111111-2222-3333-4444-555555555555", "name": "n", "cwd": "/tmp"})
@@ -838,6 +841,7 @@ class LiveTail(unittest.TestCase):
         try:
             s.loop = loop
             s.client = object()   # truthy — interrupt() only guards on `self.loop and self.client`
+            s.inflight = 1        # a turn is running — the case the synchronous flip exists for
             self.assertFalse(s._interrupted)
             s.interrupt()         # loop never runs → the scheduled _do_interrupt does NOT execute
             self.assertTrue(s._interrupted, "the flag flips synchronously, before the scheduled _do_interrupt")

--- a/tests/test_sdk_launch_defaults.py
+++ b/tests/test_sdk_launch_defaults.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""The launch-defaults file (~/.config/romp/session-defaults) governs EVERY spawn path, not just
+the tmux launcher (the user 2026-08-13: one answer for what a new session launches as — and then
+set PERM_MODE=auto and watched a board-spawned SDK session launch asking for permissions anyway,
+because SdkBackend.spawn read only its remembered last-pick seed). Precedence: explicit per-spawn
+choice > the file > the remembered seed > the hardcoded floor. Validation mirrors bin/romp's exact
+rules so the two readers can never accept different values. Synthetic only: tmp HOME/state dirs."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+sb = SourceFileLoader("romp_sdk_backend_launchdef", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+
+def _backend(d):
+    return sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None)
+
+
+class LaunchDefaultsFile(unittest.TestCase):
+    def setUp(self):
+        self._home = os.environ.get("HOME")
+        self.home = tempfile.mkdtemp()
+        os.environ["HOME"] = self.home
+        self.d = tempfile.mkdtemp()
+        self.be = _backend(self.d)
+
+    def tearDown(self):
+        if self._home is not None:
+            os.environ["HOME"] = self._home
+
+    def _write(self, text):
+        cfg = os.path.join(self.home, ".config", "romp")
+        os.makedirs(cfg, exist_ok=True)
+        with open(os.path.join(cfg, "session-defaults"), "w") as f:
+            f.write(text)
+
+    def test_absent_file_reads_empty_and_spawn_behaves_as_before(self):
+        self.assertEqual(sb.read_session_defaults(), {})
+        reg = sb.read_reg(self.d, self.be.spawn("web", self.d))
+        self.assertEqual(reg["mode"], "acceptEdits")
+        self.assertEqual(reg["effort"], sb.DEFAULT_EFFORT)
+
+    def test_the_file_seeds_mode_model_and_effort(self):
+        self._write("MODEL=fable\nEFFORT=max\nPERM_MODE=auto\n")
+        reg = sb.read_reg(self.d, self.be.spawn("web", self.d))
+        self.assertEqual(reg["mode"], "auto")
+        self.assertEqual(reg["model"], "fable")
+        self.assertEqual(reg["effort"], "max")
+
+    def test_the_file_outranks_the_remembered_seed(self):
+        sb.write_sdk_default(self.d, model="opus", effort="low", mode="acceptEdits")
+        self._write("MODEL=fable\nEFFORT=max\nPERM_MODE=auto\n")
+        reg = sb.read_reg(self.d, self.be.spawn("web", self.d))
+        self.assertEqual((reg["model"], reg["effort"], reg["mode"]), ("fable", "max", "auto"))
+
+    def test_an_explicit_spawn_choice_outranks_the_file(self):
+        self._write("MODEL=fable\nEFFORT=max\n")
+        reg = sb.read_reg(self.d, self.be.spawn("web", self.d, model="haiku", effort="low"))
+        self.assertEqual((reg["model"], reg["effort"]), ("haiku", "low"))
+
+    def test_validation_mirrors_the_launcher_never_sources(self):
+        # bash-parity: values are NOT stripped, so a trailing space fails exactly as it does in
+        # bin/romp's regex check; junk lines and unknown keys are skipped, never executed
+        self._write("PERM_MODE=auto \nMODEL=$(rm -rf /)\nEFFORT=turbo\nGARBAGE\n# comment\n")
+        self.assertEqual(sb.read_session_defaults(), {})
+        self._write("PERM_MODE=dontAsk\nEFFORT=ultracode\n")
+        self.assertEqual(sb.read_session_defaults(), {"mode": "dontAsk"},
+                         "ultracode is per-session only — the file cannot set it, matching bin/romp")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -414,7 +414,7 @@ class DrivePlumbing(unittest.TestCase):
 
     def test_create_paths_pass_the_pick_through(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn("def _create_sdk_session(nm, cwd, auth=\"\"):", src)
+        self.assertIn("def _create_sdk_session(nm, cwd, auth=\"\", model=\"\", effort=\"\"):", src)
         self.assertEqual(src.count('auth=(a if a in ("login", "key") else "")'), 2,
                          "the WS op and POST /new both pass it")
 

--- a/tests/test_session_create_defaults.py
+++ b/tests/test_session_create_defaults.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Where a new session lands, and what it is shown as while it boots (the user 2026-08-13).
+
+Three contracts pinned here, all from one night's debugging of a create that appeared to fail:
+
+  1. A LIVE tmux session with no transcript yet is still SHOWN. tmux writes no transcript record
+     until the first message, and a session parked on the CLI's first-run folder-trust prompt never
+     writes one at all — so the old SDK-only rescue in _alive_sessions filtered a perfectly healthy
+     session off every surface. The client, holding a tab open for it, then timed its create cue out
+     with "Couldn't start", naming a session that HAD started. Per the fail-loudly rule the session
+     must be surfaced and left to report its own state, never silently dropped.
+  2. The default create HOST is persisted kernel-side (~/.config/romp/default-host) and served to
+     the client, so the + picker and the hive tray both spawn on the machine the user actually works
+     on instead of resetting to this one every time.
+  3. A tmux create carries the tray's per-spawn model/effort through to the launcher, so a bean drop
+     means the same thing on either backend.
+
+Synthetic only: invented names, placeholder uuids, tmp state dirs."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # isolate: importing the kernel must not touch live state
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+km = SourceFileLoader("romp_kernel_createdefaults", os.path.join(BIN, "romp-kernel")).load_module()
+
+WEB = "11111111-2222-3333-4444-555555555555"
+API = "11111111-2222-3333-4444-666666666666"
+
+
+class AliveSessionsShowsTranscriptlessTmux(unittest.TestCase):
+    """_alive_sessions must not drop a live tmux session just because discover() can't see it yet."""
+
+    def setUp(self):
+        self._sessions = km._sessions
+        self._name_of = km._name_of
+        self._sdk = km._sdk
+        km._sdk = lambda: None                      # no SDK backend here: the tmux leg is what's under test
+        km._name_of = lambda sid: {WEB: "web", API: "api"}.get(sid)
+
+    def tearDown(self):
+        km._sessions, km._name_of, km._sdk = self._sessions, self._name_of, self._sdk
+
+    def test_a_live_tmux_session_with_no_transcript_still_gets_a_tab(self):
+        km._sessions = lambda *a, **k: []           # discover() sees nothing — no transcript on disk
+        out = km._alive_sessions(1000, {WEB: {"state": "", "backend": "tmux"}})
+        self.assertEqual([s["sid"] for s in out], [WEB])
+        self.assertEqual(out[0]["name"], "web")     # named from the registry, not left as a bare uuid
+
+    def test_the_transcriptless_stub_path_does_not_exist_so_the_chip_reads_opening(self):
+        # build_session/_session_chip key "still opening" off the transcript file being absent; the
+        # stub therefore points at a sentinel that is never created, exactly like the SDK stub.
+        km._sessions = lambda *a, **k: []
+        out = km._alive_sessions(1000, {WEB: {"state": "", "backend": "tmux"}})
+        self.assertFalse(os.path.exists(out[0]["path"]))
+
+    def test_a_discovered_session_is_not_duplicated_by_the_rescue(self):
+        km._sessions = lambda *a, **k: [{"sid": WEB, "name": "web", "path": "/tmp/web.jsonl", "mtime": 5}]
+        out = km._alive_sessions(1000, {WEB: {"state": "working", "backend": "tmux"}})
+        self.assertEqual([s["sid"] for s in out], [WEB])
+        self.assertEqual(out[0]["path"], "/tmp/web.jsonl")   # the real entry wins, not the stub
+
+    def test_a_dead_session_is_still_dropped(self):
+        # the hard liveness filter is unchanged: not in the live map → not on any surface
+        km._sessions = lambda *a, **k: [{"sid": API, "name": "api", "path": "/tmp/api.jsonl", "mtime": 5}]
+        self.assertEqual(km._alive_sessions(1000, {WEB: {"state": "", "backend": "tmux"}}),
+                         [s for s in km._alive_sessions(1000, {WEB: {"state": "", "backend": "tmux"}})])
+        self.assertNotIn(API, [s["sid"] for s in km._alive_sessions(1000, {WEB: {"state": "", "backend": "tmux"}})])
+
+
+class DefaultCreateHost(unittest.TestCase):
+    """The persisted 'create new sessions over there' choice."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._file = km._DEFAULT_HOST_FILE
+        km._DEFAULT_HOST_FILE = km.Path(self.tmp) / "default-host"
+
+    def tearDown(self):
+        km._DEFAULT_HOST_FILE = self._file
+
+    def test_unset_means_this_machine(self):
+        self.assertEqual(km._default_create_host(), "")
+
+    def test_round_trips_a_host_name(self):
+        got, err = km._set_default_host("TESTHOST")
+        self.assertIsNone(err)
+        self.assertEqual(got, "TESTHOST")
+        self.assertEqual(km._default_create_host(), "TESTHOST")
+
+    def test_blank_clears_it(self):
+        km._set_default_host("TESTHOST")
+        got, err = km._set_default_host("")
+        self.assertIsNone(err)
+        self.assertEqual((got, km._default_create_host()), ("", ""))
+
+    def test_an_ssh_option_shaped_name_is_refused(self):
+        # the name reaches ssh as a positional arg elsewhere; a leading '-' must never be storable
+        got, err = km._set_default_host("-oProxyCommand=touch /tmp/pwned")
+        self.assertIsNone(got)
+        self.assertIn("not a host name", err)
+        self.assertEqual(km._default_create_host(), "")
+
+    def test_a_stored_host_is_returned_even_when_that_machine_is_detached(self):
+        # liveness is the CLIENT's call (it falls back to this machine when the host isn't attached);
+        # the kernel must not forget the preference just because the tunnel is down right now
+        km._set_default_host("TESTHOST")
+        self.assertEqual(km._default_create_host(), "TESTHOST")
+
+
+class TmuxSpawnCarriesModelAndEffort(unittest.TestCase):
+    """A tray bean drop onto a tmux board reaches the launcher as real flags."""
+
+    def setUp(self):
+        self.calls = []
+        self._run = km.subprocess.run
+        km.subprocess.run = lambda argv, **kw: self.calls.append(list(argv))
+        self._live = km._live_names
+        km._live_names = lambda *a, **k: {}
+        self._push = km._mark_views_dirty
+        km._mark_views_dirty = lambda *a, **k: None
+        self._reap = km._reap_if_cancelled
+        km._reap_if_cancelled = lambda *a, **k: None
+
+    def tearDown(self):
+        km.subprocess.run = self._run
+        km._live_names, km._mark_views_dirty, km._reap_if_cancelled = self._live, self._push, self._reap
+
+    def test_explicit_model_and_effort_become_launcher_flags(self):
+        km._spawn_session("web", "/tmp", model="fable", effort="max")
+        argv = self.calls[0]
+        self.assertIn("--model", argv)
+        self.assertEqual(argv[argv.index("--model") + 1], "fable")
+        self.assertEqual(argv[argv.index("--effort") + 1], "max")
+
+    def test_no_choice_means_no_flags_so_the_launcher_default_stands(self):
+        km._spawn_session("web", "/tmp")
+        self.assertNotIn("--model", self.calls[0])
+        self.assertNotIn("--effort", self.calls[0])
+
+    def test_an_unknown_value_is_dropped_rather_than_passed_through(self):
+        km._spawn_session("web", "/tmp", model="; rm -rf /", effort="turbo")
+        self.assertNotIn("--model", self.calls[0])
+        self.assertNotIn("--effort", self.calls[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spawn_model_tray.py
+++ b/tests/test_spawn_model_tray.py
@@ -14,6 +14,9 @@ BIN = os.path.join(os.path.dirname(HERE), "bin")
 # Hermetic state BEFORE the load — the module resolves its state root at import time.
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)
+# Hermetic HOME too: spawn() also reads the launch-defaults file (~/.config/romp/session-defaults,
+# which OUTRANKS the remembered seed) — the developer machine's real file must not leak in here.
+os.environ["HOME"] = tempfile.mkdtemp()
 sb = SourceFileLoader("romp_sdk_backend_tray", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 

--- a/tests/test_spawn_model_tray.py
+++ b/tests/test_spawn_model_tray.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""The hive tray's per-spawn model/effort choice (the user 2026-08-13): an explicit choice
+handed to spawn() outranks the remembered sdk-defaults seed for THAT session only — the seed
+itself is untouched, so a one-off spawn never silently becomes everyone's default — and
+set_spawn_defaults() is the deliberate 'make this my default' write to the same store the
+statusline picks feed implicitly. Synthetic only: invented names, tmp state dirs."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the load — the module resolves its state root at import time.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+sb = SourceFileLoader("romp_sdk_backend_tray", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+
+def _backend(d):
+    return sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None)
+
+
+class SpawnOverrides(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.be = _backend(self.d)
+
+    def test_explicit_choice_outranks_the_seed_for_this_session_only(self):
+        sb.write_sdk_default(self.d, model="opus", effort="high")
+        sid = self.be.spawn("web", self.d, model="fable", effort="max")
+        reg = sb.read_reg(self.d, sid)
+        self.assertEqual(reg["model"], "fable")
+        self.assertEqual(reg["effort"], "max")
+        # the SEED is untouched: the next plain spawn still starts from the remembered pick
+        reg2 = sb.read_reg(self.d, self.be.spawn("api", self.d))
+        self.assertEqual(reg2.get("model"), "opus")
+        self.assertEqual(reg2["effort"], "high")
+
+    def test_bogus_effort_override_falls_back_to_the_seed(self):
+        sb.write_sdk_default(self.d, effort="low")
+        sid = self.be.spawn("tests", self.d, effort="turbo")
+        self.assertEqual(sb.read_reg(self.d, sid)["effort"], "low")
+
+    def test_ultracode_is_a_valid_per_spawn_choice(self):
+        # per-session by design — allowed as an explicit spawn choice, never written as a seed
+        sid = self.be.spawn("web", self.d, effort="ultracode")
+        self.assertEqual(sb.read_reg(self.d, sid)["effort"], "ultracode")
+        self.assertNotEqual(sb.read_sdk_defaults(sb.Path(self.d)).get("effort"), "ultracode")
+
+
+class SetSpawnDefaults(unittest.TestCase):
+    def test_writes_the_shared_store_and_merges_per_field(self):
+        d = tempfile.mkdtemp()
+        be = _backend(d)
+        be.set_spawn_defaults(model="fable", effort="max")
+        got = sb.read_sdk_defaults(sb.Path(d))
+        self.assertEqual((got.get("model"), got.get("effort")), ("fable", "max"))
+        # None leaves a field alone: a model-only update keeps the remembered effort
+        be.set_spawn_defaults(model="haiku")
+        got = sb.read_sdk_defaults(sb.Path(d))
+        self.assertEqual((got.get("model"), got.get("effort")), ("haiku", "max"))
+        # …and the next spawn seeds from it
+        reg = sb.read_reg(d, be.spawn("web", d))
+        self.assertEqual((reg.get("model"), reg["effort"]), ("haiku", "max"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -36,6 +36,16 @@ test("the chat strip uses the FULL render on web, and the host data-URL flow for
   assert.doesNotMatch(RENDER, /previewThumb/, "the chat no longer renders mention thumbnails — full renders now");
 });
 
+test("a photo the agent READ renders under its tool row, remote sessions included", () => {
+  // the user 2026-08-14: 'when it looked at photos, render them in the chat — even on the
+  // devbox'. The Read tool branch reuses the mention flow wholesale: previewFull(path, sid)
+  // → fileUrl's /remote/<host>/file relay for host-prefixed sids, buildPathImg for VS Code.
+  assert.match(RENDER, /if \(readPath && previewKind\(readPath\) === "img"\) \{/);
+  assert.match(RENDER, /const full = canPreview\(\) \? previewFull\(readPath, activeId\) : buildPathImg\(readPath\);/);
+  assert.match(RENDER, /if \(o && typeof o\.file_path === "string"\) readPath = o\.file_path;/,
+    "the path comes from the Read tool's own input, resolved like every other preview");
+});
+
 test("imgRequest carries the session id so RELATIVE mentioned paths resolve against the session cwd", () => {
   assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "imgRequest", path: p, id: activeId \}\);/);
   assert.match(KERNEL, /_img_data_url\(_resolve_open_path\(p, msg\.get\("id"\)\)\)/);

--- a/ui/webview/chat-relpath-link.test.ts
+++ b/ui/webview/chat-relpath-link.test.ts
@@ -26,6 +26,15 @@ test("a relative path click carries the active session id so the kernel resolves
   assert.match(RENDER, /function openPathLink\(raw: string, open: string, relative = false\)/);
   assert.match(RENDER, /\{ type: "openFile", path: open, id: activeId \}/);   // relative → send the session id
   assert.match(RENDER, /\{ type: "openFile", path: open \}/);                 // absolute/file:// → no id needed
+  // …but a REMOTE session's path opens on the VIEWER's screen instead (the user 2026-08-14:
+  // clicking a devbox file did nothing — the owning kernel's `open` has no display here): on a
+  // web origin the click rides the /remote/<host>/file relay in a new tab, via ONE shared
+  // helper every chat path-click uses (openPathLink and the image caption links alike)
+  assert.match(RENDER, /function openFileClick\(open: string, relative = false\): void \{/);
+  assert.match(RENDER, /const host = activeId \? hostOf\(activeId\) : "";/);
+  assert.match(RENDER, /window\.open\(fileUrl\(open, activeId\), "_blank", "noopener,noreferrer"\);/);
+  assert.ok((RENDER.match(/openFileClick\(/g) || []).length >= 3,
+    "declared once, used by both the path links and the image caption link");
 });
 
 test("the cheap pre-filter keys on a slash — or, inside inline code, a dot", () => {

--- a/ui/webview/create-defaults.test.ts
+++ b/ui/webview/create-defaults.test.ts
@@ -1,0 +1,66 @@
+// Where a new session lands, from BOTH spawn surfaces (the user 2026-08-13, whose sessions all live on
+// one remote machine — the + picker resetting to "this machine" on every open, and the hive tray always
+// dropping locally, meant re-picking the same host all day and creating on the wrong box when they
+// forgot). The default create host is the LOCAL kernel's persisted choice (~/.config/romp/default-host),
+// served on its sessionList reply and on /models for the tray; "" means this machine.
+//
+// The routing is the existing federation contract: a `host` field on createSession wins outright and is
+// stripped before the kernel sees it. That is EXECUTED here; the picker/tray plumbing is source-pinned,
+// like the rest of render.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { routeOutbound } from "./federation";
+import { DEFAULT_SETTINGS } from "./settings";
+
+const W = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const RENDER = W("render.ts");
+const HIVE = W("hive.ts");
+
+test("a create carrying a host routes to that kernel, with the field stripped", () => {
+  const routes = routeOutbound({ type: "createSession", name: "api", backend: "tmux", host: "TESTHOST" });
+  assert.equal(routes.length, 1);
+  assert.equal(routes[0].host, "TESTHOST");
+  assert.equal(routes[0].msg.host, undefined, "the kernel's handlers are host-blind");
+  assert.equal(routes[0].msg.name, "api");
+});
+
+test("a create with no host still goes local", () => {
+  const [r] = routeOutbound({ type: "createSession", name: "api", backend: "tmux" });
+  assert.equal(r.host, "");
+});
+
+test("the picker preselects the default host ONLY when that machine is attached", () => {
+  // a stored name whose host is detached must not select a button that isn't on the row — the create
+  // would be aimed at a kernel this dashboard cannot reach
+  assert.match(RENDER, /defaultCreateHost && hs\.includes\(defaultCreateHost\) \? defaultCreateHost : ""/);
+});
+
+test("the picker opens its dir prefill, Browse state and session list on that SAME host", () => {
+  // all four used to be hardcoded to local, so a preselected remote host would have shown this
+  // machine's folder completions and this machine's session list under it
+  assert.match(RENDER, /applyBrowseState\(openHost\)/);
+  assert.match(RENDER, /di\.value = dirPrefill\(openHost\)/);
+  assert.match(RENDER, /requestSessionList\(openHost\)/);
+});
+
+test("the default host is adopted from the LOCAL kernel's reply only", () => {
+  // a remote kernel's own default says nothing about where THIS dashboard creates
+  assert.match(RENDER, /typeof m\.defaultHost === "string" && !from\) defaultCreateHost = m\.defaultHost/);
+});
+
+test("a tray drop carries the default host, and omits the field when it is this machine", () => {
+  assert.match(HIVE, /const host = SPAWN_DEFAULTS\.host \|\| "";/);
+  assert.match(HIVE, /\.\.\.\(host \? \{ host \} : \{\}\)/);
+});
+
+test("a tray drop uses the gear's backend, not a hardcoded one", () => {
+  // it hardcoded "sdk", so a board set to terminal sessions still dropped SDK ones
+  assert.match(HIVE, /backend: loadSettings\(\)\.backend/);
+  assert.doesNotMatch(HIVE, /createSession",[^)]*backend: "sdk"/);
+});
+
+test("new sessions default to the terminal backend", () => {
+  assert.equal(DEFAULT_SETTINGS.backend, "tmux");
+});

--- a/ui/webview/dir-complete.test.ts
+++ b/ui/webview/dir-complete.test.ts
@@ -208,7 +208,8 @@ test("a remote's prefill is what you used THERE, never this machine's default", 
   // the gear default is one path on this machine; prefilling it into a Linux box's field is a path
   // that cannot exist there. Blank asks that kernel for its own default instead.
   assert.match(RENDER, /return host \? "" : \(kernelDefaultDir \|\| loadSettings\(\)\.defaultDir \|\| ""\);/);
-  assert.match(RENDER, /if \(di\) di\.value = dirPrefill\(""\);/, "the open prefill goes through it");
+  assert.match(RENDER, /di\.value = dirPrefill\(openHost\);/,
+    "the open prefill goes through it, for whichever host the picker opened on (the user 2026-08-13)");
   assert.match(RENDER, /if \(dirIn\) \{ dirIn\.value = dirPrefill\(h\); askDirComplete\(dirIn\.value\); \}/,
     "switching host swaps the path AND re-vets it against that host");
 });

--- a/ui/webview/feed-artifacts.test.ts
+++ b/ui/webview/feed-artifacts.test.ts
@@ -63,7 +63,11 @@ test("feed card: 'N artifacts' rides the bottom of the summary section and opens
 test("feed modal: artifacts strip below the tree — previews on the web, open-the-file chips in VS Code", () => {
   assert.match(FEED, /applyModalArtifacts\(body, it\);/, "wired in the single-ask modal branch");
   assert.match(FEED, /const sig = arts\.join\("\\n"\);\n  if \(strip && \(strip as any\)\._sig === sig\) return;/, "sig-guarded so a kernel repush doesn't re-fetch every thumb");
-  assert.match(FEED, /chip\.onclick = \(ev: Event\) => \{ ev\.stopPropagation\(\); vscodeApi\?\.postMessage\(\{ type: "openFile", path: p, id: it\.sid \}\); \};/, "no-preview fallback still opens the file");
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "openFile", path: p, id: it\.sid \}\);/, "no-preview fallback still opens the file");
+  // a REMOTE card's artifact must open on the VIEWER's screen (the user 2026-08-14: a devbox
+  // file click did nothing — `open` ran on the headless owning kernel): web origin + host-
+  // prefixed sid → the /remote/<host>/file relay in a new tab, local cards keep the native open
+  assert.match(FEED, /if \(hostOf\(it\.sid\) && \(location\.protocol === "http:" \|\| location\.protocol === "https:"\)\) \{\n\s*window\.open\(fileUrl\(p, it\.sid\), "_blank", "noopener,noreferrer"\);/);
   assert.match(FEED_CSS, /\.fmodal-arts \{ margin-top: 12px;/);
 });
 

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -9,7 +9,7 @@
 import { distillText, distillInputs, applyDistillLine, distillPending } from "./distiller-line";
 import { spinFor } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
-import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote } from "./host-prefix";
+import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
 import { provenanceRows, provenanceGroupRows, rootStart, type ProvFmt, type ProvRow } from "./provenance";
 import { ageColorReadable } from "./age-color";
@@ -17,7 +17,7 @@ import { badgeNotices, clearBoundaryNotices, sdkProblemNotices, syncNotices,
   type ClearNoticeRow, type SdkNoticeRow, type SyncNoticeRow } from "./badge-mirror";
 import { initStrip } from "./strip";
 import { installSettingsSync } from "./settings";
-import { previewThumb, previewKind } from "./preview";
+import { previewThumb, previewKind, fileUrl } from "./preview";
 import { VIEW_STATE_KEY, parseViewState, serializeViewState, pruneViewState, capViewState, type FeedViewState } from "./feed-view-state";
 
 // (The standalone-deliverable "FeedItem" subsystem was REMOVED 2026-07-07: the kernel had emitted
@@ -2204,7 +2204,17 @@ function applyModalArtifacts(host: HTMLElement, it: AskItem): void {
       const chip = el("button", "fmodal-art-chip");
       chip.textContent = name;
       chip.title = "open " + p;
-      chip.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openFile", path: p, id: it.sid }); };
+      chip.onclick = (ev: Event) => {
+        ev.stopPropagation();
+        // a REMOTE card's artifact lives on the owning kernel's disk — `open` there lands on a
+        // headless machine's display (the user 2026-08-14: click, nothing). On the web, open the
+        // bytes on the VIEWER's screen through the /remote/<host>/file relay instead.
+        if (hostOf(it.sid) && (location.protocol === "http:" || location.protocol === "https:")) {
+          window.open(fileUrl(p, it.sid), "_blank", "noopener,noreferrer");
+          return;
+        }
+        vscodeApi?.postMessage({ type: "openFile", path: p, id: it.sid });
+      };
       cell.appendChild(chip);
     }
     row.appendChild(cell);

--- a/ui/webview/hive-card-rename.test.ts
+++ b/ui/webview/hive-card-rename.test.ts
@@ -61,7 +61,8 @@ test("an ended session stops offering rename; refresh() restores it for a live o
 test("a refused rename surfaces on the card (fail loudly), via the kernel's warn reply", () => {
   assert.ok(KERNEL.includes('"type": "warn", "text": "session names use letters'),
     "the kernel answers a bad name with a warn");
-  assert.match(HIVE, /m\.type === "warn" && world && world\.card\.sid/, "the hive routes warns to the card");
+  assert.match(HIVE, /if \(world\.card\.sid\) world\.card\.error/, "an open card owns the warn");
+  assert.match(HIVE, /else world\.note\(/, "…and with no card open, the board-level note shows it");
 });
 
 test("the editor's chrome lives in hive-pane.css (this page loads only its own stylesheet)", () => {

--- a/ui/webview/hive-card-rename.test.ts
+++ b/ui/webview/hive-card-rename.test.ts
@@ -1,0 +1,70 @@
+// Renaming a hexagon (the user 2026-08-13): the fly-in card's name is a click-to-edit that
+// posts the SAME renameSession op the chat tab strip uses, under the same contracts —
+// the host prefix of a remote session is fixed chrome (tab-rename-host.test.ts), the label
+// changes only when the kernel's push lands, and a refusal surfaces on the card instead of
+// vanishing. Source-pinned like tab-rename-host.test.ts: card and kernel only meet at runtime.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const HIVE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "hive.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "hive-pane.css"), "utf8");
+const rename = HIVE.slice(HIVE.indexOf("private startRename()"), HIVE.indexOf("show(s: HiveSession"));
+
+test("the card's name is a delegated rename action (click-safe by construction)", () => {
+  assert.match(HIVE, /class="hc-name" data-act="rename"/, "the name carries the action");
+  assert.match(HIVE, /rename: \(\) => this\.startRename\(\)/, "…dispatched off the stable card root");
+});
+
+test("the editor opens on the session name alone, with a remote's host beside it", () => {
+  assert.match(rename, /const p = hostPrefix\(this\.curName, sid\);/);
+  assert.match(rename, /const base = p \? p\.rest : this\.curName;/);
+  assert.match(rename, /input\.value = base;/, "the field holds the part that is theirs to change");
+  assert.match(rename, /fixed\.className = "host-prefix";/, "the host reads as the quiet fixed chrome");
+  assert.match(rename, /input\.before\(fixed\)/, "sitting before the field, not inside it");
+  assert.match(rename, /fixed\?\.remove\(\)/, "…and torn down with the editor");
+});
+
+test("commit posts the kernel's own renameSession op, never the display string", () => {
+  assert.match(rename, /this\.onRename\(sid, v\)/);
+  assert.match(rename, /v !== base/, "unchanged is measured against the name, not the display string");
+  assert.match(HIVE, /\{ type: "renameSession", id: sid, name \}/, "the world posts the drive op");
+  assert.ok(KERNEL.includes('elif t == "renameSession" and msg.get("name"):'), "the kernel still handles it");
+});
+
+test("the commit targets the sid the editor OPENED on, not whatever the card shows now", () => {
+  assert.match(rename, /const sid = this\.sid;/, "captured at open — a blur can land after a switch");
+  assert.doesNotMatch(rename, /onRename\(this\.sid/, "never the card's current sid at commit time");
+});
+
+test("Enter/blur commit, Esc cancels, and typing never leaks into the world", () => {
+  assert.match(rename, /if \(e\.key === "Enter"\) \{ e\.preventDefault\(\); done\(true\); \}/);
+  assert.match(rename, /else if \(e\.key === "Escape"\) \{ e\.preventDefault\(\); done\(false\); \}/);
+  assert.match(rename, /addEventListener\("blur", \(\) => done\(true\)\)/);
+  assert.match(rename, /e\.stopPropagation\(\)/, "keystrokes must not orbit the camera or close the card");
+});
+
+test("a live editor is abandoned when the card switches, hides, or the session ends", () => {
+  assert.match(HIVE, /if \(fresh\) this\.endEdit\?\.\(false\);/, "show() on a new sid cancels");
+  assert.match(HIVE, /hide\(\) \{ this\.endEdit\?\.\(false\);/, "hide() cancels");
+  const gone = HIVE.slice(HIVE.indexOf("gone() {"), HIVE.indexOf("error(title"));
+  assert.match(gone, /this\.endEdit\?\.\(false\);/, "gone() cancels");
+});
+
+test("an ended session stops offering rename; refresh() restores it for a live one", () => {
+  assert.match(HIVE, /delete this\.name\.dataset\.act;/, "gone() revokes the affordance");
+  assert.match(HIVE, /this\.name\.dataset\.act = "rename";/, "refresh() grants it");
+});
+
+test("a refused rename surfaces on the card (fail loudly), via the kernel's warn reply", () => {
+  assert.ok(KERNEL.includes('"type": "warn", "text": "session names use letters'),
+    "the kernel answers a bad name with a warn");
+  assert.match(HIVE, /m\.type === "warn" && world && world\.card\.sid/, "the hive routes warns to the card");
+});
+
+test("the editor's chrome lives in hive-pane.css (this page loads only its own stylesheet)", () => {
+  for (const sel of ['.hc-name[data-act="rename"]', ".hc-rename", ".host-prefix"])
+    assert.ok(CSS.includes(sel), "hive-pane.css styles " + sel);
+});

--- a/ui/webview/hive-card-rename.test.ts
+++ b/ui/webview/hive-card-rename.test.ts
@@ -65,6 +65,20 @@ test("a refused rename surfaces on the card (fail loudly), via the kernel's warn
   assert.match(HIVE, /else world\.note\(/, "…and with no card open, the board-level note shows it");
 });
 
+test("the BOARD rename: click the nameplate, edit in place (the city-banner pattern)", () => {
+  const board = HIVE.slice(HIVE.indexOf("beginBoardRename(sid: string)"));
+  assert.match(HIVE, /if \(pad && !hit\.name\) \{/,
+    "a nameplate press never switches chat — the plate is its own affordance");
+  assert.match(HIVE, /if \(pp\.name && Math\.hypot\(e\.clientX - pp\.x, e\.clientY - pp\.y\) <= 5\) this\.beginBoardRename\(pp\.sid\);/,
+    "the edit opens on the clean UP, so a drag from the plate still picks the session up");
+  assert.match(HIVE, /nh\.length && pad\.nameVisible\(\)/,
+    "only a READABLE plate is clickable — an invisible plate is never a secret button");
+  assert.match(board, /const hp = hostPrefix\(pad\.sess\.name, sid\);/, "a remote's host is fixed chrome here too");
+  assert.match(board, /pad\.setNameHidden\(true\);/, "the editor STANDS IN for the plate");
+  assert.match(board, /\{ type: "renameSession", id: sid, name: v \}/, "same kernel op as every rename surface");
+  assert.match(board, /else if \(e\.key === "Escape"\) \{ e\.preventDefault\(\); finish\(false\); \}/, "Esc cancels");
+});
+
 test("the editor's chrome lives in hive-pane.css (this page loads only its own stylesheet)", () => {
   for (const sel of ['.hc-name[data-act="rename"]', ".hc-rename", ".host-prefix"])
     assert.ok(CSS.includes(sel), "hive-pane.css styles " + sel);

--- a/ui/webview/hive-labels.test.ts
+++ b/ui/webview/hive-labels.test.ts
@@ -1,0 +1,48 @@
+// Nameplates lie flat ON their cell, map-label style (the user 2026-08-13, after the
+// floating billboards — camera-scaled, bloom-fed — stacked into unreadable fog). A label
+// that belongs to its cell can geometrically never overlap a neighbour's: the projection
+// of disjoint coplanar regions stays disjoint under any camera. Source-pinned plus the fit
+// arithmetic against the real cell dimensions from hive-layout.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { HEX_SIZE } from "./hive-layout";
+
+const HIVE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "hive.ts"), "utf8");
+const decal = HIVE.slice(HIVE.indexOf("function makeNameDecal"), HIVE.indexOf("function disposeDecal"));
+const num = (re: RegExp) => parseFloat((HIVE.match(re) || ["", "NaN"])[1]);
+
+test("the nameplate FITS its cell, so names can never leave it or pile up", () => {
+  const W = num(/const LABEL_W_MAX = ([\d.]+)/);
+  const H = num(/const LABEL_H = ([\d.]+)/);
+  const F = num(/const LABEL_FRONT = ([\d.]+)/);
+  assert.ok(W > 0 && H > 0 && F > 0, "the constants exist");
+  const apothem = (Math.sqrt(3) / 2) * HEX_SIZE;
+  assert.ok(W <= Math.sqrt(3) * HEX_SIZE, "plate width within the across-flats span");
+  const zFar = F + H / 2;
+  assert.ok(zFar <= apothem, "the plate's far edge stays inside the apothem");
+  // past the corner ring (z > size/2) the hex narrows linearly to its tip — still fits
+  const xAt = zFar <= HEX_SIZE / 2 ? apothem : (apothem * (HEX_SIZE - zFar)) / (HEX_SIZE / 2);
+  assert.ok(W / 2 <= xAt, `half-width ${W / 2} exceeds the cell's ${xAt} at z=${zFar}`);
+});
+
+test("flat on the tile, camera-yawed, ellipsized to width — never inflated by distance", () => {
+  assert.match(decal, /mesh\.rotation\.x = -Math\.PI \/ 2;/, "the plate lies flat");
+  assert.match(decal, /rest \+= "…";/, "long names ellipsize instead of spilling");
+  assert.match(HIVE, /this\.labelYaw\.rotation\.y = camYaw;/, "yawed to face the camera");
+  assert.ok(!HIVE.includes("camDist / 13"), "the old distance-upscaling is gone");
+});
+
+test("zooming out fades names away; hover/selection keeps yours readable", () => {
+  assert.match(HIVE, /focus \? 1 : Math\.min\(1, Math\.max\(0, \(42 - camDist\) \/ 12\)\)/);
+  assert.match(HIVE, /psid === this\.hovered \|\| psid === this\.selected/,
+    "focus is the hovered or selected pad — an event of the user's pointer, not a heuristic");
+});
+
+test("crisp and bloom-safe: no glow, quiet host prefix, identity color dimmed", () => {
+  assert.ok(!decal.includes("shadowBlur"), "nameplates carry NO glow — glow was the fog");
+  assert.match(decal, /hostPrefix\(name, sid\)/, "a remote's host renders as the quiet prefix");
+  assert.match(decal, /"#8a8a8a"/, "…in the standing quiet gray");
+  assert.match(decal, /multiplyScalar\(0\.82\)/, "identity color held under the bloom threshold");
+});

--- a/ui/webview/hive-layout.test.ts
+++ b/ui/webview/hive-layout.test.ts
@@ -1,0 +1,74 @@
+// Hive layout invariants (plans/hive.md): the spiral covers the plane ring by ring with no
+// holes and no reshuffles — a session's hex is stable for its whole life, so the user's
+// spatial memory of the board keeps working across pushes and reloads.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { assignSlots, axialToXZ, frameRadius, hexDistance, spiralSlot } from "./hive-layout";
+
+test("slot 0 is the origin; ring k holds 6k slots at hex distance k", () => {
+  assert.deepEqual(spiralSlot(0), { q: 0, r: 0 });
+  const O = { q: 0, r: 0 };
+  for (const [k, lo, hi] of [[1, 1, 6], [2, 7, 18], [3, 19, 36]] as const) {
+    for (let i = lo; i <= hi; i++) {
+      assert.equal(hexDistance(spiralSlot(i), O), k, `slot ${i} sits on ring ${k}`);
+    }
+  }
+});
+
+test("the first 169 slots are unique (rings 0..7 tile without collisions)", () => {
+  const seen = new Set<string>();
+  for (let i = 0; i < 169; i++) {
+    const { q, r } = spiralSlot(i);
+    const key = q + "," + r;
+    assert.ok(!seen.has(key), `slot ${i} collides at ${key}`);
+    seen.add(key);
+  }
+});
+
+test("consecutive slots inside a ring are neighbours (the walk never jumps)", () => {
+  for (const [lo, hi] of [[1, 6], [7, 18], [19, 36]] as const) {
+    for (let i = lo; i < hi; i++) {
+      assert.equal(hexDistance(spiralSlot(i), spiralSlot(i + 1)), 1, `slots ${i}→${i + 1} adjacent`);
+    }
+  }
+});
+
+test("pointy-top spacing: all six neighbours of the origin sit √3·size away", () => {
+  const size = 2;
+  const o = axialToXZ({ q: 0, r: 0 }, size);
+  for (let i = 1; i <= 6; i++) {
+    const p = axialToXZ(spiralSlot(i), size);
+    const d = Math.hypot(p.x - o.x, p.z - o.z);
+    assert.ok(Math.abs(d - Math.sqrt(3) * size) < 1e-9, `neighbour ${i} at ${d}`);
+  }
+});
+
+test("assignSlots: everyone keeps their slot; new sids fill the lowest free holes", () => {
+  const first = assignSlots(new Map(), ["a", "b", "c"]);
+  assert.deepEqual([...first.values()], [0, 1, 2]);
+  // b leaves, d+e arrive: a and c stay put, d takes b's freed slot 1, e takes 3
+  const second = assignSlots(first, ["a", "c", "d", "e"]);
+  assert.equal(second.get("a"), 0);
+  assert.equal(second.get("c"), 2);
+  assert.equal(second.get("d"), 1);
+  assert.equal(second.get("e"), 3);
+  // an identical roster re-push changes nothing at all (the no-reshuffle invariant)
+  const third = assignSlots(second, ["a", "c", "d", "e"]);
+  assert.deepEqual([...third.entries()], [...second.entries()]);
+});
+
+test("assignSlots: a corrupt duplicate slot resolves first-claim-wins, loser re-slots", () => {
+  const prev = new Map([["a", 4], ["b", 4]]);
+  const out = assignSlots(prev, ["a", "b"]);
+  assert.equal(out.get("a"), 4, "first claimant keeps the slot");
+  assert.equal(out.get("b"), 0, "the duplicate falls to the lowest free slot");
+});
+
+test("frameRadius grows with the occupied ring and never returns zero", () => {
+  const size = 2;
+  const r0 = frameRadius([0], size);
+  const r1 = frameRadius([0, 1, 2, 3], size);
+  const r2 = frameRadius([0, 7], size);
+  assert.ok(r0 >= size * 2, "even a lone pad frames with margin");
+  assert.ok(r1 > r0 && r2 > r1, "farther occupied slots widen the frame");
+});

--- a/ui/webview/hive-layout.test.ts
+++ b/ui/webview/hive-layout.test.ts
@@ -3,7 +3,7 @@
 // spatial memory of the board keeps working across pushes and reloads.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexCorner, hexDistance, latticeSegments, PAD_R, PAD_THETA, RIM_THETA, ringOf, spiralSlot } from "./hive-layout";
+import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexCorner, hexDistance, latticeSegments, PAD_R, PAD_THETA, RIM_THETA, ringOf, slotOfAxial, spiralSlot, xzToAxial } from "./hive-layout";
 
 test("frameDt never goes negative or huge — a bad clock can't diverge the eases", () => {
   assert.equal(frameDt(1016, 1000), 0.016, "a normal frame passes through");
@@ -97,6 +97,21 @@ test("hexCorner IS the cylinder parametrization (the corners everything shares)"
 test("ringOf inverts the spiral: it agrees with hex distance from the origin", () => {
   const O = { q: 0, r: 0 };
   for (let i = 0; i < 169; i++) assert.equal(ringOf(i), hexDistance(spiralSlot(i), O), `slot ${i}`);
+});
+
+test("xzToAxial inverts axialToXZ — any point inside a cell maps back to that cell", () => {
+  for (let i = 0; i < 169; i++) {
+    const a = spiralSlot(i);
+    const p = axialToXZ(a, HEX_SIZE);
+    assert.deepEqual(xzToAxial(p.x, p.z, HEX_SIZE), a, `center of slot ${i}`);
+    // a point pushed 80% of the way toward a corner is still inside the hex
+    const c = hexCorner(p.x, p.z, HEX_SIZE * 0.8, i % 6);
+    assert.deepEqual(xzToAxial(c.x, c.z, HEX_SIZE), a, `off-center point in slot ${i}`);
+  }
+});
+
+test("slotOfAxial inverts spiralSlot (click a cell → its exact slot index)", () => {
+  for (let i = 0; i < 169; i++) assert.equal(slotOfAxial(spiralSlot(i)), i, `slot ${i}`);
 });
 
 test("lattice: shared edges are emitted once, so every line weighs the same", () => {

--- a/ui/webview/hive-layout.test.ts
+++ b/ui/webview/hive-layout.test.ts
@@ -3,7 +3,7 @@
 // spatial memory of the board keeps working across pushes and reloads.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexDistance, PAD_R, spiralSlot } from "./hive-layout";
+import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexDistance, PAD_R, PAD_THETA, RIM_THETA, spiralSlot } from "./hive-layout";
 
 test("frameDt never goes negative or huge — a bad clock can't diverge the eases", () => {
   assert.equal(frameDt(1016, 1000), 0.016, "a normal frame passes through");
@@ -61,6 +61,38 @@ test("pads snap flush: twice the pad apothem exactly spans the gap to every neig
     const p = axialToXZ(spiralSlot(i), HEX_SIZE);
     const d = Math.hypot(p.x - o.x, p.z - o.z);
     assert.ok(Math.abs(2 * apothem - d) < 1e-9, `neighbour ${i} leaves a ${d - 2 * apothem} gap`);
+  }
+});
+
+// The prism's corners, as CylinderGeometry actually places them: x = r·sinθ, z = r·cosθ.
+function padCorners(c: { x: number; z: number }): { x: number; z: number }[] {
+  return Array.from({ length: 6 }, (_, k) => {
+    const th = PAD_THETA + (k * Math.PI) / 3;
+    return { x: c.x + PAD_R * Math.sin(th), z: c.z + PAD_R * Math.cos(th) };
+  });
+}
+
+test("pads FIT, not overlap: adjacent hexes share exactly two corners (a whole edge)", () => {
+  // Two equal regular hexagons sharing two adjacent corners share that edge and cannot
+  // interpenetrate. thetaStart π/6 (the 2026-08-13 overlap) shares ZERO corners here —
+  // it aims a corner at each neighbour, past the apothem line into the neighbouring cell.
+  const o = padCorners(axialToXZ({ q: 0, r: 0 }, HEX_SIZE));
+  for (let i = 1; i <= 6; i++) {
+    const n = padCorners(axialToXZ(spiralSlot(i), HEX_SIZE));
+    let shared = 0;
+    for (const a of o) for (const b of n) if (Math.hypot(a.x - b.x, a.z - b.z) < 1e-9) shared++;
+    assert.equal(shared, 2, `neighbour ${i} shares ${shared} corners`);
+  }
+});
+
+test("rim corners land on prism corners (Ring and Cylinder walk θ from different axes)", () => {
+  // RingGeometry places x = r·cosθ, y = r·sinθ; rotation.x = −π/2 maps (x, y) → (x, −z).
+  const prism = padCorners({ x: 0, z: 0 });
+  for (let k = 0; k < 6; k++) {
+    const th = RIM_THETA + (k * Math.PI) / 3;
+    const rim = { x: PAD_R * Math.cos(th), z: -PAD_R * Math.sin(th) };
+    const hit = prism.some((c) => Math.hypot(c.x - rim.x, c.z - rim.z) < 1e-9);
+    assert.ok(hit, `rim corner ${k} sits off the prism's corner grid`);
   }
 });
 

--- a/ui/webview/hive-layout.test.ts
+++ b/ui/webview/hive-layout.test.ts
@@ -3,7 +3,7 @@
 // spatial memory of the board keeps working across pushes and reloads.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { assignSlots, axialToXZ, frameDt, frameRadius, hexDistance, spiralSlot } from "./hive-layout";
+import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexDistance, PAD_R, spiralSlot } from "./hive-layout";
 
 test("frameDt never goes negative or huge — a bad clock can't diverge the eases", () => {
   assert.equal(frameDt(1016, 1000), 0.016, "a normal frame passes through");
@@ -49,6 +49,18 @@ test("pointy-top spacing: all six neighbours of the origin sit √3·size away",
     const p = axialToXZ(spiralSlot(i), size);
     const d = Math.hypot(p.x - o.x, p.z - o.z);
     assert.ok(Math.abs(d - Math.sqrt(3) * size) < 1e-9, `neighbour ${i} at ${d}`);
+  }
+});
+
+test("pads snap flush: twice the pad apothem exactly spans the gap to every neighbour", () => {
+  // The prism turns an edge toward each neighbour, so flush = apothem·2 === center distance.
+  // Shrinking PAD_R below HEX_SIZE reopens the moat between cells; growing it overlaps them.
+  const o = axialToXZ({ q: 0, r: 0 }, HEX_SIZE);
+  const apothem = (PAD_R * Math.sqrt(3)) / 2;
+  for (let i = 1; i <= 6; i++) {
+    const p = axialToXZ(spiralSlot(i), HEX_SIZE);
+    const d = Math.hypot(p.x - o.x, p.z - o.z);
+    assert.ok(Math.abs(2 * apothem - d) < 1e-9, `neighbour ${i} leaves a ${d - 2 * apothem} gap`);
   }
 });
 

--- a/ui/webview/hive-layout.test.ts
+++ b/ui/webview/hive-layout.test.ts
@@ -3,7 +3,16 @@
 // spatial memory of the board keeps working across pushes and reloads.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { assignSlots, axialToXZ, frameRadius, hexDistance, spiralSlot } from "./hive-layout";
+import { assignSlots, axialToXZ, frameDt, frameRadius, hexDistance, spiralSlot } from "./hive-layout";
+
+test("frameDt never goes negative or huge — a bad clock can't diverge the eases", () => {
+  assert.equal(frameDt(1016, 1000), 0.016, "a normal frame passes through");
+  assert.equal(frameDt(1000, 5000), 1 / 60, "a BACKWARD step falls back to one frame, never negative");
+  assert.equal(frameDt(1000, 1000), 1 / 60, "a zero step too (exp ease with dt=0 is a no-op otherwise)");
+  assert.equal(frameDt(99999, 1000), 0.05, "a long stall caps — nothing teleports after a tab restore");
+  assert.equal(frameDt(1016, -1), 1 / 60, "the loop-start sentinel takes the nominal frame");
+  assert.equal(frameDt(NaN, 1000), 1 / 60, "non-finite clocks fall back safely");
+});
 
 test("slot 0 is the origin; ring k holds 6k slots at hex distance k", () => {
   assert.deepEqual(spiralSlot(0), { q: 0, r: 0 });

--- a/ui/webview/hive-layout.test.ts
+++ b/ui/webview/hive-layout.test.ts
@@ -3,7 +3,7 @@
 // spatial memory of the board keeps working across pushes and reloads.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexDistance, PAD_R, PAD_THETA, RIM_THETA, spiralSlot } from "./hive-layout";
+import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexCorner, hexDistance, latticeSegments, PAD_R, PAD_THETA, RIM_THETA, ringOf, spiralSlot } from "./hive-layout";
 
 test("frameDt never goes negative or huge — a bad clock can't diverge the eases", () => {
   assert.equal(frameDt(1016, 1000), 0.016, "a normal frame passes through");
@@ -82,6 +82,47 @@ test("pads FIT, not overlap: adjacent hexes share exactly two corners (a whole e
     let shared = 0;
     for (const a of o) for (const b of n) if (Math.hypot(a.x - b.x, a.z - b.z) < 1e-9) shared++;
     assert.equal(shared, 2, `neighbour ${i} shares ${shared} corners`);
+  }
+});
+
+test("hexCorner IS the cylinder parametrization (the corners everything shares)", () => {
+  for (let k = 0; k < 6; k++) {
+    const th = PAD_THETA + (k * Math.PI) / 3;
+    const c = hexCorner(3, -2, PAD_R, k);
+    assert.ok(Math.abs(c.x - (3 + PAD_R * Math.sin(th))) < 1e-12);
+    assert.ok(Math.abs(c.z - (-2 + PAD_R * Math.cos(th))) < 1e-12);
+  }
+});
+
+test("ringOf inverts the spiral: it agrees with hex distance from the origin", () => {
+  const O = { q: 0, r: 0 };
+  for (let i = 0; i < 169; i++) assert.equal(ringOf(i), hexDistance(spiralSlot(i), O), `slot ${i}`);
+});
+
+test("lattice: shared edges are emitted once, so every line weighs the same", () => {
+  // ring 0 is one hex: 6 edges. rings 0..1 are 7 cells: 42 edge incidences, of which the
+  // 6 center–ring and 6 ring–ring adjacencies are shared pairs → 42 − 12 = 30 unique.
+  assert.equal(latticeSegments(0, HEX_SIZE).length / 4, 6);
+  assert.equal(latticeSegments(1, HEX_SIZE).length / 4, 30);
+});
+
+test("lattice: every segment is exactly one hex side long (side = circumradius)", () => {
+  const seg = latticeSegments(2, HEX_SIZE);
+  for (let i = 0; i < seg.length; i += 4) {
+    const d = Math.hypot(seg[i + 2] - seg[i], seg[i + 3] - seg[i + 1]);
+    assert.ok(Math.abs(d - HEX_SIZE) < 1e-9, `segment ${i / 4} has length ${d}`);
+  }
+});
+
+test("lattice: no duplicate segments in either direction", () => {
+  const seg = latticeSegments(3, HEX_SIZE);
+  const seen = new Set<string>();
+  const q = (v: number) => Math.round(v * 1e5);
+  for (let i = 0; i < seg.length; i += 4) {
+    const a = q(seg[i]) + "," + q(seg[i + 1]), b = q(seg[i + 2]) + "," + q(seg[i + 3]);
+    const key = a < b ? a + "|" + b : b + "|" + a;
+    assert.ok(!seen.has(key), `segment ${i / 4} repeats ${key}`);
+    seen.add(key);
   }
 });
 

--- a/ui/webview/hive-layout.ts
+++ b/ui/webview/hive-layout.ts
@@ -60,6 +60,48 @@ export function hexDistance(a: Axial, b: Axial): number {
   return (Math.abs(dq) + Math.abs(dr) + Math.abs(dq + dr)) / 2;
 }
 
+// Ring number of a spiral slot — the inverse of spiralSlot's ring arithmetic.
+export function ringOf(i: number): number {
+  if (!Number.isFinite(i) || i <= 0) return 0;
+  let k = 1;
+  while (3 * k * (k + 1) < i) k++;
+  return k;
+}
+
+// Corner k (0..5) of the hex at center (cx, cz) with circumradius r — the ONE place corner
+// positions are computed, in the same parametrization CylinderGeometry uses for the pad
+// prism (x = r·sinθ, z = r·cosθ, θ from PAD_THETA): the lattice below, hive.ts's line
+// loops, and the prism all agree on where a corner is by construction.
+export function hexCorner(cx: number, cz: number, r: number, k: number): { x: number; z: number } {
+  const th = PAD_THETA + (k * Math.PI) / 3;
+  return { x: cx + r * Math.sin(th), z: cz + r * Math.cos(th) };
+}
+
+// The one-layer board: every UNIQUE edge of the honeycomb covering rings 0..`rings`, flat
+// [ax, az, bx, bz, …] ready for a LineSegments buffer. The cells tessellate (PAD_R =
+// HEX_SIZE), so an interior edge belongs to exactly two cells — it is emitted ONCE, keyed
+// by its quantized endpoints, so every line in the lattice draws at the same weight
+// (the user 2026-08-13: one thin line, mathematically even — never doubled where cells
+// meet, never a second grid underneath).
+export function latticeSegments(rings: number, size: number): number[] {
+  const seen = new Set<string>();
+  const out: number[] = [];
+  const q = (v: number) => Math.round(v * 1e5);
+  const last = 3 * Math.max(0, rings) * (Math.max(0, rings) + 1);
+  for (let i = 0; i <= last; i++) {
+    const c = axialToXZ(spiralSlot(i), size);
+    for (let e = 0; e < 6; e++) {
+      const a = hexCorner(c.x, c.z, size, e), b = hexCorner(c.x, c.z, size, (e + 1) % 6);
+      const ka = q(a.x) + "," + q(a.z), kb = q(b.x) + "," + q(b.z);
+      const key = ka < kb ? ka + "|" + kb : kb + "|" + ka;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(a.x, a.z, b.x, b.z);
+    }
+  }
+  return out;
+}
+
 // Stable slot assignment. `prev` is the last known sid→slot map (persisted by the caller);
 // `sids` the sessions present NOW, in arrival order. Every sid that had a slot keeps it
 // (first claim wins on a corrupt duplicate); new sids fill the lowest free slots in order.

--- a/ui/webview/hive-layout.ts
+++ b/ui/webview/hive-layout.ts
@@ -60,6 +60,19 @@ export function assignSlots(prev: ReadonlyMap<string, number>, sids: readonly st
   return out;
 }
 
+// Frame delta from two rAF-ish timestamps, in seconds — SAFE against every clock the
+// browser can throw: a negative step (rAF timeline vs performance.now skew, VM clock
+// adjustments, headless virtual time) falls back to one nominal frame instead of going
+// negative — a negative dt would flip every exponential ease into a runaway AWAY from its
+// target (the 2026-08-13 camera-divergence bug: distCur 10.5 → 426 in four seconds). A
+// huge step (tab restored after minutes) caps at 50ms so nothing teleports.
+export function frameDt(nowMs: number, lastMs: number): number {
+  if (!Number.isFinite(nowMs) || !Number.isFinite(lastMs) || lastMs < 0) return 1 / 60;
+  const dt = (nowMs - lastMs) / 1000;
+  if (dt <= 0) return 1 / 60;
+  return Math.min(0.05, dt);
+}
+
 // World-space radius of the occupied board (for camera framing): the farthest pad center
 // from the origin, plus one pad of margin so the frame never crops a rim.
 export function frameRadius(slots: readonly number[], size: number): number {

--- a/ui/webview/hive-layout.ts
+++ b/ui/webview/hive-layout.ts
@@ -8,13 +8,25 @@
 export interface Axial { q: number; r: number }
 
 // Board scale. Neighbour centers sit √3·HEX_SIZE apart (axialToXZ); each pad's top is a hex
-// prism of circumradius PAD_R with an EDGE turned toward every neighbour (hive.ts thetaStart
-// π/6), so its apothem is PAD_R·√3/2. PAD_R = HEX_SIZE makes twice the apothem exactly the
+// prism of circumradius PAD_R with an EDGE turned toward every neighbour (PAD_THETA below),
+// so its apothem is PAD_R·√3/2. PAD_R = HEX_SIZE makes twice the apothem exactly the
 // neighbour gap: adjacent pads snap flush and share their edge, one connected honeycomb
 // rather than islands (the user 2026-08-13, who wanted the hexagons snapped together). The
 // pads' slight base flare (hive.ts ×1.04) tucks under the shared rim, hiding any seam.
 export const HEX_SIZE = 2.05;
 export const PAD_R = HEX_SIZE;
+
+// Prism orientation — the turn that makes flush pads FIT instead of overlap (the user
+// 2026-08-13: full-size pads first went in corner-first and interpenetrated). Three's
+// CylinderGeometry walks θ as x = r·sinθ, z = r·cosθ, so a vertex lands at XZ angle 90°−θ:
+// thetaStart 0 puts corners at 30°+k·60°, which puts the EDGES' midpoints at k·60° — the
+// exact angles axialToXZ hands the six neighbours. (The old π/6 landed corners at k·60°,
+// aiming a PAD_R-long corner straight at each neighbour, past the √3/2 apothem line.)
+// Flat hexes (RingGeometry/CircleGeometry) walk θ as x = r·cosθ, y = r·sinθ and lie down
+// via rotation.x = −π/2, landing a vertex at XZ angle −θ: −π/6 lines their corners up with
+// the prism's. Both constants are pinned together by hive-layout.test.ts.
+export const PAD_THETA = 0;
+export const RIM_THETA = -Math.PI / 6;
 
 // The six axial neighbour directions, in the ring-walk order the spiral uses.
 const DIRS: readonly Axial[] = [

--- a/ui/webview/hive-layout.ts
+++ b/ui/webview/hive-layout.ts
@@ -7,6 +7,15 @@
 
 export interface Axial { q: number; r: number }
 
+// Board scale. Neighbour centers sit √3·HEX_SIZE apart (axialToXZ); each pad's top is a hex
+// prism of circumradius PAD_R with an EDGE turned toward every neighbour (hive.ts thetaStart
+// π/6), so its apothem is PAD_R·√3/2. PAD_R = HEX_SIZE makes twice the apothem exactly the
+// neighbour gap: adjacent pads snap flush and share their edge, one connected honeycomb
+// rather than islands (the user 2026-08-13, who wanted the hexagons snapped together). The
+// pads' slight base flare (hive.ts ×1.04) tucks under the shared rim, hiding any seam.
+export const HEX_SIZE = 2.05;
+export const PAD_R = HEX_SIZE;
+
 // The six axial neighbour directions, in the ring-walk order the spiral uses.
 const DIRS: readonly Axial[] = [
   { q: 1, r: 0 }, { q: 1, r: -1 }, { q: 0, r: -1 },
@@ -28,7 +37,7 @@ export function spiralSlot(i: number): Axial {
 }
 
 // Pointy-top axial → world XZ. `size` is the hex circumradius (center to corner); adjacent
-// pad centers land size·√3 apart, so pads with outer radius < size·√3/2 never touch.
+// pad centers land size·√3 apart.
 export function axialToXZ(a: Axial, size: number): { x: number; z: number } {
   const s3 = Math.sqrt(3);
   return { x: size * (s3 * a.q + (s3 / 2) * a.r), z: size * 1.5 * a.r };

--- a/ui/webview/hive-layout.ts
+++ b/ui/webview/hive-layout.ts
@@ -1,0 +1,72 @@
+// Hive layout — the pure hex math (no DOM, no three imports; tested by hive-layout.test.ts).
+// Pointy-top axial coordinates. Slot i counts a center-out spiral: slot 0 is the origin and
+// ring k holds 6k slots, so the board grows evenly in every direction and a slot index alone
+// fixes a pad's place. Sessions KEEP their slot for life (assignSlots) — the board never
+// reshuffles on a push, only on a real arrival or departure (CLAUDE.md ## Design: a pad may
+// move only on new information).
+
+export interface Axial { q: number; r: number }
+
+// The six axial neighbour directions, in the ring-walk order the spiral uses.
+const DIRS: readonly Axial[] = [
+  { q: 1, r: 0 }, { q: 1, r: -1 }, { q: 0, r: -1 },
+  { q: -1, r: 0 }, { q: -1, r: 1 }, { q: 0, r: 1 },
+];
+
+// Ring k spans spiral indices [3k(k-1)+1, 3k(k+1)]; walk starts at DIRS[4]·k (the south-west
+// corner) and takes k steps along each of the six directions in order.
+export function spiralSlot(i: number): Axial {
+  if (!Number.isFinite(i) || i <= 0) return { q: 0, r: 0 };
+  let k = 1;
+  while (3 * k * (k + 1) < i) k++;
+  const idx = i - (3 * k * (k - 1) + 1);
+  let q = DIRS[4].q * k, r = DIRS[4].r * k;
+  const side = Math.floor(idx / k), step = idx % k;
+  for (let s = 0; s < side; s++) { q += DIRS[s].q * k; r += DIRS[s].r * k; }
+  q += DIRS[side].q * step; r += DIRS[side].r * step;
+  return { q, r };
+}
+
+// Pointy-top axial → world XZ. `size` is the hex circumradius (center to corner); adjacent
+// pad centers land size·√3 apart, so pads with outer radius < size·√3/2 never touch.
+export function axialToXZ(a: Axial, size: number): { x: number; z: number } {
+  const s3 = Math.sqrt(3);
+  return { x: size * (s3 * a.q + (s3 / 2) * a.r), z: size * 1.5 * a.r };
+}
+
+export function hexDistance(a: Axial, b: Axial): number {
+  const dq = a.q - b.q, dr = a.r - b.r;
+  return (Math.abs(dq) + Math.abs(dr) + Math.abs(dq + dr)) / 2;
+}
+
+// Stable slot assignment. `prev` is the last known sid→slot map (persisted by the caller);
+// `sids` the sessions present NOW, in arrival order. Every sid that had a slot keeps it
+// (first claim wins on a corrupt duplicate); new sids fill the lowest free slots in order.
+// Dropping a sid from `sids` frees its slot for FUTURE arrivals only — nothing already
+// placed ever moves.
+export function assignSlots(prev: ReadonlyMap<string, number>, sids: readonly string[]): Map<string, number> {
+  const out = new Map<string, number>();
+  const used = new Set<number>();
+  for (const sid of sids) {
+    const s = prev.get(sid);
+    if (s !== undefined && Number.isInteger(s) && s >= 0 && !used.has(s)) { out.set(sid, s); used.add(s); }
+  }
+  let next = 0;
+  for (const sid of sids) {
+    if (out.has(sid)) continue;
+    while (used.has(next)) next++;
+    out.set(sid, next); used.add(next);
+  }
+  return out;
+}
+
+// World-space radius of the occupied board (for camera framing): the farthest pad center
+// from the origin, plus one pad of margin so the frame never crops a rim.
+export function frameRadius(slots: readonly number[], size: number): number {
+  let r = 0;
+  for (const i of slots) {
+    const { x, z } = axialToXZ(spiralSlot(i), size);
+    r = Math.max(r, Math.hypot(x, z));
+  }
+  return r + size * 2;
+}

--- a/ui/webview/hive-layout.ts
+++ b/ui/webview/hive-layout.ts
@@ -60,6 +60,32 @@ export function hexDistance(a: Axial, b: Axial): number {
   return (Math.abs(dq) + Math.abs(dr) + Math.abs(dq + dr)) / 2;
 }
 
+// World XZ → the axial cell containing it: the inverse of axialToXZ, cube-rounded so a
+// point anywhere inside a hex maps to that hex (nearest-center in hex metric).
+export function xzToAxial(x: number, z: number, size: number): Axial {
+  const qf = ((Math.sqrt(3) / 3) * x - z / 3) / size;
+  const rf = (2 / 3) * z / size;
+  const sf = -qf - rf;
+  let q = Math.round(qf), r = Math.round(rf);
+  const s = Math.round(sf);
+  const dq = Math.abs(q - qf), dr = Math.abs(r - rf), ds = Math.abs(s - sf);
+  if (dq > dr && dq > ds) q = -r - s;
+  else if (dr > ds) r = -q - s;
+  return { q: q + 0 === 0 ? 0 : q, r: r + 0 === 0 ? 0 : r };   // Math.round(-0.2) is -0
+}
+
+// Spiral index of an axial cell — the inverse of spiralSlot. Walks the cell's own ring
+// (6k cells, k small on any real board), so no closed-form arithmetic to get subtly wrong.
+export function slotOfAxial(a: Axial): number {
+  const k = hexDistance(a, { q: 0, r: 0 });
+  if (k === 0) return 0;
+  for (let i = 3 * k * (k - 1) + 1; i <= 3 * k * (k + 1); i++) {
+    const s = spiralSlot(i);
+    if (s.q === a.q && s.r === a.r) return i;
+  }
+  return -1;                                   // unreachable for a well-formed axial
+}
+
 // Ring number of a spiral slot — the inverse of spiralSlot's ring arithmetic.
 export function ringOf(i: number): number {
   if (!Number.isFinite(i) || i <= 0) return 0;

--- a/ui/webview/hive-model.test.ts
+++ b/ui/webview/hive-model.test.ts
@@ -63,15 +63,64 @@ test("goal = the freshest not-done top; provisional gist when no node exists yet
   assert.equal(prov[1].goal, "Refactor the auth flow");
 });
 
-test("brief prefers the blocked card's decision brief, then its boxed why", () => {
+test("brief prefers the needs-input card's decision brief, then its boxed why", () => {
+  // column values are the kernel's REAL vocabulary (working | needs_input | completed) —
+  // the first cut of this file guessed "blocked", a value build_feed never emits
   const withBrief = buildSessions(payload({
-    asks: [{ sid: SID_WEB, itemId: "g-ship", column: "blocked", blockSummary: "Pick auth: cookie or token?" }],
+    asks: [{ sid: SID_WEB, itemId: "g-ship", column: "needs_input", blockSummary: "Pick auth: cookie or token?" }],
   }))!;
   assert.equal(withBrief[0].brief, "Pick auth: cookie or token?");
   const withWhat = buildSessions(payload({
-    asks: [{ sid: SID_WEB, itemId: "g-ship", column: "blocked", blocked: { state: "apiError", what: "stopped on an API error" } }],
+    asks: [{ sid: SID_WEB, itemId: "g-ship", column: "needs_input", blocked: { state: "apiError", what: "stopped on an API error" } }],
   }))!;
   assert.equal(withWhat[0].brief, "stopped on an API error");
+});
+
+test("a filed needs-you card lights the session: calm chips read awaiting", () => {
+  const card = { sid: SID_WEB, itemId: "g-ship", column: "needs_input", blockSummary: "Cookie or token?" };
+  for (const chip of ["ready", "awaitingBg", "working"]) {
+    const out = buildSessions(payload({ webState: chip, asks: [card] }))!;
+    assert.equal(out[0].state, "awaiting", `chip ${chip} + filed card → awaiting`);
+    assert.equal(out[0].needsYou, true);
+    assert.equal(out[0].brief, "Cookie or token?");
+  }
+  // chips that carry their own urgent story keep it — the card evidence outranks only calm
+  for (const chip of ["blocked", "retrying", "compacting", "clearing", "interrupting", "opening"]) {
+    const out = buildSessions(payload({ webState: chip, asks: [card] }))!;
+    assert.equal(out[0].state, chip, `chip ${chip} keeps its own state`);
+    assert.equal(out[0].needsYou, true, "…but the evidence still rides along");
+  }
+  // the synth placeholder for a live prompt with no goal is provisional AND needs_input —
+  // it lights too, and its boxed why is the brief
+  const synth = buildSessions(payload({
+    webState: "ready",
+    asks: [{ sid: SID_WEB, itemId: "blocked:" + SID_WEB, column: "needs_input", provisional: true,
+             blocked: { state: "permission", what: "this session is stopped awaiting your approval" } }],
+  }))!;
+  assert.equal(synth[0].state, "awaiting");
+  assert.equal(synth[0].brief, "this session is stopped awaiting your approval");
+});
+
+test("an answered card pending judgment does NOT light (rejudging/recheck)", () => {
+  for (const flag of ["rejudging", "recheck"]) {
+    const out = buildSessions(payload({
+      webState: "working",
+      asks: [{ sid: SID_WEB, itemId: "g-ship", column: "needs_input", [flag]: true, blockSummary: "answered already" }],
+    }))!;
+    assert.equal(out[0].state, "working", `${flag} card → chip state stands`);
+    assert.equal(out[0].needsYou, false);
+  }
+});
+
+test("the needs-you latch cannot flap across turn-boundary chip flips", () => {
+  const card = { sid: SID_WEB, itemId: "g-ship", column: "needs_input", blockSummary: "Cookie or token?" };
+  const a = buildSessions(payload({ webState: "working", asks: [card] }))!;
+  const b = buildSessions(payload({ webState: "ready", asks: [card] }))!;
+  assert.deepEqual(diffSessions(a, b).stateChanged, [],
+    "chip working→ready under a filed card is NOT an event — awaiting holds");
+  const answered = buildSessions(payload({ webState: "ready", asks: [{ ...card, rejudging: true }] }))!;
+  assert.equal(diffSessions(b, answered).stateChanged.length, 1,
+    "…the reply (rejudging) IS the event that releases it");
 });
 
 test("open-turn narration rides through from the working card", () => {
@@ -125,7 +174,7 @@ test("the card's state line speaks the user's terms for every chip", () => {
   assert.equal(
     stateLine({ ...base, state: "working", narration: { since: 990, toolUses: 1 } }, 1000),
     "working — 1 tool in, 10s");
-  assert.equal(at("awaiting"), "needs you — stopped on a question");
+  assert.equal(at("awaiting"), "needs you — waiting on your answer");
   assert.equal(at("blocked"), "stopped on an API error");
   assert.equal(at("retrying"), "hitting API errors, retrying");
   assert.equal(at("awaitingBg"), "idle, waiting on background work");

--- a/ui/webview/hive-model.test.ts
+++ b/ui/webview/hive-model.test.ts
@@ -4,7 +4,7 @@
 // done-transition. All fixture data is synthetic (notes-api demo world, placeholder sids).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { buildSessions, diffSessions, finishedLine, foldSeenDone, HiveSession, hiveAge, stateLine } from "./hive-model";
+import { buildSessions, diffSessions, finishedLine, foldSeenAsk, foldSeenDone, HiveSession, hiveAge, stateLine } from "./hive-model";
 
 const SID_WEB = "11111111-2222-3333-4444-555555555555";
 const SID_API = "66666666-7777-8888-9999-aaaaaaaaaaaa";
@@ -241,6 +241,40 @@ test("foldSeenDone: history is not an event; a NEW completion latches until acke
   // the ack (the user's look gesture advances the watermark) clears it for good
   const acked = { ...f1.seen, [SID_WEB]: 400 };
   assert.deepEqual([...foldSeenDone(acked, after).unseen], []);
+});
+
+test("filed asks carry their time and the live-prompt bit rides separately", () => {
+  const card = { sid: SID_WEB, itemId: "g-ship", column: "needs_input", t: 900, blockSummary: "Cookie or token?" };
+  const out = buildSessions(payload({ webState: "ready", asks: [card] }))!;
+  assert.equal(out[0].needsYouT, 900, "the newest filed card's own time is the watermark evidence");
+  assert.equal(out[0].liveAsk, false, "a filed question is not a live prompt");
+  const live = buildSessions(payload({ webState: "awaiting" }))!;
+  assert.equal(live[0].liveAsk, true);
+  assert.equal(live[0].needsYouT, 0);
+});
+
+test("the awaiting line: a live prompt speaks in the present, a filed ask wears its age", () => {
+  const card = { sid: SID_WEB, itemId: "g-ship", column: "needs_input", t: 900 };
+  const filed = buildSessions(payload({ webState: "ready", asks: [card] }))![0];
+  assert.equal(stateLine(filed, 900 + 7200), "needs you — asked 2h ago",
+    "last night's question must not read as being asked right now");
+  const live = buildSessions(payload({ webState: "awaiting" }))![0];
+  assert.equal(stateLine(live, 1000), "needs you — waiting on your answer");
+});
+
+test("foldSeenAsk: a filed question is a DEBT — no first-sight seeding, shouts until looked at", () => {
+  const card = { sid: SID_WEB, itemId: "g-ship", column: "needs_input", t: 900 };
+  const sessions = buildSessions(payload({ webState: "ready", asks: [card] }))!;
+  // unlike foldSeenDone, an unknown sid does NOT seed away: a fresh browser/reload still owes the shout
+  const f0 = foldSeenAsk({}, sessions);
+  assert.deepEqual([...f0.unseen], [SID_WEB], "a standing question survives any reload");
+  assert.equal(f0.seen[SID_WEB], undefined, "…and nothing is written until the user actually looks");
+  // the look (the ack writes the card's time) quiets it…
+  const acked = { [SID_WEB]: 900 };
+  assert.deepEqual([...foldSeenAsk(acked, sessions).unseen], []);
+  // …until a NEWER filed ask arrives (a fresh judge verdict = new information)
+  const newer = buildSessions(payload({ webState: "ready", asks: [{ ...card, t: 950 }] }))!;
+  assert.deepEqual([...foldSeenAsk(acked, newer).unseen], [SID_WEB], "a new question re-arms the shout");
 });
 
 test("foldSeenDone keeps absentees for revival, bounded like the slot map", () => {

--- a/ui/webview/hive-model.test.ts
+++ b/ui/webview/hive-model.test.ts
@@ -112,6 +112,20 @@ test("an answered card pending judgment does NOT light (rejudging/recheck)", () 
   }
 });
 
+test("a session the user STOPPED does not claim to be waiting on them", () => {
+  // the interrupted card files under needs-you in the feed (re-engaging is the user's move,
+  // the badge says why) — but its quiet is user-chosen, so the board must not wave
+  // "waiting on your answer" at the person who just pressed stop
+  for (const flag of ["interrupting", "interrupted"]) {
+    const out = buildSessions(payload({
+      webState: "ready",
+      asks: [{ sid: SID_WEB, itemId: "g-ship", column: "needs_input", [flag]: true, blockSummary: "stopped by you" }],
+    }))!;
+    assert.equal(out[0].state, "ready", `${flag} card → chip state stands`);
+    assert.equal(out[0].needsYou, false);
+  }
+});
+
 test("the needs-you latch cannot flap across turn-boundary chip flips", () => {
   const card = { sid: SID_WEB, itemId: "g-ship", column: "needs_input", blockSummary: "Cookie or token?" };
   const a = buildSessions(payload({ webState: "working", asks: [card] }))!;

--- a/ui/webview/hive-model.test.ts
+++ b/ui/webview/hive-model.test.ts
@@ -1,0 +1,126 @@
+// Hive model invariants (plans/hive.md): the scene animates ONLY from diff events, so the
+// board can never move without new information — an identical payload twice must yield zero
+// events (CLAUDE.md ## Design), and a goal celebration fires exactly once per observed
+// done-transition. All fixture data is synthetic (notes-api demo world, placeholder sids).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { buildSessions, diffSessions, HiveSession } from "./hive-model";
+
+const SID_WEB = "11111111-2222-3333-4444-555555555555";
+const SID_API = "66666666-7777-8888-9999-aaaaaaaaaaaa";
+
+function payload(over?: {
+  webState?: string; webDone?: boolean; webFaded?: boolean;
+  asks?: any[]; ledgers?: any[];
+}) {
+  const ledgers = over?.ledgers ?? [
+    {
+      sid: SID_WEB, name: "web", color: { bg: "#88ccff", fg: "#001122" },
+      status: { state: over?.webState ?? "working", faded: !!over?.webFaded },
+      ledger: {
+        tree: [
+          { id: "g-ship", depth: 0, done: !!over?.webDone, text: "Ship the notes list page", t: 300, mt: 400 },
+          { id: "g-sub", depth: 1, done: false, text: "wire the fetch", t: 320 },
+          { id: "g-old", depth: 0, done: true, text: "Set up the repo", t: 100, mt: 120 },
+        ],
+        archivedTops: [{ id: "g-arch", depth: 0, done: true, text: "Pick a framework", t: 50, mt: 60 }],
+      },
+    },
+    {
+      sid: SID_API, name: "api", color: { bg: "#ffcc88", fg: "#221100" },
+      status: { state: "ready", faded: false },
+      ledger: { tree: [], archivedTops: [] },
+    },
+  ];
+  return { type: "feed", ledgers, asks: over?.asks ?? [] };
+}
+
+test("no ledgers key → null (loader stays up); empty ledgers → empty board", () => {
+  assert.equal(buildSessions({ type: "feed" }), null);
+  assert.equal(buildSessions(null), null);
+  assert.deepEqual(buildSessions({ type: "feed", ledgers: [] }), []);
+});
+
+test("chip states pass through; unknown or missing states fall to ready", () => {
+  for (const s of ["working", "awaiting", "blocked", "retrying", "awaitingBg",
+                   "compacting", "clearing", "interrupting", "opening", "ready"]) {
+    const out = buildSessions(payload({ webState: s }))!;
+    assert.equal(out[0].state, s);
+  }
+  assert.equal(buildSessions(payload({ webState: "someFutureChip" }))![0].state, "ready");
+  const noStatus = payload();
+  (noStatus.ledgers as any)[0].status = null;
+  assert.equal(buildSessions(noStatus)![0].state, "ready");
+});
+
+test("goal = the freshest not-done top; provisional gist when no node exists yet", () => {
+  const out = buildSessions(payload())!;
+  assert.equal(out[0].goal, "Ship the notes list page");
+  assert.equal(out[1].goal, null, "api has no open work and no provisional card");
+  const prov = buildSessions(payload({
+    asks: [{ sid: SID_API, provisional: true, text: "Refactor the auth flow" }],
+  }))!;
+  assert.equal(prov[1].goal, "Refactor the auth flow");
+});
+
+test("brief prefers the blocked card's decision brief, then its boxed why", () => {
+  const withBrief = buildSessions(payload({
+    asks: [{ sid: SID_WEB, itemId: "g-ship", column: "blocked", blockSummary: "Pick auth: cookie or token?" }],
+  }))!;
+  assert.equal(withBrief[0].brief, "Pick auth: cookie or token?");
+  const withWhat = buildSessions(payload({
+    asks: [{ sid: SID_WEB, itemId: "g-ship", column: "blocked", blocked: { state: "apiError", what: "stopped on an API error" } }],
+  }))!;
+  assert.equal(withWhat[0].brief, "stopped on an API error");
+});
+
+test("open-turn narration rides through from the working card", () => {
+  const out = buildSessions(payload({
+    asks: [{ sid: SID_WEB, itemId: "g-ship", column: "working", working: { since: 1234, toolUses: 7 } }],
+  }))!;
+  assert.deepEqual(out[0].narration, { since: 1234, toolUses: 7 });
+  assert.equal(out[1].narration, null);
+});
+
+test("identical payload twice → ZERO events (the no-flap invariant)", () => {
+  const a = buildSessions(payload())!;
+  const b = buildSessions(payload())!;
+  const d = diffSessions(a, b);
+  assert.deepEqual(d, { added: [], removed: [], stateChanged: [], goalDone: [] });
+});
+
+test("first payload: everything is added, nothing 'changed' against a void", () => {
+  const d = diffSessions(null, buildSessions(payload())!);
+  assert.deepEqual(d.added.sort(), [SID_API, SID_WEB].sort());
+  assert.equal(d.stateChanged.length, 0);
+  assert.equal(d.goalDone.length, 0);
+});
+
+test("state changes carry from→to; arrivals and departures name their sid", () => {
+  const a = buildSessions(payload())!;
+  const b = buildSessions(payload({ webState: "awaiting" }))!;
+  const d = diffSessions(a, b);
+  assert.deepEqual(d.stateChanged, [{ sid: SID_WEB, from: "working", to: "awaiting" }]);
+  const gone = diffSessions(b, b.filter((s: HiveSession) => s.sid !== SID_API));
+  assert.deepEqual(gone.removed, [SID_API]);
+});
+
+test("goalDone fires once per observed done-transition, never for history", () => {
+  const before = buildSessions(payload({ webDone: false }))!;
+  const after = buildSessions(payload({ webDone: true }))!;
+  assert.deepEqual(diffSessions(before, after).goalDone, [SID_WEB], "the transition fires");
+  assert.deepEqual(diffSessions(after, after).goalDone, [], "…exactly once");
+  // a session ARRIVING with done goals is history, not an event
+  assert.deepEqual(diffSessions(null, after).goalDone, []);
+});
+
+test("a top completing straight into the archive still fires (known id, newly done)", () => {
+  const before = buildSessions(payload({ webDone: false }))!;
+  const archived = payload({ webDone: false });
+  const tree = (archived.ledgers as any)[0].ledger;
+  // the compaction sweep moved g-ship out of the live tree into archivedTops, now done
+  tree.tree = tree.tree.filter((n: any) => n.id !== "g-ship" && n.id !== "g-sub");
+  tree.archivedTops.push({ id: "g-ship", depth: 0, done: true, text: "Ship the notes list page", t: 300, mt: 500 });
+  const after = buildSessions(archived)!;
+  assert.deepEqual(diffSessions(before, after).goalDone, [SID_WEB]);
+});

--- a/ui/webview/hive-model.test.ts
+++ b/ui/webview/hive-model.test.ts
@@ -4,7 +4,7 @@
 // done-transition. All fixture data is synthetic (notes-api demo world, placeholder sids).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { buildSessions, diffSessions, HiveSession } from "./hive-model";
+import { buildSessions, diffSessions, HiveSession, hiveAge, stateLine } from "./hive-model";
 
 const SID_WEB = "11111111-2222-3333-4444-555555555555";
 const SID_API = "66666666-7777-8888-9999-aaaaaaaaaaaa";
@@ -112,6 +112,37 @@ test("goalDone fires once per observed done-transition, never for history", () =
   assert.deepEqual(diffSessions(after, after).goalDone, [], "…exactly once");
   // a session ARRIVING with done goals is history, not an event
   assert.deepEqual(diffSessions(null, after).goalDone, []);
+});
+
+test("the card's state line speaks the user's terms for every chip", () => {
+  const base = buildSessions(payload())![0];
+  const at = (state: string, extra?: Partial<HiveSession>) =>
+    stateLine({ ...base, state: state as HiveSession["state"], narration: null, ...extra }, 1000);
+  assert.equal(at("working"), "working");
+  assert.equal(
+    stateLine({ ...base, state: "working", narration: { since: 860, toolUses: 7 } }, 1000),
+    "working — 7 tools in, 2m");
+  assert.equal(
+    stateLine({ ...base, state: "working", narration: { since: 990, toolUses: 1 } }, 1000),
+    "working — 1 tool in, 10s");
+  assert.equal(at("awaiting"), "needs you — stopped on a question");
+  assert.equal(at("blocked"), "stopped on an API error");
+  assert.equal(at("retrying"), "hitting API errors, retrying");
+  assert.equal(at("awaitingBg"), "idle, waiting on background work");
+  assert.equal(at("compacting"), "compacting its context");
+  assert.equal(at("clearing"), "clearing its context");
+  assert.equal(at("interrupting"), "stopping…");
+  assert.equal(at("opening"), "starting up");
+  assert.equal(at("ready"), "ready");
+  assert.equal(at("ready", { faded: true }), "idle for a while");
+});
+
+test("hiveAge compacts like the outline's ages", () => {
+  assert.equal(hiveAge(42), "42s");
+  assert.equal(hiveAge(180), "3m");
+  assert.equal(hiveAge(7200), "2h");
+  assert.equal(hiveAge(200000), "2d");
+  assert.equal(hiveAge(-5), "0s");
 });
 
 test("a top completing straight into the archive still fires (known id, newly done)", () => {

--- a/ui/webview/hive-model.test.ts
+++ b/ui/webview/hive-model.test.ts
@@ -4,7 +4,7 @@
 // done-transition. All fixture data is synthetic (notes-api demo world, placeholder sids).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { buildSessions, diffSessions, HiveSession, hiveAge, stateLine } from "./hive-model";
+import { buildSessions, diffSessions, finishedLine, foldSeenDone, HiveSession, hiveAge, stateLine } from "./hive-model";
 
 const SID_WEB = "11111111-2222-3333-4444-555555555555";
 const SID_API = "66666666-7777-8888-9999-aaaaaaaaaaaa";
@@ -192,6 +192,53 @@ test("hiveAge compacts like the outline's ages", () => {
   assert.equal(hiveAge(7200), "2h");
   assert.equal(hiveAge(200000), "2d");
   assert.equal(hiveAge(-5), "0s");
+});
+
+test("doneT is the newest completion event across live + archived tops", () => {
+  const out = buildSessions(payload())!;
+  assert.equal(out[0].doneT, 120, "g-old done at mt 120 beats archived g-arch at 60");
+  assert.equal(out[1].doneT, 0, "api has no completions");
+  const after = buildSessions(payload({ webDone: true }))!;
+  assert.equal(after[0].doneT, 400, "g-ship completing moves the watermark to its mt");
+});
+
+test("finishedLine says what the ✓ means, with the completion's age", () => {
+  const s = buildSessions(payload({ webDone: true }))![0];
+  assert.equal(finishedLine(s, 520), "finished working — 2m ago");
+  assert.equal(finishedLine(s, 400), "finished working — 0s ago");
+});
+
+test("foldSeenDone: history is not an event; a NEW completion latches until acked", () => {
+  const before = buildSessions(payload({ webDone: false }))!;
+  // first sight seeds watermarks to the current doneT — a board opening onto old
+  // completions must not celebrate history (the goalDone rule, applied to the latch)
+  const f0 = foldSeenDone({}, before);
+  assert.deepEqual([...f0.unseen], []);
+  assert.equal(f0.seen[SID_WEB], 120);
+  assert.equal(f0.changed, true, "the seeding is a persistable change");
+  // a completion after the seed latches…
+  const after = buildSessions(payload({ webDone: true }))!;
+  const f1 = foldSeenDone(f0.seen, after);
+  assert.deepEqual([...f1.unseen], [SID_WEB]);
+  assert.equal(f1.changed, false, "deriving the unseen set writes nothing by itself");
+  // …and holds across a reload (the persisted record is the whole latch)
+  const f2 = foldSeenDone(f1.seen, after);
+  assert.deepEqual([...f2.unseen], [SID_WEB], "reload cannot swallow an unseen finish");
+  // the ack (the user's look gesture advances the watermark) clears it for good
+  const acked = { ...f1.seen, [SID_WEB]: 400 };
+  assert.deepEqual([...foldSeenDone(acked, after).unseen], []);
+});
+
+test("foldSeenDone keeps absentees for revival, bounded like the slot map", () => {
+  const sessions = buildSessions(payload())!;
+  const seed: Record<string, number> = { "dead-1": 50 };
+  const f = foldSeenDone(seed, sessions);
+  assert.equal(f.seen["dead-1"], 50, "a departed sid keeps its stamp — revival must not celebrate its past");
+  const big: Record<string, number> = {};
+  for (let i = 0; i < 220; i++) big["gone-" + i] = i;
+  const pruned = foldSeenDone(big, sessions).seen;
+  assert.ok(Object.keys(pruned).length <= 202, "absentees drop once the record outgrows the memory cap");
+  assert.equal(pruned[SID_WEB], 120, "live sids always survive the prune");
 });
 
 test("a top completing straight into the archive still fires (known id, newly done)", () => {

--- a/ui/webview/hive-model.ts
+++ b/ui/webview/hive-model.ts
@@ -85,15 +85,19 @@ export function buildSessions(msg: any): HiveSession[] | null {
     }
     // needs-you: a card FILED under needs_input (a judge verdict, a floored live prompt, a
     // synth placeholder) — the feed's own column vocabulary, not the "blocked" guess this
-    // code first shipped with (a column value the kernel never emits). rejudging/recheck
-    // cards are excluded: the user already answered those, the judges own the next move —
-    // counting them would wave ❗ at a person who owes nothing (and would clear again on
-    // the verdict, a move with no new information for the user).
+    // code first shipped with (a column value the kernel never emits). Excluded, because in
+    // each the user owes nothing NEW:
+    //   - rejudging/recheck: they already answered; the judges own the next move;
+    //   - interrupting/interrupted: THEIR OWN stop is why it's quiet (feed.ts calls that
+    //     quiet user-chosen — even auto-nudge holds off) — waving "waiting on your answer"
+    //     right after their own gesture claimed a question nobody asked (the user
+    //     2026-08-14, who was told a session waited on their response when it wasn't).
     let needsYou = false;
     // why it needs you — the blocked card's own copy, briefest honest form first
     let brief: string | null = null;
     for (const a of cards) {
-      const filed = a.column === "needs_input" && !a.rejudging && !a.recheck;
+      const filed = a.column === "needs_input" && !a.rejudging && !a.recheck
+        && !a.interrupting && !a.interrupted;
       if (filed) needsYou = true;
       // provisional cards are placeholders EXCEPT the needs-input one (a live prompt with
       // no goal to floor) — its boxed why is exactly the brief for that state

--- a/ui/webview/hive-model.ts
+++ b/ui/webview/hive-model.ts
@@ -1,0 +1,140 @@
+// Hive model — feed payload in, session snapshots + DIFF EVENTS out (pure; tested by
+// hive-model.test.ts). The scene animates ONLY from these events, never by re-deriving per
+// push: an identical payload twice yields zero events, so nothing on the board can move
+// without new information (CLAUDE.md ## Design). The state values are the kernel's shared
+// session chip (_session_chip) as it rides ledgers[].status.state.
+
+export type HiveState =
+  | "opening" | "working" | "awaiting" | "blocked" | "retrying"
+  | "awaitingBg" | "compacting" | "clearing" | "interrupting" | "ready";
+
+const STATES: ReadonlySet<string> = new Set<string>([
+  "opening", "working", "awaiting", "blocked", "retrying",
+  "awaitingBg", "compacting", "clearing", "interrupting", "ready",
+]);
+
+export interface HiveColor { bg: string; fg: string }
+
+export interface HiveSession {
+  sid: string;
+  name: string;
+  color: HiveColor | null;
+  state: HiveState;
+  faded: boolean;                 // ready for >1h — the doze cue
+  goal: string | null;            // what it's on: the freshest open top goal, else the provisional gist
+  brief: string | null;           // why it needs you: the blocked card's decision brief / boxed why
+  narration: { since: number; toolUses: number } | null;   // open-turn progress (working cards)
+  topIds: string[];               // every known top-level goal id (live + archived)
+  doneTopIds: string[];           // the done subset — goalDone transition detection
+}
+
+export interface HiveDiff {
+  added: string[];                          // sids that appeared
+  removed: string[];                        // sids that left
+  stateChanged: { sid: string; from: HiveState; to: HiveState }[];
+  goalDone: string[];                       // sids where a KNOWN top goal newly completed
+}
+
+interface LedgerNodeIn {
+  id?: string; depth?: number; done?: boolean; cleared?: boolean;
+  text?: string; t?: number; mt?: number; current?: boolean;
+}
+
+function normState(v: unknown): HiveState {
+  return (typeof v === "string" && STATES.has(v) ? v : "ready") as HiveState;
+}
+
+function topNodes(ledger: any): { live: LedgerNodeIn[]; archived: LedgerNodeIn[] } {
+  const tree: LedgerNodeIn[] = Array.isArray(ledger?.tree) ? ledger.tree : [];
+  const arch: LedgerNodeIn[] = Array.isArray(ledger?.archivedTops) ? ledger.archivedTops : [];
+  return {
+    live: tree.filter((n) => n && n.depth === 0 && typeof n.id === "string"),
+    archived: arch.filter((n) => n && n.depth === 0 && typeof n.id === "string"),
+  };
+}
+
+// Build the per-session snapshots from one feed payload. Returns null when the payload
+// carries no `ledgers` yet (cold build still running) — the caller keeps its loader up,
+// exactly like the outline pane does.
+export function buildSessions(msg: any): HiveSession[] | null {
+  if (!msg || !Array.isArray(msg.ledgers)) return null;
+  const asks: any[] = Array.isArray(msg.asks) ? msg.asks : [];
+  const bySid = new Map<string, any[]>();
+  for (const a of asks) {
+    if (!a || typeof a.sid !== "string") continue;
+    const l = bySid.get(a.sid); if (l) l.push(a); else bySid.set(a.sid, [a]);
+  }
+  const out: HiveSession[] = [];
+  for (const m of msg.ledgers) {
+    if (!m || typeof m.sid !== "string") continue;
+    const cards = bySid.get(m.sid) || [];
+    const { live, archived } = topNodes(m.ledger);
+    // the freshest not-done, not-cleared top = "what it's on"; a session on a brand-new,
+    // not-yet-classified prompt has no node — its provisional card carries the live gist
+    let goal: string | null = null, goalT = -1;
+    for (const n of live) {
+      if (n.done || n.cleared) continue;
+      const t = (n.current ? Number.MAX_SAFE_INTEGER : (n.mt ?? n.t ?? 0)) || 0;
+      if (t > goalT) { goalT = t; goal = (n.text || "").trim() || null; }
+    }
+    if (goal === null) {
+      const prov = cards.find((a) => a.provisional && typeof a.text === "string" && a.text.trim());
+      if (prov) goal = prov.text.trim();
+    }
+    // why it needs you — the blocked card's own copy, briefest honest form first
+    let brief: string | null = null;
+    for (const a of cards) {
+      if (a.provisional) continue;
+      const b = (typeof a.blockSummary === "string" && a.blockSummary.trim())
+        || (a.blocked && typeof a.blocked.what === "string" && a.blocked.what.trim())
+        || (a.awaiting && typeof a.awaiting.why === "string" && a.awaiting.why.trim()) || "";
+      if (b && (a.column === "blocked" || a.blocked)) { brief = b; break; }
+      if (b && !brief) brief = b;
+    }
+    // open-turn narration rides the working card (kernel _open_turn_progress)
+    let narration: { since: number; toolUses: number } | null = null;
+    for (const a of cards) {
+      const w = a && a.working;
+      if (w && typeof w === "object" && typeof w.toolUses === "number") {
+        narration = { since: Number(w.since) || 0, toolUses: w.toolUses };
+        break;
+      }
+    }
+    const topIds = [...live, ...archived].map((n) => n.id as string);
+    const doneTopIds = [...live.filter((n) => !!n.done), ...archived].map((n) => n.id as string);
+    out.push({
+      sid: m.sid,
+      name: typeof m.name === "string" ? m.name : m.sid.slice(0, 8),
+      color: m.color && typeof m.color.bg === "string" ? { bg: m.color.bg, fg: m.color.fg || "#000" } : null,
+      state: normState(m.status && m.status.state),
+      faded: !!(m.status && m.status.faded),
+      goal, brief, narration,
+      topIds: [...new Set(topIds)].sort(),
+      doneTopIds: [...new Set(doneTopIds)].sort(),
+    });
+  }
+  return out;
+}
+
+// The event stream between two snapshots. `prev` null means "first payload": everything is
+// `added`, and no state/goal events fire (there is no earlier world to compare against).
+export function diffSessions(prev: HiveSession[] | null, next: HiveSession[]): HiveDiff {
+  const d: HiveDiff = { added: [], removed: [], stateChanged: [], goalDone: [] };
+  const pm = new Map((prev || []).map((s) => [s.sid, s] as const));
+  const nm = new Map(next.map((s) => [s.sid, s] as const));
+  for (const s of next) if (!pm.has(s.sid)) d.added.push(s.sid);
+  if (prev) {
+    for (const s of prev) if (!nm.has(s.sid)) d.removed.push(s.sid);
+    for (const s of next) {
+      const p = pm.get(s.sid);
+      if (!p) continue;
+      if (p.state !== s.state) d.stateChanged.push({ sid: s.sid, from: p.state, to: s.state });
+      // goalDone: a top the previous world already KNEW (id in p.topIds) moved into the done
+      // set — the observed transition, once per completion, never re-derived (the outline's
+      // seenDone pattern). A brand-new id arriving already-done is history, not an event.
+      const prevDone = new Set(p.doneTopIds), prevKnown = new Set(p.topIds);
+      if (s.doneTopIds.some((id) => !prevDone.has(id) && prevKnown.has(id))) d.goalDone.push(s.sid);
+    }
+  }
+  return d;
+}

--- a/ui/webview/hive-model.ts
+++ b/ui/webview/hive-model.ts
@@ -27,6 +27,8 @@ export interface HiveSession {
   topIds: string[];               // every known top-level goal id (live + archived)
   doneTopIds: string[];           // the done subset — goalDone transition detection
   needsYou: boolean;              // a filed needs-you card exists (see buildSessions) — why state may read "awaiting" beyond the live-prompt chip
+  needsYouT: number;              // the newest filed needs-you card's time (0 = none) — the unseen-ask watermark
+  liveAsk: boolean;               // the CHIP itself says awaiting (a live permission/picker prompt) — always shouts, no watermark
   doneT: number;                  // the LATEST completion event across its top goals (0 = none) — the unseen-finished watermark
 }
 
@@ -93,12 +95,13 @@ export function buildSessions(msg: any): HiveSession[] | null {
     //     right after their own gesture claimed a question nobody asked (the user
     //     2026-08-14, who was told a session waited on their response when it wasn't).
     let needsYou = false;
+    let needsYouT = 0;              // the newest filed ask's own time — what the shout watermark compares
     // why it needs you — the blocked card's own copy, briefest honest form first
     let brief: string | null = null;
     for (const a of cards) {
       const filed = a.column === "needs_input" && !a.rejudging && !a.recheck
         && !a.interrupting && !a.interrupted;
-      if (filed) needsYou = true;
+      if (filed) { needsYou = true; needsYouT = Math.max(needsYouT, Number(a.t) || 0); }
       // provisional cards are placeholders EXCEPT the needs-input one (a live prompt with
       // no goal to floor) — its boxed why is exactly the brief for that state
       if (a.provisional && !filed) continue;
@@ -127,6 +130,7 @@ export function buildSessions(msg: any): HiveSession[] | null {
       doneT = Math.max(doneT, (n.mt ?? n.t ?? 0) || 0);
     }
     let state = normState(m.status && m.status.state);
+    const liveAsk = state === "awaiting";   // the chip's own live prompt — before any card override
     // The board must LIGHT UP whenever the session has a question filed for the user (the
     // user 2026-08-13: a session with a question showed a calm pad) — the chip alone only
     // covers the LIVE prompt ("awaiting"); a session that ended its turn by asking, or has
@@ -144,7 +148,7 @@ export function buildSessions(msg: any): HiveSession[] | null {
       color: m.color && typeof m.color.bg === "string" ? { bg: m.color.bg, fg: m.color.fg || "#000" } : null,
       state,
       faded: !!(m.status && m.status.faded),
-      goal, brief, narration, needsYou, doneT,
+      goal, brief, narration, needsYou, needsYouT, liveAsk, doneT,
       topIds: [...new Set(topIds)].sort(),
       doneTopIds: [...new Set(doneTopIds)].sort(),
     });
@@ -170,9 +174,13 @@ export function stateLine(s: HiveSession, now: number): string {
       return n ? `working — ${n.toolUses} tool${n.toolUses === 1 ? "" : "s"} in, ${hiveAge(now - n.since)}`
                : "working";
     }
-    // covers the live prompt AND a filed question (needsYou): the session may even still be
-    // working a sibling goal, so "waiting on your answer" — never "stopped" — stays true
-    case "awaiting": return "needs you — waiting on your answer";
+    // a LIVE prompt is now; a FILED question wears its age — "asked 9h ago" reads honestly
+    // stale where a bare "waiting on your answer" claimed a live question (the user
+    // 2026-08-14, shown last night's asks as if they were being asked right then)
+    case "awaiting":
+      return s.liveAsk || !s.needsYouT
+        ? "needs you — waiting on your answer"
+        : `needs you — asked ${hiveAge(now - s.needsYouT)} ago`;
     case "blocked": return "stopped on an API error";
     case "retrying": return "hitting API errors, retrying";
     case "awaitingBg": return "idle, waiting on background work";
@@ -215,6 +223,33 @@ export function foldSeenDone(prev: SeenDone, sessions: HiveSession[]):
     live.add(s.sid);
     if (!(s.sid in seen)) { seen[s.sid] = s.doneT; changed = true; }
     else if (s.doneT > seen[s.sid]) unseen.add(s.sid);
+  }
+  let extra = Object.keys(seen).length - 200;
+  if (extra > 0) {
+    for (const k of Object.keys(seen)) {
+      if (extra <= 0) break;
+      if (!live.has(k)) { delete seen[k]; changed = true; extra--; }
+    }
+  }
+  return { seen, unseen, changed };
+}
+
+// The unseen-ASK twin (the user 2026-08-14, whose board banged last night's filed questions
+// as if they were being asked right then): a filed needs-you SHOUTS (bang/sonar/wave) only
+// until the user has gone to look — then the pad keeps its honest red (the card still sits
+// in the feed's needs-you column) but stops shouting. ONE deliberate difference from
+// foldSeenDone: NO first-sight seeding. A completion is news (history can be swallowed); a
+// filed question is a DEBT — it must survive reloads, fresh browsers, and this feature
+// shipping, so an unknown sid compares against 0 and shouts until the first real look.
+export function foldSeenAsk(prev: SeenDone, sessions: HiveSession[]):
+    { seen: SeenDone; unseen: Set<string>; changed: boolean } {
+  const seen: SeenDone = { ...prev };
+  const unseen = new Set<string>();
+  let changed = false;
+  const live = new Set<string>();
+  for (const s of sessions) {
+    live.add(s.sid);
+    if (s.needsYouT > (seen[s.sid] ?? 0)) unseen.add(s.sid);
   }
   let extra = Object.keys(seen).length - 200;
   if (extra > 0) {

--- a/ui/webview/hive-model.ts
+++ b/ui/webview/hive-model.ts
@@ -27,6 +27,7 @@ export interface HiveSession {
   topIds: string[];               // every known top-level goal id (live + archived)
   doneTopIds: string[];           // the done subset — goalDone transition detection
   needsYou: boolean;              // a filed needs-you card exists (see buildSessions) — why state may read "awaiting" beyond the live-prompt chip
+  doneT: number;                  // the LATEST completion event across its top goals (0 = none) — the unseen-finished watermark
 }
 
 export interface HiveDiff {
@@ -114,6 +115,13 @@ export function buildSessions(msg: any): HiveSession[] | null {
     }
     const topIds = [...live, ...archived].map((n) => n.id as string);
     const doneTopIds = [...live.filter((n) => !!n.done), ...archived].map((n) => n.id as string);
+    // the newest completion event among its tops (archived tops are all done by definition):
+    // mt is the judge's done-write, t the node's birth — the same freshness read the goal
+    // pick above uses. This is the "finished working" watermark the unseen-done latch compares.
+    let doneT = 0;
+    for (const n of [...live.filter((n) => !!n.done), ...archived]) {
+      doneT = Math.max(doneT, (n.mt ?? n.t ?? 0) || 0);
+    }
     let state = normState(m.status && m.status.state);
     // The board must LIGHT UP whenever the session has a question filed for the user (the
     // user 2026-08-13: a session with a question showed a calm pad) — the chip alone only
@@ -132,7 +140,7 @@ export function buildSessions(msg: any): HiveSession[] | null {
       color: m.color && typeof m.color.bg === "string" ? { bg: m.color.bg, fg: m.color.fg || "#000" } : null,
       state,
       faded: !!(m.status && m.status.faded),
-      goal, brief, narration, needsYou,
+      goal, brief, narration, needsYou, doneT,
       topIds: [...new Set(topIds)].sort(),
       doneTopIds: [...new Set(doneTopIds)].sort(),
     });
@@ -170,6 +178,48 @@ export function stateLine(s: HiveSession, now: number): string {
     case "opening": return "starting up";
     default: return s.faded ? "idle for a while" : "ready";
   }
+}
+
+// The unseen-finished tip/card line: what the ✓ over the bean means, with the age of the
+// completion it is holding for you (the user 2026-08-14, who wanted "finished working"
+// feedback that waits until they have looked).
+export function finishedLine(s: HiveSession, now: number): string {
+  return `finished working — ${hiveAge(now - s.doneT)} ago`;
+}
+
+// ── the unseen-finished latch ─────────────────────────────────────────────────────────────
+// A finished session used to drop straight to a calm blue pad — indistinguishable from one
+// idle all day — with only the one-shot goalDone confetti marking the moment (missed unless
+// you were watching). The latch: per sid, the completion watermark the user has LOOKED at;
+// a session whose doneT is past it wears the finished cue until an actual look gesture
+// (their click through to it) advances the watermark. Every transition is an event — a judge
+// filing done (doneT moves) arms it, the user's own gesture clears it — so it cannot flap,
+// and the record persists (the caller keeps it in localStorage) so a reload can't silently
+// swallow a finish. First sight of a sid seeds its watermark to the current doneT: arriving
+// with old completions is HISTORY, not an event — the exact rule diffSessions applies to
+// goalDone. Absent sids keep their stamps (a revived session must not celebrate its past)
+// until the record outgrows the same 200-entry memory the slot map keeps.
+export type SeenDone = Record<string, number>;
+
+export function foldSeenDone(prev: SeenDone, sessions: HiveSession[]):
+    { seen: SeenDone; unseen: Set<string>; changed: boolean } {
+  const seen: SeenDone = { ...prev };
+  const unseen = new Set<string>();
+  let changed = false;
+  const live = new Set<string>();
+  for (const s of sessions) {
+    live.add(s.sid);
+    if (!(s.sid in seen)) { seen[s.sid] = s.doneT; changed = true; }
+    else if (s.doneT > seen[s.sid]) unseen.add(s.sid);
+  }
+  let extra = Object.keys(seen).length - 200;
+  if (extra > 0) {
+    for (const k of Object.keys(seen)) {
+      if (extra <= 0) break;
+      if (!live.has(k)) { delete seen[k]; changed = true; extra--; }
+    }
+  }
+  return { seen, unseen, changed };
 }
 
 // The event stream between two snapshots. `prev` null means "first payload": everything is

--- a/ui/webview/hive-model.ts
+++ b/ui/webview/hive-model.ts
@@ -26,6 +26,7 @@ export interface HiveSession {
   narration: { since: number; toolUses: number } | null;   // open-turn progress (working cards)
   topIds: string[];               // every known top-level goal id (live + archived)
   doneTopIds: string[];           // the done subset — goalDone transition detection
+  needsYou: boolean;              // a filed needs-you card exists (see buildSessions) — why state may read "awaiting" beyond the live-prompt chip
 }
 
 export interface HiveDiff {
@@ -81,14 +82,25 @@ export function buildSessions(msg: any): HiveSession[] | null {
       const prov = cards.find((a) => a.provisional && typeof a.text === "string" && a.text.trim());
       if (prov) goal = prov.text.trim();
     }
+    // needs-you: a card FILED under needs_input (a judge verdict, a floored live prompt, a
+    // synth placeholder) — the feed's own column vocabulary, not the "blocked" guess this
+    // code first shipped with (a column value the kernel never emits). rejudging/recheck
+    // cards are excluded: the user already answered those, the judges own the next move —
+    // counting them would wave ❗ at a person who owes nothing (and would clear again on
+    // the verdict, a move with no new information for the user).
+    let needsYou = false;
     // why it needs you — the blocked card's own copy, briefest honest form first
     let brief: string | null = null;
     for (const a of cards) {
-      if (a.provisional) continue;
+      const filed = a.column === "needs_input" && !a.rejudging && !a.recheck;
+      if (filed) needsYou = true;
+      // provisional cards are placeholders EXCEPT the needs-input one (a live prompt with
+      // no goal to floor) — its boxed why is exactly the brief for that state
+      if (a.provisional && !filed) continue;
       const b = (typeof a.blockSummary === "string" && a.blockSummary.trim())
         || (a.blocked && typeof a.blocked.what === "string" && a.blocked.what.trim())
         || (a.awaiting && typeof a.awaiting.why === "string" && a.awaiting.why.trim()) || "";
-      if (b && (a.column === "blocked" || a.blocked)) { brief = b; break; }
+      if (b && filed) { brief = b; break; }
       if (b && !brief) brief = b;
     }
     // open-turn narration rides the working card (kernel _open_turn_progress)
@@ -102,13 +114,25 @@ export function buildSessions(msg: any): HiveSession[] | null {
     }
     const topIds = [...live, ...archived].map((n) => n.id as string);
     const doneTopIds = [...live.filter((n) => !!n.done), ...archived].map((n) => n.id as string);
+    let state = normState(m.status && m.status.state);
+    // The board must LIGHT UP whenever the session has a question filed for the user (the
+    // user 2026-08-13: a session with a question showed a calm pad) — the chip alone only
+    // covers the LIVE prompt ("awaiting"); a session that ended its turn by asking, or has
+    // one goal blocked on you while it works another, reads ready/working there. The filed
+    // card is the deciding event (a judge verdict / floor), so this can't flap between
+    // builds: it latches "awaiting" across turn-boundary chip flips (working↔ready) until
+    // the verdict that retires the card. Chip states with their own urgent story — blocked,
+    // retrying, the context ops, opening — keep it; the card evidence outranks only calm.
+    if (needsYou && (state === "ready" || state === "awaitingBg" || state === "working")) {
+      state = "awaiting";
+    }
     out.push({
       sid: m.sid,
       name: typeof m.name === "string" ? m.name : m.sid.slice(0, 8),
       color: m.color && typeof m.color.bg === "string" ? { bg: m.color.bg, fg: m.color.fg || "#000" } : null,
-      state: normState(m.status && m.status.state),
+      state,
       faded: !!(m.status && m.status.faded),
-      goal, brief, narration,
+      goal, brief, narration, needsYou,
       topIds: [...new Set(topIds)].sort(),
       doneTopIds: [...new Set(doneTopIds)].sort(),
     });
@@ -134,7 +158,9 @@ export function stateLine(s: HiveSession, now: number): string {
       return n ? `working — ${n.toolUses} tool${n.toolUses === 1 ? "" : "s"} in, ${hiveAge(now - n.since)}`
                : "working";
     }
-    case "awaiting": return "needs you — stopped on a question";
+    // covers the live prompt AND a filed question (needsYou): the session may even still be
+    // working a sibling goal, so "waiting on your answer" — never "stopped" — stays true
+    case "awaiting": return "needs you — waiting on your answer";
     case "blocked": return "stopped on an API error";
     case "retrying": return "hitting API errors, retrying";
     case "awaitingBg": return "idle, waiting on background work";

--- a/ui/webview/hive-model.ts
+++ b/ui/webview/hive-model.ts
@@ -116,6 +116,36 @@ export function buildSessions(msg: any): HiveSession[] | null {
   return out;
 }
 
+// Compact age for the card's state line ("2m", "1h") — mirrors the outline's agehms.
+export function hiveAge(secs: number): string {
+  secs = Math.max(0, Math.floor(secs));
+  if (secs < 60) return `${secs}s`;
+  if (secs < 3600) return `${Math.floor(secs / 60)}m`;
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h`;
+  return `${Math.floor(secs / 86400)}d`;
+}
+
+// The card's one-line state, in the user's terms (never romp nouns): what the session is
+// doing and, when it matters, for how long. Pure so every phrasing is tested.
+export function stateLine(s: HiveSession, now: number): string {
+  switch (s.state) {
+    case "working": {
+      const n = s.narration;
+      return n ? `working — ${n.toolUses} tool${n.toolUses === 1 ? "" : "s"} in, ${hiveAge(now - n.since)}`
+               : "working";
+    }
+    case "awaiting": return "needs you — stopped on a question";
+    case "blocked": return "stopped on an API error";
+    case "retrying": return "hitting API errors, retrying";
+    case "awaitingBg": return "idle, waiting on background work";
+    case "compacting": return "compacting its context";
+    case "clearing": return "clearing its context";
+    case "interrupting": return "stopping…";
+    case "opening": return "starting up";
+    default: return s.faded ? "idle for a while" : "ready";
+  }
+}
+
 // The event stream between two snapshots. `prev` null means "first payload": everything is
 // `added`, and no state/goal events fire (there is no earlier world to compare against).
 export function diffSessions(prev: HiveSession[] | null, next: HiveSession[]): HiveDiff {

--- a/ui/webview/hive-pane.css
+++ b/ui/webview/hive-pane.css
@@ -68,6 +68,31 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #090b10; }
   padding: 5px 10px; }
 #hive-card .hc-open:hover { color: #ffffff; border-color: rgba(255, 255, 255, 0.3); }
 
+/* ── the trash dock: slides in from the bottom only while a session is being carried;
+   dropping the bean on it ends the session. pointer-events none — the canvas keeps the
+   pointer and rect-tests the drop; .armed answers the hover so the drop never surprises. */
+#hive-trash {
+  position: fixed; left: 50%; bottom: 18px; transform: translateX(-50%) translateY(160%);
+  z-index: 6; pointer-events: none;
+  display: flex; align-items: center; gap: 7px;
+  background: rgba(22, 25, 31, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(6px);
+  color: #c9c9c9;
+  font: 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 9px 14px;
+  transition: transform 0.22s cubic-bezier(0.2, 0.9, 0.3, 1.15), border-color 0.15s ease,
+    color 0.15s ease, box-shadow 0.15s ease;
+}
+#hive-trash.show { transform: translateX(-50%) translateY(0); }
+#hive-trash.armed {
+  color: #ffb3b6; border-color: #e5484d;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5), 0 0 14px rgba(229, 72, 77, 0.45);
+  transform: translateX(-50%) translateY(0) scale(1.07);
+}
+
 /* press-pulse for delegated actions (./actions flash) — feed.css keeps its own copy too,
    since each pane page loads only its own stylesheet */
 .romp-acted { animation: romp-acted-pulse 0.26s ease; }

--- a/ui/webview/hive-pane.css
+++ b/ui/webview/hive-pane.css
@@ -1,0 +1,6 @@
+/* Hive page frame (plans/hive.md). The world is one WebGL canvas filling the pane; every
+   readable surface (the fly-in card, composers) is DOM layered over it — those styles join
+   this file as they land. Kernel _hive_page reads this live; esbuild bundles it for the VSIX. */
+html, body { height: 100%; margin: 0; overflow: hidden; background: #1e1e1e; }
+#hive-root { position: fixed; inset: 0; }
+#hive-root canvas { display: block; width: 100%; height: 100%; touch-action: none; }

--- a/ui/webview/hive-pane.css
+++ b/ui/webview/hive-pane.css
@@ -1,6 +1,65 @@
 /* Hive page frame (plans/hive.md). The world is one WebGL canvas filling the pane; every
-   readable surface (the fly-in card, composers) is DOM layered over it — those styles join
-   this file as they land. Kernel _hive_page reads this live; esbuild bundles it for the VSIX. */
-html, body { height: 100%; margin: 0; overflow: hidden; background: #1e1e1e; }
+   readable surface (the fly-in card, composer) is DOM layered over it. Kernel _hive_page
+   reads this live; esbuild bundles it for the VSIX. */
+html, body { height: 100%; margin: 0; overflow: hidden; background: #090b10; }
 #hive-root { position: fixed; inset: 0; }
 #hive-root canvas { display: block; width: 100%; height: 100%; touch-action: none; }
+
+/* ── the fly-in card (pane-local dialog, CLAUDE.md ## Design) ──────────────────────────
+   Dark glass over the Tron world; the menu vocabulary's hairline + radius family. Slides
+   in from the right when a hex is selected; all text updates in place, never rebuilt. */
+#hive-card {
+  position: fixed; top: 14px; right: 14px; width: 296px; z-index: 5;
+  background: rgba(22, 25, 31, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(6px);
+  font: 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #d6d6d6;
+  padding: 10px 12px 12px;
+  opacity: 0; transform: translateX(14px); pointer-events: none;
+  transition: opacity 0.18s ease, transform 0.22s cubic-bezier(0.2, 0.9, 0.3, 1.15);
+}
+#hive-card.open { opacity: 1; transform: none; pointer-events: auto; }
+#hive-card .hc-head { display: flex; align-items: center; gap: 8px; }
+#hive-card .hc-dot { flex: 0 0 auto; width: 9px; height: 9px; border-radius: 50%; background: #8a8a8a; }
+#hive-card .hc-name { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; font-weight: 700; font-size: 13px; }
+#hive-card .hc-x { flex: 0 0 auto; background: none; border: 0; color: #8a8a8a; font-size: 17px;
+  line-height: 1; cursor: pointer; padding: 2px 4px; border-radius: 4px; }
+#hive-card .hc-x:hover { color: #ffffff; background: rgba(255, 255, 255, 0.08); }
+#hive-card .hc-state { margin-top: 4px; font-size: 12px; color: #9aa0a6; }
+#hive-card .hc-state[data-state="working"] { color: #e0b020; }
+#hive-card .hc-state[data-state="awaiting"], #hive-card .hc-state[data-state="blocked"] { color: #ff8589; }
+#hive-card .hc-state[data-state="awaitingBg"] { color: #7fd24a; }
+#hive-card .hc-state[data-state="compacting"], #hive-card .hc-state[data-state="clearing"] { color: #2dd4bf; }
+#hive-card .hc-goal { margin-top: 8px; font-size: 12px; line-height: 1.45; color: #d6d6d6; }
+#hive-card .hc-brief { margin-top: 8px; font-size: 12px; line-height: 1.45; color: #ffd7d9;
+  background: rgba(229, 72, 77, 0.12); border: 1px solid rgba(229, 72, 77, 0.35);
+  border-radius: 6px; padding: 7px 9px; }
+#hive-card .hc-err { margin-top: 8px; font-size: 12px; line-height: 1.4; color: #ffb3b6; }
+#hive-card .hc-talk { display: flex; gap: 6px; margin-top: 10px; align-items: flex-end; }
+#hive-card .hc-input { flex: 1 1 auto; min-width: 0; resize: none; border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06); border: 1px solid rgba(255, 255, 255, 0.14);
+  color: #e8e8e8; font: 12px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 6px 8px; }
+#hive-card .hc-input:focus { outline: none; border-color: var(--accent, #9cd2ff); }
+#hive-card .hc-send { flex: 0 0 auto; cursor: pointer; border: 0; border-radius: 6px;
+  background: var(--accent, #9cd2ff); color: var(--accent-fg, #0c1a2e); font: 600 12px -apple-system,
+  BlinkMacSystemFont, "Segoe UI", sans-serif; padding: 7px 11px; }
+#hive-card .hc-send:disabled { opacity: 0.75; cursor: default; }
+#hive-card .hc-foot { margin-top: 9px; display: flex; justify-content: flex-end; }
+#hive-card .hc-open { cursor: pointer; background: none; border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 6px; color: #c9c9c9; font: 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 5px 10px; }
+#hive-card .hc-open:hover { color: #ffffff; border-color: rgba(255, 255, 255, 0.3); }
+
+/* press-pulse for delegated actions (./actions flash) — feed.css keeps its own copy too,
+   since each pane page loads only its own stylesheet */
+.romp-acted { animation: romp-acted-pulse 0.26s ease; }
+@keyframes romp-acted-pulse {
+  0% { transform: scale(1); filter: brightness(1); }
+  35% { transform: scale(0.96); filter: brightness(1.35); }
+  100% { transform: scale(1); filter: brightness(1); }
+}

--- a/ui/webview/hive-pane.css
+++ b/ui/webview/hive-pane.css
@@ -89,6 +89,9 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #090b10; }
 #hive-tip[data-state="awaiting"], #hive-tip[data-state="blocked"] { color: #ff8589; }
 #hive-tip[data-state="awaitingBg"] { color: #7fd24a; }
 #hive-tip[data-state="compacting"], #hive-tip[data-state="clearing"] { color: #2dd4bf; }
+/* the unseen-finished line — the done-check family (--check-bg #1EA1EB), brightened for dark
+   ground the way the other tip hues are */
+#hive-tip[data-state="done"] { color: #4db9f2; }
 
 /* ── the tray: one draggable model bean per /models entry (bottom-left). Drag a bean onto
    a free hexagon to spawn that model there; the badge cycles its effort; a clean click

--- a/ui/webview/hive-pane.css
+++ b/ui/webview/hive-pane.css
@@ -68,6 +68,28 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #090b10; }
   padding: 5px 10px; }
 #hive-card .hc-open:hover { color: #ffffff; border-color: rgba(255, 255, 255, 0.3); }
 
+/* ── the hover tip: the hovered session's live status over its bean — the menus
+   vocabulary chrome, state colors matching the card's state line; pointer-events none
+   so it never steals the hover it answers. Placed per frame by the render loop. */
+#hive-tip {
+  position: fixed; left: 0; top: 0; z-index: 6; pointer-events: none;
+  display: flex; align-items: center; gap: 6px;
+  background: #252526;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  font: 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #9aa0a6; padding: 5px 9px; white-space: nowrap;
+  opacity: 0; transition: opacity 0.1s ease;
+  will-change: transform;
+}
+#hive-tip.show { opacity: 1; }
+#hive-tip .tip-dot { flex: 0 0 auto; width: 8px; height: 8px; border-radius: 50%; background: #8a8a8a; }
+#hive-tip[data-state="working"] { color: #e0b020; }
+#hive-tip[data-state="awaiting"], #hive-tip[data-state="blocked"] { color: #ff8589; }
+#hive-tip[data-state="awaitingBg"] { color: #7fd24a; }
+#hive-tip[data-state="compacting"], #hive-tip[data-state="clearing"] { color: #2dd4bf; }
+
 /* ── the trash dock: slides in from the bottom only while a session is being carried;
    dropping the bean on it ends the session. pointer-events none — the canvas keeps the
    pointer and rect-tests the drop; .armed answers the hover so the drop never surprises. */

--- a/ui/webview/hive-pane.css
+++ b/ui/webview/hive-pane.css
@@ -124,6 +124,21 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #090b10; }
 .ht-bean.carried { position: fixed; left: 0; top: 0; z-index: 9; pointer-events: none; margin: 0;
   background: none; }
 
+/* ── the in-place board rename: the nameplate becomes an editor exactly where it sits ── */
+#hive-rename {
+  position: fixed; left: 0; top: 0; z-index: 8;
+  display: flex; align-items: baseline; gap: 2px;
+  background: rgba(22, 25, 31, 0.94);
+  border: 1px solid var(--accent, #9cd2ff);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  padding: 3px 8px;
+  font: 700 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+#hive-rename input { background: none; border: 0; outline: none; padding: 0;
+  font: inherit; min-width: 2ch; }
+#hive-rename .host-prefix { font-weight: 400; font-style: italic; font-size: 0.88em; color: #8a8a8a; }
+
 /* the board-level notice: refusals with no card open (a bad create, a refused default) */
 #hive-note {
   position: fixed; left: 50%; bottom: 64px; transform: translateX(-50%);

--- a/ui/webview/hive-pane.css
+++ b/ui/webview/hive-pane.css
@@ -26,6 +26,19 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #090b10; }
 #hive-card .hc-dot { flex: 0 0 auto; width: 9px; height: 9px; border-radius: 50%; background: #8a8a8a; }
 #hive-card .hc-name { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis;
   white-space: nowrap; font-weight: 700; font-size: 13px; }
+#hive-card .hc-name[data-act="rename"] { cursor: text; }
+#hive-card .hc-name[data-act="rename"]:hover { text-decoration: underline dotted rgba(255, 255, 255, 0.45);
+  text-underline-offset: 3px; }
+/* the inline rename editor — the name's own 13px/700, in the composer's field chrome */
+#hive-card .hc-rename { flex: 1 1 auto; min-width: 0; border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06); border: 1px solid rgba(255, 255, 255, 0.14);
+  color: #e8e8e8; font: 700 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 1px 5px; }
+#hive-card .hc-rename:focus { outline: none; border-color: var(--accent, #9cd2ff); }
+/* a remote's fixed "host:" chrome beside the editor — styles.css's quiet treatment, carried
+   here because this page loads only its own stylesheet */
+#hive-card .host-prefix { flex: 0 0 auto; color: #8a8a8a; font-weight: 400; font-style: italic;
+  font-size: 0.88em; }
 #hive-card .hc-x { flex: 0 0 auto; background: none; border: 0; color: #8a8a8a; font-size: 17px;
   line-height: 1; cursor: pointer; padding: 2px 4px; border-radius: 4px; }
 #hive-card .hc-x:hover { color: #ffffff; background: rgba(255, 255, 255, 0.08); }

--- a/ui/webview/hive-pane.css
+++ b/ui/webview/hive-pane.css
@@ -90,6 +90,54 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #090b10; }
 #hive-tip[data-state="awaitingBg"] { color: #7fd24a; }
 #hive-tip[data-state="compacting"], #hive-tip[data-state="clearing"] { color: #2dd4bf; }
 
+/* ── the tray: one draggable model bean per /models entry (bottom-left). Drag a bean onto
+   a free hexagon to spawn that model there; the badge cycles its effort; a clean click
+   makes that bean the default seed. The default wears the accent ring. */
+#hive-tray {
+  position: fixed; left: 14px; bottom: 14px; z-index: 6;
+  display: flex; gap: 10px; align-items: flex-end;
+  background: rgba(22, 25, 31, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(6px);
+  padding: 9px 12px;
+  font: 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+.ht-bean { display: flex; flex-direction: column; align-items: center; gap: 3px; cursor: grab;
+  color: #c9c9c9; user-select: none; -webkit-user-select: none; padding: 2px 4px; border-radius: 6px; }
+.ht-bean.lifted { opacity: 0.35; }
+.ht-bean .hb-body { width: 26px; height: 30px; position: relative;
+  border-radius: 46% 46% 44% 44% / 58% 58% 40% 40%;
+  background: radial-gradient(circle at 35% 28%, #dfe9f5, #9fb3c8 78%);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4); }
+.ht-bean.default .hb-body { box-shadow: 0 0 0 2px var(--accent, #9cd2ff), 0 2px 6px rgba(0, 0, 0, 0.4); }
+.ht-bean .hb-body i { position: absolute; top: 38%; width: 4px; height: 5px; border-radius: 50%;
+  background: #10151c; }
+.ht-bean .hb-body i:first-child { left: 30%; }
+.ht-bean .hb-body i:last-child { right: 30%; }
+.ht-bean .hb-name { font-size: 12px; }
+.ht-bean .hb-eff { border: 1px solid rgba(255, 255, 255, 0.16); background: none; color: #9aa0a6;
+  border-radius: 6px; font-size: 0.82em; opacity: 0.85; padding: 0 6px; cursor: pointer;
+  font-family: inherit; }
+.ht-bean .hb-eff:hover { color: #ffffff; border-color: rgba(255, 255, 255, 0.3); }
+.ht-bean.carried { position: fixed; left: 0; top: 0; z-index: 9; pointer-events: none; margin: 0;
+  background: none; }
+
+/* the board-level notice: refusals with no card open (a bad create, a refused default) */
+#hive-note {
+  position: fixed; left: 50%; bottom: 64px; transform: translateX(-50%);
+  z-index: 7; pointer-events: none;
+  background: #252526;
+  border: 1px solid rgba(229, 72, 77, 0.45);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  color: #ffb3b6; font: 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 6px 12px; white-space: nowrap;
+  opacity: 0; transition: opacity 0.15s ease;
+}
+#hive-note.show { opacity: 1; }
+
 /* ── the trash dock: slides in from the bottom only while a session is being carried;
    dropping the bean on it ends the session. pointer-events none — the canvas keeps the
    pointer and rect-tests the drop; .armed answers the hover so the drop never surprises. */

--- a/ui/webview/hive-recruit.test.ts
+++ b/ui/webview/hive-recruit.test.ts
@@ -1,0 +1,47 @@
+// Click ANY empty hexagon to spawn a session there (the user 2026-08-13). The ghost is the
+// standing invitation: parked on the first free slot, gliding under the pointer over any
+// empty cell; a clean click reserves that cell and opens the new-session picker, and the
+// next NEW arrival takes the reserved cell. Source-pinned in the tab-rename-host style —
+// these behaviors only meet the pure math (hive-layout) and the shell relay at runtime.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const HIVE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "hive.ts"), "utf8");
+const pick = HIVE.slice(HIVE.indexOf("private pick()"), HIVE.indexOf("select(sid: string)"));
+const up = HIVE.slice(HIVE.indexOf("private onPointerUp"), HIVE.indexOf("private static GHOST"));
+const sync = HIVE.slice(HIVE.indexOf("sync(sessions:"), HIVE.indexOf("private ensureLattice"));
+
+test("pick() sees every empty cell: ground-plane fallthrough via the layout inverses", () => {
+  assert.match(pick, /xzToAxial\(px, pz, HEX_SIZE\)/, "world point → cell");
+  assert.match(pick, /slotOfAxial\(cell\)/, "cell → spiral slot");
+  assert.match(pick, /!new Set\(this\.slots\.values\(\)\)\.has\(slot\)/, "only FREE cells invite");
+  assert.match(pick, /hexDistance\(cell, \{ q: 0, r: 0 \}\) <= this\.latticeRings/,
+    "only cells of the visible board — not the infinite plane");
+});
+
+test("recruit is a clean CLICK, decided on the up — the empty board still orbits", () => {
+  assert.match(HIVE, /this\.pendingRecruit = \{ x: e\.clientX, y: e\.clientY, slot: this\.ghostSlot \};/);
+  assert.match(HIVE, /this\.dragging = \{ mode: "orbit", x: e\.clientX, y: e\.clientY \};\s*\n\s*return;/,
+    "the down starts the orbit too");
+  assert.match(up, /Math\.hypot\(e\.clientX - pr\.x, e\.clientY - pr\.y\) > 5\) return;/,
+    "the gate is the gesture (px travelled), never a timer");
+  assert.match(up, /this\.reservedSlot = pr\.slot;/, "the click claims the cell");
+  assert.match(up, /openPicker/, "…then asks the shell for the picker");
+  assert.match(up, /particles\.burst/, "acknowledged immediately, before any round-trip");
+});
+
+test("sync() honors the reservation before pads are built; revived sessions outrank it", () => {
+  assert.match(sync, /diff\.added\.find\(\(id\) => !stored\.has\(id\)\)/,
+    "only a sid with NO remembered home takes the clicked cell — a revival returns to its hex");
+  assert.match(sync, /this\.reservedSlot = null;/, "spent (or dropped) at the first arrival");
+  assert.ok(sync.indexOf("reservedSlot") < sync.indexOf("new Pad("),
+    "the override lands before any pad is constructed");
+});
+
+test("the ghost glides — follows the hovered empty cell, parks back on the first free slot", () => {
+  assert.match(HIVE, /this\.ghost\.position\.lerp\(this\.ghostTarget/, "eased, never teleported");
+  assert.match(HIVE, /if \(this\.hovered !== HiveWorld\.GHOST && this\.ghostSlot !== this\.ghostHome\) this\.ghostTo\(this\.ghostHome\);/,
+    "pointer off the board → back to the park");
+});

--- a/ui/webview/hive-trash.test.ts
+++ b/ui/webview/hive-trash.test.ts
@@ -19,8 +19,8 @@ test("a pick-up is gated on the GESTURE: a held press must move before it become
     "same px gate as the recruit click — never a timer");
   assert.match(HIVE, /if \(this\.dragSession\) \{ this\.moveSessionDrag\(e\); return; \}/,
     "a carry never orbits the camera");
-  assert.match(HIVE, /this\.pressedPad = \{ sid, x: e\.clientX, y: e\.clientY, bean: hit\.bean \};/,
-    "the press arms the pick-up; the tile's click resolves on the clean UP (the bean's is instant on the down)");
+  assert.match(HIVE, /this\.pressedPad = \{ sid, x: e\.clientX, y: e\.clientY, bean: hit\.bean, name: hit\.name \};/,
+    "the press arms the pick-up; chat switches on the down, the nameplate's edit resolves on the clean UP");
 });
 
 test("dropping on the armed dock ends the session via the kernel's own op", () => {

--- a/ui/webview/hive-trash.test.ts
+++ b/ui/webview/hive-trash.test.ts
@@ -46,6 +46,18 @@ test("the dock arms only under the pointer, and shows WHO the drop would end", (
     assert.ok(CSS.includes(frag), "hive-pane.css carries: " + frag);
 });
 
+test("the carry is pinned under the cursor EVERY FRAME, on a flat plane", () => {
+  // Recomputed after the camera eases (frame()), never only per pointer event — a spring,
+  // idle drift, or a still pointer can no longer pull the bean out from under the cursor
+  // (the user 2026-08-13, who watched them drift apart). The flat CARRY_Y plane keeps the
+  // cursor→bean mapping projectively exact anywhere on screen; fixed camera DEPTH did not.
+  const frame = HIVE.slice(HIVE.indexOf("this.camera.lookAt(this.targetCur);"));
+  assert.match(frame, /if \(this\.dragSession\) \{\s*\n\s*this\.idleT = 0;/,
+    "holding someone is not idle — no board sway mid-carry");
+  assert.match(frame, /const t = \(CARRY_Y - o\.y\) \/ v\.y;/, "plane intersection, not camera depth");
+  assert.ok(!HIVE.includes("multiplyScalar(d.depth)"), "the depth-sphere carry is gone");
+});
+
 test("the carrier wraps the dweller, so a carry never fights the idle animation", () => {
   assert.match(HIVE, /this\.carrier\.add\(this\.guy\.group\);/);
   assert.match(HIVE, /this\.group\.add\(this\.carrier\);/);

--- a/ui/webview/hive-trash.test.ts
+++ b/ui/webview/hive-trash.test.ts
@@ -1,0 +1,53 @@
+// Drag a session to the trash dock to end it (the user 2026-08-13, TFT-style): a held
+// press that MOVES picks the bean up, the dock slides in from the bottom, dropping on the
+// armed dock posts the kernel's own endSession op — and a drop anywhere else springs them
+// home, no harm done. The deliberate carry + the highlighted dock is the confirmation (an
+// ended session still revives with its history). Source-pinned like the pane's other
+// interaction contracts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const HIVE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "hive.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "hive-pane.css"), "utf8");
+const drop = HIVE.slice(HIVE.indexOf("private dropSessionDrag"), HIVE.indexOf("private static GHOST"));
+
+test("a pick-up is gated on the GESTURE: a held press must move before it becomes a drag", () => {
+  assert.match(HIVE, /this\.pressedPad && !this\.dragSession\s*\n\s*&& Math\.hypot\(e\.clientX - this\.pressedPad\.x, e\.clientY - this\.pressedPad\.y\) > 6/,
+    "same px gate as the recruit click — never a timer");
+  assert.match(HIVE, /if \(this\.dragSession\) \{ this\.moveSessionDrag\(e\); return; \}/,
+    "a carry never orbits the camera");
+  assert.match(HIVE, /this\.pressedPad = \{ sid, x: e\.clientX, y: e\.clientY, bean: hit\.bean \};/,
+    "the press arms; the click actions fire on the clean UP");
+});
+
+test("dropping on the armed dock ends the session via the kernel's own op", () => {
+  assert.match(drop, /\{ type: "endSession", id: d\.sid \}/, "the same op the chat tab's × posts");
+  assert.ok(KERNEL.includes('elif t == "endSession":'), "the kernel still handles it");
+  assert.match(drop, /pad\.consumeBean\(\);/, "the bean vanishes into the dock");
+  assert.match(drop, /pad\.dyingT = 0\.26;/, "straight to the sink — the hop is for natural exits");
+  assert.match(drop, /particles\.burst/, "the drop is acknowledged where it happened");
+});
+
+test("dropping anywhere else springs them home — no kill outside the dock", () => {
+  const misses = drop.slice(drop.indexOf("} else {"));
+  assert.match(misses, /pad\.carryTo\(null\);/, "release → spring home");
+  assert.ok(!misses.includes("endSession"), "no end op on a missed drop");
+  assert.match(HIVE, /if \(this\.dragSession\) \{ this\.dropSessionDrag\(false\); return; \}/,
+    "Esc aborts the carry the same way");
+});
+
+test("the dock arms only under the pointer, and shows WHO the drop would end", () => {
+  assert.match(HIVE, /label\.textContent = "Drop to end " \+ pad\.sess\.name;/);
+  assert.match(HIVE, /this\.trashEl\.classList\.toggle\("armed", over\);/);
+  for (const frag of ["#hive-trash {", "#hive-trash.show {", "#hive-trash.armed {", "pointer-events: none;"])
+    assert.ok(CSS.includes(frag), "hive-pane.css carries: " + frag);
+});
+
+test("the carrier wraps the dweller, so a carry never fights the idle animation", () => {
+  assert.match(HIVE, /this\.carrier\.add\(this\.guy\.group\);/);
+  assert.match(HIVE, /this\.group\.add\(this\.carrier\);/);
+  assert.match(HIVE, /this\.carrier\.position\.lerp\(this\.carryWant/, "eased, never teleported");
+});

--- a/ui/webview/hive-trash.test.ts
+++ b/ui/webview/hive-trash.test.ts
@@ -31,12 +31,15 @@ test("dropping on the armed dock ends the session via the kernel's own op", () =
   assert.match(drop, /particles\.burst/, "the drop is acknowledged where it happened");
 });
 
-test("dropping anywhere else springs them home — no kill outside the dock", () => {
-  const misses = drop.slice(drop.indexOf("} else {"));
-  assert.match(misses, /pad\.carryTo\(null\);/, "release → spring home");
-  assert.ok(!misses.includes("endSession"), "no end op on a missed drop");
-  assert.match(HIVE, /if \(this\.dragSession\) \{ this\.dropSessionDrag\(false\); return; \}/,
-    "Esc aborts the carry the same way");
+test("dropping outside the dock never kills: a free cell re-homes, anywhere else springs home", () => {
+  const misses = drop.slice(drop.indexOf("// a FREE cell under the drop"));
+  assert.ok(!misses.includes("endSession"), "no end op anywhere off the dock");
+  assert.match(misses, /const slot = cancel \|\| pad\.dyingT >= 0 \? null : this\.freeCellAt\(\);/,
+    "Esc and a dying pad NEVER re-home — only a real drop does");
+  assert.match(misses, /if \(slot !== null\) this\.rehome\(d\.sid, slot, pad\);/, "free cell → new home");
+  assert.match(misses, /else pad\.carryTo\(null\);/, "occupied/off-board → spring home");
+  assert.match(HIVE, /if \(this\.dragSession\) \{ this\.dropSessionDrag\(false, true\); return; \}/,
+    "Esc aborts the carry as a CANCEL, not a drop");
 });
 
 test("the dock arms only under the pointer, and shows WHO the drop would end", () => {

--- a/ui/webview/hive-trash.test.ts
+++ b/ui/webview/hive-trash.test.ts
@@ -20,7 +20,7 @@ test("a pick-up is gated on the GESTURE: a held press must move before it become
   assert.match(HIVE, /if \(this\.dragSession\) \{ this\.moveSessionDrag\(e\); return; \}/,
     "a carry never orbits the camera");
   assert.match(HIVE, /this\.pressedPad = \{ sid, x: e\.clientX, y: e\.clientY, bean: hit\.bean \};/,
-    "the press arms; the click actions fire on the clean UP");
+    "the press arms the pick-up; the tile's click resolves on the clean UP (the bean's is instant on the down)");
 });
 
 test("dropping on the armed dock ends the session via the kernel's own op", () => {

--- a/ui/webview/hive-tray.test.ts
+++ b/ui/webview/hive-tray.test.ts
@@ -1,0 +1,57 @@
+// The tray (the user 2026-08-13): config embedded in the board's own drag language. One
+// bean per MODEL from the kernel's /models — the ONE list every picker shares, never a
+// hardcoded copy — dragged onto a free hexagon to spawn that model there; the badge cycles
+// the bean's EFFORT; a clean click makes that bean the default seed for new sessions. And
+// dragging an EXISTING session to a free cell re-homes it there. Source-pinned like the
+// pane's other interaction contracts: these surfaces only meet at runtime.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const HIVE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "hive.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const SDK = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
+
+test("the tray builds from /models — the shared list plus the remembered defaults", () => {
+  assert.match(HIVE, /fetch\("\/models", \{ cache: "no-store" \}\)/, "choices come from the kernel");
+  assert.ok(!/["'](fable|opus|sonnet|haiku)["']/.test(HIVE), "no model literal is hardcoded in the hive");
+  assert.ok(KERNEL.includes('"defaults": {k: _sd[k] for k in ("model", "effort") if _sd.get(k)}'),
+    "/models now reports the remembered seed, so the tray can mark the default bean");
+});
+
+test("a dropped bean spawns THAT model there: reservation + createSession(model, effort)", () => {
+  assert.match(HIVE, /world\.spawnAt\(slot, mc\.value, effort\)/, "the drop hands cell+model+effort over");
+  assert.match(HIVE, /\{ type: "createSession", name: this\.autoName\(model\), backend: "sdk", model, effort \}/,
+    "an SDK session, auto-named, with the bean's choice riding the create op");
+  assert.ok(KERNEL.includes('mdl = msg.get("model") if msg.get("model") in _MODEL_VALUES else ""'),
+    "the kernel validates the model against the offered choices");
+  assert.ok(KERNEL.includes("model=mdl, effort=eff)"), "…and hands it to the SDK spawn");
+  assert.ok(SDK.includes("eff = (effort if effort in EFFORT_LEVELS"),
+    "spawn(): the explicit choice outranks the remembered seed");
+});
+
+test("a clean click sets the DEFAULT seed — kernel-validated, confirmed back, ultracode refused", () => {
+  assert.match(HIVE, /\{ type: "setSpawnDefaults", model: mc\.value, effort \}/);
+  assert.ok(KERNEL.includes('msg.get("type") == "setSpawnDefaults"'), "the kernel op exists");
+  assert.ok(KERNEL.includes("be.set_spawn_defaults(model=mdl, effort=eff)"), "…writing the shared store");
+  assert.ok(KERNEL.includes('"type": "spawnDefaults"'), "…and confirming, never silently");
+  assert.match(HIVE, /m\.type === "spawnDefaults"/, "the tray re-marks on the confirmation");
+  assert.ok(/eff = None\s+# per-session by design/.test(KERNEL),
+    "ultracode can ride a single spawn but is refused as a seed");
+});
+
+test("dragging a session to a free cell re-homes it: persisted, glided, ghost re-parked", () => {
+  assert.match(HIVE, /this\.slots\.set\(sid, slot\);\s*\n\s*saveSlots\(loadSlots\(this\.slots\)\);/,
+    "the new home lands in the slot map AND localStorage, so it survives reloads");
+  assert.match(HIVE, /pad\.homeTo\(p\.x, p\.z\);/, "the tile GLIDES to the new cell");
+  assert.match(HIVE, /this\.group\.position\.x = ease\(this\.group\.position\.x, this\.homeX, dt, 10\);/,
+    "…via the eased home, never a teleport");
+  assert.match(HIVE, /const slot = cancel \|\| pad\.dyingT >= 0 \? null : this\.freeCellAt\(\);/,
+    "only a real drop re-homes — Esc and dying pads spring home");
+});
+
+test("the effort badge cycles the /models efforts and persists per bean", () => {
+  assert.match(HIVE, /SPAWN_EFFORTS\[\(cur \+ 1\) % Math\.max\(1, SPAWN_EFFORTS\.length\)\]/);
+  assert.match(HIVE, /localStorage\.setItem\(effKey, JSON\.stringify\(effSel\)\)/);
+});

--- a/ui/webview/hive-tray.test.ts
+++ b/ui/webview/hive-tray.test.ts
@@ -16,17 +16,22 @@ const SDK = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_bac
 test("the tray builds from /models — the shared list plus the remembered defaults", () => {
   assert.match(HIVE, /fetch\("\/models", \{ cache: "no-store" \}\)/, "choices come from the kernel");
   assert.ok(!/["'](fable|opus|sonnet|haiku)["']/.test(HIVE), "no model literal is hardcoded in the hive");
-  assert.ok(KERNEL.includes('"defaults": {k: _sd[k] for k in ("model", "effort") if _sd.get(k)}'),
+  assert.ok(KERNEL.includes('_defaults = {k: _sd[k] for k in ("model", "effort") if _sd.get(k)}'),
     "/models now reports the remembered seed, so the tray can mark the default bean");
+  assert.ok(KERNEL.includes('_defaults["host"] = _dh'),
+    "…and WHERE a drop lands, so the tray spawns on the same machine the + picker does");
 });
 
 test("a dropped bean spawns THAT model there: reservation + createSession(model, effort)", () => {
   assert.match(HIVE, /world\.spawnAt\(slot, mc\.value, effort\)/, "the drop hands cell+model+effort over");
-  assert.match(HIVE, /\{ type: "createSession", name: this\.autoName\(model\), backend: "sdk", model, effort \}/,
-    "an SDK session, auto-named, with the bean's choice riding the create op");
-  assert.ok(KERNEL.includes('mdl = msg.get("model") if msg.get("model") in _MODEL_VALUES else ""'),
+  // auto-named, with the bean's choice riding the create op — on the gear's backend rather than a
+  // hardcoded "sdk" (the user 2026-08-13), and on the default create host when there is one
+  assert.match(HIVE, /type: "createSession", name: this\.autoName\(model\),\s*\n\s*backend: loadSettings\(\)\.backend, model, effort/);
+  assert.ok(KERNEL.includes('mdl0 = msg.get("model") if msg.get("model") in _MODEL_VALUES else ""'),
     "the kernel validates the model against the offered choices");
-  assert.ok(KERNEL.includes("model=mdl, effort=eff)"), "…and hands it to the SDK spawn");
+  assert.ok(KERNEL.includes("model=mdl0, effort=eff0)"), "…and hands it to the SDK spawn");
+  assert.ok(KERNEL.includes('kwargs={"model": mdl0, "effort": eff0}'),
+    "…and to the tmux spawn, so a bean drop means the same thing on either backend");
   assert.ok(SDK.includes("eff = (effort if effort in EFFORT_LEVELS"),
     "spawn(): the explicit choice outranks the remembered seed");
 });

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -49,6 +49,15 @@ test("esbuild bundles hive.ts and hive-pane.css like the other panes", () => {
   assert.ok(ESBUILD.includes('"../ui/webview/hive-pane.css"'), "hive-pane.css entry");
 });
 
+test("the talk path speaks the kernel's drive-op protocol", () => {
+  // the card's Send posts the SAME sendMessage op the chat composer uses — _drive routes it
+  // by sid to the owning backend from ANY app socket, and a foreign sid is refused loudly
+  assert.ok(HIVE.includes('{ type: "sendMessage", id: sid, text }'), "hive posts sendMessage");
+  assert.ok(KERNEL.includes('if t == "sendMessage" and msg.get("text"):'), "kernel still handles it");
+  assert.ok(HIVE.includes('m.type === "err"'), "kernel refusals surface on the card, never vanish");
+  assert.ok(HIVE.includes('{ type: "openSession", id: sid }'), "the card can jump to the full session");
+});
+
 test("hive's WebGL palette matches the styles.css status tokens (one meaning per color)", () => {
   // hive draws in WebGL where CSS vars can't reach, so it carries the values — this pin is
   // what keeps them the SAME values. Each pair: [styles.css token, hive.ts literal].

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -99,12 +99,29 @@ test("hovering a session floats its live status over the bean (the card's own st
   assert.match(HIVE, /this\.tipEl\.id = "hive-tip";/, "the tip element exists");
   assert.match(HIVE, /stateLine\(tipPad\.sess, Math\.floor\(Date\.now\(\) \/ 1000\)\)/,
     "the text is the SAME line the card's state row shows — one vocabulary for status");
-  assert.match(HIVE, /this\.tipEl\.dataset\.state = tipPad\.sess\.state;/, "state drives the color");
+  assert.match(HIVE, /finishedLine\(tipPad\.sess, Math\.floor\(Date\.now\(\) \/ 1000\)\)/,
+    "…except an unseen finish, which says what the ✓ is holding for you");
+  assert.match(HIVE, /this\.tipEl\.dataset\.state = done \? "done" : tipPad\.sess\.state;/,
+    "state drives the color (an unseen finish wears the done hue)");
   assert.match(HIVE, /!this\.dragSession\s*\n\s*\? this\.pads\.get\(this\.hovered\) : null;/,
     "no tip mid-carry — the dock speaks then");
   for (const frag of ['#hive-tip {', "pointer-events: none;", '#hive-tip[data-state="working"] { color: #e0b020; }',
-    '#hive-tip[data-state="awaiting"], #hive-tip[data-state="blocked"] { color: #ff8589; }'])
+    '#hive-tip[data-state="awaiting"], #hive-tip[data-state="blocked"] { color: #ff8589; }',
+    '#hive-tip[data-state="done"] { color: #4db9f2; }'])
     assert.ok(CSS2.includes(frag), "hive-pane.css carries: " + frag);
+});
+
+test("a finished session holds its ✓ until the user goes to look (the unseen-done latch)", () => {
+  assert.match(HIVE, /makeTextSprite\("✓", "#ffffff", "#1EA1EB"\)/,
+    "the note is the app's done-check: white ✓ on --check-bg, the ledger/feed mark");
+  assert.match(HIVE, /st === "ready" && this\.unseenDone/,
+    "shown only over a READY pad — a new turn hides it, needs-you (the bang) outranks it");
+  assert.match(HIVE, /foldSeenDone\(this\.seenDone, sessions\)/, "the latch derives per payload");
+  for (const frag of ["this.lookedAt(sid);", 'localStorage.getItem(SEEN_KEY)', 'localStorage.setItem(SEEN_KEY']) {
+    assert.ok(HIVE.includes(frag), "hive.ts carries: " + frag);
+  }
+  assert.ok(HIVE.indexOf("this.lookedAt(sid);") !== HIVE.lastIndexOf("this.lookedAt(sid);"),
+    "BOTH look gestures ack: the chat click-through and the deep-link select");
 });
 
 test("hive's WebGL palette matches the styles.css status tokens (one meaning per color)", () => {

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -11,6 +11,7 @@ const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kern
 const ESBUILD = fs.readFileSync(path.resolve(process.cwd(), "esbuild.js"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 const HIVE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "hive.ts"), "utf8");
+const CSS2 = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "hive-pane.css"), "utf8");
 
 test("kernel serves /hive from _hive_page with the hive shim + bundle", () => {
   assert.ok(KERNEL.includes('if p == "/hive":'), "the /hive route exists");
@@ -75,13 +76,25 @@ test("clicking the bean opens their chat; the tile keeps opening the card", () =
   // session and reveals the chat pane — one path shared with the card's Open and dblclick.
   assert.match(HIVE, /new THREE\.CapsuleGeometry\(0\.55/, "the bean has a whole-body hit capsule");
   assert.match(HIVE, /colorWrite: false/, "…that draws nothing but still raycasts");
-  assert.match(HIVE, /if \(hit\.bean && pad\) \{\s*\n\s*pad\.pokeBean\(\);\s*\n\s*this\.openChat\(sid\);/,
-    "bean press: chat switches ON THE DOWN — instant, even if the press then becomes a pick-up");
+  assert.match(HIVE, /if \(pad\) \{\s*\n\s*if \(hit\.bean\) pad\.pokeBean\(\);\s*\n\s*this\.openChat\(sid\);/,
+    "ANY press on an occupied cell switches chat ON THE DOWN — hexagon and bean alike");
   assert.match(HIVE, /if \(!pp\.bean && this\.pads\.has\(pp\.sid\)\) this\.select\(pp\.sid\);/,
     "the tile's card (camera fly-in) still resolves on the clean UP");
   assert.match(HIVE, /openChat\(sid: string\) \{/, "one shared open path");
   assert.match(HIVE, /this\.card\.onOpen = \(sid\) => this\.openChat\(sid\);/, "the card's Open uses it");
   assert.match(HIVE, /\{ romp: "reveal", pane: "chat" \}/, "…and it reveals the chat pane");
+});
+
+test("hovering a session floats its live status over the bean (the card's own stateLine)", () => {
+  assert.match(HIVE, /this\.tipEl\.id = "hive-tip";/, "the tip element exists");
+  assert.match(HIVE, /stateLine\(tipPad\.sess, Math\.floor\(Date\.now\(\) \/ 1000\)\)/,
+    "the text is the SAME line the card's state row shows — one vocabulary for status");
+  assert.match(HIVE, /this\.tipEl\.dataset\.state = tipPad\.sess\.state;/, "state drives the color");
+  assert.match(HIVE, /!this\.dragSession\s*\n\s*\? this\.pads\.get\(this\.hovered\) : null;/,
+    "no tip mid-carry — the dock speaks then");
+  for (const frag of ['#hive-tip {', "pointer-events: none;", '#hive-tip[data-state="working"] { color: #e0b020; }',
+    '#hive-tip[data-state="awaiting"], #hive-tip[data-state="blocked"] { color: #ff8589; }'])
+    assert.ok(CSS2.includes(frag), "hive-pane.css carries: " + frag);
 });
 
 test("hive's WebGL palette matches the styles.css status tokens (one meaning per color)", () => {

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -75,8 +75,8 @@ test("clicking the bean opens their chat; the tile keeps opening the card", () =
   // session and reveals the chat pane — one path shared with the card's Open and dblclick.
   assert.match(HIVE, /new THREE\.CapsuleGeometry\(0\.55/, "the bean has a whole-body hit capsule");
   assert.match(HIVE, /colorWrite: false/, "…that draws nothing but still raycasts");
-  assert.match(HIVE, /if \(hit\.bean && pad\) \{\s*\n\s*pad\.pokeBean\(\);\s*\n\s*this\.openChat\(sid\);/,
-    "bean click: acknowledge on them, then straight to the chat");
+  assert.match(HIVE, /if \(pp\.bean && pad\) \{\s*\n\s*pad\.pokeBean\(\);\s*\n\s*this\.openChat\(pp\.sid\);/,
+    "bean click: acknowledge on them, then straight to the chat (on the clean UP — a moved press is a pick-up)");
   assert.match(HIVE, /openChat\(sid: string\) \{/, "one shared open path");
   assert.match(HIVE, /this\.card\.onOpen = \(sid\) => this\.openChat\(sid\);/, "the card's Open uses it");
   assert.match(HIVE, /\{ romp: "reveal", pane: "chat" \}/, "…and it reveals the chat pane");

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -80,7 +80,8 @@ test("a click's whole answer is the chat on the left; the card stays out of the 
     "ANY press on an occupied cell switches chat ON THE DOWN — except the nameplate, which edits");
   // the fly-in card + camera zoom on every click read as noise (the user 2026-08-13):
   // a click does NOTHING more on the up, and select() serves only the deep-link jump
-  assert.match(HIVE, /if \(pp\) return;/, "a click is DONE on the down — no card, no fly-in on the up");
+  assert.match(HIVE, /if \(pp\.name && Math\.hypot[^\n]+this\.beginBoardRename\(pp\.sid\);\s*\n\s*return;/,
+    "the up resolves ONLY the nameplate's edit — no card, no fly-in");
   assert.ok(!/this\.select\(pp\.sid\)/.test(HIVE), "no click path reaches select()");
   assert.match(HIVE, /openChat\(sid: string\) \{/, "one shared open path");
   assert.match(HIVE, /this\.card\.onOpen = \(sid\) => this\.openChat\(sid\);/, "the card's Open uses it");

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -69,6 +69,19 @@ test("cell lines trace the EXACT boundary, so used and empty cells are one conne
   assert.ok(!HIVE.includes("LINE_INSET"), "no inset constant survives");
 });
 
+test("clicking the bean opens their chat; the tile keeps opening the card", () => {
+  // The bean is the direct line (the user 2026-08-13): an invisible capsule makes the
+  // whole character clickable, the pop acknowledges on THEM, and openChat both opens the
+  // session and reveals the chat pane — one path shared with the card's Open and dblclick.
+  assert.match(HIVE, /new THREE\.CapsuleGeometry\(0\.55/, "the bean has a whole-body hit capsule");
+  assert.match(HIVE, /colorWrite: false/, "…that draws nothing but still raycasts");
+  assert.match(HIVE, /if \(hit\.bean && pad\) \{\s*\n\s*pad\.pokeBean\(\);\s*\n\s*this\.openChat\(sid\);/,
+    "bean click: acknowledge on them, then straight to the chat");
+  assert.match(HIVE, /openChat\(sid: string\) \{/, "one shared open path");
+  assert.match(HIVE, /this\.card\.onOpen = \(sid\) => this\.openChat\(sid\);/, "the card's Open uses it");
+  assert.match(HIVE, /\{ romp: "reveal", pane: "chat" \}/, "…and it reveals the chat pane");
+});
+
 test("hive's WebGL palette matches the styles.css status tokens (one meaning per color)", () => {
   // hive draws in WebGL where CSS vars can't reach, so it carries the values — this pin is
   // what keeps them the SAME values. Each pair: [styles.css token, hive.ts literal].

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -83,6 +83,13 @@ test("clicking the bean opens their chat; the tile keeps opening the card", () =
   assert.match(HIVE, /openChat\(sid: string\) \{/, "one shared open path");
   assert.match(HIVE, /this\.card\.onOpen = \(sid\) => this\.openChat\(sid\);/, "the card's Open uses it");
   assert.match(HIVE, /\{ romp: "reveal", pane: "chat" \}/, "…and it reveals the chat pane");
+  // the INSTANT leg: the shell hands the chat its focus directly — the tab flips with no
+  // kernel round trip in the way; the kernel op follows for its side effects
+  assert.ok(HIVE.indexOf('{ romp: "focusChat", id: sid }') < HIVE.indexOf('{ type: "openSession", id: sid }'),
+    "the client-side flip is posted BEFORE the kernel op");
+  assert.ok(KERNEL.includes("m.romp!=='focusChat'"), "the shell carries the focusChat relay");
+  assert.ok(KERNEL.includes("f.contentWindow.postMessage({type:'focus',id:m.id},'*')"),
+    "…which injects the same focus frame the kernel would send");
 });
 
 test("hovering a session floats its live status over the bean (the card's own stateLine)", () => {

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -75,8 +75,10 @@ test("clicking the bean opens their chat; the tile keeps opening the card", () =
   // session and reveals the chat pane — one path shared with the card's Open and dblclick.
   assert.match(HIVE, /new THREE\.CapsuleGeometry\(0\.55/, "the bean has a whole-body hit capsule");
   assert.match(HIVE, /colorWrite: false/, "…that draws nothing but still raycasts");
-  assert.match(HIVE, /if \(pp\.bean && pad\) \{\s*\n\s*pad\.pokeBean\(\);\s*\n\s*this\.openChat\(pp\.sid\);/,
-    "bean click: acknowledge on them, then straight to the chat (on the clean UP — a moved press is a pick-up)");
+  assert.match(HIVE, /if \(hit\.bean && pad\) \{\s*\n\s*pad\.pokeBean\(\);\s*\n\s*this\.openChat\(sid\);/,
+    "bean press: chat switches ON THE DOWN — instant, even if the press then becomes a pick-up");
+  assert.match(HIVE, /if \(!pp\.bean && this\.pads\.has\(pp\.sid\)\) this\.select\(pp\.sid\);/,
+    "the tile's card (camera fly-in) still resolves on the clean UP");
   assert.match(HIVE, /openChat\(sid: string\) \{/, "one shared open path");
   assert.match(HIVE, /this\.card\.onOpen = \(sid\) => this\.openChat\(sid\);/, "the card's Open uses it");
   assert.match(HIVE, /\{ romp: "reveal", pane: "chat" \}/, "…and it reveals the chat pane");

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -1,0 +1,68 @@
+// Pins the Hive pane's wiring across its three homes — kernel/kernel.py (route, page, shell
+// landing), vscode-extension/esbuild.js (bundle entries), and the status palette shared with
+// styles.css — so a refactor of any one of them can't silently unwire the pane (the
+// prebuild.test.ts / fleet pattern: these files only meet at runtime, never at compile time).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const ESBUILD = fs.readFileSync(path.resolve(process.cwd(), "esbuild.js"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const HIVE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "hive.ts"), "utf8");
+
+test("kernel serves /hive from _hive_page with the hive shim + bundle", () => {
+  assert.ok(KERNEL.includes('if p == "/hive":'), "the /hive route exists");
+  assert.ok(KERNEL.includes("def _hive_page():"), "_hive_page exists");
+  assert.ok(KERNEL.includes('_shim("hive", v)'), "the page connects as app=hive");
+  assert.ok(KERNEL.includes("/dist/hive.js"), "the page loads the hive bundle");
+  assert.ok(KERNEL.includes('_pane_spin("hive-root")'), "the romp loader guards the empty root");
+});
+
+test("the push loop treats app=hive as a feed rider with the ledgers attach", () => {
+  assert.ok(KERNEL.includes('any(c["app"] in ("fleet", "hive") for c in targets)'),
+    "want_fleet counts hive (the ledgers attach)");
+  assert.ok(KERNEL.includes('any(c["app"] in ("feed", "fleet", "hive", "chat") for c in targets)'),
+    "want_feed counts hive");
+  assert.ok(KERNEL.includes('c["app"] in ("feed", "fleet", "hive")'),
+    "the send loop delivers the feed payload to hive clients");
+});
+
+test("the landing shell mounts the hive pane, gutter, rail button and toggles", () => {
+  for (const frag of [
+    "<div class=pane id=hive-pane><iframe id=f-hive src=/hive></iframe></div>",
+    "<div class=gv id=gv-c></div>",
+    "<div class=rail-btn data-pane=hive>Hive</div>",
+    "body:not(.po-hive) #hive-pane{display:none}",
+    "#hive-pane{flex:var(--g-hive,50) 1 0}",
+    "'f-hive':'hive-pane'",
+  ]) assert.ok(KERNEL.includes(frag), "landing carries: " + frag);
+  assert.ok(KERNEL.includes("po={chat:true,fleet:false,feed:true,hive:false,timeline:true}"),
+    "hive defaults OFF in the rail toggles");
+  assert.ok(/PANES=\['chat-pane','fleet-pane','feed-pane','hive-pane'\]/.test(KERNEL),
+    "the gutter controller knows the hive pane");
+});
+
+test("esbuild bundles hive.ts and hive-pane.css like the other panes", () => {
+  assert.ok(ESBUILD.includes('"../ui/webview/hive.ts"'), "hive.ts entry");
+  assert.ok(ESBUILD.includes('"../ui/webview/hive-pane.css"'), "hive-pane.css entry");
+});
+
+test("hive's WebGL palette matches the styles.css status tokens (one meaning per color)", () => {
+  // hive draws in WebGL where CSS vars can't reach, so it carries the values — this pin is
+  // what keeps them the SAME values. Each pair: [styles.css token, hive.ts literal].
+  const pairs: [string, RegExp][] = [
+    ["--st-working-bg: #e0b020", /working:\s*0xe0b020/],
+    ["--st-ready-bg: #2b7fb8", /ready:\s*0x2b7fb8/],
+    ["--st-awaiting-bg: #c0392b", /awaiting:\s*0xc0392b/],
+    ["--st-blocked-bg: #e5484d", /blocked:\s*0xe5484d/],
+    ["--st-awaitbg-bg: #54B204", /awaitingBg:\s*0x54b204/],
+    ["--st-compacting-bg: #14b8a6", /compacting:\s*0x14b8a6/],
+    ["--accent: #9cd2ff", /ACCENT\s*=\s*0x9cd2ff/],
+  ];
+  for (const [cssToken, hiveLit] of pairs) {
+    assert.ok(CSS.includes(cssToken), "styles.css still declares: " + cssToken);
+    assert.ok(hiveLit.test(HIVE), "hive.ts carries the same value: " + hiveLit);
+  }
+});

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -117,11 +117,22 @@ test("a finished session holds its ✓ until the user goes to look (the unseen-d
   assert.match(HIVE, /st === "ready" && this\.unseenDone/,
     "shown only over a READY pad — a new turn hides it, needs-you (the bang) outranks it");
   assert.match(HIVE, /foldSeenDone\(this\.seenDone, sessions\)/, "the latch derives per payload");
-  for (const frag of ["this.lookedAt(sid);", 'localStorage.getItem(SEEN_KEY)', 'localStorage.setItem(SEEN_KEY']) {
+  for (const frag of ["this.lookedAt(sid);", "loadSeen(SEEN_DONE_KEY)", "saveSeen(SEEN_DONE_KEY"]) {
     assert.ok(HIVE.includes(frag), "hive.ts carries: " + frag);
   }
   assert.ok(HIVE.indexOf("this.lookedAt(sid);") !== HIVE.lastIndexOf("this.lookedAt(sid);"),
     "BOTH look gestures ack: the chat click-through and the deep-link select");
+});
+
+test("a filed question shouts only until looked at; a live prompt always shouts", () => {
+  assert.match(HIVE, /st === "awaiting" && !this\.askAck/,
+    "the bang/sonar shout is gated on the ask being unseen");
+  assert.match(HIVE, /foldSeenAsk\(this\.seenAsk, sessions\)/, "the ask latch derives per payload");
+  assert.match(HIVE, /s\.state === "awaiting" && !s\.liveAsk && !ask\.unseen\.has\(s\.sid\)/,
+    "acked = filed (never live) and looked at — the red ring stays, the shout stops");
+  for (const frag of ["loadSeen(SEEN_ASK_KEY)", "saveSeen(SEEN_ASK_KEY"]) {
+    assert.ok(HIVE.includes(frag), "hive.ts carries: " + frag);
+  }
 });
 
 test("hive's WebGL palette matches the styles.css status tokens (one meaning per color)", () => {

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -70,7 +70,7 @@ test("cell lines trace the EXACT boundary, so used and empty cells are one conne
   assert.ok(!HIVE.includes("LINE_INSET"), "no inset constant survives");
 });
 
-test("clicking the bean opens their chat; the tile keeps opening the card", () => {
+test("a click's whole answer is the chat on the left; the card stays out of the way", () => {
   // The bean is the direct line (the user 2026-08-13): an invisible capsule makes the
   // whole character clickable, the pop acknowledges on THEM, and openChat both opens the
   // session and reveals the chat pane — one path shared with the card's Open and dblclick.
@@ -78,8 +78,10 @@ test("clicking the bean opens their chat; the tile keeps opening the card", () =
   assert.match(HIVE, /colorWrite: false/, "…that draws nothing but still raycasts");
   assert.match(HIVE, /if \(pad\) \{\s*\n\s*if \(hit\.bean\) pad\.pokeBean\(\);\s*\n\s*this\.openChat\(sid\);/,
     "ANY press on an occupied cell switches chat ON THE DOWN — hexagon and bean alike");
-  assert.match(HIVE, /if \(!pp\.bean && this\.pads\.has\(pp\.sid\)\) this\.select\(pp\.sid\);/,
-    "the tile's card (camera fly-in) still resolves on the clean UP");
+  // the fly-in card + camera zoom on every click read as noise (the user 2026-08-13):
+  // a click does NOTHING more on the up, and select() serves only the deep-link jump
+  assert.match(HIVE, /if \(pp\) return;/, "a click is DONE on the down — no card, no fly-in on the up");
+  assert.ok(!/this\.select\(pp\.sid\)/.test(HIVE), "no click path reaches select()");
   assert.match(HIVE, /openChat\(sid: string\) \{/, "one shared open path");
   assert.match(HIVE, /this\.card\.onOpen = \(sid\) => this\.openChat\(sid\);/, "the card's Open uses it");
   assert.match(HIVE, /\{ romp: "reveal", pane: "chat" \}/, "…and it reveals the chat pane");

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -76,8 +76,8 @@ test("a click's whole answer is the chat on the left; the card stays out of the 
   // session and reveals the chat pane — one path shared with the card's Open and dblclick.
   assert.match(HIVE, /new THREE\.CapsuleGeometry\(0\.55/, "the bean has a whole-body hit capsule");
   assert.match(HIVE, /colorWrite: false/, "…that draws nothing but still raycasts");
-  assert.match(HIVE, /if \(pad\) \{\s*\n\s*if \(hit\.bean\) pad\.pokeBean\(\);\s*\n\s*this\.openChat\(sid\);/,
-    "ANY press on an occupied cell switches chat ON THE DOWN — hexagon and bean alike");
+  assert.match(HIVE, /if \(pad && !hit\.name\) \{\s*\n\s*if \(hit\.bean\) pad\.pokeBean\(\);\s*\n\s*this\.openChat\(sid\);/,
+    "ANY press on an occupied cell switches chat ON THE DOWN — except the nameplate, which edits");
   // the fly-in card + camera zoom on every click read as noise (the user 2026-08-13):
   // a click does NOTHING more on the up, and select() serves only the deep-link jump
   assert.match(HIVE, /if \(pp\) return;/, "a click is DONE on the down — no card, no fly-in on the up");

--- a/ui/webview/hive-wiring.test.ts
+++ b/ui/webview/hive-wiring.test.ts
@@ -58,6 +58,17 @@ test("the talk path speaks the kernel's drive-op protocol", () => {
   assert.ok(HIVE.includes('{ type: "openSession", id: sid }'), "the card can jump to the full session");
 });
 
+test("cell lines trace the EXACT boundary, so used and empty cells are one connected web", () => {
+  // The status line, the sonar ping and the ghost all draw hexLineGeo(PAD_R) — the same
+  // corners and radius the lattice's edges use — never an inset copy floating inside the
+  // cell (the user 2026-08-13: they should be connected).
+  const loops = HIVE.match(/new THREE\.LineLoop\(hexLineGeo\([^)]*\)/g) || [];
+  assert.ok(loops.length >= 3, "the line treatment is in use");
+  for (const l of loops)
+    assert.equal(l, "new THREE.LineLoop(hexLineGeo(PAD_R)", "a line loop is not on the boundary: " + l);
+  assert.ok(!HIVE.includes("LINE_INSET"), "no inset constant survives");
+});
+
 test("hive's WebGL palette matches the styles.css status tokens (one meaning per color)", () => {
   // hive draws in WebGL where CSS vars can't reach, so it carries the values — this pin is
   // what keeps them the SAME values. Each pair: [styles.css token, hive.ts literal].

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -35,8 +35,6 @@ const ST: Record<HiveState, number> = {
 const ACCENT = 0x9cd2ff;
 const PAD_H = 0.06;           // a hair of thickness so a lifted tile isn't paper; the board
                               // reads as ONE flat layer (HEX_SIZE/PAD_R: hive-layout.ts)
-const LINE_INSET = 0.94;      // a cell's own neon line sits just inside its boundary, so two
-                              // adjacent sessions' colors never fight over the shared edge
 // Tron world (the user 2026-08-13): near-black glossy ground with a faint accent grid, the
 // pads dark slabs whose STATUS light is their glowing rim, bloom doing the neon work. The
 // beans stay cute (session-colored, softly self-lit) with dark visors and glowing eyes.
@@ -103,14 +101,17 @@ class Pad {
     this.padMesh.position.y = PAD_H / 2;
     this.group.add(this.padMesh);
 
-    // the status LIGHT: ONE thin neon line tracing the cell, a hair inside its boundary
-    // (LINE_INSET) — additive + bloom does the glow; no halo, no thickness, the
-    // mathematically even look (the user 2026-08-13)
+    // the status LIGHT: ONE thin neon line tracing the cell's EXACT boundary — the same
+    // corners (hexCorner) and radius the lattice draws, so a used cell's walls ARE segments
+    // of the shared web, connected to the empty cells and to its neighbours (the user
+    // 2026-08-13, twice: connected, never floating inside its cell). Where two live
+    // sessions share a wall the additive lines blend — that wall belongs to both. Bloom
+    // does the glow; no halo, no thickness.
     this.ringMat = new THREE.LineBasicMaterial({
       color: ST[sess.state], transparent: true, opacity: 0.95,
       blending: THREE.AdditiveBlending, depthWrite: false,
     });
-    this.ring = new THREE.LineLoop(hexLineGeo(PAD_R * LINE_INSET), this.ringMat);
+    this.ring = new THREE.LineLoop(hexLineGeo(PAD_R), this.ringMat);
     this.ring.position.y = PAD_H + 0.012;
     this.group.add(this.ring);
 
@@ -119,7 +120,7 @@ class Pad {
       color: ST.awaiting, transparent: true, opacity: 0,
       blending: THREE.AdditiveBlending, depthWrite: false,
     });
-    this.sonar = new THREE.LineLoop(hexLineGeo(PAD_R * LINE_INSET), this.sonarMat);
+    this.sonar = new THREE.LineLoop(hexLineGeo(PAD_R), this.sonarMat);
     this.sonar.position.y = this.ring.position.y;
     this.group.add(this.sonar);
 
@@ -842,10 +843,12 @@ class HiveWorld {
 
     // deliberately QUIETER than any real pad: smaller, hairline ring, near-invisible fill —
     // an invitation at the spiral's frontier, not a resident
-    const ghostRing = new THREE.LineLoop(hexLineGeo(PAD_R * 0.74), this.ghostRingMat);
+    // the ghost lights its whole cell like a resident would, just barely: the full boundary
+    // line (connected to the web like every other cell) + a whisper of fill
+    const ghostRing = new THREE.LineLoop(hexLineGeo(PAD_R), this.ghostRingMat);
     ghostRing.position.y = 0.03;
     this.ghostFill = new THREE.Mesh(
-      new THREE.CircleGeometry(PAD_R * 0.76, 6, RIM_THETA),
+      new THREE.CircleGeometry(PAD_R, 6, RIM_THETA),
       new THREE.MeshBasicMaterial({ color: ACCENT, transparent: true, opacity: 0.012, depthWrite: false }));
     this.ghostFill.rotation.x = -Math.PI / 2;
     this.ghostFill.position.y = 0.02;

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -12,7 +12,7 @@ import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
 import { delegate } from "./actions";
 import { hostPrefix } from "./host-prefix";
-import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, PAD_R, PAD_THETA, RIM_THETA, spiralSlot } from "./hive-layout";
+import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexCorner, latticeSegments, PAD_R, PAD_THETA, RIM_THETA, ringOf, spiralSlot } from "./hive-layout";
 import { buildSessions, diffSessions, HiveSession, HiveState, hiveAge, stateLine } from "./hive-model";
 
 const vscodeApi =
@@ -33,7 +33,10 @@ const ST: Record<HiveState, number> = {
   opening: 0x9aa0a6,     // pale — CLI still coming up
 };
 const ACCENT = 0x9cd2ff;
-const PAD_H = 0.42;           // HEX_SIZE/PAD_R live in hive-layout.ts, snapped flush there
+const PAD_H = 0.06;           // a hair of thickness so a lifted tile isn't paper; the board
+                              // reads as ONE flat layer (HEX_SIZE/PAD_R: hive-layout.ts)
+const LINE_INSET = 0.94;      // a cell's own neon line sits just inside its boundary, so two
+                              // adjacent sessions' colors never fight over the shared edge
 // Tron world (the user 2026-08-13): near-black glossy ground with a faint accent grid, the
 // pads dark slabs whose STATUS light is their glowing rim, bloom doing the neon work. The
 // beans stay cute (session-colored, softly self-lit) with dark visors and glowing eyes.
@@ -44,16 +47,27 @@ function ease(cur: number, target: number, dt: number, rate: number): number {
   return cur + (target - cur) * (1 - Math.exp(-rate * dt));
 }
 
+// one thin hex outline in the XZ plane (hexCorner — the corners the prism uses), for a
+// LineLoop: THE line treatment of the board. Per-instance so Pad.dispose() can dispose it.
+function hexLineGeo(r: number): THREE.BufferGeometry {
+  const pos = new Float32Array(18);
+  for (let k = 0; k < 6; k++) {
+    const c = hexCorner(0, 0, r, k);
+    pos[k * 3] = c.x; pos[k * 3 + 1] = 0; pos[k * 3 + 2] = c.z;
+  }
+  const g = new THREE.BufferGeometry();
+  g.setAttribute("position", new THREE.BufferAttribute(pos, 3));
+  return g;
+}
+
 // ── one session's pad: hex prism + status ring + label + its dweller ─────────────────────
 class Pad {
   group = new THREE.Group();
   private padMesh: THREE.Mesh;
-  private ring: THREE.Mesh;
-  private ringMat: THREE.MeshBasicMaterial;
-  private halo!: THREE.Mesh;
-  private haloMat!: THREE.MeshBasicMaterial;
-  private sonar: THREE.Mesh;
-  private sonarMat: THREE.MeshBasicMaterial;
+  private ring: THREE.LineLoop;
+  private ringMat: THREE.LineBasicMaterial;
+  private sonar: THREE.LineLoop;
+  private sonarMat: THREE.LineBasicMaterial;
   private label: THREE.Sprite;
   private labelW = 1; private labelH = 1;   // base sprite size; update() re-scales by camera distance
   private bang: THREE.Sprite;              // the ❗ that bobs over a needs-you pad
@@ -89,35 +103,23 @@ class Pad {
     this.padMesh.position.y = PAD_H / 2;
     this.group.add(this.padMesh);
 
-    // the status LIGHT: a glowing hex rim hugging the top edge (additive, bloom-fed).
-    // RIM_THETA lines its corners up with the cylinder's PAD_THETA once its XY maps into
-    // XZ below — the two parametrise their angles from different axes.
-    this.ringMat = new THREE.MeshBasicMaterial({
+    // the status LIGHT: ONE thin neon line tracing the cell, a hair inside its boundary
+    // (LINE_INSET) — additive + bloom does the glow; no halo, no thickness, the
+    // mathematically even look (the user 2026-08-13)
+    this.ringMat = new THREE.LineBasicMaterial({
       color: ST[sess.state], transparent: true, opacity: 0.95,
       blending: THREE.AdditiveBlending, depthWrite: false,
     });
-    const ringGeo = new THREE.RingGeometry(PAD_R * 0.9, PAD_R * 0.985, 6, 1, RIM_THETA);
-    this.ring = new THREE.Mesh(ringGeo, this.ringMat);
-    this.ring.rotation.x = -Math.PI / 2;
+    this.ring = new THREE.LineLoop(hexLineGeo(PAD_R * LINE_INSET), this.ringMat);
     this.ring.position.y = PAD_H + 0.012;
     this.group.add(this.ring);
-    // …and its soft halo: a wider, fainter copy that sells the glow even before bloom
-    this.haloMat = new THREE.MeshBasicMaterial({
-      color: ST[sess.state], transparent: true, opacity: 0.22,
-      blending: THREE.AdditiveBlending, depthWrite: false, side: THREE.DoubleSide,
-    });
-    this.halo = new THREE.Mesh(new THREE.RingGeometry(PAD_R * 0.86, PAD_R * 1.12, 6, 1, RIM_THETA), this.haloMat);
-    this.halo.rotation.x = -Math.PI / 2;
-    this.halo.position.y = PAD_H + 0.006;
-    this.group.add(this.halo);
 
-    // sonar ping: an expanding, fading copy — the needs-you beacon (awaiting only)
-    this.sonarMat = new THREE.MeshBasicMaterial({
+    // sonar ping: an expanding, fading copy of the line — the needs-you beacon (awaiting only)
+    this.sonarMat = new THREE.LineBasicMaterial({
       color: ST.awaiting, transparent: true, opacity: 0,
-      blending: THREE.AdditiveBlending, depthWrite: false, side: THREE.DoubleSide,
+      blending: THREE.AdditiveBlending, depthWrite: false,
     });
-    this.sonar = new THREE.Mesh(new THREE.RingGeometry(PAD_R * 0.93, 0.05 + PAD_R * 0.93, 6, 1, RIM_THETA), this.sonarMat);
-    this.sonar.rotation.copy(this.ring.rotation);
+    this.sonar = new THREE.LineLoop(hexLineGeo(PAD_R * LINE_INSET), this.sonarMat);
     this.sonar.position.y = this.ring.position.y;
     this.group.add(this.sonar);
 
@@ -187,15 +189,15 @@ class Pad {
     this.group.position.y = this.liftCur;
 
     this.ringColor.lerp(this.ringTarget, 1 - Math.exp(-8 * dt));
-    this.ringMat.color.copy(this.ringColor);
-    this.haloMat.color.copy(this.ringColor);
+    // a 1px line carries less light than the old fat rim, so overdrive the color past 1 —
+    // that's what pushes it over the bloom threshold into neon
+    this.ringMat.color.copy(this.ringColor).multiplyScalar(1.6);
     const st = this.sess.state;
     // pulse only the states that are genuinely in motion; steady states hold steady
     if (st === "working") this.ringMat.opacity = 0.62 + 0.3 * (0.5 + 0.5 * Math.sin(this.t * 3.6));
     else if (st === "awaiting") this.ringMat.opacity = 0.55 + 0.45 * (0.5 + 0.5 * Math.sin(this.t * 7));
     else if (st === "retrying") this.ringMat.opacity = 0.5 + 0.5 * (Math.sin(this.t * 11) > 0.2 ? 1 : 0.35);
     else this.ringMat.opacity = 0.95;
-    this.haloMat.opacity = this.ringMat.opacity * 0.24;
 
     if (st === "awaiting") {
       // sonar ping: 1.4s loop, ring swells to ~1.8× and fades — visible from any zoom
@@ -496,29 +498,6 @@ function makeTextSprite(text: string, color: string, bubble?: string): THREE.Spr
 }
 function disposeSprite(s: THREE.Sprite) { s.material.map?.dispose(); s.material.dispose(); }
 
-// the floor grid tile: one accent line pair per edge, a brighter major every 4th repeat is
-// faked by drawing the major into the same tile at quarter opacity steps — cheap, seamless
-function makeGridTexture(): THREE.CanvasTexture {
-  const c = document.createElement("canvas");
-  c.width = 256; c.height = 256;
-  const g = c.getContext("2d")!;
-  g.clearRect(0, 0, 256, 256);
-  g.strokeStyle = "rgba(156,210,255,0.30)";
-  g.lineWidth = 2;
-  g.strokeRect(0.5, 0.5, 256, 256);
-  g.strokeStyle = "rgba(156,210,255,0.10)";
-  g.lineWidth = 1;
-  for (const q of [64, 128, 192]) {
-    g.beginPath(); g.moveTo(q, 0); g.lineTo(q, 256); g.stroke();
-    g.beginPath(); g.moveTo(0, q); g.lineTo(256, q); g.stroke();
-  }
-  const tex = new THREE.CanvasTexture(c);
-  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
-  tex.repeat.set(42, 42);                    // 300-unit plane → ~7.1-unit majors, pad-scaled
-  tex.colorSpace = THREE.SRGBColorSpace;
-  return tex;
-}
-
 // ── confetti / puffs: one pooled particle system for every burst ─────────────────────────
 class Particles {
   points: THREE.Points;
@@ -775,12 +754,17 @@ class HiveWorld {
   // the ghost hex: a faint outline on the first FREE slot — hover it and a "+" wakes up;
   // click recruits (opens the new-session picker via the shell relay)
   private ghost = new THREE.Group();
-  private ghostRingMat = new THREE.MeshBasicMaterial({
+  private ghostRingMat = new THREE.LineBasicMaterial({
     color: ACCENT, transparent: true, opacity: 0.14, blending: THREE.AdditiveBlending, depthWrite: false,
   });
   private ghostFill: THREE.Mesh;
   private ghostPlus: THREE.Sprite;
   private ghostHover = false;
+  // the one-layer board: every cell of the honeycomb as thin faint lines — EMPTY cells are
+  // this lattice, USED cells are the pads docked flush into it. Rebuilt only when the
+  // needed ring count changes (an arrival/departure at the frontier), never per push.
+  private lattice: THREE.LineSegments | null = null;
+  private latticeRings = -1;
 
   constructor(private root: HTMLElement) {
     this.renderer = new THREE.WebGLRenderer({ antialias: true });
@@ -801,8 +785,9 @@ class HiveWorld {
     this.scene.add(rim);
     this.scene.add(this.particles.points);
 
-    // the floor: a dark glossy disc with a faint accent grid riding just above it, both
-    // fading into the fog — the Tron ground the pads dock on
+    // the floor: a dark matte disc fading into the fog. The only pattern on it is the hex
+    // LATTICE (ensureLattice) — the square grid is gone: two grids at once fought the
+    // tessellation instead of underlining it (the user 2026-08-13)
     const floor = new THREE.Mesh(
       new THREE.CircleGeometry(150, 64),
       // matte enough that the key light can't smear a bloom highlight across the floor
@@ -811,19 +796,9 @@ class HiveWorld {
     floor.rotation.x = -Math.PI / 2;
     floor.position.y = -0.02;
     this.scene.add(floor);
-    const grid = new THREE.Mesh(
-      new THREE.PlaneGeometry(300, 300),
-      new THREE.MeshBasicMaterial({
-        map: makeGridTexture(), transparent: true, opacity: 0.38,
-        blending: THREE.AdditiveBlending, depthWrite: false,
-      }),
-    );
-    grid.rotation.x = -Math.PI / 2;
-    grid.position.y = 0.0;
-    this.scene.add(grid);
 
-    // bloom is the neon: everything over the threshold (rims, eyes, screens, grid majors)
-    // halos out; the dark slabs and floor stay dark
+    // bloom is the neon: everything over the threshold (the overdriven status lines, eyes,
+    // screens) halos out; the dark tiles, lattice and floor stay dark
     this.composer = new EffectComposer(this.renderer);
     this.composer.addPass(new RenderPass(this.scene, this.camera));
     this.bloom = new UnrealBloomPass(new THREE.Vector2(1, 1), 0.7, 0.45, 0.72);
@@ -867,9 +842,7 @@ class HiveWorld {
 
     // deliberately QUIETER than any real pad: smaller, hairline ring, near-invisible fill —
     // an invitation at the spiral's frontier, not a resident
-    const ghostRing = new THREE.Mesh(
-      new THREE.RingGeometry(PAD_R * 0.72, PAD_R * 0.76, 6, 1, RIM_THETA), this.ghostRingMat);
-    ghostRing.rotation.x = -Math.PI / 2;
+    const ghostRing = new THREE.LineLoop(hexLineGeo(PAD_R * 0.74), this.ghostRingMat);
     ghostRing.position.y = 0.03;
     this.ghostFill = new THREE.Mesh(
       new THREE.CircleGeometry(PAD_R * 0.76, 6, RIM_THETA),
@@ -1059,6 +1032,8 @@ class HiveWorld {
     while (taken.has(free)) free++;
     const gp = axialToXZ(spiralSlot(free), HEX_SIZE);
     this.ghost.position.set(gp.x, 0, gp.z);
+    // …and keep the one-layer lattice one ring wider than anything on it
+    this.ensureLattice(Math.max(3, ringOf(Math.max(free, ...this.slots.values())) + 1));
 
     if (first || diff.added.length || diff.removed.length) {
       if (this.selected === null) this.frameAll();
@@ -1071,6 +1046,32 @@ class HiveWorld {
       if (sid && this.pads.has(sid)) this.select(sid);
     }
     this.ensureLoop();
+  }
+
+  // (re)build the empty-cell lattice for rings 0..n: one LineSegments of every unique edge
+  // (latticeSegments dedupes shared ones), faint accent, flat on the board — the layer the
+  // pads dock into
+  private ensureLattice(rings: number) {
+    if (rings === this.latticeRings) return;
+    this.latticeRings = rings;
+    if (this.lattice) {
+      this.scene.remove(this.lattice);
+      this.lattice.geometry.dispose();
+      (this.lattice.material as THREE.Material).dispose();
+    }
+    const seg = latticeSegments(rings, HEX_SIZE);
+    const pos = new Float32Array((seg.length / 4) * 6);
+    for (let i = 0, j = 0; i < seg.length; i += 4) {
+      pos[j++] = seg[i]; pos[j++] = 0; pos[j++] = seg[i + 1];
+      pos[j++] = seg[i + 2]; pos[j++] = 0; pos[j++] = seg[i + 3];
+    }
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute("position", new THREE.BufferAttribute(pos, 3));
+    this.lattice = new THREE.LineSegments(geo, new THREE.LineBasicMaterial({
+      color: ACCENT, transparent: true, opacity: 0.13, blending: THREE.AdditiveBlending, depthWrite: false,
+    }));
+    this.lattice.position.y = 0.004;
+    this.scene.add(this.lattice);
   }
 
   private ensureLoop() {

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -1074,8 +1074,9 @@ class HiveWorld {
       // ANY press on an occupied cell switches chat ON THE DOWN — hexagon and bean alike,
       // instant (the user 2026-08-13, twice); the bean adds its pop. The same press can
       // still become a pick-up: the switch has already happened, and seeing their chat
-      // while you carry them is coherent. The TILE'S deeper level (card + camera fly-in)
-      // stays on the clean UP — a fly-in mid-drag is chaos.
+      // while you carry them is coherent. That is ALL a click does: the chat on the left
+      // is the answer — the fly-in card + camera zoom on every click read as noise (the
+      // user 2026-08-13) and now serve only the deep-link jump (select()).
       if (pad) {
         if (hit.bean) pad.pokeBean();
         this.openChat(sid);
@@ -1093,12 +1094,7 @@ class HiveWorld {
     this.pressedPad = null;
     this.dragging = null;
     if (this.dragSession) { this.dropSessionDrag(this.dragSession.over); return; }
-    if (pp) {
-      if (Math.hypot(e.clientX - pp.x, e.clientY - pp.y) > 5) return;   // it was a nudge, not a click
-      // the bean already switched chat on the DOWN; the tile's card resolves here
-      if (!pp.bean && this.pads.has(pp.sid)) this.select(pp.sid);
-      return;
-    }
+    if (pp) return;   // the press already did everything (chat switch on the DOWN); a drag ended above
     if (!pr) return;
     // a real drag is a camera move, not a click — the gate is the gesture itself (px
     // travelled between down and up), never a timer
@@ -1213,6 +1209,9 @@ class HiveWorld {
     this.ghostTarget.set(p.x, 0, p.z);
   }
 
+  // The SELECTED state (camera fly-in + the fly-in card) is the DEEP-LINK presentation
+  // only — a feed/outline "show me" jump lands here (#focus=<sid>). A plain click never
+  // opens it: the chat on the left is the click's whole answer (the user 2026-08-13).
   select(sid: string) {
     this.selected = sid;
     const pad = this.pads.get(sid);

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -1,0 +1,709 @@
+// Hive — the game-feel command view (plans/hive.md): a 3D honeycomb, one hex pad + one
+// little character per session, acting out that session's live state. Rides the feed
+// payload over its own app=hive socket (ledgers + asks — see hive-model.ts); the scene is
+// built ONCE and then mutated only by the model's diff events, never rebuilt per push, so
+// nothing here can flap without new information (CLAUDE.md ## Design).
+//
+// Status colors keep their standing meanings (styles.css --st-*); the romp accent #9cd2ff
+// is reserved for selection/hover chrome. All geometry is procedural — no runtime assets.
+import * as THREE from "three";
+import { assignSlots, axialToXZ, frameRadius, spiralSlot } from "./hive-layout";
+import { buildSessions, diffSessions, HiveSession, HiveState } from "./hive-model";
+
+const vscodeApi =
+  typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
+
+// ── status palette (mirrors styles.css --st-*; hive draws in WebGL so the CSS vars can't
+//    reach it — the values are pinned by hive-wiring.test.ts against styles.css instead) ──
+const ST: Record<HiveState, number> = {
+  working: 0xe0b020,     // gold — actively in a turn
+  ready: 0x2b7fb8,       // calm blue — idle, nothing owed
+  awaiting: 0xc0392b,    // needs YOU: a live permission/picker prompt
+  blocked: 0xe5484d,     // alarm red — stopped on an API error
+  retrying: 0xe08020,    // amber — riding an api-retry storm
+  awaitingBg: 0x54b204,  // green — idle main thread, waiting on background work
+  compacting: 0x14b8a6,  // teal — context operation in flight
+  clearing: 0x14b8a6,
+  interrupting: 0x8a8a8a,
+  opening: 0x9aa0a6,     // pale — CLI still coming up
+};
+const ACCENT = 0x9cd2ff;
+const HEX_SIZE = 2.05;        // axial size: neighbour centers sit √3·size apart
+const PAD_R = 1.62;           // pad circumradius (< √3/2·size, so pads never touch)
+const PAD_H = 0.42;
+
+// exponential smoothing toward a target — frame-rate independent; `rate`/s is the snap speed
+function ease(cur: number, target: number, dt: number, rate: number): number {
+  return cur + (target - cur) * (1 - Math.exp(-rate * dt));
+}
+
+// ── one session's pad: hex prism + status ring + label + its dweller ─────────────────────
+class Pad {
+  group = new THREE.Group();
+  private padMesh: THREE.Mesh;
+  private ring: THREE.Mesh;
+  private ringMat: THREE.MeshBasicMaterial;
+  private sonar: THREE.Mesh;
+  private sonarMat: THREE.MeshBasicMaterial;
+  private label: THREE.Sprite;
+  private bang: THREE.Sprite;              // the ❗ that bobs over a needs-you pad
+  private guy: Dweller;
+  private baseY = 0;
+  lift = 0;                                 // hover/press target offset, eased in update()
+  private liftCur = 0;
+  private ringColor = new THREE.Color(ST.ready);
+  private ringTarget = new THREE.Color(ST.ready);
+  private t = Math.random() * 100;          // free-running clock, de-synced per pad
+  private spawnT = 0;                       // 0→1 arrival pop
+  dyingT = -1;                              // ≥0 → departure animation clock
+  sess: HiveSession;
+
+  constructor(sess: HiveSession, slot: number) {
+    this.sess = sess;
+    const { x, z } = axialToXZ(spiralSlot(slot), HEX_SIZE);
+    this.group.position.set(x, 0, z);
+
+    const tint = new THREE.Color(sess.color?.bg || "#8a8a8a");
+    const top = new THREE.Color(0x2f3136).lerp(tint, 0.22);
+    const side = new THREE.Color(0x232427).lerp(tint, 0.10);
+    // CylinderGeometry with 6 radial segments IS the hex prism; thetaStart π/6 turns an
+    // edge (not a corner) toward each axial neighbour so the honeycomb reads as tiling.
+    const geo = new THREE.CylinderGeometry(PAD_R, PAD_R * 1.06, PAD_H, 6, 1, false, Math.PI / 6);
+    this.padMesh = new THREE.Mesh(geo, [
+      new THREE.MeshStandardMaterial({ color: side, roughness: 0.9, metalness: 0 }),
+      new THREE.MeshStandardMaterial({ color: top, roughness: 0.82, metalness: 0 }),
+      new THREE.MeshStandardMaterial({ color: side, roughness: 0.9, metalness: 0 }),
+    ]);
+    this.padMesh.position.y = PAD_H / 2;
+    this.group.add(this.padMesh);
+
+    // status ring: a hex annulus laid flat on the pad top. thetaStart -π/3 lines its corners
+    // up with the cylinder's (thetaStart π/6) once RingGeometry's XY maps into XZ below —
+    // the two parametrise their angles from different axes.
+    this.ringMat = new THREE.MeshBasicMaterial({ color: ST[sess.state], transparent: true, opacity: 0.9 });
+    const ringGeo = new THREE.RingGeometry(PAD_R * 0.74, PAD_R * 0.82, 6, 1, -Math.PI / 3);
+    this.ring = new THREE.Mesh(ringGeo, this.ringMat);
+    this.ring.rotation.x = -Math.PI / 2;
+    this.ring.position.y = PAD_H + 0.015;
+    this.group.add(this.ring);
+
+    // sonar ping: an expanding, fading copy — the needs-you beacon (awaiting only)
+    this.sonarMat = new THREE.MeshBasicMaterial({ color: ST.awaiting, transparent: true, opacity: 0, side: THREE.DoubleSide });
+    this.sonar = new THREE.Mesh(new THREE.RingGeometry(PAD_R * 0.78, 0.045 + PAD_R * 0.78, 6, 1, -Math.PI / 3), this.sonarMat);
+    this.sonar.rotation.copy(this.ring.rotation);
+    this.sonar.position.y = this.ring.position.y;
+    this.group.add(this.sonar);
+
+    this.label = makeTextSprite(sess.name, sess.color?.bg || "#cccccc");
+    this.label.position.y = 3.1;
+    this.group.add(this.label);
+
+    this.bang = makeTextSprite("!", "#ffffff", "#c0392b");
+    this.bang.position.y = 2.35;
+    this.bang.visible = false;
+    this.group.add(this.bang);
+
+    this.guy = new Dweller(sess.color?.bg || "#9cd2ff");
+    this.guy.group.position.y = PAD_H;
+    this.group.add(this.guy.group);
+    this.guy.setState(sess.state, sess.faded);
+
+    this.group.scale.setScalar(0.001);      // arrival pop plays from ~zero
+    this.ringColor.setHex(ST[sess.state]);
+    this.ringTarget.setHex(ST[sess.state]);
+  }
+
+  // a real state/name change arrived (diff event) — retarget; update() animates the morph
+  apply(sess: HiveSession, stateChanged: boolean) {
+    const prevName = this.sess.name, prevColor = this.sess.color?.bg;
+    this.sess = sess;
+    if (stateChanged) {
+      this.ringTarget.setHex(ST[sess.state]);
+      this.guy.setState(sess.state, sess.faded);
+    }
+    if (sess.name !== prevName || sess.color?.bg !== prevColor) {
+      this.group.remove(this.label);
+      disposeSprite(this.label);
+      this.label = makeTextSprite(sess.name, sess.color?.bg || "#cccccc");
+      this.label.position.y = 3.1;
+      this.group.add(this.label);
+    }
+  }
+
+  hitMeshes(): THREE.Object3D[] { return [this.padMesh]; }
+
+  update(dt: number, camYaw: number): boolean {
+    this.t += dt;
+    if (this.spawnT < 1) {
+      this.spawnT = Math.min(1, this.spawnT + dt / 0.5);
+      const s = this.spawnT;
+      const overshoot = 1 + 0.28 * Math.sin(s * Math.PI) * (1 - s);   // pop past 1, settle back
+      this.group.scale.setScalar(Math.max(0.001, s * overshoot));
+    }
+    if (this.dyingT >= 0) {
+      // departure: a small farewell hop, then sink through the floor and fade
+      this.dyingT += dt;
+      const d = this.dyingT;
+      this.group.position.y = d < 0.25 ? Math.sin(d / 0.25 * Math.PI) * 0.3 : -(d - 0.25) * 2.2;
+      const sc = Math.max(0.001, 1 - Math.max(0, d - 0.25) * 1.1);
+      this.group.scale.setScalar(sc);
+      return d > 1.15;                      // done → caller disposes
+    }
+    this.liftCur = ease(this.liftCur, this.lift, dt, 14);
+    this.group.position.y = this.liftCur;
+
+    this.ringColor.lerp(this.ringTarget, 1 - Math.exp(-8 * dt));
+    this.ringMat.color.copy(this.ringColor);
+    const st = this.sess.state;
+    // pulse only the states that are genuinely in motion; steady states hold steady
+    if (st === "working") this.ringMat.opacity = 0.62 + 0.3 * (0.5 + 0.5 * Math.sin(this.t * 3.6));
+    else if (st === "awaiting") this.ringMat.opacity = 0.55 + 0.45 * (0.5 + 0.5 * Math.sin(this.t * 7));
+    else if (st === "retrying") this.ringMat.opacity = 0.5 + 0.5 * (Math.sin(this.t * 11) > 0.2 ? 1 : 0.35);
+    else this.ringMat.opacity = 0.85;
+
+    if (st === "awaiting") {
+      // sonar ping: 1.4s loop, ring swells to ~1.8× and fades — visible from any zoom
+      const p = (this.t % 1.4) / 1.4;
+      this.sonarMat.opacity = (1 - p) * 0.5;
+      this.sonar.scale.setScalar(1 + p * 0.85);
+      this.bang.visible = true;
+      this.bang.position.y = 2.35 + 0.14 * Math.abs(Math.sin(this.t * 5));
+    } else {
+      this.sonarMat.opacity = 0;
+      this.bang.visible = false;
+    }
+    this.guy.update(dt, this.t, camYaw);
+    return false;
+  }
+
+  dispose() {
+    this.group.traverse((o) => {
+      const m = o as THREE.Mesh;
+      if (m.geometry) m.geometry.dispose();
+      const mats = Array.isArray(m.material) ? m.material : m.material ? [m.material] : [];
+      for (const mat of mats) { const t = (mat as THREE.MeshBasicMaterial).map; if (t) t.dispose(); mat.dispose(); }
+    });
+  }
+}
+
+// ── the little guy (v1 rig: capsule + eyes, per-state posture/motion; deeper costumes and
+//    props land with the character pass — plans/hive.md "State → performance") ────────────
+class Dweller {
+  group = new THREE.Group();
+  private body: THREE.Mesh;
+  private bodyMat: THREE.MeshStandardMaterial;
+  private eyeL: THREE.Group; private eyeR: THREE.Group;
+  private aura: THREE.Mesh;                 // compacting swirl / awaitingBg marker, recolored per state
+  private auraMat: THREE.MeshBasicMaterial;
+  private state: HiveState = "ready";
+  private faded = false;
+  private blinkAt = 2 + Math.random() * 4;
+  private blinkT = -1;
+  private phase = Math.random() * Math.PI * 2;
+  private baseColor: THREE.Color;
+  private pop = 0;                          // hatch flourish clock (opening → live)
+
+  constructor(tint: string) {
+    this.baseColor = new THREE.Color(tint).lerp(new THREE.Color(0xffffff), 0.12);
+    this.bodyMat = new THREE.MeshStandardMaterial({ color: this.baseColor.clone(), roughness: 0.6 });
+    this.body = new THREE.Mesh(new THREE.CapsuleGeometry(0.34, 0.42, 6, 14), this.bodyMat);
+    this.body.position.y = 0.56;
+    this.group.add(this.body);
+    const mkEye = () => {
+      const g = new THREE.Group();
+      const white = new THREE.Mesh(new THREE.SphereGeometry(0.085, 10, 10), new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.35 }));
+      const pupil = new THREE.Mesh(new THREE.SphereGeometry(0.038, 8, 8), new THREE.MeshStandardMaterial({ color: 0x1a1a1a, roughness: 0.3 }));
+      pupil.position.z = 0.062;
+      g.add(white, pupil);
+      return g;
+    };
+    this.eyeL = mkEye(); this.eyeR = mkEye();
+    this.eyeL.position.set(-0.125, 0.78, 0.28);
+    this.eyeR.position.set(0.125, 0.78, 0.28);
+    this.group.add(this.eyeL, this.eyeR);
+    this.auraMat = new THREE.MeshBasicMaterial({ color: ST.compacting, transparent: true, opacity: 0 });
+    this.aura = new THREE.Mesh(new THREE.TorusGeometry(0.52, 0.035, 6, 24), this.auraMat);
+    this.aura.position.y = 0.62;
+    this.aura.rotation.x = Math.PI / 2.4;
+    this.group.add(this.aura);
+  }
+
+  setState(s: HiveState, faded: boolean) {
+    if (this.state === "opening" && s !== "opening") {
+      this.pop = 0.45;                       // hatched! — one pop, then normal life
+      this.bodyMat.color.copy(this.baseColor);
+    }
+    this.state = s; this.faded = faded;
+  }
+
+  update(dt: number, t: number, camYaw: number) {
+    const s = this.state;
+    // blink (life for every state except the egg)
+    if (s !== "opening") {
+      this.blinkAt -= dt;
+      if (this.blinkAt <= 0) { this.blinkT = 0.12; this.blinkAt = 3 + Math.random() * 4; }
+      if (this.blinkT > 0) this.blinkT -= dt;
+      const bl = this.blinkT > 0 ? 0.12 : 1;
+      this.eyeL.scale.y = bl; this.eyeR.scale.y = bl;
+    }
+    const breathe = 1 + 0.02 * Math.sin(t * 2.1 + this.phase);
+    this.body.scale.set(1, breathe, 1);
+    if (this.pop > 0) {
+      this.pop = Math.max(0, this.pop - dt);
+      const p = this.pop / 0.45;             // 1→0: a quick overshoot pulse on the whole body
+      this.body.scale.multiplyScalar(1 + 0.3 * Math.sin(p * Math.PI));
+    }
+
+    let y = 0, rotX = 0, rotZ = 0, yaw = 0, sx = 0;
+    let aura = 0;
+    switch (s) {
+      case "working": {
+        // typing bursts: bob fast for ~1.4s, rest ~0.8s — the rhythm reads as real keys
+        const burst = Math.sin(t * 2.8 + this.phase) > -0.35;
+        rotX = 0.14;
+        y = burst ? 0.02 * Math.abs(Math.sin(t * 11)) : 0;
+        break;
+      }
+      case "awaiting":                       // they need YOU: face the camera and wave
+        yaw = camYaw;
+        y = 0.2 * Math.abs(Math.sin(t * 4.6));
+        rotZ = 0.14 * Math.sin(t * 6.5);
+        break;
+      case "blocked":
+        rotZ = 0.42; y = -0.04; rotX = 0.1;  // slumped against the wreckage
+        break;
+      case "retrying":
+        sx = 0.34 * Math.sin(t * 1.6);       // pacing the pad
+        yaw = Math.cos(t * 1.6) > 0 ? Math.PI / 2 : -Math.PI / 2;
+        break;
+      case "awaitingBg":
+        rotX = -0.12;                        // leaning back, watching its dispatched work
+        aura = 0.4; this.auraMat.color.setHex(ST.awaitingBg);
+        this.aura.rotation.z = t * 0.9;
+        break;
+      case "compacting": case "clearing":
+        y = 0.16 + 0.05 * Math.sin(t * 2.4); // levitating meditation, teal swirl orbiting
+        yaw = t * 0.8;
+        aura = 0.75; this.auraMat.color.setHex(ST.compacting);
+        this.aura.rotation.z = t * 2.2;
+        break;
+      case "interrupting":
+        this.body.scale.y = 0.85;            // freeze-frame squash; no motion at all
+        break;
+      case "opening":
+        // the egg: eyes hidden, whole body wobbling toward the hatch
+        this.eyeL.scale.setScalar(0.001); this.eyeR.scale.setScalar(0.001);
+        this.bodyMat.color.lerp(new THREE.Color(0xf2ead9), 0.2);
+        rotZ = 0.09 * Math.sin(t * 9);
+        break;
+      default:                               // ready
+        if (this.faded) { rotX = -0.3; y = -0.06; }   // dozing off after an hour idle
+        else rotZ = 0.03 * Math.sin(t * 1.3 + this.phase);
+    }
+    if (s !== "opening") { this.eyeL.scale.x = 1; this.eyeR.scale.x = 1; this.eyeL.scale.z = 1; this.eyeR.scale.z = 1; }
+    this.group.position.x = sx;
+    this.group.position.y = PAD_H + y;
+    this.group.rotation.set(rotX, yaw, rotZ);
+    this.auraMat.opacity = ease(this.auraMat.opacity, aura, dt, 6);
+  }
+}
+
+// name/❗ sprites: canvas-drawn, crisp at 2× — the one text surface WebGL owns; everything
+// readable-at-length (the fly-in card) stays DOM
+function makeTextSprite(text: string, color: string, bubble?: string): THREE.Sprite {
+  const c = document.createElement("canvas");
+  const ctx = c.getContext("2d")!;
+  const font = "600 44px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  ctx.font = font;
+  const w = Math.min(560, Math.max(bubble ? 72 : 120, ctx.measureText(text).width + (bubble ? 44 : 28)));
+  c.width = Math.ceil(w); c.height = bubble ? 96 : 64;
+  const ctx2 = c.getContext("2d")!;
+  ctx2.font = font;
+  ctx2.textAlign = "center"; ctx2.textBaseline = "middle";
+  if (bubble) {
+    ctx2.fillStyle = bubble;
+    const r = 26, cw = c.width, ch = c.height;
+    ctx2.beginPath();
+    ctx2.roundRect(cw / 2 - 34, 6, 68, 68, r);
+    ctx2.fill();
+    ctx2.moveTo(cw / 2, ch - 2); ctx2.lineTo(cw / 2 - 12, ch - 22); ctx2.lineTo(cw / 2 + 12, ch - 22);
+    ctx2.fill();
+  } else {
+    ctx2.shadowColor = "rgba(0,0,0,0.85)"; ctx2.shadowBlur = 8;
+  }
+  ctx2.fillStyle = color;
+  ctx2.fillText(text, c.width / 2, bubble ? 40 : c.height / 2, c.width - 16);
+  const tex = new THREE.CanvasTexture(c);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  const sp = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, transparent: true, depthWrite: false }));
+  sp.scale.set(c.width / 110, c.height / 110, 1);
+  return sp;
+}
+function disposeSprite(s: THREE.Sprite) { s.material.map?.dispose(); s.material.dispose(); }
+
+// ── confetti / puffs: one pooled particle system for every burst ─────────────────────────
+class Particles {
+  points: THREE.Points;
+  private geo = new THREE.BufferGeometry();
+  private max = 600;
+  private pos = new Float32Array(this.max * 3);
+  private col = new Float32Array(this.max * 3);
+  private vel: Float32Array = new Float32Array(this.max * 3);
+  private life = new Float32Array(this.max);
+  private n = 0;
+
+  constructor() {
+    this.geo.setAttribute("position", new THREE.BufferAttribute(this.pos, 3));
+    this.geo.setAttribute("color", new THREE.BufferAttribute(this.col, 3));
+    this.points = new THREE.Points(this.geo, new THREE.PointsMaterial({
+      size: 0.14, vertexColors: true, transparent: true, opacity: 0.95, depthWrite: false,
+    }));
+    this.points.frustumCulled = false;
+    this.geo.setDrawRange(0, 0);
+  }
+
+  burst(at: THREE.Vector3, colors: number[], count: number, speed: number) {
+    for (let i = 0; i < count && this.n < this.max; i++, this.n++) {
+      const j = this.n * 3;
+      this.pos[j] = at.x; this.pos[j + 1] = at.y; this.pos[j + 2] = at.z;
+      const th = Math.random() * Math.PI * 2, up = 0.5 + Math.random() * 0.9;
+      this.vel[j] = Math.cos(th) * speed * (0.4 + Math.random() * 0.6);
+      this.vel[j + 1] = up * speed;
+      this.vel[j + 2] = Math.sin(th) * speed * (0.4 + Math.random() * 0.6);
+      const c = new THREE.Color(colors[i % colors.length]);
+      this.col[j] = c.r; this.col[j + 1] = c.g; this.col[j + 2] = c.b;
+      this.life[this.n] = 1.1 + Math.random() * 0.5;
+    }
+  }
+
+  update(dt: number) {
+    let w = 0;
+    for (let i = 0; i < this.n; i++) {
+      this.life[i] -= dt;
+      if (this.life[i] <= 0) continue;
+      const j = i * 3, k = w * 3;
+      this.vel[j + 1] -= 7.5 * dt;
+      this.pos[k] = this.pos[j] + this.vel[j] * dt;
+      this.pos[k + 1] = this.pos[j + 1] + this.vel[j + 1] * dt;
+      this.pos[k + 2] = this.pos[j + 2] + this.vel[j + 2] * dt;
+      if (w !== i) {
+        this.vel[k] = this.vel[j]; this.vel[k + 1] = this.vel[j + 1]; this.vel[k + 2] = this.vel[j + 2];
+        this.col[k] = this.col[j]; this.col[k + 1] = this.col[j + 1]; this.col[k + 2] = this.col[j + 2];
+        this.life[w] = this.life[i];
+      }
+      w++;
+    }
+    this.n = w;
+    this.geo.setDrawRange(0, this.n);
+    (this.geo.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+    (this.geo.attributes.color as THREE.BufferAttribute).needsUpdate = true;
+  }
+}
+
+// ── the world ────────────────────────────────────────────────────────────────────────────
+class HiveWorld {
+  private renderer: THREE.WebGLRenderer;
+  private scene = new THREE.Scene();
+  private camera: THREE.PerspectiveCamera;
+  private pads = new Map<string, Pad>();
+  private slots = new Map<string, number>();
+  private particles = new Particles();
+  private raycaster = new THREE.Raycaster();
+  private pointer = new THREE.Vector2(-2, -2);
+  private hovered: string | null = null;
+  selected: string | null = null;
+  // camera rig: yaw/pitch/dist orbit around an eased target — every value glides, per the
+  // "everything springs, nothing teleports" rule
+  private yaw = 0.0; private yawCur = 0.0;
+  private pitch = 0.72; private pitchCur = 0.72;
+  private dist = 26; private distCur = 30;
+  private target = new THREE.Vector3(); private targetCur = new THREE.Vector3();
+  private idleT = 99;                        // seconds since last user camera input
+  private running = false;
+  private visible = true;
+  private lastFrame = 0;
+  private dragging: { mode: "orbit" | "pan"; x: number; y: number } | null = null;
+  private clock = 0;
+
+  constructor(private root: HTMLElement) {
+    this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    this.renderer.setClearColor(0x1e1e1e);
+    this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+    root.appendChild(this.renderer.domElement);
+    this.camera = new THREE.PerspectiveCamera(42, 1, 0.1, 400);
+    this.scene.fog = new THREE.FogExp2(0x1e1e1e, 0.016);
+    this.scene.add(new THREE.HemisphereLight(0xbfd4e6, 0x2a2622, 1.15));
+    const key = new THREE.DirectionalLight(0xfff2dd, 1.7);
+    key.position.set(7, 12, 5);
+    this.scene.add(key);
+    const rim = new THREE.DirectionalLight(ACCENT, 0.5);
+    rim.position.set(-6, 6, -8);
+    this.scene.add(rim);
+    this.scene.add(this.particles.points);
+
+    const cv = this.renderer.domElement;
+    cv.addEventListener("pointermove", (e) => this.onPointerMove(e));
+    cv.addEventListener("pointerdown", (e) => this.onPointerDown(e));
+    window.addEventListener("pointerup", () => { this.dragging = null; });
+    cv.addEventListener("wheel", (e) => {
+      e.preventDefault();
+      this.dist = Math.min(70, Math.max(7, this.dist * Math.exp(e.deltaY * 0.0012)));
+      this.idleT = 0;
+    }, { passive: false });
+    cv.addEventListener("dblclick", () => {
+      const sid = this.hovered;
+      if (sid) { vscodeApi?.postMessage({ type: "openSession", id: sid }); }
+    });
+    window.addEventListener("keydown", (e) => { if (e.key === "Escape") this.deselect(); });
+
+    const fit = () => {
+      const w = root.clientWidth || 1, h = root.clientHeight || 1;
+      this.renderer.setSize(w, h, false);
+      cv.style.width = "100%"; cv.style.height = "100%";
+      this.camera.aspect = w / h;
+      this.camera.updateProjectionMatrix();
+    };
+    fit();
+    new ResizeObserver(fit).observe(root);
+
+    // render only while there's a viewer: page visible AND the pane on screen (a pane
+    // toggled off is display:none → not intersecting). Paused = zero GPU work.
+    const io = new IntersectionObserver((es) => {
+      this.visible = es.some((e) => e.isIntersecting);
+      this.ensureLoop();
+    });
+    io.observe(root);
+    document.addEventListener("visibilitychange", () => this.ensureLoop());
+    this.ensureLoop();
+  }
+
+  private canvasPoint(e: PointerEvent) {
+    const r = this.renderer.domElement.getBoundingClientRect();
+    this.pointer.set(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1);
+  }
+
+  private onPointerMove(e: PointerEvent) {
+    this.canvasPoint(e);
+    if (this.dragging) {
+      const dx = e.clientX - this.dragging.x, dy = e.clientY - this.dragging.y;
+      this.dragging.x = e.clientX; this.dragging.y = e.clientY;
+      this.idleT = 0;
+      if (this.dragging.mode === "orbit") {
+        this.yaw -= dx * 0.0052;
+        this.pitch = Math.min(1.32, Math.max(0.32, this.pitch + dy * 0.004));
+      } else {
+        // pan in the ground plane, screen-aligned
+        const s = this.distCur * 0.0016;
+        const right = new THREE.Vector3(Math.cos(this.yawCur), 0, -Math.sin(this.yawCur));
+        const fwd = new THREE.Vector3(-Math.sin(this.yawCur), 0, -Math.cos(this.yawCur));
+        this.target.addScaledVector(right, -dx * s).addScaledVector(fwd, dy * s);
+      }
+    }
+  }
+
+  private onPointerDown(e: PointerEvent) {
+    this.canvasPoint(e);
+    const sid = this.pick();
+    if (e.button === 2 || e.shiftKey) { this.dragging = { mode: "pan", x: e.clientX, y: e.clientY }; return; }
+    if (sid) {
+      // acknowledge on the DOWN, before anything async: the pad dips under the press
+      const pad = this.pads.get(sid);
+      if (pad) { pad.lift = -0.07; setTimeout(() => { if (this.pads.get(sid) === pad) pad.lift = this.hovered === sid ? 0.12 : 0; }, 130); }
+      this.select(sid);
+    } else {
+      this.dragging = { mode: "orbit", x: e.clientX, y: e.clientY };
+    }
+  }
+
+  private pick(): string | null {
+    this.raycaster.setFromCamera(this.pointer, this.camera);
+    let best: { sid: string; d: number } | null = null;
+    for (const [sid, pad] of this.pads) {
+      if (pad.dyingT >= 0) continue;
+      const hits = this.raycaster.intersectObjects(pad.hitMeshes(), false);
+      if (hits.length && (!best || hits[0].distance < best.d)) best = { sid, d: hits[0].distance };
+    }
+    return best ? best.sid : null;
+  }
+
+  select(sid: string) {
+    this.selected = sid;
+    const pad = this.pads.get(sid);
+    if (pad) {
+      this.target.copy(pad.group.position).setY(0.6);
+      this.dist = 10.5;
+      this.pitch = 0.62;
+      this.idleT = 0;
+    }
+  }
+  deselect() {
+    if (this.selected === null) return;
+    this.selected = null;
+    this.frameAll();
+  }
+
+  frameAll() {
+    const occupied = [...this.pads.values()].filter((p) => p.dyingT < 0);
+    const slots = occupied.map((p) => this.slots.get(p.sess.sid) ?? 0);
+    const r = Math.max(6, frameRadius(slots, HEX_SIZE));
+    let cx = 0, cz = 0;
+    for (const p of occupied) { cx += p.group.position.x; cz += p.group.position.z; }
+    const n = Math.max(1, occupied.length);
+    this.target.set(cx / n, 0, cz / n);
+    this.dist = Math.min(70, Math.max(12, (r / Math.tan((this.camera.fov * Math.PI) / 360)) * 0.62));
+    this.pitch = 0.72;
+  }
+
+  // apply one payload's worth of change — called with the model's diff, never per frame
+  sync(sessions: HiveSession[], first: boolean) {
+    const prevSessions = [...this.pads.values()].map((p) => p.sess);
+    const diff = diffSessions(first ? null : prevSessions, sessions);
+    const stored = loadSlots(this.slots);
+    this.slots = assignSlots(stored, sessions.map((s) => s.sid));
+    // persist the present sessions PLUS absent sids' remembered homes (a revived session
+    // returns to its old hex), dropping the memories only if the map outgrows 200 entries
+    const keep = new Map(this.slots);
+    if (stored.size <= 200) for (const [k, v] of stored) if (!keep.has(k) && ![...keep.values()].includes(v)) keep.set(k, v);
+    saveSlots(keep);
+    const bySid = new Map(sessions.map((s) => [s.sid, s] as const));
+    // a session that comes BACK while its pad is mid-departure gets a fresh pad — the dying
+    // one can't be rewound (its death already told the true story of the earlier exit)
+    for (const s of sessions) {
+      const pad = this.pads.get(s.sid);
+      if (pad && pad.dyingT >= 0) {
+        this.scene.remove(pad.group);
+        pad.dispose();
+        this.pads.delete(s.sid);
+        if (!diff.added.includes(s.sid)) diff.added.push(s.sid);
+      }
+    }
+
+    for (const sid of diff.removed) {
+      const pad = this.pads.get(sid);
+      if (pad && pad.dyingT < 0) pad.dyingT = 0;   // departure plays; disposal in the loop
+      if (this.selected === sid) this.deselect();
+      if (this.hovered === sid) this.hovered = null;
+    }
+    for (const sid of diff.added) {
+      const s = bySid.get(sid)!;
+      const pad = new Pad(s, this.slots.get(sid) ?? 0);
+      this.pads.set(sid, pad);
+      this.scene.add(pad.group);
+    }
+    const changed = new Set(diff.stateChanged.map((c) => c.sid));
+    for (const s of sessions) {
+      const pad = this.pads.get(s.sid);
+      if (pad && !diff.added.includes(s.sid)) pad.apply(s, changed.has(s.sid));
+    }
+    for (const sid of diff.goalDone) {
+      const pad = this.pads.get(sid);
+      if (pad) {
+        const at = pad.group.position.clone().setY(PAD_H + 1.1);
+        const tint = new THREE.Color(pad.sess.color?.bg || "#9cd2ff").getHex();
+        this.particles.burst(at, [tint, 0xffffff, ACCENT, 0xffd700], 70, 4.2);
+      }
+    }
+    if (first || diff.added.length || diff.removed.length) {
+      if (this.selected === null) this.frameAll();
+    }
+    this.ensureLoop();
+  }
+
+  private ensureLoop() {
+    const want = this.visible && !document.hidden;
+    if (want && !this.running) {
+      this.running = true;
+      this.lastFrame = performance.now();
+      requestAnimationFrame(this.frame);
+    } else if (!want) {
+      this.running = false;                  // the in-flight rAF sees this and stops
+    }
+  }
+
+  private frame = (now: number) => {
+    if (!this.running) return;
+    const dt = Math.min(0.05, (now - this.lastFrame) / 1000);
+    this.lastFrame = now;
+    this.clock += dt;
+    this.idleT += dt;
+
+    // hover pick once per frame (not per pointermove — cheaper and steadier)
+    const sid = this.pick();
+    if (sid !== this.hovered) {
+      const old = this.hovered ? this.pads.get(this.hovered) : null;
+      if (old) old.lift = 0;
+      this.hovered = sid;
+      const nw = sid ? this.pads.get(sid) : null;
+      if (nw) nw.lift = 0.12;
+      this.renderer.domElement.style.cursor = sid ? "pointer" : "default";
+    }
+
+    // idle drift: after 6s hands-off the whole board breathes on a slow orbital sway
+    const driftYaw = this.idleT > 6 ? Math.sin(this.clock * 0.1) * 0.05 : 0;
+    this.yawCur = ease(this.yawCur, this.yaw + driftYaw, dt, 5);
+    this.pitchCur = ease(this.pitchCur, this.pitch, dt, 5);
+    this.distCur = ease(this.distCur, this.dist, dt, 5);
+    this.targetCur.lerp(this.target, 1 - Math.exp(-5 * dt));
+    this.camera.position.set(
+      this.targetCur.x + this.distCur * Math.cos(this.pitchCur) * Math.sin(this.yawCur),
+      this.targetCur.y + this.distCur * Math.sin(this.pitchCur),
+      this.targetCur.z + this.distCur * Math.cos(this.pitchCur) * Math.cos(this.yawCur),
+    );
+    this.camera.lookAt(this.targetCur);
+
+    const dead: string[] = [];
+    for (const [psid, pad] of this.pads) if (pad.update(dt, this.yawCur)) dead.push(psid);
+    for (const psid of dead) {
+      const pad = this.pads.get(psid)!;
+      this.scene.remove(pad.group);
+      pad.dispose();
+      this.pads.delete(psid);
+    }
+    this.particles.update(dt);
+
+    this.renderer.render(this.scene, this.camera);
+    requestAnimationFrame(this.frame);
+  };
+}
+
+// slot persistence: the board must look the same after a reload — spatial memory is the
+// point of the hex layout. Plain sid→slot map; entries for sids gone from the payload are
+// kept (a revived session returns HOME) until the map grows past 200, then absentees drop.
+const SLOTS_KEY = "romp:hiveSlots";
+function loadSlots(live: Map<string, number>): Map<string, number> {
+  try {
+    const d = JSON.parse(localStorage.getItem(SLOTS_KEY) || "null");
+    const m = new Map<string, number>();
+    if (d && typeof d === "object") for (const k of Object.keys(d)) if (Number.isInteger(d[k])) m.set(k, d[k]);
+    for (const [k, v] of live) m.set(k, v);
+    return m;
+  } catch { return new Map(live); }
+}
+function saveSlots(m: Map<string, number>) {
+  try {
+    const o: Record<string, number> = {};
+    for (const [k, v] of m) o[k] = v;
+    localStorage.setItem(SLOTS_KEY, JSON.stringify(o));
+  } catch { /* private mode etc — the board still works, it just re-deals on reload */ }
+}
+
+// ── boot ─────────────────────────────────────────────────────────────────────────────────
+let world: HiveWorld | null = null;
+let firstPayload = true;
+
+window.addEventListener("message", (e: MessageEvent) => {
+  const m = e.data;
+  if (!m || m.type !== "feed") return;
+  const sessions = buildSessions(m);
+  if (sessions === null) return;             // ledgers not built yet → loader stays up
+  const root = document.getElementById("hive-root");
+  if (!root) return;
+  if (!world) world = new HiveWorld(root);   // first real data: mount → _pane_spin fades
+  world.sync(sessions, firstPayload);
+  firstPayload = false;
+});
+
+vscodeApi?.postMessage({ type: "ready" });   // ask the kernel for the connect-time push
+
+export {};

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -35,6 +35,14 @@ const ST: Record<HiveState, number> = {
 const ACCENT = 0x9cd2ff;
 const PAD_H = 0.06;           // a hair of thickness so a lifted tile isn't paper; the board
                               // reads as ONE flat layer (HEX_SIZE/PAD_R: hive-layout.ts)
+// The nameplate is written flat ON the tile, map-label style, sized to FIT ITS CELL — so a
+// name can geometrically never leave its hex or pile onto a neighbour's (the user
+// 2026-08-13, after the floating billboards stacked into fog). Fit math against the cell:
+// across-flats width √3·HEX_SIZE ≈ 3.55 ≥ LABEL_W_MAX, and the plate's far edge
+// LABEL_FRONT + LABEL_H/2 = 1.12 stays inside the apothem (≈ 1.78).
+const LABEL_W_MAX = 2.7;
+const LABEL_H = 0.4;
+const LABEL_FRONT = 0.92;     // parked in the camera-side half of the cell, clear of the bean
 // Tron world (the user 2026-08-13): near-black glossy ground with a faint accent grid, the
 // pads dark slabs whose STATUS light is their glowing rim, bloom doing the neon work. The
 // beans stay cute (session-colored, softly self-lit) with dark visors and glowing eyes.
@@ -66,8 +74,8 @@ class Pad {
   private ringMat: THREE.LineBasicMaterial;
   private sonar: THREE.LineLoop;
   private sonarMat: THREE.LineBasicMaterial;
-  private label: THREE.Sprite;
-  private labelW = 1; private labelH = 1;   // base sprite size; update() re-scales by camera distance
+  private labelYaw = new THREE.Group();     // yaws to face the camera; the nameplate rides its +z
+  private labelMesh: THREE.Mesh;
   private bang: THREE.Sprite;              // the ❗ that bobs over a needs-you pad
   private guy: Dweller;
   private baseY = 0;
@@ -124,13 +132,14 @@ class Pad {
     this.sonar.position.y = this.ring.position.y;
     this.group.add(this.sonar);
 
-    this.label = makeTextSprite(sess.name, sess.color?.bg || "#cccccc");
-    this.labelW = this.label.scale.x; this.labelH = this.label.scale.y;
-    this.label.position.y = 2.7;
-    this.group.add(this.label);
+    this.labelMesh = makeNameDecal(sess.name, sess.sid, sess.color?.bg || "#cccccc");
+    this.labelMesh.position.z = LABEL_FRONT;
+    this.labelYaw.position.y = PAD_H + 0.02;
+    this.labelYaw.add(this.labelMesh);
+    this.group.add(this.labelYaw);
 
     this.bang = makeTextSprite("!", "#ffffff", "#c0392b");
-    this.bang.position.y = 2.05;             // between head and label, kissing neither
+    this.bang.position.y = 2.05;             // floats over the bean — the one deliberate float
     this.bang.visible = false;
     this.group.add(this.bang);
 
@@ -153,24 +162,24 @@ class Pad {
       this.guy.setState(sess.state, sess.faded);
     }
     if (sess.name !== prevName || sess.color?.bg !== prevColor) {
-      this.group.remove(this.label);
-      disposeSprite(this.label);
-      this.label = makeTextSprite(sess.name, sess.color?.bg || "#cccccc");
-      this.labelW = this.label.scale.x; this.labelH = this.label.scale.y;
-      this.label.position.y = 2.7;
-      this.group.add(this.label);
+      this.labelYaw.remove(this.labelMesh);
+      disposeDecal(this.labelMesh);
+      this.labelMesh = makeNameDecal(sess.name, sess.sid, sess.color?.bg || "#cccccc");
+      this.labelMesh.position.z = LABEL_FRONT;
+      this.labelYaw.add(this.labelMesh);
     }
   }
 
   hitMeshes(): THREE.Object3D[] { return [this.padMesh]; }
 
-  update(dt: number, camYaw: number, camDist: number): boolean {
+  update(dt: number, camYaw: number, camDist: number, focus: boolean): boolean {
     this.t += dt;
-    // RTS labels: scale with camera distance so the name reads the SAME size from orbit
-    // and from a fly-in — spatial UI, constant legibility
-    const ls = Math.min(2.4, Math.max(0.85, camDist / 13));
-    this.label.scale.set(this.labelW * ls, this.labelH * ls, 1);
-    this.label.position.y = 2.45 + 0.5 * ls;
+    // map-label behavior: the plate faces the camera in yaw and FADES with altitude —
+    // zoomed out, the board is shapes and colors; zoom in (or hover/select) to read names.
+    // Never scaled up: an inflated label is how the old billboards piled into fog.
+    this.labelYaw.rotation.y = camYaw;
+    const lmat = this.labelMesh.material as THREE.MeshBasicMaterial;
+    lmat.opacity = ease(lmat.opacity, focus ? 1 : Math.min(1, Math.max(0, (42 - camDist) / 12)), dt, 10);
     if (this.spawnT < 1) {
       this.spawnT = Math.min(1, this.spawnT + dt / 0.5);
       const s = this.spawnT;
@@ -498,6 +507,62 @@ function makeTextSprite(text: string, color: string, bubble?: string): THREE.Spr
   return sp;
 }
 function disposeSprite(s: THREE.Sprite) { s.material.map?.dispose(); s.material.dispose(); }
+
+// A cell's nameplate: written flat ON the tile, map-label style (how Civ-like grids and map
+// engines keep names from piling up — a label that belongs to its cell can never leave it).
+// Crisp and glow-free: two-tone like every other surface (quiet "host:" prefix + identity
+// color), the color dimmed to sit UNDER the bloom threshold so text never fuzzes. Long
+// names ellipsize to the cell's width. The caller yaws it to the camera and fades it by
+// zoom (Pad.update) — a map fades labels out at altitude, it never inflates them.
+function makeNameDecal(name: string, sid: string, color: string): THREE.Mesh {
+  const p = hostPrefix(name, sid);
+  const host = p ? p.host : "";
+  let rest = p ? p.rest : name;
+  const c = document.createElement("canvas");
+  const g = c.getContext("2d")!;
+  const F = 46;
+  const hostFont = `italic 400 ${Math.round(F * 0.88)}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
+  const nameFont = `600 ${F}px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`;
+  const px = (s: string, f: string) => { g.font = f; return g.measureText(s).width; };
+  const budget = (LABEL_W_MAX / LABEL_H) * (F * 1.35) - 24;   // px that fit at the fixed world height
+  const hostPx = host ? px(host, hostFont) : 0;
+  let cut = false;
+  while (rest.length > 2 && hostPx + px(rest, nameFont) + (cut ? px("…", nameFont) : 0) > budget) {
+    rest = rest.slice(0, -1);
+    cut = true;
+  }
+  if (cut) rest += "…";
+  c.width = Math.ceil(hostPx + px(rest, nameFont)) + 24;
+  c.height = Math.round(F * 1.35);
+  const g2 = c.getContext("2d")!;                 // resizing reset the context state above
+  g2.textBaseline = "middle";
+  const dim = new THREE.Color(color || "#cccccc").multiplyScalar(0.82);
+  let x = 12;
+  if (host) {
+    g2.font = hostFont;
+    g2.fillStyle = "#8a8a8a";
+    g2.fillText(host, x, c.height / 2);
+    x += hostPx;
+  }
+  g2.font = nameFont;
+  g2.fillStyle = "#" + dim.getHexString();
+  g2.fillText(rest, x, c.height / 2);
+  const tex = new THREE.CanvasTexture(c);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.anisotropy = 8;                             // flat text at a glancing pitch smears without it
+  const mesh = new THREE.Mesh(
+    new THREE.PlaneGeometry(LABEL_H * (c.width / c.height), LABEL_H),
+    new THREE.MeshBasicMaterial({ map: tex, transparent: true, opacity: 0, depthWrite: false }),
+  );
+  mesh.rotation.x = -Math.PI / 2;                 // lie flat; text-top points away from the viewer
+  return mesh;
+}
+function disposeDecal(m: THREE.Mesh) {
+  m.geometry.dispose();
+  const mat = m.material as THREE.MeshBasicMaterial;
+  mat.map?.dispose();
+  mat.dispose();
+}
 
 // ── confetti / puffs: one pooled particle system for every burst ─────────────────────────
 class Particles {
@@ -1206,7 +1271,8 @@ class HiveWorld {
       }
     }
     const dead: string[] = [];
-    for (const [psid, pad] of this.pads) if (pad.update(dt, this.yawCur, this.distCur)) dead.push(psid);
+    for (const [psid, pad] of this.pads)
+      if (pad.update(dt, this.yawCur, this.distCur, psid === this.hovered || psid === this.selected)) dead.push(psid);
     for (const psid of dead) {
       const pad = this.pads.get(psid)!;
       this.scene.remove(pad.group);

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -7,7 +7,10 @@
 // Status colors keep their standing meanings (styles.css --st-*); the romp accent #9cd2ff
 // is reserved for selection/hover chrome. All geometry is procedural — no runtime assets.
 import * as THREE from "three";
-import { assignSlots, axialToXZ, frameRadius, spiralSlot } from "./hive-layout";
+import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
+import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
+import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
+import { assignSlots, axialToXZ, frameDt, frameRadius, spiralSlot } from "./hive-layout";
 import { buildSessions, diffSessions, HiveSession, HiveState } from "./hive-model";
 
 const vscodeApi =
@@ -31,6 +34,10 @@ const ACCENT = 0x9cd2ff;
 const HEX_SIZE = 2.05;        // axial size: neighbour centers sit √3·size apart
 const PAD_R = 1.62;           // pad circumradius (< √3/2·size, so pads never touch)
 const PAD_H = 0.42;
+// Tron world (the user 2026-08-13): near-black glossy ground with a faint accent grid, the
+// pads dark slabs whose STATUS light is their glowing rim, bloom doing the neon work. The
+// beans stay cute (session-colored, softly self-lit) with dark visors and glowing eyes.
+const WORLD_BG = 0x090b10;
 
 // exponential smoothing toward a target — frame-rate independent; `rate`/s is the snap speed
 function ease(cur: number, target: number, dt: number, rate: number): number {
@@ -43,9 +50,12 @@ class Pad {
   private padMesh: THREE.Mesh;
   private ring: THREE.Mesh;
   private ringMat: THREE.MeshBasicMaterial;
+  private halo!: THREE.Mesh;
+  private haloMat!: THREE.MeshBasicMaterial;
   private sonar: THREE.Mesh;
   private sonarMat: THREE.MeshBasicMaterial;
   private label: THREE.Sprite;
+  private labelW = 1; private labelH = 1;   // base sprite size; update() re-scales by camera distance
   private bang: THREE.Sprite;              // the ❗ that bobs over a needs-you pad
   private guy: Dweller;
   private baseY = 0;
@@ -64,38 +74,55 @@ class Pad {
     this.group.position.set(x, 0, z);
 
     const tint = new THREE.Color(sess.color?.bg || "#8a8a8a");
-    const top = new THREE.Color(0x2f3136).lerp(tint, 0.22);
-    const side = new THREE.Color(0x232427).lerp(tint, 0.10);
-    // CylinderGeometry with 6 radial segments IS the hex prism; thetaStart π/6 turns an
-    // edge (not a corner) toward each axial neighbour so the honeycomb reads as tiling.
-    const geo = new THREE.CylinderGeometry(PAD_R, PAD_R * 1.06, PAD_H, 6, 1, false, Math.PI / 6);
+    // Tron slab: near-black glossy top with only a whisper of the identity color; the
+    // pad's LIGHT is its rim. CylinderGeometry with 6 radial segments IS the hex prism;
+    // thetaStart π/6 turns an edge (not a corner) toward each axial neighbour.
+    const top = new THREE.Color(0x0e1116).lerp(tint, 0.06);
+    const side = new THREE.Color(0x080a0d).lerp(tint, 0.03);
+    const geo = new THREE.CylinderGeometry(PAD_R, PAD_R * 1.04, PAD_H, 6, 1, false, Math.PI / 6);
     this.padMesh = new THREE.Mesh(geo, [
-      new THREE.MeshStandardMaterial({ color: side, roughness: 0.9, metalness: 0 }),
-      new THREE.MeshStandardMaterial({ color: top, roughness: 0.82, metalness: 0 }),
-      new THREE.MeshStandardMaterial({ color: side, roughness: 0.9, metalness: 0 }),
+      new THREE.MeshStandardMaterial({ color: side, roughness: 0.55, metalness: 0.35 }),
+      new THREE.MeshStandardMaterial({ color: top, roughness: 0.3, metalness: 0.45 }),
+      new THREE.MeshStandardMaterial({ color: side, roughness: 0.55, metalness: 0.35 }),
     ]);
     this.padMesh.position.y = PAD_H / 2;
     this.group.add(this.padMesh);
 
-    // status ring: a hex annulus laid flat on the pad top. thetaStart -π/3 lines its corners
-    // up with the cylinder's (thetaStart π/6) once RingGeometry's XY maps into XZ below —
-    // the two parametrise their angles from different axes.
-    this.ringMat = new THREE.MeshBasicMaterial({ color: ST[sess.state], transparent: true, opacity: 0.9 });
-    const ringGeo = new THREE.RingGeometry(PAD_R * 0.74, PAD_R * 0.82, 6, 1, -Math.PI / 3);
+    // the status LIGHT: a glowing hex rim hugging the top edge (additive, bloom-fed).
+    // RingGeometry thetaStart -π/3 lines its corners up with the cylinder's π/6 once its
+    // XY maps into XZ below — the two parametrise their angles from different axes.
+    this.ringMat = new THREE.MeshBasicMaterial({
+      color: ST[sess.state], transparent: true, opacity: 0.95,
+      blending: THREE.AdditiveBlending, depthWrite: false,
+    });
+    const ringGeo = new THREE.RingGeometry(PAD_R * 0.9, PAD_R * 0.985, 6, 1, -Math.PI / 3);
     this.ring = new THREE.Mesh(ringGeo, this.ringMat);
     this.ring.rotation.x = -Math.PI / 2;
-    this.ring.position.y = PAD_H + 0.015;
+    this.ring.position.y = PAD_H + 0.012;
     this.group.add(this.ring);
+    // …and its soft halo: a wider, fainter copy that sells the glow even before bloom
+    this.haloMat = new THREE.MeshBasicMaterial({
+      color: ST[sess.state], transparent: true, opacity: 0.22,
+      blending: THREE.AdditiveBlending, depthWrite: false, side: THREE.DoubleSide,
+    });
+    this.halo = new THREE.Mesh(new THREE.RingGeometry(PAD_R * 0.86, PAD_R * 1.12, 6, 1, -Math.PI / 3), this.haloMat);
+    this.halo.rotation.x = -Math.PI / 2;
+    this.halo.position.y = PAD_H + 0.006;
+    this.group.add(this.halo);
 
     // sonar ping: an expanding, fading copy — the needs-you beacon (awaiting only)
-    this.sonarMat = new THREE.MeshBasicMaterial({ color: ST.awaiting, transparent: true, opacity: 0, side: THREE.DoubleSide });
-    this.sonar = new THREE.Mesh(new THREE.RingGeometry(PAD_R * 0.78, 0.045 + PAD_R * 0.78, 6, 1, -Math.PI / 3), this.sonarMat);
+    this.sonarMat = new THREE.MeshBasicMaterial({
+      color: ST.awaiting, transparent: true, opacity: 0,
+      blending: THREE.AdditiveBlending, depthWrite: false, side: THREE.DoubleSide,
+    });
+    this.sonar = new THREE.Mesh(new THREE.RingGeometry(PAD_R * 0.93, 0.05 + PAD_R * 0.93, 6, 1, -Math.PI / 3), this.sonarMat);
     this.sonar.rotation.copy(this.ring.rotation);
     this.sonar.position.y = this.ring.position.y;
     this.group.add(this.sonar);
 
     this.label = makeTextSprite(sess.name, sess.color?.bg || "#cccccc");
-    this.label.position.y = 3.1;
+    this.labelW = this.label.scale.x; this.labelH = this.label.scale.y;
+    this.label.position.y = 2.7;
     this.group.add(this.label);
 
     this.bang = makeTextSprite("!", "#ffffff", "#c0392b");
@@ -125,15 +152,21 @@ class Pad {
       this.group.remove(this.label);
       disposeSprite(this.label);
       this.label = makeTextSprite(sess.name, sess.color?.bg || "#cccccc");
-      this.label.position.y = 3.1;
+      this.labelW = this.label.scale.x; this.labelH = this.label.scale.y;
+      this.label.position.y = 2.7;
       this.group.add(this.label);
     }
   }
 
   hitMeshes(): THREE.Object3D[] { return [this.padMesh]; }
 
-  update(dt: number, camYaw: number): boolean {
+  update(dt: number, camYaw: number, camDist: number): boolean {
     this.t += dt;
+    // RTS labels: scale with camera distance so the name reads the SAME size from orbit
+    // and from a fly-in — spatial UI, constant legibility
+    const ls = Math.min(2.4, Math.max(0.85, camDist / 13));
+    this.label.scale.set(this.labelW * ls, this.labelH * ls, 1);
+    this.label.position.y = 2.45 + 0.5 * ls;
     if (this.spawnT < 1) {
       this.spawnT = Math.min(1, this.spawnT + dt / 0.5);
       const s = this.spawnT;
@@ -154,12 +187,14 @@ class Pad {
 
     this.ringColor.lerp(this.ringTarget, 1 - Math.exp(-8 * dt));
     this.ringMat.color.copy(this.ringColor);
+    this.haloMat.color.copy(this.ringColor);
     const st = this.sess.state;
     // pulse only the states that are genuinely in motion; steady states hold steady
     if (st === "working") this.ringMat.opacity = 0.62 + 0.3 * (0.5 + 0.5 * Math.sin(this.t * 3.6));
     else if (st === "awaiting") this.ringMat.opacity = 0.55 + 0.45 * (0.5 + 0.5 * Math.sin(this.t * 7));
     else if (st === "retrying") this.ringMat.opacity = 0.5 + 0.5 * (Math.sin(this.t * 11) > 0.2 ? 1 : 0.35);
-    else this.ringMat.opacity = 0.85;
+    else this.ringMat.opacity = 0.95;
+    this.haloMat.opacity = this.ringMat.opacity * 0.24;
 
     if (st === "awaiting") {
       // sonar ping: 1.4s loop, ring swells to ~1.8× and fades — visible from any zoom
@@ -186,15 +221,22 @@ class Pad {
   }
 }
 
-// ── the little guy (v1 rig: capsule + eyes, per-state posture/motion; deeper costumes and
-//    props land with the character pass — plans/hive.md "State → performance") ────────────
+// ── the bean (the user 2026-08-13: cute and blobby, Fall Guys / PEAK — not angular
+//    fantasy). A lathe-profile bean in the session's identity color, cream face plate with
+//    big dot eyes, stubby nub arms, squash-and-stretch on every landing. The TORSO group
+//    pivots at the feet so leans read as body language, not sliding. ────────────────────────
 class Dweller {
   group = new THREE.Group();
+  private torso = new THREE.Group();        // feet-pivot: body + face + arms live here
   private body: THREE.Mesh;
   private bodyMat: THREE.MeshStandardMaterial;
-  private eyeL: THREE.Group; private eyeR: THREE.Group;
+  private face: THREE.Mesh;
+  private eyeL: THREE.Mesh; private eyeR: THREE.Mesh;
+  private armL: THREE.Mesh; private armR: THREE.Mesh;
   private aura: THREE.Mesh;                 // compacting swirl / awaitingBg marker, recolored per state
   private auraMat: THREE.MeshBasicMaterial;
+  private desk: THREE.Group;                // tiny desk + glowing laptop — the "working" silhouette
+  private screenMat: THREE.MeshStandardMaterial;
   private state: HiveState = "ready";
   private faded = false;
   private blinkAt = 2 + Math.random() * 4;
@@ -202,30 +244,92 @@ class Dweller {
   private phase = Math.random() * Math.PI * 2;
   private baseColor: THREE.Color;
   private pop = 0;                          // hatch flourish clock (opening → live)
+  private squash = 1;                       // landing squash factor, springs back to 1
+  private prevY = 0;
 
   constructor(tint: string) {
-    this.baseColor = new THREE.Color(tint).lerp(new THREE.Color(0xffffff), 0.12);
-    this.bodyMat = new THREE.MeshStandardMaterial({ color: this.baseColor.clone(), roughness: 0.6 });
-    this.body = new THREE.Mesh(new THREE.CapsuleGeometry(0.34, 0.42, 6, 14), this.bodyMat);
-    this.body.position.y = 0.56;
-    this.group.add(this.body);
-    const mkEye = () => {
-      const g = new THREE.Group();
-      const white = new THREE.Mesh(new THREE.SphereGeometry(0.085, 10, 10), new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.35 }));
-      const pupil = new THREE.Mesh(new THREE.SphereGeometry(0.038, 8, 8), new THREE.MeshStandardMaterial({ color: 0x1a1a1a, roughness: 0.3 }));
-      pupil.position.z = 0.062;
-      g.add(white, pupil);
-      return g;
-    };
+    this.baseColor = new THREE.Color(tint).lerp(new THREE.Color(0xffffff), 0.1);
+    // the suit self-lights a little (Tron creature), so beans stay cute against the dark
+    this.bodyMat = new THREE.MeshStandardMaterial({
+      color: this.baseColor.clone(), roughness: 0.45, metalness: 0.1,
+      emissive: this.baseColor.clone(), emissiveIntensity: 0.22,
+    });
+    // the bean silhouette: chubby low waist, rounded shoulders, narrow rounded crown
+    const prof: [number, number][] = [
+      [0.001, 0], [0.30, 0.03], [0.42, 0.14], [0.475, 0.32], [0.48, 0.52],
+      [0.44, 0.72], [0.375, 0.90], [0.29, 1.04], [0.18, 1.13], [0.001, 1.17],
+    ];
+    this.body = new THREE.Mesh(
+      new THREE.LatheGeometry(prof.map(([r, y]) => new THREE.Vector2(r, y)), 26),
+      this.bodyMat,
+    );
+    this.torso.add(this.body);
+    // dark glossy visor sunk into the front (the Fall Guys face zone, program-grade),
+    // with two GLOWING eyes inside it — bloom turns them into the character's light
+    this.face = new THREE.Mesh(
+      new THREE.SphereGeometry(0.27, 18, 14),
+      new THREE.MeshStandardMaterial({ color: 0x0b0d12, roughness: 0.15, metalness: 0.6 }),
+    );
+    this.face.scale.set(1, 1.28, 0.45);
+    this.face.position.set(0, 0.78, 0.29);
+    this.torso.add(this.face);
+    const mkEye = () => new THREE.Mesh(
+      new THREE.SphereGeometry(0.05, 10, 10),
+      new THREE.MeshBasicMaterial({ color: 0xdff1ff }),
+    );
     this.eyeL = mkEye(); this.eyeR = mkEye();
-    this.eyeL.position.set(-0.125, 0.78, 0.28);
-    this.eyeR.position.set(0.125, 0.78, 0.28);
-    this.group.add(this.eyeL, this.eyeR);
+    this.eyeL.position.set(-0.095, 0.83, 0.405);
+    this.eyeR.position.set(0.095, 0.83, 0.405);
+    this.torso.add(this.eyeL, this.eyeR);
+    const armGeo = new THREE.CapsuleGeometry(0.085, 0.2, 4, 10);
+    armGeo.translate(0, -0.12, 0);          // hang from the shoulder joint, so rotation swings
+    this.armL = new THREE.Mesh(armGeo, this.bodyMat);
+    this.armR = new THREE.Mesh(armGeo, this.bodyMat);
+    this.armL.position.set(-0.44, 0.72, 0.05);
+    this.armR.position.set(0.44, 0.72, 0.05);
+    this.armL.rotation.z = 0.35; this.armR.rotation.z = -0.35;
+    this.torso.add(this.armL, this.armR);
+    this.group.add(this.torso);
+
     this.auraMat = new THREE.MeshBasicMaterial({ color: ST.compacting, transparent: true, opacity: 0 });
-    this.aura = new THREE.Mesh(new THREE.TorusGeometry(0.52, 0.035, 6, 24), this.auraMat);
-    this.aura.position.y = 0.62;
+    this.aura = new THREE.Mesh(new THREE.TorusGeometry(0.58, 0.035, 6, 24), this.auraMat);
+    this.aura.position.y = 0.66;
     this.aura.rotation.x = Math.PI / 2.4;
     this.group.add(this.aura);
+
+    // the desk: tabletop + laptop with an emissive screen, parked in front of the bean;
+    // shown only while working (the strongest one-glance "busy" silhouette there is)
+    this.desk = new THREE.Group();
+    const slab = new THREE.MeshStandardMaterial({ color: 0x141920, roughness: 0.35, metalness: 0.5 });
+    const top = new THREE.Mesh(new THREE.BoxGeometry(0.78, 0.05, 0.42), slab);
+    top.position.y = 0.5;
+    this.desk.add(top);
+    // a hairline of accent light along the desk's front edge — the Tron detail line
+    const edge = new THREE.Mesh(
+      new THREE.BoxGeometry(0.78, 0.012, 0.012),
+      new THREE.MeshBasicMaterial({ color: ACCENT, transparent: true, opacity: 0.8, blending: THREE.AdditiveBlending, depthWrite: false }),
+    );
+    edge.position.set(0, 0.527, 0.21);
+    this.desk.add(edge);
+    for (const [lx, lz] of [[-0.34, -0.16], [0.34, -0.16], [-0.34, 0.16], [0.34, 0.16]]) {
+      const leg = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.5, 0.05), slab);
+      leg.position.set(lx, 0.25, lz);
+      this.desk.add(leg);
+    }
+    const shell = new THREE.MeshStandardMaterial({ color: 0x3a3d42, roughness: 0.4, metalness: 0.3 });
+    const base = new THREE.Mesh(new THREE.BoxGeometry(0.34, 0.02, 0.24), shell);
+    base.position.set(0, 0.535, 0.02);
+    this.screenMat = new THREE.MeshStandardMaterial({
+      color: 0x10151c, roughness: 0.3, emissive: 0x9fd8ff, emissiveIntensity: 0.9,
+    });
+    const screen = new THREE.Mesh(new THREE.BoxGeometry(0.34, 0.24, 0.015), this.screenMat);
+    screen.position.set(0, 0.65, 0.13);
+    screen.rotation.x = -0.22;
+    this.desk.add(base, screen);
+    this.desk.position.set(0, 0, 0.58);
+    this.desk.rotation.y = Math.PI;         // screen faces the bean
+    this.desk.visible = false;
+    this.group.add(this.desk);
   }
 
   setState(s: HiveState, faded: boolean) {
@@ -233,6 +337,7 @@ class Dweller {
       this.pop = 0.45;                       // hatched! — one pop, then normal life
       this.bodyMat.color.copy(this.baseColor);
     }
+    if (s !== this.state) this.squash = 1.18;   // every real transition lands with a squash beat
     this.state = s; this.faded = faded;
   }
 
@@ -244,66 +349,102 @@ class Dweller {
       if (this.blinkAt <= 0) { this.blinkT = 0.12; this.blinkAt = 3 + Math.random() * 4; }
       if (this.blinkT > 0) this.blinkT -= dt;
       const bl = this.blinkT > 0 ? 0.12 : 1;
-      this.eyeL.scale.y = bl; this.eyeR.scale.y = bl;
-    }
-    const breathe = 1 + 0.02 * Math.sin(t * 2.1 + this.phase);
-    this.body.scale.set(1, breathe, 1);
-    if (this.pop > 0) {
-      this.pop = Math.max(0, this.pop - dt);
-      const p = this.pop / 0.45;             // 1→0: a quick overshoot pulse on the whole body
-      this.body.scale.multiplyScalar(1 + 0.3 * Math.sin(p * Math.PI));
+      this.eyeL.scale.set(1, bl, 1); this.eyeR.scale.set(1, bl, 1);
     }
 
     let y = 0, rotX = 0, rotZ = 0, yaw = 0, sx = 0;
-    let aura = 0;
+    let aura = 0, desk = false;
+    // resting arm pose; states override
+    let armLZ = 0.35, armRZ = -0.35, armLX = 0, armRX = 0;
     switch (s) {
       case "working": {
-        // typing bursts: bob fast for ~1.4s, rest ~0.8s — the rhythm reads as real keys
+        desk = true;
+        rotX = 0.1;
+        this.bodyMat.emissiveIntensity = 0.3;   // the screen lights the bean up a touch
+        // hands over the keys, tapping in bursts; the screen glow flickers with the keys
         const burst = Math.sin(t * 2.8 + this.phase) > -0.35;
-        rotX = 0.14;
-        y = burst ? 0.02 * Math.abs(Math.sin(t * 11)) : 0;
+        armLX = -1.15 + (burst ? 0.18 * Math.sin(t * 13) : 0);
+        armRX = -1.15 + (burst ? 0.18 * Math.sin(t * 13 + Math.PI) : 0);
+        armLZ = 0.12; armRZ = -0.12;
+        this.screenMat.emissiveIntensity = 0.75 + (burst ? 0.3 * Math.abs(Math.sin(t * 9)) : 0.1);
         break;
       }
-      case "awaiting":                       // they need YOU: face the camera and wave
+      case "awaiting": {                     // they need YOU: face the camera, big both-arms wave
         yaw = camYaw;
-        y = 0.2 * Math.abs(Math.sin(t * 4.6));
-        rotZ = 0.14 * Math.sin(t * 6.5);
+        y = 0.22 * Math.abs(Math.sin(t * 4.6));
+        armLZ = 2.5 + 0.4 * Math.sin(t * 9);
+        armRZ = -2.5 - 0.4 * Math.sin(t * 9 + 1);
         break;
+      }
       case "blocked":
-        rotZ = 0.42; y = -0.04; rotX = 0.1;  // slumped against the wreckage
+        rotX = 0.55; y = -0.05;              // folded forward over the wreck, arms hanging dead
+        armLZ = 0.05; armRZ = -0.05; armLX = -0.4; armRX = -0.4;
         break;
       case "retrying":
-        sx = 0.34 * Math.sin(t * 1.6);       // pacing the pad
+        sx = 0.34 * Math.sin(t * 1.6);       // pacing the pad, arms swinging with the waddle
         yaw = Math.cos(t * 1.6) > 0 ? Math.PI / 2 : -Math.PI / 2;
+        rotZ = 0.08 * Math.sin(t * 7);
+        armLX = 0.5 * Math.sin(t * 7); armRX = -0.5 * Math.sin(t * 7);
         break;
       case "awaitingBg":
-        rotX = -0.12;                        // leaning back, watching its dispatched work
+        rotX = -0.14;                        // leaning back, watching its dispatched work spin
+        armLZ = 0.9; armRZ = -0.9;
         aura = 0.4; this.auraMat.color.setHex(ST.awaitingBg);
         this.aura.rotation.z = t * 0.9;
         break;
       case "compacting": case "clearing":
-        y = 0.16 + 0.05 * Math.sin(t * 2.4); // levitating meditation, teal swirl orbiting
+        y = 0.18 + 0.05 * Math.sin(t * 2.4); // levitating meditation, teal swirl orbiting
         yaw = t * 0.8;
+        armLZ = 1.5; armRZ = -1.5;           // arms out, zen
         aura = 0.75; this.auraMat.color.setHex(ST.compacting);
         this.aura.rotation.z = t * 2.2;
         break;
       case "interrupting":
-        this.body.scale.y = 0.85;            // freeze-frame squash; no motion at all
+        this.squash = Math.max(this.squash, 1.12);   // freeze-frame squash; no motion at all
         break;
       case "opening":
-        // the egg: eyes hidden, whole body wobbling toward the hatch
+        // the egg: eyes hidden, face hidden, wobbling toward the hatch
         this.eyeL.scale.setScalar(0.001); this.eyeR.scale.setScalar(0.001);
+        this.face.visible = false; this.armL.visible = false; this.armR.visible = false;
         this.bodyMat.color.lerp(new THREE.Color(0xf2ead9), 0.2);
         rotZ = 0.09 * Math.sin(t * 9);
         break;
       default:                               // ready
-        if (this.faded) { rotX = -0.3; y = -0.06; }   // dozing off after an hour idle
-        else rotZ = 0.03 * Math.sin(t * 1.3 + this.phase);
+        if (this.faded) { rotX = -0.32; y = -0.06; armLZ = 0.1; armRZ = -0.1; }   // dozing
+        else {
+          rotZ = 0.03 * Math.sin(t * 1.3 + this.phase);
+          armLZ = 0.35 + 0.06 * Math.sin(t * 1.3 + this.phase);
+          armRZ = -0.35 - 0.06 * Math.sin(t * 1.3 + this.phase);
+        }
     }
-    if (s !== "opening") { this.eyeL.scale.x = 1; this.eyeR.scale.x = 1; this.eyeL.scale.z = 1; this.eyeR.scale.z = 1; }
+    if (s !== "opening") { this.face.visible = true; this.armL.visible = true; this.armR.visible = true; }
+    if (s !== "working") this.bodyMat.emissiveIntensity = 0.22;
+    this.desk.visible = desk;
+
+    // squash & stretch: landings compress the bean, air time stretches it — scale about the
+    // feet (the lathe sits on y=0, so plain scale already pivots there), volume-ish preserved
+    const vy = (y - this.prevY) / Math.max(dt, 1e-4);
+    this.prevY = y;
+    if (y < 0.02 && vy < -0.6) this.squash = Math.max(this.squash, 1.22);
+    this.squash = ease(this.squash, 1, dt, 9);
+    const airStretch = Math.min(0.12, Math.max(0, vy * 0.03));
+    const syn = (1 / this.squash) + airStretch;
+    const breathe = 1 + 0.018 * Math.sin(t * 2.1 + this.phase);
+    let bs = syn * breathe;
+    if (this.pop > 0) {
+      this.pop = Math.max(0, this.pop - dt);
+      const p = this.pop / 0.45;             // 1→0: a quick overshoot pulse on the whole body
+      bs *= 1 + 0.3 * Math.sin(p * Math.PI);
+    }
+    this.torso.scale.set(this.squash * (2 - breathe), bs, this.squash * (2 - breathe));
+
+    this.armL.rotation.set(armLX, 0, armLZ);
+    this.armR.rotation.set(armRX, 0, armRZ);
     this.group.position.x = sx;
     this.group.position.y = PAD_H + y;
-    this.group.rotation.set(rotX, yaw, rotZ);
+    this.group.rotation.y = yaw;
+    this.torso.rotation.x = rotX;
+    this.torso.rotation.z = rotZ;
     this.auraMat.opacity = ease(this.auraMat.opacity, aura, dt, 6);
   }
 }
@@ -329,17 +470,41 @@ function makeTextSprite(text: string, color: string, bubble?: string): THREE.Spr
     ctx2.moveTo(cw / 2, ch - 2); ctx2.lineTo(cw / 2 - 12, ch - 22); ctx2.lineTo(cw / 2 + 12, ch - 22);
     ctx2.fill();
   } else {
-    ctx2.shadowColor = "rgba(0,0,0,0.85)"; ctx2.shadowBlur = 8;
+    ctx2.shadowColor = color; ctx2.shadowBlur = 14;   // the name IS a neon sign — its own glow
   }
   ctx2.fillStyle = color;
   ctx2.fillText(text, c.width / 2, bubble ? 40 : c.height / 2, c.width - 16);
+  if (!bubble) ctx2.fillText(text, c.width / 2, c.height / 2, c.width - 16);   // double-strike brightens the core over the glow
   const tex = new THREE.CanvasTexture(c);
   tex.colorSpace = THREE.SRGBColorSpace;
   const sp = new THREE.Sprite(new THREE.SpriteMaterial({ map: tex, transparent: true, depthWrite: false }));
-  sp.scale.set(c.width / 110, c.height / 110, 1);
+  sp.scale.set(c.width / 72, c.height / 72, 1);   // readable from the overview orbit
   return sp;
 }
 function disposeSprite(s: THREE.Sprite) { s.material.map?.dispose(); s.material.dispose(); }
+
+// the floor grid tile: one accent line pair per edge, a brighter major every 4th repeat is
+// faked by drawing the major into the same tile at quarter opacity steps — cheap, seamless
+function makeGridTexture(): THREE.CanvasTexture {
+  const c = document.createElement("canvas");
+  c.width = 256; c.height = 256;
+  const g = c.getContext("2d")!;
+  g.clearRect(0, 0, 256, 256);
+  g.strokeStyle = "rgba(156,210,255,0.30)";
+  g.lineWidth = 2;
+  g.strokeRect(0.5, 0.5, 256, 256);
+  g.strokeStyle = "rgba(156,210,255,0.10)";
+  g.lineWidth = 1;
+  for (const q of [64, 128, 192]) {
+    g.beginPath(); g.moveTo(q, 0); g.lineTo(q, 256); g.stroke();
+    g.beginPath(); g.moveTo(0, q); g.lineTo(256, q); g.stroke();
+  }
+  const tex = new THREE.CanvasTexture(c);
+  tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+  tex.repeat.set(42, 42);                    // 300-unit plane → ~7.1-unit majors, pad-scaled
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
 
 // ── confetti / puffs: one pooled particle system for every burst ─────────────────────────
 class Particles {
@@ -357,6 +522,7 @@ class Particles {
     this.geo.setAttribute("color", new THREE.BufferAttribute(this.col, 3));
     this.points = new THREE.Points(this.geo, new THREE.PointsMaterial({
       size: 0.14, vertexColors: true, transparent: true, opacity: 0.95, depthWrite: false,
+      blending: THREE.AdditiveBlending,      // sparks of light, not paper — they bloom
     }));
     this.points.frustumCulled = false;
     this.geo.setDrawRange(0, 0);
@@ -365,7 +531,12 @@ class Particles {
   burst(at: THREE.Vector3, colors: number[], count: number, speed: number) {
     for (let i = 0; i < count && this.n < this.max; i++, this.n++) {
       const j = this.n * 3;
-      this.pos[j] = at.x; this.pos[j + 1] = at.y; this.pos[j + 2] = at.z;
+      // born spread over a small shell, not one point — a point of 50 additive sprites
+      // reads as a white flashbulb on frame one, a shell reads as a firework
+      const sh = 0.28;
+      this.pos[j] = at.x + (Math.random() - 0.5) * sh * 2;
+      this.pos[j + 1] = at.y + (Math.random() - 0.5) * sh;
+      this.pos[j + 2] = at.z + (Math.random() - 0.5) * sh * 2;
       const th = Math.random() * Math.PI * 2, up = 0.5 + Math.random() * 0.9;
       this.vel[j] = Math.cos(th) * speed * (0.4 + Math.random() * 0.6);
       this.vel[j + 1] = up * speed;
@@ -403,6 +574,8 @@ class Particles {
 // ── the world ────────────────────────────────────────────────────────────────────────────
 class HiveWorld {
   private renderer: THREE.WebGLRenderer;
+  private composer!: EffectComposer;
+  private bloom!: UnrealBloomPass;
   private scene = new THREE.Scene();
   private camera: THREE.PerspectiveCamera;
   private pads = new Map<string, Pad>();
@@ -428,19 +601,49 @@ class HiveWorld {
   constructor(private root: HTMLElement) {
     this.renderer = new THREE.WebGLRenderer({ antialias: true });
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
-    this.renderer.setClearColor(0x1e1e1e);
+    this.renderer.setClearColor(WORLD_BG);
     this.renderer.outputColorSpace = THREE.SRGBColorSpace;
     root.appendChild(this.renderer.domElement);
     this.camera = new THREE.PerspectiveCamera(42, 1, 0.1, 400);
-    this.scene.fog = new THREE.FogExp2(0x1e1e1e, 0.016);
-    this.scene.add(new THREE.HemisphereLight(0xbfd4e6, 0x2a2622, 1.15));
-    const key = new THREE.DirectionalLight(0xfff2dd, 1.7);
+    this.scene.fog = new THREE.FogExp2(WORLD_BG, 0.013);
+    // cool, dim, mostly-emissive lighting — the neon does the work; the beans carry a
+    // touch of self-light so they stay cute against the dark
+    this.scene.add(new THREE.HemisphereLight(0x3b4a63, 0x0a0c10, 1.0));
+    const key = new THREE.DirectionalLight(0xcfe0ff, 1.0);
     key.position.set(7, 12, 5);
     this.scene.add(key);
-    const rim = new THREE.DirectionalLight(ACCENT, 0.5);
+    const rim = new THREE.DirectionalLight(ACCENT, 0.7);
     rim.position.set(-6, 6, -8);
     this.scene.add(rim);
     this.scene.add(this.particles.points);
+
+    // the floor: a dark glossy disc with a faint accent grid riding just above it, both
+    // fading into the fog — the Tron ground the pads dock on
+    const floor = new THREE.Mesh(
+      new THREE.CircleGeometry(150, 64),
+      // matte enough that the key light can't smear a bloom highlight across the floor
+      new THREE.MeshStandardMaterial({ color: 0x0a0c10, roughness: 0.72, metalness: 0.3 }),
+    );
+    floor.rotation.x = -Math.PI / 2;
+    floor.position.y = -0.02;
+    this.scene.add(floor);
+    const grid = new THREE.Mesh(
+      new THREE.PlaneGeometry(300, 300),
+      new THREE.MeshBasicMaterial({
+        map: makeGridTexture(), transparent: true, opacity: 0.38,
+        blending: THREE.AdditiveBlending, depthWrite: false,
+      }),
+    );
+    grid.rotation.x = -Math.PI / 2;
+    grid.position.y = 0.0;
+    this.scene.add(grid);
+
+    // bloom is the neon: everything over the threshold (rims, eyes, screens, grid majors)
+    // halos out; the dark slabs and floor stay dark
+    this.composer = new EffectComposer(this.renderer);
+    this.composer.addPass(new RenderPass(this.scene, this.camera));
+    this.bloom = new UnrealBloomPass(new THREE.Vector2(1, 1), 0.7, 0.45, 0.72);
+    this.composer.addPass(this.bloom);
 
     const cv = this.renderer.domElement;
     cv.addEventListener("pointermove", (e) => this.onPointerMove(e));
@@ -460,6 +663,7 @@ class HiveWorld {
     const fit = () => {
       const w = root.clientWidth || 1, h = root.clientHeight || 1;
       this.renderer.setSize(w, h, false);
+      this.composer.setSize(w, h);
       cv.style.width = "100%"; cv.style.height = "100%";
       this.camera.aspect = w / h;
       this.camera.updateProjectionMatrix();
@@ -476,6 +680,7 @@ class HiveWorld {
     io.observe(root);
     document.addEventListener("visibilitychange", () => this.ensureLoop());
     this.ensureLoop();
+    (window as any).__hive = this;           // debug handle (harness + console poking)
   }
 
   private canvasPoint(e: PointerEvent) {
@@ -543,6 +748,13 @@ class HiveWorld {
     this.frameAll();
   }
 
+  // snap every eased camera value to its target — debug/screenshot use (virtual-time
+  // headless runs too few frames for the springs to settle; production never calls this)
+  settle() {
+    this.yawCur = this.yaw; this.pitchCur = this.pitch; this.distCur = this.dist;
+    this.targetCur.copy(this.target);
+  }
+
   frameAll() {
     const occupied = [...this.pads.values()].filter((p) => p.dyingT < 0);
     const slots = occupied.map((p) => this.slots.get(p.sess.sid) ?? 0);
@@ -551,7 +763,7 @@ class HiveWorld {
     for (const p of occupied) { cx += p.group.position.x; cz += p.group.position.z; }
     const n = Math.max(1, occupied.length);
     this.target.set(cx / n, 0, cz / n);
-    this.dist = Math.min(70, Math.max(12, (r / Math.tan((this.camera.fov * Math.PI) / 360)) * 0.62));
+    this.dist = Math.min(70, Math.max(11, (r / Math.tan((this.camera.fov * Math.PI) / 360)) * 0.48));
     this.pitch = 0.72;
   }
 
@@ -601,11 +813,19 @@ class HiveWorld {
       if (pad) {
         const at = pad.group.position.clone().setY(PAD_H + 1.1);
         const tint = new THREE.Color(pad.sess.color?.bg || "#9cd2ff").getHex();
-        this.particles.burst(at, [tint, 0xffffff, ACCENT, 0xffd700], 70, 4.2);
+        // no pure white in the mix — additive + bloom turns white into a supernova
+        this.particles.burst(at, [tint, ACCENT, 0xffd700, tint], 48, 4.2);
       }
     }
     if (first || diff.added.length || diff.removed.length) {
       if (this.selected === null) this.frameAll();
+    }
+    // deep-link: #focus=<sid> flies straight to that session's hex on arrival — the same
+    // affordance a feed/outline "show me" tap will use (and the screenshot harness does)
+    if (first) {
+      const m = /[#&]focus=([^&]+)/.exec(location.hash);
+      const sid = m && decodeURIComponent(m[1]);
+      if (sid && this.pads.has(sid)) this.select(sid);
     }
     this.ensureLoop();
   }
@@ -614,7 +834,7 @@ class HiveWorld {
     const want = this.visible && !document.hidden;
     if (want && !this.running) {
       this.running = true;
-      this.lastFrame = performance.now();
+      this.lastFrame = -1;                   // frame() takes its dt from the rAF clock only
       requestAnimationFrame(this.frame);
     } else if (!want) {
       this.running = false;                  // the in-flight rAF sees this and stops
@@ -623,7 +843,7 @@ class HiveWorld {
 
   private frame = (now: number) => {
     if (!this.running) return;
-    const dt = Math.min(0.05, (now - this.lastFrame) / 1000);
+    const dt = frameDt(now, this.lastFrame);
     this.lastFrame = now;
     this.clock += dt;
     this.idleT += dt;
@@ -653,7 +873,7 @@ class HiveWorld {
     this.camera.lookAt(this.targetCur);
 
     const dead: string[] = [];
-    for (const [psid, pad] of this.pads) if (pad.update(dt, this.yawCur)) dead.push(psid);
+    for (const [psid, pad] of this.pads) if (pad.update(dt, this.yawCur, this.distCur)) dead.push(psid);
     for (const psid of dead) {
       const pad = this.pads.get(psid)!;
       this.scene.remove(pad.group);
@@ -662,7 +882,7 @@ class HiveWorld {
     }
     this.particles.update(dt);
 
-    this.renderer.render(this.scene, this.camera);
+    this.composer.render();
     requestAnimationFrame(this.frame);
   };
 }

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -11,7 +11,7 @@ import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer
 import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
 import { delegate } from "./actions";
-import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, PAD_R, spiralSlot } from "./hive-layout";
+import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, PAD_R, PAD_THETA, RIM_THETA, spiralSlot } from "./hive-layout";
 import { buildSessions, diffSessions, HiveSession, HiveState, hiveAge, stateLine } from "./hive-model";
 
 const vscodeApi =
@@ -75,10 +75,11 @@ class Pad {
     const tint = new THREE.Color(sess.color?.bg || "#8a8a8a");
     // Tron slab: near-black glossy top with only a whisper of the identity color; the
     // pad's LIGHT is its rim. CylinderGeometry with 6 radial segments IS the hex prism;
-    // thetaStart π/6 turns an edge (not a corner) toward each axial neighbour.
+    // PAD_THETA turns an edge (not a corner) toward each axial neighbour, so flush
+    // neighbours meet edge-to-edge (the derivation lives with the constant).
     const top = new THREE.Color(0x0e1116).lerp(tint, 0.06);
     const side = new THREE.Color(0x080a0d).lerp(tint, 0.03);
-    const geo = new THREE.CylinderGeometry(PAD_R, PAD_R * 1.04, PAD_H, 6, 1, false, Math.PI / 6);
+    const geo = new THREE.CylinderGeometry(PAD_R, PAD_R * 1.04, PAD_H, 6, 1, false, PAD_THETA);
     this.padMesh = new THREE.Mesh(geo, [
       new THREE.MeshStandardMaterial({ color: side, roughness: 0.55, metalness: 0.35 }),
       new THREE.MeshStandardMaterial({ color: top, roughness: 0.3, metalness: 0.45 }),
@@ -88,13 +89,13 @@ class Pad {
     this.group.add(this.padMesh);
 
     // the status LIGHT: a glowing hex rim hugging the top edge (additive, bloom-fed).
-    // RingGeometry thetaStart -π/3 lines its corners up with the cylinder's π/6 once its
-    // XY maps into XZ below — the two parametrise their angles from different axes.
+    // RIM_THETA lines its corners up with the cylinder's PAD_THETA once its XY maps into
+    // XZ below — the two parametrise their angles from different axes.
     this.ringMat = new THREE.MeshBasicMaterial({
       color: ST[sess.state], transparent: true, opacity: 0.95,
       blending: THREE.AdditiveBlending, depthWrite: false,
     });
-    const ringGeo = new THREE.RingGeometry(PAD_R * 0.9, PAD_R * 0.985, 6, 1, -Math.PI / 3);
+    const ringGeo = new THREE.RingGeometry(PAD_R * 0.9, PAD_R * 0.985, 6, 1, RIM_THETA);
     this.ring = new THREE.Mesh(ringGeo, this.ringMat);
     this.ring.rotation.x = -Math.PI / 2;
     this.ring.position.y = PAD_H + 0.012;
@@ -104,7 +105,7 @@ class Pad {
       color: ST[sess.state], transparent: true, opacity: 0.22,
       blending: THREE.AdditiveBlending, depthWrite: false, side: THREE.DoubleSide,
     });
-    this.halo = new THREE.Mesh(new THREE.RingGeometry(PAD_R * 0.86, PAD_R * 1.12, 6, 1, -Math.PI / 3), this.haloMat);
+    this.halo = new THREE.Mesh(new THREE.RingGeometry(PAD_R * 0.86, PAD_R * 1.12, 6, 1, RIM_THETA), this.haloMat);
     this.halo.rotation.x = -Math.PI / 2;
     this.halo.position.y = PAD_H + 0.006;
     this.group.add(this.halo);
@@ -114,7 +115,7 @@ class Pad {
       color: ST.awaiting, transparent: true, opacity: 0,
       blending: THREE.AdditiveBlending, depthWrite: false, side: THREE.DoubleSide,
     });
-    this.sonar = new THREE.Mesh(new THREE.RingGeometry(PAD_R * 0.93, 0.05 + PAD_R * 0.93, 6, 1, -Math.PI / 3), this.sonarMat);
+    this.sonar = new THREE.Mesh(new THREE.RingGeometry(PAD_R * 0.93, 0.05 + PAD_R * 0.93, 6, 1, RIM_THETA), this.sonarMat);
     this.sonar.rotation.copy(this.ring.rotation);
     this.sonar.position.y = this.ring.position.y;
     this.group.add(this.sonar);
@@ -807,11 +808,11 @@ class HiveWorld {
     // deliberately QUIETER than any real pad: smaller, hairline ring, near-invisible fill —
     // an invitation at the spiral's frontier, not a resident
     const ghostRing = new THREE.Mesh(
-      new THREE.RingGeometry(PAD_R * 0.72, PAD_R * 0.76, 6, 1, -Math.PI / 3), this.ghostRingMat);
+      new THREE.RingGeometry(PAD_R * 0.72, PAD_R * 0.76, 6, 1, RIM_THETA), this.ghostRingMat);
     ghostRing.rotation.x = -Math.PI / 2;
     ghostRing.position.y = 0.03;
     this.ghostFill = new THREE.Mesh(
-      new THREE.CircleGeometry(PAD_R * 0.76, 6, -Math.PI / 3),
+      new THREE.CircleGeometry(PAD_R * 0.76, 6, RIM_THETA),
       new THREE.MeshBasicMaterial({ color: ACCENT, transparent: true, opacity: 0.012, depthWrite: false }));
     this.ghostFill.rotation.x = -Math.PI / 2;
     this.ghostFill.position.y = 0.02;

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -11,6 +11,7 @@ import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer
 import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
 import { delegate } from "./actions";
+import { hostPrefix } from "./host-prefix";
 import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, PAD_R, PAD_THETA, RIM_THETA, spiralSlot } from "./hive-layout";
 import { buildSessions, diffSessions, HiveSession, HiveState, hiveAge, stateLine } from "./hive-model";
 
@@ -595,15 +596,20 @@ class HiveCard {
   private goal: HTMLElement; private brief: HTMLElement; private err: HTMLElement;
   private input: HTMLTextAreaElement; private sendBtn: HTMLButtonElement;
   sid: string | null = null;
+  private curName = "";                        // latest display name (refresh keeps it current)
+  private renaming = false;
+  private endEdit: ((commit: boolean) => void) | null = null;   // cancel handle for a live editor
   onSend: (sid: string, text: string) => void = () => {};
   onOpen: (sid: string) => void = () => {};
   onClose: () => void = () => {};
+  onRename: (sid: string, name: string) => void = () => {};
 
   constructor() {
     const el = document.createElement("div");
     el.id = "hive-card";
     el.innerHTML =
-      '<div class="hc-head"><span class="hc-dot"></span><span class="hc-name"></span>' +
+      '<div class="hc-head"><span class="hc-dot"></span>' +
+      '<span class="hc-name" data-act="rename" title="Rename"></span>' +
       '<button class="hc-x" data-act="close" title="Back to the board (Esc)" aria-label="Close">×</button></div>' +
       '<div class="hc-state"></div>' +
       '<div class="hc-goal" hidden></div>' +
@@ -626,6 +632,7 @@ class HiveCard {
       close: () => this.onClose(),
       open: () => { if (this.sid) this.onOpen(this.sid); },
       send: () => this.send(),
+      rename: () => this.startRename(),
     });
     this.input.addEventListener("keydown", (e) => {
       if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); this.send(); }
@@ -647,8 +654,56 @@ class HiveCard {
     setTimeout(() => { b.disabled = false; b.textContent = "Send"; }, 1100);
   }
 
+  // Click the name to rename — the same inline editor contract as the chat tab strip
+  // (render.ts startTabRename): a remote session displays as "host:name" where "host:" is
+  // metadata THIS viewer prepends (host-prefix.ts) — the kernel that owns the session knows
+  // it by the bare name, so the host renders as fixed chrome beside the field and only the
+  // name is editable. Enter/blur commits, Esc cancels; the label only changes once the
+  // kernel's push lands with the new name (never optimistically — the push is the truth).
+  private startRename() {
+    if (!this.sid || this.renaming) return;
+    const sid = this.sid;                      // commit to the session the editor OPENED on —
+    const p = hostPrefix(this.curName, sid);   // a blur can land after the card switched sids
+    const base = p ? p.rest : this.curName;
+    const input = document.createElement("input");
+    input.className = "hc-rename";
+    input.value = base;
+    input.spellcheck = false;
+    const fixed = p ? document.createElement("span") : null;
+    if (fixed) { fixed.className = "host-prefix"; fixed.textContent = p!.host; }
+    this.renaming = true;
+    this.name.style.display = "none";
+    this.name.after(input);
+    if (fixed) input.before(fixed);
+    let finished = false;
+    const done = (commit: boolean) => {
+      if (finished) return;
+      finished = true;
+      this.endEdit = null;
+      const v = input.value.trim();
+      input.remove();
+      fixed?.remove();
+      this.name.style.display = "";
+      this.renaming = false;
+      // the bare name, never the display string: the owning kernel is addressed by sid
+      if (commit && v && v !== base) this.onRename(sid, v);
+    };
+    this.endEdit = done;
+    input.addEventListener("keydown", (e) => {
+      e.stopPropagation();                     // typing must never orbit the camera / close the card
+      if (e.key === "Enter") { e.preventDefault(); done(true); }
+      else if (e.key === "Escape") { e.preventDefault(); done(false); }
+    });
+    input.addEventListener("blur", () => done(true));
+    for (const ev of ["click", "mousedown", "dblclick", "contextmenu"])
+      input.addEventListener(ev, (e) => e.stopPropagation());
+    input.focus();
+    input.select();
+  }
+
   show(s: HiveSession, now: number) {
     const fresh = this.sid !== s.sid;
+    if (fresh) this.endEdit?.(false);          // switching sessions abandons a half-typed rename
     this.sid = s.sid;
     this.refresh(s, now);
     if (fresh) { this.err.hidden = true; this.input.value = ""; }
@@ -659,9 +714,11 @@ class HiveCard {
 
   refresh(s: HiveSession, now: number) {
     if (this.sid !== s.sid) return;
+    this.curName = s.name;
     this.dot.style.background = s.color?.bg || "#8a8a8a";
     this.name.textContent = s.name;
     this.name.style.color = s.color?.bg || "#dddddd";
+    this.name.dataset.act = "rename";          // a live session is renameable (gone() revokes)
     this.state.textContent = stateLine(s, now);
     this.state.dataset.state = s.state;
     this.goal.hidden = !s.goal;
@@ -672,9 +729,12 @@ class HiveCard {
   }
 
   gone() {
-    // the selected session left the board — say so rather than silently going stale
+    // the selected session left the board — say so rather than silently going stale, and
+    // stop offering rename: there is nothing behind the sid for the kernel to rename
     this.state.textContent = "this session has ended";
     this.state.dataset.state = "";
+    this.endEdit?.(false);
+    delete this.name.dataset.act;
   }
 
   error(title: string, text: string) {
@@ -682,7 +742,7 @@ class HiveCard {
     this.err.textContent = title + (text ? " — " + text : "");
   }
 
-  hide() { this.sid = null; this.el.classList.remove("open"); }
+  hide() { this.endEdit?.(false); this.sid = null; this.el.classList.remove("open"); }
 }
 
 // ── the world ────────────────────────────────────────────────────────────────────────────
@@ -827,6 +887,11 @@ class HiveWorld {
     this.card.onOpen = (sid) => {
       vscodeApi?.postMessage({ type: "openSession", id: sid });
       try { if (window.parent !== window) window.parent.postMessage({ romp: "reveal", pane: "chat" }, "*"); } catch { /* standalone */ }
+    };
+    this.card.onRename = (sid, name) => {
+      // the SAME renameSession op the chat tab strip posts — the kernel renames the tmux
+      // session (or the names file for a dead one) and the new name rides the next push
+      vscodeApi?.postMessage({ type: "renameSession", id: sid, name });
     };
     this.card.onSend = (sid, text) => {
       vscodeApi?.postMessage({ type: "sendMessage", id: sid, text });
@@ -1120,6 +1185,13 @@ window.addEventListener("message", (e: MessageEvent) => {
   // card instead of letting the send silently vanish (the fail-loudly rule)
   if (m.type === "err" && world && world.card.sid && (!m.sid || m.sid === world.card.sid)) {
     world.card.error(String(m.title || "That message was not delivered"), String(m.text || ""));
+    return;
+  }
+  // a refused op that answers as a warn (renameSession's bad-name reply) — same fail-loudly
+  // rule: this socket only carries replies to ops THIS page sent, so an open card is the
+  // one that asked
+  if (m.type === "warn" && world && world.card.sid) {
+    world.card.error(String(m.text || "That didn't take"), "");
     return;
   }
   if (m.type !== "feed") return;

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -78,6 +78,9 @@ class Pad {
   private labelMesh: THREE.Mesh;
   private bang: THREE.Sprite;              // the ❗ that bobs over a needs-you pad
   private guy: Dweller;
+  carrier = new THREE.Group();              // rides the pointer while the user carries them
+  private carryTarget: THREE.Vector3 | null = null;
+  private carryWant = new THREE.Vector3(); // scratch — no per-frame allocation
   private baseY = 0;
   lift = 0;                                 // hover/press target offset, eased in update()
   private liftCur = 0;
@@ -145,7 +148,10 @@ class Pad {
 
     this.guy = new Dweller(sess.color?.bg || "#9cd2ff");
     this.guy.group.position.y = PAD_H;
-    this.group.add(this.guy.group);
+    // the CARRIER wraps the dweller: the bean's own animation moves guy.group, a user
+    // drag moves the carrier — so picking them up never fights the idle animation
+    this.carrier.add(this.guy.group);
+    this.group.add(this.carrier);
     this.guy.setState(sess.state, sess.faded);
 
     this.group.scale.setScalar(0.001);      // arrival pop plays from ~zero
@@ -174,6 +180,15 @@ class Pad {
   beanMeshes(): THREE.Object3D[] { return [this.guy.hit]; }
   pokeBean() { this.guy.poke(); }
 
+  // world-space carry target while the user drags them; null → spring home (update() eases)
+  carryTo(p: THREE.Vector3 | null) { this.carryTarget = p ? p.clone() : null; }
+  beanWorldPos(): THREE.Vector3 { return this.carrier.getWorldPosition(new THREE.Vector3()); }
+  consumeBean() {
+    this.guy.group.visible = false;
+    this.carrier.position.set(0, 0, 0);
+    this.carryTarget = null;
+  }
+
   update(dt: number, camYaw: number, camDist: number, focus: boolean): boolean {
     this.t += dt;
     // map-label behavior: the plate faces the camera in yaw and FADES with altitude —
@@ -199,6 +214,15 @@ class Pad {
     }
     this.liftCur = ease(this.liftCur, this.lift, dt, 14);
     this.group.position.y = this.liftCur;
+
+    // carried: the bean rides the pointer (world target → pad-local); released, it
+    // springs home — the same everything-springs rule as the rest of the board
+    if (this.carryTarget) this.carryWant.copy(this.carryTarget).sub(this.group.position);
+    else this.carryWant.set(0, 0, 0);
+    this.carrier.position.lerp(this.carryWant, 1 - Math.exp(-16 * dt));
+    const cs = this.carryTarget ? 1.12 : 1;
+    this.carrier.scale.x = ease(this.carrier.scale.x, cs, dt, 12);
+    this.carrier.scale.y = this.carrier.scale.z = this.carrier.scale.x;
 
     this.ringColor.lerp(this.ringTarget, 1 - Math.exp(-8 * dt));
     // a 1px line carries less light than the old fat rim, so overdrive the color past 1 —
@@ -845,6 +869,13 @@ class HiveWorld {
   private ghostHome = 0;                       // first-free slot — where it parks at rest
   private reservedSlot: number | null = null;  // cell claimed by a click, honored in sync()
   private pendingRecruit: { x: number; y: number; slot: number } | null = null;
+  // drag-to-end (the user 2026-08-13, TFT-style): a held press on a session that MOVES
+  // picks the bean up; it rides the pointer, the trash dock slides in, and dropping on
+  // the armed dock ends the session — the deliberate carry + highlighted dock IS the
+  // confirmation (and an ended session still revives with its history from the picker).
+  private pressedPad: { sid: string; x: number; y: number; bean: boolean } | null = null;
+  private dragSession: { sid: string; depth: number; over: boolean } | null = null;
+  private trashEl: HTMLElement;
   private ghostRingMat = new THREE.LineBasicMaterial({
     color: ACCENT, transparent: true, opacity: 0.14, blending: THREE.AdditiveBlending, depthWrite: false,
   });
@@ -908,7 +939,21 @@ class HiveWorld {
       const sid = this.hovered;
       if (sid && sid !== HiveWorld.GHOST) this.openChat(sid);
     });
-    window.addEventListener("keydown", (e) => { if (e.key === "Escape") this.deselect(); });
+    window.addEventListener("keydown", (e) => {
+      if (e.key !== "Escape") return;
+      if (this.dragSession) { this.dropSessionDrag(false); return; }   // Esc aborts a carry
+      this.deselect();
+    });
+
+    // the trash dock: hidden below the bottom edge, slides in only while a session is
+    // being carried; pointer-events none — the canvas keeps the pointer, we rect-test
+    this.trashEl = document.createElement("div");
+    this.trashEl.id = "hive-trash";
+    this.trashEl.innerHTML =
+      '<svg viewBox="0 0 24 24" width="15" height="15" aria-hidden="true">' +
+      '<path fill="currentColor" d="M9 3v1H4v2h16V4h-5V3H9zM6 8v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V8H6zm3 2h2v10H9V10zm4 0h2v10h-2V10z"/></svg>' +
+      '<span class="ht-label">Drop to end</span>';
+    document.body.appendChild(this.trashEl);
 
     const fit = () => {
       const w = root.clientWidth || 1, h = root.clientHeight || 1;
@@ -975,6 +1020,13 @@ class HiveWorld {
 
   private onPointerMove(e: PointerEvent) {
     this.canvasPoint(e);
+    // a held press on a session that moves becomes a PICK-UP; the gate is the gesture
+    // (px travelled), the same 6px the recruit click uses
+    if (this.pressedPad && !this.dragSession
+        && Math.hypot(e.clientX - this.pressedPad.x, e.clientY - this.pressedPad.y) > 6) {
+      this.beginSessionDrag(this.pressedPad.sid);
+    }
+    if (this.dragSession) { this.moveSessionDrag(e); return; }   // a carry never orbits
     if (this.dragging) {
       const dx = e.clientX - this.dragging.x, dy = e.clientY - this.dragging.y;
       this.dragging.x = e.clientX; this.dragging.y = e.clientY;
@@ -1005,18 +1057,11 @@ class HiveWorld {
       return;
     }
     if (sid) {
+      // acknowledge the press NOW (the pad dips); the ACTION fires on the clean UP —
+      // a press that MOVES becomes a pick-up instead (drag to the trash dock to end)
       const pad = this.pads.get(sid);
-      // clicking the BEAN is the direct line to their chat: they pop (immediate
-      // acknowledgement, on them), and the chat pane opens on that session — the hive
-      // stays put. Clicking the TILE keeps opening the fly-in card (the user 2026-08-13).
-      if (hit.bean && pad) {
-        pad.pokeBean();
-        this.openChat(sid);
-        return;
-      }
-      // acknowledge on the DOWN, before anything async: the pad dips under the press
       if (pad) { pad.lift = -0.07; setTimeout(() => { if (this.pads.get(sid) === pad) pad.lift = this.hovered === sid ? 0.12 : 0; }, 130); }
-      this.select(sid);
+      this.pressedPad = { sid, x: e.clientX, y: e.clientY, bean: hit.bean };
     } else {
       this.dragging = { mode: "orbit", x: e.clientX, y: e.clientY };
     }
@@ -1024,8 +1069,24 @@ class HiveWorld {
 
   private onPointerUp(e: PointerEvent) {
     const pr = this.pendingRecruit;
+    const pp = this.pressedPad;
     this.pendingRecruit = null;
+    this.pressedPad = null;
     this.dragging = null;
+    if (this.dragSession) { this.dropSessionDrag(this.dragSession.over); return; }
+    if (pp) {
+      if (Math.hypot(e.clientX - pp.x, e.clientY - pp.y) > 5) return;   // it was a nudge, not a click
+      const pad = this.pads.get(pp.sid);
+      // clicking the BEAN is the direct line to their chat: they pop (acknowledgement on
+      // THEM) and the chat pane opens; clicking the TILE opens the fly-in card
+      if (pp.bean && pad) {
+        pad.pokeBean();
+        this.openChat(pp.sid);
+      } else if (pad) {
+        this.select(pp.sid);
+      }
+      return;
+    }
     if (!pr) return;
     // a real drag is a camera move, not a click — the gate is the gesture itself (px
     // travelled between down and up), never a timer
@@ -1035,6 +1096,53 @@ class HiveWorld {
     // acknowledge NOW with a spark on the clicked cell, then ask the shell for the picker
     this.particles.burst(new THREE.Vector3(p.x, 0.6, p.z), [ACCENT, 0xd6ecff], 16, 1.8);
     try { if (window.parent !== window) window.parent.postMessage({ romp: "openPicker" }, "*"); } catch { /* standalone */ }
+  }
+
+  private beginSessionDrag(sid: string) {
+    const pad = this.pads.get(sid);
+    if (!pad || pad.dyingT >= 0) return;
+    // carry at the pad's own camera depth, so the bean stays screen-true under the cursor
+    this.dragSession = { sid, depth: this.camera.position.distanceTo(pad.group.position), over: false };
+    pad.lift = 0;
+    const label = this.trashEl.querySelector(".ht-label") as HTMLElement;
+    label.textContent = "Drop to end " + pad.sess.name;
+    this.trashEl.classList.add("show");
+    this.renderer.domElement.style.cursor = "grabbing";
+  }
+
+  private moveSessionDrag(e: PointerEvent) {
+    const d = this.dragSession!;
+    const pad = this.pads.get(d.sid);
+    if (!pad || pad.dyingT >= 0) { this.dropSessionDrag(false); return; }
+    const p = new THREE.Vector3(this.pointer.x, this.pointer.y, 0.5).unproject(this.camera)
+      .sub(this.camera.position).normalize().multiplyScalar(d.depth).add(this.camera.position);
+    if (p.y < 0.4) p.y = 0.4;                // never carried below the board
+    pad.carryTo(p);
+    const r = this.trashEl.getBoundingClientRect();
+    const over = e.clientX >= r.left - 14 && e.clientX <= r.right + 14 && e.clientY >= r.top - 14;
+    if (over !== d.over) { d.over = over; this.trashEl.classList.toggle("armed", over); }
+  }
+
+  private dropSessionDrag(over: boolean) {
+    const d = this.dragSession;
+    this.dragSession = null;
+    this.trashEl.classList.remove("show", "armed");
+    this.renderer.domElement.style.cursor = "default";
+    if (!d) return;
+    const pad = this.pads.get(d.sid);
+    if (!pad) return;
+    if (over && pad.dyingT < 0) {
+      // the drop is the decision: end the session (the kernel's own endSession op — the
+      // same one the chat tab's × posts). The bean bursts where it vanished, and the
+      // tile goes straight to the sink — the farewell hop is for natural exits.
+      vscodeApi?.postMessage({ type: "endSession", id: d.sid });
+      this.particles.burst(pad.beanWorldPos().setY(1.0), [0xe5484d, 0x8a8a8a, 0xffb3b6], 26, 2.6);
+      pad.consumeBean();
+      pad.dyingT = 0.26;
+      if (this.selected === d.sid) this.deselect();
+    } else {
+      pad.carryTo(null);                     // anywhere else: they spring home, no harm done
+    }
   }
 
   private static GHOST = "\0ghost";          // impossible sid — the ghost's pick token
@@ -1255,8 +1363,9 @@ class HiveWorld {
     this.clock += dt;
     this.idleT += dt;
 
-    // hover pick once per frame (not per pointermove — cheaper and steadier)
-    const sid = this.pick().sid;
+    // hover pick once per frame (not per pointermove — cheaper and steadier); a carried
+    // bean under the cursor must not churn hover or drag the ghost around
+    const sid = this.dragSession ? this.hovered : this.pick().sid;
     if (sid !== this.hovered) {
       const old = this.hovered && this.hovered !== HiveWorld.GHOST ? this.pads.get(this.hovered) : null;
       if (old) old.lift = 0;

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -14,7 +14,7 @@ import { delegate } from "./actions";
 import { hostPrefix } from "./host-prefix";
 import { loadSettings } from "./settings";
 import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexCorner, hexDistance, latticeSegments, PAD_R, PAD_THETA, RIM_THETA, ringOf, slotOfAxial, spiralSlot, xzToAxial } from "./hive-layout";
-import { buildSessions, diffSessions, HiveSession, HiveState, hiveAge, stateLine } from "./hive-model";
+import { buildSessions, diffSessions, finishedLine, foldSeenDone, HiveSession, HiveState, hiveAge, SeenDone, stateLine } from "./hive-model";
 
 const vscodeApi =
   typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
@@ -80,6 +80,8 @@ class Pad {
   private labelYaw = new THREE.Group();     // yaws to face the camera; the nameplate rides its +z
   private labelMesh: THREE.Mesh;
   private bang: THREE.Sprite;              // the ❗ that bobs over a needs-you pad
+  private tick: THREE.Sprite;              // the ✓ held up over an unseen-finished pad (HiveWorld sets unseenDone)
+  unseenDone = false;                       // finished work the user hasn't gone to look at (foldSeenDone)
   private guy: Dweller;
   carrier = new THREE.Group();              // rides the pointer while the user carries them
   private carryTarget: THREE.Vector3 | null = null;
@@ -150,6 +152,16 @@ class Pad {
     this.bang.position.y = 2.05;             // floats over the bean — the one deliberate float
     this.bang.visible = false;
     this.group.add(this.bang);
+
+    // the finished note: the app's done-check (white ✓ on --check-bg #1EA1EB — the ledger
+    // mark, the feed check) held up like the bang, but calm. Shown only while the session
+    // sits ready with a completion the user hasn't looked at (the user 2026-08-14): the
+    // one-shot confetti marks the MOMENT; this holds the FACT until their own click clears
+    // it. Needs-you outranks it by construction — the bang owns every non-ready state.
+    this.tick = makeTextSprite("✓", "#ffffff", "#1EA1EB");
+    this.tick.position.y = 2.05;
+    this.tick.visible = false;
+    this.group.add(this.tick);
 
     this.guy = new Dweller(sess.color?.bg || "#9cd2ff");
     this.guy.group.position.y = PAD_H;
@@ -265,6 +277,10 @@ class Pad {
       this.sonarMat.opacity = 0;
       this.bang.visible = false;
     }
+    // the finished note holds only over a READY pad: a new turn hides it (working again),
+    // needs-you replaces it (the bang), and the user's own click retires it for good
+    this.tick.visible = st === "ready" && this.unseenDone;
+    if (this.tick.visible) this.tick.position.y = 2.05 + 0.07 * Math.sin(this.t * 2.1);
     this.guy.update(dt, this.t, camYaw);
     return false;
   }
@@ -878,6 +894,9 @@ class HiveWorld {
   private dragging: { mode: "orbit" | "pan"; x: number; y: number } | null = null;
   private clock = 0;
   card = new HiveCard();
+  // per-sid completion watermarks the user has LOOKED at (localStorage — the latch survives
+  // a reload); foldSeenDone derives the unseen set from these each payload
+  private seenDone: SeenDone = loadSeenDone();
   // the ghost hex: the standing invitation. It parks on the first FREE slot, and GLIDES
   // under the pointer whenever any empty cell is hovered — every empty hexagon is
   // clickable to spawn a session there (the user 2026-08-13). A clean click (down+up,
@@ -1366,6 +1385,7 @@ class HiveWorld {
   // dead-session revive prompt). Board sessions are live, so the local flip is never
   // showing something the kernel would have refused.
   openChat(sid: string) {
+    this.lookedAt(sid);                      // going to its chat IS looking — the ✓ note retires
     try {
       if (window.parent !== window) {
         window.parent.postMessage({ romp: "focusChat", id: sid }, "*");
@@ -1373,6 +1393,19 @@ class HiveWorld {
       }
     } catch { /* standalone */ }
     vscodeApi?.postMessage({ type: "openSession", id: sid });
+  }
+
+  // The user's own gesture toward a session — the ONE event that clears its finished note
+  // (never a timer, never a re-render): the watermark advances to the completion they just
+  // went to see, persisted so a reload can't resurrect an acknowledged ✓. Known gap, on
+  // purpose for now: reading the outcome in the chat/feed PANES doesn't reach this board,
+  // so the note can outlive a look that happened elsewhere — one click here retires it.
+  private lookedAt(sid: string) {
+    const pad = this.pads.get(sid);
+    if (!pad || pad.sess.doneT <= (this.seenDone[sid] ?? 0)) return;
+    this.seenDone[sid] = pad.sess.doneT;
+    pad.unseenDone = false;
+    saveSeenDone(this.seenDone);
   }
 
   // aim the ghost at a cell; frame() glides it there (everything springs, nothing teleports)
@@ -1386,6 +1419,7 @@ class HiveWorld {
   // only — a feed/outline "show me" jump lands here (#focus=<sid>). A plain click never
   // opens it: the chat on the left is the click's whole answer (the user 2026-08-13).
   select(sid: string) {
+    this.lookedAt(sid);                      // a deep-link jump is the user arriving to look
     this.selected = sid;
     const pad = this.pads.get(sid);
     if (pad) {
@@ -1477,6 +1511,21 @@ class HiveWorld {
       if (pad && !diff.added.includes(s.sid)) pad.apply(s, changed.has(s.sid));
       if (this.selected === s.sid) this.card.refresh(s, nowS);
     }
+    // the unseen-finished latch (hive-model foldSeenDone): completions the user hasn't gone
+    // to look at wear the ✓ note until their own gesture clears it (lookedAt). The open
+    // card IS looking — a completion landing on the selected session is seen as it lands.
+    const fold = foldSeenDone(this.seenDone, sessions);
+    this.seenDone = fold.seen;
+    let seenChanged = fold.changed;
+    if (this.selected && fold.unseen.has(this.selected)) {
+      const s = bySid.get(this.selected);
+      if (s) { this.seenDone[this.selected] = s.doneT; fold.unseen.delete(this.selected); seenChanged = true; }
+    }
+    for (const s of sessions) {
+      const pad = this.pads.get(s.sid);
+      if (pad) pad.unseenDone = fold.unseen.has(s.sid);
+    }
+    if (seenChanged) saveSeenDone(this.seenDone);
     for (const sid of diff.goalDone) {
       const pad = this.pads.get(sid);
       if (pad) {
@@ -1579,12 +1628,16 @@ class HiveWorld {
           ((p.x * 0.5 + 0.5) * rr.width + rr.left).toFixed(1) + "px, " +
           ((0.5 - p.y * 0.5) * rr.height + rr.top).toFixed(1) + "px)";
         this.tipEl.classList.add("show");
-        const line = stateLine(tipPad.sess, Math.floor(Date.now() / 1000));
+        // an unseen finish outranks the plain "ready" line: the tip says what the ✓ means
+        // and how long it has been waiting for you (finishedLine)
+        const done = tipPad.unseenDone && tipPad.sess.state === "ready";
+        const line = done ? finishedLine(tipPad.sess, Math.floor(Date.now() / 1000))
+                          : stateLine(tipPad.sess, Math.floor(Date.now() / 1000));
         if (line !== this.tipText) {
           this.tipText = line;
           (this.tipEl.querySelector(".tip-state") as HTMLElement).textContent = line;
           (this.tipEl.querySelector(".tip-dot") as HTMLElement).style.background = tipPad.sess.color?.bg || "#8a8a8a";
-          this.tipEl.dataset.state = tipPad.sess.state;
+          this.tipEl.dataset.state = done ? "done" : tipPad.sess.state;
         }
       } else this.tipEl.classList.remove("show");
     } else {
@@ -1681,6 +1734,22 @@ function saveSlots(m: Map<string, number>) {
     for (const [k, v] of m) o[k] = v;
     localStorage.setItem(SLOTS_KEY, JSON.stringify(o));
   } catch { /* private mode etc — the board still works, it just re-deals on reload */ }
+}
+
+// unseen-finished persistence: the same memory policy as the slot map — the latch must
+// survive a reload (stepping away is safe), absentees keep their stamps for revival, and
+// foldSeenDone bounds the record. Unreadable/private-mode storage just resets the cues.
+const SEEN_KEY = "romp:hiveSeenDone";
+function loadSeenDone(): SeenDone {
+  try {
+    const d = JSON.parse(localStorage.getItem(SEEN_KEY) || "null");
+    const out: SeenDone = {};
+    if (d && typeof d === "object") for (const k of Object.keys(d)) if (Number.isFinite(d[k])) out[k] = d[k];
+    return out;
+  } catch { return {}; }
+}
+function saveSeenDone(m: SeenDone) {
+  try { localStorage.setItem(SEEN_KEY, JSON.stringify(m)); } catch { /* see saveSlots */ }
 }
 
 // ── boot ─────────────────────────────────────────────────────────────────────────────────

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -184,6 +184,15 @@ class Pad {
   beanMeshes(): THREE.Object3D[] { return [this.guy.hit]; }
   pokeBean() { this.guy.poke(); }
 
+  // the nameplate as a click target (board rename): only when actually readable — an
+  // invisible plate must never be a secret button, and hover already fades it in
+  nameMeshes(): THREE.Object3D[] { return [this.labelMesh]; }
+  nameVisible(): boolean {
+    return this.labelMesh.visible && (this.labelMesh.material as THREE.MeshBasicMaterial).opacity > 0.5;
+  }
+  setNameHidden(h: boolean) { this.labelMesh.visible = !h; }
+  labelWorldPos(): THREE.Vector3 { return this.labelMesh.getWorldPosition(new THREE.Vector3()); }
+
   // world-space carry target while the user drags them; null → spring home (update() eases)
   carryTo(p: THREE.Vector3 | null) { this.carryTarget = p ? p.clone() : null; }
   // move the pad's HOME to another cell (drag-to-re-home, the user 2026-08-13); update() glides it
@@ -882,7 +891,8 @@ class HiveWorld {
   // picks the bean up; it rides the pointer, the trash dock slides in, and dropping on
   // the armed dock ends the session — the deliberate carry + highlighted dock IS the
   // confirmation (and an ended session still revives with its history from the picker).
-  private pressedPad: { sid: string; x: number; y: number; bean: boolean } | null = null;
+  private pressedPad: { sid: string; x: number; y: number; bean: boolean; name: boolean } | null = null;
+  private renameEl: HTMLElement | null = null;   // the in-place board rename editor, when open
   private dragSession: { sid: string; over: boolean } | null = null;
   private trashEl: HTMLElement;
   private tipEl: HTMLElement;
@@ -949,6 +959,7 @@ class HiveWorld {
       this.idleT = 0;
     }, { passive: false });
     cv.addEventListener("dblclick", () => {
+      if (this.renameEl) return;               // typing a name — a stray dblclick must not switch chat
       const sid = this.hovered;
       if (sid && sid !== HiveWorld.GHOST) this.openChat(sid);
     });
@@ -1092,11 +1103,15 @@ class HiveWorld {
       // while you carry them is coherent. That is ALL a click does: the chat on the left
       // is the answer — the fly-in card + camera zoom on every click read as noise (the
       // user 2026-08-13) and now serve only the deep-link jump (select()).
-      if (pad) {
+      // EXCEPTION: the NAMEPLATE is its own affordance — clicking it edits the name in
+      // place (the city-banner pattern; the user 2026-08-13, who wanted renaming to feel
+      // like a great videogame), so it never switches chat; the edit opens on the clean UP
+      // so a drag from the plate still picks the session up.
+      if (pad && !hit.name) {
         if (hit.bean) pad.pokeBean();
         this.openChat(sid);
       }
-      this.pressedPad = { sid, x: e.clientX, y: e.clientY, bean: hit.bean };
+      this.pressedPad = { sid, x: e.clientX, y: e.clientY, bean: hit.bean, name: hit.name };
     } else {
       this.dragging = { mode: "orbit", x: e.clientX, y: e.clientY };
     }
@@ -1109,7 +1124,12 @@ class HiveWorld {
     this.pressedPad = null;
     this.dragging = null;
     if (this.dragSession) { this.dropSessionDrag(this.dragSession.over); return; }
-    if (pp) return;   // the press already did everything (chat switch on the DOWN); a drag ended above
+    if (pp) {
+      // most presses already did everything on the DOWN; the nameplate's clean click is
+      // the one action that resolves here — it opens the in-place editor
+      if (pp.name && Math.hypot(e.clientX - pp.x, e.clientY - pp.y) <= 5) this.beginBoardRename(pp.sid);
+      return;
+    }
     if (!pr) return;
     // a real drag is a camera move, not a click — the gate is the gesture itself (px
     // travelled between down and up), never a timer
@@ -1215,6 +1235,63 @@ class HiveWorld {
     vscodeApi?.postMessage({ type: "createSession", name: this.autoName(model), backend: "sdk", model, effort });
   }
 
+  // In-place board rename (the user 2026-08-13, who wanted renaming to feel like a great
+  // videogame): the city-banner pattern — click the nameplate and it becomes an editor
+  // exactly where it sits, in the plate's own type and the session's color. The same
+  // contracts as every other rename surface: a remote's host: prefix is fixed chrome with
+  // only the bare name editable, Enter/blur commits the kernel's renameSession op, Esc
+  // cancels, and the plate only re-renders when the push lands with the truth.
+  beginBoardRename(sid: string) {
+    const pad = this.pads.get(sid);
+    if (!pad || pad.dyingT >= 0 || this.renameEl) return;
+    const p = pad.labelWorldPos().project(this.camera);
+    const rr = this.renderer.domElement.getBoundingClientRect();
+    const x = (p.x * 0.5 + 0.5) * rr.width + rr.left;
+    const y = (0.5 - p.y * 0.5) * rr.height + rr.top;
+    pad.setNameHidden(true);                   // the editor stands where the plate was
+    const wrap = document.createElement("div");
+    wrap.id = "hive-rename";
+    wrap.style.transform = "translate(" + x.toFixed(1) + "px," + y.toFixed(1) + "px) translate(-50%, -50%)";
+    const hp = hostPrefix(pad.sess.name, sid);
+    const base = hp ? hp.rest : pad.sess.name;
+    if (hp) {
+      const fixed = document.createElement("span");
+      fixed.className = "host-prefix";
+      fixed.textContent = hp.host;
+      wrap.appendChild(fixed);
+    }
+    const input = document.createElement("input");
+    input.value = base;
+    input.spellcheck = false;
+    input.size = Math.max(base.length, 3);
+    input.style.color = pad.sess.color?.bg || "#dddddd";
+    wrap.appendChild(input);
+    document.body.appendChild(wrap);
+    this.renameEl = wrap;
+    let finished = false;
+    const finish = (commit: boolean) => {
+      if (finished) return;
+      finished = true;
+      const v = input.value.trim();
+      wrap.remove();
+      this.renameEl = null;
+      this.pads.get(sid)?.setNameHidden(false);
+      // the bare name, never the display string; the plate updates when the push lands
+      if (commit && v && v !== base) vscodeApi?.postMessage({ type: "renameSession", id: sid, name: v });
+    };
+    input.addEventListener("keydown", (e) => {
+      e.stopPropagation();                     // Esc cancels the EDIT, never a drag/selection
+      if (e.key === "Enter") { e.preventDefault(); finish(true); }
+      else if (e.key === "Escape") { e.preventDefault(); finish(false); }
+    });
+    input.addEventListener("blur", () => finish(true));
+    input.addEventListener("input", () => { input.size = Math.max(input.value.length, 3); });
+    for (const ev of ["pointerdown", "click", "dblclick"])
+      wrap.addEventListener(ev, (e) => e.stopPropagation());
+    input.focus();
+    input.select();
+  }
+
   // a transient board-level notice for refusals with no card open (fail loudly, never vanish)
   note(text: string) {
     this.noteEl.textContent = text;
@@ -1225,28 +1302,33 @@ class HiveWorld {
 
   private static GHOST = "\0ghost";          // impossible sid — the ghost's pick token
 
-  private pick(): { sid: string | null; bean: boolean } {
+  private pick(): { sid: string | null; bean: boolean; name: boolean } {
     this.raycaster.setFromCamera(this.pointer, this.camera);
-    let best: { sid: string; d: number; bean: boolean } | null = null;
+    let best: { sid: string; d: number; bean: boolean; name: boolean } | null = null;
     for (const [sid, pad] of this.pads) {
       if (pad.dyingT >= 0) continue;
       const hits = this.raycaster.intersectObjects(pad.hitMeshes(), false);
-      if (hits.length && (!best || hits[0].distance < best.d)) best = { sid, d: hits[0].distance, bean: false };
+      if (hits.length && (!best || hits[0].distance < best.d)) best = { sid, d: hits[0].distance, bean: false, name: false };
       // the bean stands proud of its tile, so when both are under the pointer the bean wins
       const bh = this.raycaster.intersectObjects(pad.beanMeshes(), false);
-      if (bh.length && (!best || bh[0].distance < best.d)) best = { sid, d: bh[0].distance, bean: true };
+      if (bh.length && (!best || bh[0].distance < best.d)) best = { sid, d: bh[0].distance, bean: true, name: false };
+      // …and the READABLE nameplate wins over its own tile (it sits a hair above it)
+      const nh = this.raycaster.intersectObjects(pad.nameMeshes(), false);
+      if (nh.length && pad.nameVisible() && (!best || nh[0].distance <= best.d)) {
+        best = { sid, d: nh[0].distance, bean: false, name: true };
+      }
     }
     const gh = this.raycaster.intersectObject(this.ghostFill, false);
-    if (gh.length && (!best || gh[0].distance < best.d)) best = { sid: HiveWorld.GHOST, d: gh[0].distance, bean: false };
-    if (best) return { sid: best.sid, bean: best.bean };
+    if (gh.length && (!best || gh[0].distance < best.d)) best = { sid: HiveWorld.GHOST, d: gh[0].distance, bean: false, name: false };
+    if (best) return { sid: best.sid, bean: best.bean, name: best.name };
     // nothing solid under the pointer: any EMPTY cell of the board is the invitation too —
     // the ghost glides to it and a clean click recruits there (the user 2026-08-13)
     const slot = this.freeCellAt();
     if (slot !== null) {
       if (slot !== this.ghostSlot) this.ghostTo(slot);
-      return { sid: HiveWorld.GHOST, bean: false };
+      return { sid: HiveWorld.GHOST, bean: false, name: false };
     }
-    return { sid: null, bean: false };
+    return { sid: null, bean: false, name: false };
   }
 
   // The FREE cell of the board under a point — the ONE ground-plane → cell mapping, shared

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -127,7 +127,7 @@ class Pad {
     this.group.add(this.label);
 
     this.bang = makeTextSprite("!", "#ffffff", "#c0392b");
-    this.bang.position.y = 2.35;
+    this.bang.position.y = 2.05;             // between head and label, kissing neither
     this.bang.visible = false;
     this.group.add(this.bang);
 
@@ -203,7 +203,7 @@ class Pad {
       this.sonarMat.opacity = (1 - p) * 0.5;
       this.sonar.scale.setScalar(1 + p * 0.85);
       this.bang.visible = true;
-      this.bang.position.y = 2.35 + 0.14 * Math.abs(Math.sin(this.t * 5));
+      this.bang.position.y = 2.05 + 0.14 * Math.abs(Math.sin(this.t * 5));
     } else {
       this.sonarMat.opacity = 0;
       this.bang.visible = false;
@@ -236,6 +236,8 @@ class Dweller {
   private armL: THREE.Mesh; private armR: THREE.Mesh;
   private aura: THREE.Mesh;                 // compacting swirl / awaitingBg marker, recolored per state
   private auraMat: THREE.MeshBasicMaterial;
+  private orb!: THREE.Mesh;                 // awaitingBg: spinning gem overhead
+  private orbMat!: THREE.MeshBasicMaterial;
   private desk: THREE.Group;                // tiny desk + glowing laptop — the "working" silhouette
   private screenMat: THREE.MeshStandardMaterial;
   private state: HiveState = "ready";
@@ -297,6 +299,12 @@ class Dweller {
     this.aura.position.y = 0.66;
     this.aura.rotation.x = Math.PI / 2.4;
     this.group.add(this.aura);
+    // the awaitingBg marker: a little hourglass-ish gem spinning overhead — "my work is
+    // out there running" — green like its status
+    this.orbMat = new THREE.MeshBasicMaterial({ color: ST.awaitingBg, transparent: true, opacity: 0 });
+    this.orb = new THREE.Mesh(new THREE.OctahedronGeometry(0.1), this.orbMat);
+    this.orb.position.y = 1.55;
+    this.group.add(this.orb);
 
     // the desk: tabletop + laptop with an emissive screen, parked in front of the bean;
     // shown only while working (the strongest one-glance "busy" silhouette there is)
@@ -378,7 +386,9 @@ class Dweller {
         break;
       }
       case "blocked":
-        rotX = 0.55; y = -0.05;              // folded forward over the wreck, arms hanging dead
+        desk = true;                          // the wreck stays on the desk, screen dead, smoking
+        this.screenMat.emissiveIntensity = 0.04;
+        rotX = 0.55; y = -0.05;              // folded forward over it, arms hanging dead
         armLZ = 0.05; armRZ = -0.05; armLX = -0.4; armRX = -0.4;
         break;
       case "retrying":
@@ -390,8 +400,9 @@ class Dweller {
       case "awaitingBg":
         rotX = -0.14;                        // leaning back, watching its dispatched work spin
         armLZ = 0.9; armRZ = -0.9;
-        aura = 0.4; this.auraMat.color.setHex(ST.awaitingBg);
-        this.aura.rotation.z = t * 0.9;
+        this.orbMat.opacity = 0.9;
+        this.orb.rotation.y = t * 2.2; this.orb.rotation.x = 0.5;
+        this.orb.position.y = 1.55 + 0.08 * Math.sin(t * 2.6);
         break;
       case "compacting": case "clearing":
         y = 0.18 + 0.05 * Math.sin(t * 2.4); // levitating meditation, teal swirl orbiting
@@ -420,6 +431,7 @@ class Dweller {
     }
     if (s !== "opening") { this.face.visible = true; this.armL.visible = true; this.armR.visible = true; }
     if (s !== "working") this.bodyMat.emissiveIntensity = 0.22;
+    if (s !== "awaitingBg") this.orbMat.opacity = ease(this.orbMat.opacity, 0, dt, 8);
     this.desk.visible = desk;
 
     // squash & stretch: landings compress the bean, air time stretches it — scale about the
@@ -516,6 +528,7 @@ class Particles {
   private col = new Float32Array(this.max * 3);
   private vel: Float32Array = new Float32Array(this.max * 3);
   private life = new Float32Array(this.max);
+  private grav = new Float32Array(this.max);   // per-particle: confetti falls, smoke rises
   private n = 0;
 
   constructor() {
@@ -529,7 +542,7 @@ class Particles {
     this.geo.setDrawRange(0, 0);
   }
 
-  burst(at: THREE.Vector3, colors: number[], count: number, speed: number) {
+  burst(at: THREE.Vector3, colors: number[], count: number, speed: number, gravity = -7.5, life = 1.1) {
     for (let i = 0; i < count && this.n < this.max; i++, this.n++) {
       const j = this.n * 3;
       // born spread over a small shell, not one point — a point of 50 additive sprites
@@ -544,7 +557,8 @@ class Particles {
       this.vel[j + 2] = Math.sin(th) * speed * (0.4 + Math.random() * 0.6);
       const c = new THREE.Color(colors[i % colors.length]);
       this.col[j] = c.r; this.col[j + 1] = c.g; this.col[j + 2] = c.b;
-      this.life[this.n] = 1.1 + Math.random() * 0.5;
+      this.life[this.n] = life + Math.random() * 0.5;
+      this.grav[this.n] = gravity;
     }
   }
 
@@ -554,14 +568,14 @@ class Particles {
       this.life[i] -= dt;
       if (this.life[i] <= 0) continue;
       const j = i * 3, k = w * 3;
-      this.vel[j + 1] -= 7.5 * dt;
+      this.vel[j + 1] += this.grav[i] * dt;
       this.pos[k] = this.pos[j] + this.vel[j] * dt;
       this.pos[k + 1] = this.pos[j + 1] + this.vel[j + 1] * dt;
       this.pos[k + 2] = this.pos[j + 2] + this.vel[j + 2] * dt;
       if (w !== i) {
         this.vel[k] = this.vel[j]; this.vel[k + 1] = this.vel[j + 1]; this.vel[k + 2] = this.vel[j + 2];
         this.col[k] = this.col[j]; this.col[k + 1] = this.col[j + 1]; this.col[k + 2] = this.col[j + 2];
-        this.life[w] = this.life[i];
+        this.life[w] = this.life[i]; this.grav[w] = this.grav[i];
       }
       w++;
     }
@@ -699,6 +713,15 @@ class HiveWorld {
   private dragging: { mode: "orbit" | "pan"; x: number; y: number } | null = null;
   private clock = 0;
   card = new HiveCard();
+  // the ghost hex: a faint outline on the first FREE slot — hover it and a "+" wakes up;
+  // click recruits (opens the new-session picker via the shell relay)
+  private ghost = new THREE.Group();
+  private ghostRingMat = new THREE.MeshBasicMaterial({
+    color: ACCENT, transparent: true, opacity: 0.14, blending: THREE.AdditiveBlending, depthWrite: false,
+  });
+  private ghostFill: THREE.Mesh;
+  private ghostPlus: THREE.Sprite;
+  private ghostHover = false;
 
   constructor(private root: HTMLElement) {
     this.renderer = new THREE.WebGLRenderer({ antialias: true });
@@ -783,6 +806,24 @@ class HiveWorld {
     document.addEventListener("visibilitychange", () => this.ensureLoop());
     this.ensureLoop();
 
+    // deliberately QUIETER than any real pad: smaller, hairline ring, near-invisible fill —
+    // an invitation at the spiral's frontier, not a resident
+    const ghostRing = new THREE.Mesh(
+      new THREE.RingGeometry(PAD_R * 0.72, PAD_R * 0.76, 6, 1, -Math.PI / 3), this.ghostRingMat);
+    ghostRing.rotation.x = -Math.PI / 2;
+    ghostRing.position.y = 0.03;
+    this.ghostFill = new THREE.Mesh(
+      new THREE.CircleGeometry(PAD_R * 0.76, 6, -Math.PI / 3),
+      new THREE.MeshBasicMaterial({ color: ACCENT, transparent: true, opacity: 0.012, depthWrite: false }));
+    this.ghostFill.rotation.x = -Math.PI / 2;
+    this.ghostFill.position.y = 0.02;
+    this.ghostPlus = makeTextSprite("+", "#9cd2ff");
+    this.ghostPlus.position.y = 0.6;
+    this.ghostPlus.scale.multiplyScalar(0.7);
+    this.ghostPlus.material.opacity = 0.25;
+    this.ghost.add(ghostRing, this.ghostFill, this.ghostPlus);
+    this.scene.add(this.ghost);
+
     this.card.onClose = () => this.deselect();
     this.card.onOpen = (sid) => {
       vscodeApi?.postMessage({ type: "openSession", id: sid });
@@ -828,6 +869,12 @@ class HiveWorld {
     this.canvasPoint(e);
     const sid = this.pick();
     if (e.button === 2 || e.shiftKey) { this.dragging = { mode: "pan", x: e.clientX, y: e.clientY }; return; }
+    if (sid === HiveWorld.GHOST) {
+      // recruit: acknowledge with a spark on the ghost, then ask the shell for the picker
+      this.particles.burst(this.ghost.position.clone().setY(0.6), [ACCENT, 0xd6ecff], 16, 1.8);
+      try { if (window.parent !== window) window.parent.postMessage({ romp: "openPicker" }, "*"); } catch { /* standalone */ }
+      return;
+    }
     if (sid) {
       // acknowledge on the DOWN, before anything async: the pad dips under the press
       const pad = this.pads.get(sid);
@@ -838,6 +885,8 @@ class HiveWorld {
     }
   }
 
+  private static GHOST = "\0ghost";          // impossible sid — the ghost's pick token
+
   private pick(): string | null {
     this.raycaster.setFromCamera(this.pointer, this.camera);
     let best: { sid: string; d: number } | null = null;
@@ -846,6 +895,8 @@ class HiveWorld {
       const hits = this.raycaster.intersectObjects(pad.hitMeshes(), false);
       if (hits.length && (!best || hits[0].distance < best.d)) best = { sid, d: hits[0].distance };
     }
+    const gh = this.raycaster.intersectObject(this.ghostFill, false);
+    if (gh.length && (!best || gh[0].distance < best.d)) best = { sid: HiveWorld.GHOST, d: gh[0].distance };
     return best ? best.sid : null;
   }
 
@@ -938,6 +989,13 @@ class HiveWorld {
         this.particles.burst(at, [tint, ACCENT, 0xffd700, tint], 48, 4.2);
       }
     }
+    // park the ghost hex on the first FREE slot — the natural "next" cell of the spiral
+    let free = 0;
+    const taken = new Set(this.slots.values());
+    while (taken.has(free)) free++;
+    const gp = axialToXZ(spiralSlot(free), HEX_SIZE);
+    this.ghost.position.set(gp.x, 0, gp.z);
+
     if (first || diff.added.length || diff.removed.length) {
       if (this.selected === null) this.frameAll();
     }
@@ -972,13 +1030,19 @@ class HiveWorld {
     // hover pick once per frame (not per pointermove — cheaper and steadier)
     const sid = this.pick();
     if (sid !== this.hovered) {
-      const old = this.hovered ? this.pads.get(this.hovered) : null;
+      const old = this.hovered && this.hovered !== HiveWorld.GHOST ? this.pads.get(this.hovered) : null;
       if (old) old.lift = 0;
       this.hovered = sid;
-      const nw = sid ? this.pads.get(sid) : null;
+      const nw = sid && sid !== HiveWorld.GHOST ? this.pads.get(sid) : null;
       if (nw) nw.lift = 0.12;
+      this.ghostHover = sid === HiveWorld.GHOST;
       this.renderer.domElement.style.cursor = sid ? "pointer" : "default";
     }
+    // the ghost breathes faintly; waking on hover
+    const gTarget = this.ghostHover ? 0.5 : 0.06 + 0.03 * (0.5 + 0.5 * Math.sin(this.clock * 1.2));
+    this.ghostRingMat.opacity = ease(this.ghostRingMat.opacity, gTarget, dt, 8);
+    this.ghostPlus.material.opacity = ease(this.ghostPlus.material.opacity, this.ghostHover ? 0.95 : 0.22, dt, 8);
+    this.ghostPlus.position.y = 0.6 + (this.ghostHover ? 0.1 * Math.abs(Math.sin(this.clock * 4)) : 0);
 
     // idle drift: after 6s hands-off the whole board breathes on a slow orbital sway
     const driftYaw = this.idleT > 6 ? Math.sin(this.clock * 0.1) * 0.05 : 0;
@@ -993,6 +1057,23 @@ class HiveWorld {
     );
     this.camera.lookAt(this.targetCur);
 
+    // ambient emitters, event-free by design: smoke while blocked, zzz while dozing — a
+    // steady drizzle tied to the CURRENT state, not a transition (they stop the moment the
+    // state moves on, no latch to forget)
+    for (const pad of this.pads.values()) {
+      if (pad.dyingT >= 0) continue;
+      const st = pad.sess.state;
+      if (st === "blocked" && Math.random() < dt * 1.6) {
+        const at = pad.group.position.clone(); at.y += PAD_H + 0.75;
+        at.x += 0.25; at.z += 0.45;           // off the dead laptop, not the bean's head
+        this.particles.burst(at, [0x555b63, 0x3c4148, 0x6a7076], 2, 0.22, 0.55, 1.4);
+      }
+      if (st === "ready" && pad.sess.faded && Math.random() < dt * 0.8) {
+        const at = pad.group.position.clone(); at.y += PAD_H + 1.25;
+        at.x += 0.3;
+        this.particles.burst(at, [0x9cd2ff, 0x6fa8d8], 1, 0.14, 0.3, 1.8);
+      }
+    }
     const dead: string[] = [];
     for (const [psid, pad] of this.pads) if (pad.update(dt, this.yawCur, this.distCur)) dead.push(psid);
     for (const psid of dead) {

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -171,6 +171,8 @@ class Pad {
   }
 
   hitMeshes(): THREE.Object3D[] { return [this.padMesh]; }
+  beanMeshes(): THREE.Object3D[] { return [this.guy.hit]; }
+  pokeBean() { this.guy.poke(); }
 
   update(dt: number, camYaw: number, camDist: number, focus: boolean): boolean {
     this.t += dt;
@@ -246,6 +248,7 @@ class Dweller {
   private face: THREE.Mesh;
   private eyeL: THREE.Mesh; private eyeR: THREE.Mesh;
   private armL: THREE.Mesh; private armR: THREE.Mesh;
+  hit!: THREE.Mesh;                         // invisible click body — see the ctor
   private aura: THREE.Mesh;                 // compacting swirl / awaitingBg marker, recolored per state
   private auraMat: THREE.MeshBasicMaterial;
   private orb!: THREE.Mesh;                 // awaitingBg: spinning gem overhead
@@ -306,6 +309,16 @@ class Dweller {
     this.torso.add(this.armL, this.armR);
     this.group.add(this.torso);
 
+    // the bean's HIT BODY: an invisible capsule over the whole character (arms, face, all
+    // of them), so clicking THEM is easy — colorWrite:false draws nothing but still
+    // raycasts. Clicking the bean is the direct line to their chat (the user 2026-08-13).
+    this.hit = new THREE.Mesh(
+      new THREE.CapsuleGeometry(0.55, 0.55, 4, 8),
+      new THREE.MeshBasicMaterial({ colorWrite: false, depthWrite: false }),
+    );
+    this.hit.position.y = 0.62;
+    this.group.add(this.hit);
+
     this.auraMat = new THREE.MeshBasicMaterial({ color: ST.compacting, transparent: true, opacity: 0 });
     this.aura = new THREE.Mesh(new THREE.TorusGeometry(0.58, 0.035, 6, 24), this.auraMat);
     this.aura.position.y = 0.66;
@@ -360,6 +373,11 @@ class Dweller {
     }
     if (s !== this.state) this.squash = 1.18;   // every real transition lands with a squash beat
     this.state = s; this.faded = faded;
+  }
+
+  // a click landed on them — the hatch pop doubles as the immediate acknowledgement
+  poke() {
+    this.pop = Math.max(this.pop, 0.45);
   }
 
   update(dt: number, t: number, camYaw: number) {
@@ -888,7 +906,7 @@ class HiveWorld {
     }, { passive: false });
     cv.addEventListener("dblclick", () => {
       const sid = this.hovered;
-      if (sid) { vscodeApi?.postMessage({ type: "openSession", id: sid }); }
+      if (sid && sid !== HiveWorld.GHOST) this.openChat(sid);
     });
     window.addEventListener("keydown", (e) => { if (e.key === "Escape") this.deselect(); });
 
@@ -932,10 +950,7 @@ class HiveWorld {
     this.scene.add(this.ghost);
 
     this.card.onClose = () => this.deselect();
-    this.card.onOpen = (sid) => {
-      vscodeApi?.postMessage({ type: "openSession", id: sid });
-      try { if (window.parent !== window) window.parent.postMessage({ romp: "reveal", pane: "chat" }, "*"); } catch { /* standalone */ }
-    };
+    this.card.onOpen = (sid) => this.openChat(sid);
     this.card.onRename = (sid, name) => {
       // the SAME renameSession op the chat tab strip posts — the kernel renames the tmux
       // session (or the names file for a dead one) and the new name rides the next push
@@ -979,7 +994,8 @@ class HiveWorld {
 
   private onPointerDown(e: PointerEvent) {
     this.canvasPoint(e);
-    const sid = this.pick();
+    const hit = this.pick();
+    const sid = hit.sid;
     if (e.button === 2 || e.shiftKey) { this.dragging = { mode: "pan", x: e.clientX, y: e.clientY }; return; }
     if (sid === HiveWorld.GHOST) {
       // recruit is decided on the UP (a clean click, not a drag) so the whole empty board
@@ -989,8 +1005,16 @@ class HiveWorld {
       return;
     }
     if (sid) {
-      // acknowledge on the DOWN, before anything async: the pad dips under the press
       const pad = this.pads.get(sid);
+      // clicking the BEAN is the direct line to their chat: they pop (immediate
+      // acknowledgement, on them), and the chat pane opens on that session — the hive
+      // stays put. Clicking the TILE keeps opening the fly-in card (the user 2026-08-13).
+      if (hit.bean && pad) {
+        pad.pokeBean();
+        this.openChat(sid);
+        return;
+      }
+      // acknowledge on the DOWN, before anything async: the pad dips under the press
       if (pad) { pad.lift = -0.07; setTimeout(() => { if (this.pads.get(sid) === pad) pad.lift = this.hovered === sid ? 0.12 : 0; }, 130); }
       this.select(sid);
     } else {
@@ -1015,17 +1039,20 @@ class HiveWorld {
 
   private static GHOST = "\0ghost";          // impossible sid — the ghost's pick token
 
-  private pick(): string | null {
+  private pick(): { sid: string | null; bean: boolean } {
     this.raycaster.setFromCamera(this.pointer, this.camera);
-    let best: { sid: string; d: number } | null = null;
+    let best: { sid: string; d: number; bean: boolean } | null = null;
     for (const [sid, pad] of this.pads) {
       if (pad.dyingT >= 0) continue;
       const hits = this.raycaster.intersectObjects(pad.hitMeshes(), false);
-      if (hits.length && (!best || hits[0].distance < best.d)) best = { sid, d: hits[0].distance };
+      if (hits.length && (!best || hits[0].distance < best.d)) best = { sid, d: hits[0].distance, bean: false };
+      // the bean stands proud of its tile, so when both are under the pointer the bean wins
+      const bh = this.raycaster.intersectObjects(pad.beanMeshes(), false);
+      if (bh.length && (!best || bh[0].distance < best.d)) best = { sid, d: bh[0].distance, bean: true };
     }
     const gh = this.raycaster.intersectObject(this.ghostFill, false);
-    if (gh.length && (!best || gh[0].distance < best.d)) best = { sid: HiveWorld.GHOST, d: gh[0].distance };
-    if (best) return best.sid;
+    if (gh.length && (!best || gh[0].distance < best.d)) best = { sid: HiveWorld.GHOST, d: gh[0].distance, bean: false };
+    if (best) return { sid: best.sid, bean: best.bean };
     // nothing solid under the pointer: any EMPTY cell of the board is the invitation too —
     // the ghost glides to it and a clean click recruits there (the user 2026-08-13)
     const oy = this.raycaster.ray.origin.y, dy = this.raycaster.ray.direction.y;
@@ -1038,11 +1065,19 @@ class HiveWorld {
         const slot = slotOfAxial(cell);
         if (slot >= 0 && !new Set(this.slots.values()).has(slot)) {
           if (slot !== this.ghostSlot) this.ghostTo(slot);
-          return HiveWorld.GHOST;
+          return { sid: HiveWorld.GHOST, bean: false };
         }
       }
     }
-    return null;
+    return { sid: null, bean: false };
+  }
+
+  // the direct line to a session: its chat opens in the chat pane (left of the board),
+  // the hive stays put on the right — one message pair, used by the bean click, the
+  // card's Open, and dblclick alike
+  openChat(sid: string) {
+    vscodeApi?.postMessage({ type: "openSession", id: sid });
+    try { if (window.parent !== window) window.parent.postMessage({ romp: "reveal", pane: "chat" }, "*"); } catch { /* standalone */ }
   }
 
   // aim the ghost at a cell; frame() glides it there (everything springs, nothing teleports)
@@ -1221,7 +1256,7 @@ class HiveWorld {
     this.idleT += dt;
 
     // hover pick once per frame (not per pointermove — cheaper and steadier)
-    const sid = this.pick();
+    const sid = this.pick().sid;
     if (sid !== this.hovered) {
       const old = this.hovered && this.hovered !== HiveWorld.GHOST ? this.pads.get(this.hovered) : null;
       if (old) old.lift = 0;

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -14,7 +14,7 @@ import { delegate } from "./actions";
 import { hostPrefix } from "./host-prefix";
 import { loadSettings } from "./settings";
 import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexCorner, hexDistance, latticeSegments, PAD_R, PAD_THETA, RIM_THETA, ringOf, slotOfAxial, spiralSlot, xzToAxial } from "./hive-layout";
-import { buildSessions, diffSessions, finishedLine, foldSeenDone, HiveSession, HiveState, hiveAge, SeenDone, stateLine } from "./hive-model";
+import { buildSessions, diffSessions, finishedLine, foldSeenAsk, foldSeenDone, HiveSession, HiveState, hiveAge, SeenDone, stateLine } from "./hive-model";
 
 const vscodeApi =
   typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
@@ -82,6 +82,10 @@ class Pad {
   private bang: THREE.Sprite;              // the ❗ that bobs over a needs-you pad
   private tick: THREE.Sprite;              // the ✓ held up over an unseen-finished pad (HiveWorld sets unseenDone)
   unseenDone = false;                       // finished work the user hasn't gone to look at (foldSeenDone)
+  // a FILED ask the user has already looked at (foldSeenAsk): the ring keeps its honest red
+  // — the card still sits in the feed's needs-you column — but the SHOUT (bang/sonar/wave)
+  // stops. A live prompt is never acked (always now). HiveWorld.setAskAck drives this.
+  private askAck = false;
   private guy: Dweller;
   carrier = new THREE.Group();              // rides the pointer while the user carries them
   private carryTarget: THREE.Vector3 | null = null;
@@ -169,11 +173,24 @@ class Pad {
     // drag moves the carrier — so picking them up never fights the idle animation
     this.carrier.add(this.guy.group);
     this.group.add(this.carrier);
-    this.guy.setState(sess.state, sess.faded);
+    this.guy.setState(this.guyState(), sess.faded);
 
     this.group.scale.setScalar(0.001);      // arrival pop plays from ~zero
     this.ringColor.setHex(ST[sess.state]);
     this.ringTarget.setHex(ST[sess.state]);
+  }
+
+  // the pose the bean acts out: an ACKNOWLEDGED filed ask stands calm (ready) under its red
+  // ring — the wave is part of the shout, and the shout is for unseen needs-you only
+  private guyState(): HiveState {
+    return this.sess.state === "awaiting" && this.askAck ? "ready" : this.sess.state;
+  }
+
+  // the user's look (or a new filed ask) flips the shout without any chip state change
+  setAskAck(ack: boolean) {
+    if (this.askAck === ack) return;
+    this.askAck = ack;
+    if (this.sess.state === "awaiting") this.guy.setState(this.guyState(), this.sess.faded);
   }
 
   // a real state/name change arrived (diff event) — retarget; update() animates the morph
@@ -182,7 +199,7 @@ class Pad {
     this.sess = sess;
     if (stateChanged) {
       this.ringTarget.setHex(ST[sess.state]);
-      this.guy.setState(sess.state, sess.faded);
+      this.guy.setState(this.guyState(), sess.faded);
     }
     if (sess.name !== prevName || sess.color?.bg !== prevColor) {
       this.labelYaw.remove(this.labelMesh);
@@ -262,12 +279,15 @@ class Pad {
     const st = this.sess.state;
     // pulse only the states that are genuinely in motion; steady states hold steady
     if (st === "working") this.ringMat.opacity = 0.62 + 0.3 * (0.5 + 0.5 * Math.sin(this.t * 3.6));
-    else if (st === "awaiting") this.ringMat.opacity = 0.55 + 0.45 * (0.5 + 0.5 * Math.sin(this.t * 7));
+    else if (st === "awaiting" && !this.askAck) this.ringMat.opacity = 0.55 + 0.45 * (0.5 + 0.5 * Math.sin(this.t * 7));   // acked → the steady red below
     else if (st === "retrying") this.ringMat.opacity = 0.5 + 0.5 * (Math.sin(this.t * 11) > 0.2 ? 1 : 0.35);
     else this.ringMat.opacity = 0.95;
 
-    if (st === "awaiting") {
-      // sonar ping: 1.4s loop, ring swells to ~1.8× and fades — visible from any zoom
+    if (st === "awaiting" && !this.askAck) {
+      // the SHOUT — sonar ping (1.4s loop, ring swells ~1.8× and fades, visible from any
+      // zoom) + the bobbing ❗ — is for needs-you the user hasn't seen: a live prompt, or a
+      // filed question they haven't looked at. Once looked at, the red ring alone carries
+      // the standing fact (the user 2026-08-14: last night's asks kept shouting as if live).
       const p = (this.t % 1.4) / 1.4;
       this.sonarMat.opacity = (1 - p) * 0.5;
       this.sonar.scale.setScalar(1 + p * 0.85);
@@ -894,9 +914,10 @@ class HiveWorld {
   private dragging: { mode: "orbit" | "pan"; x: number; y: number } | null = null;
   private clock = 0;
   card = new HiveCard();
-  // per-sid completion watermarks the user has LOOKED at (localStorage — the latch survives
-  // a reload); foldSeenDone derives the unseen set from these each payload
-  private seenDone: SeenDone = loadSeenDone();
+  // per-sid completion/ask watermarks the user has LOOKED at (localStorage — the latch
+  // survives a reload); foldSeenDone / foldSeenAsk derive the unseen sets each payload
+  private seenDone: SeenDone = loadSeen(SEEN_DONE_KEY);
+  private seenAsk: SeenDone = loadSeen(SEEN_ASK_KEY);
   // the ghost hex: the standing invitation. It parks on the first FREE slot, and GLIDES
   // under the pointer whenever any empty cell is hovered — every empty hexagon is
   // clickable to spawn a session there (the user 2026-08-13). A clean click (down+up,
@@ -1396,16 +1417,24 @@ class HiveWorld {
   }
 
   // The user's own gesture toward a session — the ONE event that clears its finished note
-  // (never a timer, never a re-render): the watermark advances to the completion they just
-  // went to see, persisted so a reload can't resurrect an acknowledged ✓. Known gap, on
-  // purpose for now: reading the outcome in the chat/feed PANES doesn't reach this board,
-  // so the note can outlive a look that happened elsewhere — one click here retires it.
+  // and quiets a filed ask's shout (never a timer, never a re-render): both watermarks
+  // advance to the evidence they just went to see, persisted so a reload can't resurrect an
+  // acknowledged cue. Known gap, on purpose for now: reading the outcome in the chat/feed
+  // PANES doesn't reach this board, so a cue can outlive a look that happened elsewhere —
+  // one click here retires it.
   private lookedAt(sid: string) {
     const pad = this.pads.get(sid);
-    if (!pad || pad.sess.doneT <= (this.seenDone[sid] ?? 0)) return;
-    this.seenDone[sid] = pad.sess.doneT;
-    pad.unseenDone = false;
-    saveSeenDone(this.seenDone);
+    if (!pad) return;
+    if (pad.sess.doneT > (this.seenDone[sid] ?? 0)) {
+      this.seenDone[sid] = pad.sess.doneT;
+      pad.unseenDone = false;
+      saveSeen(SEEN_DONE_KEY, this.seenDone);
+    }
+    if (pad.sess.needsYouT > (this.seenAsk[sid] ?? 0)) {
+      this.seenAsk[sid] = pad.sess.needsYouT;
+      pad.setAskAck(pad.sess.state === "awaiting" && !pad.sess.liveAsk);
+      saveSeen(SEEN_ASK_KEY, this.seenAsk);
+    }
   }
 
   // aim the ghost at a cell; frame() glides it there (everything springs, nothing teleports)
@@ -1525,7 +1554,21 @@ class HiveWorld {
       const pad = this.pads.get(s.sid);
       if (pad) pad.unseenDone = fold.unseen.has(s.sid);
     }
-    if (seenChanged) saveSeenDone(this.seenDone);
+    if (seenChanged) saveSeen(SEEN_DONE_KEY, this.seenDone);
+    // …and its ASK twin (foldSeenAsk): a filed question shouts until looked at, then the pad
+    // keeps its red ring and calms. A live prompt (liveAsk) never acks — it is now.
+    const ask = foldSeenAsk(this.seenAsk, sessions);
+    this.seenAsk = ask.seen;
+    let askChanged = ask.changed;
+    if (this.selected && ask.unseen.has(this.selected)) {
+      const s = bySid.get(this.selected);
+      if (s && !s.liveAsk) { this.seenAsk[this.selected] = s.needsYouT; ask.unseen.delete(this.selected); askChanged = true; }
+    }
+    for (const s of sessions) {
+      const pad = this.pads.get(s.sid);
+      if (pad) pad.setAskAck(s.state === "awaiting" && !s.liveAsk && !ask.unseen.has(s.sid));
+    }
+    if (askChanged) saveSeen(SEEN_ASK_KEY, this.seenAsk);
     for (const sid of diff.goalDone) {
       const pad = this.pads.get(sid);
       if (pad) {
@@ -1736,20 +1779,22 @@ function saveSlots(m: Map<string, number>) {
   } catch { /* private mode etc — the board still works, it just re-deals on reload */ }
 }
 
-// unseen-finished persistence: the same memory policy as the slot map — the latch must
-// survive a reload (stepping away is safe), absentees keep their stamps for revival, and
-// foldSeenDone bounds the record. Unreadable/private-mode storage just resets the cues.
-const SEEN_KEY = "romp:hiveSeenDone";
-function loadSeenDone(): SeenDone {
+// unseen-cue persistence (the finished ✓ and the filed-ask shout share one shape): the same
+// memory policy as the slot map — the latch must survive a reload (stepping away is safe),
+// absentees keep their stamps for revival, and the folds bound the records. Unreadable /
+// private-mode storage just resets the cues.
+const SEEN_DONE_KEY = "romp:hiveSeenDone";
+const SEEN_ASK_KEY = "romp:hiveSeenAsk";
+function loadSeen(key: string): SeenDone {
   try {
-    const d = JSON.parse(localStorage.getItem(SEEN_KEY) || "null");
+    const d = JSON.parse(localStorage.getItem(key) || "null");
     const out: SeenDone = {};
     if (d && typeof d === "object") for (const k of Object.keys(d)) if (Number.isFinite(d[k])) out[k] = d[k];
     return out;
   } catch { return {}; }
 }
-function saveSeenDone(m: SeenDone) {
-  try { localStorage.setItem(SEEN_KEY, JSON.stringify(m)); } catch { /* see saveSlots */ }
+function saveSeen(key: string, m: SeenDone) {
+  try { localStorage.setItem(key, JSON.stringify(m)); } catch { /* see saveSlots */ }
 }
 
 // ── boot ─────────────────────────────────────────────────────────────────────────────────

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -1190,11 +1190,20 @@ class HiveWorld {
   }
 
   // the direct line to a session: its chat opens in the chat pane (left of the board),
-  // the hive stays put on the right — one message pair, used by the bean click, the
-  // card's Open, and dblclick alike
+  // the hive stays put on the right — one path, used by the bean click, the card's Open,
+  // and dblclick alike. TWO legs: the shell relay flips the chat's tab INSTANTLY (pure
+  // client-side, no kernel round trip — the user 2026-08-13, truly reactive), then the
+  // kernel op follows for everything else it does (eager-connect, other dashboards, the
+  // dead-session revive prompt). Board sessions are live, so the local flip is never
+  // showing something the kernel would have refused.
   openChat(sid: string) {
+    try {
+      if (window.parent !== window) {
+        window.parent.postMessage({ romp: "focusChat", id: sid }, "*");
+        window.parent.postMessage({ romp: "reveal", pane: "chat" }, "*");
+      }
+    } catch { /* standalone */ }
     vscodeApi?.postMessage({ type: "openSession", id: sid });
-    try { if (window.parent !== window) window.parent.postMessage({ romp: "reveal", pane: "chat" }, "*"); } catch { /* standalone */ }
   }
 
   // aim the ghost at a cell; frame() glides it there (everything springs, nothing teleports)

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -12,6 +12,7 @@ import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
 import { delegate } from "./actions";
 import { hostPrefix } from "./host-prefix";
+import { loadSettings } from "./settings";
 import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexCorner, hexDistance, latticeSegments, PAD_R, PAD_THETA, RIM_THETA, ringOf, slotOfAxial, spiralSlot, xzToAxial } from "./hive-layout";
 import { buildSessions, diffSessions, HiveSession, HiveState, hiveAge, stateLine } from "./hive-model";
 
@@ -1232,7 +1233,13 @@ class HiveWorld {
     this.reservedSlot = slot;
     const p = axialToXZ(spiralSlot(slot), HEX_SIZE);
     this.particles.burst(new THREE.Vector3(p.x, 0.6, p.z), [ACCENT, 0xd6ecff], 16, 1.8);
-    vscodeApi?.postMessage({ type: "createSession", name: this.autoName(model), backend: "sdk", model, effort });
+    // backend: the ONE gear default every create surface reads (the user 2026-08-13) — the tray used to
+    // hardcode "sdk", so a board set to terminal sessions still dropped SDK ones. host: the default
+    // create machine, which the federation manager routes on (the field is stripped before the kernel
+    // sees it); absent = this machine, exactly as before.
+    const host = SPAWN_DEFAULTS.host || "";
+    vscodeApi?.postMessage({ type: "createSession", name: this.autoName(model),
+                             backend: loadSettings().backend, model, effort, ...(host ? { host } : {}) });
   }
 
   // In-place board rename (the user 2026-08-13, who wanted renaming to feel like a great
@@ -1723,7 +1730,10 @@ window.addEventListener("message", (e: MessageEvent) => {
 interface SpawnChoice { value: string; label: string }
 let SPAWN_MODELS: SpawnChoice[] = [];
 let SPAWN_EFFORTS: string[] = [];
-const SPAWN_DEFAULTS: { model?: string; effort?: string } = {};
+// The remembered new-session seed (model + effort) AND the machine a drop lands on — all three from
+// /models, so the tray and the + picker spawn the same way without asking two endpoints. `host` absent
+// = this machine (the user 2026-08-13: a drop should land where their sessions actually live).
+const SPAWN_DEFAULTS: { model?: string; effort?: string; host?: string } = {};
 let trayBuilt = false;
 
 fetch("/models", { cache: "no-store" }).then((r) => r.json()).then((d) => {

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -10,8 +10,9 @@ import * as THREE from "three";
 import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
 import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
+import { delegate } from "./actions";
 import { assignSlots, axialToXZ, frameDt, frameRadius, spiralSlot } from "./hive-layout";
-import { buildSessions, diffSessions, HiveSession, HiveState } from "./hive-model";
+import { buildSessions, diffSessions, HiveSession, HiveState, hiveAge, stateLine } from "./hive-model";
 
 const vscodeApi =
   typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
@@ -571,6 +572,106 @@ class Particles {
   }
 }
 
+// ── the fly-in card: the session's gist + a talk composer (plans/hive.md) ────────────────
+// DOM, not WebGL — readable text belongs to the page. Created ONCE and updated in place
+// (never rebuilt per push), actions delegated to the stable card root (./actions), so
+// clicks are click-safe by construction and every press flashes.
+class HiveCard {
+  el: HTMLElement;
+  private dot: HTMLElement; private name: HTMLElement; private state: HTMLElement;
+  private goal: HTMLElement; private brief: HTMLElement; private err: HTMLElement;
+  private input: HTMLTextAreaElement; private sendBtn: HTMLButtonElement;
+  sid: string | null = null;
+  onSend: (sid: string, text: string) => void = () => {};
+  onOpen: (sid: string) => void = () => {};
+  onClose: () => void = () => {};
+
+  constructor() {
+    const el = document.createElement("div");
+    el.id = "hive-card";
+    el.innerHTML =
+      '<div class="hc-head"><span class="hc-dot"></span><span class="hc-name"></span>' +
+      '<button class="hc-x" data-act="close" title="Back to the board (Esc)" aria-label="Close">×</button></div>' +
+      '<div class="hc-state"></div>' +
+      '<div class="hc-goal" hidden></div>' +
+      '<div class="hc-brief" hidden></div>' +
+      '<div class="hc-err" hidden></div>' +
+      '<div class="hc-talk"><textarea class="hc-input" rows="2"></textarea>' +
+      '<button class="hc-send" data-act="send">Send</button></div>' +
+      '<div class="hc-foot"><button class="hc-open" data-act="open">Open session ↗</button></div>';
+    document.body.appendChild(el);
+    this.el = el;
+    this.dot = el.querySelector(".hc-dot") as HTMLElement;
+    this.name = el.querySelector(".hc-name") as HTMLElement;
+    this.state = el.querySelector(".hc-state") as HTMLElement;
+    this.goal = el.querySelector(".hc-goal") as HTMLElement;
+    this.brief = el.querySelector(".hc-brief") as HTMLElement;
+    this.err = el.querySelector(".hc-err") as HTMLElement;
+    this.input = el.querySelector(".hc-input") as HTMLTextAreaElement;
+    this.sendBtn = el.querySelector(".hc-send") as HTMLButtonElement;
+    delegate(el, {
+      close: () => this.onClose(),
+      open: () => { if (this.sid) this.onOpen(this.sid); },
+      send: () => this.send(),
+    });
+    this.input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); this.send(); }
+      e.stopPropagation();                   // typing must never orbit the camera / close the card
+    });
+  }
+
+  private send() {
+    const sid = this.sid, text = this.input.value.trim();
+    if (!sid || !text) return;
+    this.onSend(sid, text);
+    // acknowledge NOW, before any kernel round-trip: the composer clears, the button says
+    // so, and the world fires the send-puff at the hex (the delivery itself is the kernel's
+    // normal park/forward — a refusal comes back as an err and lands in hc-err below)
+    this.input.value = "";
+    this.err.hidden = true;
+    const b = this.sendBtn;
+    b.disabled = true; b.textContent = "Sent ✓";
+    setTimeout(() => { b.disabled = false; b.textContent = "Send"; }, 1100);
+  }
+
+  show(s: HiveSession, now: number) {
+    const fresh = this.sid !== s.sid;
+    this.sid = s.sid;
+    this.refresh(s, now);
+    if (fresh) { this.err.hidden = true; this.input.value = ""; }
+    this.el.classList.add("open");
+    this.input.placeholder = "Say something to " + s.name + "…";
+    if (fresh) this.input.focus();
+  }
+
+  refresh(s: HiveSession, now: number) {
+    if (this.sid !== s.sid) return;
+    this.dot.style.background = s.color?.bg || "#8a8a8a";
+    this.name.textContent = s.name;
+    this.name.style.color = s.color?.bg || "#dddddd";
+    this.state.textContent = stateLine(s, now);
+    this.state.dataset.state = s.state;
+    this.goal.hidden = !s.goal;
+    if (s.goal) this.goal.textContent = s.goal;
+    const needsYou = s.state === "awaiting" || s.state === "blocked";
+    this.brief.hidden = !(s.brief && needsYou);
+    if (s.brief && needsYou) this.brief.textContent = s.brief;
+  }
+
+  gone() {
+    // the selected session left the board — say so rather than silently going stale
+    this.state.textContent = "this session has ended";
+    this.state.dataset.state = "";
+  }
+
+  error(title: string, text: string) {
+    this.err.hidden = false;
+    this.err.textContent = title + (text ? " — " + text : "");
+  }
+
+  hide() { this.sid = null; this.el.classList.remove("open"); }
+}
+
 // ── the world ────────────────────────────────────────────────────────────────────────────
 class HiveWorld {
   private renderer: THREE.WebGLRenderer;
@@ -597,6 +698,7 @@ class HiveWorld {
   private lastFrame = 0;
   private dragging: { mode: "orbit" | "pan"; x: number; y: number } | null = null;
   private clock = 0;
+  card = new HiveCard();
 
   constructor(private root: HTMLElement) {
     this.renderer = new THREE.WebGLRenderer({ antialias: true });
@@ -680,6 +782,21 @@ class HiveWorld {
     io.observe(root);
     document.addEventListener("visibilitychange", () => this.ensureLoop());
     this.ensureLoop();
+
+    this.card.onClose = () => this.deselect();
+    this.card.onOpen = (sid) => {
+      vscodeApi?.postMessage({ type: "openSession", id: sid });
+      try { if (window.parent !== window) window.parent.postMessage({ romp: "reveal", pane: "chat" }, "*"); } catch { /* standalone */ }
+    };
+    this.card.onSend = (sid, text) => {
+      vscodeApi?.postMessage({ type: "sendMessage", id: sid, text });
+      const pad = this.pads.get(sid);
+      if (pad) {
+        // the visible delivery: a little accent spark shower over their hex
+        const at = pad.group.position.clone().setY(PAD_H + 1.6);
+        this.particles.burst(at, [ACCENT, 0xd6ecff, 0x6fb7ff], 14, 1.6);
+      }
+    };
     (window as any).__hive = this;           // debug handle (harness + console poking)
   }
 
@@ -740,11 +857,13 @@ class HiveWorld {
       this.dist = 10.5;
       this.pitch = 0.62;
       this.idleT = 0;
+      this.card.show(pad.sess, Math.floor(Date.now() / 1000));
     }
   }
   deselect() {
     if (this.selected === null) return;
     this.selected = null;
+    this.card.hide();
     this.frameAll();
   }
 
@@ -794,7 +913,7 @@ class HiveWorld {
     for (const sid of diff.removed) {
       const pad = this.pads.get(sid);
       if (pad && pad.dyingT < 0) pad.dyingT = 0;   // departure plays; disposal in the loop
-      if (this.selected === sid) this.deselect();
+      if (this.selected === sid) { this.card.gone(); this.selected = null; this.frameAll(); }
       if (this.hovered === sid) this.hovered = null;
     }
     for (const sid of diff.added) {
@@ -804,9 +923,11 @@ class HiveWorld {
       this.scene.add(pad.group);
     }
     const changed = new Set(diff.stateChanged.map((c) => c.sid));
+    const nowS = Math.floor(Date.now() / 1000);
     for (const s of sessions) {
       const pad = this.pads.get(s.sid);
       if (pad && !diff.added.includes(s.sid)) pad.apply(s, changed.has(s.sid));
+      if (this.selected === s.sid) this.card.refresh(s, nowS);
     }
     for (const sid of diff.goalDone) {
       const pad = this.pads.get(sid);
@@ -914,7 +1035,14 @@ let firstPayload = true;
 
 window.addEventListener("message", (e: MessageEvent) => {
   const m = e.data;
-  if (!m || m.type !== "feed") return;
+  if (!m) return;
+  // a refused drive op (foreign sid, dead kernel) comes back as an err — surface it on the
+  // card instead of letting the send silently vanish (the fail-loudly rule)
+  if (m.type === "err" && world && world.card.sid && (!m.sid || m.sid === world.card.sid)) {
+    world.card.error(String(m.title || "That message was not delivered"), String(m.text || ""));
+    return;
+  }
+  if (m.type !== "feed") return;
   const sessions = buildSessions(m);
   if (sessions === null) return;             // ledgers not built yet → loader stays up
   const root = document.getElementById("hive-root");

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -43,6 +43,8 @@ const PAD_H = 0.06;           // a hair of thickness so a lifted tile isn't pape
 const LABEL_W_MAX = 2.7;
 const LABEL_H = 0.4;
 const LABEL_FRONT = 0.92;     // parked in the camera-side half of the cell, clear of the bean
+const CARRY_Y = 1.05;         // the flat plane a carried bean rides — parallel to the board,
+                              // so cursor→bean stays projectively exact anywhere on screen
 // Tron world (the user 2026-08-13): near-black glossy ground with a faint accent grid, the
 // pads dark slabs whose STATUS light is their glowing rim, bloom doing the neon work. The
 // beans stay cute (session-colored, softly self-lit) with dark visors and glowing eyes.
@@ -219,7 +221,7 @@ class Pad {
     // springs home — the same everything-springs rule as the rest of the board
     if (this.carryTarget) this.carryWant.copy(this.carryTarget).sub(this.group.position);
     else this.carryWant.set(0, 0, 0);
-    this.carrier.position.lerp(this.carryWant, 1 - Math.exp(-16 * dt));
+    this.carrier.position.lerp(this.carryWant, 1 - Math.exp(-30 * dt));   // tight to the hand
     const cs = this.carryTarget ? 1.12 : 1;
     this.carrier.scale.x = ease(this.carrier.scale.x, cs, dt, 12);
     this.carrier.scale.y = this.carrier.scale.z = this.carrier.scale.x;
@@ -874,7 +876,7 @@ class HiveWorld {
   // the armed dock ends the session — the deliberate carry + highlighted dock IS the
   // confirmation (and an ended session still revives with its history from the picker).
   private pressedPad: { sid: string; x: number; y: number; bean: boolean } | null = null;
-  private dragSession: { sid: string; depth: number; over: boolean } | null = null;
+  private dragSession: { sid: string; over: boolean } | null = null;
   private trashEl: HTMLElement;
   private ghostRingMat = new THREE.LineBasicMaterial({
     color: ACCENT, transparent: true, opacity: 0.14, blending: THREE.AdditiveBlending, depthWrite: false,
@@ -1101,8 +1103,9 @@ class HiveWorld {
   private beginSessionDrag(sid: string) {
     const pad = this.pads.get(sid);
     if (!pad || pad.dyingT >= 0) return;
-    // carry at the pad's own camera depth, so the bean stays screen-true under the cursor
-    this.dragSession = { sid, depth: this.camera.position.distanceTo(pad.group.position), over: false };
+    // the carry position itself is recomputed EVERY FRAME (see frame()) so the bean stays
+    // pinned under the cursor no matter how the camera eases; the event only arms the dock
+    this.dragSession = { sid, over: false };
     pad.lift = 0;
     const label = this.trashEl.querySelector(".ht-label") as HTMLElement;
     label.textContent = "Drop to end " + pad.sess.name;
@@ -1114,10 +1117,6 @@ class HiveWorld {
     const d = this.dragSession!;
     const pad = this.pads.get(d.sid);
     if (!pad || pad.dyingT >= 0) { this.dropSessionDrag(false); return; }
-    const p = new THREE.Vector3(this.pointer.x, this.pointer.y, 0.5).unproject(this.camera)
-      .sub(this.camera.position).normalize().multiplyScalar(d.depth).add(this.camera.position);
-    if (p.y < 0.4) p.y = 0.4;                // never carried below the board
-    pad.carryTo(p);
     const r = this.trashEl.getBoundingClientRect();
     const over = e.clientX >= r.left - 14 && e.clientX <= r.right + 14 && e.clientY >= r.top - 14;
     if (over !== d.over) { d.over = over; this.trashEl.classList.toggle("armed", over); }
@@ -1396,6 +1395,22 @@ class HiveWorld {
       this.targetCur.z + this.distCur * Math.cos(this.pitchCur) * Math.cos(this.yawCur),
     );
     this.camera.lookAt(this.targetCur);
+
+    // a carried bean is re-pinned under the CURSOR every frame — here, after the camera
+    // eases, not per pointer event — so nothing (spring, idle drift, a still pointer) can
+    // pull it out from under the pointer. Intersecting the flat CARRY_Y plane keeps the
+    // cursor→bean mapping exact anywhere on screen (the user 2026-08-13: it drifted).
+    if (this.dragSession) {
+      this.idleT = 0;                        // holding someone is not idle — no board sway mid-carry
+      const pad = this.pads.get(this.dragSession.sid);
+      if (pad && pad.dyingT < 0) {
+        this.camera.updateMatrixWorld();
+        const o = this.camera.position;
+        const v = new THREE.Vector3(this.pointer.x, this.pointer.y, 0.5).unproject(this.camera).sub(o).normalize();
+        const t = (CARRY_Y - o.y) / v.y;
+        if (t > 0) pad.carryTo(new THREE.Vector3(o.x + v.x * t, CARRY_Y, o.z + v.z * t));
+      }
+    }
 
     // ambient emitters, event-free by design: smoke while blocked, zzz while dozing — a
     // steady drizzle tied to the CURRENT state, not a transition (they stop the moment the

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -83,6 +83,7 @@ class Pad {
   carrier = new THREE.Group();              // rides the pointer while the user carries them
   private carryTarget: THREE.Vector3 | null = null;
   private carryWant = new THREE.Vector3(); // scratch — no per-frame allocation
+  private homeX = 0; private homeZ = 0;    // the pad's cell — eased toward, so a re-home GLIDES
   private baseY = 0;
   lift = 0;                                 // hover/press target offset, eased in update()
   private liftCur = 0;
@@ -97,6 +98,7 @@ class Pad {
     this.sess = sess;
     const { x, z } = axialToXZ(spiralSlot(slot), HEX_SIZE);
     this.group.position.set(x, 0, z);
+    this.homeX = x; this.homeZ = z;
 
     const tint = new THREE.Color(sess.color?.bg || "#8a8a8a");
     // Tron slab: near-black glossy top with only a whisper of the identity color; the
@@ -184,6 +186,8 @@ class Pad {
 
   // world-space carry target while the user drags them; null → spring home (update() eases)
   carryTo(p: THREE.Vector3 | null) { this.carryTarget = p ? p.clone() : null; }
+  // move the pad's HOME to another cell (drag-to-re-home, the user 2026-08-13); update() glides it
+  homeTo(x: number, z: number) { this.homeX = x; this.homeZ = z; }
   beanWorldPos(): THREE.Vector3 { return this.carrier.getWorldPosition(new THREE.Vector3()); }
   consumeBean() {
     this.guy.group.visible = false;
@@ -216,6 +220,9 @@ class Pad {
     }
     this.liftCur = ease(this.liftCur, this.lift, dt, 14);
     this.group.position.y = this.liftCur;
+    // the tile glides to its home cell (a re-home moves it; at rest this is a no-op)
+    this.group.position.x = ease(this.group.position.x, this.homeX, dt, 10);
+    this.group.position.z = ease(this.group.position.z, this.homeZ, dt, 10);
 
     // carried: the bean rides the pointer (world target → pad-local); released, it
     // springs home — the same everything-springs rule as the rest of the board
@@ -880,6 +887,8 @@ class HiveWorld {
   private trashEl: HTMLElement;
   private tipEl: HTMLElement;
   private tipText = "";
+  private noteEl: HTMLElement;
+  private noteT = 0;
   private ghostRingMat = new THREE.LineBasicMaterial({
     color: ACCENT, transparent: true, opacity: 0.14, blending: THREE.AdditiveBlending, depthWrite: false,
   });
@@ -945,7 +954,7 @@ class HiveWorld {
     });
     window.addEventListener("keydown", (e) => {
       if (e.key !== "Escape") return;
-      if (this.dragSession) { this.dropSessionDrag(false); return; }   // Esc aborts a carry
+      if (this.dragSession) { this.dropSessionDrag(false, true); return; }   // Esc aborts a carry
       this.deselect();
     });
 
@@ -966,6 +975,12 @@ class HiveWorld {
     this.tipEl.id = "hive-tip";
     this.tipEl.innerHTML = '<span class="tip-dot"></span><span class="tip-state"></span>';
     document.body.appendChild(this.tipEl);
+
+    // the board-level notice: kernel refusals that arrive with NO card open land here
+    // instead of vanishing (fail loudly) — a transient line, never a modal
+    this.noteEl = document.createElement("div");
+    this.noteEl.id = "hive-note";
+    document.body.appendChild(this.noteEl);
 
     const fit = () => {
       const w = root.clientWidth || 1, h = root.clientHeight || 1;
@@ -1122,13 +1137,13 @@ class HiveWorld {
   private moveSessionDrag(e: PointerEvent) {
     const d = this.dragSession!;
     const pad = this.pads.get(d.sid);
-    if (!pad || pad.dyingT >= 0) { this.dropSessionDrag(false); return; }
+    if (!pad || pad.dyingT >= 0) { this.dropSessionDrag(false, true); return; }
     const r = this.trashEl.getBoundingClientRect();
     const over = e.clientX >= r.left - 14 && e.clientX <= r.right + 14 && e.clientY >= r.top - 14;
     if (over !== d.over) { d.over = over; this.trashEl.classList.toggle("armed", over); }
   }
 
-  private dropSessionDrag(over: boolean) {
+  private dropSessionDrag(over: boolean, cancel = false) {
     const d = this.dragSession;
     this.dragSession = null;
     this.trashEl.classList.remove("show", "armed");
@@ -1145,9 +1160,67 @@ class HiveWorld {
       pad.consumeBean();
       pad.dyingT = 0.26;
       if (this.selected === d.sid) this.deselect();
-    } else {
-      pad.carryTo(null);                     // anywhere else: they spring home, no harm done
+      return;
     }
+    // a FREE cell under the drop re-homes them there (the user 2026-08-13, who wanted to
+    // choose where each session lives): the user's own gesture is the one sanctioned move
+    // event for a session's hex, and the slot map + localStorage move with it so the new
+    // home survives reloads. Esc / a dying pad / anywhere else springs them home unharmed.
+    const slot = cancel || pad.dyingT >= 0 ? null : this.freeCellAt();
+    if (slot !== null) this.rehome(d.sid, slot, pad);
+    else pad.carryTo(null);
+  }
+
+  private rehome(sid: string, slot: number, pad: Pad) {
+    this.slots.set(sid, slot);
+    saveSlots(loadSlots(this.slots));        // merge-persist, same shape sync() keeps
+    const p = axialToXZ(spiralSlot(slot), HEX_SIZE);
+    pad.homeTo(p.x, p.z);                    // the tile glides; the bean springs down onto it
+    pad.carryTo(null);
+    // the ghost's park may be stale now (the move may have taken or freed its cell)
+    let free = 0;
+    const taken = new Set(this.slots.values());
+    while (taken.has(free)) free++;
+    this.ghostHome = free;
+    if (this.hovered !== HiveWorld.GHOST) this.ghostTo(free);
+  }
+
+  // ── the tray (model beans): spawn-drag support ─────────────────────────────────────────
+  // The tray lives in the page DOM (buildTray below); these are the board-side halves.
+  trayHover(clientX: number, clientY: number): number | null {
+    const slot = this.freeCellAt(clientX, clientY);
+    if (slot !== null && slot !== this.ghostSlot) this.ghostTo(slot);
+    return slot;
+  }
+
+  autoName(alias: string): string {
+    // smallest free "<alias>-<n>" among the names on the board (bare names — a remote's
+    // host: prefix is viewer metadata, and collisions only matter on the owning kernel)
+    const used = new Set([...this.pads.values()].map((p) => {
+      const h = hostPrefix(p.sess.name, p.sess.sid);
+      return h ? h.rest : p.sess.name;
+    }));
+    let n = 1;
+    while (used.has(alias + "-" + n)) n++;
+    return alias + "-" + n;
+  }
+
+  spawnAt(slot: number, model: string, effort: string) {
+    // the dropped bean claims the cell (the same reservation a recruit click makes), the
+    // spark acknowledges, and the kernel's own createSession does the real work — an SDK
+    // session with THIS model+effort outranking the remembered seed for this one session
+    this.reservedSlot = slot;
+    const p = axialToXZ(spiralSlot(slot), HEX_SIZE);
+    this.particles.burst(new THREE.Vector3(p.x, 0.6, p.z), [ACCENT, 0xd6ecff], 16, 1.8);
+    vscodeApi?.postMessage({ type: "createSession", name: this.autoName(model), backend: "sdk", model, effort });
+  }
+
+  // a transient board-level notice for refusals with no card open (fail loudly, never vanish)
+  note(text: string) {
+    this.noteEl.textContent = text;
+    this.noteEl.classList.add("show");
+    clearTimeout(this.noteT);
+    this.noteT = window.setTimeout(() => this.noteEl.classList.remove("show"), 4000);
   }
 
   private static GHOST = "\0ghost";          // impossible sid — the ghost's pick token
@@ -1168,21 +1241,32 @@ class HiveWorld {
     if (best) return { sid: best.sid, bean: best.bean };
     // nothing solid under the pointer: any EMPTY cell of the board is the invitation too —
     // the ghost glides to it and a clean click recruits there (the user 2026-08-13)
-    const oy = this.raycaster.ray.origin.y, dy = this.raycaster.ray.direction.y;
-    const t = dy !== 0 ? -oy / dy : -1;
-    if (t > 0) {
-      const px = this.raycaster.ray.origin.x + this.raycaster.ray.direction.x * t;
-      const pz = this.raycaster.ray.origin.z + this.raycaster.ray.direction.z * t;
-      const cell = xzToAxial(px, pz, HEX_SIZE);
-      if (hexDistance(cell, { q: 0, r: 0 }) <= this.latticeRings) {
-        const slot = slotOfAxial(cell);
-        if (slot >= 0 && !new Set(this.slots.values()).has(slot)) {
-          if (slot !== this.ghostSlot) this.ghostTo(slot);
-          return { sid: HiveWorld.GHOST, bean: false };
-        }
-      }
+    const slot = this.freeCellAt();
+    if (slot !== null) {
+      if (slot !== this.ghostSlot) this.ghostTo(slot);
+      return { sid: HiveWorld.GHOST, bean: false };
     }
     return { sid: null, bean: false };
+  }
+
+  // The FREE cell of the board under a point — the ONE ground-plane → cell mapping, shared
+  // by hover (pick), drop-to-re-home, and the tray's spawn-drag. With client coords given,
+  // the pointer NDC is refreshed first (tray drags arrive as window events, not canvas ones).
+  freeCellAt(clientX?: number, clientY?: number): number | null {
+    if (clientX !== undefined && clientY !== undefined) {
+      const r = this.renderer.domElement.getBoundingClientRect();
+      this.pointer.set(((clientX - r.left) / r.width) * 2 - 1, -((clientY - r.top) / r.height) * 2 + 1);
+    }
+    this.raycaster.setFromCamera(this.pointer, this.camera);
+    const oy = this.raycaster.ray.origin.y, dy = this.raycaster.ray.direction.y;
+    const t = dy !== 0 ? -oy / dy : -1;
+    if (t <= 0) return null;
+    const px = this.raycaster.ray.origin.x + this.raycaster.ray.direction.x * t;
+    const pz = this.raycaster.ray.origin.z + this.raycaster.ray.direction.z * t;
+    const cell = xzToAxial(px, pz, HEX_SIZE);
+    if (!(hexDistance(cell, { q: 0, r: 0 }) <= this.latticeRings)) return null;   // the visible board only
+    const slot = slotOfAxial(cell);
+    return slot >= 0 && !new Set(this.slots.values()).has(slot) ? slot : null;
   }
 
   // the direct line to a session: its chat opens in the chat pane (left of the board),
@@ -1523,11 +1607,19 @@ window.addEventListener("message", (e: MessageEvent) => {
     world.card.error(String(m.title || "That message was not delivered"), String(m.text || ""));
     return;
   }
-  // a refused op that answers as a warn (renameSession's bad-name reply) — same fail-loudly
-  // rule: this socket only carries replies to ops THIS page sent, so an open card is the
-  // one that asked
-  if (m.type === "warn" && world && world.card.sid) {
-    world.card.error(String(m.text || "That didn't take"), "");
+  // a refused op that answers as a warn (a bad rename, a refused default, a create the
+  // kernel won't take) — same fail-loudly rule: this socket only carries replies to ops
+  // THIS page sent. An open card owns it; otherwise the board-level note shows it.
+  if (m.type === "warn" && world) {
+    if (world.card.sid) world.card.error(String(m.text || "That didn't take"), "");
+    else world.note(String(m.text || "That didn't take"));
+    return;
+  }
+  // the kernel confirmed a default change (ours or another dashboard's tray) — re-mark
+  if (m.type === "spawnDefaults") {
+    if (m.model) SPAWN_DEFAULTS.model = String(m.model);
+    if (m.effort) SPAWN_DEFAULTS.effort = String(m.effort);
+    markTrayDefaults();
     return;
   }
   if (m.type !== "feed") return;
@@ -1535,10 +1627,104 @@ window.addEventListener("message", (e: MessageEvent) => {
   if (sessions === null) return;             // ledgers not built yet → loader stays up
   const root = document.getElementById("hive-root");
   if (!root) return;
-  if (!world) world = new HiveWorld(root);   // first real data: mount → _pane_spin fades
+  if (!world) { world = new HiveWorld(root); maybeBuildTray(); }   // first real data: mount → _pane_spin fades
   world.sync(sessions, firstPayload);
   firstPayload = false;
 });
+
+// ── the tray: one draggable bean per MODEL (the user 2026-08-13) ─────────────────────────
+// Config embedded in the board's own drag language: drag a bean onto a free hexagon and a
+// session with that model spawns there (SDK-backed, the dashboard-native kind); the badge
+// on each bean cycles its EFFORT; a clean CLICK makes that bean (model + effort) the
+// default every new session seeds from. Choices come from the kernel's /models — the ONE
+// list every picker shares — never a hardcoded copy here.
+interface SpawnChoice { value: string; label: string }
+let SPAWN_MODELS: SpawnChoice[] = [];
+let SPAWN_EFFORTS: string[] = [];
+const SPAWN_DEFAULTS: { model?: string; effort?: string } = {};
+let trayBuilt = false;
+
+fetch("/models", { cache: "no-store" }).then((r) => r.json()).then((d) => {
+  if (Array.isArray(d.models)) SPAWN_MODELS = d.models;
+  if (Array.isArray(d.efforts)) SPAWN_EFFORTS = d.efforts.map((e: SpawnChoice) => e.value);
+  Object.assign(SPAWN_DEFAULTS, d.defaults || {});
+  maybeBuildTray();
+}).catch(() => { /* standalone/VS Code host without a reachable kernel HTTP — no tray, board still works */ });
+
+function markTrayDefaults() {
+  document.querySelectorAll<HTMLElement>("#hive-tray .ht-bean").forEach((b) => {
+    b.classList.toggle("default", b.dataset.model === (SPAWN_DEFAULTS.model || ""));
+  });
+}
+
+function maybeBuildTray() {
+  if (trayBuilt || !world || !SPAWN_MODELS.length) return;
+  trayBuilt = true;
+  const tray = document.createElement("div");
+  tray.id = "hive-tray";
+  const effKey = "romp:hive-tray-efforts";
+  let effSel: Record<string, string> = {};
+  try { effSel = JSON.parse(localStorage.getItem(effKey) || "{}") || {}; } catch { /* fresh */ }
+  for (const mc of SPAWN_MODELS) {
+    const bean = document.createElement("div");
+    bean.className = "ht-bean";
+    bean.dataset.model = mc.value;
+    bean.title = "Drag onto a hexagon to spawn a " + mc.label +
+      " session there. Click to make it the default for new sessions.";
+    bean.innerHTML = '<div class="hb-body"><i></i><i></i></div><span class="hb-name">' + mc.label +
+      '</span><button class="hb-eff" title="Reasoning effort for sessions spawned from this bean"></button>';
+    const effBtn = bean.querySelector(".hb-eff") as HTMLButtonElement;
+    effBtn.textContent = effSel[mc.value] || SPAWN_DEFAULTS.effort || "high";
+    effBtn.addEventListener("click", (e) => {
+      e.stopPropagation();                   // the badge cycles effort; it never sets the default
+      const cur = SPAWN_EFFORTS.indexOf(effBtn.textContent || "");
+      effBtn.textContent = SPAWN_EFFORTS[(cur + 1) % Math.max(1, SPAWN_EFFORTS.length)] || "high";
+      effSel[mc.value] = effBtn.textContent!;
+      try { localStorage.setItem(effKey, JSON.stringify(effSel)); } catch { /* private mode */ }
+    });
+    bean.addEventListener("pointerdown", (e) => {
+      if ((e.target as HTMLElement).closest(".hb-eff")) return;
+      e.preventDefault();
+      const sx = e.clientX, sy = e.clientY;
+      let chip: HTMLElement | null = null;   // the carried copy; created once the press MOVES
+      const move = (ev: PointerEvent) => {
+        if (!chip && Math.hypot(ev.clientX - sx, ev.clientY - sy) > 6) {
+          chip = bean.cloneNode(true) as HTMLElement;
+          chip.classList.add("carried");
+          document.body.appendChild(chip);
+          bean.classList.add("lifted");
+        }
+        if (chip) {
+          chip.style.transform = "translate(" + ev.clientX + "px," + ev.clientY + "px) translate(-50%, -60%)";
+          world?.trayHover(ev.clientX, ev.clientY);   // the board's ghost glides to the target cell
+        }
+      };
+      const up = (ev: PointerEvent) => {
+        window.removeEventListener("pointermove", move);
+        window.removeEventListener("pointerup", up);
+        bean.classList.remove("lifted");
+        const effort = effBtn.textContent || "";
+        if (chip) {
+          chip.remove();
+          const slot = world ? world.trayHover(ev.clientX, ev.clientY) : null;
+          if (slot !== null && world) world.spawnAt(slot, mc.value, effort);
+        } else {
+          // clean click: this bean (model + its effort) becomes the seed for new sessions.
+          // Optimistic mark now; the kernel's spawnDefaults confirmation (or warn) corrects.
+          SPAWN_DEFAULTS.model = mc.value;
+          SPAWN_DEFAULTS.effort = effort;
+          markTrayDefaults();
+          vscodeApi?.postMessage({ type: "setSpawnDefaults", model: mc.value, effort });
+        }
+      };
+      window.addEventListener("pointermove", move);
+      window.addEventListener("pointerup", up);
+    });
+    tray.appendChild(bean);
+  }
+  document.body.appendChild(tray);
+  markTrayDefaults();
+}
 
 vscodeApi?.postMessage({ type: "ready" });   // ask the kernel for the connect-time push
 

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -878,6 +878,8 @@ class HiveWorld {
   private pressedPad: { sid: string; x: number; y: number; bean: boolean } | null = null;
   private dragSession: { sid: string; over: boolean } | null = null;
   private trashEl: HTMLElement;
+  private tipEl: HTMLElement;
+  private tipText = "";
   private ghostRingMat = new THREE.LineBasicMaterial({
     color: ACCENT, transparent: true, opacity: 0.14, blending: THREE.AdditiveBlending, depthWrite: false,
   });
@@ -956,6 +958,14 @@ class HiveWorld {
       '<path fill="currentColor" d="M9 3v1H4v2h16V4h-5V3H9zM6 8v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V8H6zm3 2h2v10H9V10zm4 0h2v10h-2V10z"/></svg>' +
       '<span class="ht-label">Drop to end</span>';
     document.body.appendChild(this.trashEl);
+
+    // the hover tip: the session's LIVE STATUS floating over the hovered bean — hover is
+    // the board's "one level deeper" (progressive disclosure); pointer-events none so it
+    // can never steal the hover it answers
+    this.tipEl = document.createElement("div");
+    this.tipEl.id = "hive-tip";
+    this.tipEl.innerHTML = '<span class="tip-dot"></span><span class="tip-state"></span>';
+    document.body.appendChild(this.tipEl);
 
     const fit = () => {
       const w = root.clientWidth || 1, h = root.clientHeight || 1;
@@ -1061,12 +1071,13 @@ class HiveWorld {
     if (sid) {
       const pad = this.pads.get(sid);
       if (pad) { pad.lift = -0.07; setTimeout(() => { if (this.pads.get(sid) === pad) pad.lift = this.hovered === sid ? 0.12 : 0; }, 130); }
-      // the BEAN switches chat ON THE DOWN — instant (the user 2026-08-13, everything
-      // responsive). The same press can still become a pick-up: the switch has already
-      // happened, and seeing their chat while you carry them is coherent. The TILE'S
-      // action (card + camera fly-in) stays on the clean UP — a fly-in mid-drag is chaos.
-      if (hit.bean && pad) {
-        pad.pokeBean();
+      // ANY press on an occupied cell switches chat ON THE DOWN — hexagon and bean alike,
+      // instant (the user 2026-08-13, twice); the bean adds its pop. The same press can
+      // still become a pick-up: the switch has already happened, and seeing their chat
+      // while you carry them is coherent. The TILE'S deeper level (card + camera fly-in)
+      // stays on the clean UP — a fly-in mid-drag is chaos.
+      if (pad) {
+        if (hit.bean) pad.pokeBean();
         this.openChat(sid);
       }
       this.pressedPad = { sid, x: e.clientX, y: e.clientY, bean: hit.bean };
@@ -1372,6 +1383,32 @@ class HiveWorld {
       if (nw) nw.lift = 0.12;
       this.ghostHover = sid === HiveWorld.GHOST;
       this.renderer.domElement.style.cursor = sid ? "pointer" : "default";
+    }
+    // the hover tip rides the hovered bean, saying exactly what the card's state line
+    // would — placed per frame (the bean bobs, the camera springs), text only on change
+    const tipPad = this.hovered && this.hovered !== HiveWorld.GHOST && !this.dragSession
+      ? this.pads.get(this.hovered) : null;
+    if (tipPad && tipPad.dyingT < 0) {
+      const p = tipPad.beanWorldPos();
+      p.y += 2.3;                            // above the bang's bob, clear of the head
+      p.project(this.camera);
+      if (p.z < 1) {
+        const rr = this.renderer.domElement.getBoundingClientRect();
+        this.tipEl.style.transform = "translate(-50%, -100%) translate(" +
+          ((p.x * 0.5 + 0.5) * rr.width + rr.left).toFixed(1) + "px, " +
+          ((0.5 - p.y * 0.5) * rr.height + rr.top).toFixed(1) + "px)";
+        this.tipEl.classList.add("show");
+        const line = stateLine(tipPad.sess, Math.floor(Date.now() / 1000));
+        if (line !== this.tipText) {
+          this.tipText = line;
+          (this.tipEl.querySelector(".tip-state") as HTMLElement).textContent = line;
+          (this.tipEl.querySelector(".tip-dot") as HTMLElement).style.background = tipPad.sess.color?.bg || "#8a8a8a";
+          this.tipEl.dataset.state = tipPad.sess.state;
+        }
+      } else this.tipEl.classList.remove("show");
+    } else {
+      this.tipEl.classList.remove("show");
+      this.tipText = "";
     }
     // the ghost glides to its aim (the hovered empty cell, or its park when the pointer
     // leaves the board) and breathes faintly, waking on hover

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -12,7 +12,7 @@ import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
 import { delegate } from "./actions";
 import { hostPrefix } from "./host-prefix";
-import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexCorner, latticeSegments, PAD_R, PAD_THETA, RIM_THETA, ringOf, spiralSlot } from "./hive-layout";
+import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, hexCorner, hexDistance, latticeSegments, PAD_R, PAD_THETA, RIM_THETA, ringOf, slotOfAxial, spiralSlot, xzToAxial } from "./hive-layout";
 import { buildSessions, diffSessions, HiveSession, HiveState, hiveAge, stateLine } from "./hive-model";
 
 const vscodeApi =
@@ -752,9 +752,16 @@ class HiveWorld {
   private dragging: { mode: "orbit" | "pan"; x: number; y: number } | null = null;
   private clock = 0;
   card = new HiveCard();
-  // the ghost hex: a faint outline on the first FREE slot — hover it and a "+" wakes up;
-  // click recruits (opens the new-session picker via the shell relay)
+  // the ghost hex: the standing invitation. It parks on the first FREE slot, and GLIDES
+  // under the pointer whenever any empty cell is hovered — every empty hexagon is
+  // clickable to spawn a session there (the user 2026-08-13). A clean click (down+up,
+  // no drag) recruits: it reserves the cell and opens the new-session picker.
   private ghost = new THREE.Group();
+  private ghostTarget = new THREE.Vector3();   // eased toward in frame() — the ghost glides
+  private ghostSlot = 0;                       // the cell the ghost is offering right now
+  private ghostHome = 0;                       // first-free slot — where it parks at rest
+  private reservedSlot: number | null = null;  // cell claimed by a click, honored in sync()
+  private pendingRecruit: { x: number; y: number; slot: number } | null = null;
   private ghostRingMat = new THREE.LineBasicMaterial({
     color: ACCENT, transparent: true, opacity: 0.14, blending: THREE.AdditiveBlending, depthWrite: false,
   });
@@ -808,7 +815,7 @@ class HiveWorld {
     const cv = this.renderer.domElement;
     cv.addEventListener("pointermove", (e) => this.onPointerMove(e));
     cv.addEventListener("pointerdown", (e) => this.onPointerDown(e));
-    window.addEventListener("pointerup", () => { this.dragging = null; });
+    window.addEventListener("pointerup", (e) => this.onPointerUp(e));
     cv.addEventListener("wheel", (e) => {
       e.preventDefault();
       this.dist = Math.min(70, Math.max(7, this.dist * Math.exp(e.deltaY * 0.0012)));
@@ -910,9 +917,10 @@ class HiveWorld {
     const sid = this.pick();
     if (e.button === 2 || e.shiftKey) { this.dragging = { mode: "pan", x: e.clientX, y: e.clientY }; return; }
     if (sid === HiveWorld.GHOST) {
-      // recruit: acknowledge with a spark on the ghost, then ask the shell for the picker
-      this.particles.burst(this.ghost.position.clone().setY(0.6), [ACCENT, 0xd6ecff], 16, 1.8);
-      try { if (window.parent !== window) window.parent.postMessage({ romp: "openPicker" }, "*"); } catch { /* standalone */ }
+      // recruit is decided on the UP (a clean click, not a drag) so the whole empty board
+      // stays grabbable for orbiting — the down arms the recruit AND starts the orbit
+      this.pendingRecruit = { x: e.clientX, y: e.clientY, slot: this.ghostSlot };
+      this.dragging = { mode: "orbit", x: e.clientX, y: e.clientY };
       return;
     }
     if (sid) {
@@ -923,6 +931,21 @@ class HiveWorld {
     } else {
       this.dragging = { mode: "orbit", x: e.clientX, y: e.clientY };
     }
+  }
+
+  private onPointerUp(e: PointerEvent) {
+    const pr = this.pendingRecruit;
+    this.pendingRecruit = null;
+    this.dragging = null;
+    if (!pr) return;
+    // a real drag is a camera move, not a click — the gate is the gesture itself (px
+    // travelled between down and up), never a timer
+    if (Math.hypot(e.clientX - pr.x, e.clientY - pr.y) > 5) return;
+    this.reservedSlot = pr.slot;
+    const p = axialToXZ(spiralSlot(pr.slot), HEX_SIZE);
+    // acknowledge NOW with a spark on the clicked cell, then ask the shell for the picker
+    this.particles.burst(new THREE.Vector3(p.x, 0.6, p.z), [ACCENT, 0xd6ecff], 16, 1.8);
+    try { if (window.parent !== window) window.parent.postMessage({ romp: "openPicker" }, "*"); } catch { /* standalone */ }
   }
 
   private static GHOST = "\0ghost";          // impossible sid — the ghost's pick token
@@ -937,7 +960,31 @@ class HiveWorld {
     }
     const gh = this.raycaster.intersectObject(this.ghostFill, false);
     if (gh.length && (!best || gh[0].distance < best.d)) best = { sid: HiveWorld.GHOST, d: gh[0].distance };
-    return best ? best.sid : null;
+    if (best) return best.sid;
+    // nothing solid under the pointer: any EMPTY cell of the board is the invitation too —
+    // the ghost glides to it and a clean click recruits there (the user 2026-08-13)
+    const oy = this.raycaster.ray.origin.y, dy = this.raycaster.ray.direction.y;
+    const t = dy !== 0 ? -oy / dy : -1;
+    if (t > 0) {
+      const px = this.raycaster.ray.origin.x + this.raycaster.ray.direction.x * t;
+      const pz = this.raycaster.ray.origin.z + this.raycaster.ray.direction.z * t;
+      const cell = xzToAxial(px, pz, HEX_SIZE);
+      if (hexDistance(cell, { q: 0, r: 0 }) <= this.latticeRings) {
+        const slot = slotOfAxial(cell);
+        if (slot >= 0 && !new Set(this.slots.values()).has(slot)) {
+          if (slot !== this.ghostSlot) this.ghostTo(slot);
+          return HiveWorld.GHOST;
+        }
+      }
+    }
+    return null;
+  }
+
+  // aim the ghost at a cell; frame() glides it there (everything springs, nothing teleports)
+  private ghostTo(slot: number) {
+    this.ghostSlot = slot;
+    const p = axialToXZ(spiralSlot(slot), HEX_SIZE);
+    this.ghostTarget.set(p.x, 0, p.z);
   }
 
   select(sid: string) {
@@ -983,6 +1030,18 @@ class HiveWorld {
     const diff = diffSessions(first ? null : prevSessions, sessions);
     const stored = loadSlots(this.slots);
     this.slots = assignSlots(stored, sessions.map((s) => s.sid));
+    // a click on an empty cell reserved it for the next NEW arrival (onPointerUp) — honor
+    // it here, before pads are built. A REVIVED session outranks the click: it returns to
+    // its remembered hex (the standing invariant), so the reservation only takes a sid
+    // with no remembered home. Spent (or dropped) at the first arrival after the click.
+    if (this.reservedSlot !== null && diff.added.length) {
+      const want = this.reservedSlot;
+      this.reservedSlot = null;
+      const sid = diff.added.find((id) => !stored.has(id));
+      if (sid !== undefined && (this.slots.get(sid) === want || ![...this.slots.values()].includes(want))) {
+        this.slots.set(sid, want);
+      }
+    }
     // persist the present sessions PLUS absent sids' remembered homes (a revived session
     // returns to its old hex), dropping the memories only if the map outgrows 200 entries
     const keep = new Map(this.slots);
@@ -1029,12 +1088,13 @@ class HiveWorld {
         this.particles.burst(at, [tint, ACCENT, 0xffd700, tint], 48, 4.2);
       }
     }
-    // park the ghost hex on the first FREE slot — the natural "next" cell of the spiral
+    // the ghost's PARK is the first FREE slot — the natural "next" cell of the spiral; it
+    // only re-aims now if it isn't busy following the pointer (or its cell got taken)
     let free = 0;
     const taken = new Set(this.slots.values());
     while (taken.has(free)) free++;
-    const gp = axialToXZ(spiralSlot(free), HEX_SIZE);
-    this.ghost.position.set(gp.x, 0, gp.z);
+    this.ghostHome = free;
+    if (this.hovered !== HiveWorld.GHOST || taken.has(this.ghostSlot)) this.ghostTo(free);
     // …and keep the one-layer lattice one ring wider than anything on it
     this.ensureLattice(Math.max(3, ringOf(Math.max(free, ...this.slots.values())) + 1));
 
@@ -1106,7 +1166,10 @@ class HiveWorld {
       this.ghostHover = sid === HiveWorld.GHOST;
       this.renderer.domElement.style.cursor = sid ? "pointer" : "default";
     }
-    // the ghost breathes faintly; waking on hover
+    // the ghost glides to its aim (the hovered empty cell, or its park when the pointer
+    // leaves the board) and breathes faintly, waking on hover
+    if (this.hovered !== HiveWorld.GHOST && this.ghostSlot !== this.ghostHome) this.ghostTo(this.ghostHome);
+    this.ghost.position.lerp(this.ghostTarget, 1 - Math.exp(-14 * dt));
     const gTarget = this.ghostHover ? 0.5 : 0.06 + 0.03 * (0.5 + 0.5 * Math.sin(this.clock * 1.2));
     this.ghostRingMat.opacity = ease(this.ghostRingMat.opacity, gTarget, dt, 8);
     this.ghostPlus.material.opacity = ease(this.ghostPlus.material.opacity, this.ghostHover ? 0.95 : 0.22, dt, 8);

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -1059,10 +1059,16 @@ class HiveWorld {
       return;
     }
     if (sid) {
-      // acknowledge the press NOW (the pad dips); the ACTION fires on the clean UP —
-      // a press that MOVES becomes a pick-up instead (drag to the trash dock to end)
       const pad = this.pads.get(sid);
       if (pad) { pad.lift = -0.07; setTimeout(() => { if (this.pads.get(sid) === pad) pad.lift = this.hovered === sid ? 0.12 : 0; }, 130); }
+      // the BEAN switches chat ON THE DOWN — instant (the user 2026-08-13, everything
+      // responsive). The same press can still become a pick-up: the switch has already
+      // happened, and seeing their chat while you carry them is coherent. The TILE'S
+      // action (card + camera fly-in) stays on the clean UP — a fly-in mid-drag is chaos.
+      if (hit.bean && pad) {
+        pad.pokeBean();
+        this.openChat(sid);
+      }
       this.pressedPad = { sid, x: e.clientX, y: e.clientY, bean: hit.bean };
     } else {
       this.dragging = { mode: "orbit", x: e.clientX, y: e.clientY };
@@ -1078,15 +1084,8 @@ class HiveWorld {
     if (this.dragSession) { this.dropSessionDrag(this.dragSession.over); return; }
     if (pp) {
       if (Math.hypot(e.clientX - pp.x, e.clientY - pp.y) > 5) return;   // it was a nudge, not a click
-      const pad = this.pads.get(pp.sid);
-      // clicking the BEAN is the direct line to their chat: they pop (acknowledgement on
-      // THEM) and the chat pane opens; clicking the TILE opens the fly-in card
-      if (pp.bean && pad) {
-        pad.pokeBean();
-        this.openChat(pp.sid);
-      } else if (pad) {
-        this.select(pp.sid);
-      }
+      // the bean already switched chat on the DOWN; the tile's card resolves here
+      if (!pp.bean && this.pads.has(pp.sid)) this.select(pp.sid);
       return;
     }
     if (!pr) return;

--- a/ui/webview/hive.ts
+++ b/ui/webview/hive.ts
@@ -11,7 +11,7 @@ import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer
 import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
 import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
 import { delegate } from "./actions";
-import { assignSlots, axialToXZ, frameDt, frameRadius, spiralSlot } from "./hive-layout";
+import { assignSlots, axialToXZ, frameDt, frameRadius, HEX_SIZE, PAD_R, spiralSlot } from "./hive-layout";
 import { buildSessions, diffSessions, HiveSession, HiveState, hiveAge, stateLine } from "./hive-model";
 
 const vscodeApi =
@@ -32,9 +32,7 @@ const ST: Record<HiveState, number> = {
   opening: 0x9aa0a6,     // pale — CLI still coming up
 };
 const ACCENT = 0x9cd2ff;
-const HEX_SIZE = 2.05;        // axial size: neighbour centers sit √3·size apart
-const PAD_R = 1.62;           // pad circumradius (< √3/2·size, so pads never touch)
-const PAD_H = 0.42;
+const PAD_H = 0.42;           // HEX_SIZE/PAD_R live in hive-layout.ts, snapped flush there
 // Tron world (the user 2026-08-13): near-black glossy ground with a faint accent grid, the
 // pads dark slabs whose STATUS light is their glowing rim, bloom doing the neon work. The
 // beans stay cute (session-colored, softly self-lit) with dark visors and glowing eyes.

--- a/ui/webview/picker-dir.test.ts
+++ b/ui/webview/picker-dir.test.ts
@@ -83,7 +83,7 @@ test("Browse… disappears on a kernel with no desktop, and is disabled (not hid
   assert.match(RENDER, /function applyBrowseState\(host: string\)[\s\S]*?b\.style\.display = kernelNativeDialogs \? "" : "none";[\s\S]*?b\.disabled = !!host;/);
   // one helper, called from all three places the button's state can change
   assert.match(RENDER, /applyBrowseState\(h\);/);                // the host row was clicked
-  assert.match(RENDER, /applyBrowseState\(""\);/);               // the picker opened
+  assert.match(RENDER, /applyBrowseState\(openHost\);/);         // the picker opened (on its default host)
   assert.match(RENDER, /applyBrowseState\(pickerHost\(\)\);/);   // the capability landed while it was open
   assert.doesNotMatch(RENDER, /browse0/, "the old inline reset is gone — the state lives in the helper");
   assert.match(CSS, /\.picker-browse:disabled \{/, "a disabled button must LOOK disabled, not just ignore clicks");

--- a/ui/webview/picker-host-list.test.ts
+++ b/ui/webview/picker-host-list.test.ts
@@ -47,10 +47,13 @@ test("a click on a remote row routes to the kernel that owns the session", () =>
   assert.deepEqual([rev.host, rev.msg.id], ["TESTHOST", "1111-2222"]);
 });
 
-test("the request names the host, and every open starts from the local list", () => {
+test("the request names the host, and every open starts from the host it opened on", () => {
   assert.match(RENDER, /function requestSessionList\(host: string\): void \{\s*\n\s*pickerListHost = host;/);
   assert.match(RENDER, /postMessage\(\{ type: "requestSessions", host \}\)/);
-  assert.match(RENDER, /requestSessionList\(""\);   \/\/ the Host row resets to local on open/);
+  // was hardcoded to "" (always the local list). It now follows the Host row's opening selection —
+  // the kernel's default create host when that machine is attached, else this one (the user
+  // 2026-08-13); see create-defaults.test.ts for the selection rule itself.
+  assert.match(RENDER, /requestSessionList\(openHost\);/);
 });
 
 test("a reply for a host the picker has moved on from is dropped, not painted", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8461,6 +8461,8 @@ window.addEventListener("message", (e: MessageEvent) => {
     if (activeId && !isProvisionalId(activeId) && sessions.get(activeId)) showForkPrompt(activeId, "");
     return;
   }
+  // the hive's ghost hex (relayed by the shell): open the same new-session picker the + tab does
+  if (m.romp === "openPicker") { openPicker(); return; }
   if (m.type === "pipeState") { pipeBanner(!!m.up, Number(m.queued) || 0); return; }
   if (m.type === "session") upsert(m);
   else if (m.type === "globalRetryPaused") {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -2910,6 +2910,22 @@ function renderTool(ev: Extract<ChatEvent, { kind: "tool" }>): HTMLElement {
     }
     inlineFold(head, turn, `+${add} −${del}`, pre, fkey);
   } else if (ev.name === "Read") {
+    // A photo the agent LOOKED AT renders as the photo, right under the tool row (the user
+    // 2026-08-14) — the same full-size treatment a path mentioned in prose gets (the
+    // 2026-07-20 rule: the image, not a thumbnail), through the same plumbing: previewFull
+    // rides fileUrl, whose /remote/<host>/file relay serves a REMOTE session's disk (devbox
+    // included), and it self-removes when the kernel can't serve the bytes. VS Code's
+    // sandbox keeps the host data-URL flow (buildPathImg). The textual fold stays below for
+    // the mechanics.
+    let readPath = "";
+    try {
+      const o = JSON.parse(ev.input || "{}");
+      if (o && typeof o.file_path === "string") readPath = o.file_path;
+    } catch { /* truncated input JSON → no preview, the head still stands */ }
+    if (readPath && previewKind(readPath) === "img") {
+      const full = canPreview() ? previewFull(readPath, activeId) : buildPathImg(readPath);
+      if (full) turn.appendChild(full);
+    }
     if (ev.output) inlineFold(head, turn, `${countLines(ev.output)} lines`, preEl(ev.output), fkey);
   } else if (ev.name === "Skill") {
     // A Skill invocation (the user 2026-07-08): the head names the skill, and the skill's INSTRUCTIONS

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4838,12 +4838,20 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     auWrapEl.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.remove("sel"));
   }
   const hostWrapEl = overlay.querySelector(".picker-host") as HTMLElement | null;
+  // Which machine this open STARTS on: the kernel's default create host when it is actually attached
+  // right now, else this one. A stored name whose host is detached must not preselect a button that
+  // isn't there — the create would be routed at a kernel this dashboard cannot reach. Read once here
+  // so the Host row, the dir prefill, the Browse state and the session list all open on the SAME host.
+  const openHost = (() => {
+    const hs: string[] = ((window as any).__rompFed?.hosts?.() || []) as string[];
+    return defaultCreateHost && hs.includes(defaultCreateHost) ? defaultCreateHost : "";
+  })();
   if (hostWrapEl) {   // rebuild the host options each open (attach/detach is live); hide with no remotes
     const hosts: string[] = ((window as any).__rompFed?.hosts?.() || []) as string[];
     hostWrapEl.style.display = pick || !hosts.length ? "none" : "";
     hostWrapEl.querySelectorAll(".picker-be-opt").forEach((x) => x.remove());
     for (const h of ["", ...hosts]) {
-      const b = el("button", "picker-be-opt" + (h === "" ? " sel" : "")) as HTMLButtonElement;
+      const b = el("button", "picker-be-opt" + (h === openHost ? " sel" : "")) as HTMLButtonElement;
       // This machine wears its REAL name, like the remote options wear theirs (the user 2026-08-12):
       // "local" made the row read as one named machine plus an unnamed one. The name rides the local
       // sessionList reply (selfHost), so the very first open may briefly say "local" until it lands —
@@ -4875,11 +4883,15 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       hostWrapEl.appendChild(b);
     }
   }
-  applyBrowseState("");   // fresh open defaults back to local — enabled unless this kernel has no desktop
+  applyBrowseState(openHost);   // Browse… only stands for the LOCAL disk, so a remote open disables it
   const di = document.getElementById("picker-dir") as HTMLInputElement | null;
-  // the host row resets to local on every open, so this is the local prefill: what you last used here,
-  // else the kernel's persisted default (file→env; localStorage is a same-tab cache)
-  if (di) di.value = dirPrefill("");
+  // the prefill for the host this open starts on: what you last used THERE, else (locally) the kernel's
+  // persisted default (file→env; localStorage is a same-tab cache)
+  if (di) {
+    di.value = dirPrefill(openHost);
+    di.placeholder = openHost ? `New-session directory on ${openHost} (blank = its default)`
+                              : "New-session directory (blank = default)";
+  }
   closeDirMenu();                       // a previous open's folder list is not this one's
   if (di && !pick) askDirComplete(di.value);   // the status line says what the prefilled path is, before anything is typed
   // In a filtered view (#only=<tag>), a new session created here would vanish from the view unless its name
@@ -4899,7 +4911,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   }
   filterPicker(seed); // reset row visibility; arm the New-session button for the (possibly seeded) value
   pickerError(null);
-  requestSessionList("");   // the Host row resets to local on open, so the list starts local too
+  requestSessionList(openHost);   // the list belongs to whichever machine the Host row opened on
 }
 
 // ---- revive loader (the user 2026-07-05) ----
@@ -5210,6 +5222,11 @@ let kernelDefaultDir = "";
 // override), from the same payload. The + picker's Host row labels its first option with it, so the
 // row reads as a list of machines by name rather than named hosts plus a "local" (the user 2026-08-12).
 let localSelfHost = "";
+// The machine NEW sessions land on by default (the LOCAL kernel's ~/.config/romp/default-host, from the
+// same payload; "" = this machine). The + picker preselects it in the Host row and the hive tray drops
+// onto it, so someone whose work all lives on one remote box stops re-picking it every single time (the
+// user 2026-08-13). Exported for the tray, which creates without opening the picker at all.
+export let defaultCreateHost = "";
 // Is this session already an open tab in THIS dashboard? (loaded session, or a not-yet-loaded placeholder tab
 // the kernel's order carries.) The + picker uses it to hide sessions you can already reach by a tab-click.
 function isOpenTab(id: string): boolean {
@@ -8585,6 +8602,10 @@ window.addEventListener("message", (e: MessageEvent) => {
     }
     if (from !== pickerListHost) return;
     if (typeof m.defaultDir === "string" && !from) kernelDefaultDir = m.defaultDir;   // the LOCAL default dir
+    // …and the LOCAL kernel's default create HOST. Like selfHost this is a preference, not list data, so
+    // only the local reply carries it — a remote kernel's own default says nothing about where THIS
+    // dashboard creates.
+    if (typeof m.defaultHost === "string" && !from) defaultCreateHost = m.defaultHost;
     // …and whether that kernel can open a folder dialog at all. It arrives after the picker is already on
     // screen, so re-settle the button now rather than leaving it live until the next open.
     if (typeof m.nativeDialogs === "boolean" && !from) {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -864,6 +864,24 @@ function imgCaption(path: string): HTMLElement {
   cap.appendChild(copy);
   return cap;
 }
+// Open a clicked path where the VIEWER can actually see it (the user 2026-08-14: clicking a
+// devbox session's file did nothing — {type:"openFile"} runs `open <path>` on the OWNING
+// kernel, which is headless and on the wrong machine's display). On the web dashboard, a
+// REMOTE session's path opens in a browser tab through the same /remote/<host>/file relay
+// every preview rides — the kernel serves images/PDFs natively, text inline, and anything
+// else as a download, so every click lands something. A LOCAL session keeps the native host
+// open (the default app/editor on this machine IS the better open when the file is here),
+// and the VS Code webview keeps its host op on both.
+function openFileClick(open: string, relative = false): void {
+  const host = activeId ? hostOf(activeId) : "";
+  if (host && (location.protocol === "http:" || location.protocol === "https:")) {
+    window.open(fileUrl(open, activeId), "_blank", "noopener,noreferrer");
+    return;
+  }
+  if (vscodeApi) vscodeApi.postMessage(relative
+    ? { type: "openFile", path: open, id: activeId }   // kernel resolves against this session's cwd
+    : { type: "openFile", path: open });
+}
 // The full absolute path, clickable — opens the image file in the editor. Shown
 // verbatim (never shortened to a basename) so it can also be read and selected/
 // copied right where it stands.
@@ -873,7 +891,7 @@ function imgPathLink(path: string): HTMLElement {
   a.title = "Open " + path;
   a.addEventListener("click", (e) => {
     e.stopPropagation();
-    if (vscodeApi) vscodeApi.postMessage({ type: "openFile", path });
+    openFileClick(path);
   });
   return a;
 }
@@ -917,9 +935,7 @@ function openPathLink(raw: string, open: string, relative = false): HTMLElement 
   a.title = "Open " + open;
   a.addEventListener("click", (e) => {
     e.stopPropagation();
-    if (vscodeApi) vscodeApi.postMessage(relative
-      ? { type: "openFile", path: open, id: activeId }   // kernel resolves against this session's cwd
-      : { type: "openFile", path: open });
+    openFileClick(open, relative);           // remote session on web → the viewer's own tab (see openFileClick)
   });
   return a;
 }

--- a/ui/webview/settings.test.ts
+++ b/ui/webview/settings.test.ts
@@ -25,8 +25,10 @@ test("both judge-set toggles default OFF (the user 2026-06-29): the timeline's j
   assert.equal(DEFAULT_SETTINGS.showTriageJudges, false);
 });
 
-test("Default backend defaults to sdk (the user 2026-07-13, superseding the 06-22 tmux default); both backends coexist", () => {
-  assert.equal(DEFAULT_SETTINGS.backend, "sdk");
+test("Default backend defaults to tmux (the user 2026-08-13, superseding the 07-13 sdk default); both backends coexist", () => {
+  // the terminal session is what this user actually works in, and the default is what every create
+  // surface reads — the + picker's backend row AND the hive tray's bean drop
+  assert.equal(DEFAULT_SETTINGS.backend, "tmux");
 });
 
 test("Compact transcript defaults ON (the user 2026-07-14): fresh installs read the tidy transcript", () => {

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -13,7 +13,7 @@ export interface RompSettings {
   showIndexJudges: boolean;
   showTriageJudges: boolean;
   debug?: boolean;    // LEGACY (the user 2026-06-17): the old single judging-band toggle; read as the migration fallback for the two judge-set toggles when those are unset. The ↻ restart button is always-visible (decoupled).
-  backend: "tmux" | "sdk";   // which backend a NEWLY-created session uses (the user 2026-06-22): "tmux" (terminal) or "sdk" (Agent SDK). Both coexist; this is only the default for the + button. Read at createSession time (render.ts). Default sdk (the user 2026-07-13).
+  backend: "tmux" | "sdk";   // which backend a NEWLY-created session uses (the user 2026-06-22): "tmux" (terminal) or "sdk" (Agent SDK). Both coexist; this is only the default for the + button and the hive tray. Read at createSession time (render.ts / hive.ts). Default tmux (the user 2026-08-13, who works in the terminal sessions and wanted every surface to make the same one).
   defaultDir: string;        // default working directory PREFILLED in the new-session field (the user 2026-06-22). A session's dir is fixed at creation. Empty → the kernel's serve dir. ~ / $VAR expanded server-side.
   showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). OFF by default (the user 2026-08-10, trimming the statusline for narrow panes; an explicit stored true keeps showing it).
   tabCtx: TabCtxMode;        // chat tabs: WHEN the context gauge shows beside each session name (the user 2026-08-08) — "over50" (default: only once half full, so quiet tabs stay clean), "always", or "never".
@@ -32,7 +32,7 @@ export function tabCtxMode(v: unknown): TabCtxMode {
 // hand-written "why" as their line; they show the distiller's summary instead (the why demotes to a hover).
 // compact defaults ON (the user 2026-07-14): a fresh install reads the tidy transcript
 // (thinking hidden, tool runs folded); the gear opts back into the full stream.
-export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50" };
+export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "tmux", defaultDir: "", showBranch: false, tabCtx: "over50" };
 const KEY = "romp:settings";
 
 export function loadSettings(): RompSettings {

--- a/vscode-extension/esbuild.js
+++ b/vscode-extension/esbuild.js
@@ -41,6 +41,8 @@ const webview = {
     "../ui/webview/feed.css",
     "../ui/webview/fleet.ts",
     "../ui/webview/fleet-pane.css",      // fleet page layout — the kernel reads the same file live
+    "../ui/webview/hive.ts",             // the Hive pane: 3D honeycomb session view (plans/hive.md)
+    "../ui/webview/hive-pane.css",       // hive page frame + overlay card — the kernel reads it live
     "../ui/webview/timeline-main.ts",    // VS Code timeline view: boot glue + ui/romp-timeline-view.js inlined
     "../ui/webview/timeline-pane.css",   // timeline wrapper styles — the kernel reads the same file live
     "../ui/webview/strip.css",           // the romp strip (VS Code-only bottom rail stand-in)

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -8,11 +8,13 @@
       "name": "romp-chat-view",
       "version": "0.4.337",
       "dependencies": {
+        "@types/three": "^0.185.4",
         "@types/ws": "^8.18.1",
         "dompurify": "^3.4.10",
         "highlight.js": "^11.9.0",
         "katex": "^0.18.1",
         "marked": "^12.0.2",
+        "three": "^0.185.1",
         "ws": "^8.21.0"
       },
       "devDependencies": {
@@ -24,6 +26,12 @@
       "engines": {
         "vscode": "^1.85.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -416,6 +424,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.42",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
@@ -423,6 +437,26 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.4",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.4.tgz",
+      "integrity": "sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -437,6 +471,12 @@
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
       "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -505,6 +545,12 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/highlight.js": {
       "version": "11.11.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
@@ -541,6 +587,18 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -176,11 +176,13 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
+    "@types/three": "^0.185.4",
     "@types/ws": "^8.18.1",
     "dompurify": "^3.4.10",
     "highlight.js": "^11.9.0",
     "katex": "^0.18.1",
     "marked": "^12.0.2",
+    "three": "^0.185.1",
     "ws": "^8.21.0"
   }
 }

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -11,7 +11,10 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "baseUrl": ".",
-    "paths": { "*": ["node_modules/*"] }
+    "paths": {
+      "three": ["node_modules/@types/three"],
+      "*": ["node_modules/*"]
+    }
   },
   "include": ["src", "../ui"]
 }

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -13,6 +13,7 @@
     "baseUrl": ".",
     "paths": {
       "three": ["node_modules/@types/three"],
+      "three/examples/jsm/*": ["node_modules/@types/three/examples/jsm/*"],
       "*": ["node_modules/*"]
     }
   },


### PR DESCRIPTION
A fifth dashboard pane — a Tron-styled 3D honeycomb, one hex pad per session, a
cute bean character on each pad acting out that session's live state. Click a
hex: the camera flies in and a pane-local card shows the gist (state in plain
words, current goal, needs-you decision brief) with a composer that delivers
into that session and an Open session jump. A quiet ghost hex on the spiral's
first free slot opens the new-session picker.

## How it rides the existing machinery
- `app=hive` is a feed-payload rider (three one-line additions to the push
  loop); the pane consumes `ledgers` + `asks` — no new payload builders.
- The scene mutates ONLY on diff events from a pure model (`hive-model.ts`):
  identical pushes produce zero motion (tested), goal-done celebrations fire
  once per observed transition, hex slots are stable for a session's life
  (persisted) so spatial memory works.
- The talk composer posts the same `sendMessage` drive op the chat uses;
  foreign-sid refusals surface on the card via the err channel.
- Status colors keep their standing meanings (pinned against styles.css by
  test); the accent is reserved for selection/hover/ghost chrome.
- Click-safety: the card is built once and updated in place, actions delegated
  (`actions.ts`); canvas clicks acknowledge on pointer-down with a pad dip.
- Rendering pauses fully when the pane is hidden (IntersectionObserver +
  visibilitychange); DPR capped at 2.

## Found along the way
A backward rAF clock step (laptop sleep, tab restore, virtual time) flipped
every exponential camera ease into a runaway AWAY from its target. `frameDt()`
clamps dt into [0, 50ms]; tested.

## Tests
`hive-layout` (spiral/slot invariants, frameDt), `hive-model` (every chip,
no-flap invariant, goal-done semantics, state lines), `hive-wiring` (pins the
kernel route/landing strings, esbuild entries, palette parity, talk protocol).
Full suite: 1901 passing. `npm run typecheck` clean. three.js (MIT) joins the
webview bundle via the existing esbuild pipeline.

Design doc: `plans/hive.md`. Screenshotted end-to-end via a headless-Chrome
harness (synthetic sessions only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)