### PR TITLE
Auto Nudge reaches every connected kernel, and says so when they differ

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7912,6 +7912,12 @@ def _remote_public(r):
             "kernelVer": ver, "localVer": (_kernel_ver() or ""),
             "outOfDate": ood, "behindBy": drift["behind"], "aheadBy": drift["ahead"],
             "kernelDate": drift["date"],
+            # That machine's OWN Auto Nudge setting, from the same /version poll as the sha (so `stale`
+            # dates it like everything else here). The gear presents one switch for every attached
+            # machine and reads the box from the LOCAL kernel, which cannot see a machine that disagrees
+            # — this is what lets it say so. null when the remote never reported one (an older kernel,
+            # or a row that has not polled yet): unknown, which the gear leaves out rather than guesses.
+            "autoNudge": r.get("auto_nudge") if isinstance(r.get("auto_nudge"), bool) else None,
             # fastForward: a push here would only ADD commits (the remote's is an ancestor of ours) — the
             # exact condition the automatic update fires on, so the row can say why it will or won't.
             # autoPush: that host's live phase (pushing / waiting / failed) → the popover's progress line and
@@ -8340,12 +8346,18 @@ def _remote_forward(r, path, body):
 
 
 def _poll_remote_version(r):
-    """GET the remote kernel's /version THROUGH the -L tunnel and return {"sha", "ver"} — the git short-sha
-    and the release tag the remote is running — or None on any failure. Same transport as _poll_remote_sids
-    — /version is auth-exempt on the remote, but we pass the token anyway. Lets the local kernel tell when a
-    remote is running OLDER code than this one (the user 2026-07-04: keep remotes up to date + prompt to
-    update), and name that build in terms both machines share (the user 2026-07-30). `ver` is "" against an
-    older kernel that predates the tag — the row falls back to the sha alone rather than inventing one."""
+    """GET the remote kernel's /version THROUGH the -L tunnel and return {"sha", "ver", "autoNudge"} — the
+    git short-sha and the release tag the remote is running, plus its Auto Nudge setting — or None on any
+    failure. Same transport as _poll_remote_sids — /version is auth-exempt on the remote, but we pass the
+    token anyway. Lets the local kernel tell when a remote is running OLDER code than this one (the user
+    2026-07-04: keep remotes up to date + prompt to update), and name that build in terms both machines
+    share (the user 2026-07-30). `ver` is "" against an older kernel that predates the tag — the row falls
+    back to the sha alone rather than inventing one.
+
+    `autoNudge` is that machine's own copy of a setting the gear presents as one switch for everything you
+    are running, so the dashboard can say when the machines disagree instead of showing one kernel's answer
+    for all of them (the user 2026-08-14). None — never False — when the remote didn't say, so an older
+    kernel that has no such field reads as unknown rather than as off."""
     import urllib.parse
     try:
         c = http.client.HTTPConnection("127.0.0.1", int(r["local_port"]), timeout=4)
@@ -8358,7 +8370,9 @@ def _poll_remote_version(r):
             return None
         j = json.loads(data.decode("utf-8")) or {}
         sha = j.get("kernel_sha") or None
-        return {"sha": sha, "ver": str(j.get("kernel_ver") or "")} if sha else None
+        an = j.get("autoNudge")
+        return {"sha": sha, "ver": str(j.get("kernel_ver") or ""),
+                "autoNudge": an if isinstance(an, bool) else None} if sha else None
     except Exception:
         return None
 
@@ -9420,6 +9434,7 @@ def _tunnel_supervisor():
                     if rsha is not None:
                         r["kernel_sha"] = rsha
                         r["kernel_ver"] = (rver or {}).get("ver") or ""
+                        r["auto_nudge"] = (rver or {}).get("autoNudge")   # None = that kernel didn't say
                     if ruse is not None:
                         # {} = the host ANSWERED with nothing to show → clear; None = no answer (blip/
                         # rate-gate) → keep the last reading (see _poll_remote_usage)

