### PR TITLE
Comment threads: highlight a passage in the chat and talk about it right there

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4471,6 +4471,395 @@ def _seed_fork_stores(parent_sid, sid, path, cut_uuid):
     return None
 
 
+# ── comment threads (the user 2026-08-13) ─────────────────────────────────────────────
+# Highlight a passage in a session's chat, comment on it, and a side conversation opens right
+# there: a popover anchored to the highlighted text, powered by a FORK of the session cut at the
+# anchored message (fork_session + --resume-session-at, INCLUSIVE — the thread's agent holds
+# exactly the context that produced the passage). The fork is a comment THREAD (reg threadOf=
+# parent, no names/ entry): no tab, no lane, no cards, no judge pass — its whole user surface is
+# the parent chat's highlight + popover, and "Break out" promotes it into a full board session
+# (judge seeds first, names/ last: the fork() ordering contract). The thread REGISTRY lives in
+# comments/<parent sid>.json (anchor, thread sid, status); the CONVERSATION lives in the thread's
+# own transcript — the authoritative store — projected into the {type:"comments"} frame per push.
+
+_comments_lock = threading.Lock()          # store read-modify-writes from WS handler threads
+_thread_msgs_cache = {}                    # thread sid -> (path, mtime, cut_uuid, msgs)
+
+
+def _comments_path(sid):
+    return jd.STATE / "comments" / (sid + ".json")
+
+
+def _load_comments(sid):
+    try:
+        d = json.loads(_comments_path(sid).read_text())
+        return d if isinstance(d, dict) else {"threads": []}
+    except (OSError, ValueError):
+        return {"threads": []}
+
+
+def _save_comments(sid, data):
+    _atomic_write(_comments_path(sid), json.dumps(data))
+
+
+def _comment_thread(parent_sid, tid):
+    """The stored thread row, or None. Reads fresh — the store is tiny and mutation runs under
+    _comments_lock, so a stale row can only come from skipping this."""
+    for th in _load_comments(parent_sid).get("threads") or []:
+        if th.get("tid") == tid:
+            return th
+    return None
+
+
+def _comment_update(parent_sid, tid, **changes):
+    """Apply `changes` to one thread row under the lock. Returns the updated row or None."""
+    with _comments_lock:
+        data = _load_comments(parent_sid)
+        for th in data.get("threads") or []:
+            if th.get("tid") == tid:
+                th.update(changes)
+                _save_comments(parent_sid, data)
+                return th
+    return None
+
+
+def _comment_prose_record(r):
+    """Is this record a clean INCLUSIVE cut point — a user/assistant message that is prose, with no
+    tool traffic? A record carrying tool_use/tool_result must not end the fork's copied history: the
+    fork would open on a dangling tool call and the next turn would be malformed. (The rewind family
+    never faces this — its cut is always 'just before a typed user message', which sits after a
+    settled turn by construction.)"""
+    if not r or r.get("type") not in ("user", "assistant"):
+        return False
+    c = (r.get("message") or {}).get("content")
+    if isinstance(c, str):
+        return bool(c)
+    has_text = has_call = False
+    for b in (c or []):
+        if isinstance(b, dict):
+            if b.get("type") == "text":
+                has_text = True
+            elif b.get("type") in ("tool_use", "tool_result"):
+                has_call = True
+    return has_text and not has_call
+
+
+def _comment_cut_target(path, sid, anchor_uuid):
+    """(cut_uuid, error) — where a comment thread's fork should cut: at the anchored message itself,
+    INCLUSIVE (_rewind_target's 'just before' would drop the very passage the user highlighted).
+    Same guards as the rewind family: the record must exist, sit on the ACTIVE chain, postdate the
+    last compaction; when the anchor record isn't itself a clean prose cut (a tool row, a tool
+    result), the nearest prose ANCESTOR carries it — the opening message quotes the highlighted
+    passage verbatim, so nothing the user pointed at is lost to the thread's agent."""
+    cands = [path]
+    anchor = os.path.join(os.path.dirname(path), sid + ".jsonl")
+    if os.path.basename(path) != sid + ".jsonl" and os.path.exists(anchor):
+        cands.append(anchor)
+    ad = em.FileAdapter(cands, path)
+    if anchor_uuid not in ad.by_uuid:
+        return None, "that message isn't in the transcript yet; try again in a moment"
+    is_boundary = lambda r: r is not None and r.get("type") == "system" and r.get("subtype") == "compact_boundary"
+    u, hops, on_active = ad.leaf_uuid, 0, False
+    while u is not None and hops < 500000:
+        if u == anchor_uuid:
+            on_active = True
+            break
+        if is_boundary(ad.by_uuid.get(u)):
+            return None, "that message predates the last context compaction; only newer passages can open a thread"
+        u = ad.parent_of.get(u); hops += 1
+    if not on_active:
+        return None, "that message is on a branch that was rewound away"
+    u, hops = anchor_uuid, 0
+    while u is not None and hops < 500000:
+        r = ad.by_uuid.get(u)
+        if r is None or is_boundary(r):
+            break
+        if _comment_prose_record(r):
+            return u, None
+        u = ad.parent_of.get(u); hops += 1
+    return None, "that message can't anchor a thread; try a passage from the conversation itself"
+
+
+_COMMENT_FRAME_HEAD = "About this part of the conversation:"
+
+
+def _comment_first_message(exact, comment):
+    """The thread's opening message — romp-authored FRAMING around the user's own words, read by an
+    agent that has the conversation up to the highlight and no idea it is being tracked, so it
+    speaks as the person it works for quoting the conversation back (test_injected_voice scans it;
+    it must never name romp machinery)."""
+    q = "\n".join("> " + ln for ln in str(exact or "").splitlines()).strip() or "> …"
+    return "%s\n\n%s\n\n%s" % (_COMMENT_FRAME_HEAD, q, str(comment or "").strip())
+
+
+def _comment_strip_frame(text):
+    """The opening message, shown as the user's COMMENT alone — the framing + quote it was wrapped
+    in for the thread's agent already sit in the popover header, so rendering them again would say
+    everything twice."""
+    if not text.startswith(_COMMENT_FRAME_HEAD):
+        return text
+    lines = text.splitlines()
+    i = 1
+    while i < len(lines) and (not lines[i].strip() or lines[i].lstrip().startswith(">")):
+        i += 1
+    return "\n".join(lines[i:]).strip() or text
+
+
+def _comment_msg_text(rec):
+    """Visible text of a raw transcript user/assistant record — text blocks only (tool traffic and
+    thinking are the popover's 'working…' phase, not its conversation)."""
+    if rec.get("isMeta"):
+        return ""
+    m = rec.get("message") or {}
+    c = m.get("content")
+    if isinstance(c, str):
+        return c.strip()
+    parts = [b.get("text") or "" for b in (c or []) if isinstance(b, dict) and b.get("type") == "text"]
+    return "\n".join(p for p in parts if p).strip()
+
+
+def _thread_reg(tsid):
+    """The thread's SDK registry entry (authoritative for cwd/lastSid/threadOf), {} when unreadable."""
+    try:
+        d = json.loads((jd.STATE / "sdk" / (tsid + ".json")).read_text())
+        return d if isinstance(d, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _thread_transcript_path(reg, tsid):
+    fsid = reg.get("lastSid") or tsid
+    return str(jd._proj_dir(reg.get("cwd") or os.path.expanduser("~")) / (fsid + ".jsonl"))
+
+
+def _thread_messages(tsid, cut_uuid):
+    """The side conversation: user/assistant text AFTER the fork cut in the thread's transcript,
+    oldest first, [{who, text, t}]. The fork copies parent history VERBATIM (same uuids), so
+    everything above `cut_uuid` on the active chain IS the thread's own exchange. mtime-cached —
+    a settled thread costs one stat per push. [] before the fork lands (the CLI is still copying;
+    the popover shows its working state, not an error — the transcript's absence is expected there)."""
+    reg = _thread_reg(tsid)
+    path = _thread_transcript_path(reg, tsid)
+    try:
+        mt = os.stat(path).st_mtime
+    except OSError:
+        return []
+    hit = _thread_msgs_cache.get(tsid)
+    if hit and hit[0] == path and hit[1] == mt and hit[2] == cut_uuid:
+        return hit[3]
+    ad = em.FileAdapter([path], path)
+    rows, u, hops = [], ad.leaf_uuid, 0
+    while u is not None and hops < 500000:
+        if u == cut_uuid:
+            break                                   # copied history starts here — the parent's, not the thread's
+        r = ad.by_uuid.get(u) or {}
+        if r.get("type") in ("user", "assistant"):
+            txt = _comment_msg_text(r)
+            if txt:
+                rows.append({"who": "you" if r.get("type") == "user" else "agent",
+                             "text": txt[:4000],
+                             "t": int(em.parse_z(r.get("timestamp")) or 0)})
+        u = ad.parent_of.get(u); hops += 1
+    rows.reverse()
+    if rows and rows[0]["who"] == "you":            # the opening message: show the comment, not its frame
+        rows[0]["text"] = _comment_strip_frame(rows[0]["text"])
+    merged = []                                     # one assistant turn can span records — read as one reply
+    for r in rows:
+        if merged and merged[-1]["who"] == r["who"] == "agent":
+            merged[-1]["text"] = (merged[-1]["text"] + "\n\n" + r["text"])[:8000]
+            merged[-1]["t"] = r["t"] or merged[-1]["t"]
+        else:
+            merged.append(r)
+    merged = merged[-40:]
+    if len(_thread_msgs_cache) > 512:
+        _thread_msgs_cache.clear()
+    _thread_msgs_cache[tsid] = (path, mt, cut_uuid, merged)
+    return merged
+
+
+def _comments_frame(sid):
+    """The chat pane's {type:"comments"} frame for parent session `sid`, or None when it has never
+    had a thread. Built per push for sessions WITH a store (few) — _send_client's dedup keeps an
+    unchanged frame off the wire."""
+    p = _comments_path(sid)
+    if not p.exists():
+        return None
+    be = _sdk()
+    threads = []
+    for th in _load_comments(sid).get("threads") or []:
+        tsid = str(th.get("sid") or "")
+        status = th.get("status") or "open"
+        state = ""
+        if be and status == "open":
+            try:
+                state = be.session_state(tsid)
+            except Exception:
+                state = ""
+        msgs = [] if status == "promoted" else _thread_messages(tsid, str(th.get("cutUuid") or ""))
+        seen = int(th.get("lastSeenT") or 0)
+        unread = any(m["who"] == "agent" and m["t"] > seen for m in msgs)
+        threads.append({"tid": th.get("tid"), "anchorUuid": th.get("anchorUuid"),
+                        "exact": str(th.get("exact") or "")[:500], "status": status,
+                        "createdT": th.get("createdT") or 0, "state": state,
+                        "unread": unread, "promotedName": th.get("promotedName") or "",
+                        "msgs": msgs})
+    return {"type": "comments", "id": sid, "threads": threads}
+
+
+def _comment_create(parent_sid, anchor_uuid, exact, text, now=None):
+    """Anchor a new comment thread: fork the parent at the highlighted message (inclusive) as a
+    threadOf fork — no names/ entry, so no judge seeding is needed until promotion — and send the
+    opening message. Returns (error, tid): error is the warn-toast string (tid None), success is
+    (None, the new thread's id) so the client can adopt exactly the thread it created."""
+    be = Sessions.backend_for(parent_sid)
+    if not (hasattr(be, "fork") and _sdk_ready()):
+        return "threads need the SDK backend; this session runs on tmux, so there is nothing to fork.", None
+    if not str(exact or "").strip() or not str(text or "").strip():
+        return "nothing to send: highlight a passage and write a comment.", None
+    now = now or time.time()
+    sess = next((s for s in _sessions(now) if s["sid"] == parent_sid), None)
+    if not sess:
+        return "no transcript for this session yet, so nothing to comment on.", None
+    cut, err = _comment_cut_target(sess["path"], parent_sid, str(anchor_uuid))
+    if err:
+        return err, None
+    tsid = str(uuid.uuid4())
+    row = {"tid": tsid, "sid": tsid, "anchorUuid": str(anchor_uuid), "cutUuid": cut,
+           "exact": str(exact)[:2000], "status": "open",
+           "createdT": int(now), "lastSeenT": int(now)}
+    with _comments_lock:
+        data = _load_comments(parent_sid)
+        data.setdefault("threads", []).append(row)
+        _save_comments(parent_sid, data)
+    try:
+        be.fork("thread-" + tsid[:8], parent_sid, cut, sid=tsid, thread_of=parent_sid)
+        be.connect(tsid)
+        be.send(tsid, _comment_first_message(exact, text))
+    except Exception as e:
+        with _comments_lock:                       # loud + lossless: no half-born thread row
+            data = _load_comments(parent_sid)
+            data["threads"] = [t for t in data.get("threads") or [] if t.get("tid") != tsid]
+            _save_comments(parent_sid, data)
+        return "thread not created: %s" % e, None
+    _push_soon()
+    return None, tsid
+
+
+def _comment_reply(parent_sid, tid, text):
+    """Send the user's next message into an existing thread. A resolved thread reopens — replying IS
+    the reopen gesture (event-based; no separate arm). Returns an error string or None."""
+    th = _comment_thread(parent_sid, tid)
+    if not th:
+        return "that thread is gone."
+    if (th.get("status") or "open") == "promoted":
+        return "this thread is now the session '%s'; continue there." % (th.get("promotedName") or "")
+    be = Sessions.backend_for(parent_sid)
+    if not hasattr(be, "fork"):
+        return "threads need the SDK backend."
+    tsid = th["sid"]
+    if th.get("status") == "resolved":
+        reg = _thread_reg(tsid)
+        be.resume(reg.get("name") or ("thread-" + tsid[:8]), tsid)   # alive again; names/ untouched
+        _comment_update(parent_sid, tid, status="open")
+    if not be.send(tsid, str(text)):
+        return "couldn't reach this thread's session; it may have been removed."
+    _comment_update(parent_sid, tid, lastSeenT=int(time.time()))
+    _push_soon()
+    return None
+
+
+def _comment_resolve(parent_sid, tid):
+    """Settle a thread: status→resolved and its CLI shut down (the reg stays — a later reply
+    resumes it with the conversation intact). The highlight dims; nothing is lost."""
+    th = _comment_thread(parent_sid, tid)
+    if not th:
+        return "that thread is gone."
+    _comment_update(parent_sid, tid, status="resolved")
+    be = Sessions.backend_for(parent_sid)
+    if hasattr(be, "kill") and th.get("status") != "promoted":
+        try:
+            be.kill(th["sid"])
+        except Exception:
+            pass                                    # already dead is fine — resolved is a store fact
+    _push_soon()
+    return None
+
+
+def _comment_delete(parent_sid, tid):
+    """Remove a thread outright (the popover's delete on a resolved thread). The thread's transcript
+    stays on disk like any conversation history; only romp's row and CLI go."""
+    th = _comment_thread(parent_sid, tid)
+    if not th:
+        return "that thread is gone."
+    be = Sessions.backend_for(parent_sid)
+    if hasattr(be, "kill") and th.get("status") != "promoted":
+        try:
+            be.kill(th["sid"])
+        except Exception:
+            pass
+    with _comments_lock:
+        data = _load_comments(parent_sid)
+        data["threads"] = [t for t in data.get("threads") or [] if t.get("tid") != tid]
+        _save_comments(parent_sid, data)
+    _push_soon()
+    return None
+
+
+def _comment_seen(parent_sid, tid):
+    """The popover was opened — stamp the read watermark (view state, not a verdict)."""
+    _comment_update(parent_sid, tid, lastSeenT=int(time.time()))
+    return None
+
+
+def _comment_promote(parent_sid, tid, new_name, now=None):
+    """Break a thread out into a FULL board session. Ordering contract (same as _fork_session):
+    judge stores are seeded BEFORE promote_thread writes the names/ entry. The seeds run against
+    the PARENT transcript at the ORIGINAL cut (the history the two transcripts share, verbatim),
+    then one extra episode boundary at the thread's own leaf raises the floor past the popover
+    exchange — that conversation already happened in front of the user; the new session's fresh
+    work starts after it. Returns an error string or None."""
+    nm = (new_name or "").strip()
+    if not NAME_RE.match(nm):
+        return "session names use letters, digits, . _ - only."
+    th = _comment_thread(parent_sid, tid)
+    if not th:
+        return "that thread is gone."
+    if (th.get("status") or "open") == "promoted":
+        return "already its own session: %s" % (th.get("promotedName") or "")
+    be = Sessions.backend_for(parent_sid)
+    if not (hasattr(be, "promote_thread") and _sdk_ready()):
+        return "threads need the SDK backend."
+    now = now or time.time()
+    tsid = th["sid"]
+    reg = _thread_reg(tsid)
+    tpath = _thread_transcript_path(reg, tsid)
+    if not os.path.exists(tpath):
+        return "this thread hasn't written its conversation yet; try again in a moment."
+    sess = next((s for s in _sessions(now) if s["sid"] == parent_sid), None)
+    parent_path = sess["path"] if sess else str(jd._proj_dir(reg.get("cwd") or "~") / (parent_sid + ".jsonl"))
+    err = _seed_fork_stores(parent_sid, tsid, parent_path, str(th.get("cutUuid") or ""))
+    if err:
+        return err
+    try:                                            # floor past the settled popover exchange
+        ad = em.FileAdapter([tpath], tpath)
+        leaf = ad.leaf_uuid
+        leaf_t = int(em.parse_z((ad.by_uuid.get(leaf) or {}).get("timestamp")) or now)
+        jd.append_episode(tsid, leaf, reg.get("lastSid") or tsid, leaf_t)
+    except Exception as e:
+        return "not promoted: sealing the thread's history failed: %s" % e
+    if th.get("status") == "resolved":
+        be.resume(nm, tsid)                          # a resolved thread promotes straight to a live session
+    bg, fg = _pick_identity_color()
+    if not be.promote_thread(tsid, nm, bg, fg):
+        return "couldn't promote this thread."
+    _comment_update(parent_sid, tid, status="promoted", promotedName=nm)
+    be.connect(tsid)
+    _reveal_chat({"type": "focus", "id": tsid})
+    _mark_views_dirty()
+    _push_session_now(tsid)
+    return None
+
+
 # --- optional SDK (non-tmux) session backend (docs/sdk-backend.md) --------------------
 # A second SessionBackend that drives Claude via the Agent SDK instead of a tmux TUI,
 # selectable per session. Built lazily so the tmux-only path never imports the SDK and the
@@ -5057,7 +5446,8 @@ def _drive(msg, client):
     t = msg.get("type")
     ID_OPS = ("sendMessage", "rewindSend", "rewindDelete", "interrupt", "compactSession", "dismissDialog", "answerAsk", "navAsk", "toggleAsk", "submitAsk",
               "addCustomAsk", "cancelAsk", "askText", "cancelQueued", "dismissEcho", "apiRetry", "setModel", "setEffort", "setMode", "setFast",
-              "setAuth", "endSession", "renameSession", "stopTask", "rewindFiles", "mcpAction", "forkSession")
+              "setAuth", "endSession", "renameSession", "stopTask", "rewindFiles", "mcpAction", "forkSession",
+              "commentCreate", "commentReply", "commentResolve", "commentDelete", "commentSeen", "commentPromote")
     if t in ID_OPS and msg.get("id"):
         sid = str(msg["id"])
     elif t in ("compact", "sendCommand") and msg.get("name"):
