### PR TITLE
Give-up summaries re-arm on real recovery events, not just the usage-limit pause

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -559,6 +559,35 @@ def _mid_elide(s, cap=6200):
     return "%s\n… [%d chars elided] …\n%s" % (s[:half], len(s) - 2 * half, s[-half:])
 
 
+# ── judge call health: the degraded→serving edge (the user 2026-08-18) ─────────────────────────────
+# A give-up card's designed recovery is a retry on a discrete RECOVERY event — but the only wired event
+# was the usage-limit retry-pause clearing, and the failures that actually cause most give-ups (a 529
+# overload storm, an auth blip) never engage that pause, so their cards kept the "distill failed" chip
+# long after the API recovered. This latch tracks the exact event those cards wait on: the first SERVED
+# judge call after a call-level failure. "call" rows latch degraded (_log_judge_error); a served reply
+# flips it back and records the edge (_mark_call_served, from _judge_run's success paths); the kernel
+# consumes the edge between passes — its single-writer window — and re-arms the give-up cards once per
+# era (rearm_failed_summaries auto=True). Process-global on purpose: every judge thread shares one API.
+_CALL_HEALTH = {"degraded": False, "recovered": False}
+_health_lock = threading.Lock()
+
+
+def _mark_call_served():
+    """A judge call came back with a real reply — if calls had been failing, record the recovery edge."""
+    with _health_lock:
+        if _CALL_HEALTH["degraded"]:
+            _CALL_HEALTH["degraded"] = False
+            _CALL_HEALTH["recovered"] = True
+
+
+def consume_judge_recovery():
+    """True exactly ONCE per degraded→serving transition — the kernel's between-pass re-arm trigger."""
+    with _health_lock:
+        r = _CALL_HEALTH["recovered"]
+        _CALL_HEALTH["recovered"] = False
+        return r
+
+
 def _log_judge_error(judge, fsid, err, note=None, goal=None, seg=None):
     """Append one failure row to ERRORS (judge-errors.jsonl) so `romp judges` can surface it. The row contract
     (the user 2026-07-09) — every row answers who/where/what/why on its own:
@@ -584,6 +613,9 @@ def _log_judge_error(judge, fsid, err, note=None, goal=None, seg=None):
     `tier` is written as a legacy twin of `judge` for pre-07-09 readers. Best-effort, NEVER raises — it
     runs inside the very failure paths it records."""
     try:
+        if err == "call":                              # a call-level failure (not the model's verdict) →
+            with _health_lock:                         # latch degraded; the next served reply is the edge
+                _CALL_HEALTH["degraded"] = True
         rec = {"t": int(time.time()), "judge": judge, "tier": judge, "fsid": fsid or "",
                "err": err, "note": note or ""}
         if goal:
@@ -970,6 +1002,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 _judge_ctx.last["reply"] = _mid_elide(wrap["result"])
                 _log_judge_usage(judge or tier, tier, model, fsid, wrap, sent, recv)
                 _auth_down_clear(fsid)                # billing works → unlatch (cheap no-op when unlatched)
+                _mark_call_served()                   # calls serve again → the give-up re-arm edge
                 return wrap["result"]
         except Exception:
             pass
@@ -986,6 +1019,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                                      (getattr(p, "stderr", "") or "").strip()[-200:] or "no stderr"))
             return ""
         _judge_ctx.last["reply"] = _mid_elide(out)
+        _mark_call_served()                           # a raw reply is still a served call (recovery edge)
         return out                                    # wrapper unparseable but non-empty → raw stdout (defensive)
     finally:
         _active_end(rid)                              # call done (success/timeout/parse-fail) → drop the live bar
@@ -2304,19 +2338,33 @@ def _replay_overrides(fsid, store):
         elif op == "redistill":
             # The warn modal's "Try again" (the user 2026-08-13): re-arm a GIVEN-UP summary line so the
             # next triage pass re-runs the distiller — the same flip rearm_failed_summaries applies on
