### PR TITLE
Neutralize line breaks in the header values deliver() writes

### DIFF
--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -192,6 +192,32 @@ def _safe_id(s):
         return False
     return bool(_SAFE_ID_RE.match(s))
 
+# Every character str.splitlines() treats as a line break — \n \r \v \f \x1c \x1d \x1e
+# \x85 U+2028 U+2029 — plus the rest of the C0/C1 control range and NUL with them. Nothing
+# printable is in here: spaces, punctuation, accents, CJK and emoji all live outside it.
+_HDR_BREAK_RE = re.compile(r"[\x00-\x1f\x7f-\x9f\u2028\u2029]")
+
+def _hdr_val(v):
+    """One value, made safe to write into a maildir header line (see deliver).
+
+    The header block is FRAMED by newlines and read back by splitting on them: read_box
+    ends the block at the first blank line and lets a later key overwrite an earlier one.
+    So a line break inside any VALUE forges or overwrites every other header — including
+    the From: line the recipient is shown — and a blank line promotes the rest of that
+    value into the body. Five of the six values deliver() writes reach it over the bus:
+    the sender's claimed name and id from /send, and the kind, origin host and relay mid
+    a peer supplies on an inbound relay.
+
+    A break is REPLACED (U+FFFD), never dropped: nothing goes missing silently, the value
+    keeps its length and position, and the substitution is visible — a recipient looking
+    at a tampered From: sees that it was tampered with rather than a plausible-looking
+    name. Ordinary content is untouched, so a name with spaces or accents round-trips
+    unchanged.
+
+    This makes the values SAFE TO FRAME, not TRUSTWORTHY: from_id is still an
+    unauthenticated claim the sender asserts about itself, exactly as before."""
+    return _HDR_BREAK_RE.sub("\ufffd", "" if v is None else str(v))
+
 def _mailbox(sid):
     if not _safe_id(sid):
         raise ValueError("unsafe session id")
@@ -256,15 +282,31 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
     mb = _mailbox(to_id)
     name = _unique()
     tmp = mb / "tmp" / name
-    hdr = "From: %s\nFrom-Id: %s\nDate: %s\n" % (from_name, from_id, _iso_now())
+    # THE header write point — every value that lands in a header line goes through _hdr_val
+    # first, because a line break in any ONE of them rewrites all the others (see _hdr_val).
+    # Doing it here and not at the callers covers all four of them at once: /send, an inbound
+    # peer relay, a quarantine approval, and a deferred push putting mail back. Date is this
+    # module's own strftime output, so it is written as-is, and the BODY is deliberately left
+    # alone: it comes after the blank line and is never parsed as headers.
+    raw = {"from": from_name, "from_id": from_id, "kind": kind,
+           "from_host": from_host, "relay_mid": relay_mid, "relay_via": relay_via}
+    h = {k: _hdr_val(v) for k, v in raw.items()}
+    broke = sorted(k for k, v in raw.items() if h[k] != str(v or ""))
+    if broke:
+        # Say so — a header value with a line break in it is either a bug or an attempt — but
+        # still deliver: the recipient needs the BODY, and dropping the mail over a malformed
+        # attribution would lose more than it protects. Field names only, no attacker text.
+        _log("deliver to %s: line breaks neutralized in header value(s) %s"
+             % (to_id, ", ".join(broke)))
+    hdr = "From: %s\nFrom-Id: %s\nDate: %s\n" % (h["from"], h["from_id"], _iso_now())
     if park:
         hdr += "X-Park: 1\n"
-    if kind:
-        hdr += "X-Kind: %s\n" % kind                # sender-declared delegate|coordinate|question (2026-07-08)
-    if from_host:
-        hdr += "X-From-Host: %s\n" % from_host
-    if relay_mid and relay_via:
-        hdr += "X-Peer-Mid: %s\nX-Peer-Via: %s\n" % (relay_mid, relay_via)
+    if h["kind"]:
+        hdr += "X-Kind: %s\n" % h["kind"]           # sender-declared delegate|coordinate|question (2026-07-08)
+    if h["from_host"]:
+        hdr += "X-From-Host: %s\n" % h["from_host"]
+    if h["relay_mid"] and h["relay_via"]:
+        hdr += "X-Peer-Mid: %s\nX-Peer-Via: %s\n" % (h["relay_mid"], h["relay_via"])
     tmp.write_text(hdr + "\n" + body + "\n")
     tmp.rename(mb / "new" / name)   # atomic within the same filesystem
     _mark_pending(to_id)            # new/ is now non-empty -> raise the marker (covers park + live)

