### PR TITLE
Arm the token-absence check that was asserting nothing (follow-up to #380)

### DIFF
--- a/tests/romp-wake-hook.bats
+++ b/tests/romp-wake-hook.bats
@@ -91,7 +91,12 @@ teardown() { rm -rf "$TEST_DIR"; }
     for _ in $(seq 1 40); do [ -s "$CURL_LOG" ] && break; sleep 0.05; done
     for _ in $(seq 1 40); do [ -s "$CURL_STDIN" ] && break; sleep 0.05; done
 
-    ! grep -q "TESTTOKENDONOTUSE" "$CURL_LOG"
+    # `run` + an explicit status check, NOT `! grep …`: bats runs each test under errexit, but a
+    # `!`-prefixed pipeline is exempt from it, so a bare `! grep` anywhere except the test's LAST
+    # line reports nothing when it fails — the token could be in argv and this test would still
+    # pass. This is the one assertion in the file that has to be armed, so arm it explicitly.
+    run grep -q "TESTTOKENDONOTUSE" "$CURL_LOG"
+    [ "$status" -ne 0 ]
     grep -q -- "--config" "$CURL_LOG"
     # ...and the header really is being sent, so this is not "secure by not authenticating"
     grep -q "X-Romp-Token: TESTTOKENDONOTUSE" "$CURL_STDIN"


### PR DESCRIPTION
Follow-up to #380, fixing a defect I introduced there. Test-only.

### The problem

bats runs each test under errexit, but a `!`-prefixed pipeline is **exempt** from it. So a bare `! grep …` anywhere except a test's final line reports nothing when it fails — the assertion runs, returns non-zero, and the test carries straight on.

In `tests/romp-wake-hook.bats`, *"romp-wake never puts the serve token in curl's argv"*, the token-absence check sits mid-test with two commands after it. So the one property that test exists to pin — that the serve token never reaches curl's argv, where any other local account can read it out of `/proc/<pid>/cmdline` — has been unasserted since #380 merged.

The fix in #380 is fine and still works. Only the pin was inert.

### Demonstrated, not assumed

Leaking the token back into argv **while leaving `--config` in place**, so the neighbouring assertions still pass:

```
inert form (main today):  ok 7      romp-wake never puts the serve token in curl's argv
armed form (this PR):     not ok 7  romp-wake never puts the serve token in curl's argv
```

That "while leaving `--config` in place" is the important part, and it explains why this went unnoticed: a regression that *also* dropped `--config` gets caught either way by the following line. The inert check is masked whenever a leak happens to break something else too — so it only fails to fire on the case you'd most want it to catch, a leak that is otherwise well-formed.

I also confirmed the mechanism directly rather than inferring it from the docs:

```
ok 1      mid-test ! is INERT (passes despite a deliberately false assertion)
not ok 2  final-command ! IS armed
not ok 3  armed run+status form IS armed
```

### The fix

`run` + an explicit status check, which is armed wherever it sits in the test, plus a comment naming the errexit exemption so it doesn't get "tidied" back to the short form later.

### Scope

I swept every `.bats` file on `main` for the same pattern — a `!`-prefixed command that is not its test's last line. **This was the only instance.** Nothing else in the suite is affected, and no other assertion changes here.

`tests/romp-wake-hook.bats` 8/8, and `romp-sessions` / `romp` / `romp-launch` green alongside it.
