### PR TITLE
The needs-input chip state is named needsInput; 'awaiting' means one thing

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -756,8 +756,9 @@ fi
 #   * `waiting` is AT REST, not attention-needed. It is the ordinary state of a session sitting
 #     there having finished its turn, and it is what most of the fleet reads most of the time.
 #     Substring-matching /wait/ into an alert paints a "needs you" badge on every idle session,
-#     which is worse than the blank it replaced. The states that DO want the user are `awaiting`
-#     (a permission prompt) and `blocked`.
+#     which is worse than the blank it replaced. The states that DO want the user are `permission`
+#     and `picker` (a live prompt) and `blocked`. (These are the RAW backend states; the dashboard's
+#     chip vocabulary — needsInput, awaitingBg — never rides this command.)
 #   * `id` is the durable key, NOT `lastSid`. Every per-session store romp keeps (states/,
 #     captions/, goals/, episodes/) is filed under `id`. `lastSid` is the live Claude Code
 #     transcript's fsid, which FORKS on /clear — it is what the old tmux @romp-session-id

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -316,8 +316,12 @@ permission/API-error floors: one interrupt at a time, the present event first.
 - **auto-nudge**: a kernel trigger, not an LLM. Detects a genuinely stalled
   session and injects one nudge prompt; the planner's nudge phase does the
   judging, and a failed nudge records the block.
-- **awaiting**: event-derived, never a verdict. Only real subagents make an
-  idle session awaiting.
+- **awaiting**: layered. The LIVE sources are event-derived — subagents,
+  the pending background-task set, the delegation graph — and the CLOSER files a
+  durable awaiting verdict (the goal store's ⏳ stamp) carrying a KIND naming
+  what the wait is on: agents, task, job (an external computation), peer, timer.
+  The kind scopes the rules: a peer's answer supersedes only peer waits, and a
+  job stamp survives its watcher dying (the wake is its backstop).
 
 ## Where responsibilities overlap
 

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -210,7 +210,7 @@ Completed card. No read-time DAG rebuild, no status derivation, no handoff repai
 - **Lanes**: one per session; each **segment** is a bar `[t, end]` (segments are
   exactly "what the timeline draws as a bar" in the event model), a dot at the
   trigger, idle atoms as the not-working gaps, caption on hover.
-- **Stripes**: awaiting / compacting, from the state read.
+- **Stripes**: needs-input (a live permission/picker prompt) / compacting, from the state read.
 - **Connectors**: postal messages between lanes, from courier records / the message
   log.
 - **Overlays**: focus / hover from the feed and chat (UI ephemera, one WS channel).

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -45,7 +45,9 @@ These are for scripting and for agents rather than daily use:
 Two things to know before building on `romp sessions --json`. **`waiting` means
 at rest**, the ordinary state of a session that has finished its turn, so
 matching it as an alert badges the whole idle fleet as needing you; the states
-that want a person are `awaiting`, a permission prompt, and `blocked`. And
+that want a person are `permission` and `picker` (a live prompt) and `blocked`.
+(`romp sessions` emits the RAW backend states — the dashboard's chip states,
+`needsInput`/`awaitingBg`, never appear here.) And
 **`id` is the durable key**, not `lastSid`: everything Romp files per session is
 keyed by `id`, while `lastSid` is the live transcript's id and forks on
 `/clear`.

--- a/hooks/tmux-status.sh
+++ b/hooks/tmux-status.sh
@@ -65,7 +65,7 @@ esac
 
 # Status emoji for the ghostty tab dot (tmux.conf set-titles-string reads
 # @romp-emoji). Mirrors the dashboard's state→color: 🔵 ready (waiting/
-# idle), 🟡 working, 🔴 awaiting (permission). Updated here on every event
+# idle), 🟡 working, 🔴 needs input (permission). Updated here on every event
 # so the dot tracks Claude's live status. (A fourth dot, ⚪ inactive, is set
 # NOT here but by scripts/romp-idle-dots once a ready session sits idle > 1h —
 # the tab analog of the dashboard/timeline fade; the next event resets it here.)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2355,7 +2355,7 @@ def _auto_resume_session_retry(now, tmux):
         if _last_human_msg_t(session["turns"]) <= floor:
             continue                                      # user hasn't re-engaged since the stop → still hands-off
         chip = _session_chip(sid, path, session, tmux.get(sid), now)
-        if chip in ("ready", "idle", "awaiting", "awaitingBg", "closed"):   # re-engaged turn settled clean → the message went through
+        if chip in ("ready", "idle", "needsInput", "awaitingBg", "closed"):   # re-engaged turn settled clean → the message went through
             if _clear_session_retry_suppress(sid):
                 changed = True
                 sys.stderr.write("retry-suppress: re-armed session %s — a successful turn landed\n" % sid)
@@ -10830,7 +10830,7 @@ def _bg_owner_tops(fsid, path, tasks):
     This is the OWNERSHIP the awaiting floor's blocked-yield needs (the user 2026-07-17, quartz):
     the 2026-07-15 event-order guard (dispatch newer than block → the block is stale) compared times
     ONLY, session-wide — so a watcher relaunched after a kernel restart (89s after an unrelated card's
-    block) re-dressed a genuine needs-you as the straw awaiting badge. Ownership makes the yield exact:
+    block) re-dressed a genuine needs-you as the await-green awaiting badge. Ownership makes the yield exact:
     only a task dispatched from the blocked card's own thread can prove that card moved on. A task whose
     launch can't be resolved to a placement (a pre-fork transcript, not yet placed) attributes to
     NOTHING — the conservative failure: an unproven dispatch never masks a block (fail loudly beats a
@@ -12685,13 +12685,13 @@ def _session_chip(sid, path, session, tm, now):
             "compacting" if compacting else
             "interrupting" if _interrupting(sid, session, now, tm) else   # stop dispatched, not yet settled
             "blocked" if aerr else
-            "awaiting" if st in _NEEDS_INPUT_STATES else               # a live permission/picker prompt
+            "needsInput" if st in _NEEDS_INPUT_STATES else             # a live permission/picker prompt
             "retrying" if st == "retrying" else
             "working" if open_now else
             # idle main thread, waiting on background work it dispatched (bg tasks / subagents / overlay):
             # its OWN state, no longer folded into "working" (the user 2026-07-13, who wanted to differentiate working
-            # from awaiting) — the chip says Awaiting in the straw color, the tab/feed dots match, and the
-            # timeline badge recolors, all off this one shared value. ("awaiting" above = awaiting INPUT.)
+            # from awaiting) — the chip says Awaiting in the await-green color, the tab/feed dots match, and the
+            # timeline badge recolors, all off this one shared value. (needsInput above = a live prompt on YOU — renamed from the legacy chip state "awaiting" 2026-08-15, which collided with this state's name.)
             "awaitingBg" if awaiting_why else "ready")
 
 