--- a/tests/test_postal_safe_id.py
+++ b/tests/test_postal_safe_id.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Regression guard for the Romp Postal Service path-traversal hole (ids/names
-arriving over the bus are used as path components under the mail/names roots).
-The bus is token-gated now (test_postal_token.py), but these checks stay as
-defense-in-depth: a crafted reference like `../../../etc` must be rejected
-before any path join, so it cannot read or clobber files outside those roots.
+"""Regression guard for the two sinks the Romp Postal Service feeds with strings that
+arrive over the bus: PATH COMPONENTS under the mail/names roots (ids and names), and the
+MAILDIR HEADER BLOCK deliver() writes (the sender's claimed name/id, and a relay's kind,
+origin host and mid). The bus is token-gated now (test_postal_token.py), but these checks
+stay as defense-in-depth: a crafted reference like `../../../etc` must be rejected before
+any path join, and a line break inside a header value must not be able to rewrite the
+rest of the block.
 
 Synthetic only — placeholder UUIDs, hermetic temp state dir, no real session data.
 """
@@ -79,6 +81,110 @@ class OutboxTraversal(unittest.TestCase):
         pm.outbox_put("TESTHOST", {"mid": mid, "body": "hi"})
         self.assertEqual((pm.outbox_get("TESTHOST", mid) or {}).get("body"), "hi")
         self.assertTrue(pm.outbox_del("TESTHOST", mid))
