### PR TITLE
Comment threads: close the promote race and the review's remaining findings

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4428,7 +4428,12 @@ def _seed_fork_stores(parent_sid, sid, path, cut_uuid):
         if not root:
             return "no transcript records yet — nothing to fork."
         cut = cut_uuid or ad.leaf_uuid
-        cut_rec = ad.by_uuid.get(cut) or {}
+        cut_rec = ad.by_uuid.get(cut)
+        if cut_rec is None:
+            # a named cut that is no longer in the transcript (a /clear re-minted it, a rewind
+            # dropped it) must FAIL, not silently stamp wall-clock time: a `now` floor outranks the
+            # judges on the in-flight segment forever (the diary evidence-time rule)
+            return "the message this branches from isn't in the conversation anymore."
         cut_t = int(em.parse_z(cut_rec.get("timestamp")) or time.time())
         root_rec = ad.by_uuid.get(root) or {}
         root_t = int(em.parse_z(root_rec.get("timestamp")) or cut_t)
@@ -4521,6 +4526,34 @@ def _comment_update(parent_sid, tid, **changes):
                 _save_comments(parent_sid, data)
                 return th
     return None
+
+
+def _comment_update_if(parent_sid, tid, expect, **changes):
+    """Compare-and-set under the lock: apply `changes` only while the row's status is in `expect`.
+    Returns (prior_status, row) — row None on refusal or a missing thread ('' prior). Every op that
+    kills or mutates based on a thread's status decides THROUGH this, never on a pre-lock read: a
+    resolve racing a promote otherwise reads 'open', wins the write, and hands the follow-on delete
+    a freshly promoted BOARD session to kill."""
+    with _comments_lock:
+        data = _load_comments(parent_sid)
+        for th in data.get("threads") or []:
+            if th.get("tid") == tid:
+                prior = th.get("status") or "open"
+                if prior not in expect:
+                    return prior, None
+                th.update(changes)
+                _save_comments(parent_sid, data)
+                return prior, th
+    return "", None
+
+
+def _comment_status_refusal(prior):
+    """The warn text for a CAS refusal, by the status that won."""
+    if prior == "promoted":
+        return "this thread is now its own session; end it like any session."
+    if prior == "promoting":
+        return "this thread is becoming its own session; give it a moment."
+    return "that thread is gone."
 
 
 def _comment_prose_record(r):
@@ -4687,8 +4720,9 @@ def _thread_messages(tsid, cut_uuid):
         return []       # the cut isn't in this transcript (corrupt row?) — an empty popover beats
         #                 presenting the copied parent history as the thread's own conversation
     rows, u, hops = [], leaf, 0
-    # the boot reconcile's continuation notice is romp's, not the user's — it must not render as a
-    # 'you' bubble in the popover (the module is loaded lazily; unavailable → nothing to filter)
+    # romp's own injections are not the user's words: anything wearing the `<!-- romp-` marker
+    # (nudges, notices) plus the boot reconcile's continuation text (marker-less by design) must
+    # not render as a 'you' bubble in the popover
     boot_nudge = getattr(sys.modules.get("romp_sdk_backend"), "BOOT_RESUME_NUDGE", None)
     while u is not None and hops < 500000:
         if u == cut_uuid:
@@ -4696,7 +4730,7 @@ def _thread_messages(tsid, cut_uuid):
         r = by_uuid.get(u) or {}
         if r.get("type") in ("user", "assistant"):
             txt = _comment_msg_text(r)
-            if txt and txt != boot_nudge:
+            if txt and txt != boot_nudge and not (r.get("type") == "user" and "<!-- romp-" in txt):
                 rows.append({"who": "you" if r.get("type") == "user" else "agent",
                              "text": txt[:4000],
                              "t": int(em.parse_z(r.get("timestamp")) or 0)})
@@ -4730,18 +4764,24 @@ def _comments_frame(sid):
     for th in _load_comments(sid).get("threads") or []:
         tsid = str(th.get("sid") or "")
         status = th.get("status") or "open"
-        state = ""
+        state, err = "", ""
         if be and status == "open":
             try:
                 state = be.session_state(tsid)
             except Exception:
                 state = ""