@@ -15958,7 +15958,7 @@ def build_feed(now, tmux=None):
         sess_awaiting_why = _sess_aw["why"] if _sess_aw else None
         sess_awaiting_kind = _sess_aw["kind"] if _sess_aw else None
         if sess_awaiting_why and not who_working:
-            awaiting.append(name)                    # the AWAITING dot list (straw, the user 2026-07-13) — the
+            awaiting.append(name)                    # the AWAITING dot list (await-green, the user 2026-07-13) — the
             #                                          same split _session_chip makes; feed/chat dots match the chip
         # API-error floor: a session stopped on an API error (transcript isApiErrorMessage, event-based)
         # floors its focus top-goal under BLOCKED with an apiError reason → the feed card shows a red
@@ -15995,7 +15995,7 @@ def build_feed(now, tmux=None):
                 jauth_top = f
         plain_user_t = _last_plain_user_turn_t(ps["turns"]) if ps else 0   # re-check: a plain reply after a soft block de-urgents it
         had_working = False                          # does this session show ANY working card? → drives the provisional placeholder
-        had_awaiting = False                         # …and does any of them read AWAITING? → the session's straw dot (below)
+        had_awaiting = False                         # …and does any of them read AWAITING? → the session's await-green dot (below)
         # The live background-task set, once per session: OWNERSHIP for the blocked-yield below (any live
         # task counts there — the yield keys on the dispatch event, not on classification), and the
         # judge-classified SERVICES for the neutral per-session chip (the user 2026-07-24). Idle-gated
@@ -16025,7 +16025,7 @@ def build_feed(now, tmux=None):
             # that dispatch is NEWER than the block's own evidence. Two guards, both exact:
             #  - OWNERSHIP (the user 2026-07-17, quartz): the 07-15 time-only guard compared the
             #    session-wide newest dispatch — a campaign watcher relaunched after a kernel restart
-            #    (89s after an UNRELATED card's block) re-dressed a genuine needs-you as the straw
+            #    (89s after an UNRELATED card's block) re-dressed a genuine needs-you as the await-green
             #    awaiting badge. _bg_owner_tops resolves each live task's launch to its placed top;
             #    a task owned elsewhere — or one whose launch can't be attributed (subagents, the
             #    overlay, an unplaced launch) — never flips a blocked card. Genuinely stale blocks are
