### PR TITLE
The kind words the awaiting surfaces: chip, pill, box, and badge say what

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -313,7 +313,9 @@ function badgeFor(s) {
   // paler sibling: same family, visibly held rather than producing. The s.awaitingBg why-field key stays as
   // the fallback (a remote host on an older kernel still reports state 'working' + the field).
   // (The LEGACY lane state 'awaiting' above means blocked-on-you — this name dodges that.)
-  else if (s.state === 'awaitingBg' || s.awaitingBg) m = { label: 'Awaiting', kind: 'awaitbg' };
+  // The KIND rides the label ('Awaiting job', the user 2026-08-15) — the enum values ARE the words;
+  // an older kernel ships no awaitingKind and the badge reads plain 'Awaiting' as before.
+  else if (s.state === 'awaitingBg' || s.awaitingBg) m = { label: 'Awaiting' + (s.awaitingKind ? ' ' + s.awaitingKind : ''), kind: 'awaitbg' };
   else if (s.state === 'ready' || s.state === 'waiting' || s.state === 'idle') m = { label: 'Ready', kind: 'ready' };
   if (!m) return null;
   return { label: m.label, bg: BADGE[m.kind].bg, fg: BADGE[m.kind].fg };

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -80,7 +80,10 @@ test("the awaiting WHY lives in the background box, not the statusline (the user
   // several, and a plain-words note on what the state means. No Stop — nothing untracked is killable.
   assert.match(RENDER, /\{ renderAwaitWhy\(host, s \|\| null\); return; \}/);
   assert.match(RENDER, /"bg-fold-head bg-await"/);
-  assert.match(RENDER, /"Awaiting · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\)/);
+  assert.match(RENDER, /"Awaiting" \+ \(kw \? " " \+ kw : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\)/);
+  // …the kind word rides the visible label (the user 2026-08-15) — tooltips are dead on the touch PWA
+  assert.match(RENDER, /KIND_WORD\[\(s!\.status\.awaitingKind \|\| ""\)\]/);
+  assert.match(RENDER, /chip-awaiting-" \+ \(s\.status\.awaitingKind \|\| "untyped"\)/);
   assert.match(RENDER, /if \(items\.length > 1\)/);
   assert.match(RENDER, /bg-await-note/);
   assert.doesNotMatch(RENDER.split("function renderAwaitWhy")[1].split("\n}")[0], /bg-stop/);

--- a/ui/webview/feed-awaiting-swirl.test.ts
+++ b/ui/webview/feed-awaiting-swirl.test.ts
@@ -21,7 +21,7 @@ test("the swirl element is built in the body, right after the distiller line, an
 });
 
 test("the swirl is driven by spinFor's caption — shown when there is one, else hidden", () => {
-  assert.match(FEED, /import \{ spinFor \} from "\.\/spin-caption";/);
+  assert.match(FEED, /import \{ spinFor, KIND_WORD \} from "\.\/spin-caption";/);
   assert.match(FEED, /const spin = spinFor\(it, distillPending\(dCompleted, dBlocked, it\.summary, it\.blockSummary, !!it\.blocked\),/);
   assert.match(FEED, /const spinCaption = spin\.caption, spinTip = spin\.tip, awaitingBg = spin\.awaitingBg;/);
   assert.match(FEED, /import \{ distillText, distillInputs, applyDistillLine, distillPending \} from "\.\/distiller-line";/);
@@ -35,7 +35,7 @@ test("a bg-task wait wears the compact 'Awaiting task' pill that expands the tas
   assert.match(FEED, /"bg" \| "summary" \| "subgoals" \| "tasks" \| "stall" \| "none"/);
   // "Awaiting task", never "Waiting on task": one word per state across every surface — the chat chip
   // and timeline badge already say Awaiting for this exact state (the user 2026-08-13)
-  assert.match(FEED, /taskList\.length === 1 \? "Awaiting task" : "Awaiting " \+ taskList\.length \+ " tasks"/);
+  assert.match(FEED, /taskList\.length === 1 \? "Awaiting " \+ one : "Awaiting " \+ taskList\.length \+ " "/);
   assert.doesNotMatch(FEED, /"Waiting on task"/);
   assert.match(FEED, /taskBtn\.onclick = pick\("tasks"\);/);
   // expanded rows render in the checklist spot, same view as Sub-goals, the swirl as each row's mark

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -7,7 +7,7 @@
 // pushes and updated in place — never torn down — so hovering one doesn't flicker
 // when the fleet streams new deliverables in.
 import { distillText, distillInputs, applyDistillLine, distillPending } from "./distiller-line";
-import { spinFor } from "./spin-caption";
+import { spinFor, KIND_WORD } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
@@ -96,7 +96,7 @@ interface AskItem {
   warnRows?: { t: number; judge: string; err: string; note?: string; debug?: { input?: string; reply?: string } }[] | null;   // DEBUG MODE only (romp debug on): every judge failure touching this card (kernel _card_warn_rows) → "Warnings (debug)" modal section; rows captured in debug carry the failing call's input + reply (the user 2026-07-09)
   origin?: { peer: string; peerSid: string; peerHost?: string; color: { bg: string; fg: string } | null } | null;  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders)
   waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean; kind?: string } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip, or "Handed off to <peer>" when kind is "delegate" (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22 / 2026-07-25)
-  awaiting?: { why?: string | null; tasks?: string[] | null } | null;   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Awaiting task" pill (expands the list, like Sub-goals) replaces the boxed why.
+  awaiting?: { why?: string | null; kind?: string | null; tasks?: string[] | null } | null;   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Awaiting task" pill (expands the list, like Sub-goals) replaces the boxed why.
   groupTitle?: string;                             // host: this ask shares a typed turn with siblings → the group's title
   groupN?: number;                                 // host: sibling count for that turn (>1 ⇒ fold into one group card)
   provisional?: boolean;                           // a LIVE-PROMPT placeholder (kernel _provisional_card): the session is working an in-progress turn the planner hasn't classified yet. No goal node (empty tree) — dim, non-interactive, no clear/nudge/modal; replaced by the real card once the planner places the segment.
@@ -1296,7 +1296,12 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
   // Awaiting, and two words for one state read as two states (the user 2026-08-13).
   const taskBtn = a._taskBtn as HTMLElement;
   taskBtn.style.display = hasTasks ? "" : "none";
-  (a._taskLbl as HTMLElement).textContent = taskList.length === 1 ? "Awaiting task" : "Awaiting " + taskList.length + " tasks";
+  // the KIND words the pill (the user 2026-08-15): "Awaiting job", "Awaiting 3 agents" — the wait's
+  // class in the visible label (tooltips are dead on the touch PWA); kindless keeps the classic "task"
+  const kw = KIND_WORD[(it.awaiting && it.awaiting.kind) || ""] || "task";
+  const one = kw === "agents" ? "agent" : kw;   // singular form: "Awaiting agent", plural "N agents"
+  (a._taskLbl as HTMLElement).textContent =
+    taskList.length === 1 ? "Awaiting " + one : "Awaiting " + taskList.length + " " + (one === kw ? kw + "s" : kw);
   taskBtn.classList.toggle("on", choice === "tasks");
   taskBtn.setAttribute("aria-pressed", choice === "tasks" ? "true" : "false");
   taskBtn.title = choice === "tasks" ? "hide the tasks" : "show the tasks";

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -17,6 +17,7 @@ import { markerLabel } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
 import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompSettings } from "./settings";
 import { delegate } from "./actions";
+import { KIND_WORD } from "./spin-caption";
 import { isClearCmd, openTopTitles, clearConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
 import { reconcileTabOrder } from "./tab-order";
@@ -209,7 +210,7 @@ type ChatEvent = (
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
 type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
-interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingTasks?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingTasks?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
 // status, expandable to the command + its output. status = running | completed | failed. For a dispatched
@@ -7173,7 +7174,8 @@ function renderAwaitWhy(host: HTMLElement, s: Session | null) {
   const lab = el("span", "bg-fold-label");
   // the kernel's why leads with the verb ("waiting on a background task: …") — strip it so the
   // labeled header doesn't stutter; the expanded body keeps the full sentence
-  lab.textContent = "Awaiting · " + why.replace(/^(waiting on|awaiting)\s+/i, "");
+  const kw = KIND_WORD[(s!.status.awaitingKind || "")] || "";
+  lab.textContent = "Awaiting" + (kw ? " " + kw : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "");
   head.appendChild(lab);
   host.appendChild(head);
   if (!open) return;
@@ -8071,8 +8073,13 @@ function updateStatusline() {
     // idle main thread, waiting on background work it dispatched (the user 2026-07-13): its own straw
     // chip — no pulse (nothing is computing HERE), but the elapsed timer stays so the wait has a clock
     const chip = el("span", "chip chip-awaitingBg");
-    chip.textContent = CHIP_LABEL.awaitingBg;
-    chip.title = "idle, waiting on background work it dispatched — clears when the result lands";
+    // the KIND rides the label so a glance says WHAT is awaited (the user 2026-08-15) — tooltips are
+    // dead on the touch PWA, so the word must be visible; the subject stays in the #bg-tasks box
+    const kw = KIND_WORD[s.status.awaitingKind || ""] || "";
+    chip.classList.add("chip-awaiting-" + (s.status.awaitingKind || "untyped"));   // per-kind hook, one hue today
+    chip.textContent = CHIP_LABEL.awaitingBg + (kw ? " " + kw : "");
+    chip.title = (s.status.awaitingWhy || "idle, waiting on background work it dispatched")
+               + " — clears when the result lands";
     sl.appendChild(chip);
     const timer = el("span", "status-timer");
     timer.id = "work-timer";

--- a/ui/webview/spin-caption.test.ts
+++ b/ui/webview/spin-caption.test.ts
@@ -42,9 +42,19 @@ test("recheck/rejudging spin the same whether or not a brief exists", () => {
 // --- the rest of the ladder, in precedence order ---------------------------------------------------
 test("AWAITING outranks everything and wears the box", () => {
   const s = spinFor({ awaiting: { why: "" }, recheck: true, judging: true, column: "working" }, true, false);
-  assert.equal(s.caption, "Awaiting background agents");
+  assert.equal(s.caption, "Awaiting agents");
   assert.equal(s.awaitingBg, true, "the awaiting case gets the rounded box (.await-paused)");
   assert.match(s.tip, /Not on you|not on you/);
+});
+
+test("the kind words the box: 'Awaiting job' for an external computation, per KIND_WORD", () => {
+  // the wait's CLASS in the visible label (the user 2026-08-15) — tooltips are dead on the touch PWA
+  assert.equal(spinFor({ awaiting: { why: "", kind: "job" }, column: "working" }, false, false).caption,
+               "Awaiting job");
+  assert.equal(spinFor({ awaiting: { why: "", kind: "timer" }, column: "working" }, false, false).caption,
+               "Awaiting timer");
+  assert.equal(spinFor({ awaiting: { why: "", kind: "banana" }, column: "working" }, false, false).caption,
+               "Awaiting agents", "an unknown kind falls back to the box's historic default word");
 });
 
 test("AWAITING uses the kernel's why verbatim (capitalized) when it reads 'waiting on …'", () => {
@@ -69,7 +79,7 @@ test("a PROVISIONAL working card tells the truth about its phase", () => {
 test("a provisional AWAITING placeholder never reads a false 'Working…'", () => {
   // provisional + awaiting (a bg-task wait with no goal to floor) → the awaiting branch owns it
   const s = spinFor({ provisional: true, column: "working", awaiting: { why: "" } }, false, false);
-  assert.equal(s.caption, "Awaiting background agents");
+  assert.equal(s.caption, "Awaiting agents");
 });
 
 test("the SETTLE GAP (turn done, verdict pending) spins on a working card", () => {
@@ -132,7 +142,7 @@ test("a settled card displaced to Working loses its line but never its caption",
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
 test("feed.ts routes the card's swirl through spinFor and keeps no inline copy of the ladder", () => {
-  assert.match(FEED, /import \{ spinFor \} from "\.\/spin-caption";/);
+  assert.match(FEED, /import \{ spinFor, KIND_WORD \} from "\.\/spin-caption";/);
   assert.match(FEED, /const spin = spinFor\(it, distillPending\(/);
   assert.match(FEED, /const spinCaption = spin\.caption, spinTip = spin\.tip, awaitingBg = spin\.awaitingBg;/);
   // the inline ladder is gone — no second, drifting copy of the rule
@@ -174,7 +184,7 @@ test("the narration is the FLOOR — every richer story still wins", () => {
   assert.equal(spinFor({ column: "working", working: w, recheck: true }, false, false, 2000).caption,
                "Analyzing…", "re-check outranks narration");
   assert.equal(spinFor({ column: "working", working: w, awaiting: { why: null } }, false, false, 2000).caption,
-               "Awaiting background agents", "awaiting outranks narration");
+               "Awaiting agents", "awaiting outranks narration");
   assert.equal(spinFor({ column: "working", working: w }, true, false, 2000).caption,
                "Distilling…", "a pending distill outranks narration");
 });

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -31,7 +31,7 @@
 
 /** The card fields the ladder reads. Structural, so the test can pass plain objects. */
 export interface SpinItem {
-  awaiting?: { why?: string | null; tasks?: unknown[] | null } | null;
+  awaiting?: { why?: string | null; kind?: string | null; tasks?: unknown[] | null } | null;
   waitingOn?: unknown;
   provisional?: boolean;
   column?: string;
@@ -54,6 +54,12 @@ export interface Spin {
 
 const NONE: Spin = { caption: null, tip: "", awaitingBg: false };
 
+/** The awaiting KIND's one label word (kernel jd.AWAIT_KINDS; the user 2026-08-15). Kindless (an older
+ *  kernel, an untyped legacy stamp) falls back to "agents" — the word this box has always defaulted to. */
+export const KIND_WORD: Record<string, string> = {
+  agents: "agents", task: "task", job: "job", peer: "peer", timer: "timer",
+};
+
 /** dCompleted/dBlocked come from distillInputs(distillState, column) — the GENUINE resolution state, not
  *  the transient column. distillPending is passed in (rather than recomputed) so the two modules keep one
  *  owner for the "is the distiller still working" rule. */
@@ -70,15 +76,18 @@ export function spinFor(it: SpinItem, distillPending: boolean, dCompleted: boole
   // on the toggles row carries it (with the task list one click away, like Sub-goals) — see applySections
   const awTasks = ((aw && aw.tasks) || []).filter(Boolean);
   if (aw && !it.waitingOn && !awTasks.length) {
-    // AWAITING — the session is held, waiting on background work it dispatched (agents). It keeps its own
-    // read: a boxed "Awaiting background agents" label. The romp swirl SPINS here too (the user 2026-07-04:
-    // a spin reads as "in flight, not stalled", which is exactly the awaiting state — the box already
-    // distinguishes it from the actively-working cases, so the glyph needn't also freeze). A subagent/overlay
-    // why keeps the classic boxed label; the caption wraps to two lines if long.
+    // AWAITING — the session is held, waiting on work it dispatched. It keeps its own read: a boxed
+    // "Awaiting <kind-word>" label, the kind carried as DATA from the kernel (the user 2026-08-15) so
+    // the box says WHAT is awaited — agents, a job on a cluster, a timer — not one word for five
+    // states. The romp swirl SPINS here too (the user 2026-07-04: a spin reads as "in flight, not
+    // stalled", which is exactly the awaiting state — the box already distinguishes it from the
+    // actively-working cases, so the glyph needn't also freeze). A why that already leads with
+    // "waiting on" is shown verbatim (capitalized); the kind word is the fallback frame.
     const why = aw.why || "";
+    const word = KIND_WORD[aw.kind || ""] || "agents";   // kindless = the box's historic default
     return {
       caption: /^waiting on/i.test(why) ? why.charAt(0).toUpperCase() + why.slice(1)
-                                        : "Awaiting background agents",
+                                        : "Awaiting " + word,
       tip: why ? why + ". Not on you; paused until the background work lands."
                : "Paused, waiting on background work it dispatched (not on you). Clears when the result lands.",
       awaitingBg: true,

--- a/ui/webview/timeline-awaiting.test.ts
+++ b/ui/webview/timeline-awaiting.test.ts
@@ -13,7 +13,7 @@ const TL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timelin
 
 test("an awaitingBg lane renders an Awaiting badge in the romp brand green (the user 2026-07-22)", () => {
   // keyed on the chip state (the shared _session_chip split) OR the legacy why-field (older remote kernels)
-  assert.match(TL, /else if \(s\.state === 'awaitingBg' \|\| s\.awaitingBg\) m = \{ label: 'Awaiting', kind: 'awaitbg' \};/);
+  assert.match(TL, /else if \(s\.state === 'awaitingBg' \|\| s\.awaitingBg\) m = \{ label: 'Awaiting' \+ \(s\.awaitingKind \? ' ' \+ s\.awaitingKind : ''\), kind: 'awaitbg' \};/);
   // brand green, matching --st-awaitbg-bg in styles.css (this file loads standalone, so the hex is mirrored)
   assert.match(TL, /awaitbg: \{ bg: '#54B204', fg: '#0c1a00' \}/);
   // an awaitingBg lane still reads ACTIVE (full opacity / ongoing treatment), like working/compacting/clearing


### PR DESCRIPTION
Third of the kind-typed awaiting series: the kind that #405 threaded as data now reaches the eye. One rule everywhere: the kind's one word rides the **visible label** (tooltips are dead on the touch PWA); the subject stays one click away in the existing expands.

- **chat chip**: "Awaiting agents" / "Awaiting job" …, why in the title, per-kind class hooks (`chip-awaiting-<kind>`, one hue today so a color split stays CSS-only later)
- **feed pill**: "Awaiting job", "Awaiting 3 agents" (singular/plural); kindless keeps "Awaiting task"
- **card boxed caption**: "Awaiting \<word\>", kindless falls back to the historic "agents"
- **timeline lane badge**: "Awaiting job"; an older kernel ships no kind → plain "Awaiting"
- **#bg-tasks box header**: "Awaiting job · \<subject\>"

The "Awaiting \<peer-name\>" chip already words the peer kind best and is untouched. Executed kind cases in `spin-caption.test.ts`; moved source pins updated. Suites: 4729 py + 1977 ts green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)