### PR TITLE
A session can close itself: romp end self, deferred to the turn's settle

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -883,13 +883,40 @@ if [[ "${1:-}" =~ ^(--)?(send|interrupt|end)$ ]]; then
     _who="${1:-}"
     if [[ -z "$_who" ]]; then echo "usage: romp $_verb <session> $([[ "$_verb" == send ]] && echo '<text>')" >&2; exit 2; fi
     shift
+    # `romp end self [--now]` — a session closing ITSELF after finishing its work (the user
+    # 2026-08-15: telling a session "close yourself when done" never worked; an agent could only
+    # kill its own process, which read as a crash). `self` resolves through ROMP_SID (spawn-frozen
+    # by the SDK backend, inherited by every Bash the agent runs). Default is when=idle: the kernel
+    # kills at the turn's SETTLE, so the goodbye lands and the judges file the outcome before the
+    # clean × death. --now skips the deferral (for any target).
+    _when="";
+    if [[ "$_verb" == "end" ]]; then
+        [[ "$_who" == "self" ]] && _when="idle"
+        for _a in "$@"; do
+            [[ "$_a" == "--now" ]] && _when=""
+            [[ "$_a" == "--when-idle" ]] && _when="idle"
+        done
+    fi
     _kport="${ROMP_KERNEL_PORT:-29855}"
     if [[ "$_verb" == "send" ]]; then
         _text="$*"
         if [[ -z "$_text" ]]; then echo "usage: romp send <session> <text>" >&2; exit 2; fi
         _payload="$(python3 -c 'import json,sys; print(json.dumps({"name": sys.argv[1], "text": sys.argv[2]}))' "$_who" "$_text")"
+    elif [[ "$_verb" == "end" && "$_who" == "self" ]]; then
+        if [[ -z "${ROMP_SID:-}" ]]; then
+            echo "romp end self: ROMP_SID is not set — 'self' only works from inside a romp SDK session" >&2
+            exit 2
+        fi
+        _payload="$(python3 -c 'import json,sys; d={"id": sys.argv[1]};
+import os
+w=sys.argv[2]
+if w: d["when"]=w
+print(json.dumps(d))' "$ROMP_SID" "$_when")"
     else
-        _payload="$(python3 -c 'import json,sys; print(json.dumps({"name": sys.argv[1]}))' "$_who")"
+        _payload="$(python3 -c 'import json,sys; d={"name": sys.argv[1]};
+w=sys.argv[2] if len(sys.argv)>2 else ""
+if w: d["when"]=w
+print(json.dumps(d))' "$_who" "$_when")"
     fi
     _resp="$(_romp_token_cfg | curl -sf -m 10 --config - -X POST "http://127.0.0.1:$_kport/$_verb" \
                   -H 'Content-Type: application/json' -d "$_payload")" \

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10085,6 +10085,53 @@ def _death_stamp_due(sid):
     return int((last or {}).get("t") or 0) > int(m.get("t") or 0)
 
 
