### PR TITLE
The rail's day label rides above the stamp and never clips at the pane edge

### DIFF
--- a/ui/webview/rail-day.test.ts
+++ b/ui/webview/rail-day.test.ts
@@ -1,8 +1,9 @@
-// The day-context label rides above the rail's TOP stamp (the user 2026-08-17): whenever that
-// stamp's day is not today, a small "Yesterday" / "3 days ago" sits just above it — anchored to the
-// tracked turn's marker while it leads, to the first stamp below the line when nothing is tracked
-// ("the next one"), and to the sticky's line once it takes over, so the handoff lands at the same
-// pixel and scrolling never jumps. Source pins (dayContext's behavior is tested in time-marker.test.ts).
+// The day-context label rides ABOVE the rail's TOP stamp (the user 2026-08-17; moved above the
+// stamp 2026-08-18, with a video): whenever that stamp's day is not today, a small "Yesterday" /
+// "3 days ago" sits just above it — anchored to the tracked turn's marker while it leads, to the
+// first stamp below the line when nothing is tracked ("the next one"), and to the slot line once
+// the sticky takes over, so the handoff lands at the same pixel and scrolling never jumps.
+// Source pins (dayContext's behavior is tested in time-marker.test.ts).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -16,19 +17,93 @@ test("the label anchors to whichever stamp owns the top slot, and hands off at t
   assert.match(RENDER, /const anchorM = marker \|\| \(firstBelow \? firstBelow\[0\] : null\);/);
   assert.match(RENDER, /paintDay\(realLeads \? markerTop : \(firstBelow \? firstBelow\[1\] : cBottom \+ 1\)\);/,
     "a leading real stamp carries the label at its own position");
-  assert.match(RENDER, /paintDay\(line\);/, "the sticky carries it at the line — same pixel at handoff");
-  // BELOW the stamp, in the stamp's own box (the user 2026-08-17: floating it ABOVE bled into the
-  // tab bar at the top of the view, and transform alignment didn't match the stamp's right edge)
-  assert.match(RENDER, /const yTop = slotTop \+ stampH \+ 1;/);
-  assert.match(RENDER, /day\.style\.width = gRect!\.width \+ "px";/);
-  assert.match(RENDER, /if \(day\.textContent !== label\) day\.textContent = label;/, "text swaps only at day boundaries");
-  assert.match(RENDER, /if \(!label \|\| yTop > cBottom\) \{ day\.style\.display = "none"; return; \}/,
-    "today → no label; an off-screen anchor paints nothing");
+  assert.match(RENDER, /paintDay\(slotLine\);/, "the sticky carries it at the slot line — same pixel at handoff");
+  // The slot line drops by the label's height when a label shows, so the label above the STICKY
+  // stays inside the pane instead of bleeding into the tab bar (the 2026-08-17 first cut floated
+  // it above the sticky without shifting the sticky down). Above a leading REAL stamp the room is
+  // free: markers sit 10–15px below their turn's top, more than the label's ~10px height.
+  assert.match(RENDER, /const slotLine = line \+ \(label \? dayH \+ 1 : 0\);/);
+  assert.match(RENDER, /const realLeads = markerShown && markerTop >= slotLine;/,
+    "the handoff threshold moves with the slot, so stamp and label swap on the same pixels");
+  assert.match(RENDER, /stamp\.style\.top = slotLine \+ "px";/);
+  assert.match(RENDER, /m\.style\.visibility = top < slotLine \+ g\.height \? "hidden" : "";/,
+    "an incoming stamp hides before it can superimpose the sticky or the label riding above the slot");
+  assert.match(RENDER, /if \(slotTop > cBottom\) \{ day\.style\.display = "none"; return; \}/,
+    "an off-screen anchor paints nothing");
+  assert.match(RENDER, /\} else day\.style\.display = "none";/, "today → the label hides, never lingers stale");
+  assert.match(RENDER, /if \(!label\) return;/, "and paintDay never resurrects it");
+  // One ORDERED block: text set → shown → measured → slot computed. Order is load-bearing — measuring
+  // while display:none reads 0×0 and every downstream formula silently degenerates.
+  assert.match(RENDER, new RegExp(
+    String.raw`if \(day\.textContent !== label\) day\.textContent = label;\n` +
+    String.raw`\s*day\.style\.display = "";.*\n` +
+    String.raw`\s*const r = day\.getBoundingClientRect\(\); dayW = r\.width; dayH = r\.height;\n` +
+    String.raw`\s*\} else day\.style\.display = "none";\n` +
+    String.raw`\s*const slotLine = line \+ \(label \? dayH \+ 1 : 0\);`),
+    "measure-while-visible feeds slotLine, in that order");
 });
 
