### PR TITLE
Captioner joins the give-up ladder: an empty capture stops retrying forever

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1493,6 +1493,77 @@ def append_caption(fsid, uid, grain, t, caption, live=False, natoms=None):
         f.write(json.dumps(rec) + "\n")
 
 
+CAPTION_FAIL_CAP = 3   # empty captures per unit-set before the tombstone — ARCH_FAIL_CAP's rationale
+                       # (the 2026-07-06 archiver storm), met again by the captioner on 2026-08-18:
+                       # 2,920 caption calls in 2h produced 62 records (~24/min of pure churn), because
+                       # an empty capture wrote nothing and the same closed units re-captioned every
+                       # pass, forever, fleet-wide — and fed the API-capacity window that broke a brief.
+
+
+def _caption_fails(fsid):
+    """{unit_id: consecutive empty-capture count} for units still under the cap — the captioner's
+    fail ledger (CAPDIR/<fsid>.fails.json), the archiver give-up's per-unit sibling."""
+    try:
+        d = json.loads((CAPDIR / (fsid + ".fails.json")).read_text())
+        return d if isinstance(d, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_caption_fails(fsid, d):
+    CAPDIR.mkdir(parents=True, exist_ok=True)
+    path = CAPDIR / (fsid + ".fails.json")
+    if d:
+        path.write_text(json.dumps(d))
+    else:
+        try:
+            path.unlink()                             # empty ledger → no file (nothing to prune later)
+        except OSError:
+            pass
+
+
+def _caption_strike(task, struck, gave):
+    """One EMPTY capture on a CLOSED unit-set: the call actually ran (paused/rate-gated skips never
+    reach here — _judge_run's paused contract) and produced no usable caption. A closed unit's text
+    never changes, so retrying it is superstition: at CAPTION_FAIL_CAP each unit gets an EMPTY
+    tombstone caption record — captioned_ids dedups it, and every reader filters on caption
+    truthiness, so the unit stops costing a call without ever rendering. Re-arm is structural, not
+    timed: only a re-parse minting NEW unit ids (a fork, a cut) makes new caption work.
+    `struck` is the PASS's already-struck id set: two tasks can carry the same unit id at different
+    grains, and one pass is one world-state — the same unchanged unit is one piece of evidence, one
+    strike, however many calls the pass spent on it."""
+    fsid = task["fsid"]
+    fails = _caption_fails(fsid)
+    give_up = []
+    for w in task["writes"]:
+        if w["id"] in struck:
+            continue
+        struck.add(w["id"])
+        n = int(fails.get(w["id"], 0)) + 1
+        if n >= CAPTION_FAIL_CAP:
+            fails.pop(w["id"], None)
+            give_up.append(w)
+        else:
+            fails[w["id"]] = n
+    _write_caption_fails(fsid, fails)
+    if give_up:
+        for w in give_up:
+            append_caption(fsid, w["id"], w["grain"], w["t"], "")
+        gave[fsid] = gave.get(fsid, 0) + len(give_up)     # ONE give-up row per fsid per pass (logged
+        #                                                   after the loop) — several tasks can cross
+        #                                                   the cap in the same pass
+
+
+def _caption_unfail(task):
+    """A successful caption clears its units' strike counts — only CONSECUTIVE empties tombstone."""
+    fsid = task["fsid"]
+    fails = _caption_fails(fsid)
+    ids = {w["id"] for w in task["writes"]}
+    kept = {k: v for k, v in fails.items() if k not in ids}
+    if kept != fails:
+        _write_caption_fails(fsid, kept)
+
+
 # ───────────────────────── the archiver (index tier; per session) ─────────────────────────
 # One record per session: a TOC headline + a 2-3 sentence abstract, summarized from the
 # session's TURN captions (cheap input, not raw transcript). Refreshed when the session gains a
@@ -4074,11 +4145,12 @@ def _discover_impl(now, window=None, forks=True):
 def _caption_call(task):
     """Caption one unit in a worker thread, tagging its session for usage logging. A 'prompt' task is the
     MESSAGE caption — a present-focused gist of the ask (gist_llm, logged as the captioner); a 'work' task
-    is the past-tense 'what got done' (caption_llm)."""
+    is the past-tense 'what got done' (caption_llm). Returns (caption, paused): paused rides out of the
+    worker thread because _judge_ctx is thread-local — the strike ledger in the main loop must never
+    count a rate-gate/pause skip as the model's empty verdict (the _judge_run paused contract)."""
     _judge_ctx.fsid = task.get("fsid")
-    if task.get("kind") == "prompt":
-        return gist_llm(task["text"])
-    return caption_llm(task["text"])
+    cap = gist_llm(task["text"]) if task.get("kind") == "prompt" else caption_llm(task["text"])
+    return cap, bool(getattr(_judge_ctx, "paused", False))
 
 
 def _archive_call(fsid, caps):
@@ -4128,22 +4200,36 @@ def _run_index(now=None, budget=BUDGET, fairness=FAIRNESS, concurrency=CONCURREN
     if verbose:
         sys.stderr.write("romp-judge: %d undone caption tasks, %d selected\n" % (len(pending), len(selected)))
     captions = 0
+    struck = set()                                        # one strike per unit per PASS (grains share ids)
+    gave = {}                                             # fsid → units tombstoned this pass (one log row each)
     with ThreadPoolExecutor(max_workers=concurrency) as ex:
         futs = {ex.submit(_caption_call, t): t for t in selected}
         for fut in as_completed(futs):
             task = futs[fut]
             try:
-                cap = fut.result()
+                cap, cap_paused = fut.result()
             except Exception:
-                cap = ""
+                cap, cap_paused = "", True                # a crashed worker is not the model's verdict
             if not cap:
-                continue                                  # empty = failed capture; skip, retry next pass
+                # A LIVE task retries by design (the open segment's text grows — the chunk cadence
+                # gates it) and a paused/rate-gated skip is not a verdict. A CLOSED unit's empty
+                # capture STRIKES toward the tombstone (CAPTION_FAIL_CAP): the same unchanged input
+                # re-captioned every pass was the 2026-08-18 churn — 2,920 calls for 62 records in 2h.
+                if not task.get("live") and not cap_paused:
+                    _caption_strike(task, struck, gave)
+                continue
+            if not task.get("live"):
+                _caption_unfail(task)                     # only CONSECUTIVE empties tombstone
             for w in task["writes"]:                      # one call → all the task's records (id-deduped)
                 append_caption(task["fsid"], w["id"], w["grain"], w["t"], cap,
                                live=task.get("live", False), natoms=task.get("natoms"))
                 captions += 1
                 if verbose:
                     sys.stderr.write("  [%s] %s\n" % (w["grain"], cap))
+    for _fsid, _n in gave.items():
+        _log_judge_error("captioner", _fsid, "give-up",
+                         note="%d unit(s) tombstoned after %d empty captures each; a re-parse minting "
+                              "new unit ids re-arms" % (_n, CAPTION_FAIL_CAP))
     # ── archiver: refresh a session's record when its turn-caption count grew (runs AFTER
     #    captioning, so this pass's new turn captions are included) ──
     arch_tasks = []

--- a/tests/test_judge_captioner_giveup.py
+++ b/tests/test_judge_captioner_giveup.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Captioner give-up: an empty capture on a CLOSED unit stops retrying forever (2026-08-18).
+
+The audit that found it: 2,920 captioner calls in two hours produced 62 caption records — a
+unit whose caption came back empty was never recorded, so captioned_ids re-selected the same
+closed units on every pass, fleet-wide, ~24 calls a minute, and fed the API-capacity window
+that broke a card's brief. The archiver got exactly this ladder on 2026-07-06 (ARCH_FAIL_CAP);
+the captioner now has its per-unit sibling: CAPTION_FAIL_CAP consecutive empty captures write
+an EMPTY tombstone caption record — captioned_ids dedups it, every reader filters on caption
+truthiness so it never renders — and a success clears the strike count. Paused/rate-gated
+skips never strike (the _judge_run paused contract, threaded out of the worker by
+_caption_call's (caption, paused) return). Synthetic fixtures only."""
+import json
+import os
+import re
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_capgiveup", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "11111111-2222-3333-4444-666666666666"
+T0 = 1781200000
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "user", "content": text}, "promptSource": "typed"}
+
+
+def aline(t, text, uuid, parent):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+class CaptionerGiveUp(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        munged = re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        (proj / munged).mkdir(parents=True)
+        self.tpath = proj / munged / (SID + ".jsonl")
+        self.tpath.write_text("\n".join(json.dumps(r) for r in [
+            uline(T0, "fix the flicker", "u1"),
+            aline(T0 + 30, "Fixed the flicker.", "a1", "u1")]) + "\n")
+        names = td / "names"; names.mkdir()
+        (names / SID).write_text("testsess\t%s\t#abcdef\n" % str(cdir))
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+                      jd.caption_llm, jd.archive_llm, jd.gist_llm)
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.CAPDIR, jd.ARCHDIR, jd.PCACHE = td / "captions", td / "archive", td / "pcache"
+        self.calls = []
+        jd.caption_llm = lambda text: self.calls.append(1) or ""       # EMPTY every call
+        jd.gist_llm = lambda text, judge="gist": self.calls.append(1) or ""
+        jd.archive_llm = lambda log: {"headline": "h", "abstract": "a"}
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.PCACHE,
+         jd.caption_llm, jd.archive_llm, jd.gist_llm) = self.saved
+        self.td.cleanup()
+
+    def _giveups(self):
+        try:
+            rows = [json.loads(l) for l in jd.ERRORS.read_text().splitlines()]
+        except OSError:
+            return []
+        return [r for r in rows if r.get("err") == "give-up" and r.get("judge") == "captioner"]
+
+    def _tombstones(self):
+        try:
+            rows = [json.loads(l) for l in (jd.CAPDIR / (SID + ".jsonl")).read_text().splitlines()]
+        except OSError:
+            return []
+        return [r for r in rows if not r.get("caption") and not r.get("live")]
+
+    def test_empty_captures_tombstone_at_the_cap_and_stop_costing_calls(self):
+        now = T0 + 120
+        g0 = len(self._giveups())
+        for i in range(jd.CAPTION_FAIL_CAP):
+            before = len(self.calls)
+            jd.run_index(now=now)
+            self.assertGreater(len(self.calls), before, "still selected while under the cap")
+        self.assertTrue(self._tombstones(), "the cap writes empty tombstone records")
+        self.assertEqual(len(self._giveups()) - g0, 1, "one give-up row at the transition")
+        settled = len(self.calls)
+        jd.run_index(now=now)
+        jd.run_index(now=now)
+        self.assertEqual(len(self.calls), settled, "tombstoned units never re-caption")
+        # tombstones are invisible to every reader: no turn caption, no gist
+        self.assertEqual(jd.session_turn_captions(SID), [])
+
+    def test_a_success_clears_the_strikes(self):
+        now = T0 + 120
+        jd.run_index(now=now)                                          # strike 1
+        fails = json.loads((jd.CAPDIR / (SID + ".fails.json")).read_text())
+        self.assertTrue(all(v == 1 for v in fails.values()))
+        jd.caption_llm = lambda text: "did the thing"                  # now the calls succeed
+        jd.gist_llm = lambda text, judge="gist": "the thing"
+        jd.run_index(now=now)
+        self.assertFalse((jd.CAPDIR / (SID + ".fails.json")).exists(),
+                         "success clears the ledger (only CONSECUTIVE empties tombstone)")
+        self.assertFalse(self._tombstones())
+        self.assertTrue(jd.session_turn_captions(SID))
+
+    def test_paused_skips_never_strike(self):
+        # a rate-gate/pause skip rides the paused flag out of the worker; it is not a verdict
+        saved = jd._caption_call
+        try:
+            jd._caption_call = lambda task: ("", True)
+            for _ in range(jd.CAPTION_FAIL_CAP + 1):
+                jd.run_index(now=T0 + 120)
+            self.assertFalse((jd.CAPDIR / (SID + ".fails.json")).exists(), "no strikes recorded")
+            self.assertFalse(self._tombstones(), "no tombstones from paused passes")
+        finally:
+            jd._caption_call = saved
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judge_captions.py
+++ b/tests/test_judge_captions.py
@@ -77,11 +77,13 @@ class SplitCaptions(unittest.TestCase):
         self.assertEqual(jd._prompt_text(self.open_seg["atoms"]), "now add a regression test")
 
     def test_caption_call_routes_prompt_to_the_gister(self):
