### PR TITLE
Comment dialog: identity-colored name, whole-box drag/resize, the chat's own composer row

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5050,6 +5050,9 @@ def _thread_messages(tsid, cut_uuid, floor_t=0):
             break                                   # tip fork: copied history keeps its original (older) stamps
         if r.get("type") in ("user", "assistant"):
             txt = _comment_msg_text(r)
+            if r.get("type") == "user" and txt.lstrip().startswith("<task-notification>"):
+                txt = ""                            # harness bookkeeping for the AGENT (a parent bg task died
+                #                                     with the fork) — never the user's own words (2026-08-17)
             if txt and txt != boot_nudge and not (r.get("type") == "user" and "<!-- romp-" in txt):
                 rows.append({"who": "you" if r.get("type") == "user" else "agent",
                              "text": txt[:4000],
@@ -5109,7 +5112,7 @@ def _comments_frame(sid):
         seen = int(th.get("lastSeenT") or 0)
         unread = any(m["who"] == "agent" and m["t"] > seen for m in msgs)
         threads.append({"tid": th.get("tid"), "anchorUuid": th.get("anchorUuid"),
-                        "name": th.get("name") or "",
+                        "name": th.get("name") or "", "color": th.get("color") or "",
                         "exact": str(th.get("exact") or "")[:500], "status": status,
                         "createdT": th.get("createdT") or 0, "state": state, "error": err,
                         "unread": unread, "promotedName": th.get("promotedName") or "",
@@ -5136,7 +5139,7 @@ def _comment_markers(sid):
     return out
 
 
-def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", effort="", now=None):
+def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", effort="", color="", now=None):
     """Anchor a new comment thread: fork the parent at the highlighted message (inclusive) as a
     threadOf fork — no names/ entry, so no judge seeding is needed until promotion — and send the
     opening message. Returns (error, tid): error is the warn-toast string (tid None), success is
@@ -5163,6 +5166,9 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", eff
     nm = str(name or "").strip()
     if nm and not NAME_RE.match(nm):
         return "thread names use letters, digits, . _ - only.", None
+    col = str(color or "").strip()
+    if col and not re.fullmatch(r"#[0-9a-fA-F]{6}", col):
+        col = ""                                   # not a palette hex → let the backend hash one
     tsid = str(uuid.uuid4())
     row = {"tid": tsid, "sid": tsid, "anchorUuid": str(anchor_uuid), "cutUuid": cut,
            "anchorT": cut_t,   # the commented message's own time — the timeline square's x
@@ -5173,10 +5179,12 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", eff
         if not nm:
             nm = "%s-comment-%d" % (sess["name"], len(data.get("threads") or []) + 1)
         row["name"] = nm
+        if col:
+            row["color"] = col                     # the comment's identity color (the dialog's name tint)
         data.setdefault("threads", []).append(row)
         _save_comments(parent_sid, data)
     try:
-        be.fork(nm, parent_sid, cut, sid=tsid, thread_of=parent_sid,
+        be.fork(nm, parent_sid, cut, bg=col, fg=("#ffffff" if col else ""), sid=tsid, thread_of=parent_sid,
                 model=str(model or ""), effort=str(effort or ""))
         be.connect(tsid)
         be.send(tsid, _comment_first_message(exact, text))
@@ -6193,7 +6201,8 @@ def _drive(msg, client):
         # guess) and the fresh {type:"comments"} frame rides straight back, ahead of the pusher cycle.
         err, tid = _comment_create(sid, str(msg["uuid"]), str(msg["exact"]), str(msg["text"]),
                                    name=str(msg.get("name") or ""),
-                                   model=str(msg.get("model") or ""), effort=str(msg.get("effort") or ""))
+                                   model=str(msg.get("model") or ""), effort=str(msg.get("effort") or ""),
+                                   color=str(msg.get("color") or ""))
         if err:
             client["send"](json.dumps({"type": "warn", "text": err}))
         else:
@@ -24207,7 +24216,14 @@ class Handler(BaseHTTPRequestHandler):
                     "palettes": [{"name": k, "label": v["label"], "colors": v["bg"]}
                                  for k, v in pal.PALETTES.items()]}), "application/json", cache="no-cache")
             if p == "/models":                                # the ONE model + effort choice list — chat statusline, timeline lanes, AND judge settings all read it (the user 2026-07-02: no hardcoding in multiple places)
-                return self._send(200, json.dumps({"models": MODEL_CHOICES, "efforts": EFFORT_CHOICES}), "application/json", cache="no-cache")
+                # each choice carries its colormap tint (the user 2026-08-17: the new-comment dialog's
+                # selectors wear the same colors the statusline badges do, for ANY pick — the badge
+                # colors only cover the current value, so the list is where the shared tint belongs)
+                _stops = cm.stops_for(_colormap())
+                return self._send(200, json.dumps(
+                    {"models": [dict(c, color=_model_color(c["value"], _stops)) for c in MODEL_CHOICES],
+                     "efforts": [dict(c, color=_effort_color(c["value"], _stops)) for c in EFFORT_CHOICES]}),
+                    "application/json", cache="no-cache")
             if p == "/usage":                                 # the /usage rate-limit bars, re-read on demand: the rail's
                 # usage widget is click-to-refresh (the user 2026-06-30). Returns the freshest on-disk snapshot
                 # NOW, and (2026-07-02) also pokes one live SDK session for an exact get_usage snapshot — the

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -403,6 +403,7 @@ class FakeBackend:
              model="", effort=""):
         self.calls.append(("fork", name, parent_sid, cut_uuid, sid, thread_of))
         self.forked_meta = (model, effort)
+        self.forked_bg = bg
         return sid
 
     def connect(self, sid):
@@ -486,6 +487,31 @@ class CommentOps(CommentBase):
         self.assertEqual(self.be.forked_meta, ("haiku", "low"))
         km._comment_create(PARENT, "a1", "the cap", "Plain.")
         self.assertEqual(self.be.forked_meta, ("", ""), "no pick = inherit; the parent is never touched")
+
+    def test_the_comments_identity_color_rides_create_fork_row_and_frame(self):
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?", color="#a3be8c")
+        self.assertEqual(self.be.forked_bg, "#a3be8c")
+        self.assertEqual(km._comment_thread(PARENT, tid)["color"], "#a3be8c")
+        self.assertEqual(km._comments_frame(PARENT)["threads"][0]["color"], "#a3be8c")
+        _, tid2 = km._comment_create(PARENT, "a1", "the cap", "Junk color.", color="not-a-hex")
+        self.assertEqual(self.be.forked_bg, "", "a non-hex color falls to the backend's own pick")
+        self.assertNotIn("color", km._comment_thread(PARENT, tid2))
+
+    def test_a_harness_task_notification_never_renders_as_the_users_words(self):
+        recs = self._parent_records()
+        t = self.now - 200
+        recs += [uline(t, km._comment_first_message("exponential backoff", "Why?"), "cu1", parent="a2"),
+                 uline(t + 5, "<task-notification>\n<task-id>b1</task-id>\n<status>stopped</status>"
+                       "\n</task-notification>", "tn1", parent="cu1"),
+                 aline(t + 10, "Because herds.", "ca1", parent="tn1")]
+        self._write(THREAD, recs)
+        (jd.SDKDIR / (THREAD + ".json")).write_text(json.dumps(
+            {"sid": THREAD, "name": "t", "cwd": self.cdir, "lastSid": THREAD,
+             "alive": True, "threadOf": PARENT}))
+        msgs = km._thread_messages(THREAD, "a2")
+        self.assertEqual([m["who"] for m in msgs], ["you", "agent"],
+                         "the harness notice is for the AGENT, not a popover bubble")
+        self.assertNotIn("task-notification", json.dumps(msgs))
 
     def test_a_refused_cut_leaves_no_thread_row_behind(self):
         err, tid = km._comment_create(PARENT, "missing-uuid", "text", "comment")

--- a/tests/test_kernel_judge_model.py
+++ b/tests/test_kernel_judge_model.py
@@ -64,7 +64,8 @@ class JudgeSettings(unittest.TestCase):
     def test_models_endpoint_serves_the_shared_lists(self):
         ksrc = inspect.getsource(km)
         self.assertIn('if p == "/models":', ksrc)
-        self.assertIn('"models": MODEL_CHOICES, "efforts": EFFORT_CHOICES', ksrc)
+        # the shared lists, each choice carrying its colormap tint (the user 2026-08-17)
+        self.assertIn('{"models": [dict(c, color=_model_color(c["value"], _stops)) for c in MODEL_CHOICES]', ksrc)
 
     # ---- per-tier overrides honored + validated ----
     def test_overrides_are_honored(self):

--- a/tests/test_shell_mobile_composer_pad.py
+++ b/tests/test_shell_mobile_composer_pad.py
@@ -43,9 +43,9 @@ class MobileComposerPadding(unittest.TestCase):
 
     def test_the_buttons_are_in_flow_flex_rounded_squares(self):
         self.assertIn(
-            "#composer-attach, #composer-send {\n"
+            "#composer-attach, #composer-send, .cmt-attach, .cmt-send {\n"
             "  flex: 0 0 auto; width: calc(1.4 * var(--fs) + 18px); "
-            "height: calc(1.4 * var(--fs) + 18px); border-radius: 10px;", STYLES)
+            "height: calc(1.4 * var(--fs) + 18px); border-radius: 10px;", STYLES)   # the comment popover shares the rule (2026-08-17)
 
 
 if __name__ == "__main__":

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -137,7 +137,7 @@ test("a comments frame refreshes the open popover IN PLACE — composer and care
 });
 
 test("the popover send acknowledges before any round-trip", () => {
-  assert.match(UI, /send\.disabled = true; send\.textContent = "Commenting…"; \}\s+\/\/ ack before the round-trip/);
+  assert.match(UI, /send\.disabled = true; send\.classList\.add\("busy"\); \}\s+\/\/ ack before the round-trip/);
   assert.match(UI, /the pending bubble IS the acknowledgement/);
 });
 
@@ -216,12 +216,15 @@ test("a thread fork withholds the names/ entry; promote seeds first, then regist
   assert.match(KERNEL, /err = _seed_fork_stores\(parent_sid, tsid, parent_path, str\(th\.get\("cutUuid"\) or ""\)\)/);
 });
 
-test("the popover drags by its header and closes when you leave the session", () => {
-  assert.match(UI, /head\.addEventListener\("pointerdown"/);
-  assert.match(UI, /head\.setPointerCapture\(ev\.pointerId\)/);
+test("the WHOLE popover drags — grip anywhere that isn't a control — and closes on tab switch", () => {
+  assert.match(UI, /pop\.addEventListener\("pointerdown"/);
+  assert.match(UI, /pop\.setPointerCapture\(ev\.pointerId\)/);
+  assert.match(UI, /ev\.clientX > pr\.right - 18 && ev\.clientY > pr\.bottom - 18\) return;/);
+  assert.match(CSS, /\.cmt-pop \{[^}]*resize: both/s);
+  assert.match(CSS, /\.cmt-pop\.sized \.cmt-quote \{/, "a user resize hands the room to the quoted context");
   assert.match(UI, /commentPopPos = \{ x, y \};/);
   assert.match(UI, /if \(openCommentKey && openCommentKey\.sid !== id\) closeCommentPop\(\);/);
-  assert.match(CSS, /\.cmt-head \{[^}]*cursor: grab/s);
+  assert.match(CSS, /\.cmt-pop \{[^}]*cursor: grab/s, "the grab hand covers the whole box now");
 });
 
 test("marks use the prefix-tolerant anchor matcher", () => {
@@ -248,8 +251,8 @@ test("the create dialog names the thread right there: prefilled <session>-commen
   // the name lives IN the header ("New comment: <name>"), the button says Comment, and the picks ride along
   assert.match(UI, /"New comment:"/);
   assert.match(UI, /if \(nameBox\) head\.append\(title, nameBox, closeBtn\);/);
-  assert.match(UI, /send\.textContent = create \? "Comment" : "Send";/);
-  assert.match(UI, /text, name: nm, model: create\.model \|\| "", effort: create\.effort \|\| ""/);
+  assert.match(UI, /send\.setAttribute\("aria-label", create \? "Comment" : "Send"\);/);   // the ➤ carries the word
+  assert.match(UI, /text, name: nm, model: create\.model \|\| "", effort: create\.effort \|\| "",\s*\n\s*color: create\.color \|\| ""/);
   // the comment's own model/effort selectors reuse the statusline's /models-fed choices + menu skin
   assert.match(UI, /const metaRow = el\("div", "cmt-meta-row"\);/);
   assert.match(UI, /META_CHOICES\[kind\]/);

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -10,6 +10,7 @@ export type CommentMsg = { who: "you" | "agent"; text: string; t: number };
 export type CommentThread = {
   tid: string;
   name?: string;              // the thread's editable name (<session>-comment-<N> by default)
+  color?: string;             // the comment's identity color — picked distinct from its parent's
   anchorUuid: string;
   exact: string;
   status: "open" | "resolved" | "promoting" | "promoted";

--- a/ui/webview/composer-buttons.test.ts
+++ b/ui/webview/composer-buttons.test.ts
@@ -22,16 +22,16 @@ test("the composer is a flex row with the buttons seated at the bottom", () => {
 });
 
 test("flex order puts the paperclip LEFT of the input and send on its right", () => {
-  assert.match(CSS, /#composer-attach \{ color: var\(--accent\); opacity: 0\.8; order: 1; \}/);
+  assert.match(CSS, /#composer-attach, \.cmt-attach \{ color: var\(--accent\); opacity: 0\.8; order: 1; \}/);   // the comment popover clip shares the rule (2026-08-17)
   assert.match(CSS, /#composer-input \{\s*\n\s*order: 2; flex: 1 1 auto; min-width: 0;/);
-  assert.match(CSS, /#composer-send \{ order: 3; \}/);
+  assert.match(CSS, /#composer-send, \.cmt-send \{ order: 3; \}/);
 });
 
 test("the two buttons are the SAME rounded square, as tall as the one-line box — by arithmetic", () => {
   // the size is the input's min-height formula written against var(--fs): em on the button would key on
   // its larger glyph font and drift taller than the box (the user 2026-07-30, round 2: smaller, rounded
   // rectangle, matching the resting box height)
-  const m = CSS.match(/#composer-attach, #composer-send \{\s*\n\s*flex: 0 0 auto; width: (calc\(1\.4 \* var\(--fs\) \+ 18px\)); height: (calc\(1\.4 \* var\(--fs\) \+ 18px\)); border-radius: 10px;/);
+  const m = CSS.match(/#composer-attach, #composer-send, \.cmt-attach, \.cmt-send \{\s*\n\s*flex: 0 0 auto; width: (calc\(1\.4 \* var\(--fs\) \+ 18px\)); height: (calc\(1\.4 \* var\(--fs\) \+ 18px\)); border-radius: 10px;/);
   assert.ok(m, "the shared sizing rule is missing");
   assert.equal(m![1], m![2], "width must equal height — a square, not a bar");
   // ...and the input's own floor uses the SAME formula (1.4em at the input's font IS 1.4 * --fs)
@@ -46,7 +46,7 @@ test("the corner-overlay geometry is gone for good", () => {
 });
 
 test("a coarse pointer gets 40px rounded squares, matching the 40px one-line box", () => {
-  assert.match(coarse, /#composer-attach, #composer-send \{ width: 40px; height: 40px; border-radius: 12px; \}/);
+  assert.match(coarse, /#composer-attach, #composer-send, \.cmt-attach, \.cmt-send \{ width: 40px; height: 40px; border-radius: 12px; \}/);
   // and the resting box is ONE line — the pill — not the old two-line floor
   assert.match(coarse, /#composer-input \{ min-height: 40px; border-radius: 20px; padding: 10px 14px; \}/);
   assert.doesNotMatch(CSS, /min-height: calc\(2\.8em/);

--- a/ui/webview/composer-files.test.ts
+++ b/ui/webview/composer-files.test.ts
@@ -39,7 +39,9 @@ test("every file arrival becomes an attachment, never raw path text in the box",
   // paste-with-files and the host round-trip (dropped bytes, 📎 dialog, phone picker) too — the
   // paste's path branch is gated on LOCAL ownership (composer-attach.test.ts owns the remote rule)
   assert.match(RENDER, /if \(p && !hostOf\(activeId \|\| ""\)\) addComposerFile\(activeId, p\);\s*\n\s*else shipFileToHost\(f\);/);
-  assert.match(RENDER, /m\.type === "droppedPath" && typeof m\.path === "string"\) \{[\s\S]{0,300}addComposerFile\(owner, m\.path\);/);
+  // the window spans the popover-owned branch first (an open comment popover claims its own
+  // clip's ack; the COMPOSER path below it still always lands as an attachment)
+  assert.match(RENDER, /m\.type === "droppedPath" && typeof m\.path === "string"\) \{[\s\S]{0,900}addComposerFile\(owner, m\.path\);/);
   // the old insert-at-cursor path is gone with its last caller
   assert.doesNotMatch(RENDER, /function insertComposerText/);
 });

--- a/ui/webview/composer-icons.test.ts
+++ b/ui/webview/composer-icons.test.ts
@@ -33,6 +33,6 @@ test("the statusline directory shows a monochrome folder icon (folderIcon), not 
 test("the paperclip and send glyphs wear the romp accent blue (the user 2026-07-15)", () => {
   // action affordances (not status), so var(--accent) is the intended use — currentColor on the paperclip SVG
   // then picks up the accent tint from the button color
-  assert.match(CSS, /#composer-attach \{ color: var\(--accent\)/);   // the offset moved to the sizing block (2026-07-29)
-  assert.match(CSS, /#composer-send:not\(:disabled\) \{ color: var\(--accent\)/);
+  assert.match(CSS, /#composer-attach, \.cmt-attach \{ color: var\(--accent\)/);   // the offset moved to the sizing block (2026-07-29); the comment popover's clip shares the rule (2026-08-17)
+  assert.match(CSS, /#composer-send:not\(:disabled\), \.cmt-send:not\(:disabled\) \{ color: var\(--accent\)/);
 });

--- a/ui/webview/composer-send.test.ts
+++ b/ui/webview/composer-send.test.ts
@@ -67,8 +67,8 @@ test("the send button is disabled on a closed (read-only) session", () => {
 test("send sits on the input's right, the paperclip on its left — flex order, not offsets", () => {
   // re-laid 2026-07-30 as the Signal-style compose row; the circle sizing and the touch layout live in
   // composer-buttons.test.ts
-  assert.match(CSS, /#composer-attach \{ color: var\(--accent\); opacity: 0\.8; order: 1; \}/);
-  assert.match(CSS, /#composer-send \{ order: 3; \}/);
+  assert.match(CSS, /#composer-attach, \.cmt-attach \{ color: var\(--accent\); opacity: 0\.8; order: 1; \}/);
+  assert.match(CSS, /#composer-send, \.cmt-send \{ order: 3; \}/);
 });
 
 test("the composer sits tight to the bottom — no wasted gap below it (the user 2026-06-23)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5312,9 +5312,22 @@ const commentPending = new Map<string, { text: string; t: number }[]>(); // tid 
 const commentDrafts = new Map<string, string>();                    // draft key → unsent popover text
 let openCommentKey: { sid: string; tid: string } | null = null;     // the open thread popover
 let pendingCommentAnchor: { sid: string; uuid: string; exact: string;
-  model?: string; effort?: string } | null = null; // create mode (+ the thread's own model/effort picks)
+  model?: string; effort?: string; color?: string } | null = null; // create mode (+ the thread's own picks)
 let pendingAdoptTid: string | null = null;                          // commentCreated ack that beat its frame
 let commentPopPos: { x: number; y: number } | null = null;
+
+// the popover's own file picker (the user 2026-08-17: the attach clip, like the chat's) — files
+// ship through the SAME dropFile flow; the droppedPath ack sees the open popover and lands there
+const cmtFilePicker = document.createElement("input");
+cmtFilePicker.type = "file";
+cmtFilePicker.multiple = true;
+cmtFilePicker.style.display = "none";
+cmtFilePicker.addEventListener("change", () => {
+  const sid = pendingCommentAnchor?.sid || openCommentKey?.sid || activeId;
+  Array.from(cmtFilePicker.files || []).forEach((f) => shipFileToHost(f, sid));
+  cmtFilePicker.value = "";
+});
+document.body.appendChild(cmtFilePicker);
 
 function closeCommentPop(): void {
   document.getElementById("cmt-pop")?.remove();
@@ -5486,8 +5499,21 @@ function styleCommentMark(m: HTMLElement, th: CommentThread): void {
     : "thread: click to open";
 }
 
+/** The comment's identity color (the user 2026-08-17): one of the session palette's colors,
+ *  DISTINCT from the parent session's and, where the palette allows, from every open tab's —
+ *  the same standing-out rule _pick_identity_color applies to new sessions, decided client-side
+ *  so the dialog can wear it before the thread exists. */
+function pickThreadColor(sid: string): string {
+  const parent = (sessions.get(sid)?.color?.bg || "").toLowerCase();
+  const worn = new Set<string>();
+  sessions.forEach((se) => { const c = (se.color?.bg || "").toLowerCase(); if (c) worn.add(c); });
+  (commentThreads.get(sid) || []).forEach((t) => { if (t.color) worn.add(t.color.toLowerCase()); });
+  const free = paletteColors.find((c) => !worn.has(c.toLowerCase()) && c.toLowerCase() !== parent);
+  return free || paletteColors.find((c) => c.toLowerCase() !== parent) || "#e8b220";
+}
+
 function openCommentComposer(sid: string, uuid: string, exact: string, x: number, y: number): void {
-  pendingCommentAnchor = { sid, uuid, exact };
+  pendingCommentAnchor = { sid, uuid, exact, color: pickThreadColor(sid) };
   openCommentKey = null;
   commentPopPos = { x, y };
   renderCommentPopover();
@@ -5588,10 +5614,11 @@ function commentSendFromPop(pop: HTMLElement): void {
     const nameBox = pop.querySelector(".cmt-name") as HTMLInputElement | null;
     const nm = (nameBox?.value || "").trim();
     if (nm && !/^[A-Za-z0-9._-]+$/.test(nm)) { nameBox?.classList.add("bad"); nameBox?.focus(); return; }
-    if (send) { send.disabled = true; send.textContent = "Commenting…"; }   // ack before the round-trip;
-    //                                       the draft survives until commentCreated adopts the thread
+    if (send) { send.disabled = true; send.classList.add("busy"); }   // ack before the round-trip (the ➤
+    //                                       dims); the draft survives until commentCreated adopts the thread
     vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact,
-      text, name: nm, model: create.model || "", effort: create.effort || "" });
+      text, name: nm, model: create.model || "", effort: create.effort || "",
+      color: create.color || "" });
     return;
   }
   const cur = openCommentThread();
@@ -5640,6 +5667,7 @@ function renderCommentPopover(): void {
   const head = el("div", "cmt-head");
   const title = el("span", "cmt-title");
   title.textContent = commentPopTitle(!!create, th);
+  if (th?.color) title.style.color = th.color;   // an existing thread's title wears its identity color
   let nameBox: HTMLInputElement | null = null;
   if (create) {
     // the name lives IN the header — "New comment: <name>" — bold and editable right there (the
@@ -5657,6 +5685,7 @@ function renderCommentPopover(): void {
       || ((sess0?.name || "session").replace(/[^A-Za-z0-9._-]/g, "-")
           + "-comment-" + ((commentThreads.get(sid) || []).length + 1));
     nameBox.title = "The comment's name — edit it right here";
+    if (create.color) nameBox.style.color = create.color;   // its identity color, distinct from the parent's
     const nb = nameBox;
     nb.addEventListener("input", () => { nb.classList.remove("bad"); commentDrafts.set(nk, nb.value); });
   }
@@ -5672,12 +5701,17 @@ function renderCommentPopover(): void {
   // rebuild (a status flip) reopens where the user parked it. The header survives in-place
   // refreshes, so a drag is never cut by a comments frame; a full rebuild mid-drag just ends it.
   head.title = "Drag to move";
-  head.addEventListener("pointerdown", (ev: PointerEvent) => {
-    if ((ev.target as HTMLElement).closest(".cmt-x, .cmt-name")) return;   // editing the name is not a drag
+  // the WHOLE box drags (the user 2026-08-17), not just the header — any grip that isn't an
+  // interactive control or selectable text, and never the bottom-right resize corner
+  pop.addEventListener("pointerdown", (ev: PointerEvent) => {
+    const t = ev.target as HTMLElement;
+    if (t.closest(".cmt-x, .cmt-name, .cmt-input, .cmt-msgs, .cmt-quote, button, input, textarea, .meta-btn, .meta-menu")) return;
+    const pr = pop.getBoundingClientRect();
+    if (ev.clientX > pr.right - 18 && ev.clientY > pr.bottom - 18) return;   // the resize handle's corner
     ev.preventDefault();
     const dx = ev.clientX - pop.offsetLeft, dy = ev.clientY - pop.offsetTop;
-    head.setPointerCapture(ev.pointerId);
-    head.classList.add("dragging");
+    pop.setPointerCapture(ev.pointerId);
+    pop.classList.add("dragging");
     const move = (mv: PointerEvent) => {
       const x = Math.max(4, Math.min(mv.clientX - dx, window.innerWidth - pop.offsetWidth - 4));
       const y = Math.max(4, Math.min(mv.clientY - dy, window.innerHeight - 40));
@@ -5686,14 +5720,14 @@ function renderCommentPopover(): void {
       commentPopPos = { x, y };
     };
     const up = () => {
-      head.classList.remove("dragging");
-      head.removeEventListener("pointermove", move);
-      head.removeEventListener("pointerup", up);
-      head.removeEventListener("pointercancel", up);
+      pop.classList.remove("dragging");
+      pop.removeEventListener("pointermove", move);
+      pop.removeEventListener("pointerup", up);
+      pop.removeEventListener("pointercancel", up);
     };
-    head.addEventListener("pointermove", move);
-    head.addEventListener("pointerup", up);
-    head.addEventListener("pointercancel", up);
+    pop.addEventListener("pointermove", move);
+    pop.addEventListener("pointerup", up);
+    pop.addEventListener("pointercancel", up);
   });
   pop.appendChild(head);
   const quote = el("div", "cmt-quote");
@@ -5705,6 +5739,7 @@ function renderCommentPopover(): void {
     fillCommentMsgs(list, th);
     pop.appendChild(list);
   }
+  let metaRowPending: HTMLElement | null = null;   // appended under the composer row — the statusline position
   if (create) {
     // the thread's OWN model + effort (the user 2026-08-17): the same /models-fed choices the
     // chat's statusline selectors use, defaulting to what this session runs now — picking one
@@ -5712,14 +5747,18 @@ function renderCommentPopover(): void {
     const st = sessions.get(sid)?.status;
     const metaRow = el("div", "cmt-meta-row");
     const mkSel = (kind: "model" | "effort") => {
-      const btn = el("button", "cmt-meta") as HTMLButtonElement;
-      btn.type = "button";
+      // the statusline's own badge chrome (.meta-btn/.meta-label/.meta-caret) so the two stay in
+      // sync by construction (the user 2026-08-17), tinted from the /models list's shared colors
+      const btn = el("span", "meta-btn cmt-meta") as HTMLElement;
       const chosen = kind === "model" ? create.model : create.effort;
-      const inherit = kind === "model" ? (st?.model || "Default") : (st?.effort || "default");
-      const label = chosen
-        ? (META_CHOICES[kind].find((c) => c.value === chosen)?.label || chosen)
-        : inherit;
-      btn.textContent = (kind === "model" ? "Model: " : "Effort: ") + label;
+      const choice = chosen ? META_CHOICES[kind].find((c) => c.value === chosen) : null;
+      const label = el("span", "meta-label");
+      label.textContent = choice ? choice.label : (kind === "model" ? (st?.model || "Default") : (st?.effort || "default"));
+      const tint = choice?.color || (kind === "model" ? st?.modelColor : st?.effortColor);
+      if (tint && tint.length === 3) label.style.color = `rgb(${tint[0]},${tint[1]},${tint[2]})`;
+      const caret = el("span", "meta-caret");
+      caret.textContent = "▾";
+      btn.append(label, caret);
       btn.title = chosen ? "the comment runs on its own " + kind + "; this session keeps its"
         : "inherits this session's " + kind + " — click to pick another for the comment only";
       btn.addEventListener("click", (e) => {
@@ -5748,7 +5787,7 @@ function renderCommentPopover(): void {
       return btn;
     };
     metaRow.append(mkSel("model"), mkSel("effort"));
-    pop.appendChild(metaRow);
+    metaRowPending = metaRow;
   }
   if (create || th!.status !== "promoted") {
     const dk = create ? "new:" + create.uuid : th!.tid;
@@ -5763,13 +5802,25 @@ function renderCommentPopover(): void {
       if (ev.key === "Enter" && !ev.shiftKey) { ev.preventDefault(); commentSendFromPop(pop); }
       else if (ev.key === "Escape") { ev.stopPropagation(); closeCommentPop(); }
     });
-    pop.appendChild(box);
-    const row = el("div", "cmt-actions");
+    const crow = el("div", "cmt-composer");   // the chat composer's shape: clip left, ➤ right
+    const attach = el("button", "cmt-attach") as HTMLButtonElement;
+    attach.type = "button";
+    attach.title = "Attach a file";
+    attach.innerHTML = '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" '
+      + 'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'
+      + '<path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66'
+      + 'l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>';
+    attach.addEventListener("click", (e) => { e.preventDefault(); e.stopPropagation(); cmtFilePicker.click(); });
     const send = el("button", "cmt-send") as HTMLButtonElement;
     send.type = "button";
-    send.textContent = create ? "Comment" : "Send";
+    send.textContent = "➤";
+    send.title = create ? "Comment (Enter)" : "Send (Enter)";
+    send.setAttribute("aria-label", create ? "Comment" : "Send");
     send.dataset.act = "cmtsend";
-    row.appendChild(send);
+    crow.append(attach, box, send);
+    pop.appendChild(crow);
+    if (metaRowPending) pop.appendChild(metaRowPending);   // model/effort under the box, like the chat
+    const row = el("div", "cmt-actions");
     if (th) {
       const br = el("button", "cmt-act") as HTMLButtonElement;
       br.type = "button";
@@ -5806,6 +5857,15 @@ function renderCommentPopover(): void {
     pop.appendChild(row);
   }
   document.body.appendChild(pop);
+  if (typeof ResizeObserver === "function") {
+    // resizing the BOX (resize: both) hands the extra room to the quoted context: the .sized class
+    // unlocks the quote's clamp; armed only after a real user resize, so the natural size stays tight
+    const w0 = pop.offsetWidth, h0 = pop.offsetHeight;
+    const ro = new ResizeObserver(() => {
+      if (Math.abs(pop.offsetWidth - w0) > 6 || Math.abs(pop.offsetHeight - h0) > 6) pop.classList.add("sized");
+    });
+    ro.observe(pop);
+  }
   const r = pop.getBoundingClientRect();
   const px = Math.max(8, Math.min(commentPopPos?.x ?? (window.innerWidth - r.width) / 2, window.innerWidth - r.width - 8));
   const py = Math.max(8, Math.min(commentPopPos?.y ?? 120, window.innerHeight - r.height - 8));
@@ -7949,13 +8009,13 @@ function elapsedMs(sinceMs: number | null): string {
 type MetaKind = "mode" | "model" | "effort" | "fast";
 // One dropdown entry. `sub` is the second line for a choice whose consequence is not obvious from its
 // label; `sdkOnly` drops the entry on a tmux session, whose backend cannot apply it.
-interface MetaChoice { label: string; value: string; sub?: string; sdkOnly?: boolean }
+interface MetaChoice { label: string; value: string; sub?: string; sdkOnly?: boolean; color?: number[] | null }
 // Model + effort choices come from the kernel's /models — the ONE list shared with the timeline lanes and the
 // judge-tier settings (the user 2026-07-02, who wanted one shared code path, not hardcoded in multiple places), so
 // the client holds no model literals (mirrors paletteColors above). Populated in place on load so META_CHOICES
 // keeps its reference; the session picker appends its own "Default" (use-the-CLI-default) sentinel — not a model.
-const MODEL_CHOICES: { label: string; value: string }[] = [];
-const EFFORT_CHOICES: { label: string; value: string }[] = [];
+const MODEL_CHOICES: { label: string; value: string; color?: number[] | null }[] = [];
+const EFFORT_CHOICES: { label: string; value: string; color?: number[] | null }[] = [];
 fetch(kernelUrl("/models"), { cache: "no-store" }).then((r) => r.json()).then((d) => {
   if (Array.isArray(d.models)) { MODEL_CHOICES.length = 0; MODEL_CHOICES.push(...d.models, { label: "Default", value: "default" }); }
   if (Array.isArray(d.efforts)) { EFFORT_CHOICES.length = 0; EFFORT_CHOICES.push(...d.efforts); }
@@ -9764,6 +9824,15 @@ window.addEventListener("message", (e: MessageEvent) => {
     if (s && s.name !== m.name) { s.name = m.name; renderTabs(); }
   }
   else if (m.type === "droppedPath" && typeof m.path === "string") {   // host-saved drop/paste/pick → a thumbnail, not path text (the user 2026-08-04)
+    const cbox = document.getElementById("cmt-pop")?.querySelector(".cmt-input") as HTMLTextAreaElement | null;
+    if (cbox) {
+      // a comment popover is open — its own clip shipped this file, so the path lands in ITS box
+      retirePendingShip(m.path);
+      cbox.value = (cbox.value ? cbox.value.trimEnd() + " " : "") + m.path + " ";
+      cbox.dispatchEvent(new Event("input"));   // the draft listener persists it
+      cbox.focus();
+      return;
+    }
     const owner = retirePendingShip(m.path) || activeId;               // the chip this ack answers names the OWNING composer (no-op for pickFile, which never ships)
     addComposerFile(owner, m.path);
     if (owner && sendOnShip.has(owner) && !(pendingShips.get(owner) || []).length) {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -666,7 +666,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    against var(--fs) — em here would key on the BUTTON's larger font and drift — so the pair tracks the
    resting box height by construction. In-flow flex items, not corner overlays: no offset arithmetic
    couples them to the composer's padding, and a peer's padding change can't strand them outside the box. */
-#composer-attach, #composer-send {
+#composer-attach, #composer-send, .cmt-attach, .cmt-send {
   flex: 0 0 auto; width: calc(1.4 * var(--fs) + 18px); height: calc(1.4 * var(--fs) + 18px); border-radius: 10px;
   padding: 0; line-height: 1;
   display: flex; align-items: center; justify-content: center;
@@ -675,11 +675,11 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 }
 /* the paperclip + send glyphs wear the romp accent blue (the user 2026-07-15) — action affordances, not
    status, so var(--accent) is the intended use; resting a touch dim, full on hover */
-#composer-attach { color: var(--accent); opacity: 0.8; order: 1; }   /* clip sits LEFT of the input */
-#composer-attach:hover, #composer-send:hover { opacity: 1; background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.08)); }
-#composer-send { order: 3; }                                         /* send on the input's right */
-#composer-send:not(:disabled) { color: var(--accent); opacity: 0.85; }   /* romp-blue send affordance */
-#composer-send:disabled { opacity: 0.3; cursor: not-allowed; }
+#composer-attach, .cmt-attach { color: var(--accent); opacity: 0.8; order: 1; }   /* clip sits LEFT of the input */
+#composer-attach:hover, #composer-send:hover, .cmt-attach:hover, .cmt-send:hover { opacity: 1; background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.08)); }
+#composer-send, .cmt-send { order: 3; }                              /* send on the input's right */
+#composer-send:not(:disabled), .cmt-send:not(:disabled) { color: var(--accent); opacity: 0.85; }   /* romp-blue send affordance */
+#composer-send:disabled, .cmt-send:disabled, .cmt-send.busy { opacity: 0.3; cursor: not-allowed; }
 #composer-input {
   order: 2; flex: 1 1 auto; min-width: 0;
   resize: none; box-sizing: border-box;
@@ -705,7 +705,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    messenger's send, the paperclip on a faint chip fill so both read as buttons. The resting box stays
    ONE line, like Signal's; the mobile placeholder is shortened to fit it (composerRestingPlaceholder). */
 @media (pointer: coarse) {
-  #composer-attach, #composer-send { width: 40px; height: 40px; border-radius: 12px; }
+  #composer-attach, #composer-send, .cmt-attach, .cmt-send { width: 40px; height: 40px; border-radius: 12px; }
   #composer-attach { font-size: 19px; background: rgba(255, 255, 255, 0.07); }
   #composer-send { font-size: 21px; }
   /* hover is included on purpose: a touch device can leave a sticky :hover that would otherwise
@@ -2468,6 +2468,8 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 
 .cmt-pop {
   position: fixed; z-index: 120; width: 360px; max-width: 94vw;
+  resize: both; overflow: auto; min-width: 300px; min-height: 120px; max-height: 90vh;
+  cursor: grab;                       /* the whole box drags (interactive children override below) */
   display: flex; flex-direction: column; gap: 6px; padding: 8px;
   background: var(--vscode-menu-background, #252526);
   color: var(--vscode-menu-foreground, var(--fg));
@@ -2475,8 +2477,7 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
   font-size: 12px;
 }
-.cmt-head { display: flex; align-items: center; cursor: grab; user-select: none; }
-.cmt-head.dragging { cursor: grabbing; }
+.cmt-head { display: flex; align-items: center; user-select: none; }
 .cmt-head .cmt-x { cursor: pointer; }
 .cmt-title { font-weight: 600; }
 .cmt-x {
@@ -2490,6 +2491,14 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
   font-size: 0.92em; opacity: 0.75;
   display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
 }
+.cmt-pop.dragging { cursor: grabbing; }
+.cmt-pop .cmt-quote, .cmt-pop .cmt-msgs, .cmt-pop .cmt-input, .cmt-pop .cmt-name { cursor: auto; }
+.cmt-pop button, .cmt-pop .meta-btn { cursor: pointer; }
+/* user-resized (.sized): the quoted context takes the extra room — its clamp unlocks and it flexes */
+.cmt-pop.sized .cmt-quote {
+  display: block; -webkit-line-clamp: unset; flex: 1 1 auto; min-height: 3em; overflow-y: auto;
+}
+.cmt-pop.sized .cmt-msgs { flex: 2 1 auto; max-height: none; }
 .cmt-msgs { max-height: 45vh; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; }
 .cmt-msg { padding: 5px 8px; border-radius: 6px; line-height: 1.35; overflow-wrap: anywhere; }
 .cmt-msg.you { background: color-mix(in srgb, var(--accent) 14%, transparent); align-self: flex-end; max-width: 92%; white-space: pre-wrap; }
@@ -2506,19 +2515,19 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .cmt-dots span:nth-child(3) { animation-delay: 0.4s; }
 @keyframes cmt-dot-pulse { 0%, 100% { opacity: 0.25; } 50% { opacity: 1; } }
 .cmt-note { font-size: 0.92em; opacity: 0.7; padding: 2px 6px; }
+/* the popover's message row mirrors the CHAT composer (the user 2026-08-17): clip left, ➤ right,
+   pill input — the attach/send buttons share the chat's own selectors above, so they stay in sync */
+.cmt-composer { display: flex; align-items: flex-end; gap: 4px; }
 .cmt-input {
-  width: 100%; box-sizing: border-box; resize: vertical; min-height: 34px;
-  padding: 5px 7px; border: 1px solid var(--box-border); border-radius: 4px;
-  background: rgba(255, 255, 255, 0.05); color: inherit;
+  order: 2; flex: 1 1 auto; min-width: 0; box-sizing: border-box; resize: vertical; min-height: 34px;
+  padding: 6px 12px; border: 1px solid var(--vscode-input-border, var(--box-border));
+  border-radius: 16px;
+  background: var(--vscode-input-background, rgba(255, 255, 255, 0.05)); color: inherit;
   font: inherit;
 }
 .cmt-input:focus { outline: none; border-color: var(--accent); }
 .cmt-actions { display: flex; gap: 6px; align-items: center; }
-.cmt-send {
-  padding: 3px 10px; border: 0; border-radius: 4px; cursor: pointer;
-  background: var(--accent); color: var(--accent-fg); font: inherit; font-weight: 600;
-}
-.cmt-send:disabled { opacity: 0.55; cursor: default; }
+.cmt-actions:empty { display: none; }
 .cmt-act {
   padding: 3px 8px; border: 1px solid var(--box-border); border-radius: 4px; cursor: pointer;
   background: none; color: inherit; font: inherit; opacity: 0.85;


### PR DESCRIPTION
Dialog refinements from live use, round three:

- **The name wears an identity color** — picked from the session palette, distinct from the parent session's color and from every visible tab's (the client-side twin of `_pick_identity_color`'s standing-out rule), never the accent blue. The color rides `commentCreate` → `fork(bg=…)` → the store row → the comments frame, so the thread's reg carries it (a break-out session wears it) and the popover title tints with it thereafter.
- **Whole-box drag + resize** — the grab hand and dragging work from anywhere that isn't a control, selectable text, or the resize corner; `resize: both` on the popover, and a user resize adds the room to the quoted context (a ResizeObserver flips `.sized`, unlocking the quote's three-line clamp into a flexing scroller).
- **The chat's own composer** — paperclip left, ➤ send right, pill input. The attach/send styling is the chat's own rules with extended selectors (`#composer-attach, .cmt-attach { … }` and friends, touch sizing included), so the surfaces stay in sync by construction. The clip ships files through the same `dropFile` flow; the `droppedPath` ack sees the open popover and lands the path in its box (the composer path is untouched — pinned). Model/effort sit under the input as the statusline's `.meta-btn` chips; `/models` now ships each choice's colormap tint, so any pick colors consistently everywhere.
- **Task-notification filter** — a parent background task dying with the fork produced a `<task-notification>` block rendered as the user's own popover message (screenshot); the projection now drops those (they are addressed to the thread's agent, who still sees them).

Tests: identity-color ride-through (create/fork/row/frame + non-hex fallback), the task-notification filter, `/models` tint shape, updated pins across the composer suites (extended selectors), whole-box drag/resize pins, and the payload pin. Suites green (pytest 4875, node 2046), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)