### PR TITLE
The composer's resting hint row advertises the up-arrow history recall

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21289,7 +21289,7 @@ def _chat_body():
             '<div id="composer-staged" style="display:none"></div>'  # staged-message strip: held until the next send (the user 2026-08-15; NOT the queue — see render.ts)
             '<div id="composer-chips" style="display:none"></div>'   # click-to-cite chip strip (the user 2026-07-01)
             '<textarea id="composer-input" rows="1" '
-            'placeholder="Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · / for commands)"></textarea>'
+            'placeholder="Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · ↑ history · / for commands)"></textarea>'
             '<button id="composer-attach" title="Attach a file">'
             '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" '
             'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'

--- a/ui/webview/composer-history.test.ts
+++ b/ui/webview/composer-history.test.ts
@@ -40,3 +40,17 @@ test("the draft stashes on the first ↑ and restores past the newest; a send dr
   assert.match(RENDER, /ta\.dispatchEvent\(new Event\("input"\)\);/,
     "a recall runs the input bookkeeping (draft persist, slash menu, ask-mode) like typing would");
 });
+
+test("the resting placeholder advertises the recall, in every copy of the hint row", () => {
+  // the user 2026-08-17: now that ↑ recalls history, the empty-composer placeholder must say so.
+  // The placeholder shows exactly when the box is empty — exactly when the gate lets ↑ fire. The
+  // hint row lives in THREE places (render.ts's canonical function, the extension's static
+  // skeleton, the kernel-served skeleton); all three must carry the identical string or the hint
+  // a user sees depends on which surface painted first.
+  const ROW = "Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · ↑ history · / for commands)";
+  const SKEL = fs.readFileSync(path.resolve(process.cwd(), "..", "vscode-extension", "src", "page-skeleton.ts"), "utf8");
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.ok(RENDER.includes(JSON.stringify(ROW)), "canonical composerRestingPlaceholder carries the ↑ hint");
+  assert.ok(SKEL.includes(ROW), "extension skeleton matches");
+  assert.ok(KERNEL.includes(ROW), "kernel skeleton matches");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7729,7 +7729,7 @@ function composerRestingPlaceholder(): string {
   // "/ for commands", not "type / for commands". The static skeletons carry the same string.
   return isCoarsePointer()
     ? "Message this session…"
-    : "Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · / for commands)";
+    : "Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · ↑ history · / for commands)";
 }
 
 // How a message typed into the NORMAL composer should be routed while a live picker is up — the picker's

--- a/ui/webview/slash-commands.test.ts
+++ b/ui/webview/slash-commands.test.ts
@@ -133,5 +133,5 @@ test("the composer placeholder hints that / opens commands (the user 2026-06-30)
   // full hint row — send, newline, stage, and the bare "/ for commands" (the user 2026-08-15: "type"
   // was filler) — while mobile keeps just the core prompt (see the composer-send mobile test)
   assert.match(RENDER, /composer\.placeholder = closed \? "Session closed — read-only" : composerRestingPlaceholder\(\);/);
-  assert.match(RENDER, /"Message this session…  \(⏎ send · ⇧⏎ newline · ⌘⏎ stage · \/ for commands\)"/);
+  assert.match(RENDER, /"Message this session…  \(⏎ send · ⇧⏎ newline · ⌘⏎ stage · ↑ history · \/ for commands\)"/);
 });

--- a/vscode-extension/src/page-skeleton.ts
+++ b/vscode-extension/src/page-skeleton.ts
@@ -25,7 +25,7 @@ export function chatBody(attachTitle: string): string {
   <div id="footer">
     <div id="composer-resize" title="Drag to resize the message box"></div>
     <div id="statusline" class="statusline"></div>
-    <div id="composer"><div id="composer-files" style="display:none"></div><div id="composer-staged" style="display:none"></div><div id="composer-chips" style="display:none"></div><textarea id="composer-input" rows="1" placeholder="Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · / for commands)"></textarea><button id="composer-attach" title="${attachTitle}" aria-label="Attach file"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></button><button id="composer-send" title="Send (⏎)" aria-label="Send">➤</button></div>
+    <div id="composer"><div id="composer-files" style="display:none"></div><div id="composer-staged" style="display:none"></div><div id="composer-chips" style="display:none"></div><textarea id="composer-input" rows="1" placeholder="Message this session…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · ↑ history · / for commands)"></textarea><button id="composer-attach" title="${attachTitle}" aria-label="Attach file"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></button><button id="composer-send" title="Send (⏎)" aria-label="Send">➤</button></div>
   </div>`;
 }
 


### PR DESCRIPTION
Now that an empty composer recalls previously sent prompts on ↑, the placeholder says so. One entry in the existing terse grammar — `(⏎ send · ⇧⏎ newline · ⌘⏎ stage · ↑ history · / for commands)` — in all three copies of the hint row: the canonical `composerRestingPlaceholder`, the extension skeleton, and the kernel-served skeleton. The placeholder shows exactly when the box is empty, which is exactly when the recall gate lets the key fire. Mobile keeps the bare prompt: the gesture is keyboard-only. A new pin holds all three copies identical so the hint a user sees can't depend on which surface painted first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)