### PR TITLE
Card history popover: strict chronological interleave

### DIFF
--- a/ui/webview/provenance.test.ts
+++ b/ui/webview/provenance.test.ts
@@ -25,21 +25,23 @@ const NOW = 10_000;
 function item(over: Partial<ProvItem> = {}): ProvItem {
   return {
     itemId: "root", t: 9_400, column: "completed",
+    // NEWEST-subtree-activity FIRST, like the kernel's flatten actually ships it (_fsubmax, reverse) —
+    // the old ascending fixture was why the shuffled popover was never caught (the user 2026-08-13)
     tree: [
       { id: "root", text: "ship the notes-api", status: "done", t: 1_000, last: 9_400 },
-      { id: "s1", text: "write the parser", status: "done", t: 1_600, last: 5_000, mt: 5_200 },
-      { id: "s2", text: "ask about the schema", status: "question", t: 2_200, last: 7_000, mt: 7_000 },
       { id: "s3", text: "docs pass", status: "open", t: 8_800, last: 8_800 },
+      { id: "s2", text: "ask about the schema", status: "question", t: 2_200, last: 7_000, mt: 7_000 },
+      { id: "s1", text: "write the parser", status: "done", t: 1_600, last: 5_000, mt: 5_200 },
     ],
     ...over,
   };
 }
 
-test("the story: started at the root's mint, each sub at ITS time, the stamp explained last", () => {
+test("the story: started at the root's mint, each sub at ITS time, ONE clock throughout, the stamp last", () => {
   const rows = provenanceRows(item(), NOW, F);
   assert.deepEqual(rows[0], { when: "150m ago · @1000", what: "started", t: 1_000, kind: "start" });
   assert.deepEqual(rows[1], { when: "80m ago · @5200", what: "✓ write the parser", t: 5_200, kind: "sub" },
-    "a resolved sub stamps where it RESOLVED (mt)");
+    "a resolved sub stamps where it RESOLVED (mt) — the newest-first wire order re-sorts to the clock");
   assert.deepEqual(rows[2], { when: "50m ago · @7000", what: "⏸ ask about the schema", t: 7_000, kind: "sub" });
   assert.deepEqual(rows[3], { when: "20m ago · @8800", what: "· docs pass", t: 8_800, kind: "sub" },
     "an open sub stamps its mint (nothing resolved yet)");
@@ -47,24 +49,36 @@ test("the story: started at the root's mint, each sub at ITS time, the stamp exp
     "the visible age is named for what it marks");
 });
 
+test("events and subs INTERLEAVE on the clock — never section-by-section (the user 2026-08-13)", () => {
+  // the observed shuffle: root events ran up to now while the ✓ block jumped back a day — a sub whose
+  // resolution PRECEDES a root event must print before it
+  const it = item();
+  it.tree[0].log = [{ kind: "block", src: "romp", at: 6_000 }, { kind: "unblock", src: "romp", at: 8_000 }];
+  const rows = provenanceRows(it, NOW, F);
+  assert.deepEqual(rows.map((r) => [r.kind, r.t]),
+    [["start", 1_000], ["sub", 5_200], ["event", 6_000], ["sub", 7_000], ["event", 8_000],
+     ["sub", 8_800], ["stamp", 9_400]],
+    "one story, one clock: strict chronological, the stamp pinned last");
+});
+
 test("the final row matches the column: blocked / last update", () => {
   assert.equal(provenanceRows(item({ column: "needs_input" }), NOW, F).at(-1)!.what, "blocked");
   assert.equal(provenanceRows(item({ column: "working" }), NOW, F).at(-1)!.what, "last update");
 });
 
-test("the root's own verdict rows ride between start and subs, in the feed's outcome words", () => {
+test("the root's verdict rows land at their own times, in the feed's outcome words", () => {
   const it = item();
   it.tree[0].log = [{ kind: "block", src: "romp", at: 3_000 }, { kind: "unblock", src: "romp", evT: 4_000 }];
   const rows = provenanceRows(it, NOW, F);
   assert.deepEqual(rows[1], { when: "117m ago · @3000", what: "[block]", t: 3_000, kind: "event" });
   assert.deepEqual(rows[2], { when: "100m ago · @4000", what: "[unblock]", t: 4_000, kind: "event" },
     "evT is the time-nav fallback when `at` is absent");
-  assert.equal(rows[3].what, "✓ write the parser", "subs follow the root's events");
+  assert.equal(rows[3].what, "✓ write the parser", "the first sub follows — its mt (5200) postdates both events");
 });
 
 test("cleared subs stay out; a huge tree caps at 8 with an honest remainder", () => {
   const it = item();
-  it.tree[1].cleared = true;
+  it.tree.find((n) => n.id === "s1")!.cleared = true;   // by id — the fixture ships newest-first now
   assert.ok(!provenanceRows(it, NOW, F).some((r) => r.what.includes("write the parser")),
     "a cleared sub is not provenance");
   const big = item({

--- a/ui/webview/provenance.ts
+++ b/ui/webview/provenance.ts
@@ -53,8 +53,10 @@ export function provenanceRows(it: ProvItem, now: number, f: ProvFmt): ProvRow[]
     const rt = r.at || r.evT || 0;
     if (rt) rows.push({ when: stamp(rt, now, f), what: f.phrase(r), t: rt, kind: "event" });
   }
-  // sub-items in mint order: a resolved sub is stamped when it RESOLVED (mt — where it landed), an
-  // open one when it was minted (its resolution hasn't happened yet)
+  // sub-items: a resolved sub is stamped when it RESOLVED (mt — where it landed), an open one when it
+  // was minted (its resolution hasn't happened yet). The kernel ships the tree newest-subtree-activity
+  // FIRST (flatten's _fsubmax sort, for the ledger views) — the slice keeps that "8 most recent"
+  // selection; the sort below puts what's KEPT back on the clock.
   const subs = it.tree.filter((n) => n.id !== it.itemId && !n.cleared);
   for (const n of subs.slice(0, SUB_CAP)) {
     const mark = n.status === "done" ? "✓" : n.status === "question" ? "⏸" : "·";
@@ -62,6 +64,11 @@ export function provenanceRows(it: ProvItem, now: number, f: ProvFmt): ProvRow[]
     const txt = n.text.length > 48 ? n.text.slice(0, 47) + "…" : n.text;
     rows.push({ when: stamp(at, now, f), what: mark + " " + txt, t: at, kind: "sub" });
   }
+  // ONE story, ONE clock (the user 2026-08-13, who read the popover as shuffled): the root log runs
+  // ascending while the tree ships newest-first, so the sections read in opposite directions — strict
+  // chronological interleave, before the t:0 remainder and the pinned stamp join. The sort is stable,
+  // so equal-t rows keep their event-before-sub order.
+  rows.sort((a, b) => a.t - b.t);
   if (subs.length > SUB_CAP) rows.push({ when: "", what: "…and " + (subs.length - SUB_CAP) + " more", t: 0, kind: "more" });
   rows.push({ when: stamp(it.t, now, f), what: stampWhat(it.column), t: it.t, kind: "stamp" });
   return rows;


### PR DESCRIPTION
The hover mixed the root log (ascending) with the subtree rows (newest-first wire order) — forward, back a day, then descending. One stable sort puts everything on one clock, with the pinned status stamp still last and the 8-most-recent-subs selection unchanged. Fixture reordered to the kernel's real wire order (the old ascending fixture is why this never caught) + a new interleave pin. Suite 1884 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)