### PR TITLE
The SDK is the one live backend: liveness, routing, doors, revive, and the seams

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1237,26 +1237,30 @@ def _sessions(now, window=None, forks=True):
     return out
 
 
-def _path_of(sid, now=None):
+def _path_of(sid, now=None, window=None):
     """The transcript path for a sid (discover-cached → cheap), or None. Lets the sid-keyed backend API
-    resolve a session's transcript without the caller threading the path through (e.g. pending_queued)."""
+    resolve a session's transcript without the caller threading the path through (e.g. pending_queued).
+    `window` widens the discover reach past the default 48h caption horizon — the revive path checks
+    over the picker's 30-day window, since that is exactly how far back its Revive door offers."""
     now = int(time.time()) if now is None else now
-    s = next((s for s in _sessions(now) if s["sid"] == sid), None)
+    s = next((s for s in _sessions(now, window) if s["sid"] == sid), None)
     return s["path"] if s else None
 
 
-def _has_tmux():
-    """True iff a tmux binary exists at all. The kernel runs on the HOST where the
-    sessions + Claude live, so tmux is normally present; a 'headless' run (a test box
-    / CI with no tmux) is the only case it's absent. This is what lets _alive_sessions
-    tell 'the user has zero live sessions' (tmux present, query returned nothing →
-    show nothing) apart from 'there is no tmux here at all' (fall back to file-derived
-    sessions). Only consulted when the tmux query came back empty, so it's off the hot
-    path. Keyed on tmux's PRESENCE, not on a count or a timeout (no heuristics)."""
-    return shutil.which("tmux") is not None
+def _live_source_present():
+    """True iff a live-session SOURCE exists at all — the SDK backend built (its deps import), so an
+    empty live map means 'the user has zero live sessions' and must be TRUSTED (the user 2026-06-16:
+    after killing every session and reloading, the surfaces wrongly reopened tabs for all the dead
+    ones — that was the fallback firing on a genuine zero). A box that cannot run sessions at all (a
+    test/CI run without the SDK venv) is the only case this is False: there _alive_sessions falls
+    back to file-derived sessions so a headless box isn't blank. Only consulted when the live map
+    came back empty, so it's off the hot path. Keyed on the backend's PRESENCE, never a count or a
+    timeout (no heuristics — the same shape the tmux-binary probe had when tmux was the live
+    source). Tests stub this seam directly."""
+    return _sdk() is not None
 
 
-def _alive_sessions(now, tmux):
+def _alive_sessions(now, live_map):
     """The sessions shown on EVERY surface (feed / timeline / chat tabs): only those alive in tmux
     right now. The hard liveness filter (the user 2026-06-15) — ignore everything that isn't a living
     session: a dead session's transcript stays in discover()'s window but is dropped from all
@@ -1269,14 +1273,14 @@ def _alive_sessions(now, tmux):
     wrongly reopened tabs for all the dead ones — that was this fallback firing on a genuine zero).
     So: tmux reachable (sessions present, or a tmux binary exists) → trust the empty result and show
     only living sessions; no tmux at all → fall back so a headless box isn't blank."""
-    alive = [s for s in _sessions(now) if s["sid"] in tmux]
+    alive = [s for s in _sessions(now) if s["sid"] in live_map]
     # LIVE IS ALWAYS VISIBLE (2026-08-13, generalizing the SDK-only exception below): a genuinely
     # LIVE sid missing from the 48h _sessions set — a session idle longer than the caption window,
     # which used to silently VANISH from every surface while still running — resolves through
     # discover's cached wide walk (the picker's own (window, forks) cache key: one filesystem walk,
     # not one per session). Liveness owns visibility; age owns nothing but caption/walk cost.
     have = {s["sid"] for s in alive}
-    stale_live = [sid for sid in tmux if sid not in have]
+    stale_live = [sid for sid in live_map if sid not in have]
     if stale_live:
         wide = {f[0]: f for f in jd.discover(now, window=jd.DEATH_BACKFILL_WINDOW)}
         for sid in stale_live:
@@ -1295,10 +1299,10 @@ def _alive_sessions(now, tmux):
     # their tab never opens (the user 2026-06-22). Once they run and write a transcript, discover takes over.
     be = _sdk()
     if be:
-        for sid in tmux:
+        for sid in live_map:
             if sid not in have and be.owns(sid):
                 alive.append(_sdk_sess(sid, now))
-    if tmux or _has_tmux():
+    if live_map or _live_source_present():
         return alive
     return _sessions(now)
 
@@ -1493,10 +1497,10 @@ def _ordered(sessions):
     return sorted(sessions, key=lambda s: idx.get(s["sid"], len(idx)))   # stable sort: ties keep input order
 
 
-def _ordered_alive(now, tmux):
+def _ordered_alive(now, live_map):
     """Living sessions in the shared, persisted order (see _ordered). Kept as the source for the tab-order
     push on connect; chat tabs AND timeline lanes resolve the SAME order through _ordered, in lockstep."""
-    return _ordered(_alive_sessions(now, tmux))
+    return _ordered(_alive_sessions(now, live_map))
 
 
 # (Hidden tabs are GONE — the user 2026-08-11. ×-closing used to write the sid to hidden-tabs.json and
@@ -2227,10 +2231,10 @@ def _auto_pause_on_limit():
         _push_all()
 
 
-def _spend_capped_session(now, tmux):
+def _spend_capped_session(now, live_map):
     """The first alive session sitting blocked on a MONTHLY SPEND CAP error, or None. Account-wide by
     nature (the cap is on the account, so every session hits it), so one is enough to pause everything."""
-    for s in _alive_sessions(now, tmux):
+    for s in _alive_sessions(now, live_map):
         p = s.get("path")
         if p:
             e = _api_error(p)
@@ -2239,7 +2243,7 @@ def _spend_capped_session(now, tmux):
     return None
 
 
-def _auto_pause_on_spend_limit(now, tmux):
+def _auto_pause_on_spend_limit(now, live_map):
     """A monthly spend cap auto-engages the global retry-pause (the user 2026-07-14) — the SPEND twin of
     _auto_pause_on_limit. Unlike a 5h/7d RATE window (a known reset the card counts down to, retried at
     the reset), a spend cap has no readable reset: retrying just re-fails until the user raises it, so the
@@ -2251,14 +2255,14 @@ def _auto_pause_on_spend_limit(now, tmux):
     as the cap does. reason='spend' → the card shows 'raise your cap', not a reset countdown. Idempotent."""
     if _retry_paused_on():
         return
-    if _spend_capped_session(now, tmux) is not None:
+    if _spend_capped_session(now, live_map) is not None:
         _set_retry_paused(True, reason="spend")
         sys.stderr.write("retry-pause: auto-engaged — monthly spend limit reached → auto-retry + judges "
                          "paused until the cap is raised (claude.ai/settings/usage)\n")
         _push_all()
 
 
-def _auto_resume_retry(now, tmux):
+def _auto_resume_retry(now, live_map):
     """The global retry-pause is an API-HEALTH flag, not a permanent switch. The user flips it to stop the
     auto-retry (and, with it, the judge) storm during an API / usage-limit outage — but it must AUTO-CLEAR
     the moment the API is healthy again: "cleared the second I get a successful response that's not an API
@@ -2272,7 +2276,7 @@ def _auto_resume_retry(now, tmux):
     if not _retry_paused_on():
         return
     floor = _retry_pause_ts()
-    for s in _alive_sessions(now, tmux):
+    for s in _alive_sessions(now, live_map):
         path = s.get("path")
         if not path or _api_error(path):                 # still blocked on an API error → not proof of recovery
             continue
@@ -2349,7 +2353,7 @@ def _clear_session_retry_suppress(sid):
     return False
 
 
-def _auto_resume_session_retry(now, tmux):
+def _auto_resume_session_retry(now, live_map):
     """Per-session mirror of _auto_resume_retry: clear a thread's retry-suppression once it lands a
     SUCCESSFUL user turn again. Re-arm signal (event-based, no timer): the user spoke on the thread AFTER the
     suppression floor AND the session settled to a healthy, non-API-error chip (ready/idle/awaiting/closed) —
@@ -2360,7 +2364,7 @@ def _auto_resume_session_retry(now, tmux):
     if not d:
         return
     changed = False
-    for s in _alive_sessions(now, tmux):
+    for s in _alive_sessions(now, live_map):
         sid = str(s.get("sid"))
         floor = d.get(sid)
         if not floor:
@@ -2369,7 +2373,7 @@ def _auto_resume_session_retry(now, tmux):
         session = (_parse_cached(path) if path else None) or {"turns": []}
         if _last_human_msg_t(session["turns"]) <= floor:
             continue                                      # user hasn't re-engaged since the stop → still hands-off
-        chip = _session_chip(sid, path, session, tmux.get(sid), now)
+        chip = _session_chip(sid, path, session, live_map.get(sid), now)
         if chip in ("ready", "idle", "needsInput", "awaitingBg", "closed"):   # re-engaged turn settled clean → the message went through
             if _clear_session_retry_suppress(sid):
                 changed = True
@@ -2702,7 +2706,7 @@ def _intr_block_stands(sid, gid):
     return bool(nd and nd.get("blocked"))
 
 
-def _interrupt_block_tick(now, tmux):
+def _interrupt_block_tick(now, live_map):
     """Interrupt → Blocked, INDEPENDENT of the auto-nudge switch (the user 2026-07-14). A session the
     user genuinely STOPPED mid-turn is waiting on their next instruction: its focus goal needs THEM, so
     it belongs in the Blocked (needs-you) column — never sitting quietly in Working. This flip used to
@@ -2718,11 +2722,11 @@ def _interrupt_block_tick(now, tmux):
     it), and trusting the bare marker skipped the re-block forever — the live focus goal sat in
     Working wearing only the badge, auto-nudge suppressed: invisible-blocked."""
     changed = False
-    for s in _alive_sessions(now, tmux):
+    for s in _alive_sessions(now, live_map):
         sid = s["sid"]
         if _session_flag(sid, "hideFromFeed"):           # muted from the feed → no interrupt-block bookkeeping either
             continue
-        st = (tmux.get(sid) or {}).get("state", "")
+        st = (live_map.get(sid) or {}).get("state", "")
         if st in _NEEDS_INPUT_STATES or st == "compacting" or _compacting_now(sid):
             continue                                     # awaiting you / compacting → a different needs-you path owns it
         if _api_error(s["path"]):                        # stopped on an API error → not a user stop
@@ -2958,7 +2962,7 @@ def _closer_pending(sid, path, now, store):
     return not _closer_settled(store, lt.get("id"), len(lt.get("atoms") or []))
 
 
-def _auto_nudge_tick(now, tmux):
+def _auto_nudge_tick(now, live_map):
     """One Auto-Nudge pass (from the periodic pusher). For each ALIVE, IDLE session (its turn ended) that
     isn't awaiting/compacting/api-error, isn't WAITING ON A LIVE PEER (a wait isn't a stall — the human's
     "waiting on a peer isn't needs-you"; a mutual-wait cycle is surfaced by the deadlock chip, not nudged),
@@ -2970,7 +2974,7 @@ def _auto_nudge_tick(now, tmux):
     if not _auto_nudge_on():
         return
     nudged = dict(_auto_nudge_data().get("nudged", {}))   # {gid: {count, lastTurnId}}
-    alive = list(_alive_sessions(now, tmux))
+    alive = list(_alive_sessions(now, live_map))
     alive_ids = {s["sid"] for s in alive}
     waitfor = _wait_for_graph(now, alive_ids)             # {sid:{peerSid,name,inCycle}} — the peer-wait gate
     fired = False
@@ -2981,7 +2985,7 @@ def _auto_nudge_tick(now, tmux):
         # ticks over two days before anyone noticed; every session after the bad one in the
         # iteration lost its nudges. The failure still logs loudly, per session.
         try:
-            fired = _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids) or fired
+            fired = _auto_nudge_session(s, now, live_map, nudged, waitfor, alive_ids) or fired
         except Exception:
             sys.stderr.write("auto-nudge (session %s): %s\n"
                              % (s.get("sid") or "?", traceback.format_exc()))
@@ -3087,7 +3091,7 @@ def _stamp_written_at(nd):
     return max(best, nd.get("awaitingAt") or 0)
 
 
-def _lift_spent_awaiting(now, tmux):
+def _lift_spent_awaiting(now, live_map):
     """Retire a goal's ⏳ awaiting stamp once the dispatches it was waiting on have RETURNED (the user
     2026-07-22). The closer's lift is bounded to the goals a turn actually WORKED ON (`touched`), which is
     right for goals merely riding the menu — but it means a goal the session ABANDONED keeps its stamp
@@ -3109,10 +3113,10 @@ def _lift_spent_awaiting(now, tmux):
 
     Dormant sessions are skipped: their tasks died with their CLI, so the death notice is the truth there,
     not a lift (same rule as _session_awaiting's source 0.75)."""
-    for s in _alive_sessions(now, tmux):
+    for s in _alive_sessions(now, live_map):
         sid = s["sid"]
         try:
-            if tmux.get(sid) is None:                 # dormant → its tasks died with the CLI, don't rule
+            if live_map.get(sid) is None:                 # dormant → its tasks died with the CLI, don't rule
                 continue
             store = jd.load_goals(sid)
             nodes = store.get("nodes") or {}
@@ -3189,7 +3193,7 @@ def _lift_spent_awaiting(now, tmux):
             sys.stderr.write("awaiting-lift (session %s): %s\n" % (sid or "?", traceback.format_exc()))
 
 
-def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
+def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, live_map):
     """The AWAITING branch of _auto_nudge_session's goal walk — one stamped top goal. The stamp is a
     judged wait, so the plain status nudge stays off; but a wait is not an exemption from the ladder
     (the user 2026-08-11): fire the check-in past the backstop, track its outcome through the same record
@@ -3208,7 +3212,7 @@ def _wake_goal(sid, gid, stamp, nudged, turns, store, now, lt, tmux):
                 the block rides the normal ladder to Needs-you. A failed/moot record re-arms only on a
                 genuinely NEW stamp episode (anchor newer than the one that failed)."""
     at, why = stamp[0], stamp[1]
-    if tmux.get(sid) is None:
+    if live_map.get(sid) is None:
         return False                                 # dormant CLI → its work died with it; the death notice
         #                                              owns that story, not a wake (same rule as the lifts)
     rec = nudged.get(gid) or {}
@@ -3700,7 +3704,7 @@ def _nudge_response_ready(turns, store, rec, gid, now):
     return True, resp
 
 
-def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
+def _auto_nudge_session(s, now, live_map, nudged, waitfor, alive_ids=None):
     """One session's slice of the auto-nudge tick: the session-level gates, then the fire/stamp
     walk over its still-'working' top goals. Split from _auto_nudge_tick so the tick isolates
     failures per session (see the tick's loop). Mutates `nudged` (the tick's in-memory mirror);
@@ -3714,7 +3718,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
     sid = s["sid"]
     if _session_flag(sid, "hideFromFeed"):           # muted from the feed → no auto-nudges either; a nudge IS a
         return False                                # feed feature, so opting out of the feed opts out of nudges (the user)
-    st = (tmux.get(sid) or {}).get("state", "")
+    st = (live_map.get(sid) or {}).get("state", "")
     # awaiting your input/approval / compacting → not orphaned. The tmux `st` is EMPTY for SDK sessions
     # (no tmux), so the raw-state "compacting" check MISSES them — corroborate with _compacting_now (the
     # same signal the chip/timeline/chat use), or a /compact on an SDK session gets nudged mid-compaction
@@ -3840,7 +3844,7 @@ def _auto_nudge_session(s, now, tmux, nudged, waitfor, alive_ids=None):
             # done / block / user reply / a peer's answer superseding the stamp). But a wait is not an
             # exemption from the ladder (the user 2026-08-11): past the backstop the goal takes a WAKE —
             # same records, same response gates, same escalation, its own copy (see _wake_goal).
-            fired = _wake_goal(sid, gid, _stamp, nudged, turns, store, now, lt, tmux) or fired
+            fired = _wake_goal(sid, gid, _stamp, nudged, turns, store, now, lt, live_map) or fired
             continue
         # LAST-RESORT GATE (the user 2026-07-22): every OTHER mechanism that could still move this card
         # off 'working' must be exhausted first. This is what the 2026-07-22 false interrupt needed: the
@@ -4117,7 +4121,7 @@ def _set_working_note(sid, text):
             pass
 
 
-def _clear_done_working_notes(now, tmux):
+def _clear_done_working_notes(now, live_map):
     """Event-based expiry of the set_working ownership note (the user 2026-06-24): once a session is IDLE
     with NO working top goal left — its work is done (only done / blocked-on-you / cleared remains) — its
     @romp-working claim is moot, so clear it. Peers reading list_agents then stop coordinating against a
@@ -4130,11 +4134,11 @@ def _clear_done_working_notes(now, tmux):
     notes = _working_notes()
     if not notes:
         return
-    for s in _alive_sessions(now, tmux):
+    for s in _alive_sessions(now, live_map):
         sid = s["sid"]
         if sid not in notes:
             continue
-        if (tmux.get(sid) or {}).get("state", "") in ("working", "compacting", "permission", "picker", "retrying"):
+        if (live_map.get(sid) or {}).get("state", "") in ("working", "compacting", "permission", "picker", "retrying"):
             continue                                     # actively progressing / awaiting input per tmux → keep (cheap pre-gate, no parse)
         try:
             turns = jd.parsed_session(sid, [s["path"]], now)["turns"]
@@ -4147,13 +4151,13 @@ def _clear_done_working_notes(now, tmux):
         _set_working_note(sid, "")                        # idle + nothing working → lift the stale claim
 
 
-def _chat_tab_sessions(now, tmux):
+def _chat_tab_sessions(now, live_map):
     """The sessions shown as CHAT TABS, in the shared session order: EVERY living session PLUS only the
     dead sessions the user explicitly opened READ-ONLY (_kept_open). A dead session is otherwise
     TIMELINE-ONLY — it does NOT auto-keep a tab when it dies (the user 2026-06-17 reversed the old 'keep
     a tab when it dies'); reopen it from the timeline instead. There is no hidden/open tab subset (the
     user 2026-08-11): alive = visible, and × ends the session."""
-    live = _alive_sessions(now, tmux)
+    live = _alive_sessions(now, live_map)
     live_sids = {s["sid"] for s in live}
     all_sessions = _sessions(now)
     dead_kept = [s for s in all_sessions if s["sid"] in _kept_open and s["sid"] not in live_sids]
@@ -4176,7 +4180,7 @@ TL_LANE_WINDOW = 12 * 3600       # default: DEAD lanes only from the last 12h (t
                                  # anyway; older dead sessions just aren't loaded. LIVE sessions show at any age.
 
 
-def _timeline_sessions(now, tmux, live_only=False):
+def _timeline_sessions(now, live_map, live_only=False):
     """Sessions shown as TIMELINE LANES (the user 2026-06-16): living sessions in the shared order PLUS
     every DEAD session whose transcript is within TL_LANE_WINDOW (12h) — so scrolling back surfaces the
     sessions that were active then, struck through. Independent of chat tabs: a dead session is a lane
@@ -4191,7 +4195,7 @@ def _timeline_sessions(now, tmux, live_only=False):
     user 2026-06-17 reversed the earlier rule that ×-ing a chat tab also dropped the timeline lane). A
     now-dead session that was active during the visible span appears on scrollback regardless of tab
     state — the active filter alone gates it."""
-    live = _alive_sessions(now, tmux)
+    live = _alive_sessions(now, live_map)
     if live_only:
         return _ordered(live)                          # cold-start first paint: live sessions only, no dead reads
     live_sids = {s["sid"] for s in live}
@@ -4222,9 +4226,9 @@ def _rel_ago(now, t):
     return "%dd ago" % (d // 86400)
 
 
-def _live_names(tmux):
+def _live_names(live_map):
     """name → sid for the sessions alive in tmux right now (tmux is keyed by sid)."""
-    return {n: sid for sid in (tmux or {}) for n in [_name_of(sid)] if n}
+    return {n: sid for sid in (live_map or {}) for n in [_name_of(sid)] if n}
 
 
 PICKER_WINDOW = 30 * 86400      # how far back the + picker reaches, vs jd.WINDOW's 48h CAPTION horizon (the
@@ -4234,12 +4238,12 @@ PICKER_CAP = 600                # user 2026-07-24: scroll back through the last 
 #   walk is ~78ms cold and ~4ms cached — below noticing, so laziness would buy nothing and cost a spinner.
 
 
-def _session_list(now, tmux, window=None):
+def _session_list(now, live_map, window=None):
     """Picker payload: sessions from the last PICKER_WINDOW, RUNNING ones first then by recency, each
     {id,name,color,running,time,summary} — the shape render.ts's renderPicker expects. ONE row per
     registered session: forks are off, since a fork lane is the same session listed twice under an fsid
     that is not a romp sid, so its row pointed openSession at something that isn't a session."""
-    live = set(tmux or {})
+    live = set(live_map or {})
     items = []
     for s in _sessions(now, PICKER_WINDOW if window is None else window, forks=False)[:PICKER_CAP]:
         sid = s["sid"]
@@ -4478,7 +4482,7 @@ def _reap_if_cancelled(name):
     (the threaded tmux spawn races the ✕; the SDK path is inline so it's caught in the handler instead)."""
     if name in _cancel_pending:
         _cancel_pending.discard(name)
-        sid = _live_names(_tmux_sessions()).get(name)
+        sid = _live_names(_live_map()).get(name)
         if sid:
             _end_pending_sid(sid)
 
@@ -4501,7 +4505,7 @@ def _spawn_session(name, cwd=None):
     # Surface the new tab NOW — one targeted single-session push, not the old inline _push_all(): that
     # duplicated the whole fleet build on this thread (against the push-architecture rule) and still left
     # the tab's freshness to chance. The dirty wake covers feed/timeline on the next cycle.
-    sid = _live_names(_tmux_sessions()).get(name)
+    sid = _live_names(_live_map()).get(name)
     if sid:
         _push_session_now(sid)
     _mark_views_dirty()
@@ -5297,7 +5301,15 @@ _SDK_PROMPT = Path(os.path.expanduser("~/.claude/romp-session-prompt.md"))
 # toast and the `romp new` JSON, because they are the same sentence to the same person: nothing was
 # created, and here is the single command that fixes it. Names the remedy, not the missing module.
 SDK_SETUP_HINT = ("Session not created: romp's Agent SDK backend isn't installed. "
-                  "Run bin/romp-sdk-setup, then try again. (tmux sessions still work.)")
+                  "Run bin/romp-sdk-setup, then try again.")
+# What a creation request that still says backend:"tmux" gets. The FIELD is accepted forever — old
+# clients and stale stored settings keep sending it — but the terminal backend is retired (the user
+# 2026-08-16), so the answer is a NAMED refusal: what was removed, and that nothing was created.
+# Never a silent drop, and never a session on a backend the caller didn't ask for (the mystery-spawn
+# failure class, 2026-07-28). One string for both creation doors (POST /new + the WS createSession),
+# same one-sentence-to-the-same-person reasoning as SDK_SETUP_HINT above.
+TMUX_REMOVED_HINT = ("Session not created: the terminal (tmux) backend was removed — sessions run "
+                     "on the Agent SDK now. Retry without backend \"tmux\" (the SDK is the default).")
 
 _sdk_backend = None   # None = not built yet, False = unavailable, else the SdkBackend
 _sdk_lock = threading.Lock()   # single-flight construction: the eager boot thread races handler
@@ -5717,7 +5729,7 @@ def _fire_api_retry(sid, be, manual=False):
     _note_retry_sent(sid, manual=manual)
 
 
-def _auto_retry_tick(now, tmux):
+def _auto_retry_tick(now, live_map):
     """KERNEL-side driver for the transient-api-error auto-retry (the user 2026-08-11). The ladder, the
     episode gate and every suppression were already the kernel's — but the clock that ASKED lived in each
     open dashboard (apiRetryTick, ui/webview/render.ts), so a session that died on a transient error with
@@ -5728,10 +5740,10 @@ def _auto_retry_tick(now, tmux):
     _fire_api_retry is idempotent against double-asking, and an older kernel still needs the client).
     Dormant sessions are skipped — a dead CLI's api-error is settled history, and reviving a session is
     the nudge machinery's call, not a retry's."""
-    for s in _alive_sessions(now, tmux):
+    for s in _alive_sessions(now, live_map):
         sid = s["sid"]
         try:
-            if tmux.get(sid) is None:
+            if live_map.get(sid) is None:
                 continue                                  # dormant CLI → nothing live to retry into
             if not _api_error(s["path"]):
                 continue                                  # (mtime-cached) not api-blocked → nothing to do
@@ -6198,7 +6210,7 @@ def _reveal_or_confirm(sid, focus_msg, client=None):
     Where a CLIENT is in scope (every WS op that calls this), the reveal is aimed at that dashboard
     alone: a jump into a transcript is one viewer's navigation, and broadcasting it dragged every open
     dashboard to the same turn (the user 2026-07-29). No client → the old broadcast."""
-    if sid and sid not in _tmux_sessions():
+    if sid and sid not in _live_map():
         _reveal_chat_for(client, {"type": "confirmRevive", "id": sid, "name": _name_of(sid) or sid})
     else:
         _reveal_chat_for(client, focus_msg)
@@ -6357,7 +6369,7 @@ def _open_or_revive(sid, live=False):
     confirmRevive modal (no silent reopen, no auto read-only tab — the user 2026-06-17). `live` (the user
     2026-07-08): land the chat on its LIVE TAIL, not the last scroll — a blocked card's picker/permission
     prompt is the live bottom, so its feed chip drops you right on it."""
-    if sid in _tmux_sessions():
+    if sid in _live_map():
         be = _sdk()
         if be:
             be.connect(sid)   # SDK: eager-connect on OPEN (idempotent; no-op for tmux/unknown sids) so the
@@ -6372,12 +6384,17 @@ def _open_or_revive(sid, live=False):
 
 
 def _revive_session(sid):
-    """Bring a DEAD session back, per backend, then un-hide its tab and focus the chat on it. SDK-owned
-    (registry entry exists) → SdkBackend.resume + connect: alive again, resuming its newest transcript
-    (lastSid) with history intact. Otherwise tmux → `romp <name> --resume <sid> --detach` in the session's
-    recorded dir (dir resolution, picker-grace via bin/romp's own picker-check). Runs in a thread off the
-    WS recv loop — the ~seconds-long resume must not block it; the sid is unchanged, so the focus lands on
-    the same tab once the pusher delivers it. (the user 2026-06-16.)
+    """Bring a DEAD session back through the SDK backend, then un-hide its tab and focus the chat on it.
+    SDK-owned (registry entry exists) → SdkBackend.resume + connect: alive again, resuming its newest
+    transcript (lastSid) with history intact. A REG-LESS sid (a pre-SDK session, from the retired
+    terminal backend's era) is ADOPTED instead (the user 2026-08-16): the backend's own resume() mints
+    the registry entry from the recorded name/dir (names/<sid>) with lastSid falling back to the sid —
+    the transcript-on-disk lineage — so it comes back as a normal SDK session, history intact ("dead
+    sessions revive with their history" spans the backend removal). Adoption needs a transcript to
+    resume FROM: with none on disk (_path_of), the CLI would only fail after launch, so the refusal
+    happens up front, on the loud path below. Runs in a thread off the WS recv loop — the ~seconds-long
+    resume must not block it; the sid is unchanged, so the focus lands on the same tab once the pusher
+    delivers it. (the user 2026-06-16.)
 
     FAILURE IS LOUD (the user 2026-07-05): this used to shell `romp-postal-service revive`, a subcommand
     2b5e181 removed (live-only addressing) — the CLI printed 'unknown command' and EXITED 0, output was
@@ -6389,17 +6406,20 @@ def _revive_session(sid):
     ok, detail = False, ""
     _commands_for_cwd(_cwd_of(sid))   # pre-warm the slash-command list — a revival predicts a composer (the user 2026-08-13)
     try:
-        if be and be.owns(sid):
+        if not be:
+            detail = "the SDK backend is unavailable — run bin/romp-sdk-setup, then revive again"
+        elif be.owns(sid):
             ok = bool(be.resume(name, sid) and be.connect(sid))
             detail = "" if ok else "the SDK backend could not resume it (see the kernel log)"
+        elif not _path_of(sid, window=PICKER_WINDOW):   # the picker's reach IS the revive door's reach
+            detail = "no transcript on disk for this session — nothing to resume it from"
         else:
+            # adopt: resume() writes the missing reg itself; the recorded dir rides along when it
+            # still exists (a deleted dir falls to resume()'s own $HOME default, the old behavior)
             cwd = _cwd_of(sid)
-            workdir = cwd if cwd and os.path.isdir(cwd) else os.path.expanduser("~")
-            r = subprocess.run([str(BIN / "romp"), "resume", sid, "--name", name, "--detach"],
-                               cwd=workdir, capture_output=True, text=True, timeout=40)
-            ok = r.returncode == 0
-            if not ok:
-                detail = (r.stderr or r.stdout or "romp exited %d" % r.returncode).strip()[:200]
+            ok = bool(be.resume(name, sid, cwd=(cwd if cwd and os.path.isdir(cwd) else None))
+                      and be.connect(sid))
+            detail = "" if ok else "the SDK backend could not resume it (see the kernel log)"
     except Exception as e:
         ok, detail = False, str(e)[:200]
     if not ok:
@@ -6621,7 +6641,7 @@ class TmuxBackend(sb.SessionBackend):
         # _cycle_mode already declined those — but this returned True anyway, so the caller was told a
         # permission mode had been set when nothing had happened. Say no instead (the user 2026-08-15,
         # on the picker gaining Bypass: the SDK's own control channel takes it, this backend cannot).
-        if _mode_presses((_tmux_sessions().get(str(sid)) or {}).get("mode") or "default", mode) is None:
+        if _mode_presses((_live_map().get(str(sid)) or {}).get("mode") or "default", mode) is None:
             return False
         _cycle_mode(_name_of(sid) or sid, str(sid), mode)                     # shift+tab cycle to the target mode
         return True
@@ -6889,6 +6909,7 @@ class TmuxBackend(sb.SessionBackend):
 
 
 _TMUX = TmuxBackend()
+_NULL_BACKEND = sb.NullBackend()   # backend_for's SDK-deps-absent answer: documented refusals, never None
 
 
 def _unify_model_labels(rows):
@@ -6919,23 +6940,31 @@ def _unify_model_labels(rows):
 
 
 class Sessions:
-    """The kernel's backend-agnostic session API. backend_for(sid) routes a per-sid op to whichever backend
-    drives the sid (the SDK backend if it owns sid, else the tmux backend); live() is the fleet-wide liveness
-    merge across both backends. Everything above the backend speaks THIS — never a backend object directly,
-    never tmux. (the user 2026-06-26: tmux + SDK behind one session API.)"""
+    """The kernel's backend-agnostic session API. backend_for(sid) routes a per-sid op to the SDK
+    backend; live() is the fleet-wide liveness view. Everything above the backend speaks THIS —
+    never a backend object directly. (the user 2026-06-26: one session API; 2026-08-16: the tmux
+    backend retired — the SDK is the one live backend, and a sid no backend owns routes to the
+    NullBackend, whose every op is the documented can't-do-it default, never a crash and never a
+    silent success.)"""
     @staticmethod
     def backend_for(sid):
         be = _sdk()
         sid = str(sid)
-        return be if (be and be.owns(sid)) else _TMUX
+        if be and be.owns(sid):
+            return be          # registry-based: the SDK backend drives every REGISTERED sid, dormant included
+        # Reg-less (a pre-SDK archived session — revive ADOPTS it, see _revive_session) or SDK deps
+        # absent: every op answers with its documented can't-do-it default, never None and never a
+        # backend that would invent state for a sid it has no record of (a dep-less SdkBackend answers
+        # launch_error for EVERY sid, which painted every dead session's chat red on a headless box).
+        return _NULL_BACKEND
 
     @staticmethod
     def live():
-        """Live lane metadata, MERGING tmux sessions with the SDK backend's live sessions so SDK-backed
-        (non-tmux) sessions appear alongside tmux ones everywhere the kernel reads liveness/state. tmux stays
-        authoritative for tmux sessions; the SDK backend reports its own (state/model/effort/mode, event-based).
-        A headless box with no tmux still surfaces SDK sessions. SDK rows have no context%/compaction% → None."""
-        out = _TMUX.live_sessions()
+        """Live lane metadata from the SDK backend — every consumer (chips, feed, timeline, nudge,
+        awaiting) reads this map. Rows keep the merged-map shape from the two-backend era (state/
+        model/effort/mode, event-based; context% from usage). A headless box (no SDK deps) yields {}
+        and _alive_sessions' file-derived fallback covers the surfaces."""
+        out = {}
         be = _sdk()
         if be:
             try:
@@ -7036,13 +7065,13 @@ def _num(x):
 # so one cycle was paying DOZENS of forks+sweeps: profiling attributed the pusher as the kernel's
 # hottest thread, ~50-90% of a core sustained. The scope is the EVENT (one cycle), not a TTL, and it
 # is THREAD-CONFINED: only the thread that opened the scope (the pusher, for exactly one cycle) reads
-# its snapshot; a WS handler or backend thread calling _tmux_sessions() concurrently still gets a
+# its snapshot; a WS handler or backend thread calling _live_map() concurrently still gets a
 # fresh read. Within a cycle the jobs always saw a snapshot aged by whatever ran before them — the
 # scope makes that one honest snapshot instead of dozens of marginally-different ones.
 _live_scope = threading.local()   # .snapshot = the current cycle's liveness map, else absent
 
 
-def _tmux_sessions():
+def _live_map():
     """Live lane metadata across both backends — the fleet-wide liveness merge. Thin delegator kept for its
     ~20 call sites; the impl is Sessions.live() (tmux @claude-* vars + the SDK backend's live_sessions).
     Inside a pusher cycle (this thread's _live_scope), the cycle's one snapshot is served instead."""
@@ -10001,13 +10030,13 @@ def _interrupt(name, _async=True):
 _prev_live_sids = [None]   # last cycle's live-map sids — the set-diff death TRIGGER; corroboration decides
 
 
-def _death_sweep_tick(now, tmux):
+def _death_sweep_tick(now, live_map):
     """Stamp deaths as they happen: a sid that LEFT the live map since the last cycle is a candidate,
     and the liveness OWNER answers before anything is written (per-batch TmuxBackend.alive_sids —
     identity-true; probe failure → loud no-op, never a stamp). SDK-owned sids are skipped here: their
     death event is the kill gesture (reg alive:False partitions ownership — alive:True is
     revivable/crash-looped and must NEVER be stamped, the boot-resume contract rides on that bit)."""
-    cur = set(tmux or {})
+    cur = set(live_map or {})
     prev = _prev_live_sids[0]
     _prev_live_sids[0] = cur
     if prev is None:
@@ -10114,7 +10143,7 @@ def _end_on_idle_save(reqs):
     _atomic_write(jd.STATE / "end-on-idle.json", json.dumps(sorted(reqs)))
 
 
-def _end_on_idle_sweep(now, tmux):
+def _end_on_idle_sweep(now, live_map):
     """Kill each end-on-idle sid once its turn settles — the same clean path as the dashboard × /
     the immediate /end route (intentional death, no reviver, tab closed). A sid already dead by any
     other path just retires its request."""
@@ -10123,7 +10152,7 @@ def _end_on_idle_sweep(now, tmux):
         return
     changed = False
     for sid in sorted(reqs):
-        if tmux.get(sid) is None:                    # already dead → the request is spent
+        if live_map.get(sid) is None:                    # already dead → the request is spent
             reqs.discard(sid); changed = True
             continue
         try:
@@ -10281,7 +10310,7 @@ def _mode_presses(cur, target):
 def _cycle_mode(name, sid, target):
     if not name:
         return
-    cur = (_tmux_sessions().get(sid) or {}).get("mode") or "default"
+    cur = (_live_map().get(sid) or {}).get("mode") or "default"
     presses = _mode_presses(cur, target)
     if not presses:
         return
@@ -10731,7 +10760,7 @@ def _session_awaiting(sid, path, idle, stamp=False):
     # agents are still running, falsely clearing the verdict; the API-error floor then painted a red
     # "API error" + "stalled" card over a session with two agents mid-flight. Tmux sessions carry no
     # subagents field → None → fall through unchanged.
-    live = _tmux_sessions().get(str(sid))    # None = not a live CLI (dormant); {}-like = live snapshot
+    live = _live_map().get(str(sid))    # None = not a live CLI (dormant); {}-like = live snapshot
     tm = live or {}
     subs = tm.get("subagents")
     if subs:
@@ -10801,7 +10830,7 @@ def _bg_live_norm(sid, path):
     never overridden) or, for a live CLI carrying no lifecycle set (tmux; SDK mid-reattach), the
     transcript's launch↔notification pairing ghost-gated by the CLI spawn stamp (source 0.75 — id/summary/
     launch t). [] for a dormant session: its tasks died with its CLI."""
-    live = _tmux_sessions().get(str(sid))
+    live = _live_map().get(str(sid))
     if live is None:
         return []
     if "bgTasks" in live:
@@ -12533,8 +12562,8 @@ def _warm_fleet_bg(now):
 
     def go():
         try:
-            tmux = _tmux_sessions()
-            for s in _alive_sessions(now, tmux):         # live sessions first
+            live_map = _live_map()
+            for s in _alive_sessions(now, live_map):         # live sessions first
                 if _has_parsing_client():                 # a chat/timeline tab just opened → it'll warm the rest
                     break
                 _parse(s["path"], s["sid"], now)          # warm the kernel parse cache
@@ -12562,8 +12591,8 @@ def _boot_warm():
         try:
             now = int(time.time())
             jd.discover(now)                              # warm the shared discover cache (every builder needs it)
-            tmux = _tmux_sessions()
-            for s in _alive_sessions(now, tmux):
+            live_map = _live_map()
+            for s in _alive_sessions(now, live_map):
                 if _has_parsing_client():                 # the browser reconnected → it warms the rest; stand down
                     return
                 try:
@@ -12876,7 +12905,7 @@ def _compacting_now(sid):
     live/optimistic state, disproved by resumed work or a compact_boundary, 180s optimistic cap), read
     from the CACHED parse only so it's cheap enough for the WS handler and the producer tick."""
     sid = str(sid)
-    tm = _tmux_sessions().get(sid)
+    tm = _live_map().get(sid)
     path = _path_of(sid)
     session = (_parse_cached(path) if path else None) or {"turns": []}
     return _compacting(sid, (tm or {}).get("state", ""), session, int(time.time()), (tm or {}).get("since"))
@@ -13878,7 +13907,7 @@ def _stamp_interrupt_causes(events):
     return events
 
 
-def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
+def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None):
     """A {type:"session"} message the render.js bundle consumes: the event tree reshaped to
     ChatEvent[], plus the TOC ledger (archiver headline + turn captions) and a status chip.
 
@@ -13888,14 +13917,14 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     and it returns early with just {type:"session", id, events}. tail_cap_t bounds the final durable-note
     flush (orphan replies / retry notes are sid-keyed and span episodes — without the cap, notes from AFTER
     the /clear would dump into the old episode's tail)."""
