### PR TITLE
Confirming cards keep their summary warns; orphaned sentinels re-check on recovery

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3582,8 +3582,13 @@ def rollup_status(store, session_closed, now=None):
         dead = set()
         if st != "blocked":
             dead.add("brief")                          # the card left Needs-you → the brief isn't shown
-        if st != "completed":
-            dead.add("summary")                        # the card isn't completed → the takeaway isn't shown
+        if st != "completed" and nid not in confirming:
+            # the card isn't completed → the takeaway isn't shown. CONFIRMING is the exception (the user
+            # 2026-08-18, the chipless summaryless card): the distiller enters done-confirming tops, so
+            # its give-up/unreadable warns stamp while status still reads "working" — retiring them here
+            # ate the warn within the same pass, before the user ever saw a chip, leaving the "" sentinel
+            # orphaned with nothing armed to retry it.
+            dead.add("summary")
         if any(_warn_surface(w) == "stall" for w in ws):
             if _stalls is None:
                 _stalls = stalled_facts(store.get("rompUuid") or "")
@@ -9490,6 +9495,27 @@ def rearm_failed_summaries(now=None, auto=False):
             else:
                 nd.pop("autoRearmed", None)            # a discrete event (startup/pause-clear) opens a fresh era
             changed = True; n += 1
+        if not auto:
+            # ORPHANED "" sentinels (the user 2026-08-18, the chipless summaryless card): a completed top
+            # WITH recorded work settled to "" and no summary-surface warn survived (stamped during the
+            # confirming window, rollup's retire ate it — fixed alongside, but already-eaten cards stay
+            # silent forever: every path above is warn-gated and Try again needs the chip). On DISCRETE
+            # recovery events only, clear the stamp so the distiller re-enters: work that resolves now
+            # writes the real summary; work still unreadable re-settles "" and re-warns (the warn now
+            # survives confirming), so the card is loud either way. One-shot per card: once a warn
+            # exists, the no-warn gate here excludes it and the warn-gated path above owns it. Umbrellas
+            # (no recorded work anywhere in the subtree) keep their designed silent "".
+            for nid, nd in (store.get("nodes") or {}).items():
+                if not isinstance(nd, dict) or nd.get("parentId") is not None:
+                    continue
+                if status.get(nid) != "completed" and nid not in confirming:
+                    continue
+                if nd.get("summary") == "" and nd.get("distilledMt") is not None \
+                        and not any(isinstance(w, dict) and _warn_surface(w) == "summary"
+                                    for w in nd.get("warns") or []) \
+                        and _goal_has_recorded_work(store, nid):
+                    nd["distilledMt"] = None
+                    changed = True; n += 1
         if changed:
             save_goals(fsid, store)
     return n

--- a/tests/test_distill_rearm.py
+++ b/tests/test_distill_rearm.py
@@ -266,6 +266,78 @@ class GiveUpWarnNamesTheError(unittest.TestCase):
         self.assertNotIn("last attempt failed", nd["warns"][0]["detail"])
 
 
