### PR TITLE
Card deep-links land on the work, not the ruling: DONE-ANCHOR is turn-menu-only

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -7193,6 +7193,8 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
     DONE-ANCHOR (the user 2026-06-17): a top resolved at turn-end deep-links to the turn's FINAL segment
     (the rich recap), not an intermediate tool-narration step — so we append that segment to each resolved
     node's trail (the read side anchors a done/blocked card to trail[-1]). The latest close wins.
+    Turn-menu nodes ONLY (the user 2026-08-14): the riders below are ruled from goal history, so the
+    recap holds none of their work — appending it re-aimed their cards' deep-links at the ruling turn.
 
     STEPS-FINISHED CANDIDATES (the user 2026-07-15): nodes whose every child is complete but which carry
     no verdict of their own ride ALONG with the touched menu — bottom-up completion is a nomination to
@@ -7326,9 +7328,18 @@ def _close_turn(store, turn, samples=None, seg_by_id=None):
         if nd["id"] in store["nodes"]:
             nd["closerLookT"] = _newest_filed(store["nodes"], kidmap, nd["id"])
     segs = _segs(turn, store)                          # seam-aware: post-split, the recap lives in the tail
-    if segs:                                           # anchor each resolved (done/blocked) top to the recap
+    if segs:                                           # anchor each resolved (done/blocked) TURN goal to the recap
+        # …but ONLY the turn's own menu (i <= n_touched). The riders behind it — steps-finished,
+        # starved, status-report, lifts — are ruled from GOAL HISTORY: this turn's tail holds none of
+        # their work, and stamping it on their trails re-pointed every read-side anchor (the work
+        # anchor trail[-1], the completed card's summary pin) at the RULING turn's unrelated prose.
+        # A card's summary click landed on shepherding chatter minutes after the real answer that way
+        # (the user 2026-08-14). A rider's organic trail already ends where its work truly happened —
+        # the same evidence-not-ruling principle the verdicts' ev_t anchoring follows.
         recap, resolved = segs[-1]["id"], set(out["done"]) | set(out["block"])
         for i, nd in enumerate(menu, 1):
+            if i > n_touched:                          # menu lists turn goals first, riders after
+                break
             if i in resolved and recap not in nd.setdefault("trail", []):
                 nd["trail"].append(recap)
     if samples is not None and newly:

