### PR TITLE
Analytics: instant modal, incremental judge-ledger parse, honest 7d/30d

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16401,23 +16401,77 @@ def _session_tokens(path, t0):
     return acc
 
 
+# judge-usage.jsonl is append-only, time-ordered, and never rotated (38.7 MB / 148k lines measured
+# 2026-08-13) — and BOTH the analytics modal and EVERY timeline build used to re-read and re-parse it
+# in full, on the GIL, so a slow /analytics also froze the pusher and the whole dashboard with it (the
+# user 2026-08-13, who watched the cost modal sit on "loading…"). One shared incremental reader now:
+# rows parse ONCE, appends parse from the last byte offset, and rows older than the widest consumer
+# window (30 days, plus a day of slack) are pruned so memory stays bounded. A shrunken file (rotation,
+# a fresh install) resets cleanly.
+_JUDGE_USAGE_RETAIN = 31 * 86400
+_JUDGE_USAGE_CACHE = {"path": None, "size": -1, "mtime": 0.0, "rows": []}
+
+
+def _judge_usage_rows():
+    """Every parsed judge-usage row from the last ~31 days, incrementally maintained. Fully defensive —
+    a missing or garbled log never breaks a build; a mid-append partial line is left for the next read.
+    Keyed on the PATH too (a test repointing jd.STATE must never inherit another dir's offset — the
+    overrides-sandbox lesson) and reset on a same-size mtime change (an in-place rewrite)."""
+    p = jd.STATE / "judge-usage.jsonl"
+    c = _JUDGE_USAGE_CACHE
+    try:
+        st = os.stat(p)
+        size = st.st_size
+    except OSError:
+        c["path"], c["size"], c["rows"] = str(p), -1, []
+        return c["rows"]
+    if str(p) != c["path"]:
+        c["path"], c["size"], c["rows"] = str(p), -1, []
+    if size == c["size"] and st.st_mtime == c["mtime"]:
+        return c["rows"]
+    if size <= c["size"] or c["size"] < 0:
+        c["size"], c["rows"] = 0, []                    # rotated/truncated/rewritten, or the first read
+    try:
+        with open(p, "rb") as fh:
+            fh.seek(c["size"])
+            chunk = fh.read()
+    except OSError:
+        return c["rows"]
+    cut = chunk.rfind(b"\n")
+    if cut < 0:
+        return c["rows"]                                # nothing complete beyond the offset yet
+    for ln in chunk[:cut].split(b"\n"):
+        if not ln.strip():
+            continue
+        try:
+            o = json.loads(ln.decode("utf-8", errors="replace"))
+        except Exception:
+            continue
+        if isinstance(o, dict):
+            c["rows"].append(o)
+    c["size"] += cut + 1
+    c["mtime"] = st.st_mtime
+    # retention keyed to the DATA's own newest row, never the wall clock (a replayed/synthetic log's
+    # history must not evaporate): rows arrive in time order, so prune the left edge only
+    newest = (c["rows"][-1].get("t") or 0) if c["rows"] else 0
+    floor = newest - _JUDGE_USAGE_RETAIN
+    if c["rows"] and (c["rows"][0].get("t") or 0) < floor:
+        i = 0
+        while i < len(c["rows"]) and (c["rows"][i].get("t") or 0) < floor:
+            i += 1
+        del c["rows"][:i]
+    return c["rows"]
+
+
 def _judge_usage(t0):
-    """Roll up the judge PIPELINE's token usage from judge-usage.jsonl (one line per judge call, written
-    by romp-judge) within [t0, now]: a grand total plus per-judge and per-tier {calls,in,out,cost,ms}.
-    Empty/zeros until the log exists. Fully defensive — a missing or garbled log never breaks the build."""
+    """Roll up the judge PIPELINE's token usage (one row per judge call, written by romp-judge) within
+    [t0, now]: a grand total plus per-judge and per-tier {calls,in,out,cost,ms}. Reads the shared
+    incremental row cache — never the file. Empty/zeros until the log exists."""
     def blank():
         return {"calls": 0, "in": 0, "out": 0, "cost": 0.0, "ms": 0}
     total, by_judge, by_tier = blank(), {}, {}
