### PR TITLE
A delegate transfers ownership: only questions set the awaiting-peer edge

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15564,9 +15564,13 @@ _POSTAL_WAIT_CACHE = [None, None]   # (mtime_ns, size) , (last_any, last_ask) �
 def _postal_wait_maps():
     """(last_any, last_ask) from the postal log, cached on the file's (mtime, size): per ordered pair
     (from_id, to_id), last_any holds the latest t of ANY message, last_ask the latest (t, kind) of a
-    reply-EXPECTING ask — a QUESTION (an answer is required) or a DELEGATE (the recipient owns work whose
-    result comes back to the sender; the user 2026-07-25, whose handoff to a peer wore the generic
-    "background agents" box because only questions counted). COORDINATE/FYI rows never make last_ask.
+    reply-EXPECTING ask — a QUESTION only (an answer is definitionally required). A DELEGATE transfers
+    OWNERSHIP and sets no edge (the user 2026-08-15: a handoff whose body said "no reply needed" still
+    parked its sender as awaiting-peer, and a sender with many outstanding handoffs read as permanently
+    stalled — this REVERSES the 2026-07-25 rule that counted delegates, whose real want, handoff
+    visibility, is carried by the courier goal graph now: "delegated to X; waiting on their result"
+    rides _all_outstanding_delegated with the peer's completion as the exact ending event; a delegate
+    who genuinely needs a report-back asks with kind=question). COORDINATE/FYI rows never make last_ask.
     Rows carrying the schema `kind` use it; kindless legacy rows fall back to the QUESTION/ASK body
     prefix. Shared by _wait_for_graph (twice per push) and _peer_answered_at (the stamp readers), which
     each re-scanned the log per call before this cache."""
@@ -15603,7 +15607,7 @@ def _postal_wait_maps():
             ts = int(ts)
             last_any[(f, t_)] = max(last_any.get((f, t_), 0), ts)
             k = o.get("kind")                            # the sender's DECLARED intent (schema field) wins
-            is_ask = (k in ("question", "delegate")) if k else bool(_WAIT_Q_RE.match(o.get("body") or ""))
+            is_ask = (k == "question") if k else bool(_WAIT_Q_RE.match(o.get("body") or ""))
             if is_ask and ts >= last_ask.get((f, t_), (0, ""))[0]:
                 # the ask's HEAD rides along (the user 2026-07-26): the debt reminder quotes the asker's
                 # own first words back at the debtor, so the reminder needs no second log scan

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -2564,7 +2564,7 @@ def _mcp_call(name, args):
             if note:
                 return "Message to '%s': %s" % (to, note), False
             # Echo what the DECLARATION did, not just that bytes moved (the user 2026-07-26): a question
-            # or delegate records the SENDER as waiting on the recipient — a real hold that a mis-declared
+            # records the SENDER as waiting on the recipient — a real hold that a mis-declared
             # kind creates by accident (a "question" whose prose said no reply was needed parked its
             # sender for a day). Reading the cost back lets the sender self-correct on the spot, while
             # recall_message still works.
@@ -2573,8 +2573,10 @@ def _mcp_call(name, args):
                         "reply until they answer. If you don't actually need a reply, recall this "
                         "message and resend it as coordinate." % to, False)
             if kind == "delegate":
-                return ("Delivered to '%s' as a handoff — you are now recorded as waiting on them to "
-                        "report back; their next message to you clears it." % to, False)
+                return ("Delivered to '%s' as a handoff — they own it now; you are NOT recorded as "
+                        "waiting (the user 2026-08-15: ownership transferred is not a dependency). "
+                        "If you genuinely need their report before you can proceed, send a question "
+                        "instead." % to, False)
             return "Delivered to '%s'." % to, False
         except BusError as e:
             return str(e), True

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -7441,15 +7441,14 @@ class WaitGraphDelegatesAndStampSupersede(unittest.TestCase):
         g = km._wait_for_graph(NOW, {self.A, self.B})
         self.assertIn(self.A, g, "no alias for the name -> the raw relay id keeps today's behavior")
 
