### PR TITLE
The update notice watches the whole mesh, not just release tags

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1970,15 +1970,133 @@ def _update_check():
 # of one ls-remote.
 _UPDATE_CHECK_EVERY_S = 6 * 3600
 
+# ── the mesh/origin-aware update notice (the user 2026-08-14) ────────────────────────────────────
+# The release banner above only ever watched TAGS, so the day the deploy driver died, three ordinary
+# merges sat undeployed for an hour while every machine read "in sync" — all equally stale, nothing
+# anywhere with a signal. The user's design: every attached machine converges on the newest commit,
+# the dashboard being viewed shows ONE notice when anything is ahead, and the click converges the
+# mesh — no cron jobs. Two comparisons cover what releases can't see (the pure verdict is
+# _main_drift_verdict, unit-tested): origin/main ahead of the CHECKOUT (pull + restart), and the
+# checkout ahead of the RUNNING kernel (restart alone — the hand-advanced case). Remotes need no
+# third comparison here: every change lands through origin in this repo's PR-only flow, and once the
+# local checkout advances, the tunnel supervisor's existing autoPush/fastForward machinery spreads it
+# to the machines behind. The update-mode setting governs this watcher exactly like the release one:
+# off = silent, ask = the one-click notice, auto = converge unattended (the pull refuses a dirty
+# tree LOUDLY — peers' uncommitted work is never discarded — and the restart rides the manager's
+# quiet window, whose chain is silent-death-proof since the same day's fix).
+_MAIN_CHECK_EVERY_S = 300              # one ls-remote — cheap enough to notice a merge within minutes
+_MAIN_DRIFT = ["", ""]                 # [origin sha a notice fired for, checkout sha one fired for]
+
+
+def _origin_main_sha():
+    """origin/main's commit (short), '' when unreachable — offline is a normal state, never a crash."""
+    try:
+        out = subprocess.run(["git", "ls-remote", "origin", "refs/heads/main"],
+                             cwd=str(ROOT), capture_output=True, text=True, timeout=15)
+        return (out.stdout.split() or [""])[0][:8]
+    except Exception:
+        return ""
+
+
+def _checkout_sha():
+    """The shared checkout's HEAD (short), '' on any failure."""
+    try:
+        out = subprocess.run(["git", "rev-parse", "--short=8", "HEAD"],
+                             cwd=str(ROOT), capture_output=True, text=True, timeout=10)
+        return out.stdout.strip()[:8]
+    except Exception:
+        return ""
+
+
+def _main_drift_verdict(origin, checkout, running):
+    """(kind, target) — the pure decision. kind: "pull" (origin ahead of the checkout: fetch + advance
+    + restart), "restart" (the checkout is ahead of the running kernel: restart alone), or "" (in sync
+    or unknowable). A sha that could not be read ('' anywhere) is unknown → no verdict: guessing would
+    invent a notice. Comparison is by INEQUALITY, not ancestry — the checkout only ever moves by
+    fast-forwarding to origin/main here, so a differing sha IS new information, and a wrongly-diverged
+    checkout surfaces in the pull step's own fast-forward refusal rather than being guessed at."""
+    if origin and checkout and origin != checkout:
+        return ("pull", origin)
+    if checkout and running and checkout != running:
+        return ("restart", checkout)
+    return ("", "")
+
+
+def _main_drift_check():
+    """One origin/checkout/running comparison pass; fires the SAME banner as the release check (the
+    shell's offer() renders the main-drift wording off kind:"main"). Re-fires only when the target sha
+    CHANGES — new information, never a re-nag of the sha already offered or dismissed."""
+    if _update_mode() == "off":
+        return
+    kind, target = _main_drift_verdict(_origin_main_sha(), _checkout_sha(), _kernel_sha())
+    if not kind:
+        _MAIN_DRIFT[0] = _MAIN_DRIFT[1] = ""          # in sync: a future drift is new information again
+        return
+    slot = 0 if kind == "pull" else 1
+    if _MAIN_DRIFT[slot] == target:
+        return                                        # already offered/acted on this exact sha
+    _MAIN_DRIFT[slot] = target
+    if _update_mode() == "auto":
+        _run_main_update(kind)
+    else:
+        _send_to_app("shell", {"type": "updateAvail", "kind": "main", "drift": kind,
+                               "cur": _kernel_sha() or "", "tag": target})
+
+
+def _run_main_update(kind, immediate=False):
+    """Converge on newest main: advance the checkout (fast-forward only; a DIRTY shared tree refuses
+    LOUDLY — peer sessions' uncommitted work is never discarded) and bounce every kernel through the
+    manager. `kind` "restart" skips the pull (the checkout is already ahead). Unattended (auto mode)
+    the bounce rides the quiet window; a banner CLICK is the user's own deliberate cut → immediate."""
+    if kind == "pull":
+        try:
+            dirty = subprocess.run(["git", "status", "--porcelain"], cwd=str(ROOT),
+                                   capture_output=True, text=True, timeout=10).stdout.strip()
+            if dirty:
+                _sync_notice("main moved at origin, but the romp checkout has uncommitted work — "
+                             "not touching it. Commit or stash it, then Update again.", ok=False)
+                _MAIN_DRIFT[0] = ""                   # let the notice re-fire once the tree is clean
+                return
+            subprocess.run(["git", "fetch", "origin", "main"], cwd=str(ROOT),
+                           capture_output=True, text=True, timeout=60)
+            r = subprocess.run(["git", "checkout", "--detach", "origin/main"], cwd=str(ROOT),
+                               capture_output=True, text=True, timeout=30)
+            if r.returncode != 0:
+                _sync_notice("main moved at origin, but advancing the checkout failed: %s"
+                             % (r.stderr or r.stdout or "").strip()[-200:], ok=False)
+                _MAIN_DRIFT[0] = ""
+                return
+        except Exception as e:
+            _sync_notice("main moved at origin, but the pull step failed: %s" % e, ok=False)
+            _MAIN_DRIFT[0] = ""
+            return
+    try:
+        import urllib.request
+        req = urllib.request.Request("http://127.0.0.1:%d/restart-all%s"
+                                     % (int(os.environ.get("ROMP_MANAGER_PORT") or 7432),
+                                        "" if immediate else "?when=quiet"), method="POST")
+        urllib.request.urlopen(req, timeout=5).read()
+    except Exception as e:
+        _sync_notice("romp is updated on disk but the restart request failed (%s) — "
+                     "restart it yourself: romp refresh" % e, ok=False)
+
 
 def _update_check_loop():
