### PR TITLE
Comment threads: seamless marching ants, and the color persists to break-out

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -5338,7 +5338,7 @@ def _comment_create(parent_sid, anchor_uuid, exact, text, name="", model="", eff
         data.setdefault("threads", []).append(row)
         _save_comments(parent_sid, data)
     try:
-        be.fork(nm, parent_sid, cut, bg=col, fg=("#ffffff" if col else ""), sid=tsid, thread_of=parent_sid,
+        be.fork(nm, parent_sid, cut, bg=col, fg=(pal.fg_for(col) if col else ""), sid=tsid, thread_of=parent_sid,
                 model=str(model or ""), effort=str(effort or ""))
         be.connect(tsid)
         be.send(tsid, _comment_first_message(exact, text))
@@ -5495,7 +5495,10 @@ def _comment_promote(parent_sid, tid, new_name, now=None, client=None):
         return _revert("not promoted: sealing the thread's history failed: %s" % e)
     if prior == "resolved":
         be.resume(nm, tsid)                          # a resolved thread promotes straight to a live session
-    bg, fg = _pick_identity_color()
+    # the thread KEEPS its identity color (the user 2026-08-19: the color the dialog suggested must
+    # persist to the session it becomes) — a fresh pick here handed the board session a different one
+    col = str(th.get("color") or "")
+    bg, fg = (col, pal.fg_for(col)) if col else _pick_identity_color()
     if not be.promote_thread(tsid, nm, bg, fg):
         return _revert("couldn't promote this thread.")
     _comment_update(parent_sid, tid, status="promoted", promotedName=nm)

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -429,6 +429,7 @@ class FakeBackend:
 
     def promote_thread(self, sid, name, bg="", fg=""):
         self.calls.append(("promote", sid, name))
+        self.promoted_color = (bg, fg)
         return True
 
 
@@ -576,6 +577,31 @@ class CommentOps(CommentBase):
         self.assertIsNotNone(floor)
         self.assertGreaterEqual(floor, t + 10,
                                 "the floor sits at the thread's leaf — the popover exchange is settled history")
+
+    def _promotable(self, tid):
+        """The transcript + reg a thread needs before _comment_promote will touch it."""
+        t = self.now - 200
+        self._write(tid, [uline(t, "opener", "cu1"), aline(t + 10, "reply", "ca1", parent="cu1")])
+        (jd.SDKDIR / (tid + ".json")).write_text(json.dumps(
+            {"sid": tid, "name": "thread-x", "cwd": self.cdir,
+             "lastSid": tid, "alive": True, "threadOf": PARENT}))
+
+    def test_promote_keeps_the_threads_own_color(self):
+        # the color the dialog suggested rides create → row → PROMOTE (the user 2026-08-19: it used
+        # to be re-picked at break-out, so the session never matched the color the thread had worn)
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?", color="#F9D849")
+        self._promotable(tid)
+        self.assertIsNone(km._comment_promote(PARENT, tid, "sidework"))
+        self.assertEqual(self.be.promoted_color, ("#F9D849", "black"),
+                         "the row's color, with the palette's readable fg — never a fresh pick")
+
+    def test_promote_picks_fresh_only_for_a_colorless_row(self):
+        _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")
+        self._promotable(tid)
+        self.assertIsNone(km._comment_promote(PARENT, tid, "sidework"))
+        bg, fg = self.be.promoted_color
+        self.assertTrue(bg.startswith("#") and fg in ("white", "black"),
+                        "a pre-color row still gets a real identity")
 
     def test_promote_refuses_a_bad_name(self):
         _, tid = km._comment_create(PARENT, "a1", "exponential backoff", "Why?")

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -334,9 +334,15 @@ test("while the thread is WRITING the region wears marching ants; the fill lands
   // a dashed outline whose dashes crawl around the box — four gradient strips, animated offsets,
   // no fill, never a border (it would shift the inline text); solid returns when busy drops
   assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background-color: transparent;\s*\n\s*background-image:\s*\n\s*repeating-linear-gradient/);
-  assert.match(CSS, /background-size: 100% 1\.5px, 100% 1\.5px, 1\.5px 100%, 1\.5px 100%;/);
-  assert.match(CSS, /@keyframes cmt-ants \{\s*\n\s*to \{ background-position: 12px 0, -12px 100%, 0 -12px, 100% 12px; \}/);
+  // each no-repeat strip is oversized by one 12px dash period along its travel axis and starts a
+  // period back, and the keyframe travels exactly that period — a strip sized to its edge slid open
+  // a gap that snapped shut every cycle, a visible lurch on text-height vertical edges (2026-08-19)
+  assert.match(CSS, /background-size: calc\(100% \+ 12px\) 1\.5px, calc\(100% \+ 12px\) 1\.5px, 1\.5px calc\(100% \+ 12px\), 1\.5px calc\(100% \+ 12px\);/);
+  assert.match(CSS, /background-position: -12px 0, 0 100%, 0 0, 100% -12px;/);
+  assert.match(CSS, /@keyframes cmt-ants \{\s*\n\s*to \{ background-position: 0 0, -12px 100%, 0 -12px, 100% 0; \}/);
   assert.match(CSS, /code\.cmt-hl-host:has\(mark\.cmt-hl\.busy\)/, "hosts march too, or their tint defeats the cue");
+  // both ants blocks (mark + host) carry the oversize — a lone fixed block leaves the other lurching
+  assert.strictEqual((CSS.match(/background-size: calc\(100% \+ 12px\) 1\.5px/g) || []).length, 2);
   assert.match(KERNEL, /state = be\.session_state\(tsid\)/);
 });
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2508,17 +2508,20 @@ mark.cmt-hl.busy {
     repeating-linear-gradient(90deg, color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
     repeating-linear-gradient(0deg,  color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
     repeating-linear-gradient(0deg,  color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px);
-  background-size: 100% 1.5px, 100% 1.5px, 1.5px 100%, 1.5px 100%;
-  background-position: 0 0, 0 100%, 0 0, 100% 0;
+  background-size: calc(100% + 12px) 1.5px, calc(100% + 12px) 1.5px, 1.5px calc(100% + 12px), 1.5px calc(100% + 12px);
+  background-position: -12px 0, 0 100%, 0 0, 100% -12px;
   background-repeat: no-repeat;
   animation: cmt-ants 1.2s linear infinite;
 }
 mark.cmt-hl.hl-first { border-top-left-radius: 2px; border-bottom-left-radius: 2px; }
 mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 2px; }
-/* the ants march clockwise: top strip right, bottom left, left edge up, right edge down — one
-   12px dash cycle per period, slow and steady */
+/* the ants march clockwise: top strip right, bottom left, left edge up, right edge down — exactly
+   one 12px dash cycle per period, so the loop point is invisible. Each no-repeat strip is oversized
+   by that same 12px along its travel axis and starts one period back: a strip sized exactly to its
+   edge slid open a growing gap at its trailing end and snapped shut every cycle — a lurch that on a
+   text-height vertical edge swallowed most of the edge (the user 2026-08-19). */
 @keyframes cmt-ants {
-  to { background-position: 12px 0, -12px 100%, 0 -12px, 100% 12px; }
+  to { background-position: 0 0, -12px 100%, 0 -12px, 100% 0; }
 }
 /* a code/math HOST whose mark is mid-reply wears the ants too — its element tint would otherwise
    stay solid and defeat the outline-then-fill cue */
@@ -2530,8 +2533,8 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
     repeating-linear-gradient(90deg, color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
     repeating-linear-gradient(0deg,  color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px),
     repeating-linear-gradient(0deg,  color-mix(in srgb, var(--cmt-hl) 85%, transparent) 0 6px, transparent 6px 12px);
-  background-size: 100% 1.5px, 100% 1.5px, 1.5px 100%, 1.5px 100%;
-  background-position: 0 0, 0 100%, 0 0, 100% 0;
+  background-size: calc(100% + 12px) 1.5px, calc(100% + 12px) 1.5px, 1.5px calc(100% + 12px), 1.5px calc(100% + 12px);
+  background-position: -12px 0, 0 100%, 0 0, 100% -12px;
   background-repeat: no-repeat;
   animation: cmt-ants 1.2s linear infinite;
 }


### PR DESCRIPTION
Two comment-thread fixes, both user-reported.

## Marching ants lurched on the vertical edges
Each of the four dash strips was a no-repeat gradient sized exactly to its edge, slid 12px per cycle: the slide opened a growing gap at the strip's trailing end and snapped it shut at the loop point. On a long horizontal edge that read as a corner flicker; on a text-height vertical edge the gap was most of the edge — a visible jump every 1.2s. Each strip is now oversized by one 12px dash period along its travel axis and starts one period back, so the edge is fully covered at every phase and the loop lands exactly one period over.

Verified with a headless-Chrome pixel probe (marks of three sizes, animation frozen at nine phases via negative delay): the old strips gap up to 17px near the cycle end; the new ones never exceed the designed 6px dash gap and the loop point renders pixel-identical. An adversarial review swept for collateral (inline fragmentation, the 2px corner radii, other copies of the ants CSS, host padding, percentage-position interpolation) and found nothing.

## The dialog's suggested color didn't survive break-out
The identity color suggested in the new-comment dialog rides create → thread row → fork reg, but `_comment_promote` re-picked a fresh color at break-out, so the promoted session never matched what the thread had worn. It now reuses the row's color with the palette's readable fg word (`pal.fg_for`), falling back to a fresh pick only for a colorless legacy row. `_comment_create`'s fork call stamps the fg word too (convention alignment; thread forks skip the names write today).

## Tests
- CSS pins updated + a count pin that both ants blocks carry the oversize.
- Two new kernel tests: promote passes the row's color/fg to `promote_thread`; a colorless row still gets a real identity.
- Suites: pytest 4915 passed, node suite + typecheck clean. An adversarial verify pass confirmed the row's color key survives the CAS, nothing re-derives the color after promote, and no surface expected the fresh pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)