### PR TITLE
Every awaiting carries a KIND — what the wait is on, threaded as data

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1851,10 +1851,12 @@ def _parse_plan(raw, menu_len, allow_extend=False):
                 ops.append({"do": "mint", "why": why, "text": text})   # no valid parent → place it, never orphan
         elif do in ("done", "block", "awaiting"):
             g, r = _int(o, "goal"), _int(o, "ref")
+            ak = str(o.get("kind") or "").strip().lower() if do == "awaiting" else ""
+            ak = {"kind": ak} if ak in AWAIT_KINDS else {}             # garbage/absent → kindless (legacy)
             if g and 1 <= g <= menu_len:
-                ops.append({"do": do, "why": why, "goal": g})
+                ops.append({"do": do, "why": why, "goal": g, **ak})
             elif r and r >= 1:
-                ops.append({"do": do, "why": why, "ref": r})           # resolved against this reply's mints
+                ops.append({"do": do, "why": why, "ref": r, **ak})     # resolved against this reply's mints
         elif do == "retitle":
             g = _int(o, "goal")                         # goal-only (no "ref"): retitle targets a PRE-EXISTING
             if g and 1 <= g <= menu_len and _has_alpha(text):   # node, never a same-reply mint
@@ -1879,7 +1881,7 @@ PROTECTED = frozenset((
     "log", "logTrunc",                                 # the diary itself
     "followupPending", "followupAt",                   # user-action stamps (reopen-event-derived)
     "settledAt", "settledDone", "deltaSince",          # settle stamps (settle-event-derived)
-    "awaitingWhy", "awaitingAt",                       # ⏳ awaiting stamps (awaiting-event-derived)
+    "awaitingWhy", "awaitingAt", "awaitingKind",       # ⏳ awaiting stamps (awaiting-event-derived)
     "rolledUp",                                        # roll-down's tree-derived marker
 ))
 
@@ -2988,7 +2990,8 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
             # path and _mark_nudge_failed's own escape, so recording it suppresses the false interrupt
             # through machinery that already exists. Lifted by the closer's next audit of the goal.
             t = _target(o)
-            if t and record_verdict(store, nodes[t], "planner", "awaiting", seg_t, why=o["why"], seg=seg_id):
+            if t and record_verdict(store, nodes[t], "planner", "awaiting", seg_t, why=o["why"], seg=seg_id,
+                                    await_kind=o.get("kind")):
                 touched = t                           # mt deliberately NOT bumped: an annotation, not work
         elif do == "extend":
             # A queued-fragment landing (the opener's sibling <note>, the user 2026-07-11): this message
@@ -3575,7 +3578,11 @@ def plan_llm(segment_text, menu_text, model=None, effort=None, human=False, nudg
                  "**resumed** real, still-unfinished work on the goal, keep it working — never force a false "
                  "done/block; and in that case say so explicitly with **awaiting** on #1, the why naming what "
                  "it is waiting on or working through (a long run, a watcher it armed, a background task, a "
-                 "step still in progress). Emit awaiting whenever the reply shows the agent is progressing "
+                 "step still in progress), plus a \"kind\" naming what the wait is on when one fits — exactly "
+                 "one of \"agents\" (agents it dispatched), \"task\" (a background command or watcher), "
+                 "\"job\" (a computation outside the session: a cluster/CI job, a build), \"peer\" (another "
+                 "session), \"timer\" (a check-back it scheduled); omit kind if none fits. "
+                 "Emit awaiting whenever the reply shows the agent is progressing "
                  "and needs **nothing** from the user — silence is not enough, because an unresolved nudge "
                  "with no verdict is read as needing the user's direction. When the nudge enumerated the goal's unfinished pieces and the reply reports on "
                  "them, also resolve each reported piece on its **own** listed item: done where it is "
@@ -5060,7 +5067,8 @@ LOG_CAP = 64                             # per-node verdict-log bound (a node ra
 #                                          is a runaway backstop — oldest drop, logTrunc marks the loss)
 
 
-def record_verdict(store, nd, src, kind, ev_t=None, why=None, seg=None, msg=False, undo=False, lift=False):
+def record_verdict(store, nd, src, kind, ev_t=None, why=None, seg=None, msg=False, undo=False, lift=False,
+                   await_kind=None):
     """P3.1 DUAL-WRITE (the user 2026-07-06): the gate AND the recorder, fused into the one seam every
     verdict write goes through. Asks may_apply; when allowed, appends the event to the node's
     append-only verdict LOG and returns True — the caller then writes the flags exactly as before
@@ -5086,6 +5094,9 @@ def record_verdict(store, nd, src, kind, ev_t=None, why=None, seg=None, msg=Fals
                     **({"msg": True} if msg else {}),  # a user message rides this reopen (chip derivation)
                     **({"undo": True} if undo else {}),   # an undo-restore reopen: not a "not done" assertion
                     **({"lift": True} if lift else {}),   # an `awaiting` row that ENDS the wait, not asserts it
+                    # what an `awaiting` assert waits ON (AWAIT_KINDS; "kind" is taken by the verdict kind).
+                    # Absent = a kindless legacy stamp, which every rule treats exactly as before the enum.
+                    **({"awaitKind": await_kind} if await_kind else {}),
                     "at": int(time.time())})
         if len(log) > LOG_CAP:
             del log[:len(log) - LOG_CAP]
@@ -5165,7 +5176,7 @@ def _fold_node(nd):
                    audited turn's own processing, not a fresh event (see the guard in the loop)."""
     state, floor = "open", 0
     cur_settle, prev_settle = None, None
-    awaiting_why = awaiting_at = None     # the live ⏳ stamp (see docstring); None = not awaiting
+    awaiting_why = awaiting_at = awaiting_kind = None     # the live ⏳ stamp (see docstring); None = not awaiting
     done_why = block_why = None           # the landing verdicts' rationale (doneWhy/blockWhy derivation)
     held = pending = False                # held: an unanswered USER reopen pins the node open (no bottom-up
     #                                       re-completion); pending: an unanswered msg-reopen wears the chip.
@@ -5189,7 +5200,7 @@ def _fold_node(nd):
                 # peer's postal reply sat wedged-invisible in Working. Same-trigger symmetry as the
                 # assert's own `t >= floor` equality-lands rule below: within one turn the reopen is the
                 # trigger, the wait is how the turn ENDED.
-                awaiting_why = awaiting_at = None
+                awaiting_why = awaiting_at = awaiting_kind = None
             if e.get("undo") and clear_snap is not None:
                 state, cur_settle, prev_settle = clear_snap      # restore what the cross-off displaced
                 clear_snap = None
@@ -5212,13 +5223,13 @@ def _fold_node(nd):
                 state = "done"
                 done_why = e.get("why") or done_why
                 reopen_snap = None
-                awaiting_why = awaiting_at = None
+                awaiting_why = awaiting_at = awaiting_kind = None
         elif kind == "block":
             if src in ("user", "agent") or t > floor:
                 state = "blocked"
                 block_why = e.get("why") or block_why
                 reopen_snap = None
-                awaiting_why = awaiting_at = None
+                awaiting_why = awaiting_at = awaiting_kind = None
         elif kind == "unblock":
             if state == "blocked":
                 state = "open"
@@ -5226,15 +5237,22 @@ def _fold_node(nd):
             clear_snap = (state, cur_settle, prev_settle)
             state = "cleared"
             reopen_snap = None
-            awaiting_why = awaiting_at = None
+            awaiting_why = awaiting_at = awaiting_kind = None
         elif kind == "settle":            # display annotation: WHEN the card entered Completed; never state
             cur_settle = t
         elif kind == "awaiting":          # ⏳ annotation (like settle, never state): the closer audited a
             if e.get("lift"):             # turn on this goal — either the wait is (still) on, or it ended
-                awaiting_why = awaiting_at = None
+                awaiting_why = awaiting_at = awaiting_kind = None
             elif src in ("user", "agent") or t >= floor:   # done-style floor: equality LANDS — the turn that
-                awaiting_why = e.get("why") or awaiting_why  # processes the user's reply may itself dispatch
-                awaiting_at = t                              # and wait (the reply IS that turn's trigger)
+                new_why = e.get("why") or awaiting_why       # processes the user's reply may itself dispatch
+                #                                              and wait (the reply IS that turn's trigger)
+                # a kindless re-assert of the SAME why keeps the standing kind (the classification is
+                # already on record); a kindless assert of a DIFFERENT why is a different wait — carrying
+                # a neighbor's label onto it would ship an affirmatively wrong kind (review 2026-08-15)
+                awaiting_kind = (e.get("awaitKind")
+                                 or (awaiting_kind if new_why == awaiting_why else None))
+                awaiting_why = new_why
+                awaiting_at = t
         elif kind == "dismiss":           # the judge rejected the provisional msg-reopen: restore what the
             if reopen_snap is not None:   # optimistic flip displaced (a pivoted completed card returns to
                 state, cur_settle, prev_settle = reopen_snap     # Completed with its original settledAt)
@@ -5247,6 +5265,7 @@ def _fold_node(nd):
             "settledAt": cur_settle, "deltaSince": prev_settle,
             "awaitingWhy": awaiting_why if state == "open" else None,
             "awaitingAt": awaiting_at if state == "open" else None,
+            "awaitingKind": awaiting_kind if state == "open" else None,
             "doneWhy": done_why, "blockWhy": block_why}
 
 
