### PR TITLE
A feed section folded in the stacked layout un-hides itself side by side

### DIFF
--- a/ui/webview/feed-col-fold.test.ts
+++ b/ui/webview/feed-col-fold.test.ts
@@ -15,7 +15,15 @@ test("the caret folds a category to its header and persists like every other dis
   assert.match(FEED, /const fold = el\("button", "fcol-fold"\);/);
   assert.match(FEED, /if \(collapsedCols\.has\(key\)\) collapsedCols\.delete\(key\); else collapsedCols\.add\(key\);/);
   assert.match(FEED, /cols: \[\.\.\.collapsedCols\],\s*\n\s*order: stackOrder\.slice\(\)/, "rides the persisted view state");
-  assert.match(CSS, /\.feed-col\.col-collapsed \.feed-col-list \{ display: none; \}/);
+  // The fold BITES only in the stacked layout (the user 2026-08-18): collapsed while stacked, then
+  // widened to three columns, the section stayed hidden with no caret to reopen it. The rule must
+  // live INSIDE the stacked container query — side by side, every card always shows.
+  const stacked = CSS.slice(CSS.indexOf("@container (max-width: 540px)"));
+  assert.match(stacked, /\.feed-col\.col-collapsed \.feed-col-list \{ display: none; \}/,
+    "the collapse rule is scoped to the stacked layout");
+  assert.doesNotMatch(CSS.slice(0, CSS.indexOf("@container (max-width: 540px)")),
+    /\.col-collapsed \.feed-col-list/,
+    "and no unscoped copy survives to hide cards side-by-side");
   assert.match(FEED, /fold\.textContent = folded \? "▸" : "▾";/);
   // consistency with the session headers' fold (the user 2026-08-16): same side — caret RIGHT of the
   // label — and the same rendered size (the header's 0.72em compensated back to the feed's base)

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -147,10 +147,15 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    thumb-padded); the category CHIP is itself the drag surface (no separate handle — the grab cursor
    it wears in the stacked layout is the affordance). */
 .fcol-fold { display: none; }
-.feed-col.col-collapsed .feed-col-list { display: none; }   /* folded: the header (chip + count) stands in */
 
 @container (max-width: 540px) {
   .feed-cols { flex-direction: column; }
+  /* Folding exists ONLY here, so the fold BITING lives here too (the user 2026-08-18): this rule used
+     to sit outside the query, so a section collapsed while stacked stayed hidden after the feed
+     widened to side-by-side — an empty column with no caret to reopen it (the caret is stacked-only).
+     Scoped, the side-by-side layout always shows every card; the persisted fold re-applies the moment
+     the feed narrows back to one column. */
+  .feed-col.col-collapsed .feed-col-list { display: none; }   /* folded: the header (chip + count) stands in */
   /* stacked, the columns read TOP-DOWN as Completed → Blocked (needs you) → Working by default (the
      user 2026-07-30, moving Completed up from the middle; supersedes the 2026-07-08 Blocked-first
      order): what finished first, then what needs you, then what's still running. DOM order stays


### PR DESCRIPTION
Folding a feed category (the caret on Working/Blocked/Completed) exists only in the one-column stacked layout, but the rule that hides the folded section's cards sat outside the stacked container query. A section collapsed while narrow therefore stayed hidden after the feed widened to three columns: an empty column with no caret to reopen it (user report 2026-08-18).

The rule now lives inside the `@container (max-width: 540px)` block with the rest of the stacked-only furniture: side by side, every card always shows; the persisted fold re-applies the moment the feed narrows back to one column.

Verified headless at both widths with the real stylesheet (wide: cards visible, caret hidden; narrow: fold bites, caret shows). The test now pins the rule INSIDE the query and fails if an unscoped copy ever reappears. Also checked: no other consumer of the collapsed class anywhere in the repo, the 3-class selector wins regardless of rule order, and both feed hosts are Chromium (container queries supported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)