### PR TITLE
The closer stops re-asking the filter about refused content: tombstone at the cap

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -8079,10 +8079,37 @@ def _close_session(fsid, path, now, cap=CLOSE_FAIRNESS):
             continue
         if cap is not None and did >= cap:             # cap is None by default now (no per-pass close cap);
             break                                      # an explicit caller (a test) can still bound a backfill
+        _judge_ctx.last_call_fail = None               # a stale stash must never charge THIS turn (below)
         res = _close_turn(store, turn, seg_by_id=seg_by_id)
         if res is None:
+            # SAFEGUARDS TOMBSTONE (the user 2026-08-18): a safeguards refusal is the filter ruling on
+            # this turn's CONTENT — deterministic per prompt — so the retry-next-pass contract for
+            # transient failures burned one doomed call per pass, forever (2,955 refusals in six days,
+            # 1,301 on one research session alone). Strike-count refusals per turn AT ITS CURRENT SIZE;
+            # at the cap, adopt the turn exactly as a success would (swept + closedSig at fp), loudly —
+            # the turn GROWING then re-judges it through the same closedSig growth check that re-judges
+            # any closed turn, so the re-arm event is new evidence, never a clock. Transient failures
+            # (529s, timeouts) keep the plain retry: their recovery is the storm ending, and each pass
+            # costs one call, not a give-up.
+            if not getattr(_judge_ctx, "paused", False):
+                last = getattr(_judge_ctx, "last_call_fail", None)
+                if isinstance(last, dict) and "safeguards flagged" in str(last.get("note") or ""):
+                    fails = dict(store.get("closeFails") or {})
+                    rec = fails.get(tid) if isinstance(fails.get(tid), dict) else None
+                    k = (rec.get("fails", 0) + 1) if rec and rec.get("fp") == fp else 1
+                    if k >= DISTILL_FAIL_CAP:
+                        swept.add(tid); sig[tid] = fp; did += 1
+                        fails.pop(tid, None)
+                        _log_judge_error("closer", fsid, "give-up",
+                                         note="%d safeguards refusals on this turn's content; swept "
+                                              "without verdicts; the turn growing re-judges it" % k)
+                    else:
+                        fails[tid] = {"fp": fp, "fails": k}
+                    store["closeFails"] = fails
             continue                                   # LLM/parse failed → leave unswept, retry next pass
         newly += res
+        if isinstance(store.get("closeFails"), dict):
+            store["closeFails"].pop(tid, None)         # a landed judgment retires the strike record
         swept.add(tid); sig[tid] = fp; did += 1        # remember the size we judged at → detect later growth
     store["closedTurns"] = sorted(swept)
     store["closedSig"] = sig

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -3760,6 +3760,64 @@ class SweepSession(unittest.TestCase):
         jd.closer_llm = lambda tt, mt, *_a: (_ for _ in ()).throw(AssertionError("a stable closed turn must not be re-judged"))
         self.assertEqual(jd.run_close(now=self.now), 0, "unchanged closed turns are skipped (closedSig matches)")
 
