### PR TITLE
Timeline lineage: git-graph branch bars, branch-clipped lanes, comment squares

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5051,6 +5051,25 @@ def _comments_frame(sid):
     return {"type": "comments", "id": sid, "threads": threads}
 
 
+def _comment_markers(sid):
+    """The timeline lane's comment SQUARES: [{t, uuid, tid, status}] for threads anchored on this
+    session — open + resolved only (a promoted thread is a session with a branch connector; a
+    dead-promoted one is done). anchorT (stamped at create) places the square at the commented
+    message; rows from before that stamp fall back to createdT, the comment's own moment. One
+    exists() stat for every session that never had a thread."""
+    p = _comments_path(sid)
+    if not p.exists():
+        return []
+    out = []
+    for th in _load_comments(sid).get("threads") or []:
+        if (th.get("status") or "open") not in ("open", "resolved"):
+            continue
+        out.append({"t": th.get("anchorT") or th.get("createdT") or 0,
+                    "uuid": th.get("anchorUuid") or "", "tid": th.get("tid"),
+                    "status": th.get("status") or "open"})
+    return out
+
+
 def _comment_create(parent_sid, anchor_uuid, exact, text, now=None):
     """Anchor a new comment thread: fork the parent at the highlighted message (inclusive) as a
     threadOf fork — no names/ entry, so no judge seeding is needed until promotion — and send the
@@ -17981,6 +18000,21 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
     id2name = {s["sid"]: s["name"] for s in alive}
     sessions, turns, semantic = [], {}, []   # `semantic`: artifact-derived marks (for gloss text); the band's marks are RUN spans, below
     ctx_stops = cm.stops_for(_colormap())    # the GLOBAL colormap (the user 2026-06-26): color the per-lane context bar server-side
+    # BRANCH LINEAGE on the timeline (the user 2026-08-14: a fork drawn like a git graph). branch_of
+    # maps a forked lane to its durable forkedFrom — only while the PARENT's lane is in this build:
+    # that presence is also the CLIP condition below (a fork's transcript carries the parent history
+    # VERBATIM; while the parent's lane shows that history, the child's must not repeat it — parent
+    # gone, and the child shows the whole story, as if it had been one session all along). Costs one
+    # stat steady-state (fork_children's sdk/ dir-mtime memo), so the skeleton path can afford it.
+    _be_fk = _sdk()
+    _kid_map = (_be_fk.fork_children() if _be_fk and hasattr(_be_fk, "fork_children") else {}) or {}
+    branch_of = {}
+    for _psid, _kids in _kid_map.items():
+        if _psid not in id2name:
+            continue
+        for _k in _kids:
+            if _k["sid"] in id2name and _k.get("t"):
+                branch_of[_k["sid"]] = {"fromId": _psid, "t": _k["t"], "cut": _k.get("cut") or ""}
     for s in alive:
         sid, name = s["sid"], s["name"]
         tm = tmux.get(sid)
@@ -18061,7 +18095,10 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
                          and not any(x["type"] == "idle" for x in turn["atoms"])
                          and not _suspended_after(turn["end"]))   # dead lane (live False) or pre-sleep freeze → not an open bar
             segs = _segs_seam(turn, goals)
+            _bft = (branch_of.get(sid) or {}).get("t")
             for si, seg in enumerate(segs):
+                if _bft and (seg.get("end") or seg["t"]) <= _bft:
+                    continue                                       # copied pre-branch history — the parent's lane owns it
                 # A bar must not span a host sleep. EXCISE every suspension inside the segment → one bar per
                 # awake stretch, so work done AFTER the lid reopened isn't erased (the user 2026-06-22). The
                 # asleep gaps between pieces read as idle (and collapse under 'collapse gaps'). The segment's
@@ -18106,8 +18143,10 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         if with_bars:
             turns[sid] = bars
             _derive_judging(sid, caps, goals, now - TL_HORIZON, semantic, seg_ends)
+        _bft = (branch_of.get(sid) or {}).get("t")
         compactions = [{"t": a["t"]} for turn in st_turns for a in turn["atoms"]
-                       if a.get("type") == "system" and a.get("subtype") == "compact_boundary" and a.get("t")]
+                       if a.get("type") == "system" and a.get("subtype") == "compact_boundary" and a.get("t")
+                       and not (_bft and a["t"] <= _bft)]           # copied boundaries stay on the parent's lane
         # Idle fade: the SAME rule the chat tab uses (ready + idle > 1h — see the `faded` beside the chat
         # chip), keyed on the DERIVED chip `state` computed above, not the raw tmux state. The old form read
         # tmux's vocabulary and counted "waiting" as active — but "waiting" IS the post-turn idle state, so
@@ -18149,6 +18188,11 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
             # a clear) — the lane marks where a conversation ended and a blank one began
             "clears": [{"t": r["t"]} for r in jd.episode_rows(sid)[1:] if r.get("t")],
             "faded": faded,
+            # branch lineage (the user 2026-08-14): the child lane's connector endpoint + clip point,
+            # present only while the parent's lane is in this build; comment squares ride every lane
+            # that has threads (anchorT-placed, open/resolved only — a promoted thread IS a session)
+            "branch": branch_of.get(sid),
+            "comments": _comment_markers(sid),
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),    # lane checkbox → mute from feed (timeline-only)
             "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"),  # lane mailbox → isolate from the Romp Postal Service (bin/romp-postal-service)
             "notify": _notify_session_effective(sid)})   # lane bell, EFFECTIVE (override, else the master default) → OS notification when this session's work blocks on you / completes (the user 2026-07-28)

--- a/tests/test_timeline_lineage.py
+++ b/tests/test_timeline_lineage.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Branch lineage on the TIMELINE (the user 2026-08-14): a forked lane carries `branch` (its
+connector endpoint) only while the parent's lane is in the same build; its copied pre-fork bars are
+clipped in that case and shown in full when the parent's lane is gone (as if one session all
+along); comment threads never become lanes — each rides its parent lane as a square marker. All
+fixtures SYNTHETIC."""
+import json
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["ROMP_TMUX_AVAILABLE"] = "1"
+os.environ["ROMP_SERVE_TOKEN"] = "testtok"
+em = SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+jd = SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+km._limit_hold = lambda sid: None
+
+PARENT = "11111111-2222-3333-4444-555555555555"
+CHILD = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+THREAD = "99999999-8888-7777-6666-555555555555"
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+class TimelineLineageBase(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.STATE
+        self._saved_proj = jd.PROJECTS
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        jd.PROJECTS = Path(self._td) / "projects"
+        jd._discover_cache.clear()
+        jd._PARSE_CACHE.clear()
+        km._parse_cache.clear()
+        km._dismissed_lanes.clear()   # a durable module-level set: an earlier test file dismissing
+        #                               the shared placeholder sid silently filtered these lanes
+        self.now = int(time.time())
+        self.fork_t = self.now - 300
+        self.cdir = str(Path(self._td) / "work")
+        self.proj = jd._proj_dir(self.cdir)
+        self.proj.mkdir(parents=True, exist_ok=True)
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+        jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+        t = self.now - 600
+        shared = [uline(t, "how should the retry loop back off?", "u1"),
+                  aline(t + 20, "Use exponential backoff.", "a1", parent="u1")]
+        own = [uline(self.fork_t + 60, "and inside the fork?", "u9", parent="a1"),
+               aline(self.fork_t + 80, "Cap the delay at two minutes.", "a9", parent="u9")]
+        for sid, name, recs in ((PARENT, "parent", shared), (CHILD, "child", shared + own)):
+            (jd.NAMES / sid).write_text("%s\t%s" % (name, self.cdir))
+            (self.proj / (sid + ".jsonl")).write_text(
+                "\n".join(json.dumps(r) for r in recs) + "\n")
+        self._saved_sdk = km._sdk
+        kids = {PARENT: [{"sid": CHILD, "name": "child", "cut": "a1", "t": self.fork_t}]}
+
+        class FakeBe:
+            def fork_children(self):
+                return kids
+
+            def owns(self, sid):
+                return False
+
+            def __getattr__(self, name):
+                return lambda *a, **k: None
+
+        self._fake_be = FakeBe()
+        km._sdk = lambda: self._fake_be
+
+    def tearDown(self):
+        km._sdk = self._saved_sdk
+        jd._rebind_state(self._saved)
+        jd.PROJECTS = self._saved_proj
+        shutil.rmtree(self._td, ignore_errors=True)
+
+    def _lane(self, tl, sid):
+        return next((l for l in tl["sessions"] if l["id"] == sid), None)
+
+
+class BranchOnTheTimeline(TimelineLineageBase):
+    def test_the_forked_lane_carries_its_branch_and_clips_the_copied_history(self):
+        tl = km.build_timeline(self.now, tmux={})
+        lane = self._lane(tl, CHILD)
+        self.assertEqual(lane["branch"], {"fromId": PARENT, "t": self.fork_t, "cut": "a1"})
+        starts = [b["start"] for b in tl["turns"][CHILD]]
+        self.assertTrue(starts, "the child's own post-fork work still draws")
+        self.assertTrue(all(st > self.fork_t for st in starts),
+                        "copied pre-branch bars belong to the parent's lane: %r" % starts)
+        self.assertTrue(any(b["start"] < self.fork_t for b in tl["turns"][PARENT]),
+                        "the parent's lane still owns the shared history")
+
+    def test_a_gone_parent_returns_the_whole_story_to_the_child(self):
+        (jd.NAMES / PARENT).unlink()                 # the parent session is gone from the timeline
+        jd._discover_cache.clear()
+        tl = km.build_timeline(self.now, tmux={})
+        self.assertIsNone(self._lane(tl, CHILD)["branch"],
+                          "no parent lane, no connector endpoint")
+        self.assertTrue(any(b["start"] < self.fork_t for b in tl["turns"][CHILD]),
+                        "with the parent gone the child reads as one session all along")
+
+    def test_the_skeleton_carries_lineage_without_parsing(self):
+        tl = km.build_timeline(self.now, tmux={}, with_bars=False)
+        self.assertEqual(self._lane(tl, CHILD)["branch"]["fromId"], PARENT)
+        self.assertEqual(tl["turns"], {}, "the skeleton still parses nothing")
+
+    def test_an_unforked_lane_carries_no_branch(self):
+        tl = km.build_timeline(self.now, tmux={})
+        self.assertIsNone(self._lane(tl, PARENT)["branch"])
+
+
+class CommentSquares(TimelineLineageBase):
+    def test_threads_ride_their_parent_lane_as_markers(self):
+        km._save_comments(PARENT, {"threads": [
+            {"tid": THREAD, "sid": THREAD, "anchorUuid": "a1", "cutUuid": "a1",
+             "anchorT": self.now - 580, "exact": "exponential backoff", "status": "open",
+             "createdT": self.now - 200, "lastSeenT": self.now},
+            {"tid": "t2", "sid": "t2", "anchorUuid": "a1", "cutUuid": "a1",
+             "exact": "backoff", "status": "resolved",
+             "createdT": self.now - 100, "lastSeenT": self.now},
+            {"tid": "t3", "sid": "t3", "anchorUuid": "a1", "cutUuid": "a1",
+             "exact": "x", "status": "promoted", "promotedName": "sidework",
+             "createdT": self.now - 50, "lastSeenT": self.now}]})
+        tl = km.build_timeline(self.now, tmux={})
+        marks = self._lane(tl, PARENT)["comments"]
+        self.assertEqual([m["tid"] for m in marks], [THREAD, "t2"],
+                         "open + resolved ride the lane; a promoted thread IS a session")
+        self.assertEqual(marks[0]["t"], self.now - 580, "anchorT places the square at the message")
+        self.assertEqual(marks[1]["t"], self.now - 100, "older rows fall back to createdT")
+        self.assertEqual(marks[0]["uuid"], "a1")
+
+    def test_a_lane_with_no_threads_pays_one_stat_and_carries_none(self):
+        tl = km.build_timeline(self.now, tmux={})
+        self.assertEqual(self._lane(tl, CHILD)["comments"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3053,6 +3053,33 @@ class TimelinePanel {
     this._reapWorkLabels(workSeen);        // drop overlay WORKING labels for lanes no longer working / off-screen
     this._reapMetaDots(metaSeen);          // drop switching-dots overlays for lanes whose /model pick has landed / off-screen
 
+    // ── branch connectors (the user 2026-08-14): a fork drawn like a git graph — one thick
+    // perpendicular bar, work-bar weight (BAR_H), from the parent's lane to the child's at the fork
+    // moment, in the CHILD's color: the branch is the child's beginning, and the child's own bars
+    // start here (the kernel clips its copied history while the parent's lane is in the build).
+    // Click → the child's chat at its branch divider; drawn before the message connectors so the
+    // thin lines and their dots stay on top.
+    vis.forEach((s) => {
+      const br = s.branch;
+      if (!br || vidx[br.fromId] == null || vidx[s.id] == null || !inWin(br.t)) return;
+      const bx = x(br.t), y1 = laneY(vidx[br.fromId]), y2 = laneY(vidx[s.id]);
+      if (y1 === y2) return;
+      const bTop = Math.min(y1, y2), bH = Math.abs(y2 - y1);
+      const bbar = el('rect', { x: bx - BAR_H / 2, y: bTop, width: BAR_H, height: bH, rx: BAR_H / 2, fill: s.color, opacity: 0.85 });
+      svg.appendChild(bbar);
+      const bhit = el('rect', { x: bx - 9, y: bTop - 4, width: 18, height: bH + 8, fill: 'transparent' });
+      bhit.style.cursor = 'pointer';
+      const pname = (data.sessions.find((p) => p.id === br.fromId) || {}).name || '';
+      const bHtml = () => '<div class="r"><span class="chip" style="background:' + s.color + '"></span><span class="who" style="color:' + s.color + '">' + esc(s.name) + '</span><span class="t">' + clock(br.t) + '</span></div>' + this.body('branched from ' + pname + ' here');
+      const bEnter = (e) => { bbar.setAttribute('opacity', '1'); this.showTip(bHtml(), e); };
+      bhit.__tlHoverIn = bEnter;
+      bhit.addEventListener('mouseenter', bEnter);
+      bhit.addEventListener('mousemove', (e) => this.moveTip(e));
+      bhit.addEventListener('mouseleave', () => { bbar.setAttribute('opacity', '0.85'); this.hideTip(); });
+      bhit.addEventListener('click', () => { this._select(s.id); this.openChat(s.id, br.cut ? 'branch:' + br.cut : '', false, false, br.t); });
+      svg.appendChild(bhit);
+    });
+
     // obstacles for routing — at each event's process-start (a pending event rides `now` via execAt/startAt)
     const obstacles = [];
     data.messages.forEach((mm) => { if (inWin(execAt(mm)) && vidx[mm.toId] != null) obstacles.push({ x: x(execAt(mm)), lane: vidx[mm.toId] }); });
@@ -3201,6 +3228,32 @@ class TimelinePanel {
           const sz = DOT_R * 1.9;
           svg.appendChild(el('image', { x: dx - sz / 2, y: y - sz / 2, width: sz, height: sz, href: mediaUrl('romp-swirl-glyph.svg'), 'pointer-events': 'none' }));
         }
+      });
+    });
+
+    // ── comment squares (the user 2026-08-14): a comment thread never becomes a lane — a small
+    // SQUARE (against the round message/prompt dots) sits on the lane at the commented message, in
+    // the chat highlight's own yellow, dimmed once resolved. Click → the chat at that message,
+    // where the yellow highlight opens the thread.
+    const CMT_YELLOW = '#ffd54a';            // = styles.css --cmt-hl (the timeline loads no stylesheet)
+    vis.forEach((s, i) => {
+      const y = laneY(i);
+      (s.comments || []).forEach((c) => {
+        if (!c.t || !inWin(c.t)) return;
+        const side = 9, cx = x(c.t);
+        const sq = el('rect', { x: cx - side / 2, y: y - side / 2, width: side, height: side, rx: 1.5,
+          fill: CMT_YELLOW, stroke: '#e8eef5', 'stroke-width': 0.75,
+          opacity: c.status === 'resolved' ? 0.45 : 0.95 });
+        sq.style.cursor = 'pointer';
+        const qHtml = () => '<div class="r"><span class="chip" style="background:' + CMT_YELLOW + '"></span><span class="who" style="color:' + CMT_YELLOW + '">' + esc(s.name) + '</span><span class="t">' + clock(c.t) + '</span></div>' + this.body(c.status === 'resolved' ? 'a resolved comment on this message' : 'a comment on this message — click to open it there');
+        const qGrow = (g) => { sq.setAttribute('width', side + g); sq.setAttribute('height', side + g); sq.setAttribute('x', cx - (side + g) / 2); sq.setAttribute('y', y - (side + g) / 2); };
+        const qEnter = (e) => { qGrow(3); this.showTip(qHtml(), e); };
+        sq.__tlHoverIn = qEnter;
+        sq.addEventListener('mouseenter', qEnter);
+        sq.addEventListener('mousemove', (e) => this.moveTip(e));
+        sq.addEventListener('mouseleave', () => { qGrow(0); this.hideTip(); });
+        sq.addEventListener('click', () => { this._select(s.id); this.openChat(s.id, c.uuid, false, false, c.t); });
+        svg.appendChild(sq);
       });
     });
 

