### PR TITLE
Recovery re-arm hardening: per-model edge, per-line eras, model-switch trigger

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -564,19 +564,29 @@ def _mid_elide(s, cap=6200):
 # was the usage-limit retry-pause clearing, and the failures that actually cause most give-ups (a 529
 # overload storm, an auth blip) never engage that pause, so their cards kept the "distill failed" chip
 # long after the API recovered. This latch tracks the exact event those cards wait on: the first SERVED
-# judge call after a call-level failure. "call" rows latch degraded (_log_judge_error); a served reply
-# flips it back and records the edge (_mark_call_served, from _judge_run's success paths); the kernel
-# consumes the edge between passes — its single-writer window — and re-arms the give-up cards once per
-# era (rearm_failed_summaries auto=True). Process-global on purpose: every judge thread shares one API.
-_CALL_HEALTH = {"degraded": False, "recovered": False}
+# judge call after a call-level failure, PER MODEL — the 2026-08-18 storm was Opus-scoped, and a Sonnet
+# captioner success fired the old model-blind edge mid-storm, spending each card's one automatic retry
+# on a doomed Opus call; the edge must be the failing model itself serving again. _judge_run's failure
+# sites latch the model degraded (_mark_call_failed); a served reply on that same model flips it back
+# and records the edge (_mark_call_served); the kernel consumes the edge between passes — its
+# single-writer window — and re-arms the give-up cards once per era (rearm_failed_summaries auto=True).
+# Process-global on purpose: every judge thread shares one API.
+_CALL_HEALTH = {"degraded": set(), "recovered": False}
 _health_lock = threading.Lock()
 
 
-def _mark_call_served():
-    """A judge call came back with a real reply — if calls had been failing, record the recovery edge."""
+def _mark_call_failed(model):
+    """A judge call failed at the call level (subprocess error, timeout, error envelope, dead CLI) —
+    latch this model degraded; its next served reply is the recovery edge."""
     with _health_lock:
-        if _CALL_HEALTH["degraded"]:
-            _CALL_HEALTH["degraded"] = False
+        _CALL_HEALTH["degraded"].add(model)
+
+
+def _mark_call_served(model):
+    """A judge call came back with a real reply — if THIS model had been failing, record the edge."""
+    with _health_lock:
+        if model in _CALL_HEALTH["degraded"]:
+            _CALL_HEALTH["degraded"].discard(model)
             _CALL_HEALTH["recovered"] = True
 
 
