### PR TITLE
A revival preserves the session's recorded identity

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3721,10 +3721,24 @@ class SdkBackend:
         registry (spread) and especially its lastSid when set — lastSid tracks the NEWEST transcript
         fsid (a /clear or relaunch mints new fsids under the same romp sid) and SdkSession resumes from
         it; stamping the original sid here would silently resume an OLD conversation state (the
-        picker-revive fix, the user 2026-07-05)."""
+        picker-revive fix, the user 2026-07-05).
+
+        A REVIVAL PRESERVES IDENTITY (2026-08-17): when the reg already carries a name, that name WINS
+        over the caller's — the caller's copy came from the names/ registry or a discovery row, both of
+        which other paths rewrite (the tmux launcher's dead-name freeing, fork-lane rows whose "sid" is
+        a transcript stem), and trusting it let a machine-panic relaunch respawn a session under a name
+        nobody chose while it carried its whole history (the local session incident, 2026-08-17: reg
+        name X, caller name Y → revived as Y with X's past, and the spawn-frozen env made Y permanent).
+        The caller's name is only ever ADOPTED when the reg has none — the create-from-nothing revive
+        of a session this backend has never seen, which is also logged, because a sid with no reg is
+        usually a transcript fsid that leaked out of a discovery row rather than a real romp sid."""
         reg = read_reg(self.state_dir, sid) or {}
+        kept = str(reg.get("name") or "").strip()
+        if not reg:
+            self._log("resume minting a reg for unknown sid %s as %r — a sid with no reg is usually "
+                      "a transcript fsid, not a romp session" % (sid[:13], name))
         cwd = cwd or reg.get("cwd") or os.path.expanduser("~")
-        write_reg(self.state_dir, sid, {**reg, "sid": sid, "name": name, "cwd": cwd,
+        write_reg(self.state_dir, sid, {**reg, "sid": sid, "name": kept or name, "cwd": cwd,
                                         "mode": reg.get("mode", "acceptEdits"),
                                         "effort": reg.get("effort", DEFAULT_EFFORT),
                                         "lastSid": reg.get("lastSid") or sid, "alive": True})

--- a/tests/test_revive_identity.py
+++ b/tests/test_revive_identity.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""A revival preserves the session's recorded identity (2026-08-17).
+
+The incident: a machine kernel-panicked and the relaunch brought a session back under a NAME nobody
+chose, carrying its whole history — the spawn-frozen env made the new name permanent. The mechanism:
+SdkBackend.resume() trusted the CALLER's name outright, and the callers read it from the names/
+registry or a discovery row — both rewritten by other machinery (the tmux launcher frees a dead
+session's name by renaming its names/ entry; fork lanes emit rows whose "sid" is a transcript stem).
+
+The rule now: when the reg already carries a name, that name WINS; the caller's is adopted only on a
+create-from-nothing revive (no reg at all — usually a leaked transcript fsid, so it is also logged).
+SYNTHETIC fixtures only."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+sb = SourceFileLoader("romp_sdk_backend_reviveid", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+SID = "11111111-2222-3333-4444-dddddddddddd"
+
+
+class ReviveIdentity(unittest.TestCase):
+    def _backend(self, td):
+        be = sb.SdkBackend.__new__(sb.SdkBackend)   # no threads/venv — resume touches only the reg store
+        be.state_dir = td
+        be.sessions = {}
+        be._poke = lambda: None
+        be._log = lambda *a, **k: (be.__dict__.setdefault("_logged", []).append(a))
+        return be
+
+    def test_the_regs_own_name_outranks_the_callers(self):
+        with tempfile.TemporaryDirectory() as td:
+            be = self._backend(td)
+            sb.write_reg(td, SID, {"sid": SID, "name": "local_butler", "cwd": td,
+                                   "lastSid": "22222222-3333-4444-5555-eeeeeeeeeeee", "alive": False})
+            self.assertTrue(be.resume("local_misc", SID))
+            reg = sb.read_reg(td, SID)
+            self.assertEqual(reg["name"], "local_butler",
+                             "a revival keeps the recorded identity — the caller's copy may be rewritten state")
+            self.assertTrue(reg["alive"])
+            self.assertEqual(reg["lastSid"], "22222222-3333-4444-5555-eeeeeeeeeeee", "history pointer untouched")
+
+    def test_a_create_from_nothing_revive_adopts_the_callers_name_and_says_so(self):
+        with tempfile.TemporaryDirectory() as td:
+            be = self._backend(td)
+            self.assertTrue(be.resume("fresh_name", SID))
+            reg = sb.read_reg(td, SID)
+            self.assertEqual(reg["name"], "fresh_name", "no reg → nothing recorded to preserve")
+            self.assertTrue(getattr(be, "_logged", []), "minting a reg for an unknown sid is logged, never silent")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Live incident (2026-08-17): a Mac kernel panic relaunched everything and one session came back as a different name — its own spawn-frozen environment proves it was launched under the new name, while it carries the old session's full history. Nobody chose the rename.

The recon over every respawn path shows boot reconcile, crash-heal, and delivery-revives are identity-safe (name always from the reg). The hole is `SdkBackend.resume`: it stamped the caller's name over the reg unconditionally, and its callers read that name from the names/ registry or a discovery row — both rewritten by other machinery (the tmux launcher frees a dead session's name by renaming its names/ entry; fork-lane discovery rows carry a transcript stem as their "sid", and reviving one mints a reg keyed by that fsid).

The fix lives at the single chokepoint every revive crosses: **when the reg already carries a name, that name wins**; the caller's is adopted only on a create-from-nothing revive (no reg at all), which is also logged — a sid with no reg is usually a leaked transcript fsid, not a real session id, and minting it silently is how identities drift.

Behavior tests in test_revive_identity.py (reg-name-wins with history pointer untouched; create-from-nothing adopts and logs). Both suites + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)