### PR TITLE
Distiller notes: a user-editable style memory for the prose judges

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -186,6 +186,15 @@ stretch after your follow-up, so the takeaway is the update, never a recap.
 May cite a `SOURCE: mN` line, parsed into the summary's deep link; a cite
 that misses logs and chips the card instead of failing.
 
+**Distiller notes.** Every judge that writes prose you read — distiller,
+briefer, staller, captioner, gister, archiver — also carries your standing
+style notes, when you keep any: `~/.config/romp/distiller-notes.md` is read
+at call time (no restart needed) and appended to the prompt, notes winning
+over prompt defaults on conflict. Plain language, e.g. "never cite PR or
+commit numbers; say what the change does". Delete the file and the next
+call runs bare. The placement judges and the courier never see it: those
+emit verdicts and agent-directed copy, not prose for you.
+
 **briefer.** When a top card blocks (and live for the focused picker or
 permission goal): a decision brief that leads with exactly what you must
 decide or provide, then options and tradeoffs. Same `SOURCE:` contract as

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -710,6 +710,41 @@ def _judge_env(tier, auth="login"):
 _RATE_GATE_LOGGED = {}                   # bucket -> resets_at already announced (one line per window)
 
 
+# ───────────────────────── distiller notes (the user's standing style memory) ─────────────────────────
+# The prose judges write copy the USER reads (takeaways, decision briefs, stall notes, captions, resume
+# rows). This file is their standing style memory: plain-language notes on how that copy should read
+# (the user 2026-08-14, whose first note bans PR/commit numbers in favor of what the change does).
+# Read at CALL time like the other ~/.config/romp knobs, so an edit applies from the very next call, no
+# restart; $ROMP_DISTILLER_NOTES overrides the path (the test seam). Absent/empty/unreadable → "" and no
+# section: no notes is a normal state, not a degraded source — the file itself IS the authoritative
+# source. Capped so a runaway file cannot bloat every prompt. The PLACEMENT judges (planner, opener,
+# placer, grouper, closer, unblocker) are deliberately excluded — they emit verdicts, not user-facing
+# prose — and so is the courier, whose copy is read by AGENTS in the user's voice: style notes about
+# what the user wants to READ must never leak into what an agent is asked to DO.
+_USER_NOTES_JUDGES = frozenset({"distiller", "briefer", "staller", "captioner", "gister", "archiver"})
+_USER_NOTES_CAP = 4000
+
+
+def _user_notes():
+    try:
+        p = Path(os.environ.get("ROMP_DISTILLER_NOTES") or os.path.expanduser("~/.config/romp/distiller-notes.md"))
+        return p.read_text(errors="replace").strip()[:_USER_NOTES_CAP]
+    except OSError:
+        return ""
+
+
+def _with_user_notes(sys_prompt, judge):
+    """sys_prompt, plus the user's standing notes when this judge writes prose the user reads."""
+    if judge not in _USER_NOTES_JUDGES:
+        return sys_prompt
+    notes = _user_notes()
+    if not notes:
+        return sys_prompt
+    return (sys_prompt + "\n\nThe user keeps standing notes on how the prose you write for them should "
+            "read. They are style preferences, not material: never quote, mention, or answer them. Where "
+            "a note conflicts with the rules above, the note wins:\n<user-notes>\n" + notes + "\n</user-notes>")
+
+
 def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage"):
     """Run ONE judge model call. ..."""
     _judge_ctx.paused = False                         # a SKIPPED-because-paused call is not a failure: the
@@ -742,6 +777,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage"):
     except Exception:
         pass
     fsid = getattr(_judge_ctx, "fsid", None)
+    sys_prompt = _with_user_notes(sys_prompt, judge)  # the user's standing style notes ride every prose call
     auth = _judge_auth(fsid)                          # this call bills what the judged session bills
     env = _judge_env(tier, auth)
     # Per-tier effort from the gear (STATE/judge-effort | index-effort) when the caller didn't pass one — "" or