-    """The daemon thread: one pass at boot, then one per cadence, forever."""
+    """The daemon thread: one pass at boot, then one per cadence, forever. The cheap main-drift probe
+    runs every pass; the release-tag check keeps its six-hour stride."""
+    last_release = 0.0
     while True:
         try:
-            _update_check()
+            if time.time() - last_release >= _UPDATE_CHECK_EVERY_S:
+                last_release = time.time()
+                _update_check()
         except Exception:
             sys.stderr.write("update check pass: %s\n" % traceback.format_exc())
-        time.sleep(_UPDATE_CHECK_EVERY_S)
+        try:
+            _main_drift_check()
+        except Exception:
+            sys.stderr.write("main drift pass: %s\n" % traceback.format_exc())
+        time.sleep(_MAIN_CHECK_EVERY_S)
 
 
 def _auto_update_remotes_on():
@@ -21918,7 +22036,7 @@ try{(m.n?navigator.setAppBadge(m.n):navigator.clearAppBadge())['catch'](function
 // the master bell toggled somewhere (this tab included) — repaint ours from the kernel's word
 else if(m&&m.type==='notifyAll'&&window.__rompNotifyAllPaint)window.__rompNotifyAllPaint(!!m.on);
 // the boot check found a newer romp release — raise the update banner on every open dashboard
-else if(m&&m.type==='updateAvail'&&window.__rompUpdateOffer)window.__rompUpdateOffer(m.cur||'',m.tag||'');};
+else if(m&&m.type==='updateAvail'&&window.__rompUpdateOffer)window.__rompUpdateOffer(m.cur||'',m.tag||'',m.drift||'');};
 ws.onclose=function(){setTimeout(shellWS,2000);};}catch(e){}}
 shellWS();
 var last='chat';try{var s=localStorage.getItem(KT);if(s&&F[s])last=s;}catch(e){}show(last);
