### PR TITLE
A flaky link finishes the picture across retries: resume, narrate, hold still

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -23751,6 +23751,36 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_header("Vary", "Origin")
             self.end_headers()
             return
+        # RESUME (the user 2026-08-16, on flaky wifi): a preview fetch that dies mid-transfer used to
+        # restart from byte 0 on every retry, so a large figure never finished arriving over a link
+        # that keeps dropping. The chat's resumable retry asks for the REST with `Range: bytes=N-`
+        # (the one suffix form; anything else is served whole as a plain 200, which the client treats
+        # as a restart). MEDIA only — the text viewer slurps. Past-the-end asks get 416 so a client
+        # holding a stale offset restarts cleanly instead of appending garbage.
+        rng = None
+        if not text:
+            m = re.match(r"^bytes=(\d+)-$", (getattr(self, "headers", None) or {}).get("Range") or "")
+            if m:
+                rng = int(m.group(1))
+        if rng:
+            if rng >= size:
+                return self._send(416, "range starts past the end: %d >= %d" % (rng, size), "text/plain")
+            with open(fp, "rb") as f:
+                f.seek(rng)
+                raw = f.read()
+            self.send_response(206)
+            self.send_header("Content-Type", mime)
+            self.send_header("Content-Length", str(len(raw)))
+            self.send_header("Content-Range", "bytes %d-%d/%d" % (rng, size - 1, size))
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("Cache-Control", "no-cache")
+            if getattr(self, "_cors_origin", None):
+                self.send_header("Access-Control-Allow-Origin", self._cors_origin)
+                self.send_header("Access-Control-Expose-Headers", "Content-Range")
+                self.send_header("Vary", "Origin")
+            self.end_headers()
+            self.wfile.write(raw)
+            return
         with open(fp, "rb") as f:
             raw = f.read()
         if text:
@@ -25446,11 +25476,18 @@ class Handler(BaseHTTPRequestHandler):
             q["token"] = [rtok]      # the remote's own credential; whatever the browser sent means nothing there
         conn = http.client.HTTPConnection("127.0.0.1", int(port), timeout=15)
         try:
-            conn.request("HEAD" if head else "GET", "/file?" + urlencode(q, doseq=True))
+            # The resumable retry's Range rides through (the user 2026-08-16): the SAME suffix form the
+            # local route honors, validated here so the relay forwards byte arithmetic and nothing else.
+            hdrs = {}
+            _rng = (getattr(self, "headers", None) or {}).get("Range") or ""
+            if not head and re.match(r"^bytes=\d+-$", _rng):
+                hdrs["Range"] = _rng
+            conn.request("HEAD" if head else "GET", "/file?" + urlencode(q, doseq=True), headers=hdrs)
             resp = conn.getresponse()
             body = b"" if head else resp.read(_PREVIEW_MAX_BYTES + 1)
             status, ctype = resp.status, mime          # OUR mime, never resp.getheader("Content-Type")
             clen = resp.getheader("Content-Length")
+            crange = resp.getheader("Content-Range") or ""
         except (OSError, http.client.HTTPException):
             return self._send(502, b"" if head else ("tunnel to %s is not answering" % host), "text/plain")
         finally:
@@ -25472,6 +25509,24 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_header("Access-Control-Allow-Origin", self._cors_origin)
                 self.send_header("Vary", "Origin")
             self.end_headers()
+            return
+        if status == 206:
+            # A partial reply needs its Content-Range mirrored — but only the exact byte-arithmetic
+            # shape (same lying-remote reasoning as the Content-Type above: mirror math, never prose).
+            if not re.match(r"^bytes \d+-\d+/\d+$", crange):
+                return self._send(502, "malformed partial reply from %s" % host, "text/plain")
+            self.send_response(206)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Content-Range", crange)
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("Cache-Control", "no-cache")
+            if getattr(self, "_cors_origin", None):
+                self.send_header("Access-Control-Allow-Origin", self._cors_origin)
+                self.send_header("Access-Control-Expose-Headers", "Content-Range")
+                self.send_header("Vary", "Origin")
+            self.end_headers()
+            self.wfile.write(body)
             return
         return self._send(status, body, ctype, cache="no-cache")
 

--- a/tests/test_kernel_preview.py
+++ b/tests/test_kernel_preview.py
@@ -77,6 +77,40 @@ class FilePreviewEndpoint(unittest.TestCase):
         self.assertEqual(hdrs.get("Content-Type"), "image/png")
         self.assertEqual(body, PNG)
 
