### PR TITLE
The chips and banner say WHICH model is failing, show every attempt, and suggest the fix

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -571,23 +571,39 @@ def _mid_elide(s, cap=6200):
 # and records the edge (_mark_call_served); the kernel consumes the edge between passes — its
 # single-writer window — and re-arms the give-up cards once per era (rearm_failed_summaries auto=True).
 # Process-global on purpose: every judge thread shares one API.
-_CALL_HEALTH = {"degraded": set(), "recovered": False}
+_CALL_HEALTH = {"degraded": set(), "recovered": False, "stats": {}}
 _health_lock = threading.Lock()
 
 
-def _mark_call_failed(model):
+def _mark_call_failed(model, note=""):
     """A judge call failed at the call level (subprocess error, timeout, error envelope, dead CLI) —
-    latch this model degraded; its next served reply is the recovery edge."""
+    latch this model degraded and bump its consecutive-fail count; its next served reply is the
+    recovery edge. The count + last error feed _giveup_cause's model-scoped diagnosis (the user
+    2026-08-18: when one model is down while the others serve, the banner and the chips must SAY so
+    and suggest the fix)."""
     with _health_lock:
         _CALL_HEALTH["degraded"].add(model)
+        s = _CALL_HEALTH["stats"].setdefault(model, {"fails": 0, "last": ""})
+        s["fails"] += 1
+        if note:
+            s["last"] = str(note)[:160]
 
 
 def _mark_call_served(model):
     """A judge call came back with a real reply — if THIS model had been failing, record the edge."""
     with _health_lock:
+        _CALL_HEALTH["stats"].pop(model, None)
         if model in _CALL_HEALTH["degraded"]:
             _CALL_HEALTH["degraded"].discard(model)
             _CALL_HEALTH["recovered"] = True
+
+
+def _sick_models():
+    """{model: {fails, last}} for every model whose CONSECUTIVE call-failure count has reached the
+    give-up cap — a deterministic count, reset by that model's next served reply, never a clock."""
+    with _health_lock:
+        return {m: dict(s) for m, s in _CALL_HEALTH["stats"].items()
+                if (s.get("fails") or 0) >= DISTILL_FAIL_CAP}
 
 
 def consume_judge_recovery():
@@ -984,7 +1000,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             # so callers never double-log: to a caller every failed call is just "", and "call" rows always
             # carry the judge's own name + fsid (pre-07-09 rows said "index"/"triage" with no session).
             _judge_ctx.last_call_fail = {"note": type(e).__name__, "model": model}
-            _mark_call_failed(model)
+            _mark_call_failed(model, type(e).__name__)
             _log_judge_error(judge or tier, fsid, "call", note=type(e).__name__)
             return ""
         recv = time.time()                            # literal wall-clock: the response is back
@@ -1006,7 +1022,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
                     # per prompt, not model health (the 2026-08-18 closer storm: 2,955 flags on research
                     # transcripts while the same model served every other call). Latching it would flap
                     # the degraded→serving edge on every flag/success interleave.
-                    _mark_call_failed(model)
+                    _mark_call_failed(model, msg[:160])
                 _log_judge_error(judge or tier, fsid, "call",
                                  note="error envelope: %r" % msg[:160])
                 if _is_auth_error(msg):
