### PR TITLE
The awaiting wake directs the session to check the thing, not report feelings

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3131,9 +3131,13 @@ AWAITING_BACKSTOP_SECS = 6 * 3600
 # banned by the injected-voice rule — and sat outside tests/test_injected_voice.py's index, which is how it
 # survived the 2026-07-24 sweep. It is indexed there now.
 AWAITING_BACKSTOP_TEXT = (
-    "Checking in on the background work you set in motion here. If it finished, pick the result up and "
-    "keep going. If it stalled or died, relaunch it or find another way; your call. If you're now blocked, "
-    "say exactly what you need from me. If it's genuinely still running, a one-line status is enough.")
+    "Checking in on the background work you set in motion here. Go LOOK at the thing itself first — "
+    "the job queue, the pull request, the run's output, whatever you were waiting on — rather than "
+    "answering from memory. If it finished, pick the result up and keep going. If it stalled or died, "
+    "relaunch it or find another way; your call. If it can only move when someone acts on it and "
+    "they haven't, chase it or route around it. If you're now blocked, say exactly what you need "
+    "from me. Only if you checked just now and it's genuinely still running is a one-line status "
+    "enough.")
 
 
 def _put_nudged(gid, rec):

--- a/tests/test_wake_checks_the_thing.py
+++ b/tests/test_wake_checks_the_thing.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""The 6h awaiting wake directs the session to CHECK the awaited thing, not report feelings.
+
+The 2026-08-18 awaiting audit: for waits on EXTERNAL events (a PR review, a CI run, a peer who
+must act) the wake was the only recheck — and its copy invited a status answer ("a one-line
+status is enough"), so a session could answer "still waiting" from memory forever while the
+awaited thing sat resolved or dead. The copy now leads with going and LOOKING at the named thing
+and reserves the one-line status for a check performed just now. Voice rules hold: it speaks as
+the person the agent works for, no romp vocabulary (test_injected_voice renders it)."""
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_wakecheck", os.path.join(BIN, "romp-kernel")).load_module()
+
+
+class WakeChecksTheThing(unittest.TestCase):
+    def test_the_wake_leads_with_looking_at_the_thing(self):
+        self.assertIn("Go LOOK at the thing itself first", km.AWAITING_BACKSTOP_TEXT)
+        self.assertIn("rather than", km.AWAITING_BACKSTOP_TEXT)
+        self.assertIn("answering from memory", km.AWAITING_BACKSTOP_TEXT)
+
+    def test_a_wait_on_someone_else_gets_chased_not_narrated(self):
+        self.assertIn("chase it or route around it", km.AWAITING_BACKSTOP_TEXT)
+
+    def test_the_status_answer_is_gated_on_a_fresh_check(self):
+        self.assertIn("Only if you checked just now", km.AWAITING_BACKSTOP_TEXT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Last fix from the awaiting audit. For waits on EXTERNAL events (a PR review, a CI run, a peer who must act) the 6h wake was the only recheck — and its copy invited a status answer ("a one-line status is enough"), so a session could reply still-waiting from memory forever while the awaited thing sat resolved or dead, re-arming another six hours each time. The copy now leads with going and LOOKING at the named thing itself, tells the session to chase or route around a wait stuck on someone else, and reserves the one-line status for a check performed just now. Voice rules hold (test_injected_voice renders it); pins in tests/test_wake_checks_the_thing.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)