@@ -5455,9 +5474,14 @@ def _materialize_node(nd):
         if f["awaitingWhy"]:
             nd["awaitingWhy"] = f["awaitingWhy"]       # the live ⏳ stamp (open nodes only; the fold
             nd["awaitingAt"] = f["awaitingAt"]         # already returns None for any other state)
+            if f.get("awaitingKind"):
+                nd["awaitingKind"] = f["awaitingKind"]
+            else:
+                nd.pop("awaitingKind", None)           # a kindless stamp carries no kind field at all
         else:
             nd.pop("awaitingWhy", None)
             nd.pop("awaitingAt", None)
+            nd.pop("awaitingKind", None)
     return f
 
 
@@ -7032,13 +7056,17 @@ CLOSER_SYS = (
     "(omit it). When unsure between awaiting and omitting, omit.\n"
     "Reply with only a JSON object (no prose, no markdown fences):\n"
     '{\"done\": [ {\"goal\": <n>, \"why\": \"...\"} ], \"block\": [ {\"goal\": <n>, \"why\": \"...\"} ], '
-    '\"awaiting\": [ {\"goal\": <n>, \"why\": \"...\"} ]}\n'
+    '\"awaiting\": [ {\"goal\": <n>, \"why\": \"...\", \"kind\": \"...\"} ]}\n'
     "Each goal appears in at most one list; omit the goals still working. goal is the goal's number. "
     "For done, why is one sentence on what got it done. For block, why is the question or ask itself, "
     "addressed to the user (the decision you need plus only the context to make it), not a narration, "
     "e.g. \"Approve the staged commit? Nothing is committed yet.\" For awaiting, why is one short line "
     "naming what it waits on and what happens when that lands, e.g. \"a fleet-wide test run it "
-    "launched; merges when green\". All lists may be empty: "
+    "launched; merges when green\", and kind names WHAT it waits on, exactly one of: \"agents\" (agents "
+    "or subagents it dispatched), \"task\" (a background command or watcher it started), \"job\" (a "
+    "computation outside this session — a cluster/CI job, a build, a long run on another machine), "
+    "\"peer\" (another session it handed work to or asked), \"timer\" (a check-back it scheduled). "
+    "All lists may be empty: "
     "{\"done\": [], \"block\": [], \"awaiting\": []}.\n"
     "Write each \"why\" plainly, from the user's vantage: only what they need to know, not a "
     "play-by-play. Drop self-narration (\"The assistant…\", \"The segment…\"). Lead with the real "
@@ -7049,18 +7077,27 @@ CLOSER_SYS = (
     "markdown fences.")
 
 
+# The awaiting KINDS — what a wait is on, as data (the user 2026-08-15, who wanted the surfaces to
+# say WHAT is awaited, and the rules scoped by it): agents/subagents dispatched in-harness; a
+# background task/watcher; an external job (cluster/CI/build); a peer session; a scheduled check-back.
+# The judge files one per awaiting verdict; a stamp without one (older judges, legacy stores) is
+# kindless and behaves exactly as before the enum existed.
+AWAIT_KINDS = ("agents", "task", "job", "peer", "timer")
+
+
 def _parse_close(raw, menu_len):
-    """Parse the closer's {"done":[{goal,why}], "block":[{goal,why}], "awaiting":[{goal,why}]} reply into
-    {"done": {1-based idx: doneWhy}, "block": {1-based idx: blockWhy}, "awaiting": {1-based idx: why}} —
-    the touched open tops now fully DONE / now BLOCKED (needs the user) / now AWAITING async work they set
-    in motion; omitted goals stay open (the conservative default). Empty lists → empty maps. None on
-    unparseable output or a missing/non-list "done" key (skip the turn). A goal in more than one list →
-    block wins, then done (the user 2026-07-27: a hedged both-lists reply is the diagnosed-then-"want
-    me to fix it?" shape, and a wrong done silently buries the owed decision while a wrong block is
-    visible and one click to cross off). Out-of-range and duplicate indices
+    """Parse the closer's {"done":[{goal,why}], "block":[{goal,why}], "awaiting":[{goal,why,kind}]} reply
+    into {"done": {1-based idx: doneWhy}, "block": {1-based idx: blockWhy}, "awaiting": {1-based idx:
+    {"why", "kind"}}} — the touched open tops now fully DONE / now BLOCKED (needs the user) / now AWAITING
+    async work they set in motion; omitted goals stay open (the conservative default). Empty lists →
+    empty maps. None on unparseable output or a missing/non-list "done" key (skip the turn). A goal in
+    more than one list → block wins, then done (the user 2026-07-27: a hedged both-lists reply is the
+    diagnosed-then-"want me to fix it?" shape, and a wrong done silently buries the owed decision while
+    a wrong block is visible and one click to cross off). Out-of-range and duplicate indices
     dropped (first wins) — except a 0/negative index anywhere, which rejects the whole reply (see
     _zero_based_tell: an off-base reply's other indices silently done/block the wrong goals).
-    Tolerant of an absent "block"/"awaiting" key (older replies)."""
+    Tolerant of an absent "block"/"awaiting" key (older replies) and of a missing/garbage awaiting
+    "kind" (→ None, the kindless legacy behavior)."""
     obj = _json_obj(raw)
     if obj is None:
         return None
@@ -7070,7 +7107,7 @@ def _parse_close(raw, menu_len):
             or _zero_based_tell(obj.get("awaiting")):
         return None
 
-    def _collect(items, skip=()):
+    def _collect(items, skip=(), kinds=False):
         out = {}
         for it in items if isinstance(items, list) else []:
             if not isinstance(it, dict):
@@ -7080,13 +7117,18 @@ def _parse_close(raw, menu_len):
             except (TypeError, ValueError):
                 continue
             if 1 <= n <= menu_len and n not in out and n not in skip:
-                out[n] = " ".join(str(it.get("why", "")).split())[:300]
+                why = " ".join(str(it.get("why", "")).split())[:300]
+                if kinds:
+                    k = str(it.get("kind") or "").strip().lower()
+                    out[n] = {"why": why, "kind": k if k in AWAIT_KINDS else None}
+                else:
+                    out[n] = why
         return out
 
     block = _collect(obj.get("block"))
     done = _collect(obj.get("done"), skip=block)                            # block wins for the same goal
     return {"done": done, "block": block,
-            "awaiting": _collect(obj.get("awaiting"), skip=set(done) | set(block))}
+            "awaiting": _collect(obj.get("awaiting"), skip=set(done) | set(block), kinds=True)}
 
 
 def closer_llm(turn_text, menu_text, goal_history="", lift_whys=""):
@@ -7382,7 +7424,10 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
     worked on (menu indices 1..touched): the history-nominated candidates riding the menu
     (_subtree_done_candidates/_starved_candidates) got no new turn, so their omission says nothing about
     their wait. A re-assert with the SAME why is skipped, not re-appended — the stamp keeps its original
-    since-time and a long poll loop never chews through LOG_CAP."""
+    since-time and a long poll loop never chews through LOG_CAP. ONE exception rides that rule without
+    breaking it: a same-why re-assert whose kind fills a KINDLESS stamp lands once, AT the original
+    anchor (ev_t = the standing awaitingAt), so the classification catches up while the since-time, the
+    wake's patience, and the supersede ordering stay keyed to the first assertion."""
     done, block = verdicts.get("done", {}), verdicts.get("block", {})
     awaiting = verdicts.get("awaiting", {})
     newly = []
@@ -7406,8 +7451,19 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None):
             if ev is not None:                        # (the event materialized the flags + blockWhy)
                 nd["mt"] = ev
         elif i in awaiting:
