### PR TITLE
Hydrate only mail this session actually received

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11312,6 +11312,22 @@ _CLI_SEND_RE = re.compile(   # capture the optional --kind that rides between se
     # alias — and old transcripts (whose Bash rows this matcher re-reads forever) only have the latter.
     r"\bromp\s+(?:--)?mail\s+send\s+(?:--kind\s+(delegate|coordinate|question)\s+)?([A-Za-z0-9._-]+)\s+([\s\S]+)$")
 
+# The MAIL READERS — the only tools whose OUTPUT can carry the postal formatter's romp-msg-id
+# markers (format_inbox / format_push, the postal service's documented consumer contract). Every
+# OTHER tool output is text the agent merely READ: a file, a fetched page, a grep hit, its own echo
+# of mail it already received. Scanning those let any such text swap a Bash/Read/WebFetch row out of
+# the chat for a postal card, so the scan is scoped to the readers plus user text (which is how the
+# kernel actually delivers mail: the Stop-hook drain's block reason and the pane/socket push both
+# land as user records). check_sent is NOT here: format_receipts prints no marker, and the rows it
+# lists are mail this session SENT — a to_id that is never ours, so scanning it could only ever
+# produce false unresolved reports.
+_INBOX_TOOL_RE = re.compile(r"(?:^|__)check_inbox$")   # the MCP tool, bare or mcp__<server>__ prefixed
+_CLI_MAIL_READ_RE = re.compile(
+    # `romp mail inbox|recv|peek`, the permanent `romp --mail` alias, `romp-postal-service` direct,
+    # and the drain the Stop hook runs — all print format_inbox. ANCHORED at a command position so a
+    # command that merely MENTIONS the subcommand (grep "romp mail inbox" …) is not a mail read.
+    r"(?:\A|[;&|\n])\s*romp(?:-postal-service|\s+(?:--)?mail)\s+(?:inbox|recv|peek|drain)\b")
+
 _POSTAL_KINDS = ("delegate", "coordinate", "question")
 
 
@@ -11412,10 +11428,44 @@ def _cli_send_card(ev):
             "ts": ev.get("ts"), "uuid": ev.get("uuid")}
 
 
