### PR TITLE
POST /send and romp new grow the scheduled-sender tag, and the rail dot agrees

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1101,6 +1101,7 @@ model_arg=""
 effort_arg=""
 use_tmux=false
 msg_arg=""
+tag_arg=""
 
 case "${1:-}" in
     new)
@@ -1111,7 +1112,7 @@ case "${1:-}" in
                 --detach)  detach=true; shift ;;
                 -d)        shift
                            if [[ $# -eq 0 || "$1" == -* ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            dir_arg="$1"; shift ;;
                 -m|--message) shift
@@ -1120,34 +1121,51 @@ case "${1:-}" in
                            # last two-step on the idea-to-working path). Empty text is a usage
                            # error, not a silent no-op.
                            if [[ $# -eq 0 || -z "$1" ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            msg_arg="$1"; shift ;;
+                --tag)     shift
+                           # scheduled/scripted kickoff (the user 2026-08-18, for the nightly
+                           # optimizer's briefing): the -m text is machine-sent under this label
+                           # (the same third identity `romp send --tag` writes) instead of posing
+                           # as the user's typed words. Rides POST /send's "tag" field — the
+                           # kernel validates and appends the render-hint marker itself.
+                           if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                           fi
+                           tag_arg="$1"; shift ;;
                 --model)   shift
                            # per-spawn model, riding POST /new (the user 2026-08-14: the nightly
                            # optimizer must always run fable, and a headless script has no WS).
                            # FULL id as the picker sends it (claude-fable-5) — the alias table
                            # stops at opus/sonnet/haiku and quietly resolved "fable" to Opus 5.
                            if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            model_arg="$1"; shift ;;
                 --effort)  shift
                            # per-spawn effort (e.g. high, ultracode) — ultracode is per-session
                            # by design, never a machine default, so /new is its sanctioned door.
                            if [[ $# -eq 0 || -z "$1" || "$1" == -* ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            effort_arg="$1"; shift ;;
                 -*)        echo "romp new: unknown option: $1" >&2; exit 2 ;;
                 *)         if [[ -n "$session_arg" ]]; then
-                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+                               echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
                            fi
                            session_arg="$1"; shift ;;
             esac
         done
         if [[ -z "$session_arg" ]]; then
-            echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+            echo "usage: romp new [-t] [-d <dir>] [-m <text>] [--tag <label>] [--model <id>] [--effort <level>] <name>" >&2; exit 2
+        fi
+        if [[ -n "$tag_arg" && -z "$msg_arg" ]]; then
+            # a tag labels the -m text; without -m there is nothing to label
+            echo "romp new: --tag needs -m <text> (the tag labels the delivered message)" >&2; exit 2
+        fi
+        if [[ -n "$tag_arg" ]] && ! [[ "$tag_arg" =~ ^[A-Za-z0-9][A-Za-z0-9-]{0,23}$ ]]; then
+            echo "romp new: --tag must be one word (letters/digits/dashes, <=24 chars)" >&2; exit 2
         fi
         if [[ -n "$msg_arg" ]] && $use_tmux; then
             # the tmux variant attaches a terminal you type into yourself; delivering a first
@@ -1264,7 +1282,10 @@ if [[ -n "$session_arg" ]] && ! $use_tmux && ! $resume; then
         # session EXISTS by now (the /new above acked), so a failed send names the exact
         # retry command instead of pretending the spawn failed.
         if [[ -n "$msg_arg" ]]; then
