### PR TITLE
The staged context chip keeps the composer's blue pill; width bound tight

### DIFF
--- a/ui/webview/composer-send.test.ts
+++ b/ui/webview/composer-send.test.ts
@@ -90,7 +90,7 @@ test("a staged chip clips IN BOUNDS with an ellipsis and expands on click (the u
   const STYLES = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
   // the flex label could never shrink (no min-width:0), so long texts ran off the pane edge with no
   // ellipsis; expanded, the same label wraps to the full text — the context-fold idiom
-  assert.match(STYLES, /\.staged-chip \.composer-chip-label \{ flex: 1 1 auto; max-width: none; min-width: 0; \}/);
+  assert.match(STYLES, /\.staged-chip \.composer-chip-label \{ flex: 1 1 auto; max-width: 100%; min-width: 0; \}/);
   assert.match(STYLES, /\.staged-chip\.open \.staged-row \.composer-chip-label \{ white-space: pre-wrap; overflow: visible; \}/);
   // the affordance is visibly CHROME, not message text: dim, parenthesized, at the line's end
   assert.match(STYLES, /\.staged-expand \{ flex: 0 0 auto; color: var\(--dim\); font-size: 0\.85em; \}/);
@@ -102,6 +102,9 @@ test("a staged chip clips IN BOUNDS with an ellipsis and expands on click (the u
   // expandable (its click never toggles the reply's own fold), keyed sid:i:j
   assert.match(RENDER, /const quotes = \(s\.cites as Citation\[\]\)\.filter\(\(c\) => c && c\.quote\);/);
   assert.match(RENDER, /const ck = id \+ ":" \+ i \+ ":" \+ j;/);
+  // the context keeps the composer's blue citation-pill look inside the staged box
+  assert.match(RENDER, /el\("div", "composer-chip staged-cite"/);
+  assert.match(STYLES, /\.staged-cite \{ min-width: 0; max-width: 100%; cursor: pointer; \}/);
   assert.match(RENDER, /cite\.addEventListener\("click", \(ev\) => \{\s*\n\s*ev\.stopPropagation\(\);/);
   assert.match(STYLES, /\.staged-cite\.open \.composer-chip-label \{ white-space: pre-wrap; overflow: visible; \}/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8434,7 +8434,9 @@ function renderStagedStrip(id: string | null): void {
     for (let j = 0; j < quotes.length; j++) {
       const ck = id + ":" + i + ":" + j;
       const cOpen = stagedOpen.has(ck);
-      const cite = el("div", "staged-cite" + (cOpen ? " open" : ""));
+      // the SAME blue citation pill the composer wears (the user 2026-08-15: the context must keep
+      // "its little blue background chip", not restyle inside the staged box)
+      const cite = el("div", "composer-chip staged-cite" + (cOpen ? " open" : ""));
       const cm = el("span", "composer-chip-mark"); cm.textContent = "“";
       const cl = el("span", "composer-chip-label"); cl.textContent = quotes[j].quote || "";
       const ch = el("span", "staged-expand"); ch.textContent = cOpen ? "(collapse)" : "(expand)";

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -571,14 +571,16 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   border-left: 2px solid var(--accent); border-radius: 6px; padding: 2px 6px; font-size: 12px; color: var(--fg);
   cursor: pointer; }
 .staged-row, .staged-cite { display: flex; align-items: center; gap: 6px; min-width: 0; }
-/* the context the reply was written against, INSIDE the box (the user 2026-08-15): quieter than the
-   reply line, its own fold — same one-line-ellipsis-then-expand read as everything else here */
-.staged-cite { color: var(--dim); }
+/* the context the reply was written against, INSIDE the box (the user 2026-08-15): it keeps the
+   composer's own blue citation-pill look (the class rides along), its own fold — same
+   one-line-ellipsis-then-expand read as everything else here. min-width:0 + max-width guard the
+   pane against sideways growth at every level. */
+.staged-cite { min-width: 0; max-width: 100%; cursor: pointer; }
 .staged-cite.open .composer-chip-label { white-space: pre-wrap; overflow: visible; }
 .staged-cite.open { align-items: flex-start; }
 /* min-width:0 lets the flex label actually SHRINK — without it the line ran off the pane edge with no
    ellipsis (the user 2026-08-15); expanded, the same label wraps to the full text */
-.staged-chip .composer-chip-label { flex: 1 1 auto; max-width: none; min-width: 0; }
+.staged-chip .composer-chip-label { flex: 1 1 auto; max-width: 100%; min-width: 0; }
 .staged-chip.open .staged-row .composer-chip-label { white-space: pre-wrap; overflow: visible; }
 .staged-chip.open .staged-row { align-items: flex-start; }
 .staged-expand { flex: 0 0 auto; color: var(--dim); font-size: 0.85em; }   /* chrome, not message text */


### PR DESCRIPTION
Two follow-ups on the staged strip:

- The context quote inside a staged box wears the **same blue citation pill** the composer shows (the `composer-chip` class rides along) instead of restyling as dim text.
- The label's `max-width` goes `none` → `100%` and the cite row carries `min-width:0; max-width:100%`, so no level of the staged box can grow the chat pane sideways (the reported horizontal scroll). Collapsed rows ellipsize in bounds; expanded rows wrap.

Pins updated in `composer-send.test.ts`; suites green (2002 ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)