### PR TITLE
The tab strip grows a drag-to-resize grip instead of clipping at four rows

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -20984,6 +20984,7 @@ _CHAT_MOBILE_CSS = (
     "@media (pointer:coarse) and (max-width:1024px){"
     "#tabbar{max-height:none;overflow:visible;position:relative;padding:6px 8px}"
     "#tabbar #tabs{display:none}"                       # the wrapping multi-row tab strip
+    "#tabbar-resize{display:none}"                      # nothing to resize under the mobile header
     "#mhdr{display:flex;align-items:stretch;gap:6px;width:100%}"
     "#mcur{flex:1 1 auto;min-width:0;display:flex;align-items:center;gap:8px;cursor:pointer;"
     "background:#2a2a2a;color:#dddddd;border:1px solid #3a3a3a;border-radius:6px;padding:7px 10px;"
@@ -21318,6 +21319,7 @@ def _timeline_page():
 def _chat_body():
     # ported from vscode-extension/src/page-skeleton.chatBody
     return ('<div id="winframe"></div><div id="tabbar"><span id="tabs"></span></div>'
+            '<div id="tabbar-resize" title="Drag to resize the tab strip"></div>'
             '<div id="ledger" style="display:none"></div>'
             # the live-ask picker lives INSIDE #content (the user 2026-06-27) so it flows at the bottom of the
             # transcript and scrolls WITH the chat history, instead of a fixed mini-window below it.

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13,6 +13,7 @@ import diff from "highlight.js/lib/languages/diff";
 import yaml from "highlight.js/lib/languages/yaml";
 import type { ParsedAsk } from "../ask-types";
 import { quoteReply } from "../quote";
+import { TABBAR_H_KEY, TABBAR_H_DEFAULT, clampTabbarH, parseTabbarH } from "./tabbar-resize";
 import { markerLabel, dayContext } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
 import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompSettings } from "./settings";
@@ -7435,6 +7436,80 @@ if (typeof ResizeObserver === "function") {
       lastH = h;
     });
     tro.observe(box);
