### PR TITLE
Scroll marks translate event indices to display units, and tagged sends lose the blue notch

### DIFF
--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -307,7 +307,8 @@ test("ticks and message notches share ONE scrollbar frame, so they can never dis
   // drifts from the notches' measured-height pixel offsets. Both painters now consume
   // contentOffsetFrame, the one event-index → content-pixel mapping.
   assert.match(UI, /function contentOffsetFrame\(/);
-  assert.match(UI, /const off = frame\.offsetOf\(idx\);/, "ticks place by the shared frame");
+  assert.match(UI, /const off = frame\.offsetOf\(evUnit\[idx\]\);/,
+    "ticks place by the shared frame, in UNIT space (anchors are events; the frame speaks units)");
   assert.doesNotMatch(UI, /\(idx \/ n\) \* 100/, "the uniform index-fraction percent frame is gone");
   // the rail repaints with the notches (same rAF), so both always draw from one world
   assert.match(UI, /paintRailSticky\(\); paintScrollMarks\(\); updateCommentRail\(\);/);

--- a/ui/webview/compact.test.ts
+++ b/ui/webview/compact.test.ts
@@ -79,3 +79,24 @@ test("summarizeTools: a single tool is singular; Bash pluralizes correctly", () 
 test("toolCounts: returns ordered, pluralized {label,count} for styled rendering", () => {
   assert.deepEqual(toolCounts(["Edit", "Edit", "Read"]), [{ label: "Edits", count: 2 }, { label: "Read", count: 1 }]);
 });
+
+test("every non-tool event owns exactly one display unit — the scroll-mark translation's ground truth", () => {
+  // eventUnitIndex (render.ts) inverts this stream to map mark anchors (events) onto the frame's
+  // unit space; that inversion is sound only if a user/assistant event is never folded into a
+  // group and never dropped (the user 2026-08-18, whose reply notches vanished in compact mode)
+  const kinds = ["user", "tool", "tool", "assistant", "user", "tool", "user"];
+  const items = compactDisplay(kinds, kinds.map((k) => (k === "tool" ? "Bash" : undefined)));
+  const seen = new Map<number, number>();
+  items.forEach((it, u) => {
+    if (it.kind === "toolgroup") for (const i of it.indices) seen.set(i, u);
+    else seen.set(it.index, u);
+  });
+  for (let i = 0; i < kinds.length; i++) {
+    assert.ok(seen.has(i), "event " + i + " (" + kinds[i] + ") maps to a unit");
+    if (kinds[i] !== "tool") {
+      const u = seen.get(i)!;
+      const it = items[u];
+      assert.equal(it.kind, "event", "a non-tool event is its OWN unit, never inside a fold");
+    }
+  }
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1656,6 +1656,23 @@ let scrollMarksSig = "";
 // spacer's actual height) match truth so closely that boundary crossings correct by ~nothing.
 const unitHeights = new Map<string, Map<number, number>>();
 
+// EVENT index → DISPLAY-UNIT index. Unit === event only in NORMAL mode; in compact mode tool runs
+// fold into toolgroup units, so the two spaces diverge — and contentOffsetFrame speaks UNITS
+// (data-unit tags, spacer counts, cached heights are all unit-keyed) while marks anchor to EVENTS.
+// Passing event indices straight through was the missing-notch bug (the user 2026-08-18: "some are
+// displayed, others aren't" — replies land beside big tool runs, exactly where the spaces diverge
+// most, and a wrong unit index found no node, so the mark silently vanished).
+function eventUnitIndex(s: Session): Int32Array {
+  const map = new Int32Array(s.events.length).fill(-1);
+  const items = displayItems(s);
+  for (let u = 0; u < items.length; u++) {
+    const it = items[u];
+    if (it.kind === "toolgroup") { for (const i of it.indices) map[i] = u; }
+    else map[it.index] = u;
+  }
+  return map;
+}
+
 // ONE content-space frame for every scrollbar overlay (the user 2026-08-17, watching comment ticks
 // drift past message notches as history loaded): marks anchored to transcript positions share an
 // inherent monotonic order, so every overlay must place them with the SAME event-index → pixel
@@ -1743,13 +1760,18 @@ function paintScrollMarks(): void {
   if (!frame) { box.style.display = "none"; scrollMarksSig = ""; return; }
   const sh = frame.sh;
   const offs: number[] = [];
+  const evUnit = eventUnitIndex(s);                       // marks anchor to EVENTS; the frame speaks UNITS
   for (let i = 0; i < s.events.length; i++) {
-    const ev = s.events[i] as ChatEvent & { human?: boolean; romp?: boolean; rompAuto?: boolean; canned?: string; md?: string };
-    if (ev.kind !== "user" || !ev.human || ev.romp || ev.rompAuto) continue;
+    const ev = s.events[i] as ChatEvent & { human?: boolean; romp?: boolean; rompAuto?: boolean; canned?: string; md?: string; tag?: string };
+    // a TAGGED message is machine-sent under a label, not the user's words — the blue that means
+    // "yours" would lie (the same identity rule the rail dot follows since the tag dress landed)
+    if (ev.kind !== "user" || !ev.human || ev.romp || ev.rompAuto || ev.tag) continue;
     const md = (ev.md || "").trim();
     // gestures are the user's DOINGS, not their words — no notch (the Continue row, a /command)
     if (!md || ev.canned === "continue" || SLASH_CMD_RE.test(md)) continue;
-    const off = frame.offsetOf(i);
+    const u = evUnit[i];
+    if (u < 0) continue;                                  // not in the display stream (never for user events)
+    const off = frame.offsetOf(u);
     if (off == null) continue;
     offs.push(off);
   }
@@ -5564,10 +5586,11 @@ function updateCommentRail(): void {
   const frame = contentOffsetFrame(content, v, s);
   if (!frame) { rail?.remove(); cmtRailSig = ""; return; }
   const ticks: Array<{ th: CommentThread; y: number }> = [];
+  const evUnit = eventUnitIndex(s);                       // anchors are EVENTS; the frame speaks UNITS
   for (const th of threads) {
     const idx = s.events.findIndex((e) => e.uuid === th.anchorUuid);
-    if (idx < 0) continue;
-    const off = frame.offsetOf(idx);
+    if (idx < 0 || evUnit[idx] < 0) continue;
+    const off = frame.offsetOf(evUnit[idx]);
     if (off == null) continue;
     // the same proportional map the notches use, clamped so the last tick stays on the strip
     ticks.push({ th, y: Math.min(r.height - 6, Math.round((off / frame.sh) * (r.height - 4))) });

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -17,7 +17,8 @@ test("one notch per real user message across the WHOLE loaded conversation", () 
   // come from the full resident events array: true pixels for rendered turns, a proportional slot
   // inside the MEASURED spacer for the rest — the same estimate the scrollbar itself stands on.
   assert.match(RENDER, /for \(let i = 0; i < s\.events\.length; i\+\+\) \{/);
-  assert.match(RENDER, /if \(ev\.kind !== "user" \|\| !ev\.human \|\| ev\.romp \|\| ev\.rompAuto\) continue;/);
+  assert.match(RENDER, /if \(ev\.kind !== "user" \|\| !ev\.human \|\| ev\.romp \|\| ev\.rompAuto \|\| ev\.tag\) continue;/,
+    "machine-sent tagged messages never wear the blue that means yours");
   assert.match(RENDER, /ev\.canned === "continue" \|\| SLASH_CMD_RE\.test\(md\)/,
     "a /command or Continue gesture is a doing, not words — no notch");
   assert.match(RENDER, /'\.turn\[data-unit="' \+ i \+ '"\]'/, "rendered events use their true pixel offset");
@@ -50,4 +51,18 @@ test("positions are proportional and pure scrolls do no DOM work", () => {
 test("passive chrome in the user's own blue", () => {
   assert.match(CSS, /\.scroll-marks \{ position: fixed; z-index: 3; pointer-events: none; width: 12px; \}/);
   assert.match(CSS, /background: #2b6cef; opacity: 0\.65;/, "the outgoing-bubble blue, never the romp accent");
+});
+
+test("marks translate EVENT indices to DISPLAY UNITS before asking the frame", () => {
+  // the user 2026-08-18: "some notches are displayed, others aren't — maybe the ones where I
+  // replied". Unit === event only in normal mode; compact mode folds tool runs into toolgroup
+  // units, so event indices passed straight to the unit-keyed frame found no node (or the wrong
+  // one) and the mark silently vanished — worst exactly beside big tool runs, where replies to a
+  // working session land. Both painters now translate through eventUnitIndex.
+  assert.match(RENDER, /function eventUnitIndex\(s: Session\): Int32Array/);
+  assert.match(RENDER, /if \(it\.kind === "toolgroup"\) \{ for \(const i of it\.indices\) map\[i\] = u; \}/);
+  assert.match(RENDER, /const evUnit = eventUnitIndex\(s\);/);
+  assert.match(RENDER, /const u = evUnit\[i\];/);
+  assert.match(RENDER, /const off = frame\.offsetOf\(u\);/, "notches ask the frame in unit space");
+  assert.match(RENDER, /const off = frame\.offsetOf\(evUnit\[idx\]\);/, "comment ticks too — one translation, both overlays");
 });


### PR DESCRIPTION
Some user messages showed no blue notch while others did — replies especially. Unit === event only in normal mode: compact mode folds tool runs into toolgroup units, so the `data-unit` tags, spacer counts, and cached heights all speak DISPLAY-UNIT indices while the notch and comment-tick painters passed EVENT indices straight into the shared frame. A wrong unit index found no node (or the wrong one) and the mark silently vanished — worst exactly beside big tool runs, which is where replies to a working session land.

Both painters now translate through `eventUnitIndex` (event → display unit, inverted from the same `displayItems` stream the renderer tags nodes from), and compact.test.ts pins the inversion's ground truth: a non-tool event is always its own unit, never folded, never dropped.

Also: a TAGGED message (machine-sent under a label) no longer paints the blue notch — the blue means the user's own words, the same identity rule the rail dot adopted with the tag dress.

The reply-context chip that was reported alongside this was verified NOT broken: a live scan of every follow-up record in the last 5-6 days (308 native + 61 mid-turn splices) shows the kernel stripping the quoted context into `fuCtx` and the header rendering it; both halves were already pinned by test_kernel_followup_render.py and followup-expand.test.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)