--- a/tests/test_auto_nudge_every_kernel.py
+++ b/tests/test_auto_nudge_every_kernel.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Auto Nudge is one switch for every attached machine, but each kernel stores its own copy.
+
+The user 2026-08-14: Auto Nudge was switched off in the dashboard and the sessions running on the other
+machine went on being nudged for days. Two halves to that, and this file covers the kernel's:
+
+  ROUTING (ui/webview/federation.ts, pinned in multi-kernel-merge.test.ts) — setAutoNudge carries no
+  session id, so it went to the local kernel alone and no remote ever heard it.
+
+  DISPLAY (here) — the gear fills its box from /version, which answers for the kernel serving the page.
+  A machine that disagreed was invisible: the box read unchecked while that kernel kept nudging. The
+  /version poll the supervisor already runs per pass now carries each remote's own setting onto its
+  /tunnels row, so the gear can say who differs instead of speaking for machines it cannot see.
+
+An older remote kernel has no such field, and "didn't say" must not read as "off" — that would invent a
+disagreement and, worse, invite a click that changes a setting nobody asked about. It stays None.
+
+Synthetic only — placeholder host/token, a throwaway loopback server for the poll, no real state.
+"""
+import json
+import os
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = SourceFileLoader("romp_kernel_autonudge_hosts", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _row(**kw):
+    r = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 51000, "bus_port": 51001,
+         "token": "tok", "trust": "trusted", "status": "up", "detail": "", "sids": [],
+         "fails": 0, "next_try": 0, "kernel_sha": "abc1234", "proc": None}
+    r.update(kw)
+    return r
+
+
+class _Fake(BaseHTTPRequestHandler):
+    """A stand-in remote kernel that answers /version with whatever PAYLOAD holds."""
+    PAYLOAD = {}
+
+    def do_GET(self):
+        body = json.dumps(self.PAYLOAD).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):
+        pass
+
+
+class RemoteRowCarriesItsOwnSetting(unittest.TestCase):
+    def test_the_public_row_carries_the_remote_s_setting(self):
+        for val in (True, False):
+            with self.subTest(autoNudge=val):
+                self.assertIs(km._remote_public(_row(auto_nudge=val))["autoNudge"], val,
+                              "the gear reads each machine's own answer off its row")
+
+    def test_a_remote_that_never_reported_reads_as_unknown_not_off(self):
+        # An older kernel has no autoNudge in /version, and a row polled zero times has nothing cached.
+        # Either way the honest answer is null: the gear leaves an unknown host out of the comparison
+        # rather than inventing a disagreement (and a click) over a setting it never learned.
+        self.assertIsNone(km._remote_public(_row())["autoNudge"])
+        self.assertIsNone(km._remote_public(_row(auto_nudge=None))["autoNudge"])
+
+    def test_a_non_boolean_never_reaches_the_gear(self):
+        # /version is whatever the far side chose to send; the row must not pass a string or a number
+        # through to a checkbox, where "0" or "off" would both read as truthy on the way in.
+        for junk in ("false", 0, 1, [], {}):
+            with self.subTest(value=junk):
+                self.assertIsNone(km._remote_public(_row(auto_nudge=junk))["autoNudge"])
+
+
+class ThePollReadsIt(unittest.TestCase):
+    def setUp(self):
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), _Fake)
+        self.port = self.srv.server_address[1]
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+
+    def tearDown(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+
+    def _poll(self, payload):
+        _Fake.PAYLOAD = payload
+        return km._poll_remote_version({"local_port": self.port, "token": "tok"})
+
+    def test_the_version_poll_brings_the_setting_back_with_the_sha(self):
+        got = self._poll({"kernel_sha": "abc1234", "kernel_ver": "v0.5.0", "autoNudge": False})
+        self.assertEqual(got["sha"], "abc1234")
+        self.assertIs(got["autoNudge"], False, "False is a real answer, not a missing one")
+        self.assertIs(self._poll({"kernel_sha": "abc1234", "autoNudge": True})["autoNudge"], True)
+
+    def test_an_older_kernel_that_omits_the_field_polls_as_unknown(self):
+        got = self._poll({"kernel_sha": "abc1234", "kernel_ver": "v0.4.0"})
+        self.assertEqual(got["sha"], "abc1234", "the sha still lands — the field is additive")
+        self.assertIsNone(got["autoNudge"])
+
+
+class ThisKernelPublishesIt(unittest.TestCase):
+    def test_version_reports_this_kernel_s_own_setting(self):
+        # The other half of the same wire: what a remote polls off US. /version is the gear's source for
+        # the local box too, so both ends of the comparison come from one field.
+        for val in (True, False):
+            with self.subTest(enabled=val):
+                km._set_auto_nudge(val)
+                self.assertIs(km._version_info()["autoNudge"], val)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -54,6 +54,14 @@ const ARRAY_ID = ["order", "names", "working", "awaiting", "stateUnknown"]; // a
 const OBJ_SID = ["asks", "items", "ledgers", "sessions"]; //  an array of objects keyed by `.sid`
 const OBJ_ID = ["tabs"]; //                       an array of objects keyed by `.id`
 
+// Gear settings the KERNEL acts on, which each kernel stores its own copy of: they describe how romp
+// behaves towards the sessions it is running, so a machine that never hears the change goes on behaving
+// the old way. Broadcast in routeOutbound rather than routed. Deliberately NOT here: setDefaultDir (a
+// path on one machine, meaningless on another) and setColormap/setPalette (the viewer's display prefs,
+// which the local kernel persists for this browser).
+const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel",
+                                "setJudgeEffort", "setIndexEffort"]);
+
 /** Return a COPY of an inbound message with every session-id field prefixed by `host`. The local host
  *  ("") is the identity transform, so local messages are untouched. Unknown fields pass through. */
 export function prefixInbound(host: string, msg: any): any {
@@ -184,8 +192,8 @@ export interface Route {
  *  `knownHosts` (the manager passes its attached set) enables two extra routings that need to know which
  *  hosts exist: NAME-addressed messages (the timeline's compact/sendCommand target a session by display
  *  name, which inbound prefixing made `host:name`) route to a KNOWN host only — a local name that happens
- *  to contain ":" must never misroute — and a hover CLEAR (`timelineHover {off}` carries no sid) fans out
- *  to every kernel so a remote highlight can't stick. */
+ *  to contain ":" must never misroute — and messages with no sid that mean the same thing on every kernel
+ *  (a hover CLEAR, the gear's kernel-side settings) fan out to all of them. */
 export function routeOutbound(msg: any, knownHosts?: ReadonlySet<string>): Route[] {
   if (!msg || typeof msg !== "object") return [{ host: LOCAL, msg }];
 
@@ -210,6 +218,14 @@ export function routeOutbound(msg: any, knownHosts?: ReadonlySet<string>): Route
 
   // a hover CLEAR has no session id — broadcast so every kernel drops its highlight.
   if (msg.type === "timelineHover" && msg.off) return [LOCAL, ...(knownHosts || [])].map((h) => ({ host: h, msg }));
+
+  // The gear's kernel-side settings mean the same thing on every attached machine, and carry no session
+  // id to route by — so the fall-through at the bottom sent them to the LOCAL kernel alone. Every other
+  // kernel silently kept its old setting while the gear, which fills from the local /version, showed the
+  // change as applied everywhere: Auto Nudge switched off in the dashboard, still nudging the sessions
+  // running on the other machine (the user 2026-08-14, whose two kernels had been disagreeing for days
+  // with nothing on screen to say so). Broadcast, like the hover clear above.
+  if (KERNEL_SETTING.has(msg.type)) return [LOCAL, ...(knownHosts || [])].map((h) => ({ host: h, msg }));
 
   // openFolder ALWAYS stays LOCAL, `id` UNSTRIPPED (the user 2026-07-03): unlike every other id-bearing
   // message, this one means "open a window on the machine the BROWSER is running on" — routing it to a

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -59,6 +59,10 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
   margin-top: 2px; color: #cdd3da; font-size: .92em; line-height: 1.35; background: #1b1b1c; border: 1px solid #3a3a3a;
   border-radius: 6px; padding: 6px 9px; box-shadow: 0 4px 14px #000000aa; pointer-events: none; }
 #rsettings .rs-sub code { background: #0d0d0d; border-radius: 3px; padding: 0 3px; }
+/* A setting whose value differs between the connected machines: the checkbox goes tri-state, and this
+   says so in words beside the label, because an indeterminate box alone is easy to read straight past.
+   Label size, section grey — the hover line names which machines. */
+#rsettings .rs-mixed { color: #6f747c; margin-left: 6px; }
 /* judge model/effort rows are one-liners (the user 2026-07-12): label left, picker right */
 #rsettings .rs-jrow { align-items: center; cursor: default; }
 #rsettings .rs-jrow b { flex: 1 1 auto; }

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -38,6 +38,11 @@ var SHORTCUT_ROWS =
   '<span class=rs-key-desc>view, record and rebind every dashboard shortcut</span></div>' +
   '<div class=rs-key id=rs-keys-vsc hidden><span class=rs-key-desc>Shortcuts are VS Code keybindings here — search "rompChat" in Keyboard Shortcuts.</span></div>';
 
+// Auto Nudge's hover description lives in a var because fillAutoNudge() appends to it when the attached
+// machines disagree — the row then has to say WHICH ones, and this is the one level down from the label.
+var AUTONUDGE_SUB = "When a session goes idle but its goal still shows working (not blocked, not awaiting "
+  + "you), automatically nudge it once for a status update. Applies to every connected machine's kernel.";
+
 // The modal markup — ported verbatim from the kernel's _gear_html; the model/
 // effort selects start empty and are filled from /models (see fill()).
 var GEAR_HTML =
@@ -53,8 +58,8 @@ var GEAR_HTML =
   "<button id=rs-defaultdir-browse type=button style='flex:0 0 auto;cursor:pointer;background:#2a2a2a;color:#ccc;border:1px solid #3a3a3a;border-radius:5px;padding:3px 8px'>Browse…</button>" +
   '</div></span></div>' +
   "<label class='rs-row rs-sep'><input type=checkbox id=rs-autonudge>" +
-  '<span><b>Auto Nudge</b>' +
-  '<span class=rs-sub>When a session goes idle but its goal still shows working (not blocked, not awaiting you), automatically nudge it once for a status update.</span>' +
+  '<span><b>Auto Nudge</b><span class=rs-mixed id=rs-autonudge-split hidden></span>' +
+  '<span class=rs-sub id=rs-autonudge-sub>' + AUTONUDGE_SUB + '</span>' +
   '</span></label>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Automatic updates</b>" +
   '<span class=rs-sub>romp checks its repo for a new tagged release at start-up and every 6 hours (ordinary commits never trigger it; updating lands exactly on the release). Check and ask (the default) offers it as a banner with an Update button; Install automatically fetches, installs and restarts by itself; Off never checks. Kernel-side setting.</span>' +
@@ -156,7 +161,8 @@ function initGear(post) {
     cg = document.getElementById('rs-collapsegaps'), ao = document.getElementById('rs-activeonly'),
     jm = document.getElementById('rs-judgemodel'),
     im = document.getElementById('rs-indexmodel'), je = document.getElementById('rs-judgeeffort'),
-    ie = document.getElementById('rs-indexeffort'), upm = document.getElementById('rs-updates');
+    ie = document.getElementById('rs-indexeffort'), upm = document.getElementById('rs-updates'),
+    ans = document.getElementById('rs-autonudge-split'), asub = document.getElementById('rs-autonudge-sub');
   function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }; } }
   // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
   // few hours as a boolean toggle — false was an explicit hide, true the default nobody chose.
@@ -183,7 +189,13 @@ function initGear(post) {
   if (ao) ao.addEventListener('change', function () { var s = load(); s.activeOnly = ao.checked; save(s); });
   // Auto Nudge / judge tiers are SERVER-SIDE (the kernel runs them): post the
   // change; the controls re-initialize from /version on every open (fill()).
-  if (an) an.addEventListener('change', function () { post({ type: 'setAutoNudge', enabled: an.checked }); });
+  // Each attached kernel keeps its own copy, so the post goes to all of them
+  // (federation.ts KERNEL_SETTING) — which is also what resolves a split box:
+  // the click picks one answer and every machine takes it.
+  if (an) an.addEventListener('change', function () {
+    clearAutoNudgeSplit();
+    post({ type: 'setAutoNudge', enabled: an.checked });
+  });
   if (upm) upm.addEventListener('change', function () { post({ type: 'setUpdateMode', mode: upm.value }); });
   if (jm) jm.addEventListener('change', function () { post({ type: 'setJudgeModel', model: jm.value }); });
   if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value }); });
@@ -255,8 +267,41 @@ function initGear(post) {
   }
   function lv() { var t = document.querySelector('script[src*="feed.js"]');
     var m = t && t.getAttribute('src').match(/[?&]v=(\d+)/); return m ? +m[1] : 0; }
+  function clearAutoNudgeSplit() {
+    if (an) an.indeterminate = false;
+    if (ans) { ans.hidden = true; ans.textContent = ''; }
+    if (asub) asub.textContent = AUTONUDGE_SUB;
+  }
+  // Auto Nudge is one switch for every connected machine, but each kernel keeps its own copy — and
+  // /version answers for THIS one alone. So the box takes the local kernel's setting, then checks the
+  // others: a connected host that disagrees puts the box in the mixed state (a tri-state checkbox plus
+  // the word beside the label — glanceable) and is NAMED in the hover line, one level down. Before this
+  // the box quietly spoke for machines it could not see, and the other kernel went on nudging for days
+  // behind an unchecked box (the user 2026-08-14). Clicking a mixed box picks one answer for everyone,
+  // since the post goes to every kernel.
+  //
+  // A host that never reported a setting — an older kernel, a row that has not polled — is left OUT
+  // rather than read as off: guessing would invent a disagreement and invite a click that changes a
+  // machine nobody asked about. Same for a host that is not `up`, whose row is a memory (see
+  // _remote_public's stale note). A /tunnels that fails leaves the local answer standing.
+  function fillAutoNudge(mine) {
+    if (!an) return;
+    an.checked = !!mine;
+    clearAutoNudgeSplit();
+    fetch(ku('/tunnels'), { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (d) {
+      var split = ((d && d.tunnels) || []).filter(function (t) {
+        return t && t.status === 'up' && typeof t.autoNudge === 'boolean' && t.autoNudge !== !!mine;
+      }).map(function (t) { return t.host; });
+      if (!split.length) return;
+      an.indeterminate = true;
+      if (ans) { ans.textContent = 'mixed'; ans.hidden = false; }
+      if (asub) asub.textContent = AUTONUDGE_SUB
+        + (mine ? ' Right now these have it off: ' : ' Right now these still have it on: ')
+        + split.join(', ') + '. Clicking sets them all the same way.';
+    }).catch(function () {});
+  }
   function fill() { fillChoices().then(function () { return fetch(ku('/version'), { cache: 'no-store' }); }).then(function (r) { return r.json(); }).then(function (v) {
-    if (an) an.checked = !!v.autoNudge;
+    fillAutoNudge(v.autoNudge);
     if (upm && typeof v.updateMode === 'string') upm.value = v.updateMode;   // the kernel's persisted mode is authoritative
     if (jm && typeof v.judgeModel === 'string') jm.value = v.judgeModel;   // the judge's ACTUAL current model/effort per tier is authoritative
     if (im && typeof v.indexModel === 'string') im.value = v.indexModel;

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -49,6 +49,21 @@ test("the gear posts kernel ops through ONE shared channel (never re-acquires th
     assert.ok(GEAR.includes(`'${op}'`), `gear must post ${op}`);
 });
 
+test("the Auto Nudge box speaks for every attached machine, and says so when they disagree", () => {
+  // /version answers for the kernel serving this page only, so the box used to show one machine's
+  // setting as everyone's — the user 2026-08-14 unchecked it and the other machine kept nudging with
+  // nothing on screen to say so. The reconcile reads each attached row's own setting off /tunnels.
+  assert.ok(GEAR.includes("fetch(ku('/tunnels')"), "the box must check the OTHER kernels, not just /version");
+  assert.ok(GEAR.includes("an.indeterminate = true"), "hosts that disagree put the box in the mixed state");
+  assert.ok(GEAR.includes("rs-autonudge-split"), "…said in words too — a tri-state box alone reads past");
+  assert.ok(GEAR_CSS.includes(".rs-mixed"), "…and that marker needs its styling, or it inherits nothing");
+  assert.ok(/t\.status === 'up'/.test(GEAR) && /typeof t\.autoNudge === 'boolean'/.test(GEAR),
+    "only a CONNECTED host that actually reported a setting counts — never guess for a silent one");
+  // The description is the one level down: it names the machines, so it cannot be a frozen literal.
+  assert.ok(/asub\.textContent = AUTONUDGE_SUB\s*\n?\s*\+/.test(GEAR) && GEAR.includes("split.join("),
+    "the hover line must name who differs");
+});
+
 test("the gear owns its browseResult (the reply lands in the FEED document, not the chat's)", () => {
   assert.ok(GEAR.includes("'browseResult'") && GEAR.includes("'gear'"));
 });

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -420,6 +420,33 @@ test("routeOutbound: a hover CLEAR broadcasts to every kernel (no sid to route b
   assert.deepEqual(on, [{ host: "TESTHOST", msg: { type: "timelineHover", sid: U, segIds: [] } }]);
 });
 
+test("routeOutbound: the gear's kernel-side settings reach EVERY attached kernel", () => {
+  // The user 2026-08-14: Auto Nudge switched off in the dashboard, and the sessions on the other machine
+  // went on being nudged for days. setAutoNudge carries no session id, so it fell through to LOCAL and
+  // the remote kernel never heard it — while the gear, which fills the box from the LOCAL /version,
+  // showed the change as applied everywhere. Silent in both directions.
+  for (const msg of [{ type: "setAutoNudge", enabled: false },
+                     { type: "setJudgeModel", model: "haiku" },
+                     { type: "setIndexModel", model: "haiku" },
+                     { type: "setJudgeEffort", effort: "high" },
+                     { type: "setIndexEffort", effort: "" }]) {
+    const routes = routeOutbound(msg, new Set(["TESTHOST", "gpu1"]));
+    assert.deepEqual(routes.map((r) => r.host).sort(), ["", "TESTHOST", "gpu1"].sort(), msg.type);
+    for (const r of routes) assert.deepEqual(r.msg, msg, "the kernels are host-blind: same message to each");
+  }
+  // with nothing attached it is the single-kernel path, byte for byte
+  assert.deepEqual(routeOutbound({ type: "setAutoNudge", enabled: true }),
+                   [{ host: "", msg: { type: "setAutoNudge", enabled: true } }]);
+  // an explicit host still wins — the popover can ask ONE machine (that branch runs first)
+  assert.deepEqual(routeOutbound({ type: "setAutoNudge", enabled: true, host: "gpu1" }, new Set(["gpu1"])),
+                   [{ host: "gpu1", msg: { type: "setAutoNudge", enabled: true } }]);
+  // NOT broadcast: a default directory is a path on one machine, and the colormap/palette are this
+  // viewer's display prefs — both stay with the kernel serving the page.
+  for (const msg of [{ type: "setDefaultDir", value: "~/code" }, { type: "setColormap", name: "aurora" },
+                     { type: "setPalette", name: "default" }])
+    assert.deepEqual(routeOutbound(msg, new Set(["gpu1"])), [{ host: "", msg }], msg.type);
+});
+
 test("routeOutbound: openFolder ALWAYS stays local, with a remote id's host prefix left INTACT", () => {
   // the user 2026-07-03: unlike every other id-bearing message, opening a folder means "open a window on
   // the machine the BROWSER runs on" — routing it to the remote kernel would open it on that headless


### PR DESCRIPTION
## The bug

`setAutoNudge` carries no session id, so `routeOutbound` fell through to
`return [{ host: LOCAL, msg }]` and no attached kernel ever heard it.

Switching Auto Nudge off in the dashboard left the other machine nudging its
sessions — for days, with nothing on screen to say so. The gear fills its box
from `/version`, which answers for the kernel serving the page, so the box read
unchecked while that kernel kept going. Silent in both directions: the routing
dropped nothing visibly (`dropWarn` never fires for a route that was never
made), and the display had no way to know.

Reproduced on two attached kernels: one reporting `autoNudge: false`, the other
`autoNudge: true` and firing nudges. The kernel handler itself was always fine —
sending `setAutoNudge` straight over the WS flips `auto-nudge.json` and
`/version` immediately.

The four judge-tier pickers routed the same way, and their own `.rs-sub`
descriptions already promise they follow to every connected machine's kernel.

## The fix

**Routing** — the five kernel-side gear settings broadcast, like the hover clear
(`timelineHover` + `off`) that had the same no-sid problem. `setDefaultDir` stays
local (a path on one machine means nothing on another), as do `setColormap` /
`setPalette`, which are this viewer's display prefs. An explicit `host` still
wins; with nothing attached the single-kernel path is byte-for-byte unchanged.

**Display** — broadcasting fixes it going forward but says nothing about machines
that already disagree, so the box stops speaking for kernels it cannot see. The
`/version` poll the supervisor already runs per pass carries each remote's own
setting onto its `/tunnels` row; a connected host that differs puts the checkbox
in the mixed state, marks the label `mixed`, and is named in the hover line.
Clicking a mixed box picks one answer for everyone.

A host that never reported a setting — an older kernel, a row that has not
polled — is left out rather than read as off: guessing would invent a
disagreement and invite a click that changes a machine nobody asked about. Same
for a row that is not `up`, whose values are a memory (`_remote_public`'s stale
note). A failed `/tunnels` leaves the local answer standing.

## Tests

- `ui/webview/multi-kernel-merge.test.ts` — each of the five settings reaches
  every attached kernel; explicit `host` still wins; nothing attached is
  unchanged; the three viewer/machine-local settings stay local.
- `ui/webview/gear.test.ts` — the box reconciles off `/tunnels`, goes
  indeterminate, is marked in words, and counts only connected hosts that
  actually reported.
- `tests/test_auto_nudge_every_kernel.py` — the poll brings the setting back with
  the sha; an older kernel that omits the field polls as `None`, not `False`; a
  non-boolean never reaches the checkbox; the public row carries it.

Each new test fails on `main` and passes here (10 Python failures, 2 node
failures before the fix).

`python3 -m pytest -q` → 4561 passed, 34 skipped. `npm test` → 1949 passed.
`npm run typecheck` clean. The bats suite was not run (no `bats` on this
machine); this change touches no shell surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)