### PR TITLE
Every stale-banner raise leaves a breadcrumb naming the pane and the path

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20316,7 +20316,16 @@ else{var b=document.getElementById("romp-stale-self");if(b&&b.dataset.kind==="co
 // the background; if it is shown again while genuinely stale, its watchdog re-raises within one tick,
 // now visible, and the resync retires it exactly as before.
 function paneHidden(){try{return window.parent!==window&&(window.innerWidth===0||window.innerHeight===0);}catch(e){return false;}}
-function raiseStale(){if(paneHidden())return;if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale"},"*");}catch(e){}}else{selfStale();}}
+// every raise (and every hidden-pane suppression) leaves a clientDiag breadcrumb naming the pane, the
+// PATH that raised (reconnect/foreground), the socket state and the quiet gap — so the next "the banner
+// keeps flapping" report is diagnosable from client-diag.jsonl instead of re-hypothesized (the user
+// 2026-08-15, whose repro was Chrome-on-Android after an iOS-shaped diagnosis). send() queues while the
+// socket is down and delivers on reconnect, so the breadcrumb survives the very drop it describes.
+function staleDiag(what,why){try{send({type:"clientDiag",surface:"pane-shim",what:what,
+data:{app:APP,why:why||"",ready:ws?ws.readyState:-1,quietMs:lastRecv?Date.now()-lastRecv:-1,hidden:paneHidden()}});}catch(e){}}
+function raiseStale(why){if(paneHidden()){staleDiag("stale-suppressed-hidden",why);return;}
+staleDiag("stale-raise",why);
+if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale"},"*");}catch(e){}}else{selfStale();}}
 // ARM it rather than show it (the user 2026-08-01): the resync almost always lands within a beat of the
 // reconnect, so raising immediately made the prompt FLASH up and straight back down on nearly every
 // dashboard open — visual noise for a problem that fixed itself. A short arming window lets the common
@@ -20326,7 +20335,7 @@ function raiseStale(){if(paneHidden())return;if(window.parent!==window){try{wind
 // is that resync FAILING to arrive, which has no event to key on at all. So the window is exactly the
 // unavoidable minimum, and the event still wins whenever it exists.
 var staleTimer=0;
-function armStale(){if(staleTimer)return;staleTimer=setTimeout(function(){staleTimer=0;raiseStale();},1000);}
+function armStale(why){if(staleTimer)return;staleTimer=setTimeout(function(){staleTimer=0;raiseStale(why);},1000);}
 // BUILD drift (the user 2026-07-13): the keepalive carries the kernel's current dist token (dv); a page whose
 // baked LOADEDV is older is running outdated code against newer kernel state — prompt a reload (never auto).
 // In the dashboard the raise routes to the shell's #rstale banner (build:1 → its BUILDMSG); standalone pages
@@ -20346,7 +20355,7 @@ ws=new WebSocket(proto+location.host+"/ws?app=%s"+(wid?"&wid="+encodeURIComponen
 // socket dropped (the pane's romp loader) needs the socket's RETURN as its event to come back down. The
 // first connect deliberately doesn't fire it — nothing is waiting on it, and the loader must stay up until
 // real content lands.
-ws.onopen=function(){lastRecv=Date.now();netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];if(wasReconn){armStale();freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
+ws.onopen=function(){lastRecv=Date.now();netState("up");var wasReconn=everConnected;everConnected=true;for(var i=0;i<queue.length;i++)ws.send(queue[i]);queue=[];if(wasReconn){armStale("reconnect");freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}};
 ws.onmessage=function(ev){lastRecv=Date.now();var msg;try{msg=JSON.parse(ev.data);}catch(e){return;}
 if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();return;}   // keepalive: stamped lastRecv above; carries the build token (drift → reload banner); nothing for the bundle to render
 // the first REAL frame after a reconnect is the kernel's connect-time push — the resync itself, so the
@@ -20370,7 +20379,7 @@ setState:function(s){try{localStorage.setItem(SK,JSON.stringify(s));}catch(e){}}
 // "Disconnected — reconnecting…" banner sat until a manual refresh). CLOSED with no fresh attempt = the 1.5s
 // retry timer was lost (throttled/killed) — re-dial directly; connect()'s own guard makes this idempotent.
 setInterval(function(){if(!ws)return;
-if(ws.readyState===1){if(everConnected&&Date.now()-lastRecv>STALE_MS){try{ws.close();}catch(e){}}return;}
+if(ws.readyState===1){if(everConnected&&Date.now()-lastRecv>STALE_MS){staleDiag("watchdog-close","quiet");try{ws.close();}catch(e){}}return;}
 if(ws.readyState===0&&Date.now()-connT>15000){try{ws.close();}catch(e){}return;}
 if(ws.readyState===3&&Date.now()-connT>8000){connect();}},5000);
 // visibility fast-path (the user 2026-07-05): a BACKGROUNDED tab has its timers throttled, so the 5s watchdog
@@ -20378,7 +20387,7 @@ if(ws.readyState===3&&Date.now()-connT>8000){connect();}},5000);
 // foregrounded, if the socket isn't open or has gone quiet past the watchdog window, treat the view as stale —
 // prompt at once AND force a reconnect (which resyncs live), rather than leaving the user on a frozen frame.
 document.addEventListener("visibilitychange",function(){if(document.visibilityState!=="visible"||!everConnected)return;
-if(!ws||ws.readyState!==1||Date.now()-lastRecv>STALE_MS){armStale();freshPending=true;
+if(!ws||ws.readyState!==1||Date.now()-lastRecv>STALE_MS){armStale("foreground");freshPending=true;
 try{if(ws&&ws.readyState<=1)ws.close();}catch(e){}   // OPEN or stuck-CONNECTING both die here → onclose retries
 if(!ws||ws.readyState===3)connect();}});})();
 """ % (app, int(v), app, app)

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -39,7 +39,7 @@ class DisconnectBanner(unittest.TestCase):
         # (test_pane_loader_reconnect.py owns that half)
         # …and ARMS the retire (freshPending) so the prompt clears itself when the resync frame lands
         # (the user 2026-08-01) — see test_the_connection_prompt_retires_when_the_resync_lands
-        self.assertIn('if(wasReconn){armStale();freshPending=true;'
+        self.assertIn('if(wasReconn){armStale("reconnect");freshPending=true;'
                       'try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}', js)
         self.assertNotIn("if(everConnected){location.reload();return;}", js,
                          "the silent auto-reload-on-reconnect is replaced by a reload PROMPT")
@@ -56,7 +56,7 @@ class DisconnectBanner(unittest.TestCase):
         # after the throttled 5s watchdog), and forces a reconnect to resync — which disarms it again if the
         # resync lands inside the arming window (the user 2026-08-01).
         self.assertIn('document.addEventListener("visibilitychange"', js)
-        self.assertIn("Date.now()-lastRecv>STALE_MS){armStale();freshPending=true;", js)
+        self.assertIn('Date.now()-lastRecv>STALE_MS){armStale("foreground");freshPending=true;', js)
 
     def test_a_hidden_pane_never_raises_the_stale_banner(self):
         # the user 2026-08-15, on the phone: the mobile shell shows ONE pane, hiding the rest with
@@ -68,8 +68,22 @@ class DisconnectBanner(unittest.TestCase):
         js = km._shim("feed")
         self.assertIn("function paneHidden(){try{return window.parent!==window"
                       "&&(window.innerWidth===0||window.innerHeight===0);}", js)
-        self.assertIn("function raiseStale(){if(paneHidden())return;", js,
+        self.assertIn('function raiseStale(why){if(paneHidden()){staleDiag("stale-suppressed-hidden",why);return;}', js,
                       "the visibility gate is at RAISE time, so hidden panes reconnect silently")
+
+    def test_every_stale_raise_leaves_a_breadcrumb_naming_pane_and_path(self):
+        # the user 2026-08-15: the flapping-banner repro was Chrome-on-Android after an iOS-shaped
+        # diagnosis — the next report must carry recorded evidence. Every raise (and every hidden-pane
+        # suppression, and every watchdog force-close) posts a clientDiag with the pane, the arming
+        # path (reconnect/foreground), the socket state and the quiet gap; send() queues while the
+        # socket is down, so the breadcrumb survives the drop it describes.
+        js = km._shim("feed")
+        self.assertIn('send({type:"clientDiag",surface:"pane-shim",what:what,', js)
+        self.assertIn('staleDiag("stale-raise",why);', js)
+        self.assertIn('staleDiag("stale-suppressed-hidden",why);', js)
+        self.assertIn('staleDiag("watchdog-close","quiet");', js)
+        self.assertIn('armStale("reconnect");', js)
+        self.assertIn('armStale("foreground");', js)
 
     def test_shim_reconnect_loop_cannot_die(self):
         # The retry chain used to hang entirely off onclose, and the watchdog only ever closed OPEN
@@ -81,7 +95,7 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn("function connect(){if(ws&&(ws.readyState===0||ws.readyState===1))return;", js)
         self.assertIn("connT=Date.now();", js)
         # the watchdog handles EVERY socket state: half-open OPEN, stuck CONNECTING, and lost-timer CLOSED
-        self.assertIn("if(ws.readyState===1){if(everConnected&&Date.now()-lastRecv>STALE_MS){try{ws.close();}catch(e){}}return;}", js)
+        self.assertIn('if(ws.readyState===1){if(everConnected&&Date.now()-lastRecv>STALE_MS){staleDiag("watchdog-close","quiet");try{ws.close();}catch(e){}}return;}', js)
         self.assertIn("if(ws.readyState===0&&Date.now()-connT>15000){try{ws.close();}catch(e){}return;}", js)
         self.assertIn("if(ws.readyState===3&&Date.now()-connT>8000){connect();}", js)
         # the foregrounding fast-path tears down a stuck CONNECTING socket too, and re-dials a closed one
@@ -124,9 +138,9 @@ class DisconnectBanner(unittest.TestCase):
         self.assertIn("freshPending=true", js, "a reconnect arms the retire")
         # …and the prompt is ARMED, not shown (the user 2026-08-01): raising it at once made it flash up
         # and straight back down on nearly every dashboard open, since the resync lands within a beat.
-        self.assertIn("staleTimer=setTimeout(function(){staleTimer=0;raiseStale();},1000)", js,
+        self.assertIn("staleTimer=setTimeout(function(){staleTimer=0;raiseStale(why);},1000)", js,
                       "a one-second arming window, not an immediate raise")
-        self.assertIn("if(wasReconn){armStale();", js, "the reconnect ARMS it")
+        self.assertIn('if(wasReconn){armStale("reconnect");', js, "the reconnect ARMS it")
         self.assertNotIn("if(wasReconn){raiseStale();", js, "…and never raises it outright")
         self.assertIn("if(staleTimer){clearTimeout(staleTimer);staleTimer=0;}", js,
                       "a resync inside the window disarms it, so it never appears at all")
@@ -146,7 +160,7 @@ class DisconnectBanner(unittest.TestCase):
         # a tab foregrounded onto a dead socket forces a reconnect and used to prompt immediately; that
         # reconnect resyncs like any other, so it arms the same window and disarms on the same frame
         js = km._shim("chat", 7777)
-        self.assertIn("Date.now()-lastRecv>STALE_MS){armStale();freshPending=true;", js)
+        self.assertIn('Date.now()-lastRecv>STALE_MS){armStale("foreground");freshPending=true;', js)
         self.assertNotIn("STALE_MS){raiseStale();", js)
 
     def test_a_standalone_page_retires_only_its_connection_bar(self):

--- a/tests/test_pane_loader_reconnect.py
+++ b/tests/test_pane_loader_reconnect.py
@@ -69,7 +69,7 @@ class PaneLoaderReconnect(unittest.TestCase):
         """A first connect must NOT fire it: the loader is legitimately up during a cold load and has to
         stay there until real content lands (an 8s timer that hid it early was the 2026-07-03 bug)."""
         shim = km._shim("chat")
-        self.assertIn('if(wasReconn){armStale();freshPending=true;'
+        self.assertIn('if(wasReconn){armStale("reconnect");freshPending=true;'
                       'try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}}',
                       shim, "wsup rides the same wasReconn gate as the reload prompt (which now also arms "
                             "its own retire — the user 2026-08-01)")


### PR DESCRIPTION
The flapping-banner diagnosis shipped iOS-shaped (hidden panes throttled, #409), and the user's repro turned out to be Chrome on Android — where foreground same-origin iframes are not throttled the way iOS suspends them, so the raiser may be something else (screen-lock freeze cycles with a >1s reconnect over the tunnel, or genuine 30s network stalls). Rather than re-hypothesize, the shim now records what actually happened: every raise, every hidden-pane suppression, and every watchdog force-close posts a `clientDiag` breadcrumb (the 2026-07-14 channel built for exactly this) carrying the pane, the arming path (reconnect/foreground), the socket readyState, the quiet gap, and the hidden bit, into `client-diag.jsonl`. `send()` queues while the socket is down, so the breadcrumb survives the very drop it describes.

Source pins in `test_kernel_disconnect_banner.py`; moved pins updated in place. Full suite green (4737).

🤖 Generated with [Claude Code](https://claude.com/claude-code)