### PR TITLE
Delegation-linked cards show their link for life

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -6886,13 +6886,17 @@ def _consolidate_tops(store, cap=20):
     """The session's COMPLETED top-level goals, oldest-first, capped — the consolidator's candidate forest.
     A candidate is a top (parentId None) that is currently `completed` in the rolled-up status, is NOT itself
     an umbrella (don't re-group already-grouped trees into umbrella-of-umbrellas), and is neither node-cleared
-    nor view-cleared (the user crossed it off — never resurrect it under a fresh umbrella)."""
+    nor view-cleared (the user crossed it off — never resurrect it under a fresh umbrella). A top carrying
+    courier ORIGIN provenance is excluded too (the user 2026-08-16): build_feed reads origin from the TOP
+    node only, so umbrella absorption would erase the "↪ from <peer>" badge — the one visible record that
+    this card's work was a delegation and that its clear rides the cross-session link."""
     nodes = store["nodes"]
     status = store.get("status", {})
     vc = _view_cleared()
     tops = [nd for nd in nodes.values()
             if nd.get("parentId") is None and not nd.get("umbrella")
             and not nd.get("cleared") and nd["id"] not in vc
+            and not (isinstance(nd.get("origin"), dict) and nd["origin"].get("peer"))
             and status.get(nd["id"]) == "completed"]
     tops.sort(key=lambda nd: nd.get("t", 0))
     return tops[-cap:] if len(tops) > cap else tops

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16147,8 +16147,20 @@ def build_feed(now, tmux=None):
             # The node's deep-link target SEGMENT: its NEWEST trail seg — the resolve turn for
             # done/blocked nodes, the latest activity for open ones (where it stands, not where born).
             _pa, _wa = _node_anchor_uuids(nd, seg_trig, seg_uuid)