-            if nd.get("awaitingWhy") != (awaiting[i] or None):     # same why → keep the original stamp
-                record_verdict(store, nd, "closer", "awaiting", t, why=awaiting[i] or None)
+            aw_why = (awaiting[i] or {}).get("why") or None
+            aw_kind = (awaiting[i] or {}).get("kind")
+            if nd.get("awaitingWhy") != aw_why:
+                # a changed why is a real event → new row, new anchor (as ever)
+                record_verdict(store, nd, "closer", "awaiting", t, why=aw_why, await_kind=aw_kind)
+            elif aw_why and aw_kind and not nd.get("awaitingKind"):
+                # a kind GAIN on the standing why lands AT THE ORIGINAL ANCHOR: the stamp's since-time,
+                # the wake's patience, and the peer-supersede ordering all key on the first assertion —
+                # a classification catching up is not a new wait (review 2026-08-15). A kind CHANGE on
+                # an unchanged why coalesces like any same-why re-assert: an LLM relabel (task↔job) is
+                # not new information, and landing it would re-anchor + chew LOG_CAP every audit.
+                record_verdict(store, nd, "closer", "awaiting", nd.get("awaitingAt"),
+                               why=aw_why, await_kind=aw_kind)
         elif nd.get("awaitingWhy") and (touched is None or i <= touched):
             record_verdict(store, nd, "closer", "awaiting", t, lift=True)
     return newly

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2411,9 +2411,10 @@ def _goal_awaiting_stamp(nodes, top, children=None, answered_at=0):
 
 
 def _goal_awaiting_stamp_full(nodes, top, children=None, answered_at=0):
-    """(awaitingAt, why) of the freshest live ⏳ stamp in `top`'s subtree, or None — _goal_awaiting_stamp
-    with the ANCHOR alongside the why. The awaiting wake's due-check needs the anchor (see the awaiting
-    branch of _auto_nudge_session's goal walk); every display consumer keeps the why-only twin above."""
+    """(awaitingAt, why, kind) of the freshest live ⏳ stamp in `top`'s subtree, or None —
+    _goal_awaiting_stamp with the ANCHOR and the wait's KIND (jd.AWAIT_KINDS or None) alongside the why.
+    The awaiting wake's due-check needs the anchor (see the awaiting branch of _auto_nudge_session's
+    goal walk); display consumers that only word the wait keep the why-only twin above."""
     if children is None:
         children = {}
         for nid, nd in nodes.items():
@@ -2427,10 +2428,10 @@ def _goal_awaiting_stamp_full(nodes, top, children=None, answered_at=0):
         if nd.get("awaitingWhy") and not nd.get("rolledUp"):
             at = nd.get("awaitingAt") or 0
             if not (at and answered_at and at < answered_at):
-                cand = (at, nd["awaitingWhy"])
+                cand = (at, nd["awaitingWhy"], nd.get("awaitingKind") or "")   # "" keeps max() comparable
                 best = cand if best is None else max(best, cand)
         stack.extend(children.get(x, []))
-    return best
+    return (best[0], best[1], best[2] or None) if best else None
 
 
 def _mark_nudge_failed(gid, ev_t=None, wake=False):
@@ -3178,7 +3179,7 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
       silent    no response within the same window (from the FIRE, rec["at"]) → _mark_nudge_failed(wake=True):
                 the block rides the normal ladder to Needs-you. A failed/moot record re-arms only on a
                 genuinely NEW stamp episode (anchor newer than the one that failed)."""
-    at, why = stamp
+    at, why = stamp[0], stamp[1]
     if tmux.get(sid) is None:
         return False                                 # dormant CLI → its work died with it; the death notice
         #                                              owns that story, not a wake (same rule as the lifts)
@@ -10409,11 +10410,12 @@ def _pending_queued(path):
 _api_err_cache = {}           # path -> ((mtime, size), err|None)
 
 
-_SESSION_STAMP_CACHE = {}    # sid -> ((goals mtime,size, overrides mtime,size), ((gid, at, why), stamped tops)) — see _session_stamp_read
+_SESSION_STAMP_CACHE = {}    # sid -> ((goals mtime,size, overrides mtime,size), ((gid, at, why, kind), stamped tops)) — see _session_stamp_read
 
 
 def _session_stamp_read(sid):
-    """ONE cached store read under both stamp views: the freshest live ⏳ stamp (gid, awaitingAt, why) AND
+    """ONE cached store read under both stamp views: the freshest live ⏳ stamp (gid, awaitingAt, why,
+    kind) AND
     the frozenset of TOP ancestors carrying any live stamp in their subtree. The tuple is the SESSION-level
     twin of _goal_awaiting_stamp, so the rail chip and timeline lane (which read _session_awaiting, not the
     per-goal stamp) light up the same restart-proof awaiting the feed card already shows off the stamp (the
@@ -10427,7 +10429,7 @@ def _session_stamp_read(sid):
         gs = (jd.GOALDIR / (sid + ".json")).stat()
         gkey = (gs.st_mtime, gs.st_size)
     except Exception:
-        return ((None, None, None), frozenset(), ())   # no store yet → nothing to stamp, nothing delegated
+        return ((None, None, None, None), frozenset(), ())   # no store yet → nothing to stamp, nothing delegated
     try:
         ostt = (jd._overrides_dir() / (sid + ".jsonl")).stat()
         okey = (ostt.st_mtime, ostt.st_size)
@@ -10442,7 +10444,7 @@ def _session_stamp_read(sid):
     hit = _SESSION_STAMP_CACHE.get(sid)
     if hit and hit[0] == key:
         return hit[1]
-    full, tops, deleg = (None, None, None), set(), ()
+    full, tops, deleg = (None, None, None, None), set(), ()
     try:                                               # load_goals (not a raw read) so overrides replay —
         nodes = jd.load_goals(sid).get("nodes", {})    # the same view _goal_awaiting_stamp sees on the card
         best = None
@@ -10452,7 +10454,7 @@ def _session_stamp_read(sid):
                 at = nd.get("awaitingAt") or 0
                 if at and answered and at < answered:
                     continue                           # the awaited answer landed after this stamp — superseded
-                cand = (at, nid, nd["awaitingWhy"])
+                cand = (at, nid, nd["awaitingWhy"], nd.get("awaitingKind"))
                 best = cand if best is None else max(best, cand)
                 top, seen = nid, set()                 # stamped node → its TOP ancestor (cycle-guarded)
                 while top in nodes and nodes[top].get("parentId") is not None and top not in seen:
@@ -10460,7 +10462,7 @@ def _session_stamp_read(sid):
                     top = nodes[top]["parentId"]
                 tops.add(top)
         if best:
-            full = (best[1], best[0], best[2])         # (gid, at, why)
+            full = (best[1], best[0], best[2], best[3])   # (gid, at, why, kind)
         # DELEGATION, the same pass (the user 2026-08-08, whose fully-delegated session wore the feed's
         # green awaiting dot while chat/timeline/rail read plain ready): a top whose every OPEN leaf is a
         # courier handoff node is work handed to PEERS — the exact evidence the feed's per-card flavor
@@ -10480,15 +10482,15 @@ def _session_stamp_read(sid):
                     peers.add(str(h["peer"]))
         deleg = tuple(sorted(peers))
     except Exception:
-        full, tops, deleg = (None, None, None), set(), ()
+        full, tops, deleg = (None, None, None, None), set(), ()
     val = (full, frozenset(tops), deleg)
     _SESSION_STAMP_CACHE[sid] = (key, val)
     return val
 
 
 def _session_stamp_full(sid):
-    """(gid, awaitingAt, why) of the freshest durable ⏳ awaiting stamp across ALL of a session's goals, or
-    (None, None, None). _session_stamp_cached returns just the why (the display surfaces)."""
+    """(gid, awaitingAt, why, kind) of the freshest durable ⏳ awaiting stamp across ALL of a session's
+    goals, or (None, None, None, None)."""
     return _session_stamp_read(sid)[0]
 
 
@@ -10497,11 +10499,6 @@ def _session_stamped_tops(sid):
     (_bg_split): a placed launch owned by one of these tops is AWAITED, any other placed launch is a
     SERVICE."""
     return _session_stamp_read(sid)[1]
-
-
-def _session_stamp_cached(sid):
-    """The freshest durable ⏳ stamp's WHY for a session (or None) — the display surfaces' view."""
-    return _session_stamp_full(sid)[2]
 
 
 def _session_delegated_why(sid):
@@ -10520,9 +10517,11 @@ def _session_delegated_why(sid):
 
 
 def _session_awaiting(sid, path, idle, stamp=False):
-    """A session AWAITING dispatched/delegated background work (a WORKING flavor, the user 2026-06-22) → a
-    one-line 'why' for the ⏳ awaiting badge, else None. Only when IDLE — an actively producing turn is
-    just 'working'. Three EVENT-BASED sources, in order:
+    """A session AWAITING dispatched/delegated background work (a WORKING flavor, the user 2026-06-22) →
+    {"kind", "why"}: the one-line 'why' for the ⏳ awaiting badge plus WHAT the wait is on (jd.AWAIT_KINDS,
+    the user 2026-08-15 — kind rides as DATA so surfaces can word it and rules can scope by it; None =
+    kindless, the legacy shape). Falsy (None) when not awaiting, so truthiness callers read unchanged.
+    Only when IDLE — an actively producing turn is just 'working'. The EVENT-BASED sources, in order:
       0. the backend snapshot's LIVE subagent count (SubagentStart/Stop) — genuine delegated Claude
          AGENTS in flight, held in memory, independent of any turn.
       0.5 the backend snapshot's LIVE bg-task set — the CLI's DESIGNED task lifecycle stream
