### PR TITLE
Idle sessions' Working cards always keep a live reviver

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -250,11 +250,13 @@ def _scan_bg_tasks(path, want_all=False):
     missing this left finished tasks reading 'running' forever), and a queue-operation enqueue holding
     the notification while the session is busy — the task itself is already finished the moment any of
     the three exists.
-    Returns [{id,status,summary,command,outputFile}] (+ type on agent/workflow rows)."""
+    Returns [{id,status,summary,command,outputFile}] (+ type on agent/workflow rows; + endT — the
+    transcript time its result LANDED — on rows a notification has terminal-marked, so the awaiting-stamp
+    lift can tell a return that ENDED a stamped wait from one the stamping judge had already seen)."""
     tasks, order = {}, []
     dispatch = {}   # tool_use id -> the launching Agent/Task/Workflow block's own words (see docstring)
 
-    def _mark(note):
+    def _mark(note, end_t=None):
         # a notification keyed by its INNER <tool-use-id> (the string/queue shapes have no wrapper block)
         tid = (note or {}).get("tool_use_id")
         if tid and tid in tasks:
@@ -262,6 +264,8 @@ def _scan_bg_tasks(path, want_all=False):
                 return                     # a monitor EVENT (no <status> tag) — the watch is still live
             tasks[tid].update(status=note["status"], outputFile=note["output_file"],
                               summary=note["summary"] or tasks[tid]["summary"])
+            if end_t:                      # WHEN the result landed — the awaiting-stamp lift keys the
+                tasks[tid]["endT"] = end_t  # "returned after the stamp was written" test on it (2026-08-16)
 
     try:
         with open(path, errors="replace") as f:
@@ -366,16 +370,22 @@ def _scan_bg_tasks(path, want_all=False):
                                     continue               # a wrapped monitor EVENT — not a terminal (see _mark)
                                 tasks[tid].update(status=note["status"], outputFile=note["output_file"],
                                                   summary=note["summary"] or tasks[tid]["summary"])
+                                et = parse_z(o.get("timestamp"))
+                                if et:                     # the return's moment (see _mark)
+                                    tasks[tid]["endT"] = et
                             elif tid in tasks and note is None and b.get("is_error") \
                                     and tasks[tid]["status"] == "running":
                                 # the LAUNCH's own ack errored (refused permission, bad input) → nothing ever
                                 # started, and no notification will ever come. Without this, the phantom
                                 # reads "running" forever and holds awaiting/nudge gates open on nothing.
                                 tasks[tid]["status"] = "failed"
+                                et = parse_z(o.get("timestamp"))
+                                if et:
+                                    tasks[tid]["endT"] = et
                 elif t == "user" and isinstance(c, str):
-                    _mark(_parse_task_notification(c))
+                    _mark(_parse_task_notification(c), parse_z(o.get("timestamp")))
                 elif t == "queue-operation" and o.get("operation") == "enqueue":
-                    _mark(_parse_task_notification(o.get("content") or ""))
+                    _mark(_parse_task_notification(o.get("content") or ""), parse_z(o.get("timestamp")))
     except OSError:
         return []
     if want_all:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4364,9 +4364,11 @@ def plan_units(session, store=None):
     prompt-run always FOLLOWS the earlier work-runs (close-before-open, for free, no time sort). A tagged
     FOLLOW-UP gets only its work unit (its card already reopens optimistically, and the work-run reopens +
     files under the target); `followup` = that goal-node id, or None.
-    A PEER/postal segment yields a 'delegation' work unit (the user 2026-06-22, via link_audit): its work
-    is filed UNDER the goal the COURIER planted for it, so a handed-off goal gets the same sub/done/block
-    expressivity as a human-minted top. A romp NUDGE segment (auto-nudge / Nudge button, on a goal) yields a
+    A PEER/postal segment with a KNOWN sender yields a 'delegation' work unit (the user 2026-06-22, via
+    link_audit): its work is filed UNDER the goal the COURIER planted for it, so a handed-off goal gets the
+    same sub/done/block expressivity as a human-minted top. A sender-LESS postal segment (author.peer None)
+    yields a plain work unit instead — the courier can never place a '#d' for it, and an unplaceable unit
+    wedges auto-nudge's placement gate (see the branch comment, 2026-08-16). A romp NUDGE segment (auto-nudge / Nudge button, on a goal) yields a
     'nudge' unit instead of a plain work unit: the planner must RESOLVE the goal to done/block, not file a
     step (the user 2026-06-22, via track_change). Empty segments drop.
     Each unit's LAST field is `quote` (_mint_quote): the trigger's verbatim head, cached on every node the
