### PR TITLE
Offer Bypass permissions in the mode picker, on SDK sessions only

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5856,7 +5856,14 @@ def _drive(msg, client):
                                        "text": "Couldn't toggle fast mode — the session isn't connected right now."}))
         _push_soon()
     elif t == "setMode" and msg.get("value"):
-        be.set_mode(sid, str(msg["value"])); _push_soon()
+        # LOUD on refusal (fail loudly, never degrade silently): a tmux session reaches its permission
+        # mode only through the shift+tab cycle, so Bypass — which the picker offers on SDK sessions —
+        # has no keystroke there. Without this the badge just sat on the old mode with no reason given.
+        if not be.set_mode(sid, str(msg["value"])):
+            client["send"](json.dumps({"type": "warn",
+                                       "text": "A terminal session can only reach the modes in its "
+                                               "shift+tab cycle — Normal, Accept edits, Auto, Plan."}))
+        _push_soon()
     elif t == "setAuth" and msg.get("value") in ("login", "key"):
         # per-session billing (login vs the manager env's API key) — SDK-only, applied via reconnect
         # like /effort; mid-compaction → parked in the same FIFO. LOUD on refusal (fail loudly): tmux
@@ -6376,6 +6383,13 @@ class TmuxBackend(sb.SessionBackend):
         return True
 
     def set_mode(self, sid, mode):
+        # Only the CYCLE modes are reachable here: shift+tab is the only handle the TUI gives us, so a
+        # mode outside _MODE_CYCLE (bypassPermissions, dontAsk) has no keystroke that reaches it.
+        # _cycle_mode already declined those — but this returned True anyway, so the caller was told a
+        # permission mode had been set when nothing had happened. Say no instead (the user 2026-08-15,
+        # on the picker gaining Bypass: the SDK's own control channel takes it, this backend cannot).
+        if _mode_presses((_tmux_sessions().get(str(sid)) or {}).get("mode") or "default", mode) is None:
+            return False
         _cycle_mode(_name_of(sid) or sid, str(sid), mode)                     # shift+tab cycle to the target mode
         return True
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4186,13 +4186,24 @@ class SdkBackend:
         self._wake_push()
         return True
 
+    # bypassPermissions is the one mode that must not become the remembered default. Every other pick
+    # here is a preference worth inheriting; this one removes the approval gate, and spawn() seeds a new
+    # session from the remembered mode with NOTHING in the create UI that shows it — so one click on one
+    # tab would quietly hand every session you started afterwards an unprompted agent. It stays where you
+    # set it: this session, until you change it (the user 2026-08-15, on the picker adding the entry).
+    # The carve-out is HERE and not in spawn() on purpose: romp declines to remember bypass off a click,
+    # but a mode written into sdk-defaults.json by hand is still honoured, so the escape hatch is open to
+    # anyone who genuinely wants every new session unprompted — they just have to say so deliberately.
+    STICKY_MODE_EXCLUDES = {"bypassPermissions"}
+
     def set_mode(self, sid: str, mode: str) -> bool:
         """Change the permission mode. Persisted in the registry and applied LIVE via the SDK control
         channel (set_permission_mode) — not merely stored for the next reconnect."""
         if not read_reg(self.state_dir, sid):
             return False
         self._update_reg(sid, mode=mode)   # locked RMW — see set_effort's race note
-        write_sdk_default(self.state_dir, mode=mode)   # remember as the seed for the NEXT new session, like model/effort (the user 2026-06-27)
+        if mode not in self.STICKY_MODE_EXCLUDES:
+            write_sdk_default(self.state_dir, mode=mode)   # remember as the seed for the NEXT new session, like model/effort (the user 2026-06-27)
         s = self.sessions.get(sid)
         if s:
             s.mode = mode

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -5155,6 +5155,26 @@ class ViewBuilder(unittest.TestCase):
                       "after cycling, the kernel records the new mode so the chat label updates")
         self.assertIn(["__push_all__"], calls, "and re-renders so the label flips immediately")
 