@@ -613,9 +623,6 @@ def _log_judge_error(judge, fsid, err, note=None, goal=None, seg=None):
     `tier` is written as a legacy twin of `judge` for pre-07-09 readers. Best-effort, NEVER raises — it
     runs inside the very failure paths it records."""
     try:
-        if err == "call":                              # a call-level failure (not the model's verdict) →
-            with _health_lock:                         # latch degraded; the next served reply is the edge
-                _CALL_HEALTH["degraded"] = True
         rec = {"t": int(time.time()), "judge": judge, "tier": judge, "fsid": fsid or "",
                "err": err, "note": note or ""}
         if goal:
@@ -977,6 +984,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             # so callers never double-log: to a caller every failed call is just "", and "call" rows always
             # carry the judge's own name + fsid (pre-07-09 rows said "index"/"triage" with no session).
             _judge_ctx.last_call_fail = {"note": type(e).__name__, "model": model}
+            _mark_call_failed(model)
             _log_judge_error(judge or tier, fsid, "call", note=type(e).__name__)
             return ""
         recv = time.time()                            # literal wall-clock: the response is back
@@ -993,6 +1001,12 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 msg = str(wrap.get("result") or wrap.get("subtype") or "")
                 _judge_ctx.last["reply"] = str(wrap.get("result") or "")[:2000]
                 _judge_ctx.last_call_fail = {"note": msg[:160], "model": model}
+                if "safeguards flagged" not in msg:
+                    # A safeguards refusal is the FILTER ruling on this call's CONTENT — deterministic
+                    # per prompt, not model health (the 2026-08-18 closer storm: 2,955 flags on research
+                    # transcripts while the same model served every other call). Latching it would flap
+                    # the degraded→serving edge on every flag/success interleave.
+                    _mark_call_failed(model)
                 _log_judge_error(judge or tier, fsid, "call",
                                  note="error envelope: %r" % msg[:160])
                 if _is_auth_error(msg):
@@ -1004,7 +1018,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                 _judge_ctx.last["reply"] = _mid_elide(wrap["result"])
                 _log_judge_usage(judge or tier, tier, model, fsid, wrap, sent, recv)
                 _auth_down_clear(fsid)                # billing works → unlatch (cheap no-op when unlatched)
-                _mark_call_served()                   # calls serve again → the give-up re-arm edge
+                _mark_call_served(model)              # THIS model serves again → the give-up re-arm edge
                 _judge_ctx.last_call_fail = None      # a served reply retires the stashed error evidence
                 return wrap["result"]
         except Exception:
@@ -1019,13 +1033,14 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             _judge_ctx.last_call_fail = {
                 "note": "the model CLI died with no output (exit %s)" % getattr(p, "returncode", "?"),
                 "model": model}
+            _mark_call_failed(model)
             _log_judge_error(judge or tier, fsid, "call",
                              note="empty stdout (exit %s): %s"
                                   % (getattr(p, "returncode", "?"),
                                      (getattr(p, "stderr", "") or "").strip()[-200:] or "no stderr"))
             return ""
         _judge_ctx.last["reply"] = _mid_elide(out)
-        _mark_call_served()                           # a raw reply is still a served call (recovery edge)
+        _mark_call_served(model)                      # a raw reply is still a served call (recovery edge)
         return out                                    # wrapper unparseable but non-empty → raw stdout (defensive)
     finally:
         _active_end(rid)                              # call done (success/timeout/parse-fail) → drop the live bar
@@ -2350,8 +2365,19 @@ def _replay_overrides(fsid, store):
             # replays past a success never clobber it. A give-up that KEPT an older real summary (a
             # re-completion's give-up never blanks prior text) re-arms by clearing its event stamp
             # instead — gated on the live "*-failed" warn, which a later success clears, so that replay
-            # is a no-op past a success too. No supersede guard needed — these are field flips, not log
-            # verdicts, and their no-op forms ARE the guard.
+            # is a no-op past a success too.
+            # STAND-DOWN (2026-08-18, the eternal-click review finding): the journal replays on every
+            # load forever, so the shape guards alone let one historical click loop a persistently
+            # failing card — the retry re-gives-up, the give-up re-stamps its warn and sentinel, and the
+            # next load's replay re-armed it again (and its old counter reset zeroed distillFails every
+            # load, making DISTILL_FAIL_CAP unreachable: one doomed model call per pass, forever, from a
+            # single click). A give-up warn stamped AFTER the click is the judges ruling on a newer
+            # world: the click answered an OLDER give-up, so it stands down — the writer-predates-diary
+            # rule. No counter reset at all: a click only exists post-give-up, where the counter is
+            # already 0 by the give-up write.
+            if max((int(w.get("t") or 0) for w in nd.get("warns") or []
+                    if isinstance(w, dict) and w.get("kind") in _FAILED_WARN_KINDS), default=0) > t:
+                continue                               # a later give-up superseded this click
             warned = {w.get("kind") for w in nd.get("warns") or [] if isinstance(w, dict)}
             for k, stamp, wkind in (("summary", "distilledMt", "summary-failed"),
                                     ("blockSummary", "briefedMt", "brief-failed"),
@@ -2361,10 +2387,6 @@ def _replay_overrides(fsid, store):
                     applied = True
                 elif nd.get(k) and wkind in warned and nd.get(stamp) is not None:
                     nd[stamp] = None
-                    applied = True
-            for k in ("distillFails", "briefFails", "stallFails"):
-                if nd.get(k):
-                    nd[k] = 0
                     applied = True
             # Deliberately NOT touching nd["autoRearmed"] here: the journal replays on EVERY load,
             # forever, so a single historical click would erase the era mark on each replay and defeat
@@ -3457,9 +3479,13 @@ def rollup_status(store, session_closed, now=None):
     # brief-failed, brief-unreadable) annotates the brief, which is the card's surface only while it
     # sits in Needs-you — once the card unblocks, no new brief is ever written to clear it, so a healthy
     # Working card wore the yellow "warning" chip indefinitely. Same for the summary family on a
-    # reopened completed card. Retire each warn with the state that shows its surface; a re-block /
-    # re-completion writes a fresh brief/summary, which re-warns if it fails again. Runs inside rollup —
-    # the status owner — so the store heals on its next touch, no display-side twin logic.
+    # reopened completed card, and (2026-08-18) for the stall family once its stall episode ends: the
+    # staller only ever runs for a goal live in stalled_facts, so an ended stall's warn had NO clear
+    # path and — once stall-failed joined the fleet failure scan — inflated the top banner permanently.
+    # Retire each warn with the state that shows its surface; a re-block / re-completion / fresh stall
+    # writes a fresh brief/summary/note, which re-warns if it fails again. Runs inside rollup — the
+    # status owner — so the store heals on its next touch, no display-side twin logic.
+    _stalls = None                                     # lazy: one stalled_facts read, only if a stall warn exists
     for nid, nd in nodes.items():
         ws = nd.get("warns")
         if not ws:
@@ -3470,6 +3496,11 @@ def rollup_status(store, session_closed, now=None):
             dead.add("brief")                          # the card left Needs-you → the brief isn't shown
         if st != "completed":
             dead.add("summary")                        # the card isn't completed → the takeaway isn't shown
+        if any(_warn_surface(w) == "stall" for w in ws):
+            if _stalls is None:
+                _stalls = stalled_facts(store.get("rompUuid") or "")
+            if st != "working" or nid not in _stalls:
+                dead.add("stall")                      # the stall this note reported is over
         keep = [w for w in ws if _warn_surface(w) not in dead]
         if len(keep) != len(ws):
             if keep:
@@ -9041,7 +9072,7 @@ def _distill_session(fsid, path, now):
             _node_warn_clear(nodes[top], "cite-miss")
             nodes[top]["stalledMt"] = due
             nodes[top]["stallFails"] = 0
-            nodes[top].pop("autoRearmed", None)        # a landed note ends the give-up era (see rearm)
+            _era_clear(nodes[top], "stall-failed")     # a landed note ends its line's give-up era (see rearm)
             _node_warn_clear(nodes[top], "stall-failed")
             _node_warn_clear(nodes[top], "stall-unreadable")
             n += 1; changed = True
@@ -9090,8 +9121,16 @@ def _distill_session(fsid, path, now):
                 # to write one now with the staller's own prompt — grounded in the work, forbidden from
                 # inventing a decision (STALL_BRIEF_SYS), which is what feeding these whys to the BRIEFER
                 # used to do (the 2026-07-21 lesson).
+                # A live brief-failed warn refuses the keep (2026-08-18, review finding): the kept text
+                # under a give-up warn IS the give-up's kept older brief, and the re-arm cleared
+                # briefedMt to force a retry — but _brief_superseded(None) is False by construction, so
+                # this keep restamped the gate shut without ever calling the model: the re-arm's one
+                # retry (and its era) spent on a no-op, the chip permanent. With the warn live, fall
+                # through to a real regeneration; success clears the warn and the keep resumes.
                 if (nodes[top].get("blockSummary") or "").strip() \
-                        and not _brief_superseded(nodes, sub, nodes[top].get("briefedMt")):
+                        and not _brief_superseded(nodes, sub, nodes[top].get("briefedMt")) \
+                        and not any(isinstance(w, dict) and w.get("kind") == "brief-failed"
+                                    for w in nodes[top].get("warns") or []):
                     nodes[top]["briefedMt"] = due; changed = True
                     continue
                 _note = (nodes[top].get("stallSummary") or "").strip()
@@ -9100,6 +9139,7 @@ def _distill_session(fsid, path, now):
                     nodes[top]["briefParts"] = None      # a stall note has no per-item paragraphs
                     nodes[top]["briefedMt"] = due
                     nodes[top]["briefFails"] = 0
+                    _era_clear(nodes[top], "brief-failed")   # a promoted note lands the brief line too
                     _node_warn_clear(nodes[top], "brief-failed")
                     n += 1; changed = True
                     continue
@@ -9166,7 +9206,7 @@ def _distill_session(fsid, path, now):
             _node_warn_clear(nodes[top], "cite-miss")      # anchored either way → any older warn is over
             nodes[top]["briefedMt"] = due
             nodes[top]["briefFails"] = 0                # success → reset the counter (for a future re-open)
-            nodes[top].pop("autoRearmed", None)         # a landed brief ends the give-up era (see rearm)
+            _era_clear(nodes[top], "brief-failed")      # a landed brief ends its line's give-up era (see rearm)
             _node_warn_clear(nodes[top], "brief-failed")   # a brief landed → drop any earlier give-up warn
             _node_warn_clear(nodes[top], "brief-unreadable")   # …and any earlier orphaned-history warn
             n += 1; changed = True
@@ -9229,7 +9269,7 @@ def _distill_session(fsid, path, now):
         _node_warn_clear(nodes[top], "cite-miss")          # anchored either way → any older warn is over
         nodes[top]["distilledMt"] = due
         nodes[top]["distillFails"] = 0                 # success → reset the counter
-        nodes[top].pop("autoRearmed", None)            # a landed summary ends the give-up era (see rearm)
+        _era_clear(nodes[top], "summary-failed")       # a landed summary ends its line's give-up era (see rearm)
         _node_warn_clear(nodes[top], "summary-failed") # a summary landed → drop any earlier give-up warn
         _node_warn_clear(nodes[top], "summary-unreadable")   # …and any earlier orphaned-history warn
         n += 1; changed = True
@@ -9276,19 +9316,49 @@ def judge_failure_scan():
     return {"count": count, "cause": cause, "ratelimited": ratelimited}
 
 
+def _era_spent(nd, kind):
+    """Has this LINE's give-up era already had its one automatic retry? The mark is per warn KIND
+    (2026-08-18, review finding): a node can carry two live give-up warns — e.g. an old stall's plus the
+    completion's — and a node-level bool let the first (possibly dead) line consume the whole node's era,
+    skipping the line the user actually sees. A legacy bool True reads as spent-for-every-line; the next
+    discrete event clears it."""
+    m = nd.get("autoRearmed")
+    return bool(m.get(kind)) if isinstance(m, dict) else bool(m)
+
+
+def _era_mark(nd, kind):
+    m = nd.get("autoRearmed")
+    m = dict(m) if isinstance(m, dict) else ({k: True for k in _FAILED_WARN_KINDS} if m else {})
+    m[kind] = True
+    nd["autoRearmed"] = m
+
+
+def _era_clear(nd, kind):
+    """A landed summary/brief/note ends ITS line's give-up era (the summarizer success paths call this)."""
+    m = nd.get("autoRearmed")
+    if isinstance(m, dict):
+        m.pop(kind, None)
+        if not m:
+            nd.pop("autoRearmed", None)
+    elif m:
+        nd.pop("autoRearmed", None)                    # legacy bool: any success opens the whole node
+
+
 def rearm_failed_summaries(now=None, auto=False):
     """Auto-retry give-up cards on a RECOVERY event — the kernel calls this once at startup, when the
     retry-pause clears, and (auto=True) on the judge-health edge: the first served judge call after a
-    call-level failure (consume_judge_recovery). A genuine transient failure (a 529 storm, a timeout under
-    load, an auth blip) blanks a card to the "" sentinel + a "*-failed" warn and would otherwise stay
-    failed until a manual Try again. Re-arm = put the sentinel back to None so the summarizer re-enters
-    and retries — or, when the give-up KEPT an older real summary (a re-completion's give-up never
-    clobbers prior text), clear the event stamp instead so the gate re-enters with the prior intact. The
-    warn stays until a re-summarize SUCCEEDS (then _node_warn_clear) or FAILS again (re-gives-up,
-    re-warns, visible). Bounded two ways: only nodes with a live give-up warn, and the health edge
-    (auto=True) retries each give-up era at most ONCE (nd["autoRearmed"], dropped on success and by the
-    discrete events) — otherwise a card whose own call is broken would burn DISTILL_FAIL_CAP calls on
-    every edge a healthy neighbor produces. Returns the count re-armed."""
+    call-level failure on that same model (consume_judge_recovery). A genuine transient failure (a 529
+    storm, a timeout under load, an auth blip) blanks a card to the "" sentinel + a "*-failed" warn and
+    would otherwise stay failed until a manual Try again. Re-arm = put the sentinel back to None so the
+    summarizer re-enters and retries — or, when the give-up KEPT an older real summary (a re-completion's
+    give-up never clobbers prior text), clear the event stamp instead so the gate re-enters with the
+    prior intact. The warn stays until a re-summarize SUCCEEDS (then _node_warn_clear) or FAILS again
+    (re-gives-up, re-warns, visible). Bounded two ways: only lines whose summarizer GATE can actually
+    reopen (a summary needs a completed/confirming top, a brief a blocked one, a stall note a live stall
+    — flipping a dead line burns work, and an era, on a surface nothing regenerates), and the health edge
+    (auto=True) retries each line's give-up era at most ONCE (nd["autoRearmed"], per warn kind, dropped
+    on that line's success and by the discrete events) — otherwise a card whose own call is broken would
+    burn DISTILL_FAIL_CAP calls on every edge a healthy neighbor produces. Returns the count re-armed."""
     import glob
     n = 0
     for fp in glob.glob(str(GOALDIR / "*.json")):
@@ -9297,10 +9367,23 @@ def rearm_failed_summaries(now=None, auto=False):
             store = load_goals(fsid)
         except Exception:
             continue
+        status = store.get("status") or {}
+        confirming = set(store.get("confirming") or ())
+        stalls = None                                  # lazy: one stalled_facts read, only if a stall warn shows
         changed = False
         for nid, nd, kind in _failed_nodes(store):
-            if auto and nd.get("autoRearmed"):
-                continue                               # this era already got its one automatic retry
+            if auto and _era_spent(nd, kind):
+                continue                               # this line's era already got its one automatic retry
+            st = status.get(nid)
+            if kind == "summary-failed" and st != "completed" and nid not in confirming:
+                continue                               # the distiller gate needs a (re)completed top
+            if kind == "brief-failed" and st != "blocked":
+                continue                               # the briefer gate needs a blocked top
+            if kind == "stall-failed":
+                if stalls is None:
+                    stalls = stalled_facts(fsid)
+                if st != "working" or nid not in stalls:
+                    continue                           # the staller gate needs the stall still live
             field, stamp = _FAILED_FIELDS[kind]
             if nd.get(field) == "":
                 nd[field] = None                       # "" (gave up) → None (owed): the next pass retries
@@ -9309,7 +9392,7 @@ def rearm_failed_summaries(now=None, auto=False):
             else:
                 continue                               # already owed (None) → nothing to flip
             if auto:
-                nd["autoRearmed"] = True
+                _era_mark(nd, kind)
             else:
                 nd.pop("autoRearmed", None)            # a discrete event (startup/pause-clear) opens a fresh era
             changed = True; n += 1

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19208,9 +19208,27 @@ def _apply_judge_settings(body):
     the ack shows what actually landed, since an invalid value is deliberately ignored. The
     distill pair answers RAW ("triage" = following the triage pick), matching /version: the
     gear shows the user's choice, not its resolution."""
