### PR TITLE
A machine-cut turn's resume fork keeps its history: recorded lineage, stitched chain

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -513,7 +513,8 @@ class FileAdapter:
     ancestors and drop out for free; `/clear` leaves no parent link so the walk
     stops there and pre-clear history drops out naturally."""
 
-    def __init__(self, candidate_files, leaf_path, leaf_override=None):
+    def __init__(self, candidate_files, leaf_path, leaf_override=None, resume_links=None):
+        self.resume_links = dict(resume_links or {})   # {to_fsid: from_fsid} — recorded resume forks (states/ rows)
         self.by_uuid = {}        # uuid -> record
         self.fsid_of = {}        # uuid -> transcript file stem (provenance / click-to-open)
         self.seq_of = {}         # uuid -> global read order (tie-break for equal timestamps)
@@ -560,6 +561,32 @@ class FileAdapter:
         if leaf_override and leaf_override in self.by_uuid:
             self.leaf_uuid = leaf_override
         self._repair_compaction_stitches()
+        self._stitch_resume_forks()
+
+    def _stitch_resume_forks(self):
+        """Some CLI resumes of a machine-cut turn FORK the transcript with a FRESH head (parentUuid
+        null, no cross-file back-link) instead of continuing the chain. On disk that fork is
+        byte-indistinguishable from a /clear, so kept_uuids dropped the ENTIRE pre-cut conversation
+        and the judges never saw the cut turn's work again — an hourly watch's finding lost its card
+        to two mid-turn restarts (the user 2026-08-14). The kernel records the fork the moment the
+        resumed CLI's init reports the new fsid (states/ resumeFork rows -> resume_links), so the
+        lineage is an exact recorded event, never a guess: re-point the fork head's parent at the
+        resumed file's last uuid-bearing record, restoring ONE chain the walk can cross (the
+        compaction-stitch precedent above). Only a genuinely fresh head is stitched — an intact
+        back-link is never overridden — and a /clear records no lineage, so its history keeps
+        dropping by design."""
+        if not self.resume_links:
+            return
+        first_of, last_of = {}, {}
+        for u in self.by_uuid:               # insertion order = file read order
+            fs = self.fsid_of.get(u)
+            if fs not in first_of:
+                first_of[fs] = u
+            last_of[fs] = u
+        for to, frm in self.resume_links.items():
+            head, tail = first_of.get(to), last_of.get(frm)
+            if head and tail and head != tail and self.parent_of.get(head) is None:
+                self.parent_of[head] = tail
 
     def _repair_compaction_stitches(self):
         """Claude Code sometimes writes a compact_boundary whose logicalParentUuid points
@@ -1308,6 +1335,20 @@ def _load_states(states):
     return list(states) if isinstance(states, list) else list(_read_jsonl(states))
 
 
+def resume_fork_links(srows):
+    """{to_fsid: from_fsid} from states/ resumeFork rows — the kernel's exact record that a resume of
+    a machine-cut turn FORKED the transcript (fresh head) instead of continuing the chain. See
+    FileAdapter._stitch_resume_forks for why the parse needs it; the kernel's episode-boundary check
+    reads the same rows (jd.resume_lineage) to keep the fork from being processed as a /clear. Last
+    row wins per fork head; malformed rows are skipped (a missing lineage simply keeps the old drop)."""
+    links = {}
+    for r in srows or []:
+        rf = r.get("resumeFork")
+        if isinstance(rf, dict) and rf.get("from") and rf.get("to"):
+            links[str(rf["to"])] = str(rf["from"])
+    return links
+
+
 def parse_session(leaf_path, rompuuid=None, name=None, color="#888888", dir=None,
                   candidate_files=None, states=None, postal_log=None, now=None, sdk_human=False,
                   leaf_override=None):
