### PR TITLE
A send never silently drops an attachment that is still uploading

### DIFF
--- a/ui/webview/composer-files.test.ts
+++ b/ui/webview/composer-files.test.ts
@@ -39,7 +39,7 @@ test("every file arrival becomes an attachment, never raw path text in the box",
   // paste-with-files and the host round-trip (dropped bytes, 📎 dialog, phone picker) too — the
   // paste's path branch is gated on LOCAL ownership (composer-attach.test.ts owns the remote rule)
   assert.match(RENDER, /if \(p && !hostOf\(activeId \|\| ""\)\) addComposerFile\(activeId, p\);\s*\n\s*else shipFileToHost\(f\);/);
-  assert.match(RENDER, /m\.type === "droppedPath" && typeof m\.path === "string"\) \{[\s\S]{0,300}addComposerFile\(activeId, m\.path\);/);
+  assert.match(RENDER, /m\.type === "droppedPath" && typeof m\.path === "string"\) \{[\s\S]{0,300}addComposerFile\(owner, m\.path\);/);
   // the old insert-at-cursor path is gone with its last caller
   assert.doesNotMatch(RENDER, /function insertComposerText/);
 });

--- a/ui/webview/composer-send.test.ts
+++ b/ui/webview/composer-send.test.ts
@@ -17,7 +17,7 @@ test("the composer markup includes a send button to the right of 📎", () => {
 });
 
 test("⏎ and the send button share ONE sendComposer() path", () => {
-  assert.match(RENDER, /const sendComposer = \(\) => \{/);
+  assert.match(RENDER, /const sendComposer = \(opts\?: \{ pastShipGate\?: boolean \}\) => \{/);   // the opts are the ship gate's re-entry door (composer-ship-gate.test.ts)
   assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "sendMessage", id: sid, text \}\)/);   // routeUserMessage — one routing owner since the staged flush (2026-08-15)
   // Enter calls it (desktop only — the mobile guard is asserted separately below)
   assert.match(RENDER, /if \(e\.key === "Enter" && !e\.shiftKey && !isCoarsePointer\(\)\) \{\s*e\.preventDefault\(\);\s*sendComposer\(\);/);

--- a/ui/webview/composer-ship-gate.test.ts
+++ b/ui/webview/composer-ship-gate.test.ts
@@ -1,0 +1,54 @@
+// Sending while an attachment is still UPLOADING must never silently drop it (the user 2026-08-16:
+// the composer said "uploading", allowed the send, and the message went without the image — the send
+// reads only the acked composerFiles list, and pendingShips was never consulted). The gate: a send
+// with ships in flight opens the same pane-local confirm the /clear guard uses — send WITHOUT the
+// upload explicitly, or hold the send and let the LAST droppedPath ack fire it (event-based). A save
+// nack cancels the hold loudly; any successful send supersedes it. The ack also attaches the file to
+// the composer that SHIPPED it (retirePendingShip now returns the owning sid) instead of whatever tab
+// is active at ack time — the same report's second face. Source pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("a send with ships in flight is gated by the confirm: send-without is explicit, wait is the default", () => {
+  assert.match(RENDER, /const shipping = \(pendingShips\.get\(activeId\) \|\| \[\]\)\.length;/,
+    "the send path finally consults the in-flight list");
+  assert.match(RENDER, /if \(shipping && !opts\?\.pastShipGate\) \{/);
+  assert.match(RENDER, /\{ label: "Wait for the upload", value: "wait" \}/);
+  assert.match(RENDER, /\{ label: "Send without " \+ them, value: "now", danger: true \}/,
+    "sending without the file is the marked-dangerous, explicit choice");
+  assert.match(RENDER, /if \(v === "now"\) sendComposer\(\{ pastShipGate: true \}\);/);
+  assert.match(RENDER, /else if \(v === "wait"\) \{ sendOnShip\.add\(sid\); renderComposerFiles\(sid\); \}/);
+});
+
+test("the held send fires on the LAST ack — event-based — and a nack cancels it loudly", () => {
+  assert.match(RENDER, /if \(owner && sendOnShip\.has\(owner\) && !\(pendingShips\.get\(owner\) \|\| \[\]\)\.length\) \{/,
+    "the deciding event is the last pending ship retiring");
+  assert.match(RENDER, /if \(owner === activeId\) fireHeldSend\(\);/);
+  assert.match(RENDER, /the held message was not sent; review it there/,
+    "a mid-hold tab switch surfaces instead of sending a background composer");
+  assert.match(RENDER, /const held = !!owner && sendOnShip\.delete\(owner\);/,
+    "a failed save cancels the hold — it must not fire without the file it waited for");
+  assert.match(RENDER, /\+ \(held \? " Your message was NOT sent\." : ""\)/);
+});
+
+test("any successful send supersedes a hold, so a spent hold can never double-send", () => {
+  const hits = RENDER.match(/sendOnShip\.delete\(sid\);\s+\/\/ a send happened — any held one is superseded/g) || [];
+  assert.equal(hits.length, 2, "both delivery paths (provisional queue and live route) clear it");
+});
+
+test("the ack attaches to the composer that SHIPPED the file, not whatever tab is active", () => {
+  assert.match(RENDER, /function retirePendingShip\(key: string\): string \| null \{/);
+  assert.match(RENDER, /const owner = retirePendingShip\(m\.path\) \|\| activeId;/);
+  assert.match(RENDER, /addComposerFile\(owner, m\.path\);/);
+});
+
+test("a held send is visible on the button and always inspectable", () => {
+  assert.match(RENDER, /sendBtn\.classList\.toggle\("send-held", held\);/);
+  assert.match(RENDER, /"sends when the upload finishes"/);
+  assert.match(CSS, /#composer-send\.send-held \{ opacity: 0\.45; \}/);
+});

--- a/ui/webview/pending-attach.test.ts
+++ b/ui/webview/pending-attach.test.ts
@@ -39,8 +39,9 @@ test("the strip renders pending chips (name + pulsing dots) and shows even with 
 });
 
 test("the droppedPath ack retires the chip it answers, then attaches the thumbnail", () => {
-  assert.match(RENDER, /retirePendingShip\(m\.path\);/);
-  assert.match(RENDER, /retirePendingShip\(m\.path\);[\s\S]{0,200}addComposerFile\(activeId, m\.path\)/);
+  assert.match(RENDER, /const owner = retirePendingShip\(m\.path\) \|\| activeId;/);
+  assert.match(RENDER, /retirePendingShip\(m\.path\)[\s\S]{0,300}addComposerFile\(owner, m\.path\)/,
+    "the ack attaches to the composer that SHIPPED the file (the 2026-08-16 wrong-tab attach)");
 });
 
 test("ack↔chip matching mirrors the kernel's saved-name sanitizer, FIFO as the fallback", () => {
@@ -56,7 +57,7 @@ test("a failed kernel save is NACKED and surfaces loudly — never a silent stuc
   assert.match(KERNEL, /_reply\(client, \{"type": "dropSaveFailed", "name": str\(msg\["name"\]\)\}\)/);
   // client: the nack retires the chip and says so in a toast
   assert.match(RENDER, /m\.type === "dropSaveFailed" && typeof m\.name === "string"/);
-  assert.match(RENDER, /retirePendingShip\(m\.name\);\s*\n\s*warnToast\(m\.name \+ " couldn't be saved on the kernel/);
+  assert.match(RENDER, /retirePendingShip\(m\.name\) \|\| activeId;[\s\S]{0,300}warnToast\(m\.name \+ " couldn't be saved on the kernel/);
   // a FileReader failure retires it too — an unreadable file must not pulse forever
   assert.match(RENDER, /reader\.onerror = \(\) => retirePendingShip\(name\);/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8377,9 +8377,12 @@ function addPendingShip(id: string | null, name: string): void {
 // An ack (or nack) retires ONE pending chip: the entry whose sanitized name `key` ends with — `key`
 // is the saved path on ack (basename <ms>-<safe name>) or the raw name on nack, and both end with
 // the sanitized original — else the oldest (the kernel answers a connection's dropFiles in order).
-// Searched active-tab-first across all sessions because the ack carries no session id — like the
-// attachment itself, it lands wherever the user now is.
-function retirePendingShip(key: string): void {
+// Searched active-tab-first across all sessions because the ack carries no session id. Returns the
+// sid whose chip it retired (null if none matched), so the ack can attach the file to the composer
+// that SHIPPED it — attaching to whatever tab was active at ack time put a slow upload's file on the
+// wrong session's strip after a mid-flight tab switch (the user 2026-08-16, the send-while-uploading
+// report's second face).
+function retirePendingShip(key: string): string | null {
   const k = "-" + shipSafeName(key.split("/").pop() || key);
   const ids = activeId ? [activeId, ...pendingShips.keys()] : [...pendingShips.keys()];
   for (const id of ids) {
@@ -8389,9 +8392,19 @@ function retirePendingShip(key: string): void {
     list.splice(i >= 0 ? i : 0, 1);
     if (!list.length) pendingShips.delete(id);
     if (id === activeId) renderComposerFiles(id);
-    return;
+    return id;
   }
+  return null;
 }
+
+// Sids whose SEND is HELD until every pending ship acks (the user 2026-08-16: sending mid-upload
+// silently dropped the attachment — the send read only the acked list). Armed by the confirm's
+// "wait" pick in sendComposer's gate; fired by the LAST droppedPath ack (event-based), cancelled by
+// a dropSaveFailed nack or by any successful send for the sid.
+const sendOnShip = new Set<string>();
+// Assigned by setupComposer (sendComposer lives in its closure); the WS ack handler fires a held
+// send through it when the last pending ship lands.
+let fireHeldSend: () => void = () => {};
 
 // Persist drafts across a full RELOAD (the user 2026-06-25: a half-typed message must survive a refresh, not
 // only a tab switch). The Map is in-memory, so mirror it into the webview's persisted state — the same store
@@ -8629,6 +8642,16 @@ function renderComposerChips(id: string | null): void {
 function renderComposerFiles(id: string | null): void {
   const strip = document.getElementById("composer-files");
   if (!strip) return;
+  // the held-send state rides the send button (see sendOnShip): dimmed + titled while a "wait for
+  // the upload" pick is armed, restored the moment the hold fires or cancels — this renderer runs
+  // on every strip change AND every tab switch, so the button always reflects the ACTIVE tab
+  const sendBtn = document.getElementById("composer-send");
+  if (sendBtn) {
+    const held = !!id && sendOnShip.has(id);
+    sendBtn.classList.toggle("send-held", held);
+    if (held) sendBtn.setAttribute("title", "sends when the upload finishes");
+    else if (sendBtn.getAttribute("title") === "sends when the upload finishes") sendBtn.removeAttribute("title");
+  }
   strip.replaceChildren();
   const paths = (id ? composerFiles.get(id) : undefined) || [];
   const pending = (id ? pendingShips.get(id) : undefined) || [];
@@ -9649,13 +9672,22 @@ window.addEventListener("message", (e: MessageEvent) => {
     if (s && s.name !== m.name) { s.name = m.name; renderTabs(); }
   }
   else if (m.type === "droppedPath" && typeof m.path === "string") {   // host-saved drop/paste/pick → a thumbnail, not path text (the user 2026-08-04)
-    retirePendingShip(m.path);                                         // the in-flight chip this ack answers (no-op for pickFile, which never ships)
-    addComposerFile(activeId, m.path);
+    const owner = retirePendingShip(m.path) || activeId;               // the chip this ack answers names the OWNING composer (no-op for pickFile, which never ships)
+    addComposerFile(owner, m.path);
+    if (owner && sendOnShip.has(owner) && !(pendingShips.get(owner) || []).length) {
+      // the LAST ship landed — the event the held send was waiting for (the user 2026-08-16)
+      sendOnShip.delete(owner);
+      if (owner === activeId) fireHeldSend();
+      else warnToast("attachments finished uploading on another tab — the held message was not sent; review it there.");
+    }
   } else if (m.type === "dropSaveFailed" && typeof m.name === "string") {
     // the kernel could not SAVE the shipped bytes — clear the pending chip and say so loudly,
     // never leave dots pulsing over a file that is not coming (fail loudly, don't degrade silently)
-    retirePendingShip(m.name);
-    warnToast(m.name + " couldn't be saved on the kernel, so it was not attached — try again.");
+    const owner = retirePendingShip(m.name) || activeId;
+    const held = !!owner && sendOnShip.delete(owner);    // a held send must not fire without the file it waited for
+    warnToast(m.name + " couldn't be saved on the kernel, so it was not attached — try again."
+              + (held ? " Your message was NOT sent." : ""));
+    if (owner && owner === activeId) renderComposerFiles(owner);   // the held-send button state clears with the hold
   }
   // an EDITOR highlight (VS Code host, onDidChangeTextEditorSelection — the user 2026-07-13) seeds the
   // same quote chip a transcript highlight does, labeled + wrapped with its file:lines origin (m.src)
@@ -9789,7 +9821,7 @@ function setupComposer() {
     persistDrafts();
     renderStagedStrip(activeId);
   };
-  const sendComposer = () => {
+  const sendComposer = (opts?: { pastShipGate?: boolean }) => {
     const typed = ta.value.trim();
     if (!activeId) return;
     // an empty plain send with a staged stack = "go": release what's held, nothing new to add
@@ -9802,6 +9834,26 @@ function setupComposer() {
       return;
     }
     const attached = composerFiles.get(activeId) || [];
+    // SHIP GATE (the user 2026-08-16): an upload still in flight is NOT in `attached` (the send reads
+    // only acked paths), so sending now silently drops it — the exact report. Intercept with the same
+    // pane-local confirm the /clear guard uses: send WITHOUT it explicitly, or hold the send and let
+    // the last droppedPath ack fire it (event-based; a save nack cancels the hold loudly instead).
+    const shipping = (pendingShips.get(activeId) || []).length;
+    if (shipping && !opts?.pastShipGate) {
+      const sid = activeId;
+      const what = shipping === 1 ? "An attachment is" : shipping + " attachments are";
+      const them = shipping === 1 ? "it" : "them";
+      showConfirm(what + " still uploading",
+                  "Send now and your message goes without " + them + ". Wait, and it sends itself "
+                  + "the moment the upload finishes.",
+                  [{ label: "Wait for the upload", value: "wait" },
+                   { label: "Send without " + them, value: "now", danger: true }],
+                  (v) => {
+                    if (v === "now") sendComposer({ pastShipGate: true });
+                    else if (v === "wait") { sendOnShip.add(sid); renderComposerFiles(sid); }
+                  });
+      return;
+    }
     if (!typed && !attached.length) return;
     // Attachment thumbnails ride the send as a trailing line of paths — quoted when they contain spaces,
     // the way a person would type them (the user 2026-08-04). Not for a picker answer or an edit: a
@@ -9864,6 +9916,7 @@ function setupComposer() {
         }
         provisionalQueue.push(text);
         registerOptimistic(sid, text);
+        sendOnShip.delete(sid);                       // a send happened — any held one is superseded
         if (attached.length) { composerFiles.delete(sid); if (sid === activeId) renderComposerFiles(sid); }
         drafts.delete(sid); draftStartedAt.delete(sid); persistDrafts();
         ta.value = ""; composerManualH = null; ta.style.height = "";
@@ -9891,6 +9944,7 @@ function setupComposer() {
       routeUserMessage(activeId, text, cites);
       // (a citation follow-up/quote has its own kernel-side echo path; the optimistic bubble covers the plain send)
       if (cites) { composerCitations.delete(activeId); renderComposerChips(activeId); }   // consumed on send
+      sendOnShip.delete(sid);                       // a send happened — any held one is superseded
       if (attached.length) { composerFiles.delete(sid); if (sid === activeId) renderComposerFiles(sid); }   // the strip emptied into this message
       drafts.delete(activeId); draftStartedAt.delete(activeId); persistDrafts();   // sent — no draft to restore on a later switch-back
       ta.value = "";
@@ -9929,6 +9983,7 @@ function setupComposer() {
   // blur instead so the keyboard collapses and the box drops back to the bottom (the user 2026-07-22).
   const sendBtn = document.getElementById("composer-send") as HTMLButtonElement | null;
   sendBtn?.addEventListener("mousedown", (e) => { e.preventDefault(); sendComposer(); if (isCoarsePointer()) ta.blur(); else ta.focus(); });
+  fireHeldSend = () => sendComposer();   // the ack handler's door into this closure (see sendOnShip)
 
   // ── drag-to-resize the message box (the user 2026-07-07) ── the #composer-resize handle straddles the
   // top-edge divider; dragging it UP grows the composer (to see a long message in full), DOWN shrinks it.

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -544,6 +544,9 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .composer-file-pending { gap: 6px; padding: 4px 8px; border-radius: 6px; cursor: default;
   background: color-mix(in srgb, var(--accent) 8%, transparent);
   border: 1px dashed color-mix(in srgb, var(--accent) 35%, transparent); }
+/* a held send (waiting for an upload to finish — render.ts sendOnShip): dimmed, not disabled;
+   clicking re-opens the same confirm, so the state is always inspectable */
+#composer-send.send-held { opacity: 0.45; }
 .composer-ship-dots { display: inline-flex; gap: 3px; }
 .composer-ship-dots i { width: 4px; height: 4px; border-radius: 50%; background: var(--accent);
   animation: ship-bnc 1.1s ease-in-out infinite; }


### PR DESCRIPTION
User report (2026-08-16): uploading an image to a remote box showed "uploading", but the composer allowed the send and the message went without it. Two faces of one gap — the send path read only the acked attachment list and never consulted the in-flight set, and the upload's late ack then attached the file to whatever tab was active.

- **The ship gate.** A send with uploads in flight opens the same pane-local confirm the /clear guard uses. "Send without it" is the explicit, danger-marked choice; "Wait for the upload" holds the send, and the last droppedPath ack fires it — event-based, no timers. A save nack cancels the hold inside the same loud toast ("Your message was NOT sent."), and any successful send supersedes a stale hold so it can never double-send.
- **Acks attach to the composer that shipped the file.** retirePendingShip already matches the ack to its chip; it now returns the owning sid, so a mid-upload tab switch no longer lands the file on the wrong session's strip. If a held send's last ack arrives while another tab is active, nothing is sent from the background — a toast points back at the tab instead.
- **The hold is visible and inspectable.** The send button dims with a "sends when the upload finishes" title while a hold is armed; clicking it re-opens the confirm.

Pinned in a new composer-ship-gate.test.ts (gate, hold-fire, nack-cancel, supersede, owner-attach, button state); the four existing pins on the old ack/send literals are updated to the new seam. UI suite + typecheck + python suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)