### PR TITLE
Writing threads trace their highlight as a pulsing outline

### DIFF
--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -288,9 +288,12 @@ test("scroll-rail ticks mark the commented spots and jump-open on click", () => 
   assert.match(CSS, /\.cmt-rail \{ position: fixed;/);
 });
 
-test("the highlight pulses while its thread is writing — the badge's old job", () => {
+test("while the thread is WRITING the region is a pulsing outline; the fill lands with the reply", () => {
   assert.match(UI, /m\.classList\.toggle\("busy", threadBusy\(th\.state\) && th\.status === "open"\)/);
-  assert.match(CSS, /mark\.cmt-hl\.busy \{ animation: cmt-busy-pulse/);
+  // outline, not fill: transparent background + an inset ring, pulsing — solid returns when busy drops
+  assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background: transparent;\s*\n\s*box-shadow: inset 0 0 0 1\.5px/);
+  assert.match(CSS, /@keyframes cmt-busy-pulse \{\s*\n\s*50% \{ box-shadow: inset/);
+  assert.match(CSS, /code\.cmt-hl-host:has\(mark\.cmt-hl\.busy\)/, "hosts outline too, or their tint defeats the cue");
   assert.match(KERNEL, /state = be\.session_state\(tsid\)/);
 });
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2462,10 +2462,32 @@ mark.cmt-hl {
 mark.cmt-hl.unread { background: color-mix(in srgb, var(--cmt-hl) 45%, transparent); }
 mark.cmt-hl:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, transparent); }
 mark.cmt-hl.resolved { background: rgba(255, 255, 255, 0.08); }
-mark.cmt-hl.busy { animation: cmt-busy-pulse 1.2s ease-in-out infinite; }
+/* WRITING (the user 2026-08-17): while the thread is mid-reply the region shows as a pulsing
+   OUTLINE of the highlight — the shape traced, no fill — and turns into the solid highlight the
+   moment the reply lands (the busy class drops with the thread's working state). Inset box-shadow,
+   not border: an inline border would shift the text it wraps. */
+mark.cmt-hl.busy {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--cmt-hl) 80%, transparent);
+  animation: cmt-busy-pulse 1.2s ease-in-out infinite;
+}
 mark.cmt-hl.hl-first { border-top-left-radius: 2px; border-bottom-left-radius: 2px; }
 mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 2px; }
-@keyframes cmt-busy-pulse { 50% { background: color-mix(in srgb, var(--cmt-hl) 50%, transparent); } }
+@keyframes cmt-busy-pulse {
+  50% { box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--cmt-hl) 25%, transparent); }
+}
+/* a code/math HOST whose mark is mid-reply outlines too — its element tint would otherwise stay
+   solid and defeat the outline-then-fill cue */
+.md :not(pre) > code.cmt-hl-host:has(mark.cmt-hl.busy) {
+  background: var(--code-bg);
+  box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--cmt-hl) 80%, transparent);
+  animation: cmt-busy-pulse 1.2s ease-in-out infinite;
+}
+.md .katex.cmt-hl-host:has(mark.cmt-hl.busy) {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--cmt-hl) 80%, transparent);
+  animation: cmt-busy-pulse 1.2s ease-in-out infinite;
+}
 .md :not(pre) > code.cmt-hl-host { background: color-mix(in srgb, var(--cmt-hl) 30%, var(--code-bg)); }
 .md :not(pre) > code.cmt-hl-host > mark.cmt-hl { background: transparent; }
 .md :not(pre) > code.cmt-hl-host:hover { background: color-mix(in srgb, var(--cmt-hl) 58%, var(--code-bg)); }


### PR DESCRIPTION
While a comment thread is mid-reply, its highlighted region now shows the *shape* of the highlight — a pulsing inset outline with no fill — and becomes the solid highlight the moment the reply lands. The `busy` class already tracked the thread's working state; only its appearance changes: transparent background plus an inset `box-shadow` ring (never a border, which would shift the inline text it wraps), with the keyframes pulsing the ring instead of the old background tint. Code and math hosts (`cmt-hl-host`) outline too while their mark is busy — their element tint would otherwise stay solid and defeat the outline-then-fill cue.

Tests: the busy-state pin reworked to assert outline-not-fill (transparent background + inset ring + ring-pulsing keyframes + the host `:has` variants). Suites green (pytest 4816, node 2051), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)