### PR TITLE
A dormant created session reads ready, never opening

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6024,6 +6024,7 @@ class Sessions:
                                 "retryCount": int(st.get("retryCount") or 0),   # api_retry backoff attempts → the chat's "API retrying — attempt N…" element
                                 "retryInfo": st.get("retryInfo") or None,   # the attempt's detail (attempt/max, error, next-attempt epoch) → the retrying element's context lines (the user 2026-07-10)
                                 "connected": bool(st.get("connected")),   # SDK handshake up → the opening-chip override stands down (fresh sessions have no transcript yet)
+                                "spawning": bool(st.get("spawning")),   # spawn/handshake in flight NOW — the ONLY window the opening chip covers (a dormant created session must read ready, the user 2026-08-13)
                                 "context": ctx if isinstance(ctx, (int, float)) else None, "compactPct": None,
                                 "fast": st.get("fast", ""),   # fast-mode state from the CLI's init ("on"/"off"/"cooldown"; "" = unknown → no badge)
                                 "fastReason": st.get("fastReason", ""),   # init's disabled_reason — non-empty hides the chat toggle
@@ -13271,22 +13272,25 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
         # compaction stalls. After that, blocked is the strongest signal — the turn ended in an error, so it
         # beats the live tmux states (the session can't simultaneously be at a permission prompt mid-error).
         chip = _session_chip(sid, sess["path"], session, tm, now)   # THE shared derivation — identical to the timeline lane (the user 2026-07-03)
-        # A session whose transcript DOESN'T EXIST YET is OPENING, whatever the snapshot claims (the
+        # A session whose transcript DOESN'T EXIST YET reads OPENING while its spawn is IN FLIGHT (the
         # user 2026-08-05: a just-spawned tab said "Working" over a clock with no honest base). The
-        # deciding event — "the CLI is up" — is per-backend. SDK: the handshake (tm.connected) — a
-        # fresh SDK session writes NO transcript until its first turn, so keying its chip on the file
-        # left a fully-up, idle session wearing the opening dots until the user's first message,
-        # indefinitely (the user 2026-08-08, who read minutes of dots as creation still running).
-        # tmux: the CLI's statusline hook publishing its first @claude-state — the same wait, the
-        # matching event (2026-08-10; the transcript's first record only lands with the first MESSAGE,
-        # so keying on the file alone held a fully-up tmux session on the dots until the user typed).
-        # SDK snapshots always carry a non-empty state ("waiting" from birth), so the state leg is
-        # tmux-only by construction (backend == "tmux"). Never for an override render (a closed
-        # episode's path is historical).
-        cli_up = bool(tm.get("connected")) or \
-            (tm.get("backend") == "tmux" and bool((tm.get("state") or "").strip()))
+        # window is per-backend. SDK: the backend's live `spawning` report (session thread up, client
+        # not yet; the handshake closes it) — a fresh SDK session writes NO transcript until its first
+        # turn, so keying its chip on the file left a fully-up, idle session wearing the opening dots
+        # until the user's first message, indefinitely (the user 2026-08-08, who read minutes of dots
+        # as creation still running). tmux: no @claude-state published yet — the statusline hook's
+        # first publish is the matching CLI-up event (2026-08-10; tmux panes and their state vars
+        # outlive kernel restarts, so that leg needs no dormant case). The SDK leg keys on `spawning`,
+        # NOT on `connected` being falsy: a DORMANT created session — every fresh SDK session after a
+        # kernel restart, since idle CLIs die with the kernel and boot reconcile leaves them lazy —
+        # also reports no `connected`, and reading that as "still opening" kept the dots up for HOURS
+        # on a session one message from answering (the user 2026-08-13, whose created-but-unmessaged
+        # session "opened" all morning). A dormant row carries no spawning key, so it reads ready — a
+        # send wakes it. Never for an override render (a closed episode's path is historical).
+        spawn_inflight = bool(tm.get("spawning")) or \
+            (tm.get("backend") == "tmux" and not (tm.get("state") or "").strip())
         if chip in ("working", "ready") and not path_override and not os.path.exists(sess["path"]) \