+class ConfirmingWarnSurvives(unittest.TestCase):
+    """rollup's summary-surface warn retire must NOT eat a warn during the done-CONFIRMING window (the
+    user 2026-08-18, the chipless summaryless card): the distiller enters confirming tops, so its
+    give-up/unreadable warns stamp while status still reads "working" — the old `st != "completed"`
+    retire dropped them within the same pass, before any chip ever rendered, leaving the "" sentinel
+    orphaned with nothing armed to retry it."""
+
+    def tearDown(self):
+        for f in jd.GOALDIR.glob("*"):
+            f.unlink()
+
+    def _store(self, done_verdict):
+        node = {"id": NID, "text": "ship the api", "parentId": None, "nodeComplete": bool(done_verdict),
+                "blocked": False, "cleared": False, "trail": [], "t": T0, "mt": T0 + 30,
+                "summary": "", "warns": [_warn("summary-failed")],
+                "log": ([{"src": "planner", "kind": "done", "ev_t": T0 + 20, "at": T0 + 21}]
+                        if done_verdict else [])}
+        return {"rompUuid": SID, "seq": 1, "placementsV": jd.PLACEMENTS_V, "lastNode": NID,
+                "placements": {}, "status": {NID: "working"}, "nodes": {NID: jd.GuardedNode(node)}}
+
+    def test_a_confirming_tops_summary_warn_survives_the_retire(self):
+        store = self._store(done_verdict=True)         # done verdict in, focus unmoved, session open
+        jd.rollup_status(store, False)
+        self.assertIn(NID, store.get("confirming") or (), "the window this test exists for")
+        self.assertTrue(any(w.get("kind") == "summary-failed"
+                            for w in (store["nodes"][NID].get("warns") or [])),
+                        "the give-up warn lives to render its chip")
+
+    def test_a_plain_working_tops_summary_warn_still_retires(self):
+        store = self._store(done_verdict=False)        # no done verdict → genuinely working
+        jd.rollup_status(store, False)
+        self.assertNotIn(NID, store.get("confirming") or ())
+        self.assertFalse(any(w.get("kind") == "summary-failed"
+                             for w in (store["nodes"][NID].get("warns") or [])),
+                         "a reopened/working card's takeaway isn't shown — its warn retires as before")
+
+
+class OrphanedSentinelRecheck(unittest.TestCase):
+    """A completed top WITH recorded work whose summary is the "" sentinel and whose warn never survived
+    (eaten during confirming, before the fix above) is re-checked on DISCRETE recovery events: the stamp
+    clears so the distiller re-enters — resolving work writes the real summary; unreadable work
+    re-settles and re-warns loudly. Umbrellas (no recorded work) keep their designed silent ""."""
+
+    def tearDown(self):
+        for f in jd.GOALDIR.glob("*"):
+            f.unlink()
+
+    def test_a_discrete_event_reopens_an_orphaned_sentinel_with_recorded_work(self):
+        _seed(status="completed", summary="", distilledMt=T0, trail=[SID + ":s1"])
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 100), 1)
+        nd = _node()
+        self.assertIsNone(nd.get("distilledMt"), "the cleared stamp re-enters the distiller")
+        self.assertEqual(nd.get("summary"), "", "the sentinel itself is untouched until the retry rules")
+
+    def test_the_health_edge_never_touches_orphans(self):
+        _seed(status="completed", summary="", distilledMt=T0, trail=[SID + ":s1"])
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 100, auto=True), 0,
+                         "warn-less orphans re-check on discrete events only — the auto edge is "
+                         "reserved for the warn-gated era machinery")
+
+    def test_an_umbrella_keeps_its_designed_silent_sentinel(self):
+        _seed(status="completed", summary="", distilledMt=T0)   # no trail, no placements anywhere
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 100), 0,
+                         "no recorded work → the silent '' is correct (the 2026-07-10 design)")
+
+    def test_a_card_with_a_live_summary_warn_is_the_warn_paths_business(self):
+        _seed(status="completed", summary="", distilledMt=T0, trail=[SID + ":s1"],
+              warns=[_warn("summary-unreadable")])
+        self.assertEqual(jd.rearm_failed_summaries(T0 + 100), 0,
+                         "a visible chip means the loud path owns it — the sweep is for eaten warns")
+
+
 class ModelHealthDiagnosis(unittest.TestCase):
     """_giveup_cause names the failing MODEL once its consecutive call failures reach the give-up cap —
     a deterministic count, reset by that model's next served reply — and suggests the settings switch


### PR DESCRIPTION
## Why

One card stayed broken after every heal: completed, real work, no summary, no Distilling swirl, no chip. A peer session inspected its raw node on its own kernel: `summary=""`, `distilledMt` stamped, `distillFails=0`, **no warns key at all**, completed, non-empty trail.

Root cause is a warn-eating window: the distiller enters done-CONFIRMING tops (done verdict in, settle pending, status still "working"), so its give-up/unreadable warns stamp while rollup's summary-surface retire still reads `st != "completed"` — the warn dropped within the same pass, before any chip rendered. With the warn gone, every recovery path (all warn-gated) and the Try-again click (needs the chip) were unreachable: the "" sentinel was orphaned forever.

## What

- rollup's summary-surface retire spares CONFIRMING tops — the exact window the distiller writes those warns in.
- `rearm_failed_summaries`' discrete-event path (startup / retry-pause clear / distill-model switch) re-checks orphaned sentinels: completed/confirming top + recorded work + `""` + live stamp + no summary-surface warn → clear the stamp, so the distiller re-enters. Resolving work writes the real summary; unreadable work re-settles and re-warns (loudly, now that the warn survives). One-shot per card; umbrellas keep their designed silent `""` (2026-07-10).

The affected card heals on its kernel's next restart or model switch after deploy.

## Tests

The confirming warn surviving rollup (and a plain working top's still retiring), the sweep firing on discrete events only, skipping umbrellas, and deferring to the warn path when a chip exists. Full Python suite 4873 passed; UI suite 2070 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)