### PR TITLE
Feed links into a closed chat open the pane, then land the jump

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20749,6 +20749,12 @@ var B=bar.querySelectorAll('button'),KT='romp-mobile-tab';
 function show(p){if(!F[p])return;document.body.setAttribute('data-tab',p);for(var k in F)F[k].classList.toggle('m-on',k===p);
 for(var i=0;i<B.length;i++)B[i].classList.toggle('on',B[i].getAttribute('data-pane')===p);
 try{localStorage.setItem(KT,p);}catch(e){}}
+// A REVEAL un-hides a desktop-toggled-off pane before the mobile tab switch (the user 2026-08-13: a feed
+// click that jumps into a CLOSED chat used to land invisibly — the hidden iframe's WS stays live, so the
+// scroll ran under display:none and nothing appeared to happen). Same __rompPaneToggle(…, true) the Log
+// jump (feed) and toggleFleet (chat) precedents use; it persists via romp-panes like any manual toggle.
+// Guarded: the collapse script that defines __rompPaneToggle parses after this one — fine at message time.
+function reveal(p){try{window.__rompPaneToggle&&window.__rompPaneToggle(p,true);}catch(e){}show(p);}
 for(var i=0;i<B.length;i++)(function(b){var pk=b.getAttribute('data-pane');if(pk){b.addEventListener('click',function(){show(pk);});}})(B[i]);
 // the rail's actions on mobile: settings opens the feed iframe's modal (same path as the desktop
 // gear), net opens the shell's remotes panel, usage opens the tooltip's window bars as a modal, and
@@ -20760,7 +20766,7 @@ restart:function(){try{window.__rompRestart&&window.__rompRestart();}catch(e){}}
 errs:function(){try{window.__rompOpenErrs&&window.__rompOpenErrs();}catch(e){}}};
 Array.prototype.forEach.call(bar.querySelectorAll('button[data-act]'),function(b){
 b.addEventListener('click',function(){var f=A[b.getAttribute('data-act')];if(f)f();});});