@@ -10549,7 +10548,7 @@ def _session_awaiting(sid, path, idle, stamp=False):
       1. the states/<sid>.jsonl AWAITING OVERLAY — {"awaiting":bool,"why":…} the SDK/tmux Stop hooks write.
          POSITIVE rows only: an awaiting:false row contributes nothing and falls through (the Stop hook
          writes false unconditionally at every turn end, so a false row is ambient, not an answer).
-      2. the JUDGE's durable ⏳ stamp (_session_stamp_cached), OPT-IN via stamp=True — the closer's awaiting
+      2. the JUDGE's durable ⏳ stamp (_session_stamp_full), OPT-IN via stamp=True — the closer's awaiting
          verdict, materialized in the goal store, so it OUTLIVES a kernel restart (sources 0-1 die with the
          backend, which is how a genuinely-waiting session read 'stalled'). LIVE-only: a dormant session's
          dispatched work died with its CLI, so a stale stamp must not resurrect it. Only the SESSION-scoped
@@ -10583,7 +10582,7 @@ def _session_awaiting(sid, path, idle, stamp=False):
         # formatted the list itself with %d (latent TypeError since 3325771, masked because a subagent
         # normally runs inside an open turn → idle=False → this branch never ran) — count via len().
         n = len(subs)
-        return "%d background agent%s still working" % (n, "" if n == 1 else "s")
+        return {"kind": "agents", "why": "%d background agent%s still working" % (n, "" if n == 1 else "s")}
     tasks = _bg_live_norm(sid, path)
     if tasks:
         # Sources 0.5/0.75 — only the PENDING tasks (launch not yet placed) count; a placed launch's
@@ -10591,12 +10590,19 @@ def _session_awaiting(sid, path, idle, stamp=False):
         pending = _bg_pending(sid, path, tasks)
         if pending:
             d0 = pending[0]["desc"]
+            # a dispatched agent/workflow is kind agents even through the task stream; a mixed set
+            # (or plain shell work) is kind task — the generic word for in-harness background work
+            kind = ("agents" if all("agent" in (t.get("type") or "") or t.get("type") == "local_workflow"
+                                    for t in pending) else "task")
             if len(pending) == 1:
-                return "waiting on a background task%s" % ((": " + d0) if d0 else "")
-            return "waiting on %d background tasks%s" % (len(pending), (" — " + d0 + ", …") if d0 else "")
+                return {"kind": kind, "why": "waiting on a background task%s" % ((": " + d0) if d0 else "")}
+            return {"kind": kind, "why": "waiting on %d background tasks%s"
+                                         % (len(pending), (" — " + d0 + ", …") if d0 else "")}
     ov = _states_awaiting_overlay(sid)
     if ov is not None and ov.get("awaiting"):         # a producer wrote a LIVE awaiting:true → trust its why
-        return ov.get("why") or "waiting on dispatched work"
+        ovk = ov.get("kind")
+        return {"kind": ovk if ovk in jd.AWAIT_KINDS else None,
+                "why": ov.get("why") or "waiting on dispatched work"}
     # An awaiting:false overlay row is NOT a veto — it says only that THIS channel has nothing to add.
     # The SDK Stop hook has written an unconditional false at every turn end since 2026-07-07 while
     # nothing writes true, so treating "most recent row is false" as the session's answer made source 2
@@ -10620,7 +10626,15 @@ def _session_awaiting(sid, path, idle, stamp=False):
         # AFTER the judge's stamp, mirroring the feed's own precedence (its _deleg_why yields to
         # _stamp_why/_await_ok). Without this arm a fully-delegated session was the feed's green dot
         # and nobody else's (the user 2026-08-08): the three surfaces answered one question two ways.
-        return _owned_yield_why(sid, path) or _session_stamp_cached(sid) or _session_delegated_why(sid)
+        y = _owned_yield_why(sid, path)
+        if y:
+            return {"kind": "task", "why": y}          # a live owned dispatch — in-harness work
+        _gid, _at, st_why, st_kind = _session_stamp_full(sid)
+        if st_why:
+            return {"kind": st_kind, "why": st_why}    # the judge's own classification rides the stamp
+        d = _session_delegated_why(sid)
+        if d:
+            return {"kind": "peer", "why": d}          # the courier handoff graph is peer by construction
     return None
 
 
@@ -14200,7 +14214,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     # user 2026-06-22), the SAME signal _nudge + build_feed use. Only meaningful when the main turn is idle
     # (_session_awaiting returns None while open_now). Session-scoped chat-view chip → the durable stamp too,
     # so the composer's awaiting chip survives a kernel restart like the feed card.
-    awaiting_why = _session_awaiting(sid, sess["path"], not open_now, stamp=True)
+    _aw = _session_awaiting(sid, sess["path"], not open_now, stamp=True)
+    awaiting_why = _aw["why"] if _aw else None
+    awaiting_kind = _aw["kind"] if _aw else None
     # API error → the session is BLOCKED until retried: a bottom card (renderApiError, a RED dot) AND the chip
     # flips to "blocked" below. Detected event-based from the transcript (isApiErrorMessage), so the exact
     # text (500 / timeout / model-not-found) doesn't matter (the user 2026-06-16). GATED on the session NOT
@@ -14425,6 +14441,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   # the live AWAITED task descriptions behind it (same source as the timeline lane + feed
                   # pill), so a multi-task wait can list them all on hover.
                   "awaitingWhy": awaiting_why or None,
+                  "awaitingKind": awaiting_kind,   # WHAT the wait is on (jd.AWAIT_KINDS; None = kindless)
                   "awaitingTasks": (_awaiting_task_descs(sid, sess["path"]) if awaiting_why else []),
                   "apiTooLong": bool(aerr and aerr.get("tooLong")),
                   # a spend cap is on-you like tooLong (red tab, "raise your cap") AND never auto-retried:
@@ -15287,7 +15304,7 @@ def _provisional_card(s, name, color, fsid, live, now, store=None):
             "provisional": True, "judging": not turn_open, "tree": []}
 
 
