### PR TITLE
The bundle staleness scan watches *.js — a gear.js-only edit rebuilds again

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -24621,14 +24621,18 @@ class Handler(BaseHTTPRequestHandler):
 
 def _ensure_bundles():
     """Build the shared webview bundles (the human's tuned UI) if missing/stale — keeps the
-    kernel a single command and auto-rebuilds after TS/CSS edits (mirrors bin/romp-serve). Watches
-    .css as well as .ts: a CSS-only change must still trigger a rebuild on restart (the user 2026-06-16
+    kernel a single command and auto-rebuilds after TS/CSS/JS edits (mirrors bin/romp-serve).
+    Watches .css as well as .ts: a CSS-only change must still trigger a rebuild on restart (the user 2026-06-16
     hit a shipped style that didn't go live because only *.ts was checked). Watches ui/webview TOO,
     not just vscode-extension/src: esbuild.js builds the webview entrypoints from ../ui/webview
     (render.ts, styles.css, feed.ts, …), so an edit there never marked the bundle stale — a
     render.ts-only fix could sit unshipped through every kernel restart, with the ?v= cache token
     frozen so browsers kept the old bundle as well (found 2026-08-09 hunting the optimistic-echo
-    bug: the docstring promised a rebuild the check couldn't see).
+    bug: the docstring promised a rebuild the check couldn't see). Watches .js as well:
+    gear.js is a plain-JS module feed.ts/render.ts require() into the chat bundle — not an
+    esbuild entry point, just a bundled source — so a gear.js-only edit never marked dist
+    stale. Safe to widen over both roots: neither holds build outputs (DIST is elsewhere),
+    so *.js cannot match a bundle and self-trigger rebuilds.
 
     A failed build gets ONE retry after `npm install`: the common failure is dep drift — a merged
     commit imports a package this machine's node_modules predates (2026-08-10: the katex import
@@ -24643,7 +24647,7 @@ def _ensure_bundles():
     srcs = [cv / "src", ROOT / "ui" / "webview"]
     stale = not render.exists() or any(
         f.stat().st_mtime > render.stat().st_mtime
-        for src in srcs for f in [*src.rglob("*.ts"), *src.rglob("*.css")])
+        for src in srcs for f in [*src.rglob("*.ts"), *src.rglob("*.css"), *src.rglob("*.js")])
     if stale:
         sys.stderr.write("romp-kernel: building UI bundles…\n")
         # --production (minified, no sourcemaps), matching vscode-extension/install.sh. Both

--- a/tests/test_bundle_build_mode.py
+++ b/tests/test_bundle_build_mode.py
@@ -11,6 +11,7 @@ passed --production, any later source touch would swap the served dashboard back
 bundle on the next kernel restart, with nothing saying so. Source-level assertions, because the
 real build needs npm install and a network.
 """
+import glob
 import os
 import re
 import unittest
@@ -88,6 +89,27 @@ class BundleBuildMode(unittest.TestCase):
         self.assertIn('ROOT / "ui" / "webview"', body,
                       "the staleness scan must watch ui/webview, where the webview sources live")
         self.assertIn("for src in srcs", body, "…as one scan over every source root")
+
+    def test_webview_js_modules_required_by_the_bundles_are_watched(self):
+        """esbuild follows require("./x.js") into plain-JS webview modules (gear.js), so they are
+        bundle sources exactly like the .ts files — but the staleness scan globbed only *.ts/*.css,
+        so a gear.js-only edit never marked dist stale and sat unshipped through every kernel
+        restart. Derive the requirement from the sources rather than pinning a filename list, so
+        the next required .js module is covered the day it is added, whatever it is named."""
+        webview = os.path.join(ROOT, "ui", "webview")
+        mods = set()
+        for ts in glob.glob(os.path.join(webview, "*.ts")):
+            mods.update(re.findall(r'require\("\./([\w-]+\.js)"\)', _read(ts)))
+        self.assertIn("gear.js", mods,
+                      "the derivation lost its known case — did the require() shape change?")
+        for mod in sorted(mods):
+            self.assertTrue(os.path.exists(os.path.join(webview, mod)),
+                            "%s is require()d by a webview source but does not exist" % mod)
+        src = _read(KERNEL)
+        m = re.search(r"def _ensure_bundles\(\):.*?(?=\ndef )", src, re.S)
+        body = m.group(0)
+        self.assertIn('rglob("*.js")', body,
+                      "the staleness scan must watch the plain-JS modules the bundles require()")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What breaks

`_ensure_bundles` rebuilds the webview bundles when any watched source is newer than `dist/render.js`, but the watch globs only `*.ts`/`*.css`. `ui/webview/gear.js` is a plain-JS module that `feed.ts` (line 406) and `render.ts` (line 229) `require()` into the bundles — not an esbuild entry point, just a bundled source. So a gear.js-only change never marks dist stale: the kernel restarts, `/version` reports the new sha, and the served bundle predates the change — with the `?v=` cache token frozen so browsers keep the old bundle too. Found live on our fork: a settings-gear-only change shipped dark through a kernel restart until a hand rebuild.

## Reproduce

Edit only `ui/webview/gear.js` (e.g. add a visible control), then restart the kernel: no "building UI bundles…" line, `dist/render.js` mtime unchanged, and the gear renders without the change while `/version` reports the commit that contains it.

## The fix

Add `*.js` to the scan's globs, alongside `*.ts`/`*.css`. This is the third incarnation of the same seam: first the extensions were wrong (a CSS-only change didn't rebuild), then the directory was wrong (`ui/webview` wasn't watched — fixed in v0.7.0), now an extension in the right directory. Safe to widen over both roots: `vscode-extension/src` has no `.js` files, and `dist/` sits outside both watch roots, so build outputs can't self-trigger rebuilds.

## The test

In `tests/test_bundle_build_mode.py`, same source-level style as its neighbors (no module load, no npm, no network). Rather than pinning "gear.js" as a filename list that rots on the next rename, it derives the requirement from the sources: it scans `ui/webview/*.ts` for `require("./x.js")`, asserts each derived module exists under `ui/webview`, and asserts the `_ensure_bundles` scan globs `*.js`. `gear.js` appears only as a sentinel assertion that the derivation still finds the known case — if the require() pattern ever changes shape, the test fails loudly instead of silently checking nothing. Combined with the file's existing `test_the_staleness_scan_covers_every_source_root_esbuild_reads`, this proves every require()d `.js` is watched, and the next required `.js` module is covered the day it is added, whatever it is named. Red before the fix (fails on the missing `rglob("*.js")`), green after.

## Adjacent gap, noted not fixed here

`ui/webview/timeline-main.ts` (line 10) requires `../romp-timeline-view.js`, which lives outside both watch roots — an edit to that file also never triggers a rebuild, and `*.js` on the existing roots doesn't reach it. Left out to keep this change minimal; happy to send that separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)