### PR TITLE
Command twins drop for both wrapper shapes; live stream matches skills

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -740,7 +740,14 @@ class FileAdapter:
         for u in kept:
             r = self.by_uuid.get(u) or {}
             if r.get("type") == "user" and r.get("promptId"):
-                m = COMMAND_NAME_RE.match(_text_of(_content(r.get("message"))) or "")
+                btext = _text_of(_content(r.get("message"))) or ""
+                # the SAME matcher the emit path uses (COMMAND_NAME_ANY_RE inside a wrapper record): the
+                # anchored-only form missed every <command-message>-FIRST invocation (skills / custom
+                # commands), so shape-B twins survived as phantom human segments beside the real command
+                # atom — same hash, different t (2026-08-13; the emit path got this fix on 2026-07-22 and
+                # this pre-pass silently didn't).
+                m = COMMAND_NAME_RE.match(btext) or (COMMAND_NAME_ANY_RE.search(btext)
+                                                     if CMD_WRAP_RE.match(btext) else None)
                 if m:
                     name = m.group(1).strip() or "/?"
                     cmd_prompt_names.setdefault(r["promptId"], set()).add(

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -141,7 +141,7 @@ JUDGE_FAIL_CAP = 3                       # the same rule for every other retryin
 #                                          model actually wrote. Closer / grouper / consolidator / courier; the
 #                                          planner (PLAN_PARSE_RETRIES) and distiller/briefer (DISTILL_FAIL_CAP)
 #                                          already had their own.
-PLACEMENTS_V = 7                         # placements-identity schema version (plan P2, the user 2026-07-06).
+PLACEMENTS_V = 8                         # placements-identity schema version (plan P2, the user 2026-07-06).
 #                                          v2 (2026-07-09): a 07-07/07-08 change to segment-text derivation
 #                                          stepped the text hash without this bump — dormant segments' old-hash
 #                                          placements stopped matching, and every restart/touch replayed them as
@@ -182,6 +182,12 @@ PLACEMENTS_V = 7                         # placements-identity schema version (p
 #                                          every compacted transcript (one live session: 5825 → 5850 atoms,
 #                                          25 messages recovered). Exactly v3's shape — a bigger atom set,
 #                                          not a shifted hash — so it takes the same seal.
+#                                          v8 (2026-08-13): the twin-drop pre-pass now matches
+#                                          <command-message>-FIRST wrappers like the emit path always did
+#                                          (COMMAND_NAME_ANY_RE) — the phantom raw-twin human atom beside
+#                                          every skill/custom-command invocation drops out. v5's shape in
+#                                          reverse: a SMALLER atom set for transcripts carrying shape-B
+#                                          commands, same seal.
 PLAN_SESSIONS = None                     # per-pass session cap — REMOVED (the user 2026-06-30): the fairness
                                          # caps were a recurring source of confusing starvation bugs (a goal/
                                          # nudge stuck behind a full per-pass window), never clearly needed.

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -229,6 +229,10 @@ def _block_to_dict(b):
 # UserMessages wrapped in these markers, and the LIVE atom must classify them exactly like the file
 # adapter classifies the matching transcript records.
 _COMMAND_NAME_RE = re.compile(r"^\s*<command-name>([^<]*)</command-name>")
+# …and the tag ANYWHERE inside a wrapper record (the event model's COMMAND_NAME_ANY_RE twin): a SKILL /
+# custom command writes <command-message> first, so the anchored form missed it and the live stream
+# swallowed the invocation as wrapper noise (2026-08-13 — the same shape the file adapter fixed 2026-07-22).
+_COMMAND_NAME_ANY_RE = re.compile(r"<command-name>([^<]*)</command-name>")
 _COMMAND_ARGS_RE = re.compile(r"<command-args>([\s\S]*?)</command-args>")
 _LOCAL_STDOUT_RE = re.compile(r"^\s*<local-command-stdout>([\s\S]*?)</local-command-stdout>")
 _CMD_WRAP_RE = re.compile(r"^\s*<(?:command-(?:name|message|args|contents)|local-command-(?:stdout|caveat))>")
@@ -298,7 +302,8 @@ def msg_to_atom(msg, sid, fsid, t, skill_tool_ids=()):
             return None
         text = " ".join(b.get("text", "") for b in content
                         if isinstance(b, dict) and b.get("type") == "text")
-        mcmd = _COMMAND_NAME_RE.match(text)
+        mcmd = _COMMAND_NAME_RE.match(text) or (_COMMAND_NAME_ANY_RE.search(text)
+                                                if _CMD_WRAP_RE.match(text) else None)
         if mcmd:                                     # the command INVOCATION → the command-flagged user atom
             name = mcmd.group(1).strip() or "/?"
             if not name.startswith("/"):

--- a/tests/test_cmd_twin_shapes.py
+++ b/tests/test_cmd_twin_shapes.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""The bare slash-invocation TWIN drops for BOTH wrapper shapes (2026-08-13). CLI 2.1.215+ writes a
+typed command TWICE — a raw-text user record and the wrapper record, sharing a promptId — and the
+wrapper's ORDER is not fixed: a built-in writes <command-name> first (shape A), a skill / custom
+command writes <command-message> first (shape B). The emit path has matched both since 2026-07-22
+(COMMAND_NAME_ANY_RE inside a wrapper record), but the twin-drop pre-pass stayed anchored-only, so a
+shape-B invocation kept its raw twin: a phantom human segment beside the real command atom — same
+text hash, different t — which read as a plannable human ask. Fixed under PLACEMENTS_V=8 (a SMALLER
+atom set for transcripts carrying shape-B commands — v5's shape in reverse, same seal).
+SYNTHETIC fixtures only (placeholder UUIDs, invented text)."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+em = SourceFileLoader("romp_em_twinshapes", os.path.join(BIN, "romp-event-model")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def urec(t, text, uuid, parent, prompt_id=None):
+    r = {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+         "message": {"role": "user", "content": text}, "sessionId": SID}
+    if prompt_id:
+        r["promptId"] = prompt_id
+    return r
+
+
+class TwinDropsForBothWrapperShapes(unittest.TestCase):
+    def _parse(self, recs, path_dir):
+        p = os.path.join(path_dir, SID + ".jsonl")
+        with open(p, "w") as fh:
+            fh.write("\n".join(json.dumps(r) for r in recs) + "\n")
+        return em.parse_session(p, rompuuid=SID)
+
+    def test_shape_a_name_first_twin_drops(self):
+        with tempfile.TemporaryDirectory() as td:
+            recs = [urec(1000, "/autocompact auto", "tw1", None, "p1"),
+                    urec(1001, "<command-name>/autocompact</command-name>\n"
+                               "<command-args>auto</command-args>", "cw1", "tw1", "p1")]
+            sess = self._parse(recs, td)
+            atoms = [a for t in sess["turns"] for a in t["atoms"] if a["type"] == "user"]
+            self.assertEqual(len(atoms), 1, "one atom per invocation — the raw twin is the echo")
+            self.assertEqual(atoms[0].get("command"), "/autocompact")
+
+    def test_shape_b_message_first_twin_drops_too(self):
+        with tempfile.TemporaryDirectory() as td:
+            recs = [urec(1000, "/jld help me write the abstract", "tw1", None, "p1"),
+                    urec(1001, "<command-message>jld</command-message>\n"
+                               "<command-name>/jld</command-name>\n"
+                               "<command-args>help me write the abstract</command-args>", "cw1", "tw1", "p1")]
+            sess = self._parse(recs, td)
+            atoms = [a for t in sess["turns"] for a in t["atoms"] if a["type"] == "user"]
+            self.assertEqual(len(atoms), 1,
+                             "the message-first wrapper is the same invocation — its twin is the same echo "
+                             "(the pre-pass used to match name-first only, leaving a phantom human segment)")
+            self.assertEqual(atoms[0].get("command"), "/jld")
+
+    def test_prose_quoting_a_wrapper_is_never_an_invocation(self):
+        with tempfile.TemporaryDirectory() as td:
+            recs = [urec(1000, "why does <command-name>/x</command-name> appear in my transcript?", "u1", None)]
+            sess = self._parse(recs, td)
+            atoms = [a for t in sess["turns"] for a in t["atoms"] if a["type"] == "user"]
+            self.assertEqual(len(atoms), 1)
+            self.assertIsNone(atoms[0].get("command"),
+                              "ANY-match applies only inside a record that BEGINS with a command wrapper")
+
+
+class LiveStreamMirrorsTheAnyMatch(unittest.TestCase):
+    def test_sdk_backend_builder_uses_the_any_match_inside_wrappers(self):
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
+        self.assertIn("_COMMAND_NAME_ANY_RE = re.compile", src)
+        self.assertIn("_COMMAND_NAME_RE.match(text) or (_COMMAND_NAME_ANY_RE.search(text)", src,
+                      "the live twin of the file adapter's matcher — a skill-shaped invocation must not "
+                      "stream as wrapper noise")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_placements_canary.py
+++ b/tests/test_placements_canary.py
@@ -116,7 +116,10 @@ class PlacementIdentityCanary(unittest.TestCase):
         # without a bump) should both fail loudly.
         # v6 (2026-07-22, the uuid-anchored text-less seg id) shifted the LAST pinned id off da39a3ee;
         # text-bearing ids are unchanged. Pins and version re-recorded together.
-        self.assertEqual(jd.PLACEMENTS_V, 7, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=7 — "
+        # v8 (2026-08-13, the shape-B twin drop): this fixture carries no command wrappers, so every
+        # pinned id is UNCHANGED — the bump seals transcripts that DO carry shape-B commands, whose
+        # phantom twin atom drops out of the set.
+        self.assertEqual(jd.PLACEMENTS_V, 8, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=8 — "
                          "re-pin the ids and this version together, in the same commit")
 
 


### PR DESCRIPTION
The twin-drop pre-pass now uses the emit path's matcher (`COMMAND_NAME_ANY_RE` inside a wrapper record), killing the phantom duplicate segment beside every `<command-message>`-first (skill/custom) invocation; `sdk_backend`'s live builder mirrors it so those invocations stop streaming as noise. `PLACEMENTS_V` → 8 with the canary re-pinned in the same commit per the deploy rule (the fixture has no command wrappers, so ids are unchanged — the seal covers dormant transcripts whose shape-B twin atom drops out). Tests: `tests/test_cmd_twin_shapes.py` (both shapes + the prose-quoting guard + the live mirror). Suites green (Python 4416, node 1881).

🤖 Generated with [Claude Code](https://claude.com/claude-code)