### PR TITLE
The session prompt asks for cleanup once work has shipped

### DIFF
--- a/claude/romp-session-prompt.md
+++ b/claude/romp-session-prompt.md
@@ -26,6 +26,16 @@ genuinely mine to make.
 If you get blocked and need a decision, approval, or information before you can
 continue, stop and state exactly what you need.
 
+# Clean up after yourself
+
+When a piece of work is fully done — published, merged, or dropped on my
+say-so — remove the scaffolding you made for it, in the same turn you report it
+finished: worktrees you added (`git worktree remove`), branches that have
+merged, scratch files and one-off scripts. Say what you removed. Two hard
+limits: never delete anything holding uncommitted or unpushed work (park it
+and say where it is instead), and clean up only what you yourself created —
+another session's worktrees, branches, and files are not yours to touch.
+
 # Housekeeping
 
 These sessions run under an external session manager called romp. Anything it

--- a/tests/test_session_prompt.py
+++ b/tests/test_session_prompt.py
@@ -48,6 +48,21 @@ class SessionPrompt(unittest.TestCase):
         self.assertIn("make progress", self.flat,
                       "the prompt must license taking any visible path to progress without checking in")
 
+    def test_asks_for_cleanup_when_work_is_fully_done(self):
+        # the user 2026-08-14 (from a Claude Code team member's advice, via the systems audit): sessions
+        # should clean up their own scaffolding — worktrees, merged branches, scratch files — once work
+        # is PUBLISHED, so stale worktrees stop accumulating. Guarded on both sides: never anything
+        # holding uncommitted/unpushed work (the July-22 lost-prototype lesson), and never another
+        # session's things.
+        self.assertIn("clean up after yourself", self.flat,
+                      "the prompt must carry a cleanup-when-done section")
+        self.assertIn("worktree", self.flat,
+                      "the cleanup ask must name worktrees, the scaffolding that actually accumulates")
+        self.assertIn("never delete anything holding uncommitted or unpushed work", self.flat,
+                      "cleanup must be fenced off from the park-your-work safety net")
+        self.assertIn("only what you yourself created", self.flat,
+                      "cleanup must not license touching peer sessions' worktrees/branches")
+
     def test_housekeeping_note_preexplains_romp_artifacts(self):
         # The ONE place romp is named to a session (the user 2026-07-25): pre-explain the artifacts
         # every session eventually sees — [romp] notices and <!-- romp-* --> comments — so a kernel


### PR DESCRIPTION
Worktree/branch cleanup existed only as prose in this repo's CLAUDE.md, enforced by nothing (2026-08-14 systems audit, from a Claude Code team member's advice). The harness prompt appended to every session now carries a "Clean up after yourself" section: when work is published, merged, or expressly dropped, remove the worktrees/branches/scratch you created, in the wrap-up turn, saying what was removed. Fenced on both sides: never anything holding uncommitted or unpushed work (the July-22 lost-prototype lesson stays intact — the clear wrap-up is deliberately untouched, since a clear is the moment work gets parked, not deleted), and never another session's things. Tests: four new pins in tests/test_session_prompt.py; test_session_prompt + test_injected_voice pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)