### PR TITLE
The API-spend hover leads with a rolling 1-hour row

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16883,6 +16883,7 @@ def _spend_windows(keyed_only=False):
     # sums its cell from them (version skew), and the strip reads day||fiveHour meanwhile. month stays
     # calendar month-to-date — it matches the bill.
     win = {"fiveHour": _rolling(5), "sevenDay": _rolling(7 * 24),
+           "hour": _rolling(1),   # the last hour, same rolling bucket math as day (the user 2026-08-15)
            "day": _rolling(24), "week": _rolling(7 * 24),
            "month": _sum(v for k, v in days.items() if isinstance(k, str) and k.startswith(month))}
     for k, v in _spend_budgets().items():
@@ -21197,9 +21198,10 @@ function fmtTok(n){if(n>=1e9)return fmtSig3(n/1e9)+'B';
 if(n>=1e6)return fmtSig3(n/1e6)+'M';
 if(n>=1e3)return fmtSig3(n/1e3)+'k';return String(n);}
 function fmtUsd(v){return '$'+String(Math.round(v));}   // whole dollars everywhere — no cents (the user 2026-08-09)
-// pay-per-token has no reset windows (the user 2026-08-13): the key's story is 1 day / 1 week / 1 month.
+// pay-per-token has no reset windows (the user 2026-08-13): the key's story is 1 hour (the user
+// 2026-08-15) / 1 day / 1 week / 1 month.
 // fiveHour/sevenDay fallbacks remain readable from older remote kernels (version skew) via day||fiveHour.
-var SPEND_WINS=[['day','1 day'],['week','1 week'],['month','1 month']];
+var SPEND_WINS=[['hour','1 hour'],['day','1 day'],['week','1 week'],['month','1 month']];
 // The per-host SPEND detail for the rich hover: plain NUMBERS per window (dollars, tokens, turns).
 // No bars anywhere for spend (the user 2026-08-08: the spend bar graphs told you nothing. The old
 // hover scaled each window's bar to the largest window, a shape with no meaning, and the budget-fill

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -291,6 +291,27 @@ class SpendKeyedSplit(_Keyed):
         self.assertEqual(day["key"]["turns"], 1)
         self.assertEqual(day["key"]["tok"], 15)
 
+    def test_spend_windows_carry_a_rolling_hour(self):
+        # the hover's API-spend section leads with "1 hour" (the user 2026-08-15): the last hour by
+        # the same rolling bucket math as day, so a burst shows up without waiting for the day sum
+        self.be._record_spend(2.0, {"input_tokens": 10}, keyed=True)
+        real_state = km.jd.STATE
+        try:
+            km.jd.STATE = Path(self.d)
+            win = km._spend_windows()
+            # …and an old bucket (3h ago) stays out of the hour window while the day keeps it
+            import json as _json, time as _time
+            sp = _json.loads((Path(self.d) / "spend.json").read_text())
+            oldkey = _time.strftime("%Y-%m-%dT%H", _time.localtime(_time.time() - 3 * 3600))
+            sp.setdefault("hours", {})[oldkey] = {"usd": 7.0, "turns": 1, "tokIn": 5}
+            (Path(self.d) / "spend.json").write_text(_json.dumps(sp))
+            win2 = km._spend_windows()
+        finally:
+            km.jd.STATE = real_state
+        self.assertEqual(win["hour"]["usd"], 2.0)
+        self.assertEqual(win2["hour"]["usd"], 2.0, "a 3h-old bucket is outside the rolling hour")
+        self.assertEqual(win2["day"]["usd"], 9.0, "…but inside the rolling day")
+
     def test_spend_windows_keyed_only_reads_the_subcounts(self):
         self.be._record_spend(1.5, {"input_tokens": 10}, keyed=True)
         self.be._record_spend(4.0, None, keyed=False)

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -24,6 +24,9 @@ test("the kernel serves spend windows for BOTH payload shapes, keyed-only beside
   // and keeps TOTAL sums (everything there bills the key; legacy files predate the split)
   assert.ok(KERNEL.includes('if o.get("apiKey") or (not _claude_account() and (jd.STATE / "spend.json").exists()):'));
   assert.ok(KERNEL.includes('out = {"apiKey": True, "spend": _spend_windows(),'));
+  // the hover's spend rows lead with the rolling hour (the user 2026-08-15); the collapsed cell keeps day+month
+  assert.ok(KERNEL.includes("var SPEND_WINS=[['hour','1 hour'],['day','1 day'],['week','1 week'],['month','1 month']];"));
+  assert.ok(KERNEL.includes('"hour": _rolling(1),'));
   // …and the $/hour series rides beside the windows for the hover graph (the user 2026-08-13)
   assert.ok(KERNEL.includes('out["spendSeries"] = ss'));
   // the bars payload attaches the KEYED split only — a login turn's computed cost there would be


### PR DESCRIPTION
One line above "1 day": the hover's API-spend section now opens with **1 hour** — the last hour by the same rolling bucket math the day window uses, so a burst of spend is visible without waiting for it to move the day sum. `_spend_windows` gains `"hour": _rolling(1)`; `SPEND_WINS` leads with the new row; the collapsed API cell keeps day+month.

Tests: a rolling-hour case (a 3h-old bucket stays out of the hour sum, in the day sum) plus source pins. Suites green (4741 py + 1984 ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)