### PR TITLE
Staged chips clip in bounds, expand on click, and carry their context

### DIFF
--- a/ui/webview/composer-send.test.ts
+++ b/ui/webview/composer-send.test.ts
@@ -85,3 +85,24 @@ test("focusing a tab (after ⏎-send) draws NO white UA focus ring around its co
   // the dashed STATE outlines stay (higher specificity than the base .tab rule, so outline:none can't kill them)
   assert.match(CSS, /\.tab\.tab-awaiting, \.tab\.tab-blocked, \.tab\.tab-retrying \{ outline: 2px dashed/);
 });
+
+test("a staged chip clips IN BOUNDS with an ellipsis and expands on click (the user 2026-08-15)", () => {
+  const STYLES = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+  // the flex label could never shrink (no min-width:0), so long texts ran off the pane edge with no
+  // ellipsis; expanded, the same label wraps to the full text — the context-fold idiom
+  assert.match(STYLES, /\.staged-chip \.composer-chip-label \{ flex: 1 1 auto; max-width: none; min-width: 0; \}/);
+  assert.match(STYLES, /\.staged-chip\.open \.staged-row \.composer-chip-label \{ white-space: pre-wrap; overflow: visible; \}/);
+  // the affordance is visibly CHROME, not message text: dim, parenthesized, at the line's end
+  assert.match(STYLES, /\.staged-expand \{ flex: 0 0 auto; color: var\(--dim\); font-size: 0\.85em; \}/);
+  assert.match(RENDER, /hint\.textContent = open \? "\(collapse\)" : "\(expand\)";/);
+  // expansion survives the strip re-render (keyed set), and the discard ✕ does not toggle the fold
+  assert.match(RENDER, /const stagedOpen = new Set<string>\(\);/);
+  assert.match(RENDER, /x\.addEventListener\("click", \(ev\) => \{ ev\.stopPropagation\(\);/);
+  // each staged reply carries its CONTEXT inside the dotted box: one chip per quote, independently
+  // expandable (its click never toggles the reply's own fold), keyed sid:i:j
+  assert.match(RENDER, /const quotes = \(s\.cites as Citation\[\]\)\.filter\(\(c\) => c && c\.quote\);/);
+  assert.match(RENDER, /const ck = id \+ ":" \+ i \+ ":" \+ j;/);
+  assert.match(RENDER, /cite\.addEventListener\("click", \(ev\) => \{\s*\n\s*ev\.stopPropagation\(\);/);
+  assert.match(STYLES, /\.staged-cite\.open \.composer-chip-label \{ white-space: pre-wrap; overflow: visible; \}/);
+});
+

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8376,6 +8376,7 @@ const composerEdits = new Map<string, { uuid: string; orig: string }>();
 // drafts (a reload or tab switch never drops a stack). The pure stack rules live in staged-messages.ts,
 // executed by its test; this file owns the strip DOM and the send routing.
 const stagedMsgs = new StagedStack();
+const stagedOpen = new Set<string>();   // sid:index of staged chips expanded to their full text
 try { stagedMsgs.restore(((vscodeApi?.getState?.() || {}) as any).staged); } catch { /* ignore */ }
 
 // One routing owner for a user message (the deliver path and the staged flush both speak it): a goal
@@ -8425,16 +8426,50 @@ function renderStagedStrip(id: string | null): void {
   strip.appendChild(head);
   list.forEach((s, i) => {
     const chip = el("div", "staged-chip");
-    chip.title = s.text;
+    // each staged reply keeps the CONTEXT it was written against visible inside its own dotted box
+    // (the user 2026-08-15): one small context chip per quote, independently expandable — clicking
+    // the quote opens the quote, clicking anywhere else in the box opens the reply text. Both folds
+    // are keyed so they survive the strip re-render.
+    const quotes = (s.cites as Citation[]).filter((c) => c && c.quote);
+    for (let j = 0; j < quotes.length; j++) {
+      const ck = id + ":" + i + ":" + j;
+      const cOpen = stagedOpen.has(ck);
+      const cite = el("div", "staged-cite" + (cOpen ? " open" : ""));
+      const cm = el("span", "composer-chip-mark"); cm.textContent = "“";
+      const cl = el("span", "composer-chip-label"); cl.textContent = quotes[j].quote || "";
+      const ch = el("span", "staged-expand"); ch.textContent = cOpen ? "(collapse)" : "(expand)";
+      cite.append(cm, cl, ch);
+      cite.addEventListener("click", (ev) => {
+        ev.stopPropagation();
+        if (stagedOpen.has(ck)) stagedOpen.delete(ck); else stagedOpen.add(ck);
+        renderStagedStrip(id);
+      });
+      chip.appendChild(cite);
+    }
+    const row = el("div", "staged-row");
     const mark = el("span", "composer-chip-mark");
-    mark.textContent = (s.cites as Citation[]).some((c) => c && c.quote) ? "“" : "•";
+    mark.textContent = "•";
     const label = el("span", "composer-chip-label");
     label.textContent = s.text;
+    // one line, ellipsized IN BOUNDS, with a colored "(expand)" that is visibly chrome, not message
+    // text; click toggles the full text — the context-fold idiom (the user 2026-08-15, whose staged
+    // line ran off the right edge with no ellipsis and no way to read the rest)
+    const open = stagedOpen.has(id + ":" + i);
+    if (open) chip.classList.add("open");
+    const hint = el("span", "staged-expand");
+    hint.textContent = open ? "(collapse)" : "(expand)";
+    const toggle = () => {
+      const k = id + ":" + i;
+      if (stagedOpen.has(k)) stagedOpen.delete(k); else stagedOpen.add(k);
+      renderStagedStrip(id);
+    };
+    chip.addEventListener("click", toggle);
     const x = el("button", "composer-chip-x");
     x.setAttribute("aria-label", "Discard staged message");
     x.textContent = "✕";
-    x.addEventListener("click", () => { stagedMsgs.removeAt(id, i); persistDrafts(); renderStagedStrip(id); });
-    chip.append(mark, label, x);
+    x.addEventListener("click", (ev) => { ev.stopPropagation(); stagedMsgs.removeAt(id, i); persistDrafts(); renderStagedStrip(id); });
+    row.append(mark, label, hint, x);
+    chip.appendChild(row);
     strip.appendChild(chip);
   });
 }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -567,9 +567,21 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .staged-head .staged-go { margin-left: auto; background: none; border: 1px solid var(--accent); color: var(--accent);
   border-radius: 5px; font: inherit; padding: 1px 8px; cursor: pointer; }
 .staged-head .staged-go:hover { background: var(--accent); color: var(--accent-fg); }
-.staged-chip { display: flex; align-items: center; gap: 6px; border: 1px dashed rgba(156, 210, 255, 0.45);
-  border-left: 2px solid var(--accent); border-radius: 6px; padding: 2px 6px; font-size: 12px; color: var(--fg); }
-.staged-chip .composer-chip-label { flex: 1 1 auto; max-width: none; }
+.staged-chip { display: flex; flex-direction: column; gap: 2px; border: 1px dashed rgba(156, 210, 255, 0.45);
+  border-left: 2px solid var(--accent); border-radius: 6px; padding: 2px 6px; font-size: 12px; color: var(--fg);
+  cursor: pointer; }
+.staged-row, .staged-cite { display: flex; align-items: center; gap: 6px; min-width: 0; }
+/* the context the reply was written against, INSIDE the box (the user 2026-08-15): quieter than the
+   reply line, its own fold — same one-line-ellipsis-then-expand read as everything else here */
+.staged-cite { color: var(--dim); }
+.staged-cite.open .composer-chip-label { white-space: pre-wrap; overflow: visible; }
+.staged-cite.open { align-items: flex-start; }
+/* min-width:0 lets the flex label actually SHRINK — without it the line ran off the pane edge with no
+   ellipsis (the user 2026-08-15); expanded, the same label wraps to the full text */
+.staged-chip .composer-chip-label { flex: 1 1 auto; max-width: none; min-width: 0; }
+.staged-chip.open .staged-row .composer-chip-label { white-space: pre-wrap; overflow: visible; }
+.staged-chip.open .staged-row { align-items: flex-start; }
+.staged-expand { flex: 0 0 auto; color: var(--dim); font-size: 0.85em; }   /* chrome, not message text */
 .composer-chip-x {
   flex: 0 0 auto; border: none; background: none; cursor: pointer; color: var(--dim);
   font-size: 11px; line-height: 1; padding: 2px 4px; border-radius: 8px;


### PR DESCRIPTION
Three asks on the staged-message strip:

- The reply line ran off the pane edge with no ellipsis (flex label without `min-width:0` can never shrink). It now clips **in bounds** with an ellipsis plus a dim parenthesized "(expand)" — visibly chrome, not message text — and clicking the box toggles the full text (the context-fold idiom). Fold state is keyed so it survives re-renders.
- Each staged reply carries the **context it was written against inside its dotted box**: one quieter chip per quote, independently expandable (its click never toggles the reply's own fold).
- The per-message discard ✕ stays, `stopPropagation`ed against the fold.

Source pins in `composer-send.test.ts`; suites green (4749 py + 2002 ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)