### PR TITLE
One word for the awaiting state, and the chat statusline says what's awaited

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13473,6 +13473,13 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
         # error (auto-retrying → the tab renders amber/retrying, not alarm-red). chip stays "blocked" either way
         # so the client auto-retry still fires + recovers the transient ones (the user 2026-06-29).
         status = {"state": chip, "sinceEpoch": since_ms, "faded": faded,
+                  # WHAT the session is awaiting, beside the chip (the user 2026-08-13: the chat pane said
+                  # "Awaiting" with the reason nowhere in sight — the feed pill and timeline hover had it,
+                  # the statusline didn't). The why is _session_awaiting's own phrasing; awaitingTasks are
+                  # the live AWAITED task descriptions behind it (same source as the timeline lane + feed
+                  # pill), so a multi-task wait can list them all on hover.
+                  "awaitingWhy": awaiting_why or None,
+                  "awaitingTasks": (_awaiting_task_descs(sid, sess["path"]) if awaiting_why else []),
                   "apiTooLong": bool(aerr and aerr.get("tooLong")),
                   # a spend cap is on-you like tooLong (red tab, "raise your cap") AND never auto-retried:
                   # the client's apiRetryTick skips it, and the global pause it engages stops the loop too
@@ -16874,11 +16881,20 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
                 state = tm["state"] or "idle"
                 if state == "compacting" and not _compacting(sid, state, {"turns": []}, now, tm.get("since")):
                     state = "working" if open_now else "waiting"
+            # The awaitingBg WHY below must read the SAME working signal the chip just derived (the
+            # 2026-07-03 same-INPUT rule). In the skeleton build `open_now` is the RAW snapshot state
+            # while the chip reads the event model over the cached+merged parse — feeding the raw bit
+            # to _session_awaiting shipped payloads that disagreed with themselves: a lane whose badge
+            # said Awaiting (chip) with a null why beside it, so the hover/stretch had nothing to show
+            # (audited live 2026-08-13). Cold cache (comp_sess None) falls back to the raw signal —
+            # exactly then the chip fell back to the raw state too, so the pair stays aligned.
+            aw_open = _session_working(comp_sess["turns"]) if comp_sess is not None else open_now
         else:                             # dead lane: NEVER "working" — a turn left open at death (e.g. a stalled API
                                           # turn that never returned a ResultMessage, then ended) must not read as
                                           # active (the user 2026-06-23); badgeFor dims a dead lane anyway.
             blocked = "blocked" in goals.get("status", {}).values() and not _session_flag(sid, "hideFromFeed")
             state = "awaiting" if blocked else "idle"   # muted → no 'awaiting'/background-task badge on the lane
+            aw_open = open_now                          # unused (awaitingBg is None for a dead lane) — kept defined
         bars, last_t, seg_ends = [], None, {}            # seg_ends: seg-start t → work-END t (for completion marks)
         for ti, turn in enumerate(st_turns):
             turn_open = (live and ti == len(st_turns) - 1 and not turn["ended"]
@@ -16943,8 +16959,9 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         # of a bare READY (the user 2026-07-01: the surfaces must share one working model; this was the
         # last designed chat/timeline split). Named awaitingBg: the lane's legacy 'awaiting' STATE and the
         # `awaiting` intervals field below both mean blocked-on-YOU. Cheap (live subagent snapshot + states
-        # overlay), so both the skeleton and the bars build carry it.
-        awaiting_bg = (_session_awaiting(sid, s["path"], not open_now, stamp=True) if live else None)
+        # overlay), so both the skeleton and the bars build carry it. Idle input = `aw_open`, the chip's
+        # own event-model signal (see its derivation above), NOT the raw-snapshot `open_now`.
+        awaiting_bg = (_session_awaiting(sid, s["path"], not aw_open, stamp=True) if live else None)
         sessions.append({
             "id": sid, "name": name, "live": live, "state": state, "awaitingBg": awaiting_bg,
             # the live bg-task descriptions behind awaitingBg (the user 2026-07-13): the lane draws the

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -2680,7 +2680,7 @@ class TimelinePanel {
       // segment (BAR_H, the work-bar reference) in the lane color from the last work period's end to the
       // live edge, but FADED to 0.4 alpha — "something is pending here", a faded continuation of the work
       // bar rather than active work (which stays the solid ~0.9 bar). Its own hover lists the task(s),
-      // consistent with the feed's "Waiting on task" pill. Event-gated on the SAME live signal the lane
+      // consistent with the feed's "Awaiting task" pill. Event-gated on the SAME live signal the lane
       // badge reads (s.awaitingBg — kernel _session_awaiting, non-null only while the turn is CLOSED), so
       // it appears with the wait and vanishes the moment the tasks settle or a new turn opens.
       if (s.live && s.awaitingBg) {
@@ -2694,7 +2694,7 @@ class TimelinePanel {
           const rows = ((s.awaitingTasks && s.awaitingTasks.length) ? s.awaitingTasks : [s.awaitingBg])
             .map((d) => '<div class="b" style="opacity:.85">' + esc(d) + '</div>').join('');
           const tip = '<div class="r"><span class="chip" style="background:' + s.color + '"></span><span class="who" style="color:' + s.color + '">' + esc(s.name)
-            + '</span><span class="t">' + clock(anchor) + '– waiting…</span></div>' + rows;
+            + '</span><span class="t">' + clock(anchor) + '– awaiting…</span></div>' + rows;
           const wh = el('rect', { x: lx1, y: y - 7, width: lx2 - lx1, height: 14, fill: 'transparent' }); wh.style.cursor = 'grab';
           wh.addEventListener('mouseenter', (e) => { ln.setAttribute('stroke-width', String(BAR_H + 2)); ln.setAttribute('opacity', '0.6'); this.showTip(tip, e); });
           wh.addEventListener('mousemove', (e) => this.moveTip(e));

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -58,3 +58,28 @@ test("the kernel split happens in the ONE shared derivation (_session_chip), not
   assert.match(KERNEL, /"working" if open_now else\n/);
   assert.match(KERNEL, /"awaitingBg" if awaiting_why else "ready"\)/);
 });
+
+test("the statusline says WHAT the session is awaiting, beside the chip (the user 2026-08-13)", () => {
+  // the kernel ships the why + the live awaited task descriptions in the chat status payload…
+  assert.match(KERNEL, /"awaitingWhy": awaiting_why or None,/);
+  assert.match(KERNEL, /"awaitingTasks": \(_awaiting_task_descs\(sid, sess\["path"\]\) if awaiting_why else \[\]\),/);
+  // …and the awaitingBg statusline branch renders it: verb stripped (the chip already says Awaiting),
+  // full why + every task description on hover
+  const branch = RENDER.split('state === "awaitingBg") {')[1].split("} else if")[0];
+  assert.match(branch, /el\("span", "sl-await-why"\)/);
+  assert.match(branch, /why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\)/);
+  assert.match(branch, /det\.title = why \+ \(tasks\.length > 1/);
+  // one ellipsized line that shrinks instead of pushing the right-side cluster off
+  assert.match(STYLES, /\.sl-await-why \{[\s\S]*?min-width: 0;[\s\S]*?text-overflow: ellipsis/);
+});
+
+test("the timeline lane's awaitingBg why reads the SAME working signal as its badge (same input, 2026-07-03 rule)", () => {
+  // the skeleton build's raw-snapshot open_now fed _session_awaiting while the chip read the event
+  // model — a lane badge could say Awaiting with a null why beside it (audited live 2026-08-13)
+  assert.match(KERNEL, /aw_open = _session_working\(comp_sess\["turns"\]\) if comp_sess is not None else open_now/);
+  assert.match(KERNEL, /_session_awaiting\(sid, s\["path"\], not aw_open, stamp=True\) if live else None/);
+  // the awaiting stretch's hover labels the wait with the state's one word
+  const TL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
+  assert.match(TL, /– awaiting…/);
+  assert.doesNotMatch(TL, /– waiting…/);
+});

--- a/ui/webview/distill-background.test.ts
+++ b/ui/webview/distill-background.test.ts
@@ -50,7 +50,7 @@ test("hovering the SELECTED (.on) toggle gives it a reverse highlight — the ac
 
 test("state: a single mutually-exclusive secChoice (bg | summary | subgoals | tasks | none); default follows Collapsed", () => {
   // Sub-goals joined Background/Summary as the THIRD mutually-exclusive section (the user 2026-07-08);
-  // the "Waiting on task" list is the FOURTH (the user 2026-07-13)
+  // the "Awaiting task" list is the FOURTH (the user 2026-07-13)
   assert.match(FEED, /const secChoice = new Map<string, "bg" \| "summary" \| "subgoals" \| "tasks" \| "stall" \| "none">\(\);/);
   // absent from the map → the DEFAULT, set by the footer "Collapsed" toggle (off → summary, on → none)
   assert.match(FEED, /return secChoice\.get\(id\) \?\? \(feedPrefs\(\)\.collapsed \? "none" : "summary"\);/);

--- a/ui/webview/feed-awaiting-swirl.test.ts
+++ b/ui/webview/feed-awaiting-swirl.test.ts
@@ -29,11 +29,14 @@ test("the swirl is driven by spinFor's caption — shown when there is one, else
   assert.match(FEED, /a\._awaitWhy\.textContent = spinCaption; a\._awaitSpin\.title = spinTip \|\| spinCaption;/);
 });
 
-test("a bg-task wait wears the compact 'Waiting on task' pill that expands the task list (the user 2026-07-13)", () => {
+test("a bg-task wait wears the compact 'Awaiting task' pill that expands the task list (the user 2026-07-13)", () => {
   // the pill joins the mutually-exclusive card sections (bg / summary / subgoals / tasks), swirl inside
   assert.match(FEED, /const taskBtn = el\("button", "fask-secbtn fask-taskbtn"\)/);
   assert.match(FEED, /"bg" \| "summary" \| "subgoals" \| "tasks" \| "stall" \| "none"/);
-  assert.match(FEED, /taskList\.length === 1 \? "Waiting on task" : "Waiting on " \+ taskList\.length \+ " tasks"/);
+  // "Awaiting task", never "Waiting on task": one word per state across every surface — the chat chip
+  // and timeline badge already say Awaiting for this exact state (the user 2026-08-13)
+  assert.match(FEED, /taskList\.length === 1 \? "Awaiting task" : "Awaiting " \+ taskList\.length \+ " tasks"/);
+  assert.doesNotMatch(FEED, /"Waiting on task"/);
   assert.match(FEED, /taskBtn\.onclick = pick\("tasks"\);/);
   // expanded rows render in the checklist spot, same view as Sub-goals, the swirl as each row's mark
   assert.match(FEED, /if \(choice === "tasks"\) \{[\s\S]*?el\("div", "fcheck ftask"\)[\s\S]*?ftask-swirl/);

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -97,7 +97,7 @@ interface AskItem {
   warnRows?: { t: number; judge: string; err: string; note?: string; debug?: { input?: string; reply?: string } }[] | null;   // DEBUG MODE only (romp debug on): every judge failure touching this card (kernel _card_warn_rows) → "Warnings (debug)" modal section; rows captured in debug carry the failing call's input + reply (the user 2026-07-09)
   origin?: { peer: string; peerSid: string; peerHost?: string; color: { bg: string; fg: string } | null } | null;  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders)
   waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean; kind?: string } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip, or "Handed off to <peer>" when kind is "delegate" (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22 / 2026-07-25)
-  awaiting?: { why?: string | null; tasks?: string[] | null } | null;   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Waiting on task" pill (expands the list, like Sub-goals) replaces the boxed why.
+  awaiting?: { why?: string | null; tasks?: string[] | null } | null;   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Awaiting task" pill (expands the list, like Sub-goals) replaces the boxed why.
   groupTitle?: string;                             // host: this ask shares a typed turn with siblings → the group's title
   groupN?: number;                                 // host: sibling count for that turn (>1 ⇒ fold into one group card)
   provisional?: boolean;                           // a LIVE-PROMPT placeholder (kernel _provisional_card): the session is working an in-progress turn the planner hasn't classified yet. No goal node (empty tree) — dim, non-interactive, no clear/nudge/modal; replaced by the real card once the planner places the segment.
@@ -956,7 +956,7 @@ function makeAskCard(it: AskItem): HTMLElement {
   // point is that something is wrong. Filled in applySections.
   const stallBtn = el("button", "fask-secbtn fask-stallbtn"); stallBtn.textContent = "Stalled"; stallBtn.style.display = "none";
   const stallBody = el("div", "fask-stall-body");
-  // "Waiting on task" — the FOURTH mutually-exclusive section (the user 2026-07-13): a compact pill (with
+  // "Awaiting task" — the FOURTH mutually-exclusive section (the user 2026-07-13): a compact pill (with
   // the mini spinning swirl inside) that replaces the old boxed awaiting caption when live bg TASKS exist;
   // click expands the task list in the checklist spot, same interaction as Sub-goals. Filled in applySections.
   const taskBtn = el("button", "fask-secbtn fask-taskbtn"); taskBtn.style.display = "none";
@@ -1227,7 +1227,7 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
   }
   const hasSubs = subCount > 0;
   // live background tasks (the user 2026-07-13): when the card is AWAITING on tasks, the compact
-  // "Waiting on task" pill joins the section toggles and expands this list (the old boxed caption is gone)
+  // "Awaiting task" pill joins the section toggles and expands this list (the old boxed caption is gone)
   const taskList = ((it.awaiting && it.awaiting.tasks) || []).filter(Boolean);
   const hasTasks = taskList.length > 0;
   // resolve the selection (default = summary open), falling back to "none" if the chosen section is empty
@@ -1290,11 +1290,13 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
   subBtn.setAttribute("aria-pressed", choice === "subgoals" ? "true" : "false");
   subBtn.title = choice === "subgoals" ? "hide the sub-goals" : "show the sub-goals";
   subBtn.onclick = pick("subgoals");
-  // "Waiting on task" pill (the user 2026-07-13) — visible only while live bg tasks exist; the mini swirl
+  // "Awaiting task" pill (the user 2026-07-13) — visible only while live bg tasks exist; the mini swirl
   // inside keeps the "in flight" cue; pressed when the task list is showing. No preachy tooltip.
+  // "Awaiting", not "Waiting on": the chat chip and timeline badge already label this exact state
+  // Awaiting, and two words for one state read as two states (the user 2026-08-13).
   const taskBtn = a._taskBtn as HTMLElement;
   taskBtn.style.display = hasTasks ? "" : "none";
-  (a._taskLbl as HTMLElement).textContent = taskList.length === 1 ? "Waiting on task" : "Waiting on " + taskList.length + " tasks";
+  (a._taskLbl as HTMLElement).textContent = taskList.length === 1 ? "Awaiting task" : "Awaiting " + taskList.length + " tasks";
   taskBtn.classList.toggle("on", choice === "tasks");
   taskBtn.setAttribute("aria-pressed", choice === "tasks" ? "true" : "false");
   taskBtn.title = choice === "tasks" ? "hide the tasks" : "show the tasks";

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -198,7 +198,7 @@ type ChatEvent = (
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
 type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
-interface Status { state: ChipState; sinceEpoch: number | null; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingTasks?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the statusline shows it beside the Awaiting chip (the user 2026-08-13)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed.
@@ -7444,6 +7444,18 @@ function updateStatusline() {
     timer.id = "work-timer";
     timer.textContent = elapsedMs(s.status.sinceEpoch);
     sl.appendChild(timer);
+    // WHAT it's awaiting, right here in the statusline (the user 2026-08-13: the chip alone said
+    // "Awaiting" and the reason showed nowhere in the chat pane). The kernel's why leads with the
+    // verb ("waiting on a background task: …") and the chip already says Awaiting — strip the verb
+    // so the line doesn't stutter; the hover carries the full why plus every live task description.
+    const why = (s.status.awaitingWhy || "").trim();
+    if (why) {
+      const det = el("span", "sl-await-why");
+      det.textContent = why.replace(/^(waiting on|awaiting)\s+/i, "");
+      const tasks = s.status.awaitingTasks || [];
+      det.title = why + (tasks.length > 1 ? "\n" + tasks.map((t) => "· " + t).join("\n") : "");
+      sl.appendChild(det);
+    }
   } else if (s.status.state === "compacting") {
     const c = el("span", "compacting-line");
     c.textContent = "⟳ Compacting context…";

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -54,7 +54,7 @@ test("AWAITING uses the kernel's why verbatim (capitalized) when it reads 'waiti
 });
 
 test("a peer wait (waitingOn chip) and a bg-TASK wait (pill) both defer — no generic awaiting box", () => {
-  // the "Awaiting <peer>" chip / the "Waiting on task" pill already carry these; the box would double up
+  // the "Awaiting <peer>" chip / the "Awaiting task" pill already carry these; the box would double up
   assert.equal(spinFor({ awaiting: { why: "x" }, waitingOn: "peer" }, false, false).caption, null);
   assert.equal(spinFor({ awaiting: { why: "x", tasks: ["t1"] } }, false, false).caption, null);
 });

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -58,7 +58,7 @@ function workingFor(secs: number): string {
 
 export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boolean, nowS?: number): Spin {
   const aw = it.awaiting;
-  // a bg-TASK wait no longer boxes its why here (the user 2026-07-13): the compact "Waiting on task" pill
+  // a bg-TASK wait no longer boxes its why here (the user 2026-07-13): the compact "Awaiting task" pill
   // on the toggles row carries it (with the task list one click away, like Sub-goals) — see applySections
   const awTasks = ((aw && aw.tasks) || []).filter(Boolean);
   if (aw && !it.waitingOn && !awTasks.length) {
@@ -81,7 +81,7 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
     // judge has nothing to classify yet; once the turn settles (kernel `judging`) the planner's pass is
     // due/in flight and only THEN does the chip say Analyzing…. An AWAITING placeholder (a bg-task wait with
     // no goal to floor, the user 2026-07-13) is provisional too but NOT working: !aw defers it to the boxed
-    // why (branch above) or, when tasks exist, to the "Waiting on task" pill — never a false "Working…".
+    // why (branch above) or, when tasks exist, to the "Awaiting task" pill — never a false "Working…".
     return {
       caption: it.judging ? "Analyzing…" : "Working…",
       tip: it.judging

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -723,6 +723,11 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .chip-idle { background: rgba(255, 255, 255, 0.08); color: var(--dim); }
 .chip-closed { background: rgba(255, 255, 255, 0.07); color: var(--dim); }
 .status-timer { color: var(--dim); font-variant-numeric: tabular-nums; font-size: 0.92em; }
+/* WHAT an awaitingBg session is waiting on, beside the Awaiting chip + clock (the user 2026-08-13).
+   One ellipsized line (full why + task list on hover) — min-width 0 so the flex row can shrink it
+   instead of pushing the right-side cluster off. Same size/color as the timer it sits next to. */
+.sl-await-why { color: var(--dim); font-size: 0.92em; flex: 0 1 auto; min-width: 0;
+                overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* stop/interrupt button beside the state badge (the user 2026-06-19): sends the SAME interrupt as the
    composer's Ctrl+C. It renders ONLY while the session is busy (updateStatusline omits it when idle), so
    it's always the live control — a crisp white square, and ONLY on hover does it reveal the pale-red


### PR DESCRIPTION
## What

The green "idle but waiting on background work it dispatched" state (`awaitingBg`) was named differently per surface, and the chat pane never said what was being awaited:

- **Feed pill**: "Waiting on task" → now **"Awaiting task"** / **"Awaiting N tasks"** — the chat chip and timeline badge already label this exact state *Awaiting*, and two words for one state read as two states.
- **Timeline awaiting-stretch hover**: "– waiting…" → "– awaiting…".
- **Chat statusline**: the Awaiting chip now has the *reason* beside it. The kernel ships `awaitingWhy` + `awaitingTasks` in the chat status payload; the statusline renders the why (leading verb stripped — the chip already says Awaiting) with the full why + every live task description on hover, in an ellipsized `.sl-await-why` span that shrinks instead of pushing the right-side cluster off.
- **Same-input fix (build_timeline)**: the skeleton build fed the RAW snapshot `open_now` to `_session_awaiting` while the lane badge (`_session_chip`) read the event model over the cached+merged parse — a live audit caught a lane whose badge said *Awaiting* beside a `null` why (no hover, no stretch). The why now reads the same event-model signal as the badge (`aw_open`), falling back to the raw bit exactly when the chip does (cold cache).

## Tests

- `awaiting-state.test.ts`: two new tests pin the status-payload fields, the statusline branch (span, verb strip, hover), the `.sl-await-why` ellipsis rule, the `aw_open` alignment, and the hover label word.
- `feed-awaiting-swirl.test.ts`: pill pins updated to the new labels, plus a `doesNotMatch` on the old one.
- Full suites green: 1886 UI tests, 4461 Python tests (40 pre-existing skips), `tsc --noEmit` clean, production bundle builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)