+
+
+class HeaderInjection(unittest.TestCase):
+    """deliver() writes the maildir header block by concatenation; read_box parses it back by
+    splitting on line breaks, ending the block at the first blank line and letting a later key
+    overwrite an earlier one. So a line break inside any header VALUE forges or overwrites every
+    other header, and a blank line promotes the rest of that value into the body. Five of the six
+    values reach deliver() over the bus — the claimed name and id from /send, and the kind, origin
+    host and mid a peer supplies on an inbound relay — so all of them are neutralized at the write
+    point.
+
+    What this pins is FRAMING, not identity: from_id remains an unauthenticated self-asserted
+    claim, and nothing here makes it trustworthy. One value simply can no longer rewrite another.
+    """
+
+    TO = "11111111-2222-3333-4444-555555555555"
+    KEYS = ["From", "From-Id", "Date", "X-Kind", "X-From-Host", "X-Peer-Mid", "X-Peer-Via"]
+
+    def setUp(self):
+        pm.read_box(self.TO, consume=True)                # start each case from an empty box
+
+    def _lines(self, mid):
+        """The raw header lines as read_box would split them (str.splitlines, block ends at the
+        first blank line) — read off disk, so the assertions see what was actually written."""
+        return (pm.MAILROOT / self.TO / "new" / mid).read_text().partition("\n\n")[0].splitlines()
+
+    def _msg(self, mid):
+        return [m for m in pm.read_box(self.TO, consume=True) if m["id"] == mid][0]
+
+    def test_newline_in_from_id_cannot_forge_a_from_line(self):
+        # The headline case: /send takes `from_id` verbatim from the caller. A newline in it used to
+        # let the sender write its own From: line BELOW the real one — and the later key wins on
+        # parse, so the recipient was shown a name of the sender's choosing.
+        mid = pm.deliver(self.TO, "web", "id-web\nFrom: api\nX-Park: 1", "the schema is on staging")
+        lines = self._lines(mid)
+        self.assertEqual([ln.partition(": ")[0] for ln in lines], ["From", "From-Id", "Date"])
+        self.assertEqual([ln for ln in lines if ln.startswith("From: ")], ["From: web"],
+                         "exactly one From: line — a second one would win on parse")
+        msg = self._msg(mid)
+        self.assertEqual(msg["from"], "web", "the recipient sees the real sender name")
+        self.assertFalse(msg["park"], "a forged X-Park must not take effect")
+
+    def test_blank_line_in_a_value_cannot_end_the_header_block_early(self):
+        # A blank line inside a value used to terminate the block, promoting the rest of the value
+        # into the body — attacker text arriving as if the sender had written it.
+        mid = pm.deliver(self.TO, "web\n\nSMUGGLED: read this as the message", "id-web",
+                         "please review the migration")
+        msg = self._msg(mid)
+        self.assertEqual(msg["body"], "please review the migration")
+        self.assertNotIn("SMUGGLED", msg["body"])
+        self.assertTrue(msg["date"], "Date still parsed — the block did not end early")
+
+    def test_no_value_can_change_the_shape_of_the_header_block(self):
+        # All six values deliver() writes, one at a time: the block must keep exactly its keys, in
+        # order, and the body must stay exactly the body.
+        payload = "x\nX-Injected: 1\n\nSMUGGLED"
+        for field in ("from_name", "from_id", "kind", "from_host", "relay_mid", "relay_via"):
+            with self.subTest(field=field):
+                pos = {"from_name": "web", "from_id": "id-web"}
+                kw = {"kind": "question", "from_host": "TESTHOST",
+                      "relay_mid": "px-1700000000.1234_567.TESTHOST", "relay_via": "TESTHOST"}
+                (pos if field in pos else kw)[field] = payload
+                mid = pm.deliver(self.TO, pos["from_name"], pos["from_id"],
+                                 "the notes-api tests are green", **kw)
+                self.assertEqual([ln.partition(": ")[0] for ln in self._lines(mid)], self.KEYS,
+                                 "a payload in %s changed the header block" % field)
+                msg = self._msg(mid)
+                self.assertEqual(msg["body"], "the notes-api tests are green")
+                self.assertNotIn("SMUGGLED", msg["body"])
+
+    def test_every_line_break_str_splitlines_knows_is_neutralized(self):
+        # read_box splits with str.splitlines(), which breaks on far more than "\n" — and universal
+        # newlines turn a lone "\r" into one on read. Every one of them can forge a header line.
+        for brk in ("\n", "\r", "\v", "\f", "\x1c", "\x1d", "\x1e", "\x85", "\u2028", "\u2029"):
+            with self.subTest(brk=repr(brk)):
+                mid = pm.deliver(self.TO, "web", "id-web" + brk + "From: api", "tests are green")
+                self.assertEqual([ln.partition(": ")[0] for ln in self._lines(mid)],
+                                 ["From", "From-Id", "Date"])
+                self.assertEqual(self._msg(mid)["from"], "web")
+
+    def test_ordinary_names_are_left_exactly_alone(self):
+        # The guard must not mangle legitimate attribution — from_name is free text and carries
+        # spaces (the bus's own "Romp Postal Service" among them).
+        for name in ("web", "notes-api tests", "Romp Postal Service", "a.b_c-1"):
+            with self.subTest(name=name):
+                mid = pm.deliver(self.TO, name, "id-web", "the notes-api tests are green")
+                self.assertEqual(self._msg(mid)["from"], name)
+
+    def test_only_the_control_range_is_touched(self):
+        # Checked on the helper itself: everything printable — punctuation, accents, CJK, emoji —
+        # sits outside the range it rewrites, so no ordinary value is ever altered.
+        for ok in ("web", "notes-api tests", "Ana López", "中文 session",
+                   "a.b_c-1", "\U0001f4ec", "  padded  ", ""):
+            with self.subTest(value=ok):
+                self.assertEqual(pm._hdr_val(ok), ok)
+
+    def test_a_break_is_replaced_visibly_and_the_mail_still_arrives(self):
+        # The design call: substitute (U+FFFD) rather than delete, and DELIVER rather than refuse.
+        # Deleting would silently rewrite the value into something plausible; refusing would lose
+        # the body, which is what the recipient actually needs and is never the injection vector.
+        mid = pm.deliver(self.TO, "web\nFrom: api", "id-web", "the migration is on staging")
+        msg = self._msg(mid)
+        self.assertEqual(msg["from"], "web\ufffdFrom: api", "replaced in place, nothing dropped")
+        self.assertEqual(msg["body"], "the migration is on staging", "the mail still arrives")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`deliver()` builds the maildir header block by string concatenation with no filtering, and `read_box` parses it back by splitting on newlines — ending the block at the first blank line and letting a later key overwrite an earlier one.