-window.addEventListener('message',function(e){var m=e.data;if(!m)return;if(m.romp==='reveal'&&m.pane)show(m.pane);// the chat header's Fleet pill / the fleet's back-to-chat post toggleFleet — on mobile that IS a tab switch
+window.addEventListener('message',function(e){var m=e.data;if(!m)return;if(m.romp==='reveal'&&m.pane)reveal(m.pane);// the chat header's Fleet pill / the fleet's back-to-chat post toggleFleet — on mobile that IS a tab switch
 if(m.romp==='toggleFleet')show(m.to==='chat'?'chat':'fleet');});
 function shellWS(){try{var proto=location.protocol==='https:'?'wss://':'ws://';
 var ws=new WebSocket(proto+location.host+'/ws?app=shell');
@@ -20768,7 +20774,7 @@ var ws=new WebSocket(proto+location.host+'/ws?app=shell');
 // its icon badge immediately instead of waiting for the next change (plans/ios-app.md proposal 3)
 ws.onopen=function(){try{ws.send(JSON.stringify({type:'ready'}));}catch(e){}};
 ws.onmessage=function(ev){var m;try{m=JSON.parse(ev.data);}catch(e){return;}
-if(m&&m.type==='reveal'&&m.pane)show(m.pane);
+if(m&&m.type==='reveal'&&m.pane)reveal(m.pane);
 // the app-icon badge: setAppBadge only exists where badging works (installed apps) — everyone
 // else falls through silently, so this needs no capability gymnastics
 else if(m&&m.type==='badge'&&'setAppBadge' in navigator){

--- a/tests/test_per_viewer_focus.py
+++ b/tests/test_per_viewer_focus.py
@@ -122,8 +122,10 @@ class RemoteRevealReachesTheShell(unittest.TestCase):
         self.assertIn('else if (m.type === "confirmRevive" && m.id) {\n    revealSelfPane();', self.render)
 
     def test_the_mobile_shell_switches_tabs_on_that_window_message(self):
-        # the receiving half already existed (the Fleet pill posts the same shape); this pins the contract
-        self.assertIn("if(m.romp==='reveal'&&m.pane)show(m.pane);", km._LANDING_MOBILE_JS)
+        # the receiving half already existed (the Fleet pill posts the same shape); this pins the contract.
+        # reveal() = un-hide a desktop-toggled-off pane FIRST, then the mobile tab switch (the user
+        # 2026-08-13 — see tests/test_shell_reveal_unhide.py).
+        self.assertIn("if(m.romp==='reveal'&&m.pane)reveal(m.pane);", km._LANDING_MOBILE_JS)
 
 
 if __name__ == "__main__":

--- a/tests/test_shell_reveal_unhide.py
+++ b/tests/test_shell_reveal_unhide.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""A REVEAL un-hides a desktop-toggled-off pane (the user 2026-08-13): clicking a feed card that jumps
+into a CLOSED chat used to land invisibly — the hidden iframe's WS stays live, so the focus/scroll ran
+under display:none and the click read as a no-op. The shell's two reveal arrivals (the pane's own
+postMessage and the kernel's app=shell push) now both un-hide via __rompPaneToggle(p, true) — the same
+move the Log jump (feed) and toggleFleet (chat) precedents make — before the mobile tab switch, and the
+un-hide persists in romp-panes like any manual toggle. Source pins on the inline shell JS."""
+import os
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+SRC = open(os.path.join(os.path.dirname(HERE), "bin", "romp-kernel")).read()
+
+
+class RevealUnhidesThePane(unittest.TestCase):
+    def test_the_reveal_helper_unhides_then_tab_switches(self):
+        self.assertIn("function reveal(p){try{window.__rompPaneToggle&&window.__rompPaneToggle(p,true);}"
+                      "catch(e){}show(p);}", SRC,
+                      "un-hide FIRST (guarded — the collapse script parses later), then the mobile tab")
+
+    def test_both_reveal_arrivals_use_it(self):
+        self.assertIn("if(m.romp==='reveal'&&m.pane)reveal(m.pane);", SRC,
+                      "the pane's own postMessage (revealSelfPane — the only path that reaches the shell)")
+        self.assertIn("if(m&&m.type==='reveal'&&m.pane)reveal(m.pane);", SRC,
+                      "the kernel's app=shell push")
+
+    def test_hover_paths_stay_reveal_free(self):
+        # showAskPath / glowTurns are hover affordances — they must never yank a hidden pane open.
+        # They send no reveal at all, so it's enough that ONLY the two arrivals above call reveal().
+        self.assertEqual(SRC.count(")reveal(m.pane);"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/render-scroll.test.ts
+++ b/ui/webview/render-scroll.test.ts
@@ -169,6 +169,8 @@ test("ResizeObservers on #tabbar AND #ledger compensate #content.scrollTop by th
 test("a focus with `live` lands on the live tail — a blocked card's picker/permission prompt (the user 2026-07-08)", () => {
   // stick the target view to bottom so showActive scrolls there
   assert.match(RENDER, /if \(m\.live\) \{ const v = views\.get\(m\.id\); if \(v\) v\.stick = true; \}/);
-  // cover the ALREADY-ACTIVE case, where setActive early-returns (activeId === id, no anchor) → jump to bottom now
-  assert.match(RENDER, /if \(m\.live && activeId === m\.id\) \{\s*\n\s*const c = document\.getElementById\("content"\); if \(c\) c\.scrollTop = c\.scrollHeight;/);
+  // cover the ALREADY-ACTIVE case, where setActive early-returns (activeId === id, no anchor) → jump to
+  // bottom ONE FRAME later (the user 2026-08-13): when this focus is what un-hid a closed pane, the
+  // synchronous scroll ran at display:none (scrollHeight 0) and the jump read as a no-op
+  assert.match(RENDER, /if \(m\.live && activeId === m\.id\) \{[\s\S]{0,700}?window\.requestAnimationFrame\(\(\) => \{\s*\n\s*const c = document\.getElementById\("content"\); if \(c\) c\.scrollTop = c\.scrollHeight;/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8510,7 +8510,14 @@ window.addEventListener("message", (e: MessageEvent) => {
     // id, no anchor) and would otherwise leave a scrolled-up chat parked in history, not at the prompt.
     if (m.live) { const v = views.get(m.id); if (v) v.stick = true; }
     if (m.live && activeId === m.id) {
-      const c = document.getElementById("content"); if (c) c.scrollTop = c.scrollHeight;
+      // one frame LATER, not now: when this focus is what un-hid the pane (the shell's reveal lands a
+      // task after revealSelfPane's postMessage), the pane is still display:none here and scrollHeight
+      // is 0 — the jump read as a no-op (the user 2026-08-13). Next frame the layout is real; when the
+      // pane was already visible the deferral is invisible. Anchored jumps need nothing: landOn's
+      // ResizeObserver realign already re-lands them when the pane sizes in.
+      window.requestAnimationFrame(() => {
+        const c = document.getElementById("content"); if (c) c.scrollTop = c.scrollHeight;
+      });
     } else {
       setActive(m.id, m.anchor, typeof m.anchorT === "number" ? m.anchorT : undefined, typeof m.anchorKind === "string" ? m.anchorKind : undefined);
     }

--- a/ui/webview/reveal-unhide.test.ts
+++ b/ui/webview/reveal-unhide.test.ts
@@ -1,0 +1,17 @@
+// The chat side of the closed-pane jump (the user 2026-08-13): when a feed click's focus is what un-hid
+// the pane, the shell's reveal lands one task AFTER revealSelfPane's postMessage — so the synchronous
+// live-tail scroll ran at display:none (scrollHeight 0) and the jump read as a no-op. The live branch
+// defers one frame; anchored jumps need nothing (landOn's ResizeObserver realign re-lands them when the
+// pane sizes in). Source pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("focus reveals the pane first, and the live-tail scroll waits one frame for real layout", () => {
+  assert.match(RENDER, /revealSelfPane\(\);\s+\/\/ every focus is someone jumping HERE/);
+  assert.match(RENDER, /window\.requestAnimationFrame\(\(\) => \{\s*\n\s*const c = document\.getElementById\("content"\); if \(c\) c\.scrollTop = c\.scrollHeight;\s*\n\s*\}\);/,
+    "one frame later, not now — the un-hide lands a task after the postMessage");
+});


### PR DESCRIPTION
With the chat pane toggled off, a feed click's jump ran invisibly in the hidden iframe. The shell's two reveal arrivals now un-hide the pane first (`__rompPaneToggle(p, true)`, the Log-jump precedent, persisted like a manual toggle), and the chat's live-tail scroll defers one frame so it never scrolls zero-height content. Hover paths stay reveal-free (pinned). Tests: `tests/test_shell_reveal_unhide.py` + `ui/webview/reveal-unhide.test.ts`; suites green (Python 4464, node 1882).

🤖 Generated with [Claude Code](https://claude.com/claude-code)