### PR TITLE
One sender classifier feeds bubbles, dots, and notches; machine sends get gray notches

### DIFF
--- a/ui/webview/chat-msg-tag.test.ts
+++ b/ui/webview/chat-msg-tag.test.ts
@@ -29,12 +29,14 @@ test("kernel: the tag lifts on HUMAN-author turns only, riding the user event", 
 
 test("chat: a tagged message wears the gray injected family with the sender's ⚙ label, never user blue", () => {
   assert.match(RENDER, /tag\?: string/, "the user event carries the kernel's lift");
-  assert.match(RENDER, /const tagged = !romp && !injected && !!ev\.tag && !!ev\.md;/);
+  // the predicate lives in sender-identity.ts since 2026-08-18 (ONE classifier for bubble, dot,
+  // and notch); render.ts derives its flags from that one verdict
+  assert.match(RENDER, /const tagged = kind === "tagged";/);
   // the rail dot is its own identity channel and must AGREE with the bubble (2026-08-18): a tagged
   // machine-sent message wears the gray tag dot, never the blue "you typed this" one — so `tagged`
   // is hoisted above the dot call
   assert.match(RENDER, /turn\.appendChild\(dot\(romp \? "romp" : tagged \? "tag" : injected \? "ring" : "user"\)\);/);
-  assert.ok(RENDER.indexOf("const tagged = !romp && !injected") < RENDER.indexOf('dot(romp ? "romp" : tagged'),
+  assert.ok(RENDER.indexOf('const tagged = kind === "tagged"') < RENDER.indexOf('dot(romp ? "romp" : tagged'),
     "tagged must be declared before the dot call reads it");
   assert.match(CSS, /\.dot\.tag \{ background: #8a8f98; border: none; \}/);
   // the label chip reuses the romp-tag dress (one vocabulary), ⚙ marking "scripted" vs romp's swirl

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -17,6 +17,7 @@ import { TABBAR_H_KEY, TABBAR_H_DEFAULT, clampTabbarH, parseTabbarH } from "./ta
 import { SessionViews, viewVisible, viewsKey, hideIn, revealIn } from "./session-views";
 import { markerLabel, dayContext } from "./time-marker";
 import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
+import { senderKind } from "./sender-identity";
 import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompSettings } from "./settings";
 import { delegate } from "./actions";
 import { KIND_WORD } from "./spin-caption";
@@ -1790,13 +1791,18 @@ function paintScrollMarks(): void {
   const frame = contentOffsetFrame(content, v, s);
   if (!frame) { box.style.display = "none"; scrollMarksSig = ""; return; }
   const sh = frame.sh;
-  const offs: number[] = [];
+  const offs: Array<{ top: number; m: string }> = [];
   const evUnit = eventUnitIndex(s);                       // marks anchor to EVENTS; the frame speaks UNITS
   for (let i = 0; i < s.events.length; i++) {
     const ev = s.events[i] as ChatEvent & { human?: boolean; romp?: boolean; rompAuto?: boolean; canned?: string; md?: string; tag?: string };
-    // a TAGGED message is machine-sent under a label, not the user's words — the blue that means
-    // "yours" would lie (the same identity rule the rail dot follows since the tag dress landed)
-    if (ev.kind !== "user" || !ev.human || ev.romp || ev.rompAuto || ev.tag) continue;
+    if (ev.kind !== "user") continue;
+    // the SAME classifier the bubble and rail dot read (sender-identity.ts, the user 2026-08-18:
+    // "reuse the same functions that compute how they render in the chat, so there's never any
+    // chance of desynchronization"). user → the blue that means yours; romp/tagged → a light gray
+    // notch (machine-sent activity, visible on the map but never posing as your words); harness
+    // noise ("injected") → no notch at all.
+    const kind = senderKind(ev);
+    if (kind === "injected") continue;
     const md = (ev.md || "").trim();
     // gestures are the user's DOINGS, not their words — no notch (the Continue row, a /command)
     if (!md || ev.canned === "continue" || SLASH_CMD_RE.test(md)) continue;
@@ -1804,11 +1810,11 @@ function paintScrollMarks(): void {
     if (u < 0) continue;                                  // not in the display stream (never for user events)
     const off = frame.offsetOf(u);
     if (off == null) continue;
-    offs.push(off);
+    offs.push({ top: off, m: kind === "user" ? "" : "machine" });
   }
-  const ys = offs.map((top) => Math.round((top / sh) * (cRect.height - 4)));
+  const ys = offs.map((o) => ({ y: Math.round((o.top / sh) * (cRect.height - 4)), m: o.m }));
   const sig = activeId + "|" + Math.round(cRect.top) + "," + Math.round(cRect.right) + ","
-    + Math.round(cRect.height) + "|" + ys.join(",");
+    + Math.round(cRect.height) + "|" + ys.map((o) => o.y + (o.m ? "m" : "")).join(",");
   if (sig !== scrollMarksSig) {
     scrollMarksSig = sig;
     // UPDATE IN PLACE when the notch count is unchanged (the user 2026-08-17: scrolling back streams
@@ -1819,11 +1825,11 @@ function paintScrollMarks(): void {
     // tab) still rebuild outright — those are new marks, not moved ones.
     const kids = Array.from(box.children) as HTMLElement[];
     if (kids.length === ys.length) {
-      ys.forEach((y, i) => { kids[i].style.top = y + "px"; });
+      ys.forEach((o, i) => { kids[i].style.top = o.y + "px"; kids[i].className = "scroll-mark" + (o.m ? " " + o.m : ""); });
     } else {
-      box.replaceChildren(...ys.map((y) => {
-        const m = el("div", "scroll-mark");
-        m.style.top = y + "px";
+      box.replaceChildren(...ys.map((o) => {
+        const m = el("div", "scroll-mark" + (o.m ? " " + o.m : ""));
+        m.style.top = o.y + "px";
         return m;
       }));
     }
@@ -1992,14 +1998,15 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
     // message romp INJECTED (a feed nudge / follow-up — ev.romp) → a GRAY right-aligned bubble with a
     // "romp" tag, so it's clear romp (not you) sent it (the user 2026-06-19); everything else harness-
     // injected (compact summary, /command stdout, system reminders) → a neutral left note box.
-    const romp = !!ev.romp;
-    const injected = !ev.human && !romp;
-    // sender-declared render hint (kernel MSG_TAG_RE lift, the user 2026-08-15): auto-generated
-    // text — a kickoff template, a scripted brief — is machine-sent on the user's behalf, so it
-    // sheds the typed-words blue for the gray injected family, labeled with the SENDER's own word
-    // (romp attaches no meaning to the label; ⚙ marks "scripted", vs romp's swirl). Hoisted above
-    // the rail dot (2026-08-18): the dot is its own identity channel and must agree with the bubble.
-    const tagged = !romp && !injected && !!ev.tag && !!ev.md;
+    // ONE classifier (sender-identity.ts, the user 2026-08-18): the bubble dress here, the rail
+    // dot below, and paintScrollMarks' notch color all read the SAME senderKind verdict, so the
+    // surfaces can never desynchronize. The sender-declared render hint (kernel MSG_TAG_RE lift,
+    // the user 2026-08-15) classifies as "tagged": machine-sent on the user's behalf, shedding the
+    // typed-words blue for the gray family under the SENDER's own ⚙ label.
+    const kind = senderKind(ev);
+    const romp = kind === "romp";
+    const injected = kind === "injected";
+    const tagged = kind === "tagged";
     const turn = el("div", "turn turn-user" + (romp ? " romp" : injected ? " injected" : ""));
     // Unresolved postal ids ride the raw turn so a timeline message arc can still land on it. Without
     // this the arc pointed at a turn with nothing to match and the click died silently (the user

--- a/ui/webview/romp-bubble.test.ts
+++ b/ui/webview/romp-bubble.test.ts
@@ -14,9 +14,9 @@ test("a user ChatEvent can carry a romp flag", () => {
 });
 
 test("a romp event renders the gray romp-bubble + a romp tag, NOT the blue or the note box", () => {
-  assert.match(RENDER, /const romp = !!ev\.romp;/);
+  assert.match(RENDER, /const romp = kind === "romp";/, "derived from the ONE senderKind verdict (2026-08-18)");
   // 'injected' (the neutral left note) excludes romp, so romp gets its own branch
-  assert.match(RENDER, /const injected = !ev\.human && !romp;/);
+  assert.match(RENDER, /const injected = kind === "injected";/, "same verdict — the predicate itself lives in sender-identity.ts");
   // the tag shows the romp swirl-glyph LOGO (not the old ↯ symbol) + "romp" (the user 2026-06-19)
   assert.match(RENDER, /el\("img", "romp-tag-logo"\)/);
   assert.match(RENDER, /logo\.src = mediaSrc\("romp-swirl-glyph\.svg"\)/);

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -17,8 +17,9 @@ test("one notch per real user message across the WHOLE loaded conversation", () 
   // come from the full resident events array: true pixels for rendered turns, a proportional slot
   // inside the MEASURED spacer for the rest — the same estimate the scrollbar itself stands on.
   assert.match(RENDER, /for \(let i = 0; i < s\.events\.length; i\+\+\) \{/);
-  assert.match(RENDER, /if \(ev\.kind !== "user" \|\| !ev\.human \|\| ev\.romp \|\| ev\.rompAuto \|\| ev\.tag\) continue;/,
-    "machine-sent tagged messages never wear the blue that means yours");
+  // the filter reads the ONE senderKind verdict (2026-08-18): user → blue, romp/tagged → the gray
+  // machine notch, harness noise → none — the same classifier the bubble and rail dot wear
+  assert.match(RENDER, /const kind = senderKind\(ev\);\s*\n\s*if \(kind === "injected"\) continue;/);
   assert.match(RENDER, /ev\.canned === "continue" \|\| SLASH_CMD_RE\.test\(md\)/,
     "a /command or Continue gesture is a doing, not words — no notch");
   assert.match(RENDER, /'\.turn\[data-unit="' \+ i \+ '"\]'/, "rendered events use their true pixel offset");
@@ -37,7 +38,8 @@ test("a history load rescales the map smoothly — moved notches are carried, ne
   // the user 2026-08-17: scrolling back streams older history in; the scroller's world grows and
   // every proportional position compresses (the native thumb does the same). Rebuilt nodes can't
   // transition, so same-count updates move the EXISTING nodes and CSS carries them.
-  assert.match(RENDER, /if \(kids\.length === ys\.length\) \{\s*\n\s*ys\.forEach\(\(y, i\) => \{ kids\[i\]\.style\.top = y \+ "px"; \}\);/);
+  assert.match(RENDER, /if \(kids\.length === ys\.length\) \{\s*\n\s*ys\.forEach\(\(o, i\) => \{ kids\[i\]\.style\.top = o\.y \+ "px"; kids\[i\]\.className = "scroll-mark" \+ \(o\.m \? " " \+ o\.m : ""\); \}\);/,
+    "…and the kind class updates in place too (a machine notch stays gray through a rescale)");
   assert.match(CSS, /transition: top 180ms ease;/);
   assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.scroll-marks \.scroll-mark \{ transition: none; \} \}/);
 });

--- a/ui/webview/sender-identity.test.ts
+++ b/ui/webview/sender-identity.test.ts
@@ -1,0 +1,30 @@
+// The ONE sender classifier (the user 2026-08-18): bubble, rail dot, and scrollbar notch all read
+// senderKind, so the surfaces can never desynchronize. Behavioral on the module, plus source pins
+// holding both consumers to it.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { senderKind } from "./sender-identity";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("the four kinds, and their precedence", () => {
+  assert.equal(senderKind({ human: true, md: "hello" }), "user");
+  assert.equal(senderKind({ human: false, romp: true, md: "checking in" }), "romp");
+  assert.equal(senderKind({ human: true, romp: true, md: "x" }), "romp", "romp wins — an injection never poses as typed words");
+  assert.equal(senderKind({ human: true, tag: "nightly-optimizer", md: "briefing" }), "tagged");
+  assert.equal(senderKind({ human: true, tag: "t" }), "user", "a tag without a body renders no tag chip — same rule as the dress");
+  assert.equal(senderKind({ human: false }), "injected");
+});
+
+test("both consumers read the classifier — never a second hand-maintained predicate", () => {
+  // the bubble/dot site derives its flags from the ONE verdict…
+  assert.match(RENDER, /const kind = senderKind\(ev\);\s*\n\s*const romp = kind === "romp";\s*\n\s*const injected = kind === "injected";\s*\n\s*const tagged = kind === "tagged";/);
+  // …and the notch painter reads the SAME function, coloring by it
+  assert.match(RENDER, /const kind = senderKind\(ev\);\s*\n\s*if \(kind === "injected"\) continue;/);
+  assert.match(RENDER, /offs\.push\(\{ top: off, m: kind === "user" \? "" : "machine" \}\);/);
+  // machine notches wear the light gray, never the blue that means "yours"
+  assert.match(CSS, /\.scroll-marks \.scroll-mark\.machine \{ background: #8a8f98; opacity: 0\.55; \}/);
+});

--- a/ui/webview/sender-identity.ts
+++ b/ui/webview/sender-identity.ts
@@ -1,0 +1,15 @@
+// ONE classifier for who a user-row message is FROM (the user 2026-08-18): the chat bubble, the
+// rail dot, and the scrollbar notch all read the SAME verdict, so the surfaces can never
+// desynchronize — the notch filter and the bubble dress used to be two hand-maintained predicates.
+// The kinds mirror the dress taxonomy: "user" = the user's own typed words (blue bubble, blue dot,
+// blue notch); "romp" = romp-injected (gray romp-bubble + swirl, gray notch); "tagged" =
+// machine-sent under a sender-declared label (tag-bubble + ⚙, gray notch); "injected" = harness
+// noise (system reminders, command stdout — the neutral note box, NO notch).
+export type SenderKind = "user" | "romp" | "tagged" | "injected";
+
+export function senderKind(ev: { human?: boolean; romp?: boolean; tag?: string; md?: string }): SenderKind {
+  const romp = !!ev.romp;
+  const injected = !ev.human && !romp;
+  const tagged = !romp && !injected && !!ev.tag && !!ev.md;
+  return romp ? "romp" : injected ? "injected" : tagged ? "tagged" : "user";
+}

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2799,3 +2799,8 @@ body.fileview-open { overflow: hidden; }
 .fileview-md th, .fileview-md td { border: 1px solid var(--box-border); padding: 4px 10px; text-align: left; }
 .fileview-md th { background: rgba(255, 255, 255, 0.03); }
 .fileview-md img { max-width: 100%; }
+
+/* a MACHINE-sent message's notch (romp injections, ⚙-tagged sends — the same senderKind verdict the
+   bubble wears): light gray, visibly quieter than the user's blue, so the scroll map separates "you
+   spoke" from "something was injected" at a glance (the user 2026-08-18) */
+.scroll-marks .scroll-mark.machine { background: #8a8f98; opacity: 0.55; }


### PR DESCRIPTION
The chat bubble dress and the scrollbar notch filter were two hand-maintained predicates over the same event fields — exactly the desynchronization the user flagged (romp injections could in principle wear the blue that means the user's own words, and nothing structural prevented drift). `senderKind(ev)` in sender-identity.ts is now the ONE verdict: renderEventInner derives its romp/injected/tagged flags from it (every downstream ternary — bubble class, rail dot, chip guards — reads unchanged), and paintScrollMarks reads the same function, so the surfaces cannot drift apart.

And romp injections stop being invisible on the scroll map: a machine-sent message (a romp nudge, a ⚙-tagged scheduled send) now paints a LIGHT GRAY notch — visible activity, never posing as the user's blue — while harness noise keeps painting nothing and gestures (the Continue row, /commands) stay excluded. The gray survives in-place rescales (the kind class updates alongside the top).

Behavioral tests on the module (the four kinds and their precedence: romp wins over tagged; a tag without a body is no tag — the dress's own rule) plus source pins holding BOTH consumers to the classifier; the four pins that froze the old inline predicates are updated to the shared form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)