+    def test_tmux_set_mode_refuses_a_mode_the_cycle_cannot_reach(self):
+        # The picker gained Bypass for SDK sessions (the user 2026-08-15). shift+tab is the only handle
+        # the TUI gives us, so a tmux session cannot reach bypassPermissions/dontAsk at all — and
+        # set_mode used to return True regardless, telling the caller a permission mode had been set
+        # when _cycle_mode had already declined it. Refuse, so the kernel can say so.
+        saved_tmux, saved_cycle = km._tmux_sessions, km._cycle_mode
+        cycled = []
+        km._tmux_sessions = lambda: {SID: {"mode": "auto"}}
+        km._cycle_mode = lambda name, sid, target: cycled.append(target)
+        try:
+            be = km.TmuxBackend()
+            self.assertFalse(be.set_mode(SID, "bypassPermissions"), "no keystroke reaches it → say no")
+            self.assertFalse(be.set_mode(SID, "dontAsk"), "same for the other flag-only mode")
+            self.assertEqual(cycled, [], "and don't pretend to cycle")
+            for m in km._MODE_CYCLE:
+                self.assertTrue(be.set_mode(SID, m), "every cycle mode still goes through: %s" % m)
+            self.assertEqual(cycled, list(km._MODE_CYCLE))
+        finally:
+            km._tmux_sessions, km._cycle_mode = saved_tmux, saved_cycle
+
     def test_recency_colormap_chooser(self):
         # the colormap chooser (the user 2026-06-16): several perceptually-uniform maps + a persisted pick.
         for name in ("hawaii", "viridis", "magma", "inferno", "plasma", "cividis"):

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -1181,6 +1181,31 @@ class SetModelModePure(unittest.TestCase):
         self.assertTrue(self.be.set_mode(sid, "plan"))
         self.assertEqual(sb.read_reg(self.d, sid)["mode"], "plan")
 
+    def test_bypass_applies_to_THIS_session_and_is_never_remembered(self):
+        # The picker offers Bypass on SDK sessions (the user 2026-08-15). Every other mode is a
+        # preference worth inheriting, so it seeds the next new session — but spawn() reads that seed
+        # with nothing in the create UI showing it, so remembering BYPASS would hand every session you
+        # started afterwards an unprompted agent, off one click on one tab. It stays where you set it.
+        sid = self.be.spawn("m", self.d)
+        self.assertTrue(self.be.set_mode(sid, "plan"))
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("mode"), "plan", "an ordinary mode is remembered")
+
+        self.assertTrue(self.be.set_mode(sid, "bypassPermissions"))
+        self.assertEqual(sb.read_reg(self.d, sid)["mode"], "bypassPermissions",
+                         "it DOES apply to the session you set it on")
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("mode"), "plan",
+                         "…and leaves the remembered default alone, rather than clobbering it")
+        self.assertEqual(sb.read_reg(self.d, self.be.spawn("m2", self.d))["mode"], "plan",
+                         "so the NEXT new session comes up prompting, not bypassing")
+
+    def test_bypass_is_not_remembered_even_as_the_first_mode_ever_picked(self):
+        # The guard cannot be "keep the previous default" alone: with no default written yet there is
+        # nothing to keep, and spawn()'s own fallback has to be what a new session lands on.
+        sid = self.be.spawn("m", self.d)
+        self.assertTrue(self.be.set_mode(sid, "bypassPermissions"))
+        self.assertNotEqual(sb.read_sdk_defaults(self.d).get("mode"), "bypassPermissions")
+        self.assertNotEqual(sb.read_reg(self.d, self.be.spawn("m2", self.d))["mode"], "bypassPermissions")
+
     def test_chosen_model_read_from_reg_on_construct(self):
         sess = sb.SdkSession(self.be, {"sid": "x", "name": "n", "cwd": self.d, "model": "sonnet"})
         self.assertEqual(sess.chosen_model, "sonnet")
@@ -1250,13 +1275,23 @@ class RememberedDefaults(unittest.TestCase):
 
     def test_set_mode_is_remembered_and_seeds_the_next_session(self):
         # the bug (the user 2026-06-27): mode wasn't remembered like model/effort, so every new SDK session
