### PR TITLE
Fast-mode permission follows billing on key sessions

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1138,6 +1138,70 @@ def work_api_key() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Fast-mode permission for key-billed sessions — ask the account that PAYS.
+# ---------------------------------------------------------------------------
+
+FAST_ORG_PATH = "/api/claude_code_penguin_mode"   # the CLI's own fast-mode availability endpoint
+
+_FAST_ORG_VERDICTS: dict[str, bool] = {}   # key -> the server's last definitive answer
+
+
+def _fetch_key_fast_org(key: str) -> bool | None:
+    """The fast-mode availability answer for the API key's OWN account, from the same endpoint the
+    CLI asks — True/False on a definitive server answer, None on any failure (network, bad status,
+    unexpected shape). Split out so tests replace it; the policy lives in key_fast_org_env."""
+    import urllib.request
+    base = (os.environ.get("ANTHROPIC_BASE_URL") or "https://api.anthropic.com").rstrip("/")
+    req = urllib.request.Request(base + FAST_ORG_PATH, headers={"x-api-key": key})
+    try:
+        with urllib.request.urlopen(req, timeout=3) as r:
+            d = json.loads(r.read().decode("utf-8"))
+    except Exception:
+        return None
+    v = d.get("enabled") if isinstance(d, dict) else None
+    return v if isinstance(v, bool) else None
+
+
+def key_fast_org_env(key: str, log) -> dict[str, str]:
+    """Env additions that make the CLI's fast-mode PERMISSION follow the session's BILLING (the user
+    2026-08-14, who found fast mode refused on a key-billed session the key's account allows). The
+    CLI's availability probe asks the saved claude.ai login whenever one exists, even on a session
+    whose inference bills the injected key (verified against claude 2.1.228 on 2026-08-14: the probe
+    prefers the stored OAuth token over the key, so a machine whose login has extra usage off refuses
+    the fast mode the paying account permits). So at every key-billed connect the kernel asks the
+    paying account itself — the same endpoint, credentialed with the key — and translates the answer
+    into the CLI's own switches:
+      * enabled  -> CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK=1 — the CLI skips its wrong-account probe.
+      * disabled -> CLAUDE_CODE_DISABLE_FAST_MODE=1 — the wrong-account probe could just as well say
+        YES to a fast mode the paying org turned OFF; permission follows billing in both directions.
+      * unknown  -> last definitive answer if one exists (logged), else {} — no answer is no licence
+        to skip, so the CLI's own behavior stands and the failure is logged where the Log panel
+        shows it. Retry is event-keyed on the next connect; there is no timer.
+    Asked per connect (connects are rare and already network-bound; a fast toggle reconnects, so the
+    check is fresh exactly when it matters), capped at 3s so a black-holed network cannot hang a
+    connect. Never injected for login sessions: there the CLI's probe already asks the account that
+    pays."""
+    verdict = _fetch_key_fast_org(key)
+    if verdict is None:
+        if key in _FAST_ORG_VERDICTS:
+            verdict = _FAST_ORG_VERDICTS[key]
+            log("fast-mode org check (key account): unreachable — standing on the last answer "
+                "(%s)" % ("enabled" if verdict else "disabled"))
+        else:
+            log("fast-mode org check (key account): unreachable and no prior answer — the CLI's "
+                "own check stands (it may consult the claude.ai login, not the paying account)",
+                problem=True)
+            return {}
+    else:
+        if _FAST_ORG_VERDICTS.get(key) != verdict:
+            log("fast-mode org check (key account): %s" % ("enabled" if verdict else "disabled"))
+        _FAST_ORG_VERDICTS[key] = verdict
+    if verdict:
+        return {"CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK": "1"}
+    return {"CLAUDE_CODE_DISABLE_FAST_MODE": "1"}
+
+
+# ---------------------------------------------------------------------------
 # The live session (one quarantined asyncio thread).
 # ---------------------------------------------------------------------------
 
@@ -3432,7 +3496,8 @@ class SdkBackend:
         # inject or stay silent; never blank (an empty var reads as "API-key mode, no key" to the CLI).
         launch_keyed = sess.effective_auth() == "key"
         if launch_keyed:
-            kw["env"] = dict(kw["env"], ANTHROPIC_API_KEY=self.work_key)
+            kw["env"] = dict(kw["env"], ANTHROPIC_API_KEY=self.work_key,
+                             **key_fast_org_env(self.work_key, self._log))
         elif sess.auth == "key":
             # picked "key", but this manager's env carries none — falling to login silently would bill
             # the wrong account with nothing to see; say so where the Log panel shows it.

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -54,12 +54,19 @@ class _Keyed(unittest.TestCase):
         self._env_before = os.environ.pop("ANTHROPIC_API_KEY", None)
         self._stash_before = sb._WORK_KEY
         sb._WORK_KEY = None                       # force a fresh claim from the env
+        # the key-account fast-mode probe is a real HTTPS GET — never from a test. Cases that
+        # exercise the policy arm their own answers (FastOrgPermissionFollowsBilling).
+        self._fetch_before = sb._fetch_key_fast_org
+        sb._fetch_key_fast_org = lambda key: None
+        sb._FAST_ORG_VERDICTS.clear()
         if self.KEY:
             os.environ["ANTHROPIC_API_KEY"] = self.KEY
         self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None)
 
     def tearDown(self):
         sb._WORK_KEY = self._stash_before
