### PR TITLE
Comment popover: the chat's own renderer from the branch point; Resolve retired

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5075,7 +5075,40 @@ def _thread_messages(tsid, cut_uuid, floor_t=0):
     return merged
 
 
-def _comments_frame(sid):
+def _thread_events(tsid, cut_uuid, now, tmux):
+    """The thread rendered with the CHAT's own builder (the user 2026-08-17: the popover shows the
+    same thing the chat shows), sliced to AFTER the branch point: build_session on the thread sid
+    (reachable via _sdk_sess's reg fallback — no names/ entry), events after the cut record's, the
+    head system card never included (it sits before the cut by construction). [] pre-fork, same
+    guard as the plain projection."""
+    reg = _thread_reg(tsid)
+    if reg.get("forkOf"):
+        return []
+    try:
+        m = build_session(tsid, now, tmux if tmux is not None else {})
+    except Exception:
+        return []
+    evs = (m or {}).get("events") or []
+    if cut_uuid:
+        at = next((i for i, e in enumerate(evs)
+                   if e.get("uuid") == cut_uuid or e.get("resultUuid") == cut_uuid), None)
+        if at is None:
+            return []                              # the cut isn't in this transcript — never the copy
+        evs = evs[at + 1:]
+    else:
+        floor = int((_comment_thread_row_created(tsid) or 0))
+        evs = [e for e in evs if not e.get("ts") or int(em.parse_z(e.get("ts")) or 0) >= floor]
+    return evs[-80:]
+
+
+_comment_created_memo = {}                          # tsid -> createdT, for the tip-fork event floor
+
+
+def _comment_thread_row_created(tsid):
+    return _comment_created_memo.get(tsid)
+
+
+def _comments_frame(sid, tmux=None):
     """The chat pane's {type:"comments"} frame for parent session `sid`, or None when it has never
     had a thread. Built per push for sessions WITH a store (few) — _send_client's dedup keeps an
     unchanged frame off the wire."""
@@ -5083,10 +5116,14 @@ def _comments_frame(sid):
     if not p.exists():
         return None
     be = _sdk()
+    now = int(time.time())
     threads = []
     for th in _load_comments(sid).get("threads") or []:
         tsid = str(th.get("sid") or "")
         status = th.get("status") or "open"
+        _comment_created_memo[tsid] = int(th.get("createdT") or 0)
+        if len(_comment_created_memo) > 512:
+            _comment_created_memo.clear()
         # A promoted thread whose session was later ENDED is done, full stop (the user 2026-08-13,
         # who found the highlight still claiming "now its own session" after closing that session):
         # drop it from the frame entirely rather than point at a session that no longer runs. The
@@ -5107,16 +5144,23 @@ def _comments_frame(sid):
                 #                                                 say so, not pulse dots forever
             except Exception:
                 err = ""
+        # the plain projection still computes UNREAD (cheap, mtime-cached); the DISPLAY is the
+        # chat's own events from the branch point on (the user 2026-08-17: same component, rail
+        # dots and all — tool folds, notice cards, markdown, exactly as the chat renders them)
         msgs = [] if status == "promoted" else _thread_messages(
             tsid, str(th.get("cutUuid") or ""), floor_t=(0 if th.get("cutUuid") else int(th.get("createdT") or 0)))
         seen = int(th.get("lastSeenT") or 0)
         unread = any(m["who"] == "agent" and m["t"] > seen for m in msgs)
+        events = [] if status == "promoted" else _thread_events(tsid, str(th.get("cutUuid") or ""), now, tmux)
+        reg = _thread_reg(tsid)
         threads.append({"tid": th.get("tid"), "anchorUuid": th.get("anchorUuid"),
                         "name": th.get("name") or "", "color": th.get("color") or "",
                         "exact": str(th.get("exact") or "")[:500], "status": status,
                         "createdT": th.get("createdT") or 0, "state": state, "error": err,
                         "unread": unread, "promotedName": th.get("promotedName") or "",
-                        "msgs": msgs})
+                        "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",
+                        "effort": (reg.get("effort") or "") if reg else "",
+                        "msgs": msgs, "events": events})
     return {"type": "comments", "id": sid, "threads": threads}
 
 
