### PR TITLE
Failed figures heal for real: the 416 loop resets, the settled chip rides the push-heal, taps always acknowledge

### DIFF
--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -37,7 +37,8 @@ test("a kernel-VERIFIED preview fails LOUDLY: a retry chip holds the figure's sp
   // unverified (old kernel, no pathLinks verdict) keeps self-removal — there the error means "no such file"
   assert.match(pf, /if \(!verified\) \{ box\.remove\(\); return; \}/);
   assert.match(pf, /chip\.className = "path-full-retry";/);
-  assert.match(pf, /chip\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); autoRetries = 3; build\(true\); \};/, "a tap re-arms persistence, then retries");
+  assert.match(pf, /chip\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); autoRetries = 3; ackTap\(ev\); build\(true\); \};/,
+    "a tap re-arms persistence, acknowledges even mid-attempt, then retries");
   assert.match(pf, /headers: got > 0 \? \{ Range: "bytes=" \+ got \+ "-" \} : \{\}/,
     "a retry RESUMES from the bytes already received (kernel /file honors the suffix range)");
   // the render layer feeds the verdict: spacePaths and pathLinks hits are kernel-stat'd paths
@@ -57,8 +58,8 @@ test("the failure chip narrates what happens next, escalates on repeat, and a re
   // "trying" and "unavailable" on every retry cycle read as impatient even when it eventually loaded)
   assert.match(pf, /if \(autoRetries > 0 \|\| transient\) \{\s*\n\s*if \(!transient\) autoRetries--;\s*\n\s*failedPreviews\.set\(box, \(\) => build\(true\)\);/);
   assert.match(pf, /\+ " — retrying · tap to retry now";/);
-  assert.match(pf, /wait\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); autoRetries = 3; build\(true\); \};/,
-    "the whole retrying box is the tap target — and a tap re-arms persistence");
+  assert.match(pf, /wait\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); autoRetries = 3; ackTap\(ev\); build\(true\); \};/,
+    "the whole retrying box is the tap target — a tap re-arms persistence and acknowledges");
   assert.match(pf, /"⚠ preview unavailable"\)\)\s*\n\s*\+ " — tap to retry";/,
     "the chip exists only once the budget is spent, so it carries no retrying-automatically claim");
   // a repeat failure pulses the chip on swap-in — the acknowledge-every-click rule

