### PR TITLE
Anonymous mail is refused at the door, and unknown never wears a name

### DIFF
--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -444,9 +444,16 @@ def format_inbox(msgs, me_id=""):
         mid = ("\n<!-- romp-msg-id: %s -->" % m["id"]) if m.get("id") else ""   # exact id for the timeline join
         if m.get("kind"):
             mid += "\n<!-- romp-msg-kind: %s -->" % m["kind"]   # sender-declared kind, read by the courier
-        out.append("\n— from %s%s%s:\n%s%s" % (m.get("from", "?"), d, pk, m.get("body", ""), mid))
+        out.append("\n— from %s%s%s:\n%s%s" % (_from_disp(m), d, pk, m.get("body", ""), mid))
     out.append("\n" + REPLY_HINT)
     return "\n".join(out)
+
+def _from_disp(m):
+    """The sender name a banner shows. Never the literal "unknown"/"?" a broken sender minted
+    (pre-2026-08-18 mail, or a peer bus older than the /send refusal): a canned body over
+    "from unknown" reads as a greeting from a ghost. Say what is true instead."""
+    nm = str(m.get("from") or "").strip()
+    return nm if nm and nm.lower() != "unknown" and nm != "?" else "an unidentified session"
 
 def format_agents(agents, me, me_id=""):
     if not agents:
@@ -1011,7 +1018,7 @@ def format_push(msgs):
     out = []
     for m in msgs:
         pk = " · ⏸ parked (you were offline)" if m.get("park") else ""
-        head = "## \U0001F4EC from %s · %s%s" % (m.get("from", "?"), _hhmm(m.get("date", "")), pk)
+        head = "## \U0001F4EC from %s · %s%s" % (_from_disp(m), _hhmm(m.get("date", "")), pk)
         out += [bar, head, bar, m.get("body", "")]
         if m.get("id"):
             out.append("<!-- romp-msg-id: %s -->" % m["id"])   # exact id for the timeline join
@@ -1192,6 +1199,17 @@ class Handler(BaseHTTPRequestHandler):
             to = data.get("to", "")
             frm, frm_id = data.get("from", "unknown"), data.get("from_id", "")
             body = data.get("body", "")
+            if not frm_id:
+                # An unidentifiable sender's mail arrives literally "from unknown" — a canned-sounding
+                # greeting the recipient can neither place nor answer (the user 2026-08-18, who met one
+                # on their laptop; the 2026-07-27 clear-fork minted the same ghost). Refuse LOUDLY at
+                # the one door every sender uses: the breakage is the SENDER's identity resolution, and
+                # a visible error there beats ghost mail here (fail loudly, 2026-07-03). Cross-host
+                # relays are unaffected — they arrive on the peer routes with identity in their headers.
+                return self._send({"error": "sender identity required: this send carried no from_id, so "
+                                   "it would arrive as mail 'from unknown' that the recipient cannot "
+                                   "place or answer. The sender should know its own session id — fix "
+                                   "that resolution and resend."}, 400)
             kind = str(data.get("kind", "")).strip().lower()
             if kind not in ("delegate", "coordinate", "question"):
                 kind = ""                              # legacy/CLI mail may be undeclared; never invent one
@@ -2555,8 +2573,14 @@ def _mcp_call(name, args):
         if kind not in ("delegate", "coordinate", "question"):
             return ("Need 'kind': one of delegate (the recipient owns the work now), "
                     "coordinate (aligning/heads-up), or question (you need an answer).", True)
+        if not mid:
+            # the bus would refuse this anyway (anonymous mail arrives "from unknown"); say it
+            # HERE with the actionable half — the sender's own identity is what's broken
+            return ("Cannot send: this session's own identity did not resolve (no session id), so "
+                    "the mail would arrive anonymously and the recipient could not place or answer "
+                    "it. This is a session-identity bug worth surfacing to the user.", True)
         try:
-            resp = _http("POST", "/send", {"to": to, "from": me or "unknown", "from_id": mid or "", "body": body,
+            resp = _http("POST", "/send", {"to": to, "from": me or "unknown", "from_id": mid, "body": body,
                                            "kind": kind})
             # "Delivered" has to MEAN delivered. A cross-host send is only relaying (or parked for
             # an unreachable host, or held for the human on the far side), and the bus says so in
@@ -2687,8 +2711,14 @@ def cli_send(argv):
     if not ensure():
         sys.stderr.write("[romp mail] %s\n" % _unreachable_hint()); return 1
     me, mid = my_name(), my_id()
+    if not mid:
+        # the bus refuses anonymous sends; say it here with the actionable half
+        sys.stderr.write("[romp mail] cannot send: this session's own identity did not resolve "
+                         "(no session id), so the mail would arrive anonymously. Surface this to "
+                         "the user as a session-identity bug.\n")
+        return 1
     try:
-        resp = _http("POST", "/send", {"to": to, "from": me or "unknown", "from_id": mid or "", "body": body,
+        resp = _http("POST", "/send", {"to": to, "from": me or "unknown", "from_id": mid, "body": body,
                                        "kind": kind})
     except BusError as e:
         sys.stderr.write("[romp mail] %s\n" % e); return 1

--- a/tests/romp-postal.bats
+++ b/tests/romp-postal.bats
@@ -95,7 +95,10 @@ iso() { mkdir -p "$XDG_STATE_HOME/romp"; printf '{"%s":{"postalServiceOff":true}
 
 @test "an anonymous send is refused at the door, and by the CLI before it" {
     # the bus: a raw POST without from_id names the sender's identity resolution as the breakage
-    run curl -s -X POST "127.0.0.1:$ROMP_POSTAL_PORT/send" \
+    # (authorized with the machine's serve token, like every direct caller — the CLI carries it)
+    _tok="${ROMP_SERVE_TOKEN:-$(cat "$XDG_STATE_HOME/romp/serve-token")}"
+    run curl -s -X POST -H "X-Romp-Token: $_tok" \
+        "127.0.0.1:$ROMP_POSTAL_PORT/send" \
         -d '{"to": "beta", "body": "How is it going?", "kind": "question"}'
     [[ "$output" == *"sender identity required"* ]]
     [ "$(cnt "$(mb uuid-b)/new")" = "0" ]        # no ghost mail minted

--- a/tests/romp-postal.bats
+++ b/tests/romp-postal.bats
@@ -93,6 +93,19 @@ iso() { mkdir -p "$XDG_STATE_HOME/romp"; printf '{"%s":{"postalServiceOff":true}
     grep -q "From: alpha" "$(mb uuid-b)/new/"*
 }
 
+@test "an anonymous send is refused at the door, and by the CLI before it" {
+    # the bus: a raw POST without from_id names the sender's identity resolution as the breakage
+    run curl -s -X POST "127.0.0.1:$ROMP_POSTAL_PORT/send" \
+        -d '{"to": "beta", "body": "How is it going?", "kind": "question"}'
+    [[ "$output" == *"sender identity required"* ]]
+    [ "$(cnt "$(mb uuid-b)/new")" = "0" ]        # no ghost mail minted
+    # the CLI: with no resolvable self, it refuses with the actionable half and posts nothing
+    CLAUDE_CODE_SESSION_ID= ROMP_SID= run "$POSTAL" send beta "How is it going?"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"identity did not resolve"* ]]
+    [ "$(cnt "$(mb uuid-b)/new")" = "0" ]
+}
+
 @test "send to an unknown session errors" {
     run "$POSTAL" send ghost "x"
     [ "$status" -ne 0 ]

--- a/tests/test_fresh_install_federation.py
+++ b/tests/test_fresh_install_federation.py
@@ -86,6 +86,11 @@ class SpawnedSessionPath(unittest.TestCase):
 class CliSendEchoesRouting(unittest.TestCase):
     def _send(self, resp):
         saved_http, saved_ensure = ps._http, ps.ensure
+        saved_name, saved_id = ps.my_name, ps.my_id
+        # the sender must be IDENTIFIED (2026-08-18: an anonymous send is refused before _http —
+        # the guard these routing tests would otherwise trip in CI, where no session env exists);
+        # this class tests echo ROUTING, and its scenario always implied an identified sender
+        ps.my_name, ps.my_id = (lambda: "alpha"), (lambda: "uuid-a")
         ps.ensure = lambda: True
         ps._http = lambda method, path, payload=None: resp
         out = io.StringIO()
@@ -96,6 +101,7 @@ class CliSendEchoesRouting(unittest.TestCase):
         finally:
             ps.sys.stdout = saved_out
             ps._http, ps.ensure = saved_http, saved_ensure
+            ps.my_name, ps.my_id = saved_name, saved_id
         return rc, out.getvalue()
 
     def test_local_delivery_still_reads_delivered(self):

--- a/tests/test_postal_sender_identity.py
+++ b/tests/test_postal_sender_identity.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Anonymous mail is refused at the door, and legacy "unknown" mail never renders the mint.
+
+A sender that failed to resolve its own identity used to mail anyway: the bus minted a message
+literally "from unknown" (empty from_id), and the recipient's injected banner printed that word
+raw — a canned-sounding body over a ghost sender, met by the user on their laptop 2026-08-18
+("a greeting from an unknown thread"; the 2026-07-27 clear-fork minted the same ghost). Three
+seams now hold, all pinned here:
+  - the bus /send handler REFUSES a from_id-less send with an error naming the sender's own
+    identity resolution as the breakage (fail loudly, 2026-07-03);
+  - the MCP/CLI sender paths say the same thing BEFORE posting, with the actionable half;
+  - the banner formatters never print the literal "unknown"/"?" for mail already on disk or
+    arriving from an older peer bus — "an unidentified session" is what is true.
+"""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+ps = SourceFileLoader("romp_postal_sender_identity",
+                      os.path.join(BIN, "romp-postal-service")).load_module()
+
+
+class FromDisplay(unittest.TestCase):
+    def test_minted_ghosts_render_as_unidentified(self):
+        for ghost in ("unknown", "Unknown", "?", "", None):
+            self.assertEqual(ps._from_disp({"from": ghost}), "an unidentified session")
+
+    def test_real_names_pass_through(self):
+        self.assertEqual(ps._from_disp({"from": "web"}), "web")
+        self.assertEqual(ps._from_disp({"from": "TESTHOST:api"}), "TESTHOST:api")
+
+    def test_push_banner_uses_the_guard(self):
+        out = ps.format_push([{"from": "unknown", "date": "", "body": "How's it going?",
+                               "id": "m1", "kind": ""}])
+        self.assertIn("from an unidentified session", out)
+        self.assertNotIn("from unknown", out)
+
+    def test_inbox_banner_uses_the_guard(self):
+        out = ps.format_inbox([{"from": "?", "date": "", "body": "checking in",
+                                "id": "m2", "kind": ""}], me_id="abc")
+        self.assertIn("from an unidentified session", out)
+        self.assertNotIn("from ?", out)
+
+
+class SendRefusal(unittest.TestCase):
+    def test_handler_source_refuses_fromless_sends(self):
+        # the handler is route-bound (an HTTP class method); pin the guard at source the way
+        # the UI pins render branches — the bats drive the live route
+        src = open(os.path.join(BIN, "romp-postal-service")).read()
+        self.assertIn('if not frm_id:', src)
+        self.assertIn("sender identity required", src)
+
+    def test_mcp_and_cli_guards_precede_the_post(self):
+        src = open(os.path.join(BIN, "romp-postal-service")).read()
+        self.assertEqual(src.count("identity did not resolve"), 2, "both sender surfaces guard")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A sender that failed to resolve its own identity could mail anyway: the bus minted a message literally `from unknown` (empty `from_id`), and the recipient's injected banner printed the word raw — a canned-sounding body over a ghost sender, which the user met on their laptop as a greeting from a thread they couldn't place (the 2026-07-27 clear-fork minted the same ghost, fixed then only at one resolution site).

Three seams now hold:
- The bus `/send` handler refuses a `from_id`-less send with an error naming the sender's own identity resolution as the breakage — a visible refusal at the one door every sender uses beats ghost mail (the fail-loudly rule).
- The MCP and CLI sender paths say the same thing BEFORE posting, with the actionable half ("this session's own identity did not resolve — a session-identity bug worth surfacing to the user").
- The banner formatters never print the literal `unknown`/`?` for mail already on disk or arriving from an older peer bus: "an unidentified session" is what is true.

Cross-host relays are unaffected — they arrive on the peer routes with identity in their own headers. Tests: the display guard + both formatter surfaces + source pins (python), and a live-route refusal + CLI-guard case (bats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)