-            # the usage-limit recovery edge, journaled here so a concurrent pass's last-writer save
-            # can't silently erase the click. Idempotent by shape: only the "" give-up sentinel flips
-            # to None (owed); a line that has since succeeded (non-empty) or is already owed (None) is
-            # untouched, so replays past a success never clobber it. No supersede guard needed — this
-            # is a field flip, not a log verdict, and its no-op form IS the guard.
-            for k in ("summary", "blockSummary"):
+            # the recovery edges, journaled here so a concurrent pass's last-writer save can't silently
+            # erase the click. Idempotent by shape: only the "" give-up sentinel flips to None (owed); a
+            # line that has since succeeded (non-empty) or is already owed (None) is untouched, so
+            # replays past a success never clobber it. A give-up that KEPT an older real summary (a
+            # re-completion's give-up never blanks prior text) re-arms by clearing its event stamp
+            # instead — gated on the live "*-failed" warn, which a later success clears, so that replay
+            # is a no-op past a success too. No supersede guard needed — these are field flips, not log
+            # verdicts, and their no-op forms ARE the guard.
+            warned = {w.get("kind") for w in nd.get("warns") or [] if isinstance(w, dict)}
+            for k, stamp, wkind in (("summary", "distilledMt", "summary-failed"),
+                                    ("blockSummary", "briefedMt", "brief-failed"),
+                                    ("stallSummary", "stalledMt", "stall-failed")):
                 if nd.get(k) == "":
                     nd[k] = None
                     applied = True
-            for k in ("distillFails", "briefFails"):
+                elif nd.get(k) and wkind in warned and nd.get(stamp) is not None:
+                    nd[stamp] = None
+                    applied = True
+            for k in ("distillFails", "briefFails", "stallFails"):
                 if nd.get(k):
                     nd[k] = 0
                     applied = True
+            # Deliberately NOT touching nd["autoRearmed"] here: the journal replays on EVERY load,
+            # forever, so a single historical click would erase the era mark on each replay and defeat
+            # the one-auto-retry bound for good. The mark clears only where the era truly ends — a
+            # landed summary, or a discrete recovery event (startup / retry-pause clear) in
+            # rearm_failed_summaries. The click still always retries: the flips above don't consult it.
     return applied
 
 
