### PR TITLE
Canonicalise the judge scratch path before the guards read it

### DIFF
--- a/bin/romp-uninstall
+++ b/bin/romp-uninstall
@@ -182,39 +182,82 @@ echo "==> judge scratch"
 # guard test caught it, and only GNU rm's --preserve-root stopped it.) So require a path
 # that could only be romp's own scratch: absolute, at least two components deep, not $HOME
 # or any ancestor of it, and named for romp. Anything else is skipped loudly, never guessed at.
-_judge_ok=1
-# Claude Code names a project dir after its cwd by replacing EVERY non-alphanumeric character with
-# '-', over the REALPATH — kernel/judge.py's _proj_dir implements exactly that, and this has to
-# agree with it or --purge sweeps a directory that does not exist. A shell `${p//\//-}` replaces
-# only the slashes, which agreed by luck while the scratch was /tmp/romp-judge (no other
-# non-alnum char in it) and stopped agreeing the moment it moved under ~/.local/state: the dot in
-# `.local` survives, so the two spell the same path differently and the transcripts are left
-# behind. Derived here the same way judge.py derives it, so they cannot drift apart again.
-_scratch_slug="$(python3 - "$JUDGE_SCRATCH" <<'PYEOF'
+#
+# Every one of those checks compares STRINGS, and one directory has many spellings: "$HOME/",
+# "$HOME/.", "$STATE//x", a value with a trailing newline, a case variant on a case-insensitive
+# filesystem. Each is a different string for the same directory, so the string checks miss it
+# and the `rm -rf` below does not — a trailing slash alone is enough to walk $HOME past both
+# the equality check and the ancestor pattern. A trailing slash also switches OFF a symlink
+# refusal, because `[[ -L "$p/" ]]` resolves the link instead of lstat'ing it.
+#
+# So canonicalise ONCE, and run every check against the canonical path, so the path that is
+# validated is the path that gets deleted. It happens in python3 (already required above)
+# rather than a shell suffix-trimmer: a trimmer only closes the spellings that sit at the END
+# of the string, and it never sees a trailing newline at all, because $(...) strips that after
+# the trimmer has already run.
+#
+# The same call emits the Claude Code project slug, because that has to be derived from the very
+# same path: Claude Code names a project dir after its cwd by replacing EVERY non-alphanumeric
+# character with '-', over the REALPATH — kernel/judge.py's _proj_dir implements exactly that. A
+# shell `${p//\//-}` replaces only the slashes, which agreed by luck while the scratch was
+# /tmp/romp-judge (no other non-alnum char in it) and stopped agreeing the moment it moved under
+# ~/.local/state: the dot in `.local` survives, so the two spell the same path differently and the
+# transcripts are left behind.
+_judge_lines="$(python3 - "$JUDGE_SCRATCH" "$STATE" "$HOME" <<'PYEOF'
 import os, re, sys
-print(re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(sys.argv[1])))
+
+raw, state, home = sys.argv[1], sys.argv[2], sys.argv[3]
+
+
+def canon(p):
+    """One spelling per directory. Surrounding whitespace goes first (a trailing newline is a
+    different string for the same dir), then a doubled leading slash — which normpath is
+    required to preserve — then normpath collapses '//', '/./' and any trailing slash."""
+    p = re.sub(r"^//+", "/", p.strip())
+    return os.path.normpath(p) if p else ""
+
+
+cp, chome, cstate = canon(raw), canon(home), canon(state)
+ok = (
+    ".." not in raw                     # never resolved away: '..' through a symlink is not lexical
+    and cp.startswith("/")              # absolute...
+    and cp.count("/") >= 2              # ...and at least two components deep
+    # It is romp's scratch or it is not ours: named for romp, OR sitting inside romp's own state
+    # root — the default is "$STATE/judge-scratch", and a custom ROMP_STATE_DIR with no "romp" in
+    # it (say /data/agents) would otherwise fail this and silently skip the teardown.
+    and ("romp" in cp or cp.startswith(cstate + "/"))
+    and cp != chome                     # $HOME itself...
+    and not chome.startswith(cp + "/")  # ...or any ancestor of it
+    and cp != cstate                    # the state root: only --purge removes that, confirmed
+    and not os.path.islink(cp)          # a symlinked scratch is somebody else's directory
+)
+for danger in (chome, cstate):
+    # The last word whenever the path exists. A symlinked or case-variant spelling of $HOME or
+    # the state dir is a different string for the same inode, and no comparison above sees it.
+    try:
+        if ok and os.path.samefile(cp, danger):
+            ok = False
+    except OSError:
+        pass
+# Line 1 the canonical path the rm gets, line 2 the project slug — both off the same `cp`, so the
+# string that was validated and the directory removed below are one and the same.
+sys.stdout.write("%s\n%s\n" % (cp, re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cp))) if ok else "")
 PYEOF
 )"
