### PR TITLE
File links open in the browser you are actually looking at: an in-feed viewer, /file text serving, and downloads

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from datetime import datetime, timezone
 from importlib.machinery import SourceFileLoader
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from urllib.parse import urlparse, parse_qs, unquote, urlencode
+from urllib.parse import urlparse, parse_qs, quote, unquote, urlencode
 
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent
@@ -18818,6 +18818,29 @@ _TEXT_MAX_BYTES = 2 * 1024 * 1024                # 2 MB of source is already pas
 #   power-of-two so the 413 _human_bytes renders it as the "2.0 MB" the constant means, not "1.9 MB"
 
 
+# ---- …and the DOWNLOAD half of the route (the user 2026-08-09): `/file?download=1` serves ANY file
+#      that exists, no extension allowlist, no NUL sniff, no size cap. The view allowlists above are a
+#      RENDERING choice — what the browser can usefully paint — not a security boundary: the user's call
+#      (2026-08-09) is that anything on disk is downloadable, since the OS layer still guards against
+#      running whatever lands, and the dashboard's owner can already read any file by asking an agent
+#      for it. Served as application/octet-stream with an attachment disposition, so the browser SAVES
+#      it and never interprets it, and STREAMED in fixed chunks — _send slurps whole bodies, and a
+#      multi-GB download through it would OOM the kernel that self-hosts the very sessions using it.
+_DOWNLOAD_CHUNK = 256 * 1024                     # fixed stream chunk: bounded memory whatever the file size
+
+
+def _attachment_disposition(name):
+    """Content-Disposition for the download path. The basename lands inside a quoted-string, so anything
+    that could terminate or extend the HEADER is replaced: CR/LF (header injection), the quote and the
+    backslash (quoted-string escapes), other control bytes. A name the ASCII form had to mangle also
+    rides the RFC 6266/5987 `filename*` form, so a browser that speaks it saves the real name."""
+    safe = "".join(c if " " <= c < "\x7f" and c not in '"\\' else "_" for c in name) or "download"
+    disp = 'attachment; filename="%s"' % safe
+    if safe != name:
+        disp += "; filename*=UTF-8''" + quote(name, safe="")
+    return disp
+
+
 def _is_text_path(fp):
     """Is `fp` a path /file may serve as TEXT? Extension allowlist plus the extensionless names that are
     text by convention. Name-based only; the BYTES are sniffed separately, so a mislabelled binary still
@@ -23427,14 +23450,22 @@ class Handler(BaseHTTPRequestHandler):
         nowhere near the kernel's machine — its own, much smaller cap, and a NUL sniff so a binary that
         slipped past the name allowlist 415s instead of arriving as mojibake."""
         fp = _resolve_open_path((q.get("path") or [""])[0], (q.get("sid") or [None])[0])
+        if (q.get("download") or [""])[0] == "1":
+            return self._file_download(fp, head=head)
         mime = _PREVIEW_MIME.get(os.path.splitext(fp)[1].lower())
         text = not mime and _is_text_path(fp)
         if text:
             mime = "text/plain; charset=utf-8"
         # Every error body NAMES the resolved path (home-collapsed) — a bare "not found" told the user
         # nothing about WHAT was tried when a relative link resolved somewhere unexpected (2026-08-09).
-        if not mime or not os.path.isabs(fp) or not os.path.isfile(fp):
+        if not os.path.isabs(fp) or not os.path.isfile(fp):
             return self._send(404, b"" if head else "not found: %s" % _tilde(fp), "text/plain")
+        if not mime:
+            # Exists, but on neither VIEW allowlist (a .zip, a .so). Its own status, distinct from 404,
+            # because the truths differ and the client acts on the difference: "not found" means give
+            # up, "not viewable" means offer the download the route above serves (the user 2026-08-09).
+            return self._send(415, b"" if head else
+                              "not viewable in the browser: %s" % _tilde(fp), "text/plain")
         size = os.path.getsize(fp)
         cap = _TEXT_MAX_BYTES if text else _PREVIEW_MAX_BYTES
         if size > cap:
@@ -23461,6 +23492,43 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(415, "not a text file: %s" % _tilde(fp), "text/plain")
             return self._send(200, body, mime, cache="no-cache")
         return self._send(200, raw, mime, cache="no-cache")
+
+    def _file_download(self, fp, head=False):
+        """GET/HEAD /file?download=1 — the SAVE half of the route (the user 2026-08-09): any file that
+        exists at the resolved path, streamed to the browser as an attachment. No extension allowlist,
+        no NUL sniff, no size cap — the view gates are a rendering choice, not a security boundary (see
+        _DOWNLOAD_CHUNK's comment for the user's rationale). application/octet-stream + attachment +
+        nosniff means the browser saves the bytes and never interprets them on this origin.
+
+        The body is STREAMED in fixed chunks, never slurped: _send reads whole bodies into memory, and
+        a multi-GB artifact through it would OOM the kernel — which self-hosts the sessions asking."""
+        if not os.path.isabs(fp) or not os.path.isfile(fp):
+            return self._send(404, b"" if head else "not found: %s" % _tilde(fp), "text/plain")
+        size = os.path.getsize(fp)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Disposition", _attachment_disposition(os.path.basename(fp)))
+        self.send_header("Content-Length", str(size))      # the real length — the browser shows progress
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("Cache-Control", "no-cache")
+        if getattr(self, "_cors_origin", None):
+            self.send_header("Access-Control-Allow-Origin", self._cors_origin)
+            self.send_header("Vary", "Origin")
+        self.end_headers()
+        if head:
+            return
+        # Exactly Content-Length bytes, chunk by chunk. A file truncated mid-stream can no longer honor
+        # the promised length, so the connection closes instead of leaving the browser waiting on bytes
+        # that will never come — a visibly failed download, not a hang (fail loudly).
+        remaining = size
+        with open(fp, "rb") as f:
+            while remaining > 0:
+                chunk = f.read(min(_DOWNLOAD_CHUNK, remaining))
+                if not chunk:
+                    self.close_connection = True
+                    break
+                self.wfile.write(chunk)
+                remaining -= len(chunk)
 
     def do_OPTIONS(self):
         """CORS preflight. The strip's tunnel actions POST JSON (Content-Type:
@@ -25056,19 +25124,31 @@ class Handler(BaseHTTPRequestHandler):
         is rewritten into the forwarded query (so the browser only ever needs its local credential,
         and the per-host trust boundary is unchanged — THAT kernel still runs its own allowlist,
         size cap and path resolution), and this kernel reads nothing but the reply it mirrors.
-        Deliberately /file only — a preview relay, not a general proxy."""
+        Deliberately /file only — a preview relay, not a general proxy.
+
+        The Content-Type is derived HERE, from the requested extension against _PREVIEW_MIME —
+        the same table and the same 404 the local /file route applies — and the remote's own
+        Content-Type header is discarded. Mirroring it let a compromised remote kernel answer
+        `text/html` for a path the preview lightbox opens in a SAME-ORIGIN, unsandboxed iframe
+        (ui/webview/preview.ts), i.e. script on the dashboard's origin with the token cookie
+        attached. An attached host is trusted to serve its own files, not to choose how this
+        browser interprets them."""
         with _remotes_lock:
             r = _remotes.get(host)
             port, rtok = (r or {}).get("local_port") or 0, (r or {}).get("token") or ""
         if not port:
             return self._send(404, b"" if head else ("no attached host %r" % host), "text/plain")
         q = parse_qs(query or "")
-        # Our own verdict on the type, before the remote gets a say: derive the Content-Type from the
-        # requested extension against _PREVIEW_MIME (the same table + 404 the local /file route uses)
-        # and DISCARD the remote's own Content-Type below. Mirroring it let a compromised remote answer
-        # text/html for a path the preview lightbox opens in a same-origin, unsandboxed iframe
-        # (ui/webview/preview.ts) — script on the dashboard's origin with the cookie attached. An
-        # extension the local route would 404 is 404'd here too, so the relay never widens what renders.
+        if (q.get("download") or [""])[0] == "1":
+            # The download half rides the same relay (the user 2026-08-09: anything on disk is
+            # downloadable — see _file_download). No local extension gate: the gate below exists so the
+            # relay can never widen what a preview may RENDER, and a download renders nothing — the
+            # headers this side writes (octet-stream + attachment + nosniff, derived HERE, never from
+            # the remote's reply) are what guarantee that. The remote still resolves the path and
+            # decides existence; this side streams its answer through without buffering it.
+            return self._relay_download(host, port, rtok, q, head=head)
+        # Our own verdict on the type, before the remote gets a say. An extension the local route
+        # would 404 is 404'd here too, so the relay can never widen what a preview may render.
         rp = (q.get("path") or [""])[0]
         mime = _PREVIEW_MIME.get(os.path.splitext(rp)[1].lower())
         if not mime and _is_text_path(rp):
@@ -25112,6 +25192,72 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             return
         return self._send(status, body, ctype, cache="no-cache")
+
+    def _relay_download(self, host, port, rtok, q, head=False):
+        """GET/HEAD /remote/<host>/file?download=1 — the download half of the relay. Forwards the one
+        request (download=1 intact, the remote's own token rewritten in, same trust boundary as
+        _remote_file) and STREAMS the reply back chunk by chunk — a download has no size cap, so
+        buffering it here would OOM this kernel exactly the way _file_download's streaming exists to
+        avoid. Every attachment header is derived HERE from the requested basename, never mirrored
+        from the remote's reply — the lying-remote reasoning of _remote_file's Content-Type check —
+        which also means Content-Disposition survives the relay by construction."""
+        if rtok:
+            q["token"] = [rtok]      # the remote's own credential; whatever the browser sent means nothing there
+        conn = http.client.HTTPConnection("127.0.0.1", int(port), timeout=15)
+        try:
+            # Phase 1 — dial and read the verdict. Nothing has been written to the browser yet, so a
+            # failure here can still answer with a clean 502.
+            try:
+                conn.request("HEAD" if head else "GET", "/file?" + urlencode(q, doseq=True))
+                resp = conn.getresponse()
+                if resp.status != 200:
+                    # the remote's error verdict (its 404 names the path IT resolved) — small, safe to slurp
+                    body = b"" if head else resp.read(_TEXT_MAX_BYTES)
+                    return self._send(resp.status, body, "text/plain", cache="no-cache")
+                clen = resp.getheader("Content-Length")
+            except (OSError, http.client.HTTPException):
+                return self._send(502, b"" if head else ("tunnel to %s is not answering" % host), "text/plain")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Disposition",
+                             _attachment_disposition(os.path.basename((q.get("path") or [""])[0])))
+            if clen is not None:
+                self.send_header("Content-Length", clen)   # the remote's real length, passed through
+            else:
+                self.close_connection = True                # no length → the close marks the body's end
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("Cache-Control", "no-cache")
+            if getattr(self, "_cors_origin", None):
+                self.send_header("Access-Control-Allow-Origin", self._cors_origin)
+                self.send_header("Vary", "Origin")
+            self.end_headers()
+            if head:
+                return
+            # Phase 2 — the body. Headers are out, so a second status line is no longer possible: a
+            # tunnel that dies mid-stream just closes this connection short of Content-Length, which
+            # the browser reports as a failed download — visible, not a hang (fail loudly).
+            copied = 0
+            try:
+                while True:
+                    chunk = resp.read(_DOWNLOAD_CHUNK)
+                    if not chunk:
+                        break
+                    self.wfile.write(chunk)
+                    copied += len(chunk)
+            except (OSError, http.client.HTTPException):
+                self.close_connection = True
+            if clen is not None and copied < int(clen):
+                # A remote that truncates CLEANLY — its own _file_download sends short and closes
+                # when the file shrank mid-stream — ends the read with b'' and NO exception, so the
+                # except above never sees it. The Content-Length already forwarded is now a broken
+                # promise on a keep-alive connection: close, the same visibly-failed download as
+                # the exception path, instead of a browser waiting on bytes that never come.
+                self.close_connection = True
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
 
     def _push_one(self, client):
         _push([client], connect=True)             # full state to a fresh client (its per-client dedup is empty);

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18790,6 +18790,64 @@ _img_cache = {}                                  # "path:mtime:size" → dataURL
 _PREVIEW_MIME = dict(_IMG_MIME, **{".pdf": "application/pdf"})
 _PREVIEW_MAX_BYTES = 50_000_000                  # a plot/report, not a dataset — bigger 413s (fail loudly)
 
+# ---- …and the SOURCE/TEXT half of the same route (the user 2026-08-08). Clicking a file link used to
+#      post openFile, which runs an opener on the KERNEL's machine — useless when you are reading the
+#      dashboard over the internet from another device, and on a non-macOS kernel it did nothing at all
+#      (see _open_file). The dashboard can only show you a file if the bytes reach YOUR browser, and
+#      /file already does that for images and PDFs; this widens it to the text the links actually point
+#      at. Served as text/plain, never text/html — the viewer highlights source itself rather than
+#      rendering it, and _send's nosniff means even an .html here is inert.
+#
+#      The cap is its own, and far smaller than the media one (the user asked for one): a 50 MB log
+#      dragged down an ssh tunnel to a phone helps nobody, and a viewer that then has to paint it is
+#      worse than the 413 explaining why it stopped.
+_TEXT_EXT = set((
+    "txt md markdown rst adoc org text log err out diff patch csv tsv"
+    " py pyi rb rs go java kt kts swift c h cc cpp hpp cs m mm scala clj lua pl php r jl dart"
+    " js jsx mjs cjs ts tsx json jsonc json5 yaml yml toml ini cfg conf properties"
+    " html htm xml svg css scss sass less vue svelte astro"
+    " sh bash zsh fish ps1 bat cmd nix tf hcl proto graphql gql sql prisma"
+    " lock mod sum gradle cmake mk make bazel bzl gemspec podspec bats"
+).split())
+# Extensionless files that are text by convention — an agent links these as often as it links a .py.
+_TEXT_NAMES = {"makefile", "dockerfile", "jenkinsfile", "procfile", "rakefile", "gemfile", "brewfile",
+               "vagrantfile", "caddyfile", "justfile", "license", "licence", "notice", "authors",
+               "changelog", "readme", "todo", "codeowners", ".gitignore", ".gitattributes",
+               ".dockerignore", ".editorconfig", ".env", ".bashrc", ".zshrc", ".profile"}
+_TEXT_MAX_BYTES = 2 * 1024 * 1024                # 2 MB of source is already past what anyone reads — a
+#   power-of-two so the 413 _human_bytes renders it as the "2.0 MB" the constant means, not "1.9 MB"
+
+
+def _is_text_path(fp):
+    """Is `fp` a path /file may serve as TEXT? Extension allowlist plus the extensionless names that are
+    text by convention. Name-based only; the BYTES are sniffed separately, so a mislabelled binary still
+    never comes back as garbage."""
+    base = os.path.basename(fp).lower()
+    ext = os.path.splitext(base)[1].lstrip(".")
+    return (ext in _TEXT_EXT) or (base in _TEXT_NAMES)
+
+
+def _human_bytes(n):
+    """Byte count → a short human size, for the 413 that has to explain itself."""
+    for unit, step in (("GB", 1 << 30), ("MB", 1 << 20), ("KB", 1 << 10)):
+        if n >= step:
+            return "%.1f %s" % (n / float(step), unit)
+    return "%d bytes" % n
+
+
+def _decode_text(raw):
+    """File bytes → text for the viewer, or None if this is not really text. A NUL byte is the sniff:
+    every real source file lacks one and every binary that slipped past the name allowlist (a `.out`
+    executable, a `.lock` that is actually a database) has one within the first block. UTF-8 first,
+    then latin-1, which cannot fail — a stray byte in an otherwise fine log shows as one odd glyph
+    rather than costing the user the whole file."""
+    if b"\0" in raw[:8192]:
+        return None
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return raw.decode("latin-1")
+
 
 def _img_data_url(p0):
     """A `path:<abs>` image → a data: URL the webview can <img src>. ~ expanded; absolute + known image
@@ -19001,13 +19059,33 @@ def _path_links(md, sid, uuid, memo):
     return dict(links) if (links or misses) else None
 
 
+def _opener_cmd():
+    """The command that hands a path to this machine's desktop, or None if it has none. Sibling of
+    _dialog_cmd, and broken the same way until 2026-08-08: it was bare macOS `open`, so off macOS the
+    OSError was swallowed and a click-to-open did nothing at all, silently."""
+    if sys.platform == "darwin":
+        return "open"
+    if not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")):
+        return None                              # headless — nothing to hand a file to
+    return "xdg-open" if shutil.which("xdg-open") else None
+
+
 def _open_file(p, sid=None):
-    """Open a path in the user's default app/editor (macOS `open`); best-effort, never raises."""
+    """Open a path in the user's default app/editor on the KERNEL's machine. True if handed off, False
+    if this machine has no desktop to hand it to — callers surface that rather than swallowing it.
+
+    Note what this is NOT: it opens on the machine the kernel runs on, which is the wrong screen
+    entirely when the dashboard is being read remotely. That case is served by /file + the viewer, not
+    by this (the user 2026-08-08)."""
+    exe = _opener_cmd()
+    if not exe:
+        return False
     try:
