### PR TITLE
The command gesture outlives its live chip: durable /effort on the user's side

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10862,6 +10862,33 @@ def _effort_changes(sid):
     return out
 
 
+def _cmd_gestures(sid):
+    """Durable command-gesture markers from states/<sid>.jsonl — {"t":…,"cmdGesture":"/effort high"} lines the
+    SDK backend writes the moment a /model-/effort-/auth-style pick is made (append_cmd_gesture). Returns
+    [{"t":epoch,"cmd":str}, …] oldest first, so build_session can interleave a persistent right-side gesture
+    chip once prune_live retires the synthesized live one (the user 2026-08-14: the user's side of the history
+    keeps what they did; the applied note keeps that it happened). SDK-only — tmux commands are real
+    transcript turns already."""
+    p = jd.STATE / "states" / ("%s.jsonl" % sid)
+    out = []
+    try:
+        with open(p, errors="replace") as f:
+            for line in f:
+                if '"cmdGesture"' not in line:             # cheap prefilter — most lines are plain state records
+                    continue
+                try:
+                    o = json.loads(line)
+                except Exception:
+                    continue
+                v = o.get("cmdGesture")
+                if isinstance(v, str) and v and o.get("t"):
+                    out.append({"t": int(o["t"]), "cmd": v})
+    except OSError:
+        return []
+    out.sort(key=lambda r: r["t"])
+    return out
+
+
 # ── background-task box (the user 2026-06-26) ───────────────────────────────────────────────────────
 # Surface run_in_background tasks in the chat: a launch (a tool_use with run_in_background:true) paired with
 # its <task-notification> result. The harness folds those notifications into "system reminders" inline; this
@@ -13468,6 +13495,16 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     recoveries = _retry_recoveries(sid); _ri = 0
     gaveups = _retry_gaveups(sid); _gi = 0            # the storm that DIDN'T recover → "gave up after N retries"
     efforts = _effort_changes(sid); _ei = 0
+    # Persistent command-gesture chips (the user 2026-08-14): the synthesized /model-/effort-/auth chip lives
+    # only in the backend's _live tail and stale_cmd prunes it on the next human turn — the durable marker
+    # takes over here. DEDUP'd by (t, text) against a still-live chip so the same gesture never doubles;
+    # flushed BEFORE the efforts loop so a same-second "/effort X" gesture sits above its "effort set to X".
+    gestures = _cmd_gestures(sid); _cgi = 0
+    _live_cmd_keys = set()
+    for _t in session["turns"]:
+        for _a in _t["atoms"]:
+            if _a.get("command") and _a.get("_echo_text"):
+                _live_cmd_keys.add((int(_a.get("t") or 0), _a["_echo_text"]))
     # Orphan replies (the user 2026-07-21): assistant text that streamed live but the transcript never kept
     # (an API-errored try). Interleave it back at its timestamp, DEDUP'd against what the disk DID keep — a
     # retry that re-replied must not double. Match exact, and either-way prefix (a partial stream vs its full
@@ -13487,7 +13524,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     # rollback was consumed (the user 2026-08-03).
     _landed_uuids = set(parsed.get("landedTextUuids") or ())
     def _flush_recoveries(upto):
-        nonlocal _ri, _ei, _oi, _gi
+        nonlocal _ri, _ei, _oi, _gi, _cgi
         while _oi < len(orphans) and (upto is None or orphans[_oi]["t"] <= upto):
             _o = orphans[_oi]; _oi += 1
             if _o["uuid"] and _o["uuid"] in _landed_uuids:
@@ -13506,6 +13543,12 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
             events.append({"kind": "retryGaveUp", "retries": _g["retries"],   # above the error text it settled with
                            "errorKind": _g["errorKind"], "ts": iso(_g["t"]),
                            "uuid": "gaveup:%d" % _g["t"]})