-case "$JUDGE_SCRATCH" in
-    /*/?*) ;;                                    # absolute AND at least two components
-    *)     _judge_ok="" ;;
-esac
-# It is romp's scratch or it is not ours. Named for romp, OR sitting inside romp's own state root —
-# the default is "$STATE/judge-scratch" now, and a custom ROMP_STATE_DIR with no "romp" in it (say
-# /data/agents) would otherwise fail this check and silently skip the teardown.
-[[ "$JUDGE_SCRATCH" == *romp* || "$JUDGE_SCRATCH" == "$STATE"/?* ]] || _judge_ok=""
-[[ "$JUDGE_SCRATCH" != "$HOME" ]]           || _judge_ok=""
-[[ "$HOME" != "$JUDGE_SCRATCH"/* ]]         || _judge_ok=""   # never an ancestor of $HOME
-[[ "$JUDGE_SCRATCH" != *".."* ]]            || _judge_ok=""
+_judge_scratch="$(printf '%s\n' "$_judge_lines" | sed -n 1p)"
+_scratch_slug="$(printf '%s\n' "$_judge_lines" | sed -n 2p)"
 
-if [[ -z "$_judge_ok" ]]; then
+if [[ -z "$_judge_scratch" ]]; then
     echo "    skipped: '$JUDGE_SCRATCH' doesn't look like romp's judge scratch — remove it yourself" >&2
 else
+    JUDGE_SCRATCH="$_judge_scratch"
     rm -rf "$JUDGE_SCRATCH"
     # The transcripts Claude Code wrote for those judge runs. It names a project dir after the
-    # cwd with '/' → '-'. Derived, not hardcoded, so it follows JUDGE_SCRATCH if that ever moves
-    # — and gated on the same validation above, so this can never resolve to the projects dir
-    # itself or to one of YOUR sessions.
+    # cwd, every non-alphanumeric character to '-', over the realpath. Derived, not hardcoded, so
+    # it follows JUDGE_SCRATCH if that ever moves — and derived from the SAME canonical path the
+    # rm above deleted, so the string that was validated and the target removed here are one
+    # directory. Gated on the same validation above, so this can never resolve to the projects
+    # dir itself or to one of YOUR sessions.
     _judge_proj="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/$_scratch_slug"
     if [[ -d "$_judge_proj" && -n "$_scratch_slug" && "$_judge_proj" != */projects ]]; then
         rm -rf "$_judge_proj"

--- a/tests/romp-uninstall.bats
+++ b/tests/romp-uninstall.bats
@@ -291,3 +291,82 @@ EOF
     done
     [ -d "/tmp" ]
 }
