### PR TITLE
A staged message can never widen the chat pane

### DIFF
--- a/ui/webview/composer-send.test.ts
+++ b/ui/webview/composer-send.test.ts
@@ -94,7 +94,7 @@ test("a staged chip clips IN BOUNDS with an ellipsis and expands on click (the u
   assert.match(STYLES, /\.staged-chip\.open \.staged-row \.composer-chip-label \{ white-space: pre-wrap; overflow: visible; \}/);
   // the affordance is visibly CHROME, not message text: dim, parenthesized, at the line's end
   assert.match(STYLES, /\.staged-expand \{ flex: 0 0 auto; color: var\(--dim\); font-size: 0\.85em; \}/);
-  assert.match(RENDER, /hint\.textContent = open \? "\(collapse\)" : "\(expand\)";/);
+  assert.match(RENDER, /hint\.textContent = open \? "\(collapse\)" : "\(click to expand\)";/);   // the tail names the gesture (the user 2026-08-16)
   // expansion survives the strip re-render (keyed set), and the discard ✕ does not toggle the fold
   assert.match(RENDER, /const stagedOpen = new Set<string>\(\);/);
   assert.match(RENDER, /x\.addEventListener\("click", \(ev\) => \{ ev\.stopPropagation\(\);/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8541,7 +8541,7 @@ function renderStagedStrip(id: string | null): void {
     const open = stagedOpen.has(id + ":" + i);
     if (open) chip.classList.add("open");
     const hint = el("span", "staged-expand");
-    hint.textContent = open ? "(collapse)" : "(expand)";
+    hint.textContent = open ? "(collapse)" : "(click to expand)";
     const toggle = () => {
       const k = id + ":" + i;
       if (stagedOpen.has(k)) stagedOpen.delete(k); else stagedOpen.add(k);

--- a/ui/webview/staged-messages.test.ts
+++ b/ui/webview/staged-messages.test.ts
@@ -1,6 +1,8 @@
 // The staged stack (the user 2026-08-15): every rule executed.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { StagedStack } from "./staged-messages";
 
 test("stage order is release order, and a flush is one-shot", () => {
@@ -42,4 +44,20 @@ test("the persistence round-trip keeps text, context and order — and drops jun
   r.restore({ b: [{ text: "" }, { nope: 1 }, "junk"], c: "junk" });   // a hand-edited/old store
   assert.equal(r.count("b"), 0, "junk hydrates to nothing, never a crash");
   assert.equal(r.count("c"), 0);
+});
+
+test("a staged line stays inside the pane: shrinkable strips, ellipsis, click-to-expand tail", () => {
+  // the user 2026-08-16 (screenshot): one long staged message refused to shrink — the composer's
+  // strips are wrapped flex ITEMS, and without flex-basis 100% + min-width 0 their min-content
+  // width is the nowrap label's full intrinsic width, so the line blew past the pane and dragged a
+  // horizontal scroll with it. The pane must NEVER scroll sideways.
+  const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+  const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+  assert.match(CSS, /#composer-files, #composer-staged, #composer-chips \{ flex: 1 1 100%; min-width: 0; max-width: 100%; \}/);
+  assert.match(CSS, /body \{ display: flex; flex-direction: column; overflow-x: hidden; \}/,
+    "the hard guarantee: a wide child is a layout bug, never a sideways scroll");
+  assert.match(CSS, /\.composer-chip-label \{ overflow: hidden; text-overflow: ellipsis; white-space: nowrap;/,
+    "the one-line ellipsis that the shrinkable strip finally lets engage");
+  assert.match(RENDER, /hint\.textContent = open \? "\(collapse\)" : "\(click to expand\)";/,
+    "the tail names the gesture");
 });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -66,7 +66,8 @@ html, body {
   background: var(--bg); color: var(--fg);
   font-family: var(--sans); font-size: var(--fs); line-height: 1.6;
 }
-body { display: flex; flex-direction: column; }
+body { display: flex; flex-direction: column; overflow-x: hidden; }   /* the chat pane NEVER scrolls
+   sideways (the user 2026-08-16) — a wide child is a layout bug to fix, not a scroll to offer */
 /* a 2px NEUTRAL frame around the WHOLE pane — drawn as a fixed overlay ON TOP so the tab bar /
    composer backgrounds can't paint over it. pointer-events:none so it never blocks clicks. The
    session's identity color now lives on the conversation RAIL instead (the user 2026-06-15). */
@@ -565,6 +566,11 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    the queued idiom (queued = sent, awaiting injection; these are unsent by choice). Same chip anatomy
    as citations, its own read: a dashed accent edge instead of the pill, no hourglass; the head wears
    the queued-head size (labels match labels). */
+/* the three composer strips are wrapped flex ITEMS of #composer: without flex-basis 100% +
+   min-width 0 their min-content width is a nowrap child's full intrinsic width, so one long staged
+   line refused to shrink, blew the strip past the pane and dragged a horizontal scroll with it (the
+   user 2026-08-16, screenshot) — the ellipsis never got the chance to engage */
+#composer-files, #composer-staged, #composer-chips { flex: 1 1 100%; min-width: 0; max-width: 100%; }
 #composer-staged { flex-direction: column; gap: 3px; padding: 5px 8px 0; }
 .staged-head { display: flex; align-items: center; gap: 8px; font-size: 0.78em; color: var(--dim); letter-spacing: 0.02em; }
 .staged-head .staged-go { margin-left: auto; background: none; border: 1px solid var(--accent); color: var(--accent);


### PR DESCRIPTION
User report with screenshot: a long staged message ran past the chat pane's right edge and dragged a horizontal scroll with it, with no ellipsis and no way to read the rest.

The composer's strips are wrapped flex items of `#composer`; without `flex: 1 1 100%; min-width: 0` a strip's min-content width is its nowrap label's full intrinsic width, so it refused to shrink and the staged row's existing one-line ellipsis never engaged. All three strips (files, staged, chips) are now full-width shrinkable items; the collapsed tail reads "(click to expand)" so the gesture is named; and the pane body carries `overflow-x: hidden` as the standing guarantee the user asked for — the chat pane never scrolls sideways.

Pinned in staged-messages.test.ts (strip flex, body guard, ellipsis, tail copy); the one existing pin on the old "(expand)" copy is updated. Both suites + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)