### PR TITLE
API spend: persistent 1 day / 1 week / 1 month; unknown windows hover-only

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15630,7 +15630,7 @@ def _usage():
     # dollars belong on the rail next to the login's real %.
     if _auth_key_present():
         ksp = _spend_windows(keyed_only=True)
-        if any((ksp.get(k) or {}).get("turns") for k in ("fiveHour", "sevenDay", "month")):
+        if any((ksp.get(k) or {}).get("turns") for k in ("day", "week", "month")):
             out["spend"] = ksp
     return out
 
@@ -15711,7 +15711,13 @@ def _spend_windows(keyed_only=False):
         return _sum(v for k, v in hours.items() if k in keys)
 
     month = time.strftime("%Y-%m")
+    # day/week are the API-key cell's windows (the user 2026-08-13: pay-per-token has no reset windows,
+    # so "one day / one week / one month" is the honest read; the hour ledger holds 192h = 8 days, so
+    # both fit). fiveHour/sevenDay stay emitted for ONE release: a remote host on an older kernel still
+    # sums its cell from them (version skew), and the strip reads day||fiveHour meanwhile. month stays
+    # calendar month-to-date — it matches the bill.
     win = {"fiveHour": _rolling(5), "sevenDay": _rolling(7 * 24),
+           "day": _rolling(24), "week": _rolling(7 * 24),
            "month": _sum(v for k, v in days.items() if isinstance(k, str) and k.startswith(month))}
     for k, v in _spend_budgets().items():
         win[k]["budget"] = v
@@ -19828,12 +19834,14 @@ function hasBars(u){return !!(u&&(u.fiveHour||u.sevenDay||u.fable));}
 // machine, spend INSTEAD of bars); with per-session auth one host carries bars AND its key's spend at
 // once (the user 2026-08-08), so presence of the windows is the whole test. strip.ts carries the same
 // branch; the two copies must stay in step (rail-spend pins).
-function hasSpend(u){return !!(u&&u.spend&&u.spend.fiveHour);}
+function hasSpend(u){return !!(u&&u.spend&&(u.spend.day||u.spend.fiveHour));}
 function fmtTok(n){if(n>=1e9)return (n/1e9).toFixed(1).replace(/\.0$/,'')+'B';
 if(n>=1e6)return (n/1e6).toFixed(1).replace(/\.0$/,'')+'M';
 if(n>=1e3)return (n/1e3).toFixed(1).replace(/\.0$/,'')+'k';return String(n);}
 function fmtUsd(v){return '$'+String(Math.round(v));}   // whole dollars everywhere — no cents (the user 2026-08-09)
-var SPEND_WINS=[['fiveHour','5 hours'],['sevenDay','7 days'],['month','Month']];
+// pay-per-token has no reset windows (the user 2026-08-13): the key's story is 1 day / 1 week / 1 month.
+// fiveHour/sevenDay fallbacks remain readable from older remote kernels (version skew) via day||fiveHour.
+var SPEND_WINS=[['day','1 day'],['week','1 week'],['month','1 month']];
 // The per-host SPEND detail for the rich hover: plain NUMBERS per window (dollars, tokens, turns).
 // No bars anywhere for spend (the user 2026-08-08: the spend bar graphs told you nothing. The old
 // hover scaled each window's bar to the largest window, a shape with no meaning, and the budget-fill