-    try:
-        lines = (jd.STATE / "judge-usage.jsonl").read_text(errors="replace").splitlines()
-    except OSError:
-        return {"total": total, "byJudge": by_judge, "byTier": by_tier}
-    for ln in lines:
-        try:
-            o = json.loads(ln)
-        except Exception:
-            continue
-        if not isinstance(o, dict) or (o.get("t") or 0) < t0:
+    for o in _judge_usage_rows():
+        if (o.get("t") or 0) < t0:
             continue
         for b in (total, by_judge.setdefault(o.get("judge") or "?", blank()),
                   by_tier.setdefault(o.get("tier") or "?", blank())):
@@ -16429,20 +16483,8 @@ def _judge_usage(t0):
     return {"total": total, "byJudge": by_judge, "byTier": by_tier}
 
 
-def _token_windows(paths, now):
-    """Token usage by the two windows Claude meters — 5h ("session") + 7d ("week") — each split into the
-    coding SESSIONS (summed transcript usage of `paths`) and the judge PIPELINE (_judge_usage), in/out kept
-    apart, cache_r carried for the tooltip. Both halves draw the same subscription quota, so the summed
-    in+out reflects what that window's /usage % is spending. Cheap: _session_tokens caches per-path rows,
-    so re-summing per window just re-iterates the cache."""
-    def split(t0):
-        s = {"in": 0, "out": 0, "cache_r": 0}
-        for p in paths:
-            d = _session_tokens(p, t0)
-            s["in"] += d["in"]; s["out"] += d["out"]; s["cache_r"] += d["cache_r"]
-        return {"sessions": s, "pipeline": _judge_usage(t0)}
-    return {"fiveHour": split(now - WIN_5H), "week": split(now - WIN_WEEK),
-            "windows": {"fiveHour": WIN_5H, "week": WIN_WEEK}}
+# (_token_windows, the footer's old fixed 5h/7d token split, was removed 2026-08-13 — it had no callers
+# left; the analytics modal's _token_analytics is the one arbitrary-window rollup.)
 
 
 # ── per-model $ prices for the cost-weighted analytics view ──────────────────────────────────────
@@ -16566,21 +16608,36 @@ def _session_cost(path, t0, prices):
     return c
 
 
