### PR TITLE
The End confirm names the session's open cards before the click

### DIFF
--- a/ui/webview/clear-confirm.test.ts
+++ b/ui/webview/clear-confirm.test.ts
@@ -7,7 +7,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { isClearCmd, openTopTitles, clearConfirmDetail } from "./clear-confirm";
+import { isClearCmd, openTopTitles, clearConfirmDetail, endConfirmDetail } from "./clear-confirm";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
@@ -42,6 +42,16 @@ test("the confirm detail: null with nothing open; singular/plural; long lists ca
   const long = clearConfirmDetail(Array.from({ length: 30 }, (_, i) => "card number " + i))!;
   assert.ok(long.length < 400, "the titles list is capped so the modal stays readable");
   assert.match(long, /…/);
+});
+
+test("endConfirmDetail names the open cards before an End, and stays quiet with none", () => {
+  const base = "The session shuts down.";
+  assert.equal(endConfirmDetail([], base), base, "nothing open -> the short static line");
+  const one = endConfirmDetail(["ship the exporter"], base);
+  assert.ok(one.startsWith("1 card is still open on its board: ship the exporter."));
+  assert.ok(one.endsWith(base));
+  const two = endConfirmDetail(["a", "b"], base);
+  assert.ok(two.startsWith("2 cards are still open on its board: a, b."));
 });
 
 test("sendComposer gates a /clear behind showConfirm — Cancel first (safe default), send only on confirm", () => {

--- a/ui/webview/clear-confirm.ts
+++ b/ui/webview/clear-confirm.ts
@@ -29,3 +29,17 @@ export function clearConfirmDetail(titles: string[]): string | null {
     + shown
     + ". Undo clear on the feed restores the cards, but the agent will no longer remember the work behind them.";
 }
+
+// The END confirm's detail (the user 2026-08-15, who ended a session holding an open task and got no
+// warning before its card left the working surfaces): same open-top population as the /clear gate,
+// framed for ending — the cards aren't destroyed (the goal store keeps them; revive brings them back),
+// but they leave the board with the session, and that deserves naming before the click.
+export function endConfirmDetail(titles: string[], base: string): string {
+  if (!titles.length) return base;
+  const list = titles.join(", ");
+  const shown = list.length > 140 ? list.slice(0, 139) + "…" : list;
+  const n = titles.length;
+  return (n === 1 ? "1 card is still open on its board: " : n + " cards are still open on its board: ")
+    + shown + ". Ending takes them off the working surfaces with it. " + base;
+}
+

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -18,7 +18,7 @@ import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
 import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompSettings } from "./settings";
 import { delegate } from "./actions";
 import { KIND_WORD } from "./spin-caption";
-import { isClearCmd, openTopTitles, clearConfirmDetail } from "./clear-confirm";
+import { isClearCmd, openTopTitles, clearConfirmDetail, endConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
 import { reconcileTabOrder } from "./tab-order";
 import { writeViewOrder } from "./view-order";
@@ -10511,8 +10511,12 @@ setupSettings();
       // session — still judged and billed, but invisible — a tmux-era affordance with no SDK-era use
       // case. Close-and-reopen is End + Revive, which keeps the whole history.
       const nm = sessions.get(id)?.name || "";
+      // …and the confirm NAMES what is still open on its board (the user 2026-08-15, who ended a
+      // session holding an open task with no warning — the /clear gate has warned this way since
+      // 2026-07-27, and ending drops the cards from the working surfaces the same way)
       showConfirm(`End “${nm}”?`,
-        "The session shuts down. Its history stays on disk — revive it any time from the picker or timeline.",
+        endConfirmDetail(openTopTitles(ledgers.get(id)?.tree),
+          "The session shuts down. Its history stays on disk — revive it any time from the picker or timeline."),
         [{ label: "End session", value: "end", danger: true }, { label: "Cancel", value: "" }],
         (v) => {
           if (v !== "end") return;   // Cancel → nothing


### PR DESCRIPTION
The user ended a session holding an open task and got no warning before its card left the working surfaces — the guard they remembered was the /clear gate's (naming open cards since 2026-07-27). Ending drops cards from the board the same way (the goal store keeps them; revive brings them back), so the End confirm now carries the same detail, reusing the clear gate's open-top machinery (`endConfirmDetail` beside `clearConfirmDetail`, pure and node-tested). Nothing open keeps the short static line.

Suites green (4759 py + 2003 ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)