@@ -1335,10 +1376,28 @@ def parse_session(leaf_path, rompuuid=None, name=None, color="#888888", dir=None
     if candidate_files is None:
         candidate_files = [str(leaf_path)]
     postal_index = _load_postal_index(postal_log)
-    adapter = FileAdapter(candidate_files, leaf_path, leaf_override=leaf_override)
+    _srows = _load_states(states)
+    links = resume_fork_links(_srows)
+    if links:
+        # The lineage closure joins the candidate set: a fork chain across several restarts needs
+        # every resumed-from file present for the stitched walk to cross (the caller's anchor covers
+        # only one hop). Resolved HERE so both parses (the judge's and the kernel's) inherit it from
+        # the one states plumbing they already share. From-files are frozen after their fork (the CLI
+        # writes only the new file), so the callers' cache keys — candidate files + the states file,
+        # whose mtime moves when a lineage row lands — stay honest without knowing about these.
+        have = {Path(f).stem for f in candidate_files}
+        stem, hops = leaf_path.stem, 0
+        candidate_files = list(candidate_files)
+        while stem in links and hops < 16:
+            stem = links[stem]
+            hops += 1
+            fp = leaf_path.with_name(stem + ".jsonl")
+            if stem not in have and fp.exists():
+                candidate_files.append(str(fp))
+                have.add(stem)
+    adapter = FileAdapter(candidate_files, leaf_path, leaf_override=leaf_override, resume_links=links)
     adapter.sdk_human = sdk_human            # SDK-backed session → unmarked promptSource "sdk" is the human
     atoms = adapter.atoms(rompuuid, postal_index)
-    _srows = _load_states(states)
     landed = adapter.landed_text_uuids()         # replies the disk kept on ANY branch — never a loss
     orphans = synthesize_orphans(_srows, atoms, landed_text_uuids=landed)
     #                                            # salvaged replies FIRST: they are real atoms the turn

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -146,7 +146,7 @@ JUDGE_FAIL_CAP = 3                       # the same rule for every other retryin
 #                                          model actually wrote. Closer / grouper / consolidator / courier; the
 #                                          planner (PLAN_PARSE_RETRIES) and distiller/briefer (DISTILL_FAIL_CAP)
 #                                          already had their own.
-PLACEMENTS_V = 8                         # placements-identity schema version (plan P2, the user 2026-07-06).
+PLACEMENTS_V = 9                         # placements-identity schema version (plan P2, the user 2026-07-06).
 #                                          v2 (2026-07-09): a 07-07/07-08 change to segment-text derivation
 #                                          stepped the text hash without this bump — dormant segments' old-hash
 #                                          placements stopped matching, and every restart/touch replayed them as
@@ -193,6 +193,13 @@ PLACEMENTS_V = 8                         # placements-identity schema version (p
 #                                          every skill/custom-command invocation drops out. v5's shape in
 #                                          reverse: a SMALLER atom set for transcripts carrying shape-B
 #                                          commands, same seal.
+#                                          v9 (2026-08-14): the resume-fork stitch (em._stitch_resume_forks)
+#                                          restores the pre-cut conversation of every machine-cut turn whose
+#                                          resume forked a fresh-headed transcript — previously dropped as a
+#                                          /clear, so a cut turn's work never carded (the lost PR-watch
+#                                          finding). v3's shape: a GROWN atom set for every forked session
+#                                          (865 such files in one live corpus), so the seal is what keeps
+#                                          months of restored history from replaying as fresh cards.
 PLAN_SESSIONS = None                     # per-pass session cap — REMOVED (the user 2026-06-30): the fairness
                                          # caps were a recurring source of confusing starvation bugs (a goal/
                                          # nudge stuck behind a full per-pass window), never clearly needed.
@@ -3632,6 +3639,28 @@ def episode_last(sid):
     """The last recorded episode row of `sid` ({"head","fsid","t"}) or None."""
     rows = episode_rows(sid)
     return rows[-1] if rows else None
+
+
+def resume_lineage(sid):
+    """states/ resumeFork rows for this session ([{"from","to","t"}, ...]) — the kernel's exact record
+    that a resume of a machine-cut turn FORKED the transcript (fresh head) rather than continuing the
+    chain. The episode-boundary check reads this to keep such a fork from being processed as a /clear
+    (which settled the session's open cards mid-turn, 2026-08-14); the parser consumes the same rows
+    through parse_session's states plumbing (em.resume_fork_links / FileAdapter._stitch_resume_forks)."""
+    out = []
+    try:
+        lines = (STATESDIR / (sid + ".jsonl")).read_text().splitlines()
+    except OSError:
+        return []
+    for line in lines:
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        rf = r.get("resumeFork")
+        if isinstance(rf, dict) and rf.get("from") and rf.get("to"):
+            out.append({"from": str(rf["from"]), "to": str(rf["to"]), "t": r.get("t")})
+    return out
 
 
 def append_episode(sid, head, fsid, t):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11886,8 +11886,11 @@ def _parse(path, sid, now):
         return hit[1]
     # A FORKED leaf (SDK /clear: discover hands the lastSid file under the stable romp sid) parses with
     # the session's anchor transcript among the candidates — a resume-style fork's cross-file chain keeps
-    # its history via the FileAdapter walk; a /clear fork (parentUuid null) still starts fresh. Mirrors
-    # jd.parsed_session. Cache stays keyed on the LEAF alone: the anchor file is dead once forked.
+    # its history via the FileAdapter walk (a RECORDED fresh-headed resume fork stitches through the
+    # states/ resumeFork lineage inside parse_session, 2026-08-14); a /clear fork (parentUuid null, no
+    # lineage) still starts fresh. Mirrors jd.parsed_session. Cache stays keyed on the LEAF alone plus
+    # the states file (folded above), which moves when a lineage row lands: the anchor file is dead
+    # once forked.
     cands = [path]
     anchor = os.path.join(os.path.dirname(path), sid + ".jsonl")
     if os.path.basename(path) != sid + ".jsonl" and os.path.exists(anchor):
@@ -14397,6 +14400,13 @@ def _episode_boundary_check(sid, path, now):
     if not head or not head["root"]:
         return                       # no head yet, or a resume-style leaf (chains into a prior file):
     #                                  either way the recorded episode is still the current one
+    if any(l.get("to") == Path(path).stem for l in jd.resume_lineage(sid)):
+        return                       # a RECORDED resume fork: the CLI resumed a machine-cut turn onto a
+    #                                  fresh-headed file, byte-identical to a /clear on disk. The
+    #                                  conversation CONTINUES (the parser stitches the chain from the
+    #                                  same states/ rows), so this head is no boundary — treating it as
+    #                                  one settled the session's open cards mid-turn and the cut turn's
+    #                                  work never carded (the lost PR-watch finding, the user 2026-08-14).
     if any(r.get("head") == head["uuid"] for r in jd.episode_rows(sid)):
         return                       # this head is already recorded — the current episode, or a
     #                                  HISTORICAL one re-sighted through a stale path (a peer writer

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -615,6 +615,25 @@ def append_machine_cut(state_dir: Path, sid: str, cause: str, t: float | None = 
         f.write(json.dumps(rec) + "\n")
 
 
+def append_resume_fork(state_dir: Path, sid: str, from_fsid: str, to_fsid: str, t: float | None = None) -> None:
+    """Record that a RESUME landed on a fresh-headed transcript fork: the CLI's init reported a NEW
+    fsid for a conversation we asked it to continue (--resume), with no /clear in flight and no
+    born-as-a-fork copy pending. On disk that fork is byte-indistinguishable from a /clear
+    (parentUuid-null head, no cross-file back-link), so without this row the parser dropped the entire
+    pre-cut conversation and the episode check settled its open cards — a machine-cut watch turn's
+    finding vanished to two mid-turn restarts (the user 2026-08-14). Written at the init flip, the one
+    event that knows the old->new binding (the registry can't serve: lastSid is overwritten per fork).
+    Consumers: em.resume_fork_links/_stitch_resume_forks (the parse) and jd.resume_lineage (the
+    kernel's episode-boundary stand-down). Its own "resumeFork" key, like machineCut, so the
+    state/awaiting readers skip it."""
+    p = Path(state_dir) / "states" / (sid + ".jsonl")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    rec = {"t": time.time() if t is None else float(t),
+           "resumeFork": {"from": str(from_fsid), "to": str(to_fsid)}}
+    with open(p, "a") as f:
+        f.write(json.dumps(rec) + "\n")
+
+
 def append_awaiting(state_dir: Path, sid: str, awaiting: bool, why: str = "") -> None:
     """Append an "awaiting" OVERLAY record to states/<sid>.jsonl (interleaved with the state
     records; the kernel reader scans for the latest line carrying an "awaiting" key). "Awaiting" =
@@ -2148,11 +2167,18 @@ class SdkSession:
             self.backend._note_auth_source(self, d.get("apiKeySource"))
             fsid = d.get("session_id")
             if fsid and fsid != self.resume_sid:
+                old = self.resume_sid
                 self.resume_sid = fsid
                 self.backend._update_reg(self.sid, lastSid=fsid)
                 # A lastSid flip IS a fork landing — for a /clear, the fresh conversation now exists, so the
                 # clearing bracket ends here (event-based; the ResultMessage below is only the backstop).
+                clearing = self._clearing
                 self._clearing = False
+                # A RESUME landing on a NEW fsid = a fresh-headed fork: record the old->new lineage
+                # (see append_resume_fork for the full story — the parser stitches the chain from it,
+                # the user 2026-08-14). A /clear's flip and a born-as-a-fork copy record nothing.
+                if old and not clearing and not self._fork_of:
+                    append_resume_fork(self.backend.state_dir, self.sid, old, fsid)
             if self._fork_of and fsid == self.sid:
                 # The BORN-AS-A-FORK session's copy landed (the CLI now owns a transcript pinned to this
                 # sid). Spend the fork flags: a later reconnect must resume the fork's OWN conversation

--- a/tests/test_kernel_resume_fork_lineage.py
+++ b/tests/test_kernel_resume_fork_lineage.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""A machine-cut turn whose RESUME forks the transcript keeps its history (the user 2026-08-14).
+
+Some CLI resumes of a machine-cut turn fork a FRESH-HEADED transcript (parentUuid-null head, no
+cross-file back-link) instead of continuing the chain. On disk that fork is byte-indistinguishable
+from a /clear, so the parser dropped the entire pre-cut conversation (kept_uuids' clear branch), the
+planner never saw the cut turn's work (no card, ever), and the kernel's episode check settled the
+session's open cards as if the user typed /clear. Observed live: an hourly PR watch's finding — a
+full recommendation with a decision for the user — vanished to two mid-turn restarts.
+
+The fix records the fork as an exact event: the resumed CLI's init reports the new fsid, the backend
+appends a states/ resumeFork row binding old->new, the parser stitches the fork head onto the resumed
+file's tail (and follows the lineage when assembling candidate files), and the episode check stands
+down on a recorded fork. A genuine /clear records no lineage, so its history keeps dropping.
+
+SYNTHETIC fixtures only (placeholder uuids, temp dirs), modeled on test_placements_canary."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_rfl", os.path.join(BIN, "romp-judge")).load_module()
+em = SourceFileLoader("romp_em_rfl", os.path.join(BIN, "romp-event-model")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_rfl", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+km = SourceFileLoader("romp_kernel_rfl", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+F2 = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+F3 = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+T0 = 1780000000
+NOTICE = ("<!-- romp-injected --><!-- romp-system -->[romp] The romp kernel restarted and cut this "
+          "session's in-flight turn; the session has been resumed with its history intact.")
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": text}, "promptSource": "typed"}
+
+
+def aline(t, text, uuid, parent, stop="end_turn"):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+def write_jsonl(path, records):
+    Path(path).write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+# The pre-cut conversation: a real ask, work, and the machine cut's interrupt record.
+ANCHOR_RECORDS = [
+    uline(T0, "review the new pull request on notes-api and recommend a disposition", "u1"),
+    aline(T0 + 60, "Reading the diff and running the touched tests now.", "a1", "u1", stop=None),
+    uline(T0 + 300, "[Request interrupted by user]", "u2", "a1"),
+]
+# The resume fork: a FRESH head (parentUuid None) carrying the restart notice, then the finish.
+FORK_RECORDS = [
+    uline(T0 + 320, NOTICE, "f1", None),
+    aline(T0 + 380, "Review finished: recommend merging the notes-api pull request.", "f2", "f1"),
+]
+
+
+def parse(td, states_rows, leaf=F2, candidates=None):
+    files = candidates if candidates is not None else [str(Path(td) / (F2 + ".jsonl")),
+                                                       str(Path(td) / (SID + ".jsonl"))]
+    return em.parse_session(str(Path(td) / (leaf + ".jsonl")), rompuuid=SID,
+                            candidate_files=files, states=states_rows, now=T0 + 400)
+
+
+def turn_texts(sess):
+    out = []
+    for turn in sess["turns"]:
+        for a in turn["atoms"]:
+            blocks = (a.get("message") or {}).get("content") or []
+            if isinstance(blocks, str):
+                out.append(blocks)
+            else:
+                out.extend(b.get("text", "") for b in blocks if isinstance(b, dict))
+    return "\n".join(out)
+
+
+class ResumeForkStitch(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        write_jsonl(Path(self.td.name) / (SID + ".jsonl"), ANCHOR_RECORDS)
+        write_jsonl(Path(self.td.name) / (F2 + ".jsonl"), FORK_RECORDS)
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def test_a_recorded_fork_keeps_the_precut_conversation(self):
+        rows = [{"t": T0 + 310, "machineCut": "restart"},
+                {"t": T0 + 320, "resumeFork": {"from": SID, "to": F2}}]
+        sess = parse(self.td.name, rows)
+        text = turn_texts(sess)
+        self.assertIn("review the new pull request", text,
+                      "the pre-cut prompt must survive a recorded resume fork")
+        self.assertIn("recommend merging", text, "the post-fork finish stays too")
+        # …and the pre-cut prompt's segment is derivable again, anchored at ITS OWN t — the unit the
+        # planner keys a card on (its absence was the lost-card bug).
+        ts = [seg["t"] for turn in sess["turns"] for seg in em.segments(turn)]
+        self.assertIn(T0, ts, "a segment anchored at the original prompt's t must exist")
+
+    def test_without_lineage_the_fork_still_drops_history_like_a_clear(self):
+        # A genuine /clear records no resumeFork row — pre-fork history keeps dropping by design.
+        sess = parse(self.td.name, [{"t": T0 + 310, "machineCut": "restart"}])
+        text = turn_texts(sess)
+        self.assertNotIn("review the new pull request", text)
+        self.assertIn("recommend merging", text)
+
+    def test_lineage_extends_candidates_across_a_fork_chain(self):
+        # Two restarts, two forks: SID -> F2 -> F3. The caller passes only leaf+anchor (the real
+        # callers' shape); the middle file joins via the lineage closure inside parse_session.
+        write_jsonl(Path(self.td.name) / (F3 + ".jsonl"),
+                    [uline(T0 + 500, NOTICE, "g1", None),
+                     aline(T0 + 560, "Chain finish after the second restart.", "g2", "g1")])
+        rows = [{"t": T0 + 320, "resumeFork": {"from": SID, "to": F2}},
+                {"t": T0 + 500, "resumeFork": {"from": F2, "to": F3}}]
+        sess = parse(self.td.name, rows, leaf=F3,
+                     candidates=[str(Path(self.td.name) / (F3 + ".jsonl")),
+                                 str(Path(self.td.name) / (SID + ".jsonl"))])
+        text = turn_texts(sess)
+        self.assertIn("review the new pull request", text, "history crosses BOTH forks")
+        self.assertIn("recommend merging", text, "the middle fork's records joined via the closure")
+        self.assertIn("Chain finish", text)
+
+    def test_an_intact_backlink_is_never_overridden(self):
+        # A resume that DID continue the chain (back-linked head) keeps its own parent even if a
+        # stray lineage row names it.
+        linked = [dict(FORK_RECORDS[0], parentUuid="u2")] + FORK_RECORDS[1:]
+        write_jsonl(Path(self.td.name) / (F2 + ".jsonl"), linked)
+        rows = [{"t": T0 + 320, "resumeFork": {"from": SID, "to": F2}}]
+        sess = parse(self.td.name, rows)
+        self.assertIn("review the new pull request", turn_texts(sess))
+
+
+class ResumeForkStates(unittest.TestCase):
+    def test_appender_reader_and_links_roundtrip(self):
+        with tempfile.TemporaryDirectory() as td:
+            sb.append_resume_fork(Path(td), SID, SID, F2, t=T0 + 320.5)
+            rows = [json.loads(l) for l in (Path(td) / "states" / (SID + ".jsonl")).read_text().splitlines()]
+            self.assertEqual(rows[0]["resumeFork"], {"from": SID, "to": F2})
+            self.assertEqual(em.resume_fork_links(rows), {F2: SID})
+
+    def test_the_init_flip_records_lineage_only_for_true_resume_forks(self):
+        # The one code path that knows the old->new binding: guarded so a /clear's flip and a
+        # born-as-a-fork copy record nothing, and a first connect (no old fsid) has nothing to bind.
+        src = open(os.path.join(BIN, "romp_sdk_backend.py")).read()
+        self.assertIn("if old and not clearing and not self._fork_of:", src)
+        self.assertIn("append_resume_fork(self.backend.state_dir, self.sid, old, fsid)", src)
+
+    def test_judge_reader_sees_the_rows(self):
+        # own sid: the suite shares one hermetic state root, and the common placeholder uuid's
+        # states/episodes files belong to other tests' fixtures
+        sid = "12121212-3434-5656-7878-909090909090"
+        jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+        (jd.STATESDIR / (sid + ".jsonl")).write_text(
+            json.dumps({"t": T0, "resumeFork": {"from": sid, "to": F2}}) + "\n")
+        try:
+            rows = jd.resume_lineage(sid)
+            self.assertEqual([(r["from"], r["to"]) for r in rows], [(sid, F2)])
+        finally:
+            (jd.STATESDIR / (sid + ".jsonl")).unlink()
+
+
+class EpisodeBoundaryStandsDown(unittest.TestCase):
+    def test_a_recorded_fork_is_not_a_clear_boundary(self):
+        # own sid (the suite shares one hermetic state root; the common placeholder uuid's files
+        # belong to other tests), and everything goes through KM.JD: the kernel loads judge.py under
+        # the shared module name "romp_judge", so in a full-suite run km's judge instance is the
+        # FIRST-loaded kernel's — rooted in that module's state dir, not this module's (the
+        # test_kernel_opening_chip lesson). Writing via this module's jd left km reading no lineage.
+        kjd = km.jd
+        sid = "13131313-2424-3535-4646-575757575757"
+        with tempfile.TemporaryDirectory() as td:
+            fork = Path(td) / (F2 + ".jsonl")
+            write_jsonl(fork, FORK_RECORDS)
+            kjd.STATESDIR.mkdir(parents=True, exist_ok=True)
+            sp = kjd.STATESDIR / (sid + ".jsonl")
+            sp.write_text(json.dumps({"t": T0 + 320, "resumeFork": {"from": sid, "to": F2}}) + "\n")
+            try:
+                before = list(kjd.episode_rows(sid))
+                km._episode_boundary_check(sid, str(fork), T0 + 400)
+                self.assertEqual(list(kjd.episode_rows(sid)), before,
+                                 "a recorded resume fork must not append an episode boundary")
+                # control: with NO lineage the same fresh head IS a boundary (the /clear path)
+                sp.unlink()
+                km._episode_boundary_check(sid, str(fork), T0 + 400)
+                self.assertTrue(any(r.get("head") == "f1" for r in kjd.episode_rows(sid)),
+                                "an unrecorded fresh head keeps the /clear boundary behavior")
+            finally:
+                if sp.exists():
+                    sp.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_placements_canary.py
+++ b/tests/test_placements_canary.py
@@ -119,7 +119,11 @@ class PlacementIdentityCanary(unittest.TestCase):
         # v8 (2026-08-13, the shape-B twin drop): this fixture carries no command wrappers, so every
         # pinned id is UNCHANGED — the bump seals transcripts that DO carry shape-B commands, whose
         # phantom twin atom drops out of the set.
-        self.assertEqual(jd.PLACEMENTS_V, 8, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=8 — "
+        # v9 (2026-08-14, the resume-fork stitch): this fixture records no resumeFork lineage, so
+        # every pinned id is UNCHANGED — the bump seals sessions whose machine-cut resumes forked
+        # fresh-headed transcripts, whose previously-dropped pre-cut atoms rejoin the set
+        # (tests/test_kernel_resume_fork_lineage.py covers the stitch itself).
+        self.assertEqual(jd.PLACEMENTS_V, 9, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=9 — "
                          "re-pin the ids and this version together, in the same commit")
 
 


### PR DESCRIPTION
Fixes the lost-work gap found via the PR-watch incident: a kernel restart cutting an in-flight turn could erase the turn's pre-cut work from judging entirely when the CLI's resume forked a fresh-headed transcript (byte-identical to /clear on disk), so no card was ever minted for the finding and the episode check settled open cards mid-turn.

- The backend records the fork at the init fsid flip (states/ resumeFork row; /clear and born-as-fork record nothing).
- parse_session follows the lineage across fork chains and the FileAdapter stitches the fork head onto the resumed file's tail (compaction-stitch precedent), restoring one walkable chain for BOTH parses via their shared states plumbing.
- The episode-boundary check stands down on a recorded fork, so it is no longer processed as /clear.
- PLACEMENTS_V 8 -> 9: the stitch grows the atom set of every previously-forked session; the seal keeps restored history from replaying as fresh cards (v3's shape).

Tests: tests/test_kernel_resume_fork_lineage.py (stitch keeps pre-cut history + its T0-anchored segment; no-lineage control keeps the /clear drop; chain closure across two forks; intact back-links never overridden; appender/reader round-trip; episode stand-down with /clear control). Canary re-pinned to v9 (seg ids unchanged, atom-set growth sealed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)