### PR TITLE
The judge rate-gate follows the call's model, and a limit-down says so loudly

### DIFF
--- a/claude/skills/romp-postal/SKILL.md
+++ b/claude/skills/romp-postal/SKILL.md
@@ -14,6 +14,8 @@ Message sibling sessions with the postal MCP tools (each tool's own description 
 
 Addressing is live-only: you can message only currently-live sessions (see `list_agents`). Dead names error, with no parked mail or reviving.
 
+Role-named recipients go stale: a role handed to a new session keeps the OLD name in your memory of it, and the retired name just bounces. Before sending to a role-style name (a router, a watcher, a manager), confirm it against `list_agents` and address whoever holds the role now.
+
 Names are not guaranteed unique. If more than one live session answers to the one you used, the send is refused and the candidates are listed as `host:name`: pick one and resend. Your own name is refused outright, since a message there arrives in your own inbox looking exactly like a reply from someone else. Your row in `list_agents` is the one marked `(you)`.
 
 From the shell (also how the human drives it): `romp mail send <name> "<text>"`, `romp mail inbox|agents|sent`, `romp mail working "<note>"`, `romp mail recall <name> [id]`.

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -51,6 +51,9 @@ MESSAGES = STATE / "timeline" / "messages.jsonl"
 ERRORS   = STATE / "judge-errors.jsonl"  # swallowed judge-call failures (parse-fails, call timeouts/exceptions) — surfaced by `romp judges`
 USAGE    = STATE / "judge-usage.jsonl"   # one line per successful judge call: tokens/cost/ms — the kernel/UI roll up pipeline cost
 JUDGE_AUTH = STATE / "judge-auth.json"   # judge-auth-down latch {fsid: {t, mode, note}}: set by a credential-class error
+JUDGE_LIMIT = STATE / "judge-limit.json"  # usage-limit-down latch {t, bucket, pct, resets_at, model}: the gate
+#                                           (or a limit-shaped error envelope) proved the account can't bill a
+#                                           judge call — build_feed ships it so the pause is LOUD (2026-08-18)
                                          #   envelope, cleared by the session's next successful call — build_feed floors from it
 GONEDIR  = STATE / "gone"                # session-death markers {t, by[, endedAt]} — one small json per sid, written by the
                                          #   kernel's death writers at the death EVENT (kill gesture / probe-confirmed absence),
@@ -112,6 +115,8 @@ def _rebind_state(path):
     GOALARCHDIR = STATE / "goals-archive"
     STATESDIR, PCACHE = STATE / "states", STATE / "judge-units-cache"
     MESSAGES, ERRORS, USAGE = STATE / "timeline" / "messages.jsonl", STATE / "judge-errors.jsonl", STATE / "judge-usage.jsonl"
+    global JUDGE_LIMIT
+    JUDGE_LIMIT = STATE / "judge-limit.json"
     SDKDIR = STATE / "sdk"
     EPIDIR = STATE / "episodes"
     _lastsid_memo.clear()   # sdk-registry reads are mtime-memoized per sid — a rebind must not serve the old root's values
@@ -794,6 +799,64 @@ def _auth_down_clear(fsid):
             _auth_write_locked(d)
 
 
+_limit_cache = [None, {}]
+_USAGE_REFRESH_FN = None   # the kernel wires this to SdkBackend.refresh_usage: a limit-shaped error
+#                            envelope triggers ONE exact usage poll, so an idle-stale usage.json
+#                            (get_usage rides turn ends — an idle fleet refreshes nothing, measured
+#                            ~15h stale) updates on the FIRST doomed call and the gate blocks the rest.
+_LIMIT_ENVELOPE_RE = re.compile(r"usage limit|rate.?limit|limit reached", re.I)
+
+
+def _limit_down():
+    """The usage-limit-down latch, or None when absent/expired. SELF-EXPIRING on resets_at — the
+    window reset IS the deciding event, no age heuristics — and mtime-cached like _auth_down_map."""
+    try:
+        key = JUDGE_LIMIT.stat().st_mtime_ns
+    except OSError:
+        return None
+    if _limit_cache[0] != key:
+        try:
+            d = json.loads(JUDGE_LIMIT.read_text())
+            _limit_cache[:] = [key, d if isinstance(d, dict) else {}]
+        except Exception:
+            _limit_cache[:] = [key, {}]
+    row = _limit_cache[1]
+    if not row:
+        return None
+    ra = row.get("resets_at")
+    if isinstance(ra, (int, float)) and ra <= time.time():
+        return None
+    return row
+
+
+def _limit_mark(bucket, pct, resets_at, model):
+    """LATCH usage-limit-down: the gate (or a limit-shaped envelope) just proved the account cannot
+    bill this judge call. The first evidence is decisive; the latch holds until the window resets
+    (self-expiry in _limit_down) or a call SUCCEEDS (_limit_clear) — never re-derived per build.
+    Loud by design (the user 2026-08-18, whose judges failed quietly into ~22,400 doomed retries
+    over two days): build_feed ships this row and the dashboard says the pause out loud."""
+    try:
+        cur = _limit_down() or {}
+        if cur.get("bucket") == bucket and cur.get("resets_at") == resets_at:
+            return
+        tmp = JUDGE_LIMIT.with_suffix(".tmp")
+        tmp.write_text(json.dumps({"t": int(time.time()), "bucket": bucket, "pct": pct,
+                                   "resets_at": resets_at, "model": str(model or "")}))
+        os.replace(tmp, JUDGE_LIMIT)
+    except Exception:
+        pass
+
+
+def _limit_clear():
+    """Unlatch on the deciding event in the other direction: a judge call SUCCEEDED, so whatever
+    window blocked billing is no longer in the way (a reset, or the judges moved to another model)."""
+    try:
+        if JUDGE_LIMIT.exists():
+            JUDGE_LIMIT.unlink()
+    except OSError:
+        pass
+
+
 def _judge_env(tier, auth="login"):
     """The subprocess env for ONE judge call. Drops the TMUX vars (so the child isn't taken for a live
     pane) and trips the Stop-hook recursion guard. For the INDEX tier it also disables extended thinking
@@ -883,10 +946,19 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
         # failure. The `fable` bucket is deliberately ignored (judges run Sonnet). Unreadable/absent
         # usage.json → never gate: the gate is an optimization, judging is the job.
         u = json.loads((STATE / "usage.json").read_text())
-        for _b in ("five_hour", "seven_day"):
+        # The gated buckets FOLLOW THE CALL'S MODEL (2026-08-18, user-approved via the optimizer's
+        # audit): the account-wide windows gate every model, and a model-scoped window gates exactly
+        # the calls that would bill it. The old tuple hardcoded the account buckets and deliberately
+        # ignored `fable` ("judges run Sonnet") — stale the day the judge-model pin read fable: the
+        # fable window sat at 100% through 08-16/17 while this gate saw a healthy account, and
+        # ~22,400 doomed retries burned (9,305 on 08-17 alone), goal filing and mail summarizing
+        # down the whole stretch.
+        _buckets = ["five_hour", "seven_day"] + (["fable"] if "fable" in str(model).lower() else [])
+        for _b in _buckets:
             _lim = u.get(_b) or {}
             if (_lim.get("pct") or 0) >= 100 and (_lim.get("resets_at") or 0) > time.time():
                 _judge_ctx.paused = True
+                _limit_mark(_b, _lim.get("pct"), _lim.get("resets_at"), model)   # the LOUD half: build_feed ships it
                 if _RATE_GATE_LOGGED.get(_b) != _lim.get("resets_at"):   # one log line per limit window
                     _RATE_GATE_LOGGED[_b] = _lim.get("resets_at")
                     _log_judge_error(tier, None, "rate-limited",
@@ -961,6 +1033,16 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 _judge_ctx.last["reply"] = str(wrap.get("result") or "")[:2000]
                 _log_judge_error(judge or tier, fsid, "call",
                                  note="error envelope: %r" % msg[:160])
+                if _LIMIT_ENVELOPE_RE.search(msg):
+                    # a limit-shaped envelope is the EVENT that says usage.json is stale (get_usage
+                    # rides turn ends; an idle fleet refreshes nothing): latch the loud banner NOW
+                    # and poke one exact poll so the gate blocks the follow-on calls
+                    _limit_mark("account", None, None, model)
+                    if _USAGE_REFRESH_FN:
+                        try:
+                            _USAGE_REFRESH_FN()
+                        except Exception:
+                            pass
                 if _is_auth_error(msg):
                     # credential-class: only the user can fix it — latch, so build_feed floors this
                     # session's focus card instead of leaving the board silently frozen (2026-08-12)
@@ -970,6 +1052,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 _judge_ctx.last["reply"] = _mid_elide(wrap["result"])
                 _log_judge_usage(judge or tier, tier, model, fsid, wrap, sent, recv)
                 _auth_down_clear(fsid)                # billing works → unlatch (cheap no-op when unlatched)
+                _limit_clear()                        # ...and the usage-limit latch (a reset, or a model switch)
                 return wrap["result"]
         except Exception:
             pass

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5503,6 +5503,10 @@ def _sdk_locked():
                 append_prompt_path=(str(_SDK_PROMPT) if _SDK_PROMPT.exists() else None),
                 log=lambda m: sys.stderr.write("sdk-backend: %s\n" % m),
                 reconcile=True)   # boot reconcile: reap orphaned CLIs, resume cut turns, deliver persisted queues
+            # a limit-shaped judge error envelope pokes ONE exact usage poll (get_usage rides turn
+            # ends, so an idle fleet's usage.json goes stale — measured ~15h — and the rate gate is
+            # only as good as that file); the backend picks any live login session to ask
+            jd._USAGE_REFRESH_FN = getattr(_sdk_backend, "refresh_usage", None)   # best-effort hook (judge guards None)
         except Exception:
             sys.stderr.write("sdk-backend unavailable: %s\n" % traceback.format_exc())
             _sdk_problem("the SDK backend could not be built: %s" % traceback.format_exc())
@@ -16904,6 +16908,10 @@ def build_feed(now, tmux=None):
     for _a in asks:
         _a["notify"] = True if _notify_card_effective(_ncards, _a["itemId"], str(_a.get("sid") or "")) else None
     return {"type": "feed", "asks": asks, "now": now,
+            # usage-limit-down latch (judge-limit.json): analysis is paused because the account
+            # cannot bill judge calls — the dashboard must SAY so, never fail quietly into retries
+            # (the user 2026-08-18); self-expires at the window reset, cleared by the next success
+            "judgeLimit": jd._limit_down(),
             "working": working, "awaiting": awaiting,   # awaiting = idle-but-waiting-on-bg-work names → await-green dot (the user 2026-07-13)
             # listed-but-unreadable names → an explicit gray ring, so a BLANK pip means "alive and
             # quiet" and nothing else (see _state_unknown_names)

--- a/tests/test_judge_rate_limit_gate.py
+++ b/tests/test_judge_rate_limit_gate.py
@@ -73,9 +73,48 @@ class RateLimitGate(unittest.TestCase):
     def test_missing_usage_never_gates(self):
         self.assertEqual(jd._judge_run("m", "sys", "user"), "the-model-reply")
 
-    def test_fable_bucket_is_ignored(self):
-        self._usage(100, 3600, bucket="fable")        # judges run Sonnet: the Fable cap is irrelevant
-        self.assertEqual(jd._judge_run("m", "sys", "user"), "the-model-reply")
+    def test_fable_bucket_gates_exactly_the_calls_that_bill_it(self):
+        # The gated buckets FOLLOW THE CALL'S MODEL (2026-08-18): the old tuple ignored `fable`
+        # ("judges run Sonnet") — stale once the judge-model pin read fable, and ~22,400 doomed
+        # retries burned across 08-16/17 while the fable window sat at 100%.
+        self._usage(100, 3600, bucket="fable")
+        self.assertEqual(jd._judge_run("sonnet", "sys", "user"), "the-model-reply",
+                         "a sonnet call does not bill the fable window — never gated by it")
+        self.assertEqual(jd._judge_run("fable", "sys", "user"), "",
+                         "a fable call IS gated by the fable window")
+        self.assertTrue(jd._judge_ctx.paused)
+
+    def test_the_gate_latches_the_loud_limit_banner(self):
+        # a limit-down judge layer must SAY so (the user 2026-08-18), never fail quietly: the gate
+        # writes the judge-limit latch, self-expiring at the window reset, cleared by a success
+        self._usage(100, 3600, bucket="fable")
+        jd._judge_run("fable", "sys", "user")
+        row = jd._limit_down()
+        self.assertEqual(row["bucket"], "fable")
+        self.assertEqual(row["model"], "fable")
+        # a successful call (model switched to sonnet, say) clears the latch — the deciding event
+        self.assertEqual(jd._judge_run("sonnet", "sys", "user"), "the-model-reply")
+        self.assertIsNone(jd._limit_down())
+
+    def test_the_latch_self_expires_at_the_reset(self):
+        jd._limit_mark("fable", 100, int(time.time()) - 5, "fable")   # already past its reset
+        self.assertIsNone(jd._limit_down(), "the window reset IS the deciding event — no age heuristics")
+
+    def test_limit_shaped_envelope_latches_and_pokes_a_usage_poll(self):
+        # get_usage rides turn ends, so an idle fleet's usage.json goes stale; the FIRST doomed call
+        # is the event that refreshes it — the envelope latches the banner and fires the wired poll
+        class _FakeErr:
+            stdout = '{"is_error": true, "result": "Claude AI usage limit reached — resets 12:00"}'
+        jd.subprocess.run = lambda *a, **k: _FakeErr()
+        poked = []
+        saved = jd._USAGE_REFRESH_FN
+        try:
+            jd._USAGE_REFRESH_FN = lambda: poked.append(1)
+            self.assertEqual(jd._judge_run("fable", "sys", "user"), "")
+            self.assertEqual(poked, [1], "one exact usage poll fired")
+            self.assertEqual((jd._limit_down() or {}).get("bucket"), "account")
+        finally:
+            jd._USAGE_REFRESH_FN = saved
 
 
 class SegKeyUnified(unittest.TestCase):

--- a/ui/webview/feed-limit-banner.test.ts
+++ b/ui/webview/feed-limit-banner.test.ts
@@ -23,7 +23,8 @@ test("the kernel ships the latch and the judge gate writes it model-aware", () =
   assert.match(JUDGE, /_limit_mark\(_b, _lim\.get\("pct"\), _lim\.get\("resets_at"\), model\)/);
   assert.match(JUDGE, /_limit_clear\(\) {8,}# \.\.\.and the usage-limit latch|_limit_clear\(\)/, "a success clears it");
   assert.match(JUDGE, /jd\._USAGE_REFRESH_FN|_USAGE_REFRESH_FN = None/, "the idle-stale poke hook exists");
-  assert.match(KERNEL, /jd\._USAGE_REFRESH_FN = _sdk_backend\.refresh_usage/, "…and the kernel wires it");
+  assert.match(KERNEL, /jd\._USAGE_REFRESH_FN = getattr\(_sdk_backend, "refresh_usage", None\)/,
+    "…and the kernel wires it (getattr: the hook is best-effort, so a stub backend can't break the build)");
 });
 
 test("the banner is build-once, acknowledges, and offers Opus only for the Fable window", () => {

--- a/ui/webview/feed-limit-banner.test.ts
+++ b/ui/webview/feed-limit-banner.test.ts
@@ -1,0 +1,41 @@
+// A judge layer down on a USAGE LIMIT says so loudly (the user 2026-08-18, whose judges failed
+// quietly into ~22,400 doomed retries over two days while the Fable window sat at 100%): the
+// kernel ships the judge-limit latch on the feed payload, and the feed renders a compact banner
+// above the columns — for a Fable-window exhaustion it offers switching analysis to Opus (cheaper
+// per token); for a general exhaustion it states the account is full and when it resumes. The
+// banner is built ONCE and updated in place (the click-safety rule), and the button acknowledges
+// before the round-trip. Source pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const FEED = fs.readFileSync(path.join(UI, "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.join(UI, "feed.css"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const JUDGE = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "judge.py"), "utf8");
+
+test("the kernel ships the latch and the judge gate writes it model-aware", () => {
+  assert.match(KERNEL, /"judgeLimit": jd\._limit_down\(\),/);
+  assert.match(JUDGE, /_buckets = \["five_hour", "seven_day"\] \+ \(\["fable"\] if "fable" in str\(model\)\.lower\(\) else \[\]\)/,
+    "the gated buckets follow the CALL'S model — a fable pin gates on the fable window");
+  assert.match(JUDGE, /_limit_mark\(_b, _lim\.get\("pct"\), _lim\.get\("resets_at"\), model\)/);
+  assert.match(JUDGE, /_limit_clear\(\) {8,}# \.\.\.and the usage-limit latch|_limit_clear\(\)/, "a success clears it");
+  assert.match(JUDGE, /jd\._USAGE_REFRESH_FN|_USAGE_REFRESH_FN = None/, "the idle-stale poke hook exists");
+  assert.match(KERNEL, /jd\._USAGE_REFRESH_FN = _sdk_backend\.refresh_usage/, "…and the kernel wires it");
+});
+
+test("the banner is build-once, acknowledges, and offers Opus only for the Fable window", () => {
+  assert.match(FEED, /function ensureJudgeLimit\(\): HTMLElement/);
+  assert.match(FEED, /let b = document\.getElementById\("judge-limit-banner"\);\s*\n\s*if \(b\) return b;/,
+    "built once — the button survives re-renders (click-safety)");
+  assert.match(FEED, /btn\.textContent = "Switching…";\s*\n\s*\/\/ ?.*|btn\.textContent = "Switching…";/,
+    "acknowledges before the kernel round-trip");
+  assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "setJudgeModel", model: "opus" \}\)/);
+  assert.match(FEED, /btn\.style\.display = fable \? "" : "none";/, "the switch offer is Fable-specific");
+  assert.match(FEED, /the account's usage window is full/, "general exhaustion states it plainly");
+  assert.match(FEED, /paintJudgeLimit\(\);   \/\/ the usage-limit banner above the columns/,
+    "painted on every feed render");
+  assert.match(CSS, /\.judge-limit-banner \{/);
+});

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1134,3 +1134,16 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fitem.ask:hover .fask-bellbtn { visibility: visible; }
 .fitem.ask .fask-bellbtn:hover { opacity: 1; background: rgba(255, 255, 255, 0.10); }
 .fask-bellbtn.on { visibility: visible; opacity: 0.85; color: var(--accent); }
+
+/* usage-limit banner (2026-08-18): analysis paused on a usage limit says so above the columns —
+   loud but compact, one line + (Fable only) the switch-to-Opus action. Neutral card chrome, never
+   the accent (this is status, not highlight); red would overstate it — the pause is expected and
+   self-resolving at the window reset. */
+.judge-limit-banner { display: flex; align-items: center; gap: 10px; margin: 6px 8px 2px;
+  padding: 7px 12px; background: #252526; border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px; font-size: 0.9em; }
+.judge-limit-banner .jl-text { opacity: 0.85; }
+.judge-limit-banner .jl-switch { flex: none; padding: 3px 10px; border-radius: 4px; border: 1px solid
+  rgba(255, 255, 255, 0.18); background: #333; color: inherit; cursor: pointer; font-size: 0.95em; }
+.judge-limit-banner .jl-switch:hover { background: #3c3c3c; }
+.judge-limit-banner .jl-switch:disabled { opacity: 0.6; cursor: default; }

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3464,10 +3464,54 @@ function feedToast(text: string) {
   }, 4200);
 }
 
+// ── usage-limit banner (the user 2026-08-18): a judge layer down on a USAGE LIMIT must say so ──
+// loudly, never fail quietly into retries. The kernel ships the judge-limit latch on the feed
+// payload (self-expiring at the window reset, cleared by the next successful call). Built ONCE and
+// updated in place — the button must survive re-renders (the click-safety rule), and it
+// acknowledges immediately, then the latch clearing hides the banner on a later payload.
+let judgeLimit: { bucket?: string; resets_at?: number; model?: string } | null = null;
+function ensureJudgeLimit(): HTMLElement {
+  let b = document.getElementById("judge-limit-banner");
+  if (b) return b;
+  b = el("div", "judge-limit-banner");
+  b.id = "judge-limit-banner";
+  const txt = el("span", "jl-text"); b.appendChild(txt);
+  const btn = el("button", "jl-switch") as HTMLButtonElement;
+  btn.type = "button";
+  btn.textContent = "Run analysis on Opus until then";
+  btn.title = "switch the analysis model to Opus (cheaper per token than Fable) while the Fable window is full";
+  btn.onclick = () => {
+    btn.disabled = true;
+    btn.textContent = "Switching…";                      // acknowledge before the round-trip
+    vscodeApi?.postMessage({ type: "setJudgeModel", model: "opus" });
+  };
+  b.appendChild(btn);
+  const list = document.getElementById("feed-list")!;
+  list.parentElement!.insertBefore(b, list);
+  return b;
+}
+function paintJudgeLimit(): void {
+  const b = ensureJudgeLimit();
+  if (!judgeLimit) { b.style.display = "none"; return; }
+  const ra = judgeLimit.resets_at;
+  const when = typeof ra === "number" && ra > 0
+    ? new Date(ra * 1000).toTimeString().slice(0, 5) : "";
+  const fable = judgeLimit.bucket === "fable";
+  const txt = b.querySelector(".jl-text")!;
+  txt.textContent = fable
+    ? "Analysis is paused — the Fable usage window is full" + (when ? " (resets " + when + ")." : ".")
+    : "Analysis is paused — the account's usage window is full" + (when ? "; it resumes at " + when + "." : ".");
+  const btn = b.querySelector(".jl-switch") as HTMLButtonElement;
+  btn.style.display = fable ? "" : "none";
+  if (!judgeLimit || !fable) { btn.disabled = false; btn.textContent = "Run analysis on Opus until then"; }
+  b.style.display = "";
+}
+
 function render() {
   const list = document.getElementById("feed-list")!;
   pruneAgeTip();   // drop the tip only if the render tore its hovered stamp out (see pruneAgeTip)
   applyFollowMove(asks);   // keep optimistically-moved follow-up cards in Working until the kernel confirms (or reverts)
+  paintJudgeLimit();   // the usage-limit banner above the columns (build-once; hidden when unlatched)
   auditShownColumns(asks); // tripwire: what this render SHOWS is the record a bounce report needs
   const prevScroll = list.scrollTop;
   // footer pane (below the cards, no overlap): Newest first · Collapsed · Clear all · UndoClear
@@ -3803,6 +3847,8 @@ window.addEventListener("message", (e: MessageEvent) => {
     return;
   }
   if (m.type === "feed") {
+    judgeLimit = m.judgeLimit && typeof m.judgeLimit === "object"
+      ? m.judgeLimit as { bucket?: string; resets_at?: number; model?: string } : null;
     const incomingAsks: AskItem[] = Array.isArray(m.asks) ? m.asks : [];
     // A clear is CONFIRMED once the kernel's payload no longer lists it → stop suppressing it. Then drop
     // any still-pending (kernel hasn't caught up) from this payload so a stale push can't resurrect them.


### PR DESCRIPTION
Two commits, one delegated audit (user-approved via the nightly optimizer):

**The gate.** `_judge_run`'s rate gate hardcoded the account-wide buckets and deliberately ignored the `fable` window ("judges run Sonnet") — stale the day the judge-model pin read fable. Through 08-16/17 the fable window sat at 100% while the gate saw a healthy account, and ~22,400 doomed retries burned (9,305 on 08-17 alone; goal filing and peer-mail summarizing down the whole stretch). The gated buckets now follow the CALL'S model: account windows gate every call; a model-scoped window gates exactly the calls that would bill it.

**The loud half** (the user's own requirement): a judge layer down on a usage limit says so instead of failing quietly. The gate writes a judge-limit latch (self-expiring at the window reset, cleared by the next successful call — the two deciding events, never re-derived per build); build_feed ships it; the feed shows a compact banner above the columns. A fable-window exhaustion offers one action — run analysis on Opus until the reset (cheaper per token: $5/$25 vs $10/$50 per M) — wired to the existing judge-model setting; a general exhaustion states plainly the account's window is full and when it resumes. Built once, updated in place (click-safe); the button acknowledges before the round-trip.

**The stale-file gap**: get_usage rides turn ends, so an idle fleet's usage.json goes stale (~15h measured) and the gate is only as good as that file. A limit-shaped error envelope now latches the banner AND pokes one exact usage poll through a kernel-wired hook — the first doomed call refreshes the file and the gate blocks the rest.

Plus a one-line `romp-postal` skill addition: verify a role-style recipient against `list_agents` before sending (role handoffs leave stale addresses).

Tests: the old ignore-fable pin flipped to the model-aware contract; latch mark/self-expiry/clear-on-success; envelope→poll hook; feed banner + wiring pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)