### PR TITLE
The lightbox offers a download beside the close

### DIFF
--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -59,3 +59,21 @@ test("the chat sheet carries the lightbox + preview styles (the feed no longer p
   assert.match(CHAT_CSS, /\.path-full-img \{ display: block; max-width: 100%;/, "the full render's image scale");
   assert.match(CHAT_CSS, /\.path-thumbs \{ display: flex; flex-wrap: wrap;/, "the chat strip container");
 });
+
+test("the lightbox offers a download beside the close, saving the same bytes it shows", () => {
+  // the user 2026-08-19: full-screen images need a save affordance. An anchor with the download
+  // attribute, carrying the SAME pinned url the lightbox <img> renders — so a re-generated file
+  // can't swap the image between viewing and saving — dressed exactly like the ✕ beside it.
+  const at = PREVIEW.indexOf("export function openLightbox");
+  const body = PREVIEW.slice(at, PREVIEW.indexOf("\n}", at));
+  assert.ok(body.indexOf('dl.href = fileUrl(path, sid) + (pin ? "&pin=" + encodeURIComponent(pin) : "")') > 0,
+    "the download url matches the shown image, pin included");
+  assert.ok(body.indexOf('dl.download = path.slice(path.lastIndexOf("/") + 1) || "image"') > 0,
+    "saved under the file's own basename");
+  assert.ok(body.indexOf("dl.onclick = (ev) => ev.stopPropagation()") > 0,
+    "saving must not also dismiss the lightbox");
+  assert.ok(body.indexOf('bar.append(name, dl, close)') > 0, "between the filename and the ✕");
+  const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+  assert.match(CSS, /\.romp-lightbox-dl \{ font: inherit; font-size: 0\.86em;/,
+    "one control vocabulary — the same chip dress as the close beside it");
+});

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -140,11 +140,21 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   name.className = "romp-lightbox-name";
   name.textContent = path;
   name.title = path;
+  // download rides an ANCHOR with the download attribute (the user 2026-08-19): the browser saves
+  // the same bytes the lightbox is showing — the pinned URL when a pin rode in, so a re-generated
+  // file can't swap the image between viewing and saving. The filename is the path's basename.
+  const dl = document.createElement("a");
+  dl.className = "romp-lightbox-dl";
+  dl.href = fileUrl(path, sid) + (pin ? "&pin=" + encodeURIComponent(pin) : "");
+  dl.download = path.slice(path.lastIndexOf("/") + 1) || "image";
+  dl.textContent = "⭳";
+  dl.title = "download";
+  dl.onclick = (ev) => ev.stopPropagation();               // saving must not also dismiss
   const close = document.createElement("button");
   close.className = "romp-lightbox-close";
   close.textContent = "✕";
   close.title = "close (Esc)";
-  bar.append(name, close);
+  bar.append(name, dl, close);
   inner.appendChild(bar);
   wrap.appendChild(inner);
   const dismiss = () => { wrap.remove(); document.removeEventListener("keydown", onKey, true); };

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2406,6 +2406,12 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
   padding: 2px 9px; border-radius: 6px; background: rgba(255, 255, 255, 0.1); color: var(--fg);
   border: 1px solid rgba(255, 255, 255, 0.18); }
 .romp-lightbox-close:hover { border-color: var(--accent); }
+/* download: an anchor dressed exactly like the close button beside it (one control vocabulary —
+   same chip, same hover cue), sitting between the filename and the ✕ */
+.romp-lightbox-dl { font: inherit; font-size: 0.86em; cursor: pointer; flex: 0 0 auto;
+  padding: 2px 9px; border-radius: 6px; background: rgba(255, 255, 255, 0.1); color: var(--fg);
+  border: 1px solid rgba(255, 255, 255, 0.18); text-decoration: none; line-height: normal; }
+.romp-lightbox-dl:hover { border-color: var(--accent); }
 
 /* The "host:" prefix on a FEDERATED session's name (host-prefix.ts): metadata, not part of the name
    (the user 2026-07-11) — quiet gray, never bold, italic, a step smaller than the name it precedes.


### PR DESCRIPTION
Full-screen images had no save affordance. An anchor with the `download` attribute sits between the filename and the ✕, dressed exactly like the close chip beside it (one control vocabulary). It carries the SAME pinned url the lightbox `<img>` renders — so a re-generated file under the same name can't swap the image between viewing and saving — and saves under the file's own basename. Clicking it never dismisses the lightbox. Pins in preview-core.test.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)