+            try:
+                le = be.launch_error(tsid) if hasattr(be, "launch_error") else None
+                err = str((le or {}).get("text") or "")[:300]   # a thread whose CLI can't start must
+                #                                                 say so, not pulse dots forever
+            except Exception:
+                err = ""
         msgs = [] if status == "promoted" else _thread_messages(tsid, str(th.get("cutUuid") or ""))
         seen = int(th.get("lastSeenT") or 0)
         unread = any(m["who"] == "agent" and m["t"] > seen for m in msgs)
         threads.append({"tid": th.get("tid"), "anchorUuid": th.get("anchorUuid"),
                         "exact": str(th.get("exact") or "")[:500], "status": status,
-                        "createdT": th.get("createdT") or 0, "state": state,
+                        "createdT": th.get("createdT") or 0, "state": state, "error": err,
                         "unread": unread, "promotedName": th.get("promotedName") or "",
                         "msgs": msgs})
     return {"type": "comments", "id": sid, "threads": threads}
@@ -4793,38 +4833,34 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, now=None):
 def _comment_reply(parent_sid, tid, text):
     """Send the user's next message into an existing thread. A resolved thread reopens — replying IS
     the reopen gesture (event-based; no separate arm). Returns an error string or None."""
-    th = _comment_thread(parent_sid, tid)
-    if not th:
-        return "that thread is gone."
-    if (th.get("status") or "open") == "promoted":
-        return "this thread is now the session '%s'; continue there." % (th.get("promotedName") or "")
     be = Sessions.backend_for(parent_sid)
     if not hasattr(be, "fork"):
         return "threads need the SDK backend."
+    prior, th = _comment_update_if(parent_sid, tid, ("open", "resolved"),
+                                   status="open", lastSeenT=int(time.time()))
+    if th is None:
+        if prior == "promoted":
+            row = _comment_thread(parent_sid, tid) or {}
+            return "this thread is now the session '%s'; continue there." % (row.get("promotedName") or "")
+        return _comment_status_refusal(prior)
     tsid = th["sid"]
-    if th.get("status") == "resolved":
+    if prior == "resolved":
         reg = _thread_reg(tsid)
         be.resume(reg.get("name") or ("thread-" + tsid[:8]), tsid)   # alive again; names/ untouched
-        _comment_update(parent_sid, tid, status="open")
     if not be.send(tsid, str(text)):
         return "couldn't reach this thread's session; it may have been removed."