-        subprocess.Popen(["open", _resolve_open_path(p, sid)], stdin=subprocess.DEVNULL,
+        subprocess.Popen([exe, _resolve_open_path(p, sid)], stdin=subprocess.DEVNULL,
                          stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
     except OSError:
-        pass
+        return False
 
 
 # ── native file/folder dialogs ─────────────────────────────────────────────────────────────────────
@@ -21324,7 +21402,18 @@ _LANDING_SETTINGS_JS = """
 (function(){window.addEventListener('message',function(e){var m=e.data;if(!m)return;
 if(m.romp==='settings')document.body.classList.toggle('settings-open',!!m.on);
 // the /chat iframe's new-session picker asks the shell to lift it full-window (see body.picker-open CSS)
-if(m.romp==='picker')document.body.classList.toggle('picker-open',!!m.on);});
+if(m.romp==='picker')document.body.classList.toggle('picker-open',!!m.on);
+// A file link clicked in the CHAT shows the file in the FEED pane, which is a different document — so
+// the shell relays it (the user 2026-08-08, reading the dashboard from another machine, where the old
+// openFile would have opened the file on the kernel's screen). If the feed pane is toggled off we turn
+// it on for the duration and remember to put it back, so the viewer never costs the user their layout.
+if(m.romp==='viewFile'){var vf=document.getElementById('f-feed');
+  if(!document.body.classList.contains('po-feed')){window.__rompFeedWasOff=true;
+    try{window.__rompPaneToggle&&window.__rompPaneToggle('feed',true);}catch(e){}}
+  try{window.__rompMobileTab&&window.__rompMobileTab('feed');}catch(e){}   // phone: one pane at a time
+  try{vf&&vf.contentWindow&&vf.contentWindow.postMessage({romp:'viewFile',path:m.path,sid:m.sid},'*');}catch(e){}}
+if(m.romp==='viewFileClosed'&&window.__rompFeedWasOff){window.__rompFeedWasOff=false;
+  try{window.__rompPaneToggle&&window.__rompPaneToggle('feed',false);}catch(e){}}});
 // One id per dashboard (per browser tab/window), minted here so every pane in it reports the same one.
 // sessionStorage, deliberately: it survives a reload (the panes keep their identity) and a second window
 // gets its own, which is what makes "the dashboard that asked" a thing the kernel can address.
@@ -22023,6 +22112,7 @@ var B=bar.querySelectorAll('button'),KT='romp-mobile-tab';
 function show(p){if(!F[p])return;document.body.setAttribute('data-tab',p);for(var k in F)F[k].classList.toggle('m-on',k===p);
 for(var i=0;i<B.length;i++)B[i].classList.toggle('on',B[i].getAttribute('data-pane')===p);
 try{localStorage.setItem(KT,p);}catch(e){}}
+window.__rompMobileTab=show;   // the file-viewer bridge brings the feed tab forward on a phone
 // A REVEAL un-hides a desktop-toggled-off pane before the mobile tab switch (the user 2026-08-13: a feed
 // click that jumps into a CLOSED chat used to land invisibly — the hidden iframe's WS stays live, so the
 // scroll ran under display:none and nothing appeared to happen). Same __rompPaneToggle(…, true) the Log
@@ -23331,14 +23421,27 @@ class Handler(BaseHTTPRequestHandler):
         cwd — _resolve_open_path); RENDERABLE media only (_PREVIEW_MIME), anything else 404s and the
         client keeps its plain link. Oversize 413s rather than silently truncating. HEAD is the
         existence probe for a chip that can't self-verify like an <img> (a PDF): headers only, so a
-        since-deleted file costs no download and never shows a dead chip."""
+        since-deleted file costs no download and never shows a dead chip.
+
+        Also serves SOURCE/TEXT (the user 2026-08-08) so the viewer can show a file to a browser that is
+        nowhere near the kernel's machine — its own, much smaller cap, and a NUL sniff so a binary that
+        slipped past the name allowlist 415s instead of arriving as mojibake."""
         fp = _resolve_open_path((q.get("path") or [""])[0], (q.get("sid") or [None])[0])
         mime = _PREVIEW_MIME.get(os.path.splitext(fp)[1].lower())
+        text = not mime and _is_text_path(fp)
+        if text:
+            mime = "text/plain; charset=utf-8"
+        # Every error body NAMES the resolved path (home-collapsed) — a bare "not found" told the user
+        # nothing about WHAT was tried when a relative link resolved somewhere unexpected (2026-08-09).
         if not mime or not os.path.isabs(fp) or not os.path.isfile(fp):
-            return self._send(404, b"" if head else "not found", "text/plain")
+            return self._send(404, b"" if head else "not found: %s" % _tilde(fp), "text/plain")
         size = os.path.getsize(fp)
-        if size > _PREVIEW_MAX_BYTES:
-            return self._send(413, b"" if head else "too large to preview", "text/plain")
+        cap = _TEXT_MAX_BYTES if text else _PREVIEW_MAX_BYTES
+        if size > cap:
+            return self._send(413, b"" if head else
+                              "too large to show: %s (%s, limit %s)"
+                              % (_tilde(fp), _human_bytes(size), _human_bytes(cap)),
+                              "text/plain")
         if head:
             self.send_response(200)
             self.send_header("Content-Type", mime)
@@ -23351,7 +23454,13 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             return
         with open(fp, "rb") as f:
-            return self._send(200, f.read(), mime, cache="no-cache")
+            raw = f.read()
+        if text:
+            body = _decode_text(raw)
+            if body is None:                     # named like text, isn't — say so rather than serve garbage
+                return self._send(415, "not a text file: %s" % _tilde(fp), "text/plain")
+            return self._send(200, body, mime, cache="no-cache")
+        return self._send(200, raw, mime, cache="no-cache")
 
     def do_OPTIONS(self):
         """CORS preflight. The strip's tunnel actions POST JSON (Content-Type:
@@ -24725,7 +24834,13 @@ class Handler(BaseHTTPRequestHandler):
                 # chip up from the moment the file was picked, and only this reply can retire it
                 _reply(client, {"type": "dropSaveFailed", "name": str(msg["name"])})
         elif msg and msg.get("type") == "openFile" and msg.get("path"):
-            _open_file(str(msg["path"]), sid=msg.get("id"))       # caption / linkified path click → open it (relative → resolved vs the session cwd)
+            # caption / linkified path click → open it on the kernel's machine (relative → resolved vs
+            # the session cwd). The web dashboard sends this only where it IS the right answer; a remote
+            # viewer gets the in-page viewer instead. If we still cannot, say so (the user 2026-08-08).
+            if not _open_file(str(msg["path"]), sid=msg.get("id")):
+                client["send"](json.dumps({"type": "warn", "text":
+                    "Could not open %s: %s has no desktop session to open it on."
+                    % (os.path.basename(str(msg["path"])) or str(msg["path"]), _self_host())}))
         elif msg and msg.get("type") == "pickFile":
             if not _native_dialogs():                             # same silent-nothing as Browse… — say it instead
                 client["send"](json.dumps({"type": "warn", "text": _no_dialog_why("file")}))
@@ -24954,7 +25069,15 @@ class Handler(BaseHTTPRequestHandler):
         # text/html for a path the preview lightbox opens in a same-origin, unsandboxed iframe
         # (ui/webview/preview.ts) — script on the dashboard's origin with the cookie attached. An
         # extension the local route would 404 is 404'd here too, so the relay never widens what renders.
-        mime = _PREVIEW_MIME.get(os.path.splitext((q.get("path") or [""])[0])[1].lower())
+        rp = (q.get("path") or [""])[0]
+        mime = _PREVIEW_MIME.get(os.path.splitext(rp)[1].lower())
+        if not mime and _is_text_path(rp):
+            # The text half of /file (the user 2026-08-08) relays too — this gate predated it, so a
+            # remote session's .py/.md 404'd here while the LOCAL route served the same file (found
+            # 2026-08-14, planning the file browser). Same defense, wider list: the type is OURS —
+            # text/plain never executes, nosniff rides every reply — and the remote's own text cap
+            # and NUL sniff still rule at its end; its non-200 verdicts pass through below.
+            mime = "text/plain; charset=utf-8"
         if not mime:
             return self._send(404, b"" if head else "not found", "text/plain")
         if rtok:

--- a/tests/test_file_view.py
+++ b/tests/test_file_view.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Serving SOURCE/TEXT over /file, so a file link can be FOLLOWED from a remote dashboard.
+
+Clicking a path in the chat used to post `openFile`, which the kernel served by handing the path to an
+opener on ITS machine. Two things were wrong with that (the user 2026-08-08). The opener was bare macOS
+`open`, so off macOS the OSError was swallowed and the click did nothing whatsoever — no reply, no error,
+a link that looked alive. And even repaired it opens the file on the KERNEL's screen, which is the wrong
+machine entirely when the dashboard is being read over the internet from somewhere else.
+
+The bytes have to reach the browser. /file already did that for images and PDFs; these tests cover the
+text half of it — the allowlist, the size cap the user asked for, the binary sniff behind it — plus the
+opener now reporting that it cannot open anything instead of failing mute.
+
+Synthetic files in a temp dir only.
+"""
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # hermetic BEFORE any romp code loads
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_fileview", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class TextAllowlist(unittest.TestCase):
+    def test_source_and_prose_extensions_are_text(self):
+        for p in ["/a/kernel.py", "/a/render.ts", "/a/notes.md", "/a/server.log", "/a/c.json",
+                  "/a/x.yaml", "/a/run.sh", "/a/Main.java", "/a/q.sql", "/a/t.bats", "/a/d.patch"]:
+            self.assertTrue(km._is_text_path(p), p)
+
+    def test_extensionless_conventions_count_and_case_does_not(self):
+        for p in ["/a/Makefile", "/a/Dockerfile", "/a/LICENSE", "/a/.gitignore", "/a/README"]:
+            self.assertTrue(km._is_text_path(p), p)
+        self.assertTrue(km._is_text_path("/a/MAKEFILE"))
+        self.assertTrue(km._is_text_path("/a/KERNEL.PY"))
+
+    def test_media_and_binaries_are_not_text(self):
+        # images/PDF keep their OWN branch (bytes, not decoded); a real binary is not offered at all
+        for p in ["/a/plot.png", "/a/report.pdf", "/a/x.zip", "/a/lib.so", "/a/photo.jpeg", "/a/db.sqlite"]:
+            self.assertFalse(km._is_text_path(p), p)
+
+
+class DecodeText(unittest.TestCase):
+    def test_utf8_round_trips_and_latin1_never_loses_the_file(self):
+        self.assertEqual(km._decode_text("héllo\n".encode("utf-8")), "héllo\n")
+        # one bad byte in an otherwise fine log costs one odd glyph, not the whole file
+        self.assertEqual(km._decode_text(b"ok \xff done"), "ok \xff done".replace("\xff", "ÿ"))
+
+    def test_a_nul_byte_means_this_is_not_text(self):
+        self.assertIsNone(km._decode_text(b"\x7fELF\x00\x00binary"))
+        self.assertIsNone(km._decode_text(b"text then \x00 a nul"))
+        # …and the sniff only reads the head, so a NUL past it is not what decides
+        self.assertIsNotNone(km._decode_text(b"a" * 9000 + b"\x00"))
+
+
+class HumanBytes(unittest.TestCase):
+    def test_it_reads_like_a_size(self):
+        self.assertEqual(km._human_bytes(512), "512 bytes")
+        self.assertEqual(km._human_bytes(2048), "2.0 KB")
+        self.assertEqual(km._human_bytes(3 * (1 << 20)), "3.0 MB")
+
+    def test_the_text_cap_reads_as_the_round_number_it_means(self):
+        # 2_000_000 divided by 1<<20 read "limit 1.9 MB" — a cap that sounds miscopied. The constant
+        # is a power of two now, so the 413 says "2.0 MB" (the user 2026-08-09).
+        self.assertEqual(km._TEXT_MAX_BYTES, 2 * 1024 * 1024)
+        self.assertEqual(km._human_bytes(km._TEXT_MAX_BYTES), "2.0 MB")
+
+
+class _Route(unittest.TestCase):
+    """/file driven through the real Handler method, with _send captured."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.h = object.__new__(km.Handler)
+        self.sent = []
+        self.h._send = lambda *a, **k: self.sent.append(a)
+
+    def get(self, path, **q):
+        qs = {"path": [path]}
+        qs.update({k: [v] for k, v in q.items()})
+        km.Handler._file_preview(self.h, qs)
+        return self.sent[-1]
+
+    def write(self, name, data):
+        fp = os.path.join(self.tmp, name)
+        with open(fp, "wb") as f:
+            f.write(data if isinstance(data, bytes) else data.encode())
+        return fp
+
+
+class ServeText(_Route):
+    def test_a_source_file_comes_back_as_text_the_browser_can_show(self):
+        fp = self.write("kernel.py", "def hi():\n    return 1\n")
+        status, body, mime = self.get(fp)[:3]
+        self.assertEqual(status, 200)
+        self.assertEqual(body, "def hi():\n    return 1\n")
+        self.assertTrue(mime.startswith("text/plain"), mime)
+        self.assertIn("charset=utf-8", mime)
+
+    def test_html_is_served_as_text_not_as_a_page(self):
+        # the viewer highlights source; serving text/html would make the kernel a hosting origin
+        fp = self.write("page.html", "<b>hi</b>")
+        status, body, mime = self.get(fp)[:3]
+        self.assertEqual(status, 200)
+        self.assertTrue(mime.startswith("text/plain"), mime)
+
+    def test_a_type_we_do_not_serve_still_404s_so_the_client_keeps_its_plain_link(self):
+        fp = self.write("archive.zip", b"PK\x03\x04stuff")
+        self.assertEqual(self.get(fp)[0], 404)
+
+    def test_a_missing_file_404s_naming_the_path_it_tried(self):
+        # a bare "not found" told the user nothing about WHAT was tried — a relative link resolves
+        # against the session's cwd, which is exactly the part they can't see (the user 2026-08-09)
+        fp = os.path.join(self.tmp, "nope.py")
+        status, body = self.get(fp)[:2]
+        self.assertEqual(status, 404)
+        self.assertIn(km._tilde(fp), body)
+
+    def test_a_binary_wearing_a_text_name_is_refused_rather_than_served_as_garbage(self):
+        fp = self.write("weird.log", b"\x00\x01\x02 binary pretending")
+        status, body = self.get(fp)[:2]
+        self.assertEqual(status, 415)
+        self.assertIn("not a text file", body)
+        self.assertIn(km._tilde(fp), body, "every /file error names the resolved path")
+
+    def test_oversize_text_413s_and_the_message_names_the_path_size_and_cap(self):
+        fp = self.write("huge.log", b"x" * (km._TEXT_MAX_BYTES + 1))
+        status, body = self.get(fp)[:2]
+        self.assertEqual(status, 413)
+        self.assertIn("too large", body)
+        self.assertIn(km._tilde(fp), body, "every /file error names the resolved path")
+        self.assertIn("2.0 MB", body, "the cap reads as the round number it means")
+        self.assertIn(km._human_bytes(km._TEXT_MAX_BYTES), body, "say what the limit IS, not just that one exists")
+
+    def test_the_text_cap_is_its_own_and_far_under_the_media_one(self):
+        # a 50 MB log dragged down a tunnel to a phone helps nobody (the user asked for a size cap)
+        self.assertLess(km._TEXT_MAX_BYTES, km._PREVIEW_MAX_BYTES)
+        img = self.write("plot.png", b"\x89PNG\r\n\x1a\n" + b"p" * (km._TEXT_MAX_BYTES + 1))
+        self.assertEqual(self.get(img)[0], 200, "the media cap is untouched by the text one")
+
+    def test_a_relative_path_still_resolves_against_the_session_cwd(self):
+        self.write("rel.md", "# hi\n")
+        with mock.patch.object(km, "_cwd_of", lambda sid: self.tmp):
+            status, body = self.get("rel.md", sid="11111111-2222-3333-4444-555555555555")[:2]
+        self.assertEqual(status, 200)
+        self.assertEqual(body, "# hi\n")
+
+
+class OpenerReportsInsteadOfSwallowing(unittest.TestCase):
+    """_open_file's silent-nothing was the same shape as the Browse… bug, and is fixed the same way."""
+
+    def test_a_headless_machine_has_no_opener(self):
+        with mock.patch.object(km.sys, "platform", "linux"), \
+             mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DISPLAY", None); os.environ.pop("WAYLAND_DISPLAY", None)
+            self.assertIsNone(km._opener_cmd())
+            self.assertFalse(km._open_file("/tmp/x.py"), "no desktop → says no, rather than pretending")
+
+    def test_a_linux_desktop_uses_xdg_open_and_macos_keeps_open(self):
+        with mock.patch.object(km.sys, "platform", "linux"), \
+             mock.patch.object(km.shutil, "which", lambda e: "/usr/bin/" + e), \
+             mock.patch.dict(os.environ, {"DISPLAY": ":0"}, clear=False):
+            self.assertEqual(km._opener_cmd(), "xdg-open")
+        with mock.patch.object(km.sys, "platform", "darwin"):
+            self.assertEqual(km._opener_cmd(), "open")
+
+    def test_the_click_is_answered_when_the_kernel_cannot_serve_it(self):
+        sent = []
+        client = {"app": "chat", "alive": True, "send": lambda s: sent.append(json.loads(s))}
+        with mock.patch.object(km, "_open_file", lambda *a, **k: False):
+            km.Handler._dispatch_ws(object.__new__(km.Handler),
+                                    {"type": "openFile", "path": "/tmp/notes.md"}, client)
+        self.assertTrue(sent, "silence is the bug")
+        self.assertEqual(sent[-1]["type"], "warn")
+        self.assertIn("notes.md", sent[-1]["text"])
+        self.assertIn("no desktop session", sent[-1]["text"])
+
+    def test_a_kernel_that_can_open_it_says_nothing(self):
+        sent = []
+        client = {"app": "chat", "alive": True, "send": lambda s: sent.append(json.loads(s))}
+        with mock.patch.object(km, "_open_file", lambda *a, **k: True):
+            km.Handler._dispatch_ws(object.__new__(km.Handler),
+                                    {"type": "openFile", "path": "/tmp/notes.md"}, client)
+        self.assertEqual(sent, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_file_view.py
+++ b/tests/test_file_view.py
@@ -111,9 +111,14 @@ class ServeText(_Route):
         self.assertEqual(status, 200)
         self.assertTrue(mime.startswith("text/plain"), mime)
 
-    def test_a_type_we_do_not_serve_still_404s_so_the_client_keeps_its_plain_link(self):
+    def test_a_type_we_do_not_view_415s_naming_the_path_so_the_client_can_offer_the_download(self):
+        # was a 404, indistinguishable from "no such file" — but the truths differ and the client acts
+        # on the difference: 404 means give up, 415 means offer ?download=1 (the user 2026-08-09)
         fp = self.write("archive.zip", b"PK\x03\x04stuff")
-        self.assertEqual(self.get(fp)[0], 404)
+        status, body = self.get(fp)[:2]
+        self.assertEqual(status, 415)
+        self.assertIn("not viewable in the browser", body)
+        self.assertIn(km._tilde(fp), body, "every /file error names the resolved path")
 
     def test_a_missing_file_404s_naming_the_path_it_tried(self):
         # a bare "not found" told the user nothing about WHAT was tried — a relative link resolves

--- a/tests/test_kernel_preview.py
+++ b/tests/test_kernel_preview.py
@@ -50,6 +50,11 @@ class FilePreviewEndpoint(unittest.TestCase):
         cls.txt = os.path.join(cls.tmp.name, "notes.txt")
         with open(cls.txt, "w") as f:
             f.write("not renderable")
+        # …and something served NEITHER as media nor as text, which is what "off the allowlist" means
+        # now that source/text is ON it (2026-08-08 — see tests/test_file_view.py)
+        cls.bin = os.path.join(cls.tmp.name, "archive.zip")
+        with open(cls.bin, "wb") as f:
+            f.write(b"PK\x03\x04not renderable, not text")
 
     @classmethod
     def tearDownClass(cls):
@@ -75,10 +80,18 @@ class FilePreviewEndpoint(unittest.TestCase):
         code, _, _ = self._req("/file?path=" + urllib.parse.quote(os.path.join(self.tmp.name, "gone.png")))
         self.assertEqual(code, 404)
 
-    def test_non_renderable_extension_404s(self):
-        # the allowlist is RENDERABLE media only — a .txt (or anything else) never leaves the machine
-        code, _, _ = self._req("/file?path=" + urllib.parse.quote(self.txt))
+    def test_an_extension_on_neither_allowlist_404s(self):
+        # the allowlist is renderable media PLUS source/text; a .zip is neither and never leaves the box
+        code, _, _ = self._req("/file?path=" + urllib.parse.quote(self.bin))
         self.assertEqual(code, 404)
+
+    def test_text_is_served_so_a_remote_dashboard_can_actually_show_it(self):
+        # widened 2026-08-08: a file link is only followable if the bytes reach the browser, since the
+        # kernel-side opener draws on the kernel's screen — the wrong machine when you are remote
+        code, hdrs, body = self._req("/file?path=" + urllib.parse.quote(self.txt))
+        self.assertEqual(code, 200)
+        self.assertTrue(hdrs.get("Content-Type", "").startswith("text/plain"), hdrs.get("Content-Type"))
+        self.assertEqual(body, b"not renderable")
 
     def test_relative_path_without_sid_404s(self):
         # unresolvable relative path (no session cwd) must not fall back to the kernel's own cwd
@@ -100,7 +113,7 @@ class FilePreviewEndpoint(unittest.TestCase):
         self.assertEqual(code, 200)
         self.assertEqual(hdrs.get("Content-Length"), str(len(PNG)))
         self.assertEqual(body, b"")
-        code, _, _ = self._req("/file?path=" + urllib.parse.quote(self.txt), method="HEAD")
+        code, _, _ = self._req("/file?path=" + urllib.parse.quote(self.bin), method="HEAD")
         self.assertEqual(code, 404)
 
 

--- a/tests/test_kernel_preview.py
+++ b/tests/test_kernel_preview.py
@@ -9,6 +9,7 @@ import os
 import tempfile
 import threading
 import unittest
+from unittest import mock
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -80,10 +81,12 @@ class FilePreviewEndpoint(unittest.TestCase):
         code, _, _ = self._req("/file?path=" + urllib.parse.quote(os.path.join(self.tmp.name, "gone.png")))
         self.assertEqual(code, 404)
 
-    def test_an_extension_on_neither_allowlist_404s(self):
-        # the allowlist is renderable media PLUS source/text; a .zip is neither and never leaves the box
+    def test_an_extension_on_neither_allowlist_415s_as_exists_but_unviewable(self):
+        # the VIEW allowlist is renderable media PLUS source/text; a .zip is neither — but it EXISTS,
+        # which is a different truth from 404's "no such file", and the client acts on the difference
+        # (415 → offer the ?download=1 the route serves; 404 → nothing to offer). The user 2026-08-09.
         code, _, _ = self._req("/file?path=" + urllib.parse.quote(self.bin))
-        self.assertEqual(code, 404)
+        self.assertEqual(code, 415)
 
     def test_text_is_served_so_a_remote_dashboard_can_actually_show_it(self):
         # widened 2026-08-08: a file link is only followable if the bytes reach the browser, since the
@@ -114,7 +117,167 @@ class FilePreviewEndpoint(unittest.TestCase):
         self.assertEqual(hdrs.get("Content-Length"), str(len(PNG)))
         self.assertEqual(body, b"")
         code, _, _ = self._req("/file?path=" + urllib.parse.quote(self.bin), method="HEAD")
+        self.assertEqual(code, 415, "HEAD carries the same exists-but-unviewable verdict as GET")
+
+
+class FileDownloadEndpoint(unittest.TestCase):
+    """/file?download=1 (the user 2026-08-09): anything on disk is downloadable — the view allowlists
+    are a rendering choice, not a security boundary (the OS still guards execution, and the dashboard's
+    owner can already read any file through an agent). Served as an attachment the browser saves, never
+    interprets, and STREAMED so a multi-GB file cannot OOM the kernel that self-hosts the sessions."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+        cls.tmp = tempfile.TemporaryDirectory()
+        # NUL bytes up front: off both view allowlists AND would fail the text sniff — the exact
+        # kind of file the download path exists for
+        cls.blob = os.path.join(cls.tmp.name, "model.bin")
+        cls.blob_bytes = b"\x00\x7fELF binary-ish payload\x00" * 40
+        with open(cls.blob, "wb") as f:
+            f.write(cls.blob_bytes)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.tmp.cleanup()
+
+    def _req(self, path, method="GET"):
+        url = "http://127.0.0.1:%d%s%stoken=%s" % (self.port, path, "&" if "?" in path else "?", TOKEN)
+        req = urllib.request.Request(url, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, dict(r.headers), r.read()
+        except urllib.error.HTTPError as e:
+            return e.code, dict(e.headers), e.read()
+
+    def test_an_off_allowlist_binary_downloads_as_an_attachment(self):
+        code, hdrs, body = self._req("/file?path=" + urllib.parse.quote(self.blob) + "&download=1")
+        self.assertEqual(code, 200)
+        self.assertEqual(body, self.blob_bytes)
+        self.assertEqual(hdrs.get("Content-Type"), "application/octet-stream")
+        self.assertEqual(hdrs.get("Content-Disposition"), 'attachment; filename="model.bin"')
+        self.assertEqual(hdrs.get("Content-Length"), str(len(self.blob_bytes)))
+        self.assertEqual(hdrs.get("X-Content-Type-Options"), "nosniff")
+
+    def test_the_view_path_is_unchanged_without_the_param(self):
+        # same file, no download=1 → the exists-but-unviewable 415, exactly as before this route
+        code, _, _ = self._req("/file?path=" + urllib.parse.quote(self.blob))
+        self.assertEqual(code, 415)
+
+    def test_a_missing_file_still_404s_naming_the_path(self):
+        gone = os.path.join(self.tmp.name, "gone.bin")
+        code, _, body = self._req("/file?path=" + urllib.parse.quote(gone) + "&download=1")
         self.assertEqual(code, 404)
+        self.assertIn(km._tilde(gone).encode(), body, "every /file error names the resolved path")
+
+    def test_the_text_cap_gates_the_view_but_not_the_download(self):
+        big = os.path.join(self.tmp.name, "huge.log")
+        data = b"x" * (km._TEXT_MAX_BYTES + 1)
+        with open(big, "wb") as f:
+            f.write(data)
+        code, _, _ = self._req("/file?path=" + urllib.parse.quote(big))
+        self.assertEqual(code, 413, "the VIEW keeps its cap")
+        code, hdrs, body = self._req("/file?path=" + urllib.parse.quote(big) + "&download=1")
+        self.assertEqual(code, 200, "the download has none")
+        self.assertEqual(len(body), len(data))
+        self.assertEqual(hdrs.get("Content-Length"), str(len(data)))
+
+    def test_head_reports_the_attachment_without_the_bytes(self):
+        code, hdrs, body = self._req("/file?path=" + urllib.parse.quote(self.blob) + "&download=1",
+                                     method="HEAD")
+        self.assertEqual(code, 200)
+        self.assertEqual(body, b"")
+        self.assertEqual(hdrs.get("Content-Disposition"), 'attachment; filename="model.bin"')
+        self.assertEqual(hdrs.get("Content-Length"), str(len(self.blob_bytes)))
+
+
+class _StreamSink:
+    def __init__(self, sink):
+        self.sink = sink
+
+    def write(self, b):
+        self.sink.append(bytes(b))
+
+
+class _DownloadRecorder:
+    """Just enough Handler surface for a direct _file_download call: records every wfile.write, so the
+    test can see the CHUNKING itself — the over-HTTP tests above only see the reassembled body."""
+
+    def __init__(self):
+        self.writes, self.headers, self.status = [], {}, None
+        self.close_connection = False
+        self.wfile = _StreamSink(self.writes)
+
+    def send_response(self, code):
+        self.status = code
+
+    def send_header(self, k, v):
+        self.headers[k] = v
+
+    def end_headers(self):
+        pass
+
+    _send = km.Handler._send      # the 404 path routes through the real _send, captured by the fakes
+
+
+class DownloadStreams(unittest.TestCase):
+    """The body is streamed in fixed chunks, never slurped. _send reads whole files into memory, and a
+    multi-GB download through it would OOM the kernel — which self-hosts the very sessions using it.
+    This pins the chunked WRITES, not just the reassembled bytes."""
+
+    def test_the_body_arrives_as_bounded_chunks_never_one_slurp(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fp = os.path.join(tmp, "big.dat")
+            data = bytes(range(256)) * ((3 * km._DOWNLOAD_CHUNK) // 256) + b"tail"
+            with open(fp, "wb") as f:
+                f.write(data)
+            rec = _DownloadRecorder()
+            km.Handler._file_download(rec, fp)
+        self.assertEqual(rec.status, 200)
+        self.assertGreater(len(rec.writes), 1, "one write means the file was slurped")
+        self.assertTrue(all(len(w) <= km._DOWNLOAD_CHUNK for w in rec.writes),
+                        "every write is bounded by the chunk size, whatever the file size")
+        self.assertEqual(b"".join(rec.writes), data, "…and the chunks reassemble to the exact file")
+        self.assertEqual(rec.headers.get("Content-Length"), str(len(data)))
+
+    def test_a_file_truncated_mid_stream_closes_rather_than_hanging(self):
+        # the promised Content-Length can no longer be honored → close, a visibly failed download
+        rec = _DownloadRecorder()
+        with tempfile.TemporaryDirectory() as tmp:
+            fp = os.path.join(tmp, "shrinks.dat")
+            with open(fp, "wb") as f:
+                f.write(b"x" * 64)
+            real_getsize = os.path.getsize
+            with mock.patch.object(km.os.path, "getsize", lambda p: real_getsize(p) + 1000):
+                km.Handler._file_download(rec, fp)
+        self.assertTrue(rec.close_connection, "short bytes must close the connection, not hang it")
+
+
+class AttachmentDisposition(unittest.TestCase):
+    """The basename lands inside a header's quoted-string, so header-hostile characters are replaced;
+    a mangled name also rides the RFC 5987 filename* form so capable browsers save the real one."""
+
+    def test_a_plain_name_passes_through(self):
+        self.assertEqual(km._attachment_disposition("model.bin"), 'attachment; filename="model.bin"')
+
+    def test_header_hostile_characters_cannot_escape_the_quoted_string(self):
+        d = km._attachment_disposition('a"b\\c\r\nSet-Cookie: x=y.bin')
+        header_value = d.split("filename=")[1]
+        self.assertNotIn("\r", d)
+        self.assertNotIn("\n", d)
+        self.assertNotIn('"', header_value[1:].split('"')[0], "no quote survives inside the quotes")
+        self.assertIn('filename="a_b_c__Set-Cookie: x=y.bin"', d)
+
+    def test_a_non_ascii_name_keeps_its_real_form_in_filename_star(self):
+        d = km._attachment_disposition("données.csv")
+        self.assertIn('filename="donn_es.csv"', d, "the ASCII fallback is mangled but present")
+        self.assertIn("filename*=UTF-8''donn%C3%A9es.csv", d, "the real name rides RFC 5987")
+
+    def test_an_empty_name_still_yields_a_usable_filename(self):
+        self.assertIn('filename="download"', km._attachment_disposition(""))
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_remote_file_relay.py
+++ b/tests/test_kernel_remote_file_relay.py
@@ -41,17 +41,37 @@ km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_modu
 REMOTE_TOKEN = "remote-token-DO-NOT-USE"
 PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-png-bytes"
 PY_BYTES = b"print('hello from the remote box')\n"
+# the download fixture: NUL-ridden, off every view allowlist, and BIGGER than one relay stream chunk,
+# so the pass-through provably crosses a chunk boundary intact
+BIN_BYTES = bytes(range(256)) * ((km._DOWNLOAD_CHUNK // 256) + 60)
 
 
 class _FakeRemoteFileHandler(BaseHTTPRequestHandler):
     """The attached host's kernel behind the ssh -L port, /file route only: serves PNG_BYTES for
-    path=/tmp/plot.png and PY_BYTES for path=/tmp/app.py (recording the request lines), 404s
-    anything else."""
+    path=/tmp/plot.png and BIN_BYTES for path=/tmp/data.bin&download=1 (recording the request
+    lines), 404s anything else."""
     requests = []               # class-level: the recorded request lines
     ctype = "image/png"         # what this remote CLAIMS the bytes are (a hostile one lies)
+    dl_ctype = "application/octet-stream"          # …and the download-side claims (a hostile one lies)
+    dl_disp = 'attachment; filename="data.bin"'
+    dl_truncate = False         # short body then a clean close, as _file_download sends when the file shrank
 
     def _serve(self, head):
         _FakeRemoteFileHandler.requests.append(self.path)
+        if "download=1" in self.path and "data.bin" in self.path:
+            self.send_response(200)
+            self.send_header("Content-Type", _FakeRemoteFileHandler.dl_ctype)
+            self.send_header("Content-Disposition", _FakeRemoteFileHandler.dl_disp)
+            self.send_header("Content-Length", str(len(BIN_BYTES)))
+            self.end_headers()
+            if not head:
+                if _FakeRemoteFileHandler.dl_truncate:
+                    # the remote kernel's own truncation path: a short body, then a clean close
+                    self.wfile.write(BIN_BYTES[: len(BIN_BYTES) // 2])
+                    self.close_connection = True
+                else:
+                    self.wfile.write(BIN_BYTES)
+            return
         if "app.py" in self.path:
             self.send_response(200)
             self.send_header("Content-Type", _FakeRemoteFileHandler.ctype)
@@ -61,10 +81,13 @@ class _FakeRemoteFileHandler(BaseHTTPRequestHandler):
                 self.wfile.write(PY_BYTES)
             return
         if "plot.png" not in self.path:
+            body = b"not found: /tmp/gone" if "download=1" in self.path else b""
             self.send_response(404)
             self.send_header("Content-Type", "text/plain")
-            self.send_header("Content-Length", "0")
+            self.send_header("Content-Length", str(len(body)))
             self.end_headers()
+            if not head:
+                self.wfile.write(body)
             return
         self.send_response(200)
         self.send_header("Content-Type", _FakeRemoteFileHandler.ctype)
@@ -83,6 +106,36 @@ class _FakeRemoteFileHandler(BaseHTTPRequestHandler):
         pass
 
 
+class _RecorderSink:
+    def __init__(self, sink):
+        self.sink = sink
+
+    def write(self, b):
+        self.sink.append(bytes(b))
+
+
+class _RelayRecorder:
+    """Just enough Handler surface for a direct _relay_download call: records status, headers and
+    every wfile.write, and starts with close_connection False — so a test can see the one thing an
+    over-HTTP client cannot: whether the relay itself decided to close the connection."""
+
+    def __init__(self):
+        self.writes, self.headers, self.status = [], {}, None
+        self.close_connection = False
+        self.wfile = _RecorderSink(self.writes)
+
+    def send_response(self, code):
+        self.status = code
+
+    def send_header(self, k, v):
+        self.headers[k] = v
+
+    def end_headers(self):
+        pass
+
+    _send = km.Handler._send      # the error paths route through the real _send, captured by the fakes
+
+
 class RemoteFileRelay(unittest.TestCase):
     def setUp(self):
         self.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
@@ -92,6 +145,9 @@ class RemoteFileRelay(unittest.TestCase):
         threading.Thread(target=self.fake.serve_forever, daemon=True).start()
         _FakeRemoteFileHandler.requests = []
         _FakeRemoteFileHandler.ctype = "image/png"
+        _FakeRemoteFileHandler.dl_ctype = "application/octet-stream"
+        _FakeRemoteFileHandler.dl_disp = 'attachment; filename="data.bin"'
+        _FakeRemoteFileHandler.dl_truncate = False
         self._saved_remotes = dict(km._remotes)
 
     def tearDown(self):
@@ -155,7 +211,10 @@ class RemoteFileRelay(unittest.TestCase):
         """The text half of /file relays too — this gate predated it, so a remote session's
         .py/.md 404'd here while the LOCAL route served the same file (the viewer just failed
         on every federated text file). The defense is unchanged and now covers text: the type
-        is OURS — a lying remote's text/html arrives as inert text/plain + nosniff."""
+        is OURS — a lying remote's text/html arrives as inert text/plain + nosniff. (.html is
+        on _TEXT_EXT, so it too relays as text/plain now — same inertness, matching the local
+        route; the never-asked decline for off-every-allowlist extensions is pinned by the
+        .bin test below.)"""
         self._register("gpu1", self.fake.server_address[1])
         _FakeRemoteFileHandler.ctype = "text/html"
         status, body, headers = self._get("/remote/gpu1/file?path=%2Ftmp%2Fapp.py")
@@ -175,6 +234,89 @@ class RemoteFileRelay(unittest.TestCase):
         self.assertEqual(status, 403, "the local auth gate must run before the relay")
         self.assertEqual(_FakeRemoteFileHandler.requests, [],
                          "an unauthorized request must never touch the tunnel")
+
+    # ── the download half (the user 2026-08-09): /remote/<host>/file?download=1 relays ANY file the
+    # remote will serve, streamed through, with the attachment headers derived on THIS side ──
+
+    def test_download_relays_any_extension_and_the_disposition_survives(self):
+        self._register("gpu1", self.fake.server_address[1])
+        status, body, headers = self._get(
+            "/remote/gpu1/file?path=%2Ftmp%2Fdata.bin&download=1&token=whatever-the-browser-sent")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, BIN_BYTES,
+                         "bigger than one stream chunk, so the pass-through crossed a boundary intact")
+        self.assertEqual(headers.get("Content-Disposition"), 'attachment; filename="data.bin"')
+        self.assertEqual(headers.get("Content-Type"), "application/octet-stream")
+        self.assertEqual(headers.get("Content-Length"), str(len(BIN_BYTES)))
+        self.assertEqual(headers.get("X-Content-Type-Options"), "nosniff")
+        # forwarded intact: download=1 rides through, the REMOTE's token replaces the browser's
+        (req,) = _FakeRemoteFileHandler.requests
+        self.assertIn("download=1", req)
+        self.assertIn("token=" + REMOTE_TOKEN, req)
+        self.assertNotIn("whatever-the-browser-sent", req)
+
+    def test_download_headers_are_derived_locally_never_mirrored_from_the_remote(self):
+        # the lying-remote rule, download edition: an attached host serves its own bytes but never
+        # chooses how this browser handles them — a hostile Content-Type/Disposition is discarded
+        self._register("gpu1", self.fake.server_address[1])
+        _FakeRemoteFileHandler.dl_ctype = "text/html"
+        _FakeRemoteFileHandler.dl_disp = "inline"
+        status, body, headers = self._get("/remote/gpu1/file?path=%2Ftmp%2Fdata.bin&download=1")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, BIN_BYTES)
+        self.assertEqual(headers.get("Content-Type"), "application/octet-stream")
+        self.assertEqual(headers.get("Content-Disposition"), 'attachment; filename="data.bin"')
+
+    def test_the_view_relay_still_declines_that_same_extension(self):
+        # without download=1 nothing changed: a .bin is off _PREVIEW_MIME, 404'd HERE, remote unasked
+        self._register("gpu1", self.fake.server_address[1])
+        status, _, _ = self._get("/remote/gpu1/file?path=%2Ftmp%2Fdata.bin")
+        self.assertEqual(status, 404)
+        self.assertEqual(_FakeRemoteFileHandler.requests, [])
+
+    def test_a_remote_download_404_passes_through(self):
+        self._register("gpu1", self.fake.server_address[1])
+        status, body, _ = self._get("/remote/gpu1/file?path=%2Ftmp%2Fgone.bin&download=1")
+        self.assertEqual(status, 404)
+        self.assertIn(b"not found", body, "the remote's own verdict, which names the path IT resolved")
+
+    def test_head_download_relays_the_attachment_without_a_body(self):
+        self._register("gpu1", self.fake.server_address[1])
+        status, body, headers = self._get("/remote/gpu1/file?path=%2Ftmp%2Fdata.bin&download=1",
+                                          method="HEAD")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b"")
+        self.assertEqual(headers.get("Content-Disposition"), 'attachment; filename="data.bin"')
+        self.assertEqual(headers.get("Content-Length"), str(len(BIN_BYTES)))
+
+    def test_a_remote_that_truncates_cleanly_still_closes_this_connection_short(self):
+        """The remote's own _file_download truncation path sends SHORT and then closes cleanly — on
+        this side http.client's read() answers that with b'' and NO exception, so only counting the
+        copied bytes against the Content-Length already forwarded can spot the broken promise.
+        Without the close, this keep-alive (HTTP/1.1) connection leaves the browser waiting on
+        bytes that will never come — a hung download instead of a visibly failed one. Pinned by a
+        direct _relay_download call: over HTTP a test client's own Connection: close (urllib sends
+        it always) would close the connection for the wrong reason and hide exactly this bug."""
+        _FakeRemoteFileHandler.dl_truncate = True
+        rec = _RelayRecorder()
+        km.Handler._relay_download(rec, "gpu1", self.fake.server_address[1], REMOTE_TOKEN,
+                                   {"path": ["/tmp/data.bin"], "download": ["1"]})
+        self.assertEqual(rec.status, 200)
+        self.assertEqual(rec.headers.get("Content-Length"), str(len(BIN_BYTES)),
+                         "the remote's promised length went out before the truncation")
+        self.assertEqual(b"".join(rec.writes), BIN_BYTES[: len(BIN_BYTES) // 2],
+                         "the bytes that did arrive still pass through")
+        self.assertTrue(rec.close_connection,
+                        "short of the forwarded Content-Length must CLOSE, or the browser hangs")
+
+    def test_a_dead_tunnel_502s_the_download_too(self):
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.bind(("127.0.0.1", 0))
+        dead_port = probe.getsockname()[1]
+        probe.close()
+        self._register("gpu1", dead_port)
+        status, _, _ = self._get("/remote/gpu1/file?path=%2Ftmp%2Fdata.bin&download=1")
+        self.assertEqual(status, 502)
 
     def test_dead_tunnel_502s(self):
         # a registered host whose forwarded port has no listener (the ssh died mid-flight)

--- a/tests/test_kernel_remote_file_relay.py
+++ b/tests/test_kernel_remote_file_relay.py
@@ -40,15 +40,26 @@ km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_modu
 
 REMOTE_TOKEN = "remote-token-DO-NOT-USE"
 PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-png-bytes"
+PY_BYTES = b"print('hello from the remote box')\n"
 
 
 class _FakeRemoteFileHandler(BaseHTTPRequestHandler):
     """The attached host's kernel behind the ssh -L port, /file route only: serves PNG_BYTES for
-    path=/tmp/plot.png (recording the request line), 404s anything else."""
+    path=/tmp/plot.png and PY_BYTES for path=/tmp/app.py (recording the request lines), 404s
+    anything else."""
     requests = []               # class-level: the recorded request lines
+    ctype = "image/png"         # what this remote CLAIMS the bytes are (a hostile one lies)
 
     def _serve(self, head):
         _FakeRemoteFileHandler.requests.append(self.path)
+        if "app.py" in self.path:
+            self.send_response(200)
+            self.send_header("Content-Type", _FakeRemoteFileHandler.ctype)
+            self.send_header("Content-Length", str(len(PY_BYTES)))
+            self.end_headers()
+            if not head:
+                self.wfile.write(PY_BYTES)
+            return
         if "plot.png" not in self.path:
             self.send_response(404)
             self.send_header("Content-Type", "text/plain")
@@ -56,7 +67,7 @@ class _FakeRemoteFileHandler(BaseHTTPRequestHandler):
             self.end_headers()
             return
         self.send_response(200)
-        self.send_header("Content-Type", "image/png")
+        self.send_header("Content-Type", _FakeRemoteFileHandler.ctype)
         self.send_header("Content-Length", str(len(PNG_BYTES)))
         self.end_headers()
         if not head:
@@ -80,6 +91,7 @@ class RemoteFileRelay(unittest.TestCase):
         self.fake = ThreadingHTTPServer(("127.0.0.1", 0), _FakeRemoteFileHandler)
         threading.Thread(target=self.fake.serve_forever, daemon=True).start()
         _FakeRemoteFileHandler.requests = []
+        _FakeRemoteFileHandler.ctype = "image/png"
         self._saved_remotes = dict(km._remotes)
 
     def tearDown(self):
@@ -138,6 +150,19 @@ class RemoteFileRelay(unittest.TestCase):
         self._register("gpu1", self.fake.server_address[1])
         status, _, _ = self._get("/remote/gpu1/file?path=%2Ftmp%2Fgone.png")
         self.assertEqual(status, 404)
+
+    def test_text_relays_with_a_locally_derived_type_the_remote_cannot_override(self):
+        """The text half of /file relays too — this gate predated it, so a remote session's
+        .py/.md 404'd here while the LOCAL route served the same file (the viewer just failed
+        on every federated text file). The defense is unchanged and now covers text: the type
+        is OURS — a lying remote's text/html arrives as inert text/plain + nosniff."""
+        self._register("gpu1", self.fake.server_address[1])
+        _FakeRemoteFileHandler.ctype = "text/html"
+        status, body, headers = self._get("/remote/gpu1/file?path=%2Ftmp%2Fapp.py")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, PY_BYTES)
+        self.assertEqual(headers.get("Content-Type"), "text/plain; charset=utf-8")
+        self.assertNotIn("html", (headers.get("Content-Type") or "").lower())
 
     def test_unknown_host_404s(self):
         status, _, _ = self._get("/remote/nosuch/file?path=%2Ftmp%2Fplot.png")

--- a/ui/webview/chat-path-links.test.ts
+++ b/ui/webview/chat-path-links.test.ts
@@ -16,6 +16,7 @@ import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const VIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "file-view.ts"), "utf8");
 
 test("the chat event carries the kernel's pathLinks verdict on user and assistant turns", () => {
   assert.match(RENDER, /kind: "user";[^\n]*pathLinks\?: Record<string, string>/);
@@ -58,6 +59,14 @@ test("the kernel resolves in three tiers over the session repo's real file list"
   // one repo listing per build pass, built lazily, never keyed on .git/index mtime
   assert.ok(KERNEL.includes("_pl_memo = {}"), "per-build memo");
   assert.ok(KERNEL.includes("_REPO_LIST_MAX"), "a runaway listing skips tiers 2/3");
+});
+
+test("the /file error bodies name the resolved path, and the viewer doesn't repeat it", () => {
+  assert.ok(KERNEL.includes('"not found: %s" % _tilde(fp)'));
+  assert.ok(KERNEL.includes('"too large to show: %s (%s, limit %s)"'));
+  assert.ok(KERNEL.includes('"not a text file: %s" % _tilde(fp)'));
+  // the viewer's hint line exists for errors that DON'T name the path (network, old kernel)
+  assert.match(VIEW, /if \(!msg\.includes\(path\)\) \{/);
 });
 
 // executed: the Python tokenizer (_path_tokens) and CLICKABLE_PATH_RE must agree on what a token IS —

--- a/ui/webview/chat-relpath-link.test.ts
+++ b/ui/webview/chat-relpath-link.test.ts
@@ -22,10 +22,11 @@ test("the linkifier matches file:// URIs AND bare paths, and gates each token ki
   assert.match(RENDER, /frag\.appendChild\(isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\)\);/);
 });
 
