### PR TITLE
Stacked feed sections fold from a caret and drag to a new order

### DIFF
--- a/ui/webview/feed-col-fold.test.ts
+++ b/ui/webview/feed-col-fold.test.ts
@@ -1,0 +1,36 @@
+// Stacked-layout column controls (the user 2026-08-16): a caret LEFT of each category chip folds the
+// whole section to its header, and a hover-revealed grip drags the section to a new slot in the
+// stack. Both live on the build-once headers (click-safe across the feed's constant re-renders),
+// both persist with the view state, and both exist ONLY in the stacked layout — the side-by-side
+// layout hides them and ignores the dragged order entirely. Source pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+test("the caret folds a category to its header and persists like every other disclosure", () => {
+  assert.match(FEED, /const fold = el\("button", "fcol-fold"\);/);
+  assert.match(FEED, /if \(collapsedCols\.has\(key\)\) collapsedCols\.delete\(key\); else collapsedCols\.add\(key\);/);
+  assert.match(FEED, /cols: \[\.\.\.collapsedCols\],\s*\n\s*order: stackOrder\.slice\(\)/, "rides the persisted view state");
+  assert.match(CSS, /\.feed-col\.col-collapsed \.feed-col-list \{ display: none; \}/);
+  assert.match(FEED, /fold\.textContent = folded \? "▸" : "▾";/);
+});
+
+test("the grip is quiet-until-wanted, findable on touch, and drags only the stacked layout", () => {
+  assert.match(CSS, /\.fcol-fold, \.fcol-grip \{ display: none; \}/, "side-by-side shows neither control");
+  assert.match(CSS, /\.feed-col-head:hover \.fcol-grip, \.fcol-grip:focus-visible \{ opacity: 1; \}/);
+  assert.match(CSS, /@media \(hover: none\) \{ \.fcol-grip \{ opacity: 0\.35; \} \}/, "touch has no hover");
+  assert.match(CSS, /\.feed-col\.col-completed\s+\{ order: var\(--stack-order, 1\); \}/,
+    "the dragged order overrides the stacked default and only there");
+  assert.match(FEED, /grip\.setPointerCapture\(down\.pointerId\);/, "the drag survives leaving the grip");
+  assert.match(FEED, /grip\.addEventListener\("pointercancel", up\);/, "a cancelled drag still cleans up + persists");
+});
+
+test("both controls live on the build-once header — click-safe across re-renders", () => {
+  const build = FEED.slice(FEED.indexOf("function ensureCols"), FEED.indexOf("return {", FEED.indexOf("function ensureCols")));
+  assert.ok(build.includes('el("button", "fcol-fold")') && build.includes('el("span", "fcol-grip")'),
+    "wired inside ensureCols' one-time scaffold, never in a render loop");
+});

--- a/ui/webview/feed-foot.test.ts
+++ b/ui/webview/feed-foot.test.ts
@@ -36,7 +36,8 @@ test("when the feed stacks (narrow), the columns read Completed → Blocked → 
   // re-sequences ONLY the stacked case: done first (moved up from the middle, superseding the 2026-07-08
   // Blocked-first order), then needs-you, then still-running.
   assert.match(CSS, /@container \(max-width: 540px\) \{[\s\S]*?\.feed-cols \{ flex-direction: column; \}/);
-  assert.match(CSS, /\.feed-col\.col-completed\s+\{ order: 1; \}/);
-  assert.match(CSS, /\.feed-col\.col-needsInput \{ order: 2; \}/);
-  assert.match(CSS, /\.feed-col\.col-asks\s+\{ order: 3; \}/);
+  assert.match(CSS, /\.feed-col\.col-completed\s+\{ order: var\(--stack-order, 1\); \}/);   // the DEFAULT — a
+  // dragged section overrides via --stack-order (feed-col-fold.test.ts owns that rule)
+  assert.match(CSS, /\.feed-col\.col-needsInput \{ order: var\(--stack-order, 2\); \}/);
+  assert.match(CSS, /\.feed-col\.col-asks\s+\{ order: var\(--stack-order, 3\); \}/);
 });

--- a/ui/webview/feed-view-state.test.ts
+++ b/ui/webview/feed-view-state.test.ts
@@ -21,6 +21,7 @@ function sample(): FeedViewState {
     logs: ["card-b:n4"],
     asks: ["card-a"],
     threads: [],   // the card-prune tests below assert on CARD state; the thread exemption has its own
+    cols: ["completed"], order: ["asks", "completed", "needsInput"],
   };
 }
 
