### PR TITLE
docs: distiller notes' durable home is dotfiles plus a symlink

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -193,7 +193,11 @@ at call time (no restart needed) and appended to the prompt, notes winning
 over prompt defaults on conflict. Plain language, e.g. "never cite PR or
 commit numbers; say what the change does". Delete the file and the next
 call runs bare. The placement judges and the courier never see it: those
-emit verdicts and agent-directed copy, not prose for you.
+emit verdicts and agent-directed copy, not prose for you. The path is a
+plain read that follows symlinks, so the durable setup is the content in
+your dotfiles with a symlink here — one edit then reaches every machine's
+judges through your normal dotfiles sync (the user 2026-08-15), instead
+of each kernel keeping its own hand-seeded copy.
 
 **briefer.** When a top card blocks (and live for the focused picker or
 permission goal): a decision brief that leads with exactly what you must


### PR DESCRIPTION
Docs-only. The user (2026-08-15): the distiller-notes file should travel with their dotfiles rather than sit per-machine. No code change needed — the reader is a plain read that follows symlinks — so the docs now name the durable pattern: content in dotfiles, symlink at `~/.config/romp/distiller-notes.md`, one edit reaching every machine's judges via the normal dotfiles sync. (Their dotfiles now carry exactly that arrangement, installed by their setup script.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)