-            out.append({"id": nid, "kind": "ask", "text": nd["text"], "who": name, "whoSid": fsid,
-                        "whoColor": color, "whoWorking": who_working, "status": st, "derived": derived,
+            # A HANDOFF tracking node ("↪ delegated to <peer>") finally ships as its designed kind: the
+            # feed's delegations section (fask-delegations, built to the 2026-06-10 handoff spec) keys on
+            # kind "handoff" and had sat dormant because flatten hardcoded "ask" — the sender's card
+            # showed a bare text row with no recipient identity and no visible cross-card LINK (the user
+            # 2026-08-16, who watched a clear take the linked card with it and had no way to see why).
+            # who/whoSid/whoColor become the RECIPIENT's identity for these rows — exact, from the
+            # courier-recorded handoff.peer, never inferred.
+            _ho = nd.get("handoff") if isinstance(nd.get("handoff"), dict) else None
+            _ho_sid = str(_ho.get("peer") or "") if _ho else ""
+            out.append({"id": nid, "kind": "handoff" if _ho_sid else "ask", "text": nd["text"],
+                        "who": (_name_of(_ho_sid) or _ho_sid[:8]) if _ho_sid else name,
+                        "whoSid": _ho_sid or fsid,
+                        "whoColor": _name_color(_ho_sid) if _ho_sid else color,
+                        "whoWorking": who_working, "status": st, "derived": derived,
                         # user-cleared sub (nodeOverride op:clear) → renders struck-through + faded with a
                         # "cleared" chip; `status` above stays honest (box = done, the user 2026-07-26)
                         "cleared": bool(nd.get("cleared")),
@@ -16329,21 +16341,27 @@ def build_feed(now, tmux=None):
             o = nodes[nid].get("origin")             # courier delegation provenance: planted by a peer
             origin = None
             if isinstance(o, dict) and o.get("peer"):
-                # Show the "↪ from <peer>" badge only while the handoff is LIVE — the sender still has an
-                # OPEN linked goal. Once the sender's piece is done/cleared/gone (or there was no link),
-                # the work is fully absorbed → render as the recipient's native goal. (the user 2026-06-16.)
+                # The "↪ from <peer>" badge is PROVENANCE and stays for the card's life (the user
+                # 2026-08-16: the badge used to vanish at the exact moment the recipient finished —
+                # run_propagate completes the sender's tracking node instantly — so a COMPLETED card
+                # never showed where its work came from, and a propagated clear read as one card
+                # mysteriously taking another with it). `live` says whether the sender's linked goal
+                # is still OPEN: live → the affordance of an active handoff; absorbed → the same badge,
+                # dimmed, purely historical. This is the completed-column MERGE, heuristic-free: the
+                # one surviving card wears both identities, keyed on the courier's recorded link.
                 psid, gid = o["peer"], o.get("goalId")
                 sgoal = jd.load_goals(psid).get("nodes", {}).get(gid) if gid else None
-                if sgoal and not sgoal.get("nodeComplete") and not sgoal.get("cleared") and gid not in cleared:
-                    # Name resolution: the live names registry first (a local sender may have been
-                    # renamed), then the courier's plant-time snapshot (the only source for a
-                    # FEDERATED sender, whose sid this kernel can't resolve), then the sid stub.
-                    # peerHost renders as the same quiet "host:" prefix remote sessions wear on the
-                    # timeline (host-prefix.ts) — a local resolve means a local sender, no host.
-                    pname = _name_of(psid)
-                    origin = {"peer": pname or o.get("peerName") or psid[:8],
-                              "peerHost": ("" if pname else o.get("peerHost") or ""),
-                              "peerSid": psid, "color": _name_color(psid)}
+                live = bool(sgoal and not sgoal.get("nodeComplete") and not sgoal.get("cleared")
+                            and gid not in cleared)
+                # Name resolution: the live names registry first (a local sender may have been
+                # renamed), then the courier's plant-time snapshot (the only source for a
+                # FEDERATED sender, whose sid this kernel can't resolve), then the sid stub.
+                # peerHost renders as the same quiet "host:" prefix remote sessions wear on the
+                # timeline (host-prefix.ts) — a local resolve means a local sender, no host.
+                pname = _name_of(psid)
+                origin = {"peer": pname or o.get("peerName") or psid[:8],
+                          "peerHost": ("" if pname else o.get("peerHost") or ""),
+                          "peerSid": psid, "color": _name_color(psid), "live": live}
             await_why = (sess_awaiting_why or _stamp_why or _deleg_why or _owned_why) if col == "awaiting" else None   # the ⏳ awaiting badge's "why": live snapshot, then the judge's durable stamp, then the delegation graph, then the blocked-yield's owned dispatch (None for the postal-only case → the waitingOn chip names the peer)
             await_kind = None                        # the winning why's KIND rides beside it, mirroring the
             if col == "awaiting":                    # or-chain exactly (a kindless winner stays kindless)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4908,8 +4908,8 @@ class ViewBuilder(unittest.TestCase):
             "placements": {}, "status": {g: "working"}}))
         card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
         self.assertEqual(card["origin"], {"peer": "sendersess", "peerHost": "", "peerSid": sender,
-                                          "color": {"bg": "#ff8800", "fg": "#ffffff"}},
-                         "origin.peer (a sid) resolves to the sender's name + color")
+                                          "color": {"bg": "#ff8800", "fg": "#ffffff"}, "live": True},
+                         "origin.peer (a sid) resolves to the sender's name + color; the link is live")
 
     def test_feed_handoff_origin_falls_back_to_short_sid_when_unnamed(self):
         """If the sender isn't in the names registry, fall back to a short sid (never crash / show blank)."""
@@ -4962,9 +4962,12 @@ class ViewBuilder(unittest.TestCase):
         self.assertEqual(card["origin"]["peer"], "renamedsess")
         self.assertEqual(card["origin"]["peerHost"], "")
 
-    def test_feed_handoff_origin_hidden_when_fully_absorbed(self):
-        """Once the sender's linked goal is done/cleared/gone (or there was no link), the handoff is fully
-        absorbed → origin=None, so the badge hides and the card reads as the recipient's native goal."""
+    def test_feed_handoff_origin_persists_absorbed_with_live_false(self):
+        """PROVENANCE IS HISTORY (the user 2026-08-16): the "↪ from <peer>" badge used to vanish the
+        moment the sender's linked goal closed — which run_propagate makes the exact moment THIS card
+        completes — so a completed card never showed where its work came from, and a propagated clear
+        read as one card mysteriously taking another. The badge now stays for the card's life with
+        live=False once absorbed; only the AFFORDANCE changes (dimmed, historical)."""
         sender = "11112222-3333-4444-5555-666677778888"
         (jd.NAMES / sender).write_text("sendersess\t/elsewhere\t#ff8800\n")
         self._sender_goal(sender, sender + ":g1", nodeComplete=True)   # sender finished its piece