-    if tmux is None:
-        tmux = _tmux_sessions()
+    if live_map is None:
+        live_map = _live_map()
     sess = next((s for s in _sessions(now) if s["sid"] == sid), None)
     if not sess:
         be = _sdk()
         if be and be.owns(sid):            # SDK session with no transcript on disk yet → build from live tail/empty
             sess = _sdk_sess(sid, now)
-    if not sess and sid in tmux:
+    if not sess and sid in live_map:
         # A LIVE tmux session discovery can't see yet — brand-new, the TUI hasn't written its first
         # transcript record (a ~7s boot window). Returning None here left the session FRAMELESS: no
         # session frame exists, so nothing can carry its input echo or queued bubble, and the first
@@ -13930,7 +13959,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     # (SDK queues in memory → pending_queued is instant, no gap; its echoes are skipped here via the unqueue
     # discriminator.) Keys on the EVENT MODEL (_session_working / _compacting), never the tmux pane state — and
     # an echo-only merge keeps the turn's real ended state.
-    tm0 = tmux.get(sid)
+    tm0 = live_map.get(sid)
     compacting_now = (False if path_override else
                       _compacting(sid, (tm0 or {}).get("state", ""), parsed, now, (tm0 or {}).get("since")))
     busy = not path_override and (_session_working(parsed["turns"]) or compacting_now)
@@ -14560,7 +14589,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
     # working, else the last activity; None when unknown (render then shows no timer).
     work_start = last_turn["t"] if (open_now and last_turn) else last_t
     since_ms = int(work_start * 1000) if work_start else None
-    tm = tmux.get(sid)
+    tm = live_map.get(sid)
     if tm:
         # WORKING comes from the event model (open turn, no idle atom) — a stable, transcript-derived
         # signal — NOT @claude-state, which lags/flips between hook events (the user saw the chip go
@@ -14659,7 +14688,7 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                   # battery + tab tooltip just apply it (mirrors the usage bar + timeline lanes). bright = full.
                   "ctxColor": (list(cm.ramp(tm["context"] / 100.0, cm.stops_for(_colormap())))
                                if tm["context"] is not None else None)}
-    elif tmux or _has_tmux():                          # tmux usable but this session isn't running → closed
+    elif live_map or _live_source_present():                          # tmux usable but this session isn't running → closed
         status = {"state": "closed", "sinceEpoch": since_ms, "faded": True}
     else:                                              # no tmux at all (rare headless) → event-model fallback
         status = {"state": "working" if open_now else "idle", "sinceEpoch": since_ms,
@@ -14743,10 +14772,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
             "events": events, "status": status, "ledger": ledger,
             # SDK sessions gate the box on the backend's LIVE task set (the CLI's task lifecycle stream —
             # authoritative, terminal-cleared); the spawned_at heuristic remains the tmux/no-snapshot fallback.
-            # Reads the CALLER's snapshot — a fresh _tmux_sessions() here cost a tmux fork + a reg sweep
+            # Reads the CALLER's snapshot — a fresh _live_map() here cost a tmux fork + a reg sweep
             # per session build, on the pusher's hottest path (the 2026-08-10 CPU fix).
             "bgTasks": _bg_tasks(sess["path"], _sdk_spawned_at(sid),
-                                 live=(tmux.get(str(sid)) or {}).get("bgTasks")),
+                                 live=(live_map.get(str(sid)) or {}).get("bgTasks")),
             # per-session view flags (the user 2026-06-26): the tab right-click menu toggles these too, mirroring
             # the timeline lane's feed checkbox + postal mailbox. Same flags + legacy fallback as build_timeline.
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),
@@ -15150,7 +15179,7 @@ def _clear_wrap_notify(item_ids):
         targets = _clear_wrap_targets(item_ids)
         if not targets:
             return
-        live = _tmux_sessions()
+        live = _live_map()
         for sid, gids in targets.items():
             if live.get(str(sid)) is None:
                 continue
@@ -15807,7 +15836,7 @@ def _boundary_clear_notices(alive):
     return out
 
 
-def _state_unknown_names(alive, tmux, working, awaiting):
+def _state_unknown_names(alive, live_map, working, awaiting):
     """Sessions the feed LISTS but whose live state it could not read — no row in the merged live
     map (e.g. the headless file-derived fallback). The client draws these a gray ring, so a blank
     pip goes back to meaning exactly one thing: alive and quiet.
@@ -15823,19 +15852,19 @@ def _state_unknown_names(alive, tmux, working, awaiting):
         nm = s["name"]
         if nm in working or nm in awaiting:
             continue                                  # state read: it is working or awaiting
-        if tmux.get(s["sid"]) is None:
+        if live_map.get(s["sid"]) is None:
             out.append(nm)
     return out
 
 
-def build_feed(now, tmux=None):
+def build_feed(now, live_map=None):
     """The {type:"feed"} message the tuned feed.js bundle consumes (ui-parity.md: feed = ADAPT).
     Goals map onto the AskItem/AskTreeNode shape the render already speaks: the goal tree IS the
     card's tree, rolled-up status → the Working/Blocked/Completed column, dead-concept fields
     (relevance/liveness/suspects/openQuestions/decision-briefs) left empty so the render's
     conditional paths hide them — no edits to the tuned card code. Stream = turn captions."""
-    if tmux is None:
-        tmux = _tmux_sessions()
+    if live_map is None:
+        live_map = _live_map()
     cleared = _cleared_ids()
     # Debug mode (the user 2026-07-09): join judge-failure rows onto each card so a rejection is
     # inspectable from the card modal (judge, kind, evidence, and in-debug capture: input + reply).
@@ -15843,7 +15872,7 @@ def build_feed(now, tmux=None):
     dbg_rows = _judge_error_rows(now) if jd._debug_mode() else None
     asks, working, awaiting = [], [], []
     bg_services = {}          # session name -> live SERVICE descs (judge-classified, _bg_split) → the neutral chip
-    alive = _alive_sessions(now, tmux)               # hard filter: living sessions only
+    alive = _alive_sessions(now, live_map)               # hard filter: living sessions only
     wmap = _wait_for_graph(now, {s["sid"] for s in alive})   # per-session 'waiting on a live peer' (the user 2026-06-22)
     _stalls = _stalled_goals()                       # goals romp's nudge gate is holding → the card's Stalled section
     _jauth_map = jd._auth_down_map()                 # judge-auth-down latch → the per-session card floor below
@@ -15854,7 +15883,7 @@ def build_feed(now, tmux=None):
         if _session_flag(fsid, "hideFromFeed"):      # muted from the feed (the user 2026-06-19) → timeline-only
             continue
         color = _name_color(fsid)
-        tm = tmux.get(fsid); live = tm is not None
+        tm = live_map.get(fsid); live = tm is not None
         # CACHE-ONLY parse (the user 2026-06-26): the CARDS come from the goal store (cheap) and must paint at
         # once on a cold start, so the working-dot + the deep-link anchors read the parse ONLY if it's already
         # cached — never paying the ~1s cold parse here. _warm_fleet_bg fills the cache + re-pushes; the dots
@@ -16653,7 +16682,7 @@ def build_feed(now, tmux=None):
             "working": working, "awaiting": awaiting,   # awaiting = idle-but-waiting-on-bg-work names → await-green dot (the user 2026-07-13)
             # listed-but-unreadable names → an explicit gray ring, so a BLANK pip means "alive and
             # quiet" and nothing else (see _state_unknown_names)
-            "stateUnknown": _state_unknown_names(alive, tmux, working, awaiting),
+            "stateUnknown": _state_unknown_names(alive, live_map, working, awaiting),
             # session name -> live judge-classified SERVICE descs (a dev server the session keeps around;
             # _bg_split) → the grouped-mode session header's neutral chip, never a waiting state (2026-07-24)
             "bgServices": bg_services,
@@ -16666,7 +16695,7 @@ def build_feed(now, tmux=None):
             # a session with no cards on the board, which filters to an empty board rather than being
             # unlistable. Federation prefixes sid+name per host and concatenates.
             "sessions": [{"sid": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}
-                         for s in _chat_tab_sessions(now, tmux)],
+                         for s in _chat_tab_sessions(now, live_map)],
             # /clear boundary settles, newest per session → the bell logs each once (the user 2026-07-27)
             "clearNotices": _boundary_clear_notices(alive),
             # SDK-backend failures → the same bell, one entry per occurrence (the user 2026-07-28)
@@ -18073,7 +18102,7 @@ def _nudge_times():
     return idx
 
 
-def build_timeline(now, tmux=None, with_bars=True, live_only=False):
+def build_timeline(now, live_map=None, with_bars=True, live_only=False):
     """A {type:"timeline"} message the ported timeline bundle consumes (ui-parity.md: timeline =
     ADAPT). Lanes per session; work bars are SEGMENTS [t,end] from the event model (not the deleted
     `romp-events --emit`); prompt dots at segment starts; tooltips from the captioner; awaiting/
@@ -18087,12 +18116,12 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
     skeleton FIRST so the lanes paint instantly, then ships the bars as a separate {type:"bars"} message
     (the user 2026-06-25, who wanted everything else loaded and the bars loaded after). build_timeline is ~95%
     bars+judging by payload and the dominant startup cost, so the skeleton is cheap and lands immediately."""
-    if tmux is None:
-        tmux = _tmux_sessions()
-    alive = _timeline_sessions(now, tmux, live_only=live_only)   # living + window-dead (≤12h) lanes; per-session `live` below marks the dead ones (struck). live_only → live sessions only (cold-start first paint)
+    if live_map is None:
+        live_map = _live_map()
+    alive = _timeline_sessions(now, live_map, live_only=live_only)   # living + window-dead (≤12h) lanes; per-session `live` below marks the dead ones (struck). live_only → live sessions only (cold-start first paint)
     if _dismissed_lanes:   # drop lanes the user cleared — but ONLY while still dead; a revived sid reappears and sheds its record (durable set, survives restarts)
-        _undismiss_lanes(s["sid"] for s in alive if tmux.get(s["sid"]) is not None)
-        alive = [s for s in alive if not (s["sid"] in _dismissed_lanes and tmux.get(s["sid"]) is None)]
+        _undismiss_lanes(s["sid"] for s in alive if live_map.get(s["sid"]) is not None)
+        alive = [s for s in alive if not (s["sid"] in _dismissed_lanes and live_map.get(s["sid"]) is None)]
     id2name = {s["sid"]: s["name"] for s in alive}
     sessions, turns, semantic = [], {}, []   # `semantic`: artifact-derived marks (for gloss text); the band's marks are RUN spans, below
     ctx_stops = cm.stops_for(_colormap())    # the GLOBAL colormap (the user 2026-06-26): color the per-lane context bar server-side
@@ -18113,7 +18142,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
                 branch_of[_k["sid"]] = {"fromId": _psid, "t": _k["t"], "cut": _k.get("cut") or ""}
     for s in alive:
         sid, name = s["sid"], s["name"]
-        tm = tmux.get(sid)
+        tm = live_map.get(sid)
         live = tm is not None
         hexcol = (tm and tm["color"]) or (_name_color(sid) or {}).get("bg", "#888888")
         goals = jd.load_goals(sid)
@@ -19442,7 +19471,7 @@ def _note_chat_divergence(sid, name, chat_state, row_state, now):
         pass
 
 
-def _push(targets, connect=False, tmux=None):
+def _push(targets, connect=False, live_map=None):
     """Build the payloads once (cached parses) and send each target only the pieces that CHANGED for it.
     Drives both the periodic pusher (all clients) and a fresh connect (one client): a new/reconnecting
     client (empty dedup) gets the full state; steady-state sends only diffs. Builds only the apps the
@@ -19453,8 +19482,8 @@ def _push(targets, connect=False, tmux=None):
     if not targets:
         return
     now = int(time.time())
-    tmux = _tmux_sessions() if tmux is None else tmux   # one liveness read per push, shared by all builders
-    _seen_live.update(tmux)                       # remember who's been alive → keep their tab when they die
+    live_map = _live_map() if live_map is None else live_map   # one liveness read per push, shared by all builders
+    _seen_live.update(live_map)                       # remember who's been alive → keep their tab when they die
     want_chat = any(c["app"] == "chat" for c in targets)
     # The FLEET connects as its OWN app (the user 2026-06-29) so we build its per-session ledgers EVEN when no
     # chat client is open — previously the fleet rode app=feed and got ledgers only as a side effect of a chat
@@ -19464,7 +19493,7 @@ def _push(targets, connect=False, tmux=None):
     want_tl = any(c["app"] == "timeline" for c in targets)
     chat_clients = [c for c in targets if c["app"] == "chat"]
     try:
-        chat_list = _chat_tab_sessions(now, tmux)   # living + recently-died-while-shown, minus ×-hidden
+        chat_list = _chat_tab_sessions(now, live_map)   # living + recently-died-while-shown, minus ×-hidden
         tab_order = [s["sid"] for s in chat_list]
         # order audit: a PERMUTED push (survivors swapped slots vs the previous push) is the reorder bug
         # leaving the kernel — log it with the stack. Set churn (a tab appearing/dying) is routine → skipped.
@@ -19507,7 +19536,7 @@ def _push(targets, connect=False, tmux=None):
                     _perf("chatbuild", sid=str(s["sid"])[:8], cached=1, ms=0, active=int(is_active))
                 else:
                     _t0 = time.monotonic()
-                    m = build_session(s["sid"], now, tmux)
+                    m = build_session(s["sid"], now, live_map)
                     # The full serialization is LAZY (the 2026-08-10 CPU fix, round two): steady state
                     # sends only chatTail suffixes, so an eager json.dumps of the WHOLE payload — multi-MB
                     # for a busy active tab, re-dumped every cycle just to be discarded — was the largest
@@ -19525,7 +19554,7 @@ def _push(targets, connect=False, tmux=None):
                     continue
                 _note_chat_divergence(s["sid"], m.get("name") or "",
                                       ((m.get("status") or {}).get("state") or ""),
-                                      ((tmux.get(s["sid"]) or {}).get("state") or ""), now)
+                                      ((live_map.get(s["sid"]) or {}).get("state") or ""), now)
                 chat_sessions.append(m)
                 # delta-send: diff this build's events against the previous one ONCE, then each client gets
                 # only the changed suffix (chatTail) if it's caught up, else the full session. Keeps the whole
@@ -19573,8 +19602,8 @@ def _push(targets, connect=False, tmux=None):
                 if fr:
                     for c in chat_clients:
                         _send_client(c, ("comments", s["sid"]), fr)
-        fsig = _fleet_view_sig(now, tmux) if (want_feed or want_tl) else None
-        feed_src = _cached_feed(now, tmux, fsig, connect) if want_feed else None
+        fsig = _fleet_view_sig(now, live_map) if (want_feed or want_tl) else None
+        feed_src = _cached_feed(now, live_map, fsig, connect) if want_feed else None
         feed = feed_src
         if feed is not None:
             feed = dict(feed_src)                        # copy so the per-push ledger attach never dirties the cache
@@ -19608,16 +19637,16 @@ def _push(targets, connect=False, tmux=None):
         if want_tl:
             tl_clients = [c for c in targets if c["app"] == "timeline"]
             live_first = connect and _built_timeline[1] is None     # cold start, nothing warmed yet → live only
-            skel = build_timeline(now, tmux, with_bars=False, live_only=live_first)
+            skel = build_timeline(now, live_map, with_bars=False, live_only=live_first)
             for c in tl_clients:
                 _send_client(c, ("timeline",), {"type": "data", "data": skel})
             if live_first:
-                timeline = build_timeline(now, tmux, with_bars=True, live_only=True)   # live bars now (no dead reads)
+                timeline = build_timeline(now, live_map, with_bars=True, live_only=True)   # live bars now (no dead reads)
                 tl_warming = True                                   # this is the PARTIAL cold build — the client keeps its loader up
                 _producer_wake.set()                                # ...if it lands empty (SDK/federation not yet merged), rather than flashing
                 #                                                     "no activity"; a later warmed push (tl_warming False) settles it (the user 2026-07-03)
             else:
-                timeline = _cached_timeline(now, tmux, fsig, connect)
+                timeline = _cached_timeline(now, live_map, fsig, connect)
     except Exception:
         sys.stderr.write("push build: %s\n" % traceback.format_exc())
         return
@@ -19660,10 +19689,10 @@ def _push(targets, connect=False, tmux=None):
         _clients[:] = [c for c in _clients if c.get("alive", True)]
 
 
-def _push_all(tmux=None):
+def _push_all(live_map=None):
     with _clients_lock:
         clients = list(_clients)
-    _push(clients, tmux=tmux)
+    _push(clients, live_map=live_map)
 
 
 def _push_session_now(sid):
@@ -19688,13 +19717,13 @@ def _push_session_now(sid):
         return
     try:
         now = int(time.time())
-        tmux = _tmux_sessions()
-        chat_list = _chat_tab_sessions(now, tmux)
+        live_map = _live_map()
+        chat_list = _chat_tab_sessions(now, live_map)
         if not any(s["sid"] == sid for s in chat_list):
             return                                   # hidden / raced a teardown — the periodic pusher owns the rest
         tab_order = [s["sid"] for s in chat_list]
         tab_meta = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])} for s in chat_list]
-        m = build_session(sid, now, tmux)
+        m = build_session(sid, now, live_map)
         if not m:
             return
         ms = None                                    # lazy: the first full send materializes it, the rest reuse
@@ -19811,7 +19840,7 @@ def _next_feed_build_id():
         return _feed_build_id[0]
 
 
-def _fleet_view_sig(now, tmux):
+def _fleet_view_sig(now, live_map):
     """Cheap fingerprint of everything build_feed/build_timeline read. Busts on any transcript/names/states/
     postal change (_producer_sig), a judge pass (goal/caption via _judge_gen), a live tmux BADGE change
     (state/model/ctx/effort — touches no file), a colormap or session-flags change, a SESSION-ORDER change
@@ -19830,13 +19859,13 @@ def _fleet_view_sig(now, tmux):
             sig[k] = os.stat(p).st_mtime
         except OSError:
             pass
-    for s in sorted(tmux):
-        t = tmux[s]
+    for s in sorted(live_map):
+        t = live_map[s]
         sig["t:" + s] = (t.get("state"), t.get("model"), t.get("ctx"), t.get("effort"), t.get("mode"), t.get("fast"), t.get("since"))
     return tuple(sorted(sig.items()))
 
 
-def _cached_feed(now, tmux, sig, connect=False):
+def _cached_feed(now, live_map, sig, connect=False):
     # connect (a fresh client) NEVER triggers a rebuild — it serves whatever the pusher has warmed, so startup
     # is instant; the pusher refreshes it within a tick. Else: reuse on an unchanged sig OR a recent rebuild —
     # UNLESS an optimistic kernel-side mutation postdates the build (_views_dirty): that state is invisible
@@ -19855,7 +19884,7 @@ def _cached_feed(now, tmux, sig, connect=False):
         return e[1]
     bid = _next_feed_build_id()          # claimed BEFORE the read, so an ack issued during this build outranks it
     started = time.time()                # …and the dirty floor for the NEXT check: mutations after this
-    feed = build_feed(now, tmux)         # instant may be invisible to the build below → must rebuild
+    feed = build_feed(now, live_map)         # instant may be invisible to the build below → must rebuild
     feed["buildId"] = bid
     _built_feed[:] = [sig, feed, time.time(), started]
     _badge = _needs_you_count(feed)
@@ -20226,7 +20255,7 @@ def _reveal_msg(sid):
         # (plans/federated-push.md) — so hand the focus over as-is, never a confirmRevive minted
         # from the wrong kernel's session list.
         return {"type": "focus", "id": sid, "live": True}
-    if sid and sid not in _tmux_sessions():
+    if sid and sid not in _live_map():
         return {"type": "confirmRevive", "id": sid, "name": _name_of(sid) or sid}
     return {"type": "focus", "id": sid, "live": True}
 
@@ -20266,13 +20295,13 @@ def _consume_pending_reveal(client):
         pass
 
 
-def _cached_timeline(now, tmux, sig, connect=False):
+def _cached_timeline(now, live_map, sig, connect=False):
     e = _built_timeline
     dirty = not connect and _views_dirty[0] > e[3]        # start-keyed, same as _cached_feed above
     if e[1] is not None and not dirty and (connect or e[0] == sig or (time.time() - e[2]) < REBUILD_MIN_S):
         return e[1]
     started = time.time()
-    tl = build_timeline(now, tmux)
+    tl = build_timeline(now, live_map)
     _built_timeline[:] = [sig, tl, time.time(), started]
     return tl
 
@@ -20308,7 +20337,7 @@ def _producer():
             # segment, an uncaptioned unit, a fresh completion) — so an idle pass costs filesystem stats, not
             # model calls. (_producer_sig stays available but no longer gates triage.)
             tiers = []
-            if _tmux_sessions() and not _retry_paused_on():
+            if _live_map() and not _retry_paused_on():
                 tiers.append(threading.Thread(target=_run_tier, args=(jd.run_index,), name="index"))
                 tiers.append(threading.Thread(target=_run_tier, args=(jd.run_triage,), name="triage"))
             try:                                       # /clear boundaries FIRST (before the snapshot + tiers), so
@@ -20354,7 +20383,7 @@ def _pusher_cycle():
     """ONE pusher cycle: the client push + every tick job, all sharing ONE liveness snapshot. Split out
     of the loop so a test can run a single cycle and count the snapshot reads.
 
-    The snapshot hoist is the 2026-08-10 CPU fix: each _tmux_sessions() forks `tmux list-sessions`
+    The snapshot hoist is the 2026-08-10 CPU fix: each _live_map() forks `tmux list-sessions`
     (~15ms) and re-reads every SDK reg file (~7ms across a couple hundred), and this cycle used to
     take NINE of them — one in _push plus one per tick job — at the 0.5s cadence: ~200-350ms of CPU
     per cycle before any build work, sampled live as the kernel's single hottest thread (~50-90% of a
@@ -20365,30 +20394,30 @@ def _pusher_cycle():
     with _clients_lock:
         any_client = bool(_clients)
     now = int(time.time())
-    tmux = _tmux_sessions()               # THE cycle's liveness snapshot — one fork + one reg sweep
-    _live_scope.snapshot = tmux           # …served to every read on THIS thread until the cycle ends,
+    live_map = _live_map()               # THE cycle's liveness snapshot — one fork + one reg sweep
+    _live_scope.snapshot = live_map           # …served to every read on THIS thread until the cycle ends,
     #                                       however deep it hides (_bg_live_norm, _compacting_now,
     #                                       build_feed's per-session gates) — see _live_scope
     try:
-        _pusher_cycle_jobs(now, tmux, any_client)
+        _pusher_cycle_jobs(now, live_map, any_client)
     finally:
         _live_scope.snapshot = None
 
 
-def _pusher_cycle_jobs(now, tmux, any_client):
+def _pusher_cycle_jobs(now, live_map, any_client):
     if any_client:
-        _push_all(tmux=tmux)
+        _push_all(live_map=live_map)
     # (the WS keepalive lives on its own _heartbeat thread — NOT here — so a slow push can't starve it)
     try:                                  # EXACT retraction first: dispatches returned → the stamp is spent,
-        _lift_spent_awaiting(now, tmux)   # so the nudge tick below never wakes a wait that already ended
+        _lift_spent_awaiting(now, live_map)   # so the nudge tick below never wakes a wait that already ended
     except Exception:
         sys.stderr.write("awaiting-lift: %s\n" % traceback.format_exc())
     try:                                  # death is a recorded EVENT: a sid that left the live map is
-        _death_sweep_tick(now, tmux)      # corroborated with the liveness owner, then stamped (2026-08-13)
+        _death_sweep_tick(now, live_map)      # corroborated with the liveness owner, then stamped (2026-08-13)
     except Exception:
         sys.stderr.write("death-sweep: %s\n" % traceback.format_exc())
     try:                                  # a session that asked to close itself dies at its turn's settle
-        _end_on_idle_sweep(now, tmux)     # (the clean × path — the user 2026-08-15's "close yourself")
+        _end_on_idle_sweep(now, live_map)     # (the clean × path — the user 2026-08-15's "close yourself")
     except Exception:
         sys.stderr.write("end-on-idle: %s\n" % traceback.format_exc())
     try:                                  # deferral records retire on their reasons' own events — BEFORE
@@ -20396,11 +20425,11 @@ def _pusher_cycle_jobs(now, tmux, any_client):
     except Exception:                     # surfaces read these records regardless)
         sys.stderr.write("deferral-sweep: %s\n" % traceback.format_exc())
     try:                                  # Auto Nudge runs server-side even with no browser open (cheap when
-        _auto_nudge_tick(now, tmux)       # off); the awaiting WAKE rides its goal walk (see _wake_goal)
+        _auto_nudge_tick(now, live_map)       # off); the awaiting WAKE rides its goal walk (see _wake_goal)
     except Exception:
         sys.stderr.write("auto-nudge: %s\n" % traceback.format_exc())
     try:                                  # Interrupt → Blocked runs EVERY push, independent of the nudge toggle
-        _interrupt_block_tick(now, tmux)
+        _interrupt_block_tick(now, live_map)
     except Exception:
         sys.stderr.write("interrupt-block: %s\n" % traceback.format_exc())
     try:                                  # hitting a usage limit auto-engages the retry-pause (before the resume check)
@@ -20408,23 +20437,23 @@ def _pusher_cycle_jobs(now, tmux, any_client):
     except Exception:
         sys.stderr.write("auto-pause-on-limit: %s\n" % traceback.format_exc())
     try:                                  # a monthly spend cap (no readable reset) also engages it — else it storms forever
-        _auto_pause_on_spend_limit(now, tmux)
+        _auto_pause_on_spend_limit(now, live_map)
     except Exception:
         sys.stderr.write("auto-pause-on-spend-limit: %s\n" % traceback.format_exc())
     try:                                  # a paused retry auto-clears once any session serves a request again
-        _auto_resume_retry(now, tmux)
+        _auto_resume_retry(now, live_map)
     except Exception:
         sys.stderr.write("auto-resume-retry: %s\n" % traceback.format_exc())
     try:                                  # a per-session interrupt-suppressed retry re-arms once that thread lands a clean turn
-        _auto_resume_session_retry(now, tmux)
+        _auto_resume_session_retry(now, live_map)
     except Exception:
         sys.stderr.write("auto-resume-session-retry: %s\n" % traceback.format_exc())
     try:                                  # the kernel drives the transient-api-error retry itself (unattended;
-        _auto_retry_tick(now, tmux)       # the dashboard tick is just the countdown + a redundant asker)
+        _auto_retry_tick(now, live_map)       # the dashboard tick is just the countdown + a redundant asker)
     except Exception:
         sys.stderr.write("auto-retry-tick: %s\n" % traceback.format_exc())
     try:                                  # expire stale set_working notes once a session goes idle + done (cheap when no notes)
-        _clear_done_working_notes(now, tmux)
+        _clear_done_working_notes(now, live_map)
     except Exception:
         sys.stderr.write("clear-working-notes: %s\n" % traceback.format_exc())
 
@@ -24319,13 +24348,13 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, json.dumps({"ok": True}), "application/json")
             if u.path == "/new":
                 # Headless session creation (`romp new`, 2026-07-25): the WS createSession op as a
-                # one-shot POST, so a terminal can start a session — SDK by default, the recommended
-                # backend — without a browser. Body: {"name": ..., "dir": ..., "backend": "sdk"|"tmux"},
-                # plus optional "model"/"effort" (full ids/levels, applied park-aware and echoed back;
-                # also applied on the existing:true open, so a re-brief re-asserts them — see
-                # _apply_new_session_prefs).
+                # one-shot POST, so a terminal can start a session without a browser. Body: {"name":
+                # ..., "dir": ..., "backend": "sdk"}, plus optional "model"/"effort" (full ids/levels,
+                # applied park-aware and echoed back; also applied on the existing:true open, so a
+                # re-brief re-asserts them — see _apply_new_session_prefs). A missing/empty backend
+                # means the SDK — the one backend; "tmux" gets the named refusal below.
                 # Same validation and the same no-silent-fallback rule as the WS op: when the SDK
-                # backend is unavailable, say so (ok:false + reason), never hand back a mystery tmux
+                # backend is unavailable, say so (ok:false + reason), never hand back a mystery
                 # session. An already-live name is a success (idempotent open), not an error.
                 try:
                     b = json.loads(raw_body or b"{}")
@@ -24341,22 +24370,24 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps({"ok": False, "error": derr,
                                                        "dirStatus": _dir_status(b.get("dir"))}),
                                       "application/json")
-                live = _live_names(_tmux_sessions())
+                live = _live_names(_live_map())
                 if nm in live:
                     extra = _apply_new_session_prefs(live[nm], b)
                     return self._send(200, json.dumps({"ok": True, "id": live[nm], "existing": True, **extra}),
                                       "application/json")
-                if (b.get("backend") or "sdk") == "sdk":
-                    if not _sdk_ready():          # see _sdk_ready — a built backend is not a working one
-                        return self._send(200, json.dumps({"ok": False, "error": SDK_SETUP_HINT}),
-                                          "application/json")
-                    a = (b or {}).get("auth")
-                    sid = _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""))
-                    extra = _apply_new_session_prefs(sid, b)
-                    return self._send(200, json.dumps({"ok": True, "id": sid, "dir": cwd, **extra}),
+                # backend:"tmux" → the named refusal, in the same ok:false shape as every other
+                # refusal on this route (bad dir, missing SDK). The one thing that must never happen
+                # here is a session the caller didn't ask for or a request that silently vanishes.
+                if b.get("backend") == "tmux":
+                    return self._send(200, json.dumps({"ok": False, "error": TMUX_REMOVED_HINT}),
                                       "application/json")
-                threading.Thread(target=_spawn_session, args=(nm, cwd), daemon=True).start()
-                return self._send(200, json.dumps({"ok": True, "pending": True, "dir": cwd}),
+                if not _sdk_ready():          # see _sdk_ready — a built backend is not a working one
+                    return self._send(200, json.dumps({"ok": False, "error": SDK_SETUP_HINT}),
+                                      "application/json")
+                a = (b or {}).get("auth")
+                sid = _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""))
+                extra = _apply_new_session_prefs(sid, b)
+                return self._send(200, json.dumps({"ok": True, "id": sid, "dir": cwd, **extra}),
                                   "application/json")
             if u.path == "/working":
                 # Publish/clear a session's working-note in the backend-agnostic store, so the postal bus's
@@ -24763,7 +24794,7 @@ class Handler(BaseHTTPRequestHandler):
             # back to ordering tabs by session STATE — so they drift on their own (worse now that the
             # heartbeat auto-reloads). _ordered_alive is the same order chat tabs + timeline lanes use.
             try:
-                _alive = _ordered_alive(int(time.time()), _tmux_sessions())
+                _alive = _ordered_alive(int(time.time()), _live_map())
                 _o = [s["sid"] for s in _alive]
                 # name+color per tab → the client paints the whole strip as placeholders up front (tabs-first)
                 _tabs = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])} for s in _alive]
@@ -24803,7 +24834,7 @@ class Handler(BaseHTTPRequestHandler):
                 _mark_views_dirty()
         elif msg and msg.get("type") == "setAutoNudge" and msg.get("enabled") is not None:
             _set_auto_nudge(bool(msg["enabled"]))   # feed gear → server-side Auto Nudge on/off
-            _auto_nudge_tick(int(time.time()), _tmux_sessions())   # act immediately on turn-on (don't wait 4s)
+            _auto_nudge_tick(int(time.time()), _live_map())   # act immediately on turn-on (don't wait 4s)
         elif msg and msg.get("type") == "setUpdateMode" and msg.get("mode") in _UPDATE_MODES:
             _set_update_mode(str(msg["mode"]))      # feed gear → how romp handles new releases at boot
         elif msg and msg.get("type") == "askClear" and msg.get("itemId"):
@@ -24956,7 +24987,7 @@ class Handler(BaseHTTPRequestHandler):
                 # the session dir is fixed at creation — validate now. mkdir: the user already saw the
                 # "that folder doesn't exist" dialog and chose to make it (see createDirMissing below).
                 cwd, derr = _resolve_create_dir(msg.get("dir"), create=bool(msg.get("mkdir")))
-                live = _live_names(_tmux_sessions())
+                live = _live_names(_live_map())
                 if derr:
                     st = _dir_status(msg.get("dir"))
                     if st["canCreate"] and not msg.get("mkdir"):
@@ -24972,7 +25003,14 @@ class Handler(BaseHTTPRequestHandler):
                 elif nm in live:                 # already running → its tab is already up; just focus it
                     _reveal_chat_for(client, {"type": "focus", "id": live[nm]})
                     _mark_views_dirty()          # pusher ships the tab; never a synchronous fleet build here
-                elif msg.get("backend") == "sdk":   # non-tmux: drive via the Agent SDK
+                elif msg.get("backend") == "tmux":
+                    # The field is accepted forever (old clients / stale stored settings still send it)
+                    # but the terminal backend is retired (the user 2026-08-16) — refuse by NAME, in
+                    # the same warn shape as this op's other refusals: never a silent drop, never a
+                    # session on a backend the user didn't ask for (the 2026-07-28 mystery-spawn class).
+                    client["send"](json.dumps({"type": "warn", "text": TMUX_REMOVED_HINT}))
+                else:
+                    # missing/empty backend = the default: the SDK, the one backend.
                     # _sdk_ready(), not _sdk(): the backend object exists even with the dependency
                     # missing, so the old check took it as a yes and created a session that could never
                     # run — silently, which is the whole failure (the user 2026-07-28).
@@ -24982,11 +25020,9 @@ class Handler(BaseHTTPRequestHandler):
                         a = msg.get("auth")
                         _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""))
                     else:
-                        # NEVER silently fall back to tmux (the user asked for SDK and got a mystery tmux
-                        # session on a remote host without the venv, 2026-07-02). Say what's missing.
+                        # NEVER silently create something else instead (the user asked for SDK and got a
+                        # mystery terminal session on a host without the venv, 2026-07-02). Name the fix.
                         client["send"](json.dumps({"type": "warn", "text": SDK_SETUP_HINT}))
-                else:
-                    threading.Thread(target=_spawn_session, args=(nm, cwd), daemon=True).start()
         elif msg and msg.get("type") == "cancelCreate" and msg.get("name"):
             # The webview's "Opening…" cue was cancelled (the ✕/Esc/backdrop — the spawn hung/failed, or the
             # user changed their mind). We only know the NAME (no id yet). Tear down a matching LOCAL session
@@ -24995,7 +25031,7 @@ class Handler(BaseHTTPRequestHandler):
             # is dismissed client-side only — nothing local to reap.
             host, bare = _split_host_id(str(msg["name"]).strip())
             if not host and bare:
-                sid = _live_names(_tmux_sessions()).get(bare)   # tmux + SDK live names (Sessions.live merge)
+                sid = _live_names(_live_map()).get(bare)   # tmux + SDK live names (Sessions.live merge)
                 if sid:
                     _end_pending_sid(sid)
                 else:
@@ -25004,7 +25040,7 @@ class Handler(BaseHTTPRequestHandler):
             # ONE request, the whole 30 days. It was briefly a lazy two-step, but measuring said the wide
             # walk is ~78ms cold once forks are off, so paging it in bought nothing (the user 2026-07-24).
             client["send"](json.dumps({"type": "sessionList",
-                                       "items": _session_list(int(time.time()), _tmux_sessions()),
+                                       "items": _session_list(int(time.time()), _live_map()),
                                        "defaultDir": _tilde(_default_create_dir()),   # prefill the new-session dir field
                                        # …and whether Browse… can do anything here, so a kernel with no
                                        # desktop shows the button as unavailable rather than inert.
@@ -25017,7 +25053,7 @@ class Handler(BaseHTTPRequestHandler):
                                        # option is a machine by name (the user 2026-08-12)
                                        "selfHost": _self_host()}))
         elif msg and msg.get("type") in ("pickResult", "openByName") and (msg.get("id") or msg.get("name")):
-            sid = msg.get("id") or _live_names(_tmux_sessions()).get(str(msg.get("name")))
+            sid = msg.get("id") or _live_names(_live_map()).get(str(msg.get("name")))
             if sid:
                 _reveal_chat_for(client, {"type": "focus", "id": sid})
         elif msg and msg.get("type") == "closeSession" and msg.get("id"):

--- a/kernel/session_backend.py
+++ b/kernel/session_backend.py
@@ -188,6 +188,13 @@ class SessionBackend(ABC):
         tmux pressed Enter in the pane; the SDK enqueues a drain. True if a wake was issued."""
         return False
 
+    def pending_cut(self, sid: str) -> str:
+        """The uuid of an ARMED, unconsumed bare-rollback cut for `sid`, or "" when none. The auto-nudge
+        tick reads it bare on whatever backend it holds: while a cut is armed the transcript still shows
+        the deleted turn, and a nudge fired in that window quotes rolled-back content back into the
+        thread (the 2026-07-20 resurrection). Default: no such signal."""
+        return ""
+
     def deliver(self, sid: str, text: str) -> bool:
         """Live-deliver a postal banner to `sid` as the deliver-time WAKE — put it into the session's input so
         an idle recipient surfaces the mail NOW instead of on its next turn. tmux pastes it into the pane
@@ -218,3 +225,29 @@ class SessionBackend(ABC):
     @abstractmethod
     def current_ask(self, sid: str):
         """The session's live AskUserQuestion state for the webview, or None."""
