### PR TITLE
Failed previews heal on tunnel recovery, not just chat traffic

### DIFF
--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -785,6 +785,14 @@ export class FederationManager {
     // "last seen" a pane shows survives a page reload and doesn't restart with the browser.
     for (const [host, t] of want) if (typeof t.lastOk === "number" && t.lastOk) this.lastSeen[host] = t.lastOk;
     const changed = down.size !== this.downHosts.size || [...down].some((h) => !this.downHosts.has(h));
+    // A host coming BACK is the recovery event failed previews wait for. The message-driven heal
+    // (render.ts's listener re-runs retryFailedPreviews on any kernel message) never ticks on an
+    // idle session — no traffic flows — so a relay-failed figure sat as a chip until the user's
+    // next send generated pushes (the user 2026-08-17). This poll is the authority on tunnel
+    // state; the down→up transition is the exact moment the relay works again, so it dispatches
+    // through the same message path and the heal fires with zero chat traffic.
+    const recovered = [...this.downHosts].filter((h) => want.has(h) && !down.has(h));
+    if (recovered.length) window.dispatchEvent(new MessageEvent("message", { data: { type: "hostUp", hosts: recovered } }));
     this.downHosts = down;
     if (changed) window.dispatchEvent(new Event("romp-hosts"));   // panes repaint their disconnected marks
   }

--- a/ui/webview/heal-on-hostup.test.ts
+++ b/ui/webview/heal-on-hostup.test.ts
@@ -1,0 +1,42 @@
+// Failed figure previews must heal when the TUNNEL comes back, not when the user next speaks
+// (the user 2026-08-17: "a lot of the time these figure renders don't land until I send another
+// message"). The heal is message-driven — render.ts re-runs retryFailedPreviews on any window
+// message — which covers kernel restarts (the reconnect payload is a message) but never ticks on
+// an idle session, where no traffic flows. So a relay-failed figure sat as a chip until the
+// user's next send generated pushes. The fix: federation's /tunnels poll, already the authority
+// on tunnel state, dispatches {type:"hostUp", hosts} through the same window-message path on a
+// host's down→up transition. These pins hold the three load-bearing pieces of that contract.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const read = (f: string) => fs.readFileSync(path.join(UI, f), "utf8");
+const RENDER = read("render.ts");
+const FED = read("federation.ts");
+
+test("the tunnel poll dispatches hostUp on a down→up transition, through the window-message path", () => {
+  // recovery = was in downHosts last poll, still attached (want), not down now — a DETACHED host
+  // leaving downHosts is not a recovery and must not fire the heal
+  assert.match(FED, /const recovered = \[\.\.\.this\.downHosts\]\.filter\(\(h\) => want\.has\(h\) && !down\.has\(h\)\);/);
+  assert.match(FED,
+    /if \(recovered\.length\) window\.dispatchEvent\(new MessageEvent\("message", \{ data: \{ type: "hostUp", hosts: recovered \} \}\)\);/,
+    "a MessageEvent, not a bare Event — it must ride the same listener whose top re-runs the preview heal");
+});
+
+test("the recovery set is computed BEFORE downHosts is overwritten with this poll's state", () => {
+  const compute = FED.indexOf("const recovered = [...this.downHosts]");
+  const overwrite = FED.indexOf("this.downHosts = down;");
+  assert.ok(compute >= 0 && overwrite >= 0 && compute < overwrite,
+    "reading this.downHosts after the overwrite would compare the new state to itself and never see a transition");
+});
+
+test("render.ts's message listener heals previews unconditionally at the top, so hostUp needs no case of its own", () => {
+  const at = RENDER.indexOf('window.addEventListener("message", (e: MessageEvent) => {');
+  assert.ok(at >= 0);
+  const heal = RENDER.indexOf("retryFailedPreviews();", at);
+  const firstCase = RENDER.indexOf('if (m.type === "session")', at);
+  assert.ok(heal >= 0 && firstCase >= 0 && heal < firstCase,
+    "the heal must run before the type dispatch — moving it under a type check would silently drop hostUp");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9793,7 +9793,10 @@ window.addEventListener("message", (e: MessageEvent) => {
   if (m.romp === "chatNav") { navHist.go(m.dir === 1 ? 1 : -1); return; }
   if (m.type === "pipeState") { pipeBanner(!!m.up, Number(m.queued) || 0); return; }
   // any kernel message proves the kernel is reachable again — heal previews whose fetch died in a
-  // restart window (preview.ts retryFailedPreviews; a no-op when nothing failed)
+  // restart window (preview.ts retryFailedPreviews; a no-op when nothing failed). federation's
+  // tunnel poll rides this same path: it dispatches {type:"hostUp"} on a host's down→up transition,
+  // so relay-failed figures heal the moment the tunnel returns even when no chat traffic flows
+  // (idle sessions generated no messages, so figures sat until the user's next send — 2026-08-17)
   retryFailedPreviews();
   if (m.type === "session") upsert(m);
   else if (m.type === "globalRetryPaused") {


### PR DESCRIPTION
The preview heal is message-driven: render.ts re-runs retryFailedPreviews on any window message. That covers kernel restarts (the reconnect payload is a message) but never ticks on an idle session, where no traffic flows — so a relay-failed figure sat as a give-up chip until the user's next send generated pushes, which is exactly the reported symptom: figures kept landing only after another message.

federation's /tunnels poll is already the authority on tunnel state. It now dispatches `{type: "hostUp", hosts}` through the same window-message path on a host's down→up transition, so the heal fires the moment the relay works again, with zero chat traffic. A detached host leaving `downHosts` is not a recovery and does not fire. The recovery set is computed before `downHosts` is overwritten; a new pin file holds all three load-bearing pieces of the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)