### PR TITLE
Keep the serve token out of curl's argv

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -713,6 +713,19 @@ _romp_token() {
     cat "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/serve-token" 2>/dev/null || true
 }
 
+# The auth header as a curl CONFIG on stdin, for `curl --config -`. Never `-H "X-Romp-Token: $tok"`:
+# argv is world-readable through /proc/<pid>/cmdline, so every other account on the machine can read
+# the token off a running curl — and the token is full control of every session. These curls are
+# short-lived, which makes reading one a race rather than a certainty; that is not a boundary.
+# curl's config syntax is quoted, so a token carrying " or \ (only possible via ROMP_SERVE_TOKEN —
+# the minted one is base64url) is escaped rather than silently truncating the header.
+_romp_token_cfg() {
+    local _t _e
+    _t="$(_romp_token)"
+    _e="${_t//\\/\\\\}"; _e="${_e//\"/\\\"}"
+    printf 'header = "X-Romp-Token: %s"\n' "$_e"
+}
+
 # `romp url` — print the tokened dashboard URL, nothing else (scripting/piping; bare `romp` is the
 # human entry point). The first open seeds a year-long cookie; after that the bare URL works.
 # `--url` stays as a silent alias (agent-facing text names it).
@@ -762,7 +775,7 @@ if [[ "${1:-}" == "sessions" ]]; then
         *)      echo "usage: romp sessions [--json]" >&2; exit 2 ;;
     esac
     _kport="${ROMP_KERNEL_PORT:-29855}"
-    _resp="$(curl -sf -m 10 "http://127.0.0.1:$_kport/sessions" -H "X-Romp-Token: $(_romp_token)")" \
+    _resp="$(_romp_token_cfg | curl -sf -m 10 --config - "http://127.0.0.1:$_kport/sessions")" \
         || { echo "romp sessions: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
     if $_json; then
         printf '%s\n' "$_resp"
@@ -847,8 +860,7 @@ if [[ "${1:-}" =~ ^(checkin|checkout)$ ]]; then
     if [[ -z "$_host" ]]; then echo "usage: romp $_verb <host>" >&2; exit 2; fi
     _kport="${ROMP_KERNEL_PORT:-29855}"
     _on="false"; [[ "$_verb" == "checkin" ]] && _on="true"
-    _resp="$(curl -sf -m 10 -X POST "http://127.0.0.1:$_kport/tunnels/checkin" \
-                  -H "X-Romp-Token: $(_romp_token)" \
+    _resp="$(_romp_token_cfg | curl -sf -m 10 --config - -X POST "http://127.0.0.1:$_kport/tunnels/checkin" \
                   -H 'Content-Type: application/json' -d "{\"host\": \"$_host\", \"on\": $_on}")" \
         || { echo "romp $_verb: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
@@ -878,8 +890,7 @@ if [[ "${1:-}" =~ ^(--)?(send|interrupt|end)$ ]]; then
     else
         _payload="$(python3 -c 'import json,sys; print(json.dumps({"name": sys.argv[1]}))' "$_who")"
     fi
-    _resp="$(curl -sf -m 10 -X POST "http://127.0.0.1:$_kport/$_verb" \
-                  -H "X-Romp-Token: $(_romp_token)" \
+    _resp="$(_romp_token_cfg | curl -sf -m 10 --config - -X POST "http://127.0.0.1:$_kport/$_verb" \
                   -H 'Content-Type: application/json' -d "$_payload")" \
         || { echo "romp $_verb: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
@@ -1184,8 +1195,7 @@ if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
         exit 1
     fi
     _payload="$(python3 -c 'import json,sys; d={"name": sys.argv[1], "dir": sys.argv[2], "backend": "sdk"}; sys.argv[3] and d.update(model=sys.argv[3]); sys.argv[4] and d.update(effort=sys.argv[4]); print(json.dumps(d))' "$session_arg" "$_dir" "$model_arg" "$effort_arg")"
