### PR TITLE
tests: arm the 19 mid-test negated-grep assertions that assert nothing

### DIFF
--- a/tests/release-sh.bats
+++ b/tests/release-sh.bats
@@ -115,7 +115,9 @@ STUB
     # half-finished release this script exists to prevent.
     grep -q "pr merge 4242 " "$GH_LOG"
     grep -q "pr view 4242 " "$GH_LOG"
-    ! grep -qE "pr (merge|view) release-" "$GH_LOG"
+    # `run` + status, NOT a bare `! grep`: `!` is exempt from set -e, so mid-test it asserts nothing.
+    run grep -qE "pr (merge|view) release-" "$GH_LOG"
+    [ "$status" -ne 0 ]
     run git -C "$REPO" tag -l
     [ "$output" = "v0.2.0" ]
 }
@@ -150,7 +152,8 @@ STUB
     run "$REPO/scripts/release.sh" 0.1.0 --skip-tests
     [ "$status" -eq 0 ]
     [[ "$output" == *"no bump PR needed"* ]]
-    ! grep -q "pr create" "$GH_LOG"
+    run grep -q "pr create" "$GH_LOG"
+    [ "$status" -ne 0 ]
     run git -C "$REPO" tag -l
     [ "$output" = "v0.1.0" ]
 }
@@ -210,7 +213,8 @@ STUB
     run "$REPO/scripts/release.sh" --skip-macos --skip-tests
     [ "$status" -eq 0 ]
     [[ "$output" == *"SKIPPING the macOS check"* ]]
-    ! grep -q "workflow run CI" "$GH_LOG"     # no CI was dispatched
+    run grep -q "workflow run CI" "$GH_LOG"   # no CI was dispatched
+    [ "$status" -ne 0 ]
     run git -C "$REPO" tag -l
     [ "$output" = "v0.1.0" ]
 }

--- a/tests/romp-manager-ensure.bats
+++ b/tests/romp-manager-ensure.bats
@@ -96,8 +96,11 @@ teardown() {
     for i in $(seq 1 50); do [ -s "$envdump" ] && break; sleep 0.1; done
     curl -fsS -X POST "http://127.0.0.1:7581/stop" >/dev/null 2>&1 || true
     [ -s "$envdump" ]
-    ! grep -q '^TMUX=' "$envdump"
-    ! grep -q '^TMUX_PANE=' "$envdump"
+    # `run` + status, NOT a bare `! grep`: `!` is exempt from set -e, so mid-test it asserts nothing.
+    run grep -q '^TMUX=' "$envdump"
+    [ "$status" -ne 0 ]
+    run grep -q '^TMUX_PANE=' "$envdump"
+    [ "$status" -ne 0 ]
     grep -q '^ROMP_SERVE_BIN=' "$envdump"   # the dump is real: other env DID flow through
 }
 

--- a/tests/romp-service.bats
+++ b/tests/romp-service.bats
@@ -67,7 +67,9 @@ teardown() { rm -rf "$TEST_DIR"; }
     [ "$status" -eq 0 ]
     local unit="$ROMP_SYSTEMD_DIR/romp-manager.service"
     grep -q "ExecStart=$ROMP_MANAGER_BIN up" "$unit"
-    ! grep -q "romp-node-launch" "$unit"
+    # `run` + status, NOT a bare `! grep`: `!` is exempt from set -e, so mid-test it asserts nothing.
+    run grep -q "romp-node-launch" "$unit"
+    [ "$status" -ne 0 ]
     [ ! -e "$XDG_STATE_HOME/romp/romp-node" ]
 }
 
@@ -265,7 +267,8 @@ EOF2
     ROMP_OS_OVERRIDE=Linux run "$SVC" install
     [ "$status" -eq 0 ]
     local unit="$ROMP_SYSTEMD_DIR/romp-manager.service"
-    ! grep -q "ROMP_SERVE_PORT\|ROMP_KERNEL_PORT\|ROMP_POSTAL_PORT\|ROMP_MANAGER_PORT\|ROMP_STATE_DIR\|CLAUDE_CONFIG_DIR\|ROMP_TMUX_SOCKET" "$unit"
+    run grep -q "ROMP_SERVE_PORT\|ROMP_KERNEL_PORT\|ROMP_POSTAL_PORT\|ROMP_MANAGER_PORT\|ROMP_STATE_DIR\|CLAUDE_CONFIG_DIR\|ROMP_TMUX_SOCKET" "$unit"
+    [ "$status" -ne 0 ]
     # ...and the file is still well-formed around the seam: the always-present
     # (optional, dash-prefixed) EnvironmentFile line, a blank line, then [Install].
     grep -q "^Environment=ROMP_SUPERVISED=1$" "$unit"

--- a/tests/romp-uninstall.bats
+++ b/tests/romp-uninstall.bats
@@ -127,8 +127,11 @@ EOF
     run "$CLONE/bin/romp-uninstall" --yes
     [ "$status" -eq 0 ]
 