@@ -2684,7 +2732,7 @@ def _warn_summary_failed(nd, judge, t):
     cause, ratelimited = _giveup_cause()
     retry = ("romp retries it automatically the moment the limit resets; nudging the session refreshes it sooner."
              if ratelimited else
-             "Nudge the session to refresh it, or it retries on its own the next time that session works on this goal.")
+             "romp retries it on its own after it recovers or restarts — or hit Try again to retry it now.")
     _node_warn(nd, kind, t,
                "romp couldn't write this card's %s." % line,
                "romp tried to generate this %s several times and each attempt failed, because %s. No work was "
@@ -8980,6 +9028,7 @@ def _distill_session(fsid, path, now):
             _node_warn_clear(nodes[top], "cite-miss")
             nodes[top]["stalledMt"] = due
             nodes[top]["stallFails"] = 0
+            nodes[top].pop("autoRearmed", None)        # a landed note ends the give-up era (see rearm)
             _node_warn_clear(nodes[top], "stall-failed")
             _node_warn_clear(nodes[top], "stall-unreadable")
             n += 1; changed = True
@@ -9104,6 +9153,7 @@ def _distill_session(fsid, path, now):
             _node_warn_clear(nodes[top], "cite-miss")      # anchored either way → any older warn is over
             nodes[top]["briefedMt"] = due
             nodes[top]["briefFails"] = 0                # success → reset the counter (for a future re-open)
+            nodes[top].pop("autoRearmed", None)         # a landed brief ends the give-up era (see rearm)
             _node_warn_clear(nodes[top], "brief-failed")   # a brief landed → drop any earlier give-up warn
             _node_warn_clear(nodes[top], "brief-unreadable")   # …and any earlier orphaned-history warn
             n += 1; changed = True
@@ -9166,6 +9216,7 @@ def _distill_session(fsid, path, now):
         _node_warn_clear(nodes[top], "cite-miss")          # anchored either way → any older warn is over
         nodes[top]["distilledMt"] = due
         nodes[top]["distillFails"] = 0                 # success → reset the counter
+        nodes[top].pop("autoRearmed", None)            # a landed summary ends the give-up era (see rearm)
         _node_warn_clear(nodes[top], "summary-failed") # a summary landed → drop any earlier give-up warn
         _node_warn_clear(nodes[top], "summary-unreadable")   # …and any earlier orphaned-history warn
         n += 1; changed = True
@@ -9175,7 +9226,12 @@ def _distill_session(fsid, path, now):
 
 
 # ── failed-summary give-up: fleet count (for the banner) + re-arm on recovery (auto-retry) ──
-_FAILED_WARN_KINDS = ("summary-failed", "brief-failed")
+# stall-failed joined 2026-08-18: the staller's give-up warns "stall-failed" (_warn_line_kind), but the
+# scan/re-arm knew only the other two — a given-up stall note was invisible to the banner and never retried.
+_FAILED_WARN_KINDS = ("summary-failed", "brief-failed", "stall-failed")
+_FAILED_FIELDS = {"summary-failed": ("summary", "distilledMt"),     # warn kind → (line field, event stamp)
+                  "brief-failed": ("blockSummary", "briefedMt"),
+                  "stall-failed": ("stallSummary", "stalledMt")}
 
 
 def _failed_nodes(store):
@@ -9189,8 +9245,8 @@ def _failed_nodes(store):
 
 
 def judge_failure_scan():
-    """Fleet-wide give-up state for the top banner (the user 2026-07-03): every card whose summary/brief GAVE
-    UP carries a live "*-failed" warn; count them across all goal stores and name the current CAUSE (an
+    """Fleet-wide give-up state for the top banner (the user 2026-07-03): every card whose summary/brief/
+    stall note GAVE UP carries a live "*-failed" warn; count them across all goal stores and name the CAUSE (an
     account usage limit if one is maxed, else errors/timeouts). Returns {count, cause, ratelimited} or None
     when nothing is failing. Cheap: read-only, one parse per store; the kernel mtime-caches it."""
     import glob
@@ -9207,13 +9263,19 @@ def judge_failure_scan():
     return {"count": count, "cause": cause, "ratelimited": ratelimited}
 
 
-def rearm_failed_summaries(now=None):
-    """Auto-retry give-up cards on a RECOVERY event (the kernel calls this when the retry-pause clears and once
-    at startup): a genuine transient failure (a timeout under load, a brief rate-limit spike) blanks a card to
-    the "" sentinel + a "*-failed" warn and would otherwise stay blank until the goal's mt advances. Re-arm =
-    put the sentinel back to None so the distiller re-enters and retries; the warn stays until a re-summarize
-    SUCCEEDS (then _node_warn_clear) or FAILS again (re-gives-up, re-warns, visible). Bounded: only nodes with
-    a live give-up warn, and only on discrete recovery events — never a per-pass loop. Returns the count."""
+def rearm_failed_summaries(now=None, auto=False):
+    """Auto-retry give-up cards on a RECOVERY event — the kernel calls this once at startup, when the
+    retry-pause clears, and (auto=True) on the judge-health edge: the first served judge call after a
+    call-level failure (consume_judge_recovery). A genuine transient failure (a 529 storm, a timeout under
+    load, an auth blip) blanks a card to the "" sentinel + a "*-failed" warn and would otherwise stay
+    failed until a manual Try again. Re-arm = put the sentinel back to None so the summarizer re-enters
+    and retries — or, when the give-up KEPT an older real summary (a re-completion's give-up never
+    clobbers prior text), clear the event stamp instead so the gate re-enters with the prior intact. The
+    warn stays until a re-summarize SUCCEEDS (then _node_warn_clear) or FAILS again (re-gives-up,
+    re-warns, visible). Bounded two ways: only nodes with a live give-up warn, and the health edge
+    (auto=True) retries each give-up era at most ONCE (nd["autoRearmed"], dropped on success and by the
+    discrete events) — otherwise a card whose own call is broken would burn DISTILL_FAIL_CAP calls on
+    every edge a healthy neighbor produces. Returns the count re-armed."""
     import glob
     n = 0
     for fp in glob.glob(str(GOALDIR / "*.json")):
@@ -9224,10 +9286,20 @@ def rearm_failed_summaries(now=None):
             continue
         changed = False
         for nid, nd, kind in _failed_nodes(store):
-            if kind == "summary-failed" and nd.get("summary") == "":
-                nd["summary"] = None; changed = True; n += 1
-            elif kind == "brief-failed" and nd.get("blockSummary") == "":
-                nd["blockSummary"] = None; changed = True; n += 1
+            if auto and nd.get("autoRearmed"):
+                continue                               # this era already got its one automatic retry
+            field, stamp = _FAILED_FIELDS[kind]
+            if nd.get(field) == "":
+                nd[field] = None                       # "" (gave up) → None (owed): the next pass retries
+            elif nd.get(field) and nd.get(stamp) is not None:
+                nd[stamp] = None                       # give-up kept an older summary → re-enter by stamp
+            else:
+                continue                               # already owed (None) → nothing to flip
+            if auto:
+                nd["autoRearmed"] = True
+            else:
+                nd.pop("autoRearmed", None)            # a discrete event (startup/pause-clear) opens a fresh era
+            changed = True; n += 1
         if changed:
             save_goals(fsid, store)
     return n

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20696,6 +20696,13 @@ def _producer():
                     sys.stderr.write("compact: archived %d cleared goal node(s)\n" % moved)
             except Exception:
                 sys.stderr.write("compact: %s\n" % traceback.format_exc())
+            try:                                       # judge calls served again after failing (the degraded→
+                if jd.consume_judge_recovery():        # serving edge, e.g. a 529 storm ending) → re-arm the
+                    _n = jd.rearm_failed_summaries(int(time.time()), auto=True)   # give-up cards; next pass retries
+                    if _n:
+                        sys.stderr.write("distiller: re-armed %d given-up card(s) — judge calls serving again\n" % _n)
+            except Exception:
+                sys.stderr.write("rearm-on-recovery: %s\n" % traceback.format_exc())
             _end_goals_pass()      # pass + compact done → drop the snapshot BEFORE bumping the gen, so the cache-
                                    # busting rebuild below reads the fully-applied (post-pass) state, not pre-pass.
             _judge_gen[0] += 1     # a judge pass may have changed goal/caption state WITHOUT touching any
@@ -26076,6 +26083,12 @@ def main():
             sys.stderr.write("romp-kernel: pruned %d judge scratch transcript(s)\n" % _n)
     except Exception:
         sys.stderr.write("judge scratch prune: %s\n" % traceback.format_exc())
+    try:                                                      # a restart is a discrete recovery event: re-arm
+        _n = jd.rearm_failed_summaries(int(time.time()))      # every given-up summary/brief/stall line so the
+        if _n:                                                # first passes retry them (rearm's docstring
+            sys.stderr.write("romp-kernel: re-armed %d given-up summary line(s) at startup\n" % _n)   # promised this since 07-03; now wired)
+    except Exception:
+        sys.stderr.write("startup rearm: %s\n" % traceback.format_exc())
     _write_palette_mirror()                                   # keep bin/romp's palette-colors mirror current across code updates
     _boot_warm()                                              # pre-parse the live fleet during the reconnect gap (fast first paint)
     threading.Thread(target=_sdk, daemon=True).start()        # construct the SDK backend NOW so its boot

--- a/tests/test_distill_rearm.py
+++ b/tests/test_distill_rearm.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Give-up cards re-arm on RECOVERY EVENTS (the user 2026-08-18): most give-ups come from call-level
+failures (a 529 overload storm, an auth blip) that never engage the usage-limit retry-pause — so the one
+wired recovery edge never fired and the "distill failed" chip outlived the outage until a manual Try
+again. Under test here:
+  - the judge-call health latch: a "call" failure latches degraded; the first SERVED reply after it is
+    the degraded→serving edge, consumable exactly once (consume_judge_recovery);
+  - rearm_failed_summaries(auto=True), the edge's consumer: one automatic retry per give-up era
+    (nd["autoRearmed"]), while discrete events (startup, retry-pause clear, Try again) open a fresh era;
+  - a give-up that KEPT an older real summary (a re-completion never blanks prior text) re-arms by
+    clearing its event stamp, since the "" flip cannot apply;
+  - "stall-failed" joins the scan/re-arm family (the staller's give-ups were invisible to both).
+SYNTHETIC fixtures only (placeholder UUIDs, invented text)."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = SourceFileLoader("romp_judge_rearm", os.path.join(BIN, "romp-judge")).load_module()
+
+SID = "11111111-2222-3333-4444-555555555555"
+NID = SID + ":g1"
+T0 = 1781100000
+
+
+def _warn(kind):
+    return [{"kind": kind, "t": T0, "msg": "synthetic msg", "detail": "synthetic detail"}]
+
+
+def _seed(**nd_extra):
+    store = jd.load_goals(SID)
+    nd = {"text": "ship the api", "parentId": None, "mt": T0}
+    nd.update(nd_extra)
+    store["nodes"][NID] = jd.GuardedNode(nd)
+    jd.save_goals(SID, store)
+
+
+def _node():
+    return jd.load_goals(SID)["nodes"][NID]
+
+
+def _drain_edge():
+    while jd.consume_judge_recovery():
+        pass
+
+
+class JudgeCallHealthEdge(unittest.TestCase):
+    def setUp(self):
+        jd.STATE.mkdir(parents=True, exist_ok=True)
+        _drain_edge()
+        with jd._health_lock:
+            jd._CALL_HEALTH["degraded"] = False
+
+    def test_first_served_reply_after_a_call_failure_is_one_edge(self):
+        jd._log_judge_error("captioner", None, "call", note="error envelope: 'Overloaded'")
+        self.assertFalse(jd.consume_judge_recovery(), "a failure alone is not a recovery")
+        jd._mark_call_served()
+        self.assertTrue(jd.consume_judge_recovery(), "first served reply after a failure = the edge")
+        self.assertFalse(jd.consume_judge_recovery(), "the edge is consumed exactly once")
+
+    def test_serving_while_healthy_is_not_an_edge(self):
+        jd._mark_call_served()
+        self.assertFalse(jd.consume_judge_recovery(), "no prior failure → nothing recovered")
+
+    def test_non_call_errors_do_not_latch_degraded(self):
+        # a parse reject / cite-miss is the MODEL's verdict on one prompt, not API sickness — the next
+        # served call must not read as a recovery and re-arm every give-up card in the deployment
+        jd._log_judge_error("planner", None, "parse", note="reply rejected")
+        jd._log_judge_error("distiller", None, "cite-miss", note="no SOURCE line")
+        jd._mark_call_served()
+        self.assertFalse(jd.consume_judge_recovery(), "only call-level failures arm the edge")
+
+
+class RearmRecoveryEvents(unittest.TestCase):
+    def tearDown(self):
+        for d in (jd.GOALDIR, jd._overrides_dir()):
+            for f in d.glob("*"):
+                f.unlink()
+
+    def test_auto_rearm_retries_a_give_up_era_exactly_once(self):
+        _seed(summary="", distillFails=0, warns=_warn("summary-failed"))
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 100, auto=True), 1)
+        nd = _node()
+        self.assertIsNone(nd.get("summary"), '"" (gave up) → None (owed): the next pass retries')
+        self.assertTrue(nd.get("autoRearmed"), "the era's one automatic retry is marked spent")
+        # the retry re-gives-up (sentinel + warn re-stamped; the mark survives the give-up write)
+        st = jd.load_goals(SID)
+        st["nodes"][NID]["summary"] = ""
+        jd.save_goals(SID, st)
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 200, auto=True), 0,
+                         "a healthy neighbor's every edge must not burn DISTILL_FAIL_CAP calls on a "
+                         "card whose own call is broken — one automatic retry per era")
+
+    def test_a_discrete_event_rearms_and_opens_a_fresh_era(self):
+        _seed(summary="", warns=_warn("summary-failed"), autoRearmed=True)
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 300), 1,
+                         "startup / retry-pause clear re-arm regardless of the era mark")
+        nd = _node()
+        self.assertIsNone(nd.get("summary"))
+        self.assertNotIn("autoRearmed", nd, "a discrete event opens a fresh era for the health edge")
+
+    def test_rearm_reenters_a_giveup_that_kept_an_older_summary(self):
+        # a re-completion's give-up never blanks prior text — so there is no "" to flip; the stamp
+        # clears instead and the gate re-enters with the prior summary intact
+        _seed(summary="Old takeaway.", distilledMt=T0, warns=_warn("summary-failed"))
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 100), 1)
+        nd = _node()
+        self.assertEqual(nd.get("summary"), "Old takeaway.", "the prior text is never clobbered")
+        self.assertIsNone(nd.get("distilledMt"), "the cleared stamp is what re-enters the distiller")
+
+    def test_an_already_owed_line_is_not_recounted(self):
+        _seed(summary=None, warns=_warn("summary-failed"))
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 100), 0,
+                         "None is already owed — nothing to flip, nothing to count")
+
+    def test_stall_failed_joins_the_scan_and_the_rearm(self):
+        _seed(stallSummary="", warns=_warn("stall-failed"))
+        scan = jd.judge_failure_scan()
+        self.assertEqual(scan["count"], 1, "a given-up stall note counts toward the banner")
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 100), 1)
+        self.assertIsNone(_node().get("stallSummary"), "the stall note re-arms like the other lines")
+
+
+class KernelRearmWiring(unittest.TestCase):
+    """Source pins on the kernel's two recovery-event call sites (the RedistillOpWiring precedent —
+    the wiring is a few lines inside 400-line functions no unit test can enter cheaply)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.km = SourceFileLoader("romp_kernel_rearm", os.path.join(BIN, "romp-kernel")).load_module()
+
+    def test_startup_rearms_before_the_server_loop(self):
+        import inspect
+        src = inspect.getsource(self.km.main)
+        self.assertIn("rearm_failed_summaries", src, "a restart is a discrete recovery event — wired in main()")
+        self.assertLess(src.index("rearm_failed_summaries"), src.index("serve_forever"),
+                        "the boot sweep re-arms before the kernel starts serving")
+
+    def test_producer_consumes_the_health_edge_after_the_tier_join(self):
+        import inspect
+        src = inspect.getsource(self.km._producer)
+        i_join = src.index("t.join()")
+        i_edge = src.index("consume_judge_recovery")
+        self.assertGreater(i_edge, i_join,
+                           "the edge is consumed AFTER the join — the single-writer window, so the "
+                           "re-arm's store writes can't race the judge worker threads")
+        seg = src[i_edge:]
+        self.assertIn("rearm_failed_summaries", seg[:400], "the consumed edge drives the auto re-arm")
+        self.assertIn("auto=True", seg[:400], "the health edge is the era-bounded auto path")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_redistill.py
+++ b/tests/test_kernel_redistill.py
@@ -73,6 +73,56 @@ class RedistillOverrideReplay(unittest.TestCase):
         self.assertIsNone(jd.load_goals(SID).get("nodes", {}).get(SID + ":gone"))
 
 