+    def _req_range(self, path, rng):
+        url = "http://127.0.0.1:%d%s&token=%s" % (self.port, path, TOKEN)
+        req = urllib.request.Request(url, headers={"Range": rng})
+        try:
+            with urllib.request.urlopen(req, timeout=3) as r:
+                return r.status, dict(r.headers), r.read()
+        except urllib.error.HTTPError as e:
+            return e.code, dict(e.headers), e.read()
+
+    def test_a_suffix_range_resumes_mid_file(self):
+        # the resumable preview retry (the user 2026-08-16, flaky wifi): bytes already received are
+        # never re-sent — the client asks for the rest and stitches the picture across attempts
+        code, hdrs, body = self._req_range("/file?path=" + urllib.parse.quote(self.png), "bytes=10-")
+        self.assertEqual(code, 206)
+        self.assertEqual(body, PNG[10:])
+        self.assertEqual(hdrs.get("Content-Range"), "bytes 10-%d/%d" % (len(PNG) - 1, len(PNG)))
+        self.assertEqual(hdrs.get("Content-Type"), "image/png")
+
+    def test_a_range_past_the_end_416s_so_the_client_restarts(self):
+        code, _, _ = self._req_range("/file?path=" + urllib.parse.quote(self.png), "bytes=%d-" % (len(PNG) + 5))
+        self.assertEqual(code, 416)
+
+    def test_a_non_suffix_range_is_served_whole(self):
+        # only the one suffix form is honored; anything else means a plain 200 the client treats as a restart
+        code, _, body = self._req_range("/file?path=" + urllib.parse.quote(self.png), "bytes=0-5")
+        self.assertEqual(code, 200)
+        self.assertEqual(body, PNG)
+
+    def test_text_ignores_range(self):
+        # the viewer slurps text; a range on it is served whole
+        code, _, body = self._req_range("/file?path=" + urllib.parse.quote(self.txt), "bytes=3-")
+        self.assertEqual(code, 200)
+        self.assertEqual(body, b"not renderable")
+
     def test_missing_file_404s(self):
         code, _, _ = self._req("/file?path=" + urllib.parse.quote(os.path.join(self.tmp.name, "gone.png")))
         self.assertEqual(code, 404)

--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -38,7 +38,8 @@ test("a kernel-VERIFIED preview fails LOUDLY: a retry chip holds the figure's sp
   assert.match(pf, /if \(!verified\) \{ box\.remove\(\); return; \}/);
   assert.match(pf, /chip\.className = "path-full-retry";/);
   assert.match(pf, /chip\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); build\(true\); \};/, "tap to retry rebuilds the img");
-  assert.match(pf, /img\.src = bust \? url \+ "&r=" \+ Date\.now\(\) : url;/, "a retry cache-busts the failed entry");
+  assert.match(pf, /headers: got > 0 \? \{ Range: "bytes=" \+ got \+ "-" \} : \{\}/,
+    "a retry RESUMES from the bytes already received (kernel /file honors the suffix range)");
   // the render layer feeds the verdict: spacePaths and pathLinks hits are kernel-stat'd paths
   assert.match(RENDER, /const kernelVerified = new Set<string>\(\);/);
   assert.match(RENDER, /if \(!isUri && typeof fixed === "string"\) kernelVerified\.add\(open\);/);
