### PR TITLE
Every spawned session carries its own name in env: ROMP_SESSION_NAME

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3455,9 +3455,13 @@ class SdkBackend:
             # command-not-found and re-prompted for permission on the absolute-path retry). options.env
             # merges OVER the inherited environment in the SDK's transport, so this is additive.
             # ROMP_SID gives the CLI process (and every Bash it runs) the session's STABLE identity —
-            # what lets `romp end self` resolve itself to the kernel (the user 2026-08-15). The sid,
-            # not the name: names rename after spawn, env is spawn-frozen.
-            env={**_bin_on_path_env(os.environ), "ROMP_SID": str(sess.sid)},
+            # what lets `romp end self` resolve itself to the kernel (the user 2026-08-15). And
+            # ROMP_SESSION_NAME gives child processes the session's human NAME (the user 2026-08-16):
+            # a generic identity surface, deliberately coupled to no consumer. Env is spawn-frozen, so
+            # a rename after spawn is NOT reflected here — the sid stays the stable identity; the name
+            # is a spawn-time label, right for attribution and logging, wrong for addressing.
+            env={**_bin_on_path_env(os.environ), "ROMP_SID": str(sess.sid),
+                 "ROMP_SESSION_NAME": str(sess.name)},
             # Registering this is what makes the CLI's stderr EXIST for romp at all: the SDK transport
             # pipes the child's stderr only when options.stderr is set (otherwise it hands the child
             # our own stderr and reports SDK_STDERR_PLACEHOLDER on failure). Without it, a CLI that

--- a/tests/test_fresh_install_federation.py
+++ b/tests/test_fresh_install_federation.py
@@ -79,7 +79,7 @@ class SpawnedSessionPath(unittest.TestCase):
 
     def test_options_pass_the_overlay(self):
         src = Path(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read_text()
-        self.assertIn('env={**_bin_on_path_env(os.environ), "ROMP_SID": str(sess.sid)}', src,
+        self.assertIn('env={**_bin_on_path_env(os.environ), "ROMP_SID": str(sess.sid),', src,
                       "_options wires the overlay through the SDK's designed env field")
 
 

--- a/tests/test_session_env.py
+++ b/tests/test_session_env.py
@@ -1,0 +1,38 @@
+"""The session-identity environment surface (the user 2026-08-15 sid, 2026-08-16 name).
+
+Every SDK session's CLI process — and every Bash it runs — carries its romp identity in env:
+ROMP_SID (the stable uuid; what `romp end self` resolves through) and ROMP_SESSION_NAME (the
+human name at spawn). The name is a GENERIC capability for child processes that need to know
+which session they belong to (attribution, logging), deliberately coupled to no consumer.
+Env is spawn-frozen, so a post-spawn rename is not reflected — the sid is the address, the
+name a label. Source pins over _options' env line (the SDK merges options.env OVER the
+inherited environment, so both ride the same additive overlay as the bin PATH)."""
+import os
+import unittest
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SDK = Path(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read_text()
+
+
+class SessionIdentityEnv(unittest.TestCase):
+    def test_sid_and_name_ride_the_spawn_env(self):
+        self.assertIn('"ROMP_SID": str(sess.sid),', SDK,
+                      "the stable identity — addressing (romp end self)")
+        self.assertIn('"ROMP_SESSION_NAME": str(sess.name)', SDK,
+                      "the human name at spawn — attribution/logging for child processes")
+
+    def test_the_name_is_documented_as_spawn_frozen(self):
+        # the caveat is the contract: a rename after spawn is NOT reflected in a live session's
+        # env, so nothing may treat the name as an address — the comment must keep saying so
+        self.assertIn("a rename after spawn is NOT reflected", SDK)
+
+    def test_one_env_overlay_only(self):
+        # both vars ride _options' single env= overlay (additive over os.environ via
+        # _bin_on_path_env) — a second env assembly would fork the truth
+        self.assertEqual(SDK.count('"ROMP_SESSION_NAME":'), 1)
+        self.assertEqual(SDK.count('env={**_bin_on_path_env(os.environ)'), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
User ask (2026-08-16, relayed): child processes should be able to learn which session they belong to by NAME, not just by stable id — a generic identity surface, deliberately coupled to no consumer (headless sessions had no way to self-identify in human terms, which broke author attribution in an external tool that now reads this var).

`ROMP_SESSION_NAME` joins `ROMP_SID` on the SDK spawn-env overlay (additive over os.environ, same field as the bin PATH). Env is spawn-frozen: a post-spawn rename is not reflected — the sid remains the address, the name a spawn-time label for attribution/logging; comment and test both carry the caveat.

Tests: new tests/test_session_env.py (both vars on the overlay, spawn-frozen caveat pinned, single-overlay pin); the federation env pin updated. Python suite: 4762 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)