+_ANALYTICS_MEMO = {}   # window -> {"t": epoch, "jkey": judge-usage cache size, "resp": the payload}
+
+
 def _token_analytics(now, window):
     """Token usage over the trailing `window` seconds for the analytics modal (the /analytics endpoint):
     the coding SESSIONS total (summed transcript usage of the discovered fleet) vs the judge PIPELINE
-    broken out per judge AND per tier (_judge_usage). One ARBITRARY window — the modal's period picker —
-    where the footer's _token_windows only does the two fixed Claude meters (5h/7d). Each side also carries
-    $ cost so the modal can toggle tokens↔cost without a refetch: judges = exact logged cost, sessions =
-    tokens × _model_prices. Cheap: _session_tokens caches per-path rows, so this re-sums the cache."""
+    broken out per judge AND per tier (_judge_usage). One ARBITRARY window — the modal's period picker.
+    Each side also carries $ cost so the modal can toggle tokens↔cost without a refetch: judges = exact
+    logged cost, sessions = tokens × _model_prices. Cheap: _session_tokens caches per-path rows and
+    _judge_usage reads the shared incremental row cache, so this re-sums memory."""
+    # a tiny TTL memo: the modal refetches on every period click and every reopen, and the recompute is
+    # honest-but-pointless within seconds of itself (the user 2026-08-13's fast-and-visible rule); a new
+    # judge row (cache size moved) invalidates early so the numbers never sit stale behind live judging
+    memo = _ANALYTICS_MEMO.get(window)
+    jkey = _JUDGE_USAGE_CACHE["size"]
+    if memo and memo["jkey"] == jkey and now - memo["t"] < 15:
+        return memo["resp"]
     t0 = now - window
     prices = _model_prices(now)
     s = {"in": 0, "out": 0, "cost": 0.0}
-    for fsid, path, anchor, name in jd.discover(now):
+    # discover at the MODAL's window, never the 48h default: the 7d/30d views used to sum judges over
+    # the full window but sessions over only the last 48h of activity — the "judges = N% of session
+    # cost" note was wrong there by construction (the user 2026-08-13's map)
+    for fsid, path, anchor, name in jd.discover(now, window=max(window, 48 * 3600)):
         d = _session_tokens(str(path), t0)
         s["in"] += d["in"]; s["out"] += d["out"]
         s["cost"] += _session_cost(str(path), t0, prices)
-    return {"window": window, "now": now, "sessions": s, "judges": _judge_usage(t0)}
+    resp = {"window": window, "now": now, "sessions": s, "judges": _judge_usage(t0)}
+    _ANALYTICS_MEMO[window] = {"t": now, "jkey": _JUDGE_USAGE_CACHE["size"], "resp": resp}
+    return resp
 
 
 # Usage/error logs carry one name per distinct prompt (the user 2026-07-08): gister, opener, placer,
@@ -16603,15 +16660,9 @@ def _attach_run_usage(judging, t0, alive_sids):
         mk["ms"] = mk["in"] = mk["out"] = 0
         mk["sent"] = mk["recv"] = None
     runs = {}                                            # (sid, judge) -> [{t,ms,in,out,sent,recv}] sorted by t
-    try:
-        lines = (jd.STATE / "judge-usage.jsonl").read_text(errors="replace").splitlines()
-    except OSError:
-        return
-    for ln in lines:
-        try:
-            o = json.loads(ln)
-        except Exception:
-            continue
+    # the shared incremental row cache (_judge_usage_rows) — this used to re-read + re-parse the whole
+    # append-only log on EVERY timeline build (0.46s at 38.7 MB, on the GIL, growing without bound)
+    for o in _judge_usage_rows():
         t, sid = o.get("t"), o.get("fsid")
         if not isinstance(t, (int, float)) or t < t0 or sid not in alive_sids:
             continue

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -57,44 +57,73 @@ class SessionTokens(unittest.TestCase):
                          {"in": 0, "out": 0, "cache_w": 0, "cache_r": 0})
 
 
-class TokenWindows(unittest.TestCase):
-    """_token_windows splits sessions + the judge pipeline across the two Claude meters (5h / 7d),
-    each windowed independently. _judge_usage reads jd.STATE, so point it at a temp dir."""
+class JudgeUsageIncrementalCache(unittest.TestCase):
+    """_judge_usage_rows (2026-08-13): the append-only, never-rotated judge-usage.jsonl used to be
+    re-read and re-parsed IN FULL by both the analytics modal and every timeline build (38.7 MB
+    measured) — the term that froze the dashboard as the log grew. Rows now parse once, appends parse
+    from the last byte offset, and the cache is keyed on the PATH too (a test repointing jd.STATE must
+    never inherit another dir's offset — the overrides-sandbox lesson)."""
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self.saved = jd.STATE
         jd.STATE = pathlib.Path(self.td.name)
+        km._JUDGE_USAGE_CACHE.update(path=None, size=-1, mtime=0.0, rows=[])
 
     def tearDown(self):
         jd.STATE = self.saved
+        km._JUDGE_USAGE_CACHE.update(path=None, size=-1, mtime=0.0, rows=[])
         self.td.cleanup()
 
-    def test_splits_sessions_and_pipeline_by_5h_and_week(self):
-        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False, dir=self.td.name) as f:
-            f.write(_asst({"input_tokens": 100, "output_tokens": 20, "cache_read_input_tokens": 5000}, iso(NOW - 3600)) + "\n")  # in 5h
-            f.write(_asst({"input_tokens": 40, "output_tokens": 10}, iso(NOW - 3 * 86400)) + "\n")    # in week, not 5h
-            f.write(_asst({"input_tokens": 999, "output_tokens": 999}, iso(NOW - 30 * 86400)) + "\n")  # older than a week
-            path = f.name
-        (jd.STATE / "judge-usage.jsonl").write_text("\n".join(json.dumps(r) for r in [
-            {"t": NOW - 1800, "judge": "captioner", "tier": "index", "in": 10, "out": 5, "cost": 0.01, "ms": 100},
-            {"t": NOW - 2 * 86400, "judge": "planner", "tier": "triage", "in": 70, "out": 30, "cost": 0.2, "ms": 200},
-            {"t": NOW - 20 * 86400, "judge": "planner", "tier": "triage", "in": 9, "out": 9, "cost": 9, "ms": 9},
-        ]) + "\n")
-        tk = km._token_windows([path], NOW)
-        # 5h: only the first transcript msg + the first judge call
-        self.assertEqual(tk["fiveHour"]["sessions"], {"in": 100, "out": 20, "cache_r": 5000})
-        self.assertEqual(tk["fiveHour"]["pipeline"]["total"]["in"], 10)
-        self.assertEqual(tk["fiveHour"]["pipeline"]["total"]["calls"], 1)
-        # week: first two transcript msgs + first two judge calls (the >week rows drop)
-        self.assertEqual(tk["week"]["sessions"], {"in": 140, "out": 30, "cache_r": 5000})
-        self.assertEqual(tk["week"]["pipeline"]["total"]["in"], 80)
-        self.assertEqual(tk["week"]["pipeline"]["total"]["calls"], 2)
-        self.assertEqual(tk["windows"], {"fiveHour": km.WIN_5H, "week": km.WIN_WEEK})
+    def _row(self, t, judge="captioner", **kw):
+        return json.dumps({"t": t, "judge": judge, "tier": kw.get("tier", "index"),
+                           "in": kw.get("i", 10), "out": kw.get("o", 5),
+                           "cost": kw.get("cost", 0.01), "ms": 100})
 
