### PR TITLE
History loads rescale the scroll map smoothly, never teleport it

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1678,11 +1678,22 @@ function paintScrollMarks(): void {
     + Math.round(cRect.height) + "|" + ys.join(",");
   if (sig !== scrollMarksSig) {
     scrollMarksSig = sig;
-    box.replaceChildren(...ys.map((y) => {
-      const m = el("div", "scroll-mark");
-      m.style.top = y + "px";
-      return m;
-    }));
+    // UPDATE IN PLACE when the notch count is unchanged (the user 2026-08-17: scrolling back streams
+    // older history in, the scroller's world grows, and every proportional position legitimately
+    // compresses — the native thumb does the same — but rebuilt nodes TELEPORTED there). Moving the
+    // existing nodes lets the CSS transition carry them, so a history load reads as the map
+    // rescaling rather than notches jumping to wrong places. Count changes (new messages, a fresh
+    // tab) still rebuild outright — those are new marks, not moved ones.
+    const kids = Array.from(box.children) as HTMLElement[];
+    if (kids.length === ys.length) {
+      ys.forEach((y, i) => { kids[i].style.top = y + "px"; });
+    } else {
+      box.replaceChildren(...ys.map((y) => {
+        const m = el("div", "scroll-mark");
+        m.style.top = y + "px";
+        return m;
+      }));
+    }
     box.style.left = (cRect.right - 12) + "px";
     box.style.top = cRect.top + "px";
     box.style.height = cRect.height + "px";

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -17,6 +17,15 @@ test("one notch per real user message, none for gestures or romp turns", () => {
     "a /command or Continue gesture is a doing, not words — no notch");
 });
 
+test("a history load rescales the map smoothly — moved notches are carried, never teleported", () => {
+  // the user 2026-08-17: scrolling back streams older history in; the scroller's world grows and
+  // every proportional position compresses (the native thumb does the same). Rebuilt nodes can't
+  // transition, so same-count updates move the EXISTING nodes and CSS carries them.
+  assert.match(RENDER, /if \(kids\.length === ys\.length\) \{\s*\n\s*ys\.forEach\(\(y, i\) => \{ kids\[i\]\.style\.top = y \+ "px"; \}\);/);
+  assert.match(CSS, /transition: top 180ms ease;/);
+  assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.scroll-marks \.scroll-mark \{ transition: none; \} \}/);
+});
+
 test("positions are proportional and pure scrolls do no DOM work", () => {
   assert.match(RENDER, /t\.getBoundingClientRect\(\)\.top - cRect\.top \+ content\.scrollTop/);
   assert.match(RENDER, /if \(sig !== scrollMarksSig\) \{/, "signature skip: rebuild only on real change");

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1097,7 +1097,9 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    The blue is the OUTGOING-BUBBLE blue (#2b6cef, "yours"), deliberately not the romp accent. */
 .scroll-marks { position: fixed; z-index: 3; pointer-events: none; width: 12px; }
 .scroll-marks .scroll-mark { position: absolute; right: 1px; width: 8px; height: 2px;
-  border-radius: 1px; background: #2b6cef; opacity: 0.65; }
+  border-radius: 1px; background: #2b6cef; opacity: 0.65;
+  transition: top 180ms ease; }   /* history streaming in rescales the map — carried, not teleported */
+@media (prefers-reduced-motion: reduce) { .scroll-marks .scroll-mark { transition: none; } }
 .rail-day {
   position: fixed; z-index: 3; pointer-events: none; white-space: nowrap;
   transform: translate(-100%, calc(-100% - 2px));


### PR DESCRIPTION
User report on the new scroll notches: they change position when scrolling back as older history loads — reading as wrong placement or phantom spacing.

Verified against the windowed-history mechanics: the positions are correct — the chat streams older events in on scroll-back, the scroller's world grows, and every proportional position compresses exactly as the native scrollbar thumb does. What made it read as a bug is that the notches teleported: the repaint rebuilt the nodes, so CSS transitions could never engage. Same-count repaints now move the existing notch nodes in place, carried by a 180ms transition — a history load reads as the map rescaling rather than marks jumping. Count changes (new messages, tab switches) still rebuild outright, and reduced-motion disables the carry.

Pins extended in scroll-marks.test.ts. UI suite + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)