### PR TITLE
Branch lineage in the chat: a divider in the fork, a chip on the parent

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14140,7 +14140,29 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                               "ts": iso(boundary["t"]) if boundary.get("t") else None,
                               "clearedAt": boundary.get("t"), "episodes": len(_epi_rows),
                               "dropped": [d.get("text") or "" for d in (_settle.get("settled") or [])] or None})
+    # BRANCH LINEAGE (the user 2026-08-13: branching must SHOW). A session born as a fork carries a
+    # durable forkedFrom in its reg (the one-shot forkOf launch flags say nothing after the init
+    # spends them): a branch DIVIDER event lands right after the branch-point record — everything
+    # above it is history shared with the parent — and the top-level `branch` field survives
+    # windowing. The other direction, `branches`, lists the forks that left FROM this session's own
+    # turns, so the parent shows a chip where each branch departed. Both sides deep-link across.
+    branch = None
+    _ff = (_thread_reg(sid) or {}).get("forkedFrom")   # _thread_reg is the generic sdk-reg reader
+    if isinstance(_ff, dict) and _ff.get("sid"):
+        branch = {"fromSid": str(_ff["sid"]),
+                  "fromName": _name_of(str(_ff["sid"])) or _ff.get("name") or "",
+                  "cut": str(_ff.get("cut") or ""), "t": _ff.get("t") or 0}
+        if branch["cut"]:
+            _at = next((i for i, e in enumerate(events) if e.get("uuid") == branch["cut"]), None)
+            if _at is not None:
+                events.insert(_at + 1, {"kind": "branch", "uuid": "branch:" + branch["cut"],
+                                        "fromSid": branch["fromSid"], "fromName": branch["fromName"],
+                                        "cut": branch["cut"],
+                                        "ts": iso(branch["t"]) if branch.get("t") else None})
+    _be_fk = _sdk()
+    _kids = (_be_fk.fork_children().get(sid) if _be_fk and hasattr(_be_fk, "fork_children") else None) or None
     return {"type": "session", "id": sid, "name": sess["name"], "color": _name_color(sid),
+            "branch": branch, "branches": _kids,
             "cwd": _tilde(_cwd_of(sid) or meta.get("cwd") or ""),   # fixed-at-creation dir; lane tab shows it (the user 2026-06-22)
             # git branch as a TOP-LEVEL session field, NOT just inside the head system event: the status-bar
             # branch + tab tooltip must show for EVERY session, but the system event lives at events[0] and the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2730,6 +2730,7 @@ class SdkBackend:
         self._pending_ask: dict[str, bool] = {}   # sid -> has an ask awaiting answer
         self._live: dict[str, dict] = {}          # sid -> {key -> atom}: the in-memory LIVE TAIL (ahead of disk)
         self._rl_lock = threading.Lock()          # serializes usage.json read-merge-write (_record_rate_limit)
+        self._fork_children_memo = None           # (sdk/ dir mtime_ns, {parent sid: [child lineage]}) — fork_children()
         self.work_key = work_api_key()            # the manager env's API key, claimed out of os.environ
         #   ("" = none): per-session auth injects it via _options; its presence is the "key" half of
         #   the availability the kernel publishes to the picker/gear (the user 2026-08-08)
@@ -3503,6 +3504,15 @@ class SdkBackend:
                "effort": parent.get("effort", DEFAULT_EFFORT),
                "lastSid": parent.get("lastSid") or parent_sid,
                "forkOf": parent_sid, "forkAt": cut_uuid or "", "alive": True}
+        # Durable LINEAGE (the user 2026-08-13: branching must SHOW in the UI): forkOf/forkAt above
+        # are one-shot launch flags, spent the moment the init lands, so the branch point is recorded
+        # separately and forever. A tip fork (no cut) stamps the parent's CURRENT leaf — that is
+        # where the two histories diverge. The chat renders this as the child's branch divider and
+        # the parent's branch chip (build_session `branch`/`branches`).
+        lineage_cut = cut_uuid or last_record_uuid(
+            transcript_path(cwd, parent.get("lastSid") or parent_sid))
+        reg["forkedFrom"] = {"sid": parent_sid, "name": parent.get("name", ""),
+                             "cut": lineage_cut, "t": int(time.time())}
         if thread_of:
             reg["threadOf"] = thread_of
         if parent.get("model") and parent["model"] != "default":
@@ -3927,6 +3937,33 @@ class SdkBackend:
             s.shutdown()
         self._poke()
         return True
