### PR TITLE
Usage hover: window + spend graphs; one fleet spend number; devbox fix

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15694,13 +15694,14 @@ def _series_index(hour_key, h0):
         return None
 
 
-def _spend_series(keyed_only=False):
+def _spend_series(keyed_only=False, now=None):
     """The hover graph's money-rate series (the user 2026-08-13): $/hour over the last 192 hours, a
     DENSE array plus a base hour (h0, epoch-hours), so cross-host summing is an index-wise add after
     aligning on h0 — correct without dedup, because each host records only its own turns even on a
     shared key. Zero IS the honest value for an hour with no turns (money, unlike pct, has a true
     zero). None when nothing is recorded at all. Same keyed_only split as _spend_windows, for the same
-    reason."""
+    reason. `now` anchors h0 — injectable so a caller with a frozen evidence clock (tests) can't
+    straddle an hour boundary between writing a bucket and reading its index (the 23:00 UTC CI run)."""
     try:
         d = json.loads((jd.STATE / "spend.json").read_text())
     except Exception:
@@ -15708,7 +15709,7 @@ def _spend_series(keyed_only=False):
     hours = d.get("hours") if isinstance(d.get("hours"), dict) else {}
     if not hours:
         return None
-    h0 = int(time.time() // 3600) - (_SERIES_HOURS - 1)
+    h0 = int((time.time() if now is None else now) // 3600) - (_SERIES_HOURS - 1)
     usd = [0.0] * _SERIES_HOURS
     for k, e in hours.items():
         i = _series_index(k, h0)
@@ -15720,11 +15721,12 @@ def _spend_series(keyed_only=False):
     return {"h0": h0, "usd": usd}
 
 
-def _usage_history_series():
+def _usage_history_series(now=None):
     """winSeries for the hover graphs: per window, 192 hourly pct-or-null points from
     usage-history.json — null is an hour with no reading (the unknown-≠-0 rule, drawn as a gap).
     Readings stamped by a DIFFERENT login than the current one are skipped, mirroring the bars'
-    own logout rule. None until the ledger exists."""
+    own logout rule. None until the ledger exists. `now` anchors h0, injectable for the same
+    hour-boundary determinism as _spend_series."""
     try:
         d = json.loads((jd.STATE / "usage-history.json").read_text())
     except Exception:
@@ -15733,7 +15735,7 @@ def _usage_history_series():
     if not hours:
         return None
     cur = _claude_account()
