### PR TITLE
Figures render at their mention, and a verified preview never fails silently

### DIFF
--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -1,11 +1,12 @@
 // A mentioned image/PDF renders FULL-SIZE in the chat (the user 2026-07-20, who wanted not even a thumbnail
-// but a rendered image, similar to how it renders the user messages), absolute OR relative path —
-// the kernel resolves a relative one against the session's cwd exactly like click-to-open. Per
-// surface: web renders via previewFull (kernel /file bytes → <img> at the user-image scale / a PDF's
-// native inline <iframe>, both self-removing when the kernel can't serve the path); the VS Code
+// but a rendered image, similar to how it renders the user messages), AT its mention — the figure
+// follows the block whose prose names it (the user 2026-08-15) — absolute OR relative path; the
+// kernel resolves a relative one against the session's cwd exactly like click-to-open. Per surface:
+// web renders via previewFull (kernel /file bytes → <img> at the user-image scale / a PDF card;
+// kernel-verified paths fail LOUDLY with a retry chip, only unverified ones self-remove); the VS Code
 // webview can't reach the kernel origin from an <img>, so images ride the SAME host data-URL flow the
 // user-message pictures use (imgRequest, now carrying the session id) and PDFs keep the click-to-open
-// link. The feed's artifact strips deliberately keep their compact thumbnails. Source pins.
+// link. Source pins.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -18,22 +19,52 @@ const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", 
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
 test("previewFull renders the image itself; a PDF is a click-to-view CARD, never an auto-loading frame", () => {
-  assert.match(PREVIEW, /export function previewFull\(path: string, sid\?: string \| null\): HTMLElement \| null/);
+  assert.match(PREVIEW, /export function previewFull\(path: string, sid\?: string \| null, verified = false\): HTMLElement \| null/);
   assert.match(PREVIEW, /img\.className = "path-full-img";/);
-  assert.match(PREVIEW, /img\.onerror = \(\) => box\.remove\(\);/);
   // NO inline <iframe> for PDFs (2026-07-20): a browser set to "Download PDFs" saved a fresh copy on
   // EVERY chat re-render — the Downloads folder silently filled. The fetch must be user-initiated.
   const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
   assert.doesNotMatch(pf, /createElement\("iframe"\)/, "no auto-loading PDF frame in the chat strip");
   assert.match(pf, /box\.classList\.add\("path-full-pdfcard"\);/);
   assert.match(pf, /box\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); openLightbox\(path, sid\); \};/);
-  // the HEAD probe (headers only — never a download) still removes a dead card
-  assert.match(pf, /fetch\(fileUrl\(path, sid\), \{ method: "HEAD" \}\)/);
+  // the HEAD probe (headers only — never a download) still removes a dead UNVERIFIED card; a
+  // kernel-verified card skips it — a transient probe failure must not erase a real file's card
+  assert.match(pf, /if \(!verified\) fetch\(fileUrl\(path, sid\), \{ method: "HEAD" \}\)/);
 });
 
