### PR TITLE
The distilling judges get their own gear tier, and every kernel-side setting says so when machines disagree

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -160,6 +160,27 @@ def _triage_model():  return _state_str("judge-model", TRIAGE_MODEL)   # gear "T
 def _index_model():   return _state_str("index-model", INDEX_MODEL)    # gear "Indexing model" → STATE/index-model
 def _triage_effort(): return _state_str("judge-effort", "")   # "" → pass NO --effort (the long-standing default)
 def _index_effort():  return _state_str("index-effort", "")
+
+
+# The DISTILLING tier (the user 2026-08-14): the card-prose writers — distiller, briefer, staller — get
+# their own gear pair, split out of triage so the copy the user actually reads can run a richer model
+# than the placement judges without dragging every planner call along. The stored sentinel "triage"
+# (the default) means FOLLOW the triage setting live — exactly what these judges did before the split,
+# so nothing changes until the user pins a value. "" for effort still means "no --effort flag", which is
+# why "follow" needed a sentinel rather than the empty string.
+def _distill_model():
+    v = _state_str("distill-model", "triage")
+    return _triage_model() if v == "triage" else v
+
+
+def _distill_effort():
+    # Three states, and "" can only be ONE of them: _state_str's `v or default` folds an empty file into
+    # the default, so the no-flag pin gets its own stored sentinel "none" (caught by test_distill_tier
+    # before it shipped: a pinned-empty file read back as "follow triage" and rode the triage effort).
+    v = _state_str("distill-effort", "triage")
+    if v == "triage":
+        return _triage_effort()
+    return "" if v == "none" else v
 WINDOW      = 48 * 3600                  # only caption transcripts touched in the last N hours (matches the parse horizon)
 COURIER_RETRY_HORIZON = WINDOW           # a usage-limited courier call comes back empty and retries every pass, but a
 #                                          peer message still unsummarized past this many seconds (matches discover()'s
@@ -817,10 +838,12 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage"):
     sys_prompt = _with_user_notes(sys_prompt, judge)  # the user's standing style notes ride every prose call
     auth = _judge_auth(fsid)                          # this call bills what the judged session bills
     env = _judge_env(tier, auth)
-    # Per-tier effort from the gear (STATE/judge-effort | index-effort) when the caller didn't pass one — "" or
-    # None means NO --effort flag, the long-standing default. An explicit caller effort (the plan A/B) still wins.
+    # Per-tier effort from the gear (STATE/judge-effort | index-effort | distill-effort) when the caller
+    # didn't pass one — "" or None means NO --effort flag, the long-standing default. An explicit caller
+    # effort (the plan A/B) still wins.
     if effort is None:
-        effort = (_index_effort() if tier == "index" else _triage_effort()) or None
+        effort = ((_index_effort() if tier == "index" else
+                   _distill_effort() if tier == "distill" else _triage_effort()) or None)
     # Stash this call for the debug view: if the CALLER later rejects the reply, _log_judge_error attaches
     # this input+reply pair to the failure row (debug mode only), so a rejection is inspectable from the
     # card modal. Per-thread and overwritten per call: only the failing call's pair can ever be attached.
@@ -8214,7 +8237,7 @@ def distill_llm(goal_text, work_text, done_why="", prior_summary="", items=None)
                  "**update**: what the follow-up stretch delivered or answered, never a recap of "
                  "<prior-summary>. Rebuild the background from <prior-summary> and <goal> so a fresh "
                  "reader is still oriented.</note>" % prior_summary)
-    return _judge_run(_triage_model(), DISTILL_SYS, user, judge="distiller").strip()   # caller splits SOURCE, then caps
+    return _judge_run(_distill_model(), DISTILL_SYS, user, judge="distiller", tier="distill").strip()   # caller splits SOURCE, then caps
 
 
 # PROCEDURAL block reasons — romp's OWN bookkeeping, authored by the kernel, not a question the user was
@@ -8334,7 +8357,7 @@ def brief_llm(goal_text, work_text, owed):
         owed_block = "\n".join("%d. %s: %s" % (i + 1, (t or "this sub-goal").strip(), (w or "").strip())
                                for i, (t, w) in enumerate(owed))
     user = "<goal>\n%s\n</goal>\n<work>\n%s\n</work>\n<owed>\n%s\n</owed>" % (goal_text, work_text, owed_block)
-    return _judge_run(_triage_model(), BLOCK_BRIEF_SYS, user, judge="briefer").strip()   # caller splits SOURCE, then caps
+    return _judge_run(_distill_model(), BLOCK_BRIEF_SYS, user, judge="briefer", tier="distill").strip()   # caller splits SOURCE, then caps
 
 
 # The STALL note (the user 2026-07-23). A goal that is neither done nor blocked-on-you but that romp has
