### PR TITLE
New-comment dialog: name in the header, per-thread model/effort, badge retired

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5136,7 +5136,7 @@ def _comment_markers(sid):
     return out
 
 
-def _comment_create(parent_sid, anchor_uuid, exact, text, name="", now=None):
+def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", effort="", now=None):
     """Anchor a new comment thread: fork the parent at the highlighted message (inclusive) as a
     threadOf fork — no names/ entry, so no judge seeding is needed until promotion — and send the
     opening message. Returns (error, tid): error is the warn-toast string (tid None), success is
@@ -5144,7 +5144,10 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", now=None):
 
     `name` (the user 2026-08-15, who wanted to name the thread right in the dialog): the thread's
     editable name, defaulting to <parent>-comment-<N> where N counts the threads this session has
-    had. It rides the reg (so a break-out inherits it) and the frame (the popover's title)."""
+    had. It rides the reg (so a break-out inherits it) and the frame (the popover's title).
+
+    `model`/`effort` (the user 2026-08-17): per-thread overrides picked in the same dialog — the
+    thread runs on them, the parent is untouched (fork() writes them into the thread's reg only)."""
     be = Sessions.backend_for(parent_sid)
     if not (hasattr(be, "fork") and _sdk_ready()):
         return "threads need the SDK backend; this session runs on tmux, so there is nothing to fork.", None
@@ -5173,7 +5176,8 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", now=None):
         data.setdefault("threads", []).append(row)
         _save_comments(parent_sid, data)
     try:
-        be.fork(nm, parent_sid, cut, sid=tsid, thread_of=parent_sid)
+        be.fork(nm, parent_sid, cut, sid=tsid, thread_of=parent_sid,
+                model=str(model or ""), effort=str(effort or ""))
         be.connect(tsid)
         be.send(tsid, _comment_first_message(exact, text))
     except Exception as e:
@@ -6188,7 +6192,8 @@ def _drive(msg, client):
         # success a commentCreated ack names the new thread (the popover adopts exactly it — never a
         # guess) and the fresh {type:"comments"} frame rides straight back, ahead of the pusher cycle.
         err, tid = _comment_create(sid, str(msg["uuid"]), str(msg["exact"]), str(msg["text"]),
-                                   name=str(msg.get("name") or ""))
+                                   name=str(msg.get("name") or ""),
+                                   model=str(msg.get("model") or ""), effort=str(msg.get("effort") or ""))
         if err:
             client["send"](json.dumps({"type": "warn", "text": err}))
         else:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3623,7 +3623,7 @@ class SdkBackend:
         return sid
 
     def fork(self, name: str, parent_sid: str, cut_uuid: str = "", bg: str = "", fg: str = "",
-             sid: str | None = None, thread_of: str = "") -> str:
+             sid: str | None = None, thread_of: str = "", model: str = "", effort: str = "") -> str:
         """Mint a NEW session that is a FORK of `parent_sid`'s conversation — up to `cut_uuid` when given
         (a transcript record uuid; empty = the whole conversation), the parent untouched either way (the
         user 2026-08-13). The new session gets its OWN sid, registry, name and identity colour — a fork
@@ -3667,6 +3667,17 @@ class SdkBackend:
             reg["threadOf"] = thread_of
         if parent.get("model") and parent["model"] != "default":
             reg["model"] = parent["model"]
+        # Per-fork model/effort OVERRIDES (the user 2026-08-17: a comment thread on a different model
+        # or effort, without touching the parent). Applied HERE, in the reg the first connect reads —
+        # never via set_model, whose write_sdk_default side effect would make a thread's pick the seed
+        # for every future session. 'default' clears the inherited model back to the account default.
+        if model:
+            if model == "default":
+                reg.pop("model", None)
+            else:
+                reg["model"] = model
+        if effort in EFFORT_LEVELS:
+            reg["effort"] = effort
         if parent.get("auth") in ("login", "key"):
             reg["auth"] = parent["auth"]
         write_reg(self.state_dir, sid, reg)

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -399,8 +399,10 @@ class FakeBackend:
         self.calls = []
         self.sent = []
 
-    def fork(self, name, parent_sid, cut_uuid="", bg="", fg="", sid=None, thread_of=""):
+    def fork(self, name, parent_sid, cut_uuid="", bg="", fg="", sid=None, thread_of="",
+             model="", effort=""):
         self.calls.append(("fork", name, parent_sid, cut_uuid, sid, thread_of))
+        self.forked_meta = (model, effort)
         return sid
 
     def connect(self, sid):
@@ -478,6 +480,12 @@ class CommentOps(CommentBase):
         fr = km._comments_frame(PARENT)
         self.assertEqual(fr["threads"][0]["name"], "parent-comment-1",
                          "the popover titles threads by name off the frame")
+
+    def test_model_and_effort_picks_ride_the_fork_untouched_by_default(self):
+        km._comment_create(PARENT, "a1", "exponential backoff", "Why?", model="haiku", effort="low")
+        self.assertEqual(self.be.forked_meta, ("haiku", "low"))
+        km._comment_create(PARENT, "a1", "the cap", "Plain.")
+        self.assertEqual(self.be.forked_meta, ("", ""), "no pick = inherit; the parent is never touched")
 
     def test_a_refused_cut_leaves_no_thread_row_behind(self):
         err, tid = km._comment_create(PARENT, "missing-uuid", "text", "comment")

--- a/tests/test_fork_lineage.py
+++ b/tests/test_fork_lineage.py
@@ -85,6 +85,21 @@ class ForkStampsLineage(unittest.TestCase):
         self.assertEqual(self._reg(CHILD)["forkedFrom"]["cut"], "a9",
                          "no cut given = the histories diverge at the parent's leaf")
 
+    def test_fork_model_and_effort_overrides_land_in_the_reg_only(self):
+        self.be.fork("child", PARENT, "a1", sid=CHILD, model="haiku", effort="low")
+        reg = self._reg(CHILD)
+        self.assertEqual(reg.get("model"), "haiku")
+        self.assertEqual(reg.get("effort"), "low")
+        self.assertNotIn("model", self._reg(PARENT), "the parent's reg is untouched")
+
+    def test_fork_model_default_clears_the_inherited_pick(self):
+        (Path(self.td) / "sdk" / (PARENT + ".json")).write_text(json.dumps(
+            {**self._reg(PARENT), "model": "opus"}))
+        self.be.fork("child", PARENT, "a1", sid=CHILD, model="default", effort="not-a-level")
+        reg = self._reg(CHILD)
+        self.assertNotIn("model", reg, "'default' = back to the account default, not a literal")
+        self.assertNotEqual(reg.get("effort"), "not-a-level", "an unknown effort is ignored")
+
     def test_fork_children_indexes_by_parent_and_skips_threads(self):
         self.be.fork("child", PARENT, "a1", sid=CHILD)
         self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT)

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -115,7 +115,8 @@ test("the selection menu offers Comment, gated on a real transcript turn", () =>
 test("marks, badges AND every popover button ride the stable document.body delegate", () => {
   assert.match(UI, /cmtopen: \(elx\) =>/, "delegated — marks are re-created on every rebuild");
   assert.match(UI, /m\.dataset\.act = "cmtopen"/);
-  assert.match(UI, /b\.dataset\.act = "cmtopen"/);
+  // the count badge is GONE (the user 2026-08-17): the highlight + the rail tick do the speaking
+  assert.doesNotMatch(UI, /cmt-badge/);
   for (const act of ["cmtclose", "cmtsend", "cmtbreak", "cmtresolve", "cmtdelete", "cmtopensession"]) {
     assert.ok(UI.includes(`${act}:`), `${act} handler missing from the body delegate`);
     assert.ok(UI.includes(`dataset.act = "${act}"`), `${act} button missing its data-act`);
@@ -136,7 +137,7 @@ test("a comments frame refreshes the open popover IN PLACE — composer and care
 });
 
 test("the popover send acknowledges before any round-trip", () => {
-  assert.match(UI, /send\.disabled = true; send\.textContent = "Starting…"; \}\s+\/\/ ack before the round-trip/);
+  assert.match(UI, /send\.disabled = true; send\.textContent = "Commenting…"; \}\s+\/\/ ack before the round-trip/);
   assert.match(UI, /the pending bubble IS the acknowledgement/);
 });
 
@@ -244,7 +245,15 @@ test("the highlight is highlighter-YELLOW — never the selection blue — and o
 
 test("the create dialog names the thread right there: prefilled <session>-comment-<N>, validated", () => {
   assert.match(UI, /nameBox\.value = commentDrafts\.get\(nk\)\s*\n\s*\|\| \(\(sess0\?\.name \|\| "session"\)\.replace\(\/\[\^A-Za-z0-9._-\]\/g, "-"\)\s*\n\s*\+ "-comment-" \+ \(\(commentThreads\.get\(sid\) \|\| \[\]\)\.length \+ 1\)\);/);
-  assert.match(UI, /type: "commentCreate", id: create\.sid, uuid: create\.uuid, exact: create\.exact, text, name: nm/);
+  // the name lives IN the header ("New comment: <name>"), the button says Comment, and the picks ride along
+  assert.match(UI, /"New comment:"/);
+  assert.match(UI, /if \(nameBox\) head\.append\(title, nameBox, closeBtn\);/);
+  assert.match(UI, /send\.textContent = create \? "Comment" : "Send";/);
+  assert.match(UI, /text, name: nm, model: create\.model \|\| "", effort: create\.effort \|\| ""/);
+  // the comment's own model/effort selectors reuse the statusline's /models-fed choices + menu skin
+  assert.match(UI, /const metaRow = el\("div", "cmt-meta-row"\);/);
+  assert.match(UI, /META_CHOICES\[kind\]/);
+  assert.match(KERNEL, /model=str\(msg\.get\("model"\) or ""\), effort=str\(msg\.get\("effort"\) or ""\)/);
   assert.match(KERNEL, /"%s-comment-%d" % \(sess\["name"\], len\(data\.get\("threads"\) or \[\]\) \+ 1\)/);
   assert.match(UI, /const base = thName \|\|/, "break-out prefills the thread's own name");
 });
@@ -269,6 +278,12 @@ test("scroll-rail ticks mark the commented spots and jump-open on click", () => 
   assert.match(UI, /if \(sid === activeId\) updateCommentRail\(\);/);
   assert.match(CSS, /\.cmt-tick \{/);
   assert.match(CSS, /\.cmt-rail \{ position: fixed;/);
+});
+
+test("the highlight pulses while its thread is writing — the badge's old job", () => {
+  assert.match(UI, /m\.classList\.toggle\("busy", threadBusy\(th\.state\) && th\.status === "open"\)/);
+  assert.match(CSS, /mark\.cmt-hl\.busy \{ animation: cmt-busy-pulse/);
+  assert.match(KERNEL, /state = be\.session_state\(tsid\)/);
 });
 
 test("the tint ladder keeps every state distinct: base < unread < hover", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5311,7 +5311,8 @@ const commentThreads = new Map<string, CommentThread[]>();          // parent si
 const commentPending = new Map<string, { text: string; t: number }[]>(); // tid → optimistic sends
 const commentDrafts = new Map<string, string>();                    // draft key → unsent popover text
 let openCommentKey: { sid: string; tid: string } | null = null;     // the open thread popover
-let pendingCommentAnchor: { sid: string; uuid: string; exact: string } | null = null; // create mode
+let pendingCommentAnchor: { sid: string; uuid: string; exact: string;
+  model?: string; effort?: string } | null = null; // create mode (+ the thread's own model/effort picks)
 let pendingAdoptTid: string | null = null;                          // commentCreated ack that beat its frame
 let commentPopPos: { x: number; y: number } | null = null;
 
@@ -5340,15 +5341,10 @@ function applyCommentMarks(sid: string): void {
   for (const old of Array.from(v.el.querySelectorAll("mark.cmt-hl"))) {
     if (!have.has((old as HTMLElement).dataset.tid || "")) unwrapCommentMark(old as HTMLElement);
   }
-  for (const b of Array.from(v.el.querySelectorAll(".cmt-badge"))) {
-    const uuid = (b.closest(".turn") as HTMLElement | null)?.dataset.uuid || "";
-    if (!threads.some((t) => t.anchorUuid === uuid)) b.remove();
-  }
   if (!threads.length) return;
   for (const [uuid, list] of threadsByAnchor(threads)) {
     const turn = v.el.querySelector(`.turn[data-uuid="${cssEscape(uuid)}"]`) as HTMLElement | null;
     if (!turn) continue;                       // windowed out — the mark returns when the turn does
-    ensureCommentBadge(turn, list);
     for (const th of list) ensureCommentMark(turn, th);
   }
 }
@@ -5417,6 +5413,9 @@ function updateCommentRail(): void {
 }
 window.addEventListener("resize", () => updateCommentRail());
 
+// (The per-turn count badge is GONE — the user 2026-08-17: the highlight does the speaking, and
+// the scroll-rail tick already covers a thread whose rendered text drifted beyond re-matching.)
+
 function unwrapCommentMark(markEl: HTMLElement): void {
   const p = markEl.parentNode;
   if (!p) return;
@@ -5427,22 +5426,6 @@ function unwrapCommentMark(markEl: HTMLElement): void {
   while (markEl.firstChild) p.insertBefore(markEl.firstChild, markEl);
   markEl.remove();
   p.normalize();
-}
-
-function ensureCommentBadge(turn: HTMLElement, list: CommentThread[]): void {
-  turn.classList.add("has-cmt");               // positions the badge (styles.css .turn.has-cmt)
-  let b = turn.querySelector(":scope > .cmt-badge") as HTMLButtonElement | null;
-  if (!b) {
-    b = el("button", "cmt-badge") as HTMLButtonElement;
-    b.type = "button";
-    b.dataset.act = "cmtopen";                 // delegated on document.body — click-safe across rebuilds
-    turn.appendChild(b);
-  }
-  b.textContent = String(list.length);
-  b.dataset.tid = (list.find((t) => t.unread && t.status === "open") || list[list.length - 1]).tid;
-  b.classList.toggle("unread", list.some((t) => t.unread && t.status === "open"));
-  b.classList.toggle("busy", list.some((t) => threadBusy(t.state) && t.status === "open"));
-  b.title = (list.length === 1 ? "1 thread" : list.length + " threads") + " on this message. Click to open";
 }
 
 function ensureCommentMark(turn: HTMLElement, th: CommentThread): void {
@@ -5587,7 +5570,7 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
 
 function commentPopTitle(create: boolean, th: CommentThread | null | undefined): string {
   const nm = th?.name || "Thread";
-  return create ? "New thread"
+  return create ? "New comment:"
     : th!.status === "promoted" ? "Now its own session: " + th!.promotedName
     : th!.status === "promoting" ? "Breaking out…"
     : th!.status === "resolved" ? nm + " (resolved)" : nm;
@@ -5605,9 +5588,10 @@ function commentSendFromPop(pop: HTMLElement): void {
     const nameBox = pop.querySelector(".cmt-name") as HTMLInputElement | null;
     const nm = (nameBox?.value || "").trim();
     if (nm && !/^[A-Za-z0-9._-]+$/.test(nm)) { nameBox?.classList.add("bad"); nameBox?.focus(); return; }
-    if (send) { send.disabled = true; send.textContent = "Starting…"; }   // ack before the round-trip;
+    if (send) { send.disabled = true; send.textContent = "Commenting…"; }   // ack before the round-trip;
     //                                       the draft survives until commentCreated adopts the thread
-    vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact, text, name: nm });
+    vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact,
+      text, name: nm, model: create.model || "", effort: create.effort || "" });
     return;
   }
   const cur = openCommentThread();
@@ -5656,19 +5640,40 @@ function renderCommentPopover(): void {
   const head = el("div", "cmt-head");
   const title = el("span", "cmt-title");
   title.textContent = commentPopTitle(!!create, th);
+  let nameBox: HTMLInputElement | null = null;
+  if (create) {
+    // the name lives IN the header — "New comment: <name>" — bold and editable right there (the
+    // user 2026-08-17); prefilled <session>-comment-<N>, drafted under its own key so a refused
+    // create hands an edited name back too
+    const nk = "newname:" + create.uuid;
+    nameBox = document.createElement("input");
+    nameBox.type = "text";
+    nameBox.className = "cmt-name";
+    nameBox.setAttribute("autocapitalize", "off");
+    nameBox.setAttribute("autocomplete", "off");
+    nameBox.setAttribute("spellcheck", "false");
+    const sess0 = sessions.get(sid);
+    nameBox.value = commentDrafts.get(nk)
+      || ((sess0?.name || "session").replace(/[^A-Za-z0-9._-]/g, "-")
+          + "-comment-" + ((commentThreads.get(sid) || []).length + 1));
+    nameBox.title = "The comment's name — edit it right here";
+    const nb = nameBox;
+    nb.addEventListener("input", () => { nb.classList.remove("bad"); commentDrafts.set(nk, nb.value); });
+  }
   const closeBtn = el("button", "cmt-x") as HTMLButtonElement;
   closeBtn.type = "button";
   closeBtn.textContent = "×";
   closeBtn.title = "Close (the thread stays on its highlight)";
   closeBtn.dataset.act = "cmtclose";
-  head.append(title, closeBtn);
+  if (nameBox) head.append(title, nameBox, closeBtn);
+  else head.append(title, closeBtn);
   // DRAG by the header (the user 2026-08-13, who found the popover's spot inconvenient): pointer
   // capture, viewport-clamped, and the position writes through to commentPopPos so a later full
   // rebuild (a status flip) reopens where the user parked it. The header survives in-place
   // refreshes, so a drag is never cut by a comments frame; a full rebuild mid-drag just ends it.
   head.title = "Drag to move";
   head.addEventListener("pointerdown", (ev: PointerEvent) => {
-    if ((ev.target as HTMLElement).closest(".cmt-x")) return;
+    if ((ev.target as HTMLElement).closest(".cmt-x, .cmt-name")) return;   // editing the name is not a drag
     ev.preventDefault();
     const dx = ev.clientX - pop.offsetLeft, dy = ev.clientY - pop.offsetTop;
     head.setPointerCapture(ev.pointerId);
@@ -5701,22 +5706,49 @@ function renderCommentPopover(): void {
     pop.appendChild(list);
   }
   if (create) {
-    // the thread's NAME, editable right here (the user 2026-08-15): prefilled
-    // <session>-comment-<N>, N counting the threads this session has had; an edited value
-    // drafts under its own key so a refused create hands it back too
-    const nk = "newname:" + create.uuid;
-    const nameBox = document.createElement("input");
-    nameBox.type = "text";
-    nameBox.className = "cmt-name";
-    nameBox.setAttribute("autocapitalize", "off");
-    nameBox.setAttribute("autocomplete", "off");
-    nameBox.setAttribute("spellcheck", "false");
-    const sess0 = sessions.get(sid);
-    nameBox.value = commentDrafts.get(nk)
-      || ((sess0?.name || "session").replace(/[^A-Za-z0-9._-]/g, "-")
-          + "-comment-" + ((commentThreads.get(sid) || []).length + 1));
-    nameBox.addEventListener("input", () => { nameBox.classList.remove("bad"); commentDrafts.set(nk, nameBox.value); });
-    pop.appendChild(nameBox);
+    // the thread's OWN model + effort (the user 2026-08-17): the same /models-fed choices the
+    // chat's statusline selectors use, defaulting to what this session runs now — picking one
+    // affects only the thread; the conversation it branches from is never touched
+    const st = sessions.get(sid)?.status;
+    const metaRow = el("div", "cmt-meta-row");
+    const mkSel = (kind: "model" | "effort") => {
+      const btn = el("button", "cmt-meta") as HTMLButtonElement;
+      btn.type = "button";
+      const chosen = kind === "model" ? create.model : create.effort;
+      const inherit = kind === "model" ? (st?.model || "Default") : (st?.effort || "default");
+      const label = chosen
+        ? (META_CHOICES[kind].find((c) => c.value === chosen)?.label || chosen)
+        : inherit;
+      btn.textContent = (kind === "model" ? "Model: " : "Effort: ") + label;
+      btn.title = chosen ? "the comment runs on its own " + kind + "; this session keeps its"
+        : "inherits this session's " + kind + " — click to pick another for the comment only";
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        closeMetaMenu();
+        const menu = el("div", "meta-menu");
+        for (const c of META_CHOICES[kind]) {
+          const cur = chosen ? c.value === chosen : (st ? isCurrentMeta(kind, st, c.value) : false);
+          const item = el("div", "meta-item" + (cur ? " current" : ""));
+          item.textContent = c.label;
+          item.addEventListener("click", (ev) => {
+            ev.stopPropagation();
+            if (pendingCommentAnchor) pendingCommentAnchor[kind] = c.value;
+            closeMetaMenu();
+            document.getElementById("cmt-pop")?.remove();   // full rebuild shows the pick
+            renderCommentPopover();
+          });
+          menu.appendChild(item);
+        }
+        document.body.appendChild(menu);
+        const r2 = btn.getBoundingClientRect();
+        menu.style.left = r2.left + "px";
+        menu.style.top = (r2.bottom + 4) + "px";
+        metaMenuEl = menu;
+      });
+      return btn;
+    };
+    metaRow.append(mkSel("model"), mkSel("effort"));
+    pop.appendChild(metaRow);
   }
   if (create || th!.status !== "promoted") {
     const dk = create ? "new:" + create.uuid : th!.tid;
@@ -5735,7 +5767,7 @@ function renderCommentPopover(): void {
     const row = el("div", "cmt-actions");
     const send = el("button", "cmt-send") as HTMLButtonElement;
     send.type = "button";
-    send.textContent = create ? "Start thread" : "Send";
+    send.textContent = create ? "Comment" : "Send";
     send.dataset.act = "cmtsend";
     row.appendChild(send);
     if (th) {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2463,17 +2463,8 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .md :not(pre) > code.cmt-hl-host:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, var(--code-bg)); }
 
 .turn.has-cmt { position: relative; }
-.cmt-badge {
-  position: absolute; top: 2px; right: 4px; z-index: 5;
-  min-width: 16px; height: 16px; padding: 0 4px;
-  border: 1px solid var(--box-border); border-radius: 8px;
-  background: var(--vscode-menu-background, #252526);
-  color: var(--accent); font-size: 10px; line-height: 14px;
-  cursor: pointer; opacity: 0.75;
-}
-.cmt-badge:hover { opacity: 1; }
-.cmt-badge.unread { border-color: var(--accent); opacity: 1; }
-.cmt-badge.busy { animation: cmt-busy-pulse 1.2s ease-in-out infinite; }
+/* (the count badge is gone — the user 2026-08-17: the highlight does the speaking; the busy pulse
+   below and the scroll-rail tick carry the states it used to) */
 
 .cmt-pop {
   position: fixed; z-index: 120; width: 360px; max-width: 94vw;
@@ -2559,7 +2550,6 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
   position: absolute; top: 2px; right: 24px; z-index: 5;
   display: flex; gap: 4px;
 }
-.cmt-badge ~ .branch-chips, .turn:has(> .cmt-badge) .branch-chips { right: 28px; }
 .branch-chip {
   height: 16px; padding: 0 6px; border: 1px solid var(--box-border); border-radius: 8px;
   background: var(--vscode-menu-background, #252526);
@@ -2568,15 +2558,26 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 }
 .branch-chip:hover { opacity: 1; border-color: var(--accent); }
 
-/* the create popover's thread-name row (the user 2026-08-15): editable, prefilled
-   <session>-comment-<N>; .bad = failed the session-name charset, matching the fork modal */
+/* the comment's NAME, inline in the header — "New comment: <name>" (the user 2026-08-17): bold and
+   accent-tinted so it reads as a name, editable in place; a dashed underline hints at that. .bad =
+   failed the session-name charset, matching the fork modal. */
 .cmt-name {
-  width: 100%; box-sizing: border-box; padding: 4px 7px;
-  border: 1px solid var(--box-border); border-radius: 4px;
-  background: rgba(255, 255, 255, 0.05); color: inherit; font: inherit;
+  flex: 1; min-width: 60px; margin: 0 6px; padding: 0 2px;
+  border: 0; border-bottom: 1px dashed color-mix(in srgb, var(--accent) 45%, transparent);
+  border-radius: 0; background: transparent;
+  color: var(--accent); font: inherit; font-weight: 600;
 }
-.cmt-name:focus { outline: none; border-color: var(--accent); }
-.cmt-name.bad { border-color: var(--st-blocked-bg, #c94f4f); }
+.cmt-name:focus { outline: none; border-bottom-color: var(--accent); }
+.cmt-name.bad { border-bottom: 1px solid var(--st-blocked-bg, #c94f4f); color: var(--st-blocked-bg, #c94f4f); }
+
+/* the comment's own model/effort selectors (the user 2026-08-17) — chip-shaped buttons opening the
+   same .meta-menu the statusline uses; the picks ride the create call and touch only the thread */
+.cmt-meta-row { display: flex; gap: 6px; }
+.cmt-meta {
+  padding: 2px 8px; border: 1px solid var(--box-border); border-radius: 4px; cursor: pointer;
+  background: none; color: inherit; font: inherit; opacity: 0.85;
+}
+.cmt-meta:hover { opacity: 1; border-color: var(--accent); }
 
 /* comment ticks on the chat's scroll rail (the user 2026-08-15): where the comments are, at the
    anchor's proportional position in the whole conversation; click = jump + open the thread */


### PR DESCRIPTION
Dialog refinements from live use (the user's screenshots):

- **"New comment: *name*"** — the editable name moves into the header, bold and accent-tinted so it reads as a name, replacing both the "New thread" title and the separate name row. The button says **Comment** (it isn't a session yet). Dragging still works by the header; typing in the name never drags.
- **Per-thread model and effort** — the dialog carries the same `/models`-fed selectors the chat's statusline uses (same `.meta-menu` skin), defaulting to the session's current values. A pick rides `commentCreate` into the thread's reg at `fork()` time and affects only the thread — deliberately not `set_model`, whose `write_sdk_default` side effect would turn a comment's pick into the seed for every future session. `default` clears the inherited model; an unknown effort is ignored.
- **The per-turn count badge is retired** — the highlight does the speaking, and the scroll-rail tick already covers the drifted-text fallback the badge existed for. The badge's other job, showing a thread mid-write, was already on the highlight (busy pulse) and is now pinned end to end (frame `state` → `.busy` → `cmt-busy-pulse`).

Tests: kernel fork-override tests (reg-only application, `default` clearing, unknown-effort ignore, untouched parent), create-op passthrough, updated dialog pins (header name, Comment button, selector row, payload), a badge-absence pin, and the busy-pulse chain pin. Suites green (pytest 4757, node 2043), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)