-    h0 = int(time.time() // 3600) - (_SERIES_HOURS - 1)
+    h0 = int((time.time() if now is None else now) // 3600) - (_SERIES_HOURS - 1)
     ser = {"h0": h0, "fiveHour": [None] * _SERIES_HOURS, "sevenDay": [None] * _SERIES_HOURS,
            "fable": [None] * _SERIES_HOURS}
     any_pt = False

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7793,7 +7793,11 @@ def _poll_remote_usage(r):
             return r.get("usage")
         u = json.loads(data.decode("utf-8"))
         r["_usage_at"] = now
-        return u if isinstance(u, dict) and u else None
+        # an ANSWERED empty payload is a real "nothing to show" — return the sentinel so the caller
+        # CLEARS the row instead of freezing the last reading forever (the user 2026-08-13: a host that
+        # stopped reporting kept stale bars for the kernel's whole lifetime); a network blip below still
+        # keeps the last good reading
+        return u if isinstance(u, dict) and u else {}
     except Exception:
         return r.get("usage")   # keep the last good reading rather than blanking the bars on one blip
 
@@ -8822,7 +8826,12 @@ def _tunnel_supervisor():
                         r["kernel_sha"] = rsha
                         r["kernel_ver"] = (rver or {}).get("ver") or ""
                     if ruse is not None:
-                        r["usage"] = ruse
+                        # {} = the host ANSWERED with nothing to show → clear; None = no answer (blip/
+                        # rate-gate) → keep the last reading (see _poll_remote_usage)
+                        if ruse:
+                            r["usage"] = ruse
+                        else:
+                            r.pop("usage", None)
                     auto_check = (st == "up")
                     peer_up = (st == "up")
                     peer_port, peer_tok = r.get("bus_port"), r.get("token") or ""
@@ -15555,7 +15564,11 @@ def _usage():
     try:
         o = json.loads((jd.STATE / "usage.json").read_text())
     except Exception:
-        return None
+        # A pure API-key host NEVER writes usage.json (both snapshot writers skip keyed sessions), so
+        # bailing here starved the no-login spend arm below of exactly the machine it was written for —
+        # the devbox answered /usage with {} and its spend vanished from the fleet sum (the user
+        # 2026-08-13). An empty snapshot falls through instead; every read below tolerates absence.
+        o = {}
 
     stops = cm.stops_for(_colormap())                 # the GLOBAL colormap (the user 2026-06-26) colors the used bar
     def seg(s):
@@ -15599,9 +15612,13 @@ def _usage():
             # keyed split: on a no-login machine every turn bills the key, and legacy files predate
             # the split. The rail's label is the constant 'API' — no fragment of the key travels
             # (the user 2026-08-08; hosts are told apart by name in the hover, not by key).
-            return {"apiKey": True, "spend": _spend_windows(),
-                    "t": o.get("t") if isinstance(o.get("t"), (int, float)) else None,
-                    "acct": _claude_account()}
+            out = {"apiKey": True, "spend": _spend_windows(),
+                   "t": o.get("t") if isinstance(o.get("t"), (int, float)) else None,
+                   "acct": _claude_account()}
+            ss = _spend_series()          # TOTAL, like the windows above: everything here bills the key
+            if ss:
+                out["spendSeries"] = ss   # the hover's money-rate graph (the user 2026-08-13)
+            return out
         return None
     # LIMIT REACHED (the user 2026-07-01): a window at 100% whose reset is still in the future = the account is
     # rate-limited on it now. Drives the top banner + the auto retry-pause. A window past its resetsAt has rolled
@@ -15632,6 +15649,15 @@ def _usage():
         ksp = _spend_windows(keyed_only=True)
         if any((ksp.get(k) or {}).get("turns") for k in ("day", "week", "month")):
             out["spend"] = ksp
+            ss = _spend_series(keyed_only=True)   # the keyed split, like the windows it graphs
+            if ss:
+                out["spendSeries"] = ss
+    # the window-utilization series for the hover graphs (the user 2026-08-13) — present once the
+    # usage-history ledger has readings for the CURRENT login; an older kernel simply omits it and the
+    # client draws that host's bars with no spark (the same graceful-degrade contract as day||fiveHour)
+    ws = _usage_history_series()
+    if ws:
+        out["winSeries"] = ws
     return out
 
 
@@ -15655,6 +15681,75 @@ def _judge_failures():
         val = None
     _jf_cache["fp"], _jf_cache["val"] = fp, val
     return val
+
+
+_SERIES_HOURS = 192          # 8 days of hourly points — covers the 7-day hover graphs with a day of slack
+
+
+def _series_index(hour_key, h0):
+    """spend.json/usage-history.json hour keys ("%Y-%m-%dT%H", localtime) → dense-array index, or None."""
+    try:
+        return int(time.mktime(time.strptime(hour_key, "%Y-%m-%dT%H")) // 3600) - h0
+    except Exception:
+        return None
+
+
+def _spend_series(keyed_only=False):
+    """The hover graph's money-rate series (the user 2026-08-13): $/hour over the last 192 hours, a
+    DENSE array plus a base hour (h0, epoch-hours), so cross-host summing is an index-wise add after
+    aligning on h0 — correct without dedup, because each host records only its own turns even on a
+    shared key. Zero IS the honest value for an hour with no turns (money, unlike pct, has a true
+    zero). None when nothing is recorded at all. Same keyed_only split as _spend_windows, for the same
+    reason."""
+    try:
+        d = json.loads((jd.STATE / "spend.json").read_text())
+    except Exception:
+        return None
+    hours = d.get("hours") if isinstance(d.get("hours"), dict) else {}
+    if not hours:
+        return None
+    h0 = int(time.time() // 3600) - (_SERIES_HOURS - 1)
+    usd = [0.0] * _SERIES_HOURS
+    for k, e in hours.items():
+        i = _series_index(k, h0)
+        if i is None or not (0 <= i < _SERIES_HOURS) or not isinstance(e, dict):
+            continue
+        if keyed_only:
+            e = e.get("key") if isinstance(e.get("key"), dict) else {}
+        usd[i] = round(float((e or {}).get("usd") or 0), 4)
+    return {"h0": h0, "usd": usd}
+
+
+def _usage_history_series():
+    """winSeries for the hover graphs: per window, 192 hourly pct-or-null points from
+    usage-history.json — null is an hour with no reading (the unknown-≠-0 rule, drawn as a gap).
+    Readings stamped by a DIFFERENT login than the current one are skipped, mirroring the bars'
+    own logout rule. None until the ledger exists."""
+    try:
+        d = json.loads((jd.STATE / "usage-history.json").read_text())
+    except Exception:
+        return None
+    hours = d.get("hours") if isinstance(d.get("hours"), dict) else {}
+    if not hours:
+        return None
+    cur = _claude_account()
+    h0 = int(time.time() // 3600) - (_SERIES_HOURS - 1)
+    ser = {"h0": h0, "fiveHour": [None] * _SERIES_HOURS, "sevenDay": [None] * _SERIES_HOURS,
+           "fable": [None] * _SERIES_HOURS}
+    any_pt = False
+    for k, e in hours.items():
+        i = _series_index(k, h0)
+        if i is None or not (0 <= i < _SERIES_HOURS) or not isinstance(e, dict):
+            continue
+        stamped = e.get("acct") or ""
+        if stamped and cur and stamped != cur:
+            continue
+        for raw, out_k in (("five_hour", "fiveHour"), ("seven_day", "sevenDay"), ("fable", "fable")):
+            s = e.get(raw)
+            if isinstance(s, dict) and isinstance(s.get("pct"), (int, float)):
+                ser[out_k][i] = int(s["pct"])
+                any_pt = True
+    return ser if any_pt else None
 
 
 def _spend_budgets():
@@ -19899,12 +19994,14 @@ var SPEND_WINS=[['day','1 day'],['week','1 week'],['month','1 month']];
 // tracks die with it): the numbers are the information, so the numbers are the rendering.
 function spendDet(u,det){var sp=u&&u.spend;if(!sp||!det)return;
 SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='number')return;
-(det._spend=det._spend||{})[w[0]]={label:w[1],usd:seg.usd,tok:seg.tok||0,turns:seg.turns||0};});}
+(det._spend=det._spend||{})[w[0]]={label:w[1],usd:seg.usd,tok:seg.tok||0,turns:seg.turns||0};});
+if(u.spendSeries&&u.spendSeries.usd)det._spendSeries=u.spendSeries;   // $/hour, for the hover graph (the user 2026-08-13)
 // One payload's WINDOW detail for the hover (used/elapsed/reset per window). Detail only, no markup:
 // the rail no longer draws each account's own bars (they aggregate, below), but the tip still tells
 // each host's story from this.
 function winDet(u,det){var nowS=Math.floor(Date.now()/1000);
 if(u.acctLabel)det._acct=u.acctLabel;   // WHICH login the windows belong to (the user 2026-08-09) — hover-only
+if(u.winSeries)det._winSeries=u.winSeries;   // hourly pct history per window, for the hover sparks (2026-08-13)
 WINS.forEach(function(w){var seg=u[w[0]];if(!seg)return;
 // A ROLLED window (its reset passed since the last report) is UNKNOWN, not 0 (the user 2026-07-31: a
 // remote whose kernel had no live session to ask sat on a days-old snapshot, and the rail drew a
@@ -19999,6 +20096,29 @@ function render(u){notices(u);
 var rest=ROWS.filter(function(r){return r.host;});
 renderRows([{host:'',acct:(u&&u.acct)||'',usage:u}].concat(rest),SELF);}
 // ONE shared tooltip for BOTH windows: per window, the used bar (colormap) over the elapsed bar (slate) +
+// A SPARKLINE for the hover graphs (the user 2026-08-13): one inline SVG per series, hourly points
+// oldest→newest, gaps where a point is null (an hour with no reading — the unknown-≠-0 rule; a run of
+// one draws a dot so a lone reading is not invisible). vmax pins the scale (100 for pct series, so
+// every window graph shares one honest y-axis); null auto-scales (money). fill=true adds the area
+// wash for the $/hour graph. The panel is pointer-events:none, so the graph must speak alone — no
+// <title> tooltips would ever fire.
+function sparkHTML(arr,color,fill,vmax){if(!arr||!arr.length)return '';
+var W=120,H=28,n=arr.length,mx=vmax;
+if(mx==null){mx=0;for(var i=0;i<n;i++)if(arr[i]!=null&&arr[i]>mx)mx=arr[i];}
+if(mx<=0)return '';
+var segs=[],cur=[];
+for(var i=0;i<n;i++){var v=arr[i];
+if(v==null){if(cur.length){segs.push(cur);cur=[];}continue;}
+cur.push([(n>1?i/(n-1):0.5)*W,H-2-Math.max(0,Math.min(1,v/mx))*(H-4)]);}
+if(cur.length)segs.push(cur);
+if(!segs.length)return '';
+var body=segs.map(function(s){
+if(s.length===1)return '<circle cx="'+s[0][0].toFixed(1)+'" cy="'+s[0][1].toFixed(1)+'" r="1.5" fill="'+color+'"/>';
+var pts=s.map(function(p){return p[0].toFixed(1)+','+p[1].toFixed(1);}).join(' ');
+var out='<polyline points="'+pts+'" fill="none" stroke="'+color+'" stroke-width="1.5"/>';
+if(fill)out+='<polygon points="'+s[0][0].toFixed(1)+','+(H-2)+' '+pts+' '+s[s.length-1][0].toFixed(1)+','+(H-2)+'" fill="'+color+'" opacity="0.18" stroke="none"/>';
+return out;}).join('');
+return '<svg class=ru-tip-spark viewBox="0 0 '+W+' '+H+'" preserveAspectRatio="none">'+body+'</svg>';}
 // the % + reset — the exact set of bars that used to sit under the timeline, nothing more.
 function barRows(d){return (d.unk
 ? '<div class="ru-tip-row ru-unk"><span class=ru-tip-k>last known</span>'
@@ -20017,29 +20137,45 @@ function barRows(d){return (d.unk
 // who found the tip overly verbose): the host name alone heads a section, the spend rows label
 // themselves, and config hints live in the docs, not a hover.
 function setHTML(e,many){var d=e.det,keys=['fiveHour','sevenDay','fable'].filter(function(k){return d[k];});
-var sp=d._spend||null;
-if(!keys.length&&!sp)return '';
+if(!keys.length)return '';
 var h=(many?'<div class=ru-tip-host>'+esc(e.host)+'</div>':'');
 // the account the window bars belong to, named the way the tab hover names it (the user 2026-08-09);
 // only beside actual window sections — a key-only host's spend already says whose dollars they are
 if(d._acct&&keys.length)h+='<div class=ru-tip-acct>'+esc(d._acct)+'</div>';
 h+=keys.map(function(k){var v=d[k];
+// the window's own history under its bars (the user 2026-08-13): hourly utilization over the last
+// 8 days, y pinned to 0-100 so every window graph shares one honest scale; gaps = no reading
+var spark=(d._winSeries&&d._winSeries[k])?sparkHTML(d._winSeries[k],v.col,false,100):'';
 return '<div class=ru-tip-win><div class=ru-tip-name><span>'+esc(v.name)+'</span>'
 +(v.unk?'<span class=ru-tip-reset>window reset '+esc(v.ago)+'; no reading since</span>'
-:(v.reset?'<span class=ru-tip-reset>resets in '+esc(v.reset)+'</span>':''))+'</div>'+barRows(v)+'</div>';}).join('');
-// The API-KEY SPEND rows (the user 2026-08-08): dollars, tokens and turns per window, NUMBERS ONLY.
-// The old token-volume graph scaled each window's bar to the largest window, a shape that told the
-// reader nothing; it is gone, and this section now renders for ANY host with key spend, beside that
-// host's own bars when it has both (per-session auth).
-if(sp){var ks=['fiveHour','sevenDay','month'].filter(function(k){return sp[k];});
-if(ks.length){
-h+='<div class=ru-tip-win><div class=ru-tip-name><span>API spend</span></div>'
-+ks.map(function(k){var v=sp[k];
-return '<div class=ru-tip-row><span class=ru-tip-k>'+esc(v.label)+'</span>'
-+'<span class=ru-tip-v>'+fmtUsd(v.usd)+' \u00b7 '+fmtTok(v.tok)+' tok \u00b7 '+(v.turns||0)+' turns</span></div>';}).join('')
-+'</div>';}}
+:(v.reset?'<span class=ru-tip-reset>resets in '+esc(v.reset)+'</span>':''))+'</div>'+barRows(v)+spark+'</div>';}).join('');
+// (the per-host API-spend rows moved to the ONE fleet-level section in tipHTML — the user 2026-08-13:
+// one shared key reads as one number; each host records only its own turns, so the sum IS the number)
 h+=(d._t?'<div class=ru-tip-age>updated '+fmtAgo(d._t)+'</div>':'');
 return h;}
+// The ONE API-spend section for the whole hover (the user 2026-08-13): every host's windows summed —
+// one shared key is one number — plus the summed $/hour over the last 7 days as an area graph. A host
+// that ships no series (an older kernel) still joins the window sums; the graph adds only contributors.
+function fleetSpendHTML(sets){var sum={},series=null,hosts=0;
+sets.forEach(function(e){var sp=e.det&&e.det._spend;if(!sp)return;hosts++;
+SPEND_WINS.forEach(function(w){var v=sp[w[0]];if(!v)return;
+var t=(sum[w[0]]=sum[w[0]]||{label:w[1],usd:0,tok:0,turns:0});
+t.usd+=v.usd;t.tok+=v.tok;t.turns+=v.turns;});
+var ss=e.det._spendSeries;
+if(ss&&ss.usd){if(!series){series={h0:ss.h0,usd:ss.usd.slice()};}
+else{var off=ss.h0-series.h0;   // align on the base hour — hosts' polls may straddle an hour edge
+for(var i=0;i<ss.usd.length;i++){var j=i+off;if(j>=0&&j<series.usd.length)series.usd[j]+=ss.usd[i];}}}});
+var ks=SPEND_WINS.map(function(w){return w[0];}).filter(function(k){return sum[k];});
+if(!ks.length)return '';
+var h='<div class="ru-tip-win ru-tip-fleetspend"><div class=ru-tip-name><span>API spend'+(hosts>1?' \u00b7 '+hosts+' machines':'')+'</span></div>'
++ks.map(function(k){var v=sum[k];
+return '<div class=ru-tip-row><span class=ru-tip-k>'+esc(v.label)+'</span>'
++'<span class=ru-tip-v>'+fmtUsd(v.usd)+' \u00b7 '+fmtTok(v.tok)+' tok \u00b7 '+(v.turns||0)+' turns</span></div>';}).join('');
+if(series){var wk=series.usd.slice(-168),mx=0;for(var i=0;i<wk.length;i++)if(wk[i]>mx)mx=wk[i];
+if(mx>0)h+='<div class=ru-tip-row><span class=ru-tip-k>$/h \u00b7 7d</span>'
++sparkHTML(wk,'#9cd2ff',true,null)
++'<span class=ru-tip-v>peak '+fmtUsd(mx)+'</span></div>';}
+return h+'</div>';}
 function tipHTML(){var sets=LAST||[];if(!sets.length)return '';
 var many=sets.length>1;
 var blocks=sets.map(function(e){return setHTML(e,many);}).filter(function(b){return b;});
@@ -20049,7 +20185,7 @@ if(!blocks.length)return '';
 // flex-wrap folds the columns back into a stack when width runs out — the mobile Usage modal
 // reuses this exact HTML, so narrow screens degrade on their own, no second layout.
 var h=many?('<div class=ru-tip-cols>'+blocks.map(function(b){return '<div class=ru-tip-col>'+b+'</div>';}).join('')+'</div>'):blocks[0];
-return h+'<div class=ru-tip-age>click to refresh</div>';}
+return h+fleetSpendHTML(sets)+'<div class=ru-tip-age>click to refresh</div>';}
 // The tip anchors ABOVE the rail, centered on the cursor (the user 2026-08-08: it used to pin to the
 // container's RIGHT edge, nowhere near a hover on the left end of a wide multi-account rail).
 function showTip(ev){var h=tipHTML();
@@ -21541,6 +21677,7 @@ def _landing():
             ".ru-tip-row{display:flex;align-items:center;gap:6px;margin-top:3px}"
             ".ru-tip-k{opacity:.55;min-width:46px}"
             ".ru-tip-track{width:64px;height:6px;border-radius:3px;background:rgba(255,255,255,0.10);overflow:hidden;display:inline-block}"
+            ".ru-tip-spark{display:block;width:120px;height:28px;margin-top:3px;opacity:.9}"
             ".ru-tip-track i{display:block;height:100%;border-radius:3px;transition:width .3s ease}"
             # margin-left:auto right-aligns every value to one edge, so the bar rows and the numbers-only
             # spend rows (no track span, the user 2026-08-08) read as one table.

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3159,7 +3159,41 @@ class SdkBackend:
             except Exception:
                 self._log("usage.json write failed: %s" % traceback.format_exc())   # never silent
                 return
+            self._record_usage_history(data)
         self._poke()
+
+    def _record_usage_history(self, data) -> None:
+        """Append the reading to usage-history.json — the hover graphs' time base (the user 2026-08-13:
+        the window bars kept only the CURRENT snapshot, so nothing could be graphed). Same bounded-hours
+        shape as spend.json so both series share one x-axis: per hour keep the MAX pct seen per window
+        (utilization only climbs within a window; a ROLL is a new resets_at, which takes the fresh
+        reading outright), pruned to 192 hours — 8 days covers the 7-day graph. Caller holds _rl_lock;
+        a write failure logs and never blocks the snapshot that fed it."""
+        p = self.state_dir / "usage-history.json"
+        try:
+            hist = json.loads(p.read_text())
+        except Exception:
+            hist = {}
+        hours = hist.get("hours") if isinstance(hist, dict) and isinstance(hist.get("hours"), dict) else {}
+        hour = time.strftime("%Y-%m-%dT%H")
+        ent = hours.get(hour) if isinstance(hours.get(hour), dict) else {}
+        ent["acct"] = data.get("acct") or ""
+        for k in ("five_hour", "seven_day", "fable"):
+            s = data.get(k)
+            if not (isinstance(s, dict) and isinstance(s.get("pct"), (int, float))):
+                continue
+            prev = ent.get(k) if isinstance(ent.get(k), dict) else None
+            if not prev or s.get("resets_at") != prev.get("ra") or int(s["pct"]) >= int(prev.get("pct") or 0):
+                ent[k] = {"pct": int(s["pct"]), "ra": s.get("resets_at")}
+        hours[hour] = ent
+        for k in sorted(hours)[:-192]:
+            hours.pop(k, None)
+        try:
+            tmp = self.state_dir / "usage-history.json.tmp"
+            tmp.write_text(json.dumps({"hours": hours}))
+            os.replace(tmp, p)
+        except Exception:
+            self._log("usage-history.json write failed: %s" % traceback.format_exc())
 
     def _record_rate_limit(self, info) -> None:
         """Persist the account-wide rate-limit /usage the CLI streams as a RateLimitEvent — the SDK's DESIGNED
@@ -3252,6 +3286,7 @@ class SdkBackend:
             except Exception:
                 self._log("usage.json write failed: %s" % traceback.format_exc())   # never silent (the user 2026-07-02)
                 return
+            self._record_usage_history(data)
         self._poke()   # nudge the producer so the rail re-reads usage.json promptly, not on the next backstop
 
     # ---- logging / wakeups ----

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3162,20 +3162,21 @@ class SdkBackend:
             self._record_usage_history(data)
         self._poke()
 
-    def _record_usage_history(self, data) -> None:
+    def _record_usage_history(self, data, now=None) -> None:
         """Append the reading to usage-history.json — the hover graphs' time base (the user 2026-08-13:
         the window bars kept only the CURRENT snapshot, so nothing could be graphed). Same bounded-hours
         shape as spend.json so both series share one x-axis: per hour keep the MAX pct seen per window
         (utilization only climbs within a window; a ROLL is a new resets_at, which takes the fresh
         reading outright), pruned to 192 hours — 8 days covers the 7-day graph. Caller holds _rl_lock;
-        a write failure logs and never blocks the snapshot that fed it."""
+        a write failure logs and never blocks the snapshot that fed it. `now` stamps the hour bucket,
+        injectable so a frozen-clock caller (tests) never straddles an hour boundary mid-assertion."""
         p = self.state_dir / "usage-history.json"
         try:
             hist = json.loads(p.read_text())
         except Exception:
             hist = {}
         hours = hist.get("hours") if isinstance(hist, dict) and isinstance(hist.get("hours"), dict) else {}
-        hour = time.strftime("%Y-%m-%dT%H")
+        hour = time.strftime("%Y-%m-%dT%H", time.localtime(time.time() if now is None else now))
         ent = hours.get(hour) if isinstance(hours.get(hour), dict) else {}
         ent["acct"] = data.get("acct") or ""
         for k in ("five_hour", "seven_day", "fable"):

--- a/tests/test_usage_per_account.py
+++ b/tests/test_usage_per_account.py
@@ -196,7 +196,10 @@ class RailRendering(unittest.TestCase):
         # and the spend rows are numbers only — no track span
         self.assertIn("function winDet(u,det)", self.js)
         self.assertIn("winDet(r.usage,det);spendDet(r.usage,det);", self.js)
-        self.assertIn("<span>API spend</span>", self.js)
+        # spend is ONE fleet-level section now (the user 2026-08-13): one shared key, one number,
+        # "· N machines" when several — never a per-host repeat
+        self.assertIn("function fleetSpendHTML(sets)", self.js)
+        self.assertIn("API spend'+(hosts>1?' · '+hosts+' machines':'')", self.js)
         self.assertIn("' tok · '+(v.turns||0)+' turns</span>", self.js)
 
     def test_the_account_wide_notices_read_off_THIS_machine(self):

--- a/tests/test_usage_series.py
+++ b/tests/test_usage_series.py
@@ -3,7 +3,13 @@
 (usage-history.json, appended by both usage writers, hourly max-pct with roll-aware overwrites, 192h
 bound), spend.json's hour buckets ship as a dense $/hour series, and a pure API-key host — which never
 gets a usage.json at all — finally reaches the no-login spend arm instead of reporting {} (the devbox,
-whose spend was missing from the fleet sum). SYNTHETIC fixtures only."""
+whose spend was missing from the fleet sum). SYNTHETIC fixtures only.
+
+Clock discipline: every writer/reader takes an injectable `now`, and these tests FREEZE it (FIXED) —
+an import-time "current hour" diverges from a call-time stamp whenever the suite straddles an hour
+boundary, which is exactly how the 23:00 UTC CI run failed while local runs passed. Where a path still
+reads the real clock (_usage), assertions derive the index from the payload's own h0, never from an
+assumed position."""
 import json
 import os
 import pathlib
@@ -24,11 +30,12 @@ km = SourceFileLoader("romp_kernel_useries", os.path.join(BIN, "romp-kernel")).l
 sb = SourceFileLoader("romp_sdkb_useries", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 jd = km.jd
 
-HOUR_NOW = time.strftime("%Y-%m-%dT%H")
+FIXED = 1765000000.0                 # frozen mid-hour instant; every key below derives from it
 
 
-def _hour_ago(n):
-    return time.strftime("%Y-%m-%dT%H", time.localtime(time.time() - n * 3600))
+def _h(n=0):
+    """Hour key n hours before FIXED, in the stores' own format."""
+    return time.strftime("%Y-%m-%dT%H", time.localtime(FIXED - n * 3600))
 
 
 class UsageHistoryLedger(unittest.TestCase):
@@ -47,26 +54,26 @@ class UsageHistoryLedger(unittest.TestCase):
         return json.loads((pathlib.Path(self.td.name) / "usage-history.json").read_text())
 
     def test_max_pct_per_hour_and_roll_takes_the_fresh_reading(self):
-        self.b._record_usage_history({"acct": "a1", "five_hour": {"pct": 30, "resets_at": 100}})
-        self.b._record_usage_history({"acct": "a1", "five_hour": {"pct": 20, "resets_at": 100}})
-        ent = self._read()["hours"][HOUR_NOW]
+        self.b._record_usage_history({"acct": "a1", "five_hour": {"pct": 30, "resets_at": 100}}, now=FIXED)
+        self.b._record_usage_history({"acct": "a1", "five_hour": {"pct": 20, "resets_at": 100}}, now=FIXED)
+        ent = self._read()["hours"][_h()]
         self.assertEqual(ent["five_hour"], {"pct": 30, "ra": 100},
                          "within one window the hour keeps its MAX (usage only climbs)")
-        self.b._record_usage_history({"acct": "a1", "five_hour": {"pct": 5, "resets_at": 200}})
-        ent = self._read()["hours"][HOUR_NOW]
+        self.b._record_usage_history({"acct": "a1", "five_hour": {"pct": 5, "resets_at": 200}}, now=FIXED)
+        ent = self._read()["hours"][_h()]
         self.assertEqual(ent["five_hour"], {"pct": 5, "ra": 200},
                          "a ROLL (new resets_at) takes the fresh reading outright")
 
     def test_windows_accumulate_independently_and_prune_bounds_the_file(self):
         self.b._record_usage_history({"acct": "a1", "seven_day": {"pct": 11, "resets_at": 7},
-                                      "fable": {"pct": 3, "resets_at": 9}})
-        ent = self._read()["hours"][HOUR_NOW]
+                                      "fable": {"pct": 3, "resets_at": 9}}, now=FIXED)
+        ent = self._read()["hours"][_h()]
         self.assertEqual(ent["seven_day"]["pct"], 11)
         self.assertEqual(ent["fable"]["pct"], 3)
         self.assertNotIn("five_hour", ent, "a window the reading lacks stays absent — never a made-up 0")
-        hours = {_hour_ago(i): {"acct": "a1", "five_hour": {"pct": 1, "ra": 1}} for i in range(1, 250)}
+        hours = {_h(i): {"acct": "a1", "five_hour": {"pct": 1, "ra": 1}} for i in range(1, 250)}
         (pathlib.Path(self.td.name) / "usage-history.json").write_text(json.dumps({"hours": hours}))
-        self.b._record_usage_history({"acct": "a1", "five_hour": {"pct": 50, "resets_at": 1}})
+        self.b._record_usage_history({"acct": "a1", "five_hour": {"pct": 50, "resets_at": 1}}, now=FIXED)
         self.assertLessEqual(len(self._read()["hours"]), 192, "8 days of hours, never unbounded")
 
 
@@ -75,40 +82,43 @@ class SeriesPayloads(unittest.TestCase):
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
-        self.saved = jd.STATE
+        self.saved = (jd.STATE, km._claude_account)
         jd.STATE = pathlib.Path(self.td.name)
+        km._claude_account = lambda: "me"    # pinned: the foreign-skip below must not float on the
+        # machine's real login (CI has none, which turns the skip inert)
 
     def tearDown(self):
-        jd.STATE = self.saved
+        jd.STATE, km._claude_account = self.saved
         self.td.cleanup()
 
     def test_spend_series_places_hours_and_splits_keyed(self):
         (jd.STATE / "spend.json").write_text(json.dumps({"hours": {
-            HOUR_NOW: {"usd": 2.5, "key": {"usd": 2.0, "turns": 1, "tok": 5}},
-            _hour_ago(3): {"usd": 1.0},
+            _h(): {"usd": 2.5, "key": {"usd": 2.0, "turns": 1, "tok": 5}},
+            _h(3): {"usd": 1.0},
         }, "days": {}}))
-        ss = km._spend_series()
+        ss = km._spend_series(now=FIXED)
         self.assertEqual(len(ss["usd"]), 192)
         self.assertEqual(ss["usd"][-1], 2.5)
         self.assertEqual(ss["usd"][-4], 1.0)
         self.assertEqual(ss["usd"][-2], 0.0, "an hour with no turns genuinely spent $0 — money has a true zero")
-        self.assertEqual(km._spend_series(keyed_only=True)["usd"][-1], 2.0)
-        self.assertEqual(km._spend_series(keyed_only=True)["usd"][-4], 0.0,
+        self.assertEqual(km._spend_series(keyed_only=True, now=FIXED)["usd"][-1], 2.0)
+        self.assertEqual(km._spend_series(keyed_only=True, now=FIXED)["usd"][-4], 0.0,
                          "an hour with no key sub-counter contributes nothing to the keyed series")
 
     def test_win_series_gaps_are_null_and_foreign_accounts_are_skipped(self):
         (jd.STATE / "usage-history.json").write_text(json.dumps({"hours": {
-            HOUR_NOW: {"acct": "", "five_hour": {"pct": 40, "ra": 1}},
-            _hour_ago(2): {"acct": "someone-else", "five_hour": {"pct": 99, "ra": 1}},
+            _h(): {"acct": "me", "five_hour": {"pct": 40, "ra": 1}},
+            _h(2): {"acct": "someone-else", "five_hour": {"pct": 99, "ra": 1}},
         }}))
-        ws = km._usage_history_series()
+        ws = km._usage_history_series(now=FIXED)
         self.assertEqual(ws["fiveHour"][-1], 40)
         self.assertIsNone(ws["fiveHour"][-2], "no reading is null — the unknown-is-not-0 rule, drawn as a gap")
+        self.assertIsNone(ws["fiveHour"][-3], "another login's reading is skipped, like the bars' logout rule")
         self.assertEqual(ws["sevenDay"], [None] * 192)
 
     def test_empty_stores_return_none(self):
-        self.assertIsNone(km._spend_series())
-        self.assertIsNone(km._usage_history_series())
+        self.assertIsNone(km._spend_series(now=FIXED))
+        self.assertIsNone(km._usage_history_series(now=FIXED))
 
 
 class ApiKeyHostReportsSpend(unittest.TestCase):
@@ -126,14 +136,18 @@ class ApiKeyHostReportsSpend(unittest.TestCase):
         self.td.cleanup()
 
     def test_missing_usage_json_still_reports_key_spend(self):
+        # _usage() runs on the REAL clock, so the fixture stamps the real current hour and the
+        # assertion asks the payload's own h0 where that hour landed — position-independent.
+        hour_key = time.strftime("%Y-%m-%dT%H")
         (jd.STATE / "spend.json").write_text(json.dumps({
-            "hours": {HOUR_NOW: {"usd": 3.0, "turns": 2, "tok": 10}},
+            "hours": {hour_key: {"usd": 3.0, "turns": 2, "tok": 10}},
             "days": {time.strftime("%Y-%m-%d"): {"usd": 3.0, "turns": 2, "tok": 10}}}))
         u = km._usage()
         self.assertIsNotNone(u, "a keyed host with recorded spend must never answer {}")
         self.assertTrue(u.get("apiKey"))
         self.assertEqual(u["spend"]["day"]["usd"], 3.0)
-        self.assertEqual(u["spendSeries"]["usd"][-1], 3.0, "…and ships the $/hour series for the hover graph")
+        i = km._series_index(hour_key, u["spendSeries"]["h0"])
+        self.assertEqual(u["spendSeries"]["usd"][i], 3.0, "…and ships the $/hour series for the hover graph")
 
     def test_nothing_recorded_still_answers_none(self):
         self.assertIsNone(km._usage(), "a fresh box with neither login nor spend has nothing to show")
@@ -141,7 +155,6 @@ class ApiKeyHostReportsSpend(unittest.TestCase):
 
 class RemoteUsageStaleness(unittest.TestCase):
     def test_an_answered_empty_payload_clears_instead_of_freezing(self):
-        import inspect
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('r.pop("usage", None)', src,
                       "a host that ANSWERS with nothing to show clears its row — only an unanswered "

--- a/tests/test_usage_series.py
+++ b/tests/test_usage_series.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""The usage hover's time series (the user 2026-08-13): window utilization gets a recorded past
+(usage-history.json, appended by both usage writers, hourly max-pct with roll-aware overwrites, 192h
+bound), spend.json's hour buckets ship as a dense $/hour series, and a pure API-key host — which never
+gets a usage.json at all — finally reaches the no-login spend arm instead of reporting {} (the devbox,
+whose spend was missing from the fleet sum). SYNTHETIC fixtures only."""
+import json
+import os
+import pathlib
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_useries", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdkb_useries", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+jd = km.jd
+
+HOUR_NOW = time.strftime("%Y-%m-%dT%H")
+
+
+def _hour_ago(n):
+    return time.strftime("%Y-%m-%dT%H", time.localtime(time.time() - n * 3600))
+
+
+class UsageHistoryLedger(unittest.TestCase):
+    """_record_usage_history: hourly max-pct per window, roll-aware, bounded, atomic."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.b = object.__new__(sb.SdkBackend)
+        self.b.state_dir = pathlib.Path(self.td.name)
+        self.b._log = lambda *a, **k: None
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def _read(self):
+        return json.loads((pathlib.Path(self.td.name) / "usage-history.json").read_text())
+
+    def test_max_pct_per_hour_and_roll_takes_the_fresh_reading(self):
+        self.b._record_usage_history({"acct": "a1", "five_hour": {"pct": 30, "resets_at": 100}})
+        self.b._record_usage_history({"acct": "a1", "five_hour": {"pct": 20, "resets_at": 100}})
+        ent = self._read()["hours"][HOUR_NOW]
+        self.assertEqual(ent["five_hour"], {"pct": 30, "ra": 100},
+                         "within one window the hour keeps its MAX (usage only climbs)")
+        self.b._record_usage_history({"acct": "a1", "five_hour": {"pct": 5, "resets_at": 200}})
+        ent = self._read()["hours"][HOUR_NOW]
+        self.assertEqual(ent["five_hour"], {"pct": 5, "ra": 200},
+                         "a ROLL (new resets_at) takes the fresh reading outright")
+
+    def test_windows_accumulate_independently_and_prune_bounds_the_file(self):
+        self.b._record_usage_history({"acct": "a1", "seven_day": {"pct": 11, "resets_at": 7},
+                                      "fable": {"pct": 3, "resets_at": 9}})
+        ent = self._read()["hours"][HOUR_NOW]
+        self.assertEqual(ent["seven_day"]["pct"], 11)
+        self.assertEqual(ent["fable"]["pct"], 3)
+        self.assertNotIn("five_hour", ent, "a window the reading lacks stays absent — never a made-up 0")
+        hours = {_hour_ago(i): {"acct": "a1", "five_hour": {"pct": 1, "ra": 1}} for i in range(1, 250)}
+        (pathlib.Path(self.td.name) / "usage-history.json").write_text(json.dumps({"hours": hours}))
+        self.b._record_usage_history({"acct": "a1", "five_hour": {"pct": 50, "resets_at": 1}})
+        self.assertLessEqual(len(self._read()["hours"]), 192, "8 days of hours, never unbounded")
+
+
+class SeriesPayloads(unittest.TestCase):
+    """_spend_series / _usage_history_series: dense arrays + base hour; honest gaps."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = pathlib.Path(self.td.name)
+
+    def tearDown(self):
+        jd.STATE = self.saved
+        self.td.cleanup()
+
+    def test_spend_series_places_hours_and_splits_keyed(self):
+        (jd.STATE / "spend.json").write_text(json.dumps({"hours": {
+            HOUR_NOW: {"usd": 2.5, "key": {"usd": 2.0, "turns": 1, "tok": 5}},
+            _hour_ago(3): {"usd": 1.0},
+        }, "days": {}}))
+        ss = km._spend_series()
+        self.assertEqual(len(ss["usd"]), 192)
+        self.assertEqual(ss["usd"][-1], 2.5)
+        self.assertEqual(ss["usd"][-4], 1.0)
+        self.assertEqual(ss["usd"][-2], 0.0, "an hour with no turns genuinely spent $0 — money has a true zero")
+        self.assertEqual(km._spend_series(keyed_only=True)["usd"][-1], 2.0)
+        self.assertEqual(km._spend_series(keyed_only=True)["usd"][-4], 0.0,
+                         "an hour with no key sub-counter contributes nothing to the keyed series")
+
+    def test_win_series_gaps_are_null_and_foreign_accounts_are_skipped(self):
+        (jd.STATE / "usage-history.json").write_text(json.dumps({"hours": {
+            HOUR_NOW: {"acct": "", "five_hour": {"pct": 40, "ra": 1}},
+            _hour_ago(2): {"acct": "someone-else", "five_hour": {"pct": 99, "ra": 1}},
+        }}))
+        ws = km._usage_history_series()
+        self.assertEqual(ws["fiveHour"][-1], 40)
+        self.assertIsNone(ws["fiveHour"][-2], "no reading is null — the unknown-is-not-0 rule, drawn as a gap")
+        self.assertEqual(ws["sevenDay"], [None] * 192)
+
+    def test_empty_stores_return_none(self):
+        self.assertIsNone(km._spend_series())
+        self.assertIsNone(km._usage_history_series())
+
+
+class ApiKeyHostReportsSpend(unittest.TestCase):
+    """The devbox fix: no usage.json at all + spend.json present + no login → the no-login spend arm
+    answers (spend + spendSeries), never {} (kernel _usage used to bail on the missing file)."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = (jd.STATE, km._claude_account)
+        jd.STATE = pathlib.Path(self.td.name)
+        km._claude_account = lambda: ""      # the devbox shape: NO login — never the dev machine's real one
+
+    def tearDown(self):
+        jd.STATE, km._claude_account = self.saved
+        self.td.cleanup()
+
+    def test_missing_usage_json_still_reports_key_spend(self):
+        (jd.STATE / "spend.json").write_text(json.dumps({
+            "hours": {HOUR_NOW: {"usd": 3.0, "turns": 2, "tok": 10}},
+            "days": {time.strftime("%Y-%m-%d"): {"usd": 3.0, "turns": 2, "tok": 10}}}))
+        u = km._usage()
+        self.assertIsNotNone(u, "a keyed host with recorded spend must never answer {}")
+        self.assertTrue(u.get("apiKey"))
+        self.assertEqual(u["spend"]["day"]["usd"], 3.0)
+        self.assertEqual(u["spendSeries"]["usd"][-1], 3.0, "…and ships the $/hour series for the hover graph")
+
+    def test_nothing_recorded_still_answers_none(self):
+        self.assertIsNone(km._usage(), "a fresh box with neither login nor spend has nothing to show")
+
+
+class RemoteUsageStaleness(unittest.TestCase):
+    def test_an_answered_empty_payload_clears_instead_of_freezing(self):
+        import inspect
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn('r.pop("usage", None)', src,
+                      "a host that ANSWERS with nothing to show clears its row — only an unanswered "
+                      "poll (blip/rate-gate) keeps the last good reading")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -23,7 +23,9 @@ test("the kernel serves spend windows for BOTH payload shapes, keyed-only beside
   // the spend-only view arms on the legacy apiKey marker OR a login-less machine with recorded spend,
   // and keeps TOTAL sums (everything there bills the key; legacy files predate the split)
   assert.ok(KERNEL.includes('if o.get("apiKey") or (not _claude_account() and (jd.STATE / "spend.json").exists()):'));
-  assert.ok(KERNEL.includes('return {"apiKey": True, "spend": _spend_windows(),'));
+  assert.ok(KERNEL.includes('out = {"apiKey": True, "spend": _spend_windows(),'));
+  // …and the $/hour series rides beside the windows for the hover graph (the user 2026-08-13)
+  assert.ok(KERNEL.includes('out["spendSeries"] = ss'));
   // the bars payload attaches the KEYED split only — a login turn's computed cost there would be
   // dollars nobody is billed — and only when key turns actually exist (the user 2026-08-08)
   assert.ok(KERNEL.includes("def _spend_windows(keyed_only=False):"));
@@ -126,14 +128,21 @@ test("the rich tip is the ONE hover surface: no native titles, per-host sections
     const code = line.split("//")[0];
     assert.ok(!/\btitle\s*=/.test(code) && !code.includes(".title="), `native title in usage JS: ${line.trim()}`);
   }
-  // a host section can carry BOTH its login's windows and its key's spend (per-session auth) — the
-  // spendOnly gate that hid a bars host's dollars is gone
-  assert.ok(usageJS.includes("if(!keys.length&&!sp)return '';"));
+  // host sections carry WINDOWS only now — spend is ONE fleet-level section (the user 2026-08-13:
+  // one shared key reads as one number; each host records only its own turns, so the sum IS the number)
+  assert.ok(usageJS.includes("if(!keys.length)return '';"));
   assert.ok(!usageJS.includes("spendOnly"), "spend renders for ANY host that has it");
-  assert.ok(usageJS.includes("if(sp){var ks=['fiveHour','sevenDay','month'].filter(function(k){return sp[k];});"));
+  assert.ok(usageJS.includes("function fleetSpendHTML(sets)"));
+  assert.ok(usageJS.includes("return h+fleetSpendHTML(sets)+'<div class=ru-tip-age>click to refresh</div>';"));
+  // …with the summed $/hour area graph and its peak beside it
+  assert.ok(usageJS.includes("sparkHTML(wk,'#9cd2ff',true,null)"));
+  assert.ok(usageJS.includes("'<span class=ru-tip-v>peak '+fmtUsd(mx)+'</span>"));
+  // and each window section carries its own utilization spark, y pinned to the honest 0-100
+  assert.ok(usageJS.includes("sparkHTML(d._winSeries[k],v.col,false,100)"));
   // numbers only: dollars · tokens · turns per window, under a plain 'API spend' heading
   assert.ok(usageJS.includes("function spendDet(u,det)"));
-  assert.ok(usageJS.includes("<span>API spend</span>"));
+  assert.ok(usageJS.includes("API spend'+(hosts>1?' \\u00b7 '+hosts+' machines':'')"),
+    "one fleet-level section — one shared key, one number (the user 2026-08-13)");
   assert.ok(usageJS.includes("fmtUsd(v.usd)+' \\u00b7 '+fmtTok(v.tok)+' tok \\u00b7 '+(v.turns||0)+' turns</span>"));
   // the tip anchors ABOVE the rail, centered on the CURSOR — never pinned to the container edge
   assert.ok(usageJS.includes("var x=(ev&&typeof ev.clientX==='number')?ev.clientX:(r.left+r.width/2);"));


### PR DESCRIPTION
The hover gains time-series graphs — utilization sparklines under each window's bars (0-100 pinned, null-gapped) from a new 8-day `usage-history.json` ledger appended by both existing usage writers, and a 7-day $/hour area graph with peak in a new ONE-fleet-level API-spend section that sums every host (one shared key, one number, "· N machines"). The devbox's missing spend was a missing-usage.json bail before the no-login arm — fixed with a fall-through — plus the answered-empty staleness clear on the remote poll. Version-skew safe: hosts without series still join sums; the graphs add contributors only. Tests: `tests/test_usage_series.py` (8) + updated pins; suites green (Python 4478, node 1883).

🤖 Generated with [Claude Code](https://claude.com/claude-code)