-                and not cli_up:
+                and spawn_inflight:
             chip = "opening"
         faded = chip == "ready" and bool(tm["since"]) and now - tm["since"] > 3600
         # apiTooLong distinguishes a "prompt is too long" block (on YOU → red dashed tab) from a TRANSIENT API

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2637,6 +2637,14 @@ class SdkSession:
                 #   ready the moment it can take a message instead of wearing the opening dots until
                 #   its first turn writes a transcript (the user 2026-08-08, whose fresh session sat
                 #   on animated dots for minutes while fully up)
+                "spawning": not self.client,   # the spawn/handshake window is open RIGHT NOW (this
+                #   thread is up, the client isn't yet) — the ONLY window the kernel's opening chip
+                #   may cover. Its ABSENCE must mean "not opening": the chip once keyed on `connected`
+                #   being falsy, which a DORMANT created session also reports (a kernel restart kills
+                #   idle CLIs, boot reconcile leaves them lazy, and a never-messaged session has no
+                #   transcript either) — so the dots outlived the create by hours when one message
+                #   would wake it in seconds (the user 2026-08-13). Dormant rows carry no spawning
+                #   key at all, so they read ready.
                 "fast": self.fast,   # fast-mode state from init ("on"/"off"/"cooldown"; "" = unknown → no badge)
                 "fastReason": self.fast_reason,   # init's disabled_reason — non-empty hides the chat toggle
                 "retryCount": self.retry_count,   # api_retry backoff attempts in the current storm → the live 'attempt N' in the chat's retrying element

--- a/tests/test_kernel_opening.py
+++ b/tests/test_kernel_opening.py
@@ -93,11 +93,21 @@ class OpeningChipStandsDownOnTheBackendEvent(_Base):
 
     def test_sdk_pre_handshake_reads_opening(self):
         # SDK snapshots carry a non-empty state from birth ("waiting"), so the state leg must not
-        # stand the override down for them — only the handshake does
-        self.assertEqual(self._chip(_row(state="waiting", backend="sdk", connected=False)), "opening")
+        # stand the override down for them — the chip covers the backend's live spawn window
+        # (`spawning`: thread up, client not yet), which the handshake closes
+        self.assertEqual(self._chip(_row(state="waiting", backend="sdk", connected=False,
+                                         spawning=True)), "opening")
 
     def test_sdk_handshake_ends_opening(self):
         self.assertEqual(self._chip(_row(state="waiting", backend="sdk", connected=True)), "ready")
+
+    def test_sdk_dormant_created_session_reads_ready(self):
+        # No spawn in flight and no connected flag — the dormant row every created-but-unmessaged
+        # SDK session reports after a kernel restart (idle CLIs die with the kernel, boot reconcile
+        # leaves them lazy, the transcript only lands with the first turn). Reading the missing
+        # `connected` as "still opening" wore the dots for hours (the user 2026-08-13); a send
+        # wakes a dormant session in seconds, so it is READY.
+        self.assertEqual(self._chip(_row(state="waiting", backend="sdk", connected=False)), "ready")
 
 
 class PushSessionNow(_Base):

--- a/tests/test_kernel_opening_chip.py
+++ b/tests/test_kernel_opening_chip.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""The opening chip's deciding event is per-backend.
+"""The opening chip's deciding event is per-backend, and it covers ONLY a spawn in flight.
 
 A session whose transcript doesn't exist yet reads "opening" (2026-08-05: a just-spawned tab said
 "Working" over a clock with no honest base). For tmux the transcript's first record is the only
@@ -9,6 +9,13 @@ the animated opening dots until the user's first message — indefinitely (the u
 minutes of dots as creation still running). The SDK backend knows the earlier designed event — the
 handshake (snapshot `connected`, set the moment the client context opens) — and the override stands
 down on it.
+
+The override must also NOT outlive the create (the user 2026-08-13): `connected` is in-memory only, so
+a created-but-never-messaged session whose CLI isn't up right now — the normal state of every fresh SDK
+session after a kernel restart, since idle CLIs die with the kernel and boot reconcile leaves them
+lazy — read the missing flag as "still opening" and wore the dots for HOURS, while one message would
+wake it in seconds. The chip now keys on the backend's live `spawning` report (thread up, client not
+yet): opening covers exactly the spawn/handshake window, and a dormant created session reads ready.
 
 SYNTHETIC fixtures only (placeholder uuid, temp dirs), modeled on test_chat_payload_clock_invariant.
 """