+
+
+class NullBackend(SessionBackend):
+    """The backend of last resort: what backend_for returns when the SDK backend could not be built
+    (its deps absent) or a sid belongs to no backend (a dead, reg-less session — e.g. one archived
+    before the SDK era). Every method IS the documented can't-do-it default above — False / {} / [] /
+    None / the loud MCP refusal — so call sites never crash on a be.* call and never silently
+    pretend an op landed. It exists so backend_for can hold its contract ("never returns None")
+    without a live fallback backend behind it."""
+    def owns(self, sid): return False
+    def live_sessions(self): return {}
+    def send(self, sid, text): return False
+    def interrupt(self, sid): return False
+    def set_model(self, sid, value): return False
+    def set_mode(self, sid, mode): return False
+    def set_effort(self, sid, value): return False
+    def set_fast(self, sid, value): return False
+    def spawn(self, name, cwd, bg="", fg="", sid=None, auth=""): return None
+    def resume(self, name, sid, cwd=None): return False
+    def kill(self, sid): return False
+    def rename(self, sid, new_name): return False
+    def pending_queued(self, sid): return []
+    def live_atoms(self, sid): return []
+    def prune_live(self, sid, tx_uuids, tx_user_texts=()): return None
+    def on_ask(self, sid, kind, payload=None): return False
+    def current_ask(self, sid): return None

--- a/tests/test_chat_payload_clock_invariant.py
+++ b/tests/test_chat_payload_clock_invariant.py
@@ -73,7 +73,7 @@ class ChatPayloadIsClockInvariant(unittest.TestCase):
         (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
 
         self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-                      km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD)
+                      km.NAMES, km._live_map, km._GLOBAL_CLAUDE_MD)
         jd.NAMES, jd.PROJECTS = names, proj
         jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
         jd.STATE = td
@@ -82,13 +82,13 @@ class ChatPayloadIsClockInvariant(unittest.TestCase):
         km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
         # Alive + idle, and FIXED: a `since` derived from the real clock would itself vary between the
         # two builds and mask the very thing under test.
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None,
                                            "color": None}}
 
     def tearDown(self):
         (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-         km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD) = self.saved
+         km.NAMES, km._live_map, km._GLOBAL_CLAUDE_MD) = self.saved
         self.td.cleanup()
 
     def _write_turns(self):

--- a/tests/test_clear_wrap.py
+++ b/tests/test_clear_wrap.py
@@ -165,7 +165,7 @@ class ClearWrapNotify(unittest.TestCase):
         self.td = tempfile.TemporaryDirectory()
         self.saved_state = jd.STATE
         jd.STATE = Path(self.td.name)
-        self._orig = {n: getattr(km, n) for n in ("_tmux_sessions", "_sessions", "_mark_nodes_cleared")}
+        self._orig = {n: getattr(km, n) for n in ("_live_map", "_sessions", "_mark_nodes_cleared")}
         self._orig_load = jd.load_goals
         self._orig_backend = km.Sessions.backend_for
         km._sessions = lambda now: []
@@ -179,7 +179,7 @@ class ClearWrapNotify(unittest.TestCase):
             def send(self, sid, body):
                 test.sent.append((sid, body))
         km.Sessions.backend_for = staticmethod(lambda sid: FakeBackend())
-        km._tmux_sessions = lambda: {SID: {"state": "waiting"}}
+        km._live_map = lambda: {SID: {"state": "waiting"}}
 
     def tearDown(self):
         for n, v in self._orig.items():
@@ -213,7 +213,7 @@ class ClearWrapNotify(unittest.TestCase):
         self.assertEqual(self.sent, [], "one round only — the confirm card's clear is final")
 
     def test_a_dead_session_gets_nothing(self):
-        km._tmux_sessions = lambda: {}
+        km._live_map = lambda: {}
         km._clear_all([G_OPEN])
         self.assertEqual(self.sent, [], "no live CLI → no agent holding WIP to ask")
 

--- a/tests/test_feed_status_lists.py
+++ b/tests/test_feed_status_lists.py
@@ -41,19 +41,19 @@ class StateUnknownIsTheUnREADABLEOnes(unittest.TestCase):
         self.addCleanup(lambda: setattr(km, "_session_flag", self._flag))
 
     def test_a_session_with_no_live_row_is_unknown(self):
-        tmux = {ALIVE[0]["sid"]: {}, ALIVE[1]["sid"]: {}}     # 'tests' has no row at all
-        self.assertEqual(km._state_unknown_names(ALIVE, tmux, [], []), ["tests"])
+        live_map = {ALIVE[0]["sid"]: {}, ALIVE[1]["sid"]: {}}     # 'tests' has no row at all
+        self.assertEqual(km._state_unknown_names(ALIVE, live_map, [], []), ["tests"])
 
     def test_a_readable_idle_session_is_NOT_unknown(self):
         # the whole point: a session we CAN read and that is quiet gets no pip, so it must not
         # appear here — otherwise every idle session would wear the gray ring
-        tmux = {s["sid"]: {} for s in ALIVE}
-        self.assertEqual(km._state_unknown_names(ALIVE, tmux, [], []), [])
+        live_map = {s["sid"]: {} for s in ALIVE}
+        self.assertEqual(km._state_unknown_names(ALIVE, live_map, [], []), [])
 
     def test_working_and_awaiting_are_never_unknown(self):
         # their state was read by definition; they already have their own dots
-        tmux = {}                                             # no live rows at all
-        out = km._state_unknown_names(ALIVE, tmux, ["web"], ["api"])
+        live_map = {}                                             # no live rows at all
+        out = km._state_unknown_names(ALIVE, live_map, ["web"], ["api"])
         self.assertEqual(out, ["tests"], "only the session with neither a dot nor a readable state")
 
     def test_hidden_sessions_are_in_no_list(self):
@@ -64,7 +64,7 @@ class StateUnknownIsTheUnREADABLEOnes(unittest.TestCase):
     def test_build_feed_ships_the_list(self):
         import inspect
         src = inspect.getsource(km.build_feed)
-        self.assertIn('"stateUnknown": _state_unknown_names(alive, tmux, working, awaiting)', src)
+        self.assertIn('"stateUnknown": _state_unknown_names(alive, live_map, working, awaiting)', src)
 
     def test_no_ready_list_is_published(self):
         # a healthy idle session is deliberately NOT enumerated: blank means quiet, so there is

--- a/tests/test_fork_lineage.py
+++ b/tests/test_fork_lineage.py
@@ -154,7 +154,7 @@ class BuildSessionLineage(unittest.TestCase):
         shutil.rmtree(self._td, ignore_errors=True)
 
     def test_the_child_gets_its_divider_right_after_the_branch_point(self):
-        m = km.build_session(CHILD, self.now, tmux={})
+        m = km.build_session(CHILD, self.now, live_map={})
         self.assertEqual(m["branch"]["fromSid"], PARENT)
         self.assertEqual(m["branch"]["fromName"], "parent")
         evs = m["events"]
@@ -165,7 +165,7 @@ class BuildSessionLineage(unittest.TestCase):
         self.assertEqual(evs[at + 1]["fromName"], "parent")
 
     def test_the_parent_gets_its_children_list(self):
-        m = km.build_session(PARENT, self.now, tmux={})
+        m = km.build_session(PARENT, self.now, live_map={})
         self.assertIsNone(m["branch"], "the parent is not itself a fork")
         self.assertEqual([k["sid"] for k in m["branches"]], [CHILD])
         self.assertEqual(m["branches"][0]["cut"], "a1")
@@ -174,7 +174,7 @@ class BuildSessionLineage(unittest.TestCase):
         (jd.SDKDIR / (CHILD + ".json")).write_text(json.dumps(
             {"sid": CHILD, "name": "child", "cwd": self.cdir, "lastSid": CHILD, "alive": True}))
         km._sdk = lambda: None
-        m = km.build_session(CHILD, self.now, tmux={})
+        m = km.build_session(CHILD, self.now, live_map={})
         self.assertIsNone(m["branch"])
         self.assertIsNone(m["branches"])
         self.assertFalse(any(e.get("kind") == "branch" for e in m["events"]))

--- a/tests/test_interrupt_lift_evidence_time.py
+++ b/tests/test_interrupt_lift_evidence_time.py
@@ -220,7 +220,7 @@ class EndToEndThroughTheTick(unittest.TestCase):
         km._autonudge_cache.clear()
         km._pending_ops.clear()
         km._write_auto_nudge({"enabled": True, "nudged": {}, "intrBlocked": {}})
-        self.tmux = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+        self.live_map = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
                            "context": None, "compactPct": None, "color": None}}
         recs = [uline(NOW - 3600, "wire up the reconnect banner", "u1"),
                 aline(NOW - 3580, "on it", "a1", "u1", "tool_use"),
@@ -247,19 +247,19 @@ class EndToEndThroughTheTick(unittest.TestCase):
         km._parse_cache.clear()
 
     def test_the_lift_records_the_reengagement_turns_trigger(self):
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][GID], "blocked")
         self._reengage()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         nd = jd.load_goals(SID)["nodes"][GID]
         self.assertEqual(jd.load_goals(SID)["status"][GID], "working")
         self.assertEqual(_row(nd, "unblock")["ev_t"], RESUME_T,
                          "the message's own turn trigger — the stamp the judges will use for it too")
 
     def test_the_verdict_on_the_reengaged_turn_puts_the_card_back_in_needs_you(self):
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self._reengage()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         st = jd.load_goals(SID)                       # the judges audit that turn once it ends
         self.assertTrue(jd.record_verdict(st, st["nodes"][GID], "closer", "block", RESUME_T,
                                           why="which host for prod?"))
@@ -270,13 +270,13 @@ class EndToEndThroughTheTick(unittest.TestCase):
 
     def test_a_machine_cut_lift_is_stamped_the_same_way(self):
         # the audited shape: romp's own resume notice is the re-engagement, and the tick lifts on it
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         with open(self.tpath, "a") as f:
             f.write(json.dumps(uline(RESUME_T, sb.BOOT_RESUME_NUDGE, "u3", "u2")) + "\n")
             f.write(json.dumps(aline(RESUME_T + 40, "picked it up; which host for prod?",
                                      "a2", "u3", "end_turn")) + "\n")
         km._parse_cache.clear()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         nd = jd.load_goals(SID)["nodes"][GID]
         self.assertEqual(_row(nd, "unblock")["ev_t"], RESUME_T)
         st = jd.load_goals(SID)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -111,7 +111,7 @@ class ViewBuilder(unittest.TestCase):
         names = td / "names"; names.mkdir()
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
         self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-                      km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD, jd.gist_llm)
+                      km.NAMES, km._live_map, km._GLOBAL_CLAUDE_MD, jd.gist_llm)
         # the captioner's MESSAGE caption (jd.gist_llm) — stub it so NO test fires a real LLM subprocess.
         # The provisional card reads the PERSISTED message caption ('<segid>#p'), not this directly; the
         # gist-specific tests write that caption to drive the card's "Analyzing: …" text.
@@ -128,7 +128,7 @@ class ViewBuilder(unittest.TestCase):
         km.NAMES = names
         # deterministic tmux: the fixture session is ALIVE + idle (so the alive-only filter shows it);
         # individual tests override this map to exercise other states.
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         session = em.parse_session(str(self.tpath), rompuuid=SID, candidate_files=[str(self.tpath)], now=NOW)
         turn = session["turns"][0]
@@ -155,7 +155,7 @@ class ViewBuilder(unittest.TestCase):
 
     def tearDown(self):
         (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-         km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD, jd.gist_llm) = self.saved
+         km.NAMES, km._live_map, km._GLOBAL_CLAUDE_MD, jd.gist_llm) = self.saved
         self.td.cleanup()
 
     def _write_msg_caption(self, caption):
@@ -183,16 +183,16 @@ class ViewBuilder(unittest.TestCase):
         the fleet-view sig MUST change when the order changes — else _cached_feed serves the stale order and
         the reordered cards lag the tabs by up to a 5s bucket (the user 2026-07-15). The chat tab strip never
         lagged because its tab_order is read fresh each push, not from the cached feed."""
-        tmux = {}
+        live_map = {}
         p = jd.STATE / "session-order.json"
         km._write_session_order(["11111111-2222-3333-4444-555555555555"])
-        sig1 = km._fleet_view_sig(NOW, tmux)
+        sig1 = km._fleet_view_sig(NOW, live_map)
         self.assertIn("__order__", dict(sig1), "the sig must watch session-order.json")
         self.assertEqual(dict(sig1)["__order__"], os.stat(p).st_mtime, "the sig tracks the order file's mtime")
         # a reorder rewrites the file → new mtime → the sig changes → _cached_feed rebuilds with the new order.
         # set a distinct mtime explicitly so the assertion never rides on sub-second write resolution.
         os.utime(p, (NOW - 100, NOW - 100))
-        sig2 = km._fleet_view_sig(NOW, tmux)
+        sig2 = km._fleet_view_sig(NOW, live_map)
         self.assertNotEqual(sig1, sig2, "a session-order change must bust the fleet-view sig")
 
     def test_reorder_within_the_throttle_needs_a_dirty_mark(self):
@@ -200,19 +200,19 @@ class ViewBuilder(unittest.TestCase):
         when the sig changed — so a reorder within 2s of the last feed build kept serving the OLD order (the
         'still slow' report, the user 2026-07-15). The reorder handler now _mark_views_dirty()s, and a dirty
         mark bypasses the throttle so the fresh order ships at once."""
-        now = int(time.time()); tmux = km._tmux_sessions()
+        now = int(time.time()); live_map = km._live_map()
         km._built_feed[:] = [None, None, 0.0, 0.0]; km._views_dirty[0] = 0.0
         other = "22222222-3333-4444-5555-666666666666"
         km._write_session_order([SID])
-        f1 = km._cached_feed(now, tmux, km._fleet_view_sig(now, tmux))   # warm the cache with this order
+        f1 = km._cached_feed(now, live_map, km._fleet_view_sig(now, live_map))   # warm the cache with this order
         self.assertEqual(f1["order"], [SID])
         # reorder within REBUILD_MIN_S: the sig changes, but the throttle still hands back the cached feed
         km._write_session_order([other, SID])
-        f2 = km._cached_feed(now, tmux, km._fleet_view_sig(now, tmux))
+        f2 = km._cached_feed(now, live_map, km._fleet_view_sig(now, live_map))
         self.assertEqual(f2["order"], [SID], "throttled reuse → still the pre-reorder order (the bug)")
         # a dirty mark (what the reorder handler now does) bypasses the throttle → rebuild with the new order
         km._mark_views_dirty()
-        f3 = km._cached_feed(now, tmux, km._fleet_view_sig(now, tmux))
+        f3 = km._cached_feed(now, live_map, km._fleet_view_sig(now, live_map))
         self.assertEqual(f3["order"], [other, SID], "dirty mark → immediate rebuild with the fresh order")
 
     def test_resolving_a_picker_marks_views_dirty_so_the_card_leaves_needs_you_at_once(self):
@@ -575,7 +575,7 @@ class ViewBuilder(unittest.TestCase):
         feed = km.build_feed(NOW)
         rows = feed["sessions"]
         self.assertEqual([r["sid"] for r in rows],
-                         [s["sid"] for s in km._chat_tab_sessions(NOW, km._tmux_sessions())])
+                         [s["sid"] for s in km._chat_tab_sessions(NOW, km._live_map())])
         me = next(r for r in rows if r["sid"] == SID)
         self.assertEqual(me["name"], "testsess")
         self.assertEqual(me["color"], km._name_color(SID), "the tab_meta colour resolution, verbatim")
@@ -1085,12 +1085,11 @@ class ViewBuilder(unittest.TestCase):
         with self.tpath.open("a") as f:                  # an OPEN turn → _session_working is true
             f.write(json.dumps(uline(NOW, "keep working on the strip", "uOpen", parent="a2")) + "\n")
         km._parse_cache.clear()
-        km._tmux_echo.pop(SID, None)
-        km._tmux_echo_add(SID, "and also fix the header")  # the send fired while busy → will be queued by Claude Code
+        restore = _echo_stub(km, SID, "and also fix the header")  # the send fired while busy → will be queued by Claude Code
         try:
             events = km.build_session(SID, NOW)["events"]
         finally:
-            km._tmux_echo.pop(SID, None)
+            restore()
         qmsgs = [m["md"] for e in events if e["kind"] == "queued" for m in e["texts"]]
         self.assertIn("and also fix the header", qmsgs, "a send while working shows as a QUEUED (dotted) bubble")
         sent = [e for e in events if e["kind"] == "user" and e.get("md") == "and also fix the header"]
@@ -1100,12 +1099,11 @@ class ViewBuilder(unittest.TestCase):
         # the gate: when the session is IDLE (default fixture ends on an ended turn), the SAME echo is a
         # genuine sent message — it shows as a solid user bubble, never the dotted queued indicator.
         km._parse_cache.clear()
-        km._tmux_echo.pop(SID, None)
-        km._tmux_echo_add(SID, "a fresh idle send")
+        restore = _echo_stub(km, SID, "a fresh idle send")
         try:
             events = km.build_session(SID, NOW)["events"]
         finally:
-            km._tmux_echo.pop(SID, None)
+            restore()
         sent = [e for e in events if e["kind"] == "user" and e.get("md") == "a fresh idle send"]
         self.assertEqual(len(sent), 1, "an idle send shows as a solid user bubble")
         qmsgs = [m["md"] for e in events if e["kind"] == "queued" for m in e["texts"]]
@@ -1119,15 +1117,14 @@ class ViewBuilder(unittest.TestCase):
         # default fixture ends on an ENDED turn (idle/not working); the optimistic compacting flag makes
         # _compacting true with no tmux needed.
         km._parse_cache.clear()
-        km._tmux_echo.pop(SID, None)
         km._compact_clicked[SID] = NOW                    # optimistic compacting cue (no open turn, no boundary-since)
-        km._tmux_echo_add(SID, "switch to the dark palette")  # sent mid-compaction → Claude Code will queue it
+        restore = _echo_stub(km, SID, "switch to the dark palette")  # sent mid-compaction → Claude Code will queue it
         try:
             self.assertTrue(km._compacting(SID, "", km._parse(str(self.tpath), SID, NOW), NOW, None),
                             "precondition: the session reads as compacting")
             events = km.build_session(SID, NOW)["events"]
         finally:
-            km._tmux_echo.pop(SID, None)
+            restore()
             km._compact_clicked.pop(SID, None)
         qmsgs = [m["md"] for e in events if e["kind"] == "queued" for m in e["texts"]]
         self.assertIn("switch to the dark palette", qmsgs, "a send while compacting shows as a QUEUED (dotted) bubble")
@@ -1139,12 +1136,11 @@ class ViewBuilder(unittest.TestCase):
         # NOT the blue human bubble (the user 2026-06-29). This is the colour half of the nudge-vanish fix:
         # the optimistic echo bridges the dequeue→landed gap, so it must read like the real romp atom will.
         km._parse_cache.clear()
-        km._tmux_echo.pop(SID, None)
-        km._tmux_echo_add(SID, "checking in on the goal", author="romp")
+        restore = _echo_stub(km, SID, "checking in on the goal", author="romp")
         try:
             events = km.build_session(SID, NOW)["events"]
         finally:
-            km._tmux_echo.pop(SID, None)
+            restore()
         ev = next(e for e in events if e["kind"] == "user" and e.get("md") == "checking in on the goal")
         self.assertTrue(ev.get("romp"), "a romp-authored echo is a gray romp bubble")
         self.assertFalse(ev.get("human"), "and NOT a blue human bubble")
@@ -1233,8 +1229,8 @@ class ViewBuilder(unittest.TestCase):
         km._task_seg_cache.clear()
         km._BG_TOPS_CACHE.clear()          # both classifier caches key on store/transcript file stats —
         km._SESSION_STAMP_CACHE.clear()    # cleared so a same-stat rewrite can't serve a stale verdict
