### PR TITLE
A fresh spawn's kickoff message survives the effort-pin reconnect

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4608,7 +4608,7 @@ def _apply_new_session_prefs(sid, body):
     return out
 
 
-def _create_sdk_session(nm, cwd, auth=""):
+def _create_sdk_session(nm, cwd, auth="", prefs=None):
     """Create + open a new SDK-backed session, ACK-FAST (the user 2026-07-14, who asked why it took so long
     to open a new SDK session). spawn() is file writes and connect() is threaded (~0.4s to a booting
     CLI) — the 7-10s the user waited was the handler's inline _push_all(): a new session invalidates the
@@ -4619,15 +4619,24 @@ def _create_sdk_session(nm, cwd, auth=""):
     (the push-architecture rule, 2026-07-05) — but DO push this ONE session's tab+payload directly
     (_push_session_now, one near-free transcript-less build): the dirty wake alone left the tab riding
     the next full cycle, ~5-6s on a busy fleet, all of it spent staring at the provisional dots
-    (measured live, the user 2026-08-10)."""
+    (measured live, the user 2026-08-10).
+
+    `prefs`: the /new body's per-spawn model/effort pins, applied BETWEEN spawn and connect so the FIRST
+    connect's options carry them (--effort is connect-time). Applied after connect they RACED it:
+    set_effort's request_reconnect armed a teardown of the just-connected client, and a `romp new -m`
+    kickoff fed into that dying client's stdin was cancelled mid-delivery and landed nowhere (a fresh
+    spawn's briefing sat as a dropped echo for 5.5h on a conversation that never started, 2026-08-16).
+    Pre-connect there is no session object yet, so the setters are pure reg writes the connect reads —
+    no reconnect exists to race. Returns (sid, echo) — echo is the applied-prefs ack for /new's reply."""
     bg, fg = _pick_identity_color()   # fleet-aware: only the kernel sees BOTH backends' live sessions
     _commands_for_cwd(cwd)   # pre-warm the slash-command list — a new session predicts a composer (the user 2026-08-13)
     sid = _sdk().spawn(nm, cwd, bg, fg, auth=auth)
+    extra = _apply_new_session_prefs(sid, prefs or {})
     _sdk().connect(sid)    # eager-connect so the model lists immediately, not only after the 1st message
     _reveal_chat({"type": "focus", "id": sid})
     _mark_views_dirty()
     _push_session_now(sid)   # the tab the user is staring at, ahead of the woken cycle
-    return sid
+    return sid, extra
 
 
 def _fork_session(parent_sid, cut_msg_uuid, new_name, now=None):
@@ -24392,8 +24401,8 @@ class Handler(BaseHTTPRequestHandler):
                         return self._send(200, json.dumps({"ok": False, "error": SDK_SETUP_HINT}),
                                           "application/json")
                     a = (b or {}).get("auth")
-                    sid = _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""))
-                    extra = _apply_new_session_prefs(sid, b)
+                    sid, extra = _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""),
+                                                     prefs=b)   # pins ride the FIRST connect — see the def
                     return self._send(200, json.dumps({"ok": True, "id": sid, "dir": cwd, **extra}),
                                       "application/json")
                 threading.Thread(target=_spawn_session, args=(nm, cwd), daemon=True).start()

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1276,6 +1276,12 @@ class SdkSession:
         self.loop: asyncio.AbstractEventLoop | None = None
         self.client = None
         self.inflight = 0
+        # The TEXTS of turns fed to the current client whose ResultMessage hasn't landed — the fed-turn
+        # twin of `inflight` (append at feed, cleared at the authoritative settle), all on the loop
+        # thread. Exists for the reconnect teardown: a turn fed into a client being torn down is in NO
+        # store (inputs() already removed it from the persisted queue), and without its text the
+        # loop-top reconcile could only settle counters while the turn itself vanished (2026-08-16).
+        self._inflight_texts: list[str] = []
         # The CLI's own stderr, last few lines (see _on_cli_stderr). The SDK only PIPES the child's
         # stderr when this callback is registered, so without it a launch failure's real cause — the
         # line the CLI printed before exiting — is discarded by the transport and never reaches the
