### PR TITLE
A working card can never be mute: the spin floor is total

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15654,6 +15654,11 @@ def build_feed(now, tmux=None):
         # the open turn's live narration (the user 2026-08-13) — computed once per session, ridden by
         # every working card below; cache-warm like the dot (a cold start paints plain, then snaps in)
         sess_progress = _open_turn_progress(ps["turns"]) if (ps and who_working) else None
+        # The card-floor disposition (the user 2026-08-14: NO working card is ever mute — even unknown
+        # shows as such): "open" = a turn is running (the narration above rides when parsed), "quiet" =
+        # parsed and between turns, "unknown" = no parse to read (a cold cache, or a machine that isn't
+        # reporting). The feed's spin ladder renders a floor line for each — see spin-caption.ts.
+        sess_state = "open" if who_working else ("quiet" if ps else "unknown")
         # The user's LAST action on this session was an INTERRUPT (no message from them since): its quiet
         # is user-chosen, not a stall — auto-nudge is suppressed (same predicate, _auto_nudge_tick) and
         # the working card wears an "interrupted" badge saying so (the user 2026-07-05). Cache-only,
@@ -16329,6 +16334,7 @@ def build_feed(now, tmux=None):
                 "rejudging": rejudging,              # plain thread reply after a block → STAYS in Needs-You, "Re-judging…" swirl while a turn is in flight (the user 2026-06-30)
                 "judging": bool((sess_judging or _stall_inflight) and column == "working"),
                 "working": (sess_progress if column == "working" else None),   # open-turn narration: tool count + since (the user 2026-08-13)   # turn settled, closer verdict pending → "Analyzing…" swirl covers the finished-but-still-Working beat (the user 2026-07-13); same key the provisional card wears
+                "sessState": (sess_state if column == "working" else None),   # the mute-proof floor: open | quiet | unknown (the user 2026-08-14 — a working card ALWAYS says its state)
                 "warnRows": (_card_warn_rows(dbg_rows, fsid, set(_subtree(nid)),
                                              store.get("placements") or {}) or None)
                             if dbg_rows is not None else None,   # debug mode only: the card's judge failures, modal "Warnings" section

--- a/tests/test_kernel_working_narration.py
+++ b/tests/test_kernel_working_narration.py
@@ -55,6 +55,16 @@ class PayloadPins(unittest.TestCase):
         self.assertIn('sess_progress = _open_turn_progress(ps["turns"]) if (ps and who_working) else None', src)
         self.assertIn('"working": (sess_progress if column == "working" else None)', src)
 
+    def test_working_cards_carry_the_mute_proof_floor(self):
+        # the user 2026-08-14: a working card ALWAYS says its state. The kernel grades each session's
+        # disposition — "open" (turn running), "quiet" (parsed, between turns), "unknown" (no parse to
+        # read: a cold cache or a machine reporting nothing) — and every working card carries it, so
+        # the feed's spin floor can speak even when the narration payload cannot ride.
+        import inspect
+        src = inspect.getsource(km.build_feed)
+        self.assertIn('sess_state = "open" if who_working else ("quiet" if ps else "unknown")', src)
+        self.assertIn('"sessState": (sess_state if column == "working" else None)', src)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -344,6 +344,11 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   -webkit-line-clamp: 2; line-clamp: 2; }
 @keyframes fask-swirl-spin { to { transform: rotate(-360deg); } }
 @media (prefers-reduced-motion: reduce) { .fask-awaiting-swirl { animation: none; } }