-        saved = km._tmux_sessions
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+        saved = km._live_map
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
                                            "context": None, "compactPct": None, "color": None,
                                            "bgTasks": [{"desc": "campaign watcher", "type": "local_bash",
                                                         "since": since, "toolUseId": "tu_a1_0",
@@ -1244,7 +1240,7 @@ class ViewBuilder(unittest.TestCase):
             blocked = next(a for a in asks if a["itemId"] == top)
             return (blocked, next(a for a in asks if a["itemId"] == other)) if second_top else blocked
         finally:
-            km._tmux_sessions = saved
+            km._live_map = saved
 
     def test_a_block_newer_than_the_owned_dispatched_work_stays_needs_input(self):
         # the user 2026-07-15 (nimbus): the turn ENDED by asking the user questions while a background
@@ -1303,8 +1299,8 @@ class ViewBuilder(unittest.TestCase):
         km._task_seg_cache.clear()
         km._BG_TOPS_CACHE.clear()
         km._SESSION_STAMP_CACHE.clear()
-        saved = km._tmux_sessions
-        km._tmux_sessions = lambda: {SID: {"bgTasks": [
+        saved = km._live_map
+        km._live_map = lambda: {SID: {"bgTasks": [
             {"desc": "campaign watcher", "since": T0 + 200, "toolUseId": "tu_a1_0"},
             {"desc": "mystery task", "since": T0 + 300, "toolUseId": "tu_never_seen"}]}}
         try:
@@ -1316,7 +1312,7 @@ class ViewBuilder(unittest.TestCase):
             self.assertEqual([t["tid"] for t in km._bg_pending(SID, str(self.tpath), tasks)],
                              ["tu_never_seen"])
         finally:
-            km._tmux_sessions = saved
+            km._live_map = saved
 
     def test_a_placed_unstamped_task_is_a_service_not_a_wait(self):
         # the user 2026-07-24: a dev server (mkdocs serve) wore 'Waiting on task' long after the judge
@@ -1335,8 +1331,8 @@ class ViewBuilder(unittest.TestCase):
         km._task_seg_cache.clear()
         km._BG_TOPS_CACHE.clear()
         km._SESSION_STAMP_CACHE.clear()
-        saved = km._tmux_sessions
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+        saved = km._live_map
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
                                            "context": None, "compactPct": None, "color": None,
                                            "bgTasks": [{"desc": "mkdocs serve 2>&1", "type": "local_bash",
                                                         "since": T0 + 200, "toolUseId": "tu_a1_0",
@@ -1351,7 +1347,7 @@ class ViewBuilder(unittest.TestCase):
             self.assertIn("mkdocs serve 2>&1", sum(feed["bgServices"].values(), []),
                           "the process surfaces as the neutral session chip instead")
         finally:
-            km._tmux_sessions = saved
+            km._live_map = saved
 
     def test_a_placed_task_under_a_stamped_top_stays_awaited(self):
         # the same placement, but the CLOSER affirmed the wait (a live ⏳ stamp on the placed node):
@@ -1369,8 +1365,8 @@ class ViewBuilder(unittest.TestCase):
         km._task_seg_cache.clear()
         km._BG_TOPS_CACHE.clear()
         km._SESSION_STAMP_CACHE.clear()
-        saved = km._tmux_sessions
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+        saved = km._live_map
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
                                            "context": None, "compactPct": None, "color": None,
                                            "bgTasks": [{"desc": "campaign watcher", "type": "local_bash",
                                                         "since": T0 + 200, "toolUseId": "tu_a1_0",
@@ -1385,7 +1381,7 @@ class ViewBuilder(unittest.TestCase):
                              "the pill lists the judge-affirmed task")
             self.assertEqual(feed["bgServices"], {}, "an awaited task is never a service")
         finally:
-            km._tmux_sessions = saved
+            km._live_map = saved
 
     def test_a_service_only_session_gets_no_phantom_awaiting_card(self):
         # every goal cleared + a judged-service process still up: the ephemeral 'Waiting on a background
@@ -1402,8 +1398,8 @@ class ViewBuilder(unittest.TestCase):
         km._task_seg_cache.clear()
         km._BG_TOPS_CACHE.clear()
         km._SESSION_STAMP_CACHE.clear()
-        saved = km._tmux_sessions
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+        saved = km._live_map
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
                                            "context": None, "compactPct": None, "color": None,
                                            "bgTasks": [{"desc": "mkdocs serve 2>&1", "type": "local_bash",
                                                         "since": T0 + 200, "toolUseId": "tu_a1_0",
@@ -1414,7 +1410,7 @@ class ViewBuilder(unittest.TestCase):
                              "no permanent phantom card for a process nobody waits on")
             self.assertIn("mkdocs serve 2>&1", sum(feed["bgServices"].values(), []))
         finally:
-            km._tmux_sessions = saved
+            km._live_map = saved
 
     def test_stale_awaiting_overlay_superseded_by_a_later_work_turn(self):
         # the user 2026-06-26: open_mvv showed the yellow 'working' dot + badge + timer + interrupt button in
@@ -1525,32 +1521,32 @@ class ViewBuilder(unittest.TestCase):
         p.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
         timer = {"desc": "20-minute timer for campaign-start check", "type": "local_bash",
                  "since": T0 + 9, "toolUseId": "tu_bg", "lastTool": ""}
-        saved = km._tmux_sessions
+        saved = km._live_map
         try:
-            km._tmux_sessions = lambda: {}                         # no live sources at all
+            km._live_map = lambda: {}                         # no live sources at all
             self.assertIsNone(km._session_awaiting(SID, str(p), True),
                               "a transcript-scrape bg launch alone is NOT awaiting (no live signal)")
             # source 0: real subagents in flight — the snapshot carries the live LIST (a {"type","since"}
             # per agent); the why counts via len() (the pre-fix code %d-formatted the list itself)
-            km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "", "since": T0}, {"type": "", "since": T0}]}}
+            km._live_map = lambda: {SID: {"subagents": [{"type": "", "since": T0}, {"type": "", "since": T0}]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
                              {"kind": "agents", "why": "2 background agents still working"},
                              "a live subagent DOES leave an idle session awaiting (a working flavor)")
             # source 0.5: the live bg-task set — one task shows its description verbatim
-            km._tmux_sessions = lambda: {SID: {"bgTasks": [timer]}}
+            km._live_map = lambda: {SID: {"bgTasks": [timer]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
                              {"kind": "task",
                               "why": "waiting on a background task: 20-minute timer for campaign-start check"})
-            km._tmux_sessions = lambda: {SID: {"bgTasks": [timer, dict(timer, desc="power watcher")]}}
+            km._live_map = lambda: {SID: {"bgTasks": [timer, dict(timer, desc="power watcher")]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
                              {"kind": "task",
                               "why": "waiting on 2 background tasks — 20-minute timer for campaign-start check, …"})
             # subagents outrank bg tasks when both run (they're the bigger dispatch)
-            km._tmux_sessions = lambda: {SID: {"subagents": [{"type": "", "since": T0}], "bgTasks": [timer]}}
+            km._live_map = lambda: {SID: {"subagents": [{"type": "", "since": T0}], "bgTasks": [timer]}}
             self.assertEqual(km._session_awaiting(SID, str(p), True),
                              {"kind": "agents", "why": "1 background agent still working"})
         finally:
-            km._tmux_sessions = saved
+            km._live_map = saved
 
     def test_session_awaiting_reads_the_states_overlay(self):
         # the SDK channel (api 2026-06-22): the kernel reads an {"awaiting":bool,"why":…} overlay from
@@ -1729,7 +1725,7 @@ class ViewBuilder(unittest.TestCase):
         (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(store))
 
     def _working_tmux(self):
-        km._tmux_sessions = lambda: {SID: {"state": "working", "since": NOW - 10, "model": "",
+        km._live_map = lambda: {SID: {"state": "working", "since": NOW - 10, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
 
     def test_provisional_card_surfaces_for_an_in_progress_prompt_with_no_card(self):
@@ -1895,7 +1891,7 @@ class ViewBuilder(unittest.TestCase):
             {"enabled": True, "nudged": {g1: {"count": 1, "failed": True}}}))
         km._autonudge_cache.clear(); km._nudge_times_cache.clear()
         # the LIVE SubagentStart/Stop count rides the backend snapshot (the designed signal) — 2 agents running
-        km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None,
                                            "subagents": [{"type": "", "since": 1}, {"type": "", "since": 2}]}}
         c = {a["itemId"]: a for a in km.build_feed(NOW)["asks"]}[g1]
@@ -1904,7 +1900,7 @@ class ViewBuilder(unittest.TestCase):
         self.assertIsNone(c.get("blocked"), "no red apiError floor while agents run")
         self.assertFalse(c.get("nudgeFailed"), "no stalled chip while agents run")
         # control: the SAME transcript with no live agents is genuinely dead in the water → the floor applies
-        km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         c = {a["itemId"]: a for a in km.build_feed(NOW)["asks"]}[g1]
         self.assertEqual((c.get("blocked") or {}).get("state"), "apiError",
@@ -1922,7 +1918,7 @@ class ViewBuilder(unittest.TestCase):
             + json.dumps({"t": NOW - 30, "state": "waiting"}) + "\n")
         ov = km._states_awaiting_overlay(SID)
         self.assertFalse(ov and ov.get("awaiting"), "the overlay alone still reads superseded (the hole)")
-        km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None,
                                            "subagents": [{"type": "", "since": 1}, {"type": "", "since": 2}]}}
         self.assertIn("2 background agents", (km._session_awaiting(SID, str(self.tpath), True) or {}).get("why", ""),
@@ -2200,14 +2196,14 @@ class ViewBuilder(unittest.TestCase):
         # straight from the backend snapshot's bgTasks (the CLI task-lifecycle set); a desc-less task gets
         # a generic label; tmux sessions / unknown sids read []. Tasks with no launch id can't be
         # classified (2026-07-24: the service split) → pending → still AWAITED, listed as before.
-        saved = km._tmux_sessions
-        km._tmux_sessions = lambda: {SID: {"bgTasks": [{"task_id": "t1", "desc": "Watch for round3 copy"},
+        saved = km._live_map
+        km._live_map = lambda: {SID: {"bgTasks": [{"task_id": "t1", "desc": "Watch for round3 copy"},
                                                        {"task_id": "t2", "desc": ""}]}}
         try:
             self.assertEqual(km._awaiting_task_descs(SID, "/nonexistent"),
                              ["Watch for round3 copy", "background task"])
         finally:
-            km._tmux_sessions = saved
+            km._live_map = saved
         self.assertEqual(km._awaiting_task_descs("00000000-0000-0000-0000-000000000000", "/nonexistent"), [])
         # build_feed attaches the list on awaiting cards, beside the why (source pin)
         src = Path(BIN, "romp-kernel").read_text()
@@ -2288,14 +2284,21 @@ class ViewBuilder(unittest.TestCase):
 
     # ── Auto Nudge (the user 2026-06-19): follow up ONCE on an orphaned working goal ──
     def _stub_nudge(self):
-        # capture nudges instead of pasting into tmux; returns (sent_list, restore_fn)
+        # capture nudges at the backend seam (Sessions.backend_for(sid).send — the delivery path on
+        # every backend), WRAPPING the current backend so its other answers (pending_cut, queued)
+        # keep flowing; returns (sent_list, restore_fn)
         sent = []
-        saved_send, saved_fu = km._tmux_send, jd.optimistic_followup
-        km._tmux_send = lambda name, body, **kw: sent.append((name, body))
+        saved_bf, saved_fu = km.Sessions.backend_for, jd.optimistic_followup
+
+        class _SendVia:
+            def __init__(self, inner): self._inner = inner
+            def send(self, sid, body): sent.append((sid, body)); return True
+            def __getattr__(self, name): return getattr(self._inner, name)
+        km.Sessions.backend_for = staticmethod(lambda sid, _bf=saved_bf: _SendVia(_bf(sid)))
         jd.optimistic_followup = lambda sid, gid: True
 
         def restore():
-            km._tmux_send, jd.optimistic_followup = saved_send, saved_fu
+            km.Sessions.backend_for, jd.optimistic_followup = saved_bf, saved_fu
         return sent, restore
 
     def test_working_top_goal_picks_only_a_working_top(self):
@@ -2323,7 +2326,7 @@ class ViewBuilder(unittest.TestCase):
         saved = (km._working_notes, km._alive_sessions, km._set_working_note,
                  km._session_working, km._working_top_goal, jd.parsed_session)
         km._working_notes = lambda: dict(notes)
-        km._alive_sessions = lambda now, tmux: [{"sid": SID, "path": str(self.tpath)}]
+        km._alive_sessions = lambda now, live_map: [{"sid": SID, "path": str(self.tpath)}]
         km._set_working_note = lambda sid, text: cleared.append((sid, text))
         km._session_working = lambda turns: working
         km._working_top_goal = lambda sid: top_goal
@@ -2382,22 +2385,22 @@ class ViewBuilder(unittest.TestCase):
         # (its client["active"], from the ?active= connect hint), then streams the rest — so first paint is the
         # active transcript, not a wait on every tab building. The tab strip is sent before any heavy build.
         sent = []   # (key, msg) in SEND order
-        saved = (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
+        saved = (km._live_map, km._chat_tab_sessions, km.build_session, km.build_feed,
                  km.build_timeline, km._send_client)
-        km._tmux_sessions = lambda: {}
+        km._live_map = lambda: {}
         p = str(self.tpath)   # a transcript ON DISK — a pathless fake would rank as just-created (top tier)
-        km._chat_tab_sessions = lambda now, tmux: [{"sid": "A", "path": p}, {"sid": "B", "path": p},
+        km._chat_tab_sessions = lambda now, live_map: [{"sid": "A", "path": p}, {"sid": "B", "path": p},
                                                    {"sid": "C", "path": p}]
-        km.build_session = lambda sid, now, tmux: {"id": sid, "name": sid, "color": None,
+        km.build_session = lambda sid, now, live_map: {"id": sid, "name": sid, "color": None,
                                                    "status": None, "ledger": None}
-        km.build_feed = lambda now, tmux: {"working": [], "asks": []}
-        km.build_timeline = lambda now, tmux: None
+        km.build_feed = lambda now, live_map: {"working": [], "asks": []}
+        km.build_timeline = lambda now, live_map: None
         km._send_client = lambda c, key, msg, pre=None: sent.append((key, msg))
         client = {"app": "chat", "active": "B", "alive": True}
         try:
             km._push([client])
         finally:
-            (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
+            (km._live_map, km._chat_tab_sessions, km.build_session, km.build_feed,
              km.build_timeline, km._send_client) = saved
         chat_order = [key[1] for (key, _) in sent if key[0] == "chat"]
         self.assertEqual(chat_order[0], "B", "the ACTIVE tab is built + streamed first")
@@ -2410,21 +2413,21 @@ class ViewBuilder(unittest.TestCase):
         # no client["active"] (e.g. nothing persisted yet) → graceful fallback: stream in tab order, still
         # incrementally (no regression, just no prioritization).
         sent = []
-        saved = (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
+        saved = (km._live_map, km._chat_tab_sessions, km.build_session, km.build_feed,
                  km.build_timeline, km._send_client)
-        km._tmux_sessions = lambda: {}
+        km._live_map = lambda: {}
         p = str(self.tpath)
-        km._chat_tab_sessions = lambda now, tmux: [{"sid": "A", "path": p}, {"sid": "B", "path": p},
+        km._chat_tab_sessions = lambda now, live_map: [{"sid": "A", "path": p}, {"sid": "B", "path": p},
                                                    {"sid": "C", "path": p}]
-        km.build_session = lambda sid, now, tmux: {"id": sid, "name": sid, "color": None,
+        km.build_session = lambda sid, now, live_map: {"id": sid, "name": sid, "color": None,
                                                    "status": None, "ledger": None}
-        km.build_feed = lambda now, tmux: {"working": [], "asks": []}
-        km.build_timeline = lambda now, tmux: None
+        km.build_feed = lambda now, live_map: {"working": [], "asks": []}
+        km.build_timeline = lambda now, live_map: None
         km._send_client = lambda c, key, msg, pre=None: sent.append((key, msg))
         try:
             km._push([{"app": "chat", "alive": True}])
         finally:
-            (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
+            (km._live_map, km._chat_tab_sessions, km.build_session, km.build_feed,
              km.build_timeline, km._send_client) = saved
         self.assertEqual([key[1] for (key, _) in sent if key[0] == "chat"], ["A", "B", "C"],
                          "no active hint → tab order, all tabs still delivered")
@@ -2436,23 +2439,23 @@ class ViewBuilder(unittest.TestCase):
         session that had been ready the whole time (the user 2026-08-08). Its build is near-free, so
         it rides the ACTIVE tier and its payload streams at the top of the cycle."""
         sent = []
-        saved = (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
+        saved = (km._live_map, km._chat_tab_sessions, km.build_session, km.build_feed,
                  km.build_timeline, km._send_client)
-        km._tmux_sessions = lambda: {}
+        km._live_map = lambda: {}
         p = str(self.tpath)
-        km._chat_tab_sessions = lambda now, tmux: [
+        km._chat_tab_sessions = lambda now, live_map: [
             {"sid": "A", "path": p},
             {"sid": "NEW", "path": p + ".does-not-exist"},   # just created: nothing on disk yet
             {"sid": "C", "path": p}]
-        km.build_session = lambda sid, now, tmux: {"id": sid, "name": sid, "color": None,
+        km.build_session = lambda sid, now, live_map: {"id": sid, "name": sid, "color": None,
                                                    "status": None, "ledger": None}
-        km.build_feed = lambda now, tmux: {"working": [], "asks": []}
-        km.build_timeline = lambda now, tmux: None
+        km.build_feed = lambda now, live_map: {"working": [], "asks": []}
+        km.build_timeline = lambda now, live_map: None
         km._send_client = lambda c, key, msg, pre=None: sent.append((key, msg))
         try:
             km._push([{"app": "chat", "active": "C", "alive": True}])
         finally:
-            (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
+            (km._live_map, km._chat_tab_sessions, km.build_session, km.build_feed,
              km.build_timeline, km._send_client) = saved
         chat_order = [key[1] for (key, _) in sent if key[0] == "chat"]
         self.assertEqual(chat_order, ["NEW", "C", "A"],
@@ -2471,14 +2474,14 @@ class ViewBuilder(unittest.TestCase):
             with open(p, "w") as f:
                 f.write("{}\n")
         calls = []
-        saved = (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
+        saved = (km._live_map, km._chat_tab_sessions, km.build_session, km.build_feed,
                  km.build_timeline, km._send_client)
-        km._tmux_sessions = lambda: {}
-        km._chat_tab_sessions = lambda now, tmux: [{"sid": "A", "path": pa}, {"sid": "B", "path": pb}]
-        km.build_session = lambda sid, now, tmux: (calls.append(sid) or
+        km._live_map = lambda: {}
+        km._chat_tab_sessions = lambda now, live_map: [{"sid": "A", "path": pa}, {"sid": "B", "path": pb}]
+        km.build_session = lambda sid, now, live_map: (calls.append(sid) or
                                                    {"id": sid, "name": sid, "color": None, "status": None, "ledger": None})
-        km.build_feed = lambda now, tmux: {"working": [], "asks": []}
-        km.build_timeline = lambda now, tmux: None
+        km.build_feed = lambda now, live_map: {"working": [], "asks": []}
+        km.build_timeline = lambda now, live_map: None
         km._send_client = lambda c, key, msg, pre=None: None
         km._built_chat.clear()
         client = {"app": "chat", "active": "A", "alive": True}
@@ -2491,7 +2494,7 @@ class ViewBuilder(unittest.TestCase):
             os.utime(pb, None)
             km._push([client])                       # 3rd: A rebuilt; B rebuilt (changed)
         finally:
-            (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
+            (km._live_map, km._chat_tab_sessions, km.build_session, km.build_feed,
              km.build_timeline, km._send_client) = saved
             km._built_chat.clear()
         self.assertEqual(calls.count("A"), 3, "the ACTIVE tab rebuilds on every push (stays live)")
@@ -2525,13 +2528,13 @@ class ViewBuilder(unittest.TestCase):
         km._set_auto_nudge(True)
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "first nudge on the stall turn")
             self.assertIn("romp-goal-id: " + g, sent[0][1], "the follow-up targets that goal")
             self.assertIn(km.AUTO_NUDGE_TEXT, sent[0][1])         # carries the nudge prompt verbatim
-            km._auto_nudge_tick(NOW, km._tmux_sessions())          # SAME turn → NO re-fire
+            km._auto_nudge_tick(NOW, km._live_map())          # SAME turn → NO re-fire
             self.assertEqual(len(sent), 1, "no second nudge on the same turn — one per turn")
-            km._auto_nudge_tick(NOW, km._tmux_sessions())          # SAME turn again → still capped
+            km._auto_nudge_tick(NOW, km._live_map())          # SAME turn again → still capped
             self.assertEqual(len(sent), 1, "a persistent stop does not re-fire each tick")
         finally:
             restore()
@@ -2548,12 +2551,12 @@ class ViewBuilder(unittest.TestCase):
         km._set_auto_nudge(True)
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 0, "no nudge while the planner hasn't placed the turn's units")
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 0, "the hold persists across ticks, not a one-shot skip")
             self._orphaned_goal(idle=True, planned=True)    # the planner catches up (placements recorded)
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "the placement landing opens the gate — the nudge fires")
             self.assertIn("romp-goal-id: " + g, sent[0][1])
         finally:
@@ -2573,7 +2576,7 @@ class ViewBuilder(unittest.TestCase):
         km._set_auto_nudge(True)
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             bodies = [b for (_n, b) in sent]
             self.assertEqual(len(sent), 1, "same-tick nudges bundle into ONE message, never N sends")
             self.assertTrue(any("romp-goal-id: " + g1 in b for b in bodies), "g1 nudged")
@@ -2587,15 +2590,19 @@ class ViewBuilder(unittest.TestCase):
         g = self._orphaned_goal(idle=True)
         km._set_auto_nudge(True)
         sent, fu_calls = [], []
-        saved_send, saved_fu = km._tmux_send, jd.optimistic_followup
-        km._tmux_send = lambda name, body, **kw: sent.append(body)
+
+        class _SendBE:
+            def send(self, sid, body): sent.append(body); return True
+        be = _SendBE()
+        saved_bf, saved_fu = km.Sessions.backend_for, jd.optimistic_followup
+        km.Sessions.backend_for = staticmethod(lambda sid: be)
         jd.optimistic_followup = lambda sid, gid, **kw: fu_calls.append(gid)
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "the nudge fired")
             self.assertEqual(fu_calls, [], "auto-nudge does NOT optimistic-followup → no Followed-up chip")
         finally:
-            km._tmux_send, jd.optimistic_followup = saved_send, saved_fu
+            km.Sessions.backend_for, jd.optimistic_followup = saved_bf, saved_fu
 
     def _drive_nudge_over(self, turn, last_state):
         # Drive one _auto_nudge_tick over a single controlled TURN + _last_state, exercising the REAL
@@ -2610,7 +2617,7 @@ class ViewBuilder(unittest.TestCase):
         km._downtime[:] = []                                         # no host-sleep interfering with _session_working
         jd.parsed_session = lambda sid, paths, now: {"turns": [turn]}
         km._last_state = lambda sid: last_state
-        km._alive_sessions = lambda now, tmux: [{"sid": SID, "path": str(self.tpath)}]
+        km._alive_sessions = lambda now, live_map: [{"sid": SID, "path": str(self.tpath)}]
         km._session_awaiting = lambda *a, **k: None
         km._api_error = lambda p: None
         km._wait_for_graph = lambda now, sids: {}
@@ -2679,7 +2686,7 @@ class ViewBuilder(unittest.TestCase):
         km._set_auto_nudge(True)
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "the stalled goal is nudged")
             # the fork ask (both the flat and the hierarchical-enumeration form carry these sentences):
             # the continue-or-name-the-blocker fork (the user 2026-07-02), leading with permission to
@@ -2798,20 +2805,18 @@ class ViewBuilder(unittest.TestCase):
         turn = {"id": SID + ":t1", "ended": True, "t": T0, "end": NOW,
                 "atoms": [{"type": "user", "t": T0}, {"type": "assistant", "t": NOW}]}
         cut = {"v": "11111111-2222-3333-4444-555555555555"}
-        fired = []                 # backend-owned sids fire via backend.send, not _tmux_send
         fake = type("B", (), {"pending_cut": staticmethod(lambda sid: cut["v"]),
-                              "pending_queued": staticmethod(lambda sid: []),
-                              "send": staticmethod(lambda sid, body: fired.append(body))})()
+                              "pending_queued": staticmethod(lambda sid: [])})()
         saved_bf = km.Sessions.backend_for
         km.Sessions.backend_for = staticmethod(lambda sid: fake)
         try:
             sent = self._drive_nudge_over(turn, last_state=("waiting", NOW))
-            self.assertEqual((sent, fired), ([], []),
+            self.assertEqual(sent, [],
                              "an armed, unconsumed bare rollback holds the nudge — "
                              "the parse still shows the deleted turn")
             cut["v"] = ""          # the cut was spent: a record landed on the new branch
-            self._drive_nudge_over(turn, last_state=("waiting", NOW))
-            self.assertEqual(len(fired), 1, "cut consumed → the nudge flows again")
+            sent2 = self._drive_nudge_over(turn, last_state=("waiting", NOW))
+            self.assertEqual(len(sent2), 1, "cut consumed → the nudge flows again")
         finally:
             km.Sessions.backend_for = saved_bf
 
@@ -2824,7 +2829,7 @@ class ViewBuilder(unittest.TestCase):
             g: {"count": 3, "lastTurnId": SID + ":told", "failed": True, "stalled": True}}})
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "the new genuine stall fires")
             rec = km._auto_nudge_data()["nudged"][g]
             self.assertNotIn("failed", rec, "a fresh fire opens a fresh episode — failed resets")
@@ -2952,14 +2957,14 @@ class ViewBuilder(unittest.TestCase):
         km._write_auto_nudge({"enabled": True, "nudged": {}})
         seen = []
 
-        def boom(s, now, tmux, nudged, waitfor, alive_ids=None):
+        def boom(s, now, live_map, nudged, waitfor, alive_ids=None):
             if s["sid"] == "bad-session":
                 raise TypeError("%d format: a real number is required, not list")
             seen.append(s["sid"])
             return False
         orig_one, orig_alive = km._auto_nudge_session, km._alive_sessions
         km._auto_nudge_session = boom
-        km._alive_sessions = lambda now, tmux: [{"sid": "bad-session", "path": "x"},
+        km._alive_sessions = lambda now, live_map: [{"sid": "bad-session", "path": "x"},
                                                 {"sid": "good-session", "path": "y"}]
         try:
             km._auto_nudge_tick(NOW, {})
@@ -2987,12 +2992,12 @@ class ViewBuilder(unittest.TestCase):
         km._set_auto_nudge(True)
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "first stall → nudged")
             self.assertEqual(km._auto_nudge_data()["nudged"][g]["count"], 1)
             self._stall_transcript(base + [uline(T0 + 200, "a3", "u3", "a2", ps="typed"),
                                            aline(T0 + 210, "d3", "a3", "u3", stop="end_turn")])   # NEW genuine turn
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 2, "a new genuine stall turn re-arms the nudge")
             self.assertEqual(km._auto_nudge_data()["nudged"][g]["count"], 2, "total count climbs each fire")
         finally:
@@ -3012,10 +3017,10 @@ class ViewBuilder(unittest.TestCase):
         sp.write_text(json.dumps({"t": T0 + 300, "state": "working"}) + "\n")   # working AFTER the parsed end → still going
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 0, "no nudge: the 'working' record is newer than the parsed turn end")
             sp.write_text(json.dumps({"t": T0 + 301, "state": "waiting"}) + "\n")   # genuine stop now
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "once genuinely stopped (state log 'waiting'), the nudge fires")
         finally:
             restore()
@@ -3037,7 +3042,7 @@ class ViewBuilder(unittest.TestCase):
         sp.write_text(json.dumps({"t": T0 + 50, "state": "working"}) + "\n")   # stale: BEFORE the turn end, no later 'waiting'
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "a finished turn with a stale pre-end 'working' record still gets nudged")
             self.assertIn("romp-goal-id: " + g, sent[0][1], "the nudge targets the orphaned working goal")
         finally:
@@ -3057,12 +3062,12 @@ class ViewBuilder(unittest.TestCase):
         km._set_auto_nudge(True)
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "the genuine stall is nudged once")
             nudge = "Status?\n\n<!-- romp-injected --><!-- romp-goal-id: %s -->" % g   # romp-authored turn
             self._stall_transcript(base + [uline(T0 + 100, nudge, "u2", "a1", ps="typed"),
                                            aline(T0 + 110, "still working", "a2", "u2", stop="end_turn")])
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "the nudge-RESPONSE turn does NOT re-arm — kills the runaway (the user 2026-07-01)")
         finally:
             restore()
@@ -3077,10 +3082,10 @@ class ViewBuilder(unittest.TestCase):
                                                        "color": None, "inCycle": False, "since": NOW}}
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(sent, [], "a session waiting on a live peer is held, not nudged")
             km._wait_for_graph = lambda now, alive: {}            # no longer waiting → the genuine stall is nudged
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "once the wait clears, the genuine stall is nudged")
         finally:
             restore(); km._wait_for_graph = saved
@@ -3093,10 +3098,10 @@ class ViewBuilder(unittest.TestCase):
         sent, restore = self._stub_nudge()
         try:
             km._set_session_flag(SID, "hideFromFeed", True); km._flags_cache.clear()
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(sent, [], "a session muted from the feed is not auto-nudged")
             km._set_session_flag(SID, "hideFromFeed", False); km._flags_cache.clear()
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(sent, [], "un-mute does NOT re-nudge: muting VIEW-CLEARED the goal, so it stays sealed")
         finally:
             restore()
@@ -3110,10 +3115,10 @@ class ViewBuilder(unittest.TestCase):
         km._session_awaiting = lambda sid, path, idle, stamp=False: {"kind": "agents", "why": "Waiting on its background agents."}
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(sent, [], "an awaiting session is held, not nudged")
             km._session_awaiting = lambda sid, path, idle, stamp=False: None   # no longer awaiting → the genuine stall is nudged
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "once the wait clears, the genuine stall is nudged")
         finally:
             restore(); km._session_awaiting = saved
@@ -3124,7 +3129,7 @@ class ViewBuilder(unittest.TestCase):
         km._set_auto_nudge(True)
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             ev = [json.loads(l) for l in (jd.STATE / "nudge-events.jsonl").read_text().splitlines()]
             self.assertEqual(len(ev), 1)
             self.assertEqual(ev[0]["gid"], g)
@@ -3139,7 +3144,7 @@ class ViewBuilder(unittest.TestCase):
         km._set_auto_nudge(False)                                  # explicitly turned off
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(sent, [], "explicitly off → no nudges")
         finally:
             restore()
@@ -3149,7 +3154,7 @@ class ViewBuilder(unittest.TestCase):
         km._set_auto_nudge(True)
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(sent, [], "an actively-working session isn't orphaned")
         finally:
             restore()
@@ -3163,7 +3168,7 @@ class ViewBuilder(unittest.TestCase):
         km._set_auto_nudge(True)
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(sent, [], "no nudge until the closer has processed the latest turn")
         finally:
             restore()
@@ -3171,11 +3176,11 @@ class ViewBuilder(unittest.TestCase):
     def test_auto_nudge_skips_an_awaiting_session(self):
         self._orphaned_goal(idle=True)
         km._set_auto_nudge(True)
-        km._tmux_sessions = lambda: {SID: {"state": "permission", "since": NOW - 10, "model": "",
+        km._live_map = lambda: {SID: {"state": "permission", "since": NOW - 10, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(sent, [], "a session awaiting your approval is not orphaned")
         finally:
             restore()
@@ -3210,7 +3215,7 @@ class ViewBuilder(unittest.TestCase):
         km._set_auto_nudge(True)
         sent, restore = self._stub_nudge()
         try:
-            km._auto_nudge_tick(NOW, km._tmux_sessions())
+            km._auto_nudge_tick(NOW, km._live_map())
             self.assertEqual(len(sent), 1, "the tick takes its turn id from the closer's parse → matches closedTurns → fires")
         finally:
             restore(); jd.parsed_session = real
@@ -3927,7 +3932,7 @@ class ViewBuilder(unittest.TestCase):
         # the + picker's payload (requestSessions → sessionList). Was always empty: bin/romp-kernel had
         # no requestSessions handler, so the kernel never replied. Running sessions first; archive headline
         # as the summary; the names-registry color.
-        items = km._session_list(NOW, km._tmux_sessions())
+        items = km._session_list(NOW, km._live_map())
         self.assertTrue(items, "picker must list the live session")
         it = next(i for i in items if i["id"] == SID)
         self.assertEqual(it["name"], "testsess")
@@ -3999,26 +4004,26 @@ class ViewBuilder(unittest.TestCase):
         # reopened tabs for the dead ones. Cause: an EMPTY tmux result fell back to file-derived
         # sessions. With a tmux binary present (the host case), an empty result is a GENUINE zero —
         # show nothing, not the dead session in the discover() window.
-        saved = km._has_tmux
-        km._has_tmux = lambda: True
+        saved = km._live_source_present
+        km._live_source_present = lambda: True
         try:
             self.assertEqual(km._alive_sessions(NOW, {}), [], "tmux present + empty → no sessions")
-            feed = km.build_feed(NOW, tmux={})
+            feed = km.build_feed(NOW, live_map={})
             self.assertEqual(feed.get("cards", []), [], "feed shows no card for a dead session")
             self.assertEqual(km._ordered_alive(NOW, {}), [], "no chat tabs / timeline lanes either")
         finally:
-            km._has_tmux = saved
+            km._live_source_present = saved
 
     def test_alive_filter_headless_no_tmux_falls_back_to_discover(self):
         # The ONLY case that still falls back: a genuinely headless run with no tmux binary at all
         # (a test box / CI), so a review-only surface isn't blank. Keyed on tmux PRESENCE, not a count.
-        saved = km._has_tmux
-        km._has_tmux = lambda: False
+        saved = km._live_source_present
+        km._live_source_present = lambda: False
         try:
             sids = [s["sid"] for s in km._alive_sessions(NOW, {})]
             self.assertIn(SID, sids, "no tmux at all → fall back to the discovered session")
         finally:
-            km._has_tmux = saved
+            km._live_source_present = saved
 
     def test_producer_sig_tracks_renames(self):
         # The user 2026-06-16: tmux/tab renames didn't propagate to the chat. A rename touches only the
@@ -4098,40 +4103,40 @@ class ViewBuilder(unittest.TestCase):
         # the user 2026-06-17 REVERSED the earlier keep-a-tab-when-it-dies rule: a session shown alive then dead is now
         # TIMELINE-ONLY — it does NOT linger as a chat tab (reopen from the timeline instead). It still
         # reports 'closed' (so wherever it IS shown — a read-only tab — it renders struck-through).
-        saved_seen, saved_has, saved_kept = set(km._seen_live), km._has_tmux, set(km._kept_open)
-        km._has_tmux = lambda: True
+        saved_seen, saved_has, saved_kept = set(km._seen_live), km._live_source_present, set(km._kept_open)
+        km._live_source_present = lambda: True
         try:
             km._seen_live.clear(); km._seen_live.add(SID); km._kept_open.discard(SID)
             tabs = [s["sid"] for s in km._chat_tab_sessions(NOW, {})]
             self.assertNotIn(SID, tabs, "a dead session no longer auto-keeps a tab (timeline-only)")
             self.assertEqual(km.build_session(SID, NOW, {})["status"]["state"], "closed")
         finally:
-            km._seen_live.clear(); km._seen_live.update(saved_seen); km._has_tmux = saved_has
+            km._seen_live.clear(); km._seen_live.update(saved_seen); km._live_source_present = saved_has
             km._kept_open.clear(); km._kept_open.update(saved_kept)
 
     def test_dead_session_not_kept_when_never_seen_live(self):
         # A fresh kernel start (_seen_live empty) must NOT resurrect a dead session's tab (the Part-A rule).
-        saved_seen, saved_has = set(km._seen_live), km._has_tmux
-        km._has_tmux = lambda: True
+        saved_seen, saved_has = set(km._seen_live), km._live_source_present
+        km._live_source_present = lambda: True
         try:
             km._seen_live.clear()
             tabs = [s["sid"] for s in km._chat_tab_sessions(NOW, {})]
             self.assertNotIn(SID, tabs, "never-seen dead session is not shown on a fresh start")
         finally:
-            km._seen_live.clear(); km._seen_live.update(saved_seen); km._has_tmux = saved_has
+            km._seen_live.clear(); km._seen_live.update(saved_seen); km._live_source_present = saved_has
 
     def test_dead_kept_tab_excluded_once_forgotten(self):
         # ×-closing a dead read-only tab discards it from _kept_open — dead is timeline-only again
         # (the closeTab route's one remaining duty; hidden-tabs is gone, the user 2026-08-11).
-        saved_seen, saved_has, saved_kept = set(km._seen_live), km._has_tmux, set(km._kept_open)
-        km._has_tmux = lambda: True
+        saved_seen, saved_has, saved_kept = set(km._seen_live), km._live_source_present, set(km._kept_open)
+        km._live_source_present = lambda: True
         try:
             km._seen_live.clear(); km._seen_live.add(SID)
             km._kept_open.discard(SID)
             tabs = [s["sid"] for s in km._chat_tab_sessions(NOW, {})]
             self.assertNotIn(SID, tabs, "a forgotten dead tab is not shown")
         finally:
-            km._seen_live.clear(); km._seen_live.update(saved_seen); km._has_tmux = saved_has
+            km._seen_live.clear(); km._seen_live.update(saved_seen); km._live_source_present = saved_has
             km._kept_open.clear(); km._kept_open.update(saved_kept)
 
     def test_rel_ago_buckets(self):
@@ -4166,16 +4171,27 @@ class ViewBuilder(unittest.TestCase):
         self.assertFalse(any(e["kind"] == "tool" and e["name"] in ("TaskCreate", "TaskUpdate") for e in m["events"]),
                          "raw Task* tool calls are folded away, not shown as tool cards")
 
-    def test_queued_card_from_transcript_queue_ops(self):
-        # Messages queued in the TUI while busy/compacting are written to the transcript as queue-operation
-        # records; _pending_queued folds them so they surface as a {kind:"queued"} card at the bottom (the
-        # "vanished during compaction" fix). EVENT-BASED (was pane-scraped) — and BOTH of two queued messages
-        # show: the pane scrape dropped the 2nd and lost both (the user 2026-06-16).
-        km._queued_parse_cache.clear()
-        with self.tpath.open("a") as f:
-            f.write(json.dumps(qop("enqueue", "fix the flaky test")) + "\n")
-            f.write(json.dumps(qop("enqueue", "then bump the version")) + "\n")
-        m = km.build_session(SID, NOW)
+    def test_queued_card_from_the_backends_pending_queue(self):
+        # Messages queued while busy/compacting surface as ONE {kind:"queued"} card at the bottom (the
+        # "vanished during compaction" fix), fed by the backend's pending_queued — and BOTH of two queued
+        # messages show, in submission order (the 2-message regression, the user 2026-06-16).
+        class _QBE:
+            def owns(self, s): return True
+            def pending_queued(self, s): return ["fix the flaky test", "then bump the version"]
+            def live_atoms(self, s): return []
+            def prune_live(self, s, u, t=(), human_floor=0): return None
+            def current_ask(self, s): return None
+            def busy(self, s): return None
+            def compacting(self, s): return None
+            def clearing(self, s): return None
+            def launch_error(self, s): return None
+            def pending_cut(self, s): return ""
+        saved = km._sdk
+        km._sdk = lambda: _QBE()
+        try:
+            m = km.build_session(SID, NOW)
+        finally:
+            km._sdk = saved
         q = [e for e in m["events"] if e["kind"] == "queued"]
         self.assertEqual(len(q), 1, "one queued card")
         self.assertEqual([t["md"] for t in q[0]["texts"]], ["fix the flaky test", "then bump the version"],
@@ -4424,7 +4440,7 @@ class ViewBuilder(unittest.TestCase):
             "nodes": {g: {"id": g, "text": "Work in progress", "parentId": None,
                           "nodeComplete": False, "blocked": False, "cleared": False, "trail": [], "t": NOW - 50}},
             "placements": {}, "status": {g: "working"}}))
-        km._tmux_sessions = lambda: {SID: {"state": "permission", "since": NOW - 30, "model": "",
+        km._live_map = lambda: {SID: {"state": "permission", "since": NOW - 30, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
         self.assertEqual(card["blocked"]["state"], "permission", "a live permission prompt floors the focus card")
@@ -4441,7 +4457,7 @@ class ViewBuilder(unittest.TestCase):
             "nodes": {g: {"id": g, "text": "Work in progress", "parentId": None,
                           "nodeComplete": False, "blocked": False, "cleared": False, "trail": [], "t": NOW - 50}},
             "placements": {}, "status": {g: "working"}}))
-        km._tmux_sessions = lambda: {SID: {"state": "picker", "since": NOW - 30, "model": "",
+        km._live_map = lambda: {SID: {"state": "picker", "since": NOW - 30, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
         self.assertEqual(card["blocked"]["state"], "picker", "a live picker floors the focus card to blocked")
@@ -4455,7 +4471,7 @@ class ViewBuilder(unittest.TestCase):
         """The floor applies only to an OPEN focus goal — a live prompt while the focus is already
         completed (the block is on not-yet-placed new work) leaves the completed card alone."""
         # default store: lastNode = g1 (completed). A permission state must NOT floor g1.
-        km._tmux_sessions = lambda: {SID: {"state": "permission", "since": NOW - 30, "model": "",
+        km._live_map = lambda: {SID: {"state": "permission", "since": NOW - 30, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         comp = next(a for a in km.build_feed(NOW)["asks"] if a["column"] == "completed")
         self.assertIsNone(comp["blocked"], "a completed focus card is not floored by a live prompt")
@@ -4471,7 +4487,7 @@ class ViewBuilder(unittest.TestCase):
             "nodes": {g: {"id": g, "text": "Read the system prompt", "parentId": None,
                           "nodeComplete": True, "blocked": False, "cleared": False, "trail": [], "t": NOW - 50}},
             "placements": {}, "status": {g: "working"}}))
-        km._tmux_sessions = lambda: {SID: {"state": "permission", "since": NOW - 30, "model": "",
+        km._live_map = lambda: {SID: {"state": "permission", "since": NOW - 30, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
         self.assertEqual(card["blocked"]["state"], "permission",
@@ -4508,7 +4524,7 @@ class ViewBuilder(unittest.TestCase):
         (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
             "rompUuid": SID, "seq": 1, "lastNode": g,
             "nodes": {g: nd}, "placements": {}, "status": {g: "blocked"}}))
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         return g
 
@@ -4597,7 +4613,7 @@ class ViewBuilder(unittest.TestCase):
             "rompUuid": SID, "seq": 2, "lastNode": g1,
             "nodes": {g1: nd(g1, followupPending=True), g2: nd(g2)},
             "placements": {}, "status": {g1: "blocked", g2: "blocked"}}))
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         saved = km._last_plain_user_turn_t
         try:
@@ -4621,7 +4637,7 @@ class ViewBuilder(unittest.TestCase):
         (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
             "rompUuid": SID, "seq": 2, "lastNode": sub,
             "nodes": {top: tn, sub: sn}, "placements": {}, "status": {top: "blocked"}}))
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         return top
 
@@ -4673,7 +4689,7 @@ class ViewBuilder(unittest.TestCase):
         # the feed serve a pass-boundary-consistent view: the card holds its pre-pass state for the whole pass,
         # then jumps straight to the post-pass state. (Without the snapshot, the first assert reads live "blocked"
         # and fails — this is the regression guard.)
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         g = self._store_with_status("working")             # PRE-pass state: working
         km._begin_goals_pass()                             # judge pass starts → snapshot the pre-pass stores
@@ -4693,7 +4709,7 @@ class ViewBuilder(unittest.TestCase):
     def test_feed_reads_live_outside_a_judge_pass(self):
         # the snapshot only applies DURING a pass — with no pass active a write shows immediately, so user
         # actions (clear/follow-up) aren't delayed (the user 2026-06-30).
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         g = self._store_with_status("working")
         km._end_goals_pass()                               # ensure no pass snapshot is active
@@ -4727,7 +4743,7 @@ class ViewBuilder(unittest.TestCase):
         # window expired first and toasted "that follow-up didn't move the card to Working" while the session
         # was already working the reply. A user gesture must never wait out a judge pass: the override journal
         # it records is replayed onto the snapshot, so the card flies to Working on the very next build.
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         g = self._settled_store()
         km._begin_goals_pass()                             # a judge pass is already in flight when the user replies
@@ -4749,7 +4765,7 @@ class ViewBuilder(unittest.TestCase):
         # The re-punch is keyed on the user-write MARK, not a once-per-snapshot flag: replying to one card
         # and then another, both inside a single (long) judge pass, must move BOTH. A plain done-flag would
         # have served the first reply and silently swallowed every reply after it for the rest of the pass.
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         ga, gb = self._settled_store("gA", "gB")
         km._begin_goals_pass()
@@ -4771,7 +4787,7 @@ class ViewBuilder(unittest.TestCase):
         # re-open the store to the judges' half-applied writes, which is the whole reason the snapshot exists.
         # Three states are distinguishable here and only one is right: completed (frozen, the bug), needs_input
         # (the planner's transient, the flicker), working (the user's reply on the pre-pass card).
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         g = self._settled_store()
         km._begin_goals_pass()
@@ -4790,7 +4806,7 @@ class ViewBuilder(unittest.TestCase):
         # write racing the read loop must never be the one that gets lost. That is only safe because the
         # replay is idempotent, so pin the property the tie-break leans on: however many builds run, the
         # user's reopen appears in the card's diary exactly ONCE.
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         g = self._settled_store()
         km._end_goals_pass()
@@ -4811,16 +4827,16 @@ class ViewBuilder(unittest.TestCase):
         # buildId is what lets a client tell "this payload predates my click" from "this is the kernel's
         # answer to it" (see _next_feed_build_id / cardMoveAck), so it must advance on every real build and
         # hold steady on a cache hit — otherwise an acked prediction clears against a stale payload.
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         km._built_feed[:] = [None, None, 0.0, 0.0]
         km._views_dirty[0] = 0.0
-        first = km._cached_feed(NOW, km._tmux_sessions(), ("sig", 1))
+        first = km._cached_feed(NOW, km._live_map(), ("sig", 1))
         self.assertIsInstance(first.get("buildId"), int)
-        again = km._cached_feed(NOW, km._tmux_sessions(), ("sig", 1))
+        again = km._cached_feed(NOW, km._live_map(), ("sig", 1))
         self.assertEqual(again["buildId"], first["buildId"], "a cache hit re-sends the SAME build, same id")
         km._views_dirty[0] = time.time()                   # a user write forces a rebuild past the cache
-        third = km._cached_feed(NOW, km._tmux_sessions(), ("sig", 1))
+        third = km._cached_feed(NOW, km._live_map(), ("sig", 1))
         self.assertGreater(third["buildId"], first["buildId"], "a real rebuild advances the id")
 
     def test_seg_key_strips_the_volatile_timestamp(self):
@@ -4851,7 +4867,7 @@ class ViewBuilder(unittest.TestCase):
                           "blocked": False, "cleared": False, "trail": [drifted], "t": NOW - 100,
                           "mt": NOW - 95, "summary": "Wired the overview strip."}},
             "placements": {}, "status": {g: "completed"}}))
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
         self.assertEqual(card["summaryAnchorUuid"], "aReply",
@@ -4870,7 +4886,7 @@ class ViewBuilder(unittest.TestCase):
             "rompUuid": SID, "seq": 2, "lastNode": new,
             "nodes": {old: nd(old, NOW - 1000), new: nd(new, NOW - 10)},
             "placements": {}, "status": {old: "working", new: "working"}}))
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 50, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         saved = km._wait_for_graph
         try:                                              # the question was sent at NOW-500 (between gOld and gNew)
@@ -5044,7 +5060,7 @@ class ViewBuilder(unittest.TestCase):
         # @claude-state says "working" but the fixture's turn ENDED -> chip is ready, not working:
         # working is the stable event-model signal (open turn), not the laggy tmux state (the user's
         # "working shows blue / flickers" regression)
-        km._tmux_sessions = lambda: {SID: {"state": "working", "since": NOW - 5, "model": "Opus 4.8",
+        km._live_map = lambda: {SID: {"state": "working", "since": NOW - 5, "model": "Opus 4.8",
                                            "effort": "max", "context": 30, "compactPct": None, "color": None}}
         self.assertEqual(km.build_session(SID, NOW)["status"]["state"], "ready",
                          "ended turn -> ready even when tmux says working")
@@ -5063,11 +5079,11 @@ class ViewBuilder(unittest.TestCase):
         # _reveal_chat_for since 2026-07-29: the reveal is aimed at the dashboard that asked (its wid),
         # so a jump in one window no longer drags every other open one to the same turn. With no client
         # in scope it still broadcasts, which is the path this exercises.
-        cap, orig_rc, orig_tx, orig_pa = [], km._reveal_chat_for, km._tmux_sessions, km._push_all
+        cap, orig_rc, orig_tx, orig_pa = [], km._reveal_chat_for, km._live_map, km._push_all
         try:
             km._reveal_chat_for = lambda c, m: cap.append(m)
             km._push_all = lambda: None
-            km._tmux_sessions = lambda: {SID: {}}            # SID alive; deadsid000 dead
+            km._live_map = lambda: {SID: {}}            # SID alive; deadsid000 dead
             cap.clear(); km._open_or_revive("deadsid000")
             self.assertEqual([m["type"] for m in cap], ["confirmRevive"])
             self.assertEqual(cap[0]["id"], "deadsid000")
@@ -5080,28 +5096,44 @@ class ViewBuilder(unittest.TestCase):
             live_focus = next(m for m in cap if m.get("type") == "focus" and m.get("id") == SID)
             self.assertTrue(live_focus.get("live"), "live open lands the chat on its live tail (the picker prompt)")
         finally:
-            km._reveal_chat_for = orig_rc; km._tmux_sessions = orig_tx; km._push_all = orig_pa
+            km._reveal_chat_for = orig_rc; km._live_map = orig_tx; km._push_all = orig_pa
 
     def test_revive_session_resumes(self):
-        # confirming the modal's "Revive" must actually resume the session. The kernel owns the resume
-        # now (`romp <name> --resume <sid> --detach`): the old `romp-postal-service revive` subcommand
-        # was REMOVED in 2b5e181 but _revive_session kept shelling it — the CLI exits 0 on unknown
-        # commands with output DEVNULL'd, so the picker's Revive silently did nothing (the user
-        # 2026-07-05). Full coverage: tests/test_kernel_revive.py.
+        # confirming the modal's "Revive" must actually resume the session — through the SDK backend
+        # for EVERY sid now (the user 2026-08-16, retiring the terminal backend). A sid with no SDK
+        # registry entry (a pre-SDK session) is ADOPTED: the backend's own resume() mints the reg from
+        # the recorded name/dir and the transcript on disk, so dead sessions keep reviving with their
+        # history. The old path shelled `bin/romp resume ... --detach` (itself the fix for the
+        # 2b5e181 `romp-postal-service revive` silent no-op, the user 2026-07-05) — a revive must
+        # never shell out or spawn a terminal session again. Full coverage: tests/test_kernel_revive.py.
         import subprocess as _sp
-        calls, saved = [], km.subprocess.run
+        calls, shelled = [], []
+
+        class _Be:
+            def owns(self, sid):
+                return False                     # no reg → the adopt path
+
+            def resume(self, name, sid, cwd=None):
+                calls.append(("resume", name, sid))
+                return True
+
+            def connect(self, sid):
+                calls.append(("connect", sid))
+                return True
+
+        saved = km.subprocess.run, km._sdk, km._path_of
         km.subprocess.run = (lambda *a, **k:
-                             calls.append(list(a[0])) or _sp.CompletedProcess(a[0], 0, "", ""))
+                             shelled.append(list(a[0])) or _sp.CompletedProcess(a[0], 0, "", ""))
+        km._sdk = lambda: _Be()
+        km._path_of = lambda sid, now=None, window=None: "/tmp/synthetic/%s.jsonl" % sid
         try:
             km._revive_session("deadsid000")
         finally:
-            km.subprocess.run = saved
-        self.assertTrue(calls, "revive must shell out to the resume path")
-        argv = calls[0]
-        self.assertTrue(str(argv[0]).endswith("/romp"),
-                        "the kernel owns the resume (bin/romp), never the removed postal subcommand")
-        # --name pins the recorded name; this fixture has none, so _name_of falls back to the sid
-        self.assertEqual(argv[1:], ["resume", "deadsid000", "--name", "deadsid000", "--detach"])
+            km.subprocess.run, km._sdk, km._path_of = saved
+        # the recorded name pins the reg; this fixture has none, so _name_of falls back to the sid
+        self.assertEqual(calls, [("resume", "deadsid000", "deadsid000"), ("connect", "deadsid000")],
+                         "a reg-less sid adopts-and-resumes through the SDK backend")
+        self.assertEqual(shelled, [], "no shell-out: revive never spawns a terminal session")
 
     def test_split_reminders(self):
         p, r = km._split_reminders("do the thing <system-reminder>be careful</system-reminder> now")
@@ -5162,20 +5194,20 @@ class ViewBuilder(unittest.TestCase):
         # mode has no event source to self-heal from — _cycle_mode must record the mode it just cycled to,
         # or the var stays frozen (and the next press count is computed from a stale `cur`).
         calls, saved_run, saved_sleep = [], km.subprocess.run, km.time.sleep
-        saved_tmux, saved_thread, saved_push = km._tmux_sessions, km.threading.Thread, km._push_all
+        saved_tmux, saved_thread, saved_push = km._live_map, km.threading.Thread, km._push_all
         class _SyncThread:                                  # run go() inline so the test sees the result
             def __init__(self, target=None, daemon=None): self._t = target
             def start(self): self._t()
         km.subprocess.run = lambda args, **k: calls.append(list(args)) or type("R", (), {"stdout": ""})()
         km.time.sleep = lambda *_a, **_k: None
-        km._tmux_sessions = lambda: {SID: {"mode": "auto"}}   # current mode is auto
+        km._live_map = lambda: {SID: {"mode": "auto"}}   # current mode is auto
         km.threading.Thread = _SyncThread
         km._push_all = lambda: calls.append(["__push_all__"])
         try:
             km._cycle_mode("mysess", SID, "plan")
         finally:
             km.subprocess.run, km.time.sleep = saved_run, saved_sleep
-            km._tmux_sessions, km.threading.Thread, km._push_all = saved_tmux, saved_thread, saved_push
+            km._live_map, km.threading.Thread, km._push_all = saved_tmux, saved_thread, saved_push
         btab = [c for c in calls if c[:2] == ["tmux", "send-keys"] and "BTab" in c]
         self.assertEqual(len(btab), 3, "auto → plan is 3 shift+tab presses")
         self.assertIn(["tmux", "set", "-t", "mysess", "@claude-permission-mode", "plan"], calls,
@@ -5187,9 +5219,9 @@ class ViewBuilder(unittest.TestCase):
         # the TUI gives us, so a tmux session cannot reach bypassPermissions/dontAsk at all — and
         # set_mode used to return True regardless, telling the caller a permission mode had been set
         # when _cycle_mode had already declined it. Refuse, so the kernel can say so.
-        saved_tmux, saved_cycle = km._tmux_sessions, km._cycle_mode
+        saved_tmux, saved_cycle = km._live_map, km._cycle_mode
         cycled = []
-        km._tmux_sessions = lambda: {SID: {"mode": "auto"}}
+        km._live_map = lambda: {SID: {"mode": "auto"}}
         km._cycle_mode = lambda name, sid, target: cycled.append(target)
         try:
             be = km.TmuxBackend()
@@ -5200,7 +5232,7 @@ class ViewBuilder(unittest.TestCase):
                 self.assertTrue(be.set_mode(SID, m), "every cycle mode still goes through: %s" % m)
             self.assertEqual(cycled, list(km._MODE_CYCLE))
         finally:
-            km._tmux_sessions, km._cycle_mode = saved_tmux, saved_cycle
+            km._live_map, km._cycle_mode = saved_tmux, saved_cycle
 
     def test_recency_colormap_chooser(self):
         # the colormap chooser (the user 2026-06-16): several perceptually-uniform maps + a persisted pick.
@@ -5529,10 +5561,10 @@ class ViewBuilder(unittest.TestCase):
         once and keeps its slot even when its mtime later jumps ahead (the user 2026-06-15)."""
         saved = km._alive_sessions
         try:
-            km._alive_sessions = lambda now, tmux: [{"sid": "A", "mtime": 100}, {"sid": "B", "mtime": 50}]
+            km._alive_sessions = lambda now, live_map: [{"sid": "A", "mtime": 100}, {"sid": "B", "mtime": 50}]
             first = [s["sid"] for s in km._ordered_alive(NOW, {})]
             # B now becomes the most-recently-active (its mtime jumps past A) — the order must NOT change
-            km._alive_sessions = lambda now, tmux: [{"sid": "A", "mtime": 100}, {"sid": "B", "mtime": 999}]
+            km._alive_sessions = lambda now, live_map: [{"sid": "A", "mtime": 100}, {"sid": "B", "mtime": 999}]
             second = [s["sid"] for s in km._ordered_alive(NOW, {})]
             self.assertEqual(first, ["A", "B"], "new sessions frozen newest-active-first, once")
             self.assertEqual(second, first, "activity (mtime) must not reorder existing lanes/tabs")
@@ -5545,7 +5577,7 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(km._session_order(), ["b", "a", "c"])
         fake = [{"sid": "a", "mtime": 3}, {"sid": "b", "mtime": 2}, {"sid": "c", "mtime": 1}]
         saved = km._alive_sessions
-        km._alive_sessions = lambda now, tmux: list(fake)
+        km._alive_sessions = lambda now, live_map: list(fake)
         try:
             self.assertEqual([s["sid"] for s in km._ordered_alive(NOW, {})], ["b", "a", "c"],
                              "living sessions follow the saved shared order")
@@ -5604,7 +5636,7 @@ class ViewBuilder(unittest.TestCase):
         km._parse_cache.clear()
         self.assertTrue(km._session_working(em.parse_session(str(self.tpath), rompuuid=SID,
                         candidate_files=[str(self.tpath)], now=NOW)["turns"]), "fixture IS working by the event model")
-        km._tmux_sessions = lambda: {}                   # DEAD: not in the live map
+        km._live_map = lambda: {}                   # DEAD: not in the live map
         m = km.build_timeline(NOW)
         lane = next(s for s in m["sessions"] if s["id"] == SID)
         self.assertFalse(lane["live"], "session is dead (not in tmux)")
@@ -5632,7 +5664,7 @@ class ViewBuilder(unittest.TestCase):
     def test_retrying_state_maps_to_retrying_chip(self):
         """An SDK session stalled in an api_retry storm publishes state 'retrying'; the chat chip surfaces
         it distinctly (not 'working'), so the user sees it's an API issue, not a hang (the user 2026-06-23)."""
-        km._tmux_sessions = lambda: {SID: {"state": "retrying", "since": NOW - 5, "model": "Opus 4.8",
+        km._live_map = lambda: {SID: {"state": "retrying", "since": NOW - 5, "model": "Opus 4.8",
                                            "effort": "high", "context": None, "compactPct": None,
                                            "color": None, "backend": "sdk"}}
         self.assertEqual(km.build_session(SID, NOW)["status"]["state"], "retrying")
@@ -5685,29 +5717,55 @@ class ViewBuilder(unittest.TestCase):
     def test_createSession_sdk_backend_unavailable_warns_instead_of_tmux_fallback(self):
         """The user asked for an SDK session on a kernel without the SDK venv and got a MYSTERY TMUX session
         instead (TESTHOST, 2026-07-02) — the handler silently fell through to _spawn_session. Now it warns
-        (naming bin/romp-sdk-setup) and creates nothing."""
-        saved_sdk, saved_spawn, saved_tmux = km._sdk, km._spawn_session, km._tmux_sessions
-        km._sdk = lambda: None                               # the backend is unavailable (no venv / py<3.10)
-        spawned = []
-        km._spawn_session = lambda nm, cwd: spawned.append(nm)
-        km._tmux_sessions = lambda: {}
+        (naming bin/romp-sdk-setup) and creates nothing. Pinned for BOTH request shapes: an explicit
+        backend:"sdk" and a MISSING backend field, which means the SDK too (the user 2026-08-16: the
+        SDK is the one backend, so an old client sending nothing must not land anywhere else)."""
+        for extra in ({"backend": "sdk"}, {}):
+            saved_sdk, saved_spawn, saved_tmux = km._sdk, km._spawn_session, km._live_map
+            km._sdk = lambda: None                           # the backend is unavailable (no venv / py<3.10)
+            spawned = []
+            km._spawn_session = lambda nm, cwd: spawned.append(nm)
+            km._live_map = lambda: {}
+            sent = []
+            client = {"send": lambda s: sent.append(json.loads(s)), "app": "chat"}
+            try:
+                km.Handler._dispatch_ws(None, {"type": "createSession", "name": "sdlkless", **extra}, client)
+                time.sleep(0.05)                             # were a spawn wrongly threaded, give it a beat
+            finally:
+                km._sdk, km._spawn_session, km._live_map = saved_sdk, saved_spawn, saved_tmux
+            warn = next((m for m in sent if m.get("type") == "warn"), None)
+            self.assertIsNotNone(warn, "the client is told, not silently given a different backend (%r)" % (extra,))
+            self.assertIn("romp-sdk-setup", warn["text"], "the warn names the fix")
+            self.assertEqual(spawned, [], "no fallback session is created (%r)" % (extra,))
+
+    def test_createSession_backend_tmux_is_a_named_refusal(self):
+        """backend:"tmux" from an old client / stale stored setting → a warn NAMING the removal, and
+        nothing created on any backend (the user 2026-08-16; the POST /new twin is
+        NewSessionRoute.test_backend_tmux_is_a_named_refusal_not_a_spawn)."""
+        saved = km._spawn_session, km._create_sdk_session, km._live_map
+        created = []
+        km._spawn_session = lambda nm, cwd=None: created.append(("tmux", nm))
+        km._create_sdk_session = lambda nm, cwd, auth="": created.append(("sdk", nm))
+        km._live_map = lambda: {}
         sent = []
         client = {"send": lambda s: sent.append(json.loads(s)), "app": "chat"}
         try:
-            km.Handler._dispatch_ws(None, {"type": "createSession", "name": "sdlkless", "backend": "sdk"}, client)
-            time.sleep(0.05)                                 # the tmux path spawns on a thread — give it a beat
+            km.Handler._dispatch_ws(None, {"type": "createSession", "name": "term1", "backend": "tmux",
+                                           "dir": tempfile.gettempdir()}, client)
+            time.sleep(0.05)                                 # were a spawn wrongly threaded, give it a beat
         finally:
-            km._sdk, km._spawn_session, km._tmux_sessions = saved_sdk, saved_spawn, saved_tmux
+            km._spawn_session, km._create_sdk_session, km._live_map = saved
         warn = next((m for m in sent if m.get("type") == "warn"), None)
-        self.assertIsNotNone(warn, "the client is told, not silently given a different backend")
-        self.assertIn("romp-sdk-setup", warn["text"], "the warn names the fix")
-        self.assertEqual(spawned, [], "no tmux fallback session is created")
+        self.assertIsNotNone(warn, "the client hears the refusal")
+        self.assertIn("removed", warn["text"], "the refusal names WHY: the terminal backend is gone")
+        self.assertIn("not created", warn["text"])
+        self.assertEqual(created, [], "no session on any backend — a refusal, not a redirect")
 
     def test_timeline_state_and_metadata_from_tmux(self):
         # live lanes take model/effort/context from tmux @claude-* vars; the STATE is the shared
         # _session_chip derivation (the user 2026-07-03) — an idle tmux 'waiting' reads as chip 'ready'.
         # badgeFor hides the badge unless live, so live must be true here
-        km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": NOW - 10, "model": "Opus 4.8",
+        km._live_map = lambda: {SID: {"state": "waiting", "since": NOW - 10, "model": "Opus 4.8",
                                            "effort": "xhigh", "context": 43, "compactPct": None,
                                            "color": "#abcdef"}}
         lane = next(s for s in km.build_timeline(NOW)["sessions"] if s["id"] == SID)
@@ -5722,7 +5780,7 @@ class ViewBuilder(unittest.TestCase):
         # lane sat on raw-snapshot 'working' — two derivations of one fact. Both surfaces now call the
         # shared _session_chip, so under ANY backend snapshot they read the SAME state: tmux claims
         # 'working' here, but the transcript's turn ENDED → both say 'ready', together.
-        km._tmux_sessions = lambda: {SID: {"state": "working", "since": NOW - 10, "model": "", "effort": "",
+        km._live_map = lambda: {SID: {"state": "working", "since": NOW - 10, "model": "", "effort": "",
                                            "context": None, "compactPct": None, "color": None}}
         lane = next(s for s in km.build_timeline(NOW)["sessions"] if s["id"] == SID)
         chip = km.build_session(SID, NOW)["status"]["state"]
@@ -5783,9 +5841,9 @@ class ViewBuilder(unittest.TestCase):
             def live_atoms(self, sid): return list(self.atoms)
             def prune_live(self, *a, **k): pass
             def __getattr__(self, n): return getattr(self._inner, n)
-        saved_bf, saved_tmux = km.Sessions.backend_for, km._tmux_sessions
+        saved_bf, saved_tmux = km.Sessions.backend_for, km._live_map
         fake = _FakeBE(saved_bf(SID))
-        km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": NOW - 10, "model": "", "effort": "",
+        km._live_map = lambda: {SID: {"state": "waiting", "since": NOW - 10, "model": "", "effort": "",
                                            "context": None, "compactPct": None, "color": None}}
         try:
             km.Sessions.backend_for = lambda sid: fake
@@ -5801,14 +5859,14 @@ class ViewBuilder(unittest.TestCase):
                              "both surfaces fall back to the disk truth together")
         finally:
             km.Sessions.backend_for = saved_bf
-            km._tmux_sessions = saved_tmux
+            km._live_map = saved_tmux
 
     def test_timeline_includes_dead_sessions_for_scrollback(self):
         # the user 2026-06-16: dead sessions appear as struck lanes so scrolling back surfaces them. The
         # regression was build_timeline feeding only LIVING sessions; it now includes window-dead ones
         # too (the render's active-filter only shows a dead lane when the window covers its activity).
         # SID has a transcript but is passed NO tmux → it must still be a lane, marked dead.
-        s = {x["id"]: x for x in km.build_timeline(NOW, tmux={})["sessions"]}
+        s = {x["id"]: x for x in km.build_timeline(NOW, live_map={})["sessions"]}
         self.assertIn(SID, s, "a window-dead session is still a timeline lane")
         self.assertFalse(s[SID]["live"], "no tmux → a dead lane (the render strikes it)")
 
@@ -5816,7 +5874,7 @@ class ViewBuilder(unittest.TestCase):
         # the user 2026-07-03: while a /model switch resolves, BOTH the chat chip and the timeline lane
         # show switching-dots — so the SDK snapshot's modelPending must reach both surfaces (the kernel
         # merges it in Sessions.live() and passes it through build_session + build_timeline).
-        km._tmux_sessions = lambda: {SID: {"state": "working", "since": NOW - 10, "model": "Fable 5",
+        km._live_map = lambda: {SID: {"state": "working", "since": NOW - 10, "model": "Fable 5",
                                            "effort": "high", "context": 20, "compactPct": None,
                                            "color": None, "modelPending": True}}
         st = km.build_session(SID, NOW)["status"]
@@ -5824,7 +5882,7 @@ class ViewBuilder(unittest.TestCase):
         lane = next(s for s in km.build_timeline(NOW)["sessions"] if s["id"] == SID)
         self.assertTrue(lane.get("modelPending"), "the timeline lane carries it too")
         # a snapshot without the key must not crash and reads False (tmux sessions never set it)
-        km._tmux_sessions = lambda: {SID: {"state": "working", "since": NOW - 10, "model": "Opus 4.8",
+        km._live_map = lambda: {SID: {"state": "working", "since": NOW - 10, "model": "Opus 4.8",
                                            "effort": "high", "context": 20, "compactPct": None, "color": None}}
         self.assertFalse(km.build_session(SID, NOW)["status"].get("modelPending"))
 
@@ -5839,7 +5897,7 @@ class ViewBuilder(unittest.TestCase):
         saved_push, km._push_all = km._push_all, lambda: None
         try:
             km._model_switch_pending.clear()
-            km._tmux_sessions = lambda: {SID: {"state": "working", "since": NOW - 10, "model": "Haiku",
+            km._live_map = lambda: {SID: {"state": "working", "since": NOW - 10, "model": "Haiku",
                                                "effort": "high", "context": 20, "compactPct": None, "color": None}}
             fake_be = types.SimpleNamespace(set_model=lambda sid, value: None)
             km._set_model_or_park(fake_be, SID, "opus")   # accepted, from EITHER surface — same call either way
@@ -5848,7 +5906,7 @@ class ViewBuilder(unittest.TestCase):
             lane = next(s for s in km.build_timeline(NOW)["sessions"] if s["id"] == SID)
             self.assertTrue(lane.get("modelPending"), "…and so does the timeline lane, from the SAME stamp")
             # the live tmux model now reflects the pick (a later poll) → the signal clears on BOTH surfaces
-            km._tmux_sessions = lambda: {SID: {"state": "working", "since": NOW - 10, "model": "Opus 4.8",
+            km._live_map = lambda: {SID: {"state": "working", "since": NOW - 10, "model": "Opus 4.8",
                                                "effort": "high", "context": 20, "compactPct": None, "color": None}}
             self.assertFalse(km.build_session(SID, NOW)["status"].get("modelPending"), "cleared once the name lands")
         finally:
@@ -5888,7 +5946,7 @@ class ViewBuilder(unittest.TestCase):
         # the timeline is a complete activity history (the user 2026-06-17): a dead session within the
         # lane window is still a struck lane, with no tab needed. (The ×-hidden variant of this pin died
         # with hidden tabs, the user 2026-08-11 — there is no tab state that could erase a lane anymore.)
-        s = {x["id"]: x for x in km.build_timeline(NOW, tmux={})["sessions"]}
+        s = {x["id"]: x for x in km.build_timeline(NOW, live_map={})["sessions"]}
         self.assertIn(SID, s, "a dead session in-window is STILL a timeline lane")
         self.assertFalse(s[SID]["live"], "and it's a dead (struck) lane")
 
@@ -5898,13 +5956,13 @@ class ViewBuilder(unittest.TestCase):
         saved = set(km._kept_open)
         # tmux={} is AMBIGUOUS to _alive_sessions: "zero live sessions" (trust it, show nothing) vs
         # "no tmux here at all" (headless → fall back to every file-derived session). It disambiguates
-        # with _has_tmux(), i.e. whether a tmux BINARY exists on the machine running the tests. Left
+        # with _live_source_present(), i.e. whether a tmux BINARY exists on the machine running the tests. Left
         # inherited, this test therefore asserts the opposite thing on a box without tmux: the fallback
         # fires, SID comes back alive, and "not auto-kept as a tab" fails. Ubuntu runners ship tmux and
         # macOS runners do not, so it passed on Linux CI and failed on macOS CI. Pin it: this test is
         # about _kept_open in a tmux-capable environment, not about the headless fallback.
-        saved_has = km._has_tmux
-        km._has_tmux = lambda: True
+        saved_has = km._live_source_present
+        km._live_source_present = lambda: True
         try:
             km._kept_open.discard(SID)
             tabs = lambda: {x["sid"] for x in km._chat_tab_sessions(NOW, {})}   # tmux={} → SID is dead
@@ -5914,27 +5972,27 @@ class ViewBuilder(unittest.TestCase):
             km._kept_open.discard(SID)                   # ×-close
             self.assertNotIn(SID, tabs(), "×-close forgets it → timeline-only again")
         finally:
-            km._has_tmux = saved_has
+            km._live_source_present = saved_has
             km._kept_open.clear(); km._kept_open.update(saved)
 
     def test_headless_box_falls_back_to_file_derived_sessions(self):
         """The other side of that ambiguity, which nothing covered: with NO tmux binary, an empty tmux
         map means headless, not 'zero sessions', so surfaces fall back to file-derived sessions rather
         than going blank. This is what made the test above machine-dependent, so pin both directions."""
-        saved_has = km._has_tmux
+        saved_has = km._live_source_present
         try:
-            km._has_tmux = lambda: False
+            km._live_source_present = lambda: False
             self.assertIn(SID, {s["sid"] for s in km._alive_sessions(NOW, {})},
                           "no tmux at all → fall back so a headless box isn't blank")
-            km._has_tmux = lambda: True
+            km._live_source_present = lambda: True
             self.assertNotIn(SID, {s["sid"] for s in km._alive_sessions(NOW, {})},
                              "tmux present + empty result → a genuine zero, show nothing")
         finally:
-            km._has_tmux = saved_has
+            km._live_source_present = saved_has
 
     def test_chat_chip_maps_tmux_state(self):
         # the chat chip maps tmux state: permission -> awaiting, plus model/effort/ctx for the statusline
-        km._tmux_sessions = lambda: {SID: {"state": "permission", "since": NOW - 5, "model": "Opus 4.8",
+        km._live_map = lambda: {SID: {"state": "permission", "since": NOW - 5, "model": "Opus 4.8",
                                            "effort": "max", "context": 20, "compactPct": None, "color": None}}
         st = km.build_session(SID, NOW)["status"]
         self.assertEqual(st["state"], "needsInput", "permission -> the needs-input chip (renamed 2026-08-15)")
@@ -6514,9 +6572,10 @@ class ServeSecurity(unittest.TestCase):
 
 class NewSessionRoute(unittest.TestCase):
     """POST /new — `romp new` (2026-07-25): the WS createSession op as a one-shot token-gated POST.
-    SDK is the default backend and there is NO silent fallback: an unavailable SDK answers ok:false
-    with the remedy; backend "tmux" threads the same _spawn_session the WS op uses. Runs the REAL
-    handler over loopback with the spawn/SDK seams patched (never a real session from a test)."""
+    The SDK is the one backend (missing/empty backend field means it) and every failure is a LOUD
+    ok:false with the reason: an unavailable SDK names the remedy, and backend "tmux" — still sent
+    by old clients — names the removal (the user 2026-08-16) instead of creating anything. Runs the
+    REAL handler over loopback with the spawn/SDK seams patched (never a real session from a test)."""
 
     @classmethod
     def setUpClass(cls):
@@ -6557,6 +6616,11 @@ class NewSessionRoute(unittest.TestCase):
         self.assertIn("directory not found", body["error"])
 
     def test_sdk_unavailable_never_falls_back_to_tmux(self):
+        # The loud-refusal pin: a request with NO backend field means the SDK (the one backend), and
+        # an unavailable SDK answers ok:false + the remedy — never a silent spawn of something else.
+        # The name keeps the history: this door once fell through to a mystery tmux session; the
+        # terminal backend is gone now (the user 2026-08-16), so the only right answer left is the
+        # refusal.
         saved_sdk, saved_live = km._sdk, km._live_names
         km._sdk, km._live_names = (lambda: None), (lambda t: {})
         try:
@@ -6564,7 +6628,7 @@ class NewSessionRoute(unittest.TestCase):
         finally:
             km._sdk, km._live_names = saved_sdk, saved_live
         self.assertEqual(code, 200)
-        self.assertFalse(body["ok"], "no silent tmux session when the SDK is missing")
+        self.assertFalse(body["ok"], "no silent session on any backend when the SDK is missing")
         # asserted by MEANING, not by the old phrasing: nothing was created, and the one command that
         # fixes it is named (the user 2026-07-28 — "SDK backend unavailable" named nothing to do)
         self.assertIn("not created", body["error"])
@@ -6598,23 +6662,27 @@ class NewSessionRoute(unittest.TestCase):
         self.assertEqual(code, 200)
         self.assertEqual((body["ok"], body["existing"], body["id"]), (True, True, "sid-existing"))
 
-    def test_tmux_backend_threads_the_spawn(self):
-        calls = []
-        saved_spawn, saved_live = km._spawn_session, km._live_names
-        km._spawn_session, km._live_names = (lambda nm, cwd=None: calls.append((nm, cwd))), (lambda t: {})
+    def test_backend_tmux_is_a_named_refusal_not_a_spawn(self):
+        """The terminal backend is gone but the FIELD lives forever — old clients and stale stored
+        settings still send backend:"tmux" (the user 2026-08-16). The answer must be a NAMED refusal:
+        what was removed, and that nothing was created — never a silent drop, and never a session on
+        a backend the caller didn't ask for (the 2026-07-28 mystery-spawn class)."""
+        created = []
+        saved = km._spawn_session, km._create_sdk_session, km._live_names
+        km._spawn_session = lambda nm, cwd=None: created.append(("tmux", nm))
+        km._create_sdk_session = lambda nm, cwd, auth="": created.append(("sdk", nm)) or "sid-x"
+        km._live_names = lambda t: {}
         try:
             code, body = self._post({"name": "term1", "dir": tempfile.gettempdir(),
                                      "backend": "tmux"})
-            for _ in range(100):                     # the spawn is threaded — wait for it
-                if calls:
-                    break
-                time.sleep(0.05)
+            time.sleep(0.1)                      # were a spawn wrongly threaded, let it record itself
         finally:
-            km._spawn_session, km._live_names = saved_spawn, saved_live
+            km._spawn_session, km._create_sdk_session, km._live_names = saved
         self.assertEqual(code, 200)
-        self.assertTrue(body["ok"] and body.get("pending"))
-        self.assertEqual(len(calls), 1)
-        self.assertEqual(calls[0][0], "term1")
+        self.assertFalse(body["ok"], "the session is NOT created")
+        self.assertIn("not created", body["error"])
+        self.assertIn("removed", body["error"], "the refusal names WHY: the terminal backend is gone")
+        self.assertEqual(created, [], "no session on any backend — a refusal, not a redirect")
 
 
 class HostSuspend(unittest.TestCase):
@@ -6716,22 +6784,22 @@ class HostSuspend(unittest.TestCase):
 
 class SessionListNameCollision(unittest.TestCase):
     """Regression (the user 2026-06-22): two functions were both named _session_list — the picker payload
-    builder _session_list(now, tmux) and a 0-arg tmux query for GET /sessions (commit 7b89bd9). The 0-arg
+    builder _session_list(now, live_map) and a 0-arg tmux query for GET /sessions (commit 7b89bd9). The 0-arg
     def came LATER, so it SHADOWED the picker's. The webview's `requestSessions` handler calls it with two
     args → TypeError → the WS handler thread died → the socket dropped → the client reconnected and BLANKED
     the chat (wiping the half-typed new-session name), and the picker dropdown showed NO existing sessions.
     Fix: the GET /sessions query is its OWN distinct 0-arg name (now _session_rows). Guard the re-collision."""
 
-    def test_picker_session_list_keeps_its_now_tmux_signature(self):
+    def test_picker_session_list_keeps_its_now_live_map_signature(self):
         import inspect
         params = inspect.signature(km._session_list).parameters
-        self.assertEqual(list(params)[:2], ["now", "tmux"],
-                         "the picker payload builder must stay callable as _session_list(now, tmux) — requestSessions calls it that way")
+        self.assertEqual(list(params)[:2], ["now", "live_map"],
+                         "the picker payload builder must stay callable as _session_list(now, live_map) — requestSessions calls it that way")
         # Anything AFTER those two must be optional (`window`, the 30-day deep list, 2026-07-24), so the
         # bare two-arg call the handler makes can never become a TypeError again — which is what this
         # regression is really about. A 0-arg def shadowing it still fails the first assert.
         self.assertTrue(all(p.default is not inspect.Parameter.empty for p in list(params.values())[2:]),
-                        "extra picker params must carry defaults, so _session_list(now, tmux) keeps working")
+                        "extra picker params must carry defaults, so _session_list(now, live_map) keeps working")
 
     def test_session_rows_is_a_distinct_zero_arg_function(self):
         import inspect
@@ -6740,7 +6808,7 @@ class SessionListNameCollision(unittest.TestCase):
                          "_session_rows is the 0-arg unified (tmux+SDK) query GET /sessions serves")
 
     def test_requestSessions_call_shape_does_not_raise_typeerror(self):
-        # exactly how the WS handler invokes it (now, tmux) — must NOT TypeError (the shadowing bug), and the
+        # exactly how the WS handler invokes it (now, live_map) — must NOT TypeError (the shadowing bug), and the
         # result is the list shape renderPicker consumes. Empty fixture dir → [] is fine; we only guard the call.
         items = km._session_list(int(time.time()), {})
         self.assertIsInstance(items, list, "the picker payload is a list of session rows")
@@ -6973,8 +7041,8 @@ class SessionOrderStable(unittest.TestCase):
         # _chat_tab_sessions/_timeline_sessions now read _alive_sessions directly and order via _ordered
         # (the session-order refactor, 15f5037) — stub THAT for the live list; _ordered_alive is no longer
         # on their path. B has DIED → only A, C live, in persisted order.
-        km._alive_sessions = lambda now, tmux: [A, C]
-        km._ordered_alive = lambda now, tmux: [A, C]
+        km._alive_sessions = lambda now, live_map: [A, C]
+        km._ordered_alive = lambda now, live_map: [A, C]
         return A, B, C
 
     def test_dead_timeline_lane_keeps_its_slot(self):
@@ -6989,21 +7057,67 @@ class SessionOrderStable(unittest.TestCase):
         self.assertEqual(got, ["A", "B", "C"], "kept-open dead tab keeps its slot, same stable key as the timeline")
 
 
-class TmuxInputEcho(unittest.TestCase):
-    """Optimistic input echo for tmux sends (the user via bugs 2026-06-25): the SDK backend echoes a
-    composer message instantly, but tmux had none — a send whose Enter dropped at the pane prompt was
-    INVISIBLE in the web chat, so the user thought they'd replied. _merge_live_atoms now also merges a
-    kernel-side _tmux_echo for tmux sids: a successful send's echo prunes when the real user turn writes;
-    a DROPPED send's echo PERSISTS so the lost message stays visible. Synthetic only."""
+
+def _echo_stub(km, sid, *texts, author="human"):
+    """Install a stub backend owning `sid` whose live_atoms are optimistic input echoes for `texts` —
+    the SessionBackend seam every backend feeds _merge_live_atoms through. Returns a restore fn."""
+    atoms = [{"type": "user", "uuid": "echo:%d" % i, "session_id": sid, "t": int(time.time()),
+              "parentUuid": None, "author": author, "_echo_text": t,
+              "message": {"role": "user", "content": [{"type": "text", "text": t}]}} for i, t in enumerate(texts)]
+
+    class _BE:
+        def owns(self, s): return s == sid
+        def live_atoms(self, s): return list(atoms) if s == sid else []
+        def prune_live(self, s, tx_uuids, tx_user_texts=(), human_floor=0): return None
+        def pending_queued(self, s): return []
+        def current_ask(self, s): return None
+        def busy(self, s): return None
+        def compacting(self, s): return None
+        def clearing(self, s): return None
+        def launch_error(self, s): return None
+        def pending_cut(self, s): return ""
+    saved = km._sdk
+    be = _BE()
+    km._sdk = lambda: be
+
+    def restore():
+        km._sdk = saved
+    return restore
+
+
+class InputEchoMerge(unittest.TestCase):
+    """Optimistic input echo (the user via bugs 2026-06-25): a composer send echoes instantly, ahead
+    of the transcript on disk, through the backend's live_atoms — and _merge_live_atoms (shared kernel
+    code, whatever backend feeds it) dedups the echo against the landed atom, suppresses it while
+    queued, keeps a dropped send visible, and never lets a lone echo reopen an ended turn. Driven
+    through a stub backend at the SessionBackend seam. Synthetic only."""
 
     def setUp(self):
         self._saved_sdk = km._sdk
-        km._sdk = lambda: None                 # tmux path: no SDK backend owns the sid
-        km._tmux_echo.clear()
+        self.echoes = {}                       # key -> synthetic user atom (the stub backend's store)
+        outer = self
+
+        class _BE:
+            def owns(self, s): return True
+            def live_atoms(self, s): return list(outer.echoes.values())
+            def prune_live(self, s, tx_uuids, tx_user_texts=(), human_floor=0):
+                # land-based retirement only (uuid or text): a dropped send's echo must PERSIST so the
+                # lost message stays visible — the merge owns suppression, the backend owns retirement
+                for k in [k for k, a in list(outer.echoes.items())
+                          if a.get("uuid") in tx_uuids
+                          or (a.get("_echo_text") and a["_echo_text"] in tx_user_texts)]:
+                    outer.echoes.pop(k, None)
+        be = _BE()
+        km._sdk = lambda: be
 
     def tearDown(self):
         km._sdk = self._saved_sdk
-        km._tmux_echo.clear()
+
+    def _echo_add(self, text, author="human"):
+        key = "echo:%d" % len(self.echoes)
+        self.echoes[key] = {"type": "user", "uuid": key, "session_id": SID, "t": int(time.time()),
+                            "parentUuid": None, "author": author, "_echo_text": text,
+                            "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
 
     def _session(self, atoms):
         return {"turns": [{"id": "t", "trigger": None, "t": T0, "end": T0, "ended": True, "atoms": atoms}]}
@@ -7013,26 +7127,26 @@ class TmuxInputEcho(unittest.TestCase):
                 "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
 
     def test_echo_shows_instantly_before_the_transcript_has_it(self):
-        km._tmux_echo_add(SID, "restart Obsidian and I'll check")
+        self._echo_add("restart Obsidian and I'll check")
         merged = km._merge_live_atoms(self._session([self._real_user("earlier")]), SID)
         texts = [km._atom_user_text(a) for a in merged["turns"][-1]["atoms"]]
-        self.assertIn("restart Obsidian and I'll check", texts, "the tmux send echoes instantly, ahead of disk")
+        self.assertIn("restart Obsidian and I'll check", texts, "the send echoes instantly, ahead of disk")
         self.assertTrue(merged["turns"][-1]["ended"], "but an echo must NOT reopen the turn (it's a user msg, not work)")
 
     def test_successful_send_echo_prunes_when_the_real_user_atom_lands(self):
         text = "edit the files and I'll rerun"
-        km._tmux_echo_add(SID, text)
+        self._echo_add(text)
         merged = km._merge_live_atoms(self._session([self._real_user(text)]), SID)
         texts = [km._atom_user_text(a) for a in merged["turns"][-1]["atoms"]]
         self.assertEqual(texts.count(text), 1, "no duplicate bubble: the echo dedups against the real atom")
-        self.assertNotIn(SID, km._tmux_echo, "the echo is pruned once the real user turn writes")
+        self.assertEqual(self.echoes, {}, "the echo is pruned once the real user turn writes")
 
     def test_dropped_send_echo_persists_so_the_lost_message_stays_visible(self):
-        km._tmux_echo_add(SID, "this Enter dropped at the prompt")
+        self._echo_add("this Enter dropped at the prompt")
         merged = km._merge_live_atoms(self._session([]), SID)   # transcript never gets it — the send dropped
         texts = [km._atom_user_text(a) for a in merged["turns"][-1]["atoms"]]
         self.assertIn("this Enter dropped at the prompt", texts, "a dropped send stays visible, not silent")
-        self.assertIn(SID, km._tmux_echo, "the echo persists until the real turn lands")
+        self.assertTrue(self.echoes, "the echo persists until the real turn lands")
 
     def test_no_echo_is_a_noop(self):
         sess = self._session([self._real_user("hello")])
@@ -7042,11 +7156,11 @@ class TmuxInputEcho(unittest.TestCase):
         # No double-show: a send that's QUEUED behind a busy turn is surfaced by the event-based
         # kind:"queued" indicator. The echo for that same text must be hidden so it doesn't render twice.
         text = "do the thing while you're busy"
-        km._tmux_echo_add(SID, text)
+        self._echo_add(text)
         merged = km._merge_live_atoms(self._session([]), SID, shown_texts=[text])
         texts = [km._atom_user_text(a) for a in merged["turns"][-1]["atoms"]]
         self.assertNotIn(text, texts, "a queued message is owned by the queued indicator, not double-shown by the echo")
-        self.assertIn(SID, km._tmux_echo, "the echo is only HIDDEN while queued, not pruned — it retires when the real atom lands")
+        self.assertTrue(self.echoes, "the echo is only HIDDEN while queued, not pruned — it retires when the real atom lands")
 
     def test_echo_only_merge_does_not_make_the_session_look_working(self):
         # THE chat↔timeline split (the user 2026-06-25): the chat is the only surface that merges live
@@ -7054,7 +7168,7 @@ class TmuxInputEcho(unittest.TestCase):
         # send persists forever) made the chat show 'working' + a counting timer while the timeline/feed (no
         # merge) correctly showed idle. An echo is a pending USER message, not the assistant working.
         ended_turn = self._session([self._real_user("earlier prompt")])  # last turn is ended=True
-        km._tmux_echo_add(SID, "this send dropped — its echo lingers")
+        self._echo_add("this send dropped — its echo lingers")
         merged = km._merge_live_atoms(ended_turn, SID)
         self.assertTrue(merged["turns"][-1]["ended"], "an echo-only merge keeps the turn ENDED (not reopened)")
         self.assertFalse(km._session_working(merged["turns"]), "a lone echo must NOT read as working")
@@ -7062,24 +7176,20 @@ class TmuxInputEcho(unittest.TestCase):
         self.assertIn("this send dropped — its echo lingers", texts, "the echo still renders (stays visible)")
 
     def test_live_assistant_work_still_reopens_the_turn(self):
-        # The flip side: a genuine live ASSISTANT atom (an SDK stream reply leading the disk write) DOES
+        # The flip side: a genuine live ASSISTANT atom (a stream reply leading the disk write) DOES
         # reopen the turn → working. Only the lone-echo case is suppressed.
-        saved = km._sdk
         live = [{"type": "assistant", "uuid": "live-a", "t": NOW,
                  "message": {"role": "assistant", "content": [{"type": "text", "text": "on it"}]}}]
         km._sdk = lambda: type("B", (), {"owns": lambda self, s: True,
                                          "live_atoms": lambda self, s: live,
                                          "prune_live": lambda self, s, u, t, hf=0: None})()
-        try:
-            merged = km._merge_live_atoms(self._session([self._real_user("go")]), SID)
-        finally:
-            km._sdk = saved
+        merged = km._merge_live_atoms(self._session([self._real_user("go")]), SID)
         self.assertFalse(merged["turns"][-1]["ended"], "live assistant work reopens the turn")
         self.assertTrue(km._session_working(merged["turns"]), "streaming assistant work reads as working")
 
     def test_queued_suppression_strips_whitespace(self):
         # _pending_queued .strip()s its texts; the echo stores the raw composer text. Match on stripped text.
-        km._tmux_echo_add(SID, "padded message\n")
+        self._echo_add("padded message\n")
         merged = km._merge_live_atoms(self._session([]), SID, shown_texts=["padded message"])
         texts = [km._atom_user_text(a) for a in merged["turns"][-1]["atoms"]]
         self.assertNotIn("padded message", texts, "stripped-text match suppresses the echo against the queued bubble")
@@ -7196,14 +7306,14 @@ class BootWarm(unittest.TestCase):
     reconnect/reload gap, so the first connect is warm instead of paying the cold serial parse (the user
     2026-07-03: local sessions take a long time to load on restart)."""
     def setUp(self):
-        self._saved = (km._alive_sessions, km._has_parsing_client, km._parse, km._tmux_sessions, km.jd.discover)
+        self._saved = (km._alive_sessions, km._has_parsing_client, km._parse, km._live_map, km.jd.discover)
         self.parsed = []
         km.jd.discover = lambda now: []
-        km._tmux_sessions = lambda: {}
+        km._live_map = lambda: {}
         km._parse = lambda path, sid, now: self.parsed.append(sid)
 
     def tearDown(self):
-        (km._alive_sessions, km._has_parsing_client, km._parse, km._tmux_sessions, km.jd.discover) = self._saved
+        (km._alive_sessions, km._has_parsing_client, km._parse, km._live_map, km.jd.discover) = self._saved
 
     def _wait(self, pred, timeout=1.0):
         end = time.time() + timeout
@@ -7215,14 +7325,14 @@ class BootWarm(unittest.TestCase):
 
     def test_boot_warm_parses_every_live_session(self):
         km._has_parsing_client = lambda: False
-        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "path": "/p1"}, {"sid": "s2", "path": "/p2"}]
+        km._alive_sessions = lambda now, live_map: [{"sid": "s1", "path": "/p1"}, {"sid": "s2", "path": "/p2"}]
         km._boot_warm()
         self.assertTrue(self._wait(lambda: sorted(self.parsed) == ["s1", "s2"]),
                         "boot-warm parsed every live session into the cache")
 
     def test_boot_warm_stands_down_for_a_live_parsing_client(self):
         km._has_parsing_client = lambda: True     # the browser already reconnected → its build warms the cache
-        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "path": "/p1"}]
+        km._alive_sessions = lambda now, live_map: [{"sid": "s1", "path": "/p1"}]
         km._boot_warm()
         time.sleep(0.1)
         self.assertEqual(self.parsed, [], "boot-warm defers to a live parsing client — no GIL contention")

--- a/tests/test_kernel_apiretry.py
+++ b/tests/test_kernel_apiretry.py
@@ -150,7 +150,7 @@ class KernelAutoRetryTick(unittest.TestCase):
                        km._api_error, km._path_of, km._alive_sessions)
         km._retry_paused_on = lambda: False
         km._session_retry_suppressed = lambda sid: False
-        km._alive_sessions = lambda now, tmux: [{"sid": self.SID, "path": "/TESTDIR/x.jsonl"}]
+        km._alive_sessions = lambda now, live_map: [{"sid": self.SID, "path": "/TESTDIR/x.jsonl"}]
         km._path_of = lambda sid, now=None: "/TESTDIR/x.jsonl"
         self.aerr = {"text": "Unable to connect to API (ENOTFOUND)", "status": None,
                      "category": "network", "uuid": "ep-1",
@@ -167,8 +167,8 @@ class KernelAutoRetryTick(unittest.TestCase):
         km._auto_retried.clear()
         km._auto_retry_state.clear()
 
-    def _tick(self, tmux=None):
-        km._auto_retry_tick(1_000_000, {self.SID: {"state": ""}} if tmux is None else tmux)
+    def _tick(self, live_map=None):
+        km._auto_retry_tick(1_000_000, {self.SID: {"state": ""}} if live_map is None else live_map)
 
     def test_fires_unattended_with_no_client(self):
         # THE live wedge: a transient-errored idle session, zero clients. The kernel now asks for itself.
@@ -205,7 +205,7 @@ class KernelAutoRetryTick(unittest.TestCase):
         self.assertEqual(self.be.sent, [RETRY])
 
     def test_dormant_sessions_are_skipped(self):
-        self._tick(tmux={})                          # SID not in the live set → no live CLI
+        self._tick(live_map={})                          # SID not in the live set → no live CLI
         self.assertEqual(self.be.sent, [], "a dead CLI's api-error is settled history, not retried into")
 
     def test_global_pause_stands(self):
@@ -219,7 +219,7 @@ class KernelAutoRetryTick(unittest.TestCase):
         self.assertEqual(self.be.sent, [], "no api error → nothing to retry")
 
     def test_the_pusher_cycle_runs_the_tick(self):
-        self.assertIn("_auto_retry_tick(now, tmux)", SRC,
+        self.assertIn("_auto_retry_tick(now, live_map)", SRC,
                       "the pusher cycle drives retries server-side — unattended recovery")
 
 

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -77,7 +77,7 @@ class AwaitingLift(unittest.TestCase):
         km.jd.GOALDIR = td / "goals"
         km.jd.GOALDIR.mkdir(parents=True)
         self.path = str(td / (SID + ".jsonl"))
-        km._alive_sessions = lambda now, tmux: [{"sid": SID, "path": self.path}]
+        km._alive_sessions = lambda now, live_map: [{"sid": SID, "path": self.path}]
         km._mark_views_dirty = lambda *a, **k: None
         km._SESSION_STAMP_CACHE.clear()
         km._bgall_cache.clear()

--- a/tests/test_kernel_awaiting_merge.py
+++ b/tests/test_kernel_awaiting_merge.py
@@ -6,7 +6,7 @@ never read awaiting, the auto-nudge fired on a genuinely-waiting session, and th
 hard-blocked its card with "it needs your direction". Two guards here:
 
   * the MERGE itself carries bgTasks through — tested through the REAL Sessions.live() with a fake
-    backend, exactly the seam the earlier _tmux_sessions-stubbing tests bypassed;
+    backend, exactly the seam the earlier _live_map-stubbing tests bypassed;
   * _mark_nudge_failed never converts a nudge into a block while the session is AWAITING — its reply
     ("waiting on the experiment") DID explain itself.
 
@@ -46,32 +46,29 @@ class _FakeSdkBackend:
 
 class MergeCarriesBgTasks(unittest.TestCase):
     def test_the_real_merge_carries_bgTasks_and_subagents_through(self):
-        # through the REAL Sessions.live(), not a _tmux_sessions stub — the seam the bug lived in
+        # through the REAL Sessions.live(), not a _live_map stub — the seam the bug lived in
         snap = {"state": "waiting", "since": "1", "model": "Fable 5", "effort": "xhigh",
                 "modelPending": False, "effortPending": False, "retryCount": 0, "retryInfo": None,
                 "ctx": 10, "mode": "auto", "subagents": [], "bgTasks": [dict(TIMER)]}
-        saved_sdk, saved_tmux = km._sdk, km.Sessions._TMUX_LIVE if hasattr(km.Sessions, "_TMUX_LIVE") else None
+        saved_sdk = km._sdk
         fake = _FakeSdkBackend(snap)
         km._sdk = lambda: fake
-        tmux_saved = km._TMUX.live_sessions
-        km._TMUX.live_sessions = staticmethod(lambda: {})
         try:
             out = km.Sessions.live()
         finally:
             km._sdk = saved_sdk
-            km._TMUX.live_sessions = tmux_saved
         self.assertIn(SID, out)
         self.assertEqual([t["desc"] for t in out[SID]["bgTasks"]],
                          ["20-minute timer for campaign-start check"],
                          "the merged map carries the live bg-task set — the awaiting/nudge gates read it here")
         self.assertEqual(out[SID]["subagents"], [])
         # ...and _session_awaiting source 0.5 fires off exactly that merged map
-        saved_sessions = km._tmux_sessions
-        km._tmux_sessions = lambda: out
+        saved_sessions = km._live_map
+        km._live_map = lambda: out
         try:
             why = km._session_awaiting(SID, "/nonexistent", True)
         finally:
-            km._tmux_sessions = saved_sessions
+            km._live_map = saved_sessions
         self.assertEqual(why, {"kind": "task",
                                "why": "waiting on a background task: 20-minute timer for campaign-start check"})
 

--- a/tests/test_kernel_awaiting_stamp.py
+++ b/tests/test_kernel_awaiting_stamp.py
@@ -126,7 +126,7 @@ class SessionLevelStamp(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         td = Path(self.td.name)
-        self._saved = (km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions, km._states_awaiting_overlay)
+        self._saved = (km.jd.STATE, km.jd.GOALDIR, km._live_map, km._states_awaiting_overlay)
         km.jd.STATE = td
         km.jd.GOALDIR = td / "goals"
         km.jd.GOALDIR.mkdir(parents=True)
@@ -134,10 +134,10 @@ class SessionLevelStamp(unittest.TestCase):
         km._states_awaiting_overlay = lambda sid: None
         # a LIVE snapshot with an EMPTY bg-task set (SDK-style): sources 0-1 find nothing and fall through to
         # the stamp; the present "bgTasks" key means source 0.75 (transcript pairing) is skipped as well
-        km._tmux_sessions = lambda: {SID: {"state": "", "since": None, "subagents": [], "bgTasks": []}}
+        km._live_map = lambda: {SID: {"state": "", "since": None, "subagents": [], "bgTasks": []}}
 
     def tearDown(self):
-        km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions, km._states_awaiting_overlay = self._saved
+        km.jd.STATE, km.jd.GOALDIR, km._live_map, km._states_awaiting_overlay = self._saved
         km._SESSION_STAMP_CACHE.clear()
         self.td.cleanup()
 
@@ -176,7 +176,7 @@ class SessionLevelStamp(unittest.TestCase):
 
     def test_a_dormant_session_never_resurrects_off_a_stale_stamp(self):
         self._seed(("g1", "a wait whose CLI is gone", 200))
-        km._tmux_sessions = lambda: {}          # SID not in the live set → live is None
+        km._live_map = lambda: {}          # SID not in the live set → live is None
         self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True))
 
     def test_an_open_turn_is_working_not_awaiting_even_with_a_stamp(self):
@@ -192,7 +192,7 @@ class SessionLevelStamp(unittest.TestCase):
         km._compacting = lambda *a, **k: False
         km._interrupting = lambda *a, **k: False
         try:
-            chip = km._session_chip(SID, "/p", {"turns": []}, km._tmux_sessions()[SID], NOW)
+            chip = km._session_chip(SID, "/p", {"turns": []}, km._live_map()[SID], NOW)
         finally:
             km._session_working, km._api_error, km._compacting, km._interrupting = saved
         self.assertEqual(chip, "awaitingBg")
@@ -217,7 +217,7 @@ class SessionLevelDelegation(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         td = Path(self.td.name)
-        self._saved = (km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions,
+        self._saved = (km.jd.STATE, km.jd.GOALDIR, km._live_map,
                        km._states_awaiting_overlay, km._name_of)
         km.jd.STATE = td
         km.jd.GOALDIR = td / "goals"
@@ -226,10 +226,10 @@ class SessionLevelDelegation(unittest.TestCase):
         km._states_awaiting_overlay = lambda sid: None
         km._name_of = lambda s: "probe" if s == self.PEER else None
         # LIVE snapshot, empty bg sets (SDK-style): every live source falls through, like SessionLevelStamp
-        km._tmux_sessions = lambda: {SID: {"state": "", "since": None, "subagents": [], "bgTasks": []}}
+        km._live_map = lambda: {SID: {"state": "", "since": None, "subagents": [], "bgTasks": []}}
 
     def tearDown(self):
-        (km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions,
+        (km.jd.STATE, km.jd.GOALDIR, km._live_map,
          km._states_awaiting_overlay, km._name_of) = self._saved
         km._SESSION_STAMP_CACHE.clear()
         self.td.cleanup()
@@ -287,7 +287,7 @@ class SessionLevelDelegation(unittest.TestCase):
 
     def test_a_dormant_session_never_lights_off_the_graph(self):
         self._seed(self._delegated_store())
-        km._tmux_sessions = lambda: {}
+        km._live_map = lambda: {}
         self.assertIsNone(km._session_awaiting(SID, "/p", True, stamp=True))
 
     def test_the_chip_reads_awaitingBg_end_to_end(self):
@@ -299,7 +299,7 @@ class SessionLevelDelegation(unittest.TestCase):
         km._compacting = lambda *a, **k: False
         km._interrupting = lambda *a, **k: False
         try:
-            chip = km._session_chip(SID, "/p", {"turns": []}, km._tmux_sessions()[SID], NOW)
+            chip = km._session_chip(SID, "/p", {"turns": []}, km._live_map()[SID], NOW)
         finally:
             km._session_working, km._api_error, km._compacting, km._interrupting = saved
         self.assertEqual(chip, "awaitingBg")
@@ -313,7 +313,7 @@ class KindScopedRules(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         td = Path(self.td.name)
-        self._saved = (km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions, km._states_awaiting_overlay,
+        self._saved = (km.jd.STATE, km.jd.GOALDIR, km._live_map, km._states_awaiting_overlay,
                        km._peer_answered_at)
         km.jd.STATE = td
         km.jd.GOALDIR = td / "goals"
@@ -321,10 +321,10 @@ class KindScopedRules(unittest.TestCase):
         km._SESSION_STAMP_CACHE.clear()
         km._states_awaiting_overlay = lambda sid: None
         km._peer_answered_at = lambda sid: 900          # a peer exchange answered AFTER every stamp below
-        km._tmux_sessions = lambda: {SID: {"state": "", "since": None, "subagents": [], "bgTasks": []}}
+        km._live_map = lambda: {SID: {"state": "", "since": None, "subagents": [], "bgTasks": []}}
 
     def tearDown(self):
-        (km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions, km._states_awaiting_overlay,
+        (km.jd.STATE, km.jd.GOALDIR, km._live_map, km._states_awaiting_overlay,
          km._peer_answered_at) = self._saved
         km._SESSION_STAMP_CACHE.clear()
         self.td.cleanup()
@@ -382,16 +382,16 @@ class OverlayDoesNotVeto(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         td = Path(self.td.name)
-        self._saved = (km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions)
+        self._saved = (km.jd.STATE, km.jd.GOALDIR, km._live_map)
         km.jd.STATE = td
         km.jd.GOALDIR = td / "goals"
         km.jd.GOALDIR.mkdir(parents=True)
         (td / "states").mkdir()
         km._SESSION_STAMP_CACHE.clear()
-        km._tmux_sessions = lambda: {SID: {"state": "", "since": None, "subagents": [], "bgTasks": []}}
+        km._live_map = lambda: {SID: {"state": "", "since": None, "subagents": [], "bgTasks": []}}
 
     def tearDown(self):
-        km.jd.STATE, km.jd.GOALDIR, km._tmux_sessions = self._saved
+        km.jd.STATE, km.jd.GOALDIR, km._live_map = self._saved
         km._SESSION_STAMP_CACHE.clear()
         self.td.cleanup()
 
@@ -480,7 +480,7 @@ class AwaitingWake(unittest.TestCase):
         (km.jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
             "rompUuid": SID, "seq": 1, "placements": {}, "status": {}, "nodes": {self.gid: nd}}))
 
-    def _wake(self, now, rec=None, tmux=None):
+    def _wake(self, now, rec=None, live_map=None):
         km._SESSION_STAMP_CACHE.clear(); km._autonudge_cache.clear()   # deterministic: never a stale cache
         if rec is not None:
             d = json.loads((Path(self.td.name) / "auto-nudge.json").read_text())
@@ -491,7 +491,7 @@ class AwaitingWake(unittest.TestCase):
         stamp = km._goal_awaiting_stamp_full(store.get("nodes", {}), self.gid)
         self.assertIsNotNone(stamp, "fixture: the goal must be stamped")
         out = km._wake_goal(SID, self.gid, stamp, nudged, self.turns, store, now,
-                            self.turns[-1], {SID: {"state": ""}} if tmux is None else tmux)
+                            self.turns[-1], {SID: {"state": ""}} if live_map is None else live_map)
         km._autonudge_cache.clear()
         return out
 
@@ -588,7 +588,7 @@ class AwaitingWake(unittest.TestCase):
     def test_dormant_session_is_not_woken(self):
         now = 1_000_000
         self._seed(at=now - 7 * 3600)
-        self.assertFalse(self._wake(now, tmux={}))   # SID not in the live set → not a live CLI
+        self.assertFalse(self._wake(now, live_map={}))   # SID not in the live set → not a live CLI
         self.assertEqual(self.fb.sent, [], "a dormant session's dispatched work is gone, not asleep")
 
     def test_wake_that_judges_resolved_mid_tick_stands_down(self):

--- a/tests/test_kernel_bg_tasks.py
+++ b/tests/test_kernel_bg_tasks.py
@@ -328,14 +328,14 @@ class DispatchGist(unittest.TestCase):
         ack["toolUseResult"] = {"isAsync": True, "status": "async_launched", "taskType": "local_agent",
                                 "outputFile": "/tmp/agent-a1.output"}
         path = _write([use, ack])
-        saved = (km._tmux_sessions, km._sdk_spawned_at)
-        km._tmux_sessions = lambda: {"11111111-2222-3333-4444-555555555555": {"name": "web"}}
+        saved = (km._live_map, km._sdk_spawned_at)
+        km._live_map = lambda: {"11111111-2222-3333-4444-555555555555": {"name": "web"}}
         km._sdk_spawned_at = lambda s: None
         try:
             res = km._bg_tasks(path)
             row = km._bg_live_norm("11111111-2222-3333-4444-555555555555", path)[0]
         finally:
-            km._tmux_sessions, km._sdk_spawned_at = saved
+            km._live_map, km._sdk_spawned_at = saved
             os.unlink(path)
         self.assertEqual(res["count"], 1, "the ack must not duplicate the launch row")
         self.assertEqual(res["tasks"][0]["summary"], "Audit the sampler")
@@ -384,13 +384,13 @@ class DispatchGist(unittest.TestCase):
         bare = _agent_launch(tid="tu_agent1")
         bare["toolUseResult"] = {"isAsync": True, "status": "async_launched"}
         path = _write([use, ack, _agent_tool_use(tid="tu_agent1"), bare])
-        saved = (km._tmux_sessions, km._sdk_spawned_at)
-        km._tmux_sessions = lambda: {sid: {"name": "web"}}   # live CLI, no lifecycle set → scan source
+        saved = (km._live_map, km._sdk_spawned_at)
+        km._live_map = lambda: {sid: {"name": "web"}}   # live CLI, no lifecycle set → scan source
         km._sdk_spawned_at = lambda s: None
         try:
             rows = {r["desc"]: r["type"] for r in km._bg_live_norm(sid, path)}
         finally:
-            km._tmux_sessions, km._sdk_spawned_at = saved
+            km._live_map, km._sdk_spawned_at = saved
             os.unlink(path)
         self.assertEqual(rows["Sweep the notes-api routes for slow spots"], "local_workflow")
         self.assertEqual(rows["Map the parser"], "local_agent")
@@ -404,14 +404,14 @@ class DurableAwaitingSource(unittest.TestCase):
     SID = "11111111-2222-3333-4444-555555555555"
 
     def _patched(self, live_map, spawned=None):
-        saved = (km._tmux_sessions, km._sdk_spawned_at, km._states_awaiting_overlay)
-        km._tmux_sessions = lambda: live_map
+        saved = (km._live_map, km._sdk_spawned_at, km._states_awaiting_overlay)
+        km._live_map = lambda: live_map
         km._sdk_spawned_at = lambda sid: spawned
         km._states_awaiting_overlay = lambda sid: None
         return saved
 
     def _restore(self, saved):
-        km._tmux_sessions, km._sdk_spawned_at, km._states_awaiting_overlay = saved
+        km._live_map, km._sdk_spawned_at, km._states_awaiting_overlay = saved
 
     def test_pending_agent_dispatches_read_kind_agents_not_task(self):
         # dispatched agents/workflows are kind agents even through the task stream; a MIXED pending
@@ -510,13 +510,13 @@ class AgentTasksAreNeverServices(unittest.TestCase):
         self.assertEqual(awaited, [t], "the closer affirmed this thread's wait")
 
     def test_norm_threads_the_type_through_both_sources(self):
-        saved = km._tmux_sessions
-        km._tmux_sessions = lambda: {self.SID: {"bgTasks": [
+        saved = km._live_map
+        km._live_map = lambda: {self.SID: {"bgTasks": [
             {"toolUseId": "t4", "desc": "an agent", "since": 5, "type": "local_agent"}]}}
         try:
             rows = km._bg_live_norm(self.SID, None)
         finally:
-            km._tmux_sessions = saved
+            km._live_map = saved
         self.assertEqual(rows[0]["type"], "local_agent", "the lifecycle set's type survives normalization")
 
 

--- a/tests/test_kernel_bg_tasks_stale.py
+++ b/tests/test_kernel_bg_tasks_stale.py
@@ -82,10 +82,10 @@ class BgTasksStale(unittest.TestCase):
     def test_build_session_wires_spawned_at(self):
         # spawned_at stays the tmux/no-snapshot fallback; an SDK session's box is gated by the backend's
         # LIVE task-lifecycle set (the user 2026-07-11) — both ride the same call. The live gate reads
-        # the CALLER's snapshot, never a fresh _tmux_sessions() (the 2026-08-10 pusher CPU fix).
+        # the CALLER's snapshot, never a fresh _live_map() (the 2026-08-10 pusher CPU fix).
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('_bg_tasks(sess["path"], _sdk_spawned_at(sid),', src)
-        self.assertIn('live=(tmux.get(str(sid)) or {}).get("bgTasks")', src)
+        self.assertIn('live=(live_map.get(str(sid)) or {}).get("bgTasks")', src)
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_boot_stub.py
+++ b/tests/test_kernel_boot_stub.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""A brand-new LIVE tmux session has no transcript for its first ~7s, and build_session used to return
-None for it — no session frame existed, so its input echo / queued bubble had nothing to render onto and
-the first message typed into a just-created session was invisible until the transcript appeared (the
-user 2026-07-20: the UI must respond even when the kernel can't get the session going yet). Discovery
-misses now synthesize a transcriptless entry for a sid that is LIVE in tmux — the same treatment the SDK
-path always had via _sdk_sess — so the frame exists from second zero and the live-echo merge lands on
-it. SYNTHETIC fixtures only."""
+"""A brand-new LIVE session has no transcript for its first few seconds, and build_session used to
+return None for it — no session frame existed, so its input echo / queued bubble had nothing to render
+onto and the first message typed into a just-created session was invisible until the transcript appeared
+(the user 2026-07-20: the UI must respond even when the kernel can't get the session going yet).
+Discovery misses synthesize a transcriptless entry for a sid that is LIVE — and the backend's live
+atoms (the optimistic input echo) merge onto that synthesized frame, so the frame exists from second
+zero. Driven through a stub backend (the SessionBackend seam), SYNTHETIC fixtures only."""
 import os
 import time
 import unittest
@@ -24,27 +24,48 @@ km = SourceFileLoader("romp_kernel_bootstub", os.path.join(BIN, "romp-kernel")).
 
 SID = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
 
-# the shape _tmux_sessions() always provides for a live session (a booting TUI has no model/context yet)
-_TM_META = {"state": "", "since": None, "model": "", "effort": "", "mode": "",
-            "context": None, "compactPct": None, "backend": "tmux"}
+# the shape _live_map() always provides for a live session (a booting one has no model/context yet)
+_LIVE_META = {"state": "", "since": None, "model": "", "effort": "", "mode": "",
+              "context": None, "compactPct": None, "backend": "sdk"}
+
+
+class _EchoBE:
+    """A stub backend owning SID whose only live atom is the optimistic input echo — the same
+    synthetic human user atom shape the real backend mints, merged ahead of the (absent) disk parse."""
+    def __init__(self, sid, text):
+        self.sid, self._atoms = sid, [{
+            "type": "user", "uuid": "echo:1111", "session_id": sid, "t": int(time.time()),
+            "parentUuid": None, "author": "human", "_echo_text": text,
+            "message": {"role": "user", "content": [{"type": "text", "text": text}]}}]
+    def owns(self, sid): return sid == self.sid
+    def live_atoms(self, sid): return list(self._atoms) if sid == self.sid else []
+    def prune_live(self, sid, tx_uuids, tx_user_texts=(), human_floor=0): return None
+    def pending_queued(self, sid): return []
+    def current_ask(self, sid): return None
+    def busy(self, sid): return None
+    def compacting(self, sid): return None
+    def clearing(self, sid): return None
+    def launch_error(self, sid): return None
+    def live_sessions(self): return {}
+    def pending_cut(self, sid): return ""
+    def __getattr__(self, name):
+        # any other capability probe reads as absent — the documented can't-do-it default
+        raise AttributeError(name)
 
 
 class BootWindowStub(unittest.TestCase):
     def setUp(self):
         self._saved = (km._sessions, km._sdk, km._captions)
         km._sessions = lambda now: []                 # discovery can't see it (no transcript yet)
-        km._sdk = lambda: None                        # not SDK-owned either — the tmux boot window
         km._captions = lambda sid: {}
-        km._tmux_echo.pop(SID, None)
 
     def tearDown(self):
         km._sessions, km._sdk, km._captions = self._saved
-        km._tmux_echo.pop(SID, None)
 
-    def test_live_tmux_sid_builds_a_frame_with_its_echo_before_any_transcript(self):
+    def test_live_sid_builds_a_frame_with_its_echo_before_any_transcript(self):
         now = int(time.time())
-        km._tmux_echo_add(SID, "first message into a booting session")
-        m = km.build_session(SID, now, tmux={SID: _TM_META})
+        km._sdk = lambda: _EchoBE(SID, "first message into a booting session")
+        m = km.build_session(SID, now, live_map={SID: _LIVE_META})
         self.assertIsNotNone(m, "a live-but-transcriptless session must still build a frame")
         self.assertEqual(m["id"], SID)
         evs = m.get("events") or []
@@ -52,7 +73,8 @@ class BootWindowStub(unittest.TestCase):
                         "the input echo renders onto the synthesized frame")
 
     def test_a_sid_nowhere_alive_still_builds_nothing(self):
-        m = km.build_session(SID, int(time.time()), tmux={})
+        km._sdk = lambda: None
+        m = km.build_session(SID, int(time.time()), live_map={})
         self.assertIsNone(m, "unknown sids stay frameless — the stub is only for LIVE boot windows")
 
     def test_the_stub_path_can_never_shadow_a_real_transcript(self):

--- a/tests/test_kernel_cancel_create.py
+++ b/tests/test_kernel_cancel_create.py
@@ -55,8 +55,8 @@ class CancelCreateTest(unittest.TestCase):
         patch("_send_to_app", lambda app, m: self.sent.append((app, m)))
         patch("_push_soon", lambda: None)
         patch("_push_all", lambda: None)
-        patch("_tmux_sessions", lambda: self._live)
-        patch("_live_names", lambda tmux: {NAME: SID} if SID in (tmux or {}) else {})
+        patch("_live_map", lambda: self._live)
+        patch("_live_names", lambda live_map: {NAME: SID} if SID in (live_map or {}) else {})
         self._saved_bf = km.Sessions.backend_for
         km.Sessions.backend_for = staticmethod(lambda sid: self.be)
         km._cancel_pending.clear()

--- a/tests/test_kernel_cardtime.py
+++ b/tests/test_kernel_cardtime.py
@@ -58,18 +58,18 @@ class CardTime(unittest.TestCase):
         names = td / "names"; names.mkdir()
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
         self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-                      km.NAMES, km._tmux_sessions)
+                      km.NAMES, km._live_map)
         jd.NAMES, jd.PROJECTS = names, proj
         jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
         jd.STATE = td
         km.NAMES = names
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         jd.GOALDIR.mkdir(parents=True)
 
     def tearDown(self):
         (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-         km.NAMES, km._tmux_sessions) = self.saved
+         km.NAMES, km._live_map) = self.saved
         self.td.cleanup()
 
     def _store(self, nodes, status):

--- a/tests/test_kernel_dismiss_lane.py
+++ b/tests/test_kernel_dismiss_lane.py
@@ -35,7 +35,7 @@ class DismissLane(unittest.TestCase):
         src = inspect.getsource(km.build_timeline)
         # the filter drops a sid ONLY when it's both dismissed AND currently dead (tmux has no live session),
         # so a revived sid comes back on its own
-        self.assertIn('s["sid"] in _dismissed_lanes and tmux.get(s["sid"]) is None', src)
+        self.assertIn('s["sid"] in _dismissed_lanes and live_map.get(s["sid"]) is None', src)
 
     def test_build_timeline_sheds_records_on_revive(self):
         # the revive is the un-dismiss EVENT: a dismissed sid seen alive drops its durable record there,

--- a/tests/test_kernel_end_on_idle.py
+++ b/tests/test_kernel_end_on_idle.py
@@ -92,7 +92,7 @@ class EndOnIdle(unittest.TestCase):
         src = Path(BIN, "romp-kernel").read_text()
         self.assertIn('b.get("when") == "idle"', src, "/end honors the deferral")
         self.assertIn('{"ok": True, "deferred": True}', src)
-        self.assertIn("_end_on_idle_sweep(now, tmux)", src, "the sweep rides the pusher's tick jobs")
+        self.assertIn("_end_on_idle_sweep(now, live_map)", src, "the sweep rides the pusher's tick jobs")
         sdk = Path(os.path.dirname(BIN), "kernel", "sdk_backend.py").read_text()
         self.assertIn('"ROMP_SID": str(sess.sid)', sdk,
                       "the CLI process carries the session's stable identity for `romp end self`")

--- a/tests/test_kernel_fleet_cache.py
+++ b/tests/test_kernel_fleet_cache.py
@@ -22,22 +22,22 @@ km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_modu
 
 class FleetCacheTest(unittest.TestCase):
     def test_sig_is_stable_when_nothing_changes(self):
-        now, tmux = int(time.time()), km._tmux_sessions()
-        self.assertEqual(km._fleet_view_sig(now, tmux), km._fleet_view_sig(now, tmux))
+        now, live_map = int(time.time()), km._live_map()
+        self.assertEqual(km._fleet_view_sig(now, live_map), km._fleet_view_sig(now, live_map))
 
     def test_sig_busts_on_a_judge_pass(self):
-        now, tmux = int(time.time()), km._tmux_sessions()
-        a = km._fleet_view_sig(now, tmux)
+        now, live_map = int(time.time()), km._live_map()
+        a = km._fleet_view_sig(now, live_map)
         km._judge_gen[0] += 1
         try:
-            self.assertNotEqual(a, km._fleet_view_sig(now, tmux), "a judge pass must rebuild the views")
+            self.assertNotEqual(a, km._fleet_view_sig(now, live_map), "a judge pass must rebuild the views")
         finally:
             km._judge_gen[0] -= 1
 
     def test_time_bucket_advances_so_age_labels_refresh(self):
-        tmux = km._tmux_sessions()
-        self.assertEqual(km._fleet_view_sig(0, tmux), km._fleet_view_sig(4, tmux), "same 5s bucket → cache hit")
-        self.assertNotEqual(km._fleet_view_sig(0, tmux), km._fleet_view_sig(5, tmux), "next 5s bucket → refresh")
+        live_map = km._live_map()
+        self.assertEqual(km._fleet_view_sig(0, live_map), km._fleet_view_sig(4, live_map), "same 5s bucket → cache hit")
+        self.assertNotEqual(km._fleet_view_sig(0, live_map), km._fleet_view_sig(5, live_map), "next 5s bucket → refresh")
 
     def test_cached_feed_and_timeline_reuse_on_a_matching_sig(self):
         feed_save = list(km._built_feed)
@@ -84,7 +84,7 @@ class FleetCacheTest(unittest.TestCase):
         feed_save = list(km._built_feed)
         dirty_save = km._views_dirty[0]
         real_build = km.build_feed
-        def build_with_midflight_reply(now, tmux):
+        def build_with_midflight_reply(now, live_map):
             time.sleep(0.005)                         # a real build runs ~1s; keep the mark measurably
             km._mark_views_dirty()                    # past the start stamp, then: the reply lands while
             return {"type": "feed", "cards": []}      # this build is mid-read. fresh dict → `is` tells builds apart
@@ -93,7 +93,7 @@ class FleetCacheTest(unittest.TestCase):
             km._built_feed[:] = [None, None, 0.0, 0.0]
             km.build_feed = build_with_midflight_reply
             f1 = km._cached_feed(int(time.time()), {}, ("SIG",))
-            km.build_feed = lambda now, tmux: {"type": "feed", "cards": []}
+            km.build_feed = lambda now, live_map: {"type": "feed", "cards": []}
             f2 = km._cached_feed(int(time.time()), {}, ("SIG",))
             self.assertIsNot(f2, f1, "a mark set during the build postdates its start → must rebuild")
             f3 = km._cached_feed(int(time.time()), {}, ("SIG",))

--- a/tests/test_kernel_interrupt.py
+++ b/tests/test_kernel_interrupt.py
@@ -399,7 +399,7 @@ class AutoNudgeInterruptGate(unittest.TestCase):
         km._parse_cache.clear()
         km._autonudge_cache.clear()
         km._pending_ops.clear()
-        self.tmux = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+        self.live_map = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
                            "context": None, "compactPct": None, "color": None}}
         km._set_auto_nudge(True)
 
@@ -439,12 +439,15 @@ class AutoNudgeInterruptGate(unittest.TestCase):
 
     def _stub(self):
         sent = []
-        saved = km._tmux_send, jd.optimistic_followup
-        km._tmux_send = lambda name, body, **kw: sent.append((name, body))
+        class _SendBE:
+            def send(self, sid, body): sent.append((sid, body)); return True
+        _be = _SendBE()
+        saved = km.Sessions.backend_for, jd.optimistic_followup
+        km.Sessions.backend_for = staticmethod(lambda sid: _be)
         jd.optimistic_followup = lambda sid, gid: True
 
         def restore():
-            km._tmux_send, jd.optimistic_followup = saved
+            km.Sessions.backend_for, jd.optimistic_followup = saved
         return sent, restore
 
     def test_control_a_normally_ended_stall_still_nudges(self):
@@ -454,7 +457,7 @@ class AutoNudgeInterruptGate(unittest.TestCase):
         g = self._goal()
         sent, restore = self._stub()
         try:
-            km._auto_nudge_tick(NOW, self.tmux)
+            km._auto_nudge_tick(NOW, self.live_map)
             self.assertEqual(len(sent), 1, "the orphaned working goal is nudged")
             self.assertIn("romp-goal-id: " + g, sent[0][1])
         finally:
@@ -465,7 +468,7 @@ class AutoNudgeInterruptGate(unittest.TestCase):
         self._goal()
         sent, restore = self._stub()
         try:
-            km._auto_nudge_tick(NOW, self.tmux)
+            km._auto_nudge_tick(NOW, self.live_map)
             self.assertEqual(sent, [], "the user stopped this turn themselves — they're driving, not stalled")
         finally:
             restore()
@@ -476,7 +479,7 @@ class AutoNudgeInterruptGate(unittest.TestCase):
         km._pending_ops[SID] = [("model", "fable")]
         sent, restore = self._stub()
         try:
-            km._auto_nudge_tick(NOW, self.tmux)
+            km._auto_nudge_tick(NOW, self.live_map)
             self.assertEqual(sent, [], "queued user intent outranks a nudge — never jump the user's queue")
         finally:
             restore()
@@ -495,7 +498,7 @@ class AutoNudgeInterruptGate(unittest.TestCase):
         self._goal()
         sent, restore = self._stub()
         try:
-            km._auto_nudge_tick(NOW, self.tmux)
+            km._auto_nudge_tick(NOW, self.live_map)
             self.assertEqual(sent, [], "a peer spoke, the user didn't — still their pause, still suppressed")
         finally:
             restore()
@@ -507,7 +510,7 @@ class AutoNudgeInterruptGate(unittest.TestCase):
         self._goal()
         sent, restore = self._stub()
         try:
-            km._auto_nudge_tick(NOW, self.tmux)
+            km._auto_nudge_tick(NOW, self.live_map)
             self.assertEqual(len(sent), 1, "the user re-engaged and the goal re-stalled → nudging resumes")
         finally:
             restore()
@@ -518,7 +521,7 @@ class AutoNudgeInterruptGate(unittest.TestCase):
         self._transcript(interrupted=True)
         self._goal()
         km._parse(str(self.tpath), SID, NOW)                       # warm the cache (stands in for _warm_fleet_bg)
-        card = next(a for a in km.build_feed(NOW, self.tmux)["asks"] if a["itemId"] == SID + ":gw")
+        card = next(a for a in km.build_feed(NOW, self.live_map)["asks"] if a["itemId"] == SID + ":gw")
         self.assertTrue(card.get("interrupted"), "user-stopped + no message since → interrupted badge")
 
     def test_feed_badge_clears_once_the_user_re_engages(self):
@@ -526,7 +529,7 @@ class AutoNudgeInterruptGate(unittest.TestCase):
         self._append([uline(T0 + 200, "keep going with plan B", "u4", "u3")])   # user spoke; turn back open
         self._goal()
         km._parse(str(self.tpath), SID, NOW)
-        card = next(a for a in km.build_feed(NOW, self.tmux)["asks"] if a["itemId"] == SID + ":gw")
+        card = next(a for a in km.build_feed(NOW, self.live_map)["asks"] if a["itemId"] == SID + ":gw")
         self.assertFalse(card.get("interrupted"), "the user's next message retires the badge")
 
 
@@ -553,7 +556,7 @@ class AutoNudgeArming(AutoNudgeInterruptGate):
         g = self._goal()
         sent, restore = self._stub()
         try:
-            km._auto_nudge_tick(NOW, self.tmux)
+            km._auto_nudge_tick(NOW, self.live_map)
             self.assertEqual(len(sent), 1, "the working goal takes its FIRST nudge even though the "
                                            "latest turn is romp-injected (the restart banner)")
             self.assertIn("romp-goal-id: " + g, sent[0][1])
@@ -567,7 +570,7 @@ class AutoNudgeArming(AutoNudgeInterruptGate):
         self._goal()
         sent, restore = self._stub()
         try:
-            km._auto_nudge_tick(NOW, self.tmux)
+            km._auto_nudge_tick(NOW, self.live_map)
             self.assertEqual(len(sent), 1)
             self._write([
                 uline(T0, "please wire the thing", "u1"),
@@ -575,7 +578,7 @@ class AutoNudgeArming(AutoNudgeInterruptGate):
                 uline(T0 + 100, "<!-- romp-injected -->[romp] status check follow-up", "u2", "a1"),
                 aline(T0 + 120, "still where I left it.", "a2", "u2", "end_turn")])
             km._parse_cache.clear()
-            km._auto_nudge_tick(NOW + 10, self.tmux)
+            km._auto_nudge_tick(NOW + 10, self.live_map)
             self.assertEqual(len(sent), 1, "a romp-triggered response turn does not move arm_id → no re-fire")
         finally:
             restore()
@@ -587,7 +590,7 @@ class AutoNudgeArming(AutoNudgeInterruptGate):
         self._goal()
         sent, restore = self._stub()
         try:
-            km._auto_nudge_tick(NOW, self.tmux)
+            km._auto_nudge_tick(NOW, self.live_map)
             self.assertEqual(sent, [], "no genuine ended turn to arm off → never fires")
         finally:
             restore()

--- a/tests/test_kernel_interrupt_machine_cut.py
+++ b/tests/test_kernel_interrupt_machine_cut.py
@@ -195,7 +195,7 @@ class _FeedHarness(unittest.TestCase):
         km._machine_cut_cache.clear()
         km._pending_ops.clear()
         km._write_auto_nudge({"enabled": True, "nudged": {}, "intrBlocked": {}})
-        self.tmux = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+        self.live_map = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
                            "context": None, "compactPct": None, "color": None}}
 
     def tearDown(self):
@@ -246,17 +246,20 @@ class _FeedHarness(unittest.TestCase):
 
     def _stub_send(self):
         sent = []
-        saved = km._tmux_send, jd.optimistic_followup
-        km._tmux_send = lambda name, body, **kw: sent.append((name, body))
+        class _SendBE:
+            def send(self, sid, body): sent.append((sid, body)); return True
+        _be = _SendBE()
+        saved = km.Sessions.backend_for, jd.optimistic_followup
+        km.Sessions.backend_for = staticmethod(lambda sid: _be)
         jd.optimistic_followup = lambda sid, gid: True
 
         def restore():
-            km._tmux_send, jd.optimistic_followup = saved
+            km.Sessions.backend_for, jd.optimistic_followup = saved
         return sent, restore
 
     def _card(self, item_id=None):
         km._parse(str(self.tpath), SID, NOW)                       # warm the cache (stands in for _warm_fleet_bg)
-        return next(a for a in km.build_feed(NOW, self.tmux)["asks"]
+        return next(a for a in km.build_feed(NOW, self.live_map)["asks"]
                     if a["itemId"] == (item_id or SID + ":gw"))
 
 
@@ -272,7 +275,7 @@ class MachineCutFeedAndNudge(_FeedHarness):
         g = self._goal()
         sent, restore = self._stub_send()
         try:
-            km._auto_nudge_tick(NOW, self.tmux)
+            km._auto_nudge_tick(NOW, self.live_map)
             self.assertEqual(len(sent), 1, "a restart-cut, re-stalled goal is nudged to continue — not left silent")
             self.assertIn("romp-goal-id: " + g, sent[0][1])
         finally:
@@ -287,7 +290,7 @@ class MachineCutFeedAndNudge(_FeedHarness):
     def test_restart_cut_card_stays_in_working_not_blocked(self):
         self._machine_cut(sb.BOOT_RESUME_NUDGE)
         self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][SID + ":gw"], "working",
                          "a machine cut is continued, never blocked-on-you")
         self.assertEqual(self._card()["column"], "working")
@@ -295,7 +298,7 @@ class MachineCutFeedAndNudge(_FeedHarness):
     def test_crash_cut_is_also_continued_not_blocked(self):
         self._machine_cut(sb.CRASH_RESUME_NUDGE)
         self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][SID + ":gw"], "working")
         self.assertFalse(self._card().get("interrupted"))
 
@@ -308,7 +311,7 @@ class MachineCutFeedAndNudge(_FeedHarness):
                           wedge="<task-notification>the restart killed a background task"
                                 "</task-notification>")
         self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][SID + ":gw"], "working",
                          "a machine cut is continued even when a notification wedges before the notice")
         self.assertFalse(self._card().get("interrupted"))
@@ -320,7 +323,7 @@ class MachineCutFeedAndNudge(_FeedHarness):
         km._set_auto_nudge(False)                       # the toggle must not gate the needs-you flip
         self._genuine_stop()
         self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][SID + ":gw"], "blocked",
                          "a user-stopped session needs the user → Blocked, not sitting in Working")
 
@@ -328,7 +331,7 @@ class MachineCutFeedAndNudge(_FeedHarness):
         km._set_auto_nudge(False)
         self._genuine_stop()
         self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         card = self._card()
         self.assertEqual(card["column"], "needs_input", "the interrupted card comes to the user's attention")
         self.assertTrue(card.get("interrupted"), "and says WHY it's here — the user stopped it mid-turn")
@@ -337,13 +340,13 @@ class MachineCutFeedAndNudge(_FeedHarness):
         km._set_auto_nudge(False)
         self._genuine_stop()
         self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][SID + ":gw"], "blocked")
         # the user speaks → a fresh turn opens; the block WE placed lifts
         with open(self.tpath, "a") as f:
             f.write(json.dumps(uline(T0 + 200, "keep going with plan B", "u3", "u2")) + "\n")
         km._parse_cache.clear()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][SID + ":gw"], "working",
                          "the user re-engaged → our interrupt block lifts")
 