@@ -5307,6 +5697,39 @@ def _drive(msg, client):
         # user message the fork cuts just BEFORE — absent means the whole conversation. LOUD on refusal;
         # on success the new tab arrives focused via _fork_session's own push.
         err = _fork_session(sid, str(msg.get("uuid") or ""), str(msg["name"]))
+        if err:
+            client["send"](json.dumps({"type": "warn", "text": err}))
+    elif t == "commentCreate" and msg.get("uuid") and msg.get("exact") and msg.get("text"):
+        # Anchor a comment thread on a highlighted passage (the user 2026-08-13). LOUD on refusal; on
+        # success a commentCreated ack names the new thread (the popover adopts exactly it — never a
+        # guess) and the fresh {type:"comments"} frame rides straight back, ahead of the pusher cycle.
+        err, tid = _comment_create(sid, str(msg["uuid"]), str(msg["exact"]), str(msg["text"]))
+        if err:
+            client["send"](json.dumps({"type": "warn", "text": err}))
+        else:
+            client["send"](json.dumps({"type": "commentCreated", "id": sid, "tid": tid,
+                                       "uuid": str(msg["uuid"])}))
+            fr = _comments_frame(sid)
+            if fr:
+                client["send"](json.dumps(fr))
+    elif t == "commentReply" and msg.get("tid") and msg.get("text"):
+        err = _comment_reply(sid, str(msg["tid"]), str(msg["text"]))
+        if err:
+            client["send"](json.dumps({"type": "warn", "text": err}))
+    elif t == "commentResolve" and msg.get("tid"):
+        err = _comment_resolve(sid, str(msg["tid"]))
+        if err:
+            client["send"](json.dumps({"type": "warn", "text": err}))
+    elif t == "commentDelete" and msg.get("tid"):
+        err = _comment_delete(sid, str(msg["tid"]))
+        if err:
+            client["send"](json.dumps({"type": "warn", "text": err}))
+    elif t == "commentSeen" and msg.get("tid"):
+        _comment_seen(sid, str(msg["tid"]))
+    elif t == "commentPromote" and msg.get("tid") and msg.get("name"):
+        # Break the thread out into its own board session. LOUD on refusal; on success the new tab
+        # arrives focused via _comment_promote's own push (the forkSession acknowledgement shape).
+        err = _comment_promote(sid, str(msg["tid"]), str(msg["name"]))
         if err:
             client["send"](json.dumps({"type": "warn", "text": err}))
     elif t == "endSession":
@@ -11316,7 +11739,7 @@ def _rewind_target(path, sid, user_uuid):
         cands.append(anchor)
     ad = em.FileAdapter(cands, path)
     if user_uuid not in ad.by_uuid:
-        return None, "that message isn't in the transcript yet — try again in a moment"
+        return None, "that message isn't in the transcript yet; try again in a moment"
     is_boundary = lambda r: r is not None and r.get("type") == "system" and r.get("subtype") == "compact_boundary"
     # leaf → root: the edited record must appear BEFORE any compact boundary on the active chain
     u, hops, on_active = ad.leaf_uuid, 0, False
@@ -18146,6 +18569,19 @@ def _push(targets, connect=False, tmux=None):
                     _built_chat.pop(sid, None)
                     _prev_chat_events.pop(sid, None)
                     _prev_chat_ledger.pop(sid, None)
+            # COMMENT THREADS: one {type:"comments"} frame per session that has ever had one (its
+            # comments/ store exists — an ~free stat for everyone else). Each frame rides its OWN
+            # per-sid dedup slot, never the chat delta baseline (the 2026-07-28 stranded-delta rule):
+            # an unchanged frame costs nothing on the wire and the chatTail stream stays untouched.
+            for s in chat_list:
+                try:
+                    fr = _comments_frame(s["sid"])
+                except Exception:
+                    sys.stderr.write("comments frame failed for %s: %s\n" % (s["sid"], traceback.format_exc()))
+                    continue
+                if fr:
+                    for c in chat_clients:
+                        _send_client(c, ("comments", s["sid"]), fr)
         fsig = _fleet_view_sig(now, tmux) if (want_feed or want_tl) else None
         feed_src = _cached_feed(now, tmux, fsig, connect) if want_feed else None
         feed = feed_src

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4607,8 +4607,9 @@ def _comment_strip_frame(text):
 
 def _comment_msg_text(rec):
     """Visible text of a raw transcript user/assistant record — text blocks only (tool traffic and
-    thinking are the popover's 'working…' phase, not its conversation)."""
-    if rec.get("isMeta"):
+    thinking are the popover's 'working…' phase, not its conversation; a compaction's summary record
+    is bookkeeping, not something either side said)."""
+    if rec.get("isMeta") or rec.get("isCompactSummary"):
         return ""
     m = rec.get("message") or {}
     c = m.get("content")
@@ -4632,34 +4633,74 @@ def _thread_transcript_path(reg, tsid):
     return str(jd._proj_dir(reg.get("cwd") or os.path.expanduser("~")) / (fsid + ".jsonl"))
 
 
+_THREAD_TAIL_BYTES = 262144   # the tail window that usually holds the whole side conversation
+
+
 def _thread_messages(tsid, cut_uuid):
     """The side conversation: user/assistant text AFTER the fork cut in the thread's transcript,
     oldest first, [{who, text, t}]. The fork copies parent history VERBATIM (same uuids), so
     everything above `cut_uuid` on the active chain IS the thread's own exchange. mtime-cached —