@@ -1589,6 +1595,49 @@ class SdkSession:
             self._wake_set()
         else:
             self._reconnect_when_idle = True   # the ResultMessage handler fires it when the turn ends
+
+    def _reconcile_stranded(self):
+        """RECONCILE ACROSS A RECONNECT, at the loop's top where no client is connected so nothing can
+        legitimately be in flight (the user 2026-07-01, who switched the model on a new session and it
+        said working indefinitely). A reconnect abandons the previous client; a turn it left in flight
+        can NEVER get its ResultMessage on the new connection — so inflight, and the "working" signal it
+        drives, would be stranded elevated FOREVER. request_reconnect defers while inflight>0, but a race
+        (it fired at inflight==0, then the input generator fed a turn before the teardown ran) can still
+        strand a turn here: settle the counters to idle. A not-yet-STARTED _pending turn survives as
+        before (never fed to the dead client; the new inputs() re-feeds it). No-op on the first connect
+        and on a clean reconnect. Event-based on the reconnect itself, not a time/age heuristic.
+
+        And the FED turn itself must not vanish with the client it was fed to (2026-08-16: a spawn's -m
+        kickoff, fed just as an effort-pin's teardown fired, landed nowhere — not in _pending, not in the
+        persisted queue, not in any transcript — and its echo read "sent" for 5.5h until the next thread
+        spawn finally flagged it dropped). `_inflight_texts` carries the fed-but-unresulted texts across
+        the teardown:
+        - NO conversation ever materialized (no init streamed → resume_sid never set): RE-HEAD the queue —
+          the next client starts the conversation fresh, so re-feeding cannot duplicate anything the user
+          can see. (The one theoretical overlap — the dead CLI landed the atom in the same sid-keyed file
+          after our receive loop was cancelled — repeats a kickoff message, which beats silently losing
+          it.)
+        - A RESUMABLE conversation: the atom may genuinely have landed, so re-feeding risks a real
+          duplicate. Surface the loss instead: the drop-mark flips the echo to "never delivered" NOW,
+          rather than hours later at the next thread spawn."""
+        if not self.inflight:
+            return
+        stranded = list(self._inflight_texts)      # fed to the abandoned client, never resulted
+        self._inflight_texts.clear()
+        self.inflight = 0
+        self._interrupted = False
+        self._intr_level = 0
+        self._compacting = False   # an abandoned /compact turn can't emit its boundary/result on the dead client
+        self._clearing = False     # same: an abandoned /clear turn can't emit its init/result either
+        self._mark("waiting")
+        self.backend.retire_live_work(self.sid)    # the abandoned turn's stream is gone with its client
+        if stranded and not self.resume_sid:
+            with self._lock:
+                self._pending[0:0] = stranded
+            self._persist_queue()                  # the fresh inputs() drains _pending on its first pass
+        elif stranded:
+            self.backend._mark_dropped_echoes(self.sid, self.pending())
+        self.backend._poke()
 
     # ---- async internals (run inside the quarantined loop) ----
 
@@ -1915,6 +1964,7 @@ class SdkSession:
                     self._interrupted = False        # a fresh turn → clear any stale interrupt flag
                     self._intr_level = 0             #   ...and its escalation episode (a new stop starts polite)
                 self.inflight += 1