@@ -72,9 +79,36 @@ class OpeningChipDecidingEvent(unittest.TestCase):
         self.assertIsNotNone(m, "fixture session must build")
         return (m.get("status") or {}).get("state")
 
-    def test_no_transcript_and_no_handshake_is_opening(self):
-        # spawned but the CLI hasn't proven up and nothing is on disk → opening (the 2026-08-05 rule)
+    def test_a_spawn_in_flight_with_no_transcript_is_opening(self):
+        # spawn/handshake window open (the backend's live `spawning` report: thread up, client not
+        # yet) and nothing on disk → opening (the 2026-08-05 rule, scoped to the in-flight window)
+        self.tm["spawning"] = True
         self.assertEqual(self._state(), "opening")
+
+    def test_a_dormant_created_session_is_ready_not_opening(self):
+        # Created, never messaged, CLI not up RIGHT NOW — every fresh SDK session lands here after a
+        # kernel restart (idle CLIs die with the kernel; boot reconcile leaves them lazy; the
+        # transcript only appears with the first turn). A dormant row carries NO spawning key, and
+        # the old gate read the equally-missing `connected` as "still opening" — dots for hours on a
+        # session one message from answering (the user 2026-08-13).
+        self.assertEqual(self._state(), "ready",
+                         "a created-but-unmessaged dormant session is ready (a send wakes it), not opening")
+
+    def test_the_live_merge_threads_spawning_through(self):
+        # The merge dropping a backend key is a known silent killer (the 2026-07-11 bgTasks lesson:
+        # the snapshot carried it, every consumer saw None). Guard the thread-through explicitly.
+        class _FakeBackend:
+            def live_sessions(self):
+                return {SID: {"state": "waiting", "since": "5", "model": "", "effort": "",
+                              "spawning": True}}
+        saved = km._sdk
+        km._sdk = lambda: _FakeBackend()
+        try:
+            row = km.Sessions.live().get(SID)
+        finally:
+            km._sdk = saved
+        self.assertIsNotNone(row)
+        self.assertTrue(row.get("spawning"), "Sessions.live must carry the backend's spawning bit")
 
     def test_the_sdk_handshake_ends_opening_before_any_transcript_exists(self):
         # a fresh SDK session is fully open the moment its client connects — its transcript only

