### PR TITLE
Comment polish: named threads, one landing pulse, whole-math tint, colored squares, rail ticks

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5044,6 +5044,7 @@ def _comments_frame(sid):
         seen = int(th.get("lastSeenT") or 0)
         unread = any(m["who"] == "agent" and m["t"] > seen for m in msgs)
         threads.append({"tid": th.get("tid"), "anchorUuid": th.get("anchorUuid"),
+                        "name": th.get("name") or "",
                         "exact": str(th.get("exact") or "")[:500], "status": status,
                         "createdT": th.get("createdT") or 0, "state": state, "error": err,
                         "unread": unread, "promotedName": th.get("promotedName") or "",
@@ -5070,11 +5071,15 @@ def _comment_markers(sid):
     return out
 
 
-def _comment_create(parent_sid, anchor_uuid, exact, text, now=None):
+def _comment_create(parent_sid, anchor_uuid, exact, text, name="", now=None):
     """Anchor a new comment thread: fork the parent at the highlighted message (inclusive) as a
     threadOf fork — no names/ entry, so no judge seeding is needed until promotion — and send the
     opening message. Returns (error, tid): error is the warn-toast string (tid None), success is
-    (None, the new thread's id) so the client can adopt exactly the thread it created."""
+    (None, the new thread's id) so the client can adopt exactly the thread it created.
+
+    `name` (the user 2026-08-15, who wanted to name the thread right in the dialog): the thread's
+    editable name, defaulting to <parent>-comment-<N> where N counts the threads this session has
+    had. It rides the reg (so a break-out inherits it) and the frame (the popover's title)."""
     be = Sessions.backend_for(parent_sid)
     if not (hasattr(be, "fork") and _sdk_ready()):
         return "threads need the SDK backend; this session runs on tmux, so there is nothing to fork.", None
@@ -5087,6 +5092,9 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, now=None):
     cut, cut_t, err = _comment_cut_target(sess["path"], parent_sid, str(anchor_uuid))
     if err:
         return err, None
+    nm = str(name or "").strip()
+    if nm and not NAME_RE.match(nm):
+        return "thread names use letters, digits, . _ - only.", None
     tsid = str(uuid.uuid4())
     row = {"tid": tsid, "sid": tsid, "anchorUuid": str(anchor_uuid), "cutUuid": cut,
            "anchorT": cut_t,   # the commented message's own time — the timeline square's x
@@ -5094,10 +5102,13 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, now=None):
            "createdT": int(now), "lastSeenT": int(now)}
     with _comments_lock:
         data = _load_comments(parent_sid)
+        if not nm:
+            nm = "%s-comment-%d" % (sess["name"], len(data.get("threads") or []) + 1)
+        row["name"] = nm
         data.setdefault("threads", []).append(row)
         _save_comments(parent_sid, data)
     try:
-        be.fork("thread-" + tsid[:8], parent_sid, cut, sid=tsid, thread_of=parent_sid)
+        be.fork(nm, parent_sid, cut, sid=tsid, thread_of=parent_sid)
         be.connect(tsid)
         be.send(tsid, _comment_first_message(exact, text))
     except Exception as e:
@@ -6111,7 +6122,8 @@ def _drive(msg, client):
         # Anchor a comment thread on a highlighted passage (the user 2026-08-13). LOUD on refusal; on
         # success a commentCreated ack names the new thread (the popover adopts exactly it — never a
         # guess) and the fresh {type:"comments"} frame rides straight back, ahead of the pusher cycle.
-        err, tid = _comment_create(sid, str(msg["uuid"]), str(msg["exact"]), str(msg["text"]))
+        err, tid = _comment_create(sid, str(msg["uuid"]), str(msg["exact"]), str(msg["text"]),
+                                   name=str(msg.get("name") or ""))
         if err:
             client["send"](json.dumps({"type": "warn", "text": err}))
         else:

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -464,6 +464,21 @@ class CommentOps(CommentBase):
         self.assertEqual(row["status"], "open")
         self.assertEqual(row["anchorUuid"], "a1")
 
+    def test_threads_autoname_by_count_and_accept_an_edited_name(self):
+        _, tid1 = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        _, tid2 = km._comment_create(PARENT, "a1", "the cap", "And this?")
+        self.assertEqual(km._comment_thread(PARENT, tid1)["name"], "parent-comment-1")
+        self.assertEqual(km._comment_thread(PARENT, tid2)["name"], "parent-comment-2")
+        self.assertEqual(self.be.calls[0][1], "parent-comment-1",
+                         "the thread's reg wears the name — a break-out inherits it")
+        _, tid3 = km._comment_create(PARENT, "a1", "jitter", "Named.", name="my.question")
+        self.assertEqual(km._comment_thread(PARENT, tid3)["name"], "my.question")
+        err, _ = km._comment_create(PARENT, "a1", "jitter", "Bad.", name="no spaces!")
+        self.assertIn("letters, digits", err)
+        fr = km._comments_frame(PARENT)
+        self.assertEqual(fr["threads"][0]["name"], "parent-comment-1",
+                         "the popover titles threads by name off the frame")
+
     def test_a_refused_cut_leaves_no_thread_row_behind(self):
         err, tid = km._comment_create(PARENT, "missing-uuid", "text", "comment")
         self.assertTrue(err)

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3231,21 +3231,21 @@ class TimelinePanel {
       });
     });
 
