### PR TITLE
An instant preview failure names its reason, and a tap re-arms persistence

### DIFF
--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -37,7 +37,7 @@ test("a kernel-VERIFIED preview fails LOUDLY: a retry chip holds the figure's sp
   // unverified (old kernel, no pathLinks verdict) keeps self-removal — there the error means "no such file"
   assert.match(pf, /if \(!verified\) \{ box\.remove\(\); return; \}/);
   assert.match(pf, /chip\.className = "path-full-retry";/);
-  assert.match(pf, /chip\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); build\(true\); \};/, "tap to retry rebuilds the img");
+  assert.match(pf, /chip\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); autoRetries = 3; build\(true\); \};/, "a tap re-arms persistence, then retries");
   assert.match(pf, /headers: got > 0 \? \{ Range: "bytes=" \+ got \+ "-" \} : \{\}/,
     "a retry RESUMES from the bytes already received (kernel /file honors the suffix range)");
   // the render layer feeds the verdict: spacePaths and pathLinks hits are kernel-stat'd paths
@@ -57,8 +57,8 @@ test("the failure chip narrates what happens next, escalates on repeat, and a re
   // "trying" and "unavailable" on every retry cycle read as impatient even when it eventually loaded)
   assert.match(pf, /if \(autoRetries > 0\) \{\s*\n\s*autoRetries--;\s*\n\s*failedPreviews\.set\(box, \(\) => build\(true\)\);/);
   assert.match(pf, /\+ " — retrying · tap to retry now";/);
-  assert.match(pf, /wait\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); build\(true\); \};/,
-    "the whole retrying box is the tap target");
+  assert.match(pf, /wait\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); autoRetries = 3; build\(true\); \};/,
+    "the whole retrying box is the tap target — and a tap re-arms persistence");
   assert.match(pf, /"⚠ preview unavailable"\)\)\s*\n\s*\+ " — tap to retry";/,
     "the chip exists only once the budget is spent, so it carries no retrying-automatically claim");
   // a repeat failure pulses the chip on swap-in — the acknowledge-every-click rule
