### PR TITLE
romp-uninstall parses on macOS bash 3.2: the validator heredoc leaves the substitution

### DIFF
--- a/bin/romp-uninstall
+++ b/bin/romp-uninstall
@@ -203,7 +203,15 @@ echo "==> judge scratch"
 # /tmp/romp-judge (no other non-alnum char in it) and stopped agreeing the moment it moved under
 # ~/.local/state: the dot in `.local` survives, so the two spell the same path differently and the
 # transcripts are left behind.
-_judge_lines="$(python3 - "$JUDGE_SCRATCH" "$STATE" "$HOME" <<'PYEOF'
+# The validator is written to a temp file FIRST and run as a plain script (2026-08-19): feeding
+# this heredoc to python3 INSIDE the $("...") substitution parsed fine on bash 4+ but macOS ships
+# bash 3.2, whose substitution scanner tracks quotes THROUGH heredoc bodies — the apostrophes in
+# the comments below ("romp's", "somebody else's") left it hunting a closing quote to EOF and the
+# whole script died at parse time ("unexpected EOF while looking for matching quote"; caught by
+# the release gate's macOS run, which exists because macOS CI is dispatch-only). A top-level
+# heredoc into cat has no such parser, whatever the body holds.
+_judge_py="$(mktemp "${TMPDIR:-/tmp}/romp-uninstall-judge.XXXXXX")"
+cat > "$_judge_py" <<'PYEOF'
 import os, re, sys
 
 raw, state, home = sys.argv[1], sys.argv[2], sys.argv[3]
@@ -243,7 +251,8 @@ for danger in (chome, cstate):
 # string that was validated and the directory removed below are one and the same.
 sys.stdout.write("%s\n%s\n" % (cp, re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cp))) if ok else "")
 PYEOF
-)"
+_judge_lines="$(python3 "$_judge_py" "$JUDGE_SCRATCH" "$STATE" "$HOME")"
+rm -f "$_judge_py"
 _judge_scratch="$(printf '%s\n' "$_judge_lines" | sed -n 1p)"
 _scratch_slug="$(printf '%s\n' "$_judge_lines" | sed -n 2p)"
 


### PR DESCRIPTION
The v0.12.0 release's macOS gate caught `bin/romp-uninstall` dying at parse time under bash 3.2 (`unexpected EOF while looking for matching quote`): the judge-scratch validation fed its python heredoc to python3 INSIDE a quoted `$(...)` substitution, and 3.2's substitution scanner tracks quotes THROUGH heredoc bodies — the apostrophes in the validator's comments left it hunting a closing quote to EOF, so all ten uninstall tests failed at once on macOS while Linux (bash 5) parsed it fine. macOS CI is dispatch-only, so the release gate is exactly where this class surfaces.

The heredoc now writes to a mktemp file at top level (no enclosing parser to confuse, whatever the body holds) and a plain substitution runs it. Validator logic unchanged byte for byte; `bash -n` and a standalone run of the validator confirm. The Linux uninstall bats re-verify on this PR; the macOS proof is the release script's re-dispatched gate, which I'll run as soon as this merges (the release is blocked on it — VERSION 0.12.0 is merged but untagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)