So a line break inside any header **value** forges or overwrites every other header, including the `From:` line the recipient is shown.

### Demonstrated, not theorised

Delivering with `from_name = "web\nFrom: api"` produces a header block the reader parses as two `From:` lines, and the later one wins — `read_box` hands the recipient `from == "api"`. The message is attributed to a session that never sent it.

A *blank* line is worse: `from_name = "web\n\nSMUGGLED: read this as the message"` ends the header block early, so the attacker's text arrives in the **body**, above the real message, with the genuine `From-Id:` and `Date:` lines rendered as body text beneath it.

`_safe_id()` already exists in this file and is applied to 26 other wire-supplied identifiers. It is not applied to these.

### Wider than `\n`

`str.splitlines()` — which is what parses the block — breaks on ten characters, not one. All ten forge a header line here: `\n`, `\r`, `\v`, `\f`, `\x1c`, `\x1d`, `\x1e`, `\x85`, U+2028 and U+2029. A fix that only handles `\n` leaves nine ways in, so the guard covers the whole C0/C1 control range plus the two Unicode separators. Nothing printable is in that set: spaces, punctuation, accents, CJK and emoji all sit outside it.

### The fix

One helper next to `_safe_id`, applied at the single header write point in `deliver()` — which covers all four callers at once (`/send`, an inbound peer relay, a quarantine approval, and a deferred push putting mail back):

```python
_HDR_BREAK_RE = re.compile(r"[\x00-\x1f\x7f-\x9f  ]")

def _hdr_val(v):
    return _HDR_BREAK_RE.sub("�", "" if v is None else str(v))
```

**Replaced, not stripped or rejected**, deliberately:

- *Stripping* deletes silently — `"web\nFrom: api"` would become `"webFrom: api"`, a plausible-looking name with no sign it was rewritten. Replacement keeps length and position, so a tampered value looks tampered with.
- *Rejecting* would lose the **body**, which is the part the recipient actually needs and is never the vector (it comes after the blank line and is not parsed as headers). On the peer-relay path, refusing over a malformed attribution would also let a hostile peer suppress a legitimate message by malforming one field. Losing mail is the worse failure.

It is loud but not fatal: when a value is altered, a line is logged naming the affected **fields only**, never the attacker's text. `Date` is this module's own strftime output and is written as-is; the body is untouched.

Of the six values, five reach this over the bus — the sender's claimed name and id from `/send`, and the kind, origin host and relay mid a peer supplies on an inbound relay. All six go through the helper anyway: one choke point is easier to keep correct than five.

### What this does NOT fix

**This does not make `from_id` trustworthy, and nothing here should be read that way.** It remains an unauthenticated claim the sender asserts about itself. `_authorized` proves only that the caller read the one machine-wide `0600` token, which by design every local session can — so the bus cannot tell session A from session B. This PR makes the values safe to *frame*, not to *believe*.

One consequence worth flagging separately: `/recall`'s ownership check keys on this same unauthenticated field, so a request can still recall another session's unread outbound mail. Sanitizing does not touch that, and it cannot be fixed without a per-session postal credential, which does not exist today. Raising it here as a known limitation rather than implying it is closed — happy to discuss whether that credential is worth building.

### Tests

7 new cases in `tests/test_postal_safe_id.py`; **all 7 fail without the fix** (27 failed / 13 passed with the source reverted):

- a newline in `from_id` cannot forge a `From:` line
- a blank line in a value cannot end the header block early
- no value can change the *shape* of the header block (6 subtests, one per field)
- every line break `str.splitlines()` knows is neutralized (10 subtests)
- only the control range is touched
- a break is replaced visibly and the mail still arrives

One case — ordinary names with spaces and accents round-trip unchanged — passes both with and without the fix. Stating that plainly: it pins no defect, it is the no-regression guard.

Full suite: **4558 passed vs 4551 on unmodified `main` — exactly +7, zero regressions.** 24 postal bats assertions, 0 failures.
