### PR TITLE
Auto converges batch behind a cool-down: N merges, one restart

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1993,7 +1993,9 @@ _UPDATE_CHECK_EVERY_S = 6 * 3600
 # off = silent, ask = the one-click notice, auto = converge unattended (the pull refuses a dirty
 # tree LOUDLY — peers' uncommitted work is never discarded — and the restart rides the manager's
 # quiet window, whose chain is silent-death-proof since the same day's fix).
-_MAIN_CHECK_EVERY_S = 300              # one ls-remote — cheap enough to notice a merge within minutes
+_MAIN_CHECK_EVERY_S = 300
+_CONVERGE_COOLDOWN_S = float(os.environ.get("ROMP_CONVERGE_COOLDOWN", "1500"))   # min gap between AUTO converges (25 min → ≤2-3 restarts/hour on a hot main)
+_LAST_AUTO_CONVERGE = [0.0]   # when the last auto converge fired (module state; a restart resets it, which is fine — the restart WAS the converge)              # one ls-remote — cheap enough to notice a merge within minutes
 _MAIN_DRIFT = ["", ""]                 # [origin sha a notice fired for, checkout sha one fired for]
 
 
@@ -2046,6 +2048,16 @@ def _main_drift_check():
         return                                        # already offered/acted on this exact sha
     _MAIN_DRIFT[slot] = target
     if _update_mode() == "auto":
+        # BATCH hot merge days (the user 2026-08-15, after flipping auto: main took a merge every few
+        # minutes and auto mode faithfully converged once per commit — 4+ restarts/hour, each cutting
+        # every in-flight turn; a peer's workflow died three consecutive runs). After an auto converge,
+        # further auto converges HOLD for a cool-down; the slot is left unoffered so the first pass
+        # past the window converges to the LATEST sha — N merges, one restart. A deliberate rate
+        # policy on restart disruption, not a proxy for an event; a clicked Update never waits.
+        if time.time() - _LAST_AUTO_CONVERGE[0] < _CONVERGE_COOLDOWN_S:
+            _MAIN_DRIFT[slot] = ""
+            return
+        _LAST_AUTO_CONVERGE[0] = time.time()
         _run_main_update(kind)
     else:
         _send_to_app("shell", {"type": "updateAvail", "kind": "main", "drift": kind,

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -68,6 +68,36 @@ class DriftWiring(unittest.TestCase):
         self.assertIn('threading.Thread(target=_run_main_update, args=(kind, True), daemon=True)', route,
                       "the banner click is the user's own deliberate cut")
 
+    def test_auto_converges_batch_behind_the_cool_down(self):
+        # the user 2026-08-15, after flipping auto: main took a merge every few minutes and auto mode
+        # converged once per commit — 4+ restarts/hour, each cutting every in-flight turn. Behind the
+        # cool-down, N merges inside the window become ONE restart to the LATEST sha.
+        ran = []
+        saved = (km._update_mode, km._origin_main_sha, km._checkout_sha, km._kernel_sha,
+                 km._run_main_update, km._LAST_AUTO_CONVERGE[0], km._MAIN_DRIFT[0], km._MAIN_DRIFT[1])
+        km._update_mode = lambda: "auto"
+        km._checkout_sha = lambda: "aaa"
+        km._kernel_sha = lambda: "aaa"
+        km._run_main_update = lambda kind, immediate=False: ran.append(kind)
+        try:
+            km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+            km._LAST_AUTO_CONVERGE[0] = 0.0
+            km._origin_main_sha = lambda: "bbb"
+            km._main_drift_check()
+            self.assertEqual(ran, ["pull"], "the first drift converges at once")
+            km._origin_main_sha = lambda: "ccc"          # a new merge lands inside the window
+            km._main_drift_check()
+            self.assertEqual(ran, ["pull"], "inside the cool-down, no second restart")
+            self.assertEqual(km._MAIN_DRIFT[0], "", "the deferred sha is NOT marked offered")
+            km._LAST_AUTO_CONVERGE[0] = 0.0              # the window passes
+            km._main_drift_check()
+            self.assertEqual(ran, ["pull", "pull"], "past the window, one converge takes the LATEST sha")
+        finally:
+            (km._update_mode, km._origin_main_sha, km._checkout_sha, km._kernel_sha,
+             km._run_main_update) = saved[:5]
+            km._LAST_AUTO_CONVERGE[0] = saved[5]
+            km._MAIN_DRIFT[0], km._MAIN_DRIFT[1] = saved[6], saved[7]
+
     def test_the_shell_banner_carries_the_drift_variants(self):
         src = inspect.getsource(km)
         self.assertIn("m.drift||''", src, "the shell relay forwards the drift kind")


### PR DESCRIPTION
Auto update mode on a hot main turned merge cadence into restart cadence: 4+ kernel restarts an hour, each cutting every in-flight turn (a peer's workflow died three consecutive runs). After an auto converge, further auto converges hold for a cool-down (`ROMP_CONVERGE_COOLDOWN`, default 25 min → at most ~2-3 restarts/hour); the deferred sha stays unoffered so the first pass past the window converges to the **latest** sha — N merges, one restart. Ask mode and the banner click never wait.

Behavioral test (first drift converges; in-window merge defers unoffered; past-window converge takes the latest). Suites green (4759 py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)