### PR TITLE
fix(security): VS Code extension must not exec a wire-provided install path (supersedes #340)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -502,8 +502,17 @@ def _kernel_ver():
 def _version_info():
     """What this kernel is running — code sha + per-bundle build mtimes + pid/uptime. Lets the feed's
     settings gear / `romp version` / a curl tell at a glance whether the browser is on a stale bundle
-    (compare the served ?v= against bundles[].mtime here). Any path here is $HOME-collapsed for privacy
-    (like defaultDir/rompDir) — never a raw /Users/<name> path."""
+    (compare the served ?v= against bundles[].mtime here).
+
+    /version is AUTH-EXEMPT — any local process reads it with no token, and it rides the remote poll
+    between machines — so it must reveal nothing that grants leverage. `rompDir` used to ride here,
+    $HOME-collapsed: the VS Code extension read it and turned it into an `execFile("bash", …)` target,
+    so whatever answered this port chose the directory a shell ran in (the extension resolves its own
+    install path now — see vscode-extension/src/update-target.ts — and never asks). A $HOME-collapse
+    hid the username, never the checkout's location or name, so the path had no business on an
+    auth-exempt route at all. (`defaultDir`/`nativeDialogs` still ride here because the gear reads
+    them here; they also travel the authenticated sessionList, and moving the gear onto that is the
+    clean follow-up that lets `defaultDir` leave this payload too.)"""
     bundles = {}
     try:
         for p in sorted(DIST.glob("*.js")) + sorted(DIST.glob("*.css")):
@@ -521,11 +530,7 @@ def _version_info():
             "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),      # current per-tier judge models → the gear dropdowns
             "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort(),  # current per-tier judge efforts ("" = default/none)
             "defaultDir": _tilde(_default_create_dir()),   # the resolved default new-session dir → the gear "Default directory" field
-            "nativeDialogs": _native_dialogs(),   # whether Browse… can draw a dialog HERE → the gear drops the button when it can't
-            # The repo root ($HOME-collapsed), so the VS Code extension host can run vscode-extension/install.sh
-            # to self-update a drifted VSIX (a webview reload can't — the code is baked into the on-disk VSIX).
-            # ROMP_DIR is reliably exported by romp-serve/launchd; HERE.parent (kernel/ → repo root) backs it up.
-            "rompDir": _tilde(os.environ.get("ROMP_DIR") or str(HERE.parent))}
+            "nativeDialogs": _native_dialogs()}   # whether Browse… can draw a dialog HERE → the gear drops the button when it can't
 
 
 def _dist_ver():

--- a/tests/test_kernel_cachebust.py
+++ b/tests/test_kernel_cachebust.py
@@ -42,19 +42,13 @@ def test_version_info_shape():
     assert isinstance(info["bundles"], dict)
 
 
-def test_version_info_reports_romp_dir():
-    # The VS Code extension host reads rompDir off /version to run vscode-extension/install.sh and
-    # self-update a drifted VSIX. It must (a) point at the repo root and (b) stay $HOME-collapsed for
-    # privacy — never a raw /Users/<name> path (like defaultDir).
+def test_version_info_carries_no_repo_path():
+    # /version is AUTH-EXEMPT, so it must reveal nothing that grants leverage. rompDir used to ride
+    # here and the VS Code extension turned it into an execFile("bash", …) target — whatever answered
+    # the port chose the directory a shell ran in. The extension resolves its own install path now
+    # (update-target.ts), so rompDir has no reader and must not be published.
     info = km._version_info()
-    assert "rompDir" in info and isinstance(info["rompDir"], str) and info["rompDir"]
-    home = os.path.expanduser("~")
-    real = os.path.expanduser(info["rompDir"])
-    if real.startswith(home + os.sep):
-        assert info["rompDir"] == "~" or info["rompDir"].startswith("~" + os.sep), \
-            "a repo under $HOME must be reported home-collapsed (privacy)"
-    # Round-trips to the real repo root — the host expands ~ then runs vscode-extension/install.sh there.
-    assert os.path.isdir(os.path.join(real, "vscode-extension")), real
+    assert "rompDir" not in info, "rompDir must not ride the auth-exempt /version (exec-target leak)"
 
 
 def test_send_emits_cache_control():

--- a/vscode-extension/src/build-drift.test.ts
+++ b/vscode-extension/src/build-drift.test.ts
@@ -38,22 +38,35 @@ test("the extension compares keepalive dv against the stamp and prompts once", (
     "latched (one prompt per window), guarded when the stamp is absent, and only NEWER dv fires");
 });
 
-test("the drift prompt is ACTIONABLE — an Update extension button, not a bare toast", () => {
+test("the drift prompt's buttons are resolved LOCALLY and never dead-end in an error toast", () => {
   const notice = slice("function maybeBuildNotice(dv: unknown)", "async function updateExtension");
-  assert.ok(notice.includes('"Update extension"'), "offers the Update extension action");
-  assert.ok(notice.includes("void updateExtension()"), "the action runs the self-update");
+  // The buttons come from a LOCAL resolution routed through driftNotice — never a fixed string, never
+  // off the wire — so a copy that can't rebuild is offered the copy-command action, not an Update
+  // button whose only outcome is an error toast.
+  assert.ok(notice.includes("resolveInstallScript(ctx?.extensionPath || \"\", process.env.ROMP_DIR"),
+    "resolves the target locally to decide the toast's buttons");
+  assert.ok(notice.includes("driftNotice("), "the message + actions come from driftNotice");
+  assert.ok(notice.includes("notice.message") && notice.includes("...notice.actions"),
+    "shows driftNotice's message and its actions, in order");
+  assert.ok(notice.includes("choice === UPDATE_ACTION") && notice.includes("void updateExtension()"),
+    "the Update action runs the self-update");
+  assert.ok(notice.includes("choice === COPY_ACTION") && notice.includes("clipboard.writeText(INSTALL_COMMAND)"),
+    "the Copy action puts the install command on the clipboard — a client-side action that cannot fail");
   // The notice itself must NOT reload — the drift toast never auto-anything (the reload is gated later).
   assert.ok(!notice.includes("reloadWindow"), "maybeBuildNotice must not reload the window");
 });
 
 test("updateExtension rebuilds+reinstalls the VSIX, then offers a USER-gated reload", () => {
   const upd = slice("async function updateExtension", "function runInstall");
-  assert.ok(upd.includes('fetchJson("/version")') && upd.includes("info.rompDir"),
-    "learns the repo root from the kernel's /version rompDir");
-  assert.ok(upd.includes('path.join(os.homedir(), reported.slice(1))'),
-    "$HOME-collapses rompDir back to a real path (same machine as the local kernel)");
-  assert.ok(upd.includes("runInstall(script, extDir)") && upd.includes('"install.sh"'),
-    "runs vscode-extension/install.sh");
+  // The install target is resolved LOCALLY — this VSIX's own path or ROMP_DIR from our own
+  // environment (update-target.ts) — never off the kernel's auth-exempt /version, where a rompDir
+  // off the wire would let whatever answers the port pick the directory a shell command runs from.
+  assert.ok(upd.includes("resolveInstallScript(ctx?.extensionPath || \"\", process.env.ROMP_DIR"),
+    "resolves the install dir from local knowledge, not a kernel response");
+  assert.ok(!/info\.rompDir|fetchJson\("\/version"\)/.test(upd),
+    "updateExtension must not read the repo root off /version");
+  assert.ok(upd.includes("runInstall(script, extDir)") && upd.includes("target.script"),
+    "runs the resolved install.sh (script now comes from update-target, not a joined /version path)");
   assert.ok(upd.includes("packaged romp-chat-view\\.vsix") && upd.includes("install into:"),
     "a clean exit is not enough — require the packaged + installed markers (install.sh skips gracefully)");
   // Reload is behind an explicit button click, never automatic (prefer-reload-banner-not-auto).

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -29,6 +29,7 @@ import { deriveStatus, freshNeedsYou, renderStatusBar, statusTooltipLines, Fleet
 import { citeText, sessionsForWorkspace, SessionInfo } from "./workspace-sessions";
 import { parsePorcelain } from "./session-diff";
 import { buildMenu, usageSummary } from "./romp-menu";
+import { resolveInstallScript, driftNotice, UPDATE_ACTION, COPY_ACTION, INSTALL_COMMAND } from "./update-target";
 
 const HOST = "127.0.0.1";
 
@@ -63,11 +64,18 @@ let buildNotified = false;
 function maybeBuildNotice(dv: unknown): void {
   if (buildNotified || !BUILD_STAMP || typeof dv !== "number" || dv <= BUILD_STAMP) return;
   buildNotified = true;
-  void vscode.window.showInformationMessage(
-    "A newer romp build is available — these panes run an older extension bundle.",
-    "Update extension").then((choice) => {
-      if (choice === "Update extension") void updateExtension();
-    });
+  // WHICH buttons the toast offers is decided by a LOCAL resolution (this VSIX's own path or ROMP_DIR
+  // from our own environment — update-target.ts), never off the wire. A copy that is a real checkout can
+  // rebuild, so it gets the one-click Update; one that can't (a packaged VSIX — the ordinary case) is
+  // offered the client-side "copy the install command" and told the remedy in the message, instead of a
+  // button that could only end in an error toast (driftNotice). updateExtension RE-RESOLVES at click
+  // time, deliberately — the filesystem can change under a toast still on screen, and only the click may
+  // shell out.
+  const notice = driftNotice(resolveInstallScript(ctx?.extensionPath || "", process.env.ROMP_DIR, (p) => fs.existsSync(p)));
+  void vscode.window.showInformationMessage(notice.message, ...notice.actions).then((choice) => {
+    if (choice === UPDATE_ACTION) void updateExtension();
+    else if (choice === COPY_ACTION) void vscode.env.clipboard.writeText(INSTALL_COMMAND);
+  });
 }
 
 // Self-update: rebuild + repackage + reinstall the VSIX so a drifted pane heals with a click (the user
@@ -75,23 +83,26 @@ function maybeBuildNotice(dv: unknown): void {
 // banner just reloads, but VS Code loads bundled code from the on-disk VSIX, so a reload changes
 // nothing; the fix is the SAME vscode-extension/install.sh a user would run by hand). We run it from the
 // extension HOST, not the kernel: the host carries VS Code's resolved shell environment (the reliable
-// PATH with node/npm/npx/code), whereas a launchd/manager-spawned kernel often does not. The kernel
-// only tells us WHERE the repo lives (rompDir on /version). Reload stays a user click, never automatic
-// (prefer-reload-banner-not-auto).
+// PATH with node/npm/npx/code), whereas a launchd/manager-spawned kernel often does not.
+//
+// WHERE it runs is decided LOCALLY — this VSIX's own path, else ROMP_DIR from our own environment
+// (update-target.ts). It used to be whatever the kernel reported as rompDir on /version, an
+// AUTH-EXEMPT route: anything answering on the kernel port could then choose the directory we ran a
+// shell command from, and drive the prompt that invites the click besides. When this copy isn't a
+// checkout it can't rebuild anything, so we say so and point at the terminal rather than running some
+// other install.sh. Reload stays a user click, never automatic (prefer-reload-banner-not-auto).
 let updating = false;
 async function updateExtension(): Promise<void> {
   if (updating) return;                                    // one run per host (double-click, or toast + palette)
-  const info = await fetchJson("/version");
-  const reported = info && typeof info.rompDir === "string" ? String(info.rompDir) : "";
-  // rompDir is $HOME-collapsed for privacy; expand it back (same machine as the local kernel, so ~ → our home).
-  const repo = reported.startsWith("~") ? path.join(os.homedir(), reported.slice(1)) : reported;
-  if (!repo) {
+  const target = resolveInstallScript(ctx?.extensionPath || "", process.env.ROMP_DIR, (p) => fs.existsSync(p));
+  if (!target) {
     void vscode.window.showErrorMessage(
-      "romp: couldn't locate the romp repo to update from (the kernel didn't report rompDir). Run vscode-extension/install.sh in a terminal.");
+      "romp: this copy of the extension can't rebuild itself — it runs from a packaged VSIX, not a romp checkout. " +
+      "Run vscode-extension/install.sh in your romp checkout from a terminal, then reload this window.");
     return;
   }
-  const extDir = path.join(repo, "vscode-extension");
-  const script = path.join(extDir, "install.sh");
+  const extDir = target.dir;
+  const script = target.script;
   updating = true;
   try {
     const out = await vscode.window.withProgress(

--- a/vscode-extension/src/update-target.test.ts
+++ b/vscode-extension/src/update-target.test.ts
@@ -1,0 +1,112 @@
+// The self-update's exec target comes from THIS host, never from the kernel.
+//
+// `bash <dir>/install.sh` runs whatever <dir> holds, and <dir> used to be the rompDir a kernel
+// reported on /version — an auth-exempt route, so any listener that owned the port (one that grabbed
+// it before the real kernel) chose the directory a shell command ran from, then raised the drift
+// prompt that gets it clicked. These pin the replacement: candidates are the extension's own
+// installed path and ROMP_DIR from our own environment, each accepted only when it looks like a romp
+// checkout, and a copy that isn't one resolves to nothing so the caller can say so out loud.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as path from "path";
+import {
+  CANT_REBUILD, CHECKOUT_MARKERS, COPY_ACTION, INSTALL_COMMAND, MANUAL_REMEDY, UPDATE_ACTION,
+  driftNotice, installCandidates, resolveInstallScript,
+} from "./update-target";
+
+// A tiny fake filesystem: the set of paths that "exist".
+function fsWith(...dirs: { dir: string; files: string[] }[]) {
+  const present = new Set<string>();
+  for (const d of dirs) for (const f of d.files) present.add(path.join(d.dir, f));
+  return (p: string) => present.has(p);
+}
+
+const CHECKOUT = path.join("/opt", "notes-api", "romp", "vscode-extension");   // a real source tree
+const INSTALLED = path.join("/opt", "editor", "extensions", "romp.romp-chat-view-0.4.337");
+const HOSTILE = path.join("/tmp", "attacker", "vscode-extension");             // what a squatter would name
+
+test("a hostile rompDir never becomes the exec target — it is not even a candidate", () => {
+  // The squatter's directory is a picture-perfect checkout; the only thing it lacks is being ours.
+  const exists = fsWith({ dir: HOSTILE, files: CHECKOUT_MARKERS }, { dir: CHECKOUT, files: CHECKOUT_MARKERS });
+  const cands = installCandidates(CHECKOUT, path.join("/opt", "notes-api", "romp"));
+  assert.ok(!cands.some((c) => c.includes("attacker")), "nothing kernel-reported reaches the candidate list");
+  const t = resolveInstallScript(CHECKOUT, path.join("/opt", "notes-api", "romp"), exists);
+  assert.equal(t?.script, path.join(CHECKOUT, "install.sh"));
+  assert.ok(!t!.script.includes("attacker") && !t!.dir.includes("attacker"));
+});
+
+test("an installed VSIX resolves to nothing rather than to someone else's install.sh", () => {
+  // The packaged copy ships install.sh but not esbuild.js (.vscodeignore), so it cannot rebuild —
+  // and with the hostile tree sitting right there, "nothing" is the only safe answer.
+  const exists = fsWith({ dir: INSTALLED, files: ["install.sh", "package.json"] },
+                        { dir: HOSTILE, files: CHECKOUT_MARKERS });
+  assert.equal(resolveInstallScript(INSTALLED, undefined, exists), null);
+  assert.equal(resolveInstallScript(INSTALLED, "", exists), null);
+});
+
+test("the extension's own path wins; ROMP_DIR from our own environment backs it up", () => {
+  const repo = path.join("/opt", "notes-api", "romp");
+  const exists = fsWith({ dir: CHECKOUT, files: CHECKOUT_MARKERS }, { dir: INSTALLED, files: ["install.sh"] });
+  // Run from the checkout: the extension dir IS vscode-extension/.
+  assert.deepEqual(resolveInstallScript(CHECKOUT, repo, exists),
+    { dir: CHECKOUT, script: path.join(CHECKOUT, "install.sh") });
+  // Installed copy, but this host was launched from a shell that exports ROMP_DIR — same trust as
+  // whoever started VS Code, so the update still works where it legitimately can.
+  const envOnly = fsWith({ dir: INSTALLED, files: ["install.sh"] }, { dir: path.join(repo, "vscode-extension"), files: CHECKOUT_MARKERS });
+  assert.equal(resolveInstallScript(INSTALLED, repo, envOnly)?.dir, path.join(repo, "vscode-extension"));
+});
+
+test("both checkout markers are required — install.sh alone proves nothing", () => {
+  for (const only of CHECKOUT_MARKERS) {
+    assert.equal(resolveInstallScript(CHECKOUT, undefined, fsWith({ dir: CHECKOUT, files: [only] })), null,
+      `${only} on its own must not qualify as a checkout`);
+  }
+  assert.ok(CHECKOUT_MARKERS.includes("install.sh") && CHECKOUT_MARKERS.includes("esbuild.js"));
+});
+
+test("an empty extension path contributes no candidate (no probing of /install.sh)", () => {
+  assert.deepEqual(installCandidates("", undefined), []);
+  assert.equal(resolveInstallScript("", undefined, () => true), null);
+});
+
+// ---- the drift toast only offers what can actually work here ----
+// Resolving locally made "nothing to rebuild from" the ordinary case: .vscodeignore keeps the build
+// inputs out of the VSIX and ROMP_DIR is exported into the kernel/service environment, not into the
+// shell or GUI that launches VS Code. The toast kept its "Update extension" button anyway, so on
+// essentially every installation its one action was guaranteed to fail (the review, 2026-08-05).
+
+test("no resolvable checkout: the toast offers no action that would fail, and says what to run", () => {
+  const n = driftNotice(null);
+  assert.ok(!n.actions.includes(UPDATE_ACTION), "an Update button here can only end in an error toast");
+  assert.deepEqual(n.actions, [COPY_ACTION], "the one offered action is client-side and cannot fail");
+  // The remedy is in the MESSAGE too — a toast fades, and the user should not need the button to
+  // learn what to do.
+  assert.ok(n.message.includes(INSTALL_COMMAND), "names the command to run");
+  assert.ok(n.message.includes("terminal"), "says where to run it");
+  assert.ok(n.message.includes(CANT_REBUILD) && n.message.includes(MANUAL_REMEDY));
+  assert.ok(n.message.includes("newer romp build"), "still leads with the drift itself");
+});
+
+test("a resolvable checkout keeps the one-click update, with nothing added to distract from it", () => {
+  const dir = CHECKOUT;
+  const n = driftNotice({ dir, script: path.join(dir, "install.sh") });
+  assert.deepEqual(n.actions, [UPDATE_ACTION], "the existing one-click flow is unchanged");
+  assert.equal(n.message, "A newer romp build is available — these panes run an older extension bundle.");
+  assert.ok(!n.message.includes(INSTALL_COMMAND), "no terminal instructions where the button works");
+});
+
+test("the notice's actions follow the SAME resolution the click will do — no second opinion", () => {
+  // Toast time and click time must agree about this host; a copy that resolves gets the button, one
+  // that doesn't never sees it. (They are separate CALLS, deliberately: the filesystem can change
+  // under a toast that is still on screen, and only the click-time check may shell out.)
+  const repo = path.join("/opt", "notes-api", "romp");
+  const checkout = fsWith({ dir: CHECKOUT, files: CHECKOUT_MARKERS });
+  const packaged = fsWith({ dir: INSTALLED, files: ["install.sh", "package.json"] });
+  for (const [ext, env, exists, want] of [
+    [CHECKOUT, undefined, checkout, [UPDATE_ACTION]],
+    [INSTALLED, undefined, packaged, [COPY_ACTION]],
+    [INSTALLED, repo, packaged, [COPY_ACTION]],       // ROMP_DIR set but no checkout under it
+  ] as [string, string | undefined, (p: string) => boolean, string[]][]) {
+    assert.deepEqual(driftNotice(resolveInstallScript(ext, env, exists)).actions, want);
+  }
+});

--- a/vscode-extension/src/update-target.ts
+++ b/vscode-extension/src/update-target.ts
@@ -1,0 +1,87 @@
+// update-target — WHERE the one-click self-update runs, decided LOCALLY and never off the wire.
+//
+// updateExtension() shells out to `bash <dir>/install.sh`, so <dir> is an EXECUTION target and may
+// only come from something we already trust: this VSIX's own installed location
+// (context.extensionPath) or ROMP_DIR out of the extension host's own environment — both set by
+// whoever launched VS Code, i.e. the user. It used to come from `rompDir` on the kernel's /version,
+// which is the wrong kind of source: /version is auth-exempt, so anything answering on the kernel
+// port (a local process that grabbed it before the real kernel, say) got to name the directory a
+// shell command ran from — and that same listener's keepalive `dv` raises the "newer build" prompt
+// that invites the click. A path that arrives over a socket is not a path to run.
+//
+// A candidate must look like a romp CHECKOUT, not merely a directory holding an install.sh:
+// .vscodeignore drops the build inputs (esbuild.js, src/**, and install.sh itself since 2026-08-05),
+// and a copy without them can't rebuild anything — copies packaged before that date still carry
+// install.sh with no esbuild.js beside it, which is exactly the shape the pair of markers rejects.
+// Requiring BOTH is what separates "running from a checkout" — where the update genuinely works —
+// from "installed from a .vsix", which resolves to nothing so the caller can say so plainly and
+// point at the terminal (fail loudly, don't degrade).
+import * as path from "path";
+
+// Present together only in a real vscode-extension/ source dir: install.sh does the build+package,
+// esbuild.js is the build it invokes. A packaged install carries the first without the second.
+export const CHECKOUT_MARKERS = ["install.sh", "esbuild.js"];
+
+export interface InstallTarget {
+  dir: string;      // the vscode-extension/ dir to run in (install.sh cd's here itself)
+  script: string;   // <dir>/install.sh
+}
+
+// The dirs worth probing, best first. Both are this host's own knowledge of itself; nothing here
+// consults the kernel.
+export function installCandidates(extensionPath: string, rompDirEnv?: string): string[] {
+  const out: string[] = [];
+  const ext = (extensionPath || "").trim();
+  if (ext) out.push(ext);                                        // run from a checkout: the extension dir IS vscode-extension/
+  const repo = (rompDirEnv || "").trim();
+  if (repo) out.push(path.join(repo, "vscode-extension"));       // a host launched from a romp shell/service knows the repo
+  return out;
+}
+
+// The first candidate that is a romp checkout, or null when this copy can't rebuild itself.
+export function resolveInstallScript(
+  extensionPath: string,
+  rompDirEnv: string | undefined,
+  exists: (p: string) => boolean,
+): InstallTarget | null {
+  for (const dir of installCandidates(extensionPath, rompDirEnv)) {
+    if (CHECKOUT_MARKERS.every((m) => exists(path.join(dir, m)))) {
+      return { dir, script: path.join(dir, "install.sh") };
+    }
+  }
+  return null;
+}
+
+// ---- what the drift toast is allowed to OFFER ----
+//
+// Resolving locally made "no target" the COMMON case, not the exotic one: on any install that
+// vscode-extension/install.sh produces there is no checkout under the VSIX, and ROMP_DIR is exported
+// into the kernel/service environment (bin/romp-serve, bin/romp-service) — never into the shell or
+// the GUI session that launches VS Code. The drift toast kept offering "Update extension" anyway, so
+// its one button was guaranteed to fail on nearly every installation (an adversarial review of that
+// change, 2026-08-05). An action that cannot succeed is worse than no action: it costs a click, a
+// wait and an error toast to learn what the message could have said outright. So the notice picks its
+// buttons from a LIVE resolution and, when there is no target, offers the one thing that always
+// works — putting the command on the clipboard — with the remedy spelled out in the message itself.
+export const UPDATE_ACTION = "Update extension";
+export const COPY_ACTION = "Copy install command";
+
+// What to paste into a terminal, run from the top of a romp checkout.
+export const INSTALL_COMMAND = "bash vscode-extension/install.sh";
+export const CANT_REBUILD =
+  "This copy of the extension runs from a packaged VSIX, not a romp checkout, so it can't rebuild itself.";
+export const MANUAL_REMEDY =
+  `Run ${INSTALL_COMMAND} from your romp checkout in a terminal, then reload this window.`;
+
+export interface DriftNotice {
+  message: string;
+  actions: string[];   // toast buttons, in order — never one that cannot succeed on this host
+}
+
+// The build-drift toast, given what this host resolved. Pure, so the wiring in extension.ts (which
+// can't be imported under node --test — it pulls in vscode) is a one-line hand-off.
+export function driftNotice(target: InstallTarget | null): DriftNotice {
+  const lead = "A newer romp build is available — these panes run an older extension bundle.";
+  if (target) return { message: lead, actions: [UPDATE_ACTION] };
+  return { message: `${lead} ${CANT_REBUILD} ${MANUAL_REMEDY}`, actions: [COPY_ACTION] };
+}


### PR DESCRIPTION
Supersedes #340. Same core security fix, rebuilt clean on current `main` as a single commit, plus two improvements and a privacy fix.

## The hole
`/version` is auth-exempt, so any local process that answers the kernel port can put a path in `rompDir`, and the extension runs `bash <that>/vscode-extension/install.sh` when the user clicks "Update extension" — code execution as the user, chosen by whoever squats the port (which also raises the drift toast that invites the click).

## Fix
- Kernel: drop `rompDir` from the `/version` payload (the extension was its only reader).
- Extension: resolve the install script LOCALLY — this VSIX's own `extensionPath`, else `ROMP_DIR` from the host's own environment — each accepted only when the dir carries BOTH checkout markers (`install.sh` AND `esbuild.js`). A path off the wire never reaches the exec.

## Improvements over #340
- Wires the drift toast through `driftNotice()` (which #340 added and tested but never connected): a packaged VSIX that can't rebuild is offered "Copy install command" with the remedy in the message, instead of an "Update extension" button whose only outcome is an error toast. No dead code left.
- #340 accidentally committed a `vscode-extension/node_modules` symlink pointing at an absolute local home path. This branch is rebuilt from `main` so that path never enters history.

## Tests
- `tests/test_kernel_cachebust.py` asserts `/version` carries no repo path (fails on main).
- `vscode-extension/src/update-target.test.ts` pins local resolution, marker gating, and toast actions.
- `vscode-extension/src/build-drift.test.ts` pins the new local wiring.

All green locally: pytest, `tsc --noEmit`, `node --test` (1891 pass), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
