### PR TITLE
Timeline merges re-base every host's times onto the local clock

### DIFF
--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -348,6 +348,81 @@ export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly s
   return merged;
 }
 
+// ── cross-host clock re-basing (the user 2026-08-15) ─────────────────────────────────────────────
+// Every kernel stamps its payload times with ITS OWN clock, and the merges keep the LOCAL kernel as
+// the clock authority — so an attached machine whose clock runs ahead painted its bars and marks
+// shifted right, and a postal connector could touch a sender's lane AFTER that lane's last bar (the
+// screenshot: a send apparently fired by a stopped session — impossible, and false). Each payload
+// carries its emitting kernel's `now`; the delta against the LOCAL payload's `now` in the same merge
+// IS that host's offset — re-measured every merge, so drift self-corrects, and a sub-second delta is
+// measurement jitter, not skew: left alone, so pixels never move without new information. A host
+// whose payload carries no `now` (older kernel) is unknown and never guessed — its times pass
+// through untouched, exactly the not-reporting rule everywhere else in this file.
+// One field is DELIBERATELY cross-clock: a connector's `exec` is the RECIPIENT machine's event (the
+// read receipt carries the reader's clock into the sender's log — bin/romp-postal-service), so exec
+// re-bases by the offset of the host the toId lane lives on, knowable only after the stitch resolves
+// foreign endpoints onto lanes (rebaseExecs). A connector still pending (hasExec false) carries a
+// sender-clock COPY of sent in exec, which therefore shifts with its emitter like sent itself.
+const SKEW_FLOOR_S = 1;
+const BAR_TIMES = ["start", "end"] as const;      // turns[sid] bars
+const MARK_TIMES = ["t"] as const;                // judging / nudge marks
+const LANE_TIMES = ["since"] as const;            // session rows
+
+export function hostOffsets(perHost: Record<string, any>): Record<string, number> {
+  const local = perHost[LOCAL];
+  const ln = local && typeof local.now === "number" ? local.now : null;
+  const out: Record<string, number> = {};
+  if (ln == null) return out;
+  for (const [h, d] of Object.entries(perHost)) {
+    if (h === LOCAL || !d || typeof d.now !== "number") continue;
+    const off = ln - d.now;
+    if (Math.abs(off) >= SKEW_FLOOR_S) out[h] = off;
+  }
+  return out;
+}
+
+function shiftRow(r: any, keys: readonly string[], off: number): any {
+  if (!r || typeof r !== "object") return r;
+  const c: any = { ...r };
+  for (const k of keys) if (typeof c[k] === "number") c[k] += off;
+  return c;
+}
+
+/** Re-base ONE host's payload times onto the local clock (a copy; zero offset returns it untouched). */
+export function rebaseHostTimes(d: any, off: number): any {
+  if (!off || !d || typeof d !== "object") return d;
+  const c: any = { ...d };
+  if (Array.isArray(c.sessions)) c.sessions = c.sessions.map((s: any) => shiftRow(s, LANE_TIMES, off));
+  if (c.turns && typeof c.turns === "object") {
+    const t: any = {};
+    for (const [sid, bars] of Object.entries(c.turns))
+      t[sid] = Array.isArray(bars) ? bars.map((b: any) => shiftRow(b, BAR_TIMES, off)) : bars;
+    c.turns = t;
+  }
+  for (const k of ["judging", "nudges"] as const)
+    if (Array.isArray(c[k])) c[k] = c[k].map((m: any) => shiftRow(m, MARK_TIMES, off));
+  if (Array.isArray(c.messages))
+    c.messages = c.messages.map((m: any) => {
+      const s = shiftRow(m, ["sent"], off);
+      // pending exec is the emitter's copy of sent — it moves with the emitter; a REAL exec is the
+      // recipient's clock and waits for rebaseExecs (post-stitch, when the recipient lane is known)
+      if (s && typeof s === "object" && typeof s.exec === "number" && !s.hasExec) s.exec += off;
+      return s;
+    });
+  return c;
+}
+
+/** The exec pass, post-stitch: shift each delivered connector's exec by the RECIPIENT lane's host
+ *  offset (a local recipient, or an unmeasured host, shifts nothing). */
+export function rebaseExecs(messages: any[], offsets: Record<string, number>): any[] {
+  if (!messages.length) return messages;
+  return messages.map((m: any) => {
+    if (!m || typeof m !== "object" || typeof m.exec !== "number" || !m.hasExec) return m;
+    const off = offsets[hostOf(String(m.toId || ""))] || 0;
+    return off ? { ...m, exec: m.exec + off } : m;
+  });
+}
+
 /** Stitch CROSS-HOST postal connectors onto merged lanes. Each kernel emits a connector when at least
  *  one end is its own lane; the FOREIGN end's sid is bare in its log (a kernel knows nothing of host
  *  prefixes) and inbound prefixing blindly prefixed it with the EMITTING host — so on the merged board
@@ -391,9 +466,10 @@ export function stitchMessages(messages: any[], sessions: readonly any[]): any[]
 export function mergeHostTimelines(perHost: Record<string, any>, hostSeq: readonly string[],
                                    view: readonly string[] = []): any {
   const local = perHost[LOCAL] || {};
+  const offsets = hostOffsets(perHost);   // each host's clock vs the local authority, this merge
   const merged: any = { ...local, sessions: [], turns: {}, messages: [], judging: [] };
   for (const h of hostSeq) {
-    const d = perHost[h];
+    const d = rebaseHostTimes(perHost[h], offsets[h] || 0);
     if (!d) continue;
     if (Array.isArray(d.sessions)) merged.sessions.push(...d.sessions.map((s: any) => ({ ...s, host: h })));
     if (d.turns && typeof d.turns === "object") Object.assign(merged.turns, d.turns);
@@ -402,7 +478,7 @@ export function mergeHostTimelines(perHost: Record<string, any>, hostSeq: readon
   // lanes are the third surface reading this order (chat strip, feed groups, timeline lanes): arrange them
   // the same way, before the message stitch, which pairs postal arrows against the lane list.
   merged.sessions = applyViewOrderTo(merged.sessions, view, (x: any) => String((x && x.id) || ""));
-  merged.messages = stitchMessages(merged.messages, merged.sessions);
+  merged.messages = rebaseExecs(stitchMessages(merged.messages, merged.sessions), offsets);
   return merged;
 }
 
@@ -414,15 +490,16 @@ export function mergeHostTimelines(perHost: Record<string, any>, hostSeq: readon
 export function mergeHostBars(perHost: Record<string, any>, hostSeq: readonly string[],
                               sessions: readonly any[] = []): any {
   const local = perHost[LOCAL] || {};
+  const offsets = hostOffsets(perHost);   // each host's clock vs the local authority, this merge
   const merged: any = { ...local, type: "bars", turns: {}, messages: [], judging: [], warming: false };
   for (const h of hostSeq) {
-    const b = perHost[h];
+    const b = rebaseHostTimes(perHost[h], offsets[h] || 0);
     if (!b) continue;
     if (b.turns && typeof b.turns === "object") Object.assign(merged.turns, b.turns);
     for (const k of ["messages", "judging", "nudges"]) if (Array.isArray(b[k])) merged[k].push(...b[k]);
     if (b.warming) merged.warming = true;   // still warming if ANY host's build is the cold partial (keep the loader)
   }
-  merged.messages = stitchMessages(merged.messages, sessions);
+  merged.messages = rebaseExecs(stitchMessages(merged.messages, sessions), offsets);
   return merged;
 }
 

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { prefixId, hostOf, bareId, prefixInbound, routeOutbound, mergeHostOrder, mergeHostFeeds,
          prefixTimelineData, mergeHostTimelines, mergeHostBars, stitchMessages,
+         hostOffsets, rebaseHostTimes, rebaseExecs,
          FederationManager, pickWid } from "./federation";
 
 const U = "11111111-2222-3333-4444-555555555555";
@@ -591,4 +592,89 @@ test("a closed session leaves the arrangement; a detached host's sessions keep t
     assert.ok(JSON.parse(store.get("romp:vieworder")!).includes("TESTHOST:" + V),
       "the remote id stays placed — its host simply wasn't the one reporting");
   });
+});
+
+// ── cross-host clock re-basing (the user 2026-08-15) ──────────────────────────────────────────────
+// A postal connector touched a sender's lane AFTER that lane's last bar — a send apparently fired by
+// a stopped session. Every kernel stamps times with its own clock; these tests pin the re-basing that
+// puts every host's bars, marks and connectors on the LOCAL clock at merge time.
+
+test("a skewed host's bars, lanes, marks and sent-times re-base onto the local clock", () => {
+  const perHost: Record<string, any> = {
+    "": { now: 1000, sessions: [{ id: "L", since: 990 }], turns: { L: [{ start: 900, end: 950 }] },
+          messages: [], judging: [] },
+    gpu1: { now: 940, sessions: [{ id: "gpu1:R", since: 930 }],   // gpu1's clock runs 60s behind
+            turns: { "gpu1:R": [{ start: 840, end: 890 }] },
+            messages: [{ id: "m1", fromId: "gpu1:R", toId: "L", sent: 900, exec: 900, hasExec: false }],
+            judging: [{ judge: "closer", sid: "gpu1:R", t: 880 }] },
+  };
+  const m = mergeHostTimelines(perHost, ["", "gpu1"]);
+  const r = m.sessions.find((s: any) => s.id === "gpu1:R");
+  assert.equal(r.since, 990, "lane since re-based (+60)");
+  assert.deepEqual(m.turns["gpu1:R"][0], { start: 900, end: 950 }, "bars re-based (+60)");
+  assert.equal(m.judging.find((j: any) => j.sid === "gpu1:R").t, 940, "marks re-based (+60)");
+  const msg = m.messages.find((x: any) => x.id === "m1");
+  assert.equal(msg.sent, 960, "sent re-based by the EMITTING host (+60)");
+  assert.equal(msg.exec, 960, "a pending exec is the emitter's copy of sent — it moves with it");
+  // the local payload is the authority: untouched
+  assert.equal(m.sessions.find((s: any) => s.id === "L").since, 990);
+  assert.deepEqual(m.turns.L[0], { start: 900, end: 950 });
+});
+
+test("a DELIVERED exec re-bases by the RECIPIENT lane's host — the receipt carried the reader's clock", () => {
+  // sender gpu1 (-60 vs local), recipient gpu2 (+30 vs local): sent moves +60 with its emitter, exec
+  // moves -30 with the machine whose clock actually stamped the read
+  const perHost: Record<string, any> = {
+    "": { now: 1000, sessions: [{ id: "L" }], turns: {}, messages: [], judging: [] },
+    gpu1: { now: 940, sessions: [{ id: "gpu1:A" }], turns: {},
+            messages: [{ id: "m2", fromId: "gpu1:A", toId: "b-b-b-b-b", sent: 900, exec: 1010, hasExec: true }],
+            judging: [] },
+    gpu2: { now: 1030, sessions: [{ id: "gpu2:b-b-b-b-b" }], turns: {}, messages: [], judging: [] },
+  };
+  const m = mergeHostTimelines(perHost, ["", "gpu1", "gpu2"]);
+  const msg = m.messages.find((x: any) => x.id === "m2");
+  assert.equal(msg.toId, "gpu2:b-b-b-b-b", "the stitch resolved the foreign endpoint first");
+  assert.equal(msg.sent, 960, "sent: emitter's offset (+60)");
+  assert.equal(msg.exec, 980, "exec: recipient host's offset (-30), applied post-stitch");
+});
+
+test("sub-second deltas and hosts reporting no clock are never re-based", () => {
+  assert.deepEqual(hostOffsets({ "": { now: 1000 }, a: { now: 999.6 }, b: {} }), {},
+    "jitter is not skew, and an unreported clock is unknown — never guessed");
+  const d = { sessions: [{ id: "a:X", since: 10 }], turns: {}, messages: [], judging: [] };
+  assert.equal(rebaseHostTimes(d, 0), d, "zero offset returns the payload untouched");
+});
+
+test("the bars merge re-bases the same way (turns + marks + exec pass)", () => {
+  const sessions = [{ id: "L" }, { id: "gpu1:R" }];
+  const perHost: Record<string, any> = {
+    "": { now: 500, turns: { L: [{ start: 400, end: 450 }] }, messages: [], judging: [] },
+    gpu1: { now: 440, turns: { "gpu1:R": [{ start: 340, end: 390 }] },
+            messages: [{ id: "m3", fromId: "gpu1:R", toId: "L", sent: 400, exec: 430, hasExec: true }],
+            judging: [] },
+  };
+  const b = mergeHostBars(perHost, ["", "gpu1"], sessions);
+  assert.deepEqual(b.turns["gpu1:R"][0], { start: 400, end: 450 });
+  const msg = b.messages.find((x: any) => x.id === "m3");
+  assert.equal(msg.sent, 460, "sent +60 with the emitter");
+  assert.equal(msg.exec, 430, "exec stamped by the LOCAL recipient — the local clock never shifts");
+});
+
+test("re-based times cannot strand a connector after its sender's last bar (the reported artifact)", () => {
+  // gpu1's clock runs 90s AHEAD of local: unre-based, its lane bars sat 90s right of local truth,
+  // and its send mark (stamped 90s ahead) rendered after the lane's real work ended
+  const perHost: Record<string, any> = {
+    "": { now: 1000, sessions: [{ id: "L", since: 995 }], turns: { L: [{ start: 900, end: 995 }] },
+          messages: [], judging: [] },
+    gpu1: { now: 1090, sessions: [{ id: "gpu1:S", since: 1085 }],
+            turns: { "gpu1:S": [{ start: 1000, end: 1085 }] },
+            messages: [{ id: "m4", fromId: "gpu1:S", toId: "L", sent: 1080, exec: 1080, hasExec: false }],
+            judging: [] },
+  };
+  const m = mergeHostTimelines(perHost, ["", "gpu1"]);
+  const lane = m.turns["gpu1:S"][0];
+  const msg = m.messages.find((x: any) => x.id === "m4");
+  assert.ok(msg.sent <= lane.end, "the send mark sits within the sender's re-based work, not after it");
+  assert.equal(msg.sent, 990);
+  assert.deepEqual(lane, { start: 910, end: 995 });
 });


### PR DESCRIPTION
The user (2026-08-15, screenshot): a postal message connector touched its sender's lane AFTER that lane's last work bar — a send apparently fired by a stopped session, which is impossible. Root cause: every kernel stamps its timeline payload with its own clock, and the federation merges kept the local kernel as clock authority while concatenating per-host times UNADJUSTED — a machine with a fast clock painted its whole lane shifted, and cross-machine connectors (whose two ends are stamped by two different machines) could detach from either lane.

The fix, at the one merge boundary:
- **Offsets are measured, not configured**: each payload carries its kernel's `now`; the delta against the LOCAL payload's `now` in the same merge is that host's offset — re-measured every merge so drift self-corrects. Sub-second deltas are jitter, not skew, and are left alone (pixels never move without new information); a host whose payload reports no clock is unknown and never guessed — the same not-reporting rule the settings sync uses.
- **Everything shifts with its emitter**: bars (start/end), lane `since`, judge/nudge marks (t), and connector `sent`.
- **One field is deliberately cross-clock**: a delivered connector's `exec` is the RECIPIENT machine's event — the read receipt carries the reader's clock into the sender's log by design (`bin/romp-postal-service`) — so exec re-bases by the recipient lane's host offset, applied after the stitch resolves foreign endpoints onto lanes. A still-pending connector's exec is the emitter's copy of sent and moves with the emitter. Both dedup paths (either kernel's copy winning, or the in-place exec upgrade) land fully local-based by construction.

Tests execute the whole contract in the merge suite: skewed-host re-basing across bars/lanes/marks/sent, the recipient-host exec rule with three clocks in play, the jitter floor and unknown-clock exclusions, the bars-merge path, and a reconstruction of the reported artifact proving the send mark can no longer strand past its sender's re-based lane. Node suite 2001/2001, typecheck and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)