### PR TITLE
The awaiting why moves into the background box, out of the statusline

### DIFF
--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -59,18 +59,25 @@ test("the kernel split happens in the ONE shared derivation (_session_chip), not
   assert.match(KERNEL, /"awaitingBg" if awaiting_why else "ready"\)/);
 });
 
-test("the statusline says WHAT the session is awaiting, beside the chip (the user 2026-08-13)", () => {
+test("the awaiting WHY lives in the background box, not the statusline (the user 2026-08-13, twice)", () => {
   // the kernel ships the why + the live awaited task descriptions in the chat status payload…
   assert.match(KERNEL, /"awaitingWhy": awaiting_why or None,/);
   assert.match(KERNEL, /"awaitingTasks": \(_awaiting_task_descs\(sid, sess\["path"\]\) if awaiting_why else \[\]\),/);
-  // …and the awaitingBg statusline branch renders it: verb stripped (the chip already says Awaiting),
-  // full why + every task description on hover
+  // …the statusline branch stays chip + clock ONLY — the reason line PR #350 put beside the chip
+  // crowded the composer area, and the user moved it the same day
   const branch = RENDER.split('state === "awaitingBg") {')[1].split("} else if")[0];
-  assert.match(branch, /el\("span", "sl-await-why"\)/);
-  assert.match(branch, /why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\)/);
-  assert.match(branch, /det\.title = why \+ \(tasks\.length > 1/);
-  // one ellipsized line that shrinks instead of pushing the right-side cluster off
-  assert.match(STYLES, /\.sl-await-why \{[\s\S]*?min-width: 0;[\s\S]*?text-overflow: ellipsis/);
+  assert.doesNotMatch(branch, /sl-await-why/);
+  assert.doesNotMatch(STYLES, /sl-await-why/);
+  // …and the #bg-tasks box renders it when no tracked tasks claim the box: the same fold treatment
+  // (straw dot, verb-stripped header), expanding to the full why, the awaited items when there are
+  // several, and a plain-words note on what the state means. No Stop — nothing untracked is killable.
+  assert.match(RENDER, /\{ renderAwaitWhy\(host, s \|\| null\); return; \}/);
+  assert.match(RENDER, /"bg-fold-head bg-await"/);
+  assert.match(RENDER, /"Awaiting · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\)/);
+  assert.match(RENDER, /if \(items\.length > 1\)/);
+  assert.match(RENDER, /bg-await-note/);
+  assert.doesNotMatch(RENDER.split("function renderAwaitWhy")[1].split("\n}")[0], /bg-stop/);
+  assert.match(STYLES, /\.bg-fold-head\.bg-await \{ --bgt: var\(--st-awaitbg-bg\); \}/);
 });
 
 test("the timeline lane's awaitingBg why reads the SAME working signal as its badge (same input, 2026-07-03 rule)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -199,7 +199,7 @@ type ChatEvent = (
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
 type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
-interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingTasks?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the statusline shows it beside the Awaiting chip (the user 2026-08-13)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingTasks?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed.
@@ -6941,7 +6941,7 @@ function renderBgTasks() {
   const box = s && s.bgTasks;
   const tasks = (box && box.tasks) || [];
   const count = box ? box.count : 0;
-  if (!count || !tasks.length) { host.style.display = "none"; return; }
+  if (!count || !tasks.length) { renderAwaitWhy(host, s || null); return; }
   host.style.display = "";
   const sid = activeId as string;
   const open = bgFoldOpen.has(sid);
@@ -6987,6 +6987,42 @@ function renderBgTasks() {
     list.appendChild(row);
   }
   host.appendChild(list);
+}
+
+// The Awaiting session's WHY, in the same box when NO tracked tasks claim it (the user 2026-08-13:
+// the reason spent a few hours beside the statusline chip — PR #350 — and crowded the composer area;
+// this box between transcript and composer is where dispatched work has always surfaced). Same fold
+// treatment as the task header: one straw-dotted line, click → the full why, each awaited item when
+// there are several, and a plain-words note on what the state means. No Stop here — an untracked wait
+// (a peer's PR, a build) has no process to kill; tracked run_in_background tasks take the list path
+// above, which carries one Stop per running row.
+function renderAwaitWhy(host: HTMLElement, s: Session | null) {
+  const why = (s && s.status.state === "awaitingBg" && (s.status.awaitingWhy || "").trim()) || "";
+  if (!why || !activeId) { host.style.display = "none"; return; }
+  host.style.display = "";
+  const sid = activeId;
+  const open = bgFoldOpen.has(sid);
+  const head = el("div", "bg-fold-head bg-await" + (open ? " open" : ""));
+  head.dataset.act = "bg-fold"; head.dataset.id = sid;
+  const car = el("span", "bg-caret"); car.textContent = open ? "▾" : "▸"; head.appendChild(car);
+  head.appendChild(el("span", "bg-dot"));
+  const lab = el("span", "bg-fold-label");
+  // the kernel's why leads with the verb ("waiting on a background task: …") — strip it so the
+  // labeled header doesn't stutter; the expanded body keeps the full sentence
+  lab.textContent = "Awaiting · " + why.replace(/^(waiting on|awaiting)\s+/i, "");
+  head.appendChild(lab);
+  host.appendChild(head);
+  if (!open) return;
+  const det = el("div", "bg-detail bg-await-detail");
+  const w = el("div", "bg-await-why"); w.textContent = why; det.appendChild(w);
+  const items = s!.status.awaitingTasks || [];
+  if (items.length > 1) {   // a single description is already the why — list only a real plurality
+    for (const t of items) { const r = el("div", "bg-await-task"); r.textContent = "· " + t; det.appendChild(r); }
+  }
+  const note = el("div", "bg-await-note");
+  note.textContent = "The session is idle until this finishes; it picks back up on its own when the result lands.";
+  det.appendChild(note);
+  host.appendChild(det);
 }
 
 // ---- live "awaiting your input" widgets (structured: radio / checkbox / submit / text) ----
@@ -7855,18 +7891,9 @@ function updateStatusline() {
     timer.id = "work-timer";
     timer.textContent = elapsedMs(s.status.sinceEpoch);
     sl.appendChild(timer);
-    // WHAT it's awaiting, right here in the statusline (the user 2026-08-13: the chip alone said
-    // "Awaiting" and the reason showed nowhere in the chat pane). The kernel's why leads with the
-    // verb ("waiting on a background task: …") and the chip already says Awaiting — strip the verb
-    // so the line doesn't stutter; the hover carries the full why plus every live task description.
-    const why = (s.status.awaitingWhy || "").trim();
-    if (why) {
-      const det = el("span", "sl-await-why");
-      det.textContent = why.replace(/^(waiting on|awaiting)\s+/i, "");
-      const tasks = s.status.awaitingTasks || [];
-      det.title = why + (tasks.length > 1 ? "\n" + tasks.map((t) => "· " + t).join("\n") : "");
-      sl.appendChild(det);
-    }
+    // The WHY renders in the #bg-tasks box between transcript and composer (renderAwaitWhy), not
+    // here — a reason line beside the chip crowded the composer area (the user 2026-08-13, on the
+    // same day's PR #350 that first surfaced it here).
   } else if (s.status.state === "compacting") {
     const c = el("span", "compacting-line");
     c.textContent = "⟳ Compacting context…";

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -449,6 +449,7 @@ body { display: flex; flex-direction: column; }
 .bg-stop:disabled { opacity: 0.55; cursor: default; }
 .bg-fold-head.bg-failed { --bgt: var(--st-blocked-bg); }
 .bg-fold-head.bg-completed { --bgt: var(--st-ready-bg); }
+.bg-fold-head.bg-await { --bgt: var(--st-awaitbg-bg); }   /* the Awaiting why header — straw, like its chip */
 .bg-fold-label { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--fg); }
 /* level 2: a flat list of task LINES (no boxes) BELOW the header, fills the box and scrolls when many */
 .bg-list { flex: 1 1 auto; min-height: 0; overflow-y: auto; overscroll-behavior: contain;
@@ -471,6 +472,10 @@ body { display: flex; flex-direction: column; }
   font: 11px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; color: #cdd9e5;
   white-space: pre-wrap; word-break: break-word; max-height: 220px; overflow: auto; overscroll-behavior: contain; }
 .bg-cmd { color: #9cd2ff; }
+/* the Awaiting why's expanded body: the full sentence, the awaited items, a plain-words note */
+.bg-await-why { font-size: 12px; color: var(--fg); margin: 4px 0 0; }
+.bg-await-task { font-size: 12px; color: var(--dim); margin-top: 3px; }
+.bg-await-note { font-size: 11px; color: var(--dim); opacity: .8; margin-top: 6px; }
 
 #footer {
   position: relative;   /* anchors #composer-resize on the top-edge divider */
@@ -723,11 +728,6 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .chip-idle { background: rgba(255, 255, 255, 0.08); color: var(--dim); }
 .chip-closed { background: rgba(255, 255, 255, 0.07); color: var(--dim); }
 .status-timer { color: var(--dim); font-variant-numeric: tabular-nums; font-size: 0.92em; }
-/* WHAT an awaitingBg session is waiting on, beside the Awaiting chip + clock (the user 2026-08-13).
-   One ellipsized line (full why + task list on hover) — min-width 0 so the flex row can shrink it
-   instead of pushing the right-side cluster off. Same size/color as the timer it sits next to. */
-.sl-await-why { color: var(--dim); font-size: 0.92em; flex: 0 1 auto; min-width: 0;
-                overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* stop/interrupt button beside the state badge (the user 2026-06-19): sends the SAME interrupt as the
    composer's Ctrl+C. It renders ONLY while the session is busy (updateStatusline omits it when idle), so
    it's always the live control — a crisp white square, and ONLY on hover does it reveal the pale-red


### PR DESCRIPTION
The user on #350's statusline why-line, the same day it landed: it doesn't fit there — background work belongs above the composer in the chat itself, where the background-task box already lives, with a way to explain what it is and (where killable) a way to stop it.

- Statusline: back to chip + elapsed clock for awaitingBg; `.sl-await-why` removed.
- `#bg-tasks`: when no tracked tasks claim the box, an Awaiting session renders "Awaiting · why" in the same fold treatment (straw dot, verb-stripped one-liner), expanding to the full why, the awaited items when there are several, and a plain-words note on what the state means. Tracked tasks keep the existing list with per-task Stop; untracked waits get no fake kill button.
- Rides the existing `#bg-tasks` click delegate and `bgFoldOpen` keying — click-safe across re-renders, fold state survives pushes.

Kernel payload (`awaitingWhy`/`awaitingTasks`) unchanged. Test repins in `awaiting-state.test.ts`. Headless screenshot verified collapsed + expanded states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)