### PR TITLE
Marching ants start on the gesture; delete is instant and cuts the in-flight reply

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5305,6 +5305,13 @@ def _comment_delete(parent_sid, tid):
         _save_comments(parent_sid, data)
     be = Sessions.backend_for(parent_sid)
     if hasattr(be, "kill") and status != "promoted":
+        # CUT the in-flight reply first, then shut the CLI down: deleting a thread mid-generation
+        # must stop the work it represents, not just its cue (the user 2026-08-17, who deleted a
+        # marching highlight and watched the reply keep coming)
+        try:
+            be.interrupt(th["sid"])
+        except Exception:
+            pass
         try:
             be.kill(th["sid"])
         except Exception:

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -419,6 +419,10 @@ class FakeBackend:
         self.calls.append(("resume", sid))
         return True
 
+    def interrupt(self, sid):
+        self.calls.append(("interrupt", sid))
+        return True
+
     def kill(self, sid):
         self.calls.append(("kill", sid))
         return True
@@ -530,6 +534,13 @@ class CommentOps(CommentBase):
         self.assertIn(("resume", tid), self.be.calls, "replying IS the reopen gesture")
         self.assertEqual(km._comment_thread(PARENT, tid)["status"], "open")
         self.assertEqual(self.be.sent[-1], (tid, "one more question"))
+
+    def test_delete_interrupts_the_inflight_reply_before_the_kill(self):
+        # deleting a thread mid-generation must STOP the work, not just its cue (the user 2026-08-17)
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        km._comment_delete(PARENT, tid)
+        kinds = [c[0] for c in self.be.calls if c[0] in ("interrupt", "kill")]
+        self.assertEqual(kinds, ["interrupt", "kill"], "cut the turn first, then shut the CLI down")
 
     def test_delete_removes_the_row(self):
         _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -139,6 +139,19 @@ test("a comments frame refreshes the open popover IN PLACE — composer and care
   assert.match(UI, /function fillCommentMsgs\(list: HTMLElement, th: CommentThread\)/);
 });
 