-    ! grep -qF "$CLONE/bin" "$HOME/.bashrc"
-    ! grep -q '^# romp$' "$HOME/.bashrc"
+    # `run` + status, NOT a bare `! grep`: `!` is exempt from set -e, so mid-test it asserts nothing.
+    run grep -qF "$CLONE/bin" "$HOME/.bashrc"
+    [ "$status" -ne 0 ]
+    run grep -q '^# romp$' "$HOME/.bashrc"
+    [ "$status" -ne 0 ]
     grep -q 'EDITOR=vim' "$HOME/.bashrc"          # the user's own lines are untouched
     grep -q "alias ll=" "$HOME/.bashrc"
 }

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -149,9 +149,12 @@ STUB
     _stub_claude "2.1.220"
     run run_romp new -t myproject
     [ "$status" -eq 0 ]
-    ! grep -q -- '--settings' "$MOCK_LOG"
-    ! grep -q -- '@romp-inbound-accept' "$MOCK_LOG"
     [[ "$output" == *"claude update"* ]]     # the informative floor line, not a failure
+    # (checked BEFORE the greps below: `run` clobbers $output, so the output assertion must come first)
+    run grep -q -- '--settings' "$MOCK_LOG"
+    [ "$status" -ne 0 ]
+    run grep -q -- '@romp-inbound-accept' "$MOCK_LOG"
+    [ "$status" -ne 0 ]
 }
 
 @test "launch hands the exec line to respawn-pane, never typed via send-keys (dropped-char bug)" {
@@ -238,7 +241,9 @@ STUB
     line="$(grep -F 'respawn-pane' "$MOCK_LOG" | grep -F 'exec claude')"
     [ -n "$line" ]
     # no shell metacharacters survive in the exec line
-    ! grep -qE '[$();]' <<<"$line"
+    # `run` + status, NOT a bare `! grep`: `!` is exempt from set -e, so mid-test it asserts nothing.
+    run grep -qE '[$();]' <<<"$line"
+    [ "$status" -ne 0 ]
     # exactly the two quotes that wrap --name "<name>", no injected extras. The
     # fixed --settings tail romp itself appends carries its own JSON quotes — a
     # trusted constant, not name-derived — so strip it before counting.
@@ -345,7 +350,8 @@ STUB
 
     run run_romp resume abc123-uuid
     [ "$status" -eq 0 ]
-    ! grep -qE 'tmux attach-session -t myproject$' "$MOCK_LOG"
+    run grep -qE 'tmux attach-session -t myproject$' "$MOCK_LOG"
+    [ "$status" -ne 0 ]
     grep -q 'tmux new-session -d -s myproject-2' "$MOCK_LOG"
     grep -q 'tmux respawn-pane -k -t myproject-2 exec claude --resume abc123-uuid --name "myproject-2"' "$MOCK_LOG"
 }
@@ -357,8 +363,10 @@ STUB
     [ "$status" -eq 0 ]
     grep -q 'tmux new-session -d -s myproject' "$MOCK_LOG"
     grep -qE 'tmux respawn-pane -k -t myproject exec claude --name "myproject" --session-id [0-9a-f-]{36}' "$MOCK_LOG"
-    ! grep -q 'tmux attach-session' "$MOCK_LOG"
+    # $output is asserted BEFORE the `run grep` below overwrites it with grep's (empty) output.
     [[ "$output" == *"attach with: tmux attach -t myproject"* ]]
+    run grep -q 'tmux attach-session' "$MOCK_LOG"
+    [ "$status" -ne 0 ]
 }
 
 @test "detach: --resume + id + detach (the skill conversion path) still works as an alias" {
@@ -366,8 +374,10 @@ STUB
     [ "$status" -eq 0 ]
     grep -q 'tmux new-session -d -s myproject' "$MOCK_LOG"
     grep -q 'tmux respawn-pane -k -t myproject exec claude --resume sess-xyz --name "myproject"' "$MOCK_LOG"
-    ! grep -q 'tmux attach-session' "$MOCK_LOG"
+    # $output asserted before the `run grep` overwrites it.
     [[ "$output" == *"(detached)"* ]]
+    run grep -q 'tmux attach-session' "$MOCK_LOG"
+    [ "$status" -ne 0 ]
 }
 
 # ─── Misc ────────────────────────────────────────────────────────────
@@ -405,7 +415,8 @@ STUB
 
     run run_romp new -t myproject
     [ "$status" -eq 0 ]
-    ! grep -q 'tmux new-session' "$MOCK_LOG"
+    run grep -q 'tmux new-session' "$MOCK_LOG"
+    [ "$status" -ne 0 ]
     grep -q 'tmux attach-session -t myproject' "$MOCK_LOG"
 }
 