@@ -365,7 +368,7 @@ class StaleInterruptMarker(_FeedHarness):
         km._set_auto_nudge(False)
         self._genuine_stop()
         g1 = self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][g1], "blocked")
         self.assertEqual(km._intr_blocked(SID), g1)
         # the judges move on from newer turns: the stopped goal is lifted and completed, and a second
@@ -387,7 +390,7 @@ class StaleInterruptMarker(_FeedHarness):
             f.write(json.dumps(aline(T0 + 220, "wrapped that up; the build is green", "a2", "u3",
                                      "end_turn")) + "\n")
         km._parse_cache.clear()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         st = jd.load_goals(SID)
         self.assertEqual(st["status"][g2], "blocked",
                          "the marker was verified stale → the LIVE focus goal re-blocks on the user")
@@ -400,7 +403,7 @@ class StaleInterruptMarker(_FeedHarness):
         km._set_auto_nudge(False)
         self._genuine_stop()
         g1 = self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         # a judge lifts OUR block off newer evidence — rows the bare stop's stamp cannot outrank
         st = jd.load_goals(SID)
         jd.record_verdict(st, st["nodes"][g1], "unblocker", "unblock", T0 + 70,
@@ -408,7 +411,7 @@ class StaleInterruptMarker(_FeedHarness):
         jd.rollup_status(st, False)
         jd.save_goals(SID, st)
         rows = len(jd.load_goals(SID)["nodes"][g1]["log"])
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         st = jd.load_goals(SID)
         self.assertEqual(st["status"][g1], "working",
                          "the judges ruled on a newer world — the re-block stands down")
@@ -419,7 +422,7 @@ class StaleInterruptMarker(_FeedHarness):
             f.write(json.dumps(uline(T0 + 200, self.INJECTED, "u3", "u2")) + "\n")
             f.write(json.dumps(aline(T0 + 220, "wrapped that up", "a2", "u3", "end_turn")) + "\n")
         km._parse_cache.clear()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][g1], "blocked",
                          "re-surfaced the moment the stop is the newest information again")
 