@@ -4434,10 +4436,21 @@ def plan_units(session, store=None):
                     out.append((seg["id"], "work", seg["t"], work_text, _seg_human(seg),
                                 _seg_followup(seg), trig, vq))
                 continue
-            if _seg_peer(seg):                            # POSTAL segment → DELEGATION work-run (files under the courier's goal)
+            _pm = _seg_peer(seg)
+            if _pm and _pm[0]:                            # POSTAL segment with a KNOWN sender → DELEGATION work-run
                 if not is_open_final:                     # ended → the recipient's work is known; place it under G
                     out.append((seg["id"], "delegation", seg["t"], work_text, False, None, trig, vq))
                 continue                                  # peer segs never get a prompt-run or a normal work-run
+            # A SENDER-LESS postal delivery (author.peer None: mail whose id the postal index can't
+            # resolve — an external tool posting through the kernel's send route with no session
+            # identity) falls THROUGH to the normal work-run. It must NOT yield a '#d' unit: the
+            # courier is the only placer of those and it requires the sender (it files under the
+            # SENDER's goal and plants the sender-side tracking node), so a sender-less '#d' stays
+            # unplaced forever — and auto-nudge's placement gate (kernel `_auto_nudge_session`,
+            # `_unplanned`) reads any unplaced unit as "judges still pending" and silences the WHOLE
+            # session's escalation ladder (2026-08-16: two such units from an anonymous dashboard
+            # poller wedged an idle session's Working cards for two days, nudge-, wake- and
+            # reminder-proof). The planner files the segment like any non-human work stretch.
             human, followup = _seg_human(seg), _seg_followup(seg)
             if is_open_final:                             # the IN-PROGRESS segment → PROMPT-run only (place the ask now)
                 if human and not followup and not _seg_slash_shaped(seg):
@@ -9586,7 +9599,13 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=CONCURRENCY, v
                     # fired before). Defense in depth beside the fork's sealed-placements seed.
                     continue
                 pm = _seg_peer(seg)
-                if not pm or not pm[0]:                # peer-triggered with a known sender only
+                if not pm or not pm[0]:                # peer-triggered with a KNOWN sender only. This filter
+                    #                                    is one half of a partition contract with plan_units:
+                    #                                    the courier places exactly the peer segments it can
+                    #                                    file under a sender's goal, and plan_units yields a
+                    #                                    '#d' unit for exactly those (a sender-less one gets a
+                    #                                    plain work unit there instead — a '#d' nothing places
+                    #                                    wedges auto-nudge's placement gate, 2026-08-16).
                     continue
                 pending.append((seg["t"], fsid, seg["id"], _unit_text(seg["atoms"]), pm[1], pm[0],
                                 _seg_peer_kind(seg), _seg_anchor(seg)))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2406,6 +2406,19 @@ def _mark_auto_nudged(gid, turn_id, count, arm_atoms=None, at=None):
     _write_auto_nudge(d)
 
 