-    // ── comment squares (the user 2026-08-14): a comment thread never becomes a lane — a small
-    // SQUARE (against the round message/prompt dots) sits on the lane at the commented message, in
-    // the chat highlight's own yellow, dimmed once resolved. Click → the chat at that message,
-    // where the yellow highlight opens the thread.
-    const CMT_YELLOW = '#ffd54a';            // = styles.css --cmt-hl (the timeline loads no stylesheet)
+    // ── comment squares (the user 2026-08-14): a comment thread never becomes a lane — a SQUARE
+    // (against the round message/prompt dots) sits on the lane at the commented message, in the
+    // SESSION's own color with the same white border and footprint as a message dot (the user
+    // 2026-08-15 — the shape alone says "comment"), dimmed once resolved. Click → the chat at that
+    // message, where the yellow highlight opens the thread.
     vis.forEach((s, i) => {
       const y = laneY(i);
       (s.comments || []).forEach((c) => {
         if (!c.t || !inWin(c.t)) return;
-        const side = 9, cx = x(c.t);
+        const side = DOT_R * 2 - 1, cx = x(c.t);
         const sq = el('rect', { x: cx - side / 2, y: y - side / 2, width: side, height: side, rx: 1.5,
-          fill: CMT_YELLOW, stroke: '#e8eef5', 'stroke-width': 0.75,
+          fill: s.color, stroke: '#e8eef5', 'stroke-width': 0.75,
           opacity: c.status === 'resolved' ? 0.45 : 0.95 });
         sq.style.cursor = 'pointer';
-        const qHtml = () => '<div class="r"><span class="chip" style="background:' + CMT_YELLOW + '"></span><span class="who" style="color:' + CMT_YELLOW + '">' + esc(s.name) + '</span><span class="t">' + clock(c.t) + '</span></div>' + this.body(c.status === 'resolved' ? 'a resolved comment on this message' : 'a comment on this message — click to open it there');
+        const qHtml = () => '<div class="r"><span class="chip" style="background:' + s.color + '"></span><span class="who" style="color:' + s.color + '">' + esc(s.name) + '</span><span class="t">' + clock(c.t) + '</span></div>' + this.body(c.status === 'resolved' ? 'a resolved comment on this message' : 'a comment on this message — click to open it there');
         const qGrow = (g) => { sq.setAttribute('width', side + g); sq.setAttribute('height', side + g); sq.setAttribute('x', cx - (side + g) / 2); sq.setAttribute('y', y - (side + g) / 2); };
         const qEnter = (e) => { qGrow(3); this.showTip(qHtml(), e); };
         sq.__tlHoverIn = qEnter;

--- a/ui/timeline-lineage.test.ts
+++ b/ui/timeline-lineage.test.ts
@@ -20,9 +20,10 @@ test("the branch connector is a thick perpendicular bar between the two lanes, c
   assert.match(SRC, /bhit\.__tlHoverIn = bEnter;/);
 });
 
-test("a comment is a SQUARE on the parent's lane in the chat highlight's yellow — never a lane", () => {
-  assert.match(SRC, /const CMT_YELLOW = '#ffd54a';/);
-  assert.match(SRC, /el\('rect', \{ x: cx - side \/ 2, y: y - side \/ 2, width: side, height: side, rx: 1\.5,\s*\n\s*fill: CMT_YELLOW/);
+test("a comment is a SQUARE on the lane — session-colored, dot-sized, white-bordered, never a lane", () => {
+  // the SHAPE alone says comment (the user 2026-08-15): same footprint + border as a message dot
+  assert.match(SRC, /const side = DOT_R \* 2 - 1, cx = x\(c\.t\);/);
+  assert.match(SRC, /el\('rect', \{ x: cx - side \/ 2, y: y - side \/ 2, width: side, height: side, rx: 1\.5,\s*\n\s*fill: s\.color, stroke: '#e8eef5', 'stroke-width': 0\.75/);
   assert.match(SRC, /opacity: c\.status === 'resolved' \? 0\.45 : 0\.95/);
   // click → the chat at the commented message, where the highlight opens the thread
   assert.match(SRC, /this\.openChat\(s\.id, c\.uuid, false, false, c\.t\)/);

--- a/ui/webview/chat-older-restore.test.ts
+++ b/ui/webview/chat-older-restore.test.ts
@@ -73,8 +73,8 @@ test("scrollToAnchor restores a keep-offset instead of landing on it", () => {
     "the row comes back at its captured offset");
   assert.ok(!/landOn\(/.test(branch), "a restore must NOT top-align + flash the row like a jump");
   // …and the ordinary path still does land properly.
-  assert.match(body, /landTrail\.push\("pointer-exact"\);\s*\n\s*landOn\(target\);/,
-    "a genuine deep-link still lands via landOn");
+  assert.match(body, /landTrail\.push\("pointer-exact"\);\s*\n\s*landOn\(target, uuid\);/,
+    "a genuine deep-link still lands via landOn (uuid = the one-flash-per-navigation key)");
 });
 
 test("a keep-offset restore that misses does not toast the reader 'couldn't locate'", () => {

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -242,6 +242,35 @@ test("the highlight is highlighter-YELLOW — never the selection blue — and o
   assert.match(CSS, /code\.cmt-hl-host > mark\.cmt-hl \{ background: transparent/);
 });
 
+test("the create dialog names the thread right there: prefilled <session>-comment-<N>, validated", () => {
+  assert.match(UI, /nameBox\.value = commentDrafts\.get\(nk\)\s*\n\s*\|\| \(\(sess0\?\.name \|\| "session"\)\.replace\(\/\[\^A-Za-z0-9._-\]\/g, "-"\)\s*\n\s*\+ "-comment-" \+ \(\(commentThreads\.get\(sid\) \|\| \[\]\)\.length \+ 1\)\);/);
+  assert.match(UI, /type: "commentCreate", id: create\.sid, uuid: create\.uuid, exact: create\.exact, text, name: nm/);
+  assert.match(KERNEL, /"%s-comment-%d" % \(sess\["name"\], len\(data\.get\("threads"\) or \[\]\) \+ 1\)/);
+  assert.match(UI, /const base = thName \|\|/, "break-out prefills the thread's own name");
+});
+
+test("the landing pulse fires once per navigation, not once per history-fetch round", () => {
+  assert.match(UI, /let flashedAnchor: string \| null = null;/);
+  assert.match(UI, /if \(flashKey == null \|\| flashKey !== flashedAnchor\)/);
+  assert.match(UI, /landOn\(target, uuid\);/);
+  assert.match(UI, /if \(anchor\) flashedAnchor = null;/);
+});
+
+test("math hosts tint like code hosts — a mark can't paint KaTeX's glyph spacing", () => {
+  assert.match(UI, /closest\(".katex"\)/);
+  assert.match(CSS, /\.md \.katex\.cmt-hl-host \{ background: color-mix\(in srgb, var\(--cmt-hl\) 30%/);
+  assert.match(CSS, /\.md \.katex\.cmt-hl-host mark\.cmt-hl \{ background: transparent/);
+});
+
+test("scroll-rail ticks mark the commented spots and jump-open on click", () => {
+  assert.match(UI, /function updateCommentRail\(\)/);
+  assert.match(UI, /tick\.dataset\.act = "cmtjump"/);
+  assert.match(UI, /cmtjump: \(elx\) =>/);
+  assert.match(UI, /if \(sid === activeId\) updateCommentRail\(\);/);
+  assert.match(CSS, /\.cmt-tick \{/);
+  assert.match(CSS, /\.cmt-rail \{ position: fixed;/);
+});
+
 test("the tint ladder keeps every state distinct: base < unread < hover", () => {
   const base = CSS.match(/mark\.cmt-hl \{[^}]*var\(--cmt-hl\) (\d+)%/s)![1];
   const unread = CSS.match(/mark\.cmt-hl\.unread \{[^}]*var\(--cmt-hl\) (\d+)%/s)![1];

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -9,6 +9,7 @@ export type CommentMsg = { who: "you" | "agent"; text: string; t: number };
 
 export type CommentThread = {
   tid: string;
+  name?: string;              // the thread's editable name (<session>-comment-<N> by default)
   anchorUuid: string;
   exact: string;
   status: "open" | "resolved" | "promoting" | "promoted";

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -454,6 +454,9 @@ let anchorPendingOlder = false; // scrollToAnchor kicked off a loadOlder fetch f
 // around it), then restore it to this y instead of calling landOn. Sticks with pendingAnchor across
 // render-pass retries, like pendingAnchorIntent.
 let pendingAnchorKeepY: number | null = null;
+let flashedAnchor: string | null = null; // the anchor already flashed THIS navigation — a deep anchor
+// re-lands once per older-history fetch round, and each re-land used to pulse again (the user
+// 2026-08-15: "pulsating way too many times"). A NEW navigation (setActive with an anchor) re-arms.
 // Landing diagnostics (the user's ask, 2026-06-10): record HOW each deep-link
 // landing resolved — exact pointer / refused wrong-kind pointer / time-nearby
 // / gave up. The trail is posted to the host (→ ~/.local/state/romp/
@@ -5201,6 +5204,7 @@ function applyCommentMarks(sid: string): void {
   const v = views.get(sid);
   if (!v) return;
   applyBranchChips(sid, v);   // same driver, same hooks: branch chips re-anchor with the marks
+  if (sid === activeId) updateCommentRail();   // and the scroll-rail ticks follow the active view
   const threads = commentThreads.get(sid) || [];
   const have = new Set(threads.map((t) => t.tid));
   for (const old of Array.from(v.el.querySelectorAll("mark.cmt-hl"))) {
@@ -5248,10 +5252,48 @@ function applyBranchChips(sid: string, v: View): void {
   }
 }
 
+/** Yellow ticks on the chat's scroll rail marking commented spots (the user 2026-08-15) — one per
+ *  open/resolved thread of the ACTIVE session, placed by the anchor's position in the event list
+ *  (windowing-proof: no DOM measurement of unrendered turns), clicking jumps there and opens the
+ *  thread. A fixed strip over #content's right edge, rebuilt with the marks — a handful of ticks. */
+function updateCommentRail(): void {
+  let rail = document.getElementById("cmt-rail");
+  const content = document.getElementById("content");
+  const s = activeId ? sessions.get(activeId) : null;
+  const threads = ((activeId && commentThreads.get(activeId)) || [])
+    .filter((t) => t.status === "open" || t.status === "resolved");
+  if (!content || !s || !threads.length) { rail?.remove(); return; }
+  const r = content.getBoundingClientRect();
+  if (!r.height) { rail?.remove(); return; }              // hidden pane
+  if (!rail) { rail = el("div", "cmt-rail"); rail.id = "cmt-rail"; document.body.appendChild(rail); }
+  rail.style.left = (r.right - 10) + "px";
+  rail.style.top = r.top + "px";
+  rail.style.height = r.height + "px";
+  rail.replaceChildren();
+  const n = s.events.length || 1;
+  for (const th of threads) {
+    const idx = s.events.findIndex((e) => e.uuid === th.anchorUuid);
+    if (idx < 0) continue;
+    const tick = el("button", "cmt-tick" + (th.status === "resolved" ? " resolved" : "")
+      + (th.unread && th.status === "open" ? " unread" : "")) as HTMLButtonElement;
+    tick.type = "button";
+    tick.dataset.act = "cmtjump";
+    tick.dataset.tid = th.tid;
+    tick.dataset.uuid = th.anchorUuid;
+    tick.style.top = Math.min(96.5, (idx / n) * 100) + "%";
+    tick.title = (th.name || "comment") + ": click to jump to it";
+    rail.appendChild(tick);
+  }
+}
+window.addEventListener("resize", () => updateCommentRail());
+
 function unwrapCommentMark(markEl: HTMLElement): void {
   const p = markEl.parentNode;
   if (!p) return;
-  if (p instanceof Element) p.classList.remove("cmt-hl-host");   // an inline-code span it tinted
+  if (p instanceof Element) {
+    p.classList.remove("cmt-hl-host");                             // an inline-code span it tinted
+    (p.closest(".katex.cmt-hl-host") as HTMLElement | null)?.classList.remove("cmt-hl-host");   // or the math block
+  }
   while (markEl.firstChild) p.insertBefore(markEl.firstChild, markEl);
   markEl.remove();
   p.normalize();
@@ -5309,11 +5351,16 @@ function ensureCommentMark(turn: HTMLElement, th: CommentThread): void {
     styleCommentMark(segs[i], th);
     segs[i].classList.toggle("hl-first", i === 0);
     segs[i].classList.toggle("hl-last", i === segs.length - 1);
+    // hosts a mark can't paint from inside: an inline-code span's padding, and KaTeX's inter-glyph
+    // spacing (the user 2026-08-15, screenshot: math highlighted with gaps punched at every glyph
+    // box) — tint the ELEMENT instead; resolved threads drop the tint like the marks dim
     const host = segs[i].parentElement;
     if (host && host.tagName === "CODE" && host.parentElement?.tagName !== "PRE"
         && host.childNodes.length === 1) {
-      host.classList.toggle("cmt-hl-host", th.status !== "resolved");   // resolved dims like the marks
+      host.classList.toggle("cmt-hl-host", th.status !== "resolved");
     }
+    const kat = segs[i].parentElement?.closest(".katex") as HTMLElement | null;
+    if (kat) kat.classList.toggle("cmt-hl-host", th.status !== "resolved");
   }
 }
 
@@ -5350,6 +5397,7 @@ function openCommentPopover(sid: string, tid: string, x?: number, y?: number): v
 function adoptCommentThread(sid: string, tid: string): void {
   if (pendingCommentAnchor && pendingCommentAnchor.sid === sid) {
     commentDrafts.delete("new:" + pendingCommentAnchor.uuid);
+    commentDrafts.delete("newname:" + pendingCommentAnchor.uuid);
     pendingCommentAnchor = null;
   }
   pendingAdoptTid = null;
@@ -5408,10 +5456,11 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
 }
 
 function commentPopTitle(create: boolean, th: CommentThread | null | undefined): string {
+  const nm = th?.name || "Thread";
   return create ? "New thread"
     : th!.status === "promoted" ? "Now its own session: " + th!.promotedName
     : th!.status === "promoting" ? "Breaking out…"
-    : th!.status === "resolved" ? "Thread (resolved)" : "Thread";
+    : th!.status === "resolved" ? nm + " (resolved)" : nm;
 }
 
 /** Send the popover composer's text — the Enter key and the delegated Send button share this. The
@@ -5423,9 +5472,12 @@ function commentSendFromPop(pop: HTMLElement): void {
   if (!box || !text || !vscodeApi) return;
   const create = pendingCommentAnchor;
   if (create) {
+    const nameBox = pop.querySelector(".cmt-name") as HTMLInputElement | null;
+    const nm = (nameBox?.value || "").trim();
+    if (nm && !/^[A-Za-z0-9._-]+$/.test(nm)) { nameBox?.classList.add("bad"); nameBox?.focus(); return; }
     if (send) { send.disabled = true; send.textContent = "Starting…"; }   // ack before the round-trip;
     //                                       the draft survives until commentCreated adopts the thread
-    vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact, text });
+    vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact, text, name: nm });
     return;
   }
   const cur = openCommentThread();
@@ -5518,6 +5570,24 @@ function renderCommentPopover(): void {
     fillCommentMsgs(list, th);
     pop.appendChild(list);
   }
+  if (create) {
+    // the thread's NAME, editable right here (the user 2026-08-15): prefilled
+    // <session>-comment-<N>, N counting the threads this session has had; an edited value
+    // drafts under its own key so a refused create hands it back too
+    const nk = "newname:" + create.uuid;
+    const nameBox = document.createElement("input");
+    nameBox.type = "text";
+    nameBox.className = "cmt-name";
+    nameBox.setAttribute("autocapitalize", "off");
+    nameBox.setAttribute("autocomplete", "off");
+    nameBox.setAttribute("spellcheck", "false");
+    const sess0 = sessions.get(sid);
+    nameBox.value = commentDrafts.get(nk)
+      || ((sess0?.name || "session").replace(/[^A-Za-z0-9._-]/g, "-")
+          + "-comment-" + ((commentThreads.get(sid) || []).length + 1));
+    nameBox.addEventListener("input", () => { nameBox.classList.remove("bad"); commentDrafts.set(nk, nameBox.value); });
+    pop.appendChild(nameBox);
+  }
   if (create || th!.status !== "promoted") {
     const dk = create ? "new:" + create.uuid : th!.tid;
     const box = document.createElement("textarea");
@@ -5590,7 +5660,8 @@ function renderCommentPopover(): void {
 // flips to "promoted" on the next comments frame.
 function showBreakoutPrompt(sid: string, tid: string): void {
   const sess = sessions.get(sid);
-  const base = (sess?.name || "session").replace(/[^A-Za-z0-9._-]/g, "-");
+  const thName = (commentThreads.get(sid) || []).find((t) => t.tid === tid)?.name || "";
+  const base = thName || ((sess?.name || "session").replace(/[^A-Za-z0-9._-]/g, "-") + "-thread");
   document.getElementById("fork-prompt")?.remove();
   const overlay = el("div", "picker-overlay confirm-overlay");
   overlay.id = "fork-prompt";
@@ -5602,7 +5673,7 @@ function showBreakoutPrompt(sid: string, tid: string): void {
   const input = document.createElement("input");
   input.type = "text";
   input.className = "fork-name";
-  input.value = base + "-thread";
+  input.value = base;
   input.setAttribute("autocapitalize", "off");
   input.setAttribute("autocomplete", "off");
   input.setAttribute("autocorrect", "off");
@@ -6050,7 +6121,7 @@ function scrollToAnchor(uuid: string): boolean {
     return true;
   }
   landTrail.push("pointer-exact");
-  landOn(target);
+  landOn(target, uuid);
   return true;
 }
 
@@ -6064,11 +6135,14 @@ function scrollToAnchor(uuid: string): boolean {
 // off its mark. So: re-align whenever the bar/ledger actually resizes, plus two
 // timed retries for late layout (images, markdown), for ~1.2s — canceled the
 // moment the user wheel-scrolls so we never fight a real gesture.
-function landOn(target: HTMLElement) {
+function landOn(target: HTMLElement, flashKey?: string) {
   const realign = () => target.scrollIntoView({ block: "start", behavior: "auto" });
   realign();
-  target.classList.add("anchor-flash");
-  setTimeout(() => target.classList.remove("anchor-flash"), 1700);
+  if (flashKey == null || flashKey !== flashedAnchor) {   // one flash per navigation (see flashedAnchor)
+    if (flashKey != null) flashedAnchor = flashKey;
+    target.classList.add("anchor-flash");
+    setTimeout(() => target.classList.remove("anchor-flash"), 1700);
+  }
   const until = Date.now() + 1200;
   let ro: ResizeObserver | null = null;
   const stop = () => { ro?.disconnect(); ro = null; window.removeEventListener("wheel", stop); };
@@ -8783,6 +8857,7 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
     persistDrafts();   // the leaving tab's draft was just stashed → keep the persisted copy in sync
   }
   pendingAnchor = anchor ?? null;
+  if (anchor) flashedAnchor = null;        // a fresh navigation re-arms the one-per-navigation flash
   pendingAnchorIntent = anchor ? (anchorKind ?? null) : null;
   activeId = id;
   try { vscodeApi?.setState?.({ ...(vscodeApi.getState?.() || {}), activeId: id }); } catch { /* ignore */ }
@@ -9032,6 +9107,7 @@ function chatHead(msg: any) {
   // the click somewhere the user never named.
   if (anchorUuid && !pendingAnchor) {
     pendingAnchor = anchorUuid; pendingAnchorIntent = null; pendingAnchorT = null; pendingAnchorKind = null;
+    flashedAnchor = null;                  // ditto: this path is also a user navigation
     pendingAnchorKeepY = keepY ?? null;
   }
   showActive();
@@ -10190,6 +10266,16 @@ setupSettings();
       openCommentPopover(activeId, tid, Math.min(r.left, window.innerWidth - 380), r.bottom + 6);
     },
     cmtclose: () => closeCommentPop(),
+    // a scroll-rail tick: jump the chat to the commented message (fresh navigation → one flash)
+    // and open its thread beside it
+    cmtjump: (elx) => {
+      const tid = elx.dataset.tid, uuid = elx.dataset.uuid;
+      if (!tid || !uuid || !activeId) return;
+      flashedAnchor = null;
+      scrollToAnchor(uuid);
+      const r = elx.getBoundingClientRect();
+      openCommentPopover(activeId, tid, Math.max(8, r.left - 380), Math.max(60, r.top - 40));
+    },
     cmtsend: (elx) => {
       const pop = elx.closest(".cmt-pop") as HTMLElement | null;
       if (pop) commentSendFromPop(pop);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2480,3 +2480,31 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
   cursor: pointer; opacity: 0.75; white-space: nowrap;
 }
 .branch-chip:hover { opacity: 1; border-color: var(--accent); }
+
+/* the create popover's thread-name row (the user 2026-08-15): editable, prefilled
+   <session>-comment-<N>; .bad = failed the session-name charset, matching the fork modal */
+.cmt-name {
+  width: 100%; box-sizing: border-box; padding: 4px 7px;
+  border: 1px solid var(--box-border); border-radius: 4px;
+  background: rgba(255, 255, 255, 0.05); color: inherit; font: inherit;
+}
+.cmt-name:focus { outline: none; border-color: var(--accent); }
+.cmt-name.bad { border-color: var(--st-blocked-bg, #c94f4f); }
+
+/* comment ticks on the chat's scroll rail (the user 2026-08-15): where the comments are, at the
+   anchor's proportional position in the whole conversation; click = jump + open the thread */
+.cmt-rail { position: fixed; width: 10px; z-index: 40; pointer-events: none; }
+.cmt-tick {
+  position: absolute; right: 1px; width: 8px; height: 4px;
+  border: 0; border-radius: 2px; padding: 0;
+  background: var(--cmt-hl); opacity: 0.75; pointer-events: auto; cursor: pointer;
+}
+.cmt-tick:hover { opacity: 1; }
+.cmt-tick.resolved { opacity: 0.3; }
+.cmt-tick.unread { box-shadow: 0 0 0 1.5px color-mix(in srgb, var(--cmt-hl) 60%, transparent); opacity: 1; }
+
+/* a fully-covered KaTeX block tints at the ELEMENT (cmt-hl-host, same contract as inline code):
+   a mark inside it cannot paint the glyph boxes' spacing, which punched gaps through highlighted
+   math (the user 2026-08-15) */
+.md .katex.cmt-hl-host { background: color-mix(in srgb, var(--cmt-hl) 30%, transparent); border-radius: 3px; }
+.md .katex.cmt-hl-host mark.cmt-hl { background: transparent; }


### PR DESCRIPTION
Five refinements from live use of comment threads and the timeline lineage:

- **Name the thread right in the dialog.** The create popover gains an editable name field prefilled `<session>-comment-<N>` (N counts the threads that session has had), validated with the session-name charset both client- and kernel-side. The name rides the thread's reg (so Break out prefills it), titles the popover, and labels the rail tick.
- **One landing pulse.** A deep anchor re-lands once per older-history fetch round, and each re-land re-triggered the anchor flash — "pulsating way too many times". `flashedAnchor` now latches one flash per navigation, re-armed by the next anchor-carrying navigation (a fresh click flashes again).
- **Math highlights without gaps.** A mark inside KaTeX can't paint the glyph boxes' spacing, so highlighted formulas showed unpainted slivers at every box (screenshot). `.katex` joins the `cmt-hl-host` element-tint contract inline code already uses; interior marks go transparent; resolved threads drop the tint.
- **Timeline squares in the session's color.** Same footprint as a message dot (`DOT_R*2-1`), same white border, session-colored — the square shape alone marks it as a comment; yellow remains the in-chat highlight color.
- **Scroll-rail ticks.** A fixed strip over the chat's right edge shows one yellow tick per open/resolved thread, placed by the anchor's index in the event list (windowing-proof, no DOM measurement of unrendered turns); unread ticks ring, resolved dim. Clicking jumps to the message (single flash) and opens the thread beside it, through the existing delegated actions.

Tests: kernel naming (auto-numbering, custom name, charset refusal, frame carries name), updated timeline pins (color/size), new pins for the flash latch, math host, rail; one existing keep-offset pin updated for `landOn`'s new flash-key parameter. Suites green (pytest 4756, node 1991), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)