### PR TITLE
Creating, opening, forking or reviving a session moves only the asker's chat

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -4608,7 +4608,7 @@ def _apply_new_session_prefs(sid, body):
     return out
 
 
-def _create_sdk_session(nm, cwd, auth="", prefs=None):
+def _create_sdk_session(nm, cwd, auth="", prefs=None, client=None):
     """Create + open a new SDK-backed session, ACK-FAST (the user 2026-07-14, who asked why it took so long
     to open a new SDK session). spawn() is file writes and connect() is threaded (~0.4s to a booting
     CLI) — the 7-10s the user waited was the handler's inline _push_all(): a new session invalidates the
@@ -4627,19 +4627,27 @@ def _create_sdk_session(nm, cwd, auth="", prefs=None):
     kickoff fed into that dying client's stdin was cancelled mid-delivery and landed nowhere (a fresh
     spawn's briefing sat as a dropped echo for 5.5h on a conversation that never started, 2026-08-16).
     Pre-connect there is no session object yet, so the setters are pure reg writes the connect reads —
-    no reconnect exists to race. Returns (sid, echo) — echo is the applied-prefs ack for /new's reply."""
+    no reconnect exists to race. Returns (sid, echo) — echo is the applied-prefs ack for /new's reply.
+
+    The focus is aimed at `client` — the dashboard whose picker asked — per the per-viewer rule
+    (which tab you are looking at is yours, 2026-07-29). No client means NOBODY moves: the CLI's
+    POST /new has no dashboard in hand, and broadcasting its focus switched every open window's chat
+    to whatever session a terminal or a script just created (the user 2026-08-16, whose chats kept
+    jumping to sessions they had not touched). The tab itself still reaches every window via the
+    push."""
     bg, fg = _pick_identity_color()   # fleet-aware: only the kernel sees BOTH backends' live sessions
     _commands_for_cwd(cwd)   # pre-warm the slash-command list — a new session predicts a composer (the user 2026-08-13)
     sid = _sdk().spawn(nm, cwd, bg, fg, auth=auth)
     extra = _apply_new_session_prefs(sid, prefs or {})
     _sdk().connect(sid)    # eager-connect so the model lists immediately, not only after the 1st message
-    _reveal_chat({"type": "focus", "id": sid})
+    if client is not None:
+        _reveal_chat_for(client, {"type": "focus", "id": sid})
     _mark_views_dirty()
     _push_session_now(sid)   # the tab the user is staring at, ahead of the woken cycle
     return sid, extra
 
 
-def _fork_session(parent_sid, cut_msg_uuid, new_name, now=None):
+def _fork_session(parent_sid, cut_msg_uuid, new_name, now=None, client=None):
     """Fork `parent_sid`'s conversation into a NEW parallel session named `new_name` — from just BEFORE
     user message `cut_msg_uuid` when given (the chat's fork button; same _rewind_target resolution and
     guards as the edit/delete rewind, so "before this message" means the same thing everywhere), the
@@ -4675,7 +4683,8 @@ def _fork_session(parent_sid, cut_msg_uuid, new_name, now=None):
     bg, fg = _pick_identity_color()
     be.fork(nm, parent_sid, cut_uuid, bg, fg, sid=sid)
     be.connect(sid)          # eager-connect: the CLI copies the conversation and the tab fills in
-    _reveal_chat({"type": "focus", "id": sid})
+    if client is not None:   # the asker's window follows its fork; nobody else's chat moves
+        _reveal_chat_for(client, {"type": "focus", "id": sid})
     _mark_views_dirty()
     _push_session_now(sid)
     return None
@@ -5277,7 +5286,7 @@ def _comment_kill_all(parent_sid, be):
                 pass
 
 
