### PR TITLE
The awaiting rules scope by kind: peer answers end peer waits only

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2427,8 +2427,15 @@ def _goal_awaiting_stamp_full(nodes, top, children=None, answered_at=0):
             continue
         if nd.get("awaitingWhy") and not nd.get("rolledUp"):
             at = nd.get("awaitingAt") or 0
-            if not (at and answered_at and at < answered_at):
-                cand = (at, nd["awaitingWhy"], nd.get("awaitingKind") or "")   # "" keeps max() comparable
+            # the peer-answer supersede is PEER-SCOPED (the user 2026-08-15): a reply from a peer can
+            # only end a wait that was ON a peer. A job/agents/task/timer-kind stamp keeps standing
+            # through unrelated mail — before this, one answered postal exchange erased a slurm-job
+            # stamp from every session surface AND disarmed its 6h wake (the audit's worst compound).
+            # A KINDLESS stamp keeps the old behavior: it may well be a peer wait (the enum predates
+            # it), and a false lift there is the known, tested legacy trade.
+            kind = nd.get("awaitingKind")
+            if not (at and answered_at and at < answered_at and kind in (None, "peer")):
+                cand = (at, nd["awaitingWhy"], kind or "")   # "" keeps max() comparable
                 best = cand if best is None else max(best, cand)
         stack.extend(children.get(x, []))
     return (best[0], best[1], best[2] or None) if best else None