-    _comment_update(parent_sid, tid, lastSeenT=int(time.time()))
     _push_soon()
     return None
 
 
 def _comment_resolve(parent_sid, tid):
     """Settle a thread: status→resolved and its CLI shut down (the reg stays — a later reply
-    resumes it with the conversation intact). The highlight dims; nothing is lost. A PROMOTED
-    thread is refused: its session is a board citizen now, and flipping the stored status would
-    hand the follow-on delete a session to kill (the UI hides Resolve there; the guard holds for
-    a stale client regardless)."""
-    th = _comment_thread(parent_sid, tid)
-    if not th:
-        return "that thread is gone."
-    if (th.get("status") or "open") == "promoted":
-        return "this thread is now the session '%s'; end it like any session." % (th.get("promotedName") or "")
-    _comment_update(parent_sid, tid, status="resolved")
+    resumes it with the conversation intact). The highlight dims; nothing is lost. PROMOTED and
+    PROMOTING threads are refused THROUGH the CAS, never a pre-lock read: the session is (becoming)
+    a board citizen, and a racing status write would hand the follow-on delete a session to kill."""
+    prior, th = _comment_update_if(parent_sid, tid, ("open", "resolved"), status="resolved")
+    if th is None:
+        return _comment_status_refusal(prior)
     be = Sessions.backend_for(parent_sid)
     if hasattr(be, "kill"):
         try:
@@ -4837,20 +4873,26 @@ def _comment_resolve(parent_sid, tid):
 
 def _comment_delete(parent_sid, tid):
     """Remove a thread outright (the popover's delete on a resolved thread). The thread's transcript
-    stays on disk like any conversation history; only romp's row and CLI go."""
-    th = _comment_thread(parent_sid, tid)
-    if not th:
-        return "that thread is gone."
+    stays on disk like any conversation history; only romp's row and CLI go. The status is read and
+    the row removed under ONE lock hold, so the kill decision can never race a promote; a promoted
+    row deletes its highlight but never touches the board session it became."""
+    with _comments_lock:
+        data = _load_comments(parent_sid)
+        rows = data.get("threads") or []
+        th = next((t for t in rows if t.get("tid") == tid), None)
+        if not th:
+            return "that thread is gone."
+        status = th.get("status") or "open"
+        if status == "promoting":
+            return _comment_status_refusal(status)
+        data["threads"] = [t for t in rows if t.get("tid") != tid]
+        _save_comments(parent_sid, data)
     be = Sessions.backend_for(parent_sid)
-    if hasattr(be, "kill") and th.get("status") != "promoted":
+    if hasattr(be, "kill") and status != "promoted":
         try:
             be.kill(th["sid"])
         except Exception:
             pass
-    with _comments_lock:
-        data = _load_comments(parent_sid)
-        data["threads"] = [t for t in data.get("threads") or [] if t.get("tid") != tid]
-        _save_comments(parent_sid, data)
     _push_soon()
     return None
 
@@ -4885,42 +4927,53 @@ def _comment_promote(parent_sid, tid, new_name, now=None):
     nm = (new_name or "").strip()
     if not NAME_RE.match(nm):
         return "session names use letters, digits, . _ - only."
-    th = _comment_thread(parent_sid, tid)
-    if not th:
-        return "that thread is gone."
-    if (th.get("status") or "open") == "promoted":
-        return "already its own session: %s" % (th.get("promotedName") or "")
     be = Sessions.backend_for(parent_sid)
     if not (hasattr(be, "promote_thread") and _sdk_ready()):
         return "threads need the SDK backend."
+    # LATCH first (status='promoting', a CAS under the lock): the seeding below takes real time on a
+    # big parent transcript, and a resolve/delete landing inside that window used to read 'open',
+    # win its status write, and kill the just-promoted board session. With the latch they refuse.
+    prior, th = _comment_update_if(parent_sid, tid, ("open", "resolved"), status="promoting")
+    if th is None:
+        if prior == "promoted":
+            row = _comment_thread(parent_sid, tid) or {}
+            return "already its own session: %s" % (row.get("promotedName") or "")
+        return _comment_status_refusal(prior)
+    def _revert(msg):
+        _comment_update(parent_sid, tid, status=prior)   # the latch never sticks on a failed promote
+        return msg
     now = now or time.time()
     tsid = th["sid"]
     reg = _thread_reg(tsid)
     tpath = _thread_transcript_path(reg, tsid)
     if not os.path.exists(tpath):
-        return "this thread hasn't written its conversation yet; try again in a moment."
+        return _revert("this thread hasn't written its conversation yet; try again in a moment.")
     sess = next((s for s in _sessions(now) if s["sid"] == parent_sid), None)
     parent_path = sess["path"] if sess else str(jd._proj_dir(reg.get("cwd") or "~") / (parent_sid + ".jsonl"))
     err = _seed_fork_stores(parent_sid, tsid, parent_path, str(th.get("cutUuid") or ""))
     if err:
-        return err
+        return _revert(err)
     try:                                            # floor past the settled popover exchange
         ad = em.FileAdapter([tpath], tpath)
         leaf = ad.leaf_uuid
         leaf_t = int(em.parse_z((ad.by_uuid.get(leaf) or {}).get("timestamp")) or now)
         jd.append_episode(tsid, leaf, reg.get("lastSid") or tsid, leaf_t)
     except Exception as e:
-        return "not promoted: sealing the thread's history failed: %s" % e
-    if th.get("status") == "resolved":
+        return _revert("not promoted: sealing the thread's history failed: %s" % e)
+    if prior == "resolved":
         be.resume(nm, tsid)                          # a resolved thread promotes straight to a live session
     bg, fg = _pick_identity_color()
     if not be.promote_thread(tsid, nm, bg, fg):
-        return "couldn't promote this thread."
+        return _revert("couldn't promote this thread.")
     _comment_update(parent_sid, tid, status="promoted", promotedName=nm)
-    be.connect(tsid)
+    started = be.connect(tsid)
     _reveal_chat({"type": "focus", "id": tsid})
     _mark_views_dirty()
     _push_session_now(tsid)
+    if not started:
+        # promoted (the store/name writes stand), but the CLI didn't come up — say so instead of
+        # presenting a dead tab as a healthy one (fail loudly)
+        return "the thread is now the session '%s', but its process didn't start — revive it from its tab." % nm
     return None
 
 
@@ -23158,6 +23211,7 @@ class Handler(BaseHTTPRequestHandler):
                     sys.stderr.write("kill: %s via /kill route\n" % sid)   # kill attribution (the user 2026-07-16)
                     be.kill(sid)
                     _record_death(sid, int(time.time()), "kill")
+                    _comment_kill_all(sid, be)   # its comment threads must not outlive it (the WS endSession twin)
                     _send_to_app("chat", {"type": "closed", "id": sid})
                 _push_all()
                 return self._send(200, json.dumps({"ok": True}), "application/json")

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -284,6 +284,27 @@ class ThreadProjection(CommentBase):
              "alive": True, "threadOf": PARENT, "forkOf": PARENT, "forkAt": "a1"}))
         self.assertEqual(km._thread_messages(THREAD, "a1"), [])
 
+    def test_an_injected_marker_message_is_not_the_users(self):
+        recs = self._thread_records()
+        recs.append({"type": "user", "timestamp": iso(self.now - 80), "uuid": "inj1",
+                     "parentUuid": "ca2", "promptSource": "typed",
+                     "message": {"role": "user",
+                                 "content": "<!-- romp-injected -->Where does this stand?"}})
+        self._seed_thread(records=recs)
+        msgs = km._thread_messages(THREAD, "a1")
+        self.assertNotIn("Where does this stand", json.dumps(msgs))
+
+    def test_frame_surfaces_a_thread_launch_error(self):
+        self._seed_thread()
+        class _Stub:
+            def session_state(self, sid):
+                return ""
+            def launch_error(self, sid):
+                return {"text": "its process couldn't start (a synthetic reason)", "at": 0, "limit": False}
+        km._sdk = lambda: _Stub()
+        fr = km._comments_frame(PARENT)
+        self.assertIn("couldn't start", fr["threads"][0]["error"])
+
     def test_a_compaction_summary_record_is_not_a_message(self):
         recs = self._thread_records()
         recs.append({"type": "user", "timestamp": iso(self.now - 90), "uuid": "cs1",
@@ -446,11 +467,47 @@ class CommentOps(CommentBase):
         err = km._comment_promote(PARENT, tid, "bad name!")
         self.assertIn("letters, digits", err)
 
+    def test_the_promoting_latch_refuses_resolve_delete_and_reply(self):
+        # promote seeds for seconds on a big transcript; ops landing in that window must refuse
+        # THROUGH the CAS, or a racing resolve kills the just-promoted board session
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        km._comment_update(PARENT, tid, status="promoting")
+        calls_before = list(self.be.calls)
+        for op in (km._comment_resolve, km._comment_delete):
+            err = op(PARENT, tid)
+            self.assertIn("becoming its own session", err)
+        err = km._comment_reply(PARENT, tid, "hello?")
+        self.assertIn("becoming its own session", err)
+        self.assertEqual(km._comment_thread(PARENT, tid)["status"], "promoting")
+        self.assertEqual(self.be.calls, calls_before, "no kill, no send — the latch holds")
+
+    def test_a_failed_promote_reverts_the_latch(self):
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        t = self.now - 200
+        self._write(tid, [uline(t, "opener", "cu1"), aline(t + 10, "reply", "ca1", parent="cu1")])
+        (jd.SDKDIR / (tid + ".json")).write_text(json.dumps(
+            {"sid": tid, "name": "thread-x", "cwd": self.cdir,
+             "lastSid": tid, "alive": True, "threadOf": PARENT}))
+        saved = km._seed_fork_stores
+        km._seed_fork_stores = lambda *a, **k: "seeding failed on purpose"
+        try:
+            err = km._comment_promote(PARENT, tid, "sidework")
+        finally:
+            km._seed_fork_stores = saved
+        self.assertIn("seeding failed", err)
+        self.assertEqual(km._comment_thread(PARENT, tid)["status"], "open",
+                         "the latch must never stick on a failed promote")
+
+    def test_seed_fork_stores_refuses_a_vanished_cut(self):
+        p = self.proj / (PARENT + ".jsonl")
+        err = km._seed_fork_stores(PARENT, THREAD, str(p), "gone-uuid")
+        self.assertIn("isn't in the conversation anymore", err)
+
     def test_resolve_refuses_a_promoted_thread_so_delete_can_never_kill_its_session(self):
         _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
         km._comment_update(PARENT, tid, status="promoted", promotedName="sidework")
         err = km._comment_resolve(PARENT, tid)
-        self.assertIn("sidework", err)
+        self.assertIn("its own session", err)
         self.assertEqual(km._comment_thread(PARENT, tid)["status"], "promoted",
                          "resolve must never overwrite promoted — that hands delete a session to kill")
         km._comment_delete(PARENT, tid)                 # removing the highlight row is fine…

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -74,6 +74,12 @@ test("prunePending spends a pending row when its message lands", () => {
   assert.deepEqual(prunePending(pending, msgs), [{ text: "and the cap?", t: 2 }]);
 });
 
+test("prunePending spends one pending per landed message — a repeated reply keeps its bubble", () => {
+  const pending = [{ text: "why?", t: 1 }, { text: "why?", t: 2 }];
+  const msgs = [{ who: "you" as const, text: "why?", t: 5 }];
+  assert.deepEqual(prunePending(pending, msgs), [{ text: "why?", t: 2 }]);
+});
+
 // ── source pins: the wiring (render.ts, kernel.py, sdk_backend.py, styles.css) ─────────────────
 
 const UI = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
@@ -135,6 +141,26 @@ test("ending the parent sweeps its threads' CLIs — no unreachable running sess
 
 test("the projection never reads the parent transcript pre-fork", () => {
   assert.match(KERNEL, /if reg\.get\("forkOf"\):\s*\n\s*return \[\]/);
+});
+
+test("promote latches the row before seeding; racing ops refuse through the CAS", () => {
+  assert.match(KERNEL, /def _comment_update_if\(parent_sid, tid, expect, \*\*changes\):/);
+  assert.match(KERNEL, /_comment_update_if\(parent_sid, tid, \("open", "resolved"\), status="promoting"\)/);
+  assert.match(KERNEL, /def _revert\(msg\):/);
+});
+
+test("the /kill route sweeps comment threads like the WS endSession op", () => {
+  assert.match(KERNEL, /_comment_kill_all\(sid, be\)\s+# its comment threads must not outlive it \(the WS endSession twin\)/);
+});
+
+test("a thread that couldn't start says so instead of pulsing dots forever", () => {
+  assert.match(KERNEL, /be\.launch_error\(tsid\) if hasattr\(be, "launch_error"\) else None/);
+  assert.match(UI, /cmt-note cmt-err/);
+  assert.match(UI, /!th\.error && \(threadBusy\(th\.state\) \|\| pend\.length\)/);
+});
+
+test("Delete is offered only on resolved threads, never mid-promote", () => {
+  assert.match(UI, /\} else if \(th\.status === "resolved"\) \{\s+\/\/ never for 'promoting'/);
 });
 
 test("break out posts commentPromote and acks with a provisional tab", () => {

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -11,9 +11,10 @@ export type CommentThread = {
   tid: string;
   anchorUuid: string;
   exact: string;
-  status: "open" | "resolved" | "promoted";
+  status: "open" | "resolved" | "promoting" | "promoted";
   createdT: number;
   state: string;              // the thread session's live state ("working"/"waiting"/…, "" when dormant)
+  error?: string;             // the thread CLI's launch error, when it could not start
   unread: boolean;            // an agent reply newer than the read watermark
   promotedName: string;       // the board session it became, when status === "promoted"
   msgs: CommentMsg[];
@@ -98,10 +99,24 @@ export function sliceRanges(nodeLens: number[], start: number, end: number):
 }
 
 /** Optimistic pending sends, reconciled against the kernel's frame (the registerOptimistic pattern):
- *  a pending row is spent the moment a server 'you' message with its text appears. Returns the
+ *  each landed 'you' message spends AT MOST ONE pending row with its text — a count-based match, so
+ *  sending the same words twice keeps the second bubble until its own message lands. Returns the
  *  still-pending remainder to render after the server messages. */
 export function prunePending(pending: { text: string; t: number }[], msgs: CommentMsg[]):
     { text: string; t: number }[] {
-  const seen = msgs.filter((m) => m.who === "you").map((m) => normalize(m.text).norm);
-  return pending.filter((p) => !seen.includes(normalize(p.text).norm));
+  const counts = new Map<string, number>();
+  for (const m of msgs) {
+    if (m.who !== "you") continue;
+    const k = normalize(m.text).norm;
+    counts.set(k, (counts.get(k) || 0) + 1);
+  }
+  return pending.filter((p) => {
+    const k = normalize(p.text).norm;
+    const c = counts.get(k) || 0;
+    if (c > 0) {
+      counts.set(k, c - 1);
+      return false;
+    }
+    return true;
+  });
 }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5229,7 +5229,7 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
     n.classList.add("pending");
     list.appendChild(n);
   }
-  if (th.status === "open" && (threadBusy(th.state) || pend.length)) {
+  if (th.status === "open" && !th.error && (threadBusy(th.state) || pend.length)) {
     const dots = el("div", "cmt-dots");
     dots.append(el("span"), el("span"), el("span"));
     list.appendChild(dots);
@@ -5239,12 +5239,19 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
     note.textContent = "This thread hit a prompt it can't answer from here. Break it out to continue.";
     list.appendChild(note);
   }
+  if (th.status === "open" && th.error) {
+    // the CLI behind this thread could not start — dots pulsing forever would be a lie
+    const note = el("div", "cmt-note cmt-err");
+    note.textContent = th.error;
+    list.appendChild(note);
+  }
   list.scrollTop = atTail ? list.scrollHeight : prevScroll;
 }
 
 function commentPopTitle(create: boolean, th: CommentThread | null | undefined): string {
   return create ? "New thread"
     : th!.status === "promoted" ? "Now its own session: " + th!.promotedName
+    : th!.status === "promoting" ? "Breaking out…"
     : th!.status === "resolved" ? "Thread (resolved)" : "Thread";
 }
 
@@ -5358,7 +5365,7 @@ function renderCommentPopover(): void {
         rs.title = "Settle this thread: the highlight dims, and replying reopens it";
         rs.dataset.act = "cmtresolve";
         row.appendChild(rs);
-      } else {
+      } else if (th.status === "resolved") {   // never for 'promoting' — the kernel would refuse anyway
         const dl = el("button", "cmt-act cmt-del") as HTMLButtonElement;
         dl.type = "button";
         dl.textContent = "Delete";
@@ -9146,8 +9153,11 @@ window.addEventListener("message", (e: MessageEvent) => {
     }
   }
   // the create ack names the new thread: adopt exactly it (never a guess). The kernel sends the
-  // frame first; if this ack somehow beat it, park the tid and the next frame adopts.
+  // frame first; if this ack somehow beat it, park the tid and the next frame adopts. The draft is
+  // spent UNCONDITIONALLY off the echoed anchor uuid — a popover closed before the ack otherwise
+  // leaves its sent words to resurface in the next composer on the same passage.
   else if (m.type === "commentCreated" && m.id && m.tid) {
+    if (m.uuid) commentDrafts.delete("new:" + String(m.uuid));
     if (pendingCommentAnchor && pendingCommentAnchor.sid === m.id) {
       const tid = String(m.tid);
       if ((commentThreads.get(String(m.id)) || []).some((t) => t.tid === tid)) adoptCommentThread(String(m.id), tid);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2424,3 +2424,4 @@ mark.cmt-hl.busy { border-bottom-style: solid; animation: cmt-busy-pulse 1.2s ea
 }
 .cmt-act:hover { opacity: 1; background: rgba(255, 255, 255, 0.06); }
 .cmt-act.cmt-del.armed { border-color: var(--st-blocked-bg, #c94f4f); color: var(--st-blocked-bg, #c94f4f); }
+.cmt-note.cmt-err { color: var(--st-blocked-bg, #c94f4f); opacity: 0.9; }


### PR DESCRIPTION
Follow-up to #354, landing the adversarial review's remaining confirmed findings.

The central one is a race: `_comment_promote` seeds judge stores for seconds on a big parent transcript, and a resolve or delete arriving in that window read status `open`, won its status write, and could hand the follow-on delete the just-promoted board session to kill. Every status-dependent mutation now decides through a compare-and-set under the store lock (`_comment_update_if`), and promote latches the row (`status: "promoting"`) before seeding; racing ops refuse, the latch reverts on every failure path, and the popover shows "Breaking out…" with Delete withheld.

The rest of the tail:

- `_seed_fork_stores` refuses a cut uuid that is no longer in the transcript instead of silently stamping wall-clock time (a `now` stamp outranks the judges on the in-flight segment forever).
- The `/kill` HTTP route sweeps a parent's comment threads exactly like the WS `endSession` op.
- The popover projection drops user records wearing the `<!-- romp-` injection marker (nudges/notices must not render as the user's words).
- A thread whose CLI cannot start surfaces its launch error in the popover instead of pulsing dots forever.
- Pending-send reconciliation spends one optimistic row per landed message (a repeated identical reply keeps its bubble).
- A create draft is spent unconditionally off the ack's echoed anchor uuid, so a popover closed before the ack can't resurface already-sent words.
- A promote whose `connect` fails says so rather than presenting a dead tab as healthy.

Tests: 10 new (42 in `test_comment_threads.py`; latch refusals, latch revert, vanished-cut refusal, marker filter, launch-error frame, sweep parity) plus new node pins and a one-for-one `prunePending` case. Both suites green (pytest 4515, node 1914), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)