@@ -591,7 +594,7 @@ class MachineCutBeforeItsNoticeLands(_FeedHarness):
     def test_the_focus_card_is_not_blocked_on_the_user(self):
         self._cut_awaiting_its_notice()
         g = self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][g], "working",
                          "romp cut this turn and is resuming it — the user is owed nothing")
 
@@ -600,7 +603,7 @@ class MachineCutBeforeItsNoticeLands(_FeedHarness):
         # log claiming they stopped a session they never touched
         self._cut_awaiting_its_notice()
         g = self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         log = jd.load_goals(SID)["nodes"][g].get("log") or []
         self.assertEqual([r for r in log if r.get("src") == "interrupt"], [],
                          "no interrupt verdict may be written for a cut romp itself caused")
@@ -609,7 +612,7 @@ class MachineCutBeforeItsNoticeLands(_FeedHarness):
     def test_the_card_stays_in_working(self):
         self._cut_awaiting_its_notice()
         self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         card = self._card()
         self.assertEqual(card["column"], "working")
         self.assertFalse(card.get("interrupted"), "and wears no 'you stopped this' badge")
@@ -617,7 +620,7 @@ class MachineCutBeforeItsNoticeLands(_FeedHarness):
     def test_a_crash_cut_awaiting_its_notice_is_also_continued(self):
         self._cut_awaiting_its_notice("crash")
         g = self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][g], "working")
 
     def test_auto_nudge_still_fires_so_a_real_re_stall_is_caught(self):
