### PR TITLE
The Continue row wears the Follow-up gesture grammar

### DIFF
--- a/ui/webview/continue-bubble.test.ts
+++ b/ui/webview/continue-bubble.test.ts
@@ -1,10 +1,10 @@
-// The Continue button's reply renders as a GESTURE in the slash-command family (the user 2026-08-15;
-// supersedes the 2026-08-13 blue-bubble fold, whose PARAPHRASED gist made it the one "user message"
-// that expanded — to different words than its label): ✦ mark, mono chip "Continue", then the SENT
-// text's own first line with the rest one click deeper — expanding only ever reveals MORE of the same
-// words, never different ones. The judges still file it as the user's reply. Keyed on the kernel's
-// romp-canned marker (event-based), never on text-matching the copy. Source pins (no jsdom for the
-// chat renderer), plus the kernel side of the contract (node-tests-pin-kernel-source).
+// The Continue button's reply renders in the FOLLOW-UP gesture grammar (the user 2026-08-17;
+// supersedes the 2026-08-15 slash-command dress — its ✦ mark said nothing, and the boxed chip +
+// trailing caret made a second grammar next to ↩ Follow-up's): caret, "→ Continue" in the accent,
+// then the SENT text's own first line with the rest one click deeper — expanding only ever reveals
+// MORE of the same words, never different ones. The judges still file it as the user's reply. Keyed
+// on the kernel's romp-canned marker (event-based), never on text-matching the copy. Source pins (no
+// jsdom for the chat renderer), plus the kernel side of the contract.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -14,12 +14,16 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
-test("the canned Continue is a GESTURE row: ✦ + chip + the sent text's own first line", () => {
+test("the canned Continue wears the Follow-up grammar: caret, → Continue, the sent text's first line", () => {
   assert.match(RENDER, /canned\?: string/, "the user event carries the kernel's lift");
   assert.match(RENDER, /\} else if \(!romp && !injected && !tagged && ev\.md && ev\.canned === "continue"\) \{/,
     "keyed on the lifted marker, never on text-matching the canned copy");
-  // the slash-command dress — same family, same classes
-  assert.match(RENDER, /turn\.classList\.add\("turn-cmd"\);\s*\n\s*bubble\.classList\.add\("cmd-row"\);\s*\n\s*const chip = el\("span", "slash-cmd-chip"\); chip\.textContent = "Continue";/);
+  // ONE gesture grammar (the user 2026-08-17): the follow-up header's own classes, no ✦, no boxed chip
+  assert.match(RENDER, /const head = el\("div", "followup-tag cont-tag"\);/);
+  assert.match(RENDER, /const lbl = el\("span", "followup-lbl"\); lbl\.textContent = "→ Continue";/);
+  assert.match(RENDER, /const g = el\("span", "followup-goal"\); g\.textContent = clipped;/,
+    "the gist wears the follow-up header's own dim ellipsis dress");
+  assert.doesNotMatch(RENDER, /slash-cmd-chip"\); chip\.textContent = "Continue"/, "the boxed chip is gone");
   // the collapsed line is the SENT text itself (first non-quote line, clipped) — never a paraphrase,
   // so expanding reveals more of the same words rather than different ones
   assert.match(RENDER, /const first = lines\.find\(\(l\) => l && !l\.startsWith\(">"\)\) \|\| lines\.find\(\(l\) => l\) \|\| raw;/);
@@ -30,13 +34,15 @@ test("the canned Continue is a GESTURE row: ✦ + chip + the sent text's own fir
   assert.match(RENDER, /bubble\.classList\.add\("nudge-collapsible"\);\s*\n\s*bubble\.dataset\.act = "nudgetoggle";\s*\n?\s*\/\/ the stable body delegate/);
 });
 
-test("the gesture fold is dim like the command family, and unfolds in place", () => {
+test("the row sheds the bubble, keeps the header when expanded, and the caret flips in CSS", () => {
   assert.match(CSS, /\.user-bubble\.nudge-collapsible \{ cursor: pointer; \}/);
-  assert.match(CSS, /\.user-bubble\.cmd-row \.nudge-gist, \.user-bubble\.cmd-row \.nudge-caret \{ color: var\(--dim\); \}/);
-  assert.match(CSS, /\.user-bubble\.cmd-row \.nudge-full \{ color: var\(--dim\); margin-top: 4px; max-width: 640px; \}/);
-  assert.match(CSS, /\.user-bubble \.nudge-full \{ display: none; \}/);
-  assert.match(CSS, /\.user-bubble\.expanded \.nudge-full \{ display: block; \}/);
-  assert.match(CSS, /\.user-bubble\.expanded \.nudge-gist \{ display: none; \}/);
+  assert.match(CSS, /\.user-bubble\.cont-row \{ max-width: none; background: none; border: none;/);
+  assert.match(CSS, /\.user-bubble\.cont-row \.cont-tri::before \{ content: "▸"; \}/);
+  assert.match(CSS, /\.user-bubble\.cont-row\.expanded \.cont-tri::before \{ content: "▾"; \}/,
+    "the same .expanded class the fold delegate flips also turns the caret");
+  assert.match(CSS, /\.user-bubble\.cont-row \.nudge-full \{ display: none; color: var\(--dim\); margin-top: 4px; max-width: 640px; \}/);
+  assert.match(CSS, /\.user-bubble\.cont-row\.expanded \.nudge-full \{ display: block; \}/,
+    "the header stays while the full words unfold beneath it — the follow-up ctx idiom");
 });
 
 test("kernel: the marker is stamped at the ONE cont send and lifted for human turns only", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1787,25 +1787,25 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         turn.classList.add("turn-cmd");
         bubble.classList.add("cmd-row");
       } else if (!romp && !injected && !tagged && ev.md && ev.canned === "continue") {
-        // The card's Continue button: a user GESTURE, not typed prose. The 2026-08-13 cut kept the
-        // blue bubble with a PARAPHRASED gist — which made it the one "user message" that expanded,
-        // and to different words than its label (the user 2026-08-15: unclear what was actually
-        // sent). Superseded: gestures read in the slash-command family (✦ mark, mono chip) — chip
-        // "Continue", then the SENT text's own first line, the rest one click deeper, so expanding
-        // only ever reveals MORE of the same words. The judges still file it as your reply, and the
-        // ↩ follow-up header above still names the goal it answers.
-        turn.classList.add("turn-cmd");
-        bubble.classList.add("cmd-row");
-        const chip = el("span", "slash-cmd-chip"); chip.textContent = "Continue";
-        bubble.appendChild(chip);
+        // The card's Continue button: a user GESTURE, not typed prose. Third cut (the user
+        // 2026-08-17, superseding the 2026-08-15 slash-command dress — its ✦ mark said nothing, and
+        // the boxed chip + trailing caret made a second gesture grammar next to ↩ Follow-up's):
+        // Continue now wears the SAME grammar as the Follow-up header — caret, "→ Continue" in the
+        // accent, the SENT text's own first line dimmed beside it, the rest one click deeper, so
+        // expanding only ever reveals MORE of the same words. Uniqueness rides the word + the →
+        // glyph exactly as Follow-up's rides ↩. The judges still file it as your reply, and the ↩
+        // follow-up header above still names the goal it answers.
+        bubble.classList.add("cont-row");
         const raw = ev.md.replace(/<!--[\s\S]*?-->/g, "").trim();
         const lines = raw.split("\n").map((l) => l.trim());
         const first = lines.find((l) => l && !l.startsWith(">")) || lines.find((l) => l) || raw;   // skip a goal-context "> …" quote
         const clipped = first.length > 90 ? first.slice(0, 88).replace(/\s+\S*$/, "") + "…" : first;
-        const gistEl = el("span", "nudge-gist");
-        const c = el("span", "nudge-caret"); c.textContent = "▸"; gistEl.appendChild(c);
-        gistEl.appendChild(document.createTextNode(clipped));
-        bubble.appendChild(gistEl);
+        const head = el("div", "followup-tag cont-tag");
+        const tri = el("span", "followup-tri cont-tri");         // glyph via CSS, so expansion flips it
+        const lbl = el("span", "followup-lbl"); lbl.textContent = "→ Continue";
+        const g = el("span", "followup-goal"); g.textContent = clipped;
+        head.append(tri, lbl, g);
+        bubble.appendChild(head);
         const full = el("div", "nudge-full md");
         full.innerHTML = md(ev.md);
         bubble.appendChild(full);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1228,12 +1228,20 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .user-bubble.cmd-row .slash-cmd-chip { background: var(--bg); color: #2b6cef;
   border-color: #2b6cef; }
 .user-bubble.cmd-row .slash-cmd-args { color: var(--dim); }
-/* The Continue button's turn wears the same gesture dress (render.ts canned === "continue", the user
-   2026-08-15): chip "Continue", then the SENT text's own first line — dim like the command family, not
-   the white-on-blue fold — with the full words unfolding in place under the row. */
 .user-bubble.cmd-row .nudge-gist, .user-bubble.cmd-row .nudge-caret { color: var(--dim); }
 .user-bubble.cmd-row .nudge-gist { margin-left: 8px; }
 .user-bubble.cmd-row .nudge-full { color: var(--dim); margin-top: 4px; max-width: 640px; }
+/* The Continue button's turn wears the FOLLOW-UP grammar (render.ts canned === "continue", the user
+   2026-08-17, superseding the 2026-08-15 ✦ + boxed-chip dress — one gesture grammar, fewer elements):
+   caret, "→ Continue" in the accent (the same dress "↩ Follow-up" wears), the sent text's own first
+   line dimmed beside it, the full words unfolding in place under the row. The caret glyph lives in CSS
+   so the same .expanded class the fold delegate flips also turns it. */
+.user-bubble.cont-row { max-width: none; background: none; border: none; border-radius: 0; padding: 2px 0; }
+.user-bubble.cont-row .followup-tag { max-width: none; }
+.user-bubble.cont-row .cont-tri::before { content: "▸"; }
+.user-bubble.cont-row.expanded .cont-tri::before { content: "▾"; }
+.user-bubble.cont-row .nudge-full { display: none; color: var(--dim); margin-top: 4px; max-width: 640px; }
+.user-bubble.cont-row.expanded .nudge-full { display: block; }
 /* ---------- romp-injected message (a feed nudge / follow-up) ----------
    A GRAY bubble in the SAME right-aligned spot as the blue user bubble (so it sits where "an outgoing
    message" goes), but clearly NOT you — gray, with a small "↯ romp" tag above it (the user 2026-06-19).


### PR DESCRIPTION
User critique with screenshot: the Continue render was busy and inconsistent — a ✦ mark that means nothing, a boxed button-looking chip, and a caret on the opposite side from the Follow-up header sitting directly above it. Two grammars for the same class of thing (a user gesture row).

Continue now reads exactly like ↩ Follow-up: caret, "→ Continue" in the accent, the sent text's own first line dimmed beside it (ellipsized in the follow-up header's own dress), and the full words one click deeper beneath the header — the follow-up ctx idiom, header staying put while the text unfolds. Uniqueness rides the word and the → glyph the way Follow-up's rides ↩. Five visual elements become three. The caret glyph moved into CSS so the fold delegate's `.expanded` class flips it with no extra wiring; the kernel marker gate, the first-line-never-a-paraphrase rule, and the keyed fold machinery are unchanged.

continue-bubble.test.ts is rewritten to the new grammar (follow-up classes, no ✦/boxed chip, CSS caret flip, header-stays-on-expand). Both suites + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)