--- a/ui/timeline-lineage.test.ts
+++ b/ui/timeline-lineage.test.ts
@@ -1,0 +1,39 @@
+// Branch lineage on the timeline (the user 2026-08-14). No DOM harness for the SVG draw path, so
+// pin the wiring at the source (the repo convention for romp-timeline-view.js): the thick
+// perpendicular branch connector, the comment squares, and the kernel payload they consume.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the branch connector is a thick perpendicular bar between the two lanes, child-colored", () => {
+  // work-bar weight (BAR_H), spanning parent lane y to child lane y at the fork moment
+  assert.match(SRC, /el\('rect', \{ x: bx - BAR_H \/ 2, y: bTop, width: BAR_H, height: bH, rx: BAR_H \/ 2, fill: s\.color/);
+  // both endpoints vidx-guarded — a hidden/dismissed lane means no connector, never a dangling one
+  assert.match(SRC, /if \(!br \|\| vidx\[br\.fromId\] == null \|\| vidx\[s\.id\] == null \|\| !inWin\(br\.t\)\) return;/);
+  // click → the child's chat at its branch divider (the divider's data-uuid is branch:<cut>)
+  assert.match(SRC, /this\.openChat\(s\.id, br\.cut \? 'branch:' \+ br\.cut : '', false, false, br\.t\)/);
+  // a wide invisible hit target + re-armable hover, like every other timeline glyph
+  assert.match(SRC, /bhit\.__tlHoverIn = bEnter;/);
+});
+
+test("a comment is a SQUARE on the parent's lane in the chat highlight's yellow — never a lane", () => {
+  assert.match(SRC, /const CMT_YELLOW = '#ffd54a';/);
+  assert.match(SRC, /el\('rect', \{ x: cx - side \/ 2, y: y - side \/ 2, width: side, height: side, rx: 1\.5,\s*\n\s*fill: CMT_YELLOW/);
+  assert.match(SRC, /opacity: c\.status === 'resolved' \? 0\.45 : 0\.95/);
+  // click → the chat at the commented message, where the highlight opens the thread
+  assert.match(SRC, /this\.openChat\(s\.id, c\.uuid, false, false, c\.t\)/);
+});
+
+test("the kernel serves lineage per lane and clips the copied history only while the parent shows", () => {
+  assert.match(KERNEL, /"branch": branch_of\.get\(sid\),/);
+  assert.match(KERNEL, /"comments": _comment_markers\(sid\),/);
+  assert.match(KERNEL, /if _psid not in id2name:\s*\n\s*continue/, "parent lane present is the connector AND clip condition");
+  assert.match(KERNEL, /if _bft and \(seg\.get\("end"\) or seg\["t"\]\) <= _bft:\s*\n\s*continue/);
+  assert.match(KERNEL, /def _comment_markers\(sid\):/);
+  // a promoted thread is a session (branch connector), not a square
+  assert.match(KERNEL, /not in \("open", "resolved"\):\s*\n\s*continue/);
+});


### PR DESCRIPTION
The timeline now shows branching the way the chat does, per the three-part ask:

**The branch bar.** A fork draws as one thick perpendicular bar (work-bar weight `BAR_H`, the child session's color) from the parent's lane to the child's at the fork moment — a git-graph split, not the thin message-connector style. Hover names the parent; click opens the child's chat landed on its branch divider (`branch:<cut>`). Both endpoints are `vidx`-guarded, so a hidden or dismissed lane never leaves a dangling bar.

**Lanes start at their branch.** A fork's transcript carries the parent's history verbatim, so its lane used to repeat everything the parent's lane already showed. While the parent's lane is in the same build, the kernel clips the child's copied pre-fork bars and compaction marks; when the parent is gone (ended, aged out of the 12h window, dismissed), the child draws its full history — one session all along.

**Comments are squares, not lanes.** A comment thread rides its parent's lane as a small square in the chat highlight's yellow (dimmed when resolved) at the commented message's time — `anchorT`, stamped at create since #411; older rows fall back to `createdT`. Click jumps to the chat at that message, where the yellow highlight opens the thread. Promoted threads are sessions, so they get the branch bar instead; dead-promoted ones show nothing.

Wire: per-lane `branch`/`comments` ride the `{type:"data"}` skeleton (a dir-mtime-memoized `fork_children()` plus one `exists()` stat per lane — the skeleton still parses no transcripts, pinned by the existing split test); the clip rides the bars build so a rebuild mints a new cached object.

Tests: `tests/test_timeline_lineage.py` (connector endpoint + clip with parent present, whole-story with parent gone, skeleton-carries-lineage-without-parsing, marker statuses/anchorT fallback) and `ui/timeline-lineage.test.ts` source pins. One test-isolation find along the way: a sibling test file dismisses the shared placeholder sid into the module-level durable `_dismissed_lanes` set, which filtered these lanes exactly like a gone parent — the new tests clear it in setUp. Suites green (pytest 4749, node 1987), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)