+        sb._fetch_key_fast_org = self._fetch_before
+        sb._FAST_ORG_VERDICTS.clear()
         os.environ.pop("ANTHROPIC_API_KEY", None)
         if self._env_before is not None:
             os.environ["ANTHROPIC_API_KEY"] = self._env_before
@@ -105,7 +112,9 @@ class EffectiveAuthKeyless(_Keyed):
                          "'key' with nothing to inject launches on the login — loudly, via _options")
 
 
-class OptionsInjection(_Keyed):
+class _OptionsHarness(_Keyed):
+    """Base for anything that calls _options directly."""
+
     def setUp(self):
         super().setUp()
         # ClaudeAgentOptions is a parameter (a dict stands in) and the in-function import only needs
@@ -128,6 +137,8 @@ class OptionsInjection(_Keyed):
     def _options_kw(self, sess):
         return self.be._options(sess, dict)
 
+
+class OptionsInjection(_OptionsHarness):
     def test_a_key_session_gets_the_key_and_a_login_session_a_clean_env(self):
         kw = self._options_kw(self._sess(1, auth="key"))
         self.assertEqual(kw["env"].get("ANTHROPIC_API_KEY"), FAKE_KEY)
@@ -146,7 +157,57 @@ class OptionsInjection(_Keyed):
     def test_a_key_pick_with_no_key_is_a_logged_problem_not_a_silent_fall(self):
         src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
         self.assertIn("session is set to the API key but the manager environment carries", src)
-        self.assertIn('kw["env"] = dict(kw["env"], ANTHROPIC_API_KEY=self.work_key)', src)
+        self.assertIn('ANTHROPIC_API_KEY=self.work_key', src)
+
+
+class FastOrgPermissionFollowsBilling(_OptionsHarness):
+    """Fast-mode permission follows BILLING (the user 2026-08-14): the CLI's availability probe asks
+    the saved claude.ai login whenever one exists, even on a session whose inference bills the
+    injected key — so _options asks the paying account itself (key_fast_org_env, fetch stubbed here)
+    and hands the CLI the switch matching the answer. Both directions matter: an enabled key account
+    skips the CLI's wrong-account probe, a disabled one forces fast mode off."""
+
+    def _env(self, answer, n=1):
+        sb._fetch_key_fast_org = lambda key: answer
+        return self._options_kw(self._sess(n, auth="key"))["env"]
+
+    def test_an_enabled_key_account_skips_the_clis_wrong_account_probe(self):
+        env = self._env(True)
+        self.assertEqual(env.get("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK"), "1")
+        self.assertNotIn("CLAUDE_CODE_DISABLE_FAST_MODE", env)
+        self.assertEqual(env.get("ANTHROPIC_API_KEY"), FAKE_KEY,
+                         "the skip rides WITH the key — same connect, same account")
+
+    def test_a_disabled_key_account_forces_fast_mode_off(self):
+        env = self._env(False)
+        self.assertEqual(env.get("CLAUDE_CODE_DISABLE_FAST_MODE"), "1")
+        self.assertNotIn("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK", env,
+                         "the wrong-account probe could say YES to a fast mode the payer turned off")
+
+    def test_no_answer_and_no_history_leaves_the_cli_default(self):
+        env = self._env(None)
+        self.assertNotIn("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK", env)
+        self.assertNotIn("CLAUDE_CODE_DISABLE_FAST_MODE", env,
+                         "no answer is no licence to skip — the CLI's own check stands")
+
+    def test_a_failure_stands_on_the_last_definitive_answer(self):
+        self._env(True, n=1)
+        env = self._env(None, n=2)
+        self.assertEqual(env.get("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK"), "1",
+                         "a transient network failure must not strip a verified permission")
+
+    def test_a_flip_is_adopted_not_cached_over(self):
+        self._env(True, n=1)
+        env = self._env(False, n=2)
+        self.assertEqual(env.get("CLAUDE_CODE_DISABLE_FAST_MODE"), "1")
+        self.assertNotIn("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK", env)
+
+    def test_login_sessions_never_ask_the_key_account(self):
+        calls = []
+        sb._fetch_key_fast_org = lambda key: calls.append(key) or True
+        env = self._options_kw(self._sess(3, auth="login"))["env"]
+        self.assertEqual(calls, [], "a login session's probe already asks the account that pays")
+        self.assertNotIn("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK", env)
 
 
 class InitMismatchIsLoud(_Keyed):


### PR DESCRIPTION
The CLI's fast-mode availability probe asks the saved claude.ai login whenever one exists, even on a session whose inference bills the injected API key (verified against claude 2.1.228 on 2026-08-14). A machine whose login has extra usage off therefore refuses the fast mode the paying account allows, which reads as a billing bug and is not one.

At every key-billed connect the kernel now asks the paying account itself, via the CLI's own availability endpoint credentialed with the key, and translates the answer into the CLI's switches:

- enabled: `CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK=1`, so the CLI skips its wrong-account probe
- disabled: `CLAUDE_CODE_DISABLE_FAST_MODE=1`, so the wrong-account probe cannot say yes to a fast mode the paying org turned off
- no answer: last definitive answer if one exists, else the CLI default stands and the failure lands in the Log panel; retry is event-keyed on the next connect

Login sessions are untouched: there the CLI's probe already asks the account that pays.

Tests: `FastOrgPermissionFollowsBilling` in tests/test_session_auth.py covers both directions, the no-answer case, failure fallback, verdict flips, and that login sessions never trigger the probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)