@@ -58,7 +59,7 @@ test("the failure chip narrates what happens next, escalates on repeat, and a re
   assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.path-full-retry\.path-retry-flash \{ animation: none;/);
   // a manual retry that dies instantly holds the swirl a perceivable beat before the chip returns
   assert.match(PREVIEW, /const MIN_RETRY_SPIN_MS = 400;/);
-  assert.match(pf, /const left = bust \? MIN_RETRY_SPIN_MS - \(Date\.now\(\) - started\) : 0;/);
+  assert.match(pf, /const left = MIN_RETRY_SPIN_MS - \(Date\.now\(\) - started\);/);
   assert.match(pf, /if \(left > 0\) setTimeout\(showChip, left\); else showChip\(\);/);
   // the delayed swap yields to a re-rendered turn — a fresh box owns the spot by then
   assert.match(pf, /if \(!box\.isConnected\) return;/);
@@ -111,4 +112,38 @@ test("full-size images wear the user-image scale — one size per information ty
 
 test("previewThumb is gone with the feed's artifact strips (2026-08-14) — the full render is the one preview", () => {
   assert.doesNotMatch(PREVIEW, /previewThumb/, "no orphaned thumbnail builder");
+});
+
+test("a flaky link finishes the picture ACROSS retries: resume, narrate progress, hold the layout", () => {
+  // the user 2026-08-16, on flaky wifi: every retry restarted the transfer from byte 0 (the pictures
+  // never arrived), the swirl said nothing about progress, and the chip/swirl height swaps thrashed
+  // the chat scroll by about a line.
+  const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
+  // the managed retry reads the stream and narrates real progress under the swirl
+  assert.match(pf, /note\.textContent = "fetching… " \+ fmtBytes\(got, total\);/);
+  assert.match(PREVIEW, /function fmtBytes\(got: number, total: number\): string/);
+  // a 206 continues the partial; a plain 200 restarts it cleanly
+  assert.match(pf, /if \(r\.status === 206\)/);
+  assert.match(pf, /parts = \[\]; got = 0;/, "a full-body reply resets the partial, never appends");
+  // an attempt that made progress refills the retry budget — forward motion proves the link works
+  assert.match(pf, /if \(got > gotBefore\) autoRetries = 3;/);
+  // a cut stream is an error that resumes next attempt, never a truncated picture
+  assert.match(pf, /if \(total && got < total\) throw new Error\("cut at " \+ got\);/);
+  // the finished bytes are remembered for the page life — re-renders must not re-pull them over
+  // the very link that struggled to deliver them once
+  assert.match(PREVIEW, /const resolvedUrls = new Map<string, string>\(\);/);
+  assert.match(pf, /rememberResolved\(url, objUrl\);/);
+  // the chip names the byte it died at, so the wait visibly advances across attempts
+  assert.match(pf, /"⚠ connection dropped at " \+ fmtBytes\(got, total\)/);
+  // swirl and chip share one fixed-footprint wait box — retry churn cannot shift the scroll
+  assert.match(PREVIEW, /function mkWait\(box: HTMLElement\): HTMLElement/);
+  assert.match(CSS, /\.path-full-wait \{ display: inline-flex; flex-direction: column;/);
+  assert.match(CSS, /\.path-load-note \{ font-size: 0\.85em;/);
+  // no artificial deadline anywhere: patience is the point — only a real error ends an attempt
+  assert.doesNotMatch(pf, /AbortController|setTimeout\([^,]*abort/i, "no client-side fetch deadline");
+  // the kernel side: /file honors the one suffix form and the federation relay passes 206 through
+  assert.match(KERNEL, /re\.match\(r"\^bytes=\(\\d\+\)-\$", \(getattr\(self, "headers", None\) or \{\}\)\.get\("Range"\) or ""\)/);
+  assert.match(KERNEL, /self\.send_header\("Content-Range", "bytes %d-%d\/%d" % \(rng, size - 1, size\)\)/);
+  assert.match(KERNEL, /hdrs\["Range"\] = _rng/, "the relay forwards the browser's range to the remote");
+  assert.match(KERNEL, /re\.match\(r"\^bytes \\d\+-\\d\+\/\\d\+\$", crange\)/, "and mirrors only byte arithmetic back");
 });

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -43,6 +43,43 @@ const loadedOnce = new Set<string>();
 // nothing but the paint.
 const MIN_RETRY_SPIN_MS = 400;
 
+// Blob types for the resumable retry's assembled bytes (an <img> renders a typed blob everywhere;
+// untyped leans on sniffing). Keyed by extension, mirroring IMG_EXT.
+const IMG_MIME: Record<string, string> = {
+  png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", gif: "image/gif",
+  webp: "image/webp", bmp: "image/bmp", svg: "image/svg+xml",
+};
+
+// Fully-fetched previews for this page life: original URL → object URL. The chat re-renders its
+// messages constantly, and a resumable fetch bypasses the HTTP cache (no-store) — without this memo
+// every re-render would re-pull the whole image over the very link that struggled to deliver it
+// once. Bounded; the evicted entry's blob is released.
+const resolvedUrls = new Map<string, string>();
+function rememberResolved(url: string, objUrl: string): void {
+  resolvedUrls.set(url, objUrl);
+  if (resolvedUrls.size > 24) {
+    const oldest = resolvedUrls.entries().next().value as [string, string];
+    resolvedUrls.delete(oldest[0]);
+    URL.revokeObjectURL(oldest[1]);
+  }
+}
+
+function fmtBytes(got: number, total: number): string {
+  const h = (n: number) => (n >= 1e6 ? (n / 1e6).toFixed(1) + " MB" : Math.max(1, Math.round(n / 1e3)) + " KB");
+  return total ? h(got) + " of " + h(total) : h(got);
+}
+
+// The fixed-footprint wait box shared by the retrying swirl AND the failure chip, so retry churn
+// never shifts the layout under the reader (the user 2026-08-16: the chat scroll thrashed by about
+// a line as the states swapped heights).
+function mkWait(box: HTMLElement): HTMLElement {
+  box.textContent = "";
+  const wait = document.createElement("span");
+  wait.className = "path-full-wait";
+  box.appendChild(wait);
+  return wait;
+}
+
 function withLoadCue(box: HTMLElement, img: HTMLImageElement, url: string): void {
   if (loadedOnce.has(url)) return;
   const spin = document.createElement("img");
@@ -161,52 +198,135 @@ export function previewFull(path: string, sid?: string | null, verified = false)
     // A verified preview whose fetch died usually died because the KERNEL was away (a restart mid-
     // deploy — the 2026-08-15 report hit exactly the converge-restart window), and delta-send never
     // rebuilds an old turn's DOM, so the chip would otherwise sit until a human tapped it. Bounded so
-    // a genuinely-dead file settles on the tap chip instead of re-fetching on every push forever.
+    // a genuinely-dead file settles on the tap chip instead of re-fetching on every push forever —
+    // but an attempt that MADE PROGRESS refills the budget (see the resumable retry below): forward
+    // motion is the event proving the link works sometimes, and only truly dead attempts spend it.
     let autoRetries = 3;
     let fails = 0;                                   // total failed attempts — the chip's copy escalates
-    const build = (bust: boolean) => {
-      box.textContent = "";
-      const started = Date.now();                    // the retry's min-visible spinner measures from here
+    // RESUMABLE RETRY STATE (the user 2026-08-16, on flaky wifi: every retry restarted the transfer
+    // from byte 0, so a large figure never finished arriving — and the swirl gave no idea how far it
+    // got). The happy path below stays a plain <img> (the browser cache makes the chat's constant
+    // re-renders free); once a load has FAILED, retries switch to a managed fetch that keeps every
+    // byte received so far and asks the kernel for the REST (Range: bytes=N-, honored by /file and
+    // across the federation relay). A dropping link then finishes the picture ACROSS attempts, with
+    // the swirl narrating real progress ("1.2 of 3.4 MB" — content-length makes it knowable). No
+    // artificial deadline anywhere: only a real network error ends an attempt.
+    let parts: Uint8Array[] = [];
+    let got = 0;
+    let total = 0;
+    let fetching = false;                            // one managed attempt at a time (a tap mid-fetch no-ops)
+    const showChip = () => {
+      if (!box.isConnected) return;                  // the turn re-rendered; a fresh box owns this spot now
+      const wait = mkWait(box);
+      const chip = document.createElement("span");
+      chip.className = "path-full-retry";
+      // The chip names what happens NEXT, not just the failure (the user 2026-08-16, on a slow
+      // link: a dead-end "unavailable" that then quietly healed itself read as broken UI). While
+      // bounded auto-retries remain, the next kernel push re-fetches on its own — say so. And a
+      // repeat failure must READ as a response to the tap, not the same chip standing still:
+      // the copy shifts to "still unavailable" (or the byte it died at) and the swap-in pulses once.
+      chip.textContent =
+        (got > 0 ? "⚠ connection dropped at " + fmtBytes(got, total)
+                 : (fails > 1 ? "⚠ still unavailable" : "⚠ preview unavailable"))
+        + (autoRetries > 0 ? " — retrying automatically · tap to retry now" : " — tap to retry");
+      chip.title = path;
+      chip.onclick = (ev) => { ev.stopPropagation(); build(true); };
+      wait.appendChild(chip);
+      if (fails > 1) {
+        chip.classList.add("path-retry-flash");
+        chip.addEventListener("animationend", () => chip.classList.remove("path-retry-flash"), { once: true });
+      }
+      if (autoRetries > 0) { autoRetries--; failedPreviews.set(box, () => build(true)); }
+    };
+    const failAfterBeat = (started: number) => {
+      fails++;
+      // A retry that dies instantly (a dead tunnel resets the connection in milliseconds) would
+      // flash the swirl for one frame and put back an identical chip — an ignored-looking tap.
+      // Hold the swirl to a perceivable beat before swapping. Presentation smoothing only: the
+      // attempt has already failed, and the auto-heal registration rides the same swap.
+      const left = MIN_RETRY_SPIN_MS - (Date.now() - started);
+      if (left > 0) setTimeout(showChip, left); else showChip();
+    };
+    const mkImg = (src: string) => {
       const img = document.createElement("img");
       img.className = "path-full-img";
-      img.src = bust ? url + "&r=" + Date.now() : url;   // bust: a retry must not re-read the failed cache entry
+      img.src = src;
       img.alt = path;
       img.loading = "lazy";
       img.onclick = (ev) => { ev.stopPropagation(); openLightbox(path, sid); };
-      img.onerror = () => {
-        if (!verified) { box.remove(); return; }
-        fails++;
-        const showChip = () => {
-          if (!box.isConnected) return;              // the turn re-rendered; a fresh box owns this spot now
-          box.textContent = "";
-          const chip = document.createElement("span");
-          chip.className = "path-full-retry";
-          // The chip names what happens NEXT, not just the failure (the user 2026-08-16, on a slow
-          // link: a dead-end "unavailable" that then quietly healed itself read as broken UI). While
-          // bounded auto-retries remain, the next kernel push re-fetches on its own — say so. And a
-          // repeat failure must READ as a response to the tap, not the same chip standing still:
-          // the copy shifts to "still unavailable" and the swap-in pulses once.
-          chip.textContent =
-            (fails > 1 ? "⚠ still unavailable" : "⚠ preview unavailable")
-            + (autoRetries > 0 ? " — retrying automatically · tap to retry now" : " — tap to retry");
-          chip.title = path;
-          chip.onclick = (ev) => { ev.stopPropagation(); build(true); };
-          box.appendChild(chip);
-          if (fails > 1) {
-            chip.classList.add("path-retry-flash");
-            chip.addEventListener("animationend", () => chip.classList.remove("path-retry-flash"), { once: true });
-          }
-          if (autoRetries > 0) { autoRetries--; failedPreviews.set(box, () => build(true)); }
+      return img;
+    };
+    const resumeFetch = async (note: HTMLElement) => {
+      const gotBefore = got;
+      const r = await fetch(url, { cache: "no-store",
+                                   headers: got > 0 ? { Range: "bytes=" + got + "-" } : {} });
+      if (r.status === 206) {
+        // the kernel continues our partial — the entity size rides Content-Range's "/<size>" tail
+        total = parseInt((r.headers.get("Content-Range") || "").split("/")[1] || "0", 10) || total;
+      } else if (r.ok) {
+        parts = []; got = 0;                         // full body (no range asked, or the server restarted us)
+        total = parseInt(r.headers.get("Content-Length") || "0", 10) || 0;
+      } else {
+        throw new Error("http " + r.status);
+      }
+      const reader = r.body!.getReader();
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          parts.push(value);
+          got += value.byteLength;
+          note.textContent = "fetching… " + fmtBytes(got, total);
+        }
+      } finally {
+        if (got > gotBefore) autoRetries = 3;        // progress refills the budget — the link works sometimes
+      }
+      if (total && got < total) throw new Error("cut at " + got);   // stream ended early → resume next attempt
+      const blob = new Blob(parts as BlobPart[], { type: IMG_MIME[path.slice(path.lastIndexOf(".") + 1).toLowerCase()] || "" });
+      return URL.createObjectURL(blob);
+    };
+    const build = (bust: boolean) => {
+      const done = resolvedUrls.get(url);
+      if (done) {                                    // already fully fetched this page-life → instant
+        box.textContent = "";
+        box.appendChild(mkImg(done));
+        return;
+      }
+      if (!bust) {                                   // first attempt: the plain <img> happy path
+        box.textContent = "";
+        const img = mkImg(url);
+        img.onerror = () => {
+          if (!verified) { box.remove(); return; }
+          failAfterBeat(0);                          // no beat on the first attempt — the cue was already up
         };
-        // A retry that dies instantly (a dead tunnel resets the connection in milliseconds) would
-        // flash the swirl for one frame and put back an identical chip — an ignored-looking tap.
-        // Hold the swirl to a perceivable beat before swapping. Presentation smoothing only: the
-        // attempt has already failed, and the auto-heal registration rides the same swap.
-        const left = bust ? MIN_RETRY_SPIN_MS - (Date.now() - started) : 0;
-        if (left > 0) setTimeout(showChip, left); else showChip();
-      };
-      withLoadCue(box, img, url);   // mini swirl holds the spot until the load event (memo on the un-busted url)
-      box.appendChild(img);
+        withLoadCue(box, img, url);   // mini swirl holds the spot until the load event (memo on the un-busted url)
+        box.appendChild(img);
+        return;
+      }
+      if (fetching) return;
+      fetching = true;
+      const started = Date.now();
+      const wait = mkWait(box);
+      const spin = document.createElement("img");
+      spin.className = "path-load-spin";
+      spin.src = "/media/romp-swirl-glyph.svg";
+      spin.alt = "loading preview…";
+      const note = document.createElement("span");
+      note.className = "path-load-note";
+      note.textContent = got > 0 ? "resuming… " + fmtBytes(got, total) : "fetching…";
+      wait.append(spin, note);
+      resumeFetch(note).then((objUrl) => {
+        fetching = false;
+        rememberResolved(url, objUrl);
+        loadedOnce.add(url);                         // re-renders skip the cue — the bytes are in hand
+        if (!box.isConnected) return;
+        box.textContent = "";
+        box.appendChild(mkImg(objUrl));
+      }).catch(() => {
+        fetching = false;
+        if (!verified) { box.remove(); return; }
+        failAfterBeat(started);
+      });
     };
     build(false);
   }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2298,6 +2298,11 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
   background: rgba(255, 255, 255, 0.08); border: 1px solid rgba(255, 255, 255, 0.14);
   font-size: 0.85em; opacity: 0.85; cursor: pointer; }
 .path-full-retry:hover { border-color: var(--accent); }
+/* the fixed-footprint wait box shared by the retrying swirl AND the failure chip, so retry churn
+   never shifts the chat's scroll (preview.ts mkWait; the user 2026-08-16 watched it thrash ~a line) */
+.path-full-wait { display: inline-flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 4px; min-width: 200px; min-height: 56px; border-radius: 8px; background: rgba(255, 255, 255, 0.04); }
+.path-load-note { font-size: 0.85em; opacity: 0.65; }
 /* a repeat failure's chip pulses once on swap-in so an identical-looking outcome still reads as a
    RESPONSE to the tap (preview.ts previewFull) */
 .path-full-retry.path-retry-flash { animation: path-retry-flash 0.45s ease; }


### PR DESCRIPTION
Follow-up to the failure-chip narration change, from live use on flaky wifi: retry taps showed the swirl for a second and bounced back to "unavailable" forever — every retry restarted the image transfer from byte zero, so a large figure never finished arriving. The swirl gave no sense of progress, and the chip/swirl height swaps thrashed the chat scroll by about a line per retry cycle.

- **Resume, don't restart.** `/file` honors the one suffix Range form (`bytes=N-`) with a 206 + Content-Range (media only; a range past the end 416s so a stale offset restarts cleanly), and the federation relay forwards the range out and mirrors only the byte-arithmetic header back — same lying-remote posture as its Content-Type rule. The retry path switches from `<img>` to a managed fetch that keeps every byte received and asks for the rest, so a dropping link finishes the picture across attempts. The happy path stays a plain `<img>` — the browser cache keeps the chat's constant re-renders free — and finished bytes are memoized as object URLs (bounded) so re-renders never re-pull an image over the very link that struggled to deliver it once.
- **Narrate progress.** The retrying swirl carries a live byte count ("1.2 MB of 3.4 MB" — content-length makes progress knowable), and the failure chip names the byte the connection dropped at, so the wait visibly advances across attempts.
- **Patience, structurally.** No artificial deadline anywhere — only a real network error ends an attempt. An attempt that made progress refills the bounded auto-retry budget: forward motion proves the link works sometimes, so only genuinely dead attempts spend it.
- **Hold the layout.** The retrying swirl and the failure chip render inside one fixed-footprint wait box, so retry churn can no longer shift the reader's scroll.

Tests: kernel Range behavior (mid-file resume, past-the-end 416, non-suffix forms served whole, text untouched) in test_kernel_preview.py; the resumable-retry mechanics, progress narration, budget refill, memo, wait box, and the kernel/relay pins in chat-inline-preview.test.ts. Both suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)