### PR TITLE
Remote kernels' sync outcomes reach the local Log; update banners stack

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -22539,7 +22539,10 @@ def _update_block():
 # back to the prompt with no feedback, so a push looked like it did nothing). Dismiss suppresses only the
 # CURRENT stale set — a newly-drifted host re-prompts.
 _RDRIFT_CSS = (
-    "#rdrift{position:fixed;top:60px;left:50%;transform:translateX(-50%);z-index:99998;display:none;"
+    # top:104px stacks BELOW #rupd (top:56px), which stacks below #rstale (top:14px): the three banners
+# used to overlap at 56/60px when a self-update offer and a remote-drift ask were both live (the user
+# 2026-08-15, whose screenshot showed exactly that pileup) — three claims, three targets, one spot.
+    "#rdrift{position:fixed;top:104px;left:50%;transform:translateX(-50%);z-index:99998;display:none;"
     "align-items:center;gap:10px;max-width:92vw;background:#2b2d30;border:1px solid #4a4d51;"
     "border-radius:10px;padding:10px 14px;color:#e6e6e6;box-shadow:0 10px 30px #0000008a;"
     "font:13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}"

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -308,9 +308,21 @@ export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly s
   // dismissed/undo chrome spans hosts: the count SUMS and undo is possible when ANY kernel can undo —
   // clearing a remote card must light the local Undo button (the clear routed to that kernel).
   let dismissed = 0, anyDismissed = false, canUndo = false;
+  // remote kernels' automatic-sync outcomes (self-updates, pushes, pulls) reach the local Log too
+  // (the user 2026-08-15: a devbox updating itself all day left no trace on the laptop dashboard —
+  // mergeHostFeeds kept only the local host's scalar chrome, dropping remote syncNotices on the
+  // floor). Remote rows are host-prefixed like every other remote surface; the SIG is host-scoped so
+  // two kernels' ring sequences can never collide in the seen-set.
+  const syncs: any[] = [];
   for (const h of hostSeq) {
     const f = perHost[h];
     if (!f) continue;
+    if (Array.isArray(f.syncNotices)) {
+      for (const r of f.syncNotices) {
+        if (!r || !r.sig) continue;
+        syncs.push(h === LOCAL ? r : { ...r, sig: h + "|" + r.sig, text: h + ": " + (r.text || "") });
+      }
+    }
     if (Array.isArray(f.items)) merged.items.push(...f.items);
     if (Array.isArray(f.asks)) merged.asks.push(...f.asks);
     if (Array.isArray(f.working)) merged.working.push(...f.working);
@@ -331,6 +343,8 @@ export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly s
   else delete merged.ledgers;
   if (anyDismissed) merged.dismissedCount = dismissed;
   if ("canUndoClear" in merged || canUndo) merged.canUndoClear = canUndo;
+  if (syncs.length) merged.syncNotices = syncs;
+  else delete merged.syncNotices;
   return merged;
 }
 

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -194,6 +194,24 @@ test("mergeHostOrder: never re-sorts within a host (kernel order is authoritativ
   assert.deepEqual(merged, ["gpu1:" + U, "gpu1:" + V]);
 });
 
+test("mergeHostFeeds: remote syncNotices reach the local Log, host-prefixed and sig-scoped", () => {
+  // the user 2026-08-15: a devbox updating itself all day left no trace on the laptop dashboard —
+  // the merge kept only local chrome and dropped remote kernels' sync outcomes on the floor.
+  const perHost = {
+    "": { type: "feed", items: [], asks: [], working: [],
+          syncNotices: [{ sig: "b1|3", t: 10, text: "updated to abc123", ok: true }] },
+    TESTHOST: { type: "feed", items: [], asks: [], working: [],
+             syncNotices: [{ sig: "b2|7", t: 11, text: "pulled and restarted", ok: true }] },
+  };
+  const m = mergeHostFeeds(perHost, ["", "TESTHOST"]);
+  assert.deepEqual(m.syncNotices, [
+    { sig: "b1|3", t: 10, text: "updated to abc123", ok: true },
+    { sig: "TESTHOST|b2|7", t: 11, text: "TESTHOST: pulled and restarted", ok: true },
+  ], "local rows verbatim; remote rows host-prefixed in text and sig-scoped per host");
+  const none = mergeHostFeeds({ "": { type: "feed", items: [], asks: [], working: [] } }, [""]);
+  assert.ok(!("syncNotices" in none), "no rows anywhere → the key stays absent, like the single-kernel path");
+});
+
 test("mergeHostFeeds: concatenates items/asks/working across hosts (local first), keeps local chrome", () => {
   // Regression: without a merge, the local + remote feed snapshots (each pushed ~2s) clobber each other and
   // the feed visibly flips back and forth. mergeHostFeeds combines them into one stable snapshot.


### PR DESCRIPTION
Second slice of the update-notice consolidation:

- `mergeHostFeeds` kept only the local host's scalar chrome, dropping remote kernels' `syncNotices` — a devbox updating itself all day (`update-mode: auto`) left no trace on the laptop dashboard. Remote rows now merge **host-prefixed** in text and **host-scoped** in sig; local rows verbatim; no rows anywhere keeps the key absent like the single-kernel path.
- `#rdrift` (top:60px) overlapped `#rupd` (top:56px) when a self-update offer and a remote-drift ask were both live — the screenshot pileup. It now stacks at top:104px below the other two.

Tests: a `mergeHostFeeds` sync-notice case in `multi-kernel-merge.test.ts`; suites green (4747 py + 1988 ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)