@@ -632,7 +635,7 @@ class MachineCutBeforeItsNoticeLands(_FeedHarness):
         # still reach the user. If this ever goes green-by-default the mechanism has stopped discriminating.
         self._genuine_stop()
         g = self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][g], "blocked",
                          "a real Esc with no machine-cut stamp still needs the user")
 
@@ -648,7 +651,7 @@ class MachineCutBeforeItsNoticeLands(_FeedHarness):
         self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
         sb.append_machine_cut(jd.STATE, SID, "restart", T0 + 62)
         g = self._goal()
-        km._interrupt_block_tick(NOW, self.tmux)
+        km._interrupt_block_tick(NOW, self.live_map)
         self.assertEqual(jd.load_goals(SID)["status"][g], "blocked",
                          "the user stopped the RESUMED turn — that one is theirs and belongs in needs-you")
 

--- a/tests/test_kernel_model_queue.py
+++ b/tests/test_kernel_model_queue.py
@@ -105,16 +105,16 @@ class CompactingNowGate(unittest.TestCase):
     """_compacting_now composes the REAL _compacting corroboration from cheap parts (cached parse only)."""
 
     def setUp(self):
-        self._saved = (km._tmux_sessions, km._path_of, km._parse_cached)
+        self._saved = (km._live_map, km._path_of, km._parse_cached)
         km._path_of = lambda sid: "/tmp/x.jsonl"
         km._compact_clicked.clear()
 
     def tearDown(self):
-        (km._tmux_sessions, km._path_of, km._parse_cached) = self._saved
+        (km._live_map, km._path_of, km._parse_cached) = self._saved
         km._compact_clicked.clear()
 
     def test_optimistic_click_reads_compacting_until_the_boundary_lands(self):
-        km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": None}}
+        km._live_map = lambda: {SID: {"state": "waiting", "since": None}}
         km._parse_cached = lambda p: {"turns": []}
         km._compact_clicked[SID] = time.time()          # the kernel itself just sent /compact
         self.assertTrue(km._compacting_now(SID), "the optimistic click reads compacting at once")
@@ -124,7 +124,7 @@ class CompactingNowGate(unittest.TestCase):
         self.assertFalse(km._compacting_now(SID), "the compact_boundary event ends it — the parked switch can fire")
 
     def test_no_signal_reads_not_compacting(self):
-        km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": None}}
+        km._live_map = lambda: {SID: {"state": "waiting", "since": None}}
         km._parse_cached = lambda p: {"turns": []}
         self.assertFalse(km._compacting_now(SID))
 

--- a/tests/test_kernel_msgcaption.py
+++ b/tests/test_kernel_msgcaption.py
@@ -58,12 +58,12 @@ class MsgCaption(unittest.TestCase):
         names = td / "names"; names.mkdir()
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
         self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-                      km.NAMES, km._tmux_sessions)
+                      km.NAMES, km._live_map)
         jd.NAMES, jd.PROJECTS = names, proj
         jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
         jd.STATE = td
         km.NAMES = names
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         jd.CAPDIR.mkdir(parents=True)
         jd.GOALDIR.mkdir(parents=True)
@@ -72,7 +72,7 @@ class MsgCaption(unittest.TestCase):
 
     def tearDown(self):
         (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-         km.NAMES, km._tmux_sessions) = self.saved
+         km.NAMES, km._live_map) = self.saved
         self.td.cleanup()
 
     def _cap(self, uid, grain, caption):

--- a/tests/test_kernel_nudge_compacting_skip.py
+++ b/tests/test_kernel_nudge_compacting_skip.py
@@ -53,7 +53,7 @@ class NudgeCompactingSkip(unittest.TestCase):
         # got PAST the compacting guard. The spy returns an empty session so the tick continues harmlessly
         # (a raise would be swallowed by the tick's own `except Exception: continue`, hiding a guard failure).
         km._auto_nudge_on = lambda: True
-        km._alive_sessions = lambda now, tmux: [{"sid": SID, "path": "/nonexistent.jsonl"}]
+        km._alive_sessions = lambda now, live_map: [{"sid": SID, "path": "/nonexistent.jsonl"}]
         km._wait_for_graph = lambda now, sids: {}
         km._session_flag = lambda sid, flag: False
         km._api_error = lambda path: None

--- a/tests/test_kernel_nudgebar.py
+++ b/tests/test_kernel_nudgebar.py
@@ -62,12 +62,12 @@ class NudgeBar(unittest.TestCase):
         names = td / "names"; names.mkdir()
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
         self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-                      km.NAMES, km._tmux_sessions)
+                      km.NAMES, km._live_map)
         jd.NAMES, jd.PROJECTS = names, proj
         jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
         jd.STATE = td
         km.NAMES = names
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         jd.CAPDIR.mkdir(parents=True)
         jd.GOALDIR.mkdir(parents=True)
@@ -76,7 +76,7 @@ class NudgeBar(unittest.TestCase):
 
     def tearDown(self):
         (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-         km.NAMES, km._tmux_sessions) = self.saved
+         km.NAMES, km._live_map) = self.saved
         self.td.cleanup()
 
     def _bars(self):

--- a/tests/test_kernel_opening.py
+++ b/tests/test_kernel_opening.py
@@ -51,7 +51,7 @@ class _Base(unittest.TestCase):
         self.td = tempfile.TemporaryDirectory()
         td = Path(self.td.name)
         self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-                      km.NAMES, km._tmux_sessions, km._sdk)
+                      km.NAMES, km._live_map, km._sdk)
         names = td / "names"; names.mkdir()
         proj = td / "projects"; proj.mkdir()
         jd.NAMES, jd.PROJECTS = names, proj
@@ -65,7 +65,7 @@ class _Base(unittest.TestCase):
 
     def tearDown(self):
         (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-         km.NAMES, km._tmux_sessions, km._sdk) = self.saved
+         km.NAMES, km._live_map, km._sdk) = self.saved
         self.td.cleanup()
 
 
@@ -75,9 +75,9 @@ class OpeningChipStandsDownOnTheBackendEvent(_Base):
     never until the first transcript record (that lands only with the first message)."""
 
     def _chip(self, row):
-        tmux = {SID: row}
-        km._tmux_sessions = lambda: tmux
-        m = km.build_session(SID, NOW, tmux)
+        live_map = {SID: row}
+        km._live_map = lambda: live_map
+        m = km.build_session(SID, NOW, live_map)
         self.assertIsNotNone(m, "a live transcript-less session still gets a frame")
         return m["status"]["state"]
 
@@ -125,8 +125,8 @@ class PushSessionNow(_Base):
                "message": {"role": "user", "content": "hello there"}}
         (pdir / (SID + ".jsonl")).write_text(json.dumps(rec) + "\n")
         (jd.NAMES / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
-        self.tmux = {SID: _row(state="waiting", since=NOW - 5)}
-        km._tmux_sessions = lambda: self.tmux
+        self.live_map = {SID: _row(state="waiting", since=NOW - 5)}
+        km._live_map = lambda: self.live_map
         self.sent = []
         self.client = {"app": "chat", "alive": True, "wid": "", "qbytes": 0,
                        "send": lambda s: self.sent.append(json.loads(s))}

--- a/tests/test_kernel_opening_chip.py
+++ b/tests/test_kernel_opening_chip.py
@@ -57,7 +57,7 @@ class OpeningChipDecidingEvent(unittest.TestCase):
         # real ~/.claude/projects, and the fixture transcript is never found (chip stuck "opening").
         self.saved = [(m, k, getattr(m, k)) for m in (jd, km.jd)
                       for k in ("NAMES", "PROJECTS", "CAPDIR", "ARCHDIR", "GOALDIR", "STATE")]
-        self.saved += [(km, "NAMES", km.NAMES), (km, "_tmux_sessions", km._tmux_sessions),
+        self.saved += [(km, "NAMES", km.NAMES), (km, "_live_map", km._live_map),
                        (km, "_GLOBAL_CLAUDE_MD", km._GLOBAL_CLAUDE_MD)]
         for m in (jd, km.jd):
             m.NAMES, m.PROJECTS = names, proj
@@ -67,7 +67,7 @@ class OpeningChipDecidingEvent(unittest.TestCase):
         km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
         self.tm = {"state": "waiting", "since": NOW - 5, "model": "Opus 5", "effort": "xhigh",
                    "context": None, "compactPct": None, "color": None, "backend": "sdk"}
-        km._tmux_sessions = lambda: {SID: dict(self.tm)}
+        km._live_map = lambda: {SID: dict(self.tm)}
 
     def tearDown(self):
         for m, k, v in self.saved:

--- a/tests/test_kernel_ops_gate_busy.py
+++ b/tests/test_kernel_ops_gate_busy.py
@@ -101,15 +101,15 @@ class CompactingAuthoritativeSignal(unittest.TestCase):
     def setUp(self):
         self._saved_sdk = km._sdk
         self._saved_parse = km._parse_cached
-        self._saved_tmux = km._tmux_sessions
+        self._saved_tmux = km._live_map
         km._parse_cached = lambda *a, **k: {"turns": []}
-        km._tmux_sessions = lambda: {}
+        km._live_map = lambda: {}
         km._compact_clicked[SID] = km.time.time()   # optimistic latch STAMPED (would hold 180s on its own)
 
     def tearDown(self):
         km._sdk = self._saved_sdk
         km._parse_cached = self._saved_parse
-        km._tmux_sessions = self._saved_tmux
+        km._live_map = self._saved_tmux
         km._compact_clicked.pop(SID, None)
 
     def test_backend_says_done_overrides_a_stamped_optimistic_latch(self):

--- a/tests/test_kernel_order.py
+++ b/tests/test_kernel_order.py
@@ -78,19 +78,19 @@ class SessionOrder(unittest.TestCase):
 
     # ── _chat_tab_sessions / _timeline_sessions: stable through activity + death ───────────────────
     def test_chat_tabs_keep_order_when_a_session_dies(self):
-        km._alive_sessions = lambda now, tmux: [sess(A, 100), sess(B, 200), sess(C, 300)]
+        km._alive_sessions = lambda now, live_map: [sess(A, 100), sess(B, 200), sess(C, 300)]
         km._sessions = lambda now: [sess(A, 100), sess(B, 200), sess(C, 300)]
         self.assertEqual(self.sids(km._chat_tab_sessions(0, {})), [A, B, C])
         # B dies (leaves the alive set); not kept-open → its tab drops, A & C keep their relative order
-        km._alive_sessions = lambda now, tmux: [sess(A, 100), sess(C, 300)]
+        km._alive_sessions = lambda now, live_map: [sess(A, 100), sess(C, 300)]
         self.assertEqual(self.sids(km._chat_tab_sessions(0, {})), [A, C])
 
     def test_timeline_lanes_never_reshuffle_on_activity(self):
-        km._alive_sessions = lambda now, tmux: [sess(A, 100), sess(B, 200)]
+        km._alive_sessions = lambda now, live_map: [sess(A, 100), sess(B, 200)]
         km._sessions = lambda now: [sess(A, 100), sess(B, 200), sess(C, 50), sess(D, 60)]
         self.assertEqual(self.sids(km._timeline_sessions(0, {})), [A, B, C, D])
         # B works hard + dead lane C's transcript gets touched (both mtimes spike) — lanes must hold
-        km._alive_sessions = lambda now, tmux: [sess(A, 100), sess(B, 99999)]
+        km._alive_sessions = lambda now, live_map: [sess(A, 100), sess(B, 99999)]
         km._sessions = lambda now: [sess(A, 100), sess(B, 99999), sess(C, 88888), sess(D, 60)]
         self.assertEqual(self.sids(km._timeline_sessions(0, {})), [A, B, C, D])
 
@@ -124,14 +124,14 @@ class SessionOrder(unittest.TestCase):
 
     def test_chat_push_prunes_a_truly_gone_session_from_the_file(self):
         km._write_session_order([A, B, C])
-        km._alive_sessions = lambda now, tmux: [sess(A, 100), sess(C, 300)]    # B not alive
+        km._alive_sessions = lambda now, live_map: [sess(A, 100), sess(C, 300)]    # B not alive
         km._sessions = lambda now: [sess(A, 100), sess(C, 300)]               # B's transcript gone → GONE
         km._chat_tab_sessions(0, {})
         self.assertEqual(self.order_file(), [A, C])        # B pruned on a chat push (self-cleaning)
 
     def test_chat_push_keeps_a_dead_but_in_window_session(self):
         km._write_session_order([A, B, C])
-        km._alive_sessions = lambda now, tmux: [sess(A, 100), sess(C, 300)]    # B not alive...
+        km._alive_sessions = lambda now, live_map: [sess(A, 100), sess(C, 300)]    # B not alive...
         km._sessions = lambda now: [sess(A, 100), sess(B, 200), sess(C, 300)]  # ...but B is still in-window
         km._chat_tab_sessions(0, {})
         self.assertEqual(self.order_file(), [A, B, C])     # dead-but-in-window B keeps its slot
@@ -186,7 +186,7 @@ class SessionOrder(unittest.TestCase):
         km._name_of = lambda sid: reg.get(sid)
         self.addCleanup(lambda: setattr(km, "_name_of", saved_name_of))
         # A is no longer alive (relaunched) but its transcript is still in-window; OBS2 is the live fork
-        km._alive_sessions = lambda now, tmux: [f(OBS2, "obsidian"), f(B, "bee"), f(C, "see")]
+        km._alive_sessions = lambda now, live_map: [f(OBS2, "obsidian"), f(B, "bee"), f(C, "see")]
         km._sessions = lambda now: [f(A, "obsidian"), f(OBS2, "obsidian"), f(B, "bee"), f(C, "see")]
         out = self.sids(km._chat_tab_sessions(0, {}))
         # OBS2 inherited slot 1 (right after A); A is dead-but-in-window so it keeps its slot in the FILE

--- a/tests/test_kernel_owned_yield_awaiting.py
+++ b/tests/test_kernel_owned_yield_awaiting.py
@@ -53,11 +53,11 @@ class OwnedYieldAwaiting(unittest.TestCase):
         km.jd.GOALDIR.mkdir(parents=True)
         self.path = str(td / (SID + ".jsonl"))
         Path(self.path).write_text("")
-        self.saved = {k: getattr(km, k) for k in ("_bg_live_norm", "_bg_placed_tops", "_tmux_sessions")}
+        self.saved = {k: getattr(km, k) for k in ("_bg_live_norm", "_bg_placed_tops", "_live_map")}
         # one live background task, attributed by the judge to TOP's subtree
         km._bg_live_norm = lambda sid, path: [{"tid": "t1", "desc": DESC, "t": DISPATCH, "type": ""}]
         km._bg_placed_tops = lambda sid, path, tids: {"t1": TOP}
-        km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": DISPATCH, "model": "",
+        km._live_map = lambda: {SID: {"state": "waiting", "since": DISPATCH, "model": "",
                                            "effort": "", "context": None, "compactPct": None,
                                            "color": None}}
         km._SESSION_STAMP_CACHE.clear()

--- a/tests/test_kernel_producer.py
+++ b/tests/test_kernel_producer.py
@@ -32,9 +32,9 @@ class ProducerPolicy(unittest.TestCase):
 
     def test_both_tiers_share_the_same_live_session_guard(self):
         body = self._producer_body()
-        # index + triage appends sit inside one `if _tmux_sessions():` block (same guard for both)
-        guard = re.search(r"if _tmux_sessions\(\) and not _retry_paused_on\(\):\n(.*?)\n            for t in tiers:", body, re.S)
-        self.assertTrue(guard, "the two tiers are guarded by a single _tmux_sessions() and not _retry_paused_on() check")
+        # index + triage appends sit inside one `if _live_map():` block (same guard for both)
+        guard = re.search(r"if _live_map\(\) and not _retry_paused_on\(\):\n(.*?)\n            for t in tiers:", body, re.S)
+        self.assertTrue(guard, "the two tiers are guarded by a single _live_map() and not _retry_paused_on() check")
         block = guard.group(1)
         self.assertIn('name="index"', block)
         self.assertIn('name="triage"', block)

--- a/tests/test_kernel_pusher_snapshot.py
+++ b/tests/test_kernel_pusher_snapshot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """The pusher cycle takes ONE liveness snapshot (the 2026-08-10 CPU fix).
 
-Every _tmux_sessions() read forks `tmux list-sessions` and sweeps the whole SDK reg registry.
+Every _live_map() read forks `tmux list-sessions` and sweeps the whole SDK reg registry.
 The pusher's cycle used to take NINE of them — one inside _push plus one per tick job — at its
 0.5s cadence, which profiling attributed as the kernel's single hottest thread (~50-90% of one
 core sustained, three quarters of total process CPU). The jobs all take the map as a parameter
@@ -75,15 +75,15 @@ class OneSnapshotPerCycle(unittest.TestCase):
 
     def test_one_cycle_reads_liveness_once_however_deep_the_call(self):
         # count REAL liveness reads (Sessions.live — the tmux fork + reg sweep), not the delegator:
-        # inside the cycle's scope every _tmux_sessions() call, at any depth of the build stack,
+        # inside the cycle's scope every _live_map() call, at any depth of the build stack,
         # must be served the cycle's one snapshot instead of taking a fresh read
         reads = []
         row = self.row
         km.Sessions.live = lambda: (reads.append(1), dict(row))[1]
         got = {}
         # bracket the job list: the FIRST and the LAST tick job must both receive the cycle's one map
-        km._auto_nudge_tick = lambda now, tmux: got.setdefault("first", tmux)
-        km._clear_done_working_notes = lambda now, tmux: got.setdefault("last", tmux)
+        km._auto_nudge_tick = lambda now, live_map: got.setdefault("first", live_map)
+        km._clear_done_working_notes = lambda now, live_map: got.setdefault("last", live_map)
         sent = []
         with km._clients_lock:   # a connected chat client, so the _push leg builds for real
             km._clients[:] = [{"app": "chat", "alive": True, "wid": "", "qbytes": 0,
@@ -97,7 +97,7 @@ class OneSnapshotPerCycle(unittest.TestCase):
         self.assertIsNone(km._live_scope.snapshot, "the scope ends with the cycle")
         # OUTSIDE a cycle the delegator reads fresh — a WS handler must never see a stale snapshot
         n = len(reads)
-        km._tmux_sessions()
+        km._live_map()
         self.assertEqual(len(reads), n + 1)
 
     def test_build_session_reuses_the_callers_snapshot(self):

--- a/tests/test_kernel_revive.py
+++ b/tests/test_kernel_revive.py
@@ -2,10 +2,12 @@
 """Picker revive-from-disk (the user 2026-07-05). _revive_session shelled `romp-postal-service revive`,
 a subcommand 2b5e181 removed (live-only postal addressing) — the CLI printed 'unknown command' and
 EXITED 0, the output was DEVNULL'd, and the kernel then focused a still-dead session: the picker's
-Revive silently did nothing for a week. The kernel now owns revive per backend (SDK resume+connect /
-tmux `romp <name> --resume <sid> --detach` in the recorded dir), CHECKS the result, and on failure
-sends the chat a reviveFailed event (clears the client's revive loader, shows why) instead of
-pretending it worked. Synthetic fixtures only."""
+Revive silently did nothing for a week. The kernel now owns revive through the SDK backend for EVERY
+sid (the user 2026-08-16, retiring the terminal backend): an SDK-owned sid resumes (reg alive +
+connect), a reg-less pre-SDK sid is ADOPTED — the backend's own resume() mints its registry entry
+from the recorded name/dir and the transcript on disk — and a sid with no transcript at all fails
+up front. The result is CHECKED, and any failure sends the chat a reviveFailed event (clears the
+client's revive loader, shows why) instead of pretending it worked. Synthetic fixtures only."""
 import os
 import subprocess
 import tempfile
@@ -48,17 +50,18 @@ class ReviveSession(unittest.TestCase):
     that success → focus while failure → reviveFailed (loud), never both."""
 
     def setUp(self):
-        self.saved = (km._sdk, km._name_of, km._cwd_of, km._push_all, km._reveal_chat,
+        self.saved = (km._sdk, km._name_of, km._cwd_of, km._path_of, km._push_all, km._reveal_chat,
                       km._send_to_app, subprocess.run)
         self.sent, self.focused, self.runs = [], [], []
         km._name_of = lambda sid: "testsess"
         km._cwd_of = lambda sid: "/nonexistent-dir-for-test"
+        km._path_of = lambda sid, now=None, window=None: "/tmp/synthetic/%s.jsonl" % sid
         km._push_all = lambda: None
         km._reveal_chat = lambda msg: self.focused.append(msg)
         km._send_to_app = lambda app, msg: self.sent.append((app, msg))
 
     def tearDown(self):
-        (km._sdk, km._name_of, km._cwd_of, km._push_all, km._reveal_chat,
+        (km._sdk, km._name_of, km._cwd_of, km._path_of, km._push_all, km._reveal_chat,
          km._send_to_app, subprocess.run) = self.saved
 
     def _stub_run(self, returncode=0, stderr=""):
@@ -84,34 +87,59 @@ class ReviveSession(unittest.TestCase):
         app, msg = self.sent[0]
         self.assertEqual((app, msg["type"], msg["id"]), ("chat", "reviveFailed", SID))
 
-    def test_tmux_session_revives_via_romp_resume_detach(self):
+    def test_reg_less_sid_is_adopted_and_resumed_via_the_sdk(self):
+        """A sid with NO SDK registry entry (a pre-SDK session, from the retired terminal backend's
+        era) revives through the SDK path too (the user 2026-08-16): the backend's own resume() mints
+        the reg from the recorded name/dir and the transcript on disk, then connect resumes it —
+        history intact, exactly like an owned sid. The old path shelled `bin/romp resume ... --detach`;
+        a revive must never shell out or spawn a terminal session again."""
+        be = FakeSdk(owns=False)
+        km._sdk = lambda: be
+        self._stub_run(returncode=0)      # any shell-out would land in self.runs — there must be none
+        km._revive_session(SID)
+        self.assertEqual(be.calls, [("resume", "testsess", SID), ("connect", SID)],
+                         "adopt-and-resume: the backend mints the reg and resumes, same as an owned sid")
+        self.assertEqual(self.runs, [], "no shell-out — the terminal resume path is gone")
+        self.assertEqual([m["type"] for m in self.focused], ["focus"])
+        self.assertEqual(self.sent, [], "no failure event on success")
+
+    def test_unrevivable_sid_fails_loudly_with_the_reason(self):
+        """A reg-less sid with NO transcript on disk cannot be adopted — resuming it would only fail
+        after the CLI launches, quietly. The refusal happens up front and takes the LOUD path:
+        reviveFailed names why, and the chat never focuses a still-dead session ('dead sessions
+        revive with their history' — and when they can't, the user hears it, never a silent no-op)."""
+        be = FakeSdk(owns=False)
+        km._sdk = lambda: be
+        km._path_of = lambda sid, now=None, window=None: None
+        km._revive_session(SID)
+        self.assertEqual(be.calls, [], "no resume attempt without a transcript to resume from")
+        self.assertEqual(self.focused, [], "a failed revive must not focus a still-dead session")
+        app, msg = self.sent[0]
+        self.assertEqual((app, msg["type"], msg["id"]), ("chat", "reviveFailed", SID))
+        self.assertIn("transcript", msg["text"], "the failure names WHY")
+
+    def test_sdk_backend_unavailable_is_a_loud_failure(self):
+        # no backend at all (module unavailable) → the same loud path, naming the remedy — the old
+        # code shelled the terminal launcher here, which is gone (the user 2026-08-16)
         km._sdk = lambda: None
         self._stub_run(returncode=0)
         km._revive_session(SID)
-        cmd, kw = self.runs[0]
-        self.assertEqual(cmd, [os.path.join(BIN, "romp"), "resume", SID, "--name", "testsess", "--detach"],
-                         "the launcher resume path the old postal revive used, now owned by the kernel "
-                         "(round-3 spelling, 2026-07-25: resume <id> --name <name>)")
-        self.assertEqual(kw.get("cwd"), os.path.expanduser("~"),
-                         "a missing recorded dir falls back to $HOME (old postal behavior)")
-        self.assertEqual([m["type"] for m in self.focused], ["focus"])
-        self.assertEqual(self.sent, [])
-
-    def test_tmux_failure_carries_the_launcher_error(self):
-        km._sdk = lambda: None
-        self._stub_run(returncode=3, stderr="no transcript for that uuid")
-        km._revive_session(SID)
+        self.assertEqual(self.runs, [], "no shell-out fallback when the SDK backend is missing")
         self.assertEqual(self.focused, [])
         app, msg = self.sent[0]
         self.assertEqual(msg["type"], "reviveFailed")
-        self.assertIn("no transcript", msg["text"], "the launcher's stderr reaches the user, not DEVNULL")
+        self.assertIn("romp-sdk-setup", msg["text"], "the failure names the fix")
 
     def test_the_removed_postal_subcommand_is_gone(self):
         # the regression pin: 2b5e181 removed `romp-postal-service revive`; the kernel must never
         # shell it again (it exits 0 on unknown commands, so the failure is undetectable). The
-        # docstring may NAME the old path as history — the pin is on the invocation form.
+        # docstring may NAME the old path as history — the pin is on the invocation form. Since
+        # 2026-08-16 the pin widens: _revive_session shells NOTHING (the terminal launcher's
+        # `bin/romp resume` shell-out went with the backend) — the SDK owns revive end to end.
         import inspect
-        self.assertNotIn('HERE / "romp-postal-service"', inspect.getsource(km._revive_session))
+        src = inspect.getsource(km._revive_session)
+        self.assertNotIn('HERE / "romp-postal-service"', src)
+        self.assertNotIn("subprocess", src, "revive never shells out at all now")
 
 
 class SdkResumePreservesLastSid(unittest.TestCase):
@@ -147,6 +175,17 @@ class SdkResumePreservesLastSid(unittest.TestCase):
     def test_empty_lastsid_falls_back_to_the_sid(self):
         reg = self._resume({"sid": SID, "name": "testsess", "cwd": "/tmp", "lastSid": "", "alive": False})
         self.assertEqual(reg["lastSid"], SID, "a never-relaunched session resumes from its own transcript")
+
+    def test_a_reg_less_sid_gets_a_minted_reg(self):
+        """The ADOPTION surface (the user 2026-08-16): resume() on a sid with no registry entry at all
+        writes one — name, defaults, lastSid = the sid (the transcript-on-disk lineage) — which is
+        exactly what lets the kernel revive a pre-SDK session as a normal SDK session instead of
+        hand-writing reg files (or shelling the retired terminal launcher)."""
+        reg = self._resume(None)
+        self.assertIsNotNone(reg, "resume() mints the missing reg — the backend owns adoption")
+        self.assertEqual(reg["lastSid"], SID, "the sid IS the lineage: resume from its own transcript")
+        self.assertTrue(reg["alive"])
+        self.assertEqual(reg["name"], "testsess")
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_timeline_awaiting.py
+++ b/tests/test_kernel_timeline_awaiting.py
@@ -54,18 +54,18 @@ class TimelineAwaiting(unittest.TestCase):
         os.utime(self.tpath, (NOW - 30, NOW - 30))       # recently-touched → discovered as a lane
         names = td / "names"; names.mkdir()
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
-        self.saved = (km.jd.NAMES, km.jd.PROJECTS, km.jd.GOALDIR, km.jd.STATE, km.NAMES, km._tmux_sessions)
+        self.saved = (km.jd.NAMES, km.jd.PROJECTS, km.jd.GOALDIR, km.jd.STATE, km.NAMES, km._live_map)
         km.jd.NAMES, km.jd.PROJECTS, km.jd.GOALDIR = names, proj, td / "goals"
         km.jd.STATE = td                                 # sandbox states/ + usage/ + session-flags reads
         km.NAMES = names
-        km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "", "effort": "",
+        km._live_map = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "", "effort": "",
                                            "context": None, "compactPct": None, "color": None, "mode": ""}}
         (td / "states").mkdir()
         self.states = td / "states" / (SID + ".jsonl")
         km._parse_cache.pop(str(self.tpath), None)
 
     def tearDown(self):
-        (km.jd.NAMES, km.jd.PROJECTS, km.jd.GOALDIR, km.jd.STATE, km.NAMES, km._tmux_sessions) = self.saved
+        (km.jd.NAMES, km.jd.PROJECTS, km.jd.GOALDIR, km.jd.STATE, km.NAMES, km._live_map) = self.saved
         self.td.cleanup()
 
     def _lane(self, with_bars=True):
@@ -90,7 +90,7 @@ class TimelineAwaiting(unittest.TestCase):
         self.assertEqual(self._lane(with_bars=False)["awaitingBg"], "bg agents")
 
     def test_dead_lane_never_awaits(self):
-        km._tmux_sessions = lambda: {}                   # session process gone → window-dead lane
+        km._live_map = lambda: {}                   # session process gone → window-dead lane
         self.states.write_text(json.dumps({"t": T0 + 21, "awaiting": True, "why": "bg"}) + "\n")
         lane = self._lane()
         self.assertFalse(lane["live"])
@@ -99,7 +99,7 @@ class TimelineAwaiting(unittest.TestCase):
     def test_bg_task_wait_carries_the_task_descriptions(self):
         # the dashed idle-but-waiting stretch (the user 2026-07-13): the lane carries the live bg-task
         # descriptions beside the why, so the stretch's hover lists exactly what's pending
-        km._tmux_sessions = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "", "effort": "",
+        km._live_map = lambda: {SID: {"state": "waiting", "since": NOW - 100, "model": "", "effort": "",
                                            "context": None, "compactPct": None, "color": None, "mode": "",
                                            "bgTasks": [{"task_id": "t1", "desc": "Watch for round3 copy"}]}}
         lane = self._lane()
@@ -152,7 +152,7 @@ class TimelineLiveTail(TimelineAwaiting):
             km.Sessions.backend_for = saved
 
     def test_dead_lane_skips_the_live_merge(self):
-        km._tmux_sessions = lambda: {}                   # session process gone
+        km._live_map = lambda: {}                   # session process gone
         called = []
         saved = km.Sessions.backend_for
         km.Sessions.backend_for = lambda sid: (called.append(sid), self._fake_backend([]))[1]

--- a/tests/test_kernel_timeline_split.py
+++ b/tests/test_kernel_timeline_split.py
@@ -44,7 +44,7 @@ class BuildGating(unittest.TestCase):
         # mtime. Only the {type:"bars"} build (with_bars=True) does the real parse.
         calls = {"parse": 0}
         o_ts, o_parse = km._timeline_sessions, km._parse
-        km._timeline_sessions = lambda now, tmux, live_only=False: [{"sid": "S", "name": "n", "path": "/no/such/transcript"}]
+        km._timeline_sessions = lambda now, live_map, live_only=False: [{"sid": "S", "name": "n", "path": "/no/such/transcript"}]
         km._parse = lambda path, sid, now: (calls.__setitem__("parse", calls["parse"] + 1), {"turns": []})[1]
         try:
             km.build_timeline(0, {}, with_bars=False)
@@ -80,16 +80,16 @@ class PushSplit(unittest.TestCase):
         FULL = {"type": "timeline", "sessions": [{"id": "S"}], "turns": {"S": [{"id": "b1"}]},
                 "judging": [{"k": "planner"}], "messages": [{"m": 1}], "now": 1}
         o_bt, o_ct, o_tmux, o_sig = (km.build_timeline, km._cached_timeline,
-                                     km._tmux_sessions, km._fleet_view_sig)
-        km.build_timeline = lambda now, tmux, with_bars=True, live_only=False: (FULL if with_bars else SKEL)
-        km._cached_timeline = lambda now, tmux, sig, connect=False: FULL
-        km._tmux_sessions = lambda: {}
-        km._fleet_view_sig = lambda now, tmux: ("sig",)
+                                     km._live_map, km._fleet_view_sig)
+        km.build_timeline = lambda now, live_map, with_bars=True, live_only=False: (FULL if with_bars else SKEL)
+        km._cached_timeline = lambda now, live_map, sig, connect=False: FULL
+        km._live_map = lambda: {}
+        km._fleet_view_sig = lambda now, live_map: ("sig",)
         try:
             km._push([client])
         finally:
             (km.build_timeline, km._cached_timeline,
-             km._tmux_sessions, km._fleet_view_sig) = o_bt, o_ct, o_tmux, o_sig
+             km._live_map, km._fleet_view_sig) = o_bt, o_ct, o_tmux, o_sig
         msgs = [json.loads(s) for s in sent]
         types = [m["type"] for m in msgs]
         self.assertIn("data", types)
@@ -110,7 +110,7 @@ class DeadLaneWindow(unittest.TestCase):
     def test_dead_lanes_limited_to_12h_live_only_drops_them_all(self):
         now = 1_000_000
         o_alive, o_sessions, o_ordered = km._alive_sessions, km._sessions, km._ordered
-        km._alive_sessions = lambda now, tmux: [{"sid": "LIVE", "name": "l", "path": "/l", "mtime": now}]
+        km._alive_sessions = lambda now, live_map: [{"sid": "LIVE", "name": "l", "path": "/l", "mtime": now}]
         km._sessions = lambda now: [
             {"sid": "LIVE", "name": "l", "path": "/l", "mtime": now},
             {"sid": "RECENT", "name": "r", "path": "/r", "mtime": now - 6 * 3600},    # dead, within 12h
@@ -132,18 +132,18 @@ class DeadLaneWindow(unittest.TestCase):
               "now": 1, "usage": {}}
         FB = {"type": "timeline", "sessions": [], "turns": {"S": []}, "judging": [],
               "messages": [], "now": 1}
-        o_bt, o_tmux, o_sig = km.build_timeline, km._tmux_sessions, km._fleet_view_sig
+        o_bt, o_tmux, o_sig = km.build_timeline, km._live_map, km._fleet_view_sig
         o_built = list(km._built_timeline)
-        km.build_timeline = lambda now, tmux, with_bars=True, live_only=False: (
+        km.build_timeline = lambda now, live_map, with_bars=True, live_only=False: (
             calls.append(("bars" if with_bars else "skel", live_only)) or (FB if with_bars else SK))
-        km._tmux_sessions = lambda: {}
-        km._fleet_view_sig = lambda now, tmux: ("sig",)
+        km._live_map = lambda: {}
+        km._fleet_view_sig = lambda now, live_map: ("sig",)
         km._built_timeline[0], km._built_timeline[1], km._built_timeline[2] = None, None, 0.0   # cold cache
         km._producer_wake.clear()
         try:
             km._push([client], connect=True)
         finally:
-            km.build_timeline, km._tmux_sessions, km._fleet_view_sig = o_bt, o_tmux, o_sig
+            km.build_timeline, km._live_map, km._fleet_view_sig = o_bt, o_tmux, o_sig
             km._built_timeline[:] = o_built
         self.assertIn(("skel", True), calls, "cold connect: the lanes skeleton is built LIVE-ONLY")
         self.assertIn(("bars", True), calls, "cold connect: the bars are built LIVE-ONLY (no dead reads)")

--- a/tests/test_kernel_usage_limit.py
+++ b/tests/test_kernel_usage_limit.py
@@ -162,7 +162,7 @@ class AutoPauseOnSpendLimit(unittest.TestCase):
     def _sessions(self, *errs):
         sess = [{"sid": "s%d" % i, "path": "/tmp/s%d.jsonl" % i} for i in range(len(errs))]
         emap = {s["path"]: e for s, e in zip(sess, errs)}
-        km._alive_sessions = lambda now, tmux: sess
+        km._alive_sessions = lambda now, live_map: sess
         km._api_error = lambda p: emap.get(p)
 
     def test_a_spend_cap_engages_the_pause_with_reason_spend(self):

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -401,20 +401,20 @@ class RevealAiming(unittest.TestCase):
 
     def test_connected_pane_gets_it_now_dead_session_gets_revive(self):
         c, got = self._register("chat", "W1")
-        with mock.patch.object(km, "_tmux_sessions", return_value={"SID-live": {}}):
+        with mock.patch.object(km, "_live_map", return_value={"SID-live": {}}):
             self.assertTrue(km._reveal_request("SID-live", "W1"))
         self.assertEqual(got, [{"type": "focus", "id": "SID-live", "live": True}])
         self.assertIsNone(km._PENDING_REVEAL[0], "delivered → nothing parked")
         # a DEAD session never silently reveals — the revive prompt instead (_reveal_or_confirm's split)
         got.clear()
-        with mock.patch.object(km, "_tmux_sessions", return_value={}), \
+        with mock.patch.object(km, "_live_map", return_value={}), \
              mock.patch.object(km, "_name_of", return_value="web"):
             km._reveal_request("SID-gone", "W1")
         self.assertEqual(got[0]["type"], "confirmRevive")
 
     def test_boot_race_parks_then_ready_consumes_aimed_by_wid(self):
         # the norm: the shell's fetch beats its chat iframe's WS, so nothing is connected yet
-        with mock.patch.object(km, "_tmux_sessions", return_value={"SID-live": {}}):
+        with mock.patch.object(km, "_live_map", return_value={"SID-live": {}}):
             self.assertFalse(km._reveal_request("SID-live", "W-phone"))
             self.assertEqual(km._PENDING_REVEAL[0], {"sid": "SID-live", "wid": "W-phone"})
             # another dashboard's pane saying ready must NOT steal it (the 2026-07-29 rule)
@@ -436,7 +436,7 @@ class RevealAiming(unittest.TestCase):
 
     def test_a_widless_park_matches_the_first_chat_pane(self):
         # sessionStorage blocked → the shell has no wid; better the first chat pane than a dropped tap
-        with mock.patch.object(km, "_tmux_sessions", return_value={"S": {}}):
+        with mock.patch.object(km, "_live_map", return_value={"S": {}}):
             km._reveal_request("S", "")
             c, got = _fake_ws_client("chat", "W-any")
             km._consume_pending_reveal(c)

--- a/tests/test_kernel_webpush_federation.py
+++ b/tests/test_kernel_webpush_federation.py
@@ -252,7 +252,7 @@ class FederatedReveal(unittest.TestCase):
     def test_a_prefixed_sid_is_handed_to_the_merged_dashboard(self):
         # liveness is the ORIGIN kernel's truth: the local session list must not turn a remote
         # session's tap into a confirmRevive minted from the wrong world
-        with mock.patch.object(km, "_tmux_sessions", return_value={}), \
+        with mock.patch.object(km, "_live_map", return_value={}), \
              mock.patch.object(km, "_name_of", return_value="web"):
             self.assertEqual(km._reveal_msg("boxa:11111111-2222"),
                              {"type": "focus", "id": "boxa:11111111-2222", "live": True})

--- a/tests/test_model_fallback_notice.py
+++ b/tests/test_model_fallback_notice.py
@@ -113,10 +113,10 @@ class BuildSessionEmitsTheNoticeEvent(unittest.TestCase):
             mod.NAMES, mod.PROJECTS = names, proj
             mod.CAPDIR, mod.ARCHDIR, mod.GOALDIR = td / "captions", td / "archive", td / "goals"
             mod.STATE, mod.STATESDIR = td, td / "states"
-        self.saved_km = (km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD)
+        self.saved_km = (km.NAMES, km._live_map, km._GLOBAL_CLAUDE_MD)
         km.NAMES = names
         km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None,
                                            "color": None}}
         km._parse_cache.clear()
@@ -125,7 +125,7 @@ class BuildSessionEmitsTheNoticeEvent(unittest.TestCase):
         for mod, *vals in self.saved:
             (mod.NAMES, mod.PROJECTS, mod.CAPDIR, mod.ARCHDIR,
              mod.GOALDIR, mod.STATE, mod.STATESDIR) = vals
-        (km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD) = self.saved_km
+        (km.NAMES, km._live_map, km._GLOBAL_CLAUDE_MD) = self.saved_km
         km._parse_cache.clear()
         self.td.cleanup()
 

--- a/tests/test_new_route_prefs.py
+++ b/tests/test_new_route_prefs.py
@@ -46,17 +46,17 @@ class NewRoutePrefs(unittest.TestCase):
 
     def setUp(self):
         self.calls = []
-        self._saved = (km._live_names, km._tmux_sessions, km._set_model_or_park,
+        self._saved = (km._live_names, km._live_map, km._set_model_or_park,
                        km._set_effort_or_park, km.Sessions.backend_for,
                        km._sdk_ready, km._create_sdk_session, km._push_soon)
-        km._tmux_sessions = lambda: []
+        km._live_map = lambda: []
         km._set_model_or_park = lambda be, sid, v: self.calls.append(("model", sid, v))
         km._set_effort_or_park = lambda be, sid, v: self.calls.append(("effort", sid, v))
         km.Sessions.backend_for = staticmethod(lambda sid: object())
         km._push_soon = lambda: None
 
     def tearDown(self):
-        (km._live_names, km._tmux_sessions, km._set_model_or_park,
+        (km._live_names, km._live_map, km._set_model_or_park,
          km._set_effort_or_park, km.Sessions.backend_for,
          km._sdk_ready, km._create_sdk_session, km._push_soon) = self._saved
 

--- a/tests/test_notice_cards.py
+++ b/tests/test_notice_cards.py
@@ -60,19 +60,19 @@ class BuildSessionRompSystemFlag(unittest.TestCase):
         names = td / "names"; names.mkdir()
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
         self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE, km.NAMES,
-                      km._tmux_sessions, km._read_task_store, km._GLOBAL_CLAUDE_MD)
+                      km._live_map, km._read_task_store, km._GLOBAL_CLAUDE_MD)
         jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE = names, proj, td / "goals", td
         km.NAMES = names
         km._GLOBAL_CLAUDE_MD = td / "no-global.md"
         km._read_task_store = lambda fsid, fold=None: []
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         jd.GOALDIR.mkdir(parents=True)
         km._parse_cache.clear()
 
     def tearDown(self):
         (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE, km.NAMES,
-         km._tmux_sessions, km._read_task_store, km._GLOBAL_CLAUDE_MD) = self.saved
+         km._live_map, km._read_task_store, km._GLOBAL_CLAUDE_MD) = self.saved
         km._parse_cache.clear()
         self.td.cleanup()
 

--- a/tests/test_payload_dedup_invariant.py
+++ b/tests/test_payload_dedup_invariant.py
@@ -141,7 +141,7 @@ class BuiltFeedIsClockInvariantApartFromTheClockItself(unittest.TestCase):
         km.NAMES = names
         km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
         # Fixed so the stub itself contributes nothing clock-derived (mirrors the chat invariant test).
-        self.tmux = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+        self.live_map = {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
                            "context": None, "compactPct": None, "color": None}}
 
     def tearDown(self):
@@ -150,8 +150,8 @@ class BuiltFeedIsClockInvariantApartFromTheClockItself(unittest.TestCase):
         self.td.cleanup()
 
     def test_only_the_declared_volatile_fields_move_with_the_clock(self):
-        a = km.build_feed(NOW, self.tmux)
-        b = km.build_feed(NOW + 600, self.tmux)
+        a = km.build_feed(NOW, self.live_map)
+        b = km.build_feed(NOW + 600, self.live_map)
         varying = sorted(k for k in set(list(a) + list(b))
                          if json.dumps(a.get(k), sort_keys=True, default=str)
                          != json.dumps(b.get(k), sort_keys=True, default=str))
@@ -164,8 +164,8 @@ class BuiltFeedIsClockInvariantApartFromTheClockItself(unittest.TestCase):
         """End to end: the builder's output, run through the real sender, must send once."""
         sent = []
         client = {"send": sent.append, "alive": True}
-        km._send_client(client, ("feed",), km.build_feed(NOW, self.tmux))
-        km._send_client(client, ("feed",), km.build_feed(NOW + 600, self.tmux))
+        km._send_client(client, ("feed",), km.build_feed(NOW, self.live_map))
+        km._send_client(client, ("feed",), km.build_feed(NOW + 600, self.live_map))
         self.assertEqual(len(sent), 1,
                          "an unchanging fleet must not re-send the feed just because time passed")
 

--- a/tests/test_retry_pause_autoresume.py
+++ b/tests/test_retry_pause_autoresume.py
@@ -63,7 +63,7 @@ class RetryPauseAutoResume(unittest.TestCase):
         km._set_retry_paused(True)
         floor = km._retry_pause_ts()
         path = self._transcript("healthy.jsonl", floor + 5)   # wrote output AFTER the pause
-        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "path": path}]
+        km._alive_sessions = lambda now, live_map: [{"sid": "s1", "path": path}]
         km._api_error = lambda p: None                        # not blocked on an API error
         km._auto_resume_retry(int(time.time()), {})
         self.assertFalse(km._retry_paused_on(), "a served request after the pause proves recovery → resume")
@@ -73,7 +73,7 @@ class RetryPauseAutoResume(unittest.TestCase):
         km._set_retry_paused(True)
         floor = km._retry_pause_ts()
         path = self._transcript("errored.jsonl", floor + 5)   # fresh mtime, but the last record is an API error
-        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "path": path}]
+        km._alive_sessions = lambda now, live_map: [{"sid": "s1", "path": path}]
         km._api_error = lambda p: {"text": "overloaded", "status": 529}
         km._auto_resume_retry(int(time.time()), {})
         self.assertTrue(km._retry_paused_on(), "a session still blocked on an API error must not clear the pause")