+class RedistillReplayRecoveryExtensions(unittest.TestCase):
+    """Try again reaches the give-ups the "" flip can't (2026-08-18): a give-up that KEPT an older real
+    summary (a re-completion never blanks prior text) re-arms by clearing its event stamp — gated on the
+    live "*-failed" warn, so replays past a success stay no-ops; the stall line joins the family; and a
+    manual retry drops the era mark so the health-edge auto-rearm starts fresh."""
+
+    def tearDown(self):
+        for d in (jd.GOALDIR, jd._overrides_dir()):
+            for f in d.glob("*"):
+                f.unlink()
+
+    def _seed(self, nd):
+        base = {"text": "ship the api", "parentId": None, "mt": 1781100000}
+        base.update(nd)
+        store = jd.load_goals(SID)
+        store["nodes"][NID] = jd.GuardedNode(base)
+        jd.save_goals(SID, store)
+
+    def test_replay_rearms_a_kept_older_summary_by_stamp(self):
+        self._seed({"summary": "Old takeaway.", "distilledMt": 1781100000,
+                    "warns": [{"kind": "summary-failed", "t": 1781100000,
+                               "msg": "synthetic msg", "detail": "synthetic detail"}]})
+        jd.append_override(SID, NID, "redistill", 1781100100)
+        nd = jd.load_goals(SID)["nodes"][NID]
+        self.assertEqual(nd.get("summary"), "Old takeaway.", "prior text is never clobbered")
+        self.assertIsNone(nd.get("distilledMt"), "stamp cleared → the done gate re-enters, prior intact")
+        # the retry then succeeds: new text, new stamp, warn cleared → the journaled click goes no-op
+        st = jd.load_goals(SID)
+        st["nodes"][NID]["summary"] = "New takeaway."
+        st["nodes"][NID]["distilledMt"] = 1781100500
+        st["nodes"][NID]["warns"] = []
+        jd.save_goals(SID, st)
+        nd = jd.load_goals(SID)["nodes"][NID]            # journal replays again on this load
+        self.assertEqual(nd.get("distilledMt"), 1781100500,
+                         "no live warn → the stamp-clear never replays past a success")
+
+    def test_replay_flips_the_stall_sentinel_and_leaves_the_era_mark(self):
+        self._seed({"stallSummary": "", "stallFails": 2, "autoRearmed": True,
+                    "warns": [{"kind": "stall-failed", "t": 1781100000,
+                               "msg": "synthetic msg", "detail": "synthetic detail"}]})
+        jd.append_override(SID, NID, "redistill", 1781100100)
+        nd = jd.load_goals(SID)["nodes"][NID]
+        self.assertIsNone(nd.get("stallSummary"), "the stall line re-arms like summary/blockSummary")
+        self.assertEqual(nd.get("stallFails"), 0, "the consecutive-fail counter starts over")
+        self.assertTrue(nd.get("autoRearmed"),
+                        "the era mark SURVIVES replay: the journal replays on every load forever, so a "
+                        "historical click erasing it would defeat the one-auto-retry bound for good — "
+                        "the mark clears only on a landed summary or a discrete recovery event")
+
+
 class RedistillOpWiring(unittest.TestCase):
     """Source pins on the kernel handler — the ws plumbing is exercised end-to-end by the push
     responsiveness suite; here we pin the journal-first order and the loud ACK."""


