### PR TITLE
Fix the empty usage bar: restore spendDet's brace, parse-test every inline JS blob

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20579,7 +20579,7 @@ var SPEND_WINS=[['day','1 day'],['week','1 week'],['month','1 month']];
 function spendDet(u,det){var sp=u&&u.spend;if(!sp||!det)return;
 SPEND_WINS.forEach(function(w){var seg=sp[w[0]];if(!seg||typeof seg.usd!=='number')return;
 (det._spend=det._spend||{})[w[0]]={label:w[1],usd:seg.usd,tok:seg.tok||0,turns:seg.turns||0};});
-if(u.spendSeries&&u.spendSeries.usd)det._spendSeries=u.spendSeries;   // $/hour, for the hover graph (the user 2026-08-13)
+if(u.spendSeries&&u.spendSeries.usd)det._spendSeries=u.spendSeries;}   // $/hour, for the hover graph (the user 2026-08-13)
 // One payload's WINDOW detail for the hover (used/elapsed/reset per window). Detail only, no markup:
 // the rail no longer draws each account's own bars (they aggregate, below), but the tip still tells
 // each host's story from this.

--- a/tests/test_inline_js_parses.py
+++ b/tests/test_inline_js_parses.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Every inline JS blob the kernel serves must PARSE (the user 2026-08-13: an edit ate spendDet's
+closing brace in _LANDING_USAGE_JS, the whole usage script died on one SyntaxError, and the bottom
+bar rendered NOTHING — no test read the blobs as JavaScript, so a broken script shipped green through
+both suites). node --check each _*_JS module attribute — the RUNTIME value, not the source text, so
+Python-level escapes are resolved exactly as the browser receives them. Skipped only where node is
+genuinely absent (GitHub's runners ship it)."""
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the load — the kernel resolves its state root (and runs boot reconcile)
+# at import time; a bare run must never touch real state.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_jsparse", os.path.join(BIN, "romp-kernel")).load_module()
+
+NODE = shutil.which("node")
+
+
+class InlineJsParses(unittest.TestCase):
+    @unittest.skipUnless(NODE, "node not installed on this machine")
+    def test_every_inline_js_blob_parses(self):
+        blobs = {n: v for n, v in vars(km).items() if n.endswith("_JS") and isinstance(v, str)}
+        self.assertGreaterEqual(len(blobs), 10, "the kernel's inline scripts should all be discovered")
+        for name, js in sorted(blobs.items()):
+            with self.subTest(blob=name):
+                with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+                    f.write(js)
+                    path = f.name
+                try:
+                    r = subprocess.run([NODE, "--check", path], capture_output=True, text=True)
+                    self.assertEqual(r.returncode, 0, name + " does not parse:\n" + r.stderr[:2000])
+                finally:
+                    os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The bottom bar showed no usage at all after #349 deployed (the user 2026-08-13): the spendDet edit in _LANDING_USAGE_JS dropped the function's closing brace, the blob stopped parsing, and the whole usage script — bars, API cell, click target — never ran. Data was fine; only the renderer died.

Fix restores the brace. Prevention: a new test loads the kernel and runs node --check over every inline _*_JS blob (17 today), the runtime string exactly as served, so an unparseable inline script fails the suite instead of shipping green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)