### PR TITLE
The federated timeline can't blank local lanes at boot, and its joins get their inputs

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18441,9 +18441,10 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
     if with_bars:
         messages = _postal_messages(now, set(id2name), id2name)
         _bind_message_execs(messages, turns)             # connector exec → the recipient's process-start (real transit)
-        for _bs in turns.values():                       # mids/fromOrig are the binder's INPUTS, not payload
-            for _b in _bs:                               # (2026-07-07 payload audit: no client ever read them)
-                _b.pop("mids", None)
+        # mids STAY on the wire (2026-08-17): the merged-view dmid join (romp-timeline-view.js) re-binds
+        # a relayed connector's exec to the recipient turn by bar mids — the 2026-07-07 payload-audit pop
+        # ("no client ever read them") predated that 2026-08-06 feature and had silently starved it: the
+        # join's key set was always empty on live payloads, so relayed execs never re-bound client-side.
         for _m in messages:
             _m.pop("fromOrig", None)
         # The band's marks are the per-call RUN SPANS (g70): each judge call plotted at its real [sent, recv],

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -132,6 +132,11 @@ function _prefixIdBearing(host: string, o: any, idKey: string): any {
   // and keep peerSid bare — the viewer may be that very host, where the bare uuid opens directly.
   if (out.origin && typeof out.origin === "object" && typeof out.origin.peerSid === "string" && !out.origin.peerHost)
     out.origin = { ...out.origin, peerHost: host, peerSid: prefixId(host, out.origin.peerSid) };
+  // a timeline lane's fork parent (sessions[].branch.fromId): the view looks it up against PREFIXED
+  // lane ids (vidx), so an unprefixed remote parent silently missed and the branch connector never
+  // drew for remote lanes (found 2026-08-17 auditing the merge)
+  if (out.branch && typeof out.branch === "object" && typeof out.branch.fromId === "string")
+    out.branch = { ...out.branch, fromId: prefixId(host, out.branch.fromId) };
   return out;
 }
 
@@ -652,6 +657,13 @@ export class FederationManager {
     // lines, no bars" bug, 2026-07-15). The local kernel pushes on connect, so the hold is momentary,
     // and the local arrival itself emits (event-based, no timer).
     if (!(LOCAL in this.perHostTl)) return;
+    // The BARS emission holds for the LOCAL bars snapshot too (2026-08-17, the after-attach "most of
+    // my sessions vanished" report): at page boot with hosts already attached, a remote's bars can
+    // land before the local kernel's — and the panel's applyBars REPLACES turns wholesale, so the
+    // merged-without-local emission blanked every local lane until the next local push. Same
+    // discipline as the lanes hold above: the local kernel pushes bars on connect, so the hold is
+    // momentary, and the local arrival itself emits.
+    if (bars && !(LOCAL in this.perHostTlBars)) return;
     const data = bars
       // the bars message carries no lanes — hand the merged lane list in for the connector stitch
       ? mergeHostBars(this.perHostTlBars, this.hostSeq, mergeHostTimelines(this.perHostTl, this.hostSeq, this.view()).sessions)

--- a/ui/webview/timeline-merge-holds.test.ts
+++ b/ui/webview/timeline-merge-holds.test.ts
@@ -1,0 +1,34 @@
+// The federated timeline's merge holds and prefix coverage (the user 2026-08-17, whose dashboard —
+// freshly reloaded with snape newly attached — showed most local sessions bar-less, connectors from
+// a session that wasn't running, and idle remote lanes). Three exact defects, pinned here:
+// 1. BOOT BARS RACE: the merged BARS emission was gated only on the local LANES snapshot, so a
+//    remote's bars landing first emitted a merged-without-local payload — and the panel's applyBars
+//    REPLACES turns wholesale, blanking every local lane until the next local push.
+// 2. A lane's fork parent (sessions[].branch.fromId) was never host-prefixed, so remote branch
+//    connectors silently missed their vidx lookup and never drew.
+// 3. The kernel stripped bar `mids` from the wire (a 2026-07-07 payload audit) that the 2026-08-06
+//    merged-view dmid join READS — the join's key set was always empty on live payloads. Source pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("the merged bars emission waits for the LOCAL bars snapshot, like the lanes hold", () => {
+  assert.match(FED, /if \(!\(LOCAL in this\.perHostTl\)\) return;/);
+  assert.match(FED, /if \(bars && !\(LOCAL in this\.perHostTlBars\)\) return;/,
+    "a remote winning the connect race can no longer blank every local lane");
+});
+
+test("a remote lane's fork parent is prefixed so its branch connector draws", () => {
+  assert.match(FED, /if \(out\.branch && typeof out\.branch === "object" && typeof out\.branch\.fromId === "string"\)/);
+  assert.match(FED, /out\.branch = \{ \.\.\.out\.branch, fromId: prefixId\(host, out\.branch\.fromId\) \};/);
+});
+
+test("bar mids ride the wire — the merged-view dmid join reads them", () => {
+  assert.doesNotMatch(KERNEL, /_b\.pop\("mids", None\)/, "the payload-audit pop predated the dmid join and starved it");
+  assert.match(KERNEL, /mids STAY on the wire \(2026-08-17\)/);
+  assert.match(KERNEL, /_m\.pop\("fromOrig", None\)/, "fromOrig stays binder-only — nothing client-side reads it");
+});


### PR DESCRIPTION
Investigation of the after-snape-attach report (most local sessions bar-less, connectors from a non-running session, idle remote lanes crowding the view). Live evidence gathered Mac-side rules out clock skew (three hosts agree within ~2s, so the rebase path is sound); three defects were certain from code alone and are fixed here:

- **Boot bars race — the likely "most of my sessions vanished".** The merged BARS emission was gated only on the local LANES snapshot. At page boot with hosts already attached (exactly the post-kernel-restart reload in the report), a remote's bars can land before the local kernel's — and the panel's `applyBars` replaces `turns` wholesale, so the merged-without-local emission blanks every local lane until the next local push. The bars emission now also holds for the LOCAL bars snapshot — the same held-until-local discipline the lanes emission has worn since the 2026-07-15 NaN-window fix, momentary for the same reason.
- **Remote fork connectors never drew**: `sessions[].branch.fromId` was the one id-bearing field the prefixer missed, so the view's lane lookup failed for remote forks (bare uuid against prefixed ids — silent, no false match).
- **The relayed-exec dmid join was starved**: the kernel stripped bar `mids` from the wire per a 2026-07-07 payload audit that predated the 2026-08-06 merged-view join which reads exactly those — its key set was always empty on live payloads. `mids` stay on the wire; `fromOrig` stays binder-only.

Pinned in timeline-merge-holds.test.ts. Both suites + typecheck green. Remaining open threads from the live evidence (an anonymous overnight mail row addressed to an unknown sid; the crowding of idle-but-recent remote lanes being expected 12h-window behavior worth a design look) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)