### PR TITLE
Run the judge and the announcer from a private dir, not /tmp

### DIFF
--- a/bin/romp-uninstall
+++ b/bin/romp-uninstall
@@ -154,19 +154,26 @@ rm -f  "$ROMP_DIR/vscode-extension"/*.vsix "$ROMP_DIR/vscode-extension/package.j
 echo "==> SDK venv"
 rm -rf "$STATE/sdkvenv"
 
-# ── 4b. the judge scratch, which lives OUTSIDE the state dir ───────────
-# romp runs its judges as `claude` processes rooted at /tmp/romp-judge (kernel/judge.py's
-# JUDGE_SCRATCH), so Claude Code writes their transcripts into a project dir keyed on that
-# path — outside $STATE, and therefore untouched by --purge. A purged, reinstalled romp kept
-# showing judge records from the PREVIOUS install because of it (the user 2026-07-27, who
-# rightly read that as an incomplete teardown).
+# ── 4b. the judge scratch's Claude Code project dir, which lives OUTSIDE the state dir ───────────
+# romp runs its judges as `claude` processes rooted at JUDGE_SCRATCH (kernel/judge.py), so Claude
+# Code writes their transcripts into a project dir keyed on that path — outside $STATE, and
+# therefore untouched by --purge. A purged, reinstalled romp kept showing judge records from the
+# PREVIOUS install because of it (the user 2026-07-27, who rightly read that as an incomplete
+# teardown).
+#
+# The scratch moved from /tmp/romp-judge to "$STATE/judge-scratch": a world-writable /tmp with a
+# guessable name let another local account create the path first and hand romp's judges — and this
+# teardown — a directory they control. The scratch itself is inside $STATE now, so --purge takes it
+# either way; but the DERIVED project dir is still keyed on the path, so this default has to move
+# with it or the 07-27 symptom comes back under a new name.
 #
 # These are romp's own droppings: every transcript here is a judge call romp made, never a
 # session anyone started, so removing them completes the teardown rather than deleting user
 # data. Scoped to exactly that one derived directory — YOUR project dirs are never touched.
-# Claude Code names a project dir after its cwd with '/' → '-', so /tmp/romp-judge maps to
-# '-tmp-romp-judge'; derived, not hardcoded, so it follows JUDGE_SCRATCH if that ever moves.
-JUDGE_SCRATCH="${ROMP_JUDGE_SCRATCH:-/tmp/romp-judge}"
+# Claude Code names a project dir after its cwd with '/' → '-', so ~/.local/state/romp/judge-scratch
+# maps to '-home-<you>-local-state-romp-judge-scratch'; derived, not hardcoded, so it follows
+# JUDGE_SCRATCH if that ever moves again.
+JUDGE_SCRATCH="${ROMP_JUDGE_SCRATCH:-$STATE/judge-scratch}"
 echo "==> judge scratch"
 
 # Validate BEFORE removing anything. Both paths below are derived from a variable, and an
@@ -176,12 +183,26 @@ echo "==> judge scratch"
 # that could only be romp's own scratch: absolute, at least two components deep, not $HOME
 # or any ancestor of it, and named for romp. Anything else is skipped loudly, never guessed at.
 _judge_ok=1
-_scratch_slug="${JUDGE_SCRATCH//\//-}"
+# Claude Code names a project dir after its cwd by replacing EVERY non-alphanumeric character with
+# '-', over the REALPATH — kernel/judge.py's _proj_dir implements exactly that, and this has to
+# agree with it or --purge sweeps a directory that does not exist. A shell `${p//\//-}` replaces
+# only the slashes, which agreed by luck while the scratch was /tmp/romp-judge (no other
+# non-alnum char in it) and stopped agreeing the moment it moved under ~/.local/state: the dot in
+# `.local` survives, so the two spell the same path differently and the transcripts are left
+# behind. Derived here the same way judge.py derives it, so they cannot drift apart again.
+_scratch_slug="$(python3 - "$JUDGE_SCRATCH" <<'PYEOF'
+import os, re, sys
+print(re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(sys.argv[1])))
+PYEOF
+)"
 case "$JUDGE_SCRATCH" in
     /*/?*) ;;                                    # absolute AND at least two components
     *)     _judge_ok="" ;;
 esac
