### PR TITLE
A chat message's embedded image keeps its mention-time bytes

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14188,6 +14188,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                             pl = _path_links(prompt, sid, a.get("uuid"), _pl_memo)
                             if pl is not None:
                                 ev["pathLinks"] = pl    # path-shaped tokens, filesystem-verified/fixed → the client's link gate
+                            pp = _path_pins(sid, a.get("uuid"))
+                            if pp:
+                                ev["pathPins"] = pp     # mention-time snapshots: this message's embeds keep these bytes
                             if reminders:                # join each task-notification to its command + output tail
                                 to = _task_outputs_for(reminders, sess["path"])
                                 if to:
@@ -14277,6 +14280,9 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None):
                         pl = _path_links(txt, sid, a.get("uuid"), _pl_memo)
                         if pl is not None:
                             ev["pathLinks"] = pl    # path-shaped tokens, filesystem-verified/fixed → the client's link gate
+                        pp = _path_pins(sid, a.get("uuid"))
+                        if pp:
+                            ev["pathPins"] = pp     # mention-time snapshots: this message's embeds keep these bytes
                         if _interrupt_settle(events, txt, a):   # the null settle-reply closing an interrupted
                             ev["interruptSettle"] = True        # turn → rendered as seam marker, not a bubble
                         events.append(ev)
@@ -19261,10 +19267,30 @@ def _space_paths(md, sid, uuid):
                 continue
             if tok not in out and os.path.isfile(_resolve_open_path(tok, sid)):
                 out.append(tok)
+        pins = {}
+        for tok in out:                      # the verify moment doubles as the mention-time snapshot
+            pin = _pin_for(tok, sid)         # (see _pin_mention) — latched with the span's verdict
+            if pin:
+                pins[tok] = pin
         if len(_SPACE_PATH_CACHE) > 50000:   # runaway backstop; one entry per rendered message
             _SPACE_PATH_CACHE.clear()
-        _SPACE_PATH_CACHE[key] = hit = tuple(out)
-    return list(hit) or None
+        _SPACE_PATH_CACHE[key] = hit = (tuple(out), pins)
+    spans = hit[0] if isinstance(hit, tuple) and len(hit) == 2 and isinstance(hit[0], tuple) else hit
+    return list(spans) or None
+
+
+def _path_pins(sid, uuid):
+    """The mention-time pins latched for this message by _path_links / _space_paths — {open target:
+    pin id}, shipped as pathPins on the chat event (a SIBLING map: pathLinks values must stay strings,
+    or an older client's string-gate would unlink every token). Empty when nothing pinned."""
+    pins = {}
+    hit = _SPACE_PATH_CACHE.get((sid, uuid))
+    if isinstance(hit, tuple) and len(hit) == 2 and isinstance(hit[1], dict):
+        pins.update(hit[1])
+    hit = _PATH_LINK_CACHE.get((sid, uuid))
+    if hit is not None and len(hit) == 3:
+        pins.update(hit[2])
+    return pins
 
 
 # ── verified path links ────────────────────────────────────────────────────────────────────────────
@@ -19386,6 +19412,77 @@ def _path_tokens(md):
     return toks
 
 