--- a/tests/test_judge_done_anchor.py
+++ b/tests/test_judge_done_anchor.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""The closer's DONE-ANCHOR appends the recap segment only to goals the turn actually worked on
+(the user 2026-08-14). A rider ruled from goal history — steps-finished, starved, status-report,
+lift — keeps its organic trail, whose tail is where its work truly happened. Before this, every
+resolved rider's trail gained the RULING turn's tail segment, so the read side (work anchor =
+trail[-1]; the completed card's summary pin = newest subtree tail) deep-linked the card to the
+ruling turn's unrelated prose: a summary click landed on later chatter minutes below the answer
+the card was about.
+
+All fixtures synthetic (placeholder UUIDs, invented text).
+"""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+em = SourceFileLoader("romp_event_model_da", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge_da", os.path.join(BIN, "romp-judge")).load_module()
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = NOW - 3600
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": text}, "promptSource": "typed"}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+def _turn():
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / (SID + ".jsonl")
+        recs = [uline(T0, "wire the widget end to end", "u1"),
+                aline(T0 + 20, "Shipped: the widget wiring merged and deployed.", "a1", "u1")]
+        p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        return em.parse_session(str(p), rompuuid=SID, candidate_files=[str(p)], now=NOW)["turns"][0]
+
+
+def _store():
+    return {"rompUuid": SID, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": {},
+            "placements": {}, "status": {}}
+
+
+def _row(kind, ev, src="closer", why=None, at=None):
+    return {"ev_t": ev, "src": src, "kind": kind, **({"why": why} if why else {}),
+            "at": at if at is not None else ev}
+
+
+def _node(s, g, text, parent=None, log=None, **extra):
+    nd = {"id": SID + ":" + g, "text": text,
+          "parentId": (SID + ":" + parent) if parent else None,
+          "nodeComplete": False, "blocked": False, "cleared": False, "trail": [], "t": T0,
+          "log": log or []}
+    nd.update(extra)
+    s["nodes"][nd["id"]] = nd
+    return nd
+
+
+# an OLD segment id, the shape _segs mints (<sid>:<t>:<hash>): the rider's real work, filed long
+# before the audited turn — the anchor the read side must keep pointing at
+WORK_SEG = SID + ":%d:aaaa1111" % (T0 - 500)
+
+
+class DoneAnchorScope(unittest.TestCase):
+    def setUp(self):
+        self._llm = jd.closer_llm
+        self.turn = _turn()
+
+    def tearDown(self):
+        jd.closer_llm = self._llm
+
+    def test_a_turn_menu_node_gains_the_recap(self):
+        # the 2026-06-17 design case, unchanged: the turn's own goal deep-links to its recap tail
+        s = _store()
+        nd = _node(s, "g1", "wire the widget end to end", trail=[WORK_SEG])
+        seg = jd._segs(self.turn, s)[-1]
+        s["placements"][seg["id"]] = nd["id"]          # this turn's work IS g1's work
+        jd.closer_llm = lambda tt, mt, *_a: '{"done": [{"goal": 1, "why": "it shipped"}], "block": []}'
+        newly = jd._close_turn(s, self.turn)
+        self.assertEqual(newly, [nd["id"]])
+        self.assertEqual(nd["trail"][-1], seg["id"],
+                         "a goal resolved from its own turn anchors to that turn's recap")
+
+    def test_a_steps_finished_rider_keeps_its_organic_trail(self):
+        # the observed bug's shape: the goal rides the menu on goal history (here the steps-finished
+        # channel), the closer rules it done on an unrelated turn — its trail must NOT gain that
+        # turn's tail, or the card's work anchor and summary pin re-aim at the ruling turn's prose
+        s = _store()
+        nd = _node(s, "g1", "explain the widget design decisions", trail=[WORK_SEG])
+        _node(s, "g2", "answered all four design questions", parent="g1",
+              log=[_row("done", T0 + 50)], nodeComplete=True, trail=[WORK_SEG])   # filed after the
+        #                                       parent's mint → nominates (the look-stamp default is t)
+        jd.closer_llm = lambda tt, mt, *_a: '{"done": [{"goal": 1, "why": "history shows it delivered"}], "block": []}'
+        newly = jd._close_turn(s, self.turn)
+        self.assertEqual(newly, [nd["id"]], "the rider's done still lands")
+        self.assertEqual(nd["trail"], [WORK_SEG],
+                         "a history-ruled rider keeps its organic trail — the ruling turn's recap "
+                         "holds none of its work")
+
+    def test_a_lift_rider_keeps_its_organic_trail(self):
+        # same guarantee on the lift channel: unblocker ruled the wait over, the closer's rider
+        # ruling must not stamp the audited turn's tail onto the goal
+        s = _store()
+        nd = _node(s, "g1", "explain the widget design decisions", trail=[WORK_SEG],
+                   log=[_row("block", T0 + 100, src="planner", why="add the caveat too?"),
+                        _row("unblock", T0 + 150, src="unblocker",
+                             why="answered in passing — the full explanation landed")])
+        jd.closer_llm = lambda tt, mt, *_a: '{"done": [{"goal": 1, "why": "the history shows the answer shipped"}], "block": []}'
+        newly = jd._close_turn(s, self.turn)
+        self.assertEqual(newly, [nd["id"]], "the lift-ridden done still lands")
+        self.assertEqual(nd["trail"], [WORK_SEG],
+                         "a lift-ridden rider keeps its organic trail")
+
+    def test_a_blocked_turn_menu_node_gains_the_recap_too(self):
+        # block shares the resolved set: the turn's own goal blocking at turn-end anchors its brief
+        # to the recap, as ever
+        s = _store()
+        nd = _node(s, "g1", "wire the widget end to end", trail=[WORK_SEG])
+        seg = jd._segs(self.turn, s)[-1]
+        s["placements"][seg["id"]] = nd["id"]
+        jd.closer_llm = lambda tt, mt, *_a: '{"done": [], "block": [{"goal": 1, "why": "which env?"}]}'
+        jd._close_turn(s, self.turn)
+        self.assertEqual(nd["trail"][-1], seg["id"],
+                         "a goal blocked from its own turn anchors to that turn's recap")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_umbrella_completion.py
+++ b/tests/test_judge_umbrella_completion.py
@@ -183,7 +183,11 @@ class CloserRulesTheCandidate(unittest.TestCase):
         self.assertTrue(top["nodeComplete"])
         self.assertEqual([e for e in top["log"] if e.get("kind") == "done"][0].get("src"), "closer",
                          "the completion has an author and a diary row")
-        self.assertTrue(top["trail"], "DONE-ANCHOR: the ruling turn's recap segment lands on the trail")
+        self.assertEqual(top["trail"], [],
+                         "DONE-ANCHOR is turn-menu-only (the user 2026-08-14): a candidate is ruled "
+                         "from goal history, so the ruling turn's recap holds none of its work — "
+                         "appending it aimed the card's deep-links at unrelated prose. The umbrella "
+                         "keeps its organic trail (none here); its children's tails carry the links.")
         self.assertIn("Run long soak experiment", seen["mt"])
         self.assertIn("is finished", seen["mt"], "the steps-finished note rides the menu")
         self.assertGreaterEqual(s["nodes"][SID + ":g1"].get("closerLookT") or 0, T1,


### PR DESCRIPTION
Clicking a completed card's title or summary line could land far below the relevant part of the conversation, on unrelated newer prose (reported 2026-08-14 from a live card; both click targets landed in later shepherding chatter instead of the answer the card summarized).

**The receiver was innocent.** The kernel's locate-audit log showed every click landing pointer-exact on the uuid it was sent. The wrong uuid was chosen at feed build — and the damage was written earlier still, at the closer's write site.

**Root cause:** when the closer resolves a **rider** — a goal on its menu via the steps-finished, starved, status-report, or lift channel, i.e. ruled from *goal history* rather than the audited turn — `_close_turn` stamped the audited turn's tail segment onto the rider's trail. Every read-side anchor follows the trail: the work anchor is `trail[-1]`, and a completed card's summary pin picks the newest subtree tail. Both re-aimed at the *ruling* turn's prose. The DONE-ANCHOR (2026-06-17) was designed for the turn's **own** goals, whose recap genuinely holds their resolution; the rider channels (2026-07-15, 2026-07-26, 2026-08-13) inherited the append silently.

**Fix:** the recap append stops at `n_touched` — the turn's own menu. Riders keep their organic trails, which already end where their work truly happened. This is the same evidence-not-ruling principle the verdicts' `ev_t` anchoring follows, applied to the spatial anchor.

**Tests:** `tests/test_judge_done_anchor.py` — a turn-menu goal still gains the recap (done and block), and both rider shapes (steps-finished, lift) keep their organic trails; the rider tests fail on the unfixed code. `test_judge_umbrella_completion.py` had codified the old append on a candidate and now asserts the new contract: an umbrella with no trail of its own stays honestly link-less (children's tails carry the links) rather than wrongly linked.

Pre-fix trail rows already written to stores are left as-is (append-only history); new closes anchor correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)