@@ -4978,13 +4981,60 @@ class ViewBuilder(unittest.TestCase):
                 "placements": {}, "status": {g: "working"}}))
         write_origin(sender + ":g1", "m-y.2")
         card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
-        self.assertIsNone(card["origin"], "sender's linked goal is done → fully absorbed → no badge")
+        self.assertEqual(card["origin"]["peer"], "sendersess", "the badge survives absorption")
+        self.assertFalse(card["origin"]["live"], "sender's linked goal is done → absorbed → live False")
         write_origin(None, "m-y.3")                              # no link at all
         card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
-        self.assertIsNone(card["origin"], "no link (goalId null) → absorbed → no badge")
+        self.assertFalse(card["origin"]["live"], "no link (goalId null) → absorbed")
         write_origin(sender + ":gGONE", "m-y.4")                 # link to a goal that no longer exists
         card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
-        self.assertIsNone(card["origin"], "link to a missing goal → absorbed → no badge")
+        self.assertFalse(card["origin"]["live"], "link to a missing goal → absorbed")
+
+    def test_feed_tree_ships_the_handoff_kind_with_the_recipients_identity(self):
+        """The sender's "↪ delegated to <peer>" tracking node ships kind "handoff" + the RECIPIENT's
+        identity (from the courier-recorded handoff.peer — exact, never inferred), so the feed's
+        long-dormant delegations section finally populates and the checklist stops showing a bare
+        text row with no visible cross-card link (the user 2026-08-16)."""
+        recip = "99998888-7777-6666-5555-444433332222"
+        (jd.NAMES / recip).write_text("recipsess\t/elsewhere\t#22cc88\n")
+        top, leaf, own = "%s:g20" % SID, "%s:g21" % SID, "%s:g22" % SID
+        # the top keeps ONE ordinary leaf of its own — a pure-delegation top (every leaf a handoff)
+        # is suppressed from the feed entirely, by design
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 22, "lastNode": None,
+            "nodes": {top: {"id": top, "text": "Broader goal", "parentId": None, "nodeComplete": False,
+                            "blocked": False, "cleared": False, "trail": [], "t": NOW - 80},
+                      leaf: {"id": leaf, "text": "↪ delegated to recipsess: run the sweep", "parentId": top,
+                             "nodeComplete": False, "blocked": False, "cleared": False, "trail": [],
+                             "t": NOW - 70, "handoff": {"peer": recip, "msgId": "m-h.1"}},
+                      own: {"id": own, "text": "Own remaining step", "parentId": top,
+                            "nodeComplete": False, "blocked": False, "cleared": False, "trail": [],
+                            "t": NOW - 65}},
+            "placements": {}, "status": {top: "working"}}))
+        card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == top)
+        row = next(n for n in card["tree"] if n["id"] == leaf)
+        self.assertEqual(row["kind"], "handoff")
+        self.assertEqual(row["who"], "recipsess", "the row wears the RECIPIENT's identity")
+        self.assertEqual(row["whoSid"], recip)
+        plain = next(n for n in card["tree"] if n["id"] == top)
+        self.assertEqual(plain["kind"], "ask", "ordinary nodes are untouched")
+
+    def test_consolidator_never_absorbs_an_origin_top(self):
+        """Umbrella absorption makes a top a non-top, and build_feed reads origin from the TOP only —
+        so consolidating an origin-carrying completed card would erase the "↪ from <peer>" provenance
+        from the board entirely (the user 2026-08-16). Excluded from the candidate forest."""
+        sender = "11112222-3333-4444-5555-666677778888"
+        g1, g2 = "%s:g30" % SID, "%s:g31" % SID
+        store = {"rompUuid": SID, "seq": 31, "lastNode": None,
+                 "nodes": {g1: {"id": g1, "text": "Native done goal", "parentId": None, "nodeComplete": True,
+                                "blocked": False, "cleared": False, "trail": [], "t": NOW - 60},
+                           g2: {"id": g2, "text": "Delegated done goal", "parentId": None, "nodeComplete": True,
+                                "blocked": False, "cleared": False, "trail": [], "t": NOW - 50,
+                                "origin": {"peer": sender, "goalId": sender + ":g1", "msgId": "m-c.1"}}},
+                 "placements": {}, "status": {g1: "completed", g2: "completed"}}
+        cands = [nd["id"] for nd in jd._consolidate_tops(store)]
+        self.assertIn(g1, cands)
+        self.assertNotIn(g2, cands, "provenance stays on the board — its card keeps its own face")
 
     def test_feed_clear_and_undo(self):
         g1 = "%s:g1" % SID