+        # _caption_call returns (caption, paused) since 2026-08-18 — paused rides out of the worker
+        # thread so the strike ledger never counts a rate-gate skip as the model's empty verdict
         with mock.patch.object(jd, "gist_llm", return_value="G") as g, \
              mock.patch.object(jd, "caption_llm", return_value="W") as c:
-            self.assertEqual(jd._caption_call({"kind": "prompt", "text": "x"}), "G")
+            self.assertEqual(jd._caption_call({"kind": "prompt", "text": "x"}), ("G", False))
             g.assert_called_once_with("x")                                # message caption → the gister (its own label, 2026-07-08)
-            self.assertEqual(jd._caption_call({"kind": "work", "text": "y"}), "W")
+            self.assertEqual(jd._caption_call({"kind": "work", "text": "y"}), ("W", False))
             c.assert_called_once_with("y")                                # work caption → the past-tense captioner
 
 


### PR DESCRIPTION
A live audit (asked for by the user when a card sat "analyzing" for hours) found the captioner in a runaway loop: **2,920 calls in two hours produced 62 caption records** (~24 calls a minute of churn, fleet-wide), because a unit whose caption came back empty was never recorded as attempted — `captioned_ids` re-selected the same closed units on every pass, forever. The archiver got its give-up cap for the same failure mode on 2026-07-06; the captioner never joined, and the churn helped feed the API-capacity window that broke a card's brief (three 529s → briefer give-up), and grew judge-usage.jsonl to 59.5MB — which a follow-on PR will stop the timeline from re-reading per build.

Now: a CLOSED unit's empty capture strikes toward `CAPTION_FAIL_CAP` (one strike per unit per pass — grains share ids, and one pass is one world-state); at the cap the unit gets an EMPTY tombstone caption record, which `captioned_ids` dedups and every reader filters out on caption truthiness, so it stops costing a call without ever rendering. A success clears the strikes (only consecutive empties tombstone). Paused/rate-gated skips never strike — `_caption_call` now returns `(caption, paused)` so the thread-local paused contract rides out of the worker. LIVE tasks are exempt: an open segment's text legitimately grows. One give-up row logs per session per pass. Re-arm is structural, never timed: a re-parse minting new unit ids makes new caption work.

Tests mirror test_judge_archiver_giveup.py: tombstone at the cap + calls stop + invisible to readers; success clears strikes; paused skips never strike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)