+    _dm_before = jd._distill_model()
     for key, setter in _JUDGE_SETTING_FIELDS:
         if isinstance(body, dict) and key in body:
             setter(str(body.get(key) or ""))
+    if jd._distill_model() != _dm_before:
+        # Switching the distill tier's EFFECTIVE model is a discrete recovery event (the user
+        # 2026-08-18, who pointed the tier away from an outage-scoped model and expected the failed
+        # cards to retry): re-arm every given-up summary/brief/stall line so the next pass retries on
+        # the new model, wake the producer so that pass starts now, and push so the cards trade their
+        # "distill failed" chip for the live "Distilling…" swirl immediately. The effective compare
+        # (jd._distill_model, not the raw field) also catches a triage-model change while the distill
+        # pick is "triage" (follow). Propagated picks land here too on each receiving kernel, so a
+        # switch made on one machine re-arms the whole mesh.
+        try:
+            _n = jd.rearm_failed_summaries(int(time.time()))
+            if _n:
+                sys.stderr.write("distiller: re-armed %d given-up card(s) — distill model changed\n" % _n)
+        except Exception:
+            sys.stderr.write("rearm-on-model-change: %s\n" % traceback.format_exc())
+        _producer_wake.set()
+        _push_all()
     return {"ok": True, "judgeModel": jd._triage_model(), "indexModel": jd._index_model(),
             "judgeEffort": jd._triage_effort(), "indexEffort": jd._index_effort(),
             "distillModel": jd._state_str("distill-model", "triage"),

--- a/tests/test_distill_rearm.py
+++ b/tests/test_distill_rearm.py
@@ -3,13 +3,19 @@
 failures (a 529 overload storm, an auth blip) that never engage the usage-limit retry-pause — so the one
 wired recovery edge never fired and the "distill failed" chip outlived the outage until a manual Try
 again. Under test here:
-  - the judge-call health latch: a "call" failure latches degraded; the first SERVED reply after it is
-    the degraded→serving edge, consumable exactly once (consume_judge_recovery);
-  - rearm_failed_summaries(auto=True), the edge's consumer: one automatic retry per give-up era
-    (nd["autoRearmed"]), while discrete events (startup, retry-pause clear, Try again) open a fresh era;
+  - the judge-call health latch, PER MODEL: a call-level failure latches that model degraded; the first
+    SERVED reply on the SAME model is the degraded→serving edge, consumable exactly once — a healthy
+    model's success is never the failing model's recovery (the Opus-scoped storm, where a Sonnet
+    captioner success fired the old model-blind edge mid-storm);
+  - rearm_failed_summaries(auto=True), the edge's consumer: one automatic retry per give-up era PER
+    LINE (nd["autoRearmed"] keyed by warn kind), gate-aware (a line whose summarizer gate cannot reopen
+    is skipped, not burned), while discrete events (startup, retry-pause clear, a distill-model switch)
+    open a fresh era;
   - a give-up that KEPT an older real summary (a re-completion never blanks prior text) re-arms by
     clearing its event stamp, since the "" flip cannot apply;
-  - "stall-failed" joins the scan/re-arm family (the staller's give-ups were invisible to both).
+  - "stall-failed" joins the scan/re-arm family, and an ENDED stall's warn retires on rollup instead of
+    inflating the fleet failure count forever;
+  - a safeguards refusal (the filter ruling on content) never latches the health edge.
 SYNTHETIC fixtures only (placeholder UUIDs, invented text)."""
 import json
 import os
@@ -33,15 +39,20 @@ NID = SID + ":g1"
 T0 = 1781100000
 
 
-def _warn(kind):
-    return [{"kind": kind, "t": T0, "msg": "synthetic msg", "detail": "synthetic detail"}]
+def _warn(kind, t=T0):
+    return {"kind": kind, "t": t, "msg": "synthetic msg", "detail": "synthetic detail"}
 
 
-def _seed(**nd_extra):
+def _seed(status="completed", warns=None, **nd_extra):
     store = jd.load_goals(SID)
+    store["rompUuid"] = SID
     nd = {"text": "ship the api", "parentId": None, "mt": T0}
+    if warns is not None:
+        nd["warns"] = warns
     nd.update(nd_extra)
     store["nodes"][NID] = jd.GuardedNode(nd)
+    if status:
+        store.setdefault("status", {})[NID] = status
     jd.save_goals(SID, store)
 
 
@@ -49,36 +60,37 @@ def _node():
     return jd.load_goals(SID)["nodes"][NID]
 
 
-def _drain_edge():
+def _drain_health():
     while jd.consume_judge_recovery():
         pass
+    with jd._health_lock:
+        jd._CALL_HEALTH["degraded"] = set()
 
 
 class JudgeCallHealthEdge(unittest.TestCase):
     def setUp(self):
         jd.STATE.mkdir(parents=True, exist_ok=True)
-        _drain_edge()
-        with jd._health_lock:
-            jd._CALL_HEALTH["degraded"] = False
+        _drain_health()
 
-    def test_first_served_reply_after_a_call_failure_is_one_edge(self):
-        jd._log_judge_error("captioner", None, "call", note="error envelope: 'Overloaded'")
+    def test_first_served_reply_on_the_failing_model_is_one_edge(self):
+        jd._mark_call_failed("opus")
         self.assertFalse(jd.consume_judge_recovery(), "a failure alone is not a recovery")
-        jd._mark_call_served()
-        self.assertTrue(jd.consume_judge_recovery(), "first served reply after a failure = the edge")
+        jd._mark_call_served("opus")
+        self.assertTrue(jd.consume_judge_recovery(), "the failing model serving again = the edge")
         self.assertFalse(jd.consume_judge_recovery(), "the edge is consumed exactly once")
 
-    def test_serving_while_healthy_is_not_an_edge(self):
-        jd._mark_call_served()
-        self.assertFalse(jd.consume_judge_recovery(), "no prior failure → nothing recovered")
+    def test_a_healthy_models_success_is_not_the_failing_models_edge(self):
+        # the 2026-08-18 storm: Opus-scoped 529s while Sonnet served — the old model-blind edge fired
+        # on every Sonnet success and spent each card's one automatic retry on a doomed Opus call
+        jd._mark_call_failed("opus")
+        jd._mark_call_served("sonnet")
+        self.assertFalse(jd.consume_judge_recovery(), "another model serving proves nothing about opus")
+        jd._mark_call_served("opus")
+        self.assertTrue(jd.consume_judge_recovery(), "opus itself serving is the real recovery")
 
-    def test_non_call_errors_do_not_latch_degraded(self):
-        # a parse reject / cite-miss is the MODEL's verdict on one prompt, not API sickness — the next
-        # served call must not read as a recovery and re-arm every give-up card in the deployment
-        jd._log_judge_error("planner", None, "parse", note="reply rejected")
-        jd._log_judge_error("distiller", None, "cite-miss", note="no SOURCE line")
-        jd._mark_call_served()
-        self.assertFalse(jd.consume_judge_recovery(), "only call-level failures arm the edge")
+    def test_serving_while_healthy_is_not_an_edge(self):
+        jd._mark_call_served("sonnet")
+        self.assertFalse(jd.consume_judge_recovery(), "no prior failure → nothing recovered")
 
 
 class RearmRecoveryEvents(unittest.TestCase):
@@ -86,13 +98,14 @@ class RearmRecoveryEvents(unittest.TestCase):
         for d in (jd.GOALDIR, jd._overrides_dir()):
             for f in d.glob("*"):
                 f.unlink()
+        (jd.STATE / "auto-nudge.json").unlink(missing_ok=True)
 
     def test_auto_rearm_retries_a_give_up_era_exactly_once(self):
-        _seed(summary="", distillFails=0, warns=_warn("summary-failed"))
+        _seed(summary="", distillFails=0, warns=[_warn("summary-failed")])
         self.assertEqual(jd.rearm_failed_summaries(T0 + 100, auto=True), 1)
         nd = _node()
         self.assertIsNone(nd.get("summary"), '"" (gave up) → None (owed): the next pass retries')
-        self.assertTrue(nd.get("autoRearmed"), "the era's one automatic retry is marked spent")
+        self.assertTrue(jd._era_spent(nd, "summary-failed"), "the line's one automatic retry is spent")
         # the retry re-gives-up (sentinel + warn re-stamped; the mark survives the give-up write)
         st = jd.load_goals(SID)
         st["nodes"][NID]["summary"] = ""
@@ -102,9 +115,9 @@ class RearmRecoveryEvents(unittest.TestCase):
                          "card whose own call is broken — one automatic retry per era")
 
     def test_a_discrete_event_rearms_and_opens_a_fresh_era(self):
-        _seed(summary="", warns=_warn("summary-failed"), autoRearmed=True)
+        _seed(summary="", warns=[_warn("summary-failed")], autoRearmed=True)   # legacy bool mark
         self.assertEqual(jd.rearm_failed_summaries(T0 + 300), 1,
-                         "startup / retry-pause clear re-arm regardless of the era mark")
+                         "startup / retry-pause clear / model switch re-arm regardless of the era mark")
         nd = _node()
         self.assertIsNone(nd.get("summary"))
         self.assertNotIn("autoRearmed", nd, "a discrete event opens a fresh era for the health edge")
@@ -112,23 +125,77 @@ class RearmRecoveryEvents(unittest.TestCase):
     def test_rearm_reenters_a_giveup_that_kept_an_older_summary(self):
         # a re-completion's give-up never blanks prior text — so there is no "" to flip; the stamp
         # clears instead and the gate re-enters with the prior summary intact
-        _seed(summary="Old takeaway.", distilledMt=T0, warns=_warn("summary-failed"))
+        _seed(summary="Old takeaway.", distilledMt=T0, warns=[_warn("summary-failed")])
         self.assertEqual(jd.rearm_failed_summaries(T0 + 100), 1)
         nd = _node()
         self.assertEqual(nd.get("summary"), "Old takeaway.", "the prior text is never clobbered")
         self.assertIsNone(nd.get("distilledMt"), "the cleared stamp is what re-enters the distiller")
 
     def test_an_already_owed_line_is_not_recounted(self):
-        _seed(summary=None, warns=_warn("summary-failed"))
+        _seed(summary=None, warns=[_warn("summary-failed")])
         self.assertEqual(jd.rearm_failed_summaries(T0 + 100), 0,
                          "None is already owed — nothing to flip, nothing to count")
 
-    def test_stall_failed_joins_the_scan_and_the_rearm(self):
-        _seed(stallSummary="", warns=_warn("stall-failed"))
+    def test_a_line_whose_gate_is_closed_is_skipped_not_burned(self):
+        # summary gate needs a completed/confirming top: re-arming a working card's summary line would
+        # flip a field nothing regenerates AND spend its era (the review's dead-surface finding)
+        _seed(status="working", summary="", warns=[_warn("summary-failed")])
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 100, auto=True), 0)
+        nd = _node()
+        self.assertEqual(nd.get("summary"), "", "no flip on a closed gate")
+        self.assertFalse(jd._era_spent(nd, "summary-failed"), "and no era spent on it either")
+
+    def test_two_warn_card_retries_the_live_line_not_the_dead_one(self):
+        # the review's two-warn finding: an old stall's warn (no live stall → gate closed) must not
+        # consume the retry that the completed card's summary line — the one the user sees — needs
+        _seed(status="completed", summary="", stallSummary="",
+              warns=[_warn("stall-failed", T0), _warn("summary-failed", T0 + 50)])
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 100, auto=True), 1)
+        nd = _node()
+        self.assertEqual(nd.get("stallSummary"), "", "the dead stall line is left alone")
+        self.assertIsNone(nd.get("summary"), "the live summary line gets the retry")
+        self.assertTrue(jd._era_spent(nd, "summary-failed"))
+        self.assertFalse(jd._era_spent(nd, "stall-failed"), "eras are per line, not per node")
+
+    def test_stall_failed_rearms_only_while_the_stall_is_live(self):
+        _seed(status="working", stallSummary="", warns=[_warn("stall-failed")])
         scan = jd.judge_failure_scan()
         self.assertEqual(scan["count"], 1, "a given-up stall note counts toward the banner")
-        self.assertEqual(jd.rearm_failed_summaries(T0 + 100), 1)
-        self.assertIsNone(_node().get("stallSummary"), "the stall note re-arms like the other lines")
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 100), 0, "no live stall → nothing to retry")
+        jd.STATE.mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "auto-nudge.json").write_text(json.dumps(
+            {"deferred": {NID: {"why": "reviver-hold", "at": T0}}}))
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 200), 1)
+        self.assertIsNone(_node().get("stallSummary"), "a live stall's note re-arms like the other lines")
+
+
+class StallWarnRetires(unittest.TestCase):
+    """An ENDED stall's give-up warn retires on rollup (the review finding: once stall-failed joined the
+    fleet scan, an un-stalled card's warn had no clear path and inflated the top banner forever)."""
+
+    def tearDown(self):
+        for f in jd.GOALDIR.glob("*"):
+            f.unlink()
+        (jd.STATE / "auto-nudge.json").unlink(missing_ok=True)
+
+    def test_an_ended_stalls_warn_retires_on_rollup(self):
+        _seed(status="working", stallSummary="", warns=[_warn("stall-failed")])
+        store = jd.load_goals(SID)
+        jd.rollup_status(store, False)                 # no live stall record → the stall is over
+        self.assertFalse(any(w.get("kind") == "stall-failed"
+                             for w in (store["nodes"][NID].get("warns") or [])),
+                         "the warn retires with the surface — the banner count can reach zero again")
+
+    def test_a_live_stalls_warn_survives_rollup(self):
+        jd.STATE.mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "auto-nudge.json").write_text(json.dumps(
+            {"deferred": {NID: {"why": "reviver-hold", "at": T0}}}))
+        _seed(status="working", stallSummary="", warns=[_warn("stall-failed")])
+        store = jd.load_goals(SID)
+        jd.rollup_status(store, False)
+        self.assertTrue(any(w.get("kind") == "stall-failed"
+                            for w in (store["nodes"][NID].get("warns") or [])),
+                        "a live stall keeps its warn — the failure is still current")
 
 
 class GiveUpWarnNamesTheError(unittest.TestCase):
@@ -141,6 +208,10 @@ class GiveUpWarnNamesTheError(unittest.TestCase):
         (jd.STATE / "usage.json").write_text(json.dumps(
             {"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
         jd._judge_ctx.last_call_fail = None
+        while jd.consume_judge_recovery():
+            pass
+        with jd._health_lock:
+            jd._CALL_HEALTH["degraded"] = set()
 
     def _run_fake(self, envelope, model="opus"):
         def fake_run(cmd, input=None, capture_output=None, text=None, cwd=None, env=None, timeout=None):
@@ -158,6 +229,22 @@ class GiveUpWarnNamesTheError(unittest.TestCase):
         st = jd._judge_ctx.last_call_fail
         self.assertIn("529 Overloaded", st["note"])
         self.assertEqual(st["model"], "opus")
+
+    def test_an_error_envelope_latches_the_models_health(self):
+        self._run_fake({"is_error": True, "result": "API Error: Repeated 529 Overloaded errors."})
+        jd._mark_call_served("opus")
+        self.assertTrue(jd.consume_judge_recovery(), "the envelope failure latched opus degraded")
+
+    def test_a_safeguards_refusal_never_latches_the_health_edge(self):
+        # the filter ruling on one call's CONTENT — deterministic per prompt, not model health; latching
+        # it would flap the edge on every flag/success interleave (the closer storm, 2,955 flags)
+        self._run_fake({"is_error": True,
+                        "result": "API Error: the model's safeguards flagged this message."},
+                       model="fable")
+        st = jd._judge_ctx.last_call_fail
+        self.assertIn("safeguards", st["note"], "the evidence still reaches the warn")
+        jd._mark_call_served("fable")
+        self.assertFalse(jd.consume_judge_recovery(), "a content refusal is not API degradation")
 
     def test_a_served_reply_retires_the_stash(self):
         self._run_fake({"is_error": True, "result": "API Error: Repeated 529 Overloaded errors."})
@@ -182,8 +269,8 @@ class GiveUpWarnNamesTheError(unittest.TestCase):
 
 
 class KernelRearmWiring(unittest.TestCase):
-    """Source pins on the kernel's two recovery-event call sites (the RedistillOpWiring precedent —
-    the wiring is a few lines inside 400-line functions no unit test can enter cheaply)."""
+    """Source pins on the kernel's recovery-event call sites (the RedistillOpWiring precedent —
+    the wiring is a few lines inside functions no unit test can enter cheaply)."""
 
     @classmethod
     def setUpClass(cls):
@@ -207,6 +294,17 @@ class KernelRearmWiring(unittest.TestCase):
         seg = src[i_edge:]
         self.assertIn("rearm_failed_summaries", seg[:400], "the consumed edge drives the auto re-arm")
         self.assertIn("auto=True", seg[:400], "the health edge is the era-bounded auto path")
+
+    def test_a_distill_model_switch_rearms_wakes_and_pushes(self):
+        # the user 2026-08-18: switching the distill model away from an outage-scoped one must itself
+        # retry everything that failed — and show it on the board immediately
+        import inspect
+        src = inspect.getsource(self.km._apply_judge_settings)
+        self.assertIn("jd._distill_model()", src,
+                      "the EFFECTIVE model is compared — a triage change while following counts too")
+        self.assertIn("rearm_failed_summaries", src, "the switch is a discrete recovery event")
+        self.assertIn("_producer_wake.set()", src, "the retry pass starts now, not at the next tick")
+        self.assertIn("_push_all()", src, "the swirl replaces the chip immediately")
 
 
 if __name__ == "__main__":

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -4636,6 +4636,21 @@ class ProceduralBlockStillSpeaks(unittest.TestCase):
         self.assertEqual(calls["stall"], [])
         self.assertEqual(calls["brief"], [])
 
+    def test_a_kept_brief_under_a_live_giveup_warn_regenerates_instead_of_keeping(self):
+        # the review's never-retries finding (2026-08-18): a proc-only give-up KEPT an older brief and
+        # stamped brief-failed; the recovery re-arm then cleared briefedMt to force a retry — but the
+        # keep short-circuit (_brief_superseded(None) is False by construction) restamped the gate shut
+        # without any model call, burning the re-arm (and its era) on a no-op forever. A live
+        # brief-failed warn refuses the keep, so the re-arm's retry actually runs and clears the warn.
+        calls, node = self._run(node_extra={
+            "blockSummary": "the give-up's kept older brief", "briefedMt": None,
+            "warns": [{"kind": "brief-failed", "t": T0 + 30, "msg": "synthetic msg",
+                       "detail": "synthetic detail"}]})
+        self.assertEqual(node["blockSummary"], "stall take.",
+                         "regenerated through the staller's prompt, not kept")
+        self.assertFalse(any(w.get("kind") == "brief-failed" for w in node.get("warns") or []),
+                         "the landed note clears the give-up warn")
+
     def test_a_fresh_real_block_reopens_a_settled_blank(self):
         # the launch-prep shape: a procedural block settled the brief to "" (that episode had nothing to
         # say), then a REAL decision landed later in the subtree — "" must not keep muting the card
@@ -5503,6 +5518,25 @@ class Distiller(unittest.TestCase):
         self.assertEqual(nd.get("blockSummary"), "Decide A or B.")
         self.assertFalse(any(w.get("kind") == "brief-failed" for w in nd.get("warns") or []),
                          "a landed brief drops the give-up warn")
+
+    def test_a_landed_brief_ends_its_lines_giveup_era(self):
+        # the mutation-test gap from the review (2026-08-18): with the success-path era pops deleted,
+        # the whole suite still passed — so pin them through the REAL path: an auto-re-armed line whose
+        # retry succeeds must drop its era mark, or the health edge is one-per-lifetime per card
+        gid, now = self._blocked_goal()
+        jd.brief_llm = lambda g, w, ow="": ""
+        for _ in range(jd.DISTILL_FAIL_CAP):
+            jd.run_distill(now=now)
+        st = jd.load_goals(SID)                          # the health edge re-armed it (as rearm would):
+        st["nodes"][gid]["blockSummary"] = None          # line owed again, era spent
+        st["nodes"][gid]["autoRearmed"] = {"brief-failed": True}
+        jd.save_goals(SID, st)
+        jd.brief_llm = lambda g, w, ow="": "Decide A or B."
+        jd.run_distill(now=now)
+        nd = jd.load_goals(SID)["nodes"][gid]
+        self.assertEqual(nd.get("blockSummary"), "Decide A or B.")
+        self.assertNotIn("autoRearmed", nd,
+                         "the landed brief pops its line's era mark — the next give-up era can auto-retry")
 
     def test_scan_counts_failures_and_rearm_reopens_only_warned_cards(self):
         gid, now = self._blocked_goal()

--- a/tests/test_kernel_redistill.py
+++ b/tests/test_kernel_redistill.py
@@ -51,7 +51,28 @@ class RedistillOverrideReplay(unittest.TestCase):
         nd = jd.load_goals(SID).get("nodes", {}).get(NID)
         self.assertIsNone(nd.get("summary"), '"" (gave up) → None (owed): the next pass re-runs the distiller')
         self.assertIsNone(nd.get("blockSummary"), "the blocked line re-arms the same way")
-        self.assertEqual(nd.get("distillFails"), 0, "the consecutive-fail counter starts over")
+        self.assertEqual(nd.get("distillFails"), 2,
+                         "the fail counter SURVIVES replay (2026-08-18): the journal replays on every "
+                         "load, so a per-load reset made DISTILL_FAIL_CAP unreachable — fails ping-ponged "
+                         "0↔1 forever, one doomed model call per pass from a single click; a real click "
+                         "only exists post-give-up anyway, where the give-up write already zeroed it")
+
+    def test_a_later_giveup_supersedes_the_click(self):
+        # the stand-down rule at the replay: the retry the click asked for ran and GAVE UP again — the
+        # re-stamped warn (newer than the click) is the judges ruling on a newer world, so the historical
+        # click must stop re-arming the card on every load (the eternal-click review finding)
+        _seed_store(summary="", fails=0)
+        jd.append_override(SID, NID, "redistill", 1781100100)
+        nd = jd.load_goals(SID)["nodes"][NID]            # the click answers THIS give-up: applies
+        self.assertIsNone(nd.get("summary"))
+        st = jd.load_goals(SID)                          # the retry re-gives-up: sentinel + NEWER warn
+        st["nodes"][NID]["summary"] = ""
+        st["nodes"][NID]["warns"] = [{"kind": "summary-failed", "t": 1781100200,
+                                      "msg": "synthetic msg", "detail": "synthetic detail"}]
+        jd.save_goals(SID, st)
+        nd = jd.load_goals(SID)["nodes"][NID]            # journal replays again on this load
+        self.assertEqual(nd.get("summary"), "",
+                         "a give-up stamped AFTER the click supersedes it — the click stands down")
 
     def test_replay_never_clobbers_a_line_that_succeeded_since(self):
         _seed_store(summary="", fails=0)
@@ -76,8 +97,10 @@ class RedistillOverrideReplay(unittest.TestCase):
 class RedistillReplayRecoveryExtensions(unittest.TestCase):
     """Try again reaches the give-ups the "" flip can't (2026-08-18): a give-up that KEPT an older real
     summary (a re-completion never blanks prior text) re-arms by clearing its event stamp — gated on the
-    live "*-failed" warn, so replays past a success stay no-ops; the stall line joins the family; and a
-    manual retry drops the era mark so the health-edge auto-rearm starts fresh."""
+    live "*-failed" warn, so replays past a success stay no-ops; and the stall line joins the family.
+    The replay deliberately leaves nd["autoRearmed"] ALONE: the journal replays on every load forever,
+    so a historical click erasing the era mark would defeat the one-auto-retry bound for good — the mark
+    clears only on that line's landed summary or a discrete recovery event."""
 
     def tearDown(self):
         for d in (jd.GOALDIR, jd._overrides_dir()):
@@ -116,7 +139,7 @@ class RedistillReplayRecoveryExtensions(unittest.TestCase):
         jd.append_override(SID, NID, "redistill", 1781100100)
         nd = jd.load_goals(SID)["nodes"][NID]
         self.assertIsNone(nd.get("stallSummary"), "the stall line re-arms like summary/blockSummary")
-        self.assertEqual(nd.get("stallFails"), 0, "the consecutive-fail counter starts over")
+        self.assertEqual(nd.get("stallFails"), 2, "the fail counter survives replay (see the flip test)")
         self.assertTrue(nd.get("autoRearmed"),
                         "the era mark SURVIVES replay: the journal replays on every load forever, so a "
                         "historical click erasing it would defeat the one-auto-retry bound for good — "


### PR DESCRIPTION
## Why

Two sources: the adversarial review of the re-arm mechanism confirmed 13 findings (two high), and the user hit one gap directly — switching the distill model away from the outage-scoped one did NOT retrigger the failed cards.

## What

- **Per-model health edge.** A call failure latches *that model* degraded; only that model serving again fires the edge. During today's Opus-scoped storm, Sonnet successes fired the model-blind edge and spent each card's one automatic retry on a doomed Opus call. Safeguards refusals (content-deterministic, not health — 2,955 closer flags today) never latch it.
- **Model switch = recovery event.** `_apply_judge_settings` compares the *effective* distill model; on change it re-arms every given-up line, wakes the producer, and pushes — the "Distilling…" swirl replaces the chip immediately, on every kernel the pick propagates to.
- **Per-line, gate-aware eras.** `autoRearmed` is keyed by warn kind, and lines whose summarizer gate cannot reopen are skipped, not burned (the dead-stall-warn-eats-the-node's-era finding).
- **Try-again replay stands down** when a give-up postdates the click, and no longer resets fail counters — the journal replays on every load, so the unconditional reset made `DISTILL_FAIL_CAP` unreachable: one doomed call per pass, forever, from a single click.
- **Proc-only kept brief** under a live `brief-failed` warn regenerates instead of restamping the gate shut without a model call (`_brief_superseded(None)` is False by construction).
- **Ended stalls retire their warns** on rollup — otherwise `stall-failed` in the fleet scan inflated the banner count permanently.

## Tests

15 new/updated across `tests/test_distill_rearm.py`, `tests/test_kernel_redistill.py`, `tests/test_judge.py` — including the review's mutation-test gap (era pops driven through `run_distill`). Full Python suite 4853 passed; UI suite 2069 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)