### PR TITLE
romp new grows --model/--effort, applied through /new even on an already-running session

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -633,6 +633,8 @@ EOF
     _romp_cmd "romp new -t <name>"         -            "Start it as a terminal (tmux) session and attach (--detach: don't attach)"
     _romp_cmd "romp new -d <dir> <name>"   -            "Working directory for the new session (default: the current folder)"
     _romp_cmd "romp new -m <text> <name>"  -            "Start it AND deliver <text> as its first prompt (one command, idea to working)"
+    _romp_cmd "romp new --model <id> <name>" -          "Model for the SDK session, as a FULL id (e.g. claude-fable-5); re-asserted if <name> already runs"
+    _romp_cmd "romp new --effort <level> <name>" -      "Reasoning effort for the SDK session (e.g. high, ultracode); re-asserted if <name> already runs"
     _romp_cmd "romp resume [<id>]"         -            "Resume a past conversation (full-screen picker; or an exact UUID)"
     _romp_cmd "romp status"                romp-manager "Show manager + kernel status"
     _romp_cmd "romp refresh"               romp-manager "Restart the postal bus + all romp kernels (picks up new code — run after an update)"
@@ -1042,6 +1044,8 @@ resume=false
 resume_id=""
 detach=false
 dir_arg=""
+model_arg=""
+effort_arg=""
 use_tmux=false
 msg_arg=""
 
@@ -1054,7 +1058,7 @@ case "${1:-}" in
                 --detach)  detach=true; shift ;;
                 -d)        shift
                            if [[ $# -eq 0 || "$1" == -* ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            dir_arg="$1"; shift ;;
                 -m|--message) shift
@@ -1063,23 +1067,44 @@ case "${1:-}" in
                            # last two-step on the idea-to-working path). Empty text is a usage
                            # error, not a silent no-op.
                            if [[ $# -eq 0 || -z "$1" ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            msg_arg="$1"; shift ;;
+                --model)   shift
+                           # per-spawn model, riding POST /new (the user 2026-08-14: the nightly
+                           # optimizer must always run fable, and a headless script has no WS).
+                           # FULL id as the picker sends it (claude-fable-5) — the alias table
+                           # stops at opus/sonnet/haiku and quietly resolved "fable" to Opus 5.
+                           if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                           fi
+                           model_arg="$1"; shift ;;
+                --effort)  shift
+                           # per-spawn effort (e.g. high, ultracode) — ultracode is per-session
+                           # by design, never a machine default, so /new is its sanctioned door.
+                           if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                           fi
+                           effort_arg="$1"; shift ;;
                 -*)        echo "romp new: unknown option: $1" >&2; exit 2 ;;
                 *)         if [[ -n "$session_arg" ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            session_arg="$1"; shift ;;
             esac
         done
         if [[ -z "$session_arg" ]]; then
-            echo "usage: romp new [-t] [-d <dir>] [-m <text>] <name>" >&2; exit 2
+            echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
         fi
         if [[ -n "$msg_arg" ]] && $use_tmux; then
             # the tmux variant attaches a terminal you type into yourself; delivering a first
             # prompt is the SDK path's job. Refuse loudly rather than dropping the text.
             echo "romp new: -m needs the default (SDK) session — with -t you type into the terminal yourself" >&2; exit 2
+        fi
+        if [[ -n "$model_arg$effort_arg" ]] && $use_tmux; then
+            # per-spawn model/effort ride the kernel's /new (SDK); a terminal session picks them
+            # inside Claude itself. Refuse loudly rather than dropping the flags (no silent divergence).
+            echo "romp new: --model/--effort need the default (SDK) session — with -t, pick them inside Claude itself" >&2; exit 2
         fi
         ;;
     resume|--resume)
@@ -1158,7 +1183,7 @@ if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
         echo "romp new: the kernel isn't running (no serve token). Start romp (the login service, or \`romp up\`), or use \`romp new -t $session_arg\` for a terminal session." >&2
         exit 1
     fi
-    _payload="$(python3 -c 'import json,sys; print(json.dumps({"name": sys.argv[1], "dir": sys.argv[2], "backend": "sdk"}))' "$session_arg" "$_dir")"
+    _payload="$(python3 -c 'import json,sys; d={"name": sys.argv[1], "dir": sys.argv[2], "backend": "sdk"}; sys.argv[3] and d.update(model=sys.argv[3]); sys.argv[4] and d.update(effort=sys.argv[4]); print(json.dumps(d))' "$session_arg" "$_dir" "$model_arg" "$effort_arg")"
     _resp="$(curl -sf -m 15 -X POST "http://127.0.0.1:$_kport/new" \
                   -H "X-Romp-Token: $_tok" \
                   -H 'Content-Type: application/json' -d "$_payload")" \
@@ -1169,6 +1194,18 @@ if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
         else
             echo "romp new: started \"$session_arg\" (SDK session, working in $_dir)"
             echo "romp new: watch it on the dashboard: romp"