@@ -154,4 +154,20 @@ test("a flaky link finishes the picture ACROSS retries: resume, narrate progress
   assert.match(KERNEL, /self\.send_header\("Content-Range", "bytes %d-%d\/%d" % \(rng, size - 1, size\)\)/);
   assert.match(KERNEL, /hdrs\["Range"\] = _rng/, "the relay forwards the browser's range to the remote");
   assert.match(KERNEL, /re\.match\(r"\^bytes \\d\+-\\d\+\/\\d\+\$", crange\)/, "and mirrors only byte arithmetic back");
+});
+
+test("an instant server failure names its reason, and a tap genuinely re-arms", () => {
+  // the user 2026-08-16 (fourth report, live on a broken tunnel): retries "failed immediately" with
+  // no reason — the image was fine, the LINK to its host was down, and the kernel's 502 body said so
+  // ("tunnel to <host> is not answering") while the UI showed a generic "unavailable". And after the
+  // budget spent, each tap bought exactly ONE feeble attempt — "a click makes it seemingly not try
+  // so hard". The error body's first line now rides the note and the chip verbatim, and a tap
+  // refills the auto-retry budget (a human gesture is new information; the kernel-push auto-heal
+  // path deliberately does NOT refill, or the bound would be infinite).
+  const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
+  assert.match(pf, /why = \(\(await r\.text\(\)\) \|\| ""\)\.split\("\\n"\)\[0\]\.slice\(0, 120\);/);
+  assert.match(pf, /throw new Error\(why \|\| "http " \+ r\.status\);/);
+  assert.match(pf, /: lastErr \|\| "connection dropped"\)/, "the retrying note carries the server's reason");
+  assert.match(pf, /: lastErr \? "⚠ " \+ lastErr/, "so does the give-up chip");
+  assert.match(pf, /if \(lastErr\.startsWith\("cut at "\)\) lastErr = "";/, "mid-stream cuts narrate via byte progress instead");
 });

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -218,6 +218,7 @@ export function previewFull(path: string, sid?: string | null, verified = false,
     let got = 0;
     let total = 0;
     let fetching = false;                            // one managed attempt at a time (a tap mid-fetch no-ops)
+    let lastErr = "";                                // the newest attempt's server-side reason, shown verbatim
     const showChip = () => {
       if (!box.isConnected) return;                  // the turn re-rendered; a fresh box owns this spot now
       // ONE continuous narrative while the machinery is still going (the user 2026-08-16, third
@@ -233,7 +234,7 @@ export function previewFull(path: string, sid?: string | null, verified = false,
         const wait = mkWait(box);
         wait.title = path + " — tap to retry now";
         wait.style.cursor = "pointer";
-        wait.onclick = (ev) => { ev.stopPropagation(); build(true); };
+        wait.onclick = (ev) => { ev.stopPropagation(); autoRetries = 3; build(true); };   // a tap re-arms persistence
         const spin = document.createElement("img");
         spin.className = "path-load-spin";
         spin.src = "/media/romp-swirl-glyph.svg";
@@ -241,7 +242,7 @@ export function previewFull(path: string, sid?: string | null, verified = false,
         const note = document.createElement("span");
         note.className = "path-load-note";
         note.textContent = (got > 0 ? "connection dropped at " + fmtBytes(got, total)
-                                    : "connection dropped")
+                                    : lastErr || "connection dropped")
                            + " — retrying · tap to retry now";
         wait.append(spin, note);
         if (fails > 1) {
@@ -256,10 +257,11 @@ export function previewFull(path: string, sid?: string | null, verified = false,
       // the budget is spent: three attempts gained nothing (progress refills it), so say so plainly
       chip.textContent =
         (got > 0 ? "⚠ connection dropped at " + fmtBytes(got, total)
+                 : lastErr ? "⚠ " + lastErr
                  : (fails > 1 ? "⚠ still unavailable" : "⚠ preview unavailable"))
         + " — tap to retry";
       chip.title = path;
-      chip.onclick = (ev) => { ev.stopPropagation(); build(true); };
+      chip.onclick = (ev) => { ev.stopPropagation(); autoRetries = 3; build(true); };   // a tap re-arms persistence
       wait.appendChild(chip);
       if (fails > 1) {
         chip.classList.add("path-retry-flash");
@@ -295,7 +297,11 @@ export function previewFull(path: string, sid?: string | null, verified = false,
         parts = []; got = 0;                         // full body (no range asked, or the server restarted us)
         total = parseInt(r.headers.get("Content-Length") || "0", 10) || 0;
       } else {
-        throw new Error("http " + r.status);
+        // the error BODY is the diagnostic (the kernel's 502 says "tunnel to <host> is not
+        // answering") — a bare status code hid that the IMAGE was fine and the LINK was down
+        let why = "";
+        try { why = ((await r.text()) || "").split("\n")[0].slice(0, 120); } catch { /* body unavailable */ }
+        throw new Error(why || "http " + r.status);
       }
       const reader = r.body!.getReader();
       try {
@@ -345,13 +351,16 @@ export function previewFull(path: string, sid?: string | null, verified = false,
       wait.append(spin, note);
       resumeFetch(note).then((objUrl) => {
         fetching = false;
+        lastErr = "";
         rememberResolved(url, objUrl);
         loadedOnce.add(url);                         // re-renders skip the cue — the bytes are in hand
         if (!box.isConnected) return;
         box.textContent = "";
         box.appendChild(mkImg(objUrl));
-      }).catch(() => {
+      }).catch((e: unknown) => {
         fetching = false;
+        lastErr = String((e as Error)?.message || "");
+        if (lastErr.startsWith("cut at ")) lastErr = "";   // a mid-stream cut narrates via got/fmtBytes
         if (!verified) { box.remove(); return; }
         failAfterBeat(started);
       });


### PR DESCRIPTION
Fourth live preview report, on a broken tunnel: remote-image retries "failed immediately" with a generic unavailable — the image was fine (the owning kernel serves it locally in milliseconds) and the LINK to its host was down, which the kernel's 502 body states plainly ("tunnel to <host> is not answering") while the UI discarded the body. And once the bounded retry budget spent, each tap bought exactly one attempt — "a click makes it seemingly not try so hard."

- The managed fetch reads a failed reply's first body line (bounded) and shows it verbatim in the retrying note and the give-up chip, so a dead tunnel is distinguishable from a missing image at a glance. Mid-stream cuts keep narrating via byte progress instead.
- A tap refills the auto-retry budget: a human gesture is new information ("try again properly"), so clicking re-arms the kernel-push auto-heal rather than buying one feeble attempt. The auto-heal path itself deliberately does not refill — the bound stays finite.

Pinned in chat-inline-preview.test.ts (error-body surfacing, both copy sites, the cut-narration exception, and both re-arm click sites). UI suite + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)