### PR TITLE
Staged messages: compose against each highlight, release the whole run with one send

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20859,9 +20859,10 @@ def _chat_body():
             # web dashboard's skeleton — when only the extension skeleton grew the div, a file dropped on
             # the web surface attached invisibly, showing nothing at all (the user 2026-08-04)
             '<div id="composer"><div id="composer-files" style="display:none"></div>'
+            '<div id="composer-staged" style="display:none"></div>'  # staged-message strip: held until the next send (the user 2026-08-15; NOT the queue — see render.ts)
             '<div id="composer-chips" style="display:none"></div>'   # click-to-cite chip strip (the user 2026-07-01)
             '<textarea id="composer-input" rows="1" '
-            'placeholder="Message this session…"></textarea>'
+            'placeholder="Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage)"></textarea>'
             '<button id="composer-attach" title="Attach a file">'
             '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" '
             'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'

--- a/ui/webview/composer-citation.test.ts
+++ b/ui/webview/composer-citation.test.ts
@@ -54,9 +54,12 @@ test("Backspace at the start of the box deletes the citation like a character", 
 });
 
 test("sending with a GOAL citation routes as an askFollowUp (reopen) and consumes the chip", () => {
+  // the three routing branches live in routeUserMessage since the staged flush (2026-08-15) — ONE
+  // owner for the live send and the staged release; deliver feeds it activeId as the sid
   assert.match(RENDER, /const cites = composerCitations\.get\(activeId\);/);
-  assert.match(RENDER, /if \(goalCite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid: activeId \}\);/);
-  assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: activeId, text \}\); registerOptimistic\(activeId, text\); \}/);
+  assert.match(RENDER, /routeUserMessage\(activeId, text, cites\);/);
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\);/);
+  assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text \}\); registerOptimistic\(sid, text\); \}/);
   assert.match(RENDER, /if \(cites\) \{ composerCitations\.delete\(activeId\); renderComposerChips\(activeId\); \}/);
 });
 
@@ -68,7 +71,8 @@ test("a citation follow-up carries its SID, so a reply to a REMOTE card reaches 
   // sid from the itemId, owns no such session, and hands it to tmux by uuid — dropped in silence. The card
   // still flashed to Working (the kernel's cardPredict fires before any of that) and snapped back on the
   // ok:false ack, so the only visible trace was a bounce.
-  assert.match(RENDER, /if \(goalCite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid: activeId \}\);/);
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\);/);
+  assert.match(RENDER, /routeUserMessage\(activeId, text, cites\);/);   // deliver's sid IS the active session
   // every OTHER card-addressed op already routes this way — the citation follow-up was the lone omission
   assert.match(FEED, /type: "askClear", itemId: it\.itemId, sid: it\.sid/);
   assert.match(FEED, /type: "askFollowUp", itemId: tgt \? tgt\.itemId : fbId, title: tgt \? tgt\.title : fbTitle, text: txt, sid: fbSid/);
@@ -193,8 +197,8 @@ test("closing a session clears its composer reply context — chip, draft, and e
 });
 
 test("quote chips send a plain message wrapped by quoteReplyBody — never askFollowUp (no goal to reopen)", () => {
-  assert.match(RENDER, /if \(goalCite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid: activeId \}\);/);
-  assert.match(RENDER, /else if \(quoteCites\.length\) vscodeApi\.postMessage\(\{ type: "sendMessage", id: activeId, text: quoteReplyBody\(quoteCites, text\) \}\);/);
+  assert.match(RENDER, /if \(goalCite\?\.itemId\) vscodeApi\.postMessage\(\{ type: "askFollowUp", itemId: goalCite\.itemId, text, sid \}\);/);
+  assert.match(RENDER, /else if \(quoteCites\.length\) vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text: quoteReplyBody\(quoteCites, text\) \}\);/);
   // the wrap: one section per stacked chip (lead-in + the highlighted text as a markdown quote block), in
   // strip order, then the typed message — a single chip composes byte-identically to the pre-stack form
   assert.match(RENDER, /return sections\.join\("\\n\\n"\) \+ "\\n\\n" \+ text;/);