@@ -61,7 +62,7 @@ test("an itemId containing a colon is not mis-attributed by the prune", () => {
   // its FIRST colon would read this card as "blocked" and prune state that is very much live.
   const s: FeedViewState = {
     v: 1, sec: { "blocked:sess-7": "bg" }, tree: ["blocked:sess-7:n1"], nodes: [], logs: [], asks: [],
-    threads: [],
+    threads: [], cols: [], order: [],
   };
   const pruned = pruneViewState(s, new Set(["blocked:sess-7"]));
   assert.deepEqual(pruned.sec, { "blocked:sess-7": "bg" }, "the colon-bearing id survives");
@@ -92,7 +93,7 @@ test("the cap is a backstop that trims cheap state first and section choices las
     nodes: Array.from({ length: 10 }, (_, i) => `a:n${i}`),
     logs: Array.from({ length: 10 }, (_, i) => `a:l${i}`),
     asks: ["a"],
-    threads: ["sid-1"],
+    threads: ["sid-1"], cols: [], order: [],
   };
   const capped = capViewState(big, 20);
   assert.equal(viewStateSize(capped), 20);
@@ -107,7 +108,7 @@ test("a folded thread SURVIVES the card prune — that is the whole point of it"
   // describes a SESSION: it has to hold while that session has no cards on the board, or clearing the last
   // card would silently re-expand the thread and the next card would arrive unfolded.
   const s: FeedViewState = {
-    v: 1, sec: { "card-a": "bg" }, tree: [], nodes: [], logs: [], asks: [], threads: ["sid-quiet"],
+    v: 1, sec: { "card-a": "bg" }, tree: [], nodes: [], logs: [], asks: [], threads: ["sid-quiet"], cols: [], order: [],
   };
   const pruned = pruneViewState(s, new Set<string>());   // no live cards at all
   assert.deepEqual(pruned.threads, ["sid-quiet"]);
@@ -175,4 +176,19 @@ test("blocked/quota-limited storage never breaks the feed", () => {
 test("the storage key is namespaced alongside the feed's existing settings key", () => {
   assert.equal(VIEW_STATE_KEY, "romp:feedview");
   assert.ok(VIEW_STATE_KEY.startsWith("romp:"));
+});
+
+test("stacked-column state persists, tolerates old blobs, and gates on the three known keys", () => {
+  // the user 2026-08-16: fold + drag order are LAYOUT state — prune-exempt like threads, and a
+  // pre-upgrade blob (no cols/order) reads as nothing-folded, default order — never as corrupt
+  const old = parseViewState(JSON.stringify({ v: 1, sec: {}, tree: [], nodes: [], logs: [], asks: [], threads: [] }));
+  assert.deepEqual(old.cols, []);
+  assert.deepEqual(old.order, []);
+  const junk = parseViewState(JSON.stringify({ v: 1, sec: {}, tree: [], nodes: [], logs: [], asks: [],
+                                               threads: [], cols: ["asks", "evil", 5], order: ["completed", "x"] }));
+  assert.deepEqual(junk.cols, ["asks"], "unknown keys are dropped at the parse gate");
+  assert.deepEqual(junk.order, ["completed"]);
+  const pruned = pruneViewState(sample(), new Set<string>([]));
+  assert.deepEqual(pruned.cols, ["completed"], "layout state survives a full card prune");
+  assert.deepEqual(pruned.order, ["asks", "completed", "needsInput"]);
 });

--- a/ui/webview/feed-view-state.ts
+++ b/ui/webview/feed-view-state.ts
@@ -28,6 +28,11 @@ export interface FeedViewState {
   // alone. Keyed by SESSION, not by card, because the point is that cards which do not exist yet inherit
   // it — see the prune exemption below.
   threads: string[];
+  // Stacked-layout COLUMN state (the user 2026-08-16): collapsed column keys ("asks"/"needsInput"/
+  // "completed") and the user's dragged column order. Both describe the LAYOUT, not any card, so both
+  // are prune-EXEMPT like `threads` and bounded by their three known keys instead.
+  cols: string[];
+  order: string[];
 }
 
 export const VIEW_STATE_KEY = "romp:feedview";
@@ -36,7 +41,7 @@ export const VIEW_STATE_KEY = "romp:feedview";
 export const VIEW_STATE_CAP = 4000;
 
 export function emptyViewState(): FeedViewState {
-  return { v: 1, sec: {}, tree: [], nodes: [], logs: [], asks: [], threads: [] };
+  return { v: 1, sec: {}, tree: [], nodes: [], logs: [], asks: [], threads: [], cols: [], order: [] };
 }
 
 /** Parse a stored blob. ANY malformed/foreign/old-version value reads as empty rather than throwing — a
@@ -53,8 +58,10 @@ export function parseViewState(raw: string | null | undefined): FeedViewState {
     }
     // `threads` post-dates v1 blobs, so a stored entry without it reads as "nothing collapsed" rather
     // than as corrupt — no version bump, and yesterday's saved sections survive the upgrade.
+    const col = (x: unknown): string[] =>
+      arr(x).filter((k) => k === "asks" || k === "needsInput" || k === "completed");
     return { v: 1, sec, tree: arr(o.tree), nodes: arr(o.nodes), logs: arr(o.logs), asks: arr(o.asks),
-             threads: arr(o.threads) };
+             threads: arr(o.threads), cols: col(o.cols), order: col(o.order) };
   } catch {
     return emptyViewState();
   }
@@ -102,7 +109,7 @@ export function pruneViewState(s: FeedViewState, liveIds: Set<string>): FeedView
   for (const [k, v] of Object.entries(s.sec)) if (keyIsLive(k, liveIds)) sec[k] = v;
   const keep = (xs: string[]) => xs.filter((k) => keyIsLive(k, liveIds));
   return capViewState({ v: 1, sec, tree: keep(s.tree), nodes: keep(s.nodes), logs: keep(s.logs),
-                        asks: keep(s.asks), threads: s.threads });
+                        asks: keep(s.asks), threads: s.threads, cols: s.cols, order: s.order });
 }
 
 export function viewStateSize(s: FeedViewState): number {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -142,15 +142,34 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 
 /* responsive: stack the three columns when the panel is too narrow for them to
    sit side by side — prevents thin columns that break words mid-word ("Shippe/d") */
+/* the stacked layout's header furniture (the user 2026-08-16) exists ONLY there — hidden by default,
+   revealed inside the container query below. The fold caret wears the .feed-sess-fold treatment (dim,
+   thumb-padded); the grip is quiet-until-wanted on pointer devices and faintly present on touch, where
+   hover does not exist and the stacked layout is the primary one. */
+.fcol-fold, .fcol-grip { display: none; }
+.feed-col.col-collapsed .feed-col-list { display: none; }   /* folded: the header (chip + count) stands in */
+
 @container (max-width: 540px) {
   .feed-cols { flex-direction: column; }
-  /* stacked, the columns read TOP-DOWN as Completed → Blocked (needs you) → Working (the user 2026-07-30,
-     moving Completed up from the middle; supersedes the 2026-07-08 Blocked-first order): what finished
-     first, then what needs you, then what's still running. DOM order stays Working/Blocked/Completed
-     (unchanged for the side-by-side layout); `order` only re-sequences the stacked case. */
-  .feed-col.col-completed  { order: 1; }
-  .feed-col.col-needsInput { order: 2; }
-  .feed-col.col-asks       { order: 3; }
+  /* stacked, the columns read TOP-DOWN as Completed → Blocked (needs you) → Working by default (the
+     user 2026-07-30, moving Completed up from the middle; supersedes the 2026-07-08 Blocked-first
+     order): what finished first, then what needs you, then what's still running. DOM order stays
+     Working/Blocked/Completed (unchanged for the side-by-side layout); `order` only re-sequences the
+     stacked case — and a dragged section (feed.ts applyColStack) overrides via --stack-order, so the
+     user's arrangement wins and survives reloads with the rest of the view state. */
+  .feed-col.col-completed  { order: var(--stack-order, 1); }
+  .feed-col.col-needsInput { order: var(--stack-order, 2); }
+  .feed-col.col-asks       { order: var(--stack-order, 3); }
+  .fcol-fold { display: inline-block; flex: none; padding: 0 6px 0 2px; color: var(--dim);
+    background: transparent; border: 0; font: inherit; font-weight: 400; line-height: 1;
+    cursor: pointer; transition: color 0.12s ease; }
+  .fcol-fold:hover, .fcol-fold:focus-visible { color: var(--fg); }
+  .fcol-grip { display: inline-block; margin-left: auto; padding: 0 4px; color: var(--dim);
+    cursor: grab; opacity: 0; transition: opacity 0.12s ease; touch-action: none; user-select: none; }
+  .feed-col-head:hover .fcol-grip, .fcol-grip:focus-visible { opacity: 1; }
+  @media (hover: none) { .fcol-grip { opacity: 0.35; } }   /* touch has no hover — keep it findable */
+  .feed-col.col-dragging { opacity: 0.75; }
+  .feed-col.col-dragging .fcol-grip { cursor: grabbing; opacity: 1; }
 }
 
 /* ---------- ask card (the inbox unit): three rows (the user 2026-06-14) ---------- */

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -1181,6 +1181,11 @@ const cardTreeExpanded = new Set<string>();
 // above are exactly the state worth carrying: what the USER chose to open. Everything else module-level here
 // is a DOM cache or an in-flight optimistic record, and restoring those would resurrect predictions made
 // against a kernel that no longer exists — see feed-view-state.ts.
+// Stacked-layout column state (the user 2026-08-16): which categories are folded to their header, and
+// the dragged top-down order. Layout state, not card state — prune-exempt, persisted with the rest.
+const collapsedCols = new Set<string>();
+let stackOrder: string[] = [];                       // [] = the CSS default (Completed, Blocked, Working)
+
 (function hydrateViewState() {
   let st;
   try { st = parseViewState(localStorage.getItem(VIEW_STATE_KEY)); } catch { return; }   // private mode / blocked storage → run without it
@@ -1190,13 +1195,16 @@ const cardTreeExpanded = new Set<string>();
   for (const k of st.logs) nodeLogOpen.add(k);
   for (const k of st.asks) expandedAsks.add(k);
   for (const k of st.threads) collapsedThreads.add(k);
+  for (const k of st.cols) collapsedCols.add(k);
+  stackOrder = st.order.slice();
 })();
 
 function currentViewState(): FeedViewState {
   const sec: Record<string, string> = {};
   secChoice.forEach((v, k) => { sec[k] = v; });
   return { v: 1, sec, tree: [...cardTreeExpanded], nodes: [...collapsedNodes], logs: [...nodeLogOpen],
-           asks: [...expandedAsks], threads: [...collapsedThreads] };
+           asks: [...expandedAsks], threads: [...collapsedThreads], cols: [...collapsedCols],
+           order: stackOrder.slice() };
 }
 
 // Written at the END of every render rather than from each toggle handler: the feed re-renders on every
@@ -3164,6 +3172,72 @@ function ensureSessionFilter(): HTMLElement {
 // rebuild if torn down (empty state). "Awaiting" (the user's ruling 2026-06-10):
 // matches the session-chip vocabulary — anything here awaits HIM (a question,
 // an action like reload, an idea), red like the awaiting chip.
+const STACK_DEFAULT = ["completed", "needsInput", "asks"];   // the CSS default top-down stacking
+
+// Paint the stacked-column state: each section's fold (list hidden, caret pointed) and its top-down
+// slot (a --stack-order var the container query applies — the side-by-side layout ignores it, so a
+// drag in the narrow view never rearranges the wide one). Idempotent; runs at build and per toggle.
+function applyColStack(): void {
+  const order = stackOrder.length === 3 ? stackOrder : STACK_DEFAULT;
+  for (const key of ["asks", "needsInput", "completed"]) {
+    const col = document.querySelector<HTMLElement>(".feed-col.col-" + key);
+    if (!col) continue;
+    const folded = collapsedCols.has(key);
+    col.classList.toggle("col-collapsed", folded);
+    col.style.setProperty("--stack-order", String(order.indexOf(key) + 1));
+    const fold = col.querySelector<HTMLElement>(".fcol-fold");
+    if (fold) {
+      fold.textContent = folded ? "▸" : "▾";
+      fold.setAttribute("aria-expanded", String(!folded));
+    }
+  }
+}
+
+// Drag a section header by its grip to re-slot the category in the STACK (pointer events, capture on
+// the grip so the drag survives leaving it). Only the stacked layout listens: in the side-by-side
+// layout the grip is display:none. The order updates live while dragging (flex `order` reflows), and
+// the drop persists it.
+function wireColDrag(grip: HTMLElement, col: HTMLElement, key: string): void {
+  grip.addEventListener("pointerdown", (down) => {
+    down.preventDefault();
+    down.stopPropagation();
+    grip.setPointerCapture(down.pointerId);
+    col.classList.add("col-dragging");
+    const move = (ev: PointerEvent) => {
+      const order = (stackOrder.length === 3 ? stackOrder : STACK_DEFAULT).slice();
+      const from = order.indexOf(key);
+      // the slot whose vertical midpoint the pointer is past — walk the OTHER two sections' rects
+      let to = from;
+      for (const other of order) {
+        if (other === key) continue;
+        const oc = document.querySelector<HTMLElement>(".feed-col.col-" + other);
+        if (!oc) continue;
+        const r = oc.getBoundingClientRect();
+        const mid = r.top + r.height / 2;
+        const oi = order.indexOf(other);
+        if (oi < from && ev.clientY < mid) { to = Math.min(to, oi); }
+        if (oi > from && ev.clientY > mid) { to = Math.max(to, oi); }
+      }
+      if (to !== from) {
+        order.splice(from, 1);
+        order.splice(to, 0, key);
+        stackOrder = order;
+        applyColStack();
+      }
+    };
+    const up = () => {
+      grip.removeEventListener("pointermove", move);
+      grip.removeEventListener("pointerup", up);
+      grip.removeEventListener("pointercancel", up);
+      col.classList.remove("col-dragging");
+      persistViewState();
+    };
+    grip.addEventListener("pointermove", move);
+    grip.addEventListener("pointerup", up);
+    grip.addEventListener("pointercancel", up);
+  });
+}
+
 function ensureCols(list: HTMLElement) {
   if (!document.getElementById("feed-cols")) {
     list.innerHTML = "";
@@ -3175,14 +3249,31 @@ function ensureCols(list: HTMLElement) {
     for (const [key, label, chip] of [["asks", "Working", "working"], ["needsInput", "Blocked", "blocked"], ["completed", "Completed", "completed"]] as const) {
       const col = el("div", "feed-col col-" + key);
       const head = el("div", "feed-col-head");
+      // stacked-layout furniture (the user 2026-08-16), both hidden in the side-by-side layout by CSS:
+      // a caret LEFT of the chip folds the whole category to its header, and a grip (hover-revealed on
+      // pointer devices, faintly visible on touch) drags the section to a new spot in the stack. These
+      // live on the build-once header, so they are click-safe across the feed's constant re-renders.
+      const fold = el("button", "fcol-fold");
+      fold.setAttribute("aria-label", "Collapse " + label);
+      fold.addEventListener("click", (ev) => {
+        ev.stopPropagation();
+        if (collapsedCols.has(key)) collapsedCols.delete(key); else collapsedCols.add(key);
+        applyColStack();
+        persistViewState();
+      });
       const name = el("span", "feed-col-name fcol-chip fcol-chip-" + chip); name.textContent = label;
       const count = el("span", "feed-col-count"); count.id = "col-" + key + "-count";
-      head.append(name, count);
+      const grip = el("span", "fcol-grip");
+      grip.textContent = "⠿";
+      grip.title = "drag to reorder";
+      wireColDrag(grip, col, key);
+      head.append(fold, name, count, grip);
       const body = el("div", "feed-col-list"); body.id = "col-" + key + "-list";
       col.append(head, body);
       cols.appendChild(col);
     }
     list.appendChild(cols);
+    applyColStack();
   }
   return {
     asks: document.getElementById("col-asks-list")!,


### PR DESCRIPTION
User ask: in column mode (narrow feed, mobile), add carets left of Working/Blocked/Completed to collapse each category, and make the sections draggable to reposition — with the drag control shown only on hover.

- **Fold caret**, left of the category chip, stacked layout only: folds the section to its header, with the chip + count standing in so what's folded away stays countable. State persists with the feed view state (prune-exempt like collapsed threads — it's layout, not card state; a pre-upgrade blob reads as nothing-folded) and survives reloads.
- **Drag grip**, right end of the header: invisible until the header is hovered or the grip is focused; faintly visible on touch, where hover doesn't exist and the stacked layout is the primary one. Pointer-captured so the drag survives leaving the grip; the order updates live while dragging and persists on drop. It applies through a `--stack-order` variable that only the narrow container query reads, so a drag in the stacked view never rearranges the side-by-side layout, whose Completed → Blocked → Working default (2026-07-30) stays the fallback.
- Both controls live on `ensureCols`' build-once header scaffold — click-safe across the feed's constant re-renders per the standing button rule.

Tests: feed-col-fold.test.ts pins the fold/persist/grip/pointer-capture/stacked-only rules; feed-view-state.test.ts gains the schema round-trip, old-blob tolerance, known-key gating, and prune exemption; the feed-foot stacked-order pins learn the var-with-default form. Both suites + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)