-    def test_no_paths_no_log_is_zero_but_shaped(self):
-        tk = km._token_windows([], NOW)
-        self.assertEqual(tk["fiveHour"]["sessions"], {"in": 0, "out": 0, "cache_r": 0})
-        self.assertEqual(tk["week"]["pipeline"]["total"]["calls"], 0)
+    def test_appends_parse_incrementally_and_rollup_reads_the_cache(self):
+        p = jd.STATE / "judge-usage.jsonl"
+        p.write_text(self._row(NOW - 1800) + "\n")
+        self.assertEqual(len(km._judge_usage_rows()), 1)
+        u = km._judge_usage(NOW - 3600)
+        self.assertEqual(u["total"]["calls"], 1)
+        with p.open("a") as fh:                          # an append parses from the offset, not from zero
+            fh.write(self._row(NOW - 600, judge="planner", tier="triage", i=70, o=30) + "\n")
+        rows = km._judge_usage_rows()
+        self.assertEqual(len(rows), 2)
+        u = km._judge_usage(NOW - 3600)
+        self.assertEqual(u["total"]["calls"], 2)
+        self.assertEqual(u["byJudge"]["planner"]["in"], 70)
+
+    def test_a_mid_append_partial_line_waits_for_its_newline(self):
+        p = jd.STATE / "judge-usage.jsonl"
+        p.write_text(self._row(NOW - 1800) + "\n")
+        self.assertEqual(len(km._judge_usage_rows()), 1)
+        with p.open("a") as fh:
+            fh.write('{"t": ')                           # the writer is mid-append
+        self.assertEqual(len(km._judge_usage_rows()), 1, "the fragment is left for the next read")
+        with p.open("a") as fh:
+            fh.write(str(NOW - 60) + ', "judge": "closer", "in": 1, "out": 1, "cost": 0, "ms": 1}\n')
+        self.assertEqual(len(km._judge_usage_rows()), 2, "…and picked up whole once complete")
+
+    def test_repointing_state_never_inherits_an_offset(self):
+        (jd.STATE / "judge-usage.jsonl").write_text(self._row(NOW - 1800) + "\n")
+        self.assertEqual(len(km._judge_usage_rows()), 1)
+        td2 = tempfile.TemporaryDirectory()
+        try:
+            jd.STATE = pathlib.Path(td2.name)            # a different state dir (the sandbox trap)
+            (jd.STATE / "judge-usage.jsonl").write_text(
+                self._row(NOW - 300, judge="grouper") + "\n")
+            rows = km._judge_usage_rows()
+            self.assertEqual([r["judge"] for r in rows], ["grouper"], "fresh path → fresh parse")
+        finally:
+            jd.STATE = pathlib.Path(self.td.name)
+            td2.cleanup()
+
+    def test_truncation_resets_cleanly(self):
+        p = jd.STATE / "judge-usage.jsonl"
+        p.write_text(self._row(NOW - 1800) + "\n" + self._row(NOW - 900) + "\n")
+        self.assertEqual(len(km._judge_usage_rows()), 2)
+        p.write_text(self._row(NOW - 60) + "\n")         # rotated/truncated
+        self.assertEqual(len(km._judge_usage_rows()), 1)
 
 
 class JudgeUsageRollup(unittest.TestCase):