-test("a relative path click carries the active session id so the kernel resolves against its cwd", () => {
+test("a relative path click carries the active session id so whoever resolves it uses that cwd", () => {
   assert.match(RENDER, /function openPathLink\(raw: string, open: string, relative = false\)/);
-  assert.match(RENDER, /\{ type: "openFile", path: open, id: activeId \}/);   // relative → send the session id
-  assert.match(RENDER, /\{ type: "openFile", path: open \}/);                 // absolute/file:// → no id needed
+  // relative → send the session id; absolute/file:// → none needed. Both go through openPath, which
+  // picks the host (VS Code editor vs the feed pane's viewer) — see the openPath test below.
+  assert.match(RENDER, /openPath\(open, relative \? activeId : null\);/);
 });
 
 test("the cheap pre-filter keys on a slash — or, inside inline code, a dot", () => {

--- a/ui/webview/composer-files.test.ts
+++ b/ui/webview/composer-files.test.ts
@@ -56,8 +56,9 @@ test("an image thumbnail renders per surface; other files wear an ext + name chi
   // non-image: extension badge + basename, both TEXT (no glyphs)
   assert.match(RENDER, /ext\.textContent = \(dot > 0 \? p\.slice\(dot \+ 1\) : "file"\)\.slice\(0, 5\)\.toUpperCase\(\);/);
   assert.match(RENDER, /nm\.textContent = p\.split\("\/"\)\.pop\(\) \|\| p;/);
-  // click opens the file; the ✕ removes exactly that attachment
-  assert.match(fn, /vscodeApi\?\.postMessage\(\{ type: "openFile", path: p, id: id \|\| undefined \}\);/);
+  // click opens the file — routed by openPath (VS Code editor / the feed pane's viewer on the web);
+  // the ✕ removes exactly that attachment
+  assert.match(fn, /openPath\(p, id \|\| null\);/);
   assert.match(fn, /if \(id\) removeComposerFile\(id, i\);/);
   // the same file dropped twice attaches once
   assert.match(RENDER, /if \(!list\.includes\(path\)\) list\.push\(path\);/);

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1066,6 +1066,9 @@ body.fileview-open { overflow: hidden; }
 .fileview-err { padding: 18px 14px; font-size: 0.86em; color: #e0a030; }
 .fileview-err-hint { margin-top: 6px; color: var(--dim); font-size: 0.92em;
   font-family: var(--mono, ui-monospace, monospace); word-break: break-all; }
+/* the way out of a refusal: when the file exists but cannot render (413/415), the kernel's words are
+   followed by the Download the view could not be — same button treatment as the title bar's */
+.fileview-err-dl { display: block; margin-top: 10px; }
 /* the romp loader, per the loading-state rule: swirl + wordmark + three pulsing accent dots */
 .fileview-load { display: flex; align-items: center; justify-content: center; gap: 7px;
   padding: 30px 0; color: var(--dim); font-size: 0.86em; }

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1026,6 +1026,137 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   background: rgba(0, 0, 0, 0.25); border: 1px solid rgba(255, 255, 255, 0.08);
   white-space: pre-wrap; overflow-wrap: anywhere; max-height: 300px; overflow-y: auto; }
 
+/* ── file viewer (file-view.ts) ────────────────────────────────────────────────────────────────────
+   A file path clicked in the CHAT shows the file HERE, filling the feed pane (the user 2026-08-08).
+   Absolute over this document rather than a floating modal: the cards behind it are what you are least
+   likely to be mid-read on when you follow a path out of a transcript, and a whole pane is what long
+   source needs. `body.fileview-open` stops the cards underneath scrolling behind it. */
+.fileview { position: fixed; inset: 0; z-index: 900; display: flex; flex-direction: column;
+  background: var(--bg, #1e1e1e); }
+body.fileview-open { overflow: hidden; }
+.fileview-bar { flex: 0 0 auto; display: flex; align-items: center; gap: 10px; min-width: 0;
+  padding: 7px 10px; border-bottom: 1px solid var(--box-border); }
+/* Only the DIRECTORY may be truncated: the filename identifies the file, so it holds its width however
+   deep the path is, and the dimmed directory in front of it gives up room first. */
+.fileview-name { flex: 1 1 auto; min-width: 0; font-size: 0.86em; color: var(--fg);
+  display: flex; align-items: baseline; white-space: nowrap; }
+.fileview-dir { flex: 0 1 auto; min-width: 0; color: var(--dim);
+  overflow: hidden; text-overflow: ellipsis; }
+.fileview-base { flex: 0 0 auto; }
+.fileview-acts { flex: 0 0 auto; display: flex; align-items: center; gap: 6px; }
+.fileview-btn { font: inherit; font-size: 0.82em; cursor: pointer; flex: 0 0 auto;
+  padding: 3px 9px; border-radius: 6px; background: rgba(255, 255, 255, 0.08); color: var(--fg);
+  border: 1px solid var(--box-border); }
+.fileview-btn:hover { border-color: var(--accent); }
+.fileview-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
+/* gutter + code as two columns of ONE scroller: the numbers stay put horizontally against long lines,
+   and because they are a sibling element a selection of the code copies without dragging them along */
+.fileview-code { display: flex; align-items: flex-start; min-height: 100%; }
+.fileview-gutter { flex: 0 0 auto; position: sticky; left: 0; z-index: 1;
+  padding: 10px 8px 10px 10px; text-align: right; user-select: none;
+  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  color: var(--dim); opacity: 0.55; background: var(--bg, #1e1e1e);
+  border-right: 1px solid var(--box-border); white-space: pre; }
+.fileview-pre { flex: 1 1 auto; margin: 0; padding: 10px 12px;
+  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  white-space: pre; tab-size: 4; }
+.fileview-pre code { background: none; padding: 0; font: inherit; }
+/* a refusal explains itself in place, in the kernel's own words (too large — with the size and the
+   cap; not a text file; not found) over the path it was asked for. Never a blank pane. */
+.fileview-err { padding: 18px 14px; font-size: 0.86em; color: #e0a030; }
+.fileview-err-hint { margin-top: 6px; color: var(--dim); font-size: 0.92em;
+  font-family: var(--mono, ui-monospace, monospace); word-break: break-all; }
+/* the romp loader, per the loading-state rule: swirl + wordmark + three pulsing accent dots */
+.fileview-load { display: flex; align-items: center; justify-content: center; gap: 7px;
+  padding: 30px 0; color: var(--dim); font-size: 0.86em; }
+.fileview-load img { width: 17px; height: 17px; animation: fileview-spin 1.6s linear infinite reverse; }
+.fileview-dot { width: 4px; height: 4px; border-radius: 50%; background: var(--accent);
+  animation: fileview-pulse 1.1s ease-in-out infinite; }
+.fileview-dot:nth-of-type(2) { animation-delay: 0.18s; }
+.fileview-dot:nth-of-type(3) { animation-delay: 0.36s; }
+@keyframes fileview-spin { to { transform: rotate(360deg); } }
+@keyframes fileview-pulse { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
+
+/* A pressed viewer toggle (Rendered/Raw, Wrap) wears the app-wide selected language — accent text +
+   border + faint wash, gray = off (the .fask-secbtn.on / .feed-modetoggle.on treatment) — with the same
+   reverse-highlight hover so a selected toggle never reads as dead. */
+.fileview-btn.on { color: var(--accent); border-color: var(--accent);
+  background: rgba(156, 210, 255, 0.10); font-weight: 600; }
+.fileview-btn.on:hover { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+
+/* Wrap mode (the Wrap toggle, persisted per browser): long lines soft-wrap instead of scrolling
+   sideways. The flat sibling gutter cannot survive that — one logical line becomes several visual lines
+   and every number below it drifts — so wrap mode restructures: each logical line is a flex row (.fv-cl)
+   numbered by a CSS counter in its ::before (the chat's .cl/.ct treatment in styles.css). The number is
+   ::before content and user-select: none, so a selection still copies clean, same as the gutter it
+   replaces. */
+.fileview-pre.fileview-wrap { white-space: pre-wrap; overflow-wrap: anywhere;
+  counter-reset: fvln; padding-left: 0; }
+.fileview-wrap .fv-cl { display: flex; align-items: baseline; }
+.fileview-wrap .fv-cl::before {
+  counter-increment: fvln; content: counter(fvln);
+  flex: 0 0 3.5em; padding-right: 10px; text-align: right;
+  color: var(--dim); opacity: 0.55; user-select: none;
+}
+.fileview-wrap .fv-ct { flex: 1 1 auto; min-width: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+
+/* Rendered markdown (the Raw ⇄ Rendered toggle; Rendered is the default — the user 2026-08-09).
+   Typography mirrors the chat's .md block in styles.css, the reference aesthetic (one treatment, two
+   sheets — the .romp-acted precedent); font sizes reuse what this surface already wears (the page base,
+   12px mono, the err-hint's 0.92em). Vars the feed sheet does not define carry the chat's literals as
+   fallbacks (feed-css-vars.test.ts holds that line). */
+.fileview-md { padding: 14px 18px; max-width: 860px; overflow-wrap: anywhere; }
+.fileview-md > :first-child { margin-top: 0; }
+.fileview-md > :last-child { margin-bottom: 0; }
+.fileview-md p { margin: 0.5em 0; }
+.fileview-md h1, .fileview-md h2, .fileview-md h3, .fileview-md h4 {
+  font-weight: 600; color: var(--fg); margin: 1em 0 0.4em; line-height: 1.3; }
+.fileview-md h1 { font-size: 1.3em; } .fileview-md h2 { font-size: 1.15em; } .fileview-md h3 { font-size: 1.05em; }
+.fileview-md ul, .fileview-md ol { margin: 0.4em 0; padding-left: 1.4em; }
+.fileview-md li { margin: 0.2em 0; }
+.fileview-md strong { color: var(--fg); font-weight: 600; }
+.fileview-md em { font-style: italic; }
+.fileview-md a { color: var(--vscode-textLink-foreground, #4daafc); text-decoration: none; }
+.fileview-md a:hover { text-decoration: underline; }
+.fileview-md blockquote { margin: 0.5em 0; padding-left: 12px;
+  border-left: 2px solid var(--box-border); color: var(--dim); }
+.fileview-md hr { border: none; border-top: 1px solid var(--box-border); margin: 1em 0; }
+.fileview-md :not(pre) > code {
+  font-family: var(--mono, ui-monospace, monospace); font-size: 0.92em;
+  color: var(--code-fg, #e1c08d); background: var(--code-bg, rgba(217, 119, 87, 0.10));
+  padding: 0.12em 0.4em; border-radius: 4px;
+}
+.fileview-md pre {
+  background: var(--box-bg, rgba(255, 255, 255, 0.03)); border: 1px solid var(--box-border);
+  border-radius: 6px; padding: 11px 14px; margin: 0.6em 0; overflow-x: auto;
+}
+.fileview-md pre code {
+  background: none; padding: 0; display: block;
+  font-family: var(--mono, ui-monospace, monospace); font-size: 12px; line-height: 1.5;
+  color: var(--code-fg, #e1c08d); white-space: pre-wrap; overflow-wrap: anywhere;
+}
+.fileview-md table { border-collapse: collapse; margin: 0.6em 0; }
+.fileview-md th, .fileview-md td { border: 1px solid var(--box-border); padding: 4px 10px; text-align: left; }
+.fileview-md th { background: rgba(255, 255, 255, 0.03); }
+.fileview-md img { max-width: 100%; }
+
+/* ---------- syntax highlighting (warm, restrained) ----------
+   The hljs token palette, mirrored from styles.css (one treatment, two sheets — the .romp-acted
+   precedent: each page loads only its own sheet). The viewer wraps every token in .hljs-* spans, and
+   until this block landed the feed sheet had NO rules for them, so highlighting rendered colorless. */
+.hljs { color: #d8c6a8; background: transparent; }
+.hljs-keyword, .hljs-built_in, .hljs-literal, .hljs-type { color: #c98a6a; }
+.hljs-string, .hljs-attr, .hljs-regexp { color: #9fb878; }
+.hljs-number { color: #d4a36a; }
+.hljs-comment, .hljs-quote { color: #6f6a5f; font-style: italic; }
+.hljs-title, .hljs-title.function_, .hljs-section { color: #e1c08d; }
+.hljs-name, .hljs-tag { color: #c98a6a; }
+.hljs-params, .hljs-variable, .hljs-property { color: #d8c6a8; }
+.hljs-meta { color: #9a8f7a; }
+.hljs-attribute { color: #cdaf7e; }
+.hljs-addition { color: #9fb878; }
+.hljs-deletion { color: var(--err); }
+
 /* the "host:" prefix on a federated session's name — see styles.css (one treatment, two sheets) */
 .host-prefix { color: var(--dim); font-weight: 400; font-style: italic; font-size: 0.88em; }
 /* DISCONNECTED host (the user 2026-07-29): its sessions keep their tabs, lanes and cards — dropping them

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -17,6 +17,7 @@ import { badgeNotices, clearBoundaryNotices, sdkProblemNotices, syncNotices,
   type ClearNoticeRow, type SdkNoticeRow, type SyncNoticeRow } from "./badge-mirror";
 import { initStrip } from "./strip";
 import { installSettingsSync } from "./settings";
+import { initFileView } from "./file-view";
 import { VIEW_STATE_KEY, parseViewState, serializeViewState, pruneViewState, capViewState, type FeedViewState } from "./feed-view-state";
 
 // (The standalone-deliverable "FeedItem" subsystem was REMOVED 2026-07-07: the kernel had emitted
@@ -3963,5 +3964,7 @@ setInterval(() => {
     if (it && t) t.textContent = relAge(now - it.t);
   }
 }, 15000);
+
+initFileView();   // the shell relays a chat file-link click here; the viewer takes over this pane
 
 vscodeApi?.postMessage({ type: "ready" });

--- a/ui/webview/file-uri-link.test.ts
+++ b/ui/webview/file-uri-link.test.ts
@@ -14,10 +14,10 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("a bare file:// URL becomes a clickable .file-uri-link that opens the file in the host app", () => {
   assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>\): void/);
   assert.match(RENDER, /el\("span", "file-uri-link"\)/);
-  // clicking routes to the host opener (kernel `open <path>`), NOT a blocked window.open(file://) — a file://
-  // URI is absolute, so it goes through the shared openPathLink's no-session-id branch
+  // clicking is ROUTED by openPath, never a blocked window.open(file://) — a file:// URI is absolute,
+  // so it takes the shared openPathLink's no-session-id branch
   assert.match(RENDER, /function fileUriLink\(uri: string\): HTMLElement \{ return openPathLink\(uri, fileUriToPath\(uri\)\); \}/);
-  assert.match(RENDER, /\{ type: "openFile", path: open \}/);
+  assert.match(RENDER, /openPath\(open, relative \? activeId : null\);/);
   // the URL is turned into a real filesystem path: scheme stripped, percent-decoded
   assert.match(RENDER, /\.replace\(\/\^file:/);
   assert.match(RENDER, /decodeURIComponent\(p\)/);

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -1,0 +1,236 @@
+// The file viewer in the FEED pane (the user 2026-08-08). Clicking a file path in the chat used to post
+// `openFile`, which the kernel served by running an opener on ITS OWN machine — the wrong screen when the
+// dashboard is read from another device, and nothing at all on a kernel with no desktop, because the
+// opener was macOS-only. The bytes have to reach the browser, so the click now routes to a viewer fed by
+// the same /file route the image thumbnails use. Source pins (no jsdom for these modules) + executed
+// replicas of the pure helpers.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const web = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const VIEW = web("file-view.ts");
+const RENDER = web("render.ts");
+const FEED = web("feed.ts");
+const FEED_CSS = web("feed.css");
+
+test("openPath routes by HOST: the feed viewer on the web, the editor in VS Code", () => {
+  assert.match(RENDER, /function openPath\(path: string, sid\?: string \| null\): void/);
+  // web dashboard inside the shell → relay up; the chat and the feed are different documents
+  assert.match(RENDER, /const web = location\.protocol === "http:" \|\| location\.protocol === "https:";/);
+  assert.match(RENDER, /if \(web && window\.parent !== window\) \{/);
+  assert.match(RENDER, /window\.parent\.postMessage\(\{ romp: "viewFile", path, sid: sid \|\| activeId \|\| null \}, "\*"\);/);
+  // everything else (VS Code, or /chat opened standalone with no shell) keeps the kernel-side opener
+  assert.match(RENDER, /vscodeApi\.postMessage\(sid \? \{ type: "openFile", path, id: sid \} : \{ type: "openFile", path \}\);/);
+});
+
+test("every file-link surface in the chat goes through openPath — no direct openFile posts left", () => {
+  for (const call of [/openPath\(path\);/, /openPath\(open, relative \? activeId : null\);/,
+                      /openPath\(p, id \|\| null\);/]) assert.match(RENDER, call);
+  // the ONLY openFile postMessage left in render.ts is openPath's own fallback branch
+  assert.equal((RENDER.match(/type: "openFile"/g) || []).length, 2,
+               "both remaining mentions are the two arms of openPath's fallback");
+});
+
+test("the shell relays chat → feed, and restores a pane it had to turn on", () => {
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNEL, /if\(m\.romp==='viewFile'\)\{var vf=document\.getElementById\('f-feed'\);/);
+  // a feed pane the user had toggled OFF is turned on for the viewer and put back on close — the viewer
+  // must never silently rearrange the layout they chose
+  assert.match(KERNEL, /window\.__rompFeedWasOff=true;/);
+  assert.match(KERNEL, /if\(m\.romp==='viewFileClosed'&&window\.__rompFeedWasOff\)\{window\.__rompFeedWasOff=false;/);
+  assert.match(KERNEL, /window\.__rompMobileTab&&window\.__rompMobileTab\('feed'\)/, "phone: one pane at a time");
+  assert.match(KERNEL, /window\.__rompMobileTab=show;/, "…which means the mobile switcher has to be exposed");
+});
+
+test("the viewer is a singleton that fills the pane and always tells the shell when it closes", () => {
+  assert.match(VIEW, /document\.getElementById\("romp-fileview"\)\?\.remove\(\);/, "re-opening replaces, never stacks");
+  assert.match(VIEW, /window\.parent\.postMessage\(\{ romp: "viewFileClosed" \}, "\*"\);/);
+  // Esc and ✕ are the same close path, so the shell's restore can't be skipped by one of them
+  assert.match(VIEW, /close\.addEventListener\("click", closeFileView\);/);
+  assert.match(VIEW, /if \(e\.key !== "Escape" \|\| !document\.getElementById\("romp-fileview"\)\) return;/);
+  assert.match(FEED, /initFileView\(\);/, "the feed boots the listener");
+  assert.match(FEED_CSS, /\.fileview \{ position: fixed; inset: 0;/);
+});
+
+test("it waits with the romp loader and fails with the kernel's own words, never a blank pane", () => {
+  assert.match(VIEW, /romp-swirl-glyph\.svg/, "loading-state rule: the swirl goes up first");
+  assert.match(VIEW, /fileview-dot/);
+  // a 404/413/415 body IS the explanation (the 413 names the size and the cap) — show it, don't swallow it
+  assert.match(VIEW, /if \(!r\.ok\) return r\.text\(\)\.then\(\(t\) => \{ throw new Error\(t \|\| \("HTTP " \+ r\.status\)\); \}\);/);
+  assert.match(VIEW, /const why = el\("div", "fileview-err"\);/);
+  // a reply that lands after the user closed the viewer paints nothing
+  assert.match(VIEW, /if \(!document\.getElementById\("romp-fileview"\)\) return;/);
+});
+
+test("it reuses fileUrl, so a REMOTE session's file is relayed from the host that owns it", () => {
+  assert.match(VIEW, /import \{ fileUrl \} from "\.\/preview";/);
+  assert.match(VIEW, /fetch\(fileUrl\(path, sid\), \{ cache: "no-store" \}\)/);
+});
+
+// executed: the extension→language map must never GUESS. highlightAuto on a config file or a log picks a
+// language at random and paints it as information the file does not contain.
+test("langFor maps known extensions and returns null rather than guessing", () => {
+  const LANG: Record<string, string> = {
+    py: "python", pyi: "python", js: "javascript", jsx: "javascript", mjs: "javascript",
+    cjs: "javascript", ts: "typescript", tsx: "typescript", json: "json", jsonc: "json",
+    yaml: "yaml", yml: "yaml", sh: "bash", bash: "bash", zsh: "bash", bats: "bash",
+    html: "xml", htm: "xml", xml: "xml", svg: "xml", vue: "xml", css: "css", scss: "css",
+    md: "markdown", markdown: "markdown", diff: "diff", patch: "diff",
+  };
+  const langFor = (p: string): string | null => LANG[p.slice(p.lastIndexOf(".") + 1).toLowerCase()] || null;
+  assert.equal(langFor("kernel/kernel.py"), "python");
+  assert.equal(langFor("ui/webview/render.TS"), "typescript");   // case-insensitive
+  assert.equal(langFor("notes.md"), "markdown");
+  for (const p of ["server.log", "Makefile", "a.conf", "data.csv", "x.rs"]) {
+    assert.equal(langFor(p), null, p + " has no registered grammar → plain, not a guess");
+  }
+  assert.doesNotMatch(VIEW, /hljs\.highlightAuto\(/, "auto-detection is what this map exists to avoid");
+});
+
+// ── formatting (the user 2026-08-09): the hljs palette, Raw ⇄ Rendered for markdown, and word wrap ──
+
+// A. The viewer wraps every token in .hljs-* spans, but the feed page loads ONLY feed.css — with no
+// palette there the highlighting rendered colorless. Both sheets must carry the SAME palette (one
+// treatment, two sheets — the .romp-acted precedent), so this pins every rule in both and catches drift.
+test("the hljs token palette lives in feed.css too, identical to the chat's", () => {
+  const STYLES = web("styles.css");
+  const rules = [
+    /\.hljs \{ color: #d8c6a8; background: transparent; \}/,
+    /\.hljs-keyword, \.hljs-built_in, \.hljs-literal, \.hljs-type \{ color: #c98a6a; \}/,
+    /\.hljs-string, \.hljs-attr, \.hljs-regexp \{ color: #9fb878; \}/,
+    /\.hljs-number \{ color: #d4a36a; \}/,
+    /\.hljs-comment, \.hljs-quote \{ color: #6f6a5f; font-style: italic; \}/,
+    /\.hljs-title, \.hljs-title\.function_, \.hljs-section \{ color: #e1c08d; \}/,
+    /\.hljs-name, \.hljs-tag \{ color: #c98a6a; \}/,
+    /\.hljs-params, \.hljs-variable, \.hljs-property \{ color: #d8c6a8; \}/,
+    /\.hljs-meta \{ color: #9a8f7a; \}/,
+    /\.hljs-attribute \{ color: #cdaf7e; \}/,
+    /\.hljs-addition \{ color: #9fb878; \}/,
+    /\.hljs-deletion \{ color: var\(--err\); \}/,
+  ];
+  for (const r of rules) {
+    assert.match(FEED_CSS, r, "feed.css is missing a palette rule: " + r.source);
+    assert.match(STYLES, r, "styles.css drifted from the shared palette: " + r.source);
+  }
+});
+
+// B, executed: the persisted view-format prefs. RENDERED is the markdown default (the user's explicit
+// call, 2026-08-09) and any malformed stored value reads as the defaults — a corrupt entry may cost the
+// preference, never the viewer (feed-view-state's parseViewState contract).
+test("format prefs: rendered is the markdown default, and a corrupt entry reads as the defaults", () => {
+  type Fmt = { md: "rendered" | "raw"; wrap: boolean };
+  const parseFmt = (raw: string | null): Fmt => {
+    const def: Fmt = { md: "rendered", wrap: false };
+    if (!raw) return def;
+    try {
+      const o = JSON.parse(raw) as { md?: unknown; wrap?: unknown };
+      if (!o || typeof o !== "object") return def;
+      return { md: o.md === "raw" ? "raw" : "rendered", wrap: o.wrap === true };
+    } catch { return def; }
+  };
+  assert.deepEqual(parseFmt(null), { md: "rendered", wrap: false }, "first open: rendered, unwrapped");
+  assert.deepEqual(parseFmt('{"md":"raw","wrap":true}'), { md: "raw", wrap: true }, "the round-trip");
+  assert.deepEqual(parseFmt("not json"), { md: "rendered", wrap: false });
+  assert.deepEqual(parseFmt('{"md":"purple","wrap":"yes"}'), { md: "rendered", wrap: false },
+                   "foreign values fall to the defaults field by field");
+  // replica ↔ source
+  assert.match(VIEW, /const def: FileViewFmt = \{ md: "rendered", wrap: false \};/);
+  assert.match(VIEW, /return \{ md: o\.md === "raw" \? "raw" : "rendered", wrap: o\.wrap === true \};/);
+  // …and the prefs persist in localStorage, the feed-view-state call: per-BROWSER view state that must
+  // survive a kernel restart without a round-trip to the thing that just restarted
+  assert.match(VIEW, /const FMT_KEY = "romp:fileviewFmt";/);
+  assert.match(VIEW, /localStorage\.getItem\(FMT_KEY\)/);
+  assert.match(VIEW, /localStorage\.setItem\(FMT_KEY, JSON\.stringify\(f\)\)/);
+});
+
+// B: the toggle itself — markdown only, and the rendered path is sanitized. These are arbitrary bytes
+// off a disk and marked emits raw HTML verbatim, so DOMPurify sits between it and .innerHTML with the
+// same profile the chat's md() uses (render.ts).
+test("Raw ⇄ Rendered exists for markdown ONLY, and nothing reaches innerHTML unsanitized", () => {
+  assert.match(VIEW, /const isMd = langFor\(path\) === "markdown";/);
+  // the two buttons are built inside the isMd gate — a .py file shows no Rendered/Raw toggle
+  assert.match(VIEW, /if \(isMd\) \{\s*\n\s*for \(const mode of \["rendered", "raw"\] as const\)/);
+  assert.match(VIEW, /const rendered = isMd && fmt\.md === "rendered";/, "non-md never renders as prose");
+  assert.match(VIEW, /import DOMPurify from "dompurify";/);
+  assert.match(VIEW, /box\.innerHTML = DOMPurify\.sanitize\(dirty, \{ USE_PROFILES: \{ html: true \}, ADD_DATA_URI_TAGS: \["img"\] \}\);/);
+  // a README's links open a NEW tab rather than navigating the feed pane's iframe away
+  assert.match(VIEW, /target = "_blank"/);
+  assert.match(VIEW, /rel = "noopener"/);
+  // fenced blocks highlight only a NAMED, registered language — same no-guessing rule as langFor
+  assert.match(VIEW, /if \(!lang \|\| !hljs\.getLanguage\(lang\)\) return;/);
+  // the prose typography exists on this sheet (the chat's .md block is the reference aesthetic)
+  assert.match(FEED_CSS, /\.fileview-md \{/);
+  assert.match(FEED_CSS, /\.fileview-md pre code \{/);
+  // toggles acknowledge in the same synchronous tick: click → save → renderBody, which flips .on
+  assert.match(VIEW, /b\.addEventListener\("click", \(\) => \{ fmt\.md = mode; saveFmt\(fmt\); renderBody\(\); \}\);/);
+  assert.match(VIEW, /b\.classList\.toggle\("on", on\);/);
+  assert.match(FEED_CSS, /\.fileview-btn\.on \{ color: var\(--accent\); border-color: var\(--accent\);/);
+});
+
+// C, executed: wrap mode's numbering. A flat gutter misaligns the moment one logical line wraps onto
+// several visual lines, so wrap mode restructures — each logical line is a .fv-cl row numbered by a CSS
+// counter — instead of shipping a drifting column. hljs spans can cross newlines, so each row must
+// re-open what the previous row left unclosed (render.ts's wrapCodeLines balance walk).
+test("wrap mode: per-line rows, spans rebalanced across newlines, no phantom trailing row", () => {
+  const wrapNumberedHtml = (html: string): string => {
+    const lines = html.split("\n");
+    if (lines.length && lines[lines.length - 1] === "") lines.pop();
+    let open: string[] = [];
+    return lines.map((ln) => {
+      const prefix = open.join("");
+      const re = /<span[^>]*>|<\/span>/g; let m; const stack = open.slice();
+      while ((m = re.exec(ln))) { if (m[0] === "</span>") stack.pop(); else stack.push(m[0]); }
+      const suffix = "</span>".repeat(Math.max(0, stack.length));
+      open = stack;
+      return `<span class="fv-cl"><span class="fv-ct">${prefix}${ln}${suffix}</span></span>`;
+    }).join("");
+  };
+  // a string token spanning a newline: closed at the end of row 1, re-opened at the start of row 2
+  const out = wrapNumberedHtml('<span class="hljs-string">"a\nb"</span>\nplain');
+  const rows = out.split('<span class="fv-cl">').filter(Boolean);
+  assert.equal(rows.length, 3, "three logical lines, three rows");
+  for (const row of rows) {
+    const opens = (row.match(/<span[^>]*>/g) || []).length;
+    const closes = (row.match(/<\/span>/g) || []).length;
+    // +1: the .fv-cl open itself was consumed as the split delimiter
+    assert.equal(opens + 1, closes, "a row must close every span it opens: " + row);
+  }
+  assert.match(rows[0], /<span class="hljs-string">"a<\/span>/);
+  assert.match(rows[1], /^<span class="fv-ct"><span class="hljs-string">b"<\/span>/);
+  assert.equal((wrapNumberedHtml("a\n").match(/fv-cl/g) || []).length, 1,
+               "a trailing newline is not a phantom row — same rule as the gutter");
+  // replica ↔ source
+  assert.match(VIEW, /return `<span class="fv-cl"><span class="fv-ct">\$\{prefix\}\$\{ln\}\$\{suffix\}<\/span><\/span>`;/);
+});
+
+// C: the toggle and the CSS that carries the honest gutter answer
+test("the Wrap toggle persists, hides with rendered prose, and its numbers still never copy", () => {
+  assert.match(VIEW, /wrapBtn\.addEventListener\("click", \(\) => \{ fmt\.wrap = !fmt\.wrap; saveFmt\(fmt\); renderBody\(\); \}\);/);
+  // wrap mode returns BEFORE the sibling gutter is built — a misaligned column cannot exist
+  assert.match(VIEW, /if \(wrapLines\) \{[\s\S]*?return wrap;\s*\}\s*const gutter = el\("div", "fileview-gutter"\);/);
+  // plain files wrap too: no grammar → the text is HTML-escaped before the line walk
+  assert.match(VIEW, /code\.innerHTML = wrapNumberedHtml\(hl !== null \? hl : escapeHtml\(text\)\);/);
+  assert.match(FEED_CSS, /\.fileview-pre\.fileview-wrap \{ white-space: pre-wrap/);
+  assert.match(FEED_CSS, /\.fileview-wrap \.fv-cl::before \{[\s\S]*?counter-increment: fvln/);
+  assert.match(FEED_CSS, /\.fileview-wrap \.fv-cl::before \{[\s\S]*?user-select: none/);
+  // wrap governs the pre view only — rendered prose always wraps — so the button leaves with it
+  assert.match(VIEW, /wrapBtn\.hidden = rendered;/);
+  assert.match(VIEW, /wrapBtn\.classList\.toggle\("on", fmt\.wrap\);/, "pressed state flips synchronously");
+});
+
+// executed: the gutter is a SIBLING of the code, so selecting the code copies it without line numbers
+test("the line gutter numbers every line and drops a trailing newline's phantom line", () => {
+  const lines = (text: string): string[] => {
+    const l = text.split("\n");
+    if (l.length && l[l.length - 1] === "") l.pop();
+    return l;
+  };
+  assert.deepEqual(lines("a\nb\nc\n").length, 3, "a trailing newline is not a fourth line");
+  assert.deepEqual(lines("a\nb\nc").length, 3);
+  assert.deepEqual(lines(""), []);
+  assert.match(VIEW, /gutter\.textContent = lines\.map\(\(_, i\) => String\(i \+ 1\)\)\.join\("\\n"\);/);
+  assert.match(VIEW, /wrap\.appendChild\(gutter\); wrap\.appendChild\(pre\);/, "sibling, not inside the pre");
+  assert.match(FEED_CSS, /\.fileview-gutter \{[\s\S]*?user-select: none;/);
+});

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -57,8 +57,9 @@ test("the viewer is a singleton that fills the pane and always tells the shell w
 test("it waits with the romp loader and fails with the kernel's own words, never a blank pane", () => {
   assert.match(VIEW, /romp-swirl-glyph\.svg/, "loading-state rule: the swirl goes up first");
   assert.match(VIEW, /fileview-dot/);
-  // a 404/413/415 body IS the explanation (the 413 names the size and the cap) — show it, don't swallow it
-  assert.match(VIEW, /if \(!r\.ok\) return r\.text\(\)\.then\(\(t\) => \{ throw new Error\(t \|\| \("HTTP " \+ r\.status\)\); \}\);/);
+  // a 404/413/415 body IS the explanation (the 413 names the size and the cap) — show it, don't swallow
+  // it. The status rides along since 2026-08-09, so the catch can decide whether to offer the download.
+  assert.match(VIEW, /if \(!r\.ok\) return r\.text\(\)\.then\(\(t\) => \{\s*\n\s*throw Object\.assign\(new Error\(t \|\| \("HTTP " \+ r\.status\)\), \{ status: r\.status \}\);\s*\n\s*\}\);/);
   assert.match(VIEW, /const why = el\("div", "fileview-err"\);/);
   // a reply that lands after the user closed the viewer paints nothing
   assert.match(VIEW, /if \(!document\.getElementById\("romp-fileview"\)\) return;/);
@@ -218,6 +219,55 @@ test("the Wrap toggle persists, hides with rendered prose, and its numbers still
   // wrap governs the pre view only — rendered prose always wraps — so the button leaves with it
   assert.match(VIEW, /wrapBtn\.hidden = rendered;/);
   assert.match(VIEW, /wrapBtn\.classList\.toggle\("on", fmt\.wrap\);/, "pressed state flips synchronously");
+});
+
+// ── download (the user 2026-08-09): any linked file can be SAVED, including everything the pane cannot
+// show — the kernel's ?download=1 serves anything on disk (the rationale lives with _file_download in
+// kernel.py: the view allowlists are a rendering choice, not a security boundary). ──
+
+test("the title bar offers Download next to Copy path, at the same-origin download URL", () => {
+  // the URL is fileUrl + the download switch: same origin, cookie-authed, and federation-aware for
+  // free — fileUrl already routes a remote session's file through the /remote/<host>/file relay
+  assert.match(VIEW, /const dlUrl = fileUrl\(path, sid\) \+ "&download=1";/);
+  assert.match(VIEW, /dl\.textContent = "Download";/);
+  // next to Copy path: appended into the same acts bar, wearing the same button class
+  assert.match(VIEW, /acts\.appendChild\(dl\);\n\n  const copy = el\("button", "fileview-btn"\)/);
+  assert.match(VIEW, /const dl = el\("button", "fileview-btn"\) as HTMLButtonElement;/, "no new styling, no new font size");
+});
+
+test("startDownload hands the URL to the browser's downloader and never wipes the pane", () => {
+  // an <a download> click: the BROWSER owns the request (its progress UI, its save location), and the
+  // kernel's attachment disposition means the page never navigates — the viewer stays put
+  assert.match(VIEW, /const a = document\.createElement\("a"\);\s*\n\s*a\.href = url;\s*\n\s*a\.download = "";/);
+  assert.match(VIEW, /document\.body\.appendChild\(a\);\s*\n\s*a\.click\(\);\s*\n\s*a\.remove\(\);/);
+  assert.doesNotMatch(VIEW, /location\.href\s*=/, "no navigation — a wiped pane is the failure mode this avoids");
+  // …and the click acknowledges itself (ui/CLAUDE.md): the download UI can take a beat over a tunnel
+  assert.match(VIEW, /btn\.textContent = "Downloading…";/);
+});
+
+// executed: which fetch failures still deserve a Download offer? Exactly the ones that mean the file
+// EXISTS — 413 (too large to render) and 415 (on disk but not viewable: a .zip, a binary named like
+// text). A 404 is genuinely missing, and offering to download it would be a lie.
+test("offersDownload: 413 and 415 offer, 404 and everything else do not", () => {
+  const offersDownload = (status: number | undefined): boolean => status === 413 || status === 415;
+  assert.equal(offersDownload(413), true, "too big to render ≠ too big to save");
+  assert.equal(offersDownload(415), true, "exists-but-unviewable is the case the button exists for");
+  assert.equal(offersDownload(404), false, "genuinely missing → nothing to offer");
+  assert.equal(offersDownload(403), false);
+  assert.equal(offersDownload(undefined), false, "a network failure carries no status and no offer");
+  // replica ↔ source
+  assert.match(VIEW, /return status === 413 \|\| status === 415;/);
+});
+
+test("a refusal renders the kernel's words PLUS the way out — gated on offersDownload", () => {
+  // the status rides the thrown error so the catch can tell "there but unshowable" from "not there"
+  assert.match(VIEW, /throw Object\.assign\(new Error\(t \|\| \("HTTP " \+ r\.status\)\), \{ status: r\.status \}\);/);
+  // the offer appends to the SAME error pane that shows the kernel's message — an offer, not a dead end
+  assert.match(VIEW, /if \(offersDownload\(\(err as \{ status\?: number \}\)\.status\)\) \{/);
+  assert.match(VIEW, /const offer = el\("button", "fileview-btn fileview-err-dl"\) as HTMLButtonElement;/);
+  assert.match(VIEW, /why\.appendChild\(offer\);/);
+  assert.match(VIEW, /offer\.addEventListener\("click", \(\) => startDownload\(dlUrl, offer\)\);/);
+  assert.match(FEED_CSS, /\.fileview-err-dl \{ display: block; margin-top: 10px; \}/);
 });
 
 // executed: the gutter is a SIBLING of the code, so selecting the code copies it without line numbers

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -163,6 +163,16 @@ export function openFileView(path: string, sid?: string | null): void {
   wrapBtn.addEventListener("click", () => { fmt.wrap = !fmt.wrap; saveFmt(fmt); renderBody(); });
   acts.appendChild(wrapBtn);
 
+  // ── download (the user 2026-08-09) ── Any linked file can be SAVED, including everything the pane
+  // cannot show: the kernel's ?download=1 serves anything on disk (the rationale lives with
+  // _file_download in kernel.py). Same-origin and cookie-authed like the view fetch, and
+  // federation-aware for free — fileUrl already routes a remote session's file through the relay.
+  const dlUrl = fileUrl(path, sid) + "&download=1";
+  const dl = el("button", "fileview-btn") as HTMLButtonElement;
+  dl.type = "button"; dl.textContent = "Download"; dl.title = "Save this file to your device";
+  dl.addEventListener("click", () => startDownload(dlUrl, dl));
+  acts.appendChild(dl);
+
   const copy = el("button", "fileview-btn") as HTMLButtonElement;
   copy.type = "button"; copy.textContent = "Copy path"; copy.title = path;
   copy.addEventListener("click", () => {
@@ -218,8 +228,11 @@ export function openFileView(path: string, sid?: string | null): void {
   fetch(fileUrl(path, sid), { cache: "no-store" }).then((r) => {
     // Every failure says WHY, in the pane, rather than leaving a blank one: the kernel distinguishes
     // "not a type I serve" from "too big" from "not text after all", and that is exactly what the
-    // person who clicked needs to know (a 413 names the size and the cap).
-    if (!r.ok) return r.text().then((t) => { throw new Error(t || ("HTTP " + r.status)); });
+    // person who clicked needs to know (a 413 names the size and the cap). The status rides along so
+    // the catch below can tell "the file is there but I can't show it" from "there is no file".
+    if (!r.ok) return r.text().then((t) => {
+      throw Object.assign(new Error(t || ("HTTP " + r.status)), { status: r.status });
+    });
     return r.text();
   }).then((t) => {
     if (!document.getElementById("romp-fileview")) return;    // closed while it was in flight
@@ -237,8 +250,42 @@ export function openFileView(path: string, sid?: string | null): void {
       hint.textContent = path;
       why.appendChild(hint);
     }
+    // A refusal-to-RENDER is not a dead end (ui/CLAUDE.md): when the file exists, the kernel's own
+    // words are followed by the way out — the download the view could not be. A 404 stays offerless,
+    // because offering to download a file that is not there would be a lie.
+    if (offersDownload((err as { status?: number }).status)) {
+      const offer = el("button", "fileview-btn fileview-err-dl") as HTMLButtonElement;
+      offer.type = "button"; offer.textContent = "Download";
+      offer.title = "Save this file to your device";
+      offer.addEventListener("click", () => startDownload(dlUrl, offer));
+      why.appendChild(offer);
+    }
     body.replaceChildren(why);
   });
+}
+
+// Which fetch failures still deserve a Download offer? Exactly the ones that mean the file EXISTS:
+// 413 (too large to render) and 415 (on disk but not viewable — a .zip, a binary named like text).
+// A 404 is genuinely missing, and gets nothing.
+function offersDownload(status: number | undefined): boolean {
+  return status === 413 || status === 415;
+}
+
+// Kick the browser's downloader at `url` without touching the pane: a clicked <a download> starts a
+// same-origin, cookie-authed request the BROWSER owns (its progress UI, its save location), and since
+// the kernel answers with Content-Disposition: attachment the page never navigates — the viewer, the
+// feed behind it, and the scroll position all stay put. The button acknowledges the click itself
+// (ui/CLAUDE.md), because the browser's download UI can take a beat to appear over a slow tunnel.
+function startDownload(url: string, btn: HTMLButtonElement): void {
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "";               // a hint; the kernel's attachment disposition is what actually decides
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  const was = btn.textContent;
+  btn.textContent = "Downloading…";
+  setTimeout(() => { btn.textContent = was; }, 1500);
 }
 
 function escapeHtml(s: string): string {

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -1,0 +1,340 @@
+// The file viewer that lives in the FEED pane (the user 2026-08-08).
+//
+// Clicking a file path in the chat used to post `openFile`, which the kernel served by running an
+// opener on ITS machine. Read the dashboard from another device — a laptop across the internet, a
+// phone — and that is the wrong screen entirely; on a kernel with no desktop it did nothing at all,
+// silently, which is how the user found it. The only place a file can actually be shown is the browser
+// you are looking at, so the bytes come over the same `/file` route the image thumbnails already use
+// (federation-aware via fileUrl, so a remote session's file is relayed from the host that owns it).
+//
+// It takes over the FEED pane rather than floating a modal: the cards are the thing you are least
+// likely to be reading while you follow a path out of a transcript, and a full pane gives long source
+// somewhere to scroll. The shell brings that pane forward if it was toggled off and puts it back on
+// close, so the viewer never silently rearranges the layout you chose.
+import hljs from "highlight.js/lib/core";
+import { marked } from "marked";
+import DOMPurify from "dompurify";
+import { fileUrl } from "./preview";
+
+// hljs is registered per-bundle; the feed had none until this viewer needed it. Same language set the
+// chat registers, so a file reads identically in either place.
+import bash from "highlight.js/lib/languages/bash";
+import python from "highlight.js/lib/languages/python";
+import javascript from "highlight.js/lib/languages/javascript";
+import typescript from "highlight.js/lib/languages/typescript";
+import json from "highlight.js/lib/languages/json";
+import xml from "highlight.js/lib/languages/xml";
+import cssLang from "highlight.js/lib/languages/css";
+import markdown from "highlight.js/lib/languages/markdown";
+import diff from "highlight.js/lib/languages/diff";
+import yaml from "highlight.js/lib/languages/yaml";
+
+for (const [name, lang] of Object.entries({
+  bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
+  typescript, ts: typescript, json, xml, html: xml, css: cssLang, markdown, md: markdown,
+  diff, yaml, yml: yaml,
+})) {
+  try { hljs.registerLanguage(name, lang as any); } catch { /* dup alias */ }
+}
+
+// Extension → the hljs language to force. Anything absent is shown unhighlighted rather than guessed:
+// highlightAuto on a config file or a log picks a language at random and paints it misleadingly, and a
+// wrong highlight reads as information the file does not contain.
+const LANG: Record<string, string> = {
+  py: "python", pyi: "python", js: "javascript", jsx: "javascript", mjs: "javascript",
+  cjs: "javascript", ts: "typescript", tsx: "typescript", json: "json", jsonc: "json",
+  yaml: "yaml", yml: "yaml", sh: "bash", bash: "bash", zsh: "bash", bats: "bash",
+  html: "xml", htm: "xml", xml: "xml", svg: "xml", vue: "xml", css: "css", scss: "css",
+  md: "markdown", markdown: "markdown", diff: "diff", patch: "diff",
+};
+
+function langFor(path: string): string | null {
+  const ext = path.slice(path.lastIndexOf(".") + 1).toLowerCase();
+  return LANG[ext] || null;
+}
+
+// marked is a per-bundle singleton and nothing else in the FEED bundle configures it, so the viewer makes
+// the same choices the chat's render.ts made: GFM without hard breaks, and strikethrough only on DOUBLE
+// tildes — marked's stock GFM `del` tokenizer fires on a single ~, so prose between two "approximately"
+// tildes renders struck through; GitHub itself only strikes ~~double~~.
+marked.setOptions({ gfm: true, breaks: false });
+marked.use({
+  tokenizer: {
+    del(src: string) {
+      const m = /^~~(?=\S)([\s\S]*?\S)~~/.exec(src);
+      if (!m) return undefined;
+      return { type: "del", raw: m[0], text: m[1], tokens: (this as { lexer: { inlineTokens(s: string): unknown[] } }).lexer.inlineTokens(m[1]) };
+    },
+  },
+} as Parameters<typeof marked.use>[0]);
+
+// ── view-format preferences ────────────────────────────────────────────────────────────────────────
+// The Raw ⇄ Rendered choice for markdown and the word-wrap toggle persist in localStorage, NOT a kernel
+// file — per-browser view state, the same call feed-view-state.ts makes for the feed's open sections (it
+// must survive a kernel restart without a round-trip to the thing that just restarted). RENDERED is the
+// default for markdown (the user 2026-08-09); Raw stays one click away.
+const FMT_KEY = "romp:fileviewFmt";
+type FileViewFmt = { md: "rendered" | "raw"; wrap: boolean };
+
+// Any malformed/foreign value reads as the defaults rather than throwing — a corrupt entry may cost the
+// stored preference, never the viewer (feed-view-state's parseViewState contract).
+function parseFmt(raw: string | null | undefined): FileViewFmt {
+  const def: FileViewFmt = { md: "rendered", wrap: false };
+  if (!raw) return def;
+  try {
+    const o = JSON.parse(raw) as { md?: unknown; wrap?: unknown };
+    if (!o || typeof o !== "object") return def;
+    return { md: o.md === "raw" ? "raw" : "rendered", wrap: o.wrap === true };
+  } catch { return def; }
+}
+
+function loadFmt(): FileViewFmt {
+  try { return parseFmt(localStorage.getItem(FMT_KEY)); } catch { return parseFmt(null); }
+}
+
+function saveFmt(f: FileViewFmt): void {
+  try { localStorage.setItem(FMT_KEY, JSON.stringify(f)); } catch { /* storage full */ }
+}
+
+function el(tag: string, cls?: string): HTMLElement {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  return e;
+}
+
+// The shell restores the pane's previous visibility on this, so it must fire on EVERY close path.
+function tellShellClosed(): void {
+  try {
+    if (window.parent !== window) window.parent.postMessage({ romp: "viewFileClosed" }, "*");
+  } catch { /* no shell (standalone /feed) — nothing to restore */ }
+}
+
+export function closeFileView(): void {
+  const box = document.getElementById("romp-fileview");
+  if (!box) return;
+  box.remove();
+  document.body.classList.remove("fileview-open");
+  tellShellClosed();
+}
+
+/** Show `path` in the feed pane. Re-opening replaces whatever is up — never stacks. */
+export function openFileView(path: string, sid?: string | null): void {
+  document.getElementById("romp-fileview")?.remove();
+  const box = el("div", "fileview");
+  box.id = "romp-fileview";
+  document.body.classList.add("fileview-open");
+
+  const bar = el("div", "fileview-bar");
+  // Directory then basename as TWO elements, because only the directory may be truncated: the filename
+  // is what identifies the file, so it never shrinks however deep the path is. (A single text node with
+  // the rtl-ellipsis trick would truncate the right end — exactly the wrong half.)
+  const name = el("div", "fileview-name");
+  name.title = path;                                   // the full path, one hover away
+  const cut = path.lastIndexOf("/");
+  const dir = el("span", "fileview-dir");
+  dir.textContent = cut >= 0 ? path.slice(0, cut + 1) : "";
+  const base = el("span", "fileview-base");
+  base.textContent = path.slice(cut + 1);
+  name.appendChild(dir); name.appendChild(base);
+  const acts = el("div", "fileview-acts");
+
+  // ── format toggles (the user 2026-08-09) ── A markdown file opens RENDERED, its Raw form one click
+  // away; everything else keeps the code view, whose long lines the Wrap toggle can soft-wrap. Both
+  // choices persist per browser (FMT_KEY above). These buttons are built once per open and never
+  // re-rendered by kernel pushes — the viewer is a static overlay — so direct listeners are click-safe
+  // here, same as Copy path below.
+  const fmt = loadFmt();
+  let text: string | null = null;             // set once the fetch lands; earlier clicks just save the pref
+  const isMd = langFor(path) === "markdown";  // .md/.markdown — the only kind with a Rendered form
+  const segBtns: Array<["rendered" | "raw", HTMLButtonElement]> = [];
+  if (isMd) {
+    for (const mode of ["rendered", "raw"] as const) {
+      const b = el("button", "fileview-btn") as HTMLButtonElement;
+      b.type = "button";
+      b.textContent = mode === "rendered" ? "Rendered" : "Raw";
+      b.title = mode === "rendered" ? "The prose the markdown means" : "The file's actual bytes";
+      b.addEventListener("click", () => { fmt.md = mode; saveFmt(fmt); renderBody(); });
+      segBtns.push([mode, b]);
+      acts.appendChild(b);
+    }
+  }
+  const wrapBtn = el("button", "fileview-btn") as HTMLButtonElement;
+  wrapBtn.type = "button"; wrapBtn.textContent = "Wrap"; wrapBtn.title = "Soft-wrap long lines";
+  wrapBtn.addEventListener("click", () => { fmt.wrap = !fmt.wrap; saveFmt(fmt); renderBody(); });
+  acts.appendChild(wrapBtn);
+
+  const copy = el("button", "fileview-btn") as HTMLButtonElement;
+  copy.type = "button"; copy.textContent = "Copy path"; copy.title = path;
+  copy.addEventListener("click", () => {
+    navigator.clipboard?.writeText(path).then(
+      () => { copy.textContent = "Copied"; setTimeout(() => { copy.textContent = "Copy path"; }, 1200); },
+      () => { copy.textContent = "Copy failed"; });
+  });
+  const close = el("button", "fileview-btn fileview-close") as HTMLButtonElement;
+  close.type = "button"; close.textContent = "✕"; close.title = "Close (Esc)";
+  close.setAttribute("aria-label", "Close the file viewer");
+  close.addEventListener("click", closeFileView);
+  acts.appendChild(copy); acts.appendChild(close);
+  bar.appendChild(name); bar.appendChild(acts);
+
+  const body = el("div", "fileview-body");
+  // Per the loading-state rule the first thing up is the romp loader, not a blank pane — a file coming
+  // over an ssh tunnel to a phone is a real wait.
+  const load = el("div", "fileview-load");
+  load.innerHTML = '<img src="/media/romp-swirl-glyph.svg" alt=""><span>romp</span>'
+    + '<i class="fileview-dot"></i><i class="fileview-dot"></i><i class="fileview-dot"></i>';
+  body.appendChild(load);
+
+  box.appendChild(bar); box.appendChild(body);
+  document.body.appendChild(box);
+
+  // Chooses the body for the current prefs and syncs the buttons. The pressed state flips SYNCHRONOUSLY
+  // in the click handler — the immediate acknowledgement ui/CLAUDE.md requires — and so does the content
+  // swap, since the text is already in memory.
+  const renderBody = () => {
+    const rendered = isMd && fmt.md === "rendered";
+    for (const [mode, b] of segBtns) {
+      const on = fmt.md === mode;
+      b.classList.toggle("on", on);
+      b.setAttribute("aria-pressed", String(on));
+    }
+    // wrap governs the pre view only — rendered prose always wraps — so the button leaves with it
+    wrapBtn.hidden = rendered;
+    wrapBtn.classList.toggle("on", fmt.wrap);
+    wrapBtn.setAttribute("aria-pressed", String(fmt.wrap));
+    if (text === null) return;   // still loading; the saved pref is honored when the bytes land
+    body.replaceChildren(rendered ? mdBlock(text) : codeBlock(text, path, fmt.wrap));
+  };
+  renderBody();   // buttons take their initial state now; the loader stays up until the fetch lands
+
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key !== "Escape" || !document.getElementById("romp-fileview")) return;
+    e.preventDefault();
+    closeFileView();
+    document.removeEventListener("keydown", onKey);
+  };
+  document.addEventListener("keydown", onKey);
+
+  fetch(fileUrl(path, sid), { cache: "no-store" }).then((r) => {
+    // Every failure says WHY, in the pane, rather than leaving a blank one: the kernel distinguishes
+    // "not a type I serve" from "too big" from "not text after all", and that is exactly what the
+    // person who clicked needs to know (a 413 names the size and the cap).
+    if (!r.ok) return r.text().then((t) => { throw new Error(t || ("HTTP " + r.status)); });
+    return r.text();
+  }).then((t) => {
+    if (!document.getElementById("romp-fileview")) return;    // closed while it was in flight
+    text = t;
+    renderBody();
+  }).catch((err) => {
+    if (!document.getElementById("romp-fileview")) return;
+    const why = el("div", "fileview-err");
+    const msg = String(err && err.message || err);
+    why.textContent = msg;
+    if (!msg.includes(path)) {
+      // The kernel's 404/413/415 bodies name the RESOLVED path themselves now — the hint exists for
+      // errors that don't (a network failure, an old kernel), not to say the same path twice.
+      const hint = el("div", "fileview-err-hint");
+      hint.textContent = path;
+      why.appendChild(hint);
+    }
+    body.replaceChildren(why);
+  });
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// Wrap mode's numbering. The flat sibling gutter cannot survive soft-wrapping — one logical line becomes
+// several visual lines and every number below it drifts — so wrap mode RESTRUCTURES instead of shipping a
+// misaligned column: each logical line is its own row (.fv-cl) whose number is a CSS counter in ::before
+// (the chat's .cl/.ct treatment, styles.css), so the numbers stay glued to their lines however tall a
+// wrapped line grows, and being ::before content they still never copy with the code. hljs spans can
+// cross newlines, so each row re-opens the spans the previous row left unclosed and closes its own —
+// render.ts's wrapCodeLines balance walk.
+function wrapNumberedHtml(html: string): string {
+  const lines = html.split("\n");
+  if (lines.length && lines[lines.length - 1] === "") lines.pop();   // a trailing newline is not a line
+  let open: string[] = [];
+  return lines.map((ln) => {
+    const prefix = open.join("");
+    const re = /<span[^>]*>|<\/span>/g; let m; const stack = open.slice();
+    while ((m = re.exec(ln))) { if (m[0] === "</span>") stack.pop(); else stack.push(m[0]); }
+    const suffix = "</span>".repeat(Math.max(0, stack.length));
+    open = stack;
+    return `<span class="fv-cl"><span class="fv-ct">${prefix}${ln}${suffix}</span></span>`;
+  }).join("");
+}
+
+// Line-numbered <pre>. In the default (no-wrap) view the gutter is a sibling column rather than text in
+// the same <pre>, so selecting the code and copying it does NOT drag the line numbers along with it; the
+// wrap view keeps that copy-safety a different way (see wrapNumberedHtml above).
+function codeBlock(text: string, path: string, wrapLines: boolean): HTMLElement {
+  const wrap = el("div", "fileview-code");
+  const lines = text.split("\n");
+  if (lines.length && lines[lines.length - 1] === "") lines.pop();   // a trailing newline is not a line
+  const lang = langFor(path);
+  let hl: string | null = null;
+  if (lang) {
+    try { hl = hljs.highlight(text, { language: lang }).value; }
+    catch { hl = null; }                               // a broken grammar must never cost the content
+  }
+  const pre = el("pre", "fileview-pre");
+  const code = el("code", "hljs");
+  if (wrapLines) {
+    pre.classList.add("fileview-wrap");
+    code.innerHTML = wrapNumberedHtml(hl !== null ? hl : escapeHtml(text));
+    pre.appendChild(code);
+    wrap.appendChild(pre);
+    return wrap;
+  }
+  const gutter = el("div", "fileview-gutter");
+  gutter.textContent = lines.map((_, i) => String(i + 1)).join("\n");
+  gutter.setAttribute("aria-hidden", "true");
+  if (hl !== null) code.innerHTML = hl; else code.textContent = text;
+  pre.appendChild(code);
+  wrap.appendChild(gutter); wrap.appendChild(pre);
+  return wrap;
+}
+
+// Markdown rendered as the prose it means (the user 2026-08-09: Rendered is the default, Raw one click
+// away). The file is arbitrary bytes off a disk and marked emits raw HTML verbatim, so — exactly like the
+// chat's md() in render.ts — the output goes through DOMPurify before it ever reaches .innerHTML: an
+// <img onerror> or a javascript: href in a README must never run in the dashboard.
+function mdBlock(text: string): HTMLElement {
+  const box = el("div", "fileview-md");
+  try {
+    const dirty = marked.parse(text) as string;
+    box.innerHTML = DOMPurify.sanitize(dirty, { USE_PROFILES: { html: true }, ADD_DATA_URI_TAGS: ["img"] });
+  } catch {
+    box.textContent = text;                            // a marked bug must never cost the content
+  }
+  // Links open a NEW tab: the viewer lives inside the feed pane's iframe, and letting a README link
+  // navigate that iframe away would silently eat the feed until a reload.
+  box.querySelectorAll("a[href]").forEach((a) => {
+    (a as HTMLAnchorElement).target = "_blank";
+    (a as HTMLAnchorElement).rel = "noopener";
+  });
+  // Fenced blocks: highlight only a language the fence NAMES and this bundle registers — the same
+  // no-guessing rule as langFor; an unnamed block stays plain rather than being painted at random.
+  box.querySelectorAll("pre code").forEach((node) => {
+    const codeEl = node as HTMLElement;
+    const lang = (codeEl.className.match(/language-([\w-]+)/) || [])[1];
+    if (!lang || !hljs.getLanguage(lang)) return;
+    try {
+      codeEl.innerHTML = hljs.highlight(codeEl.textContent || "", { language: lang }).value;
+      codeEl.classList.add("hljs");
+    } catch { /* leave plain */ }
+  });
+  return box;
+}
+
+/** Listen for the shell's relay of a chat file-link click. Called once, from the feed's boot. */
+export function initFileView(): void {
+  window.addEventListener("message", (e: MessageEvent) => {
+    const m = e.data;
+    if (m && m.romp === "viewFile" && typeof m.path === "string" && m.path) {
+      openFileView(m.path, typeof m.sid === "string" ? m.sid : null);
+    }
+  });
+}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -675,15 +675,39 @@ document.addEventListener("click", (e) => {
   }
 }, true);
 
-// A clickable file name that opens the real file in the editor (shared
-// open/navigate surface — see extension.ts openFile handler).
+// Where a clicked file path should actually open, which depends entirely on which host you are in.
+//
+//   • VS Code → the host extension's openFile handler, i.e. the editor two inches away. Unbeatable.
+//   • Web dashboard → the FEED PANE's viewer, via the shell (file-view.ts). This is the case that used
+//     to be broken (the user 2026-08-08): the browser sent `openFile` to the kernel, which ran an
+//     opener on the KERNEL's machine. Reading the dashboard from another device, that opens the file on
+//     a screen you are not looking at — and on a kernel with no desktop it did nothing at all, silently,
+//     because the opener was macOS-only. The bytes have to come to the browser; nothing else can work.
+//
+// The chat lives in an iframe and the feed is a different document, so the shell relays it. Standalone
+// (no parent frame, e.g. /chat opened directly) there is nobody to relay to, so it falls back to asking
+// the kernel — which is still right when the kernel IS this machine.
+function openPath(path: string, sid?: string | null): void {
+  if (!vscodeApi) return;
+  const web = location.protocol === "http:" || location.protocol === "https:";
+  if (web && window.parent !== window) {
+    try {
+      window.parent.postMessage({ romp: "viewFile", path, sid: sid || activeId || null }, "*");
+      return;
+    } catch { /* no shell — fall through to the kernel-side opener */ }
+  }
+  vscodeApi.postMessage(sid ? { type: "openFile", path, id: sid } : { type: "openFile", path });
+}
+
+// A clickable file name that opens the real file — in the editor (VS Code) or the feed pane's viewer
+// (web). Shared open/navigate surface; see extension.ts's openFile handler and file-view.ts.
 function fileLink(path: string): HTMLElement {
   const a = el("span", "tool-file");
   a.textContent = shortPath(path);
   a.title = "Open " + path;
   a.addEventListener("click", (e) => {
     e.stopPropagation();
-    if (vscodeApi) vscodeApi.postMessage({ type: "openFile", path });
+    openPath(path);
   });
   return a;
 }
@@ -899,7 +923,7 @@ function imgPathLink(path: string): HTMLElement {
   a.title = "Open " + path;
   a.addEventListener("click", (e) => {
     e.stopPropagation();
-    if (vscodeApi) vscodeApi.postMessage({ type: "openFile", path });
+    openPath(path);
   });
   return a;
 }
@@ -930,22 +954,19 @@ function fileUriToPath(uri: string): string {
   try { p = decodeURIComponent(p); } catch { /* malformed %-escape — use verbatim */ }
   return p;
 }
-// A clickable, VERBATIM file link that opens in the host's default app — the SAME open-the-file path the
-// caption/image links use ({type:"openFile"} → the kernel runs `open <path>`, so e.g. a PDF opens in the
-// viewer). `raw` is shown as written; `open` is what the host opens. A bare file:// can't be followed by the
-// browser from the http dashboard (blocked scheme) and a VS Code editor won't render a PDF, so it's routed to
-// the host opener instead of navigated. `relative` bare paths carry the active session id so the KERNEL
-// resolves them against THAT session's cwd — a relative `design/foo.md` is relative to the repo the agent
-// runs in, not the kernel's cwd (the user 2026-07-06).
+// A clickable, VERBATIM file link — the SAME open-the-file path the caption/image links use (openPath:
+// the editor in VS Code, the feed pane's viewer on the web). `raw` is shown as written; `open` is what
+// gets opened. A bare file:// can't be followed by the browser from the http dashboard (blocked scheme)
+// and a VS Code editor won't render a PDF, so it's routed rather than navigated. `relative` bare paths
+// carry the active session id so whoever resolves them uses THAT session's cwd — a relative
+// `design/foo.md` is relative to the repo the agent runs in, not the kernel's cwd (the user 2026-07-06).
 function openPathLink(raw: string, open: string, relative = false): HTMLElement {
   const a = el("span", "file-uri-link");
   a.textContent = raw;                       // shown exactly as written, selectable/copyable in place
   a.title = "Open " + open;
   a.addEventListener("click", (e) => {
     e.stopPropagation();
-    if (vscodeApi) vscodeApi.postMessage(relative
-      ? { type: "openFile", path: open, id: activeId }   // kernel resolves against this session's cwd
-      : { type: "openFile", path: open });
+    openPath(open, relative ? activeId : null);
   });
   return a;
 }
@@ -8347,7 +8368,7 @@ function renderComposerFiles(id: string | null): void {
     } else {
       box.appendChild(composerFileDoc(p));
     }
-    box.addEventListener("click", () => { vscodeApi?.postMessage({ type: "openFile", path: p, id: id || undefined }); });
+    box.addEventListener("click", () => { openPath(p, id || null); });
     const x = el("button", "composer-file-x");
     x.setAttribute("aria-label", "Remove attachment");
     x.textContent = "\u2715";


### PR DESCRIPTION
## What breaks today

Clicking a file path in the chat does nothing when the dashboard is read from any machine other than the kernel's — and on any non-macOS kernel it does nothing anywhere. Two stacked causes:

1. The click posts `openFile`, which the kernel serves with `subprocess.Popen(["open", path])` — macOS's opener. Elsewhere the `OSError` is caught and passed: no reply, no error, a link that looks alive.
2. Fixing the opener alone can't help remotely: `openFile` opens the file on the **kernel's** screen, which is the wrong machine whenever the dashboard is viewed from another device (the same story as #258's pickers, one layer up).

Images and PDFs already worked because `/file` serves those bytes to the browser; a `.py`/`.md`/log fell off the `_PREVIEW_MIME` allowlist, 404'd, and hit cause 1's dead end.

**Repro:** run the kernel on a Linux box (or view a macOS kernel's dashboard from a phone or laptop), click any source-file link in a transcript — nothing happens.

## The fix, per host (first commit)

One `openPath()` replaces the four scattered `openFile` posts in the chat, routed per host — the in-feed viewer on the web dashboard, an `openFile` post to the host editor in VS Code. (As first opened this PR also routed the feed's artifact chips through the same switch; c1f0dc03 removed the artifact strip, so the rebase dropped that hunk and the chat link is the viewer's single entry point.) In the VS Code webview clicks still go to the host editor — unchanged, the right answer there. On the web dashboard the click is relayed by the shell to a viewer filling the feed pane: line-numbered, syntax-highlighted from a fixed extension→language map (never `highlightAuto` — a guessed language paints information the file doesn't contain), Esc/✕ to close, Copy path, and the shell restores the pane's prior visibility on close.

`/file` widens to source/text: `text/plain` with its own 2 MB cap (separate from the 50 MB media cap; the 413 names the path, the size, and the limit) and a NUL sniff so a binary wearing a `.log` name is refused rather than served as mojibake; `.html` is served as text, never as a page; error bodies name the resolved path so a relative link that resolved somewhere unexpected explains itself. `_open_file` gets the #258 treatment (`xdg-open` behind a DISPLAY/WAYLAND_DISPLAY gate; a kernel with no desktop answers the click with a warning naming the host instead of silence).

Markdown opens as sanitized rendered prose by default (`marked` → DOMPurify before `innerHTML`; links target `_blank`) with Raw one click away; a word-wrap toggle renumbers via CSS counters so numbers never copy with the code; both prefs persist per browser. The viewer reuses `fileUrl`, so a federated session's file is relayed from the host that owns it — and the `/remote/<host>/file` relay's extension gate widens to match the text half (its Content-Type still derived locally, so a lying remote's `text/html` arrives as inert `text/plain` + nosniff; without this the relay 404'd a federated `.py` the local route serves).

One heads-up: this pulls `marked`/`dompurify`/`highlight.js` into the **feed** bundle for the first time (previously chat-only). No `package.json` change — they're already dependencies — but the feed bundle grows.

## Downloads (second commit — deliberately separable)

`/file?download=1` serves any existing file as a streamed `application/octet-stream` attachment — fixed 256 KB chunks, because `_send` slurps whole bodies and a multi-GB artifact would OOM the kernel; `Content-Disposition` is sanitized against header injection with the real name riding RFC 5987 `filename*`; a file truncated mid-stream closes the connection short of `Content-Length` so the browser reports a failed download instead of hanging. Exists-but-unviewable becomes a 415, distinct from 404, so the viewer offers Download exactly when the file is real (413/415) and never for a missing one. The `/remote/<host>/file` relay passes `download=1` through, streaming without buffering, with every attachment header derived locally from the requested basename — the same never-trust-the-remote's-headers rule the relay's Content-Type check already applies. The relay also counts the bytes it copies against the `Content-Length` it forwarded: a remote that truncates cleanly (short body, then a close — `b''` from the tunnel, no exception) still ends in this connection closing short, a visibly failed download rather than a keep-alive hang.

## ⚠ Tradeoff to weigh (deliberate, and yours to scope)

This widens what an authenticated dashboard session can read. The text-extension allowlist opens viewing to any text-named path on the kernel's machine, not just session directories — links point all over the disk. And `?download=1` goes further by design: anything on disk is downloadable, no allowlist, no cap. The reasoning: the view allowlist is a rendering choice (what a browser can usefully paint), not a security boundary — the dashboard's owner can already read any file by asking an agent for it, and `/file` sits behind the same token gate as every other route (the browser never interprets a download on this origin: octet-stream + attachment + nosniff). If you want a narrower scope — session-cwd-rooted paths, or view-allowlist-only downloads — the seam is `_file_download`/`_relay_download` plus the 415 offer, and the PR's second commit carries the whole download layer so it can be dropped or reshaped independently of the viewer.

## Tests

- `tests/test_file_view.py` (19): the text allowlist (incl. extensionless names and case), NUL sniff, latin-1 fallback, the 2 MB cap and its message (path, size, limit), 415-vs-404 naming the resolved path, relative-path resolution against the session cwd, and the opener quartet (headless → refusal spoken as a warn, `xdg-open`/`open` per platform, silence only when actually served).
- `tests/test_kernel_preview.py` widened: text serving, the 415-vs-404 split incl. HEAD, download headers, chunked streaming pinned via a recording handler (bounded writes, never one slurp), truncation-closes, `_attachment_disposition` header-injection safety.
- `tests/test_kernel_remote_file_relay.py`: the text relay with a locally-derived type against a lying remote, and the download slice — passthrough provably crossing a chunk boundary intact, locally-derived attachment headers, 404/HEAD/502 pass-through, a cleanly-truncating remote still closing this side's connection short of the forwarded `Content-Length` (pinned by a direct `_relay_download` call with a recording handler — an over-HTTP client's own `Connection: close` masks exactly that bug), and the view relay still declining off-allowlist extensions without asking the remote.
- `ui/webview/file-view.test.ts` (17): openPath host routing, no direct `openFile` posts left in the chat, shell relay + pane-restore pins, viewer singleton/close protocol, loader-first and kernel-words errors, `fileUrl` reuse, `langFor` never guesses, hljs palette parity across both sheets, format prefs with corrupt-entry fallback, DOMPurify-before-innerHTML, wrap-mode span rebalancing, and the Download offer gated to 413/415 only — plus updated pins in four existing webview tests. `tsc --noEmit` clean; existing `test_kernel_open_relative_path.py` passes unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