@@ -3080,7 +3087,10 @@ def _lift_spent_awaiting(now, tmux):
     stamp time and every one of those has come back. A stamp naming a CI run, a scheduled check-back or a
     peer handoff owns no such dispatches, so it never matches and keeps its stamp — those still rely on the
     6h awaiting wake (_wake_goal, in the nudge tick's goal walk), which is exactly the case a timer is the
-    only tool for.
+    only tool for. A kind=job stamp that DOES own dispatches (the standard shape: a watcher armed over an
+    external computation) lifts only on their REAL terminal records: a watcher dying with a restart or
+    expiring is the CARRIER going, not the job returning — before this, the watcher's silent death lifted
+    the stamp while the slurm job ran on (the user 2026-08-15; the wake stays the backstop).
 
     Dormant sessions are skipped: their tasks died with their CLI, so the death notice is the truth there,
     not a lift (same rule as _session_awaiting's source 0.75)."""
@@ -3121,6 +3131,8 @@ def _lift_spent_awaiting(now, tmux):
             # record (its CLI died mid-watch; the notification can never arrive) — see em._bg_expired
             running = {t.get("id") for t in every
                        if t.get("status") == "running" and not em._bg_expired(t, now)}
+            # kind=job: expiry is not a return (see docstring) — only a real terminal record lifts
+            running_job = {t.get("id") for t in every if t.get("status") == "running"}
             placed = _bg_placed_tops(sid, s["path"], [t.get("id") for t in every])
             def _top_of(x):
                 seen = set()
@@ -3149,7 +3161,8 @@ def _lift_spent_awaiting(now, tmux):
                         own.append(t)
                 if not own:                           # nothing dispatched → not a background wait; leave it
                     continue
-                if any(t.get("id") in running for t in own):
+                live_set = running_job if nd.get("awaitingKind") == "job" else running
+                if any(t.get("id") in live_set for t in own):
                     continue                          # at least one is genuinely still out
                 if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
                     changed = True
@@ -10446,21 +10459,33 @@ def _session_stamp_read(sid):
         return hit[1]
     full, tops, deleg = (None, None, None, None), set(), ()
     try:                                               # load_goals (not a raw read) so overrides replay —
-        nodes = jd.load_goals(sid).get("nodes", {})    # the same view _goal_awaiting_stamp sees on the card
+        store = jd.load_goals(sid)                     # the same view _goal_awaiting_stamp sees on the card
+        nodes = store.get("nodes", {})
+        status = store.get("status", {}) or {}
         best = None
-        answered = _peer_answered_at(sid)              # a peer's later answer supersedes older stamps
+        answered = _peer_answered_at(sid)              # a peer's later answer supersedes older PEER waits
         for nid, nd in nodes.items():
             if nd.get("awaitingWhy") and not nd.get("rolledUp"):
                 at = nd.get("awaitingAt") or 0
-                if at and answered and at < answered:
-                    continue                           # the awaited answer landed after this stamp — superseded
-                cand = (at, nid, nd["awaitingWhy"], nd.get("awaitingKind"))
-                best = cand if best is None else max(best, cand)
+                kind = nd.get("awaitingKind")
+                if at and answered and at < answered and kind in (None, "peer"):
+                    continue                           # peer-scoped (the user 2026-08-15): a reply can only
+                #                                        end a wait that was ON a peer; kindless keeps the
+                #                                        legacy trade — see _goal_awaiting_stamp_full
                 top, seen = nid, set()                 # stamped node → its TOP ancestor (cycle-guarded)
                 while top in nodes and nodes[top].get("parentId") is not None and top not in seen:
                     seen.add(top)
                     top = nodes[top]["parentId"]
                 tops.add(top)
+                # the SESSION-LEVEL pick (the chip/lane why) takes only stamps whose TOP still rolls up
+                # WORKING — the wake ladder fires for working tops only, so a stamp under a blocked/
+                # completed top would light a chip with no retirement mechanism behind it, disagreeing
+                # with the feed (status-gated since ever) — the 2026-08-08 one-fact-two-answers class.
+                # The TOPS SET above stays status-blind on purpose: it feeds _bg_split's awaited-vs-
+                # service classification, where a temporarily blocked top's live task is still awaited.
+                if status.get(top, "working") == "working":
+                    cand = (at, nid, nd["awaitingWhy"], kind)
+                    best = cand if best is None else max(best, cand)
         if best:
             full = (best[1], best[0], best[2], best[3])   # (gid, at, why, kind)
         # DELEGATION, the same pass (the user 2026-08-08, whose fully-delegated session wore the feed's

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -59,6 +59,14 @@ def _notification(tid, t):
             "message": {"role": "user", "content": body}}
 
 
+def _monitor(tid, t, timeout_ms=300000):
+    """A non-persistent Monitor launch — the watcher shape; expires at t + timeout + grace with no
+    terminal record when its CLI dies mid-watch (em._bg_expired)."""
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": "m" + tid, "parentUuid": None,
+            "message": {"role": "assistant", "content": [
+                {"type": "tool_use", "id": tid, "name": "Monitor", "input": {"timeout_ms": timeout_ms}}]}}
+
+
 class AwaitingLift(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
@@ -90,13 +98,15 @@ class AwaitingLift(unittest.TestCase):
         km._bgall_cache.clear(); km._bgtasks_cache.clear()
 
     def _seed(self, why="waiting on two dispatched investigations; will act when they return",
-              born=BORN, anchor=STAMP, written=None):
+              born=BORN, anchor=STAMP, written=None, kind=None):
         """`anchor` is awaitingAt (the audited turn's TRIGGER time); `written` is when the closer actually
         wrote the verdict (its `at`), which defaults to the anchor for the pre-2026-07-27 fixture shape."""
         nd = {"id": self.gid, "text": "a goal", "parentId": None, "nodeComplete": False,
               "blocked": False, "cleared": False, "trail": [], "t": born, "mt": born,
               "awaitingWhy": why, "awaitingAt": anchor,
+              **({"awaitingKind": kind} if kind else {}),
               "log": [{"ev_t": anchor, "src": "closer", "kind": "awaiting", "why": why,
+                       **({"awaitKind": kind} if kind else {}),
                        "at": anchor if written is None else written}]}
         (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
             {"rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}))
@@ -123,6 +133,31 @@ class AwaitingLift(unittest.TestCase):
         self._seed()
         self._tick()
         self.assertIsNotNone(self._stamp(), "one dispatch is still out → still genuinely awaiting")
+
+    # ---- kind=job: the watcher is the CARRIER, not the wait (the user 2026-08-15) ----
+    def test_a_job_stamps_expired_watcher_does_not_lift_it(self):
+        # the observed slurm shape: a watcher armed over an external job dies with a restart (no
+        # terminal record, expires past its deadline) — the JOB may still be running, so the stamp
+        # stands; the 6h wake is the backstop, per the lift's own design note
+        self._transcript([_monitor("t1", LAUNCH)])   # deadline LAUNCH+300s; no terminal record
+        self._seed(why="slurm 4821 regenerating the parts; verifies when done", kind="job")
+        self._tick(now=LAUNCH + 1000)                # well past deadline + grace → expired
+        self.assertIsNotNone(self._stamp(), "a dead watcher is not the external job returning")
+
+    def test_the_same_expired_watcher_lifts_a_kindless_stamp_as_before(self):
+        # the legacy trade stands for untyped stamps: expiry counts as returned (the pre-enum rule,
+        # 'the awaiting-stamp lift must not wait forever on a dead monitor')
+        self._transcript([_monitor("t1", LAUNCH)])
+        self._seed(why="watching the long sweep")
+        self._tick(now=LAUNCH + 1000)
+        self.assertIsNone(self._stamp(), "kindless keeps the pre-enum expiry behavior")
+
+    def test_a_job_stamps_real_terminal_record_still_lifts(self):
+        # the watcher genuinely returned and reported — that IS the deciding event, job kind or not
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed(why="slurm 4821 regenerating the parts", kind="job")
+        self._tick()
+        self.assertIsNone(self._stamp(), "a real terminal record ends the wait for every kind")
 
     # ---- self-scoping: the other awaiting flavors are untouched ----
     def test_a_wait_with_no_dispatches_of_its_own_is_untouched(self):

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -305,6 +305,71 @@ class SessionLevelDelegation(unittest.TestCase):
         self.assertEqual(chip, "awaitingBg")
 
 
+class KindScopedRules(unittest.TestCase):
+    """The kind-scoped rules (the user 2026-08-15): a peer's answer supersedes only PEER waits (kindless
+    keeps the legacy trade); the session-level stamp pick takes only stamps whose TOP still rolls up
+    working (the wake ladder's own gate), while the stamped-TOPS set stays status-blind for _bg_split."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self._saved = (km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions, km._states_awaiting_overlay,
+                       km._peer_answered_at)
+        km.jd.STATE = td
+        km.jd.GOALDIR = td / "goals"
+        km.jd.GOALDIR.mkdir(parents=True)
+        km._SESSION_STAMP_CACHE.clear()
+        km._states_awaiting_overlay = lambda sid: None
+        km._peer_answered_at = lambda sid: 900          # a peer exchange answered AFTER every stamp below
+        km._tmux_sessions = lambda: {SID: {"state": "", "since": None, "subagents": [], "bgTasks": []}}
+
+    def tearDown(self):
+        (km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions, km._states_awaiting_overlay,
+         km._peer_answered_at) = self._saved
+        km._SESSION_STAMP_CACHE.clear()
+        self.td.cleanup()
+
+    def _seed(self, kind, status=None):
+        nodes = {"g1": _node("g1", why="the wait", at=200)}
+        if kind:
+            nodes["g1"]["awaitingKind"] = kind
+        (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "placements": {}, "status": status or {}, "nodes": nodes}))
+        km._SESSION_STAMP_CACHE.clear()
+
+    def test_a_peer_answer_supersedes_only_peer_waits(self):
+        self._seed("job")
+        self.assertEqual(km._session_awaiting(SID, "/p", True, stamp=True),
+                         {"kind": "job", "why": "the wait"},
+                         "unrelated mail cannot end a wait on an external job")
+        self._seed("peer")
+        self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True),
+                          "a peer wait IS what the answer ends")
+        self._seed(None)
+        self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True),
+                          "a kindless stamp keeps the legacy supersede — it may well be a peer wait")
+
+    def test_the_goal_level_read_scopes_the_same_way(self):
+        nodes = {"g1": dict(_node("g1", why="the wait", at=200), awaitingKind="job")}
+        self.assertEqual(km._goal_awaiting_stamp_full(nodes, "g1", answered_at=900),
+                         (200, "the wait", "job"))
+        nodes["g1"]["awaitingKind"] = "peer"
+        self.assertIsNone(km._goal_awaiting_stamp_full(nodes, "g1", answered_at=900))
+        nodes["g1"].pop("awaitingKind")
+        self.assertIsNone(km._goal_awaiting_stamp_full(nodes, "g1", answered_at=900),
+                          "kindless keeps the legacy supersede at the goal level too")
+
+    def test_the_session_pick_takes_working_tops_only(self):
+        km._peer_answered_at = lambda sid: 0
+        self._seed("job", status={"g1": "blocked"})
+        self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True),
+                          "a stamp under a blocked top has no wake ladder behind it — the chip may not"
+                          " claim a wait the feed and the wake both disown")
+        self.assertEqual(km._session_stamped_tops(SID), frozenset({"g1"}),
+                         "the classifier's tops set stays status-blind: the top's live task is still"
+                         " awaited while the block resolves")
+
+
 class OverlayDoesNotVeto(unittest.TestCase):
     """The production regression (the user 2026-07-27): the SDK Stop hook writes awaiting:false at EVERY
     turn end, and nothing has written true since 2026-07-07 — so every real SDK session carries a trailing


### PR DESCRIPTION
Second of the kind-typed awaiting series — the rule changes the enum exists for:

- **Peer-scoped supersede**, per stamp, at both reads: a peer's reply can only end a wait that was ON a peer. Before this, one answered postal exchange erased a slurm-job stamp from every session surface and disarmed its 6h wake. Kindless stamps keep the legacy behavior (tested trade).
- **kind=job survives watcher death**: an expired monitor (dead CLI, no terminal record) no longer completes `_lift_spent_awaiting`'s all-returned condition for a job-kind stamp — the watcher is the carrier, not the wait. A real terminal record still lifts for every kind; kindless keeps the pre-enum expiry behavior; the 6h wake stays the backstop.
- **The session-level stamp pick takes working tops only** (the wake ladder's own gate), so the chip can no longer claim a wait the feed and the wake both disown. The stamped-TOPS set stays status-blind on purpose: it feeds `_bg_split`'s awaited-vs-service split.

Tests: `KindScopedRules` (supersede scoping at both reads, status gate + tops-set contrast), three job-lift cases (expired watcher keeps a job stamp, lifts a kindless one, real terminal lifts both). Suites: 4735 py + 1976 ts green; the `test_bg_scan_monitor.py` source pin survives untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)