+  }
+}
+
+// ── drag-to-resize the tab strip (the user 2026-08-18) ── #tabbar wraps its tabs into rows and scrolls
+// past its max-height cap (150px ≈ four rows), which clipped the fifth row of a many-session strip with
+// no way to see more. The #tabbar-resize grip straddles the strip's bottom border: drag DOWN for more
+// rows, UP for fewer; it stays a scroll pane at every size. The dragged cap is per-viewer arrangement
+// like the tab ORDER (romp:vieworder), so it lives in localStorage — applied at boot, written on release
+// (not per-move). A double-click resets to the CSS default. Same pattern as #composer-resize; the grip
+// is a SIBLING below the bar (a child would scroll away with the rows), so it also survives every #tabs
+// re-render. The content-anchor ResizeObserver above cancels the scroll jump the resize would cause.
+{
+  const bar = document.getElementById("tabbar");
+  const grip = document.getElementById("tabbar-resize");
+  if (bar && grip) {
+    // `cap` is the preference of record. The APPLIED value re-clamps to the live window on every
+    // resize (an oversized cap must not crush the transcript when the window shrinks), but a
+    // briefly-small window never rewrites the preference — the applied style heals back when the
+    // window grows. Applied through the --tabbar-cap VAR, never the max-height property: the mobile
+    // page's `#tabbar{max-height:none}` must keep winning (an inline max-height would override that
+    // media rule and clip the mobile header, e.g. after a tablet rotation).
+    let cap = parseTabbarH(localStorage.getItem(TABBAR_H_KEY));
+    const applyCap = () => {
+      if (cap == null) bar.style.removeProperty("--tabbar-cap");
+      else bar.style.setProperty("--tabbar-cap", clampTabbarH(cap, window.innerHeight) + "px");
+    };
+    applyCap();
+    window.addEventListener("resize", applyCap);
+    let startY = 0, startH = 0, pid = 0, dragging = false, stick = false;
+    const onMove = (e: PointerEvent) => {
+      if (!dragging) return;
+      if (!(e.buttons & 1)) { onUp(); return; }    // release swallowed (context menu, off-window) → end, never strand a phantom drag
+      cap = clampTabbarH(startH + (e.clientY - startY), window.innerHeight);
+      applyCap();
+      // growing the bar shrinks #content, which would push a tail-following view off the tail one
+      // sub-threshold step at a time — if it was at the tail when the drag began, keep it there
+      const content = document.getElementById("content");
+      if (stick && content) content.scrollTop = content.scrollHeight;
+    };
+    const onUp = () => {
+      if (!dragging) return;
+      dragging = false;
+      try { grip.releasePointerCapture(pid); } catch { /* already released */ }
+      grip.classList.remove("dragging");
+      document.body.classList.remove("tabbar-resizing");
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+      if (cap != null) localStorage.setItem(TABBAR_H_KEY, String(cap));
+    };
+    grip.addEventListener("pointerdown", (e) => {
+      if (e.button !== 0) return;                  // a right-click opens menus, never a drag
+      e.preventDefault();
+      dragging = true;
+      startY = e.clientY;
+      // Anchor to the EFFECTIVE cap, never the rendered height: with fewer rows than the cap the
+      // rect is content-sized, and anchoring there silently collapsed a larger stored cap to about
+      // the content height on any drag — invisible at the time, and the clipped strip came back
+      // weeks later with no visible cause.
+      startH = cap != null ? clampTabbarH(cap, window.innerHeight) : TABBAR_H_DEFAULT;
+      const content = document.getElementById("content");
+      stick = !!content && nearBottom(content);
+      pid = e.pointerId;
+      // capture so the drag survives leaving the pane; a pointer already gone throws — the window
+      // listeners below carry the drag either way, so a failed capture must not abort the setup
+      try { grip.setPointerCapture(pid); } catch { /* pointer already released */ }
+      grip.classList.add("dragging");
+      document.body.classList.add("tabbar-resizing");
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
+    });
+    // a double-click resets to the CSS default cap — the quick escape hatch, like the composer's
+    grip.addEventListener("dblclick", () => { cap = null; applyCap(); localStorage.removeItem(TABBAR_H_KEY); });
   }
 }
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -81,8 +81,10 @@ body { display: flex; flex-direction: column; overflow-x: hidden; }   /* the cha
   display: flex; align-items: flex-start; gap: 4px;
   padding: 5px 8px 0;
   flex: 0 0 auto;
-  /* wrap tabs onto extra rows; only scroll once they'd eat ~4+ rows */
-  max-height: 150px; overflow-y: auto; overflow-x: hidden;
+  /* wrap tabs onto extra rows; only scroll once they'd eat ~4+ rows. The cap rides a VAR so the
+     #tabbar-resize drag can move it while the mobile page's max-height:none still wins over it
+     (an inline max-height would override that media rule and clip the mobile header) */
+  max-height: var(--tabbar-cap, 150px); overflow-y: auto; overflow-x: hidden;
   border-bottom: 1px solid var(--box-border);
   background: var(--vscode-sideBar-background, var(--bg));
 }
@@ -90,6 +92,23 @@ body { display: flex; flex-direction: column; overflow-x: hidden; }   /* the cha
    2026-08-08): the strip trades its empty inter-tab space for room for the per-tab context gauge —
    the active/hover fills and per-tab padding still separate neighbours visually. */
 #tabs { display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; }
