### PR TITLE
The distill-failed modal names the exact error and the model that failed

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -976,6 +976,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             # _judge_run owns ALL call-level logging (this, the error envelope below, the rate gate above)
             # so callers never double-log: to a caller every failed call is just "", and "call" rows always
             # carry the judge's own name + fsid (pre-07-09 rows said "index"/"triage" with no session).
+            _judge_ctx.last_call_fail = {"note": type(e).__name__, "model": model}
             _log_judge_error(judge or tier, fsid, "call", note=type(e).__name__)
             return ""
         recv = time.time()                            # literal wall-clock: the response is back
@@ -991,6 +992,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 # No usage row: a zero-cost error envelope is not a model call the cost rollup should count.
                 msg = str(wrap.get("result") or wrap.get("subtype") or "")
                 _judge_ctx.last["reply"] = str(wrap.get("result") or "")[:2000]
+                _judge_ctx.last_call_fail = {"note": msg[:160], "model": model}
                 _log_judge_error(judge or tier, fsid, "call",
                                  note="error envelope: %r" % msg[:160])
                 if _is_auth_error(msg):
@@ -1003,6 +1005,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 _log_judge_usage(judge or tier, tier, model, fsid, wrap, sent, recv)
                 _auth_down_clear(fsid)                # billing works → unlatch (cheap no-op when unlatched)
                 _mark_call_served()                   # calls serve again → the give-up re-arm edge
+                _judge_ctx.last_call_fail = None      # a served reply retires the stashed error evidence
                 return wrap["result"]
         except Exception:
             pass
@@ -1013,6 +1016,9 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             # and the card's warn could only GUESS its cause ("errors or timeouts"). The returncode and
             # stderr tail are the only evidence a dead CLI leaves — record them (fail loudly; a silent
             # fallback hides the very breakage we need to know about).
