### PR TITLE
The category chips drag directly, with live provisional movement

### DIFF
--- a/ui/webview/feed-col-fold.test.ts
+++ b/ui/webview/feed-col-fold.test.ts
@@ -19,22 +19,33 @@ test("the caret folds a category to its header and persists like every other dis
   assert.match(FEED, /fold\.textContent = folded \? "▸" : "▾";/);
   // consistency with the session headers' fold (the user 2026-08-16): same side — caret RIGHT of the
   // label — and the same rendered size (the header's 0.72em compensated back to the feed's base)
-  assert.match(FEED, /head\.append\(name, fold, count, grip\);/);
+  assert.match(FEED, /head\.append\(name, fold, count\);/);
   assert.match(CSS, /\.fcol-fold \{ display: inline-block; flex: none; padding: 0 5px; margin-left: -2px;[^}]*font-size: 1\.389em;/);
 });
 
-test("the grip is quiet-until-wanted, findable on touch, and drags only the stacked layout", () => {
-  assert.match(CSS, /\.fcol-fold, \.fcol-grip \{ display: none; \}/, "side-by-side shows neither control");
-  assert.match(CSS, /\.feed-col-head:hover \.fcol-grip, \.fcol-grip:focus-visible \{ opacity: 1; \}/);
-  assert.match(CSS, /@media \(hover: none\) \{ \.fcol-grip \{ opacity: 0\.35; \} \}/, "touch has no hover");
+test("the chip itself drags — grab cursor as the affordance, live provisional movement, stacked only", () => {
+  // the user 2026-08-16, dropping the earlier grip handle: grabbing the Working/Blocked/Completed
+  // chip moves the section, the grabbed section follows the pointer, and the displaced sections
+  // FLIP-animate into their provisional slots — what you see mid-drag is what you get on drop.
+  assert.match(CSS, /\.feed-col-head \.fcol-chip \{ cursor: grab; touch-action: none; user-select: none; \}/);
+  assert.match(CSS, /\.feed-col\.col-dragging \{ position: relative; z-index: 5;/, "lifted over siblings while following");
   assert.match(CSS, /\.feed-col\.col-completed\s+\{ order: var\(--stack-order, 1\); \}/,
     "the dragged order overrides the stacked default and only there");
-  assert.match(FEED, /grip\.setPointerCapture\(down\.pointerId\);/, "the drag survives leaving the grip");
-  assert.match(FEED, /grip\.addEventListener\("pointercancel", up\);/, "a cancelled drag still cleans up + persists");
+  assert.match(FEED, /wireColDrag\(name, col, key\);/, "no separate handle — the chip is the drag surface");
+  assert.doesNotMatch(FEED, /fcol-grip/, "the grip is gone");
+  assert.match(FEED, /if \(!colsEl \|\| getComputedStyle\(colsEl\)\.flexDirection !== "column"\) return;/,
+    "side by side, the chip never captures the pointer");
+  assert.match(FEED, /chip\.setPointerCapture\(down\.pointerId\);/, "the drag survives leaving the chip");
+  assert.match(FEED, /col\.style\.transform = "translateY\(" \+ \(ev\.clientY - startY - slotShift\) \+ "px\)";/,
+    "the grabbed section follows the pointer");
+  assert.match(FEED, /e\.animate\(\[\{ transform: "translateY\(" \+ d \+ "px\)" \}, \{ transform: "translateY\(0\)" \}\]/,
+    "displaced sections FLIP into their provisional slots");
+  assert.match(FEED, /\{ slotShift -= d; continue; \}/, "a re-slot never yanks the section out from under the pointer");
+  assert.match(FEED, /chip\.addEventListener\("pointercancel", up\);/, "a cancelled drag still settles + persists");
 });
 
 test("both controls live on the build-once header — click-safe across re-renders", () => {
   const build = FEED.slice(FEED.indexOf("function ensureCols"), FEED.indexOf("return {", FEED.indexOf("function ensureCols")));
-  assert.ok(build.includes('el("button", "fcol-fold")') && build.includes('el("span", "fcol-grip")'),
+  assert.ok(build.includes('el("button", "fcol-fold")') && build.includes("wireColDrag(name, col, key)"),
     "wired inside ensureCols' one-time scaffold, never in a render loop");
 });

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -144,9 +144,9 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    sit side by side — prevents thin columns that break words mid-word ("Shippe/d") */
 /* the stacked layout's header furniture (the user 2026-08-16) exists ONLY there — hidden by default,
    revealed inside the container query below. The fold caret wears the .feed-sess-fold treatment (dim,
-   thumb-padded); the grip is quiet-until-wanted on pointer devices and faintly present on touch, where
-   hover does not exist and the stacked layout is the primary one. */
-.fcol-fold, .fcol-grip { display: none; }
+   thumb-padded); the category CHIP is itself the drag surface (no separate handle — the grab cursor
+   it wears in the stacked layout is the affordance). */
+.fcol-fold { display: none; }
 .feed-col.col-collapsed .feed-col-list { display: none; }   /* folded: the header (chip + count) stands in */
 
 @container (max-width: 540px) {
@@ -167,12 +167,9 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
     background: transparent; border: 0; font: inherit; font-size: 1.389em; font-weight: 400;
     line-height: 1; cursor: pointer; transition: color 0.12s ease; }
   .fcol-fold:hover, .fcol-fold:focus-visible { color: var(--fg); }
-  .fcol-grip { display: inline-block; margin-left: auto; padding: 0 4px; color: var(--dim);
-    cursor: grab; opacity: 0; transition: opacity 0.12s ease; touch-action: none; user-select: none; }
-  .feed-col-head:hover .fcol-grip, .fcol-grip:focus-visible { opacity: 1; }
-  @media (hover: none) { .fcol-grip { opacity: 0.35; } }   /* touch has no hover — keep it findable */
-  .feed-col.col-dragging { opacity: 0.75; }
-  .feed-col.col-dragging .fcol-grip { cursor: grabbing; opacity: 1; }
+  .feed-col-head .fcol-chip { cursor: grab; touch-action: none; user-select: none; }
+  .feed-col.col-dragging { position: relative; z-index: 5; opacity: 0.9; }   /* lifted over its siblings while it follows the pointer */
+  .feed-col.col-dragging .fcol-chip { cursor: grabbing; }
 }
 
 /* ---------- ask card (the inbox unit): three rows (the user 2026-06-14) ---------- */

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3197,12 +3197,39 @@ function applyColStack(): void {
 // the grip so the drag survives leaving it). Only the stacked layout listens: in the side-by-side
 // layout the grip is display:none. The order updates live while dragging (flex `order` reflows), and
 // the drop persists it.
-function wireColDrag(grip: HTMLElement, col: HTMLElement, key: string): void {
-  grip.addEventListener("pointerdown", (down) => {
+// Drag a section by its CATEGORY CHIP (the user 2026-08-16, dropping the earlier grip handle): the
+// grab cursor on the chip is the affordance. While dragging, the grabbed section FOLLOWS the pointer
+// (a transform, so nothing reflows under the hand) and the displaced sections FLIP-animate into their
+// provisional slots — the arrangement you see mid-drag is the arrangement you get. Only the stacked
+// layout listens: side by side the chip keeps its normal cursor and this returns before capturing.
+function wireColDrag(chip: HTMLElement, col: HTMLElement, key: string): void {
+  chip.addEventListener("pointerdown", (down) => {
+    const colsEl = document.getElementById("feed-cols");
+    if (!colsEl || getComputedStyle(colsEl).flexDirection !== "column") return;
     down.preventDefault();
     down.stopPropagation();
-    grip.setPointerCapture(down.pointerId);
+    chip.setPointerCapture(down.pointerId);
     col.classList.add("col-dragging");
+    const startY = down.clientY;
+    let slotShift = 0;   // the dragged section's own accumulated slot movement — folded into its
+    //                      follow-transform so a re-slot never yanks it out from under the pointer
+    const applyOrderFlip = (order: string[]) => {
+      const els: Array<[string, HTMLElement]> = [];
+      for (const k of ["asks", "needsInput", "completed"]) {
+        const e = document.querySelector<HTMLElement>(".feed-col.col-" + k);
+        if (e) els.push([k, e]);
+      }
+      const before = new Map(els.map(([k, e]) => [k, e.getBoundingClientRect().top]));
+      stackOrder = order;
+      applyColStack();
+      for (const [k, e] of els) {
+        const d = (before.get(k) || 0) - e.getBoundingClientRect().top;
+        if (!d) continue;
+        if (k === key) { slotShift -= d; continue; }   // both rects carry the follow-transform, so d is pure slot delta
+        e.animate([{ transform: "translateY(" + d + "px)" }, { transform: "translateY(0)" }],
+                  { duration: 150, easing: "ease" });
+      }
+    };
     const move = (ev: PointerEvent) => {
       const order = (stackOrder.length === 3 ? stackOrder : STACK_DEFAULT).slice();
       const from = order.indexOf(key);
@@ -3221,20 +3248,27 @@ function wireColDrag(grip: HTMLElement, col: HTMLElement, key: string): void {
       if (to !== from) {
         order.splice(from, 1);
         order.splice(to, 0, key);
-        stackOrder = order;
-        applyColStack();
+        applyOrderFlip(order);
       }
+      col.style.transform = "translateY(" + (ev.clientY - startY - slotShift) + "px)";
     };
     const up = () => {
-      grip.removeEventListener("pointermove", move);
-      grip.removeEventListener("pointerup", up);
-      grip.removeEventListener("pointercancel", up);
+      chip.removeEventListener("pointermove", move);
+      chip.removeEventListener("pointerup", up);
+      chip.removeEventListener("pointercancel", up);
+      // settle: animate from wherever the hand left it into its slot, then drop the transform
+      const hang = col.style.transform;
+      col.style.transform = "";
+      if (hang && hang !== "translateY(0px)") {
+        col.animate([{ transform: hang }, { transform: "translateY(0)" }],
+                    { duration: 150, easing: "ease" });
+      }
       col.classList.remove("col-dragging");
       persistViewState();
     };
-    grip.addEventListener("pointermove", move);
-    grip.addEventListener("pointerup", up);
-    grip.addEventListener("pointercancel", up);
+    chip.addEventListener("pointermove", move);
+    chip.addEventListener("pointerup", up);
+    chip.addEventListener("pointercancel", up);
   });
 }
 
@@ -3262,12 +3296,11 @@ function ensureCols(list: HTMLElement) {
         persistViewState();
       });
       const name = el("span", "feed-col-name fcol-chip fcol-chip-" + chip); name.textContent = label;
+      name.title = "drag to reorder";
+      wireColDrag(name, col, key);            // the chip ITSELF drags (the user 2026-08-16) — the grab
+      //                                         cursor it wears in the stacked layout is the affordance
       const count = el("span", "feed-col-count"); count.id = "col-" + key + "-count";
-      const grip = el("span", "fcol-grip");
-      grip.textContent = "⠿";
-      grip.title = "drag to reorder";
-      wireColDrag(grip, col, key);
-      head.append(name, fold, count, grip);   // caret RIGHT of the chip — the same side as the
+      head.append(name, fold, count);         // caret RIGHT of the chip — the same side as the
       //                                          session headers' fold (the user 2026-07-31 / 2026-08-16)
       const body = el("div", "feed-col-list"); body.id = "col-" + key + "-list";
       col.append(head, body);


### PR DESCRIPTION
User refinement on the stacked-section reordering: no separate grip — grabbing the Working/Blocked/Completed chip itself moves the section, discovered through the grab cursor the chip wears in the stacked layout.

And the drag now feels like one: the grabbed section follows the pointer via a transform (nothing reflows under the hand), the displaced sections FLIP-animate into their provisional slots as the pointer crosses their midpoints — what you see mid-drag is what you get on drop — and the section settles into place on release. A re-slot's height delta folds into the follow-transform (both measurements carry the transform, so the delta is pure slot movement), keeping the section glued to the pointer through order changes. Side-by-side layout: the chip never captures the pointer and keeps its normal cursor.

Pins updated in feed-col-fold.test.ts: chip-as-drag-surface (grip absent), the grab/grabbing cursors, the follow-transform, the FLIP animation, the slot-shift continuity rule, and cancel-settles-and-persists. Both suites + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)