-def _comment_promote(parent_sid, tid, new_name, now=None):
+def _comment_promote(parent_sid, tid, new_name, now=None, client=None):
     """Break a thread out into a FULL board session. Ordering contract (same as _fork_session):
     judge stores are seeded BEFORE promote_thread writes the names/ entry. The seeds run against
     the PARENT transcript at the ORIGINAL cut (the history the two transcripts share, verbatim),
@@ -5327,7 +5336,8 @@ def _comment_promote(parent_sid, tid, new_name, now=None):
         return _revert("couldn't promote this thread.")
     _comment_update(parent_sid, tid, status="promoted", promotedName=nm)
     started = be.connect(tsid)
-    _reveal_chat({"type": "focus", "id": tsid})
+    if client is not None:   # the promoter's window follows the new session; nobody else's chat moves
+        _reveal_chat_for(client, {"type": "focus", "id": tsid})
     _mark_views_dirty()
     _push_session_now(tsid)
     if not started:
@@ -6180,7 +6190,7 @@ def _drive(msg, client):
         # Fork this conversation into a NEW parallel session (the user 2026-08-13). uuid (optional) is the
         # user message the fork cuts just BEFORE — absent means the whole conversation. LOUD on refusal;
         # on success the new tab arrives focused via _fork_session's own push.
-        err = _fork_session(sid, str(msg.get("uuid") or ""), str(msg["name"]))
+        err = _fork_session(sid, str(msg.get("uuid") or ""), str(msg["name"]), client=client)
         if err:
             client["send"](json.dumps({"type": "warn", "text": err}))
     elif t == "commentCreate" and msg.get("uuid") and msg.get("exact") and msg.get("text"):
@@ -6220,7 +6230,7 @@ def _drive(msg, client):
     elif t == "commentPromote" and msg.get("tid") and msg.get("name"):
         # Break the thread out into its own board session. LOUD on refusal; on success the new tab
         # arrives focused via _comment_promote's own push (the forkSession acknowledgement shape).
-        err = _comment_promote(sid, str(msg["tid"]), str(msg["name"]))
+        err = _comment_promote(sid, str(msg["tid"]), str(msg["name"]), client=client)
         if err:
             client["send"](json.dumps({"type": "warn", "text": err}))
     elif t == "endSession":
@@ -6242,7 +6252,7 @@ def _drive(msg, client):
 def _reveal_or_confirm(sid, focus_msg, client=None):
     """Bring the chat to `sid`. LIVE → the focus message. DEAD → never silently reveal; pop the chat's
     confirmRevive modal (Revive / View read-only), bringing the chat forward (the user 2026-06-17: dead
-    = timeline-only, reopen on demand). Routing the prompt through _reveal_chat means a feed/timeline tap
+    = timeline-only, reopen on demand). Routing the prompt through _reveal_chat_for means a feed/timeline tap
     lands the modal in the chat, which owns it — even though the tap came from another pane.
 
     Where a CLIENT is in scope (every WS op that calls this), the reveal is aimed at that dashboard
@@ -6402,11 +6412,16 @@ def _split_host_id(sid):
     return (s[:i], s[i + 1:]) if i > 0 else ("", s)
 
 
-def _open_or_revive(sid, live=False):
+def _open_or_revive(sid, live=False, client=None):
     """openSession routing: a LIVE session → focus the chat (its tab is always shown); a DEAD one → the
     confirmRevive modal (no silent reopen, no auto read-only tab — the user 2026-06-17). `live` (the user
     2026-07-08): land the chat on its LIVE TAIL, not the last scroll — a blocked card's picker/permission
-    prompt is the live bottom, so its feed chip drops you right on it."""
+    prompt is the live bottom, so its feed chip drops you right on it.
+
+    `client` rides through to _reveal_or_confirm so the jump moves the ASKING dashboard alone. This was
+    the one click-op the per-viewer fix (2026-07-29) missed — its guard test counted _reveal_chat_for
+    call sites and the other branches satisfied the count — so every feed/fleet/picker tap kept
+    switching the chat in EVERY open window (the user 2026-08-16)."""
     if sid in _tmux_sessions():
         be = _sdk()
         if be:
@@ -6418,11 +6433,13 @@ def _open_or_revive(sid, live=False):
     focus = {"type": "focus", "id": sid}
     if live:
         focus["live"] = True
-    _reveal_or_confirm(sid, focus)
+    _reveal_or_confirm(sid, focus, client)
 
 
-def _revive_session(sid):
-    """Bring a DEAD session back, per backend, then un-hide its tab and focus the chat on it. SDK-owned
+def _revive_session(sid, client=None):
+    """Bring a DEAD session back, per backend, then un-hide its tab and focus the chat on it — the chat
+    of the dashboard that clicked Revive (`client`), not every open window's (the per-viewer rule; the
+    reviveFailed notice is aimed the same way, since only the asker has a revive loader up). SDK-owned
     (registry entry exists) → SdkBackend.resume + connect: alive again, resuming its newest transcript
     (lastSid) with history intact. Otherwise tmux → `romp <name> --resume <sid> --detach` in the session's
     recorded dir (dir resolution, picker-grace via bin/romp's own picker-check). Runs in a thread off the
@@ -6454,12 +6471,13 @@ def _revive_session(sid):
         ok, detail = False, str(e)[:200]
     if not ok:
         sys.stderr.write("revive '%s' (%s): %s\n" % (name, sid, detail))
-        _send_to_app("chat", {"type": "reviveFailed", "id": sid, "name": name,
-                              "text": detail or "unknown error"})
+        _send_to_view("chat", {"type": "reviveFailed", "id": sid, "name": name,
+                               "text": detail or "unknown error"}, (client or {}).get("wid") or "")
         return
     _kept_open.discard(sid)       # it's live again → no longer a read-only kept tab
     _push_all()                   # surface it promptly (the 4s pusher would catch it anyway)
-    _reveal_chat({"type": "focus", "id": sid})
+    if client is not None:        # the asker's revive loader clears on this focus; other windows stay put
+        _reveal_chat_for(client, {"type": "focus", "id": sid})
 
 
 # ─────────────────────────── TmuxBackend: the ONE place that shells tmux ───────────────────────────
@@ -18689,20 +18707,6 @@ def _heartbeat():
             sys.stderr.write("heartbeat: %s\n" % traceback.format_exc())
 
 
-def _reveal_chat(focus_msg):
-    """A cross-pane action that brings the chat forward (a feed/timeline session tap): focus the chat
-    clients AND tell the mobile shell (app=shell) to switch to its Chat tab. On desktop the shell
-    ignores the reveal (all three panes are visible at once), so this is a no-op there.
-
-    The shell half only ever reaches THIS kernel's own dashboards: a federated dashboard opens a socket
-    per host for each PANE, never for the shell, so a click on a remote host's session routes to that
-    host's kernel and its reveal lands nowhere. The chat pane therefore asks for the switch itself when
-    it takes a focus (render.ts revealSelfPane) — which covers every kernel, local included, and makes
-    this line a harmless duplicate rather than the only mover."""
-    _send_to_app("chat", focus_msg)
-    _send_to_app("shell", {"type": "reveal", "pane": "chat"})
-
-
 def _send_to_view(app, msg, wid):
     """Push to the clients of `app` belonging to ONE dashboard — the one whose `wid` this is. Which tab a
     viewer is looking at, and where in a transcript they jumped, is theirs alone: broadcasting it made two