+/* Drag handle straddling the tab strip's bottom border (the user 2026-08-18): the strip scrolls past
+   its max-height cap, which clipped the fifth row of a many-session strip with no way to see more.
+   Drag DOWN for more rows, UP for fewer; double-click resets; the strip stays a scroll pane at every
+   size. A SIBLING below #tabbar (a child would scroll away with the rows) whose negative margins
+   cancel its 7px grab zone, so it costs zero layout height — the #composer-resize affordance, worn
+   the same way. */
+#tabbar-resize {
+  position: relative; z-index: 6; flex: 0 0 auto;
+  height: 7px; margin: -3px 0 -4px;   /* 2px over the last tab row (net of the border), 4px over the transcript's top padding — tabs are interactive, the padding isn't */
+  cursor: ns-resize; touch-action: none;
+}
+#tabbar-resize::after {
+  content: ""; position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
+  width: 36px; height: 3px; border-radius: 2px; background: var(--box-border); transition: background 0.12s, width 0.12s;
+}
+#tabbar-resize:hover::after, #tabbar-resize.dragging::after { background: var(--accent); width: 52px; }
+body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 /* (the settings gear + modal live on the TIMELINE now — see ui/romp-timeline-view.js) */
 
 .tab {

--- a/ui/webview/tabbar-resize.test.ts
+++ b/ui/webview/tabbar-resize.test.ts
@@ -1,0 +1,90 @@
+// Drag-to-resize the chat tab strip (the user 2026-08-18): #tabbar wraps its session tabs into rows
+// and scrolls past a max-height cap, which clipped the fifth row of a many-session strip with no way
+// to see more. A #tabbar-resize grip straddles the strip's bottom border — drag DOWN for more rows,
+// UP for fewer, double-click to reset — and the strip stays a scroll pane at every size. The dragged
+// cap is per-viewer arrangement (localStorage, like romp:vieworder). Executed tests on the pure
+// module + source pins for the wiring (no jsdom for the chat renderer).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { TABBAR_H_KEY, TABBAR_H_DEFAULT, TABBAR_H_MIN, clampTabbarH, parseTabbarH } from "../../ui/webview/tabbar-resize";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const SKELETON = fs.readFileSync(path.resolve(process.cwd(), "src", "page-skeleton.ts"), "utf8");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+
+test("executed: the cap clamps to [one row, 60% of the window], and never below the CSS default's reach", () => {
+  assert.equal(clampTabbarH(10, 900), TABBAR_H_MIN, "at least one tab row stays visible");
+  assert.equal(clampTabbarH(-50, 900), TABBAR_H_MIN);
+  assert.equal(clampTabbarH(300, 900), 300, "inside the bounds a drag lands where it dragged");
+  assert.equal(clampTabbarH(163.4, 900), 163, "whole pixels");
+  assert.equal(clampTabbarH(5000, 900), 540, "at most 60% of the window");
+  assert.equal(clampTabbarH(150, 100), TABBAR_H_DEFAULT,
+    "a tiny window never clamps a stored height below the CSS default's own reach");
+});
+
+test("executed: a stored height parses to a positive number or null — never NaN into layout", () => {
+  assert.equal(parseTabbarH(null), null, "never dragged");
+  assert.equal(parseTabbarH(""), null, "reset");
+  assert.equal(parseTabbarH("garbage"), null);
+  assert.equal(parseTabbarH("-12"), null);
+  assert.equal(parseTabbarH("0"), null);
+  assert.equal(parseTabbarH("210"), 210);
+});
+
+test("the grip is a sibling BELOW the bar in both page skeletons — a child would scroll away with the rows", () => {
+  assert.match(SKELETON, /<div id="tabbar"><span id="tabs"><\/span><\/div>\s*\n\s*<div id="tabbar-resize"[^>]*><\/div>/);
+  assert.match(KERNEL, /<div id="tabbar"><span id="tabs"><\/span><\/div>'\s*\n\s*'<div id="tabbar-resize"/);
+  // the mobile page replaces the strip with its own header — nothing there to resize
+  assert.match(KERNEL, /"#tabbar-resize\{display:none\}"/);
+});
+
+test("the CSS keeps the strip a scroll pane and the grip layout-free, wearing the composer grip's affordance", () => {
+  // the cap rides a VAR, never an inline max-height: the mobile page's #tabbar{max-height:none}
+  // must keep winning, or a stored desktop cap clips the mobile header after a rotation
+  assert.match(CSS, /#tabbar \{[^}]*max-height: var\(--tabbar-cap, 150px\); overflow-y: auto;/s,
+    "the cap the grip drags; scroll stays; the mobile rule can still zero it out");
+  assert.match(CSS, /#tabbar-resize \{[^}]*height: 7px; margin: -3px 0 -4px;[^}]*\n[^}]*cursor: ns-resize;/s,
+    "negative margins cancel the 7px grab zone — zero layout height, and only 2px over the last tab row");
+  assert.match(CSS, /#tabbar-resize:hover::after, #tabbar-resize\.dragging::after \{ background: var\(--accent\); width: 52px; \}/,
+    "same hover/drag brightening as #composer-resize");
+});
+
+test("the cap is applied at boot and re-clamped on every window resize, via the var", () => {
+  const at = RENDER.indexOf("drag-to-resize the tab strip");
+  const end = RENDER.indexOf("// Keep the rendered window over the viewport");
+  assert.ok(at > 0 && end > at, "the wiring block exists and the end anchor follows it");
+  const fn = RENDER.slice(at, end);
+  // one ORDERED block: read → applyCap defined on the var → applied → re-applied on resize. The
+  // apply itself is pinned (not just the read): deleting the apply left the suite green once.
+  assert.match(fn, new RegExp(
+    String.raw`let cap = parseTabbarH\(localStorage\.getItem\(TABBAR_H_KEY\)\);[\s\S]*?` +
+    String.raw`bar\.style\.setProperty\("--tabbar-cap", clampTabbarH\(cap, window\.innerHeight\) \+ "px"\);[\s\S]*?` +
+    String.raw`applyCap\(\);\n\s*window\.addEventListener\("resize", applyCap\);`),
+    "boot applies the stored cap and a window resize re-clamps it");
+  assert.match(fn, /bar\.style\.removeProperty\("--tabbar-cap"\);/, "a reset removes the var — the CSS default returns");
+});
+
+test("dragging moves the EFFECTIVE cap, guarded and captured, persists on release, dblclick resets", () => {
+  const at = RENDER.indexOf("drag-to-resize the tab strip");
+  const fn = RENDER.slice(at, RENDER.indexOf("// Keep the rendered window over the viewport"));
+  assert.match(fn, /if \(e\.button !== 0\) return;/, "a right-click opens menus, never a drag");
+  assert.match(fn, /if \(!\(e\.buttons & 1\)\) \{ onUp\(\); return; \}/,
+    "a swallowed release ends the drag — no phantom resize, no stuck cursor");
+  assert.match(fn, /try \{ grip\.setPointerCapture\(pid\); \} catch/,
+    "the drag survives leaving the pane — and a failed capture never aborts the setup");
+  assert.match(fn, /grip\.releasePointerCapture\(pid\);/, "and the capture never outlives it");
+  assert.match(fn, /startH = cap != null \? clampTabbarH\(cap, window\.innerHeight\) : TABBAR_H_DEFAULT;/,
+    "anchored to the EFFECTIVE cap — anchoring to the rendered height silently collapsed a larger stored cap");
+  assert.match(fn, /cap = clampTabbarH\(startH \+ \(e\.clientY - startY\), window\.innerHeight\);/,
+    "drag DOWN grows — the cap follows the pointer");
+  assert.match(fn, /stick = !!content && nearBottom\(content\);/, "a tail-following transcript is noted at drag start…");
+  assert.match(fn, /if \(stick && content\) content\.scrollTop = content\.scrollHeight;/,
+    "…and held on the tail while the bar grows over it");
+  assert.match(fn, /if \(cap != null\) localStorage\.setItem\(TABBAR_H_KEY, String\(cap\)\);/,
+    "persisted on release, not per-move");
+  assert.match(fn, /grip\.addEventListener\("dblclick", \(\) => \{ cap = null; applyCap\(\); localStorage\.removeItem\(TABBAR_H_KEY\); \}\)/,
+    "double-click resets to the CSS default");
+});

--- a/ui/webview/tabbar-resize.ts
+++ b/ui/webview/tabbar-resize.ts
@@ -1,0 +1,25 @@
+// Drag-to-resize state for the chat tab strip (the user 2026-08-18): #tabbar wraps its session tabs
+// into rows and scrolls past a max-height cap, which clipped the fifth row of a many-session strip
+// with no way to see more. The #tabbar-resize grip drags that cap; the strip stays a scroll pane at
+// every size. Pure logic split out of render.ts so it can be unit-tested without a DOM (the
+// time-marker.ts pattern).
+
+// localStorage key: the dragged cap is per-viewer ARRANGEMENT, like the tab order (romp:vieworder) —
+// a property of how you are looking at your sessions, not of the sessions.
+export const TABBAR_H_KEY = "romp:tabbarH";
+export const TABBAR_H_DEFAULT = 150;   // the CSS max-height when never dragged (~four rows)
+export const TABBAR_H_MIN = 40;        // at least one tab row stays visible
+
+// The dragged cap, clamped: at least one row, at most 60% of the window (the composer's convention,
+// composerMaxH) — but never below the CSS default's reach, so a stored height survives a tiny window.
+export function clampTabbarH(h: number, winH: number): number {
+  const max = Math.max(TABBAR_H_DEFAULT, Math.round(winH * 0.6));
+  return Math.max(TABBAR_H_MIN, Math.min(max, Math.round(h)));
+}
+
+// A stored height: a finite positive number, or null (never dragged / reset / garbage).
+export function parseTabbarH(raw: string | null): number | null {
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}

--- a/vscode-extension/src/page-skeleton.ts
+++ b/vscode-extension/src/page-skeleton.ts
@@ -20,6 +20,7 @@
 export function chatBody(attachTitle: string): string {
   return `  <div id="winframe"></div>
   <div id="tabbar"><span id="tabs"></span></div>
+  <div id="tabbar-resize" title="Drag to resize the tab strip"></div>
   <div id="ledger" style="display:none"></div>
   <div id="content"><div id="live-ask" style="display:none"></div></div>
   <div id="footer">


### PR DESCRIPTION
With many sessions open the chat tab strip wraps past its 150px max-height cap and clips the fifth row mid-tab, with no way to see more (user report 2026-08-18, with a screenshot). The strip stays a scroll pane; a grip on its bottom border now drags the cap — down for more rows, up for fewer, double-click to reset.

Same affordance as the composer's existing resize handle, with the differences the strip forces and the ones adversarial review caught:

- **Sibling, not child**: the grip sits below `#tabbar` (a child would scroll away with the rows) and survives every `#tabs` re-render; negative margins make it zero layout cost (2px over the last tab row, 4px over the transcript's top padding).
- **Persisted per viewer**: the cap is arrangement like the tab order (`romp:vieworder` ruling), stored in localStorage (`romp:tabbarH`), applied at boot, written on release, and **re-clamped to 60% of the window on every resize** without rewriting the stored preference — a briefly-small window must not destroy it.
- **Var, not inline max-height**: the cap rides `--tabbar-cap`, so the mobile page's `#tabbar{max-height:none}` keeps winning and a stored desktop cap can never clip the mobile header after a rotation.
- **Anchored to the effective cap**, not the rendered height — anchoring to the rect silently collapsed a larger stored cap on any jitter when the strip held fewer rows than the cap (review-confirmed high).
- **Guards**: primary button only, failure-tolerant pointer capture, and a `buttons===0` bail so a swallowed release (context menu, off-window) can never strand a phantom drag that persists an accidental cap.
- **Tail-follow held**: a transcript at the tail when the drag starts stays on the tail while the bar grows over it.

Verification: all drag scenarios exercised headless against the real sliced source and stylesheet (boot apply, sparse-strip jitter preserving the stored cap, right-click no-op, swallowed-release recovery, tail-hold with the cap really moving mid-drag, mobile-rule precedence, resize clamp-and-restore). Executed tests for the clamp/parse module; ordered source pins for boot-apply → resize re-clamp and every guard; both page skeletons pinned. Full extension suite and pytest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)