--- a/ui/webview/feed-delegation.test.ts
+++ b/ui/webview/feed-delegation.test.ts
@@ -57,3 +57,21 @@ test("a delegation card's title anchors on 'work' (not 'prompt') so it doesn't j
   assert.match(FEED, /let titleAnchor = it\.origin \? "work" : "prompt"/);
   assert.match(FEED, /anchor: titleAnchor/);
 });
+
+test("the '↪ from' badge is provenance for the card's LIFE: dimmed once absorbed, never removed", () => {
+  // the user 2026-08-16: the badge used to vanish the moment the recipient finished (run_propagate
+  // closes the sender's entry instantly), so a completed card never showed where its work came from
+  // — and a propagated clear read as one card mysteriously taking another with it.
+  assert.match(FEED, /live\?: boolean/);
+  assert.match(FEED, /og\.classList\.toggle\("fask-origin-absorbed", it\.origin\.live === false\);/);
+  assert.match(FEED, /their linked entry closed with this card/);
+  assert.match(FEED, /clearing this card also clears their linked entry/,
+    "the standing link is explained before the user discovers it by surprise");
+  assert.match(CSS, /\.fask-origin-absorbed \{ opacity: 0\.55; \}/);
+});
+
+test("flatten finally feeds the delegations section: kind 'handoff' with the recipient's identity", () => {
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(KERNEL, /"kind": "handoff" if _ho_sid else "ask"/);
+  assert.match(KERNEL, /_name_of\(_ho_sid\) or _ho_sid\[:8\]/, "recipient name from the recorded handoff.peer");
+});

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -280,6 +280,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fask-origin { flex: 0 0 auto; font-size: 0.8em; cursor: pointer; white-space: nowrap; }
 .fask-origin-pre { color: var(--dim); }
 .fask-origin-peer { font-weight: 600; }