+def _drop_auto_nudge_rec(gid):
+    """Erase `gid`'s ledger record outright — called when NEW INFORMATION voids the episode the record
+    tracks (today: an awaiting-stamp LIFT in _lift_spent_awaiting — the wait the episode ended on has
+    returned). The record's arm-key dedup and its failed/moot latches all assume the world the episode
+    saw; once a later event supersedes that world, keeping them latched leaves an IDLE session (which
+    never produces the genuine turn a re-arm needs) in Working forever with no reviver (2026-08-16)."""
+    d = dict(_auto_nudge_data())
+    nudged = dict(d.get("nudged", {}))
+    if nudged.pop(gid, None) is not None:
+        d["nudged"] = nudged
+        _write_auto_nudge(d)
+
+
 def _goal_awaiting_stamp(nodes, top, children=None, answered_at=0):
     """The freshest live ⏳ stamp in `top`'s subtree — the JUDGE's durable awaiting verdict (the closer's
     `awaiting` annotation, kernel/judge.py: the goal's latest audited turn ended waiting on async work it
@@ -3099,7 +3112,9 @@ def _lift_spent_awaiting(now, tmux):
     The retraction is the EVENT, never a timer: the <task-notification> that answered each dispatch is in
     the transcript, and _scan_bg_tasks already pairs launches to results. SELF-SCOPING, so the broader
     awaiting flavors are untouched: we lift only when this goal DID dispatch background work of its own by
-    stamp time and every one of those has come back. A stamp naming a CI run, a scheduled check-back or a
+    stamp time, every one of those has come back, and at least one came back AFTER the stamp's anchor —
+    a return already sitting in a turn the stamping judge had audited can't be what the stamp waits on
+    (see the loop's _returned_after note, 2026-08-16). A stamp naming a CI run, a scheduled check-back or a
     peer handoff owns no such dispatches, so it never matches and keeps its stamp — those still rely on the
     6h awaiting wake (_wake_goal, in the nudge tick's goal walk), which is exactly the case a timer is the
     only tool for. A kind=job stamp that DOES own dispatches (the standard shape: a watcher armed over an
@@ -3179,8 +3194,34 @@ def _lift_spent_awaiting(now, tmux):
                 live_set = running_job if nd.get("awaitingKind") == "job" else running
                 if any(t.get("id") in live_set for t in own):
                     continue                          # at least one is genuinely still out
+                # The lift's event is a return the stamp was WAITING ON — one that landed after the
+                # stamp's ANCHOR (endT past the audited turn's trigger; a launch past it necessarily
+                # returned past it too; a kindless expiry "returns" at its recorded deadline). A
+                # dispatch already terminal in a turn the stamping judge had ALREADY AUDITED can't
+                # evidence the wait's end: the judge stamped knowing that completion, so the wait is
+                # about something else, and the goal keeps its stamp + 6h wake like any dispatch-less
+                # wait. The boundary is the anchor, NOT the write time (`horizon`): the write postdates
+                # the whole audited turn, so testing against it would also disown mid-turn and
+                # audit-lag returns the judge never saw (the suite pins those as lifting). Without
+                # this, a stamp about external cluster work lifted the same minute it was written off
+                # a workflow hours dead — and the lift row then MOOTED the nudge-failure evaluation,
+                # parking the card in Working with no reviver left (an idle experiment session,
+                # 2026-08-16).
+                _anchor = nd.get("awaitingAt") or 0
+                def _returned_after(t):
+                    return ((t.get("endT") or 0) > _anchor or (t.get("t") or 0) > _anchor
+                            or (t.get("status") == "running" and (t.get("deadline") or 0) > _anchor))
+                if not any(_returned_after(t) for t in own):
+                    continue
                 if jd.record_verdict(store, nd, "romp", "awaiting", _lift_ev_t(nd, now), lift=True):
                     changed = True
+                    # The lift is NEW INFORMATION for the escalation ladder: the wait this goal's last
+                    # nudge/wake episode ended on has returned. Drop the goal's spent ledger record
+                    # (failed/moot/answered alike) so the next tick can re-engage — an idle session
+                    # never produces the genuine turn the arm-key dedup otherwise waits for, and a
+                    # latched record left its cards in Working forever (2026-08-16). Event-keyed and
+                    # bounded: record_verdict lifts a given stamp exactly once.
+                    _drop_auto_nudge_rec(top)
             if changed:
                 jd.rollup_status(store, False)
                 jd.save_goals(sid, store)

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -2296,7 +2296,19 @@ class PostalDelegation(unittest.TestCase):
             tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
             saved = (jd.GOALDIR, jd.PCACHE, jd.MESSAGES, jd.plan_llm, jd.opener_llm, jd._group_store, jd._view_cleared)
             jd.GOALDIR, jd.PCACHE = td / "goals", td / "pcache"
-            jd.MESSAGES = td / "messages.jsonl"           # hermetic: empty postal index (no live data, peer=None)
+            jd.MESSAGES = td / "messages.jsonl"           # hermetic postal index in which every delivered mid
+            #                                               RESOLVES to a sender — the courier only plants for a
+            #                                               known sender, and a sender-less delivery yields no
+            #                                               '#d' at all (test_judge_senderless_delegation)
+            mids = set()
+            for r in recs:
+                c = (r.get("message") or {}).get("content")
+                if isinstance(c, str):
+                    for part in c.split("<!-- romp-msg-id:")[1:]:
+                        mids.add(part.split("-->")[0].strip())
+            jd.MESSAGES.write_text("".join(
+                json.dumps({"ev": "sent", "id": m, "from_id": "11111111-2222-3333-4444-00000000cccc"}) + "\n"
+                for m in sorted(mids)))
             jd.plan_llm, jd.opener_llm = work, (lambda *a, **k: "")
             jd._group_store = lambda *a, **k: None
             try:

--- a/tests/test_judge_senderless_delegation.py
+++ b/tests/test_judge_senderless_delegation.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""A sender-less postal delivery must never yield a '#d' delegation unit — nothing can place one, and one
+unplaceable unit silences auto-nudge for the WHOLE session (2026-08-16).
+
+The incident: an external tool posted a delegate-kind message into a session through the kernel's send
+route with no session identity, so the delivered marker's id resolved to no sender in the postal index
+(author.peer None). `plan_units` treated ANY postal segment as a delegation work-run and yielded a '#d'
+unit; `run_courier` — the only placer of '#d' units — requires a KNOWN sender (it files under the
+sender's goal and plants the sender-side tracking node), so it skipped the segment every pass, without
+retiring it. auto-nudge's `_unplanned` gate reads every unplaced unit as "judges still pending", so the
+session's whole escalation ladder (status nudges, awaiting wakes, debt reminders) went dead: two Working
+cards sat untouched on an idle session for two days, with no chip and no block.
+
+The partition contract now: the courier places exactly the peer segments whose sender it can resolve,
+and `plan_units` yields a '#d' unit for exactly those. A sender-less postal segment falls through to the
+planner's plain WORK unit — placeable like any non-human stretch, so the gate can never wedge on it.
+SYNTHETIC fixtures only: placeholder UUIDs, invented message bodies.
+"""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_senderless_deleg", os.path.join(BIN, "romp-judge")).load_module()
+
+NOW = 1781200000
+SID = "11111111-2222-3333-4444-777777777777"
+SENDER = "11111111-2222-3333-4444-888888888888"
+MID = "1781199000.000001_11111.TESTHOST"
+T0 = NOW - 3600
+BODY = ("Compute request: run the standard comparison suite over the five staged runs and report "
+        "the embedding drift.\n<!-- romp-msg-id: %s -->\n<!-- romp-msg-kind: delegate -->" % MID)
+
+MINT = '{"ops":[{"why":"real work landed","do":"mint","text":"Run the staged comparison suite"}]}'
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "sdk", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+RECORDS = [
+    uline(T0, BODY, "u1"),
+    aline(T0 + 60, "Suite dispatched; drift summary written to the shared report.", "a1", "u1"),
+]
+
+
+class SenderlessDelegation(unittest.TestCase):
+    def _units(self, path, store=None):
+        turns = jd.parsed_session(SID, [path], NOW)["turns"]
+        return [(u[0], u[1]) for u in jd.plan_units({"turns": turns}, store)]
+
+    def _gate_is_open(self, store, path):
+        """Mirror kernel `_auto_nudge_session`'s `_unplanned` check: every unit already placed?"""
+        turns = jd.parsed_session(SID, [path], NOW)["turns"]
+        live = {sg["id"] for tn in turns for sg in jd._segs(tn, store)}
+        placements = store.get("placements") or {}
+        return all(jd._placed_key(placements, jd._unit_key(u[0], u[1]), live)
+                   for u in jd.plan_units({"turns": turns}, store))
+
+    def test_senderless_postal_segment_yields_a_plain_work_unit(self):
+        with tempfile.TemporaryDirectory() as td:
+            tpath = Path(td) / (SID + ".jsonl")
+            tpath.write_text("\n".join(json.dumps(r) for r in RECORDS) + "\n")
+            jd._PARSE_CACHE.clear()
+            phases = [ph for _sg, ph in self._units(str(tpath))]
+            self.assertNotIn("delegation", phases,
+                             "no sender resolved → the courier can never place a '#d'; none may be yielded")
+            self.assertIn("work", phases, "the delivered ask files through the planner's plain work-run")
+
+    def test_a_known_sender_still_yields_the_delegation_unit(self):
+        with tempfile.TemporaryDirectory() as td:
+            tpath = Path(td) / (SID + ".jsonl")
+            tpath.write_text("\n".join(json.dumps(r) for r in RECORDS) + "\n")
+            saved = jd.MESSAGES
+            jd.MESSAGES = Path(td) / "messages.jsonl"
+            jd.MESSAGES.write_text(json.dumps(
+                {"t": T0 - 1, "ev": "sent", "id": MID, "from_id": SENDER, "to_id": SID}) + "\n")
+            try:
+                jd._PARSE_CACHE.clear()
+                phases = [ph for _sg, ph in self._units(str(tpath))]
+                self.assertIn("delegation", phases, "a resolvable sender keeps the courier's '#d' work-run")
+                self.assertNotIn("work", phases, "and the planner does not double-place it")
+            finally:
+                jd.MESSAGES = saved
+                jd._PARSE_CACHE.clear()
+
+    def test_one_planner_pass_opens_the_nudge_gate(self):
+        """The systemic claim: with the sender-less segment owned by the planner, one ordinary pass
+        places it and auto-nudge's placement gate reads planned — no unit is left forever pending."""
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            tpath = td / (SID + ".jsonl")
+            tpath.write_text("\n".join(json.dumps(r) for r in RECORDS) + "\n")
+            saved = (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store)
+            jd.GOALDIR, jd.PCACHE = td / "goals", td / "pcache"
+            jd.plan_llm = jd.opener_llm = lambda *a, **k: MINT
+            jd._group_store = lambda *a, **k: None
+            try:
+                jd._PARSE_CACHE.clear()
+                store = jd.load_goals(SID)
+                self.assertFalse(self._gate_is_open(store, str(tpath)),
+                                 "precondition: the fresh unit starts unplaced (gate closed)")
+                jd._plan_session(SID, str(tpath), NOW)
+                store = jd.load_goals(SID)
+                self.assertTrue(self._gate_is_open(store, str(tpath)),
+                                "the planner places the sender-less segment; the gate reopens")
+            finally:
+                (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store) = saved
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_awaiting_lift.py
+++ b/tests/test_kernel_awaiting_lift.py
@@ -359,6 +359,46 @@ class AwaitingLift(unittest.TestCase):
         self.assertEqual(sorted(t["id"] for t in every), ["t1", "t2"])
         self.assertEqual({t["id"]: t["status"] for t in every}["t1"], "completed")
 
