### PR TITLE
Token counts at 3 significant figures on the bar and hover

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20587,9 +20587,12 @@ function hasBars(u){return !!(u&&(u.fiveHour||u.sevenDay||u.fable));}
 // once (the user 2026-08-08), so presence of the windows is the whole test. strip.ts carries the same
 // branch; the two copies must stay in step (rail-spend pins).
 function hasSpend(u){return !!(u&&u.spend&&(u.spend.day||u.spend.fiveHour));}
-function fmtTok(n){if(n>=1e9)return (n/1e9).toFixed(1).replace(/\.0$/,'')+'B';
-if(n>=1e6)return (n/1e6).toFixed(1).replace(/\.0$/,'')+'M';
-if(n>=1e3)return (n/1e3).toFixed(1).replace(/\.0$/,'')+'k';return String(n);}
+// 3 significant figures at every magnitude (the user 2026-08-13: a bare '1B tok' hides a third of a
+// billion tokens) — 1.32B / 13.2B / 132B, trailing zeros kept so the precision reads as meant.
+function fmtSig3(v){return v.toFixed(v>=100?0:v>=10?1:2);}
+function fmtTok(n){if(n>=1e9)return fmtSig3(n/1e9)+'B';
+if(n>=1e6)return fmtSig3(n/1e6)+'M';
+if(n>=1e3)return fmtSig3(n/1e3)+'k';return String(n);}
 function fmtUsd(v){return '$'+String(Math.round(v));}   // whole dollars everywhere — no cents (the user 2026-08-09)
 // pay-per-token has no reset windows (the user 2026-08-13): the key's story is 1 day / 1 week / 1 month.
 // fiveHour/sevenDay fallbacks remain readable from older remote kernels (version skew) via day||fiveHour.

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -205,3 +205,15 @@ test("every tip string carries data — the narration is gone and stays gone", (
   assert.ok(!code.includes("click the bars"), "the short hint replaced it");
   assert.ok(code.includes("window reset '+esc(v.ago)+'; no reading since"), "the rolled note keeps only its facts");
 });
+
+test("token counts carry 3 significant figures, and both fmtTok twins share the formula (the user 2026-08-13)", () => {
+  const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
+  // one adaptive-decimals helper in each copy — 1.32B / 13.2B / 132B, trailing zeros kept
+  assert.ok(usageJS.includes("function fmtSig3(v){return v.toFixed(v>=100?0:v>=10?1:2);}"));
+  assert.ok(usageJS.includes("if(n>=1e9)return fmtSig3(n/1e9)+'B';"));
+  assert.match(STRIP, /return v\.toFixed\(v >= 100 \? 0 : v >= 10 \? 1 : 2\);/);
+  assert.match(STRIP, /if \(n >= 1e9\) return fmtSig3\(n \/ 1e9\) \+ "B";/);
+  // the old 1-decimal + strip-trailing-zero form is gone from both
+  assert.ok(!usageJS.includes("toFixed(1).replace"));
+  assert.ok(!STRIP.includes('toFixed(1).replace'));
+});

--- a/ui/webview/strip.test.ts
+++ b/ui/webview/strip.test.ts
@@ -6,7 +6,18 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { usageColor, fmtAgo, fmtReset, fmtUsd, usageWindows, apiCell, STRIP_PANES } from "./strip";
+import { usageColor, fmtAgo, fmtReset, fmtUsd, fmtTok, usageWindows, apiCell, STRIP_PANES } from "./strip";
+
+test("fmtTok: 3 significant figures at every magnitude (the user 2026-08-13)", () => {
+  assert.equal(fmtTok(1_318_619_909), "1.32B");
+  assert.equal(fmtTok(13_200_000_000), "13.2B");
+  assert.equal(fmtTok(132_000_000_000), "132B");
+  assert.equal(fmtTok(1_300_000_000), "1.30B");   // trailing zero KEPT — the precision is the point
+  assert.equal(fmtTok(433_181_617), "433M");
+  assert.equal(fmtTok(4_330_000), "4.33M");
+  assert.equal(fmtTok(9_990), "9.99k");
+  assert.equal(fmtTok(999), "999");               // below 1k the raw count already carries 3 figures
+});
 
 test("usageColor mirrors the rail's green/amber/red ramp", () => {
   assert.equal(usageColor(0), "#54B204");
@@ -173,8 +184,8 @@ test("apiCell arms on the spend windows' presence and carries 1 day + 1 month", 
     "the collapsed cell shows 1 day + 1 month only — 1 week lives in the hover");
   assert.deepEqual(cell!.segs.map((s) => fmtUsd(s.usd)), ["$12", "$88"], "whole dollars, no cents");
   assert.match(cell!.title, /^API-key spend\n/);
-  assert.match(cell!.title, /1 week — \$40 · 9M tok · 21 turns/, "the hover keeps the full breakdown");
-  assert.match(cell!.title, /1 day — \$12 · 3\.5M tok · 5 turns/);
+  assert.match(cell!.title, /1 week — \$40 · 9\.00M tok · 21 turns/, "the hover keeps the full breakdown");
+  assert.match(cell!.title, /1 day — \$12 · 3\.46M tok · 5 turns/);   // 3 sig figs (the user 2026-08-13)
 });
 
 test("an older kernel's fiveHour window still arms the cell (version skew)", () => {

--- a/ui/webview/strip.ts
+++ b/ui/webview/strip.ts
@@ -84,10 +84,16 @@ export function usageWindows(usage: any, nowS: number): UsageWindow[] {
   return out;
 }
 
+// 3 significant figures at every magnitude (the user 2026-08-13: a bare "1B tok" hides a third of a
+// billion tokens) — 1.32B / 13.2B / 132B, trailing zeros kept so the precision reads as meant.
+// Twin of the kernel rail's fmtTok; the two must stay in step (rail-spend pins).
+function fmtSig3(v: number): string {
+  return v.toFixed(v >= 100 ? 0 : v >= 10 ? 1 : 2);
+}
 export function fmtTok(n: number): string {
-  if (n >= 1e9) return (n / 1e9).toFixed(1).replace(/\.0$/, "") + "B";
-  if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
-  if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "k";
+  if (n >= 1e9) return fmtSig3(n / 1e9) + "B";
+  if (n >= 1e6) return fmtSig3(n / 1e6) + "M";
+  if (n >= 1e3) return fmtSig3(n / 1e3) + "k";
   return String(n);
 }
 


### PR DESCRIPTION
"1B tok" hid a third of a billion tokens. fmtTok in both copies (kernel _LANDING_USAGE_JS and ui/webview/strip.ts) now formats to 3 significant figures with adaptive decimals — 1.32B / 13.2B / 132B, trailing zeros kept. Unit test on real values, twin-sync pins so the copies can't drift, apiCell hover pins updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)