+.fask-origin-absorbed { opacity: 0.55; }   /* provenance of a finished handoff — history, not an active link */
 /* the DISTILLER's one line on a card (restored 2026-06-29): completed → takeaway, blocked → decision brief.
    No why-rationale line; hidden until the distiller produces. pre-wrap keeps a copy-pasteable artifact intact. */
 .fask-distill { font-size: 0.86em; line-height: 1.4; margin: 1px 0 2px; color: var(--fg); opacity: 0.82; white-space: pre-wrap; overflow-wrap: anywhere; }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -93,7 +93,7 @@ interface AskItem {
   warns?: { kind: string; t: number; msg: string; detail: string }[] | null;   // judge-stamped anomalies (judge _node_warn → kernel build_feed): yellow "warning" chip; click opens the detail modal (the user 2026-07-02)
   nudged?: { count: number; times: number[] } | null;   // auto-nudge HISTORY (kernel _nudge_times): how many times romp followed up + when — the stalled chip's evidence (tooltip + modal line, the user 2026-07-02)
   warnRows?: { t: number; judge: string; err: string; note?: string; debug?: { input?: string; reply?: string } }[] | null;   // DEBUG MODE only (romp debug on): every judge failure touching this card (kernel _card_warn_rows) → "Warnings (debug)" modal section; rows captured in debug carry the failing call's input + reply (the user 2026-07-09)
-  origin?: { peer: string; peerSid: string; peerHost?: string; color: { bg: string; fg: string } | null } | null;  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders)
+  origin?: { peer: string; peerSid: string; peerHost?: string; color: { bg: string; fg: string } | null; live?: boolean } | null;  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders). live = the sender's linked entry is still OPEN; false → the badge is PROVENANCE, dimmed (the completed-column merge, the user 2026-08-16)
   waitingOn?: { peerSid: string; name: string; color: { bg: string; fg: string } | null; inCycle: boolean; kind?: string } | null;  // unanswered msg out to a live peer → "Awaiting <peer>" chip, or "Handed off to <peer>" when kind is "delegate" (peer name in native colour, no emoji; kernel _wait_for_graph; the user 2026-06-22 / 2026-07-25)
   awaiting?: { why?: string | null; kind?: string | null; tasks?: string[] | null } | null;   // AWAITING flavor: held in Working, ⏳ awaiting badge — waiting on dispatched/delegated work (agents/subagents/a build), NOT on you (kernel build_feed; the user 2026-06-22). The peer case rides waitingOn; this carries the generic "why". `tasks` = live bg-task descriptions (the user 2026-07-13): present → the compact "Awaiting task" pill (expands the list, like Sub-goals) replaces the boxed why.
   groupTitle?: string;                             // host: this ask shares a typed turn with siblings → the group's title
@@ -1461,6 +1461,15 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     peer.replaceChildren(...hostPartsNodes(it.origin.peerHost, it.origin.peer));
     if (it.origin.color) peer.style.color = it.origin.color.bg;
     og.append(pre, peer);
+    // absorbed (the sender's linked entry closed — usually because THIS card completed and the
+    // link-back checked it off): same badge, dimmed — provenance, not an active handoff. The title
+    // also warns that a clear takes the linked entry with it (the user 2026-08-16, who watched that
+    // happen with no visible cause).
+    og.classList.toggle("fask-origin-absorbed", it.origin.live === false);
+    og.title = (it.origin.live === false
+      ? "delegated by " + it.origin.peer + "; their linked entry closed with this card"
+      : "delegated by " + it.origin.peer + " — clearing this card also clears their linked entry")
+      + " · click opens the session";
     og.onclick = (ev: Event) => { ev.stopPropagation(); vscodeApi?.postMessage({ type: "openSession", id: it.origin!.peerSid }); };
   } else {
     og.style.display = "none";


### PR DESCRIPTION
User question, confirmed by investigation: yes — clearing either end of a delegation clears its partner (same batch, one undo restores both), manual cross-offs propagate both directions, and completions link back deterministically. All of it keys on the courier's recorded msgId/goalId, never a heuristic. What was missing is any VISIBLE record of the link, exactly when it acts:

- **The recipient's "↪ from <peer>" badge now lives as long as the card.** It used to be gated on the sender's linked entry being open — and run_propagate closes that entry the instant the card completes, so a completed card never showed where its work came from, and a propagated clear read as one card mysteriously taking another. The badge now ships with a `live` flag: an active handoff renders as before; an absorbed one keeps the same badge dimmed, and its title explains both states, including that a clear rides the link. This is the requested completed-column merge, heuristic-free — the one surviving card wears both identities (the sender side deliberately never shows a competing completed card: pure-delegation tops stay suppressed).
- **The sender's "↪ delegated to <peer>" rows finally ship as their designed `kind: "handoff"`** with the recipient's identity (name, sid, color from the recorded handoff.peer). The feed's delegations section — built to the 2026-06-10 handoff spec — had sat dormant because flatten hardcoded `kind: "ask"`, leaving a bare text row with no visible cross-card link.
- **The consolidator no longer absorbs origin-carrying completed tops**: build_feed reads origin from the top node only, so umbrella absorption erased the provenance from the board entirely.

Tests: the absorbed-origin feed test is rewritten to the new persist-with-live-flag contract; new kernel tests pin the handoff kind with the recipient's identity and the consolidator exclusion; feed-delegation.test.ts pins the absorbed render, the explanatory titles, and the activated kind. Both suites + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)