@@ -16492,7 +16492,7 @@ def build_feed(now, tmux=None):
     for _a in asks:
         _a["notify"] = True if _notify_card_effective(_ncards, _a["itemId"], str(_a.get("sid") or "")) else None
     return {"type": "feed", "asks": asks, "now": now,
-            "working": working, "awaiting": awaiting,   # awaiting = idle-but-waiting-on-bg-work names → straw dot (the user 2026-07-13)
+            "working": working, "awaiting": awaiting,   # awaiting = idle-but-waiting-on-bg-work names → await-green dot (the user 2026-07-13)
             # listed-but-unreadable names → an explicit gray ring, so a BLANK pip means "alive and
             # quiet" and nothing else (see _state_unknown_names)
             "stateUnknown": _state_unknown_names(alive, tmux, working, awaiting),
@@ -18009,7 +18009,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
                                           # turn that never returned a ResultMessage, then ended) must not read as
                                           # active (the user 2026-06-23); badgeFor dims a dead lane anyway.
             blocked = "blocked" in goals.get("status", {}).values() and not _session_flag(sid, "hideFromFeed")
-            state = "awaiting" if blocked else "idle"   # muted → no 'awaiting'/background-task badge on the lane
+            state = "needsInput" if blocked else "idle"   # muted → no awaiting/background-task badge on the lane
             aw_open = open_now                          # unused (awaitingBg is None for a dead lane) — kept defined
         bars, last_t, seg_ends = [], None, {}            # seg_ends: seg-start t → work-END t (for completion marks)
         for ti, turn in enumerate(st_turns):
@@ -19409,7 +19409,7 @@ def _push(targets, connect=False, tmux=None):
                                                if isinstance(m.get("ledger"), dict)
                                                else m.get("ledger"))} for m in chat_sessions]
             for c in chat_clients:                       # the working-dot list (chat reads feed["working"]);
-                #                                          awaiting rides along for the straw dots (2026-07-13)
+                #                                          awaiting rides along for the await-green dots (2026-07-13)
                 _send_client(c, ("working",), {"type": "working", "names": feed["working"],
                                                "awaiting": feed.get("awaiting") or []})
         # TIMELINE in two messages (the user 2026-06-25): the LANES SKELETON ({type:"data"}) flushes FIRST —

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4448,7 +4448,7 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(card["column"], "needs_input", "a picker-floored card files under BLOCKED directly")
         self.assertIn("input", card["blocked"]["what"], "picker wording reflects a question, not an approval")
         # the session chip (build_session payload) also reads "awaiting" on a picker, like a permission