@@ -22135,8 +22253,13 @@ _UPD_JS = (
     "function show(m){msg.textContent=m;box.classList.add('show');}"
     # Not-now is PER RELEASE (the periodic re-check re-finds versions for weeks): the dismissed tag
     # stays quiet, a strictly newer one is new information and re-offers.
-    "function offer(cur,tag){if(waiting||tag===dismissedTag)return;curTag=tag;go.hidden=false;go.disabled=false;dm.hidden=false;"
-    "show('romp '+tag+' is available'+(cur?' \\u2014 you are on '+cur:'')+'.');}"
+    # drift (the user 2026-08-14): the same banner also carries new MAIN commits — origin ahead of the
+    # checkout ('pull') or the checkout ahead of the running kernel ('restart'). One click converges
+    # every attached machine; per-sha dismissal works exactly like per-release.
+    "function offer(cur,tag,drift){if(waiting||tag===dismissedTag)return;curTag=tag;go.hidden=false;go.disabled=false;dm.hidden=false;"
+    "if(drift==='pull')show('new romp commits are on main ('+tag+') \\u2014 Update pulls them and restarts every kernel.');"
+    "else if(drift==='restart')show('romp '+tag+' is ready on disk \\u2014 Update restarts every kernel onto it.');"
+    "else show('romp '+tag+' is available'+(cur?' \\u2014 you are on '+cur:'')+'.');}"
     "window.__rompUpdateOffer=offer;"   # the shell WS relays the kernel's boot-check push here
     "function poll(){fetch('/update-check',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){"
     "if(!waiting)return;"
@@ -23563,15 +23686,23 @@ class Handler(BaseHTTPRequestHandler):
                 except OSError:
                     return self._send(200, json.dumps({"rows": []}), "application/json")
             if u.path == "/update":
-                # the banner's Update button (the user 2026-08-09). Only a release the boot check
-                # actually found is ever installed — the route takes no version from the client.
+                # the banner's Update button (the user 2026-08-09). Only what the kernel's own checks
+                # found is ever acted on — the route takes no version from the client. A pending
+                # RELEASE outranks main drift (rarer and strictly bigger); the drift click converges
+                # the mesh immediately: the user's own deliberate cut (the user 2026-08-14).
                 tag = _UPDATE_AVAIL[0]
-                if not tag:
-                    return self._send(409, "no newer release known to this kernel", "text/plain")
-                if _UPDATE_STATE[0] != "running":
-                    _audit_restart_request("self-update", tag=tag, addr=str(self.client_address[0]))
-                    _run_update(tag)
-                return self._send(200, json.dumps({"ok": True, "state": _UPDATE_STATE[0]}), "application/json")
+                if tag:
+                    if _UPDATE_STATE[0] != "running":
+                        _audit_restart_request("self-update", tag=tag, addr=str(self.client_address[0]))
+                        _run_update(tag)
+                    return self._send(200, json.dumps({"ok": True, "state": _UPDATE_STATE[0]}), "application/json")
+                kind = "pull" if _MAIN_DRIFT[0] else ("restart" if _MAIN_DRIFT[1] else "")
+                if kind:
+                    _audit_restart_request("main-converge", tag=_MAIN_DRIFT[0] or _MAIN_DRIFT[1],
+                                           addr=str(self.client_address[0]))
+                    threading.Thread(target=_run_main_update, args=(kind, True), daemon=True).start()
+                    return self._send(200, json.dumps({"ok": True, "state": "converging"}), "application/json")
+                return self._send(409, "no newer release or main commit known to this kernel", "text/plain")
             if u.path == "/notify-all":
                 # the master bell's toggle (the user 2026-08-09). Kernel-authoritative: the click
                 # posts here first, and only a 200 flips the bell — the device push subscription is

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -13,6 +13,7 @@ import os
 import subprocess
 import tempfile
 import threading
+import time
 import unittest
 from unittest import mock
 from importlib.machinery import SourceFileLoader
@@ -33,6 +34,10 @@ _PREV_STATE_DIR = os.environ.get("ROMP_STATE_DIR")
 os.environ["ROMP_STATE_DIR"] = _STATE_TD.name
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+# A dead manager port: any update/converge path a test exercises unstubbed dials nothing real.
+# (2026-08-14: the converge route, hit by this suite while genuine main-drift existed, posted an
+# IMMEDIATE restart-all to the LIVE manager — every suite run bounced every kernel on the box.)
+os.environ["ROMP_MANAGER_PORT"] = "1"
 SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
 jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
 km = SourceFileLoader("romp_kernel_update", os.path.join(BIN, "romp-kernel")).load_module()
@@ -226,8 +231,13 @@ class UpdateCheck(Fresh):
 
 
 class CheckLoop(Fresh):
-    def test_one_pass_per_cadence_and_a_crash_never_kills_the_thread(self):
-        passes = []
+    def test_two_cadences_one_loop_and_a_crash_never_kills_the_thread(self):
+        # The loop carries TWO watchers since the mesh-aware notice (the user 2026-08-14): the cheap
+        # origin/main drift probe every round (minutes — a merge should be noticed promptly), the
+        # release-tag check on its old six-hour stride. Either watcher dying must not kill the loop,
+        # nor one watcher's crash starve the other.
+        releases = []
+        drifts = []
         naps = []
 
         def nap(s):
@@ -235,17 +245,24 @@ class CheckLoop(Fresh):
             if len(naps) == 2:
                 raise SystemExit                       # unhook the forever-loop after two rounds
 
-        def one_pass():
-            passes.append(1)
-            if len(passes) == 1:
-                raise RuntimeError("boom")             # the first pass dies — the loop must survive it
-        with mock.patch.object(km, "_update_check", side_effect=one_pass), \
+        def release_pass():
+            releases.append(1)
+            raise RuntimeError("boom")                 # a dying release check must not kill the loop…
+
+        def drift_pass():
+            drifts.append(1)
+            if len(drifts) == 1:
+                raise RuntimeError("boom")             # …nor a dying drift probe the NEXT drift probe
+        with mock.patch.object(km, "_update_check", side_effect=release_pass), \
+             mock.patch.object(km, "_main_drift_check", side_effect=drift_pass), \
              mock.patch.object(km.time, "sleep", side_effect=nap), \
              self.assertRaises(SystemExit):
             km._update_check_loop()
-        self.assertEqual(len(passes), 2, "the pass after a crashed pass still ran")
-        self.assertEqual(naps, [km._UPDATE_CHECK_EVERY_S] * 2)
+        self.assertEqual(len(releases), 1, "the six-hour stride: one release check across two fast rounds")
+        self.assertEqual(len(drifts), 2, "the drift probe runs every round, surviving its own crash")
+        self.assertEqual(naps, [km._MAIN_CHECK_EVERY_S] * 2)
         self.assertEqual(km._UPDATE_CHECK_EVERY_S, 6 * 3600)
+        self.assertEqual(km._MAIN_CHECK_EVERY_S, 300)
 
 
 class RunUpdate(Fresh):
@@ -370,16 +387,36 @@ class Routes(Fresh):
         self.assertTrue((jd.STATE / "update-report.json").exists(), "not consumed — the next boot files it")
         self.assertEqual(self.notices(), [])
 
-    def test_post_update_requires_a_known_release_and_the_token(self):
+    def test_post_update_requires_something_known_and_the_token(self):
         code, _ = self._post("/update", token=False)
         self.assertEqual(code, 403)
+        km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""     # module state: a prior drift pass must not leak in
         code, body = self._post("/update")
-        self.assertEqual(code, 409, "no newer release known → nothing to install: " + body)
+        self.assertEqual(code, 409, "nothing known → nothing to act on: " + body)
         km._UPDATE_AVAIL[0] = "v0.7.0"
         ran = []
         with mock.patch.object(km, "_run_update", side_effect=lambda tag: ran.append(tag) or True):
             code, body = self._post("/update")
         self.assertEqual((code, ran), (200, ["v0.7.0"]))
+
+    def test_post_update_converges_main_drift_when_no_release_is_pending(self):
+        # the drift click is a REAL restart, so the converge is stubbed: a live manager must never hear
+        # a test (2026-08-14: this exact route, exercised unstubbed while real drift existed, restart-
+        # stormed the machine running the suite — each run bounced every kernel on the box)
+        km._UPDATE_AVAIL[0] = ""
+        km._MAIN_DRIFT[0], km._MAIN_DRIFT[1] = "aaaa1111", ""
+        ran = []
+        with mock.patch.object(km, "_run_main_update",
+                               side_effect=lambda kind, immediate=False: ran.append((kind, immediate))):
+            code, body = self._post("/update")
+            self.assertEqual(code, 200)
+            self.assertIn("converging", body)
+            for _ in range(200):                       # the route hands off to a daemon thread
+                if ran:
+                    break
+                time.sleep(0.01)
+        self.assertEqual(ran, [("pull", True)], "the banner click is the user's own deliberate cut")
+        km._MAIN_DRIFT[0] = ""
 
 
 class Wiring(unittest.TestCase):

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""The mesh/origin-aware update notice (the user 2026-08-14): the release banner only watched TAGS, so
+ordinary merges sat undeployed with every machine reading "in sync" — all equally stale. The kernel now
+also compares origin/main vs the checkout vs the RUNNING build, fires the same banner (kind:"main"),
+and converges on click or unattended per the update mode. Pure verdict unit-tested; the wiring pinned
+by source (the rail-spend pattern). Synthetic only; hermetic state dir."""
+import inspect
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+os.environ["ROMP_MANAGER_PORT"] = "1"   # dead port: an unstubbed converge dials nothing real
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_drift", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class DriftVerdict(unittest.TestCase):
+    def test_origin_ahead_of_the_checkout_wants_a_pull(self):
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "bbbb2222", "bbbb2222"), ("pull", "aaaa1111"))
+
+    def test_checkout_ahead_of_the_running_kernel_wants_a_restart(self):
+        # the hand-advanced case: updated code sits on disk, nothing booted it
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "aaaa1111", "cccc3333"), ("restart", "aaaa1111"))
+
+    def test_pull_outranks_restart_when_both_hold(self):
+        # origin ahead AND the running build stale: one pull converges both in a single bounce
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "bbbb2222", "cccc3333")[0], "pull")
+
+    def test_in_sync_is_quiet(self):
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "aaaa1111", "aaaa1111"), ("", ""))
+
+    def test_unknown_shas_never_invent_a_notice(self):
+        # offline ls-remote, unreadable checkout, missing running sha: unknown, not a disagreement
+        self.assertEqual(km._main_drift_verdict("", "bbbb2222", "bbbb2222"), ("", ""))
+        self.assertEqual(km._main_drift_verdict("aaaa1111", "", "bbbb2222"), ("", ""))
+        self.assertEqual(km._main_drift_verdict("", "", ""), ("", ""))
+
+
+class DriftWiring(unittest.TestCase):
+    def test_off_mode_silences_the_watcher_and_auto_converges_unattended(self):
+        src = inspect.getsource(km._main_drift_check)
+        self.assertIn('if _update_mode() == "off":', src)
+        self.assertIn('if _update_mode() == "auto":', src)
+        self.assertIn("_run_main_update(kind)", src)
+        self.assertIn('"kind": "main"', src, "ask mode fires the shared banner with the drift variant")
+
+    def test_a_dirty_shared_tree_refuses_loudly_and_rearms(self):
+        src = inspect.getsource(km._run_main_update)
+        self.assertIn('"status", "--porcelain"', src)
+        self.assertIn("uncommitted work", src, "the refusal names the real problem")
+        self.assertIn('_MAIN_DRIFT[0] = ""', src, "the notice re-fires once the tree is clean")
+        self.assertIn('"checkout", "--detach", "origin/main"', src, "advance is the repo's own convention")
+
+    def test_the_click_converges_immediately_and_auto_rides_the_quiet_window(self):
+        src = inspect.getsource(km._run_main_update)
+        self.assertIn('"" if immediate else "?when=quiet"', src)
+        route = inspect.getsource(km)
+        self.assertIn('threading.Thread(target=_run_main_update, args=(kind, True), daemon=True)', route,
+                      "the banner click is the user's own deliberate cut")
+
+    def test_the_shell_banner_carries_the_drift_variants(self):
+        src = inspect.getsource(km)
+        self.assertIn("m.drift||''", src, "the shell relay forwards the drift kind")
+        self.assertIn("new romp commits are on main", src)
+        self.assertIn("is ready on disk", src)
+
+    def test_the_route_acts_only_on_what_the_kernel_itself_found(self):
+        src = inspect.getsource(km)
+        self.assertIn('kind = "pull" if _MAIN_DRIFT[0] else ("restart" if _MAIN_DRIFT[1] else "")', src,
+                      "no version or kind is ever taken from the client")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -62,7 +62,7 @@ var GEAR_HTML =
   '<span class=rs-sub id=rs-autonudge-sub>' + AUTONUDGE_SUB + '</span>' +
   '</span></label>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto'><b>Automatic updates <span class=rs-mixed hidden></span></b>" +
-  '<span class=rs-sub>romp checks its repo for a new tagged release at start-up and every 6 hours (ordinary commits never trigger it; updating lands exactly on the release). Check and ask (the default) offers it as a banner with an Update button; Install automatically fetches, installs and restarts by itself; Off never checks. Kernel-side setting.</span>' +
+  '<span class=rs-sub>romp watches for new tagged releases (every 6 hours) AND new commits on main (origin polled every few minutes, plus a restart offer when updated code sits on disk unbooted) — one banner covers both, and acting on it converges every attached machine. Check and ask (the default) offers the banner with an Update button; Install automatically converges by itself, restarting at the next quiet moment; Off never checks. Kernel-side setting.</span>' +
   "<select id=rs-updates style='margin-top:5px;width:100%;background:#1e1e1e;color:#ccc;" +
   "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
   '<option value=ask>Check and ask</option><option value=auto>Install automatically</option><option value=off>Off</option>' +


### PR DESCRIPTION
The user's design (2026-08-14), replacing both the dead push-driver and the scheduled-job idea: every attached machine converges on the newest commit; the dashboard being viewed shows ONE notice when anything is ahead; the click converges the mesh. No cron jobs.

**What was missing.** The banner only watched release tags, and the mesh comparison only powered "this remote is behind you — push". The day the old push-driver machine went away, three ordinary merges sat undeployed for an hour while every machine read "in sync" — all equally stale, no signal anywhere.

**What this adds.**
- A cheap origin probe (one ls-remote, every 5 minutes) beside the six-hour release check, in the same loop — poll-by-nature, per the existing doctrine.
- A pure verdict (`_main_drift_verdict`, unit-tested): origin ahead of the checkout → "pull"; checkout ahead of the RUNNING kernel → "restart" (the hand-advanced case); unknown shas are never a notice.
- The SAME banner carries both via a `drift` variant; per-sha dismissal works like per-release.
- The click POSTs the existing update route, which acts only on what the kernel itself found (never a client-supplied version) and converges immediately — the user's own deliberate cut. Unattended (`auto` mode) the restart rides the manager's quiet window (its chain silent-death-proof as of today's fix), and the pull REFUSES a dirty shared tree loudly — peers' uncommitted work is never discarded.
- Once local advances, the tunnel supervisor's existing autoPush/fastForward machinery spreads it to machines behind; the gear's update-mode copy now describes both watchers.

**Test hygiene, learned live:** the /update route test, exercised unstubbed while genuine drift existed, posted a real IMMEDIATE restart-all to the live manager — every suite run bounced every kernel on the machine running it. The converge is now stubbed where exercised, and every update test runs against a dead manager port, so an unstubbed path dials nothing real.

Suites: drift verdict + wiring (10), kernel update (32, two reconciled to the new contracts), node 1955/1955, kernel compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)