+            _judge_ctx.last_call_fail = {
+                "note": "the model CLI died with no output (exit %s)" % getattr(p, "returncode", "?"),
+                "model": model}
             _log_judge_error(judge or tier, fsid, "call",
                              note="empty stdout (exit %s): %s"
                                   % (getattr(p, "returncode", "?"),
@@ -2726,17 +2732,24 @@ def _warn_line_kind(judge):
 
 def _warn_summary_failed(nd, judge, t):
     """Stamp this card's summary/brief-FAILED warning after a give-up. Concise, takeaway-first, names the
-    cause; the developer audit (the raw call failures) stays in judge-errors.jsonl."""
+    cause — including the LAST attempt's literal error and the model it called (the user 2026-08-18, who
+    could not tell from "errors or timeouts" that only the distill tier's model was down while everything
+    else served): _judge_run stashes each call-level failure per-thread, and the give-up is written in the
+    same thread right after the capping failure, so the stash IS this give-up's evidence. The developer
+    audit (every raw call failure) stays in judge-errors.jsonl."""
     line, pre = _warn_line_kind(judge)
     kind = pre + "-failed"
     cause, ratelimited = _giveup_cause()
     retry = ("romp retries it automatically the moment the limit resets; nudging the session refreshes it sooner."
              if ratelimited else
              "romp retries it on its own after it recovers or restarts — or hit Try again to retry it now.")
+    last = getattr(_judge_ctx, "last_call_fail", None)
+    spec = ("" if (ratelimited or not isinstance(last, dict) or not last.get("note")) else
+            ' The last attempt failed with: "%s" (the %s model).' % (last["note"], last.get("model") or "?"))
     _node_warn(nd, kind, t,
                "romp couldn't write this card's %s." % line,
-               "romp tried to generate this %s several times and each attempt failed, because %s. No work was "
-               "lost — this is only the summary line. %s" % (line, cause, retry))
+               "romp tried to generate this %s several times and each attempt failed, because %s.%s No work "
+               "was lost — this is only the summary line. %s" % (line, cause, spec, retry))
 
 
 def _warn_history_unreadable(nd, judge, t):

--- a/tests/test_distill_rearm.py
+++ b/tests/test_distill_rearm.py
@@ -11,10 +11,12 @@ again. Under test here:
     clearing its event stamp, since the "" flip cannot apply;
   - "stall-failed" joins the scan/re-arm family (the staller's give-ups were invisible to both).
 SYNTHETIC fixtures only (placeholder UUIDs, invented text)."""
+import json
 import os
 import tempfile
 import unittest
 from importlib.machinery import SourceFileLoader
+from types import SimpleNamespace
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -127,6 +129,56 @@ class RearmRecoveryEvents(unittest.TestCase):
         self.assertEqual(scan["count"], 1, "a given-up stall note counts toward the banner")
         self.assertEqual(jd.rearm_failed_summaries(T0 + 100), 1)
         self.assertIsNone(_node().get("stallSummary"), "the stall note re-arms like the other lines")
+
+
+class GiveUpWarnNamesTheError(unittest.TestCase):
+    """The "distill failed" modal names the LAST attempt's literal error and the model it called (the
+    user 2026-08-18): an Opus-scoped 529 outage read as generic "errors or timeouts" while every other
+    tier served — the modal gave no way to see that only the distill tier's model was down."""
+
+    def setUp(self):
+        jd.STATE.mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "usage.json").write_text(json.dumps(
+            {"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        jd._judge_ctx.last_call_fail = None
+
+    def _run_fake(self, envelope, model="opus"):
+        def fake_run(cmd, input=None, capture_output=None, text=None, cwd=None, env=None, timeout=None):
+            return SimpleNamespace(stdout=json.dumps(envelope), stderr="", returncode=0)
+        saved = jd.subprocess.run
+        jd.subprocess.run = fake_run
+        try:
+            return jd._judge_run(model, "SYS", "u", judge="distiller", tier="distill")
+        finally:
+            jd.subprocess.run = saved
+
+    def test_an_error_envelope_stashes_the_note_and_the_model(self):
+        out = self._run_fake({"is_error": True, "result": "API Error: Repeated 529 Overloaded errors."})
+        self.assertEqual(out, "", "an error envelope is a failed call to the caller")
+        st = jd._judge_ctx.last_call_fail
+        self.assertIn("529 Overloaded", st["note"])
+        self.assertEqual(st["model"], "opus")
+
+    def test_a_served_reply_retires_the_stash(self):
+        self._run_fake({"is_error": True, "result": "API Error: Repeated 529 Overloaded errors."})
+        self._run_fake({"result": "a fine reply", "usage": {}}, model="sonnet")
+        self.assertIsNone(jd._judge_ctx.last_call_fail,
+                          "a served reply must retire the evidence — a later unrelated give-up "
+                          "never wears a stale error")
+
+    def test_warn_detail_names_the_error_and_the_model(self):
+        jd._judge_ctx.last_call_fail = {"note": "API Error: Repeated 529 Overloaded errors.",
+                                        "model": "opus"}
+        nd = {}
+        jd._warn_summary_failed(nd, "distiller", T0)
+        det = nd["warns"][0]["detail"]
+        self.assertIn("529 Overloaded", det, "the literal error reaches the modal")
+        self.assertIn("opus", det, "the model is named — a model-scoped outage is visible as such")
+
+    def test_warn_detail_stays_generic_without_evidence(self):
+        nd = {}
+        jd._warn_summary_failed(nd, "distiller", T0)
+        self.assertNotIn("last attempt failed", nd["warns"][0]["detail"])
 
 
 class KernelRearmWiring(unittest.TestCase):


### PR DESCRIPTION
## Why

Today's outage was invisible in the modal: an Anthropic incident scoped to ONE model (Opus) failed every distill-tier call with 529 Overloaded while every other tier — on other models — kept serving. The "distill failed" modal said only "repeated errors or timeouts", so there was no way to see what actually failed, or that pointing the distill tier at a healthy model would fix it instantly.

## What

`_judge_run` stashes each call-level failure per-thread — the literal error message (error envelope / exception name / dead-CLI note) plus the model it called — and retires the stash on the next served reply. The give-up warn is written in the same thread immediately after the capping failure, so `_warn_summary_failed` appends the evidence to the modal detail:

> … each attempt failed, because of repeated errors or timeouts. The last attempt failed with: "API Error: Repeated 529 Overloaded errors. …" (the opus model). No work was lost …

The account-limit branch keeps its existing copy; a give-up with no stashed evidence stays generic.

## Tests

`tests/test_distill_rearm.py`: `_judge_run` end to end with a fake CLI (an error envelope stashes note+model, a served reply retires it) and the warn-detail join, plus the generic-without-evidence guard. Targeted run: 501 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)