+        while _cgi < len(gestures) and (upto is None or gestures[_cgi]["t"] <= upto):
+            _cg = gestures[_cgi]; _cgi += 1
+            if (_cg["t"], _cg["cmd"]) in _live_cmd_keys:
+                continue                                   # the synthesized live chip still shows this gesture
+            events.append({"kind": "cmdGesture", "cmd": _cg["cmd"], "ts": iso(_cg["t"]),
+                           "uuid": "cmdg:%d" % _cg["t"]})
         while _ei < len(efforts) and (upto is None or efforts[_ei]["t"] <= upto):
             _e = efforts[_ei]; _ei += 1
             events.append({"kind": "effortApplied", "effort": _e["effort"], "ts": iso(_e["t"]),

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -586,6 +586,21 @@ def append_effort_applied(state_dir: Path, sid: str, effort: str, t: int | None 
         f.write(json.dumps(rec) + "\n")
 
 
+def append_cmd_gesture(state_dir: Path, sid: str, text: str, t: int | None = None) -> None:
+    """Record a command GESTURE — a /model-/effort-/auth-style pick — at the moment it was ASKED FOR. The
+    synthesized live chip that acknowledges the pick is in-memory only and prune_live's stale_cmd retires it
+    on the next human turn, so the user's own gesture vanished from their side of the history (the user
+    2026-08-14: the right side should keep what you did; the applied note keeps that it happened). The kernel
+    interleaves a durable `cmdGesture` chat event from this marker, deduped against the still-live chip by
+    (t, text). Its own key ("cmdGesture") so the state/awaiting/recovery readers, which filter by their own
+    keys, skip it. `text` is the full display form, e.g. "/effort high"."""
+    p = Path(state_dir) / "states" / (sid + ".jsonl")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    rec = {"t": int(time.time()) if t is None else int(t), "cmdGesture": str(text)}
+    with open(p, "a") as f:
+        f.write(json.dumps(rec) + "\n")
+
+
 def append_machine_cut(state_dir: Path, sid: str, cause: str, t: float | None = None) -> None:
     """Record that ROMP cut this session's turn and is continuing it — written at the instant a resume
     notice is QUEUED (boot reconcile → "restart"; _heal_cut_session → "crash"), which is the event the
@@ -4095,6 +4110,9 @@ class SdkBackend:
                 "type": "user", "uuid": uid, "session_id": sid, "fsid": s.resume_sid, "parentUuid": None,
                 "t": t, "author": "human", "command": "/model", "_echo_text": disp,
                 "message": {"role": "user", "content": [{"type": "text", "text": disp}]}}
+            # The DURABLE twin of the live chip (the user 2026-08-14): same t and text, so build_session
+            # can dedup while the chip is live and take over seamlessly once stale_cmd retires it.
+            append_cmd_gesture(self.state_dir, sid, disp, t=t)
             self._wake_push()
         else:
             # DORMANT (no live thread): no turn is coming to report a real name, so resolve to the chosen
@@ -4217,6 +4235,7 @@ class SdkBackend:
                 "type": "user", "uuid": uid, "session_id": sid, "fsid": s.resume_sid, "parentUuid": None,
                 "t": t, "author": "human", "command": "/effort", "_echo_text": disp,
                 "message": {"role": "user", "content": [{"type": "text", "text": disp}]}}
+            append_cmd_gesture(self.state_dir, sid, disp, t=t)   # durable twin — see set_model
             self._wake_push()
         return True
 
@@ -4252,6 +4271,7 @@ class SdkBackend:
                 "type": "user", "uuid": uid, "session_id": sid, "fsid": s.resume_sid, "parentUuid": None,
                 "t": t, "author": "human", "command": "/auth", "_echo_text": disp,
                 "message": {"role": "user", "content": [{"type": "text", "text": disp}]}}
+            append_cmd_gesture(self.state_dir, sid, disp, t=t)   # durable twin — see set_model
             self._wake_push()
         return True
 

--- a/tests/test_kernel_cmd_gesture.py
+++ b/tests/test_kernel_cmd_gesture.py
@@ -1,0 +1,95 @@
+"""Durable command-gesture chips (the user 2026-08-14): a /model-/effort-/auth-style pick synthesizes a live
+chip on the user's side of the chat, but the chip lives only in the backend's in-memory _live tail and
+prune_live's stale_cmd retires it on the next human turn — the user's own gesture then vanished from their
+side of the history, while the left-rail "effort set to X" note (the applied moment) stayed. Mirror the
+effortApplied mechanism at the REQUEST moment: the backend writes a durable {"t":…,"cmdGesture":"/effort
+high"} line alongside the live chip (same t, same text), and build_session interleaves a persistent
+`cmdGesture` event by time, DEDUP'd by (t, text) against a still-live chip so the gesture never doubles.
+Right side keeps what you did; the applied note keeps that it happened.
+
+Behavioural tests of the marker (append_cmd_gesture) + the kernel reader (_cmd_gestures), plus source pins on
+the three write sites and the build interleave/dedup.
+"""
+import inspect
+import json
+import os
+import unittest
+from importlib.machinery import SourceFileLoader
+import tempfile
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_cmdg", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_cmdg", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+BACKEND_SRC = open(os.path.join(BIN, "romp_sdk_backend.py")).read()
+
+
+class CmdGestureMarkerRoundTrip(unittest.TestCase):
+    """append_cmd_gesture writes to states/<sid>.jsonl; _cmd_gestures reads it back — and the plain
+    state / awaiting / recovery / effort readers must SKIP it (each filters by its own key)."""
+    def _states_dir(self):
+        (km.jd.STATE / "states").mkdir(parents=True, exist_ok=True)
+        return km.jd.STATE
+
+    def test_write_then_read_returns_gestures_oldest_first(self):
+        state_dir = self._states_dir()
+        sid = "TESTHOST-cmdg-1"
+        (km.jd.STATE / "states" / (sid + ".jsonl")).unlink(missing_ok=True)
+        sb.append_cmd_gesture(state_dir, sid, "/effort high", t=1000)
+        sb.append_cmd_gesture(state_dir, sid, "/model sonnet", t=2000)
+        self.assertEqual(km._cmd_gestures(sid),
+                         [{"t": 1000, "cmd": "/effort high"}, {"t": 2000, "cmd": "/model sonnet"}])
+
+    def test_no_file_or_no_markers_is_empty(self):
+        self.assertEqual(km._cmd_gestures("TESTHOST-nope-cmdg"), [])
+
+    def test_gesture_markers_do_not_disturb_the_other_readers(self):
+        state_dir = self._states_dir()
+        sid = "TESTHOST-cmdg-2"
+        p = km.jd.STATE / "states" / (sid + ".jsonl")
+        p.unlink(missing_ok=True)
+        sb.append_state(state_dir, sid, "working", t=10)
+        sb.append_cmd_gesture(state_dir, sid, "/effort high", t=20)      # interleaved, later
+        sb.append_effort_applied(state_dir, sid, "high", t=30)
+        self.assertEqual(km._last_state(sid)[0], "working", "the gesture line has no 'state' key → skipped")
+        self.assertEqual(km._effort_changes(sid), [{"t": 30, "effort": "high"}], "effort reader skips it too")
+        self.assertEqual(km._cmd_gestures(sid), [{"t": 20, "cmd": "/effort high"}], "and it ignores the effort line")
+        # an empty value is not surfaced
+        p.write_text(json.dumps({"t": 40, "cmdGesture": ""}) + "\n")
+        self.assertEqual(km._cmd_gestures(sid), [])
+
+
+class CmdGestureSourcePins(unittest.TestCase):
+    def test_backend_writes_the_marker_beside_each_synthesized_live_chip(self):
+        # every setter that synthesizes a live command chip (set_model / set_effort / set_auth) writes the
+        # durable twin with the SAME t and disp, so build_session's (t, text) dedup holds while the chip is
+        # live and the durable event takes over seamlessly once stale_cmd retires it.
+        self.assertEqual(BACKEND_SRC.count("append_cmd_gesture(self.state_dir, sid, disp, t=t)"), 3)
+        for uid_tag in ('"cmd:%d:model"', '"cmd:%d:effort"', '"cmd:%d:auth"'):
+            i = BACKEND_SRC.index(uid_tag)
+            j = BACKEND_SRC.index("append_cmd_gesture(self.state_dir, sid, disp, t=t)", i)
+            k = BACKEND_SRC.index("self._wake_push()", i)
+            self.assertLess(j, k, "the marker is on disk before the push that rebuilds the chat")
+
+    def test_build_session_interleaves_and_dedups_against_the_live_chip(self):
+        src = inspect.getsource(km.build_session)
+        self.assertIn("gestures = _cmd_gestures(sid)", src)
+        self.assertIn('if (_cg["t"], _cg["cmd"]) in _live_cmd_keys:', src)
+        self.assertIn('events.append({"kind": "cmdGesture", "cmd": _cg["cmd"], "ts": iso(_cg["t"]),', src)
+        # flushed by the SAME time-gate as the other durable notes, and BEFORE the efforts loop, so a
+        # same-second "/effort X" gesture renders above its "effort set to X" applied note
+        gi = src.index('while _cgi < len(gestures) and (upto is None or gestures[_cgi]["t"] <= upto):')
+        ei = src.index('while _ei < len(efforts) and (upto is None or efforts[_ei]["t"] <= upto):')
+        self.assertLess(gi, ei, "gesture flush precedes the effort-applied flush")
+        # the dedup keys come from the LIVE-MERGED atoms' (t, echo text) — the exact pair the setters stamp
+        self.assertIn('_live_cmd_keys.add((int(_a.get("t") or 0), _a["_echo_text"]))', src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/chat-cmd-gesture.test.ts
+++ b/ui/webview/chat-cmd-gesture.test.ts
@@ -1,0 +1,41 @@
+// Durable command-gesture chip in the chat (the user 2026-08-14): the synthesized /model-/effort-/auth chip
+// lives in the backend's _live tail and stale_cmd prunes it on the next human turn — the user's own gesture
+// vanished from their side of the history while the left-rail applied note stayed. The kernel now writes a
+// durable {"t","cmdGesture"} marker at the request moment and interleaves a `cmdGesture` event once the live
+// chip retires; render.ts draws it in the SAME dress as a live command turn (turn-user flex-end → the user's
+// side, ✦ + the shared mono chip), so the live→durable swap is invisible. Source pins (no jsdom for the chat
+// renderer).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("cmdGesture is a ChatEvent, dispatched to its own renderer", () => {
+  assert.match(RENDER, /kind: "cmdGesture"; cmd: string; ts\?: string; uuid\?: string/);
+  assert.match(RENDER, /ev\.kind === "cmdGesture"\) return renderCmdGesture\(ev\)/);
+});
+
+test("renderCmdGesture wears the live command turn's exact dress — right side, ✦ + shared chip", () => {
+  const body = RENDER.slice(RENDER.indexOf("function renderCmdGesture"));
+  assert.match(body, /el\("div", "turn turn-user turn-cmd"\)/);   // .turn-user's flex-end → the user's side
+  assert.match(body, /dot\("user"\)/);                            // same solid rail dot as a live prompt
+  assert.match(body, /el\("div", "user-bubble md cmd-row"\)/);
+  assert.match(body, /renderSlashCmd\(bubble, ev\.cmd\)/);        // the SHARED chip renderer, not a copy
+  assert.match(body, /bubble\.textContent = ev\.cmd/);            // non-command text still shows, never drops
+});
+
+test("no edit/delete/fork affordances — a gesture is not a rewindable message", () => {
+  const body = RENDER.slice(RENDER.indexOf("function renderCmdGesture"),
+                            RENDER.indexOf("function", RENDER.indexOf("function renderCmdGesture") + 10));
+  assert.doesNotMatch(body, /msg-edit|msg-del|msg-fork/);
+});
+
+test("the gesture chip's ink is the outgoing-bubble blue on the chat's own ground", () => {
+  // the user 2026-08-14: the --code-bg terracotta tint read as a stray red — the chip now borrows
+  // .user-bubble's #2b6cef for border + text so the gesture still reads as "yours" without the bubble
+  assert.match(CSS, /\.user-bubble\.cmd-row \.slash-cmd-chip \{ background: var\(--bg\); color: #2b6cef;/);
+  assert.match(CSS, /\.user-bubble\.cmd-row \.slash-cmd-chip \{[^}]*border-color: #2b6cef/);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -187,6 +187,13 @@ type ChatEvent = (
   // and the synthesized /effort chip prunes on the next message — so this rail-anchored note marks WHEN the
   // new effort took effect, and stays. Kernel-interleaved by time, like `retried`. SDK-only.
   | { kind: "effortApplied"; effort: string; ts?: string; uuid?: string }
+  // Durable command GESTURE (the user 2026-08-14): a /model-/effort-/auth-style pick used to survive only as
+  // the synthesized live chip, which stale_cmd prunes on the next human turn — the user's own gesture then
+  // vanished from their side of the history while the applied note stayed. The kernel writes a
+  // {"t","cmdGesture"} marker at the request moment and interleaves this once the live chip retires, so the
+  // right side keeps "what you did" and the left rail keeps "it took effect". cmd is the full "/effort high"
+  // text. SDK-only, like effortApplied.
+  | { kind: "cmdGesture"; cmd: string; ts?: string; uuid?: string }
   // The model's safeguards flagged the prompt and the CLI retried the turn on a fallback model (the
   // transcript's system/model_refusal_fallback record). The reply that follows came from a DIFFERENT
   // model — conversation state that must be apparent in the chat, never silent (the user 2026-08-03).
@@ -1949,6 +1956,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
   if (ev.kind === "retryGaveUp") return renderRetryGaveUp(ev);
   if (ev.kind === "apiErrorNote") return renderApiErrorNote(ev);
   if (ev.kind === "effortApplied") return renderEffortApplied(ev);
+  if (ev.kind === "cmdGesture") return renderCmdGesture(ev);
   if (ev.kind === "modelFallback") return renderModelFallback(ev);
   if (ev.kind === "compact") return renderCompact(ev);
   return renderTool(ev);
@@ -2528,6 +2536,20 @@ function renderEffortApplied(ev: Extract<ChatEvent, { kind: "effortApplied" }>):
   line.appendChild(txt);
   line.title = "reasoning effort is a connect-time setting; the session reconnected to apply it, and this marks when the new level took effect";
   turn.appendChild(line);
+  return turn;
+}
+
+// The durable COMMAND-GESTURE row (the user 2026-08-14): wears the SAME dress as a live command turn —
+// turn-user's flex-end puts it on the user's side, ✦ + the mono chip via the shared renderSlashCmd — so the
+// moment prune_live retires the synthesized chip and this interleaved event takes over is invisible. No
+// edit/delete/fork affordances on purpose: the uuid is synthetic ("cmdg:<t>"), not a rewindable transcript
+// atom, and a gesture is not a message to edit.
+function renderCmdGesture(ev: Extract<ChatEvent, { kind: "cmdGesture" }>): HTMLElement {
+  const turn = el("div", "turn turn-user turn-cmd");
+  turn.appendChild(dot("user"));
+  const bubble = el("div", "user-bubble md cmd-row");
+  if (!renderSlashCmd(bubble, ev.cmd)) bubble.textContent = ev.cmd;
+  turn.appendChild(bubble);
   return turn;
 }
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1179,8 +1179,11 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .user-bubble.cmd-row { max-width: none; background: none; border: none; border-radius: 0;
   padding: 2px 0; color: var(--dim); }
 .user-bubble.cmd-row::before { content: "✦"; margin-right: 8px; color: var(--dim); }
-.user-bubble.cmd-row .slash-cmd-chip { background: var(--code-bg); color: var(--fg);
-  border-color: var(--box-border); }
+/* The chip's ink is the OUTGOING-BUBBLE blue on the chat's own ground (the user 2026-08-14: the --code-bg
+   terracotta tint read as a stray red here) — the same #2b6cef as .user-bubble, so the gesture still reads
+   as "yours" without the said-thing bubble. */
+.user-bubble.cmd-row .slash-cmd-chip { background: var(--bg); color: #2b6cef;
+  border-color: #2b6cef; }
 .user-bubble.cmd-row .slash-cmd-args { color: var(--dim); }
 /* ---------- romp-injected message (a feed nudge / follow-up) ----------
    A GRAY bubble in the SAME right-aligned spot as the blue user bubble (so it sits where "an outgoing


### PR DESCRIPTION
A /model-/effort-/auth pick synthesized a live chip that `stale_cmd` pruned on the next human turn, so the user's own gesture vanished from their side of the history while the left-rail "effort set to X" note stayed. The intended reading (the user 2026-08-14): the right side keeps what you did, the left rail keeps that it happened.

- **Backend**: each setter that synthesizes a live command chip (`set_model`/`set_effort`/`set_auth`) now also writes a durable `{"t","cmdGesture"}` marker to `states/<sid>.jsonl` with the same `t` and text (`append_cmd_gesture`, the `effortApplied` idiom at the request moment).
- **Kernel**: `build_session` interleaves a persistent `cmdGesture` event by time, deduped by `(t, text)` against a still-live chip so the gesture never doubles; flushed before the efforts loop so a same-second `/effort X` sits above its "effort set to X".
- **Webview**: `renderCmdGesture` wears the live command turn's exact dress (`turn-user turn-cmd`, ✦ + the shared `renderSlashCmd` chip), so the live-to-durable swap is invisible; no edit/delete/fork affordances (synthetic uuid, not a rewindable atom).
- **CSS**: the gesture chip sheds the `--code-bg` terracotta tint (read as a stray red) for the outgoing bubble's `#2b6cef` as border + text ink on `var(--bg)`.

Tests: `tests/test_kernel_cmd_gesture.py` (marker round-trip, reader isolation, source pins on the three write sites + interleave/dedup/order) and `ui/webview/chat-cmd-gesture.test.ts` (event kind, dispatch, dress, no affordances, chip ink). Full webview suite (1951) + typecheck + affected kernel modules pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)