-        # came up acceptEdits regardless of the user's preferred (e.g. bypassPermissions/auto-accept) mode.
+        # came up acceptEdits regardless of the user's preferred mode. (This used to demonstrate the point
+        # with bypassPermissions, which is now the ONE mode deliberately left out of the memory — see
+        # SetModelModePure.test_bypass_applies_to_THIS_session_and_is_never_remembered. Any other mode
+        # still seeds, which is what this covers.)
         s1 = self.be.spawn("a", self.d)
-        self.assertTrue(self.be.set_mode(s1, "bypassPermissions"))
-        self.assertEqual(sb.read_sdk_defaults(self.d).get("mode"), "bypassPermissions", "remembered globally")
+        self.assertTrue(self.be.set_mode(s1, "auto"))
+        self.assertEqual(sb.read_sdk_defaults(self.d).get("mode"), "auto", "remembered globally")
         s2 = self.be.spawn("b", self.d)                                  # a NEW session, created AFTER the pick
-        self.assertEqual(sb.read_reg(self.d, s2)["mode"], "bypassPermissions", "new session seeds the mode")
-        self.assertEqual(self.be.live_sessions()[s2]["mode"], "bypassPermissions", "and the badge shows it")
+        self.assertEqual(sb.read_reg(self.d, s2)["mode"], "auto", "new session seeds the mode")
+        self.assertEqual(self.be.live_sessions()[s2]["mode"], "auto", "and the badge shows it")
+
+    def test_a_hand_written_bypass_default_is_still_honoured(self):
+        # The carve-out lives in set_mode, NOT in spawn: romp declines to remember bypass off a click,
+        # but it does not overrule someone who wrote the default themselves. The escape hatch stays open
+        # for anyone who genuinely wants every new session unprompted.
+        sb.write_sdk_default(self.d, mode="bypassPermissions")
+        self.assertEqual(sb.read_reg(self.d, self.be.spawn("a", self.d))["mode"], "bypassPermissions")
 
     def test_remembering_mode_does_not_clobber_model_or_effort(self):
         s1 = self.be.spawn("a", self.d)

--- a/ui/webview/mode-selector.test.ts
+++ b/ui/webview/mode-selector.test.ts
@@ -19,3 +19,21 @@ test("the mode button renders FIRST (left of model) and the picker posts setMode
   assert.match(RENDER, /"setMode"/);
   assert.match(RENDER, /const META_CHOICES: Record<MetaKind/);   // model/effort + mode share the menu path
 });