+        fi
+        # --model/--effort: report what the kernel APPLIED — it echoes them back (the same park-aware
+        # setters as the dashboard pickers, re-asserted even on an already-running session). An ack
+        # WITHOUT the echo means an older kernel dropped the ask — say so loudly instead of letting
+        # this machine and the session quietly diverge.
+        if [[ -n "$model_arg$effort_arg" ]]; then
+            _applied="$(python3 -c 'import json,sys; r=json.loads(sys.argv[1]); print(", ".join("%s %s" % (k, r[k]) for k in ("model","effort") if r.get(k)))' "$_resp" 2>/dev/null || true)"
+            if [[ -n "$_applied" ]]; then
+                echo "romp new: applied $_applied"
+            else
+                echo "romp new: WARNING — the kernel did not acknowledge --model/--effort (older kernel?); set them from the dashboard" >&2
+            fi
         fi
         # -m: deliver the first prompt through the same kernel route `romp send` uses, so one
         # command goes from idea to a working session. Per-leg reporting, never silent: the

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4374,6 +4374,36 @@ def _pick_identity_color(now=None):
     return bgs[i], fgs[i]
 
 
+def _apply_new_session_prefs(sid, body):
+    """POST /new's optional per-spawn "model"/"effort" (the user 2026-08-14): applied through the SAME
+    park-aware setters as the dashboard's setModel/setEffort ops, and echoed back so the caller can be
+    loud when a kernel ignores them. Values pass through VERBATIM — full model ids as the picker sends
+    them (claude-fable-5), never a short alias: the CLI alias table stops at opus/sonnet/haiku and
+    quietly resolved "fable" to Opus 5 (observed live 2026-08-14). Runs on the idempotent existing:true
+    open too, so a nightly re-brief re-asserts them on the standing session — ultracode is per-session
+    by design (never a write_sdk_default seed), and a headless script has no WS, so this is the
+    sanctioned door."""
+    out = {}
+    m = str((body or {}).get("model") or "").strip()
+    e = str((body or {}).get("effort") or "").strip()
+    if not (m or e):
+        return out
+    try:
+        be = Sessions.backend_for(str(sid))
+    except Exception:
+        be = None
+    if be is None:
+        return out
+    if m:
+        _set_model_or_park(be, str(sid), m)
+        out["model"] = m
+    if e:
+        _set_effort_or_park(be, str(sid), e)
+        out["effort"] = e
+    _push_soon()
+    return out
+
+
 def _create_sdk_session(nm, cwd, auth=""):
     """Create + open a new SDK-backed session, ACK-FAST (the user 2026-07-14, who asked why it took so long
     to open a new SDK session). spawn() is file writes and connect() is threaded (~0.4s to a booting
@@ -23588,7 +23618,10 @@ class Handler(BaseHTTPRequestHandler):
             if u.path == "/new":
                 # Headless session creation (`romp new`, 2026-07-25): the WS createSession op as a
                 # one-shot POST, so a terminal can start a session — SDK by default, the recommended
-                # backend — without a browser. Body: {"name": ..., "dir": ..., "backend": "sdk"|"tmux"}.
+                # backend — without a browser. Body: {"name": ..., "dir": ..., "backend": "sdk"|"tmux"},
+                # plus optional "model"/"effort" (full ids/levels, applied park-aware and echoed back;
+                # also applied on the existing:true open, so a re-brief re-asserts them — see
+                # _apply_new_session_prefs).
                 # Same validation and the same no-silent-fallback rule as the WS op: when the SDK
                 # backend is unavailable, say so (ok:false + reason), never hand back a mystery tmux
                 # session. An already-live name is a success (idempotent open), not an error.
@@ -23608,7 +23641,8 @@ class Handler(BaseHTTPRequestHandler):
                                       "application/json")
                 live = _live_names(_tmux_sessions())
                 if nm in live:
-                    return self._send(200, json.dumps({"ok": True, "id": live[nm], "existing": True}),
+                    extra = _apply_new_session_prefs(live[nm], b)
+                    return self._send(200, json.dumps({"ok": True, "id": live[nm], "existing": True, **extra}),
                                       "application/json")
                 if (b.get("backend") or "sdk") == "sdk":
                     if not _sdk_ready():          # see _sdk_ready — a built backend is not a working one
@@ -23616,7 +23650,8 @@ class Handler(BaseHTTPRequestHandler):
                                           "application/json")
                     a = (b or {}).get("auth")
                     sid = _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""))
-                    return self._send(200, json.dumps({"ok": True, "id": sid, "dir": cwd}),
+                    extra = _apply_new_session_prefs(sid, b)
+                    return self._send(200, json.dumps({"ok": True, "id": sid, "dir": cwd, **extra}),
                                       "application/json")
                 threading.Thread(target=_spawn_session, args=(nm, cwd), daemon=True).start()
                 return self._send(200, json.dumps({"ok": True, "pending": True, "dir": cwd}),

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -1026,3 +1026,86 @@ PY
     grep -q '"backend": "sdk"' "$TEST_DIR/req.log"
     [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
 }
+
+@test "new --model/--effort: ride /new VERBATIM (full ids, no alias munging) and report what was applied" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    touch "$MOCK_LOG"
+    mkdir -p "$XDG_STATE_HOME/romp"
+    printf 'tok-test' > "$XDG_STATE_HOME/romp/serve-token"
+    # fake kernel echoes model/effort back, the applied-ack contract of the real /new
+    python3 - "$TEST_DIR/port" "$TEST_DIR/req.log" <<'PY' &
+import sys, json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+portfile, log = sys.argv[1], sys.argv[2]
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers.get("Content-Length") or 0)) or b"{}")
+        with open(log, "w") as f:
+            json.dump({"path": self.path, "body": body}, f)
+        out = json.dumps({"ok": True, "id": "11111111-2222-3333-4444-555555555555",
+                          "model": body.get("model"), "effort": body.get("effort")}).encode()
+        self.send_response(200); self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(out))); self.end_headers()
+        self.wfile.write(out)
+    def log_message(self, *a): pass
+srv = HTTPServer(("127.0.0.1", 0), H)
+with open(portfile, "w") as f:
+    f.write(str(srv.server_address[1]))
+srv.handle_request()
+PY
+    local srv=$!
+    until [ -s "$TEST_DIR/port" ]; do sleep 0.05; done
+    ROMP_KERNEL_PORT="$(cat "$TEST_DIR/port")" run run_romp new --model claude-fable-5 --effort ultracode opt
+    kill "$srv" 2>/dev/null || true
+    [ "$status" -eq 0 ]
+    grep -q '"model": "claude-fable-5"' "$TEST_DIR/req.log"
+    grep -q '"effort": "ultracode"' "$TEST_DIR/req.log"
+    [[ "$output" == *"applied model claude-fable-5, effort ultracode"* ]]
+    [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
+}
+
+@test "new --model/--effort: a kernel that does NOT ack them warns loudly (no silent divergence)" {
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+    touch "$MOCK_LOG"
+    mkdir -p "$XDG_STATE_HOME/romp"
+    printf 'tok-test' > "$XDG_STATE_HOME/romp/serve-token"
+    # fake OLDER kernel: acks ok but ignores the keys — the CLI must say so, not pretend
+    python3 - "$TEST_DIR/port" "$TEST_DIR/req.log" <<'PY' &
+import sys, json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+portfile, log = sys.argv[1], sys.argv[2]
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        out = json.dumps({"ok": True, "id": "11111111-2222-3333-4444-555555555555"}).encode()
+        self.send_response(200); self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(out))); self.end_headers()
+        self.wfile.write(out)
+    def log_message(self, *a): pass
+srv = HTTPServer(("127.0.0.1", 0), H)
+with open(portfile, "w") as f:
+    f.write(str(srv.server_address[1]))
+srv.handle_request()
+PY
+    local srv=$!
+    until [ -s "$TEST_DIR/port" ]; do sleep 0.05; done
+    ROMP_KERNEL_PORT="$(cat "$TEST_DIR/port")" run run_romp new --model claude-fable-5 opt
+    kill "$srv" 2>/dev/null || true
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"did not acknowledge --model/--effort"* ]]
+}
+
+@test "new --model with -t refuses loudly (SDK-only flags), and starts nothing" {
+    touch "$MOCK_LOG"
+    run run_romp new -t --model claude-fable-5 x
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--model/--effort need the default (SDK) session"* ]]
+    [ "$(grep -c 'tmux new-session' "$MOCK_LOG")" -eq 0 ]
+}
+
+@test "new: help names --model and --effort (the nightly optimizer's presence guard greps help)" {
+    run run_romp -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--model <id>"* ]]
+    [[ "$output" == *"--effort <level>"* ]]
+}

--- a/tests/test_new_route_prefs.py
+++ b/tests/test_new_route_prefs.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""POST /new's per-spawn model/effort (the user 2026-08-14): applied via the park-aware setters on
+CREATE and on the idempotent existing:true open (a nightly re-brief re-asserts them), echoed in the
+response so a caller can be loud when ignored; absent keys touch nothing.
+
+Drives the REAL Handler over HTTP (the test_kernel_ws_auth.py pattern). Synthetic only — placeholder
+UUIDs, temp dirs, no session state touched (the setters are recorded, never executed).
+"""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+SID2 = "66666666-7777-8888-9999-000000000000"
+
+
+class NewRoutePrefs(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+        cls.dir = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.calls = []
+        self._saved = (km._live_names, km._tmux_sessions, km._set_model_or_park,
+                       km._set_effort_or_park, km.Sessions.backend_for,
+                       km._sdk_ready, km._create_sdk_session, km._push_soon)
+        km._tmux_sessions = lambda: []
+        km._set_model_or_park = lambda be, sid, v: self.calls.append(("model", sid, v))
+        km._set_effort_or_park = lambda be, sid, v: self.calls.append(("effort", sid, v))
+        km.Sessions.backend_for = staticmethod(lambda sid: object())
+        km._push_soon = lambda: None
+
+    def tearDown(self):
+        (km._live_names, km._tmux_sessions, km._set_model_or_park,
+         km._set_effort_or_park, km.Sessions.backend_for,
+         km._sdk_ready, km._create_sdk_session, km._push_soon) = self._saved
+
+    def _post(self, body):
+        req = urllib.request.Request("http://127.0.0.1:%d/new" % self.port,
+                                     data=json.dumps(body).encode(),
+                                     headers={"X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"],
+                                              "Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=5) as r:
+            return json.loads(r.read())
+
+    def test_existing_open_reasserts_model_and_effort_and_echoes_them(self):
+        km._live_names = lambda *_: {"opt": SID}
+        r = self._post({"name": "opt", "dir": self.dir,
+                        "model": "claude-fable-5", "effort": "ultracode"})
+        self.assertTrue(r["ok"])
+        self.assertTrue(r["existing"])
+        self.assertEqual(r.get("model"), "claude-fable-5")
+        self.assertEqual(r.get("effort"), "ultracode")
+        self.assertIn(("model", SID, "claude-fable-5"), self.calls)
+        self.assertIn(("effort", SID, "ultracode"), self.calls)
+
+    def test_existing_open_without_prefs_touches_nothing(self):
+        km._live_names = lambda *_: {"opt": SID}
+        r = self._post({"name": "opt", "dir": self.dir})
+        self.assertTrue(r["ok"])
+        self.assertNotIn("model", r)
+        self.assertNotIn("effort", r)
+        self.assertEqual(self.calls, [])
+
+    def test_fresh_sdk_create_applies_both_and_echoes_them(self):
+        km._live_names = lambda *_: {}
+        km._sdk_ready = lambda: True
+        km._create_sdk_session = lambda nm, cwd, auth="": SID2
+        r = self._post({"name": "opt", "dir": self.dir,
+                        "model": "claude-fable-5", "effort": "ultracode"})
+        self.assertTrue(r["ok"])
+        self.assertEqual(r.get("model"), "claude-fable-5")
+        self.assertEqual(r.get("effort"), "ultracode")
+        self.assertIn(("model", SID2, "claude-fable-5"), self.calls)
+        self.assertIn(("effort", SID2, "ultracode"), self.calls)
+
+    def test_model_alone_applies_and_echoes_only_model(self):
+        km._live_names = lambda *_: {"opt": SID}
+        r = self._post({"name": "opt", "dir": self.dir, "model": "claude-fable-5"})
+        self.assertTrue(r["ok"])
+        self.assertEqual(r.get("model"), "claude-fable-5")
+        self.assertNotIn("effort", r)
+        self.assertEqual(self.calls, [("model", SID, "claude-fable-5")])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Delegated by the workflows session (the user's ask, 2026-08-14): the nightly optimizer must always run fable + ultracode, ultracode is per-session by design, and headless scripts have no WS — so `romp new` needed a sanctioned door.

- `romp new --model <id> --effort <level>` (SDK path only; refuses with `-t` like `-m` does, loudly).
- Values ride POST /new as optional `model`/`effort` keys and pass through VERBATIM — full ids as the picker sends them (`claude-fable-5`), never short aliases: the CLI alias table stops at opus/sonnet/haiku and silently resolved `fable` to Opus 5 (observed live today).
- The kernel applies them via the same park-aware `_set_model_or_park`/`_set_effort_or_park` the WS ops use — after `_create_sdk_session` AND on the `existing:true` idempotent open, so a nightly re-brief re-asserts them on the standing session.
- The response echoes what was applied; the CLI reports it and warns loudly when an older kernel ignores the flags (no silent divergence).
- Help names both flags (`--model <id>` / `--effort <level>`) — the dotfiles consumer greps help for `--model` before passing them.

Tests: four new bats cases (verbatim ride + applied report, older-kernel loud warning, `-t` refusal, help presence) and `tests/test_new_route_prefs.py` driving the real Handler over HTTP (apply-on-existing, apply-on-create, echo shape, no-pref no-op). Full romp.bats (67) and the kernel preview suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)