### PR TITLE
Chat history back/forward on the user's own Obsidian nav keys

### DIFF
--- a/ui/webview/commands.ts
+++ b/ui/webview/commands.ts
@@ -22,6 +22,10 @@ export const DEFAULT_CHORDS: Record<string, string> = {
   "session.jump": "Mod+O",
   "session.new": "Mod+Shift+O",
   "palette.toggle": "Mod+P",
+  // LITERAL Ctrl, not Mod: these mirror the user's own Obsidian nav bindings (their vault's
+  // hotkeys.json, verified 2026-08-14), where "Ctrl" is the Control key on every platform.
+  "chat.navBack": "Ctrl+M",
+  "chat.navForward": "Ctrl+,",
 };
 
 const commands = new Map<string, PaletteCommand>();

--- a/ui/webview/nav-history.test.ts
+++ b/ui/webview/nav-history.test.ts
@@ -1,0 +1,86 @@
+// The chat's back/forward trail (the user 2026-08-14): every rule executed, not regex-pinned.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { NavHistory, type NavSpot } from "./nav-history";
+
+function rig(alive: (sid: string) => boolean = () => true) {
+  let here: NavSpot | null = { sid: "a", top: 0 };
+  const applied: NavSpot[] = [];
+  const h = new NavHistory({
+    now: () => (here ? { ...here } : null),
+    alive,
+    apply: (s) => { applied.push({ ...s }); here = { ...s }; },
+  });
+  return {
+    h, applied,
+    moveTo(sid: string, top: number) { h.record(); here = { sid, top }; },   // what setActive does
+    at: () => here!,
+  };
+}
+
+test("back returns to the spot you left, forward re-walks it — across tabs", () => {
+  const r = rig();
+  r.moveTo("b", 500);                       // a → b (records a@0)
+  r.moveTo("c", 900);                       // b → c (records b@500)
+  assert.ok(r.h.go(-1));
+  assert.deepEqual(r.at(), { sid: "b", top: 500 });
+  assert.ok(r.h.go(-1));
+  assert.deepEqual(r.at(), { sid: "a", top: 0 });
+  assert.ok(r.h.go(1));
+  assert.deepEqual(r.at(), { sid: "b", top: 500 });
+  assert.ok(r.h.go(1));
+  assert.deepEqual(r.at(), { sid: "c", top: 900 });
+  assert.equal(r.h.go(1), false, "the trail's end says so instead of pretending");
+});
+
+test("a new move truncates the forward trail — the browser rule", () => {
+  const r = rig();
+  r.moveTo("b", 100);
+  r.h.go(-1);                               // back to a
+  r.moveTo("z", 50);                        // branch off somewhere new
+  assert.equal(r.h.go(1), false, "forward history died at the branch point");
+});
+
+test("re-recording the same reading spot is one entry, not many", () => {
+  const r = rig();
+  r.moveTo("a", 10);                        // within SAME_TOP of a@0 — deduped
+  r.moveTo("b", 100);                       // records a once
+  r.h.go(-1);
+  assert.deepEqual(r.at().sid, "a");
+  assert.equal(r.h.go(-1), false, "one entry for one spot");
+});
+
+test("spots on closed tabs are skipped, not shown", () => {
+  const dead = new Set<string>();
+  const r = rig((sid) => !dead.has(sid));
+  r.moveTo("b", 100);
+  r.moveTo("c", 200);
+  dead.add("b");
+  assert.ok(r.h.go(-1), "one press: b is gone, so it lands on a — silently past the dead tab");
+  assert.deepEqual(r.at(), { sid: "a", top: 0 });
+  assert.equal(r.h.go(-1), false, "the dead spot was consumed, not left to trip over");
+});
+
+test("a history jump never records itself (the applying latch)", () => {
+  let here: NavSpot = { sid: "a", top: 0 };
+  const h = new NavHistory({
+    now: () => ({ ...here }),
+    alive: () => true,
+    // the real wiring: apply() lands via setActive, whose first act is record() — re-entrant
+    apply: (s) => { here = { ...s }; h.record(); },
+  });
+  h.record();                       // a@0 onto the trail
+  here = { sid: "b", top: 300 };    // the move the record above preceded
+  assert.ok(h.go(-1));
+  assert.equal(here.sid, "a");
+  assert.equal(h.go(-1), false, "the re-entrant record() inside apply() minted no phantom entry");
+});
+
+test("the trail is capped — old spots age out, the walk stays sound", () => {
+  const r = rig();
+  for (let i = 1; i <= 150; i++) r.moveTo("s" + i, i);
+  let steps = 0;
+  while (r.h.go(-1)) steps++;
+  assert.ok(steps <= 101, `bounded: walked ${steps}`);
+  assert.ok(steps >= 99, `the cap keeps the recent hundred: walked ${steps}`);
+});