+
+# ── one directory, many spellings ────────────────────────────────────────────
+# Every guard on the scratch path compares strings, and "$HOME" and "$HOME/" are different
+# strings for the same directory — as are "$HOME/.", "$DIR//home", "$DIR/./home" and a value
+# with a trailing newline. Each one walks past the equality checks and reaches the `rm -rf`.
+# These enumerate the spelling CLASS as inputs and assert the protected directory survives,
+# rather than the two or three spellings any one normalisation happens to handle.
+
+@test "romp-uninstall: no spelling of \$HOME reaches rm -rf (trailing slash, /., //, newline)" {
+    # The hole needs a home path that passes the *romp* name check — real ones exist (a user
+    # named after the project, a home under /srv/romp). Everything in it is then at stake.
+    export HOME="$TEST_DIR/romp-home"
+    mkdir -p "$HOME/keep"
+    echo "irreplaceable" > "$HOME/keep/precious.txt"
+    for bad in "$HOME/" "$HOME//" "$HOME/." "$HOME/./" "$HOME/"$'\n' \
+               "$TEST_DIR//romp-home" "$TEST_DIR/./romp-home" "$TEST_DIR/romp-home/."$'\n'; do
+        ROMP_JUDGE_SCRATCH="$bad" run "$CLONE/bin/romp-uninstall" --yes
+        [ -f "$HOME/keep/precious.txt" ]          # the whole home directory, one character away
+        [ "$status" -eq 0 ]                       # skipped loudly, never aborted mid-run
+        [[ "$output" == *"skipped"* ]]
+    done
+}
+
+@test "romp-uninstall: no spelling of the state dir reaches rm -rf — a plain --yes keeps every record" {
+    # The state dir contains "romp" on every default install, so it passes the name check, and
+    # this teardown is NOT gated on --purge. Without an explicit refusal a scratch aimed at the
+    # state root deletes the very records a no---purge uninstall promises to keep — and the
+    # state dir is only ever removed by --purge, behind its own separate confirmation.
+    export ROMP_STATE_DIR="$TEST_DIR/state-romp"
+    mkdir -p "$ROMP_STATE_DIR"
+    echo '{"synthetic":"record"}' > "$ROMP_STATE_DIR/serve-token"
+    for bad in "$ROMP_STATE_DIR" "$ROMP_STATE_DIR/" "$ROMP_STATE_DIR/." "$ROMP_STATE_DIR/"$'\n' \
+               "$TEST_DIR//state-romp" "$TEST_DIR/./state-romp" "$TEST_DIR/state-romp/."$'\n'; do
+        ROMP_JUDGE_SCRATCH="$bad" run "$CLONE/bin/romp-uninstall" --yes
+        [ -f "$ROMP_STATE_DIR/serve-token" ]      # a plain --yes keeps the records, always
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"skipped"* ]]
+    done
+}
+
+@test "romp-uninstall: a symlinked scratch is refused, trailing slash or not" {
+    # A symlink at the scratch path points the teardown at a directory romp never created, so
+    # there is nothing romp-owned under it to clean. Refused on the final component only, so a
+    # symlinked ANCESTOR — a relocated state dir — still works. The trailing-slash spelling is
+    # the one that matters: `[[ -L "$p/" ]]` is FALSE for a symlink to a directory, because the
+    # slash makes the test resolve the link instead of lstat'ing it.
+    export CLAUDE_CONFIG_DIR="$HOME/.claude"
+    mkdir -p "$TEST_DIR/someone-elses-project"
+    echo "not romp's" > "$TEST_DIR/someone-elses-project/keep.txt"
+    ln -s "$TEST_DIR/someone-elses-project" "$TEST_DIR/romp-judge"
+    for spell in "$TEST_DIR/romp-judge/" "$TEST_DIR/romp-judge"; do
+        ROMP_JUDGE_SCRATCH="$spell" run "$CLONE/bin/romp-uninstall" --yes
+        # `rm -rf "$link/"` cannot unlink the link, so it empties the directory behind it.
+        [ -f "$TEST_DIR/someone-elses-project/keep.txt" ]
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"skipped"* ]]
+        [ -L "$TEST_DIR/romp-judge" ]
+    done
+}
+
+@test "romp-uninstall: romp's own scratch is still cleaned when spelt with // or a trailing slash" {
+    # Normalising must not become a reason to SKIP a legitimate scratch: "$DIR//romp-judge" and
+    # "$DIR/romp-judge/" both name romp's own directory and must still be torn down, transcripts
+    # and all.
+    export CLAUDE_CONFIG_DIR="$HOME/.claude"
+    scratch="$TEST_DIR/romp-judge"
+    for spell in "$TEST_DIR//romp-judge" "$scratch/" "$scratch/."; do
+        mkdir -p "$scratch"
+        proj="$CLAUDE_CONFIG_DIR/projects/$(_proj_slug "$scratch")"
+        mkdir -p "$proj"
+        echo '{"synthetic":"judge call"}' > "$proj/11111111-2222-3333-4444-555555555555.jsonl"
+
+        ROMP_JUDGE_SCRATCH="$spell" run "$CLONE/bin/romp-uninstall" --yes --purge
+        [ "$status" -eq 0 ]
+        [[ "$output" != *"skipped:"* ]]           # NOT skipped — it is romp's own
+        [ ! -d "$scratch" ]
+        [ ! -d "$proj" ]
+    done
+}


### PR DESCRIPTION
## What

`ROMP_JUDGE_SCRATCH` is validated by string comparison, but the `rm -rf` it guards resolves paths the way the kernel does. One directory has many spellings, so several values name a directory the guards mean to refuse while matching none of them.

Reachable on a plain `--yes` with **no `--purge`** — this teardown is not gated on `--purge`:

| value | result on `main` today |
|---|---|
| `ROMP_JUDGE_SCRATCH="$STATE"` | **`$STATE` deleted.** Every recorded session, summary and message a no-`--purge` uninstall promises to keep. |
| `"$STATE/"`, `"$DIR//romp"`, `"$DIR/./romp"` | same |
| `"$HOME/"`, `"$HOME//"`, `"$DIR//home"`, `"$DIR/./home"` | **`$HOME` deleted**, when the home path contains `romp` |
| `"$HOME/."`, `"$HOME/./"` | uninstall aborts mid-run (GNU rm refuses a `.` path) |
| a symlinked scratch spelt with a trailing slash | **the link's target is emptied** — `rm -rf "$link/"` can't unlink the link, so it recurses into the directory behind it |

