### PR TITLE
Comment highlight: highlighter yellow, one unbroken stroke

### DIFF
--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -221,8 +221,30 @@ test("marks use the prefix-tolerant anchor matcher", () => {
   assert.match(UI, /findAnchorRange\(nodes\.map\(\(t\) => t\.data\)\.join\(""\), th\.exact\)/);
 });
 
-test("highlight chrome wears the romp accent, popover wears the menu card", () => {
-  assert.match(CSS, /mark\.cmt-hl \{[^}]*var\(--accent\)/s);
+test("the highlight is highlighter-YELLOW — never the selection blue — and one unbroken block", () => {
+  assert.match(CSS, /--cmt-hl: #ffd54a;/);
+  assert.match(CSS, /mark\.cmt-hl \{[^}]*var\(--cmt-hl\)/s);
+  assert.doesNotMatch(CSS.match(/mark\.cmt-hl \{[^}]*\}/s)![0], /var\(--accent\)/);
+  // the radius sits only on the run's outer ends — per-segment rounding drew word-boundary seams
+  assert.match(UI, /classList\.toggle\("hl-first", i === 0\)/);
+  assert.match(CSS, /mark\.cmt-hl\.hl-first \{ border-top-left-radius: 2px/);
+  // a fully-covered inline-code span tints at the ELEMENT: a mark inside it can't paint the code's
+  // padded background, which left an untinted sliver around every code word (the word-island look)
+  assert.match(UI, /host\.classList\.toggle\("cmt-hl-host", th\.status !== "resolved"\)/);
+  assert.match(UI, /p\.classList\.remove\("cmt-hl-host"\)/);
+  assert.match(CSS, /code\.cmt-hl-host \{ background: color-mix\(in srgb, var\(--cmt-hl\) 30%, var\(--code-bg\)\)/);
+  assert.match(CSS, /code\.cmt-hl-host > mark\.cmt-hl \{ background: transparent/);
+});
+
+test("the tint ladder keeps every state distinct: base < unread < hover", () => {
+  const base = CSS.match(/mark\.cmt-hl \{[^}]*var\(--cmt-hl\) (\d+)%/s)![1];
+  const unread = CSS.match(/mark\.cmt-hl\.unread \{[^}]*var\(--cmt-hl\) (\d+)%/s)![1];
+  const hover = CSS.match(/mark\.cmt-hl:hover \{[^}]*var\(--cmt-hl\) (\d+)%/s)![1];
+  assert.ok(Number(base) < Number(unread), "unread must read stronger than read");
+  assert.ok(Number(unread) < Number(hover), "hovering an unread mark must still answer");
+});
+
+test("comment chrome (badge, popover card) stays on the menu vocabulary", () => {
   assert.match(CSS, /\.cmt-pop \{[^}]*#252526[^}]*\}/s);
   assert.match(CSS, /\.cmt-pop \{[^}]*border-radius: 6px/s);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5182,6 +5182,7 @@ function applyBranchChips(sid: string, v: View): void {
 function unwrapCommentMark(markEl: HTMLElement): void {
   const p = markEl.parentNode;
   if (!p) return;
+  if (p instanceof Element) p.classList.remove("cmt-hl-host");   // an inline-code span it tinted
   while (markEl.firstChild) p.insertBefore(markEl.firstChild, markEl);
   markEl.remove();
   p.normalize();
@@ -5228,7 +5229,23 @@ function ensureCommentMark(turn: HTMLElement, th: CommentThread): void {
       m.appendChild(mid);
     }
   }
-  for (const seg of Array.from(turn.querySelectorAll(sel))) styleCommentMark(seg as HTMLElement, th);
+  // One unbroken stroke. The wrap pass is hole-free by construction (sliceRanges covers every text
+  // node of the contiguous match range, interior whitespace included — verified against a DOM port,
+  // 2026-08-13), so the word-island look had two OTHER causes: per-segment corner rounding (the
+  // radius now sits only on the run's outer ends) and inline-code PADDING — a mark inside a <code>
+  // span cannot paint the element's own padded background, leaving an untinted sliver around every
+  // code word. When a segment covers a code span's whole text, tint the span itself (cmt-hl-host).
+  const segs = Array.from(turn.querySelectorAll(sel)) as HTMLElement[];
+  for (let i = 0; i < segs.length; i++) {
+    styleCommentMark(segs[i], th);
+    segs[i].classList.toggle("hl-first", i === 0);
+    segs[i].classList.toggle("hl-last", i === segs.length - 1);
+    const host = segs[i].parentElement;
+    if (host && host.tagName === "CODE" && host.parentElement?.tagName !== "PRE"
+        && host.childNodes.length === 1) {
+      host.classList.toggle("cmt-hl-host", th.status !== "resolved");   // resolved dims like the marks
+    }
+  }
 }
 
 function styleCommentMark(m: HTMLElement, th: CommentThread): void {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -35,6 +35,10 @@
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
      their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it. */
   --accent: #9cd2ff; --accent-fg: #0c1a2e;
+  /* Comment-highlight yellow (the user 2026-08-13): the marked passage reads like a highlighter
+     stroke, DISTINCT from both the accent blue (selection/chrome) and the working-status yellow
+     chip. Text-highlight use only — comment chrome (badge, buttons, chips) stays var(--accent). */
+  --cmt-hl: #ffd54a;
   /* fast mode ON — the CLI's own fastMode orange, a STATUS color (means "this session runs fast
      mode"), so the badge reads the same here as in the Claude Code TUI. Not the accent. */
   --fast: #ff6a00;
@@ -2345,20 +2349,29 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
    rendered text drifts and the exact-match mark can't land. The popover is a pane-local card on the
    menu vocabulary (#252526, hairline border, 6px radius, the .ctx-menu shadow) — deliberately NOT a
    dimmed modal: the conversation stays readable beside the thread. */
-/* A SOLID tint, not a dashed underline (the user 2026-08-13: "like a comment would be on Google
-   Docs") — the underline read as a link, not a highlight. Unread strengthens the same tint rather
-   than adding a second cue, so "there's something to read" stays legible at a glance. */
+/* A SOLID highlighter-YELLOW stroke (the user 2026-08-13: like a comment on a Google Doc, and
+   never the same color as plain text selection). One unbroken block: the wrap pass covers every
+   interior node by construction; the radius sits only on the run's outer ends (hl-first/hl-last)
+   so segment boundaries never draw seams; and a fully-covered inline-code span is tinted at the
+   ELEMENT (cmt-hl-host) — a mark inside it can't paint the code's padded background, which left an
+   untinted sliver around every code word. Tint ladder, each state distinct: base 30% < unread 45%
+   < hover 58% (hovering an unread mark still answers). */
 mark.cmt-hl {
-  background: color-mix(in srgb, var(--accent) 32%, transparent);
+  background: color-mix(in srgb, var(--cmt-hl) 30%, transparent);
   color: inherit;
-  border-radius: 2px;
+  border-radius: 0;
   cursor: pointer;
 }
-mark.cmt-hl:hover { background: color-mix(in srgb, var(--accent) 46%, transparent); }
+mark.cmt-hl.unread { background: color-mix(in srgb, var(--cmt-hl) 45%, transparent); }
+mark.cmt-hl:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, transparent); }
 mark.cmt-hl.resolved { background: rgba(255, 255, 255, 0.08); }
-mark.cmt-hl.unread { background: color-mix(in srgb, var(--accent) 44%, transparent); }
 mark.cmt-hl.busy { animation: cmt-busy-pulse 1.2s ease-in-out infinite; }
-@keyframes cmt-busy-pulse { 50% { background: color-mix(in srgb, var(--accent) 50%, transparent); } }
+mark.cmt-hl.hl-first { border-top-left-radius: 2px; border-bottom-left-radius: 2px; }
+mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 2px; }
+@keyframes cmt-busy-pulse { 50% { background: color-mix(in srgb, var(--cmt-hl) 50%, transparent); } }
+.md :not(pre) > code.cmt-hl-host { background: color-mix(in srgb, var(--cmt-hl) 30%, var(--code-bg)); }
+.md :not(pre) > code.cmt-hl-host > mark.cmt-hl { background: transparent; }
+.md :not(pre) > code.cmt-hl-host:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, var(--code-bg)); }
 
 .turn.has-cmt { position: relative; }
 .cmt-badge {
@@ -2392,7 +2405,7 @@ mark.cmt-hl.busy { animation: cmt-busy-pulse 1.2s ease-in-out infinite; }
 }
 .cmt-x:hover { opacity: 1; }
 .cmt-quote {
-  padding: 4px 8px; border-left: 2px solid var(--accent); border-radius: 2px;
+  padding: 4px 8px; border-left: 2px solid var(--cmt-hl); border-radius: 2px;
   background: rgba(255, 255, 255, 0.04);
   font-size: 0.92em; opacity: 0.75;
   display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;


### PR DESCRIPTION
Two reports from live use, both fixed:

**Wrong color.** The comment highlight wore the accent blue — indistinguishable from plain text selection. It now uses a highlighter yellow (`--cmt-hl: #ffd54a`), applied only to the marked text and the popover's quote bar; badges, buttons, and branch chips stay on the accent. Tint ladder keeps states distinct: base 30% < unread 45% < hover 58%.

**The highlight looked broken into words.** An adversarial DOM-port verification (jsdom port of the exact wrap code, 10 scenarios) proved the text wrap itself is hole-free — interior spaces are always wrapped — and identified the two real causes: per-segment `border-radius` drew a seam at every styled-word boundary (the radius now sits only on the run's outer ends via `hl-first`/`hl-last`), and inline-code padding, which a mark inside the `code` span cannot paint, leaving an untinted sliver around every code word. A segment covering a code span's whole text now tints the span itself (`cmt-hl-host`, cleared on unwrap and dimmed like the marks when resolved). The same verification showed my first-draft "bridge" pass could never fire; it is removed rather than shipped as dead code.

Tests: pins for the yellow variable, the accent's absence from the mark rule, the end-cap radius, the code-host tint and its unwrap cleanup, plus a ladder test asserting base < unread < hover numerically. Suites green (pytest 4558, node 1949), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)