-[[ "$JUDGE_SCRATCH" == *romp* ]]            || _judge_ok=""   # it is romp's scratch or it is not ours
+# It is romp's scratch or it is not ours. Named for romp, OR sitting inside romp's own state root —
+# the default is "$STATE/judge-scratch" now, and a custom ROMP_STATE_DIR with no "romp" in it (say
+# /data/agents) would otherwise fail this check and silently skip the teardown.
+[[ "$JUDGE_SCRATCH" == *romp* || "$JUDGE_SCRATCH" == "$STATE"/?* ]] || _judge_ok=""
 [[ "$JUDGE_SCRATCH" != "$HOME" ]]           || _judge_ok=""
 [[ "$HOME" != "$JUDGE_SCRATCH"/* ]]         || _judge_ok=""   # never an ancestor of $HOME
 [[ "$JUDGE_SCRATCH" != *".."* ]]            || _judge_ok=""
@@ -191,11 +212,11 @@ if [[ -z "$_judge_ok" ]]; then
 else
     rm -rf "$JUDGE_SCRATCH"
     # The transcripts Claude Code wrote for those judge runs. It names a project dir after the
-    # cwd with '/' → '-', so /tmp/romp-judge maps to '-tmp-romp-judge'. Derived, not hardcoded,
-    # so it follows JUDGE_SCRATCH if that ever moves — and gated on the same slug carrying
-    # "romp", so this can never resolve to the projects dir itself or to one of YOUR sessions.
+    # cwd with '/' → '-'. Derived, not hardcoded, so it follows JUDGE_SCRATCH if that ever moves
+    # — and gated on the same validation above, so this can never resolve to the projects dir
+    # itself or to one of YOUR sessions.
     _judge_proj="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/$_scratch_slug"
-    if [[ -d "$_judge_proj" && "$_scratch_slug" == *romp* ]]; then
+    if [[ -d "$_judge_proj" && -n "$_scratch_slug" && "$_judge_proj" != */projects ]]; then
         rm -rf "$_judge_proj"
         echo "    removed romp's judge transcripts ($_judge_proj)"
     fi

--- a/hooks/romp-summarize.sh
+++ b/hooks/romp-summarize.sh
@@ -10,8 +10,9 @@
 #
 # Design constraints (all per the user's ask):
 #   - CANNOT take action — the summarizer model runs with `--tools ""` (zero
-#     tools) + MCP disabled, so it can only emit text; it structurally cannot
-#     edit/run/fetch anything, regardless of how it reads the transcript.
+#     tools), MCP disabled, `--safe-mode` (no discovered memory/skills/hooks)
+#     and a cwd only we can write, so it can only emit text; it structurally
+#     cannot edit/run/fetch anything, regardless of how it reads the transcript.
 #   - NEVER blocks — every expensive step runs in a detached subshell, so the
 #     hook returns instantly (critical for UserPromptSubmit, which gates the
 #     prompt) and the phrase lands a poll later. Emits NOTHING on stdout.
@@ -277,14 +278,36 @@ Reply with ONLY the <=8-word past-tense phrase describing what the ASSISTANT acc
   #                          reads the input (and it's cheaper — no tool
   #                          schemas in the prompt).
   #   --strict-mcp-config + empty --mcp-config → no MCP tools either.
-  # Plus: own existing auth (no API key), /tmp cwd so it skips the project
-  # CLAUDE.md, TMUX unset for the recursion guard, portable 45s timeout
-  # (macOS has no `timeout`).
+  #   --safe-mode          → drops auto-discovered CLAUDE.md/memory, skills AND
+  #                          HOOKS — the hole the two flags above leave open,
+  #                          since they gate tools and MCP but nothing stops a
+  #                          discovered settings.json from running commands.
+  #                          Mirrors the judges' isolation (kernel/judge.py
+  #                          _judge_cmd); it keeps auth + model, so subscription
+  #                          billing is unchanged (NOT --bare, which drops the
+  #                          login too).
+  # Plus: own existing auth (no API key), TMUX unset for the recursion guard,
+  # portable 45s timeout (macOS has no `timeout`).
+  #
+  # The cwd is a private directory we own, NOT /tmp — which is what it was, on
+  # the stated grounds that /tmp skips the project CLAUDE.md. That had the risk
+  # backwards: /tmp is world-writable, so on a shared machine any other local
+  # user can plant /tmp/.claude/settings.json and have its hook commands run as
+  # us — once per prompt and once per stop, for anyone who has opted this hook
+  # in at all (the gates at the top keep that off by default).
+  # Dropping the project CLAUDE.md is --safe-mode's job; the cwd's only job is
+  # to be a directory nobody else can write into. mkdir is idempotent, so the
+  # first summarize on a fresh install creates it.
+  work_dir="${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/summarize"
+  mkdir -p "$work_dir" 2>/dev/null && chmod 700 "$work_dir" 2>/dev/null
+  # Unwritable state root (full disk, bad perms): $HOME is still ours and still
+  # not plantable by anyone else. Never fall back to a world-writable dir.
+  [[ -d "$work_dir" ]] || work_dir="$HOME"
   summary=""
   for _attempt in 1 2; do