-test("the chat strip uses the FULL render on web, and the host data-URL flow for images in VS Code", () => {
-  assert.match(RENDER, /const full = canPreview\(\) \? previewFull\(p, activeId\)\s*\n\s*: previewKind\(p\) === "img" \? buildPathImg\(p\) : null;/);
+test("a kernel-VERIFIED preview fails LOUDLY: a retry chip holds the figure's spot, never silent removal", () => {
+  const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
+  // unverified (old kernel, no pathLinks verdict) keeps self-removal — there the error means "no such file"
+  assert.match(pf, /if \(!verified\) \{ box\.remove\(\); return; \}/);
+  assert.match(pf, /chip\.className = "path-full-retry";/);
+  assert.match(pf, /chip\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); build\(true\); \};/, "tap to retry rebuilds the img");
+  assert.match(pf, /img\.src = bust \? url \+ "&r=" \+ Date\.now\(\) : url;/, "a retry cache-busts the failed entry");
+  // the render layer feeds the verdict: spacePaths and pathLinks hits are kernel-stat'd paths
+  assert.match(RENDER, /const kernelVerified = new Set<string>\(\);/);
+  assert.match(RENDER, /if \(!isUri && typeof fixed === "string"\) kernelVerified\.add\(open\);/);
+  assert.match(CSS, /\.path-full-retry \{ display: inline-flex;/, "visible chrome — the chip has chat-sheet css");
+});
+
+test("the chat uses the FULL render on web, and the host data-URL flow for images in VS Code", () => {
+  assert.match(RENDER, /const full = canPreview\(\) \? previewFull\(p, activeId, kernelVerified\.has\(p\)\)\s*\n\s*: previewKind\(p\) === "img" \? buildPathImg\(p\) : null;/);
   assert.doesNotMatch(RENDER, /previewThumb/, "the chat no longer renders mention thumbnails — full renders now");
+});
+
+test("figures render AT their mention: after the block naming them; same-block figures share a strip", () => {
+  // path → first mention element, captured in BOTH linkify passes (space paths and the token walker)
+  assert.match(RENDER, /const mentionAt = new Map<string, HTMLElement>\(\);/);
+  assert.match(RENDER, /mentionAt\.set\(tok, code\);/, "the space-path pass anchors on its code span");
+  assert.match(RENDER, /mentionAt\.set\(open, link\);/, "the token walker anchors on the link it minted");
+  assert.match(RENDER, /const BLOCK_SEL = "p, li, h1, h2, h3, h4, h5, h6, blockquote, td, th";/);
+  assert.match(RENDER, /anchor\.insertAdjacentElement\("afterend", strip\);/, "a paragraph's figure lands right after it");
+  assert.match(RENDER, /\/\^\(LI\|TD\|TH\)\$\/\.test\(anchor\.tagName\)/, "a list item keeps its figure inside, under its bullet");
+  assert.match(RENDER, /previewable\.slice\(0, 4\)/, "the wallpaper cap stays");
+});
+
+test("VS Code's pending image chip pulses while the host round-trip is in flight; a failed one doesn't", () => {
+  assert.match(RENDER, /"user-img-path" \+ \(imgFailed\.has\(p\) \? "" : " img-pending"\)/);
+  assert.match(CSS, /\.user-img-path\.img-pending::after \{ content: " ···";/);
+  assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.user-img-path\.img-pending::after \{ animation: none;/);
 });
 
 test("imgRequest carries the session id so RELATIVE mentioned paths resolve against the session cwd", () => {

--- a/ui/webview/chat-path-links.test.ts
+++ b/ui/webview/chat-path-links.test.ts
@@ -36,7 +36,8 @@ test("membership in pathLinks gates the link, and the map's value is the OPEN ta
   // the fixed target is what opens (and openPathLink titles it, so hover shows where a fix points);
   // with NO pathLinks key on the event (old kernel, cached payload) the token opens as written
   assert.match(RENDER, /const open = isUri \? fileUriToPath\(tok\) : \(fixed \?\? tok\);/);
-  assert.match(RENDER, /frag\.appendChild\(isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\)\);/);
+  assert.match(RENDER, /const link = isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\);/);
+  assert.match(RENDER, /frag\.appendChild\(link\);/);
   assert.match(RENDER, /a\.title = "Open " \+ open;/);
 });
 

--- a/ui/webview/chat-relpath-link.test.ts
+++ b/ui/webview/chat-relpath-link.test.ts
@@ -19,7 +19,8 @@ test("the linkifier matches file:// URIs AND bare paths, and gates each token ki
   assert.match(RENDER, /if \(!isUri && !looksLikeFilePath\(tok\) && !\(inCode && looksLikeBareFileName\(tok\)\)\) continue;/);
   // the kernel's pathLinks verdict then narrows further, and its value is the OPEN target — pinned
   // in chat-path-links.test.ts; here we pin that the link opens `open`, whatever chose it
-  assert.match(RENDER, /frag\.appendChild\(isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\)\);/);
+  assert.match(RENDER, /const link = isUri \? fileUriLink\(tok\) : openPathLink\(tok, open, true\);/);
+  assert.match(RENDER, /frag\.appendChild\(link\);/);
 });
 
 test("a relative path click carries the active session id so whoever resolves it uses that cwd", () => {

--- a/ui/webview/chat-space-paths.test.ts
+++ b/ui/webview/chat-space-paths.test.ts
@@ -41,8 +41,8 @@ test("linkifyFileUris whole-links a verified span's entire inline-code content",
   // exact-match against the kernel's verified set, then the whole content becomes one open link
   assert.match(RENDER, /const tok = \(code\.textContent \|\| ""\)\.trim\(\);\s*\n\s*if \(!verified\.has\(tok\)\) continue;/);
   assert.match(RENDER, /code\.replaceChildren\(link\);/);
-  // a verified image/PDF joins the same full-size preview strip the token links feed
-  assert.match(RENDER, /if \(previewKind\(tok\) && !previewable\.includes\(tok\) && !\(skipThumbs && skipThumbs\.includes\(tok\)\)\) previewable\.push\(tok\);/);
+  // a verified image/PDF joins the same full-size previews the token links feed (figure at its mention)
+  assert.match(RENDER, /if \(previewKind\(tok\) && !previewable\.includes\(tok\) && !\(skipThumbs && skipThumbs\.includes\(tok\)\)\) \{\s*\n\s*previewable\.push\(tok\);\s*\n\s*mentionAt\.set\(tok, code\);/);
 });
 
 test("the whole-span pass runs BEFORE the token walk, so the new link is skipped by it", () => {

--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -27,9 +27,10 @@ test("preview.ts: kind classification, kernel /file URL, and self-removing rende
   assert.match(PREVIEW, /"\/remote\/" \+ encodeURIComponent\(host\) \+ "\/file"/);
   // web dashboard only: the VS Code webview can't reach the kernel origin from an <img>
   assert.match(PREVIEW, /location\.protocol === "http:" \|\| location\.protocol === "https:"/);
-  // a render the kernel can't serve REMOVES ITSELF (no dead chips): img onerror, pdf HEAD probe
-  assert.match(PREVIEW, /img\.onerror = \(\) => box\.remove\(\);/);
-  assert.match(PREVIEW, /fetch\(fileUrl\(path, sid\), \{ method: "HEAD" \}\)\.then\(\(r\) => \{ if \(!r\.ok\) box\.remove\(\); \}\)\.catch\(\(\) => box\.remove\(\)\)/);
+  // an UNVERIFIED render the kernel can't serve REMOVES ITSELF (no dead chips): img onerror, pdf HEAD
+  // probe. Kernel-VERIFIED paths keep a visible retry chip instead — chat-inline-preview.test.ts pins that.
+  assert.match(PREVIEW, /if \(!verified\) \{ box\.remove\(\); return; \}/);
+  assert.match(PREVIEW, /if \(!verified\) fetch\(fileUrl\(path, sid\), \{ method: "HEAD" \}\)\.then\(\(r\) => \{ if \(!r\.ok\) box\.remove\(\); \}\)\.catch\(\(\) => box\.remove\(\)\)/);
   assert.match(KERNEL, /if p == "\/file":/, "the preview bytes endpoint exists");
   assert.match(KERNEL, /def do_HEAD\(self\):/, "HEAD probe for chips that can't self-verify like an <img>");
 });
@@ -41,14 +42,15 @@ test("preview.ts: lightbox is a singleton overlay — img or native-viewer ifram
   assert.match(PREVIEW, /wrap\.onclick = \(ev\) => \{ if \(ev\.target === wrap\) dismiss\(\); \};/, "backdrop closes; content clicks don't");
 });
 
-test("chat: a mentioned image/PDF grows a FULL-render strip under the message, deduped and capped", () => {
-  // (the user 2026-07-20: full renders replaced the 2026-07-08 thumbnails in the chat;
-  // chat-inline-preview.test.ts pins the full-render shape)
+test("chat: a mentioned image/PDF grows a FULL render at its mention, deduped and capped", () => {
+  // (the user 2026-07-20: full renders replaced the 2026-07-08 thumbnails in the chat; the user
+  // 2026-08-15: figures moved from a tail strip to the mentioning block —
+  // chat-inline-preview.test.ts pins the placement shape)
   assert.match(RENDER, /import \{ previewKind, previewFull, canPreview, fileUrl \} from "\.\/preview";/);
-  assert.match(RENDER, /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) previewable\.push\(open\);/, "collected while linkifying — same detection, no second regex pass; an in-bubble image never re-renders");
+  assert.match(RENDER, /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) \{/, "collected while linkifying — same detection, no second regex pass; an in-bubble image never re-renders");
   assert.match(RENDER, /if \(previewable\.length\) \{/, "both surfaces now — VS Code images ride the host data-URL flow");
   assert.match(RENDER, /previewable\.slice\(0, 4\)/, "capped so a directory listing doesn't wallpaper the chat");
-  assert.match(RENDER, /previewFull\(p, activeId\)/, "relative paths resolve against the ACTIVE session's cwd, as openPathLink");
+  assert.match(RENDER, /previewFull\(p, activeId, kernelVerified\.has\(p\)\)/, "relative paths resolve against the ACTIVE session's cwd, as openPathLink; verified paths fail loudly");
 });
 
 test("the chat sheet carries the lightbox + preview styles (the feed no longer previews)", () => {

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -120,7 +120,14 @@ export function openLightbox(path: string, sid?: string | null): void {
 // that declines to render inline) saved a FRESH COPY on every chat re-render — the user's Downloads
 // folder silently filled with datasheet copies (2026-07-20). A fetch must be user-initiated, once.
 // Web only — callers gate on canPreview and fall back per surface.
-export function previewFull(path: string, sid?: string | null): HTMLElement | null {
+// `verified`: the KERNEL already stat'd this path (spacePaths / a pathLinks verdict), so a load
+// error is TRANSIENT — the kernel restarting mid-fetch, a tunnel blip — not a dead path. Removing
+// the box then erases the preview silently until some later re-render (the user 2026-08-15, who sat
+// through exactly that: verified path pills, no images, no cue). A verified path's failure therefore
+// stays VISIBLE — a "preview unavailable — tap to retry" chip in the figure's spot — per the
+// fail-loudly rule. Only an UNVERIFIED path (old kernel, no pathLinks key) keeps self-removal:
+// there the error really does mean "no such file".
+export function previewFull(path: string, sid?: string | null, verified = false): HTMLElement | null {
   const kind = previewKind(path);
   if (!kind || !canPreview()) return null;
   const box = document.createElement("span");
@@ -139,19 +146,33 @@ export function previewFull(path: string, sid?: string | null): HTMLElement | nu
     box.title = "click to view " + path;
     box.onclick = (ev) => { ev.stopPropagation(); openLightbox(path, sid); };
     // a chip can't self-verify like an <img> — HEAD-probe (headers only, no body — never a download)
-    // so a missing PDF never shows a dead card
-    fetch(fileUrl(path, sid), { method: "HEAD" }).then((r) => { if (!r.ok) box.remove(); }).catch(() => box.remove());
+    // so a missing PDF never shows a dead card. A kernel-VERIFIED card skips the probe: the kernel
+    // said the file exists, and a transient probe failure must not erase the card.
+    if (!verified) fetch(fileUrl(path, sid), { method: "HEAD" }).then((r) => { if (!r.ok) box.remove(); }).catch(() => box.remove());
   } else {
-    const img = document.createElement("img");
-    img.className = "path-full-img";
     const url = fileUrl(path, sid);
-    img.src = url;
-    img.alt = path;
-    img.loading = "lazy";
-    img.onerror = () => box.remove();
-    img.onclick = (ev) => { ev.stopPropagation(); openLightbox(path, sid); };
-    withLoadCue(box, img, url);   // mini swirl holds the spot until the load event (first load only)
-    box.appendChild(img);
+    const build = (bust: boolean) => {
+      box.textContent = "";
+      const img = document.createElement("img");
+      img.className = "path-full-img";
+      img.src = bust ? url + "&r=" + Date.now() : url;   // bust: a retry must not re-read the failed cache entry
+      img.alt = path;
+      img.loading = "lazy";
+      img.onclick = (ev) => { ev.stopPropagation(); openLightbox(path, sid); };
+      img.onerror = () => {
+        if (!verified) { box.remove(); return; }
+        box.textContent = "";
+        const chip = document.createElement("span");
+        chip.className = "path-full-retry";
+        chip.textContent = "⚠ preview unavailable — tap to retry";
+        chip.title = path;
+        chip.onclick = (ev) => { ev.stopPropagation(); build(true); };
+        box.appendChild(chip);
+      };
+      withLoadCue(box, img, url);   // mini swirl holds the spot until the load event (memo on the un-busted url)
+      box.appendChild(img);
+    };
+    build(false);
   }
   return box;
 }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -864,7 +864,10 @@ function fillPathImg(wrap: HTMLElement, p: string): void {
     const img = document.createElement("img"); img.className = "user-img"; img.src = url; img.loading = "lazy"; img.title = p;
     wrap.appendChild(img);
   } else {
-    const chip = el("div", "user-img-path"); chip.textContent = "🖼 " + (p.split("/").pop() || p); chip.title = p;
+    // still waiting on the host round-trip → pulsing-dots loading cue (pure CSS — the sandbox can't
+    // fetch the swirl asset); a FAILED path drops the pulse and reads as the plain chip it is
+    const chip = el("div", "user-img-path" + (imgFailed.has(p) ? "" : " img-pending"));
+    chip.textContent = "🖼 " + (p.split("/").pop() || p); chip.title = p;
     wrap.appendChild(chip);
   }
 }
@@ -1032,7 +1035,9 @@ const CLICKABLE_PATH_RE = /file:\/\/\/?[^\s<>"'`)]+|[~.\w\-]*\/[~.\w\-/]*[\w\-]|
 // file:// URIs are explicit absolute paths — never gated on the map.
 function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: string[],
                          pathLinks?: Record<string, string>): void {
-  const previewable: string[] = [];   // renderable paths found in this message → a thumbnail strip below it
+  const previewable: string[] = [];   // renderable paths found in this message → full renders at their mentions
+  const mentionAt = new Map<string, HTMLElement>();   // path → its FIRST mention's element (figure anchor)
+  const kernelVerified = new Set<string>();           // paths the kernel stat'd — their previews fail loudly, never silently
   if (spacePaths && spacePaths.length) {
     const verified = new Set(spacePaths);
     for (const code of Array.from(root.querySelectorAll("code"))) {
@@ -1041,7 +1046,11 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
       if (!verified.has(tok)) continue;
       const link = openPathLink(tok, tok, true);
       code.replaceChildren(link);                              // the <code> chrome stays; its content is the link
-      if (previewKind(tok) && !previewable.includes(tok) && !(skipThumbs && skipThumbs.includes(tok))) previewable.push(tok);
+      kernelVerified.add(tok);
+      if (previewKind(tok) && !previewable.includes(tok) && !(skipThumbs && skipThumbs.includes(tok))) {
+        previewable.push(tok);
+        mentionAt.set(tok, code);
+      }
     }
   }
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
@@ -1067,8 +1076,13 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
       if (!isUri && pathLinks && typeof fixed !== "string") continue;   // checked against the filesystem: no such file (or several) → prose
       if (m.index > last) frag.appendChild(document.createTextNode(text.slice(last, m.index)));
       const open = isUri ? fileUriToPath(tok) : (fixed ?? tok);
-      frag.appendChild(isUri ? fileUriLink(tok) : openPathLink(tok, open, true));
-      if (previewKind(open) && !previewable.includes(open) && !(skipThumbs && skipThumbs.includes(open))) previewable.push(open);
+      const link = isUri ? fileUriLink(tok) : openPathLink(tok, open, true);
+      frag.appendChild(link);
+      if (!isUri && typeof fixed === "string") kernelVerified.add(open);   // the kernel stat'd it this build
+      if (previewKind(open) && !previewable.includes(open) && !(skipThumbs && skipThumbs.includes(open))) {
+        previewable.push(open);
+        mentionAt.set(open, link);
+      }
       last = m.index + tok.length;
       re.lastIndex = last;
       any = true;
@@ -1077,12 +1091,16 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
     if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
     tn.replaceWith(frag);
   }
-  // A mentioned image/PDF renders FULL-SIZE under the message (the user 2026-07-20, who wanted not even a
-  // thumbnail but a rendered image, like the user messages; supersedes the 2026-07-08 thumbnail
-  // strip). Absolute AND relative paths work — the kernel
-  // resolves a relative one against this session's cwd, same as click-to-open. Per surface:
+  // A mentioned image/PDF renders FULL-SIZE at its MENTION — the figure lands right after the
+  // paragraph/list item that names it, like figures in a document (the user 2026-08-15, whose four
+  // captioned plots all collected at the message's tail, far from the prose describing each; the
+  // 2026-07-20 rule — a rendered image, not a thumbnail — stands, this moves WHERE it renders).
+  // Figures mentioned in the same block share one strip; a mention with no block anchor (bare text
+  // at the root) keeps the old below-message placement. Absolute AND relative paths work — the
+  // kernel resolves a relative one against this session's cwd, same as click-to-open. Per surface:
   //   web       — previewFull: the kernel serves the bytes straight into an <img> at the user-image
-  //               scale / a PDF's native inline viewer; a path the kernel can't serve removes itself.
+  //               scale / a PDF card. A KERNEL-VERIFIED path that fails to load shows a retry chip
+  //               (transient failure — restart, tunnel blip); only an unverified one self-removes.
   //   VS Code   — the webview sandbox can't reach the kernel origin from an <img>, so an IMAGE rides
   //               the same host data-URL flow the user-message pictures use (buildPathImg, imgRequest
   //               now carrying the session id for relative resolution); a PDF keeps its click-to-open
@@ -1090,13 +1108,24 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
   // Capped so a message that enumerates a directory of images doesn't wallpaper the chat; every path
   // stays clickable regardless.
   if (previewable.length) {
-    const strip = el("div", "path-thumbs");
+    const BLOCK_SEL = "p, li, h1, h2, h3, h4, h5, h6, blockquote, td, th";
+    const strips = new Map<HTMLElement, HTMLElement>();   // figure anchor → its strip (same block shares one)
     for (const p of previewable.slice(0, 4)) {
-      const full = canPreview() ? previewFull(p, activeId)
+      const full = canPreview() ? previewFull(p, activeId, kernelVerified.has(p))
         : previewKind(p) === "img" ? buildPathImg(p) : null;
-      if (full) strip.appendChild(full);
+      if (!full) continue;
+      const block = mentionAt.get(p)?.closest(BLOCK_SEL) as HTMLElement | null;
+      const anchor = block && root.contains(block) && block !== root ? block : root;
+      let strip = strips.get(anchor);
+      if (!strip) {
+        strip = el("div", "path-thumbs");
+        // an li/td keeps its figure INSIDE (stays under its bullet/cell); a p/heading takes it after
+        if (anchor === root || /^(LI|TD|TH)$/.test(anchor.tagName)) anchor.appendChild(strip);
+        else anchor.insertAdjacentElement("afterend", strip);
+        strips.set(anchor, strip);
+      }
+      strip.appendChild(full);
     }
-    if (strip.childElementCount) root.appendChild(strip);
   }
 }
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2286,6 +2286,18 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .path-full-pdfcard { display: inline-flex; align-items: center; gap: 7px; padding: 7px 11px;
   border-radius: 8px; border: 1px solid rgba(255, 255, 255, 0.14); background: rgba(0, 0, 0, 0.25); }
 .path-full-pdfcard:hover { border-color: var(--accent); }
+/* a kernel-VERIFIED preview whose bytes failed to arrive (restart, tunnel blip) — visible, retryable,
+   never silently removed (preview.ts previewFull) */
+.path-full-retry { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08); border: 1px solid rgba(255, 255, 255, 0.14);
+  font-size: 0.85em; opacity: 0.85; cursor: pointer; }
+.path-full-retry:hover { border-color: var(--accent); }
+/* VS Code's host-round-trip image chip while the bytes are still on their way (render.ts fillPathImg) —
+   pure-CSS pulse, the sandbox can't fetch the swirl asset */
+.user-img-path.img-pending::after { content: " ···"; letter-spacing: 2px;
+  animation: img-pending-pulse 1.2s ease-in-out infinite; }
+@keyframes img-pending-pulse { 0%, 100% { opacity: 0.25; } 50% { opacity: 0.9; } }
+@media (prefers-reduced-motion: reduce) { .user-img-path.img-pending::after { animation: none; opacity: 0.6; } }
 
 /* full-view lightbox (preview.ts openLightbox): image at natural-but-capped size, or the PDF in the
    browser's native viewer. Above every overlay layer. Backdrop click / Esc / ✕ closes. */

--- a/ui/webview/user-img-dedup.test.ts
+++ b/ui/webview/user-img-dedup.test.ts
@@ -16,9 +16,9 @@ const RENDER = fs.readFileSync(
 
 test("linkifyFileUris takes skipThumbs and excludes those paths from the thumbnail strip", () => {
   assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>\): void/);
-  // the previewable push gates on skipThumbs — the path stays a LINK, it just doesn't thumb
+  // the previewable push gates on skipThumbs — the path stays a LINK, it just doesn't render a figure
   assert.match(RENDER,
-    /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) previewable\.push\(open\);/);
+    /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) \{\s*\n\s*previewable\.push\(open\);\s*\n\s*mentionAt\.set\(open, link\);/);
 });
 
 test("the user bubble passes its ev.images paths (caption path AND path:-src) as skipThumbs", () => {


### PR DESCRIPTION
Two preview asks from the user (2026-08-15), one session:

**Inline-at-position figures.** A message described four plots, one paragraph each, and all four images collected in a strip at the message's very end. Previews now render right after the block (paragraph / list item / heading) whose prose mentions the path — figures where they're cited. Same-block mentions share one strip; no block anchor → old below-message placement; the 4-figure cap and every-path-stays-clickable stand.

**Verified previews fail loudly.** The user sat through verified path pills with no images and no cue: the swirl cue exists, but a preview whose bytes fail to arrive removed itself — right for a hallucinated path, wrong for one the kernel just stat'd (spacePaths / pathLinks), where the failure is transient (kernel restart mid-fetch, tunnel blip). A kernel-verified preview now shows a "preview unavailable — tap to retry" chip in the figure's spot (retry cache-busts); a verified PDF card skips the HEAD probe. Unverified paths keep self-removal.

**VS Code pending chip** pulses (pure CSS) while the host round-trip is in flight; a failed chip reads plain.

Tests: placement, retry-chip, verified-gating, and pending-pulse pins added in chat-inline-preview.test.ts; stale pins updated across preview-core / chat-path-links / chat-relpath-link / chat-space-paths / user-img-dedup. Full UI suite: 2007 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)