+                self._inflight_texts.append(item)   # the fed-turn twin — see its init comment
                 self._mark("working")
                 self.backend._poke()
                 yield {"type": "user",
@@ -1938,25 +1988,8 @@ class SdkSession:
         while not self.ended:
             self._wake.clear()
             self._reconnect = False
-            # RECONCILE INFLIGHT ACROSS A RECONNECT (the user 2026-07-01, who switched the model on a new session
-            # and it said working indefinitely). A reconnect abandons the previous client; a turn it left in
-            # flight can NEVER get its ResultMessage on the new connection (that client, and its receive loop,
-            # are gone) — so inflight, and the "working" signal it drives, would be stranded elevated FOREVER.
-            # request_reconnect defers while inflight>0, but a race (it fired at inflight==0, then the input
-            # generator started a turn before the teardown ran) can still leave a turn stranded here. At the
-            # TOP of the loop no client is connected, so nothing can legitimately be in flight: settle it to
-            # idle. A not-yet-STARTED _pending turn survives (it was never fed to the dead client) and the new
-            # inputs() re-feeds it, re-stamping "working". No-op on the first connect and on a clean reconnect
-            # (inflight already 0). Event-based on the reconnect itself, not a time/age heuristic.
-            if self.inflight:
-                self.inflight = 0
-                self._interrupted = False
-                self._intr_level = 0
-                self._compacting = False   # an abandoned /compact turn can't emit its boundary/result on the dead client
-                self._clearing = False     # same: an abandoned /clear turn can't emit its init/result either
-                self._mark("waiting")
-                self.backend.retire_live_work(self.sid)   # the abandoned turn's stream is gone with its client
-                self.backend._poke()
+            # settle + recover anything the abandoned client stranded — see _reconcile_stranded
+            self._reconcile_stranded()
             opts = self.backend._options(self, ClaudeAgentOptions)
             # Whether THIS connection carries the fastMode opt-in — snapshotted at the same moment
             # _options composes the flag-settings file, so the two can never disagree. The CLI only
@@ -2367,6 +2400,7 @@ class SdkSession:
             # phantom-working bug, the user 2026-07-09.) If a genuinely separate turn is still queued in
             # the CLI, its next streamed atom re-asserts 'working' via _forward — the stream is the truth.
             self.inflight = 0
+            self._inflight_texts.clear()           # the CLI processed everything fed — same settle semantics
             # A /compact that found NOTHING to compact emits no boundary — the turn just settles here. Clear
             # the authoritative flag so parked ops proceed immediately, instead of waiting out a 180s cap.
             self._compacting = False

--- a/tests/test_kernel_create_session_ack.py
+++ b/tests/test_kernel_create_session_ack.py
@@ -58,8 +58,9 @@ class CreateSessionAckFast(unittest.TestCase):
             setattr(km, n, v)
 
     def test_create_reveals_first_and_never_builds_inline(self):
-        sid = km._create_sdk_session("newsesh", "/tmp")
+        sid, extra = km._create_sdk_session("newsesh", "/tmp")   # (sid, applied-prefs echo) since 2026-08-16
         self.assertEqual(sid, "11111111-2222-3333-4444-555555555555")
+        self.assertEqual(extra, {}, "no prefs asked for -> nothing applied, nothing echoed")
         self.assertEqual(self.fake.calls[0][0], "spawn")
         self.assertEqual(self.fake.calls[1], ("connect", sid), "eager-connect still runs (model lists immediately)")
         kinds = [e[0] for e in self.events]

--- a/tests/test_new_route_prefs.py
+++ b/tests/test_new_route_prefs.py
@@ -90,7 +90,10 @@ class NewRoutePrefs(unittest.TestCase):
     def test_fresh_sdk_create_applies_both_and_echoes_them(self):
         km._live_names = lambda *_: {}
         km._sdk_ready = lambda: True
-        km._create_sdk_session = lambda nm, cwd, auth="": SID2
+        # the create path owns the prefs now — applied between spawn and connect, so the FIRST
+        # connect carries them (the 2026-08-16 -m drop); the stub mirrors that seam
+        km._create_sdk_session = (lambda nm, cwd, auth="", prefs=None:
+                                  (SID2, km._apply_new_session_prefs(SID2, prefs or {})))
         r = self._post({"name": "opt", "dir": self.dir,
                         "model": "claude-fable-5", "effort": "ultracode"})
         self.assertTrue(r["ok"])

--- a/tests/test_sdk_spawn_pin_send.py
+++ b/tests/test_sdk_spawn_pin_send.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""A fresh spawn's -m kickoff must never vanish into an effort-pin reconnect (2026-08-16).
+
+The incident: `romp new --model <id> --effort <level> -m <briefing>` acked both /new and /send, but the
+briefing never started a conversation — its echo sat dropped for 5.5h until a manual re-send. The race:
+the effort pin was applied AFTER connect() had been kicked off, so set_effort's request_reconnect armed a
+teardown of the just-connected client; the -m send was then FED into that dying client's stdin (inputs()
+had already removed it from the persisted queue) and the teardown cancelled the feeder mid-delivery. With
+lastSid still empty, the next iteration started a FRESH conversation — the text existed nowhere.
+
+Two independent halves close it:
+1. kernel: /new's per-spawn pins are applied BETWEEN spawn() and connect(), so the FIRST connect's
+   options carry them (--effort is connect-time) and no reconnect exists to race.
+2. backend: the reconnect loop's reconcile carries fed-but-unresulted turn TEXTS across the teardown —
+   re-headed onto the queue when no conversation ever materialized (nothing landed → re-feeding cannot
+   duplicate), or surfaced as dropped echoes NOW when the conversation is resumable (re-feeding there
+   risks a real duplicate; the loss must be visible, not discovered hours later).
+
+SYNTHETIC fixtures only: placeholder UUIDs, invented briefing text, no SDK dependency (SdkSession imports
+claude_agent_sdk lazily inside _amain, so the reconcile is drivable with a fake backend here)."""
+import os
+import re
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+sb = SourceFileLoader("romp_sdk_backend_spawnpin", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-aaaaaaaaaaaa"
+BRIEF = "Kick off: run the staged comparison suite and report embedding drift."
+
+
+class _FakeBackend:
+    def __init__(self, state_dir):
+        self.state_dir = state_dir
+        self.dropped_calls = []
+        self.retired = 0
+    def retire_live_work(self, sid): self.retired += 1
+    def _poke(self): pass
+    def _update_reg(self, *a, **k): pass
+    def _mark_dropped_echoes(self, sid, surviving): self.dropped_calls.append((sid, list(surviving)))
+    # the ResultMessage settle's other hooks (mirrors test_sdk_compacting_signal's fake)
+    def _turn_completed(self, sid): pass
+    def _record_spend(self, *a, **k): pass
+    def _forward(self, s, msg): pass
+
+
+def _session(reg_extra=None):
+    be = _FakeBackend(tempfile.mkdtemp())
+    return sb.SdkSession(be, {"sid": SID, "name": "x", **(reg_extra or {})}), be
+
+
+class ReconcileStranded(unittest.TestCase):
+    def test_fresh_conversation_reheads_the_fed_turn(self):
+        # the incident's shape: fed, never resulted, and no conversation ever materialized
+        s, be = _session()
+        self.assertFalse(s.resume_sid, "precondition: a fresh spawn has no resumable conversation")
+        s.inflight = 1
+        s._inflight_texts.append(BRIEF)
+        s._reconcile_stranded()
+        self.assertEqual(s._pending, [BRIEF], "the fed turn is back at the queue's head, not vanished")
+        self.assertEqual(s.inflight, 0, "counters settle as before")
+        self.assertEqual(s._inflight_texts, [])
+        self.assertEqual(be.dropped_calls, [], "recovered, so nothing to surface as dropped")
+
+    def test_reheaded_turn_precedes_a_not_yet_started_one(self):
+        s, _ = _session()
+        s._pending.append("a later message")
+        s.inflight = 1
+        s._inflight_texts.append(BRIEF)
+        s._reconcile_stranded()
+        self.assertEqual(s._pending, [BRIEF, "a later message"],
+                         "delivery order is preserved: the stranded turn was accepted first")
+
+    def test_resumable_conversation_surfaces_the_loss_instead(self):
+        # the atom may genuinely have landed in the resumable transcript — re-feeding risks a duplicate,
+        # so the echo flips to dropped NOW instead of at the next thread spawn hours later
+        s, be = _session({"lastSid": "22222222-3333-4444-5555-bbbbbbbbbbbb"})
+        self.assertTrue(s.resume_sid, "precondition: an established conversation")
+        s.inflight = 1
+        s._inflight_texts.append(BRIEF)
+        s._reconcile_stranded()
+        self.assertEqual(s._pending, [], "never re-fed into a resumable conversation")
+        self.assertEqual(len(be.dropped_calls), 1, "the loss is surfaced immediately")
+
+    def test_clean_reconnect_is_a_no_op(self):
+        s, be = _session()
+        s._pending.append("queued but never fed")
+        s._reconcile_stranded()
+        self.assertEqual(s._pending, ["queued but never fed"], "an unfed turn rides across untouched")
+        self.assertEqual(be.retired, 0, "nothing was stranded, nothing settles")
+
+    def test_the_result_settle_clears_the_fed_twin(self):
+        # the authoritative turn-end empties the twin exactly as it zeroes inflight — a later reconnect
+        # must not re-deliver turns the CLI already processed
+        s, _ = _session()
+        s.inflight = 1
+        s._inflight_texts.append(BRIEF)
+
+        class AssistantMessage: ...
+        class ResultMessage: ...
+        class SystemMessage: ...
+        saved = sb.asyncio.ensure_future
+        sb.asyncio.ensure_future = lambda coro: (coro.close() if hasattr(coro, "close") else None)
+        try:
+            s._on_message(ResultMessage(), AssistantMessage, ResultMessage, SystemMessage)
+        finally:
+            sb.asyncio.ensure_future = saved
+        self.assertEqual(s._inflight_texts, [], "settled turns leave the twin")
+        self.assertEqual(s.inflight, 0)
+
+
+class SpawnPinsRideTheFirstConnect(unittest.TestCase):
+    """Source pins on kernel.py: the /new pins are applied BETWEEN spawn and connect, so the first
+    connect's options carry them and no reconnect teardown exists for the -m send to race."""
+    KERNEL = open(os.path.join(BIN, "romp-kernel")).read()
+
+    def test_prefs_apply_before_the_eager_connect(self):
+        body = self.KERNEL[self.KERNEL.index("def _create_sdk_session"):]
+        body = body[:body.index("\ndef ")]
+        spawn_at = body.index("_sdk().spawn(")
+        prefs_at = body.index("_apply_new_session_prefs(sid, prefs or {})")
+        connect_at = body.index("_sdk().connect(sid)")
+        self.assertTrue(spawn_at < prefs_at < connect_at,
+                        "pins land in the reg after spawn and BEFORE connect — connect-time, race-free")
+
+    def test_the_new_route_threads_the_body_through(self):
+        self.assertTrue(re.search(r"_create_sdk_session\(nm, cwd, auth=\(a if a in \(\"login\", \"key\"\) else \"\"\),\s*\n\s*prefs=b\)", self.KERNEL),
+                        "/new hands its body to the create path instead of applying pins after connect")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -496,7 +496,7 @@ class DrivePlumbing(unittest.TestCase):
 
     def test_create_paths_pass_the_pick_through(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn("def _create_sdk_session(nm, cwd, auth=\"\"):", src)
+        self.assertIn("def _create_sdk_session(nm, cwd, auth=\"\", prefs=None):", src)
         self.assertEqual(src.count('auth=(a if a in ("login", "key") else "")'), 2,
                          "the WS op and POST /new both pass it")
 


### PR DESCRIPTION
Reported by a peer session: `romp new --model <id> --effort <level> -m <briefing>` on a fresh SDK session acked both /new and /send, but the briefing never started a conversation — its echo sat in the reg with dropped:true and lastSid stayed empty until a manual re-send 5.5 hours later.

The race: /new applied the model/effort pins AFTER connect() had been kicked off. `--effort` is connect-time, so set_effort requested a reconnect — arming a teardown of the just-connected client. The -m send then arrived, was fed into that dying client's stdin (and removed from the persisted queue at feed time), and the teardown cancelled the feeder mid-delivery. With lastSid still empty, the next loop iteration started a fresh conversation: the text existed in no store, and nothing flagged the echo dropped until the next thread spawn.

Two independent halves close it:

- **The pins ride the first connect.** `_create_sdk_session` now applies /new's per-spawn model/effort between spawn() and connect(). Pre-connect there is no session object, so the setters are pure reg writes the connect-time options read — no reconnect exists for the send to race. The applied-prefs echo still rides the /new reply.
- **A fed turn survives any reconnect teardown.** The loop-top reconcile (extracted to `_reconcile_stranded`, now unit-testable) tracks the texts of fed-but-unresulted turns. When no conversation ever materialized (no init streamed), they're re-headed onto the queue — nothing landed anywhere, so re-feeding cannot duplicate anything visible. On a resumable conversation, where the atom may genuinely have landed, the loss is surfaced instead: the echo flips to "never delivered" immediately rather than hours later.

Tests: `test_sdk_spawn_pin_send.py` covers the reconcile's three shapes (re-head, surface, no-op), delivery-order preservation, the ResultMessage settle clearing the fed-turn twin, and pins the spawn→prefs→connect order; the three existing tests that pinned the old create contract are updated to the new seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)