-    def test_delegate_creates_a_wait_edge_and_any_reply_clears_it(self):
+    def test_a_delegate_transfers_ownership_and_sets_no_edge(self):
+        # the user 2026-08-15 (reversing 2026-07-25): a handoff whose body said "no reply needed" still
+        # parked its sender as awaiting-peer, and a sender with many outstanding handoffs read as
+        # permanently stalled. Ownership transferred is not a dependency — only a QUESTION edges; real
+        # handoff visibility rides the courier goal graph with the peer's completion as the exact end.
         self._log(self._msg(self.A, self.B, NOW - 300, "delegate"))
-        g = km._wait_for_graph(NOW, {self.A, self.B})
-        self.assertEqual((g[self.A]["peerSid"], g[self.A]["kind"], g[self.A]["since"]),
-                         (self.B, "delegate", NOW - 300),
-                         "a handoff is a reply-expecting ask: it creates the edge, labeled delegate")
-        # ANY later message back — even a coordinate — answers the handoff; the edge clears on that event
-        self._log(self._msg(self.B, self.A, NOW - 100, "coordinate", body="done, merged"))
-        self.assertEqual(km._wait_for_graph(NOW, {self.A, self.B}), {})
+        self.assertEqual(km._wait_for_graph(NOW, {self.A, self.B}), {},
+                         "the delegator is free the moment the handoff sends")
 
     def test_coordinate_makes_no_edge_and_question_keeps_its_kind(self):
         self._log(self._msg(self.A, self.B, NOW - 300, "coordinate"))
@@ -7459,7 +7458,7 @@ class WaitGraphDelegatesAndStampSupersede(unittest.TestCase):
 
     def test_peer_answered_at_tracks_only_answered_pairs(self):
         self.assertEqual(km._peer_answered_at(self.A), 0, "no traffic → nothing answered")
-        self._log(self._msg(self.A, self.B, NOW - 300, "delegate"))
+        self._log(self._msg(self.A, self.B, NOW - 300, "question"))
         self.assertEqual(km._peer_answered_at(self.A), 0, "outstanding ask → not answered")
         self._log(self._msg(self.B, self.A, NOW - 200, "coordinate"))
         self.assertEqual(km._peer_answered_at(self.A), NOW - 200, "the reply time, once it lands")
@@ -7489,7 +7488,7 @@ class WaitGraphDelegatesAndStampSupersede(unittest.TestCase):
                           "awaitingWhy": "sent to a peer to build the flag parser",
                           "awaitingAt": NOW - 500}},
             "placements": {}, "status": {g: "working"}}))
-        self._log(self._msg(self.A, self.B, NOW - 600, "delegate"))
+        self._log(self._msg(self.A, self.B, NOW - 600, "question"))
         full, tops, _deleg = km._session_stamp_read(self.A)   # 3rd slot = delegated-peer sids (2026-08-08)
         self.assertEqual(full[2], "sent to a peer to build the flag parser")
         self.assertEqual(tops, frozenset({g}))

--- a/tests/test_postal_send_echo.py
+++ b/tests/test_postal_send_echo.py
@@ -43,10 +43,14 @@ class SendEcho(unittest.TestCase):
                       "…and the self-correction path while recall still works")
         self.assertEqual(self.posts[0][1], "/send", "the message itself still went out")
 
-    def test_a_handoff_reads_its_wait_back(self):
+    def test_a_handoff_reads_the_ownership_transfer_back(self):
+        # the user 2026-08-15 (reversing 2026-07-25): a delegate transfers ownership — the sender is
+        # NOT recorded as waiting; a sender needing the report before proceeding asks with question
         out = self._send("delegate")
         self.assertIn("as a handoff", out)
-        self.assertIn("waiting on them to report back", out)
+        self.assertIn("they own it now", out)
+        self.assertIn("NOT recorded as waiting", out)
+        self.assertIn("send a question", out)
 
     def test_a_coordinate_stays_the_plain_delivery_line(self):
         self.assertEqual(self._send("coordinate"), "Delivered to 'api'.")


### PR DESCRIPTION
A handoff whose body explicitly ended "no reply needed" still parked its sender as "Awaiting \<peer\>"; a sender with many outstanding handoffs would read as permanently stalled. Ownership transferred is not a dependency.

Reverses the 2026-07-25 rule counting delegates as reply-expecting asks — its real want (handoff visibility) is carried by the courier goal graph, which ends on the peer's completion. A delegator who genuinely needs the report asks with `kind=question`. Kindless legacy rows keep the body-regex. The postal send ack reads the transfer back honestly.

WaitGraph + send-echo tests flipped with rationale; suites green (4758 py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)