### PR TITLE
A retrying preview keeps one continuous loading narrative until it truly gives up

### DIFF
--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -52,11 +52,19 @@ test("the failure chip narrates what happens next, escalates on repeat, and a re
   const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
   // copy names the armed auto-heal while bounded retries remain; plain tap-to-retry once spent
   assert.match(pf, /"⚠ still unavailable" : "⚠ preview unavailable"/);
-  assert.match(pf, /autoRetries > 0 \? " — retrying automatically · tap to retry now" : " — tap to retry"/);
+  // while auto-retries remain the box KEEPS its loading persona (swirl + note, whole box tappable);
+  // the ⚠ chip is the GIVE-UP state only (the user 2026-08-16, third report: state bouncing between
+  // "trying" and "unavailable" on every retry cycle read as impatient even when it eventually loaded)
+  assert.match(pf, /if \(autoRetries > 0\) \{\s*\n\s*autoRetries--;\s*\n\s*failedPreviews\.set\(box, \(\) => build\(true\)\);/);
+  assert.match(pf, /\+ " — retrying · tap to retry now";/);
+  assert.match(pf, /wait\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); build\(true\); \};/,
+    "the whole retrying box is the tap target");
+  assert.match(pf, /"⚠ preview unavailable"\)\)\s*\n\s*\+ " — tap to retry";/,
+    "the chip exists only once the budget is spent, so it carries no retrying-automatically claim");
   // a repeat failure pulses the chip on swap-in — the acknowledge-every-click rule
   assert.match(pf, /chip\.classList\.add\("path-retry-flash"\);/);