-    _resp="$(curl -sf -m 15 -X POST "http://127.0.0.1:$_kport/new" \
-                  -H "X-Romp-Token: $_tok" \
+    _resp="$(_romp_token_cfg | curl -sf -m 15 --config - -X POST "http://127.0.0.1:$_kport/new" \
                   -H 'Content-Type: application/json' -d "$_payload")" \
         || { echo "romp new: kernel not reachable on :$_kport (is romp running?). \`romp new -t $session_arg\` starts a terminal session without it." >&2; exit 1; }
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
@@ -1213,8 +1223,7 @@ if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
         # retry command instead of pretending the spawn failed.
         if [[ -n "$msg_arg" ]]; then
             _mpayload="$(python3 -c 'import json,sys; print(json.dumps({"name": sys.argv[1], "text": sys.argv[2]}))' "$session_arg" "$msg_arg")"
-            _mresp="$(curl -sf -m 10 -X POST "http://127.0.0.1:$_kport/send" \
-                          -H "X-Romp-Token: $_tok" \
+            _mresp="$(_romp_token_cfg | curl -sf -m 10 --config - -X POST "http://127.0.0.1:$_kport/send" \
                           -H 'Content-Type: application/json' -d "$_mpayload")" \
                 || { echo "romp new: session is up but the message did NOT land (kernel send failed). Retry: romp send $session_arg '<text>'" >&2; exit 1; }
             if [[ "$_mresp" == *'"ok": true'* || "$_mresp" == *'"ok":true'* ]]; then

--- a/hooks/romp-wake.sh
+++ b/hooks/romp-wake.sh
@@ -25,5 +25,12 @@ port="${ROMP_SERVE_PORT:-${ROMP_KERNEL_PORT:-29855}}"
 # 403s silently, same posture as no kernel at all (the 20s backstop covers it).
 tok="${ROMP_SERVE_TOKEN:-}"
 [[ -n "$tok" ]] || tok="$(cat "${ROMP_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/romp}/serve-token" 2>/dev/null || true)"
-( curl -sf -m 0.5 -X POST -H "X-Romp-Token: ${tok}" "http://127.0.0.1:${port}/tick" -o /dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
+# The token goes in on STDIN as a curl config, never in argv: /proc/<pid>/cmdline is world-readable,
+# so `-H "X-Romp-Token: $tok"` publishes full control of every session to any other account on the
+# machine for as long as the curl lives. This one is short-lived, which makes reading it a race
+# rather than a certainty — not a boundary. Quotes/backslashes escaped because curl's config syntax
+# is quoted (only reachable via ROMP_SERVE_TOKEN; the minted one is base64url).
+esc="${tok//\\/\\\\}"; esc="${esc//\"/\\\"}"
+( printf 'header = "X-Romp-Token: %s"\n' "$esc" \
+    | curl -sf -m 0.5 --config - -X POST "http://127.0.0.1:${port}/tick" -o /dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
 exit 0

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -576,8 +576,14 @@ def _load_token():
     v = base64.urlsafe_b64encode(os.urandom(18)).decode().rstrip("=")
     try:
         jd.STATE.mkdir(parents=True, exist_ok=True)
-        f.write_text(v)
-        os.chmod(f, 0o600)
+        # 0600 from birth, not written-then-chmod'd: between those two calls the file carried the
+        # token at the umask's mercy, and the whole same-user gate is this file's mode.
+        fd = os.open(str(f), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, v.encode())
+        finally:
+            os.close(fd)
+        os.chmod(f, 0o600)                       # a PRE-EXISTING file keeps its old mode through O_CREAT
     except OSError:
         pass
     return v

--- a/tests/romp-sessions.bats
+++ b/tests/romp-sessions.bats
@@ -31,9 +31,14 @@ setup() {
    "dir": "/tmp/notes-api", "bg": "#54B204", "fg": "black", "backend": "tmux", "working": ""}
 ]}
 JSON
+    export CURL_STDIN="$TEST_DIR/curl.stdin"
+    # Record argv AND stdin: the serve token travels on stdin now (curl --config -), so a mock that
+    # only watched argv could not tell a working auth header from no header at all. Read stdin
+    # BEFORE writing the response, or the config never lands.
     cat > "$MOCK/curl" <<'MOCK'
 #!/usr/bin/env bash
 echo "$*" >> "$CURL_LOG"
+cat >> "$CURL_STDIN" 2>/dev/null
 [ -n "${CURL_FAIL:-}" ] && exit 22
 cat "$FLEET_JSON"
 MOCK
@@ -72,7 +77,10 @@ teardown() { rm -rf "$TEST_DIR"; }
     run "$ROMP_SCRIPT" sessions
     [ "$status" -eq 0 ]
     grep -q "127.0.0.1:29855/sessions" "$CURL_LOG"
-    grep -q "TESTTOKEN123" "$CURL_LOG"
+    # The token goes in on stdin, never argv: /proc/<pid>/cmdline is world-readable, so a token in
+    # argv hands full control of every session to any other account on the machine.
+    grep -q "X-Romp-Token: TESTTOKEN123" "$CURL_STDIN"
+    ! grep -q "TESTTOKEN123" "$CURL_LOG"
 }
 
 @test "romp sessions: a dead kernel fails LOUDLY, never an empty list read as no sessions" {

--- a/tests/romp-wake-hook.bats
+++ b/tests/romp-wake-hook.bats
@@ -11,9 +11,14 @@ setup() {
     export CURL_LOG="$TEST_DIR/curl.log"
     # Mock curl: log args (the hook detaches it into a subshell, so the test polls
     # for the log below). Exported CURL_LOG so the detached mock can still find it.
+    export CURL_STDIN="$TEST_DIR/curl.stdin"
+    # ...and whatever arrived on stdin — the token travels on stdin now (curl --config -), so a
+    # test that only watched argv could not tell a working auth header from none at all. Read
+    # stdin BEFORE anything else, or the config never lands.
     cat > "$MOCK/curl" <<'MOCK'
 #!/usr/bin/env bash
 echo "curl $*" >> "$CURL_LOG"
+cat >> "$CURL_STDIN" 2>/dev/null
 MOCK
     chmod +x "$MOCK/curl"
     export PATH="$MOCK:$PATH"
@@ -57,8 +62,8 @@ teardown() { rm -rf "$TEST_DIR"; }
     # must carry X-Romp-Token or it 403s silently and the judges fall back to the backstop.
     ROMP_SERVE_TOKEN=tok-from-env run bash -c 'echo "{}" | "'"$HOOK"'"'
     [ "$status" -eq 0 ]
-    for _ in $(seq 1 40); do [ -s "$CURL_LOG" ] && break; sleep 0.05; done
-    grep -q 'X-Romp-Token: tok-from-env' "$CURL_LOG"
+    for _ in $(seq 1 40); do [ -s "$CURL_STDIN" ] && break; sleep 0.05; done
+    grep -q 'X-Romp-Token: tok-from-env' "$CURL_STDIN"   # on stdin now, never argv
 }
 
 @test "romp-wake reads the serve token from the state file" {
@@ -67,12 +72,40 @@ teardown() { rm -rf "$TEST_DIR"; }
     printf 'tok-from-file\n' > "$XDG_STATE_HOME/romp/serve-token"
     run bash -c 'echo "{}" | "'"$HOOK"'"'
     [ "$status" -eq 0 ]
-    for _ in $(seq 1 40); do [ -s "$CURL_LOG" ] && break; sleep 0.05; done
-    grep -q 'X-Romp-Token: tok-from-file' "$CURL_LOG"
+    for _ in $(seq 1 40); do [ -s "$CURL_STDIN" ] && break; sleep 0.05; done
+    grep -q 'X-Romp-Token: tok-from-file' "$CURL_STDIN"  # on stdin now, never argv
 }
 
 @test "romp-wake never fails the turn when the kernel is unreachable" {
     rm "$MOCK/curl"                       # use the real curl against a dead port
     ROMP_SERVE_PORT=1 run bash -c 'printf "" | "'"$HOOK"'"'
     [ "$status" -eq 0 ]
+}
+
+@test "romp-wake never puts the serve token in curl's argv" {
+    # /proc/<pid>/cmdline is world-readable, so a token in argv is full control of every session
+    # handed to any other account on the machine. It goes in on stdin as a curl config instead.
+    export ROMP_SERVE_TOKEN="TESTTOKENDONOTUSE"
+    ROMP_SERVE_PORT=7777 run bash -c 'echo "{}" | "'"$HOOK"'"'
+    [ "$status" -eq 0 ]
+    for _ in $(seq 1 40); do [ -s "$CURL_LOG" ] && break; sleep 0.05; done
+    for _ in $(seq 1 40); do [ -s "$CURL_STDIN" ] && break; sleep 0.05; done
+
+    ! grep -q "TESTTOKENDONOTUSE" "$CURL_LOG"
+    grep -q -- "--config" "$CURL_LOG"
+    # ...and the header really is being sent, so this is not "secure by not authenticating"
+    grep -q "X-Romp-Token: TESTTOKENDONOTUSE" "$CURL_STDIN"
+}
+
+@test "romp-wake escapes a token that would otherwise break curl's config syntax" {
+    # Only reachable via ROMP_SERVE_TOKEN (the minted token is base64url), but a quote in the
+    # value would truncate the header and silently unauthenticate the poke.
+    export ROMP_SERVE_TOKEN='ab"c\d'
+    ROMP_SERVE_PORT=7777 run bash -c 'echo "{}" | "'"$HOOK"'"'
+    [ "$status" -eq 0 ]
+    for _ in $(seq 1 40); do [ -s "$CURL_STDIN" ] && break; sleep 0.05; done
+    # curl's config syntax is quoted, so the " and the \ must arrive escaped; curl parses them
+    # back to the original token. Compared as a fixed string — the escaping is the point here.
+    run cat "$CURL_STDIN"
+    [ "$output" = 'header = "X-Romp-Token: ab\"c\\d"' ]
 }

--- a/tests/test_kernel_serve_token_mode.py
+++ b/tests/test_kernel_serve_token_mode.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""The serve-token file's MODE is the same-user gate on the whole kernel: anything that reads it can
+drive every session. `_load_token` used to `write_text()` and then `chmod 0600`, so between those two
+calls the token sat on disk at whatever the umask allowed (0644 on a stock account, 0666 under a
+permissive one). Opening the file 0600 closes that window.
+
+This is consistency, not an exploit: `judge.py` chmods the state root to 0700 at import, long before
+the token is minted, so the loose file already sat behind a tight door. But the credential's own mode
+is what the docstring above `_load_token` names as the gate, so it should be right from birth rather
+than a moment later — and the state root's mode is not something this function gets to assume.
+
+The mode test has to INTERPOSE on os.chmod. Without that the trailing chmod repairs the mode before
+anything can observe it, and the assertion passes on the unfixed code too.
+
+Synthetic only — hermetic temp STATE, placeholder token.
+"""
+import os
+import stat
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+def _mode(p):
+    return stat.S_IMODE(os.stat(p).st_mode)
+
+
+class ServeTokenFileMode(unittest.TestCase):
+    def setUp(self):
+        self.f = km.jd.STATE / "serve-token"
+        km.jd.STATE.mkdir(parents=True, exist_ok=True)
+        if self.f.exists():
+            self.f.unlink()
+        # _load_token returns ROMP_SERVE_TOKEN verbatim and never touches the file while it is set,
+        # so the mint path is only reachable with it out of the way.
+        self._env = os.environ.pop("ROMP_SERVE_TOKEN", None)
+        self._umask = os.umask(0)            # the widest case: only the open mode protects the file
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        os.umask(self._umask)
+        if self._env is not None:
+            os.environ["ROMP_SERVE_TOKEN"] = self._env
+        if self.f.exists():
+            self.f.unlink()
+
+    def test_minted_0600_before_any_chmod_can_repair_it(self):
+        chmods = []
+        real_chmod = os.chmod
+
+        def _no_chmod(path, mode, *a, **k):
+            """Record the repair and DON'T perform it — the mode the open() gave the file is the
+            whole question, and a chmod one line later hides the answer."""
+            chmods.append((str(path), mode))
+
+        os.chmod = _no_chmod
+        try:
+            tok = km._load_token()
+        finally:
+            os.chmod = real_chmod
+
+        self.assertTrue(self.f.exists(), "the mint path never ran — this test proves nothing")
+        self.assertEqual(self.f.read_text().strip(), tok, "the file must hold the token it returned")
+        self.assertEqual(_mode(self.f), 0o600,
+                         "the serve token must be 0600 from the open() that created it: writing it "
+                         "first and chmod'ing after leaves the credential at the umask's mercy for "
+                         "the gap between the two calls")
+        self.assertEqual(chmods, [(str(self.f), 0o600)],
+                         "the chmod after the write must stay — it is what tightens a PRE-EXISTING "
+                         "file, whose mode O_CREAT does not touch")
+
+    def test_a_pre_existing_loose_file_is_still_tightened(self):
+        # O_CREAT applies its mode only when it actually creates the file. An empty serve-token left
+        # at 0644 (a stale one, or one written before this change) re-mints through the same path and
+        # must come out 0600 — that is the chmod's remaining job, so it does not get dropped.
+        self.f.write_text("")                # empty → falsy → falls through to the mint
+        os.chmod(self.f, 0o644)
+        tok = km._load_token()
+        self.assertEqual(self.f.read_text().strip(), tok)
+        self.assertEqual(_mode(self.f), 0o600,
+                         "a token file that already existed at 0644 must not keep that mode")
+
+    def test_the_env_override_never_writes_the_file(self):
+        # Guards this test file's own premise: with ROMP_SERVE_TOKEN set there is nothing on disk to
+        # have a mode, so the cases above would be vacuous if the pop in setUp ever stopped working.
+        os.environ["ROMP_SERVE_TOKEN"] = "env-token-DO-NOT-USE"
+        try:
+            self.assertEqual(km._load_token(), "env-token-DO-NOT-USE")
+        finally:
+            os.environ.pop("ROMP_SERVE_TOKEN", None)
+        self.assertFalse(self.f.exists(), "the env override must not mint or persist anything")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The serve token is passed to `curl` as `-H "X-Romp-Token: ..."`, which puts a full-control credential into process argv. On Linux `/proc/<pid>/cmdline` is world-readable, so any other local account can read it out of `ps` while the request is in flight.

### Scope, stated honestly

**The shell clients stop publishing it.** This does *not* mean the token never appears in any argv — `bin/romp` still hands it to the browser when it opens the dashboard, which is a separate problem I am flagging at the bottom rather than fixing here.

Severity is Medium **on Linux only**: on macOS another user cannot read a process's argv (`KERN_PROCARGS2` is same-uid-or-root). And these curls are short-lived, so this is a race, not a durable exposure — but a race is not a boundary, and `romp-wake` fires at every turn boundary, re-offering the attempt.

### The change

A `_romp_token_cfg()` helper emits a curl config line (`header = "X-Romp-Token: %s"`, with `\` and `"` escaped for curl's quoted-config syntax) and the five shell call sites pipe it into `curl --config -`. That is four sites in `bin/romp` plus the `/tick` poke in `hooks/romp-wake.sh`. `-d` keeps the request body in argv, so nothing else contends for stdin.