+
+test("Bypass is offered, and offered ONLY on an SDK session", () => {
+  // The SDK sets the mode outright (set_permission_mode), so bypassPermissions is reachable there; a
+  // tmux session has nothing but the shift+tab cycle, which cannot express it. Listing it on tmux would
+  // be a menu entry that silently does nothing — the state this same change made the kernel refuse.
+  assert.match(RENDER, /value: "bypassPermissions", sdkOnly: true/);
+  assert.match(RENDER, /\.filter\(\(c\) => !c\.sdkOnly \|\| s\.status\.backend === "sdk"\)/);
+});
+
+test("Bypass carries a sub-line saying what it costs", () => {
+  // Not decoration: it is the one mode that removes the gate instead of moving it, and it also takes
+  // romp's approve/deny cards with it (they render from can_use_tool, which bypass never fires).
+  assert.match(RENDER, /sub: "every tool runs unasked, and romp stops showing approvals"/);
+  assert.match(RENDER, /interface MetaChoice \{[^}]*sub\?: string; sdkOnly\?: boolean/);
+  const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+  assert.match(CSS, /\.meta-item-sub \{ font-size: 0\.82em; opacity: 0\.6; \}/,
+    "one sub-line size across every romp menu — same as .ctx-item-sub");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7661,6 +7661,9 @@ function elapsedMs(sinceMs: number | null): string {
 // /model or /effort slash command into the session's pane; the label then updates
 // when the TUI's statusline republishes the tmux vars (meta-pending bridges the gap).
 type MetaKind = "mode" | "model" | "effort" | "fast";
+// One dropdown entry. `sub` is the second line for a choice whose consequence is not obvious from its
+// label; `sdkOnly` drops the entry on a tmux session, whose backend cannot apply it.
+interface MetaChoice { label: string; value: string; sub?: string; sdkOnly?: boolean }
 // Model + effort choices come from the kernel's /models — the ONE list shared with the timeline lanes and the
 // judge-tier settings (the user 2026-07-02, who wanted one shared code path, not hardcoded in multiple places), so
 // the client holds no model literals (mirrors paletteColors above). Populated in place on load so META_CHOICES
@@ -7671,13 +7674,22 @@ fetch(kernelUrl("/models"), { cache: "no-store" }).then((r) => r.json()).then((d
   if (Array.isArray(d.models)) { MODEL_CHOICES.length = 0; MODEL_CHOICES.push(...d.models, { label: "Default", value: "default" }); }
   if (Array.isArray(d.efforts)) { EFFORT_CHOICES.length = 0; EFFORT_CHOICES.push(...d.efforts); }
 }).catch(() => { /* picker stays empty until it lands */ });
-// Permission mode: the shift+tab cycle (no slash command), so the picker offers the three cycle modes;
-// the host sets them by sending shift+tab the right number of times (the user 2026-06-16).
-const MODE_CHOICES: { label: string; value: string }[] = [
+// Permission mode. A tmux session has no slash command for it — the host cycles shift+tab the right
+// number of times (the user 2026-06-16) — so the four CYCLE modes are all that backend can reach.
+// An SDK session sets it outright over the control channel (set_permission_mode), which is what makes
+// Bypass offerable there and only there: on tmux the click would land on a mode the cycle cannot
+// express, and _cycle_mode would drop it. `sdkOnly` is the filter, applied in toggleMetaMenu.
+const MODE_CHOICES: MetaChoice[] = [
   { label: "Normal", value: "default" },
   { label: "Accept edits", value: "acceptEdits" },
   { label: "Auto", value: "auto" },
   { label: "Plan", value: "plan" },
+  // The one mode that removes the gate rather than moving it, so it says what that costs right in the
+  // menu (the user 2026-08-15). Two things are worth the sub-line: every tool runs unasked, and romp's
+  // own approve/deny cards go with them — they are rendered from the SDK's can_use_tool callback, which
+  // bypass never fires, so you lose the RECORD of what ran, not just the asking.
+  { label: "Bypass permissions", value: "bypassPermissions", sdkOnly: true,
+    sub: "every tool runs unasked, and romp stops showing approvals" },
 ];
 // Fast mode (the CLI's /fast — Opus-only research preview): a two-state toggle offered as the same
 // dropdown shape as the other badges. The badge exists only when the session REPORTS a fast state
@@ -7726,7 +7738,7 @@ function prettyMode(m: string | undefined): string {
     default: return "Normal";   // default / normal / unknown
   }
 }
-const META_CHOICES: Record<MetaKind, { label: string; value: string }[]> = {
+const META_CHOICES: Record<MetaKind, MetaChoice[]> = {
   mode: MODE_CHOICES, model: MODEL_CHOICES, effort: EFFORT_CHOICES, fast: FAST_CHOICES,
 };
 // the live value of a meta kind for the active session
@@ -7858,9 +7870,20 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement) {
   if (s.status.state === "awaiting") return;
   const menu = el("div", "meta-menu");
   menu.dataset.kind = kind;
-  for (const c of META_CHOICES[kind]) {
+  // An sdkOnly entry is dropped on tmux rather than shown-and-refused: the backend cannot apply it, and
+  // a menu that lists a mode you can't have is worse than one that doesn't.
+  for (const c of META_CHOICES[kind].filter((c) => !c.sdkOnly || s.status.backend === "sdk")) {
     const item = el("div", "meta-item" + (isCurrentMeta(kind, s.status, c.value) ? " current" : ""));
-    item.textContent = c.label;
+    if (c.sub) {
+      const head = el("div");
+      head.textContent = c.label;
+      const sub = el("div", "meta-item-sub");
+      sub.textContent = c.sub;
+      item.appendChild(head);
+      item.appendChild(sub);
+    } else {
+      item.textContent = c.label;
+    }
     item.addEventListener("click", (e) => {
       e.stopPropagation();
       if (activeId && vscodeApi) {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -832,6 +832,9 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   color: var(--fg); position: relative; white-space: nowrap;
 }
 .meta-item:hover { background: rgba(255, 255, 255, 0.09); }
+/* second line for a choice whose consequence its label doesn't carry (Bypass permissions). Same
+   0.82em / 0.6 opacity as .ctx-item-sub — one sub-line size across every romp menu. */
+.meta-item-sub { font-size: 0.82em; opacity: 0.6; }
 .meta-item.current::after {
   content: "✓"; position: absolute; right: 6px; top: 50%; transform: translateY(-50%);
   background: var(--check-bg); color: #fff; border-radius: 50%;


### PR DESCRIPTION
Follow-up to #371.

## What

`bypassPermissions` was already reachable on SDK sessions — `set_mode` takes
any string, persists it, and applies it live via `set_permission_mode` — but
`MODE_CHOICES` offered only the four shift+tab cycle modes, so the only way in
was to send the WS message by hand. `prettyMode()` already rendered it
("Bypass"), so the display half was built and the menu half wasn't.

## SDK sessions only

A tmux session reaches its permission mode through the shift+tab cycle and
nothing else, so `bypassPermissions` (and `dontAsk`) have no keystroke that
gets to them. `MetaChoice.sdkOnly` drops the entry on tmux rather than showing
one that quietly does nothing.

The same silence existed a layer down: `TmuxBackend.set_mode` returned `True`
for those modes even though `_cycle_mode` had already declined them, so the
caller was told a mode had been set when nothing happened. It refuses now, and
the kernel's `setMode` handler warns the pane — matching the `stopTask` /
`setAuth` precedent for a backend that can't service a request.

## The sub-line

The entry gets a second line, because its label doesn't say what it costs:
every tool runs unasked, **and romp's own approve/deny cards go with them**.
Those render from the SDK's `can_use_tool` callback, which bypass never fires
— so what you lose is the record of what ran, not just the asking. New
`.meta-item-sub` reuses `.ctx-item-sub`'s 0.82em / 0.6 opacity, so there's
still one sub-line size across the menus.

## Bypass is the one mode romp won't remember

`set_mode` seeds the remembered default for the next new session, and `spawn()`
reads it with nothing in the create UI showing the value. Remembering *this*
mode would hand every session you started afterwards an unprompted agent, off a
single click on a single tab — invisible until you noticed an agent never
asking. So `STICKY_MODE_EXCLUDES` skips the write for `bypassPermissions`
alone; it still applies to the session you set it on.

The carve-out sits in `set_mode`, not `spawn()`, deliberately: a default
written into `sdk-defaults.json` by hand is still honoured, so the escape hatch
stays open to anyone who wants every new session unprompted — they just have to
say so on purpose rather than by clicking a menu.

One existing test (`test_set_mode_is_remembered_and_seeds_the_next_session`)
used `bypassPermissions` incidentally as its example of a remembered mode; it
now uses `auto` and points at the carve-out. Its original 2026-06-27 regression
coverage is unchanged.

## Not included

`dontAsk` is the other valid-but-unoffered `PermissionMode`. It has the same
tmux limitation and would slot into the same `sdkOnly` mechanism, but it's a
different call from bypass and isn't what this change is about.

## Tests

- `ui/webview/mode-selector.test.ts` — Bypass is present, `sdkOnly`, filtered
  by `status.backend`, carries the sub, and the sub-line style matches.
- `tests/test_sdk_backend.py` — bypass applies to the session but never becomes
  the seed (including when it's the first mode ever picked); a hand-written
  default is still honoured; ordinary modes still seed.
- `tests/test_kernel.py` — tmux `set_mode` refuses the two flag-only modes
  without pretending to cycle, and still accepts all four cycle modes.

Each fails on `main`: 2 node, 3 Python.

`python3 -m pytest -q` → 4629 passed, 40 skipped. `npm test` → 1954 passed.
`npm run typecheck` clean. bats not run (no `bats` on this machine); no shell
surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)