@@ -83,7 +83,7 @@ class RetryPauseAutoResume(unittest.TestCase):
         km._set_retry_paused(True)
         floor = km._retry_pause_ts()
         path = self._transcript("stale.jsonl", floor - 60)    # last wrote BEFORE the pause
-        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "path": path}]
+        km._alive_sessions = lambda now, live_map: [{"sid": "s1", "path": path}]
         km._api_error = lambda p: None
         km._auto_resume_retry(int(time.time()), {})
         self.assertTrue(km._retry_paused_on(), "no fresh output since the pause → no evidence the API recovered")
@@ -92,7 +92,7 @@ class RetryPauseAutoResume(unittest.TestCase):
     def test_noop_when_not_paused(self):
         km._set_retry_paused(False)
         called = []
-        km._alive_sessions = lambda now, tmux: called.append(1) or []
+        km._alive_sessions = lambda now, live_map: called.append(1) or []
         km._auto_resume_retry(int(time.time()), {})
         self.assertEqual(called, [], "not paused → the resume check does no work")
 

--- a/tests/test_rewind_ghost_reply.py
+++ b/tests/test_rewind_ghost_reply.py
@@ -172,10 +172,10 @@ class BuildSessionNeverResurrectsARolledBackReply(unittest.TestCase):
             mod.NAMES, mod.PROJECTS = names, proj
             mod.CAPDIR, mod.ARCHDIR, mod.GOALDIR = td / "captions", td / "archive", td / "goals"
             mod.STATE, mod.STATESDIR = td, td / "states"
-        self.saved_km = (km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD)
+        self.saved_km = (km.NAMES, km._live_map, km._GLOBAL_CLAUDE_MD)
         km.NAMES = names
         km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None,
                                            "color": None}}
         km._parse_cache.clear()
@@ -184,7 +184,7 @@ class BuildSessionNeverResurrectsARolledBackReply(unittest.TestCase):
         for mod, *vals in self.saved:
             (mod.NAMES, mod.PROJECTS, mod.CAPDIR, mod.ARCHDIR,
              mod.GOALDIR, mod.STATE, mod.STATESDIR) = vals
-        (km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD) = self.saved_km
+        (km.NAMES, km._live_map, km._GLOBAL_CLAUDE_MD) = self.saved_km
         km._parse_cache.clear()
         self.td.cleanup()
 

--- a/tests/test_sdk_kernel.py
+++ b/tests/test_sdk_kernel.py
@@ -98,23 +98,34 @@ class KernelWiring(unittest.TestCase):
         self.assertTrue(self._route({"type": "sendMessage", "id": "sid-sdk", "text": "hi"}))
         self.assertIn(("send", "sid-sdk", "hi"), self.be.calls)
 
-    def test_non_sdk_sid_routes_to_the_tmux_backend(self):
-        # a non-SDK sid no longer "falls through" — _drive routes it to the tmux backend via
-        # Sessions.backend_for (the fallback). The unified dispatch handles BOTH kinds.
-        # It must be a session this kernel HAS, though: since 2026-07-29 _drive refuses an id it has never
-        # heard of rather than letting backend_for's tmux fallback type at a pane that isn't there. The
-        # names entry is what a real tmux session would carry; test_drive_foreign_sid.py owns the refusal.
-        tm = FakeBackend(); tm._owned = set()
-        saved, saved_name = km._TMUX, km._name_of
-        km._TMUX = tm
+    def test_a_reg_less_sid_routes_to_the_null_backend_and_the_sdk_stays_untouched(self):
+        # backend_for is registry-gated (owns()): a sid with no SDK reg — the retired terminal
+        # backend's era, revived only through _revive_session's adoption — routes to the NullBackend,
+        # whose every op is the documented refusal. Routing it to the SDK backend instead would let a
+        # dep-less backend invent state for sids it has no record of (its launch_error answers for
+        # EVERY sid, which painted every dead session's chat red). _drive still refuses ids this
+        # kernel has never heard of (test_drive_foreign_sid.py owns that).
+        saved_name = km._name_of
         km._name_of = lambda sid: "web"
         try:
-            self.assertTrue(self._route({"type": "sendMessage", "id": "sid-tmux", "text": "hi"}))
-            self.assertIn(("send", "sid-tmux", "hi"), tm.calls)   # routed to the tmux backend
-            self.assertEqual(self.be.calls, [])                   # the SDK backend was untouched
+            self.assertTrue(self._route({"type": "sendMessage", "id": "sid-unowned", "text": "hi"}))
+            self.assertEqual(self.be.calls, [], "the SDK backend is never asked about a reg-less sid")
         finally:
-            km._TMUX, km._name_of = saved, saved_name
-            km._tmux_echo.pop("sid-tmux", None)                   # the optimistic echo wrote here — don't leak it
+            km._name_of = saved_name
+
+    def test_backend_for_without_the_sdk_is_the_null_backend_never_none(self):
+        # SDK deps absent → every be.* call still lands on an object whose ops are the documented
+        # can't-do-it defaults (False/[]/None), never a crash (the ~35 bare be.* call sites)
+        saved = km._sdk
+        km._sdk = lambda: None
+        try:
+            be = km.Sessions.backend_for("11111111-2222-3333-4444-555555555555")
+            self.assertFalse(be.send("11111111-2222-3333-4444-555555555555", "hi"))
+            self.assertEqual(be.pending_queued("11111111-2222-3333-4444-555555555555"), [])
+            self.assertIsNone(be.current_ask("11111111-2222-3333-4444-555555555555"))
+            self.assertFalse(be.kill("11111111-2222-3333-4444-555555555555"))
+        finally:
+            km._sdk = saved
 
     def test_ui_op_falls_through_even_for_sdk_sid(self):
         # closeTab/openSession are backend-agnostic UI ops → never intercepted
@@ -273,8 +284,8 @@ class KernelWiring(unittest.TestCase):
         self.assertIn(("send", "sid-sdk", "hi"), self.be.calls)
         self.assertEqual(self.fu_calls, [], "no itemId → nothing to reopen")
 
-    def test_tmux_sessions_merges_sdk_rows(self):
-        sess = km._tmux_sessions()                     # merges tmux (real/empty) + the fake SDK row
+    def test_live_map_merges_sdk_rows(self):
+        sess = km._live_map()                     # merges tmux (real/empty) + the fake SDK row
         self.assertIn("sid-sdk", sess)
         row = sess["sid-sdk"]
         self.assertEqual(row["state"], "working")

--- a/tests/test_session_retry_suppress.py
+++ b/tests/test_session_retry_suppress.py
@@ -63,7 +63,7 @@ class SessionRetrySuppress(unittest.TestCase):
     def test_reengaged_and_settled_clean_rearms(self):
         km._suppress_session_retry("s1")
         floor = json.loads((self.dir / "retry-suppressed.json").read_text())["s1"]
-        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "path": "x"}]
+        km._alive_sessions = lambda now, live_map: [{"sid": "s1", "path": "x"}]
         km._parse_cached = lambda p: {"turns": [_human_turn(floor + 5)]}   # user spoke AFTER the stop
         km._session_chip = lambda *a, **k: "ready"                          # and it settled clean → success
         km._auto_resume_session_retry(int(time.time()), {})
@@ -75,7 +75,7 @@ class SessionRetrySuppress(unittest.TestCase):
     def test_reengaged_but_still_blocked_stays_suppressed(self):
         km._suppress_session_retry("s1")
         floor = json.loads((self.dir / "retry-suppressed.json").read_text())["s1"]
-        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "path": "x"}]
+        km._alive_sessions = lambda now, live_map: [{"sid": "s1", "path": "x"}]
         km._parse_cached = lambda p: {"turns": [_human_turn(floor + 5)]}   # user spoke...
         km._session_chip = lambda *a, **k: "blocked"                        # ...but the turn errored again
         km._auto_resume_session_retry(int(time.time()), {})
@@ -87,7 +87,7 @@ class SessionRetrySuppress(unittest.TestCase):
     def test_no_reengagement_stays_suppressed(self):
         km._suppress_session_retry("s1")
         floor = json.loads((self.dir / "retry-suppressed.json").read_text())["s1"]
-        km._alive_sessions = lambda now, tmux: [{"sid": "s1", "path": "x"}]
+        km._alive_sessions = lambda now, live_map: [{"sid": "s1", "path": "x"}]
         km._parse_cached = lambda p: {"turns": [_human_turn(floor - 60)]}  # last human message was BEFORE the stop
         km._session_chip = lambda *a, **k: "ready"
         km._auto_resume_session_retry(int(time.time()), {})
@@ -97,7 +97,7 @@ class SessionRetrySuppress(unittest.TestCase):
 
     def test_noop_when_nothing_suppressed(self):
         called = []
-        km._alive_sessions = lambda now, tmux: called.append(1) or []
+        km._alive_sessions = lambda now, live_map: called.append(1) or []
         km._auto_resume_session_retry(int(time.time()), {})
         self.assertEqual(called, [], "no suppressed sessions → the sweep does no work")
 
@@ -121,8 +121,8 @@ class SessionRetrySuppressWiring(unittest.TestCase):
                       "the chat status exposes retrySuppressed so the client retry loop + card can read it")
 
     def test_pusher_runs_the_per_session_resume_sweep(self):
-        # (now, tmux) — the cycle's ONE liveness snapshot, not a per-job fresh read (2026-08-10 CPU fix)
-        self.assertIn("_auto_resume_session_retry(now, tmux)", SRC,
+        # (now, live_map) — the cycle's ONE liveness snapshot, not a per-job fresh read (2026-08-10 CPU fix)
+        self.assertIn("_auto_resume_session_retry(now, live_map)", SRC,
                       "the pusher tick re-arms suppressed threads that land a clean turn")
 
 

--- a/tests/test_skill_content.py
+++ b/tests/test_skill_content.py
@@ -211,19 +211,19 @@ class BuildSessionJoin(unittest.TestCase):
         names = td / "names"; names.mkdir()
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
         self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE, km.NAMES,
-                      km._tmux_sessions, km._read_task_store, km._GLOBAL_CLAUDE_MD)
+                      km._live_map, km._read_task_store, km._GLOBAL_CLAUDE_MD)
         jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE = names, proj, td / "goals", td
         km.NAMES = names
         km._GLOBAL_CLAUDE_MD = td / "no-global.md"
         km._read_task_store = lambda fsid, fold=None: []
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         jd.GOALDIR.mkdir(parents=True)
         km._parse_cache.clear()
 
     def tearDown(self):
         (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE, km.NAMES,
-         km._tmux_sessions, km._read_task_store, km._GLOBAL_CLAUDE_MD) = self.saved
+         km._live_map, km._read_task_store, km._GLOBAL_CLAUDE_MD) = self.saved
         km._parse_cache.clear()
         self.td.cleanup()
 

--- a/tests/test_teammate_message.py
+++ b/tests/test_teammate_message.py
@@ -145,19 +145,19 @@ class BuildSessionEmitsTeammateCard(unittest.TestCase):
         names = td / "names"; names.mkdir()
         (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
         self.saved = (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE, km.NAMES,
-                      km._tmux_sessions, km._read_task_store, km._GLOBAL_CLAUDE_MD)
+                      km._live_map, km._read_task_store, km._GLOBAL_CLAUDE_MD)
         jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE = names, proj, td / "goals", td
         km.NAMES = names
         km._GLOBAL_CLAUDE_MD = td / "no-global.md"           # keep a real ~/.claude/CLAUDE.md out of the fixture
         km._read_task_store = lambda fsid, fold=None: []                # no to-do card in the way
-        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None, "color": None}}
         jd.GOALDIR.mkdir(parents=True)
         km._parse_cache.clear()
 
     def tearDown(self):
         (jd.NAMES, jd.PROJECTS, jd.GOALDIR, jd.STATE, km.NAMES,
-         km._tmux_sessions, km._read_task_store, km._GLOBAL_CLAUDE_MD) = self.saved
+         km._live_map, km._read_task_store, km._GLOBAL_CLAUDE_MD) = self.saved
         km._parse_cache.clear()
         self.td.cleanup()
 

--- a/tests/test_timeline_lineage.py
+++ b/tests/test_timeline_lineage.py
@@ -103,7 +103,7 @@ class TimelineLineageBase(unittest.TestCase):
 
 class BranchOnTheTimeline(TimelineLineageBase):
     def test_the_forked_lane_carries_its_branch_and_clips_the_copied_history(self):
-        tl = km.build_timeline(self.now, tmux={})
+        tl = km.build_timeline(self.now, live_map={})
         lane = self._lane(tl, CHILD)
         self.assertEqual(lane["branch"], {"fromId": PARENT, "t": self.fork_t, "cut": "a1"})
         starts = [b["start"] for b in tl["turns"][CHILD]]
@@ -116,19 +116,19 @@ class BranchOnTheTimeline(TimelineLineageBase):
     def test_a_gone_parent_returns_the_whole_story_to_the_child(self):
         (jd.NAMES / PARENT).unlink()                 # the parent session is gone from the timeline
         jd._discover_cache.clear()
-        tl = km.build_timeline(self.now, tmux={})
+        tl = km.build_timeline(self.now, live_map={})
         self.assertIsNone(self._lane(tl, CHILD)["branch"],
                           "no parent lane, no connector endpoint")
         self.assertTrue(any(b["start"] < self.fork_t for b in tl["turns"][CHILD]),
                         "with the parent gone the child reads as one session all along")
 
     def test_the_skeleton_carries_lineage_without_parsing(self):
-        tl = km.build_timeline(self.now, tmux={}, with_bars=False)
+        tl = km.build_timeline(self.now, live_map={}, with_bars=False)
         self.assertEqual(self._lane(tl, CHILD)["branch"]["fromId"], PARENT)
         self.assertEqual(tl["turns"], {}, "the skeleton still parses nothing")
 
     def test_an_unforked_lane_carries_no_branch(self):
-        tl = km.build_timeline(self.now, tmux={})
+        tl = km.build_timeline(self.now, live_map={})
         self.assertIsNone(self._lane(tl, PARENT)["branch"])
 
 
@@ -144,7 +144,7 @@ class CommentSquares(TimelineLineageBase):
             {"tid": "t3", "sid": "t3", "anchorUuid": "a1", "cutUuid": "a1",
              "exact": "x", "status": "promoted", "promotedName": "sidework",
              "createdT": self.now - 50, "lastSeenT": self.now}]})
-        tl = km.build_timeline(self.now, tmux={})
+        tl = km.build_timeline(self.now, live_map={})
         marks = self._lane(tl, PARENT)["comments"]
         self.assertEqual([m["tid"] for m in marks], [THREAD, "t2"],
                          "open + resolved ride the lane; a promoted thread IS a session")
@@ -153,7 +153,7 @@ class CommentSquares(TimelineLineageBase):
         self.assertEqual(marks[0]["uuid"], "a1")
 
     def test_a_lane_with_no_threads_pays_one_stat_and_carries_none(self):
-        tl = km.build_timeline(self.now, tmux={})
+        tl = km.build_timeline(self.now, live_map={})
         self.assertEqual(self._lane(tl, CHILD)["comments"], [])
 
 

--- a/tests/test_tmux_optional.py
+++ b/tests/test_tmux_optional.py
@@ -64,7 +64,7 @@ class TmuxOptional(unittest.TestCase):
     def _no_tmux(self):
         km.shutil.which = lambda name, *a, **k: None
 
-    def _has_tmux(self):
+    def _live_source_present(self):
         km.shutil.which = lambda name, *a, **k: "/usr/bin/tmux" if name == "tmux" else None
 
     # ── availability tracks PATH ──────────────────────────────────────────────
@@ -73,7 +73,7 @@ class TmuxOptional(unittest.TestCase):
         self.assertFalse(self.tb.available())
 
     def test_available_true_with_tmux(self):
-        self._has_tmux()
+        self._live_source_present()
         self.assertTrue(self.tb.available())
 
     # ── disabled means inert, not "failing quietly" ───────────────────────────
@@ -109,7 +109,7 @@ class TmuxOptional(unittest.TestCase):
         os.environ["ROMP_TMUX_AVAILABLE"] = "1"
         self.assertTrue(self.tb.available())
 
-        self._has_tmux()
+        self._live_source_present()
         for off in ("0", ""):
             os.environ["ROMP_TMUX_AVAILABLE"] = off
             self.assertFalse(self.tb.available(), "%r should force the backend off" % off)
@@ -121,7 +121,7 @@ class TmuxOptional(unittest.TestCase):
         self._no_tmux()
         self.assertFalse(self.tb.available())
 
-        self._has_tmux()
+        self._live_source_present()
         self.assertTrue(self.tb.available())        # same instance, no restart, no expiry wait
 
         seen = []

--- a/ui/webview/feed-colflip.test.ts
+++ b/ui/webview/feed-colflip.test.ts
@@ -36,11 +36,11 @@ test("kernel: the dirty floor keys on build START, so a mid-build mutation still
   assert.ok(!/_views_dirty\[0\] > e\[2\]/.test(KERNEL), "no dirty check keys on build finish");
   // the start stamp is taken BEFORE the build runs, in both caches
   const feedBody = KERNEL.slice(KERNEL.indexOf("def _cached_feed"), KERNEL.indexOf("def _cached_timeline"));
-  assert.ok(feedBody.indexOf("started = time.time()") < feedBody.indexOf("build_feed(now, tmux)"),
+  assert.ok(feedBody.indexOf("started = time.time()") < feedBody.indexOf("build_feed(now, live_map)"),
     "feed: start stamped before the build reads anything");
   assert.match(feedBody, /_built_feed\[:\] = \[sig, feed, time\.time\(\), started\]/);
   const tlBody = KERNEL.slice(KERNEL.indexOf("def _cached_timeline"), KERNEL.indexOf("def _run_tier"));
-  assert.ok(tlBody.indexOf("started = time.time()") < tlBody.indexOf("build_timeline(now, tmux)"),
+  assert.ok(tlBody.indexOf("started = time.time()") < tlBody.indexOf("build_timeline(now, live_map)"),
     "timeline: start stamped before the build reads anything");
   assert.match(tlBody, /_built_timeline\[:\] = \[sig, tl, time\.time\(\), started\]/);
   // the rebuild rate limit still keys on the finish, so back-to-back starts don't shrink its window

--- a/ui/webview/feed-move-ack.test.ts
+++ b/ui/webview/feed-move-ack.test.ts
@@ -51,7 +51,7 @@ test("kernel: the feed payload carries the build id, claimed BEFORE the read it 
   assert.match(KERNEL, /def _next_feed_build_id\(\):/);
   const cached = KERNEL.slice(KERNEL.indexOf("def _cached_feed("), KERNEL.indexOf("def _cached_timeline("));
   const claim = cached.indexOf("bid = _next_feed_build_id()");
-  const build = cached.indexOf("feed = build_feed(now, tmux)");
+  const build = cached.indexOf("feed = build_feed(now, live_map)");
   assert.ok(claim >= 0 && build > claim,
     "claimed before the build: one already in flight when a click lands gets the LOWER id it deserves");
   assert.match(cached, /feed\["buildId"\] = bid/);

--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -20,7 +20,7 @@ const V = "99999999-8888-7777-6666-555555555555";
 
 test("the kernel's feed payload carries the chat tab strip's sessions, tab_meta-shaped", () => {
   assert.ok(KERNEL.includes('"sessions": [{"sid": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}'));
-  assert.ok(KERNEL.includes("for s in _chat_tab_sessions(now, tmux)]"), "the SAME list the tabs render, in ITS order");
+  assert.ok(KERNEL.includes("for s in _chat_tab_sessions(now, live_map)]"), "the SAME list the tabs render, in ITS order");
 });
 
 test("federation prefixes each sessions[] entry's sid AND name, and the merge concatenates local-first", () => {

--- a/ui/webview/feed-status-pips.test.ts
+++ b/ui/webview/feed-status-pips.test.ts
@@ -23,8 +23,8 @@ const STYLES = here("styles.css");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
 test("the kernel publishes the unreadable-state list, and no ready list", () => {
-  assert.ok(KERNEL.includes("def _state_unknown_names(alive, tmux, working, awaiting):"));
-  assert.ok(KERNEL.includes('"stateUnknown": _state_unknown_names(alive, tmux, working, awaiting)'));
+  assert.ok(KERNEL.includes("def _state_unknown_names(alive, live_map, working, awaiting):"));
+  assert.ok(KERNEL.includes('"stateUnknown": _state_unknown_names(alive, live_map, working, awaiting)'));
   const feedSrc = KERNEL.slice(KERNEL.indexOf("def build_feed"), KERNEL.indexOf("def _push_feed"));
   assert.ok(!/"ready":\s*ready/.test(feedSrc), "a quiet session is not enumerated — blank already says it");
 });

--- a/ui/webview/picker-deep-list.test.ts
+++ b/ui/webview/picker-deep-list.test.ts
@@ -25,7 +25,7 @@ test("opening the picker asks for the whole list once — no lazy second fetch t
 test("the kernel serves the picker 30 days, with forks off so it stays cheap", () => {
   assert.match(KERNEL, /PICKER_WINDOW = 30 \* 86400/);
   assert.match(KERNEL, /_sessions\(now, PICKER_WINDOW if window is None else window, forks=False\)\[:PICKER_CAP\]/);
-  assert.match(KERNEL, /"items": _session_list\(int\(time\.time\(\)\), _tmux_sessions\(\)\)/);
+  assert.match(KERNEL, /"items": _session_list\(int\(time\.time\(\)\), _live_map\(\)\)/);
 });
 
 test("discover takes a window and a forks switch, cached per pair", () => {

--- a/ui/webview/render-settings.test.ts
+++ b/ui/webview/render-settings.test.ts
@@ -41,5 +41,7 @@ test("the chat has NO gear of its own — it only consumes the shared setting (g
 test("the + New session button sends the picker's backend toggle, defaulting to the gear's (the user 2026-06-23)", () => {
   // the per-session toggle wins; it RESETS to the gear default (read fresh via loadSettings()) on each open
   assert.match(RENDER, /startCreate\(\{ name, backend: beSel\?\.dataset\.be \|\| loadSettings\(\)\.backend,/);
-  assert.match(RENDER, /const def = loadSettings\(\)\.backend \|\| "tmux";/);   // toggle defaults to the gear setting
+  // the belt-and-braces fallback is "sdk" — the one backend since the terminal one's retirement
+  // (2026-08-16); loadSettings also normalizes a stale stored "tmux" (settings.test.ts pins that)
+  assert.match(RENDER, /const def = loadSettings\(\)\.backend \|\| "sdk";/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5038,7 +5038,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   const beWrapEl = overlay.querySelector(".picker-backend:not(.picker-host):not(.picker-auth)") as HTMLElement | null;
   if (beWrapEl) {   // reset the backend toggle to the gear default each open (overridable for this session)
     beWrapEl.style.display = pick ? "none" : "";
-    const def = loadSettings().backend || "tmux";
+    const def = loadSettings().backend || "sdk";
     beWrapEl.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", (x as HTMLElement).dataset.be === def));
   }
   const auWrapEl = overlay.querySelector(".picker-auth") as HTMLElement | null;

--- a/ui/webview/settings.test.ts
+++ b/ui/webview/settings.test.ts
@@ -63,6 +63,14 @@ test("the backend pref roundtrips through storage (the gear writes it; createSes
   assert.equal(loadSettings().backend, "sdk");
 });
 
+test('a stale stored backend:"tmux" normalizes to "sdk" on load (the terminal backend is retired, 2026-08-16)', () => {
+  // createSession reads this field verbatim, so a store written before the removal must never leak
+  // a "tmux" pick into a create call — the kernel would refuse it loudly, but the right default is
+  // simply the one backend that exists.
+  store["romp:settings"] = JSON.stringify({ backend: "tmux" });
+  assert.equal(loadSettings().backend, "sdk");
+});
+
 test("saveSettings persists a patch and merges over defaults", () => {
   delete store["romp:settings"];
   const next = saveSettings({ compact: true });

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -13,7 +13,7 @@ export interface RompSettings {
   showIndexJudges: boolean;
   showTriageJudges: boolean;
   debug?: boolean;    // LEGACY (the user 2026-06-17): the old single judging-band toggle; read as the migration fallback for the two judge-set toggles when those are unset. The ↻ restart button is always-visible (decoupled).
-  backend: "tmux" | "sdk";   // which backend a NEWLY-created session uses (the user 2026-06-22): "tmux" (terminal) or "sdk" (Agent SDK). Both coexist; this is only the default for the + button. Read at createSession time (render.ts). Default sdk (the user 2026-07-13).
+  backend: "tmux" | "sdk";   // which backend a NEWLY-created session uses (the user 2026-06-22). The terminal (tmux) backend is retired (2026-08-16): "tmux" survives in the type only because old stores may still hold it — loadSettings normalizes it to "sdk", so a stale pick can never reach a create call (the kernel refuses backend:"tmux" loudly anyway). Read at createSession time (render.ts). Default sdk (the user 2026-07-13).
   defaultDir: string;        // default working directory PREFILLED in the new-session field (the user 2026-06-22). A session's dir is fixed at creation. Empty → the kernel's serve dir. ~ / $VAR expanded server-side.
   showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). OFF by default (the user 2026-08-10, trimming the statusline for narrow panes; an explicit stored true keeps showing it).
   tabCtx: TabCtxMode;        // chat tabs: WHEN the context gauge shows beside each session name (the user 2026-08-08) — "over50" (default: only once half full, so quiet tabs stay clean), "always", or "never".
@@ -41,6 +41,11 @@ export function loadSettings(): RompSettings {
     if (raw) {
       const s = { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
       s.tabCtx = tabCtxMode(s.tabCtx);   // a store written by the boolean-era gear holds true/false
+      // A store written before the terminal backend's retirement (2026-08-16) can still hold
+      // backend:"tmux", and createSession reads this field verbatim — normalize on load so a
+      // stale pick never reaches a create call (the kernel refuses it loudly; the default here
+      // should simply be the one backend that exists).
+      if (s.backend === "tmux") s.backend = "sdk";
       return s;
     }
   } catch { /* corrupt / unavailable → defaults */ }


### PR DESCRIPTION
First of two changes retiring the terminal (tmux) backend (user directive 2026-08-15; external consumers were ported off tmux the same day). This PR lands every behavior change while the tmux code is still in-tree, so the unchanged full suite proves the shared mechanisms weren't disturbed; the follow-up is then near-pure deletion.

- Liveness map renamed off tmux: `_tmux_sessions()` → `_live_map()`, the `tmux` param → `live_map` across the build/tick layer; test stubs and UI source pins follow.
- Headless disambiguator keys on the live source (`_live_source_present()` — the SDK backend built), not a tmux binary probe; empty-map trust semantics unchanged.
- `Sessions.backend_for` routes registry-gated: SDK for every registered sid (dormant included), else a new `NullBackend` (documented refusals, never None, never a backend inventing state for unrecorded sids). `pending_cut` joins the contract with a `""` default. `Sessions.live()` seeds from `{}`.
- Creation doors refuse `backend:"tmux"` by name; missing field = SDK; webview stale-settings fallback flips to "sdk" with load-time normalization.
- Revive adopts reg-less (pre-SDK) sids through the backend's own resume — dead sessions revive with their history across the backend removal; no-transcript stays the loud reviveFailed.
- Shared-mechanism tests ported off tmux seams onto the SessionBackend seam (input-echo merge, queued-card assembly, nudge captures, boot-window synth, awaiting merge).

Suites: python 4766 pass, UI 2013 pass (bats surfaces untouched — CI's Shell check gates them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)