### PR TITLE
Scroll notches cover the whole loaded conversation, not just the DOM window

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1661,19 +1661,46 @@ function paintScrollMarks(): void {
   const box = ensureScrollMarks();
   const content = document.getElementById("content");
   const v = activeId ? views.get(activeId) : null;
-  if (!content || !v || v.el.style.display === "none") { box.style.display = "none"; scrollMarksSig = ""; return; }
+  const s = activeId ? sessions.get(activeId) : null;
+  if (!content || !v || !s || v.el.style.display === "none") { box.style.display = "none"; scrollMarksSig = ""; return; }
   const cRect = content.getBoundingClientRect();
   const sh = content.scrollHeight;
   if (!sh || cRect.height <= 40) { box.style.display = "none"; scrollMarksSig = ""; return; }
-  const turns: HTMLElement[] = [];
-  for (const t of Array.from(v.el.querySelectorAll<HTMLElement>(".turn-user:not(.romp):not(.injected)"))) {
-    // gestures (a /command row, the Continue row) are the user's DOINGS, not their words — no notch
-    if (t.querySelector(".user-bubble:not(.cmd-row):not(.cont-row)")) turns.push(t);
+  // The WHOLE loaded conversation gets notches, not just the rendered DOM window (the user
+  // 2026-08-17, who scrolled back and watched the newer messages' marks vanish): the chat
+  // virtualizes — a window of real turns between two spacers sized by the renderer's avg-height
+  // estimate, and the scrollbar spans that estimated whole. Notches use the SAME frame: a rendered
+  // event's true pixel offset (its data-unit node), and for events inside a spacer, a proportional
+  // slot within that spacer's MEASURED height — exactly as accurate as the scrollbar the user is
+  // reading them against, with no extra caching (the events array + the spacer model already exist).
+  const winStart = v.winStart ?? 0;
+  const winEnd = v.winEnd ?? s.events.length;
+  const unitTotal = v.unitTotal ?? s.events.length;
+  const topSp = v.el.querySelector<HTMLElement>(".tx-spacer-top");
+  const botSp = v.el.querySelector<HTMLElement>(".tx-spacer-bot");
+  const topH = topSp ? topSp.offsetHeight : 0;
+  const botH = botSp ? botSp.offsetHeight : 0;
+  const scrollTop = content.scrollTop;
+  const offs: number[] = [];
+  for (let i = 0; i < s.events.length; i++) {
+    const ev = s.events[i] as ChatEvent & { human?: boolean; romp?: boolean; rompAuto?: boolean; canned?: string; md?: string };
+    if (ev.kind !== "user" || !ev.human || ev.romp || ev.rompAuto) continue;
+    const md = (ev.md || "").trim();
+    // gestures are the user's DOINGS, not their words — no notch (the Continue row, a /command)
+    if (!md || ev.canned === "continue" || SLASH_CMD_RE.test(md)) continue;
+    let off: number | null = null;
+    if (i >= winStart && i < winEnd) {
+      const node = v.el.querySelector<HTMLElement>('.turn[data-unit="' + i + '"]');
+      if (node) off = node.getBoundingClientRect().top - cRect.top + scrollTop;
+    }
+    if (off == null) {
+      if (i < winStart && winStart > 0) off = topH * ((i + 0.5) / winStart);              // inside the top spacer
+      else if (i >= winEnd && unitTotal > winEnd) off = (sh - botH) + botH * ((i - winEnd + 0.5) / (unitTotal - winEnd));
+      else continue;                                   // window bookkeeping mid-update — skip this one, next paint has it
+    }
+    offs.push(off);
   }
-  const ys = turns.map((t) => {
-    const top = t.getBoundingClientRect().top - cRect.top + content.scrollTop;
-    return Math.round(((top / sh) * (cRect.height - 4)));
-  });
+  const ys = offs.map((top) => Math.round((top / sh) * (cRect.height - 4)));
   const sig = activeId + "|" + Math.round(cRect.top) + "," + Math.round(cRect.right) + ","
     + Math.round(cRect.height) + "|" + ys.join(",");
   if (sig !== scrollMarksSig) {

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -11,10 +11,19 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-test("one notch per real user message, none for gestures or romp turns", () => {
-  assert.match(RENDER, /querySelectorAll<HTMLElement>\(".turn-user:not\(\.romp\):not\(\.injected\)"\)/);
-  assert.match(RENDER, /t\.querySelector\("\.user-bubble:not\(\.cmd-row\):not\(\.cont-row\)"\)/,
+test("one notch per real user message across the WHOLE loaded conversation", () => {
+  // the user 2026-08-17: the chat virtualizes (a rendered window between two estimated-height
+  // spacers), and window-only notches "forgot" the newer messages when scrolled back. Notches now
+  // come from the full resident events array: true pixels for rendered turns, a proportional slot
+  // inside the MEASURED spacer for the rest — the same estimate the scrollbar itself stands on.
+  assert.match(RENDER, /for \(let i = 0; i < s\.events\.length; i\+\+\) \{/);
+  assert.match(RENDER, /if \(ev\.kind !== "user" \|\| !ev\.human \|\| ev\.romp \|\| ev\.rompAuto\) continue;/);
+  assert.match(RENDER, /ev\.canned === "continue" \|\| SLASH_CMD_RE\.test\(md\)/,
     "a /command or Continue gesture is a doing, not words — no notch");
+  assert.match(RENDER, /'\.turn\[data-unit="' \+ i \+ '"\]'/, "rendered events use their true pixel offset");
+  assert.match(RENDER, /off = topH \* \(\(i \+ 0\.5\) \/ winStart\);/, "top-spacer events slot proportionally");
+  assert.match(RENDER, /\(sh - botH\) \+ botH \* \(\(i - winEnd \+ 0\.5\) \/ \(unitTotal - winEnd\)\)/,
+    "bottom-spacer events too — aligned with the scrollbar's own spacer estimate");
 });
 
 test("a history load rescales the map smoothly — moved notches are carried, never teleported", () => {
@@ -27,7 +36,7 @@ test("a history load rescales the map smoothly — moved notches are carried, ne
 });
 
 test("positions are proportional and pure scrolls do no DOM work", () => {
-  assert.match(RENDER, /t\.getBoundingClientRect\(\)\.top - cRect\.top \+ content\.scrollTop/);
+  assert.match(RENDER, /node\.getBoundingClientRect\(\)\.top - cRect\.top \+ scrollTop/);
   assert.match(RENDER, /if \(sig !== scrollMarksSig\) \{/, "signature skip: rebuild only on real change");
   assert.match(RENDER, /paintRailSticky\(\); paintScrollMarks\(\);/, "rides the existing rAF scheduler");
 });


### PR DESCRIPTION
User follow-up on the scroll notches, with the correct diagnosis: they only showed messages inside the locally rendered window, so scrolling back "forgot" the newer messages' marks — misleading against a scrollbar that spans the whole loaded range.

The chat virtualizes: a window of real turns between two spacers sized by the renderer's average-height estimate, and the scrollbar's extent is exactly that estimated whole. The notch pass now walks the full resident events array instead of the DOM: a rendered event uses its true pixel offset (via its data-unit node), and an event inside a spacer takes a proportional slot within that spacer's measured height — the same estimate the scrollbar stands on, so notch and thumb share one frame and cannot disagree. The user's suggested caching turns out unnecessary: the events array plus the renderer's own spacer model already hold everything, at zero extra memory. Gesture exclusion (Continue rows, /commands) moves to event space — the canned marker and the slash shape — one uniform rule for rendered and unrendered alike, and the smooth-rescale carry from the previous fix applies to all of them.

Pins rewritten in scroll-marks.test.ts. UI suite + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)