### PR TITLE
Inner fold scroll survives the per-push rebuild

### DIFF
--- a/ui/webview/fold-scroll.test.ts
+++ b/ui/webview/fold-scroll.test.ts
@@ -1,0 +1,31 @@
+// Inner fold scroll positions survive the per-push rebuild (the user 2026-08-14: scrolling a
+// CLAUDE.md doc inside the expanded System context card snapped back to the top "randomly" — i.e.
+// on every kernel push, since the first 25 turns rebuild and a fresh .fold-pre starts at scrollTop
+// 0). keepScroll mirrors openFolds: saved per stable key on scroll, reapplied a frame after the
+// rebuilt node lands (an unlaid-out node clamps scrollTop writes to 0). Source pins (no jsdom).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("keepScroll: keyed map, passive save on scroll, rAF restore after rebuild", () => {
+  assert.match(RENDER, /const foldScroll = new Map<string, number>\(\);/);
+  assert.match(RENDER, /box\.addEventListener\("scroll", \(\) => \{ foldScroll\.set\(key, box\.scrollTop\); \}, \{ passive: true \}\);/);
+  // the restore waits a frame — writing scrollTop to a node that hasn't laid out clamps to 0
+  assert.match(RENDER, /if \(saved\) requestAnimationFrame\(\(\) => \{ box\.scrollTop = saved; \}\);/);
+  // keyless callers stay transient, like keyless folds
+  assert.match(RENDER, /if \(!key\) return box;/);
+});
+
+test("every scrollable .fold-pre a rebuild can hit carries a stable scroll key", () => {
+  // preEl is the ONE .fold-pre factory, and it routes through keepScroll
+  assert.match(RENDER, /function preEl\(text: string, scrollKey\?: string\): HTMLElement \{/);
+  assert.match(RENDER, /return keepScroll\(pre, scrollKey\);/);
+  // the System context card keys each CLAUDE.md doc by session + doc index
+  assert.match(RENDER, /preEl\(doc\.text, key \? key \+ ":doc" \+ i : undefined\)/);
+  // Read dumps (and the legacy Skill-output fold) key on the turn's fold key
+  assert.ok((RENDER.match(/preEl\(ev\.output, fkey && fkey \+ ":out"\)/g) || []).length >= 2,
+    "both tail preEl(ev.output) folds pass a scroll key");
+});

--- a/ui/webview/render-system.test.ts
+++ b/ui/webview/render-system.test.ts
@@ -35,9 +35,10 @@ test("the card is a bordered box with a ⚙ header + one-line summary + caret, c
 });
 
 test("each CLAUDE.md doc renders as a raw, scrollable SUB-box with a scope badge + path", () => {
-  assert.match(RENDER, /for \(const doc of ev\.claudemd \|\| \[\]\)/);
+  assert.match(RENDER, /\(ev\.claudemd \|\| \[\]\)\.forEach\(\(doc, i\) =>/);   // indexed — each doc's scroll key needs its position
   assert.match(RENDER, /el\("span", "sys-doc-scope " \+ \(doc\.scope === "global" \? "global" : "project"\)\)/);
-  assert.match(RENDER, /sec\.appendChild\(preEl\(doc\.text\)\)/, "raw text in a .fold-pre box, not markdown-rendered");
+  assert.match(RENDER, /sec\.appendChild\(preEl\(doc\.text, key \? key \+ ":doc" \+ i : undefined\)\)/,
+    "raw text in a .fold-pre box, not markdown-rendered — scroll keyed per doc (fold-scroll.test.ts)");
 });
 
 test("the card never claims to be the verbatim harness prompt — it says the base prompt isn't recorded", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -623,10 +623,25 @@ function countLines(s: string): number {
   return s.endsWith("\n") ? n - 1 : n;
 }
 
-function preEl(text: string): HTMLElement {
+// A .fold-pre's inner scroll position must survive the same rebuilds openFolds survives (the user
+// 2026-08-14: reading a scrolled CLAUDE.md doc in the System context card, the box snapped to its
+// top on every kernel push — the rebuilt node is a fresh element at scrollTop 0, and pushes land
+// every 0.5–3s). Saved per stable key as the user scrolls; reapplied a frame after the rebuilt node
+// lands, because a node that hasn't laid out yet clamps any scrollTop write back to 0. Keyless
+// callers (notices, reminder bodies) stay transient, exactly like keyless folds.
+const foldScroll = new Map<string, number>();
+function keepScroll(box: HTMLElement, key?: string): HTMLElement {
+  if (!key) return box;
+  box.addEventListener("scroll", () => { foldScroll.set(key, box.scrollTop); }, { passive: true });
+  const saved = foldScroll.get(key);
+  if (saved) requestAnimationFrame(() => { box.scrollTop = saved; });
+  return box;
+}
+
+function preEl(text: string, scrollKey?: string): HTMLElement {
   const pre = el("pre", "io-pre fold-pre");
   pre.textContent = text;
-  return pre;
+  return keepScroll(pre, scrollKey);
 }
 
 // Links in the chat (markdown [x](url) and GFM-autolinked bare URLs alike, all rendered as <a href>
@@ -2026,7 +2041,7 @@ function renderSystem(ev: Extract<ChatEvent, { kind: "system" }>): HTMLElement {
     }
     body.appendChild(grid);
   }
-  for (const doc of ev.claudemd || []) {
+  (ev.claudemd || []).forEach((doc, i) => {
     const sec = el("div", "sys-doc");
     const dh = el("div", "sys-doc-head");
     const scope = el("span", "sys-doc-scope " + (doc.scope === "global" ? "global" : "project"));
@@ -2034,9 +2049,11 @@ function renderSystem(ev: Extract<ChatEvent, { kind: "system" }>): HTMLElement {
     const pth = el("span", "sys-doc-path"); pth.textContent = doc.path;
     dh.appendChild(scope); dh.appendChild(pth);
     sec.appendChild(dh);
-    sec.appendChild(preEl(doc.text));   // raw text in a bordered, scrollable sub-box (.fold-pre)
+    // raw text in a bordered, scrollable sub-box (.fold-pre) — scroll position keyed per doc so a
+    // reader's place survives the per-push rebuild of this turn (keepScroll)
+    sec.appendChild(preEl(doc.text, key ? key + ":doc" + i : undefined));
     body.appendChild(sec);
-  }
+  });
   const note = el("div", "sys-note");
   note.textContent = "Claude Code’s base harness prompt isn’t recorded in the transcript, so it isn’t shown here — this is the CLAUDE.md instructions and session config that were in effect.";
   body.appendChild(note);
@@ -2949,7 +2966,7 @@ function renderTool(ev: Extract<ChatEvent, { kind: "tool" }>): HTMLElement {
     }
     inlineFold(head, turn, `+${add} −${del}`, pre, fkey);
   } else if (ev.name === "Read") {
-    if (ev.output) inlineFold(head, turn, `${countLines(ev.output)} lines`, preEl(ev.output), fkey);
+    if (ev.output) inlineFold(head, turn, `${countLines(ev.output)} lines`, preEl(ev.output, fkey && fkey + ":out"), fkey);
   } else if (ev.name === "Skill") {
     // A Skill invocation (the user 2026-07-08): the head names the skill, and the skill's INSTRUCTIONS
     // (ev.skillMd, kernel-joined) are the fold body — DEFAULT COLLAPSED like every tool body. They used
@@ -2963,7 +2980,7 @@ function renderTool(ev: Extract<ChatEvent, { kind: "tool" }>): HTMLElement {
       inlineFold(head, turn, `skill · ${countLines(ev.skillMd)} lines`, box, fkey);
     } else if (ev.output) {
       // an older record with no joined content — keep the result reachable as before
-      inlineFold(head, turn, `${countLines(ev.output)} line${countLines(ev.output) === 1 ? "" : "s"}`, preEl(ev.output), fkey);
+      inlineFold(head, turn, `${countLines(ev.output)} line${countLines(ev.output) === 1 ? "" : "s"}`, preEl(ev.output, fkey && fkey + ":out"), fkey);
     }
   } else if (!ack && (ev.input || ev.output)) {
     const signal = ev.name === "Task" || ev.name === "Agent";


### PR DESCRIPTION
Scrolling inside the expanded System context card (or any scrolled Read-dump fold in the 25-turn tail) snapped to the top on every kernel push — the rebuilt .fold-pre node starts at scrollTop 0. Adds keepScroll, the scroll twin of openFolds: keyed positions saved on scroll, restored a frame after rebuild. New fold-scroll.test.ts pins the mechanism; the render-system pin follows the indexed loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)