+    # ---- a return the stamping judge already saw cannot end the wait (2026-08-16) ----
+    def test_scan_records_when_the_result_landed(self):
+        # the substrate: endT is the notification record's transcript time, the lift's evidence
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        every = km._scan_bg_tasks(self.path, want_all=True)
+        self.assertEqual(int(every[0].get("endT") or 0), BACK)
+
+    def test_returns_the_stamp_already_knew_do_not_lift_it(self):
+        # the incident: a stamp about EXTERNAL work (cluster captures due hours later) was written
+        # while the goal's only local dispatch had returned HOURS earlier, in a turn the stamping
+        # judge had long since audited — the all-returned test was instantly true and the stamp
+        # lifted the same minute it was written, whereupon the lift row mooted the nudge-failure
+        # evaluation and the card idled in Working with no reviver left. A return that predates the
+        # stamp's ANCHOR (the audited turn's trigger) is evidence the judge stamped WITH; only a
+        # return past the anchor can be the event the stamp waited on. (Mid-turn and audit-lag
+        # returns — after the anchor, before the write — keep lifting, per the tests above.)
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed(why="waiting on the four cluster captures landing overnight",
+                   anchor=BACK + 80, written=BACK + 100)   # stamped well after the return landed
+        self._tick(now=BACK + 500)
+        self.assertIsNotNone(self._stamp(),
+                             "a pre-anchor return can't end the wait — the 6h wake owns this one")
+
+    def test_a_lift_drops_the_goals_spent_nudge_record(self):
+        # the lift is NEW INFORMATION for the escalation ladder: an idle session never produces the
+        # genuine turn the ledger's arm-key dedup waits for, so a latched (failed/moot) record would
+        # otherwise silence nudges on this goal forever — erase it with the stamp (2026-08-16)
+        self._transcript([_launch("t1", LAUNCH), _notification("t1", BACK)])
+        self._seed()
+        km._mark_auto_nudged(self.gid, "SOME-ARM-TURN", 3, at=BACK - 50)
+        d = dict(km._auto_nudge_data())
+        n = dict(d.get("nudged", {}))
+        n[self.gid] = dict(n[self.gid], moot=True)      # the latch the incident carried
+        d["nudged"] = n
+        km._write_auto_nudge(d)
+        self._tick()
+        self.assertIsNone(self._stamp(), "precondition: this lift lands")
+        self.assertNotIn(self.gid, km._auto_nudge_data().get("nudged", {}),
+                         "the lift erases the spent record so the ladder can re-engage")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Investigation of two idle experiment sessions whose Working cards sat untouched for up to two days with no nudge, no wake, and no block found three compounding latches; each alone can park a card in Working forever on a session that produces no new turns.