### PR DESCRIPTION
## The bug

Completed cards across the board are stuck with "distill failed" chips (or no summary at all after the starvation window). The give-up design (fail loudly + auto-retry on recovery) had only ONE wired recovery event: the usage-limit retry-pause clearing. The failures that actually cause most give-ups — 529 overload storms, auth blips ("Not logged in") — never engage that pause, so their give-ups could never auto-recover; each card needed a manual Try again. The judge-errors log on the devbox shows exactly this shape: give-ups from a not-logged-in window (08-12) and from today's 529 storm, all permanent.

## The fix — recovery events, exact and bounded

- **Judge-call health latch** (`kernel/judge.py`): a call-level failure (`err == "call"`) latches degraded; the first served reply after it is the degraded→serving edge. The kernel consumes the edge once, between passes (the single-writer window after the tier join), and re-arms give-up cards.
- **Startup re-arm** (`kernel/kernel.py main()`): `rearm_failed_summaries`' docstring promised this since 07-03 but it was never wired. A restart is a discrete recovery event.
- **Era bound**: the health-edge path (`auto=True`) retries each give-up era at most ONCE (`nd["autoRearmed"]`, dropped on success and by the discrete events) — a card whose own call is broken can't burn the fail cap on every edge a healthy neighbor produces. The Try-again replay deliberately leaves the mark alone (the override journal replays on every load, forever).
- **Give-ups the `""` flip couldn't reach**: a give-up that KEPT an older real summary (re-completion give-ups never blank prior text) was un-re-armable — even Try again was a no-op on it. It now re-arms by clearing its event stamp, gated on the live warn so replays past a success stay no-ops. And `stall-failed` joins the scan/re-arm family (the staller's give-ups were invisible to both).
- Warn-modal copy now tells the truth about auto-retry.

## Tests

`tests/test_distill_rearm.py` (health edge one-shot semantics, era bound, kept-older-summary stamp re-arm, stall kind, source pins on both kernel wiring sites) plus extended replay cases in `tests/test_kernel_redistill.py`. Full Python suite 4833 passed; UI suite 2059 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)