--- a/ui/webview/preview-heal.test.ts
+++ b/ui/webview/preview-heal.test.ts
@@ -1,0 +1,38 @@
+// The managed image fetch heals from every failure mode the wire can produce (the user 2026-08-18,
+// whose inline figures "never render until I send another message"): a refused status voids the
+// resume state (the stale-Range 416 loop), a settled give-up chip still rides the push-heal (one
+// attempt per NEW error, never one per push), and every tap acknowledges even when an attempt is
+// already in flight. Source pins on ui/webview/preview.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const PREVIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "preview.ts"), "utf8");
+
+test("a refused status voids the resume state — the stale-Range 416 loop (2026-08-18)", () => {
+  // an agent re-plotting the same filename SHRINKS the file; the kernel's 416 expects a clean
+  // restart, but the client kept `got`, so every tap and heal replayed the same stale Range and
+  // failed deterministically fast — while a send's freshly-minted box (got=0) rendered instantly
+  const at = PREVIEW.indexOf("a refused status VOIDS the resume state");
+  assert.ok(at > 0);
+  const tail = PREVIEW.slice(at, at + 700);
+  assert.ok(tail.indexOf("parts = []; got = 0;") > 0, "reset BEFORE the throw");
+  assert.ok(tail.indexOf("throw new Error(why") > tail.indexOf("parts = []; got = 0;"));
+});
+
+test("a settled chip still rides the push-heal, one attempt per NEW error (2026-08-18)", () => {
+  // only the retrying branch registered for the heal, so a spent budget dropped the box from the
+  // map forever — "figures never render on their own, only when I send a message" (the send's tail
+  // re-render minted a fresh box; the old one healed never)
+  assert.match(PREVIEW, /let chipHealedErr: string \| null = null;/);
+  assert.match(PREVIEW, /if \(lastErr !== chipHealedErr\) \{\s*\n\s*failedPreviews\.set\(box, \(\) => \{ chipHealedErr = lastErr; autoRetries = 1; build\(true\); \}\);/,
+    "re-registers ONLY on new information — never one fetch per push for a dead figure");
+});
+
+test("every tap acknowledges, even mid-attempt when build() no-ops on its fetching guard", () => {
+  assert.match(PREVIEW, /const ackTap = \(ev: Event\) => \{/);
+  assert.match(PREVIEW, /autoRetries = 3; ackTap\(ev\); build\(true\); \};   \/\/ a tap re-arms persistence/);
+  assert.equal((PREVIEW.match(/ackTap\(ev\); build\(true\)/g) || []).length, 2,
+    "both the retrying note and the settled chip acknowledge");
+});

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -205,6 +205,7 @@ export function previewFull(path: string, sid?: string | null, verified = false,
     // but an attempt that MADE PROGRESS refills the budget (see the resumable retry below): forward
     // motion is the event proving the link works sometimes, and only truly dead attempts spend it.
     let autoRetries = 3;
+    let chipHealedErr: string | null = null;    // the error a settled chip already spent its one heal on
     let fails = 0;                                   // total failed attempts — the chip's copy escalates
     // RESUMABLE RETRY STATE (the user 2026-08-16, on flaky wifi: every retry restarted the transfer
     // from byte 0, so a large figure never finished arriving — and the swirl gave no idea how far it
@@ -241,7 +242,7 @@ export function previewFull(path: string, sid?: string | null, verified = false,
         const wait = mkWait(box);
         wait.title = path + " — tap to retry now";
         wait.style.cursor = "pointer";
-        wait.onclick = (ev) => { ev.stopPropagation(); autoRetries = 3; build(true); };   // a tap re-arms persistence
+        wait.onclick = (ev) => { ev.stopPropagation(); autoRetries = 3; ackTap(ev); build(true); };   // a tap re-arms persistence
         const spin = document.createElement("img");
         spin.className = "path-load-spin";
         spin.src = "/media/romp-swirl-glyph.svg";
@@ -268,8 +269,18 @@ export function previewFull(path: string, sid?: string | null, verified = false,
                  : (fails > 1 ? "⚠ still unavailable" : "⚠ preview unavailable"))
         + " — tap to retry";
       chip.title = path;
-      chip.onclick = (ev) => { ev.stopPropagation(); autoRetries = 3; build(true); };   // a tap re-arms persistence
+      chip.onclick = (ev) => { ev.stopPropagation(); autoRetries = 3; ackTap(ev); build(true); };   // a tap re-arms persistence
       wait.appendChild(chip);
+      // A settled chip still rides the push-heal (the user 2026-08-18: "they never render on their
+      // own — only when I send a message"): only the retrying branch registered for the heal, so a
+      // spent budget dropped the box from the map forever — pushes and tunnel recovery ignored it,
+      // and a send only "worked" because the tail re-render minted a FRESH box. One heal attempt
+      // per registration, and the box re-registers ONLY when the error CHANGED (new information —
+      // the same verdict re-answered is no reason to fetch again): a truly-dead figure costs one
+      // extra fetch per new-evidence transition, never one per push.
+      if (lastErr !== chipHealedErr) {
+        failedPreviews.set(box, () => { chipHealedErr = lastErr; autoRetries = 1; build(true); });
+      }
       if (fails > 1) {
         chip.classList.add("path-retry-flash");
         chip.addEventListener("animationend", () => chip.classList.remove("path-retry-flash"), { once: true });
@@ -293,6 +304,14 @@ export function previewFull(path: string, sid?: string | null, verified = false,
       img.onclick = (ev) => { ev.stopPropagation(); openLightbox(path, sid, pin); };
       return img;
     };
+    // every tap READS as a tap even when the click lands mid-attempt and build() no-ops on its
+    // `fetching` guard (the buttons-always-acknowledge rule: an unacknowledged tap gets re-tapped)
+    const ackTap = (ev: Event) => {
+      const t = ev.currentTarget as HTMLElement | null;
+      if (!t) return;
+      t.classList.add("path-retry-flash");
+      t.addEventListener("animationend", () => t.classList.remove("path-retry-flash"), { once: true });
+    };
     const resumeFetch = async (note: HTMLElement) => {
       const gotBefore = got;
       const r = await fetch(url, { cache: "no-store",
@@ -308,6 +327,12 @@ export function previewFull(path: string, sid?: string | null, verified = false,
         // answering") — a bare status code hid that the IMAGE was fine and the LINK was down
         let why = "";
         try { why = ((await r.text()) || "").split("\n")[0].slice(0, 120); } catch { /* body unavailable */ }
+        // a refused status VOIDS the resume state (the user 2026-08-18, whose re-generated figures
+        // never loaded): the file changed under our offset — an agent re-plotting the same name
+        // shrinks it — and the kernel's 416 expects the client to RESTART cleanly. Keeping `got`
+        // made every later attempt, tap and heal alike, replay the same stale Range and fail
+        // deterministically fast, while a send's fresh box (got=0) rendered instantly.
+        parts = []; got = 0;
         throw new Error(why || "http " + r.status);
       }
       const reader = r.body!.getReader();


### PR DESCRIPTION
Inline figures never rendered on their own, tapping the chip errored out instantly, and sending any message made them appear at once. The send was never the heal: it grows the event tail, the tail re-render mints a BRAND-NEW preview box (fresh budget, no stale offset, current pin) whose plain `<img>` path succeeds — while the old failed box is dropped disconnected. Three real defects underneath:

- **A refused status now voids the resume state.** An agent re-plotting the same filename shrinks the file; the kernel's 416 expects a clean restart, but the client kept its `got` offset, so every later attempt — tap and heal alike — replayed the same stale `Range` and failed deterministically fast. The reset happens before the throw, so the next attempt starts clean.
- **A settled give-up chip still rides the push-heal.** Only the retrying branch registered for the heal, so a spent budget dropped the box from the map forever — kernel pushes and tunnel recovery ignored it. The chip branch now registers a ONE-SHOT heal that re-arms a single attempt, re-registering only when the error CHANGED (new information) — a truly-dead figure costs one extra fetch per new-evidence transition, never one per push.
- **Every tap acknowledges,** even when an attempt is already in flight — the build's `fetching` guard used to swallow the click with no visual response, which read as "clicking does nothing".

Pins in preview-heal.test.ts; the two stale tap pins in chat-inline-preview.test.ts updated to the acknowledging form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)