`romp new` keeps `_tok` — it still gates the "kernel isn't running (no serve token)" error — only the header moves.

One thing worth pre-empting: `bin/romp` runs under `set -euo pipefail`, so the new pipeline is pipefail-sensitive. `_romp_token_cfg` can only fail on a printf failure, the config line is far under the pipe buffer so there is no realistic SIGPIPE, and any non-zero status lands on the existing `|| { echo "kernel not reachable" ...}` branch, which is the message the old code already produced.

### The token file's mode — consistency, not an exploit

`kernel/kernel.py` wrote the token with `write_text` and chmod'd it afterwards, leaving a brief window at the umask's mercy. It now opens `0600` from the start, keeping the trailing `chmod` for a pre-existing file.

I want to be precise that **this is not an exploitable window today**: `kernel/judge.py` chmods the state root to `0700` at import, well before `_load_token` runs, so the gap sat behind a closed door. The honest argument is narrower — this file's own mode is what `_load_token`'s docstring names as the same-user gate, and the function should not have to assume the directory did its job. (I used `os.open` rather than `_atomic_write`, which is defined after `_load_token` and whose temp file has the same window on a predictably-named path.)

### Tests this flips — three of yours, and why

Three existing assertions currently pin the leak by grepping the token out of the mock's **argv** record:

- `tests/romp-wake-hook.bats:61` and `:71`
- `tests/romp-sessions.bats:75`

All three now assert against the mock's **stdin** record instead. `tests/romp-wake-hook.bats` also gains a case asserting the token is absent from argv *while the header really is sent*, so this cannot pass by quietly not authenticating.

New `tests/test_kernel_serve_token_mode.py` (3 cases). The pinning one monkeypatches `os.chmod` to a no-op and asserts the file is already `0600` — only that interposed form actually fails on unfixed code. The other two are guards (the retained chmod still tightens a pre-existing loose file; the env-override path writes nothing) and pass either way; I kept them because they are what a future simplifier would delete, but say the word and I will drop them.

Your existing end-to-end coverage against a **real** curl is unchanged and still passes: `tests/romp.bats` and all seven `tests/romp-headless.bats` cases stand up a real HTTP server and assert the header arrives.

Full suite: **4554 passed vs 4551 on unmodified `main` — exactly +3, the new file, zero regressions.** 250 bats assertions across 20 suites, 0 failures.

### One exposure I am flagging rather than fixing

The fix here is a design call that belongs to you, so I have not made it.

The URL romp opens carries the serve token, so it becomes the argv of `open`/`xdg-open` and then of the browser itself (`bin/romp:795` + `:828`, the path a normal install takes since `bin/romp-serve:107` sets `ROMP_KERNEL_NO_OPEN=1`; `kernel/kernel.py:24760` for a hand-run kernel). On Linux that argv is world-readable, so another local account can lift a full-control credential out of `ps` for as long as that browser process lives. The token is read back from the state file rather than re-minted per boot, so one read is good until the file is deleted. A *cold* browser start leaves the tokened URL in the long-lived main-process argv — a certainty, not a race; a warm start is the short race.

Shapes that would close it: a single-use short-TTL code spent on arrival, a POST-once bootstrap, or simply opening the bare URL and letting the login page do the work. Each has real costs (a new credential type needs its own mint cap and a no-kernel fallback). Happy to implement whichever you prefer.

Note the *printed* link should keep the token deliberately — that is the one you copy to a phone.
