### PR TITLE
A queued quiet-window refresh can no longer die silently

### DIFF
--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -340,6 +340,34 @@ function clearPendingQuiet() {
   pendingQuiet = null;
 }
 
+// One evaluation step of the pending-quiet chain, dependencies injected so the CHAIN is unit-testable —
+// quietGate always was, but the loop around it wasn't, and that is exactly where the 2026-08-14 incident
+// lived: a queued refresh logged "backstop 15 min" and then silently never applied, because the old chain
+// re-armed the next tick only INSIDE the busy-probe callback — a probe whose callback never fired killed
+// the whole pending refresh with zero further log lines. Contract, each piece load-bearing:
+//  - SCHEDULE-FIRST: the next tick is armed before the probe, so a hung callback costs one evaluation,
+//    never the chain (apply clears the pre-armed timer via clearPendingQuiet);
+//  - the callback acts at most once (http 'timeout' destroys the request and 'error' follows — a double
+//    fire must not evaluate twice);
+//  - a throwing evaluation is LOUD and leaves the refresh queued (fail loudly, never evaporate).
+function quietTick(deps) {
+  const { pending, fetchBusy, now, opts, apply, schedule, log } = deps;
+  if (!pending()) return;                 // an immediate restart satisfied it meanwhile
+  schedule();                             // schedule-first: the chain outlives any probe failure
+  let acted = false;
+  fetchBusy((busy) => {
+    if (acted) return;
+    acted = true;
+    if (!pending()) return;
+    try {
+      const g = quietGate(pending(), busy, now(), opts);
+      if (g.action === 'apply') apply(g);
+    } catch (e) {
+      log(`quiet-window evaluation failed (${e && e.message}) — the pending refresh stays queued`);
+    }
+  });
+}
+
 function queueQuietRestart(mode) {
   if (pendingQuiet) {
     pendingQuiet.count++;
@@ -349,21 +377,20 @@ function queueQuietRestart(mode) {
   }
   pendingQuiet = { since: Date.now(), count: 1, mode, timer: null };
   log(`refresh queued — applying at the next quiet window (no SDK turn in flight; backstop ${Math.round(QUIET_MAX_DEFER_MS / 60000)} min)`);
-  const tick = () => {
-    if (!pendingQuiet) return;                       // an immediate restart satisfied it meanwhile
-    fetchBusy(KERNEL_PORT, (busy) => {
-      if (!pendingQuiet) return;
-      const g = quietGate(pendingQuiet, busy, Date.now(), { maxDeferMs: QUIET_MAX_DEFER_MS });
-      if (g.action === 'apply') {
-        const p = pendingQuiet;
-        clearPendingQuiet();
-        log(`applying deferred refresh — ${g.reason} (${p.count} request(s) coalesced, waited ${Math.round((Date.now() - p.since) / 1000)}s)`);
-        if (p.mode === 'all') restartAllOrSelf(); else restartKernel(p.mode);
-      } else {
-        pendingQuiet.timer = setTimeout(tick, QUIET_POLL_MS);
-      }
-    });
-  };
+  const tick = () => quietTick({
+    pending: () => pendingQuiet,
+    fetchBusy: (cb) => fetchBusy(KERNEL_PORT, cb),
+    now: Date.now,
+    opts: { maxDeferMs: QUIET_MAX_DEFER_MS },
+    log,
+    schedule: () => { pendingQuiet.timer = setTimeout(tick, QUIET_POLL_MS); },
+    apply: (g) => {
+      const p = pendingQuiet;
+      clearPendingQuiet();               // also disarms the pre-armed next tick
+      log(`applying deferred refresh — ${g.reason} (${p.count} request(s) coalesced, waited ${Math.round((Date.now() - p.since) / 1000)}s)`);
+      if (p.mode === 'all') restartAllOrSelf(); else restartKernel(p.mode);
+    },
+  });
   tick();
   return 1;
 }
@@ -515,7 +542,7 @@ function ensureUp() {
 // ── dispatch ────────────────────────────────────────────────────────────────
 // Exported for unit tests (restartGate = the pure storm-cap decision). The CLI dispatch runs only when this
 // file is executed directly, so require()-ing it from a test has no side effects.
-module.exports = { restartGate, quietGate, loadSpecs, specEnv, fileStamp };
+module.exports = { restartGate, quietGate, quietTick, loadSpecs, specEnv, fileStamp };
 if (require.main === module) {
   const cmd = process.argv[2];
   // `restart-all` (the `romp refresh` deploy path) defers to the next quiet window by default —

--- a/tests/manager-restart.test.js
+++ b/tests/manager-restart.test.js
@@ -75,3 +75,46 @@ test('the backstop cap applies even while busy — a deploy can never starve', (
 test('just under the cap still waits', () => {
   assert.equal(quietGate({ since: 1000 }, 5, 999 + QOPTS.maxDeferMs, QOPTS).action, 'wait');
 });
+
+// quietTick — the CHAIN around quietGate (the 2026-08-14 incident: a queued refresh logged its backstop
+// and then silently never applied; the old loop re-armed the next tick only inside the busy-probe
+// callback, so a probe whose callback never fired killed the pending refresh with zero further log
+// lines). Dependency-injected: these tests drive the exact seams that failed.
+const { quietTick } = require(path.join(__dirname, '..', 'bin', 'romp-manager'));
+
+test('quietTick: a probe whose callback never fires cannot kill the chain (schedule-first)', () => {
+  let scheduled = 0;
+  quietTick({ pending: () => ({ since: 0 }), fetchBusy: () => {}, now: () => 1000,
+              opts: QOPTS, log: () => {}, schedule: () => { scheduled++; }, apply: () => {} });
+  assert.equal(scheduled, 1);
+});
+
+test('quietTick: a double-fired probe callback evaluates once (http timeout + error both fire)', () => {
+  let applied = 0; let cb;
+  quietTick({ pending: () => ({ since: 0 }), fetchBusy: (c) => { cb = c; }, now: () => 1000,
+              opts: QOPTS, log: () => {}, schedule: () => {}, apply: () => { applied++; } });
+  cb(0); cb(0);
+  assert.equal(applied, 1);
+});
+
+test('quietTick: a throwing evaluation is LOUD and leaves the refresh queued', () => {
+  let logged = ''; let applied = 0;
+  quietTick({ pending: () => ({ since: 0 }), fetchBusy: (c) => c(0), now: () => { throw new Error('boom'); },
+              opts: QOPTS, log: (m) => { logged = m; }, schedule: () => {}, apply: () => { applied++; } });
+  assert.match(logged, /stays queued/);
+  assert.equal(applied, 0);
+});
+
+test('quietTick: a satisfied pending (an immediate restart won) neither probes nor re-arms', () => {
+  let scheduled = 0;
+  quietTick({ pending: () => null, fetchBusy: () => { throw new Error('must not probe'); },
+              now: () => 0, opts: QOPTS, log: () => {}, schedule: () => { scheduled++; }, apply: () => {} });
+  assert.equal(scheduled, 0);
+});
+
+test('quietTick: a quiet fleet applies through the injected apply', () => {
+  let applied = null;
+  quietTick({ pending: () => ({ since: 0 }), fetchBusy: (c) => c(0), now: () => 1000,
+              opts: QOPTS, log: () => {}, schedule: () => {}, apply: (g) => { applied = g; } });
+  assert.equal(applied && applied.reason, 'quiet');
+});


### PR DESCRIPTION
Live incident today: `romp refresh` (quiet mode) logged "refresh queued — applying at the next quiet window (backstop 15 min)" and then nothing, an hour past the cap — no apply line, no restart, no error. The deferred refresh had simply evaporated. Root cause: the tick chain re-armed the next tick only INSIDE the busy-probe callback, so any probe whose callback never fires (a hung response is enough) kills the entire pending refresh with zero further log lines — the silent-degrade shape the repo rules ban.

The loop around `quietGate` (which was already pure and tested) is now `quietTick`, dependency-injected and unit-tested on exactly the seams that failed:
- **Schedule-first:** the next tick is armed before the probe, so a hung callback costs one evaluation, never the chain; the apply path disarms the pre-armed timer via `clearPendingQuiet`.
- **At-most-once:** an http `timeout` destroys the request and `error` follows — a double-fired callback must not evaluate twice.
- **Fail loudly:** a throwing evaluation logs and leaves the refresh queued rather than evaporating.

Five new chain tests in `tests/manager-restart.test.js` (hung probe, double fire, throwing evaluation, satisfied-pending no-op, quiet apply); the existing end-to-end quiet-mode bats test passes unchanged on the restructured loop. Manager node suite 24/24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)