### PR TITLE
Top banner wraps on narrow screens: full-width text, buttons beneath

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21705,7 +21705,15 @@ _STALE_CSS = (
     "#rstale .rs-reload{background:#54B204;color:#0c1a00;font-weight:600;border-color:#3f8a00}"
     "#rstale .rs-reload:hover{background:#62c80a}"
     "#rstale .rs-dismiss{background:none;color:#9aa0a6;border-color:#4a4d51}"
-    "#rstale .rs-dismiss:hover{color:#e6e6e6}")
+    "#rstale .rs-dismiss:hover{color:#e6e6e6}"
+    # Narrow screens (the user 2026-08-13): the one-row layout squeezed the message into a cramped,
+    # tall left column beside two nowrap buttons. The message takes the FULL row and the buttons drop
+    # to their own row beneath, splitting its width for finger-sized targets. Desktop keeps one line.
+    # width is explicit here: a fixed box with left:50% shrink-to-fits against the half-viewport,
+    # which is what cramped the old one-row layout — and off-centers this one
+    "@media (max-width:640px){#rstale{flex-wrap:wrap;gap:10px 12px;width:92vw;box-sizing:border-box}"
+    "#rstale .rs-msg{flex:1 1 100%}"
+    "#rstale button{flex:1 1 auto}}")
 _STALE_HTML = (
     "<div id=rstale role=alert><span class=rs-msg>A newer romp build is available.</span>"
     "<button class=rs-reload id=rstale-reload>Reload</button>"

--- a/tests/test_kernel_cachebust.py
+++ b/tests/test_kernel_cachebust.py
@@ -86,6 +86,10 @@ def test_landing_shows_build_staleness_banner():
     assert "rstale-reload" in html and "rstale-dismiss" in html
     assert "__LOADEDVER__" not in html, "load-time version must be interpolated, not a placeholder"
     assert "/version" in html and "location.reload()" in html
+    # narrow screens: the message spans the full row and the buttons wrap beneath it (the user
+    # 2026-08-13 — the one-row layout read as a cramped, tall left column on a phone)
+    assert "@media (max-width:640px){#rstale{flex-wrap:wrap" in html
+    assert "#rstale .rs-msg{flex:1 1 100%}" in html
 
 
 def test_gear_panel_drops_inline_stale_hint():


### PR DESCRIPTION
The reload/lost-connection banner read as a cramped tall column on mobile — nowrap buttons squeezed the message in the one-row flex layout, and the fixed box's left:50% shrink-to-fit halved its available width. Under 640px the message now spans the full row with the buttons on their own row below, box at an explicit 92vw. Pin in test_kernel_cachebust.py; verified at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)