### PR TITLE
A failed preview narrates its retry plan and every tap visibly responds

### DIFF
--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -45,6 +45,25 @@ test("a kernel-VERIFIED preview fails LOUDLY: a retry chip holds the figure's sp
   assert.match(CSS, /\.path-full-retry \{ display: inline-flex;/, "visible chrome — the chip has chat-sheet css");
 });
 
+test("the failure chip narrates what happens next, escalates on repeat, and a retry's swirl is perceivable", () => {
+  // the user 2026-08-16, on a slow connection: a dead-end "unavailable" that later healed itself read
+  // as broken UI, and a tap whose instant failure re-rendered an identical chip read as ignored.
+  const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
+  // copy names the armed auto-heal while bounded retries remain; plain tap-to-retry once spent
+  assert.match(pf, /"⚠ still unavailable" : "⚠ preview unavailable"/);
+  assert.match(pf, /autoRetries > 0 \? " — retrying automatically · tap to retry now" : " — tap to retry"/);
+  // a repeat failure pulses the chip on swap-in — the acknowledge-every-click rule
+  assert.match(pf, /chip\.classList\.add\("path-retry-flash"\);/);
+  assert.match(CSS, /\.path-full-retry\.path-retry-flash \{ animation: path-retry-flash/);
+  assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.path-full-retry\.path-retry-flash \{ animation: none;/);
+  // a manual retry that dies instantly holds the swirl a perceivable beat before the chip returns
+  assert.match(PREVIEW, /const MIN_RETRY_SPIN_MS = 400;/);
+  assert.match(pf, /const left = bust \? MIN_RETRY_SPIN_MS - \(Date\.now\(\) - started\) : 0;/);
+  assert.match(pf, /if \(left > 0\) setTimeout\(showChip, left\); else showChip\(\);/);
+  // the delayed swap yields to a re-rendered turn — a fresh box owns the spot by then
+  assert.match(pf, /if \(!box\.isConnected\) return;/);
+});
+
 test("a failed preview heals on the next kernel push — the kernel-is-back event, not a tap or a timer", () => {
   // the 2026-08-15 report: the fetch died in a converge-restart window, and delta-send never rebuilds
   // an old turn's DOM, so the chip sat until a human tapped it. Any incoming kernel message proves the

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -36,6 +36,13 @@ export function canPreview(): boolean {
 // per URL for this page life: chat re-renders rebuild these elements constantly, and re-flashing a
 // spinner over bytes the browser just painted would itself be flicker — only a URL's FIRST load spins.
 const loadedOnce = new Set<string>();
+
+// A manual retry's swirl stays up at least this long before a failure may swap the chip back in —
+// an instant connection reset otherwise flashes it for one frame and the tap looks ignored (the
+// user 2026-08-16). Presentation smoothing only: the failed state is already decided, this paces
+// nothing but the paint.
+const MIN_RETRY_SPIN_MS = 400;
+
 function withLoadCue(box: HTMLElement, img: HTMLImageElement, url: string): void {
   if (loadedOnce.has(url)) return;
   const spin = document.createElement("img");
@@ -156,8 +163,10 @@ export function previewFull(path: string, sid?: string | null, verified = false)
     // rebuilds an old turn's DOM, so the chip would otherwise sit until a human tapped it. Bounded so
     // a genuinely-dead file settles on the tap chip instead of re-fetching on every push forever.
     let autoRetries = 3;
+    let fails = 0;                                   // total failed attempts — the chip's copy escalates
     const build = (bust: boolean) => {
       box.textContent = "";
+      const started = Date.now();                    // the retry's min-visible spinner measures from here
       const img = document.createElement("img");
       img.className = "path-full-img";
       img.src = bust ? url + "&r=" + Date.now() : url;   // bust: a retry must not re-read the failed cache entry
@@ -166,14 +175,35 @@ export function previewFull(path: string, sid?: string | null, verified = false)
       img.onclick = (ev) => { ev.stopPropagation(); openLightbox(path, sid); };
       img.onerror = () => {
         if (!verified) { box.remove(); return; }
-        box.textContent = "";
-        const chip = document.createElement("span");
-        chip.className = "path-full-retry";
-        chip.textContent = "⚠ preview unavailable — tap to retry";
-        chip.title = path;
-        chip.onclick = (ev) => { ev.stopPropagation(); build(true); };
-        box.appendChild(chip);
-        if (autoRetries > 0) { autoRetries--; failedPreviews.set(box, () => build(true)); }
+        fails++;
+        const showChip = () => {
+          if (!box.isConnected) return;              // the turn re-rendered; a fresh box owns this spot now
+          box.textContent = "";
+          const chip = document.createElement("span");
+          chip.className = "path-full-retry";
+          // The chip names what happens NEXT, not just the failure (the user 2026-08-16, on a slow
+          // link: a dead-end "unavailable" that then quietly healed itself read as broken UI). While
+          // bounded auto-retries remain, the next kernel push re-fetches on its own — say so. And a
+          // repeat failure must READ as a response to the tap, not the same chip standing still:
+          // the copy shifts to "still unavailable" and the swap-in pulses once.
+          chip.textContent =
+            (fails > 1 ? "⚠ still unavailable" : "⚠ preview unavailable")
+            + (autoRetries > 0 ? " — retrying automatically · tap to retry now" : " — tap to retry");
+          chip.title = path;
+          chip.onclick = (ev) => { ev.stopPropagation(); build(true); };
+          box.appendChild(chip);
+          if (fails > 1) {
+            chip.classList.add("path-retry-flash");
+            chip.addEventListener("animationend", () => chip.classList.remove("path-retry-flash"), { once: true });
+          }
+          if (autoRetries > 0) { autoRetries--; failedPreviews.set(box, () => build(true)); }
+        };
+        // A retry that dies instantly (a dead tunnel resets the connection in milliseconds) would
+        // flash the swirl for one frame and put back an identical chip — an ignored-looking tap.
+        // Hold the swirl to a perceivable beat before swapping. Presentation smoothing only: the
+        // attempt has already failed, and the auto-heal registration rides the same swap.
+        const left = bust ? MIN_RETRY_SPIN_MS - (Date.now() - started) : 0;
+        if (left > 0) setTimeout(showChip, left); else showChip();
       };
       withLoadCue(box, img, url);   // mini swirl holds the spot until the load event (memo on the un-busted url)
       box.appendChild(img);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2298,6 +2298,11 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
   background: rgba(255, 255, 255, 0.08); border: 1px solid rgba(255, 255, 255, 0.14);
   font-size: 0.85em; opacity: 0.85; cursor: pointer; }
 .path-full-retry:hover { border-color: var(--accent); }
+/* a repeat failure's chip pulses once on swap-in so an identical-looking outcome still reads as a
+   RESPONSE to the tap (preview.ts previewFull) */
+.path-full-retry.path-retry-flash { animation: path-retry-flash 0.45s ease; }
+@keyframes path-retry-flash { 0% { background: rgba(255, 255, 255, 0.3); } 100% { background: rgba(255, 255, 255, 0.08); } }
+@media (prefers-reduced-motion: reduce) { .path-full-retry.path-retry-flash { animation: none; } }
 /* VS Code's host-round-trip image chip while the bytes are still on their way (render.ts fillPathImg) —
    pure-CSS pulse, the sandbox can't fetch the swirl asset */
 .user-img-path.img-pending::after { content: " ···"; letter-spacing: 2px;


### PR DESCRIPTION
On a slow connection the preview failure chip read as a dead end (the user, 2026-08-16): it said only "unavailable" while the bounded auto-heal was silently armed — so previews that later healed on their own looked like broken UI — and a tap whose retry failed instantly flashed the load swirl for a single frame before re-rendering an identical chip, which reads as an ignored click.

Three changes, all presentation-side (the transport and the event-keyed retry machinery are untouched):

- The chip names what happens next: "⚠ preview unavailable — retrying automatically · tap to retry now" while bounded auto-retries remain, plain "tap to retry" once they're spent.
- A repeat failure escalates the copy to "⚠ still unavailable" and pulses the chip once on swap-in, so an identical outcome still visibly responds to the tap (the acknowledge-every-click rule; reduced-motion disables the pulse).
- A manual retry holds the swirl a perceivable beat (400ms floor) before a failure may swap the chip back — an instant connection reset no longer looks like nothing happened. The delayed swap yields to a re-rendered turn's fresh box.

Pinned in chat-inline-preview.test.ts alongside the existing preview pins; typecheck and the UI suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)