### PR TITLE
setUpdateMode reaches every attached kernel, like the other kernel-side gear settings

### DIFF
--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -56,11 +56,13 @@ const OBJ_ID = ["tabs"]; //                       an array of objects keyed by `
 
 // Gear settings the KERNEL acts on, which each kernel stores its own copy of: they describe how romp
 // behaves towards the sessions it is running, so a machine that never hears the change goes on behaving
-// the old way. Broadcast in routeOutbound rather than routed. Deliberately NOT here: setDefaultDir (a
-// path on one machine, meaningless on another) and setColormap/setPalette (the viewer's display prefs,
-// which the local kernel persists for this browser).
+// the old way. setUpdateMode belongs here too: each kernel runs its own boot release check, so a machine
+// that misses the change keeps handling new releases under the old policy (ask/auto/off). Broadcast in
+// routeOutbound rather than routed. Deliberately NOT here: setDefaultDir (a path on one machine,
+// meaningless on another) and setColormap/setPalette (the viewer's display prefs, which the local kernel
+// persists for this browser).
 const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel",
-                                "setJudgeEffort", "setIndexEffort"]);
+                                "setJudgeEffort", "setIndexEffort", "setUpdateMode"]);
 
 /** Return a COPY of an inbound message with every session-id field prefixed by `host`. The local host
  *  ("") is the identity transform, so local messages are untouched. Unknown fields pass through. */

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -429,7 +429,8 @@ test("routeOutbound: the gear's kernel-side settings reach EVERY attached kernel
                      { type: "setJudgeModel", model: "haiku" },
                      { type: "setIndexModel", model: "haiku" },
                      { type: "setJudgeEffort", effort: "high" },
-                     { type: "setIndexEffort", effort: "" }]) {
+                     { type: "setIndexEffort", effort: "" },
+                     { type: "setUpdateMode", mode: "auto" }]) {
     const routes = routeOutbound(msg, new Set(["TESTHOST", "gpu1"]));
     assert.deepEqual(routes.map((r) => r.host).sort(), ["", "TESTHOST", "gpu1"].sort(), msg.type);
     for (const r of routes) assert.deepEqual(r.msg, msg, "the kernels are host-blind: same message to each");


### PR DESCRIPTION
Follow-up to the auto-nudge-every-kernel change, which made the five kernel-side gear settings broadcast to every attached kernel but left update mode routed local-only — the one kernel-acted setting still exposed to the silent-divergence trap it fixed for the others: set "Install automatically" on the dashboard and every remote kernel silently keeps its old policy. Each kernel runs its own boot release check (ask/auto/off), so a machine that never hears the change keeps handling new releases the old way.

- `"setUpdateMode"` joins `KERNEL_SETTING` in `ui/webview/federation.ts`, with the comment extended to say why it broadcasts (and the "Deliberately NOT here" list left accurate).
- `{type:"setUpdateMode", mode:"auto"}` joins the every-kernel broadcast test in `ui/webview/multi-kernel-merge.test.ts`.

Validated on a preview merge the day the gap went live, now cherry-picked onto current main: typecheck, node tests (1952 pass, 0 fail), build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)