-def _hydrate_postal(events, index):
+def _bash_command(ev):
+    """The `command` string of a Bash tool event. build_session stores a tool input as JSON
+    ({"command": …, "description": …}); anything that isn't that shape (a raw command string, a
+    4000-char truncation) is returned as-is for the caller's own matcher to judge."""
+    raw = ev.get("input") or ""
+    try:
+        args = json.loads(raw)
+    except Exception:
+        return raw
+    return args["command"] if isinstance(args, dict) and isinstance(args.get("command"), str) else raw
+
+
+def _reads_mail(ev):
+    """Is this tool event a MAIL READER — one whose output legitimately carries romp-msg-id markers?
+    check_inbox, or a Bash mail-read subcommand. Everything else is text the agent merely read."""
+    if ev.get("kind") != "tool":
+        return False
+    if _INBOX_TOOL_RE.search(ev.get("name") or ""):
+        return True
+    return ev.get("name") == "Bash" and bool(_CLI_MAIL_READ_RE.search(_bash_command(ev)))
+
+
+def _postal_addressed_to(rec, sid):
+    """Was this logged message addressed to THIS session? The postal log's to_id is the recipient's
+    romp session id — the same id build_session is rendering (deliver() keys the maildir by it, and
+    the timeline connectors match it against live sids). Without this, an id lifted from ANY text
+    rendered another session's message body, wearing that session's name and colour, in a chat that
+    was never a recipient. Unknown sid (a direct caller that passes none) or a pre-schema row with no
+    to_id → pass through: the check is a scope guard, not a reason to lose real mail."""
+    to = rec.get("toId") or ""
+    return not to or not sid or to == sid
+
+
+def _hydrate_postal(events, index, sid=None):
     """Replace postal traffic with clean cards: a send_message tool (or `romp mail send` Bash) → an
-    OUTGOING card; a user/tool event carrying romp-msg-id marker(s) → INCOMING card(s) with the clean
-    body from the log. Anything not fully resolved passes through unchanged. Mirrors hydratePostal."""
+    OUTGOING card; a user event (or a MAIL READER's output — see _reads_mail) carrying romp-msg-id
+    marker(s) addressed to `sid` → INCOMING card(s) with the clean body from the log. Anything not
+    fully resolved passes through unchanged."""
     out = []
     # {id: Haiku caption} → show the ≤9-word caption, not the verbose body. Computed LAZILY (the user
     # 2026-07-03: "startup is slow"): _msg_summaries() re-scans the WHOLE fleet's captioned transcripts,
@@ -11451,12 +11501,14 @@ def _hydrate_postal(events, index):
             card = _cli_send_card(ev)
             if card:
                 out.append(enrich_out(card, ev)); continue
-        text = ev.get("md") if ev.get("kind") == "user" else (ev.get("output") if ev.get("kind") == "tool" else "")
+        text = ev.get("md") if ev.get("kind") == "user" else (ev.get("output") if _reads_mail(ev) else "")
         ids = em.POSTAL_RE.findall(text or "")
         if ids:
             cards = []
             for mid in ids:
                 rec = index.get(mid)
+                if rec and not _postal_addressed_to(rec, sid):
+                    rec = None                           # someone else's mail → the unresolved path below
                 if rec:
                     frm = rec["from"]
                     if not frm or frm in ("?", "unknown"):
@@ -13716,7 +13768,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                                "md": a.get("content") or ""})
     _flush_recoveries(tail_cap_t)                       # a recovery on the still-open tail turn (t past the last atom) → bottom of the flow
     #                                                     (tail_cap_t: an episode render stops at its /clear — later notes belong to the next episode)
-    events = _hydrate_postal(events, _postal_index())   # swap postal traffic for clean in/out cards (no boilerplate)
+    events = _hydrate_postal(events, _postal_index(), sid)   # swap postal traffic for clean in/out cards (no boilerplate)
     _stamp_interrupt_causes(events)                     # a restart/crash resume notice names the seam's cause
     for ev in events:
         # tlId = the timeline atom a chat hover lights: a message/prompt → the DOT (segment promptId),

--- a/tests/test_postal_hydrate_scope.py
+++ b/tests/test_postal_hydrate_scope.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""_hydrate_postal must only hydrate mail this session actually received.
+
+It scanned the output of EVERY tool for `romp-msg-id` markers and looked each id up in a BOX-WIDE
+index, with no check of who the message was addressed to — then REPLACED the event when every id
+resolved. So text the agent merely READ (a file, a fetched page, a grep hit, its own echo of mail)
+could make a Bash/Read/WebFetch row vanish from the chat and come back as a postal card wearing
+another session's name and colour; and an id belonging to a message between two OTHER sessions
+rendered that message's body in a chat that was never a recipient.
+
+Two scopes now: only the MAIL READERS' output is scanned (check_inbox, `romp mail inbox|recv|peek`,
+the drain) alongside user text — those are the only places format_inbox / format_push output can
+legitimately land — and a record whose to_id names someone else falls through to the existing loud
+unresolved path instead of rendering.
+
+A genuine multi-message drain must still hydrate EVERY id, so that stays covered here too.
+
+SYNTHETIC fixtures only: invented sessions (notes-api's web/api/tests), placeholder UUIDs, TESTHOST.
+"""
+import inspect
+import io
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_hscope", os.path.join(BIN, "romp-kernel")).load_module()
+
+ME = "11111111-2222-3333-4444-555555555555"       # the session whose chat is being built ('web')
+PEER = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"     # the sender ('api')
+OTHER = "99999999-8888-7777-6666-555555555555"    # a third session ('tests') — never this chat
+
+M1 = "1700000000.11111_22222.TESTHOST"
+M2 = "1700000001.33333_44444.TESTHOST"
+M3 = "1700000002.55555_66666.TESTHOST"
+
+MARKER = "<!-- romp-msg-id: %s -->"
+
+
+def row(mid, to, body="the changelog is the last thing left on the deploy"):
+    return {"id": mid, "from": "api", "fromId": PEER, "fromHost": "", "toId": to,
+            "body": body, "kind": "coordinate", "t": 1700000000, "park": False}
+
+
+def tool(name, output, **kw):
+    ev = {"kind": "tool", "name": name, "input": "", "output": output,
+          "isError": False, "uuid": "cccccccc-dddd-eeee-ffff-000000000000", "ts": "x"}
+    ev.update(kw)
+    return ev
+
+
+def bash(command, output):
+    return tool("Bash", output, input=json.dumps({"command": command, "description": "d"}))
+
+
+def user(text):
+    return {"kind": "user", "md": text, "uuid": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
+            "ts": "x", "human": False}
+
+
+INBOX_TOOL = "mcp__romp-postal-service__check_inbox"
+
+
+class HydrateScope(unittest.TestCase):
+    """Only a mail reader's output (and user text) is scanned for message ids."""
+
+    def _run(self, events, index, sid=ME):
+        err = io.StringIO()
+        saved_sum, saved_err = km._msg_summaries, km.sys.stderr
+        km._msg_summaries, km.sys.stderr = (lambda: {}), err
+        try:
+            return km._hydrate_postal(events, index, sid), err.getvalue()
+        finally:
+            km._msg_summaries, km.sys.stderr = saved_sum, saved_err
+
+    def test_a_file_read_that_mentions_a_message_id_is_not_hydrated(self):
+        # The core bug: a Read of a file that happens to carry the marker replaced the tool row with a
+        # postal card. The row must survive intact — and this is not a postal event, so nothing is warned.
+        ev = tool("Read", "notes.md line 3: %s\nsee the handoff above" % (MARKER % M1))
+        out, warned = self._run([ev], {M1: row(M1, ME)})
+        self.assertEqual(out, [ev], "a Read row is untouched — no card, no mid stamped on it")
+        self.assertEqual(warned, "", "and nothing is reported: it was never postal traffic")
+
+    def test_a_bash_row_echoing_a_received_id_keeps_its_output(self):
+        # An agent's own echo of mail it received (grep, cat, a script that prints the marker back)
+        # used to swap the Bash row out for a duplicate card of a message already shown once.
+        ev = bash("grep -n romp-msg-id handoff.md", "handoff.md:7:%s" % (MARKER % M1))
+        out, _ = self._run([ev], {M1: row(M1, ME)})
+        self.assertEqual(out, [ev], "the command and its output stay in the chat")
+
+    def test_a_web_fetch_carrying_a_marker_is_not_hydrated(self):
+        ev = tool("WebFetch", "the page said: %s" % (MARKER % M1))
+        out, _ = self._run([ev], {M1: row(M1, ME)})
+        self.assertEqual(out, [ev])
+
+    def test_a_command_that_merely_mentions_the_subcommand_is_not_a_mail_read(self):
+        # The matcher is anchored at a command position, so quoting the subcommand as an ARGUMENT
+        # doesn't turn an ordinary grep into a mailbox reader.
+        ev = bash('grep -rn "romp mail inbox" docs/', "docs/reference.md:86:%s" % (MARKER % M1))
+        out, _ = self._run([ev], {M1: row(M1, ME)})
+        self.assertEqual(out, [ev], "'romp mail inbox' inside a quoted argument is not a mail read")
+
+    def test_the_check_inbox_tool_output_still_hydrates(self):
+        out, warned = self._run([tool(INBOX_TOOL, "\U0001F4EC New message(s):\nhi\n" + MARKER % M1)],
+                                {M1: row(M1, ME)})
+        self.assertEqual([e["kind"] for e in out], ["postal-service"])
+        self.assertEqual((out[0]["direction"], out[0]["peer"], out[0]["mid"]), ("in", "api", M1))
+        self.assertEqual(warned, "")
+
+    def test_the_mail_reading_cli_subcommands_still_hydrate(self):
+        for cmd in ("romp mail inbox", "romp mail recv", "romp mail peek", "romp --mail inbox",
+                    "romp-postal-service inbox", "romp mail drain --id " + ME,
+                    "cd /tmp/notes-api && romp mail inbox"):
+            with self.subTest(cmd=cmd):
+                out, _ = self._run([bash(cmd, "from api:\n" + MARKER % M1)], {M1: row(M1, ME)})
+                self.assertEqual([e["kind"] for e in out], ["postal-service"], cmd)
+
+    def test_delivered_mail_as_user_text_still_hydrates(self):
+        # How mail actually reaches a session: the Stop-hook drain's block reason and the kernel's
+        # pane/socket push both land as user records. That path is unchanged.
+        out, _ = self._run([user("####\n\U0001F4EC from api\n####\nbody\n" + MARKER % M1)],
+                           {M1: row(M1, ME)})
+        self.assertEqual([e["kind"] for e in out], ["postal-service"])
+
+    def test_the_outgoing_card_paths_are_untouched(self):
+        # send_message / `romp mail send` are matched before the scan and never depended on it.
+        mcp = tool("mcp__romp-postal-service__send_message", "Delivered to 'api'.",
+                   input=json.dumps({"to": "api", "body": "taking the deploy"}))
+        cli = tool("Bash", "[romp mail] delivered to api",
+                   input='romp mail send api "taking the deploy"')
+        out, _ = self._run([mcp, cli], {})
+        self.assertEqual([(e["kind"], e["direction"]) for e in out],
+                         [("postal-service", "out")] * 2)
+
+
+class HydrateRecipient(unittest.TestCase):
+    """Only mail addressed to THIS session is rendered in its chat."""
+
+    def _run(self, events, index, sid=ME):
+        err = io.StringIO()
+        saved_sum, saved_err = km._msg_summaries, km.sys.stderr
+        km._msg_summaries, km.sys.stderr = (lambda: {}), err
+        try:
+            return km._hydrate_postal(events, index, sid), err.getvalue()
+        finally:
+            km._msg_summaries, km.sys.stderr = saved_sum, saved_err
+
+    def test_a_message_addressed_to_another_session_is_not_rendered(self):
+        # A peer's message body (delivered as user text) quoting an id from a conversation between two
+        # OTHER sessions used to render THAT conversation's body here, wearing its sender's identity.
+        secret = row(M2, OTHER, body="the staging credentials rotate on friday")
+        out, warned = self._run([user("look at this: " + MARKER % M2)], {M2: secret})
+        self.assertEqual([e["kind"] for e in out], ["user"], "no card for someone else's mail")
+        self.assertNotIn("the staging credentials rotate on friday",
+                         json.dumps(out[0]), "and its body never reaches this chat")
+        self.assertEqual(out[0]["mids"], [M2], "the turn still carries the id it mentioned (deep-link)")
+        self.assertIn("unresolved", warned, "it goes down the existing loud path, not silence")
+        self.assertIn(M2, warned)
+
+    def test_the_same_id_addressed_to_us_does_render(self):
+        out, warned = self._run([user("mail: " + MARKER % M1)], {M1: row(M1, ME)})
+        self.assertEqual([e["kind"] for e in out], ["postal-service"])
+        self.assertEqual(warned, "")
+
+    def test_a_check_inbox_output_naming_someone_elses_id_is_not_rendered(self):
+        out, warned = self._run([tool(INBOX_TOOL, "spoofed: " + MARKER % M2)], {M2: row(M2, OTHER)})
+        self.assertEqual([e["kind"] for e in out], ["tool"], "even a real mail reader is scoped")
+        self.assertIn("unresolved", warned)
+
+    def test_a_genuine_multi_message_drain_hydrates_every_id(self):
+        # One drain legitimately carries several messages — all of them must still become cards.
+        ev = user("\n".join(["\U0001F4EC New message(s):"]
+                            + [MARKER % m for m in (M1, M2, M3)]))
+        idx = {M1: row(M1, ME, "one"), M2: row(M2, ME, "two"), M3: row(M3, ME, "three")}
+        out, warned = self._run([ev], idx)
+        self.assertEqual([e["kind"] for e in out], ["postal-service"] * 3)
+        self.assertEqual([e["mid"] for e in out], [M1, M2, M3])
+        self.assertEqual([e["body"] for e in out], ["one", "two", "three"])
+        self.assertEqual(warned, "")
+
+    def test_a_drain_with_one_foreign_id_stays_all_or_nothing(self):
+        ev = user("\n".join(MARKER % m for m in (M1, M2)))
+        out, warned = self._run([ev], {M1: row(M1, ME), M2: row(M2, OTHER)})
+        self.assertEqual([e["kind"] for e in out], ["user"], "a partial run never half-renders")
+        self.assertEqual(out[0]["mids"], [M1, M2])
+        self.assertIn("1 of 2", warned)
+
+    def test_a_log_row_with_no_recipient_still_renders(self):
+        # Safety net: pre-schema rows (and any writer that omits to_id) must not lose their cards —
+        # the check scopes what we render, it is not a reason to drop real mail.
+        out, warned = self._run([user(MARKER % M1)], {M1: row(M1, "")})
+        self.assertEqual([e["kind"] for e in out], ["postal-service"])
+        self.assertEqual(warned, "")
+
+    def test_a_caller_that_passes_no_sid_keeps_the_old_behavior(self):
+        out, _ = self._run([user(MARKER % M2)], {M2: row(M2, OTHER)}, sid=None)
+        self.assertEqual([e["kind"] for e in out], ["postal-service"],
+                         "no sid to compare against → no recipient check (direct callers)")
+
+    def test_build_session_passes_its_sid_in(self):
+        # Without the wiring the recipient check is dead code in the only caller that matters.
+        self.assertIn("_hydrate_postal(events, _postal_index(), sid)",
+                      inspect.getsource(km.build_session))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`_hydrate_postal` turns postal message ids found in a transcript into rendered mail cards. It scans the output of **every tool**, looks each id up in a **box-wide** index with no check that the message was addressed to this session, and **replaces** the original tool event when all ids resolve.

Two consequences, neither requiring an attacker:

1. **A tool row disappears.** Text an agent merely *read* — a file, a fetched page, its own echo of mail it received — makes a `Bash`/`Read`/`WebFetch` row vanish from the chat, replaced by a card wearing another session's name, colour and the postal glyph. The output the user was looking for is gone from the transcript view.
2. **Another conversation leaks in.** Because the index is box-wide and nothing checks the recipient, an id belonging to a message between two *other* sessions renders that message's body in a chat that was never a recipient.

The first is the everyday one: this repo discusses message ids constantly, and any transcript that quotes one trips it.

### The fix

Two contained changes.

**Scope the scan to the mailbox readers.** Only the tools that can legitimately carry the postal formatter's output are scanned — the `check_inbox` MCP tool, and `Bash` whose command is actually reading mail. Everything else keeps its output verbatim.

`check_sent` is deliberately **not** in that set, and the reasoning is worth stating because it looks like an omission: `format_receipts` prints no marker, and the rows it lists are mail this session *sent* — a `to_id` that is never ours — so scanning it could only ever produce false unresolved reports.

**Check the recipient.** The session id is passed through, so a record whose `to_id` names someone else falls through to the existing loud unresolved path instead of being rendered. An empty `to_id` passes through rather than being dropped, as a safety net for records that predate the field.

**Keeping all ids is correct and stays.** One drain legitimately carries several messages; this is not changed to last-id-only.

### Tests

16 new cases in `tests/test_postal_hydrate_scope.py`, covering both halves:

- a file read that mentions a message id is not hydrated
- a web fetch carrying a marker is not hydrated
- a Bash row echoing a received id keeps its output
- a command that merely *mentions* the subcommand is not treated as a mail read
- `check_inbox` output naming someone else's id is not rendered
- a drain with one foreign id still renders the rest
- a genuine multi-message drain still hydrates every id

**On the fail-without-fix proof, one honest caveat:** a plain revert is not a usable proof here, because the fix widens `_hydrate_postal`'s signature — all 16 tests then die with the same `TypeError` rather than showing behaviour. So the proof was built against a *behaviour-only* pre-fix kernel: upstream's scan line restored and the two recipient-check lines removed, but the new signature kept so the tests still call it. Against that, 8 of the 16 fail, including every case above. The remaining 8 are guards that pass either way.

Full suite: **4567 passed vs 4551 on unmodified `main` — exactly +16, zero regressions.**

### Notes for review

This is written fresh rather than ported, so it has not run anywhere in production — worth a closer read than a change with mileage on it.

It does not depend on #381 (the marker-form change), which is cut off the same base; the two touch different files and different mechanisms. It also does not overlap #380, which edits `kernel/kernel.py` around `_load_token`, roughly ten thousand lines away.

This does not address the other provenance gap: `from_id` is still an unauthenticated claim, so a card's *attribution* is only as good as the sender's honesty. The companion PR covers the framing half of that.