@@ -19861,25 +19869,24 @@ det[w[0]]={name:w[2],pct:pct,col:col,tp:tp,unk:rolled,ago:(rolled?fmtAgo(seg.res
 // every reporter has ROLLED is unknown ('?'), exactly as a single account's was; a shared login on two
 // hosts reports the same number twice and the max collapses it for free.
 function aggBarsHTML(live){var html='';
-WINS.forEach(function(w){var best=null,anyRolled=false;
+WINS.forEach(function(w){var best=null;
 live.forEach(function(e){var d=e.det[w[0]];if(!d)return;
-if(d.unk){anyRolled=true;return;}
+if(d.unk)return;
 if(!best||d.pct>best.pct)best=d;});
-if(!best&&!anyRolled)return;
+if(!best)return;
 // Horizontal fill bars (the user 2026-07-05): an expanded label, then TWO stacked horizontal tracks: the
 // used-% bar (colormap colour) ON TOP of the elapsed-% bar (slate) so you can compare pace at a glance (used
 // ahead of elapsed = burning too fast), then the used-% readout. All inline (label \u00b7 bars \u00b7 %).
-// An UNKNOWN window draws NO BARS (the user 2026-07-31, round 2): a faded last-known fill still
-// asserts a value we do not have; the length itself is the lie. Its slot holds a single '?' so the
-// rows stay aligned, and the last-known number lives in the hover, labelled as such.
-html+='<div class="ru-w'+(best?'':' ru-unk')+'" data-w="'+w[0]+'">'
+// An UNKNOWN window is not drawn AT ALL on the bar (the user 2026-08-13; supersedes the 2026-07-31 '?'
+// slot): the bar shows only what we know, and the last-known number keeps living in the hover,
+// labelled as such (winDet still computes unk/ago for exactly that).
+html+='<div class="ru-w" data-w="'+w[0]+'">'
 +'<div class=ru-name>'+w[2]+'</div>'
-+(best?('<div class=ru-bars>'
++'<div class=ru-bars>'
 +'<div class=ru-track><i class=ru-fill style="width:'+best.pct+'%;background:'+best.col+'"></i></div>'
 +'<div class=ru-track><i class=ru-fill style="width:'+(best.tp||0)+'%;background:#6b7a8c"></i></div>'
 +'</div>'
-+'<div class=ru-pct>'+best.pct+'%</div>')
-:'<div class=ru-bars><div class=ru-qmark>?</div></div>')
++'<div class=ru-pct>'+best.pct+'%</div>'
 +'</div>';});
 return html;}
 // The API cell (the user 2026-08-08): ONE compact entry for everything key-billed across the fleet \u2014
@@ -19890,15 +19897,19 @@ return html;}
 // constant 'API' \u2014 no fragment of any key, not even a last-4 tail, reaches a surface (2026-08-08,
 // evening: a tail is still key material, and the hover's HOST names already tell whose spend is
 // whose). The full per-window, per-host breakdown is the hover's job.
-function apiCellHTML(live){var sum={fiveHour:{usd:0,tok:0},month:{usd:0,tok:0}},any=false;
+function apiCellHTML(live){var sum={day:{usd:0,tok:0},month:{usd:0,tok:0}},any=false;
 live.forEach(function(e){var sp=e.det._spend;if(!sp)return;any=true;
-['fiveHour','month'].forEach(function(k){var s=sp[k];if(s){sum[k].usd+=s.usd;sum[k].tok+=s.tok||0;}});});
+// day||fiveHour: an older remote kernel ships no 'day' window yet (version skew) \u2014 its 5h burn is the
+// closest honest stand-in until it updates, and dropping it entirely would blank that host's spend
+var d=sp.day||sp.fiveHour,m=sp.month;
+if(d){sum.day.usd+=d.usd;sum.day.tok+=d.tok||0;}
+if(m){sum.month.usd+=m.usd;sum.month.tok+=m.tok||0;}});
 if(!any)return '';
 var seg=function(k,lbl){return '<div class=ru-name>'+lbl+'</div>'
 +'<div class=ru-pct>'+fmtUsd(sum[k].usd)+' \u00b7 '+fmtTok(sum[k].tok)+' tok</div>';};
 return '<div class="ru-w ru-api">'
 +'<div class=ru-name>API</div>'
-+seg('fiveHour','5 hours')+seg('month','Month')
++seg('day','1 day')+seg('month','1 month')
 +'</div>';}
 // The collapsed rail is the AGGREGATE story (the user 2026-08-08; supersedes the one-set-per-account
 // rendering of 2026-07-30): one set of window bars for the whole fleet plus one API cell, never a
@@ -21444,11 +21455,9 @@ def _landing():
             ".ru-bars{display:flex;flex-direction:column;gap:2px;flex:0 0 auto}"   # used bar stacked over elapsed bar
             ".ru-track{position:relative;width:54px;height:5px;background:rgba(255,255,255,0.12);border-radius:3px;overflow:hidden;flex:0 0 auto}"
             ".ru-fill{position:absolute;left:0;top:0;height:100%;border-radius:3px;transition:width .3s ease}"
-            # UNKNOWN (the user 2026-07-31): a rolled window draws NO bars at all — a fill of any length
-            # asserts a value we do not have — only a '?' in the bars' slot. The last-known reading survives
-            # in the tooltip, labelled "last known" and faded, which is honest because it says what it is.
-            ".ru-qmark{width:54px;display:flex;align-items:center;justify-content:center;"
-            "font:600 11px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#8a97a6}"
+            # UNKNOWN (the user 2026-08-13; supersedes the 2026-07-31 '?' slot): a rolled window is not
+            # drawn on the bar AT ALL — only what we know shows there. The last-known reading survives in
+            # the tooltip, labelled "last known" and faded, which is honest because it says what it is.
             ".ru-tip-row.ru-unk i{opacity:.3}.ru-tip-row.ru-unk .ru-tip-k,.ru-tip-row.ru-unk .ru-tip-v{color:#8a97a6}"
             ".ru-pct{font:600 10px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#cfe6ff;font-variant-numeric:tabular-nums;white-space:nowrap}"
             # ONE shared hover panel for BOTH windows (the user 2026-06-26): it reproduces exactly the used/

--- a/tests/test_kernel_rail_usage.py
+++ b/tests/test_kernel_rail_usage.py
@@ -119,15 +119,13 @@ class RailUsage(unittest.TestCase):
                       self.html, "the reading survives the roll — it is last-known, not zeroed")
         self.assertIn("var tp=(!rolled&&seg.resetsAt&&w[1])", self.html,
                       "no pace bar against a window that already ended")
-        # NO BARS at all (round 2): a fill of any length asserts a value we do not have, so the bars'
-        # slot holds only a '?'. The last-known number survives in the tooltip, labelled as such.
-        # (2026-08-08: the aggregate draws the '?' only when EVERY host's reading of that window has
-        # rolled — one live reading is a real value, and an unknown never counts as one.)
-        self.assertIn("if(d.unk){anyRolled=true;return;}", self.html,
+        # NOT DRAWN at all (the user 2026-08-13; supersedes the 2026-07-31 '?' slot): the bar shows
+        # only what we know — an all-unknown window contributes no row. The last-known number keeps
+        # living in the tooltip, labelled as such (the pins below).
+        self.assertIn("if(d.unk)return;", self.html,
                       "a rolled reading never competes as a value in the aggregate")
-        self.assertIn(":'<div class=ru-bars><div class=ru-qmark>?</div></div>'", self.html,
-                      "an all-unknown window draws a '?' where its bars would be")
-        self.assertIn(".ru-qmark{width:54px", self.html, "the mark takes the bars' width, so rows stay aligned")
+        self.assertIn("if(!best)return;", self.html, "no known reading → no row at all")
+        self.assertNotIn("ru-qmark", self.html, "the '?' slot is gone from the bar")
         self.assertNotIn(".ru-unk .ru-fill{opacity:.3}", self.html, "no faded fill on the face any more")
         self.assertIn("<span class=ru-tip-k>last known</span>", self.html,
                       "the hover is the ONE place the stale number appears, and it says what it is")

--- a/tests/test_usage_per_account.py
+++ b/tests/test_usage_per_account.py
@@ -180,7 +180,10 @@ class RailRendering(unittest.TestCase):
         # graphs are gone everywhere (2026-08-08, morning: they told you nothing)
         self.assertIn("'<div class=ru-name>API</div>'", self.js)
         self.assertNotIn("_tail", self.js)
-        self.assertIn("seg('fiveHour','5 hours')+seg('month','Month')", self.js)
+        # pay-per-token wears calendar-ish windows (the user 2026-08-13): 1 day + 1 month on the cell
+        # (1 week rides the hover); day||fiveHour keeps an older remote's spend visible (version skew)
+        self.assertIn("seg('day','1 day')+seg('month','1 month')", self.js)
+        self.assertIn("var d=sp.day||sp.fiveHour,m=sp.month;", self.js)
         self.assertIn("'<div class=ru-pct>'+fmtUsd(sum[k].usd)+' · '+fmtTok(sum[k].tok)+' tok</div>'", self.js)
         self.assertNotIn("spendColor", self.js)
         self.assertNotIn("spendWinsHTML", self.js)

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -28,13 +28,15 @@ test("the kernel serves spend windows for BOTH payload shapes, keyed-only beside
   // dollars nobody is billed — and only when key turns actually exist (the user 2026-08-08)
   assert.ok(KERNEL.includes("def _spend_windows(keyed_only=False):"));
   assert.ok(KERNEL.includes("ksp = _spend_windows(keyed_only=True)"));
-  assert.match(KERNEL, /if any\(\(ksp\.get\(k\) or \{\}\)\.get\("turns"\) for k in \("fiveHour", "sevenDay", "month"\)\):/);
+  assert.match(KERNEL, /if any\(\(ksp\.get\(k\) or \{\}\)\.get\("turns"\) for k in \("day", "week", "month"\)\):/);
   // no fragment of the key rides ANY payload (the user 2026-08-08, evening): the tail plumbing is
   // gone from the kernel wholesale, and the keyed-spend gate is a plain existence check
   assert.ok(KERNEL.includes("if _auth_key_present():"));
   assert.ok(!KERNEL.includes("apiTail"), "no key material in any usage payload");
   assert.ok(!KERNEL.includes("authTail"), "no key material in the status payload either");
-  // rolling 5h/7d read the HOUR buckets; month-to-date reads the day ledger
+  // rolling day/week read the HOUR buckets (192h = 8 days fits both); month-to-date reads the day
+  // ledger. fiveHour/sevenDay stay emitted ONE release for version skew (the user 2026-08-13).
+  assert.match(KERNEL, /"day": _rolling\(24\), "week": _rolling\(7 \* 24\)/);
   assert.match(KERNEL, /"fiveHour": _rolling\(5\), "sevenDay": _rolling\(7 \* 24\)/);
   assert.ok(KERNEL.includes("k.startswith(month)"));
   // the accumulator: cumulative-per-process DELTAS, and each bucket splits out the key's own turns
@@ -54,12 +56,14 @@ test("VS Code strip: spend is ONE API cell keyed on the windows' PRESENCE — th
   // presence, not the apiKey flag: a mixed host's payload carries bars AND spend at once — and the
   // 5h window is the whole test, the same hasSpend branch the rail runs
   assert.ok(STRIP.includes("const sp = usage && usage.spend;"));
-  assert.ok(STRIP.includes("if (!sp || !sp.fiveHour) return null;"));
+  // day||fiveHour: an older kernel ships no 'day' yet (version skew) — its 5h burn stands in
+  assert.ok(STRIP.includes("if (!sp || !(sp.day || sp.fiveHour)) return null;"));
+  assert.ok(STRIP.includes("const daySeg = sp.day || sp.fiveHour;"));
   assert.doesNotMatch(STRIP, /usage\.apiKey && usage\.spend/);
   assert.doesNotMatch(STRIP, /spendWindows/, "spend never renders as window rows any more");
-  // the collapsed cell carries 5h + month (like the rail's seg('fiveHour')+seg('month')); one display
-  // name per window, dollars AND tokens beside each other
-  assert.match(STRIP, /\[\["fiveHour", "5 hours", "5h"\], \["month", "Month", "mo"\]\]/);
+  // the collapsed cell carries 1 day + 1 month (the user 2026-08-13: pay-per-token has no reset
+  // windows); one display name per window, dollars AND tokens beside each other
+  assert.match(STRIP, /\[\["day", "1 day", "1d", daySeg\],\s*\n\s*\["month", "1 month", "1mo", sp\.month\]\]/);
   assert.match(STRIP, /tok\.textContent = " · " \+ fmtTok\(s\.tok\) \+ " tok";/);
   // the old one-off chip is gone, and with it any minted style
   assert.doesNotMatch(STRIP, /spendChip/);
@@ -74,7 +78,8 @@ test("the web rail's API cell is numbers under a constant label — no spend bar
   assert.ok(usageJS.includes("function apiCellHTML(live)"));
   assert.ok(usageJS.includes("'<div class=ru-name>API</div>'"));
   assert.ok(!usageJS.includes("_tail"), "no tail plumbing survives in the rail JS");
-  assert.ok(usageJS.includes("seg('fiveHour','5 hours')+seg('month','Month')"));
+  assert.ok(usageJS.includes("seg('day','1 day')+seg('month','1 month')"));
+  assert.ok(usageJS.includes("var d=sp.day||sp.fiveHour,m=sp.month;"), "older remote kernels stay visible");
   assert.ok(usageJS.includes("var seg=function(k,lbl){return '<div class=ru-name>'+lbl+'</div>'"));
   assert.ok(usageJS.includes("'<div class=ru-pct>'+fmtUsd(sum[k].usd)+' \\u00b7 '+fmtTok(sum[k].tok)+' tok</div>'"));
   // the graph and the budget fills are gone: no spend track, no spend color ramp, no shared scale
@@ -82,7 +87,7 @@ test("the web rail's API cell is numbers under a constant label — no spend bar
   assert.ok(!usageJS.includes("spendWinsHTML"), "spend never renders as window rows with tracks");
   assert.ok(!usageJS.includes("var mx=1;"), "the token auto-scale graph is gone");
   // presence-keyed, like the strip
-  assert.ok(usageJS.includes("function hasSpend(u){return !!(u&&u.spend&&u.spend.fiveHour);}"));
+  assert.ok(usageJS.includes("function hasSpend(u){return !!(u&&u.spend&&(u.spend.day||u.spend.fiveHour));}"));
 });
 
 test("one display name per window, worn everywhere: bars, hover sections, API cell, notices", () => {

--- a/ui/webview/strip.css
+++ b/ui/webview/strip.css
@@ -55,12 +55,9 @@
 .ru-track { position: relative; width: auto; height: 5px; background: rgba(255, 255, 255, 0.12);
   border-radius: 3px; overflow: hidden; flex: 0 0 auto; display: block; }
 .ru-fill { position: absolute; left: 0; top: 0; height: 100%; border-radius: 3px; transition: width .3s ease; }
-/* UNKNOWN (the user 2026-07-31): the window reset since the last report, so the reading no longer
-   describes the present. NO BARS are drawn — a fill of any length asserts a value we do not have —
-   just a "?" in the bars' slot, which keeps the rows aligned and survives the narrow tiers where the
-   % readout is hidden. The last-known number lives in the hover, labelled as such. */
-.ru-qmark { display: flex; align-items: center; justify-content: center; width: 100%;
-  color: #8a97a6; font: 600 11px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+/* UNKNOWN (the user 2026-08-13; supersedes the 2026-07-31 '?' slot): a window whose reading no longer
+   describes the present is not drawn at all — the bar shows only what we know, and the last-known
+   number rides the usage wrap's hover title, labelled as such. */
 .ru-pct { font: 600 10px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #cfe6ff;
   font-variant-numeric: tabular-nums; white-space: nowrap; }
 

--- a/ui/webview/strip.test.ts
+++ b/ui/webview/strip.test.ts
@@ -159,27 +159,34 @@ test("both bundles init the strip; the web pages never opt in", () => {
 });
 
 // ── the API spend CELL (the user 2026-08-11): the rail moved key spend to one compact cell — "API",
-// then the 5-hour burn and the month-to-date as designator → dollars·tokens pairs, no bars — and the
-// strip must mirror it. Spend-as-rows was the old grammar; on a key-billed machine it read as broken.
-test("apiCell arms on the spend windows' presence and carries the 5-hour burn + month-to-date", () => {
+// then designator → dollars·tokens pairs, no bars — and the strip must mirror it. Pay-per-token wears
+// calendar-ish windows (the user 2026-08-13): 1 day + 1 month on the cell, 1 week in the hover.
+test("apiCell arms on the spend windows' presence and carries 1 day + 1 month", () => {
   const cell = apiCell({ spend: {
-    fiveHour: { usd: 12.34, tok: 3_456_000, turns: 5 },
-    sevenDay: { usd: 40.2, tok: 9_000_000, turns: 21 },
+    day: { usd: 12.34, tok: 3_456_000, turns: 5 },
+    week: { usd: 40.2, tok: 9_000_000, turns: 21 },
     month: { usd: 87.9, tok: 20_500_000, turns: 60 },
   } });
   assert.ok(cell);
   assert.deepEqual(cell!.segs.map((s) => [s.key, s.label, s.short]),
-    [["fiveHour", "5 hours", "5h"], ["month", "Month", "mo"]],
-    "the collapsed cell shows 5h + month only — 7 days lives in the hover");
+    [["day", "1 day", "1d"], ["month", "1 month", "1mo"]],
+    "the collapsed cell shows 1 day + 1 month only — 1 week lives in the hover");
   assert.deepEqual(cell!.segs.map((s) => fmtUsd(s.usd)), ["$12", "$88"], "whole dollars, no cents");
   assert.match(cell!.title, /^API-key spend\n/);
-  assert.match(cell!.title, /7 days — \$40 · 9M tok · 21 turns/, "the hover keeps the full breakdown");
-  assert.match(cell!.title, /5 hours — \$12 · 3\.5M tok · 5 turns/);
+  assert.match(cell!.title, /1 week — \$40 · 9M tok · 21 turns/, "the hover keeps the full breakdown");
+  assert.match(cell!.title, /1 day — \$12 · 3\.5M tok · 5 turns/);
+});
+
+test("an older kernel's fiveHour window still arms the cell (version skew)", () => {
+  const cell = apiCell({ spend: { fiveHour: { usd: 3.2, tok: 900_000, turns: 2 } } });
+  assert.ok(cell, "day||fiveHour — a remote host on an older kernel must not blank its spend");
+  assert.deepEqual(cell!.segs.map((s) => [s.key, fmtUsd(s.usd)]), [["day", "$3"]],
+    "the 5h burn stands in under the 1-day designator until that host updates");
 });
 
 test("no key spend → no cell; and no fragment of any key ever reaches the strip", () => {
   assert.equal(apiCell(null), null);
-  assert.equal(apiCell({ spend: {} }), null, "presence of the 5h window is the whole test — the rail's hasSpend branch");
+  assert.equal(apiCell({ spend: {} }), null, "presence of the day window is the whole test — the rail's hasSpend branch");
   const ROOT = path.resolve(process.cwd(), "..");
   const src = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
   assert.ok(!src.includes("apiTail") && !src.includes("authTail"), "constant 'API' label — no key-tail plumbing");
@@ -199,15 +206,15 @@ test("the cell's dollars survive every tier; tokens fold at tier 2, labels at 3 
   assert.doesNotMatch(css, /ru-textonly/, "the ghost-row mechanism died with spend-as-rows");
 });
 
-test("an unknown window draws NO bars — just a '?' in their slot (the user 2026-07-31, round 2)", () => {
-  // a faded last-known fill still asserts a value we do not have: the length itself is the lie. The
-  // mark takes the bars' slot (so rows stay aligned, and it survives the narrow tiers where the %
-  // readout is hidden), and the % readout is dropped — the "?" IS the readout.
+test("an unknown window is not drawn on the bar at all — its last-known lives on hover (the user 2026-08-13)", () => {
+  // supersedes the 2026-07-31 '?' slot: the bar shows only what we know. The strip has no rich hover
+  // panel, so the hidden rows' last-known text rides the usage wrap's own title, labelled as such.
   const ROOT = path.resolve(process.cwd(), "..");
   const src = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.ts"), "utf8");
   const css = fs.readFileSync(path.join(ROOT, "ui", "webview", "strip.css"), "utf8");
-  assert.match(src, /if \(w\.unknown\) \{[\s\S]{0,700}q\.className = "ru-qmark";\s*\n\s*q\.textContent = "\?";/);
-  assert.match(src, /bars\.appendChild\(q\);\s*\n\s*box\.append\(name, bars\);/, "no .ru-pct on an unknown row");
-  assert.doesNotMatch(css, /\.ru-w\.ru-unk \.ru-fill \{ opacity: 0\.3; \}/, "the faded fill is gone");
-  assert.match(css, /\.ru-qmark \{ display: flex; align-items: center; justify-content: center; width: 100%;/);
+  assert.match(src, /if \(w\.unknown\) \{ unknownLines\.push\(w\.title\); continue; \}/);
+  assert.match(src, /usageWrap\.title = unknownLines\.length\s*\n\s*\? "Not shown \(no current reading\):\\n" \+ unknownLines\.join\("\\n"\) : "";/);
+  assert.doesNotMatch(src, /ru-qmark/, "the '?' slot is gone");
+  assert.doesNotMatch(css, /ru-qmark/);
+  assert.doesNotMatch(css, /\.ru-w\.ru-unk \.ru-fill \{ opacity: 0\.3; \}/, "the faded fill stays gone");
 });

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -107,16 +107,20 @@ export type ApiCell = {
 };
 export function apiCell(usage: any): ApiCell | null {
   const sp = usage && usage.spend;
-  if (!sp || !sp.fiveHour) return null;
+  // pay-per-token has no reset windows (the user 2026-08-13): the key's story is 1 day / 1 week /
+  // 1 month. day||fiveHour: an older kernel ships no 'day' yet (version skew) — its 5h burn is the
+  // closest honest stand-in until it updates.
+  if (!sp || !(sp.day || sp.fiveHour)) return null;
   const segs: ApiCell["segs"] = [];
-  for (const [key, label, short] of [["fiveHour", "5 hours", "5h"], ["month", "Month", "mo"]] as const) {
-    const seg = sp[key];
+  const daySeg = sp.day || sp.fiveHour;
+  for (const [key, label, short, seg] of [["day", "1 day", "1d", daySeg],
+                                          ["month", "1 month", "1mo", sp.month]] as const) {
     if (!seg || typeof seg.usd !== "number") continue;
     segs.push({ key, label, short, usd: seg.usd, tok: seg.tok || 0 });
   }
   if (!segs.length) return null;
   const lines = ["API-key spend"];
-  for (const [key, label] of [["fiveHour", "5 hours"], ["sevenDay", "7 days"], ["month", "Month"]] as const) {
+  for (const [key, label] of [["day", "1 day"], ["week", "1 week"], ["month", "1 month"]] as const) {
     const seg = sp[key];
     if (!seg || typeof seg.usd !== "number") continue;
     const turns = seg.turns || 0;
@@ -235,9 +239,14 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
     const nowS = Math.floor(Date.now() / 1000);
     usageWrap.textContent = "";
     // the subscription windows render as bar rows; key spend follows as ONE API cell (the rail's order)
+    // An UNKNOWN window is not drawn AT ALL (the user 2026-08-13; supersedes the 2026-07-31 '?' slot):
+    // the bar shows only what we know. Its last-known reading survives on HOVER — the strip has no rich
+    // panel, so the unknown rows' text rides the whole strip's title, labelled as such.
+    const unknownLines: string[] = [];
     for (const w of usageWindows(usage, nowS)) {
+      if (w.unknown) { unknownLines.push(w.title); continue; }
       const box = document.createElement("span");
-      box.className = "ru-w" + (w.unknown ? " ru-unk" : "");
+      box.className = "ru-w";
       box.title = w.title;
       // Both the expanded label and the compressed tag render; the [data-tier]
       // ladder in strip.css shows exactly one (or neither at the narrowest tier),
@@ -263,25 +272,12 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
         track.appendChild(fill);
         return track;
       };
-      if (w.unknown) {
-        // NO BARS AT ALL for an unknown window (the user 2026-07-31, round 2): a faded last-known fill
-        // still draws a value, and we do not have one — the length itself is the lie. The bars' slot
-        // holds a single "?" instead, keeping the row's alignment; the last-known number stays in the
-        // hover, explicitly labelled. The % readout is dropped too — the "?" IS the readout, and it
-        // survives the narrow tiers, where .ru-pct is hidden but the bars slot is always drawn.
-        const q = document.createElement("span");
-        q.className = "ru-qmark";
-        q.textContent = "?";
-        bars.appendChild(q);
-        box.append(name, bars);
-      } else {
-        if (w.pct != null) bars.appendChild(mkTrack(w.pct, usageColor(w.pct)));
-        if (w.elapsedPct != null) bars.appendChild(mkTrack(w.elapsedPct, "#6b7a8c"));
-        const pct = document.createElement("span");
-        pct.className = "ru-pct";
-        pct.textContent = `${w.pct}%`;
-        box.append(name, bars, pct);
-      }
+      if (w.pct != null) bars.appendChild(mkTrack(w.pct, usageColor(w.pct)));
+      if (w.elapsedPct != null) bars.appendChild(mkTrack(w.elapsedPct, "#6b7a8c"));
+      const pct = document.createElement("span");
+      pct.className = "ru-pct";
+      pct.textContent = `${w.pct}%`;
+      box.append(name, bars, pct);
       usageWrap.appendChild(box);
     }
     // The API cell — the rail's apiCellHTML twin (see apiCell above): "API", then designator → value
@@ -318,6 +314,9 @@ export function initStrip(openSettings: () => void, post?: (m: Record<string, un
       }
       usageWrap.appendChild(box);
     }
+    // the hidden-from-the-bar unknowns keep a hover home: the wrap's own title says what we last knew
+    usageWrap.title = unknownLines.length
+      ? "Not shown (no current reading):\n" + unknownLines.join("\n") : "";
     fit();
   }
 


### PR DESCRIPTION
The API-key cell moves to pay-per-token's honest windows — **1 day + 1 month** on the cell, **1 week** on hover — from the restart-proof `spend.json` ledger (rollups computed at read time, so restarts can't zero them). Login keeps 5h/7d. Unknown ("?") windows leave the bottom bar entirely on both surfaces; last-known readings stay on hover (the strip carries them on the usage wrap's title since it has no rich panel). One-release `day||fiveHour` skew fallback keeps older remote kernels' spend visible. Pins updated across the four suites; all green (Python 4461, node 1882).

Known limitation, deliberately out of scope: judge-pipeline spend is logged per call in judge-usage.jsonl but never folds into the cell (rows carry no billing-account stamp — judges bill per-session accounts), so the key's cell undercounts by the judge pipeline. Fixing that needs per-row account stamping going forward; filed for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)