@@ -13795,13 +13839,23 @@ def _sdk_transcript_path(sid):
 
 def _sdk_sess(sid, now):
     """A _sessions()-shaped entry for a live SDK session that discover() can't see yet (no transcript
-    on disk). Lets its tab open + chat build immediately; once it runs, discover() takes over."""
+    on disk). Lets its tab open + chat build immediately; once it runs, discover() takes over.
+
+    A comment THREAD never gets a names/ entry, so _sdk_transcript_path (names-fed cwd, sid-named
+    file) points nowhere for it — its reg is the authority: cwd + lastSid name the real transcript
+    (the user 2026-08-17: the popover renders the thread with the chat's own builder)."""
     p = _sdk_transcript_path(sid)
+    name = _name_of(sid)
+    if not name and not os.path.exists(str(p)):
+        reg = _thread_reg(sid)
+        if reg:
+            p = jd._proj_dir(reg.get("cwd") or os.path.expanduser("~")) / ((reg.get("lastSid") or sid) + ".jsonl")
+            name = reg.get("name") or ""
     try:
         mtime = p.stat().st_mtime
     except OSError:
         mtime = now
-    return {"sid": sid, "name": _name_of(sid) or sid[:8], "path": str(p), "mtime": mtime}
+    return {"sid": sid, "name": name or sid[:8], "path": str(p), "mtime": mtime}
 
 
 _arch_tops_cache = {}    # archive path -> (mtime, [projected top nodes]); the fleet's archived-completed tops
@@ -19855,7 +19909,7 @@ def _push(targets, connect=False, tmux=None):
             # an unchanged frame costs nothing on the wire and the chatTail stream stays untouched.
             for s in (chat_list if chat_clients else []):
                 try:
-                    fr = _comments_frame(s["sid"])
+                    fr = _comments_frame(s["sid"], tmux)
                 except Exception:
                     sys.stderr.write("comments frame failed for %s: %s\n" % (s["sid"], traceback.format_exc()))
                     continue

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -117,10 +117,13 @@ test("marks, badges AND every popover button ride the stable document.body deleg
   assert.match(UI, /m\.dataset\.act = "cmtopen"/);
   // the count badge is GONE (the user 2026-08-17): the highlight + the rail tick do the speaking
   assert.doesNotMatch(UI, /cmt-badge/);
-  for (const act of ["cmtclose", "cmtsend", "cmtbreak", "cmtresolve", "cmtdelete", "cmtopensession"]) {
+  for (const act of ["cmtclose", "cmtsend", "cmtbreak", "cmtdelete", "cmtopensession"]) {
     assert.ok(UI.includes(`${act}:`), `${act} handler missing from the body delegate`);
     assert.ok(UI.includes(`dataset.act = "${act}"`), `${act} button missing its data-act`);
   }
+  // Resolve is GONE (the user 2026-08-17): Delete is the only closer — the handler survives for
+  // legacy resolved rows, but no button mints new ones
+  assert.ok(!UI.includes('rs.dataset.act = "cmtresolve"'), "no Resolve button remains");
 });
 
 test("highlights re-apply after every render path", () => {
@@ -190,8 +193,10 @@ test("a thread that couldn't start says so instead of pulsing dots forever", () 
   assert.match(UI, /!th\.error && \(threadBusy\(th\.state\) \|\| pend\.length\)/);
 });
 
-test("Delete is offered only on resolved threads, never mid-promote", () => {
-  assert.match(UI, /\} else if \(th\.status === "resolved"\) \{\s+\/\/ never for 'promoting'/);
+test("Delete is offered on open and resolved threads, never mid-promote", () => {
+  // Resolve is gone (the user 2026-08-17) — Delete is the closer for BOTH, still gated off
+  // 'promoting'/'promoted' (the kernel refuses those anyway; the button never dangles one)
+  assert.match(UI, /if \(th\.status === "open" \|\| th\.status === "resolved"\) \{/);
 });
 
 test("break out posts commentPromote and acks with a provisional tab", () => {
@@ -287,6 +292,15 @@ test("the highlight pulses while its thread is writing — the badge's old job",
   assert.match(UI, /m\.classList\.toggle\("busy", threadBusy\(th\.state\) && th\.status === "open"\)/);
   assert.match(CSS, /mark\.cmt-hl\.busy \{ animation: cmt-busy-pulse/);
   assert.match(KERNEL, /state = be\.session_state\(tsid\)/);
+});
+
+test("the popover renders the thread with the CHAT's own renderer from the branch point", () => {
+  assert.match(UI, /renderingSid = th\.tid;/);
+  assert.match(UI, /list\.appendChild\(renderEvent\(ev, prev, null\)\);/);
+  assert.match(KERNEL, /def _thread_events\(tsid, cut_uuid, now, tmux\):/);
+  assert.match(KERNEL, /evs = evs\[at \+ 1:\]/, "sliced to AFTER the branch point — the head system card never rides");
+  // the thread's own live model/effort chips post the chat's own ops, keyed to the thread sid
+  assert.match(UI, /type: kind === "model" \? "setModel" : "setEffort", id: th\.tid, value: c\.value/);
 });
 
 test("the tint ladder keeps every state distinct: base < unread < hover", () => {

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -19,7 +19,10 @@ export type CommentThread = {
   error?: string;             // the thread CLI's launch error, when it could not start
   unread: boolean;            // an agent reply newer than the read watermark
   promotedName: string;       // the board session it became, when status === "promoted"
+  model?: string;             // the thread's live/chosen model (the popover's switchable chip)
+  effort?: string;            // the thread's effort level (ditto)
   msgs: CommentMsg[];
+  events?: unknown[];         // the CHAT's own ChatEvents from the branch point on (render parity)
 };
 
 export type CommentsFrame = { type: "comments"; id: string; threads: CommentThread[] };

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5657,7 +5657,21 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread): void {
   list.replaceChildren();
   const pend = prunePending(commentPending.get(th.tid) || [], th.msgs);
   commentPending.set(th.tid, pend);
-  for (const m of th.msgs) list.appendChild(commentMsgEl(m.who, m.text));
+  const evs = (th.events || []) as ChatEvent[];
+  if (evs.length) {
+    // the CHAT's own renderer, from the branch point on (the user 2026-08-17: the same component —
+    // rail dots, markdown, tool folds, notice cards — never a simplified twin). renderingSid keys
+    // the folds per thread, exactly as a chat tab would.
+    const saved = renderingSid;
+    renderingSid = th.tid;
+    let prev: number | null = null;
+    for (const ev of evs) {
+      list.appendChild(renderEvent(ev, prev, null));
+      const ep = eventEpoch(ev);
+      if (ep != null) prev = ep;
+    }
+    renderingSid = saved;
+  } else for (const m of th.msgs) list.appendChild(commentMsgEl(m.who, m.text));
   for (const p of pend) {
     const n = commentMsgEl("you", p.text);
     n.classList.add("pending");
@@ -5818,10 +5832,13 @@ function renderCommentPopover(): void {
     pop.addEventListener("pointercancel", up);
   });
   pop.appendChild(head);
-  const quote = el("div", "cmt-quote");
-  quote.textContent = create ? create.exact : th!.exact;
-  quote.title = "the highlighted passage this thread is about";
-  pop.appendChild(quote);
+  if (create || !(th!.events || []).length) {
+    // the chat-parity view opens ON the quoting message, so a second quote block would say it twice
+    const quote = el("div", "cmt-quote");
+    quote.textContent = create ? create.exact : th!.exact;
+    quote.title = "the highlighted passage this thread is about";
+    pop.appendChild(quote);
+  }
   if (th) {
     const list = el("div", "cmt-msgs");
     fillCommentMsgs(list, th);
@@ -5908,6 +5925,46 @@ function renderCommentPopover(): void {
     crow.append(attach, box, send);
     pop.appendChild(crow);
     if (metaRowPending) pop.appendChild(metaRowPending);   // model/effort under the box, like the chat
+    if (th && th.status === "open") {
+      // the thread is a real session under the hood — its model/effort switch LIVE through the
+      // chat's own ops (setModel/setEffort route by sid; be.owns makes the thread reachable)
+      const mrow = el("div", "cmt-meta-row");
+      const mkLive = (kind: "model" | "effort") => {
+        const btn = el("span", "meta-btn cmt-meta") as HTMLElement;
+        const label = el("span", "meta-label");
+        label.textContent = (kind === "model" ? (th.model || "Default") : (th.effort || "default"));
+        const choice = META_CHOICES[kind].find((c) => (label.textContent || "").toLowerCase().startsWith(c.value));
+        if (choice?.color && choice.color.length === 3)
+          label.style.color = `rgb(${choice.color[0]},${choice.color[1]},${choice.color[2]})`;
+        const caret = el("span", "meta-caret");
+        caret.textContent = "▾";
+        btn.append(label, caret);
+        btn.title = "the thread's own " + kind + " — switching it never touches the session it branched from";
+        btn.addEventListener("click", (e) => {
+          e.stopPropagation();
+          closeMetaMenu();
+          const menu = el("div", "meta-menu");
+          for (const c of META_CHOICES[kind]) {
+            const item = el("div", "meta-item");
+            item.textContent = c.label;
+            item.addEventListener("click", (ev) => {
+              ev.stopPropagation();
+              vscodeApi?.postMessage({ type: kind === "model" ? "setModel" : "setEffort", id: th.tid, value: c.value });
+              closeMetaMenu();
+            });
+            menu.appendChild(item);
+          }
+          document.body.appendChild(menu);
+          const r2 = btn.getBoundingClientRect();
+          menu.style.left = r2.left + "px";
+          menu.style.top = (r2.bottom + 4) + "px";
+          metaMenuEl = menu;
+        });
+        return btn;
+      };
+      mrow.append(mkLive("model"), mkLive("effort"));
+      pop.appendChild(mrow);
+    }
     const row = el("div", "cmt-actions");
     if (th) {
       const br = el("button", "cmt-act") as HTMLButtonElement;
@@ -5916,18 +5973,15 @@ function renderCommentPopover(): void {
       br.title = "Continue this thread as its own session; it keeps everything it knows";
       br.dataset.act = "cmtbreak";
       row.appendChild(br);
-      if (th.status === "open") {
-        const rs = el("button", "cmt-act") as HTMLButtonElement;
-        rs.type = "button";
-        rs.textContent = "Resolve";
-        rs.title = "Settle this thread: the highlight dims, and replying reopens it";
-        rs.dataset.act = "cmtresolve";
-        row.appendChild(rs);
-      } else if (th.status === "resolved") {   // never for 'promoting' — the kernel would refuse anyway
+      // Resolve is GONE (the user 2026-08-17): an idle thread draws no usage and its transcript
+      // is on disk either way, so the real verbs are Break out and Delete. Legacy resolved rows
+      // still render dimmed and reopen on reply; they just can't be minted anymore. Never for
+      // 'promoting' — the kernel would refuse anyway.
+      if (th.status === "open" || th.status === "resolved") {
         const dl = el("button", "cmt-act cmt-del") as HTMLButtonElement;
         dl.type = "button";
         dl.textContent = "Delete";
-        dl.title = "Remove this thread and its highlight";
+        dl.title = "Remove this thread and its highlight (the conversation file stays on disk)";
         dl.dataset.act = "cmtdelete";
         dl.addEventListener("pointerleave", () => { dl.classList.remove("armed"); dl.textContent = "Delete"; });
         row.appendChild(dl);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2475,7 +2475,7 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
    below and the scroll-rail tick carry the states it used to) */
 
 .cmt-pop {
-  position: fixed; z-index: 120; width: 360px; max-width: 94vw;
+  position: fixed; z-index: 120; width: 440px; max-width: 94vw;
   resize: both; overflow: auto; min-width: 300px; min-height: 120px; max-height: 90vh;
   cursor: grab;                       /* the whole box drags (interactive children override below) */
   display: flex; flex-direction: column; gap: 6px; padding: 8px;
@@ -2508,6 +2508,9 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 }
 .cmt-pop.sized .cmt-msgs { flex: 2 1 auto; max-height: none; }
 .cmt-msgs { max-height: 45vh; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; }
+/* chat-parity turns inside the popover (the user 2026-08-17): the chat's own .turn nodes, given a
+   little rail room; the popover's card is the backdrop, so no extra chrome */
+.cmt-msgs .turn { max-width: 100%; box-sizing: border-box; }
 .cmt-msg { padding: 5px 8px; border-radius: 6px; line-height: 1.35; overflow-wrap: anywhere; }
 .cmt-msg.you { background: color-mix(in srgb, var(--accent) 14%, transparent); align-self: flex-end; max-width: 92%; white-space: pre-wrap; }
 .cmt-msg.agent { background: rgba(255, 255, 255, 0.05); align-self: flex-start; max-width: 96%; }


### PR DESCRIPTION
Two changes from live use:

**Chat parity, literally.** The popover renders the thread with the chat's own `renderEvent` — rail dots, markdown, tool folds, notice cards — from the branch point onward. The comments frame ships real `build_session` ChatEvents sliced after the cut record (`_thread_events`); the head system card (directory, mode) sits before the cut by construction, so it never appears. `_sdk_sess` gains a reg fallback (cwd + lastSid) so `build_session` reaches a names-less thread. The popover's quote block yields to the opening bubble in thread view (it carries the quote verbatim), and harness `<task-notification>` blocks now render as the chat's informative cards instead of raw XML. Open threads carry live model/effort chips that post the chat's own `setModel`/`setEffort` keyed to the thread sid; the parent session is never touched. Unread stays on the cheap cached projection.

**Resolve retired.** An idle thread draws no API usage and its transcript is on disk either way, so "resolved" was a state without a job: the verbs are now Break out and Delete (two-click armed, never offered mid-promote). The kernel op and dimmed rendering survive for legacy resolved rows — they still reopen on reply — but no button mints new ones.

Tests: kernel `_thread_events` slice pins, `_sdk_sess` fallback exercised through the frame, chat-parity render pins (renderingSid keying, renderEvent reuse, live-chip ops), the Delete-scope pin updated. Suites green (pytest 4816, node 2051), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