@@ -18722,8 +18726,20 @@ def _send_to_view(app, msg, wid):
 
 
 def _reveal_chat_for(client, focus_msg):
-    """_reveal_chat, aimed at the dashboard that asked. Use this wherever a WS op is being handled: the
-    client IS the asker, so its wid names the one window that should follow the click."""
+    """Bring the chat forward for the dashboard that asked — and ONLY that one: the client IS the asker,
+    so its wid names the one window that should follow the click (which tab you are looking at is yours,
+    2026-07-29). This is the sole reveal path since 2026-08-16, when the last broadcast reveals
+    (create/fork/open/revive) were retired for switching every open window's chat; a caller with no
+    dashboard in hand (the CLI's POST /new) reveals to nobody instead of calling this with None —
+    None's empty wid would fall through to _send_to_view's legacy broadcast.
+
+    Focus the chat clients AND tell the mobile shell (app=shell) to switch to its Chat tab; on desktop
+    the shell ignores the reveal (all three panes are visible at once). The shell half only ever reaches
+    THIS kernel's own dashboards: a federated dashboard opens a socket per host for each PANE, never for
+    the shell, so a click on a remote host's session routes to that host's kernel and its shell reveal
+    lands nowhere. The chat pane therefore asks for the switch itself when it takes a focus (render.ts
+    revealSelfPane) — which covers every kernel, local included, and makes the shell line a harmless
+    duplicate rather than the only mover."""
     wid = (client or {}).get("wid") or ""
     _send_to_view("chat", focus_msg, wid)
     _send_to_view("shell", {"type": "reveal", "pane": "chat"}, wid)
@@ -22582,7 +22598,7 @@ refresh();   // self-schedules (fast while attaching, slow keep-alive otherwise)
 # Mobile shell behavior, layered on top of the desktop splitter above. The bottom tab bar (#mtabs,
 # shown only by the media query below) swaps which single iframe is full-screen by toggling `m-on`.
 # A cross-pane "reveal" auto-switches the visible tab: the kernel pushes {type:"reveal",pane} over an
