### PR TITLE
comment: the frame headers need no VS Code allowlist (follow-up to #337)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -22733,10 +22733,11 @@ class Handler(BaseHTTPRequestHandler):
         # Framing gate (clickjacking): the authenticated dashboard must not be loadable in a
         # cross-origin frame, or a hostile same-site loopback page (the same attacker the cookie
         # Origin gate below defends against) could frame it and drive it invisibly. SAMEORIGIN keeps
-        # the dashboard's own same-origin sub-frames (/chat, /feed) working. NOTE: the VS Code
-        # webview loads the dashboard from a vscode-webview:// origin — if that surface is still
-        # needed it must be added to a frame-ancestors allowlist; confirm against every shipped
-        # client (webview / phone / tailnet) before relying on this.
+        # the dashboard's own same-origin sub-frames (/chat, /feed) working, and 'self' is tight
+        # enough to need no allowlist: the VS Code panes are extension-authored webviews that load
+        # their bundle via asWebviewUri and reach the kernel only over connect-src (fetch + WS) —
+        # they never frame this origin as a document, and neither header applies to fetch/XHR/WS.
+        # Phone and tailnet frame the kernel's own origin, which 'self' permits.
         self.send_header("X-Frame-Options", "SAMEORIGIN")
         self.send_header("Content-Security-Policy", "frame-ancestors 'self'")
         for k, v in (headers or {}).items():


### PR DESCRIPTION
Follow-up to your review on #337 — you flagged that the new `_send` comment warns of a VS Code break that can't happen, and you were right.

The comment claimed the webview might need a `frame-ancestors` allowlist entry. It can't: the panes are extension-authored webviews that load their bundle via `asWebviewUri` and reach the kernel only over `connect-src` (fetch + WebSocket). `X-Frame-Options` and `frame-ancestors` gate document framing only — no effect on fetch/XHR/WS, and a WS handshake is never subject to XFO. Phone and tailnet frame the kernel's own origin, which `'self'` permits.

Comment only, no behaviour change. `test_kernel_auth_hardening` and `test_kernel_ws_auth` pass.

Thanks for the thorough trace on #337 — the false premise was mine and the correction is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)