### PR TITLE
The mobile usage panel scrolls instead of losing its top off-screen

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -22603,8 +22603,15 @@ def _landing():
             # elapsed bars that used to sit under the timeline — per window, a "used" bar (selected colormap)
             # over an "elapsed" bar (slate) with the % + reset countdown, and nothing else (no prose).
             # .ru-modal = the mobile Usage button's centered-panel placement (same element + content as the
-            # hover tooltip; only the positioning differs)
+            # hover tooltip; only the positioning differs). Height-capped WITH a scroll pane (the user
+            # 2026-08-14: the $/h chart + multi-host rows outgrew a phone screen and the centered transform
+            # pushed the TOP off-screen with no way to reach it). dvh overrides vh where supported so the
+            # mobile browser's collapsing chrome can't eat the cap; pointer-events comes back on (the base
+            # #ru-tip is a hover tooltip, pointer-events:none) so the pane can actually scroll — which also
+            # stops a tap on the panel itself falling through to the dismiss backdrop; only backdrop taps
+            # (and Escape) close it now, the modal contract everywhere else on the dashboard.
             "#ru-tip.ru-modal{left:50%!important;top:44%!important;transform:translate(-50%,-50%);max-width:92vw;"
+            "max-height:84vh;max-height:84dvh;overflow-y:auto;pointer-events:auto;"
             "box-shadow:0 12px 36px #000000aa}"
             # the dismiss backdrop for the mobile Usage modal: below the tip (z 300), above the panes; a tap
             # anywhere over it closes the modal (see _LANDING_USAGE_JS). Faint dim so it reads as tap-to-close.

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -252,3 +252,18 @@ test("the $/h chart is a real chart, and refresh is automatic with no stale hint
   assert.ok(usageJS.includes("if(tip.style.display==='block'&&!tip.classList.contains('ru-modal'))"),
     "an open tip follows data landings");
 });
+
+test("the mobile usage modal is height-capped with a scroll pane, and taps on it don't fall through", () => {
+  // The user 2026-08-14: the $/h chart + multi-host rows outgrew a phone screen, and the centered
+  // translate(-50%,-50%) pushed the TOP off-screen with nothing to scroll. The modal variant caps its
+  // height to the DYNAMIC viewport (dvh overrides vh where supported — mobile browser chrome collapses)
+  // and scrolls; pointer-events comes back on (the base #ru-tip is a hover tooltip, pointer-events:none),
+  // which is what makes scrolling possible AND stops a tap on the panel closing it through the backdrop.
+  const modal = KERNEL.split("#ru-tip.ru-modal{")[1].split("}")[0];
+  assert.ok(modal.includes("max-height:84vh"), "a vh cap for browsers without dvh");
+  assert.ok(modal.includes("max-height:84dvh"), "the dvh override tracks mobile chrome");
+  assert.ok(modal.indexOf("max-height:84vh") < modal.indexOf("max-height:84dvh"),
+    "the dvh declaration must come second to win where supported");
+  assert.ok(modal.includes("overflow-y:auto"), "the scroll pane");
+  assert.ok(modal.includes("pointer-events:auto"), "scrollable — and panel taps no longer dismiss");
+});


### PR DESCRIPTION
The user (2026-08-14, on a phone): the usage dialog is taller than the screen and the top is unreachable. Root cause: the mobile modal variant (`#ru-tip.ru-modal`) caps width but not height, so once the $/h chart and multi-host rows grew the content past the viewport, the centered `translate(-50%,-50%)` pushed the top off-screen — and the base `#ru-tip` is a hover tooltip with `pointer-events:none`, so nothing could scroll even in principle (and any tap on the panel fell through to the dismiss backdrop and closed it).

The modal variant now:
- caps height at `84vh` with an `84dvh` override where supported (mobile browser chrome collapses; the dynamic unit tracks it),
- gets `overflow-y:auto` — the scroll pane,
- restores `pointer-events:auto`, which enables the scrolling and makes taps on the panel inert; backdrop taps and Escape still dismiss (the dashboard's modal contract).

Pins in `rail-spend.test.ts` including declaration order (the `dvh` override must come second to win). Node suite 1955/1955, kernel compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)