### PR TITLE
The composer hint row says everything once: send, newline, stage, / for commands

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20862,7 +20862,7 @@ def _chat_body():
             '<div id="composer-staged" style="display:none"></div>'  # staged-message strip: held until the next send (the user 2026-08-15; NOT the queue — see render.ts)
             '<div id="composer-chips" style="display:none"></div>'   # click-to-cite chip strip (the user 2026-07-01)
             '<textarea id="composer-input" rows="1" '
-            'placeholder="Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage)"></textarea>'
+            'placeholder="Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · / for commands)"></textarea>'
             '<button id="composer-attach" title="Attach a file">'
             '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" '
             'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7320,9 +7320,11 @@ function isCoarsePointer(): boolean {
 // the two buttons (the user 2026-07-30), so even the "/" hint wrapped and got clipped: mobile keeps just
 // the core prompt, and slash-command discovery stays a desktop hint.
 function composerRestingPlaceholder(): string {
+  // the one canonical hint line (the user 2026-08-15): send, newline, stage, commands — and just
+  // "/ for commands", not "type / for commands". The static skeletons carry the same string.
   return isCoarsePointer()
     ? "Message this session…"
-    : "Message this session…  (⏎ send · ⇧⏎ newline · type / for commands)";
+    : "Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · / for commands)";
 }
 
 // How a message typed into the NORMAL composer should be routed while a live picker is up — the picker's

--- a/ui/webview/slash-commands.test.ts
+++ b/ui/webview/slash-commands.test.ts
@@ -129,8 +129,9 @@ test("the expanded view lists a multi-group arg hint one bracketed group per lin
 });
 
 test("the composer placeholder hints that / opens commands (the user 2026-06-30)", () => {
-  // the resting placeholder now comes from composerRestingPlaceholder(); its DESKTOP form keeps the "type /
-  // for commands" hint (mobile drops the ⏎/⇧⏎ part — see the composer-send mobile test)
+  // the resting placeholder now comes from composerRestingPlaceholder(); its DESKTOP form carries the
+  // full hint row — send, newline, stage, and the bare "/ for commands" (the user 2026-08-15: "type"
+  // was filler) — while mobile keeps just the core prompt (see the composer-send mobile test)
   assert.match(RENDER, /composer\.placeholder = closed \? "Session closed — read-only" : composerRestingPlaceholder\(\);/);
-  assert.match(RENDER, /"Message this session…  \(⏎ send · ⇧⏎ newline · type \/ for commands\)"/);
+  assert.match(RENDER, /"Message this session…  \(⏎ send · ⇧⏎ newline · ⌘⏎ stage · \/ for commands\)"/);
 });

--- a/vscode-extension/src/page-skeleton.ts
+++ b/vscode-extension/src/page-skeleton.ts
@@ -25,7 +25,7 @@ export function chatBody(attachTitle: string): string {
   <div id="footer">
     <div id="composer-resize" title="Drag to resize the message box"></div>
     <div id="statusline" class="statusline"></div>
-    <div id="composer"><div id="composer-files" style="display:none"></div><div id="composer-staged" style="display:none"></div><div id="composer-chips" style="display:none"></div><textarea id="composer-input" rows="1" placeholder="Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage)"></textarea><button id="composer-attach" title="${attachTitle}" aria-label="Attach file"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></button><button id="composer-send" title="Send (⏎)" aria-label="Send">➤</button></div>
+    <div id="composer"><div id="composer-files" style="display:none"></div><div id="composer-staged" style="display:none"></div><div id="composer-chips" style="display:none"></div><textarea id="composer-input" rows="1" placeholder="Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · / for commands)"></textarea><button id="composer-attach" title="${attachTitle}" aria-label="Attach file"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></button><button id="composer-send" title="Send (⏎)" aria-label="Send">➤</button></div>
   </div>`;
 }
 


### PR DESCRIPTION
The user (2026-08-15): the message box's default hint should name the whole row — Enter to send, Shift+Enter for a newline, Cmd+Enter to stage — and "type / for commands" reads better as just "/ for commands".

One canonical string now: `Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · / for commands)` — in the dynamic resting placeholder (which previously replaced the static hint at boot and dropped the stage key) and both static skeletons; mobile keeps the bare prompt as before. The slash-hint pin updated to the new wording. Node suite 1996/1996, kernel compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)