### PR TITLE
postal bats setup fails loudly when the bus never comes up (de-flakes CI)

### DIFF
--- a/tests/romp-postal.bats
+++ b/tests/romp-postal.bats
@@ -36,7 +36,21 @@ setup() {
 
     "$POSTAL" serve >/dev/null 2>&1 &
     BUS_PID=$!
-    for _ in $(seq 1 50); do curl -s "127.0.0.1:$ROMP_POSTAL_PORT/ping" >/dev/null 2>&1 && break; sleep 0.1; done
+    # Readiness is load-bearing: every test assumes the bus is up, and proceeding without it surfaces as a
+    # confusing DOWNSTREAM failure (a 2026-08-14 CI runner lost this race: "remote --force" probed a port
+    # the bus hadn't bound yet and failed three asserts later, reading like a tunnel bug). Fail HERE,
+    # naming the real problem. A dead bus process is the early exit; the doubled bound is only a backstop.
+    local up=0 _
+    for _ in $(seq 1 100); do
+        curl -s "127.0.0.1:$ROMP_POSTAL_PORT/ping" >/dev/null 2>&1 && { up=1; break; }
+        kill -0 "$BUS_PID" 2>/dev/null || break
+        sleep 0.1
+    done
+    if [ "$up" != 1 ]; then
+        local alive=no; kill -0 "$BUS_PID" 2>/dev/null && alive=yes
+        echo "# setup: postal bus never came up on 127.0.0.1:$ROMP_POSTAL_PORT (pid $BUS_PID, alive=$alive)" >&2
+        return 1
+    fi
 }
 
 teardown() {


### PR DESCRIPTION
The bats job on the artifact-removal PR failed on an unrelated postal test: `remote --force with the bus reachable` printed the not-connected tunnel instructions and exited nonzero. Root cause is in the suite's `setup()`: it starts the per-test bus, polls `/ping` for up to 5s, and on exhaustion proceeds SILENTLY — so a slow or dead bus surfaces as a confusing downstream failure instead of naming itself (the silent-degrade shape the repo rules ban).

Mechanism proven, not assumed, with a delayed-bus harness on scratch copies:
- old setup + 6s-delayed bus → the exact CI failure signature (downstream, tunnel instructions)
- fixed setup + 6s delay → passes (bound doubled to 10s absorbs slow starts)
- fixed setup + 12s delay → fails in setup, loudly: `postal bus never came up on 127.0.0.1:<port> (pid <pid>, alive=yes)`

A dead bus process now exits the wait immediately (`kill -0`), rather than waiting out the clock. Full postal suite green locally (21/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)