### PR TITLE
The column fold caret matches the session headers' caret exactly

### DIFF
--- a/ui/webview/feed-col-fold.test.ts
+++ b/ui/webview/feed-col-fold.test.ts
@@ -17,6 +17,10 @@ test("the caret folds a category to its header and persists like every other dis
   assert.match(FEED, /cols: \[\.\.\.collapsedCols\],\s*\n\s*order: stackOrder\.slice\(\)/, "rides the persisted view state");
   assert.match(CSS, /\.feed-col\.col-collapsed \.feed-col-list \{ display: none; \}/);
   assert.match(FEED, /fold\.textContent = folded \? "▸" : "▾";/);
+  // consistency with the session headers' fold (the user 2026-08-16): same side — caret RIGHT of the
+  // label — and the same rendered size (the header's 0.72em compensated back to the feed's base)
+  assert.match(FEED, /head\.append\(name, fold, count, grip\);/);
+  assert.match(CSS, /\.fcol-fold \{ display: inline-block; flex: none; padding: 0 5px; margin-left: -2px;[^}]*font-size: 1\.389em;/);
 });
 
 test("the grip is quiet-until-wanted, findable on touch, and drags only the stacked layout", () => {

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -160,9 +160,12 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   .feed-col.col-completed  { order: var(--stack-order, 1); }
   .feed-col.col-needsInput { order: var(--stack-order, 2); }
   .feed-col.col-asks       { order: var(--stack-order, 3); }
-  .fcol-fold { display: inline-block; flex: none; padding: 0 6px 0 2px; color: var(--dim);
-    background: transparent; border: 0; font: inherit; font-weight: 400; line-height: 1;
-    cursor: pointer; transition: color 0.12s ease; }
+  /* the SAME caret the session headers wear (.feed-sess-fold): same glyphs, same side (right of
+     the label), same rendered size — the header's 0.72em is compensated explicitly so the glyph
+     paints at the feed's base size instead of shrinking with the label (the user 2026-08-16) */
+  .fcol-fold { display: inline-block; flex: none; padding: 0 5px; margin-left: -2px; color: var(--dim);
+    background: transparent; border: 0; font: inherit; font-size: 1.389em; font-weight: 400;
+    line-height: 1; cursor: pointer; transition: color 0.12s ease; }
   .fcol-fold:hover, .fcol-fold:focus-visible { color: var(--fg); }
   .fcol-grip { display: inline-block; margin-left: auto; padding: 0 4px; color: var(--dim);
     cursor: grab; opacity: 0; transition: opacity 0.12s ease; touch-action: none; user-select: none; }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3267,7 +3267,8 @@ function ensureCols(list: HTMLElement) {
       grip.textContent = "⠿";
       grip.title = "drag to reorder";
       wireColDrag(grip, col, key);
-      head.append(fold, name, count, grip);
+      head.append(name, fold, count, grip);   // caret RIGHT of the chip — the same side as the
+      //                                          session headers' fold (the user 2026-07-31 / 2026-08-16)
       const body = el("div", "feed-col-list"); body.id = "col-" + key + "-list";
       col.append(head, body);
       cols.appendChild(col);


### PR DESCRIPTION
Follow-up to the stacked-column fold: the new category caret must be indistinguishable from the session-name fold caret. Glyphs already matched (▸/▾); this aligns the remaining two properties:

- **Side**: the caret moves to the RIGHT of the category chip — the same side the session-name fold has worn since 2026-07-31, keeping one placement convention instead of introducing a second.
- **Size**: the column header's 0.72em context was shrinking the glyph; the caret's font-size is compensated explicitly back to the feed's base size so both carets paint identically (per the standing font-size rule: nested em contexts never compound silently).

Pins extended in feed-col-fold.test.ts (header order, compensated size). UI suite + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)