### PR TITLE
Comment highlight: solid tint, and it's gone once its thread is truly done

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4769,6 +4769,14 @@ def _comments_frame(sid):
     for th in _load_comments(sid).get("threads") or []:
         tsid = str(th.get("sid") or "")
         status = th.get("status") or "open"
+        # A promoted thread whose session was later ENDED is done, full stop (the user 2026-08-13,
+        # who found the highlight still claiming "now its own session" after closing that session):
+        # drop it from the frame entirely rather than point at a session that no longer runs. The
+        # client already unwraps any mark/badge for a tid absent from this list (applyCommentMarks),
+        # so omitting it here is the whole fix — no client-side special case needed. The row stays in
+        # the store (reviving the session from the Fleet would legitimately bring the thread back).
+        if status == "promoted" and not _thread_reg(tsid).get("alive"):
+            continue
         state, err = "", ""
         if be and status == "open":
             try:

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -275,6 +275,25 @@ class ThreadProjection(CommentBase):
     def test_no_store_no_frame(self):
         self.assertIsNone(km._comments_frame(PARENT))
 
+    def test_a_promoted_thread_whose_session_ended_drops_off_the_frame(self):
+        # the user 2026-08-13: broke a thread out, closed the resulting session, and the highlight
+        # kept claiming "now its own session" — a dead promotion is done, not a stale pointer
+        self._write(THREAD, self._thread_records())
+        (jd.SDKDIR / (THREAD + ".json")).write_text(json.dumps(
+            {"sid": THREAD, "name": "sidework", "cwd": self.cdir, "lastSid": THREAD, "alive": True}))
+        km._save_comments(PARENT, {"threads": [
+            {"tid": THREAD, "sid": THREAD, "anchorUuid": "a1", "cutUuid": "a1",
+             "exact": "exponential backoff", "status": "promoted", "promotedName": "sidework",
+             "createdT": self.now - 400, "lastSeenT": self.now}]})
+        fr = km._comments_frame(PARENT)
+        self.assertEqual(len(fr["threads"]), 1, "still alive — the mark and chip stay")
+        (jd.SDKDIR / (THREAD + ".json")).write_text(json.dumps(
+            {"sid": THREAD, "name": "sidework", "cwd": self.cdir, "lastSid": THREAD, "alive": False}))
+        fr = km._comments_frame(PARENT)
+        self.assertEqual(fr["threads"], [], "ended — no highlight, no badge, nothing on the message")
+        # the row survives in the store: reviving the session from the Fleet should bring it back
+        self.assertEqual(len(km._load_comments(PARENT)["threads"]), 1)
+
     def test_pre_fork_thread_reads_nothing_not_the_parent(self):
         # Until the CLI init spends forkOf, the thread reg's lastSid points at the PARENT
         # transcript — reading it would present the parent's post-anchor turns as the thread's own.

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -163,6 +163,10 @@ test("the projection never reads the parent transcript pre-fork", () => {
   assert.match(KERNEL, /if reg\.get\("forkOf"\):\s*\n\s*return \[\]/);
 });
 
+test("a promoted thread whose session ended drops off the frame entirely", () => {
+  assert.match(KERNEL, /if status == "promoted" and not _thread_reg\(tsid\)\.get\("alive"\):\s*\n\s*continue/);
+});
+
 test("promote latches the row before seeding; racing ops refuse through the CAS", () => {
   assert.match(KERNEL, /def _comment_update_if\(parent_sid, tid, expect, \*\*changes\):/);
   assert.match(KERNEL, /_comment_update_if\(parent_sid, tid, \("open", "resolved"\), status="promoting"\)/);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2341,18 +2341,20 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
    rendered text drifts and the exact-match mark can't land. The popover is a pane-local card on the
    menu vocabulary (#252526, hairline border, 6px radius, the .ctx-menu shadow) — deliberately NOT a
    dimmed modal: the conversation stays readable beside the thread. */
+/* A SOLID tint, not a dashed underline (the user 2026-08-13: "like a comment would be on Google
+   Docs") — the underline read as a link, not a highlight. Unread strengthens the same tint rather
+   than adding a second cue, so "there's something to read" stays legible at a glance. */
 mark.cmt-hl {
-  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  background: color-mix(in srgb, var(--accent) 32%, transparent);
   color: inherit;
-  border-bottom: 1px dashed color-mix(in srgb, var(--accent) 55%, transparent);
   border-radius: 2px;
   cursor: pointer;
 }
-mark.cmt-hl:hover { background: color-mix(in srgb, var(--accent) 30%, transparent); }
-mark.cmt-hl.resolved { background: rgba(255, 255, 255, 0.06); border-bottom-color: rgba(255, 255, 255, 0.2); }
-mark.cmt-hl.unread { border-bottom-style: solid; }
-mark.cmt-hl.busy { border-bottom-style: solid; animation: cmt-busy-pulse 1.2s ease-in-out infinite; }
-@keyframes cmt-busy-pulse { 50% { background: color-mix(in srgb, var(--accent) 32%, transparent); } }
+mark.cmt-hl:hover { background: color-mix(in srgb, var(--accent) 46%, transparent); }
+mark.cmt-hl.resolved { background: rgba(255, 255, 255, 0.08); }
+mark.cmt-hl.unread { background: color-mix(in srgb, var(--accent) 44%, transparent); }
+mark.cmt-hl.busy { animation: cmt-busy-pulse 1.2s ease-in-out infinite; }
+@keyframes cmt-busy-pulse { 50% { background: color-mix(in srgb, var(--accent) 50%, transparent); } }
 
 .turn.has-cmt { position: relative; }
 .cmt-badge {


### PR DESCRIPTION
Two fixes reported from live use of comment threads.

**The highlight didn't read as a highlight.** A dashed underline under the passage looked like a link, not a Google-Docs-style comment marker. Swapped for a solid accent tint (32% base, 44% on unread, both a bit stronger on hover) — no other visual language changes.

**A promoted-then-ended thread left a stale mark.** Break a thread out into its own session, then end that session, and the original passage's highlight and badge kept saying "now its own session" — pointing at a session that no longer runs. `_comments_frame` now drops a promoted thread the instant its target session's registry reads not-alive; the client already unwraps any mark/badge for a tid absent from the frame (the existing dead-thread-cleanup path), so that's the entire fix. Nothing else changes: no highlight, no badge, nothing on the message, as if the comment were never made. The store row is untouched, so reviving the ended session from the Fleet brings the thread straight back.

Tests: one new kernel test (alive → 1 thread in the frame, not-alive → 0, store row intact) and its node pin. Suites green (pytest 4536, node 1932), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)