@@ -205,6 +234,8 @@ class TokenAnalytics(unittest.TestCase):
         jd.STATE = pathlib.Path(self.td.name)
         km.PRICE_CONFIG = pathlib.Path(self.td.name) / "no-prices.json"   # nonexistent → defaults only
         km._refresh_remote_prices = lambda now: None                     # no network in tests
+        km._ANALYTICS_MEMO.clear()                                       # the TTL memo must not leak across tests
+        km._JUDGE_USAGE_CACHE.update(path=None, size=-1, mtime=0.0, rows=[])
 
     def tearDown(self):
         jd.STATE, jd.discover = self.saved_state, self.saved_discover
@@ -217,7 +248,7 @@ class TokenAnalytics(unittest.TestCase):
                       _asst({"input_tokens": 999, "output_tokens": 999}, iso(NOW - 99999)) + "\n")     # outside → dropped
         p2 = pathlib.Path(self.td.name) / "s2.jsonl"
         p2.write_text(_asst({"input_tokens": 30, "output_tokens": 8}, iso(NOW - 600)) + "\n")
-        jd.discover = lambda now: [("fs1", p1, "a1", "s1"), ("fs2", p2, "a2", "s2")]
+        jd.discover = lambda now, window=None, forks=True: [("fs1", p1, "a1", "s1"), ("fs2", p2, "a2", "s2")]
         (jd.STATE / "judge-usage.jsonl").write_text("\n".join(json.dumps(r) for r in [
             {"t": NOW - 900, "judge": "captioner", "tier": "index", "in": 10, "out": 4, "cost": 0.01, "ms": 50},
             {"t": NOW - 800, "judge": "archiver", "tier": "index", "in": 6, "out": 2, "cost": 0.01, "ms": 40},
@@ -234,7 +265,7 @@ class TokenAnalytics(unittest.TestCase):
         self.assertEqual(a["judges"]["byTier"]["triage"]["in"], 70)
 
     def test_empty_fleet_and_no_log_is_zero_but_shaped(self):
-        jd.discover = lambda now: []
+        jd.discover = lambda now, window=None, forks=True: []
         a = km._token_analytics(NOW, 86400)
         self.assertEqual((a["sessions"]["in"], a["sessions"]["out"], a["sessions"]["cost"]), (0, 0, 0.0))
         self.assertEqual(a["judges"]["total"]["calls"], 0)
@@ -254,6 +285,8 @@ class CostWeighting(unittest.TestCase):
         km._refresh_remote_prices = lambda now: None      # no network in tests → defaults/config only
         km._price_cache["remote"] = {}
         jd.STATE = pathlib.Path(self.td.name)
+        km._ANALYTICS_MEMO.clear()                        # the TTL memo must not leak across tests
+        km._JUDGE_USAGE_CACHE.update(path=None, size=-1, mtime=0.0, rows=[])
 
     def tearDown(self):
         km.PRICE_CONFIG, km._refresh_remote_prices = self.saved_cfg, self.saved_refresh
@@ -316,7 +349,7 @@ class CostWeighting(unittest.TestCase):
         p1 = pathlib.Path(self.td.name) / "s1.jsonl"
         p1.write_text(_asst({"input_tokens": 1000, "output_tokens": 200, "cache_read_input_tokens": 100000},
                             iso(NOW - 600), model="claude-opus-4-8") + "\n")
-        jd.discover = lambda now: [("fs1", p1, "a", "s1")]
+        jd.discover = lambda now, window=None, forks=True: [("fs1", p1, "a", "s1")]
         (jd.STATE / "judge-usage.jsonl").write_text(json.dumps(
             {"t": NOW - 500, "judge": "captioner", "tier": "index", "in": 10, "out": 4,
              "cost": 0.0123, "ms": 50}) + "\n")


### PR DESCRIPTION
The minute-long "computing" wait: the never-rotated 38.7 MB judge-usage ledger was fully re-parsed on every modal open, every period click, and **every timeline build**, on the GIL. Now one shared incremental reader (parse once, byte-offset appends, ~31-day bounded memory, path-keyed against state repoints) plus a 15s TTL memo; the 7d/30d views also stop under-counting sessions (discover at the modal's window, not the 48h default). Dead `_token_windows` removed. Four new cache tests; suites green (Python 4470, node 1882).

Progress-bar note: post-fix the wait is a sub-second flash, below the bar threshold — speed was the fix; the streaming-progress insertion points are mapped if a real wait ever returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)