--- a/ui/webview/opening-state.test.ts
+++ b/ui/webview/opening-state.test.ts
@@ -14,25 +14,30 @@ const RENDER = fs.readFileSync(path.join(ROOT, "ui", "webview", "render.ts"), "u
 const CSS = fs.readFileSync(path.join(ROOT, "ui", "webview", "styles.css"), "utf8");
 const KERNEL = fs.readFileSync(path.join(ROOT, "kernel", "kernel.py"), "utf8");
 
-test("the kernel reports OPENING while the transcript doesn't exist — never a working chip on a broken clock", () => {
+test("the kernel reports OPENING while the transcript doesn't exist and the spawn is in flight — never a working chip on a broken clock", () => {
   assert.ok(KERNEL.includes('if chip in ("working", "ready") and not path_override and not os.path.exists(sess["path"]) \\'));
-  assert.ok(KERNEL.includes("and not cli_up:"));
+  assert.ok(KERNEL.includes("and spawn_inflight:"));
   assert.ok(KERNEL.includes('chip = "opening"'));
 });
 
-// The deciding event — "the CLI is up" — is per-backend (the user 2026-08-08, who read minutes of dots
-// as creation still running): a fresh session of EITHER backend writes NO transcript until its first
-// turn, so keying the chip on the file alone held a fully-up idle session on the opening dots until the
-// user typed. SDK: the handshake (snapshot `connected`, set the moment the client context opens).
-// tmux: the CLI's statusline hook publishing its first @claude-state (2026-08-10) — the matching event,
-// since the transcript's first record only lands with the first MESSAGE.
-test("each backend's own 'CLI is up' event ends OPENING before any transcript exists", () => {
+// The opening window is per-backend (the user 2026-08-08, who read minutes of dots as creation still
+// running): a fresh session of EITHER backend writes NO transcript until its first turn, so keying the
+// chip on the file alone held a fully-up idle session on the opening dots until the user typed.
+// SDK: the backend's live `spawning` report (session thread up, client not yet; the handshake closes
+// it). tmux: the CLI's statusline hook publishing its first @claude-state (2026-08-10). The SDK leg
+// must key on `spawning`, NOT on `connected` being falsy — a DORMANT created session (kernel restarts
+// kill idle CLIs; boot reconcile leaves them lazy) also reports no `connected`, and reading that as
+// "still opening" kept the dots up for hours on a session one message from answering (the user
+// 2026-08-13). A dormant row carries no spawning key, so it reads ready.
+test("OPENING covers exactly each backend's spawn window — a dormant created session reads ready", () => {
   const SDK = fs.readFileSync(path.join(ROOT, "kernel", "sdk_backend.py"), "utf8");
   assert.ok(SDK.includes('"connected": bool(self.client)'), "the snapshot carries the handshake event");
-  assert.ok(KERNEL.includes('"connected": bool(st.get("connected"))'), "the live merge threads it through");
-  assert.ok(KERNEL.includes('cli_up = bool(tm.get("connected")) or \\'), "SDK: the handshake");
-  assert.ok(KERNEL.includes('(tm.get("backend") == "tmux" and bool((tm.get("state") or "").strip()))'),
-    "tmux: the first published @claude-state");
+  assert.ok(SDK.includes('"spawning": not self.client'), "the snapshot carries the in-flight window");
+  assert.ok(KERNEL.includes('"connected": bool(st.get("connected"))'), "the live merge threads connected through");
+  assert.ok(KERNEL.includes('"spawning": bool(st.get("spawning"))'), "the live merge threads spawning through");
+  assert.ok(KERNEL.includes('spawn_inflight = bool(tm.get("spawning")) or \\'), "SDK: the live spawn window");
+  assert.ok(KERNEL.includes('(tm.get("backend") == "tmux" and not (tm.get("state") or "").strip())'),
+    "tmux: no @claude-state published yet");
 });
 
 // A per-session chip event must not ride the periodic full push cycle, which runs SECONDS on a busy


### PR DESCRIPTION
## The bug

Creating a new SDK session showed "Opening session" dots seemingly forever, until the first message, which then answered instantly (reported 2026-08-13). Forensics on the live episode: the session was created at 08:54 (`states/<sid>.jsonl` first row), the kernel restarted at 09:50, and the dots persisted until the first message at 10:42.

Three designed behaviors compose into the wedge:
- a fresh SDK session writes **no transcript until its first turn**;
- the opening chip's SDK stand-down was the snapshot's `connected` flag, which is **in-memory only** — the dormant branch of `live_sessions()` omits the key entirely;
- kernel restarts kill idle SDK CLIs (they are children of the kernel) and boot reconcile deliberately leaves idle sessions lazy.

So every created-but-never-messaged session becomes dormant at the next restart, reports no `connected`, has no transcript, and the chip reads "opening" indefinitely — conflating "still connecting" with "dormant, a send wakes it in seconds".

Reproduced live pre-fix: create an SDK session, watch opening flip to ready on the handshake, kill just its CLI — the chip reverts to "opening" and stays there; one message respawns and answers instantly.

## The fix

The chip now covers exactly the event window it was always approximating: **a spawn in flight**.

- `kernel/sdk_backend.py` — the snapshot reports `spawning` (session thread up, client not yet; the handshake closes it). Dormant rows carry no spawning key.
- `kernel/kernel.py` — `Sessions.live()` threads `spawning` through the merge (the bgTasks lesson: a key the merge drops is invisible to every consumer), and the opening override keys on it instead of on `connected` being falsy. A dormant created session reads **ready**.
- The tmux leg is unchanged: tmux panes and their `@claude-state` outlive kernel restarts, so it never had the dormant case.

## Tests

- `tests/test_kernel_opening_chip.py` — the dormant regression (fails pre-fix), the spawn-window case, and a merge thread-through guard.
- `tests/test_kernel_opening.py` — pre-handshake row now models the real snapshot (`spawning=True`); new dormant-reads-ready case.
- `ui/webview/opening-state.test.ts` — source pins updated to the new gate.

Full suites green: pytest 4415 passed, node 1881 passed, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)