### PR TITLE
The bars frame never silently starves: shared reader, bounded wire, loud degradation

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -653,6 +653,41 @@ def active_runs():
         return [dict(v) for v in _active.values()]
 
 
+_USAGE_PRUNE_BYTES = 48 * 1024 * 1024   # prune trigger — never reached at healthy volume (a normal
+                                         # month is a few MB); the 2026-08-18 captioner storm grew the
+                                         # log to 59.5MB, which the kernel then re-read per timeline build
+_USAGE_RETAIN_S = 31 * 86400             # matches the kernel reader's widest consumer window
+                                         # (_JUDGE_USAGE_RETAIN, the 30-day analytics view + slack)
+
+
+def _prune_usage_log():
+    """Rewrite USAGE keeping the newest 31 days once it outgrows the cap. The kernel's incremental
+    reader detects the shrink (size < offset) and re-reads cleanly. Best-effort and racy by design:
+    an append from a concurrent judge process during the rewrite window can be lost — this is
+    telemetry whose consumers read a bounded window, and the trigger only fires in pathological
+    growth. The prune says what it did (one stderr line), never silently."""
+    try:
+        if USAGE.stat().st_size <= _USAGE_PRUNE_BYTES:
+            return
+        parsed = []
+        for ln in USAGE.read_text(errors="replace").splitlines():
+            try:
+                o = json.loads(ln)
+            except Exception:
+                continue
+            if isinstance(o, dict):
+                parsed.append((o.get("t") or 0, ln))
+        floor = max((t for t, _ in parsed), default=0) - _USAGE_RETAIN_S
+        keep = [ln for t, ln in parsed if t >= floor]
+        tmp = USAGE.with_name(USAGE.name + ".tmp")
+        tmp.write_text("\n".join(keep) + ("\n" if keep else ""))
+        os.replace(tmp, USAGE)
+        sys.stderr.write("romp-judge: judge-usage.jsonl outgrew %dMB — pruned to the newest 31 days "
+                         "(%d rows kept)\n" % (_USAGE_PRUNE_BYTES // (1024 * 1024), len(keep)))
+    except Exception:
+        pass
+
+
 def _log_judge_usage(judge, tier, model, fsid, wrap, sent=None, recv=None):
     """Append ONE per-call usage line to USAGE for the kernel/UI cost rollup (judge_ui 2026-06-17).
     `wrap` is the claude -p JSON envelope. `sent`/`recv` are the LITERAL wall-clock floats bracketing the
@@ -663,6 +698,7 @@ def _log_judge_usage(judge, tier, model, fsid, wrap, sent=None, recv=None):
     must not break a judge call."""
     try:
         u = wrap.get("usage") or {}
+        _prune_usage_log()                       # bounded growth (one cheap stat at healthy sizes)
         with open(USAGE, "a") as f:
             f.write(json.dumps({"t": int(time.time()), "judge": judge, "tier": tier, "model": model,
                                 "fsid": fsid or None, "ms": wrap.get("duration_ms"),

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18215,6 +18215,27 @@ def _attach_run_usage(judging, t0, alive_sids):
                 mk["sent"], mk["recv"] = r.get("sent"), r.get("recv")
 
 
+_BARS_COMPLAINED = {}   # (who, stage) → cause head already logged: one line per DISTINCT cause,
+#                       never one per 2s build — but never silence (fail loudly, 2026-07-03)
+
+
+def _bars_complain(who, stage, e):
+    """A bars-build stage failed for `who` (a sid, or "*" for a global stage). The old behavior was a
+    silent swallow — a working session rendered its lane with ZERO bars forever and nothing said why
+    (the user 2026-08-18). The lane/frame still degrades the same way; the difference is the trace."""
+    head = "%s: %s" % (type(e).__name__, str(e)[:160])
+    if _BARS_COMPLAINED.get((who, stage)) == head:
+        return
+    _BARS_COMPLAINED[(who, stage)] = head
+    sys.stderr.write("timeline bars: %s %s failed — rendering without that data: %s\n"
+                     % (str(who)[:8], stage, head))
+
+
+_JUDGING_ROW_CAP = 20000     # judging marks per bars frame — far above any legible band density,
+                             # far below the 147k-mark storm frame that starved bars (2026-08-18)
+_JUDGING_TRIMMED = {}        # transition latch for the trim log line (order-of-magnitude keyed)
+
+
 def _run_judging(t0, alive_sids, semantic):
     """The judging band built from the per-call LOG (judge-usage.jsonl) instead of back-placed onto the
     work: ONE span per API call, plotted at its real wall-clock [sent, recv] — so the band shows WHEN each
@@ -18230,16 +18251,15 @@ def _run_judging(t0, alive_sids, semantic):
     for v in by.values():
         v.sort(key=lambda m: m["t"])
     out = []
-    try:
-        lines = (jd.STATE / "judge-usage.jsonl").read_text(errors="replace").splitlines()
-    except OSError:
-        return out
+    # The SHARED incremental reader, not a per-build full read: this used to read_text + json.loads
+    # the whole of judge-usage.jsonl on EVERY bars build (measured 2026-08-18 during the captioner
+    # storm: 59.5MB / 222,947 rows ≈ 1s per build, cache-busted every ~2s by the next usage row) —
+    # the pusher then spent its cycles parsing telemetry while {type:"bars"} frames starved and
+    # working sessions painted lanes with no bars. _judge_usage_rows already existed for exactly
+    # this (the 2026-08-13 analytics freeze); the band just never adopted it.
+    rows = _judge_usage_rows()
     done = set()                                      # (sid, judge, sent) of completed runs — to dedup live ones
-    for ln in lines:
-        try:
-            o = json.loads(ln)
-        except Exception:
-            continue
+    for o in rows:
         sid, judge = o.get("fsid"), o.get("judge")
         judge = _JUDGE_FAMILY.get(judge, judge)
         if sid not in alive_sids:
@@ -18275,6 +18295,21 @@ def _run_judging(t0, alive_sids, semantic):
         out.append({"judge": judge, "sid": sid, "t": sent, "t1": now,
                     "kind": (src or {}).get("kind", "run"), "text": (src or {}).get("text", ""),
                     "ms": 0, "in": 0, "out": 0, "sent": sent, "recv": None, "open": True})
+    # VOLUME BOUND on what rides the wire: every {type:"bars"} frame carries this array, and during
+    # the 2026-08-18 captioner storm 147,803 rows passed the 48h horizon and serialized to ~35MB per
+    # frame per client — the frames arrived minutes late or killed the socket, which IS the
+    # lanes-without-bars symptom. Past any legible density the band gains nothing, so keep the
+    # NEWEST marks and say what was dropped (never a silent cap) — one line per order-of-change,
+    # not per 2s build.
+    if len(out) > _JUDGING_ROW_CAP:
+        out.sort(key=lambda m: m["t"])
+        cut = len(out) - _JUDGING_ROW_CAP
+        del out[:cut]
+        if _JUDGING_TRIMMED.get("mag") != cut // 10000:
+            _JUDGING_TRIMMED["mag"] = cut // 10000
+            sys.stderr.write("timeline judging band: %d oldest marks trimmed from the frame "
+                             "(cap %d; a judge storm is the usual cause — see judge-usage.jsonl)\n"
+                             % (cut, _JUDGING_ROW_CAP))
     return out
 
 
@@ -18356,7 +18391,8 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
         if with_bars:
             try:
                 session = _parse(s["path"], sid, now)
-            except Exception:
+            except Exception as e:
+                _bars_complain(sid, "parse", e)           # a lane with zero bars must SAY why
                 session = {"turns": []}
             if live:
                 # Merge the LIVE TAIL like the chat does (the user 2026-07-02): a /model change streams the
@@ -18367,8 +18403,8 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
                 # Safe for the working signal — a command atom never forces the turn open (live_work).
                 try:
                     session = _merge_live_atoms(session, sid)
-                except Exception:
-                    pass
+                except Exception as e:
+                    _bars_complain(sid, "live-merge", e)  # disk-only bars from here — say so
             caps = _captions(sid)
             st_turns = session["turns"]
             open_now = _session_working(st_turns)         # WORKING from the event model — the one shared signal
@@ -18426,7 +18462,16 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
             turn_open = (live and ti == len(st_turns) - 1 and not turn["ended"]
                          and not any(x["type"] == "idle" for x in turn["atoms"])
                          and not _suspended_after(turn["end"]))   # dead lane (live False) or pre-sleep freeze → not an open bar
-            segs = _segs_seam(turn, goals)
+            try:
+                segs = _segs_seam(turn, goals)
+            except Exception as e:
+                # a malformed goals row must cost the SEAMS, not the lane's bars (2026-08-18: any
+                # exception here used to abort the whole bars frame after the skeleton had shipped)
+                _bars_complain(sid, "seams", e)
+                try:
+                    segs = em.segments(turn)
+                except Exception:
+                    segs = []
             _bft = (branch_of.get(sid) or {}).get("t")
             for si, seg in enumerate(segs):
                 if _bft and (seg.get("end") or seg["t"]) <= _bft:
@@ -18474,7 +18519,10 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
                 pass
         if with_bars:
             turns[sid] = bars
-            _derive_judging(sid, caps, goals, now - TL_HORIZON, semantic, seg_ends)
+            try:
+                _derive_judging(sid, caps, goals, now - TL_HORIZON, semantic, seg_ends)
+            except Exception as e:
+                _bars_complain(sid, "judging-marks", e)   # this lane loses its marks, the frame ships
         _bft = (branch_of.get(sid) or {}).get("t")
         compactions = [{"t": a["t"]} for turn in st_turns for a in turn["atoms"]
                        if a.get("type") == "system" and a.get("subtype") == "compact_boundary" and a.get("t")
@@ -18529,18 +18577,31 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
             "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"),  # lane mailbox → isolate from the Romp Postal Service (bin/romp-postal-service)
             "notify": _notify_session_effective(sid)})   # lane bell, EFFECTIVE (override, else the master default) → OS notification when this session's work blocks on you / completes (the user 2026-07-28)
     if with_bars:
-        messages = _postal_messages(now, set(id2name), id2name)
-        _bind_message_execs(messages, turns)             # connector exec → the recipient's process-start (real transit)
-        # mids STAY on the wire (2026-08-17): the merged-view dmid join (romp-timeline-view.js) re-binds
-        # a relayed connector's exec to the recipient turn by bar mids — the 2026-07-07 payload-audit pop
-        # ("no client ever read them") predated that 2026-08-06 feature and had silently starved it: the
-        # join's key set was always empty on live payloads, so relayed execs never re-bound client-side.
-        for _m in messages:
-            _m.pop("fromOrig", None)
+        # Each with_bars-only stage is guarded ALONE (2026-08-18): the pusher sends the cheap lane
+        # SKELETON before this heavy build, and its shared try used to abort the WHOLE bars frame on
+        # one malformed store row — every cycle re-sent fresh skeletons while {type:"bars"} never
+        # shipped, so every live lane painted bar-less with only a "push build:" stderr line as
+        # evidence. A band that fails now costs THAT band, loudly, never the frame.
+        try:
+            messages = _postal_messages(now, set(id2name), id2name)
+            _bind_message_execs(messages, turns)         # connector exec → the recipient's process-start (real transit)
+            # mids STAY on the wire (2026-08-17): the merged-view dmid join (romp-timeline-view.js) re-binds
+            # a relayed connector's exec to the recipient turn by bar mids — the 2026-07-07 payload-audit pop
+            # ("no client ever read them") predated that 2026-08-06 feature and had silently starved it: the
+            # join's key set was always empty on live payloads, so relayed execs never re-bound client-side.
+            for _m in messages:
+                _m.pop("fromOrig", None)
+        except Exception as e:
+            _bars_complain("*", "messages", e)
+            messages = []
         # The band's marks are the per-call RUN SPANS (g70): each judge call plotted at its real [sent, recv],
         # glossed by the nearest artifact mark — so a judge that ran shows up WHEN it ran (incl. distiller lag +
         # coordinating-courier classifications the artifact marks miss), not back-placed onto the work.
-        judging = _run_judging(now - TL_HORIZON, set(id2name), semantic)
+        try:
+            judging = _run_judging(now - TL_HORIZON, set(id2name), semantic)
+        except Exception as e:
+            _bars_complain("*", "judging", e)
+            judging = []
     else:                                                # SKELETON: the heavy time-plotted detail rides the {type:"bars"} message
         messages, judging = [], []
     # compaction-sweep gradient (widest→narrowest): the timeline's scan-bar has no client-side colormap, so

--- a/tests/test_timeline_bars_resilience.py
+++ b/tests/test_timeline_bars_resilience.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""The bars frame never silently starves (the user 2026-08-18: working sessions, lanes, no bars).
+
+Two mechanisms produced that symptom, both fixed and pinned here:
+  - _run_judging re-read and re-parsed the WHOLE judge-usage.jsonl on every bars build (measured
+    live: 59.5MB / 222,947 rows ≈ 1s per build during a captioner storm) and shipped every
+    horizon-passing row (147,803 → ~35MB) on EVERY {type:"bars"} frame — frames arrived minutes
+    late or killed the socket while the cheap lane skeleton kept painting. It now consumes the
+    SHARED incremental reader (_judge_usage_rows, built for the 2026-08-13 analytics freeze) and
+    bounds the wire at _JUDGING_ROW_CAP newest marks, logging what a trim dropped (never silent).
+  - with_bars-only stages ran unguarded inside a try whose handler aborted the WHOLE frame after
+    the skeleton had already shipped, and the per-lane parse swallowed exceptions silently — a
+    working session rendered bar-less forever with no trace. Every stage now degrades ALONE and
+    says so (_bars_complain, one line per distinct cause — the fail-loudly rule).
+Synthetic rows only (placeholder ids)."""
+import inspect
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_barsres", os.path.join(BIN, "romp-judge")).load_module()
+km = SourceFileLoader("romp_kernel_barsres", os.path.join(BIN, "romp-kernel")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NOW = 1781100000.0
+
+
+def _rows(n, t0):
+    return [{"t": int(t0 + i), "judge": "captioner", "fsid": SID,
+             "sent": t0 + i, "recv": t0 + i + 0.5, "ms": 500, "in": 10, "out": 5}
+            for i in range(n)]
+
+
+class RunJudgingFeed(unittest.TestCase):
+    def setUp(self):
+        self.saved = (km._judge_usage_rows, km.jd.active_runs)
+        km.jd.active_runs = lambda: []
+
+    def tearDown(self):
+        km._judge_usage_rows, km.jd.active_runs = self.saved
+
+    def test_consumes_the_shared_incremental_reader(self):
+        km._judge_usage_rows = lambda: _rows(3, NOW - 100)
+        out = km._run_judging(NOW - 3600, {SID}, [])
+        self.assertEqual(len(out), 3)
+        self.assertTrue(all(m["sid"] == SID and m["judge"] == "captioner" for m in out))
+        # and at source: no per-build full read of the log file remains
+        src = inspect.getsource(km._run_judging)
+        self.assertIn("_judge_usage_rows()", src)
+        self.assertNotIn(".read_text(", src, "the per-build full read is gone")
+
+    def test_the_wire_is_bounded_and_the_trim_says_so(self):
+        n = km._JUDGING_ROW_CAP + 50
+        km._judge_usage_rows = lambda: _rows(n, NOW - n - 10)
+        km._JUDGING_TRIMMED.clear()
+        out = km._run_judging(NOW - (n + 3600), {SID}, [])
+        self.assertEqual(len(out), km._JUDGING_ROW_CAP, "the frame carries at most the cap")
+        starts = [m["t"] for m in out]
+        self.assertEqual(max(starts), NOW - 11, "the NEWEST marks survive")
+        self.assertLess(n - km._JUDGING_ROW_CAP - 1 + (NOW - n - 10), min(starts),
+                        "the oldest were the ones trimmed")
+        self.assertIn("mag", km._JUDGING_TRIMMED, "the trim logged its transition (never a silent cap)")
+
+
+class FrameNeverSilentlyDies(unittest.TestCase):
+    def test_every_bars_stage_degrades_alone_and_loudly(self):
+        src = inspect.getsource(km.build_timeline)
+        # the per-lane parse swallow SAYS why a lane has no bars
+        self.assertIn('_bars_complain(sid, "parse", e)', src)
+        self.assertIn('_bars_complain(sid, "live-merge", e)', src)
+        # seam refinement failing costs the seams, never the lane's bars
+        self.assertIn('_bars_complain(sid, "seams", e)', src)
+        self.assertIn('_bars_complain(sid, "judging-marks", e)', src)
+        # the global stages are guarded ALONE — one malformed row costs that band, never the frame
+        self.assertIn('_bars_complain("*", "messages", e)', src)
+        self.assertIn('_bars_complain("*", "judging", e)', src)
+
+    def test_complain_is_once_per_distinct_cause(self):
+        km._BARS_COMPLAINED.clear()
+        km._bars_complain(SID, "parse", ValueError("boom"))
+        km._bars_complain(SID, "parse", ValueError("boom"))
+        self.assertEqual(len(km._BARS_COMPLAINED), 1)
+        km._bars_complain(SID, "parse", ValueError("other"))
+        self.assertEqual(km._BARS_COMPLAINED[(SID, "parse")], "ValueError: other",
+                         "a NEW cause logs again — silence is only for repeats")
+
+
+class UsageLogPrune(unittest.TestCase):
+    def test_outgrown_log_prunes_to_the_reader_window(self):
+        with tempfile.TemporaryDirectory() as td:
+            saved_usage, saved_cap = jd.USAGE, jd._USAGE_PRUNE_BYTES
+            try:
+                jd.USAGE = Path(td) / "judge-usage.jsonl"
+                old_t, new_t = 1700000000, 1781100000
+                rows = [json.dumps({"t": old_t + i, "judge": "captioner"}) for i in range(50)]
+                rows += [json.dumps({"t": new_t + i, "judge": "planner"}) for i in range(5)]
+                jd.USAGE.write_text("\n".join(rows) + "\n")
+                jd._USAGE_PRUNE_BYTES = 10                     # force the trigger
+                jd._prune_usage_log()
+                kept = [json.loads(l) for l in jd.USAGE.read_text().splitlines()]
+                self.assertEqual(len(kept), 5, "only rows within the newest 31 days survive")
+                self.assertTrue(all(r["t"] >= new_t for r in kept))
+            finally:
+                jd.USAGE, jd._USAGE_PRUNE_BYTES = saved_usage, saved_cap
+
+    def test_healthy_log_untouched(self):
+        with tempfile.TemporaryDirectory() as td:
+            saved_usage = jd.USAGE
+            try:
+                jd.USAGE = Path(td) / "judge-usage.jsonl"
+                jd.USAGE.write_text('{"t": 1781100000}\n')
+                jd._prune_usage_log()                          # under the real 48MB cap → no-op
+                self.assertEqual(jd.USAGE.read_text(), '{"t": 1781100000}\n')
+            finally:
+                jd.USAGE = saved_usage
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Several working sessions painted timeline lanes with NO work bars. Two mechanisms, both live-measured during the captioner storm (companion PR: the captioner give-up ladder):

- `_run_judging` re-read and re-parsed the whole of judge-usage.jsonl on every bars build (59.5MB / 222,947 rows, ~1s per build, cache-busted every ~2s by the next usage row) and shipped every horizon-passing row — 147,803 marks, ~35MB — on every `{type:"bars"}` frame to every client. Frames arrived minutes late or killed the socket while the cheap lane skeleton kept painting: lanes visible, zero bars. The band now consumes the shared incremental reader (`_judge_usage_rows`, built for the 2026-08-13 analytics freeze and never adopted here) and bounds the wire at the newest 20,000 marks, logging what a trim dropped — never a silent cap.
- The with_bars-only stages ran unguarded inside a try whose handler aborted the whole frame after the skeleton had already shipped, and the per-lane parse/live-merge swallowed exceptions silently — a working session rendered bar-less forever with no trace. Every stage now degrades ALONE and says so (`_bars_complain`, one stderr line per distinct cause): a bad goals row costs the seams, a bad store costs that band, never the frame.
- judge-usage.jsonl gains a writer-side prune (past 48MB, keep the newest 31 days — the reader's widest consumer window; the incremental reader detects the shrink and re-reads cleanly).

Tests: behavioral (shared-reader consumption, wire bound keeps the newest + logs the trim, prune keeps the reader window, healthy log untouched, complain-once-per-cause) + source pins holding every guard (the user's ask: this class of silent starvation must never recur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)