### PR TITLE
The $/h chart's ceiling line and label draw unconditionally

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21405,11 +21405,15 @@ var top=50*Math.ceil(mx/50),step=50;
 while(top/step>4)step*=2;
 var X=function(i){return (n>1?i/(n-1):0.5)*W;},Y=function(v){return H-1-Math.max(0,Math.min(1,v/top))*(H-2);};
 var grid='',ylab='',xlab='';
-for(var g=step;g<=top;g+=step){var gy=Y(g);
-grid+='<line x1="0" y1="'+gy.toFixed(1)+'" x2="'+W+'" y2="'+gy.toFixed(1)+'" stroke="rgba(255,255,255,0.10)" stroke-width="1" vector-effect="non-scaling-stroke"/>';
-// ONE y label, the top gridline only (the user 2026-08-15): a $100/$200/$300/$400 stack said the
-// same thing four times in a chart 64px tall — the gridlines keep the rhythm, the ceiling names it
-if(g===top)ylab+='<span class=ru-tip-gy style="top:'+(gy/H*56).toFixed(0)+'px">$'+g+'</span>';}
+for(var g=step;g<top;g+=step){var gy=Y(g);
+grid+='<line x1="0" y1="'+gy.toFixed(1)+'" x2="'+W+'" y2="'+gy.toFixed(1)+'" stroke="rgba(255,255,255,0.10)" stroke-width="1" vector-effect="non-scaling-stroke"/>';}
+// ONE y label, the CEILING, always (the user 2026-08-15 twice: first the $100..$400 stack said the
+// same thing four times; then the ceiling-only label vanished whenever step-doubling made top (450)
+// miss the step loop entirely). The ceiling is already the nice number (the next $50 above the
+// peak: 423→450, 597→600) — draw its line and its one label unconditionally, off the loop.
+var ty=Y(top);
+grid+='<line x1="0" y1="'+ty.toFixed(1)+'" x2="'+W+'" y2="'+ty.toFixed(1)+'" stroke="rgba(255,255,255,0.10)" stroke-width="1" vector-effect="non-scaling-stroke"/>';
+ylab='<span class=ru-tip-gy style="top:'+(ty/H*56).toFixed(0)+'px">$'+top+'</span>';
 for(var i=0;i<n;i++){var d=new Date((h0+i)*3600000);
 if(d.getHours()===0){var gx=X(i);
 grid+='<line x1="'+gx.toFixed(1)+'" y1="0" x2="'+gx.toFixed(1)+'" y2="'+H+'" stroke="rgba(255,255,255,0.06)" stroke-width="1" vector-effect="non-scaling-stroke"/>';

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -240,6 +240,12 @@ test("the $/h chart is a real chart, and refresh is automatic with no stale hint
   const usageJS = KERNEL.split('_LANDING_USAGE_JS = """')[1].split('"""')[0];
   // y-axis scaled to the ceiling of the nearest $50; rules thin to $100/$200/... past four
   assert.ok(usageJS.includes("var top=50*Math.ceil(mx/50),step=50;"), "y ceiling = nearest $50");
+  // the ceiling's line + its ONE label draw unconditionally, OFF the step loop (the user 2026-08-15:
+  // step-doubling made top=450 miss the $200-step loop and the chart lost its only y label)
+  assert.ok(usageJS.includes("for(var g=step;g<top;g+=step)"), "interior gridlines stop below the ceiling");
+  assert.ok(usageJS.includes("var ty=Y(top);"), "the ceiling edge is computed once");
+  assert.ok(usageJS.includes(`ylab='<span class=ru-tip-gy style="top:'+(ty/H*56).toFixed(0)+'px">$'+top+'</span>';`),
+    "the one y label is the ceiling, always present");
   assert.ok(usageJS.includes("while(top/step>4)step*=2;"), "at most four horizontal rules");
   // x-axis: midnight ticks placed in LOCAL time off the series' epoch-hour base, weekday initials under
   assert.ok(usageJS.includes("if(d.getHours()===0)"), "midnight ticks");


### PR DESCRIPTION
The one y label (the ceiling) vanished whenever step-doubling made the ceiling miss the step loop: top=450 with $200 rules draws gridlines at 200/400 and never 450 — the chart lost its y scale entirely. The ceiling is already the nice number requested (next $50 above the peak: 423→450, 597→600); it now gets its own line and its one label unconditionally, off the loop, with interior gridlines below.

Pins in `rail-spend.test.ts`; suites green (4753 py + 2002 ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)