### PR TITLE
Feed controls: a Stack toggle, the sort arrow, and Collapsed moves to settings

### DIFF
--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -25,11 +25,12 @@ class SettingsSectionsTest(unittest.TestCase):
     def test_the_subsection_headers_are_present_in_order(self):
         h = _gear_src()
         self.assertIn("<div class='rs-sec rs-sec-first'>Sessions</div>", h)
-        for sec in ("Judges", "Keyboard shortcuts", "Chat", "Timeline", "Colors", "Debug"):
+        for sec in ("Judges", "Keyboard shortcuts", "Chat", "Feed", "Timeline", "Colors", "Debug"):
             self.assertIn("<div class=rs-sec>%s</div>" % sec, h)
-        self.assertNotIn(">Feed<", h, "the Feed section dissolved into Colors (its colormap is global)")
+        # (The 2026-07-12 "Feed dissolved into Colors" rule ended 2026-08-18: the Feed section is back,
+        # carrying the collapse-by-default checkbox moved off the feed footer.)
         order = [">Sessions<", ">Judges<", ">Keyboard shortcuts<", ">Chat<",
-                 ">Timeline<", ">Colors<", ">Debug<", ">romp · version<"]
+                 ">Feed<", ">Timeline<", ">Colors<", ">Debug<", ">romp · version<"]
         idx = [h.index(t) for t in order]
         self.assertEqual(idx, sorted(idx), "sections in the 2026-07-12 order, version last")
 

--- a/ui/webview/feed-card-prefs.test.ts
+++ b/ui/webview/feed-card-prefs.test.ts
@@ -15,8 +15,8 @@ test("feed prefs from romp:settings: newestFirst/collapsed default OFF, grouped 
   // newestFirst + collapsed default OFF (=== true); grouped defaults ON (!== false — the user 2026-07-13:
   // by-session grouping is the feed's normal reading mode, the footer Group toggle opts OUT).
   // `subgoals` is no longer a feed-wide pref (per-card button now).
-  assert.match(FEED, /return \{ newestFirst: s\.newestFirst === true, collapsed: s\.collapsed === true, grouped: s\.grouped !== false \};/);
-  assert.match(FEED, /catch \{ return \{ newestFirst: false, collapsed: false, grouped: true \}; \}/);
+  assert.match(FEED, /return \{ newestFirst: s\.newestFirst === true, collapsed: s\.collapsed === true, grouped: s\.grouped !== false,\s*\n\s*stacked: s\.stacked === true \};/);
+  assert.match(FEED, /catch \{ return \{ newestFirst: false, collapsed: false, grouped: true, stacked: false \}; \}/);
   assert.doesNotMatch(FEED, /s\.subgoals/, "no feed-wide subgoals pref — it's a per-card toggle now");
   assert.doesNotMatch(FEED, /explanations/);   // every trace of the old pref is gone from the feed
 });
@@ -59,6 +59,6 @@ test("Sub-goals is a PER-CARD button — the THIRD mutually-exclusive section; n
 });
 
 test("the feed re-renders when the prefs change (storage cross-pane + same-doc romp:settings event)", () => {
-  assert.match(FEED, /window\.addEventListener\("storage", \(e\) => \{ if \(e\.key === "romp:settings"\) render\(\); \}\)/);
-  assert.match(FEED, /window\.addEventListener\("romp:settings", \(\) => render\(\)\)/);
+  assert.match(FEED, /window\.addEventListener\("storage", \(e\) => \{ if \(e\.key === "romp:settings"\) onSettingsChanged\(\); \}\)/);
+  assert.match(FEED, /window\.addEventListener\("romp:settings", \(\) => onSettingsChanged\(\)\)/);
 });