-    a settled thread costs one stat per push. [] before the fork lands (the CLI is still copying;
-    the popover shows its working state, not an error — the transcript's absence is expected there)."""
+    a settled thread costs one stat per push. [] before the fork lands: while the reg still carries
+    forkOf (spent by the CLI init that pins the new fsid), lastSid points at the PARENT transcript,
+    and reading it here would present the parent's post-anchor conversation as the thread's own.
+    The exchange sits strictly AFTER the copied history, so a streaming thread re-reads only the
+    file TAIL per push (the pusher must not reparse a whole copied conversation every 0.5s); the
+    full parse is the fallback when the window misses the cut."""
     reg = _thread_reg(tsid)
+    if reg.get("forkOf"):
+        return []
     path = _thread_transcript_path(reg, tsid)
     try:
-        mt = os.stat(path).st_mtime
+        st = os.stat(path)
+        mt, size = st.st_mtime, st.st_size
     except OSError:
         return []
     hit = _thread_msgs_cache.get(tsid)
     if hit and hit[0] == path and hit[1] == mt and hit[2] == cut_uuid:
         return hit[3]
-    ad = em.FileAdapter([path], path)
-    rows, u, hops = [], ad.leaf_uuid, 0
+    by_uuid = parent_of = leaf = None
+    if cut_uuid and size > _THREAD_TAIL_BYTES:
+        try:
+            with open(path, "rb") as f:
+                f.seek(size - _THREAD_TAIL_BYTES)
+                lines = f.read().split(b"\n")[1:]    # drop the partial first line of the window
+        except OSError:
+            lines = []
+        tail = []
+        for ln in lines:
+            if not ln.strip():
+                continue
+            try:
+                tail.append(json.loads(ln))
+            except ValueError:
+                continue
+        if any(r.get("uuid") == cut_uuid for r in tail):
+            by_uuid = {r["uuid"]: r for r in tail if r.get("uuid")}
+            parent_of = {r["uuid"]: r.get("parentUuid") for r in tail if r.get("uuid")}
+            # the last uuid-bearing record IS the live leaf (the CLI appends the active branch —
+            # the same assumption sdk_backend.last_record_uuid rides for rewinds)
+            leaf = next((r["uuid"] for r in reversed(tail) if r.get("uuid")), None)
+    if by_uuid is None:
+        ad = em.FileAdapter([path], path)
+        by_uuid, parent_of, leaf = ad.by_uuid, ad.parent_of, ad.leaf_uuid
+    if cut_uuid and cut_uuid not in by_uuid:
+        return []       # the cut isn't in this transcript (corrupt row?) — an empty popover beats
+        #                 presenting the copied parent history as the thread's own conversation
+    rows, u, hops = [], leaf, 0
+    # the boot reconcile's continuation notice is romp's, not the user's — it must not render as a
+    # 'you' bubble in the popover (the module is loaded lazily; unavailable → nothing to filter)
+    boot_nudge = getattr(sys.modules.get("romp_sdk_backend"), "BOOT_RESUME_NUDGE", None)
     while u is not None and hops < 500000:
         if u == cut_uuid:
             break                                   # copied history starts here — the parent's, not the thread's
-        r = ad.by_uuid.get(u) or {}
+        r = by_uuid.get(u) or {}
         if r.get("type") in ("user", "assistant"):
             txt = _comment_msg_text(r)
-            if txt:
+            if txt and txt != boot_nudge:
                 rows.append({"who": "you" if r.get("type") == "user" else "agent",
                              "text": txt[:4000],
                              "t": int(em.parse_z(r.get("timestamp")) or 0)})
-        u = ad.parent_of.get(u); hops += 1
+        u = parent_of.get(u); hops += 1
     rows.reverse()
     if rows and rows[0]["who"] == "you":            # the opening message: show the comment, not its frame
         rows[0]["text"] = _comment_strip_frame(rows[0]["text"])
@@ -4740,6 +4781,10 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, now=None):
             data = _load_comments(parent_sid)
             data["threads"] = [t for t in data.get("threads") or [] if t.get("tid") != tsid]
             _save_comments(parent_sid, data)
+        try:
+            be.kill(tsid)                          # and no orphaned reg/CLI behind the removed row
+        except Exception:
+            pass
         return "thread not created: %s" % e, None
     _push_soon()
     return None, tsid
@@ -4770,13 +4815,18 @@ def _comment_reply(parent_sid, tid, text):
 
 def _comment_resolve(parent_sid, tid):
     """Settle a thread: status→resolved and its CLI shut down (the reg stays — a later reply
-    resumes it with the conversation intact). The highlight dims; nothing is lost."""
+    resumes it with the conversation intact). The highlight dims; nothing is lost. A PROMOTED
+    thread is refused: its session is a board citizen now, and flipping the stored status would
+    hand the follow-on delete a session to kill (the UI hides Resolve there; the guard holds for
+    a stale client regardless)."""
     th = _comment_thread(parent_sid, tid)
     if not th:
         return "that thread is gone."
+    if (th.get("status") or "open") == "promoted":
+        return "this thread is now the session '%s'; end it like any session." % (th.get("promotedName") or "")
     _comment_update(parent_sid, tid, status="resolved")
     be = Sessions.backend_for(parent_sid)
-    if hasattr(be, "kill") and th.get("status") != "promoted":
+    if hasattr(be, "kill"):
         try:
             be.kill(th["sid"])
         except Exception:
@@ -4809,6 +4859,20 @@ def _comment_seen(parent_sid, tid):
     """The popover was opened — stamp the read watermark (view state, not a verdict)."""
     _comment_update(parent_sid, tid, lastSeenT=int(time.time()))
     return None
+
+
+def _comment_kill_all(parent_sid, be):
+    """The parent session was ENDED — shut down its open threads' CLIs too, or they outlive the tab
+    that is their only surface as unreachable running processes. Store rows stay untouched: a
+    revived parent finds its threads dormant and a reply resumes them, history intact."""
+    if not hasattr(be, "kill"):
+        return
+    for th in _load_comments(parent_sid).get("threads") or []:
+        if (th.get("status") or "open") != "promoted" and th.get("sid"):
+            try:
+                be.kill(th["sid"])
+            except Exception:
+                pass
 
 
 def _comment_promote(parent_sid, tid, new_name, now=None):
@@ -5707,15 +5771,21 @@ def _drive(msg, client):
         if err:
             client["send"](json.dumps({"type": "warn", "text": err}))
         else:
-            client["send"](json.dumps({"type": "commentCreated", "id": sid, "tid": tid,
-                                       "uuid": str(msg["uuid"])}))
+            # the FRAME rides ahead of the ack: the ack's handler adopts the new thread from the
+            # client's thread map, so the thread must be in it first (reversed, the popover looked
+            # up a thread it had never heard of and closed itself)
             fr = _comments_frame(sid)
             if fr:
                 client["send"](json.dumps(fr))
+            client["send"](json.dumps({"type": "commentCreated", "id": sid, "tid": tid,
+                                       "uuid": str(msg["uuid"])}))
     elif t == "commentReply" and msg.get("tid") and msg.get("text"):
         err = _comment_reply(sid, str(msg["tid"]), str(msg["text"]))
         if err:
+            # the named failure ack lets the popover drop its optimistic bubble — the toast alone
+            # names no thread, and an unspent pending row reads as 'still thinking' forever
             client["send"](json.dumps({"type": "warn", "text": err}))
+            client["send"](json.dumps({"type": "commentSendFailed", "id": sid, "tid": str(msg["tid"])}))
     elif t == "commentResolve" and msg.get("tid"):
         err = _comment_resolve(sid, str(msg["tid"]))
         if err:
@@ -5735,6 +5805,7 @@ def _drive(msg, client):
     elif t == "endSession":
         sys.stderr.write("kill: %s via endSession WS op\n" % sid)   # kill attribution (the user 2026-07-16)
         be.kill(sid); _record_death(sid, int(time.time()), "kill")   # the one SDK event with no designed reviver
+        _comment_kill_all(sid, be)   # its comment threads must not outlive it as unreachable running CLIs
         _send_to_app("chat", {"type": "closed", "id": sid}); _push_soon()
     elif t == "renameSession" and msg.get("name"):
         new = str(msg["name"]).strip()
@@ -18573,7 +18644,7 @@ def _push(targets, connect=False, tmux=None):
             # comments/ store exists — an ~free stat for everyone else). Each frame rides its OWN
             # per-sid dedup slot, never the chat delta baseline (the 2026-07-28 stranded-delta rule):
             # an unchanged frame costs nothing on the wire and the chatTail stream stays untouched.
-            for s in chat_list:
+            for s in (chat_list if chat_clients else []):
                 try:
                     fr = _comments_frame(s["sid"])
                 except Exception:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3436,7 +3436,7 @@ class SdkBackend:
         return sid
 
     def fork(self, name: str, parent_sid: str, cut_uuid: str = "", bg: str = "", fg: str = "",
-             sid: str | None = None) -> str:
+             sid: str | None = None, thread_of: str = "") -> str:
         """Mint a NEW session that is a FORK of `parent_sid`'s conversation — up to `cut_uuid` when given
         (a transcript record uuid; empty = the whole conversation), the parent untouched either way (the
         user 2026-08-13). The new session gets its OWN sid, registry, name and identity colour — a fork
@@ -3445,7 +3445,18 @@ class SdkBackend:
         into resume + fork_session + session_id (+ resume-session-at) on first connect; the init's
         lastSid flip to this sid spends the flags. Model / effort / mode / auth inherit from the parent —
         it is that conversation, continued elsewhere. Resumable by construction: a fork whose CLI dies
-        before init still carries the flags and retries on the next connect."""
+        before init still carries the flags and retries on the next connect.
+
+        `thread_of` (the user 2026-08-13, who asked to comment on a highlighted passage and keep a side
+        conversation there): this fork is a COMMENT THREAD of parent session `thread_of` — a side
+        conversation the chat surfaces as an anchored highlight + popover, not as a session of its own.
+        The reg carries threadOf and the names/ entry is withheld, so it gets no tab, no lane, no feed
+        cards and no judge pass (names/ is the discoverability trigger; live_sessions skips threadOf
+        regs for the tab side) — its ENTIRE user surface is the parent chat's comment UI, which is why
+        this is not the hidden-running-session failure mode the 2026-08-11 rule removed: every thread is
+        visible and reachable right where it was made. Everything else is a normal session: the reg
+        keeps its CLI under the boot reconcile's orphan reap, a mid-turn kernel death resumes it, and
+        promote_thread() later turns it into a full board session."""
         parent = read_reg(self.state_dir, parent_sid) or {}
         cwd = parent.get("cwd") or os.path.expanduser("~")
         sid = sid or str(uuid.uuid4())      # the kernel pre-mints it so the judge seeds can precede us
@@ -3456,17 +3467,47 @@ class SdkBackend:
                "effort": parent.get("effort", DEFAULT_EFFORT),
                "lastSid": parent.get("lastSid") or parent_sid,
                "forkOf": parent_sid, "forkAt": cut_uuid or "", "alive": True}
+        if thread_of:
+            reg["threadOf"] = thread_of
         if parent.get("model") and parent["model"] != "default":
             reg["model"] = parent["model"]
         if parent.get("auth") in ("login", "key"):
             reg["auth"] = parent["auth"]
         write_reg(self.state_dir, sid, reg)
         # the names/ entry LAST — it is the discoverability trigger (discover() iterates names/), and
-        # everything above must exist before any judge pass can see the session
-        write_name(self.state_dir, sid, name, cwd, bg, fg)
+        # everything above must exist before any judge pass can see the session. A comment thread never
+        # writes it: promote_thread() does, after the kernel seeds the judge stores.
+        if not thread_of:
+            write_name(self.state_dir, sid, name, cwd, bg, fg)
         append_state(self.state_dir, sid, "waiting")
         self._poke()
         return sid
+
+    def thread_of(self, sid: str) -> str:
+        """The parent sid when `sid` is a comment thread, else ''."""
+        reg = read_reg(self.state_dir, sid) or {}
+        return str(reg.get("threadOf") or "")
+
+    def promote_thread(self, sid: str, name: str, bg: str = "", fg: str = "") -> bool:
+        """Break a comment thread out into a FULL board session (the user 2026-08-13: 'a button that
+        breaks it out into its own session'). The caller (kernel _comment_promote) must have seeded the
+        judge stores FIRST — the names/ write below is the discoverability trigger, same ordering
+        contract as fork(). Clears threadOf (the reg becomes an ordinary session's) and registers the
+        identity; the running CLI, transcript and queue carry over untouched."""
+        reg = read_reg(self.state_dir, sid)
+        if not reg or not reg.get("threadOf"):
+            return False
+        reg.pop("threadOf", None)
+        reg["name"] = name
+        write_reg(self.state_dir, sid, reg)
+        if not bg:
+            bg, fg = pick_identity_color(sid, self.state_dir)
+        write_name(self.state_dir, sid, name, reg.get("cwd", ""), bg, fg)
+        s = self.sessions.get(sid)
+        if s:
+            s.name = name
+        self._poke()
+        return True
 
     def resume(self, name: str, sid: str, cwd: str | None = None) -> bool:
         """Mark a dormant/dead SDK session alive again so _ensure/connect restarts it. PRESERVE the
@@ -3851,6 +3892,18 @@ class SdkBackend:
         self._poke()
         return True
 
+    def session_state(self, sid: str) -> str:
+        """Live state ('working'/'waiting'/…) for ONE sid, comment threads included — live_sessions
+        deliberately filters threadOf regs, so the comments frame reads its thread's pulse here."""
+        with self._lock:
+            s = self.sessions.get(sid)
+        if s and s.thread.is_alive():
+            try:
+                return str(s.snapshot().get("state") or "")
+            except Exception:
+                return ""
+        return ""
+
     def rename(self, sid: str, new_name: str) -> bool:
         reg = read_reg(self.state_dir, sid)
         if not reg:
@@ -4082,6 +4135,8 @@ class SdkBackend:
         for reg in list_regs(self.state_dir):
             if not reg.get("alive"):
                 continue
+            if reg.get("threadOf"):
+                continue   # a comment thread: its surface is the parent chat's comment UI, never a tab
             sid = reg["sid"]
             s = self.sessions.get(sid)
             if s and s.thread.is_alive():

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -275,6 +275,44 @@ class ThreadProjection(CommentBase):
     def test_no_store_no_frame(self):
         self.assertIsNone(km._comments_frame(PARENT))
 
+    def test_pre_fork_thread_reads_nothing_not_the_parent(self):
+        # Until the CLI init spends forkOf, the thread reg's lastSid points at the PARENT
+        # transcript — reading it would present the parent's post-anchor turns as the thread's own.
+        self._write(PARENT, self._parent_records())
+        (jd.SDKDIR / (THREAD + ".json")).write_text(json.dumps(
+            {"sid": THREAD, "name": "thread-x", "cwd": self.cdir, "lastSid": PARENT,
+             "alive": True, "threadOf": PARENT, "forkOf": PARENT, "forkAt": "a1"}))
+        self.assertEqual(km._thread_messages(THREAD, "a1"), [])
+
+    def test_a_compaction_summary_record_is_not_a_message(self):
+        recs = self._thread_records()
+        recs.append({"type": "user", "timestamp": iso(self.now - 90), "uuid": "cs1",
+                     "parentUuid": "ca2", "isCompactSummary": True,
+                     "message": {"role": "user", "content": "summary of the earlier exchange"}})
+        self._seed_thread(records=recs)
+        msgs = km._thread_messages(THREAD, "a1")
+        self.assertNotIn("summary of the earlier exchange", json.dumps(msgs))
+
+    def test_a_large_transcript_reads_from_the_tail_window(self):
+        # the copied history can be huge; the side conversation sits at the END, so the projection
+        # must come out of the tail window without a full reparse — and be IDENTICAL to it
+        filler = [aline(self.now - 550 + i, "filler %d " % i + "x" * 4000, "f%d" % i,
+                        parent=("u1" if i == 0 else "f%d" % (i - 1))) for i in range(120)]
+        t = self.now - 500
+        recs = ([uline(self.now - 600, "how should the retry loop back off?", "u1")] + filler +
+                [aline(t + 5, "Use exponential backoff.", "a1", parent="f119"),
+                 uline(t + 100, km._comment_first_message("exponential backoff", "Why jitter?"),
+                       "cu1", parent="a1"),
+                 aline(t + 110, "Jitter prevents thundering herds.", "ca1", parent="cu1")])
+        self._seed_thread(records=recs)
+        p = self.proj / (THREAD + ".jsonl")
+        self.assertGreater(p.stat().st_size, km._THREAD_TAIL_BYTES,
+                           "the fixture must actually overflow the tail window")
+        msgs = km._thread_messages(THREAD, "a1")
+        self.assertEqual([m["who"] for m in msgs], ["you", "agent"])
+        self.assertEqual(msgs[0]["text"], "Why jitter?")
+        self.assertIn("thundering herds", msgs[1]["text"])
+
 
 # ── the ops: create / reply / resolve / promote ───────────────────────────────────────────────────
 
@@ -407,6 +445,41 @@ class CommentOps(CommentBase):
         _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
         err = km._comment_promote(PARENT, tid, "bad name!")
         self.assertIn("letters, digits", err)
+
+    def test_resolve_refuses_a_promoted_thread_so_delete_can_never_kill_its_session(self):
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        km._comment_update(PARENT, tid, status="promoted", promotedName="sidework")
+        err = km._comment_resolve(PARENT, tid)
+        self.assertIn("sidework", err)
+        self.assertEqual(km._comment_thread(PARENT, tid)["status"], "promoted",
+                         "resolve must never overwrite promoted — that hands delete a session to kill")
+        km._comment_delete(PARENT, tid)                 # removing the highlight row is fine…
+        self.assertNotIn(("kill", tid), self.be.calls)  # …but the promoted session is never killed
+        self.assertIsNone(km._comment_thread(PARENT, tid))
+
+    def test_a_missing_cut_shows_nothing_never_the_copied_history(self):
+        self._write(THREAD, self._parent_records())
+        (jd.SDKDIR / (THREAD + ".json")).write_text(json.dumps(
+            {"sid": THREAD, "name": "thread-x", "cwd": self.cdir,
+             "lastSid": THREAD, "alive": True, "threadOf": PARENT}))
+        self.assertEqual(km._thread_messages(THREAD, "not-in-transcript"), [])
+
+    def test_ending_the_parent_sweeps_its_threads_clis(self):
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        km._comment_update(PARENT, tid, status="promoted", promotedName="kept")
+        _, tid2 = km._comment_create(PARENT, "a1", "exponential backoff", "And the cap?")
+        km._comment_kill_all(PARENT, self.be)
+        self.assertIn(("kill", tid2), self.be.calls, "open threads die with their only surface")
+        self.assertNotIn(("kill", tid), self.be.calls, "a promoted thread is a board session — untouched")
+
+    def test_a_failed_create_kills_the_half_born_reg(self):
+        self.be.send = lambda sid, text: (_ for _ in ()).throw(RuntimeError("boom"))
+        err, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        self.assertIn("boom", err)
+        self.assertIsNone(tid)
+        self.assertEqual(km._load_comments(PARENT).get("threads", []), [])
+        self.assertIn(("kill",), {c[:1] for c in self.be.calls},
+                      "the forked reg/CLI must not outlive the removed row")
 
     def test_drive_ops_are_registered(self):
         src = (Path(BIN) / "romp-kernel").resolve().read_text()

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Comment threads (the user 2026-08-13): highlight a passage in a session's chat, comment on it,
+and a side conversation opens there — a popover backed by a FORK of the session cut at the anchored
+message, kept OFF the board (reg threadOf, no names/ entry) until "Break out" promotes it.
+
+Covered here: the inclusive cut-target resolution, the thread-fork's invisibility contract (no
+names/, skipped by live_sessions, skipped by discover), the opening message's frame + its strip,
+the transcript→popover projection, the create/reply/resolve/promote ops, and promotion's seeding
+order. All fixtures SYNTHETIC: invented text, placeholder UUIDs.
+"""
+import json
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["ROMP_TMUX_AVAILABLE"] = "1"
+os.environ["ROMP_SERVE_TOKEN"] = "testtok"
+em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_ct", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+km._limit_hold = lambda sid: None
+
+PARENT = "11111111-2222-3333-4444-555555555555"
+THREAD = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None, meta=False):
+    r = {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+         "promptSource": "typed", "message": {"role": "user", "content": text}}
+    if meta:
+        r["isMeta"] = True
+    return r
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+def tline(t, uuid, parent):
+    """A tool_use-only assistant record — a spine node that is not prose."""
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant",
+                        "content": [{"type": "tool_use", "id": "tu_" + uuid, "name": "Read", "input": {}}]}}
+
+
+def boundary(t, uuid, parent):
+    return {"type": "system", "subtype": "compact_boundary", "timestamp": iso(t),
+            "uuid": uuid, "parentUuid": parent}
+
+
+class CommentBase(unittest.TestCase):
+    """Temp state root shared by kernel + judge (km.jd IS the loaded jd module), synthetic
+    transcripts under a temp projects/ dir — the test_sdk_clear_fork conventions."""
+
+    def setUp(self):
+        self._saved = jd.STATE
+        self._saved_proj = jd.PROJECTS
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        jd.PROJECTS = Path(self._td) / "projects"
+        jd._discover_cache.clear()
+        jd._PARSE_CACHE.clear()
+        km._thread_msgs_cache.clear()
+        self.now = int(time.time())
+        self.cdir = str(Path(self._td) / "work")
+        self.proj = jd._proj_dir(self.cdir)
+        self.proj.mkdir(parents=True, exist_ok=True)
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        # never build the real SDK backend in here — the frame reads state "" from a None backend
+        self._saved_sdk = km._sdk
+        km._sdk = lambda: None
+
+    def tearDown(self):
+        km._sdk = self._saved_sdk
+        jd._rebind_state(self._saved)
+        jd.PROJECTS = self._saved_proj
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _write(self, stem, records):
+        p = self.proj / (stem + ".jsonl")
+        p.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        return p
+
+    def _parent_records(self):
+        t = self.now - 600
+        return [uline(t, "how should the retry loop back off?", "u1"),
+                aline(t + 5, "Use exponential backoff with a jitter of ten percent.", "a1", parent="u1"),
+                uline(t + 60, "and the cap?", "u2", parent="a1"),
+                aline(t + 65, "Cap the delay at two minutes.", "a2", parent="u2")]
+
+
+# ── the cut target: inclusive, guarded ────────────────────────────────────────────────────────────
+
+class CutTarget(CommentBase):
+    def test_an_assistant_anchor_cuts_at_itself_not_its_ancestor(self):
+        p = self._write(PARENT, self._parent_records())
+        cut, err = km._comment_cut_target(str(p), PARENT, "a1")
+        self.assertIsNone(err)
+        self.assertEqual(cut, "a1", "the thread must HOLD the highlighted answer — inclusive cut")
+
+    def test_a_tool_row_anchor_falls_to_its_nearest_prose_ancestor(self):
+        # a tool_use record is type "assistant" but NOT a clean cut — including it would leave the
+        # fork's history ending on a dangling tool call; the nearest prose record carries the anchor
+        t = self.now - 300
+        recs = self._parent_records() + [tline(t, "tu9", "a2")]
+        p = self._write(PARENT, recs)
+        cut, err = km._comment_cut_target(str(p), PARENT, "tu9")
+        self.assertIsNone(err)
+        self.assertEqual(cut, "a2")
+
+    def test_a_pre_compaction_anchor_is_refused_loudly(self):
+        t = self.now - 600
+        recs = [uline(t, "old ask", "u1"),
+                aline(t + 5, "old answer", "a1", parent="u1"),
+                boundary(t + 100, "b1", "a1"),
+                uline(t + 200, "fresh ask", "u2", parent="b1")]
+        p = self._write(PARENT, recs)
+        cut, err = km._comment_cut_target(str(p), PARENT, "a1")
+        self.assertIsNone(cut)
+        self.assertIn("compaction", err)
+
+    def test_an_unknown_anchor_is_refused(self):
+        p = self._write(PARENT, self._parent_records())
+        cut, err = km._comment_cut_target(str(p), PARENT, "nope")
+        self.assertIsNone(cut)
+        self.assertTrue(err)
+
+
+# ── the thread fork's invisibility contract ───────────────────────────────────────────────────────
+
+class ThreadForkInvisibility(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        self.be = sb.SdkBackend(Path(self.td), "/bin/true", lambda *a, **k: None)
+        self.be.spawn("parent", self.td, sid=PARENT)
+
+    def tearDown(self):
+        shutil.rmtree(self.td, ignore_errors=True)
+
+    def test_a_thread_fork_writes_no_names_entry_and_carries_threadOf(self):
+        self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT)
+        self.assertFalse((Path(self.td) / "names" / THREAD).exists(),
+                         "names/ is the discoverability trigger — a thread must never write it")
+        reg = json.loads((Path(self.td) / "sdk" / (THREAD + ".json")).read_text())
+        self.assertEqual(reg.get("threadOf"), PARENT)
+        self.assertEqual(reg.get("forkOf"), PARENT)
+        self.assertEqual(reg.get("forkAt"), "a1")
+
+    def test_a_plain_fork_still_writes_its_names_entry(self):
+        self.be.fork("fork-x", PARENT, "a1", sid=THREAD)
+        self.assertTrue((Path(self.td) / "names" / THREAD).exists())
+
+    def test_live_sessions_skips_threads_so_no_tab_is_born(self):
+        self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT)
+        self.assertIn(PARENT, self.be.live_sessions())
+        self.assertNotIn(THREAD, self.be.live_sessions(),
+                         "a thread's only surface is the parent chat's comment UI")
+
+    def test_promote_writes_names_and_clears_threadOf(self):
+        self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT)
+        self.assertTrue(self.be.promote_thread(THREAD, "sidework", "#123456", "#ffffff"))
+        self.assertTrue((Path(self.td) / "names" / THREAD).exists())
+        reg = json.loads((Path(self.td) / "sdk" / (THREAD + ".json")).read_text())
+        self.assertNotIn("threadOf", reg)
+        self.assertEqual(reg.get("name"), "sidework")
+        self.assertIn(THREAD, self.be.live_sessions(), "a promoted thread is an ordinary session")
+
+    def test_promote_refuses_a_non_thread(self):
+        self.assertFalse(self.be.promote_thread(PARENT, "nope"))
+
+    def test_session_state_reads_a_dormant_thread_as_empty(self):
+        self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT)
+        self.assertEqual(self.be.session_state(THREAD), "")
+
+
+class ThreadDiscoverBlindness(CommentBase):
+    def test_discover_never_lists_a_thread(self):
+        self._write(PARENT, self._parent_records())
+        (jd.NAMES / PARENT).write_text("parent\t%s" % self.cdir)
+        self._write(THREAD, self._parent_records())     # the fork's transcript exists on disk
+        (jd.SDKDIR / (THREAD + ".json")).write_text(json.dumps(
+            {"sid": THREAD, "name": "thread-x", "cwd": self.cdir,
+             "lastSid": THREAD, "alive": True, "threadOf": PARENT}))
+        sids = [r[0] for r in jd.discover(self.now)]
+        self.assertIn(PARENT, sids)
+        self.assertNotIn(THREAD, sids, "no names/ entry → no judge pass, no cards, no lane")
+
+
+# ── the opening message: frame + strip ────────────────────────────────────────────────────────────
+
+class OpeningMessage(unittest.TestCase):
+    def test_frame_quotes_the_passage_and_carries_the_comment(self):
+        body = km._comment_first_message("Cap the delay at two minutes.", "Why two minutes and not five?")
+        self.assertIn("> Cap the delay at two minutes.", body)
+        self.assertTrue(body.endswith("Why two minutes and not five?"))
+        self.assertTrue(body.startswith(km._COMMENT_FRAME_HEAD))
+
+    def test_strip_returns_exactly_the_comment(self):
+        body = km._comment_first_message("line one\nline two", "The comment.\n\nWith two paragraphs.")
+        self.assertEqual(km._comment_strip_frame(body), "The comment.\n\nWith two paragraphs.")
+
+    def test_strip_leaves_an_unframed_message_alone(self):
+        self.assertEqual(km._comment_strip_frame("plain reply"), "plain reply")
+
+
+# ── the transcript → popover projection ───────────────────────────────────────────────────────────
+
+class ThreadProjection(CommentBase):
+    def _thread_records(self):
+        """The fork copy (u1..a1, verbatim uuids) + the side conversation after the cut."""
+        t = self.now - 500
+        return [uline(t, "how should the retry loop back off?", "u1"),
+                aline(t + 5, "Use exponential backoff with a jitter of ten percent.", "a1", parent="u1"),
+                uline(t + 100, km._comment_first_message(
+                    "exponential backoff", "Why jitter at all?"), "cu1", parent="a1"),
+                aline(t + 110, "Jitter prevents thundering herds.", "ca1", parent="cu1"),
+                aline(t + 111, "It also spreads retries across the window.", "ca2", parent="ca1")]
+
+    def _seed_thread(self, records=None, seen=None):
+        self._write(THREAD, records or self._thread_records())
+        (jd.SDKDIR / (THREAD + ".json")).write_text(json.dumps(
+            {"sid": THREAD, "name": "thread-x", "cwd": self.cdir,
+             "lastSid": THREAD, "alive": True, "threadOf": PARENT}))
+        km._save_comments(PARENT, {"threads": [
+            {"tid": THREAD, "sid": THREAD, "anchorUuid": "a1", "cutUuid": "a1",
+             "exact": "exponential backoff", "status": "open",
+             "createdT": self.now - 400, "lastSeenT": seen if seen is not None else self.now}]})
+
+    def test_projection_starts_after_the_cut_and_strips_the_frame(self):
+        self._seed_thread()
+        msgs = km._thread_messages(THREAD, "a1")
+        self.assertEqual([m["who"] for m in msgs], ["you", "agent"])
+        self.assertEqual(msgs[0]["text"], "Why jitter at all?",
+                         "the popover shows the comment, not its quoting frame")
+        self.assertNotIn("thundering", msgs[0]["text"])
+
+    def test_consecutive_agent_records_merge_into_one_reply(self):
+        self._seed_thread()
+        msgs = km._thread_messages(THREAD, "a1")
+        self.assertIn("thundering herds", msgs[1]["text"])
+        self.assertIn("spreads retries", msgs[1]["text"])
+
+    def test_frame_reports_unread_from_the_watermark(self):
+        self._seed_thread(seen=self.now - 450)      # replies landed after the last look
+        fr = km._comments_frame(PARENT)
+        self.assertEqual(fr["type"], "comments")
+        self.assertEqual(fr["id"], PARENT)
+        self.assertTrue(fr["threads"][0]["unread"])
+        km._comment_seen(PARENT, THREAD)
+        km._thread_msgs_cache.clear()
+        fr = km._comments_frame(PARENT)
+        self.assertFalse(fr["threads"][0]["unread"])
+
+    def test_no_store_no_frame(self):
+        self.assertIsNone(km._comments_frame(PARENT))
+
+
+# ── the ops: create / reply / resolve / promote ───────────────────────────────────────────────────
+
+class FakeBackend:
+    """Records calls; shaped like SdkBackend where the ops touch it."""
+
+    def __init__(self):
+        self.calls = []
+        self.sent = []
+
+    def fork(self, name, parent_sid, cut_uuid="", bg="", fg="", sid=None, thread_of=""):
+        self.calls.append(("fork", name, parent_sid, cut_uuid, sid, thread_of))
+        return sid
+
+    def connect(self, sid):
+        self.calls.append(("connect", sid))
+        return True
+
+    def send(self, sid, text):
+        self.calls.append(("send", sid))
+        self.sent.append((sid, text))
+        return True
+
+    def resume(self, name, sid, cwd=None):
+        self.calls.append(("resume", sid))
+        return True
+
+    def kill(self, sid):
+        self.calls.append(("kill", sid))
+        return True
+
+    def promote_thread(self, sid, name, bg="", fg=""):
+        self.calls.append(("promote", sid, name))
+        return True
+
+
+class CommentOps(CommentBase):
+    def setUp(self):
+        super().setUp()
+        self.be = FakeBackend()
+        self._saved_backend_for = km.Sessions.backend_for
+        self._saved_ready = km._sdk_ready
+        self._saved_sessions = km._sessions
+        self._saved_reveal = km._reveal_chat
+        self._saved_push_now = km._push_session_now
+        km.Sessions.backend_for = staticmethod(lambda sid: self.be)
+        km._sdk_ready = lambda: True
+        p = self._write(PARENT, self._parent_records())
+        km._sessions = lambda now, window=None, forks=True: [
+            {"sid": PARENT, "name": "parent", "path": str(p), "mtime": self.now}]
+        km._reveal_chat = lambda msg: None
+        km._push_session_now = lambda sid: None
+
+    def tearDown(self):
+        km.Sessions.backend_for = self._saved_backend_for
+        km._sdk_ready = self._saved_ready
+        km._sessions = self._saved_sessions
+        km._reveal_chat = self._saved_reveal
+        km._push_session_now = self._saved_push_now
+        super().tearDown()
+
+    def test_create_forks_a_thread_and_sends_the_framed_opener(self):
+        err, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why jitter at all?")
+        self.assertIsNone(err)
+        self.assertTrue(tid)
+        kinds = [c[0] for c in self.be.calls]
+        self.assertEqual(kinds, ["fork", "connect", "send"])
+        fork = self.be.calls[0]
+        self.assertEqual(fork[3], "a1", "inclusive cut — the thread holds the highlighted answer")
+        self.assertEqual(fork[5], PARENT, "born as a threadOf fork, never a board session")
+        self.assertTrue(self.be.sent[0][1].startswith(km._COMMENT_FRAME_HEAD))
+        row = km._comment_thread(PARENT, tid)
+        self.assertEqual(row["status"], "open")
+        self.assertEqual(row["anchorUuid"], "a1")
+
+    def test_a_refused_cut_leaves_no_thread_row_behind(self):
+        err, tid = km._comment_create(PARENT, "missing-uuid", "text", "comment")
+        self.assertTrue(err)
+        self.assertIsNone(tid)
+        self.assertEqual(km._load_comments(PARENT).get("threads", []), [])
+        self.assertEqual(self.be.calls, [])
+
+    def test_reply_reaches_the_thread_and_reopens_a_resolved_one(self):
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        km._comment_resolve(PARENT, tid)
+        self.assertEqual(km._comment_thread(PARENT, tid)["status"], "resolved")
+        self.assertIn(("kill", tid), self.be.calls)
+        err = km._comment_reply(PARENT, tid, "one more question")
+        self.assertIsNone(err)
+        self.assertIn(("resume", tid), self.be.calls, "replying IS the reopen gesture")
+        self.assertEqual(km._comment_thread(PARENT, tid)["status"], "open")
+        self.assertEqual(self.be.sent[-1], (tid, "one more question"))
+
+    def test_delete_removes_the_row(self):
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        km._comment_resolve(PARENT, tid)
+        km._comment_delete(PARENT, tid)
+        self.assertIsNone(km._comment_thread(PARENT, tid))
+
+    def test_promote_seeds_before_names_and_floors_past_the_exchange(self):
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        t = self.now - 200
+        self._write(tid, [uline(self.now - 600, "how should the retry loop back off?", "u1"),
+                          aline(self.now - 595, "Use exponential backoff.", "a1", parent="u1"),
+                          uline(t, "opener", "cu1", parent="a1"),
+                          aline(t + 10, "reply", "ca1", parent="cu1")])
+        (jd.SDKDIR / (tid + ".json")).write_text(json.dumps(
+            {"sid": tid, "name": "thread-x", "cwd": self.cdir,
+             "lastSid": tid, "alive": True, "threadOf": PARENT}))
+        order = []
+        saved_seed = km._seed_fork_stores
+        km._seed_fork_stores = lambda *a, **k: order.append("seed") or saved_seed(*a, **k)
+        real_promote = self.be.promote_thread
+        self.be.promote_thread = lambda *a, **k: order.append("names") or real_promote(*a, **k)
+        try:
+            err = km._comment_promote(PARENT, tid, "sidework")
+        finally:
+            km._seed_fork_stores = saved_seed
+        self.assertIsNone(err)
+        self.assertEqual(order, ["seed", "names"],
+                         "judge seeds must land before the names/ write — the fork() contract")
+        self.assertEqual(km._comment_thread(PARENT, tid)["status"], "promoted")
+        self.assertEqual(km._comment_thread(PARENT, tid)["promotedName"], "sidework")
+        floor = jd.episode_floor(tid)
+        self.assertIsNotNone(floor)
+        self.assertGreaterEqual(floor, t + 10,
+                                "the floor sits at the thread's leaf — the popover exchange is settled history")
+
+    def test_promote_refuses_a_bad_name(self):
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        err = km._comment_promote(PARENT, tid, "bad name!")
+        self.assertIn("letters, digits", err)
+
+    def test_drive_ops_are_registered(self):
+        src = (Path(BIN) / "romp-kernel").resolve().read_text()
+        for op in ("commentCreate", "commentReply", "commentResolve", "commentDelete",
+                   "commentSeen", "commentPromote"):
+            self.assertIn('"%s"' % op, src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -126,6 +126,10 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             # index, so it shipped saying "goal" twice and announcing "(Automated re-check…)" until
             # 2026-08-11 — exactly the drift this index exists to catch
             "awaiting backstop": km.AWAITING_BACKSTOP_TEXT,
+            # a comment thread's opening message (the user 2026-08-13): the highlight + comment are
+            # the user's own words; the quoting frame around them is romp-authored and scanned here
+            "comment thread opener": km._comment_first_message(
+                "Cap the retry delay at two minutes.", "Why two minutes and not five?"),
         }
         # every repeat-nudge variant wears the same voice as the first fire (the user 2026-08-11): the
         # rotation exists so a re-ask doesn't read canned, so a variant that broke the voice rule would
@@ -173,10 +177,11 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
         for name, body in self._bodies().items():
             # the wrap-up is a stop order, not a status ask; a TYPED follow-up carries the user's OWN
             # words as its body, so there is no romp-authored ask in it to check; the DEBT reminder
-            # asks for a reply to a PEER, not a progress report to the user
+            # asks for a reply to a PEER, not a progress report to the user; a comment thread's
+            # opener is the user's own comment on a quoted passage — a conversation, never a nudge
             if name in ("clear wrap-up", "clear wrap-up (batch)", "typed follow-up on a summary",
                         "debt reminder (question)", "debt reminder (handoff)",
-                        "debt reminder (several)"):
+                        "debt reminder (several)", "comment thread opener"):
                 continue
             text = prose(body).lower()
             with self.subTest(message=name):

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -1,0 +1,137 @@
+// Comment threads (the user 2026-08-13): the pure half (comments.ts) is driven behaviorally; the
+// render.ts / kernel / CSS wiring is pinned at the source (no jsdom harness for the renderers — the
+// repo convention). Synthetic text only.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { threadsByAnchor, threadBusy, threadStuck, findExact, sliceRanges, prunePending,
+         type CommentThread } from "./comments";
+
+const th = (over: Partial<CommentThread>): CommentThread => ({
+  tid: "t1", anchorUuid: "a1", exact: "the passage", status: "open", createdT: 0,
+  state: "", unread: false, promotedName: "", msgs: [], ...over,
+});
+
+// ── findExact: whitespace-tolerant re-anchoring ────────────────────────────────────────────────
+
+test("findExact finds a verbatim passage", () => {
+  const r = findExact("Use exponential backoff with jitter.", "exponential backoff");
+  assert.ok(r);
+  assert.equal("Use exponential backoff with jitter.".slice(r!.start, r!.end), "exponential backoff");
+});
+
+test("findExact tolerates collapsed and rewrapped whitespace", () => {
+  // the selection was made on one rendering; the re-render wraps the line elsewhere
+  const hay = "Cap the delay\n  at two   minutes.";
+  const r = findExact(hay, "delay at two minutes");
+  assert.ok(r);
+  assert.equal(hay.slice(r!.start, r!.end).replace(/\s+/g, " "), "delay at two minutes");
+});
+
+test("findExact returns null when the text drifted away", () => {
+  assert.equal(findExact("something else entirely", "the old passage"), null);
+});
+
+test("findExact never matches an empty selection", () => {
+  assert.equal(findExact("anything", "   "), null);
+});
+
+// ── sliceRanges: one global range over many text nodes ─────────────────────────────────────────
+
+test("sliceRanges splits a range across nodes", () => {
+  // nodes: "Use " (4) | "exponential" (11) | " backoff." (9); range covers "exponential backoff"
+  const slices = sliceRanges([4, 11, 9], 4, 23);
+  assert.deepEqual(slices, [
+    { idx: 1, s: 0, e: 11 },
+    { idx: 2, s: 0, e: 8 },
+  ]);
+});
+
+test("sliceRanges stays inside one node when the range does", () => {
+  assert.deepEqual(sliceRanges([10, 10], 12, 15), [{ idx: 1, s: 2, e: 5 }]);
+});
+
+// ── grouping + state predicates ────────────────────────────────────────────────────────────────
+
+test("threadsByAnchor groups threads per turn", () => {
+  const by = threadsByAnchor([th({ tid: "t1" }), th({ tid: "t2" }), th({ tid: "t3", anchorUuid: "a2" })]);
+  assert.deepEqual([...by.keys()], ["a1", "a2"]);
+  assert.equal(by.get("a1")!.length, 2);
+});
+
+test("busy and stuck are disjoint state families", () => {
+  for (const s of ["working", "retrying", "compacting"]) assert.ok(threadBusy(s) && !threadStuck(s));
+  for (const s of ["permission", "picker"]) assert.ok(threadStuck(s) && !threadBusy(s));
+  assert.ok(!threadBusy("waiting") && !threadStuck(""));
+});
+
+// ── optimistic sends reconcile against the frame ───────────────────────────────────────────────
+
+test("prunePending spends a pending row when its message lands", () => {
+  const pending = [{ text: "why jitter?", t: 1 }, { text: "and the cap?", t: 2 }];
+  const msgs = [{ who: "you" as const, text: "why  jitter?", t: 5 }];   // whitespace drift tolerated
+  assert.deepEqual(prunePending(pending, msgs), [{ text: "and the cap?", t: 2 }]);
+});
+
+// ── source pins: the wiring (render.ts, kernel.py, sdk_backend.py, styles.css) ─────────────────
+
+const UI = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const BACKEND = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
+
+test("the selection menu offers Comment, gated on a real transcript turn", () => {
+  assert.match(UI, /mk\("Comment", \(\) => openCommentComposer\(/);
+  assert.match(UI, /q\?\.uuid && activeId && !isProvisionalId\(activeId\)/);
+});
+
+test("marks and badges open threads through the stable document.body delegate", () => {
+  assert.match(UI, /cmtopen: \(elx\) =>/, "delegated — marks are re-created on every rebuild");
+  assert.match(UI, /m\.dataset\.act = "cmtopen"/);
+  assert.match(UI, /b\.dataset\.act = "cmtopen"/);
+});
+
+test("highlights re-apply after every payload that rebuilds transcript DOM", () => {
+  assert.match(UI, /m\.type === "session" \|\| m\.type === "chatTail" \|\| m\.type === "chatHead" \|\| m\.type === "chatEpisode"\)\)\s*\n\s*applyCommentMarks\(String\(m\.id\)\)/);
+  assert.match(UI, /applyCommentMarks\(activeId\);\s+\/\/ the re-window rebuilt turns/,
+               "the scroll re-window path re-anchors too");
+});
+
+test("the popover send acknowledges before any round-trip", () => {
+  assert.match(UI, /send\.disabled = true;\s+\/\/ acknowledged before any round-trip/);
+  assert.match(UI, /send\.textContent = "Sending…"/);
+});
+
+test("create adopts exactly the thread the kernel named — never a guess", () => {
+  assert.match(UI, /m\.type === "commentCreated"/);
+  assert.match(KERNEL, /"type": "commentCreated", "id": sid, "tid": tid/);
+});
+
+test("break out posts commentPromote and acks with a provisional tab", () => {
+  assert.match(UI, /function showBreakoutPrompt\(sid: string, tid: string\)/);
+  assert.match(UI, /type: "commentPromote", id: sid, tid, name \}\);\s*\n\s*close\(\);\s*\n\s*closeCommentPop\(\);\s*\n\s*openProvisional\(\{ name, backend: "sdk", dir: "", host: hostOf\(sid\) \}\);/);
+});
+
+test("kernel registers every comment drive op", () => {
+  for (const op of ["commentCreate", "commentReply", "commentResolve", "commentDelete", "commentSeen", "commentPromote"]) {
+    assert.ok(KERNEL.includes(`"${op}"`), `${op} missing from ID_OPS/handlers`);
+  }
+});
+
+test("the comments frame rides its own dedup slot, never the chat delta baseline", () => {
+  assert.match(KERNEL, /_send_client\(c, \("comments", s\["sid"\]\), fr\)/);
+});
+
+test("a thread fork withholds the names/ entry; promote seeds first, then registers", () => {
+  assert.match(BACKEND, /if not thread_of:\s*\n\s*write_name/);
+  assert.match(BACKEND, /def promote_thread\(/);
+  assert.match(BACKEND, /reg\.get\("threadOf"\):\s*\n\s*continue/, "live_sessions skips threads — no tab");
+  assert.match(KERNEL, /err = _seed_fork_stores\(parent_sid, tsid, parent_path, str\(th\.get\("cutUuid"\) or ""\)\)/);
+});
+
+test("highlight chrome wears the romp accent, popover wears the menu card", () => {
+  assert.match(CSS, /mark\.cmt-hl \{[^}]*var\(--accent\)/s);
+  assert.match(CSS, /\.cmt-pop \{[^}]*#252526[^}]*\}/s);
+  assert.match(CSS, /\.cmt-pop \{[^}]*border-radius: 6px/s);
+});

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -86,26 +86,55 @@ test("the selection menu offers Comment, gated on a real transcript turn", () =>
   assert.match(UI, /q\?\.uuid && activeId && !isProvisionalId\(activeId\)/);
 });
 
-test("marks and badges open threads through the stable document.body delegate", () => {
+test("marks, badges AND every popover button ride the stable document.body delegate", () => {
   assert.match(UI, /cmtopen: \(elx\) =>/, "delegated — marks are re-created on every rebuild");
   assert.match(UI, /m\.dataset\.act = "cmtopen"/);
   assert.match(UI, /b\.dataset\.act = "cmtopen"/);
+  for (const act of ["cmtclose", "cmtsend", "cmtbreak", "cmtresolve", "cmtdelete", "cmtopensession"]) {
+    assert.ok(UI.includes(`${act}:`), `${act} handler missing from the body delegate`);
+    assert.ok(UI.includes(`dataset.act = "${act}"`), `${act} button missing its data-act`);
+  }
 });
 
-test("highlights re-apply after every payload that rebuilds transcript DOM", () => {
+test("highlights re-apply after every render path", () => {
   assert.match(UI, /m\.type === "session" \|\| m\.type === "chatTail" \|\| m\.type === "chatHead" \|\| m\.type === "chatEpisode"\)\)\s*\n\s*applyCommentMarks\(String\(m\.id\)\)/);
   assert.match(UI, /applyCommentMarks\(activeId\);\s+\/\/ the re-window rebuilt turns/,
                "the scroll re-window path re-anchors too");
+  // the syncView wrapper covers renders that run OFF the message handlers (tab switch, prebuild)
+  assert.match(UI, /function syncView\(id: string, atBottom\?: boolean\): View \{\s*\n\s*const v = syncViewInner\(id, atBottom\);\s*\n\s*applyCommentMarks\(id\);/);
+});
+
+test("a comments frame refreshes the open popover IN PLACE — composer and caret survive", () => {
+  assert.match(UI, /prev\.dataset\.mode === mode && prev\.dataset\.tid === \(th \? th\.tid : create!\.uuid\)\s*\n\s*&& prev\.dataset\.status === status/);
+  assert.match(UI, /function fillCommentMsgs\(list: HTMLElement, th: CommentThread\)/);
 });
 
 test("the popover send acknowledges before any round-trip", () => {
-  assert.match(UI, /send\.disabled = true;\s+\/\/ acknowledged before any round-trip/);
-  assert.match(UI, /send\.textContent = "Sending…"/);
+  assert.match(UI, /send\.disabled = true; send\.textContent = "Starting…"; \}\s+\/\/ ack before the round-trip/);
+  assert.match(UI, /the pending bubble IS the acknowledgement/);
 });
 
 test("create adopts exactly the thread the kernel named — never a guess", () => {
   assert.match(UI, /m\.type === "commentCreated"/);
+  assert.match(UI, /function adoptCommentThread\(sid: string, tid: string\)/);
   assert.match(KERNEL, /"type": "commentCreated", "id": sid, "tid": tid/);
+  // the FRAME rides ahead of the ack, so adoption always finds the thread in the map
+  assert.match(KERNEL, /fr = _comments_frame\(sid\)\s*\n\s*if fr:\s*\n\s*client\["send"\]\(json\.dumps\(fr\)\)\s*\n\s*client\["send"\]\(json\.dumps\(\{"type": "commentCreated"/);
+});
+
+test("a refused reply hands the words back instead of thinking forever", () => {
+  assert.match(KERNEL, /"type": "commentSendFailed", "id": sid, "tid": str\(msg\["tid"\]\)/);
+  assert.match(UI, /m\.type === "commentSendFailed"/);
+  assert.match(UI, /commentDrafts\.set\(String\(m\.tid\), lost\.text\)/);
+});
+
+test("ending the parent sweeps its threads' CLIs — no unreachable running sessions", () => {
+  assert.match(KERNEL, /_comment_kill_all\(sid, be\)/);
+  assert.match(KERNEL, /def _comment_kill_all\(parent_sid, be\):/);
+});
+
+test("the projection never reads the parent transcript pre-fork", () => {
+  assert.match(KERNEL, /if reg\.get\("forkOf"\):\s*\n\s*return \[\]/);
 });
 
 test("break out posts commentPromote and acks with a provisional tab", () => {

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -1,0 +1,107 @@
+// Comment threads (the user 2026-08-13): highlight a passage in the chat, comment on it, and a side
+// conversation opens right there — an anchored highlight + popover, powered kernel-side by a fork of
+// the session cut at the anchored message. This module is the PURE half (node-testable, no DOM):
+// thread types, the whitespace-tolerant exact-text matcher that re-finds a highlight inside a
+// re-rendered turn, and the small derivations the popover renders from. All DOM wiring lives in
+// render.ts (source-pinned by comments.test.ts, the repo convention).
+
+export type CommentMsg = { who: "you" | "agent"; text: string; t: number };
+
+export type CommentThread = {
+  tid: string;
+  anchorUuid: string;
+  exact: string;
+  status: "open" | "resolved" | "promoted";
+  createdT: number;
+  state: string;              // the thread session's live state ("working"/"waiting"/…, "" when dormant)
+  unread: boolean;            // an agent reply newer than the read watermark
+  promotedName: string;       // the board session it became, when status === "promoted"
+  msgs: CommentMsg[];
+};
+
+export type CommentsFrame = { type: "comments"; id: string; threads: CommentThread[] };
+
+/** Threads grouped by the turn they anchor to — what the mark/badge pass walks per rendered view. */
+export function threadsByAnchor(threads: CommentThread[]): Map<string, CommentThread[]> {
+  const by = new Map<string, CommentThread[]>();
+  for (const th of threads) {
+    const list = by.get(th.anchorUuid);
+    if (list) list.push(th); else by.set(th.anchorUuid, [th]);
+  }
+  return by;
+}
+
+/** The thread session is mid-turn — the popover shows its thinking dots. */
+export function threadBusy(state: string): boolean {
+  return state === "working" || state === "retrying" || state === "compacting";
+}
+
+/** The thread session is stuck on an interactive prompt the popover can't answer — say so, and point
+ *  at Break out (a full session can). */
+export function threadStuck(state: string): boolean {
+  return state === "permission" || state === "picker";
+}
+
+// ── exact-text re-anchoring ────────────────────────────────────────────────────────────────────
+// A highlight is stored as the selected text (`exact`); every re-render must re-find it inside the
+// anchor turn's rendered text. Rendered whitespace is not byte-stable (markdown collapses runs,
+// wraps lines), so both sides are matched through a whitespace-NORMALIZED view with an index map
+// back into the raw string. First occurrence wins — same-turn duplicate phrases anchor to their
+// first appearance, a known and acceptable simplification.
+
+/** Collapse whitespace runs to single spaces; `map[i]` = raw index of normalized char i. */
+function normalize(raw: string): { norm: string; map: number[] } {
+  let norm = "";
+  const map: number[] = [];
+  let inWs = false;
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw[i];
+    if (/\s/.test(c)) {
+      inWs = true;
+      continue;
+    }
+    if (inWs && norm.length) {
+      norm += " ";
+      map.push(i);              // the space stands for the run; anchor it at the run's end
+    }
+    inWs = false;
+    norm += c;
+    map.push(i);
+  }
+  return { norm, map };
+}
+
+/** Find `exact` inside `hay`, whitespace-tolerantly. Returns raw [start, end) in `hay`, or null. */
+export function findExact(hay: string, exact: string): { start: number; end: number } | null {
+  const target = normalize(exact).norm;
+  if (!target) return null;
+  const { norm, map } = normalize(hay);
+  const at = norm.indexOf(target);
+  if (at < 0) return null;
+  return { start: map[at], end: map[at + target.length - 1] + 1 };
+}
+
+/** Split a global [start, end) character range over consecutive text-node lengths into per-node
+ *  slices — what the DOM pass wraps in <mark> elements. */
+export function sliceRanges(nodeLens: number[], start: number, end: number):
+    { idx: number; s: number; e: number }[] {
+  const out: { idx: number; s: number; e: number }[] = [];
+  let off = 0;
+  for (let i = 0; i < nodeLens.length && off < end; i++) {
+    const len = nodeLens[i];
+    const s = Math.max(start, off);
+    const e = Math.min(end, off + len);
+    if (e > s) out.push({ idx: i, s: s - off, e: e - off });
+    off += len;
+  }
+  return out;
+}
+
+/** Optimistic pending sends, reconciled against the kernel's frame (the registerOptimistic pattern):
+ *  a pending row is spent the moment a server 'you' message with its text appears. Returns the
+ *  still-pending remainder to render after the server messages. */
+export function prunePending(pending: { text: string; t: number }[], msgs: CommentMsg[]):
+    { text: string; t: number }[] {
+  const seen = msgs.filter((m) => m.who === "you").map((m) => normalize(m.text).norm);
+  return pending.filter((p) => !seen.includes(normalize(p.text).norm));
+}

--- a/ui/webview/fork-session.test.ts
+++ b/ui/webview/fork-session.test.ts
@@ -45,7 +45,7 @@ test("the palette forks the ACTIVE session from the tip, via the chat pane", () 
 });
 
 test("kernel: forkSession is a session op; seeding precedes discoverability; the fsid is pinned to the sid", () => {
-  assert.match(KERNEL, /"forkSession"\)/);   // in ID_OPS — routed by session id like every session op
+  assert.match(KERNEL, /"mcpAction", "forkSession",/);   // in ID_OPS — routed by session id like every session op
   assert.match(KERNEL, /elif t == "forkSession" and msg\.get\("name"\):/);
   assert.match(KERNEL, /def _fork_session\(parent_sid, cut_msg_uuid, new_name, now=None\):/);
   // the cut means the same thing the edit/delete rewind means: just before the clicked user message

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -34,6 +34,7 @@ import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
 import { apiErrorReason } from "./api-error-reason";
 import { mathBlock, mathInline } from "./math";
+import { threadsByAnchor, threadBusy, threadStuck, findExact, sliceRanges, prunePending, type CommentThread } from "./comments";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -3747,6 +3748,13 @@ function showSelectionMenu(e: MouseEvent) {
     menu.appendChild(item);
   };
   mk("Reply", () => quoteSelectionIntoComposer(text));
+  // Comment (the user 2026-08-13): open a side thread anchored to this passage. Only when the
+  // selection sits in a real transcript turn (transcriptSelection's uuid) on a real session.
+  const q = transcriptSelection();
+  if (q?.uuid && activeId && !isProvisionalId(activeId) && sessions.get(activeId)) {
+    const sid = activeId, uuid = q.uuid, qtext = q.text;
+    mk("Comment", () => openCommentComposer(sid, uuid, qtext, e.clientX, e.clientY));
+  }
   mk("Copy", () => copyToClipboard(text));
   document.body.appendChild(menu);
   ctxMenuEl = menu;
@@ -5048,6 +5056,337 @@ function showForkPrompt(sid: string, uuid: string): void {
   input.focus(); input.setSelectionRange(0, input.value.length);
 }
 
+// ── COMMENT THREADS (the user 2026-08-13) ───────────────────────────────────────────────────────────
+// Highlight a passage → "Comment" on the selection menu → a side conversation opens right there, in a
+// pane-local popover anchored to the highlighted text. The kernel forks the session at the anchored
+// message (the thread's agent holds exactly the context that produced the passage) and keeps the fork
+// off the board; this side owns the anchoring: a <mark> over the exact text (re-found per render,
+// whitespace-tolerantly — comments.ts) plus a per-turn badge that survives even when the rendered text
+// drifts, so a thread is never unreachable. State lives in module maps keyed by sid/tid, so every
+// re-render (the transcript rebuilds constantly) reapplies it — the openFolds pattern.
+const commentThreads = new Map<string, CommentThread[]>();          // parent sid → last frame's threads
+const commentPending = new Map<string, { text: string; t: number }[]>(); // tid → optimistic sends
+const commentDrafts = new Map<string, string>();                    // draft key → unsent popover text
+let openCommentKey: { sid: string; tid: string } | null = null;     // the open thread popover
+let pendingCommentAnchor: { sid: string; uuid: string; exact: string } | null = null; // create mode
+let commentPopPos: { x: number; y: number } | null = null;
+
+function closeCommentPop(): void {
+  document.getElementById("cmt-pop")?.remove();
+  openCommentKey = null;
+  pendingCommentAnchor = null;
+}
+
+// close on any press outside the popover (drafts persist in commentDrafts; reopening restores them)
+document.addEventListener("mousedown", (ev) => {
+  const pop = document.getElementById("cmt-pop");
+  if (pop && !pop.contains(ev.target as Node)) closeCommentPop();
+}, true);
+
+/** Re-anchor every thread of `sid` onto its rendered turn: the exact-text <mark> plus the turn badge.
+ *  Idempotent and cheap (early-out when the session has no threads) — called after every payload that
+ *  can rebuild transcript DOM, and after each comments frame. */
+function applyCommentMarks(sid: string): void {
+  const v = views.get(sid);
+  if (!v) return;
+  const threads = commentThreads.get(sid) || [];
+  const have = new Set(threads.map((t) => t.tid));
+  for (const old of Array.from(v.el.querySelectorAll("mark.cmt-hl"))) {
+    if (!have.has((old as HTMLElement).dataset.tid || "")) unwrapCommentMark(old as HTMLElement);
+  }
+  for (const b of Array.from(v.el.querySelectorAll(".cmt-badge"))) {
+    const uuid = (b.closest(".turn") as HTMLElement | null)?.dataset.uuid || "";
+    if (!threads.some((t) => t.anchorUuid === uuid)) b.remove();
+  }
+  if (!threads.length) return;
+  for (const [uuid, list] of threadsByAnchor(threads)) {
+    const turn = v.el.querySelector(`.turn[data-uuid="${cssEscape(uuid)}"]`) as HTMLElement | null;
+    if (!turn) continue;                       // windowed out — the mark returns when the turn does
+    ensureCommentBadge(turn, list);
+    for (const th of list) ensureCommentMark(turn, th);
+  }
+}
+
+function unwrapCommentMark(markEl: HTMLElement): void {
+  const p = markEl.parentNode;
+  if (!p) return;
+  while (markEl.firstChild) p.insertBefore(markEl.firstChild, markEl);
+  markEl.remove();
+  p.normalize();
+}
+
+function ensureCommentBadge(turn: HTMLElement, list: CommentThread[]): void {
+  turn.classList.add("has-cmt");               // positions the badge (styles.css .turn.has-cmt)
+  let b = turn.querySelector(":scope > .cmt-badge") as HTMLButtonElement | null;
+  if (!b) {
+    b = el("button", "cmt-badge") as HTMLButtonElement;
+    b.type = "button";
+    b.dataset.act = "cmtopen";                 // delegated on document.body — click-safe across rebuilds
+    turn.appendChild(b);
+  }
+  b.textContent = String(list.length);
+  b.dataset.tid = (list.find((t) => t.unread && t.status === "open") || list[list.length - 1]).tid;
+  b.classList.toggle("unread", list.some((t) => t.unread && t.status === "open"));
+  b.classList.toggle("busy", list.some((t) => threadBusy(t.state) && t.status === "open"));
+  b.title = (list.length === 1 ? "1 thread" : list.length + " threads") + " on this message. Click to open";
+}
+
+function ensureCommentMark(turn: HTMLElement, th: CommentThread): void {
+  const sel = `mark.cmt-hl[data-tid="${cssEscape(th.tid)}"]`;
+  if (!turn.querySelector(sel)) {
+    const body = turn.querySelector(".md") as HTMLElement | null;
+    if (!body) return;                          // no prose body (a tool row) — the badge carries it
+    const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT);
+    const nodes: Text[] = [];
+    let n: Node | null;
+    while ((n = walker.nextNode())) nodes.push(n as Text);
+    const r = findExact(nodes.map((t) => t.data).join(""), th.exact);
+    if (!r) return;                             // rendered text drifted — the badge still reaches it
+    for (const sl of sliceRanges(nodes.map((t) => t.data.length), r.start, r.end)) {
+      const t = nodes[sl.idx];
+      const mid = sl.s > 0 ? t.splitText(sl.s) : t;
+      if (sl.e - sl.s < mid.data.length) mid.splitText(sl.e - sl.s);
+      const m = document.createElement("mark");
+      m.className = "cmt-hl";
+      m.dataset.tid = th.tid;
+      m.dataset.act = "cmtopen";
+      mid.parentNode?.insertBefore(m, mid);
+      m.appendChild(mid);
+    }
+  }
+  for (const seg of Array.from(turn.querySelectorAll(sel))) styleCommentMark(seg as HTMLElement, th);
+}
+
+function styleCommentMark(m: HTMLElement, th: CommentThread): void {
+  m.classList.toggle("resolved", th.status === "resolved");
+  m.classList.toggle("unread", !!th.unread && th.status === "open");
+  m.classList.toggle("busy", threadBusy(th.state) && th.status === "open");
+  m.title = th.status === "promoted" ? "thread, now the session '" + th.promotedName + "'"
+    : th.status === "resolved" ? "resolved thread: click to read or reopen"
+    : "thread: click to open";
+}
+
+function openCommentComposer(sid: string, uuid: string, exact: string, x: number, y: number): void {
+  pendingCommentAnchor = { sid, uuid, exact };
+  openCommentKey = null;
+  commentPopPos = { x, y };
+  renderCommentPopover();
+}
+
+function openCommentPopover(sid: string, tid: string, x?: number, y?: number): void {
+  openCommentKey = { sid, tid };
+  pendingCommentAnchor = null;
+  if (x != null && y != null) commentPopPos = { x, y };
+  vscodeApi?.postMessage({ type: "commentSeen", id: sid, tid });
+  const th = (commentThreads.get(sid) || []).find((t) => t.tid === tid);
+  if (th) th.unread = false;                    // optimistic; the kernel's watermark reconciles
+  renderCommentPopover();
+  applyCommentMarks(sid);
+}
+
+function commentMsgEl(who: "you" | "agent", text: string): HTMLElement {
+  const n = el("div", "cmt-msg " + who);
+  if (who === "agent") n.innerHTML = md(text);
+  else n.textContent = text;
+  return n;
+}
+
+/** The popover — ONE pane-local card (no backdrop: the conversation stays readable beside it),
+ *  rebuilt from state so a comments frame landing mid-conversation just re-renders it in place. */
+function renderCommentPopover(): void {
+  const prev = document.getElementById("cmt-pop");
+  const prevScroll = (prev?.querySelector(".cmt-msgs") as HTMLElement | null)?.scrollTop ?? null;
+  const hadFocus = !!prev?.querySelector(".cmt-input:focus-within, .cmt-input:focus");
+  prev?.remove();
+  const create = pendingCommentAnchor;
+  const key = openCommentKey;
+  if (!create && !key) return;
+  const sid = create ? create.sid : key!.sid;
+  const th = key ? (commentThreads.get(sid) || []).find((t) => t.tid === key.tid) : null;
+  if (key && !th) { closeCommentPop(); return; }
+  const pop = el("div", "cmt-pop");
+  pop.id = "cmt-pop";
+  const head = el("div", "cmt-head");
+  const title = el("span", "cmt-title");
+  title.textContent = create ? "New thread"
+    : th!.status === "promoted" ? "Now its own session: " + th!.promotedName
+    : th!.status === "resolved" ? "Thread (resolved)" : "Thread";
+  const closeBtn = el("button", "cmt-x") as HTMLButtonElement;
+  closeBtn.type = "button";
+  closeBtn.textContent = "×";
+  closeBtn.title = "Close (the thread stays on its highlight)";
+  closeBtn.addEventListener("click", closeCommentPop);
+  head.append(title, closeBtn);
+  pop.appendChild(head);
+  const quote = el("div", "cmt-quote");
+  quote.textContent = create ? create.exact : th!.exact;
+  quote.title = "the highlighted passage this thread is about";
+  pop.appendChild(quote);
+  if (th) {
+    const list = el("div", "cmt-msgs");
+    const pend = prunePending(commentPending.get(th.tid) || [], th.msgs);
+    commentPending.set(th.tid, pend);
+    for (const m of th.msgs) list.appendChild(commentMsgEl(m.who, m.text));
+    for (const p of pend) {
+      const n = commentMsgEl("you", p.text);
+      n.classList.add("pending");
+      list.appendChild(n);
+    }
+    if (th.status === "open" && (threadBusy(th.state) || pend.length)) {
+      const dots = el("div", "cmt-dots");
+      dots.append(el("span"), el("span"), el("span"));
+      list.appendChild(dots);
+    }
+    if (th.status === "open" && threadStuck(th.state)) {
+      const note = el("div", "cmt-note");
+      note.textContent = "This thread hit a prompt it can't answer from here. Break it out to continue.";
+      list.appendChild(note);
+    }
+    pop.appendChild(list);
+  }
+  if (create || th!.status !== "promoted") {
+    const dk = create ? "new:" + create.uuid : th!.tid;
+    const send = el("button", "cmt-send") as HTMLButtonElement;
+    send.type = "button";
+    send.textContent = create ? "Start thread" : "Send";
+    const box = document.createElement("textarea");
+    box.className = "cmt-input";
+    box.rows = 2;
+    box.placeholder = create ? "Comment on this passage…"
+      : th!.status === "resolved" ? "Reply to reopen…" : "Reply…";
+    box.value = commentDrafts.get(dk) || "";
+    box.addEventListener("input", () => commentDrafts.set(dk, box.value));
+    box.addEventListener("keydown", (ev) => {
+      if (ev.key === "Enter" && !ev.shiftKey) { ev.preventDefault(); send.click(); }
+      else if (ev.key === "Escape") { ev.stopPropagation(); closeCommentPop(); }
+    });
+    send.addEventListener("click", () => {
+      const text = box.value.trim();
+      if (!text || !vscodeApi) return;
+      send.disabled = true;                     // acknowledged before any round-trip
+      send.textContent = "Sending…";
+      if (create) {
+        // the draft survives until commentCreated adopts the thread — a refused create keeps the words
+        vscodeApi.postMessage({ type: "commentCreate", id: sid, uuid: create.uuid, exact: create.exact, text });
+      } else {
+        vscodeApi.postMessage({ type: "commentReply", id: sid, tid: th!.tid, text });
+        const pl = commentPending.get(th!.tid) || [];
+        pl.push({ text, t: Date.now() / 1000 });
+        commentPending.set(th!.tid, pl);
+        commentDrafts.delete(dk);
+        renderCommentPopover();
+      }
+    });
+    pop.appendChild(box);
+    const row = el("div", "cmt-actions");
+    row.appendChild(send);
+    if (th) {
+      const br = el("button", "cmt-act") as HTMLButtonElement;
+      br.type = "button";
+      br.textContent = "Break out";
+      br.title = "Continue this thread as its own session; it keeps everything it knows";
+      br.addEventListener("click", () => showBreakoutPrompt(sid, th.tid));
+      row.appendChild(br);
+      if (th.status === "open") {
+        const rs = el("button", "cmt-act") as HTMLButtonElement;
+        rs.type = "button";
+        rs.textContent = "Resolve";
+        rs.title = "Settle this thread: the highlight dims, and replying reopens it";
+        rs.addEventListener("click", () => {
+          rs.disabled = true;
+          rs.textContent = "Resolving…";
+          vscodeApi?.postMessage({ type: "commentResolve", id: sid, tid: th.tid });
+        });
+        row.appendChild(rs);
+      } else {
+        const dl = el("button", "cmt-act cmt-del") as HTMLButtonElement;
+        dl.type = "button";
+        dl.textContent = "Delete";
+        dl.title = "Remove this thread and its highlight";
+        const disarm = () => { dl.classList.remove("armed"); dl.textContent = "Delete"; };
+        dl.addEventListener("click", () => {
+          if (!dl.classList.contains("armed")) { dl.classList.add("armed"); dl.textContent = "Really delete?"; return; }
+          vscodeApi?.postMessage({ type: "commentDelete", id: sid, tid: th.tid });
+          closeCommentPop();
+        });
+        dl.addEventListener("pointerleave", disarm);
+        dl.addEventListener("blur", disarm);
+        row.appendChild(dl);
+      }
+    }
+    pop.appendChild(row);
+  } else if (th) {
+    const row = el("div", "cmt-actions");
+    const open = el("button", "cmt-send") as HTMLButtonElement;
+    open.type = "button";
+    open.textContent = "Open the session";
+    open.addEventListener("click", () => { closeCommentPop(); setActive(th.tid); });
+    row.appendChild(open);
+    pop.appendChild(row);
+  }
+  document.body.appendChild(pop);
+  const r = pop.getBoundingClientRect();
+  const px = Math.max(8, Math.min(commentPopPos?.x ?? (window.innerWidth - r.width) / 2, window.innerWidth - r.width - 8));
+  const py = Math.max(8, Math.min(commentPopPos?.y ?? 120, window.innerHeight - r.height - 8));
+  pop.style.left = px + "px";
+  pop.style.top = py + "px";
+  const msgs = pop.querySelector(".cmt-msgs") as HTMLElement | null;
+  if (msgs) msgs.scrollTop = prevScroll != null ? Math.max(prevScroll, msgs.scrollHeight - msgs.clientHeight) : msgs.scrollHeight;
+  if (create || hadFocus || !th || !th.msgs.length) (pop.querySelector(".cmt-input") as HTMLTextAreaElement | null)?.focus();
+}
+
+// BREAK OUT (the user 2026-08-13: "a button that breaks it out into its own session") — the fork
+// modal's shape: a name box, Enter/Break out, provisional tab as the instant acknowledgement. The
+// kernel seeds the judge stores and registers the session (commentPromote); the popover's thread
+// flips to "promoted" on the next comments frame.
+function showBreakoutPrompt(sid: string, tid: string): void {
+  const sess = sessions.get(sid);
+  const base = (sess?.name || "session").replace(/[^A-Za-z0-9._-]/g, "-");
+  document.getElementById("fork-prompt")?.remove();
+  const overlay = el("div", "picker-overlay confirm-overlay");
+  overlay.id = "fork-prompt";
+  const box = el("div", "picker-box confirm-box");
+  const h = el("div", "confirm-title");
+  h.textContent = "Break out the thread";
+  const d = el("div", "confirm-detail");
+  d.textContent = "The thread becomes its own session, keeping the conversation up to its highlight plus everything discussed since.";
+  const input = document.createElement("input");
+  input.type = "text";
+  input.className = "fork-name";
+  input.value = base + "-thread";
+  input.setAttribute("autocapitalize", "off");
+  input.setAttribute("autocomplete", "off");
+  input.setAttribute("autocorrect", "off");
+  input.setAttribute("spellcheck", "false");
+  const actions = el("div", "confirm-actions");
+  const cancel = el("button", "picker-action confirm-btn");
+  cancel.textContent = "Cancel";
+  const create = el("button", "picker-action confirm-btn");
+  create.textContent = "Break out";
+  const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.stopPropagation(); close(); } };
+  const close = () => { overlay.remove(); document.removeEventListener("keydown", onKey, true); };
+  const go = () => {
+    const name = input.value.trim();
+    if (!/^[A-Za-z0-9._-]+$/.test(name)) { input.classList.add("bad"); input.focus(); return; }
+    vscodeApi?.postMessage({ type: "commentPromote", id: sid, tid, name });
+    close();
+    closeCommentPop();
+    openProvisional({ name, backend: "sdk", dir: "", host: hostOf(sid) });
+  };
+  cancel.addEventListener("click", close);
+  create.addEventListener("click", go);
+  input.addEventListener("keydown", (e) => { if (e.key === "Enter") { e.preventDefault(); go(); } });
+  input.addEventListener("input", () => input.classList.remove("bad"));
+  overlay.addEventListener("click", (e) => { if (e.target === overlay) close(); });
+  box.append(h, d, input, actions);
+  actions.append(cancel, create);
+  overlay.appendChild(box);
+  document.body.appendChild(overlay);
+  document.addEventListener("keydown", onKey, true);
+  input.focus();
+  input.setSelectionRange(0, input.value.length);
+}
+
 // THE MCP PANEL (the user 2026-08-05). `/mcp` in a romp session used to be a dead end: the CLI's own
 // panel is an interactive TUI an SDK-driven session cannot render, so it replied "use a terminal". The
 // SDK exposes the same facts and repairs as control requests (get_mcp_status / toggle_mcp_server /
@@ -6323,6 +6662,7 @@ function virtualizeToViewport(): void {
         const yNow = anchor.getBoundingClientRect().top - content.getBoundingClientRect().top + content.scrollTop;
         content.scrollTop = yNow - beforeY;
       }
+      if (activeId) applyCommentMarks(activeId);   // the re-window rebuilt turns — re-anchor highlights
       scheduleRailSticky();
     } finally {
       hideLoadingPill();
@@ -8707,7 +9047,29 @@ window.addEventListener("message", (e: MessageEvent) => {
     seedEditorQuote(activeId, m.text, typeof m.src === "string" ? m.src : undefined);
   // the editor selection collapsed (deselect / click away) — drop the chip that highlight seeded
   else if (m.type === "editorSelectionCleared") clearEditorCitation(activeId);
+  // comment threads (the user 2026-08-13): the per-session thread frame — store, re-anchor the
+  // highlights, and refresh the popover if it's showing one of these threads
+  else if (m.type === "comments" && m.id) {
+    commentThreads.set(String(m.id), (m.threads || []) as CommentThread[]);
+    applyCommentMarks(String(m.id));
+    if (openCommentKey && openCommentKey.sid === m.id) renderCommentPopover();
+  }
+  // the create ack: adopt exactly the thread this popover made (never a guess), spend its draft
+  else if (m.type === "commentCreated" && m.id && m.tid) {
+    if (pendingCommentAnchor && pendingCommentAnchor.sid === m.id) {
+      commentDrafts.delete("new:" + pendingCommentAnchor.uuid);
+      pendingCommentAnchor = null;
+      openCommentKey = { sid: String(m.id), tid: String(m.tid) };
+      vscodeApi?.postMessage({ type: "commentSeen", id: String(m.id), tid: String(m.tid) });
+      renderCommentPopover();
+    }
+  }
   else if (m.type === "closed") dismissSession(m.id);   // a session died on its own (or the kernel confirms our close)
+  // any payload that rebuilt transcript DOM must get its highlights re-applied (marks live IN that DOM)
+  if (m && m.id && (m.type === "session" || m.type === "chatTail" || m.type === "chatHead" || m.type === "chatEpisode"))
+    applyCommentMarks(String(m.id));
+  // a refused create (warn) must hand the popover back — the draft is intact, the button un-sticks
+  if (m && m.type === "warn" && pendingCommentAnchor) renderCommentPopover();
 });
 
 // Tick the working timer (the chip color-pulse is pure CSS) and keep the model/ctx
@@ -9426,6 +9788,14 @@ setupSettings();
       const grp = bub?.closest(".turn-queued") as HTMLElement | null;
       bub?.remove();
       if (grp) reflowQueuedGroup(grp);
+    },
+    // a comment highlight or its turn badge (the user 2026-08-13): open the thread's popover at the
+    // click. Delegated — marks and badges are re-created on every transcript rebuild.
+    cmtopen: (elx) => {
+      const tid = elx.dataset.tid;
+      if (!tid || !activeId) return;
+      const r = elx.getBoundingClientRect();
+      openCommentPopover(activeId, tid, Math.min(r.left, window.innerWidth - 380), r.bottom + 6);
     },
     // "copy to composer" on a never-delivered bubble: the echo is the only surviving copy of the text —
     // hand it back for review-and-resend (the same restore the queued ✕ uses). Delegated like qx: the

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5069,6 +5069,7 @@ const commentPending = new Map<string, { text: string; t: number }[]>(); // tid 
 const commentDrafts = new Map<string, string>();                    // draft key → unsent popover text
 let openCommentKey: { sid: string; tid: string } | null = null;     // the open thread popover
 let pendingCommentAnchor: { sid: string; uuid: string; exact: string } | null = null; // create mode
+let pendingAdoptTid: string | null = null;                          // commentCreated ack that beat its frame
 let commentPopPos: { x: number; y: number } | null = null;
 
 function closeCommentPop(): void {
@@ -5184,6 +5185,21 @@ function openCommentPopover(sid: string, tid: string, x?: number, y?: number): v
   applyCommentMarks(sid);
 }
 
+/** commentCreated's adoption: swap the create popover for the named thread's (never a guess — the
+ *  kernel sends the frame first, then the ack naming the tid). When the frame hasn't landed yet
+ *  (a dropped/reordered leg), the tid parks in pendingAdoptTid and the next frame adopts it. */
+function adoptCommentThread(sid: string, tid: string): void {
+  if (pendingCommentAnchor && pendingCommentAnchor.sid === sid) {
+    commentDrafts.delete("new:" + pendingCommentAnchor.uuid);
+    pendingCommentAnchor = null;
+  }
+  pendingAdoptTid = null;
+  openCommentKey = { sid, tid };
+  vscodeApi?.postMessage({ type: "commentSeen", id: sid, tid });
+  renderCommentPopover();
+  applyCommentMarks(sid);
+}
+
 function commentMsgEl(who: "you" | "agent", text: string): HTMLElement {
   const n = el("div", "cmt-msg " + who);
   if (who === "agent") n.innerHTML = md(text);
@@ -5191,31 +5207,112 @@ function commentMsgEl(who: "you" | "agent", text: string): HTMLElement {
   return n;
 }
 
-/** The popover — ONE pane-local card (no backdrop: the conversation stays readable beside it),
- *  rebuilt from state so a comments frame landing mid-conversation just re-renders it in place. */
+/** The open thread + parent sid behind the popover, resolved fresh (delegated handlers must never
+ *  close over a stale thread object). */
+function openCommentThread(): { sid: string; th: CommentThread } | null {
+  if (!openCommentKey) return null;
+  const th = (commentThreads.get(openCommentKey.sid) || []).find((t) => t.tid === openCommentKey!.tid);
+  return th ? { sid: openCommentKey.sid, th } : null;
+}
+
+/** The popover's conversation area, (re)filled in place — shared by the full build and the
+ *  frame-driven refresh so an update never rebuilds the composer under the user's caret. */
+function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
+  const prevScroll = list.scrollTop;
+  const atTail = list.scrollTop >= list.scrollHeight - list.clientHeight - 8;
+  list.replaceChildren();
+  const pend = prunePending(commentPending.get(th.tid) || [], th.msgs);
+  commentPending.set(th.tid, pend);
+  for (const m of th.msgs) list.appendChild(commentMsgEl(m.who, m.text));
+  for (const p of pend) {
+    const n = commentMsgEl("you", p.text);
+    n.classList.add("pending");
+    list.appendChild(n);
+  }
+  if (th.status === "open" && (threadBusy(th.state) || pend.length)) {
+    const dots = el("div", "cmt-dots");
+    dots.append(el("span"), el("span"), el("span"));
+    list.appendChild(dots);
+  }
+  if (th.status === "open" && threadStuck(th.state)) {
+    const note = el("div", "cmt-note");
+    note.textContent = "This thread hit a prompt it can't answer from here. Break it out to continue.";
+    list.appendChild(note);
+  }
+  list.scrollTop = atTail ? list.scrollHeight : prevScroll;
+}
+
+function commentPopTitle(create: boolean, th: CommentThread | null | undefined): string {
+  return create ? "New thread"
+    : th!.status === "promoted" ? "Now its own session: " + th!.promotedName
+    : th!.status === "resolved" ? "Thread (resolved)" : "Thread";
+}
+
+/** Send the popover composer's text — the Enter key and the delegated Send button share this. The
+ *  button acknowledges instantly; a thread reply also renders its optimistic pending bubble. */
+function commentSendFromPop(pop: HTMLElement): void {
+  const box = pop.querySelector(".cmt-input") as HTMLTextAreaElement | null;
+  const send = pop.querySelector('[data-act="cmtsend"]') as HTMLButtonElement | null;
+  const text = box?.value.trim();
+  if (!box || !text || !vscodeApi) return;
+  const create = pendingCommentAnchor;
+  if (create) {
+    if (send) { send.disabled = true; send.textContent = "Starting…"; }   // ack before the round-trip;
+    //                                       the draft survives until commentCreated adopts the thread
+    vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact, text });
+    return;
+  }
+  const cur = openCommentThread();
+  if (!cur) return;
+  vscodeApi.postMessage({ type: "commentReply", id: cur.sid, tid: cur.th.tid, text });
+  const pl = commentPending.get(cur.th.tid) || [];
+  pl.push({ text, t: Date.now() / 1000 });
+  commentPending.set(cur.th.tid, pl);
+  commentDrafts.delete(cur.th.tid);
+  box.value = "";
+  const list = pop.querySelector(".cmt-msgs") as HTMLElement | null;
+  if (list) fillCommentMsgs(list, cur.th);      // the pending bubble IS the acknowledgement
+}
+
+/** The popover — ONE pane-local card (no backdrop: the conversation stays readable beside it).
+ *  Same thread still open → the conversation refreshes IN PLACE: the composer, its caret and the
+ *  action row survive every comments frame (a full rebuild per push ate mid-press clicks and
+ *  jumped the caret — the click-safety rule). Identity or status changed → full rebuild. Buttons
+ *  carry data-act only; their actions live on the document.body delegate. */
 function renderCommentPopover(): void {
-  const prev = document.getElementById("cmt-pop");
-  const prevScroll = (prev?.querySelector(".cmt-msgs") as HTMLElement | null)?.scrollTop ?? null;
-  const hadFocus = !!prev?.querySelector(".cmt-input:focus-within, .cmt-input:focus");
-  prev?.remove();
   const create = pendingCommentAnchor;
   const key = openCommentKey;
-  if (!create && !key) return;
+  const prev = document.getElementById("cmt-pop");
+  if (!create && !key) { prev?.remove(); return; }
   const sid = create ? create.sid : key!.sid;
   const th = key ? (commentThreads.get(sid) || []).find((t) => t.tid === key.tid) : null;
   if (key && !th) { closeCommentPop(); return; }
+  const mode = create ? "create" : "thread";
+  const status = th ? th.status : "";
+  if (prev && prev.dataset.mode === mode && prev.dataset.tid === (th ? th.tid : create!.uuid)
+      && prev.dataset.status === status) {
+    // in-place refresh: conversation + title only
+    const t = prev.querySelector(".cmt-title") as HTMLElement | null;
+    if (t) t.textContent = commentPopTitle(!!create, th);
+    const list = prev.querySelector(".cmt-msgs") as HTMLElement | null;
+    if (th && list) fillCommentMsgs(list, th);
+    return;
+  }
+  const hadFocus = !!prev?.querySelector(".cmt-input:focus-within, .cmt-input:focus");
+  prev?.remove();
   const pop = el("div", "cmt-pop");
   pop.id = "cmt-pop";
+  pop.dataset.mode = mode;
+  pop.dataset.tid = th ? th.tid : create!.uuid;
+  pop.dataset.status = status;
   const head = el("div", "cmt-head");
   const title = el("span", "cmt-title");
-  title.textContent = create ? "New thread"
-    : th!.status === "promoted" ? "Now its own session: " + th!.promotedName
-    : th!.status === "resolved" ? "Thread (resolved)" : "Thread";
+  title.textContent = commentPopTitle(!!create, th);
   const closeBtn = el("button", "cmt-x") as HTMLButtonElement;
   closeBtn.type = "button";
   closeBtn.textContent = "×";
   closeBtn.title = "Close (the thread stays on its highlight)";
-  closeBtn.addEventListener("click", closeCommentPop);
+  closeBtn.dataset.act = "cmtclose";
   head.append(title, closeBtn);
   pop.appendChild(head);
   const quote = el("div", "cmt-quote");
@@ -5224,31 +5321,11 @@ function renderCommentPopover(): void {
   pop.appendChild(quote);
   if (th) {
     const list = el("div", "cmt-msgs");
-    const pend = prunePending(commentPending.get(th.tid) || [], th.msgs);
-    commentPending.set(th.tid, pend);
-    for (const m of th.msgs) list.appendChild(commentMsgEl(m.who, m.text));
-    for (const p of pend) {
-      const n = commentMsgEl("you", p.text);
-      n.classList.add("pending");
-      list.appendChild(n);
-    }
-    if (th.status === "open" && (threadBusy(th.state) || pend.length)) {
-      const dots = el("div", "cmt-dots");
-      dots.append(el("span"), el("span"), el("span"));
-      list.appendChild(dots);
-    }
-    if (th.status === "open" && threadStuck(th.state)) {
-      const note = el("div", "cmt-note");
-      note.textContent = "This thread hit a prompt it can't answer from here. Break it out to continue.";
-      list.appendChild(note);
-    }
+    fillCommentMsgs(list, th);
     pop.appendChild(list);
   }
   if (create || th!.status !== "promoted") {
     const dk = create ? "new:" + create.uuid : th!.tid;
-    const send = el("button", "cmt-send") as HTMLButtonElement;
-    send.type = "button";
-    send.textContent = create ? "Start thread" : "Send";
     const box = document.createElement("textarea");
     box.className = "cmt-input";
     box.rows = 2;
@@ -5257,60 +5334,37 @@ function renderCommentPopover(): void {
     box.value = commentDrafts.get(dk) || "";
     box.addEventListener("input", () => commentDrafts.set(dk, box.value));
     box.addEventListener("keydown", (ev) => {
-      if (ev.key === "Enter" && !ev.shiftKey) { ev.preventDefault(); send.click(); }
+      if (ev.key === "Enter" && !ev.shiftKey) { ev.preventDefault(); commentSendFromPop(pop); }
       else if (ev.key === "Escape") { ev.stopPropagation(); closeCommentPop(); }
-    });
-    send.addEventListener("click", () => {
-      const text = box.value.trim();
-      if (!text || !vscodeApi) return;
-      send.disabled = true;                     // acknowledged before any round-trip
-      send.textContent = "Sending…";
-      if (create) {
-        // the draft survives until commentCreated adopts the thread — a refused create keeps the words
-        vscodeApi.postMessage({ type: "commentCreate", id: sid, uuid: create.uuid, exact: create.exact, text });
-      } else {
-        vscodeApi.postMessage({ type: "commentReply", id: sid, tid: th!.tid, text });
-        const pl = commentPending.get(th!.tid) || [];
-        pl.push({ text, t: Date.now() / 1000 });
-        commentPending.set(th!.tid, pl);
-        commentDrafts.delete(dk);
-        renderCommentPopover();
-      }
     });
     pop.appendChild(box);
     const row = el("div", "cmt-actions");
+    const send = el("button", "cmt-send") as HTMLButtonElement;
+    send.type = "button";
+    send.textContent = create ? "Start thread" : "Send";
+    send.dataset.act = "cmtsend";
     row.appendChild(send);
     if (th) {
       const br = el("button", "cmt-act") as HTMLButtonElement;
       br.type = "button";
       br.textContent = "Break out";
       br.title = "Continue this thread as its own session; it keeps everything it knows";
-      br.addEventListener("click", () => showBreakoutPrompt(sid, th.tid));
+      br.dataset.act = "cmtbreak";
       row.appendChild(br);
       if (th.status === "open") {
         const rs = el("button", "cmt-act") as HTMLButtonElement;
         rs.type = "button";
         rs.textContent = "Resolve";
         rs.title = "Settle this thread: the highlight dims, and replying reopens it";
-        rs.addEventListener("click", () => {
-          rs.disabled = true;
-          rs.textContent = "Resolving…";
-          vscodeApi?.postMessage({ type: "commentResolve", id: sid, tid: th.tid });
-        });
+        rs.dataset.act = "cmtresolve";
         row.appendChild(rs);
       } else {
         const dl = el("button", "cmt-act cmt-del") as HTMLButtonElement;
         dl.type = "button";
         dl.textContent = "Delete";
         dl.title = "Remove this thread and its highlight";
-        const disarm = () => { dl.classList.remove("armed"); dl.textContent = "Delete"; };
-        dl.addEventListener("click", () => {
-          if (!dl.classList.contains("armed")) { dl.classList.add("armed"); dl.textContent = "Really delete?"; return; }
-          vscodeApi?.postMessage({ type: "commentDelete", id: sid, tid: th.tid });
-          closeCommentPop();
-        });
-        dl.addEventListener("pointerleave", disarm);
-        dl.addEventListener("blur", disarm);
+        dl.dataset.act = "cmtdelete";
+        dl.addEventListener("pointerleave", () => { dl.classList.remove("armed"); dl.textContent = "Delete"; });
         row.appendChild(dl);
       }
     }
@@ -5320,7 +5374,8 @@ function renderCommentPopover(): void {
     const open = el("button", "cmt-send") as HTMLButtonElement;
     open.type = "button";
     open.textContent = "Open the session";
-    open.addEventListener("click", () => { closeCommentPop(); setActive(th.tid); });
+    open.dataset.act = "cmtopensession";
+    open.dataset.tid = th.tid;
     row.appendChild(open);
     pop.appendChild(row);
   }
@@ -5331,7 +5386,7 @@ function renderCommentPopover(): void {
   pop.style.left = px + "px";
   pop.style.top = py + "px";
   const msgs = pop.querySelector(".cmt-msgs") as HTMLElement | null;
-  if (msgs) msgs.scrollTop = prevScroll != null ? Math.max(prevScroll, msgs.scrollHeight - msgs.clientHeight) : msgs.scrollHeight;
+  if (msgs) msgs.scrollTop = msgs.scrollHeight;
   if (create || hadFocus || !th || !th.msgs.length) (pop.querySelector(".cmt-input") as HTMLTextAreaElement | null)?.focus();
 }
 
@@ -5906,7 +5961,16 @@ function ensureView(id: string): View {
 // Bring this view's DOM up to date with its session's events: append new ones
 // and re-render a bounded trailing window (cheap), or rebuild fully on a shrink
 // (rewind). Does NOT touch scroll. No-op cost when nothing changed is ~O(TAIL).
+// The wrapper re-anchors comment highlights after EVERY sync (the user 2026-08-13): marks live in
+// the rebuilt DOM, and hanging the re-apply only on inbound messages missed the renders that run
+// off them (a tab switch, a prebuild) — idempotent and ~free for sessions with no threads.
 function syncView(id: string, atBottom?: boolean): View {
+  const v = syncViewInner(id, atBottom);
+  applyCommentMarks(id);
+  return v;
+}
+
+function syncViewInner(id: string, atBottom?: boolean): View {
   // atBottom (passed by appendActive): false ⇒ the user is scrolled UP reading. A compact append must then
   // NOT evict the window top — evicting shifts the content above the viewport, and since the compact path
   // FULL-REBUILDS (clears the DOM, resetting scrollTop), the caller can only restore the position if the
@@ -9047,21 +9111,49 @@ window.addEventListener("message", (e: MessageEvent) => {
     seedEditorQuote(activeId, m.text, typeof m.src === "string" ? m.src : undefined);
   // the editor selection collapsed (deselect / click away) — drop the chip that highlight seeded
   else if (m.type === "editorSelectionCleared") clearEditorCitation(activeId);
-  // comment threads (the user 2026-08-13): the per-session thread frame — store, re-anchor the
-  // highlights, and refresh the popover if it's showing one of these threads
+  // comment threads (the user 2026-08-13): the per-session thread frame — store, prune dead
+  // client-side state, re-anchor the highlights, adopt a parked create ack, refresh the popover
   else if (m.type === "comments" && m.id) {
-    commentThreads.set(String(m.id), (m.threads || []) as CommentThread[]);
-    applyCommentMarks(String(m.id));
-    if (openCommentKey && openCommentKey.sid === m.id) renderCommentPopover();
+    const sid = String(m.id);
+    const threads = (m.threads || []) as CommentThread[];
+    commentThreads.set(sid, threads);
+    const live = new Set(threads.filter((t) => t.status !== "promoted").map((t) => t.tid));
+    for (const k of Array.from(commentPending.keys())) if (!live.has(k)) commentPending.delete(k);
+    for (const k of Array.from(commentDrafts.keys())) if (!k.startsWith("new:") && !live.has(k)) commentDrafts.delete(k);
+    if (pendingAdoptTid && threads.some((t) => t.tid === pendingAdoptTid)) adoptCommentThread(sid, pendingAdoptTid);
+    applyCommentMarks(sid);
+    if (openCommentKey && openCommentKey.sid === sid) {
+      // reading IS seeing: a reply that lands while its popover is open must not dot the mark
+      const th = threads.find((t) => t.tid === openCommentKey!.tid);
+      if (th && th.unread) {
+        th.unread = false;
+        vscodeApi?.postMessage({ type: "commentSeen", id: sid, tid: th.tid });
+        applyCommentMarks(sid);
+      }
+      renderCommentPopover();
+    }
   }
-  // the create ack: adopt exactly the thread this popover made (never a guess), spend its draft
+  // the create ack names the new thread: adopt exactly it (never a guess). The kernel sends the
+  // frame first; if this ack somehow beat it, park the tid and the next frame adopts.
   else if (m.type === "commentCreated" && m.id && m.tid) {
     if (pendingCommentAnchor && pendingCommentAnchor.sid === m.id) {
-      commentDrafts.delete("new:" + pendingCommentAnchor.uuid);
-      pendingCommentAnchor = null;
-      openCommentKey = { sid: String(m.id), tid: String(m.tid) };
-      vscodeApi?.postMessage({ type: "commentSeen", id: String(m.id), tid: String(m.tid) });
-      renderCommentPopover();
+      const tid = String(m.tid);
+      if ((commentThreads.get(String(m.id)) || []).some((t) => t.tid === tid)) adoptCommentThread(String(m.id), tid);
+      else pendingAdoptTid = tid;
+    }
+  }
+  // a reply the kernel refused: drop its optimistic bubble (it must not read as 'still thinking'
+  // forever) and hand the words back for review-and-resend — the toast says why it failed
+  else if (m.type === "commentSendFailed" && m.tid) {
+    const pl = commentPending.get(String(m.tid));
+    if (pl && pl.length) {
+      const lost = pl.pop()!;
+      commentDrafts.set(String(m.tid), lost.text);
+      if (openCommentKey && openCommentKey.tid === m.tid) {
+        const box = document.getElementById("cmt-pop")?.querySelector(".cmt-input") as HTMLTextAreaElement | null;
+        if (box && !box.value.trim()) box.value = lost.text;
+        renderCommentPopover();
+      }
     }
   }
   else if (m.type === "closed") dismissSession(m.id);   // a session died on its own (or the kernel confirms our close)
@@ -9790,12 +9882,42 @@ setupSettings();
       if (grp) reflowQueuedGroup(grp);
     },
     // a comment highlight or its turn badge (the user 2026-08-13): open the thread's popover at the
-    // click. Delegated — marks and badges are re-created on every transcript rebuild.
+    // click. Delegated — marks and badges are re-created on every transcript rebuild — and so is
+    // every popover BUTTON below: the popover's conversation refreshes on comments frames, and a
+    // per-render listener would eat the mid-press click (the click-safety rule).
     cmtopen: (elx) => {
       const tid = elx.dataset.tid;
       if (!tid || !activeId) return;
       const r = elx.getBoundingClientRect();
       openCommentPopover(activeId, tid, Math.min(r.left, window.innerWidth - 380), r.bottom + 6);
+    },
+    cmtclose: () => closeCommentPop(),
+    cmtsend: (elx) => {
+      const pop = elx.closest(".cmt-pop") as HTMLElement | null;
+      if (pop) commentSendFromPop(pop);
+    },
+    cmtbreak: () => {
+      const cur = openCommentThread();
+      if (cur) showBreakoutPrompt(cur.sid, cur.th.tid);
+    },
+    cmtresolve: (elx) => {
+      const cur = openCommentThread();
+      if (!cur) return;
+      (elx as HTMLButtonElement).disabled = true;
+      elx.textContent = "Resolving…";
+      vscodeApi?.postMessage({ type: "commentResolve", id: cur.sid, tid: cur.th.tid });
+    },
+    cmtdelete: (elx) => {
+      const cur = openCommentThread();
+      if (!cur) return;
+      if (!elx.classList.contains("armed")) { elx.classList.add("armed"); elx.textContent = "Really delete?"; return; }
+      vscodeApi?.postMessage({ type: "commentDelete", id: cur.sid, tid: cur.th.tid });
+      closeCommentPop();
+    },
+    cmtopensession: (elx) => {
+      const tid = elx.dataset.tid;
+      closeCommentPop();
+      if (tid) setActive(tid);
     },
     // "copy to composer" on a never-delivered bubble: the echo is the only surviving copy of the text —
     // hand it back for review-and-resend (the same restore the queued ✕ uses). Delegated like qx: the

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2329,3 +2329,93 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .mcp-act:disabled { opacity: 0.55; cursor: default; }
 .mcp-err { flex: 1 1 100%; color: #E5534B; }
 .mcp-none { color: var(--dim); }
+
+/* ── comment threads (the user 2026-08-13) ─────────────────────────────────────────────────────────
+   A highlighted passage wears a <mark> in the romp accent (highlight chrome — var(--accent), never a
+   status color); its turn carries a small count badge so the thread stays reachable even when the
+   rendered text drifts and the exact-match mark can't land. The popover is a pane-local card on the
+   menu vocabulary (#252526, hairline border, 6px radius, the .ctx-menu shadow) — deliberately NOT a
+   dimmed modal: the conversation stays readable beside the thread. */
+mark.cmt-hl {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: inherit;
+  border-bottom: 1px dashed color-mix(in srgb, var(--accent) 55%, transparent);
+  border-radius: 2px;
+  cursor: pointer;
+}
+mark.cmt-hl:hover { background: color-mix(in srgb, var(--accent) 30%, transparent); }
+mark.cmt-hl.resolved { background: rgba(255, 255, 255, 0.06); border-bottom-color: rgba(255, 255, 255, 0.2); }
+mark.cmt-hl.unread { border-bottom-style: solid; }
+mark.cmt-hl.busy { border-bottom-style: solid; animation: cmt-busy-pulse 1.2s ease-in-out infinite; }
+@keyframes cmt-busy-pulse { 50% { background: color-mix(in srgb, var(--accent) 32%, transparent); } }
+
+.turn.has-cmt { position: relative; }
+.cmt-badge {
+  position: absolute; top: 2px; right: 4px; z-index: 5;
+  min-width: 16px; height: 16px; padding: 0 4px;
+  border: 1px solid var(--box-border); border-radius: 8px;
+  background: var(--vscode-menu-background, #252526);
+  color: var(--accent); font-size: 10px; line-height: 14px;
+  cursor: pointer; opacity: 0.75;
+}
+.cmt-badge:hover { opacity: 1; }
+.cmt-badge.unread { border-color: var(--accent); opacity: 1; }
+.cmt-badge.busy { animation: cmt-busy-pulse 1.2s ease-in-out infinite; }
+
+.cmt-pop {
+  position: fixed; z-index: 120; width: 360px; max-width: 94vw;
+  display: flex; flex-direction: column; gap: 6px; padding: 8px;
+  background: var(--vscode-menu-background, #252526);
+  color: var(--vscode-menu-foreground, var(--fg));
+  border: 1px solid var(--box-border); border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  font-size: 12px;
+}
+.cmt-head { display: flex; align-items: center; }
+.cmt-title { font-weight: 600; }
+.cmt-x {
+  margin-left: auto; padding: 0 4px; border: 0; background: none;
+  color: inherit; opacity: 0.6; font-size: 14px; cursor: pointer;
+}
+.cmt-x:hover { opacity: 1; }
+.cmt-quote {
+  padding: 4px 8px; border-left: 2px solid var(--accent); border-radius: 2px;
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 0.92em; opacity: 0.75;
+  display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
+}
+.cmt-msgs { max-height: 45vh; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; }
+.cmt-msg { padding: 5px 8px; border-radius: 6px; line-height: 1.35; overflow-wrap: anywhere; }
+.cmt-msg.you { background: color-mix(in srgb, var(--accent) 14%, transparent); align-self: flex-end; max-width: 92%; white-space: pre-wrap; }
+.cmt-msg.agent { background: rgba(255, 255, 255, 0.05); align-self: flex-start; max-width: 96%; }
+.cmt-msg.agent > *:first-child { margin-top: 0; }
+.cmt-msg.agent > *:last-child { margin-bottom: 0; }
+.cmt-msg.pending { opacity: 0.55; }
+.cmt-dots { display: flex; gap: 4px; padding: 2px 6px; }
+.cmt-dots span {
+  width: 5px; height: 5px; border-radius: 50%; background: var(--accent);
+  animation: cmt-dot-pulse 1.2s ease-in-out infinite;
+}
+.cmt-dots span:nth-child(2) { animation-delay: 0.2s; }
+.cmt-dots span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes cmt-dot-pulse { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
+.cmt-note { font-size: 0.92em; opacity: 0.7; padding: 2px 6px; }
+.cmt-input {
+  width: 100%; box-sizing: border-box; resize: vertical; min-height: 34px;
+  padding: 5px 7px; border: 1px solid var(--box-border); border-radius: 4px;
+  background: rgba(255, 255, 255, 0.05); color: inherit;
+  font: inherit;
+}
+.cmt-input:focus { outline: none; border-color: var(--accent); }
+.cmt-actions { display: flex; gap: 6px; align-items: center; }
+.cmt-send {
+  padding: 3px 10px; border: 0; border-radius: 4px; cursor: pointer;
+  background: var(--accent); color: var(--accent-fg); font: inherit; font-weight: 600;
+}
+.cmt-send:disabled { opacity: 0.55; cursor: default; }
+.cmt-act {
+  padding: 3px 8px; border: 1px solid var(--box-border); border-radius: 4px; cursor: pointer;
+  background: none; color: inherit; font: inherit; opacity: 0.85;
+}
+.cmt-act:hover { opacity: 1; background: rgba(255, 255, 255, 0.06); }
+.cmt-act.cmt-del.armed { border-color: var(--st-blocked-bg, #c94f4f); color: var(--st-blocked-bg, #c94f4f); }


### PR DESCRIPTION
Select text in a session's chat, pick **Comment** on the selection menu, and a side conversation opens in a popover anchored to the highlighted text. Under the hood it is a fork of the session cut at the anchored message (inclusive, via the SDK's `fork_session` + `--resume-session-at`), so the thread's agent holds exactly the context that produced the passage. **Break out** promotes the thread into a full board session.

## How it stays off the board

The fork is a comment *thread*: its reg carries `threadOf` and the `names/` entry, the single discoverability trigger, is withheld. No tab, no lane, no feed cards, no judge pass, no postal identity. Its entire surface is the parent chat's highlight + popover, which is why this is not the hidden-running-session failure mode the 2026-08-11 rule removed: every thread is visible and reachable where it was made, and ending the parent sweeps its threads' CLIs. The reg keeps the thread's CLI under the boot reconcile's orphan reap, and a mid-turn kernel death resumes it like any session.

## Anchoring

Two layers, so a thread is never unreachable: an exact-text `<mark>` re-found on every render (whitespace-tolerant matching in the new pure module `ui/webview/comments.ts`), plus a per-turn count badge keyed on the turn's `data-uuid` that survives text drift. Marks and badges re-apply from a `syncView` wrapper plus the message-dispatch tail and the scroll re-window, and every control (marks, badges, all popover buttons) rides the `document.body` delegate with instant acknowledgement, per the click-safety rule.

## Wire

Thread data rides a per-session `{type:"comments"}` frame with its own `_send_client` dedup slot, never touching the chat delta baseline. Ops (`commentCreate/Reply/Resolve/Delete/Seen/Promote`) are `_drive` ID_OPS keyed on the parent sid. The conversation itself lives in the thread's transcript (authoritative), projected after the fork cut; a streaming thread reads only the transcript tail per push.

## Promotion ordering

`_comment_promote` seeds the judge stores first (`_seed_fork_stores` at the original cut, then one extra episode boundary at the thread's leaf, so neither the copied history nor the already-read popover exchange re-judges as fresh work), and only then does the backend write `names/` — the same ordering contract as `_fork_session`.

## Review

An adversarial multi-lens review ran over the initial commit; the second commit fixes everything it confirmed, notably: the create ack racing its frame (popover closed itself), resolve on a promoted thread opening a kill path into a board session, the projection reading the parent transcript pre-fork, per-render popover listeners eating mid-press clicks, and thread CLIs outliving an ended parent.

## Known limits (v1)

- SDK-backend sessions only; tmux sessions get a loud refusal (the fork contract is the SDK's).
- Remote sessions on a merged dashboard don't get comments frames host-prefixed yet.
- A highlight whose anchor message left the parent transcript (rewind, `/clear`) keeps its thread in the store but loses its visual anchor.

Tests: `tests/test_comment_threads.py` (32 tests: cut semantics, invisibility contract, projection, ops, promotion ordering, sweeps), `ui/webview/comments.test.ts` (behavioral tests for the pure module + source pins for the wiring), a new `_bodies()` entry in `test_injected_voice.py` for the thread opener. Both suites green (pytest 4502, node 1906), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)