### PR TITLE
A standalone romp notice sits on the right, like every message from romp

### DIFF
--- a/ui/webview/notice-card.test.ts
+++ b/ui/webview/notice-card.test.ts
@@ -68,6 +68,16 @@ test("a romp SYSTEM notice becomes a romp notice card (swirl) — NOT the gray n
   assert.match(CSS, /\.notice-card-romp \{ border-left-color: rgba\(156, 210, 255, 0\.45\); \}/);
 });
 
+test("a standalone ROMP notice sits on the RIGHT, like every message from romp; other variants stay left", () => {
+  // the user 2026-08-18: in the transcript, direction says who is speaking — the session from the
+  // left, romp and the user from the right. The kernel-restart notice wore the session's side.
+  assert.match(CSS, /\.turn-notice\.notice-romp \{ display: flex; flex-direction: column; align-items: flex-end; \}/);
+  assert.match(CSS, /\.turn-notice\.notice-romp > \.notice-card \{ max-width: 72%; \}/,
+    "the bubbles' width cap — it reads beside the nudges it travels with");
+  assert.doesNotMatch(CSS, /\.turn-notice \{[^}]*flex-end/,
+    "unscoped: agent/reminder notices are session-side output and keep the left edge");
+});
+
 test("the notice family is DIFFERENTIABLE from postal + teammate", () => {
   assert.doesNotMatch(NOTICE, /postal-service|--peer-bg|teammate/, "no postal/teammate chrome inside noticeCard");
   // its own keyed collapse rule, not the postal/teammate .expanded toggle

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1750,6 +1750,14 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    it from the content above (the turn's own padding no longer wraps it). A standalone romp notice keeps its
    .turn dot. */
 .notice-nested { margin-top: 8px; }
+/* A standalone ROMP notice right-justifies like every other message FROM romp (the user 2026-08-18):
+   in the transcript, direction says who is speaking — the session from the left, romp and the user
+   from the right — and the kernel-restart/Retry notices wore the session's side, reading as session
+   output. Same card otherwise, with the bubbles' 72% width cap so it sits beside the nudges it
+   travels with. Other notice variants (an agent's report, folded reminders) ARE session-side
+   output and stay left. The dot and time marker are absolute, so the flex moves only the card. */
+.turn-notice.notice-romp { display: flex; flex-direction: column; align-items: flex-end; }
+.turn-notice.notice-romp > .notice-card { max-width: 72%; }
 .notice-head { display: flex; align-items: baseline; gap: 7px; font-size: 0.9em; }
 .notice-collapsible .notice-head { cursor: pointer; }
 .notice-caret { flex: 0 0 auto; font-size: 0.74em; opacity: 0.7; }


### PR DESCRIPTION
User-requested 2026-08-18: in the transcript, direction should say who is speaking — the session's output from the left, romp and the user from the right. The kernel-restart/Retry notice cards wore the session's side and read as session output.

The standalone romp-variant notice turn now right-justifies its card: same appearance otherwise (chip, swirl, gist, keyed collapse), with the bubbles' 72% width cap so it sits beside the nudges it travels with. Other notice variants (an agent's report, folded reminders) are session-side output and keep the left edge. The rail dot and time marker are absolutely positioned, so the flex moves only the card.

Verified headless against the real stylesheet: the romp card's right edge lands exactly on the user bubble's, the agent card stays left and full-width, the dot stays on the rail. New test pins the scoped rule and fails if the alignment ever goes unscoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)