The state-dir case needs no mangling at all: `$STATE` contains `romp` on every default install, so it passes the `*romp*` name check, and nothing else refuses the state root. The `$HOME` cases need a home path containing `romp` to clear the same check — real ones exist (a user named after the project, a home under `/srv/romp`) but it is a precondition, not the common case. `"$HOME"` on its own is already refused; `"$HOME/"` is one character away and passes both the equality check and the ancestor pattern.

**Preconditions, stated plainly.** All of these require `ROMP_JUDGE_SCRATCH` to be set in the environment running the uninstaller. Nothing in romp sets it — `kernel/judge.py` hardcodes `JUDGE_SCRATCH = "/tmp/romp-judge"` and never reads the variable, so it is an uninstaller-only override. This is not remotely triggerable and there is no attacker in the story: it is a guard that is supposed to refuse dangerous values and doesn't. The default `/tmp/romp-judge` path is not affected.

Two things I checked and am **not** claiming:

- A trailing newline (`"$STATE/"$'\n'`) walks past every guard but is inert on `main` — the path doesn't exist, so `rm -rf` no-ops. It is in the tests because it is part of the class and goes live under any normalisation that trims suffixes in the shell (a shell trimmer never sees the newline at all: `$(...)` strips it only *after* the trimmer has run).
- A symlinked scratch spelt *without* a trailing slash only removes the link on `main` today. It matters more once the slug is derived from `realpath` — see the note on #379 below.

## Fix

Canonicalise once, and run every check against the canonical path, so the path that is validated is the path that gets deleted. Done in `python3` — already required twice in this script — rather than a shell suffix-trimmer, which only closes the spellings at the end of the string.

- `os.path.normpath` after stripping surrounding whitespace and collapsing a leading `//` (which normpath is required to preserve) handles `//`, `/./` and trailing slashes.
- The checks the shell already made move across unchanged.
- Two are new: the state root itself, which only `--purge` removes and only behind its own confirmation; and a symlinked final component, which romp never created and which a `rm -rf "$link/"` would empty. A symlinked *ancestor* — a relocated state dir — still works.
- `os.path.samefile` is a second layer, for the spellings no string comparison can see: a case variant on a case-insensitive filesystem, a symlinked `$HOME` or `$STATE`. It applies whenever the path actually exists, which is the only case where anything can be destroyed.
- `..` is still refused on the raw value rather than normalised away: `..` through a symlink is not lexical, so collapsing it would point the `rm` at a different directory than the one checked.

The project-dir slug keeps the existing `${p//\//-}` rule and only changes the input it is derived from, so it now comes from the same canonical path the `rm` deleted.

## Tests

Four cases in `tests/romp-uninstall.bats`, enumerating the spelling class as *inputs* rather than the two or three spellings any one normalisation happens to handle — trailing slash, `/.`, `//`, `/./`, trailing newline, internal `//` and `/./`, aimed at both `$HOME` and the state dir — plus the symlink case with and without the slash, and a positive case: romp's own scratch is still torn down, transcripts and all, when spelt with `//` or a trailing slash.

All four were run against the unfixed script and fail there, each on the data assertion (the protected file is gone), not on a message assertion. 17/17 pass with the fix; the Python suite is unchanged at 4551 passed / 40 skipped.

## Note for whoever merges this alongside #379

#379 also edits this block. They conflict in two places in `bin/romp-uninstall` (the guard block, and one comment); the bats file auto-merges. Either order works, but merging **this one first** is worth considering: #379 moves the slug to `os.path.realpath` without a symlink guard, which means the validated string and the deleted target stop being the same path — a symlinked scratch would resolve the slug through the link and `rm -rf` the user's own `~/.claude/projects/<their-project>` on a plain `--yes`. The `islink` refusal here closes that before #379 can open it.

Resolving the conflict: keep this PR's python block, and fold in #379's two additions — its widened name rule becomes `("romp" in cp or cp.startswith(cstate + "/"))`, and its slug (`re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(...))`) moves into the same python call, emitted from the canonical path. One line in the merged test file also needs updating: the positive case builds its expected project dir with `${scratch//\//-}`, which must become `$(_proj_slug "$scratch")` under #379's slug rule. The auto-merge will not flag it.

## Known remaining edge

Only equality with `$STATE` is refused, not ancestry. On a default install the `romp` name check covers it, since `$STATE` is `~/.local/state/romp` and no ancestor contains `romp`. With a custom `ROMP_STATE_DIR` like `/data/romp-state/x`, the ancestor `/data/romp-state` would still be accepted. Happy to widen it if you want that closed too.

macOS is unverified here — I avoided `realpath` on the path components so the slug is unchanged there, but the `samefile` layer is only exercised on Linux in this run.