-        self.assertEqual(km.build_session(SID, NOW)["status"]["state"], "awaiting",
+        self.assertEqual(km.build_session(SID, NOW)["status"]["state"], "needsInput",
                          "the session chip reads awaiting on a live picker")
 
     def test_feed_permission_does_not_floor_a_completed_focus(self):
@@ -5937,7 +5937,7 @@ class ViewBuilder(unittest.TestCase):
         km._tmux_sessions = lambda: {SID: {"state": "permission", "since": NOW - 5, "model": "Opus 4.8",
                                            "effort": "max", "context": 20, "compactPct": None, "color": None}}
         st = km.build_session(SID, NOW)["status"]
-        self.assertEqual(st["state"], "awaiting", "permission -> awaiting chip")
+        self.assertEqual(st["state"], "needsInput", "permission -> the needs-input chip (renamed 2026-08-15)")
         self.assertEqual(st["model"], "Opus 4.8")
         self.assertEqual(st["ctx"], "20")
 

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -307,10 +307,11 @@ function badgeFor(s) {
   // chip vocabulary below; the legacy raw names stay accepted for the cold-skeleton fallback.
   else if (s.state === 'blocked') m = { label: 'API error', kind: 'attention' };  // same red the chat chip shows
   else if (s.state === 'interrupting') m = { label: 'Interrupting', kind: 'working' };  // stop in flight
-  else if (s.state === 'permission' || s.state === 'awaiting') m = { label: 'Blocked', kind: 'attention' };
+  else if (s.state === 'permission' || s.state === 'needsInput' || s.state === 'awaiting') m = { label: 'Blocked', kind: 'attention' };   // 'awaiting' = the legacy name, an older remote kernel
   // AWAITING dispatched/background work: its OWN chip state now ('awaitingBg', the kernel's shared
-  // _session_chip split, the user 2026-07-13 — no longer folded into working) in STRAW, the working gold's
-  // paler sibling: same family, visibly held rather than producing. The s.awaitingBg why-field key stays as
+  // _session_chip split, the user 2026-07-13 — no longer folded into working) in the romp brand GREEN
+  // (recolored from the original straw, the user 2026-07-22): visibly held rather than producing. The
+  // s.awaitingBg why-field key stays as
   // the fallback (a remote host on an older kernel still reports state 'working' + the field).
   // (The LEGACY lane state 'awaiting' above means blocked-on-you — this name dodges that.)
   // The KIND rides the label ('Awaiting job', the user 2026-08-15) — the enum values ARE the words;
@@ -2210,7 +2211,7 @@ class TimelinePanel {
     const reopen = this._metaMenu && this._metaMenu._kind === kind && this._metaMenu._sid === s.id;
     this._closeMetaMenu();
     if (reopen) return;
-    if (s.state === 'awaiting' || s.state === 'permission') return;
+    if (s.state === 'needsInput' || s.state === 'awaiting' || s.state === 'permission') return;
     // Styled inline (NOT via a CSS class): injectStyles() guards on an existing <style> id, so a CSS
     // rule added later never lands after a plugin reload — only a full restart. Inline always applies.
     // MENU_STYLE/etc = the one shared menu vocabulary (CLAUDE.md rule, the user 2026-08-09) — the chat
@@ -2664,7 +2665,7 @@ class TimelinePanel {
         const bh = lit ? eh : BAR_H;
         const bar = el('rect', { x: bx, y: y - bh / 2, width: bw, height: bh, rx: bh / 2, fill: s.color, opacity: lit ? 1 : 0.9 });
         svg.appendChild(bar);
-        const act = s.state === 'working' || s.state === 'permission' || s.state === 'awaiting' || s.state === 'awaitingBg' || s.state === 'compacting' || s.state === 'clearing';
+        const act = s.state === 'working' || s.state === 'permission' || s.state === 'needsInput' || s.state === 'awaiting' || s.state === 'awaitingBg' || s.state === 'compacting' || s.state === 'clearing';
         const ongoing = s.live && act && t.end > t.start && (data.now - t.end) <= 5;
         const hit = el('rect', { x: bx, y: y - 7, width: bw, height: 14, fill: 'transparent' }); hit.style.cursor = 'pointer';
         const html = () => '<div class="r"><span class="chip" style="background:' + s.color + '"></span><span class="who" style="color:' + s.color + '">' + esc(s.name) + '</span><span class="t">' + clock(t.start) + '–' + clock(t.end) + '</span></div>' + this.barBody(t, ongoing);
@@ -2715,7 +2716,7 @@ class TimelinePanel {
       // input (historical, from the state-transition log), plus the current open one. The
       // dashed white overlay reads as a distinct texture vs a solid "still working" bar.
       const aw = (s.awaiting && s.awaiting.length) ? s.awaiting
-                 : ((s.live && (s.state === 'permission' || s.state === 'awaiting') && s.since != null) ? [[s.since, t1]] : []);
+                 : ((s.live && (s.state === 'permission' || s.state === 'needsInput' || s.state === 'awaiting') && s.since != null) ? [[s.since, t1]] : []);
       for (const span of aw) {
         const a0 = span[0], b0 = span[1];
         const sa = Math.max(a0, t0), sb = Math.min(b0, t1); if (sb <= sa) continue;

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -18,10 +18,10 @@ const FEEDCSS = W("feed.css");
 const FED = W("federation.ts");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
 
-test("the chat chip knows awaitingBg: its own straw chip, label 'Awaiting', with the elapsed timer", () => {
+test("the chat chip knows awaitingBg: its own await-green chip, label 'Awaiting', with the elapsed timer", () => {
   assert.match(RENDER, /"awaiting" \| "awaitingBg" \|/);           // the ChipState union carries both meanings
   assert.match(RENDER, /awaitingBg: "Awaiting",/);                 // CHIP_LABEL
-  // its own statusline branch: straw chip + the wait's clock — but NO pulse (nothing computing here)
+  // its own statusline branch: await-green chip + the wait's clock — but NO pulse (nothing computing here)
   assert.match(RENDER, /\} else if \(s\.status\.state === "awaitingBg"\) \{[\s\S]*?chip chip-awaitingBg[\s\S]*?timer\.id = "work-timer";/);
   assert.doesNotMatch(RENDER.split('state === "awaitingBg") {')[1].split("} else if")[0], /chip-pulse/);
   // the ticking clock covers it, same as working
@@ -30,7 +30,7 @@ test("the chat chip knows awaitingBg: its own straw chip, label 'Awaiting', with
   assert.doesNotMatch(RENDER, /awaitingBg[^\n]*stopButton|stopButton[^\n]*awaitingBg/);
 });
 
-test("the chat tab dot matches the chip: straw for awaitingBg, yellow for working", () => {
+test("the chat tab dot matches the chip: await-green for awaitingBg, yellow for working", () => {
   assert.match(RENDER, /if \(st === "working"\) tab\.appendChild\(el\("span", "tab-dot"\)\);\s*\n\s*else if \(st === "awaitingBg"\) tab\.appendChild\(el\("span", "tab-dot await"\)\);/);
   assert.match(STYLES, /--st-awaitbg-bg: #54B204; --st-awaitbg-fg: #0c1a00;/);
   assert.match(STYLES, /\.chip-awaitingBg \{ background: var\(--st-awaitbg-bg\); color: var\(--st-awaitbg-fg\); \}/);
@@ -76,7 +76,7 @@ test("the awaiting WHY lives in the background box, not the statusline (the user
   assert.doesNotMatch(branch, /sl-await-why/);
   assert.doesNotMatch(STYLES, /sl-await-why/);
   // …and the #bg-tasks box renders it when no tracked tasks claim the box: the same fold treatment
-  // (straw dot, verb-stripped header), expanding to the full why, the awaited items when there are
+  // (await-green dot, verb-stripped header), expanding to the full why, the awaited items when there are
   // several, and a plain-words note on what the state means. No Stop — nothing untracked is killable.
   assert.match(RENDER, /\{ renderAwaitWhy\(host, s \|\| null\); return; \}/);
   assert.match(RENDER, /"bg-fold-head bg-await"/);

--- a/ui/webview/chat-blocked-chip.test.ts
+++ b/ui/webview/chat-blocked-chip.test.ts
@@ -37,7 +37,7 @@ test("build_session computes open_now + the awaiting signal BEFORE the gate cons
 test("the chip reads 'working' for an open turn, 'awaitingBg' for a held one — never 'ready'/'blocked'", () => {
   // the formula lives in the SHARED _session_chip now (the user 2026-07-03) — one derivation for the
   // chat chip AND the timeline lane, so the two surfaces can never disagree. Since 2026-07-13 the
-  // awaiting-background case is its OWN state (straw Awaiting), no longer folded into working.
+  // awaiting-background case is its OWN state (await-green Awaiting), no longer folded into working.
   assert.match(KERNEL, /"working" if open_now else\n/);
   assert.match(KERNEL, /"awaitingBg" if awaiting_why else "ready"\)/);
   assert.match(KERNEL, /chip = _session_chip\(sid, sess\["path"\], session, tm, now\)/);

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -314,7 +314,7 @@ export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly s
     if (Array.isArray(f.items)) merged.items.push(...f.items);
     if (Array.isArray(f.asks)) merged.asks.push(...f.asks);
     if (Array.isArray(f.working)) merged.working.push(...f.working);
-    if (Array.isArray(f.awaiting)) merged.awaiting.push(...f.awaiting);   // straw awaiting dots ride like working
+    if (Array.isArray(f.awaiting)) merged.awaiting.push(...f.awaiting);   // await-green awaiting dots ride like working
     // the unreadable-state list rides the same way; a host too old to send it contributes to
     // NEITHER list, so its sessions stay blank (= "quiet") rather than reading falsely as unknown
     if (Array.isArray(f.stateUnknown)) merged.stateUnknown.push(...f.stateUnknown);

--- a/ui/webview/feed-group-mode.test.ts
+++ b/ui/webview/feed-group-mode.test.ts
@@ -39,7 +39,7 @@ test("a name+dot header entry opens each session's run; only runs that exist get
   assert.match(FEED, /key = "s:" \+ listEl\.id \+ ":" \+ e\.sid;/);
   // the header carries the identity: colored name, host prefix treatment, the yellow working dot
   assert.match(FEED, /nm\.replaceChildren\(\.\.\.hostNameNodes\(e\.name, e\.sid\)\);/);
-  assert.match(FEED, /setWorkDot\(nm, dotFor\(e\.name\)\);/);   // work OR awaiting dot — straw when idle-but-awaiting (the user 2026-07-13)
+  assert.match(FEED, /setWorkDot\(nm, dotFor\(e\.name\)\);/);   // work OR awaiting dot — await-green when idle-but-awaiting (the user 2026-07-13)
   // headers aren't cards — but a FOLDED one stands in for its run, so the chip counts what it hides;
   // the column must report the board, not what the reader happens to have open (2026-07-31)
   assert.match(FEED, /const nCards = \(es: Entry\[\]\) => es\.reduce\(\(n, e\) => n \+ \(e\.kind === "sess" \? e\.folded : 1\), 0\);/);

--- a/ui/webview/feed-status-pips.test.ts
+++ b/ui/webview/feed-status-pips.test.ts
@@ -1,7 +1,7 @@
 // Status pips: what renders, and — just as load-bearing — what does NOT.
 //
 // The rule the three surfaces (feed, sessions pane, chat tab strip) agree on: a pip marks something
-// HAPPENING (gold working, straw awaiting background work) or something WRONG (a gray ring when the
+// HAPPENING (gold working, await-green awaiting background work) or something WRONG (a gray ring when the
 // live state could not be read). A healthy idle session gets no pip at all, so a blank means "alive
 // and quiet" and nothing else. Before the gray ring existed, an unreadable state drew the same
 // nothing as an idle one, which is how a rendering hole hid in plain sight.

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -490,7 +490,7 @@ const openBgSvc = new Set<string>();   // sids with the chip's process list expa
 // arrive collapsed too, and a card's column is not knowable when you fold the thread. Persisted across
 // reloads with the rest of the disclosure state, and deliberately NOT pruned when the cards go away.
 const collapsedThreads = new Set<string>();
-// names of sessions idle-but-AWAITING background work (the user 2026-07-13): the same dot in straw —
+// names of sessions idle-but-AWAITING background work (the user 2026-07-13): the same dot in await-green —
 // matching the chat chip's Awaiting color — so a held session reads differently from a working one.
 let awaitingSet = new Set<string>();
 // Sessions the kernel LISTS but whose live state it could not read. These draw a gray ring, which
@@ -3692,7 +3692,7 @@ window.addEventListener("message", (e: MessageEvent) => {
       const c = a.sid ? a.sid.indexOf(":") : -1;             // remote sid → also index the bare name under its host
       if (c > 0 && !a.name.includes(":")) sessionColors.set(a.sid.slice(0, c) + ":" + a.name, a.color.bg);
     }
-    awaitingSet = new Set(Array.isArray(m.awaiting) ? m.awaiting : []);   // straw awaiting dots (the user 2026-07-13)
+    awaitingSet = new Set(Array.isArray(m.awaiting) ? m.awaiting : []);   // await-green awaiting dots (the user 2026-07-13)
     unknownSet = new Set(Array.isArray(m.stateUnknown) ? m.stateUnknown : []);   // listed-but-unreadable → gray ring, never a blank
     bgServicesMap = m.bgServices && typeof m.bgServices === "object" ? m.bgServices : {};   // session name -> judge-classified service descs → the session-header chip (2026-07-24)
     if (Array.isArray(m.order)) sessionOrder = m.order.filter((x: any) => typeof x === "string");   // grouped-mode session rank (tab/lane order)

--- a/ui/webview/fleet-pane.css
+++ b/ui/webview/fleet-pane.css
@@ -28,7 +28,7 @@ font-size:15px;line-height:1;cursor:pointer}
 .fl-head{display:flex;align-items:center;gap:7px;padding:5px 14px 4px;cursor:pointer;font-weight:650}
 .fl-head:hover{background:rgba(255,255,255,0.05)}
 .fl-workdot{width:7px;height:7px;border-radius:50%;background:#e0b020;flex:0 0 auto}
-/* the same pip language the feed's .fwork-dot speaks: straw = awaiting dispatched background work
+/* the same pip language the feed's .fwork-dot speaks: await-green = awaiting dispatched background work
    (--st-awaitbg-bg), gray ring = the live state could not be read (the network strip's down-host
    gray). Idle stays undotted. Hexes because this sheet loads standalone. */
 .fl-workdot.await{background:#54B204}

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -145,7 +145,7 @@ function paintFoldButtons() {
 function el(tag: string, cls?: string): HTMLElement { const e = document.createElement(tag); if (cls) e.className = cls; return e; }
 
 // The status pip before a session name — the same language the feed's .fwork-dot speaks: gold =
-// working, straw = awaiting dispatched background work, gray ring = the live state could not be
+// working, await-green = awaiting dispatched background work, gray ring = the live state could not be
 // read. A healthy idle session gets NO pip, so a blank means "alive and quiet" and nothing else.
 // That only holds if every OTHER state renders, which is why the awaiting dot belongs here too: the
 // feed has shown it since 2026-07-13, but this pane did not, so an awaiting session was blank here

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -40,7 +40,7 @@ var SHORTCUT_ROWS =
 
 // Auto Nudge's hover description lives in a var because fillAutoNudge() appends to it when the attached
 // machines disagree — the row then has to say WHICH ones, and this is the one level down from the label.
-var AUTONUDGE_SUB = "When a session goes idle but its goal still shows working (not blocked, not awaiting "
+var AUTONUDGE_SUB = "When a session goes idle but its goal still shows working (not blocked, not awaiting agents or a job "
   + "you), automatically nudge it once for a status update. Applies to every connected machine's kernel.";
 
 // The modal markup — ported verbatim from the kernel's _gear_html; the model/

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -209,7 +209,7 @@ type ChatEvent = (
 
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
-type ChipState = "working" | "ready" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // awaiting = a live permission/picker prompt (on YOU); awaitingBg = idle main thread waiting on background work it dispatched (straw, the user 2026-07-13)
+type ChipState = "working" | "ready" | "needsInput" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // needsInput = a live permission/picker prompt (on YOU) — renamed from the legacy "awaiting" (2026-08-15), which stays accepted for OLDER REMOTE KERNELS across federation; awaitingBg = idle main thread waiting on background work it dispatched (the user 2026-07-13)
 interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingTasks?: string[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authPending?: boolean; authBoth?: boolean; authAcct?: string; ctx?: string; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it when no tracked tasks claim the box (renderAwaitWhy; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 interface Color { bg: string; fg: string; }
 // A run_in_background task surfaced in the #bg-tasks box (the kernel's _bg_tasks): a one-line summary +
@@ -3708,12 +3708,12 @@ function renderTabs() {
     // the user 2026-07-14), or a spent model allowance (switch model, the user 2026-08-01) — is alarm-red dashed; a TRANSIENT API error is auto-retrying and needs no attention → the
     // amber retrying treatment, not red (the user 2026-06-29).
     else if (st === "blocked") tab.classList.add((s.status.apiTooLong || s.status.apiSpendLimit || s.status.apiModelLimit || s.status.apiAuthErr) ? "tab-blocked" : "tab-retrying");
-    else if (st === "awaiting") tab.classList.add("tab-awaiting");
+    else if (st === "needsInput" || st === "awaiting") tab.classList.add("tab-awaiting");   // legacy name = an older remote kernel
     else if (st === "retrying") tab.classList.add("tab-retrying");       // amber: soft-blocked on an API auto-retry
     else if (st === "compacting" || st === "clearing") tab.classList.add("tab-compacting");   // both: a context op in flight
     else if (st === "closed") tab.classList.add("tab-closed");       // dead session: read-only, struck-through label
     if (s.status.faded) tab.classList.add("at-rest");
-    // WORKING shows a yellow dot; AWAITING-BG the same dot in straw — matching the chip's color, so the
+    // WORKING shows a yellow dot; AWAITING-BG the same dot in await-green — matching the chip's color, so the
     // tab reads the split at a glance (the user 2026-07-13); BLOCKED (API error) gets NO dot — the dashed
     // red tab highlight instead (the user 2026-06-16).
     if (st === "working") tab.appendChild(el("span", "tab-dot"));
@@ -7157,7 +7157,7 @@ function renderBgTasks() {
 // The Awaiting session's WHY, in the same box when NO tracked tasks claim it (the user 2026-08-13:
 // the reason spent a few hours beside the statusline chip — PR #350 — and crowded the composer area;
 // this box between transcript and composer is where dispatched work has always surfaced). Same fold
-// treatment as the task header: one straw-dotted line, click → the full why, each awaited item when
+// treatment as the task header: one await-green-dotted line, click → the full why, each awaited item when
 // there are several, and a plain-words note on what the state means. No Stop here — an untracked wait
 // (a peer's PR, a build) has no process to kill; tracked run_in_background tasks take the list path
 // above, which carries one Stop per running row.
@@ -7893,7 +7893,7 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement) {
   if (!s) return;
   // a pending permission/picker prompt owns the pane's keyboard — injecting a
   // slash command there would answer the prompt instead (host guards this too)
-  if (s.status.state === "awaiting") return;
+  if (s.status.state === "needsInput" || s.status.state === "awaiting") return;
   const menu = el("div", "meta-menu");
   menu.dataset.kind = kind;
   // An sdkOnly entry is dropped on tmux rather than shown-and-refused: the backend cannot apply it, and
@@ -7944,7 +7944,7 @@ function ctxBar(): HTMLElement {
     const s = activeId ? sessions.get(activeId) : null;
     if (!s || !vscodeApi) return;
     // awaiting: the pane's keyboard belongs to the prompt; compacting/closed: nothing to do
-    if (s.status.state === "awaiting" || s.status.state === "compacting" || s.status.state === "closed") return;
+    if (s.status.state === "needsInput" || s.status.state === "awaiting" || s.status.state === "compacting" || s.status.state === "closed") return;
     vscodeApi.postMessage({ type: "compactSession", id: activeId });
     bar.classList.add("ctx-clicked");   // immediate cue; the real compacting state takes over via the poll
   });
@@ -7989,8 +7989,9 @@ function setCtxBar(bar: HTMLElement, ctxStr: string | undefined, compacting = fa
 }
 
 const CHIP_LABEL: Record<ChipState, string> = {
-  working: "Working", ready: "Ready", awaiting: "Blocked",
-  awaitingBg: "Awaiting",   // idle, waiting on background work it dispatched — straw, not working-yellow (the user 2026-07-13)
+  working: "Working", ready: "Ready", needsInput: "Blocked",
+  awaiting: "Blocked",   // the legacy name for needsInput — an older remote kernel still sends it
+  awaitingBg: "Awaiting",   // idle, waiting on background work it dispatched — the romp await-green, not working-yellow (the user 2026-07-13; recolored from straw 2026-07-22)
   idle: "Idle", closed: "Closed", compacting: "Compacting", clearing: "Clearing", blocked: "API error",
   retrying: "API retrying…",   // a live session stalled on an API rate-limit/overload auto-retry (api 2026-06-23)
   interrupting: "Interrupting…",   // stop sent, turn not yet settled (the user 2026-07-02) — clears to READY on its own
@@ -8070,7 +8071,7 @@ function updateStatusline() {
     timer.textContent = elapsedMs(s.status.sinceEpoch);
     sl.appendChild(timer);
   } else if (s.status.state === "awaitingBg") {
-    // idle main thread, waiting on background work it dispatched (the user 2026-07-13): its own straw
+    // idle main thread, waiting on background work it dispatched (the user 2026-07-13): its own await-green
     // chip — no pulse (nothing is computing HERE), but the elapsed timer stays so the wait has a clock
     const chip = el("span", "chip chip-awaitingBg");
     // the KIND rides the label so a glance says WHAT is awaited (the user 2026-08-15) — tooltips are

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -151,7 +151,7 @@ body { display: flex; flex-direction: column; }
 .tab.tab-awaiting, .tab.tab-blocked, .tab.tab-retrying { outline: 2px dashed var(--state); outline-offset: -2px; }
 /* WORKING: a small yellow dot left of the name (replaces the old yellow outline). */
 .tab-dot { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: var(--st-working-bg); }   /* solid — dot oscillation was distracting (the user 2026-06-16) */
-.tab-dot.await { background: var(--st-awaitbg-bg); }   /* awaiting-bg: the dot matches the straw chip (the user 2026-07-13) */
+.tab-dot.await { background: var(--st-awaitbg-bg); }   /* awaiting-bg: the dot matches the await-green chip (the user 2026-07-13) */
 /* state UNKNOWN: a hollow ring in the same "can't see it" gray the network strip paints a down host
    (the `#8a8a8a` in strip.ts's status-dot colour pick) — no-information rendered as itself, so a
    bare tab never has to carry that meaning. */
@@ -457,7 +457,7 @@ body { display: flex; flex-direction: column; }
 .bg-stop:disabled { opacity: 0.55; cursor: default; }
 .bg-fold-head.bg-failed { --bgt: var(--st-blocked-bg); }
 .bg-fold-head.bg-completed { --bgt: var(--st-ready-bg); }
-.bg-fold-head.bg-await { --bgt: var(--st-awaitbg-bg); }   /* the Awaiting why header — straw, like its chip */
+.bg-fold-head.bg-await { --bgt: var(--st-awaitbg-bg); }   /* the Awaiting why header — await-green, like its chip */
 .bg-fold-label { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--fg); }
 /* level 2: a flat list of task LINES (no boxes) BELOW the header, fills the box and scrolls when many */
 .bg-list { flex: 1 1 auto; min-height: 0; overflow-y: auto; overscroll-behavior: contain;
@@ -728,7 +728,8 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .apierror-retry:disabled { opacity: 0.55; cursor: default; }
 .apierror-body { margin-top: 5px; font-size: 0.86em; color: var(--dim); line-height: 1.35; }
 .chip-ready { background: var(--st-ready-bg); color: var(--st-ready-fg); }
-.chip-awaiting { background: var(--st-awaiting-bg); color: var(--st-awaiting-fg); }
+.chip-needsInput { background: var(--st-awaiting-bg); color: var(--st-awaiting-fg); }
+.chip-awaiting { background: var(--st-awaiting-bg); color: var(--st-awaiting-fg); }   /* legacy name — an older remote kernel */
 .chip-awaitingBg { background: var(--st-awaitbg-bg); color: var(--st-awaitbg-fg); }
 /* retrying = a SOFT 'blocked on the API' (rate-limit / overload auto-retry) — not a hang, not working. Amber/
    orange, deliberately distinct from working-yellow and blocked-red (the user via api 2026-06-23). */

--- a/ui/webview/timeline-awaiting.test.ts
+++ b/ui/webview/timeline-awaiting.test.ts
@@ -1,7 +1,7 @@
 // Timeline AWAITING badge (the user 2026-07-01, working-state audit; recolored 2026-07-13): the lane
 // shows a distinct AWAITING badge for "waiting on dispatched/background work". Originally the badge wore
 // working-yellow; since the kernel's shared _session_chip split awaitingBg out of "working" (the user
-// 2026-07-13: "differentiate working from awaiting") it wears its OWN straw — the working gold's paler
+// 2026-07-13: "differentiate working from awaiting") it wears its OWN await-green — the working gold's paler
 // sibling — matching the chat chip and the tab/feed dots. The s.awaitingBg why-field stays the fallback
 // key for a remote host on an older kernel (state still 'working' there).
 import { test } from "node:test";
@@ -29,8 +29,8 @@ test("precedence: blocked-on-you beats awaiting, awaiting beats Ready", () => {
   assert.ok(awaiting < ready, "awaiting is checked before the plain Ready fallback");
 });
 
-test("the legacy lane state 'awaiting' (blocked-on-you) still maps to Blocked, untouched", () => {
-  assert.match(TL, /s\.state === 'permission' \|\| s\.state === 'awaiting'\) m = \{ label: 'Blocked', kind: 'attention' \}/);
+test("needsInput maps to Blocked, and the legacy 'awaiting' name (an older remote kernel) still does too", () => {
+  assert.match(TL, /s\.state === 'permission' \|\| s\.state === 'needsInput' \|\| s\.state === 'awaiting'\) m = \{ label: 'Blocked', kind: 'attention' \}/);
 });
 
 test("an idle awaitingBg lane draws a full-thickness FADED stretch (0.4 alpha), not a thin dash (the user 2026-07-13)", () => {


### PR DESCRIPTION
Fourth of the kind-typed awaiting series. The chip state for a live permission/picker prompt was named `awaiting`, the same word the not-on-you family wears, so the identifier vocabulary contradicted the screen (state `awaiting` rendered "Blocked"; `awaitingBg` rendered "Awaiting"). The kernel now emits `needsInput`; every consumer accepts **both** names (an older remote kernel across federation still sends the legacy one). The wire name `awaitingBg` deliberately stays: re-keying it to `awaiting` collides with the old meaning across version skew, so that rename waits until no federated kernel can still emit needs-input-`awaiting`.

Doc sweep rides along: `docs/reference.md` + `bin/romp` (the "states that want a person" claim was doubly wrong — `romp sessions` emits raw states and `awaiting` never rode it), `docs/judges.md` ("only real subagents…" → the shipped layered design with kinds), `docs/read-side.md` stripes, the tmux hook legend, the auto-nudge settings copy, and all 26 stale "straw" color comments (the color has been green since 2026-07-22).

Suites: 4735 py + 1976 ts green; the moved pins (two kernel chip-value tests, one timeline source pin) updated in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)