-# app=shell WebSocket when a feed/timeline tap brings the chat forward (see _reveal_chat), and the
+# app=shell WebSocket when a feed/timeline tap brings the chat forward (see _reveal_chat_for), and the
 # timeline deep-link posts the same shape as a window message. The active tab persists in localStorage.
 # Entirely inert on desktop, where #mtabs is hidden and all three panes are shown at once.
 _LANDING_MOBILE_JS = """
@@ -25307,7 +25323,7 @@ class Handler(BaseHTTPRequestHandler):
                         # auth ('login'|'key') is the picker's per-session billing pick; anything else
                         # (older clients, no pick) means the remembered/ambient default (spawn's seed).
                         a = msg.get("auth")
-                        _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""))
+                        _create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""), client=client)
                     else:
                         # NEVER silently fall back to tmux (the user asked for SDK and got a mystery tmux
                         # session on a remote host without the venv, 2026-07-02). Say what's missing.
@@ -25363,7 +25379,7 @@ class Handler(BaseHTTPRequestHandler):
         elif msg and msg.get("type") == "openSession" and msg.get("id"):
             # live → focus its (always-shown) tab; dead → the chat's confirmRevive modal. `live` lands on
             # the chat's LIVE TAIL (a blocked card's picker chip → right on the prompt, the user 2026-07-08).
-            _open_or_revive(msg["id"], live=bool(msg.get("live")))
+            _open_or_revive(msg["id"], live=bool(msg.get("live")), client=client)
         elif msg and msg.get("type") == "openFolder" and msg.get("cwd"):
             # A REMOTE session's folder icon must SSH out, not open a local path that doesn't exist here
             # (the user 2026-07-03) — federation.ts routes this message type to stay LOCAL with the id's
@@ -25377,7 +25393,7 @@ class Handler(BaseHTTPRequestHandler):
         elif msg and msg.get("type") == "reviveSession" and msg.get("id"):
             # confirmRevive → "Revive": resume the dead session in the background (the kernel had
             # no handler, so the modal's Revive silently did nothing — the user 2026-06-16)
-            threading.Thread(target=_revive_session, args=(msg["id"],), daemon=True).start()
+            threading.Thread(target=_revive_session, args=(msg["id"], client), daemon=True).start()
         elif msg and msg.get("type") == "viewReadOnly" and msg.get("id"):
             _kept_open.add(msg["id"])            # confirmRevive → "View read-only": this dead session
             #                                      gets a (struck) read-only tab now, without resuming it

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -432,21 +432,21 @@ class CommentOps(CommentBase):
         self._saved_backend_for = km.Sessions.backend_for
         self._saved_ready = km._sdk_ready
         self._saved_sessions = km._sessions
-        self._saved_reveal = km._reveal_chat
+        self._saved_reveal = km._reveal_chat_for
         self._saved_push_now = km._push_session_now
         km.Sessions.backend_for = staticmethod(lambda sid: self.be)
         km._sdk_ready = lambda: True
         p = self._write(PARENT, self._parent_records())
         km._sessions = lambda now, window=None, forks=True: [
             {"sid": PARENT, "name": "parent", "path": str(p), "mtime": self.now}]
-        km._reveal_chat = lambda msg: None
+        km._reveal_chat_for = lambda client, msg: None
         km._push_session_now = lambda sid: None
 
     def tearDown(self):
         km.Sessions.backend_for = self._saved_backend_for
         km._sdk_ready = self._saved_ready
         km._sessions = self._saved_sessions
-        km._reveal_chat = self._saved_reveal
+        km._reveal_chat_for = self._saved_reveal
         km._push_session_now = self._saved_push_now
         super().tearDown()
 

--- a/tests/test_kernel_color_pick.py
+++ b/tests/test_kernel_color_pick.py
@@ -97,14 +97,14 @@ class PickColor(unittest.TestCase):
             def connect(self, sid):
                 return True
 
-        saved = (km._sdk, km._reveal_chat, km._mark_views_dirty)
+        saved = (km._sdk, km._reveal_chat_for, km._mark_views_dirty)
         km._sdk = lambda: _FakeSdk()
-        km._reveal_chat = lambda *a: None
+        km._reveal_chat_for = lambda *a: None
         km._mark_views_dirty = lambda: None
         try:
             km._create_sdk_session("newsess", "/tmp/x")
         finally:
-            (km._sdk, km._reveal_chat, km._mark_views_dirty) = saved
+            (km._sdk, km._reveal_chat_for, km._mark_views_dirty) = saved
         self.assertEqual(got.get("bg"), self.bgs[1], "colour 0 is live → spawn is handed the next free one")
         self.assertTrue(got.get("fg"), "its paired foreground rides along")
 

--- a/tests/test_kernel_create_session_ack.py
+++ b/tests/test_kernel_create_session_ack.py
@@ -47,9 +47,9 @@ class CreateSessionAckFast(unittest.TestCase):
         self.fake = _FakeSdk()
         self.events = []
         self._saved = {n: getattr(km, n) for n in
-                       ("_sdk", "_reveal_chat", "_mark_views_dirty", "_push_all")}
+                       ("_sdk", "_reveal_chat_for", "_mark_views_dirty", "_push_all")}
         km._sdk = lambda: self.fake
-        km._reveal_chat = lambda m: self.events.append(("reveal", m))
+        km._reveal_chat_for = lambda c, m: self.events.append(("reveal", c, m))
         km._mark_views_dirty = lambda: self.events.append(("dirty",))
         km._push_all = lambda: self.events.append(("PUSH_ALL",))
 
@@ -58,7 +58,8 @@ class CreateSessionAckFast(unittest.TestCase):
             setattr(km, n, v)
 
     def test_create_reveals_first_and_never_builds_inline(self):
-        sid, extra = km._create_sdk_session("newsesh", "/tmp")   # (sid, applied-prefs echo) since 2026-08-16
+        asker = {"app": "chat", "wid": "win-A"}   # the dashboard whose picker asked — reveals are per-viewer
+        sid, extra = km._create_sdk_session("newsesh", "/tmp", client=asker)   # (sid, applied-prefs echo) since 2026-08-16
         self.assertEqual(sid, "11111111-2222-3333-4444-555555555555")
         self.assertEqual(extra, {}, "no prefs asked for -> nothing applied, nothing echoed")
         self.assertEqual(self.fake.calls[0][0], "spawn")
@@ -69,7 +70,8 @@ class CreateSessionAckFast(unittest.TestCase):
         self.assertIn("dirty", kinds, "the pusher is woken to ship the new tab")
         self.assertLess(kinds.index("reveal"), kinds.index("dirty"),
                         "focus is sent before the (async) build — the tab lands already-selected")
-        reveal = next(e[1] for e in self.events if e[0] == "reveal")
+        _, who, reveal = next(e for e in self.events if e[0] == "reveal")
+        self.assertIs(who, asker, "…selected on the ASKING window alone (the per-viewer rule)")
         self.assertEqual(reveal, {"type": "focus", "id": sid})
 
     def test_createsession_handler_has_no_inline_push(self):

--- a/tests/test_kernel_fork.py
+++ b/tests/test_kernel_fork.py
@@ -145,12 +145,12 @@ class ForkSessionOp(unittest.TestCase):
         write_transcript(self.path)
         self.be = _FakeForkBackend()
         self.saved = (km.Sessions.backend_for, km._sdk_ready, km._sessions, km._pick_identity_color,
-                      km._reveal_chat, km._mark_views_dirty, km._push_session_now, km._seed_fork_stores)
+                      km._reveal_chat_for, km._mark_views_dirty, km._push_session_now, km._seed_fork_stores)
         km.Sessions.backend_for = lambda sid: self.be
         km._sdk_ready = lambda: True
         km._sessions = lambda now: [{"sid": PARENT, "path": self.path}]
         km._pick_identity_color = lambda: ("#123456", "#ffffff")
-        km._reveal_chat = lambda m: None
+        km._reveal_chat_for = lambda c, m: None
         km._mark_views_dirty = lambda: None
         km._push_session_now = lambda sid: None
         self._real_seed = km._seed_fork_stores
@@ -158,7 +158,7 @@ class ForkSessionOp(unittest.TestCase):
 
     def tearDown(self):
         (km.Sessions.backend_for, km._sdk_ready, km._sessions, km._pick_identity_color,
-         km._reveal_chat, km._mark_views_dirty, km._push_session_now, km._seed_fork_stores) = self.saved
+         km._reveal_chat_for, km._mark_views_dirty, km._push_session_now, km._seed_fork_stores) = self.saved
         for d in (jd.EPIDIR, jd.CAPDIR, jd.GOALDIR):
             for f in Path(d).glob("*"):
                 f.unlink()

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -374,19 +374,19 @@ class ChatSessionPicker(unittest.TestCase):
 
 
 class RevealRouting(unittest.TestCase):
-    def test_reveal_chat_focuses_chat_and_nudges_shell(self):
+    def test_a_reveal_focuses_the_askers_chat_and_nudges_its_shell(self):
+        # the chat focus + the shell's switch-to-Chat travel as a pair, both addressed to the asker's wid
         sent = []
-        orig = km._send_to_app
-        km._send_to_app = lambda app, msg: sent.append((app, msg))
+        orig = km._send_to_view
+        km._send_to_view = lambda app, msg, wid: sent.append((app, wid, msg))
         try:
-            km._reveal_chat({"type": "focus", "id": "s1"})
+            km._reveal_chat_for({"app": "feed", "wid": "win-A"}, {"type": "focus", "id": "s1"})
         finally:
-            km._send_to_app = orig
-        apps = [a for a, _ in sent]
-        self.assertIn("chat", apps)                   # still focuses the chat clients (unchanged behavior)
-        self.assertIn("shell", apps)                  # AND tells the mobile shell to show the Chat tab
-        chat_msg = next(m for a, m in sent if a == "chat")
-        shell_msg = next(m for a, m in sent if a == "shell")
+            km._send_to_view = orig
+        self.assertEqual([(a, w) for a, w, _ in sent], [("chat", "win-A"), ("shell", "win-A")],
+                         "chat focus AND mobile-shell nudge, the asker's window only")
+        chat_msg = next(m for a, _, m in sent if a == "chat")
+        shell_msg = next(m for a, _, m in sent if a == "shell")
         self.assertEqual(chat_msg["id"], "s1")        # the original focus payload is preserved verbatim
         self.assertEqual(shell_msg, {"type": "reveal", "pane": "chat"})
 

--- a/tests/test_kernel_revive.py
+++ b/tests/test_kernel_revive.py
@@ -24,6 +24,7 @@ km = SourceFileLoader("romp_kernel_rev", os.path.join(BIN, "romp-kernel")).load_
 sb = SourceFileLoader("romp_sdk_backend_rev", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
 
 SID = "11111111-2222-3333-4444-555555555555"
+CLIENT = {"app": "chat", "wid": "win-A"}   # the dashboard whose Revive click asked — reveals are per-viewer
 
 
 class FakeSdk:
@@ -48,18 +49,18 @@ class ReviveSession(unittest.TestCase):
     that success → focus while failure → reviveFailed (loud), never both."""
 
     def setUp(self):