--- a/ui/webview/nav-history.ts
+++ b/ui/webview/nav-history.ts
@@ -1,0 +1,56 @@
+// Chat navigation history — back/forward through visited transcript spots, the way Obsidian walks
+// its history (the user 2026-08-14, whose own vault binds nav-back/-forward; verified from the
+// vault's hotkeys.json as Ctrl+M / Ctrl+, — they remembered Option, the config says Ctrl, and the
+// config wins). The chat records a spot on EVERY navigation through setActive — a tab switch, a
+// feed/outline/timeline jump landing on an anchor — and the two keys walk that trail across tabs
+// and positions. PURE (deps injected) so nav-history.test.ts EXECUTES the rules — dedup of
+// same-spot re-records, forward-trail truncation on a new move, dead-tab skip, the cap — instead
+// of regexing render.ts. Chat-only for now, by the user's scoping.
+
+export interface NavSpot { sid: string; top: number }
+
+export interface NavDeps {
+  now(): NavSpot | null;             // where the chat is right this moment (null: no active tab)
+  alive(sid: string): boolean;       // the tab still exists (a closed session's spots are skipped)
+  apply(spot: NavSpot): void;        // land there (switch the tab + restore the scroll position)
+}
+
+const CAP = 100;                     // plenty of trail, bounded memory
+const SAME_TOP = 40;                 // px: re-recording the same reading spot is one entry, not many
+
+export class NavHistory {
+  private back: NavSpot[] = [];
+  private fwd: NavSpot[] = [];
+  private applying = false;
+
+  constructor(private deps: NavDeps) {}
+
+  /** Record the spot being LEFT — called before a navigation applies (setActive's first act). A
+   *  history jump must never record itself: `applying` latches while apply() runs, so the
+   *  setActive it triggers records nothing. */
+  record(): void {
+    if (this.applying) return;
+    const s = this.deps.now();
+    if (!s) return;
+    const last = this.back[this.back.length - 1];
+    if (last && last.sid === s.sid && Math.abs(last.top - s.top) < SAME_TOP) return;
+    this.back.push(s);
+    if (this.back.length > CAP) this.back.shift();
+    this.fwd.length = 0;             // a NEW move truncates the forward trail (the browser rule)
+  }
+
+  /** Walk the trail: dir -1 = back, 1 = forward. Spots on closed tabs are skipped, not shown.
+   *  Returns whether anywhere was left to go. */
+  go(dir: -1 | 1): boolean {
+    const from = dir < 0 ? this.back : this.fwd;
+    const to = dir < 0 ? this.fwd : this.back;
+    let spot = from.pop();
+    while (spot && !this.deps.alive(spot.sid)) spot = from.pop();
+    if (!spot) return false;
+    const cur = this.deps.now();
+    if (cur) to.push(cur);
+    this.applying = true;
+    try { this.deps.apply(spot); } finally { this.applying = false; }
+    return true;
+  }
+}

