### PR TITLE
A whole-backtick URL is tappable, dressed as code

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1031,6 +1031,23 @@ const CLICKABLE_PATH_RE = /file:\/\/\/?[^\s<>"'`)]+|[~.\w\-]*\/[~.\w\-/]*[\w\-]|
 // file:// URIs are explicit absolute paths — never gated on the map.
 function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: string[],
     pathLinks?: Record<string, string>, pathPins?: Record<string, string>): void {
+  // A whole-backtick http(s) URL becomes a TAPPABLE link that still looks like code (the user
+  // 2026-08-16, on mobile, wanting to tap through to a dashboard link a session sent). Bare URLs
+  // and [text](url) already link via marked's gfm autolink + the global anchor click delegate;
+  // the code-span form was the one dead shape. Inline spans only (never inside <pre> blocks or an
+  // existing anchor), and only when the span's ENTIRE text is one URL — a URL quoted inside prose
+  // code stays code. The scheme is validated here, so the anchor is as safe as md()'s sanitized ones.
+  for (const code of Array.from(root.querySelectorAll("code"))) {
+    const t = (code.textContent || "").trim();
+    if (!/^https?:\/\/\S+$/.test(t)) continue;
+    if (code.closest("pre") || code.closest("a")) continue;
+    const a = document.createElement("a");
+    a.href = t;
+    a.className = "url-code-link";
+    a.title = t + " — opens in a new tab";
+    code.replaceWith(a);
+    a.appendChild(code);
+  }
   const previewable: string[] = [];   // renderable paths found in this message → full renders at their mentions
   const mentionAt = new Map<string, HTMLElement>();   // path → its FIRST mention's element (figure anchor)
   const kernelVerified = new Set<string>();           // paths the kernel stat'd — their previews fail loudly, never silently

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2301,6 +2301,10 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .path-full-pdfcard { display: inline-flex; align-items: center; gap: 7px; padding: 7px 11px;
   border-radius: 8px; border: 1px solid rgba(255, 255, 255, 0.14); background: rgba(0, 0, 0, 0.25); }
 .path-full-pdfcard:hover { border-color: var(--accent); }
+/* a whole-backtick URL, tappable but still dressed as code (render.ts linkifyFileUris) */
+.url-code-link { text-decoration: none; cursor: pointer; }
+.url-code-link code { text-decoration: underline dotted; text-underline-offset: 2px; }
+.url-code-link:hover code { color: var(--accent); }
 /* a kernel-VERIFIED preview whose bytes failed to arrive (restart, tunnel blip) — visible, retryable,
    never silently removed (preview.ts previewFull) */
 .path-full-retry { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border-radius: 8px;

--- a/ui/webview/url-code-link.test.ts
+++ b/ui/webview/url-code-link.test.ts
@@ -1,0 +1,30 @@
+// Every URL shape a session emits renders TAPPABLE in the chat (the user 2026-08-16, on mobile,
+// wanting to tap a dashboard link a session sent). Bare URLs and [text](url) already link — marked
+// runs gfm autolink and the global anchor click delegate opens any absolute-scheme href (web:
+// window.open noopener; VS Code: host openExternal). The dead shape was the WHOLE-BACKTICK URL,
+// which stayed a plain <code> span: linkifyFileUris now wraps it in an anchor that keeps the code
+// styling. Inline spans only, whole-URL-only, never double-wrapped. Source pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("bare-URL autolinking stays on (gfm) and the click delegate opens absolute schemes", () => {
+  assert.match(RENDER, /marked\.setOptions\(\{ gfm: true, breaks: false \}\);/);
+  assert.match(RENDER, /window\.open\(href, "_blank", "noopener,noreferrer"\)/);
+  assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "openLink", href \}\);/);
+});
+
+test("a whole-backtick http(s) URL becomes a tappable link that still looks like code", () => {
+  assert.match(RENDER, /if \(!\/\^https\?:\\\/\\\/\\S\+\$\/\.test\(t\)\) continue;/,
+    "only when the span's ENTIRE text is one URL — quoted URLs inside prose code stay code");
+  assert.match(RENDER, /if \(code\.closest\("pre"\) \|\| code\.closest\("a"\)\) continue;/,
+    "inline spans only, never inside a block or an existing anchor");
+  assert.match(RENDER, /a\.className = "url-code-link";/);
+  assert.match(RENDER, /code\.replaceWith\(a\);\s*\n\s*a\.appendChild\(code\);/, "the code keeps its dress inside the link");
+  assert.match(CSS, /\.url-code-link code \{ text-decoration: underline dotted;/);
+  assert.match(CSS, /\.url-code-link:hover code \{ color: var\(--accent\); \}/);
+});


### PR DESCRIPTION
Relayed user ask: a session sent dashboard URLs wrapped in single backticks and they rendered as dead code spans — untappable, which defeats the point on mobile.

Investigation first: bare URLs already autolink (marked's gfm) and `[text](url)` always worked; the global anchor click delegate opens both correctly on the web dashboard (new tab, noopener) and in VS Code (host openExternal). The whole-backtick form was the one dead shape.

`linkifyFileUris` now wraps an inline code span whose entire text is a single http(s) URL in an anchor, keeping the `<code>` element inside so it still reads as code — the same idiom as the backticked-file-path handling. Guards: inline spans only (never inside `<pre>` blocks), never double-wrapped inside an existing anchor, whole-URL-only (a URL quoted inside prose code stays code), scheme validated at wrap time so the anchor is as safe as md()'s sanitized ones.

Pinned in a new url-code-link.test.ts (the gfm setting, both click-delegate branches, the wrap guards, and the code-dress CSS). Both suites + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)