### PR TITLE
Cap a forwarded message at its forwarder's trust tier

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,7 +89,16 @@ The trust unit is the **machine**, not a session on it: any process on a remote
 box can write to that box's bus, so trust is set per host. Identity is provided
 by the ssh tunnel the message arrives on — no separate signing. The gate is
 enforced at the receiving bus's delivery point, so it holds regardless of which
-host originated the message (a forwarded message is judged by its true origin).
+host originated the message.
+
+A **forwarded** message is judged by the more restrictive of two tiers: the
+origin's and the forwarding host's. The origin stamp is written by the forwarder
+and nothing signs it, so trusting it alone would let any peer claim to speak for
+a host you tiered `trusted` and have its mail auto-injected — a `directed` host
+could promote itself simply by labelling its cargo. Capping at the forwarder's
+own tier means a directed relay stays directed whatever name it stamps, at the
+cost that mail from a trusted origin relayed through a directed hub is held for
+approval rather than delivered.
 
 The one thing romp can NOT firewall this way is same-machine peers: two sessions
 running as the same user share a UID, so mailbox trust between them is policy,

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1567,6 +1567,15 @@ def remote_holds():
             out.append(dict(hd, atHost=hd.get("via") or h))
     return out
 
+_TRUST_RANK = {"isolated": 0, "directed": 1, "trusted": 2}
+
+
+def least_trust(a, b):
+    """The more restrictive of two tiers. Used to cap a FORWARDED message at its forwarder's tier:
+    trust must never be assembled from a claim the claimant wrote about itself."""
+    return a if _TRUST_RANK.get(a, 1) <= _TRUST_RANK.get(b, 1) else b
+
+
 def my_tier_of(host):
     """The trust tier THIS bus applies to `host`'s direct mail — what _relay_in resolves for a
     token-proven direct relay (an exchange partner has, by definition, shown our serve token): an
@@ -1989,9 +1998,10 @@ def _relay_in(host, m, token_proven=False):
     kernel is gated by the same token — a holder can inject into any session directly). So holding the
     dialer's OWN mail protects nothing and only strands the user's outgoing mail on a machine they
     attached (the user 2026-07-26, whose delegation to a fresh box sat quarantined on it). The proof
-    covers only the direct dialer: mail it FORWARDED (origin-stamped) is still judged by the origin's
-    tier, and an EXPLICIT tier the user set for the dialer (directed/isolated) still wins — the
-    exemption replaces only the unknown-origin default. The dialer side (peer_exchange_apply) proves
+    covers only the direct dialer: mail it FORWARDED (origin-stamped) is judged by the origin's tier
+    CAPPED at the forwarder's own (least_trust — a relay can never hand its cargo more trust than it
+    holds itself), and an EXPLICIT tier the user set for the dialer (directed/isolated) still wins —
+    the exemption replaces only the unknown-origin default. The dialer side (peer_exchange_apply) proves
     nothing: whatever answers the tunnel port never showed our token, so tiers gate it as before."""
     mid = m.get("mid") or ""
     if not mid:
@@ -2008,6 +2018,18 @@ def _relay_in(host, m, token_proven=False):
         trust = (prow or {}).get("trust") or "directed"
         if prow is None and token_proven and not m.get("origin"):
             trust = "trusted"                        # token-proven direct dialer, no explicit tier → deliver (see docstring)