-            _mpayload="$(python3 -c 'import json,sys; print(json.dumps({"name": sys.argv[1], "text": sys.argv[2]}))' "$session_arg" "$msg_arg")"
+            _mpayload="$(python3 -c 'import json,sys
+d = {"name": sys.argv[1], "text": sys.argv[2]}
+if len(sys.argv) > 3 and sys.argv[3]: d["tag"] = sys.argv[3]
+print(json.dumps(d))' "$session_arg" "$msg_arg" "$tag_arg")"
             _mresp="$(_romp_token_cfg | curl -sf -m 10 --config - -X POST "http://127.0.0.1:$_kport/send" \
                           -H 'Content-Type: application/json' -d "$_mpayload")" \
                 || { echo "romp new: session is up but the message did NOT land (kernel send failed). Retry: romp send $session_arg '<text>'" >&2; exit 1; }

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -10375,7 +10375,17 @@ def _tmux_send(name, text, model_cmd=False, _async=True):
 
 def _parse_send_body(raw):
     """Parse a POST /send body into {"who","text"}, or None if invalid. who = id or
-    name; text must be a non-empty string. Pure (no I/O) so the route is unit-testable."""
+    name; text must be a non-empty string. Pure (no I/O) so the route is unit-testable.
+
+    Optional "tag": a one-word label (letters/digits/dashes, <=24 chars — MSG_TAG_RE's
+    grammar) for SCHEDULED/SCRIPTED senders (the user 2026-08-18, whose nightly
+    optimizer briefing wore the wrong dress): the kernel appends the render-hint marker
+    `<!-- romp-tag: <label> -->` so the chat shows the message machine-sent under that
+    label — the same third identity `romp send --tag` writes by hand — instead of
+    posing it as the user's typed words or dressing it as romp's own. A malformed tag
+    fails the WHOLE parse (loud, per the fail-loudly rule): the caller asked for an
+    identity the kernel can't honor, and delivering the text anyway would silently
+    misattribute it."""
     try:
         body = json.loads(raw or b"{}")
     except Exception:
@@ -10386,6 +10396,11 @@ def _parse_send_body(raw):
     text = body.get("text")
     if not who or not isinstance(text, str) or not text:
         return None
+    tag = body.get("tag")
+    if tag is not None:
+        if not isinstance(tag, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9-]{0,23}", tag):
+            return None
+        text = text + "\n\n<!-- romp-tag: " + tag + " -->"
     return {"who": who, "text": text}
 
 
@@ -24647,7 +24662,8 @@ class Handler(BaseHTTPRequestHandler):
                 # (X-Romp-Token read from the 0600 file, or ?token=).
                 body = _parse_send_body(raw_body)
                 if not body:
-                    return self._send(400, json.dumps({"ok": False, "error": "id and text required"}), "application/json")
+                    return self._send(400, json.dumps({"ok": False, "error":
+                        "id and text required (optional tag: one word, letters/digits/dashes, <=24 chars)"}), "application/json")
                 sid = _sid_of(body["who"])
                 # POSTAL ISOLATION holds on every sanctioned route (the user 2026-07-10): postal-SHAPED
                 # content to a mailbox-off session is agent mail arriving by the wrong door — refuse it

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -167,6 +167,22 @@ MOCK
     grep '/send' "$MOCK_LOG" | grep 'ideabox' | grep -q 'look into the flaky test'
 }
 
+@test "new --tag rides the /send tag field; needs -m; bad labels exit 2" {
+    _stub_curl
+    touch "$MOCK_LOG"
+    export ROMP_SERVE_TOKEN=testtok
+    run run_romp new -m "nightly briefing body" --tag nightly-optimizer ideabox
+    [ "$status" -eq 0 ]
+    # the send payload carries the tag as a FIELD — the kernel appends the marker itself
+    grep '/send' "$MOCK_LOG" | grep -q '"tag": *"nightly-optimizer"'
+    run run_romp new --tag nightly-optimizer ideabox
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--tag needs -m"* ]]
+    run run_romp new -m "text" --tag "two words" ideabox
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--tag must be one word"* ]]
+}
+
 @test "new -m: a failed send is loud and names the retry (the session IS up)" {
     _stub_curl
     touch "$MOCK_LOG"

--- a/tests/test_kernel_send.py
+++ b/tests/test_kernel_send.py
@@ -32,6 +32,22 @@ class ParseSendBody(unittest.TestCase):
         self.assertIsNone(km._parse_send_body(b'{"id":"alpha","text":""}'))  # empty text
         self.assertIsNone(km._parse_send_body(b'{"id":"","text":"hi"}'))    # empty id
 
+    def test_tag_appends_the_render_hint_marker(self):
+        # scheduled/scripted senders (the user 2026-08-18, the nightly optimizer briefing):
+        # the "tag" field makes the kernel append the SAME marker `romp send --tag` writes,
+        # so the chat dresses the message machine-sent under that label
+        self.assertEqual(km._parse_send_body(b'{"id":"alpha","text":"hi","tag":"nightly-optimizer"}'),
+                         {"who": "alpha", "text": "hi\n\n<!-- romp-tag: nightly-optimizer -->"})
+
+    def test_bad_tag_fails_the_whole_parse(self):
+        # a malformed tag is a 400, never a silent plain delivery — delivering anyway would
+        # misattribute the text (fail loudly, 2026-07-03)
+        self.assertIsNone(km._parse_send_body(b'{"id":"a","text":"hi","tag":"two words"}'))
+        self.assertIsNone(km._parse_send_body(b'{"id":"a","text":"hi","tag":""}'))
+        self.assertIsNone(km._parse_send_body(b'{"id":"a","text":"hi","tag":123}'))
+        self.assertIsNone(km._parse_send_body(b'{"id":"a","text":"hi","tag":"-leading-dash"}'))
+        self.assertIsNone(km._parse_send_body(b'{"id":"a","text":"hi","tag":"' + b"x" * 25 + b'"}'))
+
     def test_rejects_bad_json_non_object_and_non_string_text(self):
         self.assertIsNone(km._parse_send_body(b'not json'))
         self.assertIsNone(km._parse_send_body(b'[1,2,3]'))

--- a/ui/webview/chat-msg-tag.test.ts
+++ b/ui/webview/chat-msg-tag.test.ts
@@ -15,6 +15,7 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 const EM = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "event_model.py"), "utf8");
 const CLI = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("event_model: the marker is a comment-form regex with a bounded one-word label", () => {
   assert.match(EM, /MSG_TAG_RE = re\.compile\(r"<!--\\s\*romp-tag:\\s\*\(\[A-Za-z0-9\]\[A-Za-z0-9-\]\{0,23\}\)\\s\*-->"\)/,
@@ -29,6 +30,13 @@ test("kernel: the tag lifts on HUMAN-author turns only, riding the user event", 
 test("chat: a tagged message wears the gray injected family with the sender's ⚙ label, never user blue", () => {
   assert.match(RENDER, /tag\?: string/, "the user event carries the kernel's lift");
   assert.match(RENDER, /const tagged = !romp && !injected && !!ev\.tag && !!ev\.md;/);
+  // the rail dot is its own identity channel and must AGREE with the bubble (2026-08-18): a tagged
+  // machine-sent message wears the gray tag dot, never the blue "you typed this" one — so `tagged`
+  // is hoisted above the dot call
+  assert.match(RENDER, /turn\.appendChild\(dot\(romp \? "romp" : tagged \? "tag" : injected \? "ring" : "user"\)\);/);
+  assert.ok(RENDER.indexOf("const tagged = !romp && !injected") < RENDER.indexOf('dot(romp ? "romp" : tagged'),
+    "tagged must be declared before the dot call reads it");
+  assert.match(CSS, /\.dot\.tag \{ background: #8a8f98; border: none; \}/);
   // the label chip reuses the romp-tag dress (one vocabulary), ⚙ marking "scripted" vs romp's swirl
   assert.match(RENDER, /tchip\.appendChild\(document\.createTextNode\("⚙ " \+ ev\.tag\)\);/);
   assert.match(RENDER, /tagged \? "romp-bubble tag-bubble" : injected \? "user-note" : "user-bubble"/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -611,7 +611,7 @@ function wrapCodeLines(code: HTMLElement) {
   }).join("");
 }
 
-function dot(kind: "green" | "ring" | "user" | "red" | "romp" | "working"): HTMLElement { return el("span", "dot " + kind); }
+function dot(kind: "green" | "ring" | "user" | "red" | "romp" | "working" | "tag"): HTMLElement { return el("span", "dot " + kind); }
 
 function ioRow(label: "IN" | "OUT", text: string, isError: boolean): HTMLElement {
   const row = el("div", "io-row" + (label === "OUT" ? " io-out" : "") + (isError ? " io-error" : ""));
@@ -1926,6 +1926,12 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
     // injected (compact summary, /command stdout, system reminders) → a neutral left note box.
     const romp = !!ev.romp;
     const injected = !ev.human && !romp;
+    // sender-declared render hint (kernel MSG_TAG_RE lift, the user 2026-08-15): auto-generated
+    // text — a kickoff template, a scripted brief — is machine-sent on the user's behalf, so it
+    // sheds the typed-words blue for the gray injected family, labeled with the SENDER's own word
+    // (romp attaches no meaning to the label; ⚙ marks "scripted", vs romp's swirl). Hoisted above
+    // the rail dot (2026-08-18): the dot is its own identity channel and must agree with the bubble.
+    const tagged = !romp && !injected && !!ev.tag && !!ev.md;
     const turn = el("div", "turn turn-user" + (romp ? " romp" : injected ? " injected" : ""));
     // Unresolved postal ids ride the raw turn so a timeline message arc can still land on it. Without
     // this the arc pointed at a turn with nothing to match and the click died silently (the user
@@ -1935,7 +1941,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
     // Prompts ride the rail like every other turn: their own dot + a left-gutter HH:MM marker (added in
     // renderEvent). Genuine prompts get the solid blue dot; a romp injection a gray dot; harness notes the
     // hollow ring used by assistant turns.
-    turn.appendChild(dot(romp ? "romp" : injected ? "ring" : "user"));
+    turn.appendChild(dot(romp ? "romp" : tagged ? "tag" : injected ? "ring" : "user"));
     // a TYPED follow-up (resumed a goal) → a compact "↩ Follow-up · <goal>" header, the romp goal-context
     // quote + markers already stripped server-side. Same header the pending queued render uses (consistency).
     if (ev.followUp && !romp) turn.appendChild(followUpHeader(ev.goal, ev.fuCtx, ev.uuid ? "u:" + ev.uuid : undefined));
@@ -1955,11 +1961,6 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         tag.appendChild(document.createTextNode("romp"));
         turn.appendChild(tag);
       }
-      // sender-declared render hint (kernel MSG_TAG_RE lift, the user 2026-08-15): auto-generated
-      // text — a kickoff template, a scripted brief — is machine-sent on the user's behalf, so it
-      // sheds the typed-words blue for the gray injected family, labeled with the SENDER's own word
-      // (romp attaches no meaning to the label; ⚙ marks "scripted", vs romp's swirl).
-      const tagged = !romp && !injected && !!ev.tag && !!ev.md;
       if (tagged) {
         const tchip = el("div", "romp-tag");
         tchip.appendChild(document.createTextNode("⚙ " + ev.tag));

--- a/ui/webview/romp-bubble.test.ts
+++ b/ui/webview/romp-bubble.test.ts
@@ -24,7 +24,7 @@ test("a romp event renders the gray romp-bubble + a romp tag, NOT the blue or th
   assert.doesNotMatch(RENDER, /tag\.textContent = "↯ romp"/, "the ↯ placeholder is gone");
   assert.match(RENDER, /\(romp \? "romp-bubble" : tagged \? "romp-bubble tag-bubble" : injected \? "user-note" : "user-bubble"\)/);
   // its own gray rail dot
-  assert.match(RENDER, /dot\(romp \? "romp" : injected \? "ring" : "user"\)/);
+  assert.match(RENDER, /dot\(romp \? "romp" : tagged \? "tag" : injected \? "ring" : "user"\)/);
   assert.match(RENDER, /"green" \| "ring" \| "user" \| "red" \| "romp"/, "the dot helper knows the romp variant");
 });
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1140,6 +1140,9 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* your prompt — the SAME royal/indigo blue as your message bubble (#2b6cef), so the dot matches your
    chat box (the user 2026-06-15). Distinct from the cyan ✓ success disc (--check-bg #1EA1EB). */
 .dot.user { background: #2b6cef; border: none; }
+/* a TAGGED (machine-sent under a label) prompt: the gray of its tag-bubble family, so the rail agrees
+   with the bubble — it used to wear the blue "you typed this" dot (the identity-channel gap, 2026-08-18) */
+.dot.tag { background: #8a8f98; border: none; }
 /* A romp-injected message (a nudge, a status note) wears the SWIRL in a dark disc — the same mark the
    timeline already puts on a romp event (romp-timeline-view.js draws a black dot with the glyph inside),
    so one kind of event looks like itself on both surfaces (the user 2026-07-23). It used to be an


### PR DESCRIPTION
A scheduled send (the nightly optimizer briefing, any systemd-timer POST) had no way to say what it was: unmarked text posed as the user's typed words, and the only alternative was dressing it as romp's own injection. The third identity already exists — the sender-declared render hint that shows a message machine-sent under a one-word ⚙ label — but only `romp send --tag` could write it.

`POST /send` now accepts an optional `tag` field (one word, letters/digits/dashes, ≤24 chars — the marker grammar); the kernel validates it and appends the render-hint marker itself, and a malformed tag fails the parse with a 400 rather than delivering misattributed text. `romp new` gains `--tag`, riding that field on its `-m` delivery, so one command spawns a session whose kickoff wears the label.

The rail dot now agrees with the bubble: a tagged machine-sent message wore the blue you-typed-this dot while its bubble said machine-sent — the dot is its own identity channel, so tagged turns get a gray dot from their own family (`.dot.tag`), and the `tagged` flag is hoisted above the dot call it now feeds.

Tests: `_parse_send_body` tag composition + loud rejection (python), `romp new --tag` field passthrough + usage errors (bats), and dot/hoist/CSS pins (UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)