+test("the ants start on the gesture, and delete is optimistic and cuts the work", () => {
+  // create: a synthetic working thread marks the passage before any round-trip; the frame's
+  // wholesale list replacement retires it, and a refusal drops it with the warn
+  assert.match(UI, /tid: "pending:" \+ create\.uuid, anchorUuid: create\.uuid/);
+  assert.match(UI, /state: "working",\s*\n\s*unread: false/);
+  assert.match(UI, /t\.tid !== "pending:" \+ pa\.uuid/);
+  // reply: the local state flips on send; the kernel's next frame confirms
+  assert.match(UI, /cur\.th\.state = "working";\s+\/\/ optimistic/);
+  // delete: the highlight goes NOW, and the kernel interrupts the in-flight reply before the kill
+  assert.match(UI, /filter\(\(t\) => t\.tid !== cur\.th\.tid\)\);\s*\n\s*applyCommentMarks\(cur\.sid\);\s*\n\s*closeCommentPop\(\);/);
+  assert.match(KERNEL, /be\.interrupt\(th\["sid"\]\)[\s\S]{0,200}be\.kill\(th\["sid"\]\)/);
+});
+
 test("the popover send acknowledges before any round-trip", () => {
   assert.match(UI, /send\.disabled = true; send\.classList\.add\("busy"\); \}\s+\/\/ ack before the round-trip/);
   assert.match(UI, /the pending bubble IS the acknowledgement/);
@@ -164,7 +177,7 @@ test("ending the parent sweeps its threads' CLIs — no unreachable running sess
 });
 
 test("a refused create un-sticks the popover; a pre-seam anchor tip-forks instead of erroring", () => {
-  assert.match(UI, /m\.type === "warn" && pendingCommentAnchor\) \{\s*\n\s*document\.getElementById\("cmt-pop"\)\?\.remove\(\);/);
+  assert.match(UI, /m\.type === "warn" && pendingCommentAnchor\) \{[\s\S]{0,400}document\.getElementById\("cmt-pop"\)\?\.remove\(\);/);
   assert.match(KERNEL, /def _anchor_adapter\(path, sid\)/);
   assert.match(KERNEL, /return "", cut_t, None/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5760,6 +5760,15 @@ function commentSendFromPop(pop: HTMLElement): void {
     if (nm && !/^[A-Za-z0-9._-]+$/.test(nm)) { nameBox?.classList.add("bad"); nameBox?.focus(); return; }
     if (send) { send.disabled = true; send.classList.add("busy"); }   // ack before the round-trip (the ➤
     //                                       dims); the draft survives until commentCreated adopts the thread
+    // the ants start on the GESTURE (the user 2026-08-17: the cue lagged the kernel round-trip):
+    // a synthetic working thread marks the passage NOW; the kernel's frame replaces the whole list,
+    // so its never-listed tid unwraps through the standard sweep the moment the real thread lands
+    const synth: CommentThread = { tid: "pending:" + create.uuid, anchorUuid: create.uuid,
+      exact: create.exact, status: "open", createdT: Date.now() / 1000, state: "working",
+      unread: false, promotedName: "", msgs: [], name: nm || "comment", color: create.color || "" };
+    const cur0 = commentThreads.get(create.sid) || [];
+    commentThreads.set(create.sid, [...cur0.filter((t) => t.tid !== synth.tid), synth]);
+    applyCommentMarks(create.sid);
     vscodeApi.postMessage({ type: "commentCreate", id: create.sid, uuid: create.uuid, exact: create.exact,
       text, name: nm, model: create.model || "", effort: create.effort || "",
       color: create.color || "" });
@@ -5768,6 +5777,8 @@ function commentSendFromPop(pop: HTMLElement): void {
   const cur = openCommentThread();
   if (!cur) return;
   vscodeApi.postMessage({ type: "commentReply", id: cur.sid, tid: cur.th.tid, text });
+  cur.th.state = "working";                     // optimistic: the ants march on the SEND, not the
+  applyCommentMarks(cur.sid);                   // round-trip (the kernel's next frame confirms)
   const pl = commentPending.get(cur.th.tid) || [];
   pl.push({ text, t: Date.now() / 1000 });
   commentPending.set(cur.th.tid, pl);
@@ -10099,6 +10110,10 @@ window.addEventListener("message", (e: MessageEvent) => {
   // FULL rebuild: the in-place refresh path deliberately never touches the composer, so it would
   // leave the disabled "Starting…" button stuck (the user 2026-08-15, screenshot of exactly that)
   if (m && m.type === "warn" && pendingCommentAnchor) {
+    // the synthetic working mark must die with the refusal, or it marches forever
+    const pa = pendingCommentAnchor;
+    commentThreads.set(pa.sid, (commentThreads.get(pa.sid) || []).filter((t) => t.tid !== "pending:" + pa.uuid));
+    applyCommentMarks(pa.sid);
     document.getElementById("cmt-pop")?.remove();
     renderCommentPopover();
   }
@@ -10982,6 +10997,11 @@ setupSettings();
       if (!cur) return;
       if (!elx.classList.contains("armed")) { elx.classList.add("armed"); elx.textContent = "Really delete?"; return; }
       vscodeApi?.postMessage({ type: "commentDelete", id: cur.sid, tid: cur.th.tid });
+      // optimistic removal (the user 2026-08-17: the highlight must go NOW, mid-animation included);
+      // the kernel's next frame confirms, and kernel-side the delete also interrupts the in-flight
+      // reply so the work stops with its cue
+      commentThreads.set(cur.sid, (commentThreads.get(cur.sid) || []).filter((t) => t.tid !== cur.th.tid));
+      applyCommentMarks(cur.sid);
       closeCommentPop();
     },
     cmtopensession: (elx) => {


### PR DESCRIPTION
Two defects from live feedback, both instances of the repo's click-acknowledgement rule:

- **The ants lagged the round-trip.** The cue now starts on the user's gesture: a create mints a synthetic working thread client-side (`pending:<anchor uuid>`), so the passage wears the marching outline the instant the button is pressed — the kernel frame's wholesale list replacement retires the synthetic (its tid is never listed), and a refused create drops it with the warn toast. A reply flips the local thread's state to `working` and re-applies the marks in the same click.
- **Delete waited, and the work kept running.** The highlight now disappears optimistically on the confirming click (local list removal + mark sweep; the kernel's next frame confirms), and the kernel's `_comment_delete` interrupts the thread's in-flight turn *before* the kill, so a deleted thread's generation stops with its cue.

Tests: kernel order pin (interrupt then kill, via the fake backend's call log), synthetic-thread pins (mint, retire-by-frame, drop-on-warn), the optimistic reply-state and delete-removal pins. Suites green (pytest 4817, node 2056), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)