-        self.saved = (km._sdk, km._name_of, km._cwd_of, km._push_all, km._reveal_chat,
-                      km._send_to_app, subprocess.run)
+        self.saved = (km._sdk, km._name_of, km._cwd_of, km._push_all, km._reveal_chat_for,
+                      km._send_to_view, subprocess.run)
         self.sent, self.focused, self.runs = [], [], []
         km._name_of = lambda sid: "testsess"
         km._cwd_of = lambda sid: "/nonexistent-dir-for-test"
         km._push_all = lambda: None
-        km._reveal_chat = lambda msg: self.focused.append(msg)
-        km._send_to_app = lambda app, msg: self.sent.append((app, msg))
+        km._reveal_chat_for = lambda client, msg: self.focused.append((client, msg))
+        km._send_to_view = lambda app, msg, wid: self.sent.append((app, msg, wid))
 
     def tearDown(self):
-        (km._sdk, km._name_of, km._cwd_of, km._push_all, km._reveal_chat,
-         km._send_to_app, subprocess.run) = self.saved
+        (km._sdk, km._name_of, km._cwd_of, km._push_all, km._reveal_chat_for,
+         km._send_to_view, subprocess.run) = self.saved
 
     def _stub_run(self, returncode=0, stderr=""):
         def run(cmd, **kw):
