### PR TITLE
Anything that needs a tunnel re-sends the connect signal

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8185,6 +8185,38 @@ def _tunnel_proc_alive(r):
     return bool(p) and p.poll() is None
 
 
+def _demand_redial(host, kind):
+    """A DATA PATH just hit this host's tunnel dead — a preview relay, a WS splice, a forwarded op,
+    a postal delivery. That demand is an EVENT (the user 2026-08-16, on flaky wifi: the backoff
+    ladder reaches 300-900s while they sit there retrying — anything they do that needs the tunnel
+    should re-send the connect signal, the way the network panel's own Try-now does): clear the
+    ladder and wake the supervisor to dial NOW. Evidence-proportional, mirroring attach_remote:
+      kind "refused"  — the local -L listener refused/reset: the ssh is dead or dying; put a still-
+                        breathing zombie down so the fresh dial owns the ports.
+      kind "timeout"  — an accepted connection starved: the half-dead shape, OR just a slow remote
+                        kernel. Counts as one silent poll (the same evidence class _poll_remote_sids
+                        files), so the woken supervisor's immediate pass decides — one more silent
+                        poll tears down and re-dials; an answered one clears the miss.
+    Self-limiting: a dial already in flight ("starting"/"authorizing" with a live proc) is left to
+    finish — each user action buys at most one fresh dial, never a storm."""
+    with _remotes_lock:
+        r = _remotes.get(host)
+        if not r or r.get("checkin_peer"):
+            return
+        alive = _tunnel_proc_alive(r)
+        if alive and r.get("status") in ("starting", "authorizing"):
+            return                                   # a dial is mid-flight — the demand is already served
+        r["fails"], r["next_try"] = 0, 0
+        if alive and kind == "refused":
+            try:
+                r["proc"].terminate()
+            except OSError:
+                pass
+        elif alive and kind == "timeout":
+            r["misses"] = max(r.get("misses", 0), STALE_MISSES - 1)
+    _tunnel_wake.set()
+
+
 def _tunnel_status(proc_alive, port_up, remote_answered):
     """The tunnel row's TRUE status. `port_up` (the local -L listener accepting) said 'up' on its own
     for a dead far end — ssh accepts the local connect, then resets when the remote side refuses — so a
@@ -8674,7 +8706,9 @@ def _remote_forward(r, path, body):
         data = resp.read()
         c.close()
         return json.loads(data.decode("utf-8") or "{}") if resp.status == 200 else None
-    except Exception:
+    except Exception as e:
+        # a forwarded op hitting a dead tunnel is USER DEMAND — re-send the connect signal
+        _demand_redial(r.get("host") or "", "refused" if isinstance(e, ConnectionRefusedError) else "timeout")
         return None
 
 
@@ -24787,6 +24821,20 @@ class Handler(BaseHTTPRequestHandler):
                 if pub is None:
                     return self._send(404, json.dumps({"ok": False, "error": "no attached host '%s' — attach it first" % host}), "application/json")
                 return self._send(200, json.dumps({"ok": True, "tunnel": pub}), "application/json")
+            if u.path == "/redial":
+                # A CONSUMER just needed a host and found it unreachable (the postal bus parking mail,
+                # the composer refusing a send to a downed host): user demand, so re-send the connect
+                # signal now instead of waiting out the backoff ladder (the user 2026-08-16, on flaky
+                # wifi). Best-effort by design — an unknown host is a quiet no-op, never an error the
+                # caller has to handle on top of the failure it is already reporting.
+                try:
+                    body = json.loads(raw_body or b"{}")
+                except Exception:
+                    body = {}
+                h = str((body or {}).get("host") or "")
+                if h:
+                    _demand_redial(h, "timeout")
+                return self._send(200, json.dumps({"ok": True}), "application/json")
             if u.path == "/tunnels/autoupdate":
                 # The popover's "Automatically update" checkbox. Body: {"on": bool}. Fleet-wide, not per-host
                 # and not per-tab: the push must fire once per advance from the kernel's own supervisor.
@@ -25413,6 +25461,9 @@ class Handler(BaseHTTPRequestHandler):
             # requested path: that's what the client's element cache is waiting on.
             _reply(client, {"type": "imgData", "path": p,
                             "url": _img_data_url(_resolve_open_path(p, msg.get("id")))})
+        elif msg and msg.get("type") == "redial" and msg.get("host"):
+            # the composer just refused a send to a downed host — user demand, dial it now (2026-08-16)
+            _demand_redial(str(msg["host"]), "timeout")
         elif msg and msg.get("type") == "dropFile" and msg.get("name") and msg.get("b64"):
             fp = _save_dropped_file(str(msg["name"]), str(msg["b64"]))   # bytes → saved file → insert its path
             if fp:
@@ -25578,8 +25629,9 @@ class Handler(BaseHTTPRequestHandler):
             q["token"] = [rtok]      # the remote's own credential; whatever the browser sent means nothing there
         try:
             up = socket.create_connection(("127.0.0.1", int(port)), timeout=6)
-        except OSError:
-            return self._send(502, "tunnel to %s is not answering" % host, "text/plain")
+        except OSError as e:
+            _demand_redial(host, "refused" if isinstance(e, ConnectionRefusedError) else "timeout")
+            return self._send(502, "tunnel to %s is not answering — re-dialing now" % host, "text/plain")
         up.settimeout(None)          # create_connection's timeout would otherwise cut the long-lived splice
         lines = ["GET /ws?%s HTTP/1.1" % urlencode(q, doseq=True),
                  "Host: 127.0.0.1:%d" % int(port)]
@@ -25696,8 +25748,10 @@ class Handler(BaseHTTPRequestHandler):
             status, ctype = resp.status, mime          # OUR mime, never resp.getheader("Content-Type")
             clen = resp.getheader("Content-Length")
             crange = resp.getheader("Content-Range") or ""
-        except (OSError, http.client.HTTPException):
-            return self._send(502, b"" if head else ("tunnel to %s is not answering" % host), "text/plain")
+        except (OSError, http.client.HTTPException) as e:
+            _demand_redial(host, "refused" if isinstance(e, ConnectionRefusedError) else "timeout")
+            return self._send(502, b"" if head else ("tunnel to %s is not answering — re-dialing now" % host),
+                              "text/plain")
         finally:
             try:
                 conn.close()
@@ -25761,7 +25815,9 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(resp.status, body, "text/plain", cache="no-cache")
                 clen = resp.getheader("Content-Length")
             except (OSError, http.client.HTTPException):
-                return self._send(502, b"" if head else ("tunnel to %s is not answering" % host), "text/plain")
+                _demand_redial(host, "timeout")
+                return self._send(502, b"" if head else ("tunnel to %s is not answering — re-dialing now" % host),
+                                  "text/plain")
             self.send_response(200)
             self.send_header("Content-Type", "application/octet-stream")
             self.send_header("Content-Disposition",

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1225,6 +1225,9 @@ class Handler(BaseHTTPRequestHandler):
                 if PEERS.get(phost, {}).get("up"):
                     return self._send({"ok": True, "id": mid,
                                        "note": "relaying to '%s' on %s" % (hit.get("name") or to, phost)})
+                _kernel_post("/redial", {"host": phost})   # parking IS demand: ask the kernel to
+                #                                             re-dial the host's tunnel now instead of
+                #                                             waiting out its backoff (the user 2026-08-16)
                 return self._send({"ok": True, "id": mid, "parked": phost,
                                    "note": "parked for %s (unreachable) — delivers on reconnect, "
                                            "or bounces back to you" % phost})

--- a/tests/test_tunnel_demand_redial.py
+++ b/tests/test_tunnel_demand_redial.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""User demand re-dials a downed tunnel NOW instead of waiting out the backoff ladder (2026-08-16).
+
+On flaky wifi the ladder ratchets fast — 300s after ~5 dials, 900s after 12 — and nothing a user did
+reset it: they sat tapping retry on a remote image while the dialer slept out its timer. Every data
+path that hits a dead tunnel is now DEMAND, the event that clears the ladder and wakes the supervisor
+(mirroring the network panel's own Try-now): the preview/download relays, the remote-WS splice, the
+forwarded control ops, the postal bus parking mail (via POST /redial), and the composer's refused
+send (via the redial WS op). Evidence-proportional: a REFUSED local port means the ssh is dead or
+dying (a zombie is terminated so the fresh dial owns the ports); a TIMEOUT through an accepted
+connection counts as one silent poll — the same evidence class the supervisor's own probe files — so
+its immediate pass decides. A dial already in flight is left to finish: one fresh dial per demand,
+never a storm. The relay's 502 now says "re-dialing now", which flows verbatim into the chat's
+preview failure notes — the in-place indication. SYNTHETIC hosts only (TESTHOST)."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.request
+from http.server import ThreadingHTTPServer
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel", os.path.join(BIN, "romp-kernel")).load_module()
+
+TOKEN = os.environ["ROMP_SERVE_TOKEN"]
+
+
+class _FakeProc:
+    def __init__(self):
+        self.terminated = 0
+    def poll(self):
+        return None                                    # alive
+    def terminate(self):
+        self.terminated += 1
+
+
+class DemandRedial(unittest.TestCase):
+    def setUp(self):
+        km._remotes.clear()
+        km._tunnel_wake.clear()
+
+    def _row(self, **kw):
+        r = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 1, "token": "",
+             "status": "down", "fails": 7, "next_try": 9e12, "misses": 0, "proc": None}
+        r.update(kw)
+        km._remotes["TESTHOST"] = r
+        return r
+
+    def test_demand_clears_the_ladder_and_wakes_the_supervisor(self):
+        r = self._row()
+        km._demand_redial("TESTHOST", "timeout")
+        self.assertEqual((r["fails"], r["next_try"]), (0, 0), "the demand IS the reset event")
+        self.assertTrue(km._tunnel_wake.is_set(), "the supervisor dials now, not at its next pass")
+
+    def test_a_refused_port_puts_a_zombie_ssh_down(self):
+        proc = _FakeProc()
+        r = self._row(proc=proc, status="up")
+        km._demand_redial("TESTHOST", "refused")
+        self.assertEqual(proc.terminated, 1, "the listener refusing means the ssh is dead or dying")
+        self.assertEqual(r["fails"], 0)
+
+    def test_a_timeout_counts_as_one_silent_poll_never_a_kill(self):
+        proc = _FakeProc()
+        r = self._row(proc=proc, status="up")
+        km._demand_redial("TESTHOST", "timeout")
+        self.assertEqual(proc.terminated, 0, "an accepted-but-starved connection may just be a slow remote")
+        self.assertEqual(r["misses"], km.STALE_MISSES - 1,
+                         "one more silent poll on the woken pass tears down; an answered one clears")
+
+    def test_a_dial_in_flight_is_left_to_finish(self):
+        r = self._row(proc=_FakeProc(), status="starting", fails=3, next_try=123.0)
+        km._demand_redial("TESTHOST", "refused")
+        self.assertEqual((r["fails"], r["next_try"]), (3, 123.0), "one fresh dial per demand, never a storm")
+        self.assertFalse(km._tunnel_wake.is_set())
+
+    def test_unknown_and_checkin_peer_hosts_are_quiet_no_ops(self):
+        km._demand_redial("NOSUCH", "timeout")
+        self.assertFalse(km._tunnel_wake.is_set())
+        r = self._row(checkin_peer=True)
+        km._demand_redial("TESTHOST", "refused")
+        self.assertEqual(r["fails"], 7, "we own no proc for a checkin peer — nothing to dial")
+
+
+class DemandDoors(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        km._remotes.clear()
+        km._tunnel_wake.clear()
+        km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 1,
+                                   "token": "", "status": "down", "fails": 5, "next_try": 9e12,
+                                   "misses": 0, "proc": None}
+
+    def _req(self, path, method="GET", body=None):
+        url = "http://127.0.0.1:%d%s%stoken=%s" % (self.port, path, "&" if "?" in path else "?", TOKEN)
+        req = urllib.request.Request(url, method=method,
+                                     data=json.dumps(body).encode() if body is not None else None,
+                                     headers={"Content-Type": "application/json"} if body is not None else {})
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, r.read()
+        except urllib.error.HTTPError as e:
+            return e.code, e.read()
+
+    def test_the_dead_relay_demands_and_says_so(self):
+        # local_port 1 refuses instantly → the 502 names the plan, and the ladder is cleared
+        code, out = self._req("/remote/TESTHOST/file?path=/tmp/x.png")
+        self.assertEqual(code, 502)
+        self.assertIn(b"re-dialing now", out, "the body flows verbatim into the chat's failure note")
+        r = km._remotes["TESTHOST"]
+        self.assertEqual((r["fails"], r["next_try"]), (0, 0))
+        self.assertTrue(km._tunnel_wake.is_set())
+
+    def test_the_redial_route_is_the_demand_door_for_external_consumers(self):
+        code, out = self._req("/redial", method="POST", body={"host": "TESTHOST"})
+        self.assertEqual(code, 200)
+        self.assertEqual((km._remotes["TESTHOST"]["fails"], km._remotes["TESTHOST"]["next_try"]), (0, 0))
+        self.assertTrue(km._tunnel_wake.is_set())
+        code, _ = self._req("/redial", method="POST", body={"host": "NOSUCH"})
+        self.assertEqual(code, 200, "an unknown host is a quiet no-op — never an error on top of a failure")
+
+    def test_postal_parking_pokes_the_door(self):
+        src = open(os.path.join(os.path.dirname(HERE), "postal", "postal_service.py")).read()
+        self.assertIn('_kernel_post("/redial", {"host": phost})', src,
+                      "parking mail for an unreachable host re-sends the connect signal")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/host-offline-ux.test.ts
+++ b/ui/webview/host-offline-ux.test.ts
@@ -65,6 +65,10 @@ test("it clears itself the moment the host is back", () => {
 test("a send into a disconnected session is refused, and the text is KEPT", () => {
   assert.match(RENDER, /if \(hostIsDown\(sid\)\) \{/);
   assert.match(RENDER, /is disconnected, so this wasn't sent\. It's still in the box/);
+  // the refusal itself is DEMAND (the user 2026-08-16, on flaky wifi): it asks the kernel to
+  // re-dial the host's tunnel NOW, so the toast's "re-dialing the link now" is literally true
+  assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "redial", host \}\);/);
+  assert.match(RENDER, /re-dialing the link now; send again when it's back\./);
   // the refusal must come BEFORE the box is cleared, or the message is gone
   const deliver = RENDER.slice(RENDER.indexOf("const deliver = () =>"));
   const guard = deliver.indexOf("if (hostIsDown(sid)) {");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9902,8 +9902,11 @@ function setupComposer() {
       // it (the user 2026-07-30) — silently accepting it would clear the composer and deliver nothing.
       if (hostIsDown(sid)) {
         const host = String(sid).slice(0, String(sid).indexOf(":"));
+        // the refusal itself is DEMAND: ask the kernel to re-dial that host's tunnel right now,
+        // so "romp is re-dialing" below is literally true at the moment it is read (2026-08-16)
+        vscodeApi?.postMessage({ type: "redial", host });
         warnToast(host + " is disconnected, so this wasn't sent. It's still in the box — romp is "
-          + "reconnecting, and you can send it then.");
+          + "re-dialing the link now; send again when it's back.");
         return;
       }
       if (isProvisionalId(sid)) {


### PR DESCRIPTION
User ask, on flaky wifi: make tunnels more robust, make any action that needs a tunnel trigger a reconnect attempt, and show what's happening where the user is looking.

Recon found the robustness half already built — keepalives (15s×3), ExitOnForwardFailure, ConnectTimeout, half-dead detection (3 silent polls → terminate + re-dial), forward-port reminting, and a network-move ladder reset. The actual gap was the backoff ladder: it reaches 300s after ~5 dials and 900s after 12, and no user action reset it — the panel's "Try now" was the only demand door.

- **`_demand_redial(host, kind)`**: clears the ladder and wakes the supervisor to dial immediately, mirroring attach's Try-now semantics. Evidence-proportional: a REFUSED local port means the ssh is dead or dying (a zombie proc is terminated so the fresh dial owns the ports); a TIMEOUT through an accepted connection counts as exactly one silent poll — the same evidence class the supervisor's probe files — so its immediate woken pass decides. A dial already in flight is left to finish: one fresh dial per demand, never a storm.
- **Every data path is now demand**: the preview relay, the download relay, the remote-WS splice, the forwarded control ops (postal wake, /send, /deliver), the postal bus's parking path (via a new auth-gated POST /redial door), and the composer's refused send (via a redial WS op).
- **In-place indication with zero new UI**: the relay's 502 body now reads "tunnel to <host> is not answering — re-dialing now" and flows verbatim into the chat's preview failure notes (the error-surfacing change from earlier today); the composer's refusal toast says "re-dialing the link now" — literally true when read, because the refusal triggered the dial.

Tests: `test_tunnel_demand_redial.py` covers the helper's five behaviors (ladder clear + wake, refused-terminates-zombie, timeout-as-one-silent-poll, dial-in-flight no-op, unknown/checkin-peer no-op) and drives the real handler over HTTP for the relay 502 + the /redial door; the host-offline UX pins gain the redial op and the honest toast copy. Both suites + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)