### PR TITLE
A watcher turn is never unsure: the closer names the monitor-event shape

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -7057,7 +7057,11 @@ CLOSER_SYS = (
     "and found still running) and the stated or clear intent to take action again when its result "
     "arrives. Waiting on the user is blocked, never awaiting. Async work whose result already came "
     "back this turn is not awaiting. Unfinished work with nothing actually in flight stays working "
-    "(omit it). When unsure between awaiting and omitting, omit.\n"
+    "(omit it). When unsure between awaiting and omitting, omit. One shape is never unsure: a WATCHER "
+    "turn — the session woke on a schedule or a monitor's report, saw the external job still running, "
+    "and ended with the watch still armed — is awaiting kind \"job\": the live watcher is the work in "
+    "flight and the wake-on-events arrangement is the intent to act; file it even when the turn "
+    "reports nothing new.\n"
     "Reply with only a JSON object (no prose, no markdown fences):\n"
     '{\"done\": [ {\"goal\": <n>, \"why\": \"...\"} ], \"block\": [ {\"goal\": <n>, \"why\": \"...\"} ], '
     '\"awaiting\": [ {\"goal\": <n>, \"why\": \"...\", \"kind\": \"...\"} ]}\n'

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -7398,6 +7398,15 @@ class AwaitingVerdict(unittest.TestCase):
         with self.assertRaises(TypeError):
             nd["awaitingAt"] = 123
 
+    def test_closer_prompt_names_the_watcher_turn_as_canonical_awaiting(self):
+        # live repro 2026-08-15 (exp session, monitor over a slurm job): with the false block lifted,
+        # the closer STILL omitted on a monitor-event turn — "job still running, nothing new" read as
+        # unsure, and unsure omits. The watcher shape is never unsure: the live watcher is the work in
+        # flight and the wake-on-events arrangement is the intent to act.
+        for phrase in ("One shape is never unsure: a WATCHER", "ended with the watch still armed",
+                       "file it even when the turn " + "reports nothing new"):
+            self.assertIn(phrase, jd.CLOSER_SYS)
+
     def test_closer_prompt_forbids_filing_a_handoff_wait_as_a_block(self):
         # live case 2026-08-15: "Engage the new session when ready: it is launched... and will present
         # results" was filed as a BLOCK — a peer-wait wearing needs-you clothing. The blocked rollup


### PR DESCRIPTION
Live repro (the missing-awaiting investigation's second half): with the false block lifted, a session ended a clean monitor-event turn — woke on the watcher's report, saw slurm still running, ended with the watch armed — and six minutes later the closer had filed nothing. "Job still running, nothing new" read as unsure, and unsure omits, so the canonical external-job wait earned no stamp.

The awaiting instruction now names the shape as never-unsure: a watcher turn's live monitor IS the work in flight and the wake-on-events arrangement IS the intent to act — file awaiting kind `job` even when the turn reports nothing new.

Prompt-phrase test; suites green (4751 py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)