@@ -522,7 +533,8 @@ MOCK
     run run_romp up              # `romp up` is PURELY start-the-manager
     [ "$status" -eq 0 ]
     grep -q 'romp-manager called: up' "$MOCK_LOG"
-    ! grep -q 'romp-postal-service called' "$MOCK_LOG"   # up does not touch the bus
+    run grep -q 'romp-postal-service called' "$MOCK_LOG"   # up does not touch the bus
+    [ "$status" -ne 0 ]
 
     : > "$MOCK_LOG"
     run run_romp refresh         # restart EVERYTHING: the bus AND all kernels
@@ -858,10 +870,11 @@ _resume_rows_fn() {   # writes the extracted function to $1
     run run_romp new -t box
     [ "$status" -eq 0 ]
     grep -qF "tmux new-session -d -s box -c $expect" "$MOCK_LOG"
-    # the session must NOT be rooted at $HOME
-    ! grep -qF "tmux new-session -d -s box -c $home_real" "$MOCK_LOG"
-    # and the redirect is announced to the user
+    # the redirect is announced to the user — asserted BEFORE the `run grep` overwrites $output
     [[ "$output" == *"not launching in \$HOME"* ]]
+    # the session must NOT be rooted at $HOME
+    run grep -qF "tmux new-session -d -s box -c $home_real" "$MOCK_LOG"
+    [ "$status" -ne 0 ]
 }
 
 @test "ROMPHOME: a name-less resume from \$HOME is named after ROMPHOME, not \$HOME" {

--- a/tests/tmux-status-hook.bats
+++ b/tests/tmux-status-hook.bats
@@ -368,7 +368,9 @@ run_hook() {
     export XDG_STATE_HOME="$TEST_DIR/state"
     run run_hook '{"hook_event_name":"SessionStart","source":"clear","session_id":"fork-new","cwd":"/tmp"}'
     [ "$status" -eq 0 ]
-    ! grep -q 'set -t test @romp-session-id' "$MOCK_LOG"
+    # `run` + status, NOT a bare `! grep`: `!` is exempt from set -e, so mid-test it asserts nothing.
+    run grep -q 'set -t test @romp-session-id' "$MOCK_LOG"
+    [ "$status" -ne 0 ]
     [ ! -e "$TEST_DIR/state/romp/names/fork-new" ]
 }
 


### PR DESCRIPTION
## What breaks

bats runs each `@test` body under `set -e`, and bash exempts a `!`-prefixed pipeline from errexit — so a mid-test

```bash
! grep -q pattern file
```

whose grep FINDS the pattern returns 1 and the test just keeps going and passes. One-line demo:

```console
$ bash -ec '! true; echo reached'
reached
$ bash -ec 'false; echo reached'
$
```

Only when the negated line is the test's **final** command does its status become the function's return value that bats checks.

The result: 19 of the suite's 55 negated absence checks were mid-test and asserted nothing at all — decorative lines that could never fail, several of them guarding real regressions: env leakage (`TMUX`/`TMUX_PANE`) into a spawned manager, shell-metacharacter injection surviving into a tmux exec line, the release script dispatching CI it was told to skip, the uninstaller leaving `.bashrc` edits behind.

## Reproduction

Pick any of the 19 — say `tests/tmux-status-hook.bats`'s "no re-anchor when @romp-session-id is unset" — and point its negated grep at a pattern that is certainly present mid-test (`! grep -q 'tmux' "$MOCK_LOG"`): the test still passes on `main`. The same edit against this branch fails immediately at the armed status check.

## The fix

Each of the 19 becomes

```bash
run grep <same args>
[ "$status" -ne 0 ]
```

so a match now fails the test. The other 36 negations (35 `! grep` plus one `! printf | grep`) are the final command of their test, where the construct genuinely works — they are deliberately untouched; a blanket rewrite would churn working assertions for no gain.

Each site was converted individually rather than pattern-replaced, which mattered five times: `run` clobbers `$output`, and five sites sit in tests that assert the launching command's `$output` AFTER the absence check — those `$output` assertions are moved above the run-greps (comments at each site say why).

Counts per file: `release-sh.bats` 3, `romp-manager-ensure.bats` 2, `romp-service.bats` 2, `romp-uninstall.bats` 2, `romp.bats` 9, `tmux-status-hook.bats` 1.

## Tests

The change is tests; verification:

- All 159 tests across the six files pass with the assertions armed — none of the 19 was masking a live regression.
- Flip check on sampled sites: inverting an armed check's `-ne 0` to `-eq 0` makes the containing test fail at exactly that line, so these are guards now, not documentation. The paired reproduction above (same induced violation, base passes / armed fails) was run on the tmux-status-hook site.
- A sweep over the final tree (an awk classifier over `@test` blocks: any `!`-negated line followed by a non-comment command before the closing brace) confirms zero mid-test negations remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