+        if m.get("origin") and origin != host:
+            # A FORWARDED message can never outrank the host that forwarded it. m["origin"] is
+            # written BY the forwarder, so keying trust on the origin alone let any peer we dial
+            # stamp the name of a host tiered `trusted` and have its mail auto-injected into a
+            # session — precisely the attacker `directed` exists to hold for approval, and the
+            # names to guess are handed out by our own presence gossip. Cap at the forwarder's
+            # own tier so a directed relay stays directed however it labels its cargo.
+            hrow = PEERS.get(host)
+            htrust = (hrow or {}).get("trust") or "directed"
+            if hrow is None and token_proven:
+                htrust = "trusted"                   # token possession is already full control here (see docstring)
+            trust = least_trust(trust, htrust)
         if trust == "trusted":
             deliver(match[0]["id"], m.get("frm") or "?", m.get("frm_id") or "", m.get("body") or "",
                     kind=m.get("kind") or "", from_host=origin,

--- a/tests/test_postal_peers.py
+++ b/tests/test_postal_peers.py
@@ -292,6 +292,13 @@ class ThreeBusRelay(unittest.TestCase):
         # whose origin is "hosta" (B stamps origin when it forwards). Trust itself: test_postal_quarantine.
         pmb.PEERS["hosta"] = {"port": 1, "up": True, "trust": "trusted"}
         pmc.PEERS["hosta"] = {"port": 1, "up": True, "trust": "trusted"}
+        # A forwarded message is ALSO capped at the forwarder's own tier (2026-08-05: a relay must
+        # not out-rank itself by stamping an origin — test_postal_quarantine owns that rule), so the
+        # hub C actually exchanges with needs a tier of its own. A real deployment always has one:
+        # the kernel notifies a row for every host you dial. Without it the hub reads as an unknown
+        # host, i.e. directed, and the relayed mail is HELD — correct, but the trust tests' business,
+        # not this one's, which is about relay mechanics and end-to-end acks.
+        pmc.PEERS["hub"] = {"port": 1, "up": True, "trust": "trusted"}
 
     def tearDown(self):
         os.environ.pop("ROMP_POSTAL_PEERS", None)

--- a/tests/test_postal_quarantine.py
+++ b/tests/test_postal_quarantine.py
@@ -102,6 +102,54 @@ class InboundTrustGate(unittest.TestCase):
         self.assertEqual(verdict, "ack")
         self.assertEqual(len(ps.quarantine_list()), 1, "the ORIGIN's directed level must hold it")
 
+    def test_a_forwarder_cannot_outrank_itself_by_stamping_a_trusted_origin(self):
+        """The origin stamp is written BY the forwarder, so trust keyed on it alone is a claim the
+        claimant makes about itself. A peer you tiered `directed` — one you attached but do not let
+        drive your sessions — answers one exchange with origin set to a host you DID tier trusted,
+        and its mail is auto-injected: pasted into a live session and entered. The names to guess
+        are not secret either; presence gossip hands them out. A forwarded message is now capped at
+        the forwarder's own tier, so a directed relay stays directed however it labels its cargo."""
+        self._set_trust("EDGE", "directed")       # the peer we actually received from
+        self._set_trust("ORIGIN", "trusted")      # the name it claims to be speaking for
+        verdict, _ = ps._relay_in("EDGE", _relay("q-forge-1", origin="ORIGIN"))
+        self.assertEqual(verdict, "ack")
+        self.assertEqual(len(ps.quarantine_list()), 1,
+                         "a directed forwarder's mail must hold, whatever origin it stamps")
+        self.assertEqual(len(list((ps.MAILROOT / "sess-web" / "new").glob("*"))), 0,
+                         "nothing may reach the session's mailbox")
+
+    def test_an_isolated_forwarder_stays_dropped_however_it_labels_its_mail(self):
+        # isolated is the strongest refusal the user can express: no communication at all. It must
+        # not become a hold (visible, approvable) by stamping a trusted origin.
+        self._set_trust("EDGE", "isolated")
+        self._set_trust("ORIGIN", "trusted")
+        verdict, _ = ps._relay_in("EDGE", _relay("q-forge-2", origin="ORIGIN"))
+        self.assertEqual(verdict, "ack")
+        self.assertEqual(len(ps.quarantine_list()), 0, "isolated drops; it never even holds")
+        self.assertEqual(len(list((ps.MAILROOT / "sess-web" / "new").glob("*"))), 0)
+
+    def test_the_cap_never_promotes_a_forwarders_mail(self):
+        # The cap is a floor-lowering, not a lookup swap: a trusted forwarder relaying a DIRECTED
+        # origin's mail must still hold it (the origin's own tier still applies).
+        self._set_trust("EDGE", "trusted")
+        self._set_trust("ORIGIN", "directed")
+        verdict, _ = ps._relay_in("EDGE", _relay("q-forge-3", origin="ORIGIN"))
+        self.assertEqual(verdict, "ack")
+        self.assertEqual(len(ps.quarantine_list()), 1)
+
+
+class LeastTrust(unittest.TestCase):
+    def test_the_more_restrictive_tier_wins_either_way_round(self):
+        self.assertEqual(ps.least_trust("trusted", "directed"), "directed")
+        self.assertEqual(ps.least_trust("directed", "trusted"), "directed")
+        self.assertEqual(ps.least_trust("isolated", "trusted"), "isolated")
+        self.assertEqual(ps.least_trust("trusted", "trusted"), "trusted")
+
+    def test_an_unrecognised_tier_is_treated_as_directed_not_trusted(self):
+        # A tier this build does not know must never read as permission.
+        self.assertEqual(ps.least_trust("nonsense", "trusted"), "nonsense")
+        self.assertEqual(ps.least_trust("isolated", "nonsense"), "isolated")
+
 
 class TokenProvenDialerGate(InboundTrustGate):
     """The DIALED side of an exchange (token_proven=True): the dialer showed OUR serve token, which


### PR DESCRIPTION
Postal trust is resolved from `m["origin"]` — a field the **forwarding host writes**. Keying the gate on it alone means trust is assembled from a claim the claimant makes about itself.

### The hole

`_relay_in` looks the tier up by origin:

```python
origin = m.get("origin") or host
prow = PEERS.get(origin)
trust = (prow or {}).get("trust") or "directed"
```

So a peer tiered `directed` — one you attached but deliberately do not let drive your sessions — can answer a single exchange with `origin` set to the name of a host you tiered `trusted`, and its mail is **auto-injected into a live session** rather than held for approval. That is exactly the actor the `directed` tier exists to hold.

The names needed to pull this off are not secret: presence gossip hands them out.

### The fix

A forwarded message is capped at the more restrictive of two tiers — the origin's and the forwarder's own:

```python
if m.get("origin") and origin != host:
    hrow = PEERS.get(host)
    htrust = (hrow or {}).get("trust") or "directed"
    if hrow is None and token_proven:
        htrust = "trusted"
    trust = least_trust(trust, htrust)
```

The cap only ever **lowers**. A trusted forwarder relaying a directed origin's mail is still held, because the origin's own tier keeps applying — `least_trust` is a floor-lowering, not a lookup swap. `isolated` keeps dropping rather than softening into a visible hold. An unrecognised tier reads as `directed`, never as permission.

`token_proven` semantics are unchanged: the direct dialer showed this machine's serve token, which already grants full control here, so its own mail is exempt from the unknown-origin default — but that proof covers only the dialer, never the cargo it forwards.

### Tests

Five cases in `tests/test_postal_quarantine.py`. Three of them fail on `main` today, and because `TokenProvenDialerGate` subclasses `InboundTrustGate` they re-run on the dialed side too — **6 failures before, 30 passing after**:

- a directed forwarder cannot outrank itself by stamping a trusted origin
- an isolated forwarder stays dropped however it labels its mail
- the cap never *promotes* (trusted forwarder + directed origin still holds)
- two `least_trust` unit cases, including the unknown-tier default

Your existing `test_forwarded_origin_is_the_trust_key` passes unchanged.

`tests/test_postal_peers.py` needs one fixture line: the three-bus relay test now has to give the hub C dials a tier of its own. A real deployment always has one — the kernel notifies a row for every host you dial — and without it the hub reads as unknown, i.e. directed, so the relayed mail is correctly held, which would turn a relay-mechanics test into a trust test.

### Docs

`SECURITY.md` promised the opposite guarantee — *"a forwarded message is judged by its true origin"* — which the code did not provide and, after this change, deliberately does not: it is judged by the origin's tier **capped at the forwarder's**. The tradeoff is now written down, because it is real: mail from a trusted origin relayed through a directed hub is held for approval rather than delivered.

### Scope — what this does not close

This closes the forwarded-relay path into `deliver()`. It does not make the quarantine boundary airtight on its own: `_bounce_apply` gives a `directed` peer a second, narrow auto-injection channel with no trust check. That one is reactive (it needs an outbox entry we created), lands only on the sending session, and is framed as a bus-authored error notice — so it is a much smaller surface, and I have left it alone rather than widen this change. Happy to follow up on it separately if you want it closed too.

Verified with `pytest tests/test_postal_quarantine.py tests/test_postal_peers.py tests/test_postal_isolation.py tests/test_postal_read_receipts.py tests/test_postal_safe_id.py` — 85 passed.
