### PR TITLE
A tunnel-down failure never spends the preview retry budget

### DIFF
--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -55,7 +55,7 @@ test("the failure chip narrates what happens next, escalates on repeat, and a re
   // while auto-retries remain the box KEEPS its loading persona (swirl + note, whole box tappable);
   // the ⚠ chip is the GIVE-UP state only (the user 2026-08-16, third report: state bouncing between
   // "trying" and "unavailable" on every retry cycle read as impatient even when it eventually loaded)
-  assert.match(pf, /if \(autoRetries > 0\) \{\s*\n\s*autoRetries--;\s*\n\s*failedPreviews\.set\(box, \(\) => build\(true\)\);/);
+  assert.match(pf, /if \(autoRetries > 0 \|\| transient\) \{\s*\n\s*if \(!transient\) autoRetries--;\s*\n\s*failedPreviews\.set\(box, \(\) => build\(true\)\);/);
   assert.match(pf, /\+ " — retrying · tap to retry now";/);
   assert.match(pf, /wait\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); autoRetries = 3; build\(true\); \};/,
     "the whole retrying box is the tap target — and a tap re-arms persistence");
@@ -79,7 +79,10 @@ test("a failed preview heals on the next kernel push — the kernel-is-back even
   // kernel is reachable again; no pushes arrive while it's down, so retry-on-push can't spam.
   const pf = PREVIEW.slice(PREVIEW.indexOf("export function previewFull"));
   assert.match(pf, /let autoRetries = 3;/, "bounded — a genuinely-dead file settles on the tap chip");
-  assert.match(pf, /if \(autoRetries > 0\) \{\s*\n\s*autoRetries--;\s*\n\s*failedPreviews\.set\(box, \(\) => build\(true\)\);/);
+  // a failure naming the LINK, not the image, never spends the budget (the user 2026-08-17: the
+  // kernel-restart tunnel window burned all three attempts right before the link came back)
+  assert.match(pf, /const transient = \/tunnel to \.\* is not answering\|no attached host\|re-dialing\/i\.test\(lastErr\);/);
+  assert.match(pf, /if \(autoRetries > 0 \|\| transient\) \{\s*\n\s*if \(!transient\) autoRetries--;\s*\n\s*failedPreviews\.set\(box, \(\) => build\(true\)\);/);
   assert.match(PREVIEW, /export function retryFailedPreviews\(\): void/);
   assert.match(PREVIEW, /if \(box\.isConnected\) rebuild\(\);/, "a re-rendered turn's fresh box supersedes the old");
   assert.match(RENDER, /retryFailedPreviews\(\);/, "called from the kernel message handler");

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -228,8 +228,15 @@ export function previewFull(path: string, sid?: string | null, verified = false,
       // failure and the plan ("dropped at 1.2 MB of 3.4 MB — retrying · tap to retry now"), the
       // whole box tappable — and the ⚠ chip appears only when the budget is genuinely spent. A
       // repeat failure must still READ as a response to a tap: the note re-pulses on swap-in.
-      if (autoRetries > 0) {
-        autoRetries--;
+      // INFRASTRUCTURE-DOWN failures are FREE (the user 2026-08-17: figures gave up seconds after a
+      // kernel restart — the tunnel re-dial window produces instant "no attached host" 404s and
+      // "tunnel not answering" 502s, and three of those spent the whole budget right before the link
+      // came back). A failure that names the LINK, not the image, doesn't decrement: the preview
+      // keeps retrying on every kernel push until the tunnel is up, and only real verdicts — a true
+      // not-found from the owning kernel, a transfer that died with zero progress — spend attempts.
+      const transient = /tunnel to .* is not answering|no attached host|re-dialing/i.test(lastErr);
+      if (autoRetries > 0 || transient) {
+        if (!transient) autoRetries--;
         failedPreviews.set(box, () => build(true));
         const wait = mkWait(box);
         wait.title = path + " — tap to retry now";


### PR DESCRIPTION
User report: fisher-info figures failing with "not found" then "connection dropped" right after a kernel restart, on reliable internet.

The restart opens a predictable tunnel re-dial window producing instant failures — 404 "no attached host" before the row re-attaches, 502 "tunnel to <host> is not answering" while it dials — and three of those spent the whole bounded retry budget seconds before the link came back, parking the give-up chip on images that were about to load.

A failure whose reason names the LINK rather than the image (the tunnel-down 502, the no-attached-host 404, the re-dialing state) is now budget-free: it registers for the kernel-push auto-heal without decrementing, so the preview retries patiently until the tunnel is actually up — each attempt also demand-dials it, from the earlier change — while the wait box keeps narrating the real reason. Only real verdicts spend attempts (a true not-found from the owning kernel, a transfer dead at zero progress), so a genuinely missing file still settles on the tap chip.

Pins updated in chat-inline-preview.test.ts (the transient classifier + both budget-spend sites). UI suite + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)