### PR TITLE
The Continue click reads as a gesture, and its label is the sent words themselves

### DIFF
--- a/ui/webview/continue-bubble.test.ts
+++ b/ui/webview/continue-bubble.test.ts
@@ -1,8 +1,10 @@
-// The Continue button's reply renders as a GESTURE in the user family (the user 2026-08-13): blue —
-// the judges file it as your reply — but folded to a one-line gist ("Continue — keep going; open calls
-// are yours") with the exact canned words one click deeper, so unwritten prose never poses as typed.
-// Keyed on the kernel's romp-canned marker (event-based), never on text-matching the copy. Source pins
-// (no jsdom for the chat renderer), plus the kernel side of the contract (node-tests-pin-kernel-source).
+// The Continue button's reply renders as a GESTURE in the slash-command family (the user 2026-08-15;
+// supersedes the 2026-08-13 blue-bubble fold, whose PARAPHRASED gist made it the one "user message"
+// that expanded — to different words than its label): ✦ mark, mono chip "Continue", then the SENT
+// text's own first line with the rest one click deeper — expanding only ever reveals MORE of the same
+// words, never different ones. The judges still file it as the user's reply. Keyed on the kernel's
+// romp-canned marker (event-based), never on text-matching the copy. Source pins (no jsdom for the
+// chat renderer), plus the kernel side of the contract (node-tests-pin-kernel-source).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -12,19 +14,26 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
-test("the canned Continue folds to a gist in the BLUE bubble — gesture, not prose", () => {
+test("the canned Continue is a GESTURE row: ✦ + chip + the sent text's own first line", () => {
   assert.match(RENDER, /canned\?: string/, "the user event carries the kernel's lift");
   assert.match(RENDER, /\} else if \(!romp && !injected && ev\.md && ev\.canned === "continue"\) \{/,
     "keyed on the lifted marker, never on text-matching the canned copy");
-  assert.match(RENDER, /Continue — keep going; open calls are yours/);
+  // the slash-command dress — same family, same classes
+  assert.match(RENDER, /turn\.classList\.add\("turn-cmd"\);\s*\n\s*bubble\.classList\.add\("cmd-row"\);\s*\n\s*const chip = el\("span", "slash-cmd-chip"\); chip\.textContent = "Continue";/);
+  // the collapsed line is the SENT text itself (first non-quote line, clipped) — never a paraphrase,
+  // so expanding reveals more of the same words rather than different ones
+  assert.match(RENDER, /const first = lines\.find\(\(l\) => l && !l\.startsWith\(">"\)\) \|\| lines\.find\(\(l\) => l\) \|\| raw;/);
+  assert.match(RENDER, /const clipped = first\.length > 90 \? first\.slice\(0, 88\)\.replace\(\/\\s\+\\S\*\$\/, ""\) \+ "…" : first;/);
+  assert.doesNotMatch(RENDER, /Continue — keep going; open calls are yours/, "the paraphrased label is gone");
   // the same fold machinery nudges use: keyed expand, the stable body delegate, never a per-render listener
   assert.match(RENDER, /const ckey = ev\.uuid \? "cont:" \+ ev\.uuid : undefined;/);
   assert.match(RENDER, /bubble\.classList\.add\("nudge-collapsible"\);\s*\n\s*bubble\.dataset\.act = "nudgetoggle";\s*\n?\s*\/\/ the stable body delegate/);
 });
 
-test("the user-family fold is white-on-blue, not romp's dim gray", () => {
+test("the gesture fold is dim like the command family, and unfolds in place", () => {
   assert.match(CSS, /\.user-bubble\.nudge-collapsible \{ cursor: pointer; \}/);
-  assert.match(CSS, /\.user-bubble \.nudge-gist, \.user-bubble \.nudge-caret \{ color: rgba\(255, 255, 255, 0\.92\); \}/);
+  assert.match(CSS, /\.user-bubble\.cmd-row \.nudge-gist, \.user-bubble\.cmd-row \.nudge-caret \{ color: var\(--dim\); \}/);
+  assert.match(CSS, /\.user-bubble\.cmd-row \.nudge-full \{ color: var\(--dim\); margin-top: 4px; max-width: 640px; \}/);
   assert.match(CSS, /\.user-bubble \.nudge-full \{ display: none; \}/);
   assert.match(CSS, /\.user-bubble\.expanded \.nudge-full \{ display: block; \}/);
   assert.match(CSS, /\.user-bubble\.expanded \.nudge-gist \{ display: none; \}/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1764,13 +1764,24 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         turn.classList.add("turn-cmd");
         bubble.classList.add("cmd-row");
       } else if (!romp && !injected && ev.md && ev.canned === "continue") {
-        // The card's Continue button (the user 2026-08-13): YOUR gesture in YOUR colour — the judges
-        // file it as your reply, the bubble stays blue — but not your prose: a one-line gist says what
-        // you did, and the exact canned words sit one click deeper (the nudge fold, in the user
-        // family). The ↩ follow-up header above already names the goal it answers.
-        const gistEl = el("div", "nudge-gist");
+        // The card's Continue button: a user GESTURE, not typed prose. The 2026-08-13 cut kept the
+        // blue bubble with a PARAPHRASED gist — which made it the one "user message" that expanded,
+        // and to different words than its label (the user 2026-08-15: unclear what was actually
+        // sent). Superseded: gestures read in the slash-command family (✦ mark, mono chip) — chip
+        // "Continue", then the SENT text's own first line, the rest one click deeper, so expanding
+        // only ever reveals MORE of the same words. The judges still file it as your reply, and the
+        // ↩ follow-up header above still names the goal it answers.
+        turn.classList.add("turn-cmd");
+        bubble.classList.add("cmd-row");
+        const chip = el("span", "slash-cmd-chip"); chip.textContent = "Continue";
+        bubble.appendChild(chip);
+        const raw = ev.md.replace(/<!--[\s\S]*?-->/g, "").trim();
+        const lines = raw.split("\n").map((l) => l.trim());
+        const first = lines.find((l) => l && !l.startsWith(">")) || lines.find((l) => l) || raw;   // skip a goal-context "> …" quote
+        const clipped = first.length > 90 ? first.slice(0, 88).replace(/\s+\S*$/, "") + "…" : first;
+        const gistEl = el("span", "nudge-gist");
         const c = el("span", "nudge-caret"); c.textContent = "▸"; gistEl.appendChild(c);
-        gistEl.appendChild(document.createTextNode("Continue — keep going; open calls are yours"));
+        gistEl.appendChild(document.createTextNode(clipped));
         bubble.appendChild(gistEl);
         const full = el("div", "nudge-full md");
         full.innerHTML = md(ev.md);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1219,6 +1219,12 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .user-bubble.cmd-row .slash-cmd-chip { background: var(--bg); color: #2b6cef;
   border-color: #2b6cef; }
 .user-bubble.cmd-row .slash-cmd-args { color: var(--dim); }
+/* The Continue button's turn wears the same gesture dress (render.ts canned === "continue", the user
+   2026-08-15): chip "Continue", then the SENT text's own first line — dim like the command family, not
+   the white-on-blue fold — with the full words unfolding in place under the row. */
+.user-bubble.cmd-row .nudge-gist, .user-bubble.cmd-row .nudge-caret { color: var(--dim); }
+.user-bubble.cmd-row .nudge-gist { margin-left: 8px; }
+.user-bubble.cmd-row .nudge-full { color: var(--dim); margin-top: 4px; max-width: 640px; }
 /* ---------- romp-injected message (a feed nudge / follow-up) ----------
    A GRAY bubble in the SAME right-aligned spot as the blue user bubble (so it sits where "an outgoing
    message" goes), but clearly NOT you — gray, with a small "↯ romp" tag above it (the user 2026-06-19).


### PR DESCRIPTION
User report (2026-08-15): the Continue button's message rendered as a blue user bubble as if they'd typed it, was expandable (no other user message is), and expanded to entirely different words than its label — "unclear what the content of the message actually is."

A button press is a user gesture, so it now wears the slash-command family's dress (the precedent set the same day the old design landed): ✦ mark, mono "Continue" chip, then the sent text's own first line (dim), full words one click deeper. The collapsed line is a prefix of the actual message, so expanding only reveals more of the same words. Judges still file it as the user's reply; the ↩ follow-up header still names the goal.

Tests: continue-bubble.test.ts rewritten (gesture-row pins, paraphrase-absence pin, dim fold CSS pins). Full UI suite: 2011 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)