### PR TITLE
Session views: hide sessions and group them, from the timeline's new corner panel and the chat

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18721,7 +18721,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
     cmap_grad = [list(cm.ramp(v, ctx_stops)) for v in (0.12, 0.34, 0.56, 0.78, 1.0)]
     return {"type": "timeline", "now": now, "sessions": sessions, "turns": turns,
             "views": _timeline_views(),
-            "palette": pal.colors(),   # group color choices — the same set sessions draw identity colors from
+            "palette": pal.colors(_palette_name()),   # group color choices — the same set sessions draw identity colors from
             "messages": messages, "judging": judging,
             "cmapGrad": cmap_grad,
             "activeChat": None, "focus": None, "hover": None, "usage": _usage_for_client()}

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18721,6 +18721,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
     cmap_grad = [list(cm.ramp(v, ctx_stops)) for v in (0.12, 0.34, 0.56, 0.78, 1.0)]
     return {"type": "timeline", "now": now, "sessions": sessions, "turns": turns,
             "views": _timeline_views(),
+            "palette": pal.colors(),   # group color choices — the same set sessions draw identity colors from
             "messages": messages, "judging": judging,
             "cmapGrad": cmap_grad,
             "activeChat": None, "focus": None, "hover": None, "usage": _usage_for_client()}

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1483,6 +1483,7 @@ def _ordered(sessions):
             a = _nm(sid)
             sib = [i for i, n in enumerate(name_at) if a and n == a]   # same-name entries already placed
             if sib:
+                _heal_timeline_views(order[sib[-1]], sid)   # the fork inherits hidden/group state too
                 order.insert(sib[-1] + 1, sid)           # a fork inherits its session's slot, not the END
                 name_at.insert(sib[-1] + 1, a)           # keep name_at aligned with order as we splice
             else:
@@ -1504,6 +1505,97 @@ def _ordered_alive(now, tmux):
 # carded and billed: a secret running session, a tmux-era affordance (sessions lived outside romp) with
 # no SDK-era use case. Every running session now always shows; × means End session, and close-and-reopen
 # is End + Revive, which keeps history. A stale hidden-tabs.json on disk is inert, like web-kernel.json.)
+
+
+# ── session VIEWS: which sessions the user is looking at (the user 2026-08-18) ────────────────────
+# One blob under STATE (timeline-views.json), shared by every dashboard this kernel serves (browser,
+# VS Code, Obsidian): {"active": "all"|group-id, "hidden": [id...], "groups": [{"id","name","color",
+# "members": [id...]}]}. "all" shows every session EXCEPT the hidden set — hiding makes a BACKGROUND
+# session: out of the timeline lanes and the chat tab strip, still judged, carded and reachable (the
+# feed and the session pickers keep surfacing it, so nothing runs in secret — the 2026-08-11 rule).
+# A named group shows exactly its members; explicit membership beats the hidden set, which is the
+# one clean answer to "does a hidden session show when its group is picked". Persisted by the LOCAL
+# kernel like colormap/palette (a viewer display pref, deliberately not federated); ids are stored
+# as the viewer sees them (host-prefixed for remote sessions), opaque to this kernel. mtime-cached
+# like _session_flags. Remote-session ids that churn on a REMOTE kernel are not healed here (that
+# kernel cannot reach this blob) — same accepted gap session-flags has; SDK sids are stable anyway.
+_VIEWS_MAX_GROUPS = 32
+_VIEWS_MAX_NAME = 40
+
+
+def _views_path():
+    return jd.STATE / "timeline-views.json"
+
+
+def _norm_timeline_views(d):
+    """Validate + normalize a views blob from disk or a client: always returns the full shape, drops
+    junk quietly, clamps sizes, and falls back active→"all" when the named group does not exist."""
+    if not isinstance(d, dict):
+        d = {}
+    hidden = [str(x) for x in d.get("hidden") or [] if isinstance(x, str) and x]
+    groups = []
+    for g in (d.get("groups") or [])[:_VIEWS_MAX_GROUPS]:
+        if not isinstance(g, dict) or not g.get("id") or not isinstance(g.get("id"), str):
+            continue
+        members = [str(x) for x in g.get("members") or [] if isinstance(x, str) and x]
+        groups.append({"id": g["id"][:64],
+                       "name": str(g.get("name") or "group")[:_VIEWS_MAX_NAME],
+                       "color": str(g.get("color") or "")[:16],
+                       "members": sorted(set(members))})
+    active = d.get("active") if isinstance(d.get("active"), str) else "all"
+    if active != "all" and not any(g["id"] == active for g in groups):
+        active = "all"
+    return {"active": active, "hidden": sorted(set(hidden)), "groups": groups}
+
+
+def _timeline_views():
+    p = _views_path()
+    try:
+        st = p.stat(); key = (st.st_mtime_ns, st.st_size)
+    except OSError:
+        return _norm_timeline_views({})
+    hit = _flags_cache.get(str(p))
+    if hit is not None and hit[0] == key:
+        return hit[1]
+    try:
+        d = json.loads(p.read_text())
+    except Exception:
+        d = {}
+    d = _norm_timeline_views(d)
+    _flags_cache[str(p)] = (key, d)
+    return d
+
+
+def _set_timeline_views(blob):
+    _atomic_write(_views_path(), json.dumps(_norm_timeline_views(blob), sort_keys=True))
+
+
+def _view_visible(views, sid):
+    """The one visibility decision, kernel-authoritative: mirrored (three lines each) by the chat
+    renderer and the timeline for optimistic feedback — tests pin all three against this shape."""
+    if views["active"] == "all":
+        return sid not in views["hidden"]
+    for g in views["groups"]:
+        if g["id"] == views["active"]:
+            return sid in g["members"]
+    return True
+
+
+def _heal_timeline_views(old_sid, new_sid):
+    """fsid churn (a /clear, relaunch or revive mints a new transcript fsid for the same logical
+    session): carry the old sid's hidden bit and group memberships to the new one, exactly like the
+    order-slot inheritance that detects the churn. Without this a hidden tmux session would pop back
+    visible on every /clear — and worse, a grouped one would silently fall out of its group."""
+    v = _timeline_views()
+    if old_sid not in v["hidden"] and not any(old_sid in g["members"] for g in v["groups"]):
+        return
+    v = json.loads(json.dumps(v))                    # deep copy: never mutate the cached blob
+    if old_sid in v["hidden"]:
+        v["hidden"] = sorted((set(v["hidden"]) - {old_sid}) | {new_sid})
+    for g in v["groups"]:
+        if old_sid in g["members"]:
+            g["members"] = sorted((set(g["members"]) - {old_sid}) | {new_sid})
+    _set_timeline_views(v)
 
 
 # ── per-session view flags (the user 2026-06-19) ──────────────────────────────────────────────────
@@ -18628,6 +18720,7 @@ def build_timeline(now, tmux=None, with_bars=True, live_only=False):
     # letting the bar slide through the map's hues as it compresses — mirroring the context battery fill.
     cmap_grad = [list(cm.ramp(v, ctx_stops)) for v in (0.12, 0.34, 0.56, 0.78, 1.0)]
     return {"type": "timeline", "now": now, "sessions": sessions, "turns": turns,
+            "views": _timeline_views(),
             "messages": messages, "judging": judging,
             "cmapGrad": cmap_grad,
             "activeChat": None, "focus": None, "hover": None, "usage": _usage_for_client()}
@@ -19949,7 +20042,7 @@ def _push(targets, connect=False, tmux=None):
                 _send_client(c, ("globalRetryPaused",), {"type": "globalRetryPaused", "value": _retry_paused_on(),
                                                          "resumeAt": _retry_resume_at(),   # limit reset epoch → the card counts down to the real retry
                                                          "reason": _retry_pause_reason()})   # "spend" → the card says 'raise your cap', no countdown
-                _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta})
+                _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _timeline_views()})
             active = {c.get("active") for c in chat_clients if c.get("active")}
             # Stable: active tabs first — and TRANSCRIPT-LESS sessions with them. A just-created session
             # has no transcript, so its build is near-free, and its creator is guaranteed to be staring
@@ -20160,7 +20253,7 @@ def _push_session_now(sid):
             return
         ms = None                                    # lazy: the first full send materializes it, the rest reuse
         for c in targets:
-            _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta})
+            _send_client(c, ("taborder",), {"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _timeline_views()})
             ms = _send_chat(c, m, ms, 0, True)       # change_from 0 → always the full-session form
     except Exception:
         sys.stderr.write("push-session-now (%s): %s\n" % (sid, traceback.format_exc()))
@@ -21360,6 +21453,7 @@ window.__rompTimelineWriteOrder=function(order){if(window.__rompWriteOrder)windo
 window.__rompTimelineCompact=function(name){post({type:"compact",name:name});};
 window.__rompTimelineSendCommand=function(name,cmd){post({type:"sendCommand",name:name,cmd:cmd});};
 window.__rompTimelineSetFlag=function(id,flag,value){post({type:"setSessionFlag",id:id,flag:flag,value:!!value});};
+window.__rompTimelineSetViews=function(views){post({type:"setTimelineViews",views:views});};
 window.__rompTimelineDismiss=function(id){post({type:"dismissLane",id:id});};
 window.__rompTimelineHover=function(sid,segIds,t0,t1){post(sid?{type:"timelineHover",sid:sid,segIds:segIds||[],t0:t0,t1:t1}:{type:"timelineHover",off:true});};
 window.__rompConnectTimeline=function(p){panel=p;post({type:"ready"});};})();
@@ -25298,7 +25392,7 @@ class Handler(BaseHTTPRequestHandler):
                 _o = [s["sid"] for s in _alive]
                 # name+color per tab → the client paints the whole strip as placeholders up front (tabs-first)
                 _tabs = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])} for s in _alive]
-                client["send"](json.dumps({"type": "tabOrder", "order": _o, "tabs": _tabs}))
+                client["send"](json.dumps({"type": "tabOrder", "order": _o, "tabs": _tabs, "views": _timeline_views()}))
             except Exception:
                 pass
             # a push tap parked a reveal for this window's chat pane → deliver it now, AFTER the
@@ -25319,6 +25413,11 @@ class Handler(BaseHTTPRequestHandler):
                 _set_notify_session(str(msg["id"]), bool(msg.get("value")))
             else:
                 _set_session_flag(str(msg["id"]), str(msg["flag"]), bool(msg.get("value")))
+            _mark_views_dirty()
+        elif msg and msg.get("type") == "setTimelineViews" and isinstance(msg.get("views"), dict):
+            # timeline corner panel → replace the whole views blob (tiny; last-write-wins across
+            # dashboards, like colormap). Validation/normalization happens in the setter.
+            _set_timeline_views(msg["views"])
             _mark_views_dirty()
         elif msg and msg.get("type") == "cardNotify" and msg.get("itemId"):
             # feed card right-click → per-card bell (OS notification when THIS card blocks on you /

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1532,12 +1532,13 @@ def _norm_timeline_views(d):
     junk quietly, clamps sizes, and falls back active→"all" when the named group does not exist."""
     if not isinstance(d, dict):
         d = {}
-    hidden = [str(x) for x in d.get("hidden") or [] if isinstance(x, str) and x]
+    _lst = lambda x: x if isinstance(x, list) else []   # wrong-typed junk (a number, a string) drops, never raises
+    hidden = [str(x) for x in _lst(d.get("hidden")) if isinstance(x, str) and x]
     groups = []
-    for g in (d.get("groups") or [])[:_VIEWS_MAX_GROUPS]:
+    for g in _lst(d.get("groups"))[:_VIEWS_MAX_GROUPS]:
         if not isinstance(g, dict) or not g.get("id") or not isinstance(g.get("id"), str):
             continue
-        members = [str(x) for x in g.get("members") or [] if isinstance(x, str) and x]
+        members = [str(x) for x in _lst(g.get("members")) if isinstance(x, str) and x]
         groups.append({"id": g["id"][:64],
                        "name": str(g.get("name") or "group")[:_VIEWS_MAX_NAME],
                        "color": str(g.get("color") or "")[:16],
@@ -1590,11 +1591,15 @@ def _heal_timeline_views(old_sid, new_sid):
     if old_sid not in v["hidden"] and not any(old_sid in g["members"] for g in v["groups"]):
         return
     v = json.loads(json.dumps(v))                    # deep copy: never mutate the cached blob
+    # COPY, never move: stripping the old sid un-hid its DEAD lane, which lingers on the timeline for
+    # hours — and when the old sid is still alive (a fork beside a living parent, or an unrelated new
+    # session reusing a name), moving would steal the living session's state. A dead sid left in the
+    # lists is inert; the normalizer keeps them bounded.
     if old_sid in v["hidden"]:
-        v["hidden"] = sorted((set(v["hidden"]) - {old_sid}) | {new_sid})
+        v["hidden"] = sorted(set(v["hidden"]) | {new_sid})
     for g in v["groups"]:
         if old_sid in g["members"]:
-            g["members"] = sorted((set(g["members"]) - {old_sid}) | {new_sid})
+            g["members"] = sorted(set(g["members"]) | {new_sid})
     _set_timeline_views(v)
 
 
@@ -18988,6 +18993,21 @@ def _reveal_chat_for(client, focus_msg):
     revealSelfPane) — which covers every kernel, local included, and makes the shell line a harmless
     duplicate rather than the only mover."""
     wid = (client or {}).get("wid") or ""
+    # The reveal rule (the user 2026-08-18): every gesture that focuses a session's chat — create,
+    # open, revive, a deep link, a feed chip — REVEALS it in the session views first, or the focus
+    # would land on a tab the strip doesn't show (a session created under an active group view was
+    # born invisible, with the focus yanked away by the strip's re-point). Drop its hidden bit; when
+    # the active group excludes it, fall back to All — the same one rule the chat picker applies.
+    sid = focus_msg.get("id") if isinstance(focus_msg, dict) else None
+    if sid:
+        v = _timeline_views()
+        if not _view_visible(v, sid):
+            v = json.loads(json.dumps(v))
+            v["hidden"] = [x for x in v["hidden"] if x != sid]
+            if v["active"] != "all" and not any(g["id"] == v["active"] and sid in g["members"] for g in v["groups"]):
+                v["active"] = "all"
+            _set_timeline_views(v)
+            _mark_views_dirty()
     _send_to_view("chat", focus_msg, wid)
     _send_to_view("shell", {"type": "reveal", "pane": "chat"}, wid)
 