-    summary=$(printf '%s' "$prompt" | (cd /tmp 2>/dev/null && \
+    summary=$(printf '%s' "$prompt" | (cd "$work_dir" 2>/dev/null && \
       env -u TMUX -u TMUX_PANE ROMP_SUMMARIZING=1 perl -e 'alarm 45; exec @ARGV' \
-        claude -p --model "$ANNOUNCER_MODEL" --tools "" \
+        claude -p --safe-mode --model "$ANNOUNCER_MODEL" --tools "" \
           --strict-mcp-config --mcp-config '{"mcpServers":{}}' \
           --append-system-prompt "$sys" 2>/dev/null) | tr '\n' ' ')
     summary="$(printf '%s' "$summary" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -13,7 +13,7 @@ CLI:
   romp-judge --once               # one caption pass over the live fleet (writes captions/)
   romp-judge --test <transcript>  # caption one transcript's recent units, print them (no write)
 """
-import contextlib, json, os, re, shutil, sys, time, subprocess, threading
+import contextlib, json, os, re, shutil, stat, sys, time, subprocess, threading
 from pathlib import Path
 from importlib.machinery import SourceFileLoader
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -62,7 +62,39 @@ SDKDIR   = STATE / "sdk"                 # the SDK backend's per-session registr
 # dir (~4,600/day, 51k files) mixed with anything else ever run from /tmp — unprunable without
 # touching data romp doesn't own. A romp-owned scratch cwd isolates them so prune_judge_scratch can
 # sweep the whole project dir by age, safely.
-JUDGE_SCRATCH = "/tmp/romp-judge"
+# It lives under the 0700 state root, NOT in /tmp. /tmp is world-writable and "/tmp/romp-judge" is a
+# name anyone can guess, so on a multi-account machine another local user could create the path first
+# — as a directory with permissions of their choosing, or as a SYMLINK — and `exist_ok=True` accepted
+# whatever they left. That handed them two things: the working directory of a `claude -p` subprocess
+# (a directory you control is a directory you can plant a .claude/ in — _judge_cmd's --safe-mode is
+# what closes that today), and a steer on prune_judge_scratch below, which realpaths this path at
+# every kernel boot and unlinks the day-old *.jsonl in the project dir it derives to. Pointed at a
+# directory you actually work in, romp's own housekeeping deletes your Claude Code transcripts.
+# Same reason the root itself is 0700 above; _ensure_judge_scratch keeps the scratch dir that way on
+# every call.
+JUDGE_SCRATCH = str(STATE / "judge-scratch")
+
+
+def _ensure_judge_scratch(path=None):
+    """Create the judge scratch cwd 0700, and REFUSE one that isn't ours. Returns the path.
+
+    Raises OSError when the directory can't be made private, and the caller must then skip the judge
+    call rather than run it from somewhere else: a cwd another account owns is a cwd they can plant a
+    .claude/ in, and a quiet fallback would hide exactly the breakage we need to see (CLAUDE.md,
+    authoritative sources — fail loudly, don't degrade silently)."""
+    d = path or JUDGE_SCRATCH
+    os.makedirs(d, mode=0o700, exist_ok=True)
+    st = os.lstat(d)                            # lstat, not stat: a symlink planted in our place would
+    if not stat.S_ISDIR(st.st_mode):            # otherwise pass every check below on behalf of its target
+        raise OSError("judge scratch %s is not a directory" % d)
+    if st.st_uid != os.geteuid():
+        raise OSError("judge scratch %s belongs to uid %d, not to us (uid %d)"
+                      % (d, st.st_uid, os.geteuid()))
+    if st.st_mode & 0o077:                      # ours, but loose — a scratch from before the move, a stray umask.
+        os.chmod(d, 0o700)                      # We own it, so tightening is a repair, not a guess.
+        if os.lstat(d).st_mode & 0o077:
+            raise OSError("judge scratch %s stays group/world-accessible" % d)
+    return d
 
 
 def _rebind_state(path):
@@ -72,7 +104,9 @@ def _rebind_state(path):
     judge-errors.jsonl over those orphans every pass forever (the user 2026-06-24). A test must call this
     instead of assigning jd.STATE alone. Not used in production (STATE is bound once at import)."""
     global STATE, NAMES, CAPDIR, ARCHDIR, GOALDIR, GOALARCHDIR, STATESDIR, PCACHE, MESSAGES, ERRORS, USAGE, SDKDIR, EPIDIR, GONEDIR, JUDGE_AUTH
+    global JUDGE_SCRATCH
     STATE = path
+    JUDGE_SCRATCH = str(STATE / "judge-scratch")   # state-rooted now, so it rebinds with the rest
     NAMES, CAPDIR, ARCHDIR, GOALDIR = STATE / "names", STATE / "captions", STATE / "archive", STATE / "goals"
     GONEDIR, JUDGE_AUTH = STATE / "gone", STATE / "judge-auth.json"
     GOALARCHDIR = STATE / "goals-archive"
@@ -449,7 +483,9 @@ def _log_judge_error(judge, fsid, err, note=None, goal=None, seg=None):
              message this pass because its call came back empty — usage-limited/API error — and will
              retry it until the 48h horizon; surfaced only in debug), "cite-miss", "rate-limited",
              "unmigrated-node", "task-store" (the live task store exists but can't be read —
-             plan-sync skipped for the pass rather than silently folding the transcript)
+             plan-sync skipped for the pass rather than silently folding the transcript),
+             "scratch" (the judge scratch cwd can't be made private — call skipped, never rerouted
+             to a world-writable directory; see _ensure_judge_scratch)
       note   the evidence — reply tail, error message, exception name, or the give-up scope + re-arm
              event. Callers must pass it; an empty note means the caller has nothing at all to show.
       goal   the node id (or list of node ids) the judge was ruling on, when one exists — the feed's
@@ -701,6 +737,7 @@ def _judge_env(tier, auth="login"):
 
 
 _RATE_GATE_LOGGED = {}                   # bucket -> resets_at already announced (one line per window)
+_SCRATCH_FAIL_LOGGED = {}                # last judge-scratch refusal announced (one line per distinct reason)
 
 
 def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage"):
@@ -749,7 +786,23 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage"):
     rid = _active_begin(judge or tier, fsid, sent)    # live bar starts NOW (deregistered in finally below)
     try:
         try:
-            os.makedirs(JUDGE_SCRATCH, exist_ok=True)   # tmpfiles-cleaned /tmp: recreate per call
+            _ensure_judge_scratch()                     # 0700 and ours; recreate per call (a purge/rm mid-run)
+        except OSError as e:
+            # No scratch we can keep private → no judge call at all. A cwd another account owns is a
+            # cwd they can plant a .claude/ in, so running from it anyway would be trading the whole
+            # point of the check for one caption — the error is the useful outcome here. One row per
+            # distinct reason: it would otherwise storm the error log.
+            if _SCRATCH_FAIL_LOGGED.get("why") != str(e):
+                _SCRATCH_FAIL_LOGGED["why"] = str(e)
+                sys.stderr.write("romp-judge: %s — judge calls skipped until it is fixed\n" % e)
+                _log_judge_error(judge or tier, fsid, "scratch", note=str(e)[:200])
+            # SKIPPED, not failed. A broken scratch is not the model's verdict, so ride the same paused
+            # flag the rate gate and retry-pause set. Without it the distiller/briefer/staller count each
+            # "" toward their give-up caps and blank the card's summary to the "" sentinel after three
+            # passes — irreversible content loss from a permissions problem.
+            _judge_ctx.paused = True
+            return ""
+        try:
             p = subprocess.run(_judge_cmd(model, sys_prompt, effort), input=user,
                                capture_output=True, text=True, cwd=JUDGE_SCRATCH, env=env,
                                timeout=CALL_ALARM_S + 5)

--- a/tests/romp-summarize-gate.bats
+++ b/tests/romp-summarize-gate.bats
@@ -10,7 +10,8 @@ setup() {
     TEST_DIR="$(mktemp -d)"
     HOOK="$(cd "$(dirname "$BATS_TEST_FILENAME")/../hooks" && pwd)/romp-summarize.sh"
     export HOME="$TEST_DIR/home"; mkdir -p "$HOME/.claude"
-    unset ROMP_SUMMARIZING || true
+    export XDG_STATE_HOME="$HOME/.local/state"   # keep the state root inside the sandbox
+    unset ROMP_SUMMARIZING ROMP_STATE_DIR || true
     export TMUX="fake-socket,1,0"       # LOOK like a tmux session so only the opt-in gate can bail first
     # a tripwire tmux on PATH: if the hook gets past the gate it will call this and we fail the test
     mkdir -p "$TEST_DIR/bin"
@@ -39,4 +40,68 @@ teardown() { rm -rf "$TEST_DIR"; }
     run bash -c 'printf "{\"hook_event_name\":\"Stop\"}" | "$0"' "$HOOK"
     [ "$status" -eq 0 ]                  # the tripwire tmux fails silently (errors swallowed by design)
     [ -f "$TEST_DIR/tripped" ]           # but its invocation PROVES the gate opened
+}
+
+# --- the announcer's isolation ---------------------------------------------
+# Once the gate opens, the summarizer spawns `claude -p` on every prompt and
+# every stop. Two things make that spawn safe, and both are invisible from the
+# outside, so they are asserted on the argv and cwd the spawn actually gets:
+#   --safe-mode  — --tools ""/--mcp-config gate tools and MCP but NOT hooks, so
+#                  without it a discovered settings.json still runs commands.
+#   a private cwd — it ran from /tmp, which is world-writable: any other local
+#                  user can plant /tmp/.claude/settings.json there.
+
+# Arm the hook with a tmux that answers instead of tripping, and a `claude`
+# stand-in that records the argv + cwd it was handed. The hook detaches its
+# expensive work, so the caller returns before the spawn happens.
+arm_summarizer() {
+    touch "$HOME/.claude/romp-summarize-on"
+    export CLAUDE_ARGV="$TEST_DIR/claude-argv"
+    cat > "$TEST_DIR/bin/tmux" <<'SH'
+#!/bin/sh
+case "$1" in
+  display-message) echo web ;;                 # session name
+  show) case "$*" in *@romp*) echo 1 ;; esac ;;  # a romp-managed session
+esac
+exit 0
+SH
+    cat > "$TEST_DIR/bin/claude" <<'SH'
+#!/bin/sh
+{ echo "CWD=$(pwd)"; for a in "$@"; do echo "ARG=$a"; done; } > "$CLAUDE_ARGV"
+echo "summarized the thing"
+SH
+    chmod +x "$TEST_DIR/bin/tmux" "$TEST_DIR/bin/claude"
+}
+
+# The spawn lands a moment after the hook returns; wait for the record, don't race it.
+wait_for_argv() {
+    for _ in $(seq 1 100); do
+        [ -s "$CLAUDE_ARGV" ] && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+run_summarizer() {
+    printf '{"hook_event_name":"UserPromptSubmit","prompt":"add a retry to the notes-api client"}' \
+        | "$HOOK"
+    wait_for_argv
+}
+
+@test "the summarizer model call passes --safe-mode (tools/MCP off does not cover hooks)" {
+    arm_summarizer
+    run_summarizer
+    grep -qx 'ARG=--safe-mode' "$CLAUDE_ARGV"
+}
+
+@test "the summarizer runs from a private dir it owns, never world-writable /tmp" {
+    arm_summarizer
+    run_summarizer
+    cwd="$(sed -n 's/^CWD=//p' "$CLAUDE_ARGV")"
+    [ -n "$cwd" ]
+    [ "$cwd" != "/tmp" ]
+    [ "$cwd" = "$XDG_STATE_HOME/romp/summarize" ]
+    # Created by the hook itself (it did not exist before this run) and 0700, so
+    # no other local user can drop a settings.json into the summarizer's cwd.
+    [ "$(stat -c '%a' "$cwd" 2>/dev/null || stat -f '%Lp' "$cwd")" = "700" ]
 }

--- a/tests/romp-uninstall.bats
+++ b/tests/romp-uninstall.bats
@@ -35,6 +35,17 @@ setup() {
     fake_clone
 }
 
+# Claude Code's project-dir encoding, as kernel/judge.py's _proj_dir implements it: every
+# non-alphanumeric character replaced, over the realpath. Tests must build the expected directory
+# with THIS, never with a shell ${p//\//-} — that only replaces slashes, and a test using it
+# agrees with a buggy implementation instead of with Claude Code.
+_proj_slug() {
+    python3 - "$1" <<'PYEOF'
+import os, re, sys
+print(re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(sys.argv[1])))
+PYEOF
+}
+
 teardown() { rm -rf "$TEST_DIR"; }
 
 hook_count() {   # how many romp hook commands are left registered across all events
@@ -199,17 +210,40 @@ EOF
     [[ "$output" != *"token page"* ]]
 }
 
-# ── romp's judge scratch, which lives OUTSIDE the state dir ──────────────────
-# romp runs judges as `claude` rooted at /tmp/romp-judge, so Claude Code writes their
-# transcripts to a project dir keyed on that path — outside $STATE, so --purge missed them and a
-# reinstalled romp kept showing judge records from the PREVIOUS install. They are romp's own
-# droppings, never a session anyone started, so the teardown owns them.
+# ── the judge scratch's Claude Code project dir, which lives OUTSIDE the state dir ───────────
+# romp runs judges as `claude` rooted at JUDGE_SCRATCH, so Claude Code writes their transcripts to
+# a project dir keyed on that path — outside $STATE, so --purge missed them and a reinstalled romp
+# kept showing judge records from the PREVIOUS install. They are romp's own droppings, never a
+# session anyone started, so the teardown owns them.
+#
+# The scratch itself moved from /tmp/romp-judge into "$STATE/judge-scratch", so --purge now takes the
+# directory as part of the state root; the DERIVED project dir is still keyed on the path, which is
+# what the default below has to track.
+
+@test "romp-uninstall: the judge scratch default follows the state root, not /tmp" {
+    # A stale default would leave the derived project dir behind — the 2026-07-27 incomplete-teardown
+    # symptom, returning under a new name. ROMP_JUDGE_SCRATCH is deliberately NOT set here.
+    export CLAUDE_CONFIG_DIR="$HOME/.claude"
+    scratch="$ROMP_STATE_DIR/judge-scratch"
+    mkdir -p "$scratch"
+    # Build the expected directory the way CLAUDE CODE does — kernel/judge.py's _proj_dir rule,
+    # every non-alphanumeric replaced over the realpath — NOT with the shell substitution the
+    # script under test uses. Deriving it the same way the code does is how this test passed while
+    # --purge swept a directory that never existed: it asserted the implementation against itself.
+    proj="$CLAUDE_CONFIG_DIR/projects/$(_proj_slug "$scratch")"
+    mkdir -p "$proj"
+    echo '{"synthetic":"judge call"}' > "$proj/11111111-2222-3333-4444-555555555555.jsonl"
+
+    run "$CLONE/bin/romp-uninstall" --yes --purge
+    [ "$status" -eq 0 ]
+    [ ! -d "$proj" ]
+}
 
 @test "romp-uninstall: removes romp's judge scratch and its transcripts" {
     export ROMP_JUDGE_SCRATCH="$TEST_DIR/romp-judge"
     export CLAUDE_CONFIG_DIR="$HOME/.claude"
     mkdir -p "$ROMP_JUDGE_SCRATCH"
-    proj="$CLAUDE_CONFIG_DIR/projects/${ROMP_JUDGE_SCRATCH//\//-}"
+    proj="$CLAUDE_CONFIG_DIR/projects/$(_proj_slug "$ROMP_JUDGE_SCRATCH")"
     mkdir -p "$proj"
     echo '{"synthetic":"judge call"}' > "$proj/11111111-2222-3333-4444-555555555555.jsonl"
 
@@ -224,7 +258,7 @@ EOF
     export ROMP_JUDGE_SCRATCH="$TEST_DIR/romp-judge"
     export CLAUDE_CONFIG_DIR="$HOME/.claude"
     mkdir -p "$ROMP_JUDGE_SCRATCH"
-    mkdir -p "$CLAUDE_CONFIG_DIR/projects/${ROMP_JUDGE_SCRATCH//\//-}"
+    mkdir -p "$CLAUDE_CONFIG_DIR/projects/$(_proj_slug "$ROMP_JUDGE_SCRATCH")"
     # A real project dir of the user's, which must survive untouched — deleting it would
     # destroy their own Claude Code history, which is not romp's to remove.
     mine="$CLAUDE_CONFIG_DIR/projects/-home-someone-notes-api"

--- a/tests/test_judge_scratch_private.py
+++ b/tests/test_judge_scratch_private.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""The judge scratch cwd is private, and romp refuses to judge without one.
+
+JUDGE_SCRATCH used to be the literal "/tmp/romp-judge", created with `os.makedirs(..., exist_ok=True)`.
+/tmp is world-writable and that name is guessable, so on any machine with a second local account someone
+could create the path first — as a directory with permissions of their choosing, or as a SYMLINK — and
+`exist_ok=True` would accept whatever they left there. Two things then follow, neither of them subtle:
+
+  * `prune_judge_scratch` runs at every kernel boot, realpaths the scratch through `_proj_dir`, and
+    unlinks every `*.jsonl` older than a day in the project dir that name derives to. Point the symlink
+    at a directory you actually work in and romp's own housekeeping deletes YOUR Claude Code transcripts.
+  * It is the cwd of a `claude -p` subprocess, and a cwd someone else controls is a cwd they can plant a
+    `.claude/` in. `_judge_cmd`'s `--safe-mode` is what closes that today; the cwd should not be relying
+    on it alone.
+
+Nothing is written INTO the scratch — it is a bare cwd, and the transcripts land under ~/.claude/projects
+— so this is about who controls the directory, not about what is stored in it.
+
+So: the scratch lives under the 0700 state root, is created 0700, and a directory that cannot be made
+private makes the judge call FAIL LOUDLY (an error row + a stderr line) rather than run from somewhere
+anyone can write. All fixtures SYNTHETIC.
+"""
+import json
+import os
+import stat
+import tempfile
+import time
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest import mock
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # hermetic BEFORE any romp code loads
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_scratch", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+# The bindings as PRODUCTION sees them, captured before any test rebinds the state root — a test's own
+# tempdir usually sits in /tmp, so only these can answer "is the scratch in /tmp?"
+IMPORT_STATE, IMPORT_SCRATCH = jd.STATE, jd.JUDGE_SCRATCH
+
+
+class JudgeScratchPrivate(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.STATE
+        self.td = tempfile.TemporaryDirectory()
+        jd._rebind_state(Path(self.td.name))
+
+    def tearDown(self):
+        jd._rebind_state(self._saved)
+        self.td.cleanup()
+
+    def _mode(self, p):
+        return stat.S_IMODE(os.lstat(p).st_mode)
+
+    # ── where it lives ───────────────────────────────────────────────────────
+    def test_scratch_is_under_the_state_root_not_tmp(self):
+        self.assertEqual(Path(IMPORT_SCRATCH).parent, IMPORT_STATE,
+                         "judge scratch belongs under the 0700 state root")
+        self.assertNotEqual(IMPORT_SCRATCH, "/tmp/romp-judge",
+                            "the world-writable, guessable path is the bug this test guards")
+        # ...and the root it sits under is the private one, so no other account can even traverse to it.
+        # (The suite's own root is a tempdir — conftest.py — hence the check on the root, not on "/tmp".)
+        self.assertEqual(stat.S_IMODE(os.lstat(IMPORT_STATE).st_mode), 0o700)
+
+    def test_rebind_moves_the_scratch_with_the_rest_of_the_state(self):
+        """_rebind_state is how tests isolate a state root; a scratch left behind writes into the LIVE one."""
+        self.assertTrue(str(jd.JUDGE_SCRATCH).startswith(self.td.name))
+
+    # ── how it is created ────────────────────────────────────────────────────
+    def test_created_0700(self):
+        d = jd._ensure_judge_scratch()
+        self.assertEqual(d, jd.JUDGE_SCRATCH)
+        self.assertTrue(os.path.isdir(d))
+        self.assertEqual(self._mode(d), 0o700, "owner-only, like the state root above it")
+
+    def test_created_0700_whatever_the_umask(self):
+        old = os.umask(0o000)                      # a permissive umask must not widen the scratch
+        try:
+            jd._ensure_judge_scratch()
+        finally:
+            os.umask(old)
+        self.assertEqual(self._mode(jd.JUDGE_SCRATCH), 0o700)
+
+    def test_existing_loose_directory_is_tightened(self):
+        """Ours but group/world-readable — a pre-move install, a stray umask. We own it, so repair it."""
+        os.makedirs(jd.JUDGE_SCRATCH, exist_ok=True)
+        os.chmod(jd.JUDGE_SCRATCH, 0o755)
+        jd._ensure_judge_scratch()
+        self.assertEqual(self._mode(jd.JUDGE_SCRATCH), 0o700)
+
+    def test_directory_owned_by_someone_else_is_refused(self):
+        """The pre-create attack: another local account owns the path when romp gets there."""
+        os.makedirs(jd.JUDGE_SCRATCH, exist_ok=True)
+        theirs = os.lstat(jd.JUDGE_SCRATCH).st_uid + 1
+        with mock.patch("os.geteuid", return_value=theirs):
+            with self.assertRaises(OSError) as cm:
+                jd._ensure_judge_scratch()
+        self.assertIn("judge scratch", str(cm.exception))
+
+    def test_symlink_in_place_of_the_scratch_is_refused(self):
+        """makedirs(exist_ok=True) is happy with a symlink to a directory; the check must not be. This is
+        the shape that turns prune_judge_scratch — which realpaths the scratch — into a delete of whatever
+        the link points at."""
+        elsewhere = os.path.join(self.td.name, "elsewhere")
+        os.makedirs(elsewhere, 0o777)
+        os.symlink(elsewhere, jd.JUDGE_SCRATCH)
+        with self.assertRaises(OSError):
+            jd._ensure_judge_scratch()
+
+    # ── what happens when it can't be made private ───────────────────────────
+    def test_unsafe_scratch_skips_the_judge_call_and_logs_it(self):
+        """Fail loudly: no private cwd → no judge call. Running it from /tmp or $HOME anyway would hand the
+        subprocess a working directory someone else can plant in, and a silent downgrade hides exactly the
+        breakage we need to see."""
+        os.symlink(self.td.name, jd.JUDGE_SCRATCH)       # unsafe, by the check above
+        jd._SCRATCH_FAIL_LOGGED.clear()
+        with mock.patch.object(jd.subprocess, "run", side_effect=AssertionError("judge call must not run")):
+            out = jd._judge_run("haiku", "you are a test", "summarize this synthetic unit",
+                                judge="captioner", tier="index")
+        self.assertEqual(out, "", "callers see a failed call, not a partial one")
+        rows = [json.loads(l) for l in Path(jd.ERRORS).read_text().splitlines() if l.strip()]
+        self.assertTrue(any(r["err"] == "scratch" and r["judge"] == "captioner" for r in rows),
+                        "the refusal is surfaced as an error row (`romp judges`), not swallowed")
+        # A scratch refusal is NOT the model's fault, so it must ride the same paused flag the rate gate
+        # and retry-pause set: a "" that means "skipped, try again" — NOT one that counts toward
+        # DISTILL_FAIL_CAP. Without the flag, three refusals in a row blank the card's summary to the ""
+        # sentinel (the distiller/briefer/staller each read _judge_ctx.paused to skip the count), which is
+        # irreversible content loss from a directory-permission hiccup.
+        self.assertTrue(getattr(jd._judge_ctx, "paused", False),
+                        "the give-up counters must treat a scratch-skip as a pause, not a failure")
+
+    # ── the age-based cleanup follows the new location ───────────────────────
+    def test_prune_sweeps_the_new_scratch_project_dir(self):
+        jd.PROJECTS = Path(self.td.name) / "projects"    # not derived from STATE — bind it by hand
+        proj = jd._proj_dir(jd._ensure_judge_scratch())
+        proj.mkdir(parents=True, exist_ok=True)
+        now = time.time()
+        old = proj / ("%s.jsonl" % SID)
+        new = proj / "22222222-3333-4444-5555-666666666666.jsonl"
+        for f in (old, new):
+            f.write_text('{"synthetic": "judge call"}\n')
+        os.utime(old, (now - 48 * 3600, now - 48 * 3600))
+        self.assertEqual(jd.prune_judge_scratch(now=now), 1)
+        self.assertFalse(old.exists())
+        self.assertTrue(new.exists(), "a fresh transcript (a call still in flight) is left alone")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`kernel/judge.py` already runs its model calls with `--safe-mode`, and its own docstring says why: it *"drops auto-discovered CLAUDE.md/memory + skills + hooks"*. `hooks/romp-summarize.sh` runs the same CLI without it, from `cd /tmp`. This PR makes the announcer consistent with the judge, and moves both helpers' working directories out of `/tmp`.

The two halves ship together on purpose, because separating them is self-contradicting: arguing "a helper's cwd must not be world-writable" while `JUDGE_SCRATCH = "/tmp/romp-judge"` sits in the tree is not an argument anyone should accept.

### 1. `--safe-mode` on the announcer

The summarizer gates tools (`--tools ""`) and MCP (`--strict-mcp-config` + empty config), but nothing stops a *discovered* `settings.json` from running hook commands. From a world-writable cwd, another local account can plant `/tmp/.claude/settings.json` and have its commands run as you.

Being straight about the preconditions, because they matter and a reviewer will find them:

- the hook is **off by default** — it needs `~/.claude/romp-summarize-on`, and the feature is already marked deprecated in its own header;
- it is tmux-only (`exit 0` with no `$TMUX`);
- there is a recursion guard.

So this is not "every prompt on every install". For anyone who *has* opted in, it is once per prompt and once per stop.

I also cannot demonstrate the last mile from this repo: whether headless `claude -p` really executes a cwd-discovered `.claude/settings.json` without a trust prompt is not something I can prove here. The argument rests on your own docstring and your own test (`tests/test_judge.py`), which I think is enough for a defense-in-depth change — but I am not presenting it as a working exploit.

### 2. Both cwds move under the state root

`$STATE/summarize` and `$STATE/judge-scratch`, created `0700`, with the same `${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}` idiom already used verbatim in `hooks/romp-postal-revive.sh` and `hooks/romp-wake.sh`. `_ensure_judge_scratch()` adds an `lstat` + `S_ISDIR` + owner check and repairs loose modes, refusing rather than proceeding if the directory is not ours.

**The strongest reason for this half is one I did not expect.** Nothing is ever written into the judge scratch — it is a bare cwd, and judge transcripts land under `~/.claude/projects/`. But `prune_judge_scratch` **realpaths** `JUDGE_SCRATCH` at every kernel boot and unlinks day-old `*.jsonl` in the project directory it derives from that path. A symlink planted at the guessable `/tmp/romp-judge`, pointed at a directory the user actually works in, turns romp's own housekeeping into a deleter of their real Claude Code transcripts. That is the concrete impact, and it is what the ownership/symlink guard closes.

When the scratch refuses, the judge call is skipped, logged once per reason as an `err == "scratch"` row, and `_judge_ctx.paused` is set — so a permissions problem is not counted by the give-up counters. Without that flag three refusals blank a card summary to the empty sentinel, which is unrepairable loss rather than a visible failure.

### A test that was asserting the implementation against itself

`tests/romp-uninstall.bats` *"removes romp's judge scratch and its transcripts"* changes here, and it is worth saying why it is not me weakening coverage. The test built its expected path with the same shell `${p//\//-}` substitution the script under test used — so it ratified the implementation against itself and stayed green while `--purge` swept a directory that never existed.

That shell slug agreed with Claude Code's real encoding only while the path was `/tmp/romp-judge`. The dot in `.local` breaks the agreement the moment the scratch moves, silently stranding the transcripts. The `_proj_slug` helper encodes the path the way Claude Code and `kernel/judge.py`'s `_proj_dir` do.

### Tests

13 cases pin this, **all 13 fail on `main` today**:

- `tests/test_judge_scratch_private.py` (new, 9 cases): under the state root not `/tmp`; rebind moves it; `0700` whatever the umask; a loose existing directory is tightened; a directory owned by someone else is refused; a symlink in its place is refused; an unsafe scratch skips the call and logs it *and* sets `paused`; prune sweeps the new project dir.
- `tests/romp-summarize-gate.bats`: `--safe-mode` is passed; it runs from a private dir it owns.
- `tests/romp-uninstall.bats`: the new default follows the state root, plus the slug correction above.

Full suite: **4560 passed vs 4551 on unmodified `main` — exactly +9, my new Python cases, zero of your tests flipped.** Full bats: 313 ok, 0 not ok.

### Adjacent, out of scope

`bin/romp-uninstall`'s scratch guards compare raw strings, so several spellings of the same directory (a trailing slash or newline, `//`, `/./`) walk straight past them and reach `rm -rf`. That is pre-existing and independent of this change, so I have deliberately left it alone rather than widen the diff — happy to send it as a follow-up if you want it.

This has run in production on our fork since early August, though that is evidence you cannot re-run yourself.
