### PR TITLE
A blue notch on the scroll edge for every user message

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1640,6 +1640,56 @@ function ensureRailDay(): HTMLElement {
   return railDay;
 }
 
+// SCROLL MARKS (the user 2026-08-17): a thin blue notch on the chat's right scroll edge for every
+// USER message — the conversation's shape at a glance, VS Code overview-ruler style. Positions are
+// proportional (turn offset over scroll height), so they are scroll-INVARIANT: the paint rides the
+// rail-sticky scheduler for free, but a signature check skips the DOM work on pure scrolls and only
+// rebuilds when the geometry or the set of user turns actually changed. Passive fixed chrome, like
+// the sticky: it never intercepts the native scrollbar underneath. The blue is the outgoing-bubble
+// blue — the color that already means "yours" — never the romp accent.
+let scrollMarks: HTMLElement | null = null;
+let scrollMarksSig = "";
+function ensureScrollMarks(): HTMLElement {
+  if (scrollMarks && scrollMarks.isConnected) return scrollMarks;
+  scrollMarks = el("div", "scroll-marks");
+  scrollMarks.style.display = "none";
+  document.body.appendChild(scrollMarks);
+  return scrollMarks;
+}
+
+function paintScrollMarks(): void {
+  const box = ensureScrollMarks();
+  const content = document.getElementById("content");
+  const v = activeId ? views.get(activeId) : null;
+  if (!content || !v || v.el.style.display === "none") { box.style.display = "none"; scrollMarksSig = ""; return; }
+  const cRect = content.getBoundingClientRect();
+  const sh = content.scrollHeight;
+  if (!sh || cRect.height <= 40) { box.style.display = "none"; scrollMarksSig = ""; return; }
+  const turns: HTMLElement[] = [];
+  for (const t of Array.from(v.el.querySelectorAll<HTMLElement>(".turn-user:not(.romp):not(.injected)"))) {
+    // gestures (a /command row, the Continue row) are the user's DOINGS, not their words — no notch
+    if (t.querySelector(".user-bubble:not(.cmd-row):not(.cont-row)")) turns.push(t);
+  }
+  const ys = turns.map((t) => {
+    const top = t.getBoundingClientRect().top - cRect.top + content.scrollTop;
+    return Math.round(((top / sh) * (cRect.height - 4)));
+  });
+  const sig = activeId + "|" + Math.round(cRect.top) + "," + Math.round(cRect.right) + ","
+    + Math.round(cRect.height) + "|" + ys.join(",");
+  if (sig !== scrollMarksSig) {
+    scrollMarksSig = sig;
+    box.replaceChildren(...ys.map((y) => {
+      const m = el("div", "scroll-mark");
+      m.style.top = y + "px";
+      return m;
+    }));
+    box.style.left = (cRect.right - 12) + "px";
+    box.style.top = cRect.top + "px";
+    box.style.height = cRect.height + "px";
+  }
+  box.style.display = ys.length ? "" : "none";
+}
+
 function paintRailSticky(): void {
   const stamp = ensureRailSticky();
   const content = document.getElementById("content");
@@ -1726,7 +1776,7 @@ let railStickyPending = false;
 function scheduleRailSticky(): void {
   if (railStickyPending) return;
   railStickyPending = true;
-  requestAnimationFrame(() => { railStickyPending = false; paintRailSticky(); });
+  requestAnimationFrame(() => { railStickyPending = false; paintRailSticky(); paintScrollMarks(); });
 }
 
 function renderEventInner(ev: ChatEvent): HTMLElement {

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -1,0 +1,29 @@
+// A thin blue notch on the chat's right scroll edge for every USER message (the user 2026-08-17) —
+// the conversation's shape at a glance, overview-ruler style. Proportional positions (scroll-
+// invariant), painted by the rail-sticky scheduler with a signature skip so pure scrolls do no DOM
+// work; passive fixed chrome that never blocks the native scrollbar; gestures (command rows, the
+// Continue row) draw no notch — those are doings, not words. Source pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("one notch per real user message, none for gestures or romp turns", () => {
+  assert.match(RENDER, /querySelectorAll<HTMLElement>\(".turn-user:not\(\.romp\):not\(\.injected\)"\)/);
+  assert.match(RENDER, /t\.querySelector\("\.user-bubble:not\(\.cmd-row\):not\(\.cont-row\)"\)/,
+    "a /command or Continue gesture is a doing, not words — no notch");
+});
+
+test("positions are proportional and pure scrolls do no DOM work", () => {
+  assert.match(RENDER, /t\.getBoundingClientRect\(\)\.top - cRect\.top \+ content\.scrollTop/);
+  assert.match(RENDER, /if \(sig !== scrollMarksSig\) \{/, "signature skip: rebuild only on real change");
+  assert.match(RENDER, /paintRailSticky\(\); paintScrollMarks\(\);/, "rides the existing rAF scheduler");
+});
+
+test("passive chrome in the user's own blue", () => {
+  assert.match(CSS, /\.scroll-marks \{ position: fixed; z-index: 3; pointer-events: none; width: 12px; \}/);
+  assert.match(CSS, /background: #2b6cef; opacity: 0\.65;/, "the outgoing-bubble blue, never the romp accent");
+});

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1092,6 +1092,12 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    the stamp on purpose — context, not the time itself — and nowrap: fixed positioning escapes the
    pane's overflow clip, and the longest form ("2 weeks ago") clears the gutter into the turn
    padding, never over prose. */
+/* the user-message scroll notches (render.ts paintScrollMarks, the user 2026-08-17): passive fixed
+   chrome over the scroller's right edge, one 2px tick per user message at its proportional position.
+   The blue is the OUTGOING-BUBBLE blue (#2b6cef, "yours"), deliberately not the romp accent. */
+.scroll-marks { position: fixed; z-index: 3; pointer-events: none; width: 12px; }
+.scroll-marks .scroll-mark { position: absolute; right: 1px; width: 8px; height: 2px;
+  border-radius: 1px; background: #2b6cef; opacity: 0.65; }
 .rail-day {
   position: fixed; z-index: 3; pointer-events: none; white-space: nowrap;
   transform: translate(-100%, calc(-100% - 2px));


### PR DESCRIPTION
User ask: thin blue horizontal notches on the chat's right scroll area marking where user messages sit.

One 2px notch per real user message at its proportional position over the scroller — the conversation's shape at a glance, overview-ruler style. The blue is the outgoing-bubble blue (the color that already means "yours"), deliberately not the romp accent per the accent rule. Positions are scroll-invariant, so the paint rides the existing rail-sticky rAF scheduler with a signature skip: pure scrolls do zero DOM work, and only a geometry or turn-set change rebuilds the ticks. Passive fixed chrome (pointer-events none) that never blocks the native scrollbar. Gesture rows (/commands, Continue) draw no notch — doings, not words.

Pinned in scroll-marks.test.ts. Both suites + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)