### PR TITLE
A move prediction is judged on the card's own kernel's counter, never another's

### DIFF
--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -95,6 +95,10 @@ export function prefixInbound(host: string, msg: any): any {
   // the path checker's answer, stamped with the machine that gave it: the picker drops a verdict that
   // arrives for a host it is no longer on, instead of showing one machine's answer about another's disk.
   if (out.type === "dirCompletions") out.host = host;
+  // a remote kernel's answer to a card-move prediction: its ids are goal ids (globally unique, never
+  // prefixed), but its buildId only means something on THAT kernel's counter — stamp the host so the
+  // feed pane compares it against the same host's frame in the merged payload, never the local counter
+  if (out.type === "cardMoveAck" || out.type === "cardPredict") out.host = host;
   if (out.type === "sessionList" && Array.isArray(out.items)) {
     out.items = out.items.map((it: any) => (it && typeof it === "object" && typeof it.id === "string"
       ? { ...it, id: prefixId(host, it.id),
@@ -314,9 +318,17 @@ export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly s
   // floor). Remote rows are host-prefixed like every other remote surface; the SIG is host-scoped so
   // two kernels' ring sequences can never collide in the seen-set.
   const syncs: any[] = [];
+  // Every kernel counts feed builds on its OWN counter, so `merged.buildId` (the local scalar kept by
+  // the spread above) says nothing about any REMOTE host's frame. The per-host map is what lets the
+  // feed pane compare a payload against a cardMoveAck on the SAME counter (the user 2026-08-15, whose
+  // reply to a remote card bounced Working → Completed → Working: the local buildId, large after days
+  // of uptime, "outranked" the remote ack's small post-restart buildId on the first merged emission,
+  // dropping the prediction while the cached remote frame still predated the reopen).
+  const buildIds: Record<string, number> = {};
   for (const h of hostSeq) {
     const f = perHost[h];
     if (!f) continue;
+    if (typeof f.buildId === "number") buildIds[h] = f.buildId;
     if (Array.isArray(f.syncNotices)) {
       for (const r of f.syncNotices) {
         if (!r || !r.sig) continue;
@@ -345,6 +357,7 @@ export function mergeHostFeeds(perHost: Record<string, any>, hostSeq: readonly s
   if ("canUndoClear" in merged || canUndo) merged.canUndoClear = canUndo;
   if (syncs.length) merged.syncNotices = syncs;
   else delete merged.syncNotices;
+  merged.buildIds = buildIds;
   return merged;
 }
 

--- a/ui/webview/feed-colflip.test.ts
+++ b/ui/webview/feed-colflip.test.ts
@@ -69,6 +69,6 @@ test("feed: every prediction drop names WHY, so a bounce's trigger is in the tra
   }
   // a fresh payload marks itself as the next render's input, before reconcile can re-tag
   const payload = FEED.slice(FEED.indexOf('lastFeedEvent = "payload"'));
-  assert.ok(payload.indexOf("reconcileFollowMove(incomingAsks, lastPayloadBuildId)") > 0,
+  assert.ok(payload.indexOf("reconcileFollowMove(incomingAsks, lastPayloadBuildId, perHostBuildIds)") > 0,
     "payload tag set before reconcile runs");
 });

--- a/ui/webview/feed-followup-move.test.ts
+++ b/ui/webview/feed-followup-move.test.ts
@@ -48,7 +48,7 @@ test("the kernel is authoritative: a confirming push clears the prediction, an u
   // reconcile runs against the authoritative incoming payload on every feed push, carrying that payload's
   // buildId so an ACKED prediction can tell a pre-click payload from the kernel's answer (feed-move-ack)
   assert.match(FEED, /lastPayloadBuildId = typeof m\.buildId === "number" \? m\.buildId : 0;/);
-  assert.match(FEED, /reconcileFollowMove\(incomingAsks, lastPayloadBuildId\);/);
+  assert.match(FEED, /reconcileFollowMove\(incomingAsks, lastPayloadBuildId, perHostBuildIds\);/);
   // CONFIRMED = the kernel now lists the card as working, OR no longer lists it (cleared/absorbed).
   // (An ANSWER-kind prediction additionally yields to the first payload either way — feed-card-predict.)
   assert.match(FEED, /if \(!a \|\| a\.column === "working" \|\| pendingMoveKind\.get\(id\) === "answer"\) \{/);

--- a/ui/webview/feed-move-ack.test.ts
+++ b/ui/webview/feed-move-ack.test.ts
@@ -58,7 +58,7 @@ test("kernel: the feed payload carries the build id, claimed BEFORE the read it 
 });
 
 test("client: ok=false is the only thing that interrupts the user, and it says what actually happened", () => {
-  assert.match(FEED, /function ackFollowMove\(itemId: string, ok: boolean, buildId: number\)/);
+  assert.match(FEED, /function ackFollowMove\(itemId: string, ok: boolean, buildId: number, host: string\)/);
   assert.match(FEED, /m\.type === "cardMoveAck" && Array\.isArray\(m\.ids\)/);
   // a follow-up's MESSAGE still went out even when the card is gone — say so rather than implying it vanished
   assert.match(FEED, /Your reply was sent, but that card isn’t on the board any more to move to Working\./);
@@ -71,15 +71,30 @@ test("client: an ACKED prediction yields only to a payload built AFTER the gestu
   // the exact race the old timer papered over: a build already in flight when the click landed cannot know
   // about the reopen, and taking it as the answer is the bounce back to Completed this replaced
   assert.match(FEED, /const acked = pendingMoveAck\.get\(id\);/);
-  assert.match(FEED, /if \(acked !== undefined && buildId > acked\) clearFollowMove\(id, "outranked"\);/);
-  assert.match(FEED, /function reconcileFollowMove\(incoming: AskItem\[\], buildId: number\)/);
+  assert.match(FEED, /if \(typeof mark === "number" && mark > acked\.buildId\) clearFollowMove\(id, "outranked"\);/);
+  assert.match(FEED, /function reconcileFollowMove\(incoming: AskItem\[\], buildId: number, buildIds\?: Record<string, number>\)/);
+});
+
+test("client: 'after' is judged on the CARD's kernel's counter, never another kernel's (2026-08-15)", () => {
+  // the federated bounce: the merged payload's top-level buildId is the LOCAL kernel's counter (days of
+  // uptime → large), the ack's is the card's home kernel's (just restarted → small), so every merged
+  // emission instantly "outranked" the ack and dropped the prediction while the cached remote frame
+  // still predated the reopen — Working → Completed (a beat) → Working on every reply to a remote card.
+  assert.match(FEED, /const cardHost = hostOf\(a\.sid\);/);
+  assert.match(FEED, /if \(cardHost !== acked\.host\) continue;/, "an ack from some other kernel says nothing about this card");
+  // per-host counters from mergeHostFeeds when merged; single-kernel payloads keep the top-level buildId
+  // for local cards only — a payload that can't be placed on the ack's counter never outranks
+  assert.match(FEED, /const mark = buildIds \? buildIds\[cardHost\] : \(cardHost === "" \? buildId : undefined\);/);
+  // the ack records whose counter its buildId is on; unstamped = the local kernel (hostOf's "" for local)
+  assert.match(FEED, /const ackHost = typeof m\.host === "string" \? m\.host : "";/);
+  assert.match(FEED, /pendingMoveAck\.set\(itemId, \{ host, buildId \}\);/);
 });
 
 test("client: an ack silences the toast but never lets a prediction wedge", () => {
   // ok=true re-arms the window SILENTLY: the kernel has spoken, so nothing after that is worth a toast, but
   // a prediction must not outlive the answer either if a payload goes missing
   const ack = FEED.slice(FEED.indexOf("function ackFollowMove("), FEED.indexOf("// On a fresh authoritative payload"));
-  assert.match(ack, /pendingMoveAck\.set\(itemId, buildId\);/);
+  assert.match(ack, /pendingMoveAck\.set\(itemId, \{ host, buildId \}\);/);
   assert.match(ack, /clearFollowMove\(itemId, "backstop-noconfirm"\); render\(\);\s*\/\/ silent wedge guard/);
   assert.ok(!/feedToast/.test(ack.slice(ack.indexOf("pendingMoveAck.set"))),
     "no toast on any path after the kernel confirmed the move");

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -9,7 +9,7 @@
 import { distillText, distillInputs, applyDistillLine, distillPending } from "./distiller-line";
 import { spinFor, KIND_WORD } from "./spin-caption";
 import { onlyTag, matchesOnly } from "./only-filter";
-import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote } from "./host-prefix";
+import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from "./host-prefix";
 import { extHoverMatches } from "./card-key";
 import { provenanceRows, provenanceGroupRows, rootStart, type ProvFmt, type ProvRow } from "./provenance";
 import { ageColorReadable } from "./age-color";
@@ -192,7 +192,11 @@ function dropDismissed(ids: string[]): void {
 // possibly know about it yet. MOVE_ACK_MS is now only a backstop for an answer that never arrives.
 const MOVE_ACK_MS = 15000;
 const pendingFollowMove = new Map<string, number>();   // card itemId → backstop timer id; KEY = still predicting
-const pendingMoveAck = new Map<string, number>();      // card itemId → the buildId the kernel acked it with
+// card itemId → the ack's buildId AND the kernel whose counter it is on. Every kernel numbers feed
+// builds independently, so an ack is only comparable against the SAME host's frame of a merged payload
+// (the user 2026-08-15: the local kernel's buildId, large after days of uptime, "outranked" a remote
+// ack's small post-restart buildId on the first merged emission — see reconcileFollowMove).
+const pendingMoveAck = new Map<string, { host: string; buildId: number }>();
 // What KIND of reply put each prediction in flight (the user 2026-07-20: EVERY context-carrying reply flips
 // its card to Working instantly, not just the feed composer's own follow-up):
 //  - "followup": a message rides along → the prediction wears the re-check styling ("Followed up" chip),
@@ -283,7 +287,7 @@ function optimisticFollowMove(itemId: string, kind: MoveKind = "followup") {
 // went out. ok=true records the buildId the prediction must outlive and re-arms the window SILENTLY: the
 // kernel has spoken, so nothing from here on is worth a toast, but a prediction must never outlive the
 // answer either, so the backstop stays armed in case a payload goes missing.
-function ackFollowMove(itemId: string, ok: boolean, buildId: number) {
+function ackFollowMove(itemId: string, ok: boolean, buildId: number, host: string) {
   if (!pendingFollowMove.has(itemId)) return;
   if (!ok) {
     clearFollowMove(itemId, "ack-fail");
@@ -291,7 +295,7 @@ function ackFollowMove(itemId: string, ok: boolean, buildId: number) {
     render();
     return;
   }
-  pendingMoveAck.set(itemId, buildId);
+  pendingMoveAck.set(itemId, { host, buildId });
   const prev = pendingFollowMove.get(itemId); if (prev) clearTimeout(prev);
   pendingFollowMove.set(itemId, window.setTimeout(() => {
     if (!pendingFollowMove.has(itemId)) return;
@@ -304,7 +308,7 @@ function ackFollowMove(itemId: string, ok: boolean, buildId: number) {
 // right after retiring the picker (answerAsk → _mark_views_dirty), so a payload that still shows the card out
 // of Working is post-answer truth — a real remaining/renewed block (e.g. the next permission prompt of a
 // burst). Holding the prediction there would MASK a genuine "needs you"; dropping it re-shows the ⏸ card.
-function reconcileFollowMove(incoming: AskItem[], buildId: number) {
+function reconcileFollowMove(incoming: AskItem[], buildId: number, buildIds?: Record<string, number>) {
   for (const id of Array.from(pendingFollowMove.keys())) {
     const a = incoming.find((x) => x.itemId === id);
     if (!a || a.column === "working" || pendingMoveKind.get(id) === "answer") {
@@ -316,8 +320,22 @@ function reconcileFollowMove(incoming: AskItem[], buildId: number) {
     // reopen, and taking it as the answer is exactly the bounce back to Completed this replaced. A NEWER one
     // is the kernel's own state, so yield to it silently — the reply landed, the card simply moved on (the
     // work finished, a fresh block arrived), which is honest to show and never a failed move.
+    //
+    // "After" only means anything on ONE counter (the user 2026-08-15, whose reply to a remote card
+    // bounced Working → Completed → Working): every kernel numbers its own feed builds, and the merged
+    // payload's top-level buildId is the LOCAL kernel's — days of uptime vs a just-restarted remote made
+    // it "outrank" every remote ack instantly, dropping the prediction while the cached remote frame
+    // still predated the reopen. So compare the ack against the CARD's own kernel: its host's entry in
+    // the per-host buildIds map (mergeHostFeeds). A single-kernel payload has no map — there the
+    // top-level buildId IS the card's kernel's counter, for local (un-acked-host "") cards. A payload
+    // that can't be placed on the ack's counter simply doesn't outrank: the prediction waits for
+    // confirmation by content, with the MOVE_ACK_MS backstop unchanged behind it.
     const acked = pendingMoveAck.get(id);
-    if (acked !== undefined && buildId > acked) clearFollowMove(id, "outranked");
+    if (acked === undefined) continue;
+    const cardHost = hostOf(a.sid);
+    if (cardHost !== acked.host) continue;   // an ack from some other kernel says nothing about this card
+    const mark = buildIds ? buildIds[cardHost] : (cardHost === "" ? buildId : undefined);
+    if (typeof mark === "number" && mark > acked.buildId) clearFollowMove(id, "outranked");
   }
 }
 // Render-time: keep each still-unconfirmed predicted card in Working, styled like the kernel's own re-checked
@@ -3672,7 +3690,11 @@ window.addEventListener("message", (e: MessageEvent) => {
     // an acked prediction early, leaving the backstop to retire it.
     lastFeedEvent = "payload";                         // tripwire: this render's inputs are the fresh payload
     lastPayloadBuildId = typeof m.buildId === "number" ? m.buildId : 0;
-    reconcileFollowMove(incomingAsks, lastPayloadBuildId);
+    // per-host counters when this is a merged multi-kernel payload (mergeHostFeeds.buildIds);
+    // absent on a single-kernel payload, where the top-level buildId is the one counter there is
+    const perHostBuildIds = m.buildIds && typeof m.buildIds === "object" && !Array.isArray(m.buildIds)
+      ? m.buildIds as Record<string, number> : undefined;
+    reconcileFollowMove(incomingAsks, lastPayloadBuildId, perHostBuildIds);
     reconcilePendingDone(incomingAsks);   // retire an optimistic tick once the real tree carries it
     // An optimistic Undo clear is CONFIRMED once the kernel's payload carries the id again → stop forcing it.
     // Until then, keep the cached card in `asks` so the replace above can't drop the just-restored card (flicker).
@@ -3790,9 +3812,12 @@ window.addEventListener("message", (e: MessageEvent) => {
     // — the kernel may name a SUB-goal that a visible top card carries — and an id this view never predicted
     // is a no-op, so the ack is safe to broadcast to every feed pane.
     const bid = typeof m.buildId === "number" ? m.buildId : 0;
+    // which kernel's counter `bid` is on: federation stamps a remote ack with its host (prefixInbound);
+    // an unstamped ack came from the local kernel — host "", the same value hostOf gives local cards
+    const ackHost = typeof m.host === "string" ? m.host : "";
     for (const raw of m.ids.map(String)) {
       const top = asks.find((a) => a.itemId === raw) ?? asks.find((a) => a.tree?.some((n) => n.id === raw));
-      ackFollowMove(top ? top.itemId : raw, !!m.ok, bid);
+      ackFollowMove(top ? top.itemId : raw, !!m.ok, bid, ackHost);
     }
   }
 });

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -236,6 +236,34 @@ test("mergeHostFeeds: concatenates items/asks/working across hosts (local first)
   assert.equal(m.canUndoClear, true);
 });
 
+test("mergeHostFeeds: per-host buildIds ride the merge — each kernel's counter, separately addressable", () => {
+  // the user 2026-08-15: a reply to a remote card bounced Working → Completed → Working. The merged
+  // payload's top-level buildId is the LOCAL kernel's counter (large after days of uptime); the remote
+  // ack's buildId is the remote's (small after a restart). Comparing them cross-counter "outranked" the
+  // ack instantly. The map is what lets the feed pane compare same-counter only.
+  const perHost = {
+    "": { type: "feed", items: [], asks: [], working: [], buildId: 4032 },
+    TESTHOST: { type: "feed", items: [], asks: [], working: [], buildId: 7 },
+  };
+  const m = mergeHostFeeds(perHost, ["", "TESTHOST"]);
+  assert.deepEqual(m.buildIds, { "": 4032, TESTHOST: 7 });
+  assert.equal(m.buildId, 4032, "the local scalar stays for older panes — additive, never repurposed");
+  // a host too old to send buildId simply has no entry — absent, never guessed
+  const old = mergeHostFeeds({ "": { type: "feed", items: [], asks: [], working: [] } }, [""]);
+  assert.deepEqual(old.buildIds, {});
+});
+
+test("prefixInbound: a remote cardMoveAck/cardPredict is host-stamped; its goal ids stay bare", () => {
+  // goal ids are globally unique (uuid:gN) and match the pane's itemIds unprefixed; the HOST is what the
+  // ack was missing — without it a buildId can't be placed on the counter it was minted by
+  const ack = prefixInbound("TESTHOST", { type: "cardMoveAck", ids: [U + ":g6"], ok: true, buildId: 7 });
+  assert.equal(ack.host, "TESTHOST");
+  assert.deepEqual(ack.ids, [U + ":g6"], "goal ids pass through bare");
+  assert.equal(prefixInbound("TESTHOST", { type: "cardPredict", ids: [U + ":g6"], flavor: "followup" }).host, "TESTHOST");
+  const local = prefixInbound("", { type: "cardMoveAck", ids: [U + ":g6"], ok: true, buildId: 9 });
+  assert.ok(!("host" in local), "local is the identity transform — no stamp");
+});
+
 test("mergeHostFeeds: a remote-only undo lights the Undo button (clear routed to that kernel)", () => {
   const m = mergeHostFeeds({
     "": { type: "feed", items: [], asks: [], working: [], canUndoClear: false, dismissedCount: 0 },


### PR DESCRIPTION
Replying to a completed card on the federated dashboard bounced it Working → Completed (a beat) → Working (reported by the user 2026-08-15, on a remote session's card).

The trail: the optimistic move held the card in Working pending the kernel's answer; the ack carried the card's home kernel's feed-build counter (small — that machine restarts often); the next merged payload's top-level buildId was the local kernel's counter (large — days of uptime), because `mergeHostFeeds` keeps local scalar chrome. `reconcileFollowMove` compared the two as one clock, declared the payload newer ("outranked"), dropped the prediction, and rendered the still-cached pre-reopen remote frame — Completed — until the home kernel's post-reopen frame arrived.

Fix: mergeHostFeeds carries a per-host `buildIds` map (local scalar kept, additive); federation stamps relayed cardMoveAck/cardPredict with their host (goal ids stay bare — globally unique); the ack records whose counter it's on; reconcile compares only same-counter, resolving the card's host from its sid. A payload that can't be placed on the ack's counter never outranks — the prediction waits for confirmation by content, existing backstop unchanged.

Tests: behavioral buildIds-map and host-stamp cases in multi-kernel-merge.test.ts; cross-counter pins in feed-move-ack.test.ts; stale pins updated (colflip, followup-move). Full UI suite: 2011 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)