+
+    def fork_children(self) -> dict:
+        """{parent sid: [{sid, name, cut, t}, …]} for every session carrying a durable forkedFrom —
+        the parent chat's branch chips. Comment threads are skipped (their anchor is the comment
+        highlight; a PROMOTED thread has threadOf cleared, so it joins here). Memoized on the sdk/
+        dir's mtime: every reg write publishes via os.replace into that dir, bumping it, so the
+        steady state costs one stat instead of a full registry sweep per session build."""
+        d = Path(self.state_dir) / "sdk"
+        try:
+            mt = d.stat().st_mtime_ns
+        except OSError:
+            return {}
+        memo = self._fork_children_memo
+        if memo and memo[0] == mt:
+            return memo[1]
+        out: dict = {}
+        for reg in list_regs(self.state_dir):
+            ff = reg.get("forkedFrom")
+            if not isinstance(ff, dict) or not ff.get("sid") or reg.get("threadOf"):
+                continue
+            out.setdefault(str(ff["sid"]), []).append(
+                {"sid": reg["sid"], "name": reg.get("name", ""),
+                 "cut": ff.get("cut") or "", "t": ff.get("t") or 0})
+        for kids in out.values():
+            kids.sort(key=lambda k: k["t"])
+        self._fork_children_memo = (mt, out)
+        return out
 
     def session_state(self, sid: str) -> str:
         """Live state ('working'/'waiting'/…) for ONE sid, comment threads included — live_sessions

--- a/tests/test_fork_lineage.py
+++ b/tests/test_fork_lineage.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Branch lineage (the user 2026-08-13: branching a session must SHOW in the UI). A fork's reg
+carries a durable forkedFrom record (the one-shot forkOf launch flags are spent at init); the
+child's chat gets a branch divider right after the branch-point record, the parent's chat gets a
+chip on the turn the fork departed from, and both deep-link across. All fixtures SYNTHETIC."""
+import json
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["ROMP_TMUX_AVAILABLE"] = "1"
+os.environ["ROMP_SERVE_TOKEN"] = "testtok"
+em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_fl", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+km._limit_hold = lambda sid: None
+
+PARENT = "11111111-2222-3333-4444-555555555555"
+CHILD = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+THREAD = "99999999-8888-7777-6666-555555555555"
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+class ForkStampsLineage(unittest.TestCase):
+    """sdk_backend.fork(): the durable forkedFrom record."""
+
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        self.claude = tempfile.mkdtemp()
+        os.environ["CLAUDE_CONFIG_DIR"] = self.claude   # transcript_path resolves through this
+        self.be = sb.SdkBackend(Path(self.td), "/bin/true", lambda *a, **k: None)
+        self.cwd = self.td
+        self.be.spawn("parent", self.cwd, sid=PARENT)
+
+    def tearDown(self):
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        shutil.rmtree(self.td, ignore_errors=True)
+        shutil.rmtree(self.claude, ignore_errors=True)
+
+    def _reg(self, sid):
+        return json.loads((Path(self.td) / "sdk" / (sid + ".json")).read_text())
+
+    def test_an_explicit_cut_is_the_recorded_branch_point(self):
+        self.be.fork("child", PARENT, "a1", sid=CHILD)
+        ff = self._reg(CHILD).get("forkedFrom")
+        self.assertEqual(ff["sid"], PARENT)
+        self.assertEqual(ff["cut"], "a1")
+        self.assertEqual(ff["name"], "parent")
+        self.assertGreater(ff["t"], 0)
+
+    def test_a_tip_fork_stamps_the_parents_current_leaf(self):
+        t = int(time.time()) - 60
+        p = Path(sb.transcript_path(self.cwd, PARENT))
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("\n".join(json.dumps(r) for r in [
+            uline(t, "the ask", "u1"), aline(t + 5, "the answer", "a9", parent="u1")]) + "\n")
+        self.be.fork("child", PARENT, "", sid=CHILD)
+        self.assertEqual(self._reg(CHILD)["forkedFrom"]["cut"], "a9",
+                         "no cut given = the histories diverge at the parent's leaf")
+
+    def test_fork_children_indexes_by_parent_and_skips_threads(self):
+        self.be.fork("child", PARENT, "a1", sid=CHILD)
+        self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT)
+        kids = self.be.fork_children().get(PARENT) or []
+        self.assertEqual([k["sid"] for k in kids], [CHILD],
+                         "a comment thread's anchor is its highlight, never a branch chip")
+        self.assertEqual(kids[0]["cut"], "a1")
+
+    def test_a_promoted_thread_joins_the_children(self):
+        self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT)
+        self.assertEqual(self.be.fork_children().get(PARENT), None)
+        self.be.promote_thread(THREAD, "sidework", "#123456", "#ffffff")
+        kids = self.be.fork_children().get(PARENT) or []
+        self.assertEqual([k["sid"] for k in kids], [THREAD])
+        self.assertEqual(kids[0]["name"], "sidework")
+
+
+class BuildSessionLineage(unittest.TestCase):
+    """kernel build_session: the divider event, the top-level branch, the parent's branches."""
+
+    def setUp(self):
+        self._saved = jd.STATE
+        self._saved_proj = jd.PROJECTS
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        jd.PROJECTS = Path(self._td) / "projects"
+        jd._discover_cache.clear()
+        jd._PARSE_CACHE.clear()
+        self.now = int(time.time())
+        self.cdir = str(Path(self._td) / "work")
+        self.proj = jd._proj_dir(self.cdir)
+        self.proj.mkdir(parents=True, exist_ok=True)
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        t = self.now - 600
+        self.records = [uline(t, "how should the retry loop back off?", "u1"),
+                        aline(t + 5, "Use exponential backoff.", "a1", parent="u1"),
+                        uline(t + 60, "and the cap?", "u2", parent="a1"),
+                        aline(t + 65, "Cap the delay at two minutes.", "a2", parent="u2")]
+        for sid, name in ((PARENT, "parent"), (CHILD, "child")):
+            (jd.NAMES / sid).write_text("%s\t%s" % (name, self.cdir))
+            (self.proj / (sid + ".jsonl")).write_text(
+                "\n".join(json.dumps(r) for r in self.records) + "\n")
+        (jd.SDKDIR / (CHILD + ".json")).write_text(json.dumps(
+            {"sid": CHILD, "name": "child", "cwd": self.cdir, "lastSid": CHILD, "alive": True,
+             "forkedFrom": {"sid": PARENT, "name": "parent", "cut": "a1", "t": self.now - 300}}))
+        self._saved_sdk = km._sdk
+        kids = {PARENT: [{"sid": CHILD, "name": "child", "cut": "a1", "t": self.now - 300}]}
+
+        class FakeBe:
+            def fork_children(self):
+                return kids
+
+            def owns(self, sid):
+                return False
+
+            def __getattr__(self, name):        # every other backend accessor answers "nothing"
+                return lambda *a, **k: None
+
+        self._fake_be = FakeBe()
+        km._sdk = lambda: self._fake_be
+
+    def tearDown(self):
+        km._sdk = self._saved_sdk
+        jd._rebind_state(self._saved)
+        jd.PROJECTS = self._saved_proj
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def test_the_child_gets_its_divider_right_after_the_branch_point(self):
+        m = km.build_session(CHILD, self.now, tmux={})
+        self.assertEqual(m["branch"]["fromSid"], PARENT)
+        self.assertEqual(m["branch"]["fromName"], "parent")
+        evs = m["events"]
+        at = next(i for i, e in enumerate(evs) if e.get("uuid") == "a1")
+        self.assertEqual(evs[at + 1]["kind"], "branch",
+                         "the divider sits right after the branch-point record")
+        self.assertEqual(evs[at + 1]["uuid"], "branch:a1")
+        self.assertEqual(evs[at + 1]["fromName"], "parent")
+
+    def test_the_parent_gets_its_children_list(self):
+        m = km.build_session(PARENT, self.now, tmux={})
+        self.assertIsNone(m["branch"], "the parent is not itself a fork")
+        self.assertEqual([k["sid"] for k in m["branches"]], [CHILD])
+        self.assertEqual(m["branches"][0]["cut"], "a1")
+
+    def test_an_unforked_session_carries_no_lineage(self):
+        (jd.SDKDIR / (CHILD + ".json")).write_text(json.dumps(
+            {"sid": CHILD, "name": "child", "cwd": self.cdir, "lastSid": CHILD, "alive": True}))
+        km._sdk = lambda: None
+        m = km.build_session(CHILD, self.now, tmux={})
+        self.assertIsNone(m["branch"])
+        self.assertIsNone(m["branches"])
+        self.assertFalse(any(e.get("kind") == "branch" for e in m["events"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/fork-session.test.ts
+++ b/ui/webview/fork-session.test.ts
@@ -61,3 +61,34 @@ test("kernel: forkSession is a session op; seeding precedes discoverability; the
   // …and the names/ entry is written LAST (it is the discoverability trigger)
   assert.match(BACKEND, /write_reg\(self\.state_dir, sid, reg\)[\s\S]{0,400}write_name\(self\.state_dir, sid, name, cwd, bg, fg\)[\s\S]{0,200}append_state\(self\.state_dir, sid, "waiting"\)/);
 });
+
+// ── branch lineage (the user 2026-08-13: branching must SHOW) ───────────────────────────────────
+
+test("a forked session renders its branch divider, deep-linked to the parent", () => {
+  assert.match(RENDER, /\| \{ kind: "branch"; fromSid\?: string; fromName\?: string; cut\?: string/);
+  assert.match(RENDER, /if \(ev\.kind === "branch"\) \{/);
+  assert.match(RENDER, /label\.dataset\.act = "branchjump"/);
+  assert.match(RENDER, /"Branched from " \+ \(ev\.fromName \|\| "another session"\)/);
+});
+
+test("the parent wears a chip where each branch departed, jumping to the child's divider", () => {
+  assert.match(RENDER, /function applyBranchChips\(sid: string, v: View\)/);
+  assert.match(RENDER, /chip\.dataset\.cut = "branch:" \+ k\.cut/);
+  assert.match(RENDER, /applyBranchChips\(sid, v\);\s+\/\/ same driver, same hooks/);
+  assert.match(RENDER, /branchjump: \(elx\) =>/);
+});
+
+test("kernel persists lineage durably and serves it on the session payload", () => {
+  // forkOf/forkAt are one-shot launch flags — forkedFrom is the durable record
+  assert.match(BACKEND, /reg\["forkedFrom"\] = \{"sid": parent_sid, "name": parent\.get\("name", ""\)/);
+  assert.match(BACKEND, /lineage_cut = cut_uuid or last_record_uuid\(/);
+  assert.match(BACKEND, /def fork_children\(self\)/);
+  assert.match(KERNEL, /"branch": branch, "branches": _kids,/);
+  assert.match(KERNEL, /"kind": "branch", "uuid": "branch:" \+ branch\["cut"\]/);
+});
+
+test("branch chrome wears the accent, like every highlight", () => {
+  const css = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+  assert.match(css, /\.branch-divider::before, \.branch-divider::after \{[^}]*var\(--accent\)/s);
+  assert.match(css, /\.branch-chip \{[^}]*color: var\(--accent\)/s);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -145,6 +145,9 @@ type ChatEvent = (
   // expand (loadEpisode → chatEpisode, cached per boundary), so the cleared history stays one click away
   // instead of vanishing. `uuid` is "clear:<episode head>" — stable across pushes (the fold key).
   | { kind: "clear"; clearedAt?: number; episodes?: number; ts?: string; uuid?: string; dropped?: string[] }
+  // the BRANCH divider (the user 2026-08-13): this session forked off another at `cut` — everything
+  // above the divider is history shared with the parent. Clicking jumps to the parent at that spot.
+  | { kind: "branch"; fromSid?: string; fromName?: string; cut?: string; ts?: string; uuid?: string }
   // LIVE /clear in progress (kernel-driven, event-based off the SDK backend's clearing bracket): an
   // animated "Clearing conversation…" element between the /clear delivery and the fresh transcript
   // landing — a stretch that otherwise has NO observable state and used to render as a dead gap, then
@@ -210,7 +213,7 @@ interface BgTasks { count: number; tasks: BgTask[]; }
 // kernel ships only the last WIRE_TAIL events (headFrom > 0) to keep startup light; older history streams in
 // on scroll-back (loadOlder → chatHead prepends, lowering headFrom). headFrom 0 = the whole transcript is
 // resident. chatTail's `from` is GLOBAL and mapped through headFrom.
-interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; workTree?: { dir: string; branch: string } | null; headFrom?: number; headTotal?: number; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; notify?: boolean; }
+interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; workTree?: { dir: string; branch: string } | null; headFrom?: number; headTotal?: number; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; notify?: boolean; branch?: { fromSid: string; fromName: string; cut: string; t: number } | null; branches?: { sid: string; name: string; cut: string; t: number }[] | null; }
 
 const vscodeApi =
   typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
@@ -1908,6 +1911,23 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
   if (ev.kind === "compacting") return renderCompacting();
   if (ev.kind === "clearing") return renderClearing();
   if (ev.kind === "clear") return renderClear(ev);
+  if (ev.kind === "branch") {
+    // the branch divider: everything above is history shared with the parent session; the label
+    // deep-links to the parent AT the branch point (data-uuid there is the cut record itself)
+    const turn = el("div", "turn turn-branchmark");
+    const line = el("div", "branch-divider");
+    const label = el("button", "branch-label") as HTMLButtonElement;
+    label.type = "button";
+    label.dataset.act = "branchjump";
+    if (ev.fromSid) label.dataset.sid = ev.fromSid;
+    if (ev.cut) label.dataset.cut = ev.cut;
+    label.textContent = "Branched from " + (ev.fromName || "another session")
+      + " · the conversation above is shared";
+    label.title = "Open " + (ev.fromName || "the parent session") + " at the branch point";
+    line.appendChild(label);
+    turn.appendChild(line);
+    return turn;
+  }
   if (ev.kind === "reconnecting") return renderReconnecting(ev);
   if (ev.kind === "retrying") return renderRetrying(ev);
   if (ev.kind === "retried") return renderRetried(ev);
@@ -5090,6 +5110,7 @@ document.addEventListener("mousedown", (ev) => {
 function applyCommentMarks(sid: string): void {
   const v = views.get(sid);
   if (!v) return;
+  applyBranchChips(sid, v);   // same driver, same hooks: branch chips re-anchor with the marks
   const threads = commentThreads.get(sid) || [];
   const have = new Set(threads.map((t) => t.tid));
   for (const old of Array.from(v.el.querySelectorAll("mark.cmt-hl"))) {
@@ -5105,6 +5126,35 @@ function applyCommentMarks(sid: string): void {
     if (!turn) continue;                       // windowed out — the mark returns when the turn does
     ensureCommentBadge(turn, list);
     for (const th of list) ensureCommentMark(turn, th);
+  }
+}
+
+/** The parent side of a branch (the user 2026-08-13): a small "↳ <name>" chip on the turn a fork
+ *  departed from, deep-linking into the branched session at its divider. Idempotent, applied on the
+ *  same hooks as the comment marks (the DOM it lives in rebuilds constantly). */
+function applyBranchChips(sid: string, v: View): void {
+  const kids = (sessions.get(sid)?.branches || []) as { sid: string; name: string; cut: string }[];
+  for (const box of Array.from(v.el.querySelectorAll(".branch-chips"))) {
+    for (const c of Array.from(box.children)) {
+      if (!kids.some((k) => k.sid === (c as HTMLElement).dataset.sid)) c.remove();
+    }
+    if (!box.children.length) box.remove();
+  }
+  for (const k of kids) {
+    if (!k.cut) continue;
+    const turn = v.el.querySelector(`.turn[data-uuid="${cssEscape(k.cut)}"]`) as HTMLElement | null;
+    if (!turn || turn.querySelector(`.branch-chip[data-sid="${cssEscape(k.sid)}"]`)) continue;
+    turn.classList.add("has-cmt");             // the comment badge's positioning contract
+    let box = turn.querySelector(":scope > .branch-chips") as HTMLElement | null;
+    if (!box) { box = el("div", "branch-chips"); turn.appendChild(box); }
+    const chip = el("button", "branch-chip") as HTMLButtonElement;
+    chip.type = "button";
+    chip.dataset.act = "branchjump";
+    chip.dataset.sid = k.sid;
+    chip.dataset.cut = "branch:" + k.cut;      // the child's divider carries this uuid — land on it
+    chip.textContent = "↳ " + (k.name || "fork");
+    chip.title = "A session branched from this message: " + (k.name || k.sid) + ". Click to open it there.";
+    box.appendChild(chip);
   }
 }
 
@@ -10001,6 +10051,14 @@ setupSettings();
       const tid = elx.dataset.tid;
       closeCommentPop();
       if (tid) setActive(tid);
+    },
+    // a branch divider (child side) or branch chip (parent side): jump to the other end of the
+    // branch, landing on the branch-point turn via the deep-link anchor machinery
+    branchjump: (elx) => {
+      const sid = elx.dataset.sid;
+      if (!sid) return;
+      if (!sessions.get(sid)) { warnToast("That session isn't on this dashboard right now."); return; }
+      setActive(sid, elx.dataset.cut || undefined);
     },
     // "copy to composer" on a never-delivered bubble: the echo is the only surviving copy of the text —
     // hand it back for review-and-resend (the same restore the queued ✕ uses). Delegated like qx: the

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2427,3 +2427,35 @@ mark.cmt-hl.busy { border-bottom-style: solid; animation: cmt-busy-pulse 1.2s ea
 .cmt-act:hover { opacity: 1; background: rgba(255, 255, 255, 0.06); }
 .cmt-act.cmt-del.armed { border-color: var(--st-blocked-bg, #c94f4f); color: var(--st-blocked-bg, #c94f4f); }
 .cmt-note.cmt-err { color: var(--st-blocked-bg, #c94f4f); opacity: 0.9; }
+
+/* ── branch lineage (the user 2026-08-13: branching must show) ────────────────────────────────────
+   The child's divider marks where its history splits from the parent's — an accent hairline with a
+   clickable label that jumps to the parent at the branch point. The parent wears a small chip on
+   the departed-from turn, jumping the other way. Accent = highlight chrome, per the accent rule. */
+.turn-branchmark { padding: 2px 0; }
+.branch-divider {
+  display: flex; align-items: center; gap: 8px;
+}
+.branch-divider::before, .branch-divider::after {
+  content: ""; flex: 1; height: 1px;
+  background: color-mix(in srgb, var(--accent) 45%, transparent);
+}
+.branch-label {
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  border-radius: 10px; padding: 1px 10px; cursor: pointer;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: inherit; font: inherit; font-size: 0.82em; opacity: 0.85;
+}
+.branch-label:hover { opacity: 1; background: color-mix(in srgb, var(--accent) 22%, transparent); }
+.branch-chips {
+  position: absolute; top: 2px; right: 24px; z-index: 5;
+  display: flex; gap: 4px;
+}
+.cmt-badge ~ .branch-chips, .turn:has(> .cmt-badge) .branch-chips { right: 28px; }
+.branch-chip {
+  height: 16px; padding: 0 6px; border: 1px solid var(--box-border); border-radius: 8px;
+  background: var(--vscode-menu-background, #252526);
+  color: var(--accent); font-size: 10px; line-height: 14px;
+  cursor: pointer; opacity: 0.75; white-space: nowrap;
+}
+.branch-chip:hover { opacity: 1; border-color: var(--accent); }

--- a/vscode-extension/src/tab-menu-flags.test.ts
+++ b/vscode-extension/src/tab-menu-flags.test.ts
@@ -36,7 +36,7 @@ test("each toggle item carries an icon (slashed when off) and a sub-description"
 });
 
 test("the menu adds the notification bell toggle — inverted polarity: `notify` true is the ENABLED state (the user 2026-07-28)", () => {
-  assert.match(SRC, /notify\?: boolean; \}/);                       // rides Session like the other two flags
+  assert.match(SRC, /notify\?: boolean;/);                          // rides Session like the other two flags
   assert.match(SRC, /notify: \("notify" in msg\) \? !!msg\.notify/);  // absorbed + carried across pushes
   assert.match(SRC, /const onBell = !!\(s && s\.notify\);/);
   // the icon slashes on !onBell (bell OFF), while feed/mail slash on their own off-flags being TRUE


### PR DESCRIPTION
Branching a session now shows, both ways:

- **In the fork**: a branch divider sits right after the branch-point record — "Branched from *parent* · the conversation above is shared" — and clicking it opens the parent at that exact message (the deep-link anchor machinery; the divider's own uuid is `branch:<cut>`).
- **In the parent**: the turn a fork departed from wears a small "↳ *child*" chip, jumping onto the fork's divider. Multiple forks from one turn stack in a chip row. A promoted comment thread joins identically, its branch point being the anchored message.

Mechanics: `forkOf`/`forkAt` are one-shot launch flags spent at the init, so `fork()` stamps a durable `forkedFrom {sid, name, cut, t}` in the reg — a tip fork records the parent's current leaf, where the histories actually diverge. `build_session` serves `branch` (top-level, windowing-proof, plus the divider event inserted after the cut record) and `branches` (from the backend's `fork_children()` index, memoized on the sdk/ dir mtime so the steady state is one stat). Chips and dividers re-anchor on the same hooks as the comment marks; jumps go through the delegated `branchjump` action (click-safe).

Comment threads themselves stay chip-less by design — their anchor is the highlight — until broken out.

Tests: `tests/test_fork_lineage.py` (fork stamps lineage, tip-fork leaf resolution, children index skips threads and adopts promoted ones, build_session divider placement + parent list + no-lineage null case) plus source pins in `fork-session.test.ts`. Suites green (pytest 4534, node 1931), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)