@@ -70,39 +71,41 @@ class ReviveSession(unittest.TestCase):
     def test_sdk_session_revives_via_resume_and_connect(self):
         be = FakeSdk()
         km._sdk = lambda: be
-        km._revive_session(SID)
+        km._revive_session(SID, CLIENT)
         self.assertEqual(be.calls, [("resume", "testsess", SID), ("connect", SID)],
                          "SDK-owned dead session → registry alive again + eager connect (resumes lastSid)")
-        self.assertEqual([m["type"] for m in self.focused], ["focus"], "success lands the chat on the tab")
+        self.assertEqual([(c, m["type"]) for c, m in self.focused], [(CLIENT, "focus")],
+                         "success lands the chat on the tab — the ASKER's chat, nobody else's")
         self.assertEqual(self.sent, [], "no failure event on success")
 
     def test_sdk_failure_is_loud_and_does_not_focus(self):
         km._sdk = lambda: FakeSdk(connect_ok=False)
-        km._revive_session(SID)
+        km._revive_session(SID, CLIENT)
         self.assertEqual(self.focused, [], "a failed revive must not focus a still-dead session")
         self.assertEqual(len(self.sent), 1)
-        app, msg = self.sent[0]
-        self.assertEqual((app, msg["type"], msg["id"]), ("chat", "reviveFailed", SID))
+        app, msg, wid = self.sent[0]
+        self.assertEqual((app, msg["type"], msg["id"], wid), ("chat", "reviveFailed", SID, "win-A"),
+                         "the failure notice goes to the window whose revive loader is up")
 
     def test_tmux_session_revives_via_romp_resume_detach(self):
         km._sdk = lambda: None
         self._stub_run(returncode=0)
-        km._revive_session(SID)
+        km._revive_session(SID, CLIENT)
         cmd, kw = self.runs[0]
         self.assertEqual(cmd, [os.path.join(BIN, "romp"), "resume", SID, "--name", "testsess", "--detach"],
                          "the launcher resume path the old postal revive used, now owned by the kernel "
                          "(round-3 spelling, 2026-07-25: resume <id> --name <name>)")
         self.assertEqual(kw.get("cwd"), os.path.expanduser("~"),
                          "a missing recorded dir falls back to $HOME (old postal behavior)")
-        self.assertEqual([m["type"] for m in self.focused], ["focus"])
+        self.assertEqual([m["type"] for _, m in self.focused], ["focus"])
         self.assertEqual(self.sent, [])
 
     def test_tmux_failure_carries_the_launcher_error(self):
         km._sdk = lambda: None
         self._stub_run(returncode=3, stderr="no transcript for that uuid")
-        km._revive_session(SID)
+        km._revive_session(SID, CLIENT)
         self.assertEqual(self.focused, [])
-        app, msg = self.sent[0]
+        _, msg, _ = self.sent[0]
         self.assertEqual(msg["type"], "reviveFailed")
         self.assertIn("no transcript", msg["text"], "the launcher's stderr reaches the user, not DEVNULL")
 