--- a/ui/webview/palette-main.ts
+++ b/ui/webview/palette-main.ts
@@ -111,6 +111,18 @@ type SessionRow = { id: string; name: string; dir: string; bg: string };
     id: "settings.open", title: "Open settings",
     run: () => { try { pane("f-feed")!.contentWindow!.postMessage({ romp: "openSettings" }, "*"); } catch (e) { /* feed not loaded */ } },
   });
+  // Chat history back/forward (the user 2026-08-14; their own Obsidian nav keys — Ctrl+M / Ctrl+,
+  // per their vault's hotkeys.json). The chat pane owns the trail (it knows the tabs + scroll spots);
+  // these run when focus is in the SHELL — with focus inside the chat, its own capture handler
+  // (render.ts) reads the same bindings store, so a rebind moves both at once.
+  registerCommand({
+    id: "chat.navBack", title: "Navigate back in the chat",
+    run: () => { try { pane("f-chat")!.contentWindow!.postMessage({ romp: "chatNav", dir: -1 }, "*"); } catch (e) { /* chat not loaded */ } },
+  });
+  registerCommand({
+    id: "chat.navForward", title: "Navigate forward in the chat",
+    run: () => { try { pane("f-chat")!.contentWindow!.postMessage({ romp: "chatNav", dir: 1 }, "*"); } catch (e) { /* chat not loaded */ } },
+  });
   registerCommand({ id: "log.open", title: "Open the log", run: () => { if (w.__rompOpenErrs) w.__rompOpenErrs(); } });
   registerCommand({ id: "net.open", title: "Remote kernels", run: () => { if (w.__rompOpenNet) w.__rompOpenNet(); } });
   registerCommand({ id: "usage.open", title: "Token usage", run: () => { if (w.__rompUsagePanel) w.__rompUsagePanel(); } });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -21,7 +21,9 @@ import { isClearCmd, openTopTitles, clearConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
 import { reconcileTabOrder } from "./tab-order";
 import { writeViewOrder } from "./view-order";
-import { titleWithKey } from "./keybindings";
+import { titleWithKey, chordOf, effectiveChord, loadOverrides } from "./keybindings";
+import { DEFAULT_CHORDS } from "./commands";
+import { NavHistory } from "./nav-history";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
@@ -4204,6 +4206,26 @@ window.addEventListener("keydown", (e) => {
   if (inRompShell()) return;   // the shell's handler on this document takes it from here
   e.preventDefault(); e.stopPropagation();
   if (pickerVisible()) closePicker(); else openPicker();
+}, true);
+// Ctrl+M / Ctrl+, — chat history back/forward, the user's own Obsidian nav keys (their vault's
+// hotkeys.json, verified 2026-08-14: Ctrl, not Option). The trail lives in THIS pane (navHist), so
+// the keys are handled here whenever focus is inside the chat — capture-phase like Cmd+O above, so
+// they work from the composer too. Registered as chat.navBack/chat.navForward in the shell's command
+// registry (palette + Customize shortcuts…); this handler reads the SAME overrides store per press,
+// so a rebind in the dialog moves both dispatch paths at once. Chat-only for now (the user's scoping).
+window.addEventListener("keydown", (e) => {
+  if (!e.ctrlKey && !e.metaKey) return;                 // both defaults carry Ctrl; a rebind may use Meta
+  const ch = chordOf(e);
+  if (!ch || !ch.includes("+")) return;
+  const mac = /Mac|iP(hone|ad|od)/.test(navigator.platform || "");
+  const ov = loadOverrides();
+  if (ch === effectiveChord("chat.navBack", DEFAULT_CHORDS["chat.navBack"], ov, mac)) {
+    e.preventDefault(); e.stopPropagation();
+    navHist.go(-1);
+  } else if (ch === effectiveChord("chat.navForward", DEFAULT_CHORDS["chat.navForward"], ov, mac)) {
+    e.preventDefault(); e.stopPropagation();
+    navHist.go(1);
+  }
 }, true);
 // Nearest tab in the row above (dir<0) or below (dir>0) the given tab, by column.
 function tabInAdjacentRow(id: string, dir: number): string | null {
@@ -8679,9 +8701,30 @@ function noteMru(id: string): void {
   if (sessionMru.length > 50) sessionMru.pop();
 }
 
+// The chat's back/forward trail (the user 2026-08-14) — the rules live in nav-history.ts, executed
+// by its test. The deps close over this pane's real state: the active tab + #content scroll for
+// "now", the sessions map for liveness, and a land that pre-seeds the per-tab scroll restore (views)
+// BEFORE setActive — so the entering tab's own restore applies the remembered spot — then re-asserts
+// it once the pane is visible (a same-tab jump returns early from setActive and needs the direct set).
+const navHist = new NavHistory({
+  now: () => {
+    const c = document.getElementById("content");
+    return activeId && c ? { sid: activeId, top: c.scrollTop } : null;
+  },
+  alive: (sid) => sessions.has(sid),
+  apply: (spot) => {
+    const v = views.get(spot.sid);
+    if (v) { v.scrollTop = spot.top; v.stick = false; }   // land on the remembered spot, never the live bottom
+    setActive(spot.sid);
+    const c = document.getElementById("content");
+    if (c) whenChatVisible(() => { if (activeId === spot.sid) c.scrollTop = spot.top; });
+  },
+});
+
 function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: string) {
   noteMru(id);
   if (activeId === id && anchor == null && anchorT == null) return; // already active, nothing to do
+  navHist.record();   // every real navigation records the spot being LEFT (the user 2026-08-14: Ctrl+M / Ctrl+, walk the trail)
   closeMetaMenu(); // an open model/effort menu targets the tab we're leaving
   // a comment popover belongs to its parent session's view — leaving that session closes it (the
   // user 2026-08-13: it lingered over the next tab's chat); the highlight reopens it any time
@@ -9099,6 +9142,8 @@ window.addEventListener("message", (e: MessageEvent) => {
     if (activeId && !isProvisionalId(activeId) && sessions.get(activeId)) showForkPrompt(activeId, "");
     return;
   }
+  // the shell's palette / shell-focus chords: the chat owns the nav trail, the shell just asks
+  if (m.romp === "chatNav") { navHist.go(m.dir === 1 ? 1 : -1); return; }
   if (m.type === "pipeState") { pipeBanner(!!m.up, Number(m.queued) || 0); return; }
   if (m.type === "session") upsert(m);
   else if (m.type === "globalRetryPaused") {


### PR DESCRIPTION
The user (2026-08-14): their Obsidian navigate-back/forward shortcuts should work in romp's chat — jump around transcripts, then walk back through where you've been, tab switches included. Verified from their vault's hotkeys.json: the bindings are **Ctrl+M** (back) and **Ctrl+,** (forward) — Control, not Option as remembered — declared as LITERAL Ctrl defaults (their Obsidian "Ctrl" is the Control key on every platform, so no Mod translation).

- **The trail** (`nav-history.ts`, pure, executed by its test): every navigation through `setActive` — the single gate for tab switches and feed/outline/timeline anchor jumps — records the spot being left (session + scroll). Back/forward walk it across tabs. Rules under test: same-spot dedup, forward-trail truncation on a new move (the browser rule), closed-tab spots skipped through in one press, a 100-spot cap, and an applying-latch so a history jump never records itself.
- **Landing**: the apply pre-seeds the per-tab scroll restore before `setActive`, then re-asserts the position once the pane is visible (covers the same-tab early return and hidden-pane deep-link deferral).
- **Dispatch, two paths, one store**: a capture-phase handler in the chat pane (works from the composer, like the quick-switcher chord) plus `chat.navBack`/`chat.navForward` in the command registry — palette-listed, rebindable in Customize shortcuts…, with the in-pane handler reading the same overrides per press so a rebind moves both at once. Shell-focus presses reach the chat via the established pane postMessage pattern.

Chat-only for now, per the user's scoping. Node suite 1964/1964 (seven new trail tests), typecheck and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)