@@ -8387,7 +8410,7 @@ def stall_llm(goal_text, work_text, holding):
     verbatim: the model translates it, it never re-derives it."""
     user = "<goal>\n%s\n</goal>\n<work>\n%s\n</work>\n<holding>\n%s\n</holding>" % (
         goal_text, work_text, holding)
-    return _judge_run(_triage_model(), STALL_BRIEF_SYS, user, judge="staller").strip()   # caller splits SOURCE, then caps
+    return _judge_run(_distill_model(), STALL_BRIEF_SYS, user, judge="staller", tier="distill").strip()   # caller splits SOURCE, then caps
 
 
 # The in-flight CLASS: holds that mean "romp is working this beat right now", presented as the

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -529,6 +529,16 @@ def _version_info():
             "updateAvail": _UPDATE_AVAIL[0],   # newer release the boot check found ("" = none/unknown)
             "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),      # current per-tier judge models → the gear dropdowns
             "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort(),  # current per-tier judge efforts ("" = default/none)
+            "distillModel": jd._state_str("distill-model", "triage"),   # RAW ("triage" = follow the triage pick) — the gear shows the choice, not the resolution
+            "distillEffort": jd._state_str("distill-effort", "triage"),
+            # One dict with every kernel-side setting, lifted by a PEER kernel's /version poll onto its
+            # /tunnels row so its gear can mark controls where machines disagree (the user 2026-08-14).
+            # The top-level fields above stay: this tab's own gear and older kernels read those.
+            "settings": {"autoNudge": _auto_nudge_on(), "updateMode": _update_mode(),
+                         "judgeModel": jd._triage_model(), "judgeEffort": jd._triage_effort(),
+                         "indexModel": jd._index_model(), "indexEffort": jd._index_effort(),
+                         "distillModel": jd._state_str("distill-model", "triage"),
+                         "distillEffort": jd._state_str("distill-effort", "triage")},
             "defaultDir": _tilde(_default_create_dir()),   # the resolved default new-session dir → the gear "Default directory" field
             "nativeDialogs": _native_dialogs()}   # whether Browse… can draw a dialog HERE → the gear drops the button when it can't
 
@@ -7948,6 +7958,12 @@ def _remote_public(r):
             # — this is what lets it say so. null when the remote never reported one (an older kernel,
             # or a row that has not polled yet): unknown, which the gear leaves out rather than guesses.
             "autoNudge": r.get("auto_nudge") if isinstance(r.get("auto_nudge"), bool) else None,
+            # That machine's whole kernel-side settings dict, same /version poll (the user 2026-08-14:
+            # every kernel-side setting syncs, and the gear marks any control where a connected machine
+            # disagrees instead of showing the local answer as everyone's). null when the remote never
+            # reported one (an older kernel): unknown, left out of the mixed calc — never read as a
+            # disagreement to click away, exactly the autoNudge rule generalized.
+            "settings": r.get("settings") if isinstance(r.get("settings"), dict) else None,
             # fastForward: a push here would only ADD commits (the remote's is an ancestor of ours) — the
             # exact condition the automatic update fires on, so the row can say why it will or won't.
             # autoPush: that host's live phase (pushing / waiting / failed) → the popover's progress line and
@@ -8401,8 +8417,10 @@ def _poll_remote_version(r):
         j = json.loads(data.decode("utf-8")) or {}
         sha = j.get("kernel_sha") or None
         an = j.get("autoNudge")
+        st = j.get("settings")
         return {"sha": sha, "ver": str(j.get("kernel_ver") or ""),
-                "autoNudge": an if isinstance(an, bool) else None} if sha else None
+                "autoNudge": an if isinstance(an, bool) else None,
+                "settings": st if isinstance(st, dict) else None} if sha else None
     except Exception:
         return None
 
@@ -9465,6 +9483,7 @@ def _tunnel_supervisor():
                         r["kernel_sha"] = rsha
                         r["kernel_ver"] = (rver or {}).get("ver") or ""
                         r["auto_nudge"] = (rver or {}).get("autoNudge")   # None = that kernel didn't say
+                        r["settings"] = (rver or {}).get("settings")      # its whole kernel-side dict (None = older kernel)
                     if ruse is not None:
                         # {} = the host ANSWERED with nothing to show → clear; None = no answer (blip/
                         # rate-gate) → keep the last reading (see _poll_remote_usage)
@@ -18552,6 +18571,13 @@ def _set_judge_model(v):  _set_judge_state("judge-model", v, _MODEL_VALUES)
 def _set_index_model(v):  _set_judge_state("index-model", v, _MODEL_VALUES)
 def _set_judge_effort(v): _set_judge_state("judge-effort", v, _EFFORT_VALUES, allow_empty=True)
 def _set_index_effort(v): _set_judge_state("index-effort", v, _EFFORT_VALUES, allow_empty=True)
+# The distilling pair accepts extra sentinels (resolved by jd._distill_model/_distill_effort at call
+# time): "triage" (the default) means FOLLOW the triage pick live — exactly what the distiller/briefer/
+# staller did before the split (the user 2026-08-14) — and effort's "none" pins no-flag. "none" exists
+# because "" cannot: _state_str folds an empty file into the default, so an allow_empty pin here would
+# read back as "follow" (caught by test_distill_tier before it shipped).
+def _set_distill_model(v):  _set_judge_state("distill-model", v, _MODEL_VALUES | {"triage"})
+def _set_distill_effort(v): _set_judge_state("distill-effort", v, _EFFORT_VALUES | {"triage", "none"})
 
 
 # The four judge-tier settings PROPAGATE: a pick made here follows to every linked kernel (the user
@@ -18565,18 +18591,23 @@ def _set_index_effort(v): _set_judge_state("index-effort", v, _EFFORT_VALUES, al
 # made from (or forwarded via) the machine that owns its tunnel.
 
 _JUDGE_SETTING_FIELDS = (("judgeModel", _set_judge_model), ("indexModel", _set_index_model),
-                         ("judgeEffort", _set_judge_effort), ("indexEffort", _set_index_effort))
+                         ("judgeEffort", _set_judge_effort), ("indexEffort", _set_index_effort),
+                         ("distillModel", _set_distill_model), ("distillEffort", _set_distill_effort))
 
 
 def _apply_judge_settings(body):
-    """Apply any of the four judge-tier fields in `body` through the validated setters (garbage
-    never reaches the state files or `claude --model`), and answer with the CURRENT four values —
-    the ack shows what actually landed, since an invalid value is deliberately ignored."""
+    """Apply any of the judge-tier fields in `body` through the validated setters (garbage
+    never reaches the state files or `claude --model`), and answer with the CURRENT values —
+    the ack shows what actually landed, since an invalid value is deliberately ignored. The
+    distill pair answers RAW ("triage" = following the triage pick), matching /version: the
+    gear shows the user's choice, not its resolution."""
     for key, setter in _JUDGE_SETTING_FIELDS:
         if isinstance(body, dict) and key in body:
             setter(str(body.get(key) or ""))
     return {"ok": True, "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),
-            "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort()}
+            "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort(),
+            "distillModel": jd._state_str("distill-model", "triage"),
+            "distillEffort": jd._state_str("distill-effort", "triage")}
 
 
 def _propagate_judge_settings(body):
