### PR TITLE
The day label sits below the top stamp, in the stamp's own box

### DIFF
--- a/ui/webview/rail-day.test.ts
+++ b/ui/webview/rail-day.test.ts
@@ -14,9 +14,13 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 test("the label anchors to whichever stamp owns the top slot, and hands off at the same pixel", () => {
   assert.match(RENDER, /m\.dataset\.epoch = String\(epoch\);/, "markers carry their epoch for the day pass");
   assert.match(RENDER, /const anchorM = marker \|\| \(firstBelow \? firstBelow\[0\] : null\);/);
-  assert.match(RENDER, /paintDay\(gutterRight, realLeads \? markerTop : \(firstBelow \? firstBelow\[1\] : cBottom \+ 1\)\);/,
+  assert.match(RENDER, /paintDay\(realLeads \? markerTop : \(firstBelow \? firstBelow\[1\] : cBottom \+ 1\)\);/,
     "a leading real stamp carries the label at its own position");
-  assert.match(RENDER, /paintDay\(g\.right, line\);/, "the sticky carries it at the line — same pixel at handoff");
+  assert.match(RENDER, /paintDay\(line\);/, "the sticky carries it at the line — same pixel at handoff");
+  // BELOW the stamp, in the stamp's own box (the user 2026-08-17: floating it ABOVE bled into the
+  // tab bar at the top of the view, and transform alignment didn't match the stamp's right edge)
+  assert.match(RENDER, /const yTop = slotTop \+ stampH \+ 1;/);
+  assert.match(RENDER, /day\.style\.width = gRect!\.width \+ "px";/);
   assert.match(RENDER, /if \(day\.textContent !== label\) day\.textContent = label;/, "text swaps only at day boundaries");
   assert.match(RENDER, /if \(!label \|\| yTop > cBottom\) \{ day\.style\.display = "none"; return; \}/,
     "today → no label; an off-screen anchor paints nothing");
@@ -24,7 +28,7 @@ test("the label anchors to whichever stamp owns the top slot, and hands off at t
 
 test("the label is passive fixed chrome, right-aligned to the gutter with no width math", () => {
   assert.match(CSS, /\.rail-day \{\s*\n\s*position: fixed; z-index: 3; pointer-events: none; white-space: nowrap;/);
-  assert.match(CSS, /transform: translate\(-100%, calc\(-100% - 2px\)\);/);
+  assert.match(CSS, /text-align: right;/);
   assert.match(CSS, /font-size: 0\.68em; letter-spacing: 0\.03em; color: var\(--dim\); opacity: 0\.85;/,
     "context, not the time itself — smaller and dimmer than the stamp");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1769,16 +1769,25 @@ function paintRailSticky(): void {
   const day = ensureRailDay();
   const firstBelow = all.find(([, top]) => top >= line);
   const anchorM = marker || (firstBelow ? firstBelow[0] : null);
-  const paintDay = (right: number, yTop: number) => {
+  // The label sits BELOW the top stamp, in the STAMP'S OWN BOX (same left/width, right-aligned like
+  // the time itself, so the two right edges line up by construction — the user 2026-08-17, whose
+  // first cut floated the label ABOVE the slot: at the top of the view that bled into the tab bar,
+  // and its transform-based alignment didn't match the stamp's). Below-stamp keeps it inside the
+  // pane at every scroll position, and the handoff stays seamless: a leading stamp carries its
+  // label at markerBottom, and the sticky shows it at the very same y when it takes over.
+  const gRect = anyMarker ? anyMarker.getBoundingClientRect() : null;
+  const stampH = anchorM ? anchorM.getBoundingClientRect().height || 11 : 11;
+  const paintDay = (slotTop: number) => {
     const ep = anchorM ? Number(anchorM.dataset.epoch || 0) : 0;
-    const label = ep ? dayContext(ep, Date.now()) : "";
+    const label = ep && gRect ? dayContext(ep, Date.now()) : "";
+    const yTop = slotTop + stampH + 1;
     if (!label || yTop > cBottom) { day.style.display = "none"; return; }
     if (day.textContent !== label) day.textContent = label;
-    day.style.left = right + "px";
+    day.style.left = gRect!.left + "px";
+    day.style.width = gRect!.width + "px";
     day.style.top = yTop + "px";
     day.style.display = "";
   };
-  const gutterRight = anyMarker ? anyMarker.getBoundingClientRect().right : 0;
   // The tracked turn's OWN stamp leads the top slot while it is at or below the line — it scrolls up freely
   // until it reaches the line, and the instant it crosses ABOVE (markerTop < line) the sticky takes the same
   // slot showing the same time, so the swap is invisible: no gap, no clipped sliver (the user 2026-07-23).
@@ -1789,7 +1798,7 @@ function paintRailSticky(): void {
   if (!hm || realLeads) {
     stamp.style.display = "none";
     for (const [m] of all) m.style.visibility = "";   // real stamp leads → nothing suppressed
-    if (anyMarker) paintDay(gutterRight, realLeads ? markerTop : (firstBelow ? firstBelow[1] : cBottom + 1));
+    if (anyMarker) paintDay(realLeads ? markerTop : (firstBelow ? firstBelow[1] : cBottom + 1));
     else day.style.display = "none";
     return;
   }
@@ -1803,7 +1812,7 @@ function paintRailSticky(): void {
   stamp.style.width = g.width + "px";
   stamp.style.top = line + "px";
   stamp.style.display = "";
-  paintDay(g.right, line);
+  paintDay(line);
 }
 
 // Scroll is the sticky stamp's primary driver, and a re-render moves the geometry under it — both funnel

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1102,7 +1102,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 @media (prefers-reduced-motion: reduce) { .scroll-marks .scroll-mark { transition: none; } }
 .rail-day {
   position: fixed; z-index: 3; pointer-events: none; white-space: nowrap;
-  transform: translate(-100%, calc(-100% - 2px));
+  text-align: right;   /* the STAMP's own box + its own alignment — the right edges match by construction */
   font-size: 0.68em; letter-spacing: 0.03em; color: var(--dim); opacity: 0.85;
 }
 /* match the dot's vertical position per turn type (default dot top:15, tool/thinking top:10) */


### PR DESCRIPTION
User report with screenshot + video: the "Yesterday" gutter label floated above the top slot — outside the pane content area at the top of the view, bleeding into the tab bar and riding upward as you scroll — and its right edge did not visibly align with the timestamp's.

The label now sits directly below the stamp it names (always inside the pane at every scroll position) and takes the stamp's own box: same left, same width, text-align right — so the label's and the time's right edges match by construction instead of transform arithmetic. Handoff continuity is preserved: a leading real stamp carries its label at its own bottom edge, and the sticky presents it at the same y when it takes over.

Pins updated in rail-day.test.ts. UI suite + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)