--- a/tests/test_chat_empty_pane.py
+++ b/tests/test_chat_empty_pane.py
@@ -61,10 +61,10 @@ class ChatEmptyPane(unittest.TestCase):
 
     def test_it_runs_on_every_push_and_is_idempotent(self):
         """renderTabs runs on every kernel push (0.5-3s). Appending each time would pile up copies."""
-        self.assertRegex(RENDER, r"syncNoSessionsPlaceholder\(visibleIds\.length\)",
+        self.assertRegex(RENDER, r"syncNoSessionsPlaceholder\(visibleIds\.length, ids\.length\)",
                          "renderTabs must drive it from the visible session count")
         fn = re.search(r"function syncNoSessionsPlaceholder\(.*?\n\}", RENDER, re.S).group(0)
-        self.assertIn("if (existing) return;", fn, "must not append a second placeholder per push")
+        self.assertIn("if (existing) { existing.textContent = txt; return; }", fn, "must not append a second placeholder per push")
 
     def test_the_placeholder_is_removed_once_a_session_exists(self):
         """Otherwise it lingers above the first real transcript."""

--- a/tests/test_kernel_tabs_first.py
+++ b/tests/test_kernel_tabs_first.py
@@ -25,12 +25,12 @@ class TabsFirst(unittest.TestCase):
         src = inspect.getsource(km._push)
         self.assertIn('tab_meta = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}', src,
                       "the periodic push builds a name+color list per tab")
-        self.assertIn('{"type": "tabOrder", "order": tab_order, "tabs": tab_meta}', src,
+        self.assertIn('{"type": "tabOrder", "order": tab_order, "tabs": tab_meta, "views": _timeline_views()}', src,
                       "and ships it as the tabs field alongside the sid order")
 
     def test_connect_ready_handler_also_sends_tabs(self):
         text = open(KPATH).read()
-        self.assertIn('{"type": "tabOrder", "order": _o, "tabs": _tabs}', text,
+        self.assertIn('{"type": "tabOrder", "order": _o, "tabs": _tabs, "views": _timeline_views()}', text,
                       "the WS 'ready' connect push also carries name+color tabs")
         self.assertIn('_tabs = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])}', text)
 

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Session views (the user 2026-08-18): one timeline-views.json blob under STATE — {"active", "hidden",
+"groups"} — deciding which sessions show on the timeline lanes AND the chat tab strip. "all" shows
+everything except the hidden set (a hidden session is a BACKGROUND session: still judged and carded,
+surfaced by the feed and pickers); a named group shows exactly its members, membership beating the
+hidden bit. Local-kernel persisted (a viewer display pref, not federated). These pin the storage
+helpers, the visibility decision, the normalizer, the churn heal, the WS op, and the payload echoes.
+Synthetic only."""
+import json
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+SourceFileLoader("romp_event_model", os.path.join(BIN, "romp-event-model")).load_module()
+SourceFileLoader("romp_judge", os.path.join(BIN, "romp-judge")).load_module()
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = SourceFileLoader("romp_kernel_tv", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+G1 = {"id": "g1", "name": "pool", "color": "#DD42FF", "members": ["s2", "s3"]}
+
+
+class TimelineViews(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        km._flags_cache.clear()
+
+    def tearDown(self):
+        jd.STATE = self.saved
+        self.td.cleanup()
+
+    def test_default_shows_everything(self):
+        v = km._timeline_views()
+        self.assertEqual(v, {"active": "all", "hidden": [], "groups": []})
+        self.assertTrue(km._view_visible(v, "anything"))
+
+    def test_hidden_hides_in_all_but_membership_beats_it(self):
+        km._set_timeline_views({"active": "all", "hidden": ["s2"], "groups": [G1]})
+        km._flags_cache.clear()
+        v = km._timeline_views()
+        self.assertFalse(km._view_visible(v, "s2"), "hidden in the all view")
+        self.assertTrue(km._view_visible(v, "s1"))
+        km._set_timeline_views({"active": "g1", "hidden": ["s2"], "groups": [G1]})
+        km._flags_cache.clear()
+        v = km._timeline_views()
+        self.assertTrue(km._view_visible(v, "s2"), "explicit membership beats the hidden bit")
+        self.assertFalse(km._view_visible(v, "s1"), "a group shows exactly its members")
+
+    def test_normalizer_drops_junk_and_falls_back_to_all(self):
+        v = km._norm_timeline_views({"active": "ghost", "hidden": ["a", 7, "", "a"],
+                                     "groups": [{"id": "g1", "name": "x" * 99, "members": ["m", 3]},
+                                                {"noid": True}, "junk"]})
+        self.assertEqual(v["active"], "all", "an active group that does not exist falls back to all")
+        self.assertEqual(v["hidden"], ["a"], "junk and duplicates dropped")
+        self.assertEqual(len(v["groups"]), 1)
+        self.assertEqual(len(v["groups"][0]["name"]), km._VIEWS_MAX_NAME)
+        self.assertEqual(v["groups"][0]["members"], ["m"])
+
+    def test_cache_invalidates_on_write(self):
+        self.assertEqual(km._timeline_views()["hidden"], [])
+        km._set_timeline_views({"hidden": ["s9"]})
+        self.assertEqual(km._timeline_views()["hidden"], ["s9"], "mtime+size key sees the write")
+
+    def test_churn_heal_carries_hidden_and_membership(self):
+        km._set_timeline_views({"active": "all", "hidden": ["old"], "groups": [
+            {"id": "g1", "name": "pool", "members": ["old", "other"]}]})
+        km._heal_timeline_views("old", "new")
+        v = km._timeline_views()
+        self.assertEqual(v["hidden"], ["new"], "the hidden bit follows the fork")
+        self.assertEqual(v["groups"][0]["members"], ["new", "other"], "membership follows the fork")
+        before = json.loads((jd.STATE / "timeline-views.json").read_text())
+        km._heal_timeline_views("stranger", "new2")   # untouched sid → no write at all
+        self.assertEqual(json.loads((jd.STATE / "timeline-views.json").read_text()), before)
+
+    def test_ordered_fork_splice_heals_views(self):
+        # the same name-keyed splice that inherits the ORDER slot carries the views state with it
+        km._write_session_order(["old"])
+        (jd.STATE / "names").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "names" / "old").write_text("web\t/tmp\t#123456\twhite\n")
+        km._set_timeline_views({"active": "all", "hidden": ["old"], "groups": []})
+        km._ordered([{"sid": "old", "name": "web"}, {"sid": "new", "name": "web"}])
+        self.assertEqual(km._timeline_views()["hidden"], ["new"])
+
+    def test_ws_op_persists_via_normalizer(self):
+        # the handler body is _set_timeline_views + _mark_views_dirty; pin the setter's normalization
+        km._set_timeline_views({"active": "g9", "hidden": ["x"], "groups": []})
+        v = json.loads((jd.STATE / "timeline-views.json").read_text())
+        self.assertEqual(v["active"], "all")
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn('msg.get("type") == "setTimelineViews"', src)
+        self.assertIn('_set_timeline_views(msg["views"])', src)
+
+    def test_payloads_echo_the_views_blob(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn('"views": _timeline_views(),', src, "the timeline payload carries it")
+        self.assertIn('"tabs": tab_meta, "views": _timeline_views()', src, "tabOrder pushes carry it")
+        self.assertIn('"tabs": _tabs, "views": _timeline_views()', src, "the connect-time tabOrder carries it")
+
+    def test_web_boot_exposes_the_set_views_hook(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("window.__rompTimelineSetViews=function(views)", src)
+        self.assertIn('post({type:"setTimelineViews",views:views});', src)

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -100,6 +100,7 @@ class TimelineViews(unittest.TestCase):
     def test_payloads_echo_the_views_blob(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('"views": _timeline_views(),', src, "the timeline payload carries it")
+        self.assertIn('"palette": pal.colors(),', src, "and the palette, for group colors in every host")
         self.assertIn('"tabs": tab_meta, "views": _timeline_views()', src, "tabOrder pushes carry it")
         self.assertIn('"tabs": _tabs, "views": _timeline_views()', src, "the connect-time tabOrder carries it")
 

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -57,6 +57,11 @@ class TimelineViews(unittest.TestCase):
         v = km._norm_timeline_views({"active": "ghost", "hidden": ["a", 7, "", "a"],
                                      "groups": [{"id": "g1", "name": "x" * 99, "members": ["m", 3]},
                                                 {"noid": True}, "junk"]})
+        self.assertEqual(km._norm_timeline_views({"hidden": 7, "groups": "nope"}),
+                         {"active": "all", "hidden": [], "groups": []},
+                         "wrong-TYPED fields drop instead of raising")
+        self.assertEqual(km._norm_timeline_views({"groups": [{"id": "g", "members": 3}]})["groups"][0]["members"],
+                         [], "a wrong-typed members list drops, never raises")
         self.assertEqual(v["active"], "all", "an active group that does not exist falls back to all")
         self.assertEqual(v["hidden"], ["a"], "junk and duplicates dropped")
         self.assertEqual(len(v["groups"]), 1)
@@ -68,13 +73,15 @@ class TimelineViews(unittest.TestCase):
         km._set_timeline_views({"hidden": ["s9"]})
         self.assertEqual(km._timeline_views()["hidden"], ["s9"], "mtime+size key sees the write")
 
-    def test_churn_heal_carries_hidden_and_membership(self):
+    def test_churn_heal_copies_hidden_and_membership(self):
+        # COPY, never move: stripping the old sid un-hid its dead lane (it lingers on the timeline for
+        # hours), and a still-alive same-name session would have its state stolen
         km._set_timeline_views({"active": "all", "hidden": ["old"], "groups": [
             {"id": "g1", "name": "pool", "members": ["old", "other"]}]})
         km._heal_timeline_views("old", "new")
         v = km._timeline_views()
-        self.assertEqual(v["hidden"], ["new"], "the hidden bit follows the fork")
-        self.assertEqual(v["groups"][0]["members"], ["new", "other"], "membership follows the fork")
+        self.assertEqual(v["hidden"], ["new", "old"], "the fork inherits the hidden bit; the old sid keeps it")
+        self.assertEqual(v["groups"][0]["members"], ["new", "old", "other"], "membership copies the same way")
         before = json.loads((jd.STATE / "timeline-views.json").read_text())
         km._heal_timeline_views("stranger", "new2")   # untouched sid → no write at all
         self.assertEqual(json.loads((jd.STATE / "timeline-views.json").read_text()), before)
@@ -86,7 +93,7 @@ class TimelineViews(unittest.TestCase):
         (jd.STATE / "names" / "old").write_text("web\t/tmp\t#123456\twhite\n")
         km._set_timeline_views({"active": "all", "hidden": ["old"], "groups": []})
         km._ordered([{"sid": "old", "name": "web"}, {"sid": "new", "name": "web"}])
-        self.assertEqual(km._timeline_views()["hidden"], ["new"])
+        self.assertEqual(km._timeline_views()["hidden"], ["new", "old"], "copied, so the dead lane stays hidden too")
 
     def test_ws_op_persists_via_normalizer(self):
         # the handler body is _set_timeline_views + _mark_views_dirty; pin the setter's normalization
@@ -108,3 +115,18 @@ class TimelineViews(unittest.TestCase):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("window.__rompTimelineSetViews=function(views)", src)
         self.assertIn('post({type:"setTimelineViews",views:views});', src)
+
+    def test_focus_reveals_a_hidden_session(self):
+        # the reveal rule: every gesture that focuses a session's chat (create/open/revive/deep link,
+        # all through _reveal_chat_for) reveals it first — a session created under an active group
+        # view must not be born invisible with its focus yanked away
+        km._set_timeline_views({"active": "g1", "hidden": ["s9"],
+                                "groups": [{"id": "g1", "name": "pool", "members": ["s2"]}]})
+        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s9"})
+        v = km._timeline_views()
+        self.assertNotIn("s9", v["hidden"], "the hidden bit drops")
+        self.assertEqual(v["active"], "all", "the excluding group yields to All")
+        km._set_timeline_views({"active": "g1", "hidden": [],
+                                "groups": [{"id": "g1", "name": "pool", "members": ["s2"]}]})
+        km._reveal_chat_for({"wid": "w1"}, {"type": "focus", "id": "s2"})
+        self.assertEqual(km._timeline_views()["active"], "g1", "a member's focus changes nothing")

--- a/tests/test_timeline_views.py
+++ b/tests/test_timeline_views.py
@@ -100,7 +100,7 @@ class TimelineViews(unittest.TestCase):
     def test_payloads_echo_the_views_blob(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('"views": _timeline_views(),', src, "the timeline payload carries it")
-        self.assertIn('"palette": pal.colors(),', src, "and the palette, for group colors in every host")
+        self.assertIn('"palette": pal.colors(_palette_name()),', src, "and the palette, for group colors in every host")
         self.assertIn('"tabs": tab_meta, "views": _timeline_views()', src, "tabOrder pushes carry it")
         self.assertIn('"tabs": _tabs, "views": _timeline_views()', src, "the connect-time tabOrder carries it")
 

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -24,6 +24,29 @@ function _rompOnlyTag() {
 }
 // <tag> may be a comma-separated LIST (`#only=api,tests,web`) so demo sessions need no shared
 // on-camera prefix (the user 2026-07-16). Mirrors ui/webview/only-filter.ts's matchesOnly.
+// ── session VIEWS (the user 2026-08-18): which sessions the lanes — and the chat tab strip — show.
+// {active:"all"|gid, hidden:[id...], groups:[{id,name,color,members:[id...]}]}, kernel-persisted
+// (timeline-views.json) and echoed on every payload as data.views. "all" shows everything except the
+// hidden set (a hidden session is a BACKGROUND session: still judged and carded, surfaced by the feed
+// and the pickers); a named group shows exactly its members — membership beats the hidden bit. The
+// kernel's _view_visible is the decision of record; this is its three-line mirror for the lanes.
+function viewVisible(views, id) {
+  if (!views || !views.active || views.active === 'all')
+    return !(views && Array.isArray(views.hidden) && views.hidden.indexOf(id) >= 0);
+  const g = (views.groups || []).find((x) => x.id === views.active);
+  return g ? (g.members || []).indexOf(id) >= 0 : true;
+}
+function viewLabel(views) {
+  if (!views || !views.active || views.active === 'all') return 'All';
+  const g = (views.groups || []).find((x) => x.id === views.active);
+  return g ? (g.name || 'group') : 'All';
+}
+// live sessions the current view is NOT showing — the "N more" cue that keeps a hidden session
+// exactly one glance away (nothing may run in secret: the 2026-08-11 hidden-tabs rule)
+function viewMoreCount(views, sessions) {
+  return (sessions || []).filter((s) => s.live && !viewVisible(views, s.id)).length;
+}
+
 function _rompMatchesOnly(name, tag) {
   if (!tag) return true;
   const n = (name || "").toLowerCase();
@@ -556,6 +579,12 @@ class TimelinePanel {
     this._compactClicked = {};   // sid → click ts: show the compacting cue OPTIMISTICALLY until the real state catches up
     this._pendingFlags = {};     // sid → {flag: value}: an optimistic eye-toggle held STICKY across pushes until the kernel's data confirms it (no flicker-back)
     this._dismissed = new Set(); // sids cleared via the dead-lane Clear pill, held STICKY the same way (see _reconcileDismissed)
+    this._views = null;          // the kernel-echoed views blob (data.views); null until the first push
+    this._pendingViews = null;   // an optimistic edit held sticky until a push echoes it (see _reconcileViews)
+    this._pendingViewsAge = 0;   // pushes since the edit — the kernel is authoritative, so a stale pending yields
+    this._viewsMenu = null;      // the Show-dropdown element, when open
+    this._viewsDialog = null;    // the sessions/group dialog backdrop, when open
+    this._palette = [];          // group color choices (the kernel ships its palette on the payload)
     // "Collapse idle gaps" now lives in the SETTINGS dialog (romp:settings.collapseGaps), moved out of the
     // timeline toolbar (the user 2026-06-25). Read it fresh here + re-read on the 'storage' event so a toggle
     // in the gear iframe live-syncs. (CSTORE is the legacy per-view key — honoured as a one-time fallback so
@@ -805,8 +834,8 @@ class TimelinePanel {
     // ('sid:kind' → {was, until}) that dim a word until the tmux var actually flips (or 20s elapses).
     // _laneMenu = the per-lane GEAR drop-down (feed/postal/notify toggles — the user 2026-07-28).
     this._metaMenu = null; this._metaPending = {}; this._laneMenu = null;
-    this._onDocClick = () => { this._closeMetaMenu(); this._closeLaneMenu(); };
-    this._onDocKey = (e) => { if (e.key === 'Escape') { this._closeMetaMenu(); this._closeLaneMenu(); } };
+    this._onDocClick = () => { this._closeMetaMenu(); this._closeLaneMenu(); this._closeViewsMenu(); };
+    this._onDocKey = (e) => { if (e.key === 'Escape') { this._closeMetaMenu(); this._closeLaneMenu(); this._closeViewsMenu(); } };
     document.addEventListener('click', this._onDocClick);
     document.addEventListener('keydown', this._onDocKey);
     // The menus render in the tip's host document (see _menuHost), so a click or Escape landing on the
@@ -818,7 +847,7 @@ class TimelinePanel {
       window.addEventListener('pagehide', () => { try {
         tipDoc.removeEventListener('click', this._onDocClick);
         tipDoc.removeEventListener('keydown', this._onDocKey);
-        this._closeMetaMenu(); this._closeLaneMenu();
+        this._closeMetaMenu(); this._closeLaneMenu(); this._closeViewsMenu(); this._closeViewsDialog();
       } catch (e) {} });
     }
 
@@ -1389,8 +1418,11 @@ class TimelinePanel {
     }
     this.data = data;
     if (data.cmapGrad) this._cmapGrad = data.cmapGrad;   // compaction-sweep colormap gradient (persists across the lighter {type:bars} pushes)
+    if (data.views) this._views = data.views;            // the views blob rides every push (skeleton included)
+    if (Array.isArray(data.palette) && data.palette.length) this._palette = data.palette;
     this._reconcilePendingFlags();   // hold an optimistic eye-toggle sticky until THIS push (or a later one) confirms it
     this._reconcileDismissed();      // ...and a Cleared dead lane, so a stale/merged push can't pop it back
+    this._reconcileViews();          // ...and an optimistic view edit, until the kernel echoes it
     this._signalReady();             // first lanes are about to paint → let the shell drop the boot splash
     // Live-edge baseline: the edge free-runs off a FIXED anchor and each poll rebases it MONOTONICALLY
     // (reanchorEdge) — it catches up forward when behind but NEVER moves backward, so bursty/jittery/
@@ -2260,9 +2292,250 @@ class TimelinePanel {
   // gray = off), its label + state word, and a plain-language line on what it does. Clicking a row
   // toggles that flag with the SAME optimistic + sticky treatment as the old direct icons, and the menu
   // stays open, repainting in place — it's a settings panel, not a command.
+  // ── the corner control panel (the user 2026-08-18): "Show: <view> ▾ · N more" in the bottom-left
+  // corner — the empty strip under the lane gutter, left of the first time label. Progressive
+  // disclosure: the trigger is the one-line version; the dropdown holds the views and the two
+  // timeline display toggles; the dialog holds the per-session checkboxes. All pointerdown-based
+  // (the redraw-eats-click rule) and rebuilt per draw like the gear/lock.
+  _curViews() { return this._pendingViews || this._views || { active: 'all', hidden: [], groups: [] }; }
+
+  // one canonical serialization for echo comparison: the kernel normalizer sorts hidden/members and
+  // may clamp names, so compare shapes, not object identity
+  _viewsKey(v) {
+    return JSON.stringify({ active: v.active || 'all',
+      hidden: (v.hidden || []).slice().sort(),
+      groups: (v.groups || []).map((g) => ({ id: g.id, name: g.name, color: g.color,
+                                             members: (g.members || []).slice().sort() })) });
+  }
+
+  _reconcileViews() {
+    if (!this._pendingViews) return;
+    if (this._views && this._viewsKey(this._views) === this._viewsKey(this._pendingViews)) {
+      this._pendingViews = null; this._pendingViewsAge = 0; return;
+    }
+    // the kernel is authoritative: if three pushes came back without echoing the edit (it normalized
+    // differently, or another dashboard overwrote it), adopt the kernel's blob rather than pinning
+    // a stale optimistic view forever
+    if (++this._pendingViewsAge >= 3) { this._pendingViews = null; this._pendingViewsAge = 0; }
+  }
+
+  // Persist the whole views blob. Web/VS Code: the host WS hook (→ kernel setTimelineViews, which
+  // normalizes + rebroadcasts). Obsidian/headless fallback: write the same timeline-views.json the
+  // kernel reads (it re-normalizes on read). Optimistic + sticky, like the lane flags.
+  _setViews(v) {
+    this._pendingViews = v; this._pendingViewsAge = 0;
+    try {
+      if (typeof window !== 'undefined' && typeof window.__rompTimelineSetViews === 'function') {
+        window.__rompTimelineSetViews(v);
+      } else {
+        const fs = require('fs'), os = require('os'), path = require('path');
+        const dir = path.join(os.homedir(), '.local', 'state', 'romp');
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'timeline-views.json'), JSON.stringify(v));
+      }
+    } catch (e) { /* no host hook + no Node fs → session-local only */ }
+    this.draw();
+  }
+
+  _drawViewsTrigger(svg, axisY) {
+    const v = this._curViews();
+    const g = (v.groups || []).find((x) => x.id === v.active);
+    const more = viewMoreCount(v, (this.data && this.data.sessions) || []);
+    // ellipsize the view name so the trigger never crosses into the time labels: the gutter is all it owns
+    let name = viewLabel(v);
+    const budget = Math.max(60, this.M.left - PADL - 78);   // room for "Show: ", the caret, and the count
+    while (name.length > 3 && this.labelWidth(name) > budget) name = name.slice(0, -2) + '…';
+    const t = el('text', { x: PADL, y: axisY + 14, 'font-size': 12, 'font-family': FONT, fill: MODEL_FG });
+    const lead = el('tspan', {}); lead.textContent = 'Show: '; t.appendChild(lead);
+    const nm = el('tspan', { fill: (g && g.color) || '#cccccc', 'font-weight': 650 }); nm.textContent = name; t.appendChild(nm);
+    const caret = el('tspan', {}); caret.textContent = ' ▾'; t.appendChild(caret);
+    if (more) { const m = el('tspan', { opacity: 0.7 }); m.textContent = ' · ' + more + ' more'; t.appendChild(m); }
+    t.setAttribute('style', 'cursor:pointer;user-select:none;');
+    t.addEventListener('pointerdown', (e) => { e.preventDefault(); e.stopPropagation(); this._openViewsMenu(t); });
+    svg.appendChild(t);
+  }
+
+  _closeViewsMenu() { if (this._viewsMenu) { this._viewsMenu.remove(); this._viewsMenu = null; } }
+  _closeViewsDialog() { if (this._viewsDialog) { this._viewsDialog.remove(); this._viewsDialog = null; } }
+
+  _openViewsMenu(anchorEl) {
+    const reopen = !!this._viewsMenu;
+    this._closeViewsMenu(); this._closeLaneMenu(); this._closeMetaMenu();
+    if (reopen) return;
+    const menu = document.body.createDiv();
+    menu.setAttribute('style', 'position:fixed;z-index:1001;min-width:200px;' + MENU_STYLE);
+    menu.addEventListener('click', (e) => e.stopPropagation());
+    const item = (label, opts) => {
+      const row = menu.createDiv();
+      row.setAttribute('style', 'padding:4px 22px 4px 8px;border-radius:4px;cursor:pointer;position:relative;white-space:nowrap;'
+        + (opts && opts.dim ? 'opacity:0.85;' : ''));
+      if (opts && opts.dot) {
+        const d = row.createSpan();
+        d.setAttribute('style', 'display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:7px;background:' + opts.dot + ';');
+      }
+      row.appendChild(document.createTextNode(label));
+      if (opts && opts.current) {
+        const c = row.createSpan({ text: '✓' });
+        c.setAttribute('style', MENU_CHECK_STYLE);
+      }
+      row.addEventListener('mouseenter', () => { row.style.background = 'rgba(255,255,255,0.09)'; });
+      row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });
+      return row;
+    };
+    const sep = () => {
+      const s = menu.createDiv();
+      s.setAttribute('style', 'height:1px;margin:4px 6px;background:rgba(255,255,255,0.12);');
+    };
+    const v = this._curViews();
+    const pick = (active) => { const nv = JSON.parse(JSON.stringify(v)); nv.active = active; this._setViews(nv); this._closeViewsMenu(); };
+    item('All sessions', { current: !v.active || v.active === 'all' }).addEventListener('click', () => pick('all'));
+    for (const gr of v.groups || [])
+      item(gr.name, { dot: gr.color || MODEL_FG, current: v.active === gr.id }).addEventListener('click', () => pick(gr.id));
+    sep();
+    item('New group…', { dim: true }).addEventListener('click', () => {
+      const nv = JSON.parse(JSON.stringify(v));
+      const used = new Set((nv.groups || []).map((g) => g.color));
+      const color = (this._palette || []).find((c) => !used.has(c)) || (this._palette || [])[0] || '#1EA1EB';
+      const gr = { id: 'g' + Date.now().toString(36), name: 'group ' + ((nv.groups || []).length + 1), color, members: [] };
+      nv.groups = (nv.groups || []).concat([gr]);
+      nv.active = gr.id;                     // a new group opens ACTIVE so its checkboxes take effect live
+      this._setViews(nv);
+      this._closeViewsMenu();
+      this._openViewsDialog(gr.id);
+    });
+    item('Edit sessions…', { dim: true }).addEventListener('click', () => {
+      this._closeViewsMenu();
+      this._openViewsDialog(v.active !== 'all' ? v.active : null);
+    });
+    sep();
+    // the two timeline display prefs, finally reachable in every host (they lived only in the web
+    // gear, whose settingsSync never reached the VS Code timeline and which Obsidian has no way to
+    // open) — written to the host app's own romp:settings, the store the view already re-reads
+    const flip = (key, cur) => {
+      let s = {}; try { s = JSON.parse(localStorage.getItem('romp:settings') || '{}') || {}; } catch (e) {}
+      s[key] = !cur;
+      try { localStorage.setItem('romp:settings', JSON.stringify(s)); } catch (e) {}
+      if (key === 'collapseGaps') this._collapseGaps = !cur;
+      if (key === 'activeOnly') this._activeOnly = !cur;
+      this.draw();
+      this._closeViewsMenu();
+    };
+    item('Collapse idle gaps', { current: !!this._collapseGaps, dim: true })
+      .addEventListener('click', () => flip('collapseGaps', this._collapseGaps));
+    item('Active sessions only', { current: !!this._activeOnly, dim: true })
+      .addEventListener('click', () => flip('activeOnly', this._activeOnly));
+    const h = this._menuHost(anchorEl.getBoundingClientRect());
+    h.doc.body.appendChild(menu);
+    menu.style.left = Math.max(6, Math.min(Math.round(h.rect.left), (h.win.innerWidth || 9999) - 220)) + 'px';
+    menu.style.top = Math.round(menuTop(h.rect, menu.offsetHeight || 0, h.win.innerHeight || 9999)) + 'px';
+    this._viewsMenu = menu;
+  }
+
+  // The sessions dialog: one checkbox per session. Editing a GROUP (gid) → checked means member;
+  // editing the all-view → checked means shown (unchecked = hidden from the timeline AND the chat
+  // strip: a background session). A centered card over the usual 0.55 dim, adopted into the topmost
+  // same-origin document like every timeline overlay — the whole dashboard dims on the web, the
+  // pane alone in a cross-origin host (VS Code), Obsidian's own window otherwise.
+  _openViewsDialog(gid) {
+    this._closeViewsDialog();
+    const back = document.body.createDiv();
+    back.setAttribute('style', 'position:fixed;inset:0;z-index:1002;background:rgba(0,0,0,0.55);'
+      + 'display:flex;align-items:center;justify-content:center;');
+    const card = back.createDiv();
+    card.setAttribute('style', 'width:min(430px,92vw);max-height:76vh;overflow:auto;padding:10px 12px;' + MENU_STYLE);
+    card.addEventListener('click', (e) => e.stopPropagation());
+    const build = () => {
+      card.textContent = '';
+      const v = this._curViews();
+      const gr = gid ? (v.groups || []).find((x) => x.id === gid) : null;
+      if (gid && !gr) { this._closeViewsDialog(); return; }   // the group was deleted elsewhere
+      const head = card.createDiv();
+      head.setAttribute('style', 'display:flex;align-items:center;gap:8px;margin:0 0 4px;');
+      if (gr) {
+        const nameIn = document.createElement('input');
+        nameIn.value = gr.name; nameIn.maxLength = 40;
+        nameIn.setAttribute('style', 'flex:1 1 auto;min-width:0;background:#1e1e1e;color:#ccc;'
+          + 'border:1px solid rgba(255,255,255,0.12);border-radius:5px;padding:3px 6px;font:inherit;');
+        nameIn.addEventListener('change', () => {
+          const nv = JSON.parse(JSON.stringify(this._curViews()));
+          const g2 = nv.groups.find((x) => x.id === gid); if (!g2) return;
+          g2.name = nameIn.value.slice(0, 40) || g2.name;
+          this._setViews(nv); build();
+        });
+        head.appendChild(nameIn);
+        const del = head.createSpan({ text: 'Delete' });
+        del.setAttribute('style', 'flex:0 0 auto;cursor:pointer;opacity:0.7;color:#F85B5A;');
+        del.addEventListener('click', () => {
+          const nv = JSON.parse(JSON.stringify(this._curViews()));
+          nv.groups = nv.groups.filter((x) => x.id !== gid);
+          if (nv.active === gid) nv.active = 'all';
+          this._setViews(nv); this._closeViewsDialog();
+        });
+      } else {
+        const ttl = head.createDiv({ text: 'Sessions' });
+        ttl.setAttribute('style', 'font-weight:650;');
+      }
+      if (gr) {
+        const sw = card.createDiv();
+        sw.setAttribute('style', 'display:flex;gap:6px;margin:2px 0 6px;flex-wrap:wrap;');
+        for (const c of (this._palette && this._palette.length ? this._palette : [gr.color || '#1EA1EB'])) {
+          const d = sw.createSpan();
+          d.setAttribute('style', 'width:16px;height:16px;border-radius:50%;cursor:pointer;background:' + c + ';'
+            + (c === gr.color ? 'outline:2px solid #ffffff;outline-offset:1px;' : 'opacity:0.75;'));
+          d.addEventListener('click', () => {
+            const nv = JSON.parse(JSON.stringify(this._curViews()));
+            const g2 = nv.groups.find((x) => x.id === gid); if (!g2) return;
+            g2.color = c; this._setViews(nv); build();
+          });
+        }
+      }
+      const sub = card.createDiv({ text: gr ? 'Checked sessions are in this group.'
+        : 'Unchecked sessions are hidden from the timeline and the chat tabs.' });
+      sub.setAttribute('style', 'opacity:0.6;font-size:0.82em;margin:0 0 6px;');
+      for (const s of (this.data && this.data.sessions) || []) {
+        const row = card.createDiv();
+        row.setAttribute('style', 'display:flex;align-items:center;gap:8px;padding:3px 4px;border-radius:4px;cursor:pointer;');
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.checked = gr ? (gr.members || []).indexOf(s.id) >= 0 : (v.hidden || []).indexOf(s.id) < 0;
+        cb.setAttribute('style', 'accent-color:#1EA1EB;margin:0;flex:0 0 auto;');
+        row.appendChild(cb);
+        const dot = row.createSpan();
+        dot.setAttribute('style', 'width:8px;height:8px;border-radius:50%;flex:0 0 auto;background:' + (s.color || MODEL_FG) + ';');
+        const nm = row.createSpan({ text: s.name || s.id.slice(0, 8) });
+        nm.setAttribute('style', 'min-width:0;overflow:hidden;text-overflow:ellipsis;' + (s.live ? '' : 'opacity:0.55;'));
+        const st = row.createSpan({ text: s.live ? (s.model || '') : 'gone' });
+        st.setAttribute('style', 'margin-left:auto;flex:0 0 auto;opacity:0.5;font-size:0.82em;');
+        const toggle = () => {
+          const nv = JSON.parse(JSON.stringify(this._curViews()));
+          if (gr) {
+            const g2 = nv.groups.find((x) => x.id === gid); if (!g2) return;
+            const i = (g2.members || []).indexOf(s.id);
+            if (i >= 0) g2.members.splice(i, 1); else (g2.members = g2.members || []).push(s.id);
+          } else {
+            const i = (nv.hidden || []).indexOf(s.id);
+            if (i >= 0) nv.hidden.splice(i, 1); else (nv.hidden = nv.hidden || []).push(s.id);
+          }
+          this._setViews(nv); build();                 // the dialog stays open and repaints in place
+        };
+        cb.addEventListener('click', (e) => { e.stopPropagation(); toggle(); });
+        row.addEventListener('click', (e) => { if (e.target !== cb) toggle(); });
+        row.addEventListener('mouseenter', () => { row.style.background = 'rgba(255,255,255,0.07)'; });
+        row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });
+      }
+    };
+    build();
+    const h = this._menuHost({ left: 0, top: 0, bottom: 0, right: 0 });
+    back.addEventListener('pointerdown', (e) => { if (e.target === back) this._closeViewsDialog(); });
+    const onKey = (e) => { if (e.key === 'Escape') { this._closeViewsDialog(); h.doc.removeEventListener('keydown', onKey); } };
+    h.doc.addEventListener('keydown', onKey);
+    h.doc.body.appendChild(back);
+    this._viewsDialog = back;
+  }
+
   _openLaneMenu(s, anchorEl) {
     const reopen = this._laneMenu && this._laneMenu._sid === s.id;
-    this._closeLaneMenu(); this._closeMetaMenu();
+    this._closeLaneMenu(); this._closeMetaMenu(); this._closeViewsMenu();
     if (reopen) return;
     // Styled inline like the meta menu (injectStyles can't add rules after a plugin reload) — the
     // shared menu vocabulary again (MENU_STYLE).
@@ -2501,12 +2774,15 @@ class TimelinePanel {
     const barsKnown = (s) => this._barsSeen.has(s.id)
       || !!(data.turns && Object.prototype.hasOwnProperty.call(data.turns, s.id));
     const active = (s) => (s.live && !this._activeOnly) || hasWork(s) || (s.live && !barsKnown(s));
-    let vis = data.sessions.filter(active);
+    // the VIEW filter first (the user 2026-08-18): the active view decides who is even a candidate;
+    // activeOnly then thins candidates. data.sessions stays complete for the sessions dialog.
+    const inView = (s) => viewVisible(this._curViews(), s.id);
+    let vis = data.sessions.filter(inView).filter(active);
     // …but never hide EVERYONE: with every lane idle in this window the filter would blank the whole
     // band — which reads as broken (the loading rule), and leaves no row space to grab-drag back out
     // of the quiet stretch (rowHit is the only mouse-pan surface). An all-quiet window falls back to
     // the live lanes (the old rule), so active-only only ever THINS a view that has activity to show.
-    if (this._activeOnly && !vis.length) vis = data.sessions.filter((s) => s.live || hasWork(s));
+    if (this._activeOnly && !vis.length) vis = data.sessions.filter(inView).filter((s) => s.live || hasWork(s));
     // while a row is being dragged, honor the transient drag order so the lanes shuffle live under
     // the cursor (data.sessions still holds the persisted order; _dragOrder overrides until drop).
     if (this._dragOrder) {
@@ -3357,6 +3633,7 @@ class TimelinePanel {
 
     // 🔒 lock-to-now padlock at the now-edge (replaces the old toolbar checkbox, the user 2026-06-26)
     this._drawLockToggle(svg, lockCx, axisY);
+    this._drawViewsTrigger(svg, axisY);
 
     // The svg is fully rebuilt above — restore the hover the rebuild just swallowed, so a tip under a
     // stationary cursor comes up at once instead of waiting for the next mouse move (see _rehover).
@@ -3474,4 +3751,4 @@ class TimelinePanel {
   body(s) { return s ? '<div class="b">' + s + '</div>' : ''; }
 }
 
-module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect };
+module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount };

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -46,6 +46,22 @@ function viewLabel(views) {
 function viewMoreCount(views, sessions) {
   return (sessions || []).filter((s) => s.live && !viewVisible(views, s.id)).length;
 }
+// the dialog's two checkbox mutations, pure (executed by tests; the dialog itself only wires DOM):
+// all-view → toggle the hidden bit; group view → toggle membership in that group alone
+function viewToggleHidden(views, id) {
+  const v = JSON.parse(JSON.stringify(views || {}));
+  const i = (v.hidden || []).indexOf(id);
+  if (i >= 0) v.hidden.splice(i, 1); else (v.hidden = v.hidden || []).push(id);
+  return v;
+}
+function viewToggleMember(views, gid, id) {
+  const v = JSON.parse(JSON.stringify(views || {}));
+  const g = (v.groups || []).find((x) => x.id === gid);
+  if (!g) return v;
+  const i = (g.members || []).indexOf(id);
+  if (i >= 0) g.members.splice(i, 1); else (g.members = g.members || []).push(id);
+  return v;
+}
 
 function _rompMatchesOnly(name, tag) {
   if (!tag) return true;
@@ -584,6 +600,7 @@ class TimelinePanel {
     this._pendingViewsAge = 0;   // pushes since the edit — the kernel is authoritative, so a stale pending yields
     this._viewsMenu = null;      // the Show-dropdown element, when open
     this._viewsDialog = null;    // the sessions/group dialog backdrop, when open
+    this._viewsDialogKey = null; // its Escape hook {doc, fn}, removed on every close path
     this._palette = [];          // group color choices (the kernel ships its palette on the payload)
     // "Collapse idle gaps" now lives in the SETTINGS dialog (romp:settings.collapseGaps), moved out of the
     // timeline toolbar (the user 2026-06-25). Read it fresh here + re-read on the 'storage' event so a toggle
@@ -2327,11 +2344,18 @@ class TimelinePanel {
     try {
       if (typeof window !== 'undefined' && typeof window.__rompTimelineSetViews === 'function') {
         window.__rompTimelineSetViews(v);
-      } else {
+      } else if (typeof process !== 'undefined' && process.versions && process.versions.electron) {
+        // Obsidian only — the Electron guard keeps a bare-node test run from ever touching the real
+        // file (the 2026-07-02 _persistOrder lesson). Resolve the state root the way the kernel does
+        // (ROMP_STATE_DIR, then XDG_STATE_HOME, then the default), write tmp+rename so a reader never
+        // sees a torn blob.
         const fs = require('fs'), os = require('os'), path = require('path');
-        const dir = path.join(os.homedir(), '.local', 'state', 'romp');
-        fs.mkdirSync(dir, { recursive: true });
-        fs.writeFileSync(path.join(dir, 'timeline-views.json'), JSON.stringify(v));
+        const root = process.env.ROMP_STATE_DIR
+          || path.join(process.env.XDG_STATE_HOME || path.join(os.homedir(), '.local', 'state'), 'romp');
+        fs.mkdirSync(root, { recursive: true });
+        const fp = path.join(root, 'timeline-views.json');
+        fs.writeFileSync(fp + '.tmp', JSON.stringify(v));
+        fs.renameSync(fp + '.tmp', fp);
       }
     } catch (e) { /* no host hook + no Node fs → session-local only */ }
     this.draw();
@@ -2341,10 +2365,13 @@ class TimelinePanel {
     const v = this._curViews();
     const g = (v.groups || []).find((x) => x.id === v.active);
     const more = viewMoreCount(v, (this.data && this.data.sessions) || []);
-    // ellipsize the view name so the trigger never crosses into the time labels: the gutter is all it owns
+    // ellipsize so the WHOLE trigger stays inside the gutter — measured on the full string (the
+    // 650-weight lane font over-measures the plain spans, which is the safe direction), because a
+    // fixed reserve under-counted "· NN more" and let the tail cross into the first time label
     let name = viewLabel(v);
-    const budget = Math.max(60, this.M.left - PADL - 78);   // room for "Show: ", the caret, and the count
-    while (name.length > 3 && this.labelWidth(name) > budget) name = name.slice(0, -2) + '…';
+    const tail = ' ▾' + (more ? ' · ' + more + ' more' : '');
+    const fits = (n) => this.labelWidth('Show: ' + n + tail) <= this.M.left - PADL - 6;
+    while (name.length > 3 && !fits(name)) name = name.slice(0, -2) + '…';
     const t = el('text', { x: PADL, y: axisY + 14, 'font-size': 12, 'font-family': FONT, fill: MODEL_FG });
     const lead = el('tspan', {}); lead.textContent = 'Show: '; t.appendChild(lead);
     const nm = el('tspan', { fill: (g && g.color) || '#cccccc', 'font-weight': 650 }); nm.textContent = name; t.appendChild(nm);
@@ -2356,7 +2383,14 @@ class TimelinePanel {
   }
 
   _closeViewsMenu() { if (this._viewsMenu) { this._viewsMenu.remove(); this._viewsMenu = null; } }
-  _closeViewsDialog() { if (this._viewsDialog) { this._viewsDialog.remove(); this._viewsDialog = null; } }
+  _closeViewsDialog() {
+    if (!this._viewsDialog) return;
+    this._viewsDialog.remove(); this._viewsDialog = null;
+    if (this._viewsDialogKey) {   // the Escape hook dies with the dialog on EVERY close path, not just Escape
+      try { this._viewsDialogKey.doc.removeEventListener('keydown', this._viewsDialogKey.fn); } catch (e) {}
+      this._viewsDialogKey = null;
+    }
+  }
 
   _openViewsMenu(anchorEl) {
     const reopen = !!this._viewsMenu;
@@ -2507,16 +2541,9 @@ class TimelinePanel {
         const st = row.createSpan({ text: s.live ? (s.model || '') : 'gone' });
         st.setAttribute('style', 'margin-left:auto;flex:0 0 auto;opacity:0.5;font-size:0.82em;');
         const toggle = () => {
-          const nv = JSON.parse(JSON.stringify(this._curViews()));
-          if (gr) {
-            const g2 = nv.groups.find((x) => x.id === gid); if (!g2) return;
-            const i = (g2.members || []).indexOf(s.id);
-            if (i >= 0) g2.members.splice(i, 1); else (g2.members = g2.members || []).push(s.id);
-          } else {
-            const i = (nv.hidden || []).indexOf(s.id);
-            if (i >= 0) nv.hidden.splice(i, 1); else (nv.hidden = nv.hidden || []).push(s.id);
-          }
-          this._setViews(nv); build();                 // the dialog stays open and repaints in place
+          this._setViews(gr ? viewToggleMember(this._curViews(), gid, s.id)
+                            : viewToggleHidden(this._curViews(), s.id));
+          build();                                     // the dialog stays open and repaints in place
         };
         cb.addEventListener('click', (e) => { e.stopPropagation(); toggle(); });
         row.addEventListener('click', (e) => { if (e.target !== cb) toggle(); });
@@ -2527,8 +2554,9 @@ class TimelinePanel {
     build();
     const h = this._menuHost({ left: 0, top: 0, bottom: 0, right: 0 });
     back.addEventListener('pointerdown', (e) => { if (e.target === back) this._closeViewsDialog(); });
-    const onKey = (e) => { if (e.key === 'Escape') { this._closeViewsDialog(); h.doc.removeEventListener('keydown', onKey); } };
+    const onKey = (e) => { if (e.key === 'Escape') this._closeViewsDialog(); };
     h.doc.addEventListener('keydown', onKey);
+    this._viewsDialogKey = { doc: h.doc, fn: onKey };
     h.doc.body.appendChild(back);
     this._viewsDialog = back;
   }
@@ -3751,4 +3779,4 @@ class TimelinePanel {
   body(s) { return s ? '<div class="b">' + s + '</div>' : ''; }
 }
 
-module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount };
+module.exports = { TimelinePanel, badgeFor, roundedPath, crossX, workAnchorOf, idleGaps, fmtSpan, dotLit, barLit, interpNow, shouldReanchorEdge, reanchorEdge, isFreshNowSample, barEndT, dragAxis, stripRompMarks, collapseRepeat, reqText, menuTop, offsetRect, viewVisible, viewLabel, viewMoreCount, viewToggleHidden, viewToggleMember };

--- a/ui/timeline-dismiss.test.ts
+++ b/ui/timeline-dismiss.test.ts
@@ -80,5 +80,5 @@ test("the click holds the sid, and update() re-applies it on every push", () => 
   assert.match(SRC, /this\._dismissed\.add\(s\.id\);/);              // click site
   assert.match(SRC, /this\._reconcileDismissed\(\);/);               // called from update()
   // ...right after the wholesale replace that used to undo the optimistic removal
-  assert.match(SRC, /this\.data = data;[\s\S]{0,400}?this\._reconcileDismissed\(\);/);
+  assert.match(SRC, /this\.data = data;[\s\S]{0,700}?this\._reconcileDismissed\(\);/);
 });

--- a/ui/timeline-flags.test.ts
+++ b/ui/timeline-flags.test.ts
@@ -60,8 +60,8 @@ test("menu rows toggle with the SAME optimistic + sticky + reconcile-before-draw
 
 test("the gear menu closes on outside click / Escape / teardown, alongside the meta menu", () => {
   assert.match(SRC, /_closeLaneMenu\(\) \{ if \(this\._laneMenu\) \{ this\._laneMenu\.remove\(\); this\._laneMenu = null; \} \}/);
-  assert.match(SRC, /this\._onDocClick = \(\) => \{ this\._closeMetaMenu\(\); this\._closeLaneMenu\(\); \};/);
-  assert.match(SRC, /if \(e\.key === 'Escape'\) \{ this\._closeMetaMenu\(\); this\._closeLaneMenu\(\); \}/);
+  assert.match(SRC, /this\._onDocClick = \(\) => \{ this\._closeMetaMenu\(\); this\._closeLaneMenu\(\); this\._closeViewsMenu\(\); \};/);
+  assert.match(SRC, /if \(e\.key === 'Escape'\) \{ this\._closeMetaMenu\(\); this\._closeLaneMenu\(\); this\._closeViewsMenu\(\); \}/);
 });
 
 test("the icon drawers survive (they render inside the menu now): ON = romp blue, OFF = slashed gray", () => {
@@ -81,7 +81,7 @@ test("setSessionFlag still posts via the web host hook, with a Node-fs fallback 
 
 test("the sticky-flag machinery survives: pendingFlags reconcile on every update (no flicker-back)", () => {
   assert.match(SRC, /this\._pendingFlags = \{\};/);
-  assert.match(SRC, /this\.data = data;\s*\n(?:[^\n]*\n)?\s*this\._reconcilePendingFlags\(\);/);
+  assert.match(SRC, /this\.data = data;\s*\n(?:[^\n]*\n){0,4}\s*this\._reconcilePendingFlags\(\);/);
   assert.match(SRC, /_reconcilePendingFlags\(\) \{[\s\S]*?if \(s\[flag\] === p\[flag\]\) delete p\[flag\];[\s\S]*?else s\[flag\] = p\[flag\];/);
 });
 

--- a/ui/timeline-menu-place.test.ts
+++ b/ui/timeline-menu-place.test.ts
@@ -34,7 +34,7 @@ test("a band shorter than the menu clamps the top on-screen instead of vanishing
 test("both the lane gear menu and the model/effort menu place through menuTop", () => {
   // the fix must cover BOTH fixed-position drop-downs; a bare `r.bottom + 4` is the bug's signature
   const opens = SRC.match(/menu\.style\.top = Math\.round\(menuTop\(h\.rect, menu\.offsetHeight \|\| 0, h\.win\.innerHeight \|\| 9999\)\)/g) || [];
-  assert.equal(opens.length, 2, "expected _openMetaMenu and _openLaneMenu to both use menuTop");
+  assert.equal(opens.length, 3, "expected _openMetaMenu, _openLaneMenu and _openViewsMenu to all use menuTop");
   assert.doesNotMatch(SRC, /menu\.style\.top = Math\.round\(r\.bottom \+ 4\)/);
 });
 
@@ -58,7 +58,7 @@ test("offsetRect translates a pane-local anchor by each intervening frame's offs
 
 test("both menus append into the host document and read the host viewport", () => {
   const appends = SRC.match(/h\.doc\.body\.appendChild\(menu\)/g) || [];
-  assert.equal(appends.length, 2, "expected _openMetaMenu and _openLaneMenu to adopt into the host doc");
+  assert.equal(appends.length, 3, "expected _openMetaMenu, _openLaneMenu and _openViewsMenu to adopt into the host doc");
   assert.match(SRC, /_menuHost\(anchorRect\)[\s\S]*?offsetRect\(anchorRect, frames\)/);
   // the host page shows the menu now, so its clicks/Escape must close it (with pagehide cleanup)
   assert.match(SRC, /tipDoc\.addEventListener\('click', this\._onDocClick\)/);

--- a/ui/timeline-render.test.ts
+++ b/ui/timeline-render.test.ts
@@ -264,7 +264,7 @@ test("an ALL-quiet window falls back to the live lanes — never a blank, un-gra
   panel.draw();
   assert.equal(panel._vis.length, 2, "both LIVE lanes stand in an all-quiet window");
   const src = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
-  assert.match(src, /if \(this\._activeOnly && !vis\.length\) vis = data\.sessions\.filter\(\(s\) => s\.live \|\| hasWork\(s\)\)/);
+  assert.match(src, /if \(this\._activeOnly && !vis\.length\) vis = data\.sessions\.filter\(inView\)\.filter\(\(s\) => s\.live \|\| hasWork\(s\)\)/);
 });
 
 test("the active-only flag rides romp:settings like collapseGaps (source pins)", () => {

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -1,0 +1,96 @@
+// The timeline's corner control panel (the user 2026-08-18): "Show: <view> ▾ · N more" in the
+// bottom-left corner — the strip under the lane gutter, left of the time labels. The dropdown picks
+// the active VIEW (All sessions / named groups), holds New group… / Edit sessions…, and carries the
+// two timeline display toggles (collapse idle gaps, active only) so they finally work in every host.
+// The dialog is one checkbox per session: unchecked in the all-view = hidden from the timeline AND
+// the chat strip (a background session); checked in a group = member. House pattern: execute the
+// pure helpers + reconcile on a bare prototype, regex-pin the SVG/menu wiring.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+const requireCjs = createRequire(__filename);
+const VIEW_PATH = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
+const SRC = fs.readFileSync(VIEW_PATH, "utf8");
+const { TimelinePanel, viewVisible, viewLabel, viewMoreCount } = requireCjs(VIEW_PATH);
+
+const G = { id: "g1", name: "pool", color: "#DD42FF", members: ["s2", "s3"] };
+const V = (active: string, hidden: string[] = [], groups: any[] = [G]) => ({ active, hidden, groups });
+
+test("executed: the all-view hides the hidden set; a group shows exactly its members", () => {
+  assert.equal(viewVisible(null, "s1"), true, "no blob yet → everything shows");
+  assert.equal(viewVisible(V("all", ["s2"]), "s2"), false);
+  assert.equal(viewVisible(V("all", ["s2"]), "s1"), true);
+  assert.equal(viewVisible(V("g1", ["s2"]), "s2"), true, "membership beats the hidden bit");
+  assert.equal(viewVisible(V("g1"), "s1"), false, "a group shows exactly its members");
+  assert.equal(viewVisible(V("ghost", [], []), "s1"), true, "an orphaned active falls back open");
+});
+
+test("executed: the trigger label and the N-more cue (live sessions outside the view)", () => {
+  assert.equal(viewLabel(null), "All");
+  assert.equal(viewLabel(V("g1")), "pool");
+  const sessions = [{ id: "s1", live: true }, { id: "s2", live: true }, { id: "s4", live: false }];
+  assert.equal(viewMoreCount(V("g1"), sessions), 1, "s1 is live and outside; dead s4 never counts");
+  assert.equal(viewMoreCount(V("all", ["s1", "s4"]), sessions), 1, "hidden live s1 counts; hidden dead s4 does not");
+});
+
+test("executed: an optimistic edit holds until the kernel echoes it — then yields to authority", () => {
+  const p: any = Object.create(TimelinePanel.prototype);
+  p._views = null; p._pendingViews = V("g1"); p._pendingViewsAge = 0;
+  p._reconcileViews();
+  assert.ok(p._pendingViews, "no echo yet → still pending");
+  // the kernel echoes the same shape with re-sorted lists → canonical comparison clears it
+  p._views = { active: "g1", hidden: [], groups: [{ id: "g1", name: "pool", color: "#DD42FF", members: ["s3", "s2"] }] };
+  p._reconcileViews();
+  assert.equal(p._pendingViews, null, "echo match (order-insensitive) clears the pending edit");
+  // a pending edit the kernel never echoes yields after three pushes — the kernel is authoritative
+  p._pendingViews = V("g1"); p._pendingViewsAge = 0;
+  p._views = { active: "all", hidden: [], groups: [] };
+  p._reconcileViews(); p._reconcileViews();
+  assert.ok(p._pendingViews, "two silent pushes → still holding");
+  p._reconcileViews();
+  assert.equal(p._pendingViews, null, "the third silent push adopts the kernel's blob");
+});
+
+test("the lane gate composes the view filter first, and the all-quiet fallback respects it", () => {
+  assert.match(SRC, /const inView = \(s\) => viewVisible\(this\._curViews\(\), s\.id\);/);
+  assert.match(SRC, /let vis = data\.sessions\.filter\(inView\)\.filter\(active\);/);
+  assert.match(SRC, /if \(this\._activeOnly && !vis\.length\) vis = data\.sessions\.filter\(inView\)\.filter\(\(s\) => s\.live \|\| hasWork\(s\)\);/,
+    "the fallback can never resurrect a view-hidden lane");
+});
+
+test("the trigger sits in the corner strip and opens on pointerdown, like every timeline control", () => {
+  assert.match(SRC, /_drawViewsTrigger\(svg, axisY\);/);
+  assert.match(SRC, /lead\.textContent = 'Show: ';/);
+  assert.match(SRC, /t\.addEventListener\('pointerdown', \(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); this\._openViewsMenu\(t\); \}\);/);
+  assert.match(SRC, /' · ' \+ more \+ ' more';/, "a filtered-out live session is always one glance away");
+});
+
+test("the dropdown and dialog wear the shared menu vocabulary and adopt into the menu host", () => {
+  assert.match(SRC, /'position:fixed;z-index:1001;min-width:200px;' \+ MENU_STYLE/);
+  assert.match(SRC, /c\.setAttribute\('style', MENU_CHECK_STYLE\);/, "the ✓-in-circle current mark");
+  assert.match(SRC, /'position:fixed;inset:0;z-index:1002;background:rgba\(0,0,0,0\.55\);'/,
+    "the one modal dim, over the topmost same-origin document");
+  assert.match(SRC, /const h = this\._menuHost\(anchorEl\.getBoundingClientRect\(\)\);[\s\S]{0,400}this\._viewsMenu = menu;/);
+});
+
+test("the two display toggles write the host's own romp:settings — reachable in every host now", () => {
+  assert.match(SRC, /item\('Collapse idle gaps', \{ current: !!this\._collapseGaps, dim: true \}\)/);
+  assert.match(SRC, /item\('Active sessions only', \{ current: !!this\._activeOnly, dim: true \}\)/);
+  assert.match(SRC, /localStorage\.setItem\('romp:settings', JSON\.stringify\(s\)\);/);
+});
+
+test("_setViews posts through the host hook with the Obsidian file fallback, optimistic + sticky", () => {
+  assert.match(SRC, /window\.__rompTimelineSetViews === 'function'/);
+  assert.match(SRC, /timeline-views\.json'\), JSON\.stringify\(v\)\);/);
+  assert.match(SRC, /this\._pendingViews = v; this\._pendingViewsAge = 0;/);
+  assert.match(SRC, /this\._reconcileViews\(\);\s*\/\/ \.\.\.and an optimistic view edit/);
+});
+
+test("the views menu closes with its siblings on outside click / Escape / pagehide", () => {
+  assert.match(SRC, /this\._onDocClick = \(\) => \{ this\._closeMetaMenu\(\); this\._closeLaneMenu\(\); this\._closeViewsMenu\(\); \};/);
+  assert.match(SRC, /if \(e\.key === 'Escape'\) \{ this\._closeMetaMenu\(\); this\._closeLaneMenu\(\); this\._closeViewsMenu\(\); \}/);
+  assert.match(SRC, /this\._closeViewsMenu\(\); this\._closeViewsDialog\(\);/, "pagehide drops both overlays");
+});

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -14,7 +14,7 @@ import { createRequire } from "node:module";
 const requireCjs = createRequire(__filename);
 const VIEW_PATH = path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js");
 const SRC = fs.readFileSync(VIEW_PATH, "utf8");
-const { TimelinePanel, viewVisible, viewLabel, viewMoreCount } = requireCjs(VIEW_PATH);
+const { TimelinePanel, viewVisible, viewLabel, viewMoreCount, viewToggleHidden, viewToggleMember } = requireCjs(VIEW_PATH);
 
 const G = { id: "g1", name: "pool", color: "#DD42FF", members: ["s2", "s3"] };
 const V = (active: string, hidden: string[] = [], groups: any[] = [G]) => ({ active, hidden, groups });
@@ -82,11 +82,30 @@ test("the two display toggles write the host's own romp:settings — reachable i
   assert.match(SRC, /localStorage\.setItem\('romp:settings', JSON\.stringify\(s\)\);/);
 });
 
-test("_setViews posts through the host hook with the Obsidian file fallback, optimistic + sticky", () => {
+test("_setViews posts through the host hook with a GUARDED, atomic Obsidian fallback", () => {
   assert.match(SRC, /window\.__rompTimelineSetViews === 'function'/);
-  assert.match(SRC, /timeline-views\.json'\), JSON\.stringify\(v\)\);/);
+  // Electron-gated (a bare-node test run must never touch the real file — the 2026-07-02 lesson),
+  // env-aware state root, tmp+rename so a reader never sees a torn blob
+  assert.match(SRC, /process\.versions && process\.versions\.electron/);
+  assert.match(SRC, /process\.env\.ROMP_STATE_DIR\n?\s*\|\| path\.join\(process\.env\.XDG_STATE_HOME \|\| path\.join\(os\.homedir\(\), '\.local', 'state'\), 'romp'\)/);
+  assert.match(SRC, /fs\.renameSync\(fp \+ '\.tmp', fp\);/);
   assert.match(SRC, /this\._pendingViews = v; this\._pendingViewsAge = 0;/);
   assert.match(SRC, /this\._reconcileViews\(\);\s*\/\/ \.\.\.and an optimistic view edit/);
+});
+
+test("executed: the dialog's two checkbox mutations, pure", () => {
+  const v = { active: "all", hidden: ["a"], groups: [{ id: "g1", members: ["m"] }] };
+  assert.deepEqual(viewToggleHidden(v, "a").hidden, [], "unhide");
+  assert.deepEqual(viewToggleHidden(v, "b").hidden, ["a", "b"], "hide");
+  assert.deepEqual(viewToggleMember(v, "g1", "m").groups[0].members, [], "leave");
+  assert.deepEqual(viewToggleMember(v, "g1", "n").groups[0].members, ["m", "n"], "join");
+  assert.deepEqual(viewToggleMember(v, "ghost", "n"), v, "an unknown group mutates nothing");
+});
+
+test("the trigger measures its WHOLE string against the gutter, and the dialog's Escape hook dies on every close", () => {
+  assert.match(SRC, /const fits = \(n\) => this\.labelWidth\('Show: ' \+ n \+ tail\) <= this\.M\.left - PADL - 6;/);
+  assert.match(SRC, /this\._viewsDialogKey = \{ doc: h\.doc, fn: onKey \};/);
+  assert.match(SRC, /this\._viewsDialogKey\.doc\.removeEventListener\('keydown', this\._viewsDialogKey\.fn\);/);
 });
 
 test("the views menu closes with its siblings on outside click / Escape / pagehide", () => {

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -541,6 +541,7 @@ export class FederationManager {
   private conns = new Map<string, Conn>();
   private perHostOrder: Record<string, string[]> = {};
   private perHostTabs: Record<string, any[]> = {};
+  private localViews: any = null;   // the LOCAL kernel's session-views blob, carried on merged tabOrder re-emits
   private perHostSids: Record<string, Set<string>> = {};
   private perHostFeed: Record<string, any> = {}; // last feed snapshot per host — merged so they don't clobber
   private perHostTl: Record<string, any> = {}; //   last timeline lanes payload ({type:"data"}.data) per host
@@ -597,6 +598,11 @@ export class FederationManager {
       const prevTabs = this.perHostTabs[host] || [];
       this.perHostOrder[host] = Array.isArray(m.order) ? m.order.filter((x: any) => typeof x === "string") : [];
       this.perHostTabs[host] = Array.isArray(m.tabs) ? m.tabs : [];
+      // session VIEWS (the user 2026-08-18): the blob is the LOCAL kernel's viewer pref (ids arrive
+      // host-prefixed inside it already) — remote kernels' copies are their own dashboards' prefs.
+      // Without this passthrough the merged re-emit silently dropped the field and the browser
+      // dashboard's chat never learned the views at all.
+      if (host === LOCAL && m.views && typeof m.views === "object") this.localViews = m.views;
       this.ensureHost(host);
       this.absorbHostReport(host, prevOrder, prevTabs);   // a host just reported its sessions → the one
       this.emitMergedOrder();                             //   moment the stored arrangement may be touched
@@ -679,7 +685,7 @@ export class FederationManager {
   private emitMergedOrder(): void {
     const order = mergeHostOrder(this.perHostOrder, this.hostSeq, this.view());
     const tabs = this.hostSeq.flatMap((h) => this.perHostTabs[h] || []);
-    window.dispatchEvent(new MessageEvent("message", { data: { type: "tabOrder", order, tabs } }));
+    window.dispatchEvent(new MessageEvent("message", { data: { type: "tabOrder", order, tabs, views: this.localViews ?? undefined } }));
   }
 
   // Fold a host's OWN report — the one moment with fresh evidence about what exists — into the stored

--- a/ui/webview/only-filter.test.ts
+++ b/ui/webview/only-filter.test.ts
@@ -77,7 +77,7 @@ test("a filtered view re-points the CHAT BODY, not just the tab bar", () => {
   // whole point of the filter is a clean recording frame, so the selection must follow it.
   // the re-point covers BOTH filters since session views landed (2026-08-18): a hidden or
   // filtered-out active session must not keep its transcript on screen
-  assert.match(RENDER, /if \(activeId && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/);
+  assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/);
   assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next\) setActive\(next\); \}, 0\);/);
 });
 

--- a/ui/webview/only-filter.test.ts
+++ b/ui/webview/only-filter.test.ts
@@ -67,7 +67,7 @@ test("the timeline's standalone helper splits the tag the same way", () => {
 
 test("chat tabs filter by the #only tag", () => {
   assert.match(RENDER, /import \{ onlyTag, matchesOnly \} from "\.\/only-filter";/);
-  assert.match(RENDER, /const visibleIds = only \? ids\.filter\(\(id\) => matchesOnly\(nameOf\(id\), only\)\) : ids;/);
+  assert.match(RENDER, /const visibleIds = only \? inViewIds\.filter\(\(id\) => matchesOnly\(nameOf\(id\), only\)\) : inViewIds;/);
   assert.match(RENDER, /for \(const id of visibleIds\)/);
 });
 
@@ -75,7 +75,9 @@ test("a filtered view re-points the CHAT BODY, not just the tab bar", () => {
   // the filter hid a non-matching TAB but left its transcript rendering — a real session's chat
   // (nimbus) sat in a `#only=api,tests,web` frame, statusline and all (the user 2026-07-16). The
   // whole point of the filter is a clean recording frame, so the selection must follow it.
-  assert.match(RENDER, /if \(only && activeId && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/);
+  // the re-point covers BOTH filters since session views landed (2026-08-18): a hidden or
+  // filtered-out active session must not keep its transcript on screen
+  assert.match(RENDER, /if \(activeId && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/);
   assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next\) setActive\(next\); \}, 0\);/);
 });
 

--- a/ui/webview/picker-running.test.ts
+++ b/ui/webview/picker-running.test.ts
@@ -21,7 +21,7 @@ test("the + (open) flow hides already-open tabs and splits Running vs Recent", (
   assert.match(RENDER, /const rest = avail\.filter\(\(it\) => !it\.running\);/);
   // running group first, with a header; then Recent (only when there was a running group above)
   assert.match(RENDER, /if \(running\.length\) \{ list\.appendChild\(label\("Running — reopen"\)\);/);
-  assert.match(RENDER, /if \(rest\.length\) \{ if \(running\.length\) list\.appendChild\(label\("Recent"\)\);/);
+  assert.match(RENDER, /if \(rest\.length\) \{ if \(running\.length \|\| hidden\.length\) list\.appendChild\(label\("Recent"\)\);/);
 });
 
 test("PICK mode still shows every session, open or not", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -448,10 +448,14 @@ const CLOSE_ACK_MS = 15_000;
 let sessionViews: SessionViews | null = null;
 let pendingSessionViews: SessionViews | null = null;
 let pendingViewsAge = 0;
+let allHiddenBlanked = false;   // the active transcript was blanked because EVERY session is view-hidden
 function effViews(): SessionViews | null { return pendingSessionViews ?? sessionViews; }
-function captureViews(v: SessionViews) {
-  sessionViews = v;
-  if (pendingSessionViews && (viewsKey(v) === viewsKey(pendingSessionViews) || ++pendingViewsAge >= 3)) {
+function captureViews(v: SessionViews | null) {
+  if (v) sessionViews = v;
+  // v null = a tabOrder frame WITHOUT the blob (an older kernel in a mixed-version mesh): it still
+  // ages a pending edit, or the optimistic state would fake success forever against a kernel that
+  // will never confirm it
+  if (pendingSessionViews && ((v && viewsKey(v) === viewsKey(pendingSessionViews)) || ++pendingViewsAge >= 3)) {
     pendingSessionViews = null; pendingViewsAge = 0;
   }
 }
@@ -3949,7 +3953,7 @@ function makePlaceholderTab(id: string): HTMLElement {
 // The empty transcript case was already handled with a "No messages yet." placeholder; this is its
 // missing sibling, one level up: no sessions rather than no messages. Saying so also beats a spinner —
 // it tells a new user the pane is working and what to do next.
-function syncNoSessionsPlaceholder(visibleCount: number) {
+function syncNoSessionsPlaceholder(visibleCount: number, totalCount = 0) {
   const content = document.getElementById("content");
   if (!content) return;
   const existing = document.getElementById("no-sessions");
@@ -3957,10 +3961,14 @@ function syncNoSessionsPlaceholder(visibleCount: number) {
     existing?.remove();               // a session arrived → the real view takes over
     return;
   }
-  if (existing) return;               // idempotent: renderTabs runs on every push
+  // sessions exist but the active view hides them all — say THAT, not "no sessions yet"
+  const txt = totalCount > 0
+    ? "Every session is hidden from this view. Reveal one from the + picker, or switch views on the timeline's Show menu."
+    : "No sessions yet. Start one with  romp new <name>  or the + above.";
+  if (existing) { existing.textContent = txt; return; }   // idempotent: renderTabs runs on every push
   const ph = el("div", "tx-empty");
   ph.id = "no-sessions";
-  ph.textContent = "No sessions yet. Start one with  romp new <name>  or the + above.";
+  ph.textContent = txt;
   content.appendChild(ph);
 }
 
@@ -4018,7 +4026,7 @@ function renderTabs() {
   // found while shooting the demo, with nimbus's transcript filling a "filtered" frame. Re-point the
   // selection at the first visible session. Deferred so we never re-enter the render we're inside;
   // setActive is a no-op once activeId is visible, so this settles in one pass.
-  if (activeId && !visibleIds.includes(activeId) && visibleIds.length) {
+  if (activeId && ids.includes(activeId) && !visibleIds.includes(activeId) && visibleIds.length) {
     const next = visibleIds[0];
     setTimeout(() => { if (activeId !== next) setActive(next); }, 0);
   }
@@ -4154,7 +4162,16 @@ function renderTabs() {
   bar.appendChild(add);
   // Restore tab-mode focus if a tab held it before this rebuild (see the top of renderTabs).
   if (refocusTab) focusActiveTab();
-  syncNoSessionsPlaceholder(visibleIds.length);
+  syncNoSessionsPlaceholder(visibleIds.length, ids.length);
+  // Hiding the LAST visible session must also blank its transcript: a strip with no tabs cannot sit
+  // over a hidden session's live chat (the ghost would show exactly what the hide asked to put away).
+  // Restored the moment anything is visible again — the placeholder owns the empty state meanwhile.
+  if (activeId) {
+    const av = views.get(activeId);
+    const blank = !visibleIds.length && ids.length > 0 && !tabInView(activeId);
+    if (av && blank && av.el.style.display !== "none") { av.el.style.display = "none"; allHiddenBlanked = true; }
+    else if (av && !blank && allHiddenBlanked) { av.el.style.display = ""; allHiddenBlanked = false; }
+  }
   // (The Fleet toggle that briefly lived here as a tab-bar pill was removed 2026-06-24: Fleet/Chat are now
   // the rotated toggles in the chat pane's vertical strip — see _LANDING_FLEET_JS — so the pill was redundant.)
   // (The collapse caret moved OFF the tab bar into the #ledger strip's title row — the strip now always
@@ -10250,7 +10267,7 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "ledger") setLedger(m.id, m.ledger ?? null);
   else if (m.type === "working") { workingSet = new Set(Array.isArray(m.names) ? m.names : []); refreshPostalDots(); }
   else if (m.type === "imgData" && typeof m.path === "string") onImgData(m.path, typeof m.url === "string" ? m.url : null);
-  else if (m.type === "tabOrder") { if (m.views) captureViews(m.views); applyTabOrder(m.order, m.tabs); }
+  else if (m.type === "tabOrder") { captureViews(m.views || null); applyTabOrder(m.order, m.tabs); }
   else if (m.type === "renamed" && m.id && typeof m.name === "string") {
     const s = sessions.get(m.id);
     if (s && s.name !== m.name) { s.name = m.name; renderTabs(); }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -14,6 +14,7 @@ import yaml from "highlight.js/lib/languages/yaml";
 import type { ParsedAsk } from "../ask-types";
 import { quoteReply } from "../quote";
 import { TABBAR_H_KEY, TABBAR_H_DEFAULT, clampTabbarH, parseTabbarH } from "./tabbar-resize";
+import { SessionViews, viewVisible, viewsKey, hideIn, revealIn } from "./session-views";
 import { markerLabel, dayContext } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
 import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompSettings } from "./settings";
@@ -438,6 +439,31 @@ const CLOSE_ACK_MS = 15_000;
 // The romp identity palette for the tab right-click color picker (the user 2026-06-29). Fetched once from the
 // kernel's /palette so the client holds no color literals; empty until it lands (the menu just omits the row).
 // The palette is SELECTABLE now (the user 2026-07-12): a {type:"palette"} push lands the new set on switch.
+// ── session views (the user 2026-08-18): the kernel's views blob gates which sessions get TABS.
+// A hidden session is a BACKGROUND session — still running, judged and carded; the + picker lists it
+// under "Hidden" and the timeline's corner panel counts it, so it is always one glance away.
+// Captured from every tabOrder push; a local gesture (hide from the tab menu, reveal from the
+// picker) applies optimistically and holds sticky until a push echoes it — yielding to the kernel
+// after three silent pushes, the same machinery the timeline's copy runs.
+let sessionViews: SessionViews | null = null;
+let pendingSessionViews: SessionViews | null = null;
+let pendingViewsAge = 0;
+function effViews(): SessionViews | null { return pendingSessionViews ?? sessionViews; }
+function captureViews(v: SessionViews) {
+  sessionViews = v;
+  if (pendingSessionViews && (viewsKey(v) === viewsKey(pendingSessionViews) || ++pendingViewsAge >= 3)) {
+    pendingSessionViews = null; pendingViewsAge = 0;
+  }
+}
+function postViews(v: SessionViews) {
+  pendingSessionViews = v; pendingViewsAge = 0;
+  if (vscodeApi) vscodeApi.postMessage({ type: "setTimelineViews", views: v });
+  renderTabs();
+}
+function tabInView(id: string): boolean { return viewVisible(effViews(), id); }
+function visibleOrder(): string[] { return order.filter(tabInView); }
+function revealSession(id: string) { postViews(revealIn(effViews(), id)); }
+
 let paletteColors: string[] = [];
 fetch(kernelUrl("/palette"), { cache: "no-store" }).then((r) => r.json())
   .then((d) => { if (Array.isArray(d.colors)) paletteColors = d.colors; }).catch(() => { /* menu omits the swatch row */ });
@@ -3982,14 +4008,17 @@ function renderTabs() {
   // real sessions keep running, just hidden from this view. No tag → visibleIds === ids (unchanged).
   const only = onlyTag();
   const nameOf = (id: string) => sessions.get(id)?.name ?? tabMeta.get(id)?.name ?? "";
-  const visibleIds = only ? ids.filter((id) => matchesOnly(nameOf(id), only)) : ids;
+  // the session VIEWS filter composes here too (the user 2026-08-18): a view-hidden session keeps
+  // its state, drafts and cached transcript — it just loses its tab until revealed
+  const inViewIds = ids.filter(tabInView);
+  const visibleIds = only ? inViewIds.filter((id) => matchesOnly(nameOf(id), only)) : inViewIds;
   // ...and it must govern the CHAT BODY too, not just the bar (the user 2026-07-16). Hiding a
   // non-matching TAB while its transcript keeps rendering leaks precisely what the filter exists to
   // hide: a real session's chat sitting on screen under `#only=api,tests,web`, statusline and all —
   // found while shooting the demo, with nimbus's transcript filling a "filtered" frame. Re-point the
   // selection at the first visible session. Deferred so we never re-enter the render we're inside;
   // setActive is a no-op once activeId is visible, so this settles in one pass.
-  if (only && activeId && !visibleIds.includes(activeId) && visibleIds.length) {
+  if (activeId && !visibleIds.includes(activeId) && visibleIds.length) {
     const next = visibleIds[0];
     setTimeout(() => { if (activeId !== next) setActive(next); }, 0);
   }
@@ -4291,6 +4320,19 @@ function showTabMenu(e: MouseEvent, id: string) {
     onBell ? "Stop notifying" : "Notify me",
     onBell ? "no more system notifications for this session" : "system notification when its work blocks on you or completes",
     () => setSessionFlag(id, "notify", !onBell));
+  // Background the session (the user 2026-08-18): out of the tab strip AND the timeline lanes — it
+  // keeps running, judged and carded; the + picker lists it under "Hidden — reveal" and the
+  // timeline's corner panel counts it. Same views blob the timeline dialog edits. A plain item, not
+  // a toggle: its undo lives where the hidden session lives (the picker, the timeline panel).
+  {
+    const hide = el("div", "ctx-item ctx-item-toggle");
+    const bodyEl = el("span", "ctx-item-body");
+    const l = el("span", "ctx-item-label"); l.textContent = "Hide from chat & timeline"; bodyEl.appendChild(l);
+    const sb = el("span", "ctx-item-sub"); sb.textContent = "background it — the + picker and the feed still surface it"; bodyEl.appendChild(sb);
+    hide.appendChild(bodyEl);
+    hide.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); postViews(hideIn(effViews(), id)); });
+    menu.appendChild(hide);
+  }
   // Billing submenu (the user 2026-08-09, who wants the login/API-key switch here rather than as a
   // statusline badge). Only when the machine offers BOTH choices (st.authBoth) — a one-auth machine
   // keeps the fact on the tab hover, never a dead selector — and the key stays labelled plainly
@@ -4438,10 +4480,11 @@ function onTabKey(e: KeyboardEvent) {
   if (!activeId || !order.length) return;
   if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
     e.preventDefault();
-    const i = order.indexOf(activeId);
+    const ord = visibleOrder();                 // never cycle onto a view-hidden session
+    const i = ord.indexOf(activeId);
     if (i < 0) return;
     const dir = e.key === "ArrowRight" ? 1 : -1;
-    setActive(order[(i + dir + order.length) % order.length]);
+    setActive(ord[(i + dir + ord.length) % ord.length]);
     focusActiveTab();
   } else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
     e.preventDefault();
@@ -4498,11 +4541,12 @@ window.addEventListener("keydown", (e) => {
   if (document.querySelector(".picker-overlay")) return;   // #picker / #confirm open
   if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
     if (!activeId || order.length < 2) return;
-    const i = order.indexOf(activeId);
+    const ord = visibleOrder();                 // never cycle onto a view-hidden session
+    const i = ord.indexOf(activeId);
     if (i < 0) return;
     e.preventDefault();
     const dir = e.key === "ArrowRight" ? 1 : -1;
-    setActive(order[(i + dir + order.length) % order.length]);
+    setActive(ord[(i + dir + ord.length) % ord.length]);
   } else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
     const content = document.getElementById("content");
     if (!content) return;
@@ -6440,7 +6484,10 @@ function renderPicker(items: any[]) {
     name.replaceChildren(...hostNameNodes(it.name, it.id));
     if (it.color && it.color.bg) name.style.color = it.color.bg;
     const time = el("span", "picker-time");
-    if (it.running) {   // a live session (SDK/tmux backend) whose tab is closed → a green "running" badge
+    if (it.hiddenTab) {   // open as a tab but view-hidden (a background session) → picking reveals it
+      time.textContent = "hidden";
+      time.style.opacity = "0.7";
+    } else if (it.running) {   // a live session (SDK/tmux backend) whose tab is closed → a green "running" badge
       time.classList.add("picker-running-badge");
       time.append(el("span", "picker-run-dot"), document.createTextNode("running"));
     } else {
@@ -6458,6 +6505,9 @@ function renderPicker(items: any[]) {
       if (pickMode) {
         if (vscodeApi) vscodeApi.postMessage({ type: "pickResult", id: it.id, name: it.name });
         pickMode = false; // so closePicker doesn't also post a cancel
+      } else if (it.hiddenTab) {
+        revealSession(it.id);   // its tab already exists — un-hide it and switch to it
+        setActive(it.id);
       } else if (vscodeApi) {
         vscodeApi.postMessage({ type: "openSession", id: it.id });
       }
@@ -6474,10 +6524,16 @@ function renderPicker(items: any[]) {
     for (const it of items) list.appendChild(mkRow(it));
   } else {
     const avail = items.filter((it) => !isOpenTab(it.id));
+    // open-as-tab but view-HIDDEN sessions still list (the user 2026-08-18): a background session's
+    // one visible home on the chat side — omitting them here plus hiding the tab would recreate the
+    // secret-running-session state abolished 2026-08-11
+    const hidden = items.filter((it) => isOpenTab(it.id) && !tabInView(it.id))
+                        .map((it) => Object.assign({}, it, { hiddenTab: true }));
     const running = avail.filter((it) => it.running);
     const rest = avail.filter((it) => !it.running);
     if (running.length) { list.appendChild(label("Running — reopen")); for (const it of running) list.appendChild(mkRow(it)); }
-    if (rest.length) { if (running.length) list.appendChild(label("Recent")); for (const it of rest) list.appendChild(mkRow(it)); }
+    if (hidden.length) { list.appendChild(label("Hidden — reveal")); for (const it of hidden) list.appendChild(mkRow(it)); }
+    if (rest.length) { if (running.length || hidden.length) list.appendChild(label("Recent")); for (const it of rest) list.appendChild(mkRow(it)); }
   }
   if (!list.children.length && pickerListHost) {
     // a machine romp can reach but which has no sessions in the window: say that, or an empty list reads
@@ -9597,10 +9653,11 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
 }
 
 function cycleTab(dir: number) {
-  if (order.length < 2 || !activeId) return;
-  const i = order.indexOf(activeId);
+  const ord = visibleOrder();                   // never cycle onto a view-hidden session
+  if (ord.length < 2 || !activeId) return;
+  const i = ord.indexOf(activeId);
   if (i < 0) return;
-  setActive(order[(i + dir + order.length) % order.length]);
+  setActive(ord[(i + dir + ord.length) % ord.length]);
 }
 
 // First event carrying a uuid — a stable identity for "which transcript is this".
@@ -10193,7 +10250,7 @@ window.addEventListener("message", (e: MessageEvent) => {
   else if (m.type === "ledger") setLedger(m.id, m.ledger ?? null);
   else if (m.type === "working") { workingSet = new Set(Array.isArray(m.names) ? m.names : []); refreshPostalDots(); }
   else if (m.type === "imgData" && typeof m.path === "string") onImgData(m.path, typeof m.url === "string" ? m.url : null);
-  else if (m.type === "tabOrder") applyTabOrder(m.order, m.tabs);
+  else if (m.type === "tabOrder") { if (m.views) captureViews(m.views); applyTabOrder(m.order, m.tabs); }
   else if (m.type === "renamed" && m.id && typeof m.name === "string") {
     const s = sessions.get(m.id);
     if (s && s.name !== m.name) { s.name = m.name; renderTabs(); }

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -1,0 +1,73 @@
+// Session views on the chat side (the user 2026-08-18): the kernel's views blob — echoed on every
+// tabOrder push — gates which sessions get TABS. A hidden session is a BACKGROUND session: still
+// running, judged, carded; the + picker lists it under "Hidden — reveal" and the timeline's corner
+// panel counts it, so nothing runs in secret (the 2026-08-11 rule this feature deliberately carves
+// an exception into, keeping its spirit). Executed tests on the pure module + source pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { viewVisible, viewsKey, hideIn, revealIn } from "../../ui/webview/session-views";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+const G = { id: "g1", name: "pool", color: "#DD42FF", members: ["s2"] };
+
+test("executed: the all-view minus hidden; a group exactly; membership beats hidden", () => {
+  assert.equal(viewVisible(null, "s1"), true);
+  assert.equal(viewVisible({ active: "all", hidden: ["s1"] }, "s1"), false);
+  assert.equal(viewVisible({ active: "g1", hidden: ["s2"], groups: [G] }, "s2"), true);
+  assert.equal(viewVisible({ active: "g1", groups: [G] }, "s1"), false);
+  assert.equal(viewVisible({ active: "gone", groups: [] }, "s1"), true, "an orphaned active fails open");
+});
+
+test("executed: hide adds the bit; reveal drops it and falls back to All when the group excludes it", () => {
+  const hid = hideIn({ active: "all", hidden: [] }, "s1");
+  assert.deepEqual(hid.hidden, ["s1"]);
+  assert.deepEqual(hideIn(hid, "s1").hidden, ["s1"], "idempotent");
+  const rev = revealIn({ active: "g1", hidden: ["s1"], groups: [G] }, "s1");
+  assert.deepEqual(rev.hidden, []);
+  assert.equal(rev.active, "all", "the active group excludes it → fall back to All");
+  const rev2 = revealIn({ active: "g1", hidden: ["s2"], groups: [G] }, "s2");
+  assert.equal(rev2.active, "g1", "a member reveals in place — no view switch");
+});
+
+test("executed: the canonical key ignores list order — the kernel normalizer re-sorts", () => {
+  const a = { active: "g1", hidden: ["b", "a"], groups: [{ id: "g1", members: ["y", "x"] }] };
+  const b = { active: "g1", hidden: ["a", "b"], groups: [{ id: "g1", members: ["x", "y"] }] };
+  assert.equal(viewsKey(a), viewsKey(b));
+  assert.notEqual(viewsKey(a), viewsKey({ active: "all", hidden: ["a", "b"], groups: [] }));
+});
+
+test("the tabOrder frame carries the blob and the strip filters on it, composing with #only", () => {
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{ if \(m\.views\) captureViews\(m\.views\); applyTabOrder\(m\.order, m\.tabs\); \}/);
+  assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
+  assert.match(RENDER, /const visibleIds = only \? inViewIds\.filter\(\(id\) => matchesOnly\(nameOf\(id\), only\)\) : inViewIds;/);
+  // the active-tab re-point now covers BOTH filters — a hidden active session must not keep
+  // rendering its transcript under a strip that no longer shows it
+  assert.match(RENDER, /if \(activeId && !visibleIds\.includes\(activeId\) && visibleIds\.length\) \{/);
+});
+
+test("every cycling path walks the VISIBLE order — keyboard can never land on a hidden session", () => {
+  const hits = RENDER.match(/const ord = visibleOrder\(\);\s*(?:\/\/[^\n]*)?\n/g) || [];
+  assert.equal(hits.length, 3, "focused-tab arrows, window arrows, and the shell's cycleTab");
+  assert.doesNotMatch(RENDER, /setActive\(order\[\(i \+ dir \+ order\.length\) % order\.length\]\)/,
+    "no raw-order cycle survives");
+});
+
+test("optimistic edits hold sticky and yield to the kernel after three silent pushes", () => {
+  assert.match(RENDER, /function captureViews\(v: SessionViews\) \{[\s\S]{0,400}\+\+pendingViewsAge >= 3/);
+  assert.match(RENDER, /function postViews\(v: SessionViews\) \{[\s\S]{0,300}setTimelineViews/);
+});
+
+test("a hidden session keeps one visible home: the picker's Hidden section, and picking reveals", () => {
+  assert.match(RENDER, /isOpenTab\(it\.id\) && !tabInView\(it\.id\)/);
+  assert.match(RENDER, /label\("Hidden — reveal"\)/);
+  assert.match(RENDER, /time\.textContent = "hidden";/);
+  assert.match(RENDER, /revealSession\(it\.id\);\s*\/\/ its tab already exists[\s\S]{0,80}setActive\(it\.id\);/);
+});
+
+test("the tab menu's hide gesture posts the same blob the timeline dialog edits", () => {
+  assert.match(RENDER, /l\.textContent = "Hide from chat & timeline";/);
+  assert.match(RENDER, /postViews\(hideIn\(effViews\(\), id\)\);/);
+});

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -25,6 +25,12 @@ test("executed: hide adds the bit; reveal drops it and falls back to All when th
   const hid = hideIn({ active: "all", hidden: [] }, "s1");
   assert.deepEqual(hid.hidden, ["s1"]);
   assert.deepEqual(hideIn(hid, "s1").hidden, ["s1"], "idempotent");
+  // hiding while a group that CONTAINS the session is active must also leave that group — membership
+  // beats hidden, so without this the gesture is a silent no-op
+  const g = hideIn({ active: "g1", hidden: [], groups: [{ id: "g1", members: ["s2", "s3"] }, { id: "g2", members: ["s2"] }] }, "s2");
+  assert.deepEqual(g.hidden, ["s2"]);
+  assert.deepEqual(g.groups![0].members, ["s3"], "dropped from the ACTIVE group");
+  assert.deepEqual(g.groups![1].members, ["s2"], "other groups keep it");
   const rev = revealIn({ active: "g1", hidden: ["s1"], groups: [G] }, "s1");
   assert.deepEqual(rev.hidden, []);
   assert.equal(rev.active, "all", "the active group excludes it → fall back to All");
@@ -40,12 +46,13 @@ test("executed: the canonical key ignores list order — the kernel normalizer r
 });
 
 test("the tabOrder frame carries the blob and the strip filters on it, composing with #only", () => {
-  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{ if \(m\.views\) captureViews\(m\.views\); applyTabOrder\(m\.order, m\.tabs\); \}/);
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{ captureViews\(m\.views \|\| null\); applyTabOrder\(m\.order, m\.tabs\); \}/,
+    "echo-less frames still reach captureViews — an older kernel must age out a pending edit");
   assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
   assert.match(RENDER, /const visibleIds = only \? inViewIds\.filter\(\(id\) => matchesOnly\(nameOf\(id\), only\)\) : inViewIds;/);
-  // the active-tab re-point now covers BOTH filters — a hidden active session must not keep
-  // rendering its transcript under a strip that no longer shows it
-  assert.match(RENDER, /if \(activeId && !visibleIds\.includes\(activeId\) && visibleIds\.length\) \{/);
+  // the active-tab re-point covers BOTH filters — but only for a session that still EXISTS: a
+  // torn-down session's reselect belongs to the teardown path's MRU logic, not to us
+  assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\) \{/);
 });
 
 test("every cycling path walks the VISIBLE order — keyboard can never land on a hidden session", () => {
@@ -56,7 +63,7 @@ test("every cycling path walks the VISIBLE order — keyboard can never land on 
 });
 
 test("optimistic edits hold sticky and yield to the kernel after three silent pushes", () => {
-  assert.match(RENDER, /function captureViews\(v: SessionViews\) \{[\s\S]{0,400}\+\+pendingViewsAge >= 3/);
+  assert.match(RENDER, /function captureViews\(v: SessionViews \| null\) \{[\s\S]{0,600}\+\+pendingViewsAge >= 3/);
   assert.match(RENDER, /function postViews\(v: SessionViews\) \{[\s\S]{0,300}setTimelineViews/);
 });
 
@@ -70,4 +77,22 @@ test("a hidden session keeps one visible home: the picker's Hidden section, and 
 test("the tab menu's hide gesture posts the same blob the timeline dialog edits", () => {
   assert.match(RENDER, /l\.textContent = "Hide from chat & timeline";/);
   assert.match(RENDER, /postViews\(hideIn\(effViews\(\), id\)\);/);
+});
+
+test("federation carries the LOCAL kernel's views blob through merged tabOrder re-emits", () => {
+  const FED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "federation.ts"), "utf8");
+  assert.match(FED, /if \(host === LOCAL && m\.views && typeof m\.views === "object"\) this\.localViews = m\.views;/);
+  assert.match(FED, /\{ type: "tabOrder", order, tabs, views: this\.localViews \?\? undefined \}/,
+    "without this the browser dashboard's chat never receives the blob at all");
+});
+
+test("view edits are INTENT ops — they survive a kernel-restart reconnect instead of dropping", () => {
+  const PIPE = fs.readFileSync(path.resolve(process.cwd(), "src", "pipe-intent.ts"), "utf8");
+  assert.match(PIPE, /"setTimelineViews"/);
+});
+
+test("hiding the last visible session blanks its transcript and the placeholder says why", () => {
+  assert.match(RENDER, /const blank = !visibleIds\.length && ids\.length > 0 && !tabInView\(activeId\);/);
+  assert.match(RENDER, /Every session is hidden from this view\./);
+  assert.match(RENDER, /allHiddenBlanked = false;/, "…and the transcript restores when anything is visible again");
 });

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -1,0 +1,45 @@
+// Session views (the user 2026-08-18): the kernel's timeline-views blob, echoed on every tabOrder
+// push — which sessions the chat TAB STRIP (and the timeline lanes) show. "all" shows everything
+// except the hidden set (a hidden session is a BACKGROUND session: still running, judged and carded;
+// the feed and the + picker keep surfacing it, so nothing runs in secret — the 2026-08-11 rule); a
+// named group shows exactly its members, membership beating the hidden bit. The kernel's
+// _view_visible is the decision of record; this is its client mirror (the timeline carries its own
+// copy — it cannot import TS). Pure, split out of render.ts for tests (the time-marker.ts pattern).
+export interface SessionGroup { id: string; name?: string; color?: string; members?: string[] }
+export interface SessionViews { active?: string; hidden?: string[]; groups?: SessionGroup[] }
+
+export function viewVisible(views: SessionViews | null | undefined, id: string): boolean {
+  if (!views || !views.active || views.active === "all")
+    return !(views && Array.isArray(views.hidden) && views.hidden.includes(id));
+  const g = (views.groups || []).find((x) => x.id === views.active);
+  return g ? (g.members || []).includes(id) : true;
+}
+
+// one canonical serialization for echo comparison — the kernel normalizer re-sorts lists and may
+// clamp names, so optimistic edits compare by shape, never by identity
+export function viewsKey(v: SessionViews | null | undefined): string {
+  if (!v) return "";
+  return JSON.stringify({ active: v.active || "all",
+    hidden: (v.hidden || []).slice().sort(),
+    groups: (v.groups || []).map((g) => ({ id: g.id, name: g.name, color: g.color,
+                                           members: (g.members || []).slice().sort() })) });
+}
+
+// hide: add the session to the hidden set — its group memberships stay (membership beats hidden)
+export function hideIn(views: SessionViews | null | undefined, id: string): SessionViews {
+  const v: SessionViews = JSON.parse(JSON.stringify(views || {}));
+  if (!(v.hidden || []).includes(id)) v.hidden = (v.hidden || []).concat([id]);
+  return v;
+}
+
+// the reveal gesture: explicitly opening a hidden session always shows it — drop its hidden bit,
+// and when the active group excludes it, fall back to All. One predictable rule.
+export function revealIn(views: SessionViews | null | undefined, id: string): SessionViews {
+  const v: SessionViews = JSON.parse(JSON.stringify(views || {}));
+  v.hidden = (v.hidden || []).filter((x) => x !== id);
+  if (v.active && v.active !== "all") {
+    const g = (v.groups || []).find((x) => x.id === v.active);
+    if (!g || !(g.members || []).includes(id)) v.active = "all";
+  }
+  return v;
+}

--- a/ui/webview/session-views.ts
+++ b/ui/webview/session-views.ts
@@ -25,10 +25,17 @@ export function viewsKey(v: SessionViews | null | undefined): string {
                                            members: (g.members || []).slice().sort() })) });
 }
 
-// hide: add the session to the hidden set — its group memberships stay (membership beats hidden)
+// hide: add the session to the hidden set — and when the ACTIVE view is a group that contains it,
+// drop it from that group too, or the gesture is a silent no-op (membership beats hidden, so a
+// member stays visible however hidden it is). Other groups keep it: hiding from what you are
+// looking at must not quietly rewrite views you are not.
 export function hideIn(views: SessionViews | null | undefined, id: string): SessionViews {
   const v: SessionViews = JSON.parse(JSON.stringify(views || {}));
   if (!(v.hidden || []).includes(id)) v.hidden = (v.hidden || []).concat([id]);
+  if (v.active && v.active !== "all") {
+    const g = (v.groups || []).find((x) => x.id === v.active);
+    if (g && (g.members || []).includes(id)) g.members = (g.members || []).filter((x) => x !== id);
+  }
   return v;
 }
 

--- a/ui/webview/timeline-boot.ts
+++ b/ui/webview/timeline-boot.ts
@@ -82,6 +82,7 @@ export function bridgeFunctions(post: Post): Record<string, (...a: any[]) => voi
     __rompTimelineCompact: (name: string) => post({ type: "compact", name }),
     __rompTimelineSendCommand: (name: string, cmd: string) => post({ type: "sendCommand", name, cmd }),
     __rompTimelineSetFlag: (id: string, flag: string, value: unknown) => post({ type: "setSessionFlag", id, flag, value: !!value }),
+    __rompTimelineSetViews: (views: unknown) => post({ type: "setTimelineViews", views }),
     __rompTimelineDismiss: (id: string) => post({ type: "dismissLane", id }),
     __rompTimelineHover: (sid?: string, segIds?: unknown[], t0?: number, t1?: number) =>
       post(sid ? { type: "timelineHover", sid, segIds: segIds || [], t0, t1 } : { type: "timelineHover", off: true }),

--- a/vscode-extension/src/pipe-intent.ts
+++ b/vscode-extension/src/pipe-intent.ts
@@ -14,7 +14,7 @@ export const INTENT_OPS: ReadonlySet<string> = new Set([
   "renameSession", "endSession", "reviveSession",
   "nodeOverride", "askClear", "undoClear", "cardMove", "cardNotify", "redistill",
   "answerAsk", "submitAsk", "toggleAsk", "navAsk", "cancelAsk",
-  "setSessionFlag", "setSessionColor", "setGlobalRetryPaused",
+  "setSessionFlag", "setSessionColor", "setGlobalRetryPaused", "setTimelineViews",
   "reorderTabs", "closeTab",
 ]);
 

--- a/vscode-extension/src/tabs-first.test.ts
+++ b/vscode-extension/src/tabs-first.test.ts
@@ -17,7 +17,7 @@ test("a tabMeta map holds the kernel's name+color per tab", () => {
 test("applyTabOrder REBUILDS tabMeta from the authoritative payload (closed tabs don't linger)", () => {
   assert.match(RENDER, /function applyTabOrder\(o: any, tabs\?: any\)/);
   assert.match(RENDER, /if \(Array\.isArray\(tabs\)\) \{\s*tabMeta\.clear\(\);/);
-  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) applyTabOrder\(m\.order, m\.tabs\);/);
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{ if \(m\.views\) captureViews\(m\.views\); applyTabOrder\(m\.order, m\.tabs\); \}/);
 });
 
 test("renderTabs renders the union of arrived sessions and tabMeta, placeholders for the rest", () => {

--- a/vscode-extension/src/tabs-first.test.ts
+++ b/vscode-extension/src/tabs-first.test.ts
@@ -17,7 +17,7 @@ test("a tabMeta map holds the kernel's name+color per tab", () => {
 test("applyTabOrder REBUILDS tabMeta from the authoritative payload (closed tabs don't linger)", () => {
   assert.match(RENDER, /function applyTabOrder\(o: any, tabs\?: any\)/);
   assert.match(RENDER, /if \(Array\.isArray\(tabs\)\) \{\s*tabMeta\.clear\(\);/);
-  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{ if \(m\.views\) captureViews\(m\.views\); applyTabOrder\(m\.order, m\.tabs\); \}/);
+  assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{ captureViews\(m\.views \|\| null\); applyTabOrder\(m\.order, m\.tabs\); \}/);
 });
 
 test("renderTabs renders the union of arrived sessions and tabMeta, placeholders for the rest", () => {


### PR DESCRIPTION
The timeline's empty bottom-left corner (under the lane gutter, left of the time labels) becomes a control panel, and one kernel-persisted "views" blob decides which sessions show on BOTH the timeline lanes and the chat tab strip. Design discussed and decided with the user 2026-08-18: a single views model, timeline+chat hide together (background sessions), shared kernel-side state, "Show:" labeling, and the two marooned gear toggles folded in.

## The model
`{active: "all"|group, hidden: [id], groups: [{id, name, color, members}]}`. "All" shows everything except the hidden set; a group shows exactly its members, and membership beats the hidden bit. A hidden session is a **background session**: still running, judged, and carded — the feed, the + picker ("Hidden — reveal"), and the corner trigger's "· N more" count keep it one glance away, preserving the spirit of the no-secret-sessions rule (2026-08-11) while carving the exception the user asked for.

## Surfaces
- **Timeline corner**: "Show: <All | group> ▾ · N more" trigger (pointerdown, ellipsized to the gutter); a shared-vocabulary dropdown with the views, New group… (first unused palette color), Edit sessions…, and the collapse-idle-gaps / active-only toggles — which finally work in VS Code and Obsidian (the web gear's settingsSync reaches neither). A centered checkbox dialog over the standard dim edits hidden/membership, with group rename, palette swatches, and delete.
- **Chat**: hidden sessions lose their tab (state, drafts, transcript kept); every cycling path walks the visible order; the active tab re-points when filtered; the tab menu grows "Hide from chat & timeline"; the + picker reveals on pick. Hiding the last visible session blanks its transcript and the placeholder says why.
- **Kernel**: normalizing setter + WS op; the blob rides every timeline and tabOrder push; fsid-churn heal COPIES hidden/membership to the fork via the same name-keyed splice as order inheritance; every focus gesture (create/open/revive/deep link) reveals its target first.

## Review
An adversarial multi-agent review confirmed and this PR fixes: federation dropping the blob from merged tabOrder re-emits (the browser dashboard never saw it), sessions born invisible under a group view, the hide gesture no-op'ing when the active group contains the session, the heal un-hiding dead lanes, the re-point clobbering teardown MRU, a ghost transcript under an empty strip, missing INTENT_OPS coverage (edits dropped across kernel restarts), optimistic edits never expiring against an older kernel, an unguarded/non-atomic Obsidian fallback, a trigger that could overflow the gutter, and a leaked Escape listener.

Tests: 10 kernel tests (storage, normalizer, visibility, copy-heal, splice integration, reveal rule, payload echoes), executed pure-function tests plus prototype reconcile tests and source pins on the timeline and chat sides, and the boot-bridge parity test covers the new hook. Full pytest (4,883) and node (2,099) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)