+_MENTION_PINS = None                                   # resolved lazily: jd.STATE / "mention-pins"
+_PIN_STORE_MAX_BYTES = 500 * 1024 * 1024               # bounded: evict oldest-mtime past this
+_PIN_ID_RE = re.compile(r"^[0-9a-f]{64}\.[a-z0-9]{1,8}$")   # sha256 + the original extension
+
+
+def _pin_dir():
+    global _MENTION_PINS
+    if _MENTION_PINS is None:
+        _MENTION_PINS = jd.STATE / "mention-pins"
+        try:
+            _MENTION_PINS.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass
+    return _MENTION_PINS
+
+
+def _pin_mention(fp):
+    """Snapshot a mentioned IMAGE's bytes as they are RIGHT NOW, content-addressed — the pin an old
+    chat message's embed keeps forever (the user 2026-08-16: an agent re-generating a plot under the
+    same filename rewrote the picture inside every older message that had embedded it; history must
+    not change, and the agent's freedom to name files must not shrink). Runs at the pathLinks resolve
+    latch — the first build after the mention, the closest observable moment to the mention itself.
+    Content-addressing dedups unchanged files for free; a changed file simply stores a new blob. The
+    store is bounded: past _PIN_STORE_MAX_BYTES the oldest-mtime blobs go, and a message whose pin was
+    evicted falls back to the live file — exactly today's behavior, a nicety lost, never data.
+    Returns the pin id (sha256 + original extension) or None (not an image, oversize, unreadable)."""
+    ext = os.path.splitext(fp)[1].lower()
+    if ext not in _IMG_MIME:
+        return None
+    try:
+        if os.path.getsize(fp) > _PREVIEW_MAX_BYTES:   # /file would 413 it anyway — nothing to pin
+            return None
+        with open(fp, "rb") as f:
+            raw = f.read()
+    except OSError:
+        return None
+    pid = hashlib.sha256(raw).hexdigest() + ext
+    d = _pin_dir()
+    dst = d / pid
+    try:
+        if not dst.exists():
+            tmp = d / (pid + ".tmp.%d" % os.getpid())
+            tmp.write_bytes(raw)
+            os.replace(tmp, dst)
+            # bound the store on the write event, oldest first (mtime; serves don't touch it — a pin
+            # for a busy old chat can age out, and the fallback is the live file)
+            try:
+                rows = [(e.stat().st_mtime, e.stat().st_size, e.path)
+                        for e in os.scandir(d) if e.is_file() and not e.name.endswith(".tmp")]
+                total = sum(sz for _, sz, _ in rows)
+                for _, sz, path_ in sorted(rows):
+                    if total <= _PIN_STORE_MAX_BYTES:
+                        break
+                    os.unlink(path_)
+                    total -= sz
+            except OSError:
+                pass
+    except OSError:
+        return None
+    return pid
+
+
+def _pin_for(target, sid):
+    """The pin for a freshly-RESOLVED open target (token or repo-relative path) — absolute-resolved the
+    same way a click is, so the snapshot reads the same file the user would open."""
+    ap = _resolve_open_path(target, sid)
+    if os.path.isabs(ap) and os.path.isfile(ap):
+        return _pin_mention(ap)
+    return None
+
+
 def _path_links(md, sid, uuid, memo):
     """Path-shaped tokens in `md` the filesystem VERIFIES → {token: open target}, shipped as pathLinks
     on the chat event. Returns None when the message has no candidate tokens at all (the common message
@@ -19402,8 +19499,9 @@ def _path_links(md, sid, uuid, memo):
     hit = _PATH_LINK_CACHE.get(key)
     if hit is None:
         hit = ({}, tuple(t for t in _path_tokens(md)
-                         if not t.lower().startswith("file://")))   # file:// stays the client's verbatim link, ungated
-    links, misses = hit
+                         if not t.lower().startswith("file://")),   # file:// stays the client's verbatim link, ungated
+               {})
+    links, misses, pins = hit if len(hit) == 3 else (hit[0], hit[1], {})
     if misses:
         still = []
         for tok in misses:
@@ -19412,10 +19510,13 @@ def _path_links(md, sid, uuid, memo):
                 still.append(tok)
             else:
                 links[tok] = r
+                pin = _pin_for(r, sid)                    # the resolve moment IS the mention-time snapshot
+                if pin:                                   # (see _pin_mention) — latched with the link, so an
+                    pins[r] = pin                         # overwrite can never rewrite this message's embed
         misses = tuple(still)
     if len(_PATH_LINK_CACHE) > 50000:                     # runaway backstop; one entry per rendered message
         _PATH_LINK_CACHE.clear()
-    _PATH_LINK_CACHE[key] = (links, misses)
+    _PATH_LINK_CACHE[key] = (links, misses, pins)
     return dict(links) if (links or misses) else None
 
 
@@ -23799,6 +23900,15 @@ class Handler(BaseHTTPRequestHandler):
         fp = _resolve_open_path((q.get("path") or [""])[0], (q.get("sid") or [None])[0])
         if (q.get("download") or [""])[0] == "1":
             return self._file_download(fp, head=head)
+        # A mention-time PIN (see _pin_mention): serve the snapshot this message's embed latched, so a
+        # later overwrite of the same filename can never rewrite an old message's picture. The id is
+        # strictly shape-validated and joined only onto the pin dir (no traversal); a pin whose blob
+        # was evicted falls back to the LIVE file below — a nicety lost, never an error.
+        pin = (q.get("pin") or [""])[0]
+        if pin and _PIN_ID_RE.match(pin):
+            pf = _pin_dir() / pin
+            if pf.is_file():
+                fp = str(pf)
         mime = _PREVIEW_MIME.get(os.path.splitext(fp)[1].lower())
         text = not mime and _is_text_path(fp)
         if text:

--- a/tests/test_mention_pins.py
+++ b/tests/test_mention_pins.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""A chat message's embedded image keeps its MENTION-TIME bytes — a later overwrite of the same
+filename cannot rewrite history (the user 2026-08-16: an agent re-generating a plot under the same
+name silently changed the picture inside every older message that had embedded it).
+
+The mechanism: when a message's path token first RESOLVES (the pathLinks latch — the closest
+observable moment to the mention), the kernel snapshots the image's bytes content-addressed into a
+bounded mention-pins store and latches the pin with the link. The chat event ships pathPins as a
+SIBLING map (pathLinks values must stay strings for older clients), the embed requests
+/file?...&pin=<id>, and the federation relay forwards the query untouched so remote sessions pin the
+same way. A pin whose blob was evicted falls back to the live file — today's behavior, a nicety
+lost, never an error. A NEW message mentioning the regenerated file pins the NEW bytes, so the
+agent's naming freedom is untouched. SYNTHETIC fixtures only."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.parse
+import urllib.request
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+TOKEN = os.environ["ROMP_SERVE_TOKEN"]
+SID = "11111111-2222-3333-4444-cccccccccccc"
+
+PNG_V1 = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+    "0000000d49444154789c626001000000ffff03000006000557bfabd40000000049454e44ae426082")
+PNG_V2 = PNG_V1 + b"\x00\x01\x02\x03"               # different bytes — a regenerated plot
+
+
+class MentionPins(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.cwd = Path(self.td.name)
+        self.plot = self.cwd / "plot.png"
+        self.plot.write_bytes(PNG_V1)
+        km._PATH_LINK_CACHE.clear()
+        km._SPACE_PATH_CACHE.clear()
+        self._saved_cwd_of = km._cwd_of
+        km._cwd_of = lambda sid: str(self.cwd)
+
+    def tearDown(self):
+        km._cwd_of = self._saved_cwd_of
+        self.td.cleanup()
+
+    def _links(self, md, uuid):
+        return km._path_links(md, SID, uuid, {})
+
+    def test_the_resolve_latch_pins_the_bytes_and_an_overwrite_cannot_move_them(self):
+        self.assertEqual(self._links("see plot.png", "u1"), {"plot.png": "plot.png"})
+        pins = km._path_pins(SID, "u1")
+        pid = pins.get("plot.png")
+        self.assertTrue(pid, "an image mention pins at the resolve moment")
+        blob = (km._pin_dir() / pid).read_bytes()
+        self.assertEqual(blob, PNG_V1, "the pin holds the mention-time bytes")
+        self.plot.write_bytes(PNG_V2)                       # the agent regenerates the plot
+        self._links("see plot.png", "u1")                   # a later rebuild of the same message
+        self.assertEqual(km._path_pins(SID, "u1").get("plot.png"), pid,
+                         "the pin is latched with the link — history cannot move")
+        self.assertEqual((km._pin_dir() / pid).read_bytes(), PNG_V1)
+
+    def test_a_new_message_mentioning_the_regenerated_file_pins_the_new_bytes(self):
+        self._links("see plot.png", "u1")
+        old = km._path_pins(SID, "u1")["plot.png"]
+        self.plot.write_bytes(PNG_V2)
+        self._links("here is plot.png again", "u2")
+        new = km._path_pins(SID, "u2")["plot.png"]
+        self.assertNotEqual(old, new, "each message keeps the picture it actually showed")
+        self.assertEqual((km._pin_dir() / new).read_bytes(), PNG_V2)
+
+    def test_space_paths_pin_too(self):
+        spaced = self.cwd / "my plot.png"
+        spaced.write_bytes(PNG_V1)
+        got = km._space_paths("made `" + str(spaced) + "` for you", SID, "u3")
+        self.assertEqual(got, [str(spaced)])
+        self.assertIn(str(spaced), km._path_pins(SID, "u3"))
+
+    def test_non_images_do_not_pin(self):
+        (self.cwd / "notes.md").write_text("hello\n")
+        self._links("see notes.md", "u4")
+        self.assertEqual(km._path_pins(SID, "u4"), {}, "pins are for renderable images only")
+
+
+class PinServing(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def _get(self, path, pin=None, rng=None):
+        url = "http://127.0.0.1:%d/file?path=%s&token=%s" % (self.port, urllib.parse.quote(path), TOKEN)
+        if pin:
+            url += "&pin=" + urllib.parse.quote(pin)
+        req = urllib.request.Request(url, headers={"Range": rng} if rng else {})
+        try:
+            with urllib.request.urlopen(req, timeout=3) as r:
+                return r.status, r.read()
+        except urllib.error.HTTPError as e:
+            return e.code, e.read()
+
+    def test_a_pinned_fetch_serves_the_snapshot_not_the_live_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            live = Path(td) / "plot.png"
+            live.write_bytes(PNG_V1)
+            pid = km._pin_mention(str(live))
+            live.write_bytes(PNG_V2)                        # overwritten on disk
+            code, body = self._get(str(live), pin=pid)
+            self.assertEqual(code, 200)
+            self.assertEqual(body, PNG_V1, "the embed keeps the mention-time pixels")
+            code, body = self._get(str(live))
+            self.assertEqual(body, PNG_V2, "an unpinned fetch (the file viewer, a new message) is live")
+
+    def test_an_evicted_pin_falls_back_to_the_live_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            live = Path(td) / "plot.png"
+            live.write_bytes(PNG_V2)
+            ghost = "0" * 64 + ".png"                       # shape-valid, blob absent
+            code, body = self._get(str(live), pin=ghost)
+            self.assertEqual(code, 200)
+            self.assertEqual(body, PNG_V2, "a lost snapshot degrades to today's behavior, never an error")
+
+    def test_pin_ids_are_shape_gated_no_traversal(self):
+        with tempfile.TemporaryDirectory() as td:
+            live = Path(td) / "plot.png"
+            live.write_bytes(PNG_V1)
+            code, body = self._get(str(live), pin="../../serve-token")
+            self.assertEqual(code, 200)
+            self.assertEqual(body, PNG_V1, "a malformed pin is ignored outright — never joined to the store")
+
+    def test_range_resume_works_on_pinned_bytes(self):
+        with tempfile.TemporaryDirectory() as td:
+            live = Path(td) / "plot.png"
+            live.write_bytes(PNG_V1)
+            pid = km._pin_mention(str(live))
+            live.write_bytes(PNG_V2)
+            code, body = self._get(str(live), pin=pid, rng="bytes=10-")
+            self.assertEqual(code, 206)
+            self.assertEqual(body, PNG_V1[10:], "flaky-wifi resume and history pins compose")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -19,7 +19,7 @@ const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", 
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
 test("previewFull renders the image itself; a PDF is a click-to-view CARD, never an auto-loading frame", () => {
-  assert.match(PREVIEW, /export function previewFull\(path: string, sid\?: string \| null, verified = false\): HTMLElement \| null/);
+  assert.match(PREVIEW, /export function previewFull\(path: string, sid\?: string \| null, verified = false, pin\?: string\): HTMLElement \| null/);
   assert.match(PREVIEW, /img\.className = "path-full-img";/);
   // NO inline <iframe> for PDFs (2026-07-20): a browser set to "Download PDFs" saved a fresh copy on
   // EVERY chat re-render — the Downloads folder silently filled. The fetch must be user-initiated.
@@ -86,7 +86,7 @@ test("a failed preview heals on the next kernel push — the kernel-is-back even
 });
 
 test("the chat uses the FULL render on web, and the host data-URL flow for images in VS Code", () => {
-  assert.match(RENDER, /const full = canPreview\(\) \? previewFull\(p, activeId, kernelVerified\.has\(p\)\)\s*\n\s*: previewKind\(p\) === "img" \? buildPathImg\(p\) : null;/);
+  assert.match(RENDER, /const full = canPreview\(\) \? previewFull\(p, activeId, kernelVerified\.has\(p\), \(pathPins \|\| \{\}\)\[p\]\)\s*\n\s*: previewKind\(p\) === "img" \? buildPathImg\(p\) : null;/);
   assert.doesNotMatch(RENDER, /previewThumb/, "the chat no longer renders mention thumbnails — full renders now");
 });
 

--- a/ui/webview/chat-pin-history.test.ts
+++ b/ui/webview/chat-pin-history.test.ts
@@ -1,0 +1,40 @@
+// A chat message's embedded image keeps its MENTION-TIME bytes (the user 2026-08-16): an agent
+// re-generating a plot under the same filename used to rewrite the picture inside every older
+// message that had embedded it — an <img src="/file?path=…"> re-reads the live file on every
+// render. The kernel now snapshots a mentioned image at its pathLinks/spacePaths resolve latch
+// (content-addressed, bounded store) and ships per-message pathPins as a SIBLING map — pathLinks
+// values must stay strings, or an older client's string-gate would unlink every token. The embed
+// and its lightbox request /file with the pin; the federation relay forwards the query untouched;
+// an evicted pin falls back server-side to the live file. Source pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const PREVIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "preview.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("pathPins ride the chat events as a sibling map and thread into every linkify pass", () => {
+  assert.match(RENDER, /pathLinks\?: Record<string, string>; pathPins\?: Record<string, string> \}\n  \| \{ kind: "assistant";/);
+  assert.match(RENDER, /pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>\): void/);
+  const uses = RENDER.match(/linkifyFileUris\((?:body|bubble|full), [^)]*ev\.pathPins\)/g) || [];
+  assert.equal(uses.length, 3, "all three chat bodies thread the pins");
+});
+
+test("the embed and its lightbox request the pinned bytes; unpinned surfaces stay live", () => {
+  assert.match(RENDER, /previewFull\(p, activeId, kernelVerified\.has\(p\), \(pathPins \|\| \{\}\)\[p\]\)/);
+  assert.match(PREVIEW, /previewFull\(path: string, sid\?: string \| null, verified = false, pin\?: string\)/);
+  assert.match(PREVIEW, /const url = fileUrl\(path, sid\) \+ \(pin \? "&pin=" \+ encodeURIComponent\(pin\) : ""\);/);
+  assert.match(PREVIEW, /openLightbox\(path, sid, pin\); \};/, "the big view shows the same pixels the embed did");
+  assert.match(PREVIEW, /img\.src = fileUrl\(path, sid\) \+ \(pin \? "&pin=" \+ encodeURIComponent\(pin\) : ""\);/);
+});
+
+test("the kernel pins at the resolve latch and serves pins shape-gated with live fallback", () => {
+  assert.match(KERNEL, /def _pin_mention\(fp\):/);
+  assert.match(KERNEL, /pin = _pin_for\(r, sid\)\s+# the resolve moment IS the mention-time snapshot/);
+  assert.match(KERNEL, /ev\["pathPins"\] = pp/, "attached on both user and assistant events");
+  assert.match(KERNEL, /_PIN_ID_RE = re\.compile\(r"\^\[0-9a-f\]\{64\}\\\.\[a-z0-9\]\{1,8\}\$"\)/);
+  assert.match(KERNEL, /if pin and _PIN_ID_RE\.match\(pin\):/);
+  assert.match(KERNEL, /if pf\.is_file\(\):\s*\n\s*fp = str\(pf\)/, "a missing blob falls through to the live file");
+});

--- a/ui/webview/chat-space-paths.test.ts
+++ b/ui/webview/chat-space-paths.test.ts
@@ -35,7 +35,7 @@ test("the kernel verifies with the filesystem, resolved exactly like a click", (
 });
 
 test("linkifyFileUris whole-links a verified span's entire inline-code content", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>\): void/);
   // the pass targets inline <code> only, skips anything already linked or fenced
   assert.match(RENDER, /for \(const code of Array\.from\(root\.querySelectorAll\("code"\)\)\) \{\s*\n\s*if \(code\.closest\("a, \.file-uri-link, pre"\)\) continue;/);
   // exact-match against the kernel's verified set, then the whole content becomes one open link
@@ -54,7 +54,7 @@ test("the whole-span pass runs BEFORE the token walk, so the new link is skipped
 });
 
 test("every message render threads its event's spacePaths through", () => {
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks\);/);   // user bubble
-  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks\);/);     // expanded nudge body
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks\);/);    // assistant reply
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);/);   // user bubble
+  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);/);     // expanded nudge body
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);/);    // assistant reply
 });

--- a/ui/webview/file-uri-link.test.ts
+++ b/ui/webview/file-uri-link.test.ts
@@ -12,7 +12,7 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("a bare file:// URL becomes a clickable .file-uri-link that opens the file in the host app", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>\): void/);
   assert.match(RENDER, /el\("span", "file-uri-link"\)/);
   // clicking is ROUTED by openPath, never a blocked window.open(file://) — a file:// URI is absolute,
   // so it takes the shared openPathLink's no-session-id branch
@@ -24,9 +24,9 @@ test("a bare file:// URL becomes a clickable .file-uri-link that opens the file 
 });
 
 test("linkify runs on chat message bodies (assistant reply + user bubble + nudge full text) and nowhere else — never tool summaries", () => {
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks\)/);   // the assistant reply
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks\)/); // your own bubble (in-bubble images don't re-thumb)
-  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks\)/);   // a compact nudge's expanded full text (2026-07-17)
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\)/);   // the assistant reply
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\)/); // your own bubble (in-bubble images don't re-thumb)
+  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\)/);   // a compact nudge's expanded full text (2026-07-17)
   // exactly the definition + those three applications — so tool-use reports/summaries stay untouched
   const uses = RENDER.match(/linkifyFileUris\(/g) || [];
   assert.equal(uses.length, 4, "linkifyFileUris is defined once and applied to exactly the three chat bodies");

--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -50,7 +50,7 @@ test("chat: a mentioned image/PDF grows a FULL render at its mention, deduped an
   assert.match(RENDER, /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) \{/, "collected while linkifying — same detection, no second regex pass; an in-bubble image never re-renders");
   assert.match(RENDER, /if \(previewable\.length\) \{/, "both surfaces now — VS Code images ride the host data-URL flow");
   assert.match(RENDER, /previewable\.slice\(0, 4\)/, "capped so a directory listing doesn't wallpaper the chat");
-  assert.match(RENDER, /previewFull\(p, activeId, kernelVerified\.has\(p\)\)/, "relative paths resolve against the ACTIVE session's cwd, as openPathLink; verified paths fail loudly");
+  assert.match(RENDER, /previewFull\(p, activeId, kernelVerified\.has\(p\), \(pathPins \|\| \{\}\)\[p\]\)/, "relative paths resolve against the ACTIVE session's cwd, as openPathLink; verified paths fail loudly");
 });
 
 test("the chat sheet carries the lightbox + preview styles (the feed no longer previews)", () => {

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -113,7 +113,7 @@ export function fileUrl(path: string, sid?: string | null): string {
 // Full-view lightbox: dark backdrop, the image at natural-but-capped size or the PDF in the browser's
 // native viewer, filename caption. One singleton element; backdrop click / Esc / ✕ closes. Styles live
 // in BOTH styles.css and feed.css (each page loads only its own sheet — the .romp-acted precedent).
-export function openLightbox(path: string, sid?: string | null): void {
+export function openLightbox(path: string, sid?: string | null, pin?: string): void {
   document.getElementById("romp-lightbox")?.remove();
   const kind = previewKind(path);
   if (!kind) return;
@@ -130,7 +130,7 @@ export function openLightbox(path: string, sid?: string | null): void {
   } else {
     const img = document.createElement("img");
     img.className = "romp-lightbox-img";
-    img.src = fileUrl(path, sid);
+    img.src = fileUrl(path, sid) + (pin ? "&pin=" + encodeURIComponent(pin) : "");
     img.alt = path;
     inner.appendChild(img);
   }
@@ -171,7 +171,7 @@ export function openLightbox(path: string, sid?: string | null): void {
 // stays VISIBLE — a "preview unavailable — tap to retry" chip in the figure's spot — per the
 // fail-loudly rule. Only an UNVERIFIED path (old kernel, no pathLinks key) keeps self-removal:
 // there the error really does mean "no such file".
-export function previewFull(path: string, sid?: string | null, verified = false): HTMLElement | null {
+export function previewFull(path: string, sid?: string | null, verified = false, pin?: string): HTMLElement | null {
   const kind = previewKind(path);
   if (!kind || !canPreview()) return null;
   const box = document.createElement("span");
@@ -194,7 +194,10 @@ export function previewFull(path: string, sid?: string | null, verified = false)
     // said the file exists, and a transient probe failure must not erase the card.
     if (!verified) fetch(fileUrl(path, sid), { method: "HEAD" }).then((r) => { if (!r.ok) box.remove(); }).catch(() => box.remove());
   } else {
-    const url = fileUrl(path, sid);
+    // `pin` freezes this MESSAGE's embed to its mention-time bytes (kernel _pin_mention): the sid
+    // rides too (the pin store lives on the owning kernel; the relay forwards the query untouched),
+    // and a pin whose blob was evicted falls back server-side to the live file.
+    const url = fileUrl(path, sid) + (pin ? "&pin=" + encodeURIComponent(pin) : "");
     // A verified preview whose fetch died usually died because the KERNEL was away (a restart mid-
     // deploy — the 2026-08-15 report hit exactly the converge-restart window), and delta-send never
     // rebuilds an old turn's DOM, so the chip would otherwise sit until a human tapped it. Bounded so
@@ -278,7 +281,7 @@ export function previewFull(path: string, sid?: string | null, verified = false)
       img.src = src;
       img.alt = path;
       img.loading = "lazy";
-      img.onclick = (ev) => { ev.stopPropagation(); openLightbox(path, sid); };
+      img.onclick = (ev) => { ev.stopPropagation(); openLightbox(path, sid, pin); };
       return img;
     };
     const resumeFetch = async (note: HTMLElement) => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -81,8 +81,8 @@ type TaskOutputs = Record<string, { command: string; output: string }>;
 type ChatEvent = (
   // mid/mids: postal message ids the kernel could NOT resolve into cards, carried on the raw turn so a
   // timeline arc into it still lands (see _hydrate_postal's unresolved path)
-  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; canned?: string; tag?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; spacePaths?: string[]; pathLinks?: Record<string, string> }
-  | { kind: "assistant"; md: string; uuid?: string; ts?: string; spacePaths?: string[]; pathLinks?: Record<string, string> }   // spacePaths: backticked filenames WITH spaces the kernel verified exist (build_session _space_paths) → whole-span links. pathLinks: path-shaped tokens the kernel verified against the filesystem, token → real open target (build_session _path_links) — the linkifier's gate
+  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; canned?: string; tag?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; spacePaths?: string[]; pathLinks?: Record<string, string>; pathPins?: Record<string, string> }
+  | { kind: "assistant"; md: string; uuid?: string; ts?: string; spacePaths?: string[]; pathLinks?: Record<string, string>; pathPins?: Record<string, string> }   // spacePaths: backticked filenames WITH spaces the kernel verified exist (build_session _space_paths) → whole-span links. pathLinks: path-shaped tokens the kernel verified against the filesystem, token → real open target (build_session _path_links) — the linkifier's gate
   | { kind: "thinking"; text: string; encrypted: boolean; uuid?: string; ts?: string }
   | {
       kind: "tool";
@@ -1030,7 +1030,7 @@ const CLICKABLE_PATH_RE = /file:\/\/\/?[^\s<>"'`)]+|[~.\w\-]*\/[~.\w\-/]*[\w\-]|
 // kernel, a cached payload) keeps today's shape-only linking rather than unlinking history.
 // file:// URIs are explicit absolute paths — never gated on the map.
 function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: string[],
-                         pathLinks?: Record<string, string>): void {
+    pathLinks?: Record<string, string>, pathPins?: Record<string, string>): void {
   const previewable: string[] = [];   // renderable paths found in this message → full renders at their mentions
   const mentionAt = new Map<string, HTMLElement>();   // path → its FIRST mention's element (figure anchor)
   const kernelVerified = new Set<string>();           // paths the kernel stat'd — their previews fail loudly, never silently
@@ -1107,7 +1107,7 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
     const BLOCK_SEL = "p, li, h1, h2, h3, h4, h5, h6, blockquote, td, th";
     const strips = new Map<HTMLElement, HTMLElement>();   // figure anchor → its strip (same block shares one)
     for (const p of previewable.slice(0, 4)) {
-      const full = canPreview() ? previewFull(p, activeId, kernelVerified.has(p))
+      const full = canPreview() ? previewFull(p, activeId, kernelVerified.has(p), (pathPins || {})[p])
         : previewKind(p) === "img" ? buildPathImg(p) : null;
       if (!full) continue;
       const block = mentionAt.get(p)?.closest(BLOCK_SEL) as HTMLElement | null;
@@ -1842,7 +1842,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         if (more) {
           const full = el("div", "nudge-full md");
           full.innerHTML = md(raw);
-          linkifyFileUris(full, imgPaths, ev.spacePaths, ev.pathLinks);
+          linkifyFileUris(full, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins);
           bubble.appendChild(full);
           bubble.classList.add("nudge-collapsible");
           // toggle rides the stable document.body delegate (data-act), NOT a per-render listener —
@@ -1855,7 +1855,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         }
       } else if (ev.md) {
         bubble.innerHTML = md(ev.md);
-        linkifyFileUris(bubble, imgPaths, ev.spacePaths, ev.pathLinks);   // bare file:// URLs in a message → clickable (open in the host's default app)
+        linkifyFileUris(bubble, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins);   // bare file:// URLs in a message → clickable (open in the host's default app)
       }
       // images, IN the bubble (part of his message): thumbnail + open/copy caption;
       // a literal path in the typed text becomes the same open-link inline.
@@ -2004,7 +2004,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
     const body = el("div", "assistant md");
     body.innerHTML = md(ev.md);
     highlight(body);
-    linkifyFileUris(body, undefined, ev.spacePaths, ev.pathLinks);   // bare file:// URLs + verified spaced filenames → clickable
+    linkifyFileUris(body, undefined, ev.spacePaths, ev.pathLinks, ev.pathPins);   // bare file:// URLs + verified spaced filenames → clickable
     turn.appendChild(body);
     return turn;
   }

--- a/ui/webview/slash-cmd-chip.test.ts
+++ b/ui/webview/slash-cmd-chip.test.ts
@@ -16,7 +16,7 @@ test("a leading slash command in a human bubble becomes a .slash-cmd-chip, args 
   assert.match(RENDER, /const chip = el\("span", "slash-cmd-chip"\); chip\.textContent = m\[1\];/);
   assert.match(RENDER, /const args = el\("span", "slash-cmd-args"\); args\.textContent = rest;/);
   // the non-command path still renders markdown as before (now also linkifies bare file:// URLs)
-  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n\s*bubble\.innerHTML = md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks\);[^\n]*\n\s*\}/);
+  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n\s*bubble\.innerHTML = md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);[^\n]*\n\s*\}/);
 });
 
 test("the chip is a monospace, outlined keyword pill that reads on the blue bubble", () => {

--- a/ui/webview/user-img-dedup.test.ts
+++ b/ui/webview/user-img-dedup.test.ts
@@ -15,7 +15,7 @@ const RENDER = fs.readFileSync(
   path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
 test("linkifyFileUris takes skipThumbs and excludes those paths from the thumbnail strip", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>\): void/);
   // the previewable push gates on skipThumbs — the path stays a LINK, it just doesn't render a figure
   assert.match(RENDER,
     /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) \{\s*\n\s*previewable\.push\(open\);\s*\n\s*mentionAt\.set\(open, link\);/);
@@ -24,9 +24,9 @@ test("linkifyFileUris takes skipThumbs and excludes those paths from the thumbna
 test("the user bubble passes its ev.images paths (caption path AND path:-src) as skipThumbs", () => {
   // both ways an in-bubble image names its file: im.path (caption) and a "path:<abs>" src
   assert.match(RENDER, /\.flatMap\(\(im\) => \[im\.path, im\.src\.startsWith\("path:"\) \? im\.src\.slice\(5\) : ""\]\)/);
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks\);/);
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);/);
   // the assistant reply has no ev.images — its call stays bare (mentioned plots still thumb there)
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks\);/);
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);/);
 });
 
 // executed: replicate the strip-collection decision — a path already rendered as an in-bubble


### PR DESCRIPTION
User report (2026-08-16): a remote agent re-generating a plot under the same filename overwrote the embedded picture inside every older chat message that had shown it. The embed is an `<img src="/file?path=…">`, so every render re-reads the live file — history rewritten, and no client cache can survive a reload or a second device.

- **Snapshot at the resolve latch.** When a message's mentioned image first verifies (the existing pathLinks/spacePaths per-message latch — the first build after the mention, the closest observable moment), the owning kernel content-hashes the bytes into a bounded `mention-pins` store and latches the pin with the link. Content-addressing dedups unchanged files for free; a regenerated file simply stores a new blob.
- **Pins ride a sibling map.** The chat event ships `pathPins: {open-target: pin}` alongside `pathLinks` — its values must stay strings, or an older client's string-gate would unlink every token (the compat trap the recon flagged). Old client + new kernel ignores pins; new client + old kernel gets live behavior.
- **Serving.** The embed and its lightbox request `/file?…&pin=<sha256.ext>` — shape-validated and joined only onto the pin store, so no traversal; Range resume composes with pins (flaky-wifi retries of pinned bytes work). The federation relay already forwards the query untouched, so remote sessions pin with zero relay change. An evicted blob (500MB bound, oldest-mtime first) falls back to the live file: a nicety lost, never an error. Unpinned surfaces — the file viewer, a click-to-open — stay live by design: a click asks for the file, not history.
- **Naming freedom untouched.** A new message mentioning the regenerated file pins the new bytes; each message keeps the picture it actually showed.

Tests: kernel behavior end-to-end in test_mention_pins.py (latch immutability across overwrite + rebuild, new-message-new-pin, spaced-path pins, image-only gating, pinned serving vs live, eviction fallback, traversal rejection, Range-on-pins); UI threading pinned in chat-pin-history.test.ts; the six existing pin files that referenced the widened signatures are updated. Both suites + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)