-def _awaiting_card(s, name, color, fsid, live, now, why):
+def _awaiting_card(s, name, color, fsid, live, now, why, kind=None):
     """A lightweight WORKING-column placeholder for a LIVE, IDLE session AWAITING a dispatched BACKGROUND
     TASK when there is NO open goal to floor to awaiting (the user 2026-07-13). The turn ended and every
     card is done/cleared/placed, so the goal loop has nothing to floor AND _provisional_card bows out (its
@@ -15321,7 +15338,7 @@ def _awaiting_card(s, name, color, fsid, live, now, why):
             # awaiting flavor with the live bg-task descriptions → the "Waiting on task" pill (the user
             # 2026-07-13). judging False: this session is idle-awaiting, not analyzing — the pill, not a
             # "Working…"/"Analyzing…" chip, carries the state (feed.ts defers the provisional chip when awaiting).
-            "awaiting": {"why": why, "tasks": _awaiting_task_descs(fsid, s["path"])},
+            "awaiting": {"why": why, "kind": kind, "tasks": _awaiting_task_descs(fsid, s["path"])},
             "provisional": True, "judging": False, "tree": []}
 
 
@@ -15912,7 +15929,9 @@ def build_feed(now, tmux=None):
         # judge's stamp or the service chip — see _session_awaiting/_bg_split), or the SDK producer's
         # states overlay; None when actively working.
         # Computed BEFORE the API-error floor, which must yield to it (the user 2026-07-05).
-        sess_awaiting_why = _session_awaiting(fsid, s["path"], not who_working) if ps else None   # cache-only: fills in after the warm
+        _sess_aw = _session_awaiting(fsid, s["path"], not who_working) if ps else None   # cache-only: fills in after the warm
+        sess_awaiting_why = _sess_aw["why"] if _sess_aw else None
+        sess_awaiting_kind = _sess_aw["kind"] if _sess_aw else None
         if sess_awaiting_why and not who_working:
             awaiting.append(name)                    # the AWAITING dot list (straw, the user 2026-07-13) — the
             #                                          same split _session_chip makes; feed/chat dots match the chip
@@ -16008,8 +16027,10 @@ def build_feed(now, tmux=None):
             # across kernel restarts — exactly where the live snapshot signals above go dark and a
             # genuinely-waiting goal used to read as plain working, then "stalled". It floors WORKING
             # only: a real needs-you (block) always outranks the annotation.
-            _stamp_why = (_goal_awaiting_stamp(nodes, nid, children, answered_at=_peer_answered_at(fsid))
-                          if col == "working" else None)
+            _sf = (_goal_awaiting_stamp_full(nodes, nid, children, answered_at=_peer_answered_at(fsid))
+                   if col == "working" else None)
+            _stamp_why = _sf[1] if _sf else None
+            _stamp_kind = _sf[2] if _sf else None
             # DELEGATION-derived awaiting (the courier's durable handoff graph, not the question-regex):
             # every OPEN leaf under this top is a handoff-tracking node → the only outstanding work lives
             # with peers, so the card reads ⏳ "delegated to <peer>" instead of plain working (which reads
@@ -16047,6 +16068,13 @@ def build_feed(now, tmux=None):
                               "peerHost": ("" if pname else o.get("peerHost") or ""),
                               "peerSid": psid, "color": _name_color(psid)}
             await_why = (sess_awaiting_why or _stamp_why or _deleg_why or _owned_why) if col == "awaiting" else None   # the ⏳ awaiting badge's "why": live snapshot, then the judge's durable stamp, then the delegation graph, then the blocked-yield's owned dispatch (None for the postal-only case → the waitingOn chip names the peer)
+            await_kind = None                        # the winning why's KIND rides beside it, mirroring the
+            if col == "awaiting":                    # or-chain exactly (a kindless winner stays kindless)
+                for _w, _k in ((sess_awaiting_why, sess_awaiting_kind), (_stamp_why, _stamp_kind),
+                               (_deleg_why, "peer"), (_owned_why, "task")):
+                    if _w:
+                        await_kind = _k
+                        break
             # The card's TIME reflects its CURRENT STATE, not when the goal was minted: a COMPLETED card
             # shows when it was completed, a BLOCKED card when it was blocked — the mt of the most-recent
             # such node in its subtree — else (working/awaiting) its LAST ACTIVITY (the newest mt anywhere in
@@ -16301,7 +16329,8 @@ def build_feed(now, tmux=None):
                 # work) — the user 2026-06-22. `tasks` = the live bg-task descriptions (the user 2026-07-13):
                 # when present the card wears the compact "Waiting on task" pill (expands to this list, like
                 # Sub-goals) instead of the boxed why; empty for subagent/overlay flavors, which keep the box.
-                "awaiting": ({"why": await_why, "tasks": _awaiting_task_descs(fsid, s["path"])} if col == "awaiting" else None),
+                "awaiting": ({"why": await_why, "kind": await_kind,
+                              "tasks": _awaiting_task_descs(fsid, s["path"])} if col == "awaiting" else None),
                 "summary": nodes[nid].get("summary"),    # the distiller's key takeaway for a completed goal (modal) — the user 2026-06-17
                 "distillState": distill_state,   # "completed" | "blocked" | null — the GENUINE state the distiller line keys on, so the brief/takeaway doesn't flicker off when recheck/rejudging drops `column` to working (the user 2026-07-21)
                 "blockSummary": nodes[nid].get("blockSummary"),    # the block-distiller's decision brief for a blocked goal (modal); null until produced — the user 2026-06-18
@@ -16395,7 +16424,8 @@ def build_feed(now, tmux=None):
                 # (the same signal the timeline's faded awaiting stretch reads). Surface a working-column
                 # awaiting card so the wait shows in the FEED, not just on the timeline — the hole the user
                 # hit ("there's no card there"). Ephemeral: gone the moment sess_awaiting_why clears.
-                asks.append(_awaiting_card(s, name, color, fsid, live, now, sess_awaiting_why))
+                asks.append(_awaiting_card(s, name, color, fsid, live, now, sess_awaiting_why,
+                                           kind=sess_awaiting_kind))
     if cold_parse:
         _warm_fleet_bg(now)                          # a living session wasn't parsed yet → warm it + re-push (dots/anchors)
     # NO caption stream. The feed's cards are TOP-LEVEL GOALS ONLY (read-side.md: Inbox = goal cards;
@@ -18022,9 +18052,12 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         # `awaiting` intervals field below both mean blocked-on-YOU. Cheap (live subagent snapshot + states
         # overlay), so both the skeleton and the bars build carry it. Idle input = `aw_open`, the chip's
         # own event-model signal (see its derivation above), NOT the raw-snapshot `open_now`.
-        awaiting_bg = (_session_awaiting(sid, s["path"], not aw_open, stamp=True) if live else None)
+        _aw_bg = (_session_awaiting(sid, s["path"], not aw_open, stamp=True) if live else None)
+        awaiting_bg = _aw_bg["why"] if _aw_bg else None
+        awaiting_kind = _aw_bg["kind"] if _aw_bg else None
         sessions.append({
             "id": sid, "name": name, "live": live, "state": state, "awaitingBg": awaiting_bg,
+            "awaitingKind": awaiting_kind,
             # the live bg-task descriptions behind awaitingBg (the user 2026-07-13): the lane draws the
             # idle-but-waiting stretch as a thin dashed segment whose hover lists exactly what's pending
             "awaitingTasks": (_awaiting_task_descs(sid, s["path"]) if awaiting_bg else []),

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -7229,19 +7229,82 @@ class AwaitingVerdict(unittest.TestCase):
     def test_parse_collects_awaiting_and_resolutions_win(self):
         self.assertEqual(
             jd._parse_close('{"done": [], "block": [], "awaiting": [{"goal": 2, "why": "a test run; merges when green"}]}', 3),
-            {"done": {}, "block": {}, "awaiting": {2: "a test run; merges when green"}})
+            {"done": {}, "block": {}, "awaiting": {2: {"why": "a test run; merges when green", "kind": None}}})
         self.assertEqual(
             jd._parse_close('{"done": [{"goal": 1, "why": "shipped"}], "block": [{"goal": 2, "why": "?"}],'
                             ' "awaiting": [{"goal": 1, "why": "w"}, {"goal": 2, "why": "w"}, {"goal": 3, "why": "w"}]}', 3),
-            {"done": {1: "shipped"}, "block": {2: "?"}, "awaiting": {3: "w"}},
+            {"done": {1: "shipped"}, "block": {2: "?"}, "awaiting": {3: {"why": "w", "kind": None}}},
             "a goal resolved done/blocked never also carries the annotation")
         self.assertIsNone(jd._parse_close('{"done": [], "awaiting": [{"goal": 0, "why": "x"}]}', 3),
                           "a zero index in the awaiting list poisons the whole reply, same as the others")
 
+    def test_parse_extracts_a_valid_kind_and_drops_garbage(self):
+        # the kind enum is AWAIT_KINDS; anything else (or absent) parses to None — the kindless
+        # legacy shape every rule treats exactly as before the enum existed
+        got = jd._parse_close('{"done": [], "block": [], "awaiting": ['
+                              '{"goal": 1, "why": "slurm 4821", "kind": "job"},'
+                              '{"goal": 2, "why": "w", "kind": " PEER "},'
+                              '{"goal": 3, "why": "w", "kind": "banana"}]}', 3)
+        self.assertEqual(got["awaiting"][1], {"why": "slurm 4821", "kind": "job"})
+        self.assertEqual(got["awaiting"][2]["kind"], "peer", "kind normalizes case/whitespace")
+        self.assertIsNone(got["awaiting"][3]["kind"], "an off-enum kind degrades to kindless, never poisons")
+
+    def test_apply_files_the_kind_and_a_kind_gain_lands_at_the_original_anchor(self):
+        s = _store()
+        g = _mknode(s, "G1")
+        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "the sweep", "kind": None}}},
+                       t=T0 + 50, touched=1)
+        self.assertNotIn("awaitingKind", g, "a kindless stamp carries no kind field at all")
+        # the closer re-files the SAME why now carrying a kind: the classification catches up, but the
+        # stamp's anchor may NOT move — the wake's patience and the supersede ordering key on it
+        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "the sweep", "kind": "job"}}},
+                       t=T0 + 500, touched=1)
+        self.assertEqual(g["awaitingKind"], "job")
+        self.assertEqual(g["awaitingAt"], T0 + 50, "a kind gain is not a new wait — the anchor stays")
+        rows = [e for e in g["log"] if e["kind"] == "awaiting"]
+        self.assertEqual([e.get("awaitKind") for e in rows], [None, "job"])
+        # …an identical (why, kind) re-assert coalesces as before…
+        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "the sweep", "kind": "job"}}},
+                       t=T0 + 900, touched=1)
+        self.assertEqual(len([e for e in g["log"] if e["kind"] == "awaiting"]), 2)
+        # …and a same-why RELABEL (job↔task flip-flop) is swallowed too: an LLM changing its mind about
+        # the label is not new information, and landing it would re-anchor + chew LOG_CAP every audit
+        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "the sweep", "kind": "task"}}},
+                       t=T0 + 1300, touched=1)
+        self.assertEqual(g["awaitingKind"], "job")
+        self.assertEqual(len([e for e in g["log"] if e["kind"] == "awaiting"]), 2)
+
+    def test_a_kindful_reply_with_no_why_files_nothing_on_an_unstamped_goal(self):
+        # the old None != None skip must survive the kind clause: a malformed {kind, empty why} item
+        # on a goal with NO standing stamp appends no diary row, however often the model repeats it
+        s = _store()
+        g = _mknode(s, "G1")
+        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "", "kind": "job"}}},
+                       t=T0 + 50, touched=1)
+        self.assertEqual([e for e in g.get("log", []) if e["kind"] == "awaiting"], [])
+
+    def test_a_kindless_reassert_keeps_the_kind_only_while_the_why_stands(self):
+        # SAME why, kindless re-assert → the standing classification holds; a kindless assert of a
+        # DIFFERENT why is a different wait — inheriting the neighbor's label would ship an
+        # affirmatively wrong kind (review 2026-08-15)
+        s = _store()
+        g = _mknode(s, "G1")
+        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "the sweep", "kind": "job"}}},
+                       t=T0 + 50, touched=1)
+        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "the second pass", "kind": None}}},
+                       t=T0 + 500, touched=1)
+        self.assertEqual(g["awaitingWhy"], "the second pass")
+        self.assertNotIn("awaitingKind", g, "a new wait does not inherit the old wait's kind")
+
+    def test_awaiting_kind_is_diary_owned(self):
+        nd = jd.GuardedNode({"id": "n", "text": "G"})
+        with self.assertRaises(TypeError):
+            nd["awaitingKind"] = "job"
+
     def test_apply_stamps_the_annotation_without_resolving(self):
         s = _store()
         g = _mknode(s, "G1")
-        newly = jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: "a fleet test run; merges when green"}},
+        newly = jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "a fleet test run; merges when green", "kind": None}}},
                                t=T0 + 50, touched=1)
         self.assertEqual(newly, [], "awaiting is an annotation, never a completion")
         self.assertEqual(g["awaitingWhy"], "a fleet test run; merges when green")
@@ -7254,19 +7317,19 @@ class AwaitingVerdict(unittest.TestCase):
         # a long poll loop re-asserts every audited turn; identical whys never chew through LOG_CAP
         s = _store()
         g = _mknode(s, "G1")
-        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: "the campaign timer"}}, t=T0 + 50, touched=1)
-        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: "the campaign timer"}}, t=T0 + 500, touched=1)
+        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "the campaign timer", "kind": None}}}, t=T0 + 50, touched=1)
+        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "the campaign timer", "kind": None}}}, t=T0 + 500, touched=1)
         rows = [e for e in g["log"] if e["kind"] == "awaiting"]
         self.assertEqual(len(rows), 1, "an identical re-assert is skipped, not re-appended")
         self.assertEqual(g["awaitingAt"], T0 + 50, "the stamp keeps its original since-time")
-        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: "the deploy it kicked off"}}, t=T0 + 900, touched=1)
+        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "the deploy it kicked off", "kind": None}}}, t=T0 + 900, touched=1)
         self.assertEqual(g["awaitingWhy"], "the deploy it kicked off", "a changed why is a real event -> new row")
         self.assertEqual(g["awaitingAt"], T0 + 900)
 
     def test_the_next_audited_turn_without_reassert_lifts_the_stamp(self):
         s = _store()
         g = _mknode(s, "G1")
-        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: "the watcher"}}, t=T0 + 50, touched=1)
+        jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "the watcher", "kind": None}}}, t=T0 + 50, touched=1)
         self.assertTrue(g.get("awaitingWhy"))
         jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {}}, t=T0 + 500, touched=1)
         self.assertNotIn("awaitingWhy", g, "the goal's own next audited turn is the exact clearing event")
@@ -7278,7 +7341,7 @@ class AwaitingVerdict(unittest.TestCase):
         # from the awaiting list says nothing about their wait -> the `touched` bound excludes them
         s = _store()
         g1, g2 = _mknode(s, "touched"), _mknode(s, "candidate")
-        jd.apply_close(s, [g1, g2], {"done": {}, "block": {}, "awaiting": {2: "its own async job"}}, t=T0 + 50, touched=2)
+        jd.apply_close(s, [g1, g2], {"done": {}, "block": {}, "awaiting": {2: {"why": "its own async job", "kind": None}}}, t=T0 + 50, touched=2)
         jd.apply_close(s, [g1, g2], {"done": {}, "block": {}, "awaiting": {}}, t=T0 + 500, touched=1)
         self.assertEqual(g2.get("awaitingWhy"), "its own async job",
                          "the candidate (index 2 > touched 1) keeps its stamp; only real turns lift")
@@ -7288,7 +7351,7 @@ class AwaitingVerdict(unittest.TestCase):
                                ("block", {"done": {}, "block": {1: "Approve?"}, "awaiting": {}})):
             s = _store()
             g = _mknode(s, "G1")
-            jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: "the test run"}}, t=T0 + 50, touched=1)
+            jd.apply_close(s, [g], {"done": {}, "block": {}, "awaiting": {1: {"why": "the test run", "kind": None}}}, t=T0 + 50, touched=1)
             jd.apply_close(s, [g], verdicts, t=T0 + 500, touched=1)
             self.assertNotIn("awaitingWhy", g, "a landed %s outranks and ends the annotation" % kind)
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1196,7 +1196,7 @@ class ViewBuilder(unittest.TestCase):
             "nodes": {top: gn(top, "research the API", None, why="user asked for the research")},
             "placements": {}, "status": {top: "working"}}))
         saved = km._session_awaiting
-        km._session_awaiting = lambda sid, path, idle, stamp=False: "Waiting on the 3 research agents it dispatched."
+        km._session_awaiting = lambda sid, path, idle, stamp=False: {"kind": "agents", "why": "Waiting on the 3 research agents it dispatched."}
         try:
             card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == top)
         finally:
@@ -1443,7 +1443,8 @@ class ViewBuilder(unittest.TestCase):
         self.assertTrue(km._states_awaiting_overlay(SID).get("awaiting"),
                         "awaiting:true with no later work turn stays awaiting")
         self.assertEqual(km._session_awaiting(SID, str(self.tpath), True),
-                         "Waiting on 2 background jobs it launched.", "the genuine awaiting badge still shows")
+                         {"kind": None, "why": "Waiting on 2 background jobs it launched."},
+                         "the genuine awaiting badge still shows")
 
     def test_blocked_rolls_up_the_card_tree_so_a_buried_block_is_visible(self):
         # nimbus (the user 2026-07-11): the card sat in Needs-you off a block BURIED two levels down,
@@ -1532,18 +1533,22 @@ class ViewBuilder(unittest.TestCase):
             # source 0: real subagents in flight — the snapshot carries the live LIST (a {"type","since"}
             # per agent); the why counts via len() (the pre-fix code %d-formatted the list itself)
             km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "", "since": T0}, {"type": "", "since": T0}]}}
-            self.assertEqual(km._session_awaiting(SID, str(p), True), "2 background agents still working",
+            self.assertEqual(km._session_awaiting(SID, str(p), True),
+                             {"kind": "agents", "why": "2 background agents still working"},
                              "a live subagent DOES leave an idle session awaiting (a working flavor)")
             # source 0.5: the live bg-task set — one task shows its description verbatim
             km._tmux_sessions = lambda: {SID: {"bgTasks": [timer]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
-                             "waiting on a background task: 20-minute timer for campaign-start check")
+                             {"kind": "task",
+                              "why": "waiting on a background task: 20-minute timer for campaign-start check"})
             km._tmux_sessions = lambda: {SID: {"bgTasks": [timer, dict(timer, desc="power watcher")]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
-                             "waiting on 2 background tasks — 20-minute timer for campaign-start check, …")
+                             {"kind": "task",
+                              "why": "waiting on 2 background tasks — 20-minute timer for campaign-start check, …"})
             # subagents outrank bg tasks when both run (they're the bigger dispatch)
             km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "", "since": T0}], "bgTasks": [timer]}}
-            self.assertEqual(km._session_awaiting(SID, str(p), True), "1 background agent still working")
+            self.assertEqual(km._session_awaiting(SID, str(p), True),
+                             {"kind": "agents", "why": "1 background agent still working"})
         finally:
             km._tmux_sessions = saved
 
@@ -1557,7 +1562,8 @@ class ViewBuilder(unittest.TestCase):
             {"t": T0 + 1, "awaiting": True, "why": "3 agents in flight"},
             {"t": T0 + 2, "state": "idle"},
         ]) + "\n")
-        self.assertEqual(km._session_awaiting(SID, "/nonexistent", True), "3 agents in flight",
+        self.assertEqual(km._session_awaiting(SID, "/nonexistent", True),
+                         {"kind": None, "why": "3 agents in flight"},
                          "the latest awaiting overlay (interleaved with state records) drives the badge")
         self.assertIsNone(km._session_awaiting(SID, "/nonexistent", False),
                           "a WORKING session is not 'awaiting' (idle=False short-circuits)")
@@ -1919,7 +1925,7 @@ class ViewBuilder(unittest.TestCase):
         km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None,
                                            "subagents": [{"type": "", "since": 1}, {"type": "", "since": 2}]}}
-        self.assertIn("2 background agents", km._session_awaiting(SID, str(self.tpath), True) or "",
+        self.assertIn("2 background agents", (km._session_awaiting(SID, str(self.tpath), True) or {}).get("why", ""),
                       "the live SubagentStart/Stop count restores the truth over the superseded overlay")
 
     def test_card_carries_the_auto_nudge_history(self):
@@ -2205,7 +2211,8 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(km._awaiting_task_descs("00000000-0000-0000-0000-000000000000", "/nonexistent"), [])
         # build_feed attaches the list on awaiting cards, beside the why (source pin)
         src = Path(BIN, "romp-kernel").read_text()
-        self.assertIn('"awaiting": ({"why": await_why, "tasks": _awaiting_task_descs(fsid, s["path"])}', src)
+        self.assertIn('"awaiting": ({"why": await_why, "kind": await_kind,', src)
+        self.assertIn('"tasks": _awaiting_task_descs(fsid, s["path"])} if col == "awaiting" else None)', src)
 
     def test_provisional_card_shows_the_message_caption_once_it_lands(self):
         # The user 2026-06-19: the card reads the captioner's persisted MESSAGE caption ('<segid>#p') — the
@@ -3100,7 +3107,7 @@ class ViewBuilder(unittest.TestCase):
         self._orphaned_goal(idle=True)
         km._set_auto_nudge(True)
         saved = km._session_awaiting
-        km._session_awaiting = lambda sid, path, idle, stamp=False: "Waiting on its background agents."
+        km._session_awaiting = lambda sid, path, idle, stamp=False: {"kind": "agents", "why": "Waiting on its background agents."}
         sent, restore = self._stub_nudge()
         try:
             km._auto_nudge_tick(NOW, km._tmux_sessions())
@@ -5727,7 +5734,7 @@ class ViewBuilder(unittest.TestCase):
         # background work it dispatched is no longer folded into "working" — the shared _session_chip
         # emits `awaitingBg`, so the chat chip (straw "Awaiting") and the timeline lane split together.
         saved = km._session_awaiting
-        km._session_awaiting = lambda sid, path, idle, stamp=False: "bg agents" if idle else None
+        km._session_awaiting = lambda sid, path, idle, stamp=False: {"kind": "agents", "why": "bg agents"} if idle else None
         try:
             chip = km.build_session(SID, NOW)["status"]["state"]
             lane = next(s for s in km.build_timeline(NOW)["sessions"] if s["id"] == SID)["state"]
@@ -5740,7 +5747,7 @@ class ViewBuilder(unittest.TestCase):
         # working beats the awaiting flavor: while the main thread is actually producing, the chip says
         # Working — awaitingBg only covers the idle-but-held stretch.
         saved_aw, saved_w = km._session_awaiting, km._session_working
-        km._session_awaiting = lambda sid, path, idle, stamp=False: "bg agents"
+        km._session_awaiting = lambda sid, path, idle, stamp=False: {"kind": "agents", "why": "bg agents"}
         km._session_working = lambda turns: True
         try:
             chip = km.build_session(SID, NOW)["status"]["state"]
@@ -5752,7 +5759,7 @@ class ViewBuilder(unittest.TestCase):
         # the straw dots (feed cards/headers + chat tabs) key on feed["awaiting"] exactly as the yellow
         # dots key on feed["working"] — same names, same federation prefixing (ARRAY_ID).
         saved = km._session_awaiting
-        km._session_awaiting = lambda sid, path, idle, stamp=False: "bg agents" if idle else None
+        km._session_awaiting = lambda sid, path, idle, stamp=False: {"kind": "agents", "why": "bg agents"} if idle else None
         try:
             feed = km.build_feed(NOW)
         finally:
@@ -7467,7 +7474,7 @@ class WaitGraphDelegatesAndStampSupersede(unittest.TestCase):
         # the peer's reply lands (also busts the postal-key on the stamp cache) → the stamp view lifts
         self._log(self._msg(self.B, self.A, NOW - 100, "coordinate", body="built and merged"))
         full, tops, _deleg = km._session_stamp_read(self.A)
-        self.assertEqual(full, (None, None, None), "the answered handoff supersedes the older stamp")
+        self.assertEqual(full, (None, None, None, None), "the answered handoff supersedes the older stamp")
         self.assertEqual(tops, frozenset())
 
 

--- a/tests/test_kernel_awaiting_merge.py
+++ b/tests/test_kernel_awaiting_merge.py
@@ -72,7 +72,8 @@ class MergeCarriesBgTasks(unittest.TestCase):
             why = km._session_awaiting(SID, "/nonexistent", True)
         finally:
             km._tmux_sessions = saved_sessions
-        self.assertEqual(why, "waiting on a background task: 20-minute timer for campaign-start check")
+        self.assertEqual(why, {"kind": "task",
+                               "why": "waiting on a background task: 20-minute timer for campaign-start check"})
 
 
 class NudgeFailedRespectsAwaiting(unittest.TestCase):
@@ -102,7 +103,7 @@ class NudgeFailedRespectsAwaiting(unittest.TestCase):
         self.td.cleanup()
 
     def test_awaiting_session_never_gets_the_failure_block(self):
-        km._session_awaiting = lambda sid, path, idle, stamp=False: "waiting on a background task: the experiment watcher"
+        km._session_awaiting = lambda sid, path, idle, stamp=False: {"kind": "task", "why": "waiting on a background task: the experiment watcher"}
         km._mark_nudge_failed(self.gid)
         store = km.jd.load_goals(SID)
         self.assertFalse(store["nodes"][self.gid]["blocked"],

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -146,15 +146,27 @@ class SessionLevelStamp(unittest.TestCase):
         (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
             "rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": nodes}))
 
+    def test_a_stamped_kind_rides_the_session_signal(self):
+        # the judge classified WHAT the wait is on (jd.AWAIT_KINDS); the kind travels as data beside
+        # the why so surfaces can word it and rules can scope by it (the user 2026-08-15)
+        nodes = {"g1": _node("g1", why="slurm 4821 regenerating the parts", at=200)}
+        nodes["g1"]["awaitingKind"] = "job"
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": nodes}))
+        self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
+                         {"kind": "job", "why": "slurm 4821 regenerating the parts"})
+        self.assertEqual(km._session_stamp_full(SID),
+                         ("g1", 200, "slurm 4821 regenerating the parts", "job"))
+
     def test_session_stamp_takes_the_freshest_across_ALL_tops(self):
         # session-level, so it scans every goal (not one subtree like _goal_awaiting_stamp) for the newest
         self._seed(("g1", "the older wait, padded", 100), ("g2", "the newer wait", 300))
-        self.assertEqual(km._session_stamp_cached(SID), "the newer wait")
+        self.assertEqual(km._session_stamp_full(SID)[2], "the newer wait")
 
     def test_stamp_true_lifts_a_live_session_whose_live_sources_are_dark(self):
         self._seed(("g1", "the watcher it armed; files the clip when it triggers", 200))
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         "the watcher it armed; files the clip when it triggers")
+                         {"kind": None, "why": "the watcher it armed; files the clip when it triggers"})
 
     def test_stamp_false_stays_none_so_the_feed_scopes_per_goal(self):
         # the crux: the feed calls stamp=False, so the session-level signal is None for a stamp-only session
@@ -187,9 +199,9 @@ class SessionLevelStamp(unittest.TestCase):
 
     def test_the_cache_invalidates_when_the_store_changes(self):
         self._seed(("g1", "first wait", 200))
-        self.assertEqual(km._session_stamp_cached(SID), "first wait")
+        self.assertEqual(km._session_stamp_full(SID)[2], "first wait")
         self._seed(("g1", "second wait, a different length so size differs", 300))
-        self.assertEqual(km._session_stamp_cached(SID), "second wait, a different length so size differs")
+        self.assertEqual(km._session_stamp_full(SID)[2], "second wait, a different length so size differs")
 
 
 class SessionLevelDelegation(unittest.TestCase):
@@ -241,7 +253,7 @@ class SessionLevelDelegation(unittest.TestCase):
     def test_a_fully_delegated_session_reads_awaiting_on_the_session_surfaces(self):
         self._seed(self._delegated_store())
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         "delegated to probe; waiting on their result")
+                         {"kind": "peer", "why": "delegated to probe; waiting on their result"})
 
     def test_stamp_false_stays_none_so_the_feed_keeps_scoping_per_card(self):
         self._seed(self._delegated_store())
@@ -251,7 +263,8 @@ class SessionLevelDelegation(unittest.TestCase):
         nodes = self._delegated_store()
         nodes["g1"]["awaitingWhy"], nodes["g1"]["awaitingAt"] = "the sweep it launched", 200
         self._seed(nodes)
-        self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True), "the sweep it launched")
+        self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
+                         {"kind": None, "why": "the sweep it launched"})
 
     def test_a_pure_delegation_top_stays_dark_matching_its_suppressed_card(self):
         # EVERY leaf a handoff → the feed suppresses the card in every column, so its dot never lights;
@@ -330,13 +343,14 @@ class OverlayDoesNotVeto(unittest.TestCase):
         self._overlay({"t": 100, "awaiting": False})
         self._seed()
         self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
-                         "a dispatched release watch; tags when green",
+                         {"kind": None, "why": "a dispatched release watch; tags when green"},
                          "the Stop hook's ambient false must not hide the judge's stamp")
 
     def test_a_live_true_row_still_wins_with_its_own_why(self):
         self._overlay({"t": 100, "awaiting": True, "why": "a job the hook reported"})
         self._seed()
-        self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True), "a job the hook reported",
+        self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
+                         {"kind": None, "why": "a job the hook reported"},
                          "a positive overlay row keeps its channel")
 
     def test_false_row_and_no_stamp_is_plain_none(self):
@@ -418,7 +432,8 @@ class AwaitingWake(unittest.TestCase):
 
     def test_stamp_full_exposes_gid_and_at(self):
         self._seed(at=500)
-        self.assertEqual(km._session_stamp_full(SID), (self.gid, 500, "the trace it dispatched; reports when it returns"))
+        self.assertEqual(km._session_stamp_full(SID),
+                         (self.gid, 500, "the trace it dispatched; reports when it returns", None))
 
     def test_fires_past_the_window_and_records_the_episode(self):
         now = 1_000_000

--- a/tests/test_kernel_bg_tasks.py
+++ b/tests/test_kernel_bg_tasks.py
@@ -413,6 +413,19 @@ class DurableAwaitingSource(unittest.TestCase):
     def _restore(self, saved):
         km._tmux_sessions, km._sdk_spawned_at, km._states_awaiting_overlay = saved
 
+    def test_pending_agent_dispatches_read_kind_agents_not_task(self):
+        # dispatched agents/workflows are kind agents even through the task stream; a MIXED pending
+        # set (or plain shell work) is kind task — the generic word (the user 2026-08-15)
+        rows = [{"toolUseId": "t1", "desc": "audit the sampler", "since": 5, "type": "local_agent"},
+                {"toolUseId": "t2", "desc": "notes-api sweep", "since": 6, "type": "local_workflow"}]
+        saved = self._patched({self.SID: {"bgTasks": rows}})
+        try:
+            self.assertEqual(km._session_awaiting(self.SID, None, True)["kind"], "agents")
+            rows.append({"toolUseId": "t3", "desc": "mkdocs serve", "since": 7, "type": "local_bash"})
+            self.assertEqual(km._session_awaiting(self.SID, None, True)["kind"], "task")
+        finally:
+            self._restore(saved)
+
     def test_a_live_lifecycle_less_cli_reads_awaiting_from_the_transcript(self):
         path = _write([_launch(desc="power watcher")])
         saved = self._patched({self.SID: {"name": "web"}})
@@ -421,7 +434,7 @@ class DurableAwaitingSource(unittest.TestCase):
         finally:
             self._restore(saved)
             os.unlink(path)
-        self.assertEqual(why, "waiting on a background task: power watcher")
+        self.assertEqual(why, {"kind": "task", "why": "waiting on a background task: power watcher"})
 
     def test_the_notification_landing_ends_it(self):
         path = _write([_launch(), _notif_str(tid=TUSE)])

--- a/tests/test_kernel_owned_yield_awaiting.py
+++ b/tests/test_kernel_owned_yield_awaiting.py
@@ -113,7 +113,7 @@ class OwnedYieldAwaiting(unittest.TestCase):
     def test_the_session_surfaces_light_from_it_when_idle(self):
         self._store()
         self.assertEqual(km._session_awaiting(SID, self.path, True, stamp=True),
-                         "waiting on a background task: " + DESC,
+                         {"kind": "task", "why": "waiting on a background task: " + DESC},
                          "the lane/chip say awaiting instead of READY")
 
     def test_the_feed_path_is_unchanged_no_session_wide_floor(self):

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -66,6 +66,10 @@ test("the awaiting WHY lives in the background box, not the statusline (the user
   // the kernel ships the why + the live awaited task descriptions in the chat status payload…
   assert.match(KERNEL, /"awaitingWhy": awaiting_why or None,/);
   assert.match(KERNEL, /"awaitingTasks": \(_awaiting_task_descs\(sid, sess\["path"\]\) if awaiting_why else \[\]\),/);
+  // …plus WHAT the wait is on, as data (jd.AWAIT_KINDS; the user 2026-08-15) — on the chat status,
+  // the timeline lane, and the feed card's awaiting object alike, so every surface words one fact
+  assert.match(KERNEL, /"awaitingKind": awaiting_kind,/);
+  assert.match(KERNEL, /"kind": await_kind,/);
   // …the statusline branch stays chip + clock ONLY — the reason line PR #350 put beside the chip
   // crowded the composer area, and the user moved it the same day
   const branch = RENDER.split('state === "awaitingBg") {')[1].split("} else if")[0];

--- a/ui/webview/chat-blocked-chip.test.ts
+++ b/ui/webview/chat-blocked-chip.test.ts
@@ -26,7 +26,9 @@ test("build_session gates the API-error (chip 'blocked') on NOT busy — mirrors
 
 test("build_session computes open_now + the awaiting signal BEFORE the gate consumes them", () => {
   const onow = KERNEL.indexOf('open_now = _session_working(session["turns"])');
-  const awaiting = KERNEL.indexOf('awaiting_why = _session_awaiting(sid, sess["path"], not open_now, stamp=True)');
+  const awaiting = KERNEL.indexOf('_aw = _session_awaiting(sid, sess["path"], not open_now, stamp=True)');
+  const unpack = KERNEL.indexOf('awaiting_why = _aw["why"] if _aw else None');
+  assert.ok(unpack !== -1 && awaiting < unpack, "the {kind, why} unpack follows the one call");
   const gate = KERNEL.indexOf('aerr = _api_error(sess["path"]) if not (open_now or awaiting_why) else None');
   assert.ok(onow !== -1 && awaiting !== -1 && gate !== -1, "open_now, awaiting_why, and the gate must all be present");
   assert.ok(onow < gate && awaiting < gate, "open_now + awaiting_why must be defined before the gate (else NameError)");


### PR DESCRIPTION
First of the kind-typed awaiting series. Each awaiting verdict and live awaiting signal now names WHAT it waits on, one of `jd.AWAIT_KINDS`: **agents** (dispatched agents/subagents/workflows), **task** (a background command or watcher), **job** (a computation outside the session: cluster/CI/build), **peer** (another session), **timer** (a scheduled check-back, reserved).

**Data only.** No visible copy changes, no rule changes (kind-scoped supersede/lift/status-gate rules come next). A stamp without a kind — every existing store, an older judge's reply — behaves byte-identically to before the enum existed.

- **Judge**: closer JSON + nudge-planner op gain `kind` (garbage/absent → kindless); the stamp event stores `awaitKind`; the fold carries `awaitingKind` (a kindless re-assert keeps the standing kind only while the why stands — a different why never inherits a neighbor's label); materialize/PROTECTED own the field.
- **Coalesce**: a same-why re-assert whose kind fills a kindless stamp lands once, **at the original anchor**, keeping the wake's patience and supersede ordering on the first assertion; same-why relabels and empty-why rows coalesce away (adversarial-review findings, each with a test).
- **Kernel**: `_session_awaiting` returns `{kind, why}` (falsy when not awaiting, so truthiness callers are unchanged); sources map 1:1 (subagents→agents, pending agent-ish tasks→agents else task, stamp→the judge's classification, delegation→peer); stamp reads carry the kind; additive payload fields `awaitingKind` (status + lane) and `awaiting.kind` (feed card) ship it for the surface work to word.

Suites: 4729 py + 1976 ts green; 12 new kind tests across judge parse/apply/fold and kernel sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)