-  assert.match(CSS, /\.path-full-retry\.path-retry-flash \{ animation: path-retry-flash/);
-  assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.path-full-retry\.path-retry-flash \{ animation: none;/);
+  assert.match(CSS, /\.path-full-retry\.path-retry-flash, \.path-load-note\.path-retry-flash \{ animation: path-retry-flash/);
+  assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.path-full-retry\.path-retry-flash, \.path-load-note\.path-retry-flash \{ animation: none;/);
   // a manual retry that dies instantly holds the swirl a perceivable beat before the chip returns
   assert.match(PREVIEW, /const MIN_RETRY_SPIN_MS = 400;/);
   assert.match(pf, /const left = MIN_RETRY_SPIN_MS - \(Date\.now\(\) - started\);/);
@@ -71,7 +79,7 @@ test("a failed preview heals on the next kernel push — the kernel-is-back even
   // kernel is reachable again; no pushes arrive while it's down, so retry-on-push can't spam.
   const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
   assert.match(pf, /let autoRetries = 3;/, "bounded — a genuinely-dead file settles on the tap chip");
-  assert.match(pf, /if \(autoRetries > 0\) \{ autoRetries--; failedPreviews\.set\(box, \(\) => build\(true\)\); \}/);
+  assert.match(pf, /if \(autoRetries > 0\) \{\s*\n\s*autoRetries--;\s*\n\s*failedPreviews\.set\(box, \(\) => build\(true\)\);/);
   assert.match(PREVIEW, /export function retryFailedPreviews\(\): void/);
   assert.match(PREVIEW, /if \(box\.isConnected\) rebuild\(\);/, "a re-rendered turn's fresh box supersedes the old");
   assert.match(RENDER, /retryFailedPreviews\(\);/, "called from the kernel message handler");

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -217,18 +217,44 @@ export function previewFull(path: string, sid?: string | null, verified = false)
     let fetching = false;                            // one managed attempt at a time (a tap mid-fetch no-ops)
     const showChip = () => {
       if (!box.isConnected) return;                  // the turn re-rendered; a fresh box owns this spot now
+      // ONE continuous narrative while the machinery is still going (the user 2026-08-16, third
+      // report: the box flipped between "trying" and "unavailable" on every auto-retry cycle even
+      // though it eventually loaded — the state bounced, so the UI read as impatient). While bounded
+      // auto-retries remain, the wait box KEEPS its loading persona — swirl + a note carrying the
+      // failure and the plan ("dropped at 1.2 MB of 3.4 MB — retrying · tap to retry now"), the
+      // whole box tappable — and the ⚠ chip appears only when the budget is genuinely spent. A
+      // repeat failure must still READ as a response to a tap: the note re-pulses on swap-in.
+      if (autoRetries > 0) {
+        autoRetries--;
+        failedPreviews.set(box, () => build(true));
+        const wait = mkWait(box);
+        wait.title = path + " — tap to retry now";
+        wait.style.cursor = "pointer";
+        wait.onclick = (ev) => { ev.stopPropagation(); build(true); };
+        const spin = document.createElement("img");
+        spin.className = "path-load-spin";
+        spin.src = "/media/romp-swirl-glyph.svg";
+        spin.alt = "loading preview…";
+        const note = document.createElement("span");
+        note.className = "path-load-note";
+        note.textContent = (got > 0 ? "connection dropped at " + fmtBytes(got, total)
+                                    : "connection dropped")
+                           + " — retrying · tap to retry now";
+        wait.append(spin, note);
+        if (fails > 1) {
+          note.classList.add("path-retry-flash");
+          note.addEventListener("animationend", () => note.classList.remove("path-retry-flash"), { once: true });
+        }
+        return;
+      }
       const wait = mkWait(box);
       const chip = document.createElement("span");
       chip.className = "path-full-retry";
-      // The chip names what happens NEXT, not just the failure (the user 2026-08-16, on a slow
-      // link: a dead-end "unavailable" that then quietly healed itself read as broken UI). While
-      // bounded auto-retries remain, the next kernel push re-fetches on its own — say so. And a
-      // repeat failure must READ as a response to the tap, not the same chip standing still:
-      // the copy shifts to "still unavailable" (or the byte it died at) and the swap-in pulses once.
+      // the budget is spent: three attempts gained nothing (progress refills it), so say so plainly
       chip.textContent =
         (got > 0 ? "⚠ connection dropped at " + fmtBytes(got, total)
                  : (fails > 1 ? "⚠ still unavailable" : "⚠ preview unavailable"))
-        + (autoRetries > 0 ? " — retrying automatically · tap to retry now" : " — tap to retry");
+        + " — tap to retry";
       chip.title = path;
       chip.onclick = (ev) => { ev.stopPropagation(); build(true); };
       wait.appendChild(chip);
@@ -236,7 +262,6 @@ export function previewFull(path: string, sid?: string | null, verified = false)
         chip.classList.add("path-retry-flash");
         chip.addEventListener("animationend", () => chip.classList.remove("path-retry-flash"), { once: true });
       }
-      if (autoRetries > 0) { autoRetries--; failedPreviews.set(box, () => build(true)); }
     };
     const failAfterBeat = (started: number) => {
       fails++;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2306,11 +2306,11 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .path-full-wait { display: inline-flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 4px; min-width: 200px; min-height: 56px; border-radius: 8px; background: rgba(255, 255, 255, 0.04); }
 .path-load-note { font-size: 0.85em; opacity: 0.65; }
-/* a repeat failure's chip pulses once on swap-in so an identical-looking outcome still reads as a
-   RESPONSE to the tap (preview.ts previewFull) */
-.path-full-retry.path-retry-flash { animation: path-retry-flash 0.45s ease; }
+/* a repeat failure pulses once on swap-in so an identical-looking outcome still reads as a
+   RESPONSE to the tap (preview.ts previewFull) — on the give-up chip and the retrying note alike */
+.path-full-retry.path-retry-flash, .path-load-note.path-retry-flash { animation: path-retry-flash 0.45s ease; }
 @keyframes path-retry-flash { 0% { background: rgba(255, 255, 255, 0.3); } 100% { background: rgba(255, 255, 255, 0.08); } }
-@media (prefers-reduced-motion: reduce) { .path-full-retry.path-retry-flash { animation: none; } }
+@media (prefers-reduced-motion: reduce) { .path-full-retry.path-retry-flash, .path-load-note.path-retry-flash { animation: none; } }
 /* VS Code's host-round-trip image chip while the bytes are still on their way (render.ts fillPathImg) —
    pure-CSS pulse, the sandbox can't fetch the swirl asset */
 .user-img-path.img-pending::after { content: " ···"; letter-spacing: 2px;


### PR DESCRIPTION
Third live report from flaky wifi: even with resumable retries, a preview that was steadily inching toward completion still flipped between "trying" (swirl) and "unavailable" (⚠ chip) on every auto-retry cycle before eventually loading — the state bounced, so the UI read as impatient and broken.

While bounded auto-retries remain (and progress refills the budget), the wait box now keeps a single loading persona: the swirl plus a note carrying both the failure and the plan ("connection dropped at 1.2 MB of 3.4 MB — retrying · tap to retry now"), with the whole box as the tap target and the note re-pulsing on a repeat failure so a tap always visibly answers. The ⚠ chip is now exclusively the give-up state — three attempts that gained nothing — and accordingly no longer claims to be retrying automatically.

Pins updated in chat-inline-preview.test.ts (the loading-persona branch, the terminal-only chip, the shared pulse rule). UI suite + typecheck + python suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)