@@ -1033,7 +1049,7 @@ def _judge_run(model, sys_prompt, user, effort=None, judge=None, tier="triage", 
             _judge_ctx.last_call_fail = {
                 "note": "the model CLI died with no output (exit %s)" % getattr(p, "returncode", "?"),
                 "model": model}
-            _mark_call_failed(model)
+            _mark_call_failed(model, _judge_ctx.last_call_fail["note"])
             _log_judge_error(judge or tier, fsid, "call",
                              note="empty stdout (exit %s): %s"
                                   % (getattr(p, "returncode", "?"),
@@ -2693,6 +2709,30 @@ def _node_warn_clear(nd, kind):
         nd.pop("warns", None)
 
 
+def _fail_log(nd, line, now):
+    """Append this failed summarizer attempt — WHEN, which LINE, which MODEL, the literal ERROR — to the
+    card's attempt log (the user 2026-08-18: "tried opus — 529 Overloaded, tried opus — 529 …" on the
+    chip beats prose; seeing the same model fail thrice is what tells them to switch it). The evidence is
+    _judge_run's per-thread stash, read here in the same thread right after the failed call. Capped so a
+    store never grows unbounded; that line's next SUCCESS clears its rows (_fail_log_clear)."""
+    last = getattr(_judge_ctx, "last_call_fail", None)
+    if not isinstance(last, dict) or not last.get("note"):
+        return
+    log = [e for e in nd.get("failLog") or [] if isinstance(e, dict)]
+    log.append({"t": int(now), "line": line, "model": last.get("model") or "?",
+                "note": str(last["note"])[:160]})
+    nd["failLog"] = log[-8:]
+
+
+def _fail_log_clear(nd, line):
+    """A summarizer line landed — its attempt history is over; other lines' rows stay."""
+    log = [e for e in nd.get("failLog") or [] if isinstance(e, dict) and e.get("line") != line]
+    if log:
+        nd["failLog"] = log
+    else:
+        nd.pop("failLog", None)
+
+
 def _warn_surface(w):
     """Which card surface a warn annotates: "brief" (the blocked card's decision brief), "summary"
     (the completed card's takeaway), "stall" (the stalled card's stall note), or None (not
@@ -2739,6 +2779,18 @@ def _giveup_cause():
         pass
     if names:
         return ("the account's %s usage limit is maxed out" % " and ".join(names), True)
+    sick = _sick_models()
+    if sick:
+        # MODEL-SCOPED diagnosis (the user 2026-08-18): during the Opus-only 529 storm every give-up
+        # said "errors or timeouts" while every other tier served — the one fact that mattered (WHICH
+        # model, and that switching it would fix everything) was invisible. The count is deterministic:
+        # consecutive call failures per model, reset by that model's next served reply.
+        m = max(sick, key=lambda k: sick[k].get("fails") or 0)
+        cause = "calls on the %s model keep failing — %d in a row, most recently: %s" % (
+            m, sick[m].get("fails") or 0, (sick[m].get("last") or "an error with no message")[:120])
+        if m == _distill_model():
+            cause += ". Switching the distill model in settings retries everything that failed, immediately"
+        return (cause, False)
     return ("the summarizer kept hitting errors or timeouts", False)
 
 
@@ -9049,6 +9101,7 @@ def _distill_session(fsid, path, now):
                 if getattr(_judge_ctx, "paused", False):   # pause-skip, not a real failure (see the briefer)
                     continue
                 fails = nodes[top].get("stallFails", 0) + 1
+                _fail_log(nodes[top], "stall", now)    # the chip's attempt history: model + literal error
                 if fails >= DISTILL_FAIL_CAP:
                     if nodes[top].get("stallSummary") is None:
                         nodes[top]["stallSummary"] = ""
@@ -9073,6 +9126,7 @@ def _distill_session(fsid, path, now):
             nodes[top]["stalledMt"] = due
             nodes[top]["stallFails"] = 0
             _era_clear(nodes[top], "stall-failed")     # a landed note ends its line's give-up era (see rearm)
+            _fail_log_clear(nodes[top], "stall")
             _node_warn_clear(nodes[top], "stall-failed")
             _node_warn_clear(nodes[top], "stall-unreadable")
             n += 1; changed = True
@@ -9171,6 +9225,7 @@ def _distill_session(fsid, path, now):
                     # the "" sentinel though the API was never actually asked (the user 2026-07-03). Leave
                     # blockSummary null → re-enters next pass; retry once the pause clears.
                 fails = nodes[top].get("briefFails", 0) + 1   # the failed call itself was logged by _judge_run
+                _fail_log(nodes[top], "brief", now)    # the chip's attempt history: model + literal error
                 if fails >= DISTILL_FAIL_CAP:          # gave up after K tries → SELF-HEAL: settle to the ""
                     if nodes[top].get("blockSummary") is None:   # sentinel so the card stops showing
                         nodes[top]["blockSummary"] = ""          # "(generating…)" forever (the user 2026-06-24)
@@ -9207,6 +9262,7 @@ def _distill_session(fsid, path, now):
             nodes[top]["briefedMt"] = due
             nodes[top]["briefFails"] = 0                # success → reset the counter (for a future re-open)
             _era_clear(nodes[top], "brief-failed")      # a landed brief ends its line's give-up era (see rearm)
+            _fail_log_clear(nodes[top], "brief")
             _node_warn_clear(nodes[top], "brief-failed")   # a brief landed → drop any earlier give-up warn
             _node_warn_clear(nodes[top], "brief-unreadable")   # …and any earlier orphaned-history warn
             n += 1; changed = True
@@ -9240,6 +9296,7 @@ def _distill_session(fsid, path, now):
             if getattr(_judge_ctx, "paused", False):   # pause-skip, not a real failure — don't count it toward
                 continue                               # give-up (leave summary null → re-enters once unpaused)
             fails = nodes[top].get("distillFails", 0) + 1   # the failed call itself was logged by _judge_run
+            _fail_log(nodes[top], "summary", now)      # the chip's attempt history: model + literal error
             if fails >= DISTILL_FAIL_CAP:              # gave up after K tries → SELF-HEAL to the "" sentinel
                 if nodes[top].get("summary") is None:  # so the card stops showing "(generating…)" forever
                     nodes[top]["summary"] = ""
@@ -9270,6 +9327,7 @@ def _distill_session(fsid, path, now):
         nodes[top]["distilledMt"] = due
         nodes[top]["distillFails"] = 0                 # success → reset the counter
         _era_clear(nodes[top], "summary-failed")       # a landed summary ends its line's give-up era (see rearm)
+        _fail_log_clear(nodes[top], "summary")
         _node_warn_clear(nodes[top], "summary-failed") # a summary landed → drop any earlier give-up warn
         _node_warn_clear(nodes[top], "summary-unreadable")   # …and any earlier orphaned-history warn
         n += 1; changed = True

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16776,6 +16776,7 @@ def build_feed(now, tmux=None):
                 "background": nodes[nid].get("background"),    # the distiller's BACKGROUND section: re-orientation for a reader who forgot the thread — collapsed by default on the card (the user 2026-07-02)
                 "summaryAnchorUuid": _sa_u,    # click the summary line → the completion turn's wrap-up (completed pin), else the cited/latest prose (the user 2026-07-14)
                 "warns": nodes[nid].get("warns") or None,   # judge-stamped anomalies (judge _node_warn) → yellow "warning" chip; click shows each warn's what/why detail (the user 2026-07-02)
+                "failLog": nodes[nid].get("failLog") or None,   # the summarizer's failed attempts (judge _fail_log): model + literal error per try → the chip's hover history + modal "What was tried" (the user 2026-08-18)
                 "nudged": ({"count": int(nrec.get("count", 0)), "times": _nudge_times().get(nid, [])[-8:]}
                            if nrec.get("count") else None),   # auto-nudge HISTORY (fires + when) → the stalled chip's evidence, on the chip tooltip + modal (the user 2026-07-02)
                 "blocked": ({"state": "apiError",

--- a/tests/test_distill_rearm.py
+++ b/tests/test_distill_rearm.py
@@ -65,6 +65,7 @@ def _drain_health():
         pass
     with jd._health_lock:
         jd._CALL_HEALTH["degraded"] = set()
+        jd._CALL_HEALTH["stats"] = {}
 
 
 class JudgeCallHealthEdge(unittest.TestCase):
@@ -208,10 +209,7 @@ class GiveUpWarnNamesTheError(unittest.TestCase):
         (jd.STATE / "usage.json").write_text(json.dumps(
             {"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
         jd._judge_ctx.last_call_fail = None
-        while jd.consume_judge_recovery():
-            pass
-        with jd._health_lock:
-            jd._CALL_HEALTH["degraded"] = set()
+        _drain_health()
 
     def _run_fake(self, envelope, model="opus"):
         def fake_run(cmd, input=None, capture_output=None, text=None, cwd=None, env=None, timeout=None):
@@ -266,6 +264,88 @@ class GiveUpWarnNamesTheError(unittest.TestCase):
         nd = {}
         jd._warn_summary_failed(nd, "distiller", T0)
         self.assertNotIn("last attempt failed", nd["warns"][0]["detail"])
+
+
+class ModelHealthDiagnosis(unittest.TestCase):
+    """_giveup_cause names the failing MODEL once its consecutive call failures reach the give-up cap —
+    a deterministic count, reset by that model's next served reply — and suggests the settings switch
+    when the sick model is the distill tier's (the user 2026-08-18: the banner and the chips must say
+    WHICH model is down and what to do about it)."""
+
+    def setUp(self):
+        jd.STATE.mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "usage.json").write_text(json.dumps(
+            {"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        _drain_health()
+
+    def tearDown(self):
+        _drain_health()
+        (jd.STATE / "distill-model").unlink(missing_ok=True)
+
+    def test_a_sick_model_is_named_with_its_last_error(self):
+        for _ in range(jd.DISTILL_FAIL_CAP):
+            jd._mark_call_failed("opus", "API Error: Repeated 529 Overloaded errors.")
+        cause, ratelimited = jd._giveup_cause()
+        self.assertFalse(ratelimited)
+        self.assertIn("opus", cause, "the failing model is named")
+        self.assertIn("529 Overloaded", cause, "with its literal last error")
+
+    def test_the_distill_tiers_own_model_earns_the_switch_suggestion(self):
+        (jd.STATE / "distill-model").write_text("opus")
+        for _ in range(jd.DISTILL_FAIL_CAP):
+            jd._mark_call_failed("opus", "API Error: Repeated 529 Overloaded errors.")
+        cause, _ = jd._giveup_cause()
+        self.assertIn("Switching the distill model", cause,
+                      "the give-ups ARE this model's — the fix is one settings click, so say so")
+
+    def test_below_the_cap_stays_generic(self):
+        jd._mark_call_failed("opus", "API Error: Repeated 529 Overloaded errors.")
+        cause, _ = jd._giveup_cause()
+        self.assertIn("errors or timeouts", cause, "one blip is not a diagnosis")
+
+    def test_a_served_reply_resets_the_diagnosis(self):
+        for _ in range(jd.DISTILL_FAIL_CAP):
+            jd._mark_call_failed("opus", "API Error: Repeated 529 Overloaded errors.")
+        jd._mark_call_served("opus")
+        cause, _ = jd._giveup_cause()
+        self.assertIn("errors or timeouts", cause, "the model recovered — no stale blame")
+
+
+class AttemptLog(unittest.TestCase):
+    """The card's per-line attempt log (judge _fail_log): each failed summarizer try as when + model +
+    literal error, capped, cleared by that line's next success — the chip's hover history and the
+    modal's "What was tried" (the user 2026-08-18)."""
+
+    def tearDown(self):
+        jd._judge_ctx.last_call_fail = None
+
+    def test_appends_from_the_stash_and_caps(self):
+        nd = {}
+        jd._judge_ctx.last_call_fail = {"note": "API Error: Repeated 529 Overloaded errors.",
+                                        "model": "opus"}
+        for i in range(10):
+            jd._fail_log(nd, "summary", T0 + i)
+        self.assertEqual(len(nd["failLog"]), 8, "capped so a store never grows unbounded")
+        self.assertEqual(nd["failLog"][-1]["model"], "opus")
+        self.assertEqual(nd["failLog"][-1]["t"], T0 + 9)
+        self.assertIn("529 Overloaded", nd["failLog"][-1]["note"])
+
+    def test_clear_is_per_line(self):
+        nd = {}
+        jd._judge_ctx.last_call_fail = {"note": "boom", "model": "opus"}
+        jd._fail_log(nd, "summary", T0)
+        jd._fail_log(nd, "brief", T0 + 1)
+        jd._fail_log_clear(nd, "summary")
+        self.assertEqual([e["line"] for e in nd["failLog"]], ["brief"],
+                         "the landed line's rows drop; the other line's history stays")
+        jd._fail_log_clear(nd, "brief")
+        self.assertNotIn("failLog", nd)
+
+    def test_no_stashed_evidence_no_row(self):
+        nd = {}
+        jd._judge_ctx.last_call_fail = None
+        jd._fail_log(nd, "summary", T0)
+        self.assertNotIn("failLog", nd)
 
 
 class KernelRearmWiring(unittest.TestCase):

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -5519,6 +5519,24 @@ class Distiller(unittest.TestCase):
         self.assertFalse(any(w.get("kind") == "brief-failed" for w in nd.get("warns") or []),
                          "a landed brief drops the give-up warn")
 
+    def test_failed_attempts_reach_the_cards_attempt_log(self):
+        # the chip's hover/modal history (the user 2026-08-18): every failed try lands as when + model +
+        # literal error, and the line's eventual success clears its rows
+        gid, now = self._blocked_goal()
+        jd.brief_llm = lambda g, w, ow="": (setattr(jd._judge_ctx, "last_call_fail",
+            {"note": "API Error: Repeated 529 Overloaded errors.", "model": "opus"}), "")[1]
+        for _ in range(jd.DISTILL_FAIL_CAP):
+            jd.run_distill(now=now)
+        log = jd.load_goals(SID)["nodes"][gid].get("failLog") or []
+        self.assertEqual(len(log), jd.DISTILL_FAIL_CAP, "one row per failed attempt")
+        self.assertTrue(all(e["model"] == "opus" and "529" in e["note"] and e["line"] == "brief"
+                            for e in log), "each row carries the model and the literal error")
+        st = jd.load_goals(SID); st["nodes"][gid]["blockSummary"] = None; jd.save_goals(SID, st)
+        jd.brief_llm = lambda g, w, ow="": (setattr(jd._judge_ctx, "last_call_fail", None), "Decide A or B.")[1]
+        jd.run_distill(now=now)
+        self.assertNotIn("failLog", jd.load_goals(SID)["nodes"][gid],
+                         "the landed brief clears its line's attempt history")
+
     def test_a_landed_brief_ends_its_lines_giveup_era(self):
         # the mutation-test gap from the review (2026-08-18): with the success-path era pops deleted,
         # the whole suite still passed — so pin them through the REAL path: an auto-re-armed line whose

--- a/ui/webview/feed-warn-chip.test.ts
+++ b/ui/webview/feed-warn-chip.test.ts
@@ -30,11 +30,24 @@ test("the click reads the card's CURRENT warns and opens the detail overlay (cli
 
 test("updateAskCard toggles the chip on it.warns and refreshes the data it reads", () => {
   assert.match(FEED, /a\._warnsData = it\.warns \|\| null;/);
+  assert.match(FEED, /a\._failLog = it\.failLog \|\| null;/);
   assert.match(FEED, /a\._warnChip\.style\.display = "";/);
   assert.match(FEED, /a\._warnChip\.textContent = it\.warns\.length > 1 \? `\$\{lbl\} ×\$\{it\.warns\.length\}` : lbl;/,
     "multiple live warns show a count");
-  assert.match(FEED, /it\.warns\[it\.warns\.length - 1\]\.msg \+ " — click for what happened and why"/,
-    "hover says the latest msg + that detail is a click away");
+  assert.match(FEED, /it\.warns\[it\.warns\.length - 1\]\.msg\) \+ "\\n— click for what happened and why"/,
+    "hover: the attempt history when one exists, else the latest msg — detail is a click away");
+  assert.match(FEED, /tried \$\{f\.model\} — \$\{f\.note\}/,
+    "each hover line is one attempt: model + literal error (the user 2026-08-18)");
+});
+
+test("the modal lists the attempt log — when, which model, the literal error (the user 2026-08-18)", () => {
+  // "tried opus — 529, tried opus — 529, …" at a glance is what tells the user ONE model is down and
+  // switching it fixes everything; prose can't carry that shape
+  assert.match(FEED, /failLog\?: \{ t: number; line: string; model: string; note: string \}\[\] \| null/);
+  assert.match(FEED, /meta\.textContent = "What was tried";/);
+  assert.match(FEED, /tried \$\{f\.model\} for the \$\{f\.line\} — \$\{f\.note\}/);
+  assert.match(FEED, /\(card as any\)\._failLog as AskItem\["failLog"\]/,
+    "the click hands the modal the card's freshest attempt data");
 });
 
 test("a given-up summarizer wears its NAME — 'distill failed' — and its modal offers Try again (the user 2026-08-13)", () => {

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -91,6 +91,7 @@ interface AskItem {
   background?: string | null;                      // distiller's BACKGROUND section: re-orientation for a reader who forgot the thread → the card's collapsed-by-default section above the takeaway (the user 2026-07-02)
   summaryAnchorUuid?: string | null;               // click the summary line → the completion turn's wrap-up block (kernel build_feed completed pin; cited/latest-prose fallbacks — the user 2026-07-14)
   warns?: { kind: string; t: number; msg: string; detail: string }[] | null;   // judge-stamped anomalies (judge _node_warn → kernel build_feed): yellow "warning" chip; click opens the detail modal (the user 2026-07-02)
+  failLog?: { t: number; line: string; model: string; note: string }[] | null;   // the summarizer's failed ATTEMPTS on this card (judge _fail_log): when, which line, which MODEL, the literal error — the chip's hover history + the modal's "What was tried" (the user 2026-08-18, who needed to SEE "tried opus — 529" ×3 to know switching the model would fix it)
   nudged?: { count: number; times: number[] } | null;   // auto-nudge HISTORY (kernel _nudge_times): how many times romp followed up + when — the stalled chip's evidence (tooltip + modal line, the user 2026-07-02)
   warnRows?: { t: number; judge: string; err: string; note?: string; debug?: { input?: string; reply?: string } }[] | null;   // DEBUG MODE only (romp debug on): every judge failure touching this card (kernel _card_warn_rows) → "Warnings (debug)" modal section; rows captured in debug carry the failing call's input + reply (the user 2026-07-09)
   origin?: { peer: string; peerSid: string; peerHost?: string; color: { bg: string; fg: string } | null; live?: boolean } | null;  // courier handoff: planted by a peer's message → "↪ from <peer>"; peerHost = a FEDERATED sender's host, rendered as the quiet "host:" prefix (absent on older payloads / local senders). live = the sender's linked entry is still OPEN; false → the badge is PROVENANCE, dimmed (the completed-column merge, the user 2026-08-16)
@@ -609,7 +610,8 @@ function armRedistillWatch(itemId: string): void {
 }
 
 function feedWarnModal(cardTitle: string, warns: { kind: string; t: number; msg: string; detail: string }[],
-                       ctx?: { itemId: string; sid: string }): void {
+                       ctx?: { itemId: string; sid: string },
+                       failLog?: { t: number; line: string; model: string; note: string }[] | null): void {
   const back = el("div", "fconfirm-back fwarn-back");
   const box = el("div", "fconfirm-box fwarn-box");
   const head = el("div", "fwarn-head"); head.textContent = "Unexpected behavior";
@@ -621,6 +623,20 @@ function feedWarnModal(cardTitle: string, warns: { kind: string; t: number; msg:
     meta.textContent = w.kind + " · " + relAge(Math.max(0, Date.now() / 1000 - w.t));
     const body = el("div", "fwarn-detail"); body.textContent = w.detail || w.msg;
     entry.append(meta, body);
+    box.append(entry);
+  }
+  // The attempt log (the user 2026-08-18): each failed try as its own line — when, which model, the
+  // literal error — so a one-model outage reads as "tried opus — 529, tried opus — 529, …" at a glance
+  // instead of hiding inside prose. Chronological, capped at the kernel (judge _fail_log).
+  if (failLog && failLog.length) {
+    const entry = el("div", "fwarn-entry");
+    const meta = el("div", "fwarn-meta"); meta.textContent = "What was tried";
+    entry.append(meta);
+    for (const f of failLog) {
+      const row = el("div", "fwarn-detail");
+      row.textContent = `${clockHM(f.t)} · tried ${f.model} for the ${f.line} — ${f.note}`;
+      entry.append(row);
+    }
     box.append(entry);
   }
   const btns = el("div", "fconfirm-btns");
@@ -859,7 +875,8 @@ function makeAskCard(it: AskItem): HTMLElement {
     const ws = (card as any)._warnsData as AskItem["warns"];
     const wit = (card as any)._it as AskItem | undefined;   // freshest payload → the ids Try again posts with
     if (ws && ws.length) feedWarnModal((card as any)._title?.textContent || "", ws,
-                                       wit ? { itemId: wit.itemId, sid: wit.sid } : undefined);
+                                       wit ? { itemId: wit.itemId, sid: wit.sid } : undefined,
+                                       (card as any)._failLog as AskItem["failLog"]);
   };
   const waitOnBadge = el("span", "fask-waiton"); waitOnBadge.style.display = "none";   // "Awaiting <peer>" / "Deadlock <peer>", peer name in native colour (the user 2026-06-22)
   const blkBadge = el("a", "fask-blocked"); blkBadge.style.display = "none";   // ⏸ live permission/picker block → click opens the session
@@ -1530,12 +1547,17 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // When the warns are all GIVEN-UP summarizer lines, the chip SAYS so — "distill failed" (the user
   // 2026-08-13, who read the generic label as a mystery) — and its modal carries the Try again.
   a._warnsData = it.warns || null;
+  a._failLog = it.failLog || null;
   if (it.warns && it.warns.length) {
     const allDistill = it.warns.every((w) => DISTILL_FAIL_RE.test(w.kind));
     const lbl = allDistill ? "distill failed" : "warning";
     a._warnChip.style.display = "";
     a._warnChip.textContent = it.warns.length > 1 ? `${lbl} ×${it.warns.length}` : lbl;
-    a._warnChip.title = it.warns[it.warns.length - 1].msg + " — click for what happened and why";
+    // hover = the attempt history when one exists (the user 2026-08-18: "tried opus — 529" ×3 says
+    // what the prose can't — that ONE model keeps failing and switching it would fix this)
+    a._warnChip.title = (it.failLog && it.failLog.length
+      ? it.failLog.map((f) => `${clockHM(f.t)} tried ${f.model} — ${f.note}`).join("\n")
+      : it.warns[it.warns.length - 1].msg) + "\n— click for what happened and why";
   } else {
     a._warnChip.style.display = "none";
   }


### PR DESCRIPTION
## Why

During the Opus-scoped 529 outage, the UI could not say the one thing that mattered: ONE model was failing while every other tier served, and switching the distill model would fix everything instantly. The user had to dig through judge-errors.jsonl to see it.

## What

- **Deterministic per-model diagnosis.** `_mark_call_failed` counts consecutive call failures per model (with the last literal error); the model's next served reply resets the count. At the give-up cap, `_giveup_cause` — the text behind every "distill failed" modal and the fleet banner — names the model and its last error, and when that model is the distill tier's, says outright: *switching the distill model in settings retries everything that failed, immediately* (the switch really does that, since the previous PR).
- **The card's attempt log.** Every failed summarizer try lands on the node as `{when, line, model, error}` (capped at 8; a line's success clears its rows). The chip's hover reads "17:24 tried opus — API Error: Repeated 529 …" per attempt, and the warn modal grows a "What was tried" section — the shape "same model, failing repeatedly" is visible at a glance.
- Feed payload carries `failLog` next to `warns`.

## Tests

Model diagnosis (named + suggestion + reset-on-serve + generic-below-cap), attempt log append/cap/per-line-clear, the give-up path writing rows and a landed brief clearing them (driven through `run_distill`), plus chip/modal source pins in `feed-warn-chip.test.ts`. Full Python suite 4867 passed; UI suite 2070 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)