--- a/tests/test_judge_user_notes.py
+++ b/tests/test_judge_user_notes.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Tests for the distiller notes seam (kernel/judge.py): the user's standing style memory
+($ROMP_DISTILLER_NOTES / ~/.config/romp/distiller-notes.md) rides every PROSE judge call's
+system prompt — and only those. All fixtures are SYNTHETIC (invented text, TESTHOST)."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import SimpleNamespace
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the load — the module resolves its state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+jd = SourceFileLoader("romp_judge_notes", os.path.join(BIN, "romp-judge")).load_module()
+
+
+class WithUserNotes(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        self.notes = Path(self.td) / "distiller-notes.md"
+        os.environ["ROMP_DISTILLER_NOTES"] = str(self.notes)
+
+    def tearDown(self):
+        os.environ.pop("ROMP_DISTILLER_NOTES", None)
+
+    def test_prose_judges_get_notes_and_placement_judges_never_do(self):
+        self.notes.write_text("Never cite ticket numbers; say what the change does.")
+        for j in sorted(jd._USER_NOTES_JUDGES):
+            out = jd._with_user_notes("SYS RULES", j)
+            self.assertTrue(out.startswith("SYS RULES"), j)
+            self.assertIn("<user-notes>", out, j)
+            self.assertIn("Never cite ticket numbers", out, j)
+        # the verdict judges and the courier (agent-directed copy) stay bare — style notes about what
+        # the user wants to READ must not leak into placement judgments or injected messages
+        for j in ("planner", "opener", "placer", "grouper", "closer", "unblocker", "courier", None):
+            self.assertEqual("SYS RULES", jd._with_user_notes("SYS RULES", j), str(j))
+
+    def test_absent_empty_or_whitespace_file_means_the_bare_prompt(self):
+        self.assertEqual("SYS", jd._with_user_notes("SYS", "distiller"))   # no file at all
+        self.notes.write_text("   \n\t\n")                                 # whitespace only
+        self.assertEqual("SYS", jd._with_user_notes("SYS", "distiller"))
+
+    def test_notes_are_capped_so_a_runaway_file_cannot_bloat_prompts(self):
+        self.notes.write_text("x" * (jd._USER_NOTES_CAP + 5000))
+        out = jd._with_user_notes("SYS", "distiller")
+        body = out.split("<user-notes>\n", 1)[1].rsplit("\n</user-notes>", 1)[0]
+        self.assertEqual(len(body), jd._USER_NOTES_CAP)
+
+    def test_transport_carries_notes_inside_the_distillers_system_prompt(self):
+        self.notes.write_text("Speak plainly about TESTHOST changes.")
+        seen = {}
+
+        def fake_run(cmd, **kw):
+            seen["cmd"] = [str(c) for c in cmd]
+            return SimpleNamespace(returncode=0, stderr="",
+                                   stdout=json.dumps({"result": "BACKGROUND: b\nTAKEAWAY: t",
+                                                      "usage": {"input_tokens": 1, "output_tokens": 1},
+                                                      "total_cost_usd": 0}))
+
+        orig = jd.subprocess.run
+        jd.subprocess.run = fake_run
+        try:
+            out = jd.distill_llm("a synthetic goal", "some synthetic work")
+        finally:
+            jd.subprocess.run = orig
+        self.assertIn("TAKEAWAY", out)
+        joined = "\n".join(seen["cmd"])
+        self.assertIn("Speak plainly about TESTHOST changes.", joined)
+        self.assertIn("the note wins", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The user asked (2026-08-14) for a local memory configuring what the distiller says. This adds one: `~/.config/romp/distiller-notes.md`, plain-language standing notes on how romp's user-facing prose should read, appended at call time to the system prompt of every prose judge (distiller, briefer, staller, captioner, gister, archiver), notes winning over prompt defaults on conflict.

Design points:
- Read at CALL time like the other `~/.config/romp` knobs; an edit applies from the very next judge call, no restart. `$ROMP_DISTILLER_NOTES` overrides the path (the test seam).
- Absent/empty/unreadable file → bare prompt; no notes is a normal state, not a degraded source.
- Capped at 4000 chars so a runaway file cannot bloat every prompt.
- The placement judges (planner/opener/placer/grouper/closer/unblocker) and the courier never see it: they emit verdicts and agent-directed copy, and style notes about what the user wants to READ must not leak into what an agent is asked to DO (the injected-voice rule).

Tests: `tests/test_judge_user_notes.py` — inclusion/exclusion per judge, absence/whitespace tolerance, the cap, and a transport-level test proving the notes ride inside the distiller's system prompt argv. Judge suite (419) and distill paragraph contract (17) green locally alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)