### PR TITLE
Comment popover: draggable, session-scoped, and anchored for cross-message selections

### DIFF
--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -5,7 +5,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { threadsByAnchor, threadBusy, threadStuck, findExact, sliceRanges, prunePending,
+import { threadsByAnchor, threadBusy, threadStuck, findExact, findAnchorRange, sliceRanges, prunePending,
          type CommentThread } from "./comments";
 
 const th = (over: Partial<CommentThread>): CommentThread => ({
@@ -35,6 +35,26 @@ test("findExact returns null when the text drifted away", () => {
 
 test("findExact never matches an empty selection", () => {
   assert.equal(findExact("anything", "   "), null);
+});
+
+// ── findAnchorRange: longest-prefix fallback for cross-message selections ──────────────────────
+
+test("findAnchorRange returns the full match, not partial, when the text is present", () => {
+  const r = findAnchorRange("Use exponential backoff with jitter.", "exponential backoff");
+  assert.ok(r && !r.partial);
+});
+
+test("findAnchorRange falls back to the longest prefix that lives in this turn", () => {
+  // the selection continued into the NEXT message; only its head is in the anchor turn
+  const hay = "Cap the delay at two minutes for every retry loop.";
+  const r = findAnchorRange(hay, "delay at two minutes for every retry loop. And the jitter stays at ten percent.");
+  assert.ok(r);
+  assert.ok(r!.partial);
+  assert.equal(hay.slice(r!.start, r!.end), "delay at two minutes for every retry loop.");
+});
+
+test("findAnchorRange refuses a trivial remnant rather than mark the wrong words", () => {
+  assert.equal(findAnchorRange("The cap is fine.", "The completely different selection body"), null);
 });
 
 // ── sliceRanges: one global range over many text nodes ─────────────────────────────────────────
@@ -183,6 +203,18 @@ test("a thread fork withholds the names/ entry; promote seeds first, then regist
   assert.match(BACKEND, /def promote_thread\(/);
   assert.match(BACKEND, /reg\.get\("threadOf"\):\s*\n\s*continue/, "live_sessions skips threads — no tab");
   assert.match(KERNEL, /err = _seed_fork_stores\(parent_sid, tsid, parent_path, str\(th\.get\("cutUuid"\) or ""\)\)/);
+});
+
+test("the popover drags by its header and closes when you leave the session", () => {
+  assert.match(UI, /head\.addEventListener\("pointerdown"/);
+  assert.match(UI, /head\.setPointerCapture\(ev\.pointerId\)/);
+  assert.match(UI, /commentPopPos = \{ x, y \};/);
+  assert.match(UI, /if \(openCommentKey && openCommentKey\.sid !== id\) closeCommentPop\(\);/);
+  assert.match(CSS, /\.cmt-head \{[^}]*cursor: grab/s);
+});
+
+test("marks use the prefix-tolerant anchor matcher", () => {
+  assert.match(UI, /findAnchorRange\(nodes\.map\(\(t\) => t\.data\)\.join\(""\), th\.exact\)/);
 });
 
 test("highlight chrome wears the romp accent, popover wears the menu card", () => {

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -82,6 +82,29 @@ export function findExact(hay: string, exact: string): { start: number; end: num
   return { start: map[at], end: map[at + target.length - 1] + 1 };
 }
 
+/** findExact with a LONGEST-PREFIX fallback (the user 2026-08-13, who wanted the comment visible
+ *  in context every time): a selection that spanned several messages anchors to its FIRST turn,
+ *  whose rendered text holds only the selection's head — the full exact-match fails and the thread
+ *  fell back to the tiny badge alone. Binary-search the longest word-prefix that still matches, so
+ *  the portion that lives in the anchored turn highlights. A too-short remnant (under 3 words and
+ *  under 12 characters) stays null — highlighting a stray "The" would mark the wrong thing. */
+export function findAnchorRange(hay: string, exact: string):
+    { start: number; end: number; partial: boolean } | null {
+  const full = findExact(hay, exact);
+  if (full) return { ...full, partial: false };
+  const words = exact.trim().split(/\s+/);
+  let lo = 1, hi = words.length - 1, best: { start: number; end: number; k: number } | null = null;
+  while (lo <= hi) {
+    const k = (lo + hi) >> 1;
+    const r = findExact(hay, words.slice(0, k).join(" "));
+    if (r) { best = { ...r, k }; lo = k + 1; } else hi = k - 1;
+  }
+  if (!best) return null;
+  const matched = words.slice(0, best.k).join(" ");
+  if (best.k < 3 && matched.length < 12) return null;
+  return { start: best.start, end: best.end, partial: true };
+}
+
 /** Split a global [start, end) character range over consecutive text-node lengths into per-node
  *  slices — what the DOM pass wraps in <mark> elements. */
 export function sliceRanges(nodeLens: number[], start: number, end: number):

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -34,7 +34,7 @@ import { mediaSrc, kernelUrl } from "./media";
 import { initStrip, fmtReset } from "./strip";
 import { apiErrorReason } from "./api-error-reason";
 import { mathBlock, mathInline } from "./math";
-import { threadsByAnchor, threadBusy, threadStuck, findExact, sliceRanges, prunePending, type CommentThread } from "./comments";
+import { threadsByAnchor, threadBusy, threadStuck, findAnchorRange, sliceRanges, prunePending, type CommentThread } from "./comments";
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -5141,7 +5141,9 @@ function ensureCommentMark(turn: HTMLElement, th: CommentThread): void {
     const nodes: Text[] = [];
     let n: Node | null;
     while ((n = walker.nextNode())) nodes.push(n as Text);
-    const r = findExact(nodes.map((t) => t.data).join(""), th.exact);
+    // full match, or the longest prefix that lives in THIS turn (a cross-message selection anchors
+    // to its first turn) — so the comment is visible in context, not just on the tiny badge
+    const r = findAnchorRange(nodes.map((t) => t.data).join(""), th.exact);
     if (!r) return;                             // rendered text drifted — the badge still reaches it
     for (const sl of sliceRanges(nodes.map((t) => t.data.length), r.start, r.end)) {
       const t = nodes[sl.idx];
@@ -5321,6 +5323,34 @@ function renderCommentPopover(): void {
   closeBtn.title = "Close (the thread stays on its highlight)";
   closeBtn.dataset.act = "cmtclose";
   head.append(title, closeBtn);
+  // DRAG by the header (the user 2026-08-13, who found the popover's spot inconvenient): pointer
+  // capture, viewport-clamped, and the position writes through to commentPopPos so a later full
+  // rebuild (a status flip) reopens where the user parked it. The header survives in-place
+  // refreshes, so a drag is never cut by a comments frame; a full rebuild mid-drag just ends it.
+  head.title = "Drag to move";
+  head.addEventListener("pointerdown", (ev: PointerEvent) => {
+    if ((ev.target as HTMLElement).closest(".cmt-x")) return;
+    ev.preventDefault();
+    const dx = ev.clientX - pop.offsetLeft, dy = ev.clientY - pop.offsetTop;
+    head.setPointerCapture(ev.pointerId);
+    head.classList.add("dragging");
+    const move = (mv: PointerEvent) => {
+      const x = Math.max(4, Math.min(mv.clientX - dx, window.innerWidth - pop.offsetWidth - 4));
+      const y = Math.max(4, Math.min(mv.clientY - dy, window.innerHeight - 40));
+      pop.style.left = x + "px";
+      pop.style.top = y + "px";
+      commentPopPos = { x, y };
+    };
+    const up = () => {
+      head.classList.remove("dragging");
+      head.removeEventListener("pointermove", move);
+      head.removeEventListener("pointerup", up);
+      head.removeEventListener("pointercancel", up);
+    };
+    head.addEventListener("pointermove", move);
+    head.addEventListener("pointerup", up);
+    head.addEventListener("pointercancel", up);
+  });
   pop.appendChild(head);
   const quote = el("div", "cmt-quote");
   quote.textContent = create ? create.exact : th!.exact;
@@ -8490,6 +8520,10 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
   noteMru(id);
   if (activeId === id && anchor == null && anchorT == null) return; // already active, nothing to do
   closeMetaMenu(); // an open model/effort menu targets the tab we're leaving
+  // a comment popover belongs to its parent session's view — leaving that session closes it (the
+  // user 2026-08-13: it lingered over the next tab's chat); the highlight reopens it any time
+  if (openCommentKey && openCommentKey.sid !== id) closeCommentPop();
+  if (pendingCommentAnchor && pendingCommentAnchor.sid !== id) closeCommentPop();
   pendingAnchorT = anchorT ?? null;
   pendingAnchorKind = anchorKind ?? null;
   // Remember where we were in the tab we're leaving, so we can restore it.

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2376,7 +2376,9 @@ mark.cmt-hl.busy { border-bottom-style: solid; animation: cmt-busy-pulse 1.2s ea
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
   font-size: 12px;
 }
-.cmt-head { display: flex; align-items: center; }
+.cmt-head { display: flex; align-items: center; cursor: grab; user-select: none; }
+.cmt-head.dragging { cursor: grabbing; }
+.cmt-head .cmt-x { cursor: pointer; }
 .cmt-title { font-weight: 600; }
 .cmt-x {
   margin-left: auto; padding: 0 4px; border: 0; background: none;


### PR DESCRIPTION
Three usability fixes for comment threads, from first use:

- **Drag**: the popover drags by its header (pointer capture, viewport-clamped); the parked position writes through so a rebuild reopens it where you left it. The header survives the in-place frame refreshes, so a drag is never cut mid-gesture.
- **Session-scoped**: switching tabs closes the popover — it lingered over the next session's chat. The highlight (or the turn badge) reopens it any time, drafts intact.
- **Cross-message anchors**: a selection spanning several messages anchors to its first turn, where only the selection's head exists in the rendered text — the exact match failed and only the small badge remained. `findAnchorRange` falls back to the longest word-prefix that still matches, so the in-turn portion highlights; remnants under 3 words and 12 characters stay unmarked rather than marking the wrong words.

Tests: three behavioral cases for `findAnchorRange`, pins for the drag wiring, the tab-switch close, and the matcher swap. Suites green (pytest 4515, node 1919), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)