### PR TITLE
The rail's top stamp names its day while you scroll history

### DIFF
--- a/ui/webview/rail-day.test.ts
+++ b/ui/webview/rail-day.test.ts
@@ -1,0 +1,30 @@
+// The day-context label rides above the rail's TOP stamp (the user 2026-08-17): whenever that
+// stamp's day is not today, a small "Yesterday" / "3 days ago" sits just above it — anchored to the
+// tracked turn's marker while it leads, to the first stamp below the line when nothing is tracked
+// ("the next one"), and to the sticky's line once it takes over, so the handoff lands at the same
+// pixel and scrolling never jumps. Source pins (dayContext's behavior is tested in time-marker.test.ts).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("the label anchors to whichever stamp owns the top slot, and hands off at the same pixel", () => {
+  assert.match(RENDER, /m\.dataset\.epoch = String\(epoch\);/, "markers carry their epoch for the day pass");
+  assert.match(RENDER, /const anchorM = marker \|\| \(firstBelow \? firstBelow\[0\] : null\);/);
+  assert.match(RENDER, /paintDay\(gutterRight, realLeads \? markerTop : \(firstBelow \? firstBelow\[1\] : cBottom \+ 1\)\);/,
+    "a leading real stamp carries the label at its own position");
+  assert.match(RENDER, /paintDay\(g\.right, line\);/, "the sticky carries it at the line — same pixel at handoff");
+  assert.match(RENDER, /if \(day\.textContent !== label\) day\.textContent = label;/, "text swaps only at day boundaries");
+  assert.match(RENDER, /if \(!label \|\| yTop > cBottom\) \{ day\.style\.display = "none"; return; \}/,
+    "today → no label; an off-screen anchor paints nothing");
+});
+
+test("the label is passive fixed chrome, right-aligned to the gutter with no width math", () => {
+  assert.match(CSS, /\.rail-day \{\s*\n\s*position: fixed; z-index: 3; pointer-events: none; white-space: nowrap;/);
+  assert.match(CSS, /transform: translate\(-100%, calc\(-100% - 2px\)\);/);
+  assert.match(CSS, /font-size: 0\.68em; letter-spacing: 0\.03em; color: var\(--dim\); opacity: 0\.85;/,
+    "context, not the time itself — smaller and dimmer than the stamp");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13,7 +13,7 @@ import diff from "highlight.js/lib/languages/diff";
 import yaml from "highlight.js/lib/languages/yaml";
 import type { ParsedAsk } from "../ask-types";
 import { quoteReply } from "../quote";
-import { markerLabel } from "./time-marker";
+import { markerLabel, dayContext } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
 import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompSettings } from "./settings";
 import { delegate } from "./actions";
@@ -1572,6 +1572,7 @@ function timeMarker(epoch: number, prevEpoch: number | null): HTMLElement {
   const { text, day, hm } = markerLabel(epoch, prevEpoch, Date.now());
   const m = el("div", "time-marker");
   m.dataset.hm = hm;
+  m.dataset.epoch = String(epoch);   // the top-of-view day-context label reads this (paintRailSticky)
   // The gutter shows the TIME and nothing else. The date rides a full-width day divider
   // instead (dayDividerFor below) — no date word has to fit 47px of rail any more.
   if (text) m.textContent = day ? hm : text;
@@ -1624,11 +1625,30 @@ function ensureRailSticky(): HTMLElement {
   return railSticky;
 }
 
+// The DAY CONTEXT label (the user 2026-08-17): "Yesterday" / "3 days ago" / "Last week" riding just
+// above the rail's TOP stamp whenever that stamp is not from today — so mid-scroll through history
+// the day is always in view even with the day divider scrolled away. One fixed element, painted by
+// the same pass that owns the sticky stamp; its text swaps only at day boundaries, and its position
+// tracks whichever stamp owns the top slot (the sticky at the line, or the leading real stamp as it
+// scrolls toward the line) — the handoff lands at the same pixel, so there is no jump.
+let railDay: HTMLElement | null = null;
+function ensureRailDay(): HTMLElement {
+  if (railDay && railDay.isConnected) return railDay;
+  railDay = el("div", "rail-day");
+  railDay.style.display = "none";
+  document.body.appendChild(railDay);
+  return railDay;
+}
+
 function paintRailSticky(): void {
   const stamp = ensureRailSticky();
   const content = document.getElementById("content");
   const v = activeId ? views.get(activeId) : null;
-  if (!content || !v || v.el.style.display === "none") { stamp.style.display = "none"; return; }
+  if (!content || !v || v.el.style.display === "none") {
+    stamp.style.display = "none";
+    if (railDay) railDay.style.display = "none";
+    return;
+  }
   const cRect = content.getBoundingClientRect();
   const cTop = cRect.top, cBottom = cRect.bottom;
   const BUFFER = 6;                             // the gap kept above the sticky; ALSO the hand-off line
@@ -1651,6 +1671,26 @@ function paintRailSticky(): void {
     }
   }
   const hm = marker ? (marker.dataset.hm || "") : "";
+  // DAY CONTEXT (the user 2026-08-17): whichever stamp owns the top slot also names its DAY, in a
+  // small label riding just above it, whenever that day is not today — so scrolling through history
+  // always says where you are even with the day divider off-screen. The anchor is the tracked turn's
+  // marker when there is one, else the first stamp below the line ("the next one"); its position is
+  // wherever that stamp sits (the line itself once the sticky leads), so the label moves WITH the
+  // leading stamp and the sticky handoff lands at the same pixel — no jump at the transition. The
+  // text swaps only at day boundaries.
+  const day = ensureRailDay();
+  const firstBelow = all.find(([, top]) => top >= line);
+  const anchorM = marker || (firstBelow ? firstBelow[0] : null);
+  const paintDay = (right: number, yTop: number) => {
+    const ep = anchorM ? Number(anchorM.dataset.epoch || 0) : 0;
+    const label = ep ? dayContext(ep, Date.now()) : "";
+    if (!label || yTop > cBottom) { day.style.display = "none"; return; }
+    if (day.textContent !== label) day.textContent = label;
+    day.style.left = right + "px";
+    day.style.top = yTop + "px";
+    day.style.display = "";
+  };
+  const gutterRight = anyMarker ? anyMarker.getBoundingClientRect().right : 0;
   // The tracked turn's OWN stamp leads the top slot while it is at or below the line — it scrolls up freely
   // until it reaches the line, and the instant it crosses ABOVE (markerTop < line) the sticky takes the same
   // slot showing the same time, so the swap is invisible: no gap, no clipped sliver (the user 2026-07-23).
@@ -1661,6 +1701,8 @@ function paintRailSticky(): void {
   if (!hm || realLeads) {
     stamp.style.display = "none";
     for (const [m] of all) m.style.visibility = "";   // real stamp leads → nothing suppressed
+    if (anyMarker) paintDay(gutterRight, realLeads ? markerTop : (firstBelow ? firstBelow[1] : cBottom + 1));
+    else day.style.display = "none";
     return;
   }
   // The sticky leads: pin it at the line and hide every marker that has crossed ABOVE it, so the real stamp
@@ -1673,6 +1715,7 @@ function paintRailSticky(): void {
   stamp.style.width = g.width + "px";
   stamp.style.top = line + "px";
   stamp.style.display = "";
+  paintDay(g.right, line);
 }
 
 // Scroll is the sticky stamp's primary driver, and a re-render moves the geometry under it — both funnel

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1085,6 +1085,18 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   position: fixed; z-index: 3; pointer-events: none;
   color: var(--dim); opacity: 0.92;
 }
+/* The day-context label above the top rail stamp (render.ts paintDay, the user 2026-08-17):
+   "Yesterday" / "3 days ago" / "Last week" whenever the top stamp's day is not today. Fixed like
+   the sticky, passive like the sticky; right-aligned to the gutter's right edge via the translate
+   (left is set to that edge, no width math), sitting just above the stamp it names. Smaller than
+   the stamp on purpose — context, not the time itself — and nowrap: fixed positioning escapes the
+   pane's overflow clip, and the longest form ("2 weeks ago") clears the gutter into the turn
+   padding, never over prose. */
+.rail-day {
+  position: fixed; z-index: 3; pointer-events: none; white-space: nowrap;
+  transform: translate(-100%, calc(-100% - 2px));
+  font-size: 0.68em; letter-spacing: 0.03em; color: var(--dim); opacity: 0.85;
+}
 /* match the dot's vertical position per turn type (default dot top:15, tool/thinking top:10) */
 .turn-tool .time-marker, .turn-thinking .time-marker { top: 10px; }
 /* DAY DIVIDER (the user 2026-08-01) — the date on a hairline rule across the prose column,

--- a/ui/webview/time-marker.test.ts
+++ b/ui/webview/time-marker.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert";
-import { markerLabel } from "./time-marker";
+import { markerLabel, dayContext } from "./time-marker";
 
 // All epochs below are built from local-time components so the test is timezone-agnostic
 // (markerLabel reads getHours()/getMinutes()/getDate() in local time, matching the browser).
@@ -85,4 +85,22 @@ test("the stamp returns exactly when the minute changes", () => {
   const t1103 = at(2026, 5, 12, 11, 3), t1104 = at(2026, 5, 12, 11, 4);
   assert.equal(markerLabel(t1104, t1103, NOW).text, "11:04", "a new minute is a real change → stamp it");
   assert.equal(markerLabel(t1104 + 30, t1104, NOW).text, "", "still 11:04 → suppressed again");
+});
+
+// ── dayContext: the top-of-view day label (the user 2026-08-17) ──
+// Real behavior, not source pins: the vocabulary the label speaks, midnight-relative (calendar days,
+// never 24h buckets — 23:50 yesterday is "Yesterday" ten minutes later).
+test("dayContext speaks the relative-day vocabulary, midnight-relative", () => {
+  const now = new Date(2026, 7, 17, 10, 0, 0).getTime();          // Mon Aug 17 2026, 10:00 local
+  const at = (y: number, mo: number, d: number, h = 12) => new Date(y, mo, d, h).getTime() / 1000;
+  assert.equal(dayContext(at(2026, 7, 17, 1), now), "", "today → no label, even 9h ago");
+  assert.equal(dayContext(at(2026, 7, 16, 23), now), "Yesterday", "23:00 yesterday, 11h ago — calendar, not 24h");
+  assert.equal(dayContext(at(2026, 7, 15), now), "2 days ago");
+  assert.equal(dayContext(at(2026, 7, 11), now), "6 days ago");
+  assert.equal(dayContext(at(2026, 7, 10), now), "Last week", "7 days");
+  assert.equal(dayContext(at(2026, 7, 4), now), "Last week", "13 days");
+  assert.equal(dayContext(at(2026, 7, 3), now), "2 weeks ago", "14 days");
+  assert.equal(dayContext(at(2026, 6, 22), now), "3 weeks ago", "26 days");
+  assert.equal(dayContext(at(2026, 6, 15), now), "Jul 15", "past a month → the divider's own date form");
+  assert.equal(dayContext(at(2025, 11, 30), now), "Dec 30 2025", "a different year says so");
 });

--- a/ui/webview/time-marker.ts
+++ b/ui/webview/time-marker.ts
@@ -53,3 +53,22 @@ export function markerLabel(epoch: number, prevEpoch: number | null, nowMs: numb
 // ~6 rows so the gutter never went long without a time. The sticky rail stamp now guarantees a time at the
 // top of the view at all times, which made those repeats pure noise — so the pass is gone and a stamp means
 // exactly one thing: the time CHANGED here (the user 2026-07-23). See paintRailSticky in render.ts.)
+
+// The DAY CONTEXT for the stamp at the top of the view (the user 2026-08-17): a human-readable
+// relative day ("Yesterday", "3 days ago", "Last week", "2 weeks ago") painted ABOVE the top
+// visible rail stamp whenever that stamp is not from today — so mid-scroll through history you
+// always know which day you are reading, even with the day divider off-screen. "" for today
+// (no label). Bounded vocabulary, oldest form the divider's own "Mmm D" (+ year when different).
+export function dayContext(epoch: number, nowMs: number): string {
+  const d = new Date(epoch * 1000);
+  const now = new Date(nowMs);
+  const sod = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
+  const days = Math.round((sod(now) - sod(d)) / 86400000);
+  if (days <= 0) return "";
+  if (days === 1) return "Yesterday";
+  if (days < 7) return days + " days ago";
+  if (days < 14) return "Last week";
+  if (days < 28) return Math.floor(days / 7) + " weeks ago";
+  const md = MONTH[d.getMonth()] + " " + d.getDate();
+  return d.getFullYear() === now.getFullYear() ? md : md + " " + d.getFullYear();
+}


### PR DESCRIPTION
User ask: when the chat's side timestamps aren't from today, show a human-readable day label (yesterday / two days ago / last week) above the topmost displayed timestamp — the sticky one included — with smooth behavior as scrolling crosses stamps and day boundaries.

- **The label**: "Yesterday" / "N days ago" / "Last week" / "N weeks ago", then the day divider's own "Mmm D" (+ year when different); nothing for today. Midnight-relative — 23:50 yesterday reads "Yesterday" ten minutes later, never a 24h bucket. Pure helper (`dayContext`) with real behavior tests over the whole vocabulary.
- **The anchoring is the smoothness**: painted by the same pass that owns the sticky rail stamp, the label rides above the tracked turn's own marker while that leads, above the first stamp below the line when nothing is tracked ("the next one"), and at the sticky's line once the sticky takes over — the handoff lands at the same pixel, so there is no discontinuity at transitions, and the text swaps only when the day actually changes.
- **The gutter-width lesson is respected**: day dividers moved out of the gutter in 2026-08 because "Yesterday" doesn't fit 47px. The label is fixed-positioned (escapes the pane's overflow clip), right-aligned to the gutter's right edge with no width math, smaller and dimmer than the stamp — the longest form clears into the turn padding, never over prose and never clipped.

Behavior tests in time-marker.test.ts; integration pins in rail-day.test.ts. Both suites + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)