+    def _refusing_closer(self, calls):
+        # a safeguards refusal exactly as _judge_run leaves it: "" back to the caller, the literal
+        # error stashed per-thread (the filter ruling on content, not model health)
+        return lambda tt, mt, *_a: (calls.append(1), setattr(
+            jd._judge_ctx, "last_call_fail",
+            {"note": "API Error: the model's safeguards flagged this message.", "model": "fable"}), "")[2]
+
+    def test_safeguards_refusals_tombstone_the_turn_at_the_cap(self):
+        # the 2026-08-18 storm: 2,955 refusals, all the closer re-asking the filter about the same
+        # transcript content every pass, unbounded — a content refusal is deterministic, so the cap
+        # sweeps the turn without verdicts (loud give-up row) instead of burning a call per pass forever
+        jd.run_plan(now=self.now)
+        calls = []
+        jd.closer_llm = self._refusing_closer(calls)
+        for _ in range(jd.DISTILL_FAIL_CAP):
+            jd.run_close(now=self.now)
+        capped = len(calls)
+        self.assertEqual(capped, 2 * jd.DISTILL_FAIL_CAP, "two turns × cap attempts, then no more")
+        jd.run_close(now=self.now)
+        jd.run_close(now=self.now)
+        self.assertEqual(len(calls), capped, "tombstoned turns cost ZERO further calls")
+        store = jd.load_goals(SID)
+        tops = [nd for nd in store["nodes"].values() if nd["parentId"] is None]
+        self.assertTrue(all(not nd.get("nodeComplete") for nd in tops),
+                        "swept WITHOUT verdicts — no goal state was invented")
+        self.assertFalse(store.get("closeFails"), "strike records retire at the cap")
+
+    def test_a_grown_turn_re_judges_past_its_tombstone(self):
+        # the re-arm event is NEW EVIDENCE: growth re-enters through the same closedSig check that
+        # re-judges any closed turn — no clock, no manual step
+        path = next(p for f, p, a, n in jd.discover(self.now) if f == SID)
+        recs = [uline(T0, "fix the thing", "u1", ps="typed"),
+                aline(T0 + 30, "worked on it", "a1", "u1", stop="end_turn")]
+        Path(path).write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        jd.run_plan(now=self.now)
+        calls = []
+        jd.closer_llm = self._refusing_closer(calls)
+        for _ in range(jd.DISTILL_FAIL_CAP):
+            jd.run_close(now=self.now)
+        recs.append(aline(T0 + 200, "finished it end to end", "a2", "a1", stop="end_turn"))
+        Path(path).write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        jd.closer_llm = lambda tt, mt, *_a: '{"done": [{"goal": 1, "why": "finished"}]}'
+        n = jd.run_close(now=self.now)
+        self.assertGreaterEqual(n, 1, "the grown turn re-judged and completed the goal")
+
+    def test_transient_failures_never_tombstone(self):
+        # a 529/timeout recovers when the storm ends — those keep the plain retry-next-pass contract
+        jd.run_plan(now=self.now)
+        calls = []
+        jd.closer_llm = lambda tt, mt, *_a: (calls.append(1), setattr(
+            jd._judge_ctx, "last_call_fail",
+            {"note": "API Error: Repeated 529 Overloaded errors.", "model": "fable"}), "")[2]
+        for _ in range(jd.DISTILL_FAIL_CAP + 2):
+            jd.run_close(now=self.now)
+        self.assertEqual(len(calls), 2 * (jd.DISTILL_FAIL_CAP + 2),
+                         "still retrying every pass — transient failures never adopt the turn")
+        self.assertFalse(jd.load_goals(SID).get("closedTurns"), "nothing swept while the calls fail")
+
 
 class CloserKeyMigration(unittest.TestCase):
     """The closer's per-session 'already processed' set survives the sweep->close rename: it reads the


### PR DESCRIPTION
## Why

The judge error log shows 2,955 "safeguards flagged" refusals over six days — every one the closer re-asking the filter about the same transcript content (the research sessions trip it), because a call-level failure means "retry next pass" and a content refusal never stops failing. 1,301 doomed calls on one session alone.

## What

`_close_session` strike-counts safeguards refusals per turn at its current size (store-level `closeFails`; retired on a landed judgment or at the cap). At `DISTILL_FAIL_CAP` the turn is adopted exactly as a success would be — swept + `closedSig` at its fingerprint — with a loud give-up row. The turn growing re-judges it through the existing `closedSig` growth check, so the re-arm event is new evidence, never a clock. Transient failures (529s, timeouts) keep the plain retry: their recovery is the storm ending. The per-thread error stash is cleared before each call so a stale note can never charge the wrong turn, and pause-skips never count.

Pairs with the earlier change that keeps safeguards refusals out of the model-health edge (content, not health).

## Tests

Refusals stop costing calls at the cap and invent no goal state; a grown turn re-judges past its tombstone; transient failures never tombstone. Full Python suite 4885 passed; UI suite 2079 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)