-test("the label is passive fixed chrome, right-aligned to the gutter with no width math", () => {
-  assert.match(CSS, /\.rail-day \{\s*\n\s*position: fixed; z-index: 3; pointer-events: none; white-space: nowrap;/);
-  assert.match(CSS, /text-align: right;/);
+test("the label rides ABOVE the stamp and never clips at the pane's left edge", () => {
+  // ABOVE (the user 2026-08-18, with a video): below the stamp, the next incoming stamp scrolled
+  // straight through the label's spot and the label leapt over it at every handoff. Above it,
+  // nothing crosses the label's path — and the clamp keeps it off the tab bar in every case.
+  assert.match(RENDER, /day\.style\.top = Math\.max\(cTop \+ 1, slotTop - dayH - 1\) \+ "px";/);
+  // Natural width, right edge on the gutter's right edge, left edge never past the pane's:
+  // "2 days ago" at 0.68em is wider than the 47px gutter, and the old box pinned to the gutter's
+  // left/width clipped its leading digit at the pane edge (the user 2026-08-18, with a screenshot).
+  assert.match(RENDER, /day\.style\.left = Math\.max\(2, gRect!\.right - dayW\) \+ "px";/);
+  assert.doesNotMatch(RENDER, /day\.style\.width/, "no width pin — the box shrinkwraps its text");
+});
+
+test("the label is passive fixed chrome, smaller and dimmer than the stamp", () => {
+  assert.match(CSS, /\.rail-day \{\s*\n\s*position: fixed; z-index: 3; pointer-events: none; white-space: nowrap; line-height: 1;/);
   assert.match(CSS, /font-size: 0\.68em; letter-spacing: 0\.03em; color: var\(--dim\); opacity: 0\.85;/,
     "context, not the time itself — smaller and dimmer than the stamp");
+});
+
+// ── executed replica of the placement decision ───────────────────────────────────────────────────
+// Faithful to paintRailSticky's day pass (pinned above): slotLine = line + dayH + 1 when a label
+// shows; the label rides at slotTop - dayH - 1 (clamped to cTop + 1), its left edge at
+// max(2, gutterRight - labelWidth); an anchor below the pane paints nothing. Same style as
+// rail-sticky-stamp.test.ts's decideSticky: the pure math, executed.
+const BUFFER = 6;
+function placeDay(o: { label: string; dayW: number; dayH: number; slotTop: number;
+                       cTop: number; cBottom: number; gutterRight: number }):
+    { show: boolean; left?: number; top?: number; slotLine: number } {
+  const line = o.cTop + BUFFER;
+  const slotLine = line + (o.label ? o.dayH + 1 : 0);
+  if (!o.label) return { show: false, slotLine };
+  if (o.slotTop > o.cBottom) return { show: false, slotLine };
+  return { show: true, slotLine,
+    left: Math.max(2, o.gutterRight - o.dayW),
+    top: Math.max(o.cTop + 1, o.slotTop - o.dayH - 1) };
+}
+const G = { cTop: 100, cBottom: 700, gutterRight: 47, dayH: 9 };   // gutter per .thread's 44px pad + marker right at +3
+const LINE = G.cTop + BUFFER;
+
+test("executed: a label wider than the gutter slides right to stay whole — never past the pane's left edge", () => {
+  const r = placeDay({ ...G, label: "2 days ago", dayW: 52, slotTop: 300 });
+  assert.equal(r.left, 2, "left edge clamps at 2px, so no character is ever cut off");
+});
+
+test("executed: a label that fits keeps its right edge on the gutter's right edge, like the stamp's", () => {
+  const r = placeDay({ ...G, label: "Last week", dayW: 40, slotTop: 300 });
+  assert.equal(r.left! + 40, G.gutterRight, "right edges align when there is room");
+});
+
+test("executed: above the stamp, and above the STICKY it stays inside the pane — no tab-bar bleed", () => {
+  const marker = placeDay({ ...G, label: "Yesterday", dayW: 45, slotTop: 300 });
+  assert.equal(marker.top, 300 - G.dayH - 1, "riding a real stamp: label bottom 1px above the stamp");
+  const sticky = placeDay({ ...G, label: "Yesterday", dayW: 45, slotTop: LINE + G.dayH + 1 });
+  assert.equal(sticky.top, LINE, "riding the sticky at the slot line: label top is the buffer line itself");
+  assert.ok(sticky.top! >= G.cTop, "inside the pane — the slot shift is exactly the room the label needs");
+});
+
+test("executed: no label (today) leaves the slot line AT the line — today's layout is untouched", () => {
+  assert.equal(placeDay({ ...G, label: "", dayW: 0, dayH: 0, slotTop: 300 }).slotLine, LINE);
+  assert.equal(placeDay({ ...G, label: "Yesterday", dayW: 45, slotTop: 300 }).slotLine, LINE + G.dayH + 1);
+});
+
+test("executed: an anchor below the pane's bottom paints nothing", () => {
+  assert.equal(placeDay({ ...G, label: "Yesterday", dayW: 45, slotTop: 701 }).show, false);
 });

--- a/ui/webview/rail-sticky-stamp.test.ts
+++ b/ui/webview/rail-sticky-stamp.test.ts
@@ -26,19 +26,24 @@ test("the hand-off happens at the buffer line, with the crossed marker hidden", 
   const end = SRC.indexOf("// Scroll is the sticky stamp's primary driver");
   assert.ok(end > 0, "the slice end anchor still exists (else every assertion below matches the whole file)");
   const fn = SRC.slice(SRC.indexOf("function paintRailSticky"), end);
-  // the buffer line doubles as the sticky's rest position AND the hand-off threshold
+  // the buffer line doubles as the sticky's rest position AND the hand-off threshold. When a day
+  // label shows (old-day history), both drop by the label's height — the slot line — so the label
+  // riding above the stamp stays inside the pane; with no label, slotLine === line and nothing
+  // moves (see rail-day.test.ts).
   assert.match(fn, /const BUFFER = 6;/);
   assert.match(fn, /const line = cTop \+ BUFFER;/);
+  assert.match(fn, /const slotLine = line \+ \(label \? dayH \+ 1 : 0\);/);
   // the TRACKED turn's own stamp leads while it is at or below the line; the sticky takes over once it
   // crosses. Keyed on the tracked marker, NOT on any stamp anywhere — a later time change further down the
   // view must not blank the top slot, which would reintroduce the empty gap this exists to prevent.
   assert.match(fn, /marker = m; markerTop = r\.top; markerShown = !!m\.textContent;/);
-  assert.match(fn, /const realLeads = markerShown && markerTop >= line;/);
+  assert.match(fn, /const realLeads = markerShown && markerTop >= slotLine;/);
   assert.match(fn, /if \(!hm \|\| realLeads\) \{/);
-  // when the sticky leads, every marker that crossed ABOVE the line is hidden so no clipped duplicate shows
-  assert.match(fn, /for \(const \[m, top\] of all\) m\.style\.visibility = top < line \? "hidden" : "";/);
-  // and it rests exactly at the line
-  assert.match(fn, /stamp\.style\.top = line \+ "px";/);
+  // when the sticky leads, every marker that crossed ABOVE the slot line — or INTO the sticky's own
+  // box — is hidden, so no clipped duplicate shows and no incoming stamp superimposes the sticky
+  assert.match(fn, /for \(const \[m, top\] of all\) m\.style\.visibility = top < slotLine \+ g\.height \? "hidden" : "";/);
+  // and it rests exactly at the slot line
+  assert.match(fn, /stamp\.style\.top = slotLine \+ "px";/);
   // ...while a real stamp leading means nothing is suppressed
   assert.match(fn, /for \(const \[m\] of all\) m\.style\.visibility = "";/);
 });
@@ -60,11 +65,14 @@ test("the CSS pins it to the viewport, above the rail, click-through", () => {
 });
 
 // ── executed replica of the selection + hand-off decision ────────────────────────────────────────────────
-// Faithful to paintRailSticky: line = cTop + BUFFER; marker = the last turn whose top <= line (its time is
+// Faithful to paintRailSticky in the label-free case (today's history: slotLine === line; the day-label
+// shift is pinned at the source above and in rail-day.test.ts): line = cTop + BUFFER; marker = the last turn whose top <= line (its time is
 // what sits at the top), tracked along with WHERE its own marker is and whether that marker is stamped. That
 // tracked marker leads while it is at or below the line; otherwise the sticky leads at the line and every
-// marker with mTop < line is hidden. A turn models {top} and its marker {id, hm, text, mTop, mBottom}.
+// marker with mTop < line + STAMP_H is hidden — the sticky's bottom edge, so a stamp can never superimpose
+// it. A turn models {top} and its marker {id, hm, text, mTop, mBottom}.
 const BUFFER = 6;
+const STAMP_H = 13;   // the modeled marker box height (mBottom - mTop below)
 type Marker = { id: string; hm: string; text: string; mTop: number; mBottom: number };
 type Turn = { top: number; marker: Marker | null };
 function decideSticky(turns: Turn[], cTop: number, _cBottom: number): { show: boolean; hm: string; hidden: string[] } {
@@ -83,7 +91,7 @@ function decideSticky(turns: Turn[], cTop: number, _cBottom: number): { show: bo
   if (!hm || realLeads) return { show: false, hm: "", hidden: [] };
   // the code hides EVERY marker with top < line (so a straggler resets when it scrolls back); only the TIMED
   // ones are visually meaningful, so the replica reports those — hiding an empty same-minute marker is a no-op
-  return { show: true, hm, hidden: all.filter((m) => m.text && m.mTop < line).map((m) => m.id) };
+  return { show: true, hm, hidden: all.filter((m) => m.text && m.mTop < line + STAMP_H).map((m) => m.id) };
 }
 
 const CTOP = 100, CBOT = 700, LINE = CTOP + BUFFER;   // #content spans [100, 700]; the line sits at 106
@@ -179,4 +187,19 @@ test("executed property: the top slot always holds exactly one time — never a 
       .some((t) => !!t.marker!.text && t.marker!.mTop >= LINE);
     assert.equal(r.show || trackedLeads, true, "and never nothing: something always holds the slot");
   }
+});
+
+test("executed: a stamp intruding into the sticky's box is hidden, never superimposed", () => {
+  // The tracked turn's stamp crossed above (sticky leads, suppressed same-minute marker), and the next
+  // turn — a tool turn, marker only 10px below its top — has scrolled its stamped minute-change into the
+  // sticky's own band without its turn reaching the line yet. Under a top-edge-only threshold the two
+  // HH:MM texts superimpose in the gutter; the bottom-edge threshold hides the intruder until it leads.
+  const turns: Turn[] = [
+    { top: 90, marker: { id: "tracked", hm: "10:05", text: "", mTop: 100, mBottom: 113 } },
+    { top: 107, marker: { id: "incoming", hm: "10:06", text: "10:06", mTop: 117, mBottom: 130 } },
+  ];
+  const r = decideSticky(turns, CTOP, CBOT);
+  assert.equal(r.show, true, "the sticky still holds the slot");
+  assert.equal(r.hm, "10:05", "showing the tracked turn's time");
+  assert.deepEqual(r.hidden, ["incoming"], "the intruding stamp is hidden until it takes the lead");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1813,41 +1813,51 @@ function paintRailSticky(): void {
   }
   const hm = marker ? (marker.dataset.hm || "") : "";
   // DAY CONTEXT (the user 2026-08-17): whichever stamp owns the top slot also names its DAY, in a
-  // small label riding just above it, whenever that day is not today — so scrolling through history
+  // small label riding just ABOVE it, whenever that day is not today — so scrolling through history
   // always says where you are even with the day divider off-screen. The anchor is the tracked turn's
-  // marker when there is one, else the first stamp below the line ("the next one"); its position is
-  // wherever that stamp sits (the line itself once the sticky leads), so the label moves WITH the
-  // leading stamp and the sticky handoff lands at the same pixel — no jump at the transition. The
-  // text swaps only at day boundaries.
+  // marker when there is one, else the first stamp below the line ("the next one"); the label moves
+  // WITH the leading stamp, and at handoff the sticky takes the very pixels the stamp and label held,
+  // so there is no jump at the transition. The text swaps only at day boundaries.
   const day = ensureRailDay();
   const firstBelow = all.find(([, top]) => top >= line);
   const anchorM = marker || (firstBelow ? firstBelow[0] : null);
-  // The label sits BELOW the top stamp, in the STAMP'S OWN BOX (same left/width, right-aligned like
-  // the time itself, so the two right edges line up by construction — the user 2026-08-17, whose
-  // first cut floated the label ABOVE the slot: at the top of the view that bled into the tab bar,
-  // and its transform-based alignment didn't match the stamp's). Below-stamp keeps it inside the
-  // pane at every scroll position, and the handoff stays seamless: a leading stamp carries its
-  // label at markerBottom, and the sticky shows it at the very same y when it takes over.
   const gRect = anyMarker ? anyMarker.getBoundingClientRect() : null;
-  const stampH = anchorM ? anchorM.getBoundingClientRect().height || 11 : 11;
-  const paintDay = (slotTop: number) => {
-    const ep = anchorM ? Number(anchorM.dataset.epoch || 0) : 0;
-    const label = ep && gRect ? dayContext(ep, Date.now()) : "";
-    const yTop = slotTop + stampH + 1;
-    if (!label || yTop > cBottom) { day.style.display = "none"; return; }
+  // ABOVE the stamp, not below (the user 2026-08-18, with a video): below it, the next incoming
+  // stamp scrolled straight through the label's spot and the label had to leap over it — a visible
+  // collision and jump at every handoff. Above it, nothing ever crosses the label's path. A leading
+  // real stamp always has room for its label inside the pane: markers sit 10–20px below their
+  // turn's top, and the label band (dayH + 1 ≈ 9.8px at the default 13px chat font) fits even the
+  // smallest 10px offset — barely, so the tab-bar clamp below backstops it. The sticky alone rests
+  // AT the line, so when a
+  // label shows, the slot line drops by the label's height to make that room (the 2026-08-17 first
+  // cut floated the label above the sticky without shifting it, and bled into the tab bar).
+  const ep = anchorM ? Number(anchorM.dataset.epoch || 0) : 0;
+  const label = ep && gRect ? dayContext(ep, Date.now()) : "";
+  let dayW = 0, dayH = 0;
+  if (label) {
     if (day.textContent !== label) day.textContent = label;
-    day.style.left = gRect!.left + "px";
-    day.style.width = gRect!.width + "px";
-    day.style.top = yTop + "px";
+    day.style.display = "";                        // must be visible to measure
+    const r = day.getBoundingClientRect(); dayW = r.width; dayH = r.height;
+  } else day.style.display = "none";
+  const slotLine = line + (label ? dayH + 1 : 0);
+  const paintDay = (slotTop: number) => {
+    if (!label) return;
+    if (slotTop > cBottom) { day.style.display = "none"; return; }   // anchor is off the bottom
+    // Natural width, right edge on the gutter's right edge (the stamp's own) — but never past the
+    // pane's left edge: "2 days ago" at 0.68em is wider than the 47px gutter, and a box pinned to
+    // the gutter clipped its leading digit at the pane edge (the user 2026-08-18, with a
+    // screenshot). When it doesn't fit, the label slides right just enough to stay whole.
+    day.style.left = Math.max(2, gRect!.right - dayW) + "px";
+    day.style.top = Math.max(cTop + 1, slotTop - dayH - 1) + "px";
     day.style.display = "";
   };
-  // The tracked turn's OWN stamp leads the top slot while it is at or below the line — it scrolls up freely
-  // until it reaches the line, and the instant it crosses ABOVE (markerTop < line) the sticky takes the same
-  // slot showing the same time, so the swap is invisible: no gap, no clipped sliver (the user 2026-07-23).
+  // The tracked turn's OWN stamp leads the top slot while it is at or below the slot line — it scrolls up
+  // freely until it reaches it, and the instant it crosses ABOVE (markerTop < slotLine) the sticky takes the
+  // same slot showing the same time, so the swap is invisible: no gap, no clipped sliver (the user 2026-07-23).
   // Deliberately keyed on the TRACKED turn's marker, not on any stamp anywhere: a LATER time change further
   // down the view is a different time, so it must not blank the top — that would leave the slot empty, which
   // is the whole thing the sticky exists to prevent.
-  const realLeads = markerShown && markerTop >= line;
+  const realLeads = markerShown && markerTop >= slotLine;
   if (!hm || realLeads) {
     stamp.style.display = "none";
     for (const [m] of all) m.style.visibility = "";   // real stamp leads → nothing suppressed
@@ -1855,17 +1865,22 @@ function paintRailSticky(): void {
     else day.style.display = "none";
     return;
   }
-  // The sticky leads: pin it at the line and hide every marker that has crossed ABOVE it, so the real stamp
-  // handing off never shows a clipped duplicate beside the sticky. Markers at or below the line stay visible —
-  // they are the genuine lower stamps, not doubles.
-  for (const [m, top] of all) m.style.visibility = top < line ? "hidden" : "";
+  // The sticky leads: pin it at the slot line and hide every marker that has crossed ABOVE it — or INTO
+  // its box: with the slot dropped for the day label, a not-yet-tracked turn's stamp (marker 10–20px below
+  // a turn top that has not reached the line) can enter the sticky's own band while still "below the slot
+  // line", and two HH:MM texts superimpose. The threshold is therefore the sticky's BOTTOM edge, so an
+  // incoming stamp slides under the sticky hidden and re-emerges only when it leads. With no label this
+  // changes nothing: slotLine === line, and a stamp inside [line, line+stampH) forces its own turn tracked
+  // (offsets ≥ stamp height), which is realLeads — this branch never runs. Markers at or below the sticky's
+  // bottom stay visible — they are the genuine lower stamps, not doubles.
   const g = (anyMarker || marker!).getBoundingClientRect();
+  for (const [m, top] of all) m.style.visibility = top < slotLine + g.height ? "hidden" : "";
   stamp.textContent = hm;
   stamp.style.left = g.left + "px";
   stamp.style.width = g.width + "px";
-  stamp.style.top = line + "px";
+  stamp.style.top = slotLine + "px";
   stamp.style.display = "";
-  paintDay(line);
+  paintDay(slotLine);
 }
 
 // Scroll is the sticky stamp's primary driver, and a re-render moves the geometry under it — both funnel

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1085,13 +1085,15 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   position: fixed; z-index: 3; pointer-events: none;
   color: var(--dim); opacity: 0.92;
 }
-/* The day-context label above the top rail stamp (render.ts paintDay, the user 2026-08-17):
+/* The day-context label ABOVE the top rail stamp (render.ts paintDay, the user 2026-08-17):
    "Yesterday" / "3 days ago" / "Last week" whenever the top stamp's day is not today. Fixed like
-   the sticky, passive like the sticky; right-aligned to the gutter's right edge via the translate
-   (left is set to that edge, no width math), sitting just above the stamp it names. Smaller than
-   the stamp on purpose — context, not the time itself — and nowrap: fixed positioning escapes the
-   pane's overflow clip, and the longest form ("2 weeks ago") clears the gutter into the turn
-   padding, never over prose. */
+   the sticky, passive like the sticky. It sat BELOW the stamp until 2026-08-18 (the user, with a
+   video): there, the next incoming stamp scrolled straight through it and the label leapt over —
+   above the stamp nothing crosses its path. No width pin: the box shrinkwraps its nowrap text, and
+   paintDay puts its right edge on the gutter's right edge while never letting its left edge past
+   the pane's — "2 days ago" is wider than the 47px gutter, and the old gutter-pinned box clipped
+   the leading digit at the pane edge (the user 2026-08-18, with a screenshot). Smaller than the
+   stamp on purpose — context, not the time itself. */
 /* the user-message scroll notches (render.ts paintScrollMarks, the user 2026-08-17): passive fixed
    chrome over the scroller's right edge, one 2px tick per user message at its proportional position.
    The blue is the OUTGOING-BUBBLE blue (#2b6cef, "yours"), deliberately not the romp accent. */
@@ -1101,9 +1103,11 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   transition: top 180ms ease; }   /* history streaming in rescales the map — carried, not teleported */
 @media (prefers-reduced-motion: reduce) { .scroll-marks .scroll-mark { transition: none; } }
 .rail-day {
-  position: fixed; z-index: 3; pointer-events: none; white-space: nowrap;
-  text-align: right;   /* the STAMP's own box + its own alignment — the right edges match by construction */
+  position: fixed; z-index: 3; pointer-events: none; white-space: nowrap; line-height: 1;
   font-size: 0.68em; letter-spacing: 0.03em; color: var(--dim); opacity: 0.85;
+  background: var(--bg);   /* the widest labels ("2 weeks ago") poke a few px past the gutter into the
+                              session rail line; a pane-bg plate interrupts the line cleanly instead of
+                              striking text through it */
 }
 /* match the dot's vertical position per turn type (default dot top:15, tool/thinking top:10) */
 .turn-tool .time-marker, .turn-thinking .time-marker { top: 10px; }


### PR DESCRIPTION
Two user-reported rendering bugs in the chat rail's day-context label ("Yesterday" / "2 days ago"), reported 2026-08-18 with a screenshot and a video, plus one regression the adversarial review caught before landing.

## The clip (screenshot)
The label's box was pinned to the 47px gutter's left edge and width with right-aligned text, so any label wider than the gutter overflowed off the pane's **left** edge — "2 days ago" lost its leading digit. The box now shrinkwraps its text: right edge on the gutter's right edge when it fits, slid right just enough to stay whole when it doesn't (left edge clamped at 2px). A pane-bg plate keeps the widest labels from striking through the session rail line where they poke past the gutter.

## The jump (video)
The label sat **below** the top stamp, directly in the incoming next stamp's path — the stamp scrolled straight through it and the label leapt over at every handoff. It now rides **above** the stamp, where nothing crosses its path. When a label shows, the sticky's rest position and handoff threshold drop by the label's height (`slotLine`), so the label above the sticky stays inside the pane (no tab-bar bleed) and stamp + label land on the same pixels at handoff. With no label, `slotLine === line` and today's layout is byte-identical.

## Review-caught regression, fixed here
With the slot dropped, a not-yet-tracked turn's stamp could enter the sticky's own band and superimpose it (worst on tool turns, whose markers sit 10px into their turn). The sticky-leads visibility pass now hides markers up to the sticky's **bottom** edge, not its top; with no label this is a no-op by construction.

## Verification
- Headless-Chrome harness executing the real `paintRailSticky` source against the real stylesheet over a synthetic multi-day transcript, sweeping every scroll position: old code 2,479 invariant violations (left-clip, label-below, collisions), new code zero — invariants: no left clip, no tab-bar bleed, label above the stamp, no stamp/label collision, no stamp/sticky superimposition, never over prose, no same-text jump > 8px, label hidden on today.
- Tests: source pins updated, new executed replicas for the placement math (left clamp, right-edge alignment, slot shift, off-bottom hide) and for the intruding-stamp hide; ordered pin for the measure-while-visible block. 2,064 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)