### PR TITLE
A failed preview heals on the next kernel push, not on a human tap

### DIFF
--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -45,6 +45,18 @@ test("a kernel-VERIFIED preview fails LOUDLY: a retry chip holds the figure's sp
   assert.match(CSS, /\.path-full-retry \{ display: inline-flex;/, "visible chrome — the chip has chat-sheet css");
 });
 
+test("a failed preview heals on the next kernel push — the kernel-is-back event, not a tap or a timer", () => {
+  // the 2026-08-15 report: the fetch died in a converge-restart window, and delta-send never rebuilds
+  // an old turn's DOM, so the chip sat until a human tapped it. Any incoming kernel message proves the
+  // kernel is reachable again; no pushes arrive while it's down, so retry-on-push can't spam.
+  const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
+  assert.match(pf, /let autoRetries = 3;/, "bounded — a genuinely-dead file settles on the tap chip");
+  assert.match(pf, /if \(autoRetries > 0\) \{ autoRetries--; failedPreviews\.set\(box, \(\) => build\(true\)\); \}/);
+  assert.match(PREVIEW, /export function retryFailedPreviews\(\): void/);
+  assert.match(PREVIEW, /if \(box\.isConnected\) rebuild\(\);/, "a re-rendered turn's fresh box supersedes the old");
+  assert.match(RENDER, /retryFailedPreviews\(\);/, "called from the kernel message handler");
+});
+
 test("the chat uses the FULL render on web, and the host data-URL flow for images in VS Code", () => {
   assert.match(RENDER, /const full = canPreview\(\) \? previewFull\(p, activeId, kernelVerified\.has\(p\)\)\s*\n\s*: previewKind\(p\) === "img" \? buildPathImg\(p\) : null;/);
   assert.doesNotMatch(RENDER, /previewThumb/, "the chat no longer renders mention thumbnails — full renders now");

--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -46,7 +46,7 @@ test("chat: a mentioned image/PDF grows a FULL render at its mention, deduped an
   // (the user 2026-07-20: full renders replaced the 2026-07-08 thumbnails in the chat; the user
   // 2026-08-15: figures moved from a tail strip to the mentioning block —
   // chat-inline-preview.test.ts pins the placement shape)
-  assert.match(RENDER, /import \{ previewKind, previewFull, canPreview, fileUrl \} from "\.\/preview";/);
+  assert.match(RENDER, /import \{ previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews \} from "\.\/preview";/);
   assert.match(RENDER, /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) \{/, "collected while linkifying — same detection, no second regex pass; an in-bubble image never re-renders");
   assert.match(RENDER, /if \(previewable\.length\) \{/, "both surfaces now — VS Code images ride the host data-URL flow");
   assert.match(RENDER, /previewable\.slice\(0, 4\)/, "capped so a directory listing doesn't wallpaper the chat");

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -151,6 +151,11 @@ export function previewFull(path: string, sid?: string | null, verified = false)
     if (!verified) fetch(fileUrl(path, sid), { method: "HEAD" }).then((r) => { if (!r.ok) box.remove(); }).catch(() => box.remove());
   } else {
     const url = fileUrl(path, sid);
+    // A verified preview whose fetch died usually died because the KERNEL was away (a restart mid-
+    // deploy — the 2026-08-15 report hit exactly the converge-restart window), and delta-send never
+    // rebuilds an old turn's DOM, so the chip would otherwise sit until a human tapped it. Bounded so
+    // a genuinely-dead file settles on the tap chip instead of re-fetching on every push forever.
+    let autoRetries = 3;
     const build = (bust: boolean) => {
       box.textContent = "";
       const img = document.createElement("img");
@@ -168,6 +173,7 @@ export function previewFull(path: string, sid?: string | null, verified = false)
         chip.title = path;
         chip.onclick = (ev) => { ev.stopPropagation(); build(true); };
         box.appendChild(chip);
+        if (autoRetries > 0) { autoRetries--; failedPreviews.set(box, () => build(true)); }
       };
       withLoadCue(box, img, url);   // mini swirl holds the spot until the load event (memo on the un-busted url)
       box.appendChild(img);
@@ -175,4 +181,17 @@ export function previewFull(path: string, sid?: string | null, verified = false)
     build(false);
   }
   return box;
+}
+
+// Failed VERIFIED previews awaiting recovery. A kernel push arriving IS the kernel-is-back event —
+// no pushes arrive while it's down, so retrying on push can't spam — and render.ts calls this on
+// every incoming kernel message, healing the chips without a tap (event-based; the tap chip stays
+// as the manual path and the backstop once a box's bounded auto-retries are spent).
+const failedPreviews = new Map<HTMLElement, () => void>();
+export function retryFailedPreviews(): void {
+  if (!failedPreviews.size) return;
+  for (const [box, rebuild] of Array.from(failedPreviews.entries())) {
+    failedPreviews.delete(box);                      // one attempt per registration; re-registers on error
+    if (box.isConnected) rebuild();                  // a re-rendered turn made a fresh box — let the old go
+  }
 }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -30,7 +30,7 @@ import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional 
 import { onlyTag, matchesOnly } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, type AgentNotif } from "./agent-notif";
-import { previewKind, previewFull, canPreview, fileUrl } from "./preview";
+import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews } from "./preview";
 import { openFileView } from "./file-view";
 import { pastedFilePath } from "./paste-path";
 import { hostNameNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
@@ -9400,6 +9400,9 @@ window.addEventListener("message", (e: MessageEvent) => {
   // the shell's palette / shell-focus chords: the chat owns the nav trail, the shell just asks
   if (m.romp === "chatNav") { navHist.go(m.dir === 1 ? 1 : -1); return; }
   if (m.type === "pipeState") { pipeBanner(!!m.up, Number(m.queued) || 0); return; }
+  // any kernel message proves the kernel is reachable again — heal previews whose fetch died in a
+  // restart window (preview.ts retryFailedPreviews; a no-op when nothing failed)
+  retryFailedPreviews();
   if (m.type === "session") upsert(m);
   else if (m.type === "globalRetryPaused") {
     globalRetryPaused = !!m.value;


### PR DESCRIPTION
User report (2026-08-15): a verified relative-path figure showed "⚠ preview unavailable — tap to retry" persistently. Investigation: the file is fine — the kernel served those exact bytes on a direct probe (200, image/png, resolved against the session's cwd). The fetch had landed in one of the evening's five converge-restart windows, and after the kernel came back nothing re-attempted it: delta-send never rebuilds an old turn's DOM, so the chip waits for a human tap.

Fix: the recovery event is the kernel being reachable again, and any incoming kernel message proves exactly that (no pushes arrive while it's down → retry-on-push can't spam). The error path registers the failed box for one rebuild on the next kernel message; bounded at 3 automatic attempts per box so a genuinely-dead file settles on the tap chip. Boxes superseded by a re-rendered turn are skipped and dropped.

Tests: heal pins added to chat-inline-preview.test.ts; import pin updated in preview-core.test.ts. Full UI suite: 2013 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)