--- a/ui/webview/feed-col-fold.test.ts
+++ b/ui/webview/feed-col-fold.test.ts
@@ -18,10 +18,10 @@ test("the caret folds a category to its header and persists like every other dis
   // The fold BITES only in the stacked layout (the user 2026-08-18): collapsed while stacked, then
   // widened to three columns, the section stayed hidden with no caret to reopen it. The rule must
   // live INSIDE the stacked container query — side by side, every card always shows.
-  const stacked = CSS.slice(CSS.indexOf("@container (max-width: 540px)"));
+  const stacked = CSS.slice(CSS.indexOf("@container (max-width: 540px) or style(--romp-stack: on)"));
   assert.match(stacked, /\.feed-col\.col-collapsed \.feed-col-list \{ display: none; \}/,
     "the collapse rule is scoped to the stacked layout");
-  assert.doesNotMatch(CSS.slice(0, CSS.indexOf("@container (max-width: 540px)")),
+  assert.doesNotMatch(CSS.slice(0, CSS.indexOf("@container (max-width: 540px) or style(--romp-stack: on)")),
     /\.col-collapsed \.feed-col-list/,
     "and no unscoped copy survives to hide cards side-by-side");
   assert.match(FEED, /fold\.textContent = folded \? "▸" : "▾";/);

--- a/ui/webview/feed-foot.test.ts
+++ b/ui/webview/feed-foot.test.ts
@@ -35,7 +35,7 @@ test("when the feed stacks (narrow), the columns read Completed → Blocked → 
   // the side-by-side DOM order stays Working/Blocked/Completed; a container query stacks them and `order`
   // re-sequences ONLY the stacked case: done first (moved up from the middle, superseding the 2026-07-08
   // Blocked-first order), then needs-you, then still-running.
-  assert.match(CSS, /@container \(max-width: 540px\) \{[\s\S]*?\.feed-cols \{ flex-direction: column; \}/);
+  assert.match(CSS, /@container \(max-width: 540px\) or style\(--romp-stack: on\) \{[\s\S]*?\.feed-cols \{ flex-direction: column; \}/);
   assert.match(CSS, /\.feed-col\.col-completed\s+\{ order: var\(--stack-order, 1\); \}/);   // the DEFAULT — a
   // dragged section overrides via --stack-order (feed-col-fold.test.ts owns that rule)
   assert.match(CSS, /\.feed-col\.col-needsInput \{ order: var\(--stack-order, 2\); \}/);

--- a/ui/webview/feed-sort.test.ts
+++ b/ui/webview/feed-sort.test.ts
@@ -9,18 +9,27 @@ import * as path from "node:path";
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
 
-test("each column sorts oldest-at-top by default; the 'Newest first' toggle reverses it (the user 2026-07-07)", () => {
+test("each column sorts by modified time; the footer 'Modified ↑/↓' control reverses the direction", () => {
   assert.match(FEED, /const newestFirst = feedPrefs\(\)\.newestFirst;/);
   assert.match(FEED, /buckets\[k\]\.sort\(\(x, y\) => newestFirst \? y\.t - x\.t : x\.t - y\.t\)/);
-  // the footer toggle button writes romp:settings.newestFirst, default OFF
-  assert.match(FEED, /ensureFeedToggle\("feed-newestfirst", "Newest first", \(\) => feedPrefs\(\)\.newestFirst, "newestFirst"/);
+  // renamed from the "Newest first" on/off toggle (the user 2026-08-18): the arrow IS the state —
+  // ↓ newest at the top, ↑ oldest at the top — so the button drops the pressed accent
+  assert.match(FEED, /ensureFeedToggle\("feed-newestfirst", "Modified", \(\) => feedPrefs\(\)\.newestFirst, "newestFirst"/);
+  assert.match(FEED, /b\.textContent = "Modified " \+ \(feedPrefs\(\)\.newestFirst \? "\\u2193" : "\\u2191"\);/);
+  assert.match(FEED, /b\.classList\.remove\("on"\);/);
   assert.doesNotMatch(FEED, /oldestFirst/, "no oldestFirst pref — the natural order is oldest-first");
 });
 
-test("the 'Collapsed' toggle sets the default section state; a per-card expand overrides without leaving the mode", () => {
-  // ON → new/at-default cards collapse (resolveSec default = none); toggling drops per-card overrides
-  assert.match(FEED, /ensureFeedToggle\("feed-collapsed", "Collapsed", \(\) => feedPrefs\(\)\.collapsed, "collapsed"/);
-  assert.match(FEED, /\(\) => secChoice\.clear\(\)\)/, "toggling the mode clears the per-card section overrides so every card re-flows");
+test("the Collapsed default lives in the settings modal now; flipping it still drops per-card overrides", () => {
+  // moved off the footer (the user 2026-08-18): a set-and-forget default, not a per-glance action.
+  // The gear writes romp:settings.collapsed; the feed's settings watcher drops the per-card section
+  // overrides whenever the pref CHANGES — whichever surface changed it — so every card re-flows.
+  assert.doesNotMatch(FEED, /ensureFeedToggle\("feed-collapsed"/, "no footer Collapsed button survives");
+  assert.match(FEED, /if \(p\.collapsed !== lastCollapsedPref\) \{ lastCollapsedPref = p\.collapsed; secChoice\.clear\(\); \}/);
+  const GEAR = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "gear.js"), "utf8");
+  assert.match(GEAR, /rs-feedcollapsed/);
+  assert.match(GEAR, /s\.collapsed = fc\.checked; save\(s\);/);
+  assert.match(GEAR, /if \(fc\) fc\.checked = s\.collapsed === true;/);
   assert.doesNotMatch(FEED, /anySectionOpen/, "the old Collapse/Expand-all button is gone");
 });
 

--- a/ui/webview/feed-stack.test.ts
+++ b/ui/webview/feed-stack.test.ts
@@ -1,0 +1,28 @@
+// The Stack toggle (the user 2026-08-18): force the feed's one-column layout at ANY width, as a
+// standing choice — not only when the container narrows past 540px. The pref drives a style()
+// container condition on #feed-list, OR-combined with the existing size query, so the CSS block
+// stays the single owner of what stacking means and the two triggers can never drift apart.
+// Verified headless in the shipped Chromium: wide+forced stacks, wide+off doesn't, narrow always
+// stacks. Source pins.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+test("one stacked block, two triggers: the narrow size query OR the forced style query", () => {
+  assert.match(CSS, /@container \(max-width: 540px\) or style\(--romp-stack: on\) \{/);
+  const count = (CSS.match(/^@container /gm) || []).length;
+  assert.equal(count, 1, "still exactly one container query — no duplicated stacked rules");
+});
+
+test("the footer Stack button writes the pref and applies the style var; boot applies a persisted one", () => {
+  assert.match(FEED, /stacked: s\.stacked === true/);
+  assert.match(FEED, /ensureFeedToggle\("feed-stacked", "Stack", \(\) => feedPrefs\(\)\.stacked, "stacked"/);
+  assert.match(FEED, /\.style\.setProperty\("--romp-stack", on \? "on" : "off"\)/);
+  assert.match(FEED, /applyStacked\(feedPrefs\(\)\.stacked\);\s*\/\/ boot/);
+  assert.match(FEED, /applyStacked\(p\.stacked\);/, "a settings change from any surface re-applies it");
+  assert.match(FEED, /ensureStackToggle\(\)\.style\.display = showCA \? "" : "none";/, "docked in the footer row");
+});

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -81,7 +81,9 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   /* #feed-foot now DOCKS below as an in-flow flex item (the user 2026-06-29), so the list no longer needs to
      reserve space for a float — it just flexes to fill above the bar. */
   padding: 12px;
-  container-type: inline-size;   /* so the columns can stack responsively (see @container below) */
+  container-type: inline-size;   /* so the columns can stack responsively (see @container below);
+                                    the Stack toggle forces the same block via style(--romp-stack: on),
+                                    so the CSS stays the single owner of what stacking means */
 }
 /* inbox zero → the romp tri-color WORDMARK, centered (the user 2026-06-22; was the plain swirl
    square). This is the one unobtrusive home for the wordmark: it shows ONLY when there is nothing
@@ -148,7 +150,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    it wears in the stacked layout is the affordance). */
 .fcol-fold { display: none; }
 
-@container (max-width: 540px) {
+@container (max-width: 540px) or style(--romp-stack: on) {
   .feed-cols { flex-direction: column; }
   /* Folding exists ONLY here, so the fold BITING lives here too (the user 2026-08-18): this rule used
      to sit outside the query, so a section collapsed while stacked stayed hidden after the feed

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -433,7 +433,7 @@ installSettingsSync();   // a gear save in ANOTHER VS Code pane lands here via t
 // Card-display prefs read straight from the shared 'romp:settings' (the kernel's ⛭ gear writes it; same
 // document as this feed bundle). Default ON. These gate the CARDS only — the modal always shows everything
 // (the user 2026-06-17). `!== false` so a missing key defaults to shown.
-function feedPrefs(): { newestFirst: boolean; collapsed: boolean; grouped: boolean } {
+function feedPrefs(): { newestFirst: boolean; collapsed: boolean; grouped: boolean; stacked: boolean } {
   try {
     const s = JSON.parse(localStorage.getItem("romp:settings") || "{}");
     // newestFirst + collapsed default OFF (=== true): the feed's natural order is oldest-first, and cards
@@ -443,8 +443,9 @@ function feedPrefs(): { newestFirst: boolean; collapsed: boolean; grouped: boole
     // grouped (the user 2026-07-13): each column groups its cards by SESSION (tab/lane order), a session-name
     // header on the backdrop between runs, the per-card name dropped — the compact by-session read.
     // Default ON (!== false, same day): grouping is the feed's normal reading mode; the toggle opts OUT.
-    return { newestFirst: s.newestFirst === true, collapsed: s.collapsed === true, grouped: s.grouped !== false };
-  } catch { return { newestFirst: false, collapsed: false, grouped: true }; }
+    return { newestFirst: s.newestFirst === true, collapsed: s.collapsed === true, grouped: s.grouped !== false,
+             stacked: s.stacked === true };
+  } catch { return { newestFirst: false, collapsed: false, grouped: true, stacked: false }; }
 }
 // The kernel's session order (session-order.json — the SAME order the chat tabs + timeline lanes hold; the
 // user 2026-07-13: grouped-mode sessions must match it). Rides every feed push; federation concatenates
@@ -3083,21 +3084,33 @@ function ensureFeedToggle(id: string, label: string, get: () => boolean, key: st
   b.title = on ? onTitle : offTitle;
   return b;
 }
-// "Newest first" — reverse each column to newest-at-top (default OFF; the feed is naturally oldest-first).
+// "Modified ↑/↓" — the sort control (the user 2026-08-18, renamed from the "Newest first" toggle): cards
+// sort by modified time, the arrow shows the direction, and a click reverses it. Both directions are
+// valid sorts, so the button never wears the pressed accent — the arrow IS the state.
 function ensureNewestFirst(): HTMLElement {
-  return ensureFeedToggle("feed-newestfirst", "Newest first", () => feedPrefs().newestFirst, "newestFirst",
-    "showing newest first — click for the default oldest-first order",
-    "show the newest cards at the top (default: oldest first)");
+  const b = ensureFeedToggle("feed-newestfirst", "Modified", () => feedPrefs().newestFirst, "newestFirst",
+    "newest at the top — click for oldest first",
+    "oldest at the top — click for newest first");
+  b.textContent = "Modified " + (feedPrefs().newestFirst ? "\u2193" : "\u2191");
+  b.classList.remove("on");
+  return b;
 }
-// "Collapsed" — the DEFAULT section state cards inherit (the user 2026-07-07): ON collapses every card and
-// makes NEW cards arrive collapsed; a per-card expand overrides just that card WITHOUT turning the mode off.
-// Toggling drops the per-card overrides so the mode visibly re-flows every card to the new default.
-function ensureCollapsedToggle(): HTMLElement {
-  return ensureFeedToggle("feed-collapsed", "Collapsed", () => feedPrefs().collapsed, "collapsed",
-    "new cards arrive collapsed; expanding one is a per-card override — click to expand by default",
-    "collapse every card and have new ones arrive collapsed",
-    () => secChoice.clear());   // drop per-card section overrides so every card re-flows to the new default
+// "Stack" — force the one-column layout at ANY width (the user 2026-08-18): the same stacked view the
+// narrow container query produces, as a standing choice. The pref drives a style() container condition
+// on #feed-list (see feed.css), so the CSS stays the single owner of what stacking means; the narrow
+// query still stacks regardless.
+function applyStacked(on: boolean) {
+  document.getElementById("feed-list")?.style.setProperty("--romp-stack", on ? "on" : "off");
 }
+function ensureStackToggle(): HTMLElement {
+  return ensureFeedToggle("feed-stacked", "Stack", () => feedPrefs().stacked, "stacked",
+    "one-column layout at any width — click for side-by-side columns when the feed is wide",
+    "stack the columns into one, whatever the width",
+    (on) => applyStacked(on));
+}
+// (The "Collapsed" default-section toggle moved into the settings modal, 2026-08-18 — a set-and-forget
+// preference, not a per-glance view action. The pref and its behavior are unchanged; the gear writes
+// romp:settings.collapsed and the settings watcher below drops the per-card overrides on change.)
 
 // "Group" — organize each column BY SESSION (the user 2026-07-13): kernel tab/lane order, a name+dot header
 // on the backdrop opening each session's run, per-card names dropped (the header carries the identity).
@@ -3538,8 +3551,8 @@ function render() {
   const prevScroll = list.scrollTop;
   // footer pane (below the cards, no overlap): Newest first · Collapsed · Clear all · UndoClear
   const showCA = !!asks.length;
-  ensureNewestFirst().style.display = showCA ? "" : "none";       // reverse the column order
-  ensureCollapsedToggle().style.display = showCA ? "" : "none";   // default section state (collapsed / expanded)
+  ensureNewestFirst().style.display = showCA ? "" : "none";       // Modified ↑/↓ — the sort direction
+  ensureStackToggle().style.display = showCA ? "" : "none";       // force one-column at any width (the user 2026-08-18)
   ensureGroupToggle().style.display = showCA ? "" : "none";       // by-session grouping (the user 2026-07-13)
   ensureSessionFilter().style.display = showCA ? "" : "none";     // one-session filter menu (the user 2026-08-08)
   ensureClearAll().style.display = showCA ? "" : "none";
@@ -3802,8 +3815,21 @@ window.addEventListener("blur", () => { if (kbMode) kbExit(); });   // shell mov
 // Re-render when the card-display prefs change: a 'storage' event fires for a change made in ANOTHER
 // same-origin pane/tab, and the ⛭ gear (same document) dispatches a "romp:settings" event after it writes
 // (a same-doc write fires no storage event). Either way the cards re-gate to the new Explanations/Sub-goals.
-window.addEventListener("storage", (e) => { if (e.key === "romp:settings") render(); });
-window.addEventListener("romp:settings", () => render());
+// The collapsed DEFAULT now changes from the settings modal (2026-08-18), so the override-drop that
+// used to live in the footer toggle rides the settings-change event instead: when `collapsed` flips —
+// whichever surface flipped it — the per-card section overrides drop, so every card visibly re-flows
+// to the new default. And the stacked pref re-applies on every change (another window's gear or a
+// same-page toggle both land here).
+let lastCollapsedPref = feedPrefs().collapsed;
+function onSettingsChanged(): void {
+  const p = feedPrefs();
+  if (p.collapsed !== lastCollapsedPref) { lastCollapsedPref = p.collapsed; secChoice.clear(); }
+  applyStacked(p.stacked);
+  render();
+}
+window.addEventListener("storage", (e) => { if (e.key === "romp:settings") onSettingsChanged(); });
+window.addEventListener("romp:settings", () => onSettingsChanged());
+applyStacked(feedPrefs().stacked);   // boot: a persisted Stack takes effect before the first render
 
 // The VS Code pipe's down-banner (the user 2026-07-21): while the extension host's kernel
 // socket is down, the pane says so instead of sitting silently frozen on its last frame —

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -96,6 +96,11 @@ var GEAR_HTML =
   "border:1px solid #3a3a3a;border-radius:5px;padding:3px 4px;cursor:pointer'>" +
   '<option value=over50>When above 50%</option><option value=always>Always</option><option value=never>Never</option>' +
   '</select></span></div>' +
+  '<div class=rs-sec>Feed</div>' +
+  '<label class=rs-row><input type=checkbox id=rs-feedcollapsed>' +
+  '<span><b>Collapse cards by default</b>' +
+  '<span class=rs-sub>Every card arrives collapsed to its one-line gist; expanding one is a per-card override. Moved here from the feed footer — a set-and-forget default, not a per-glance action.</span>' +
+  '</span></label>' +
   '<div class=rs-sec>Timeline</div>' +
   '<label class=rs-row><input type=checkbox id=rs-activeonly checked>' +
   '<span><b>Show active sessions only</b>' +
@@ -161,6 +166,7 @@ function initGear(post) {
     dd = document.getElementById('rs-defaultdir'), gb = document.getElementById('rs-branch'),
     tc = document.getElementById('rs-tabctx'),
     cg = document.getElementById('rs-collapsegaps'), ao = document.getElementById('rs-activeonly'),
+    fc = document.getElementById('rs-feedcollapsed'),
     jm = document.getElementById('rs-judgemodel'),
     im = document.getElementById('rs-indexmodel'), je = document.getElementById('rs-judgeeffort'),
     ie = document.getElementById('rs-indexeffort'), upm = document.getElementById('rs-updates'),
@@ -190,6 +196,7 @@ function initGear(post) {
   jtr.addEventListener('change', function () { var s = load(); s.showTriageJudges = jtr.checked; save(s); });
   if (cg) cg.addEventListener('change', function () { var s = load(); s.collapseGaps = cg.checked; save(s); });
   if (ao) ao.addEventListener('change', function () { var s = load(); s.activeOnly = ao.checked; save(s); });
+  if (fc) fc.addEventListener('change', function () { var s = load(); s.collapsed = fc.checked; save(s); });
   // Auto Nudge / judge tiers are SERVER-SIDE (the kernel runs them): post the
   // change; the controls re-initialize from /version on every open (fill()).
   // Each attached kernel keeps its own copy, so the post goes to all of them
@@ -395,7 +402,7 @@ function initGear(post) {
     // settings-open, which is what un-hides #feed-pane when the feed is toggled off — measuring first
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (tc) tc.value = tabCtxMode(s.tabCtx); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) bk.value = s.backend || 'sdk'; if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the


### PR DESCRIPTION
Three feed-footer changes, user-requested 2026-08-18:

- **Stack** (new, one word as requested — happy to rename): force the one-column layout at any width as a standing choice, not only when the feed narrows past 540px. The pref drives a `style()` container condition OR-combined with the existing size query, so one CSS block remains the single owner of what stacking means and the two triggers can never drift apart — forcing Stack brings the complete stacked experience, fold carets and section drag included. Mechanism verified headless in the shipped Chromium against the real stylesheet (wide+forced stacks, wide+off restores columns, narrow always stacks).
- **"Newest first" → "Modified ↑/↓"**: cards sort by modified time, the arrow shows the direction, and a click reverses it. Both directions are valid sorts, so the button drops the pressed accent; the arrow is the state.
- **Collapsed moves into the settings modal** (a new Feed section): a set-and-forget default rather than a per-glance action. The pref and behavior are unchanged, and the feed's settings watcher drops per-card overrides whenever the pref changes — from any surface — so every card re-flows exactly as the footer toggle did.

Tests: new source pins for the single-container-query invariant, the Stack wiring and boot apply, the arrow label and accent-drop, the settings watcher's override-drop, and the gear's Feed section (including the retired "Feed dissolved into Colors" rule from 2026-07-12). Full pytest (4,882) and node (2,081) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)