### PR TITLE
A hidden pane never raises the stale banner

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20308,7 +20308,15 @@ function selfStale(){selfBar("romp lost the live connection, so what you see may
 function clearStale(){if(staleTimer){clearTimeout(staleTimer);staleTimer=0;}   // armed but never shown → nothing to see
 if(window.parent!==window){try{window.parent.postMessage({romp:"wsFresh"},"*");}catch(e){}}
 else{var b=document.getElementById("romp-stale-self");if(b&&b.dataset.kind==="conn")b.remove();}}
-function raiseStale(){if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale"},"*");}catch(e){}}else{selfStale();}}
+// A pane the user cannot SEE never interrupts them about ITS OWN staleness (the user 2026-08-15: the
+// phone shell shows one pane at a time via display:none, iOS throttles the hidden iframes' JS, and each
+// hidden pane's watchdog force-closed its own healthy socket and re-raised the banner every ~45s over a
+// dashboard that was visibly working). display:none gives the iframe a ZERO viewport — that is the test,
+// checked at RAISE time (there is no event for a CSS display flip). The hidden pane still reconnects in
+// the background; if it is shown again while genuinely stale, its watchdog re-raises within one tick,
+// now visible, and the resync retires it exactly as before.
+function paneHidden(){try{return window.parent!==window&&(window.innerWidth===0||window.innerHeight===0);}catch(e){return false;}}
+function raiseStale(){if(paneHidden())return;if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale"},"*");}catch(e){}}else{selfStale();}}
 // ARM it rather than show it (the user 2026-08-01): the resync almost always lands within a beat of the
 // reconnect, so raising immediately made the prompt FLASH up and straight back down on nearly every
 // dashboard open — visual noise for a problem that fixed itself. A short arming window lets the common

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -58,6 +58,19 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn('document.addEventListener("visibilitychange"', js)
         self.assertIn("Date.now()-lastRecv>STALE_MS){armStale();freshPending=true;", js)
 
+    def test_a_hidden_pane_never_raises_the_stale_banner(self):
+        # the user 2026-08-15, on the phone: the mobile shell shows ONE pane, hiding the rest with
+        # display:none; iOS throttles the hidden iframes' JS, so each hidden pane's watchdog kept
+        # force-closing its own healthy socket and re-raising the banner every ~45s over a dashboard
+        # that was visibly working. A display:none iframe has a ZERO viewport — raiseStale checks that
+        # at raise time (no event exists for a CSS display flip) and stays silent while hidden; a pane
+        # shown while genuinely stale re-raises within one watchdog tick, now visible.
+        js = km._shim("feed")
+        self.assertIn("function paneHidden(){try{return window.parent!==window"
+                      "&&(window.innerWidth===0||window.innerHeight===0);}", js)
+        self.assertIn("function raiseStale(){if(paneHidden())return;", js,
+                      "the visibility gate is at RAISE time, so hidden panes reconnect silently")
+
     def test_shim_reconnect_loop_cannot_die(self):
         # The retry chain used to hang entirely off onclose, and the watchdog only ever closed OPEN
         # sockets — so an attempt the browser held in CONNECTING (Firefox delays re-admitting a


### PR DESCRIPTION
On the phone the shell shows one pane at a time and hides the rest with `display:none`. iOS throttles the hidden iframes' JS, so a hidden pane's own `onmessage` stops running, its `lastRecv` goes stale, and when the throttler grants its watchdog a tick it force-closes its own perfectly healthy socket, reconnects, and raises the shell's "romp lost the live connection" banner — about a pane that isn't on screen — roughly every 45 seconds, over a dashboard that was visibly working.

Fix: `raiseStale` checks the pane's own viewport at raise time (`display:none` gives the iframe a zero viewport; no event exists for a CSS display flip) and stays silent while hidden. The hidden pane still reconnects in the background exactly as before; a pane shown while genuinely stale re-raises within one watchdog tick, now visible, and the resync retires it as ever. Desktop gets the same courtesy for rail-toggled-off panes.

Test pins the gate shape in `test_kernel_disconnect_banner.py`; full suite green (4736).

🤖 Generated with [Claude Code](https://claude.com/claude-code)