--- a/ui/webview/composer-draft-persist.test.ts
+++ b/ui/webview/composer-draft-persist.test.ts
@@ -11,8 +11,9 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
 test("drafts are persisted to and reloaded from the webview's saved state", () => {
-  // persist: mirror the Map into setState, alongside (not replacing) whatever else is saved — plus citations
-  assert.match(RENDER, /function persistDrafts\(\): void \{[\s\S]*setState\?\.\(\{ \.\.\.\(vscodeApi\.getState\?\.\(\) \|\| \{\}\), drafts: Object\.fromEntries\(drafts\),[\s\S]*citations: Object\.fromEntries\(composerCitations\),[\s\S]*files: Object\.fromEntries\(composerFiles\) \}\)/);
+  // persist: mirror the Map into setState, alongside (not replacing) whatever else is saved — plus
+  // citations, files, and the staged stack (2026-08-15)
+  assert.match(RENDER, /function persistDrafts\(\): void \{[\s\S]*setState\?\.\(\{ \.\.\.\(vscodeApi\.getState\?\.\(\) \|\| \{\}\), drafts: Object\.fromEntries\(drafts\),[\s\S]*citations: Object\.fromEntries\(composerCitations\),[\s\S]*files: Object\.fromEntries\(composerFiles\),[\s\S]*staged: stagedMsgs\.entries\(\) \}\)/);
   // reload: hydrate the Map from saved state at startup (string values only)
   assert.match(RENDER, /const saved = \(\(vscodeApi\?\.getState\?\.\(\) \|\| \{\}\) as any\)\.drafts;/);
   assert.match(RENDER, /for \(const \[k, v\] of Object\.entries\(saved\)\) if \(typeof v === "string"\) drafts\.set\(k, v\);/);

--- a/ui/webview/composer-files.test.ts
+++ b/ui/webview/composer-files.test.ts
@@ -17,11 +17,13 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 const SKELETON = fs.readFileSync(path.resolve(process.cwd(), "src", "page-skeleton.ts"), "utf8");
 
 test("the composer has an attachment strip, its own row above the chips — on BOTH skeletons", () => {
-  assert.match(SKELETON, /<div id="composer-files" style="display:none"><\/div><div id="composer-chips"/);
+  assert.match(SKELETON, /<div id="composer-files" style="display:none"><\/div><div id="composer-staged" style="display:none"><\/div><div id="composer-chips"/);
   // the WEB dashboard's page skeleton is the kernel's own HTML, not page-skeleton.ts — when only the
   // extension skeleton grew this div, a file dropped on the web surface attached invisibly, showing
-  // nothing at all (the user 2026-08-04). The two skeletons must carry the strip in step.
+  // nothing at all (the user 2026-08-04). The two skeletons must carry the strip in step — and the
+  // staged strip (2026-08-15) sits between files and chips on both.
   assert.match(KERNEL, /<div id="composer"><div id="composer-files" style="display:none"><\/div>'/);
+  assert.match(KERNEL, /<div id="composer-staged" style="display:none"><\/div>'/);
   assert.match(KERNEL, /<div id="composer-chips" style="display:none"><\/div>'/);
   assert.match(CSS, /#composer-files \{ flex: 1 1 100%; display: flex; flex-wrap: wrap/);
   assert.match(CSS, /\.composer-file-img \{ display: block; height: 46px/);
@@ -76,11 +78,12 @@ test("attachments ride the send as a trailing line of paths, quoted when they ho
 });
 
 test("attachments live the DRAFT lifecycle: switch, reload, close", () => {
-  // persisted beside drafts/citations, restored as a list of strings
-  assert.match(RENDER, /files: Object\.fromEntries\(composerFiles\) \}\);/);
+  // persisted beside drafts/citations/staged, restored as a list of strings
+  assert.match(RENDER, /files: Object\.fromEntries\(composerFiles\),/);
   assert.match(RENDER, /const savedFiles = \(\(vscodeApi\?\.getState\?\.\(\) \|\| \{\}\) as any\)\.files;/);
-  // a tab switch REPAINTS the strip (unlike citations, which the switch abandons)
-  assert.match(RENDER, /renderComposerChips\(id\);   \/\/ the entering tab's own citation chip \(if any\)\s*\n\s*renderComposerFiles\(id\);/);
+  // a tab switch REPAINTS the strip (unlike citations, which the switch abandons); the staged
+  // strip (2026-08-15) repaints in the same breath, between the chips and the files
+  assert.match(RENDER, /renderComposerChips\(id\);   \/\/ the entering tab's own citation chip \(if any\)\s*\n\s*renderStagedStrip\(id\);[^\n]*\n\s*renderComposerFiles\(id\);/);
   // the post-reload restore paints it once the active tab is known
   assert.match(RENDER, /renderComposerFiles\(activeId\);   \/\/ attachments persisted across the reload/);
   // closing a session drops its attachments with its draft, and repaints for the new active tab

--- a/ui/webview/composer-send.test.ts
+++ b/ui/webview/composer-send.test.ts
@@ -18,7 +18,7 @@ test("the composer markup includes a send button to the right of 📎", () => {
 
 test("⏎ and the send button share ONE sendComposer() path", () => {
   assert.match(RENDER, /const sendComposer = \(\) => \{/);
-  assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "sendMessage", id: activeId, text \}\)/);
+  assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text \}\)/);   // routeUserMessage — one routing owner since the staged flush (2026-08-15)
   // Enter calls it (desktop only — the mobile guard is asserted separately below)
   assert.match(RENDER, /if \(e\.key === "Enter" && !e\.shiftKey && !isCoarsePointer\(\)\) \{\s*e\.preventDefault\(\);\s*sendComposer\(\);/);
   // the button calls it (mousedown keeps textarea focus on desktop; on a phone it blurs so the keyboard

--- a/ui/webview/optimistic-send.test.ts
+++ b/ui/webview/optimistic-send.test.ts
@@ -23,8 +23,9 @@ const RENDER = fs.readFileSync(
   path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
 test("the plain send registers an optimistic bubble; follow-up/quote sends keep their own kernel echo", () => {
-  // only the PLAIN sendMessage branch registers — a citation follow-up/quote has its own kernel-side echo
-  assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: activeId, text \}\); registerOptimistic\(activeId, text\); \}/);
+  // only the PLAIN sendMessage branch registers — a citation follow-up/quote has its own kernel-side
+  // echo (the branch lives in routeUserMessage since the staged flush, 2026-08-15)
+  assert.match(RENDER, /else \{ vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text \}\); registerOptimistic\(sid, text\); \}/);
   // registerOptimistic shows it NOW (before any push) via reconcile + appendActive
   assert.match(RENDER, /function registerOptimistic\(id: string, text: string\): void/);
   assert.match(RENDER, /if \(v\) v\.stale = true;\s*\n\s*if \(id === activeId\) \{\s*\n\s*appendActive\(\);/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -25,6 +25,7 @@ import { writeViewOrder } from "./view-order";
 import { titleWithKey, chordOf, effectiveChord, loadOverrides } from "./keybindings";
 import { DEFAULT_CHORDS } from "./commands";
 import { NavHistory } from "./nav-history";
+import { StagedStack } from "./staged-messages";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional } from "./provisional";
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
@@ -8330,7 +8331,8 @@ function persistDrafts(): void {
   try {
     vscodeApi?.setState?.({ ...(vscodeApi.getState?.() || {}), drafts: Object.fromEntries(drafts),
                             citations: Object.fromEntries(composerCitations),
-                            files: Object.fromEntries(composerFiles) });
+                            files: Object.fromEntries(composerFiles),
+                            staged: stagedMsgs.entries() });
   } catch { /* ignore */ }
 }
 try {
@@ -8362,6 +8364,78 @@ try {
 // then sends a rewindSend (branch from just before that message) instead of a plain message. The chip
 // strip shows an "Editing message" pill whose ✕ (or Esc in the box) cancels back to normal sending.
 const composerEdits = new Map<string, { uuid: string; orig: string }>();
+
+// STAGED messages (the user 2026-08-15): compose against a highlight, ⌘/Ctrl+⏎ to HOLD it — citation
+// chips and all — clear the box and keep reading; repeat. Nothing sends until the next plain send
+// (the stack flushes first, in stage order, the typed message last) or the strip's Send now.
+// Deliberately NOT the queue and never called "queued": queued is romp's injection-side wait (sent,
+// pending injection); staged is user-side — unsent by choice, each message keeping the context it was
+// written against so the batch reads as quote → comment, quote → comment. Per-tab, persisted with the
+// drafts (a reload or tab switch never drops a stack). The pure stack rules live in staged-messages.ts,
+// executed by its test; this file owns the strip DOM and the send routing.
+const stagedMsgs = new StagedStack();
+try { stagedMsgs.restore(((vscodeApi?.getState?.() || {}) as any).staged); } catch { /* ignore */ }
+
+// One routing owner for a user message (the deliver path and the staged flush both speak it): a goal
+// chip rides askFollowUp, quote chips wrap client-side, a bare message is a plain send with the
+// optimistic bubble (chip sends have their own kernel-side echo).
+function routeUserMessage(sid: string, text: string, cites: Citation[] | undefined): void {
+  if (!vscodeApi) return;
+  const goalCite = cites?.find((c) => c.itemId);
+  const quoteCites = cites ? cites.filter((c) => c.quote) : [];
+  if (goalCite?.itemId) vscodeApi.postMessage({ type: "askFollowUp", itemId: goalCite.itemId, text, sid });
+  else if (quoteCites.length) vscodeApi.postMessage({ type: "sendMessage", id: sid, text: quoteReplyBody(quoteCites, text) });
+  else { vscodeApi.postMessage({ type: "sendMessage", id: sid, text }); registerOptimistic(sid, text); }
+}
+
+/** Release the tab's staged stack (deliver's guards — host down, provisional — run before this in the
+ *  send path; Send now re-checks reachability itself). Returns how many went. */
+function flushStaged(sid: string): number {
+  const batch = stagedMsgs.takeAll(sid);
+  for (const s of batch) routeUserMessage(sid, s.text, s.cites as Citation[]);
+  if (batch.length) { persistDrafts(); renderStagedStrip(sid); }
+  return batch.length;
+}
+
+function renderStagedStrip(id: string | null): void {
+  const strip = document.getElementById("composer-staged");
+  if (!strip) return;
+  strip.replaceChildren();
+  const list = id ? stagedMsgs.list(id) : [];
+  if (!id || !list.length) { strip.style.display = "none"; return; }
+  strip.style.display = "flex";
+  const head = el("div", "staged-head");
+  const lbl = el("span");
+  lbl.textContent = list.length + " staged — sends with your next message";
+  lbl.title = "⌘⏎ (or Ctrl+⏎) stages what you've typed, quote chips and all, without sending. "
+    + "A plain send releases them in order with your new message last — or Send now releases them alone.";
+  const go = el("button", "staged-go");
+  go.textContent = "Send now";
+  go.addEventListener("click", () => {
+    if (!id) return;
+    if (hostIsDown(id) || isProvisionalId(id)) {
+      warnToast("Can't send yet — the session isn't reachable. They stay staged.");
+      return;
+    }
+    flushStaged(id);
+  });
+  head.append(lbl, go);
+  strip.appendChild(head);
+  list.forEach((s, i) => {
+    const chip = el("div", "staged-chip");
+    chip.title = s.text;
+    const mark = el("span", "composer-chip-mark");
+    mark.textContent = (s.cites as Citation[]).some((c) => c && c.quote) ? "“" : "•";
+    const label = el("span", "composer-chip-label");
+    label.textContent = s.text;
+    const x = el("button", "composer-chip-x");
+    x.setAttribute("aria-label", "Discard staged message");
+    x.textContent = "✕";
+    x.addEventListener("click", () => { stagedMsgs.removeAt(id, i); persistDrafts(); renderStagedStrip(id); });
+    chip.append(mark, label, x);
+    strip.appendChild(chip);
+  });
+}
 
 function beginComposerEdit(sid: string, uuid: string, orig: string): void {
   composerEdits.set(sid, { uuid, orig });
@@ -8853,6 +8927,7 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
     ta.value = drafts.get(id) ?? "";
     growComposer(ta);
     renderComposerChips(id);   // the entering tab's own citation chip (if any)
+    renderStagedStrip(id);     // …and its staged stack (per-tab; the strip follows the switch)
     renderComposerFiles(id);   // …and its attachment thumbnails (draft lifecycle: they survive the switch)
     persistDrafts();   // the leaving tab's draft was just stashed → keep the persisted copy in sync
   }
@@ -9585,9 +9660,36 @@ function setupComposer() {
   if (!ta) return;
   // Send the composer's text to the active session — the single path shared by ⏎ and the explicit send
   // button (the user 2026-06-17). Trims, remembers for a Ctrl+C restore, clears the box.
+  // ⌘/Ctrl+⏎ — STAGE the box instead of sending (the user 2026-08-15): the text and its citation
+  // chips move to the staged strip, the box clears, focus stays for the next highlight-and-comment.
+  // The states that already own the box refuse loudly rather than staging a lie: a picker answer
+  // answers NOW or sends normally; an edit replaces a past message; attachments ride a normal send.
+  const stageComposer = () => {
+    if (!activeId) return;
+    const typed = ta.value.trim();
+    if (!typed) return;
+    if (composerAnswersAsk()) { warnToast("A picker is waiting on this box — answer it, or send normally."); return; }
+    if (composerEdits.has(activeId)) { warnToast("An edit replaces a past message — send it normally."); return; }
+    if ((composerFiles.get(activeId) || []).length) { warnToast("Attachments can't be staged — send them with a normal message."); return; }
+    stagedMsgs.push(activeId, { text: typed, cites: (composerCitations.get(activeId) || []).slice() });
+    composerCitations.delete(activeId); renderComposerChips(activeId);   // the chips now live on the staged item
+    drafts.delete(activeId); draftStartedAt.delete(activeId);
+    ta.value = ""; composerManualH = null; ta.style.height = "";
+    persistDrafts();
+    renderStagedStrip(activeId);
+  };
   const sendComposer = () => {
     const typed = ta.value.trim();
     if (!activeId) return;
+    // an empty plain send with a staged stack = "go": release what's held, nothing new to add
+    if (!typed && !(composerFiles.get(activeId) || []).length && stagedMsgs.count(activeId)) {
+      if (hostIsDown(activeId) || isProvisionalId(activeId)) {
+        warnToast("Can't send yet — the session isn't reachable. They stay staged.");
+        return;
+      }
+      flushStaged(activeId);
+      return;
+    }
     const attached = composerFiles.get(activeId) || [];
     if (!typed && !attached.length) return;
     // Attachment thumbnails ride the send as a trailing line of paths — quoted when they contain spaces,
@@ -9657,26 +9759,26 @@ function setupComposer() {
         return;
       }
       lastSent.set(activeId, text);   // remembered for a possible Ctrl+C restore
+      // STAGED first (the user 2026-08-15): the held run releases in stage order, each message with the
+      // context it was written against, and the message being typed right now lands LAST — the reading
+      // the user composed: quote → comment, quote → comment, then the wrap-up. The guards above (host
+      // down, provisional) have already passed, so nothing staged can be half-lost here.
+      flushStaged(sid);
       // A pending citation chip → send as a FOLLOW-UP on that goal (the user 2026-07-01): askFollowUp wraps the
       // text with the goal's context + the romp-goal-id marker (kernel side), so the goal reopens (done→working,
       // unless cleared) and the chat renders the ↩ Follow-up header — the same path the Follow-up button uses,
       // just seeded by the click. A QUOTE chip (highlighted transcript text, the user 2026-07-13) has no goal:
-      // it wraps client-side (quoteReplyBody) into a plain message. No chip → plain sendMessage.
-      // `sid: activeId` is what ROUTES this to the owning kernel in a federated dashboard (the user 2026-07-29):
-      // federation keys routing off `id`/`sid` only, and an `itemId` ("‹sid›:‹goal›") can't be one — its own
-      // colon would read the session uuid as a host. Without the sid a follow-up on a REMOTE card went to the
-      // LOCAL kernel, which owns no such session and dropped it into tmux by uuid — nothing sent, no error,
-      // the card flashing to Working and back. The kernel keeps deriving its sid from itemId, so this is inert
-      // locally; every other card op (askClear/cardNotify/showOnTimeline) already carries the sid the same way.
+      // it wraps client-side (quoteReplyBody) into a plain message. No chip → plain sendMessage. The three
+      // branches live in routeUserMessage — ONE routing owner, shared with the staged flush above.
+      // Inside it, `sid` is what ROUTES this to the owning kernel in a federated dashboard (the user
+      // 2026-07-29): federation keys routing off `id`/`sid` only, and an `itemId` ("‹sid›:‹goal›") can't
+      // be one — its own colon would read the session uuid as a host. Without the sid a follow-up on a
+      // REMOTE card went to the LOCAL kernel, which owns no such session and dropped it into tmux by
+      // uuid — nothing sent, no error, the card flashing to Working and back. The kernel keeps deriving
+      // its sid from itemId, so this is inert locally; every other card op carries the sid the same way.
       const cites = composerCitations.get(activeId);
-      const goalCite = cites?.find((c) => c.itemId);   // a goal chip rides alone (flavors never mix)
-      const quoteCites = cites ? cites.filter((c) => c.quote) : [];
-      if (vscodeApi) {
-        if (goalCite?.itemId) vscodeApi.postMessage({ type: "askFollowUp", itemId: goalCite.itemId, text, sid: activeId });
-        else if (quoteCites.length) vscodeApi.postMessage({ type: "sendMessage", id: activeId, text: quoteReplyBody(quoteCites, text) });
-        else { vscodeApi.postMessage({ type: "sendMessage", id: activeId, text }); registerOptimistic(activeId, text); }
-        // (a citation follow-up/quote has its own kernel-side echo path; the optimistic bubble covers the plain send)
-      }
+      routeUserMessage(activeId, text, cites);
+      // (a citation follow-up/quote has its own kernel-side echo path; the optimistic bubble covers the plain send)
       if (cites) { composerCitations.delete(activeId); renderComposerChips(activeId); }   // consumed on send
       if (attached.length) { composerFiles.delete(sid); if (sid === activeId) renderComposerFiles(sid); }   // the strip emptied into this message
       drafts.delete(activeId); draftStartedAt.delete(activeId); persistDrafts();   // sent — no draft to restore on a later switch-back
@@ -9953,6 +10055,13 @@ function setupComposer() {
     // Shift+Enter, and the software return key should just return. Mobile sends with the explicit Send
     // button only (the user 2026-07-15). Desktop keeps ⏎ send / ⇧⏎ newline. The `!isCoarsePointer()` guard
     // lets Enter fall through to the textarea's native newline on touch.
+    // ⌘⏎ / Ctrl+⏎ stages (the user 2026-08-15) — and focus STAYS in the box, because the whole point
+    // is highlighting the next spot and typing again. Checked before the plain-Enter send below.
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
+      e.preventDefault();
+      stageComposer();
+      return;
+    }
     if (e.key === "Enter" && !e.shiftKey && !isCoarsePointer()) {
       e.preventDefault();
       sendComposer();

--- a/ui/webview/rewind-edit.test.ts
+++ b/ui/webview/rewind-edit.test.ts
@@ -27,10 +27,14 @@ test("the edit affordance renders only on bubbles the backend can address", () =
 test("sending in edit mode posts rewindSend and never a plain sendMessage", () => {
   assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "rewindSend", id: activeId, uuid: editing\.uuid, text: typed \}\);/);
   assert.match(RENDER, /pendingRewind\.set\(activeId, \{ uuid: editing\.uuid, text: typed, ts: Date\.now\(\) \}\);/);
-  // the edit branch returns BEFORE the sendMessage path (and registers no tail-appended optimistic bubble)
+  // the edit branch returns BEFORE any send path runs — since the staged flush (2026-08-15) the first
+  // thing deliver does is release the staged stack, so preceding THAT is what proves an edit can never
+  // fall through into a plain send (the routing itself now lives in routeUserMessage, defined earlier
+  // in the file, so a source-index race against it would be meaningless)
   const editBranch = RENDER.indexOf('type: "rewindSend"');
-  const plainSend = RENDER.indexOf('else { vscodeApi.postMessage({ type: "sendMessage", id: activeId, text });');
-  assert.ok(editBranch > 0 && editBranch < plainSend, "edit branch precedes the plain send");
+  const stagedFlush = RENDER.indexOf("flushStaged(sid);");
+  assert.ok(editBranch > 0 && stagedFlush > 0 && editBranch < stagedFlush,
+    "edit branch precedes deliver's first send action");
 });
 
 test("the composer edit chip cancels via its x and via Escape", () => {

--- a/ui/webview/staged-messages.test.ts
+++ b/ui/webview/staged-messages.test.ts
@@ -1,0 +1,45 @@
+// The staged stack (the user 2026-08-15): every rule executed.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { StagedStack } from "./staged-messages";
+
+test("stage order is release order, and a flush is one-shot", () => {
+  const s = new StagedStack();
+  s.push("a", { text: "first", cites: [] });
+  s.push("a", { text: "second", cites: [{ quote: "ctx" }] });
+  s.push("a", { text: "third", cites: [] });
+  assert.equal(s.count("a"), 3);
+  assert.deepEqual(s.takeAll("a").map((m) => m.text), ["first", "second", "third"]);
+  assert.equal(s.count("a"), 0, "released, not re-sendable");
+  assert.deepEqual(s.takeAll("a"), []);
+});
+
+test("tabs hold separate stacks", () => {
+  const s = new StagedStack();
+  s.push("a", { text: "for a", cites: [] });
+  s.push("b", { text: "for b", cites: [] });
+  assert.deepEqual(s.takeAll("a").map((m) => m.text), ["for a"]);
+  assert.equal(s.count("b"), 1, "flushing one tab never touches another");
+});
+
+test("discard removes exactly the one chip", () => {
+  const s = new StagedStack();
+  s.push("a", { text: "keep", cites: [] });
+  s.push("a", { text: "drop", cites: [] });
+  s.push("a", { text: "keep too", cites: [] });
+  s.removeAt("a", 1);
+  assert.deepEqual(s.list("a").map((m) => m.text), ["keep", "keep too"]);
+});
+
+test("the persistence round-trip keeps text, context and order — and drops junk", () => {
+  const s = new StagedStack();
+  s.push("a", { text: "one", cites: [{ quote: "q", title: "t" }] });
+  s.push("a", { text: "two", cites: [] });
+  const r = new StagedStack();
+  r.restore(JSON.parse(JSON.stringify(s.entries())));
+  assert.deepEqual(r.list("a").map((m) => m.text), ["one", "two"]);
+  assert.equal((r.list("a")[0].cites[0] as any).quote, "q", "the context survives the reload");
+  r.restore({ b: [{ text: "" }, { nope: 1 }, "junk"], c: "junk" });   // a hand-edited/old store
+  assert.equal(r.count("b"), 0, "junk hydrates to nothing, never a crash");
+  assert.equal(r.count("c"), 0);
+});

--- a/ui/webview/staged-messages.ts
+++ b/ui/webview/staged-messages.ts
@@ -1,0 +1,58 @@
+// STAGED messages (the user 2026-08-15): compose against a highlight, hold it, keep reading — then
+// release the whole run together. ⌘/Ctrl+⏎ stages the composer's text WITH its citation chips; a
+// plain send flushes the stack in stage order with the typed message last; the strip's Send now
+// releases the stack alone. Deliberately NOT "queued": queued is romp's injection-side wait (sent,
+// pending injection into the session); staged is user-side — not sent at all, just held where it
+// was written so each message keeps the context it was written against.
+//
+// This is the PURE stack — per-tab isolation, order, flush-clears, discard, persistence round-trip —
+// so staged-messages.test.ts EXECUTES the rules instead of regexing render.ts (the repo's
+// extract-for-execution idiom). The DOM strip and the send routing live in render.ts.
+
+export interface StagedMsg { text: string; cites: unknown[] }
+
+export class StagedStack {
+  private m = new Map<string, StagedMsg[]>();
+
+  list(sid: string): readonly StagedMsg[] { return this.m.get(sid) || []; }
+  count(sid: string): number { return (this.m.get(sid) || []).length; }
+
+  push(sid: string, msg: StagedMsg): void {
+    const l = this.m.get(sid) || [];
+    l.push(msg);
+    this.m.set(sid, l);
+  }
+
+  removeAt(sid: string, i: number): void {
+    const l = this.m.get(sid);
+    if (!l) return;
+    l.splice(i, 1);
+    if (!l.length) this.m.delete(sid);
+  }
+
+  /** The flush: every staged message for this tab, in stage order, and the stack is now empty —
+   *  release is one-shot, never a re-send. */
+  takeAll(sid: string): StagedMsg[] {
+    const l = this.m.get(sid) || [];
+    this.m.delete(sid);
+    return l;
+  }
+
+  /** Persistence shape (rides the drafts store): sid → messages. */
+  entries(): Record<string, StagedMsg[]> {
+    return Object.fromEntries(this.m);
+  }
+
+  /** Hydrate from a persisted shape; junk entries are dropped, never a crash. */
+  restore(saved: unknown): void {
+    if (!saved || typeof saved !== "object") return;
+    for (const [sid, v] of Object.entries(saved as Record<string, unknown>)) {
+      const list: StagedMsg[] = [];
+      for (const m of Array.isArray(v) ? v : []) {
+        if (m && typeof (m as any).text === "string" && (m as any).text)
+          list.push({ text: (m as any).text, cites: Array.isArray((m as any).cites) ? (m as any).cites : [] });
+      }
+      if (list.length) this.m.set(sid, list);
+    }
+  }
+}

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -558,6 +558,18 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 }
 .composer-chip-mark { color: var(--accent); font-weight: 600; }
 .composer-chip-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 42ch; }
+/* STAGED messages (the user 2026-08-15): held in the composer until the next send — deliberately NOT
+   the queued idiom (queued = sent, awaiting injection; these are unsent by choice). Same chip anatomy
+   as citations, its own read: a dashed accent edge instead of the pill, no hourglass; the head wears
+   the queued-head size (labels match labels). */
+#composer-staged { flex-direction: column; gap: 3px; padding: 5px 8px 0; }
+.staged-head { display: flex; align-items: center; gap: 8px; font-size: 0.78em; color: var(--dim); letter-spacing: 0.02em; }
+.staged-head .staged-go { margin-left: auto; background: none; border: 1px solid var(--accent); color: var(--accent);
+  border-radius: 5px; font: inherit; padding: 1px 8px; cursor: pointer; }
+.staged-head .staged-go:hover { background: var(--accent); color: var(--accent-fg); }
+.staged-chip { display: flex; align-items: center; gap: 6px; border: 1px dashed rgba(156, 210, 255, 0.45);
+  border-left: 2px solid var(--accent); border-radius: 6px; padding: 2px 6px; font-size: 12px; color: var(--fg); }
+.staged-chip .composer-chip-label { flex: 1 1 auto; max-width: none; }
 .composer-chip-x {
   flex: 0 0 auto; border: none; background: none; cursor: pointer; color: var(--dim);
   font-size: 11px; line-height: 1; padding: 2px 4px; border-radius: 8px;

--- a/vscode-extension/src/page-skeleton.ts
+++ b/vscode-extension/src/page-skeleton.ts
@@ -25,7 +25,7 @@ export function chatBody(attachTitle: string): string {
   <div id="footer">
     <div id="composer-resize" title="Drag to resize the message box"></div>
     <div id="statusline" class="statusline"></div>
-    <div id="composer"><div id="composer-files" style="display:none"></div><div id="composer-chips" style="display:none"></div><textarea id="composer-input" rows="1" placeholder="Message this session…  (⏎ send · ⇧⏎ newline)"></textarea><button id="composer-attach" title="${attachTitle}" aria-label="Attach file"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></button><button id="composer-send" title="Send (⏎)" aria-label="Send">➤</button></div>
+    <div id="composer"><div id="composer-files" style="display:none"></div><div id="composer-staged" style="display:none"></div><div id="composer-chips" style="display:none"></div><textarea id="composer-input" rows="1" placeholder="Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage)"></textarea><button id="composer-attach" title="${attachTitle}" aria-label="Attach file"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></button><button id="composer-send" title="Send (⏎)" aria-label="Send">➤</button></div>
   </div>`;
 }
 


### PR DESCRIPTION
The user (2026-08-15): while reading a transcript they highlight a spot, type a response, and want to hold it — repeatedly — releasing the whole run only when done, with each message keeping the quote context it was written against (quote → comment, quote → comment). Explicitly not "queued", which in romp means sent-and-awaiting-injection; this is user-side holding, so the word everywhere is **staged**.

- **⌘⏎ / Ctrl+⏎ stages the box**: the text and its citation chips move onto a strip above the composer, the box clears, and focus stays put for the next highlight-and-comment. Picker answers, edits, and attachments refuse to stage with a loud toast (each already owns the box's meaning).
- **Release**: a plain send flushes the stack in stage order with the typed message last; Enter on an empty box (with a stack) or the strip's **Send now** releases it alone; every chip has a discard ✕. Host-down and provisional guards hold the stack rather than half-losing it.
- **The strip** echoes the queued idiom's anatomy with its own read — dashed accent edge, no hourglass, the header in the established label size, `N staged — sends with your next message`.
- **Per-tab and durable**: the stack rides the drafts persistence (reload/tab-switch safe), rendering with the tab it belongs to.
- **One routing owner**: the three send branches (goal follow-up / quote-wrapped / plain+optimistic) moved into `routeUserMessage`, shared by the live send and the staged flush — and the nine composer pins that codified the old single-path literals were reconciled to it (including the edit-mode ordering proof, now anchored on deliver's first send action).

Tests: the pure stack executed end to end (order, one-shot flush, per-tab isolation, discard, persistence round-trip with junk tolerance) plus the reconciled pins. Node suite 1995/1995; both skeletons carry the strip in step (pinned); kernel compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)