+/* The at-rest floor (the user 2026-08-14): a working-column card with nothing in motion (session quiet
+   between turns, or a machine reporting nothing) still shows the glyph as its state anchor — STILLED,
+   because spin reads as in-flight — with the line dimmed to match its at-rest weight. */
+.fask-awaiting.await-still .fask-awaiting-swirl { animation-play-state: paused; opacity: 0.5; }
+.fask-awaiting.await-still .fask-awaiting-why { opacity: 0.75; }
 /* awaiting-background-agents: a rounded outline box so the "held, waiting on dispatched work" state reads as
    distinct. The romp swirl SPINS here like everywhere else (the user 2026-07-04, for whom a spin reads as in flight,
    not stalled — which is the awaiting state; the box already sets it apart from the working cases). The box

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -1544,8 +1544,11 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
                        dCompleted, Date.now() / 1000);
   const spinCaption = spin.caption, spinTip = spin.tip, awaitingBg = spin.awaitingBg;
   a._awaitSpin.style.display = spinCaption ? "" : "none";
-  // The AWAITING case gets a rounded box (its distinct read); the swirl spins in every case now.
+  // The AWAITING case gets a rounded box (its distinct read); the swirl spins in every case now —
+  // except the at-rest floor (`still`): quiet/unknown keep the glyph as the state anchor, stilled,
+  // because spin reads as in-flight and nothing is (the user 2026-08-14).
   a._awaitSpin.classList.toggle("await-paused", awaitingBg);
+  a._awaitSpin.classList.toggle("await-still", !!spin.still);
   if (spinCaption) { a._awaitWhy.textContent = spinCaption; a._awaitSpin.title = spinTip || spinCaption; }
   // The swirl's "Analyzing…" caption + tooltip REPLACES the separate "↩ re-judging" chip (the user
   // 2026-06-29: don't show both) — drop the chip the recheck branch set above when the swirl is saying it.

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -94,8 +94,14 @@ test("DISTILLING names which line is being written", () => {
   assert.equal(spinFor({}, true, true).caption, "Distilling…");
 });
 
-test("an ordinary working card with its turn open shows no spin at all", () => {
-  assert.deepEqual(spinFor({ column: "working" }, false, false), { caption: null, tip: "", awaitingBg: false });
+test("a working card carrying NO signal at all reads as unknown, never as silence", () => {
+  // this pin once asserted the mute card ({caption: null}) as the ordinary case — twice updated,
+  // twice wrong: first the narration (2026-08-13) gave the open turn a voice, then the floor
+  // (2026-08-14) gave every remaining working-column shape one. The empty payload is the floor's
+  // last resort: unknown, stilled glyph, said out loud.
+  const s = spinFor({ column: "working" }, false, false);
+  assert.match(s.caption || "", /unknown/);
+  assert.equal(s.still, true);
 });
 
 test("recheck/rejudging outrank the settle gap and the distiller", () => {
@@ -173,9 +179,37 @@ test("the narration is the FLOOR — every richer story still wins", () => {
                "Distilling…", "a pending distill outranks narration");
 });
 
-test("no narration off the working column or without the payload", () => {
+test("no spin off the working column — briefs/takeaways/chips carry those cards", () => {
   assert.equal(spinFor({ column: "needs_input", working: { since: 1, toolUses: 2 } }, false, false, 100).caption,
                null);
-  assert.equal(spinFor({ column: "working" }, false, false, 100).caption, null,
-               "a cache-cold card paints plain until the payload snaps in");
+});
+
+test("THE FLOOR IS TOTAL — a working-column card can never be mute (the user 2026-08-14)", () => {
+  // Two cards sat in Working with nothing on them — a session quietly between turns — and the old
+  // contract here BLESSED it ("a cache-cold card paints plain"). Every working-column shape now
+  // yields a caption; when nothing is in motion the glyph stills instead of lying with a spin.
+  const open = spinFor({ column: "working", sessState: "open" }, false, false, 100);
+  assert.equal(open.caption, "Working…");
+  assert.ok(!open.still, "an open turn spins — it IS in flight");
+  const quiet = spinFor({ column: "working", sessState: "quiet" }, false, false, 100);
+  assert.match(quiet.caption || "", /^Paused — resumes/);
+  assert.equal(quiet.still, true, "nothing in motion → the glyph stills (a spin would lie)");
+  const unk = spinFor({ column: "working", sessState: "unknown" }, false, false, 100);
+  assert.match(unk.caption || "", /unknown — this machine isn't reporting/);
+  assert.equal(unk.still, true);
+  assert.match(spinFor({ column: "working" }, false, false, 100).caption || "",
+               /unknown/, "even a payload with NO floor field reads as unknown, never as silence");
+  // the totality sweep: every combination of the ladder's inputs with column=working → a caption
+  const bools: (true | undefined)[] = [undefined, true];
+  for (const judging of bools) for (const recheck of bools) for (const rejudging of bools)
+    for (const provisional of bools) for (const dp of [false, true])
+      for (const working of [undefined, { since: 50, toolUses: 2 }])
+        for (const sessState of [undefined, "open", "quiet", "unknown"])
+          for (const awaiting of [undefined, { why: "" }]) {
+            const s = spinFor({ column: "working", judging, recheck, rejudging, provisional,
+                                working, sessState, awaiting }, dp, false, 100);
+            assert.notEqual(s.caption, null,
+              "mute working card: " + JSON.stringify({ judging, recheck, rejudging, provisional, dp,
+                                                       working: !!working, sessState, awaiting: !!awaiting }));
+          }
 });

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -17,7 +17,13 @@
 //   4. RE-JUDGING    — a soft-block + a PLAIN thread reply, with the reply in flight
 //   5. SETTLE GAP    — the turn finished, the closer's verdict hasn't landed
 //   6. DISTILLING    — a resolved card whose takeaway/brief hasn't been written yet
-//   … else no spin (an ordinary working card with its turn open).
+//   7. NARRATION     — the ordinary working card with its turn open: live tool count + duration
+//   8. THE FLOOR     — any OTHER working-column card, by sessState: "open" (turn running, narration
+//                      not reported — an older/disconnected kernel) spins a plain Working…; "quiet"
+//                      (between turns) and "unknown" (no signal at all) render a STILLED glyph + a
+//                      line saying exactly that. Total: a working-column card can never be mute
+//                      (the user 2026-08-14 — two cards sat in Working with nothing on them).
+//   … no spin only OUTSIDE the working column (briefs/takeaways/chips carry those cards).
 // 3 and 4 do NOT depend on whether a brief exists. That independence matters more since 2026-07-22, when
 // the brief stopped showing on a card displaced to Working at all (see ./distiller-line): these two are the
 // only branches that fire in that window, so the swirl is the sole thing saying the card is in motion and
@@ -34,6 +40,7 @@ export interface SpinItem {
   rejudging?: boolean;
   blocked?: unknown;
   working?: { since?: number | null; toolUses?: number | null } | null;   // open-turn narration (kernel _open_turn_progress; the user 2026-08-13)
+  sessState?: string | null;   // the kernel's floor disposition: "open" | "quiet" | "unknown" (the user 2026-08-14)
 }
 
 /** caption: the body line, or null for no spin. tip: the fuller hover explanation. awaitingBg: the
@@ -42,6 +49,7 @@ export interface Spin {
   caption: string | null;
   tip: string;
   awaitingBg: boolean;
+  still?: boolean;   // the at-rest floor: glyph present but NOT spinning — spin reads as in-flight, and quiet/unknown are states of rest
 }
 
 const NONE: Spin = { caption: null, tip: "", awaitingBg: false };
@@ -155,6 +163,38 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
       tip: "The open turn's live progress: tool calls made so far, and how long this stretch has been "
          + "running. If the count freezes while the timer climbs, something is worth a look.",
       awaitingBg: false,
+    };
+  }
+  if (it.column === "working") {
+    // THE FLOOR IS TOTAL (the user 2026-08-14): two cards sat in Working with nothing on them.
+    // The narration above only rides when the kernel parsed an OPEN turn, so a session quietly
+    // between turns, or a machine that isn't reporting at all (an older or briefly disconnected
+    // kernel, a cold parse cache), rendered a MUTE card. Every working-column card now says its
+    // state; when nothing is in motion the glyph STILLS (`still`) — a spinning swirl on a quiet
+    // card would claim work that isn't happening.
+    if (it.sessState === "open") {
+      return {
+        caption: "Working…",
+        tip: "The turn is running, but this machine isn't reporting live progress (an older or "
+           + "briefly disconnected kernel sends none). The card updates the moment it does.",
+        awaitingBg: false,
+      };
+    }
+    if (it.sessState === "quiet") {
+      return {
+        caption: "Paused — resumes on the session's next turn",
+        tip: "Nothing is in motion right now: the session is between turns and this goal stays open. "
+           + "It picks back up the next time the session works this thread.",
+        awaitingBg: false,
+        still: true,
+      };
+    }
+    return {
+      caption: "State unknown — this machine isn't reporting",
+      tip: "No live signal from this session's kernel (a cold cache, or a machine that is offline or "
+         + "reconnecting). The card updates the moment a signal lands.",
+      awaitingBg: false,
+      still: true,
     };
   }
   return NONE;


### PR DESCRIPTION
The user (2026-08-14): two Working-column cards sat with nothing indicating their state, and the requirement is stronger than the instance — no time gap may exist where a card lacks a visual indicator, even when the state is unknown (a machine not reporting).

Root cause: the spin ladder's floor (`working` narration) only rides when the kernel parsed an OPEN turn. A session quietly between turns (the PR-watch session's hourly cadence, exactly the reported cards), or a machine reporting nothing at all, fell through to `NONE` — a mute card. One legacy test pinned the mute card as intended ("a cache-cold card paints plain"); a second still asserted `{caption: null}` for the bare working shape.

The fix makes the floor **total**:
- The kernel grades every session's disposition — `open` (turn running) / `quiet` (parsed, between turns) / `unknown` (no parse to read) — and every working-column card carries it (`sessState`).
- The ladder renders each: `open` without narration spins a plain "Working…" (the turn IS in flight, the machine just isn't reporting progress); `quiet` and `unknown` show the glyph **stilled** with an honest line ("Paused — resumes on the session's next turn" / "State unknown — this machine isn't reporting") — a spinning swirl on a quiet card would claim work that isn't happening. Absent field (an older remote's payload) reads as unknown, never silence.
- A **totality sweep** in the executing ladder test walks every combination of the ladder's inputs with `column: "working"` and fails on any shape yielding a null caption — closing the gap class, not the two instances.

Suites: node 1956/1956 (ladder + sweep + both legacy pins rewritten to the new contract), python narration suite green, kernel compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)