**1. A sender-less postal delivery wedges the auto-nudge placement gate (permanently, session-wide).**
An external tool posted a delegate-kind message through the kernel's send route with no session identity, so the delivered marker's id resolved to no sender (`author.peer` None). `plan_units` yielded a `#d` delegation unit for it, but `run_courier` — the only placer of `#d` units — requires a known sender (it files under the sender's goal) and skipped it every pass without retiring it. Auto-nudge's `_unplanned` gate reads any unplaced unit as "judges still pending" and returns before the goal walk, so nudges, awaiting wakes, and debt reminders all went dead for the whole session. `plan_units` now yields `#d` exactly for the peer segments the courier can place (the partition is documented at both ends); a sender-less delivery files through the planner's plain work-run.

**2. The awaiting-stamp lift counted returns the stamping judge had already audited.**
A stamp about external cluster work lifted the same minute it was written, because the goal's only local dispatches had returned hours earlier — evidence the judge stamped *with*, not the event the stamp waited on. The lift now requires at least one of the goal's own dispatches to have returned after the stamp's anchor (the audited turn's trigger); `_scan_bg_tasks` records `endT` (when each result landed) to make that determinable. Mid-turn and audit-lag returns keep lifting, per the existing suite. Pre-anchor-only returns keep the stamp and its 6h wake, like any dispatch-less wait.

**3. A spent nudge ledger record has no re-arm event on an idle session.**
The premature lift row then mooted the nudge-failure evaluation, and a moot (or failed) record latches on the arming turn — which an idle session never replaces. A lift now erases the goal's ledger record: the lift is the new-information event that justifies re-engaging, and `record_verdict` fires it exactly once per stamp, so no flap.

Tests: a new `test_judge_senderless_delegation.py` pins the partition and that one planner pass reopens the gate; `test_kernel_awaiting_lift.py` gains the pre-anchor-return keep, the ledger-drop-on-lift, and the `endT` substrate. The `PostalDelegation` fixture now resolves its senders the way live delivery guarantees for planted goals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)