### PR TITLE
A live lane with no bars evidence yet is presumed active, never dropped

### DIFF
--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -523,6 +523,11 @@ class TimelinePanel {
     // so draw() paints the romp swirl loader there. Set true the instant applyBars runs (or a full one-shot
     // data object arrives through update()), and the loader is gone on the next draw. CLAUDE.md loader rule.
     this._barsLoaded = false;
+    // per-LANE bars evidence (the user 2026-08-15: after a restart, a live WORKING lane vanished from
+    // the active-only view, then reappeared bar-less): every with_bars build writes a turns entry for
+    // EVERY lane it covered (empty for a quiet one), so a lane's key appearing is the exact "its
+    // evidence arrived" event — until then the active filter must not judge it.
+    this._barsSeen = new Set();
     this._loaderBackstop = null;   // timer id: force the loader done if a warming build never brings content
     this.M = { left: 130, right: 16, top: 8, bottom: 22 };   // axis labels live in the bottom margin
     this._mc = document.createElement('canvas').getContext('2d');
@@ -1376,6 +1381,7 @@ class TimelinePanel {
     // already present → no loader. The two-message path leaves turns empty here; the loader shows until
     // applyBars lands. Read the RAW turns BEFORE the prev-carry below back-fills them.
     if (data.turns && Object.keys(data.turns).length) this._barsLoaded = true;
+    if (data.turns) for (const k of Object.keys(data.turns)) this._barsSeen.add(k);
     const prev = this.data;
     if (prev && (!data.turns || !Object.keys(data.turns).length)) {
       data.turns = prev.turns || {}; data.judging = prev.judging || [];
@@ -1450,6 +1456,7 @@ class TimelinePanel {
   applyBars(m) {
     if (!m || !this.data || !this.data.sessions) return;
     this.data.turns = m.turns || {};
+    for (const k of Object.keys(this.data.turns)) this._barsSeen.add(k);
     this.data.judging = m.judging || [];
     this.data.messages = m.messages || [];
     // (nudges array retired 2026-07-07 payload audit: auto-nudges render from the bar's nudgeAuto)
@@ -2485,7 +2492,15 @@ class TimelinePanel {
     const hasWork = (s) =>
       turnsOf(s.id).some((t) => overlaps(t.start, barEndT(t, nowS, data.now))) ||
       data.messages.some((m) => (m.fromId === s.id || m.toId === s.id) && overlaps(Math.min(m.sent, m.exec), Math.max(m.sent, m.exec)));
-    const active = (s) => (s.live && !this._activeOnly) || hasWork(s);
+    // …and a LIVE lane whose bars have never arrived is PRESUMED active (the user 2026-08-15: on a
+    // cold connect — this kernel restarting, or a remote host's bars not yet merged — the filter
+    // judged a working lane by evidence that didn't exist yet and dropped it entirely). Evidence =
+    // the lane's turns key having landed in ANY bars payload (every with_bars build writes one per
+    // lane, empty for a quiet one) or being present in the current data (the one-shot/full path);
+    // that key landing is the event that hands judgment back to hasWork.
+    const barsKnown = (s) => this._barsSeen.has(s.id)
+      || !!(data.turns && Object.prototype.hasOwnProperty.call(data.turns, s.id));
+    const active = (s) => (s.live && !this._activeOnly) || hasWork(s) || (s.live && !barsKnown(s));
     let vis = data.sessions.filter(active);
     // …but never hide EVERYONE: with every lane idle in this window the filter would blank the whole
     // band — which reads as broken (the loading rule), and leaves no row space to grab-drag back out

--- a/ui/timeline-render.test.ts
+++ b/ui/timeline-render.test.ts
@@ -233,6 +233,25 @@ test("an idle live lane thins out under active-only, and returns when the toggle
   assert.equal(panel._vis.length, 2, "zoomed out over its past work, the lane returns");
 });
 
+test("a live lane with NO bars evidence yet is presumed active — never dropped cold (the user 2026-08-15)", () => {
+  // after a kernel restart, the active-only filter judged a WORKING lane by bars that had not arrived
+  // yet (its own kernel still warming, or a remote host's bars unmerged) and dropped the lane entirely;
+  // it then reappeared bar-less as data trickled in. A live lane without a turns key is unjudged, not
+  // inactive; its key landing (every with_bars build writes one per covered lane) hands judgment back.
+  const panel: any = new TimelinePanel(makeNode("div"));
+  const data: any = synthData();
+  delete data.turns.S2;             // S2's evidence has not arrived (cold connect / unmerged host)
+  panel._collapseGaps = false;
+  panel.data = data;
+  panel.draw();
+  assert.deepEqual(panel._vis.map((s: any) => s.id).sort(), ["S1", "S2"],
+    "the evidence-less live lane stands beside the working one");
+  panel._barsSeen.add("S2");        // its bars payload lands (even empty) → judgment passes to hasWork
+  panel.draw();
+  assert.deepEqual(panel._vis.map((s: any) => s.id), ["S1"],
+    "once its bars arrive empty, the same lane is genuinely quiet and thins out");
+});
+
 test("an ALL-quiet window falls back to the live lanes — never a blank, un-grabbable band", () => {
   // Panning into a stretch where nothing happened must not empty the timeline: a blank band reads as
   // broken, and the per-lane row space is the only mouse-drag pan surface, so an empty _vis would


### PR DESCRIPTION
On a day of 20+ kernel restarts: a working session on another machine did not appear on the timeline at all, then appeared with no work bar. The active-only filter (default on) judges a lane by its work bars — and on a cold connect (local kernel still warming its serial parse, or a remote host's bars not yet re-merged after the restart killed its tunnel) it judged a working lane by evidence that didn't exist yet and dropped it entirely.

Evidence-based visibility: every `with_bars` build writes a `turns` entry for every covered lane (empty for quiet ones), so a lane's key landing in any bars payload — or presence in the current data — is the "evidence arrived" event. A live lane without it is presumed active; the key landing hands judgment back to `hasWork`. The all-quiet fallback and all existing filter behavior stand unchanged (executed harness test).

Suites green (4759 py + 2004 ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)