--- a/tests/test_new_session_dir.py
+++ b/tests/test_new_session_dir.py
@@ -198,7 +198,7 @@ class CreateSessionDirFork(_Wire):
         self.spawned = []
         self._real_sdk = km._create_sdk_session
         self._real_ready = km._sdk_ready
-        km._create_sdk_session = lambda nm, cwd, auth="": self.spawned.append((nm, cwd)) or "TESTSID"
+        km._create_sdk_session = lambda nm, cwd, auth="", client=None: self.spawned.append((nm, cwd)) or "TESTSID"
         km._sdk_ready = lambda: True
         self.addCleanup(setattr, km, "_create_sdk_session", self._real_sdk)
         self.addCleanup(setattr, km, "_sdk_ready", self._real_ready)

--- a/tests/test_per_viewer_focus.py
+++ b/tests/test_per_viewer_focus.py
@@ -13,6 +13,7 @@ Synthetic clients only; no sockets.
 """
 import inspect
 import os
+import re
 import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
@@ -126,6 +127,79 @@ class RemoteRevealReachesTheShell(unittest.TestCase):
         # reveal() = un-hide a desktop-toggled-off pane FIRST, then the mobile tab switch (the user
         # 2026-08-13 — see tests/test_shell_reveal_unhide.py).
         self.assertIn("if(m.romp==='reveal'&&m.pane)reveal(m.pane);", km._LANDING_MOBILE_JS)
+
+
+class CreateOpenReviveAreAimedToo(unittest.TestCase):
+    """Creating, opening, forking or reviving a session moved EVERY dashboard's chat (the user
+    2026-08-16, whose chats kept switching to sessions some other surface had just touched — a second
+    window's click, or a bare `romp new` in a terminal). The 2026-07-29 per-viewer fix missed these
+    four: its wiring test counted _reveal_chat_for(client, …) call sites, and the branches it did
+    cover satisfied the count. Every reveal now names its asker, and an op with NO asking dashboard
+    (the CLI's POST /new) moves nobody — the new tab still reaches every window via the push, just
+    unselected."""
+
+    def setUp(self):
+        self.sink = []
+        self._saved_clients = list(km._clients)
+        self.win_a = _client("chat", "win-A", self.sink)
+        km._clients[:] = [self.win_a, _client("chat", "win-B", self.sink)]
+
+    def tearDown(self):
+        km._clients[:] = self._saved_clients
+
+    def test_opening_a_session_moves_the_asking_window_alone(self):
+        saved = (km._tmux_sessions, km._sdk, km._push_all)
+        km._tmux_sessions = lambda: {"s1": "web"}
+        km._sdk = lambda: None
+        km._push_all = lambda: None
+        try:
+            km._open_or_revive("s1", client=self.win_a)
+        finally:
+            (km._tmux_sessions, km._sdk, km._push_all) = saved
+        self.assertEqual([w for w, _ in self.sink], ["win-A"], "win-B keeps the tab it was reading")
+
+    def test_a_create_with_no_asking_dashboard_moves_nobody(self):
+        class _BE:
+            def spawn(self, nm, cwd, bg, fg, auth=""):
+                return "sid-new"
+
+            def connect(self, sid):
+                pass
+        saved = (km._sdk, km._pick_identity_color, km._mark_views_dirty, km._push_session_now)
+        km._sdk = lambda: _BE()
+        km._pick_identity_color = lambda: ("#123456", "#ffffff")
+        km._mark_views_dirty = lambda: None
+        km._push_session_now = lambda sid: None
+        try:
+            km._create_sdk_session("web", "/tmp")                     # the CLI's POST /new: no dashboard in hand
+            self.assertEqual(self.sink, [], "a terminal/script create yanks no window's chat")
+            km._create_sdk_session("api", "/tmp", client=self.win_a)  # the picker's create: the asker follows it
+        finally:
+            (km._sdk, km._pick_identity_color, km._mark_views_dirty, km._push_session_now) = saved
+        self.assertEqual([w for w, _ in self.sink], ["win-A"], "…and only the asker")
+
+    def test_the_ops_that_make_or_wake_sessions_name_their_asker(self):
+        src = inspect.getsource(km.Handler)
+        self.assertIn('_open_or_revive(msg["id"], live=bool(msg.get("live")), client=client)', src,
+                      "openSession — the click-op the 2026-07-29 fix missed")
+        self.assertIn('_create_sdk_session(nm, cwd, auth=(a if a in ("login", "key") else ""), client=client)',
+                      src, "the picker's createSession follows on the asking window")
+        flat = re.sub(r"\s+", "", src)   # the POST /new call wraps; pin it whitespace-blind
+        self.assertIn('sid,extra=_create_sdk_session(nm,cwd,auth=(aifain("login","key")else""),prefs=b)', flat,
+                      "POST /new (the CLI) has no dashboard in hand, and so names none")
+        self.assertIn('threading.Thread(target=_revive_session, args=(msg["id"], client), daemon=True)', src,
+                      "the revive thread carries its asker across to the focus that clears the loader")
+        self.assertIn('_fork_session(sid, str(msg.get("uuid") or ""), str(msg["name"]), client=client)',
+                      inspect.getsource(km._drive), "a fork's new tab arrives focused for the forker alone")
+        self.assertIn('_comment_promote(sid, str(msg["tid"]), str(msg["name"]), client=client)',
+                      inspect.getsource(km._drive), "…and so does a promoted comment thread's")
+
+    def test_the_broadcast_reveal_helper_is_gone(self):
+        # _reveal_chat pushed to EVERY chat and shell client; with all four callers retired, keeping
+        # it around is an invitation to reintroduce the yank. _reveal_chat_for is the only door, and
+        # a caller with no dashboard in hand reveals to nobody rather than passing it None (an empty
+        # wid falls through to the legacy broadcast, by design, for clients that report none).
+        self.assertFalse(hasattr(km, "_reveal_chat"))
 
 
 if __name__ == "__main__":

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -496,7 +496,7 @@ class DrivePlumbing(unittest.TestCase):
 
     def test_create_paths_pass_the_pick_through(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn("def _create_sdk_session(nm, cwd, auth=\"\", prefs=None):", src)
+        self.assertIn("def _create_sdk_session(nm, cwd, auth=\"\", prefs=None, client=None):", src)
         self.assertEqual(src.count('auth=(a if a in ("login", "key") else "")'), 2,
                          "the WS op and POST /new both pass it")
 

--- a/ui/webview/fork-session.test.ts
+++ b/ui/webview/fork-session.test.ts
@@ -47,7 +47,8 @@ test("the palette forks the ACTIVE session from the tip, via the chat pane", () 
 test("kernel: forkSession is a session op; seeding precedes discoverability; the fsid is pinned to the sid", () => {
   assert.match(KERNEL, /"mcpAction", "forkSession",/);   // in ID_OPS — routed by session id like every session op
   assert.match(KERNEL, /elif t == "forkSession" and msg\.get\("name"\):/);
-  assert.match(KERNEL, /def _fork_session\(parent_sid, cut_msg_uuid, new_name, now=None\):/);
+  // client rides through so only the ASKING dashboard's chat follows the fork (the per-viewer rule)
+  assert.match(KERNEL, /def _fork_session\(parent_sid, cut_msg_uuid, new_name, now=None, client=None\):/);
   // the cut means the same thing the edit/delete rewind means: just before the clicked user message
   assert.match(KERNEL, /cut_uuid, err = _rewind_target\(sess\["path"\], parent_sid, str\(cut_msg_uuid\)\)/);
   // the judge stores are seeded BEFORE be.fork writes the names/ entry (discoverability)


### PR DESCRIPTION
## The report

Chats kept opening at random: while working in one session's chat, the dashboard would switch to some other session unbidden.

## The cause

Every chat pane switches session on a kernel `focus` message (`render.ts` → `revealSelfPane()` + `setActive`), and four kernel paths still **broadcast** that focus to every connected dashboard — every browser window, phone PWA, VS Code pane, federated viewer:

| path | trigger | effect |
|---|---|---|
| `_create_sdk_session` | any create, incl. the CLI's POST `/new` (`romp new` in a terminal, a script) | every window's chat jumped to the new session |
| `_open_or_revive` | a feed/fleet/picker tap in **any** window | every window followed the click (a dead session's tap popped confirmRevive everywhere) |
| `_fork_session` | fork | same |
| `_revive_session` | revive | same, plus a broadcast `reviveFailed` |

`openSession` is the click-op the 2026-07-29 per-viewer fix (b36aa679, "which tab you are looking at is yours") missed: its guard test counted `_reveal_chat_for(client, …)` call sites, and the branches it did cover satisfied the count.

## The fix

Every reveal now names its asker: the WS ops pass their `client` through, the revive thread carries it, and `reviveFailed` goes to the window whose revive loader is up. An op with **no** asking dashboard (POST `/new`) moves nobody — the new tab still reaches every window via the push, just unselected. The broadcast helper `_reveal_chat` is retired so the yank cannot quietly return; `_reveal_chat_for` absorbs its shell-nudge and federation notes.

## Tests

`tests/test_per_viewer_focus.py` grows behavioral pins (open moves the asking window alone; a client-less create moves nobody) plus wiring pins for all four call sites and the helper's removal. The create-ack, revive, fork, mobile, color-pick, session-auth and new-session-dir suites follow the new signatures. Full local run: 4401 passed, 32 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
