### PR TITLE
A subagent's sidechain messages never become parent-chat atoms

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -281,6 +281,20 @@ def msg_to_atom(msg, sid, fsid, t, skill_tool_ids=()):
     still shows the confirmation line."""
     n = type(msg).__name__
     u = getattr(msg, "uuid", None)
+    # SIDECHAIN traffic is not the parent's conversation (the user 2026-08-17, screenshot of a
+    # subagent's full kickoff prompt painted as a huge expanded box below the collapsed tool group):
+    # the CLI streams a Task/Agent subagent's OWN turns tagged with parent_tool_use_id — its kickoff
+    # prompt as a UserMessage, its replies and tool calls as AssistantMessages. Untagged, the prompt
+    # fell through to the generic user atom below and, being a live-tail atom whose uuid never
+    # appears in the parent's transcript (the subagent writes its own file), the leak persisted
+    # instead of being superseded. The subagent's designed surfaces are the Task/Agent head's
+    # prompt+report folds and the background-task rows — the parent stream carries only the parent's
+    # turns. The ONE tagged shape that IS the parent's own is a Skill payload (parent_tool_use_id
+    # naming a Skill tool_use from this session's set — skills run inline, not as subagents); it
+    # passes through to the skillMd classification in the UserMessage branch.
+    ptid = getattr(msg, "parent_tool_use_id", None)
+    if ptid and ptid not in (skill_tool_ids or ()):
+        return None
     if n == "AssistantMessage":
         content = [d for b in (getattr(msg, "content", []) or []) if (d := _block_to_dict(b))]
         if not content:

--- a/tests/test_sidechain_atoms.py
+++ b/tests/test_sidechain_atoms.py
@@ -1,0 +1,112 @@
+"""A subagent's sidechain messages never become PARENT-chat atoms (the user 2026-08-17).
+
+The CLI streams a Task/Agent subagent's OWN turns to the SDK client tagged with
+parent_tool_use_id — its kickoff prompt as a UserMessage, its replies and tool calls as
+AssistantMessages. msg_to_atom used to check that tag only against the session's Skill
+tool_use ids, so subagent traffic fell through to the generic branches and the kickoff
+prompt rendered in the parent chat as a giant fully-expanded instruction box below the
+collapsed tool group (screenshot-reported). Worse, the leak was a live-tail atom whose
+uuid never appears in the parent's transcript (the subagent writes its own file), so
+the transcript merge never superseded it and the box persisted.
+
+The contract now: parent_tool_use_id set and not a known Skill tool_use → the message
+is a subagent's, and msg_to_atom returns None. The subagent's designed surfaces are the
+Task/Agent head's prompt+report folds and the background-task rows. Skill payloads
+(skills run inline, not as subagents) keep their skillMd classification.
+"""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+PROMPT = ("You are drafting prose for two research notes in a vault. Return ONLY the "
+          "three deliverables in the exact output format at the end.")
+
+
+class TextBlock:
+    def __init__(self, text):
+        self.text = text
+
+
+def _load(name):
+    return SourceFileLoader(name, os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+
+
+class SidechainDrop(unittest.TestCase):
+    def test_subagent_kickoff_prompt_is_dropped(self):
+        sb = _load("romp_sdk_backend_sc1")
+
+        class UserMessage:
+            uuid = "11111111-2222-3333-4444-555555555555"
+            parent_tool_use_id = "toolu_agent1"
+
+            def __init__(self, content):
+                self.content = content
+
+        # the expanded-instruction-box leak: the subagent's first message is its full prompt
+        a = sb.msg_to_atom(UserMessage([TextBlock(PROMPT)]), "s", "f", 5, skill_tool_ids={"skill9"})
+        self.assertIsNone(a)
+        # with NO skill set at all, still dropped — the tag alone marks it as not the parent's
+        b = sb.msg_to_atom(UserMessage([TextBlock(PROMPT)]), "s", "f", 5)
+        self.assertIsNone(b)
+
+    def test_subagent_assistant_replies_are_dropped(self):
+        sb = _load("romp_sdk_backend_sc2")
+
+        class AssistantMessage:
+            uuid = "11111111-2222-3333-4444-666666666666"
+            parent_tool_use_id = "toolu_agent1"
+            model = "m"
+            stop_reason = None
+
+            def __init__(self, content):
+                self.content = content
+
+        # untagged handling would render the subagent's words as the PARENT speaking
+        a = sb.msg_to_atom(AssistantMessage([TextBlock("working on the notes…")]), "s", "f", 5)
+        self.assertIsNone(a)
+
+    def test_parent_messages_without_the_tag_still_flow(self):
+        sb = _load("romp_sdk_backend_sc3")
+
+        class UserMessage:
+            uuid = "11111111-2222-3333-4444-777777777777"
+
+            def __init__(self, content):
+                self.content = content
+
+        class AssistantMessage:
+            uuid = "11111111-2222-3333-4444-888888888888"
+            model = "m"
+            stop_reason = "end_turn"
+
+            def __init__(self, content):
+                self.content = content
+
+        ua = sb.msg_to_atom(UserMessage([TextBlock("hello")]), "s", "f", 5)
+        self.assertEqual(ua["type"], "user")
+        aa = sb.msg_to_atom(AssistantMessage([TextBlock("hi")]), "s", "f", 5)
+        self.assertEqual(aa["type"], "assistant")
+
+    def test_none_tag_is_not_a_sidechain(self):
+        sb = _load("romp_sdk_backend_sc4")
+
+        class UserMessage:
+            uuid = "11111111-2222-3333-4444-999999999999"
+            parent_tool_use_id = None      # the SDK types default the field to None on parent turns
+
+            def __init__(self, content):
+                self.content = content
+
+        a = sb.msg_to_atom(UserMessage([TextBlock("hello")]), "s", "f", 5)
+        self.assertEqual(a["type"], "user")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_content.py
+++ b/tests/test_skill_content.py
@@ -183,10 +183,12 @@ class LiveTwin(unittest.TestCase):
         self.assertEqual(a["type"], "assistant")
         self.assertIn("# cleanplots", a["skillMd"])
         self.assertEqual(a["message"]["content"], [])
-        # same message with the id NOT in the session's Skill set → an ordinary user atom
+        # same message with the id NOT in the session's Skill set → SIDECHAIN traffic, dropped
+        # (2026-08-17: a parent_tool_use_id outside the Skill set marks a subagent's own turn — the
+        # old ordinary-user-atom fallback is exactly how kickoff prompts leaked into the parent chat
+        # as giant expanded boxes; see test_sidechain_atoms.py)
         b = sb.msg_to_atom(UserMessage([TextBlock(SKILL_MD_V2)]), "s", "f", 5, skill_tool_ids={"other"})
-        self.assertEqual(b["type"], "user")
-        self.assertNotIn("skillMd", b)
+        self.assertIsNone(b)
 
     def test_note_skill_tool_ids_collects_from_the_stream(self):
         sb = SourceFileLoader("romp_sdk_backend_skill3", os.path.join(BIN, "romp_sdk_backend.py")).load_module()


### PR DESCRIPTION
Agent instructions sometimes rendered as a giant fully-expanded markdown box in the chat transcript — below the collapsed tool group, with its own timeline row (screenshot-reported). Root cause: the CLI streams a Task/Agent subagent's OWN turns to the SDK client tagged with `parent_tool_use_id` — its kickoff prompt as a UserMessage, its replies and tool calls as AssistantMessages — and `msg_to_atom` checked that tag only against the session's Skill tool_use ids. Subagent traffic fell through to the generic branches: the prompt became an ordinary user atom, the injected-note renderer painted it expanded, and because its uuid never appears in the parent's transcript file (the subagent writes its own), the transcript merge never superseded the live-tail leak — the box persisted until a kernel restart cleared the in-memory tail, which is why it only happened "sometimes".

`msg_to_atom` now drops any message whose `parent_tool_use_id` is set and not a known Skill tool_use — sidechain traffic is not the parent's conversation. Agent instructions keep their designed compact surface: the Task/Agent head's prompt+report folds, expandable on demand. Skill payloads (inline, not subagents) keep their skillMd classification; the old ordinary-user-atom fallback pin in test_skill_content.py is updated to the new contract, and test_sidechain_atoms.py holds the whole thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)