@@ -24597,6 +24628,14 @@ class Handler(BaseHTTPRequestHandler):
             _set_index_effort(str(msg.get("effort") or ""))   # gear "Indexing effort"
             threading.Thread(target=_propagate_judge_settings,
                              args=({"indexEffort": str(msg.get("effort") or "")},), daemon=True).start()
+        elif msg and msg.get("type") == "setDistillModel" and msg.get("model"):
+            _set_distill_model(str(msg["model"]))   # gear "Distilling model" ("triage" = follow the triage pick)
+            threading.Thread(target=_propagate_judge_settings,
+                             args=({"distillModel": str(msg["model"])},), daemon=True).start()
+        elif msg and msg.get("type") == "setDistillEffort" and msg.get("effort"):
+            _set_distill_effort(str(msg["effort"]))   # gear "Distilling effort" ("triage" = follow; "none" = pinned no-flag)
+            threading.Thread(target=_propagate_judge_settings,
+                             args=({"distillEffort": str(msg["effort"])},), daemon=True).start()
 
     def _ws(self):
         key = self.headers.get("Sec-WebSocket-Key")

--- a/tests/test_distill_tier.py
+++ b/tests/test_distill_tier.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""The DISTILLING judge tier (the user 2026-08-14): distiller, briefer and staller — the card-prose
+writers — run their own model/effort pair, split out of triage. The stored sentinel "triage" (the
+default) means FOLLOW the triage setting live, exactly what these judges did before the split, so
+nothing changes until the user pins a value. Synthetic only; hermetic state dir."""
+import inspect
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_distill", os.path.join(BIN, "romp-judge")).load_module()
+
+
+class DistillTierResolution(unittest.TestCase):
+    def setUp(self):
+        for f in ("judge-model", "judge-effort", "distill-model", "distill-effort"):
+            try:
+                (jd.STATE / f).unlink()
+            except OSError:
+                pass
+        jd._state_cache.clear()
+
+    def _put(self, name, value):
+        jd.STATE.mkdir(parents=True, exist_ok=True)
+        (jd.STATE / name).write_text(value)
+        jd._state_cache.clear()   # same-second writes share an mtime; the cache is not under test
+
+    def test_unset_follows_the_triage_pick_live(self):
+        self._put("judge-model", "haiku")
+        self._put("judge-effort", "high")
+        self.assertEqual(jd._distill_model(), "haiku")
+        self.assertEqual(jd._distill_effort(), "high")
+        self._put("judge-model", "fable")     # triage moves; the unset distill pair moves WITH it
+        self.assertEqual(jd._distill_model(), "fable")
+
+    def test_the_stored_sentinel_is_follow_not_a_model_name(self):
+        self._put("distill-model", "triage")
+        self._put("judge-model", "haiku")
+        self.assertEqual(jd._distill_model(), "haiku")
+
+    def test_a_pinned_value_stops_following(self):
+        self._put("judge-model", "haiku")
+        self._put("distill-model", "fable")
+        self.assertEqual(jd._distill_model(), "fable")
+        self._put("judge-model", "sonnet")    # triage moves; the pinned pair does not
+        self.assertEqual(jd._distill_model(), "fable")
+
+    def test_pinned_none_effort_means_no_flag_even_when_triage_has_one(self):
+        # "none" is the stored no-flag pin: "" cannot be stored (_state_str folds an empty file into
+        # the default, which here means "follow triage" — the exact bug this test caught pre-ship)
+        self._put("judge-effort", "high")
+        self._put("distill-effort", "none")
+        self.assertEqual(jd._distill_effort(), "")
+
+    def test_the_prose_call_sites_run_the_distill_tier(self):
+        # the split is only real if the three card-prose judges actually resolve it — and the tier
+        # rides into _judge_run so the effort resolution and env stay per-tier
+        for fn in (jd.distill_llm, jd.brief_llm):
+            src = inspect.getsource(fn)
+            self.assertIn("_distill_model()", src, fn.__name__)
+            self.assertIn('tier="distill"', src, fn.__name__)
+        full = inspect.getsource(jd)
+        self.assertIn('_judge_run(_distill_model(), STALL_BRIEF_SYS', full)
+        self.assertIn('_distill_effort() if tier == "distill"', inspect.getsource(jd._judge_run))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -5650,7 +5650,7 @@ class Distiller(unittest.TestCase):
         # a LIST of (sub-goal, why) pairs → a numbered <owed> block, one line per pair, so the prompt can map
         # each to its own takeaway paragraph. A plain string (single block) is passed through unchanged.
         seen, saved = {}, jd._judge_run
-        jd._judge_run = lambda model, sysp, user, effort=None, judge=None: (seen.update(user=user) or "a brief")
+        jd._judge_run = lambda model, sysp, user, effort=None, judge=None, tier="triage": (seen.update(user=user) or "a brief")
         try:
             jd.brief_llm("the goal", "the work",
                          [("record the screencast", "you record it"),
@@ -5795,7 +5795,7 @@ class BlockBriefJudgeLabel(unittest.TestCase):
 
     def test_brief_llm_logs_as_the_briefer(self):
         seen, saved = {}, jd._judge_run
-        jd._judge_run = lambda model, sysp, user, effort=None, judge=None: (seen.update(judge=judge) or "a brief")
+        jd._judge_run = lambda model, sysp, user, effort=None, judge=None, tier="triage": (seen.update(judge=judge) or "a brief")
         try:
             jd.brief_llm("the goal", "the work", "owed a decision")
         finally:

--- a/tests/test_judge_settings_sync.py
+++ b/tests/test_judge_settings_sync.py
@@ -32,11 +32,44 @@ km = SourceFileLoader("romp_kernel_judgesync", os.path.join(BIN, "romp-kernel"))
 
 class ApplySettings(unittest.TestCase):
     def setUp(self):
-        for f in ("judge-model", "index-model", "judge-effort", "index-effort"):
+        for f in ("judge-model", "index-model", "judge-effort", "index-effort",
+                  "distill-model", "distill-effort"):
             try:
                 (km.jd.STATE / f).unlink()
             except OSError:
                 pass
+
+    def test_distill_pair_applies_pins_and_reports_raw(self):
+        # the ack answers the RAW stored value ("triage" = following the triage pick), matching
+        # /version, so the gear shows the user's CHOICE — never its resolution
+        res = km._apply_judge_settings({})
+        self.assertEqual((res["distillModel"], res["distillEffort"]), ("triage", "triage"))
+        res = km._apply_judge_settings({"distillModel": "haiku", "distillEffort": "none"})
+        self.assertEqual((km.jd.STATE / "distill-model").read_text(), "haiku")
+        self.assertEqual((km.jd.STATE / "distill-effort").read_text(), "none",
+                         '"none" PINS no-flag; "" is unstorable (folds into the follow default) and ignored')
+        self.assertEqual((res["distillModel"], res["distillEffort"]), ("haiku", "none"))
+        res = km._apply_judge_settings({"distillEffort": ""})
+        self.assertEqual(res["distillEffort"], "none", "an empty distill effort is invalid, not a clear")
+
+    def test_distill_sentinel_returns_the_pair_to_follow_mode(self):
+        km._apply_judge_settings({"distillModel": "haiku", "distillEffort": "high"})
+        res = km._apply_judge_settings({"distillModel": "triage", "distillEffort": "triage"})
+        self.assertEqual((res["distillModel"], res["distillEffort"]), ("triage", "triage"))
+
+    def test_distill_garbage_is_ignored_like_every_other_tier(self):
+        km._apply_judge_settings({"distillModel": "haiku"})
+        res = km._apply_judge_settings({"distillModel": "gpt-99"})
+        self.assertEqual(res["distillModel"], "haiku", "garbage never reaches `claude --model`")
+
+    def test_version_and_tunnels_carry_the_settings_dict(self):
+        # source pins in the sync file's own style: /version publishes ONE settings dict a peer
+        # kernel lifts onto its /tunnels row, and the row serializer forwards it (None = older kernel)
+        import inspect
+        src = inspect.getsource(km)
+        self.assertIn('"settings": {"autoNudge": _auto_nudge_on(), "updateMode": _update_mode()', src)
+        self.assertIn('"settings": r.get("settings") if isinstance(r.get("settings"), dict) else None', src)
+        self.assertIn('r["settings"] = (rver or {}).get("settings")', src)
 
     def test_valid_fields_land_and_the_ack_reports_them(self):
         res = km._apply_judge_settings({"judgeModel": "fable", "indexEffort": "low"})

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -70,12 +70,16 @@ class SettingsSectionsTest(unittest.TestCase):
         self.assertNotIn("headless", h)
 
     def test_judge_rows_are_one_line_label_plus_picker(self):
-        # label + picker share the line (the user 2026-07-12): four .rs-jrow rows, the select right after
-        # the hover sub, no full-width select stacked under the label; the flex CSS carries the layout
+        # label + picker share the line (the user 2026-07-12): six .rs-jrow rows since the distilling
+        # tier split out of triage (the user 2026-08-14), the select right after the hover sub, no
+        # full-width select stacked under the label; the flex CSS carries the layout. Each label now
+        # carries the hidden mixed-state marker (the settings-sync work, same day).
         h = _gear_src()
-        self.assertEqual(h.count("rs-jrow"), 4)
-        for sel in ("rs-judgemodel", "rs-judgeeffort", "rs-indexmodel", "rs-indexeffort"):
-            self.assertRegex(h, r"rs-jrow'><b>[^<]+</b><span class=rs-sub>[^<]*</span><select id=" + sel)
+        self.assertEqual(h.count("rs-jrow"), 6)
+        for sel in ("rs-judgemodel", "rs-judgeeffort", "rs-distillmodel", "rs-distilleffort",
+                    "rs-indexmodel", "rs-indexeffort"):
+            self.assertRegex(h, r"rs-jrow'><b>[^<]+<span class=rs-mixed hidden></span></b>"
+                                r"<span class=rs-sub>[^<]*</span><select id=" + sel)
         self.assertIn("#rsettings .rs-jrow select {", _gear_css_src())
 
     def test_collapse_gaps_is_wired_to_the_shared_collapseGaps_setting(self):

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -57,12 +57,15 @@ const OBJ_ID = ["tabs"]; //                       an array of objects keyed by `
 // Gear settings the KERNEL acts on, which each kernel stores its own copy of: they describe how romp
 // behaves towards the sessions it is running, so a machine that never hears the change goes on behaving
 // the old way. setUpdateMode belongs here too: each kernel runs its own boot release check, so a machine
-// that misses the change keeps handling new releases under the old policy (ask/auto/off). Broadcast in
+// that misses the change keeps handling new releases under the old policy (ask/auto/off). The distilling
+// pair rides like the other judge tiers (the user 2026-08-14: everything kernel-side stays in sync; the
+// gear's mixed marks surface any machine that disagrees rather than overwriting it silently). Broadcast in
 // routeOutbound rather than routed. Deliberately NOT here: setDefaultDir (a path on one machine,
 // meaningless on another) and setColormap/setPalette (the viewer's display prefs, which the local kernel
 // persists for this browser).
 const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel",
-                                "setJudgeEffort", "setIndexEffort", "setUpdateMode"]);
+                                "setJudgeEffort", "setIndexEffort", "setUpdateMode",
+                                "setDistillModel", "setDistillEffort"]);
 
 /** Return a COPY of an inbound message with every session-id field prefixed by `host`. The local host
  *  ("") is the identity transform, so local messages are untouched. Unknown fields pass through. */

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -61,7 +61,7 @@ var GEAR_HTML =
   '<span><b>Auto Nudge</b><span class=rs-mixed id=rs-autonudge-split hidden></span>' +
   '<span class=rs-sub id=rs-autonudge-sub>' + AUTONUDGE_SUB + '</span>' +
   '</span></label>' +
-  "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Automatic updates</b>" +
+  "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Automatic updates <span class=rs-mixed hidden></span></b>" +
   '<span class=rs-sub>romp checks its repo for a new tagged release at start-up and every 6 hours (ordinary commits never trigger it; updating lands exactly on the release). Check and ask (the default) offers it as a banner with an Update button; Install automatically fetches, installs and restarts by itself; Off never checks. Kernel-side setting.</span>' +
   "<select id=rs-updates style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
   "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
@@ -74,10 +74,12 @@ var GEAR_HTML =
   '<option value=sdk>SDK</option><option value=tmux>tmux (terminal)</option>' +
   '</select></span></div>' +
   '<div class=rs-sec>Judges</div>' +
-  "<div class='rs-row rs-jrow'><b>Triage model</b><span class=rs-sub>The model the triage judges use — planner, grouper, closer, distiller, courier (the judgment-heavy tier). Applies on the judges' next pass; no restart. A pick here follows to every connected machine's kernel.</span><select id=rs-judgemodel></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Triage effort</b><span class=rs-sub>Thinking effort for the triage judges. Default = no effort flag (the judges' standard behavior). Not every model accepts every level. Follows to every connected machine's kernel.</span><select id=rs-judgeeffort></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Indexing model</b><span class=rs-sub>The model the indexing judges use — captioner + archiver (high-volume, low-stakes summarization). Haiku by default for cost. Follows to every connected machine's kernel.</span><select id=rs-indexmodel></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Indexing effort</b><span class=rs-sub>Thinking effort for the indexing judges. Default = none (indexing runs with thinking disabled as a cost lever; leave Default unless you know you want it). Follows to every connected machine's kernel.</span><select id=rs-indexeffort></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Triage model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the triage judges use — planner, grouper, closer, courier (the judgment-heavy tier). Applies on the judges' next pass; no restart. A pick here follows to every connected machine's kernel.</span><select id=rs-judgemodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Triage effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the triage judges. Default = no effort flag (the judges' standard behavior). Not every model accepts every level. Follows to every connected machine's kernel.</span><select id=rs-judgeeffort></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Distilling model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model for the judges that write the prose you read on cards — distiller, briefer, staller. Follow triage (the default) keeps them on the triage pick; pinning a model here lets the copy you read run richer than the placement judges. Follows to every connected machine's kernel.</span><select id=rs-distillmodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Distilling effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the distilling judges. Follow triage (the default) rides the triage effort; Default pins no effort flag. Follows to every connected machine's kernel.</span><select id=rs-distilleffort></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Indexing model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the indexing judges use — captioner + archiver (high-volume, low-stakes summarization). Haiku by default for cost. Follows to every connected machine's kernel.</span><select id=rs-indexmodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Indexing effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the indexing judges. Default = none (indexing runs with thinking disabled as a cost lever; leave Default unless you know you want it). Follows to every connected machine's kernel.</span><select id=rs-indexeffort></select></div>" +
   '<div class=rs-sec>Keyboard shortcuts</div>' + SHORTCUT_ROWS +
   '<div class=rs-sec>Chat</div>' +
   '<label class=rs-row><input type=checkbox id=rs-compact>' +
@@ -162,6 +164,7 @@ function initGear(post) {
     jm = document.getElementById('rs-judgemodel'),
     im = document.getElementById('rs-indexmodel'), je = document.getElementById('rs-judgeeffort'),
     ie = document.getElementById('rs-indexeffort'), upm = document.getElementById('rs-updates'),
+    dm = document.getElementById('rs-distillmodel'), de = document.getElementById('rs-distilleffort'),
     ans = document.getElementById('rs-autonudge-split'), asub = document.getElementById('rs-autonudge-sub');
   function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', collapseGaps: true, activeOnly: true }; } }
   // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
@@ -201,6 +204,8 @@ function initGear(post) {
   if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value }); });
   if (je) je.addEventListener('change', function () { post({ type: 'setJudgeEffort', effort: je.value }); });
   if (ie) ie.addEventListener('change', function () { post({ type: 'setIndexEffort', effort: ie.value }); });
+  if (dm) dm.addEventListener('change', function () { post({ type: 'setDistillModel', model: dm.value }); });
+  if (de) de.addEventListener('change', function () { post({ type: 'setDistillEffort', effort: de.value }); });
   // feed-colormap preview bar: a horizontal gradient of the SELECTED map's stops (mirrors render.ts COLORMAPS).
   var CMAPS = { aurora: [[84, 178, 4], [0, 180, 115], [35, 175, 156], [66, 169, 176], [25, 168, 201], [14, 164, 227], [74, 155, 241], [113, 145, 244], [144, 136, 240]],
     hawaii: [[140, 2, 115], [146, 46, 85], [151, 78, 62], [155, 111, 40], [156, 150, 28], [137, 189, 74], [107, 212, 142], [103, 233, 213], [179, 242, 253]],
@@ -259,9 +264,15 @@ function initGear(post) {
     return fetch(ku('/models'), { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (d) {
       choices = d || { models: [], efforts: [] };
       var mo = (choices.models || []).map(function (m) { return '<option value="' + m.value + '">' + m.label + '</option>'; }).join('');
-      var eo = '<option value="">Default</option>' + (choices.efforts || []).map(function (m) { return '<option value="' + m.value + '">' + m.label + '</option>'; }).join('');
+      var eff = (choices.efforts || []).map(function (m) { return '<option value="' + m.value + '">' + m.label + '</option>'; }).join('');
+      var eo = '<option value="">Default</option>' + eff;
       if (jm) jm.innerHTML = mo; if (im) im.innerHTML = mo;
       if (je) je.innerHTML = eo; if (ie) ie.innerHTML = eo;
+      // the distilling pair leads with the follow-triage sentinel — its default, so a fresh kernel
+      // shows "Follow triage" rather than a model nobody picked. Its Default (no effort flag) is the
+      // stored sentinel "none", never "" — an empty state file reads back as the default ("follow").
+      if (dm) dm.innerHTML = '<option value="triage">Follow triage</option>' + mo;
+      if (de) de.innerHTML = '<option value="triage">Follow triage</option><option value="none">Default</option>' + eff;
       return choices;
     }).catch(function () { return null; });
   }
@@ -284,29 +295,61 @@ function initGear(post) {
   // rather than read as off: guessing would invent a disagreement and invite a click that changes a
   // machine nobody asked about. Same for a host that is not `up`, whose row is a memory (see
   // _remote_public's stale note). A /tunnels that fails leaves the local answer standing.
-  function fillAutoNudge(mine) {
+  function fillAutoNudge(mine, rows) {
     if (!an) return;
     an.checked = !!mine;
     clearAutoNudgeSplit();
-    fetch(ku('/tunnels'), { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (d) {
-      var split = ((d && d.tunnels) || []).filter(function (t) {
-        return t && t.status === 'up' && typeof t.autoNudge === 'boolean' && t.autoNudge !== !!mine;
+    var split = (rows || []).filter(function (t) {
+      return t && t.status === 'up' && typeof t.autoNudge === 'boolean' && t.autoNudge !== !!mine;
+    }).map(function (t) { return t.host; });
+    if (!split.length) return;
+    an.indeterminate = true;
+    if (ans) { ans.textContent = 'mixed'; ans.hidden = false; }
+    if (asub) asub.textContent = AUTONUDGE_SUB
+      + (mine ? ' Right now these have it off: ' : ' Right now these still have it on: ')
+      + split.join(', ') + '. Clicking sets them all the same way.';
+  }
+  // The autoNudge rule, generalized to EVERY kernel-side select (the user 2026-08-14): the control keeps
+  // showing the LOCAL kernel's value, and a small "mixed" mark appears when a connected, up, REPORTING
+  // machine disagrees — hover names the hosts. A machine that never reported (older kernel, unpolled row)
+  // is unknown, never a disagreement: guessing would invite a click that changes a machine nobody asked
+  // about. One pick posts to every kernel (KERNEL_SETTING) and the next fill clears the mark — the local
+  // value is the default ANSWER to confirm, never a silent overwrite of a remote's deliberate setting.
+  function fillMixedMarks(v, rows) {
+    var mine = (v && v.settings) || null;
+    [['updateMode', upm], ['judgeModel', jm], ['judgeEffort', je], ['indexModel', im],
+     ['indexEffort', ie], ['distillModel', dm], ['distillEffort', de]].forEach(function (pair) {
+      var key = pair[0], el = pair[1];
+      if (!el) return;
+      var row = el.closest ? el.closest('.rs-row') : null;
+      var mark = row ? row.querySelector('.rs-mixed') : null;
+      if (mark) { mark.hidden = true; mark.textContent = ''; mark.removeAttribute('title'); }
+      if (!mine || typeof mine[key] === 'undefined' || !mark) return;
+      var split = (rows || []).filter(function (t) {
+        return t && t.status === 'up' && t.settings && typeof t.settings[key] !== 'undefined'
+          && String(t.settings[key]) !== String(mine[key]);
       }).map(function (t) { return t.host; });
       if (!split.length) return;
-      an.indeterminate = true;
-      if (ans) { ans.textContent = 'mixed'; ans.hidden = false; }
-      if (asub) asub.textContent = AUTONUDGE_SUB
-        + (mine ? ' Right now these have it off: ' : ' Right now these still have it on: ')
-        + split.join(', ') + '. Clicking sets them all the same way.';
-    }).catch(function () {});
+      mark.textContent = 'mixed';
+      mark.title = 'differs on: ' + split.join(', ') + ' — picking here sets every machine the same way';
+      mark.hidden = false;
+    });
   }
   function fill() { fillChoices().then(function () { return fetch(ku('/version'), { cache: 'no-store' }); }).then(function (r) { return r.json(); }).then(function (v) {
-    fillAutoNudge(v.autoNudge);
+    // ONE /tunnels fetch feeds every cross-machine comparison: the autoNudge box and the select marks.
+    // A failed /tunnels leaves the local answers standing, unmarked — same fallback as before.
+    fetch(ku('/tunnels'), { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (d) {
+      var rows = (d && d.tunnels) || [];
+      fillAutoNudge(v.autoNudge, rows);
+      fillMixedMarks(v, rows);
+    }).catch(function () { fillAutoNudge(v.autoNudge, []); fillMixedMarks(v, []); });
     if (upm && typeof v.updateMode === 'string') upm.value = v.updateMode;   // the kernel's persisted mode is authoritative
     if (jm && typeof v.judgeModel === 'string') jm.value = v.judgeModel;   // the judge's ACTUAL current model/effort per tier is authoritative
     if (im && typeof v.indexModel === 'string') im.value = v.indexModel;
     if (je && typeof v.judgeEffort === 'string') je.value = v.judgeEffort;
     if (ie && typeof v.indexEffort === 'string') ie.value = v.indexEffort;
+    if (dm && typeof v.distillModel === 'string') dm.value = v.distillModel;   // RAW: "triage" selects the Follow-triage option
+    if (de && typeof v.distillEffort === 'string') de.value = v.distillEffort;
     if (dd && typeof v.defaultDir === 'string') dd.value = v.defaultDir;   // the kernel's persisted default is authoritative
     // Browse… draws on the KERNEL's screen, and a kernel with no desktop has none — the click used to
     // vanish into a macOS-only dialog. Drop the button rather than offer one that cannot work; the

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -45,8 +45,33 @@ test("every gear fetch routes through the kernel base + token (VS Code's webview
 test("the gear posts kernel ops through ONE shared channel (never re-acquires the VS Code API)", () => {
   assert.ok(!GEAR.includes("acquireVsCodeApi"), "a second acquire throws in a real webview");
   for (const op of ["setAutoNudge", "setJudgeModel", "setIndexModel", "setJudgeEffort", "setIndexEffort",
-    "setColormap", "setPalette", "setDefaultDir", "browseDir"])
+    "setDistillModel", "setDistillEffort", "setColormap", "setPalette", "setDefaultDir", "browseDir"])
     assert.ok(GEAR.includes(`'${op}'`), `gear must post ${op}`);
+});
+
+test("the distilling tier is its own gear pair, defaulting to follow-triage", () => {
+  // The user 2026-08-14: the card-prose judges (distiller, briefer, staller) split out of triage so
+  // what you READ can run a richer model than the placement judges. The stored sentinel "triage"
+  // means follow the triage pick live — today's behavior until the user pins — so the selects must
+  // lead with that option and fill from the RAW /version value, never the resolved model.
+  for (const id of ["rs-distillmodel", "rs-distilleffort"])
+    assert.ok(GEAR.includes(id), `the gear must render ${id}`);
+  assert.ok(GEAR.includes('"triage">Follow triage'), "the follow-triage option leads both selects");
+  assert.ok(GEAR.includes('"none">Default'), "the effort's no-flag pin is the stored sentinel, never ''");
+  assert.ok(GEAR.includes("v.distillModel"), "fill() reads the RAW distill model value");
+  assert.ok(GEAR.includes("v.distillEffort"), "fill() reads the RAW distill effort value");
+});
+
+test("every kernel-side select says so when connected machines disagree (the autoNudge rule generalized)", () => {
+  // The user 2026-08-14: everything stays in sync; on disagreement the gear ASKS by showing the local
+  // value with a mixed mark beside it — hover names the hosts, one pick sets every machine — and a
+  // machine that never reported (an older kernel) is unknown, never a disagreement to click away.
+  assert.ok(GEAR.includes("fillMixedMarks"), "the generalized reconcile must exist and be called");
+  assert.ok(/t\.settings && typeof t\.settings\[key\] !== 'undefined'/.test(GEAR),
+    "non-reporting rows are excluded, not read as disagreeing");
+  assert.ok(GEAR.includes("differs on: "), "the hover names the disagreeing hosts");
+  const mixedSpans = GEAR.match(/class=rs-mixed hidden/g) || [];
+  assert.ok(mixedSpans.length >= 7, `every kernel-side select carries a marker span (got ${mixedSpans.length})`);
 });
 
 test("the Auto Nudge box speaks for every attached machine, and says so when they disagree", () => {

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -430,7 +430,9 @@ test("routeOutbound: the gear's kernel-side settings reach EVERY attached kernel
                      { type: "setIndexModel", model: "haiku" },
                      { type: "setJudgeEffort", effort: "high" },
                      { type: "setIndexEffort", effort: "" },
-                     { type: "setUpdateMode", mode: "auto" }]) {
+                     { type: "setUpdateMode", mode: "auto" },
+                     { type: "setDistillModel", model: "haiku" },
+                     { type: "setDistillEffort", effort: "triage" }]) {
     const routes = routeOutbound(msg, new Set(["TESTHOST", "gpu1"]));
     assert.deepEqual(routes.map((r) => r.host).sort(), ["", "TESTHOST", "gpu1"].sort(), msg.type);
     for (const r of routes) assert.deepEqual(r.msg, msg, "the kernels are host-blind: same message to each");


### PR DESCRIPTION
The user's ask (2026-08-14, via the watch session): split the judge tiers into three separately selectable settings, and make every kernel-side setting sync across connected kernels with disagreement surfaced — local preferred, never a silent overwrite.

**Three tiers.** The card-prose writers — distiller, briefer, staller — split out of triage as the DISTILLING pair (model + effort), same jrow pattern, own persisted settings + /version fields + `setDistillModel`/`setDistillEffort` WS ops riding the existing kernel-side judge-settings fan-out. The stored sentinel `triage` (the default) follows the triage pick live — exactly what these judges did before the split, so nothing changes until the user pins. Effort's no-flag pin is the sentinel `none`: `_state_str` folds an empty file into the default, so an empty-string pin would read back as "follow" (caught by the new tests before shipping, not after).

**Every kernel-side setting broadcasts.** `setDistillModel`/`setDistillEffort` join `KERNEL_SETTING` (`setUpdateMode` already landed separately today). Viewer-local settings stay local per the existing comment.

**Disagreement is surfaced, never silent.** Each remote's kernel-side values ride its /version poll onto its /tunnels row as one `settings` dict (older kernels report none and are EXCLUDED from the comparison — unknown is never a disagreement). The gear generalizes the autoNudge rule to all seven controls: the select keeps showing the LOCAL value, a `mixed` mark appears beside any control where an up, reporting machine differs, hover names the hosts, and one pick broadcasts everywhere and clears the mark. A remote's deliberate setting is presented for the user to resolve — attach never silently overwrites it.

Tests: node — broadcast list (`multi-kernel-merge.test.ts`), gear pins for the new pair + generalized marks (`gear.test.ts`); python — tier resolution follow/pin/none semantics (`test_distill_tier.py`), setter validation + raw acks + settings-dict plumbing (`test_judge_settings_sync.py`), judge suite stubs widened for the tier kwarg. Full suites green both stacks (python 419+13+5+4, node 1954).

🤖 Generated with [Claude Code](https://claude.com/claude-code)