### PR TITLE
A cross-host reply addressed to the relay still answers the ask

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15532,14 +15532,27 @@ def _postal_wait_maps():
         return _POSTAL_WAIT_CACHE[1]
     last_any, last_ask = {}, {}
     try:
+        rows = []
+        alias = {}   # "host:name" -> sid, learned from every row a remote sender stamped
         for line in jd.MESSAGES.read_text(errors="replace").splitlines():
             try:
                 o = json.loads(line)
             except Exception:
                 continue
+            rows.append(o)
+            if o.get("from_host") and o.get("from") and o.get("from_id"):
+                alias[str(o["from_host"]) + ":" + str(o["from"])] = str(o["from_id"])
+        for o in rows:
             f, t_, ts = o.get("from_id"), o.get("to_id"), o.get("t")
             if not (f and t_ and ts):
                 continue
+            # a CROSS-HOST row is addressed to the RELAY ("peer:<host>"), not the recipient's sid —
+            # so the (from,to) pair could never close and the asker wore "Awaiting <peer>" forever
+            # (obsidian↔lab_manager, 2026-08-15: the reply landed, the edge never cleared). The row's
+            # toName ("<host>:<name>") resolves to the real sid through the alias map above; an
+            # unresolvable relay keeps the raw id and behaves exactly as before.
+            if isinstance(t_, str) and t_.startswith("peer:") and o.get("toName"):
+                t_ = alias.get(str(o["toName"]), t_)
             ts = int(ts)
             last_any[(f, t_)] = max(last_any.get((f, t_), 0), ts)
             k = o.get("kind")                            # the sender's DECLARED intent (schema field) wins

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -7419,6 +7419,28 @@ class WaitGraphDelegatesAndStampSupersede(unittest.TestCase):
         return {"ev": "sent", "id": "m%d" % ts, "from_id": f, "to_id": t, "t": ts,
                 "from": "x", "body": body, "kind": kind}
 
+    def test_a_cross_host_reply_addressed_to_the_relay_still_answers_the_ask(self):
+        # obsidian↔lab_manager (2026-08-15): a cross-host reply is logged to_id "peer:<host>" (the
+        # relay), not the recipient's sid — the (from,to) pair never closed and the asker wore
+        # "Awaiting <peer>" forever after the answer landed. The row's toName resolves through the
+        # alias map every remote sender's rows build (from_host + from -> from_id).
+        self._log(
+            # the remote asker's question, stamped with its host+name (this row TEACHES the alias)
+            dict(self._msg(self.A, self.B, NOW - 300, "question"),
+                 **{"from": "web", "from_host": "TESTHOST"}),
+            # the local session's reply, addressed to the relay — the observed cross-host shape
+            dict(self._msg(self.B, "peer:TESTHOST", NOW - 200, "coordinate"),
+                 toName="TESTHOST:web"))
+        g = km._wait_for_graph(NOW, {self.A, self.B})
+        self.assertNotIn(self.A, g, "the relay-addressed reply answers the ask once toName resolves")
+
+    def test_an_unresolvable_relay_row_behaves_as_before(self):
+        self._log(self._msg(self.A, self.B, NOW - 300, "question"),
+                  dict(self._msg(self.B, "peer:TESTHOST", NOW - 200, "coordinate"),
+                       toName="TESTHOST:never-seen"))
+        g = km._wait_for_graph(NOW, {self.A, self.B})
+        self.assertIn(self.A, g, "no alias for the name -> the raw relay id keeps today's behavior")
+
     def test_delegate_creates_a_wait_edge_and_any_reply_clears_it(self):
         self._log(self._msg(self.A, self.B, NOW - 300, "delegate"))
         g = km._wait_for_graph(NOW, {self.A, self.B})


### PR DESCRIPTION
Live phantom, reported by the session wearing it: a laptop session asked a devbox session a question, the answer came back within two minutes, and the asker's card wore "Awaiting \<peer\>" forever after. A cross-host reply is logged addressed to the **relay** (`to_id: "peer:<host>"`), not the recipient's sid, so `_postal_wait_maps`' (from, to) pair could never close — and the same shape breaks `_peer_answered_at`'s stamp supersede for cross-host peer waits.

The pairing now resolves relay-addressed rows through the host:name alias every remote sender's rows already teach (`from_host` + `from` → `from_id`), taking the row's `toName` to the real sid. An unresolvable relay keeps the raw id and behaves as before. Tests reproduce the observed row shapes verbatim (synthetic ids). Suites green (4753 py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)