### PR TITLE
The judging band reads the shared judge-usage cache — bars frames ship again

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18248,16 +18248,14 @@ def _run_judging(t0, alive_sids, semantic):
     for v in by.values():
         v.sort(key=lambda m: m["t"])
     out = []
-    try:
-        lines = (jd.STATE / "judge-usage.jsonl").read_text(errors="replace").splitlines()
-    except OSError:
-        return out
     done = set()                                      # (sid, judge, sent) of completed runs — to dedup live ones
-    for ln in lines:
-        try:
-            o = json.loads(ln)
-        except Exception:
-            continue
+    # Rows come from the SHARED incremental cache (_judge_usage_rows), never a full re-read: this used
+    # to slurp and json-parse the whole append-only log on EVERY bars build, on the GIL — at 60 MB /
+    # 225k rows (2026-08-18) the pusher thread was pinned parsing it and the bars frame effectively
+    # never shipped, so every lane on this kernel showed skeleton furniture (chips, comments, awaiting
+    # stripes) but NO work bars. The 2026-08-13 fix that introduced the cache converted the analytics
+    # reader and missed this one. The cache retains 31 days; TL_HORIZON is far inside that.
+    for o in _judge_usage_rows():
         sid, judge = o.get("fsid"), o.get("judge")
         judge = _JUDGE_FAMILY.get(judge, judge)
         if sid not in alive_sids:

--- a/tests/test_judging_band_cache.py
+++ b/tests/test_judging_band_cache.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""The judging band reads the SHARED incremental judge-usage cache, never the raw file (the user
+2026-08-18): _run_judging used to read_text + json.loads the whole append-only judge-usage.jsonl on
+EVERY bars build, on the GIL — at 60 MB / 225k rows the pusher thread sat pinned parsing it and the
+{type:"bars"} frame effectively never shipped, so every lane on that kernel showed skeleton
+furniture (state chips, comment marks, awaiting stripes) but NO work bars, while smaller-logged
+kernels' lanes rendered fine. The 2026-08-13 sweep that introduced _judge_usage_rows converted the
+analytics reader and missed this one. Synthetic rows only."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_jbc", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-555555555555"
+NOW = 1781100000.0
+
+
+def row(sent, judge="captioner", ms=800):
+    return {"fsid": SID, "judge": judge, "t": sent + 1, "sent": sent, "recv": sent + 1,
+            "ms": ms, "in": 100, "out": 20}
+
+
+class JudgingBandCache(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        # the cache keys on the path, so the tmp STATE resets it — no manual clearing needed
+
+    def tearDown(self):
+        jd.STATE = self.saved
+        self.td.cleanup()
+
+    def log(self, rows, append=False):
+        p = jd.STATE / "judge-usage.jsonl"
+        with open(p, "a" if append else "w") as fh:
+            for r in rows:
+                fh.write(json.dumps(r) + "\n")
+
+    def test_band_rows_come_from_the_log_within_the_window(self):
+        self.log([row(NOW - 100), row(NOW - 40, judge="unblocker")])
+        out = km._run_judging(NOW - 7200, {SID}, [])
+        self.assertEqual([(m["judge"], m["t"]) for m in out],
+                         [("captioner", NOW - 100), ("unblocker", NOW - 40)])
+
+    def test_appended_rows_are_seen_without_a_full_reparse(self):
+        self.log([row(NOW - 100)])
+        self.assertEqual(len(km._run_judging(NOW - 7200, {SID}, [])), 1)
+        size_after_first = km._JUDGE_USAGE_CACHE["size"]
+        self.log([row(NOW - 30)], append=True)
+        out = km._run_judging(NOW - 7200, {SID}, [])
+        self.assertEqual(len(out), 2, "the append is visible on the next build")
+        self.assertGreater(km._JUDGE_USAGE_CACHE["size"], size_after_first,
+                           "…and was consumed incrementally from the saved byte offset")
+
+    def test_rows_before_the_window_or_for_dead_sids_are_filtered(self):
+        self.log([row(NOW - 9000), row(NOW - 50), dict(row(NOW - 60), fsid="someone-else")])
+        out = km._run_judging(NOW - 7200, {SID}, [])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["t"], NOW - 50)
+
+    def test_the_band_never_rereads_the_raw_file(self):
+        # the regression itself, pinned at the source: _run_judging consumes the shared cache, and no
+        # timeline-path code full-reads judge-usage.jsonl (the cache's open/seek is the ONE reader)
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        start = src.index("def _run_judging")
+        body = src[start:src.index("\ndef ", start + 1)]   # this function only, not its neighbours
+        self.assertIn("for o in _judge_usage_rows():", body)
+        self.assertNotIn('read_text', body, "_run_judging never touches the file itself")
+        self.assertEqual(src.count('judge-usage.jsonl").read_text'), 0,
+                         "no full-file reader of judge-usage.jsonl survives anywhere")


### PR DESCRIPTION
Live incident, user-reported 2026-08-18 with a screenshot: every lane served by one kernel showed skeleton furniture (state chips, comment marks, awaiting stripes) but **no work bars**, while another kernel's lanes rendered fully. That kernel's pusher thread sat at ~100% CPU.

**Root cause** (py-spy on the live kernel): `_run_judging` — the judging band — still slurps and JSON-parses the **entire** append-only `judge-usage.jsonl` on every bars build, on the GIL. At 60 MB / 225k rows, the parse eats the pusher whole: the cheap lanes skeleton (`with_bars=False`, which skips the band) keeps flowing, but the heavy `{type:"bars"}` frame effectively never ships. Hence all-furniture-no-bars, and only on the kernel with the big log.

**Fix**: the 2026-08-13 change that introduced the shared incremental reader (`_judge_usage_rows`: parse once, consume appends from the saved byte offset, 31-day retention) converted the analytics reader and missed this one. `_run_judging` now consumes the cache. The timeline window (48h) sits far inside the retention, so band content is unchanged — only the per-push cost drops from O(whole file) to O(new lines).

**Tests**: exercises the band through the cache including the incremental-append path, filters (window, dead sids), and pins that no full-file reader of `judge-usage.jsonl` ever returns — the band body itself and the file-wide pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)