+# SELF-CLOSE, deferred to idle (the user 2026-08-15: "close yourself after you've done this thing"
+# never worked — an agent could only kill its own process, which romp read as a CRASH and kept the
+# session visible as dormant). `romp end self` records the sid here; the sweep below gives it the
+# dashboard ×'s clean death the moment its turn SETTLES — the goodbye delivered, the judges' pass
+# armed — never mid-own-turn. A state file, not memory: the request survives kernel restarts.
+def _end_on_idle_load():
+    try:
+        v = json.loads((jd.STATE / "end-on-idle.json").read_text())
+        return set(x for x in v if isinstance(x, str)) if isinstance(v, list) else set()
+    except (OSError, ValueError):
+        return set()
+
+
+def _end_on_idle_save(reqs):
+    _atomic_write(jd.STATE / "end-on-idle.json", json.dumps(sorted(reqs)))
+
+
+def _end_on_idle_sweep(now, tmux):
+    """Kill each end-on-idle sid once its turn settles — the same clean path as the dashboard × /
+    the immediate /end route (intentional death, no reviver, tab closed). A sid already dead by any
+    other path just retires its request."""
+    reqs = _end_on_idle_load()
+    if not reqs:
+        return
+    changed = False
+    for sid in sorted(reqs):
+        if tmux.get(sid) is None:                    # already dead → the request is spent
+            reqs.discard(sid); changed = True
+            continue
+        try:
+            ps = _parse(_path_of(sid) or "", sid, now)
+            if _session_working(ps.get("turns") or []):
+                continue                             # the turn it asked from is still open — its end is the event
+        except Exception:
+            continue
+        sys.stderr.write("kill: %s via end-on-idle (self-close)\n" % sid)
+        be = Sessions.backend_for(sid)
+        be.kill(sid)
+        _record_death(sid, int(now), "kill")
+        _comment_kill_all(sid, be)
+        _send_to_app("chat", {"type": "closed", "id": sid})
+        reqs.discard(sid); changed = True
+    if changed:
+        _end_on_idle_save(reqs)
+        _push_soon()
+
+
 def _record_death(sid, now, by):
     """Record a session's death: the marker (STATE/gone/<sid>.json, atomically — a re-stamp drops any
     prior endedAt, re-arming the finalize) plus ONE plain idle row via _record_idle, byte-identical to
@@ -20307,6 +20354,10 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _death_sweep_tick(now, tmux)      # corroborated with the liveness owner, then stamped (2026-08-13)
     except Exception:
         sys.stderr.write("death-sweep: %s\n" % traceback.format_exc())
+    try:                                  # a session that asked to close itself dies at its turn's settle
+        _end_on_idle_sweep(now, tmux)     # (the clean × path — the user 2026-08-15's "close yourself")
+    except Exception:
+        sys.stderr.write("end-on-idle: %s\n" % traceback.format_exc())
     try:                                  # deferral records retire on their reasons' own events — BEFORE
         _deferral_sweep_tick(now)         # the walk, independent of the nudge toggle (the stall/swirl
     except Exception:                     # surfaces read these records regardless)
@@ -24221,6 +24272,15 @@ class Handler(BaseHTTPRequestHandler):
                 if u.path == "/interrupt":
                     be.interrupt(sid)                           # Esc/stop AND settle idle (in the backend)
                     _interrupt_clicked[str(sid)] = time.time()  # chip → "interrupting" NOW, same as the WS op
+                elif isinstance(b, dict) and b.get("when") == "idle":
+                    # SELF-CLOSE deferral (the user 2026-08-15): record the wish; the pusher's sweep
+                    # kills at the turn's settle, so a session ending itself finishes its goodbye first
+                    reqs = _end_on_idle_load()
+                    if sid not in reqs:
+                        reqs.add(sid)
+                        _end_on_idle_save(reqs)
+                    _audit_restart_request("end-on-idle", tag=str(sid), addr=str(self.client_address[0]))
+                    return self._send(200, json.dumps({"ok": True, "deferred": True}), "application/json")
                 else:
                     sys.stderr.write("kill: %s via /kill route\n" % sid)   # kill attribution (the user 2026-07-16)
                     be.kill(sid)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3454,7 +3454,10 @@ class SdkBackend:
             # 2026-07-27 federation shakedown: a remote session's `romp mail send` died
             # command-not-found and re-prompted for permission on the absolute-path retry). options.env
             # merges OVER the inherited environment in the SDK's transport, so this is additive.
-            env=_bin_on_path_env(os.environ),
+            # ROMP_SID gives the CLI process (and every Bash it runs) the session's STABLE identity —
+            # what lets `romp end self` resolve itself to the kernel (the user 2026-08-15). The sid,
+            # not the name: names rename after spawn, env is spawn-frozen.
+            env={**_bin_on_path_env(os.environ), "ROMP_SID": str(sess.sid)},
             # Registering this is what makes the CLI's stderr EXIST for romp at all: the SDK transport
             # pipes the child's stderr only when options.stderr is set (otherwise it hands the child
             # our own stderr and reports SDK_STDERR_PLACEHOLDER on failure). Without it, a CLI that

--- a/tests/romp-headless.bats
+++ b/tests/romp-headless.bats
@@ -60,6 +60,27 @@ PY
     grep -q "^/end$" <(head -1 "$TEST_DIR/req")
 }
 
+@test "romp end self resolves through ROMP_SID and defers to idle by default" {
+    # a session closing ITSELF after its work (the user 2026-08-15): self = the spawn-frozen sid,
+    # and the kernel kills at the turn's settle so the goodbye lands first
+    start_fake_kernel '{"ok": true}'
+    ROMP_SID="11111111-2222-3333-4444-555555555555" run "$ROMP_SCRIPT" end self
+    [ "$status" -eq 0 ]
+    grep -q "^/end$" <(head -1 "$TEST_DIR/req")
+    grep -q '"id": "11111111-2222-3333-4444-555555555555"' "$TEST_DIR/req"
+    grep -q '"when": "idle"' "$TEST_DIR/req"
+}
+
+@test "romp end self --now skips the deferral; self outside a session fails loudly" {
+    start_fake_kernel '{"ok": true}'
+    ROMP_SID="11111111-2222-3333-4444-555555555555" run "$ROMP_SCRIPT" end self --now
+    [ "$status" -eq 0 ]
+    ! grep -q '"when"' "$TEST_DIR/req"
+    ROMP_SID="" run "$ROMP_SCRIPT" end self
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"only works from inside a romp SDK session"* ]]
+}
+
 @test "the dashed spellings are silent aliases: --send works and says nothing about it" {
     # Agent-facing text delivered before 2026-07-25 (postal reply footers, skill
     # docs in old transcripts) names the dashed forms; they must keep working

--- a/tests/test_fresh_install_federation.py
+++ b/tests/test_fresh_install_federation.py
@@ -79,7 +79,7 @@ class SpawnedSessionPath(unittest.TestCase):
 
     def test_options_pass_the_overlay(self):
         src = Path(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read_text()
-        self.assertIn("env=_bin_on_path_env(os.environ)", src,
+        self.assertIn('env={**_bin_on_path_env(os.environ), "ROMP_SID": str(sess.sid)}', src,
                       "_options wires the overlay through the SDK's designed env field")
 
 

--- a/tests/test_kernel_end_on_idle.py
+++ b/tests/test_kernel_end_on_idle.py
@@ -1,0 +1,104 @@
+"""Self-close, deferred to idle (the user 2026-08-15): telling a session "close yourself after you've
+done this thing" never worked — an agent could only kill its own process, which romp read as a CRASH
+and kept the session visible as dormant. Now `romp end self` records the sid (end-on-idle.json, a
+STATE file so the wish survives kernel restarts) and the pusher's sweep gives it the dashboard ×'s
+clean death the moment its turn settles — the goodbye delivered first, never mid-own-turn.
+SYNTHETIC fixtures only."""
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_endidle", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.killed = []
+
+    def kill(self, sid):
+        self.killed.append(sid)
+        return True
+
+
+class EndOnIdle(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = {k: getattr(km, k) for k in
+                      ("_parse", "_path_of", "_session_working", "_record_death",
+                       "_comment_kill_all", "_send_to_app", "_push_soon")}
+        self.saved_state = km.jd.STATE
+        km.jd.STATE = Path(self.td.name)
+        self.be = _FakeBackend()
+        self.saved_backend_for = km.Sessions.backend_for
+        km.Sessions.backend_for = staticmethod(lambda sid: self.be)
+        km._parse = lambda path, sid, now: {"turns": []}
+        km._path_of = lambda sid, now=None: "/p"
+        km._session_working = lambda turns: False
+        self.deaths = []
+        km._record_death = lambda sid, now, by: self.deaths.append((sid, by))
+        km._comment_kill_all = lambda sid, be: None
+        self.sent = []
+        km._send_to_app = lambda app, m: self.sent.append((app, m))
+        km._push_soon = lambda *a, **k: None
+
+    def tearDown(self):
+        for k, v in self.saved.items():
+            setattr(km, k, v)
+        km.Sessions.backend_for = self.saved_backend_for
+        km.jd.STATE = self.saved_state
+        self.td.cleanup()
+
+    def test_the_wish_survives_in_state_and_round_trips(self):
+        km._end_on_idle_save({SID})
+        self.assertEqual(km._end_on_idle_load(), {SID})
+        self.assertEqual(json.loads((km.jd.STATE / "end-on-idle.json").read_text()), [SID])
+
+    def test_the_sweep_kills_at_the_turns_settle_with_the_clean_death(self):
+        km._end_on_idle_save({SID})
+        km._end_on_idle_sweep(1000, {SID: {"state": ""}})
+        self.assertEqual(self.be.killed, [SID])
+        self.assertEqual(self.deaths, [(SID, "kill")], "the dashboard ×'s intentional death, never a crash")
+        self.assertIn(("chat", {"type": "closed", "id": SID}), self.sent, "the tab closes like the × path")
+        self.assertEqual(km._end_on_idle_load(), set(), "the wish is spent")
+
+    def test_an_open_turn_defers_the_kill(self):
+        km._session_working = lambda turns: True
+        km._end_on_idle_save({SID})
+        km._end_on_idle_sweep(1000, {SID: {"state": ""}})
+        self.assertEqual(self.be.killed, [], "the turn it asked from is still open — its end is the event")
+        self.assertEqual(km._end_on_idle_load(), {SID}, "the wish stands for the next sweep")
+
+    def test_a_sid_already_dead_retires_its_request_without_a_kill(self):
+        km._end_on_idle_save({SID})
+        km._end_on_idle_sweep(1000, {})              # not in the live map → dead by some other path
+        self.assertEqual(self.be.killed, [])
+        self.assertEqual(self.deaths, [], "no second death record over whatever really happened")
+        self.assertEqual(km._end_on_idle_load(), set())
+
+    def test_the_route_and_spawn_env_wiring_is_pinned(self):
+        src = Path(BIN, "romp-kernel").read_text()
+        self.assertIn('b.get("when") == "idle"', src, "/end honors the deferral")
+        self.assertIn('{"ok": True, "deferred": True}', src)
+        self.assertIn("_end_on_idle_sweep(now, tmux)", src, "the sweep rides the pusher's tick jobs")
+        sdk = Path(os.path.dirname(BIN), "kernel", "sdk_backend.py").read_text()
+        self.assertIn('"ROMP_SID": str(sess.sid)', sdk,
+                      "the CLI process carries the session's stable identity for `romp end self`")
+        cli = Path(BIN, "romp").read_text()
+        self.assertIn('"romp end self: ROMP_SID is not set', cli)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
"Close yourself after you've done this thing" never worked: an agent could only kill its own process, which romp read as a **crash** (resume notices, dormant entry everywhere). The headless `/end` route and CLI verb existed, but a session had no identity to call them with, and an immediate kill cuts the very turn saying goodbye.

- The SDK backend spawns every CLI with `ROMP_SID` (spawn-frozen sid — names rename, env doesn't), so **`romp end self`** works from any Bash the agent runs.
- `self` defaults to `when=idle`: the wish is recorded in `end-on-idle.json` (survives kernel restarts) and the pusher's sweep delivers the dashboard ×'s clean death at the turn's settle — goodbye delivered, judges' pass armed, intentional death record, no reviver, tab closed, revivable from the timeline. `--now` skips the deferral; an already-dead sid retires its wish without a second death record.

Tests: five kernel cases (round-trip, settle-kill, open-turn deferral, dead-sid retirement, wiring pins) + two bats cases (self resolution + `--now`/loud failure outside a session). Suites green (4758 py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)